### PR TITLE
Add gitignore for python generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@
 *.so
 *.o
 *.a
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class


### PR DESCRIPTION
**Changes proposed in this PR:**
- Add python generated extensions to gitignore

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [x]Skipped
2. Run test: [ ]Passed [ ]Failed [x]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>