### PR TITLE
Add property handler

### DIFF
--- a/nntrainer/include/properties.h
+++ b/nntrainer/include/properties.h
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: Apache-2.0-only
+/**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file properties.h
+ * @date 03 Aug 2020
+ * @brief Properties handler for NNtrainer.
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_PROPERTIES_H__
+#define __NNTRAINER_PROPERTIES_H__
+#ifdef __cplusplus
+
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <nntrainer_error.h>
+
+namespace nntrainer {
+template <typename T> struct prop_traits {
+  static constexpr bool is_property = false; /**< check if this is property */
+
+  typedef bool value_type; /**< actual value type of given property */
+
+  /**
+   * @brief validation logic for type T
+   * @param[in] value Target to have registration
+   */
+  static bool is_valid(value_type value) {  throw std::runtime_error("no trait type can be validated"); }
+
+  /**
+   * @brief get string key of current property
+   */
+  static std::string getKey() {  throw std::runtime_error("no trait type have a key"); }
+
+  /**
+   * @brief get default value of current type
+   */
+  static value_type getDefault() {
+    throw std::runtime_error("no trait type does not have default");
+  }
+
+  /**
+   * @brief serialization for type T
+   * @param[in] target Target to be converted to string
+   */
+  static std::string serialize(value_type target) {
+    throw std::runtime_error("Only property type can be serialized");
+  }
+
+  /**
+   * @brief deserialization for type T
+   * @param[in] str string to be converted to actual type T
+   * @throw std::runtime_error if T is not property
+   * @throw std::invalid_argument if @a str is not deserializable.
+   */
+  static value_type deserialize(std::string &str) {
+    throw std::runtime_error("Only property type can be deserialized");
+  }
+};
+
+/*****************************************************************************
+ *  Property registration part.                                              *
+ *  If you want to add a property, only this part need change.               *
+ *  You only have to add property struct and prop_traits.                    *
+ *                                                                           *
+ *  It is recommened to use unique key for each types.                       *
+ *  However, it is allowed to use duplicated key                             *
+ *  When those properties are mutually exclusive                             *
+ *****************************************************************************/
+
+/**< color is here for demonstration purpose. */
+
+enum class Color {
+  black,
+  white,
+  unknown,
+};
+
+/**
+ * @brief trait specialization part
+ */
+template <> struct prop_traits<Color> {
+
+  static constexpr bool is_property = true;
+
+  typedef Color value_type;
+
+  static std::string getKey() { return "color"; }
+
+  static bool is_valid(Color c) { return c != Color::unknown; }
+
+  static Color getDefault() { return Color::unknown; }
+
+  static std::string serialize(Color c) {
+    switch (c) {
+    case Color::black:
+      return "black";
+    case Color::white:
+      return "white";
+    default:
+      return "unknown";
+    }
+  }
+
+  static Color deserialize(const std::string &val) {
+    if (val == "black") {
+      return Color::black;
+    }
+    if (val == "white") {
+      return Color::white;
+    }
+    return Color::unknown;
+  }
+};
+
+/*****************************************************************************
+ *  End of property registration part.                                       *
+ *****************************************************************************/
+
+/**
+ * @brief base class of property holder. This property holder enables set/get
+ * access to props by string
+ */
+class PropertyHolder {
+
+public:
+  /**
+   * @brief virtual destructor of class
+   */
+  virtual ~PropertyHolder() {}
+
+  /**
+   * @brief setProperty from string representation of value
+   * @param[in] value to be deserialized by prop trait.
+   * @throw std::invalid_argument if validation fails
+   */
+  virtual void setProp(const std::string &val) = 0;
+
+  /**
+   * @brief getProperty to string representation of value
+   * @retval string reprenstation of current value
+   */
+  virtual std::string getProp() = 0;
+};
+
+/**
+ * @brief actual holder of property. This class holds pointer of actual type.
+ * Which will be residing on Properties::items;
+ */
+template <typename T> class _PropertyHolder : public PropertyHolder {
+  static_assert(prop_traits<T>::is_property, "Only property type can be used");
+
+public:
+  typedef typename prop_traits<T>::value_type value_type;
+  typedef T prop_type;
+
+  /**
+   * @brief property holder destructor
+   */
+  ~_PropertyHolder() {}
+
+  _PropertyHolder() {}
+
+  value_type get() { return data; }
+
+  void set(value_type _data) {
+    if (prop_traits<T>::is_valid(_data) == false) {
+      std::stringstream ss;
+      ss << "current value is not valid: " << prop_traits<T>::serialize(_data);
+
+      throw std::invalid_argument(ss.str().c_str());
+    }
+    force_set(_data);
+  }
+
+  void force_set(value_type _data) {
+    data = _data;
+  }
+
+  /**
+   * @copydoc PropertyHolder::setProp(const std::string &val)
+   */
+  void setProp(const std::string &val) {
+    value_type value = prop_traits<T>::deserialize(val);
+    set(value);
+  }
+
+  /**
+   * @copydoc PropertyHolder::getProp()
+   */
+  std::string getProp() { return prop_traits<T>::serialize(data); }
+
+private:
+  value_type data; /**< Actual data */
+};
+
+/**
+ * @brief Multiple property handler.
+ */
+template <typename... _PropTypes> struct Properties {
+  typedef std::tuple<_PropertyHolder<_PropTypes>...> TupleType;
+  typedef std::map<std::string, PropertyHolder *> MapType;
+
+  /**
+   * @brief contructor of properties. inits properties to default value and @a
+   * type_map
+   */
+  Properties() { init_properties(items); }
+
+  /**
+   * @brief Property getter that uses type directly. It is recommened to use
+   * this instead of string verion of getter
+   * @code LayerType foo = std::get<LayerType>();
+   */
+  template <typename _PropType> _PropType get() {
+    return std::get<_PropertyHolder<_PropType>>(items).get();
+  }
+
+  /**
+   * @brief Property setter that uses type directly. It is recommened to use
+   * this instead of string verion of setter
+   * @throw exception::not_supported if property is not supported.
+   * @code std::set<Beta1>(1.0);
+   */
+  template <typename _PropType>
+  void set(typename prop_traits<_PropType>::value_type &&value) {
+    std::get<_PropertyHolder<_PropType>>(items).set(
+      std::forward<prop_traits<_PropType>>(value));
+  }
+
+  /**
+   * @brief String version of property getter
+   * @param[in] key key to find. from prop_traits<Type>::getKey()
+   * @throw exception::not_supported if there are no key in the type_map
+   */
+  std::string get(const std::string &key) {
+    MapType::iterator lb = type_map.find(key);
+
+    if (lb != type_map.end()) {
+      std::stringstream ss;
+      ss << "key is not valid for current property type: " << key;
+      throw exception::not_supported(ss.str());
+    }
+
+    return lb->second->getProp();
+  }
+
+  /**
+   * @brief String version of property getter
+   * @param[in] key key to find. from prop_traits<Type>::getKey()
+   * @param[in] val value to set will eventually throw @a std::invalid_argument
+   * if @a val is not valid.
+   * @throw exception::not_supported if key is not valid.
+   */
+  void set(const std::string &key, const std::string &val) {
+    MapType::iterator lb = type_map.lower_bound(key);
+
+    if (lb == type_map.end()) {
+      std::stringstream ss;
+      ss << "key is not valid for current property type: " << key;
+      throw exception::not_supported(ss.str());
+    }
+
+    lb->second->setProp(val);
+  }
+
+  /**
+   * @brief load fle from vector of string
+   * @param[in] v vector reprenstaion of key, value as {"key = value", "key2 =
+   * value2"}
+   */
+  void load(const std::vector<std::string> &v) {
+    std::string key, val;
+    for (auto &i : v) {
+      // getKeyVal(i, key, val);
+      /**< NYI */
+      // set(key, val)
+    }
+  }
+
+  /**
+   * @brief load fle from string bar reprentation
+   * @param[in] bar_repr representation that takes like "key = value | key2 =
+   * value2"
+   */
+  void load(const std::string &bar_repr) { /**< NYI */
+  }
+
+  /**
+   * @brief load Ini Model file to property.
+   * @param[in] path of the ini file
+   */
+  void loadIni(const std::string &path) { /**< NYI */
+  }
+
+  /**
+   * @brief export current property to Ini
+   * @param[in] path of the ini file
+   */
+  void saveIni(const std::string &path){/**< NYI */};
+
+private:
+  MapType type_map; /**< Helper map to get/set in string representation */
+  TupleType items;  /**< Actual property holder */
+
+  /// base case when tuple has reached the last (this is erroneuous case)
+  template <std::size_t I = 0, typename... Tp>
+  inline typename std::enable_if<I == sizeof...(Tp), void>::type
+  init_properties(std::tuple<Tp...> &t) {
+    return;
+  }
+
+  /// general case
+  template <std::size_t I = 0, typename... Tp>
+    inline typename std::enable_if_t <
+    I<sizeof...(Tp), void> init_properties(std::tuple<Tp...> &t) {
+
+    using PropHolderType = std::decay_t<decltype(std::get<I>(t))>;
+
+    using PropType = typename PropHolderType::prop_type;
+
+    std::string key = prop_traits<PropType>::getKey();
+    PropertyHolder* item = &std::get<I>(t);
+
+    /// setting default value, this bypasses validation on purpose.
+    std::get<I>(t).force_set(prop_traits<PropType>::getDefault());
+
+    auto ret = type_map.insert(MapType::value_type(key, item));
+
+    if (ret.second == false) {
+      throw std::runtime_error("Duplicated entry for prop types.");
+    }
+
+    return init_properties<I + 1, Tp...>(t);
+  }
+};
+
+} /* namespace nntrainer */
+
+#endif /* __cplusplus */
+#endif /* __POOLING_LAYER_H__ */

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -73,6 +73,7 @@ nntrainer_headers = [
   'include/tensor.h',
   'include/tensor_dim.h',
   'include/util_func.h',
+  'include/properties.h',
   '../api/nntrainer-api-common.h'
 ]
 

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -260,6 +260,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/util_func.h
 %{_includedir}/nntrainer/parse_util.h
 %{_includedir}/nntrainer/addition_layer.h
