### PR TITLE
[ Release ] NNTrainer 0.1.1 Release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nntrainer (0.1.1) UNRELEASED; urgency=medium
+
+  * 0.1.1 released
+
+ -- jijoong Moon <jijoong.moon@samsung.com>  Wed, 23 Sep 2020 15:26:32 +0900
+
 nntrainer (0.1.0.rc1) unstable; urgency=medium
 
   * Initial debian dist files added

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -9,7 +9,7 @@
 
 Name:		nntrainer
 Summary:	Software framework for traning neural networks
-Version:	0.1.0.rc1
+Version:	0.1.1
 Release:	0
 Packager:	Jijoong Moon <jijoong.moon@sansumg.com>
 License:	Apache-2.0
@@ -334,6 +334,8 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %endif
 
 %changelog
+* Wed Sep 23 2020 Jijoong Moon <jijoong.moon@samsung.com>
+- Release of 0.1.1
 * Mon Aug 10 2020 Jijoong Moon <jijoong.moon@samsung.com>
 - Release of 0.1.0.rc1
 * Wed Mar 18 2020 Jijoong Moon <jijoong.moon@samsung.com>


### PR DESCRIPTION
NNTrainer v0.1.1 is released

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>