### PR TITLE
[optimizer] Refactor optimizer

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -42,7 +42,10 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/src/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/model_loader.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/addition_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/src/blas_interface.cpp \
-                  $(NNTRAINER_ROOT)/nntrainer/src/weight.cpp
+                  $(NNTRAINER_ROOT)/nntrainer/src/weight.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/src/adam.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/src/sgd.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/src/optimizer_factory.cpp
 
 NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer/include \
                       $(NNTRAINER_ROOT)/api \

--- a/nntrainer/include/activation_layer.h
+++ b/nntrainer/include/activation_layer.h
@@ -68,12 +68,6 @@ public:
   sharedConstTensor backwarding(sharedConstTensor in, int iteration);
 
   /**
-   * @brief     copy layer
-   * @param[in] l layer to copy
-   */
-  void copy(std::shared_ptr<Layer> l);
-
-  /**
    * @brief setActivation by preset ActivationType
    *
    * @param[in] ActivationTypeeActivationTypeeActivationTypeet

--- a/nntrainer/include/adam.h
+++ b/nntrainer/include/adam.h
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file	adam.h
+ * @date	6 October 2020
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is the Adam optimizer.
+ */
+#ifndef __ADAM_H__
+#define __ADAM_H__
+#ifdef __cplusplus
+
+#include <optimizer.h>
+
+namespace nntrainer {
+
+/**
+ * @class   Adam optimizer class
+ * @brief   Adam optimizer
+ */
+class Adam : public Optimizer {
+public:
+  /**
+   * @brief     Constructor of Optimizer Class
+   */
+  template <typename... Args>
+  Adam(float lr = 0.001f, double b1 = 0.9f, double b2 = 0.999f,
+       double ep = 1.0e-7f, Args... args) :
+    Optimizer(OptType::adam, lr, args...),
+    beta1(b1),
+    beta2(b2),
+    epsilon(ep) {}
+
+  /**
+   * @copydoc apply_gradient(Weight &weight, int tensor_idx, double updated_lr,
+   * int iteration)
+   */
+  void apply_gradient(Weight &weight, int tensor_idx, double updated_lr,
+                      int iteration);
+
+  /**
+   * @brief     get the base name for the optimizer
+   * @retval    base name of the optimizer
+   */
+  std::string getBaseName() { return "Adam"; };
+
+  /**
+   * @copydoc   getLearningRate(int iteration)
+   */
+  double getLearningRate(int iteration);
+
+  /**
+   * @copydoc setProperty(const PropertyType type,
+                           const std::string &value = "")
+   */
+  void setProperty(const PropertyType type, const std::string &value = "");
+
+  /**
+   * @copydoc Optimizer::initialize(std::shared_ptr<Weight> params, unsigned int
+   num_weights, bool setTensor)
+   */
+  int initialize(std::shared_ptr<Weight> params, unsigned int num_weights,
+                 bool setTensor);
+
+  /**
+   * @copydoc read(std::ifstream &file)
+   */
+  void read(std::ifstream &file);
+
+  /**
+   * @copydoc save(std::ofstream &file)
+   */
+  void save(std::ofstream &file);
+
+  /**
+   * @brief get beta1
+   */
+  double getBeta1() { return beta1; };
+
+  /**
+   * @brief get beta2
+   */
+  double getBeta2() { return beta2; };
+
+  /**
+   * @brief get epsilon
+   */
+  double getEpsilon() { return epsilon; }
+
+private:
+  /**
+   * @brief Internal Tensors for adam Optimizer
+   */
+  std::vector<std::pair<Tensor, Tensor>> weight_mv;
+
+  double beta1;   /** momentum for grad */
+  double beta2;   /** momentum for grad**2 */
+  double epsilon; /** epsilon to protect overflow */
+};
+} /* namespace nntrainer */
+
+#endif /* __cplusplus */
+#endif /* __ADAM_H__ */

--- a/nntrainer/include/addition_layer.h
+++ b/nntrainer/include/addition_layer.h
@@ -82,12 +82,6 @@ public:
   sharedConstTensor backwarding(sharedConstTensor in, int iteration);
 
   /**
-   * @brief     copy layer
-   * @param[in] l layer to copy
-   */
-  void copy(std::shared_ptr<Layer> l);
-
-  /**
    * @brief     get the base name for the layer
    * @retval    base name of the layer
    */

