### PR TITLE
Fix typo in capi-nntrainer spec

### DIFF
--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -106,7 +106,7 @@ Tizen Native API wrapper for NNTrainer.
 You can train neural networks efficiently.
 
 %post -n capi-nntrainer -p /sbin/ldconfig
-%postrun -n capi-nntrainer -p /sbin/ldconfig
+%postun -n capi-nntrainer -p /sbin/ldconfig
 
 %package -n capi-nntrainer-devel
 Summary:         Tizen Native API Devel Kit for NNTrainer


### PR DESCRIPTION
**Changes proposed in this PR:**
- Fix typo capi-nntrainer that are causing unexpected exit

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>