### PR TITLE
[optimizer] Bug fix

### DIFF
--- a/nntrainer/src/optimizer.cpp
+++ b/nntrainer/src/optimizer.cpp
@@ -103,7 +103,7 @@ void Optimizer::apply_gradients(
   std::vector<std::reference_wrapper<Tensor>>::iterator w_iter, g_iter;
   for (w_iter = weights.begin(), g_iter = gradients.begin();
       w_iter != weights.end(); ++w_iter, ++g_iter) {
-    Tensor x = *w_iter;
+    Tensor &x = *w_iter;
     Tensor x_grad = *g_iter;
 
     x_grad = x_grad.average();


### PR DESCRIPTION
Tensor copy constructor and copy assigment operator creates a copy of the vector
This led to bug in optimizer which updated the copy of the weight than the weight itself
Fixed by refernce of weight in optimizer

Resolves #241

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>