### PR TITLE
[Layer] Change layer type to string

### DIFF
--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -340,8 +340,8 @@ ml_optimizer_to_nntrainer_type(ml_train_optimizer_type_e type);
 /**
  * @brief Convert nntrainer API layer type to neural network layer type
  * @param[in] type Layer type API enum
- * @return nntrainer::LayerType layer type
+ * @return const std::string layer type
  */
-nntrainer::LayerType ml_layer_to_nntrainer_type(ml_train_layer_type_e type);
+const std::string ml_layer_to_nntrainer_type(ml_train_layer_type_e type);
 
 #endif

--- a/api/capi/src/nntrainer_util.cpp
+++ b/api/capi/src/nntrainer_util.cpp
@@ -37,13 +37,19 @@ ml_optimizer_to_nntrainer_type(ml_train_optimizer_type_e type) {
 /**
  * @brief Convert nntrainer API layer type to neural network layer type
  */
-nntrainer::LayerType ml_layer_to_nntrainer_type(ml_train_layer_type_e type) {
+const std::string ml_layer_to_nntrainer_type(ml_train_layer_type_e type) {
   switch (type) {
   case ML_TRAIN_LAYER_TYPE_FC:
-    return nntrainer::LayerType::LAYER_FC;
+    return nntrainer::FullyConnectedLayer::type;
   case ML_TRAIN_LAYER_TYPE_INPUT:
-    return nntrainer::LayerType::LAYER_IN;
+    return nntrainer::InputLayer::type;
+  case ML_TRAIN_LAYER_TYPE_UNKNOWN:
+  /// fall through intended
   default:
-    return nntrainer::LayerType::LAYER_UNKNOWN;
+    throw nntrainer::exception::not_supported(
+      "[ml_layer_to_nntrainer_type] Not supported type given");
   }
+
+  throw std::logic_error(
+    "[ml_layer_to_nntrainer_type] Control shouldn't reach here");
 }

--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -29,7 +29,7 @@ namespace train {
 /**
  * @brief     Enumeration of layer type
  */
-enum class LayerType {
+enum LayerType {
   LAYER_IN = ML_TRAIN_LAYER_TYPE_INPUT, /** Input Layer type */
   LAYER_FC = ML_TRAIN_LAYER_TYPE_FC,    /** Fully Connected Layer type */
   LAYER_BN,                             /** Batch Normalization Layer type */
@@ -174,6 +174,12 @@ public:
   virtual std::string getName() noexcept = 0;
 
   /**
+   * @brief Get the layer type
+   * @return const std::string type representation
+   */
+  virtual const std::string getType() const = 0;
+
+  /**
    * @brief Preset modes for printing summary for the layer
    */
   enum class PrintPreset {
@@ -195,10 +201,18 @@ public:
 };
 
 /**
+ * @brief Factory creator with constructor for layer type
+ */
+std::unique_ptr<Layer>
+createLayer(const LayerType &type,
+            const std::vector<std::string> &properties = {});
+
+/**
  * @brief Factory creator with constructor for layer
  */
 std::unique_ptr<Layer>
-createLayer(LayerType type, const std::vector<std::string> &properties = {});
+createLayer(const std::string &type,
+            const std::vector<std::string> &properties = {});
 
 } // namespace train
 } // namespace ml

--- a/api/ccapi/src/factory.cpp
+++ b/api/ccapi/src/factory.cpp
@@ -27,10 +27,17 @@
 namespace ml {
 namespace train {
 
+std::unique_ptr<Layer> createLayer(const LayerType &type,
+                                   const std::vector<std::string> &properties) {
+  const std::string &t = nntrainer::layerGetStrType(type);
+
+  return createLayer(t, properties);
+}
+
 /**
  * @brief Factory creator with constructor for layer
  */
-std::unique_ptr<Layer> createLayer(LayerType type,
+std::unique_ptr<Layer> createLayer(const std::string &type,
                                    const std::vector<std::string> &properties) {
   std::unique_ptr<Layer> layer = nntrainer::createLayer(type);
 

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -31,6 +31,8 @@
 
 namespace nntrainer {
 
+const std::string ActivationLayer::type = "activation";
+
 /**
  * @brief     Initialize the layer
  *

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -32,7 +32,7 @@ public:
    */
   template <typename... Args>
   ActivationLayer(ActivationType at = ActivationType::ACT_NONE, Args... args) :
-    Layer(LayerType::LAYER_ACTIVATION, args...) {
+    Layer(args...) {
     setActivation(at);
   }
 
@@ -79,10 +79,9 @@ public:
   void setActivation(ActivationType acti_type);
 
   /**
-   * @brief     get the base name for the layer
-   * @retval    base name of the layer
+   * @copydoc Layer::getType()
    */
-  std::string getBaseName() { return "Activation"; };
+  const std::string getType() const { return ActivationLayer::type; };
 
   /**
    * @brief       Calculate softmax for Tensor Type
@@ -146,6 +145,8 @@ public:
    * @param[in] x input
    */
   static float no_op_prime(float x);
+
+  static const std::string type;
 
 private:
   std::function<Tensor(Tensor const &)> _act_fn;

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -20,6 +20,8 @@
 
 namespace nntrainer {
 
+const std::string AdditionLayer::type = "addition";
+
 int AdditionLayer::initialize() {
   int status = ML_ERROR_NONE;
   if (num_inputs == 0) {

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -30,8 +30,7 @@ public:
    * @brief     Constructor of Addition Layer
    */
   template <typename... Args>
-  AdditionLayer(unsigned int num_inputs_ = 0, Args... args) :
-    Layer(LayerType::LAYER_ADDITION, args...) {
+  AdditionLayer(unsigned int num_inputs_ = 0, Args... args) : Layer(args...) {
     num_inputs = num_inputs_;
   }
 
@@ -83,10 +82,9 @@ public:
   sharedConstTensors backwarding(sharedConstTensors in, int iteration);
 
   /**
-   * @brief     get the base name for the layer
-   * @retval    base name of the layer
+   * @copydoc Layer::getType()
    */
-  std::string getBaseName() { return "Addition"; };
+  const std::string getType() const { return AdditionLayer::type; };
 
   using Layer::setProperty;
 
@@ -95,6 +93,8 @@ public:
    * &value)
    */
   void setProperty(const PropertyType type, const std::string &value = "");
+
+  static const std::string type;
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -32,6 +32,8 @@
 
 namespace nntrainer {
 
+const std::string BatchNormalizationLayer::type = "batch_normalization";
+
 enum class BNParams { mu, var, gamma, beta };
 
 /// @todo add multiple axis support

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -51,7 +51,7 @@ public:
     WeightInitializer gamma_initializer = WeightInitializer::WEIGHT_ONES,
     WeightInitializer beta_initializer = WeightInitializer::WEIGHT_ONES,
     Args... args) :
-    Layer(LayerType::LAYER_BN, args...),
+    Layer(args...),
     epsilon(epsilon),
     momentum(momentum),
     axis(axis),
@@ -99,10 +99,9 @@ public:
   int initialize();
 
   /**
-   * @brief     get the base name for the layer
-   * @retval    base name of the layer
+   * @copydoc Layer::getType()
    */
-  std::string getBaseName() { return "BatchNormalization"; };
+  const std::string getType() const { return BatchNormalizationLayer::type; };
 
   using Layer::setProperty;
 
@@ -111,6 +110,8 @@ public:
    * &value)
    */
   void setProperty(const PropertyType type, const std::string &value = "");
+
+  static const std::string type;
 
 private:
   Tensor cvar; /**< training variance saved in bn_layer::forwarding and used in

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -30,8 +30,7 @@ public:
    * @brief     Constructor of Concat Layer
    */
   template <typename... Args>
-  ConcatLayer(unsigned int num_inputs_ = 0, Args... args) :
-    Layer(LayerType::LAYER_CONCAT, args...) {
+  ConcatLayer(unsigned int num_inputs_ = 0, Args... args) : Layer(args...) {
     num_inputs = num_inputs_;
   }
 

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -25,6 +25,8 @@
 
 namespace nntrainer {
 
+const std::string Conv2DLayer::type = "conv2d";
+
 int Conv2DLayer::initialize() {
   int status = ML_ERROR_NONE;
 

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -38,7 +38,7 @@ public:
               const std::array<unsigned int, CONV2D_DIM> &padding_ = {0, 0},
               bool normalization_ = false, bool standardization_ = false,
               Args... args) :
-    Layer(LayerType::LAYER_CONV2D, args...),
+    Layer(args...),
     filter_size(filter_size_),
     kernel_size(kernel_size_),
     stride(stride_),
@@ -95,10 +95,9 @@ public:
   /* }; */
 
   /**
-   * @brief     get the base name for the layer
-   * @retval    base name of the layer
+   * @copydoc Layer::getType()
    */
-  std::string getBaseName() { return "Convolution2D"; };
+  const std::string getType() const { return Conv2DLayer::type; };
 
   using Layer::setProperty;
 
@@ -107,6 +106,8 @@ public:
    * &value)
    */
   void setProperty(const PropertyType type, const std::string &value = "");
+
+  static const std::string type;
 
 private:
   unsigned int filter_size;

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -31,6 +31,8 @@
 
 namespace nntrainer {
 
+const std::string FullyConnectedLayer::type = "fully_connected";
+
 enum class FCParams { weight, bias };
 
 int FullyConnectedLayer::initialize() {

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -31,7 +31,7 @@ public:
    */
   template <typename... Args>
   FullyConnectedLayer(unsigned int unit_ = 0, Args... args) :
-    Layer(LayerType::LAYER_FC, args...),
+    Layer(args...),
     unit(unit_) {}
 
   /**
@@ -75,10 +75,9 @@ public:
   int initialize();
 
   /**
-   * @brief     get the base name for the layer
-   * @retval    base name of the layer
+   * @copydoc Layer::getType()
    */
-  std::string getBaseName() { return "FullyConnected"; };
+  const std::string getType() const { return FullyConnectedLayer::type; };
 
   using Layer::setProperty;
 
@@ -87,6 +86,8 @@ public:
    * &value)
    */
   void setProperty(const PropertyType type, const std::string &value = "");
+
+  static const std::string type;
 
 private:
   unsigned int unit;

--- a/nntrainer/layers/flatten_layer.cpp
+++ b/nntrainer/layers/flatten_layer.cpp
@@ -20,6 +20,8 @@
 
 namespace nntrainer {
 
+const std::string FlattenLayer::type = "flatten";
+
 int FlattenLayer::initialize() {
   if (num_inputs != 1) {
     throw std::invalid_argument("input_shape keyword is only for one input");

--- a/nntrainer/layers/flatten_layer.h
+++ b/nntrainer/layers/flatten_layer.h
@@ -29,8 +29,7 @@ public:
   /**
    * @brief     Constructor of Flatten Layer
    */
-  template <typename... Args>
-  FlattenLayer(Args... args) : Layer(LayerType::LAYER_FLATTEN, args...) {}
+  template <typename... Args> FlattenLayer(Args... args) : Layer(args...) {}
 
   /**
    * @brief     Destructor of Flatten Layer
@@ -79,10 +78,11 @@ public:
   sharedConstTensors backwarding(sharedConstTensors in, int iteration);
 
   /**
-   * @brief     get the base name for the layer
-   * @retval    base name of the layer
+   * @copydoc Layer::getType()
    */
-  std::string getBaseName() { return "Flatten"; };
+  const std::string getType() const { return FlattenLayer::type; };
+
+  static const std::string type;
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -28,6 +28,8 @@
 
 namespace nntrainer {
 
+const std::string InputLayer::type = "input";
+
 void InputLayer::setProperty(const PropertyType type,
                              const std::string &value) {
   int status = ML_ERROR_NONE;

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -41,7 +41,7 @@ public:
   template <typename... Args>
   InputLayer(bool normalization = false, bool standardization = false,
              Args... args) :
-    Layer(LayerType::LAYER_IN, args...),
+    Layer(args...),
     normalization(false),
     standardization(false) {}
 
@@ -90,10 +90,9 @@ public:
   int initialize();
 
   /**
-   * @brief     get the base name for the layer
-   * @retval    base name of the layer
+   * @copydoc Layer::getType()
    */
-  std::string getBaseName() { return "Input"; };
+  const std::string getType() const { return InputLayer::type; };
 
   using Layer::setProperty;
 
@@ -102,6 +101,8 @@ public:
    * &value)
    */
   void setProperty(const PropertyType type, const std::string &value = "");
+
+  static const std::string type;
 
 private:
   bool normalization;

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -44,10 +44,6 @@ int Layer::setOptimizer(std::shared_ptr<Optimizer> opt) {
 
 int Layer::checkValidation() {
   int status = ML_ERROR_NONE;
-  if (type == LayerType::LAYER_UNKNOWN) {
-    ml_loge("Error: Layer type is unknown");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
 
   if (activation_type == ActivationType::ACT_UNKNOWN) {
     ml_loge("Error: Have to set activation for this layer");
@@ -79,7 +75,6 @@ void Layer::copy(std::shared_ptr<Layer> l) {
   this->hidden.copy(l->hidden);
   this->activation_type = l->activation_type;
   this->loss = l->loss;
-  this->type = l->type;
   this->weight_regularizer = l->weight_regularizer;
   this->weight_regularizer_constant = l->weight_regularizer_constant;
   this->weight_initializer = l->weight_initializer;
@@ -311,9 +306,7 @@ void Layer::print(std::ostream &out, unsigned int flags) {
     else
       out << "<" << getName() << ">" << std::endl;
 
-    out << "Layer Type: "
-        << static_cast<std::underlying_type<LayerType>::type>(type)
-        << std::endl;
+    out << "Layer Type: " << getType() << std::endl;
   }
 
   if (flags & PRINT_SHAPE_INFO) {

--- a/nntrainer/layers/layer_factory.h
+++ b/nntrainer/layers/layer_factory.h
@@ -18,10 +18,20 @@
 
 namespace nntrainer {
 
+using LayerType = ml::train::LayerType;
+
+/**
+ * @brief get string representation type from integer
+ *
+ * @param type integer type
+ * @return const std::string string represented type
+ */
+const std::string layerGetStrType(const LayerType &type);
+
 /**
  * @brief Factory creator with constructor
  */
-std::unique_ptr<Layer> createLayer(LayerType type);
+std::unique_ptr<Layer> createLayer(const std::string &type);
 
 } /* namespace nntrainer */
 

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -47,8 +47,6 @@ enum class ActivationType {
   ACT_UNKNOWN  /** unknown */
 };
 
-using LayerType = ml::train::LayerType;
-
 /**
  * @class   Layer Base class for layers
  * @brief   Base class for all layers
@@ -64,7 +62,7 @@ public:
    * @brief     Constructor of Layer Class
    */
   Layer(
-    LayerType type_, ActivationType activation_type_ = ActivationType::ACT_NONE,
+    ActivationType activation_type_ = ActivationType::ACT_NONE,
     WeightRegularizerType weight_regularizer_ = WeightRegularizerType::unknown,
     const float weight_regularizer_constant_ = 1.0f,
     WeightInitializer weight_initializer_ =
@@ -72,7 +70,6 @@ public:
     WeightInitializer bias_initializer_ = WeightInitializer::WEIGHT_ZEROS,
     bool trainable_ = true, bool flatten_ = false) :
     name(std::string()),
-    type(type_),
     loss(0.0f),
     activation_type(activation_type_),
     weight_regularizer(weight_regularizer_),
@@ -171,12 +168,6 @@ public:
    * @retval    Activation Type.
    */
   ActivationType getActivationType() { return this->activation_type; }
-
-  /**
-   * @brief     Layer type Getter
-   * @retval type LayerType
-   */
-  LayerType getType() { return type; }
 
   /**
    * @brief     Copy Layer
@@ -334,11 +325,6 @@ protected:
   std::shared_ptr<Optimizer> opt;
 
   /**
-   * @brief     Layer type
-   */
-  LayerType type;
-
-  /**
    * @brief     Loss value added by this layer
    */
   float loss;
@@ -402,12 +388,6 @@ protected:
    * @brief   Numer of outputs this layer will produce
    */
   unsigned int num_outputs;
-
-  /**
-   * @brief     Layer type Setter
-   * @param[in] type layer type
-   */
-  void setType(LayerType type) { this->type = type; }
 
   /**
    * @brief     Activation Setter
@@ -499,11 +479,6 @@ private:
    * @param[in] flags combination of LayerPrintOption
    */
   virtual void print(std::ostream &out, unsigned int flags = 0);
-
-  /**
-   * @brief     Get base name of the layer
-   */
-  virtual std::string getBaseName() = 0;
 
   /**
    * @brief     Initialize the layer

--- a/nntrainer/layers/loss_layer.cpp
+++ b/nntrainer/layers/loss_layer.cpp
@@ -33,6 +33,8 @@
 
 namespace nntrainer {
 
+const std::string LossLayer::type = "loss";
+
 int LossLayer::initialize() {
   int status = ML_ERROR_NONE;
 

--- a/nntrainer/layers/loss_layer.h
+++ b/nntrainer/layers/loss_layer.h
@@ -44,7 +44,7 @@ public:
    */
   template <typename... Args>
   LossLayer(LossType loss_type_ = LossType::LOSS_UNKNOWN, Args... args) :
-    Layer(LayerType::LAYER_LOSS, args...),
+    Layer(args...),
     loss_type(LossType::LOSS_UNKNOWN) {}
 
   /**
@@ -97,10 +97,9 @@ public:
   int initialize();
 
   /**
-   * @brief     get the base name for the layer
-   * @retval    base name of the layer
+   * @copydoc Layer::getType()
    */
-  std::string getBaseName() { return "Loss"; };
+  const std::string getType() const { return LossLayer::type; };
 
   /**
    * @brief     set loss function
@@ -109,6 +108,8 @@ public:
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
   int setLoss(LossType l);
+
+  static const std::string type;
 
 private:
   LossType loss_type; /**< loss type of loss layer */

--- a/nntrainer/layers/nnstreamer_layer.cpp
+++ b/nntrainer/layers/nnstreamer_layer.cpp
@@ -23,6 +23,8 @@
 
 namespace nntrainer {
 
+const std::string NNStreamerLayer::type = "backbone_nnstreamer";
+
 int NNStreamerLayer::nnst_info_to_tensor_dim(ml_tensors_info_h &out_res,
                                              TensorDim &dim) {
   int status = ML_ERROR_NONE;

--- a/nntrainer/layers/nnstreamer_layer.h
+++ b/nntrainer/layers/nnstreamer_layer.h
@@ -32,7 +32,7 @@ public:
    * @brief     Constructor of NNStreamer Layer
    */
   NNStreamerLayer(std::string model = "") :
-    Layer(LayerType::LAYER_BACKBONE_NNSTREAMER),
+    Layer(),
     modelfile(model),
     single(nullptr),
     in_res(nullptr),
@@ -73,10 +73,9 @@ public:
   void setTrainable(bool train);
 
   /**
-   * @brief     get the base name for the layer
-   * @retval    base name of the layer
+   * @copydoc Layer::getType()
    */
-  std::string getBaseName() { return "BackboneNNStreamer"; };
+  const std::string getType() const { return NNStreamerLayer::type; };
 
   using Layer::setProperty;
 
@@ -85,6 +84,8 @@ public:
    * &value)
    */
   void setProperty(const PropertyType type, const std::string &value = "");
+
+  static const std::string type;
 
 private:
   std::string modelfile;

--- a/nntrainer/layers/output_layer.h
+++ b/nntrainer/layers/output_layer.h
@@ -30,8 +30,7 @@ public:
    * @brief     Constructor of Output Layer
    */
   template <typename... Args>
-  OutputLayer(unsigned int num_output_ = 1, Args... args) :
-    Layer(LayerType::LAYER_OUT, args...) {
+  OutputLayer(unsigned int num_output_ = 1, Args... args) : Layer(args...) {
     num_outputs = num_output_;
   }
 

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -24,6 +24,8 @@
 
 namespace nntrainer {
 
+const std::string Pooling2DLayer::type = "pooling2d";
+
 int Pooling2DLayer::initialize() {
   int status = ML_ERROR_NONE;
 

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -47,7 +47,7 @@ public:
     const std::array<unsigned int, POOLING2D_DIM> &stride_ = {1, 1},
     const std::array<unsigned int, POOLING2D_DIM> &padding_ = {0, 0},
     Args... args) :
-    Layer(LayerType::LAYER_POOLING2D, args...),
+    Layer(args...),
     pool_size(pool_size_),
     stride(stride_),
     padding(padding_),
@@ -119,10 +119,9 @@ public:
   };
 
   /**
-   * @brief     get the base name for the layer
-   * @retval    base name of the layer
+   * @copydoc Layer::getType()
    */
-  std::string getBaseName() { return "Pooling2D"; };
+  const std::string getType() const { return Pooling2DLayer::type; };
 
   using Layer::setProperty;
 
@@ -131,6 +130,8 @@ public:
    * &value)
    */
   void setProperty(const PropertyType type, const std::string &value = "");
+
+  static const std::string type;
 
 private:
   std::array<unsigned int, POOLING2D_DIM> pool_size;

--- a/nntrainer/layers/tflite_layer.cpp
+++ b/nntrainer/layers/tflite_layer.cpp
@@ -16,6 +16,8 @@
 
 namespace nntrainer {
 
+const std::string TfLiteLayer::type = "backbone_tflite";
+
 void TfLiteLayer::setDimensions(const std::vector<int> &tensor_idx_list,
                                 std::vector<TensorDim> &dim, bool is_output) {
   unsigned int num_tensors = tensor_idx_list.size();

--- a/nntrainer/layers/tflite_layer.h
+++ b/nntrainer/layers/tflite_layer.h
@@ -34,7 +34,7 @@ public:
    * @brief     Constructor of NNStreamer Layer
    */
   TfLiteLayer(std::string model = "") :
-    Layer(LayerType::LAYER_BACKBONE_TFLITE),
+    Layer(),
     modelfile(model),
     interpreter(nullptr),
     model(nullptr) {
@@ -72,10 +72,9 @@ public:
   void setTrainable(bool train);
 
   /**
-   * @brief     get the base name for the layer
-   * @retval    base name of the layer
+   * @copydoc Layer::getType()
    */
-  std::string getBaseName() { return "BackboneTFLite"; };
+  const std::string getType() const { return TfLiteLayer::type; };
 
   using Layer::setProperty;
 
@@ -84,6 +83,8 @@ public:
    * &value)
    */
   void setProperty(const PropertyType type, const std::string &value = "");
+
+  static const std::string type;
 
 private:
   std::string modelfile;

--- a/nntrainer/models/model_loader.h
+++ b/nntrainer/models/model_loader.h
@@ -83,7 +83,7 @@ private:
    */
   int loadLayerConfigIniCommon(dictionary *ini, std::shared_ptr<Layer> &layer,
                                const std::string &layer_name,
-                               LayerType layer_type);
+                               const std::string &layer_type);
 
   /**
    * @brief     wrapper function to load layer config from ini

--- a/nntrainer/optimizers/optimizer_factory.cpp
+++ b/nntrainer/optimizers/optimizer_factory.cpp
@@ -14,14 +14,11 @@
 
 #include <adam.h>
 #include <optimizer_factory.h>
+#include <parse_util.h>
 #include <sgd.h>
 
 namespace nntrainer {
 
-static bool istrequal(const std::string &a, const std::string &b) {
-  return std::equal(a.begin(), a.end(), b.begin(),
-                    [](char a, char b) { return tolower(a) == tolower(b); });
-}
 /**
  * @brief Factory creator with copy constructor
  */

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -95,21 +95,6 @@ unsigned int parseType(std::string ll, InputType t) {
     "tanh", "sigmoid", "relu", "softmax", "none", "unknown"};
 
   /**
-   * @brief     Layer Type String from configure file
-   *            "input"  : Input Layer Object
-   *            "fully_conntected" : Fully Connected Layer Object
-   *            "batch_normalization" : Batch Normalization Layer Object
-   *            "conv2d" : Convolution 2D Layer Object
-   *            "pooling2d" : Pooling 2D Layer Object
-   *            "flatten" : Flatten Layer Object
-   *            "activation" : Activation Layer Object
-   *            "addition" : Addition Layer Object
-   */
-  std::array<std::string, 8> layer_string = {
-    "input",     "fully_connected", "batch_normalization", "conv2d",
-    "pooling2d", "flatten",         "activation",          "addition"};
-
-  /**
    * @brief     Weight Initialization Type String from configure file
    *            "zeros" : Zero Initialization
    *            "ones" : One Initialization
@@ -180,15 +165,6 @@ unsigned int parseType(std::string ll, InputType t) {
             "Moved to NO activation layer by default.",
             ll.c_str());
     ret = (unsigned int)ActivationType::ACT_UNKNOWN;
-    break;
-  case TOKEN_LAYER:
-    for (i = 0; i < layer_string.size(); i++) {
-      if (!strncasecmp(layer_string[i].c_str(), ll.c_str(),
-                       layer_string[i].size())) {
-        return (i);
-      }
-    }
-    ret = (unsigned int)LayerType::LAYER_UNKNOWN;
     break;
   case TOKEN_WEIGHT_INIT:
     for (i = 0; i < weight_ini_string.size(); i++) {
@@ -506,6 +482,11 @@ std::vector<std::string> split(const std::string &s, std::regex &reg) {
     ++iter;
   }
   return out;
+}
+
+bool istrequal(const std::string &a, const std::string &b) {
+  return std::equal(a.begin(), a.end(), b.begin(),
+                    [](char a, char b) { return tolower(a) == tolower(b); });
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/utils/parse_util.h
+++ b/nntrainer/utils/parse_util.h
@@ -29,6 +29,8 @@
 #include <string>
 #include <vector>
 
+#include <ml-api-common.h>
+
 namespace nntrainer {
 
 #define NN_RETURN_STATUS()         \
@@ -40,22 +42,19 @@ namespace nntrainer {
 
 /**
  * @brief     Enumeration for input configuration file parsing
- *            0. OPT     ( Optimizer Token )
- *            1. LOSS    ( Loss Function Token )
- *            2. MODEL   ( Model Token )
- *            3. ACTI    ( Activation Token )
- *            4. LAYER   ( Layer Token )
- *            5. WEIGHT_INIT  ( Weight Initializer Token )
- *            7. WEIGHT_REGULARIZER  ( Weight Decay Token )
- *            8. PADDING  ( Padding Token )
- *            9. POOLING  ( Pooling Token )
- *            9. UNKNOWN
+ *            0. LOSS    ( Loss Function Token )
+ *            1. MODEL   ( Model Token )
+ *            2. ACTI    ( Activation Token )
+ *            3. WEIGHT_INIT  ( Weight Initializer Token )
+ *            4. WEIGHT_REGULARIZER  ( Weight Decay Token )
+ *            5. PADDING  ( Padding Token )
+ *            6. POOLING  ( Pooling Token )
+ *            7. UNKNOWN
  */
 typedef enum {
   TOKEN_LOSS,
   TOKEN_MODEL,
   TOKEN_ACTI,
-  TOKEN_LAYER,
   TOKEN_WEIGHT_INIT,
   TOKEN_WEIGHT_REGULARIZER,
   TOKEN_PADDING,
@@ -198,6 +197,15 @@ void printInstance(std::ostream &out, const T &t) {
   out << '<' << typeid(*t).name() << " at " << t << '>' << std::endl;
 }
 
+/**
+ * @brief Cast insensitive string comparison
+ *
+ * @param a first string to compare
+ * @param b second string to compare
+ * @return true if string is case-insensitive equal
+ * @return false if string is case-insensitive not equal
+ */
+bool istrequal(const std::string &a, const std::string &b);
 } /* namespace nntrainer */
 
 #endif /* __cplusplus */

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -42,25 +42,42 @@ TEST(ccapi_model, construct_02_p) {
  * @brief Neural Network Layer Contruct Test
  */
 TEST(ccapi_layer, construct_01_n) {
-  EXPECT_THROW(ml::train::createLayer(ml::train::LayerType::LAYER_UNKNOWN),
-               std::invalid_argument);
+  EXPECT_THROW(ml::train::createLayer("unknown type"), std::invalid_argument);
 }
 
 /**
  * @brief Neural Network Layer Contruct Test
  */
 TEST(ccapi_layer, construct_02_p) {
-  EXPECT_NO_THROW(ml::train::createLayer(ml::train::LayerType::LAYER_IN));
-  EXPECT_NO_THROW(ml::train::createLayer(ml::train::LayerType::LAYER_FC));
-  EXPECT_NO_THROW(ml::train::createLayer(ml::train::LayerType::LAYER_BN));
-  EXPECT_NO_THROW(ml::train::createLayer(ml::train::LayerType::LAYER_CONV2D));
-  EXPECT_NO_THROW(
-    ml::train::createLayer(ml::train::LayerType::LAYER_POOLING2D));
-  EXPECT_NO_THROW(ml::train::createLayer(ml::train::LayerType::LAYER_FLATTEN));
-  EXPECT_NO_THROW(
-    ml::train::createLayer(ml::train::LayerType::LAYER_ACTIVATION));
-  EXPECT_NO_THROW(ml::train::createLayer(ml::train::LayerType::LAYER_ADDITION));
-  EXPECT_NO_THROW(ml::train::createLayer(ml::train::LayerType::LAYER_LOSS));
+  auto layer = ml::train::createLayer("input");
+  EXPECT_EQ(layer->getType(), "input");
+
+  layer = ml::train::createLayer("fully_connected");
+  EXPECT_EQ(layer->getType(), "fully_connected");
+
+  layer = ml::train::createLayer("batch_normalization");
+  EXPECT_EQ(layer->getType(), "batch_normalization");
+
+  layer = ml::train::createLayer("conv2d");
+  EXPECT_EQ(layer->getType(), "conv2d");
+
+  layer = ml::train::createLayer("pooling2d");
+  EXPECT_EQ(layer->getType(), "pooling2d");
+
+  layer = ml::train::createLayer("flatten");
+  EXPECT_EQ(layer->getType(), "flatten");
+
+  layer = ml::train::createLayer("activation");
+  EXPECT_EQ(layer->getType(), "activation");
+
+  layer = ml::train::createLayer("addition");
+  EXPECT_EQ(layer->getType(), "addition");
+
+  layer = ml::train::createLayer("loss");
+  EXPECT_EQ(layer->getType(), "loss");
+
+  layer = ml::train::createLayer("Loss");
+  EXPECT_EQ(layer->getType(), "loss");
 }
 
 /**
@@ -133,15 +150,14 @@ TEST(nntrainer_ccapi, train_dataset_with_file_01_p) {
   EXPECT_NO_THROW(model =
                     ml::train::createModel(ml::train::ModelType::NEURAL_NET));
 
-  EXPECT_NO_THROW(layer = ml::train::createLayer(ml::train::LayerType::LAYER_IN,
-                                                 {"input_shape=1:1:62720",
-                                                  "normalization=true",
-                                                  "bias_initializer=zeros"}));
+  EXPECT_NO_THROW(layer = ml::train::createLayer(
+                    "input", {"input_shape=1:1:62720", "normalization=true",
+                              "bias_initializer=zeros"}));
   EXPECT_NO_THROW(model->addLayer(layer));
 
   EXPECT_NO_THROW(
     layer = ml::train::createLayer(
-      ml::train::LayerType::LAYER_FC,
+      "fully_connected",
       {"unit= 10", "activation=softmax", "bias_initializer=zeros",
        "weight_regularizer=l2norm", "weight_regularizer_constant=0.005",
        "weight_initializer=xavier_uniform"}));
@@ -183,15 +199,14 @@ TEST(nntrainer_ccapi, train_dataset_with_generator_01_p) {
   EXPECT_NO_THROW(model =
                     ml::train::createModel(ml::train::ModelType::NEURAL_NET));
 
-  EXPECT_NO_THROW(layer = ml::train::createLayer(ml::train::LayerType::LAYER_IN,
-                                                 {"input_shape=1:1:62720",
-                                                  "normalization=true",
-                                                  "bias_initializer=zeros"}));
+  EXPECT_NO_THROW(layer = ml::train::createLayer(
+                    "input", {"input_shape=1:1:62720", "normalization=true",
+                              "bias_initializer=zeros"}));
   EXPECT_NO_THROW(model->addLayer(layer));
 
   EXPECT_NO_THROW(
     layer = ml::train::createLayer(
-      ml::train::LayerType::LAYER_FC,
+      "fully_connected",
       {"unit= 10", "activation=softmax", "bias_initializer=zeros",
        "weight_regularizer=l2norm", "weight_regularizer_constant=0.005",
        "weight_initializer=xavier_uniform"}));

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -170,7 +170,7 @@ TEST(nntrainer_capi_nnmodel, compile_05_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Find layer based on default name */
-  status = ml_train_model_get_layer(model, "Input0", &get_layer);
+  status = ml_train_model_get_layer(model, "input0", &get_layer);
   EXPECT_EQ(status, ML_ERROR_NONE);
   EXPECT_EQ(get_layer, layers[0]);
 
@@ -231,21 +231,21 @@ TEST(nntrainer_capi_nnmodel, compile_06_n) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Find layer before adding */
-  status = ml_train_model_get_layer(model, "Input0", &get_layer);
+  status = ml_train_model_get_layer(model, "input0", &get_layer);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 
   status = ml_train_model_add_layer(model, layers[0]);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Find layer based on default name */
-  status = ml_train_model_get_layer(model, "Input0", &get_layer);
+  status = ml_train_model_get_layer(model, "input0", &get_layer);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_train_layer_create(&layers[1], ML_TRAIN_LAYER_TYPE_FC);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Create another layer with same name, different type */
-  status = ml_train_layer_set_property(layers[1], "name=Input0", NULL);
+  status = ml_train_layer_set_property(layers[1], "name=input0", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Not add layer with existing name */

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -24,6 +24,7 @@
 #include <nntrainer_error.h>
 #include <nntrainer_test_util.h>
 #include <optimizer_factory.h>
+#include <parse_util.h>
 #include <pooling2d_layer.h>
 #include <tensor_dim.h>
 #include <util_func.h>
@@ -506,7 +507,8 @@ protected:
         EXPECT_NO_THROW(out = layers[idx]->forwarding({out})[0]);
       }
 
-      if (layers.back()->getType() == nntrainer::LayerType::LAYER_LOSS) {
+      if (nntrainer::istrequal(layers.back()->getType(),
+                               nntrainer::LossLayer::type)) {
         std::shared_ptr<nntrainer::LossLayer> loss_layer =
           std::static_pointer_cast<nntrainer::LossLayer>(layers.back());
         EXPECT_NO_THROW(out = loss_layer->forwarding({out}, {label})[0]);
@@ -532,8 +534,8 @@ protected:
       MAKE_SHARED_TENSOR(constant(1.0, 3, 1, 1, 15));
     sharedConstTensor back_out;
 
-    if (layers.size() &&
-        layers.back()->getType() == nntrainer::LayerType::LAYER_LOSS) {
+    if (layers.size() && nntrainer::istrequal(layers.back()->getType(),
+                                              nntrainer::LossLayer::type)) {
       if (with_loss) {
         EXPECT_NO_THROW(back_out = layers.back()->backwarding({label}, 1)[0]);
       } else {


### PR DESCRIPTION
- ~**#720** [Fix] Throw when read/save fails~
- ~**#721** [Optimizer] Change enum type to string~
- [Layer] Change layer type to string
```
This patch changes layer type to string

**Changes proposed in this PR:**
- Add Layer::getType() and Layer::type
- Add `istrequal` to the `parse_util` for case insensitive compare
- Test changes accordingly

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```