### PR TITLE
[application] Transfer learning using just C-API

### DIFF
--- a/Applications/TransferLearning/Draw_Classification/jni/bitmap_helpers.cpp
+++ b/Applications/TransferLearning/Draw_Classification/jni/bitmap_helpers.cpp
@@ -71,7 +71,7 @@ uint8_t *decode_bmp(const uint8_t *input, int row_size, uint8_t *const output,
   return output;
 }
 
-uint8_t *read_bmp(const std::string &input_bmp_name, int *width, int *height,
+uint8_t *read_bmp(const char *input_bmp_name, int *width, int *height,
                   int *channels) {
   int begin, end;
 

--- a/Applications/TransferLearning/Draw_Classification/jni/bitmap_helpers.h
+++ b/Applications/TransferLearning/Draw_Classification/jni/bitmap_helpers.h
@@ -22,7 +22,7 @@ limitations under the License.
 #include <iostream>
 namespace tflite {
 namespace label_image {
-uint8_t *read_bmp(const std::string &input_bmp_name, int *width, int *height,
+uint8_t *read_bmp(const char *input_bmp_name, int *width, int *height,
                   int *channels);
 } // namespace label_image
 } // namespace tflite

--- a/Applications/TransferLearning/Draw_Classification/jni/meson.build
+++ b/Applications/TransferLearning/Draw_Classification/jni/meson.build
@@ -22,4 +22,4 @@ e = executable('nntrainer_training',
   install_dir: application_install_dir
 )
 
-test('app_training', e, args: [join_paths(res_path, 'Training.ini'), res_path + '/'], timeout: 60)
+test('app_training', e, args: [join_paths(res_path, 'Training.ini'), res_path], timeout: 60)

--- a/Applications/TransferLearning/Draw_Classification/res/Training.ini
+++ b/Applications/TransferLearning/Draw_Classification/res/Training.ini
@@ -2,7 +2,7 @@
 [Model]
 Type = NeuralNetwork	# Network Type : Regression, KNN, NeuralNetwork
 Learning_rate = 0.01 	# Learning Rate
-Epochs = 100		# Epochs
+Epochs = 1000		# Epochs
 Optimizer = sgd		# Optimizer : sgd (stochastic gradien decent),
  	    		#             adam (Adamtive Moment Estimation)
 Loss = cross   		# Loss function : mse (mean squared error)

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -328,7 +328,6 @@ static int nntrainer_getOutputDim(const GstTensorFilterProperties *prop,
 
 static void nntrainer_destroyNotify(void **private_data, void *data) {
   NNTrainer *nntrainer = static_cast<NNTrainer *>(*private_data);
-  std::cout << "nnstrainer_dest" << std::endl;
   if (nntrainer) {
     nntrainer->freeOutputTensor(data);
   }

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -94,6 +94,8 @@ Summary:	NNTrainer Examples
 Requires:	nntrainer = %{version}-%{release}
 Requires:	iniparser
 Requires:	capi-nnstreamer
+Requires:	nnstreamer-tensorflow-lite
+BuildRequires:	nnstreamer-tensorflow-lite
 BuildRequires:	tensorflow-lite-devel
 BuildRequires:	pkgconfig(jsoncpp)
 BuildRequires:	pkgconfig(libcurl)
@@ -193,6 +195,13 @@ tar xzf unittest_layers.tar.gz -C build
 
 # independent unittests of nntrainer
 bash %{test_script} ./test
+
+export NNSTREAMER_CONF=$(pwd)/test/nnstreamer_filter_nntrainer/nnstreamer-test.ini
+export NNSTREAMER_FILTERS=$(pwd)/build/nnstreamer/tensor_filter
+pushd build
+TF_APP=Applications/TransferLearning/Draw_Classification
+./${TF_APP}/jni/nntrainer_training ../${TF_APP}/res/Training.ini ../${TF_APP}/res
+popd
 
 # unittest for nntrainer plugin for nnstreamer
 %if  0%{?nnstreamer_filter}


### PR DESCRIPTION
Update transfer learning application to use just C-API
This divides the application into 3 parts -
1. Running the fixed part of the model - done using nnstreamer-single C-API
2. Training the trianable part of the model - done with nntrainer C-API
3. Running the testing of the trainable part of the model - done with nnstreamer-pipeline C-API with nntrainer tensor filter extension

The outputs of section 1 is kept loaded in the memory than saving to disk and loading back

Commit - 2
Added callback for testing the model
The callback prints the top-1 predicted output for a given image file
Increased number of epochs back to 1000 to acheive better accuracy

Resolves #451 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>