### PR TITLE
[API] Add Logger for NNTrainer

### DIFF
--- a/nntrainer/include/nntrainer_log.h
+++ b/nntrainer/include/nntrainer_log.h
@@ -1,0 +1,63 @@
+/**
+* Copyright (C) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @file nntrainer_log.h
+ * @date 06 April 2020
+ * @brief NNTrainer Logger.
+ *        Log Util for NNTrainer
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_LOG_H__
+#define __NNTRAINER_LOG_H__
+
+#define TAG_NAME "nntrainer"
+
+#if defined(__TIZEN__)
+#include <dlog.h>
+
+#define ml_logi(...) dlog_print(DLOG_INFO, TAG_NAME, __VA_ARGS__)
+
+#define ml_logw(...) dlog_print(DLOG_WARN, TAG_NAME, __VA_ARGS__)
+
+#define ml_loge(...) dlog_print(DLOG_ERROR, TAG_NAME, __VA_ARGS__)
+
+#define ml_logd(...) dlog_print(DLOG_DEBUG, TAG_NAME, __VA_ARGS__)
+
+#elif defined(__ANDROID__)
+#include <android/log.h>
+
+#define ml_logi(...) __android_log_print(ANDROID_LOG_INFO, TAG_NAME, __VA_ARGS__)
+
+#define ml_logw(...) __android_log_print(ANDROID_LOG_WARN, TAG_NAME, __VA_ARGS__)
+
+#define ml_loge(...) __android_log_print(ANDROID_LOG_ERROR, TAG_NAME, __VA_ARGS__)
+
+#define ml_logd(...) __android_log_print(ANDROID_LOG_DEBUG, TAG_NAME, __VA_ARGS__)
+
+#else /* Linux distro */
+#include <nntrainer_logger.h>
+
+#define ml_logi(...) __nntrainer_log_print(NNTRAINER_LOG_INFO, __VA_ARGS__)
+
+#define ml_logw(...) __nntrainer_log_print(NNTRAINER_LOG_WARN, __VA_ARGS__)
+
+#define ml_loge(...) __nntrainer_log_print(NNTRAINER_LOG_ERROR, __VA_ARGS__)
+
+#define ml_logd(...) __nntrainer_log_print(NNTRAINER_LOG_DEBUG, __VA_ARGS__)
+#endif
+
+#endif

--- a/nntrainer/include/nntrainer_logger.h
+++ b/nntrainer/include/nntrainer_logger.h
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @file nntrainer_logger.h
+ * @date 02 April 2020
+ * @brief NNTrainer Logger
+ *        This allows to logging nntrainer logs.
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <vector>
+
+/**
+ * @brief     Log Level of NNtrainer
+ *            0. informations
+ *            1. warnings
+ *            2. errors
+ *            3. debugging informations
+ */
+typedef enum {
+  NNTRAINER_LOG_DEBUG = 0,
+  NNTRAINER_LOG_INFO,
+  NNTRAINER_LOG_WARN,
+  NNTRAINER_LOG_ERROR
+} nntrainer_loglevel;
+
+/**
+ * @class   NNTrainer Logger Class
+ * @brief   Class for Logging. This is alternatives when there is no logging system.
+ *          For the tizen, we are going to use dlog and it is android_log for android.
+ */
+class Logger {
+ public:
+  /**
+   * @brief     Logging Instance Function. Get a lock and create Logger if it is null;
+   */
+  static Logger& instance();
+
+  /**
+   * @brief     Logging member function for logging messages.
+   */
+  void log(const std::string& message, const nntrainer_loglevel loglevel = NNTRAINER_LOG_INFO);
+
+ protected:
+  /**
+   * @brief     Logging instance
+   */
+  static Logger* ainstance;
+  /**
+   * @brief     Log file name
+   */
+  static const char* const logfile_name;
+
+  /**
+   * @brief     output stream
+   */
+  std::ofstream outputstream;
+
+  /**
+   * @class     Class to make sure the single logger
+   * @brief     sure the single logger
+   */
+  friend class Cleanup;
+  class Cleanup {
+   public:
+    ~Cleanup();
+  };
+
+ private:
+  /**
+   * @brief     Constructor
+   */
+  Logger();
+  /**
+   * @brief     Destructor
+   */
+  virtual ~Logger();
+  Logger(const Logger&);
+  Logger& operator=(const Logger&);
+  static std::mutex smutex;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/**
+ * @brief     Interface function for C
+ */
+void __nntrainer_log_print(nntrainer_loglevel loglevel, const std::string format, ...);
+
+#ifdef __cplusplus
+}
+#endif

