### PR TITLE
[inference] Inference bug fix @open sesame 09/23 15:03

### DIFF
--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -212,7 +212,6 @@ int NNTrainer::run(const GstTensorMemory *input, GstTensorMemory *output) {
 #if (DBG)
   gint64 start_time = g_get_real_time();
 #endif
-  std::vector<std::shared_ptr<nntrainer::Tensor>> output_tensors;
   std::shared_ptr<nntrainer::Tensor> out;
 
   std::vector<std::int64_t> d = input_tensor_info[0].dims;
@@ -220,7 +219,6 @@ int NNTrainer::run(const GstTensorMemory *input, GstTensorMemory *output) {
     nntrainer::Tensor(nntrainer::TensorDim(d[3], d[0], d[2], d[1]),
                       static_cast<float *>(input[0].data));
 
-  output_tensors.push_back(out);
   std::shared_ptr<const nntrainer::Tensor> o;
 
   o = model->inference(X);
@@ -230,10 +228,9 @@ int NNTrainer::run(const GstTensorMemory *input, GstTensorMemory *output) {
   }
 
   out = std::const_pointer_cast<nntrainer::Tensor>(o);
-
   output[0].data = out->getData();
 
-  outputTensorMap.insert(std::make_pair(output[0].data, output_tensors[0]));
+  outputTensorMap.insert(std::make_pair(output[0].data, out));
 
 #if (DBG)
   gint64 stop_time = g_get_real_time();

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -376,6 +376,9 @@ sharedConstTensor NeuralNetwork::inference(const Tensor X) {
   sharedConstTensor out;
   try {
     out = forwarding(MAKE_SHARED_TENSOR(X));
+    /** Forward loss layer without label as well */
+    out = std::static_pointer_cast<LossLayer>(layers[layers.size() - 1])
+            ->forwarding(out);
   } catch (...) {
     ml_loge("Failed to inference Model");
     finalize();


### PR DESCRIPTION
Added inference bug fix to run the last activation layer when it has been merged in the loss layer This is done by supporting forwarding(in) method for loss which was earlier not supported We just have to be careful for this not be called in any other case other than inference

Later this will be changed to handled with train/eval mode (which I think @zhoonit will add for bn layer)

Resolves #587

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped