### PR TITLE
[CAPI] Implement summary api

### DIFF
--- a/Applications/KNN/jni/Android.mk
+++ b/Applications/KNN/jni/Android.mk
@@ -9,7 +9,9 @@ endif
 
 ifndef NNTRAINER_ROOT
 NNTRAINER_ROOT := $(LOCAL_PATH)/../../../libs/arm64-v8a
-NNTRAINER_INCLUDES := $(LOCAL_PATH)/../../../nntrainer/include
+NNTRAINER_INCLUDES := $(LOCAL_PATH)/../../../nntrainer/include \
+	$(LOCAL_PATH)/../../../api \
+	$(LOCAL_PATH)/../../../api/capi/include/platform
 endif
 
 include $(CLEAR_VARS)

--- a/Applications/LogisticRegression/jni/Android.mk
+++ b/Applications/LogisticRegression/jni/Android.mk
@@ -9,7 +9,9 @@ endif
 
 ifndef NNTRAINER_ROOT
 NNTRAINER_ROOT := $(LOCAL_PATH)/../../../libs/arm64-v8a
-NNTRAINER_INCLUDE := $(LOCAL_PATH)/../../../nntrainer/include
+NNTRAINER_INCLUDES := $(LOCAL_PATH)/../../../nntrainer/include \
+	$(LOCAL_PATH)/../../../api \
+	$(LOCAL_PATH)/../../../api/capi/include/platform
 endif
 
 LOCAL_MODULE := nntrainer
@@ -34,6 +36,6 @@ LOCAL_SRC_FILES := main.cpp
 
 LOCAL_SHARED_LIBRARIES := nntrainer
 
-LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDE)
+LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 include $(BUILD_EXECUTABLE)

--- a/Applications/ReinforcementLearning/DeepQ/jni/Android.mk
+++ b/Applications/ReinforcementLearning/DeepQ/jni/Android.mk
@@ -9,7 +9,9 @@ endif
 
 ifndef NNTRAINER_ROOT
 NNTRAINER_ROOT := $(LOCAL_PATH)/../../../../libs/arm64-v8a
-NNTRAINER_INCLUDES := $(LOCAL_PATH)/../../../../nntrainer/include
+NNTRAINER_INCLUDES := $(LOCAL_PATH)/../../../../nntrainer/include \
+	$(LOCAL_PATH)/../../../../api \
+	$(LOCAL_PATH)/../../../../api/capi/include/platform
 endif
 
 LOCAL_MODULE := nntrainer

--- a/Applications/Training/jni/Android.mk
+++ b/Applications/Training/jni/Android.mk
@@ -9,7 +9,9 @@ endif
 
 ifndef NNTRAINER_ROOT
 NNTRAINER_ROOT := $(LOCAL_PATH)/../../../libs/arm64-v8a
-NNTRAINER_INCLUDES := $(LOCAL_PATH)/../../../nntrainer/include
+NNTRAINER_INCLUDES := $(LOCAL_PATH)/../../../nntrainer/include \
+	$(LOCAL_PATH)/../../../api \
+	$(LOCAL_PATH)/../../../api/capi/include/platform
 endif
 
 NNTRAINER_APPLICATION := $(LOCAL_PATH)/../../

--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -88,18 +88,6 @@ typedef enum {
 } ml_train_optimizer_type_e;
 
 /**
- * @brief Enumeration for the neural network summary verbosity of NNTrainer
- * @since_tizen 6.x
- */
-typedef enum {
-  ML_TRAIN_SUMMARY_MODEL = 0, /**< Overview of model
-                                   summary with one-line layer information*/
-  ML_TRAIN_SUMMARY_LAYER, /**< Detailed model summary with layer properties */
-  ML_TRAIN_SUMMARY_TENSOR /**< Model summary layer's including weight
-                             information */
-} ml_train_summary_type_e;
-
-/**
  * @brief Constructs the neural network model.
  * @details Use this function to create Neural Network Model.
  * @since_tizen 6.x

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -10,6 +10,9 @@
  * @bug No known bugs except for NYI items
  */
 
