### PR TITLE
[optimzer/layers] Gradient dimension should match weight dim and sum

### DIFF
--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -53,10 +53,10 @@ int BatchNormalizationLayer::initialize(bool last) {
   beta.setZero();
 
   setParamSize(4);
-  paramsAt(0) = {std::move(mu), Tensor(dim), "BN:moving_average"};
-  paramsAt(1) = {std::move(var), Tensor(dim), "BN:moving_variance"};
-  paramsAt(2) = {std::move(gamma), Tensor(dim), "BN:gamma"};
-  paramsAt(3) = {std::move(beta), Tensor(dim), "BN:beta"};
+  paramsAt(0) = {std::move(mu), Tensor(mu.getDim()), "BN:moving_average"};
+  paramsAt(1) = {std::move(var), Tensor(var.getDim()), "BN:moving_variance"};
+  paramsAt(2) = {std::move(gamma), Tensor(gamma.getDim()), "BN:gamma"};
+  paramsAt(3) = {std::move(beta), Tensor(beta.getDim()), "BN:beta"};
 
   return status;
 }

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -224,11 +224,12 @@ Tensor Conv2DLayer::backwarding(Tensor derivative, int iteration) {
       delK = delK.chain()
                .applyIf(this->isWeightDecayL2Norm(), _LIFT(add_i), filter,
                         weight_decay.lambda)
-               .run().average(0);
+               .run()
+               .sum(0);
     }
     for (unsigned int i = filter_size; i < 2 * filter_size; ++i) {
       Tensor &delBias = paramsAt(i).grad;
-      delBias = delBias.average(0);
+      delBias = delBias.sum(0);
     }
 
     opt.apply_gradients(params, param_size, iteration);

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -224,7 +224,11 @@ Tensor Conv2DLayer::backwarding(Tensor derivative, int iteration) {
       delK = delK.chain()
                .applyIf(this->isWeightDecayL2Norm(), _LIFT(add_i), filter,
                         weight_decay.lambda)
-               .run();
+               .run().average(0);
+    }
+    for (unsigned int i = filter_size; i < 2 * filter_size; ++i) {
+      Tensor &delBias = paramsAt(i).grad;
+      delBias = delBias.average(0);
     }
 
     opt.apply_gradients(params, param_size, iteration);

--- a/nntrainer/src/fc_layer.cpp
+++ b/nntrainer/src/fc_layer.cpp
@@ -139,13 +139,14 @@ Tensor FullyConnectedLayer::backwarding(Tensor derivative, int iteration) {
   Tensor &djdb = paramsAt(bias_idx).grad;
 
   Tensor ret = derivative.dot(weight.transpose("0:2:1"));
-  djdb = derivative.average(0);
+  djdb = derivative.sum(0);
   djdw = input.chain()
            .transpose("0:2:1")
            .dot(derivative)
            .applyIf(this->isWeightDecayL2Norm(), _LIFT(add_i), weight,
                     weight_decay.lambda)
-           .run().average(0);
+           .run()
+           .sum(0);
 
   if (trainable) {
     opt.apply_gradients(params, param_size, iteration);

--- a/nntrainer/src/optimizer.cpp
+++ b/nntrainer/src/optimizer.cpp
@@ -113,11 +113,7 @@ void Optimizer::apply_gradients(std::shared_ptr<UpdatableParam> params,
     UpdatableParam &param = param_data[i];
 
     Tensor &x = param.weight;
-    /// @fixme: #280 and use const Tensor &x_grad once fixed.
-    /// @note: that current implementation does not update grad since updating
-    /// grad changes it's dimension
-    Tensor x_grad = param.grad;
-    x_grad = x_grad.average(0);
+    const Tensor &x_grad = param.grad;
     switch (type) {
     case OptType::sgd:
       x.add_i(x_grad, -ll);


### PR DESCRIPTION
Gradient dimension should match weight dimension
Currently optimizer applies averaging of gradients, which is not correct
Apply averaging of gradients before calling applyGradients

Further, Gradients of the layer should perform sum over batch than average
This is consistent with tensorflow's implementation

Resolves #280

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>