### PR TITLE
[bug fixes] [tensor] Tensor constructor should not set zero

### DIFF
--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -48,27 +48,7 @@ class LazyTensor;
  */
 class Tensor {
 public:
-  Tensor(const TensorDim &d, float *buf = nullptr) :
-    dim(d),
-    strides{{1, 2, 3}},
-    is_contiguous(true),
-    data(new float[d.getDataLen()], std::default_delete<float[]>()) {
-    // todo: initialize appropriate strides
-    if (buf == nullptr) {
-      setZero();
-    } else {
-      float *data = getData();
-      unsigned int len = length();
-
-#ifdef USE_BLAS
-      cblas_scopy(len, buf, 1, data, 1);
-#else
-      for (unsigned int i = 0; i < len; ++i) {
-        data[i] = buf[i];
-      }
-#endif
-    }
-  }
+  Tensor(const TensorDim &d, float *buf = nullptr);
 
   /**
    * @brief     Basic Constructor of Tensor

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -43,11 +43,11 @@ int Conv2DLayer::initialize(bool last) {
 
     delK.push_back(
       Tensor(input_dim.batch(), Kdim.channel(), Kdim.height(), Kdim.width()));
-    delBias.push_back(Tensor(1, 1, 1, 1));
+    delBias.push_back(Tensor(input_dim.batch(), 1, 1, 1));
     filters.push_back(Knl);
     weights.push_back(Knl);
 
-    Tensor B(input_dim.batch(), 1, 1, 1);
+    Tensor B(1, 1, 1, 1);
     if (!bias_init_zero) {
       B.apply([&](float x) { return random(); });
     }
@@ -78,6 +78,11 @@ void Conv2DLayer::save(std::ofstream &file) {
 }
 
 Tensor Conv2DLayer::forwarding(Tensor in, int &status) {
+  if (in.getDim() != input_dim) {
+    status = ML_ERROR_INVALID_PARAMETER;
+    return in;
+  }
+
   if (normalization) {
     input = in.normalization();
   } else {
@@ -88,8 +93,7 @@ Tensor Conv2DLayer::forwarding(Tensor in, int &status) {
     input = input.standardization();
   }
 
-  hidden = Tensor(in.batch(), output_dim.channel(), output_dim.height(),
-                  output_dim.width());
+  hidden = Tensor(output_dim);
 
   std::vector<float> output;
 

--- a/nntrainer/src/pooling2d_layer.cpp
+++ b/nntrainer/src/pooling2d_layer.cpp
@@ -78,6 +78,7 @@ Tensor Pooling2DLayer::backwarding(Tensor derivative, int iteration) {
 
   unsigned int J, K;
   Tensor result = Tensor(input_dim);
+  result.setZero();
   float *out = result.getData();
   switch (pooling_type) {
   case PoolingType::max: {
@@ -290,6 +291,7 @@ Tensor Pooling2DLayer::pooling2d(unsigned int batch, Tensor in, int &status) {
     }
   } break;
   case PoolingType::global_max: {
+    output.setZero();
     for (unsigned int i = 0; i < channel; ++i) {
       unsigned int idx = batch * input_dim.getFeatureLen() + i * height * width;
       float max = std::numeric_limits<float>::min();
@@ -306,6 +308,7 @@ Tensor Pooling2DLayer::pooling2d(unsigned int batch, Tensor in, int &status) {
     }
   } break;
   case PoolingType::global_average: {
+    output.setZero();
     Tensor sum_wh = in.chain().sum(3).sum(2).run();
     for (unsigned int i = 0; i < channel; ++i) {
       output.setValue(0, i, 0, 0,

--- a/nntrainer/src/util_func.cpp
+++ b/nntrainer/src/util_func.cpp
@@ -174,6 +174,7 @@ Tensor zero_pad(int batch, Tensor const &in, unsigned int const *padding) {
   unsigned int width_p_h = w + padding[1];
 
   Tensor output(1, c, height_p, width_p);
+  output.setZero();
 
   for (unsigned int j = 0; j < c; ++j) {
     for (unsigned int k = 0; k < padding[0]; ++k) {
@@ -207,6 +208,8 @@ Tensor zero_pad(int batch, Tensor const &in, unsigned int const *padding) {
 Tensor strip_pad(Tensor const &in, unsigned int const *padding) {
   Tensor output(in.batch(), in.channel(), in.width() - padding[0] * 2,
                 in.width() - padding[1] * 2);
+  output.setZero();
+
   for (unsigned int i = 0; i < in.batch(); ++i) {
     for (unsigned int j = 0; j < in.channel(); ++j) {
       for (unsigned int k = 0; k < output.height(); ++k) {

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -59,6 +59,7 @@ TEST(nntrainer_TensorDim, setTensorDim_04_p) {
 TEST(nntrainer_Tensor, Tensor_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::Tensor tensor = nntrainer::Tensor(1, 2, 3);
+  tensor.setZero();
   ASSERT_NE(nullptr, tensor.getData());
   if (tensor.getValue(0, 0, 0, 0) != 0.0)
     status = ML_ERROR_INVALID_PARAMETER;


### PR DESCRIPTION
Tensor constructors should not zero to the memory by default
This hides many bugs in the code and also leads to big overheads
Removed setting zero in constructor and corresponding many bug fixes

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>