### PR TITLE
[tensorfilter] Bug fix of tranpose

### DIFF
--- a/Applications/Tizen_native/CustomShortcut/res/model.ini
+++ b/Applications/Tizen_native/CustomShortcut/res/model.ini
@@ -24,7 +24,7 @@ LabelData="label.dat"
 # Layer Section : Name
 [inputlayer]
 Type = input
-Input_Shape = 1280:7:7	# Input Layer Dimension
+Input_Shape = 7:7:1280	# Input Layer Dimension
 Normalization = true
 
 [flatten]

--- a/Applications/Tizen_native/CustomShortcut/src/data.c
+++ b/Applications/Tizen_native/CustomShortcut/src/data.c
@@ -637,7 +637,7 @@ int run_inference_pipeline_(appdata_s *ad, const char *filesrc) {
           "tensor_transform mode=arithmetic option=%s ! "
           "tensor_filter framework=tensorflow-lite model=%s ! "
           "tensor_filter framework=nntrainer model=%s input=1280:7:7:1 "
-          "inputtype=float32 output=1:%d:1:1 outputtype=float32 ! "
+          "inputtype=float32 output=%d outputtype=float32 ! "
           "tensor_sink name=sink",
           filesrc, "typecast:float32,add:-127.5,div:127.5", tf_model_path,
           trainer_model_path, NUM_CLASS);

--- a/Applications/TransferLearning/Draw_Classification/jni/main.cpp
+++ b/Applications/TransferLearning/Draw_Classification/jni/main.cpp
@@ -486,10 +486,10 @@ int testModel(const char *data_path, const char *model) {
   snprintf(pipeline, sizeof(pipeline),
            "appsrc name=srcx ! "
            "other/"
-           "tensor,dimension=(string)1:%d:1:1,type=(string)float32,framerate=("
+           "tensor,dimension=(string)%d:1:1:1,type=(string)float32,framerate=("
            "fraction)0/1 ! "
-           "tensor_filter framework=nntrainer model=\"%s\" input=1:%d:1:1 "
-           "inputtype=float32 output=1:%d:1:1 outputtype=float32 ! tensor_sink "
+           "tensor_filter framework=nntrainer model=\"%s\" input=%d "
+           "inputtype=float32 output=%d outputtype=float32 ! tensor_sink "
            "name=sinkx",
            INPUT_SIZE, model, INPUT_SIZE, LABEL_SIZE);
 

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -115,7 +115,6 @@ void NNTrainer::validateTensor(const GstTensorsInfo *tensorInfo,
 
   nntrainer::TensorDim dim;
   nntrainer_tensor_info_s info_s;
-  unsigned int order[3] = {1, 3, 2};
 
   if (is_input)
     dim = model->getInputDimension()[0];
@@ -128,17 +127,12 @@ void NNTrainer::validateTensor(const GstTensorsInfo *tensorInfo,
 
   info_s.rank = NUM_DIM;
 
-  for (unsigned int i = 0; i < NUM_DIM - 1; ++i) {
-    if (tensorInfo->info[0].dimension[i] != dim.getDim()[order[i]])
+  for (unsigned int i = 0; i < NUM_DIM; ++i) {
+    if (tensorInfo->info[0].dimension[i] != dim.getDim()[NUM_DIM - i - 1])
       throw std::invalid_argument("Tensor dimension doesn't match");
 
-    info_s.dims.push_back(dim.getDim()[order[i]]);
+    info_s.dims.push_back(dim.getDim()[i]);
   }
-
-  if (tensorInfo->info[0].dimension[NUM_DIM - 1] != dim.getDim()[0])
-    throw std::invalid_argument("Tensor dimension doesn't match");
-
-  info_s.dims.push_back(dim.getDim()[0]);
 
   if (is_input)
     input_tensor_info.push_back(info_s);
@@ -177,7 +171,7 @@ int NNTrainer::run(const GstTensorMemory *input, GstTensorMemory *output) {
 
   std::vector<std::int64_t> d = input_tensor_info[0].dims;
   nntrainer::Tensor X =
-    nntrainer::Tensor(nntrainer::TensorDim(d[3], d[0], d[2], d[1]),
+    nntrainer::Tensor(nntrainer::TensorDim(d[0], d[1], d[2], d[3]),
                       static_cast<float *>(input[0].data));
 
   std::shared_ptr<const nntrainer::Tensor> o;

--- a/test/nnstreamer_filter_nntrainer/runTest.sh
+++ b/test/nnstreamer_filter_nntrainer/runTest.sh
@@ -75,14 +75,14 @@ fi
 PATH_TO_CONFIG="../test_models/models/mnist.ini"
 PATH_TO_DATA="../test_models/data/2.png"
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_DATA} ! pngdec ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tensor_filter framework=nntrainer model=${PATH_TO_CONFIG} input=1:28:28:1 inputtype=float32 output=1:10:1:1 outputtype=float32 ! filesink location=nntrainer.out.1.log" 1 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_DATA} ! pngdec ! tensor_converter ! other/tensor,dimension=1:28:28:1 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_transform mode=typecast option=float32 ! tensor_filter framework=nntrainer model=${PATH_TO_CONFIG} input=28:28:1:1 inputtype=float32 output=10 outputtype=float32 ! filesink location=nntrainer.out.1.log" 1 0 0 $PERFORMANCE
 python checkLabel.py nntrainer.out.1.log 2
 testResult $? 1 "Golden test comparison" 0 1
 
 PATH_TO_CONFIG="../test_models/models/mnist.ini"
 PATH_TO_DATA="../test_models/data/0.png"
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_DATA} ! pngdec ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tensor_filter framework=nntrainer model=${PATH_TO_CONFIG} input=1:28:28:1 inputtype=float32 output=1:10:1:1 outputtype=float32 ! filesink location=nntrainer.out.2.log" 1 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_DATA} ! pngdec ! tensor_converter ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_transform mode=typecast option=float32 ! tensor_filter framework=nntrainer model=${PATH_TO_CONFIG} input=28:28:1:1 inputtype=float32 output=10:1:1:1 outputtype=float32 ! filesink location=nntrainer.out.2.log" 1 0 0 $PERFORMANCE
 python checkLabel.py nntrainer.out.2.log 0
 testResult $? 2 "Golden test comparison" 0 1
 report


### PR DESCRIPTION
nntrainer takes data of NCHW
however, nnstreamer's tensor_converter produces data of format NHWC.
Existing implementation transposed the dimensions to match to NCHW format
However, the data was not transposed.
The unittest passed because the channel was just 1 which does not require
transpose on data side.

This patch removes the transpose of dimension from the nntrainer tensor_filter
and the transpose is done properly in the pipeline with nnstreamer's tensor_transform

Resolves #695

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>