### PR TITLE
[model] Merge model finalize to destructor

### DIFF
--- a/Applications/LogisticRegression/jni/main.cpp
+++ b/Applications/LogisticRegression/jni/main.cpp
@@ -189,7 +189,6 @@ int main(int argc, char *argv[]) {
     NN.init();
   } catch (...) {
     std::cerr << "Error during init" << std::endl;
-    NN.finalize();
     return 0;
   }
 
@@ -200,7 +199,6 @@ int main(int argc, char *argv[]) {
       NN.train();
     } catch (...) {
       std::cerr << "Error during train" << std::endl;
-      NN.finalize();
       return 0;
     }
   } else {
@@ -224,7 +222,6 @@ int main(int argc, char *argv[]) {
         cn += answer == l[0];
       } catch (...) {
         std::cerr << "Error during forwarding the model" << std::endl;
-        NN.finalize();
         return -1;
       }
     }
@@ -236,6 +233,5 @@ int main(int argc, char *argv[]) {
   /**
    * @brief     Finalize NN
    */
-  NN.finalize();
   return 0;
 }

--- a/Applications/MNIST/jni/main.cpp
+++ b/Applications/MNIST/jni/main.cpp
@@ -265,7 +265,6 @@ int main(int argc, char *argv[]) {
     NN.loadFromConfig(config);
   } catch (...) {
     std::cerr << "Error during loadFromConfig" << std::endl;
-    NN.finalize();
     return 0;
   }
 
@@ -273,7 +272,6 @@ int main(int argc, char *argv[]) {
     NN.init();
   } catch (...) {
     std::cerr << "Error during init" << std::endl;
-    NN.finalize();
     return 0;
   }
 
@@ -287,13 +285,11 @@ int main(int argc, char *argv[]) {
     NN.train();
   } catch (...) {
     std::cerr << "Error during train" << std::endl;
-    NN.finalize();
     return 0;
   }
 
   /**
    * @brief     Finalize NN
    */
-  NN.finalize();
   return 0;
 }

--- a/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
+++ b/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
@@ -286,8 +286,6 @@ int main(int argc, char **argv) {
     targetNet.init();
   } catch (...) {
     std::cerr << "Error during init" << std::endl;
-    mainNet.finalize();
-    targetNet.finalize();
     return 0;
   }
 
@@ -340,16 +338,12 @@ int main(int argc, char **argv) {
           in_tensor = nntrainer::Tensor({input});
         } catch (...) {
           std::cerr << "Error while construct tensor" << std::endl;
-          mainNet.finalize();
-          targetNet.finalize();
           return 0;
         }
         try {
           test = mainNet.forwarding(MAKE_SHARED_TENSOR(in_tensor));
         } catch (...) {
           std::cerr << "Error while forwarding the network" << std::endl;
-          mainNet.finalize();
-          targetNet.finalize();
           return 0;
         }
         const float *data = test->getData();
@@ -446,8 +440,6 @@ int main(int argc, char **argv) {
           nq_in = nntrainer::Tensor(next_inbatch);
         } catch (...) {
           std::cerr << "Error during tensor constructino" << std::endl;
-          mainNet.finalize();
-          targetNet.finalize();
           return 0;
         }
 
@@ -459,8 +451,6 @@ int main(int argc, char **argv) {
           Q = mainNet.forwarding(MAKE_SHARED_TENSOR(q_in));
         } catch (...) {
           std::cerr << "Error during forwarding main network" << std::endl;
-          mainNet.finalize();
-          targetNet.finalize();
           return -1;
         }
 
@@ -472,8 +462,6 @@ int main(int argc, char **argv) {
           NQ = targetNet.forwarding(MAKE_SHARED_TENSOR(nq_in));
         } catch (...) {
           std::cerr << "Error during forwarding target network" << std::endl;
-          mainNet.finalize();
-          targetNet.finalize();
           return -1;
         }
         const float *nqa = NQ->getData();
@@ -489,8 +477,6 @@ int main(int argc, char **argv) {
                              (float)in_Exp[i].reward);
             } catch (...) {
               std::cerr << "Error during set a value" << std::endl;
-              mainNet.finalize();
-              targetNet.finalize();
               return -1;
             }
           } else {
@@ -502,8 +488,6 @@ int main(int argc, char **argv) {
                              (float)in_Exp[i].reward + DISCOUNT * next);
             } catch (...) {
               std::cerr << "Error during set value" << std::endl;
-              mainNet.finalize();
-              targetNet.finalize();
               return -1;
             }
           }
@@ -514,10 +498,7 @@ int main(int argc, char **argv) {
           mainNet.backwarding(MAKE_SHARED_TENSOR(in_tensor), Q, iter);
         } catch (...) {
           std::cerr << "Error during backwarding the network" << std::endl;
-          mainNet.finalize();
-          targetNet.finalize();
-
-          return 0;
+          return -1;
         }
       }
 
@@ -539,11 +520,6 @@ int main(int argc, char **argv) {
     }
   }
 
