### PR TITLE
Add setProperty for each property type

### DIFF
--- a/nntrainer/include/activation_layer.h
+++ b/nntrainer/include/activation_layer.h
@@ -119,14 +119,6 @@ public:
   void setActivation(ActiType acti_type);
 
   /**
-   * @brief     set Property of layer
-   * @param[in] values values of property
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setProperty(std::vector<std::string> values);
-
-  /**
    * @brief     get the base name for the layer
    * @retval    base name of the layer
    */

--- a/nntrainer/include/bn_layer.h
+++ b/nntrainer/include/bn_layer.h
@@ -99,26 +99,31 @@ public:
   int initialize(bool last);
 
   /**
-   * @brief     set Property of layer
-   * @param[in] values values of property
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setProperty(std::vector<std::string> values);
-
-  /**
    * @brief     get the base name for the layer
    * @retval    base name of the layer
    */
   std::string getBaseName() { return "BatchNormalization"; };
 
+  using Layer::setProperty;
+
 private:
+  /**
+   * @brief setProperty by PropertyType
+   * @note By passing empty string, this can validate if @a type is valid
+   * @param[in] type property type to be passed
+   * @param[in] value value to be passed, if empty string is passed, do nothing
+   * but throws error when @a type is invalid
+   * @exception std::invalid_argument invalid argument
+   */
+  void setProperty(const PropertyType type, const std::string &value = "");
+
   Tensor cvar; /**< training varaince saved in bn_layer::forwarding and used in
                     bn_layer::backwarding */
 
   Tensor x_normalized;
   float epsilon;
 };
+
 } // namespace nntrainer
 
 #endif /* __cplusplus */

--- a/nntrainer/include/conv2d_layer.h
+++ b/nntrainer/include/conv2d_layer.h
@@ -124,14 +124,6 @@ public:
   void setStandardization(bool enable) { this->standardization = enable; };
 
   /**
-   * @brief     set Property of layer
-   * @param[in] values values of property
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setProperty(std::vector<std::string> values);
-
-  /**
    * @brief     Optimizer Setter
    * @param[in] opt Optimizer
    * @retval #ML_ERROR_NONE Successful.
@@ -168,7 +160,19 @@ public:
    */
   std::string getBaseName() { return "Convolution2D"; };
 
+  using Layer::setProperty;
+
 private:
+  /**
+   * @brief setProperty by PropertyType
+   * @note By passing empty string, this can validate if @a type is valid
+   * @param[in] type property type to be passed
+   * @param[in] value value to be passed, if empty string is passed, do nothing
+   * but throws error when @a type is invalid
+   * @exception std::invalid_argument invalid argument
+   */
+  void setProperty(const PropertyType type, const std::string &value = "");
+
   unsigned int filter_size;
   unsigned int kernel_size[CONV2D_DIM];
   unsigned int stride[CONV2D_DIM];

--- a/nntrainer/include/fc_layer.h
+++ b/nntrainer/include/fc_layer.h
@@ -86,14 +86,6 @@ public:
   void setUnit(unsigned int u) { unit = u; };
 
   /**
-   * @brief     set Property of layer
-   * @param[in] values values of property
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setProperty(std::vector<std::string> values);
-
-  /**
    * @brief     Optimizer Setter
    * @param[in] opt Optimizer
    * @retval #ML_ERROR_NONE Successful.
@@ -107,7 +99,19 @@ public:
    */
   std::string getBaseName() { return "FullyConnected"; };
 
+  using Layer::setProperty;
+
 private:
+  /**
+   * @brief setProperty by PropertyType
+   * @note By passing empty string, this can validate if @a type is valid
+   * @param[in] type property type to be passed
+   * @param[in] value value to be passed, if empty string is passed, do nothing
+   * but throws error when @a type is invalid
+   * @exception std::invalid_argument invalid argument
+   */
+  void setProperty(const PropertyType type, const std::string &value = "");
+
   unsigned int unit;
 };
 } // namespace nntrainer

--- a/nntrainer/include/flatten_layer.h
+++ b/nntrainer/include/flatten_layer.h
@@ -87,13 +87,6 @@ public:
   Tensor backwarding(Tensor in, int iteration);
 
   /**
-   * @brief     set Property of layer
-   * @param[in] values values of property
-   * @retval #ML_ERROR_NOT_SUPPORTED Successful.
-   */
-  int setProperty(std::vector<std::string> values);
-
-  /**
    * @brief     copy layer
    * @param[in] l layer to copy
    */
