### PR TITLE
[Fix/jni] Change tflite-dependency

### DIFF
--- a/Applications/Classification/jni/Android.mk
+++ b/Applications/Classification/jni/Android.mk
@@ -9,73 +9,32 @@ endif
 
 ifndef NNTRAINER_ROOT
 NNTRAINER_ROOT := $(LOCAL_PATH)/../../../libs/arm64-v8a
-NNTRAINER_INCLUDES := $(LOCAL_PATH)/../../../nntrainer/include/
+NNTRAINER_INCLUDES := $(LOCAL_PATH)/../../../nntrainer/include
 endif
 
-NNTRAINER_APPLICATION := $(LOCAL_PATH)/../../
+NNTRAINER_APPLICATION := $(LOCAL_PATH)/../..
 
 include $(CLEAR_VARS)
+
+TENSORFLOW_VERSION := 1.13.1
 
 ifndef TENSORFLOW_ROOT
 ifneq ($(MAKECMDGOALS),clean)
 $(warning TENSORFLOW_ROOT is not defined!)
 $(warning TENSORFLOW SRC is going to be downloaded!)
 
-# Currently we are using tensorflow 1.9.0
-$(info $(shell ($(LOCAL_PATH)/../../prepare_tflite.sh $(NNTRAINER_APPLICATION))))
+$(info $(shell ($(NNTRAINER_APPLICATION)/prepare_tflite.sh $(TENSORFLOW_VERSION) $(NNTRAINER_APPLICATION))))
 
-TENSORFLOW_ROOT := $(LOCAL_PATH)/../../tensorflow-1.9.0
+TENSORFLOW_ROOT := $(LOCAL_PATH)/../../tensorflow-$(TENSORFLOW_VERSION)/tensorflow-lite
 
 endif
 endif
-
-TF_LITE_DIR=$(TENSORFLOW_ROOT)/tensorflow/contrib/lite
 
 LOCAL_MODULE := tensorflow-lite
