### PR TITLE
[CS/Refactor] restructure code to MVP pattern @open sesame 09/24 19:32 

### DIFF
--- a/Applications/Tizen_native/CustomShortcut/inc/data.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/data.h
@@ -44,6 +44,7 @@ typedef enum DRAW_TARGET_ {
   TRAIN_SMILE,
   TRAIN_FROWN
 } DRAW_TARGET;
+
 typedef struct appdata {
   Evas_Object *win;
   Evas_Object *conform;
@@ -102,7 +103,7 @@ typedef struct train_result {
  * @param[out] length of data len
  * @retval 0 if no error
  */
-int data_parse_route(const char *source, char **route, char **data);
+int util_parse_route(const char *source, char **route, char **data);
 
 /**
  * @brief get full resource path for given file.
@@ -111,26 +112,49 @@ int data_parse_route(const char *source, char **route, char **data);
  * @param[in] shared true if resource is in shared/res
  * @retval APP_ERROR_NONE if no error
  */
-int data_get_resource_path(const char *file, char *full_path, bool shared);
+int util_get_resource_path(const char *file, char *full_path, bool shared);
+
+/**
+ * @brief handle given path_data. If data is invalid, it is essentially noop
+ *
+ * @param ad appdata
+ * @param data path_data to be handled
+ */
+void data_handle_path_data(appdata_s *ad, const char *data);
+
+/**
+ * @brief update draw target from the data. currently the label is depending on
+ * ad->tries only
+ *
+ * @param[in] ad appdata
+ * @return int APP_ERROR_NONE if success
+ */
+int data_update_draw_target(appdata_s *ad);
 
 /**
  * @brief extract data feature from given model.
  * @param[in] ad appdata
- * @param[in] dst state the name of the data set
- * @param[in] append decide whether to append to the exisiting file
  *
  * This function runs a mobilnetv2 last layer detached and saves an output
  * vector. input for this model is png file drawn to the canvas(stored in
  * appdata) output can be pased to nntrainer and used.
  */
-int data_extract_feature(appdata_s *ad, const char *dst, bool append);
+int data_extract_feature(appdata_s *ad);
 
 /**
  * @brief nntrainer training model that is to run from pthread_create
- * @param[in] data appdata.
+ * @param[in] ad appdata.
  * @return not used.
  */
 void *data_run_model(void *ad);
+
+/**
+ * @brief nntrainer update train result from data_run_model
+ *
+ * @param[in] ad appdata
+ * @return not used
+ */
+void *data_update_train_result(void *ad);
 
 /**
  * @brief parse result string

--- a/Applications/Tizen_native/CustomShortcut/inc/main.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/main.h
@@ -12,13 +12,51 @@
 #ifndef __nntrainer_example_custom_shortcut_H__
 #define __nntrainer_example_custom_shortcut_H__
 
-#include "data.h"
-#include <Elementary.h>
-#include <dlog.h>
 #include <tizen.h>
+
+#include <Elementary.h>
+
+#include "data.h"
+#include "view.h"
 
 #if !defined(PACKAGE)
 #define PACKAGE "org.example.nntrainer-example-custom-shortcut"
 #endif
+
+/**
+ * @brief presenter to handle routing to a page
+ *
+ * @param data appdata
+ * @param obj not used
+ * @param emission not used
+ * @param source string information that has where to go.
+ */
+void presenter_on_routes_request(void *data, Evas_Object *obj EINA_UNUSED,
+                                 const char *emission EINA_UNUSED,
+                                 const char *source);
+
+/**
+ * @brief presenter to handle canvas submission in the inference
+ *
+ * @param data appdata
+ * @param obj not used
+ * @param emission not used
+ * @param source not used
+ */
+void presenter_on_canvas_submit_inference(void *data, Evas_Object *obj,
+                                          const char *emission EINA_UNUSED,
+                                          const char *source EINA_UNUSED);
+
+/**
+ * @brief presenter to handle canvas submission in the training
+ *
+ * @param data appdata
+ * @param obj not used
+ * @param emission not used
+ * @param source not used
+ */
+void presenter_on_canvas_submit_training(void *data, Evas_Object *obj,
+                                         const char *emission EINA_UNUSED,
+                                         const char *source EINA_UNUSED);
 
 #endif /* __nntrainer_example_custom_shortcut_H__ */

--- a/Applications/Tizen_native/CustomShortcut/inc/view.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/view.h
@@ -21,18 +21,31 @@
 /**
  * @brief initiate window and conformant.
  * @param[in] ad appdata of the app
- * @param[in] w width
- * @param[in] h height
  * @retval #APP_ERROR_*
  */
 int view_init(appdata_s *ad);
 
 /**
- * @brief creates layout from edj
- * @param[in/out] ad appdata of the app
- * @param[in] group_name name of the layout to be pushed to main naviframe.
+ * @brief initiate canvas
+ *
+ * @param[in] ad appdata
+ * @return int APP_DATA_NONE when no error
  */
-int view_routes_to(appdata_s *ad, const char *group_name);
+int view_init_canvas(appdata_s *ad);
+
+/**
+ * @brief creates layout from edj and push it to the naviframe
+ * @param[in/out] ad appdata of the app
+ * @param[in] path name of the layout to be pushed to main naviframe.
+ */
+int view_routes_to(appdata_s *ad, const char *path);
+
+/**
+ * @brief set canvas clean and update related labels
+ *
+ * @param ad[in] appdata
+ */
+void view_set_canvas_clean(appdata_s *ad);
 
 /**
  * @brief callback function to update training result


### PR DESCRIPTION
This patch layouts Customshortcut refactor. It is being migrated
Model-View-Presenter pattern for clarity.

**Changes proposed in this PR:**
- Add `presenter_*` to main presenter function
- Add `util_*` to data for utility function
- Some static function residing in `view.c` has exposed
- Strict segregation between view and data change

Resolves #577

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>