### PR TITLE
[ LICENSE ] Fix license header

### DIFF
--- a/nntrainer/include/nntrainer_error.h
+++ b/nntrainer/include/nntrainer_error.h
@@ -1,16 +1,4 @@
-/**
- * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Library General Public License for more details.
- */
+// SPDX-License-Identifier: Apache-2.0-only
 /**
  * @file nntrainer_error.h
  * @date 03 April 2020


### PR DESCRIPTION
NNTrainer is not LGPL. It is Apache2.0 and fix accordingly.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: HyesuAhn <linim@naver.com>