### PR TITLE
[wait for #529] [tensor] Update default constructor of tensor to not throw

### DIFF
--- a/nntrainer/include/optimizer.h
+++ b/nntrainer/include/optimizer.h
@@ -33,9 +33,10 @@ namespace nntrainer {
  * @brief UpdatableParam that could be updated thorugh optimizer
  */
 struct UpdatableParam {
-  Tensor weight;    /**<  weight to be updated and used */
-  Tensor grad;      /**<  gradient for the weight */
-  std::string name; /**< name of the parameter */
+  Tensor weight;         /**< weight to be updated and used */
+  Tensor grad;           /**< gradient for the weight */
+  std::string name;      /**< name of the parameter */
+  bool updatable = true; /**< if this param is updatable */
 };
 
 /**

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -44,12 +44,19 @@ class LazyTensor;
  */
 class Tensor {
 public:
-  Tensor(const TensorDim &d, const float *buf = nullptr);
-
   /**
    * @brief     Basic Constructor of Tensor
    */
-  Tensor() : Tensor(TensorDim()){};
+  Tensor() :
+    dim(TensorDim()),
+    strides{{1, 2, 3}},
+    is_contiguous(true),
+    data(nullptr) {}
+
+  /**
+   * @brief     Constructor of Tensor with dimension/buf
+   */
+  Tensor(const TensorDim &d, const float *buf = nullptr);
 
   /**
    * @brief     Constructor of Tensor

--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -53,8 +53,8 @@ int BatchNormalizationLayer::initialize() {
   beta.setZero();
 
   setParamSize(4);
-  paramsAt(0) = {std::move(mu), Tensor(), "BN:moving_average"};
-  paramsAt(1) = {std::move(var), Tensor(), "BN:moving_variance"};
+  paramsAt(0) = {std::move(mu), Tensor(), "BN:moving_average", false};
+  paramsAt(1) = {std::move(var), Tensor(), "BN:moving_variance", false};
   paramsAt(2) = {std::move(gamma), Tensor(gamma.getDim()), "BN:gamma"};
   paramsAt(3) = {std::move(beta), Tensor(beta.getDim()), "BN:beta"};
 
@@ -145,9 +145,7 @@ BatchNormalizationLayer::backwarding(sharedConstTensor derivative,
          .divide_i(cvar.multiply(batch))
          .run();
 
-  std::shared_ptr<UpdatableParam> grad_params(params, params.get() + 2);
-
-  opt.apply_gradients(grad_params, param_size - 2, iteration);
+  opt.apply_gradients(params, param_size, iteration);
 
   return MAKE_SHARED_TENSOR(std::move(dx));
 }

--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -44,7 +44,7 @@ int Layer::setOptimizer(Optimizer &opt) {
   this->opt.setType(opt.getType());
   this->opt.setOptParam(opt.getOptParam());
 
-  return this->opt.initialize(getParams(), param_size, true);
+  return this->opt.initialize(params, param_size, true);
 }
 
 int Layer::checkValidation() {

--- a/nntrainer/src/optimizer.cpp
+++ b/nntrainer/src/optimizer.cpp
@@ -68,6 +68,9 @@ int Optimizer::initialize(std::shared_ptr<UpdatableParam> params,
     for (unsigned int i = 0; i < param_size; ++i) {
       UpdatableParam &param = param_data[i];
 
+      if (!param.updatable)
+        continue;
+
       Tensor &weight = param.weight;
       Tensor &grad = param.grad;
       Tensor w = Tensor(weight.getDim());
@@ -104,6 +107,9 @@ void Optimizer::apply_gradients(std::shared_ptr<UpdatableParam> params,
   int idx = 0;
   for (unsigned int i = 0; i < param_size; ++i) {
     UpdatableParam &param = param_data[i];
+
+    if (!param.updatable)
+      continue;
 
     Tensor &x = param.weight;
     const Tensor &x_grad = param.grad;

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -71,24 +71,19 @@ static auto rng = [] {
   return rng;
 }();
 
-Tensor::Tensor(const TensorDim &d, const float *buf) :
-  dim(d),
-  strides{{1, 2, 3}},
-  is_contiguous(true),
-  data(d.getDataLen() == 0
-         ? nullptr
-         : std::shared_ptr<float>(new float[d.getDataLen()],
-                                  std::default_delete<float[]>())) {
-  if (d.getDataLen() == 0) {
-    return;
-  }
+Tensor::Tensor(const TensorDim &d, const float *buf) : Tensor() {
+  dim = d;
+  if (d.getDataLen() != 0) {
+    data = std::shared_ptr<float>(new float[d.getDataLen()],
+                                  std::default_delete<float[]>());
 
-  // todo: initialize appropriate strides
-  if (buf != nullptr) {
-    float *data = getData();
-    unsigned int len = length();
+    // todo: initialize appropriate strides
+    if (buf != nullptr) {
+      float *data = getData();
+      unsigned int len = length();
 
-    scopy(len, buf, 1, data, 1);
+      scopy(len, buf, 1, data, 1);
+    }
   }
 }
 


### PR DESCRIPTION
The default constructor does no heap memory allocation (size is 0)
However it can still throw which isn't right
This patch updates the tensor default constructor to not throw because of heap allocation
to create less issues with static checkers which requires to add try catch around tensor declarations

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>