### PR TITLE
[inference] Remove deciding for inference at model construction

### DIFF
--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -151,7 +151,7 @@ void NNTrainer::loadModel() {
   if (model_config == nullptr)
     throw std::invalid_argument("model config is null!");
 
-  model = new nntrainer::NeuralNetwork(false);
+  model = new nntrainer::NeuralNetwork();
   model->loadFromConfig(model_config);
 #if (DBG)
   gint64 stop_time = g_get_real_time();

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -74,8 +74,7 @@ public:
   /**
    * @brief     Constructor of NeuralNetwork Class
    */
-  NeuralNetwork(bool istrain = true) :
-    is_train(istrain),
+  NeuralNetwork() :
     batch_size(1),
     epochs(1),
     loss(0.0f),
@@ -220,18 +219,6 @@ public:
   int setDataBuffer(std::shared_ptr<DataBuffer> data_buffer);
 
   /**
-   * @brief     check train or inference. Default is True (train)
-   * @retval bool True : training Mode. False : Inference Mode
-   */
-  bool isTrain() { return is_train; };
-
-  /**
-   * @param[in] train true for train mode. false for inference mode
-   * @brief     set Running Mode : Train or Inference
-   */
-  void setMode(bool train) { is_train = train; };
-
-  /**
    * @brief     add layer into neural network model
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
@@ -312,8 +299,6 @@ private:
   PRINT_METRIC       = (1 << 4), /**< Option to print if current network is set to training */
     // clang-format on
   } PrintOption;
-
-  bool is_train; /**< is train or inference */
 
   unsigned int batch_size; /**< batch size */
 
@@ -447,7 +432,6 @@ private:
     swap(lhs.layer_names, rhs.layer_names);
     swap(lhs.def_name_count, rhs.def_name_count);
     swap(lhs.loadedFromConfig, rhs.loadedFromConfig);
-    swap(lhs.is_train, rhs.is_train);
   }
 
   /**

--- a/nntrainer/src/model_loader.cpp
+++ b/nntrainer/src/model_loader.cpp
@@ -50,10 +50,8 @@ int ModelLoader::loadModelConfigIni(dictionary *ini, NeuralNetwork &model) {
   model.loss_type = (LossType)parseType(
     iniparser_getstring(ini, "Model:Loss", unknown), TOKEN_LOSS);
   model.save_path = iniparser_getstring(ini, "Model:Save_path", "./model.bin");
-  if (model.isTrain()) {
-    model.batch_size =
-      iniparser_getint(ini, "Model:Batch_Size", model.batch_size);
-  }
+  model.batch_size =
+    iniparser_getint(ini, "Model:Batch_Size", model.batch_size);
 
   /** Default to adam optimizer */
   status = model.opt.setType((OptType)parseType(
@@ -243,10 +241,8 @@ int ModelLoader::loadFromIni(std::string ini_file, NeuralNetwork &model) {
   status = loadModelConfigIni(ini, model);
   NN_INI_RETURN_STATUS();
 
-  if (model.isTrain()) {
-    status = loadDatasetConfigIni(ini, model);
-    NN_INI_RETURN_STATUS();
-  }
+  status = loadDatasetConfigIni(ini, model);
+  NN_INI_RETURN_STATUS();
 
   ml_logd("parsing ini started");
   /** Get all the section names */


### PR DESCRIPTION
Currently, with is_train, user has to decide at model construction if the model is to be used for inference or train but we still allow changing it. We dont need that difference, rather using inference/train should be allowed at anytime by just changing the batch-size (this has been allowed with the previous commit)

Now, once the train is done, with model loaded in memory, inference can be called directly. Inference can be run by creating and loading the model from disk.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
