### PR TITLE
[Spec] Fix the wrong Requires section

### DIFF
--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -44,7 +44,7 @@ BuildRequires: lcov
 %endif
 
 Requires:	iniparser
-Requires:	libopenblas
+Requires:	libopenblas_pthreads0
 
 %description
 NNtrainer is Software Framework for Training Nerual Network Models on Devices.


### PR DESCRIPTION
This patch fixes the wrong Requires for libopenblas.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped