### PR TITLE
[ Layer ] Add Output Layer to support multiple output

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -39,6 +39,7 @@ enum class LayerType {
   LAYER_ACTIVATION,                     /** Activation Layer type */
   LAYER_ADDITION,                       /** Addition Layer type */
   LAYER_CONCAT,                         /** Concat Layer type */
+  LAYER_OUT,                            /** Multi Output Layer type */
   LAYER_LOSS,                           /** Loss Layer type */
   LAYER_BACKBONE_NNSTREAMER,            /** Backbone using NNStreamer */
   LAYER_BACKBONE_TFLITE,                /** Backbone using TFLite */
@@ -93,6 +94,7 @@ public:
    *            24. beta_initializer" : string (type)
    *            25. modelfile : model file for loading config for backbone layer
    *            26. input_layers" : string (type)
+   *            27. output_layers" : string (type)
    */
   enum class PropertyType {
     input_shape = 0,
@@ -122,6 +124,7 @@ public:
     beta_initializer = 24,
     modelfile = 25, /** model file for loading config for backbone layer */
     input_layers = 26,
+    output_layers = 27,
     unknown
   };
 

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -67,6 +67,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/layer_factory.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/input_layer.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/layers/output_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/fc_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/bn_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/loss_layer.cpp \

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -208,6 +208,17 @@ void Layer::setProperty(const PropertyType type, const std::string &value) {
         num_inputs = concat_layers.size();
     }
     break;
+  case PropertyType::output_layers:
+    if (!value.empty()) {
+      std::regex reg("\\,+");
+      std::vector<std::string> concat_layers = split(value, reg);
+
+      num_outputs = concat_layers.size();
+
+      for (unsigned int i = 0; i < num_outputs; ++i)
+        output_layers.push_back(concat_layers[i]);
+    }
+    break;
   default:
     std::string msg =
       "[Layer] Unknown Layer Property Key for value " + std::string(value);

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -428,6 +428,16 @@ private:
   static int def_name_count;
 
   /**
+   * @brief     input layer names
+   */
+  std::vector<std::string> input_layers;
+
+  /**
+   * @brief     output layer names
+   */
+  std::vector<std::string> output_layers;
+
+  /**
    * @brief     Ensure that layer has a name
    */
   void ensureName();

--- a/nntrainer/layers/output_layer.cpp
+++ b/nntrainer/layers/output_layer.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file        output_layer.cpp
+ * @date        05 Nov 2020
+ * @see         https://github.com/nnstreamer/nntrainer
+ * @author      Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug         No known bugs except for NYI items
+ * @brief       This is Multi Output Layer Class for Neural Network
+ *
+ */
+
+#include <cstring>
+#include <layer_internal.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <output_layer.h>
+#include <parse_util.h>
+#include <util_func.h>
+
+namespace nntrainer {
+
+int OutputLayer::initialize() {
+  int status = ML_ERROR_NONE;
+
+  if (num_inputs == 0) {
+    ml_loge("Error: number of inputs are not initialized");
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
+  output_dim.clear();
+
+  // TODO : get output dimensions and set accordingly.
+  //        for now, it's just copy of input dim.
+
+  for (unsigned int idx = 0; idx < num_outputs; ++idx) {
+    output_dim.push_back(input_dim[0]);
+  }
+
+  return status;
+}
+
+sharedConstTensors OutputLayer::forwarding(sharedConstTensors in) {
+
+  sharedConstTensors ret;
+  for (unsigned int idx = 0; idx < num_outputs; ++idx) {
+    Tensor out = Tensor(output_dim[idx]);
+    out = *in[0];
+    ret.push_back(MAKE_SHARED_TENSOR(out));
+  }
+
+  return ret;
+}
+
+sharedConstTensors OutputLayer::backwarding(sharedConstTensors derivative,
+                                            int iteration) {
+
+  Tensor ret = Tensor(input_dim[0]);
+
+  for (unsigned int idx = 0; idx < num_outputs; ++idx) {
+    ret.add_i(*derivative[idx]);
+  }
+
+  return {MAKE_SHARED_TENSOR(ret)};
+}
+
+void OutputLayer::setProperty(const PropertyType type,
+                              const std::string &value) {
+  int status = ML_ERROR_NONE;
+
+  switch (type) {
+  case PropertyType::num_outputs: {
+    if (!value.empty()) {
+      status = setUint(num_outputs, value);
+      throw_status(status);
+      if (num_outputs < 1)
+        throw std::invalid_argument("Minimum number of outputs must be 1");
+    }
+  } break;
+  default:
+    Layer::setProperty(type, value);
+    break;
+  }
+}
+
+} /* namespace nntrainer */

--- a/nntrainer/layers/output_layer.h
+++ b/nntrainer/layers/output_layer.h
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file        output_layer.h
+ * @date        05 Nov 2020
+ * @see         https://github.com/nnstreamer/nntrainer
+ * @author      Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug         No known bugs except for NYI items
+ * @brief       This is Multi Output Layer Class for Neural Network
+ *
+ */
+
+#ifndef __OUTPUT_LAYER_H__
+#define __OUTPUT_LAYER_H__
+#ifdef __cplusplus
+
+#include <layer_internal.h>
+#include <tensor.h>
+
+namespace nntrainer {
+
+/**
+ * @class   Output Layer
+ * @brief   Output Layer
+ */
+class OutputLayer : public Layer {
+public:
+  /**
+   * @brief     Constructor of Output Layer
+   */
+  template <typename... Args>
+  OutputLayer(unsigned int num_output_ = 1, Args... args) :
+    Layer(LayerType::LAYER_OUT, args...) {
+    num_outputs = num_output_;
+  }
+
+  /**
+   * @brief     Destructor of Output Layer
+   */
+  ~OutputLayer(){};
+
+  /**
+   *  @brief  Move constructor of OutputLayer.
+   *  @param[in] OutputLayer &&
+   */
+  OutputLayer(OutputLayer &&rhs) noexcept = default;
+
+  /**
+   * @brief  Move assignment operator.
+   * @parma[in] rhs OutputLayer to be moved.
+   */
+  OutputLayer &operator=(OutputLayer &&rhs) = default;
+
+  /**
+   * @brief     initialize layer
+   * @param[in] last last layer
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int initialize();
+
+  /**
+   * @brief     Read Weight & Bias Data from file
+   * @param[in] file input stream file
+   */
+  void read(std::ifstream &file){};
+
+  /**
+   * @brief     Save Weight & Bias Data to file
+   * @param[in] file output stream file
+   */
+  void save(std::ofstream &file){};
+
+  /**
+   * @copydoc Layer::forwarding(sharedConstTensors in)
+   */
+  sharedConstTensors forwarding(sharedConstTensors in);
+
+  /**
+   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   */
+  sharedConstTensors backwarding(sharedConstTensors in, int iteration);
+
+  /**
+   * @brief     get the base name for the layer
+   * @retval    base name of the layer
+   */
+  std::string getBaseName() { return "Output"; };
+
+  using Layer::setProperty;
+
+  /**
+   * @copydoc Layer::setProperty(const PropertyType type, const std::string
+   * &value)
+   */
+  void setProperty(const PropertyType type, const std::string &value = "");
+};
+
+} // namespace nntrainer
+
+#endif /* __cplusplus */
+#endif /* __OUTPUT_LAYER_H__ */

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -277,7 +277,9 @@ unsigned int parseType(std::string ll, InputType t) {
  * moving_variance_initializer = 22
  * gamma_initializer = 23
  * beta_initializer = 24
- * input_layers = 25
+ * modelfile = 25
+ * input_layers = 26
+ * output_layers = 27
  *
  * InputLayer has 0, 1, 2, 3 properties.
  * FullyConnectedLayer has 1, 4, 6, 7, 8, 9 properties.
@@ -285,7 +287,7 @@ unsigned int parseType(std::string ll, InputType t) {
  * Pooling2DLayer has 12, 13, 14, 15 properties.
  * BatchNormalizationLayer has 0, 1, 5, 6, 7 properties.
  */
-static std::array<std::string, 28> property_string = {
+static std::array<std::string, 29> property_string = {
   "input_shape",
   "normalization",
   "standardization",
@@ -313,6 +315,7 @@ static std::array<std::string, 28> property_string = {
   "beta_initializer",
   "modelfile",
   "input_layers",
+  "output_layers",
   "unknown"};
 
 unsigned int parseLayerProperty(std::string property) {


### PR DESCRIPTION
Currently there is no way to support multiple output.
However it is not neccessary to be explicit support.
Instead if user use "output_layers = layername0, layername1", then nntrainer
automatically add output layer. ( comparing ouput dimension and input
layer's dimension, we could decide it is addition or split operation. )

Also, if certain layer is specify as an input layer from mutiple
layers, then it should be added implicitly.

TODO: support split operation

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>