### PR TITLE
[Example] Add exit when naviframe is empty

### DIFF
--- a/Applications/Tizen_native/CustomShortcut/.cproject
+++ b/Applications/Tizen_native/CustomShortcut/.cproject
@@ -16,7 +16,7 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactName="basicuiwithedc" buildArtefactType="org.tizen.nativecore.buildArtefactType.app" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.tizen.nativecore.buildArtefactType.app,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" description="" errorParsers="org.eclipse.cdt.core.MakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;" id="org.tizen.nativecore.config.sbi.gcc45.app.debug.547796387" name="Debug" parent="org.tizen.nativecore.config.sbi.gcc45.app.debug">
+				<configuration artifactName="nntrainer-custom-shortcut" buildArtefactType="org.tizen.nativecore.buildArtefactType.app" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.tizen.nativecore.buildArtefactType.app,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" description="" errorParsers="org.eclipse.cdt.core.MakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;" id="org.tizen.nativecore.config.sbi.gcc45.app.debug.547796387" name="Debug" parent="org.tizen.nativecore.config.sbi.gcc45.app.debug">
 					<folderInfo id="org.tizen.nativecore.config.sbi.gcc45.app.debug.547796387." name="/" resourcePath="">
 						<toolChain id="org.tizen.nativecore.toolchain.sbi.gcc45.app.debug.2012254494" name="Tizen Native Toolchain" superClass="org.tizen.nativecore.toolchain.sbi.gcc45.app.debug">
 							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF" id="org.tizen.nativeide.target.sbi.gnu.platform.base.534678491" osList="linux,win32" superClass="org.tizen.nativeide.target.sbi.gnu.platform.base"/>
@@ -256,10 +256,10 @@
 									<listOptionValue builtIn="false" value="&quot;${SBI_SYSROOT}/usr/lib/glib-2.0/include&quot;"/>
 								</option>
 								<option id="sbi.gnu.c.compiler.option.frameworks_cflags.core.1575194043" superClass="sbi.gnu.c.compiler.option.frameworks_cflags.core" valueType="stringList">
-									<listOptionValue builtIn="false" value="${TC_COMPILER_MISC}"/>
-									<listOptionValue builtIn="false" value="${RS_COMPILER_MISC}"/>
+									<listOptionValue builtIn="false" value="$(TC_COMPILER_MISC)"/>
+									<listOptionValue builtIn="false" value="$(RS_COMPILER_MISC)"/>
 									<listOptionValue builtIn="false" value=" -fPIE"/>
-									<listOptionValue builtIn="false" value="--sysroot=&quot;${SBI_SYSROOT}&quot;"/>
+									<listOptionValue builtIn="false" value="--sysroot=&quot;$(SBI_SYSROOT)&quot;"/>
 									<listOptionValue builtIn="false" value="--param=ssp-buffer-size=4"/>
 									<listOptionValue builtIn="false" value="-fasynchronous-unwind-tables"/>
 									<listOptionValue builtIn="false" value="-fno-omit-frame-pointer"/>
@@ -286,12 +286,12 @@
 								<option defaultValue="false" id="sbi.gnu.cpp.linker.option.shared_flag.core.1165852838" name="Linker.Shared" superClass="sbi.gnu.cpp.linker.option.shared_flag.core" valueType="boolean"/>
 								<option defaultValue="false" id="sbi.gnu.cpp.linker.option.noundefined.core.53923211" name="Report unresolved symbol references (-Wl,--no-undefined)" superClass="sbi.gnu.cpp.linker.option.noundefined.core" valueType="boolean"/>
 								<option id="sbi.gnu.cpp.linker.option.frameworks_lflags.core.676581266" superClass="sbi.gnu.cpp.linker.option.frameworks_lflags.core" valueType="stringList">
-									<listOptionValue builtIn="false" value="${TC_LINKER_MISC}"/>
-									<listOptionValue builtIn="false" value="${RS_LINKER_MISC}"/>
+									<listOptionValue builtIn="false" value="$(TC_LINKER_MISC)"/>
+									<listOptionValue builtIn="false" value="$(RS_LINKER_MISC)"/>
 									<listOptionValue builtIn="false" value="-pie -lpthread "/>
-									<listOptionValue builtIn="false" value="--sysroot=&quot;${SBI_SYSROOT}&quot;"/>
-									<listOptionValue builtIn="false" value="-Xlinker --version-script=&quot;${PROJ_PATH}/.exportMap&quot;"/>
-									<listOptionValue builtIn="false" value="-L&quot;${SBI_SYSROOT}/usr/lib&quot;"/>
+									<listOptionValue builtIn="false" value="--sysroot=&quot;$(SBI_SYSROOT)&quot;"/>
+									<listOptionValue builtIn="false" value="-Xlinker --version-script=&quot;$(PROJ_PATH)/.exportMap&quot;"/>
+									<listOptionValue builtIn="false" value="-L&quot;$(SBI_SYSROOT)/usr/lib&quot;"/>
 									<listOptionValue builtIn="false" value="$(RS_LIBRARIES)"/>
 								</option>
 								<option id="gnu.cpp.link.option.paths.1549534547" superClass="gnu.cpp.link.option.paths" valueType="libPaths">
@@ -651,4 +651,6 @@
 		</scannerConfigBuildInfo>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope"/>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
 </cproject>

--- a/Applications/Tizen_native/CustomShortcut/.gitignore
+++ b/Applications/Tizen_native/CustomShortcut/.gitignore
@@ -7,3 +7,4 @@ build_def.prop
 /res/
 mts.sh
 /workspace/
