### PR TITLE
[Fix/Optimizer] Fix decay_rate application

### DIFF
--- a/nntrainer/include/optimizer_internal.h
+++ b/nntrainer/include/optimizer_internal.h
@@ -52,7 +52,7 @@ public:
    * @brief     Default Constructor of Optimizer Class
    */
   Optimizer(const OptType t, float lr, float decay_rate = 1.0f,
-            float decay_steps = -1.0f, float continue_train = false) :
+            unsigned int decay_steps = 0, float continue_train = false) :
     type(t),
     learning_rate(lr),
     decay_rate(decay_rate),
@@ -175,9 +175,9 @@ protected:
    */
   virtual double getLearningRate(int iteration);
 
-  float learning_rate; /** learning rate */
-  float decay_rate;    /** decay rate for learning rate */
-  float decay_steps;   /** decay steps for learning rate */
+  float learning_rate;      /** learning rate */
+  float decay_rate;         /** decay rate for learning rate */
+  unsigned int decay_steps; /** decay steps for learning rate */
   bool continue_train; /** Continue training with previous tensors for adam */
 
 private:

--- a/nntrainer/src/optimizer.cpp
+++ b/nntrainer/src/optimizer.cpp
@@ -42,8 +42,8 @@ int Optimizer::initialize(std::shared_ptr<Weight> weight_list,
 double Optimizer::getLearningRate(int iteration) {
   double ll = learning_rate;
 
-  if (decay_steps != -1) {
-    ll = ll * pow(decay_rate, (iteration / decay_steps));
+  if (decay_steps != 0) {
+    ll = ll * pow(decay_rate, (iteration / (float)decay_steps));
   }
 
   return ll;
@@ -111,7 +111,7 @@ void Optimizer::setProperty(const PropertyType type, const std::string &value) {
     status = setFloat(learning_rate, value);
     break;
   case PropertyType::decay_steps:
-    status = setFloat(decay_steps, value);
+    status = setUint(decay_steps, value);
     break;
   case PropertyType::decay_rate:
     status = setFloat(decay_rate, value);


### PR DESCRIPTION
There was a bug that decay_rate were always applied when it is set to
default value. Becuase `decay_steps != -1` was evaluated to true.

This patch fixes the issue.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
