### PR TITLE
[neuralNet] Moving batch size property to compile time

### DIFF
--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -392,6 +392,18 @@ int NeuralNetwork::setProperty(std::vector<std::string> values) {
     unsigned int type = parseNetProperty(key);
 
     switch (static_cast<PropertyType>(type)) {
+    case PropertyType::batch_size: {
+      status = setInt(batch_size, value);
+      NN_RETURN_STATUS();
+      for (unsigned int i = 0; i < layers.size(); ++i) {
+        if (layers[i]->getTensorDim().batch() !=
+            static_cast<unsigned int>(batch_size)) {
+          ml_logw("Warning: Batch Size is changing!! : %d -> %d",
+                  layers[i]->getTensorDim().batch(), batch_size);
+          layers[i]->getTensorDim().batch(batch_size);
+        }
+      }
+    } break;
     case PropertyType::cost:
     case PropertyType::loss: {
       cost = (CostType)parseType(value, TOKEN_COST);
@@ -417,20 +429,7 @@ int NeuralNetwork::setTrainConfig(std::vector<std::string> values) {
 
     unsigned int type = parseNetProperty(key);
 
-    /** TODO: disable this batch size  */
     switch (static_cast<PropertyType>(type)) {
-    case PropertyType::batch_size: {
-      status = setInt(batch_size, value);
-      NN_RETURN_STATUS();
-      for (unsigned int i = 0; i < layers.size(); ++i) {
-        if (layers[i]->getTensorDim().batch() !=
-            static_cast<unsigned int>(batch_size)) {
-          ml_logw("Warning: Batch Size is changing!! : %d -> %d",
-                  layers[i]->getTensorDim().batch(), batch_size);
-          layers[i]->getTensorDim().batch(batch_size);
-        }
-      }
-    } break;
     case PropertyType::epochs: {
       int e;
       status = setInt(e, value);
@@ -450,7 +449,7 @@ int NeuralNetwork::setTrainConfig(std::vector<std::string> values) {
     default:
       ml_loge("Error: Unknown Network Property Key");
       status = ML_ERROR_INVALID_PARAMETER;
-      break;
+      return status;
     }
   }
 

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -658,11 +658,10 @@ TEST(nntrainer_capi_nnmodel, train_with_file_01_p) {
   status = ml_train_model_set_dataset(model, dataset);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_train_model_compile(model, "loss=cross", NULL);
+  status = ml_train_model_compile(model, "loss=cross", "batch_size=16", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_train_model_run(model, "epochs=2", "batch_size=16",
-                              "model_file=model.bin", NULL);
+  status = ml_train_model_run(model, "epochs=2", "model_file=model.bin", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_train_model_destroy(model);


### PR DESCRIPTION
Batch size property should be set before compiling for now
Initializing of layers allocates memory for the layers
Setting batch size property with training call requires layers to be re-initialized
which isnt supported yet

resolves #278

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>