### PR TITLE
[meson] Move dependencies to correct location

### DIFF
--- a/Applications/TransferLearning/Draw_Classification/jni/meson.build
+++ b/Applications/TransferLearning/Draw_Classification/jni/meson.build
@@ -1,8 +1,5 @@
-gst_api_version = '1.0'
 build_root = meson.build_root()
 res_path = join_paths(meson.current_source_dir(), '..', 'res')
-glib_dep = dependency('glib-2.0')
-gst_dep = dependency('gstreamer-'+gst_api_version)
 
 training_sources = [
   'main.cpp',

--- a/nnstreamer/tensor_filter/meson.build
+++ b/nnstreamer/tensor_filter/meson.build
@@ -5,6 +5,11 @@ foreach s : filter_sub_nntrainer_sources
   nnstreamer_filter_nntrainer_sources += join_paths(meson.current_source_dir(), s)
 endforeach
 
+# TODO: remove gstreamer dependency by updating nnstreamer_plugin_api.h
+gst_api_version = '1.0'
+glib_dep = dependency('glib-2.0')
+gst_dep = dependency('gstreamer-'+gst_api_version)
+
 nntrainer_prefix = get_option('prefix')
 
 nnstreamer_filter_nntrainer_deps = [glib_dep, gst_dep, nntrainer_dep, nnstreamer_dep]


### PR DESCRIPTION
Move dependencies of glib and gstreamer to nnstreamer plugin from applications

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>