### PR TITLE
Add Coverage Test badge for nntrainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NNtrainer
 
+[![Code Coverage](http://ec2-54-180-96-14.ap-northeast-2.compute.amazonaws.com/nntrainer/ci/badge/codecoverage.svg)](http://ec2-54-180-96-14.ap-northeast-2.compute.amazonaws.com/nntrainer/ci/gcov_html/index.html)
+
 NNtrainer is Software Framework for Training Neural Network Models on Devices.
 
 ## Overview


### PR DESCRIPTION
Add Coverage Test Badge for nntrainer in README.md

Resolves:

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>