### PR TITLE
[After #102] [Example] Add edc layout to the scaffolding @open sesame 05/18 16:27

### DIFF
--- a/Applications/Tizen_native/CustomShortcut/inc/data.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/data.h
@@ -14,11 +14,23 @@
 #include <tizen.h>
 #include <widget_app.h>
 #include <widget_app_efl.h>
+#include <efl_extension.h>
+
+#ifdef LOG_TAG
+#undef LOG_TAG
+#endif
+#define LOG_TAG "nntrainer-example-custom-shortcut"
+
+#define EDJ_PATH "edje/main.edj"
 
 typedef struct widget_instance_data {
   Evas_Object *win;
   Evas_Object *conform;
   Evas_Object *label;
+  Evas_Object *naviframe;
+  Eext_Circle_Surface *circle_nf;
+  Evas_Object *layout;
+  char edj_path[PATH_MAX];
 } widget_instance_data_s;
 
 #endif /* __nntrainer_example_custom_shortcut_data_H__ */

--- a/Applications/Tizen_native/CustomShortcut/inc/main.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/main.h
@@ -16,13 +16,6 @@
 #include <widget_app_efl.h>
 #include "data.h"
 
-#ifdef LOG_TAG
-#undef LOG_TAG
-#endif
-#define LOG_TAG "nntrainer-example-custom-shortcut"
-
-#define EDJ_PATH "edje/main.edj"
-
 #if !defined(PACKAGE)
 #define PACKAGE "org.example.nntrainer-example-custom-shortcut"
 #endif

--- a/Applications/Tizen_native/CustomShortcut/inc/view.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/view.h
@@ -10,11 +10,23 @@
 #define __nntrainer_example_custom_shortcut_view_H__
 
 #include "data.h"
-#include "main.h"
+#include <Elementary.h>
+#include <dlog.h>
+#include <efl_extension.h>
 
 /**
- * @brief create view
+ * @brief initiate window and conformant.
+ * @param[in] context context of widget instance
+ * @param[in] w width
+ * @param[in] h height
+ * @retval #WIDGET_ERROR_*
  */
-int view_create(widget_context_h context, int w, int h);
+int view_init(widget_context_h context, int w, int h);
+
+/**
+ * @brief creates layout from edj
+ * @param[in] context context of widget instance
+ */
+int view_create(widget_context_h context);
 
 #endif /* __nntrainer_example_custom_shortcut_view_H__ */

--- a/Applications/Tizen_native/CustomShortcut/res/edje/main.edc
+++ b/Applications/Tizen_native/CustomShortcut/res/edje/main.edc
@@ -7,23 +7,22 @@
  * @bug No known bugs except for NYI items
  */
 
- collections{
+ collections {
   group {
     name: "main" ;
-      
     parts {
       part {
         name: "main/title"; 
         type: TEXT;
-        scale: 1;
         description {
           state: "default" 0.0;
           color: 255 0 0 255;
           text {
             text: "HELLO EDC!";
-            font: "Sans";
+            font: "Tizen:style=regular";
+            size: 20;
             align: 0.5 0.5;
-         }
+          }
         }
       }
     }

--- a/Applications/Tizen_native/CustomShortcut/src/main.c
+++ b/Applications/Tizen_native/CustomShortcut/src/main.c
@@ -29,18 +29,24 @@ static int widget_instance_create(widget_context_h context, bundle *content,
   widget_app_context_set_tag(context, wid);
 
   /* Window */
-  status = view_create(context, w, h);
+  status = view_init(context, w, h);
   if (status != WIDGET_ERROR_NONE) {
     dlog_print(DLOG_ERROR, LOG_TAG, "failed to get window. err = %d", status);
     return WIDGET_ERROR_FAULT;
   }
 
-  /* Label*/
-  wid->label = elm_label_add(wid->conform);
-  evas_object_resize(wid->label, w, h / 3);
-  evas_object_move(wid->label, w / 4, h / 3);
-  evas_object_show(wid->label);
-  elm_object_text_set(wid->label, "Hello widget!");
+  char *res_path = app_get_resource_path();
+  if (res_path == NULL) {
+    status = WIDGET_ERROR_OUT_OF_MEMORY;
+    dlog_print(DLOG_ERROR, LOG_TAG, "failed to get resource. err = %d", status);
+    return status;
+  }
+  
+  snprintf(wid->edj_path, sizeof(wid->edj_path), "%s%s", res_path, EDJ_PATH);
+  free(res_path);
+  dlog_print(DLOG_INFO, LOG_TAG, "file path: %s", wid->edj_path);
+
+  status = view_create(context);
 
   return WIDGET_ERROR_NONE;
 }

--- a/Applications/Tizen_native/CustomShortcut/src/view.c
+++ b/Applications/Tizen_native/CustomShortcut/src/view.c
@@ -8,14 +8,22 @@
  */
 #include "view.h"
 
+static Evas_Object *_create_layout(Evas_Object *parent, const char *edj_path,
+                                   const char *group_name,
+                                   Eext_Event_Cb back_cb, void *user_data);
+
 /**
- * @brief create view
+ * @brief initiate window and conformant.
+ * @param[in] context context of widget
+ * @param[in] w width
+ * @param[in] h height
+ * @retval #WIDGET_ERROR_*
  */
-int view_create(widget_context_h context, int w, int h) {
+int view_init(widget_context_h context, int w, int h) {
   widget_instance_data_s *wid = NULL;
   int status = WIDGET_ERROR_NONE;
 
-  Evas_Object *win, *conform;
+  Evas_Object *win, *conform, *nf;
 
   status = widget_app_get_elm_win(context, &win);
 
@@ -27,16 +35,100 @@ int view_create(widget_context_h context, int w, int h) {
   evas_object_resize(win, w, h);
   evas_object_show(win);
 
+  // Adding conformant
   conform = elm_conformant_add(win);
+  if (conform == NULL) {
+    dlog_print(DLOG_ERROR, LOG_TAG, "failed to create conformant object");
+    evas_object_del(win);
+    return WIDGET_ERROR_FAULT;
+  }
 
   evas_object_size_hint_weight_set(conform, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
   elm_win_resize_object_add(win, conform);
   evas_object_show(conform);
 
+  // Adding naviframe
+  nf = elm_naviframe_add(conform);
+  if (nf == NULL) {
+    dlog_print(DLOG_ERROR, LOG_TAG, "failed to create naviframe object");
+    evas_object_del(win);
+    return WIDGET_ERROR_FAULT;
+  }
+
+  elm_object_part_content_set(conform, "elm.swallow.content", nf);
+  eext_object_event_callback_add(nf, EEXT_CALLBACK_BACK, eext_naviframe_back_cb,
+                                 NULL);
+  eext_object_event_callback_add(nf, EEXT_CALLBACK_MORE, eext_naviframe_more_cb,
+                                 NULL);
+
+  evas_object_show(nf);
+
   widget_app_context_get_tag(context, (void **)&wid);
 
+  wid->circle_nf = eext_circle_surface_naviframe_add(nf);
+
+  wid->naviframe = nf;
   wid->win = win;
   wid->conform = conform;
 
   return status;
+}
+
+/**
+ * @brief creates layout from edj
+ * @param[in] context context of widget instance
+ */
+int view_create(widget_context_h context) {
+  widget_instance_data_s *wid = NULL;
+  int status = WIDGET_ERROR_NONE;
+
+  widget_app_context_get_tag(context, (void **)&wid);
+  wid->layout =
+    _create_layout(wid->naviframe, wid->edj_path, "main", NULL, NULL);
+
+  if (wid->layout == NULL) {
+    dlog_print(DLOG_ERROR, LOG_TAG, "failed to create a layout of no alarm.");
+    evas_object_del(wid->win);
+    return WIDGET_ERROR_FAULT;
+  }
+
+  elm_naviframe_item_push(wid->naviframe, NULL, NULL, NULL, wid->layout,
+                          "empty");
+  return status;
+}
+
+/**
+ * @brief creates a layout for parent object with EDJ file
+ * @param[in] parent Parent object to attach to
+ * @param[in] file_path EDJ file path
+ * @param[in] group_name group name from edj
+ * @param[in] back_cb callback when back even fired.
+ * @param[in] user_data data to pass to the callback
+ */
+static Evas_Object *_create_layout(Evas_Object *parent, const char *edj_path,
+                                   const char *group_name,
+                                   Eext_Event_Cb back_cb, void *user_data) {
+  Evas_Object *layout = NULL;
+
+  if (parent == NULL) {
+    dlog_print(DLOG_ERROR, LOG_TAG, "parent cannot be NULL");
+    return NULL;
+  }
+
+  layout = elm_layout_add(parent);
+  elm_layout_file_set(layout, edj_path, group_name);
+
+  if (layout == NULL) {
+    dlog_print(DLOG_ERROR, LOG_TAG, "There was error making layout");
+    evas_object_del(layout);
+    return NULL;
+  }
+
+  if (back_cb)
+    eext_object_event_callback_add(layout, EEXT_CALLBACK_BACK, back_cb,
+                                   user_data);
+
+  evas_object_show(layout);
+
+  return layout;
 }


### PR DESCRIPTION
Add main.edc to separate UI design/interactions

**Changes proposed in this PR:**
- Add main.edc
- Add view.[ch]
- Add data.h
- Change main initiation to use view function
- Move data definitions to data.h

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
