### PR TITLE
[activation] Add missing config for activation layer

### DIFF
--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -249,6 +249,12 @@ public:
   void setLast(bool last) { last_layer = last; }
 
   /**
+   * @brief  get if this is last layer of Network
+   * @retval last true/false
+   */
+  bool getLast() { return last_layer; }
+
+  /**
    * @brief  set bias initialize with zero
    * @param[in] zero true/false
    */

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -380,9 +380,10 @@ private:
    * @brief     Add activation layer to layers
    *
    * @param[in] ActiType act Activation Type
+   * @param[in] prev previous layer
    * @returns   Create activation layer
    */
-  std::shared_ptr<Layer> _make_act_layer(ActiType act);
+  std::shared_ptr<Layer> _make_act_layer(ActiType act, std::shared_ptr<Layer>);
 };
 
 } /* namespace nntrainer */


### PR DESCRIPTION
Add missing initialization and setting input/output dimension for activation layer
Also updated setting previous dimension to be from the last computation layer

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>