### PR TITLE
[AppContext] Add AppContext

### DIFF
--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file	 app_context.cpp
+ * @date	 10 November 2020
+ * @brief	 This file contains app context related functions and classes that
+ * manages the global configuration of the current environment
+ * @see		 https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ *
+ */
+#include <dirent.h>
+#include <iostream>
+#include <sstream>
+
+#include <app_context.h>
+#include <nntrainer_log.h>
+#include <util_func.h>
+
+namespace nntrainer {
+
+AppContext AppContext::instance;
+
+/**
+ * @brief initiate global context
+ *
+ */
+static void init_global_context_nntrainer(void) __attribute__((constructor));
+
+/**
+ * @brief finialize global context
+ *
+ */
+static void fini_global_context_nntrainer(void) __attribute__((destructor));
+
+static void init_global_context_nntrainer(void) {}
+
+static void fini_global_context_nntrainer(void) {}
+
+AppContext &AppContext::Global() { return AppContext::instance; }
+
+static const std::string func_tag = "[AppContext::setWorkingDirectory] ";
+
+void AppContext::setWorkingDirectory(const std::string &base) {
+  DIR *dir = opendir(base.c_str());
+
+  if (!dir) {
+    std::stringstream ss;
+    ss << func_tag << "path is not directory or has no permission: " << base;
+    throw std::invalid_argument(ss.str().c_str());
+  }
+  closedir(dir);
+
+  char *ret = realpath(base.c_str(), nullptr);
+
+  if (ret == nullptr) {
+    std::stringstream ss;
+    ss << func_tag << "failed to get canonical path for the path: ";
+    throw std::invalid_argument(ss.str().c_str());
+  }
+
+  working_path_base = std::string(ret);
+  ml_logd("working path base has set: %s", working_path_base.c_str());
+  free(ret);
+}
+
+const std::string AppContext::getWorkingPath(const std::string &path) {
+
+  /// if path is absolute, return path
+  if (path[0] == '/') {
+    return path;
+  }
+
+  if (working_path_base == std::string()) {
+    return path == std::string() ? "." : path;
+  }
+
+  return path == std::string() ? working_path_base
+                               : working_path_base + "/" + path;
+}
+
+} // namespace nntrainer

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file	 app_context.h
+ * @date	 10 November 2020
+ * @brief	 This file contains app context related functions and classes that
+ * manages the global configuration of the current environment
+ * @see		 https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __APP_CONTEXT_H__
+#define __APP_CONTEXT_H__
+
+#include <string>
+
+namespace nntrainer {
+
+/**
+ * @class AppContext contains user-dependent configuration
+ * @brief App
+ */
+class AppContext {
+public:
+  /**
+   * @brief Get Global app context.
+   *
+   * @return AppContext&
+   */
+  static AppContext &Global();
+
+  /**
+   * @brief Set Working Directory for a relative path. working directory is set
+   * canonically
+   * @param[in] base base directory
+   * @throw std::invalid_argument if path is not valid for current system
+   */
+  void setWorkingDirectory(const std::string &base);
+
+  /**
+   * @brief Get Working Path from a relative or representation of a path
+   * strating from @a working_path_base.
+   * @param[in] path to make full path
+   * @return If absolute path is given, returns @a path
+   * If relative path is given and working_path_base is not set, return
+   * relative path.
+   * If relative path is given and working_path_base has set, return absolute
+   * path from current working directory
+   */
+  const std::string getWorkingPath(const std::string &path = "");
+
+private:
+  static AppContext instance;
+
+  std::string working_path_base;
+};
+
+} // namespace nntrainer
+
+#endif /* __APP_CONTEXT_H__ */

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -4,7 +4,7 @@ nntrainer_inc = [
 ]
 
 nntrainer_sources = []
-nntrainer_headers = []
+nntrainer_headers = ['app_context.h']
 
 # pc file is not present for 'ml-api-common' yet
 if cxx.has_header('nnstreamer/ml-api-common.h', required: false)
@@ -43,6 +43,7 @@ endforeach
 
 nntrainer_common_sources = [
   'nntrainer_logger.cpp',
+  'app_context.cpp'
 ]
 
 foreach s : nntrainer_common_sources

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -382,6 +382,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/optimizer_factory.h
 %{_includedir}/nntrainer/nntrainer-api-common.h
 %{_includedir}/nntrainer/weight.h
+%{_includedir}/nntrainer/app_context.h
 %{_libdir}/pkgconfig/nntrainer.pc
 
 %files devel-static

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -32,7 +32,8 @@ test_target = [
   'unittest_databuffer_file',
   'unittest_nntrainer_modelfile',
   'unittest_nntrainer_models',
-  'unittest_nntrainer_graph'
+  'unittest_nntrainer_graph',
+  'unittest_nntrainer_appcontext'
 ]
 
 foreach target: test_target

--- a/test/unittest/unittest_nntrainer_appcontext.cpp
+++ b/test/unittest/unittest_nntrainer_appcontext.cpp
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file	 unittest_app_context.h
+ * @date	 9 November 2020
+ * @brief	 This file contains app context related functions and classes that
+ * manages the global configuration of the current environment
+ * @see		 https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <unistd.h>
+
+#include <app_context.h>
+
+class nntrainerAppContextDirectory : public ::testing::Test {
+
+protected:
+  void SetUp() override {
+    int status = mkdir("testdir", 0777);
+    ASSERT_EQ(status, 0);
+
+    std::ofstream file("testdir/testfile.txt");
+    ASSERT_EQ(file.fail(), false);
+
+    file << "testdata";
+    ASSERT_EQ(file.fail(), false);
+
+    file.close();
+
+    char buf[2048];
+    char *ret = getcwd(buf, 2048);
+    ASSERT_NE(ret, nullptr);
+    current_directory = std::string(buf);
+  }
+
+  void TearDown() override {
+    int status = remove("testdir/testfile.txt");
+    ASSERT_EQ(status, 0);
+
+    status = rmdir("testdir");
+    ASSERT_EQ(status, 0);
+  }
+
+  std::string current_directory;
+};
+
+TEST_F(nntrainerAppContextDirectory, readFromGetPath_p) {
+  nntrainer::AppContext ac = nntrainer::AppContext::Global();
+
+  std::string path = ac.getWorkingPath("testfile.txt");
+  EXPECT_EQ(path, "testfile.txt");
+
+  ac.setWorkingDirectory("testdir");
+
+  path = ac.getWorkingPath("testfile.txt");
+  EXPECT_EQ(path, current_directory + "/testdir/testfile.txt");
+
+  std::ifstream file(path);
+  std::string s;
+  file >> s;
+  EXPECT_EQ(s, "testdata");
+
+  file.close();
+
+  path = ac.getWorkingPath("/absolute/path");
+  EXPECT_EQ(path, "/absolute/path");
+
+  path = ac.getWorkingPath("");
+  EXPECT_EQ(path, current_directory + "/testdir");
+}
+
+TEST_F(nntrainerAppContextDirectory, notExisitingSetDirectory_n) {
+  nntrainer::AppContext ac = nntrainer::AppContext::Global();
+
+  EXPECT_THROW(ac.setWorkingDirectory("testdir_does_not_exist"),
+               std::invalid_argument);
+}
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error duing InitGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error duing RUN_ALL_TSETS()" << std::endl;
+  }
+
+  return result;
+}


### PR DESCRIPTION
This patch add basic app context with setting current working directory

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

Implemented without `std::experimental::filesystem`
~Current implementation (as of `f0d969f`) uses std::experimental::filesystem.~

~**ndk does not support std::filesystem until r22**~
~So either 1. we have to support from r22 or 2. reimplement related method in this patch.~

~IMO, I think we should stick to r21 since other people might not be using r22. and reimplement `app_context.cpp`~