### PR TITLE
[layer] Update layer interface

### DIFF
--- a/nntrainer/include/activation_layer.h
+++ b/nntrainer/include/activation_layer.h
@@ -30,7 +30,7 @@ public:
   /**
    * @brief     Constructor of Activation Layer
    */
-  ActivationLayer();
+  ActivationLayer(ActivationType at = ActivationType::ACT_NONE);
 
   /**
    * @brief     Destructor of Activation Layer

--- a/nntrainer/include/conv2d_layer.h
+++ b/nntrainer/include/conv2d_layer.h
@@ -93,6 +93,37 @@ public:
    */
   void copy(std::shared_ptr<Layer> l);
 
+  /* TO DO : support keras type of padding */
+  /* enum class PaddingType { */
+  /*   full = 0, */
+  /*   same = 1, */
+  /*   valid = 2, */
+  /*   unknown = 3, */
+  /* }; */
+
+  /**
+   * @brief     get the base name for the layer
+   * @retval    base name of the layer
+   */
+  std::string getBaseName() { return "Convolution2D"; };
+
+  using Layer::setProperty;
+
+  /**
+   * @copydoc Layer::setProperty(const PropertyType type, const std::string
+   * &value)
+   */
+  void setProperty(const PropertyType type, const std::string &value = "");
+
+private:
+  unsigned int filter_size;
+  unsigned int kernel_size[CONV2D_DIM];
+  unsigned int stride[CONV2D_DIM];
+  unsigned int padding[CONV2D_DIM];
+
+  bool normalization;
+  bool standardization;
+
   /**
    * @brief     set Parameter Size
    * @param[in] * size : size arrary
@@ -156,28 +187,6 @@ public:
                   unsigned int const *pad, float *out, unsigned int osize,
                   bool channel_mode);
 
-  /* TO DO : support keras type of padding */
-  /* enum class PaddingType { */
-  /*   full = 0, */
-  /*   same = 1, */
-  /*   valid = 2, */
-  /*   unknown = 3, */
-  /* }; */
-
-  /**
-   * @brief     get the base name for the layer
-   * @retval    base name of the layer
-   */
-  std::string getBaseName() { return "Convolution2D"; };
-
-  using Layer::setProperty;
-
-  /**
-   * @copydoc Layer::setProperty(const PropertyType type, const std::string
-   * &value)
-   */
-  void setProperty(const PropertyType type, const std::string &value = "");
-
   /**
    * @brief     reform the data to 2d matrix
    * @param[in] in_padded padded input data
@@ -191,15 +200,6 @@ public:
    */
   int im2col(Tensor in_padded, TensorDim kdim, float *inCol, TensorDim outdim,
              unsigned int const *mstride, bool channel_mode);
-
-private:
-  unsigned int filter_size;
-  unsigned int kernel_size[CONV2D_DIM];
-  unsigned int stride[CONV2D_DIM];
-  unsigned int padding[CONV2D_DIM];
-
-  bool normalization;
-  bool standardization;
 };
 
 } // namespace nntrainer

--- a/nntrainer/include/fc_layer.h
+++ b/nntrainer/include/fc_layer.h
@@ -83,8 +83,6 @@ public:
    */
   int initialize();
 
-  void setUnit(unsigned int u) { unit = u; };
-
   /**
    * @brief     get the base name for the layer
    * @retval    base name of the layer

--- a/nntrainer/include/flatten_layer.h
+++ b/nntrainer/include/flatten_layer.h
@@ -88,14 +88,6 @@ public:
    * @retval    base name of the layer
    */
   std::string getBaseName() { return "Flatten"; };
-
-  using Layer::setProperty;
-
-  /**
-   * @copydoc Layer::setProperty(const PropertyType type, const std::string
-   * &value)
-   */
-  void setProperty(const PropertyType type, const std::string &value = "");
 };
 
 } // namespace nntrainer

--- a/nntrainer/include/input_layer.h
+++ b/nntrainer/include/input_layer.h
@@ -93,18 +93,6 @@ public:
   void copy(std::shared_ptr<Layer> l);
 
   /**
-   * @brief     set normalization
-   * @param[in] enable boolean
-   */
-  void setNormalization(bool enable) { this->normalization = enable; };
-
-  /**
-   * @brief     set standardization
-   * @param[in] enable boolean
-   */
-  void setStandardization(bool enable) { this->standardization = enable; };
-
-  /**
    * @brief     get the base name for the layer
    * @retval    base name of the layer
    */
@@ -121,6 +109,18 @@ public:
 private:
   bool normalization;
   bool standardization;
+
+  /**
+   * @brief     set normalization
+   * @param[in] enable boolean
+   */
+  void setNormalization(bool enable) { this->normalization = enable; };
+
+  /**
+   * @brief     set standardization
+   * @param[in] enable boolean
+   */
+  void setStandardization(bool enable) { this->standardization = enable; };
 };
 } // namespace nntrainer
 

--- a/nntrainer/include/loss_layer.h
+++ b/nntrainer/include/loss_layer.h
@@ -100,14 +100,6 @@ public:
    */
   std::string getBaseName() { return "Loss"; };
 
