### PR TITLE
Fix adam iteration start to 1 at model_test

### DIFF
--- a/nntrainer/include/neuralnet.h
+++ b/nntrainer/include/neuralnet.h
@@ -80,13 +80,14 @@ public:
   NeuralNetwork() :
     batch_size(1),
     epochs(1),
+    epoch_idx(0),
+    iter(0),
     loss(0.0f),
     loss_type(LossType::LOSS_UNKNOWN),
     weight_initializer(WeightInitializer::WEIGHT_UNKNOWN),
     net_type(NetType::UNKNOWN),
     data_buffer(nullptr),
     continue_train(false),
-    iter(0),
     initialized(false),
     def_name_count(0),
     loadedFromConfig(false) {}
@@ -343,6 +344,10 @@ private:
 
   unsigned int epochs; /**< Maximum Epochs */
 
+  unsigned int epoch_idx; /**< Number of epoch_idx  */
+
+  unsigned int iter; /**< iterations trained */
+
   float loss; /**< loss */
 
   LossType loss_type; /**< Loss Function type */
@@ -362,8 +367,6 @@ private:
 
   bool continue_train; /**< Continue train from the previous state of optimizer
    and iterations */
-
-  uint64_t iter; /**< Number of iterations trained */
 
   bool initialized; /**< Network is initialized */
 
@@ -457,6 +460,8 @@ private:
 
     swap(lhs.batch_size, rhs.batch_size);
     swap(lhs.epochs, rhs.epochs);
+    swap(lhs.epoch_idx, rhs.epoch_idx);
+    swap(lhs.iter, rhs.iter);
     swap(lhs.loss, rhs.loss);
     swap(lhs.loss_type, rhs.loss_type);
     swap(lhs.weight_initializer, rhs.weight_initializer);
@@ -466,7 +471,6 @@ private:
     swap(lhs.layers, rhs.layers);
     swap(lhs.data_buffer, rhs.data_buffer);
     swap(lhs.continue_train, rhs.continue_train);
-    swap(lhs.iter, rhs.iter);
     swap(lhs.initialized, rhs.initialized);
     swap(lhs.layer_names, rhs.layer_names);
     swap(lhs.def_name_count, rhs.def_name_count);

--- a/nntrainer/src/neuralnet.cpp
+++ b/nntrainer/src/neuralnet.cpp
@@ -344,6 +344,7 @@ void NeuralNetwork::saveModel() {
   std::ofstream model_file(save_path, std::ios::out | std::ios::binary);
   for (unsigned int i = 0; i < layers.size(); i++)
     layers[i]->save(model_file);
+  model_file.write((char *)&epoch_idx, sizeof(epoch_idx));
   model_file.write((char *)&iter, sizeof(iter));
   model_file.close();
 }
@@ -360,6 +361,7 @@ void NeuralNetwork::readModel() {
   for (unsigned int i = 0; i < layers.size(); i++)
     layers[i]->read(model_file);
   if (continue_train) {
+    model_file.read((char *)&epoch_idx, sizeof(epoch_idx));
     model_file.read((char *)&iter, sizeof(iter));
   }
   model_file.close();
@@ -430,7 +432,7 @@ int NeuralNetwork::train(std::vector<std::string> values) {
 int NeuralNetwork::train_run() {
   int status = ML_ERROR_NONE;
 
-  for (unsigned int epoch_idx = 1; epoch_idx <= epochs; ++epoch_idx) {
+  for (epoch_idx = epoch_idx + 1; epoch_idx <= epochs; ++epoch_idx) {
     training.loss = 0.0f;
     status = data_buffer->run(nntrainer::BufferType::BUF_TRAIN);
     if (status != ML_ERROR_NONE) {

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -285,7 +285,7 @@ void GraphWatcher::compareFor(const std::string &reference,
 
   auto data = prepareData(ref, label_shape);
 
-  for (unsigned int iteration = 1; iteration <= iterations; ++iteration) {
+  for (unsigned int iteration = 0; iteration < iterations; ++iteration) {
     nntrainer::sharedConstTensors input = {
       MAKE_SHARED_TENSOR(std::get<0>(data).clone())};
     nntrainer::sharedConstTensors label = {


### PR DESCRIPTION
~From the paper, adam's time t start from 1. So other framework do like
`iteration + 1` because they start iteration from 0. However, nntrainer
start iteration from 1 so, iteration + 1 is not correct.~

~Also, there was a bug that iteration is not counted correctly for the
train data, this patch fixes the issue~

- Fix bug that epoch_idx is not saved for continue_train
- Fix iteration to start from 0 in model test

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
