### PR TITLE
[Tensor] Fix bug in the broadcast support @open sesame 09/18 11:48

### DIFF
--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -368,6 +368,13 @@ nntrainer::Tensor ranged(unsigned int batch, unsigned channel, unsigned height,
                          unsigned width);
 
 /**
+ * @brief return a tensor filled with random value with given dimension
+ */
+nntrainer::Tensor randUniform(unsigned int batch, unsigned channel,
+                              unsigned height, unsigned width, float min = -1,
+                              float max = 1);
+
+/**
  * @brief replace string and save in file
  * @param[in] from string to be replaced
  * @param[in] to string to repalce with

--- a/test/nntrainer_test_util.cpp
+++ b/test/nntrainer_test_util.cpp
@@ -263,19 +263,28 @@ int getBatch_val(float **outVec, float **outLabel, bool *last,
 /**
  * @brief return a tensor filled with contant value with dimension
  */
-nntrainer::Tensor constant(float value, unsigned int batch, unsigned channel,
-                           unsigned height, unsigned width) {
+nntrainer::Tensor constant(float value, unsigned int batch,
+                           unsigned int channel, unsigned int height,
+                           unsigned int width) {
   nntrainer::Tensor t(batch, channel, height, width);
   t.setValue(value);
 
   return t;
 }
 
-nntrainer::Tensor ranged(unsigned int batch, unsigned channel, unsigned height,
-                         unsigned width) {
+nntrainer::Tensor ranged(unsigned int batch, unsigned int channel,
+                         unsigned int height, unsigned int width) {
   nntrainer::Tensor t(batch, channel, height, width);
   unsigned int i = 0;
   return t.apply([&](float in) { return i++; });
+}
+
+nntrainer::Tensor randUniform(unsigned int batch, unsigned int channel,
+                              unsigned int height, unsigned int width,
+                              float min, float max) {
+  nntrainer::Tensor t(batch, channel, height, width);
+  t.setRandUniform(min, max);
+  return t;
 }
 
 void IniSection::setEntry(const std::string &entry_str) {

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -1161,6 +1161,27 @@ TEST(nntrainer_Tensor, add_i_broadcast_01_p) {
     EXPECT_EQ(status, ML_ERROR_NONE);
     EXPECT_EQ(t, answer);
   }
+  {
+    nntrainer::TensorDim ref_dim(1, 1, 2, 1);
+    nntrainer::Tensor t = ranged(1, 1, 2, 1);
+    nntrainer::Tensor m = ranged(1, 1, 2, 1);
+    float answer_data[] = {0.0, 2.0};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
+  {
+    nntrainer::TensorDim ref_dim(16, 1, 1, 1);
+    nntrainer::Tensor t = ranged(16, 1, 1, 1);
+    nntrainer::Tensor m = ranged(1, 1, 1, 1);
+    float answer_data[] = {0.0, 1.0, 2.0,  3.0,  4.0,  5.0,  6.0,  7.0,
+                           8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0};
+    nntrainer::Tensor answer(ref_dim, answer_data);
+    int status = t.add_i(m);
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    EXPECT_EQ(t, answer);
+  }
 }
 
 TEST(nntrainer_Tensor, add_i_broadcast_not_supported_01_n) {
@@ -1940,8 +1961,8 @@ TEST(nntrainer_Tensor, print_large_size) {
 }
 
 TEST(nntrainer_Tensor, DISABLED_broadcast_info_n) {
-  nntrainer::Tensor t = ranged(3, 5, 1, 4);
-  nntrainer::Tensor b = ranged(1, 5, 1, 4);
+  nntrainer::Tensor t = ranged(1, 1, 2, 1);
+  nntrainer::Tensor b = ranged(1, 1, 2, 1);
 
   auto vector_func = [](float *buf, int stride, int size) {
     float *cur = buf;
@@ -2018,6 +2039,26 @@ TEST(nntrainer_Tensor, DISABLED_broadcast_info_n) {
     std::cerr << i << ' ';
   std::cerr << std::endl;
   std::cerr << "buffer_size: " << e.buffer_size << std::endl;
+}
+
+TEST(nntrainer_Tensor, DISABLED_equation_test_01_p) {
+  nntrainer::Tensor a, b, c;
+  nntrainer::Tensor ret1, ret2;
+
+  a = randUniform(4, 6, 7, 3, -100, 100);
+  b = randUniform(4, 6, 7, 3, -100, 100);
+  c = randUniform(4, 6, 7, 3, -100, 100);
+
+  ret1 = a.subtract(b).multiply(c);
+  ret2 = a.multiply(c).subtract(b.multiply(c));
+
+  float *data1 = ret1.getData();
+  float *data2 = ret2.getData();
+  EXPECT_EQ(ret1, ret2);
+
+  for (unsigned int i = 0; i < ret1.length(); ++i) {
+    EXPECT_FLOAT_EQ(data1[i], data2[i]);
+  }
 }
 
 /**


### PR DESCRIPTION
Fix bug that strides and buffer axis are miscalculated

**Changes proposed in this PR:**
- Clarified consecutive-one strategy and same-stride(dimension matching) strategy
- Change the last stride to 0 only if it is using a consecutive-one strategy
- Add regression test

Resolves: #559

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Cc: Jijoong Moon <jijoong.moon@samsung.com>
Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>