### PR TITLE
[ Application ] fix model file path of classification example

### DIFF
--- a/Applications/Classification/jni/main.cpp
+++ b/Applications/Classification/jni/main.cpp
@@ -121,7 +121,7 @@ static int rangeRandom(int min, int max) {
 void getFeature(const string filename, vector<float> &feature_input) {
   int input_dim[4];
   int output_dim[4];
-  std::string model_path = "../../res/mobilenetv2.tflite";
+  std::string model_path = data_path + "mobilenetv2.tflite";
   std::unique_ptr<tflite::FlatBufferModel> model =
     tflite::FlatBufferModel::BuildFromFile(model_path.c_str());
 


### PR DESCRIPTION
Previously model path is fixed as "../../res/mobilenetv2.tflite"
In this PR, data_path is used for define path.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>