### PR TITLE
[Tensor] Add broadcasting support for add_i ops @open sesame 09/14 19:00

### DIFF
--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -38,6 +38,23 @@
 namespace nntrainer {
 
 class LazyTensor;
+
+/**
+ * @struct External Loop Info for broadcasted info
+ * @brief External Loop Info for broadcasted iteration. Please refer to
+ * DISABLED_private_external_loop_n in unittest_nntrainer_tensor.
+ * @note This should better be implemented in iterator fashion before used
+ * extensively.
+ */
+struct ExternalLoopInfo {
+  unsigned int buffer_size; /**< virtual size of the buffer */
+  unsigned int buffer_cnt;  /**< total count of buffer */
+  int buffer_axis;          /**< the smallest axis that should be looped.
+                                 -1 means no loop needed*/
+  std::array<unsigned int, MAXDIM>
+    strides; /**< modified strides for the loop */
+};
+
 /**
  * @class   Tensor Class for Calculation
  * @brief   Tensor Class for Calculation
@@ -49,7 +66,7 @@ public:
    */
   Tensor() :
     dim(TensorDim()),
-    strides{{1, 2, 3}},
+    strides{dim.computeStrides()},
     is_contiguous(true),
     data(nullptr) {}
 
@@ -546,7 +563,17 @@ public:
    * @brief     return current stride of tensor.
    * @retval    int[MAXDIM] strides
    */
-  const std::array<int, MAXDIM> getStrides() const noexcept { return strides; }
+  const std::array<unsigned int, MAXDIM> getStrides() const noexcept {
+    return strides;
+  }
+
+  /**
+   * @brief compute Loop info for broadcasting and vectorization
+   *
+   * @param m target tensor to be calculated against.
+   * @return ExternalLoopInfo Loopinfo needed to run external loop
+   */
+  ExternalLoopInfo computeExternalLoop(const Tensor &m);
 
 private:
   /**
@@ -554,8 +581,7 @@ private:
    */
   inline unsigned int getIndex(unsigned int b, unsigned int c, unsigned int h,
                                unsigned int w) const {
-    return (b * dim.getFeatureLen() + c * dim.height() * dim.width() +
-            h * dim.width() + w);
+    return (b * strides[0] + c * strides[1] + h * strides[2] + w * strides[3]);
   }
 
   /**
@@ -570,7 +596,7 @@ private:
 
   /**< handle the data as a std::shared_ptr<float> type */
   TensorDim dim;
-  std::array<int, MAXDIM> strides;
+  std::array<unsigned int, MAXDIM> strides;
   bool is_contiguous;
   std::shared_ptr<float> data;
 

--- a/nntrainer/include/tensor_dim.h
+++ b/nntrainer/include/tensor_dim.h
@@ -16,6 +16,7 @@
 #define __TENSOR_DIM_H__
 #ifdef __cplusplus
 
+#include <array>
 #include <iostream>
 #include <memory>
 #include <regex>
@@ -93,6 +94,15 @@ public:
   bool operator!=(const TensorDim &rhs) const { return !(*this == rhs); }
   bool isEmpty() const { return len == 0; }
   unsigned int rank() const;
+
+  /**
+   * @brief Calculate standard strides
+   *
+   * @return std::array <int, MAXDIM>
+   */
+  std::array<unsigned int, MAXDIM> computeStrides() const {
+    return {dim[1] * dim[2] * dim[3], dim[2] * dim[3], dim[3], 1};
+  }
 
 private:
   unsigned int dim[MAXDIM];

--- a/nntrainer/src/tensor_dim.cpp
+++ b/nntrainer/src/tensor_dim.cpp
@@ -14,10 +14,11 @@
 
 #include <assert.h>
 #include <cstring>
-#include <nntrainer_error.h>
-#include <nntrainer_log.h>
 #include <sstream>
 #include <stdio.h>
+
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
 #include <tensor_dim.h>
 
 namespace nntrainer {

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -362,6 +362,12 @@ nntrainer::Tensor constant(float value, unsigned int batch, unsigned channel,
                            unsigned height, unsigned width);
 
 /**
+ * @brief return a tensor filled with ranged value with given dimension
+ */
+nntrainer::Tensor ranged(unsigned int batch, unsigned channel, unsigned height,
+                         unsigned width);
+
+/**
  * @brief replace string and save in file
  * @param[in] from string to be replaced
  * @param[in] to string to repalce with

--- a/test/nntrainer_test_util.cpp
+++ b/test/nntrainer_test_util.cpp
@@ -271,6 +271,13 @@ nntrainer::Tensor constant(float value, unsigned int batch, unsigned channel,
   return t;
 }
 
+nntrainer::Tensor ranged(unsigned int batch, unsigned channel, unsigned height,
+                         unsigned width) {
+  nntrainer::Tensor t(batch, channel, height, width);
+  unsigned int i = 0;
+  return t.apply([&](float in) { return i++; });
+}
+
 void IniSection::setEntry(const std::string &entry_str) {
   // setting property separated by "|"
   std::regex words_regex("[^|]+");

--- a/test/unittest/unittest_nntrainer_lazy_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_lazy_tensor.cpp
@@ -124,10 +124,10 @@ TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_07_p) {
 
 // other basic operations (negative)...
 TEST_F(nntrainer_LazyTensorOpsTest, LazyTensorOps_07_n) {
-  EXPECT_THROW(target.chain().add_i(constant(2.0, 1, 1, 1, 1)).run(),
+  EXPECT_THROW(target.chain().add_i(constant(2.0, 9, 9, 9, 9)).run(),
                std::runtime_error);
 
-  EXPECT_THROW(target.chain().subtract_i(constant(2.0, 1, 1, 1, 1)).run(),
+  EXPECT_THROW(target.chain().subtract_i(constant(2.0, 9, 9, 9, 9)).run(),
                std::runtime_error);
 
   EXPECT_THROW(target.chain().multiply_i(constant(2.0, 1, 1, 1, 1)).run(),
@@ -171,7 +171,7 @@ TEST_F(nntrainer_LazyTensorOpsTest, ApplyIf_01_p) {
 
 TEST_F(nntrainer_LazyTensorOpsTest, ApplyIf_01_n) {
   EXPECT_THROW(
-    target.chain().applyIf(true, _LIFT(add_i), constant(4.0, 1, 1, 1, 1)).run(),
+    target.chain().applyIf(true, _LIFT(add_i), constant(4.0, 9, 9, 9, 9)).run(),
     std::runtime_error);
 }
 

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -448,6 +448,219 @@ TEST(nntrainer_Tensor, add_i_01_n) {
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
+TEST(nntrainer_Tensor, add_i_broadcast_01_p) {
+  nntrainer::TensorDim ref_dim{3, 2, 4, 5};
+  {
+    nntrainer::Tensor t = ranged(3, 2, 4, 5);
+    nntrainer::Tensor m = ranged(1, 2, 4, 5);
+    float answer_data[] = {
+      0,   2,   4,   6,   8,   10,  12,  14,  16,  18,  20,  22,  24,  26,
+      28,  30,  32,  34,  36,  38,  40,  42,  44,  46,  48,  50,  52,  54,
+      56,  58,  60,  62,  64,  66,  68,  70,  72,  74,  76,  78,  40,  42,
+      44,  46,  48,  50,  52,  54,  56,  58,  60,  62,  64,  66,  68,  70,
+      72,  74,  76,  78,  80,  82,  84,  86,  88,  90,  92,  94,  96,  98,
+      100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 80,  82,  84,  86,
+      88,  90,  92,  94,  96,  98,  100, 102, 104, 106, 108, 110, 112, 114,
+      116, 118, 120, 122, 124, 126, 128, 130, 132, 134, 136, 138, 140, 142,
+      144, 146, 148, 150, 152, 154, 156, 158};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
+  {
+    nntrainer::Tensor t = ranged(3, 2, 4, 5);
+    nntrainer::Tensor m = ranged(3, 1, 4, 5);
+    float answer_data[] = {
+      0,   2,   4,   6,   8,   10,  12,  14,  16,  18,  20,  22,  24,  26,
+      28,  30,  32,  34,  36,  38,  20,  22,  24,  26,  28,  30,  32,  34,
+      36,  38,  40,  42,  44,  46,  48,  50,  52,  54,  56,  58,  60,  62,
+      64,  66,  68,  70,  72,  74,  76,  78,  80,  82,  84,  86,  88,  90,
+      92,  94,  96,  98,  80,  82,  84,  86,  88,  90,  92,  94,  96,  98,
+      100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124, 126,
+      128, 130, 132, 134, 136, 138, 140, 142, 144, 146, 148, 150, 152, 154,
+      156, 158, 140, 142, 144, 146, 148, 150, 152, 154, 156, 158, 160, 162,
+      164, 166, 168, 170, 172, 174, 176, 178};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
+  {
+    nntrainer::Tensor t = ranged(3, 2, 4, 5);
+    nntrainer::Tensor m = ranged(3, 2, 4, 1);
+    float answer_data[] = {
+      0,   1,   2,   3,   4,   6,   7,   8,   9,   10,  12,  13,  14,  15,
+      16,  18,  19,  20,  21,  22,  24,  25,  26,  27,  28,  30,  31,  32,
+      33,  34,  36,  37,  38,  39,  40,  42,  43,  44,  45,  46,  48,  49,
+      50,  51,  52,  54,  55,  56,  57,  58,  60,  61,  62,  63,  64,  66,
+      67,  68,  69,  70,  72,  73,  74,  75,  76,  78,  79,  80,  81,  82,
+      84,  85,  86,  87,  88,  90,  91,  92,  93,  94,  96,  97,  98,  99,
+      100, 102, 103, 104, 105, 106, 108, 109, 110, 111, 112, 114, 115, 116,
+      117, 118, 120, 121, 122, 123, 124, 126, 127, 128, 129, 130, 132, 133,
+      134, 135, 136, 138, 139, 140, 141, 142};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
+  {
+    nntrainer::Tensor t = ranged(3, 2, 4, 5);
+    nntrainer::Tensor m = ranged(3, 1, 1, 5);
+    float answer_data[] = {
+      0,   2,   4,   6,   8,   5,   7,   9,   11,  13,  10,  12,  14,  16,
+      18,  15,  17,  19,  21,  23,  20,  22,  24,  26,  28,  25,  27,  29,
+      31,  33,  30,  32,  34,  36,  38,  35,  37,  39,  41,  43,  45,  47,
+      49,  51,  53,  50,  52,  54,  56,  58,  55,  57,  59,  61,  63,  60,
+      62,  64,  66,  68,  65,  67,  69,  71,  73,  70,  72,  74,  76,  78,
+      75,  77,  79,  81,  83,  80,  82,  84,  86,  88,  90,  92,  94,  96,
+      98,  95,  97,  99,  101, 103, 100, 102, 104, 106, 108, 105, 107, 109,
+      111, 113, 110, 112, 114, 116, 118, 115, 117, 119, 121, 123, 120, 122,
+      124, 126, 128, 125, 127, 129, 131, 133};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
+  {
+    nntrainer::Tensor t = ranged(3, 2, 4, 5);
+    nntrainer::Tensor m = ranged(1, 2, 1, 5);
+    float answer_data[] = {
+      0,   2,   4,   6,   8,   5,   7,   9,   11,  13,  10,  12,  14,  16,
+      18,  15,  17,  19,  21,  23,  25,  27,  29,  31,  33,  30,  32,  34,
+      36,  38,  35,  37,  39,  41,  43,  40,  42,  44,  46,  48,  40,  42,
+      44,  46,  48,  45,  47,  49,  51,  53,  50,  52,  54,  56,  58,  55,
+      57,  59,  61,  63,  65,  67,  69,  71,  73,  70,  72,  74,  76,  78,
+      75,  77,  79,  81,  83,  80,  82,  84,  86,  88,  80,  82,  84,  86,
+      88,  85,  87,  89,  91,  93,  90,  92,  94,  96,  98,  95,  97,  99,
+      101, 103, 105, 107, 109, 111, 113, 110, 112, 114, 116, 118, 115, 117,
+      119, 121, 123, 120, 122, 124, 126, 128};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
+  {
+    nntrainer::Tensor t = ranged(3, 2, 4, 5);
+    nntrainer::Tensor m = ranged(3, 1, 4, 1);
+    float answer_data[] = {
+      0,   1,   2,   3,   4,   6,   7,   8,   9,   10,  12,  13,  14,  15,
+      16,  18,  19,  20,  21,  22,  20,  21,  22,  23,  24,  26,  27,  28,
+      29,  30,  32,  33,  34,  35,  36,  38,  39,  40,  41,  42,  44,  45,
+      46,  47,  48,  50,  51,  52,  53,  54,  56,  57,  58,  59,  60,  62,
+      63,  64,  65,  66,  64,  65,  66,  67,  68,  70,  71,  72,  73,  74,
+      76,  77,  78,  79,  80,  82,  83,  84,  85,  86,  88,  89,  90,  91,
+      92,  94,  95,  96,  97,  98,  100, 101, 102, 103, 104, 106, 107, 108,
+      109, 110, 108, 109, 110, 111, 112, 114, 115, 116, 117, 118, 120, 121,
+      122, 123, 124, 126, 127, 128, 129, 130};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
+  {
+    nntrainer::Tensor t = ranged(3, 2, 4, 5);
+    nntrainer::Tensor m = ranged(1, 1, 1, 5);
+    float answer_data[] = {
+      0,   2,   4,   6,   8,   5,   7,   9,   11,  13,  10,  12,  14,  16,
+      18,  15,  17,  19,  21,  23,  20,  22,  24,  26,  28,  25,  27,  29,
+      31,  33,  30,  32,  34,  36,  38,  35,  37,  39,  41,  43,  40,  42,
+      44,  46,  48,  45,  47,  49,  51,  53,  50,  52,  54,  56,  58,  55,
+      57,  59,  61,  63,  60,  62,  64,  66,  68,  65,  67,  69,  71,  73,
+      70,  72,  74,  76,  78,  75,  77,  79,  81,  83,  80,  82,  84,  86,
+      88,  85,  87,  89,  91,  93,  90,  92,  94,  96,  98,  95,  97,  99,
+      101, 103, 100, 102, 104, 106, 108, 105, 107, 109, 111, 113, 110, 112,
+      114, 116, 118, 115, 117, 119, 121, 123};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
+  {
+    nntrainer::Tensor t = ranged(3, 2, 4, 5);
+    nntrainer::Tensor m = ranged(1, 2, 1, 1);
+    float answer_data[] = {
+      0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,
+      14,  15,  16,  17,  18,  19,  21,  22,  23,  24,  25,  26,  27,  28,
+      29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  40,  41,
+      42,  43,  44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,
+      56,  57,  58,  59,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,
+      71,  72,  73,  74,  75,  76,  77,  78,  79,  80,  80,  81,  82,  83,
+      84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  96,  97,
+      98,  99,  101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112,
+      113, 114, 115, 116, 117, 118, 119, 120};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
+  {
+    nntrainer::Tensor t = ranged(3, 2, 4, 5);
+    nntrainer::Tensor m = ranged(3, 1, 1, 1);
+    float answer_data[] = {
+      0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,
+      14,  15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,
+      28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  41,  42,
+      43,  44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,
+      57,  58,  59,  60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,
+      71,  72,  73,  74,  75,  76,  77,  78,  79,  80,  82,  83,  84,  85,
+      86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  96,  97,  98,  99,
+      100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113,
+      114, 115, 116, 117, 118, 119, 120, 121};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
+  {
+    nntrainer::Tensor t = ranged(3, 2, 4, 5);
+    nntrainer::Tensor m = ranged(1, 1, 1, 1);
+    m.add_i(1.0);
+    float answer_data[] = {
+      1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,
+      15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,
+      29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,
+      43,  44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,
+      57,  58,  59,  60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,
+      71,  72,  73,  74,  75,  76,  77,  78,  79,  80,  81,  82,  83,  84,
+      85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  96,  97,  98,
+      99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112,
+      113, 114, 115, 116, 117, 118, 119, 120};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
+  {
+    nntrainer::TensorDim ref_dim(3, 5, 1, 4);
+    nntrainer::Tensor t = ranged(3, 5, 1, 4);
+    nntrainer::Tensor m = ranged(3, 1, 1, 4);
+    float answer_data[] = {0,  2,  4,  6,  4,  6,  8,  10, 8,  10, 12, 14,
+                           12, 14, 16, 18, 16, 18, 20, 22, 24, 26, 28, 30,
+                           28, 30, 32, 34, 32, 34, 36, 38, 36, 38, 40, 42,
+                           40, 42, 44, 46, 48, 50, 52, 54, 52, 54, 56, 58,
+                           56, 58, 60, 62, 60, 62, 64, 66, 64, 66, 68, 70};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
+}
+
+TEST(nntrainer_Tensor, add_i_broadcast_not_supported_01_n) {
+  nntrainer::Tensor target(3, 1, 3, 1);
+  nntrainer::Tensor target2(3, 1, 3, 3);
+
+  EXPECT_EQ(target.add_i(target2), ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, add_i_broadcast_not_broadcastable_02_n) {
+  nntrainer::Tensor target(3, 2, 4, 5);
+  nntrainer::Tensor target2(3, 2, 3, 1);
+
+  EXPECT_EQ(target.add_i(target2), ML_ERROR_INVALID_PARAMETER);
+}
+
 TEST(nntrainer_Tensor, add_01_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
@@ -1154,7 +1367,7 @@ TEST(nntrainer_Tensor, copy_and_reshape_n) {
                std::invalid_argument);
 }
 
-/// @note this test case demonstrates it is dangeruous to use sharedConstTensor
+/// @note this test case demonstrates it is dangerous to use sharedConstTensor
 /// to const correct the inner data.
 TEST(nntrainer_Tensor, constructor_from_shared_const_ptr_shares_variable_n) {
   nntrainer::sharedConstTensor A =
@@ -1163,7 +1376,7 @@ TEST(nntrainer_Tensor, constructor_from_shared_const_ptr_shares_variable_n) {
   nntrainer::Tensor B = *A;
   nntrainer::Tensor C = A->clone();
 
-  B.setValue(3, 4, 5, 6, 2.0f);
+  B.setValue(2, 3, 4, 5, 2.0f);
   EXPECT_EQ(*A, B);
   EXPECT_NE(*A, C);
 
@@ -1210,6 +1423,88 @@ TEST(nntrainer_Tensor, print_large_size) {
   EXPECT_EQ(ss.str(), expected.str());
 }
 
+TEST(nntrainer_Tensor, private_external_loop_n) {
+  nntrainer::Tensor t = ranged(3, 5, 1, 4);
+  nntrainer::Tensor b = ranged(1, 5, 1, 4);
+
+  auto vector_func = [](float *buf, int stride, int size) {
+    float *cur = buf;
+    std::cerr << "[ ";
+    for (int i = 0; i < size; ++i) {
+      std::cerr << *cur << ' ';
+      cur += stride;
+    }
+    std::cerr << "]\n";
+  };
+
+  nntrainer::ExternalLoopInfo e;
+  EXPECT_NO_THROW(e = t.computeExternalLoop(b));
+
+  float *buf = t.getData();
+  float *mbuf = b.getData();
+
+  auto &t_strides = t.getStrides();
+  unsigned int offset;
+  unsigned int m_offset;
+
+  if (e.buffer_axis == -1) {
+    vector_func(buf, t_strides[3], e.buffer_size);
+    vector_func(mbuf, e.strides[3], e.buffer_size);
+  } else {
+    for (unsigned int b = 0; b < t.batch(); ++b) {
+      if (e.buffer_axis == 0) {
+        offset = b * t_strides[0];
+        m_offset = b * e.strides[0];
+        std::cerr << "=====================\n";
+        vector_func(buf + offset, t_strides[3], e.buffer_size);
+        vector_func(mbuf + m_offset, e.strides[3], e.buffer_size);
+        continue;
+      }
+      for (unsigned int c = 0; c < t.channel(); ++c) {
+        if (e.buffer_axis == 1) {
+          offset = b * t_strides[0] + c * t_strides[1];
+          m_offset = b * e.strides[0] + c * e.strides[1];
+          std::cerr << "=====================\n";
+          vector_func(buf + offset, t_strides[3], e.buffer_size);
+          vector_func(mbuf + m_offset, e.strides[3], e.buffer_size);
+          continue;
+        }
+        for (unsigned int h = 0; h < t.height(); ++h) {
+          if (e.buffer_axis == 2) {
+            offset = b * t_strides[0] + c * t_strides[1] + h * t_strides[2];
+            m_offset = b * e.strides[0] + c * e.strides[1] + h * e.strides[2];
+            std::cerr << "=====================\n";
+            vector_func(buf + offset, t_strides[3], e.buffer_size);
+            vector_func(mbuf + m_offset, e.strides[3], e.buffer_size);
+            continue;
+          }
+          for (unsigned int w = 0; w < t.width(); ++w) {
+            offset = b * t_strides[0] + c * t_strides[1] + h * t_strides[2] +
+                     w * t_strides[3];
+            m_offset = b * e.strides[0] + c * e.strides[1] + h * e.strides[2] +
+                       w * e.strides[3];
+            std::cerr << "after width: " << offset << std::endl;
+            std::cerr << "=====================\n";
+            vector_func(buf + offset, t_strides[3], e.buffer_size);
+            vector_func(mbuf + m_offset, e.strides[3], e.buffer_size);
+          }
+        }
+      }
+    }
+  }
+  std::cerr << "buffer_axis: " << e.buffer_axis << std::endl;
+  std::cerr << "t strides: ";
+  for (auto i : t_strides)
+    std::cerr << i << ' ';
+  std::cerr << std::endl;
+  std::cerr << "strides: ";
+  for (auto i : e.strides)
+    std::cerr << i << ' ';
+  std::cerr << std::endl;
+  std::cerr << "buffer_size: " << e.buffer_size << std::endl;
+  std::cerr << "buffer_cnt: " << e.buffer_cnt << std::endl;
+}
+
 /**
  * @brief Main gtest
  */
@@ -1219,7 +1514,7 @@ int main(int argc, char **argv) {
   try {
     testing::InitGoogleTest(&argc, argv);
   } catch (...) {
-    std::cerr << "Error duing IniGoogleTest" << std::endl;
+    std::cerr << "Error duing InitGoogleTest" << std::endl;
     return 0;
   }
 


### PR DESCRIPTION
Batchnormalization Layer needs extensive broadcasting support other than
batchwise add.
Add broadcasting to `add` family while keeping vectorization from cblas
as much as possible.

**Changes proposed in this PR:**
- Initialize actual strides
- Implement loop mechanism to `add_i`
- Add extensive tests for broadcasted add_i

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>