### PR TITLE
Register Tensor ops to lazy tensor @open sesame 06/11 17:01

### DIFF
--- a/nntrainer/include/lazy_tensor.h
+++ b/nntrainer/include/lazy_tensor.h
@@ -33,16 +33,102 @@ public:
   LazyTensor(const Tensor &from) { target.copy(from); };
 
   /**
-   * @brief Wrapper method of add_i
+   * @brief     Wrapper method of add_i. see tensor.h for more detail
+   * @param[in] value to be added
+   * @retval    LazyTensor *this
+   */
+  LazyTensor &add_i(float const &value);
+
+  /**
+   * @brief     Wrapper method of add_i. see tensor.h for more detail
+   * @param[in] m Tensor to be added
+   * @retval    LazyTensor *this
+   */
+  LazyTensor &add_i(Tensor const &m);
+
+  /**
+   * @brief     Wrapper method of subtract_i. see tensor.h for more detail
+   * @param[in] m Tensor to subtract
+   * @retval    LazyTensor *this
+   */
+  LazyTensor &subtract_i(Tensor const &m);
+
+  /**
+   * @brief     Wrapper method of subtract_i. see tensor.h for more detail
+   * @param[in] value value to subtract
+   * @retval    LazyTensor *this
+   */
+  LazyTensor &subtract_i(float const &value);
+
+  /**
+   * @brief Wrapper method of multiply_i. see tensor.h for more detail
+   * @param[in] value to be added
    * @retval LazyTensor *this
    */
-  LazyTensor add_i(float const &value);
+  LazyTensor &multiply_i(float const &value);
+
+  /**
+   * @brief     Wrapper method of multiply_i. see tensor.h for more detail
+   * @param[in] m Tensor to be multiplied
+   * @retval    LazyTensor *this
+   */
+  LazyTensor &multiply_i(Tensor const &m);
+
+  /**
+   * @brief     Wrapper method of divide_i. see tensor.h for more detail
+   * @param[in] value divisor
+   * @retval    LazyTensor *this
+   */
+  LazyTensor &divide_i(float const &value);
+
+ /**
+   * @brief     Wrapper method of divide_i. see tensor.h for more detail
+   * @param[in] m Tensor to for division
+   * @retval    LazyTensor *this
+   */
+  LazyTensor &divide_i(Tensor const &m);
+
+  /**
+   * @brief     Wrapper method of dot. see tensor.h for more detail (memcopy happens)
+   * @param[in] m Tensor
+   * @retval    LazyTensor *this
+   */
+  LazyTensor &dot(Tensor const &m);
+
+  /**
+   * @brief     Wrapper method of transpose. see tensor.h for more detail (memcopy happens)
+   * @param[in] direction to transpose ex) 0:2:1
+   * @retval    LazyTensor *this
+   */
+  LazyTensor &transpose(std::string direction) ;
+
+  /**
+   * @brief     Wrapper method of sum. see tensor.h for more detail (memcopy happens)
+   * @retval    LazyTensor *this
+   */
+  LazyTensor &sum();
+
+  /**
+   * @brief     Wrapper method of sum. see tensor.h for more detail (memcopy happens)
+   *            0 : batch direction
+   *            1 : channel direction
+   *            2 : channel direction
+   *            3 : channel direction
+   * @retval    LazyTensor *this
+   */
+  LazyTensor &sum(int axis);
+
+  /**
+   * @brief     Wrapper method of average. see tensor.h for more detail (memcopy happens)
+   * @retval    LazyTensor *this
+   */
+  LazyTensor &average();
 
   /**
    * @brief execute the call_chain to get the tensor
    * @retval calculated tensor
    */
-  Tensor &run();
+  Tensor run();
 
 private:
   /**< handle the data as a std::vector type */

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -312,14 +312,14 @@ public:
    * @param[in] *function function pointer applied
    * @retval    Tensor
    */
-  Tensor apply(float (*function)(float)) const;
+  Tensor apply(std::function<float(float)> f) const;
 
   /**
    * @brief     Apply function to Tensor
    * @param[in] *function function pointer applied
    * @retval    Tensor
    */
