### PR TITLE
[ Bug ] Fix calculating training loss

### DIFF
--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -117,6 +117,15 @@ sharedConstTensor Conv2DLayer::forwarding(sharedConstTensor in) {
     }
   }
 
+  loss = 0.0f;
+  if (weight_decay.type == WeightDecayType::l2norm) {
+    for (unsigned int i = 0; i < filter_size; ++i) {
+      Tensor &weight = paramsAt(i).weight;
+      loss += weight_decay.lambda * 0.5f * (weight.l2norm());
+    }
+    loss /= filter_size;
+  }
+
   return MAKE_SHARED_TENSOR(hidden);
 };
 

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -580,7 +580,6 @@ float NeuralNetwork::getLoss() {
   for (unsigned int i = 0; i < layers.size(); i++) {
     loss += layers[i]->getLoss();
   }
-
   return loss;
 }
 
@@ -669,9 +668,8 @@ int NeuralNetwork::train(std::vector<std::string> values) {
 int NeuralNetwork::train_run() {
   int status = ML_ERROR_NONE;
 
-  float training_loss = 0.0f;
   for (unsigned int i = 0; i < epoch; ++i) {
-
+    float training_loss = 0.0f;
     status = data_buffer->run(nntrainer::BUF_TRAIN);
     if (status != ML_ERROR_NONE) {
       data_buffer->clear(BUF_TRAIN);
@@ -701,6 +699,7 @@ int NeuralNetwork::train_run() {
         }
         std::cout << "#" << i + 1 << "/" << epoch;
         data_buffer->displayProgress(count++, nntrainer::BUF_TRAIN, getLoss());
+        training_loss += getLoss();
       } else {
         data_buffer->clear(nntrainer::BUF_TRAIN);
         break;
@@ -708,10 +707,8 @@ int NeuralNetwork::train_run() {
     }
 
     saveModel();
-    training_loss = getLoss();
-
-    std::cout << "#" << i + 1 << "/" << epoch
-              << " - Training Loss: " << training_loss;
+    std::cout << "#" << i << "/" << epoch
+              << " - Training Loss: " << training_loss / count;
 
     if (data_buffer->getValidation()[nntrainer::BUF_VAL]) {
       int right = 0;


### PR DESCRIPTION
In this PR, calculation of training loss is fixed.
Previously, network loss is calculated using last mini_batch size data set.
This should be summarized through out whole data set and averaged.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>