### PR TITLE
[Tensor] Enable default copy constructor @open sesame 08/10 14:32

### DIFF
--- a/nntrainer/include/activation_layer.h
+++ b/nntrainer/include/activation_layer.h
@@ -64,14 +64,14 @@ public:
   void save(std::ofstream &file){/* noop */};
 
   /**
-   * @copydoc Layer::forwarding(sharedTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensor in)
    */
-  sharedTensor forwarding(sharedTensor in);
+  sharedConstTensor forwarding(sharedConstTensor in);
 
   /**
-   * @copydoc Layer::backwarding(sharedTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
    */
-  sharedTensor backwarding(sharedTensor in, int iteration);
+  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
 
   /**
    * @brief     copy layer

--- a/nntrainer/include/bn_layer.h
+++ b/nntrainer/include/bn_layer.h
@@ -62,14 +62,14 @@ public:
   BatchNormalizationLayer &operator=(BatchNormalizationLayer &&rhs) = default;
 
   /**
-   * @copydoc Layer::forwarding(sharedTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensor in)
    */
-  sharedTensor forwarding(sharedTensor in);
+  sharedConstTensor forwarding(sharedConstTensor in);
 
   /**
-   * @copydoc Layer::backwarding(sharedTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
    */
-  sharedTensor backwarding(sharedTensor in, int iteration);
+  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
 
   /**
    * @brief     copy layer

--- a/nntrainer/include/conv2d_layer.h
+++ b/nntrainer/include/conv2d_layer.h
@@ -84,14 +84,14 @@ public:
   void save(std::ofstream &file);
 
   /**
-   * @copydoc Layer::forwarding(sharedTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensor in)
    */
-  sharedTensor forwarding(sharedTensor in);
+  sharedConstTensor forwarding(sharedConstTensor in);
 
   /**
-   * @copydoc Layer::backwarding(sharedTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
    */
-  sharedTensor backwarding(sharedTensor in, int iteration);
+  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
 
   /**
    * @brief     copy layer
@@ -140,7 +140,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int conv2d(float *in, TensorDim indim, float *kernel, TensorDim kdim,
+  int conv2d(float *in, TensorDim indim, const float *kernel, TensorDim kdim,
              float *out, unsigned int const *stride, float bias);
 
   /* TO DO : support keras type of padding */

--- a/nntrainer/include/fc_layer.h
+++ b/nntrainer/include/fc_layer.h
@@ -66,14 +66,14 @@ public:
   void save(std::ofstream &file);
 
   /**
-   * @copydoc Layer::forwarding(sharedTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensor in)
    */
-  sharedTensor forwarding(sharedTensor in);
+  sharedConstTensor forwarding(sharedConstTensor in);
 
   /**
-   * @copydoc Layer::backwarding(sharedTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
    */
-  sharedTensor backwarding(sharedTensor in, int iteration);
+  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
 
   /**
    * @brief     copy layer

--- a/nntrainer/include/flatten_layer.h
+++ b/nntrainer/include/flatten_layer.h
@@ -73,14 +73,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensor in)
    */
-  sharedTensor forwarding(sharedTensor in);
+  sharedConstTensor forwarding(sharedConstTensor in);
 
   /**
-   * @copydoc Layer::backwarding(sharedTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
    */
-  sharedTensor backwarding(sharedTensor in, int iteration);
+  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
 
   /**
    * @brief     copy layer

--- a/nntrainer/include/input_layer.h
+++ b/nntrainer/include/input_layer.h
@@ -74,14 +74,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensor in)
    */
-  sharedTensor forwarding(sharedTensor in);
+  sharedConstTensor forwarding(sharedConstTensor in);
 
   /**
-   * @copydoc Layer::backwarding(sharedTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
    */
-  sharedTensor backwarding(sharedTensor in, int iteration);
+  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
 
   /**
    * @brief     Initializer of Input Layer

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -171,7 +171,7 @@ public:
    * @param[in] in List of Input Tensors taken by this layer
    * @retval    List of Output Tensors
    */
