### PR TITLE
[WAIT FOR #237] Add exception to TensorDim::setTensorDim @open sesame 07/03 11:18

### DIFF
--- a/nntrainer/include/tensor_dim.h
+++ b/nntrainer/include/tensor_dim.h
@@ -36,10 +36,10 @@ public:
   }
 
   TensorDim(unsigned int b, unsigned int c, unsigned int h, unsigned int w) {
-    dim[0] = b;
-    dim[1] = c;
-    dim[2] = h;
-    dim[3] = w;
+    setTensorDim(0, b);
+    setTensorDim(1, c);
+    setTensorDim(2, h);
+    setTensorDim(3, w);
     feature_len = c * h * w;
     len = b * feature_len;
   }

--- a/nntrainer/src/activation_layer.cpp
+++ b/nntrainer/src/activation_layer.cpp
@@ -34,11 +34,6 @@ namespace nntrainer {
  * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
  */
 int ActivationLayer::initialize(bool last) {
-  if (input_dim.batch() <= 0 || input_dim.height() <= 0 ||
-      input_dim.width() <= 0 || input_dim.channel() <= 0) {
-    ml_loge("Error: Dimension must be greater than 0");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
 
   this->last_layer = last;
 

--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -33,11 +33,6 @@ namespace nntrainer {
 
 int BatchNormalizationLayer::initialize(bool last) {
   int status = ML_ERROR_NONE;
-  if (input_dim.batch() <= 0 || input_dim.height() <= 0 ||
-      input_dim.width() <= 0 || input_dim.channel() <= 0) {
-    ml_loge("Error: Dimension must be greater than 0");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
 
   dim = input_dim;
   output_dim = dim;
@@ -117,8 +112,7 @@ Tensor BatchNormalizationLayer::backwarding(Tensor derivative, int iteration) {
   assert(dim.batch() > 0);
 
   Tensor hath = hidden;
-  Tensor dy =
-    derivative.multiply(hath.multiply(gamma).add(beta));
+  Tensor dy = derivative.multiply(hath.multiply(gamma).add(beta));
 
   dbeta = dy.sum(0);
   dgamma = (input.subtract(mu)

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -29,12 +29,6 @@ int Conv2DLayer::initialize(bool last) {
     ml_logw("Warning: the length of previous layer dimension is one");
   }
 
-  if (input_dim.batch() <= 0 || input_dim.height() <= 0 ||
-      input_dim.width() <= 0 || input_dim.channel() <= 0) {
-    ml_loge("Error: Dimension must be greater than 0");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-
   this->last_layer = last;
   TensorDim Kdim;
   Kdim.channel(input_dim.channel());

--- a/nntrainer/src/databuffer.cpp
+++ b/nntrainer/src/databuffer.cpp
@@ -346,12 +346,6 @@ int DataBuffer::setMiniBatch(unsigned int size) {
 
 int DataBuffer::setFeatureSize(TensorDim indim) {
   int status = ML_ERROR_NONE;
-  if (indim.getFeatureLen() == 0) {
-    ml_loge("Error: batch size must be greater than 0");
-    SET_VALIDATION(false);
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-
   input_dim = indim;
   return status;
 }

--- a/nntrainer/src/fc_layer.cpp
+++ b/nntrainer/src/fc_layer.cpp
@@ -33,11 +33,6 @@ namespace nntrainer {
 
 int FullyConnectedLayer::initialize(bool last) {
   int status = ML_ERROR_NONE;
-  if (input_dim.batch() <= 0 || input_dim.height() <= 0 ||
-      input_dim.width() <= 0 || input_dim.channel() <= 0) {
-    ml_loge("Error: Dimension must be greater than 0");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
 
   this->last_layer = last;
 
@@ -170,7 +165,8 @@ Tensor FullyConnectedLayer::backwarding(Tensor derivative, int iteration) {
   Tensor djdw = input.chain()
                   .transpose("0:2:1")
                   .dot(derivative)
-                  .applyIf(this->isWeightDecayL2Norm(), _LIFT(add_i), weight, weight_decay.lambda)
+                  .applyIf(this->isWeightDecayL2Norm(), _LIFT(add_i), weight,
+                           weight_decay.lambda)
                   .run();
 
   gradients.clear();

--- a/nntrainer/src/flatten_layer.cpp
+++ b/nntrainer/src/flatten_layer.cpp
@@ -26,11 +26,6 @@ int FlattenLayer::initialize(bool last) {
   if (input_dim.getDataLen() == 1) {
     ml_logw("Warning: the length of previous layer dimension is one");
   }
-  if (input_dim.batch() <= 0 || input_dim.height() <= 0 ||
-      input_dim.width() <= 0 || input_dim.channel() <= 0) {
-    ml_loge("Error: Dimension must be greater than 0");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
 
   this->last_layer = last;
 

--- a/nntrainer/src/input_layer.cpp
+++ b/nntrainer/src/input_layer.cpp
@@ -94,12 +94,6 @@ Tensor InputLayer::forwarding(Tensor in, int &status) {
 
 int InputLayer::initialize(bool last) {
   int status = ML_ERROR_NONE;
-  if (input_dim.batch() <= 0 || input_dim.channel() <= 0 ||
-      input_dim.height() <= 0 || input_dim.width() <= 0) {
-    ml_loge("Error: Dimension must be greater than 0");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-
   dim = input_dim;
   output_dim = dim;
 

--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -58,11 +58,7 @@ int Layer::checkValidation() {
     ml_loge("Error: Have to set activation for this layer");
     return ML_ERROR_INVALID_PARAMETER;
   }
-  if (dim.batch() == 0 || dim.width() == 0 || dim.height() == 0 ||
-      dim.channel() == 0) {
-    ml_loge("Error: Tensor Dimension must be set before initialization");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
+
   return status;
 }
 

--- a/nntrainer/src/loss_layer.cpp
+++ b/nntrainer/src/loss_layer.cpp
@@ -33,11 +33,6 @@ namespace nntrainer {
 
 int LossLayer::initialize(bool last) {
   int status = ML_ERROR_NONE;
-  if (input_dim.batch() <= 0 || input_dim.height() <= 0 ||
-      input_dim.width() <= 0 || input_dim.channel() <= 0) {
-    ml_loge("Error: Dimension must be greater than 0.");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
 
   if (!last) {
     ml_loge("Error: Loss layer, if exists, must be the layer.");

--- a/nntrainer/src/optimizer.cpp
+++ b/nntrainer/src/optimizer.cpp
@@ -60,10 +60,7 @@ int Optimizer::setOptParam(OptParam p) {
 
 int Optimizer::initialize(TensorDim d, bool set_tensor) {
   int status = ML_ERROR_NONE;
-  if (d.height() == 0 || d.width() == 0 || d.channel() == 0) {
-    ml_loge("Error: Tensor Dimension must be greater than 0");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
+
   if (type == OptType::adam && set_tensor) {
     Tensor wm = Tensor(d.channel(), d.height(), d.width());
     Tensor wv = Tensor(d.channel(), d.height(), d.width());
@@ -81,8 +78,8 @@ int Optimizer::initialize(TensorDim d, bool set_tensor) {
 }
 
 void Optimizer::apply_gradients(
-    std::vector<std::reference_wrapper<Tensor>> &weights,
-    std::vector<std::reference_wrapper<Tensor>> &gradients, int iteration) {
+  std::vector<std::reference_wrapper<Tensor>> &weights,
+  std::vector<std::reference_wrapper<Tensor>> &gradients, int iteration) {
   if (weights.size() != gradients.size())
     throw std::runtime_error("Number of gradients and weights should match.");
 

--- a/nntrainer/src/pooling2d_layer.cpp
+++ b/nntrainer/src/pooling2d_layer.cpp
@@ -27,11 +27,6 @@ int Pooling2DLayer::initialize(bool last) {
   if (input_dim.getDataLen() == 1) {
     ml_logw("Warning: the length of previous layer dimension is one");
   }
-  if (input_dim.batch() <= 0 || input_dim.height() <= 0 ||
-      input_dim.width() <= 0 || input_dim.channel() <= 0) {
-    ml_loge("Error: Dimension must be greater than 0");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
 
   this->last_layer = last;
 

--- a/nntrainer/src/tensor_dim.cpp
+++ b/nntrainer/src/tensor_dim.cpp
@@ -28,6 +28,11 @@ void TensorDim::resetLen() {
 }
 
 void TensorDim::setTensorDim(unsigned int idx, unsigned int value) {
+  if (value == 0) {
+    throw std::invalid_argument(
+      "[TensorDim] Trying to assign value of 0 to tensor dim");
+  }
+
   dim[idx] = value;
   resetLen();
 }
@@ -45,7 +50,7 @@ int TensorDim::setTensorDim(std::string input_shape) {
   }
   int cn = 0;
   for (std::sregex_iterator i = words_begin; i != words_end; ++i) {
-    dim[MAXDIM - cur_dim + cn] = std::stoi((*i).str());
+    setTensorDim(MAXDIM - cur_dim + cn, std::stoi((*i).str()));
     if (dim[MAXDIM - cur_dim + cn] <= 0) {
       ml_loge("Tensor Dimension should be greater than 0");
       return ML_ERROR_INVALID_PARAMETER;

--- a/test/unittest/unittest_databuffer_file.cpp
+++ b/test/unittest/unittest_databuffer_file.cpp
@@ -44,24 +44,6 @@ TEST(nntrainer_DataBuffer, setFeatureSize_01_p) {
 /**
  * @brief Data Buffer
  */
-TEST(nntrainer_DataBuffer, setFeatureSize_02_n) {
-  int status = ML_ERROR_NONE;
-  nntrainer::DataBufferFromDataFile data_buffer;
-  nntrainer::TensorDim dim;
-  status = dim.setTensorDim("32:1:1:62720");
-  status = data_buffer.setClassNum(10);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-  status = data_buffer.setDataFile("./trainingSet.dat", nntrainer::DATA_TRAIN);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-  dim.width(0);
-  std::cout << dim.width() << std::endl;
-  status = data_buffer.setFeatureSize(dim);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-}
-
-/**
- * @brief Data Buffer
- */
 TEST(nntrainer_DataBuffer, setMiniBatch_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::DataBufferFromDataFile data_buffer;

--- a/test/unittest/unittest_nntrainer_internal.cpp
+++ b/test/unittest/unittest_nntrainer_internal.cpp
@@ -108,8 +108,7 @@ TEST(nntrainer_NeuralNetwork, init_04_n) {
   nntrainer::NeuralNetwork NN;
   status = NN.setConfig("./test.ini");
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = NN.init();
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  EXPECT_THROW(NN.init(), std::invalid_argument);
 }
 
 /**

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -40,19 +40,6 @@ TEST(nntrainer_InputLayer, initialize_01_p) {
 /**
  * @brief Input Layer
  */
-TEST(nntrainer_InputLayer, initialize_02_n) {
-  int status = ML_ERROR_NONE;
-  nntrainer::InputLayer layer;
-  nntrainer::TensorDim d;
-  d.setTensorDim("32:0:28:28");
-  layer.setInputDimension(d);
-  status = layer.initialize(false);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-}
-
-/**
- * @brief Input Layer
- */
 TEST(nntrainer_InputLayer, setOptimizer_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::InputLayer layer;
@@ -119,6 +106,7 @@ TEST(nntrainer_FullyConnectedLayer, initialize_01_p) {
   nntrainer::FullyConnectedLayer layer;
   nntrainer::TensorDim d;
   d.setTensorDim("32:1:28:28");
+  layer.setProperty({"unit=1"});
   layer.setInputDimension(d);
   status = layer.initialize(false);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -128,26 +116,23 @@ TEST(nntrainer_FullyConnectedLayer, initialize_01_p) {
  * @brief Fully Connected Layer
  */
 TEST(nntrainer_FullyConnectedLayer, initialize_02_n) {
-  int status = ML_ERROR_NONE;
   nntrainer::FullyConnectedLayer layer;
   nntrainer::TensorDim d;
-  d.setTensorDim("32:0:28:28");
   layer.setInputDimension(d);
-  status = layer.initialize(false);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  EXPECT_THROW(layer.initialize(false), std::invalid_argument);
 }
 
 /**
  * @brief Fully Connected Layer
  */
 TEST(nntrainer_FullyConnectedLayer, initialize_03_n) {
-  int status = ML_ERROR_NONE;
   nntrainer::FullyConnectedLayer layer;
   nntrainer::TensorDim d;
   d.setTensorDim("32:1:28:28");
   layer.setInputDimension(d);
-  status = layer.initialize(false);
-  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  EXPECT_THROW(layer.initialize(false), std::invalid_argument);
 }
 
 /**
@@ -158,22 +143,10 @@ TEST(nntrainer_FullyConnectedLayer, initialize_04_p) {
   nntrainer::FullyConnectedLayer layer;
   nntrainer::TensorDim d;
   d.setTensorDim("32:1:28:28");
+  layer.setProperty({"unit=1"});
   layer.setInputDimension(d);
   status = layer.initialize(false);
   EXPECT_EQ(status, ML_ERROR_NONE);
-}
-
-/**
- * @brief FullyConnected Layer
- */
-TEST(nntrainer_FullyConnectedLayer, initialize_05_n) {
-  int status = ML_ERROR_NONE;
-  nntrainer::FullyConnectedLayer layer;
-  nntrainer::TensorDim d;
-  d.setTensorDim("32:1:0:28");
-  layer.setInputDimension(d);
-  status = layer.initialize(false);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
 /**
@@ -184,6 +157,7 @@ TEST(nntrainer_FullyConnectedLayer, initialize_06_p) {
   nntrainer::FullyConnectedLayer layer;
   nntrainer::TensorDim d;
   d.setTensorDim("32:1:1:28");
+  layer.setProperty({"unit=1"});
   layer.setInputDimension(d);
   status = layer.initialize(false);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -396,24 +370,11 @@ TEST(nntrainer_BatchNormalizationLayer, initialize_01_p) {
 /**
  * @brief Batch Normalization Layer
  */
-TEST(nntrainer_BatchNormalizationLayer, initialize_02_n) {
-  int status = ML_ERROR_NONE;
-  nntrainer::BatchNormalizationLayer layer;
-  nntrainer::TensorDim d;
-  d.setTensorDim("32:0:1:28");
-  layer.setInputDimension(d);
-  status = layer.initialize(false);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-}
-
-/**
- * @brief Batch Normalization Layer
- */
 TEST(nntrainer_BatchNormalizationLayer, setOptimizer_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::BatchNormalizationLayer layer;
   nntrainer::TensorDim d;
-  d.setTensorDim("32:0:1:28");
+  d.setTensorDim("32:1:1:28");
   layer.setInputDimension(d);
   status = layer.initialize(false);
 

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -33,6 +33,29 @@ TEST(nntrainer_TensorDim, setTensorDim_02_n) {
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
+TEST(nntrainer_TensorDim, setTensorDim_03_n) {
+  nntrainer::TensorDim d;
+
+  EXPECT_THROW(d.setTensorDim(0, 0), std::invalid_argument);
+  EXPECT_THROW(d.setTensorDim(1, 0), std::invalid_argument);
+  EXPECT_THROW(d.setTensorDim(2, 0), std::invalid_argument);
+  EXPECT_THROW(d.setTensorDim(3, 0), std::invalid_argument);
+}
+
+TEST(nntrainer_TensorDim, setTensorDim_04_p) {
+  nntrainer::TensorDim d;
+
+  d.setTensorDim(0, 4);
+  d.setTensorDim(1, 5);
+  d.setTensorDim(2, 6);
+  d.setTensorDim(3, 7);
+
+  EXPECT_EQ(d.batch(), 4);
+  EXPECT_EQ(d.channel(), 5);
+  EXPECT_EQ(d.height(), 6);
+  EXPECT_EQ(d.width(), 7);
+}
+
 TEST(nntrainer_Tensor, Tensor_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::Tensor tensor = nntrainer::Tensor(1, 2, 3);


### PR DESCRIPTION
**Prerequisite**
- Add capi exception wrapper (~later pr~ #237)

**Changes proposed in this PR:**
- Add `std::invalid_argument` to `TensorDim::setTensorDim`
- Fix `fc_layer` positive test does not have unit declared.
- Fix tests accordingly.

**Todo**
- ~Add TensorDim test (positive && negative)~

See also: #233

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped ~(CAPI needs error handler)~

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>