### PR TITLE
[Urgent][Fix/Coverage] Fix the coverage generator to use python3

### DIFF
--- a/test/unittestcoverage.py
+++ b/test/unittestcoverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 ##
 # Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.


### PR DESCRIPTION
This patch fixes the coverage generator to use python3.
It seems that Python2 package was removed in nntrainer.spec.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>