-  /**
-   * @brief     finalize networks
-   */
-  targetNet.finalize();
-  mainNet.finalize();
   writeFile.close();
   return 0;
 }

--- a/Applications/TransferLearning/CIFAR_Classification/jni/main.cpp
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/main.cpp
@@ -415,7 +415,6 @@ int main(int argc, char *argv[]) {
     NN.init();
   } catch (...) {
     std::cerr << "Error during init" << std::endl;
-    NN.finalize();
     return 0;
   }
   NN.readModel();
@@ -424,7 +423,6 @@ int main(int argc, char *argv[]) {
     NN.train();
   } catch (...) {
     std::cerr << "Error during train" << std::endl;
-    NN.finalize();
     return 0;
   }
 
@@ -440,13 +438,9 @@ int main(int argc, char *argv[]) {
       NN.forwarding(MAKE_SHARED_TENSOR(X))->apply(stepFunction);
     } catch (...) {
       std::cerr << "Error while forwarding the model" << std::endl;
-      NN.finalize();
       return 0;
     }
   }
-  /**
-   * @brief     Finalize NN
-   */
-  NN.finalize();
+
   return 0;
 }

--- a/Applications/TransferLearning/CIFAR_Classification/jni/main_func.cpp
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/main_func.cpp
@@ -303,14 +303,12 @@ int main(int argc, char *argv[]) {
     NN.loadFromConfig(config);
   } catch (...) {
     std::cerr << "Error during loadFromConfig" << std::endl;
-    NN.finalize();
     return 0;
   }
   try {
     NN.init();
   } catch (...) {
     std::cerr << "Error during init" << std::endl;
-    NN.finalize();
     return 0;
   }
   NN.readModel();
@@ -323,13 +321,11 @@ int main(int argc, char *argv[]) {
     NN.train();
   } catch (...) {
     std::cerr << "Error during train" << std::endl;
-    NN.finalize();
     return 0;
   }
 
   /**
    * @brief     Finalize NN
    */
-  NN.finalize();
   return 0;
 }

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -229,9 +229,6 @@ int ml_train_model_compile(ml_train_model_h model, ...) {
   if (status != ML_ERROR_NONE)
     return status;
 
-  f = [&]() { return NN->isInitializable(); };
-  status = nntrainer_exception_boundary(f);
-
   return status;
 }
 