@@ -104,6 +97,19 @@ public:
    * @retval    base name of the layer
    */
   std::string getBaseName() { return "Flatten"; };
+
+  using Layer::setProperty;
+
+private:
+  /**
+   * @brief setProperty by PropertyType
+   * @note By passing empty string, this can validate if @a type is valid
+   * @param[in] type property type to be passed
+   * @param[in] value value to be passed, if empty string is passed, do nothing
+   * but throws error when @a type is invalid
+   * @exception std::invalid_argument invalid argument
+   */
+  void setProperty(const PropertyType type, const std::string &value = "");
 };
 
 } // namespace nntrainer

--- a/nntrainer/include/input_layer.h
+++ b/nntrainer/include/input_layer.h
@@ -124,20 +124,24 @@ public:
   void setStandardization(bool enable) { this->standardization = enable; };
 
   /**
-   * @brief     set Property of layer
-   * @param[in] values values of property
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setProperty(std::vector<std::string> values);
-
-  /**
    * @brief     get the base name for the layer
    * @retval    base name of the layer
    */
   std::string getBaseName() { return "Input"; };
 
+  using Layer::setProperty;
+
 private:
+  /**
+   * @brief setProperty by PropertyType
+   * @note By passing empty string, this can validate if @a type is valid
+   * @param[in] type property type to be passed
+   * @param[in] value value to be passed, if empty string is passed, do nothing
+   * but throws error when @a type is invalid
+   * @exception std::invalid_argument invalid argument
+   */
+  void setProperty(const PropertyType type, const std::string &value = "");
+
   bool normalization;
   bool standardization;
 };

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -183,7 +183,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int setProperty(std::vector<std::string> values);
+  int setProperty(std::vector<std::string> values);
 
   /**
    * @brief     Optimizer Setter
@@ -513,6 +513,17 @@ protected:
                                 after initiation
                                 use setParamSize() to avoid
                                 setting parameters twice */
+
+  /**
+   * @brief setProperty by PropertyType
+   * @note By passing empty string, this can validate if @a type is valid
+   * @param[in] type property type to be passed
+   * @param[in] value value to be passed, if empty string is passed, do nothing
+   * but throws error when @a type is invalid
+   * @exception std::invalid_argument invalid argument
+   */
+  virtual void setProperty(const PropertyType type,
+                           const std::string &value = "");
 
 private:
   /**

--- a/nntrainer/include/loss_layer.h
+++ b/nntrainer/include/loss_layer.h
@@ -78,14 +78,6 @@ public:
   void save(std::ofstream &file) {}
 
   /**
-   * @brief     set Property of layer
-   * @param[in] values values of property
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setProperty(std::vector<std::string> values);
-
-  /**
    * @brief     copy layer
    * @param[in] l layer to copy
    */
@@ -105,7 +97,19 @@ public:
    */
   std::string getBaseName() { return "Loss"; };
 
+  using Layer::setProperty;
+
 private:
+  /**
+   * @brief setProperty by PropertyType
+   * @note By passing empty string, this can validate if @a type is valid
+   * @param[in] type property type to be passed
+   * @param[in] value value to be passed, if empty string is passed, do nothing
+   * but throws error when @a type is invalid
+   * @exception std::invalid_argument invalid argument
+   */
+  void setProperty(const PropertyType type, const std::string &value = "");
+
   /**
    * @brief     update loss
    * @param[in] l Tensor data to calculate

--- a/nntrainer/include/parse_util.h
+++ b/nntrainer/include/parse_util.h
@@ -63,6 +63,23 @@ typedef enum {
   TOKEN_UNKNOWN
 } InputType;
 
+inline void throw_status(int status) {
+  switch (status) {
+  case ML_ERROR_NONE:
+    break;
+  case ML_ERROR_INVALID_PARAMETER:
+    throw std::invalid_argument("invalid argument from c style throw");
+  case ML_ERROR_OUT_OF_MEMORY:
+    throw std::bad_alloc();
+  case ML_ERROR_TIMED_OUT:
+    throw std::runtime_error("Timed out from c style throw");
+  case ML_ERROR_PERMISSION_DENIED:
+    throw std::runtime_error("permission denied from c style throw");
+  case ML_ERROR_UNKNOWN:
+  default:
+    throw std::runtime_error("unknown error from c style throw");
+  }
+}
 /**
  * @brief     Parsing Layer Property
  * @param[in] property string to be parsed

--- a/nntrainer/include/pooling2d_layer.h
+++ b/nntrainer/include/pooling2d_layer.h
@@ -109,14 +109,6 @@ public:
   void copy(std::shared_ptr<Layer> l);
 
   /**
-   * @brief     set Property of layer
-   * @param[in] values values of property
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setProperty(std::vector<std::string> values);
-
-  /**
    * @brief     set Pooling Type
    * @param[in] t pooling type
    */
