### PR TITLE
[dataset] check bufsize at init

### DIFF
--- a/nntrainer/include/databuffer.h
+++ b/nntrainer/include/databuffer.h
@@ -170,7 +170,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int init() = 0;
+  virtual int init();
 
   /**
    * @brief     Update Data Buffer ( it is for child thread )

--- a/nntrainer/src/databuffer_file.cpp
+++ b/nntrainer/src/databuffer_file.cpp
@@ -66,27 +66,11 @@ static long getFileSize(std::string file_name) {
 }
 
 int DataBufferFromDataFile::init() {
-
   int status = ML_ERROR_NONE;
-  if (!class_num) {
-    ml_loge("Error: number of class must be set");
-    SET_VALIDATION(false);
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-  if (!this->input_dim.width()) {
-    ml_loge("Error: featuer size must be set");
-    SET_VALIDATION(false);
-    return ML_ERROR_INVALID_PARAMETER;
-  }
 
-  this->cur_train_bufsize = 0;
-  this->cur_val_bufsize = 0;
-  this->cur_test_bufsize = 0;
-  if (batch_size == 0) {
-    ml_loge("Error: batch size must be greater than 0");
-    SET_VALIDATION(false);
-    return ML_ERROR_INVALID_PARAMETER;
-  }
+  status = DataBuffer::init();
+  if (status != ML_ERROR_NONE)
+    return status;
 
   if (validation[DATA_TRAIN] && max_train < batch_size) {
     max_train = batch_size;
@@ -108,10 +92,6 @@ int DataBufferFromDataFile::init() {
   this->val_running = true;
   this->test_running = true;
 
-  trainReadyFlag = DATA_NOT_READY;
-  valReadyFlag = DATA_NOT_READY;
-  testReadyFlag = DATA_NOT_READY;
-
   if (validation[DATA_TRAIN] && max_train < train_bufsize) {
     ml_logw("Warning: Total number of train is less than train buffer size. "
             "Train buffer size is set as total number of train");
@@ -131,7 +111,7 @@ int DataBufferFromDataFile::init() {
     test_bufsize = batch_size;
   }
 
-  return status;
+  return ML_ERROR_NONE;
 }
 
 void DataBufferFromDataFile::updateData(BufferType type) {

--- a/nntrainer/src/databuffer_func.cpp
+++ b/nntrainer/src/databuffer_func.cpp
@@ -58,31 +58,13 @@ extern DataStatus testReadyFlag;
 int DataBufferFromCallback::init() {
   int status = ML_ERROR_NONE;
 
-  if (!class_num) {
-    ml_loge("Error: number of class must be set");
-    SET_VALIDATION(false);
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-
-  if (!this->input_dim.getFeatureLen()) {
-    ml_loge("Error: featuer size must be set");
-    SET_VALIDATION(false);
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-
-  this->cur_train_bufsize = 0;
-  this->cur_val_bufsize = 0;
-  this->cur_test_bufsize = 0;
+  status = DataBuffer::init();
+  if (status != ML_ERROR_NONE)
+    return status;
 
   this->max_train = 0;
   this->max_val = 0;
   this->max_test = 0;
-
-  if (batch_size == 0) {
-    ml_loge("Error: batch size must be greater than 0");
-    SET_VALIDATION(false);
-    return ML_ERROR_INVALID_PARAMETER;
-  }
 
   if (train_bufsize > batch_size || train_bufsize == 0) {
     train_bufsize = batch_size;
@@ -100,11 +82,7 @@ int DataBufferFromCallback::init() {
   this->val_running = true;
   this->test_running = true;
 
-  trainReadyFlag = DATA_NOT_READY;
-  valReadyFlag = DATA_NOT_READY;
-  testReadyFlag = DATA_NOT_READY;
-
-  return status;
+  return ML_ERROR_NONE;
 }
 
 int DataBufferFromCallback::setFunc(BufferType type, datagen_cb func) {

--- a/nntrainer/src/model_loader.cpp
+++ b/nntrainer/src/model_loader.cpp
@@ -120,13 +120,7 @@ int ModelLoader::loadDatasetConfigIni(dictionary *ini, NeuralNetwork &model) {
   status = model.data_buffer->setBatchSize(model.batch_size);
   NN_RETURN_STATUS();
 
-  unsigned int bufsize =
-    iniparser_getint(ini, "DataSet:BufferSize", model.batch_size);
-  ml_logd("buf size: %d", bufsize);
-  if (model.batch_size < bufsize) {
-    ml_logw("buffer size must be atleast the batch size. Reset to batch size.");
-    bufsize = model.batch_size;
-  }
+  unsigned int bufsize = iniparser_getint(ini, "DataSet:BufferSize", 1);
   status = model.data_buffer->setBufSize(bufsize);
   NN_RETURN_STATUS();
 

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -157,6 +157,8 @@ INSTANTIATE_TEST_CASE_P(
     mkIniTc("no_testSet_p", {nw_adam, dataset + "-TestData", input, out}, SUCCESS),
     mkIniTc("no_validSet_p", {nw_adam, dataset + "-ValidData", input, out}, SUCCESS),
     mkIniTc("no_bufferSize_p", {nw_adam, dataset + "-BufferSize", input, out}, SUCCESS),
+    mkIniTc("buffer_size_smaller_than_batch_size_p", {nw_adam, dataset + "BufferSize=26", input, out}, SUCCESS),
+    mkIniTc("buffer_size_smaller_than_batch_size2_p", {nw_adam, input, out, dataset + "BufferSize=26"}, SUCCESS),
 
 
   /**< half negative: init fail cases (1 positive and 4 negative cases) */
@@ -182,14 +184,12 @@ INSTANTIATE_TEST_CASE_P(
     mkIniTc("adam_minus_lr_n", {nw_adam + "Learning_rate = -0.1", input, out}, ALLFAIL),
     mkIniTc("sgd_minus_lr_n", {nw_sgd + "Learning_rate = -0.1", input, out}, ALLFAIL),
     mkIniTc("no_loss_n", {nw_adam + "-loss", input, out}, INITFAIL),
-    mkIniTc("buffer_size_smaller_than_batch_size_n", {nw_adam, dataset + "BufferSize=26", input, out}, ALLFAIL),
     mkIniTc("unknown_layer_type_n", {nw_adam, input + "Type = asdf", out}, ALLFAIL),
     mkIniTc("unknown_layer_type2_n", {nw_adam, input, out + "Type = asdf", I(out, "outlayer", "")}, ALLFAIL),
 
   /**< negative: little bit of tweeks to check determinancy (5 negative cases) */
     mkIniTc("wrong_nw_dataset_n", {nw_adam, input, out, dataset + "-LabelData"}, ALLFAIL),
     mkIniTc("wrong_nw_dataset2_n", {nw_adam, dataset + "-LabelData", input, out}, ALLFAIL),
-    mkIniTc("buffer_size_smaller_than_batch_size2_n", {nw_adam, input, out, dataset + "BufferSize=26"}, ALLFAIL),
 
   /**< negative: dataset is not complete (5 negative cases) */
     mkIniTc("no_trainingSet_n", {nw_adam, dataset + "-TrainData", input, out}, ALLFAIL),


### PR DESCRIPTION
This patch changes the initialization of buffer size.
The buffer size is now initialized with value 1 if user does not set it.
Then the proper checks on buffer size are performed at init
and buffer size is appropriately resized then.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>