-  virtual sharedTensor forwarding(sharedTensor in) = 0;
+  virtual sharedConstTensor forwarding(sharedConstTensor in) = 0;
 
   /**
    * @brief     Back Propagation of a layer
@@ -179,7 +179,8 @@ public:
    * @param[in] iteration Iteration value for the Optimizer
    * @retval    Derivative List of Tensor for the previous layer
    */
-  virtual sharedTensor backwarding(sharedTensor in, int iteration) = 0;
+  virtual sharedConstTensor backwarding(sharedConstTensor in,
+                                        int iteration) = 0;
 
   /**
    * @brief     Initialize the layer

--- a/nntrainer/include/lazy_tensor.h
+++ b/nntrainer/include/lazy_tensor.h
@@ -40,7 +40,7 @@ public:
    * @brief Constructor of Lazy Tensor, Tensor is copied to gaurantee
    * immutability
    */
-  LazyTensor(const Tensor &from) { target = Tensor(from); };
+  LazyTensor(const Tensor &from) { target.copy(from); };
 
   /**
    * @brief     Wrapper method of add_i. see tensor.h for more detail

--- a/nntrainer/include/loss_layer.h
+++ b/nntrainer/include/loss_layer.h
@@ -42,9 +42,9 @@ public:
   ~LossLayer(){};
 
   /**
-   * @copydoc Layer::forwarding(sharedTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensor in)
    */
-  sharedTensor forwarding(sharedTensor in);
+  sharedConstTensor forwarding(sharedConstTensor in);
 
   /**
    * @brief     Forward Propagation of a layer
@@ -52,12 +52,12 @@ public:
    * @param[in] label List of Label Tensors for the model
    * @retval    List of Input Tensors as it is.
    */
-  sharedTensor forwarding(sharedTensor in, sharedTensor label);
+  sharedConstTensor forwarding(sharedConstTensor in, sharedConstTensor label);
 
   /**
-   * @copydoc Layer::backwarding(sharedTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
    */
-  sharedTensor backwarding(sharedTensor in, int iteration);
+  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
 
   /**
    * @brief     read layer Weight & Bias data from file

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -138,7 +138,7 @@ public:
    * @param[in] input List of Input Tensors taken by the neural network
    * @retval    List of Output Tensors
    */
-  sharedTensor forwarding(sharedTensor input);
+  sharedConstTensor forwarding(sharedConstTensor input);
 
   /**
    * @brief     Forward Propagation of the neural network
@@ -146,15 +146,17 @@ public:
    * @param[in] label List of Label Tensors for the model
    * @retval    List of Output Tensors
    */
-  sharedTensor forwarding(sharedTensor input, sharedTensor label);
+  sharedConstTensor forwarding(sharedConstTensor input,
+                               sharedConstTensor label);
 
   /**
-   * @brief     Forward Propagation of the neural network
+   * @brief     Backward Propagation of the neural network
    * @param[in] input List of Input Tensors taken by the neural network
    * @param[in] label List of Label Tensors for the model
    * @param[in] iteration Iteration Number for the optimizer
    */
-  void backwarding(sharedTensor input, sharedTensor label, int iteration);
+  void backwarding(sharedConstTensor input, sharedConstTensor label,
+                   int iteration);
 
   /**
    * @brief     save model and training parameters into file

--- a/nntrainer/include/optimizer.h
+++ b/nntrainer/include/optimizer.h
@@ -248,7 +248,7 @@ private:
   OptParam popt;
 
   /**
-   * @brief Internal Tesnors for adam Optimizer
+   * @brief Internal Tensors for adam Optimizer
    */
   std::vector<std::pair<Tensor, Tensor>> weight_mv;
 };

--- a/nntrainer/include/pooling2d_layer.h
+++ b/nntrainer/include/pooling2d_layer.h
@@ -89,14 +89,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensor in)
    */
