### PR TITLE
[CAPI] Tizen CAPI Example @open sesame 05/04 17:34

### DIFF
--- a/Applications/Tizen_CAPI/Tizen_CAPI_config.ini
+++ b/Applications/Tizen_CAPI/Tizen_CAPI_config.ini
@@ -1,0 +1,45 @@
+# Network Section : Network
+[Network]
+Type = NeuralNetwork	# Network Type : Regression, KNN, NeuralNetwork
+Layers = inputlayer \
+	 outputlayer	#Layers of Neuralnetwork
+Learning_rate = 0.0001 	# Learning Rate
+Decay_rate = 0.96	# for the decay_rate for the decayed learning rate
+Decay_steps = 1000       # decay step for the exponential decayed learning rate
+Epoch = 10		# Epoch
+Optimizer = adam 	# Optimizer : sgd (stochastic gradien decent),
+ 	    		#             adam (Adamtive Moment Estimation)
+Cost = cross  		# Cost(loss) function : msr (mean square root error)
+                        #                       cross ( for cross entropy )
+Weight_Decay = l2norm
+weight_Decay_Lambda = 0.005
+Model = "model.bin"  	# model path to save / read
+minibatch = 32		# mini batch size
+beta1 = 0.9 		# beta 1 for adam
+beta2 = 0.9999	# beta 2 for adam
+epsilon = 1e-7	# epsilon for adam
+
+[DataSet]
+BufferSize=100
+TrainData="trainingSet.dat"
+ValidData="trainingSet.dat"
+LabelData="label.dat"
+
+# [DataSet]
+# BufferSize=100
+# Tflite="test.tflite"
+# Top_dir="./cifar10"
+
+# Layer Section : Name
+[inputlayer]
+Type = input
+HiddenSize = 62720		# Input Layer Dimension
+Bias_zero = true	# Zero Bias
+Normalization = true
+Activation = sigmoid 	# activation : sigmoid, tanh
+
+[outputlayer]
+Type = fully_connected
+HiddenSize = 10		# Output Layer Dimension ( = Weight Width )
+Bias_zero = true
+Activation = softmax 	# activation : sigmoid, softmax

--- a/Applications/Tizen_CAPI/main.c
+++ b/Applications/Tizen_CAPI/main.c
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * @file	main.c
+ * @date	04 May 2020
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is Classification Example with one FC Layer
+ *              The base model for feature extractor is mobilenet v2 with
+ * 1280*7*7 feature size. It read the Classification.ini in res directory and
+ * run according to the configureation.
+ */
+
+#include <nntrainer.h>
+
+int
+main (int argc, char *argv[])
+{
+  int status = ML_ERROR_NONE;
+  ml_nnmodel_h handle = NULL;
+  const char *config_file = "./Tizen_CAPI_config.ini";
+  status = ml_nnmodel_construct_with_conf (config_file, &handle);
+  if (status != ML_ERROR_NONE)
+    return status;
+  status = ml_nnmodel_compile (handle);
+  if (status != ML_ERROR_NONE)
+    return status;
+  status = ml_nnmodel_train (handle);
+  if (status != ML_ERROR_NONE)
+    return status;
+  status = ml_nnmodel_destruct (handle);
+  if (status != ML_ERROR_NONE)
+    return status;
+  return status;
+}

--- a/Applications/Tizen_CAPI/meson.build
+++ b/Applications/Tizen_CAPI/meson.build
@@ -1,0 +1,10 @@
+tizen_capi_file_sources = [
+  'main.c'
+]
+
+executable('nntrainer_tizen_capi_file',
+  tizen_capi_file_sources,
+  dependencies: [iniparser_dep, nntrainer_dep, nntrainer_capi_dep],
+  install: get_option('install-app'),
+  install_dir: application_install_dir
+)

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -3,3 +3,6 @@ subdir('KNN/jni')
 subdir('LogisticRegression/jni')
 subdir('ReinforcementLearning/DeepQ/jni')
 subdir('Training/jni')
+if get_option('enable-capi')
+  subdir('Tizen_CAPI')
+endif

--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -75,7 +75,7 @@ int ml_nnmodel_construct(ml_nnmodel_h *model);
  * @details Use this function to create Neural Netowrk Model.
  * @since_tizen 6.x
  * @param[in] model_conf The location of nntrainer model configuration file.
- * @param[in] model The NNTrainer Model handler from the given description.
+ * @param[out] model The NNTrainer Model handler from the given description.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.

--- a/meson.build
+++ b/meson.build
@@ -119,13 +119,13 @@ configure_file(input: 'nntrainer.pc.in', output: 'nntrainer.pc',
 # Build nntrainer
 subdir('nntrainer')
 
+# Build api
+subdir('api')
+
 if get_option('enable-app')
   tflite_dep = dependency('tensorflow-lite', required: true)
   subdir('Applications')
 endif
-
-# Build api
-subdir('api')
 
 if get_option('enable-test')
    subdir('test')


### PR DESCRIPTION
Add Tizen CAPI Example with configuration file

- Add example application for tizen capi which run neural network with
  configuration file

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>