### PR TITLE
[CS] Prevent HW backkey press while training  @open sesame 09/24 19:32 

### DIFF
--- a/Applications/Tizen_native/CustomShortcut/inc/main.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/main.h
@@ -24,6 +24,16 @@
 #endif
 
 /**
+ * @brief presenter to handle back press
+ *
+ * @param data appdata
+ * @param obj naviframe of the app
+ * @param event_info not used
+ */
+void presenter_on_back_button_press(void *data, Evas_Object *obj,
+                                    void *event_info EINA_UNUSED);
+
+/**
  * @brief presenter to handle routing to a page
  *
  * @param data appdata

--- a/Applications/Tizen_native/CustomShortcut/inc/view.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/view.h
@@ -26,6 +26,13 @@
 int view_init(appdata_s *ad);
 
 /**
+ * @brief pop an item from the naviframe if empty, terminate the app
+ *
+ * @param ad appdata
+ */
+void view_pop_naviframe(appdata_s *ad);
+
+/**
  * @brief initiate canvas
  *
  * @param[in] ad appdata


### PR DESCRIPTION
**Changes proposed in this PR:**
- Disable backkey press while training
- Move back_key callback to `presenter`
- Prune unnecessary argument for view/create_layout

Resolves #573

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>