### PR TITLE
[unittest] Add verification of accuracy for training metrics

### DIFF
--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -53,6 +53,16 @@ namespace nntrainer {
 typedef enum { NET_KNN, NET_REG, NET_NEU, NET_UNKNOWN } NetType;
 
 /**
+ * @brief     Statistics from running or training a model
+ */
+typedef struct RunStats_ {
+  float accuracy; /** accuracy of the model */
+  float loss;     /** loss of the model */
+
+  RunStats_() : accuracy(0), loss(0) {}
+} RunStats;
+
+/**
  * @class   NeuralNetwork Class
  * @brief   NeuralNetwork Class which has Network Configuration & Layers
  */
@@ -290,10 +300,14 @@ public:
    * @param[in] flags verbosity from ml_train_summary_type_e
    */
   /// @todo: change print to use NeuralNetPrintOption and add way to print out
-  /// metrics. Current implementation use summary level directly. and lack of
-  /// printing out metrics. It might be fine for now but later should add way to
-  /// control like layer::print
   void print(std::ostream &out, unsigned int flags = 0);
+
+  /**
+   * @brief print metrics function for neuralnet
+   * @param[in] out outstream
+   * @param[in] flags verbosity from ml_train_summary_type_e
+   */
+  void printMetrics(std::ostream &out, unsigned int flags = 0);
 
 private:
   unsigned int batch_size; /**< batch size */
@@ -331,6 +345,10 @@ private:
   int def_name_count; /**< Count assigned to layer names declared by default */
 
   bool loadedFromConfig; /**< Check if config is loaded to prevent load twice */
+
+  RunStats validation; /** validation statistics of the model */
+  RunStats training;   /** training statistics of the model */
+  RunStats testing;    /** testing statistics of the model */
 
   /**
    * @brief     Sets up and initialize the loss layer

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -36,6 +36,12 @@
 
 #define tolerance 10e-5
 
+/** Enum values to get model accuracy and loss. Sync with internal CAPI header
+ */
+#define ML_TRAIN_SUMMARY_MODEL_TRAIN_LOSS 101
+#define ML_TRAIN_SUMMARY_MODEL_VALID_LOSS 102
+#define ML_TRAIN_SUMMARY_MODEL_VALID_ACCURACY 103
+
 class IniSection {
 public:
   IniSection(const std::string &section_name, const std::string &entry_str) :

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -25,6 +25,42 @@
 #include <nntrainer_test_util.h>
 
 /**
+ * @brief Compare the training statistics
+ */
+static void nntrainer_capi_model_comp_metrics(ml_train_model_h model,
+                                              float train_loss,
+                                              float valid_loss,
+                                              float valid_accuracy) {
+  int status = ML_ERROR_NONE;
+  char *summary = nullptr;
+
+  /** Compare training statistics */
+  status = ml_train_model_get_summary(
+    model, (ml_train_summary_type_e)ML_TRAIN_SUMMARY_MODEL_TRAIN_LOSS,
+    &summary);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  EXPECT_FLOAT_EQ(std::strtof(summary, nullptr), train_loss);
+  free(summary);
+
+  status = ml_train_model_get_summary(
+    model, (ml_train_summary_type_e)ML_TRAIN_SUMMARY_MODEL_VALID_LOSS,
+    &summary);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  EXPECT_FLOAT_EQ(std::strtof(summary, nullptr), valid_loss);
+  free(summary);
+
+  status = ml_train_model_get_summary(
+    model, (ml_train_summary_type_e)ML_TRAIN_SUMMARY_MODEL_VALID_ACCURACY,
+    &summary);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  EXPECT_FLOAT_EQ(std::strtof(summary, nullptr), valid_accuracy);
+  free(summary);
+}
+
+/**
  * @brief Neural Network Model Contruct / Destruct Test (possitive test )
  */
 TEST(nntrainer_capi_nnmodel, construct_destruct_01_p) {
@@ -264,12 +300,19 @@ TEST(nntrainer_capi_nnmodel, train_01_p) {
                 config_str);
   replaceString("batch_size = 32", "batch_size = 16", config_file, config_str);
   replaceString("BufferSize=100", "", config_file, config_str);
+
   status = ml_train_model_construct_with_conf(config_file.c_str(), &handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
+
   status = ml_train_model_compile(handle, NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
+
   status = ml_train_model_run(handle, NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
+
+  /** Compare training statistics */
+  nntrainer_capi_model_comp_metrics(handle, 4.01373, 3.55134, 10.4167);
+
   status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
@@ -663,6 +706,9 @@ TEST(nntrainer_capi_nnmodel, train_with_file_01_p) {
   status = ml_train_model_run(model, "epochs=2", "save_path=model.bin", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
+  /** Compare training statistics */
+  nntrainer_capi_model_comp_metrics(model, 2.13067, 2.19975, 20.8333);
+
   status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
@@ -730,6 +776,9 @@ TEST(nntrainer_capi_nnmodel, train_with_generator_01_p) {
 
   status = ml_train_model_run(model, "epochs=2", "save_path=model.bin", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
+
+  /** Compare training statistics */
+  nntrainer_capi_model_comp_metrics(model, 2.17921, 1.96506, 60.4167);
 
   status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);


### PR DESCRIPTION
This patch add verification of accuracy for training metrics like loss and accuracy
in capi test cases

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>