### PR TITLE
[API] simplify API

### DIFF
--- a/Applications/Tizen_CAPI/main.c
+++ b/Applications/Tizen_CAPI/main.c
@@ -31,10 +31,10 @@ main (int argc, char *argv[])
   int status = ML_ERROR_NONE;
   ml_nnmodel_h handle = NULL;
   const char *config_file = "./Tizen_CAPI_config.ini";
-  status = ml_nnmodel_construct_with_conf (config_file, &handle);
+  status = ml_nnmodel_construct (&handle);
   if (status != ML_ERROR_NONE)
     return status;
-  status = ml_nnmodel_compile_with_conf (handle);
+  status = ml_nnmodel_compile_with_conf (config_file, handle);
   if (status != ML_ERROR_NONE)
     return status;
   status = ml_nnmodel_train_with_file (handle);

--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -81,7 +81,6 @@ typedef enum {
   ML_LAYER_TYPE_UNKNOWN    /**< Unknown Lyaer */
 } ml_layer_type_e;
 
-
 /**
  * @brief Constructs the neural network model.
  * @details Use this function to create Neural Netowrk Model.
@@ -94,28 +93,16 @@ typedef enum {
 int ml_nnmodel_construct(ml_nnmodel_h *model);
 
 /**
- * @brief Constructs the neural network model with configuration file.
- * @details Use this function to create Neural Netowrk Model.
- * @since_tizen 6.x
- * @param[in] model_conf The location of nntrainer model configuration file.
- * @param[out] model The NNTrainer Model handler from the given description.
- * @return @c 0 on success. Otherwise a negative error value.
- * @retval #ML_ERROR_NONE Successful.
- * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
- * @retval #ML_ERROR_CANNOT_ASSIGN_ADDRESS Cannot assign object.
- */
-int ml_nnmodel_construct_with_conf(const char *model_conf, ml_nnmodel_h *model);
-
-/**
- * @brief initialize the neural network model with configuration file.
+ * @brief Initialize the neural network model with the given configuration file.
  * @details Use this function to initialize neural network model
  * @since_tizen 6.x
+ * @param[in] model_conf The location of nntrainer model configuration file.
  * @param[in] model The NNTrainer model handler from the given description.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
-int ml_nnmodel_compile_with_conf(ml_nnmodel_h model);
+int ml_nnmodel_compile_with_conf(const char *model_conf, ml_nnmodel_h model);
 
 /**
  * @brief initialize the neural network model.
@@ -242,7 +229,6 @@ int ml_nnoptimizer_create(ml_nnopt_h *opt, const char *type);
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
 int ml_nnoptimizer_delete(ml_nnopt_h opt);
-  
 
 /**
  * @brief Set the neural network optimizer property.

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -37,6 +37,10 @@ extern "C" {
  */
 static int nn_object(ml_nnmodel_h *model) {
   int status = ML_ERROR_NONE;
+
+  if (model == NULL)
+    return ML_ERROR_INVALID_PARAMETER;
+
   ml_nnmodel *nnmodel = new ml_nnmodel;
   nnmodel->magic = ML_NNTRAINER_MAGIC;
 
@@ -60,10 +64,10 @@ int ml_nnmodel_construct(ml_nnmodel_h *model) {
   return status;
 }
 
-int ml_nnmodel_construct_with_conf(const char *model_conf,
-                                   ml_nnmodel_h *model) {
+int ml_nnmodel_compile_with_conf(const char *model_conf, ml_nnmodel_h model) {
   int status = ML_ERROR_NONE;
   ml_nnmodel *nnmodel;
+  std::shared_ptr<nntrainer::NeuralNetwork> nn;
 
   std::ifstream conf_file(model_conf);
   if (!conf_file.good()) {
@@ -71,27 +75,15 @@ int ml_nnmodel_construct_with_conf(const char *model_conf,
     return ML_ERROR_INVALID_PARAMETER;
   }
 
-  status = ml_nnmodel_construct(model);
-
-  nnmodel = (ml_nnmodel *)(*model);
-
-  std::shared_ptr<nntrainer::NeuralNetwork> nn = (nnmodel)->network;
-
-  nn->setConfig(model_conf);
-  return status;
-}
-
-int ml_nnmodel_compile_with_conf(ml_nnmodel_h model) {
-  int status = ML_ERROR_NONE;
-  ml_nnmodel *nnmodel;
-
   ML_NNTRAINER_CHECK_MODEL_VALIDATION(nnmodel, model);
-  std::shared_ptr<nntrainer::NeuralNetwork> NN;
-  NN = nnmodel->network;
-  status = NN->checkValidation();
+  nn = nnmodel->network;
+  nn->setConfig(model_conf);
+
+  status = nn->checkValidation();
   if (status != ML_ERROR_NONE)
     return status;
-  status = NN->init();
+
+  status = nn->init();
   return status;
 }
 

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -45,30 +45,12 @@ TEST(nntrainer_capi_nnmodel, construct_destruct_02_n) {
 }
 
 /**
- * @brief Neural Network Model Construct wit Configuration File Test
+ * @brief Neural Network Model Construct (negative test)
  */
 TEST(nntrainer_capi_nnmodel, construct_destruct_03_n) {
-  ml_nnmodel_h handle;
-  const char *model_conf = "/test/cannot_find.ini";
   int status;
-  status = ml_nnmodel_construct_with_conf(model_conf, &handle);
+  status = ml_nnmodel_construct(NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-}
-
-/**
- * @brief Neural Network Model Construct wit Configuration File Test
- */
-TEST(nntrainer_capi_nnmodel, construct_destruct_04_p) {
-  ml_nnmodel_h handle = NULL;
-  int status = ML_ERROR_NONE;
-  std::string config_file = "./test_construct_destruct_04_p.ini";
-  RESET_CONFIG(config_file.c_str());
-  replaceString("Layers = inputlayer outputlayer",
-                "Layers = inputlayer outputlayer", config_file, config_str);
-  status = ml_nnmodel_construct_with_conf(config_file.c_str(), &handle);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnmodel_destruct(handle);
-  EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
 /**
@@ -81,9 +63,9 @@ TEST(nntrainer_capi_nnmodel, compile_01_p) {
   RESET_CONFIG(config_file.c_str());
   replaceString("Layers = inputlayer outputlayer",
                 "Layers = inputlayer outputlayer", config_file, config_str);
-  status = ml_nnmodel_construct_with_conf(config_file.c_str(), &handle);
+  status = ml_nnmodel_construct(&handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnmodel_compile_with_conf(handle);
+  status = ml_nnmodel_compile_with_conf(config_file.c_str(), handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnmodel_destruct(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -95,9 +77,10 @@ TEST(nntrainer_capi_nnmodel, compile_01_p) {
 TEST(nntrainer_capi_nnmodel, compile_02_n) {
   ml_nnmodel_h handle = NULL;
   int status = ML_ERROR_NONE;
+  std::string config_file = "/test/cannot_find.ini";
   status = ml_nnmodel_construct(&handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnmodel_compile_with_conf(handle);
+  status = ml_nnmodel_compile_with_conf(config_file.c_str(), handle);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnmodel_destruct(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -113,9 +96,9 @@ TEST(nntrainer_capi_nnmodel, compile_03_n) {
   RESET_CONFIG(config_file.c_str());
   replaceString("Input_Shape = 32:1:1:62720", "Input_Shape= 32:1:1:0",
                 config_file, config_str);
-  status = ml_nnmodel_construct_with_conf(config_file.c_str(), &handle);
+  status = ml_nnmodel_construct(&handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnmodel_compile_with_conf(handle);
+  status = ml_nnmodel_compile_with_conf(config_file.c_str(), handle);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_nnmodel_destruct(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -123,6 +106,16 @@ TEST(nntrainer_capi_nnmodel, compile_03_n) {
 
 /**
  * @brief Neural Network Model Compile Test
+ */
+TEST(nntrainer_capi_nnmodel, compile_04_n) {
+  int status = ML_ERROR_NONE;
+  std::string config_file = "./test_compile_03_n.ini";
+  status = ml_nnmodel_compile_with_conf(config_file.c_str(), NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+/**
+ * @brief Neural Network Model Train Test
  */
 TEST(nntrainer_capi_nnmodel, train_01_p) {
   ml_nnmodel_h handle = NULL;
@@ -133,14 +126,23 @@ TEST(nntrainer_capi_nnmodel, train_01_p) {
                 config_file, config_str);
   replaceString("minibatch = 32", "minibatch = 16", config_file, config_str);
   replaceString("BufferSize=100", "", config_file, config_str);
-  status = ml_nnmodel_construct_with_conf(config_file.c_str(), &handle);
+  status = ml_nnmodel_construct(&handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnmodel_compile_with_conf(handle);
+  status = ml_nnmodel_compile_with_conf(config_file.c_str(), handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnmodel_train_with_file(handle, NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnmodel_destruct(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Model Train Test
+ */
+TEST(nntrainer_capi_nnmodel, train_02_n) {
+  int status = ML_ERROR_NONE;
+  status = ml_nnmodel_train_with_file(NULL, NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
 /**


### PR DESCRIPTION
Exposed function "model_construct_with_conf" with config input makes "compile_with_conf" looks strange without any config
Rather, just keep one common "model_construct"  for construction of the model and "compile_with_conf" can take the config file

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>