### PR TITLE
[layers] Move constructors must be noexcept

### DIFF
--- a/nntrainer/include/addition_layer.h
+++ b/nntrainer/include/addition_layer.h
@@ -46,7 +46,7 @@ public:
    *  @brief  Move constructor of AdditionLayer.
    *  @param[in] AdditionLayer &&
    */
-  AdditionLayer(AdditionLayer &&rhs) = default;
+  AdditionLayer(AdditionLayer &&rhs) noexcept = default;
 
   /**
    * @brief  Move assignment operator.

--- a/nntrainer/include/bn_layer.h
+++ b/nntrainer/include/bn_layer.h
@@ -63,7 +63,7 @@ public:
    *  @brief  Move constructor of Pooling 2D Layer.
    *  @param[in] BatchNormalization &&
    */
-  BatchNormalizationLayer(BatchNormalizationLayer &&rhs) = default;
+  BatchNormalizationLayer(BatchNormalizationLayer &&rhs) noexcept = default;
 
   /**
    * @brief  Move assignment operator.

--- a/nntrainer/include/conv2d_layer.h
+++ b/nntrainer/include/conv2d_layer.h
@@ -54,7 +54,7 @@ public:
    *  @brief  Move constructor of Conv 2D Layer.
    *  @param[in] Conv2dLayer &&
    */
-  Conv2DLayer(Conv2DLayer &&rhs) = default;
+  Conv2DLayer(Conv2DLayer &&rhs) noexcept = default;
 
   /**
    * @brief  Move assignment operator.

--- a/nntrainer/include/fc_layer.h
+++ b/nntrainer/include/fc_layer.h
@@ -44,7 +44,7 @@ public:
    *  @brief  Move constructor of Pooling 2D Layer.
    *  @param[in] FullyConnected &&
    */
-  FullyConnectedLayer(FullyConnectedLayer &&rhs) = default;
+  FullyConnectedLayer(FullyConnectedLayer &&rhs) noexcept = default;
 
   /**
    * @brief  Move assignment operator.

--- a/nntrainer/include/flatten_layer.h
+++ b/nntrainer/include/flatten_layer.h
@@ -43,7 +43,7 @@ public:
    *  @brief  Move constructor of FlattenLayer.
    *  @param[in] FlattenLayer &&
    */
-  FlattenLayer(FlattenLayer &&rhs) = default;
+  FlattenLayer(FlattenLayer &&rhs) noexcept = default;
 
   /**
    * @brief  Move assignment operator.

--- a/nntrainer/include/input_layer.h
+++ b/nntrainer/include/input_layer.h
@@ -55,7 +55,7 @@ public:
    *  @brief  Move constructor of Pooling 2D Layer.
    *  @param[in] Input &&
    */
-  InputLayer(InputLayer &&rhs) = default;
+  InputLayer(InputLayer &&rhs) noexcept = default;
 
   /**
    * @brief  Move assignment operator.

--- a/nntrainer/include/optimizer.h
+++ b/nntrainer/include/optimizer.h
@@ -123,7 +123,7 @@ public:
    *  @brief  Move constructor of Conv 2D Layer.
    *  @param[in] Conv2dLayer &&
    */
-  Optimizer(Optimizer &&rhs) = default;
+  Optimizer(Optimizer &&rhs) noexcept = default;
 
   /**
    * @brief  Move assignment operator.

--- a/nntrainer/include/pooling2d_layer.h
+++ b/nntrainer/include/pooling2d_layer.h
@@ -59,7 +59,7 @@ public:
    *  @brief  Move constructor of Pooling 2D Layer.
    *  @param[in] Pooling2D &&
    */
-  Pooling2DLayer(Pooling2DLayer &&rhs) = default;
+  Pooling2DLayer(Pooling2DLayer &&rhs) noexcept = default;
 
   /**
    * @brief  Move assignment operator.


### PR DESCRIPTION
Make all move constructors to be noexcept
Without noexcept, compiler many times does not use move constructor but rather uses copy constructor

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>