### PR TITLE
[Tensor] Add multiple axes support

### DIFF
--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -306,7 +306,16 @@ public:
    * @param[in] alpha Scale the sum by this value
    * @retval    Calculated Tensor
    */
-  Tensor sum(int axis, float alpha = 1.0) const;
+  Tensor sum(unsigned int axis, float alpha = 1.0) const;
+
+  /**
+   * @brief sum all the Tensor by multiple axes
+   *
+   * @param axes axes to sum along
+   * @param alpha Scale the sum by this value
+   * @return Tensor
+   */
+  Tensor sum(const std::vector<unsigned int> &axes, float alpha = 1.0) const;
 
   /**
    * @brief     Averaging the Tensor elements according to the axis
@@ -316,7 +325,15 @@ public:
    *            3 : width direction
    * @retval    Calculated Tensor
    */
-  Tensor average(int axis) const;
+  Tensor average(unsigned int axis) const;
+
+  /**
+   * @brief average all the Tensor by multiple axes
+   *
+   * @param axes axes to sum along
+   * @return Tensor
+   */
+  Tensor average(const std::vector<unsigned int> &axes) const;
 
   /**
    * @brief     Averaging the Tensor elements by all axis

--- a/nntrainer/include/tensor_dim.h
+++ b/nntrainer/include/tensor_dim.h
@@ -84,7 +84,7 @@ public:
   const unsigned int *getDim() const { return dim; }
   unsigned int getNumDim() const { return MAXDIM; }
 
-  unsigned int getTensorDim(unsigned int idx);
+  const unsigned int getTensorDim(unsigned int idx) const;
   void setTensorDim(unsigned int idx, unsigned int value);
   int setTensorDim(std::string input_shape);
 

--- a/nntrainer/src/tensor_dim.cpp
+++ b/nntrainer/src/tensor_dim.cpp
@@ -45,7 +45,7 @@ void TensorDim::resetLen() {
   len = dim[0] * feature_len;
 }
 
-unsigned int TensorDim::getTensorDim(unsigned int idx) {
+const unsigned int TensorDim::getTensorDim(unsigned int idx) const {
   if (idx > MAXDIM)
     throw std::invalid_argument(
       "[TensorDim] Tensor Dimension index should be between 0 and 4");


### PR DESCRIPTION
This patch adds multiple axes support for sum and average.
which is esentially needed to build bn_layer

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>