+%{_includedir}/nntrainer/properties.h
 %{_includedir}/nntrainer/nntrainer-api-common.h
 %{_libdir}/pkgconfig/nntrainer.pc
 

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -21,7 +21,8 @@ test_target = [
   'unittest_nntrainer_tensor',
   'unittest_util_func',
   'unittest_databuffer_file',
-  'unittest_nntrainer_modelfile'
+  'unittest_nntrainer_modelfile',
+  'unittest_properties'
 ]
 
 foreach target: test_target

--- a/test/unittest/unittest_properties.cpp
+++ b/test/unittest/unittest_properties.cpp
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: Apache-2.0-only
+/**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file properties.h
+ * @date 03 Aug 2020
+ * @brief Properties handler for NNtrainer.
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <properties.h>
+#include <vector>
+
+namespace Example {
+enum class FruitType {
+  POME,
+  DRUPE,
+  BERRY,
+  MELON,
+  CITRUS,
+  TROPICAL,
+  UNKNOWN,
+};
+
+enum class FruitColor {
+  WHITE,
+  ORANGE,
+  RED,
+  GREEN,
+  BLACK,
+  UNKNOWN,
+};
+
+struct FruitSize {};
+
+} // namespace Example
+
+namespace nntrainer {
+/**
+ * @brief trait specialization part
+ */
+template <> struct prop_traits<Example::FruitType> {
+
+  static constexpr bool is_property = true;
+
+  typedef Example::FruitType value_type;
+
+  static std::string getKey() { return "type"; }
+
+  static bool is_valid(value_type c) { return c != value_type::UNKNOWN; }
+
+  static value_type getDefault() { return value_type::UNKNOWN; }
+
+  static std::string serialize(value_type c) {
+    switch (c) {
+    case value_type::POME:
+      return "pome";
+    case value_type::DRUPE:
+      return "drupe";
+    case value_type::BERRY:
+      return "berry";
+    case value_type::MELON:
+      return "melon";
+    case value_type::CITRUS:
+      return "citrus";
+    case value_type::TROPICAL:
+      return "tropical";
+    case value_type::UNKNOWN:
+      return "unknown";
+    default:
+      throw std::invalid_argument("given parameter is not serializable");
+    }
+  }
+
+  static value_type deserialize(const std::string &val) {
+    if (val == "pome")
+      return value_type::POME;
+    if (val == "drupe")
+      return value_type::DRUPE;
+    if (val == "berry")
+      return value_type::BERRY;
+    if (val == "melon")
+      return value_type::MELON;
+    if (val == "citrus")
+      return value_type::CITRUS;
+    if (val == "tropical")
+      return value_type::TROPICAL;
+    if (val == "unknown")
+      return value_type::UNKNOWN;
+    throw std::invalid_argument("given value is not deserializable");
+  }
+};
+
+template <> struct prop_traits<Example::FruitColor> {
+  static constexpr bool is_property = true;
+
+  typedef Example::FruitColor value_type;
+
+  static std::string getKey() { return "color"; }
+
+  static bool is_valid(value_type c) { return c != value_type::UNKNOWN; }
+
+  static value_type getDefault() { return value_type::UNKNOWN; }
+
+  static std::string serialize(value_type c) {
+    switch (c) {
+    case value_type::WHITE:
+      return "white";
+    case value_type::ORANGE:
+      return "orange";
+    case value_type::RED:
+      return "red";
+    case value_type::GREEN:
+      return "green";
+    case value_type::BLACK:
+      return "black";
+    case value_type::UNKNOWN:
+      return "unknown";
+    default:
+      /// should not reach here
+      throw std::invalid_argument("c is not serializable");
+    }
+  }
+
+  static value_type deserialize(const std::string &val) {
+    if (val == "white")
+      return value_type::WHITE;
+    if (val == "orange")
+      return value_type::ORANGE;
+    if (val == "red")
+      return value_type::RED;
+    if (val == "green")
+      return value_type::GREEN;
+    if (val == "black")
+      return value_type::BLACK;
+    if (val == "unknown")
+      return value_type::UNKNOWN;
+    throw std::invalid_argument("given value is not deserializable");
+  }
+};
+
+template <> struct prop_traits<Example::FruitSize> {
+  static constexpr bool is_property = true;
+
+  typedef int value_type;
+
+  static std::string getKey() { return "size"; }
+
+  static bool is_valid(value_type c) { return c > 0; }
+
+  static value_type getDefault() { return 0; }
+
+  static std::string serialize(value_type c) { return std::to_string(c); }
+
+  static value_type deserialize(const std::string &val) {
+    return std::stoi(val.c_str());
+  }
+};
+} // namespace nntrainer
+
+namespace prop_test {
+template <typename T> struct test_cases {
+  static const std::vector<T> validValues() {
+    throw std::runtime_error("no test case available");
+  } /**< valid values to be tested */
+
+  static const std::vector<std::string> validStrings() {
+    throw std::runtime_error("no test case available");
+  } /**< valid strings to be tested, should be aligned with valid_values */
+
+  static const std::vector<T> notValidValues() {
+    throw std::runtime_error("no test case available");
+  } /**< invalid values for negative cases (should throw error when check valid)
+     */
+
+  static const std::vector<std::string> notValidStrings() {
+    throw std::runtime_error("no test case available");
+  } /**< invalid strings for negative cases (should NOT throw error when
+       deserialize, should throw error when check valid) */
+
+  static const std::vector<std::string> erronuousStrings() {
+    throw std::runtime_error("no test case available");
+  } /**< invalid strings for negative cases (should throw error because it is
+       not deserializable) */
+};
+
+template <> struct test_cases<Example::FruitType> {
+  typedef nntrainer::prop_traits<Example::FruitType>::value_type value_type;
+
+  static const std::vector<value_type> validValues() {
+    return {value_type::POME,  value_type::DRUPE,  value_type::BERRY,
+            value_type::MELON, value_type::CITRUS, value_type::TROPICAL};
+  }
+
+  static const std::vector<std::string> validStrings() {
+    return {"pome", "drupe", "berry", "melon", "citrus", "tropical"};
+  }
+
+  static const std::vector<value_type> notValidValues() {
+    return {value_type::UNKNOWN};
+  }
+
+  static const std::vector<std::string> notValidStrings() {
+    return {"unknown"};
+  }
+
+  static const std::vector<std::string> erronuousStrings() {
+    return {"pame", "drape", "verry"};
+  }
+};
+
+template <> struct test_cases<Example::FruitColor> {
+  typedef nntrainer::prop_traits<Example::FruitColor>::value_type value_type;
+
+  static const std::vector<value_type> validValues() {
+    return {value_type::WHITE, value_type::ORANGE, value_type::RED,
+            value_type::GREEN, value_type::BLACK};
+  }
+
+  static const std::vector<std::string> validStrings() {
+    return {"white", "orange", "red", "green", "black"};
+  }
+
+  static const std::vector<value_type> notValidValues() {
+    return {value_type::UNKNOWN};
+  }
+
+  static const std::vector<std::string> notValidStrings() {
+    return {"unknown"};
+  }
+
+  static const std::vector<std::string> erronuousStrings() {
+    return {"whate", "abcd", "kdb"};
+  }
+};
+
+template <> struct test_cases<Example::FruitSize> {
+  typedef nntrainer::prop_traits<Example::FruitSize>::value_type value_type;
+
+  static const std::vector<value_type> validValues() {
+    return {1, 2, 3, 4, 5, 6};
+  }
+
+  static const std::vector<std::string> validStrings() {
+    return {"1", "2", "3", "4", "5", "6"};
+  }
+
+  static const std::vector<value_type> notValidValues() { return {0, -1, -2}; }
+
+  static const std::vector<std::string> notValidStrings() {
+    return {"0", "-1", "-2"};
+  }
+
+  static const std::vector<std::string> erronuousStrings() {
+    return {"i_am", "not ", "integer "};
+  }
+};
+} // namespace prop_test
+
+template <typename T> class PropertyTest : public testing::Test {};
+
+/** todo add test case for unregistered proptraits */
+
+TYPED_TEST_CASE_P(PropertyTest);
+
+TYPED_TEST_P(PropertyTest, validValuesAreValid_p) {
+  for (auto &i : prop_test::test_cases<TypeParam>::validValues())
+    EXPECT_TRUE(nntrainer::prop_traits<TypeParam>::is_valid(i));
+}
+
+TYPED_TEST_P(PropertyTest, validValuesAreSerializable_p) {
+  auto v = prop_test::test_cases<TypeParam>::validValues();
+  auto s = prop_test::test_cases<TypeParam>::validStrings();
+
+  for (size_t i = 0; i < v.size(); i++)
+    EXPECT_EQ(nntrainer::prop_traits<TypeParam>::serialize(v[i]), s[i]);
+}
+
+TYPED_TEST_P(PropertyTest, validStringsAreDeserializable_p) {
+  auto v = prop_test::test_cases<TypeParam>::validValues();
+  auto s = prop_test::test_cases<TypeParam>::validStrings();
+
+  for (size_t i = 0; i < v.size(); i++)
+    EXPECT_EQ(v[i], nntrainer::prop_traits<TypeParam>::deserialize(s[i]));
+}
+
+TYPED_TEST_P(PropertyTest, notValidValuesAreNotValid_n) {
+  for (auto &i : prop_test::test_cases<TypeParam>::notValidValues())
+    EXPECT_FALSE(nntrainer::prop_traits<TypeParam>::is_valid(i));
+}
+
+TYPED_TEST_P(PropertyTest, notValidValuesAreSerializable_n) {
+  auto v = prop_test::test_cases<TypeParam>::notValidValues();
+  auto s = prop_test::test_cases<TypeParam>::notValidStrings();
+
+  for (size_t i = 0; i < v.size(); i++)
+    EXPECT_EQ(nntrainer::prop_traits<TypeParam>::serialize(v[i]), s[i]);
+}
+
+TYPED_TEST_P(PropertyTest, notValidStringsAreDeserializable_n) {
+  auto v = prop_test::test_cases<TypeParam>::notValidValues();
+  auto s = prop_test::test_cases<TypeParam>::notValidStrings();
+
+  for (size_t i = 0; i < v.size(); i++)
+    EXPECT_EQ(v[i], nntrainer::prop_traits<TypeParam>::deserialize(s[i]));
+}
+
+TYPED_TEST_P(PropertyTest, errorneuousStringThrowInvalidArgument_n) {
+  for (auto &i : prop_test::test_cases<TypeParam>::erronuousStrings())
+    EXPECT_THROW(nntrainer::prop_traits<TypeParam>::deserialize(i),
+                 std::invalid_argument);
+}
+
+TYPED_TEST_P(PropertyTest, singlePropertiesSetGetValidType_p) {
+  nntrainer::Properties<TypeParam> props;
+  for (auto &i : prop_test::test_cases<TypeParam>::validValues()) {
+    EXPECT_NO_THROW(props.template set<TypeParam>(i));
+    EXPECT_EQ(props.template get<TypeParam>(), i);
+  }
+}
+
+TYPED_TEST_P(PropertyTest, singlePropertiesSetGetValidString_p) {
+  nntrainer::Properties<TypeParam> props;
+  std::string key = nntrainer::prop_traits<TypeParam>::getKey();
+
+  for (auto &i : prop_test::test_cases<TypeParam>::validStrings()) {
+    EXPECT_NO_THROW(props.set(key, i));
+    EXPECT_EQ(props.get(key), i);
+  }
+}
+
+// TYPED_TEST_P(PropertyTest,
+// singlePropertiesSetErroneuousStringThrowInvalidArgument_n){
+
+// }
+
+// TYPED_TEST_P(PropertyTest,
+// singlePropertiesSetInvalidStringThrowInvalidArgument_n){
+
+// }
+
+// TYPED_TEST_P(PropertyTest, singlePropertiesGetInValidType_n) {
+//   /// This will make a compile time error so commented
+// }
+
+// TYPED_TEST_P(PropertyTest, singlePropertiesGetValidInvalidKey_n) {
+
+// }
+
+REGISTER_TYPED_TEST_CASE_P(
+  PropertyTest, validValuesAreValid_p, validValuesAreSerializable_p,
+  validStringsAreDeserializable_p, notValidValuesAreNotValid_n,
+  notValidValuesAreSerializable_n, notValidStringsAreDeserializable_n,
+  errorneuousStringThrowInvalidArgument_n, singlePropertiesSetGetValidType_p,
+  singlePropertiesSetGetValidString_p);
+
+using ExamplePropertyTypes =
+  ::testing::Types<Example::FruitType, Example::FruitColor, Example::FruitSize>;
+
+INSTANTIATE_TYPED_TEST_CASE_P(ExampleTest, PropertyTest, ExamplePropertyTypes);
+
+/// @todo instantiate test case with real types (from nntrainer)
+
+/// @todo Add parametrized test for proptypes
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    ml_loge("Failed to init gtest\n");
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    ml_loge("Failed to run test.\n");
+  }
+
+  return result;
+}


### PR DESCRIPTION
Add property handler. Current validation of `setProperty` is not done
centrally, hiding bugs when invalid props are given as well as resulting
in many duplicated codes.

This property handler take care of save, load, setting default,
validation of props. So there is no need to take care of properties.
plus, this would enable automated model file save.

See also: #269, #395, #392, #391

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>