### PR TITLE
[API] change key, value format for the property

### DIFF
--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -185,7 +185,7 @@ int ml_nnlayer_delete(ml_nnlayer_h layer);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
  */
-int ml_nnlayer_set_property(ml_nnlayer_h layer, const char *key,...);
+int ml_nnlayer_set_property(ml_nnlayer_h layer, ...);
 
 /**
  * @brief Create the neural network optimizer.

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -179,7 +179,7 @@ int ml_nnlayer_delete(ml_nnlayer_h layer) {
   return status;
 }
 
-int ml_nnlayer_set_property(ml_nnlayer_h layer, const char *key, ...) {
+int ml_nnlayer_set_property(ml_nnlayer_h layer, ...) {
   int status = ML_ERROR_NONE;
   ml_nnlayer *nnlayer;
   const char *data;
@@ -188,7 +188,7 @@ int ml_nnlayer_set_property(ml_nnlayer_h layer, const char *key, ...) {
 
   std::vector<std::string> arg_list;
   va_list arguments;
-  va_start(arguments, key);
+  va_start(arguments, layer);
 
   while ((data = va_arg(arguments, const char *))) {
     arg_list.push_back(data);
@@ -199,7 +199,7 @@ int ml_nnlayer_set_property(ml_nnlayer_h layer, const char *key, ...) {
   std::shared_ptr<nntrainer::Layer> NL;
   NL = nnlayer->layer;
 
-  status = NL->setProperty(key, arg_list);
+  status = NL->setProperty(arg_list);
 
   return status;
 }
@@ -235,7 +235,6 @@ int ml_nnoptimizer_set_property(ml_nnopt_h opt, ...) {
   int status = ML_ERROR_NONE;
   ml_nnopt *nnopt;
   const char *data;
-  int count = 0;
   nnopt = (ml_nnopt *)opt;
   ML_NNTRAINER_CHECK_OPT_VALIDATION(nnopt, opt);
 
@@ -246,7 +245,6 @@ int ml_nnoptimizer_set_property(ml_nnopt_h opt, ...) {
 
   while ((data = va_arg(arguments, const char *))) {
     arg_list.push_back(data);
-    count++;
   }
 
   va_end(arguments);

--- a/nntrainer/include/layers.h
+++ b/nntrainer/include/layers.h
@@ -144,12 +144,11 @@ public:
 
   /**
    * @brief     set Property of layer
-   * @param[in] key key of property
    * @param[in] values values of property
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int setProperty(const char *key, std::vector<std::string> values) = 0;
+  virtual int setProperty(std::vector<std::string> values) = 0;
 
   /**
    * @brief     Optimizer Setter
@@ -341,12 +340,11 @@ public:
 
   /**
    * @brief     set Property of layer
-   * @param[in] key key of property
    * @param[in] values values of property
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int setProperty(const char *key, std::vector<std::string> values);
+  int setProperty(std::vector<std::string> values);
 
   /**
    * @brief     Property Enumeration
@@ -454,25 +452,26 @@ public:
 
   /**
    * @brief     set Property of layer
-   * @param[in] key key of property
    * @param[in] values values of property
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int setProperty(const char *key, std::vector<std::string> values);
+  int setProperty(std::vector<std::string> values);
 
   /**
    * @brief     Property Enumeration
    *            0. input shape : string
    *            1. bias zero : bool
    *            4. activation : bool
-   *            6. weight_decay : string (type), float
+   *            6. weight_decay : string (type)
+   *            7. weight_decay_lambda : float
    */
   enum class PropertyType {
     input_shape = 0,
     bias_zero = 1,
     activation = 4,
-    weight_decay = 6
+    weight_decay = 6,
+    weight_decay_lambda = 7,
   };
 
 private:
@@ -573,12 +572,11 @@ public:
 
   /**
    * @brief     set Property of layer
-   * @param[in] key key of property
    * @param[in] values values of property
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int setProperty(const char *key, std::vector<std::string> values);
+  int setProperty(std::vector<std::string> values);
 
   /**
    * @brief     Property Enumeration

--- a/nntrainer/include/parse_util.h
+++ b/nntrainer/include/parse_util.h
@@ -29,6 +29,13 @@
 
 namespace nntrainer {
 
+#define NN_RETURN_STATUS()         \
+  do {                             \
+    if (status != ML_ERROR_NONE) { \
+      return status;               \
+    }                              \
+  } while (0)
+
 /**
  * @brief     Enumeration for input configuration file parsing
  *            0. OPT     ( Optimizer Token )
@@ -99,6 +106,16 @@ int setDouble(double &val, std::string str);
  * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
  */
 int setBoolean(bool &val, std::string str);
