### PR TITLE
Fix potential bug in pooling 2D layer

### DIFF
--- a/nntrainer/src/pooling2d_layer.cpp
+++ b/nntrainer/src/pooling2d_layer.cpp
@@ -39,6 +39,9 @@ int Pooling2DLayer::initialize(bool last) {
       (input_dim.height() - pooling_size[0] + 2 * padding[0]) / stride[0] + 1);
     output_dim.width(
       (input_dim.width() - pooling_size[1] + 2 * padding[1]) / stride[1] + 1);
+  } else {
+    output_dim.height(1);
+    output_dim.width(1);
   }
 
   hidden = Tensor(output_dim);


### PR DESCRIPTION
When pooling2d_layer is initialized once as a default.
and initialized again as a `global_max` | `global_pooling`
`output.width`, `output.height` is set to 2.

Although following scenario is highly unlikely, initializing layer
should be done deterministically.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>