### PR TITLE
[ Refactor ] Modify to deal with 3D Tensor @open sesame 06/08 18:08

### DIFF
--- a/Applications/LogisticRegression/jni/main.cpp
+++ b/Applications/LogisticRegression/jni/main.cpp
@@ -141,7 +141,7 @@ int main(int argc, char *argv[]) {
       label.push_back(outputVector[j]);
       if (NN.forwarding(nntrainer::Tensor(in), status)
             .apply(stepFunction)
-            .getValue(0, 0, 0) == label[0][0])
+            .getValue(0, 0, 0, 0) == label[0][0])
         cn++;
     }
     std::cout << "[ Accuracy ] : " << ((float)(cn) / inputVector.size()) * 100.0

--- a/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
+++ b/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
@@ -393,8 +393,8 @@ int main(int argc, char **argv) {
          * @brief     Get Minibatch size of Experience
          */
         std::vector<Experience> in_Exp = getMiniBatch(expQ);
-        std::vector<std::vector<std::vector<float>>> inbatch;
-        std::vector<std::vector<std::vector<float>>> next_inbatch;
+        std::vector<std::vector<std::vector<std::vector<float>>>> inbatch;
+        std::vector<std::vector<std::vector<std::vector<float>>>> next_inbatch;
 
         /**
          * @brief     Generate Lable with next state
@@ -404,11 +404,11 @@ int main(int argc, char **argv) {
           STATE next_state = in_Exp[i].next_state;
           std::vector<float> in(state.observation.begin(),
                                 state.observation.end());
-          inbatch.push_back({in});
+          inbatch.push_back({{in}});
 
           std::vector<float> next_in(next_state.observation.begin(),
                                      next_state.observation.end());
-          next_inbatch.push_back({next_in});
+          next_inbatch.push_back({{next_in}});
         }
 
         /**
@@ -429,12 +429,13 @@ int main(int argc, char **argv) {
          */
         for (unsigned int i = 0; i < in_Exp.size(); i++) {
           if (in_Exp[i].done) {
-            Q.setValue(i, 0, (int)in_Exp[i].action[0], (float)in_Exp[i].reward);
+            Q.setValue(i, 0, 0, (int)in_Exp[i].action[0],
+                       (float)in_Exp[i].reward);
           } else {
             float next = (nqa[i * NQ.getWidth()] > nqa[i * NQ.getWidth() + 1])
                            ? nqa[i * NQ.getWidth()]
                            : nqa[i * NQ.getWidth() + 1];
-            Q.setValue(i, 0, (int)in_Exp[i].action[0],
+            Q.setValue(i, 0, 0, (int)in_Exp[i].action[0],
                        (float)in_Exp[i].reward + DISCOUNT * next);
           }
         }

--- a/nntrainer/include/bn_layer.h
+++ b/nntrainer/include/bn_layer.h
@@ -42,7 +42,7 @@ public:
   /**
    * @brief     Constructor of Batch Noramlization Layer
    */
-  BatchNormalizationLayer() : epsilon(0.0){ setType (LAYER_BN); };
+  BatchNormalizationLayer() : epsilon(0.0) { setType(LAYER_BN); };
 
   /**
    * @brief     Destructor of BatchNormalizationLayer
@@ -113,6 +113,7 @@ public:
   /**
    * @brief     initialize layer
    * @param[in] b batch size
+   * @param[in] c channel
    * @param[in] h height
    * @param[in] w width
    * @param[in] last last layer
@@ -120,7 +121,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(int b, int h, int w, bool last, bool init_zero);
+  int initialize(int b, int c, int h, int w, bool last, bool init_zero);
 
   /**
    * @brief     set Property of layer

--- a/nntrainer/include/conv2d_layer.h
+++ b/nntrainer/include/conv2d_layer.h
@@ -54,6 +54,7 @@ public:
   /**
    * @brief     Initializer of Input Layer
    * @param[in] b batch size
+   * @param[in] c channel
    * @param[in] h height
    * @param[in] w width
    * @param[in] last last layer
@@ -61,7 +62,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(int b, int h, int w, bool last, bool init_zero);
+  int initialize(int b, int c, int h, int w, bool last, bool init_zero);
 
   /**
    * @brief     Read Weight & Bias Data from file

--- a/nntrainer/include/databuffer.h
+++ b/nntrainer/include/databuffer.h
@@ -39,7 +39,7 @@
  */
 #define NBUFTYPE 4
 
-typedef std::vector<std::vector<std::vector<float>>> vec_3d;
+typedef std::vector<std::vector<std::vector<std::vector<float>>>> vec_4d;
 
 #define SET_VALIDATION(val)                                              \
   do {                                                                   \
@@ -187,10 +187,10 @@ public:
    * @param[in] outLabel label data ( minibatch size )
    * @retval    true/false
    */
-  virtual bool
-  getDataFromBuffer(BufferType type,
-                    std::vector<std::vector<std::vector<float>>> &out_vec,
-                    std::vector<std::vector<std::vector<float>>> &out_label);
+  virtual bool getDataFromBuffer(
+    BufferType type,
+    std::vector<std::vector<std::vector<std::vector<float>>>> &out_vec,
+    std::vector<std::vector<std::vector<std::vector<float>>>> &out_label);
 
   /**
    * @brief     set number of class

--- a/nntrainer/include/fc_layer.h
+++ b/nntrainer/include/fc_layer.h
@@ -42,7 +42,7 @@ public:
   /**
    * @brief     Constructor of Fully Connected Layer
    */
-  FullyConnectedLayer() : loss(0.0), cost(COST_UNKNOWN){ setType (LAYER_FC); };
+  FullyConnectedLayer() : loss(0.0), cost(COST_UNKNOWN) { setType(LAYER_FC); };
 
   /**
    * @brief     Destructor of Fully Connected Layer
@@ -103,6 +103,7 @@ public:
   /**
    * @brief     initialize layer
    * @param[in] b batch size
+   * @param[in] c channel
    * @param[in] h height
    * @param[in] w width
    * @param[in] last last layer
@@ -111,7 +112,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(int b, int h, int w, bool last, bool init_zero);
+  int initialize(int b, int c, int h, int w, bool last, bool init_zero);
   /**
    * @brief     get Loss value
    */

--- a/nntrainer/include/input_layer.h
+++ b/nntrainer/include/input_layer.h
@@ -42,7 +42,9 @@ public:
   /**
    * @brief     Constructor of InputLayer
    */
-  InputLayer() : normalization(false), standardization(false){ setType (LAYER_IN); };
+  InputLayer() : normalization(false), standardization(false) {
+    setType(LAYER_IN);
+  };
 
   /**
    * @brief     Destructor of InputLayer
@@ -106,6 +108,7 @@ public:
   /**
    * @brief     Initializer of Input Layer
    * @param[in] b batch size
+   * @param[in] c channel
    * @param[in] h height
    * @param[in] w width
    * @param[in] last last layer
@@ -113,7 +116,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(int b, int h, int w, bool last, bool init_zero);
+  int initialize(int b, int c, int h, int w, bool last, bool init_zero);
 
   /**
    * @brief     Copy Layer

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -63,7 +63,13 @@ typedef enum {
  *            3. Convolution 2D Layer type
  *            4. Unknown
  */
- typedef enum { LAYER_IN, LAYER_FC, LAYER_BN, LAYER_CONV2D, LAYER_UNKNOWN } LayerType;
+typedef enum {
+  LAYER_IN,
+  LAYER_FC,
+  LAYER_BN,
+  LAYER_CONV2D,
+  LAYER_UNKNOWN
+} LayerType;
 
 /**
  * @brief     Enumeration of Weight Initialization Type
@@ -130,8 +136,9 @@ public:
 
   /**
    * @brief     Initialize the layer
-   *            - Weight(Height, Width), Bias(1, Width)
+   *            - Weight(Channel, Height, Width), Bias(1, 1, Width)
    * @param[in] b batch
+   * @param[in] c channel
    * @param[in] h Height
    * @param[in] w Width
    * @param[in] last last layer
@@ -139,7 +146,8 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int initialize(int b, int h, int w, bool last, bool init_zero) = 0;
+  virtual int initialize(int b, int c, int h, int w, bool last,
+                         bool init_zero) = 0;
 
   /**
    * @brief     read layer Weight & Bias data from file
@@ -234,14 +242,13 @@ public:
 
   /**
    * @brief  initialize Weight
-   * @param[in] width width of Tensor
-   * @param[in] height height of Tensor
+   * @param[in] w_dim TensorDim
    * @param[in] init_type Weight Initialization Type
    * @param[out] status Status
    * @retval Tensor Initialized Tensor
    */
-  Tensor initializeWeight(unsigned int width, unsigned int height,
-                          WeightIniType init_type, int &status);
+  Tensor initializeWeight(TensorDim w_dim, WeightIniType init_type,
+                          int &status);
 
 protected:
   /**

--- a/nntrainer/include/optimizer.h
+++ b/nntrainer/include/optimizer.h
@@ -132,15 +132,14 @@ public:
 
   /**
    * @brief     initialize optimizer. Initialize Weight if it is adam
-   * @param[in] height height of Weight
-   * @param[in] width width of Weight
+   * @param[in] d TensorDim
    * @param[in] setTensor true if the layer need wieght update.
    *            Input Layer and Batch Noramlization layer won't need it.
    *            Therefore, it sets false.
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(unsigned int height, unsigned int width, bool setTensor);
+  int initialize(TensorDim d, bool setTensor);
 
   /**
    * @brief     calculate optimizer and Update Weight & Bais

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -67,11 +67,20 @@ public:
 
   /**
    * @brief     Constructor of Tensor
-   * @param[in] batch Batch of Tensor
+   * @param[in] channel Channel of Tensor
    * @param[in] heihgt Height of Tensor
    * @param[in] width Width of Tensor
    */
-  Tensor(int batch, int height, int width);
+  Tensor(int channel, int height, int width);
+
+  /**
+   * @brief     Constructor of Tensor
+   * @param[in] batch Batch of Tensor
+   * @param[in] channel Channel of Tensor
+   * @param[in] heihgt Height of Tensor
+   * @param[in] width Width of Tensor
+   */
+  Tensor(int batch, int channel, int height, int width);
 
   /**
    * @brief   Constructor of Tensor
@@ -86,12 +95,20 @@ public:
   Tensor(std::vector<std::vector<std::vector<float>>> const &d);
 
   /**
+   * @brief     Constructor of Tensor
+   * @param[in] d data for the Tensor
+   */
+  Tensor(std::vector<std::vector<std::vector<std::vector<float>>>> const &d);
+
+  /**
    * @brief     return value at specific location
    * @param[in] batch batch location
+   * @param[in] c channel location
    * @param[in] h height location
    * @param[in] w width location
    */
-  float getValue(unsigned int batch, unsigned int h, unsigned int w);
+  float getValue(unsigned int batch, unsigned int c, unsigned int h,
+                 unsigned int w);
 
   /**
    * @brief     Multiply value element by element
@@ -158,9 +175,10 @@ public:
 
   /**
    * @brief     Transpose Tensor
+   * @param[in] direction to transpose ex) 0:2:1
    * @retval    Calculated Tensor
    */
-  Tensor transpose() const;
+  Tensor transpose(std::string direction) const;
 
   /**
    * @brief     sum all the Tensor elements according to the batch
@@ -170,6 +188,10 @@ public:
 
   /**
    * @brief     sum all the Tensor elements according to the axis
+   *            0 : batch direction
+   *            1 : channel direction
+   *            2 : channel direction
+   *            3 : channel direction
    * @retval    Calculated Tensor
    */
   Tensor sum(int axis) const;
@@ -243,6 +265,12 @@ public:
   int getWidth() const { return dim.width(); };
 
   /**
+   * @brief     Get Channel of Tensor
+   * @retval    int Channel
+   */
+  int getChannel() const { return dim.channel(); };
+
+  /**
    * @brief     Get Height of Tensor
    * @retval    int Height
    */
@@ -257,12 +285,13 @@ public:
   /**
    * @brief     Set the elelemnt value
    * @param[in] batch batch location
+   * @param[in] c channel location
    * @param[in] i height location
    * @param[in] j width location
    * @param[in] value value to be stored
    */
-  void setValue(unsigned int batch, unsigned int i, unsigned int j,
-                float value);
+  void setValue(unsigned int batch, unsigned int c, unsigned int i,
+                unsigned int j, float value);
 
   /**
    * @brief     Copy the Tensor
@@ -288,6 +317,12 @@ public:
    * @retval    int argument index
    */
   int argmax();
+
+  /**
+   * @brief     return Tensor Dim
+   * @retval    TensorDim
+   */
+  TensorDim getDim() { return dim; }
 
   /**
    * @brief     return Data pointer of Tensor

--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -33,22 +33,26 @@ namespace nntrainer {
 
 int BatchNormalizationLayer::initialize(bool last) {
   int status = ML_ERROR_NONE;
-  if (dim.batch() <= 0 || dim.height() <= 0 || dim.width() <= 0) {
+  if (dim.batch() <= 0 || dim.height() <= 0 || dim.width() <= 0 ||
+      dim.channel() <= 0) {
     ml_loge("Error: Dimension must be greater than 0");
     return ML_ERROR_INVALID_PARAMETER;
   }
 
-  this->gamma = Tensor(dim.batch(), dim.width());
-  this->beta = Tensor(dim.batch(), dim.width());
+  this->gamma = Tensor(dim.channel(), dim.batch(), dim.width());
+  this->beta = Tensor(dim.channel(), dim.batch(), dim.width());
+  beta.setZero();
+  gamma.setZero();
 
   return status;
 }
 
-int BatchNormalizationLayer::initialize(int b, int h, int w, bool last,
+int BatchNormalizationLayer::initialize(int b, int c, int h, int w, bool last,
                                         bool init_zero) {
   int status = ML_ERROR_NONE;
 
   this->dim.batch(b);
+  this->dim.channel(c);
   this->dim.width(w);
   this->dim.height(h);
 
@@ -64,7 +68,7 @@ int BatchNormalizationLayer::setOptimizer(Optimizer &opt) {
   this->opt.setOptParam(opt.getOptParam());
 
   this->epsilon = 0.0;
-  return this->opt.initialize(dim.height(), dim.width(), false);
+  return this->opt.initialize(dim, false);
 }
 
 int BatchNormalizationLayer::setProperty(std::vector<std::string> values) {

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -28,7 +28,8 @@ int Conv2DLayer::initialize(bool last) {
   return status;
 }
 
-int Conv2DLayer::initialize(int b, int h, int w, bool last, bool init_zero) {
+int Conv2DLayer::initialize(int b, int c, int h, int w, bool last,
+                            bool init_zero) {
   int status = ML_ERROR_NONE;
 
   return status;

--- a/nntrainer/src/databuffer.cpp
+++ b/nntrainer/src/databuffer.cpp
@@ -184,11 +184,12 @@ int DataBuffer::clear() {
   return status;
 }
 
-bool DataBuffer::getDataFromBuffer(BufferType type, vec_3d &outVec,
-                                   vec_3d &outLabel) {
-  unsigned int J, i, j, k;
+bool DataBuffer::getDataFromBuffer(BufferType type, vec_4d &outVec,
+                                   vec_4d &outLabel) {
+  unsigned int J, i, j, k, L, l;
   unsigned int width = input_dim.width();
   unsigned int height = input_dim.height();
+  unsigned int channel = input_dim.channel();
 
   switch (type) {
   case BUF_TRAIN: {
@@ -201,18 +202,22 @@ bool DataBuffer::getDataFromBuffer(BufferType type, vec_3d &outVec,
     }
 
     for (k = 0; k < mini_batch; ++k) {
-      std::vector<std::vector<float>> v_height;
-      for (j = 0; j < height; ++j) {
-        J = j * width;
-        std::vector<float> v_width;
-        for (i = 0; i < width; ++i) {
-          v_width.push_back(train_data[k][J + i]);
+      std::vector<std::vector<std::vector<float>>> v_channel;
+      for (l = 0; l < channel; ++l) {
+        L = l * width * height;
+        std::vector<std::vector<float>> v_height;
+        for (j = 0; j < height; ++j) {
+          J = L + j * width;
+          std::vector<float> v_width;
+          for (i = 0; i < width; ++i) {
+            v_width.push_back(train_data[k][J + i]);
+          }
+          v_height.push_back(v_width);
         }
-        v_height.push_back(v_width);
+        v_channel.push_back(v_height);
       }
-
-      outVec.push_back(v_height);
-      outLabel.push_back({train_data_label[k]});
+      outVec.push_back(v_channel);
+      outLabel.push_back({{train_data_label[k]}});
     }
 
     data_lock.lock();
@@ -232,18 +237,22 @@ bool DataBuffer::getDataFromBuffer(BufferType type, vec_3d &outVec,
     }
 
     for (k = 0; k < mini_batch; ++k) {
-      std::vector<std::vector<float>> v_height;
-      for (j = 0; j < height; ++j) {
-        J = j * width;
-        std::vector<float> v_width;
-        for (i = 0; i < width; ++i) {
-          v_width.push_back(val_data[k][J + i]);
+      std::vector<std::vector<std::vector<float>>> v_channel;
+      for (l = 0; l < channel; ++l) {
+        L = l * width * height;
+        std::vector<std::vector<float>> v_height;
+        for (j = 0; j < height; ++j) {
+          J = L + j * width;
+          std::vector<float> v_width;
+          for (i = 0; i < width; ++i) {
+            v_width.push_back(val_data[k][J + i]);
+          }
+          v_height.push_back(v_width);
         }
-        v_height.push_back(v_width);
+        v_channel.push_back(v_height);
       }
-
-      outVec.push_back(v_height);
-      outLabel.push_back({val_data_label[k]});
+      outVec.push_back(v_channel);
+      outLabel.push_back({{val_data_label[k]}});
     }
 
     data_lock.lock();
@@ -265,18 +274,22 @@ bool DataBuffer::getDataFromBuffer(BufferType type, vec_3d &outVec,
     }
 
     for (k = 0; k < mini_batch; ++k) {
-      std::vector<std::vector<float>> v_height;
-      for (j = 0; j < height; ++j) {
-        J = j * width;
-        std::vector<float> v_width;
-        for (i = 0; i < width; ++i) {
-          v_width.push_back(test_data[k][J + i]);
+      std::vector<std::vector<std::vector<float>>> v_channel;
+      for (l = 0; l < channel; ++l) {
+        L = l * width * height;
+        std::vector<std::vector<float>> v_height;
+        for (j = 0; j < height; ++j) {
+          J = L + j * width;
+          std::vector<float> v_width;
+          for (i = 0; i < width; ++i) {
+            v_width.push_back(test_data[k][J + i]);
+          }
+          v_height.push_back(v_width);
         }
-        v_height.push_back(v_width);
+        v_channel.push_back(v_height);
       }
-
-      outVec.push_back(v_height);
-      outLabel.push_back({test_data_label[k]});
+      outVec.push_back(v_channel);
+      outLabel.push_back({{test_data_label[k]}});
     }
 
     data_lock.lock();

--- a/nntrainer/src/input_layer.cpp
+++ b/nntrainer/src/input_layer.cpp
@@ -32,7 +32,7 @@ int InputLayer::setOptimizer(Optimizer &opt) {
   this->opt.setType(opt.getType());
   this->opt.setOptParam(opt.getOptParam());
 
-  return this->opt.initialize(dim.height(), dim.width(), false);
+  return this->opt.initialize(dim, false);
 }
 
 int InputLayer::setProperty(std::vector<std::string> values) {
@@ -90,7 +90,8 @@ Tensor InputLayer::forwarding(Tensor in, int &status) {
 
 int InputLayer::initialize(bool last) {
   int status = ML_ERROR_NONE;
-  if (dim.batch() <= 0 || dim.height() <= 0 || dim.width() <= 0) {
+  if (dim.batch() <= 0 || dim.channel() <= 0 || dim.height() <= 0 ||
+      dim.width() <= 0) {
     ml_loge("Error: Dimension must be greater than 0");
     return ML_ERROR_INVALID_PARAMETER;
   }
@@ -98,10 +99,12 @@ int InputLayer::initialize(bool last) {
   return status;
 }
 
-int InputLayer::initialize(int b, int h, int w, bool last, bool init_zero) {
+int InputLayer::initialize(int b, int c, int h, int w, bool last,
+                           bool init_zero) {
   int status = ML_ERROR_NONE;
 
   this->dim.batch(b);
+  this->dim.channel(c);
   this->dim.width(w);
   this->dim.height(h);
 

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -279,7 +279,7 @@ int NeuralNetwork::init() {
 
       input_layer->setType(t);
       status =
-        input_layer->initialize(batch_size, 1, hidden_size[i], last, b_zero);
+        input_layer->initialize(batch_size, 1, 1, hidden_size[i], last, b_zero);
       NN_INI_RETURN_STATUS();
 
       status = input_layer->setOptimizer(opt);
@@ -314,7 +314,7 @@ int NeuralNetwork::init() {
                             unknown),
         TOKEN_WEIGHTINI));
 
-      status = fc_layer->initialize(batch_size, hidden_size[i - 1],
+      status = fc_layer->initialize(batch_size, 1, hidden_size[i - 1],
                                     hidden_size[i], last, b_zero);
       NN_INI_RETURN_STATUS();
       status = fc_layer->setOptimizer(opt);
@@ -339,7 +339,7 @@ int NeuralNetwork::init() {
       status = bn_layer->setOptimizer(opt);
       NN_INI_RETURN_STATUS();
       status =
-        bn_layer->initialize(batch_size, 1, hidden_size[i], last, b_zero);
+        bn_layer->initialize(batch_size, 1, 1, hidden_size[i], last, b_zero);
       NN_INI_RETURN_STATUS();
       layers.push_back(bn_layer);
       if (i == 0) {
@@ -464,6 +464,7 @@ int NeuralNetwork::init(std::shared_ptr<Optimizer> optimizer,
       last = true;
     switch (layers[i]->getType()) {
     case LAYER_FC:
+      layers[i]->getTensorDim().height(previous_dim.channel());
       layers[i]->getTensorDim().height(previous_dim.width());
       layers[i]->getTensorDim().batch(previous_dim.batch());
       status =
@@ -717,7 +718,7 @@ int NeuralNetwork::train_run() {
     }
 
     while (true) {
-      vec_3d in, label;
+      vec_4d in, label;
       if (data_buffer->getDataFromBuffer(nntrainer::BUF_TRAIN, in, label)) {
         backwarding(nntrainer::Tensor(in), nntrainer::Tensor(label), i);
         count++;
@@ -745,7 +746,7 @@ int NeuralNetwork::train_run() {
       }
 
       while (true) {
-        vec_3d in, label;
+        vec_4d in, label;
         if (data_buffer->getDataFromBuffer(nntrainer::BUF_VAL, in, label)) {
           for (int i = 0; i < batch_size; ++i) {
             nntrainer::Tensor X = nntrainer::Tensor({in[i]});

--- a/nntrainer/src/optimizer.cpp
+++ b/nntrainer/src/optimizer.cpp
@@ -66,18 +66,21 @@ int Optimizer::setOptParam(OptParam p) {
   return status;
 }
 
-int Optimizer::initialize(unsigned int height, unsigned int width,
-                          bool set_tensor) {
+int Optimizer::initialize(TensorDim d, bool set_tensor) {
   int status = ML_ERROR_NONE;
-  if (height == 0 || width == 0) {
+  if (d.height() == 0 || d.width() == 0 || d.channel() == 0) {
     ml_loge("Error: Tensor Dimension must be greater than 0");
     return ML_ERROR_INVALID_PARAMETER;
   }
   if (type == OptType::adam && set_tensor) {
-    wm = Tensor(height, width);
-    wv = Tensor(height, width);
-    bm = Tensor(1, width);
-    bv = Tensor(1, width);
+    wm = Tensor(d.channel(), d.height(), d.width());
+    wv = Tensor(d.channel(), d.height(), d.width());
+    wm.setZero();
+    wv.setZero();
+    bm = Tensor(1, 1, d.width());
+    bv = Tensor(1, 1, d.width());
+    bm.setZero();
+    bv.setZero();
   }
   return status;
 }

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
+#include <parse_util.h>
 #include <sstream>
 #include <stdio.h>
 #include <tensor.h>
@@ -33,6 +34,20 @@
 #include <helper_cuda.h>
 #include <helper_functions.h>
 #endif
+
+#define transposeloop(cl, ci, cj, ck, sl, si, sj, sk)                 \
+  do {                                                                \
+    unsigned int i, j, k, l;                                          \
+    int inidx = 0, outidx = 0;                                        \
+    for (cl = 0; cl < sl; cl++)                                       \
+      for (ci = 0; ci < si; ci++)                                     \
+        for (cj = 0; cj < sj; cj++)                                   \
+          for (ck = 0; ck < sk; ck++) {                               \
+            outidx = si * sj * sk * cl + sj * sk * ci + sk * cj + ck; \
+            inidx = l * SI * SJ * SK + i * SJ * SK + j * SK + k;      \
+            outptr[outidx] = inptr[inidx];                            \
+          }                                                           \
+  } while (0);
 
 namespace nntrainer {
 
@@ -49,21 +64,33 @@ Tensor::Tensor(int height, int width) {
   setZero();
 }
 
-Tensor::Tensor(int batch, int height, int width) {
+Tensor::Tensor(int channel, int height, int width) {
   dim.height(height);
   dim.width(width);
-  dim.batch(batch);
+  dim.batch(channel);
   this->data = std::vector<float>(dim.getDataLen());
   setZero();
 }
 
-float Tensor::getValue(unsigned int batch, unsigned int h, unsigned int w) {
-  return this->data[batch * dim.height() * dim.width() + h * dim.width() + w];
+Tensor::Tensor(int batch, int channel, int height, int width) {
+  dim.height(height);
+  dim.width(width);
+  dim.batch(batch);
+  dim.channel(channel);
+  this->data = std::vector<float>(dim.getDataLen());
+  setZero();
 }
 
-void Tensor::setValue(unsigned int batch, unsigned int h, unsigned int w,
-                      float value) {
-  this->data[batch * dim.height() * dim.width() + h * dim.width() + w] = value;
+float Tensor::getValue(unsigned int batch, unsigned int c, unsigned int h,
+                       unsigned int w) {
+  return this->data[batch * dim.channel() * dim.height() * dim.width() +
+                    c * dim.height() * dim.width() + h * dim.width() + w];
+}
+
+void Tensor::setValue(unsigned int batch, unsigned int c, unsigned int h,
+                      unsigned int w, float value) {
+  this->data[batch * dim.channel() * dim.height() * dim.width() +
+             c * dim.height() * dim.width() + h * dim.width() + w] = value;
 }
 
 Tensor::Tensor(std::vector<std::vector<float>> const &d) {
@@ -74,20 +101,35 @@ Tensor::Tensor(std::vector<std::vector<float>> const &d) {
 
   for (unsigned int j = 0; j < dim.height(); ++j)
     for (unsigned int k = 0; k < dim.width(); ++k)
-      this->setValue(0, j, k, d[j][k]);
+      this->setValue(0, 0, j, k, d[j][k]);
 }
 
 Tensor::Tensor(std::vector<std::vector<std::vector<float>>> const &d) {
-
-  dim.batch(d.size());
+  dim.channel(d.size());
   dim.height(d[0].size());
   dim.width(d[0][0].size());
   this->data = std::vector<float>(dim.getDataLen());
 
+  for (unsigned int j = 0; j < dim.channel(); ++j)
+    for (unsigned int k = 0; k < dim.height(); ++k)
+      for (unsigned int l = 0; l < dim.width(); ++l)
+        this->setValue(0, j, k, l, d[j][k][l]);
+}
+
+Tensor::Tensor(
+  std::vector<std::vector<std::vector<std::vector<float>>>> const &d) {
+
+  dim.batch(d.size());
+  dim.channel(d[0].size());
+  dim.height(d[0][0].size());
+  dim.width(d[0][0][0].size());
+  this->data = std::vector<float>(dim.getDataLen());
+
   for (unsigned int i = 0; i < dim.batch(); ++i)
-    for (unsigned int j = 0; j < dim.height(); ++j)
-      for (unsigned int k = 0; k < dim.width(); ++k)
-        this->setValue(i, j, k, d[i][j][k]);
+    for (unsigned int j = 0; j < dim.channel(); ++j)
+      for (unsigned int k = 0; k < dim.height(); ++k)
+        for (unsigned int l = 0; l < dim.width(); ++l)
+          this->setValue(i, j, k, l, d[i][j][k][l]);
 }
 
 Tensor Tensor::multiply(float const &value) {
@@ -147,7 +189,8 @@ Tensor Tensor::add(Tensor const &m) const {
   Tensor result(dim);
 #ifdef USE_BLAS
   cblas_scopy(dim.getDataLen(), this->data.data(), 1, result.data.data(), 1);
-  unsigned int size = dim.width() * dim.height();
+  unsigned int size = dim.channel() * dim.width() * dim.height();
+
   if (m.dim.batch() == 1) {
     for (unsigned int k = 0; k < dim.batch(); ++k) {
       cblas_saxpy(size, 1.0, m.data.data(), 1, &(result.data.data()[k * size]),
@@ -160,8 +203,8 @@ Tensor Tensor::add(Tensor const &m) const {
   unsigned int i, j, k;
   if (m.dim.batch() == 1) {
     for (k = 0; k < dim.batch(); ++k) {
-      for (i = 0; i < m.dim.getDataLen(); ++i) {
-        j = k * m.dim.getDataLen();
+      for (i = 0; i < m.dim.getFeatureLen(); ++i) {
+        j = k * m.dim.getFeatureLen();
         result.data[j + i] = data[j + i] + m.data[i];
       }
     }
@@ -176,7 +219,8 @@ Tensor Tensor::add(Tensor const &m) const {
 }
 
 Tensor Tensor::subtract(Tensor const &m) const {
-  if (dim.height() != m.dim.height() || dim.width() != m.dim.width()) {
+  if (dim.channel() != m.dim.channel() || dim.height() != m.dim.height() ||
+      dim.width() != m.dim.width()) {
     throw std::runtime_error("Error: Dimension must be equal each other");
   }
 
@@ -184,7 +228,9 @@ Tensor Tensor::subtract(Tensor const &m) const {
 
 #ifdef USE_BLAS
   cblas_scopy(dim.getDataLen(), this->data.data(), 1, result.data.data(), 1);
-  unsigned int size = this->dim.width() * this->dim.height();
+
+  unsigned int size =
+    this->dim.channel() * this->dim.width() * this->dim.height();
   float alpha = -1.0;
 
   if (m.dim.batch() == 1) {
@@ -199,7 +245,7 @@ Tensor Tensor::subtract(Tensor const &m) const {
   }
 #else
   unsigned int i, j, k, len;
-  len = m.dim.getDataLen();
+  len = m.dim.getFeatureLen();
   if (m.dim.batch() == 1) {
     for (k = 0; k < dim.batch(); ++k) {
       for (i = 0; i < len; ++i) {
@@ -208,7 +254,7 @@ Tensor Tensor::subtract(Tensor const &m) const {
       }
     }
   } else {
-    for (k = 0; k < len; ++k) {
+    for (k = 0; k < m.dim.getDataLen(); ++k) {
       result.data[k] = data[k] - m.data[k];
     }
   }
@@ -235,25 +281,26 @@ Tensor Tensor::subtract(float const &value) {
 }
 
 Tensor Tensor::multiply(Tensor const &m) const {
-  if (dim.height() != m.dim.height() || dim.width() != m.dim.width()) {
+  if (dim.channel() != m.dim.channel() || dim.height() != m.dim.height() ||
+      dim.width() != m.dim.width()) {
     throw std::runtime_error("Error: Dimension must be equal each other");
   }
 
   Tensor result(dim);
 
   int end = dim.getDataLen() / 4;
-  int e = dim.width() * dim.height() / 4;
+  int e = dim.getFeatureLen() / 4;
   int i;
   if (m.dim.batch() == 1) {
     for (unsigned int k = 0; k < dim.batch(); ++k) {
-      int b = k * dim.width() * dim.height();
+      int b = k * dim.getFeatureLen();
       for (i = 0; i < e * 4; i += 4) {
         result.data[b + i + 0] = this->data[b + i + 0] * m.data[i + 0];
         result.data[b + i + 1] = this->data[b + i + 1] * m.data[i + 1];
         result.data[b + i + 2] = this->data[b + i + 2] * m.data[i + 2];
         result.data[b + i + 3] = this->data[b + i + 3] * m.data[i + 3];
       }
-      for (unsigned int j = i; j < dim.width() * dim.height(); j++)
+      for (unsigned int j = i; j < dim.getFeatureLen(); j++)
         result.data[b + j] = this->data[b + j] * m.data[j];
     }
   } else {
@@ -271,26 +318,27 @@ Tensor Tensor::multiply(Tensor const &m) const {
 }
 
 Tensor Tensor::divide(Tensor const &m) const {
-  if (dim.height() != m.dim.height() || dim.width() != m.dim.width()) {
+  if (dim.channel() != m.dim.channel() || dim.height() != m.dim.height() ||
+      dim.width() != m.dim.width()) {
     throw std::runtime_error("Error: Dimension must be equal each other");
   }
 
-  Tensor result(dim.batch(), dim.height(), dim.width());
+  Tensor result(dim.batch(), dim.channel(), dim.height(), dim.width());
 
   unsigned int end = dim.getDataLen() / 4;
-  unsigned int e = dim.width() * dim.height() / 4;
+  unsigned int e = dim.getFeatureLen() / 4;
   unsigned int i, j, k;
 
   if (m.dim.batch() == 1) {
     for (k = 0; k < dim.batch(); ++k) {
-      unsigned int b = k * dim.width() * dim.height();
+      unsigned int b = k * dim.getFeatureLen();
       for (i = 0; i < e * 4; i += 4) {
         result.data[b + i + 0] = this->data[b + i + 0] / m.data[i + 0];
         result.data[b + i + 1] = this->data[b + i + 1] / m.data[i + 1];
         result.data[b + i + 2] = this->data[b + i + 2] / m.data[i + 2];
         result.data[b + i + 3] = this->data[b + i + 3] / m.data[i + 3];
       }
-      for (unsigned int j = i; j < dim.width() * dim.height(); ++j)
+      for (unsigned int j = i; j < dim.getFeatureLen(); ++j)
         result.data[b + j] = this->data[b + j] / m.data[j];
     }
   } else {
@@ -313,18 +361,18 @@ Tensor Tensor::divide(Tensor const &m) const {
  */
 Tensor Tensor::sum() const {
   unsigned int k;
-  Tensor ret(dim.batch(), 1, 1);
+  Tensor ret(dim.batch(), 1, 1, 1);
 #ifdef USE_BLAS
   for (k = 0; k < dim.batch(); ++k)
-    ret.data[k] =
-      cblas_sasum(dim.width() * dim.height(),
-                  &(data.data()[k * dim.width() * dim.height()]), 1);
+    ret.data[k] = cblas_sasum(dim.getFeatureLen(),
+                              &(data.data()[k * dim.getFeatureLen()]), 1);
 #else
   unsigned int i;
   for (k = 0; k < dim.batch(); ++k) {
-    unsigned int id = k * dim.width() * dim.height();
+
+    unsigned int id = k * dim.getFeatureLen();
     ret.data[id] = 0.0;
-    for (i = 0; i < dim.height() * dim.width(); ++i) {
+    for (i = 0; i < dim.getFeatureLen(); ++i) {
       ret.data[id] += data[id + i];
     }
   }
@@ -335,61 +383,96 @@ Tensor Tensor::sum() const {
 
 Tensor Tensor::sum(int axis) const {
   Tensor ret;
-
   switch (axis) {
   case 0: {
-    ret = Tensor(1, dim.height(), dim.width());
-    for (unsigned int i = 0; i < dim.height(); ++i) {
-      unsigned int I = i * dim.width();
-      for (unsigned int j = 0; j < dim.width(); ++j) {
-        for (unsigned int k = 0; k < dim.batch(); ++k) {
-          unsigned int K = k * dim.width() * dim.height();
-          ret.data[I + j] += data[K + I + j];
+
+    ret = Tensor(1, dim.channel(), dim.height(), dim.width());
+    for (unsigned int l = 0; l < dim.channel(); ++l) {
+      unsigned int L = l * dim.width() * dim.height();
+      for (unsigned int i = 0; i < dim.height(); ++i) {
+        unsigned int I = i * dim.width();
+        for (unsigned int j = 0; j < dim.width(); ++j) {
+          for (unsigned int k = 0; k < dim.batch(); ++k) {
+            unsigned int K = k * dim.getFeatureLen();
+            ret.data[L + I + j] += data[K + L + I + j];
+          }
         }
       }
     }
   } break;
   case 1: {
-    ret = Tensor(dim.batch(), 1, dim.width());
-    for (unsigned int k = 0; k < dim.batch(); ++k) {
-      unsigned int K = k * dim.width();
-      for (unsigned int j = 0; j < dim.width(); ++j) {
-        for (unsigned int i = 0; i < dim.height(); ++i) {
-          unsigned int I = i * dim.width() * dim.batch();
-          ret.data[K + j] += data[K + I + j];
+    ret = Tensor(dim.batch(), 1, dim.height(), dim.width());
+    for (unsigned int l = 0; l < dim.batch(); ++l) {
+      unsigned int L = dim.width() * dim.height() * l;
+      unsigned int LL = l * dim.getFeatureLen();
+      for (unsigned int j = 0; j < dim.height(); ++j) {
+        unsigned int J = j * dim.width();
+        for (unsigned int i = 0; i < dim.width(); ++i) {
+          for (unsigned int k = 0; k < dim.channel(); ++k) {
+            unsigned int K = k * dim.width() * dim.height();
+            ret.data[(L + J + i)] += data[LL + K + J + i];
+          }
         }
       }
     }
   } break;
   case 2: {
-    ret = Tensor(dim.batch(), dim.height(), 1);
+    ret = Tensor(dim.batch(), dim.channel(), 1, dim.width());
     for (unsigned int k = 0; k < dim.batch(); ++k) {
-      unsigned int K = k * dim.height();
-      for (unsigned int i = 0; i < dim.height(); ++i) {
+      unsigned int K = k * dim.channel() * dim.width();
+      unsigned int KK = k * dim.getFeatureLen();
+      for (unsigned int l = 0; l < dim.channel(); ++l) {
+        unsigned int L = l * dim.width();
+        unsigned int LL = l * dim.width() * dim.height();
         for (unsigned int j = 0; j < dim.width(); ++j) {
-          unsigned int J = j * dim.height() * dim.batch();
-          ret.data[K + i] += data[K + J + i];
+          for (unsigned int i = 0; i < dim.height(); ++i) {
+            unsigned int I = i * dim.width();
+            ret.data[K + L + j] += data[KK + LL + j + I];
+          }
+        }
+      }
+    }
+  } break;
+  case 3: {
+    ret = Tensor(dim.batch(), dim.channel(), dim.height(), 1);
+    for (unsigned int k = 0; k < dim.batch(); ++k) {
+      unsigned int K = k * dim.channel() * dim.height();
+      unsigned int KK = k * dim.getFeatureLen();
+      for (unsigned int l = 0; l < dim.channel(); ++l) {
+        unsigned int L = l * dim.height();
+        unsigned int LL = l * dim.height() * dim.width();
+        for (unsigned int i = 0; i < dim.height(); ++i) {
+          unsigned int II = i * dim.width();
+          for (unsigned int j = 0; j < dim.width(); ++j) {
+            ret.data[K + L + i] += data[KK + LL + II + j];
+          }
         }
       }
     }
   } break;
   default:
-    throw std::out_of_range("Error: Cannot exceede 2");
+    throw std::out_of_range("Error: Cannot exceede 3");
     break;
   }
   return ret;
 }
 
 /**
- * If the dim.batch() sizeo of m is one, the it is reused for
- * every calculation along with dim.batch()
+ * If the dim.batch() size of m is one, the it is reused for
+ * every calculation along with dim.batch().
+ * Currently dot function only supports the case which dim.channel() == 1.
  */
 Tensor Tensor::dot(Tensor const &m) const {
   if (dim.width() != m.dim.height()) {
     throw std::runtime_error("Error dim.width() != m.dim.height()");
   }
+
+  if (dim.channel() != 1 || m.dim.channel() != 1) {
+    throw std::runtime_error("Error channel() != 1");
+  }
+
   int mwidth = m.dim.width();
-  Tensor result(dim.batch(), dim.height(), mwidth);
+  Tensor result(dim.batch(), 1, dim.height(), mwidth);
 
 #ifdef USE_BLAS
   float alpha_dgemm = 1.0;
@@ -520,22 +603,59 @@ Tensor Tensor::dot(Tensor const &m) const {
   return result;
 }
 
-Tensor Tensor::transpose() const {
-  Tensor result(dim.batch(), dim.width(), dim.height());
-  unsigned int i, j, k;
-  for (k = 0; k < dim.batch(); ++k) {
-    unsigned int b = k * dim.width() * dim.height();
-    for (i = 0; i < dim.width(); ++i) {
-      for (j = 0; j < dim.height(); ++j) {
-        result.data[b + i * dim.height() + j] = data[b + j * dim.width() + i];
-      }
+Tensor Tensor::transpose(std::string direction) const {
+  unsigned int SL, SI, SJ, SK;
+  int dir[MAXDIM - 1];
+  unsigned int fromDim[4];
+  const float *inptr;
+  float *outptr;
+
+  fromDim[0] = dim.batch();
+  fromDim[1] = dim.channel();
+  fromDim[2] = dim.height();
+  fromDim[3] = dim.width();
+
+  getValues(3, direction, dir);
+  Tensor result(dim.batch(), fromDim[dir[0] + 1], fromDim[dir[1] + 1],
+                fromDim[dir[2] + 1]);
+
+  int indexI = dir[0];
+  int indexJ = dir[1];
+
+  SL = fromDim[0], SI = fromDim[1], SJ = fromDim[2], SK = fromDim[3];
+
+  inptr = data.data();
+  outptr = result.getData();
+
+  switch (indexI) {
+  case 0:
+    if (indexJ == 1) {
+      transposeloop(l, i, j, k, SL, SI, SJ, SK);
+    } else {
+      transposeloop(l, i, k, j, SL, SI, SK, SJ);
     }
+    break;
+  case 1:
+    if (indexJ == 0) {
+      transposeloop(l, j, i, k, SL, SJ, SI, SK);
+    } else {
+      transposeloop(l, j, k, i, SL, SJ, SK, SI);
+    }
+    break;
+  case 2:
+    if (indexJ == 0) {
+      transposeloop(l, k, i, j, SL, SK, SI, SJ);
+    } else {
+      transposeloop(l, k, j, i, SL, SK, SJ, SI);
+    }
+    break;
   }
+
   return result;
 }
 
 Tensor Tensor::apply(float (*function)(float)) const {
-  Tensor result(dim.batch(), dim.height(), dim.width());
+  Tensor result(dim.batch(), dim.channel(), dim.height(), dim.width());
   unsigned int i;
 
   for (i = 0; i < dim.getDataLen(); ++i)
@@ -549,17 +669,21 @@ Tensor Tensor::apply(Tensor (*function)(Tensor)) const {
 }
 
 void Tensor::print(std::ostream &out) const {
-  unsigned int i, j, k;
+  unsigned int i, j, k, l;
   std::stringstream ss;
   for (k = 0; k < dim.batch(); k++) {
-    for (i = 0; i < dim.height(); i++) {
-      for (j = 0; j < dim.width(); j++) {
-        out << data[k * dim.width() * dim.height() + i * dim.width() + j]
-            << " ";
+    for (l = 0; l < dim.channel(); l++) {
+      for (i = 0; i < dim.height(); i++) {
+        for (j = 0; j < dim.width(); j++) {
+          out << data[k * dim.getFeatureLen() + l * dim.width() * dim.height() +
+                      i * dim.width() + j]
+              << " ";
+        }
+        out << std::endl;
       }
       out << std::endl;
     }
-    out << std::endl;
+    out << "-------" << std::endl;
   }
 }
 
@@ -570,6 +694,7 @@ std::ostream &operator<<(std::ostream &out, Tensor const &m) {
 
 Tensor &Tensor::copy(const Tensor &from) {
   if (this != &from && from.dim.getDataLen() != 0) {
+    dim.channel(from.dim.channel());
     dim.height(from.dim.height());
     dim.width(from.dim.width());
     dim.batch(from.dim.batch());
@@ -611,21 +736,14 @@ void Tensor::read(std::ifstream &file) {
  * That is the why it has (1, dim.height(), dim.width()) dimension.
  */
 Tensor Tensor::average() const {
-  unsigned int I;
   if (dim.batch() == 1)
     return *this;
 
-  Tensor result(1, dim.height(), dim.width());
-  for (unsigned int i = 0; i < dim.height(); i++) {
-    I = i * dim.width();
-    for (unsigned int j = 0; j < dim.width(); j++) {
-      result.data[I + j] = 0.0;
-      for (unsigned int k = 0; k < dim.batch(); k++) {
-        result.data[I + j] += data[k * dim.width() * dim.height() + I + j];
-      }
-      result.data[I + j] = result.data[I + j] / (float)dim.batch();
-    }
-  }
+  Tensor result(1, dim.channel(), dim.height(), dim.width());
+
+  result = this->sum(0);
+  result.divide(dim.batch());
+
   return result;
 }
 
@@ -659,70 +777,85 @@ float Tensor::l2norm() const {
 }
 
 Tensor Tensor::normalization() const {
-  Tensor results(dim.batch(), dim.height(), dim.width());
+  Tensor results(dim);
   float Min = 1000000.0;
   float Max = 0.0;
 
   for (unsigned int k = 0; k < dim.batch(); ++k) {
-    for (unsigned int i = 0; i < dim.height(); ++i) {
-      for (unsigned int j = 0; j < dim.width(); ++j) {
-        unsigned int id = k * dim.height() * dim.width() + i * dim.width() + j;
-        if (this->data[id] < Min)
-          Min = this->data[id];
-        if (this->data[id] > Max)
-          Max = this->data[id];
+    for (unsigned int l = 0; l < dim.channel(); ++l) {
+      for (unsigned int i = 0; i < dim.height(); ++i) {
+        for (unsigned int j = 0; j < dim.width(); ++j) {
+          unsigned int id = k * dim.getFeatureLen() +
+                            l * dim.height() * dim.width() + i * dim.width() +
+                            j;
+          if (this->data[id] < Min)
+            Min = this->data[id];
+          if (this->data[id] > Max)
+            Max = this->data[id];
+        }
       }
     }
   }
   float dif = Max - Min;
 
   for (unsigned int k = 0; k < dim.batch(); ++k) {
-    for (unsigned int i = 0; i < dim.height(); ++i) {
-      for (unsigned int j = 0; j < dim.width(); ++j) {
-        unsigned int id = k * dim.height() * dim.width() + i * dim.width() + j;
-        results.data[id] = (this->data[id] - Min) / dif;
+    for (unsigned int l = 0; l < dim.channel(); ++l) {
+      for (unsigned int i = 0; i < dim.height(); ++i) {
+        for (unsigned int j = 0; j < dim.width(); ++j) {
+          unsigned int id = k * dim.getFeatureLen() +
+                            l * dim.height() * dim.width() + i * dim.width() +
+                            j;
+          results.data[id] = (this->data[id] - Min) / dif;
+        }
       }
     }
   }
-
   return results;
 }
 
 Tensor Tensor::standardization() const {
-  Tensor result(dim.batch(), dim.height(), dim.width());
+  Tensor result(dim);
 
   for (unsigned int k = 0; k < dim.batch(); ++k) {
-    int K = k * dim.height() * dim.width();
+    int K = k * dim.getFeatureLen();
     float mean;
     float mean_tmp = 0.0;
     float std_tmp = 0.0;
     float std_dev = 0.0;
 
-    for (unsigned int i = 0; i < dim.height(); ++i) {
-      unsigned int I = K + i * dim.width();
-      for (unsigned int j = 0; j < dim.width(); ++j) {
-        unsigned int J = I + j;
-        mean_tmp += this->data[J];
+    for (unsigned int l = 0; l < dim.channel(); ++l) {
+      unsigned int L = K + l * dim.height() * dim.width();
+      for (unsigned int i = 0; i < dim.height(); ++i) {
+        unsigned int I = L + i * dim.width();
+        for (unsigned int j = 0; j < dim.width(); ++j) {
+          unsigned int J = I + j;
+          mean_tmp += this->data[J];
+        }
       }
     }
 
-    mean = mean_tmp / (this->dim.width() * this->dim.height());
+    mean = mean_tmp / (this->dim.getFeatureLen());
 
-    for (unsigned int i = 0; i < dim.height(); ++i) {
-      unsigned int I = K + i * dim.width();
-      for (unsigned int j = 0; j < dim.width(); ++j) {
-        unsigned int J = I + j;
-        std_tmp += (this->data[J] - mean) * (this->data[J] - mean);
+    for (unsigned int l = 0; l < dim.channel(); ++l) {
+      unsigned int L = K + l * dim.height() * dim.width();
+      for (unsigned int i = 0; i < dim.height(); ++i) {
+        unsigned int I = L + i * dim.width();
+        for (unsigned int j = 0; j < dim.width(); ++j) {
+          unsigned int J = I + j;
+          std_tmp += (this->data[J] - mean) * (this->data[J] - mean);
+        }
       }
     }
+    std_dev = sqrt(std_tmp) / (this->dim.getFeatureLen());
 
-    std_dev = sqrt(std_tmp) / (this->dim.height() * this->dim.width());
-
-    for (unsigned int i = 0; i < dim.height(); ++i) {
-      unsigned int I = K + i * dim.width();
-      for (unsigned int j = 0; j < dim.width(); ++j) {
-        unsigned int J = I + j;
-        result.data[J] = (this->data[J] - mean) / std_dev;
+    for (unsigned int l = 0; l < dim.channel(); ++l) {
+      unsigned int L = K + l * dim.height() * dim.width();
+      for (unsigned int i = 0; i < dim.height(); ++i) {
+        unsigned int I = L + i * dim.width();
+        for (unsigned int j = 0; j < dim.width(); ++j) {
+          unsigned int J = I + j;
+          result.data[J] = (this->data[J] - mean) / std_dev;
+        }
       }
     }
   }

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -96,16 +96,18 @@ const std::string config_str = "[Network]"
                                "Activation = softmax"
                                "\n";
 
-#define GEN_TEST_INPUT(input, eqation_i_j_k) \
-  do {                                       \
-    for (int i = 0; i < batch; ++i) {        \
-      for (int j = 0; j < height; ++j) {     \
-        for (int k = 0; k < width; ++k) {    \
-          float val = eqation_i_j_k;         \
-          input.setValue(i, j, k, val);      \
-        }                                    \
-      }                                      \
-    }                                        \
+#define GEN_TEST_INPUT(input, eqation_i_j_k_l) \
+  do {                                         \
+    for (int i = 0; i < batch; ++i) {          \
+      for (int j = 0; j < channel; ++j) {      \
+        for (int k = 0; k < height; ++k) {     \
+          for (int l = 0; l < width; ++l) {    \
+            float val = eqation_i_j_k_l;       \
+            input.setValue(i, j, k, l, val);   \
+          }                                    \
+        }                                      \
+      }                                        \
+    }                                          \
   } while (0)
 
 #define ASSERT_EXCEPTION(TRY_BLOCK, EXCEPTION_TYPE, MESSAGE)                  \

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -430,7 +430,7 @@ TEST(nntrainer_capi_nnmodel, train_with_file_01_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_nnmodel_train_with_file(
-    model, "epochs=1", "batch_size=16", "train_data=trainingSet.dat",
+    model, "epochs=2", "batch_size=16", "train_data=trainingSet.dat",
     "val_data=valSet.dat", "label_data=label.dat", "buffer_size=100",
     "model_file=model.bin", NULL);
 
@@ -492,7 +492,7 @@ TEST(nntrainer_capi_nnmodel, train_with_generator_01_p) {
   status = ml_nnmodel_compile(model, optimizer, "loss=cross", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnmodel_train_with_generator(
-    model, getMiniBatch_train, getMiniBatch_val, NULL, "epochs=1",
+    model, getMiniBatch_train, getMiniBatch_val, NULL, "epochs=2",
     "batch_size=16", "buffer_size=100", "model_file=model.bin", NULL);
 
   EXPECT_EQ(status, ML_ERROR_NONE);

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -10,15 +10,15 @@
  * @author      Jijoong Moon <jijoong.moon@samsung.com>
  * @bug         No known bugs
  */
-#include <nntrainer_test_util.h>
-#include <util_func.h>
-#include <input_layer.h>
-#include <fc_layer.h>
 #include <bn_layer.h>
 #include <conv2d_layer.h>
+#include <fc_layer.h>
 #include <fstream>
-#include <optimizer.h>
+#include <input_layer.h>
 #include <nntrainer_error.h>
+#include <nntrainer_test_util.h>
+#include <optimizer.h>
+#include <util_func.h>
 
 /**
  * @brief Input Layer
@@ -26,7 +26,7 @@
 TEST(nntrainer_InputLayer, initialize_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::InputLayer layer;
-  status = layer.initialize(1, 1, 1, false, true);
+  status = layer.initialize(1, 1, 1, 1, false, true);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -36,7 +36,7 @@ TEST(nntrainer_InputLayer, initialize_01_p) {
 TEST(nntrainer_InputLayer, initialize_02_n) {
   int status = ML_ERROR_NONE;
   nntrainer::InputLayer layer;
-  status = layer.initialize(1, 0, 1, false, true);
+  status = layer.initialize(1, 1, 0, 1, false, true);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -46,7 +46,7 @@ TEST(nntrainer_InputLayer, initialize_02_n) {
 TEST(nntrainer_InputLayer, setOptimizer_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::InputLayer layer;
-  status = layer.initialize(1, 1, 1, false, true);
+  status = layer.initialize(1, 1, 1, 1, false, true);
   nntrainer::Optimizer op;
   nntrainer::OptType t = nntrainer::OptType::adam;
   nntrainer::OptParam p;
@@ -88,7 +88,7 @@ TEST(nntrainer_InputLayer, setActivation_02_n) {
 TEST(nntrainer_InputLayer, checkValidation_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::InputLayer layer;
-  layer.initialize(1, 1, 1, false, true);
+  layer.initialize(1, 1, 1, 1, false, true);
   layer.setActivation(nntrainer::ACT_TANH);
 
   status = layer.checkValidation();
@@ -101,7 +101,7 @@ TEST(nntrainer_InputLayer, checkValidation_01_p) {
 TEST(nntrainer_FullyConnectedLayer, initialize_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::FullyConnectedLayer layer;
-  status = layer.initialize(1, 1, 1, false, true);
+  status = layer.initialize(1, 1, 1, 1, false, true);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -111,7 +111,7 @@ TEST(nntrainer_FullyConnectedLayer, initialize_01_p) {
 TEST(nntrainer_FullyConnectedLayer, initialize_02_n) {
   int status = ML_ERROR_NONE;
   nntrainer::FullyConnectedLayer layer;
-  status = layer.initialize(1, 0, 1, false, true);
+  status = layer.initialize(1, 1, 0, 1, false, true);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -121,7 +121,7 @@ TEST(nntrainer_FullyConnectedLayer, initialize_02_n) {
 TEST(nntrainer_FullyConnectedLayer, initialize_03_n) {
   int status = ML_ERROR_NONE;
   nntrainer::FullyConnectedLayer layer;
-  status = layer.initialize(1, 1, 1, false, true);
+  status = layer.initialize(1, 1, 1, 1, false, true);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -131,7 +131,7 @@ TEST(nntrainer_FullyConnectedLayer, initialize_03_n) {
 TEST(nntrainer_FullyConnectedLayer, initialize_04_p) {
   int status = ML_ERROR_NONE;
   nntrainer::FullyConnectedLayer layer;
-  status = layer.initialize(1, 1, 1, true, true);
+  status = layer.initialize(1, 1, 1, 1, true, true);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -141,7 +141,7 @@ TEST(nntrainer_FullyConnectedLayer, initialize_04_p) {
 TEST(nntrainer_FullyConnectedLayer, initialize_05_n) {
   int status = ML_ERROR_NONE;
   nntrainer::FullyConnectedLayer layer;
-  status = layer.initialize(1, 0, 1, true, true);
+  status = layer.initialize(1, 1, 0, 1, true, true);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -151,7 +151,7 @@ TEST(nntrainer_FullyConnectedLayer, initialize_05_n) {
 TEST(nntrainer_FullyConnectedLayer, initialize_06_p) {
   int status = ML_ERROR_NONE;
   nntrainer::FullyConnectedLayer layer;
-  status = layer.initialize(1, 1, 1, true, true);
+  status = layer.initialize(1, 1, 1, 1, true, true);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -161,7 +161,7 @@ TEST(nntrainer_FullyConnectedLayer, initialize_06_p) {
 TEST(nntrainer_FullyConnectedLayer, setOptimizer_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::FullyConnectedLayer layer;
-  status = layer.initialize(1, 1, 1, false, true);
+  status = layer.initialize(1, 1, 1, 1, false, true);
   nntrainer::Optimizer op;
   nntrainer::OptType t = nntrainer::OptType::adam;
   nntrainer::OptParam p;
@@ -183,7 +183,7 @@ TEST(nntrainer_FullyConnectedLayer, setOptimizer_01_p) {
 TEST(nntrainer_FullyConnectedLayer, setOptimizer_02_p) {
   int status = ML_ERROR_NONE;
   nntrainer::FullyConnectedLayer layer;
-  status = layer.initialize(1, 1, 1, true, true);
+  status = layer.initialize(1, 1, 1, 1, true, true);
   nntrainer::Optimizer op;
   nntrainer::OptType t = nntrainer::OptType::adam;
   nntrainer::OptParam p;
@@ -246,7 +246,7 @@ TEST(nntrainer_FullyConnectedLayer, checkValidation_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::FullyConnectedLayer layer;
 
-  layer.initialize(1, 1, 1, false, true);
+  layer.initialize(1, 1, 1, 1, false, true);
   layer.setActivation(nntrainer::ACT_RELU);
 
   status = layer.checkValidation();
@@ -259,7 +259,7 @@ TEST(nntrainer_FullyConnectedLayer, checkValidation_01_p) {
 TEST(nntrainer_BatchNormalizationLayer, initialize_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::BatchNormalizationLayer layer;
-  status = layer.initialize(1, 1, 1, false, true);
+  status = layer.initialize(1, 1, 1, 1, false, true);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -269,7 +269,7 @@ TEST(nntrainer_BatchNormalizationLayer, initialize_01_p) {
 TEST(nntrainer_BatchNormalizationLayer, initialize_02_n) {
   int status = ML_ERROR_NONE;
   nntrainer::BatchNormalizationLayer layer;
-  status = layer.initialize(1, 0, 1, false, true);
+  status = layer.initialize(1, 1, 0, 1, false, true);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -279,7 +279,7 @@ TEST(nntrainer_BatchNormalizationLayer, initialize_02_n) {
 TEST(nntrainer_BatchNormalizationLayer, setOptimizer_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::BatchNormalizationLayer layer;
-  status = layer.initialize(1, 1, 1, 0, true);
+  status = layer.initialize(1, 1, 1, 1, 0, true);
   nntrainer::Optimizer op;
   nntrainer::OptType t = nntrainer::OptType::adam;
   nntrainer::OptParam p;
@@ -321,7 +321,7 @@ TEST(nntrainer_BatchNormalizationLayer, setActivation_02_n) {
 TEST(nntrainer_BatchNormalizationLayer, checkValidation_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::BatchNormalizationLayer layer;
-  layer.initialize(1, 1, 1, false, true);
+  layer.initialize(1, 1, 1, 1, false, true);
   layer.setActivation(nntrainer::ACT_RELU);
 
   status = layer.checkValidation();
@@ -331,7 +331,7 @@ TEST(nntrainer_BatchNormalizationLayer, checkValidation_01_p) {
 /**
  * @brief Convolution 2D Layer
  */
-TEST(nntrainer_Conv2DLayer, initialize_01_p){
+TEST(nntrainer_Conv2DLayer, initialize_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::Conv2DLayer layer;
   std::vector<std::string> input_str;

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -37,7 +37,7 @@ TEST(nntrainer_Tensor, Tensor_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::Tensor tensor = nntrainer::Tensor(1, 2, 3);
   ASSERT_NE(nullptr, tensor.getData());
-  if (tensor.getValue(0, 0, 0) != 0.0)
+  if (tensor.getValue(0, 0, 0, 0) != 0.0)
     status = ML_ERROR_INVALID_PARAMETER;
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
@@ -58,7 +58,7 @@ TEST(nntrainer_Tensor, Tensor_02_p) {
   nntrainer::Tensor tensor = nntrainer::Tensor(in);
   ASSERT_NE(nullptr, tensor.getData());
 
-  if (tensor.getValue(0, 0, 1) != 1.0)
+  if (tensor.getValue(0, 0, 0, 1) != 1.0)
     status = ML_ERROR_INVALID_PARAMETER;
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
@@ -84,7 +84,7 @@ TEST(nntrainer_Tensor, Tensor_03_p) {
   nntrainer::Tensor tensor = nntrainer::Tensor(in);
   ASSERT_NE(nullptr, tensor.getData());
 
-  if (tensor.getValue(0, 0, 1) != 1.0)
+  if (tensor.getValue(0, 0, 0, 1) != 1.0)
     status = ML_ERROR_INVALID_PARAMETER;
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
@@ -92,14 +92,15 @@ TEST(nntrainer_Tensor, Tensor_03_p) {
 TEST(nntrainer_Tensor, multiply_01_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
 
   nntrainer::Tensor result = input.multiply(0.0);
-  if (result.getValue(0, 1, 1) != 0.0)
+  if (result.getValue(0, 0, 1, 1) != 0.0)
     status = ML_ERROR_RESULT_OUT_OF_RANGE;
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
@@ -107,10 +108,11 @@ TEST(nntrainer_Tensor, multiply_01_p) {
 TEST(nntrainer_Tensor, multiply_02_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
   nntrainer::Tensor result = input.multiply(input);
@@ -132,10 +134,11 @@ TEST(nntrainer_Tensor, multiply_02_p) {
 
 TEST(nntrainer_Tensor, multiply_03_n) {
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
   nntrainer::Tensor test(batch - 1, height - 1, width - 1);
@@ -147,24 +150,26 @@ TEST(nntrainer_Tensor, multiply_03_n) {
 TEST(nntrainer_Tensor, divide_01_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
   nntrainer::Tensor result = input.divide(1.0);
-  if (result.getValue(0, 1, 1) != input.getValue(0, 1, 1))
+  if (result.getValue(0, 0, 1, 1) != input.getValue(0, 0, 1, 1))
     status = ML_ERROR_RESULT_OUT_OF_RANGE;
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
 TEST(nntrainer_Tensor, divide_02_n) {
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
   ASSERT_EXCEPTION({ input.divide(0.0); }, std::runtime_error,
@@ -173,13 +178,14 @@ TEST(nntrainer_Tensor, divide_02_n) {
 
 TEST(nntrainer_Tensor, divide_03_n) {
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
-  nntrainer::Tensor test(batch - 1, height - 1, width - 1);
+  nntrainer::Tensor test(batch - 1, channel, height - 1, width - 1);
 
   ASSERT_EXCEPTION({ input.divide(test); }, std::runtime_error,
                    "Error: Dimension must be equal each other");
@@ -188,10 +194,11 @@ TEST(nntrainer_Tensor, divide_03_n) {
 TEST(nntrainer_Tensor, add_01_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
   nntrainer::Tensor result = input.add(1.0);
@@ -214,10 +221,11 @@ TEST(nntrainer_Tensor, add_01_p) {
 TEST(nntrainer_Tensor, add_02_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
   nntrainer::Tensor result = input.add(input);
@@ -239,13 +247,14 @@ TEST(nntrainer_Tensor, add_02_p) {
 
 TEST(nntrainer_Tensor, add_03_n) {
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
-  nntrainer::Tensor test(batch - 1, height - 1, width - 1);
+  nntrainer::Tensor test(batch - 1, channel, height - 1, width - 1);
 
   ASSERT_EXCEPTION({ input.add(test); }, std::runtime_error,
                    "Error: Dimension must be equal each other");
@@ -254,10 +263,11 @@ TEST(nntrainer_Tensor, add_03_n) {
 TEST(nntrainer_Tensor, subtract_01_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
   nntrainer::Tensor result = input.subtract(1.0);
@@ -280,10 +290,11 @@ TEST(nntrainer_Tensor, subtract_01_p) {
 TEST(nntrainer_Tensor, subtract_02_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
   nntrainer::Tensor result = input.subtract(input);
@@ -305,13 +316,14 @@ TEST(nntrainer_Tensor, subtract_02_p) {
 
 TEST(nntrainer_Tensor, subtract_03_n) {
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
-  nntrainer::Tensor test(batch - 1, height - 1, width - 1);
+  nntrainer::Tensor test(batch - 1, channel, height - 1, width - 1);
 
   ASSERT_EXCEPTION({ input.subtract(test); }, std::runtime_error,
                    "Error: Dimension must be equal each other");
@@ -319,65 +331,103 @@ TEST(nntrainer_Tensor, subtract_03_n) {
 
 TEST(nntrainer_Tensor, sum_01_n) {
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
 
-  ASSERT_EXCEPTION({ input.sum(3); }, std::out_of_range,
-                   "Error: Cannot exceede 2");
+  ASSERT_EXCEPTION({ input.sum(4); }, std::out_of_range,
+                   "Error: Cannot exceede 3");
 }
 
 TEST(nntrainer_Tensor, sum_02_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
+  int channel = 2;
   int height = 2;
   int width = 10;
 
-  float ans0[1][2][10] = {{{21, 24, 27, 30, 33, 36, 39, 42, 45, 48},
-                           {51, 54, 57, 60, 63, 66, 69, 72, 75, 78}}};
+  float ans0[1][2][2][10] = {{{{39, 42, 45, 48, 51, 54, 57, 60, 63, 66},
+                               {69, 72, 75, 78, 81, 84, 87, 90, 93, 96}},
+                              {{57, 60, 63, 66, 69, 72, 75, 78, 81, 84},
+                               {87, 90, 93, 96, 99, 102, 105, 108, 111, 114}}}};
 
-  float ans1[3][1][10] = {{{18, 20, 22, 24, 26, 28, 30, 32, 34, 36}},
-                          {{24, 26, 28, 30, 32, 34, 36, 38, 40, 42}},
-                          {{30, 32, 34, 36, 38, 40, 42, 44, 46, 48}}};
-  float ans2[3][2][1] = {{{154}, {164}}, {{160}, {170}}, {{166}, {176}}};
+  float ans1[3][1][2][10] = {{{{8, 10, 12, 14, 16, 18, 20, 22, 24, 26},
+                               {28, 30, 32, 34, 36, 38, 40, 42, 44, 46}}},
+                             {{{32, 34, 36, 38, 40, 42, 44, 46, 48, 50},
+                               {52, 54, 56, 58, 60, 62, 64, 66, 68, 70}}},
+                             {{{56, 58, 60, 62, 64, 66, 68, 70, 72, 74},
+                               {76, 78, 80, 82, 84, 86, 88, 90, 92, 94}}}};
 
-  nntrainer::Tensor input(batch, height, width);
-  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
+  float ans2[3][2][1][10] = {{{{12, 14, 16, 18, 20, 22, 24, 26, 28, 30}},
+                              {{24, 26, 28, 30, 32, 34, 36, 38, 40, 42}}},
+                             {{{36, 38, 40, 42, 44, 46, 48, 50, 52, 54}},
+                              {{48, 50, 52, 54, 56, 58, 60, 62, 64, 66}}},
+                             {{{60, 62, 64, 66, 68, 70, 72, 74, 76, 78}},
+                              {{72, 74, 76, 78, 80, 82, 84, 86, 88, 90}}}};
+
+  float ans3[3][2][2][1] = {{{{55}, {155}}, {{115}, {215}}},
+                            {{{175}, {275}}, {{235}, {335}}},
+                            {{{295}, {395}}, {{355}, {455}}}};
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, i * (batch * height * channel) + j * (batch * height) +
+                          k * (width) + l + 1);
 
   nntrainer::Tensor result0 = input.sum(0);
   nntrainer::Tensor result1 = input.sum(1);
   nntrainer::Tensor result2 = input.sum(2);
+  nntrainer::Tensor result3 = input.sum(3);
 
   for (int i = 0; i < result0.getBatch(); ++i) {
-    for (int j = 0; j < result0.getHeight(); ++j) {
-      for (int k = 0; k < result0.getWidth(); ++k) {
-        if (ans0[i][j][k] != result0.getValue(i, j, k)) {
-          status = ML_ERROR_RESULT_OUT_OF_RANGE;
-          goto end_test;
+    for (int l = 0; l < result0.getChannel(); ++l) {
+      for (int j = 0; j < result0.getHeight(); ++j) {
+        for (int k = 0; k < result0.getWidth(); ++k) {
+          if (ans0[i][l][j][k] != result0.getValue(i, l, j, k)) {
+            status = ML_ERROR_RESULT_OUT_OF_RANGE;
+            goto end_test;
+          }
         }
       }
     }
   }
 
   for (int i = 0; i < result1.getBatch(); ++i) {
-    for (int j = 0; j < result1.getHeight(); ++j) {
-      for (int k = 0; k < result1.getWidth(); ++k) {
-        if (ans1[i][j][k] != result1.getValue(i, j, k)) {
-          status = ML_ERROR_RESULT_OUT_OF_RANGE;
-          goto end_test;
+    for (int l = 0; l < result1.getChannel(); ++l) {
+      for (int j = 0; j < result1.getHeight(); ++j) {
+        for (int k = 0; k < result1.getWidth(); ++k) {
+          if (ans1[i][l][j][k] != result1.getValue(i, l, j, k)) {
+            status = ML_ERROR_RESULT_OUT_OF_RANGE;
+            goto end_test;
+          }
         }
       }
     }
   }
 
   for (int i = 0; i < result2.getBatch(); ++i) {
-    for (int j = 0; j < result2.getHeight(); ++j) {
-      for (int k = 0; k < result2.getWidth(); ++k) {
-        if (ans2[i][j][k] != result2.getValue(i, j, k)) {
-          status = ML_ERROR_RESULT_OUT_OF_RANGE;
-          goto end_test;
+    for (int l = 0; l < result2.getChannel(); ++l) {
+      for (int j = 0; j < result2.getHeight(); ++j) {
+        for (int k = 0; k < result2.getWidth(); ++k) {
+          if (ans2[i][l][j][k] != result2.getValue(i, l, j, k)) {
+            status = ML_ERROR_RESULT_OUT_OF_RANGE;
+            goto end_test;
+          }
+        }
+      }
+    }
+  }
+
+  for (int i = 0; i < result3.getBatch(); ++i) {
+    for (int l = 0; l < result3.getChannel(); ++l) {
+      for (int j = 0; j < result3.getHeight(); ++j) {
+        for (int k = 0; k < result3.getWidth(); ++k) {
+          if (ans3[i][l][j][k] != result3.getValue(i, l, j, k)) {
+            status = ML_ERROR_RESULT_OUT_OF_RANGE;
+            goto end_test;
+          }
         }
       }
     }
@@ -390,14 +440,18 @@ end_test:
 TEST(nntrainer_Tensor, sum_03_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
+  int channel = 2;
   int height = 2;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
-  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, i * (batch * height * channel) + j * (height * width) +
+                          k * width + l + 1);
+
   nntrainer::Tensor result = input.sum();
-  if (result.getValue(0, 0, 0) != 210 || result.getValue(1, 0, 0) != 330 ||
-      result.getValue(2, 0, 0) != 450)
+  if (result.getValue(0, 0, 0, 0) != 820 ||
+      result.getValue(1, 0, 0, 0) != 1300 ||
+      result.getValue(2, 0, 0, 0) != 1780)
     status = ML_ERROR_RESULT_OUT_OF_RANGE;
 
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -406,21 +460,24 @@ TEST(nntrainer_Tensor, sum_03_p) {
 TEST(nntrainer_Tensor, dot_01_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 3;
-  float ans[3][3][3] = {
-    {{30, 36, 42}, {66, 81, 96}, {102, 126, 150}},
-    {{435, 468, 501}, {552, 594, 636}, {669, 720, 771}},
-    {{1326, 1386, 1446}, {1524, 1593, 1662}, {1722, 1800, 1878}}};
+  float ans[3][1][3][3] = {
+    {{{30, 36, 42}, {66, 81, 96}, {102, 126, 150}}},
+    {{{435, 468, 501}, {552, 594, 636}, {669, 720, 771}}},
+    {{{1326, 1386, 1446}, {1524, 1593, 1662}, {1722, 1800, 1878}}}};
 
-  nntrainer::Tensor input(batch, height, width);
-  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, i * (channel * width * height) + j * (height * width) +
+                          k * (width) + l + 1);
+
   nntrainer::Tensor result = input.dot(input);
 
   for (int i = 0; i < result.getBatch(); ++i) {
     for (int j = 0; j < result.getHeight(); ++j) {
       for (int k = 0; k < result.getWidth(); ++k) {
-        if (ans[i][j][k] != result.getValue(i, j, k)) {
+        if (ans[i][0][j][k] != result.getValue(i, 0, j, k)) {
           status = ML_ERROR_RESULT_OUT_OF_RANGE;
           goto end_dot_01_p;
         }
@@ -434,19 +491,21 @@ end_dot_01_p:
 TEST(nntrainer_Tensor, transpose_01_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
+  int channel = 1;
   int height = 3;
   int width = 3;
-  float ans[3][3][3] = {{{1, 4, 7}, {2, 5, 8}, {3, 6, 9}},
-                        {{10, 13, 16}, {11, 14, 17}, {12, 15, 18}},
-                        {{19, 22, 25}, {20, 23, 26}, {21, 24, 27}}};
-  nntrainer::Tensor input(batch, height, width);
-  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
-  nntrainer::Tensor result = input.transpose();
+  float ans[3][1][3][3] = {{{{1, 4, 7}, {2, 5, 8}, {3, 6, 9}}},
+                           {{{10, 13, 16}, {11, 14, 17}, {12, 15, 18}}},
+                           {{{19, 22, 25}, {20, 23, 26}, {21, 24, 27}}}};
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, i * (channel * width * height) + j * (height * width) +
+                          k * (width) + l + 1);
+  nntrainer::Tensor result = input.transpose("0:2:1");
 
   for (int i = 0; i < result.getBatch(); ++i) {
     for (int j = 0; j < result.getHeight(); ++j) {
       for (int k = 0; k < result.getWidth(); ++k) {
-        if (ans[i][j][k] != result.getValue(i, j, k)) {
+        if (ans[i][0][j][k] != result.getValue(i, 0, j, k)) {
           status = ML_ERROR_RESULT_OUT_OF_RANGE;
           goto end_transpose_01_p;
         }

--- a/test/unittest/unittest_util_func.cpp
+++ b/test/unittest/unittest_util_func.cpp
@@ -21,25 +21,26 @@
  * @bug         No known bugs
  */
 
-
 #include <gtest/gtest.h>
-#include <nntrainer_error.h>
 #include <neuralnet.h>
+#include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <util_func.h>
 
 #define tolerance 10e-5
 
-#define GEN_TEST_INPUT(input, eqation_i_j_k) \
-  do {                                       \
-    for (int i = 0; i < batch; ++i) {        \
-      for (int j = 0; j < height; ++j) {     \
-        for (int k = 0; k < width; ++k) {    \
-          float val = eqation_i_j_k;         \
-          input.setValue(i, j, k, val);      \
-        }                                    \
-      }                                      \
-    }                                        \
+#define GEN_TEST_INPUT(input, eqation_i_j_k_l) \
+  do {                                         \
+    for (int i = 0; i < batch; ++i) {          \
+      for (int j = 0; j < channel; ++j) {      \
+        for (int k = 0; k < height; ++k) {     \
+          for (int l = 0; l < width; ++l) {    \
+            float val = eqation_i_j_k_l;       \
+            input.setValue(i, j, k, l, val);   \
+          }                                    \
+        }                                      \
+      }                                        \
+    }                                          \
   } while (0)
 
 /**
@@ -47,6 +48,7 @@
  */
 TEST(nntrainer_util_func, softmax_01_p) {
   int batch = 3;
+  int channel = 1;
   int height = 1;
   int width = 10;
   float results[10] = {7.80134161e-05, 2.12062451e-04, 5.76445508e-04,
@@ -54,10 +56,10 @@ TEST(nntrainer_util_func, softmax_01_p) {
                        3.14728583e-02, 8.55520989e-02, 2.32554716e-01,
                        6.32149258e-01};
 
-  nntrainer::Tensor T(batch, height, width);
-  nntrainer::Tensor Results(batch, height, width);
+  nntrainer::Tensor T(batch, channel, height, width);
+  nntrainer::Tensor Results(batch, channel, height, width);
 
-  GEN_TEST_INPUT(T, (i * (width) + k + 1));
+  GEN_TEST_INPUT(T, (i * (width) + l + 1));
 
   Results = T.apply(nntrainer::softmax);
   float *data = Results.getData();
@@ -70,20 +72,22 @@ TEST(nntrainer_util_func, softmax_01_p) {
 
 TEST(nntrainer_util_func, softmax_prime_01_p) {
   int batch = 3;
+  int channel = 1;
   int height = 1;
   int width = 10;
   float results[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, (i * (width) + k + 1));
-  
+
   nntrainer::Tensor softmax_result = input.apply(nntrainer::softmax);
 
   float *data = softmax_result.getData();
   ASSERT_NE(nullptr, data);
 
-  nntrainer::Tensor softmax_prime_result = softmax_result.apply(nntrainer::softmaxPrime);
-  data = softmax_prime_result.getData(); 
+  nntrainer::Tensor softmax_prime_result =
+    softmax_result.apply(nntrainer::softmaxPrime);
+  data = softmax_prime_result.getData();
   ASSERT_NE(nullptr, data);
 
   for (int i = 0; i < batch * height * width; ++i) {
@@ -113,10 +117,11 @@ TEST(nntrainer_util_func, sqrtFloat_01_p) {
 
 TEST(nntrainer_util_func, logFloat_01_p) {
   int batch = 1;
+  int channel = 1;
   int height = 1;
   int width = 10;
 
-  nntrainer::Tensor input(batch, height, width);
+  nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (width) + k + 1);
 
   nntrainer::Tensor Results = input.apply(nntrainer::logFloat);
@@ -133,17 +138,19 @@ TEST(nntrainer_util_func, logFloat_01_p) {
 
 TEST(nntrainer_util_func, sigmoid_01_p) {
   int batch = 3;
+  int channel = 1;
   int height = 1;
   int width = 10;
 
-  float answer[30] = { 0.4013123, 0.4255575, 0.450166, 0.4750208, 0.5,
-    0.5249792, 0.549834, 0.5744425, 0.5986877, 0.6224593,
-    0.3100255, 0.3543437, 0.4013123, 0.450166, 0.5, 0.549834,
-    0.5986877, 0.6456563, 0.6899745, 0.7310586, 0.2314752, 0.2890505,
-    0.3543437, 0.4255575, 0.5, 0.5744425, 0.6456563, 0.7109495, 0.7685248, 0.8175745 };
+  float answer[30] = {0.4013123, 0.4255575, 0.450166,  0.4750208, 0.5,
+                      0.5249792, 0.549834,  0.5744425, 0.5986877, 0.6224593,
+                      0.3100255, 0.3543437, 0.4013123, 0.450166,  0.5,
+                      0.549834,  0.5986877, 0.6456563, 0.6899745, 0.7310586,
+                      0.2314752, 0.2890505, 0.3543437, 0.4255575, 0.5,
+                      0.5744425, 0.6456563, 0.7109495, 0.7685248, 0.8175745};
 
-  nntrainer::Tensor input(batch, height, width);
-  GEN_TEST_INPUT(input, (k - 4) * 0.1 * (i + 1));
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
 
   nntrainer::Tensor Results = input.apply(nntrainer::sigmoid);
 
@@ -157,24 +164,30 @@ TEST(nntrainer_util_func, sigmoid_01_p) {
   }
 }
 
-TEST(nntrainer_util_func, sigmoidPrime_01_p){
+TEST(nntrainer_util_func, sigmoidPrime_01_p) {
   int batch = 3;
+  int channel = 1;
   int height = 1;
   int width = 10;
-  float answer[30] = {2.40198421e-01, 2.39014374e-01, 2.37750225e-01, 2.36411103e-01, 2.35003712e-01,
-   2.33536203e-01, 2.32017974e-01, 2.30459419e-01, 2.28871631e-01, 2.27266092e-01, 2.44087699e-01, 
-   2.42313881e-01, 2.40198421e-01, 2.37750225e-01, 2.35003712e-01, 2.32017974e-01, 2.28871631e-01, 
-   2.25654341e-01, 2.22456864e-01, 2.19361864e-01, 2.46680881e-01, 2.44849977e-01, 2.42313881e-01, 
-   2.39014374e-01, 2.35003712e-01, 2.30459419e-01, 2.25654341e-01, 2.2089191e-01, 2.16437141e-01, 2.12472086e-01};
+  float answer[30] = {
+    2.40198421e-01, 2.39014374e-01, 2.37750225e-01, 2.36411103e-01,
+    2.35003712e-01, 2.33536203e-01, 2.32017974e-01, 2.30459419e-01,
+    2.28871631e-01, 2.27266092e-01, 2.44087699e-01, 2.42313881e-01,
+    2.40198421e-01, 2.37750225e-01, 2.35003712e-01, 2.32017974e-01,
+    2.28871631e-01, 2.25654341e-01, 2.22456864e-01, 2.19361864e-01,
+    2.46680881e-01, 2.44849977e-01, 2.42313881e-01, 2.39014374e-01,
+    2.35003712e-01, 2.30459419e-01, 2.25654341e-01, 2.2089191e-01,
+    2.16437141e-01, 2.12472086e-01};
 
-  nntrainer::Tensor input(batch, height, width);
-  GEN_TEST_INPUT(input, (k - 4) * 0.1 * (i + 1));
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
 
   nntrainer::Tensor sigmoid_result = input.apply(nntrainer::sigmoid);
   float *data = sigmoid_result.getData();
   ASSERT_NE(nullptr, data);
 
-  nntrainer::Tensor prime_result = sigmoid_result.apply(nntrainer::sigmoidePrime);
+  nntrainer::Tensor prime_result =
+    sigmoid_result.apply(nntrainer::sigmoidePrime);
   data = prime_result.getData();
   ASSERT_NE(nullptr, data);
 
@@ -185,16 +198,21 @@ TEST(nntrainer_util_func, sigmoidPrime_01_p){
 
 TEST(nntrainer_util_func, tanhFloat_01_p) {
   int batch = 3;
+  int channel = 1;
   int height = 1;
   int width = 10;
-  float answer[30] = { -3.79948962e-01, -2.91312612e-01, -1.9737532e-01, -9.96679946e-02, 0e+00, 9.96679946e-02, 
-   1.9737532e-01, 2.91312612e-01, 3.79948962e-01, 4.62117157e-01, -6.6403677e-01, -5.37049567e-01, 
-   -3.79948962e-01, -1.9737532e-01, 0e+00, 1.9737532e-01, 3.79948962e-01, 5.37049567e-01, 6.6403677e-01,
-   7.61594156e-01, -8.33654607e-01, -7.1629787e-01, -5.37049567e-01, -2.91312612e-01, 0e+00, 2.91312612e-01,
-   5.37049567e-01, 7.1629787e-01, 8.33654607e-01, 9.05148254e-01 };
+  float answer[30] = {
+    -3.79948962e-01, -2.91312612e-01, -1.9737532e-01,  -9.96679946e-02,
+    0e+00,           9.96679946e-02,  1.9737532e-01,   2.91312612e-01,
+    3.79948962e-01,  4.62117157e-01,  -6.6403677e-01,  -5.37049567e-01,
+    -3.79948962e-01, -1.9737532e-01,  0e+00,           1.9737532e-01,
+    3.79948962e-01,  5.37049567e-01,  6.6403677e-01,   7.61594156e-01,
+    -8.33654607e-01, -7.1629787e-01,  -5.37049567e-01, -2.91312612e-01,
+    0e+00,           2.91312612e-01,  5.37049567e-01,  7.1629787e-01,
+    8.33654607e-01,  9.05148254e-01};
 
-  nntrainer::Tensor input(batch, height, width);
-  GEN_TEST_INPUT(input, (k - 4) * 0.1 * (i + 1));
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
 
   nntrainer::Tensor Results = input.apply(nntrainer::tanhFloat);
 
@@ -210,16 +228,18 @@ TEST(nntrainer_util_func, tanhFloat_01_p) {
 
 TEST(nntrainer_util_func, tanhFloatPrime_01_p) {
   int batch = 3;
+  int channel = 1;
   int height = 1;
   int width = 10;
-  float answer[30] = { 0.8684754, 0.919717, 0.9620329, 0.9901317, 1, 
-   0.9901317, 0.9620329, 0.919717, 0.8684754, 0.8135417, 0.6623883,
-   0.7591631, 0.8684754, 0.9620329, 1, 0.9620329, 0.8684754,
-   0.7591631, 0.6623883, 0.5878168, 0.5342845, 0.6222535, 
-   0.7591631, 0.919717, 1, 0.919717, 0.7591631, 0.6222535, 0.5342845, 0.4833332 };
+  float answer[30] = {0.8684754, 0.919717,  0.9620329, 0.9901317, 1,
+                      0.9901317, 0.9620329, 0.919717,  0.8684754, 0.8135417,
+                      0.6623883, 0.7591631, 0.8684754, 0.9620329, 1,
+                      0.9620329, 0.8684754, 0.7591631, 0.6623883, 0.5878168,
+                      0.5342845, 0.6222535, 0.7591631, 0.919717,  1,
+                      0.919717,  0.7591631, 0.6222535, 0.5342845, 0.4833332};
 
-  nntrainer::Tensor input(batch, height, width);
-  GEN_TEST_INPUT(input, (k - 4) * 0.1 * (i + 1));
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
 
   nntrainer::Tensor tanh_result = input.apply(nntrainer::tanhFloat);
   float *data = tanh_result.getData();
@@ -236,14 +256,15 @@ TEST(nntrainer_util_func, tanhFloatPrime_01_p) {
 
 TEST(nntrainer_util_func, relu_01_p) {
   int batch = 3;
+  int channel = 1;
   int height = 1;
   int width = 10;
   float answer[30] = {0, 0, 0, 0, 0, 0.1, 0.2, 0.3, 0.4, 0.5,
-    0, 0, 0, 0, 0, 0.2, 0.4, 0.6,
-    0.8, 1, 0, 0, 0, 0, 0, 0.3, 0.6, 0.9, 1.2, 1.5};
+                      0, 0, 0, 0, 0, 0.2, 0.4, 0.6, 0.8, 1,
+                      0, 0, 0, 0, 0, 0.3, 0.6, 0.9, 1.2, 1.5};
 
-  nntrainer::Tensor input(batch, height, width);
-  GEN_TEST_INPUT(input, (k - 4) * 0.1 * (i + 1));
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
 
   nntrainer::Tensor Results = input.apply(nntrainer::relu);
 
@@ -259,14 +280,14 @@ TEST(nntrainer_util_func, relu_01_p) {
 
 TEST(nntrainer_util_func, reluPrime_01_p) {
   int batch = 3;
+  int channel = 1;
   int height = 1;
   int width = 10;
-  float answer[30] = { 0, 0, 0, 0, 0, 1, 1, 1, 1, 1,
-    0, 0, 0, 0, 0, 1, 1, 1,
-    1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1 };
+  float answer[30] = {0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0,
+                      1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1};
 
-  nntrainer::Tensor input(batch, height, width);
-  GEN_TEST_INPUT(input, (k - 4) * 0.1 * (i + 1));
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
 
   nntrainer::Tensor relu_result = input.apply(nntrainer::relu);
   float *data = relu_result.getData();
@@ -288,7 +309,7 @@ int main(int argc, char **argv) {
   int result = -1;
 
   try {
-    testing::InitGoogleTest (&argc, argv);
+    testing::InitGoogleTest(&argc, argv);
   } catch (...) {
     ml_loge("Failed to init gtest\n");
   }
@@ -301,4 +322,3 @@ int main(int argc, char **argv) {
 
   return result;
 }
-


### PR DESCRIPTION
Until now, nntrainer cannot handle 3D Tensor including channel. Only
supported 2D Tensor which is batch, height, width.
From this PR, nntrainer can handle 3D Tensor include channel. But more
optimization is required.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>