### PR TITLE
Make .clang-format competible with version 6

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,12 +34,12 @@ BraceWrapping:
 BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
-AllowAllConstructorInitializersOnNextLine: true
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
 Cpp11BracedListStyle: true

--- a/nntrainer/include/activation_layer.h
+++ b/nntrainer/include/activation_layer.h
@@ -25,7 +25,6 @@
 #include <vector>
 
 namespace nntrainer {
-  
 
 /**
  * @class   Activation Layer
@@ -37,7 +36,7 @@ public:
   /**
    * @brief     Constructor of Activation Layer
    */
-  ActivationLayer() : Layer(){ this->type = LAYER_ACTIVATION; };
+  ActivationLayer() : Layer() { this->type = LAYER_ACTIVATION; };
 
   /**
    * @brief     Destructor of Activation Layer
@@ -57,13 +56,13 @@ public:
    * @brief     Read Activation layer params. This is essentially noops for now.
    * @param[in] file input stream file
    */
-  void read(std::ifstream &file) { /* noop */ };
+  void read(std::ifstream &file){/* noop */};
 
   /**
    * @brief     Save Activation layer params. This is essentially noops for now.
    * @param[in] file output stream file
    */
-  void save(std::ofstream &file) {  /* noop */ };
+  void save(std::ofstream &file){/* noop */};
 
   /**
    * @brief     forward propagation with input
@@ -109,9 +108,9 @@ public:
    *            activation_prime_function to be used
    * @retval #ML_ERROR_NONE when successful
    */
-  int
-  setActivation(std::function<float(float const)> const &activation_fn,
-                std::function<float(float const)> const &activation_prime_fn);
+  int setActivation(
+    std::function<float(float const)> const &activation_fn,
+    std::function<float(float const)> const &activation_prime_fn);
 
   /**
    * @brief setActivation by preset actiType

--- a/nntrainer/include/databuffer.h
+++ b/nntrainer/include/databuffer.h
@@ -116,13 +116,13 @@ public:
    * @brief     Create Buffer
    * @retval    DataBuffer
    */
-  DataBuffer()
-    : train_running(),
-      val_running(),
-      test_running(),
-      train_thread(),
-      val_thread(),
-      test_thread() {
+  DataBuffer() :
+    train_running(),
+    val_running(),
+    test_running(),
+    train_thread(),
+    val_thread(),
+    test_thread() {
     SET_VALIDATION(false);
     class_num = 0;
     cur_train_bufsize = 0;

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -36,8 +36,10 @@ namespace nntrainer {
  * @brief     Enumeration of cost(loss) function type
  *            0. MSR ( Mean Squared Roots )
  *            1. ENTROPY ( Cross Entropy )
- *            2. ENTROPY_SIGMOID (Cross Entropy amalgamated with sigmoid for stability)
- *            2. ENTROPY_SOFTMAX (Cross Entropy amalgamated with softmax for stability)
+ *            2. ENTROPY_SIGMOID (Cross Entropy amalgamated with sigmoid for
+ * stability)
+ *            2. ENTROPY_SOFTMAX (Cross Entropy amalgamated with softmax for
+ * stability)
  *            2. Unknown
  */
 typedef enum {
@@ -115,18 +117,18 @@ typedef enum {
  */
 class Layer {
 public:
-  Layer()
-    : last_layer(false),
-      init_zero(false),
-      type(LAYER_UNKNOWN),
-      activation(NULL),
-      activation_prime(NULL),
-      loss(0.0),
-      cost(COST_UNKNOWN),
-      activation_type(ACT_UNKNOWN),
-      bn_follow(false),
-      weight_decay(),
-      weight_ini_type(WEIGHT_UNKNOWN) {}
+  Layer() :
+    last_layer(false),
+    init_zero(false),
+    type(LAYER_UNKNOWN),
+    activation(NULL),
+    activation_prime(NULL),
+    loss(0.0),
+    cost(COST_UNKNOWN),
+    activation_type(ACT_UNKNOWN),
+    bn_follow(false),
+    weight_decay(),
+    weight_ini_type(WEIGHT_UNKNOWN) {}
 
   /**
    * @brief     Destructor of Layer Class

--- a/nntrainer/include/lazy_tensor.h
+++ b/nntrainer/include/lazy_tensor.h
@@ -20,10 +20,11 @@
 
 #define FWD(...) std::forward<decltype(__VA_ARGS__)>(__VA_ARGS__)
 
-#define _LIFT(X)                                                  \
-  [](nntrainer::Tensor &t, auto &&... args) noexcept(             \
-    noexcept(t.X(FWD(args)...))) -> decltype(t.X(FWD(args)...)) { \
-    return t.X(FWD(args)...);                                     \
+#define _LIFT(X)                                            \
+  [](nntrainer::Tensor & t,                                 \
+     auto &&... args) noexcept(noexcept(t.X(FWD(args)...))) \
+    ->decltype(t.X(FWD(args)...)) {                         \
+    return t.X(FWD(args)...);                               \
   }
 
 namespace nntrainer {

--- a/nntrainer/include/loss_layer.h
+++ b/nntrainer/include/loss_layer.h
@@ -104,7 +104,7 @@ private:
    * @brief     update loss
    * @param[in] l Tensor data to calculate
    */
-  void updateLoss(const Tensor& l);
+  void updateLoss(const Tensor &l);
 };
 } // namespace nntrainer
 

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -336,7 +336,8 @@ private:
   std::shared_ptr<DataBuffer> data_buffer;
 
   /**
-   * @brief    Continue train from the previous state of optimizer and iterations
+   * @brief    Continue train from the previous state of optimizer and
+   * iterations
    */
   bool continue_train;
 

--- a/nntrainer/include/optimizer.h
+++ b/nntrainer/include/optimizer.h
@@ -64,10 +64,16 @@ typedef struct _OptParam {
   double epsilon;
   float decay_rate;
   float decay_steps;
-  bool continue_train;  /** Continue training with previous tensors for adam */
+  bool continue_train; /** Continue training with previous tensors for adam */
 
-  _OptParam() : learning_rate(0.0), beta1(0.0), beta2(0.0), epsilon(0.0),
-    decay_rate(0.0), decay_steps(0.0), continue_train(false) {}
+  _OptParam() :
+    learning_rate(0.0),
+    beta1(0.0),
+    beta2(0.0),
+    epsilon(0.0),
+    decay_rate(0.0),
+    decay_steps(0.0),
+    continue_train(false) {}
 } OptParam;
 
 class Optimizer {

--- a/nntrainer/include/pooling2d_layer.h
+++ b/nntrainer/include/pooling2d_layer.h
@@ -119,7 +119,6 @@ public:
    */
   int setProperty(std::vector<std::string> values);
 
-
   /* TO DO : support keras type of padding */
   enum class PaddingType {
     full = 0,
@@ -143,7 +142,6 @@ private:
    * @retval Tensor outoput tensor
    */
   Tensor pooling2d(unsigned int batch, Tensor in, int &status);
-  
 };
 
 } // namespace nntrainer

--- a/nntrainer/src/fc_layer.cpp
+++ b/nntrainer/src/fc_layer.cpp
@@ -192,12 +192,11 @@ Tensor FullyConnectedLayer::backwarding(Tensor derivative, int iteration) {
 
     case COST_ENTROPY:
       throw std::runtime_error(
-          "Error: Cross Entropy not supported without softmax or sigmoid.");
+        "Error: Cross Entropy not supported without softmax or sigmoid.");
     case COST_UNKNOWN:
       /** Intended */
     default:
-      throw std::runtime_error(
-          "Error: unknown cost.");
+      throw std::runtime_error("Error: unknown cost.");
     }
   }
 

--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -107,16 +107,15 @@ Tensor Layer::initializeWeight(TensorDim w_dim, WeightIniType init_type,
     w.setRandNormal(0, sqrt(2.0 / (dim.height())));
     break;
   case WEIGHT_LECUN_UNIFORM:
-    w.setRandUniform(-1.0 * sqrt(1.0 / dim.height()),
-        sqrt(1.0 / dim.height()));
+    w.setRandUniform(-1.0 * sqrt(1.0 / dim.height()), sqrt(1.0 / dim.height()));
     break;
   case WEIGHT_XAVIER_UNIFORM:
     w.setRandUniform(-1.0 * sqrt(6.0 / (dim.height() + dim.width())),
-        sqrt(6.0 / (dim.height() + dim.width())));
+                     sqrt(6.0 / (dim.height() + dim.width())));
     break;
   case WEIGHT_HE_UNIFORM:
     w.setRandUniform(-1.0 * sqrt(6.0 / (dim.height())),
-        sqrt(6.0 / (dim.height())));
+                     sqrt(6.0 / (dim.height())));
     break;
   default:
     break;

--- a/nntrainer/src/loss_layer.cpp
+++ b/nntrainer/src/loss_layer.cpp
@@ -21,9 +21,9 @@
  *
  */
 
-#include <loss_layer.h>
 #include <layer.h>
 #include <lazy_tensor.h>
+#include <loss_layer.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <parse_util.h>
@@ -67,12 +67,15 @@ Tensor LossLayer::forwarding(Tensor output, Tensor label, int &status) {
     // @note: the output should be logit before applying sigmoid
     // log(1 + exp(-abs(y))) + max(y, 0)
     Tensor mid_term = y.apply(static_cast<float (*)(float)>(&std::fabs))
-      .multiply(-1.0).apply(static_cast<float (*)(float)>(&std::exp))
-      .add(1.0).apply(logFloat);
+                        .multiply(-1.0)
+                        .apply(static_cast<float (*)(float)>(&std::exp))
+                        .add(1.0)
+                        .apply(logFloat);
     mid_term = mid_term.add(mid_term.apply(relu));
 
     // loss = y * y2 - (log(1 + exp(-abs(y))) + max(y, 0))
-    l = y2.chain().multiply_i(y)
+    l = y2.chain()
+          .multiply_i(y)
           .add_i(mid_term)
           .multiply_i(-1.0 / y2.getWidth())
           .run()
@@ -106,7 +109,7 @@ Tensor LossLayer::forwarding(Tensor output, Tensor label, int &status) {
   return y;
 }
 
-void LossLayer::updateLoss(const Tensor& l) {
+void LossLayer::updateLoss(const Tensor &l) {
   float loss_sum = 0.0;
   const float *data = l.getData();
 
@@ -117,8 +120,7 @@ void LossLayer::updateLoss(const Tensor& l) {
 }
 
 void LossLayer::copy(std::shared_ptr<Layer> l) {
-  std::shared_ptr<LossLayer> from =
-    std::static_pointer_cast<LossLayer>(l);
+  std::shared_ptr<LossLayer> from = std::static_pointer_cast<LossLayer>(l);
   this->last_layer = from->last_layer;
   this->input.copy(from->input);
   this->cost = from->cost;
@@ -144,7 +146,7 @@ Tensor LossLayer::backwarding(Tensor derivative, int iteration) {
     break;
   case COST_ENTROPY:
     throw std::runtime_error(
-        "Error: Cross Entropy not supported without softmax or sigmoid.");
+      "Error: Cross Entropy not supported without softmax or sigmoid.");
   case COST_UNKNOWN:
     /** intended */
   default:

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -93,7 +93,8 @@ std::vector<std::string> parseLayerName(std::string ll) {
 
 NeuralNetwork::NeuralNetwork() : NeuralNetwork("") {}
 
-NeuralNetwork::NeuralNetwork(std::string config) : batch_size(0),
+NeuralNetwork::NeuralNetwork(std::string config) :
+  batch_size(0),
   learning_rate(0.0),
   decay_rate(0.0),
   decay_steps(0.0),
@@ -294,8 +295,7 @@ int NeuralNetwork::init() {
                     ini, (layers_name[i] + ":kernel_size").c_str(), unknown),
                   (int *)size);
       NN_INI_RETURN_STATUS();
-      status = conv2d_layer->setSize(
-        size, Layer::PropertyType::kernel_size);
+      status = conv2d_layer->setSize(size, Layer::PropertyType::kernel_size);
       NN_INI_RETURN_STATUS();
 
       status = getValues(
@@ -303,8 +303,7 @@ int NeuralNetwork::init() {
         iniparser_getstring(ini, (layers_name[i] + ":stride").c_str(), unknown),
         (int *)size);
       NN_INI_RETURN_STATUS();
-      status = conv2d_layer->setSize(
-        size, Layer::PropertyType::stride);
+      status = conv2d_layer->setSize(size, Layer::PropertyType::stride);
       NN_INI_RETURN_STATUS();
 
       status = getValues(CONV2D_DIM,
@@ -312,8 +311,7 @@ int NeuralNetwork::init() {
                            ini, (layers_name[i] + ":padding").c_str(), unknown),
                          (int *)size);
       NN_INI_RETURN_STATUS();
-      status = conv2d_layer->setSize(
-        size, Layer::PropertyType::padding);
+      status = conv2d_layer->setSize(size, Layer::PropertyType::padding);
       NN_INI_RETURN_STATUS();
 
       status = conv2d_layer->setFilter(
@@ -586,7 +584,7 @@ int NeuralNetwork::init(std::shared_ptr<Optimizer> optimizer,
       status = fc_layer->setOptimizer(opt);
       NN_RETURN_STATUS();
 
-    }  break;
+    } break;
     case LAYER_BN:
       layers[i]->setInputDimension(previous_dim);
       status = layers[i]->initialize(last);
@@ -643,12 +641,12 @@ Tensor NeuralNetwork::forwarding(Tensor input, Tensor output, int &status) {
   Tensor X = input;
   Tensor Y2 = output;
 
-  X = forwarding (input, status);
+  X = forwarding(input, status);
   if (status != ML_ERROR_NONE)
     return X;
 
   X = std::static_pointer_cast<LossLayer>(layers[layers.size() - 1])
-      ->forwarding(X, Y2, status);
+        ->forwarding(X, Y2, status);
   return X;
 }
 
@@ -674,7 +672,7 @@ int NeuralNetwork::backwarding(Tensor input, Tensor expected_output,
 
 float NeuralNetwork::getLoss() {
   loss = 0.0;
-  for (unsigned int i=0; i < layers.size(); i++) {
+  for (unsigned int i = 0; i < layers.size(); i++) {
     loss += layers[i]->getLoss();
   }
 
@@ -853,7 +851,7 @@ int NeuralNetwork::train_run() {
           backwarding(nntrainer::Tensor(in), nntrainer::Tensor(label), iter++);
         if (status != ML_ERROR_NONE) {
           data_buffer->clear(nntrainer::BUF_TRAIN);
-          ml_loge ("Error: training error in #%d/%d.", i+1, epoch);
+          ml_loge("Error: training error in #%d/%d.", i + 1, epoch);
           return status;
         }
         std::cout << "#" << i + 1 << "/" << epoch;
@@ -889,7 +887,7 @@ int NeuralNetwork::train_run() {
             nntrainer::Tensor Y2 = nntrainer::Tensor({label[i]});
             nntrainer::Tensor Y = forwarding(X, Y2, status);
             if (status != ML_ERROR_NONE) {
-              ml_loge ("Error: forwarding the network resulted in error.");
+              ml_loge("Error: forwarding the network resulted in error.");
               return status;
             }
 

--- a/nntrainer/src/optimizer.cpp
+++ b/nntrainer/src/optimizer.cpp
@@ -22,9 +22,9 @@
  */
 
 #include <iostream>
+#include <lazy_tensor.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
-#include <lazy_tensor.h>
 #include <optimizer.h>
 #include <parse_util.h>
 #include <util_func.h>
@@ -93,9 +93,9 @@ void Optimizer::calculate(Tensor &djdw, Tensor &djdb, Tensor &weight,
   bool isL2norm = weight_decay.type == WeightDecayType::l2norm;
 
   djdwAvg = djdw.chain()
-                .applyIf(isL2norm, _LIFT(add_i), weight, weight_decay.lambda)
-                .average()
-                .run();
+              .applyIf(isL2norm, _LIFT(add_i), weight, weight_decay.lambda)
+              .average()
+              .run();
 
   djdbAvg = djdb.average();
 
@@ -103,9 +103,13 @@ void Optimizer::calculate(Tensor &djdw, Tensor &djdb, Tensor &weight,
   case OptType::sgd:
     weight.add_i(djdwAvg, -ll);
     break;
-  case OptType::adam:{
-    std::function<float(float)> sqrtEps = [&](float f){ return sqrtFloat(f) + this->popt.epsilon; };
-    std::function<float(float)> biasCorrection = [&](float f){ return 1 - pow(f, iteration + 1); };
+  case OptType::adam: {
+    std::function<float(float)> sqrtEps = [&](float f) {
+      return sqrtFloat(f) + this->popt.epsilon;
+    };
+    std::function<float(float)> biasCorrection = [&](float f) {
+      return 1 - pow(f, iteration + 1);
+    };
 
     ll *= sqrt(biasCorrection(popt.beta2)) / biasCorrection(popt.beta1);
 
@@ -195,7 +199,8 @@ void Optimizer::read(std::ifstream &file) {
       wv.read(file);
       bv.read(file);
     } else {
-      size_t total_size = wm.getSize() + bm.getSize() + wv.getSize() + bv.getSize();
+      size_t total_size =
+        wm.getSize() + bm.getSize() + wv.getSize() + bv.getSize();
       file.seekg(total_size, std::ifstream::cur);
     }
   }

--- a/nntrainer/src/parse_util.cpp
+++ b/nntrainer/src/parse_util.cpp
@@ -105,8 +105,8 @@ unsigned int parseType(std::string ll, InputType t) {
    *            "unknown" :
    */
   std::array<std::string, 6> layer_string = {
-    "input", "fully_connected", "batch_normalization", "conv2d", "pooling2d",
-    "flatten"};
+    "input",  "fully_connected", "batch_normalization",
+    "conv2d", "pooling2d",       "flatten"};
 
   /**
    * @brief     Weight Initialization Type String from configure file
@@ -118,8 +118,8 @@ unsigned int parseType(std::string ll, InputType t) {
    *            "he_uniform"  : He Uniform Initialization
    */
   std::array<std::string, 6> weight_ini_string = {
-    "lecun_normal", "lecun_uniform", "xavier_normal", "xavier_uniform",
-    "he_normal", "he_uniform"};
+    "lecun_normal",   "lecun_uniform", "xavier_normal",
+    "xavier_uniform", "he_normal",     "he_uniform"};
 
   /**
    * @brief     Weight Decay String from configure file
@@ -153,7 +153,7 @@ unsigned int parseType(std::string ll, InputType t) {
         return (i);
       }
     }
-    ret = (unsigned int) OptType::unknown;
+    ret = (unsigned int)OptType::unknown;
     break;
   case TOKEN_COST:
     for (i = 0; i < cost_string.size(); i++) {
@@ -162,7 +162,7 @@ unsigned int parseType(std::string ll, InputType t) {
         return (i);
       }
     }
-    ret = (unsigned int) CostType::COST_UNKNOWN;
+    ret = (unsigned int)CostType::COST_UNKNOWN;
     break;
   case TOKEN_NET:
     for (i = 0; i < network_type_string.size(); i++) {
@@ -181,7 +181,7 @@ unsigned int parseType(std::string ll, InputType t) {
         return (i);
       }
     }
-    ret = (unsigned int) ActiType::ACT_UNKNOWN;
+    ret = (unsigned int)ActiType::ACT_UNKNOWN;
     break;
   case TOKEN_LAYER:
     for (i = 0; i < layer_string.size(); i++) {
@@ -190,7 +190,7 @@ unsigned int parseType(std::string ll, InputType t) {
         return (i);
       }
     }
-    ret = (unsigned int) LayerType::LAYER_UNKNOWN;
+    ret = (unsigned int)LayerType::LAYER_UNKNOWN;
     break;
   case TOKEN_WEIGHTINI:
     for (i = 0; i < weight_ini_string.size(); i++) {
@@ -199,7 +199,7 @@ unsigned int parseType(std::string ll, InputType t) {
         return (i);
       }
     }
-    ret = (unsigned int) WeightIniType::WEIGHT_UNKNOWN;
+    ret = (unsigned int)WeightIniType::WEIGHT_UNKNOWN;
     break;
   case TOKEN_WEIGHT_DECAY:
     for (i = 0; i < weight_decay_string.size(); i++) {
@@ -208,7 +208,7 @@ unsigned int parseType(std::string ll, InputType t) {
         return (i);
       }
     }
-    ret = (unsigned int) WeightDecayType::unknown;
+    ret = (unsigned int)WeightDecayType::unknown;
     break;
   case TOKEN_PADDING:
     for (i = 0; i < padding_string.size(); i++) {
@@ -217,7 +217,7 @@ unsigned int parseType(std::string ll, InputType t) {
         return (i);
       }
     }
-    ret = (unsigned int) Pooling2DLayer::PaddingType::unknown;
+    ret = (unsigned int)Pooling2DLayer::PaddingType::unknown;
     break;
   case TOKEN_POOLING:
     for (i = 0; i < pooling_string.size(); i++) {
@@ -226,7 +226,7 @@ unsigned int parseType(std::string ll, InputType t) {
         return (i);
       }
     }
-    ret = (unsigned int) Pooling2DLayer::PoolingType::unknown;
+    ret = (unsigned int)Pooling2DLayer::PoolingType::unknown;
     break;
   case TOKEN_UNKNOWN:
   default:
@@ -282,7 +282,7 @@ unsigned int parseLayerProperty(std::string property) {
     }
   }
 
-  return (unsigned int) Layer::PropertyType::unknown;
+  return (unsigned int)Layer::PropertyType::unknown;
 }
 
 unsigned int parseOptProperty(std::string property) {
@@ -299,8 +299,8 @@ unsigned int parseOptProperty(std::string property) {
    * continue_train = 6,
    */
   std::array<std::string, 7> property_string = {
-    "learning_rate", "decay_rate", "decay_steps", "beta1", "beta2", "epsilon",
-    "continue_train"};
+    "learning_rate", "decay_rate", "decay_steps",   "beta1",
+    "beta2",         "epsilon",    "continue_train"};
 
   for (i = 0; i < property_string.size(); i++) {
     unsigned int size = (property_string[i].size() > property.size())
@@ -312,7 +312,7 @@ unsigned int parseOptProperty(std::string property) {
     }
   }
 
-  return (unsigned int) Optimizer::PropertyType::unknown;
+  return (unsigned int)Optimizer::PropertyType::unknown;
 }
 
 unsigned int parseNetProperty(std::string property) {
@@ -332,9 +332,8 @@ unsigned int parseNetProperty(std::string property) {
    * model_file = 9
    */
   std::array<std::string, 10> property_string = {
-    "loss",      "cost",       "train_data",  "val_data",
-    "test_data", "label_data", "buffer_size", "batch_size",
-    "epochs",    "model_file"};
+    "loss",       "cost",        "train_data", "val_data", "test_data",
+    "label_data", "buffer_size", "batch_size", "epochs",   "model_file"};
 
   for (i = 0; i < property_string.size(); i++) {
     unsigned int size = (property_string[i].size() > property.size())
@@ -346,7 +345,7 @@ unsigned int parseNetProperty(std::string property) {
     }
   }
 
-  return (unsigned int) NeuralNetwork::PropertyType::unknown;
+  return (unsigned int)NeuralNetwork::PropertyType::unknown;
 }
 
 int setInt(int &val, std::string str) {

--- a/nntrainer/src/pooling2d_layer.cpp
+++ b/nntrainer/src/pooling2d_layer.cpp
@@ -168,7 +168,7 @@ int Pooling2DLayer::setProperty(std::vector<std::string> values) {
     case PropertyType::padding:
       status = getValues(POOLING2D_DIM, value, (int *)(padding));
       NN_RETURN_STATUS();
-      if ((int) padding[0] < 0 || (int) padding[1] < 0) {
+      if ((int)padding[0] < 0 || (int)padding[1] < 0) {
         ml_loge("Error: padding must be greater than 0");
         return ML_ERROR_INVALID_PARAMETER;
       }
@@ -222,7 +222,7 @@ Tensor Pooling2DLayer::pooling2d(unsigned int batch, Tensor in, int &status) {
     }
   } break;
   case PoolingType::average: {
-    unsigned int p_size = p_height*p_width;
+    unsigned int p_size = p_height * p_width;
     for (unsigned int i = 0; i < channel; ++i) {
       J = 0;
       for (unsigned int j = 0; j <= height - p_height; j += stride[0]) {

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -103,8 +103,7 @@ void Tensor::setValue(unsigned int batch, unsigned int c, unsigned int h,
              c * dim.height() * dim.width() + h * dim.width() + w] = value;
 }
 
-template<typename T>
-void Tensor::setDist(T dist) {
+template <typename T> void Tensor::setDist(T dist) {
   for (unsigned int i = 0; i < dim.getDataLen(); ++i) {
     data[i] = dist(rng);
   }
@@ -112,12 +111,12 @@ void Tensor::setDist(T dist) {
 
 void Tensor::setRandNormal(float mean, float std) {
   setDist<std::normal_distribution<float>>(
-      std::normal_distribution<float> (mean, std));
+    std::normal_distribution<float>(mean, std));
 }
 
 void Tensor::setRandUniform(float min, float max) {
   setDist<std::uniform_real_distribution<float>>(
-      std::uniform_real_distribution<float> (min, max));
+    std::uniform_real_distribution<float>(min, max));
 }
 
 Tensor::Tensor(std::vector<std::vector<float>> const &d) {
@@ -849,13 +848,9 @@ Tensor Tensor::average(int axis) const {
   return result;
 }
 
-void Tensor::setValue(float val) {
-  std::fill(data.begin(), data.end(), val);
-}
+void Tensor::setValue(float val) { std::fill(data.begin(), data.end(), val); }
 
-void Tensor::setZero() {
-  setValue(0);
-}
+void Tensor::setZero() { setValue(0); }
 
 int Tensor::argmax() {
   int index = 0;

--- a/nntrainer/src/util_func.cpp
+++ b/nntrainer/src/util_func.cpp
@@ -179,15 +179,15 @@ Tensor zero_pad(int batch, Tensor const &in, unsigned int const *padding) {
   for (unsigned int j = 0; j < c; ++j) {
     for (unsigned int k = 0; k < padding[0]; ++k) {
       for (unsigned int l = 0; l < width_p; ++l) {
-	output.setValue(0, j, k, l, 0.0);
-	output.setValue(0, j, k + height_p_h, l, 0.0);
+        output.setValue(0, j, k, l, 0.0);
+        output.setValue(0, j, k + height_p_h, l, 0.0);
       }
     }
 
     for (unsigned int l = 0; l < padding[1]; ++l) {
       for (unsigned int k = padding[0]; k < h; ++k) {
-	output.setValue(0, j, k, l, 0.0);
-	output.setValue(0, j, k, l + width_p_h, 0.0);
+        output.setValue(0, j, k, l, 0.0);
+        output.setValue(0, j, k, l + width_p_h, 0.0);
       }
     }
   }


### PR DESCRIPTION
Clang-format 6 is widely used. However,
`AllowAllConstructorInitializersOnNextLine` added from #203 is supported
from clang-format 9.

This Pr reverts use of `AllowAllConstructorInitializersOnNextLine`
while having similar linting style.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>