### PR TITLE
[Tensor] Change Add_i to have alpha signature

### DIFF
--- a/nntrainer/include/lazy_tensor.h
+++ b/nntrainer/include/lazy_tensor.h
@@ -44,7 +44,7 @@ public:
    * @param[in] m Tensor to be added
    * @retval    LazyTensor *this
    */
-  LazyTensor &add_i(Tensor const &m);
+  LazyTensor &add_i(Tensor const &m, float const alpha = 1);
 
   /**
    * @brief     Wrapper method of subtract_i. see tensor.h for more detail
@@ -81,7 +81,7 @@ public:
    */
   LazyTensor &divide_i(float const &value);
 
- /**
+  /**
    * @brief     Wrapper method of divide_i. see tensor.h for more detail
    * @param[in] m Tensor to for division
    * @retval    LazyTensor *this
@@ -89,44 +89,43 @@ public:
   LazyTensor &divide_i(Tensor const &m);
 
   /**
-   * @brief     Wrapper method of dot. see tensor.h for more detail (memcopy happens)
+   * @brief     Wrapper method of dot. see tensor.h for more detail (memcopy
+   * happens)
    * @param[in] m Tensor
    * @retval    LazyTensor *this
    */
   LazyTensor &dot(Tensor const &m);
 
   /**
-   * @brief     Wrapper method of transpose. see tensor.h for more detail (memcopy happens)
+   * @brief     Wrapper method of transpose. see tensor.h for more detail
+   * (memcopy happens)
    * @param[in] direction to transpose ex) 0:2:1
    * @retval    LazyTensor *this
    */
-  LazyTensor &transpose(std::string direction) ;
+  LazyTensor &transpose(std::string direction);
 
   /**
-   * @brief     Wrapper method of sum_by_batch. see tensor.h for more detail (memcopy happens)
+   * @brief     Wrapper method of sum_by_batch. see tensor.h for more detail
+   * (memcopy happens)
    * @retval    LazyTensor *this
    */
   LazyTensor &sum_by_batch();
 
   /**
-   * @brief     Wrapper method of sum. see tensor.h for more detail (memcopy happens)
-   *            0 : batch direction
-   *            1 : channel direction
-   *            2 : height direction
-   *            3 : width direction
+   * @brief     Wrapper method of sum. see tensor.h for more detail (memcopy
+   * happens) 0 : batch direction 1 : channel direction 2 : height direction 3 :
+   * width direction
    * @retval    LazyTensor *this
    */
-  LazyTensor &sum(int axis=0);
+  LazyTensor &sum(int axis = 0);
 
   /**
-   * @brief     Wrapper method of average. see tensor.h for more detail (memcopy happens)
-   *            0 : batch direction
-   *            1 : channel direction
-   *            2 : height direction
-   *            3 : width direction
+   * @brief     Wrapper method of average. see tensor.h for more detail (memcopy
+   * happens) 0 : batch direction 1 : channel direction 2 : height direction 3 :
+   * width direction
    * @retval    LazyTensor *this
    */
-  LazyTensor &average(int axis=0);
+  LazyTensor &average(int axis = 0);
 
   /**
    * @brief execute the call_chain to get the tensor

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -144,17 +144,18 @@ public:
   /**
    * @brief Add Tensor Element by Element without mem copy
    * @param[in] m Tensor to be added
-   * #retval #ML_ERROR_NONE  Successful
-   * #retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter
+   * @param[out] alpha Values to be scaled
+   * @retval #ML_ERROR_NONE  Successful
+   * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter
    */
-  int add_i(Tensor const &m);
+  int add_i(Tensor const &m, float const alpha = 1);
 
   /**
    * @brief     Add Tensor Element by Element
    * @param[in] m Tensor to be added
    * @retval    Calculated Tensor
    */
-  Tensor add(Tensor const &m) const;
+  Tensor add(Tensor const &m, float const alpha = 1) const;
 
   /**
    * @brief Add Tensor Element immediately to target tensor without mem copy

--- a/nntrainer/src/lazy_tensor.cpp
+++ b/nntrainer/src/lazy_tensor.cpp
@@ -31,8 +31,8 @@ LazyTensor &LazyTensor::add_i(float const &value) {
  * @param[in] m Tensor to be added
  * @retval    LazyTensor *this
  */
-LazyTensor &LazyTensor::add_i(Tensor const &m) {
-  auto f = [&m](Tensor &t) mutable -> int { return t.add_i(m); };
+LazyTensor &LazyTensor::add_i(Tensor const &m, float const alpha) {
+  auto f = [&m, alpha](Tensor &t) mutable -> int { return t.add_i(m, alpha); };
   call_chain.push_back(f);
   return *this;
 }

--- a/test/unittest/unittest_nntrainer_lazy_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_lazy_tensor.cpp
@@ -125,8 +125,8 @@ TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_04_p) {
 
 // chain and add_i(float) add_i(Tensor)
 TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_05_p) {
-  expected = original.add(4.1);
-  test_eq(target.chain().add_i(2.1).add_i(constant(2.0)).run(), expected);
+  expected = original.add(6.1);
+  test_eq(target.chain().add_i(2.1).add_i(constant(2.0), 2).run(), expected);
 }
 
 // chain and add_i(float) subtract(float)

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -379,7 +379,7 @@ TEST(nntrainer_Tensor, add_i_02_p) {
   nntrainer::Tensor original(batch, height, width);
   original.copy(target);
 
-  status = target.add_i(target);
+  status = target.add_i(target, 3.0);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   float *previous = original.getData();
@@ -388,7 +388,7 @@ TEST(nntrainer_Tensor, add_i_02_p) {
   ASSERT_NE(nullptr, data);
 
   for (int i = 0; i < batch * height * width; ++i) {
-    EXPECT_FLOAT_EQ(data[i], previous[i] + previous[i]);
+    EXPECT_FLOAT_EQ(data[i], previous[i] * 4.0);
   }
 }
 


### PR DESCRIPTION
**Changes proposed in this PR:**
- `Add_i(Tensor &T, float alpha)` for coefficient multiplication
- Change test accordingly
- Optimize `blas` implementation for `multiply_i`
- run clang format to auto lint

See also: #166

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>