### PR TITLE
[License] s/Apache-2.0-only/Apache-2.0

### DIFF
--- a/Applications/KNN/jni/main.cpp
+++ b/Applications/KNN/jni/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *

--- a/Applications/KNN/jni/main_sample.cpp
+++ b/Applications/KNN/jni/main_sample.cpp
@@ -1,5 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
+ * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
+ *
  * @file	main.cpp for K Nearest Neighbor
  * @date	04 December 2019
  * @see		https://github.com/nnstreamer/nntrainer

--- a/Applications/MNIST/Tensorflow/Training_Keras.py
+++ b/Applications/MNIST/Tensorflow/Training_Keras.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: Apache-2.0-only
+# SPDX-License-Identifier: Apache-2.0
 #
 # Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
 #

--- a/Applications/MNIST/Tensorflow/dataset.py
+++ b/Applications/MNIST/Tensorflow/dataset.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: Apache-2.0-only
+# SPDX-License-Identifier: Apache-2.0
 #
 # Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
 #

--- a/Applications/MNIST/jni/main.cpp
+++ b/Applications/MNIST/jni/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *

--- a/Applications/Tizen_native/CustomShortcut/inc/data.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/data.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *

--- a/Applications/Tizen_native/CustomShortcut/inc/main.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/main.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *

--- a/Applications/Tizen_native/CustomShortcut/inc/view.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/view.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *

--- a/Applications/Tizen_native/CustomShortcut/res/edje/main.edc
+++ b/Applications/Tizen_native/CustomShortcut/res/edje/main.edc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *

--- a/Applications/Tizen_native/CustomShortcut/src/data.c
+++ b/Applications/Tizen_native/CustomShortcut/src/data.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *

--- a/Applications/Tizen_native/CustomShortcut/src/main.c
+++ b/Applications/Tizen_native/CustomShortcut/src/main.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *

--- a/Applications/Tizen_native/CustomShortcut/src/view.c
+++ b/Applications/Tizen_native/CustomShortcut/src/view.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *

--- a/api/capi/doc/nntrainer_doc.h
+++ b/api/capi/doc/nntrainer_doc.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/api/capi/src/nntrainer-capi-tizen-feature-check.cpp
+++ b/api/capi/src/nntrainer-capi-tizen-feature-check.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/api/capi/src/nntrainer_util.cpp
+++ b/api/capi/src/nntrainer_util.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/nntrainer/include/activation_layer.h
+++ b/nntrainer/include/activation_layer.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *

--- a/nntrainer/include/addition_layer.h
+++ b/nntrainer/include/addition_layer.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/nntrainer/include/blas_interface.h
+++ b/nntrainer/include/blas_interface.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *

--- a/nntrainer/include/conv2d_layer.h
+++ b/nntrainer/include/conv2d_layer.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *

--- a/nntrainer/include/fc_layer.h
+++ b/nntrainer/include/fc_layer.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/nntrainer/include/flatten_layer.h
+++ b/nntrainer/include/flatten_layer.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *

--- a/nntrainer/include/lazy_tensor.h
+++ b/nntrainer/include/lazy_tensor.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /* Copyright (C) 2020 Jihoon Lee <jihoon.it.lee@samsung.com>
  *
  * @file	lazy_tensor.h

--- a/nntrainer/include/loss_layer.h
+++ b/nntrainer/include/loss_layer.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/nntrainer/include/model_loader.h
+++ b/nntrainer/include/model_loader.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/nntrainer/include/nntrainer_error.h
+++ b/nntrainer/include/nntrainer_error.h
@@ -1,5 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
+ * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
+ *
  * @file nntrainer_error.h
  * @date 03 April 2020
  * @brief NNTrainer Error Codes

--- a/nntrainer/include/pooling2d_layer.h
+++ b/nntrainer/include/pooling2d_layer.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *

--- a/nntrainer/include/tensor_dim.h
+++ b/nntrainer/include/tensor_dim.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  */

--- a/nntrainer/src/activation_layer.cpp
+++ b/nntrainer/src/activation_layer.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *

--- a/nntrainer/src/addition_layer.cpp
+++ b/nntrainer/src/addition_layer.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/nntrainer/src/blas_interface.cpp
+++ b/nntrainer/src/blas_interface.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *

--- a/nntrainer/src/flatten_layer.cpp
+++ b/nntrainer/src/flatten_layer.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *

--- a/nntrainer/src/lazy_tensor.cpp
+++ b/nntrainer/src/lazy_tensor.cpp
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0-only
+/* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2020 Jihoon Lee <jihoon.it.lee@samsung.com>
  *

--- a/nntrainer/src/model_loader.cpp
+++ b/nntrainer/src/model_loader.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/nntrainer/src/pooling2d_layer.cpp
+++ b/nntrainer/src/pooling2d_layer.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *

--- a/nntrainer/src/tensor_dim.cpp
+++ b/nntrainer/src/tensor_dim.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  */

--- a/test/input_gen/genInput.py
+++ b/test/input_gen/genInput.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: Apache-2.0-only
+# SPDX-License-Identifier: Apache-2.0
 ##
 # Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
 # Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>

--- a/test/tizen_capi/unittest_tizen_capi_dataset.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_dataset.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *

--- a/test/unittest/unittest_nntrainer_lazy_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_lazy_tensor.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /* Copyright (C) 2020 Jihoon Lee <jihoon.it.lee@samsung.com>
  *
  * @file	unittest_nntrainer_lazy_tensor.cpp

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *


### PR DESCRIPTION
Apache-2.0 license does not have to state `-only`. It is removed

This resolves `findings #10` from https://github.com/nnstreamer/nnstreamer/issues/2765

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [x]Skipped
2. Run test: [ ]Passed [ ]Failed [x]Skipped

Cc: Jaeyun-jung <jy1210.jung@samsung.com>
Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

resolves #598
