### PR TITLE
[Bugfix] Set layer type in constructor

### DIFF
--- a/nntrainer/include/bn_layer.h
+++ b/nntrainer/include/bn_layer.h
@@ -42,7 +42,7 @@ public:
   /**
    * @brief     Constructor of Batch Noramlization Layer
    */
-  BatchNormalizationLayer() : epsilon(0.0){};
+  BatchNormalizationLayer() : epsilon(0.0){ setType (LAYER_BN); };
 
   /**
    * @brief     Destructor of BatchNormalizationLayer

--- a/nntrainer/include/fc_layer.h
+++ b/nntrainer/include/fc_layer.h
@@ -42,7 +42,7 @@ public:
   /**
    * @brief     Constructor of Fully Connected Layer
    */
-  FullyConnectedLayer() : loss(0.0), cost(COST_UNKNOWN){};
+  FullyConnectedLayer() : loss(0.0), cost(COST_UNKNOWN){ setType (LAYER_FC); };
 
   /**
    * @brief     Destructor of Fully Connected Layer

--- a/nntrainer/include/input_layer.h
+++ b/nntrainer/include/input_layer.h
@@ -42,7 +42,7 @@ public:
   /**
    * @brief     Constructor of InputLayer
    */
-  InputLayer() : normalization(false), standardization(false){};
+  InputLayer() : normalization(false), standardization(false){ setType (LAYER_IN); };
 
   /**
    * @brief     Destructor of InputLayer

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -58,7 +58,8 @@ typedef enum {
  * @brief     Enumeration of layer type
  *            0. Input Layer type
  *            1. Fully Connected Layer type
- *            2. Unknown
+ *            2. Batch Normalization Layer type
+ *            3. Unknown
  */
 typedef enum { LAYER_IN, LAYER_FC, LAYER_BN, LAYER_UNKNOWN } LayerType;
 

--- a/test/unittest/unittest_nntrainer_internal.cpp
+++ b/test/unittest/unittest_nntrainer_internal.cpp
@@ -325,6 +325,19 @@ TEST(nntrainer_InputLayer, setActivation_02_n) {
 }
 
 /**
+ * @brief Input Layer
+ */
+TEST(nntrainer_InputLayer, checkValidation_01_p) {
+  int status = ML_ERROR_NONE;
+  nntrainer::InputLayer layer;
+  layer.initialize(1, 1, 1, false, true);
+  layer.setActivation(nntrainer::ACT_TANH);
+
+  status = layer.checkValidation();
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
  * @brief Fully Connected Layer
  */
 TEST(nntrainer_FullyConnectedLayer, initialize_01_p) {
@@ -469,6 +482,20 @@ TEST(nntrainer_FullyConnectedLayer, setCost_02_n) {
 }
 
 /**
+ * @brief FullyConnected Layer
+ */
+TEST(nntrainer_FullyConnectedLayer, checkValidation_01_p) {
+  int status = ML_ERROR_NONE;
+  nntrainer::FullyConnectedLayer layer;
+
+  layer.initialize(1, 1, 1, false, true);
+  layer.setActivation(nntrainer::ACT_RELU);
+
+  status = layer.checkValidation();
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
  * @brief Batch Normalization Layer
  */
 TEST(nntrainer_BatchNormalizationLayer, initialize_01_p) {
@@ -528,6 +555,20 @@ TEST(nntrainer_BatchNormalizationLayer, setActivation_02_n) {
   nntrainer::BatchNormalizationLayer layer;
   status = layer.setActivation(nntrainer::ACT_UNKNOWN);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+/**
+ * @brief Batch Normalization Layer
+ */
+TEST(nntrainer_BatchNormalizationLayer, checkValidation_01_p)
+{
+  int status = ML_ERROR_NONE;
+  nntrainer::BatchNormalizationLayer layer;
+  layer.initialize(1, 1, 1, false, true);
+  layer.setActivation(nntrainer::ACT_RELU);
+
+  status = layer.checkValidation();
+  EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
 TEST(nntrainer_TensorDim, setTensorDim_01_p) {


### PR DESCRIPTION
Even though the layer instance is created, its type of property is not set properly so it is LAYER_UNKNOWN as default. Because of this reason, checkValidation() method is not working properly. 

Detailed patches of this PR are as below.
* Set layer type in constructor
* Add checkValidation() test case of each Layer class


Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped