### PR TITLE
[backbone] Add ini backbone properties

### DIFF
--- a/docs/configuration-ini.md
+++ b/docs/configuration-ini.md
@@ -281,7 +281,27 @@ Start with a "[ ${layer name} ]" which must be unique throughtout the model. In 
 
 2. ```trainable = <bool>```
 
-   If this backbone must be trained. Only supported for ini backbones (nntrainer models).
+   If this backbone must be trained (defaults to false). Only supported for ini backbones (nntrainer models).
+
+3. ```Preload = <bool>```
+
+   Load pretrained weights from the saved modelfile of backbone (defaults to false). Only supported for ini backbone (nntrainer models).
+
+4. ```ScaleSize = <float>```
+
+   Scale the size of the layers from backbone (defaults to 1.0). This applies for fully connected and convolution layer for now, where the units and the output channels are scaled respectively. Only supported for ini backbone (nntrainer models). If the model is being scaled, it cannot be preloaded from the saved modelfile. Only of the two options, ScaleSize and Preload, must be set at once.
+
+5. ```InputShape = <string>```
+
+   Set the shape of the input layer for the backbone model. Only supported for ini backbones (nntrainer models).
+
+6. ```InputLayer = <string>```
+
+   Choose the start layer for the backbone. This allows taking a subgraph starting with the specified layer name as a backbone. Only supported for ini backbones (nntrainer models).
+
+7. ```OutputLayer = <string>```
+
+   Choose the end layer for the backbone. This allows taking a subgraph ending with the specified layer name as a backbone. Only supported for ini backbones (nntrainer models).
 ``
 Below is sample backbone section.
 

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -620,4 +620,9 @@ int Conv2DLayer::im2col(Tensor in_padded, TensorDim kdim, float *in_col,
   return status;
 }
 
+void Conv2DLayer::scaleSize(float scalesize) noexcept {
+  filter_size = (unsigned int)(scalesize * (float)filter_size);
+  filter_size = std::max(filter_size, 1u);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -109,6 +109,11 @@ public:
 
   static const std::string type;
 
+  /**
+   * @copydoc Layer::scaleSize(float scalesize)
+   */
+  void scaleSize(float scalesize) noexcept;
+
 private:
   unsigned int filter_size;
   std::array<unsigned int, CONV2D_DIM> kernel_size;

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -122,4 +122,10 @@ FullyConnectedLayer::backwarding(sharedConstTensors derivative, int iteration) {
 
   return {MAKE_SHARED_TENSOR(std::move(ret))};
 }
+
+void FullyConnectedLayer::scaleSize(float scalesize) noexcept {
+  unit = (unsigned int)(scalesize * (float)unit);
+  unit = std::max(unit, 1u);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -89,6 +89,11 @@ public:
 
   static const std::string type;
 
+  /**
+   * @copydoc Layer::scaleSize(float scalesize)
+   */
+  void scaleSize(float scalesize) noexcept;
+
 private:
   unsigned int unit;
 };

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -265,9 +265,36 @@ public:
   /**
    * @brief Set the batch for the layer
    * @param batch Batch value to be set
-   * @todo Make this private. Only model should be able to do this.
    */
   virtual void setBatch(unsigned int batch);
+
+  /**
+   * @brief Scale the size of this layer
+   * @param scalesize Scaling factor
+   * @note As the final size is going to be integer and the scalesize is float,
+   * the size is rounded to integer after scaling.
+   * @note Layer containing local variable must define this and update their
+   * shapes correspondingly. This can be called only prior to the initialization
+   * of the layer.
+   * @note We can assume that scale size is a non-zero positive value.
+   * @note In case the scaled size is less than 0, the size must be scaled back
+   * to 1 with a warning.
+   * @note The layer must be re-initialized for the new size to come to effect,
+   * if the layer has already been initialized. It is recommended to re-init the
+   * whole model as the neighboring layers will also need re-initialization.
+   */
+  virtual void scaleSize(float scalesize) noexcept {}
+
+  /**
+   * @brief Resets the input and output dimension for the layer
+   * @note This does not affect the number of inputs/outputs
+   */
+  void resetDimension() {
+    input_dim.clear();
+    input_dim.resize(num_inputs);
+    output_dim.clear();
+    output_dim.resize(num_outputs);
+  }
 
 protected:
   /**

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -618,6 +618,43 @@ int NeuralNetwork::extendGraph(GraphType graph, std::string prefix) {
   return ML_ERROR_NONE;
 }
 
+std::vector<std::shared_ptr<Layer>>
+NeuralNetwork::getGraph(const std::string &input_layer,
+                        const std::string &output_layer) {
+  /** count layers after output layer */
+  unsigned int num_layers_remove_end = 0;
+  if (!output_layer.empty()) {
+    for (auto iter = layers.rbegin(); iter != layers.rend(); iter++) {
+      if ((*iter)->getName() != output_layer)
+        num_layers_remove_end++;
+      else
+        break;
+    }
+  }
+
+  if (num_layers_remove_end == layers.size())
+    return {};
+
+  /** count layers before input layer */
+  unsigned int num_layers_remove_start = 0;
+  if (!input_layer.empty()) {
+    for (auto iter = layers.begin();
+         iter != layers.end() - num_layers_remove_end; iter++) {
+      if ((*iter)->getName() != input_layer)
+        num_layers_remove_start++;
+      else
+        break;
+    }
+  }
+
+  /** copy the graph and return */
+  GraphType ret;
+  std::copy(layers.begin() + num_layers_remove_start,
+            layers.end() - num_layers_remove_end, std::back_inserter(ret));
+
+  return ret;
+}
+
 int NeuralNetwork::setOptimizer(
   std::shared_ptr<ml::train::Optimizer> optimizer) {
   if (initialized) {

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -308,7 +308,8 @@ public:
    * copied.
    * @retval current graph
    */
-  GraphType getGraph() { return layers; }
+  GraphType getGraph(const std::string &input_layer = "",
+                     const std::string &output_layer = "");
 
   /**
    * @brief     Set loss type for the neural network.


### PR DESCRIPTION
Added ini backbone properties :
    - scaleSize - scale the size of the model
    - preload - load the weights of this backbone model before adding to the model
    preload has issues which requires the format of the model file to update
    wait for #361 

Commit2:
    Added support for subgraph of a given ini backbone
    Added corresponding unittests as well
    
**Self evaluation:**
    1. Build test: [x]Passed [ ]Failed [ ]Skipped
    2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
