### PR TITLE
[ TENSOR ] Change to get Tensor Vector

### DIFF
--- a/Applications/LogisticRegression/jni/main.cpp
+++ b/Applications/LogisticRegression/jni/main.cpp
@@ -215,9 +215,10 @@ int main(int argc, char *argv[]) {
       getData(dataFile, o, l, j);
 
       try {
-        float answer = NN.forwarding(MAKE_SHARED_TENSOR(nntrainer::Tensor({o})))
-                         ->apply(stepFunction)
-                         .getValue(0, 0, 0, 0);
+        float answer =
+          NN.forwarding({MAKE_SHARED_TENSOR(nntrainer::Tensor({o}))})[0]
+            ->apply(stepFunction)
+            .getValue(0, 0, 0, 0);
         std::cout << answer << " : " << l[0] << std::endl;
         cn += answer == l[0];
       } catch (...) {

--- a/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
+++ b/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
@@ -341,7 +341,7 @@ int main(int argc, char **argv) {
           return 0;
         }
         try {
-          test = mainNet.forwarding(MAKE_SHARED_TENSOR(in_tensor));
+          test = mainNet.forwarding({MAKE_SHARED_TENSOR(in_tensor)})[0];
         } catch (...) {
           std::cerr << "Error while forwarding the network" << std::endl;
           return 0;
@@ -448,7 +448,7 @@ int main(int argc, char **argv) {
          */
         nntrainer::sharedConstTensor Q;
         try {
-          Q = mainNet.forwarding(MAKE_SHARED_TENSOR(q_in));
+          Q = mainNet.forwarding({MAKE_SHARED_TENSOR(q_in)})[0];
         } catch (...) {
           std::cerr << "Error during forwarding main network" << std::endl;
           return -1;
@@ -459,7 +459,7 @@ int main(int argc, char **argv) {
          */
         nntrainer::sharedConstTensor NQ;
         try {
-          NQ = targetNet.forwarding(MAKE_SHARED_TENSOR(nq_in));
+          NQ = targetNet.forwarding({MAKE_SHARED_TENSOR(nq_in)})[0];
         } catch (...) {
           std::cerr << "Error during forwarding target network" << std::endl;
           return -1;
@@ -495,7 +495,7 @@ int main(int argc, char **argv) {
         nntrainer::Tensor in_tensor;
         try {
           in_tensor = nntrainer::Tensor(inbatch);
-          mainNet.backwarding(MAKE_SHARED_TENSOR(in_tensor), Q, iter);
+          mainNet.backwarding({MAKE_SHARED_TENSOR(in_tensor)}, {Q}, iter);
         } catch (...) {
           std::cerr << "Error during backwarding the network" << std::endl;
           return -1;

--- a/Applications/TransferLearning/CIFAR_Classification/jni/main.cpp
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/main.cpp
@@ -435,7 +435,7 @@ int main(int argc, char *argv[]) {
     nntrainer::Tensor X;
     try {
       X = nntrainer::Tensor({featureVector});
-      NN.forwarding(MAKE_SHARED_TENSOR(X))->apply(stepFunction);
+      NN.forwarding({MAKE_SHARED_TENSOR(X)})[0]->apply(stepFunction);
     } catch (...) {
       std::cerr << "Error while forwarding the model" << std::endl;
       return 0;

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -183,7 +183,7 @@ int NNTrainer::run(const GstTensorMemory *input, GstTensorMemory *output) {
   std::shared_ptr<const nntrainer::Tensor> o;
 
   try {
-    o = model->inference(X);
+    o = model->inference({MAKE_SHARED_TENSOR(X)})[0];
   } catch (std::exception &e) {
     ml_loge("%s %s", typeid(e).name(), e.what());
     return -2;

--- a/nntrainer/include/activation_layer.h
+++ b/nntrainer/include/activation_layer.h
@@ -62,14 +62,14 @@ public:
   void save(std::ofstream &file){/* noop */};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensors in)
    */
-  sharedConstTensor forwarding(sharedConstTensor in);
+  sharedConstTensors forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
    */
-  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
+  sharedConstTensors backwarding(sharedConstTensors in, int iteration);
 
   /**
    * @brief setActivation by preset ActivationType

--- a/nntrainer/include/addition_layer.h
+++ b/nntrainer/include/addition_layer.h
@@ -73,14 +73,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensors in)
    */
-  sharedConstTensor forwarding(sharedConstTensor in);
+  sharedConstTensors forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
    */
-  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
+  sharedConstTensors backwarding(sharedConstTensors in, int iteration);
 
   /**
    * @brief     get the base name for the layer

--- a/nntrainer/include/bn_layer.h
+++ b/nntrainer/include/bn_layer.h
@@ -78,14 +78,14 @@ public:
   BatchNormalizationLayer &operator=(BatchNormalizationLayer &&rhs) = default;
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensors in)
    */
-  sharedConstTensor forwarding(sharedConstTensor in);
+  sharedConstTensors forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
    */
-  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
+  sharedConstTensors backwarding(sharedConstTensors in, int iteration);
 
   /**
    * @brief     copy layer

--- a/nntrainer/include/conv2d_layer.h
+++ b/nntrainer/include/conv2d_layer.h
@@ -83,14 +83,14 @@ public:
   void save(std::ofstream &file);
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensors in)
    */
-  sharedConstTensor forwarding(sharedConstTensor in);
+  sharedConstTensors forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
    */
-  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
+  sharedConstTensors backwarding(sharedConstTensors in, int iteration);
 
   /**
    * @brief     copy layer

--- a/nntrainer/include/fc_layer.h
+++ b/nntrainer/include/fc_layer.h
@@ -64,14 +64,14 @@ public:
   void save(std::ofstream &file);
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensors in)
    */
-  sharedConstTensor forwarding(sharedConstTensor in);
+  sharedConstTensors forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
    */
-  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
+  sharedConstTensors backwarding(sharedConstTensors in, int iteration);
 
   /**
    * @brief     copy layer

--- a/nntrainer/include/flatten_layer.h
+++ b/nntrainer/include/flatten_layer.h
@@ -69,14 +69,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensors in)
    */
-  sharedConstTensor forwarding(sharedConstTensor in);
+  sharedConstTensors forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
    */
-  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
+  sharedConstTensors backwarding(sharedConstTensors in, int iteration);
 
   /**
    * @brief     get the base name for the layer

--- a/nntrainer/include/input_layer.h
+++ b/nntrainer/include/input_layer.h
@@ -73,14 +73,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensors in)
    */
-  sharedConstTensor forwarding(sharedConstTensor in);
+  sharedConstTensors forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
    */
-  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
+  sharedConstTensors backwarding(sharedConstTensors in, int iteration);
 
   /**
    * @brief     Initializer of Input Layer

--- a/nntrainer/include/layer_internal.h
+++ b/nntrainer/include/layer_internal.h
@@ -102,7 +102,7 @@ public:
    * @param[in] in List of Input Tensors taken by this layer
    * @retval    List of Output Tensors
    */
-  virtual sharedConstTensor forwarding(sharedConstTensor in) = 0;
+  virtual sharedConstTensors forwarding(sharedConstTensors in) = 0;
 
   /**
    * @brief     Back Propagation of a layer
@@ -110,8 +110,8 @@ public:
    * @param[in] iteration Iteration value for the Optimizer
    * @retval    Derivative List of Tensor for the previous layer
    */
-  virtual sharedConstTensor backwarding(sharedConstTensor in,
-                                        int iteration) = 0;
+  virtual sharedConstTensors backwarding(sharedConstTensors in,
+                                         int iteration) = 0;
 
   /**
    * @brief     read layer Weight & Bias data from file

--- a/nntrainer/include/loss_layer.h
+++ b/nntrainer/include/loss_layer.h
@@ -53,9 +53,9 @@ public:
   ~LossLayer(){};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensors in)
    */
-  sharedConstTensor forwarding(sharedConstTensor in);
+  sharedConstTensors forwarding(sharedConstTensors in);
 
   /**
    * @brief     Forward Propagation of a layer
@@ -63,12 +63,13 @@ public:
    * @param[in] label List of Label Tensors for the model
    * @retval    List of Input Tensors as it is.
    */
-  sharedConstTensor forwarding(sharedConstTensor in, sharedConstTensor label);
+  sharedConstTensors forwarding(sharedConstTensors in,
+                                sharedConstTensors label);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
    */
-  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
+  sharedConstTensors backwarding(sharedConstTensors in, int iteration);
 
   /**
    * @brief     read layer Weight & Bias data from file

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -149,7 +149,7 @@ public:
    * @param[in] input List of Input Tensors taken by the neural network
    * @retval    List of Output Tensors
    */
-  sharedConstTensor forwarding(sharedConstTensor input);
+  sharedConstTensors forwarding(sharedConstTensors input);
 
   /**
    * @brief     Forward Propagation of the neural network
@@ -157,8 +157,8 @@ public:
    * @param[in] label List of Label Tensors for the model
    * @retval    List of Output Tensors
    */
-  sharedConstTensor forwarding(sharedConstTensor input,
-                               sharedConstTensor label);
+  sharedConstTensors forwarding(sharedConstTensors input,
+                                sharedConstTensors label);
 
   /**
    * @brief     Backward Propagation of the neural network
@@ -166,7 +166,7 @@ public:
    * @param[in] label List of Label Tensors for the model
    * @param[in] iteration Iteration Number for the optimizer
    */
-  void backwarding(sharedConstTensor input, sharedConstTensor label,
+  void backwarding(sharedConstTensors input, sharedConstTensors label,
                    int iteration);
 
   /**
@@ -205,7 +205,7 @@ public:
    * @param[in] X input tensor
    * @retval shared_ptr<const Tensor>
    */
-  sharedConstTensor inference(const Tensor X);
+  sharedConstTensors inference(sharedConstTensors X);
 
   /**
    * @brief     Run NeuralNetwork train with callback function by user

--- a/nntrainer/include/pooling2d_layer.h
+++ b/nntrainer/include/pooling2d_layer.h
@@ -90,14 +90,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensor in)
+   * @copydoc Layer::forwarding(sharedConstTensors in)
    */
-  sharedConstTensor forwarding(sharedConstTensor in);
+  sharedConstTensors forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensor in, int iteration)
+   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
    */
-  sharedConstTensor backwarding(sharedConstTensor in, int iteration);
+  sharedConstTensors backwarding(sharedConstTensors in, int iteration);
 
   /**
    * @copydoc Layer::setBatch(unsigned int batch)

--- a/nntrainer/include/tensor.h
+++ b/nntrainer/include/tensor.h
@@ -629,6 +629,10 @@ typedef std::shared_ptr<Tensor> sharedTensor;
 
 typedef std::shared_ptr<const Tensor> sharedConstTensor;
 
+typedef std::vector<sharedConstTensor> sharedConstTensors;
+
+typedef std::vector<sharedTensor> sharedTensors;
+
 } /* namespace nntrainer */
 
 #endif /* __cplusplus */

--- a/nntrainer/src/activation_layer.cpp
+++ b/nntrainer/src/activation_layer.cpp
@@ -44,24 +44,24 @@ int ActivationLayer::initialize() {
   return ML_ERROR_NONE;
 }
 
-sharedConstTensor ActivationLayer::forwarding(sharedConstTensor in) {
-  input = *in;
+sharedConstTensors ActivationLayer::forwarding(sharedConstTensors in) {
+  input = *in[0];
   /// @note @a _act_fn is expected to work out of place and not modify @a input
   hidden = _act_fn(input);
 
-  return MAKE_SHARED_TENSOR(hidden);
+  return {MAKE_SHARED_TENSOR(hidden)};
 }
 
-sharedConstTensor ActivationLayer::backwarding(sharedConstTensor derivative,
-                                               int iteration) {
-  Tensor deriv = *derivative;
+sharedConstTensors ActivationLayer::backwarding(sharedConstTensors derivative,
+                                                int iteration) {
+  Tensor deriv = *derivative[0];
   Tensor ret;
   if (activation_type == ActivationType::ACT_SOFTMAX)
     ret = _act_prime_fn(hidden, deriv);
   else
     ret = _act_prime_fn(input, deriv);
 
-  return MAKE_SHARED_TENSOR(std::move(ret));
+  return {MAKE_SHARED_TENSOR(std::move(ret))};
 }
 
 int ActivationLayer::setActivation(

--- a/nntrainer/src/addition_layer.cpp
+++ b/nntrainer/src/addition_layer.cpp
@@ -37,31 +37,31 @@ int AdditionLayer::initialize() {
   return status;
 }
 
-sharedConstTensor AdditionLayer::forwarding(sharedConstTensor in) {
+sharedConstTensors AdditionLayer::forwarding(sharedConstTensors in) {
   hidden = Tensor(input_dim);
   hidden.setZero();
 
   for (unsigned int idx = 0; idx < num_inputs; ++idx) {
-    if (input_dim != in.get()[idx].getDim())
+    if (input_dim != in[0].get()[idx].getDim())
       throw std::runtime_error("Error: addition layer requires same "
                                "shape from all input layers");
-    hidden.add_i(in.get()[idx]);
+    hidden.add_i(in[0].get()[idx]);
   }
 
-  return MAKE_SHARED_TENSOR(hidden);
+  return {MAKE_SHARED_TENSOR(hidden)};
 }
 
-sharedConstTensor AdditionLayer::backwarding(sharedConstTensor derivative,
-                                             int iteration) {
+sharedConstTensors AdditionLayer::backwarding(sharedConstTensors derivative,
+                                              int iteration) {
   sharedTensor ret = std::shared_ptr<Tensor>(new Tensor[num_inputs],
                                              std::default_delete<Tensor[]>());
 
   for (unsigned int idx = 0; idx < num_inputs; ++idx) {
     Tensor &t = ret.get()[idx];
-    t = *derivative;
+    t = *derivative[0];
   }
 
-  return ret;
+  return {ret};
 }
 
 void AdditionLayer::setProperty(const PropertyType type,

--- a/nntrainer/src/bn_layer.cpp
+++ b/nntrainer/src/bn_layer.cpp
@@ -114,13 +114,13 @@ void BatchNormalizationLayer::setProperty(const PropertyType type,
   }
 }
 
-sharedConstTensor BatchNormalizationLayer::forwarding(sharedConstTensor in) {
+sharedConstTensors BatchNormalizationLayer::forwarding(sharedConstTensors in) {
   Tensor &mu = weightAt(static_cast<int>(BNParams::mu)).getVariableRef();
   Tensor &var = weightAt(static_cast<int>(BNParams::var)).getVariableRef();
   Tensor &gamma = weightAt(static_cast<int>(BNParams::gamma)).getVariableRef();
   Tensor &beta = weightAt(static_cast<int>(BNParams::beta)).getVariableRef();
 
-  input = *in;
+  input = *in[0];
   /// @todo change trainable #524
   if (trainable) {
     Tensor cmu = input.average(axes_to_reduce);
@@ -145,18 +145,18 @@ sharedConstTensor BatchNormalizationLayer::forwarding(sharedConstTensor in) {
     this->hidden.add(beta);
   }
 
-  return MAKE_SHARED_TENSOR(hidden);
+  return {MAKE_SHARED_TENSOR(hidden)};
 }
 
-sharedConstTensor
-BatchNormalizationLayer::backwarding(sharedConstTensor derivative,
+sharedConstTensors
+BatchNormalizationLayer::backwarding(sharedConstTensors derivative,
                                      int iteration) {
   Tensor &gamma = weightAt(static_cast<int>(BNParams::gamma)).getVariableRef();
   Tensor &dgamma = weightAt(static_cast<int>(BNParams::gamma)).getGradientRef();
   Tensor &dbeta = weightAt(static_cast<int>(BNParams::beta)).getGradientRef();
   Tensor dx_normalized;
 
-  Tensor deriv = *derivative;
+  Tensor deriv = *derivative[0];
 
   int N = 1;
 
@@ -178,7 +178,7 @@ BatchNormalizationLayer::backwarding(sharedConstTensor derivative,
 
   opt->apply_gradients(weight_list, num_weights, iteration);
 
-  return MAKE_SHARED_TENSOR(std::move(dx));
+  return {MAKE_SHARED_TENSOR(std::move(dx))};
 }
 
 void BatchNormalizationLayer::copy(std::shared_ptr<Layer> l) {

--- a/nntrainer/src/conv2d_layer.cpp
+++ b/nntrainer/src/conv2d_layer.cpp
@@ -64,9 +64,9 @@ void Conv2DLayer::read(std::ifstream &file) { Layer::read(file); }
 
 void Conv2DLayer::save(std::ofstream &file) { Layer::save(file); }
 
-sharedConstTensor Conv2DLayer::forwarding(sharedConstTensor in) {
+sharedConstTensors Conv2DLayer::forwarding(sharedConstTensors in) {
   int status = ML_ERROR_NONE;
-  input = *in;
+  input = *in[0];
 
   if (normalization) {
     input = input.normalization();
@@ -161,13 +161,14 @@ sharedConstTensor Conv2DLayer::forwarding(sharedConstTensor in) {
     loss /= filter_size;
   }
 
-  return MAKE_SHARED_TENSOR(hidden);
+  return {MAKE_SHARED_TENSOR(hidden)};
 };
 
-sharedConstTensor Conv2DLayer::backwarding(sharedConstTensor derivative,
-                                           int iteration) {
+sharedConstTensors Conv2DLayer::backwarding(sharedConstTensors derivatives,
+                                            int iteration) {
 
   std::array<unsigned int, CONV2D_DIM> same_pad;
+  sharedConstTensor derivative = derivatives[0];
 
   same_pad[0] = kernel_size[0] - 1;
   same_pad[1] = kernel_size[1] - 1;
@@ -351,7 +352,7 @@ sharedConstTensor Conv2DLayer::backwarding(sharedConstTensor derivative,
     opt->apply_gradients(weight_list, num_weights, iteration);
   }
 
-  return MAKE_SHARED_TENSOR(std::move(strip_pad(ret, padding.data())));
+  return {MAKE_SHARED_TENSOR(std::move(strip_pad(ret, padding.data())))};
 }
 
 void Conv2DLayer::copy(std::shared_ptr<Layer> l) {

--- a/nntrainer/src/flatten_layer.cpp
+++ b/nntrainer/src/flatten_layer.cpp
@@ -34,21 +34,21 @@ int FlattenLayer::initialize() {
   return status;
 }
 
-sharedConstTensor FlattenLayer::forwarding(sharedConstTensor in) {
-  input = *in;
+sharedConstTensors FlattenLayer::forwarding(sharedConstTensors in) {
+  input = *in[0];
   hidden = input;
 
   hidden.reshape(output_dim);
 
-  return MAKE_SHARED_TENSOR(hidden);
+  return {MAKE_SHARED_TENSOR(hidden)};
 }
 
-sharedConstTensor FlattenLayer::backwarding(sharedConstTensor in,
-                                            int iteration) {
-  Tensor temp = *in;
+sharedConstTensors FlattenLayer::backwarding(sharedConstTensors in,
+                                             int iteration) {
+  Tensor temp = *in[0];
   temp.reshape(input_dim);
 
-  return MAKE_SHARED_TENSOR(std::move(temp));
+  return {MAKE_SHARED_TENSOR(std::move(temp))};
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/src/input_layer.cpp
+++ b/nntrainer/src/input_layer.cpp
@@ -51,8 +51,8 @@ void InputLayer::setProperty(const PropertyType type,
   }
 }
 
-sharedConstTensor InputLayer::forwarding(sharedConstTensor in) {
-  input = *in;
+sharedConstTensors InputLayer::forwarding(sharedConstTensors in) {
+  input = *in[0];
 
   hidden = input;
   if (normalization)
@@ -60,10 +60,11 @@ sharedConstTensor InputLayer::forwarding(sharedConstTensor in) {
   if (standardization)
     hidden = hidden.standardization();
 
-  return MAKE_SHARED_TENSOR(hidden);
+  return {MAKE_SHARED_TENSOR(hidden)};
 }
 
-sharedConstTensor InputLayer::backwarding(sharedConstTensor in, int iteration) {
+sharedConstTensors InputLayer::backwarding(sharedConstTensors in,
+                                           int iteration) {
   return in;
 }
 

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -211,7 +211,7 @@ NodeWatcher::forward(nntrainer::sharedConstTensor in, int iteration) {
   std::string err_msg = ss.str();
 
   verify(*in, expected_input, err_msg + " at input ");
-  nntrainer::sharedConstTensor out = node->forwarding(in);
+  nntrainer::sharedConstTensor out = node->forwarding({in})[0];
   verify(*out, expected_output, err_msg + " at output ");
   return out;
 }
@@ -224,8 +224,8 @@ NodeWatcher::lossForward(nntrainer::sharedConstTensor pred,
   std::string err_msg = ss.str();
 
   nntrainer::sharedConstTensor out =
-    std::static_pointer_cast<nntrainer::LossLayer>(node)->forwarding(pred,
-                                                                     answer);
+    std::static_pointer_cast<nntrainer::LossLayer>(node)->forwarding(
+      {pred}, {answer})[0];
 
   return out;
 }
@@ -238,7 +238,7 @@ NodeWatcher::backward(nntrainer::sharedConstTensor deriv, int iteration,
      << iteration;
   std::string err_msg = ss.str();
 
-  nntrainer::sharedConstTensor out = node->backwarding(deriv, iteration);
+  nntrainer::sharedConstTensor out = node->backwarding({deriv}, iteration)[0];
 
   if (should_verify) {
     verify(*out, expected_dx, err_msg);


### PR DESCRIPTION
Currently we only take and push one tensor per layer. For the skip
connection or other layer which takes and make multiple tensors, we
need to handle tensors as an input and output of layer.

In this PR, tensor input chaneged to tensor vector.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>