### PR TITLE
[CS] Show inference

### DIFF
--- a/Applications/Tizen_native/CustomShortcut/inc/data.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/data.h
@@ -128,6 +128,15 @@ int util_get_resource_path(const char *file, char *full_path, bool shared);
 int util_save_drawing(cairo_surface_t *cr_surface, const char *dst);
 
 /**
+ * @brief get emoji string from LABEL enum
+ *
+ * @param[in] label label allocate outside.
+ * @param[out] emoji_str string emoticon from the enum. free after use
+ * @return int APP_ERROR_NONE if success;
+ */
+int util_get_emoji(LABEL label, char **emoji_str);
+
+/**
  * @brief handle given path_data. If data is invalid, it is essentially noop
  *
  * @param ad appdata

--- a/Applications/Tizen_native/CustomShortcut/inc/data.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/data.h
@@ -38,17 +38,20 @@
 #define FEATURE_SIZE 62720
 #define NUM_CLASS 2
 
-typedef enum DRAW_TARGET_ {
-  INFER = 0,
-  TRAIN_UNSET,
-  TRAIN_SMILE,
-  TRAIN_FROWN
-} DRAW_TARGET;
+typedef enum MODE_ {
+  MODE_INFER = 0,
+  MODE_TRAIN,
+} MODE;
+
+typedef enum LABEL_ {
+  LABEL_SMILE = 0,
+  LABEL_FROWN,
+  LABEL_UNSET,
+} LABEL;
 
 typedef struct appdata {
   Evas_Object *win;
   Evas_Object *conform;
-  Evas_Object *label;
   Evas_Object *naviframe;
   Elm_Object_Item *nf_it;
   Eext_Circle_Surface *circle_nf;
@@ -67,8 +70,9 @@ typedef struct appdata {
 
   cairo_surface_t *cr_surface; /**< cairo surface for the canvas */
   cairo_t *cr;                 /**< cairo engine for the canvas */
-  DRAW_TARGET draw_target;     /**< draw target for the canvas */
-  int tries;                   /**< tells how many data has been labeled */
+  MODE mode;                   /**< draw mode for the canvas */
+  LABEL label; /**< target label, if infer mode, it is answer else label */
+  int tries;   /**< tells how many data has been labeled */
 
   /**< Feature extraction related */
   ml_pipeline_h pipeline;       /**< handle of feature extractor */
@@ -133,12 +137,12 @@ void data_handle_path_data(appdata_s *ad, const char *data);
 
 /**
  * @brief update draw target from the data. currently the label is depending on
- * ad->tries only
+ * ad->tries and ad->mode
  *
  * @param[in] ad appdata
  * @return int APP_ERROR_NONE if success
  */
-int data_update_draw_target(appdata_s *ad);
+int data_update_label(appdata_s *ad);
 
 /**
  * @brief extract data feature from given model.

--- a/Applications/Tizen_native/CustomShortcut/inc/view.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/view.h
@@ -62,4 +62,12 @@ void view_set_canvas_clean(appdata_s *ad);
  */
 void view_update_result_cb(void *data, void *buffer, unsigned int nbytes);
 
+/**
+ * @brief update guess from the inference result
+ *
+ * @param[in] ad appdata
+ * @return int APP_ERROR_NONE if success
+ */
+void view_update_guess(void *ad);
+
 #endif /* __nntrainer_example_custom_shortcut_view_H__ */