--- a/nntrainer/include/flatten_layer.h
+++ b/nntrainer/include/flatten_layer.h
@@ -78,12 +78,6 @@ public:
   sharedConstTensor backwarding(sharedConstTensor in, int iteration);
 
   /**
-   * @brief     copy layer
-   * @param[in] l layer to copy
-   */
-  void copy(std::shared_ptr<Layer> l);
-
-  /**
    * @brief     get the base name for the layer
    * @retval    base name of the layer
    */

--- a/nntrainer/include/input_layer.h
+++ b/nntrainer/include/input_layer.h
@@ -87,12 +87,6 @@ public:
   int initialize();
 
   /**
-   * @brief     Copy Layer
-   * @param[in] l layer to copy
-   */
-  void copy(std::shared_ptr<Layer> l);
-
-  /**
    * @brief     get the base name for the layer
    * @retval    base name of the layer
    */

--- a/nntrainer/include/layer.h
+++ b/nntrainer/include/layer.h
@@ -230,7 +230,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int setOptimizer(Optimizer &opt);
+  int setOptimizer(std::shared_ptr<Optimizer> opt);
 
   /**
    * @brief     Activation Type Getter
@@ -400,7 +400,8 @@ protected:
   /**
    * @brief     Optimizer for this layer
    */
-  Optimizer opt;
+  // TODO: fix with #630
+  std::shared_ptr<Optimizer> opt;
 
   /**
    * @brief     Layer type

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -115,7 +115,7 @@ public:
    * @brief     Get Learning rate
    * @retval    Learning rate
    */
-  float getLearningRate() { return opt.getLearningRate(); };
+  float getLearningRate() { return opt->getLearningRate(); };
 
   /**
    * @brief     Create and load the Network with ini configuration file.
@@ -305,8 +305,8 @@ private:
 
   std::string save_path; /**< Model path to save / read */
 
-  Optimizer opt; /**< Optimizer, This gets copied into each layer, do not use
-                    this directly */
+  std::shared_ptr<Optimizer> opt; /**< Optimizer; this gets copied into each
+                    layer, do not use this directly */
 
   NetType net_type; /**< Network Type */
 

--- a/nntrainer/include/optimizer_factory.h
+++ b/nntrainer/include/optimizer_factory.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file	optimizer_factory.h
+ * @date	7 October 2020
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is the optimizer factory.
+ */
+
+#ifndef __OPTIMIZER_FACTORY_H__
+#define __OPTIMIZER_FACTORY_H__
+#ifdef __cplusplus
+
+#include <adam.h>
+#include <optimizer.h>
+#include <sgd.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Factory creator with copy constructor
+ */
+std::unique_ptr<Optimizer> createOptimizer(OptType type, const Optimizer &opt);
+
+/**
+ * @brief Factory creator with constructor
+ */
+template <typename... Args>
+std::unique_ptr<Optimizer> createOptimizer(OptType type, Args... args) {
+  switch (type) {
+  case OptType::sgd:
+    return std::make_unique<SGD>(args...);
+  case OptType::adam:
+    return std::make_unique<Adam>(args...);
+  case OptType::unknown:
+    /** fallthrough intended */
+  default:
+    throw std::invalid_argument("Unknown type for the optimizer");
+  }
+}
+
+} // namespace nntrainer
+
+#endif // __cplusplus
+#endif // __OPTIMIZER_FACTORY_H__

--- a/nntrainer/include/sgd.h
+++ b/nntrainer/include/sgd.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file	sgd.h
+ * @date	6 October 2020
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is the SGD optimizer.
+ */
+#ifndef __SGD_H__
+#define __SGD_H__
+#ifdef __cplusplus
+
+#include <optimizer.h>
+
+namespace nntrainer {
+
+/**
+ * @class   SGD optimizer class
+ * @brief   Stochastic Gradient Descent optimizer class
+ */
+class SGD : public Optimizer {
+public:
+  /**
+   * @brief     Constructor of Optimizer Class
+   */
+  template <typename... Args>
+  SGD(float lr = 0.0001f, Args... args) :
+    Optimizer(OptType::sgd, lr, args...) {}
+
+  /**
+   * @copydoc apply_gradient(Weight &weight, int tensor_idx, double updated_lr,
+   * int iteration)
+   */
+  void apply_gradient(Weight &weight, int tensor_idx, double updated_lr,
+                      int iteration);
+
+  /**
+   * @brief     get the base name for the optimizer
+   * @retval    base name of the optimizer
+   */
+  std::string getBaseName() { return "SGD"; };
+};
+} /* namespace nntrainer */
+
+#endif /* __cplusplus */
+#endif /* __SGD_H__ */

