### PR TITLE
[unittest] install unittest dependent files

### DIFF
--- a/test/tizen_capi/meson.build
+++ b/test/tizen_capi/meson.build
@@ -19,3 +19,7 @@ foreach test_name : unittest_name_list
 
   test(unittest_name, exec)
 endforeach
+
+if (get_option('enable-test'))
+  install_data('test_conf.ini', install_dir: application_install_dir)
+endif

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -29,8 +29,8 @@ foreach target: test_target
     target,
     target + '.cpp',
     dependencies: unittest_nntrainer_deps,
-    install_dir: application_install_dir,
-    install: get_option('enable-test')
+    install: get_option('enable-test'),
+    install_dir: application_install_dir
   )
   test(target, exe)
 endforeach


### PR DESCRIPTION
Install missing unittest dependent files when installing the unittest

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>