### PR TITLE
Refactor getDataFromBuffer

### DIFF
--- a/nntrainer/include/databuffer.h
+++ b/nntrainer/include/databuffer.h
@@ -70,8 +70,6 @@
  */
 constexpr const unsigned int NBUFTYPE = 4;
 
-typedef std::vector<std::vector<std::vector<std::vector<float>>>> vec_4d;
-
 typedef enum {
   DATA_NOT_READY = 0,
   DATA_READY = 1,
@@ -175,14 +173,13 @@ public:
   /**
    * @brief     get Data from Data Buffer using databuffer param
    * @param[in] BufferType training, validation, test
-   * @param[in] outVec feature data ( batch_size size )
-   * @param[in] outLabel label data ( batch_size size )
+   * @param[out] out feature data ( batch_size size ), a contiguous and
+   * allocated memory block should be passed
+   * @param[out] label label data ( batch_size size ), a contiguous and
+   * allocated memory block should be passed
    * @retval    true/false
    */
-  virtual bool getDataFromBuffer(
-    BufferType type,
-    std::vector<std::vector<std::vector<std::vector<float>>>> &out_vec,
-    std::vector<std::vector<std::vector<std::vector<float>>>> &out_label);
+  bool getDataFromBuffer(BufferType type, float *out, float *label);
 
   /**
    * @brief     set number of class

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -32,7 +32,7 @@
 
 #include <tensor_dim.h>
 
-#define MAKE_SHARED_TENSOR(x) std::make_shared<nntrainer::Tensor>(x)
+#define MAKE_SHARED_TENSOR(...) std::make_shared<nntrainer::Tensor>(__VA_ARGS__)
 
 namespace nntrainer {
 


### PR DESCRIPTION
This patch rearranges getDataFromBuffer to not rely on nested buffers to
avoid unnecessary allocation & deallocation.

This patch provides notable speedup for some cases.

resolves #611 

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
