### PR TITLE
Tizen C-API application bug fix

### DIFF
--- a/Applications/Tizen_CAPI/capi_file.c
+++ b/Applications/Tizen_CAPI/capi_file.c
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
 
   /* create dataset */
   status = ml_train_dataset_create_with_file(&dataset, "trainingSet.dat",
-                                             "valSet.dat", NULL);
+                                             "trainingSet.dat", NULL);
   NN_RETURN_STATUS();
 
   /* set property for dataset */


### PR DESCRIPTION
issue #377 has occurred since #403.

Found that current classification assumes to have trainingSet as a
validationSet.

Fixed accordingly, which resolves #377

I think it is hard to say as a bug though, this patch enables training.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>