### PR TITLE
Fix nntrainer home URL @open sesame 3/25 10:06

### DIFF
--- a/Applications/Classification/TensorFlow/Training_Keras.py
+++ b/Applications/Classification/TensorFlow/Training_Keras.py
@@ -16,7 +16,7 @@
 # @file	Training_Keras.py
 # @date	13 March 2020
 # @brief	This is Simple Classification Example using Keras
-# @see		https://github.sec.samsung.net/AIP/nntrainer
+# @see		https://github.com/nnstreamer/nntrainer
 # @author	Jijoong Moon <jijoong.moon@samsung.com>
 # @bug		No known bugs except for NYI items
 #

--- a/Applications/Classification/TensorFlow/Training_tf.py
+++ b/Applications/Classification/TensorFlow/Training_tf.py
@@ -16,7 +16,7 @@
 # @file	Training_tf.py
 # @date	13 March 2020
 # @brief	This is Simple Classification Example using tensorflow
-# @see		https://github.sec.samsung.net/AIP/nntrainer
+# @see		https://github.com/nnstreamer/nntrainer
 # @author	Jijoong Moon <jijoong.moon@samsung.com>
 # @bug		No known bugs except for NYI items
 #

--- a/Applications/Classification/jni/main.cpp
+++ b/Applications/Classification/jni/main.cpp
@@ -14,7 +14,7 @@
  *
  * @file	main.cpp
  * @date	04 December 2019
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  * @brief	This is Classification Example with one FC Layer

--- a/Applications/KNN/jni/demo.cpp
+++ b/Applications/KNN/jni/demo.cpp
@@ -14,7 +14,7 @@
  *
  * @file	main.cpp for K Nearest Neighbor
  * @date	04 December 2019
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  * @brief	This is Transfer Learning Example with KNN

--- a/Applications/LogisticRegression/jni/main.cpp
+++ b/Applications/LogisticRegression/jni/main.cpp
@@ -14,7 +14,7 @@
  *
  * @file	main.cpp
  * @date	04 December 2019
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  * @brief	This is Binary Logistic Regression Example

--- a/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
+++ b/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
@@ -14,7 +14,7 @@
  *
  * @file	main.cpp
  * @date	04 December 2019
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  * @brief	This is DeepQ Reinforcement Learning Example

--- a/Applications/ReinforcementLearning/Environment/CartPole/cartpole.cpp
+++ b/Applications/ReinforcementLearning/Environment/CartPole/cartpole.cpp
@@ -15,7 +15,7 @@
  * @file	cartpole.cpp
  * @date	04 December 2019
  * @brief	This is environment class for cartpole example
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/Applications/ReinforcementLearning/Environment/CartPole/cartpole.h
+++ b/Applications/ReinforcementLearning/Environment/CartPole/cartpole.h
@@ -15,7 +15,7 @@
  * @file	cartpole.h
  * @date	04 December 2019
  * @brief	This is environment class for cartpole example
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/Applications/ReinforcementLearning/Environment/CartPole/main.cpp
+++ b/Applications/ReinforcementLearning/Environment/CartPole/main.cpp
@@ -15,7 +15,7 @@
  * @file	main.cpp
  * @date	04 December 2019
  * @brief	This is simple example to use Env CartPole-v0
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/Applications/Training/jni/main.cpp
+++ b/Applications/Training/jni/main.cpp
@@ -14,7 +14,7 @@
  *
  * @file	main.cpp
  * @date	04 December 2019
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  * @brief	This is Transfer Learning Example with one FC Layer

--- a/include/databuffer.h
+++ b/include/databuffer.h
@@ -14,8 +14,8 @@
  *
  * @file	databuffer.h
  * @date	04 December 2019
- * @brief	This is Matrix class for calculation using blas library.
- * @see https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @brief	This is buffer object to handle big data
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/include/layers.h
+++ b/include/layers.h
@@ -14,7 +14,7 @@
  * @file	layers.h
  * @date	04 December 2019
  * @brief	This is Layer classes of Neural Network
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/include/neuralnet.h
+++ b/include/neuralnet.h
@@ -15,7 +15,7 @@
  * @file	neuralnet.h
  * @date	04 December 2019
  * @brief	This is Neural Network Class
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/include/tensor.h
+++ b/include/tensor.h
@@ -15,7 +15,7 @@
  * @file	tensor.h
  * @date	04 December 2019
  * @brief	This is Tensor class for calculation
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/src/databuffer.cpp
+++ b/src/databuffer.cpp
@@ -14,8 +14,8 @@
  *
  * @file	databuffer.cpp
  * @date	04 December 2019
- * @brief	This is Matrix class for calculation using blas library
- * @see https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @brief	This is buffer object to handle big data
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/src/layers.cpp
+++ b/src/layers.cpp
@@ -15,7 +15,7 @@
  * @file	layers.cpp
  * @date	04 December 2019
  * @brief	This is Layers Classes for Neural Network
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/src/neuralnet.cpp
+++ b/src/neuralnet.cpp
@@ -15,7 +15,7 @@
  * @file	neuralnet.cpp
  * @date	04 December 2019
  * @brief	This is Neural Network Class
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -15,7 +15,7 @@
  * @file	tensor.cpp
  * @date	04 December 2019
  * @brief	This is Tensor class for calculation
- * @see		https://github.sec.samsung.net/jijoong-moon/Transfer-Learning.git
+ * @see		https://github.com/nnstreamer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @bug		No known bugs except for NYI items
  *


### PR DESCRIPTION
Change nntrainer home URL to github.com/nnstreamer/nntrainer

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>