### PR TITLE
[NN] call setBatchSize at init

### DIFF
--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -249,6 +249,7 @@ int NeuralNetwork::init() {
     ml_logd("layer name: %s", l->getName().c_str());
 
   initialized = true;
+  setBatchSize(batch_size);
   return status;
 }
 


### PR DESCRIPTION
setBatchSize is not called at init which cause a problem when calling
layers from outside.
This fixes the issue

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
