### PR TITLE
Fix possible error that cause double free on destruction @open sesame 05/20 21:09

### DIFF
--- a/nntrainer/src/databuffer.cpp
+++ b/nntrainer/src/databuffer.cpp
@@ -135,33 +135,33 @@ int DataBuffer::clear(BufferType type) {
   switch (type) {
   case BUF_TRAIN: {
     train_running = false;
+    if (validation[DATA_TRAIN] && true == train_thread.joinable())
+      train_thread.join();
     this->train_data.clear();
     this->train_data_label.clear();
     this->cur_train_bufsize = 0;
     this->rest_train = max_train;
     trainReadyFlag = DATA_NOT_READY;
-    if (validation[DATA_TRAIN] && true == train_thread.joinable())
-      train_thread.join();
   } break;
   case BUF_VAL: {
     val_running = false;
+    if (validation[DATA_VAL] && true == val_thread.joinable())
+      val_thread.join();
     this->val_data.clear();
     this->val_data_label.clear();
     this->cur_val_bufsize = 0;
     this->rest_val = max_val;
     valReadyFlag = DATA_NOT_READY;
-    if (validation[DATA_VAL] && true == val_thread.joinable())
-      val_thread.join();
   } break;
   case BUF_TEST: {
     test_running = false;
+    if (validation[DATA_TEST] && true == test_thread.joinable())
+      test_thread.join();
     this->test_data.clear();
     this->test_data_label.clear();
     this->cur_test_bufsize = 0;
     this->rest_test = max_test;
     testReadyFlag = DATA_NOT_READY;
-    if (validation[DATA_TEST] && true == test_thread.joinable())
-      test_thread.join();
   } break;
   default:
     ml_loge("Error: Not Supported Data Type");


### PR DESCRIPTION
There is an occasional error from `unittest_tizen_capi` 
This PR is a possible fix for the problem.

unittests runs more than 200 times without error with this patch.

```bash
[ RUN      ] nntrainer_capi_nnmodel.train_with_file_01_p
training
data_buffer made
data_buffer made done
size: 2
data_buffer clear
data_buffer end
double free or corruption (out)
Aborted (core dumped)
```

**Changes proposed in this PR:**
join data buffer threads first before clearing vectors that are
used in the target function to (possibly) prevent double free

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>