### PR TITLE
[API] Set Property API for Neural Network Layer

### DIFF
--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -76,6 +76,22 @@ typedef enum {
 } ml_layer_type_e;
 
 /**
+ * @brief Enumeration for the neural network layer property
+ *        InputLayer has 0, 1, 2, 3 properties.
+ *        FullyConnectedLayer has 0, 1, 4 properties.
+ *        BatchNormalizationLayer has 0, 1, 5 properties.
+ * @since_tizen 6.x
+ */
+typedef enum {
+  ML_INPUT_SHAPE = 0,     /**< Input Shaep */
+  ML_BIAS_ZERO = 1,       /**< Fill Bias with Zero  */
+  ML_NORMALIZATION = 2,   /**< Noramlization Flag  */
+  ML_STANDARDIZATION = 3, /**< Standardization Flag  */
+  ML_ACTIVATION = 4,      /**< Actication for Layer  */
+  ML_EPSILON = 5          /**< Epsilon for Batch Normalization  */
+} ml_layer_property_e;
+
+/**
  * @brief Constructs the neural network model.
  * @details Use this function to create Neural Netowrk Model.
  * @since_tizen 6.x
@@ -155,6 +171,20 @@ int ml_nnlayer_create(ml_nnlayer_h *layer, ml_layer_type_e type);
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
 int ml_nnlayer_delete(ml_nnlayer_h layer);
+
+/**
+ * @brief Set the neural network layer Property.
+ * @details Use this function to set Neural Netowrk Layer Property.
+ * @since_tizen 6.x
+ * @param[in] layer The NNTrainer Layer handler from the given description.
+ * @param[in]  key Property key to set
+ * @param[in]  value Property value
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ */
+int ml_nnlayer_set_property(ml_nnlayer_h layer, ml_layer_property_e key,
+                            const char *value);
 
 /**
  * @}

--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @file nntrainer_internal.h
+ * @date 02 April 2020
+ * @brief NNTrainer C-API Internal Header.
+ *        This allows to construct and control NNTrainer Model.
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_INTERNAL_H__
+#define __NNTRAINER_INTERNAL_H__
+
+#include <nntrainer.h>
+
+#define ML_NNTRAINER_MAGIC 0x777F888F
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+typedef struct {
+  uint magic;
+  nntrainer::NeuralNetwork *network;
+} ml_nnmodel;
+
+typedef struct {
+  uint magic;
+  nntrainer::Layer *layer;
+} ml_nnlayer;
+
+#define ML_NNTRAINER_CHECK_MODEL_VALIDATION(nnmodel, model)      \
+  do {                                                           \
+    if (!model) {                                                \
+      ml_loge("Error: Invalid Parameter : model is empty.");     \
+      return ML_ERROR_INVALID_PARAMETER;                         \
+    }                                                            \
+    nnmodel = (ml_nnmodel *)model;                               \
+    if (nnmodel->magic != ML_NNTRAINER_MAGIC) {                  \
+      ml_loge("Error: Invalid Parameter : nnmodel is invalid."); \
+      return ML_ERROR_INVALID_PARAMETER;                         \
+    }                                                            \
+  } while (0)
+
+#define ML_NNTRAINER_CHECK_LAYER_VALIDATION(nnlayer, layer)      \
+  do {                                                           \
+    if (!layer) {                                                \
+      ml_loge("Error: Invalid Parameter : layer is empty.");     \
+      return ML_ERROR_INVALID_PARAMETER;                         \
+    }                                                            \
+    nnlayer = (ml_nnlayer *)layer;                               \
+    if (nnlayer->magic != ML_NNTRAINER_MAGIC) {                  \
+      ml_loge("Error: Invalid Parameter : nnlayer is invalid."); \
+      return ML_ERROR_INVALID_PARAMETER;                         \
+    }                                                            \
+  } while (0)
+
+#ifdef __cplusplus
+}
+
+#endif /* __cplusplus */  
+#endif

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -22,51 +22,13 @@
  */
 
 #include "neuralnet.h"
