### PR TITLE
Add layer print

### DIFF
--- a/nntrainer/include/parse_util.h
+++ b/nntrainer/include/parse_util.h
@@ -88,6 +88,13 @@ inline void throw_status(int status) {
 unsigned int parseLayerProperty(std::string property);
 
 /**
+ * @brief     Unparse Layer property to string
+ * @param[in] type property type
+ * @retval    string representation of the type
+ */
+std::string propToStr(const unsigned int type);
+
+/**
  * @brief     Parsing Configuration Token
  * @param[in] ll string to be parsed
  * @param[in] t  Token type
@@ -164,6 +171,17 @@ int getKeyValue(std::string input_str, std::string &key, std::string &value);
 const char *getValues(std::vector<int> values, const char *delimiter = ",");
 
 int getValues(int n_str, std::string str, int *value);
+
+/**
+ * @brief     print instance info. as <Type at (address)>
+ * @param[in] std::ostream &out, T&& t
+ * @param[in] t pointer to the instance
+ */
+template <typename T,
+          typename std::enable_if_t<std::is_pointer<T>::value, T> * = nullptr>
+void printInstance(std::ostream &out, const T &t) {
+  out << '<' << typeid(*t).name() << " at " << t << '>' << std::endl;
+}
 
 } /* namespace nntrainer */
 

--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -223,4 +223,77 @@ int Layer::setName(std::string name) {
   return ML_ERROR_NONE;
 }
 
+template <typename T>
+void Layer::printIfValid(std::ostream &out, const PropertyType type,
+                         const T target) {
+  try {
+    setProperty(type);
+  } catch (std::invalid_argument &e) {
+    return;
+  }
+
+  out << propToStr(static_cast<unsigned int>(type)) << ": " << target
+      << std::endl;
+}
+
+void Layer::printShapeInfo(std::ostream &out) {
+  out << "input " << input_dim << "inner " << dim << "output " << output_dim;
+}
+
+void Layer::printPropertiesMeta(std::ostream &out) {
+  printIfValid(out, PropertyType::activation, activation_type);
+  printIfValid(out, PropertyType::flatten, flatten);
+}
+
+void Layer::printProperties(std::ostream &out) {
+  out << "Trainable: " << trainable << std::endl;
+  printIfValid(out, PropertyType::bias_init_zero, bias_init_zero);
+  printIfValid(out, PropertyType::weight_decay,
+               static_cast<int>(weight_decay.type));
+  printIfValid(out, PropertyType::weight_decay_lambda, weight_decay.lambda);
+}
+
+void Layer::printMetric(std::ostream &out) {
+  if (loss > 0) {
+    out << "Weight regularization loss: " << loss;
+  }
+}
+
+void Layer::print(std::ostream &out, unsigned int flags) {
+  if (flags & PRINT_INST_INFO) {
+    std::cout << "======instance info: " << std::endl;
+    printInstance(out, this);
+
+    out << "Layer Type: " << type << std::endl;
+  }
+
+  if (flags & PRINT_SHAPE_INFO) {
+    std::cout << "======shape information: " << std::endl;
+    printShapeInfo(out);
+  }
+
+  if (flags & PRINT_PROP_META) {
+    std::cout << "======meta properties: " << std::endl;
+    printPropertiesMeta(out);
+  }
+
+  if (flags & PRINT_PROP) {
+    std::cout << "======properties: " << std::endl;
+    printProperties(out);
+  }
+
+  if (flags & PRINT_WEIGHTS) {
+    std::cout << "======weights: " << std::endl;
+    for (unsigned int i = 0; i < param_size; ++i) {
+      out << '[' << paramsAt(i).name << ']' << std::endl;
+      out << paramsAt(i).weight;
+    }
+  }
+
+  if (flags & PRINT_METRIC) {
+    std::cout << "======metrics: " << std::endl;
+    printMetric(out);
+  }
+};
+
 } /* namespace nntrainer */

--- a/nntrainer/src/parse_util.cpp
+++ b/nntrainer/src/parse_util.cpp
@@ -244,42 +244,42 @@ unsigned int parseType(std::string ll, InputType t) {
   return ret;
 }
 
