### PR TITLE
[Tensor] Set param size cannot update size

### DIFF
--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -519,11 +519,12 @@ protected:
    * shouldn't be changed again.
    */
   void setParamSize(unsigned int psize) {
+    if (psize == param_size)
+      return;
 
-    /// @todo uncomment this after fixing layer test. #293
-    // if (param_size > 0) {
-    //   throw std::invalid_argument("param size can't be set once it is set");
-    // }
+    if (param_size > 0) {
+      throw std::invalid_argument("param size can't be set once it is set");
+    }
 
     param_size = psize;
     params = std::shared_ptr<UpdatableParam>(

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -350,9 +350,6 @@ TEST_F(nntrainer_FullyConnectedLayer, initialize_04_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
   EXPECT_EQ(layer.getName(), layer_name);
 
-  status = layer.initialize();
-  EXPECT_EQ(status, ML_ERROR_NONE);
-
   /** Layer name can be updated */
   layer_name = "FCLayer1";
   status = layer.setName(layer_name);
@@ -872,8 +869,6 @@ protected:
 };
 
 TEST_F(nntrainer_Conv2DLayer, print_01_p) {
-  setProperty("filter=3");
-  reinitialize();
   unsigned int option = nntrainer::LayerPrintOption::PRINT_INST_INFO |
                         nntrainer::LayerPrintOption::PRINT_SHAPE_INFO |
                         nntrainer::LayerPrintOption::PRINT_PROP |


### PR DESCRIPTION
Add the restriction of updating the param size for layer weights once set
As of now, this adds the restriction of changing filter size for convolution once set
But this needs to be fixes in convolution. Conv2D should just have 1 weights and bias,
not split by filter size

Resolves #293

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>