@@ -280,12 +277,6 @@ int ml_train_model_destroy(ml_train_model_h model) {
 
   std::shared_ptr<nntrainer::NeuralNetwork> NN;
   NN = nnmodel->network;
-
-  returnable f = [&]() {
-    NN->finalize();
-    return ML_ERROR_NONE;
-  };
-  status = nntrainer_exception_boundary(f);
 
   if (nnmodel->optimizer) {
     ML_TRAIN_RESET_VALIDATED_HANDLE(nnmodel->optimizer);

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -89,7 +89,6 @@ NNTrainer::NNTrainer(const char *model_config_) {
 
 NNTrainer::~NNTrainer() {
   if (model != nullptr) {
-    model->finalize();
     delete model;
   }
 
@@ -119,7 +118,6 @@ int NNTrainer::init(const GstTensorFilterProperties *prop) {
     model->readModel();
   } catch (...) {
     ml_loge("Failed to initialize model");
-    model->finalize();
     return -1;
   }
 
@@ -186,7 +184,6 @@ int NNTrainer::loadModel() {
     model->loadFromConfig(model_config);
   } catch (...) {
     ml_loge("Cannot load model from config\n");
-    model->finalize();
     g_free(content);
     return -1;
   }
@@ -224,7 +221,6 @@ int NNTrainer::run(const GstTensorMemory *input, GstTensorMemory *output) {
 
   o = model->inference(X);
   if (o == nullptr) {
-    model->finalize();
     return -1;
   }
 

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -67,7 +67,7 @@ typedef struct RunStats_ {
  * @brief   NeuralNetwork Class which has Network Configuration & Layers
  */
 class NeuralNetwork {
-  friend class ModelLoader;
+  friend class ModelLoader; /** access private members of ModelLoader */
 
 public:
   /**
@@ -91,29 +91,7 @@ public:
   /**
    * @brief     Destructor of NeuralNetwork Class
    */
-  ~NeuralNetwork() {}
-
-  friend void swap(NeuralNetwork &lhs, NeuralNetwork &rhs) {
-    using std::swap;
-
-    swap(lhs.batch_size, rhs.batch_size);
-    swap(lhs.epochs, rhs.epochs);
-    swap(lhs.loss, rhs.loss);
-    swap(lhs.loss_type, rhs.loss_type);
-    swap(lhs.weight_initializer, rhs.weight_initializer);
-    swap(lhs.save_path, rhs.save_path);
-    swap(lhs.opt, rhs.opt);
-    swap(lhs.net_type, rhs.net_type);
-    swap(lhs.layers, rhs.layers);
-    swap(lhs.data_buffer, rhs.data_buffer);
-    swap(lhs.continue_train, rhs.continue_train);
-    swap(lhs.iter, rhs.iter);
-    swap(lhs.initialized, rhs.initialized);
-    swap(lhs.layer_names, rhs.layer_names);
-    swap(lhs.def_name_count, rhs.def_name_count);
-    swap(lhs.loadedFromConfig, rhs.loadedFromConfig);
-    swap(lhs.is_train, rhs.is_train);
-  }
+  ~NeuralNetwork();
 
   /**
    * @brief     Get Loss
@@ -122,22 +100,10 @@ public:
   float getLoss();
 
   /**
-   * @brief     Set Optimizer
-   * @retval    Optimizer
-   */
-  void setOptimizer(Optimizer optimizer) { opt = optimizer; };
-
-  /**
    * @brief     Get Learning rate
    * @retval    Learning rate
    */
   float getLearningRate() { return opt.getLearningRate(); };
-
-  /**
-   * @brief     Set Loss
-   * @param[in] l loss value
-   */
-  void setLoss(float l);
 
   /**
    * @brief     Create and load the Network with ini configuration file.
@@ -154,15 +120,6 @@ public:
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
   int setProperty(std::vector<std::string> values);
-
-  /**
-   * @brief     set Property/Configuration of Network for training after the
-   * network has been initialized
-   * @param[in] values values of property
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setTrainConfig(std::vector<std::string> values);
 
   /**
    * @brief     Initialize Network. This should be called after set all
@@ -221,31 +178,12 @@ public:
   NeuralNetwork &copy(NeuralNetwork &from);
 
   /**
-   * @brief     finalize NeuralNetwork Object
-   */
-  void finalize();
-
-  /**
-   * @brief     Run NeuralNetwork train
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int train_run();
-
-  /**
-   * @brief     Run NeuralNetwork train
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int train();
-
-  /**
    * @brief     Run NeuralNetwork train
    * @param[in] values hyper parameters
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int train(std::vector<std::string> values);
+  int train(std::vector<std::string> values = {});
 
   /**
    * @brief     Run NeuralNetwork inference
@@ -267,13 +205,6 @@ public:
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
   int setDataBuffer(std::shared_ptr<DataBuffer> data_buffer);
-
-  /**
-   * @brief     check neural network is ready to init.
-   * @retval #ML_ERROR_NONE neuralnetwork is ready to init
-   * @retval #ML_ERROR_INVALID_PARAMETER not ready to init.
-   */
-  int isInitializable();
 
   /**
    * @brief     check train or inference. Default is True (train)
@@ -404,6 +335,26 @@ private:
   int initLossLayer();
 
   /**
+   * @brief     Set Loss
+   * @param[in] l loss value
+   */
+  void setLoss(float l);
+
+  /**
+   * @brief     Run NeuralNetwork train
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int train_run();
+
+  /**
+   * @brief     check neural network is ready to init.
+   * @retval #ML_ERROR_NONE neuralnetwork is ready to init
+   * @retval #ML_ERROR_INVALID_PARAMETER not ready to init.
+   */
+  int isInitializable();
+
+  /**
    * @brief     Realize act type to layer and insert it to layers
    * @param[in] ActivationType act Activation Type
    * @param[in] int Position position to insert activation layer.
@@ -437,6 +388,37 @@ private:
    * @brief     Ensure that layer has a name
    */
   void ensureName(std::shared_ptr<Layer> layer, std::string prefix = "");
+
+  friend void swap(NeuralNetwork &lhs, NeuralNetwork &rhs) {
+    using std::swap;
+
+    swap(lhs.batch_size, rhs.batch_size);
+    swap(lhs.epochs, rhs.epochs);
+    swap(lhs.loss, rhs.loss);
+    swap(lhs.loss_type, rhs.loss_type);
+    swap(lhs.weight_initializer, rhs.weight_initializer);
+    swap(lhs.save_path, rhs.save_path);
+    swap(lhs.opt, rhs.opt);
+    swap(lhs.net_type, rhs.net_type);
+    swap(lhs.layers, rhs.layers);
+    swap(lhs.data_buffer, rhs.data_buffer);
+    swap(lhs.continue_train, rhs.continue_train);
+    swap(lhs.iter, rhs.iter);
+    swap(lhs.initialized, rhs.initialized);
+    swap(lhs.layer_names, rhs.layer_names);
+    swap(lhs.def_name_count, rhs.def_name_count);
+    swap(lhs.loadedFromConfig, rhs.loadedFromConfig);
+    swap(lhs.is_train, rhs.is_train);
+  }
+
+  /**
+   * @brief     set Property/Configuration of Network for training after the
+   * network has been initialized
+   * @param[in] values values of property
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int setTrainConfig(std::vector<std::string> values);
 };
 
 } /* namespace nntrainer */


### PR DESCRIPTION
Merge model finalize to destructor itself
User need not call finalize explicitly

Other minor updates:
- Merge all train methods into 1
- isInitializable() is made private. Removed some of the name checking from this function
to when the layer itself was created.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>