### PR TITLE
[ DataBuffer ] Fix Undeterministic Behavior when validation is false

### DIFF
--- a/nntrainer/src/databuffer.cpp
+++ b/nntrainer/src/databuffer.cpp
@@ -77,6 +77,9 @@ int DataBuffer::run(BufferType type) {
           return ML_ERROR_INVALID_PARAMETER;
         }
       }
+    } else {
+      ml_loge("Error: Training Data Set is not valid");
+      return ML_ERROR_INVALID_PARAMETER;
     }
     break;
   case BUF_VAL:
@@ -93,6 +96,9 @@ int DataBuffer::run(BufferType type) {
           return ML_ERROR_INVALID_PARAMETER;
         }
       }
+    } else {
+      ml_loge("Error: Validation Data Set is not valid");
+      return ML_ERROR_INVALID_PARAMETER;
     }
     break;
   case BUF_TEST:
@@ -110,6 +116,9 @@ int DataBuffer::run(BufferType type) {
           return ML_ERROR_INVALID_PARAMETER;
         }
       }
+    } else {
+      ml_loge("Error: Test Data Set is not valid");
+      return ML_ERROR_INVALID_PARAMETER;
     }
     break;
   default:


### PR DESCRIPTION
Add check and return INVALID_PARAM when the validation bit is false.
If it returns INVALID_PARAM, then train_run return INVALID_PARAM as
well.

related issues : #425 

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>