### PR TITLE
[ Layer copy ] copy function for conv2d & pooling

### DIFF
--- a/nntrainer/include/pooling2d_layer.h
+++ b/nntrainer/include/pooling2d_layer.h
@@ -127,15 +127,6 @@ public:
   void copy(std::shared_ptr<Layer> l);
 
   /**
-   * @brief     set Parameter Size
-   * @param[in] * size : size arrary
-   * @param[in] type : Property type
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setSize(int *size, PropertyType type);
-
-  /**
    * @brief     set Property of layer
    * @param[in] values values of property
    * @retval #ML_ERROR_NONE Successful.

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -127,6 +127,12 @@ void Conv2DLayer::copy(std::shared_ptr<Layer> l) {
     this->filters.push_back(from->filters[i]);
     this->bias.push_back(from->bias[i]);
   }
+  this->input.copy(from->input);
+  this->hidden.copy(from->hidden);
+  this->dim = from->dim;
+  this->input_dim = from->input_dim;
+  this->output_dim = from->output_dim;
+  this->last_layer = from->last_layer;
 }
 
 int Conv2DLayer::setSize(int *size, nntrainer::Conv2DLayer::PropertyType type) {

--- a/nntrainer/src/pooling2d_layer.cpp
+++ b/nntrainer/src/pooling2d_layer.cpp
@@ -65,14 +65,23 @@ Tensor Pooling2DLayer::backwarding(Tensor in, int iteration) {
 }
 
 void Pooling2DLayer::copy(std::shared_ptr<Layer> l) {
-  // NYI
-}
+  std::shared_ptr<Pooling2DLayer> from =
+    std::static_pointer_cast<Pooling2DLayer>(l);
 
-int Pooling2DLayer::setSize(int *size,
-                            nntrainer::Pooling2DLayer::PropertyType type) {
-  int status = ML_ERROR_NONE;
-  // NYI
-  return status;
+  this->pooling_type = from->pooling_type;
+
+  for (unsigned int i = 0; i < POOLING2D_DIM; ++i) {
+    this->pooling_size[i] = from->pooling_size[i];
+    this->stride[i] = from->stride[i];
+    this->padding[i] = from->padding[i];
+  }
+
+  this->input.copy(from->input);
+  this->hidden.copy(from->hidden);
+  this->dim = from->dim;
+  this->input_dim = from->input_dim;
+  this->output_dim = from->output_dim;
+  this->last_layer = from->last_layer;
 }
 
 int Pooling2DLayer::setProperty(std::vector<std::string> values) {


### PR DESCRIPTION
This PR fixs the copy member function of covn2d and pooling layer.
. include copy of layer varaibles for conv2d
. implemnet copy of pooling2d layer

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>