-  sharedTensor forwarding(sharedTensor in);
+  sharedConstTensor forwarding(sharedConstTensor in);
 
   /**
-   * @copydoc Layer::backwarding(sharedTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
    */
-  sharedTensor backwarding(sharedTensor in, int iteration);
+  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
 
   /**
    * @brief     copy layer

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -50,7 +50,7 @@ class LazyTensor;
  */
 class Tensor {
 public:
-  Tensor(const TensorDim &d, float *buf = nullptr);
+  Tensor(const TensorDim &d, const float *buf = nullptr);
 
   /**
    * @brief     Basic Constructor of Tensor
@@ -107,12 +107,9 @@ public:
 
   /**
    *  @brief  Copy constructor of Tensor.
-   *  @note This can be safely reverted to default
-   *        after checking using _data as a pointer is safe for functions using
-   * Tensor.
    *  @param[in] Tensor &
    */
-  Tensor(const Tensor &rhs) : Tensor(rhs.dim, rhs.data.get()){};
+  Tensor(const Tensor &rhs) = default;
 
   /**
    *  @brief  Move constructor of Tensor.
@@ -124,14 +121,13 @@ public:
    * @brief  Copy assignment operator.
    * @param[in] rhs Tensor to be copied.
    */
-  // todo: refactor operator= to consider allocated size for the data
-  Tensor &operator=(const Tensor &rhs);
+  Tensor &operator=(const Tensor &rhs) = default;
 
   /**
    * @brief  Move assignment operator.
    * @parma[in] rhs Tensor to be moved.
    */
-  Tensor &operator=(Tensor &&rhs) noexcept;
+  Tensor &operator=(Tensor &&rhs) noexcept = default;
 
   void swap(Tensor &lhs, Tensor &rhs) noexcept;
 
@@ -449,10 +445,15 @@ public:
 
   /**
    * @brief     Copy the Tensor
-   * @param[in] from Tensor to be Copyed
-   * @retval    Matix
+   * @param[in] from Tensor to be copied
    */
-  Tensor &copy(Tensor &from);
+  void copy(const Tensor &from);
+
+  /**
+   * @brief     Convient wrapper for inplace copy of @a this.
+   * @retval    Copied version of this
+   */
+  Tensor clone() const;
 
   /**
    * @brief     Save the Tensor into file
@@ -470,7 +471,7 @@ public:
    * @brief     return argument index which value is max
    * @retval    int argument index
    */
-  int argmax();
+  int argmax() const;
 
   /**
    * @brief     return Tensor Dim
@@ -517,6 +518,12 @@ public:
   float *getAddress(unsigned int i);
 
   /**
+   * @brief     i data index
+   * @retval    address of ith data
+   */
+  const float *getAddress(unsigned int i) const;
+
+  /**
    * @brief     set Tensor Dim
    * @param[in] d TensorDim
    * @retval    #ML_ERROR_NONE successful
@@ -549,6 +556,8 @@ private:
 std::ostream &operator<<(std::ostream &out, Tensor const &m);
 
 typedef std::shared_ptr<Tensor> sharedTensor;
+
+typedef std::shared_ptr<const Tensor> sharedConstTensor;
 
 } /* namespace nntrainer */
 

--- a/nntrainer/src/activation_layer.cpp
+++ b/nntrainer/src/activation_layer.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <iostream>
 #include <layer.h>
+#include <lazy_tensor.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <optimizer.h>
@@ -51,15 +52,16 @@ int ActivationLayer::initialize(bool last) {
   return ML_ERROR_NONE;
 }
 
-sharedTensor ActivationLayer::forwarding(sharedTensor in) {
+sharedConstTensor ActivationLayer::forwarding(sharedConstTensor in) {
   input = *in;
+  /// @note @a _act_fn is expected to work out of place and not modify @a input
   hidden = _act_fn(input);
 
   return MAKE_SHARED_TENSOR(hidden);
 }
 
-sharedTensor ActivationLayer::backwarding(sharedTensor derivative,
-                                          int iteration) {
+sharedConstTensor ActivationLayer::backwarding(sharedConstTensor derivative,
+                                               int iteration) {
   Tensor deriv = *derivative;
   Tensor ret;
   if (activation_type == ActiType::ACT_SOFTMAX)

--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -77,7 +77,7 @@ void BatchNormalizationLayer::setProperty(const PropertyType type,
   }
 }
 
-sharedTensor BatchNormalizationLayer::forwarding(sharedTensor in) {
+sharedConstTensor BatchNormalizationLayer::forwarding(sharedConstTensor in) {
   Tensor &mu = paramsAt(static_cast<int>(BNParams::mu)).weight;
   Tensor &var = paramsAt(static_cast<int>(BNParams::var)).weight;
   Tensor &gamma = paramsAt(static_cast<int>(BNParams::gamma)).weight;
@@ -119,8 +119,9 @@ sharedTensor BatchNormalizationLayer::forwarding(sharedTensor in) {
   return MAKE_SHARED_TENSOR(hidden);
 }
 
-sharedTensor BatchNormalizationLayer::backwarding(sharedTensor derivative,
-                                                  int iteration) {
+sharedConstTensor
+BatchNormalizationLayer::backwarding(sharedConstTensor derivative,
+                                     int iteration) {
   Tensor &gamma = paramsAt(static_cast<int>(BNParams::gamma)).weight;
   Tensor &dbeta = paramsAt(static_cast<int>(BNParams::beta)).grad;
   Tensor &dgamma = paramsAt(static_cast<int>(BNParams::beta)).grad;

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -79,7 +79,7 @@ void Conv2DLayer::read(std::ifstream &file) { Layer::read(file); }
 
 void Conv2DLayer::save(std::ofstream &file) { Layer::save(file); }
 
-sharedTensor Conv2DLayer::forwarding(sharedTensor in) {
+sharedConstTensor Conv2DLayer::forwarding(sharedConstTensor in) {
   int status = ML_ERROR_NONE;
   input = *in;
 
@@ -118,7 +118,8 @@ sharedTensor Conv2DLayer::forwarding(sharedTensor in) {
   return MAKE_SHARED_TENSOR(hidden);
 };
 
-sharedTensor Conv2DLayer::backwarding(sharedTensor derivative, int iteration) {
+sharedConstTensor Conv2DLayer::backwarding(sharedConstTensor derivative,
+                                           int iteration) {
 
   // Calculate delK : [batch, channel, height, width ] * filter_size
   unsigned int same_pad[CONV2D_DIM];
@@ -330,7 +331,7 @@ void Conv2DLayer::setProperty(const PropertyType type,
   }
 }
 
-int Conv2DLayer::conv2d(float *in, TensorDim indim, float *kernel,
+int Conv2DLayer::conv2d(float *in, TensorDim indim, const float *kernel,
                         TensorDim kdim, float *out, unsigned int const *stride,
                         float bias) {
 

--- a/nntrainer/src/fc_layer.cpp
+++ b/nntrainer/src/fc_layer.cpp
@@ -81,7 +81,7 @@ void FullyConnectedLayer::setProperty(const PropertyType type,
   }
 }
 
-sharedTensor FullyConnectedLayer::forwarding(sharedTensor in) {
+sharedConstTensor FullyConnectedLayer::forwarding(sharedConstTensor in) {
   Tensor &weight = paramsAt(static_cast<int>(FCParams::weight)).weight;
   Tensor &bias = paramsAt(static_cast<int>(FCParams::bias)).weight;
 
@@ -121,8 +121,8 @@ void FullyConnectedLayer::copy(std::shared_ptr<Layer> l) {
   this->loss = from->loss;
 }
 
-sharedTensor FullyConnectedLayer::backwarding(sharedTensor derivative,
-                                              int iteration) {
+sharedConstTensor FullyConnectedLayer::backwarding(sharedConstTensor derivative,
+                                                   int iteration) {
   unsigned int weight_idx = static_cast<int>(FCParams::weight);
   unsigned int bias_idx = static_cast<int>(FCParams::bias);
   Tensor &weight = paramsAt(weight_idx).weight;

--- a/nntrainer/src/flatten_layer.cpp
+++ b/nntrainer/src/flatten_layer.cpp
@@ -37,22 +37,22 @@ int FlattenLayer::initialize(bool last) {
   return status;
 }
 
-sharedTensor FlattenLayer::forwarding(sharedTensor in) {
-  input = *in;
+sharedConstTensor FlattenLayer::forwarding(sharedConstTensor in) {
+  Tensor ret = *in;
 
-  hidden = Tensor(input.batch(), output_dim.channel(), output_dim.height(),
-                  output_dim.width());
-  hidden.setZero();
+  /// @note in->batch can be different from input_dim.batch();
+  ret.setDim({in->batch(), output_dim.channel(), output_dim.height(),
+              output_dim.width()});
 
-  memcpy(hidden.getData(), input.getData(),
-         input.getDim().getDataLen() * sizeof(float));
-
-  return MAKE_SHARED_TENSOR(hidden);
+  return MAKE_SHARED_TENSOR(std::move(ret));
 }
 
-sharedTensor FlattenLayer::backwarding(sharedTensor in, int iteration) {
-  in->setDim(input_dim);
-  return in;
+sharedConstTensor FlattenLayer::backwarding(sharedConstTensor in,
+                                            int iteration) {
+  Tensor temp = *in;
+  temp.setDim(input_dim);
+
+  return MAKE_SHARED_TENSOR(std::move(temp));
 }
 
 void FlattenLayer::setProperty(const PropertyType type,

--- a/nntrainer/src/input_layer.cpp
+++ b/nntrainer/src/input_layer.cpp
@@ -62,7 +62,7 @@ void InputLayer::copy(std::shared_ptr<Layer> l) {
   this->hidden.copy(from->hidden);
 }
 
-sharedTensor InputLayer::forwarding(sharedTensor in) {
+sharedConstTensor InputLayer::forwarding(sharedConstTensor in) {
   input = *in;
   if (normalization)
     input = input.normalization();
@@ -72,7 +72,7 @@ sharedTensor InputLayer::forwarding(sharedTensor in) {
   return MAKE_SHARED_TENSOR(input);
 }
 
-sharedTensor InputLayer::backwarding(sharedTensor in, int iteration) {
+sharedConstTensor InputLayer::backwarding(sharedConstTensor in, int iteration) {
   return in;
 }
 

--- a/nntrainer/src/loss_layer.cpp
+++ b/nntrainer/src/loss_layer.cpp
@@ -45,7 +45,8 @@ int LossLayer::initialize(bool last) {
   return status;
 }
 
-sharedTensor LossLayer::forwarding(sharedTensor in, sharedTensor label) {
+sharedConstTensor LossLayer::forwarding(sharedConstTensor in,
+                                        sharedConstTensor label) {
   input = *in;
   Tensor y2 = *label;
   Tensor y = input;
@@ -54,9 +55,9 @@ sharedTensor LossLayer::forwarding(sharedTensor in, sharedTensor label) {
   switch (cost) {
   case COST_MSE: {
     // y2 <- y2 - y;
-    y2.subtract_i(y);
+    Tensor residual = y2.subtract(y);
 
-    l = y2.chain().multiply_i(y2).average().run();
+    l = residual.chain().multiply_i(residual).average().run();
   } break;
   case COST_ENTROPY_SIGMOID: {
     // @todo: change this to apply_i
@@ -112,7 +113,8 @@ void LossLayer::copy(std::shared_ptr<Layer> l) {
   this->loss = from->loss;
 }
 
-sharedTensor LossLayer::backwarding(sharedTensor derivative, int iteration) {
+sharedConstTensor LossLayer::backwarding(sharedConstTensor derivative,
+                                         int iteration) {
   Tensor ret_derivative;
   Tensor y2 = *derivative;
   Tensor y = input;
@@ -151,7 +153,7 @@ int LossLayer::setCost(CostType c) {
   return status;
 }
 
-sharedTensor LossLayer::forwarding(sharedTensor in) {
+sharedConstTensor LossLayer::forwarding(sharedConstTensor in) {
   throw std::runtime_error("Not supported.");
 }
 

--- a/nntrainer/src/pooling2d_layer.cpp
+++ b/nntrainer/src/pooling2d_layer.cpp
@@ -52,7 +52,7 @@ int Pooling2DLayer::initialize(bool last) {
   return status;
 }
 
-sharedTensor Pooling2DLayer::forwarding(sharedTensor in) {
+sharedConstTensor Pooling2DLayer::forwarding(sharedConstTensor in) {
   input = *in;
 
   hidden = Tensor(input.batch(), output_dim.channel(), output_dim.height(),
@@ -69,8 +69,8 @@ sharedTensor Pooling2DLayer::forwarding(sharedTensor in) {
   return MAKE_SHARED_TENSOR(hidden);
 }
 
-sharedTensor Pooling2DLayer::backwarding(sharedTensor derivative,
-                                         int iteration) {
+sharedConstTensor Pooling2DLayer::backwarding(sharedConstTensor derivative,
+                                              int iteration) {
   unsigned int batch = input_dim.batch();
   unsigned int channel = input_dim.channel();
   unsigned int height = input_dim.height();

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -25,6 +25,7 @@
 #include <pooling2d_layer.h>
 #include <util_func.h>
 
+using nntrainer::sharedConstTensor;
 using nntrainer::sharedTensor;
 
 template <typename LayerType>
@@ -380,7 +381,7 @@ protected:
   }
 
   void matchForwarding(const char *file) {
-    sharedTensor out;
+    sharedConstTensor out;
     EXPECT_NO_THROW(out = layer.forwarding(MAKE_SHARED_TENSOR(in)));
 
     if (layers.size() > 0) {
@@ -412,7 +413,7 @@ protected:
     int idx = layers.size() - 1;
     sharedTensor def_derivative =
       MAKE_SHARED_TENSOR(constant(1.0, 3, 1, 1, 15));
-    sharedTensor back_out;
+    sharedConstTensor back_out;
 
     if (layers.size() && layers.back()->getType() == nntrainer::LAYER_LOSS) {
       if (with_loss) {
@@ -478,7 +479,7 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch,
 
   setOptimizer(nntrainer::OptType::adam, "learning_rate=1.0");
 
-  sharedTensor out;
+  sharedConstTensor out;
 
   EXPECT_NO_THROW(out = layer.forwarding(MAKE_SHARED_TENSOR(in)));
 
@@ -751,11 +752,11 @@ TEST_F(nntrainer_BatchNormalizationLayer, checkValidation_01_p) {
 TEST_F(nntrainer_BatchNormalizationLayer,
        DISABLED_forward_backward_training_01_p) {
   layer.setTrainable(true);
-  sharedTensor forward_result;
+  sharedConstTensor forward_result;
 
   EXPECT_NO_THROW(forward_result = layer.forwarding(MAKE_SHARED_TENSOR(in)));
 
-  matchOutput(forward_result.get()[0], "tc_bn_1_goldenBNResultForward.out");
+  matchOutput(*forward_result, "tc_bn_1_goldenBNResultForward.out");
 
   nntrainer::Tensor backward_result;
   EXPECT_NO_THROW(


### PR DESCRIPTION
This patch enables default copy constructor to fix #281 and resolves #409 

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>