### PR TITLE
[layers] Remove extra forwarding definition from layers

### DIFF
--- a/nntrainer/include/bn_layer.h
+++ b/nntrainer/include/bn_layer.h
@@ -69,17 +69,6 @@ public:
   Tensor forwarding(Tensor in, int &status);
 
   /**
-   * @brief     foward propagation : return Input Tensor
-   *            It return Input as it is.
-   * @param[in] input input Tensor from lower layer.
-   * @param[in] output label Tensor.
-   * @retval    normalized input tensor using scaling factor
-   */
-  Tensor forwarding(Tensor in, Tensor output, int &status) {
-    return forwarding(in, status);
-  };
-
-  /**
    * @brief     back propagation
    *            Calculate dJdB & dJdW & Update W & B
    * @param[in] in Input Tensor from lower layer

--- a/nntrainer/include/flatten_layer.h
+++ b/nntrainer/include/flatten_layer.h
@@ -81,15 +81,6 @@ public:
   Tensor forwarding(Tensor in, int &status);
 
   /**
-   * @brief     foward propagation
-   * @param[in] in input Tensor from lower layer.
-   * @param[in] output dummy variable
-   * @param[out] status status
-   * @retval    return Flatten Result
-   */
-  Tensor forwarding(Tensor in, Tensor output, int &status);
-
-  /**
    * @brief     back propagation
    *            Calculate Derivatives
    * @param[in] input Input Tensor from lower layer

--- a/nntrainer/include/input_layer.h
+++ b/nntrainer/include/input_layer.h
@@ -91,17 +91,6 @@ public:
   Tensor forwarding(Tensor in, int &status);
 
   /**
-   * @brief     foward propagation : return Input Tensor
-   *            It return Input as it is.
-   * @param[in] in input Tensor from lower layer.
-   * @param[in] output label Tensor.
-   * @retval    return Input Tensor
-   */
-  Tensor forwarding(Tensor in, Tensor output, int &status) {
-    return forwarding(in, status);
-  };
-
-  /**
    * @brief     Initializer of Input Layer
    * @param[in] last last layer
    * @retval #ML_ERROR_NONE Successful.

--- a/nntrainer/include/pooling2d_layer.h
+++ b/nntrainer/include/pooling2d_layer.h
@@ -97,15 +97,6 @@ public:
   Tensor forwarding(Tensor in, int &status);
 
   /**
-   * @brief     foward propagation : return Pooling
-   * @param[in] in input Tensor from lower layer.
-   * @param[in] output dummy variable
-   * @param[out] status status
-   * @retval    return Pooling Result
-   */
-  Tensor forwarding(Tensor in, Tensor output, int &status);
-
-  /**
    * @brief     back propagation
    *            Calculate Delivatives
    * @param[in] input Input Tensor from lower layer

--- a/nntrainer/src/flatten_layer.cpp
+++ b/nntrainer/src/flatten_layer.cpp
@@ -47,10 +47,6 @@ Tensor FlattenLayer::forwarding(Tensor in, int &status) {
   return hidden;
 }
 
-Tensor FlattenLayer::forwarding(Tensor in, Tensor output, int &status) {
-  return forwarding(in, status);
-}
-
 Tensor FlattenLayer::backwarding(Tensor in, int iteration) {
   Tensor ret = in;
   ret.setDim(input_dim);

--- a/nntrainer/src/pooling2d_layer.cpp
+++ b/nntrainer/src/pooling2d_layer.cpp
@@ -65,10 +65,6 @@ Tensor Pooling2DLayer::forwarding(Tensor in, int &status) {
   return hidden;
 }
 
-Tensor Pooling2DLayer::forwarding(Tensor in, Tensor output, int &status) {
-  return forwarding(in, status);
-}
-
 Tensor Pooling2DLayer::backwarding(Tensor derivative, int iteration) {
   unsigned int batch = input_dim.batch();
   unsigned int channel = input_dim.channel();


### PR DESCRIPTION
Remove extra forwarding declaration and definition from layers
forwarding (in, out, status) is only to be supported by loss
it is not needed by other layers and should not be supported

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>