### PR TITLE
[layers] Ignoring error in training/validation

### DIFF
--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -107,6 +107,7 @@ Tensor BatchNormalizationLayer::forwarding(Tensor in, int &status) {
 
   Tensor ret = hath.multiply(gamma).add(beta).apply(activation);
 
+  status = ML_ERROR_NONE;
   return ret;
 }
 

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -104,6 +104,7 @@ Tensor Conv2DLayer::forwarding(Tensor in, int &status) {
     }
   }
 
+  status = ML_ERROR_NONE;
   return hidden.apply(activation);
 };
 

--- a/nntrainer/src/fc_layer.cpp
+++ b/nntrainer/src/fc_layer.cpp
@@ -123,6 +123,7 @@ int FullyConnectedLayer::setProperty(std::vector<std::string> values) {
 Tensor FullyConnectedLayer::forwarding(Tensor in, int &status) {
   input = in;
   hidden = input.chain().dot(weight).add_i(bias).run();
+  status = ML_ERROR_NONE;
 
   if (this->bn_follow)
     return hidden;
@@ -142,6 +143,7 @@ Tensor FullyConnectedLayer::forwarding(Tensor in, Tensor output, int &status) {
   if (!this->last_layer) {
     ml_loge("Error: Cannot update cost. This is not last layer of network");
     status = ML_ERROR_INVALID_PARAMETER;
+    return in;
   }
   input = in;
 
@@ -197,7 +199,9 @@ Tensor FullyConnectedLayer::forwarding(Tensor in, Tensor output, int &status) {
   default:
     break;
   }
+
   updateLoss(l);
+  status = ML_ERROR_NONE;
   return y;
 }
 

--- a/nntrainer/src/input_layer.cpp
+++ b/nntrainer/src/input_layer.cpp
@@ -87,6 +87,8 @@ Tensor InputLayer::forwarding(Tensor in, int &status) {
   input = in;
   if (normalization)
     input = input.normalization();
+
+  status = ML_ERROR_NONE;
   return input;
 }
 


### PR DESCRIPTION
Errors in forward and backward propagation were ignored.
Added error handling for them.

Further, model was being saved after validation.
Errors in validation would result in no model.
Changed to saving of model after training than after validation.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>