### PR TITLE
Delete overlapping logic in test/meson.build

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -2,12 +2,25 @@ gtest_dep = dependency('gtest', required: false)
 
 nntrainer_test_inc = include_directories('./include')
 
+nntrainer_test_deps = [
+  nntrainer_dep #gtest is linked in nntrainer_testutil_lib
+]
+
+# build test util when gtest is found
 if gtest_dep.found()
-  nntrainer_unittest_deps = [
-    nntrainer_dep,
-    gtest_dep
-  ]
+  nntrainer_testutil_lib = static_library(
+    'nntrainer_test_util', 
+    'nntrainer_test_util.cpp', 
+    dependencies: [nntrainer_test_deps, gtest_dep],
+    include_directories: nntrainer_test_inc
+  )
+  nntrainer_testutil_dep = declare_dependency(
+    link_with: nntrainer_testutil_lib,
+    include_directories: nntrainer_test_inc
+  )
+  nntrainer_test_deps += nntrainer_testutil_dep
 endif
+
 
 if get_option('enable-capi')
   subdir('tizen_capi')

--- a/test/tizen_capi/meson.build
+++ b/test/tizen_capi/meson.build
@@ -1,18 +1,15 @@
 unittest_tizen_deps = [
   nntrainer_capi_dep,
-  nntrainer_unittest_deps,
-  gtest_dep
+  nntrainer_test_deps,
 ]
 
 unittest_tizen_src=[
   'unittest_tizen_capi.cpp',
-  '../nntrainer_test_util.cpp'
 ]
 
 unittest_tizen_capi = executable('unittest_tizen_capi',
   unittest_tizen_src,
-  dependencies: [unittest_tizen_deps],
-  include_directories: nntrainer_test_inc,
+  dependencies: unittest_tizen_deps,
   install: get_option('enable-test'),
   install_dir: application_install_dir
 )

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -126,9 +126,17 @@ TEST(nntrainer_capi_nnmodel, compile_03_n) {
 int main(int argc, char **argv) {
   int result = -1;
 
-  testing::InitGoogleTest(&argc, argv);
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    ml_loge("Failed to init gtest\n");
+  }
 
-  result = RUN_ALL_TESTS();
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    ml_loge("Failed to run test.\n");
+  }
 
   return result;
 }

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -1,13 +1,4 @@
-unittest_nntrainer_internal_deps = [
-  nntrainer_unittest_deps,
-  gtest_dep
-]
-
-unittest_nntrainer_src=[
-  'unittest_nntrainer_internal.cpp',
-  '../nntrainer_test_util.cpp'
-]
-
+unittest_nntrainer_deps = [nntrainer_test_deps] # if unittest-wide dep is added, this is the place to add
 
 unzip_target = ['trainset.tar.gz', 'valset.tar.gz', 'testset.tar.gz']
 src_path = join_paths(meson.source_root(), 'packaging')
@@ -21,9 +12,8 @@ endforeach
 run_command(['cp', join_paths(src_path, 'label.dat'), join_paths(dest_path, 'label.dat')])
 
 unittest_nntrainer_internal = executable('unittest_nntrainer_internal',
-  unittest_nntrainer_src,
-  dependencies: [unittest_nntrainer_internal_deps],
-  include_directories: nntrainer_test_inc,
+  'unittest_nntrainer_internal.cpp',
+  dependencies: unittest_nntrainer_deps,
   install: get_option('enable-test'),
   install_dir: application_install_dir
 )
@@ -32,7 +22,7 @@ test('unittest_nntrainer_internal', unittest_nntrainer_internal)
 
 unittest_util_func = executable('unittest_util_func',
   'unittest_util_func.cpp',
-  dependencies: [unittest_nntrainer_internal_deps],
+  dependencies: unittest_nntrainer_deps,
   install: get_option('enable-test'),
   install_dir: application_install_dir
 )


### PR DESCRIPTION
 This PR..

 1. Make library for test_util so, it does not need compile over and
over again
 2. Combine identical variable with diffrent name

 Self evaluation:

 Build test: [X]Passed [ ]Failed [ ]Skipped
 Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>