### PR TITLE
[ Max Pooling ] Fix bug when max_id created

### DIFF
--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -330,10 +330,7 @@ public:
    * @param batch Batch value to be set
    * @todo Make this private. Only model should be able to do this.
    */
-  void setBatch(unsigned int batch) {
-    input_dim.setTensorDim(0, batch);
-    output_dim.setTensorDim(0, batch);
-  }
+  virtual void setBatch(unsigned int batch);
 
 protected:
 #else
@@ -343,10 +340,7 @@ protected:
    * @param batch Batch value to be set
    * @todo Make this private. Only model should be able to do this.
    */
-  void setBatch(unsigned int batch) {
-    input_dim.setTensorDim(0, batch);
-    output_dim.setTensorDim(0, batch);
-  }
+  virtual void setBatch(unsigned int batch);
 #endif
 
   /**

--- a/nntrainer/include/pooling2d_layer.h
+++ b/nntrainer/include/pooling2d_layer.h
@@ -95,6 +95,11 @@ public:
   sharedConstTensor backwarding(sharedConstTensor in, int iteration);
 
   /**
+   * @copydoc Layer::setBatch(unsigned int batch)
+   */
+  void setBatch(unsigned int batch);
+
+  /**
    * @brief     copy layer
    * @param[in] l layer to copy
    */

--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -62,6 +62,11 @@ int Layer::checkValidation() {
   return status;
 }
 
+void Layer::setBatch(unsigned int batch) {
+  input_dim.setTensorDim(0, batch);
+  output_dim.setTensorDim(0, batch);
+}
+
 void Layer::copy(std::shared_ptr<Layer> l) {
   setNumWeights(l->num_weights);
   for (unsigned int i = 0; i < num_weights; ++i) {

--- a/nntrainer/src/pooling2d_layer.cpp
+++ b/nntrainer/src/pooling2d_layer.cpp
@@ -168,6 +168,16 @@ int Pooling2DLayer::setSize(int *size, PropertyType type) {
   return status;
 }
 
+void Pooling2DLayer::setBatch(unsigned int batch) {
+  Layer::setBatch(batch);
+
+  if (pooling_type == PoolingType::max) {
+    max_idx.resize(output_dim.getDataLen());
+  } else if (pooling_type == PoolingType::global_max) {
+    max_idx_global.resize(output_dim.getDataLen());
+  }
+}
+
 void Pooling2DLayer::copy(std::shared_ptr<Layer> l) {
   std::shared_ptr<Pooling2DLayer> from =
     std::static_pointer_cast<Pooling2DLayer>(l);


### PR DESCRIPTION
This PR includs:
  - make Layer::setBatch virtual function to set batch size
  - max_id for max poooling should be created at initialization time
  but the batch size is not set properly at this time. So when the
  setBatch is called for each layer, it is set properly.

TODO: depnding on inference and training, max_id should be handled
properly. It is not needed for inference.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>