+#include "nntrainer_internal.h"
 #include "nntrainer_log.h"
-#include <nntrainer.h>
 #include <string.h>
-
-#define ML_NNTRAINER_MAGIC 0x777F888F
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef struct {
-  uint magic;
-  nntrainer::NeuralNetwork *network;
-} ml_nnmodel;
-
-typedef struct {
-  uint magic;
-  nntrainer::Layer *layer;
-} ml_nnlayer;
-
-#define ML_NNTRAINER_CHECK_MODEL_VALIDATION(nnmodel, model)      \
-  do {                                                           \
-    if (!model) {                                                \
-      ml_loge("Error: Invalid Parameter : model is empty.");     \
-      return ML_ERROR_INVALID_PARAMETER;                         \
-    }                                                            \
-    nnmodel = (ml_nnmodel *)model;                               \
-    if (nnmodel->magic != ML_NNTRAINER_MAGIC) {                  \
-      ml_loge("Error: Invalid Parameter : nnmodel is invalid."); \
-      return ML_ERROR_INVALID_PARAMETER;                         \
-    }                                                            \
-  } while (0)
-
-#define ML_NNTRAINER_CHECK_LAYER_VALIDATION(nnlayer, layer)      \
-  do {                                                           \
-    if (!layer) {                                                \
-      ml_loge("Error: Invalid Parameter : layer is empty.");     \
-      return ML_ERROR_INVALID_PARAMETER;                         \
-    }                                                            \
-    nnlayer = (ml_nnlayer *)layer;                               \
-    if (nnlayer->magic != ML_NNTRAINER_MAGIC) {                  \
-      ml_loge("Error: Invalid Parameter : nnlayer is invalid."); \
-      return ML_ERROR_INVALID_PARAMETER;                         \
-    }                                                            \
-  } while (0)
 
 /**
  * @brief Function to create Network::NeuralNetwork object.
@@ -194,8 +156,23 @@ int ml_nnlayer_delete(ml_nnlayer_h layer) {
 
   nntrainer::Layer *NL;
   NL = nnlayer->layer;
+
   delete NL;
   delete nnlayer;
+
+  return status;
+}
+
+int ml_nnlayer_set_property(ml_nnlayer_h layer, ml_layer_property_e key,
+                            const char *value) {
+  int status = ML_ERROR_NONE;
+  ml_nnlayer *nnlayer;
+  ML_NNTRAINER_CHECK_LAYER_VALIDATION(nnlayer, layer);
+
+  nntrainer::Layer *NL;
+  NL = nnlayer->layer;
+
+  status = NL->setProperty(key, value);
 
   return status;
 }

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -29,6 +29,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/src/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/databuffer_file.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/util_func.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/optimizer.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/src/parse_util.cpp \
 
 NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer/include
 

--- a/nntrainer/include/layers.h
+++ b/nntrainer/include/layers.h
@@ -143,6 +143,15 @@ public:
   virtual void save(std::ofstream &file) = 0;
 
   /**
+   * @brief     set Property of layer
+   * @param[in] key key of property
+   * @param[in] value value of property
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  virtual int setProperty(unsigned int key, const char* value) = 0;
+
+  /**
    * @brief     Optimizer Setter
    * @param[in] opt Optimizer
    * @retval #ML_ERROR_NONE Successful.
@@ -163,6 +172,12 @@ public:
    * @param[in] type layer type
    */
   void setType(LayerType type) { this->type = type; }
+
+  /**
+   * @brief     Layer type Getter
+   * @retval type LayerType
+   */
+  LayerType getType() { return type; }
 
   /**
    * @brief     Copy Layer
@@ -192,19 +207,9 @@ protected:
   bool last_layer;
 
   /**
-   * @brief     batch size of Weight Data
+   * @brief     Dimension of this layer
    */
-  unsigned int batch;
-
-  /**
-   * @brief     width size of Weight Data
-   */
-  unsigned int width;
-
-  /**
-   * @brief     height size of Weight Data
-   */
-  unsigned int height;
+  TensorDim dim;
 
   /**
    * @brief     Optimizer for this layer
@@ -330,6 +335,29 @@ public:
    */
   void setStandardization(bool enable) { this->standardization = enable; };
 
