### PR TITLE
[Proposal] Optimizing concept for Tensor operation

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -23,6 +23,7 @@ endif
 
 NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/src/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/tensor.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/src/lazy_tensor.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/input_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/fc_layer.cpp \

--- a/nntrainer/include/fc_layer.h
+++ b/nntrainer/include/fc_layer.h
@@ -146,7 +146,7 @@ private:
    * @brief     update loss
    * @param[in] l Tensor data to calculate
    */
-  void updateLoss(Tensor l);
+  void updateLoss(Tensor const &l);
   unsigned int unit;
   Tensor weight;
   Tensor bias;


### PR DESCRIPTION
This patch proposes concept of using memcopyless operation on Tensor.

**Changes proposed in this PR:**
- `i_operation` are used to calculate without memcopy in fc_layer.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>