### PR TITLE
Fix bug in `Tensor::setValue`

### DIFF
--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -850,7 +850,7 @@ Tensor Tensor::average(int axis) const {
 }
 
 void Tensor::setValue(float val) {
-  memset(this->data.data(), val, sizeof(float) * dim.getDataLen());
+  std::fill(data.begin(), data.end(), val);
 }
 
 void Tensor::setZero() {


### PR DESCRIPTION
`memset` can't be used to initialize a float array as explained [here](https://stackoverflow.com/questions/1040070/initializing-a-float-array-with-memset)

**Changes proposed in this PR:**
- change `memset` to `std::fill`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>