### PR TITLE
[Refactor] optimizer::calculate (After #175)

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -47,7 +47,7 @@ INIPARSER_INCLUDES := $(INIPARSER_ROOT)/src
 
 LOCAL_ARM_NEON      := true
 LOCAL_CFLAGS        += -pthread -fopenmp -fexceptions
-LOCAL_CXXFLAGS      += -std=c++11 -frtti -fexceptions
+LOCAL_CXXFLAGS      += -std=c++14 -frtti -fexceptions
 LOCAL_LDFLAGS       += -fuse-ld=bfd -fopenmp
 LOCAL_MODULE_TAGS   := optional
 

--- a/nntrainer/src/lazy_tensor.cpp
+++ b/nntrainer/src/lazy_tensor.cpp
@@ -12,7 +12,6 @@
  */
 
 #include <lazy_tensor.h>
-#include <nntrainer_error.h>
 #include <tensor.h>
 
 namespace nntrainer {

--- a/test/unittest/unittest_nntrainer_lazy_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_lazy_tensor.cpp
@@ -181,6 +181,25 @@ TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_08_p) {
   test_eq(target.chain().sum(3).run(), expected);
 }
 
+TEST_F(nntrainer_LazyTensorOpsTest, ApplyIf_01_p) {
+
+  test_eq(target.chain().applyIf(true, _LIFT(add_i), constant(4.0), 0.5).run(),
+          original.add(2.0));
+
+  test_eq(target.chain().applyIf(true, _LIFT(add_i), 2.0f).run(),
+          original.add(2.0));
+
+  test_eq(target.chain().applyIf(true, _LIFT(add_i), 2.0).run(),
+          original.add(2.0));
+          
+}
+
+TEST_F(nntrainer_LazyTensorOpsTest, ApplyIf_01_n) {
+  EXPECT_THROW(
+    target.chain().applyIf(true, _LIFT(add_i), constant(4.0, 1, 1, 1, 1)).run(),
+    std::runtime_error);
+}
+
 /**
  * @brief Main gtest
  */


### PR DESCRIPTION
This PR is just for proposed purpose and should not be merged(yet).
Later this PR would contain improvement on `optimizer::calculate`

##### 1. `Tensor::add(Tensor::const &m)` -> `Tensor::add(Tensor::const &m, float const alpha)`

`X = X + Y` can be viewed as special case of `X = X + 1 * Y`. If you 
look at that way, adding alpha to make `X = X + alpha * Y` is natural.

With this change
 `weight.add_i(weight.multiply(1 - beta))` can be substituted to
 `weight.add_i(weight, 1 - beta)`.

This kind of operation happens a lot in NN Training.

still alpha = 1 will be set. So user thinks it does not use alpha value
for normal adding case.

##### 2. Add `LazyTensor::applyIf(bool pred, function fn, <var args..>)`

This is initial proposal to add control flow to LazyTensor method.
applyIf can run the operation only when `pred` is `true`.
It is skipped if not.

for example this can be used like below to integrate operation using potential optimization(done by `LazyTensor`)

```cpp
  // LazyTensor::applyIf
  djdwAvg = djdw.chain()
                .applyIf(isL2norm, LazyTensor::add_i, weight, weight_decay.lambda)
                .average()
                .run();
```

whereas initial solution would be

```cpp
  if(isL2norm){
    djdwAvg = djdwAvg.add(weight.multiply(weight_decay.lambda))
  }
  djdwAvg = djdwAvg.average();
```

**Changes proposed in this PR:**
- Propose new tensor operation semantics for effective calculation
- Change optimizer signature to reflect const / non-const Tensor

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>