### PR TITLE
[bias] Bias updation missing for sgd

### DIFF
--- a/nntrainer/include/optimizer.h
+++ b/nntrainer/include/optimizer.h
@@ -160,10 +160,9 @@ public:
    * @param[in/out] Weight Weight Tensor
    * @param[in/out] Bias Bias Tensor
    * @param[in] iteration nth epoch number
-   * @param[in] init_zero bool it is true if bias sets zero.
    */
   void calculate(const Tensor &djdw, const Tensor &djdb, Tensor &weight,
-                 Tensor &bias, int iteration, bool init_zero);
+                 Tensor &bias, int iteration);
 
   /**
    * @brief     Property Enumeration

--- a/nntrainer/src/optimizer.cpp
+++ b/nntrainer/src/optimizer.cpp
@@ -78,8 +78,7 @@ int Optimizer::initialize(TensorDim d, bool set_tensor) {
 }
 
 void Optimizer::calculate(const Tensor &djdw, const Tensor &djdb,
-                          Tensor &weight, Tensor &bias, int iteration,
-                          bool init_zero) {
+    Tensor &weight, Tensor &bias, int iteration) {
   Tensor djdwAvg, djdbAvg;
   float ll = popt.learning_rate;
   if (popt.decay_steps != -1) {
@@ -92,6 +91,7 @@ void Optimizer::calculate(const Tensor &djdw, const Tensor &djdb,
   switch (type) {
   case OptType::sgd:
     weight.add_i(djdwAvg, -ll);
+    bias.add_i(djdbAvg, -ll);
     break;
   case OptType::adam: {
     std::function<float(float)> sqrtEps = [&](float f) {
@@ -123,10 +123,6 @@ void Optimizer::calculate(const Tensor &djdw, const Tensor &djdb,
   case OptType::unknown:
   default:
     break;
-  }
-
-  if (init_zero) {
-    bias.add_i(djdbAvg, -ll);
   }
 }
 


### PR DESCRIPTION
Bias updatation fixed for sgd where it only happened when bias was initialized with 0
For adam, bias updatation was happening twice

cc. @jijoongmoon Did I misinterpret a feature as a bug?

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>