+.package-stamp

--- a/Applications/Tizen_native/CustomShortcut/inc/data.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/data.h
@@ -28,6 +28,7 @@ typedef struct appdata {
   Evas_Object *label;
   Evas_Object *naviframe;
   Eext_Circle_Surface *circle_nf;
+  Elm_Object_Item *home;
   Evas_Object *layout;
   char edj_path[PATH_MAX];
 } appdata_s;

--- a/Applications/Tizen_native/CustomShortcut/inc/view.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/view.h
@@ -27,7 +27,9 @@ int view_init(appdata_s *ad);
  * @brief creates layout from edj
  * @param[in] ad appdata of the app
  * @param[in] group_name name of the layout to be pushed to main naviframe.
+ * @param[out] data naviframe_item that is pushed.
  */
-int view_routes_to(appdata_s *ad, const char *group_name);
+int view_routes_to(appdata_s *ad, const char *group_name,
+                   Elm_Object_Item **data);
 
 #endif /* __nntrainer_example_custom_shortcut_view_H__ */

--- a/Applications/Tizen_native/CustomShortcut/src/main.c
+++ b/Applications/Tizen_native/CustomShortcut/src/main.c
@@ -11,88 +11,12 @@
 #include "view.h"
 #include <tizen.h>
 
-static void win_delete_request_cb(void *data, Evas_Object *obj,
-                                  void *event_info) {
-  ui_app_exit();
-}
-
-static void layout_back_cb(void *data, Evas_Object *obj, void *event_info) {
-  appdata_s *ad = data;
-  /* Let window go to hide state. */
-  elm_win_lower(ad->win);
-}
-
-static void app_get_resource(const char *edj_file_in, char *edj_path_out,
-                             int edj_path_max) {
-  char *res_path = app_get_resource_path();
-  if (res_path) {
-    snprintf(edj_path_out, edj_path_max, "%s%s", res_path, edj_file_in);
-    free(res_path);
-  }
-}
-
-static void create_base_gui(appdata_s *ad) {
-  char edj_path[PATH_MAX] = {
-    0,
-  };
-
-  /* Window */
-  /* Create and initialize elm_win.
-     elm_win is mandatory to manipulate window. */
-  ad->win = elm_win_util_standard_add(PACKAGE, PACKAGE);
-  elm_win_conformant_set(ad->win, EINA_TRUE);
-  elm_win_autodel_set(ad->win, EINA_TRUE);
-
-  if (elm_win_wm_rotation_supported_get(ad->win)) {
-    int rots[4] = {0, 90, 180, 270};
-    elm_win_wm_rotation_available_rotations_set(ad->win, (const int *)(&rots),
-                                                4);
-  }
-
-  evas_object_smart_callback_add(ad->win, "delete,request",
-                                 win_delete_request_cb, NULL);
-
-  /* Conformant */
-  /* Create and initialize elm_conformant.
-     elm_conformant is mandatory for base gui to have proper size
-     when indicator or virtual keypad is visible. */
-  ad->conform = elm_conformant_add(ad->win);
-  elm_win_indicator_mode_set(ad->win, ELM_WIN_INDICATOR_SHOW);
-  elm_win_indicator_opacity_set(ad->win, ELM_WIN_INDICATOR_OPAQUE);
-  evas_object_size_hint_weight_set(ad->conform, EVAS_HINT_EXPAND,
-                                   EVAS_HINT_EXPAND);
-  elm_win_resize_object_add(ad->win, ad->conform);
-  evas_object_show(ad->conform);
-
-  /* Base Layout */
-  /* Create an actual view of the base gui.
-     Modify this part to change the view. */
-  app_get_resource(EDJ_PATH, edj_path, (int)PATH_MAX);
-  ad->layout = elm_layout_add(ad->win);
-  elm_layout_file_set(ad->layout, edj_path, "home");
-  evas_object_size_hint_weight_set(ad->layout, EVAS_HINT_EXPAND,
-                                   EVAS_HINT_EXPAND);
-  eext_object_event_callback_add(ad->layout, EEXT_CALLBACK_BACK, layout_back_cb,
-                                 ad);
-  elm_object_content_set(ad->conform, ad->layout);
-
-  /* Show window after base gui is set up */
-  evas_object_show(ad->win);
-}
-
 static bool app_create(void *data) {
   /* Hook to take necessary actions before main event loop starts
      Initialize UI resources and application's data
      If this function returns true, the main loop of application starts
      If this function returns false, the application is terminated */
   appdata_s *ad = data;
-  char edj_path[PATH_MAX] = {
-    0,
-  };
-
-  view_init(ad);
-
-  view_routes_to(ad, "home");
 
   char *res_path = app_get_resource_path();
   if (res_path == NULL) {
@@ -102,8 +26,10 @@ static bool app_create(void *data) {
 
   snprintf(ad->edj_path, sizeof(ad->edj_path), "%s%s", res_path, EDJ_PATH);
   free(res_path);
+  
+  view_init(ad);
 
-  if (view_routes_to(ad, "home"))
+  if (view_routes_to(ad, "home", &ad->home))
     return false;
 
   return true;


### PR DESCRIPTION
**Changes proposed in this PR:**
- Add and use _on_back_pressed_cb when back button is pressed
- Change `view_routes_to` signature to return naviframe item.
- Delete unused functions
- Bump tizen studio version to 3.7 and rebuild `.cproject` 

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>