--- a/Applications/Tizen_native/CustomShortcut/res/edje/main.edc
+++ b/Applications/Tizen_native/CustomShortcut/res/edje/main.edc
@@ -207,9 +207,20 @@ collections {
   group {
     name: "test_result";
     parts {
-      PART_TITLE("test_result/title", "eval successfully done")
-      PART_BUTTON("test_result/go_back", "😊", 0.1, 0.3, 0.9, 0.7)
-      // reserve a text area to show the guess from the model
+      PART_TITLE("test_result/title", "eval in progress")
+      part {
+        name: "test_result/label";
+        type: TEXT;
+        description {
+          state: "default" 0.0;
+          rel1.relative: 0.0 0.2;
+          rel2.relative: 1.0 0.8;
+          text {
+            text: "Guess...";
+            size: 100;
+            align: 0.5 0.5;
+          }
+        }
     }
   }
 }

--- a/Applications/Tizen_native/CustomShortcut/src/data.c
+++ b/Applications/Tizen_native/CustomShortcut/src/data.c
@@ -152,7 +152,7 @@ static void on_feature_receive_(ml_tensors_data_h data,
   /// one-hot encoding.
   /// SMILE: 0 1
   /// FROWN: 1 0
-  bool target_label = ad->draw_target == TRAIN_SMILE ? 0 : 1;
+  bool target_label = ad->label == LABEL_SMILE ? 0 : 1;
   LOG_D("writing one-hot encoded label");
   label = target_label;
   if (fwrite(&label, sizeof(float), 1, file) < 0) {
@@ -251,19 +251,25 @@ PIPE_DESTORY:
 void data_handle_path_data(appdata_s *ad, const char *data) {
   /// handling path_data to check if it's for inference or path
   if (!strcmp(data, "inference")) {
-    ad->draw_target = INFER;
+    ad->mode = MODE_INFER;
   } else if (!strcmp(data, "train")) {
-    ad->draw_target = TRAIN_UNSET;
+    ad->mode = MODE_TRAIN;
   }
+  ad->label = LABEL_UNSET;
 }
 
-int data_update_draw_target(appdata_s *ad) {
+int data_update_label(appdata_s *ad) {
+  if (ad->mode == MODE_INFER) {
+    ad->label = LABEL_UNSET;
+    return APP_ERROR_NONE;
+  }
+
   switch (ad->tries % NUM_CLASS) {
   case 0:
-    ad->draw_target = TRAIN_SMILE;
+    ad->label = LABEL_SMILE;
     return APP_ERROR_NONE;
   case 1:
-    ad->draw_target = TRAIN_FROWN;
+    ad->label = LABEL_FROWN;
     return APP_ERROR_NONE;
   default:
     LOG_E("Given label is unknown");

--- a/Applications/Tizen_native/CustomShortcut/src/data.c
+++ b/Applications/Tizen_native/CustomShortcut/src/data.c
@@ -109,6 +109,29 @@ int util_save_drawing(cairo_surface_t *cr_surface, const char *dst) {
   return APP_ERROR_NONE;
 }
 
+int util_get_emoji(LABEL label, char **emoji_str) {
+  *emoji_str = (char *)malloc(sizeof(char) * 5);
+
+  /// setting draw label and text
+  switch (label) {
+  case LABEL_UNSET:
+    strcpy(*emoji_str, "❓");
+    return APP_ERROR_NONE;
+  case LABEL_SMILE:
+    strcpy(*emoji_str, "😊");
+    return APP_ERROR_NONE;
+  case LABEL_FROWN:
+    strcpy(*emoji_str, "😢");
+    return APP_ERROR_NONE;
+  default:
+    LOG_E("unreachable code");
+    return APP_ERROR_INVALID_CONTEXT;
+  }
+  return APP_ERROR_INVALID_CONTEXT;
+}
+
+/************** data releated methods **********************/
+
 static void on_feature_receive_(ml_tensors_data_h data,
                                 const ml_tensors_info_h info, void *user_data) {
   appdata_s *ad = (appdata_s *)user_data;
@@ -533,6 +556,7 @@ static void on_inference_end_(ml_tensors_data_h data,
   /// SMILE: 0 1
   /// FROWN: 1 0
   LOG_D("label: %lf %lf", raw_data[0], raw_data[1]);
+  ad->label = raw_data[0] < raw_data[1] ? LABEL_SMILE : LABEL_FROWN;
 
 RESUME:
   status = pthread_cond_signal(&ad->pipe_cond);

--- a/Applications/Tizen_native/CustomShortcut/src/main.c
+++ b/Applications/Tizen_native/CustomShortcut/src/main.c
@@ -116,12 +116,17 @@ static int init_page_(appdata_s *ad, const char *path) {
       return status;
     }
 
-    view_set_canvas_clean(ad);
+    status = data_update_label(ad);
+    if (status != APP_ERROR_NONE) {
+      LOG_E("setting draw label failed");
+      return status;
+    }
 
-    if (ad->draw_target == INFER) {
+    view_set_canvas_clean(ad);
+    if (ad->mode == MODE_INFER) {
       elm_layout_signal_callback_add(ad->layout, "draw/proceed", "",
                                      presenter_on_canvas_submit_inference, ad);
-    } else if (ad->draw_target == TRAIN_UNSET) {
+    } else if (ad->mode == MODE_TRAIN) {
       elm_layout_signal_callback_add(ad->layout, "draw/proceed", "",
                                      presenter_on_canvas_submit_training, ad);
     } else {
@@ -189,9 +194,9 @@ void presenter_on_canvas_submit_training(void *data, Evas_Object *obj,
   appdata_s *ad = (appdata_s *)data;
   int status = APP_ERROR_NONE;
 
-  status = data_update_draw_target(ad);
+  status = data_update_label(ad);
   if (status != APP_ERROR_NONE) {
-    LOG_E("setting draw target failed");
+    LOG_E("setting draw label failed");
     return;
   }
 

--- a/Applications/Tizen_native/CustomShortcut/src/view.c
+++ b/Applications/Tizen_native/CustomShortcut/src/view.c
@@ -240,16 +240,14 @@ void view_set_canvas_clean(appdata_s *ad) {
   char emoji[5];
 
   /// setting draw label and text
-  switch (ad->draw_target) {
-  case INFER:
+  switch (ad->label) {
+  case LABEL_UNSET:
     strcpy(emoji, "❓");
     break;
-  case TRAIN_UNSET:
-    /// fall through intended
-  case TRAIN_SMILE:
+  case LABEL_SMILE:
     strcpy(emoji, "😊");
     break;
-  case TRAIN_FROWN:
+  case LABEL_FROWN:
     strcpy(emoji, "😢");
     break;
   default:

--- a/Applications/Tizen_native/CustomShortcut/src/view.c
+++ b/Applications/Tizen_native/CustomShortcut/src/view.c
@@ -237,26 +237,19 @@ static void on_canvas_exit_(void *data, Evas *e, Evas_Object *obj,
 
 void view_set_canvas_clean(appdata_s *ad) {
   char buf[256];
-  char emoji[5];
+  char *emoji;
 
-  /// setting draw label and text
-  switch (ad->label) {
-  case LABEL_UNSET:
-    strcpy(emoji, "❓");
-    break;
-  case LABEL_SMILE:
-    strcpy(emoji, "😊");
-    break;
-  case LABEL_FROWN:
-    strcpy(emoji, "😢");
-    break;
-  default:
-    LOG_E("unreachable code");
-    return;
+  int status = util_get_emoji(ad->label, &emoji);
+  if (status != APP_ERROR_NONE) {
+    LOG_E("getting emoji failed %d", status);
+    return status;
   }
+
   sprintf(buf, "draw for %s [%d/%d]", emoji, ad->tries + 1, MAX_TRIES);
   elm_object_part_text_set(ad->layout, "draw/title", buf);
   elm_object_part_text_set(ad->layout, "draw/label", emoji);
+
+  free(emoji);
 
   /// clear cairo surface
   cairo_set_source_rgba(ad->cr, 0.3, 0.3, 0.3, 0.2);
@@ -386,4 +379,22 @@ void view_update_result_cb(void *data, void *buffer, unsigned int nbytes) {
 
   snprintf(tmp, 255, "Loss: %.2f", result.train_loss);
   elm_object_part_text_set(ad->layout, "train_progress/loss", tmp);
+}
+
+void view_update_guess(void *data) {
+  appdata_s *ad = (appdata_s *)data;
+  char *emoji;
+  int status = util_get_emoji(ad->label, &emoji);
+  if (status != APP_ERROR_NONE) {
+    LOG_E("error getting emoji, reason: %d", status);
+    return status;
+  }
+
+  LOG_E("%s", emoji);
+  elm_object_part_text_set(ad->layout, "test_result/title",
+                           "guess successfully done");
+  elm_object_part_text_set(ad->layout, "test_result/label", emoji);
+  free(emoji);
+
+  return status;
 }


### PR DESCRIPTION
Commit #1

change ad->draw_target to draw->label and draw->mode to
incorporate with inference and training at the same time

Commit #2

This patch shows inference to the page after evaluation.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>