### PR TITLE
[backbone] Add trainable feature to backbone

### DIFF
--- a/nntrainer/include/layer_internal.h
+++ b/nntrainer/include/layer_internal.h
@@ -213,7 +213,13 @@ public:
    * @brief     set trainable for this layer
    * @param[in] train to enable/disable train
    */
-  void setTrainable(bool train) { trainable = train; }
+  void setTrainable(bool train) noexcept { trainable = train; }
+
+  /**
+   * @brief     get trainable for this layer
+   * @retval train to enable/disable train
+   */
+  bool getTrainable() noexcept { return trainable; }
 
   /**
    * @brief     get all weights of the layer

--- a/nntrainer/include/model_loader.h
+++ b/nntrainer/include/model_loader.h
@@ -55,7 +55,7 @@ private:
 
   /**
    * @brief     load all of model and dataset from ini
-   * @param[in] config config file path
+   * @param[in] ini_file config file path
    * @param[in/out] model model to be loaded
    */
   int loadFromIni(std::string ini_file, NeuralNetwork &model, bool bare_layers);
@@ -85,11 +85,12 @@ private:
 
   /**
    * @brief     load backbone config from ini
+   * @param[in] ini dictionary containing the config
    * @param[in] backbone_config config file containing the backbone config
    * @param[in/out] model model to be added the backbone to
    * @param[in] backbone_name name of the backbone to be loaded
    */
-  int loadBackboneConfigIni(const std::string &backbone_config,
+  int loadBackboneConfigIni(dictionary *ini, const std::string &backbone_config,
                             NeuralNetwork &model,
                             const std::string &backbone_name);
 

--- a/nntrainer/src/model_loader.cpp
+++ b/nntrainer/src/model_loader.cpp
@@ -215,14 +215,22 @@ int ModelLoader::loadLayerConfigIni(dictionary *ini,
   return ML_ERROR_NONE;
 }
 
-int ModelLoader::loadBackboneConfigIni(const std::string &backbone_config,
+int ModelLoader::loadBackboneConfigIni(dictionary *ini,
+                                       const std::string &backbone_config,
                                        NeuralNetwork &model,
                                        const std::string &backbone_name) {
   int status = ML_ERROR_NONE;
   NeuralNetwork backbone;
 
+  bool trainable =
+    iniparser_getboolean(ini, (backbone_name + ":trainable").c_str(), false);
+
   status = loadFromConfig(backbone_config, backbone, true);
   NN_RETURN_STATUS();
+
+  auto graph = backbone.getGraph();
+  for (auto &layer : graph)
+    layer->setTrainable(trainable);
 
   status = model.extendGraph(backbone.getGraph(), backbone_name);
   NN_RETURN_STATUS();
@@ -307,7 +315,7 @@ int ModelLoader::loadFromIni(std::string ini_file, NeuralNetwork &model,
     const char *backbone =
       iniparser_getstring(ini, (sec_name + ":Backbone").c_str(), unknown);
     if (backbone != unknown) {
-      loadBackboneConfigIni(backbone, model, sec_name);
+      loadBackboneConfigIni(ini, backbone, model, sec_name);
       continue;
     }
 

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -191,6 +191,12 @@ static IniSection backbone_random("block1", "backbone = random.ini");
 
 static IniSection backbone_valid("block1", "backbone = base.ini");
 
+static IniSection backbone_notrain("blockNT", "backbone = base.ini |"
+                                              "trainable = false");
+
+static IniSection backbone_train("blockT", "backbone = base.ini |"
+                                           "trainable = true");
+
 static int SUCCESS = 0;
 static int LOADFAIL = initest::LOAD;
 static int INITFAIL = initest::INIT;
@@ -397,6 +403,41 @@ TEST(nntrainerIniTest, backbone_p_05) {
               flat_direct[idx]->getActivationType());
     EXPECT_EQ(flat_backbone[idx]->getName(), flat_direct[idx]->getName());
   }
+}
+
+/**
+ * @brief Ini file unittest matching model with and without trainable
+ */
+TEST(nntrainerIniTest, backbone_p_06) {
+  const char *ini_name = "backbone_p6.ini";
+  nntrainerIniTest::save_ini("base.ini", {flatten, conv2d});
+  nntrainerIniTest::save_ini(ini_name, {nw_base, backbone_valid});
+  nntrainer::NeuralNetwork NN;
+
+  EXPECT_EQ(NN.loadFromConfig(ini_name), ML_ERROR_NONE);
+
+  /** default trainable is false */
+  auto graph = NN.getFlatGraph();
+  for (auto &layer : graph)
+    EXPECT_EQ(layer->getTrainable(), false);
+}
+
+/**
+ * @brief Ini file unittest matching model with and without trainable
+ */
+TEST(nntrainerIniTest, backbone_p_07) {
+  const char *ini_name = "backbone_p7.ini";
+  nntrainerIniTest::save_ini("base.ini", {conv2d});
+  nntrainerIniTest::save_ini(ini_name,
+                             {nw_base, backbone_notrain, backbone_train});
+  nntrainer::NeuralNetwork NN;
+
+  EXPECT_EQ(NN.loadFromConfig(ini_name), ML_ERROR_NONE);
+
+  /** trainable is set to false */
+  auto graph = NN.getFlatGraph();
+  EXPECT_EQ(graph[0]->getTrainable(), false);
+  EXPECT_EQ(graph[1]->getTrainable(), true);
 }
 
 /**


### PR DESCRIPTION
    This patch adds supporting training feature to backbone
    Corresponding unittests are also added
    
    **Self evaluation:**
    1. Build test: [x]Passed [ ]Failed [ ]Skipped
    2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
    Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>