### PR TITLE
Add bn layer properties

### DIFF
--- a/nntrainer/include/bn_layer.h
+++ b/nntrainer/include/bn_layer.h
@@ -24,12 +24,15 @@
 #define __BN_LAYER_H__
 #ifdef __cplusplus
 
+#include <array>
 #include <fstream>
+#include <functional>
 #include <iostream>
+#include <vector>
+
 #include <layer.h>
 #include <optimizer.h>
 #include <tensor.h>
-#include <vector>
 
 namespace nntrainer {
 
@@ -42,9 +45,12 @@ public:
   /**
    * @brief     Constructor of Batch Noramlization Layer
    */
-  BatchNormalizationLayer(float eps = 0.001, int axis = -1) :
-    epsilon(eps),
-    axis(axis) {
+  BatchNormalizationLayer(float epsilon = 0.001, float momentum = 0.99,
+                          int axis = -1) :
+    epsilon(epsilon),
+    momentum(momentum),
+    axis(axis),
+    initializers{WEIGHT_ZEROS, WEIGHT_ONES, WEIGHT_ZEROS, WEIGHT_ONES} {
     setType(LAYER_BN);
   };
 
@@ -103,13 +109,16 @@ public:
   void setProperty(const PropertyType type, const std::string &value = "");
 
 private:
-  Tensor cvar; /**< training varaince saved in bn_layer::forwarding and used in
+  Tensor cvar; /**< training variance saved in bn_layer::forwarding and used in
                     bn_layer::backwarding */
 
   Tensor x_normalized; /**< normalized axis saved for backwarding */
   float epsilon;       /**< epsilon */
+  float momentum;      /**< momentum */
   int axis;            /**< Target axis, axis inferred at initialize when -1 */
-  std::vector<unsigned int> axes_to_reduce; /**< target axes to reduce */
+
+  std::vector<unsigned int> axes_to_reduce;      /**< target axes to reduce */
+  std::array<WeightInitializer, 4> initializers; /**< weight initializers */
 };
 
 } // namespace nntrainer

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -99,15 +99,17 @@ typedef enum {
 /**
  * @brief     Enumeration of Weight Initialization Type
  *            0. WEIGHT_ZEROS ( Zero initialization )
- *            1. WEIGHT_LECUN_NORMAL ( LeCun normal initialization )
- *            2. WEIGHT_LECUN_UNIFORM (LeCun uniform initialization )
- *            3. WEIGHT_XAVIER_NORMAL ( Xavier normal initialization )
- *            4. WEIGHT_XAVIER_UNIFORM ( Xavier uniform initialization )
- *            5. WEIGHT_HE_NORMAL ( He normal initialization )
- *            6. WEIGHT_HE_UNIFORM ( He uniform initialization )
+ *            1. WEIGHT_ONES ( One initialization )
+ *            2. WEIGHT_LECUN_NORMAL ( LeCun normal initialization )
+ *            3. WEIGHT_LECUN_UNIFORM (LeCun uniform initialization )
+ *            4. WEIGHT_XAVIER_NORMAL ( Xavier normal initialization )
+ *            5. WEIGHT_XAVIER_UNIFORM ( Xavier uniform initialization )
+ *            6. WEIGHT_HE_NORMAL ( He normal initialization )
+ *            7. WEIGHT_HE_UNIFORM ( He uniform initialization )
  */
 typedef enum {
   WEIGHT_ZEROS,
+  WEIGHT_ONES,
   WEIGHT_LECUN_NORMAL,
   WEIGHT_LECUN_UNIFORM,
   WEIGHT_XAVIER_NORMAL,
@@ -238,6 +240,11 @@ public:
    *            18. num_inputs : unsigned int (minimum 1)
    *            19. num_outputs : unsigned int (minimum 1)
    *            20. batch_size : unsigned int (minimum 1)
+   *            21. momentum : float,
+   *            22. moving_mean_initializer : string (type),
+   *            23. moving_variance_initializer : string (type),
+   *            24. gamma_initializer : string (type),
+   *            25. beta_initializer" : string (type)
    */
   enum class PropertyType {
     input_shape = 0,
@@ -261,7 +268,12 @@ public:
     num_inputs = 18,
     num_outputs = 19,
     batch_size = 20,
-    unknown = 21
+    momentum = 21,
+    moving_mean_initializer = 22,
+    moving_variance_initializer = 23,
+    gamma_initializer = 24,
+    beta_initializer = 25,
+    unknown
   };
 
   /**
@@ -345,7 +357,7 @@ public:
    * @param[out] status Status
    * @retval Tensor Initialized Tensor
    */
-  Tensor initializeWeight(TensorDim w_dim, WeightInitializer initializer,
+  Tensor initializeWeight(const TensorDim &w_dim, WeightInitializer initializer,
                           int &status);
 
   /**

--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -81,8 +81,8 @@ void Layer::save(std::ofstream &file) {
   }
 }
 
-Tensor Layer::initializeWeight(TensorDim w_dim, WeightInitializer initializer,
-                               int &status) {
+Tensor Layer::initializeWeight(const TensorDim &w_dim,
+                               WeightInitializer initializer, int &status) {
 
   Tensor w = Tensor(w_dim);
 
@@ -95,6 +95,9 @@ Tensor Layer::initializeWeight(TensorDim w_dim, WeightInitializer initializer,
   switch (initializer) {
   case WEIGHT_ZEROS:
     w.setZero();
+    break;
+  case WEIGHT_ONES:
+    w.setValue(1.0f);
     break;
   case WEIGHT_LECUN_NORMAL:
     w.setRandNormal(0.0f, sqrt(1.0f / w_dim.height()));
@@ -226,7 +229,7 @@ void Layer::setProperty(const PropertyType type, const std::string &value) {
     break;
   default:
     std::string msg =
-      "[Layer] Unknown Layer Property Key for value" + std::string(value);
+      "[Layer] Unknown Layer Property Key for value " + std::string(value);
     throw exception::not_supported(msg);
   }
 }

--- a/nntrainer/src/parse_util.cpp
+++ b/nntrainer/src/parse_util.cpp
@@ -116,6 +116,7 @@ unsigned int parseType(std::string ll, InputType t) {
   /**
    * @brief     Weight Initialization Type String from configure file
    *            "zeros" : Zero Initialization
+   *            "ones" : One Initialization
    *            "lecun_normal"  : LeCun Normal Initialization
    *            "lecun_uniform"  : LeCun Uniform Initialization
    *            "xavier_normal"  : Xavier Normal Initialization
@@ -123,9 +124,9 @@ unsigned int parseType(std::string ll, InputType t) {
    *            "he_normal"  : He Normal Initialization
    *            "he_uniform"  : He Uniform Initialization
    */
-  std::array<std::string, 7> weight_ini_string = {
-    "zeros",          "lecun_normal", "lecun_uniform", "xavier_normal",
-    "xavier_uniform", "he_normal",    "he_uniform"};
+  std::array<std::string, 8> weight_ini_string = {
+    "zeros",         "ones",           "lecun_normal", "lecun_uniform",
+    "xavier_normal", "xavier_uniform", "he_normal",    "he_uniform"};
 
   /**
    * @brief     Weight Decay String from configure file
@@ -270,6 +271,11 @@ unsigned int parseType(std::string ll, InputType t) {
  * num_inputs = 18
  * num_outputs = 19
  * batch_size = 20
+ * momentum = 21
+ * moving_mean_initializer = 22
+ * moving_variance_initializer = 23
+ * gamma_initializer = 24
+ * beta_initializer = 25
  *
  * InputLayer has 0, 1, 2, 3 properties.
  * FullyConnectedLayer has 1, 4, 6, 7, 8, 9 properties.
@@ -277,7 +283,7 @@ unsigned int parseType(std::string ll, InputType t) {
  * Pooling2DLayer has 12, 13, 14, 15 properties.
  * BatchNormalizationLayer has 0, 1, 5, 6, 7 properties.
  */
-static std::array<std::string, 22> property_string = {
+static std::array<std::string, 27> property_string = {
   "input_shape",
   "normalization",
   "standardization",
@@ -299,6 +305,11 @@ static std::array<std::string, 22> property_string = {
   "num_inputs",
   "num_outputs",
   "batch_size",
+  "momentum",
+  "moving_mean_initializer",
+  "moving_variance_initializer",
+  "gamma_initializer",
+  "beta_initializer",
   "unknown"};
 
 unsigned int parseLayerProperty(std::string property) {
@@ -323,7 +334,7 @@ unsigned int parseOptProperty(std::string property) {
   unsigned int i;
 
   /**
-   * @brief     Layer Properties
+   * @brief     Optimizer Properties
    * learning_rate = 0,
    * decay_rate = 1,
    * decay_steps = 2

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -797,7 +797,8 @@ protected:
   }
 
   virtual void prepareLayer() {
-    setProperty("input_shape=1:1:12 | epsilon=0.001 | batch_size=3");
+    setProperty(
+      "input_shape=1:1:12 | epsilon=0.001 | batch_size=3 | momentum=0.90");
     setOptimizer(nntrainer::OptType::sgd, "learning_rate=1");
   }
 };

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -104,7 +104,12 @@ static IniSection dataset("DataSet", "BufferSize = 100 |"
                                      "ValidData = valSet.dat |"
                                      "LabelData = label.dat");
 
-static IniSection batch_normal("bn", "Type = batch_normalization");
+static IniSection batch_normal("bn", "Type = batch_normalization |"
+                                     "momentum = 1.2 |"
+                                     "moving_mean_initializer = zeros |"
+                                     "moving_variance_initializer = ones |"
+                                     "gamma_initializer = zeros |"
+                                     "beta_initializer = ones");
 
 static IniSection flatten("flat", "Type = flatten");
 


### PR DESCRIPTION
This patch add properties for bn layer

**Changes proposed in this PR:**
- momentum
- moving_mean_initializer
- moving_variance_initializer
- gamma_initializer
- beta_initializer

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>