### PR TITLE
Fix NeuralNetwork::finalize

### DIFF
--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -730,9 +730,7 @@ int NeuralNetwork::init() {
  * @brief     free layers
  */
 void NeuralNetwork::finalize() {
-  for (unsigned int i = 0; i < layers.size(); i++) {
-    layers.erase(layers.begin() + i);
-  }
+  layers.erase(layers.begin(), layers.end());
 
   if (data_buffer) {
     data_buffer->clear();


### PR DESCRIPTION
Delete layer in finalize had wrong index. This PR fix this issue

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>