### PR TITLE
[UnitTest/DCube] Genereate gtest xml files to report unittest results

### DIFF
--- a/packaging/run_unittests.sh
+++ b/packaging/run_unittests.sh
@@ -9,15 +9,21 @@
 ret=0
 pushd build
 
+run_entry() {
+  entry=$1
+  ${entry} --gtest_output="xml:${entry##*/}.xml"
+  return $?
+}
+
 if [ -f "$1" ]; then
     echo $1
-    {$1}
+    run_entry $1
     return $?
 elif [ -d "$1" ]; then
     testlist=$(find $1 -type f -executable -name "unittest_*")
     for t in ${testlist}; do
 	echo "running: ${t} @$(pwd)"
-	${t}
+	run_entry ${t}
 	ret=$?
 	if [ $ret -ne 0 ]; then
 	    break


### PR DESCRIPTION
This patch generates gtest xml files reported to DCube as unittest
results.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>