### PR TITLE
[optimizer] private ownership of optimizer in layer

### DIFF
--- a/nntrainer/include/layer_internal.h
+++ b/nntrainer/include/layer_internal.h
@@ -321,8 +321,7 @@ protected:
   /**
    * @brief     Optimizer for this layer
    */
-  // TODO: fix with #630
-  std::shared_ptr<Optimizer> opt;
+  std::unique_ptr<Optimizer> opt;
 
   /**
    * @brief     Layer type

--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -68,8 +68,7 @@ void Layer::copy(std::shared_ptr<Layer> l) {
     weightAt(i) = l->weightAt(i);
   }
 
-  // TODO: fix this #630
-  this->opt = l->opt;
+  this->opt = createOptimizer(l->opt->getType(), *opt.get());
   this->input_dim = l->input_dim;
   this->output_dim = l->output_dim;
   this->input.copy(l->input);


### PR DESCRIPTION
This patch updates the ownership semantics of optimizer in the layer.
Before this patch, although, each layer creates its own optimizer, yet it was allowed to
be shared with a shared_ptr. With this patch, optimizer is a unique_ptr meaning 
that it is owned by the layer and cannot be shared directly with other objects.
    
    **Self evaluation:**
    1. Build test: [x]Passed [ ]Failed [ ]Skipped
    2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
    Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
