### PR TITLE
[parse] Parse unknown properties

### DIFF
--- a/nntrainer/include/bn_layer.h
+++ b/nntrainer/include/bn_layer.h
@@ -118,18 +118,6 @@ public:
    */
   int setProperty(std::vector<std::string> values);
 
-  /**
-   * @brief     Property Enumeration
-   *            0. input shape : string
-   *            1. bias zero : bool
-   *            5. epsilon : float
-   */
-  enum class PropertyType {
-    input_shape = 0,
-    bias_zero = 1,
-    epsilon = 5,
-  };
-
 private:
   Tensor weight;
   Tensor bias;

--- a/nntrainer/include/conv2d_layer.h
+++ b/nntrainer/include/conv2d_layer.h
@@ -34,38 +34,6 @@ namespace nntrainer {
 class Conv2DLayer : public Layer {
 public:
   /**
-   * @brief     Property Enumeration
-   *            0. input shape : string
-   *            1. bias zero : bool
-   *            2. normalization : bool
-   *            3. standardization : bool
-   *            4. activation : string (type)
-   *            6. weight_decay : string (type)
-   *            7. weight_decay_lambda : float
-   *            8. weight_ini : string (type)
-   *            9. filter_size : int
-   *            10. kernel_size : ( n , m )
-   *            11. stride : ( n, m )
-   *            12, padding : valid | same
-   *
-   */
-
-  enum class PropertyType {
-    input_shape = 0,
-    bias_zero = 1,
-    normalization = 2,
-    standardization = 3,
-    activation = 4,
-    weight_decay = 6,
-    weight_decay_lambda = 7,
-    weight_ini = 9,
-    filter = 10,
-    kernel_size = 11,
-    stride = 12,
-    padding = 13,
-  };
-
-  /**
    * @brief     Constructor of Conv 2D Layer
    */
   Conv2DLayer() {

--- a/nntrainer/include/fc_layer.h
+++ b/nntrainer/include/fc_layer.h
@@ -101,24 +101,6 @@ public:
    */
   int setOptimizer(Optimizer &opt);
 
-  /**
-   * @brief     Property Enumeration
-   *            1. bias zero : bool
-   *            4. activation : bool
-   *            6. weight_decay : string (type)
-   *            7. weight_decay_lambda : float
-   *            8. unit : int
-   *            9. weight_init,
-   */
-  enum class PropertyType {
-    bias_zero = 1,
-    activation = 4,
-    weight_decay = 6,
-    weight_decay_lambda = 7,
-    unit = 8,
-    weight_init = 9,
-  };
-
 private:
   unsigned int unit;
   Tensor weight;

--- a/nntrainer/include/input_layer.h
+++ b/nntrainer/include/input_layer.h
@@ -131,20 +131,6 @@ public:
    */
   int setProperty(std::vector<std::string> values);
 
-  /**
-   * @brief     Property Enumeration
-   *            0. input shape : string
-   *            1. bias zero : bool
-   *            2. normalization : bool
-   *            3. normalization : bool
-   */
-  enum class PropertyType {
-    input_shape = 0,
-    bias_zero = 1,
-    normalization = 2,
-    standardization = 3
-  };
-
 private:
   bool normalization;
   bool standardization;

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -38,7 +38,11 @@ namespace nntrainer {
  *            1. ENTROPY ( Cross Entropy )
  *            2. Unknown
  */
-typedef enum { COST_MSR, COST_ENTROPY, COST_UNKNOWN } CostType;
+typedef enum {
+  COST_MSR,
+  COST_ENTROPY,
+  COST_UNKNOWN }
+CostType;
 
 /**
  * @brief     Enumeration of activation function type
@@ -276,6 +280,45 @@ public:
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
   int setCost(CostType c);
+
+  /**
+   * @brief     Property Enumeration
+   *            0. input shape : string
+   *            1. bias zero : bool
+   *            2. normalization : bool
+   *            3. standardization : bool
+   *            4. activation : string (type)
+   *            5. epsilon : float
+   *            6. weight_decay : string (type)
+   *            7. weight_decay_lambda : float
+   *            8. unit : int
+   *            9. weight_ini : string (type)
+   *            10. filter_size : int
+   *            11. kernel_size : ( n , m )
+   *            12. stride : ( n, m )
+   *            13. padding : ( n, m )
+   *            14, pooling_size : ( n,m )
+   *            15, pooling : max, average, global_max, global_average
+   */
+  enum class PropertyType {
+    input_shape = 0,
+    bias_zero = 1,
+    normalization = 2,
+    standardization = 3,
+    activation = 4,
+    epsilon = 5,
+    weight_decay = 6,
+    weight_decay_lambda = 7,
+    unit = 8,
+    weight_ini = 9,
+    filter = 10,
+    kernel_size = 11,
+    stride = 12,
+    padding = 13,
+    pooling_size = 14,
+    pooling = 15,
+    unknown = 16
+  };
 
 protected:
   /**

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -260,6 +260,7 @@ public:
     epochs = 8,
     model_file = 9,
     continue_train = 10,
+    unknown = 11,
   };
 
 private:

--- a/nntrainer/include/optimizer.h
+++ b/nntrainer/include/optimizer.h
@@ -177,6 +177,7 @@ public:
     beta2 = 4,
     epsilon = 5,
     continue_train = 6,
+    unknown = 7,
   };
 
   /**

--- a/nntrainer/include/pooling2d_layer.h
+++ b/nntrainer/include/pooling2d_layer.h
@@ -32,21 +32,6 @@ namespace nntrainer {
  */
 class Pooling2DLayer : public Layer {
 public:
-  /**
-   * @brief     Property Enumeration
-   *            12. stride : ( n, m )
-   *            13, padding : ( n, m )
-   *            14, pooling_size : ( n,m )
-   *            15, pooling : max, average, global_max, global_average
-   */
-
-  enum class PropertyType {
-    stride = 12,
-    padding = 13,
-    pooling_size = 14,
-    pooling = 15
-  };
-
   enum class PoolingType {
     max = 0,
     average = 1,
@@ -143,12 +128,12 @@ public:
   Tensor pooling2d(Tensor in, int &status);
 
   /* TO DO : support keras type of padding */
-  /* enum class PaddingType { */
-  /*   full = 0, */
-  /*   same = 1, */
-  /*   valid = 2, */
-  /*   unknown = 3, */
-  /* }; */
+  enum class PaddingType {
+    full = 0,
+    same = 1,
+    valid = 2,
+    unknown = 3,
+  };
 
 private:
   unsigned int pooling_size[POOLING2D_DIM];

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -134,7 +134,7 @@ void Conv2DLayer::copy(std::shared_ptr<Layer> l) {
   this->last_layer = from->last_layer;
 }
 
-int Conv2DLayer::setSize(int *size, nntrainer::Conv2DLayer::PropertyType type) {
+int Conv2DLayer::setSize(int *size, PropertyType type) {
   int status = ML_ERROR_NONE;
   switch (type) {
   case PropertyType::kernel_size:

--- a/nntrainer/src/fc_layer.cpp
+++ b/nntrainer/src/fc_layer.cpp
@@ -98,7 +98,7 @@ int FullyConnectedLayer::setProperty(std::vector<std::string> values) {
       status = setFloat(weight_decay.lambda, value);
       NN_RETURN_STATUS();
       break;
-    case PropertyType::weight_init:
+    case PropertyType::weight_ini:
       weight_ini_type = (WeightIniType)parseType(value, TOKEN_WEIGHTINI);
       break;
     default:

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -293,7 +293,7 @@ int NeuralNetwork::init() {
                   (int *)size);
       NN_INI_RETURN_STATUS();
       status = conv2d_layer->setSize(
-        size, nntrainer::Conv2DLayer::PropertyType::kernel_size);
+        size, Layer::PropertyType::kernel_size);
       NN_INI_RETURN_STATUS();
 
       status = getValues(
@@ -302,7 +302,7 @@ int NeuralNetwork::init() {
         (int *)size);
       NN_INI_RETURN_STATUS();
       status = conv2d_layer->setSize(
-        size, nntrainer::Conv2DLayer::PropertyType::stride);
+        size, Layer::PropertyType::stride);
       NN_INI_RETURN_STATUS();
 
       status = getValues(CONV2D_DIM,
@@ -311,7 +311,7 @@ int NeuralNetwork::init() {
                          (int *)size);
       NN_INI_RETURN_STATUS();
       status = conv2d_layer->setSize(
-        size, nntrainer::Conv2DLayer::PropertyType::padding);
+        size, Layer::PropertyType::padding);
       NN_INI_RETURN_STATUS();
 
       status = conv2d_layer->setFilter(


### PR DESCRIPTION
Properties exposed to the users and internal are different (losslayer, etc)
Hence using `*_string.size() - 1` for unknown cases will cause bugs in parse_util
Replaced with its own individual unknown value

V2:
Combined all individual layer properties into common properties in layer.h

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>