### PR TITLE
[ API ] using "unit" key to get the dimension for fc layer

### DIFF
--- a/nntrainer/include/layers.h
+++ b/nntrainer/include/layers.h
@@ -467,11 +467,11 @@ public:
    *            7. weight_decay_lambda : float
    */
   enum class PropertyType {
-    input_shape = 0,
     bias_zero = 1,
     activation = 4,
     weight_decay = 6,
     weight_decay_lambda = 7,
+    unit = 8,
   };
 
 private:

--- a/nntrainer/include/parse_util.h
+++ b/nntrainer/include/parse_util.h
@@ -81,6 +81,15 @@ unsigned int parseType(std::string ll, InputType t);
 unsigned int parseOptProperty(std::string property);
 
 /**
+ * @brief     check str to be int and assign
+ * @param[out] val assign variable
+ * @param[in] str input string
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+ */
+int setInt(int &val, std::string str);
+
+/**
  * @brief     check str to be float and assign
  * @param[out] val assign variable
  * @param[in] str input string

--- a/nntrainer/src/layers.cpp
+++ b/nntrainer/src/layers.cpp
@@ -296,9 +296,12 @@ int FullyConnectedLayer::setProperty(std::vector<std::string> values) {
     unsigned int type = parseLayerProperty(key);
 
     switch (static_cast<PropertyType>(type)) {
-    case PropertyType::input_shape:
-      status = dim.setTensorDim(value);
-      break;
+    case PropertyType::unit: {
+      int width;
+      status = setInt(width, value);
+      NN_RETURN_STATUS();
+      dim.width(width);
+    } break;
     case PropertyType::bias_zero: {
       status = setBoolean(init_zero, value);
       NN_RETURN_STATUS();

--- a/nntrainer/src/parse_util.cpp
+++ b/nntrainer/src/parse_util.cpp
@@ -206,15 +206,16 @@ unsigned int parseLayerProperty(std::string property) {
    * epsilon = 5
    * weight_decay = 6
    * weight_decay_lambda = 7
+   * unit = 8
    *
    * InputLayer has 0, 1, 2, 3 properties.
-   * FullyConnectedLayer has 0, 1, 4, 6, 7 properties.
+   * FullyConnectedLayer has 1, 4, 6, 7, 8 properties.
    * BatchNormalizationLayer has 0, 1, 5, 6, 7 properties.
    */
-  std::array<std::string, 9> property_string = {
-    "input_shape",     "bias_zero",           "normalization",
-    "standardization", "activation",          "epsilon",
-    "weight_decay",    "weight_decay_lambda", "unknown"};
+  std::array<std::string, 10> property_string = {
+    "input_shape", "bias_zero", "normalization", "standardization",
+    "activation",  "epsilon",   "weight_decay",  "weight_decay_lambda",
+    "unit",        "unknown"};
 
   for (i = 0; i < property_string.size(); i++) {
     unsigned int size = (property_string[i].size() > property.size())
@@ -259,6 +260,18 @@ unsigned int parseOptProperty(std::string property) {
   ret = i - 1;
 
   return ret;
+}
+
+int setInt(int &val, std::string str) {
+  int status = ML_ERROR_NONE;
+  try {
+    val = std::stoi(str.c_str());
+  } catch (...) {
+    ml_loge("Error: Wrong Type. Must be int");
+    status = ML_ERROR_INVALID_PARAMETER;
+  }
+
+  return status;
 }
 
 int setFloat(float &val, std::string str) {

--- a/test/tizen_capi/unittest_tizen_capi_layer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_layer.cpp
@@ -84,7 +84,7 @@ TEST(nntrainer_capi_nnlayer, setproperty_02_p) {
   int status;
   status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "input_shape=32:1:1:6270", NULL);
+  status = ml_nnlayer_set_property(handle, "unit=10", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_nnlayer_set_property(handle, "bias_zero=true", NULL);


### PR DESCRIPTION
Instead of using input_shape to get the fc layer dimenson, it is
simple to get the ouptut dimesion using unit keyword.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>