### PR TITLE
[tensor] restricted setDim is now reshape

### DIFF
--- a/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
+++ b/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
@@ -507,9 +507,9 @@ int main(int argc, char **argv) {
             tempQ.setValue(i, 0, 0, (int)in_Exp[i].action[0],
                            (float)in_Exp[i].reward);
           } else {
-            float next = (nqa[i * NQ->getWidth()] > nqa[i * NQ->getWidth() + 1])
-                           ? nqa[i * NQ->getWidth()]
-                           : nqa[i * NQ->getWidth() + 1];
+            float next = (nqa[i * NQ->width()] > nqa[i * NQ->width() + 1])
+                           ? nqa[i * NQ->width()]
+                           : nqa[i * NQ->width() + 1];
             try {
               tempQ.setValue(i, 0, 0, (int)in_Exp[i].action[0],
                              (float)in_Exp[i].reward + DISCOUNT * next);

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -383,30 +383,6 @@ public:
   void print(std::ostream &out) const;
 
   /**
-   * @brief     Get Width of Tensor
-   * @retval    int Width
-   */
-  int getWidth() const { return dim.width(); };
-
-  /**
-   * @brief     Get Channel of Tensor
-   * @retval    int Channel
-   */
-  int getChannel() const { return dim.channel(); };
-
-  /**
-   * @brief     Get Height of Tensor
-   * @retval    int Height
-   */
-  int getHeight() const { return dim.height(); };
-
-  /**
-   * @brief     Get Batch of Tensor
-   * @retval    int Batch
-   */
-  int getBatch() const { return dim.batch(); };
-
-  /**
    * @brief     Get length of current _data
    * @retval    unsigned int length of the current _data
    */
@@ -480,10 +456,16 @@ public:
   int argmax() const;
 
   /**
-   * @brief     return Tensor Dim
+   * @brief     return a copy of the Tensor Dim
    * @retval    TensorDim
    */
-  TensorDim getDim() const { return dim; }
+  TensorDim getDim() const { return TensorDim(dim); }
+
+  /**
+   * @brief     return Tensor Dim for a given axis
+   * @retval    dimension
+   */
+  unsigned int getTensorDim(unsigned int axis);
 
   /**
    * @brief     return Tensor batch size
@@ -532,10 +514,9 @@ public:
   /**
    * @brief     set Tensor Dim
    * @param[in] d TensorDim
-   * @retval    #ML_ERROR_NONE successful
-   * @retval    #ML_ERROR_INVALID_PARAMETER fail
+   * @note      Throws std::invalid_argument if size mismatch
    */
-  int setDim(TensorDim d);
+  void reshape(TensorDim d);
 
   /**
    * @brief     return current stride of tensor.

--- a/nntrainer/src/activation_layer.cpp
+++ b/nntrainer/src/activation_layer.cpp
@@ -148,16 +148,16 @@ Tensor ActivationLayer::softmax(Tensor const &t) {
    * shiftx_logit = logit - max_batch(logit)
    * softmax = exp(shiftx_logit) / (sum(exp(shiftx_logit)))
    */
-  int batch = t.getBatch();
-  int channel = t.getChannel();
-  int height = t.getHeight();
-  int width = t.getWidth();
+  unsigned int batch = t.batch();
+  unsigned int channel = t.channel();
+  unsigned int height = t.height();
+  unsigned int width = t.width();
   float *dp;
   float *rp;
   const float *tp;
 
   Tensor result(t.getDim());
-  Tensor divisor(t.getWidth());
+  Tensor divisor(t.width());
 
   dp = divisor.getData();
   rp = result.getData();
@@ -165,27 +165,27 @@ Tensor ActivationLayer::softmax(Tensor const &t) {
 
   divisor.setZero();
 
-  for (int k = 0; k < batch; k++) {
-    for (int c = 0; c < channel; c++) {
-      for (int i = 0; i < height; i++) {
+  for (unsigned int k = 0; k < batch; k++) {
+    for (unsigned int c = 0; c < channel; c++) {
+      for (unsigned int i = 0; i < height; i++) {
         int index =
           k * channel * height * width + c * height * width + i * width;
         float m = std::numeric_limits<float>::lowest();
 
         // find max
-        for (int j = 0; j < width; j++) {
+        for (unsigned int j = 0; j < width; j++) {
           if (tp[index + j] > m)
             m = tp[index + j];
         }
 
         // shiftx
         float sum = 0.0f;
-        for (int j = 0; j < width; j++) {
+        for (unsigned int j = 0; j < width; j++) {
           dp[j] = exp(tp[index + j] - m);
           sum += dp[j];
         }
 
-        for (int j = 0; j < width; j++) {
+        for (unsigned int j = 0; j < width; j++) {
           rp[index + j] = dp[j] / sum;
         }
       }
@@ -196,10 +196,10 @@ Tensor ActivationLayer::softmax(Tensor const &t) {
 
 Tensor ActivationLayer::softmaxPrime(Tensor const &x,
                                      Tensor const &derivative) {
-  int batch = x.getBatch();
-  int channel = x.getChannel();
-  int width = x.getWidth();
-  int height = x.getHeight();
+  unsigned int batch = x.batch();
+  unsigned int channel = x.channel();
+  unsigned int height = x.height();
+  unsigned int width = x.width();
   bool is_derivative = true;
 
   Tensor PI = Tensor(x.getDim());
@@ -213,15 +213,15 @@ Tensor ActivationLayer::softmaxPrime(Tensor const &x,
     is_derivative = false;
   }
 
-  for (int k = 0; k < batch; ++k) {
+  for (unsigned int k = 0; k < batch; ++k) {
     int K = k * channel * height * width;
-    for (int c = 0; c < channel; ++c) {
+    for (unsigned int c = 0; c < channel; ++c) {
       int C = K + c * height * width;
-      for (int i = 0; i < height; ++i) {
+      for (unsigned int i = 0; i < height; ++i) {
         int I = C + i * width;
-        for (int j = 0; j < width; ++j) {
+        for (unsigned int j = 0; j < width; ++j) {
           float sum = 0.0f;
-          for (int l = 0; l < width; ++l) {
+          for (unsigned int l = 0; l < width; ++l) {
             float val;
             if (j == l) {
               val = xp[I + l] * (1.0f - xp[I + j]);

--- a/nntrainer/src/flatten_layer.cpp
+++ b/nntrainer/src/flatten_layer.cpp
@@ -40,8 +40,8 @@ sharedConstTensor FlattenLayer::forwarding(sharedConstTensor in) {
   hidden = input;
 
   /// @note in->batch can be different from input_dim.batch();
-  hidden.setDim({in->batch(), output_dim.channel(), output_dim.height(),
-                 output_dim.width()});
+  hidden.reshape({in->batch(), output_dim.channel(), output_dim.height(),
+                  output_dim.width()});
 
   return MAKE_SHARED_TENSOR(hidden);
 }
@@ -49,7 +49,7 @@ sharedConstTensor FlattenLayer::forwarding(sharedConstTensor in) {
 sharedConstTensor FlattenLayer::backwarding(sharedConstTensor in,
                                             int iteration) {
   Tensor temp = *in;
-  temp.setDim(input_dim);
+  temp.reshape(input_dim);
 
   return MAKE_SHARED_TENSOR(std::move(temp));
 }

--- a/nntrainer/src/loss_layer.cpp
+++ b/nntrainer/src/loss_layer.cpp
@@ -93,10 +93,10 @@ void LossLayer::updateLoss(const Tensor &l) {
   float loss_sum = 0.0f;
   const float *data = l.getData();
 
-  for (int i = 0; i < l.getBatch(); i++) {
+  for (unsigned int i = 0; i < l.batch(); i++) {
     loss_sum += data[i];
   }
-  loss = loss_sum / (float)l.getBatch();
+  loss = loss_sum / (float)l.batch();
 }
 
 void LossLayer::copy(std::shared_ptr<Layer> l) {
@@ -122,7 +122,7 @@ sharedConstTensor LossLayer::backwarding(sharedConstTensor derivative,
     break;
   case COST_ENTROPY_SOFTMAX:
     y = y.apply(ActivationLayer::softmax);
-    ret_derivative = y.subtract(y2).divide(y.getDim().batch());
+    ret_derivative = y.subtract(y2).divide(y.batch());
     break;
   case COST_ENTROPY:
     throw std::runtime_error(

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -873,14 +873,11 @@ Tensor Tensor::clone() const {
   return t;
 }
 
-int Tensor::setDim(TensorDim d) {
-  int status = ML_ERROR_NONE;
+void Tensor::reshape(TensorDim d) {
   if (d.getDataLen() != dim.getDataLen()) {
-    ml_loge("Error: Data size is not eqaul to copy tensor dim");
-    return ML_ERROR_INVALID_PARAMETER;
+    throw std::invalid_argument("Error: reshape cannot change the tensor size");
   }
   dim = d;
-  return status;
 }
 
 void Tensor::save(std::ofstream &file) {

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -716,10 +716,10 @@ TEST(nntrainer_Tensor, sum_02_p) {
   nntrainer::Tensor result2 = input.sum(2);
   nntrainer::Tensor result3 = input.sum(3);
 
-  for (int i = 0; i < result0.getBatch(); ++i) {
-    for (int l = 0; l < result0.getChannel(); ++l) {
-      for (int j = 0; j < result0.getHeight(); ++j) {
-        for (int k = 0; k < result0.getWidth(); ++k) {
+  for (unsigned int i = 0; i < result0.batch(); ++i) {
+    for (unsigned int l = 0; l < result0.channel(); ++l) {
+      for (unsigned int j = 0; j < result0.height(); ++j) {
+        for (unsigned int k = 0; k < result0.width(); ++k) {
           if (ans0[i][l][j][k] != result0.getValue(i, l, j, k)) {
             status = ML_ERROR_RESULT_OUT_OF_RANGE;
             goto end_test;
@@ -729,10 +729,10 @@ TEST(nntrainer_Tensor, sum_02_p) {
     }
   }
 
-  for (int i = 0; i < result1.getBatch(); ++i) {
-    for (int l = 0; l < result1.getChannel(); ++l) {
-      for (int j = 0; j < result1.getHeight(); ++j) {
-        for (int k = 0; k < result1.getWidth(); ++k) {
+  for (unsigned int i = 0; i < result1.batch(); ++i) {
+    for (unsigned int l = 0; l < result1.channel(); ++l) {
+      for (unsigned int j = 0; j < result1.height(); ++j) {
+        for (unsigned int k = 0; k < result1.width(); ++k) {
           if (ans1[i][l][j][k] != result1.getValue(i, l, j, k)) {
             status = ML_ERROR_RESULT_OUT_OF_RANGE;
             goto end_test;
@@ -742,10 +742,10 @@ TEST(nntrainer_Tensor, sum_02_p) {
     }
   }
 
-  for (int i = 0; i < result2.getBatch(); ++i) {
-    for (int l = 0; l < result2.getChannel(); ++l) {
-      for (int j = 0; j < result2.getHeight(); ++j) {
-        for (int k = 0; k < result2.getWidth(); ++k) {
+  for (unsigned int i = 0; i < result2.batch(); ++i) {
+    for (unsigned int l = 0; l < result2.channel(); ++l) {
+      for (unsigned int j = 0; j < result2.height(); ++j) {
+        for (unsigned int k = 0; k < result2.width(); ++k) {
           if (ans2[i][l][j][k] != result2.getValue(i, l, j, k)) {
             status = ML_ERROR_RESULT_OUT_OF_RANGE;
             goto end_test;
@@ -755,10 +755,10 @@ TEST(nntrainer_Tensor, sum_02_p) {
     }
   }
 
-  for (int i = 0; i < result3.getBatch(); ++i) {
-    for (int l = 0; l < result3.getChannel(); ++l) {
-      for (int j = 0; j < result3.getHeight(); ++j) {
-        for (int k = 0; k < result3.getWidth(); ++k) {
+  for (unsigned int i = 0; i < result3.batch(); ++i) {
+    for (unsigned int l = 0; l < result3.channel(); ++l) {
+      for (unsigned int j = 0; j < result3.height(); ++j) {
+        for (unsigned int k = 0; k < result3.width(); ++k) {
           if (ans3[i][l][j][k] != result3.getValue(i, l, j, k)) {
             status = ML_ERROR_RESULT_OUT_OF_RANGE;
             goto end_test;
@@ -809,9 +809,9 @@ TEST(nntrainer_Tensor, dot_01_p) {
 
   nntrainer::Tensor result = input.dot(input);
 
-  for (int i = 0; i < result.getBatch(); ++i) {
-    for (int j = 0; j < result.getHeight(); ++j) {
-      for (int k = 0; k < result.getWidth(); ++k) {
+  for (unsigned int i = 0; i < result.batch(); ++i) {
+    for (unsigned int j = 0; j < result.height(); ++j) {
+      for (unsigned int k = 0; k < result.width(); ++k) {
         if (ans[i][0][j][k] != result.getValue(i, 0, j, k)) {
           status = ML_ERROR_RESULT_OUT_OF_RANGE;
           goto end_dot_01_p;
@@ -837,9 +837,9 @@ TEST(nntrainer_Tensor, transpose_01_p) {
                           k * (width) + l + 1);
   nntrainer::Tensor result = input.transpose("0:2:1");
 
-  for (int i = 0; i < result.getBatch(); ++i) {
-    for (int j = 0; j < result.getHeight(); ++j) {
-      for (int k = 0; k < result.getWidth(); ++k) {
+  for (unsigned int i = 0; i < result.batch(); ++i) {
+    for (unsigned int j = 0; j < result.height(); ++j) {
+      for (unsigned int k = 0; k < result.width(); ++k) {
         if (ans[i][0][j][k] != result.getValue(i, 0, j, k)) {
           status = ML_ERROR_RESULT_OUT_OF_RANGE;
           goto end_transpose_01_p;
@@ -924,22 +924,37 @@ TEST(nntrainer_Tensor, copy_and_shares_variable_p) {
   EXPECT_EQ(A, C);
   EXPECT_NE(B, C);
 
-  C.setDim(nntrainer::TensorDim(3, 4, 6, 5));
+  C.reshape(nntrainer::TensorDim(3, 4, 6, 5));
   EXPECT_EQ(A.getDim(), B.getDim());
   EXPECT_NE(A.getDim(), C.getDim());
 }
 
-/// #412
-TEST(nntrainer_Tensor, DISABLED_copy_and_resize_n) {
+TEST(nntrainer_Tensor, reshape_n_01) {
+  nntrainer::Tensor A = constant(1.0f, 3, 4, 5, 6);
+
+  EXPECT_THROW(A.reshape(nntrainer::TensorDim(9, 9, 9, 9)),
+               std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, reshape_n_02) {
+  nntrainer::Tensor A = constant(1.0f, 3, 4, 5, 6);
+  nntrainer::TensorDim A_dim = A.getDim();
+
+  /** Changing the dim of a tensor only affects local copy of the dim */
+  A_dim.setTensorDim(1, 100);
+  EXPECT_EQ(A_dim.getTensorDim(1), 100);
+
+  nntrainer::TensorDim A_dim_2 = A.getDim();
+  EXPECT_EQ(A_dim_2.getTensorDim(1), 4);
+}
+
+TEST(nntrainer_Tensor, copy_and_reshape_n) {
   nntrainer::Tensor A = constant(1.0f, 3, 4, 5, 6);
   nntrainer::Tensor B = A;
   nntrainer::Tensor C = A.clone();
 
-  /// this is undefined behavior
-  B.setDim(nntrainer::TensorDim(9, 9, 9, 9));
-
-  /// @todo replace this to appropriate test;
-  EXPECT_TRUE(true);
+  EXPECT_THROW(B.reshape(nntrainer::TensorDim(9, 9, 9, 9)),
+               std::invalid_argument);
 }
 
 /// @note this test case demonstrates it is dangeruous to use sharedConstTensor
@@ -955,7 +970,7 @@ TEST(nntrainer_Tensor, constructor_from_shared_const_ptr_shares_variable_n) {
   EXPECT_EQ(*A, B);
   EXPECT_NE(*A, C);
 
-  C.setDim(nntrainer::TensorDim(3, 4, 6, 5));
+  C.reshape(nntrainer::TensorDim(3, 4, 6, 5));
   EXPECT_EQ(A->getDim(), B.getDim());
   EXPECT_NE(A->getDim(), C.getDim());
 }


### PR DESCRIPTION
Tensor setDim() is renamed to reshape() as tensor should only be allowed to reshape
Resizing it invalidates the invariant for the other holders of the same data of tensor (see also #412)

This patch renames setDim() to reshape() which throws if there is an attempt to change size
Further getDim() now returns a copy of the dimension to disallow changing dimension of a tensor directly

Also some aliases in Tensor (like getWidth()) have been removed. Rather, width() like functions are kept
to maintain coherency with TensorDim() interface.

Resolves #412

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>