### PR TITLE
Fix rpm spec file dependency

### DIFF
--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -94,7 +94,7 @@ HTML pages of lcov results of NNTrainer generated during rpmbuild
 %package -n capi-nntrainer
 Summary:         Tizen Native API for NNTrainer
 Group:           Multimedia/Framework
-Requires:        %{name}=%{version}-%{release}
+Requires:        %{name} = %{version}-%{release}
 %description -n capi-nntrainer
 Tizen Native API wrapper for NNTrainer.
 You can train neural networks efficiently.


### PR DESCRIPTION
This patch fix rpm spec file dependency for `capi-nntrainer`

 Resolves #357

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>