### PR TITLE
Restructure inner data structure inside Tensor

### DIFF
--- a/nntrainer/include/lazy_tensor.h
+++ b/nntrainer/include/lazy_tensor.h
@@ -40,7 +40,7 @@ public:
    * @brief Constructor of Lazy Tensor, Tensor is copied to gaurantee
    * immutability
    */
-  LazyTensor(const Tensor &from) { target.copy(from); };
+  LazyTensor(const Tensor &from) { target = Tensor(from); };
 
   /**
    * @brief     Wrapper method of add_i. see tensor.h for more detail


### PR DESCRIPTION
This PR restructures Tensor to enable sharing between Tensor. as well as refactoring the inner data structure to not use vector also providing significant speed increases(20s -> 10s in example application)

**Changes proposed in this PR:**
- Change inner data structure
- Refactor Tensor ctors
- Add copy/move ctors & assignment operators

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>