+  /**
+   * @brief     set Property of layer
+   * @param[in] key key of property
+   * @param[in] value value of property
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int setProperty(unsigned int key, const char* value);
+
+  /**
+   * @brief     Property Enumeration
+   *            0. input shape : string
+   *            1. bias zero : bool
+   *            2. normalization : bool
+   *            3. normalization : bool
+   */
+  enum class PropertyType {
+    input_shape = 0,
+    bias_zero = 1,
+    normalization = 2,
+    standardization = 3
+  };
+
 private:
   bool normalization;
   bool standardization;
@@ -420,6 +448,27 @@ public:
    */
   int setCost(CostType c);
 
+  /**
+   * @brief     set Property of layer
+   * @param[in] key key of property
+   * @param[in] value value of property
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int setProperty(unsigned key, const char* value);
+
+  /**
+   * @brief     Property Enumeration
+   *            0. input shape : string
+   *            1. bias zero : bool
+   *            2. activation : bool
+   */
+  enum class PropertyType {
+    input_shape = 0,
+    bias_zero = 1,
+    activation = 4
+  };
+
 private:
   Tensor weight;
   Tensor bias;
@@ -509,6 +558,27 @@ public:
    */
   int initialize(int b, int h, int w, bool last, bool init_zero,
                  WeightIniType wini);
