### PR TITLE
[layer] Print layer name over layer address

### DIFF
--- a/nntrainer/src/layer.cpp
+++ b/nntrainer/src/layer.cpp
@@ -269,7 +269,10 @@ void Layer::printPreset(std::ostream &out, PrintPreset preset) {
 void Layer::print(std::ostream &out, unsigned int flags) {
   if (flags & PRINT_INST_INFO) {
     out << "===================";
-    printInstance(out, this);
+    if (getName().empty())
+      printInstance(out, this);
+    else
+      out << "<" << getName() << ">" << std::endl;
 
     out << "Layer Type: "
         << static_cast<std::underlying_type<LayerType>::type>(type)


### PR DESCRIPTION
Print layer name if available
if layer name is not avaiable, then print layer object name and its address

Resolved #666 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>