### PR TITLE
[Wait 4 #378] Change neuralnet setConfig to throw

### DIFF
--- a/Applications/Classification/jni/main.cpp
+++ b/Applications/Classification/jni/main.cpp
@@ -343,6 +343,7 @@ bool read(std::vector<std::vector<float>> &inVec,
           std::vector<std::vector<float>> &inLabel, std::string type) {
   std::string file = type + "Set.dat";
 
+  file = data_path + file;
   std::ifstream TrainingSet(file, std::ios::in | std::ios::binary);
 
   if (!TrainingSet.good())
@@ -359,7 +360,7 @@ bool read(std::vector<std::vector<float>> &inVec,
  */
 int main(int argc, char *argv[]) {
   if (argc < 3) {
-    std::cout << "./TransferLearning Config.ini resources\n";
+    std::cout << "./nntrainer_classification Config.ini resources\n";
     exit(0);
   }
   const vector<string> args(argv + 1, argv + argc);
@@ -367,7 +368,7 @@ int main(int argc, char *argv[]) {
   data_path = args[1];
 
   srand(time(NULL));
-  std::string ini_file = data_path + "ini.bin";
+
   std::vector<std::vector<float>> inputVector, outputVector;
   std::vector<std::vector<float>> inputValVector, outputValVector;
   std::vector<std::vector<float>> inputTestVector, outputTestVector;

--- a/Applications/Classification/jni/main.cpp
+++ b/Applications/Classification/jni/main.cpp
@@ -407,9 +407,9 @@ int main(int argc, char *argv[]) {
    * @brief     Neural Network Create & Initialization
    */
   nntrainer::NeuralNetwork NN;
-  NN.setConfig(config);
-  NN.loadFromConfig();
   try {
+    NN.setConfig(config);
+    NN.loadFromConfig();
     NN.init();
   } catch (...) {
     std::cerr << "Error during init" << std::endl;

--- a/Applications/Classification/jni/main_func.cpp
+++ b/Applications/Classification/jni/main_func.cpp
@@ -296,8 +296,9 @@ int main(int argc, char *argv[]) {
    * @brief     Neural Network Create & Initialization
    */
   nntrainer::NeuralNetwork NN;
-  NN.setConfig(config);
+
   try {
+    NN.setConfig(config);
     NN.loadFromConfig();
   } catch (...) {
     std::cerr << "Error during loadFromConfig" << std::endl;

--- a/Applications/Classification/jni/meson.build
+++ b/Applications/Classification/jni/meson.build
@@ -1,9 +1,12 @@
+build_root = meson.build_root()
+res_path = join_paths(meson.current_source_dir(), '..', 'res')
+
 classification_sources = [
   'main.cpp',
   'bitmap_helpers.cpp'
 ]
 
-executable('nntrainer_classification',
+e = executable('nntrainer_classification',
   classification_sources,
   dependencies: [iniparser_dep, nntrainer_dep, tflite_dep],
   include_directories: include_directories('.'),
@@ -11,14 +14,32 @@ executable('nntrainer_classification',
   install_dir: application_install_dir
 )
 
+ini_in_path = join_paths(res_path, 'Classification.ini')
+ini_out_path = join_paths(build_root, 'classification.ini')
+
+# change epoch to 5
+run_command('cp', ini_in_path, ini_out_path)
+run_command(['sed', '-i', 's/Epoch\ \=\ 30000/Epoch\ \=\ 1/', ini_out_path])
+
+test('app_classification', e, args: [ini_out_path, build_root + '/'])
+
 classification_func_sources = [
   'main_func.cpp'
 ]
 
-executable('nntrainer_classification_func',
+e = executable('nntrainer_classification_func',
   classification_func_sources,
   dependencies: [iniparser_dep, nntrainer_dep],
   include_directories: include_directories('.'),
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+ini_in_path = join_paths(res_path, 'Classification_func.ini')
+ini_out_path = join_paths(build_root, 'classification_func.ini')
+
+# change epoch to 5
+run_command('cp', ini_in_path, ini_out_path)
+run_command(['sed', '-i', 's/Epoch\ \=\ 30000/Epoch\ \=\ 1/', ini_out_path])
+
+test('app_classification_func', e, args: [ini_out_path], timeout: 60)

--- a/Applications/Classification/res/Classification_func.ini
+++ b/Applications/Classification/res/Classification_func.ini
@@ -18,14 +18,14 @@ epsilon = 1e-7	# epsilon for adam
 # Layer Section : Name
 [inputlayer]
 Type = input
-HiddenSize = 62720		# Input Layer Dimension
+Input_Shape = 32:1:1:62720	# Input Layer Dimension
 Bias_init_zero = true	# Zero Bias
 Normalization = true
 Activation = sigmoid 	# activation : sigmoid, tanh
 
 [outputlayer]
 Type = fully_connected
-HiddenSize = 10		# Output Layer Dimension ( = Weight Width )
+unit = 10		# Output Layer Dimension ( = Weight Width )
 Bias_init_zero = true
 Activation = softmax 	# activation : sigmoid, softmax
 Weight_Decay = l2norm

--- a/Applications/KNN/jni/meson.build
+++ b/Applications/KNN/jni/meson.build
@@ -1,3 +1,5 @@
+res_path = join_paths(meson.current_source_dir(), '..', 'res')
+
 knn_sources = [
   'main.cpp',
   'bitmap_helpers.cpp'
@@ -5,9 +7,11 @@ knn_sources = [
 
 knn_inc = include_directories('.')
 
-executable('nntrainer_knn',
+e = executable('nntrainer_knn',
   knn_sources,
   dependencies: [iniparser_dep, nntrainer_dep, tflite_dep],
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+test('app_knn', e, args: [res_path + '/'])

--- a/Applications/LogisticRegression/jni/meson.build
+++ b/Applications/LogisticRegression/jni/meson.build
@@ -1,6 +1,9 @@
-executable('nntrainer_logistic',
+res_path = join_paths(meson.current_source_dir(), '..', 'res')
+e = executable('nntrainer_logistic',
   'main.cpp',
   dependencies: [iniparser_dep, nntrainer_dep],
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+test('app_logistic', e, args: [join_paths(res_path, 'LogisticRegression.ini'), join_paths(res_path, 'dataset1.txt')])

--- a/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
+++ b/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
@@ -86,7 +86,7 @@
 /**
  * @brief     Maximum episodes to run
  */
-#define MAX_EPISODES 50000
+#define MAX_EPISODES 300
 
 /**
  * @brief     boolean to reder (only works for openAI/Gym)

--- a/Applications/ReinforcementLearning/DeepQ/jni/meson.build
+++ b/Applications/ReinforcementLearning/DeepQ/jni/meson.build
@@ -1,3 +1,4 @@
+res_path = meson.current_source_dir()
 env_dir='../../Environment'
 
 deepq_sources = [
@@ -23,10 +24,12 @@ if get_option('use_gym')
    deepq_deps += dependency('boost')
 endif
 
-executable('nntrainer_deepq',
+e = executable('nntrainer_deepq',
   deepq_sources,
   dependencies: deepq_deps,
   include_directories: include_directories(env_dir),
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+test('app_DeepQ', e, args: [join_paths(res_path, 'DeepQ.ini')], timeout: 60)

--- a/Applications/Tizen_CAPI/meson.build
+++ b/Applications/Tizen_CAPI/meson.build
@@ -1,13 +1,17 @@
-tizen_capi_file_sources = [
-  'main.c'
-]
+ini_in = join_paths(meson.current_source_dir(), 'Tizen_CAPI_config.ini')
+ini_out = join_paths(meson.build_root(), 'Tizen_CAPI_config.ini')
 
-executable('nntrainer_tizen_capi_file',
-  tizen_capi_file_sources,
+
+e = executable('nntrainer_tizen_capi_file',
+  'main.c',
   dependencies: [iniparser_dep, nntrainer_dep, nntrainer_capi_dep],
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+run_command('cp', ini_in, ini_out)
+test('app_classification_capi_ini', e, timeout: 60)
+
 
 executable('nntrainer_classification_capi_file',
   'capi_file.c',
@@ -16,11 +20,14 @@ executable('nntrainer_classification_capi_file',
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+test('app_classification_capi_file', e, timeout: 60)
 
-executable('nntrainer_classification_capi_func',
+e = executable('nntrainer_classification_capi_func',
   'capi_func.c',
   dependencies: [nntrainer_capi_dep, nntrainer_dep],
   include_directories: include_directories('.'),
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+test('app_classification_capi_func', e, timeout: 60)

--- a/Applications/Training/jni/main.cpp
+++ b/Applications/Training/jni/main.cpp
@@ -247,9 +247,16 @@ int main(int argc, char *argv[]) {
    * @brief     Neural Network Create & Initialization
    */
   nntrainer::NeuralNetwork NN;
-  NN.setConfig(config);
-  NN.loadFromConfig();
-  NN.init();
+
+  try {
+    NN.setConfig(config);
+    NN.loadFromConfig();
+    NN.init();
+  } catch (...) {
+    std::cerr << "Error during initiation" << std::endl;
+    NN.finalize();
+    return -1;
+  }
 
   /**
    * @brief     back propagation

--- a/Applications/Training/jni/meson.build
+++ b/Applications/Training/jni/meson.build
@@ -1,12 +1,17 @@
+build_root = meson.build_root()
+res_path = join_paths(meson.current_source_dir(), '..', 'res')
+
 training_sources = [
   'main.cpp',
   'bitmap_helpers.cpp'
 ]
 
-executable('nntrainer_training',
+e = executable('nntrainer_training',
   training_sources,
   dependencies: [iniparser_dep, nntrainer_dep, tflite_dep],
   include_directories: include_directories('.'),
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+test('app_training', e, args: [join_paths(res_path, 'Training.ini'), res_path + '/'], timeout: 60)

--- a/Applications/mnist/jni/main.cpp
+++ b/Applications/mnist/jni/main.cpp
@@ -290,8 +290,8 @@ int main(int argc, char *argv[]) {
    * @brief     Neural Network Create & Initialization
    */
   nntrainer::NeuralNetwork NN;
-  NN.setConfig(config);
   try {
+    NN.setConfig(config);
     NN.loadFromConfig();
   } catch (...) {
     std::cerr << "Error during loadFromConfig" << std::endl;

--- a/Applications/mnist/jni/meson.build
+++ b/Applications/mnist/jni/meson.build
@@ -9,3 +9,5 @@ executable('nntrainer_mnist',
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+## @todo Add test after #376

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -158,7 +158,10 @@ int ml_train_model_construct_with_conf(const char *model_conf,
   nnmodel = (ml_train_model *)(*model);
   NN = nnmodel->network;
 
-  f = [&]() { return NN->setConfig(model_conf); };
+  f = [&]() {
+    NN->setConfig(model_conf);
+    return ML_ERROR_NONE;
+  };
   status = nntrainer_exception_boundary(f);
   if (status != ML_ERROR_NONE) {
     ml_train_model_destroy(*model);

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -169,10 +169,9 @@ public:
   /**
    * @brief     set configuration file
    * @param[in] config_path configuration file path
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @throw std::invalid_argument when file path is not usuable.
    */
-  int setConfig(std::string config_path);
+  void setConfig(std::string config_path);
 
   /**
    * @brief     get Epoch

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -70,27 +70,7 @@ static bool is_file_exist(std::string file_name) {
   return infile.good();
 }
 
-/**
- * @brief     Parsing Layer Name
- * @param[in] string layer name
- * @retval    vector stored layer name
- */
-std::vector<std::string> parseLayerName(std::string ll) {
-  std::vector<std::string> ret;
-  std::istringstream ss(ll);
-  do {
-    std::string word;
-    ss >> word;
-    if (word.compare("") != 0)
-      ret.push_back(word);
-  } while (ss);
-
-  return ret;
-}
-
-NeuralNetwork::NeuralNetwork() : NeuralNetwork("") {}
-
-NeuralNetwork::NeuralNetwork(std::string config) :
+NeuralNetwork::NeuralNetwork() :
   batch_size(1),
   epoch(1),
   loss(0.0),
@@ -101,20 +81,19 @@ NeuralNetwork::NeuralNetwork(std::string config) :
   continue_train(false),
   iter(0),
   initialized(false),
-  def_name_count(0) {
+  def_name_count(0) {}
+
+NeuralNetwork::NeuralNetwork(std::string config) : NeuralNetwork() {
   this->setConfig(config);
 }
 
-int NeuralNetwork::setConfig(std::string config) {
-  int status = ML_ERROR_NONE;
-
+void NeuralNetwork::setConfig(std::string config) {
   if (!is_file_exist(config)) {
-    ml_loge("Error: Cannot open model configuration file");
-    return ML_ERROR_INVALID_PARAMETER;
+    std::stringstream ss;
+    ss << "Cannot open model configuration file, filename : " << config;
+    throw std::invalid_argument(ss.str().c_str());
   }
   this->config = config;
-
-  return status;
 }
 
 int NeuralNetwork::loadNetworkConfig(void *_ini) {

--- a/test/unittest/unittest_nntrainer_internal.cpp
+++ b/test/unittest/unittest_nntrainer_internal.cpp
@@ -29,28 +29,24 @@
 #include <nntrainer_error.h>
 
 /**
- * @brief Neural Network Model Configuration with ini file (possitive test )
+ * @brief Neural Network Model Configuration with ini file (positive test)
  */
 TEST(nntrainer_NeuralNetwork, setConfig_01_p) {
-  int status = ML_ERROR_NONE;
   std::string config_file = "./test.ini";
   RESET_CONFIG(config_file.c_str());
   replaceString("Layers = inputlayer outputlayer",
                 "Layers = inputlayer outputlayer", config_file, config_str);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig(config_file);
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  EXPECT_NO_THROW(NN.setConfig(config_file));
 }
 
 /**
- * @brief Neural Network Model Configuration with ini file (negative test )
+ * @brief Neural Network Model Configuration with ini file (negative test)
  */
 TEST(nntrainer_NeuralNetwork, setConfig_02_n) {
-  int status = ML_ERROR_NONE;
   std::string config_file = "../test/not_found.ini";
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig(config_file);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  EXPECT_THROW(NN.setConfig(config_file), std::invalid_argument);
 }
 
 /**
@@ -63,8 +59,8 @@ TEST(nntrainer_NeuralNetwork, init_01_p) {
   replaceString("Layers = inputlayer outputlayer",
                 "Layers = inputlayer outputlayer", config_file, config_str);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig(config_file);
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  EXPECT_NO_THROW(NN.setConfig(config_file));
+
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = NN.init();
@@ -79,8 +75,8 @@ TEST(nntrainer_NeuralNetwork, load_config_01_n) {
   RESET_CONFIG("./test.ini");
   replaceString("[Network]", "", "./test.ini", config_str);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig("./test.ini");
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  NN.setConfig("./test.ini");
+
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
@@ -93,8 +89,8 @@ TEST(nntrainer_NeuralNetwork, load_config_02_n) {
   RESET_CONFIG("./test.ini");
   replaceString("adam", "aaaadam", "./test.ini", config_str);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig("./test.ini");
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  NN.setConfig("./test.ini");
+
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
@@ -103,13 +99,14 @@ TEST(nntrainer_NeuralNetwork, load_config_02_n) {
  * @brief Neural Network Model initialization
  */
 TEST(nntrainer_NeuralNetwork, load_config_03_n) {
-  int status = ML_ERROR_NONE;
   RESET_CONFIG("./test.ini");
   replaceString("Input_Shape = 32:1:1:62720", "Input_Shape = 32:1:1:0",
                 "./test.ini", config_str);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig("./test.ini");
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  NN.setConfig("./test.ini");
+
+  /**< C++ exception with description "[TensorDim] Trying to assign value of 0
+   * to tensor dim" thrown in the test body. */
   EXPECT_THROW(NN.loadFromConfig(), std::invalid_argument);
 }
 
@@ -122,8 +119,8 @@ TEST(nntrainer_NeuralNetwork, load_config_04_p) {
   RESET_CONFIG("./test.ini");
   replaceString("Input_Shape = 32:1:1:62720", "", "./test.ini", config_str);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig("./test.ini");
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  NN.setConfig("./test.ini");
+
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
@@ -137,7 +134,8 @@ TEST(nntrainer_NeuralNetwork, load_config_05_n) {
   replaceString("Learning_rate = 0.0001", "Learning_rate = -0.0001",
                 "./test.ini", config_str);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig("./test.ini");
+  NN.setConfig("./test.ini");
+
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
@@ -151,7 +149,8 @@ TEST(nntrainer_NeuralNetwork, load_config_06_p) {
   RESET_CONFIG("./test.ini");
   replaceString("TrainData = trainingSet.dat", "", "./test.ini", config_str);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig("./test.ini");
+  NN.setConfig("./test.ini");
+
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
@@ -166,7 +165,8 @@ TEST(nntrainer_NeuralNetwork, load_config_07_p) {
   replaceString("bias_init_zero = true", "Bias_Init_Zero = false", "./test.ini",
                 config_str);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig("./test.ini");
+  NN.setConfig("./test.ini");
+
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -180,8 +180,8 @@ TEST(nntrainer_NeuralNetwork, init_02_p) {
   RESET_CONFIG("./test.ini");
   replaceString("TestData = testSet.dat", "", "./test.ini", config_str);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig("./test.ini");
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  NN.setConfig("./test.ini");
+
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = NN.init();
@@ -196,8 +196,8 @@ TEST(nntrainer_NeuralNetwork, load_config_07_n) {
   RESET_CONFIG("./test.ini");
   replaceString("LabelData = label.dat", "", "./test.ini", config_str);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig("./test.ini");
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  NN.setConfig("./test.ini");
+
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
@@ -211,8 +211,8 @@ TEST(nntrainer_NeuralNetwork, init_03_p) {
   RESET_CONFIG(config_file.c_str());
   replaceString("ValidData = valSet.dat", "", config_file, config_str);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig(config_file);
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  NN.setConfig(config_file);
+
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = NN.init();
@@ -279,8 +279,7 @@ TEST(nntrainer_Conv2DLayer, initialize_01_p) {
   RESET_CONFIG(config_file.c_str());
   replaceString("ValidData = valSet.dat", "", config_file, config_str2);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig(config_file);
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  NN.setConfig(config_file);
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = NN.init();
@@ -288,7 +287,7 @@ TEST(nntrainer_Conv2DLayer, initialize_01_p) {
 }
 
 /**
- * @brief Flatten Layer
+ * @brief Conv2D Layer
  */
 TEST(nntrainer_Conv2DLayer, initialize_02_p) {
   int status = ML_ERROR_NONE;
@@ -296,8 +295,7 @@ TEST(nntrainer_Conv2DLayer, initialize_02_p) {
   RESET_CONFIG(config_file.c_str());
   replaceString("flatten = false", "flatten = true", config_file, config_str2);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig(config_file);
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  NN.setConfig(config_file);
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = NN.init();
@@ -313,8 +311,7 @@ TEST(nntrainer_Layer, initialize_03_p) {
   RESET_CONFIG(config_file.c_str());
   replaceString("flatten = false", "flatten = true", config_file, config_str2);
   nntrainer::NeuralNetwork NN;
-  status = NN.setConfig(config_file);
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  NN.setConfig(config_file);
   status = NN.loadFromConfig();
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = NN.init();


### PR DESCRIPTION
Change `Neuralnet::setConfig` to throw instead of return status

**This PR also patches:**
- Minor typos
- Delete unused function
- Fix neuralnet ctor delegation order

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>