+#ifndef __NNTRAINER_API_COMMON_H__
+#define __NNTRAINER_API_COMMON_H__
+
 /**
  * @brief Dataset generator callback function for train/valid/test data.
  * @details The Containers passed will already be allocated with sufficient
@@ -29,3 +32,5 @@
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter.
  */
 typedef int (*ml_train_datagen_cb)(float **input, float **label, bool *last);
+
+#endif

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -33,4 +33,16 @@
  */
 typedef int (*ml_train_datagen_cb)(float **input, float **label, bool *last);
 
+/**
+ * @brief Enumeration for the neural network summary verbosity of NNTrainer
+ * @since_tizen 6.x
+ */
+typedef enum {
+  ML_TRAIN_SUMMARY_MODEL = 0, /**< Overview of model
+                                   summary with one-line layer information */
+  ML_TRAIN_SUMMARY_LAYER, /**< Detailed model summary with layer properties */
+  ML_TRAIN_SUMMARY_TENSOR /**< Model summary layer's including weight
+                             information */
+} ml_train_summary_type_e;
+
 #endif

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -414,6 +414,13 @@ public:
    */
   virtual std::string getBaseName() = 0;
 
+  /**
+   * @brief     Print layer related information. Do not override without clear
+   * reason. It is recommended to override printShapeInfo, printPropertiesMeta,
+   * printProperties, printMetric instead
+   * @param[in] out outstream
+   * @param[in] flags combination of LayerPrintOption
+   */
   virtual void print(std::ostream &out, unsigned int flags = 0);
 
 protected:
@@ -595,7 +602,7 @@ private:
  */
 template <typename T, typename std::enable_if_t<
                         std::is_base_of<Layer, T>::value, T> * = nullptr>
