### PR TITLE
[ Meson ] Add app sanity test

### DIFF
--- a/Applications/Classification/jni/main.cpp
+++ b/Applications/Classification/jni/main.cpp
@@ -343,6 +343,7 @@ bool read(std::vector<std::vector<float>> &inVec,
           std::vector<std::vector<float>> &inLabel, std::string type) {
   std::string file = type + "Set.dat";
 
+  file = data_path + file;
   std::ifstream TrainingSet(file, std::ios::in | std::ios::binary);
 
   if (!TrainingSet.good())
@@ -359,7 +360,7 @@ bool read(std::vector<std::vector<float>> &inVec,
  */
 int main(int argc, char *argv[]) {
   if (argc < 3) {
-    std::cout << "./TransferLearning Config.ini resources\n";
+    std::cout << "./nntrainer_classification Config.ini resources\n";
     exit(0);
   }
   const vector<string> args(argv + 1, argv + argc);
@@ -367,7 +368,7 @@ int main(int argc, char *argv[]) {
   data_path = args[1];
 
   srand(time(NULL));
-  std::string ini_file = data_path + "ini.bin";
+
   std::vector<std::vector<float>> inputVector, outputVector;
   std::vector<std::vector<float>> inputValVector, outputValVector;
   std::vector<std::vector<float>> inputTestVector, outputTestVector;

--- a/Applications/Classification/jni/meson.build
+++ b/Applications/Classification/jni/meson.build
@@ -1,9 +1,12 @@
+build_root = meson.build_root()
+res_path = join_paths(meson.current_source_dir(), '..', 'res')
+
 classification_sources = [
   'main.cpp',
   'bitmap_helpers.cpp'
 ]
 
-executable('nntrainer_classification',
+e = executable('nntrainer_classification',
   classification_sources,
   dependencies: [iniparser_dep, nntrainer_dep, tflite_dep],
   include_directories: include_directories('.'),
@@ -11,14 +14,32 @@ executable('nntrainer_classification',
   install_dir: application_install_dir
 )
 
+ini_in_path = join_paths(res_path, 'Classification.ini')
+ini_out_path = join_paths(build_root, 'classification.ini')
+
+# change epoch to 5
+run_command('cp', ini_in_path, ini_out_path)
+run_command(['sed', '-i', 's/Epoch\ \=\ 30000/Epoch\ \=\ 1/', ini_out_path])
+
+test('app_classification', e, args: [ini_out_path, build_root + '/'])
+
 classification_func_sources = [
   'main_func.cpp'
 ]
 
-executable('nntrainer_classification_func',
+e = executable('nntrainer_classification_func',
   classification_func_sources,
   dependencies: [iniparser_dep, nntrainer_dep],
   include_directories: include_directories('.'),
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+ini_in_path = join_paths(res_path, 'Classification_func.ini')
+ini_out_path = join_paths(build_root, 'classification_func.ini')
+
+# change epoch to 5
+run_command('cp', ini_in_path, ini_out_path)
+run_command(['sed', '-i', 's/Epoch\ \=\ 30000/Epoch\ \=\ 1/', ini_out_path])
+
+test('app_classification_func', e, args: [ini_out_path], timeout: 60)

--- a/Applications/Classification/res/Classification_func.ini
+++ b/Applications/Classification/res/Classification_func.ini
@@ -18,14 +18,14 @@ epsilon = 1e-7	# epsilon for adam
 # Layer Section : Name
 [inputlayer]
 Type = input
-HiddenSize = 62720		# Input Layer Dimension
+Input_Shape = 32:1:1:62720	# Input Layer Dimension
 Bias_init_zero = true	# Zero Bias
 Normalization = true
 Activation = sigmoid 	# activation : sigmoid, tanh
 
 [outputlayer]
 Type = fully_connected
-HiddenSize = 10		# Output Layer Dimension ( = Weight Width )
+unit = 10		# Output Layer Dimension ( = Weight Width )
 Bias_init_zero = true
 Activation = softmax 	# activation : sigmoid, softmax
 Weight_Decay = l2norm

--- a/Applications/KNN/jni/meson.build
+++ b/Applications/KNN/jni/meson.build
@@ -1,3 +1,5 @@
+res_path = join_paths(meson.current_source_dir(), '..', 'res')
+
 knn_sources = [
   'main.cpp',
   'bitmap_helpers.cpp'
@@ -5,9 +7,11 @@ knn_sources = [
 
 knn_inc = include_directories('.')
 
-executable('nntrainer_knn',
+e = executable('nntrainer_knn',
   knn_sources,
   dependencies: [iniparser_dep, nntrainer_dep, tflite_dep],
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+test('app_knn', e, args: [res_path + '/'])

--- a/Applications/LogisticRegression/jni/meson.build
+++ b/Applications/LogisticRegression/jni/meson.build
@@ -1,6 +1,9 @@
-executable('nntrainer_logistic',
+res_path = join_paths(meson.current_source_dir(), '..', 'res')
+e = executable('nntrainer_logistic',
   'main.cpp',
   dependencies: [iniparser_dep, nntrainer_dep],
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+test('app_logistic', e, args: [join_paths(res_path, 'LogisticRegression.ini'), join_paths(res_path, 'dataset1.txt')])

--- a/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
+++ b/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
@@ -86,7 +86,7 @@
 /**
  * @brief     Maximum episodes to run
  */
-#define MAX_EPISODES 50000
+#define MAX_EPISODES 300
 
 /**
  * @brief     boolean to reder (only works for openAI/Gym)

--- a/Applications/ReinforcementLearning/DeepQ/jni/meson.build
+++ b/Applications/ReinforcementLearning/DeepQ/jni/meson.build
@@ -1,3 +1,4 @@
+res_path = meson.current_source_dir()
 env_dir='../../Environment'
 
 deepq_sources = [
@@ -23,10 +24,12 @@ if get_option('use_gym')
    deepq_deps += dependency('boost')
 endif
 
-executable('nntrainer_deepq',
+e = executable('nntrainer_deepq',
   deepq_sources,
   dependencies: deepq_deps,
   include_directories: include_directories(env_dir),
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+test('app_DeepQ', e, args: [join_paths(res_path, 'DeepQ.ini')], timeout: 60)

--- a/Applications/Tizen_CAPI/meson.build
+++ b/Applications/Tizen_CAPI/meson.build
@@ -1,13 +1,17 @@
-tizen_capi_file_sources = [
-  'main.c'
-]
+ini_in = join_paths(meson.current_source_dir(), 'Tizen_CAPI_config.ini')
+ini_out = join_paths(meson.build_root(), 'Tizen_CAPI_config.ini')
 
-executable('nntrainer_tizen_capi_file',
-  tizen_capi_file_sources,
+
+e = executable('nntrainer_tizen_capi_file',
+  'main.c',
   dependencies: [iniparser_dep, nntrainer_dep, nntrainer_capi_dep],
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+run_command('cp', ini_in, ini_out)
+test('app_classification_capi_ini', e, timeout: 60)
+
 
 executable('nntrainer_classification_capi_file',
   'capi_file.c',
@@ -16,11 +20,14 @@ executable('nntrainer_classification_capi_file',
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+test('app_classification_capi_file', e, timeout: 60)
 
-executable('nntrainer_classification_capi_func',
+e = executable('nntrainer_classification_capi_func',
   'capi_func.c',
   dependencies: [nntrainer_capi_dep, nntrainer_dep],
   include_directories: include_directories('.'),
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+test('app_classification_capi_func', e, timeout: 60)

--- a/Applications/Training/jni/meson.build
+++ b/Applications/Training/jni/meson.build
@@ -1,12 +1,17 @@
+build_root = meson.build_root()
+res_path = join_paths(meson.current_source_dir(), '..', 'res')
+
 training_sources = [
   'main.cpp',
   'bitmap_helpers.cpp'
 ]
 
-executable('nntrainer_training',
+e = executable('nntrainer_training',
   training_sources,
   dependencies: [iniparser_dep, nntrainer_dep, tflite_dep],
   include_directories: include_directories('.'),
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+test('app_training', e, args: [join_paths(res_path, 'Training.ini'), res_path + '/'], timeout: 60)

--- a/Applications/mnist/jni/meson.build
+++ b/Applications/mnist/jni/meson.build
@@ -9,3 +9,5 @@ executable('nntrainer_mnist',
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
+
+## @todo Add test after #376


### PR DESCRIPTION
This patch currently check if example apps are running fine.

To make this better, we should add parameterized app test with golden
result plus some negative cases rather than running 1 test per 1 app,
it is not done because it is not the highest priority.

This patch only ensures that it is running fine for current setup(ini
and other stuff)

So this tests does not guarantee that app is running fine for every
cases.

resolves #375
see also #374

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>