+
+  /**
+   * @brief     set Property of layer
+   * @param[in] key key of property
+   * @param[in] value value of property
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int setProperty(unsigned int key, const char* value);
+
+  /**
+   * @brief     Property Enumeration
+   *            0. input shape : string
+   *            1. bias zero : bool
+   *            2. epsilon : float
+   */
+  enum class PropertyType {
+    input_shape = 0,
+    bias_zero = 1,
+    epsilon = 5,
+  };
 
 private:
   Tensor weight;

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -44,28 +44,6 @@ namespace nntrainer {
 typedef enum { NET_KNN, NET_REG, NET_NEU, NET_UNKNOWN } NetType;
 
 /**
- * @brief     Enumeration for input configuration file parsing
- *            0. OPT     ( Optimizer Token )
- *            1. COST    ( Cost Function Token )
- *            2. NET     ( Network Token )
- *            3. ACTI    ( Activation Token )
- *            4. LAYER   ( Layer Token )
- *            5. WEIGHTINI  ( Weight Initialization Token )
- *            7. WEIGHT_DECAY  ( Weight Decay Token )
- *            8. UNKNOWN
- */
-typedef enum {
-  TOKEN_OPT,
-  TOKEN_COST,
-  TOKEN_NET,
-  TOKEN_ACTI,
-  TOKEN_LAYER,
-  TOKEN_WEIGHTINI,
-  TOKEN_WEIGHT_DECAY,
-  TOKEN_UNKNOWN
-} InputType;
-
-/**
  * @class   NeuralNetwork Class
  * @brief   NeuralNetwork Class which has Network Configuration & Layers
  */

--- a/nntrainer/include/parse_util.h
+++ b/nntrainer/include/parse_util.h
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file	parse_util.h
+ * @date	07 May 2020
+ * @brief	This is collection of parse functions.
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#ifndef __PARSE_UTIL_H__
+#define __PARSE_UTIL_H__
+#ifdef __cplusplus
+
+#include <iostream>
+#include <string>
+
+namespace nntrainer {
+
+/**
+ * @brief     Enumeration for input configuration file parsing
+ *            0. OPT     ( Optimizer Token )
+ *            1. COST    ( Cost Function Token )
+ *            2. NET     ( Network Token )
+ *            3. ACTI    ( Activation Token )
+ *            4. LAYER   ( Layer Token )
+ *            5. WEIGHTINI  ( Weight Initialization Token )
+ *            7. WEIGHT_DECAY  ( Weight Decay Token )
+ *            8. UNKNOWN
+ */
+typedef enum {
+  TOKEN_OPT,
+  TOKEN_COST,
+  TOKEN_NET,
+  TOKEN_ACTI,
+  TOKEN_LAYER,
+  TOKEN_WEIGHTINI,
+  TOKEN_WEIGHT_DECAY,
+  TOKEN_UNKNOWN
+} InputType;
+
+/**
+ * @brief     compare character to remove case sensitivity
+ * @param[in] c1 characer #1
+ * @param[in] c2 characer #2
+ * @retval    boolean true if they are same
+ */
+bool compareChar(char &c1, char &c2);
+
+/**
+ * @brief     compare string with case insensitive
+ * @param[in] str1 string #1
+ * @param[in] str2 string #2
+ * @retval    boolean true if they are same
+ */
+bool caseInSensitiveCompare(std::string &str1, std::string &str2);
+
+/**
+ * @brief     Parsing Configuration Token
+ * @param[in] ll string to be parsed
+ * @param[in] t  Token type
+ * @retval    int enumerated type
+ */
+unsigned int parseType(std::string ll, InputType t);
+
+} /* namespace nntrainer */
+
+#endif /* __cplusplus */
+#endif /* __PARSE_UTIL_H__ */

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -22,7 +22,8 @@ nntrainer_sources = [
   'src/databuffer_func.cpp',
   'src/nntrainer_logger.cpp',
   'src/optimizer.cpp',
-  'src/util_func.cpp'
+  'src/util_func.cpp',
+  'src/parse_util.cpp'
 ]
 
 nntrainer_headers = [
@@ -35,7 +36,8 @@ nntrainer_headers = [
   'include/nntrainer_log.h',
   'include/nntrainer_logger.h',
   'include/optimizer.h',
-  'include/util_func.h'
+  'include/util_func.h',
+  'include/parse_util.h'
 ]
 
 

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -26,6 +26,7 @@
 #include "databuffer_func.h"
 #include "iniparser.h"
 #include "nntrainer_error.h"
+#include "parse_util.h"
 #include <array>
 #include <assert.h>
 #include <cmath>
@@ -44,30 +45,6 @@
 
 namespace nntrainer {
 
-/**
- * @brief     compare character to remove case sensitivity
- * @param[in] c1 characer #1
- * @param[in] c2 characer #2
- * @retval    boolean true if they are same
- */
-bool compareChar(char &c1, char &c2) {
-  if (c1 == c2)
-    return true;
-  else if (std::toupper(c1) == std::toupper(c2))
-    return true;
-  return false;
-}
-
-/**
- * @brief     compare string with case insensitive
- * @param[in] str1 string #1
- * @param[in] str2 string #2
- * @retval    boolean true if they are same
- */
-bool caseInSensitiveCompare(std::string &str1, std::string &str2) {
-  return ((str1.size() == str2.size()) &&
-          std::equal(str1.begin(), str1.end(), str2.begin(), &compareChar));
-}
 
 /**
  * @brief     Check Existance of File
@@ -94,144 +71,6 @@ std::vector<std::string> parseLayerName(std::string ll) {
       ret.push_back(word);
   } while (ss);
 
-  return ret;
-}
-
-/**
- * @brief     Parsing Configuration Token
- * @param[in] ll string to be parsed
- * @param[in] t  Token type
- * @retval    int enumerated type
- */
-unsigned int parseType(std::string ll, InputType t) {
-  int ret;
-  unsigned int i;
-  /**
-   * @brief     Optimizer String from configure file
-   *            "sgd"  : Stochestic Gradient Descent
-   *            "adam" : Adaptive Moment Estimation
-   */
-  std::array<std::string, 3> optimizer_string = {"sgd", "adam", "unknown"};
-
-  /**
-   * @brief     Cost Function String from configure file
-   *            "msr"  : Mean Squared Roots
-   *            "caterogical" : Categorical Cross Entropy
-   */
-  std::array<std::string, 3> cost_string = {"msr", "cross", "unknown"};
-
-  /**
-   * @brief     Network Type String from configure file
-   *            "knn"  : K Neearest Neighbor
-   *            "regression" : Logistic Regression
-   *            "neuralnet" : Neural Network
-   */
-  std::array<std::string, 4> network_type_string = {"knn", "regression",
-                                                    "neuralnet", "unknown"};
-
-  /**
-   * @brief     Activation Type String from configure file
-   *            "tanh"  : tanh
-   *            "sigmoid" : sigmoid
-   *            "relu" : relu
-   *            "softmax" : softmax
-   */
-  std::array<std::string, 5> activation_string = {"tanh", "sigmoid", "relu",
-                                                  "softmax", "unknown"};
-
-  /**
-   * @brief     Layer Type String from configure file
-   *            "input"  : Input Layer Object
-   *            "fully_conntected" : Fully Connected Layer Object
-   *            "batch_normalization" : Batch Normalization Layer Object
-   *            "unknown" : Batch Normalization Layer Object
-   */
-  std::array<std::string, 4> layer_string = {"input", "fully_connected",
-                                             "batch_normalization", "unknown"};
-
-  /**
-   * @brief     Weight Initialization Type String from configure file
-   *            "lecun_normal"  : LeCun Normal Initialization
-   *            "lecun_uniform"  : LeCun Uniform Initialization
-   *            "xavier_normal"  : Xavier Normal Initialization
-   *            "xavier_uniform"  : Xavier Uniform Initialization
-   *            "he_normal"  : He Normal Initialization
-   *            "he_uniform"  : He Uniform Initialization
-   */
-  std::array<std::string, 7> weight_ini_string = {
-    "lecun_normal", "lecun_uniform", "xavier_normal", "xavier_uniform",
-    "he_normal",    "he_uniform",    "unknown"};
-
-  /**
-   * @brief     Weight Decay String from configure file
-   *            "L2Norm"  : squared norm regularization
-   *            "Regression" : Regression
-   */
-  std::array<std::string, 3> weight_decay_string = {"l2norm", "regression",
-                                                    "unknown"};
-
-  switch (t) {
-  case TOKEN_OPT:
-    for (i = 0; i < optimizer_string.size(); i++) {
-      if (caseInSensitiveCompare(optimizer_string[i], ll)) {
-        return (i);
-      }
-    }
-    ret = i - 1;
-    break;
-  case TOKEN_COST:
-    for (i = 0; i < cost_string.size(); i++) {
-      if (caseInSensitiveCompare(cost_string[i], ll)) {
-        return (i);
-      }
-    }
-    ret = i - 1;
-    break;
-  case TOKEN_NET:
-    for (i = 0; i < network_type_string.size(); i++) {
-      if (caseInSensitiveCompare(network_type_string[i], ll)) {
-        return (i);
-      }
-    }
-    ret = i - 1;
-    break;
-  case TOKEN_ACTI:
-    for (i = 0; i < activation_string.size(); i++) {
-      if (caseInSensitiveCompare(activation_string[i], ll)) {
-        return (i);
-      }
-    }
-    ret = i - 1;
-    break;
-  case TOKEN_LAYER:
-    for (i = 0; i < layer_string.size(); i++) {
-      if (caseInSensitiveCompare(layer_string[i], ll)) {
-        return (i);
-      }
-    }
-    ret = i - 1;
-    break;
-  case TOKEN_WEIGHTINI:
-    for (i = 0; i < weight_ini_string.size(); i++) {
-      if (caseInSensitiveCompare(weight_ini_string[i], ll)) {
-        return (i);
-      }
-    }
-    ret = i - 1;
-    break;
-  case TOKEN_WEIGHT_DECAY:
-    for (i = 0; i < weight_decay_string.size(); i++) {
-      if (caseInSensitiveCompare(weight_decay_string[i], ll)) {
-        return (i);
-      }
-    }
-    ret = i - 1;
-    break;
-  case TOKEN_UNKNOWN:
-  default:
-    ret = 3;
-    break;
-  }
   return ret;
 }
 

--- a/nntrainer/src/parse_util.cpp
+++ b/nntrainer/src/parse_util.cpp
@@ -1,0 +1,170 @@
+/**
+ * Copyright (C) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file	parse_util.cpp
+ * @date	08 April 2020
+ * @brief	This is collection of math functions
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#include "parse_util.h"
+#include <array>
+#include <assert.h>
+#include <string.h>
+
+namespace nntrainer {
+
+unsigned int parseType(std::string ll, InputType t) {
+  int ret;
+  unsigned int i;
+  /**
+   * @brief     Optimizer String from configure file
+   *            "sgd"  : Stochestic Gradient Descent
+   *            "adam" : Adaptive Moment Estimation
+   */
+  std::array<std::string, 3> optimizer_string = {"sgd", "adam", "unknown"};
+
+  /**
+   * @brief     Cost Function String from configure file
+   *            "msr"  : Mean Squared Roots
+   *            "caterogical" : Categorical Cross Entropy
+   */
+  std::array<std::string, 3> cost_string = {"msr", "cross", "unknown"};
+
+  /**
+   * @brief     Network Type String from configure file
+   *            "knn"  : K Neearest Neighbor
+   *            "regression" : Logistic Regression
+   *            "neuralnet" : Neural Network
+   */
+  std::array<std::string, 4> network_type_string = {"knn", "regression",
+                                                    "neuralnet", "unknown"};
+
+  /**
+   * @brief     Activation Type String from configure file
+   *            "tanh"  : tanh
+   *            "sigmoid" : sigmoid
+   *            "relu" : relu
+   *            "softmax" : softmax
+   */
+  std::array<std::string, 5> activation_string = {"tanh", "sigmoid", "relu",
+                                                  "softmax", "unknown"};
+
+  /**
+   * @brief     Layer Type String from configure file
+   *            "input"  : Input Layer Object
+   *            "fully_conntected" : Fully Connected Layer Object
+   *            "batch_normalization" : Batch Normalization Layer Object
+   *            "unknown" : Batch Normalization Layer Object
+   */
+  std::array<std::string, 4> layer_string = {"input", "fully_connected",
+                                             "batch_normalization", "unknown"};
+
+  /**
+   * @brief     Weight Initialization Type String from configure file
+   *            "lecun_normal"  : LeCun Normal Initialization
+   *            "lecun_uniform"  : LeCun Uniform Initialization
+   *            "xavier_normal"  : Xavier Normal Initialization
+   *            "xavier_uniform"  : Xavier Uniform Initialization
+   *            "he_normal"  : He Normal Initialization
+   *            "he_uniform"  : He Uniform Initialization
+   */
+  std::array<std::string, 7> weight_ini_string = {
+    "lecun_normal", "lecun_uniform", "xavier_normal", "xavier_uniform",
+    "he_normal",    "he_uniform",    "unknown"};
+
+  /**
+   * @brief     Weight Decay String from configure file
+   *            "L2Norm"  : squared norm regularization
+   *            "Regression" : Regression
+   */
+  std::array<std::string, 3> weight_decay_string = {"l2norm", "regression",
+                                                    "unknown"};
+
+  switch (t) {
+  case TOKEN_OPT:
+    for (i = 0; i < optimizer_string.size(); i++) {
+      if (!strncasecmp(optimizer_string[i].c_str(), ll.c_str(),
+                       optimizer_string[i].size())) {
+        return (i);
+      }
+    }
+    ret = i - 1;
+    break;
+  case TOKEN_COST:
+    for (i = 0; i < cost_string.size(); i++) {
+      if (!strncasecmp(cost_string[i].c_str(), ll.c_str(),
+                       cost_string[i].size())) {
+        return (i);
+      }
+    }
+    ret = i - 1;
+    break;
+  case TOKEN_NET:
+    for (i = 0; i < network_type_string.size(); i++) {
+      if (!strncasecmp(network_type_string[i].c_str(), ll.c_str(),
+                       network_type_string[i].size())) {
+        return (i);
+      }
+    }
+    ret = i - 1;
+    break;
+  case TOKEN_ACTI:
+    for (i = 0; i < activation_string.size(); i++) {
+      if (!strncasecmp(activation_string[i].c_str(), ll.c_str(),
+                       activation_string[i].size())) {
+
+        return (i);
+      }
+    }
+    ret = i - 1;
+    break;
+  case TOKEN_LAYER:
+    for (i = 0; i < layer_string.size(); i++) {
+      if (!strncasecmp(layer_string[i].c_str(), ll.c_str(),
+                       layer_string[i].size())) {
+        return (i);
+      }
+    }
+    ret = i - 1;
+    break;
+  case TOKEN_WEIGHTINI:
+    for (i = 0; i < weight_ini_string.size(); i++) {
+      if (!strncasecmp(weight_ini_string[i].c_str(), ll.c_str(),
+                       weight_ini_string[i].size())) {
+        return (i);
+      }
+    }
+    ret = i - 1;
+    break;
+  case TOKEN_WEIGHT_DECAY:
+    for (i = 0; i < weight_decay_string.size(); i++) {
+      if (!strncasecmp(weight_decay_string[i].c_str(), ll.c_str(),
+                       weight_decay_string[i].size())) {
+        return (i);
+      }
+    }
+    ret = i - 1;
+    break;
+  case TOKEN_UNKNOWN:
+  default:
+    ret = 3;
+    break;
+  }
+  return ret;
+}
+
+} /* namespace nntrainer */

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -50,6 +50,10 @@ int TensorDim::setTensorDim(std::string input_shape) {
   int cn = 0;
   for (std::sregex_iterator i = words_begin; i != words_end; ++i) {
     dim[MAXDIM - cur_dim + cn] = std::stoi((*i).str());
+    if (dim[MAXDIM - cur_dim + cn] <= 0) {
+      ml_loge("Tensor Dimension should be greater than 0");
+      return ML_ERROR_INVALID_PARAMETER;
+    }
     cn++;
   }
   return status;

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -185,6 +185,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/nntrainer_logger.h
 %{_includedir}/nntrainer/optimizer.h
 %{_includedir}/nntrainer/util_func.h
+%{_includedir}/nntrainer/parse_util.h
 %{_libdir}/*.a
 %{_libdir}/pkgconfig/nntrainer.pc
 

--- a/test/tizen_capi/unittest_tizen_capi_layer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_layer.cpp
@@ -56,7 +56,41 @@ TEST(nntrainer_capi_nnlayer, create_delete_03_n) {
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
+/**
+ * @brief Neural Network Layer Create / Delete Test (negative test )
+ */
+TEST(nntrainer_capi_nnlayer, setproperty_01_p) {
+  ml_nnlayer_h handle;
+  int status;
+  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_nnlayer_set_property(handle, ML_INPUT_SHAPE, "32:1:1:6270");
+  EXPECT_EQ(status, ML_ERROR_NONE);
 
+  status = ml_nnlayer_set_property(handle, ML_NORMALIZATION, "true");
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  
+  status = ml_nnlayer_set_property(handle, ML_STANDARDIZATION, "true");
+  EXPECT_EQ(status, ML_ERROR_NONE);    
+}
+
+/**
+ * @brief Neural Network Layer Create / Delete Test (negative test )
+ */
+TEST(nntrainer_capi_nnlayer, setproperty_02_p) {
+  ml_nnlayer_h handle;
+  int status;
+  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_nnlayer_set_property(handle, ML_INPUT_SHAPE, "32:1:1:6270");
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_nnlayer_set_property(handle, ML_BIAS_ZERO, "true");
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  
+  status = ml_nnlayer_set_property(handle, ML_ACTIVATION, "sigmoid");
+  EXPECT_EQ(status, ML_ERROR_NONE);    
+}
 
 /**
  * @brief Main gtest


### PR DESCRIPTION
. Implement Set Property API for Neural Network Layer
  - Each layer has setProperty methods with its own Property enum
  class.
  - Layer Class has virtual setProperty Class
  - Seperate parseType and make parse_util.h & cpp to use other
  files.
  - Use TensorDim for Define demesion of hidden layer

**Changes proposed in this PR:**
- Added TOC generator for README.md

Resolves:

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>