### PR TITLE
[tensor] Added axis dimension to average

### DIFF
--- a/nntrainer/include/lazy_tensor.h
+++ b/nntrainer/include/lazy_tensor.h
@@ -103,26 +103,30 @@ public:
   LazyTensor &transpose(std::string direction) ;
 
   /**
-   * @brief     Wrapper method of sum. see tensor.h for more detail (memcopy happens)
+   * @brief     Wrapper method of sum_by_batch. see tensor.h for more detail (memcopy happens)
    * @retval    LazyTensor *this
    */
-  LazyTensor &sum();
+  LazyTensor &sum_by_batch();
 
   /**
    * @brief     Wrapper method of sum. see tensor.h for more detail (memcopy happens)
    *            0 : batch direction
    *            1 : channel direction
-   *            2 : channel direction
-   *            3 : channel direction
+   *            2 : height direction
+   *            3 : width direction
    * @retval    LazyTensor *this
    */
-  LazyTensor &sum(int axis);
+  LazyTensor &sum(int axis=0);
 
   /**
    * @brief     Wrapper method of average. see tensor.h for more detail (memcopy happens)
+   *            0 : batch direction
+   *            1 : channel direction
+   *            2 : height direction
+   *            3 : width direction
    * @retval    LazyTensor *this
    */
-  LazyTensor &average();
+  LazyTensor &average(int axis=0);
 
   /**
    * @brief execute the call_chain to get the tensor

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -57,7 +57,7 @@ public:
    * @brief     Constructor of Tensor with batch size one
    * @param[in] dim TensorDim
    */
-  Tensor(TensorDim dim);
+  Tensor(const TensorDim dim);
 
   /**
    * @brief     Constructor of Tensor with batch size one
@@ -112,7 +112,7 @@ public:
                  unsigned int w);
 
   /**
-   * @brief     Multiply value element by element immediately 
+   * @brief     Multiply value element by element immediately
    * @param[in] value multiplier
    * @retval    #ML_ERROR_INVALID_PARAMETER Tensor dimension is not right
    * @retval    #ML_ERROR_NONE Successful
@@ -127,7 +127,7 @@ public:
   Tensor multiply(float const &value);
 
   /**
-   * @brief     Divide value element by element immediately 
+   * @brief     Divide value element by element immediately
    * @param[in] value divisor
    * @retval    #ML_ERROR_INVALID_PARAMETER Tensor dimension is not right
    * @retval    #ML_ERROR_NONE Successful
@@ -215,7 +215,6 @@ public:
    */
   Tensor multiply(Tensor const &m) const;
 
-
   /**
    * @brief     divide Tensor Elementwise
    * @param[in] m Tensor to be multiplied
@@ -246,25 +245,29 @@ public:
 
   /**
    * @brief     sum all the Tensor elements according to the batch
-   * @retval    Calculated Tensor(batch, 1, 1)
+   * @retval    Calculated Tensor(batch, 1, 1, 1)
    */
-  Tensor sum() const;
+  Tensor sum_by_batch() const;
 
   /**
    * @brief     sum all the Tensor elements according to the axis
    *            0 : batch direction
    *            1 : channel direction
-   *            2 : channel direction
-   *            3 : channel direction
+   *            2 : height direction
+   *            3 : width direction
    * @retval    Calculated Tensor
    */
-  Tensor sum(int axis) const;
+  Tensor sum(int axis=0) const;
 
   /**
-   * @brief     Averaging the Tensor elements according to the batch
-   * @retval    Calculated Tensor(1, height, width)
+   * @brief     Averaging the Tensor elements according to the axis
+   *            0 : batch direction
+   *            1 : channel direction
+   *            2 : height direction
+   *            3 : width direction
+   * @retval    Calculated Tensor
    */
-  Tensor average() const;
+  Tensor average(int axis=0) const;
 
   /**
    * @brief     Anchor a starting point to defer following evaluation

--- a/nntrainer/include/tensor_dim.h
+++ b/nntrainer/include/tensor_dim.h
@@ -43,19 +43,20 @@ public:
   unsigned int getFeatureLen() const { return feature_len; };
 
   void resetLen();
-  void batch(unsigned int b);
-  void channel(unsigned int c);
-  void height(unsigned int h);
-  void width(unsigned int w);
+  void batch(unsigned int b) { setTensorDim(0, b); }
+  void channel(unsigned int c) { setTensorDim(1, c); }
+  void height(unsigned int h) { setTensorDim(2, h); }
+  void width(unsigned int w) { setTensorDim(3, w); }
 
-  unsigned int *getDim() { return dim; }
+  const unsigned int *getDim() const { return dim; }
 
+  void setTensorDim(unsigned int idx, unsigned int value);
   int setTensorDim(std::string input_shape);
 
   void operator=(const TensorDim &from);
 
 private:
-  unsigned int dim[4];
+  unsigned int dim[MAXDIM];
   unsigned int len;
   unsigned int feature_len;
 };

--- a/nntrainer/src/lazy_tensor.cpp
+++ b/nntrainer/src/lazy_tensor.cpp
@@ -149,10 +149,10 @@ LazyTensor &LazyTensor::transpose(std::string direction) {
  * @param[in] direction to transpose ex) 0:2:1
  * @retval    LazyTensor *this
  */
