### PR TITLE
Reduce duplicated function call

### DIFF
--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -40,8 +40,6 @@ int BatchNormalizationLayer::initialize(bool last) {
 
   this->gamma = Tensor(dim.batch(), dim.width());
   this->beta = Tensor(dim.batch(), dim.width());
-  beta.setZero();
-  gamma.setZero();
 
   return status;
 }

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -611,19 +611,19 @@ void Tensor::read(std::ifstream &file) {
  * That is the why it has (1, dim.height(), dim.width()) dimension.
  */
 Tensor Tensor::average() const {
+  unsigned int I;
   if (dim.batch() == 1)
     return *this;
 
   Tensor result(1, dim.height(), dim.width());
   for (unsigned int i = 0; i < dim.height(); i++) {
+    I = i * dim.width();
     for (unsigned int j = 0; j < dim.width(); j++) {
-      result.data[i * dim.width() + j] = 0.0;
+      result.data[I + j] = 0.0;
       for (unsigned int k = 0; k < dim.batch(); k++) {
-        result.data[i * dim.width() + j] +=
-          data[k * dim.width() * dim.height() + i * dim.width() + j];
+        result.data[I + j] += data[k * dim.width() * dim.height() + I + j];
       }
-      result.data[i * dim.width() + j] =
-        result.data[i * dim.width() + j] / (float)dim.batch();
+      result.data[I + j] = result.data[I + j] / (float)dim.batch();
     }
   }
   return result;
@@ -647,8 +647,12 @@ int Tensor::argmax() {
 
 float Tensor::l2norm() const {
   float sum = 0.0;
-  for (unsigned int i = 0; i < dim.getDataLen(); i++) {
-    sum += this->data[i] * this->data[i];
+  float tmp;
+  unsigned int len = dim.getDataLen();
+
+  for (unsigned int i = 0; i < len; i++) {
+    tmp = this->data[i];
+    sum += tmp * tmp;
   }
 
   return sqrt(sum);


### PR DESCRIPTION
**Changes proposed in this PR:**
- Reduce `average()` call in `Optimizer::calculate
- Delete setZero call after construction `Tensor`
- Reduce indexing and multiplication in few loops

This PR results in better performance including roughly 60% decrease
in time spent in `Tensor::average()` in Classification example(checked in vtune).

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>