### PR TITLE
[CS] Add inference page @open sesame 09/24 19:32

### DIFF
--- a/Applications/Tizen_native/CustomShortcut/inc/data.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/data.h
@@ -37,6 +37,13 @@
 
 #define FEATURE_SIZE 62720
 #define NUM_CLASS 2
+
+typedef enum DRAW_TARGET_ {
+  INFER = 0,
+  TRAIN_UNSET,
+  TRAIN_SMILE,
+  TRAIN_FROWN
+} DRAW_TARGET;
 typedef struct appdata {
   Evas_Object *win;
   Evas_Object *conform;
@@ -59,6 +66,7 @@ typedef struct appdata {
 
   cairo_surface_t *cr_surface; /**< cairo surface for the canvas */
   cairo_t *cr;                 /**< cairo engine for the canvas */
+  DRAW_TARGET draw_target;     /**< draw target for the canvas */
   int tries;                   /**< tells how many data has been labeled */
 
   /**< Feature extraction related */

--- a/Applications/Tizen_native/CustomShortcut/inc/main.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/main.h
@@ -1,4 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0-only
 /**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
  * @file main.h
  * @date 14 May 2020
  * @brief TIZEN Native Example App main entry with NNTrainer/CAPI.

--- a/Applications/Tizen_native/CustomShortcut/inc/view.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/view.h
@@ -1,4 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0-only
 /**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
  * @file view.h
  * @date 15 May 2020
  * @brief TIZEN Native Example App view entry with NNTrainer/CAPI.

--- a/Applications/Tizen_native/CustomShortcut/res/edje/main.edc
+++ b/Applications/Tizen_native/CustomShortcut/res/edje/main.edc
@@ -1,4 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0-only
 /**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
  * @file main.edc
  * @date 15 May 2020
  * @brief TIZEN Native Example App main edc that describes view behavior
@@ -94,11 +97,13 @@ collections {
   group {
     name: "home";
     parts {
-      PART_TITLE("home/title", "NNTrainer Demo")
-      PART_BUTTON("home/proceed", "start draw", 0.1, 0.3, 0.9, 0.7)
+      PART_TITLE("home/title", "Select actions...")
+      PART_BUTTON("home/to_train", "train", 0.55, 0.3, 0.9, 0.7)
+      PART_BUTTON("home/to_test", "test", 0.1, 0.3, 0.45, 0.7)
     }
     programs {
-      PROGRAM_BUTTON("home/proceed", "routes/to", "draw")
+      PROGRAM_BUTTON("home/to_train", "routes/to", "draw:train")
+      PROGRAM_BUTTON("home/to_test", "routes/to", "draw:inference")
     }
   }
   group {
@@ -152,6 +157,10 @@ collections {
             align: 0.5 0.5;
           }
         }
+        description {
+          state: "done" 0.0;
+          inherit: "default" 0.0;
+        }
       }
       part {
         name: "train_result/accuracy";
@@ -183,6 +192,14 @@ collections {
           }
         }
       }
+    }
+  }
+  group {
+    name: "test_result";
+    parts {
+      PART_TITLE("test_result/title", "test is successfully done")
+      PART_BUTTON("test_result/go_back", "test result: 😊", 0.1, 0.3, 0.9, 0.7)
+      // reserve a text area to show the guess from the model
     }
   }
 }

--- a/Applications/Tizen_native/CustomShortcut/src/data.c
+++ b/Applications/Tizen_native/CustomShortcut/src/data.c
@@ -133,7 +133,10 @@ static void on_data_receive_(ml_tensors_data_h data,
           write_result, data_size);
   }
 
-  bool target_label = ad->tries % 2;
+  /// one-hot encoding.
+  /// SMILE: 0 1
+  /// FROWN: 1 0
+  bool target_label = ad->draw_target == TRAIN_SMILE ? 0 : 1;
   LOG_D("writing one-hot encoded label");
   label = target_label;
   if (fwrite(&label, sizeof(float), 1, file) < 0) {

--- a/Applications/Tizen_native/CustomShortcut/src/main.c
+++ b/Applications/Tizen_native/CustomShortcut/src/main.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0-only
 /**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
  * @file main.c
  * @date 14 May 2020
  * @brief TIZEN Native Example App main entry with NNTrainer/CAPI.


### PR DESCRIPTION
**Changes proposed in this PR:**
- Change home to accomodate inference
- Route draw inference
- Add `draw_target` to use appdata to address label

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

resolves #571 

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>