+/**
+ * @brief     Layer Properties
+ * input_shape = 0,
+ * bias_init_zero = 1,
+ * normalization = 2,
+ * standardization = 3,
+ * activation = 4,
+ * epsilon = 5
+ * weight_decay = 6
+ * weight_decay_lambda = 7
+ * unit = 8
+ * weight_ini = 9
+ * filter = 10
+ * kernel_size = 11
+ * stride = 12
+ * padding = 13
+ * pooling_size = 14
+ * pooling = 15
+ * flatten = 16
+ * name = 17
+ *
+ * InputLayer has 0, 1, 2, 3 properties.
+ * FullyConnectedLayer has 1, 4, 6, 7, 8, 9 properties.
+ * Conv2DLayer has 0, 1, 4, 6, 7, 9, 10, 11, 12, 13 properties.
+ * Pooling2DLayer has 12, 13, 14, 15 properties.
+ * BatchNormalizationLayer has 0, 1, 5, 6, 7 properties.
+ */
+static std::array<std::string, 19> property_string = {
+  "input_shape", "bias_init_zero", "normalization", "standardization",
+  "activation",  "epsilon",        "weight_decay",  "weight_decay_lambda",
+  "unit",        "weight_ini",     "filter",        "kernel_size",
+  "stride",      "padding",        "pooling_size",  "pooling",
+  "flatten",     "name",           "unknown"};
+
 unsigned int parseLayerProperty(std::string property) {
   unsigned int i;
-
-  /**
-   * @brief     Layer Properties
-   * input_shape = 0,
-   * bias_init_zero = 1,
-   * normalization = 2,
-   * standardization = 3,
-   * activation = 4,
-   * epsilon = 5
-   * weight_decay = 6
-   * weight_decay_lambda = 7
-   * unit = 8
-   * weight_ini = 9
-   * filter = 10
-   * kernel_size = 11
-   * stride = 12
-   * padding = 13
-   * pooling_size = 14
-   * pooling = 15
-   * flatten = 16
-   * name = 17
-   *
-   * InputLayer has 0, 1, 2, 3 properties.
-   * FullyConnectedLayer has 1, 4, 6, 7, 8, 9 properties.
-   * Conv2DLayer has 0, 1, 4, 6, 7, 9, 10, 11, 12, 13 properties.
-   * Pooling2DLayer has 12, 13, 14, 15 properties.
-   * BatchNormalizationLayer has 0, 1, 5, 6, 7 properties.
-   */
-  std::array<std::string, 19> property_string = {
-    "input_shape", "bias_init_zero", "normalization", "standardization",
-    "activation",  "epsilon",        "weight_decay",  "weight_decay_lambda",
-    "unit",        "weight_ini",     "filter",        "kernel_size",
-    "stride",      "padding",        "pooling_size",  "pooling",
-    "flatten",     "name",           "unknown"};
 
   for (i = 0; i < property_string.size(); i++) {
     unsigned int size = (property_string[i].size() > property.size())
@@ -293,6 +293,8 @@ unsigned int parseLayerProperty(std::string property) {
 
   return (unsigned int)Layer::PropertyType::unknown;
 }
+
+std::string propToStr(unsigned int type) { return property_string[type]; }
 
 unsigned int parseOptProperty(std::string property) {
   unsigned int i;

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -23,6 +23,7 @@
 
 #include <assert.h>
 #include <cstring>
+#include <iomanip>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <parse_util.h>
@@ -802,7 +803,7 @@ Tensor Tensor::apply(std::function<float(float)> f) const {
 Tensor Tensor::apply(std::function<Tensor(Tensor)> f) const { return f(*this); }
 
 void Tensor::print(std::ostream &out) const {
-  out << "<Tensor Object at " << this << ">" << std::endl;
+  printInstance(out, this);
   const float *data = getData();
 
   unsigned int len = length();
@@ -820,7 +821,7 @@ void Tensor::print(std::ostream &out) const {
     for (unsigned int l = 0; l < dim.channel(); l++) {
       for (unsigned int i = 0; i < dim.height(); i++) {
         for (unsigned int j = 0; j < dim.width(); j++) {
-          out << this->getValue(k, l, i, j) << " ";
+          out << std::setw(10) << this->getValue(k, l, i, j) << " ";
         }
         out << std::endl;
       }

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -472,6 +472,18 @@ protected:
   }
 };
 
+TEST_F(nntrainer_Conv2DLayer, print_01_p) {
+  setProperty("filter=3");
+  reinitialize();
+  unsigned int option = nntrainer::LayerPrintOption::PRINT_INST_INFO |
+                        nntrainer::LayerPrintOption::PRINT_SHAPE_INFO |
+                        nntrainer::LayerPrintOption::PRINT_PROP |
+                        nntrainer::LayerPrintOption::PRINT_PROP_META |
+                        nntrainer::LayerPrintOption::PRINT_WEIGHTS |
+                        nntrainer::LayerPrintOption::PRINT_METRIC;
+  layer.print(std::cerr, option);
+}
+
 /**
  * @brief Convolution 2D Layer
  */

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -889,22 +889,24 @@ TEST(nntrainer_Tensor, save_read_01_n) {
 TEST(nntrainer_Tensor, print_small_size) {
   nntrainer::Tensor target = constant(1.0, 3, 1, 2, 3);
 
+  std::cerr << target;
   std::stringstream ss, expected;
   ss << target;
-  expected << "<Tensor Object at " << &target << ">\n"
+
+  expected << '<' << typeid(target).name() << " at " << &target << ">\n"
            << "Shape: 3:1:2:3\n"
-              "1 1 1 \n"
-              "1 1 1 \n"
-              "\n"
-              "-------\n"
-              "1 1 1 \n"
-              "1 1 1 \n"
-              "\n"
-              "-------\n"
-              "1 1 1 \n"
-              "1 1 1 \n"
-              "\n"
-              "-------\n";
+           << "         1          1          1 \n"
+           << "         1          1          1 \n"
+           << "\n"
+           << "-------\n"
+           << "         1          1          1 \n"
+           << "         1          1          1 \n"
+           << "\n"
+           << "-------\n"
+           << "         1          1          1 \n"
+           << "         1          1          1 \n"
+           << "\n"
+           << "-------\n";
 
   EXPECT_EQ(ss.str(), expected.str());
 }
@@ -914,7 +916,7 @@ TEST(nntrainer_Tensor, print_large_size) {
 
   std::stringstream ss, expected;
 
-  expected << "<Tensor Object at " << &target << ">\n"
+  expected << '<' << typeid(target).name() << " at " << &target << ">\n"
            << "Shape: 3:10:10:10\n"
            << "[1.2 1.2 1.2 ... 1.2 1.2 1.2]\n";
   ss << target;


### PR DESCRIPTION
Hook points and print options are added to customize print options.

**Changes proposed in this PR:**
- Add print option to layer
- Add `Layer::print` function
- Add hook point to print function for derived layer.
- Add `ostream &operater<<` for Layer type

Level of verbosity can be defined as a combination of `PrintOptions` with this PR.
For example, print with options

```cpp
  unsigned int option = nntrainer::LayerPrintOption::PRINT_INST_INFO |
                        nntrainer::LayerPrintOption::PRINT_SHAPE_INFO |
                        nntrainer::LayerPrintOption::PRINT_PROP |
                        nntrainer::LayerPrintOption::PRINT_PROP_META |
                        nntrainer::LayerPrintOption::PRINT_WEIGHTS |
                        nntrainer::LayerPrintOption::PRINT_METRIC;
```

in `conv2d layer` would result:

```
======instance info: 
<N9nntrainer11Conv2DLayerE at 0x5589a5e55fc0>
Layer Type: 3
======shape information: 
input Shape: 32:3:28:28
inner Shape: 1:3:5:5
output Shape: 32:3:9:9
======meta properties: 
activation: 1
flatten: 0
======properties: 
Trainable: 1
bias_init_zero: 1
weight_decay: 0
weight_decay_lambda: 0.005
======weights: 
[Conv2d:filter0]
<N9nntrainer6TensorE at 0x5589a5edc6b8>
Shape: 1:3:5:5
 -0.269142    0.47962  -0.284211   -0.45845 -0.0822979 
  0.459176  -0.103676  -0.361879  -0.220997  -0.312527 
   0.64287   0.740781   0.359017  -0.703313   0.352514 
 -0.480632  -0.325465  0.0323391   0.120387  -0.192109 
  0.432503  -0.399537   0.457927   0.285908  -0.240852 

  0.262181   0.419634   0.718424   0.365445   0.586525 
 -0.555376   0.770625    0.56692  -0.212413 -0.0909044 
  -0.70452 -0.0210528  -0.270649 -0.0799862 -0.00477964 
  0.105107  -0.507832   0.187715  -0.642797 -0.00282019 
-0.0732321   0.568226   0.670283   0.197886   0.407694 

 -0.152707  -0.292045  -0.129061   0.602041   0.481549 
  0.305616   -0.23518 -0.0567872  -0.447012   -0.36465 
 -0.682601   0.117017   0.582538  -0.472657   0.648409 
  0.373715  -0.588507   0.676886  -0.256432   0.246737 
 -0.502911   0.348559  -0.595048  -0.519772   0.619471 

-------
[Conv2d:filter1]
<N9nntrainer6TensorE at 0x5589a5edc758>
Shape: 1:3:5:5
  0.384547  -0.686483 -0.00409478   0.744365  -0.639224 
 -0.625176  -0.175915   0.563086    0.35546   0.103031 
  0.121163  -0.204621  -0.299951  -0.244242   0.757167 
  0.398707    0.11469  -0.287262   0.689312   0.243717 
 0.0926018  0.0268414   0.100181 -0.0232911  -0.695324 

  0.621478  -0.613359  0.0846558   0.177287   0.506372 
  0.358845   0.349457  -0.396543  -0.714864   0.718788 
    0.4231   0.373724  -0.438623  -0.405871   0.624557 
  0.223735  -0.708099  -0.248248  -0.258604   0.352412 
 -0.620091    0.13105 -0.0378172   0.397606   0.495777 

 -0.385031  -0.312647   0.669709  -0.540769   0.763754 
 -0.262949  -0.519704   0.486261  0.0199928  -0.557115 
  0.563095  -0.422368  -0.235945  -0.667932  -0.398705 
  0.318685   0.357965  -0.162304   0.739767  -0.293045 
0.00580609   0.338695  -0.166646  -0.254102  -0.167417 

-------
[Conv2d:filter2]
<N9nntrainer6TensorE at 0x5589a5edc7f8>
Shape: 1:3:5:5
  0.352862   0.456247   0.488305   0.319228  -0.437395 
 -0.280532   0.734037    0.73523  -0.523073   0.606634 
 -0.324028   0.311276  -0.496059 -0.0917476  -0.239342 
 -0.453455 -0.0308896   0.255562  0.0343547   0.393325 
  0.547804   0.161236    0.60333 -0.00679046  -0.433613 

 -0.591727   0.190387   0.441103  -0.601868 -0.0130265 
-0.0635636   0.548592   -0.27524  -0.565737  -0.284276 
  0.720513 -0.0269804 -0.0136313   0.356048  -0.662512 
 -0.667419  -0.340646   0.587413   0.623675   0.363772 
 -0.257138  -0.501165   0.728242   0.680345 -0.0865667 

0.00977892  -0.205971     0.7743   0.448909  -0.469004 
-0.0509384  0.0540795  -0.657529  -0.324946   0.509438 
 -0.303373   0.449982   0.141078  0.0232269   0.653324 
 -0.759595   0.472913  -0.563353   0.346928   0.328414 
 0.0916716   0.140756   0.654222   0.309908 -0.0118337 

-------
[Conv2d:bias0]
<N9nntrainer6TensorE at 0x5589a5edc898>
Shape: 1:1:1:1
         0 

-------
[Conv2d:bias1]
<N9nntrainer6TensorE at 0x5589a5edc938>
Shape: 1:1:1:1
         0 

-------
[Conv2d:bias2]
<N9nntrainer6TensorE at 0x5589a5edc9d8>
Shape: 1:1:1:1
         0 

-------
======metrics: 
```

And each part is customizable through overriding `Layer::print*`