### PR TITLE
[Proposal] clang format for initializer list

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,7 +38,8 @@ BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+AllowAllConstructorInitializersOnNextLine: true
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
 Cpp11BracedListStyle: true

--- a/nntrainer/include/databuffer.h
+++ b/nntrainer/include/databuffer.h
@@ -117,8 +117,12 @@ public:
    * @retval    DataBuffer
    */
   DataBuffer()
-    : train_running(), val_running(), test_running(), train_thread(),
-      val_thread(), test_thread() {
+    : train_running(),
+      val_running(),
+      test_running(),
+      train_thread(),
+      val_thread(),
+      test_thread() {
     SET_VALIDATION(false);
     class_num = 0;
     cur_train_bufsize = 0;

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -106,18 +106,18 @@ typedef enum {
  */
 class Layer {
 public:
-  Layer() :
-    last_layer(false),
-    init_zero(false),
-    type(LAYER_UNKNOWN),
-    activation(NULL),
-    activation_prime(NULL),
-    loss(0.0),
-    cost(COST_UNKNOWN),
-    activation_type(ACT_UNKNOWN),
-    bn_follow(false),
-    weight_decay(),
-    weight_ini_type(WEIGHT_UNKNOWN) {}
+  Layer()
+    : last_layer(false),
+      init_zero(false),
+      type(LAYER_UNKNOWN),
+      activation(NULL),
+      activation_prime(NULL),
+      loss(0.0),
+      cost(COST_UNKNOWN),
+      activation_type(ACT_UNKNOWN),
+      bn_follow(false),
+      weight_decay(),
+      weight_ini_type(WEIGHT_UNKNOWN) {}
 
   /**
    * @brief     Destructor of Layer Class

--- a/nntrainer/include/lazy_tensor.h
+++ b/nntrainer/include/lazy_tensor.h
@@ -139,7 +139,7 @@ public:
   /**
    * @brief     apply A tensor function when predicate is true
    * @param[in] bool predicate predicate to check to determine application
-   * @param[in] _Callable&& fn function to be applied 
+   * @param[in] _Callable&& fn function to be applied
    *            (Must be wrapped with _LIFT(X) macro to resolve overload set)
    * @param[in] _Args&&... args args for fn
    * @retval    LazyTensor *this


### PR DESCRIPTION
preivious initialization list was hard to read when it gets too long.

eg) layers initialization list

before:
```cpp
  Layer()
    : last_layer(false), init_zero(false), type(LAYER_UNKNOWN),
      activation(NULL), activation_prime(NULL), activation_type(ACT_UNKNOWN),
      bn_follow(false), weight_decay(), weight_ini_type(WEIGHT_UNKNOWN) {}
```

after:
```cpp
  Layer()
    : last_layer(false),
      init_zero(false),
      type(LAYER_UNKNOWN),
      activation(NULL),
      activation_prime(NULL),
      activation_type(ACT_UNKNOWN),
      bn_follow(false),
      weight_decay(),
      weight_ini_type(WEIGHT_UNKNOWN) {}
```

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [x]Skipped
2. Run test: [ ]Passed [ ]Failed [x]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>