-  Tensor apply(Tensor (*function)(Tensor)) const;
+  Tensor apply(std::function<Tensor(Tensor)> f) const;
 
   /**
    * @brief     Print element
@@ -392,13 +392,15 @@ public:
    * @brief     return Tensor Dim
    * @retval    TensorDim
    */
-  TensorDim getDim() { return dim; }
+  TensorDim getDim() const { return dim; }
 
   /**
    * @brief     return Data pointer of Tensor
    * @retval    float pointer
    */
   float *getData() { return data.data(); }
+
+  const float *getData() const { return data.data(); }
 
 private:
   /**< handle the data as a std::vector type */

--- a/nntrainer/src/lazy_tensor.cpp
+++ b/nntrainer/src/lazy_tensor.cpp
@@ -21,11 +21,184 @@ namespace nntrainer {
  * @brief Wrapper method of add_i (immediate version of add)
  * @retval this
  */
-LazyTensor LazyTensor::add_i(float const &value) {
-  call_chain.push_back([value](Tensor &t) mutable -> int {
-    t.add_i(value);
-    return ML_ERROR_NONE;
-  });
+LazyTensor &LazyTensor::add_i(float const &value) {
+  call_chain.push_back(
+    [value](Tensor &t) mutable -> int { return t.add_i(value); });
+  return *this;
+}
+/**
+ * @brief     Wrapper method of add_i. see tensor.h for more detail
+ * @param[in] m Tensor to be added
+ * @retval    LazyTensor *this
+ */
+LazyTensor &LazyTensor::add_i(Tensor const &m) {
+  auto f = [m](Tensor &t) mutable -> int { return t.add_i(m); };
+  call_chain.push_back(f);
+  return *this;
+}
+
+/**
+ * @brief     Wrapper method of subtract_i. see tensor.h for more detail
+ * @param[in] m Tensor to subtract
+ * @retval    LazyTensor *this
+ */
+LazyTensor &LazyTensor::subtract_i(Tensor const &m) {
+  auto f = [m](Tensor &t) mutable -> int { return t.subtract_i(m); };
+  call_chain.push_back(f);
+  return *this;
+}
+
+/**
+ * @brief     Wrapper method of subtract_i. see tensor.h for more detail
+ * @param[in] value value to subtract
+ * @retval    LazyTensor *this
+ */
+LazyTensor &LazyTensor::subtract_i(float const &value) {
+  auto f = [value](Tensor &t) mutable -> int { return t.subtract_i(value); };
+  call_chain.push_back(f);
+  return *this;
+}
+
+/**
+ * @brief Wrapper method of multiply_i. see tensor.h for more detail
+ * @param[in] value to be added
+ * @retval LazyTensor *this
+ */
+LazyTensor &LazyTensor::multiply_i(float const &value) {
+  auto f = [value](Tensor &t) mutable -> int { return t.multiply_i(value); };
+  call_chain.push_back(f);
+  return *this;
+}
+
+/**
+ * @brief     Wrapper method of multiply_i. see tensor.h for more detail
+ * @param[in] m Tensor to be multiplied
+ * @retval    LazyTensor *this
+ */
+LazyTensor &LazyTensor::multiply_i(Tensor const &m) {
+  auto f = [m](Tensor &t) mutable -> int { return t.multiply_i(m); };
+  call_chain.push_back(f);
+  return *this;
+}
+
+/**
+ * @brief     Wrapper method of divide_i. see tensor.h for more detail
+ * @param[in] value divisor
+ * @retval    LazyTensor *this
+ */
+LazyTensor &LazyTensor::divide_i(float const &value) {
+  auto f = [value](Tensor &t) mutable -> int { return t.divide_i(value); };
+  call_chain.push_back(f);
+  return *this;
+}
+
+/**
+ * @brief     Wrapper method of divide_i. see tensor.h for more detail
+ * @param[in] m Tensor to for division
+ * @retval    LazyTensor *this
+ */
+LazyTensor &LazyTensor::divide_i(Tensor const &m) {
+  auto f = [m](Tensor &t) mutable -> int { return t.divide_i(m); };
+  call_chain.push_back(f);
+  return *this;
+}
+
+/**
+ * @brief     Wrapper method of dot. see tensor.h for more detail (memcopy
+ * happens)
+ * @param[in] m Tensor
+ * @retval    LazyTensor *this
+ */
+LazyTensor &LazyTensor::dot(Tensor const &m) {
+  auto f = [m](Tensor &t) mutable -> int {
+    try {
+      t = t.dot(m);
+      return ML_ERROR_NONE;
+    } catch (std::runtime_error &e) {
+      return ML_ERROR_INVALID_PARAMETER;
+    }
+  };
+
+  call_chain.push_back(f);
+  return *this;
+}
+
+/**
+ * @brief     Wrapper method of transpose. see tensor.h for more detail (memcopy
+ * happens)
+ * @param[in] direction to transpose ex) 0:2:1
+ * @retval    LazyTensor *this
+ */
+LazyTensor &LazyTensor::transpose(std::string direction) {
+  auto f = [direction](Tensor &t) mutable -> int {
+    try {
+      t = t.transpose(direction);
+      return ML_ERROR_NONE;
+    } catch (std::runtime_error &e) {
+      return ML_ERROR_INVALID_PARAMETER;
+    }
+  };
+
+  call_chain.push_back(f);
+  return *this;
+}
+
+/**
+ * @brief     Wrapper method of sum. see tensor.h for more detail (memcopy
+ * happens)
+ * @param[in] direction to transpose ex) 0:2:1
+ * @retval    LazyTensor *this
+ */
+LazyTensor &LazyTensor::sum() {
+  auto f = [](Tensor &t) mutable -> int {
+    try {
+      t = t.sum();
+      return ML_ERROR_NONE;
+    } catch (std::runtime_error &e) {
+      return ML_ERROR_INVALID_PARAMETER;
+    }
+  };
+
+  call_chain.push_back(f);
+  return *this;
+}
+
+/**
+ * @brief     Wrapper method of sum. see tensor.h for more detail (memcopy
+ * happens) 0 : batch direction 1 : channel direction 2 : channel direction 3 :
+ * channel direction
+ * @retval    LazyTensor *this
+ */
+LazyTensor &LazyTensor::sum(int axis) {
+  auto f = [axis](Tensor &t) mutable -> int {
+    try {
+      t = t.sum(axis);
+      return ML_ERROR_NONE;
+    } catch (std::runtime_error &e) {
+      return ML_ERROR_INVALID_PARAMETER;
+    }
+  };
+
+  call_chain.push_back(f);
+  return *this;
+}
+
+/**
+ * @brief     Wrapper method of average. see tensor.h for more detail (memcopy
+ * happens)
+ * @retval    LazyTensor *this
+ */
+LazyTensor &LazyTensor::average() {
+  auto f = [](Tensor &t) mutable -> int {
+    try {
+      t = t.average();
+      return ML_ERROR_NONE;
+    } catch (std::runtime_error &e) {
+      return ML_ERROR_INVALID_PARAMETER;
+    }
+  };
+
+  call_chain.push_back(f);
   return *this;
 }
 
@@ -33,7 +206,7 @@ LazyTensor LazyTensor::add_i(float const &value) {
  * @brief execute the call_chain to evaluate
  * @retval calculated tensor
  */
-Tensor &LazyTensor::run() {
+Tensor LazyTensor::run() {
   int status;
   for (auto item : call_chain) {
     status = item(target);

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -720,18 +720,18 @@ Tensor Tensor::transpose(std::string direction) const {
   return result;
 }
 
-Tensor Tensor::apply(float (*function)(float)) const {
+Tensor Tensor::apply(std::function<float(float)> f) const {
   Tensor result(dim.batch(), dim.channel(), dim.height(), dim.width());
   unsigned int i;
 
   for (i = 0; i < dim.getDataLen(); ++i)
-    result.data[i] = (*function)(data[i]);
+    result.data[i] = f(data[i]);
 
   return result;
 }
 
-Tensor Tensor::apply(Tensor (*function)(Tensor)) const {
-  return (*function)(*this);
+Tensor Tensor::apply(std::function<Tensor(Tensor)> f) const {
+  return f(*this);
 }
 
 void Tensor::print(std::ostream &out) const {

--- a/test/unittest/unittest_nntrainer_lazy_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_lazy_tensor.cpp
@@ -12,12 +12,70 @@
 
 #include "nntrainer_test_util.h"
 #include "util_func.h"
-#include <lazy_tensor.h>
 #include <fstream>
+#include <lazy_tensor.h>
 #include <nntrainer_error.h>
 #include <tensor.h>
 #include <tensor_dim.h>
 
+class nntrainer_LazyTensorOpsTest : public ::testing::Test {
+protected:
+  nntrainer_LazyTensorOpsTest() {}
+
+  virtual void SetUp() {
+    target = nntrainer::Tensor(batch, channel, height, width);
+    GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1 + l);
+
+    original.copy(target);
+  }
+
+  // virtual void TearDown()
+  /**
+   * @brief return a tensor filled with contant value
+   */
+  nntrainer::Tensor constant(float value) {
+    nntrainer::Tensor t(batch, channel, height, width);
+    return t.apply([value](float) { return value; });
+  }
+
+  /**
+   * @brief return a tensor filled with contant value with dimension
+   */
+  nntrainer::Tensor constant(float value, unsigned int batch, unsigned channel,
+                             unsigned height, unsigned width) {
+    nntrainer::Tensor t(batch, channel, height, width);
+    return t.apply([value](float) { return value; });
+  }
+
+  void test_eq(nntrainer::Tensor const &A, nntrainer::Tensor const &B) {
+    EXPECT_EQ(A.getBatch(), B.getBatch());
+    EXPECT_EQ(A.getChannel(), B.getChannel());
+    EXPECT_EQ(A.getHeight(), B.getHeight());
+    EXPECT_EQ(A.getWidth(), B.getWidth());
+
+    int len = A.getDim().getDataLen();
+    const float *aData = A.getData();
+    ASSERT_NE(aData, (float *)NULL);
+    const float *bData = B.getData();
+    ASSERT_NE(bData, (float *)NULL);
+
+    for (int i = 0; i < len; ++i) {
+      EXPECT_FLOAT_EQ(aData[i], bData[i]);
+    }
+  }
+
+  nntrainer::Tensor target;
+  nntrainer::Tensor original;
+  nntrainer::Tensor expected;
+
+private:
+  int batch = 3;
+  int height = 2;
+  int width = 10;
+  int channel = 1;
+};
+
+// LazyTensor init test
 TEST(nntrainer_LazyTensor, LazyTensor_01_p) {
   int batch = 3;
   int height = 3;
@@ -42,70 +100,85 @@ TEST(nntrainer_LazyTensor, LazyTensor_01_p) {
   }
 }
 
-TEST(nntrainer_LazyTensor, LazyTensor_02_p) {
-  int batch = 3;
-  int height = 3;
-  int width = 10;
-  int channel = 1;
-
-  nntrainer::Tensor target(batch, channel, height, width);
-  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1);
-
-  nntrainer::Tensor result;
-  result = target.chain().run();
-
-  float *expected = target.getData();
-  ASSERT_NE(expected, (float *)NULL);
-  float *current = result.getData();
-  ASSERT_NE(current, (float *)NULL);
-
-  for (int i = 0; i < batch * height * width; ++i) {
-    EXPECT_FLOAT_EQ(current[i], expected[i]);
-  }
+// Simple chain and run
+TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_01_p) {
+  test_eq(target.chain().run(), original);
 }
 
-TEST(nntrainer_LazyTensor, LazyTensor_03_p) {
-  int batch = 3;
-  int height = 3;
-  int width = 10;
-  int channel = 1;
-
-  nntrainer::Tensor target(batch, height, width);
-  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1);
-
-  nntrainer::Tensor result;
-  result = target.chain().add_i(2.1).run();
-
-  float *expected = target.getData();
-  ASSERT_NE(expected, (float *)NULL);
-  float *current = result.getData();
-  ASSERT_NE(current, (float *)NULL);
-
-  for (int i = 0; i < batch * height * width; ++i) {
-    EXPECT_FLOAT_EQ(current[i], expected[i] + 2.1);
-  }
+// Simple chain and add_i(float)
+TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_02_p) {
+  expected = original.add(2.1);
+  test_eq(target.chain().add_i(2.1).run(), expected);
 }
 
-TEST(nntrainer_LazyTensor, LazyTensor_04_p) {
-  int batch = 3;
-  int height = 3;
-  int width = 10;
-  int channel = 1;
+// chain and add_i(float) add_i(float)
+TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_03_p) {
+  expected = original.add(4.2);
+  test_eq(target.chain().add_i(2.1).add_i(2.1).run(), expected);
+}
 
-  nntrainer::Tensor target(batch, height, width);
-  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1);
+// chain and add_i(float) add_i(float)
+TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_04_p) {
+  expected = original.add(4.2);
+  test_eq(target.chain().add_i(2.1).add_i(2.1).run(), expected);
+}
 
-  nntrainer::Tensor result;
-  result = target.chain().add_i(2.1).add_i(1.0).run();
+// chain and add_i(float) add_i(Tensor)
+TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_05_p) {
+  expected = original.add(4.1);
+  test_eq(target.chain().add_i(2.1).add_i(constant(2.0)).run(), expected);
+}
 
-  float *expected = target.getData();
-  ASSERT_NE(expected, (float *)NULL);
-  float *current = result.getData();
-  ASSERT_NE(current, (float *)NULL);
+// chain and add_i(float) subtract(float)
+TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_06_p) {
+  test_eq(target.chain().add_i(2.1).subtract_i(2.1).run(), original);
+}
 
-  for (int i = 0; i < batch * height * width; ++i) {
-    EXPECT_FLOAT_EQ(current[i], expected[i] + 3.1);
-  }
+// other basic operations (positive)...
+TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_07_p) {
+  target = constant(1.0);
+  expected = constant(2.0);
+  test_eq(target.chain().multiply_i(2.0).run(), expected);
+  test_eq(target.chain().multiply_i(constant(2.0)).run(), expected);
+
+  target = constant(1.0);
+  expected = constant(0.5);
+  test_eq(target.chain().divide_i(2.0).run(), expected);
+  test_eq(target.chain().divide_i(constant(2.0)).run(), expected);
+}
+
+// other basic operations (negative)...
+TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_07_n) {
+  EXPECT_THROW(target.chain().add_i(constant(2.0, 1, 1, 1, 1)).run(),
+               std::runtime_error);
+
+  EXPECT_THROW(target.chain().subtract_i(constant(2.0, 1, 1, 1, 1)).run(),
+               std::runtime_error);
+
+  EXPECT_THROW(target.chain().multiply_i(constant(2.0, 1, 1, 1, 1)).run(),
+               std::runtime_error);
+
+  EXPECT_THROW(target.chain().divide_i(constant(2.0, 1, 1, 1, 1)).run(),
+               std::runtime_error);
+}
+
+// sum()
+TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_08_p) {
+  target = constant(1.0, 4, 4, 4, 4);
+  expected = constant(64.0, 4, 1, 1, 1);
+  test_eq(target.chain().sum().run(), expected);
+
+  expected = constant(4.0, 1, 4, 4, 4);
+  test_eq(target.chain().sum(0).run(), expected);
+
+  expected = constant(4.0, 4, 1, 4, 4);
+  test_eq(target.chain().sum(1).run(), expected);
+
+  expected = constant(4.0, 4, 4, 1, 4);
+  test_eq(target.chain().sum(2).run(), expected);
+
+  expected = constant(4.0, 4, 4, 4, 1);
+  test_eq(target.chain().sum(3).run(), expected);
 }
 
 /**


### PR DESCRIPTION
**Changes proposed in this PR:**
- Register tensor ops to `LazyTensor`
- Add test fixture to `LazyTensor`
- Add tests to `LazyTensor`
- Change `Tensor::apply` signature to permit closures

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>