--- a/nntrainer/src/nntrainer_logger.cpp
+++ b/nntrainer/src/nntrainer_logger.cpp
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @file nntrainer_logger.cpp
+ * @date 02 April 2020
+ * @brief NNTrainer Logger
+ *        This allows to logging nntrainer logs.
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <nntrainer_logger.h>
+#include <stdarg.h>
+#include <cstring>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+
+/**
+ * @brief     logfile name
+ */
+const char* const Logger::logfile_name = "log_nntrainer_";
+
+/**
+ * @brief     instance for single logger
+ */
+Logger* Logger::ainstance = nullptr;
+
+/**
+ * @brief     mutex for lock
+ */
+std::mutex Logger::smutex;
+
+Logger& Logger::instance() {
+  static Cleanup cleanup;
+
+  std::lock_guard<std::mutex> guard(smutex);
+  if (ainstance == nullptr)
+    ainstance = new Logger();
+  return *ainstance;
+}
+
+Logger::Cleanup::~Cleanup() {
+  std::lock_guard<std::mutex> guard(Logger::smutex);
+  delete Logger::ainstance;
+  Logger::ainstance = nullptr;
+}
+
+Logger::~Logger() { outputstream.close(); }
+
+Logger::Logger() {
+  time_t t = time(0);
+  struct tm* now = localtime(&t);
+  std::stringstream ss;
+  ss << logfile_name << std::dec << (now->tm_year + 1900) << std::setfill('0') << std::setw(2) << (now->tm_mon + 1)
+     << std::setfill('0') << std::setw(2) << now->tm_mday << std::setfill('0') << std::setw(2) << now->tm_hour
+     << std::setfill('0') << std::setw(2) << now->tm_min << std::setfill('0') << std::setw(2) << now->tm_sec << ".out";
+  outputstream.open(ss.str(), std::ios_base::app);
+  if (!outputstream.good()) {
+    throw std::runtime_error("Unable to initialize the Logger!");
+  }
+}
+
+void Logger::log(const std::string& message, const nntrainer_loglevel loglevel) {
+  std::lock_guard<std::mutex> guard(smutex);
+  time_t t = time(0);
+  struct tm* now = localtime(&t);
+  std::stringstream ss;
+  switch (loglevel) {
+    case NNTRAINER_LOG_INFO:
+      ss << "[NNTRAINER INFO  ";
+      break;
+    case NNTRAINER_LOG_WARN:
+      ss << "[NNTRAINER WARNING ";
+      break;
+    case NNTRAINER_LOG_ERROR:
+      ss << "[NNTRAINER ERROR ";
+      break;
+    case NNTRAINER_LOG_DEBUG:
+      ss << "[NNTRAINER DEBUG ";
+      break;
+    default:
+      break;
+  }
+
+  ss << std::dec << (now->tm_year + 1900) << '-' << std::setfill('0') << std::setw(2) << (now->tm_mon + 1) << '-'
+     << std::setfill('0') << std::setw(2) << now->tm_mday << '-' << std::setfill('0') << std::setw(2) << now->tm_hour
+     << std::setfill('0') << std::setw(2) << now->tm_min << std::setfill('0') << std::setw(2) << now->tm_sec << ']';
+
+  outputstream << ss.str() << " " << message << std::endl;
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+void __nntrainer_log_print(nntrainer_loglevel loglevel, const std::string format_str, ...) {
+  int final_n, n = ((int)format_str.size()) * 2;
+  std::unique_ptr<char[]> formatted;
+  va_list ap;
+  while (1) {
+    formatted.reset(new char[n]);
+    std::strcpy(&formatted[0], format_str.c_str());
+    va_start(ap, format_str);
+    final_n = vsnprintf(&formatted[0], n, format_str.c_str(), ap);
+    va_end(ap);
+    if (final_n < 0 || final_n >= n)
+      n += abs(final_n - n + 1);
+    else
+      break;
+  }
+
+  std::string ss = std::string(formatted.get());
+  Logger::instance().log(ss, loglevel);
+
+#if defined(__LOGGING__)
+  Logger::instance().log(ss, loglevel);
+#else
+  switch (loglevel) {
+    case NNTRAINER_LOG_ERROR:
+      std::cerr << ss << std::endl;
+      break;
+    case NNTRAINER_LOG_INFO:
+    case NNTRAINER_LOG_WARN:
+    case NNTRAINER_LOG_DEBUG:
+      std::cout << ss << std::endl;
+    default:
+      break;
+  }
+
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
In order to log, implement Logger class to use when there is no
logging system. If there is, we are going to use them. For example,
we are going to use tizen dlog for the tizen and android log system
for android with same interface such as nn_log[i,w,e,d].

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>