### PR TITLE
[TCM] Fix no assertion test

### DIFF
--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -868,13 +868,15 @@ protected:
 };
 
 TEST_F(nntrainer_Conv2DLayer, print_01_p) {
+  std::stringstream ss;
   unsigned int option = nntrainer::LayerPrintOption::PRINT_INST_INFO |
                         nntrainer::LayerPrintOption::PRINT_SHAPE_INFO |
                         nntrainer::LayerPrintOption::PRINT_PROP |
                         nntrainer::LayerPrintOption::PRINT_PROP_META |
                         nntrainer::LayerPrintOption::PRINT_WEIGHTS |
                         nntrainer::LayerPrintOption::PRINT_METRIC;
-  layer.print(std::cerr, option);
+  layer.print(ss, option);
+  EXPECT_GT(ss.str().size(), 100);
 }
 
 /**


### PR DESCRIPTION
This patch fixes no test that has no assertion

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>