### PR TITLE
[bn] bug fix for setting optimizer for bn layer

### DIFF
--- a/nntrainer/include/optimizer.h
+++ b/nntrainer/include/optimizer.h
@@ -33,9 +33,10 @@ namespace nntrainer {
  * @brief UpdatableParam that could be updated thorugh optimizer
  */
 struct UpdatableParam {
-  Tensor weight;    /**<  weight to be updated and used */
-  Tensor grad;      /**<  gradient for the weight */
-  std::string name; /**< name of the parameter */
+  Tensor weight;         /**< weight to be updated and used */
+  Tensor grad;           /**< gradient for the weight */
+  std::string name;      /**< name of the parameter */
+  bool updatable = true; /**< if this param is updatable */
 };
 
 /**

--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -53,8 +53,8 @@ int BatchNormalizationLayer::initialize() {
   beta.setZero();
 
   setParamSize(4);
-  paramsAt(0) = {std::move(mu), Tensor(), "BN:moving_average"};
-  paramsAt(1) = {std::move(var), Tensor(), "BN:moving_variance"};
+  paramsAt(0) = {std::move(mu), Tensor(), "BN:moving_average", false};
+  paramsAt(1) = {std::move(var), Tensor(), "BN:moving_variance", false};
   paramsAt(2) = {std::move(gamma), Tensor(gamma.getDim()), "BN:gamma"};
   paramsAt(3) = {std::move(beta), Tensor(beta.getDim()), "BN:beta"};
 
@@ -145,9 +145,7 @@ BatchNormalizationLayer::backwarding(sharedConstTensor derivative,
          .divide_i(cvar.multiply(batch))
          .run();
 
-  std::shared_ptr<UpdatableParam> grad_params(params, params.get() + 2);
-
-  opt.apply_gradients(grad_params, param_size - 2, iteration);
+  opt.apply_gradients(params, param_size, iteration);
 
   return MAKE_SHARED_TENSOR(std::move(dx));
 }

--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -44,7 +44,7 @@ int Layer::setOptimizer(Optimizer &opt) {
   this->opt.setType(opt.getType());
   this->opt.setOptParam(opt.getOptParam());
 
-  return this->opt.initialize(getParams(), param_size, true);
+  return this->opt.initialize(params, param_size, true);
 }
 
 int Layer::checkValidation() {

--- a/nntrainer/src/optimizer.cpp
+++ b/nntrainer/src/optimizer.cpp
@@ -68,6 +68,9 @@ int Optimizer::initialize(std::shared_ptr<UpdatableParam> params,
     for (unsigned int i = 0; i < param_size; ++i) {
       UpdatableParam &param = param_data[i];
 
+      if (!param.updatable)
+        continue;
+
       Tensor &weight = param.weight;
       Tensor &grad = param.grad;
       Tensor w = Tensor(weight.getDim());
@@ -104,6 +107,9 @@ void Optimizer::apply_gradients(std::shared_ptr<UpdatableParam> params,
   int idx = 0;
   for (unsigned int i = 0; i < param_size; ++i) {
     UpdatableParam &param = param_data[i];
+
+    if (!param.updatable)
+      continue;
 
     Tensor &x = param.weight;
     const Tensor &x_grad = param.grad;


### PR DESCRIPTION
This patch provides bugfix for setting the optiimzer for bn layer
although the weight updates are called only for the trainable params,
the optimizer is initialized with all the weights which are not trainable
and have no gradients
This results in un-necessary memory allocation for them as well as
creates issues for #517

This patch adds a count for trainable_param_size and a getTrainableParams() for the layer
and instead of all params, only trainable params of the layer are passed to the optimizer

An alternate was for the optimizer to check gradient size and ignore the ones with 0 size
but thats over-engineering at this point.

Resolves #528 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>

cc. @zhoonit 