### PR TITLE
Add openmp parellelism to l2norm()

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -46,7 +46,7 @@ INIPARSER_INCLUDES := $(INIPARSER_ROOT)/src
 LOCAL_ARM_NEON      := true
 LOCAL_CFLAGS        += -pthread -fopenmp -fexceptions
 LOCAL_CXXFLAGS      += -std=c++11 -frtti -fexceptions
-LOCAL_LDFLAGS       += -fuse-ld=bfd
+LOCAL_LDFLAGS       += -fuse-ld=bfd -fopenmp
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog

--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,10 @@ nntrainer_conf.set('EXEC_PREFIX', nntrainer_bindir)
 nntrainer_conf.set('LIB_INSTALL_DIR', nntrainer_libdir)
 nntrainer_conf.set('INCLUDE_INSTALL_DIR', nntrainer_includedir)
 
+dummy_dep = dependency('', required: false)
+openmp_dep = dependency('openmp')
+
+blas_dep = dummy_dep
 # Dependencies
 if get_option('enable-blas')
   add_project_arguments('-DUSE_BLAS=1', language:['c','cpp'])

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -2,6 +2,7 @@ nntrainer_inc = include_directories('./include')
 
 # Dependencies
 nntrainer_base_deps=[
+  openmp_dep,
   blas_dep,
   iniparser_dep,
   libm_dep,

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -435,11 +435,10 @@ Tensor Tensor::sum() const {
 #else
   unsigned int i;
   for (k = 0; k < dim.batch(); ++k) {
-
     unsigned int id = k * dim.getFeatureLen();
-    ret.data[id] = 0.0;
+    ret.data[k] = 0.0;
     for (i = 0; i < dim.getFeatureLen(); ++i) {
-      ret.data[id] += data[id + i];
+      ret.data[k] += data[id + i];
     }
   }
 #endif
@@ -770,7 +769,7 @@ Tensor &Tensor::copy(const Tensor &from) {
 #ifdef USE_BLAS
     cblas_scopy(dim.getDataLen(), from.data.data(), 1, this->data.data(), 1);
 #else
-    for (int i = 0; i < dim.getDataLen(); ++i)
+    for (unsigned int i = 0; i < dim.getDataLen(); ++i)
       data[i] = from.data[i];
 #endif
   }
@@ -837,8 +836,9 @@ float Tensor::l2norm() const {
   float tmp;
   unsigned int len = dim.getDataLen();
 
+  #pragma omp parallel for private(tmp) reduction(+:sum)
   for (unsigned int i = 0; i < len; i++) {
-    tmp = this->data[i];
+    tmp = data[i];
     sum += tmp * tmp;
   }
 


### PR DESCRIPTION
**Changes proposed in this PR:**
- Fix:`meson -Denable-blas=false` has no dep found error
- Fix:sum() function bug when `USE_BLAS` is not defined
- Add openmp dependency
- Apply openmp to l2norm function

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>