### PR TITLE
[dataset] Support setting user_data for generator dataset

### DIFF
--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -803,18 +803,18 @@ int ml_train_dataset_create_with_file(ml_train_dataset_h *dataset,
 int ml_train_dataset_set_property(ml_train_dataset_h dataset, ...) {
   int status = ML_ERROR_NONE;
   ml_train_dataset *nndataset;
-  const char *data;
+  void *data;
   std::shared_ptr<nntrainer::DataBuffer> data_buffer;
 
   check_feature_state();
 
   ML_TRAIN_VERIFY_VALID_HANDLE(dataset);
 
-  std::vector<std::string> arg_list;
+  std::vector<void *> arg_list;
   va_list arguments;
   va_start(arguments, dataset);
 
-  while ((data = va_arg(arguments, const char *))) {
+  while ((data = va_arg(arguments, void *))) {
     arg_list.push_back(data);
   }
 

--- a/nntrainer/include/databuffer.h
+++ b/nntrainer/include/databuffer.h
@@ -135,7 +135,8 @@ public:
     train_thread(),
     val_thread(),
     test_thread(),
-    data_buffer_type(type) {
+    data_buffer_type(type),
+    user_data(nullptr) {
     SET_VALIDATION(false);
     class_num = 0;
     cur_train_bufsize = 0;
@@ -288,6 +289,14 @@ public:
   int setProperty(std::vector<std::string> values);
 
   /**
+   * @brief     set property
+   * @param[in] values values of property
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int setProperty(std::vector<void *> values);
+
+  /**
    * @brief     status of thread
    */
   DataStatus trainReadyFlag;
@@ -392,6 +401,9 @@ protected:
    * @brief     The type of data buffer
    */
   DataBufferType data_buffer_type;
+
+  /** The user_data to be used for the data generator callback */
+  void *user_data;
 
   /**
    * @brief     set property

--- a/nntrainer/src/databuffer.cpp
+++ b/nntrainer/src/databuffer.cpp
@@ -42,6 +42,8 @@ std::exception_ptr globalExceptionPtr = nullptr;
 
 namespace nntrainer {
 
+constexpr char USER_DATA[] = "user_data";
+
 std::mutex data_lock;
 
 std::mutex readyTrainData;
@@ -461,6 +463,36 @@ void DataBuffer::displayProgress(const int count, BufferType type, float loss) {
   }
 
   std::cout.flush();
+}
+
+int DataBuffer::setProperty(std::vector<void *> values) {
+  int status = ML_ERROR_NONE;
+  std::vector<std::string> properties;
+
+  for (unsigned int i = 0; i < values.size(); ++i) {
+    char *key_ptr = (char *)values[i];
+    std::string key = key_ptr;
+    std::string value;
+
+    /** Handle the user_data as a special case */
+    if (key == USER_DATA) {
+      /** This ensures that a valid user_data element is passed by the user */
+      if (i + 1 >= values.size())
+        return ML_ERROR_INVALID_PARAMETER;
+
+      this->user_data = values[i + 1];
+
+      /** As values of i+1 is consumed, increase i by 1 */
+      i++;
+    } else {
+      properties.push_back(key);
+      continue;
+    }
+  }
+
+  status = setProperty(properties);
+
+  return status;
 }
 
 int DataBuffer::setProperty(std::vector<std::string> values) {

--- a/nntrainer/src/databuffer_func.cpp
+++ b/nntrainer/src/databuffer_func.cpp
@@ -181,7 +181,7 @@ void DataBufferFromCallback::updateData(BufferType type) {
     NN_EXCEPTION_NOTI(DATA_NOT_READY);
     if (buf_size - (*cur_size) > 0) {
       /** @todo Update to support multiple inputs later */
-      status = callback(vec_arr, veclabel_arr, &endflag, NULL);
+      status = callback(vec_arr, veclabel_arr, &endflag, user_data);
       if (endflag) {
         NN_EXCEPTION_NOTI(DATA_END);
         free(vec);

--- a/test/tizen_capi/unittest_tizen_capi_dataset.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_dataset.cpp
@@ -161,6 +161,46 @@ TEST(nntrainer_capi_dataset, set_dataset_property_02_p) {
 }
 
 /**
+ * @brief Neural Network Dataset set Property Test (negative test )
+ */
+TEST(nntrainer_capi_dataset, set_dataset_property_03_n) {
+  ml_train_dataset_h dataset;
+  int status;
+
+  status = ml_train_dataset_create_with_generator(&dataset, getBatch_train,
+                                                  NULL, NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_dataset_set_property(dataset, "user_data=10", NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_dataset_set_property(dataset, "user_data", NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_dataset_destroy(dataset);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Dataset set Property Test (positive test )
+ */
+TEST(nntrainer_capi_dataset, set_dataset_property_04_p) {
+  ml_train_dataset_h dataset;
+  int status = ML_ERROR_NONE;
+
+  status = ml_train_dataset_create_with_generator(&dataset, getBatch_train,
+                                                  NULL, NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status =
+    ml_train_dataset_set_property(dataset, "user_data", (void *)&status, NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_dataset_destroy(dataset);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
  * @brief Neural Network Dataset Create / Destroy Test (negative test )
  */
 TEST(nntrainer_capi_dataset, set_dataset_01_n) {


### PR DESCRIPTION
Support setting user_data for the dataset using generators
For now, there is only 1 user_data for all 3 train/valid/test dataset
The format for setting user_data is
"ml_train_dataset_set_property(dataset, "user_data", (void *) data, NULL)"

It is to be passed two consecutive arguments, and with list being terminated by NULL

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>