### PR TITLE
Refactor: delete Tensor::mat2vec()

### DIFF
--- a/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
+++ b/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
@@ -325,7 +325,9 @@ int main(int argc, char **argv) {
          */
         nntrainer::Tensor test =
           mainNet.forwarding(nntrainer::Tensor({input}), status);
-        std::vector<float> temp = test.mat2vec();
+        float* data = test.getData();
+        unsigned int len = test.getDim().getDataLen();
+        std::vector<float> temp(data, data + len);
         action.push_back(argmax(temp));
 
         std::cout << "qvalues : [";
@@ -422,7 +424,7 @@ int main(int argc, char **argv) {
          */
         nntrainer::Tensor NQ =
           targetNet.forwarding(nntrainer::Tensor(next_inbatch), status);
-        std::vector<float> nqa = NQ.mat2vec();
+        float* nqa = NQ.getData();
 
         /**
          * @brief     Update Q values & udpate mainNetwork

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -305,12 +305,6 @@ public:
   void setZero();
 
   /**
-   * @brief     Reduce Rank ( Tensor to Vector )
-   * @retval    Saved vector
-   */
-  std::vector<float> mat2vec();
-
-  /**
    * @brief     Apply function element by element
    * @param[in] *function function pointer applied
    * @retval    Tensor

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -786,18 +786,6 @@ Tensor &Tensor::copy(const Tensor &from) {
   return *this;
 }
 
-/**
- * This generate one dimension vector has the every element in Tensor
- */
-std::vector<float> Tensor::mat2vec() {
-  std::vector<float> ret;
-
-  for (unsigned int i = 0; i < dim.getDataLen(); i++)
-    ret.push_back(data[i]);
-
-  return ret;
-}
-
 void Tensor::save(std::ofstream &file) {
   for (unsigned int i = 0; i < dim.getDataLen(); i++)
     file.write((char *)&data[i], sizeof(float));


### PR DESCRIPTION
This method is initially proposed to flatten and clone mat to vector.

However, `Tensor::getData()` can cover most of it's purpose, it seems
no longer in need.

**Changes proposed in this PR:**
- Delete `Tensor::mat2vec()`.

See also:
https://github.com/nnstreamer/nntrainer/pull/149#discussion_r439172191

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>