### PR TITLE
[Example] Add basic layout in edc file @05/27 20:54

### DIFF
--- a/Applications/Tizen_native/CustomShortcut/.gitignore
+++ b/Applications/Tizen_native/CustomShortcut/.gitignore
@@ -6,3 +6,4 @@ project_def.prop
 build_def.prop
 /res/
 mts.sh
+/workspace/

--- a/Applications/Tizen_native/CustomShortcut/res/edje/main.edc
+++ b/Applications/Tizen_native/CustomShortcut/res/edje/main.edc
@@ -7,24 +7,128 @@
  * @bug No known bugs except for NYI items
  */
 
- collections {
+#define PART_BUTTON(button_name, label, x1, y1, x2, y2) \
+  part { \
+    name: button_name"/bg"; \
+    type: RECT; \
+    description { \
+      state: "default" 0.0; \
+      rel1.relative: x1 y1; \
+      rel2.relative: x2 y2; \
+      color: 255 255 0 255; \
+      visible: 1; \
+    } \
+    description { \
+      state: "focused" 0.0; \
+      inherit: "default"; \
+      color: 255 255 0 120; \
+    } \
+  } \
+  part { \
+    name: button_name"/label"; \
+    type: TEXT; \
+    description { \
+      state: "default" 0.0; \
+      color: 0 0 0 255; \
+      rel1 { \
+        relative: 0.3 0.3; \
+        to: button_name"/bg"; \
+      } \
+      rel2 { \
+        relative: 0.7 0.7; \
+        to: button_name"/bg"; \
+      } \
+      text { \
+        text: label ; \
+        size: 24; \
+        align: 0.5 0.5; \
+      } \
+    } \
+  }
+
+#define PART_TITLE(title_name, label) \
+  part { \
+    name: title_name; \
+    type: TEXT; \
+    description { \
+      state: "default" 0.0; \
+      color: 255 255 255 255; \
+      text { \
+        text: label; \
+        font: "Tizen:style=regular"; \
+        size: 20; \
+        align: 0.5 0.1; \
+      } \
+    } \
+  }
+
+#define PROGRAM_BUTTON(target, on_click_sig, on_click_sig_source) \
+  program { \
+    name: target"/press"; \
+    signal: "mouse,down,*"; \
+    source: target"/*"; \
+    transition: LINEAR 0.5; \
+    script { \
+      set_state(PART:target"/bg", "focused", 0.0); \
+    } \
+  } \
+  program { \
+    name: target"/release"; \
+    signal: "mouse,up,*"; \
+    source: target"/*"; \
+    transition: LINEAR 0.5; \
+    script { \
+      set_state(PART:target"/bg", "default", 0.0); \
+    } \
+  } \
+  program { \
+    name: target"/click"; \
+    signal: "mouse,clicked,*"; \
+    source: target"/*"; \
+    script { \
+      emit(on_click_sig, on_click_sig_source); \
+    } \
+  }
+
+collections {
   group {
-    name: "main" ;
+    name: "home";
     parts {
-      part {
-        name: "main/title"; 
-        type: TEXT;
-        description {
-          state: "default" 0.0;
-          color: 255 0 0 255;
-          text {
-            text: "HELLO EDC!";
-            font: "Tizen:style=regular";
-            size: 20;
-            align: 0.5 0.5;
-          }
-        }
-      }
+      PART_TITLE("home/title", "Select actions...")
+      PART_BUTTON("home/to_train", "train", 0.55, 0.3, 0.9, 0.7)
+      PART_BUTTON("home/to_test", "test", 0.1, 0.3, 0.45, 0.7)
+    }
+    programs {
+      PROGRAM_BUTTON("home/to_train", "routes/to", "select")
+      PROGRAM_BUTTON("home/to_test", "routes/to", "draw")
     }
   }
- }
+  group {
+    name: "select";
+    parts {
+      PART_TITLE("select/title", "Select target emoji...")
+    }
+  }
+  // this group is meant to be used for train / test, if it is not applicable, this group is reserved for training part
+  group {
+    name: "draw";
+    parts {
+      PART_TITLE("draw/title", "draw your symbol")
+    }
+  }
+  group {
+    name: "train_result";
+    parts {
+      PART_TITLE("train_result/title", "train successfully done")
+      PART_BUTTON("train_result/go_back", "go back", 0.1, 0.3, 0.9, 0.7)
+    }
+  }
+  group {
+    name: "test_result";
+    parts {
+      PART_TITLE("test_result/title", "test is successfully done")
+      PART_BUTTON("test_result/go_back", "go back", 0.1, 0.3, 0.9, 0.7)
+      // reserve a text area to show the guess from the model
+    }
+  }
+}

--- a/Applications/Tizen_native/CustomShortcut/src/view.c
+++ b/Applications/Tizen_native/CustomShortcut/src/view.c
@@ -84,7 +84,7 @@ int view_create(widget_context_h context) {
 
   widget_app_context_get_tag(context, (void **)&wid);
   wid->layout =
-    _create_layout(wid->naviframe, wid->edj_path, "main", NULL, NULL);
+    _create_layout(wid->naviframe, wid->edj_path, "home", NULL, NULL);
 
   if (wid->layout == NULL) {
     dlog_print(DLOG_ERROR, LOG_TAG, "failed to create a layout of no alarm.");


### PR DESCRIPTION
**Changes proposed in this PR**
- Add scaffolding layouts to be used to construct multiple pages
- Change group name "main" -> "home"
- Update .gitignore to ignore tizen studio generated files

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>