### PR TITLE
[API] Update API namespace and use enum for opitmizer

### DIFF
--- a/Applications/Tizen_CAPI/capi_file.c
+++ b/Applications/Tizen_CAPI/capi_file.c
@@ -39,58 +39,58 @@ int main(int argc, char *argv[]) {
   int status = ML_ERROR_NONE;
 
   /* handlers for model, layers & optimizer */
-  ml_nnmodel_h model;
-  ml_nnlayer_h layers[2];
-  ml_nnopt_h optimizer;
+  ml_train_model_h model;
+  ml_train_layer_h layers[2];
+  ml_train_optimizer_h optimizer;
 
   /* model create */
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   NN_RETURN_STATUS();
   /* input layer create */
-  status = ml_nnlayer_create(&layers[0], ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&layers[0], ML_TRAIN_LAYER_TYPE_INPUT);
   NN_RETURN_STATUS();
 
   /* set property for input layer */
-  status =
-    ml_nnlayer_set_property(layers[0], "input_shape= 32:1:1:62720",
-                            "normalization=true", "bias_init_zero=true", NULL);
+  status = ml_train_layer_set_property(layers[0], "input_shape= 32:1:1:62720",
+                                       "normalization=true",
+                                       "bias_init_zero=true", NULL);
   NN_RETURN_STATUS();
 
   /* add input layer into model */
-  status = ml_nnmodel_add_layer(model, layers[0]);
+  status = ml_train_model_add_layer(model, layers[0]);
   NN_RETURN_STATUS();
 
   /* create fully connected layer */
-  status = ml_nnlayer_create(&layers[1], ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&layers[1], ML_TRAIN_LAYER_TYPE_FC);
   NN_RETURN_STATUS();
 
   /* set property for fc layer */
-  status = ml_nnlayer_set_property(layers[1], "unit= 10", "activation=softmax",
-                                   "bias_init_zero=true", "weight_decay=l2norm",
-                                   "weight_decay_lambda=0.005",
-                                   "weight_ini=xavier_uniform", NULL);
+  status = ml_train_layer_set_property(
+    layers[1], "unit= 10", "activation=softmax", "bias_init_zero=true",
+    "weight_decay=l2norm", "weight_decay_lambda=0.005",
+    "weight_ini=xavier_uniform", NULL);
   NN_RETURN_STATUS();
 
   /* add fc layer into model */
-  status = ml_nnmodel_add_layer(model, layers[1]);
+  status = ml_train_model_add_layer(model, layers[1]);
   NN_RETURN_STATUS();
 
   /* create optimizer */
-  status = ml_nnoptimizer_create(&optimizer, "adam");
+  status = ml_train_optimizer_create(&optimizer, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   NN_RETURN_STATUS();
 
   /* set property for optimizer */
-  status = ml_nnoptimizer_set_property(
+  status = ml_train_optimizer_set_property(
     optimizer, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
     "beta1=0.9", "beta2=0.9999", "epsilon=1e-7", NULL);
   NN_RETURN_STATUS();
 
   /* set optimizer */
-  status = ml_nnmodel_set_optimizer(model, optimizer);
+  status = ml_train_model_set_optimizer(model, optimizer);
   NN_RETURN_STATUS();
 
   /* compile model with cross entropy loss function */
-  status = ml_nnmodel_compile(model, "loss=cross", NULL);
+  status = ml_train_model_compile(model, "loss=cross", NULL);
   NN_RETURN_STATUS();
 
   /* train model with data files : epochs = 10 and store model file named
@@ -102,7 +102,7 @@ int main(int argc, char *argv[]) {
   NN_RETURN_STATUS();
 
   /* delete model */
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   NN_RETURN_STATUS();
   return 0;
 }

--- a/Applications/Tizen_CAPI/capi_func.c
+++ b/Applications/Tizen_CAPI/capi_func.c
@@ -263,58 +263,58 @@ int main(int argc, char *argv[]) {
   int status = ML_ERROR_NONE;
 
   /* handlers for model, layers & optimizer */
-  ml_nnmodel_h model;
-  ml_nnlayer_h layers[2];
-  ml_nnopt_h optimizer;
+  ml_train_model_h model;
+  ml_train_layer_h layers[2];
+  ml_train_optimizer_h optimizer;
 
   /* model create */
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   NN_RETURN_STATUS();
   /* input layer create */
-  status = ml_nnlayer_create(&layers[0], ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&layers[0], ML_TRAIN_LAYER_TYPE_INPUT);
   NN_RETURN_STATUS();
 
   /* set property for input layer */
-  status =
-    ml_nnlayer_set_property(layers[0], "input_shape= 32:1:1:62720",
-                            "normalization=true", "bias_init_zero=true", NULL);
+  status = ml_train_layer_set_property(layers[0], "input_shape= 32:1:1:62720",
+                                       "normalization=true",
+                                       "bias_init_zero=true", NULL);
   NN_RETURN_STATUS();
 
   /* add input layer into model */
-  status = ml_nnmodel_add_layer(model, layers[0]);
+  status = ml_train_model_add_layer(model, layers[0]);
   NN_RETURN_STATUS();
 
   /* create fully connected layer */
-  status = ml_nnlayer_create(&layers[1], ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&layers[1], ML_TRAIN_LAYER_TYPE_FC);
   NN_RETURN_STATUS();
 
   /* set property for fc layer */
-  status = ml_nnlayer_set_property(layers[1], "unit= 10", "activation=softmax",
-                                   "bias_init_zero=true", "weight_decay=l2norm",
-                                   "weight_decay_lambda=0.005",
-                                   "weight_ini=xavier_uniform", NULL);
+  status = ml_train_layer_set_property(
+    layers[1], "unit= 10", "activation=softmax", "bias_init_zero=true",
+    "weight_decay=l2norm", "weight_decay_lambda=0.005",
+    "weight_ini=xavier_uniform", NULL);
   NN_RETURN_STATUS();
 
   /* add fc layer into model */
-  status = ml_nnmodel_add_layer(model, layers[1]);
+  status = ml_train_model_add_layer(model, layers[1]);
   NN_RETURN_STATUS();
 
   /* create optimizer */
-  status = ml_nnoptimizer_create(&optimizer, "adam");
+  status = ml_train_optimizer_create(&optimizer, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   NN_RETURN_STATUS();
 
   /* set property for optimizer */
-  status = ml_nnoptimizer_set_property(
+  status = ml_train_optimizer_set_property(
     optimizer, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
     "beta1=0.9", "beta2=0.9999", "epsilon=1e-7", NULL);
   NN_RETURN_STATUS();
 
   /* set optimizer */
-  status = ml_nnmodel_set_optimizer(model, optimizer);
+  status = ml_train_model_set_optimizer(model, optimizer);
   NN_RETURN_STATUS();
 
   /* compile model with cross entropy loss function */
-  status = ml_nnmodel_compile(model, "loss=cross", NULL);
+  status = ml_train_model_compile(model, "loss=cross", NULL);
   NN_RETURN_STATUS();
 
   /* train model with data files : epochs = 10 and store model file named
@@ -325,7 +325,7 @@ int main(int argc, char *argv[]) {
   NN_RETURN_STATUS();
 
   /* delete model */
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   NN_RETURN_STATUS();
   return 0;
 }

--- a/Applications/Tizen_CAPI/main.c
+++ b/Applications/Tizen_CAPI/main.c
@@ -27,18 +27,18 @@
 
 int main(int argc, char *argv[]) {
   int status = ML_ERROR_NONE;
-  ml_nnmodel_h handle = NULL;
+  ml_train_model_h handle = NULL;
   const char *config_file = "./Tizen_CAPI_config.ini";
-  status = ml_nnmodel_construct_with_conf(config_file, &handle);
+  status = ml_train_model_construct_with_conf(config_file, &handle);
   if (status != ML_ERROR_NONE)
     return status;
-  status = ml_nnmodel_compile(handle, NULL);
+  status = ml_train_model_compile(handle, NULL);
   if (status != ML_ERROR_NONE)
     return status;
   status = ml_nnmodel_train_with_file(handle, NULL);
   if (status != ML_ERROR_NONE)
     return status;
-  status = ml_nnmodel_destruct(handle);
+  status = ml_train_model_destroy(handle);
   if (status != ML_ERROR_NONE)
     return status;
   return status;

--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -41,29 +41,39 @@ extern "C" {
  * @brief A handle of an NNTrainer model.
  * @since_tizen 6.x
  */
-typedef void *ml_nnmodel_h;
+typedef void *ml_train_model_h;
 
 /**
  * @brief A handle of an NNTrainer layer.
  * @since_tizen 6.x
  */
-typedef void *ml_nnlayer_h;
+typedef void *ml_train_layer_h;
 
 /**
  * @brief A handle of an NNTrainer optimizer.
  * @since_tizen 6.x
  */
-typedef void *ml_nnopt_h;
+typedef void *ml_train_optimizer_h;
 
 /**
  * @brief Enumeration for the neural network layer type of NNTrainer.
  * @since_tizen 6.x
  */
 typedef enum {
-  ML_LAYER_TYPE_INPUT = 0, /**< Input Layer */
-  ML_LAYER_TYPE_FC,        /**< Fully Connected Layer */
-  ML_LAYER_TYPE_UNKNOWN    /**< Unknown Lyaer */
-} ml_layer_type_e;
+  ML_TRAIN_LAYER_TYPE_INPUT = 0,    /**< Input Layer */
+  ML_TRAIN_LAYER_TYPE_FC,           /**< Fully Connected Layer */
+  ML_TRAIN_LAYER_TYPE_UNKNOWN = 999 /**< Unknown Layer */
+} ml_train_layer_type_e;
+
+/**
+ * @brief Enumeration for the neural network optimizer type of NNTrainer.
+ * @since_tizen 6.x
+ */
+typedef enum {
+  ML_TRAIN_OPTIMIZER_TYPE_ADAM = 0, /**< Adam Optimizer */
+  ML_TRAIN_OPTIMIZER_TYPE_SGD, /**< Stochastic Gradient Descent Optimizer */
+  ML_TRAIN_OPTIMIZER_TYPE_UNKNOWN = 999 /**< Unknown Optimizer */
+} ml_train_optimizer_type_e;
 
 /**
  * @brief Constructs the neural network model.
@@ -74,7 +84,7 @@ typedef enum {
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_CANNOT_ASSIGN_ADDRESS Cannot assign object.
  */
-int ml_nnmodel_construct(ml_nnmodel_h *model);
+int ml_train_model_construct(ml_train_model_h *model);
 
 /**
  * @brief Construct the neural network model with the given configuration file.
@@ -87,7 +97,8 @@ int ml_nnmodel_construct(ml_nnmodel_h *model);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
-int ml_nnmodel_construct_with_conf(const char *model_conf, ml_nnmodel_h *model);
+int ml_train_model_construct_with_conf(const char *model_conf,
+                                       ml_train_model_h *model);
 
 /**
  * @brief initialize the neural network model.
@@ -96,12 +107,13 @@ int ml_nnmodel_construct_with_conf(const char *model_conf, ml_nnmodel_h *model);
  * added layers is restricted.
  * @since_tizen 6.x
  * @param[in] model The NNTrainer model handler from the given description.
+ * @param[in] type The NNTrainer loss type.
  * @param[in] ... hyper parmeter for compile model
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
-int ml_nnmodel_compile(ml_nnmodel_h model, ...);
+int ml_train_model_compile(ml_train_model_h model, ...);
 
 /**
  * @brief train the neural network model.
@@ -113,7 +125,7 @@ int ml_nnmodel_compile(ml_nnmodel_h model, ...);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
-int ml_nnmodel_train_with_file(ml_nnmodel_h model, ...);
+int ml_nnmodel_train_with_file(ml_train_model_h model, ...);
 
 /**
  * @brief train the neural network model.
@@ -128,7 +140,7 @@ int ml_nnmodel_train_with_file(ml_nnmodel_h model, ...);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
-int ml_nnmodel_train_with_generator(ml_nnmodel_h model,
+int ml_nnmodel_train_with_generator(ml_train_model_h model,
                                     bool (*train_func)(float *, float *, int *),
                                     bool (*val_func)(float *, float *, int *),
                                     bool (*test_func)(float *, float *, int *),
@@ -136,19 +148,19 @@ int ml_nnmodel_train_with_generator(ml_nnmodel_h model,
 
 /**
  * @brief Destructs the neural network model.
- * @details Use this function to delete Neural Network Model.
+ * @details Use this function to destroy Neural Network Model.
  * @since_tizen 6.x
  * @param[in] model The NNTrainer model handler from the given description.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
-int ml_nnmodel_destruct(ml_nnmodel_h model);
+int ml_train_model_destroy(ml_train_model_h model);
 
 /**
  * @brief Add layer at the last of the existing layers in neural network model.
  * @details Use this function to add a layer to the model. This transfers the
- * ownership of the layer to the network. No need to delete the layer if it
+ * ownership of the layer to the network. No need to destroy the layer if it
  * belongs to a model.
  * @since_tizen 6.x
  * @param[in] model The NNTrainer model handler from the given description.
@@ -157,13 +169,13 @@ int ml_nnmodel_destruct(ml_nnmodel_h model);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
-int ml_nnmodel_add_layer(ml_nnmodel_h model, ml_nnlayer_h layer);
+int ml_train_model_add_layer(ml_train_model_h model, ml_train_layer_h layer);
 
 /**
  * @brief Set the neural network optimizer.
  * @details Use this function to set Neural Network Optimizer. Unsets the
  * previous optimizer if any. This transfers the ownership of the optimizer to
- * the network. No need to delete the optimizer if it is to a model.
+ * the network. No need to destroy the optimizer if it is to a model.
  * @since_tizen 6.x
  * @param[in] model The NNTrainer model handler from the given description.
  * @param[in] optimizer The NNTrainer Optimizer handler
@@ -171,7 +183,8 @@ int ml_nnmodel_add_layer(ml_nnmodel_h model, ml_nnlayer_h layer);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
-int ml_nnmodel_set_optimizer(ml_nnmodel_h model, ml_nnopt_h optimizer);
+int ml_train_model_set_optimizer(ml_train_model_h model,
+                                 ml_train_optimizer_h optimizer);
 
 /**
  * @brief Create the neural network layer.
@@ -184,11 +197,11 @@ int ml_nnmodel_set_optimizer(ml_nnmodel_h model, ml_nnopt_h optimizer);
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
  * @retval #ML_ERROR_CANNOT_ASSIGN_ADDRESS Cannot assign object.
  */
-int ml_nnlayer_create(ml_nnlayer_h *layer, ml_layer_type_e type);
+int ml_train_layer_create(ml_train_layer_h *layer, ml_train_layer_type_e type);
 
 /**
- * @brief Delete the neural network layer.
- * @details Use this function to delete Neural Network Layer. Fails if layer is
+ * @brief destroy the neural network layer.
+ * @details Use this function to destroy Neural Network Layer. Fails if layer is
  * owned by a model.
  * @since_tizen 6.x
  * @param[in] layer The NNTrainer layer handler from the given description.
@@ -196,7 +209,7 @@ int ml_nnlayer_create(ml_nnlayer_h *layer, ml_layer_type_e type);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
-int ml_nnlayer_delete(ml_nnlayer_h layer);
+int ml_train_layer_destroy(ml_train_layer_h layer);
 
 /**
  * @brief Set the neural network layer Property.
@@ -208,7 +221,7 @@ int ml_nnlayer_delete(ml_nnlayer_h layer);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
  */
-int ml_nnlayer_set_property(ml_nnlayer_h layer, ...);
+int ml_train_layer_set_property(ml_train_layer_h layer, ...);
 
 /**
  * @brief Create the neural network optimizer.
@@ -220,11 +233,12 @@ int ml_nnlayer_set_property(ml_nnlayer_h layer, ...);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
-int ml_nnoptimizer_create(ml_nnopt_h *optimizer, const char *type);
+int ml_train_optimizer_create(ml_train_optimizer_h *optimizer,
+                              ml_train_optimizer_type_e type);
 
 /**
- * @brief Delete the neural network optimizer.
- * @details Use this function to delete Neural Netowrk Optimizer. Fails if
+ * @brief destroy the neural network optimizer.
+ * @details Use this function to destroy Neural Netowrk Optimizer. Fails if
  * optimizer is owned by a model.
  * @since_tizen 6.x
  * @param[in] optimizer The NNTrainer optimizer handler from the given
@@ -233,7 +247,7 @@ int ml_nnoptimizer_create(ml_nnopt_h *optimizer, const char *type);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
-int ml_nnoptimizer_delete(ml_nnopt_h optimizer);
+int ml_train_optimizer_destroy(ml_train_optimizer_h optimizer);
 
 /**
  * @brief Set the neural network optimizer property.
@@ -246,7 +260,7 @@ int ml_nnoptimizer_delete(ml_nnopt_h optimizer);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
  */
-int ml_nnoptimizer_set_property(ml_nnopt_h optimizer, ...);
+int ml_train_optimizer_set_property(ml_train_optimizer_h optimizer, ...);
 
 /**
  * @}

--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -27,6 +27,7 @@
 #include <layer.h>
 #include <neuralnet.h>
 #include <nntrainer.h>
+#include <nntrainer_log.h>
 #include <optimizer.h>
 #include <string>
 #include <unordered_map>
@@ -108,11 +109,19 @@ typedef struct {
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
  * @retval #ML_ERROR_CANNOT_ASSIGN_ADDRESS Cannot assign object.
  */
-int ml_nnmodel_get_layer(ml_nnmodel_h model, const char *layer_name,
-                         ml_nnlayer_h *layer);
+int ml_train_model_get_layer(ml_train_model_h model, const char *layer_name,
+                             ml_train_layer_h *layer);
 
 #ifdef __cplusplus
 }
-
 #endif /* __cplusplus */
+
+/**
+ * @brief Convert nntrainer API optimizer type to neural network optimizer type
+ * @param[in] type Optimizer type API enum
+ * @return nntrainer::OptType optimizer type
+ */
+nntrainer::OptType
+ml_optimizer_to_nntrainer_type(ml_train_optimizer_type_e type);
+
 #endif

--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -10,6 +10,7 @@ endif
 
 capi_src = []
 capi_src += join_paths(meson.current_source_dir(), 'src','nntrainer.cpp')
+capi_src += join_paths(meson.current_source_dir(), 'src','nntrainer_util.cpp')
 
 capi_headers = []
 capi_headers += join_paths(meson.current_source_dir(), 'include', 'nntrainer.h')

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -67,7 +67,7 @@ typedef std::function<int()> returnable;
 /**
  * @brief Function to create Network::NeuralNetwork object.
  */
-static int nn_object(ml_nnmodel_h *model) {
+static int nn_object(ml_train_model_h *model) {
   int status = ML_ERROR_NONE;
 
   if (model == NULL)
@@ -90,7 +90,7 @@ static int nn_object(ml_nnmodel_h *model) {
   return status;
 }
 
-int ml_nnmodel_construct(ml_nnmodel_h *model) {
+int ml_train_model_construct(ml_train_model_h *model) {
   int status = ML_ERROR_NONE;
   returnable f = [&]() { return nn_object(model); };
 
@@ -98,8 +98,8 @@ int ml_nnmodel_construct(ml_nnmodel_h *model) {
   return status;
 }
 
-int ml_nnmodel_construct_with_conf(const char *model_conf,
-                                   ml_nnmodel_h *model) {
+int ml_train_model_construct_with_conf(const char *model_conf,
+                                       ml_train_model_h *model) {
   int status = ML_ERROR_NONE;
   ml_nnmodel *nnmodel;
   std::shared_ptr<nntrainer::NeuralNetwork> NN;
@@ -111,7 +111,7 @@ int ml_nnmodel_construct_with_conf(const char *model_conf,
     return ML_ERROR_INVALID_PARAMETER;
   }
 
-  status = ml_nnmodel_construct(model);
+  status = ml_train_model_construct(model);
   if (status != ML_ERROR_NONE)
     return status;
 
@@ -121,20 +121,20 @@ int ml_nnmodel_construct_with_conf(const char *model_conf,
   f = [&]() { return NN->setConfig(model_conf); };
   status = nntrainer_exception_boundary(f);
   if (status != ML_ERROR_NONE) {
-    ml_nnmodel_destruct(*model);
+    ml_train_model_destroy(*model);
     return status;
   }
 
   f = [&]() { return NN->loadFromConfig(); };
   status = nntrainer_exception_boundary(f);
   if (status != ML_ERROR_NONE) {
-    ml_nnmodel_destruct(*model);
+    ml_train_model_destroy(*model);
   }
 
   return status;
 }
 
-int ml_nnmodel_compile(ml_nnmodel_h model, ...) {
+int ml_train_model_compile(ml_train_model_h model, ...) {
   int status = ML_ERROR_NONE;
   const char *data;
   ml_nnmodel *nnmodel;
@@ -170,7 +170,7 @@ int ml_nnmodel_compile(ml_nnmodel_h model, ...) {
   return status;
 }
 
-int ml_nnmodel_train_with_file(ml_nnmodel_h model, ...) {
+int ml_nnmodel_train_with_file(ml_train_model_h model, ...) {
   int status = ML_ERROR_NONE;
   ml_nnmodel *nnmodel;
   const char *data;
@@ -194,7 +194,7 @@ int ml_nnmodel_train_with_file(ml_nnmodel_h model, ...) {
   return status;
 }
 
-int ml_nnmodel_train_with_generator(ml_nnmodel_h model,
+int ml_nnmodel_train_with_generator(ml_train_model_h model,
                                     bool (*train_func)(float *, float *, int *),
                                     bool (*val_func)(float *, float *, int *),
                                     bool (*test_func)(float *, float *, int *),
@@ -225,7 +225,7 @@ int ml_nnmodel_train_with_generator(ml_nnmodel_h model,
   return status;
 }
 
-int ml_nnmodel_destruct(ml_nnmodel_h model) {
+int ml_train_model_destroy(ml_train_model_h model) {
   int status = ML_ERROR_NONE;
   ml_nnmodel *nnmodel;
 
@@ -251,7 +251,7 @@ int ml_nnmodel_destruct(ml_nnmodel_h model) {
   return status;
 }
 
-int ml_nnmodel_add_layer(ml_nnmodel_h model, ml_nnlayer_h layer) {
+int ml_train_model_add_layer(ml_train_model_h model, ml_train_layer_h layer) {
   int status = ML_ERROR_NONE;
   ml_nnmodel *nnmodel;
   ml_nnlayer *nnlayer;
@@ -276,7 +276,8 @@ int ml_nnmodel_add_layer(ml_nnmodel_h model, ml_nnlayer_h layer) {
   return status;
 }
 
-int ml_nnmodel_set_optimizer(ml_nnmodel_h model, ml_nnopt_h optimizer) {
+int ml_train_model_set_optimizer(ml_train_model_h model,
+                                 ml_train_optimizer_h optimizer) {
   int status = ML_ERROR_NONE;
   ml_nnmodel *nnmodel;
   ml_nnopt *nnopt;
@@ -303,8 +304,8 @@ int ml_nnmodel_set_optimizer(ml_nnmodel_h model, ml_nnopt_h optimizer) {
   return status;
 }
 
-int ml_nnmodel_get_layer(ml_nnmodel_h model, const char *layer_name,
-                         ml_nnlayer_h *layer) {
+int ml_train_model_get_layer(ml_train_model_h model, const char *layer_name,
+                             ml_train_layer_h *layer) {
   int status = ML_ERROR_NONE;
   ml_nnmodel *nnmodel;
   ML_NNTRAINER_CHECK_MODEL_VALIDATION(nnmodel, model);
@@ -341,7 +342,7 @@ int ml_nnmodel_get_layer(ml_nnmodel_h model, const char *layer_name,
   return status;
 }
 
-int ml_nnlayer_create(ml_nnlayer_h *layer, ml_layer_type_e type) {
+int ml_train_layer_create(ml_train_layer_h *layer, ml_train_layer_type_e type) {
   int status = ML_ERROR_NONE;
   returnable f;
   ml_nnlayer *nnlayer = new ml_nnlayer;
@@ -349,10 +350,10 @@ int ml_nnlayer_create(ml_nnlayer_h *layer, ml_layer_type_e type) {
 
   try {
     switch (type) {
-    case ML_LAYER_TYPE_INPUT:
+    case ML_TRAIN_LAYER_TYPE_INPUT:
       nnlayer->layer = std::make_shared<nntrainer::InputLayer>();
       break;
-    case ML_LAYER_TYPE_FC:
+    case ML_TRAIN_LAYER_TYPE_FC:
       nnlayer->layer = std::make_shared<nntrainer::FullyConnectedLayer>();
       break;
     default:
@@ -372,7 +373,7 @@ int ml_nnlayer_create(ml_nnlayer_h *layer, ml_layer_type_e type) {
   return status;
 }
 
-int ml_nnlayer_delete(ml_nnlayer_h layer) {
+int ml_train_layer_destroy(ml_train_layer_h layer) {
   int status = ML_ERROR_NONE;
   ml_nnlayer *nnlayer;
 
@@ -389,7 +390,7 @@ int ml_nnlayer_delete(ml_nnlayer_h layer) {
   return status;
 }
 
-int ml_nnlayer_set_property(ml_nnlayer_h layer, ...) {
+int ml_train_layer_set_property(ml_train_layer_h layer, ...) {
   int status = ML_ERROR_NONE;
   ml_nnlayer *nnlayer;
   const char *data;
@@ -415,7 +416,8 @@ int ml_nnlayer_set_property(ml_nnlayer_h layer, ...) {
   return status;
 }
 
-int ml_nnoptimizer_create(ml_nnopt_h *optimizer, const char *type) {
+int ml_train_optimizer_create(ml_train_optimizer_h *optimizer,
+                              ml_train_optimizer_type_e type) {
   int status = ML_ERROR_NONE;
 
   ml_nnopt *nnopt = new ml_nnopt;
@@ -426,8 +428,7 @@ int ml_nnoptimizer_create(ml_nnopt_h *optimizer, const char *type) {
   *optimizer = nnopt;
 
   returnable f = [&]() {
-    return nnopt->optimizer->setType(
-      (nntrainer::OptType)parseType(type, nntrainer::TOKEN_OPT));
+    return nnopt->optimizer->setType(ml_optimizer_to_nntrainer_type(type));
   };
   status = nntrainer_exception_boundary(f);
 
@@ -438,7 +439,7 @@ int ml_nnoptimizer_create(ml_nnopt_h *optimizer, const char *type) {
   return status;
 }
 
-int ml_nnoptimizer_delete(ml_nnopt_h optimizer) {
+int ml_train_optimizer_destroy(ml_train_optimizer_h optimizer) {
   int status = ML_ERROR_NONE;
   ml_nnopt *nnopt;
 
@@ -454,7 +455,7 @@ int ml_nnoptimizer_delete(ml_nnopt_h optimizer) {
   return status;
 }
 
-int ml_nnoptimizer_set_property(ml_nnopt_h optimizer, ...) {
+int ml_train_optimizer_set_property(ml_train_optimizer_h optimizer, ...) {
   int status = ML_ERROR_NONE;
   ml_nnopt *nnopt;
   const char *data;

--- a/api/capi/src/nntrainer_util.cpp
+++ b/api/capi/src/nntrainer_util.cpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0-only
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file nntrainer_util.cpp
+ * @date 10 July 2020
+ * @brief NNTrainer/Utilizer C-API Wrapper.
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <nntrainer_internal.h>
+
+/**
+ * @brief Convert nntrainer API optimizer type to neural network optimizer type
+ */
+nntrainer::OptType
+ml_optimizer_to_nntrainer_type(ml_train_optimizer_type_e type) {
+  switch (type) {
+  case ML_TRAIN_OPTIMIZER_TYPE_ADAM:
+    return nntrainer::OptType::adam;
+  case ML_TRAIN_OPTIMIZER_TYPE_SGD:
+    return nntrainer::OptType::sgd;
+  default:
+    return nntrainer::OptType::unknown;
+  }
+}

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -275,6 +275,14 @@ public:
    */
   int getLayer(const char *name, std::shared_ptr<Layer> *layer);
 
+  /**
+   * @brief     Set cost type for the neural network.
+   * @param[in] cost Type of the cost.
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int setCost(CostType cost);
+
   enum class PropertyType {
     loss = 0,
     cost = 1,

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -1176,4 +1176,15 @@ int NeuralNetwork::initFlattenLayer() {
   return initFlattenLayer(position);
 }
 
+/**
+ * @brief     Set cost type for the neural network.
+ */
+int NeuralNetwork::setCost(CostType cost) {
+  if (cost == COST_UNKNOWN)
+    return ML_ERROR_INVALID_PARAMETER;
+
+  this->cost = cost;
+  return ML_ERROR_NONE;
+}
+
 } /* namespace nntrainer */

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -27,11 +27,11 @@
  * @brief Neural Network Model Contruct / Destruct Test (possitive test )
  */
 TEST(nntrainer_capi_nnmodel, construct_destruct_01_p) {
-  ml_nnmodel_h handle;
+  ml_train_model_h handle;
   int status;
-  status = ml_nnmodel_construct(&handle);
+  status = ml_train_model_construct(&handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnmodel_destruct(handle);
+  status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -39,9 +39,9 @@ TEST(nntrainer_capi_nnmodel, construct_destruct_01_p) {
  * @brief Neural Network Model Destruct Test (negative test )
  */
 TEST(nntrainer_capi_nnmodel, construct_destruct_02_n) {
-  ml_nnmodel_h handle = NULL;
+  ml_train_model_h handle = NULL;
   int status;
-  status = ml_nnmodel_destruct(handle);
+  status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -50,7 +50,7 @@ TEST(nntrainer_capi_nnmodel, construct_destruct_02_n) {
  */
 TEST(nntrainer_capi_nnmodel, construct_destruct_03_n) {
   int status;
-  status = ml_nnmodel_construct(NULL);
+  status = ml_train_model_construct(NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -58,17 +58,17 @@ TEST(nntrainer_capi_nnmodel, construct_destruct_03_n) {
  * @brief Neural Network Model Compile Test
  */
 TEST(nntrainer_capi_nnmodel, compile_01_p) {
-  ml_nnmodel_h handle = NULL;
+  ml_train_model_h handle = NULL;
   int status = ML_ERROR_NONE;
   std::string config_file = "./test_compile_01_p.ini";
   RESET_CONFIG(config_file.c_str());
   replaceString("Layers = inputlayer outputlayer",
                 "Layers = inputlayer outputlayer", config_file, config_str);
-  status = ml_nnmodel_construct_with_conf(config_file.c_str(), &handle);
+  status = ml_train_model_construct_with_conf(config_file.c_str(), &handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnmodel_compile(handle, NULL);
+  status = ml_train_model_compile(handle, NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnmodel_destruct(handle);
+  status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -76,10 +76,10 @@ TEST(nntrainer_capi_nnmodel, compile_01_p) {
  * @brief Neural Network Model Compile Test
  */
 TEST(nntrainer_capi_nnmodel, construct_conf_01_n) {
-  ml_nnmodel_h handle = NULL;
+  ml_train_model_h handle = NULL;
   int status = ML_ERROR_NONE;
   std::string config_file = "/test/cannot_find.ini";
-  status = ml_nnmodel_construct_with_conf(config_file.c_str(), &handle);
+  status = ml_train_model_construct_with_conf(config_file.c_str(), &handle);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -87,13 +87,13 @@ TEST(nntrainer_capi_nnmodel, construct_conf_01_n) {
  * @brief Neural Network Model Compile Test
  */
 TEST(nntrainer_capi_nnmodel, construct_conf_02_n) {
-  ml_nnmodel_h handle = NULL;
+  ml_train_model_h handle = NULL;
   int status = ML_ERROR_NONE;
   std::string config_file = "./test_compile_03_n.ini";
   RESET_CONFIG(config_file.c_str());
   replaceString("Input_Shape = 32:1:1:62720", "Input_Shape= 32:1:1:0",
                 config_file, config_str);
-  status = ml_nnmodel_construct_with_conf(config_file.c_str(), &handle);
+  status = ml_train_model_construct_with_conf(config_file.c_str(), &handle);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -103,7 +103,7 @@ TEST(nntrainer_capi_nnmodel, construct_conf_02_n) {
 TEST(nntrainer_capi_nnmodel, compile_02_n) {
   int status = ML_ERROR_NONE;
   std::string config_file = "./test_compile_03_n.ini";
-  status = ml_nnmodel_compile(NULL);
+  status = ml_train_model_compile(NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -113,62 +113,62 @@ TEST(nntrainer_capi_nnmodel, compile_02_n) {
 TEST(nntrainer_capi_nnmodel, compile_05_p) {
   int status = ML_ERROR_NONE;
 
-  ml_nnmodel_h model;
-  ml_nnlayer_h layers[2];
-  ml_nnlayer_h get_layer;
-  ml_nnopt_h optimizer;
+  ml_train_model_h model;
+  ml_train_layer_h layers[2];
+  ml_train_layer_h get_layer;
+  ml_train_optimizer_h optimizer;
 
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[0], ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&layers[0], ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status =
-    ml_nnlayer_set_property(layers[0], "input_shape= 32:1:1:62720",
-                            "normalization=true", "bias_init_zero=true", NULL);
+  status = ml_train_layer_set_property(layers[0], "input_shape= 32:1:1:62720",
+                                       "normalization=true",
+                                       "bias_init_zero=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layers[0]);
+  status = ml_train_model_add_layer(model, layers[0]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Find layer based on default name */
-  status = ml_nnmodel_get_layer(model, "Input0", &get_layer);
+  status = ml_train_model_get_layer(model, "Input0", &get_layer);
   EXPECT_EQ(status, ML_ERROR_NONE);
   EXPECT_EQ(get_layer, layers[0]);
 
-  status = ml_nnlayer_create(&layers[1], ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&layers[1], ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(
+  status = ml_train_layer_set_property(
     layers[1], "unit= 10", "activation=softmax", "bias_init_zero=true",
     "weight_decay=l2norm", "weight_decay_lambda=0.005",
     "weight_ini=xavier_uniform", "name=fc100", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layers[1]);
+  status = ml_train_model_add_layer(model, layers[1]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Find layer based on set name */
-  status = ml_nnmodel_get_layer(model, "fc100", &get_layer);
+  status = ml_train_model_get_layer(model, "fc100", &get_layer);
   EXPECT_EQ(status, ML_ERROR_NONE);
   EXPECT_EQ(get_layer, layers[1]);
 
-  status = ml_nnoptimizer_create(&optimizer, "adam");
+  status = ml_train_optimizer_create(&optimizer, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_set_property(
+  status = ml_train_optimizer_set_property(
     optimizer, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
     "beta1=0.002", "beta2=0.001", "epsilon=1e-7", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_set_optimizer(model, optimizer);
+  status = ml_train_model_set_optimizer(model, optimizer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_compile(model, "loss=cross", NULL);
+  status = ml_train_model_compile(model, "loss=cross", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -178,76 +178,76 @@ TEST(nntrainer_capi_nnmodel, compile_05_p) {
 TEST(nntrainer_capi_nnmodel, compile_06_n) {
   int status = ML_ERROR_NONE;
 
-  ml_nnmodel_h model;
-  ml_nnlayer_h layers[3];
-  ml_nnlayer_h get_layer;
+  ml_train_model_h model;
+  ml_train_layer_h layers[3];
+  ml_train_layer_h get_layer;
 
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[0], ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&layers[0], ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status =
-    ml_nnlayer_set_property(layers[0], "input_shape= 32:1:1:62720",
-                            "normalization=true", "bias_init_zero=true", NULL);
+  status = ml_train_layer_set_property(layers[0], "input_shape= 32:1:1:62720",
+                                       "normalization=true",
+                                       "bias_init_zero=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Find layer before adding */
-  status = ml_nnmodel_get_layer(model, "Input0", &get_layer);
+  status = ml_train_model_get_layer(model, "Input0", &get_layer);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 
-  status = ml_nnmodel_add_layer(model, layers[0]);
+  status = ml_train_model_add_layer(model, layers[0]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Find layer based on default name */
-  status = ml_nnmodel_get_layer(model, "Input0", &get_layer);
+  status = ml_train_model_get_layer(model, "Input0", &get_layer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[1], ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&layers[1], ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Create another layer with same name, different type */
-  status = ml_nnlayer_set_property(layers[1], "name=Input0", NULL);
+  status = ml_train_layer_set_property(layers[1], "name=Input0", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Not add layer with existing name */
-  status = ml_nnmodel_add_layer(model, layers[1]);
+  status = ml_train_model_add_layer(model, layers[1]);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 
-  status = ml_nnlayer_set_property(layers[1], "name=fc0", NULL);
+  status = ml_train_layer_set_property(layers[1], "name=fc0", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** add layer with different name, different layer type */
-  status = ml_nnmodel_add_layer(model, layers[1]);
+  status = ml_train_model_add_layer(model, layers[1]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Find layer based on default name */
-  status = ml_nnmodel_get_layer(model, "fc0", &get_layer);
+  status = ml_train_model_get_layer(model, "fc0", &get_layer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[2], ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&layers[2], ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Create another layer with same name, same type */
-  status = ml_nnlayer_set_property(layers[2], "name=fc0", NULL);
+  status = ml_train_layer_set_property(layers[2], "name=fc0", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** add layer with different name, different layer type */
-  status = ml_nnmodel_add_layer(model, layers[2]);
+  status = ml_train_model_add_layer(model, layers[2]);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 
-  status = ml_nnlayer_set_property(layers[2], "name=fc1", NULL);
+  status = ml_train_layer_set_property(layers[2], "name=fc1", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** add layer with different name, different layer type */
-  status = ml_nnmodel_add_layer(model, layers[2]);
+  status = ml_train_model_add_layer(model, layers[2]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_get_layer(model, "fc1", &get_layer);
+  status = ml_train_model_get_layer(model, "fc1", &get_layer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -255,7 +255,7 @@ TEST(nntrainer_capi_nnmodel, compile_06_n) {
  * @brief Neural Network Model Train Test
  */
 TEST(nntrainer_capi_nnmodel, train_01_p) {
-  ml_nnmodel_h handle = NULL;
+  ml_train_model_h handle = NULL;
   int status = ML_ERROR_NONE;
   std::string config_file = "./test_train_01_p.ini";
   RESET_CONFIG(config_file.c_str());
@@ -263,13 +263,13 @@ TEST(nntrainer_capi_nnmodel, train_01_p) {
                 config_file, config_str);
   replaceString("minibatch = 32", "minibatch = 16", config_file, config_str);
   replaceString("BufferSize=100", "", config_file, config_str);
-  status = ml_nnmodel_construct_with_conf(config_file.c_str(), &handle);
+  status = ml_train_model_construct_with_conf(config_file.c_str(), &handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnmodel_compile(handle, NULL);
+  status = ml_train_model_compile(handle, NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnmodel_train_with_file(handle, NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnmodel_destruct(handle);
+  status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -286,7 +286,7 @@ TEST(nntrainer_capi_nnmodel, train_02_n) {
  * @brief Neural Network Model Train Test
  */
 TEST(nntrainer_capi_nnmodel, train_03_n) {
-  ml_nnmodel_h handle = NULL;
+  ml_train_model_h handle = NULL;
   int status = ML_ERROR_NONE;
   std::string config_file = "./test_train_01_p.ini";
   RESET_CONFIG(config_file.c_str());
@@ -294,13 +294,13 @@ TEST(nntrainer_capi_nnmodel, train_03_n) {
                 config_file, config_str);
   replaceString("minibatch = 32", "minibatch = 16", config_file, config_str);
   replaceString("BufferSize=100", "", config_file, config_str);
-  status = ml_nnmodel_construct_with_conf(config_file.c_str(), &handle);
+  status = ml_train_model_construct_with_conf(config_file.c_str(), &handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnmodel_compile(handle, NULL);
+  status = ml_train_model_compile(handle, NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_nnmodel_train_with_file(handle, "loss=cross", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-  status = ml_nnmodel_destruct(handle);
+  status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -310,28 +310,28 @@ TEST(nntrainer_capi_nnmodel, train_03_n) {
 TEST(nntrainer_capi_nnmodel, addLayer_01_p) {
   int status = ML_ERROR_NONE;
 
-  ml_nnmodel_h model;
-  ml_nnlayer_h layer;
+  ml_train_model_h model;
+  ml_train_layer_h layer;
 
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layer, ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&layer, ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layer, "input_shape= 32:1:1:6270", NULL);
+  status = ml_train_layer_set_property(layer, "input_shape= 32:1:1:6270", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layer, "normalization = true", NULL);
+  status = ml_train_layer_set_property(layer, "normalization = true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layer);
+  status = ml_train_model_add_layer(model, layer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_delete(layer);
+  status = ml_train_layer_destroy(layer);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -341,23 +341,23 @@ TEST(nntrainer_capi_nnmodel, addLayer_01_p) {
 TEST(nntrainer_capi_nnmodel, addLayer_02_p) {
   int status = ML_ERROR_NONE;
 
-  ml_nnmodel_h model;
-  ml_nnlayer_h layer;
+  ml_train_model_h model;
+  ml_train_layer_h layer;
 
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layer, ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&layer, ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layer, "input_shape= 32:1:1:6270",
-                                   "normalization=true", NULL);
+  status = ml_train_layer_set_property(layer, "input_shape= 32:1:1:6270",
+                                       "normalization=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layer);
+  status = ml_train_model_add_layer(model, layer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -367,23 +367,23 @@ TEST(nntrainer_capi_nnmodel, addLayer_02_p) {
 TEST(nntrainer_capi_nnmodel, addLayer_03_p) {
   int status = ML_ERROR_NONE;
 
-  ml_nnmodel_h model;
-  ml_nnlayer_h layer;
+  ml_train_model_h model;
+  ml_train_layer_h layer;
 
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layer, ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&layer, ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layer, "input_shape= 32:1:1:62720",
-                                   "activation=sigmoid", NULL);
+  status = ml_train_layer_set_property(layer, "input_shape= 32:1:1:62720",
+                                       "activation=sigmoid", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_delete(layer);
+  status = ml_train_layer_destroy(layer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -393,41 +393,41 @@ TEST(nntrainer_capi_nnmodel, addLayer_03_p) {
 TEST(nntrainer_capi_nnmodel, addLayer_04_p) {
   int status = ML_ERROR_NONE;
 
-  ml_nnmodel_h model;
-  ml_nnlayer_h layers[2];
+  ml_train_model_h model;
+  ml_train_layer_h layers[2];
 
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[0], ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&layers[0], ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status =
-    ml_nnlayer_set_property(layers[0], "input_shape= 32:1:1:62720",
-                            "normalization=true", "bias_init_zero=true", NULL);
+  status = ml_train_layer_set_property(layers[0], "input_shape= 32:1:1:62720",
+                                       "normalization=true",
+                                       "bias_init_zero=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layers[0]);
+  status = ml_train_model_add_layer(model, layers[0]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[1], ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&layers[1], ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layers[1], "unit= 10", "activation=softmax",
-                                   "bias_init_zero=true", "weight_decay=l2norm",
-                                   "weight_decay_lambda=0.005", NULL);
+  status = ml_train_layer_set_property(
+    layers[1], "unit= 10", "activation=softmax", "bias_init_zero=true",
+    "weight_decay=l2norm", "weight_decay_lambda=0.005", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layers[1]);
+  status = ml_train_model_add_layer(model, layers[1]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_delete(layers[0]);
+  status = ml_train_layer_destroy(layers[0]);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 
-  status = ml_nnlayer_delete(layers[1]);
+  status = ml_train_layer_destroy(layers[1]);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -437,35 +437,35 @@ TEST(nntrainer_capi_nnmodel, addLayer_04_p) {
 TEST(nntrainer_capi_nnmodel, addLayer_05_n) {
   int status = ML_ERROR_NONE;
 
-  ml_nnmodel_h model = NULL;
-  ml_nnlayer_h layer = NULL;
+  ml_train_model_h model = NULL;
+  ml_train_layer_h layer = NULL;
 
   std::string config_file = "./test_compile_01_p.ini";
   RESET_CONFIG(config_file.c_str());
   replaceString("Layers = inputlayer outputlayer",
                 "Layers = inputlayer outputlayer", config_file, config_str);
 
-  status = ml_nnmodel_construct_with_conf(config_file.c_str(), &model);
+  status = ml_train_model_construct_with_conf(config_file.c_str(), &model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_compile(model, NULL);
+  status = ml_train_model_compile(model, NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layer, ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&layer, ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layer, "unit= 10", "activation=softmax",
-                                   "bias_init_zero=true", "weight_decay=l2norm",
-                                   "weight_decay_lambda=0.005", NULL);
+  status = ml_train_layer_set_property(
+    layer, "unit= 10", "activation=softmax", "bias_init_zero=true",
+    "weight_decay=l2norm", "weight_decay_lambda=0.005", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layer);
+  status = ml_train_model_add_layer(model, layer);
   EXPECT_EQ(status, ML_ERROR_NOT_SUPPORTED);
 
-  status = ml_nnlayer_delete(layer);
+  status = ml_train_layer_destroy(layer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -475,24 +475,24 @@ TEST(nntrainer_capi_nnmodel, addLayer_05_n) {
 TEST(nntrainer_capi_nnmodel, create_optimizer_01_p) {
   int status = ML_ERROR_NONE;
 
-  ml_nnmodel_h model;
-  ml_nnopt_h optimizer;
+  ml_train_model_h model;
+  ml_train_optimizer_h optimizer;
 
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_create(&optimizer, "adam");
+  status = ml_train_optimizer_create(&optimizer, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_set_property(
+  status = ml_train_optimizer_set_property(
     optimizer, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
     "beta1=0.002", "beta2=0.001", "epsilon=1e-7", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_delete(optimizer);
+  status = ml_train_optimizer_destroy(optimizer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -502,47 +502,47 @@ TEST(nntrainer_capi_nnmodel, create_optimizer_01_p) {
 TEST(nntrainer_capi_nnmodel, create_optimizer_02_p) {
   int status = ML_ERROR_NONE;
 
-  ml_nnmodel_h model;
-  ml_nnlayer_h layers[2];
-  ml_nnopt_h optimizer;
+  ml_train_model_h model;
+  ml_train_layer_h layers[2];
+  ml_train_optimizer_h optimizer;
 
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[0], ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&layers[0], ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status =
-    ml_nnlayer_set_property(layers[0], "input_shape= 32:1:1:62720",
-                            "normalization=true", "bias_init_zero=true", NULL);
+  status = ml_train_layer_set_property(layers[0], "input_shape= 32:1:1:62720",
+                                       "normalization=true",
+                                       "bias_init_zero=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layers[0]);
+  status = ml_train_model_add_layer(model, layers[0]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[1], ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&layers[1], ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layers[1], "unit= 10", "activation=softmax",
-                                   "bias_init_zero=true", "weight_decay=l2norm",
-                                   "weight_decay_lambda=0.005", NULL);
+  status = ml_train_layer_set_property(
+    layers[1], "unit= 10", "activation=softmax", "bias_init_zero=true",
+    "weight_decay=l2norm", "weight_decay_lambda=0.005", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layers[1]);
+  status = ml_train_model_add_layer(model, layers[1]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_create(&optimizer, "adam");
+  status = ml_train_optimizer_create(&optimizer, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_set_property(
+  status = ml_train_optimizer_set_property(
     optimizer, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
     "beta1=0.002", "beta2=0.001", "epsilon=1e-7", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_delete(optimizer);
+  status = ml_train_optimizer_destroy(optimizer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -552,50 +552,50 @@ TEST(nntrainer_capi_nnmodel, create_optimizer_02_p) {
 TEST(nntrainer_capi_nnmodel, create_optimizer_03_p) {
   int status = ML_ERROR_NONE;
 
-  ml_nnmodel_h model;
-  ml_nnlayer_h layers[2];
-  ml_nnopt_h optimizer;
+  ml_train_model_h model;
+  ml_train_layer_h layers[2];
+  ml_train_optimizer_h optimizer;
 
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[0], ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&layers[0], ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status =
-    ml_nnlayer_set_property(layers[0], "input_shape= 32:1:1:62720",
-                            "normalization=true", "bias_init_zero=true", NULL);
+  status = ml_train_layer_set_property(layers[0], "input_shape= 32:1:1:62720",
+                                       "normalization=true",
+                                       "bias_init_zero=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layers[0]);
+  status = ml_train_model_add_layer(model, layers[0]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[1], ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&layers[1], ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layers[1], "unit= 10", "activation=softmax",
-                                   "bias_init_zero=true", "weight_decay=l2norm",
-                                   "weight_decay_lambda=0.005", NULL);
+  status = ml_train_layer_set_property(
+    layers[1], "unit= 10", "activation=softmax", "bias_init_zero=true",
+    "weight_decay=l2norm", "weight_decay_lambda=0.005", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layers[1]);
+  status = ml_train_model_add_layer(model, layers[1]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_create(&optimizer, "adam");
+  status = ml_train_optimizer_create(&optimizer, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_set_property(
+  status = ml_train_optimizer_set_property(
     optimizer, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
     "beta1=0.002", "beta2=0.001", "epsilon=1e-7", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_set_optimizer(model, optimizer);
+  status = ml_train_model_set_optimizer(model, optimizer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_delete(optimizer);
+  status = ml_train_optimizer_destroy(optimizer);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -605,48 +605,48 @@ TEST(nntrainer_capi_nnmodel, create_optimizer_03_p) {
 TEST(nntrainer_capi_nnmodel, train_with_file_01_p) {
   int status = ML_ERROR_NONE;
 
-  ml_nnmodel_h model;
-  ml_nnlayer_h layers[2];
-  ml_nnopt_h optimizer;
+  ml_train_model_h model;
+  ml_train_layer_h layers[2];
+  ml_train_optimizer_h optimizer;
 
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[0], ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&layers[0], ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status =
-    ml_nnlayer_set_property(layers[0], "input_shape= 16:1:1:62720",
-                            "normalization=true", "bias_init_zero=true", NULL);
+  status = ml_train_layer_set_property(layers[0], "input_shape= 16:1:1:62720",
+                                       "normalization=true",
+                                       "bias_init_zero=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layers[0]);
+  status = ml_train_model_add_layer(model, layers[0]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[1], ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&layers[1], ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layers[1], "unit= 10", "activation=softmax",
-                                   "bias_init_zero=true", "weight_decay=l2norm",
-                                   "weight_decay_lambda=0.005",
-                                   "weight_ini=xavier_uniform", NULL);
+  status = ml_train_layer_set_property(
+    layers[1], "unit= 10", "activation=softmax", "bias_init_zero=true",
+    "weight_decay=l2norm", "weight_decay_lambda=0.005",
+    "weight_ini=xavier_uniform", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layers[1]);
+  status = ml_train_model_add_layer(model, layers[1]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_create(&optimizer, "adam");
+  status = ml_train_optimizer_create(&optimizer, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_set_property(
+  status = ml_train_optimizer_set_property(
     optimizer, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
     "beta1=0.002", "beta2=0.001", "epsilon=1e-7", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_set_optimizer(model, optimizer);
+  status = ml_train_model_set_optimizer(model, optimizer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_compile(model, "loss=cross", NULL);
+  status = ml_train_model_compile(model, "loss=cross", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_nnmodel_train_with_file(
@@ -655,7 +655,7 @@ TEST(nntrainer_capi_nnmodel, train_with_file_01_p) {
     "model_file=model.bin", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -665,55 +665,55 @@ TEST(nntrainer_capi_nnmodel, train_with_file_01_p) {
 TEST(nntrainer_capi_nnmodel, train_with_generator_01_p) {
   int status = ML_ERROR_NONE;
 
-  ml_nnmodel_h model;
-  ml_nnlayer_h layers[2];
-  ml_nnopt_h optimizer;
+  ml_train_model_h model;
+  ml_train_layer_h layers[2];
+  ml_train_optimizer_h optimizer;
 
-  status = ml_nnmodel_construct(&model);
+  status = ml_train_model_construct(&model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[0], ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&layers[0], ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status =
-    ml_nnlayer_set_property(layers[0], "input_shape= 16:1:1:62720",
-                            "normalization=true", "bias_init_zero=true", NULL);
+  status = ml_train_layer_set_property(layers[0], "input_shape= 16:1:1:62720",
+                                       "normalization=true",
+                                       "bias_init_zero=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layers[0]);
+  status = ml_train_model_add_layer(model, layers[0]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_create(&layers[1], ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&layers[1], ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(layers[1], "unit= 10", "activation=softmax",
-                                   "bias_init_zero=true", "weight_decay=l2norm",
-                                   "weight_decay_lambda=0.005",
-                                   "weight_ini=xavier_uniform", NULL);
+  status = ml_train_layer_set_property(
+    layers[1], "unit= 10", "activation=softmax", "bias_init_zero=true",
+    "weight_decay=l2norm", "weight_decay_lambda=0.005",
+    "weight_ini=xavier_uniform", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_add_layer(model, layers[1]);
+  status = ml_train_model_add_layer(model, layers[1]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_create(&optimizer, "adam");
+  status = ml_train_optimizer_create(&optimizer, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnoptimizer_set_property(
+  status = ml_train_optimizer_set_property(
     optimizer, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
     "beta1=0.002", "beta2=0.001", "epsilon=1e-7", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_set_optimizer(model, optimizer);
+  status = ml_train_model_set_optimizer(model, optimizer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnmodel_compile(model, "loss=cross", NULL);
+  status = ml_train_model_compile(model, "loss=cross", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_nnmodel_train_with_generator(
     model, getMiniBatch_train, getMiniBatch_val, NULL, "epochs=2",
     "batch_size=16", "buffer_size=100", "model_file=model.bin", NULL);
 
-  status = ml_nnmodel_destruct(model);
+  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 

--- a/test/tizen_capi/unittest_tizen_capi_layer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_layer.cpp
@@ -26,11 +26,11 @@
  * @brief Neural Network Layer Create / Delete Test (possitive test)
  */
 TEST(nntrainer_capi_nnlayer, create_delete_01_p) {
-  ml_nnlayer_h handle;
+  ml_train_layer_h handle;
   int status;
-  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_delete(handle);
+  status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -38,11 +38,11 @@ TEST(nntrainer_capi_nnlayer, create_delete_01_p) {
  * @brief Neural Network Layer Create / Delete Test (possitive test)
  */
 TEST(nntrainer_capi_nnlayer, create_delete_02_p) {
-  ml_nnlayer_h handle;
+  ml_train_layer_h handle;
   int status;
-  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_delete(handle);
+  status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -50,9 +50,9 @@ TEST(nntrainer_capi_nnlayer, create_delete_02_p) {
  * @brief Neural Network Layer Create / Delete Test (negative test)
  */
 TEST(nntrainer_capi_nnlayer, create_delete_03_n) {
-  ml_nnlayer_h handle;
+  ml_train_layer_h handle;
   int status;
-  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_UNKNOWN);
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_UNKNOWN);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -60,19 +60,19 @@ TEST(nntrainer_capi_nnlayer, create_delete_03_n) {
  * @brief Neural Network Layer Set Property Test (positive test)
  */
 TEST(nntrainer_capi_nnlayer, setproperty_01_p) {
-  ml_nnlayer_h handle;
+  ml_train_layer_h handle;
   int status;
-  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "input_shape=32:1:1:6270", NULL);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-
-  status = ml_nnlayer_set_property(handle, "normalization=true", NULL);
+  status = ml_train_layer_set_property(handle, "input_shape=32:1:1:6270", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(handle, "standardization=true", NULL);
+  status = ml_train_layer_set_property(handle, "normalization=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_delete(handle);
+
+  status = ml_train_layer_set_property(handle, "standardization=true", NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -80,19 +80,19 @@ TEST(nntrainer_capi_nnlayer, setproperty_01_p) {
  * @brief Neural Network Layer Set Property Test (positive test)
  */
 TEST(nntrainer_capi_nnlayer, setproperty_02_p) {
-  ml_nnlayer_h handle;
+  ml_train_layer_h handle;
   int status;
-  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "unit=10", NULL);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-
-  status = ml_nnlayer_set_property(handle, "bias_init_zero=true", NULL);
+  status = ml_train_layer_set_property(handle, "unit=10", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_nnlayer_set_property(handle, "activation =sigmoid", NULL);
+  status = ml_train_layer_set_property(handle, "bias_init_zero=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_delete(handle);
+
+  status = ml_train_layer_set_property(handle, "activation =sigmoid", NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -100,13 +100,13 @@ TEST(nntrainer_capi_nnlayer, setproperty_02_p) {
  * @brief Neural Network Layer Set Property Test (positive test)
  */
 TEST(nntrainer_capi_nnlayer, setproperty_03_p) {
-  ml_nnlayer_h handle;
+  ml_train_layer_h handle;
   int status;
-  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "activation= sigmoid", NULL);
+  status = ml_train_layer_set_property(handle, "activation= sigmoid", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_delete(handle);
+  status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -114,13 +114,13 @@ TEST(nntrainer_capi_nnlayer, setproperty_03_p) {
  * @brief Neural Network Layer Set Property Test (negative test)
  */
 TEST(nntrainer_capi_nnlayer, setproperty_04_n) {
-  ml_nnlayer_h handle;
+  ml_train_layer_h handle;
   int status;
-  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "input_shape=0:0:0:1", NULL);
+  status = ml_train_layer_set_property(handle, "input_shape=0:0:0:1", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-  status = ml_nnlayer_delete(handle);
+  status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -128,13 +128,13 @@ TEST(nntrainer_capi_nnlayer, setproperty_04_n) {
  * @brief Neural Network Layer Set Property Test (negative test)
  */
 TEST(nntrainer_capi_nnlayer, setproperty_05_n) {
-  ml_nnlayer_h handle;
+  ml_train_layer_h handle;
   int status;
-  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_INPUT);
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_INPUT);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "epsilon =0.0001", NULL);
+  status = ml_train_layer_set_property(handle, "epsilon =0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-  status = ml_nnlayer_delete(handle);
+  status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -142,13 +142,13 @@ TEST(nntrainer_capi_nnlayer, setproperty_05_n) {
  * @brief Neural Network Layer Set Property Test (negative test)
  */
 TEST(nntrainer_capi_nnlayer, setproperty_06_n) {
-  ml_nnlayer_h handle;
+  ml_train_layer_h handle;
   int status;
-  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "epsilon =0.0001", NULL);
+  status = ml_train_layer_set_property(handle, "epsilon =0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-  status = ml_nnlayer_delete(handle);
+  status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -156,14 +156,14 @@ TEST(nntrainer_capi_nnlayer, setproperty_06_n) {
  * @brief Neural Network Set Property Test (positive test)
  */
 TEST(nntrainer_capi_nnlayer, setproperty_07_p) {
-  ml_nnlayer_h handle;
+  ml_train_layer_h handle;
   int status;
-  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
   /** Default to none activation in case wrong activation given */
-  status = ml_nnlayer_set_property(handle, "activation=0.0001", NULL);
+  status = ml_train_layer_set_property(handle, "activation=0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_delete(handle);
+  status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -171,14 +171,14 @@ TEST(nntrainer_capi_nnlayer, setproperty_07_p) {
  * @brief Neural Network Layer Set Property Test (positive test )
  */
 TEST(nntrainer_capi_nnlayer, setproperty_08_p) {
-  ml_nnlayer_h handle;
+  ml_train_layer_h handle;
   int status;
-  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "weight_decay=l2norm",
-                                   "weight_decay_lambda=0.0001", NULL);
+  status = ml_train_layer_set_property(handle, "weight_decay=l2norm",
+                                       "weight_decay_lambda=0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_delete(handle);
+  status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -186,14 +186,14 @@ TEST(nntrainer_capi_nnlayer, setproperty_08_p) {
  * @brief Neural Network Layer Set Property Test (negitive test )
  */
 TEST(nntrainer_capi_nnlayer, setproperty_09_n) {
-  ml_nnlayer_h handle;
+  ml_train_layer_h handle;
   int status;
-  status = ml_nnlayer_create(&handle, ML_LAYER_TYPE_FC);
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnlayer_set_property(handle, "weight_decay=asdfasd",
-                                   "weight_decay_lambda=0.0001", NULL);
+  status = ml_train_layer_set_property(handle, "weight_decay=asdfasd",
+                                       "weight_decay_lambda=0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-  status = ml_nnlayer_delete(handle);
+  status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 

--- a/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
@@ -23,79 +23,77 @@
 #include <nntrainer.h>
 
 /**
- * @brief Neural Network Optimizer Create / Delete Test (possitive test)
+ * @brief Neural Network Optimizer Create / Delete Test (positive test)
  */
 TEST(nntrainer_capi_nnopt, create_delete_01_p) {
-  ml_nnopt_h handle;
+  ml_train_optimizer_h handle;
   int status;
-  status = ml_nnoptimizer_create(&handle, "sgd");
+  status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_SGD);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnoptimizer_delete(handle);
+  status = ml_train_optimizer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
 /**
- * @brief Neural Network Optimizer Create / Delete Test (possitive test )
+ * @brief Neural Network Optimizer Create / Delete Test (positive test )
  */
 TEST(nntrainer_capi_nnopt, create_delete_02_p) {
-  ml_nnopt_h handle;
+  ml_train_optimizer_h handle;
   int status;
-  status = ml_nnoptimizer_create(&handle, "adam");
+  status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnoptimizer_delete(handle);
+  status = ml_train_optimizer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
 /**
- * @brief Neural Network Optimizer Create / Delete Test (possitive test )
+ * @brief Neural Network Optimizer Create / Delete Test (negative test )
  */
 TEST(nntrainer_capi_nnopt, create_delete_03_n) {
-  ml_nnopt_h handle = NULL;
+  ml_train_optimizer_h handle = NULL;
   int status;
-  status = ml_nnoptimizer_delete(handle);
+  status = ml_train_optimizer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
 /**
- * @brief Neural Network Optimizer Create / Delete Test (possitive test)
+ * @brief Neural Network Optimizer Create / Delete Test (positive test )
  */
 TEST(nntrainer_capi_nnopt, create_delete_04_n) {
-  ml_nnopt_h handle;
+  ml_train_optimizer_h handle;
   int status;
-  status = ml_nnoptimizer_create(&handle, "adaam");
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-  status = ml_nnoptimizer_delete(handle);
+  status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_UNKNOWN);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
 /**
- * @brief Neural Network Optimizer set Property Test (possitive test )
+ * @brief Neural Network Optimizer set Property Test (positive test )
  */
 TEST(nntrainer_capi_nnopt, setOptimizer_01_p) {
-  ml_nnopt_h handle;
+  ml_train_optimizer_h handle;
   int status;
-  status = ml_nnoptimizer_create(&handle, "adam");
+  status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status =
-    ml_nnoptimizer_set_property(handle, "beta1=0.002", "beta2=0.001", NULL);
+    ml_train_optimizer_set_property(handle, "beta1=0.002", "beta2=0.001", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnoptimizer_delete(handle);
+  status = ml_train_optimizer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
 /**
- * @brief Neural Network Optimizer Set Property Test (possitive test )
+ * @brief Neural Network Optimizer Set Property Test (positive test )
  */
 TEST(nntrainer_capi_nnopt, setOptimizer_02_p) {
-  ml_nnopt_h handle;
+  ml_train_optimizer_h handle;
   int status;
-  status = ml_nnoptimizer_create(&handle, "adam");
+  status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnoptimizer_set_property(
+  status = ml_train_optimizer_set_property(
     handle, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
     "beta1=0.002", "beta2=0.001", "epsilon=1e-7", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_nnoptimizer_delete(handle);
+  status = ml_train_optimizer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -103,14 +101,14 @@ TEST(nntrainer_capi_nnopt, setOptimizer_02_p) {
  * @brief Neural Network Optimizer Set Property Test (negative test )
  */
 TEST(nntrainer_capi_nnopt, setOptimizer_03_n) {
-  ml_nnopt_h handle;
+  ml_train_optimizer_h handle;
   int status;
-  status = ml_nnoptimizer_create(&handle, "adam");
+  status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status =
-    ml_nnoptimizer_set_property(handle, "beta1=true", "beta2=0.001", NULL);
+    ml_train_optimizer_set_property(handle, "beta1=true", "beta2=0.001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-  status = ml_nnoptimizer_delete(handle);
+  status = ml_train_optimizer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 


### PR DESCRIPTION
Setting optimizer now uses enum than string

The name space of the layers has been updated
Below is the summary the updates:
ml_nnmodel_* -> ml_train_model_*
ml_nnlayer_* -> ml_train_layer_*
ml_nnopt_* -> ml_train_optimizer_*
*_delete() -> *_destroy()

ml_nnmodel_train_with_file() and ml_nnmodel_train_with_generator() have been kept back
These will be updated in the upcoming PR where dataset interface for API is updated

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>