### PR TITLE
Add COST_ENTROPY_WITH_ACTIVATION(WAIT FOR #190)

### DIFF
--- a/Applications/Classification/res/Classification.ini
+++ b/Applications/Classification/res/Classification.ini
@@ -9,8 +9,10 @@ Decay_steps = 1000       # decay step for the exponential decayed learning rate
 Epoch = 30000		# Epoch 
 Optimizer = adam 	# Optimizer : sgd (stochastic gradien decent),
  	    		#             adam (Adamtive Moment Estimation)
-Cost = cross  		# Cost(loss) function : msr (mean square root error)
-                        #                       cross ( for cross entropy )
+Cost = cross_softmax	# Cost(loss) function : msr (mean square root error)
+                        #                       cross ( autoselect by last layer, defaults to cross_softmax)
+                        #                       cross_logit ( for Cross Entropy with logit )
+                        #                       cross_softmax ( for Cross Entropy with softmax)
 Model = "model.bin"  	# model path to save / read
 minibatch = 32		# mini batch size
 beta1 = 0.9 		# beta 1 for adam

--- a/Applications/Classification/res/Classification_func.ini
+++ b/Applications/Classification/res/Classification_func.ini
@@ -10,7 +10,7 @@ Epoch = 30000		# Epoch
 Optimizer = adam 	# Optimizer : sgd (stochastic gradien decent),
  	    		#             adam (Adamtive Moment Estimation)
 Cost = cross  		# Cost(loss) function : msr (mean square root error)
-                        #                       cross ( for cross entropy )
+                        #                       cross ( autoselect by last layer, defaults to cross_softmax)
 Model = "model.bin"  	# model path to save / read
 minibatch = 32		# mini batch size
 beta1 = 0.9 		# beta 1 for adam

--- a/Applications/LogisticRegression/res/LogisticRegression.ini
+++ b/Applications/LogisticRegression/res/LogisticRegression.ini
@@ -7,8 +7,10 @@ Learning_rate = 0.001 	# Learning Rate
 Epoch = 100		# Epoch 
 Optimizer = sgd		# Optimizer : sgd (stochastic gradien decent),
  	    		#             adam (Adamtive Moment Estimation)
-Cost = cross    	# Cost(loss) function : msr (mean square root error)
+Cost = cross_logit    	# Cost(loss) function : msr (mean square root error)
                         #                       cross ( cross entropy )
+                        #                       cross_logit ( for Cross Entropy with logit )
+                        #                       cross_softmax ( for Cross Entropy with softmax)
 Model = "model.bin"  	# model path to save / read
 minibatch = 1		# mini batch size
 epsilon = 1e-5

--- a/Applications/Tizen_CAPI/Tizen_CAPI_config.ini
+++ b/Applications/Tizen_CAPI/Tizen_CAPI_config.ini
@@ -10,7 +10,9 @@ Epoch = 10		# Epoch
 Optimizer = adam 	# Optimizer : sgd (stochastic gradien decent),
  	    		#             adam (Adamtive Moment Estimation)
 Cost = cross  		# Cost(loss) function : msr (mean square root error)
-                        #                       cross ( for cross entropy )
+                        #                       cross ( autoselect by last layer, defaults to cross_softmax)
+                        #                       cross_logit ( for Cross Entropy with logit )
+                        #                       cross_softmax ( for Cross Entropy with softmax)
 Model = "model.bin"  	# model path to save / read
 minibatch = 32		# mini batch size
 beta1 = 0.9 		# beta 1 for adam

--- a/Applications/Training/res/Training.ini
+++ b/Applications/Training/res/Training.ini
@@ -8,8 +8,10 @@ Learning_rate = 0.01 	# Learning Rate
 Epoch = 100		# Epoch 
 Optimizer = sgd		# Optimizer : sgd (stochastic gradien decent),
  	    		#             adam (Adamtive Moment Estimation)
-Cost = cross   		# Cost(loss) function : msr (mean square root error)
-                        #                       cross ( for Cross Entropy )
+Cost = cross_logit   		# Cost(loss) function : msr (mean square root error)
+                        #                       cross ( autoselect by last layer, defaults to cross_softmax)
+                        #                       cross_logit ( for Cross Entropy with logit )
+                        #                       cross_softmax ( for Cross Entropy with softmax)
 Model = "model.bin"  	# model path to save / read
 minibatch = 1		# mini batch size
 # beta1 = 0.9 		# beta 1 for adam

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -36,7 +36,8 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/src/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/parse_util.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/tensor_dim.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/conv2d_layer.cpp \
-                  $(NNTRAINER_ROOT)/nntrainer/src/pooling2d_layer.cpp
+                  $(NNTRAINER_ROOT)/nntrainer/src/pooling2d_layer.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/src/activation_layer.cpp
 
 NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer/include
 

--- a/nntrainer/include/activation_layer.h
+++ b/nntrainer/include/activation_layer.h
@@ -1,0 +1,138 @@
+/**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0-only
+ *
+ * @file	activation_layer.h
+ * @date	17 June 2020
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is Activation Layer Class for Neural Network
+ *
+ */
+
+#ifndef __ACTIVATION_LAYER_H_
+#define __ACTIVATION_LAYER_H_
+#ifdef __cplusplus
+
+#include <fstream>
+#include <iostream>
+#include <layer.h>
+#include <optimizer.h>
+#include <tensor.h>
+#include <vector>
+
+namespace nntrainer {
+  
+
+/**
+ * @class   Activation Layer
+ * @brief   Activation Layer
+ */
+class ActivationLayer : public Layer {
+
+public:
+  /**
+   * @brief     Constructor of Activation Layer
+   */
+  ActivationLayer() : Layer(){};
+
+  /**
+   * @brief     Destructor of Activation Layer
+   */
+  ~ActivationLayer(){};
+
+  /**
+   * @brief     Initialize the layer
+   *
+   * @param[in] last last layer
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int initialize(bool last);
+
+  /**
+   * @brief     Read Activation layer params. This is essentially noops for now.
+   * @param[in] file input stream file
+   */
+  void read(std::ifstream &file);
+
+  /**
+   * @brief     Save Activation layer params. This is essentially noops for now.
+   * @param[in] file output stream file
+   */
+  void save(std::ofstream &file);
+
+  /**
+   * @brief     forward propagation with input
+   * @param[in] in Input Tensor from upper layer
+   * @param[out] status Error Status of this function
+   * @retval    Activation(f(x))
+   */
+  Tensor forwarding(Tensor in, int &status);
+
+  /**
+   * @brief     back propagation calculate activation prime.
+   * @param[in] input Input Tensor from lower layer
+   * @param[in] iteration Numberof Epoch for ADAM
+   * @retval    Tensor
+   */
+  Tensor backwarding(Tensor in, int iteration);
+
+  /**
+   * @brief     copy layer
+   * @param[in] l layer to copy
+   */
+  void copy(std::shared_ptr<Layer> l);
+
+  /**
+   * @brief setActivation by custom activation function
+   *
+   * @param[in] std::function<Tensor(Tensor const &)> activation_fn activation
+   *            function to be used
+   * @param[in] std::function<Tensor(Tensor const &)> activation_prime_fn
+   *            activation_prime_function to be used
+   */
+  void setActivation(
+    std::function<Tensor(Tensor const &)> const &activation_fn,
+    std::function<Tensor(Tensor const &)> const &activation_prime_fn);
+
+  /**
+   * @brief setActivation by custom activation function
+   *
+   * @param[in] std::function<float(float const &)> activation_fn activation
+   *            function to be used
+   * @param[in] std::function<float(float const &)> activation_prime_fn
+   *            activation_prime_function to be used
+   */
+  void
+  setActivation(std::function<float(float const)> const &activation_fn,
+                std::function<float(float const)> const &activation_prime_fn);
+
+  /**
+   * @brief setActivation by preset actiType
+   *
+   * @param[in] ActiType actiType actiType to be set
+   */
+  void setActivation(ActiType acti_type);
+
+  /**
+   * @brief     set Property of layer
+   * @param[in] values values of property
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int setProperty(std::vector<std::string> values);
+
+private:
+  static constexpr unsigned int ACTIVATION_PROPERTY = 4;
+
+  std::function<Tensor(Tensor const &)> _act_fn;
+  std::function<Tensor(Tensor const &)> _act_prime_fn;
+};
+
+} // namespace nntrainer
+
+#endif /* __cplusplus */
+#endif /* __ACTIVATION_LAYER_H__ */

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -45,7 +45,8 @@ typedef enum { COST_MSR, COST_ENTROPY, COST_UNKNOWN } CostType;
  *            0. tanh
  *            1. sigmoid
  *            2. relu
- *            3. Unknown
+ *            3. softmax
+ *            4. Unknown
  */
 typedef enum {
   ACT_TANH,
@@ -64,7 +65,8 @@ typedef enum {
  *            4. Pooling 2D Layer type
  *            5. Flatten Layer type
  *            6. Loss Layer type
- *            7. Unknown
+ *            7. Activation Layer type
+ *            8. Unknown
  */
 typedef enum {
   LAYER_IN,
@@ -74,6 +76,7 @@ typedef enum {
   LAYER_POOLING2D,
   LAYER_FLATTEN,
   LAYER_LOSS,
+  LAYER_ACTIVATION,
   LAYER_UNKNOWN
 } LayerType;
 

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -35,10 +35,19 @@ namespace nntrainer {
 /**
  * @brief     Enumeration of cost(loss) function type
  *            0. MSR ( Mean Squared Roots )
- *            1. ENTROPY ( Cross Entropy )
- *            2. Unknown
+ *            1. ENTROPY ( auto select by last layer activation type
+ *                        ,fallback to entropy_with_softmax )
+ *            2. ENTROPY_WITH_SIGMOID ( Cross Entropy with sigmoid )
+ *            3. ENTROPY_WITH_SOFTMAX ( Cross Entropy with softmax )
+ *            4. Unknown
  */
-typedef enum { COST_MSR, COST_ENTROPY, COST_UNKNOWN } CostType;
+typedef enum {
+  COST_MSR,
+  COST_ENTROPY,
+  COST_ENTROPY_WITH_SIGMOID,
+  COST_ENTROPY_WITH_SOFTMAX,
+  COST_UNKNOWN
+} CostType;
 
 /**
  * @brief     Enumeration of activation function type
@@ -105,18 +114,11 @@ typedef enum {
  */
 class Layer {
 public:
-  Layer() :
-    last_layer(false),
-    init_zero(false),
-    type(LAYER_UNKNOWN),
-    activation(NULL),
-    activation_prime(NULL),
-    loss(0.0),
-    cost(COST_UNKNOWN),
-    activation_type(ACT_UNKNOWN),
-    bn_follow(false),
-    weight_decay(),
-    weight_ini_type(WEIGHT_UNKNOWN) {}
+  Layer()
+    : last_layer(false), init_zero(false), type(LAYER_UNKNOWN),
+      activation(NULL), activation_prime(NULL), loss(0.0), cost(COST_UNKNOWN),
+      activation_type(ACT_UNKNOWN), bn_follow(false), weight_decay(),
+      weight_ini_type(WEIGHT_UNKNOWN) {}
 
   /**
    * @brief     Destructor of Layer Class

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -33,7 +33,8 @@ nntrainer_sources = [
   'src/conv2d_layer.cpp',
   'src/lazy_tensor.cpp',
   'src/pooling2d_layer.cpp',
-  'src/flatten_layer.cpp'
+  'src/flatten_layer.cpp',
+  'src/activation_layer.cpp'
 ]
 
 nntrainer_headers = [
@@ -56,7 +57,8 @@ nntrainer_headers = [
   'include/conv2d_layer.h',
   'include/lazy_tensor.h',
   'include/pooling2d_layer.h',
-  'include/flatten_layer.h'
+  'include/flatten_layer.h',
+  'include/activation_layer.h'
 ]
 
 # Build libraries

--- a/nntrainer/src/activation_layer.cpp
+++ b/nntrainer/src/activation_layer.cpp
@@ -1,0 +1,154 @@
+/**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0-only
+ *
+ * @file	activation_layer.cpp
+ * @date	17 June 2020
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is Activation Layer Class for Neural Network
+ *
+ */
+
+#include <activation_layer.h>
+#include <fstream>
+#include <iostream>
+#include <layer.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <optimizer.h>
+#include <parse_util.h>
+#include <tensor.h>
+#include <util_func.h>
+#include <vector>
+
+namespace nntrainer {
+
+/**
+ * @class   Activation Layer
+ * @brief   Activation Layer
+ */
+
+/**
+ * @brief     Initialize the layer
+ *
+ * @param[in] last last layer
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+ */
+int ActivationLayer::initialize(bool last) {
+  this->type = LAYER_ACTIVATION;
+  return ML_ERROR_NONE;
+}
+
+void ActivationLayer::read(std::ifstream &file){
+  /* noop */
+};
+
+void ActivationLayer::save(std::ofstream &file){
+  /* noop */
+};
+
+Tensor ActivationLayer::forwarding(Tensor in, int &status) {
+  status = ML_ERROR_NONE;
+
+  input = in;
+  hidden = _act_fn(in);
+
+  return hidden;
+}
+
+Tensor ActivationLayer::backwarding(Tensor derivative, int iteration) {
+  return derivative.multiply(_act_prime_fn(hidden));
+}
+
+/**
+ * @brief     copy layer
+ * @param[in] l layer to copy
+ */
+void ActivationLayer::copy(std::shared_ptr<Layer> l) {
+  std::shared_ptr<ActivationLayer> from =
+    std::static_pointer_cast<ActivationLayer>(l);
+  this->input.copy(from->input);
+  this->hidden.copy(from->hidden);
+  this->activation_type = from->activation_type;
+
+};
+
+void ActivationLayer::setActivation(
+  std::function<Tensor(Tensor const &)> const &activation_fn,
+  std::function<Tensor(Tensor const &)> const &activation_prime_fn) {
+  _act_fn = activation_fn;
+  _act_prime_fn = activation_prime_fn;
+}
+
+void ActivationLayer::setActivation(
+  std::function<float(float const)> const &activation_fn,
+  std::function<float(float const)> const &activation_prime_fn) {
+  _act_fn = [activation_fn](Tensor const &t) { return t.apply(activation_fn); };
+  _act_prime_fn = [activation_prime_fn](Tensor const &t) { return t.apply(activation_prime_fn); };
+}
+
+/**
+ * @brief setActivation by preset actiType
+ *
+ * @param[in] ActiType actiType actiType to be set
+ */
+void ActivationLayer::setActivation(ActiType acti_type) {
+  this->activation_type = acti_type;
+
+  switch (acti_type) {
+  case ActiType::ACT_TANH:
+    this->setActivation(tanhFloat, tanhPrime);
+    break;
+  case ActiType::ACT_SIGMOID:
+    this->setActivation(sigmoid, sigmoidePrime);
+    break;
+  case ActiType::ACT_SOFTMAX:
+    this->setActivation(softmax, softmaxPrime);
+    break;
+  case ActiType::ACT_RELU:
+    this->setActivation(relu, reluPrime);
+    break;
+  case ActiType::ACT_UNKNOWN:
+  default:
+    throw std::runtime_error("Error: Not Supported Activation Type");
+  }
+  
+}
+
+/**
+ * @brief     set Property of layer
+ * @param[in] values values of property
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+ */
+int ActivationLayer::setProperty(std::vector<std::string> values) {
+  int status = ML_ERROR_NONE;
+
+  if (values.size() != 1) {
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
+  std::string key;
+  std::string value;
+
+  status = getKeyValue(values[0], key, value);
+  NN_RETURN_STATUS();
+
+  if (parseLayerProperty(key) != ACTIVATION_PROPERTY) {
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
+  try {
+    this->setActivation((ActiType)parseType(value, TOKEN_ACTI));
+  } catch (const std::exception &ex) {
+    ml_loge("Error: Not supported Data");
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+  return ML_ERROR_NONE;
+}
+
+}; // namespace nntrainer

--- a/nntrainer/src/fc_layer.cpp
+++ b/nntrainer/src/fc_layer.cpp
@@ -185,6 +185,8 @@ Tensor FullyConnectedLayer::backwarding(Tensor derivative, int iteration) {
       break;
 
     case COST_ENTROPY:
+    case COST_ENTROPY_WITH_SIGMOID:
+    case COST_ENTROPY_WITH_SOFTMAX:
       djdb = derivative;
       break;
 

--- a/nntrainer/src/loss_layer.cpp
+++ b/nntrainer/src/loss_layer.cpp
@@ -62,8 +62,7 @@ Tensor LossLayer::forwarding(Tensor output, Tensor label, int &status) {
 
     l = y2.chain().multiply_i(y2).sum_by_batch().multiply_i(0.5).run();
   } break;
-  case COST_ENTROPY: {
-    if (activation_type == ACT_SIGMOID) {
+  case COST_ENTROPY_WITH_SIGMOID: {
       // todo: change this to apply_i
       Tensor k = y.chain().multiply_i(-1.0).add_i(1.0).run().apply(logFloat);
 
@@ -76,17 +75,14 @@ Tensor LossLayer::forwarding(Tensor output, Tensor label, int &status) {
             .multiply_i(-1.0 / y2.getWidth())
             .run()
             .sum_by_batch();
-    } else if (activation_type == ACT_SOFTMAX) {
+  } break;
+  case COST_ENTROPY:
+  case COST_ENTROPY_WITH_SOFTMAX: {
       l = y2.chain()
             .multiply_i(y.apply(logFloat))
             .multiply_i(-1.0 / y2.getWidth())
             .run()
             .sum_by_batch();
-    } else {
-      ml_loge("Only support sigmoid & softmax for cross entropy loss");
-      exit(0);
-    }
-
   } break;
   case COST_UNKNOWN:
     /** intended */

--- a/nntrainer/src/parse_util.cpp
+++ b/nntrainer/src/parse_util.cpp
@@ -67,9 +67,11 @@ unsigned int parseType(std::string ll, InputType t) {
   /**
    * @brief     Cost Function String from configure file
    *            "msr"  : Mean Squared Roots
-   *            "caterogical" : Categorical Cross Entropy
+   *            "cross" : Categorical Cross Entropy, alias for cross_softmax
+   *            "cross_logit " : Cross Entropy with sigmoid
+   *            "cross_softmax " : Cross Entropy with softmax
    */
-  std::array<std::string, 3> cost_string = {"msr", "cross", "unknown"};
+  std::array<std::string, 5> cost_string = {"msr", "cross", "cross_logit", "cross_softmax", "unknown"};
 
   /**
    * @brief     Network Type String from configure file

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -190,6 +190,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/pooling2d_layer.h
 %{_includedir}/nntrainer/flatten_layer.h
 %{_includedir}/nntrainer/loss_layer.h
+%{_includedir}/nntrainer/activation_layer.h
 %{_includedir}/nntrainer/neuralnet.h
 %{_includedir}/nntrainer/tensor.h
 %{_includedir}/nntrainer/lazy_tensor.h

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -26,6 +26,7 @@
 #ifdef __cplusplus
 
 #include "nntrainer_log.h"
+#include <tensor.h>
 #include <fstream>
 #include <gtest/gtest.h>
 
@@ -211,6 +212,20 @@ const std::string config_str2 = "[Network]"
         ml_logi("Info: deleteing file: %s", conf_name);      \
     }                                                        \
   } while (0)
+
+
+/**
+ * @brief test tensor is equal
+ * @param[in] Tensor A, tensor to be compared
+ * @param[in] Tensor B, tensor to be compared
+ */
+void test_tensor_eq(nntrainer::Tensor const &A, nntrainer::Tensor const &B);
+
+/**
+ * @brief return a tensor filled with contant value with dimension
+ */
+nntrainer::Tensor constant(float value, unsigned int batch, unsigned channel,
+                           unsigned height, unsigned width) ;
 
 /**
  * @brief replace string and save in file

--- a/test/nntrainer_test_util.cpp
+++ b/test/nntrainer_test_util.cpp
@@ -25,6 +25,7 @@
 #include <climits>
 #include <iostream>
 #include <random>
+#include <tensor.h>
 
 #define num_class 10
 #define mini_batch 16
@@ -242,4 +243,31 @@ bool getMiniBatch_val(float *outVec, float *outLabel, int *status) {
 
   F.close();
   return true;
+}
+
+/**
+ * @brief return a tensor filled with contant value with dimension
+ */
+nntrainer::Tensor constant(float value, unsigned int batch, unsigned channel,
+                           unsigned height, unsigned width) {
+  nntrainer::Tensor t(batch, channel, height, width);
+  return t.apply([value](float) { return value; });
+}
+
+
+void test_tensor_eq(nntrainer::Tensor const &A, nntrainer::Tensor const &B) {
+  EXPECT_EQ(A.getBatch(), B.getBatch());
+  EXPECT_EQ(A.getChannel(), B.getChannel());
+  EXPECT_EQ(A.getHeight(), B.getHeight());
+  EXPECT_EQ(A.getWidth(), B.getWidth());
+
+  int len = A.getDim().getDataLen();
+  const float *aData = A.getData();
+  ASSERT_NE(aData, (float *)NULL);
+  const float *bData = B.getData();
+  ASSERT_NE(bData, (float *)NULL);
+
+  for (int i = 0; i < len; ++i) {
+    EXPECT_FLOAT_EQ(aData[i], bData[i]);
+  }
 }

--- a/test/tizen_capi/test_conf.ini
+++ b/test/tizen_capi/test_conf.ini
@@ -8,8 +8,10 @@ Learning_rate = 0.01 	# Learning Rate
 Epoch = 100		# Epoch
 Optimizer = sgd		# Optimizer : sgd (stochastic gradien decent),
  	    		#             adam (Adamtive Moment Estimation)
-Cost = cross   		# Cost(loss) function : msr (mean square root error)
-                        #                       cross ( for Cross Entropy )
+Cost = cross_logit   		# Cost(loss) function : msr (mean square root error)
+                        #                       cross ( autoselect by last layer, defaults to cross_softmax)
+                        #                       cross_logit ( for Cross Entropy with logit )
+                        #                       cross_softmax ( for Cross Entropy with softmax)
 Model = "model.bin"  	# model path to save / read
 Minibatch = 1		# mini batch size
 # beta1 = 0.9 		# beta 1 for adam

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -468,7 +468,7 @@ TEST(nntrainer_capi_nnmodel, train_with_file_01_p) {
     "beta1=0.002", "beta2=0.001", "epsilon=1e-7", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_compile(model, optimizer, "loss=cross", NULL);
+  status = ml_nnmodel_compile(model, optimizer, "loss=cross_logit", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_nnmodel_train_with_file(
@@ -531,7 +531,7 @@ TEST(nntrainer_capi_nnmodel, train_with_generator_01_p) {
     "beta1=0.002", "beta2=0.001", "epsilon=1e-7", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_compile(model, optimizer, "loss=cross", NULL);
+  status = ml_nnmodel_compile(model, optimizer, "loss=cross_softmax", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnmodel_train_with_generator(
     model, getMiniBatch_train, getMiniBatch_val, NULL, "epochs=2",

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -10,6 +10,7 @@
  * @author      Jijoong Moon <jijoong.moon@samsung.com>
  * @bug         No known bugs
  */
+#include <activation_layer.h>
 #include <bn_layer.h>
 #include <conv2d_layer.h>
 #include <fc_layer.h>
@@ -857,6 +858,53 @@ TEST(nntrainer_LossLayer, setCost_02_n) {
   nntrainer::LossLayer layer;
   status = layer.setCost(nntrainer::COST_UNKNOWN);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_ActivationLayer, init_01_1) {
+  int status = ML_ERROR_NONE;
+  nntrainer::ActivationLayer layer;
+  status = layer.initialize(false);
+
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+TEST(nntrainer_ActivationLayer, setType_01_p) {
+  nntrainer::ActivationLayer layer;
+  EXPECT_NO_THROW(layer.setActivation(nntrainer::ACT_RELU));
+  EXPECT_NO_THROW(layer.setActivation(nntrainer::ACT_SOFTMAX));
+  EXPECT_NO_THROW(layer.setActivation(nntrainer::ACT_SIGMOID));
+  EXPECT_NO_THROW(layer.setActivation(nntrainer::ACT_TANH));
+}
+
+TEST(nntrainer_ActivationLayer, setType_02_n) {
+  nntrainer::ActivationLayer layer;
+  EXPECT_THROW(layer.setActivation(nntrainer::ACT_UNKNOWN), std::runtime_error);
+}
+
+TEST(nntrainer_ActivationLayer, forward_backward_01_p) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 1;
+  int width = 10;
+  std::vector<float> answer = {0, 0, 0, 0, 0, 0.1, 0.2, 0.3, 0.4, 0.5,
+                      0, 0, 0, 0, 0, 0.2, 0.4, 0.6, 0.8, 1,
+                      0, 0, 0, 0, 0, 0.3, 0.6, 0.9, 1.2, 1.5};
+  nntrainer::ActivationLayer layer;
+  layer.setActivation(nntrainer::ACT_RELU);
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
+  nntrainer::Tensor expected(batch, channel, height, width);
+  GEN_TEST_INPUT(expected, nntrainer::relu((l - 4) * 0.1 * (i + 1)));
+  nntrainer::Tensor result = layer.forwarding(input, status);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  test_tensor_eq(result, expected);
+
+  expected.copy(input);
+  result = layer.backwarding(constant(1.0, 3, 1, 1, 10), 1);
+  GEN_TEST_INPUT(expected, nntrainer::reluPrime(nntrainer::relu((l - 4) * 0.1 * (i + 1))));;
+  test_tensor_eq(result, expected);
 }
 
 /**

--- a/test/unittest/unittest_nntrainer_lazy_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_lazy_tensor.cpp
@@ -33,35 +33,9 @@ protected:
   /**
    * @brief return a tensor filled with contant value
    */
-  nntrainer::Tensor constant(float value) {
+  nntrainer::Tensor constant_(float value) {
     nntrainer::Tensor t(batch, channel, height, width);
     return t.apply([value](float) { return value; });
-  }
-
-  /**
-   * @brief return a tensor filled with contant value with dimension
-   */
-  nntrainer::Tensor constant(float value, unsigned int batch, unsigned channel,
-                             unsigned height, unsigned width) {
-    nntrainer::Tensor t(batch, channel, height, width);
-    return t.apply([value](float) { return value; });
-  }
-
-  void test_eq(nntrainer::Tensor const &A, nntrainer::Tensor const &B) {
-    EXPECT_EQ(A.getBatch(), B.getBatch());
-    EXPECT_EQ(A.getChannel(), B.getChannel());
-    EXPECT_EQ(A.getHeight(), B.getHeight());
-    EXPECT_EQ(A.getWidth(), B.getWidth());
-
-    int len = A.getDim().getDataLen();
-    const float *aData = A.getData();
-    ASSERT_NE(aData, (float *)NULL);
-    const float *bData = B.getData();
-    ASSERT_NE(bData, (float *)NULL);
-
-    for (int i = 0; i < len; ++i) {
-      EXPECT_FLOAT_EQ(aData[i], bData[i]);
-    }
   }
 
   nntrainer::Tensor target;
@@ -102,49 +76,49 @@ TEST(nntrainer_LazyTensor, LazyTensor_01_p) {
 
 // Simple chain and run
 TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_01_p) {
-  test_eq(target.chain().run(), original);
+  test_tensor_eq(target.chain().run(), original);
 }
 
 // Simple chain and add_i(float)
 TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_02_p) {
   expected = original.add(2.1);
-  test_eq(target.chain().add_i(2.1).run(), expected);
+  test_tensor_eq(target.chain().add_i(2.1).run(), expected);
 }
 
 // chain and add_i(float) add_i(float)
 TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_03_p) {
   expected = original.add(4.2);
-  test_eq(target.chain().add_i(2.1).add_i(2.1).run(), expected);
+  test_tensor_eq(target.chain().add_i(2.1).add_i(2.1).run(), expected);
 }
 
 // chain and add_i(float) add_i(float)
 TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_04_p) {
   expected = original.add(4.2);
-  test_eq(target.chain().add_i(2.1).add_i(2.1).run(), expected);
+  test_tensor_eq(target.chain().add_i(2.1).add_i(2.1).run(), expected);
 }
 
 // chain and add_i(float) add_i(Tensor)
 TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_05_p) {
   expected = original.add(6.1);
-  test_eq(target.chain().add_i(2.1).add_i(constant(2.0), 2).run(), expected);
+  test_tensor_eq(target.chain().add_i(2.1).add_i(constant_(2.0), 2).run(), expected);
 }
 
 // chain and add_i(float) subtract(float)
 TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_06_p) {
-  test_eq(target.chain().add_i(2.1).subtract_i(2.1).run(), original);
+  test_tensor_eq(target.chain().add_i(2.1).subtract_i(2.1).run(), original);
 }
 
 // other basic operations (positive)...
 TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_07_p) {
-  target = constant(1.0);
-  expected = constant(2.0);
-  test_eq(target.chain().multiply_i(2.0).run(), expected);
-  test_eq(target.chain().multiply_i(constant(2.0)).run(), expected);
+  target = constant_(1.0);
+  expected = constant_(2.0);
+  test_tensor_eq(target.chain().multiply_i(2.0).run(), expected);
+  test_tensor_eq(target.chain().multiply_i(constant_(2.0)).run(), expected);
 
-  target = constant(1.0);
-  expected = constant(0.5);
-  test_eq(target.chain().divide_i(2.0).run(), expected);
-  test_eq(target.chain().divide_i(constant(2.0)).run(), expected);
+  target = constant_(1.0);
+  expected = constant_(0.5);
+  test_tensor_eq(target.chain().divide_i(2.0).run(), expected);
+  test_tensor_eq(target.chain().divide_i(constant_(2.0)).run(), expected);
 }
 
 // other basic operations (negative)...
@@ -166,30 +140,30 @@ TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_07_n) {
 TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_08_p) {
   target = constant(1.0, 4, 4, 4, 4);
   expected = constant(64.0, 4, 1, 1, 1);
-  test_eq(target.chain().sum_by_batch().run(), expected);
+  test_tensor_eq(target.chain().sum_by_batch().run(), expected);
 
   expected = constant(4.0, 1, 4, 4, 4);
-  test_eq(target.chain().sum(0).run(), expected);
+  test_tensor_eq(target.chain().sum(0).run(), expected);
 
   expected = constant(4.0, 4, 1, 4, 4);
-  test_eq(target.chain().sum(1).run(), expected);
+  test_tensor_eq(target.chain().sum(1).run(), expected);
 
   expected = constant(4.0, 4, 4, 1, 4);
-  test_eq(target.chain().sum(2).run(), expected);
+  test_tensor_eq(target.chain().sum(2).run(), expected);
 
   expected = constant(4.0, 4, 4, 4, 1);
-  test_eq(target.chain().sum(3).run(), expected);
+  test_tensor_eq(target.chain().sum(3).run(), expected);
 }
 
 TEST_F(nntrainer_LazyTensorOpsTest, ApplyIf_01_p) {
 
-  test_eq(target.chain().applyIf(true, _LIFT(add_i), constant(4.0), 0.5).run(),
+  test_tensor_eq(target.chain().applyIf(true, _LIFT(add_i), constant_(4.0), 0.5).run(),
           original.add(2.0));
 
-  test_eq(target.chain().applyIf(true, _LIFT(add_i), 2.0f).run(),
+  test_tensor_eq(target.chain().applyIf(true, _LIFT(add_i), 2.0f).run(),
           original.add(2.0));
 
-  test_eq(target.chain().applyIf(true, _LIFT(add_i), 2.0).run(),
+  test_tensor_eq(target.chain().applyIf(true, _LIFT(add_i), 2.0).run(),
           original.add(2.0));
           
 }


### PR DESCRIPTION
Add `COST_ENTROPY_WITH_*` to decouple `activation_type` from `layers`

Now `COST_ENTROPY_WITH_SIGMOID` and `COST_ENTROPY_WITH_ACTIVATION` is used

`COST_ENTROPY` now autoselects by activation type of the last layer.
if it is not applicable, it fallbacks to `COST_ENTROPY_WITH_SOFTMAX`
internally in loss calculation for `COST_ENTROPY`.

**Changes proposed in this PR:**
- Add `COST_ENTROPY_WITH_*` to cost type
- Modify test to test `COST_ENTROPY_WITH_*`
- Update ini comments
- Run clang format
- Update loss layer accordingly

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>