@@ -145,7 +137,19 @@ public:
    */
   std::string getBaseName() { return "Pooling2D"; };
 
+  using Layer::setProperty;
+
 private:
+  /**
+   * @brief setProperty by PropertyType
+   * @note By passing empty string, this can validate if @a type is valid
+   * @param[in] type property type to be passed
+   * @param[in] value value to be passed, if empty string is passed, do nothing
+   * but throws error when @a type is invalid
+   * @exception std::invalid_argument invalid argument
+   */
+  void setProperty(const PropertyType type, const std::string &value);
+
   unsigned int pooling_size[POOLING2D_DIM];
   unsigned int stride[POOLING2D_DIM];
   unsigned int padding[POOLING2D_DIM];

--- a/nntrainer/src/activation_layer.cpp
+++ b/nntrainer/src/activation_layer.cpp
@@ -128,14 +128,4 @@ void ActivationLayer::setActivation(ActiType acti_type) {
   this->activation_type = acti_type;
 }
 
-/**
- * @brief     set Property of layer
- * @param[in] values values of property
- * @retval #ML_ERROR_NONE Successful.
- * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
- */
-int ActivationLayer::setProperty(std::vector<std::string> values) {
-  return Layer::setProperty(values);
-}
-
 }; // namespace nntrainer

--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -68,28 +68,20 @@ int BatchNormalizationLayer::setOptimizer(Optimizer &opt) {
   return this->opt.initialize(dim, false);
 }
 
