### PR TITLE
[ DataBuffer ] Fix for conner cases.

### DIFF
--- a/nntrainer/src/databuffer.cpp
+++ b/nntrainer/src/databuffer.cpp
@@ -189,9 +189,12 @@ bool DataBuffer::getDataFromBuffer(BufferType type, vec_4d &outVec,
       std::unique_lock<std::mutex> ultrain(readyTrainData);
       cv_train.wait(ultrain, [this]() -> bool { return trainReadyFlag; });
       if (trainReadyFlag == DATA_ERROR || trainReadyFlag == DATA_END) {
-        return false;
+        if (train_data.size() < batch_size)
+          return false;
+        else
+          break;
       }
-      if (trainReadyFlag == DATA_READY && train_data.size() != 0) {
+      if (trainReadyFlag == DATA_READY && train_data.size() >= batch_size) {
         break;
       }
     }
@@ -229,9 +232,12 @@ bool DataBuffer::getDataFromBuffer(BufferType type, vec_4d &outVec,
       std::unique_lock<std::mutex> ulval(readyValData);
       cv_val.wait(ulval, [this]() -> bool { return valReadyFlag; });
       if (valReadyFlag == DATA_ERROR || valReadyFlag == DATA_END) {
-        return false;
+        if (val_data.size() < batch_size)
+          return false;
+        else
+          break;
       }
-      if (valReadyFlag == DATA_READY && val_data.size() != 0) {
+      if (valReadyFlag == DATA_READY && val_data.size() >= batch_size) {
         break;
       }
     }
@@ -271,9 +277,12 @@ bool DataBuffer::getDataFromBuffer(BufferType type, vec_4d &outVec,
       cv_test.wait(ultest, [this]() -> bool { return testReadyFlag; });
 
       if (testReadyFlag == DATA_ERROR || testReadyFlag == DATA_END) {
-        return false;
+        if (test_data.size() < batch_size)
+          return false;
+        else
+          break;
       }
-      if (testReadyFlag == DATA_READY && test_data.size() != 0) {
+      if (testReadyFlag == DATA_READY && test_data.size() >= batch_size) {
         break;
       }
     }

--- a/nntrainer/src/databuffer_file.cpp
+++ b/nntrainer/src/databuffer_file.cpp
@@ -135,6 +135,10 @@ void DataBufferFromDataFile::updateData(BufferType type) {
 
     std::ifstream train_stream(train_name, std::ios::in | std::ios::binary);
     file.swap(train_stream);
+    readyTrainData.lock();
+    trainReadyFlag = DATA_NOT_READY;
+    readyTrainData.unlock();
+
   } break;
   case BUF_VAL: {
     max_size = max_val;
@@ -147,6 +151,10 @@ void DataBufferFromDataFile::updateData(BufferType type) {
 
     std::ifstream val_stream(val_name, std::ios::in | std::ios::binary);
     file.swap(val_stream);
+    readyValData.lock();
+    valReadyFlag = DATA_NOT_READY;
+    readyValData.unlock();
+
   } break;
   case BUF_TEST: {
     max_size = max_test;
@@ -159,6 +167,9 @@ void DataBufferFromDataFile::updateData(BufferType type) {
 
     std::ifstream test_stream(test_name, std::ios::in | std::ios::binary);
     file.swap(test_stream);
+    readyTestData.lock();
+    testReadyFlag = DATA_NOT_READY;
+    readyTestData.unlock();
   } break;
   default:
     try {
@@ -183,16 +194,6 @@ void DataBufferFromDataFile::updateData(BufferType type) {
   }
 
   while ((*running)) {
-
-    readyTrainData.lock();
-    trainReadyFlag = DATA_NOT_READY;
-    readyTrainData.unlock();
-    readyValData.lock();
-    valReadyFlag = DATA_NOT_READY;
-    readyValData.unlock();
-    readyTestData.lock();
-    testReadyFlag = DATA_NOT_READY;
-    readyTestData.unlock();
 
     if (mark.size() == 0) {
       NN_EXCEPTION_NOTI(DATA_END);


### PR DESCRIPTION
When the buffer thread broadcasts "DATA_END" while main thread get the
data from buffer, the main thread return even if there are data in
data buffer.

This PR includes fix this situation.

releated issues #427

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>