### PR TITLE
[bn_layer] Remove unused gradients

### DIFF
--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -53,8 +53,8 @@ int BatchNormalizationLayer::initialize(bool last) {
   beta.setZero();
 
   setParamSize(4);
-  paramsAt(0) = {std::move(mu), Tensor(mu.getDim()), "BN:moving_average"};
-  paramsAt(1) = {std::move(var), Tensor(var.getDim()), "BN:moving_variance"};
+  paramsAt(0) = {std::move(mu), Tensor(), "BN:moving_average"};
+  paramsAt(1) = {std::move(var), Tensor(), "BN:moving_variance"};
   paramsAt(2) = {std::move(gamma), Tensor(gamma.getDim()), "BN:gamma"};
   paramsAt(3) = {std::move(beta), Tensor(beta.getDim()), "BN:beta"};
 


### PR DESCRIPTION
Remove ununsed gradients for mu and variance for the batch normalization layers to remove unnecessary memory usage.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>