### PR TITLE
[model] Add support of ini based backbone to the model

### DIFF
--- a/nntrainer/include/model_loader.h
+++ b/nntrainer/include/model_loader.h
@@ -45,11 +45,20 @@ public:
 
 private:
   /**
+   * @brief     load all of model from given config file
+   * @param[in] config config file path
+   * @param[in/out] model model to be loaded
+   * @param[in] bare_layers load only the layers as backbone if enabled
+   */
+  int loadFromConfig(std::string config, NeuralNetwork &model,
+                     bool bare_layers);
+
+  /**
    * @brief     load all of model and dataset from ini
    * @param[in] config config file path
    * @param[in/out] model model to be loaded
    */
-  int loadFromIni(std::string ini_file, NeuralNetwork &model);
+  int loadFromIni(std::string ini_file, NeuralNetwork &model, bool bare_layers);
 
   /**
    * @brief     load dataset config from ini
@@ -72,7 +81,17 @@ private:
    * @param[in] layer_name name of the layer to be loaded
    */
   int loadLayerConfigIni(dictionary *ini, std::shared_ptr<Layer> &layer,
-                         std::string layer_name);
+                         const std::string &layer_name);
+
+  /**
+   * @brief     load backbone config from ini
+   * @param[in] backbone_config config file containing the backbone config
+   * @param[in/out] model model to be added the backbone to
+   * @param[in] backbone_name name of the backbone to be loaded
+   */
+  int loadBackboneConfigIni(const std::string &backbone_config,
+                            NeuralNetwork &model,
+                            const std::string &backbone_name);
 
   const char *unknown = "Unknown";
 };

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -243,6 +243,15 @@ public:
   int addLayer(NodeType layer);
 
   /**
+   * @brief     join passed graph into the existing graph model
+   * @param[in] graph graph to be added/to extend
+   * @note It is assumed that this model is valid by itself
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int extendGraph(GraphType graph, std::string prefix = "");
+
+  /**
    * @brief     set optimizer for the neural network model
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
@@ -286,6 +295,14 @@ public:
    * @retval flatGraph of the current graph
    */
   FlatGraphType getFlatGraph() { return layers; }
+
+  /**
+   * @brief get current graph from the model
+   * @note graph contains pointer to the actual nodes, which is not deeply
+   * copied.
+   * @retval current graph
+   */
+  GraphType getGraph() { return layers; }
 
   /**
    * @brief     Set loss type for the neural network.
@@ -424,7 +441,8 @@ private:
   /**
    * @brief     Ensure that layer has a name
    */
-  void ensureName(NodeType layer, const std::string &prefix = "");
+  void ensureName(NodeType layer, const std::string &prefix = "",
+                  bool force_rename = false);
 
   /**
    * @brief     Swap function for the class

--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -245,6 +245,7 @@ public:
   /**
    * @brief     join passed graph into the existing graph model
    * @param[in] graph graph to be added/to extend
+   * @param[in] prefix prefix added to names of layers from this graph
    * @note It is assumed that this model is valid by itself
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.

--- a/nntrainer/src/model_loader.cpp
+++ b/nntrainer/src/model_loader.cpp
@@ -305,8 +305,8 @@ int ModelLoader::loadFromIni(std::string ini_file, NeuralNetwork &model,
      * backbones in the model graph
      */
     const char *backbone =
-      iniparser_getstring(ini, (sec_name + ":Backbone").c_str(), nullptr);
-    if (backbone != nullptr) {
+      iniparser_getstring(ini, (sec_name + ":Backbone").c_str(), unknown);
+    if (backbone != unknown) {
       loadBackboneConfigIni(backbone, model, sec_name);
       continue;
     }

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -575,14 +575,6 @@ int NeuralNetwork::addLayer(NodeType layer) {
     return status;
   }
 
-  /** Ensure that the layer name is unique */
-  auto insert_result = layer_names.insert(layer->getName());
-  if (!insert_result.second) {
-    std::stringstream ss;
-    ss << "Layer with name " << layer->getName() << " already exists";
-    throw std::invalid_argument(ss.str());
-  }
-
   /** Insert the layer to the graph */
   layers.push_back(layer);
 

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -632,7 +632,7 @@ void NeuralNetwork::ensureName(NodeType layer, const std::string &prefix,
   /** If just prefix with layer name makes it unique - directly set the name */
   if (!orig_name_empty) {
     std::string direct_name = prefix + orig_name;
-    if (layer_names.find(direct_name) != layer_names.end()) {
+    if (layer_names.find(direct_name) == layer_names.end()) {
       layer->setName(direct_name);
       return;
     }

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -25,14 +25,15 @@
 #define __NNTRAINER_TEST_UTIL_H__
 #ifdef __cplusplus
 
-#include "nntrainer_log.h"
 #include <fstream>
 #include <gtest/gtest.h>
+#include <unordered_map>
+
 #include <neuralnet.h>
 #include <nntrainer_error.h>
+#include <nntrainer_log.h>
 #include <parse_util.h>
 #include <tensor.h>
-#include <unordered_map>
 
 #define tolerance 10e-5
 
@@ -93,6 +94,10 @@ public:
 
   IniSection operator+(const std::string &s) { return IniSection(*this) += s; }
 
+  void rename(const std::string &name) { section_name = name; }
+
+  std::string getName() { return section_name; }
+
 private:
   void setEntry(const std::unordered_map<std::string, std::string> &_entry) {
     for (auto &it : _entry) {
@@ -151,7 +156,17 @@ public:
    * @return std::ofstream ini file stream
    */
   std::ofstream getIni() {
-    std::ofstream out(getIniName().c_str());
+    return getIni(getIniName().c_str(), std::ios_base::out);
+  }
+
+  /**
+   * @brief Get the Ini object with given mode
+   *
+   * @return std::ofstream ini file stream
+   */
+  static std::ofstream getIni(const char *filename,
+                              std::ios_base::openmode mode) {
+    std::ofstream out(filename, mode);
     if (!out.good()) {
       throw std::runtime_error("cannot open ini");
     }
@@ -160,10 +175,11 @@ public:
 
   /**
    * @brief save ini to a file
-   *
    */
-  void save_ini() {
-    std::ofstream out = getIni();
+  static void save_ini(const char *filename, std::vector<IniSection> sections,
+                       std::ios_base::openmode mode = std::ios_base::out) {
+    std::ofstream out = IniTestWrapper::getIni(filename, mode);
+
     for (auto &it : sections) {
       it.print(std::cout);
       std::cout << std::endl;
@@ -173,6 +189,11 @@ public:
 
     out.close();
   }
+
+  /**
+   * @brief save ini to a file
+   */
+  void save_ini() { save_ini(getIniName().c_str(), sections); }
 
   /**
    * @brief erase ini


### PR DESCRIPTION
This patch adds support of ini based backbone to the model neural network
From the point of view of ini file, backbone is treated as a layer itself.
This allows a graph of layers to be represented as a layer itself in the
ini file.

With this design, backbone must be specified as a layer with property backbone
as shown below with a sample pseudo-ini:
```ini
[Model]
...

[Block1]
backbone: base_block.ini

[PoolLayer]
type: pooling2d

[Block2]
backbone: base_block.ini
```

ModelLoader loads the layer configuration from the backbone independently
and then extends the existing graph in the main model with this newly created
graph from the backbone ini.

The names of all layers which are inserted from the backbone to a model are
prefixed with the name of the backbone for easier management and for the user
to identify/manage the layers from a backbone.

The patch allows nested backbones and multiple backbones in a model description.
~Unittests for this backbone support will follow in the next patch.~
Extensive unittests have also been added.

See also #660

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>