-std::ostream &operator<<(std::ostream &out, T const &l) {
+std::ostream &operator<<(std::ostream &out, T &l) {
   unsigned int option = nntrainer::LayerPrintOption::PRINT_INST_INFO |
                         nntrainer::LayerPrintOption::PRINT_SHAPE_INFO |
                         nntrainer::LayerPrintOption::PRINT_PROP |

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -35,6 +35,7 @@
 #include <iostream>
 #include <layer.h>
 #include <loss_layer.h>
+#include <ml-api-common.h>
 #include <optimizer.h>
 #include <pooling2d_layer.h>
 #include <tensor.h>
@@ -274,6 +275,17 @@ public:
     continue_train = 5,
     unknown = 6
   };
+
+  /**
+   * @brief print function for neuralnet
+   * @param[in] out outstream
+   * @param[in] flags verbosity from ml_train_summary_type_e
+   */
+  /// @todo: change print to use NeuralNetPrintOption and add way to print out
+  /// metrics. Current implementation use summary level directly. and lack of
+  /// printing out metrics. It might be fine for now but later should add way to
+  /// control like layer::print
+  void print(std::ostream &out, unsigned int flags = 0);
 
 private:
   /**

--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -261,29 +261,29 @@ void Layer::printMetric(std::ostream &out) {
 
 void Layer::print(std::ostream &out, unsigned int flags) {
   if (flags & PRINT_INST_INFO) {
-    std::cout << "======instance info: " << std::endl;
+    out << "===================";
     printInstance(out, this);
 
     out << "Layer Type: " << type << std::endl;
   }
 
   if (flags & PRINT_SHAPE_INFO) {
-    std::cout << "======shape information: " << std::endl;
+    out << "======shape information: " << std::endl;
     printShapeInfo(out);
   }
 
   if (flags & PRINT_PROP_META) {
-    std::cout << "======meta properties: " << std::endl;
+    out << "======meta properties: " << std::endl;
     printPropertiesMeta(out);
   }
 
   if (flags & PRINT_PROP) {
-    std::cout << "======properties: " << std::endl;
+    out << "======properties: " << std::endl;
     printProperties(out);
   }
 
   if (flags & PRINT_WEIGHTS) {
-    std::cout << "======weights: " << std::endl;
+    out << "======weights: " << std::endl;
     for (unsigned int i = 0; i < param_size; ++i) {
       out << '[' << paramsAt(i).name << ']' << std::endl;
       out << paramsAt(i).weight;
@@ -291,7 +291,7 @@ void Layer::print(std::ostream &out, unsigned int flags) {
   }
 
   if (flags & PRINT_METRIC) {
-    std::cout << "======metrics: " << std::endl;
+    out << "======metrics: " << std::endl;
     printMetric(out);
   }
 };

--- a/nntrainer/src/loss_layer.cpp
+++ b/nntrainer/src/loss_layer.cpp
@@ -152,7 +152,7 @@ Tensor LossLayer::forwarding(Tensor in, int &status) {
 }
 
 void LossLayer::setProperty(const PropertyType type, const std::string &value) {
-  throw std::invalid_argument("[Loss Layer] setProperty not supported");
+  throw exception::invalid_property("[Loss Layer] setProperty not supported");
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -939,4 +939,54 @@ int NeuralNetwork::setCost(CostType cost) {
   return ML_ERROR_NONE;
 }
 
+static unsigned int getLayerFlag(ml_train_summary_type_e verbosity,
+                                 bool initialized = false) {
+  unsigned int flag = 0;
+
+  switch (flag) {
+  case ML_TRAIN_SUMMARY_MODEL:
+    flag =
+      LayerPrintOption::PRINT_INST_INFO | LayerPrintOption::PRINT_SHAPE_INFO;
+    /// no break intended
+
+  case ML_TRAIN_SUMMARY_LAYER:
+    if (!initialized)
+      flag |= LayerPrintOption::PRINT_PROP_META;
+    else
+      flag |= LayerPrintOption::PRINT_METRIC;
+    flag |= LayerPrintOption::PRINT_PROP;
+    /// no break intended
+
+  case ML_TRAIN_SUMMARY_TENSOR:
+    flag |= LayerPrintOption::PRINT_WEIGHTS;
+    break;
+
+  default:
+    throw std::invalid_argument("given verbosity is invalid");
+  }
+
+  return flag;
+}
+
+void NeuralNetwork::print(std::ostream &out, unsigned int flags) {
+  /// @todo print neuralnet property
+  /// @todo print optimizer (with print optimizer prop)
+  /// @todo print loss function when it is not initialized. (if it is
+  /// initialized, loss layer will be printed)
+
+  if (layers.empty()) {
+    out << "model is empty!" << std::endl;
+    return;
+  }
+  unsigned int layerFlag =
+    getLayerFlag((ml_train_summary_type_e)flags, initialized);
+
+  for (auto &layer : layers) {
+    layer->print(out, layerFlag);
+  }
+
+  /// @todo Add status to check neuralnet has been run. #290
+  /// @todo print neuralnet metric after it is run
+}
+
 } /* namespace nntrainer */

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -738,6 +738,53 @@ TEST(nntrainer_capi_nnmodel, train_with_generator_01_p) {
 }
 
 /**
+ * @brief Neural Network Model Summary Test summary verbosity of tensor
+ */
+TEST(nntrainer_capi_summary, summary_01_p) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+  std::string config_file = "./test_compile_01_p.ini";
+  RESET_CONFIG(config_file.c_str());
+  replaceString("Layers = inputlayer outputlayer",
+                "Layers = inputlayer outputlayer", config_file, config_str);
+  status = ml_train_model_construct_with_conf(config_file.c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_model_compile(handle, NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  char *sum = NULL;
+  status = ml_train_model_get_summary(handle, ML_TRAIN_SUMMARY_TENSOR, &sum);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  EXPECT_GT(strlen(sum), 100);
+
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Model Summary Test summary with tensor
+ */
+TEST(nntrainer_capi_summary, summary_02_n) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+  std::string config_file = "./test_compile_01_p.ini";
+  RESET_CONFIG(config_file.c_str());
+  replaceString("Layers = inputlayer outputlayer",
+                "Layers = inputlayer outputlayer", config_file, config_str);
+  status = ml_train_model_construct_with_conf(config_file.c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_model_compile(handle, NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_get_summary(handle, ML_TRAIN_SUMMARY_TENSOR, NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
  * @brief Main gtest
  */
 int main(int argc, char **argv) {


### PR DESCRIPTION
This PR mainly add `NeuralNetwork::print`. Note that it should be highly
refactored for proper functionality. Confer `@todo`'s in this patch.

**Changes proposed in this PR:**
- add `NeuralNetwork::print`
- implement `model_get_summary`
- Add capi test for `model_get_summary`
- move `ml_train_summary_type_e` to `api-common`
- minor bug fix

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>