### PR TITLE
[TensorDim] Change behaviour of default tensorDim constructor

### DIFF
--- a/nntrainer/include/tensor_dim.h
+++ b/nntrainer/include/tensor_dim.h
@@ -29,13 +29,14 @@ class TensorDim {
 public:
   TensorDim() {
     for (int i = 0; i < MAXDIM; ++i) {
-      dim[i] = 1;
+      dim[i] = 0;
     }
-    len = 1;
-    feature_len = 1;
+    len = 0;
+    feature_len = 0;
   }
 
-  TensorDim(unsigned int b, unsigned int c, unsigned int h, unsigned int w) {
+  TensorDim(unsigned int b, unsigned int c, unsigned int h, unsigned int w) :
+    TensorDim() {
     setTensorDim(0, b);
     setTensorDim(1, c);
     setTensorDim(2, h);

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -66,7 +66,18 @@ Tensor::Tensor(const TensorDim &d, float *buf) :
   dim(d),
   strides{{1, 2, 3}},
   is_contiguous(true),
-  data(new float[d.getDataLen()], std::default_delete<float[]>()) {
+  data(d.getDataLen() == 0
+         ? nullptr
+         : std::shared_ptr<float>(new float[d.getDataLen()],
+                                  std::default_delete<float[]>())) {
+  if (d.getDataLen() == 0) {
+    if (buf != nullptr) {
+      throw std::runtime_error(
+        "Tensor dimension and source buffer size mismatch");
+    }
+    return;
+  }
+
   // todo: initialize appropriate strides
   if (buf != nullptr) {
     float *data = getData();

--- a/nntrainer/src/tensor_dim.cpp
+++ b/nntrainer/src/tensor_dim.cpp
@@ -34,7 +34,8 @@ TensorDim &TensorDim::operator=(TensorDim &&rhs) noexcept {
 }
 
 void TensorDim::swap(TensorDim &lhs, TensorDim &rhs) noexcept {
-  std::swap(lhs.dim, rhs.dim);
+  std::swap_ranges(std::begin(lhs.dim), std::begin(lhs.dim) + MAXDIM,
+                   std::begin(rhs.dim));
   std::swap(lhs.len, rhs.len);
   std::swap(lhs.feature_len, rhs.feature_len);
 }
@@ -48,6 +49,12 @@ void TensorDim::setTensorDim(unsigned int idx, unsigned int value) {
   if (value == 0) {
     throw std::invalid_argument(
       "[TensorDim] Trying to assign value of 0 to tensor dim");
+  }
+
+  if (len == 0) {
+    for (int i = 0; i < MAXDIM; ++i) {
+      dim[i] = 1;
+    }
   }
 
   dim[idx] = value;

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -401,7 +401,7 @@ protected:
   }
 
   void matchLoss(const char *file) {
-    nntrainer::Tensor loss;
+    nntrainer::Tensor loss(1, 1, 1, 1);
     loadFile(file, loss);
     EXPECT_NEAR(layers.back()->getLoss(), *(loss.getData()), tolerance);
   }
@@ -992,15 +992,15 @@ protected:
       EXPECT_NEAR(out_ptr[i], golden[i], tolerance);
     }
   }
+
+  virtual void prepareLayer() { setInputDim("2:3:5:5"); }
 };
 
 TEST_F(nntrainer_Pooling2DLayer, setProperty_01_p) {
-  setInputDim("2:3:5:5");
   setProperty("pooling_size=2,2 | stride=1,1 | padding=0,0 | pooling=average");
 }
 
 TEST_F(nntrainer_Pooling2DLayer, setProperty_02_n) {
-  setInputDim("2:3:5:5");
   int status = layer.setProperty({"pooling_size="});
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
@@ -1166,13 +1166,15 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_04_p) {
 }
 
 class nntrainer_FlattenLayer
-  : public nntrainer_abstractLayer<nntrainer::FlattenLayer> {};
+  : public nntrainer_abstractLayer<nntrainer::FlattenLayer> {
+protected:
+  virtual void prepareLayer() { setInputDim("1:2:4:4"); }
+};
 
 /**
  * @brief Flatten Layer
  */
 TEST_F(nntrainer_FlattenLayer, forwarding_01_p) {
-  setInputDim("1:2:4:4");
   reinitialize(false);
 
   EXPECT_EQ(out.getDim(), nntrainer::TensorDim(1, 1, 1, 32));
@@ -1204,7 +1206,6 @@ TEST_F(nntrainer_FlattenLayer, forwarding_02_p) {
  * @brief Flatten Layer
  */
 TEST_F(nntrainer_FlattenLayer, backwarding_01_p) {
-  setInputDim("1:2:4:4");
   reinitialize(false);
 
   EXPECT_EQ(out.getDim(), nntrainer::TensorDim(1, 1, 1, 32));
@@ -1264,11 +1265,17 @@ TEST(nntrainer_LossLayer, setProperty_01_n) {
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
-TEST(nntrainer_ActivationLayer, init_01_1) {
+TEST(nntrainer_ActivationLayer, init_01_n) {
+  nntrainer::ActivationLayer layer;
+  EXPECT_THROW(layer.initialize(false), std::invalid_argument);
+}
+
+TEST(nntrainer_ActivationLayer, init_02_p) {
   int status = ML_ERROR_NONE;
   nntrainer::ActivationLayer layer;
-  status = layer.initialize(false);
 
+  layer.setInputDimension({1, 1, 1, 1});
+  status = layer.initialize(false);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 


### PR DESCRIPTION
Default tensor dim constructor sets up tensorDim of all 0 which are invalid to use by nature
Setting any dimension resets all the 0 dimensions to 1
This removes allocation of memory by tensor on default constructor yet allows using default constructor of tensor

Resolves #359

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>