### PR TITLE
Add lazy evaluation feature to Tensor @open sesame 06/09 16:16

### DIFF
--- a/nntrainer/include/lazy_tensor.h
+++ b/nntrainer/include/lazy_tensor.h
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: Apache-2.0-only
+ * Copyright (C) 2020 Jihoon Lee <jihoon.it.lee@samsung.com>
+ *
+ * @file	lazy_tensor.h
+ * @date	05 Jun 2020
+ * @brief	A lazy evaluation calculator for tensors
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jihoon Lee <jihoon.it.lee@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#ifndef __LAZY_TENSOR_H__
+#define __LAZY_TENSOR_H__
+#ifdef __cplusplus
+
+#include <tensor.h>
+#include <vector>
+
+namespace nntrainer {
+
+/**
+ * @class   LazyTensor a wrapper class for lazy calculation of tensor
+ * @brief   calculation is delayed until Tensor LazyTensor::run() is
+ *          called, can be contructed by Tensor::chain() method
+ */
+class LazyTensor {
+public:
+  /**
+   * @brief Constructor of Lazy Tensor, Tensor is copied to gaurantee
+   * immutability
+   */
+  LazyTensor(const Tensor &from) { target.copy(from); };
+
+  /**
+   * @brief Wrapper method of add_i
+   * @retval LazyTensor *this
+   */
+  LazyTensor add_i(float const &value);
+
+  /**
+   * @brief execute the call_chain to get the tensor
+   * @retval calculated tensor
+   */
+  Tensor &run();
+
+private:
+  /**< handle the data as a std::vector type */
+  std::vector<std::function<int(Tensor &)>> call_chain;
+  Tensor target;
+};
+
+} /* namespace nntrainer */
+
+#endif /* __cplusplus */
+#endif /* __LAZY_TENSOR_H__ */

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -41,6 +41,7 @@ extern "C" {
 
 namespace nntrainer {
 
+class LazyTensor;
 /**
  * @class   Tensor Class for Calculation
  * @brief   Tensor Class for Calculation
@@ -140,6 +141,14 @@ public:
   Tensor add(Tensor const &m) const;
 
   /**
+   * @brief Add Tensor Element immediately to target tensor without mem copy
+   * @param[in] value value to be added
+   * #retval #ML_ERROR_NONE  Successful
+   * #retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter
+   */
+  int add_i(float const &value);
+
+  /**
    * @brief     Add value Element by Element
    * @param[in] value value to be added
    * @retval    Calculated Tensor
@@ -209,6 +218,12 @@ public:
    * @retval    Calculated Tensor(1, height, width)
    */
   Tensor average() const;
+
+  /**
+   * @brief     Anchor a starting point to defer following evaluation
+   * @retval    LazyTensor class that can be used with run();
+   */
+  LazyTensor chain() const;
 
   /**
    * @brief     Softmax the Tensor elements

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -28,7 +28,8 @@ nntrainer_sources = [
   'src/util_func.cpp',
   'src/parse_util.cpp',
   'src/tensor_dim.cpp',
-  'src/conv2d_layer.cpp'
+  'src/conv2d_layer.cpp',
+  'src/lazy_tensor.cpp'
 ]
 
 nntrainer_headers = [
@@ -47,7 +48,8 @@ nntrainer_headers = [
   'include/util_func.h',
   'include/parse_util.h',
   'include/tensor_dim.h',
-  'include/conv2d_layer.h'
+  'include/conv2d_layer.h',
+  'include/lazy_tensor.h'
 ]
 
 

--- a/nntrainer/src/lazy_tensor.cpp
+++ b/nntrainer/src/lazy_tensor.cpp
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: Apache-2.0-only
+ *
+ * Copyright (C) 2020 Jihoon Lee <jihoon.it.lee@samsung.com>
+ *
+ * @file	lazy_tensor.cpp
+ * @date	05 Jun 2020
+ * @brief	A lazy evaluation calculator for tensors
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jihoon Lee <jihoon.it.lee@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#include <lazy_tensor.h>
+#include <nntrainer_error.h>
+#include <tensor.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Wrapper method of add_i (immediate version of add)
+ * @retval this
+ */
+LazyTensor LazyTensor::add_i(float const &value) {
+  call_chain.push_back([value](Tensor &t) mutable -> int {
+    t.add_i(value);
+    return ML_ERROR_NONE;
+  });
+  return *this;
+}
+
+/**
+ * @brief execute the call_chain to evaluate
+ * @retval calculated tensor
+ */
+Tensor &LazyTensor::run() {
+  int status;
+  for (auto item : call_chain) {
+    status = item(target);
+    if (status != ML_ERROR_NONE) {
+      throw std::runtime_error("Error: evaluation failed");
+    }
+  }
+  return target;
+}
+
+} /* namespace nntrainer */

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -184,6 +184,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/conv2d_layer.h
 %{_includedir}/nntrainer/neuralnet.h
 %{_includedir}/nntrainer/tensor.h
+%{_includedir}/nntrainer/lazy_tensor.h
 %{_includedir}/nntrainer/tensor_dim.h
 %{_includedir}/nntrainer/nntrainer.h
 %{_includedir}/nntrainer/nntrainer_log.h

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -51,3 +51,12 @@ unittest_databuffer_file = executable('unittest_databuffer_file',
   install_dir: application_install_dir
 )
 test('unittest_databuffer_file', unittest_databuffer_file)
+
+unittest_nntrainer_lazy_tensor = executable('unittest_nntrainer_lazy_tensor',
+  ['../nntrainer_test_util.cpp', 'unittest_nntrainer_lazy_tensor.cpp'],
+  dependencies: [unittest_nntrainer_deps],
+  include_directories: nntrainer_test_inc,
+  install: get_option('enable-test'),
+  install_dir: application_install_dir
+)
+test('unittest_nntrainer_lazy_tensor', unittest_nntrainer_lazy_tensor)

--- a/test/unittest/unittest_nntrainer_lazy_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_lazy_tensor.cpp
@@ -1,0 +1,122 @@
+/* SPDX-License-Identifier: Apache-2.0-only
+ * Copyright (C) 2020 Jihoon Lee <jihoon.it.lee@samsung.com>
+ *
+ * @file	unittest_nntrainer_lazy_tensor.cpp
+ * @date	05 Jun 2020
+ * @brief	A unittest for nntrainer_lazy_tensor
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jihoon Lee <jihoon.it.lee@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#include "nntrainer_test_util.h"
+#include "util_func.h"
+#include <lazy_tensor.h>
+#include <fstream>
+#include <nntrainer_error.h>
+#include <tensor.h>
+#include <tensor_dim.h>
+
+TEST(nntrainer_LazyTensor, LazyTensor_01_p) {
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor target(batch, channel, height, width);
+  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1 + l);
+
+  nntrainer::LazyTensor delayed(target);
+
+  nntrainer::Tensor result;
+  result = delayed.run();
+
+  float *expected = target.getData();
+  ASSERT_NE(expected, (float *)NULL);
+  float *current = result.getData();
+  ASSERT_NE(current, (float *)NULL);
+
+  for (int i = 0; i < batch * height * width; ++i) {
+    EXPECT_FLOAT_EQ(current[i], expected[i]);
+  }
+}
+
+TEST(nntrainer_LazyTensor, LazyTensor_02_p) {
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor target(batch, channel, height, width);
+  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1);
+
+  nntrainer::Tensor result;
+  result = target.chain().run();
+
+  float *expected = target.getData();
+  ASSERT_NE(expected, (float *)NULL);
+  float *current = result.getData();
+  ASSERT_NE(current, (float *)NULL);
+
+  for (int i = 0; i < batch * height * width; ++i) {
+    EXPECT_FLOAT_EQ(current[i], expected[i]);
+  }
+}
+
+TEST(nntrainer_LazyTensor, LazyTensor_03_p) {
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor target(batch, height, width);
+  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1);
+
+  nntrainer::Tensor result;
+  result = target.chain().add_i(2.1).run();
+
+  float *expected = target.getData();
+  ASSERT_NE(expected, (float *)NULL);
+  float *current = result.getData();
+  ASSERT_NE(current, (float *)NULL);
+
+  for (int i = 0; i < batch * height * width; ++i) {
+    EXPECT_FLOAT_EQ(current[i], expected[i] + 2.1);
+  }
+}
+
+TEST(nntrainer_LazyTensor, LazyTensor_04_p) {
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor target(batch, height, width);
+  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1);
+
+  nntrainer::Tensor result;
+  result = target.chain().add_i(2.1).add_i(1.0).run();
+
+  float *expected = target.getData();
+  ASSERT_NE(expected, (float *)NULL);
+  float *current = result.getData();
+  ASSERT_NE(current, (float *)NULL);
+
+  for (int i = 0; i < batch * height * width; ++i) {
+    EXPECT_FLOAT_EQ(current[i], expected[i] + 3.1);
+  }
+}
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  testing::InitGoogleTest(&argc, argv);
+
+  result = RUN_ALL_TESTS();
+
+  return result;
+}

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -191,6 +191,32 @@ TEST(nntrainer_Tensor, divide_03_n) {
                    "Error: Dimension must be equal each other");
 }
 
+TEST(nntrainer_Tensor, add_i_01_p) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor target(batch, channel, height, width);
+  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1 + channel);
+
+  nntrainer::Tensor original(batch, height, width);
+  original.copy(target);
+
+  status = target.add_i(2.1);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  float *previous = original.getData();
+  ASSERT_NE(nullptr, previous);
+  float *data = target.getData();
+  ASSERT_NE(nullptr, data);
+
+  for (int i = 0; i < batch * height * width; ++i) {
+    EXPECT_FLOAT_EQ(data[i], previous[i] + 2.1);
+  }
+}
+
 TEST(nntrainer_Tensor, add_i_02_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;


### PR DESCRIPTION
This PR propose 2 concepts.

1. Propose `*_i` type of operation to `Tensor`. Which mutates target
tensor instead of memcopying the tensor.(511c74d)
2. Add chaining for lazy & memcopyless operation.

For example Tensor could do the operation in such manner:

```cpp
Tensor t;
t.chain() /* Initial memcpy happens to guarantee immutability */
 .add_i(x)
 .multiply_i(y) /* NYI */
 .divide_i(y) /* NYI */
 .run()
```

operations are delayed until `.run()` is called. This is done by
monadic object named `DefferedTensor`.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>