### PR TITLE
Unify optimizer initialize

### DIFF
--- a/nntrainer/include/bn_layer.h
+++ b/nntrainer/include/bn_layer.h
@@ -89,14 +89,6 @@ public:
   Tensor backwarding(Tensor in, int iteration);
 
   /**
-   * @brief     set optimizer
-   * @param[in] opt Optimizer
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setOptimizer(Optimizer &opt);
-
-  /**
    * @brief     copy layer
    * @param[in] l layer to copy
    */

--- a/nntrainer/include/conv2d_layer.h
+++ b/nntrainer/include/conv2d_layer.h
@@ -136,14 +136,6 @@ public:
   void setStandardization(bool enable) { this->standardization = enable; };
 
   /**
-   * @brief     Optimizer Setter
-   * @param[in] opt Optimizer
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setOptimizer(Optimizer &opt);
-
-  /**
    * @brief     calculation convolution
    * @param[in] in input tensor data
    * @param[in] indim input tensor dimension

--- a/nntrainer/include/fc_layer.h
+++ b/nntrainer/include/fc_layer.h
@@ -98,14 +98,6 @@ public:
   void setUnit(unsigned int u) { unit = u; };
 
   /**
-   * @brief     Optimizer Setter
-   * @param[in] opt Optimizer
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setOptimizer(Optimizer &opt);
-
-  /**
    * @brief     get the base name for the layer
    * @retval    base name of the layer
    */

--- a/nntrainer/include/input_layer.h
+++ b/nntrainer/include/input_layer.h
@@ -102,14 +102,6 @@ public:
   };
 
   /**
-   * @brief     Set Optimizer
-   * @param[in] opt optimizer
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setOptimizer(Optimizer &opt);
-
-  /**
    * @brief     Initializer of Input Layer
    * @param[in] last last layer
    * @retval #ML_ERROR_NONE Successful.

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -274,7 +274,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int setOptimizer(Optimizer &opt);
+  int setOptimizer(Optimizer &opt);
 
   /**
    * @brief     Activation Setter

--- a/nntrainer/include/optimizer.h
+++ b/nntrainer/include/optimizer.h
@@ -178,17 +178,6 @@ public:
 
   /**
    * @brief     initialize optimizer. Initialize Weight if it is adam
-   * @param[in] d TensorDim
-   * @param[in] setTensor true if the layer need weight update.
-   *            Input Layer and Batch Normalization layer won't need it.
-   *            Therefore, it sets false.
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int initialize(TensorDim d, bool setTensor);
-
-  /**
-   * @brief     initialize optimizer. Initialize Weight if it is adam
    * @param[in] params UpdatableParam list
    * @param[in] param_size size of the array
    * @param[in] setTensor true if the layer need weight update.

--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -61,12 +61,6 @@ int BatchNormalizationLayer::initialize(bool last) {
   return status;
 }
 
-int BatchNormalizationLayer::setOptimizer(Optimizer &opt) {
-  this->opt.setType(opt.getType());
-  this->opt.setOptParam(opt.getOptParam());
-  return this->opt.initialize(dim, false);
-}
-
 void BatchNormalizationLayer::setProperty(const PropertyType type,
                                           const std::string &value) {
   int status = ML_ERROR_NONE;

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -116,14 +116,6 @@ Tensor Conv2DLayer::forwarding(Tensor in, int &status) {
   return hidden;
 };
 
-int Conv2DLayer::setOptimizer(Optimizer &opt) {
-  int status = Layer::setOptimizer(opt);
-  if (status != ML_ERROR_NONE)
-    return status;
-
-  return this->opt.initialize(getParams(), param_size, true);
-}
-
 Tensor Conv2DLayer::backwarding(Tensor derivative, int iteration) {
 
   // Calculate delK : [batch, channel, height, width ] * filter_size

--- a/nntrainer/src/fc_layer.cpp
+++ b/nntrainer/src/fc_layer.cpp
@@ -81,14 +81,6 @@ void FullyConnectedLayer::setProperty(const PropertyType type,
   }
 }
 
-int FullyConnectedLayer::setOptimizer(Optimizer &opt) {
-  int status = Layer::setOptimizer(opt);
-  if (status != ML_ERROR_NONE)
-    return status;
-
-  return this->opt.initialize(dim, true);
-}
-
 Tensor FullyConnectedLayer::forwarding(Tensor in, int &status) {
   Tensor &weight = paramsAt(static_cast<int>(FCParams::weight)).weight;
   Tensor &bias = paramsAt(static_cast<int>(FCParams::bias)).weight;

--- a/nntrainer/src/input_layer.cpp
+++ b/nntrainer/src/input_layer.cpp
@@ -28,13 +28,6 @@
 
 namespace nntrainer {
 
-int InputLayer::setOptimizer(Optimizer &opt) {
-  this->opt.setType(opt.getType());
-  this->opt.setOptParam(opt.getOptParam());
-
-  return this->opt.initialize(dim, false);
-}
-
 void InputLayer::setProperty(const PropertyType type,
                              const std::string &value) {
   int status = ML_ERROR_NONE;

--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -44,7 +44,7 @@ int Layer::setOptimizer(Optimizer &opt) {
   this->opt.setType(opt.getType());
   this->opt.setOptParam(opt.getOptParam());
 
-  return this->opt.initialize(dim, false);
+  return this->opt.initialize(getParams(), param_size, true);
 }
 
 int Layer::checkValidation() {

--- a/nntrainer/src/optimizer.cpp
+++ b/nntrainer/src/optimizer.cpp
@@ -87,26 +87,6 @@ int Optimizer::initialize(std::shared_ptr<UpdatableParam> params,
   return status;
 }
 
-int Optimizer::initialize(TensorDim d, bool set_tensor) {
-  int status = ML_ERROR_NONE;
-
-  if (type == OptType::adam && set_tensor) {
-    Tensor wm = Tensor(d.channel(), d.height(), d.width());
-    Tensor wv = Tensor(d.channel(), d.height(), d.width());
-    wm.setZero();
-    wv.setZero();
-    weight_mv.push_back(std::pair<Tensor, Tensor>(wm, wv));
-
-    Tensor bm = Tensor(1, 1, d.width());
-    Tensor bv = Tensor(1, 1, d.width());
-    bm.setZero();
-    bv.setZero();
-    weight_mv.push_back(std::pair<Tensor, Tensor>(bm, bv));
-  }
-
-  return status;
-}
-
 void Optimizer::apply_gradients(std::shared_ptr<UpdatableParam> params,
                                 unsigned int param_size, int iteration) {
 


### PR DESCRIPTION
Many layer has setOptimizer implemented while layer can hadle all.

**Changes proposed in this PR:**
- Delete unnecessary setOptimizer
- Unify optimizer::initialize signature

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>