### PR TITLE
[LazyTensor] Fix memcopy happening on lambda func

### DIFF
--- a/nntrainer/src/lazy_tensor.cpp
+++ b/nntrainer/src/lazy_tensor.cpp
@@ -32,7 +32,7 @@ LazyTensor &LazyTensor::add_i(float const &value) {
  * @retval    LazyTensor *this
  */
 LazyTensor &LazyTensor::add_i(Tensor const &m) {
-  auto f = [m](Tensor &t) mutable -> int { return t.add_i(m); };
+  auto f = [&m](Tensor &t) mutable -> int { return t.add_i(m); };
   call_chain.push_back(f);
   return *this;
 }
@@ -43,7 +43,7 @@ LazyTensor &LazyTensor::add_i(Tensor const &m) {
  * @retval    LazyTensor *this
  */
 LazyTensor &LazyTensor::subtract_i(Tensor const &m) {
-  auto f = [m](Tensor &t) mutable -> int { return t.subtract_i(m); };
+  auto f = [&m](Tensor &t) mutable -> int { return t.subtract_i(m); };
   call_chain.push_back(f);
   return *this;
 }
@@ -76,7 +76,7 @@ LazyTensor &LazyTensor::multiply_i(float const &value) {
  * @retval    LazyTensor *this
  */
 LazyTensor &LazyTensor::multiply_i(Tensor const &m) {
-  auto f = [m](Tensor &t) mutable -> int { return t.multiply_i(m); };
+  auto f = [&m](Tensor &t) mutable -> int { return t.multiply_i(m); };
   call_chain.push_back(f);
   return *this;
 }
@@ -98,7 +98,7 @@ LazyTensor &LazyTensor::divide_i(float const &value) {
  * @retval    LazyTensor *this
  */
 LazyTensor &LazyTensor::divide_i(Tensor const &m) {
-  auto f = [m](Tensor &t) mutable -> int { return t.divide_i(m); };
+  auto f = [&m](Tensor &t) mutable -> int { return t.divide_i(m); };
   call_chain.push_back(f);
   return *this;
 }
@@ -110,7 +110,7 @@ LazyTensor &LazyTensor::divide_i(Tensor const &m) {
  * @retval    LazyTensor *this
  */
 LazyTensor &LazyTensor::dot(Tensor const &m) {
-  auto f = [m](Tensor &t) mutable -> int {
+  auto f = [&m](Tensor &t) mutable -> int {
     try {
       t = t.dot(m);
       return ML_ERROR_NONE;


### PR DESCRIPTION
Fix unintential memcopy occurring in capture clause in lambda

With this PR combined with #115, there is significant performance boost.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>