### PR TITLE
Fix numeric limits in `Tensor`

### DIFF
--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -417,6 +417,9 @@ private:
   /**< handle the data as a std::vector type */
   std::vector<float> data;
   TensorDim dim;
+
+  static constexpr float min_limits = std::numeric_limits<float>::min();
+  static constexpr float max_limits = std::numeric_limits<float>::max();
 };
 
 /**

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -834,7 +834,7 @@ void Tensor::setZero() {
 
 int Tensor::argmax() {
   int index = 0;
-  float maximum = 0.0;
+  float maximum = min_limits;
   for (unsigned int i = 0; i < dim.getDataLen(); i++) {
     if (this->data[i] > maximum) {
       maximum = this->data[i];
@@ -859,9 +859,9 @@ float Tensor::l2norm() const {
 }
 
 Tensor Tensor::normalization() const {
-  Tensor results(dim);
-  float Min = 1000000.0;
-  float Max = 0.0;
+  Tensor results;
+  float Min = max_limits;
+  float Max = min_limits;
 
   for (unsigned int k = 0; k < dim.batch(); ++k) {
     for (unsigned int l = 0; l < dim.channel(); ++l) {
@@ -881,18 +881,8 @@ Tensor Tensor::normalization() const {
 
   float dif = Max - Min;
 
-  for (unsigned int k = 0; k < dim.batch(); ++k) {
-    for (unsigned int l = 0; l < dim.channel(); ++l) {
-      for (unsigned int i = 0; i < dim.height(); ++i) {
-        for (unsigned int j = 0; j < dim.width(); ++j) {
-          unsigned int id = k * dim.getFeatureLen() +
-                            l * dim.height() * dim.width() + i * dim.width() +
-                            j;
-          results.data[id] = (this->data[id] - Min) / dif;
-        }
-      }
-    }
-  }
+  results = this->chain().subtract_i(Min).divide_i(dif).run();
+  
   return results;
 }
 


### PR DESCRIPTION
**Changes proposed in this PR:**
- Add `static constexpr min / max` to Tensor
- Change normalization to use predefined method for acceleration

Resolves #141

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>