-  using Layer::setProperty;
-
-  /**
-   * @copydoc Layer::setProperty(const PropertyType type, const std::string
-   * &value)
-   */
-  void setProperty(const PropertyType type, const std::string &value = "");
-
   /**
    * @brief     set loss function
    * @param[in] l loss type

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -292,13 +292,6 @@ public:
    */
   void printPreset(std::ostream &out, unsigned int preset);
 
-  /**
-   * @brief print metrics function for neuralnet
-   * @param[in] out outstream
-   * @param[in] flags verbosity from ml_train_summary_type_e
-   */
-  void printMetrics(std::ostream &out, unsigned int flags = 0);
-
 private:
   /**
    * @brief   Print Options when printing layer info
@@ -463,6 +456,13 @@ private:
    * @brief     Update batch size of the model as well as its layers/dataset
    */
   void setBatchSize(unsigned int batch_size);
+
+  /**
+   * @brief print metrics function for neuralnet
+   * @param[in] out outstream
+   * @param[in] flags verbosity from ml_train_summary_type_e
+   */
+  void printMetrics(std::ostream &out, unsigned int flags = 0);
 };
 
 } /* namespace nntrainer */

--- a/nntrainer/include/pooling2d_layer.h
+++ b/nntrainer/include/pooling2d_layer.h
@@ -100,21 +100,6 @@ public:
    */
   void copy(std::shared_ptr<Layer> l);
 
-  /**
-   * @brief     set Pooling Type
-   * @param[in] t pooling type
-   */
-  void setPoolingType(PoolingType t) { pooling_type = t; };
-
-  /**
-   * @brief     set Parameter Size
-   * @param[in] * size : size arrary
-   * @param[in] type : Property type
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int setSize(int *size, PropertyType type);
-
   /* TO DO : support keras type of padding */
   enum class PaddingType {
     full = 0,
@@ -152,6 +137,21 @@ private:
    * @retval Tensor outoput tensor
    */
   Tensor pooling2d(unsigned int batch, Tensor &in);
+
+  /**
+   * @brief     set Pooling Type
+   * @param[in] t pooling type
+   */
+  void setPoolingType(PoolingType t) { pooling_type = t; };
+
+  /**
+   * @brief     set Parameter Size
+   * @param[in] * size : size arrary
+   * @param[in] type : Property type
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int setSize(int *size, PropertyType type);
 };
 
 } // namespace nntrainer

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -39,28 +39,6 @@ namespace nntrainer {
 class LazyTensor;
 
 /**
- * @struct External Loop Info for broadcasted info
- * @brief External Loop Info for broadcasted iteration. Please refer to
- * DISABLED_private_external_loop_n in unittest_nntrainer_tensor.
- * @note This should better be implemented in iterator fashion before used
- * extensively.
- */
-struct BroadcastInfo {
-
-  /**
-   * @brief Construct a new External Loop Info object
-   *
-   */
-  BroadcastInfo() : strides{0, 0, 0, 0} {}
-
-  unsigned int buffer_size; /**< virtual size of the buffer */
-  int buffer_axis;          /**< the smallest axis that should be looped.
-                                 -1 means no loop needed*/
-  std::array<unsigned int, MAXDIM>
-    strides; /**< modified strides for the loop */
-};
-
-/**
  * @class   Tensor Class for Calculation
  * @brief   Tensor Class for Calculation
  */
@@ -592,6 +570,8 @@ private:
                                unsigned int w) const {
     return (b * strides[0] + c * strides[1] + h * strides[2] + w * strides[3]);
   }
+
+  struct BroadcastInfo;
 
   /**
    * @brief Applies the given operator to the tensor with the passed argument

--- a/nntrainer/src/activation_layer.cpp
+++ b/nntrainer/src/activation_layer.cpp
@@ -34,9 +34,9 @@ namespace nntrainer {
 /**
  * @brief     Constructor of Activation Layer
  */
