### PR TITLE
[Example] Change user scenario

### DIFF
--- a/Applications/Tizen_native/CustomShortcut/inc/data.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/data.h
@@ -30,14 +30,13 @@
 
 #define EDJ_PATH "edje/main.edj"
 #define TRAIN_SET_PATH "trainingSet.dat"
+#define VALIDATION_SET_PATH "validationSet.dat"
 
-#define MAX_TRIES 5
+#define MAX_TRAIN_TRIES 5
+#define MAX_TRIES 10
 
-typedef enum _DRAW_MODE {
-  INFER = 0,
-  TRAIN_SMILE,
-  TRAIN_SAD,
-} DRAW_MODE;
+#define FEATURE_SIZE 62720
+#define NUM_CLASS 2
 typedef struct appdata {
   Evas_Object *win;
   Evas_Object *conform;
@@ -60,7 +59,6 @@ typedef struct appdata {
 
   cairo_surface_t *cr_surface; /**< cairo surface for the canvas */
   cairo_t *cr;                 /**< cairo engine for the canvas */
-  DRAW_MODE mode;              /**< drawing mode of current canvas */
   int tries;                   /**< tells how many data has been labeled */
 
   /**< ML related */

--- a/Applications/Tizen_native/CustomShortcut/res/edje/main.edc
+++ b/Applications/Tizen_native/CustomShortcut/res/edje/main.edc
@@ -94,32 +94,17 @@ collections {
   group {
     name: "home";
     parts {
-      PART_TITLE("home/title", "Select actions...")
-      PART_BUTTON("home/to_train", "train", 0.55, 0.3, 0.9, 0.7)
-      PART_BUTTON("home/to_test", "test", 0.1, 0.3, 0.45, 0.7)
+      PART_TITLE("home/title", "NNTrainer Demo")
+      PART_BUTTON("home/proceed", "start draw", 0.1, 0.3, 0.9, 0.7)
     }
     programs {
-      PROGRAM_BUTTON("home/to_train", "routes/to", "select")
-      PROGRAM_BUTTON("home/to_test", "routes/to", "draw:inference")
+      PROGRAM_BUTTON("home/proceed", "routes/to", "draw")
     }
   }
-  group {
-    name: "select";
-    parts {
-      PART_TITLE("select/title", "Select target emoji...")
-      PART_BUTTON("select/sad", "😢", 0.1, 0.3, 0.45, 0.7)
-      PART_BUTTON("select/smile", "😊", 0.55, 0.3, 0.9, 0.7)
-    }
-    programs {
-      PROGRAM_BUTTON("select/smile", "routes/to", "draw:smile")
-      PROGRAM_BUTTON("select/sad", "routes/to", "draw:sad")
-    }
-  }
-  // this group is meant to be used for train / test, if it is not applicable, this group is reserved for training part
   group {
     name: "draw";
     parts {
-      PART_TITLE("draw/title", "draw your symbol")
+      PART_TITLE("draw/title", "draw for 😊")
       part {
         name: "draw/canvas";
         type: SWALLOW;
@@ -141,14 +126,6 @@ collections {
     parts {
       PART_TITLE("train_result/title", "train successfully done")
       PART_BUTTON("train_result/go_back", "go back", 0.1, 0.3, 0.9, 0.7)
-    }
-  }
-  group {
-    name: "test_result";
-    parts {
-      PART_TITLE("test_result/title", "test is successfully done")
-      PART_BUTTON("test_result/go_back", "test result: 😊", 0.1, 0.3, 0.9, 0.7)
-      // reserve a text area to show the guess from the model
     }
   }
 }


### PR DESCRIPTION
In this patch, user draws smile face and sad face respectively for 5
times.

It is splited half to trainset/validationSet and used for training.

Thus deleting inference part and instead train result (accuracy, train result, validation result will be shown)

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>