### PR TITLE
[neuralnet] Bug fix for setTrainConfig

### DIFF
--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -450,7 +450,7 @@ int NeuralNetwork::setTrainConfig(std::vector<std::string> values) {
     default:
       ml_loge("Error: Unknown Network Property Key");
       status = ML_ERROR_INVALID_PARAMETER;
-      break;
+      return status;
     }
   }
 


### PR DESCRIPTION
Add bug fix for setTrainConfig
Break in switch in default case was hiding the error

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>