-TFLITE_SRCS := \
-    $(wildcard $(TF_LITE_DIR)/*.cc) \
-    $(wildcard $(TF_LITE_DIR)/kernels/*.cc) \
-    $(wildcard $(TF_LITE_DIR)/kernels/internal/*.cc) \
-    $(wildcard $(TF_LITE_DIR)/kernels/internal/optimized/*.cc) \
-    $(wildcard $(TF_LITE_DIR)/kernels/internal/reference/*.cc) \
-    $(wildcard $(TF_LITE_DIR)/*.c) \
-    $(wildcard $(TF_LITE_DIR)/kernels/*.c) \
-    $(wildcard $(TF_LITE_DIR)/kernels/internal/*.c) \
-    $(wildcard $(TF_LITE_DIR)/kernels/internal/optimized/*.c) \
-    $(wildcard $(TF_LITE_DIR)/kernels/internal/reference/*.c) \
-    $(wildcard $(TF_LITE_DIR)/downloads/farmhash/src/farmhash.cc) \
-    $(wildcard $(TF_LITE_DIR)/downloads/fft2d/fftsg.c)
+LOCAL_SRC_FILES := $(TENSORFLOW_ROOT)/lib/arm64/libtensorflow-lite.a
+LOCAL_EXPORT_C_INCLUDES := $(TENSORFLOW_ROOT)/include
 
-TFLITE_SRCS := $(sort $(TFLITE_SRCS))
-
-TFLITE_EXCLUDE_SRCS := \
-    $(wildcard $(TF_LITE_DIR)/*test.cc) \
-    $(wildcard $(TF_LITE_DIR)/*/*test.cc) \
-    $(wildcard $(TF_LITE_DIR)/*/*/*test.cc) \
-    $(wildcard $(TF_LITE_DIR)/*/*/*/*test.cc) \
-    $(wildcard $(TF_LITE_DIR)/kernels/test_util.cc) \
-    $(wildcard $(TF_LITE_DIR)/examples/minimal/minimal.cc)
-
-TFLITE_SRCS := $(filter-out $(TFLITE_EXCLUDE_SRCS), $(TFLITE_SRCS))
-# ANDROID_NDK env should be set before build
-TFLITE_INCLUDES := \
-    $(ANDROID_NDK)/../ \
-    $(TENSORFLOW_ROOT) \
-    $(TF_LITE_DIR)/downloads \
-    $(TF_LITE_DIR)/downloads/eigen \
-    $(TF_LITE_DIR)/downloads/gemmlowp \
-    $(TF_LITE_DIR)/downloads/neon_2_sse \
-    $(TF_LITE_DIR)/downloads/farmhash/src \
-    $(TF_LITE_DIR)/downloads/flatbuffers/include
-
-
-LOCAL_SRC_FILES := $(TFLITE_SRCS)
-LOCAL_C_INCLUDES := $(TFLITE_INCLUDES)
-
-LOCAL_CFLAGS += -O3 -DNDEBUG
-LOCAL_CXXFLAGS += -std=c++11 -frtti -fexceptions -O3 -DNDEBUG 
-
-include $(BUILD_STATIC_LIBRARY)
+include $(PREBUILT_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
 

--- a/Applications/KNN/jni/Android.mk
+++ b/Applications/KNN/jni/Android.mk
@@ -14,68 +14,25 @@ endif
 
 include $(CLEAR_VARS)
 
+TENSORFLOW_VERSION := 1.13.1
+
 ifndef TENSORFLOW_ROOT
 ifneq ($(MAKECMDGOALS),clean)
 $(warning TENSORFLOW_ROOT is not defined!)
 $(warning TENSORFLOW SRC is going to be downloaded!)
 
-NNTRAINER_APPLICATION := $(LOCAL_PATH)/../../
+$(info $(shell ($(NNTRAINER_APPLICATION)/prepare_tflite.sh $(TENSORFLOW_VERSION) $(NNTRAINER_APPLICATION))))
 
-# Currently we are using tensorflow 1.9.0
-$(info $(shell ($(LOCAL_PATH)/../../prepare_tflite.sh $(NNTRAINER_APPLICATION))))
-
-TENSORFLOW_ROOT := $(LOCAL_PATH)/../../tensorflow-1.9.0
+TENSORFLOW_ROOT := $(LOCAL_PATH)/../../tensorflow-$(TENSORFLOW_VERSION)/tensorflow-lite
 
 endif
 endif
-
-TF_LITE_DIR=$(TENSORFLOW_ROOT)/tensorflow/contrib/lite
 
 LOCAL_MODULE := tensorflow-lite
-TFLITE_SRCS := \
-     $(wildcard $(TF_LITE_DIR)/*.cc) \
-     $(wildcard $(TF_LITE_DIR)/kernels/*.cc) \
-     $(wildcard $(TF_LITE_DIR)/kernels/internal/*.cc) \
-     $(wildcard $(TF_LITE_DIR)/kernels/internal/optimized/*.cc) \
-     $(wildcard $(TF_LITE_DIR)/kernels/internal/reference/*.cc) \
-     $(wildcard $(TF_LITE_DIR)/*.c) \
-     $(wildcard $(TF_LITE_DIR)/kernels/*.c) \
-     $(wildcard $(TF_LITE_DIR)/kernels/internal/*.c) \
-     $(wildcard $(TF_LITE_DIR)/kernels/internal/optimized/*.c) \
-     $(wildcard $(TF_LITE_DIR)/kernels/internal/reference/*.c) \
-     $(wildcard $(TF_LITE_DIR)/downloads/farmhash/src/farmhash.cc) \
-     $(wildcard $(TF_LITE_DIR)/downloads/fft2d/fftsg.c)
+LOCAL_SRC_FILES := $(TENSORFLOW_ROOT)/lib/arm64/libtensorflow-lite.a
+LOCAL_EXPORT_C_INCLUDES := $(TENSORFLOW_ROOT)/include
 
-TFLITE_SRCS := $(sort $(TFLITE_SRCS))
-
-TFLITE_EXCLUDE_SRCS := \
-     $(wildcard $(TF_LITE_DIR)/*test.cc) \
-     $(wildcard $(TF_LITE_DIR)/*/*test.cc) \
-     $(wildcard $(TF_LITE_DIR)/*/*/*test.cc) \
-     $(wildcard $(TF_LITE_DIR)/*/*/*/*test.cc) \
-     $(wildcard $(TF_LITE_DIR)/kernels/test_util.cc) \
-     $(wildcard $(TF_LITE_DIR)/examples/minimal/minimal.cc)
-
-TFLITE_SRCS := $(filter-out $(TFLITE_EXCLUDE_SRCS), $(TFLITE_SRCS))
-# ANDROID_NDK env should be set before build
-TFLITE_INCLUDES := \
-     $(ANDROID_NDK)/../ \
-     $(TENSORFLOW_ROOT) \
-     $(TF_LITE_DIR)/downloads \
-     $(TF_LITE_DIR)/downloads/eigen \
-     $(TF_LITE_DIR)/downloads/gemmlowp \
-     $(TF_LITE_DIR)/downloads/neon_2_sse \
-     $(TF_LITE_DIR)/downloads/farmhash/src \
-     $(TF_LITE_DIR)/downloads/flatbuffers/include
-
-
-LOCAL_SRC_FILES := $(TFLITE_SRCS)
-LOCAL_C_INCLUDES := $(TFLITE_INCLUDES)
-
-LOCAL_CFLAGS += -O3 -DNDEBUG
-LOCAL_CXXFLAGS += -std=c++11 -frtti -fexceptions -O3 -DNDEBUG 
-
-include $(BUILD_STATIC_LIBRARY)
+include $(PREBUILT_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
 

--- a/Applications/Training/jni/Android.mk
+++ b/Applications/Training/jni/Android.mk
@@ -16,66 +16,25 @@ NNTRAINER_APPLICATION := $(LOCAL_PATH)/../../
 
 include $(CLEAR_VARS)
 
+TENSORFLOW_VERSION := 1.13.1
+
 ifndef TENSORFLOW_ROOT
 ifneq ($(MAKECMDGOALS),clean)
 $(warning TENSORFLOW_ROOT is not defined!)
 $(warning TENSORFLOW SRC is going to be downloaded!)
 
-# Currently we are using tensorflow 1.9.0
-$(info $(shell ($(LOCAL_PATH)/../../prepare_tflite.sh $(NNTRAINER_APPLICATION))))
+$(info $(shell ($(NNTRAINER_APPLICATION)/prepare_tflite.sh $(TENSORFLOW_VERSION) $(NNTRAINER_APPLICATION))))
 
-TENSORFLOW_ROOT := $(LOCAL_PATH)/../../tensorflow-1.9.0
+TENSORFLOW_ROOT := $(LOCAL_PATH)/../../tensorflow-$(TENSORFLOW_VERSION)/tensorflow-lite
 
 endif
 endif
-
-TF_LITE_DIR=$(TENSORFLOW_ROOT)/tensorflow/contrib/lite
 
 LOCAL_MODULE := tensorflow-lite
-TFLITE_SRCS := \
-    $(wildcard $(TF_LITE_DIR)/*.cc) \
-    $(wildcard $(TF_LITE_DIR)/kernels/*.cc) \
-    $(wildcard $(TF_LITE_DIR)/kernels/internal/*.cc) \
-    $(wildcard $(TF_LITE_DIR)/kernels/internal/optimized/*.cc) \
-    $(wildcard $(TF_LITE_DIR)/kernels/internal/reference/*.cc) \
-    $(wildcard $(TF_LITE_DIR)/*.c) \
-    $(wildcard $(TF_LITE_DIR)/kernels/*.c) \
-    $(wildcard $(TF_LITE_DIR)/kernels/internal/*.c) \
-    $(wildcard $(TF_LITE_DIR)/kernels/internal/optimized/*.c) \
-    $(wildcard $(TF_LITE_DIR)/kernels/internal/reference/*.c) \
-    $(wildcard $(TF_LITE_DIR)/downloads/farmhash/src/farmhash.cc) \
-    $(wildcard $(TF_LITE_DIR)/downloads/fft2d/fftsg.c)
+LOCAL_SRC_FILES := $(TENSORFLOW_ROOT)/lib/arm64/libtensorflow-lite.a
+LOCAL_EXPORT_C_INCLUDES := $(TENSORFLOW_ROOT)/include
 
-TFLITE_SRCS := $(sort $(TFLITE_SRCS))
-
-TFLITE_EXCLUDE_SRCS := \
-    $(wildcard $(TF_LITE_DIR)/*test.cc) \
-    $(wildcard $(TF_LITE_DIR)/*/*test.cc) \
-    $(wildcard $(TF_LITE_DIR)/*/*/*test.cc) \
-    $(wildcard $(TF_LITE_DIR)/*/*/*/*test.cc) \
-    $(wildcard $(TF_LITE_DIR)/kernels/test_util.cc) \
-    $(wildcard $(TF_LITE_DIR)/examples/minimal/minimal.cc)
-
-TFLITE_SRCS := $(filter-out $(TFLITE_EXCLUDE_SRCS), $(TFLITE_SRCS))
-# ANDROID_NDK env should be set before build
-TFLITE_INCLUDES := \
-    $(ANDROID_NDK)/../ \
-    $(TENSORFLOW_ROOT) \
-    $(TF_LITE_DIR)/downloads \
-    $(TF_LITE_DIR)/downloads/eigen \
-    $(TF_LITE_DIR)/downloads/gemmlowp \
-    $(TF_LITE_DIR)/downloads/neon_2_sse \
-    $(TF_LITE_DIR)/downloads/farmhash/src \
-    $(TF_LITE_DIR)/downloads/flatbuffers/include
-
-
-LOCAL_SRC_FILES := $(TFLITE_SRCS)
-LOCAL_C_INCLUDES := $(TFLITE_INCLUDES)
-
-LOCAL_CFLAGS += -O3 -DNDEBUG
-LOCAL_CXXFLAGS += -std=c++11 -frtti -fexceptions -O3 -DNDEBUG 
-
-include $(BUILD_STATIC_LIBRARY)
+include $(PREBUILT_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
 

--- a/Applications/prepare_tflite.sh
+++ b/Applications/prepare_tflite.sh
@@ -1,26 +1,28 @@
 #!/usr/bin/env bash
-#currently we are using tensorflow 1.9.0
-VERSION="1.9.0"
+VERSION=$1
+TARGET=$2
+
+echo "PREPARING TENSORFLOW ${VERSION} at ${TARGET}"
+
+pushd ${TARGET}
 
 #Get tensorflow
-cd $1
-
 if [ ! -d "tensorflow-${VERSION}" ]; then
-    if [ ! -f "v${VERSION}.tar.gz" ]; then
-	echo "[TENSORFLOW-LITE] Download tensorflow-${VERSION}\n"
-	wget "https://github.com/tensorflow/tensorflow/archive/v${VERSION}.tar.gz"
-	echo "[TENSORFLOW-LITE] Finish Downloading tensorflow-${VERSION}\n"
-	echo "[TENSORFLOW-LITE] untar tensorflow-${VERSION}\n"
+    if [ ! -f "tensorflow-lite-${VERSION}.tar.xz" ]; then
+      echo "[TENSORFLOW-LITE] Download tensorflow-${VERSION}"
+      URL="https://github.com/nnstreamer/nnstreamer-android-resource/raw/master/external/tensorflow-lite-${VERSION}.tar.xz"
+      if ! wget ${URL} ; then
+        echo "[TENSORFLOW-LITE] There was an error while downloading tflite, check if you have specified right version"
+        exit $?
+      fi
+      echo "[TENSORFLOW-LITE] Finish downloading tensorflow-${VERSION}"
+      echo "[TENSORFLOW-LITE] untar tensorflow-${VERSION}"
     fi
-    tar xf "v${VERSION}.tar.gz"
-    rm "v${VERSION}.tar.gz"
+    mkdir -p tensorflow-${VERSION}
+    tar -xf tensorflow-lite-${VERSION}.tar.xz -C tensorflow-${VERSION}
+    rm "tensorflow-lite-${VERSION}.tar.xz"
+else
+  echo "[TENSORFLOW-LITE] folder already exist, exiting without downloading"
 fi
 
-if [ ! -d "tensorflow-${VERSION}/tensorflow/contrib/lite/downloads" ]; then
-#Download Dependencys
-    pushd "tensorflow-${VERSION}"
-    echo "[TENSORFLOW-LITE] Download external libraries of tensorflow-${VERSION}\n"
-    sed -i "s|flatbuffers/archive/master.zip|flatbuffers/archive/v1.8.0.zip|g" tensorflow/contrib/lite/download_dependencies.sh
-    ./tensorflow/contrib/lite/download_dependencies.sh
-    popd
-fi
+popd


### PR DESCRIPTION
There seems a problem with building tensorflow. This PR propose to use
prebuilt tensorflow-lite instead of building one.

**Changes proposed in this PR:**
- Change `Applications/android.mk` to use prebuilt library (thanks to @jaeyun-jung )
- Change `prepare_tflite.sh`
- Bump tflite to 1.13.1 as suggested in #20

Resolves #207

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>