--- a/nntrainer/include/weight.h
+++ b/nntrainer/include/weight.h
@@ -55,6 +55,8 @@ class Weight {
 
   /** Declare opitmizer as friend to get variable/gradient reference */
   friend class Optimizer;
+  friend class SGD;
+  friend class Adam;
 
 public:
   /**

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -43,8 +43,11 @@ nntrainer_sources = [
   'src/neuralnet.cpp',
   'src/nntrainer_logger.cpp',
   'src/optimizer.cpp',
+  'src/optimizer_factory.cpp',
   'src/parse_util.cpp',
   'src/pooling2d_layer.cpp',
+  'src/sgd.cpp',
+  'src/adam.cpp',
   'src/tensor.cpp',
   'src/tensor_dim.cpp',
   'src/util_func.cpp',
@@ -73,10 +76,13 @@ nntrainer_headers = [
   'include/optimizer.h',
   'include/parse_util.h',
   'include/pooling2d_layer.h',
+  'include/sgd.h',
+  'include/adam.h',
   'include/tensor.h',
   'include/tensor_dim.h',
   'include/util_func.h',
   'include/weight.h',
+  'include/optimizer_factory.h',
   '../api/nntrainer-api-common.h'
 ]
 

--- a/nntrainer/src/activation_layer.cpp
+++ b/nntrainer/src/activation_layer.cpp
@@ -72,18 +72,6 @@ sharedConstTensor ActivationLayer::backwarding(sharedConstTensor derivative,
   return MAKE_SHARED_TENSOR(std::move(ret));
 }
 
-/**
- * @brief     copy layer
- * @param[in] l layer to copy
- */
-void ActivationLayer::copy(std::shared_ptr<Layer> l) {
-  std::shared_ptr<ActivationLayer> from =
-    std::static_pointer_cast<ActivationLayer>(l);
-  this->input.copy(from->input);
-  this->hidden.copy(from->hidden);
-  this->activation_type = from->activation_type;
-};
-
 int ActivationLayer::setActivation(
   std::function<Tensor(Tensor const &)> const &activation_fn,
   std::function<Tensor(Tensor const &, Tensor const &)> const

--- a/nntrainer/src/adam.cpp
+++ b/nntrainer/src/adam.cpp
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file	adam.cpp
+ * @date	6 October 2020
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is the Adam optimizer.
+ */
+
+#include <cmath>
+#include <fstream>
+
+#include <adam.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <parse_util.h>
+#include <util_func.h>
+
+namespace nntrainer {
+
+int Adam::initialize(std::shared_ptr<Weight> weight_list,
+                     unsigned int num_weights, bool set_tensor) {
+  int status = ML_ERROR_NONE;
+  weight_mv.clear();
+
+  if (set_tensor) {
+    for (unsigned int i = 0; i < num_weights; ++i) {
+      Weight &w = weight_list.get()[i];
+
+      // TODO: only trainable weights must be sent to optimizer
+      if (!w.getTrainable())
+        continue;
+
+      Tensor m = Tensor(w.getDim());
+      m.setZero();
+      Tensor v = Tensor(w.getDim());
+      v.setZero();
+      std::pair<Tensor, Tensor> p =
+        std::pair<Tensor, Tensor>(std::move(m), std::move(v));
+      weight_mv.push_back(std::move(p));
+    }
+  }
+  return status;
+}
+
+double Adam::getLearningRate(int iteration) {
+  double ll = Optimizer::getLearningRate(iteration);
+
+  std::function<float(double)> biasCorrection = [&](float f) {
+    return 1.0f - pow(f, iteration + 1);
+  };
+
+  ll *= sqrt(biasCorrection(beta2)) / biasCorrection(beta1);
+
+  return ll;
+}
+
+void Adam::apply_gradient(Weight &weight, int tensor_idx, double updated_lr,
+                          int iteration) {
+
+  Tensor &x = weight.getVariableRef();
+  const Tensor &x_grad = weight.getGradientRef();
+
+  // This is implementation of adam from original paper.
+  // This is not deleted intentionally.
+  // float biasCorrection1 = 1 - pow(beta1, iteration + 1);
+  // float biasCorrection2 = 1 - pow(beta2, iteration + 1);
+  // Tensor &wm = weight_mv[idx].first;
+  // Tensor &wv = weight_mv[idx].second;
+
+  // wm.multiply_i(beta1);
+  // wm.add_i(x_grad, 1.0f - beta1);
+
+  // wv.multiply_i(beta2);
+  // wv.add_i(x_grad.multiply(x_grad), 1.0f - beta2);
+
+  // Tensor denom = wv.apply(sqrtFloat)
+  //                  .divide(sqrtFloat(biasCorrection2))
+  //                  .add(epsilon);
+  // x.add_i(wm.divide(denom), -ll / biasCorrection1);
+
+  std::function<double(double)> sqrtEps = [&](double f) {
+    return sqrtDouble(f) + this->epsilon;
+  };
+
+  Tensor &wm = weight_mv[tensor_idx].first;
+  Tensor &wv = weight_mv[tensor_idx].second;
+
+  wm.multiply_i(beta1);
+  wm.add_i(x_grad, 1.0f - beta1);
+
+  wv.multiply_i(beta2);
+  wv.add_i(x_grad.multiply(x_grad), 1.0f - beta2);
+
+  x.add_i(wm.divide(wv.apply(sqrtEps)), -updated_lr);
+}
+
+void Adam::setProperty(const PropertyType type, const std::string &value) {
+  int status = ML_ERROR_NONE;
+
+  switch (type) {
+  case PropertyType::beta1:
+    status = setDouble(beta1, value);
+    break;
+  case PropertyType::beta2:
+    status = setDouble(beta2, value);
+    break;
+  case PropertyType::epsilon:
+    status = setDouble(epsilon, value);
+    break;
+  default:
+    Optimizer::setProperty(type, value);
+    status = ML_ERROR_NONE;
+    break;
+  }
+
+  throw_status(status);
+}
+
+void Adam::read(std::ifstream &file) {
+  OptType loaded_type;
+  file.read((char *)&loaded_type, sizeof(OptType));
+
+  if (loaded_type == type) {
+    if (continue_train) {
+      for (auto iter = weight_mv.begin(); iter != weight_mv.end(); iter++) {
+        (*iter).first.read(file);
+        (*iter).second.read(file);
+      }
+    } else {
+      size_t total_size = 0;
+      for (auto iter = weight_mv.begin(); iter != weight_mv.end(); iter++)
+        total_size += (*iter).first.getSize() + (*iter).second.getSize();
+
+      file.seekg(total_size, std::ifstream::cur);
+    }
+  } else {
+    ml_logw("Not loading saved optimizer parameters due to mismatched type");
+  }
+}
+
+void Adam::save(std::ofstream &file) {
+  Optimizer::save(file);
+
+  for (auto iter = weight_mv.begin(); iter != weight_mv.end(); iter++) {
+    (*iter).first.save(file);
+    (*iter).second.save(file);
+  }
+}
+
+} // namespace nntrainer

--- a/nntrainer/src/addition_layer.cpp
+++ b/nntrainer/src/addition_layer.cpp
@@ -83,13 +83,4 @@ void AdditionLayer::setProperty(const PropertyType type,
   }
 }
 
-void AdditionLayer::copy(std::shared_ptr<Layer> l) {
-  std::shared_ptr<AdditionLayer> from =
-    std::static_pointer_cast<AdditionLayer>(l);
-  this->input.copy(from->input);
-  this->hidden.copy(from->hidden);
-  this->input_dim = from->input_dim;
-  this->output_dim = from->output_dim;
-}
-
 } /* namespace nntrainer */

--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -176,7 +176,7 @@ BatchNormalizationLayer::backwarding(sharedConstTensor derivative,
   Tensor dx = dx_2.multiply(dx_1);
   dx.divide_i(N);
 
-  opt.apply_gradients(weight_list, num_weights, iteration);
+  opt->apply_gradients(weight_list, num_weights, iteration);
 
   return MAKE_SHARED_TENSOR(std::move(dx));
 }
@@ -186,11 +186,6 @@ void BatchNormalizationLayer::copy(std::shared_ptr<Layer> l) {
 
   std::shared_ptr<BatchNormalizationLayer> from =
     std::static_pointer_cast<BatchNormalizationLayer>(l);
-  this->opt = from->opt;
-  this->input_dim = from->input_dim;
-  this->output_dim = from->output_dim;
-  this->input.copy(from->input);
-  this->hidden.copy(from->hidden);
   this->cvar.copy(from->cvar);
 }
 

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -348,7 +348,7 @@ sharedConstTensor Conv2DLayer::backwarding(sharedConstTensor derivative,
       }
     }
 
-    opt.apply_gradients(weight_list, num_weights, iteration);
+    opt->apply_gradients(weight_list, num_weights, iteration);
   }
 
   return MAKE_SHARED_TENSOR(std::move(strip_pad(ret, padding)));
@@ -356,6 +356,7 @@ sharedConstTensor Conv2DLayer::backwarding(sharedConstTensor derivative,
 
 void Conv2DLayer::copy(std::shared_ptr<Layer> l) {
   Layer::copy(l);
+
   std::shared_ptr<Conv2DLayer> from = std::static_pointer_cast<Conv2DLayer>(l);
   this->filter_size = from->filter_size;
   for (unsigned int i = 0; i < CONV2D_DIM; ++i) {
@@ -363,11 +364,6 @@ void Conv2DLayer::copy(std::shared_ptr<Layer> l) {
     this->stride[i] = from->stride[i];
     this->padding[i] = from->padding[i];
   }
-
-  this->input.copy(from->input);
-  this->hidden.copy(from->hidden);
-  this->input_dim = from->input_dim;
-  this->output_dim = from->output_dim;
 }
 
 int Conv2DLayer::setSize(int *size, PropertyType type) {

--- a/nntrainer/src/fc_layer.cpp
+++ b/nntrainer/src/fc_layer.cpp
@@ -88,12 +88,14 @@ sharedConstTensor FullyConnectedLayer::forwarding(sharedConstTensor in) {
 
 void FullyConnectedLayer::read(std::ifstream &file) {
   Layer::read(file);
-  opt.read(file);
+  if (opt)
+    opt->read(file);
 }
 
 void FullyConnectedLayer::save(std::ofstream &file) {
   Layer::save(file);
-  opt.save(file);
+  if (opt)
+    opt->save(file);
 }
 
 void FullyConnectedLayer::copy(std::shared_ptr<Layer> l) {
@@ -101,13 +103,7 @@ void FullyConnectedLayer::copy(std::shared_ptr<Layer> l) {
 
   std::shared_ptr<FullyConnectedLayer> from =
     std::static_pointer_cast<FullyConnectedLayer>(l);
-  this->opt = from->opt;
   this->unit = from->unit;
-  this->input_dim = from->input_dim;
-  this->output_dim = from->output_dim;
-  this->input.copy(from->input);
-  this->hidden.copy(from->hidden);
-  this->loss = from->loss;
 }
 
 sharedConstTensor FullyConnectedLayer::backwarding(sharedConstTensor derivative,
@@ -127,7 +123,7 @@ sharedConstTensor FullyConnectedLayer::backwarding(sharedConstTensor derivative,
   djdw = djdw.sum(0);
 
   if (trainable) {
-    opt.apply_gradients(weight_list, num_weights, iteration);
+    opt->apply_gradients(weight_list, num_weights, iteration);
   }
 
   return MAKE_SHARED_TENSOR(std::move(ret));

--- a/nntrainer/src/flatten_layer.cpp
+++ b/nntrainer/src/flatten_layer.cpp
@@ -51,13 +51,4 @@ sharedConstTensor FlattenLayer::backwarding(sharedConstTensor in,
   return MAKE_SHARED_TENSOR(std::move(temp));
 }
 
-void FlattenLayer::copy(std::shared_ptr<Layer> l) {
-  std::shared_ptr<FlattenLayer> from =
-    std::static_pointer_cast<FlattenLayer>(l);
-  this->input.copy(from->input);
-  this->hidden.copy(from->hidden);
-  this->input_dim = from->input_dim;
-  this->output_dim = from->output_dim;
-}
-
 } /* namespace nntrainer */

--- a/nntrainer/src/input_layer.cpp
+++ b/nntrainer/src/input_layer.cpp
@@ -51,15 +51,6 @@ void InputLayer::setProperty(const PropertyType type,
   }
 }
 
-void InputLayer::copy(std::shared_ptr<Layer> l) {
-  std::shared_ptr<InputLayer> from = std::static_pointer_cast<InputLayer>(l);
-  this->opt = from->opt;
-  this->input_dim = from->input_dim;
-  this->output_dim = from->output_dim;
-  this->input.copy(from->input);
-  this->hidden.copy(from->hidden);
-}
-
 sharedConstTensor InputLayer::forwarding(sharedConstTensor in) {
   input = *in;
 

--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -24,6 +24,7 @@
 #include <layer.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
+#include <optimizer_factory.h>
 #include <parse_util.h>
 #include <util_func.h>
 
@@ -40,11 +41,9 @@ int Layer::setActivation(ActivationType acti) {
   return status;
 }
 
-int Layer::setOptimizer(Optimizer &opt) {
-  this->opt.setType(opt.getType());
-  this->opt.setOptParam(opt.getOptParam());
-
-  return this->opt.initialize(weight_list, num_weights, true);
+int Layer::setOptimizer(std::shared_ptr<Optimizer> opt) {
+  this->opt = createOptimizer(opt->getType(), *opt.get());
+  return this->opt->initialize(weight_list, num_weights, true);
 }
 
 int Layer::checkValidation() {
@@ -67,6 +66,23 @@ void Layer::copy(std::shared_ptr<Layer> l) {
   for (unsigned int i = 0; i < num_weights; ++i) {
     weightAt(i) = l->weightAt(i);
   }
+
+  // TODO: fix this #630
+  this->opt = l->opt;
+  this->input_dim = l->input_dim;
+  this->output_dim = l->output_dim;
+  this->input.copy(l->input);
+  this->hidden.copy(l->hidden);
+  this->activation_type = l->activation_type;
+  this->loss = l->loss;
+  this->type = l->type;
+  this->weight_regularizer = l->weight_regularizer;
+  this->weight_regularizer_constant = l->weight_regularizer_constant;
+  this->weight_initializer = l->weight_initializer;
+  this->flatten = l->flatten;
+  this->trainable = l->trainable;
+  this->num_inputs = l->num_inputs;
+  this->num_outputs = l->num_outputs;
 }
 
 void Layer::read(std::ifstream &file) {

--- a/nntrainer/src/loss_layer.cpp
+++ b/nntrainer/src/loss_layer.cpp
@@ -126,10 +126,10 @@ void LossLayer::updateLoss(const Tensor &l) {
 }
 
 void LossLayer::copy(std::shared_ptr<Layer> l) {
+  Layer::copy(l);
+
   std::shared_ptr<LossLayer> from = std::static_pointer_cast<LossLayer>(l);
-  this->input.copy(from->input);
   this->loss_type = from->loss_type;
-  this->loss = from->loss;
 }
 
 sharedConstTensor LossLayer::backwarding(sharedConstTensor derivative,

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -162,7 +162,7 @@ int NeuralNetwork::setTrainConfig(std::vector<std::string> values) {
       status = setBoolean(cont_train, value);
       NN_RETURN_STATUS();
       continue_train = cont_train;
-      opt.setProperty({values[i]});
+      opt->setProperty({values[i]});
     } break;
     case PropertyType::batch_size: {
       status = setUint(batch_size, value);
@@ -597,7 +597,7 @@ int NeuralNetwork::setOptimizer(std::shared_ptr<Optimizer> optimizer) {
     return ML_ERROR_NOT_SUPPORTED;
   }
 
-  opt = *optimizer.get();
+  opt = optimizer;
 
   return ML_ERROR_NONE;
 }

--- a/nntrainer/src/optimizer_factory.cpp
+++ b/nntrainer/src/optimizer_factory.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file	optimizer_factory.cpp
+ * @date	7 October 2020
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is the optimizer factory.
+ */
+
+#include <adam.h>
+#include <optimizer.h>
+#include <sgd.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Factory creator with copy constructor
+ */
+std::unique_ptr<Optimizer> createOptimizer(OptType type, const Optimizer &opt) {
+  switch (type) {
+  case OptType::sgd:
+    return std::make_unique<SGD>(static_cast<const SGD &>(opt));
+  case OptType::adam:
+    return std::make_unique<Adam>(static_cast<const Adam &>(opt));
+  case OptType::unknown:
+    /** fallthrough intended */
+  default:
+    throw std::invalid_argument("Unknown type for the optimizer");
+  }
+}
+
+} // namespace nntrainer

--- a/nntrainer/src/pooling2d_layer.cpp
+++ b/nntrainer/src/pooling2d_layer.cpp
@@ -169,6 +169,8 @@ int Pooling2DLayer::setSize(int *size, PropertyType type) {
 }
 
 void Pooling2DLayer::copy(std::shared_ptr<Layer> l) {
+  Layer::copy(l);
+
   std::shared_ptr<Pooling2DLayer> from =
     std::static_pointer_cast<Pooling2DLayer>(l);
 
@@ -179,11 +181,6 @@ void Pooling2DLayer::copy(std::shared_ptr<Layer> l) {
     this->stride[i] = from->stride[i];
     this->padding[i] = from->padding[i];
   }
-
-  this->input.copy(from->input);
-  this->hidden.copy(from->hidden);
-  this->input_dim = from->input_dim;
-  this->output_dim = from->output_dim;
 }
 
 void Pooling2DLayer::setProperty(const PropertyType type,

--- a/nntrainer/src/sgd.cpp
+++ b/nntrainer/src/sgd.cpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file	sgd.cpp
+ * @date	6 October 2020
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is the SGD optimizer.
+ */
+
+#include <sgd.h>
+
+namespace nntrainer {
+
+void SGD::apply_gradient(Weight &weight, int tensor_idx, double updated_lr,
+                         int iteration) {
+  Tensor &x = weight.getVariableRef();
+  const Tensor &x_grad = weight.getGradientRef();
+  x.add_i(x_grad, -updated_lr);
+}
+
+} // namespace nntrainer

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -338,6 +338,9 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/nntrainer-api-common.h
 %{_includedir}/nntrainer/blas_interface.h
 %{_includedir}/nntrainer/weight.h
+%{_includedir}/nntrainer/adam.h
+%{_includedir}/nntrainer/sgd.h
+%{_includedir}/nntrainer/optimizer_factory.h
 %{_libdir}/pkgconfig/nntrainer.pc
 
 %files devel-static

--- a/test/unittest/unittest_nntrainer_internal.cpp
+++ b/test/unittest/unittest_nntrainer_internal.cpp
@@ -20,13 +20,16 @@
  * @author      Jijoong Moon <jijoong.moon@samsung.com>
  * @bug         No known bugs
  */
-#include "databuffer_file.h"
-#include "databuffer_func.h"
-#include "neuralnet.h"
-#include "nntrainer_test_util.h"
-#include "util_func.h"
 #include <fstream>
+
+#include <databuffer_file.h>
+#include <databuffer_func.h>
+#include <neuralnet.h>
 #include <nntrainer_error.h>
+#include <optimizer_factory.h>
+#include <util_func.h>
+
+#include <nntrainer_test_util.h>
 
 /**
  * @brief Neural Network Model initialization
@@ -196,54 +199,28 @@ TEST(nntrainer_NeuralNetwork, init_03_p) {
 }
 
 /**
- * @brief Optimizer set type
+ * @brief Optimizer create
  */
-TEST(nntrainer_Optimizer, setType_01_p) {
-  int status = ML_ERROR_NONE;
-  nntrainer::Optimizer op;
-  nntrainer::OptType t = nntrainer::OptType::adam;
-  status = op.setType(t);
-  EXPECT_EQ(status, ML_ERROR_NONE);
+TEST(nntrainer_Optimizer, create_01_p) {
+  std::shared_ptr<nntrainer::Optimizer> op;
+  EXPECT_NO_THROW(op = createOptimizer(nntrainer::OptType::adam));
 }
 
 /**
- * @brief Optimizer set type
+ * @brief Optimizer create
  */
 TEST(nntrainer_Optimizer, setType_02_p) {
-  int status = ML_ERROR_NONE;
-  nntrainer::Optimizer op;
-  nntrainer::OptType t = nntrainer::OptType::sgd;
-  status = op.setType(t);
-  EXPECT_EQ(status, ML_ERROR_NONE);
+  std::shared_ptr<nntrainer::Optimizer> op;
+  EXPECT_NO_THROW(op = createOptimizer(nntrainer::OptType::sgd));
 }
 
 /**
- * @brief Optimizer set type
+ * @brief Optimizer create
  */
 TEST(nntrainer_Optimizer, setType_03_n) {
-  int status = ML_ERROR_NONE;
-  nntrainer::Optimizer op;
-  nntrainer::OptType t = nntrainer::OptType::unknown;
-  status = op.setType(t);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-}
-
-/**
- * @brief Optimizer set Opt Param
- */
-TEST(nntrainer_Optimizer, setOptParam_01_p) {
-  int status = ML_ERROR_NONE;
-  nntrainer::Optimizer op;
-  nntrainer::OptType t = nntrainer::OptType::adam;
-  nntrainer::OptParam p;
-  status = op.setType(t);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-  p.learning_rate = -0.001;
-  p.beta1 = 0.9;
-  p.beta2 = 0.9999;
-  p.epsilon = 1e-7;
-  status = op.setOptParam(p);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  std::shared_ptr<nntrainer::Optimizer> op;
+  EXPECT_THROW(op = createOptimizer(nntrainer::OptType::unknown),
+               std::invalid_argument);
 }
 
 /**

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -23,7 +23,7 @@
 #include <loss_layer.h>
 #include <nntrainer_error.h>
 #include <nntrainer_test_util.h>
-#include <optimizer.h>
+#include <optimizer_factory.h>
 #include <pooling2d_layer.h>
 #include <tensor_dim.h>
 #include <util_func.h>
@@ -134,10 +134,10 @@ protected:
       input_str.push_back((*i).str());
     }
 
-    nntrainer::Optimizer op;
-    int status = op.setType(type);
-    EXPECT_EQ(status, ML_ERROR_NONE);
-    status = op.setProperty(input_str);
+    std::shared_ptr<nntrainer::Optimizer> op;
+    EXPECT_NO_THROW(op = createOptimizer(type));
+
+    status = op->setProperty(input_str);
     EXPECT_EQ(status, ML_ERROR_NONE);
     status = layer.setOptimizer(op);
     EXPECT_EQ(status, ML_ERROR_NONE);
@@ -1288,18 +1288,16 @@ TEST_F(nntrainer_Conv2DLayer, backwarding_03_p) {
   status = layer2.initialize();
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  nntrainer::Optimizer op;
-  int status = op.setType(nntrainer::OptType::sgd);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-  status = op.setProperty({"learning_rate=1.0"});
+  std::shared_ptr<nntrainer::Optimizer> op;
+  EXPECT_NO_THROW(op = createOptimizer(nntrainer::OptType::sgd));
+  status = op->setProperty({"learning_rate=1.0"});
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = layer1.setOptimizer(op);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  nntrainer::Optimizer op2;
-  status = op2.setType(nntrainer::OptType::sgd);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-  status = op2.setProperty({"learning_rate=1.0"});
+  std::shared_ptr<nntrainer::Optimizer> op2;
+  EXPECT_NO_THROW(op2 = createOptimizer(nntrainer::OptType::sgd));
+  status = op2->setProperty({"learning_rate=1.0"});
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = layer2.setOptimizer(op2);
   EXPECT_EQ(status, ML_ERROR_NONE);


### PR DESCRIPTION
This patch refactors optimizer in the following fashion:
- split optimizer implementations of different types to derived classes of adam and sgd
- create a optimizer_factory to create the optimizer class objs based on its type
  - this can be directly used with ccapi
- OptParam struct has been removed
- applyGradients has been broken down into different methods
- updated associated unittests

In a future PR, I will create subfolders in src/include to manage files better.

See also #199

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>