### PR TITLE
[API] Modify to get Multiple Property Arguments

### DIFF
--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -174,14 +174,12 @@ int ml_nnlayer_delete(ml_nnlayer_h layer);
  * @details Use this function to set Neural Netowrk Layer Property.
  * @since_tizen 6.x
  * @param[in] layer The NNTrainer Layer handler from the given description.
- * @param[in]  key Property key to set
- * @param[in]  value Property value
+ * @param[in]  ... Property values with NULL for termination.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
  */
-int ml_nnlayer_set_property(ml_nnlayer_h layer, const char* key,
-                            const char *value);
+int ml_nnlayer_set_property(ml_nnlayer_h layer, const char *key,...);
 
 /**
  * @}

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -24,6 +24,8 @@
 #include "neuralnet.h"
 #include "nntrainer_internal.h"
 #include "nntrainer_log.h"
+#include "parse_util.h"
+#include <stdarg.h>
 #include <string.h>
 
 #ifdef __cplusplus
@@ -180,16 +182,27 @@ int ml_nnlayer_delete(ml_nnlayer_h layer) {
   return status;
 }
 
-int ml_nnlayer_set_property(ml_nnlayer_h layer, const char *key,
-                            const char *value) {
+int ml_nnlayer_set_property(ml_nnlayer_h layer, const char *key, ...) {
   int status = ML_ERROR_NONE;
   ml_nnlayer *nnlayer;
+  const char *data;
+
   ML_NNTRAINER_CHECK_LAYER_VALIDATION(nnlayer, layer);
+
+  std::vector<std::string> arg_list;
+  va_list arguments;
+  va_start(arguments, key);
+
+  while ((data = va_arg(arguments, const char *))) {
+    arg_list.push_back(data);
+  }
+
+  va_end(arguments);
 
   std::shared_ptr<nntrainer::Layer> NL;
   NL = nnlayer->layer;
 
-  status = NL->setProperty(key, value);
+  status = NL->setProperty(key, arg_list);
 
   return status;
 }

--- a/nntrainer/include/layers.h
+++ b/nntrainer/include/layers.h
@@ -145,11 +145,11 @@ public:
   /**
    * @brief     set Property of layer
    * @param[in] key key of property
-   * @param[in] value value of property
+   * @param[in] values values of property
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int setProperty(const char *key, const char *value) = 0;
+  virtual int setProperty(const char *key, std::vector<std::string> values) = 0;
 
   /**
    * @brief     Optimizer Setter
@@ -338,11 +338,11 @@ public:
   /**
    * @brief     set Property of layer
    * @param[in] key key of property
-   * @param[in] value value of property
+   * @param[in] values values of property
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int setProperty(const char *key, const char *value);
+  int setProperty(const char *key, std::vector<std::string> values);
 
   /**
    * @brief     Property Enumeration
@@ -451,11 +451,11 @@ public:
   /**
    * @brief     set Property of layer
    * @param[in] key key of property
-   * @param[in] value value of property
+   * @param[in] values values of property
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int setProperty(const char *key, const char *value);
+  int setProperty(const char *key, std::vector<std::string> values);
 
   /**
    * @brief     Property Enumeration
@@ -558,11 +558,11 @@ public:
   /**
    * @brief     set Property of layer
    * @param[in] key key of property
-   * @param[in] value value of property
+   * @param[in] values values of property
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int setProperty(const char *key, const char *value);
+  int setProperty(const char *key, std::vector<std::string> values);
 
   /**
    * @brief     Property Enumeration

--- a/nntrainer/src/layers.cpp
+++ b/nntrainer/src/layers.cpp
@@ -172,22 +172,22 @@ int InputLayer::setOptimizer(Optimizer &opt) {
   return this->opt.initialize(dim.height(), dim.width(), false);
 }
 
-int InputLayer::setProperty(const char *key, const char *value) {
+int InputLayer::setProperty(const char *key, std::vector<std::string> values) {
   int status = ML_ERROR_NONE;
   unsigned int type = parseLayerProperty(key);
 
   switch (static_cast<PropertyType>(type)) {
   case PropertyType::input_shape:
-    status = dim.setTensorDim(value);
+    status = dim.setTensorDim(values[0].c_str());
     break;
   case PropertyType::bias_zero:
-    init_zero = (strcasecmp("true", value) == 0);
+    init_zero = (strcasecmp("true", values[0].c_str()) == 0);
     break;
   case PropertyType::normalization:
-    normalization = (strcasecmp("true", value) == 0);
+    normalization = (strcasecmp("true", values[0].c_str()) == 0);
     break;
   case PropertyType::standardization:
-    standardization = (strcasecmp("true", value) == 0);
+    standardization = (strcasecmp("true", values[0].c_str()) == 0);
     break;
   default:
     ml_loge("Error: Unknown Layer Property Key");
@@ -270,20 +270,20 @@ int FullyConnectedLayer::setCost(CostType c) {
   return status;
 }
 
-int FullyConnectedLayer::setProperty(const char *key, const char *value) {
+int FullyConnectedLayer::setProperty(const char *key, std::vector<std::string> values) {
   int status = ML_ERROR_NONE;
   unsigned int type = parseLayerProperty(key);
 
   switch (static_cast<PropertyType>(type)) {
   case PropertyType::input_shape:
-    status = dim.setTensorDim(value);
+    status = dim.setTensorDim(values[0].c_str());
     break;
   case PropertyType::bias_zero: {
-    bool isTrue = (strcasecmp("true", value) == 0);
+    bool isTrue = (strcasecmp("true", values[0].c_str()) == 0);
     init_zero = isTrue;
   } break;
   case PropertyType::activation:
-    status = setActivation((ActiType)parseType(value, TOKEN_ACTI));
+    status = setActivation((ActiType)parseType(values[0].c_str(), TOKEN_ACTI));
     break;
   default:
     ml_loge("Error: Unknown Layer Property Key");
@@ -507,20 +507,20 @@ int BatchNormalizationLayer::setOptimizer(Optimizer &opt) {
   return this->opt.initialize(dim.height(), dim.width(), false);
 }
 
-int BatchNormalizationLayer::setProperty(const char *key, const char *value) {
+int BatchNormalizationLayer::setProperty(const char *key, std::vector<std::string> values) {
   int status = ML_ERROR_NONE;
   unsigned int type = parseLayerProperty(key);
 
   switch (static_cast<PropertyType>(type)) {
   case PropertyType::input_shape:
-    status = dim.setTensorDim(value);
+    status = dim.setTensorDim(values[0].c_str());
     break;
   case PropertyType::bias_zero: {
-    bool isTrue = (strcasecmp("true", value) == 0);
+    bool isTrue = (strcasecmp("true", values[0].c_str()) == 0);
     init_zero = isTrue;
   } break;
   case PropertyType::epsilon:
-    epsilon = std::stof(value);
+    epsilon = std::stof(values[0].c_str());
     break;
   default:
     ml_loge("Error: Unknown Layer Property Key");

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -156,10 +156,10 @@ TEST(nntrainer_capi_nnmodel, addLayer_01_p) {
   status = ml_nnlayer_create(&layer, ML_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layer, "input_shape", "32:1:1:6270");
+  status = ml_nnlayer_set_property(layer, "input_shape", "32:1:1:6270", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layer, "normalization", "true");
+  status = ml_nnlayer_set_property(layer, "normalization", "true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_nnmodel_add_layer(model, layer);

--- a/test/tizen_capi/unittest_tizen_capi_layer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_layer.cpp
@@ -64,13 +64,13 @@ TEST(nntrainer_capi_nnlayer, setproperty_01_p) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "input_shape", "32:1:1:6270");
+  status = ml_nnlayer_set_property(handle, "input_shape", "32:1:1:6270", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(handle, "normalization", "true");
+  status = ml_nnlayer_set_property(handle, "normalization", "true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(handle, "standardization", "true");
+  status = ml_nnlayer_set_property(handle, "standardization", "true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -84,13 +84,13 @@ TEST(nntrainer_capi_nnlayer, setproperty_02_p) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "input_shape", "32:1:1:6270");
+  status = ml_nnlayer_set_property(handle, "input_shape", "32:1:1:6270", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(handle, "bias_zero", "true");
+  status = ml_nnlayer_set_property(handle, "bias_zero", "true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(handle, "activation", "sigmoid");
+  status = ml_nnlayer_set_property(handle, "activation", "sigmoid", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -104,7 +104,7 @@ TEST(nntrainer_capi_nnlayer, setproperty_03_n) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "activation", "sigmoid");
+  status = ml_nnlayer_set_property(handle, "activation", "sigmoid", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -118,7 +118,7 @@ TEST(nntrainer_capi_nnlayer, setproperty_04_n) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "input_shape", "0:0:0:1");
+  status = ml_nnlayer_set_property(handle, "input_shape", "0:0:0:1", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -132,7 +132,7 @@ TEST(nntrainer_capi_nnlayer, setproperty_05_n) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "epsilon", "0.0001");
+  status = ml_nnlayer_set_property(handle, "epsilon", "0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -146,7 +146,7 @@ TEST(nntrainer_capi_nnlayer, setproperty_06_n) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "epsilon", "0.0001");
+  status = ml_nnlayer_set_property(handle, "epsilon", "0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -160,7 +160,7 @@ TEST(nntrainer_capi_nnlayer, setproperty_07_n) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "activation", "0.0001");
+  status = ml_nnlayer_set_property(handle, "activation", "0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);


### PR DESCRIPTION
Modify ml_nnlayer_set_property () to get multiple arguments for
property.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>