-LazyTensor &LazyTensor::sum() {
+LazyTensor &LazyTensor::sum_by_batch() {
   auto f = [](Tensor &t) mutable -> int {
     try {
-      t = t.sum();
+      t = t.sum_by_batch();
       return ML_ERROR_NONE;
     } catch (std::runtime_error &e) {
       return ML_ERROR_INVALID_PARAMETER;
@@ -188,10 +188,10 @@ LazyTensor &LazyTensor::sum(int axis) {
  * happens)
  * @retval    LazyTensor *this
  */
-LazyTensor &LazyTensor::average() {
-  auto f = [](Tensor &t) mutable -> int {
+LazyTensor &LazyTensor::average(int axis) {
+  auto f = [axis](Tensor &t) mutable -> int {
     try {
-      t = t.average();
+      t = t.average(axis);
       return ML_ERROR_NONE;
     } catch (std::runtime_error &e) {
       return ML_ERROR_INVALID_PARAMETER;

--- a/nntrainer/src/tensor_dim.cpp
+++ b/nntrainer/src/tensor_dim.cpp
@@ -26,22 +26,11 @@ void TensorDim::resetLen() {
   feature_len = dim[1] * dim[2] * dim[3];
   len = dim[0] * feature_len;
 }
-void TensorDim::batch(unsigned int b) {
-  dim[0] = b;
+
+void TensorDim::setTensorDim(unsigned int idx, unsigned int value) {
+  dim[idx] = value;
   resetLen();
-};
-void TensorDim::channel(unsigned int c) {
-  dim[1] = c;
-  resetLen();
-};
-void TensorDim::height(unsigned int h) {
-  dim[2] = h;
-  resetLen();
-};
-void TensorDim::width(unsigned int w) {
-  dim[3] = w;
-  resetLen();
-};
+}
 
 int TensorDim::setTensorDim(std::string input_shape) {
   int status = ML_ERROR_NONE;
@@ -50,7 +39,7 @@ int TensorDim::setTensorDim(std::string input_shape) {
     std::sregex_iterator(input_shape.begin(), input_shape.end(), words_regex);
   auto words_end = std::sregex_iterator();
   int cur_dim = std::distance(words_begin, words_end);
-  if (cur_dim > 4) {
+  if (cur_dim > MAXDIM) {
     ml_loge("Tensor Dimension should be less than 4");
     return ML_ERROR_INVALID_PARAMETER;
   }
@@ -69,7 +58,7 @@ int TensorDim::setTensorDim(std::string input_shape) {
 }
 
 void TensorDim::operator=(const TensorDim &from) {
-  for (int i = 0; i < 4; ++i) {
+  for (int i = 0; i < MAXDIM; ++i) {
     this->dim[i] = from.dim[i];
   }
   len = from.len;

--- a/test/unittest/unittest_nntrainer_lazy_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_lazy_tensor.cpp
@@ -166,7 +166,7 @@ TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_07_n) {
 TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_08_p) {
   target = constant(1.0, 4, 4, 4, 4);
   expected = constant(64.0, 4, 1, 1, 1);
-  test_eq(target.chain().sum().run(), expected);
+  test_eq(target.chain().sum_by_batch().run(), expected);
 
   expected = constant(4.0, 1, 4, 4, 4);
   test_eq(target.chain().sum(0).run(), expected);

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -731,7 +731,7 @@ TEST(nntrainer_Tensor, sum_03_p) {
   GEN_TEST_INPUT(input, i * (batch * height * channel) + j * (height * width) +
                           k * width + l + 1);
 
-  nntrainer::Tensor result = input.sum();
+  nntrainer::Tensor result = input.sum_by_batch();
   if (result.getValue(0, 0, 0, 0) != 820 ||
       result.getValue(1, 0, 0, 0) != 1300 ||
       result.getValue(2, 0, 0, 0) != 1780)


### PR DESCRIPTION
Current implementation of average() is confusing when compared with sum().
Both sum() and average() do not take axis, and perform similar operations.
However, the semantics of their output is different -
- sum() acts over the dimensions other than batch size
- average() acts over the batch size

To avoid this confusion, average is provided with axis argument with 0 as default.
This is now analogous to sum(axis) than sum()
Further, sum() is renamed to sum_by_batch() as thats what it does and is different from sum(axis)

Minor updates to TensorDim are also made

Resolves #99 

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>