### PR TITLE
[concat] Move validity checks to init

### DIFF
--- a/nntrainer/include/tensor_dim.h
+++ b/nntrainer/include/tensor_dim.h
@@ -99,7 +99,8 @@ public:
   bool isEmpty() const { return len == 0; }
   unsigned int rank() const;
 
-  unsigned int &operator[](unsigned int index);
+  unsigned int &operator[](const unsigned int index);
+  const unsigned int &operator[](const unsigned int index) const;
 
   /**
    * @brief Calculate standard strides

--- a/nntrainer/src/tensor_dim.cpp
+++ b/nntrainer/src/tensor_dim.cpp
@@ -114,7 +114,14 @@ unsigned int TensorDim::rank() const {
   return rank;
 }
 
-unsigned int &TensorDim::operator[](unsigned int index) {
+unsigned int &TensorDim::operator[](const unsigned int index) {
+  if (index >= MAXDIM)
+    throw std::out_of_range(
+      "[TensorDim] Tensor Dimension index should be between 0 and 4");
+  return dim[index];
+}
+
+const unsigned int &TensorDim::operator[](const unsigned int index) const {
   if (index >= MAXDIM)
     throw std::out_of_range(
       "[TensorDim] Tensor Dimension index should be between 0 and 4");


### PR DESCRIPTION
Move the dimension checks for validity of the various inputs
for concat layer are moved to initialize().
They are kept back in forwarding() under DEBUG conditional.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>