### PR TITLE
Fix optimizer signature

### DIFF
--- a/nntrainer/src/fc_layer.cpp
+++ b/nntrainer/src/fc_layer.cpp
@@ -168,7 +168,7 @@ Tensor FullyConnectedLayer::backwarding(Tensor derivative, int iteration) {
                   .applyIf(this->isWeightDecayL2Norm(), _LIFT(add_i), weight, weight_decay.lambda)
                   .run();
 
-  opt.calculate(djdw, djdb, weight, bias, iteration, init_zero);
+  opt.calculate(djdw, djdb, weight, bias, iteration);
 
   return ret;
 }


### PR DESCRIPTION
optimizer signature now does not have `init_zero`

This quick fix deletes init_zero from `fc_layer::backward`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>