### PR TITLE
Add `LazyTensor::applyIf`

### DIFF
--- a/nntrainer/src/lazy_tensor.cpp
+++ b/nntrainer/src/lazy_tensor.cpp
@@ -12,7 +12,6 @@
  */
 
 #include <lazy_tensor.h>
-#include <nntrainer_error.h>
 #include <tensor.h>
 
 namespace nntrainer {

--- a/test/unittest/unittest_nntrainer_lazy_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_lazy_tensor.cpp
@@ -181,6 +181,25 @@ TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_08_p) {
   test_eq(target.chain().sum(3).run(), expected);
 }
 
+TEST_F(nntrainer_LazyTensorOpsTest, ApplyIf_01_p) {
+
+  test_eq(target.chain().applyIf(true, _LIFT(add_i), constant(4.0), 0.5).run(),
+          original.add(2.0));
+
+  test_eq(target.chain().applyIf(true, _LIFT(add_i), 2.0f).run(),
+          original.add(2.0));
+
+  test_eq(target.chain().applyIf(true, _LIFT(add_i), 2.0).run(),
+          original.add(2.0));
+          
+}
+
+TEST_F(nntrainer_LazyTensorOpsTest, ApplyIf_01_n) {
+  EXPECT_THROW(
+    target.chain().applyIf(true, _LIFT(add_i), constant(4.0, 1, 1, 1, 1)).run(),
+    std::runtime_error);
+}
+
 /**
  * @brief Main gtest
  */


### PR DESCRIPTION
This PR propose `LazyTensor::applyIf` for more control flow.

Because of the problem proposed in http://wg21.link/P0834R0, 
function wrapping macro is used as a workaround.

**Changes proposed in this PR:**
- add `LazyTensor::applyIf` semantics
- add `LazyTensor::applyIf` tests

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>