-ActivationLayer::ActivationLayer() : Layer() {
+ActivationLayer::ActivationLayer(ActivationType at) : Layer() {
   setType(LayerType::LAYER_ACTIVATION);
-  setActivation(ActivationType::ACT_NONE);
+  setActivation(at);
 }
 
 /**

--- a/nntrainer/src/flatten_layer.cpp
+++ b/nntrainer/src/flatten_layer.cpp
@@ -51,11 +51,6 @@ sharedConstTensor FlattenLayer::backwarding(sharedConstTensor in,
   return MAKE_SHARED_TENSOR(std::move(temp));
 }
 
-void FlattenLayer::setProperty(const PropertyType type,
-                               const std::string &value) {
-  throw exception::not_supported("[Flatten Layer] setProperty not supported");
-}
-
 void FlattenLayer::copy(std::shared_ptr<Layer> l) {
   std::shared_ptr<FlattenLayer> from =
     std::static_pointer_cast<FlattenLayer>(l);

--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -181,11 +181,11 @@ void Layer::setProperty(const PropertyType type, const std::string &value) {
   }
 }
 
-int Layer::setName(std::string name) {
-  if (name.empty())
+int Layer::setName(std::string name_) {
+  if (name_.empty())
     return ML_ERROR_INVALID_PARAMETER;
 
-  this->name = name;
+  name = name_;
   return ML_ERROR_NONE;
 }
 

--- a/nntrainer/src/loss_layer.cpp
+++ b/nntrainer/src/loss_layer.cpp
@@ -172,8 +172,4 @@ int LossLayer::setLoss(LossType l) {
   return status;
 }
 
-void LossLayer::setProperty(const PropertyType type, const std::string &value) {
-  throw exception::not_supported("[Loss Layer] setProperty not supported");
-}
-
 } /* namespace nntrainer */

--- a/nntrainer/src/parse_util.cpp
+++ b/nntrainer/src/parse_util.cpp
@@ -94,9 +94,10 @@ unsigned int parseType(std::string ll, InputType t) {
    *            "relu" : relu
    *            "softmax" : softmax
    *            "none" : none
+   *            "unknown" : unknown
    */
-  std::array<std::string, 5> activation_string = {"tanh", "sigmoid", "relu",
-                                                  "softmax", "none"};
+  std::array<std::string, 6> activation_string = {
+    "tanh", "sigmoid", "relu", "softmax", "none", "unknown"};
 
   /**
    * @brief     Layer Type String from configure file
@@ -192,7 +193,7 @@ unsigned int parseType(std::string ll, InputType t) {
     ml_logw("Input activation %s cannot be identified. "
             "Moved to NO activation layer by default.",
             ll.c_str());
-    ret = (unsigned int)ActivationType::ACT_NONE;
+    ret = (unsigned int)ActivationType::ACT_UNKNOWN;
     break;
   case TOKEN_LAYER:
     for (i = 0; i < layer_string.size(); i++) {

--- a/nntrainer/src/tensor.cpp
+++ b/nntrainer/src/tensor.cpp
@@ -208,6 +208,28 @@ int Tensor::add_i(float const &value) {
 Tensor Tensor::add(float const &value) { CLONE_OP_I(add_i, value); }
 
 /**
+ * @struct External Loop Info for broadcasted info
+ * @brief External Loop Info for broadcasted iteration. Please refer to
+ * DISABLED_private_external_loop_n in unittest_nntrainer_tensor.
+ * @note This should better be implemented in iterator fashion before used
+ * extensively.
+ */
+struct Tensor::BroadcastInfo {
+
+  /**
+   * @brief Construct a new External Loop Info object
+   *
+   */
+  BroadcastInfo() : strides{0, 0, 0, 0} {}
+
+  unsigned int buffer_size; /**< virtual size of the buffer */
+  int buffer_axis;          /**< the smallest axis that should be looped.
+                                 -1 means no loop needed*/
+  std::array<unsigned int, MAXDIM>
+    strides; /**< modified strides for the loop */
+};
+
+/**
  * @brief Add Tensor Element by Element without mem copy
  * @param[in] m Tensor to be added
  * #retval #ML_ERROR_NONE  Successful
@@ -798,7 +820,7 @@ Tensor Tensor::standardization() const {
   return result;
 }
 
-BroadcastInfo Tensor::computeBroadcastInfo(const Tensor &m) {
+Tensor::BroadcastInfo Tensor::computeBroadcastInfo(const Tensor &m) {
   if (m.length() > this->length())
     throw exception::not_supported("broadcasting *this is not supported");
 

--- a/test/tizen_capi/unittest_tizen_capi_layer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_layer.cpp
@@ -155,16 +155,16 @@ TEST(nntrainer_capi_nnlayer, setproperty_06_n) {
 }
 
 /**
- * @brief Neural Network Set Property Test (positive test)
+ * @brief Neural Network Set Property Test (negative test)
  */
-TEST(nntrainer_capi_nnlayer, setproperty_07_p) {
+TEST(nntrainer_capi_nnlayer, setproperty_07_n) {
   ml_train_layer_h handle;
   int status;
   status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  /** Default to none activation in case wrong activation given */
-  status = ml_train_layer_set_property(handle, "activation=0.0001", NULL);
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  /** Setting empty property results in error */
+  status = ml_train_layer_set_property(handle, "activation=", NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
@@ -196,6 +196,24 @@ TEST(nntrainer_capi_nnlayer, setproperty_09_n) {
   status =
     ml_train_layer_set_property(handle, "weight_regularizer=asdfasd",
                                 "weight_regularizer_constant=0.0001", NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_layer_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Set Property Test (negative test)
+ */
+TEST(nntrainer_capi_nnlayer, setproperty_10_n) {
+  ml_train_layer_h handle;
+  int status;
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_FC);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  /**
+   * Default to none activation if no activation is set.
+   * If activation is set which isnt available, then error.
+   */
+  status = ml_train_layer_set_property(handle, "activation=0.0001", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);


### PR DESCRIPTION
Update the interface for layer This changes the public and private exposed member functions Corresponding unittests are updated
Major changes are for Flatten and Loss layers - they both now support setting basic layer properties such are input_shape etc.

Commit - 2:
Minor changes to tensor and model
Move BroadcastInfo to private
Move printMetrics to private

See also #199

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