+
+/**
+ * @brief     parse string and return key & value
+ * @param[in] input_str input string to split with '='
+ * @param[out] key key
+ * @param[out] value value
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+ */
+int getKeyValue(std::string input_str, std::string &key, std::string &value);
 
 } /* namespace nntrainer */
 

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -35,7 +35,7 @@
 #include <sstream>
 #include <stdio.h>
 
-#define NN_RETURN_STATUS()         \
+#define NN_INI_RETURN_STATUS()     \
   do {                             \
     if (status != ML_ERROR_NONE) { \
       iniparser_freedict(ini);     \
@@ -173,7 +173,7 @@ int NeuralNetwork::init() {
   epoch = iniparser_getint(ini, "Network:Epoch", 100);
   status = opt.setType((OptType)parseType(
     iniparser_getstring(ini, "Network:Optimizer", unknown), TOKEN_OPT));
-  NN_RETURN_STATUS();
+  NN_INI_RETURN_STATUS();
 
   cost = (CostType)parseType(iniparser_getstring(ini, "Network:Cost", unknown),
                              TOKEN_COST);
@@ -188,7 +188,7 @@ int NeuralNetwork::init() {
   popt.epsilon = iniparser_getdouble(ini, "Network:epsilon", 0.0);
 
   status = opt.setOptParam(popt);
-  NN_RETURN_STATUS();
+  NN_INI_RETURN_STATUS();
 
   for (unsigned int i = 0; i < layers_name.size(); i++)
     ml_logi("%s", layers_name[i].c_str());
@@ -235,16 +235,16 @@ int NeuralNetwork::init() {
       static_cast<DataBufferFromDataFile *>(data_buffer);
     status = dbuffer->setDataFile(
       iniparser_getstring(ini, "DataSet:TrainData", ""), DATA_TRAIN);
-    NN_RETURN_STATUS();
+    NN_INI_RETURN_STATUS();
     status = dbuffer->setDataFile(
       iniparser_getstring(ini, "DataSet:ValidData", ""), DATA_VAL);
-    NN_RETURN_STATUS();
+    NN_INI_RETURN_STATUS();
     status = dbuffer->setDataFile(
       iniparser_getstring(ini, "DataSet:TestData", ""), DATA_TEST);
-    NN_RETURN_STATUS();
+    NN_INI_RETURN_STATUS();
     status = dbuffer->setDataFile(
       iniparser_getstring(ini, "DataSet:LabelData", ""), DATA_LABEL);
-    NN_RETURN_STATUS();
+    NN_INI_RETURN_STATUS();
 
   } else if (iniparser_find_entry(ini, "DataSet:Tflite")) {
     ml_loge("Error: Not yet implemented!");
@@ -254,10 +254,10 @@ int NeuralNetwork::init() {
   }
 
   status = data_buffer->setMiniBatch(batch_size);
-  NN_RETURN_STATUS();
+  NN_INI_RETURN_STATUS();
 
   status = data_buffer->setClassNum(hidden_size[layers_name.size() - 1]);
-  NN_RETURN_STATUS();
+  NN_INI_RETURN_STATUS();
 
   status = data_buffer->setBufSize(
     iniparser_getint(ini, "DataSet:BufferSize", batch_size));
@@ -282,10 +282,10 @@ int NeuralNetwork::init() {
       input_layer->setType(t);
       status = input_layer->initialize(batch_size, 1, hidden_size[i], last,
                                        b_zero, weight_ini);
-      NN_RETURN_STATUS();
+      NN_INI_RETURN_STATUS();
 
       status = input_layer->setOptimizer(opt);
-      NN_RETURN_STATUS();
+      NN_INI_RETURN_STATUS();
 
       input_layer->setNormalization(iniparser_getboolean(
         ini, (layers_name[i] + ":Normalization").c_str(), false));
@@ -295,7 +295,7 @@ int NeuralNetwork::init() {
         iniparser_getstring(ini, (layers_name[i] + ":Activation").c_str(),
                             unknown),
         TOKEN_ACTI));
-      NN_RETURN_STATUS();
+      NN_INI_RETURN_STATUS();
       layers.push_back(input_layer);
     } break;
     case LAYER_FC: {
@@ -304,7 +304,7 @@ int NeuralNetwork::init() {
         std::make_shared<FullyConnectedLayer>();
       fc_layer->setType(t);
       status = fc_layer->setCost(cost);
-      NN_RETURN_STATUS();
+      NN_INI_RETURN_STATUS();
       if (i == 0) {
         ml_loge("Error: Fully Connected Layer should be after "
                 "InputLayer.");
@@ -312,17 +312,17 @@ int NeuralNetwork::init() {
       }
       status = fc_layer->initialize(batch_size, hidden_size[i - 1],
                                     hidden_size[i], last, b_zero, weight_ini);
-      NN_RETURN_STATUS();
+      NN_INI_RETURN_STATUS();
       status = fc_layer->setOptimizer(opt);
-      NN_RETURN_STATUS();
+      NN_INI_RETURN_STATUS();
       status = fc_layer->setActivation((ActiType)parseType(
         iniparser_getstring(ini, (layers_name[i] + ":Activation").c_str(),
                             unknown),
         TOKEN_ACTI));
-      NN_RETURN_STATUS();
+      NN_INI_RETURN_STATUS();
 
       status = setWeightDecay(ini, layers_name[i], weight_decay);
-      NN_RETURN_STATUS();
+      NN_INI_RETURN_STATUS();
 
       fc_layer->setWeightDecay(weight_decay);
       layers.push_back(fc_layer);
@@ -333,10 +333,10 @@ int NeuralNetwork::init() {
         std::make_shared<BatchNormalizationLayer>();
       bn_layer->setType(t);
       status = bn_layer->setOptimizer(opt);
-      NN_RETURN_STATUS();
+      NN_INI_RETURN_STATUS();
       status = bn_layer->initialize(batch_size, 1, hidden_size[i], last, b_zero,
                                     weight_ini);
-      NN_RETURN_STATUS();
+      NN_INI_RETURN_STATUS();
       layers.push_back(bn_layer);
       if (i == 0) {
         ml_loge("Error: BN layer shouldn't be first layer of network");
@@ -347,9 +347,9 @@ int NeuralNetwork::init() {
         iniparser_getstring(ini, (layers_name[i] + ":Activation").c_str(),
                             unknown),
         TOKEN_ACTI));
-      NN_RETURN_STATUS();
+      NN_INI_RETURN_STATUS();
       status = setWeightDecay(ini, layers_name[i], weight_decay);
-      NN_RETURN_STATUS();
+      NN_INI_RETURN_STATUS();
       bn_layer->setWeightDecay(weight_decay);
     } break;
     case LAYER_UNKNOWN:
@@ -362,10 +362,10 @@ int NeuralNetwork::init() {
   }
 
   status = data_buffer->setFeatureSize(hidden_size[0]);
-  NN_RETURN_STATUS();
+  NN_INI_RETURN_STATUS();
 
   status = data_buffer->init();
-  NN_RETURN_STATUS();
+  NN_INI_RETURN_STATUS();
 
   iniparser_freedict(ini);
   return status;

--- a/nntrainer/src/optimizer.cpp
+++ b/nntrainer/src/optimizer.cpp
@@ -27,13 +27,6 @@
 #include <parse_util.h>
 #include <util_func.h>
 
-#define NN_RETURN_STATUS()         \
-  do {                             \
-    if (status != ML_ERROR_NONE) { \
-      return status;               \
-    }                              \
-  } while (0)
-
 namespace nntrainer {
 
 Optimizer::Optimizer() {
@@ -140,40 +133,38 @@ void Optimizer::calculate(Tensor &djdw, Tensor &djdb, Tensor &weight,
 
 int Optimizer::setProperty(std::vector<std::string> values) {
   int status = ML_ERROR_NONE;
-  if (values.size() % 2 != 0) {
-    ml_loge("Error: Input values must be key:value pair!");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
 
-  for (unsigned int i = 0; i < values.size(); i += 2) {
-    unsigned int key = i;
-    unsigned int value = key + 1;
-    unsigned int type = parseOptProperty(values[key].c_str());
+  for (unsigned int i = 0; i < values.size(); ++i) {
+    std::string key;
+    std::string value;
+    status = getKeyValue(values[i], key, value);
+
+    unsigned int type = parseOptProperty(key.c_str());
 
     switch (static_cast<PropertyType>(type)) {
     case PropertyType::learning_rate:
-      status = setFloat(popt.learning_rate, values[value]);
+      status = setFloat(popt.learning_rate, value);
       NN_RETURN_STATUS();
       break;
     case PropertyType::decay_steps:
-      status = setFloat(popt.decay_steps, values[value]);
+      status = setFloat(popt.decay_steps, value);
       NN_RETURN_STATUS();
       break;
     case PropertyType::decay_rate:
-      status = setFloat(popt.decay_rate, values[value]);
+      status = setFloat(popt.decay_rate, value);
       NN_RETURN_STATUS();
       break;
     case PropertyType::beta1:
-      status = setDouble(popt.beta1, values[value]);
+      status = setDouble(popt.beta1, value);
       NN_RETURN_STATUS();
 
       break;
     case PropertyType::beta2:
-      status = setDouble(popt.beta2, values[value]);
+      status = setDouble(popt.beta2, value);
       NN_RETURN_STATUS();
       break;
     case PropertyType::epsilon:
-      status = setDouble(popt.epsilon, values[value]);
+      status = setDouble(popt.epsilon, value);
       NN_RETURN_STATUS();
       break;
     default:

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -156,10 +156,10 @@ TEST(nntrainer_capi_nnmodel, addLayer_01_p) {
   status = ml_nnlayer_create(&layer, ML_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layer, "input_shape", "32:1:1:6270", NULL);
+  status = ml_nnlayer_set_property(layer, "input_shape= 32:1:1:6270", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layer, "normalization", "true", NULL);
+  status = ml_nnlayer_set_property(layer, "normalization = true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_nnmodel_add_layer(model, layer);

--- a/test/tizen_capi/unittest_tizen_capi_layer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_layer.cpp
@@ -64,13 +64,13 @@ TEST(nntrainer_capi_nnlayer, setproperty_01_p) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "input_shape", "32:1:1:6270", NULL);
+  status = ml_nnlayer_set_property(handle, "input_shape=32:1:1:6270", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(handle, "normalization", "true", NULL);
+  status = ml_nnlayer_set_property(handle, "normalization=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(handle, "standardization", "true", NULL);
+  status = ml_nnlayer_set_property(handle, "standardization=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -84,13 +84,13 @@ TEST(nntrainer_capi_nnlayer, setproperty_02_p) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "input_shape", "32:1:1:6270", NULL);
+  status = ml_nnlayer_set_property(handle, "input_shape=32:1:1:6270", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(handle, "bias_zero", "true", NULL);
+  status = ml_nnlayer_set_property(handle, "bias_zero=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(handle, "activation", "sigmoid", NULL);
+  status = ml_nnlayer_set_property(handle, "activation =sigmoid", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -104,7 +104,7 @@ TEST(nntrainer_capi_nnlayer, setproperty_03_n) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "activation", "sigmoid", NULL);
+  status = ml_nnlayer_set_property(handle, "activation= sigmoid", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -118,7 +118,7 @@ TEST(nntrainer_capi_nnlayer, setproperty_04_n) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "input_shape", "0:0:0:1", NULL);
+  status = ml_nnlayer_set_property(handle, "input_shape=0:0:0:1", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -132,7 +132,7 @@ TEST(nntrainer_capi_nnlayer, setproperty_05_n) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "epsilon", "0.0001", NULL);
+  status = ml_nnlayer_set_property(handle, "epsilon =0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -146,7 +146,7 @@ TEST(nntrainer_capi_nnlayer, setproperty_06_n) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "epsilon", "0.0001", NULL);
+  status = ml_nnlayer_set_property(handle, "epsilon =0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -160,7 +160,7 @@ TEST(nntrainer_capi_nnlayer, setproperty_07_n) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "activation", "0.0001", NULL);
+  status = ml_nnlayer_set_property(handle, "activation=0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -174,7 +174,8 @@ TEST(nntrainer_capi_nnlayer, setproperty_08_p) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "weight_decay", "l2norm", "0.0001", NULL);
+  status = ml_nnlayer_set_property(handle, "weight_decay=l2norm",
+                                   "weight_decay_lambda=0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -188,12 +189,12 @@ TEST(nntrainer_capi_nnlayer, setproperty_09_n) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "weight_decay", "unknown", "0.0001", NULL);
+  status = ml_nnlayer_set_property(handle, "weight_decay=asdfasd",
+                                   "weight_decay_lambda=0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
-
 
 /**
  * @brief Main gtest

--- a/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
@@ -76,8 +76,8 @@ TEST(nntrainer_capi_nnopt, setOptimizer_01_p) {
   int status;
   status = ml_nnoptimizer_create(&handle, "adam");
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnoptimizer_set_property(handle, "beta1", "0.002", "beta2",
-                                      "0.001", NULL);
+  status =
+    ml_nnoptimizer_set_property(handle, "beta1=0.002", "beta2=0.001", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -91,14 +91,12 @@ TEST(nntrainer_capi_nnopt, setOptimizer_02_n) {
   int status;
   status = ml_nnoptimizer_create(&handle, "adam");
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnoptimizer_set_property(handle, "beta1", "true", "beta2",
-                                      "0.001", NULL);
+  status =
+    ml_nnoptimizer_set_property(handle, "beta1=true", "beta2=0.001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnlayer_delete(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
-
-
 
 /**
  * @brief Main gtest


### PR DESCRIPTION
Instead of using multiple string to describe key-value, it would be
more intuitive to be combine with "=".

for example,
 ml_*_set_property (handle, "beta1=0.332", "beta2=0.001", NULL)

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>