### PR TITLE
[data buffer] Bug fix for data buffer

### DIFF
--- a/nntrainer/include/databuffer.h
+++ b/nntrainer/include/databuffer.h
@@ -159,10 +159,9 @@ public:
   /**
    * @brief     Update Data Buffer ( it is for child thread )
    * @param[in] BufferType training, validation, test
-   * @param[in] file input file stream
    * @retval    void
    */
-  virtual void updateData(BufferType type, int &status) = 0;
+  virtual void updateData(BufferType type) = 0;
 
   /**
    * @brief     function for thread ( training, validation, test )

--- a/nntrainer/include/databuffer_file.h
+++ b/nntrainer/include/databuffer_file.h
@@ -65,7 +65,7 @@ public:
    * @param[in] BufferType training, validation, test
    * @retval    void
    */
-  void updateData(BufferType type, int &status);
+  void updateData(BufferType type);
 
   /**
    * @brief     set train data file name

--- a/nntrainer/include/databuffer_func.h
+++ b/nntrainer/include/databuffer_func.h
@@ -74,7 +74,7 @@ public:
    * @param[in] BufferType training, validation, test
    * @retval    void
    */
-  void updateData(BufferType type, int &status);
+  void updateData(BufferType type);
 
 private:
   /**

--- a/nntrainer/src/databuffer.cpp
+++ b/nntrainer/src/databuffer.cpp
@@ -65,8 +65,7 @@ int DataBuffer::run(BufferType type) {
 
     if (validation[DATA_TRAIN]) {
       this->train_running = true;
-      this->train_thread =
-        std::thread(&DataBuffer::updateData, this, type, std::ref(status));
+      this->train_thread = std::thread(&DataBuffer::updateData, this, type);
       if (globalExceptionPtr) {
         try {
           std::rethrow_exception(globalExceptionPtr);
@@ -82,8 +81,7 @@ int DataBuffer::run(BufferType type) {
       return ML_ERROR_INVALID_PARAMETER;
     if (validation[DATA_VAL]) {
       this->val_running = true;
-      this->val_thread =
-        std::thread(&DataBuffer::updateData, this, type, std::ref(status));
+      this->val_thread = std::thread(&DataBuffer::updateData, this, type);
       if (globalExceptionPtr) {
         try {
           std::rethrow_exception(globalExceptionPtr);
@@ -100,8 +98,7 @@ int DataBuffer::run(BufferType type) {
 
     if (validation[DATA_TEST]) {
       this->test_running = true;
-      this->test_thread =
-        std::thread(&DataBuffer::updateData, this, type, std::ref(status));
+      this->test_thread = std::thread(&DataBuffer::updateData, this, type);
       if (globalExceptionPtr) {
         try {
           std::rethrow_exception(globalExceptionPtr);

--- a/nntrainer/src/databuffer_file.cpp
+++ b/nntrainer/src/databuffer_file.cpp
@@ -134,7 +134,7 @@ int DataBufferFromDataFile::init() {
   return status;
 }
 
-void DataBufferFromDataFile::updateData(BufferType type, int &status) {
+void DataBufferFromDataFile::updateData(BufferType type) {
   unsigned int max_size = 0;
   unsigned int buf_size = 0;
   unsigned int *rest_size = NULL;
@@ -219,8 +219,6 @@ void DataBufferFromDataFile::updateData(BufferType type, int &status) {
 
       try {
         if (I > max_size) {
-          ml_loge("Error: Test case id cannot exceed maximum number of test");
-          status = ML_ERROR_INVALID_PARAMETER;
           throw std::runtime_error(
             "Error: Test case id cannot exceed maximum number of test");
         }
@@ -236,8 +234,6 @@ void DataBufferFromDataFile::updateData(BufferType type, int &status) {
         (I * input_dim.getFeatureLen() + I * class_num) * sizeof(float);
       try {
         if (position > file_length || position > ULLONG_MAX) {
-          ml_loge("Error: Cannot exceed max file size");
-          status = ML_ERROR_INVALID_PARAMETER;
           throw std::runtime_error("Error: Cannot exceed max file size");
         }
       } catch (...) {

--- a/nntrainer/src/databuffer_func.cpp
+++ b/nntrainer/src/databuffer_func.cpp
@@ -135,8 +135,8 @@ int DataBufferFromCallback::setFunc(
   return status;
 }
 
-void DataBufferFromCallback::updateData(BufferType type, int &status) {
-  status = ML_ERROR_NONE;
+void DataBufferFromCallback::updateData(BufferType type) {
+  int status = ML_ERROR_NONE;
 
   unsigned int buf_size = 0;
   unsigned int *cur_size = NULL;


### PR DESCRIPTION
data buffer updateData() passes the reference of a on-stack variable
which is deleted after the function call exits. However the callee function
remains on a new thread causing problems.

Added bug fix for this.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>