### PR TITLE
[weight] weight class to simplify headers and enums

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -41,7 +41,8 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/src/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/flatten_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/model_loader.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/addition_layer.cpp \
-                  $(NNTRAINER_ROOT)/nntrainer/src/blas_interface.cpp
+                  $(NNTRAINER_ROOT)/nntrainer/src/blas_interface.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/src/weight.cpp
 
 NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer/include \
                       $(NNTRAINER_ROOT)/api \

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -389,6 +389,9 @@ private:
    */
   void ensureName(std::shared_ptr<Layer> layer, std::string prefix = "");
 
+  /**
+   * @brief     Swap function for the class
+   */
   friend void swap(NeuralNetwork &lhs, NeuralNetwork &rhs) {
     using std::swap;
 

--- a/nntrainer/include/optimizer.h
+++ b/nntrainer/include/optimizer.h
@@ -25,19 +25,9 @@
 
 #include <memory>
 #include <tensor.h>
+#include <weight.h>
 
 namespace nntrainer {
-
-/**
- * @brief UpdatableParam that could be updated thorugh optimizer
- */
-// TODO: move this out from here
-struct UpdatableParam {
-  Tensor weight;         /**< weight to be updated and used */
-  Tensor grad;           /**< gradient for the weight */
-  std::string name;      /**< name of the parameter */
-  bool updatable = true; /**< if this param is updatable */
-};
 
 /**
  * @brief     Enumeration of Optimizer
@@ -46,27 +36,6 @@ struct UpdatableParam {
  *            2. Unknown
  */
 enum class OptType { sgd = 0, adam = 1, unknown = 2 };
-
-/**
- * @brief     Enumeration of Weight Decay type
- *            0. L2Norm
- *            1. Regression
- *            2. Unknown (equivalent to none)
- */
-// TODO: move this out of here
-enum class WeightRegularizerType { l2norm = 0, regression = 1, unknown = 2 };
-
-/**
- * @brief     type for the Weight Decay hyper-parameter
- */
-typedef struct WeightRegularizerParam_ {
-  WeightRegularizerType type;
-  float constant;
-
-  WeightRegularizerParam_() :
-    type(WeightRegularizerType::unknown),
-    constant(0.0f) {}
-} WeightRegularizerParam;
 
 /**
  * @brief     type for the Optimizor to save hyper-parameter
@@ -188,25 +157,25 @@ public:
 
   /**
    * @brief     initialize optimizer. Initialize Weight if it is adam
-   * @param[in] params UpdatableParam list
-   * @param[in] param_size size of the array
+   * @param[in] params Weight list
+   * @param[in] num_weights size of the array
    * @param[in] setTensor true if the layer need weight update.
    *            Input Layer and Batch Normalization layer won't need it.
    *            Therefore, it sets false.
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(std::shared_ptr<UpdatableParam> params,
-                 unsigned int param_size, bool setTensor);
+  int initialize(std::shared_ptr<Weight> params, unsigned int num_weights,
+                 bool setTensor);
 
   /**
-   * @brief     apply gradient to weights
-   * @param[in] params array of updatable params.
-   * @param[in] param_size size of the array
+   * @brief     apply gradient to weight_list
+   * @param[in] params Weight list
+   * @param[in] num_weights size of the array
    * @param[in] iteration nth epoch number
    */
-  void apply_gradients(std::shared_ptr<UpdatableParam> params,
-                       unsigned int param_size, int iteration);
+  void apply_gradients(std::shared_ptr<Weight> params, unsigned int num_weights,
+                       int iteration);
 
   /**
    * @brief     Property Enumeration

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -158,7 +158,12 @@ public:
    */
   Tensor &operator=(Tensor &&rhs) noexcept = default;
 
-  void swap(Tensor &lhs, Tensor &rhs) noexcept;
+  friend void swap(Tensor &lhs, Tensor &rhs) noexcept {
+    std::swap(lhs.dim, rhs.dim);
+    std::swap(lhs.data, rhs.data);
+    std::swap(lhs.strides, rhs.strides);
+    std::swap(lhs.is_contiguous, rhs.is_contiguous);
+  }
 
   /**
    * @brief     Comparison operator overload

--- a/nntrainer/include/tensor_dim.h
+++ b/nntrainer/include/tensor_dim.h
@@ -64,7 +64,12 @@ public:
    * @parma[out] lhs Optimizer
    * @parma[in] rhs Optimizer
    */
-  void swap(TensorDim &lhs, TensorDim &rhs) noexcept;
+  friend void swap(TensorDim &lhs, TensorDim &rhs) noexcept {
+    std::swap_ranges(std::begin(lhs.dim), std::begin(lhs.dim) + MAXDIM,
+                     std::begin(rhs.dim));
+    std::swap(lhs.len, rhs.len);
+    std::swap(lhs.feature_len, rhs.feature_len);
+  }
 
   unsigned int batch() const { return dim[0]; };
   unsigned int channel() const { return dim[1]; };

--- a/nntrainer/include/weight.h
+++ b/nntrainer/include/weight.h
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0-only
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file	weight.h
+ * @date	22 September 2020
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is Weight Class for Neural Network
+ *
+ */
+
+#ifndef __WEIGHT_H__
+#define __WEIGHT_H__
+
+#include <tensor.h>
+
+namespace nntrainer {
+
+/**
+ * @brief     Enumeration of Weight Decay type
+ */
+enum class WeightRegularizerType {
+  l2norm, /** L2 norm regularizer */
+  unknown /** Unknown */
+};
+
+/**
+ * @brief     Enumeration of Weight Initialization Type
+ */
+enum class WeightInitializer {
+  WEIGHT_ZEROS,          /** Zero initialization */
+  WEIGHT_ONES,           /** One initialization */
+  WEIGHT_LECUN_NORMAL,   /** LeCun normal initialization */
+  WEIGHT_LECUN_UNIFORM,  /** uniform initialization */
+  WEIGHT_XAVIER_NORMAL,  /** Xavier normal initialization */
+  WEIGHT_XAVIER_UNIFORM, /** Xavier uniform initialization */
+  WEIGHT_HE_NORMAL,      /** He normal initialization */
+  WEIGHT_HE_UNIFORM,     /** He uniform initialization */
+  WEIGHT_UNKNOWN         /** Unknown */
+};
+
+/**
+ * @class   Weight
+ * @brief   Weight with gradient, and its corresponding trainable property
+ */
+class Weight {
+
+  /** Declare layers as friend to get variable/gradient reference */
+  friend class Layer;
+  friend class Conv2DLayer;
+  friend class FullyConnectedLayer;
+  friend class BatchNormalizationLayer;
+
+  /** Declare opitmizer as friend to get variable/gradient reference */
+  friend class Optimizer;
+
+public:
+  /**
+   * @brief Weight default constructor
+   */
+  Weight() : initializer(WeightInitializer::WEIGHT_UNKNOWN), trainable(false) {}
+
+  /**
+   * @brief Construct a new Weight object
+   *
+   * @param dim Variable and gradient tensor dimension
+   * @param init Initializer for the tensor
+   * @param train If the variable is trainable
+   * @param name Name for this weight
+   */
+  Weight(
+    const TensorDim &dim,
+    const WeightInitializer init = WeightInitializer::WEIGHT_XAVIER_UNIFORM,
+    bool train = true, std::string name = "");
+
+  /**
+   * @brief Allocate and initialize the variable
+   *
+   * @param dim Dimension for the variable
+   */
+  void initializeVar(const TensorDim &dim);
+
+  /**
+   * @brief Swap for weight
+   *
+   * @param lhs Swap to
+   * @param rhs Swap from
+   * @note Only swap gradient if trainable
+   */
+  friend void swap(Weight &lhs, Weight &rhs) noexcept {
+    using std::swap;
+
+    swap(lhs.var, rhs.var);
+    swap(lhs.initializer, rhs.initializer);
+    swap(lhs.trainable, rhs.trainable);
+    swap(lhs.grad, rhs.grad);
+    swap(lhs.name, rhs.name);
+  }
+
+  /**
+   * @brief copy assigment
+   *
+   * @param rhs copy from
+   * @return Weight& Updated weight
+   */
+  Weight &operator=(const Weight &rhs) = default;
+
+  /**
+   * @brief move assignment
+   *
+   * @param rhs move from
+   * @return Weight& Updated weight
+   */
+  Weight &operator=(Weight &&rhs) = default;
+
+  /**
+   * @brief Get the TensorDim
+   *
+   * @return TensorDim Dimension
+   */
+  TensorDim getDim() { return var.getDim(); }
+
+  /**
+   * @brief Get if the weight is trainable
+   *
+   * @return true if trainable
+   * @return false is not trainable
+   */
+  bool getTrainable() { return trainable; }
+
+  /**
+   * @brief Get the name of the weight
+   *
+   * @return std::string name
+   */
+  std::string getName() { return name; }
+
+  /**
+   * @brief Get the variable tensor (by name)
+   *
+   * @return Tensor Variable tensor
+   */
+  Tensor getVariable() { return var; }
+
+  /**
+   * @brief Get the Gradient tensor (by name)
+   *
+   * @return Tensor Gradient tensor
+   */
+  Tensor getGradient() { return grad; }
+
+private:
+  /**
+   * @brief Get the variable tensor (by reference)
+   *
+   * @return Tensor Variable tensor
+   */
+  Tensor &getVariableRef() { return var; }
+
+  /**
+   * @brief Get the Gradient tensor (by reference)
+   *
+   * @return Tensor Gradient tensor
+   */
+  Tensor &getGradientRef() { return grad; }
+
+  Tensor var;                    /**< variable to be updated and used */
+  Tensor grad;                   /**< gradient for the variable */
+  WeightInitializer initializer; /**< initializer for this variable */
+  bool trainable;                /**< if this variable is trainable */
+  std::string name;              /**< name of the parameter */
+};
+
+} // namespace nntrainer
+
+#endif /** __WEIGHT_H__ */

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -27,6 +27,7 @@ endif
 nntrainer_sources = [
   'src/activation_layer.cpp',
   'src/addition_layer.cpp',
+  'src/blas_interface.cpp',
   'src/bn_layer.cpp',
   'src/conv2d_layer.cpp',
   'src/databuffer.cpp',
@@ -47,12 +48,13 @@ nntrainer_sources = [
   'src/tensor.cpp',
   'src/tensor_dim.cpp',
   'src/util_func.cpp',
-  'src/blas_interface.cpp'
+  'src/weight.cpp'
 ]
 
 nntrainer_headers = [
   'include/activation_layer.h',
   'include/addition_layer.h',
+  'include/blas_interface.h',
   'include/bn_layer.h',
   'include/conv2d_layer.h',
   'include/databuffer.h',
@@ -74,7 +76,7 @@ nntrainer_headers = [
   'include/tensor.h',
   'include/tensor_dim.h',
   'include/util_func.h',
-  'include/blas_interface.h',
+  'include/weight.h',
   '../api/nntrainer-api-common.h'
 ]
 

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -90,13 +90,6 @@ Tensor::Tensor(const TensorDim &d, const float *buf) : Tensor() {
   }
 }
 
-void Tensor::swap(Tensor &lhs, Tensor &rhs) noexcept {
-  std::swap(lhs.dim, rhs.dim);
-  std::swap(lhs.data, rhs.data);
-  std::swap(lhs.strides, rhs.strides);
-  std::swap(lhs.is_contiguous, rhs.is_contiguous);
-}
-
 bool Tensor::operator==(const Tensor &rhs) const {
   if (this->dim != rhs.dim)
     return false;

--- a/nntrainer/src/tensor_dim.cpp
+++ b/nntrainer/src/tensor_dim.cpp
@@ -24,21 +24,18 @@
 namespace nntrainer {
 
 TensorDim &TensorDim::operator=(const TensorDim &rhs) {
+  using std::swap;
+
   TensorDim tmp(rhs.batch(), rhs.channel(), rhs.height(), rhs.width());
-  this->swap(*this, tmp);
+  swap(*this, tmp);
   return *this;
 }
 
 TensorDim &TensorDim::operator=(TensorDim &&rhs) noexcept {
-  this->swap(*this, rhs);
-  return *this;
-}
+  using std::swap;
 
-void TensorDim::swap(TensorDim &lhs, TensorDim &rhs) noexcept {
-  std::swap_ranges(std::begin(lhs.dim), std::begin(lhs.dim) + MAXDIM,
-                   std::begin(rhs.dim));
-  std::swap(lhs.len, rhs.len);
-  std::swap(lhs.feature_len, rhs.feature_len);
+  swap(*this, rhs);
+  return *this;
 }
 
 void TensorDim::resetLen() {

--- a/nntrainer/src/weight.cpp
+++ b/nntrainer/src/weight.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0-only
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file	weight.cpp
+ * @date	22 September 2020
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is Weight Class for Neural Network
+ *
+ */
+
+#include <util_func.h>
+#include <weight.h>
+
+namespace nntrainer {
+
+Weight::Weight(const TensorDim &dim, const WeightInitializer init, bool train,
+               std::string name) :
+  initializer(init),
+  trainable(train),
+  name(name) {
+  if (initializer == WeightInitializer::WEIGHT_UNKNOWN)
+    throw std::invalid_argument("Weight initializer unknown");
+
+  initializeVar(dim);
+  if (trainable) {
+    grad = Tensor(dim);
+    grad.setZero();
+  } else
+    grad = Tensor();
+}
+
+void Weight::initializeVar(const TensorDim &dim) {
+  var = Tensor(dim);
+  switch (initializer) {
+  case WeightInitializer::WEIGHT_ZEROS:
+    var.setZero();
+    break;
+  case WeightInitializer::WEIGHT_ONES:
+    var.setValue(1.0f);
+    break;
+  case WeightInitializer::WEIGHT_LECUN_NORMAL:
+    var.setRandNormal(0.0f, sqrtFloat(1.0f / dim.height()));
+    break;
+  case WeightInitializer::WEIGHT_XAVIER_NORMAL:
+    var.setRandNormal(0.0f, sqrtFloat(2.0f / (dim.width() + dim.height())));
+    break;
+  case WeightInitializer::WEIGHT_HE_NORMAL:
+    var.setRandNormal(0.0f, sqrtFloat(2.0f / (dim.height())));
+    break;
+  case WeightInitializer::WEIGHT_LECUN_UNIFORM:
+    var.setRandUniform(-1.0f * sqrtFloat(1.0f / dim.height()),
+                       sqrtFloat(1.0f / dim.height()));
+    break;
+  case WeightInitializer::WEIGHT_XAVIER_UNIFORM:
+    var.setRandUniform(-1.0f * sqrtFloat(6.0f / (dim.height() + dim.width())),
+                       sqrtFloat(6.0 / (dim.height() + dim.width())));
+    break;
+  case WeightInitializer::WEIGHT_HE_UNIFORM:
+    var.setRandUniform(-1.0f * sqrtFloat(6.0f / (dim.height())),
+                       sqrtFloat(6.0 / (dim.height())));
+    break;
+  default:
+    break;
+  }
+}
+
+} // namespace nntrainer

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -321,6 +321,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/addition_layer.h
 %{_includedir}/nntrainer/nntrainer-api-common.h
 %{_includedir}/nntrainer/blas_interface.h
+%{_includedir}/nntrainer/weight.h
 %{_libdir}/pkgconfig/nntrainer.pc
 
 %files devel-static


### PR DESCRIPTION
Added a weight class to simplify headers All weight-related enums and properties go to the weight header rather being dumped in layer or optimizer.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor 