### PR TITLE
[CS] Add cutoff logic through accuracy

### DIFF
--- a/Applications/Tizen_native/CustomShortcut/inc/data.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/data.h
@@ -38,6 +38,12 @@
 #define FEATURE_SIZE 62720
 #define NUM_CLASS 2
 
+#define CUT_OFF_THRESHOLD 0.85
+
+#define EMOJI_SAD "😢"
+#define EMOJI_SMILE "😊"
+#define EMOJI_UNKNOWN "❓"
+
 typedef enum MODE_ {
   MODE_INFER = 0,
   MODE_TRAIN,
@@ -80,6 +86,7 @@ typedef struct appdata {
   char pipe_dst[PATH_MAX];      /**< destination path where to save */
   pthread_mutex_t pipe_lock; /**< ensures that only one pipe runs at a time */
   pthread_cond_t pipe_cond;  /**< pipe condition to block at a point */
+  float probability;         /**< softmax label result of the inference */
 
   /**< Training related */
   pthread_t tid_writer;       /**< thread handler to run trainer */

--- a/Applications/Tizen_native/CustomShortcut/inc/data.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/data.h
@@ -82,11 +82,12 @@ typedef struct appdata {
   pthread_cond_t pipe_cond;  /**< pipe condition to block at a point */
 
   /**< Training related */
-  pthread_t tid_writer;         /**< thread handler to run trainer */
-  pthread_t tid_reader;         /**< thread handler to read train result */
-  int pipe_fd[2];               /**< fd for pipe */
-  Ecore_Pipe *data_output_pipe; /**< pipe to write information to ui */
-  double best_accuracy;         /**< stores best accuracy */
+  pthread_t tid_writer;       /**< thread handler to run trainer */
+  pthread_t tid_reader;       /**< thread handler to read train result */
+  int pipe_fd[2];             /**< fd for pipe */
+  double best_accuracy;       /**< stores best accuracy */
+  unsigned int current_epoch; /**< current epoch */
+  double train_loss;          /**< current loss */
 } appdata_s;
 
 typedef struct train_result {
@@ -173,9 +174,10 @@ void *data_run_model(void *ad);
  * @brief nntrainer update train result from data_run_model
  *
  * @param[in] ad appdata
- * @return not used
+ * @param[in] buf buffer hooked from stdout
+ * @return APP_ERROR_NONE if suceess
  */
-void *data_update_train_result(void *ad);
+int data_update_train_progress(appdata_s *ad, const char *buf);
 
 /**
  * @brief parse result string
@@ -190,7 +192,7 @@ void *data_update_train_result(void *ad);
  * #10/10 - Training Loss: 0.398767 >> [ Accuracy: 75% - Validation Loss :
  0.467543 ]
  */
-int data_parse_result_string(const char *src, train_result_s *train_result);
+int util_parse_result_string(const char *src, train_result_s *train_result);
 
 /**
  * @brief run inference with nnstreamer

--- a/Applications/Tizen_native/CustomShortcut/inc/view.h
+++ b/Applications/Tizen_native/CustomShortcut/inc/view.h
@@ -31,7 +31,7 @@ int view_init(appdata_s *ad);
  * @param[in] ad appdata
  * @param[in] to pop until to is meet, if NULL pops only one time
  */
-void view_pop_naviframe(appdata_s *ad, const Elm_Object_Item *to);
+void view_pop_naviframe(appdata_s *ad, Elm_Object_Item *to);
 
 /**
  * @brief initiate canvas
@@ -57,17 +57,15 @@ void view_set_canvas_clean(appdata_s *ad);
 
 /**
  * @brief callback function to update training result
- * @param[in] data user data
- * @param[in] buffer arrays of null terminated characters
- * @param[in] nbytes max length of the buffer
+ * @param[in] data appdata
+ * @return Not used
  */
-void view_update_result_cb(void *data, void *buffer, unsigned int nbytes);
+void *view_update_train_progress(void *data);
 
 /**
  * @brief update guess from the inference result
  *
  * @param[in] ad appdata
- * @return int APP_ERROR_NONE if success
  */
 void view_update_guess(void *ad);
 

--- a/Applications/Tizen_native/CustomShortcut/res/model.ini
+++ b/Applications/Tizen_native/CustomShortcut/res/model.ini
@@ -4,7 +4,7 @@ Type = NeuralNetwork	# Model Type : Regression, KNN, NeuralNetwork
 Learning_rate = 0.0001 	# Learning Rate
 Decay_rate = 0.96	# for the decay_rate for the decayed learning rate
 Decay_steps = 1000       # decay step for the exponential decayed learning rate
-Epochs = 30 		# Epoch
+Epochs = 40 		# Epoch
 Optimizer = adam 	# Optimizer : sgd (stochastic gradien decent),
  	    		#             adam (Adamtive Moment Estimation)
 loss = cross  		# Cost(loss) function : mse (mean squared error)

--- a/Applications/Tizen_native/CustomShortcut/src/data.c
+++ b/Applications/Tizen_native/CustomShortcut/src/data.c
@@ -165,13 +165,13 @@ int util_get_emoji(LABEL label, char **emoji_str) {
   /// setting draw label and text
   switch (label) {
   case LABEL_UNSET:
-    strcpy(*emoji_str, "❓");
+    strcpy(*emoji_str, EMOJI_UNKNOWN);
     return APP_ERROR_NONE;
   case LABEL_SMILE:
-    strcpy(*emoji_str, "😊");
+    strcpy(*emoji_str, EMOJI_SMILE);
     return APP_ERROR_NONE;
   case LABEL_FROWN:
-    strcpy(*emoji_str, "😢");
+    strcpy(*emoji_str, EMOJI_SAD);
     return APP_ERROR_NONE;
   default:
     LOG_E("unreachable code");
@@ -599,6 +599,8 @@ static void on_inference_end_(ml_tensors_data_h data,
   /// SMILE: 0 1
   /// FROWN: 1 0
   LOG_D("\033[33mlabel: %lf %lf\033[0m", raw_data[0], raw_data[1]);
+
+  ad->probability = raw_data[0] < raw_data[1] ? raw_data[1] : raw_data[0];
   ad->label = raw_data[0] < raw_data[1] ? LABEL_SMILE : LABEL_FROWN;
 
 RESUME:

--- a/Applications/Tizen_native/CustomShortcut/src/view.c
+++ b/Applications/Tizen_native/CustomShortcut/src/view.c
@@ -353,6 +353,8 @@ void *view_update_train_progress(void *data) {
 void view_update_guess(void *data) {
   appdata_s *ad = (appdata_s *)data;
   char *emoji;
+  char title[PATH_MAX];
+  char result[PATH_MAX];
   int status = util_get_emoji(ad->label, &emoji);
   if (status != APP_ERROR_NONE) {
     LOG_E("error getting emoji, reason: %d", status);
@@ -360,12 +362,16 @@ void view_update_guess(void *data) {
   }
 
   LOG_I("\033[33m%s\033[0m", emoji);
-  elm_object_part_text_set(ad->layout, "test_result/title",
-                           "guess successfully done");
+  snprintf(title, PATH_MAX, "acc: %lf", ad->probability);
+  elm_object_part_text_set(ad->layout, "test_result/title", title);
+
   elm_config_font_overlay_set("test_result/label/class", "Tizen:style=Regular",
                               -150);
   elm_config_font_overlay_apply();
-  elm_object_part_text_set(ad->layout, "test_result/label", emoji);
+
+  snprintf(result, PATH_MAX, "%s%s", emoji,
+           ad->probability < CUT_OFF_THRESHOLD ? "?" : "");
+  elm_object_part_text_set(ad->layout, "test_result/label", result);
   free(emoji);
 
   return;


### PR DESCRIPTION
commit 1 minor retouch:.
- Ecore Pipe is no longer used to update UI
- Broaden the canvas to make it easier to draw
- s/tries/epoch for training progress
- Minor bug fix that was generating warnings


commit 2. Add cutoff logic

**Changes proposed in this PR:**
- Add more epochs
- Add cutoff logic to check if the guess is confident

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>