-int BatchNormalizationLayer::setProperty(std::vector<std::string> values) {
+void BatchNormalizationLayer::setProperty(const PropertyType type,
+                                          const std::string &value) {
   int status = ML_ERROR_NONE;
-
-  for (unsigned int i = 0; i < values.size(); ++i) {
-    std::string key;
-    std::string value;
-    status = getKeyValue(values[i], key, value);
-    NN_RETURN_STATUS();
-
-    unsigned int type = parseLayerProperty(key);
-    switch (static_cast<PropertyType>(type)) {
-    case PropertyType::epsilon:
+  switch (type) {
+  case PropertyType::epsilon:
+    if (!value.empty()) {
       status = setFloat(epsilon, value);
-      NN_RETURN_STATUS();
-      break;
-    default:
-      status = Layer::setProperty({values[i]});
-      NN_RETURN_STATUS();
-      break;
+      throw_status(status);
     }
+    break;
+  default:
+    Layer::setProperty(type, value);
+    break;
   }
-  return status;
 }
 
 Tensor BatchNormalizationLayer::forwarding(Tensor in, int &status) {
@@ -180,4 +172,5 @@ void BatchNormalizationLayer::copy(std::shared_ptr<Layer> l) {
   this->hidden.copy(from->hidden);
   this->cvar.copy(from->cvar);
 }
+
 } /* namespace nntrainer */

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -287,60 +287,60 @@ int Conv2DLayer::setFilter(int f) {
   return status;
 }
 
-int Conv2DLayer::setProperty(std::vector<std::string> values) {
+void Conv2DLayer::setProperty(const PropertyType type,
+                              const std::string &value) {
   int status = ML_ERROR_NONE;
 
-  for (unsigned int i = 0; i < values.size(); ++i) {
-    std::string key;
-    std::string value;
-
-    status = getKeyValue(values[i], key, value);
-    NN_RETURN_STATUS();
-
-    unsigned int t = parseLayerProperty(key);
-
-    switch (static_cast<PropertyType>(t)) {
-    case PropertyType::filter: {
+  switch (type) {
+  case PropertyType::filter: {
+    if (!value.empty()) {
       int size;
       status = setInt(size, value);
-      NN_RETURN_STATUS();
+      throw_status(status);
       filter_size = size;
-    } break;
-    case PropertyType::kernel_size:
-      status = getValues(CONV2D_DIM, value, (int *)(kernel_size));
-      NN_RETURN_STATUS();
-      if (kernel_size[0] == 0 || kernel_size[1] == 0) {
-        ml_loge("Error: kernel_size must be greater than 0");
-        return ML_ERROR_INVALID_PARAMETER;
-      }
-      break;
-    case PropertyType::stride:
-      status = getValues(CONV2D_DIM, value, (int *)(stride));
-      NN_RETURN_STATUS();
-      if (stride[0] == 0 || stride[1] == 0) {
-        ml_loge("Error: stride must be greater than 0");
-        return ML_ERROR_INVALID_PARAMETER;
-      }
-      break;
-    case PropertyType::padding:
-      status = getValues(CONV2D_DIM, value, (int *)(padding));
-      NN_RETURN_STATUS();
-      break;
-    case PropertyType::normalization:
-      status = setBoolean(normalization, value);
-      NN_RETURN_STATUS();
-      break;
-    case PropertyType::standardization:
-      status = setBoolean(standardization, value);
-      NN_RETURN_STATUS();
-      break;
-    default:
-      status = Layer::setProperty({values[i]});
-      NN_RETURN_STATUS();
-      break;
     }
+  } break;
+  case PropertyType::kernel_size:
+    if (!value.empty()) {
+      status = getValues(CONV2D_DIM, value, (int *)(kernel_size));
+      throw_status(status);
+      if (kernel_size[0] == 0 || kernel_size[1] == 0) {
+        throw std::out_of_range(
+          "[Conv2DLayer] kernel_size must be greater than 0");
+      }
+    }
+    break;
+  case PropertyType::stride:
+    if (!value.empty()) {
+      status = getValues(CONV2D_DIM, value, (int *)(stride));
+      throw_status(status);
+      if (stride[0] == 0 || stride[1] == 0) {
+        throw std::out_of_range("[Conv2DLayer] stride must be greater than 0");
+      }
+    }
+    break;
+  case PropertyType::padding:
+    if (!value.empty()) {
+      status = getValues(CONV2D_DIM, value, (int *)(padding));
+      throw_status(status);
+    }
+    break;
+  case PropertyType::normalization:
+    if (!value.empty()) {
+      status = setBoolean(normalization, value);
+      throw_status(status);
+    }
+    break;
+  case PropertyType::standardization:
+    if (!value.empty()) {
+      status = setBoolean(standardization, value);
+      throw_status(status);
+    }
+    break;
+  default:
+    Layer::setProperty(type, value);
+    break;
   }
-  return status;
 }
 
 int Conv2DLayer::conv2d(float *in, TensorDim indim, float *kernel,

--- a/nntrainer/src/fc_layer.cpp
+++ b/nntrainer/src/fc_layer.cpp
@@ -62,33 +62,23 @@ int FullyConnectedLayer::initialize(bool last) {
   return status;
 }
 
-int FullyConnectedLayer::setProperty(std::vector<std::string> values) {
+void FullyConnectedLayer::setProperty(const PropertyType type,
+                                      const std::string &value) {
   int status = ML_ERROR_NONE;
-
-  for (unsigned int i = 0; i < values.size(); ++i) {
-    std::string key;
-    std::string value;
-
-    status = getKeyValue(values[i], key, value);
-    NN_RETURN_STATUS();
-
-    unsigned int type = parseLayerProperty(key);
-
-    switch (static_cast<PropertyType>(type)) {
-    case PropertyType::unit: {
+  switch (type) {
+  case PropertyType::unit: {
+    if (!value.empty()) {
       int width;
       status = setInt(width, value);
-      NN_RETURN_STATUS();
+      throw_status(status);
       unit = width;
       output_dim.width(unit);
-    } break;
-    default:
-      status = Layer::setProperty({values[i]});
-      NN_RETURN_STATUS();
-      break;
     }
+  } break;
+  default:
+    Layer::setProperty(type, value);
+    break;
   }
-  return status;
 }
 
 int FullyConnectedLayer::setOptimizer(Optimizer &opt) {

--- a/nntrainer/src/flatten_layer.cpp
+++ b/nntrainer/src/flatten_layer.cpp
@@ -57,9 +57,10 @@ Tensor FlattenLayer::backwarding(Tensor in, int iteration) {
   return ret;
 }
 
-int FlattenLayer::setProperty(std::vector<std::string> values) {
-  return ML_ERROR_NOT_SUPPORTED;
-};
+void FlattenLayer::setProperty(const PropertyType type,
+                               const std::string &value) {
+  throw std::invalid_argument("[Flatten Layer] setProperty not supported");
+}
 
 void FlattenLayer::copy(std::shared_ptr<Layer> l) {
   std::shared_ptr<FlattenLayer> from =

--- a/nntrainer/src/input_layer.cpp
+++ b/nntrainer/src/input_layer.cpp
@@ -35,33 +35,27 @@ int InputLayer::setOptimizer(Optimizer &opt) {
   return this->opt.initialize(dim, false);
 }
 
-int InputLayer::setProperty(std::vector<std::string> values) {
+void InputLayer::setProperty(const PropertyType type,
+                             const std::string &value) {
   int status = ML_ERROR_NONE;
-  for (unsigned int i = 0; i < values.size(); ++i) {
-    std::string key;
-    std::string value;
 
-    status = getKeyValue(values[i], key, value);
-    NN_RETURN_STATUS();
-
-    unsigned int type = parseLayerProperty(key.c_str());
-
-    switch (static_cast<PropertyType>(type)) {
-    case PropertyType::normalization:
+  switch (type) {
+  case PropertyType::normalization:
+    if (!value.empty()) {
       status = setBoolean(normalization, value);
-      NN_RETURN_STATUS();
-      break;
-    case PropertyType::standardization:
-      status = setBoolean(standardization, value);
-      NN_RETURN_STATUS();
-      break;
-    default:
-      status = Layer::setProperty({values[i]});
-      NN_RETURN_STATUS();
-      break;
+      throw_status(status);
     }
+    break;
+  case PropertyType::standardization:
+    if (!value.empty()) {
+      status = setBoolean(standardization, value);
+      throw_status(status);
+    }
+    break;
+  default:
+    Layer::setProperty(type, value);
+    break;
   }
-  return status;
 }
 
 void InputLayer::copy(std::shared_ptr<Layer> l) {

--- a/nntrainer/src/loss_layer.cpp
+++ b/nntrainer/src/loss_layer.cpp
@@ -156,7 +156,8 @@ Tensor LossLayer::forwarding(Tensor in, int &status) {
   return in;
 }
 
-int LossLayer::setProperty(std::vector<std::string> values) {
-  return ML_ERROR_NOT_SUPPORTED;
+void LossLayer::setProperty(const PropertyType type, const std::string &value) {
+  throw std::invalid_argument("[Loss Layer] setProperty not supported");
 }
+
 } /* namespace nntrainer */

--- a/nntrainer/src/pooling2d_layer.cpp
+++ b/nntrainer/src/pooling2d_layer.cpp
@@ -181,55 +181,53 @@ void Pooling2DLayer::copy(std::shared_ptr<Layer> l) {
   this->last_layer = from->last_layer;
 }
 
-int Pooling2DLayer::setProperty(std::vector<std::string> values) {
+void Pooling2DLayer::setProperty(const PropertyType type,
+                                 const std::string &value) {
   int status = ML_ERROR_NONE;
 
-  for (unsigned int i = 0; i < values.size(); ++i) {
-    std::string key;
-    std::string value;
-
-    status = getKeyValue(values[i], key, value);
-    NN_RETURN_STATUS();
-    unsigned int t = parseLayerProperty(key);
-    switch (static_cast<PropertyType>(t)) {
-    case PropertyType::pooling:
+  switch (type) {
+  case PropertyType::pooling:
+    if (!value.empty()) {
       pooling_type = (PoolingType)parseType(value, TOKEN_POOLING);
       if (pooling_type == PoolingType::unknown) {
-        ml_loge("Error: Unknown pooling type");
-        return ML_ERROR_INVALID_PARAMETER;
+        throw std::invalid_argument("[Pooling2d_layer]: Unknown pooling type");
       }
-      break;
-    case PropertyType::pooling_size:
-      status = getValues(POOLING2D_DIM, value, (int *)(pooling_size));
-      NN_RETURN_STATUS();
-      if (pooling_size[0] == 0 || pooling_size[1] == 0) {
-        ml_loge("Error: pooling_size must be greater than 0");
-        return ML_ERROR_INVALID_PARAMETER;
-      }
-      break;
-    case PropertyType::stride:
-      status = getValues(POOLING2D_DIM, value, (int *)(stride));
-      NN_RETURN_STATUS();
-      if (stride[0] == 0 || stride[1] == 0) {
-        ml_loge("Error: stride must be greater than 0");
-        return ML_ERROR_INVALID_PARAMETER;
-      }
-      break;
-    case PropertyType::padding:
-      status = getValues(POOLING2D_DIM, value, (int *)(padding));
-      NN_RETURN_STATUS();
-      if ((int)padding[0] < 0 || (int)padding[1] < 0) {
-        ml_loge("Error: padding must be greater than 0");
-        return ML_ERROR_INVALID_PARAMETER;
-      }
-      break;
-    default:
-      ml_loge("Error: Unknown Layer Property Key : %s", key.c_str());
-      status = ML_ERROR_INVALID_PARAMETER;
       break;
     }
+  case PropertyType::pooling_size:
+    if (!value.empty()) {
+      status = getValues(POOLING2D_DIM, value, (int *)(pooling_size));
+      throw_status(status);
+      if (pooling_size[0] == 0 || pooling_size[1] == 0) {
+        throw std::invalid_argument(
+          "[Pooling2d_layer] pooling_size must be greater than 0");
+      }
+    }
+    break;
+  case PropertyType::stride:
+    if (!value.empty()) {
+      status = getValues(POOLING2D_DIM, value, (int *)(stride));
+      throw_status(status);
+      if (stride[0] == 0 || stride[1] == 0) {
+        throw std::invalid_argument(
+          "[Pooling2d_layer] stride must be greater than 0");
+      }
+    }
+    break;
+  case PropertyType::padding:
+    if (!value.empty()) {
+      status = getValues(POOLING2D_DIM, value, (int *)(padding));
+      throw_status(status);
+      if ((int)padding[0] < 0 || (int)padding[1] < 0) {
+        throw std::invalid_argument(
+          "[Pooling2d_layer] padding must be greater than 0");
+      }
+    }
+    break;
+  default:
+    Layer::setProperty(type, value);
+    break;
   }
-  return status;
 }
 
 Tensor Pooling2DLayer::pooling2d(unsigned int batch, Tensor in, int &status) {

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -768,9 +768,15 @@ protected:
   }
 };
 
-TEST_F(nntrainer_Pooling2DLayer, setPeoperty_01_p) {
+TEST_F(nntrainer_Pooling2DLayer, setProperty_01_p) {
   setInputDim("2:3:5:5");
   setProperty("pooling_size=2,2 | stride=1,1 | padding=0,0 | pooling=average");
+}
+
+TEST_F(nntrainer_Pooling2DLayer, setProperty_02_n) {
+  setInputDim("2:3:5:5");
+  int status = layer.setProperty({"pooling_size="});
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
 TEST_F(nntrainer_Pooling2DLayer, initialize_01_p) { reinitialize(); }
@@ -1031,6 +1037,16 @@ TEST(nntrainer_LossLayer, setCost_02_n) {
   int status = ML_ERROR_NONE;
   nntrainer::LossLayer layer;
   status = layer.setCost(nntrainer::COST_UNKNOWN);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+/**
+ * @brief Loss Layer
+ */
+TEST(nntrainer_LossLayer, setProperty_01_n) {
+  int status = ML_ERROR_NONE;
+  nntrainer::LossLayer layer;
+  status = layer.setProperty({"loss=cross"});
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 


### PR DESCRIPTION
Since Layer::setProperty is iterating through vectors, only part that
needs overriding is setting each particular property.

This PR add setProperty by type to relieve the issue.

w.r.t #270, this patch enables layers to check if given property type
 is valid.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>