### PR TITLE
Fix potential memory leak when finalize.

### DIFF
--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -152,6 +152,7 @@ int ml_nnmodel_destruct(ml_nnmodel_h model) {
   NN = nnmodel->network;
   NN->finalize();
   delete NN;
+  delete nnmodel;
 
   return status;
 }

--- a/nntrainer/include/databuffer.h
+++ b/nntrainer/include/databuffer.h
@@ -172,6 +172,14 @@ public:
   virtual int clear(BufferType type);
 
   /**
+   * @brief     clear all thread ( training, validation, test )
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  virtual int clear();
+
+
+  /**
    * @brief     get Status of Buffer. if number of rest data
    *            is samller than minibatch, the return false
    * @param[in] BufferType training, validation, test

--- a/nntrainer/src/databuffer.cpp
+++ b/nntrainer/src/databuffer.cpp
@@ -171,6 +171,23 @@ int DataBuffer::clear(BufferType type) {
   return status;
 }
 
+int DataBuffer::clear(){
+  unsigned int i;
+
+  int status = ML_ERROR_NONE;
+  for(i = BUF_TRAIN; i <= BUF_TEST; ++i){
+    BufferType type = static_cast<BufferType>(i);
+    status = this->clear(type);
+
+    if(status != ML_ERROR_NONE){
+      ml_loge("Error: error occurred during clearing");
+      return status;
+    }
+  }
+
+  return status;
+}
+
 DataStatus DataBuffer::getStatus(BufferType type) {
   DataStatus ret = DATA_READY;
   if (globalExceptionPtr)

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -521,6 +521,11 @@ void NeuralNetwork::finalize() {
   for (unsigned int i = 0; i < layers.size(); i++) {
     delete layers[i];
   }
+
+  if (data_buffer){
+    data_buffer->clear();
+    delete data_buffer;
+  }
 }
 
 /**

--- a/test/unittest/unittest_databuffer_file.cpp
+++ b/test/unittest/unittest_databuffer_file.cpp
@@ -186,6 +186,89 @@ TEST(nntrainer_DataBuffer, setDataFile_04_n) {
 
 
 /**
+ * @brief Data buffer clear all
+ */
+TEST(nntrainer_DataBuffer, clear_01_p){
+  int status = ML_ERROR_NONE;
+  nntrainer::DataBufferFromDataFile data_buffer;
+  status = data_buffer.setMiniBatch(32);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.setClassNum(10);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.setDataFile("trainingSet.dat", nntrainer::DATA_TRAIN);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.setDataFile("valSet.dat", nntrainer::DATA_VAL);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.setDataFile("testSet.dat", nntrainer::DATA_TEST);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.setDataFile("label.dat", nntrainer::DATA_LABEL);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.setFeatureSize(62720);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.init();
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.run(nntrainer::BUF_TRAIN);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.run(nntrainer::BUF_TEST);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.run(nntrainer::BUF_VAL);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.clear();
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Data buffer partial clear
+ */
+TEST(nntrainer_DataBuffer, clear_02_p){
+  int status = ML_ERROR_NONE;
+  nntrainer::DataBufferFromDataFile data_buffer;
+  status = data_buffer.setDataFile("testSet.dat", nntrainer::DATA_TEST);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.clear(nntrainer::BUF_TEST);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Data buffer all clear after partial clear
+ */
+TEST(nntrainer_DataBuffer, clear_03_p){
+  int status = ML_ERROR_NONE;
+  nntrainer::DataBufferFromDataFile data_buffer;
+  status = data_buffer.setDataFile("testSet.dat", nntrainer::DATA_TEST);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.clear(nntrainer::BUF_TEST);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.clear();
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+
+/**
+ * @brief Data buffer partial clear after all clear
+ */
+TEST(nntrainer_DataBuffer, clear_04_p){
+  int status = ML_ERROR_NONE;
+  nntrainer::DataBufferFromDataFile data_buffer;
+  status = data_buffer.setDataFile("testSet.dat", nntrainer::DATA_TEST);
+  ASSERT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.clear(nntrainer::BUF_TEST);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = data_buffer.clear();
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Data buffer clear BUF_UNKNOWN
+ */
+TEST(nntrainer_DataBuffer, clear_05_n){
+  int status = ML_ERROR_NONE;
+  nntrainer::DataBufferFromDataFile data_buffer;
+  status = data_buffer.clear(nntrainer::BUF_UNKNOWN);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+/**
  * @brief Main gtest
  */
 int main(int argc, char **argv) {

--- a/test/unittest/unittest_util_func.cpp
+++ b/test/unittest/unittest_util_func.cpp
@@ -17,7 +17,7 @@
  * @date        10 April 2020
  * @brief       Unit test for util_func.cpp.
  * @see         https://github.com/nnstreamer/nntrainer
- * @author      Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @author      Jijoong Moon <jijoong.moon@samsung.com>
  * @bug         No known bugs
  */
 


### PR DESCRIPTION
This PR

 1. Solves potential memory leak detected from valgrind.
 2. Correct the author of `unittest_util_func.cpp`.

Self evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>