### PR TITLE
[AppContext][Optimizer] Register Default ops at the beginning @open sesame 11/27 15:35

### DIFF
--- a/api/ccapi/include/optimizer.h
+++ b/api/ccapi/include/optimizer.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include <ml-api-common.h>
 #include <nntrainer-api-common.h>
 
 namespace ml {
@@ -131,6 +132,24 @@ std::unique_ptr<Optimizer>
 createOptimizer(const OptimizerType &type,
                 const std::vector<std::string> &properties = {});
 
+/*
+ * @brief General Optimizer Factory function to register optimizer
+ *
+ * @param props property representation
+ * @return std::unique_ptr<ml::train::Optimizer> created object
+ */
+template <typename T,
+          std::enable_if_t<std::is_base_of<Optimizer, T>::value, T> * = nullptr>
+std::unique_ptr<Optimizer>
+createOptimizer(const std::vector<std::string> &props = {}) {
+  std::unique_ptr<Optimizer> ptr = std::make_unique<T>();
+
+  if (ptr->setProperty(props) != ML_ERROR_NONE) {
+    throw std::invalid_argument("Set properties failed for optimizer");
+  }
+  return ptr;
+}
+
 namespace optimizer {
 
 /**
@@ -150,6 +169,7 @@ SGD(const std::vector<std::string> &properties = {}) {
 }
 
 } // namespace optimizer
+
 } // namespace train
 } // namespace ml
 

--- a/api/ccapi/src/factory.cpp
+++ b/api/ccapi/src/factory.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include <app_context.h>
 #include <databuffer.h>
 #include <databuffer_factory.h>
 #include <layer.h>
@@ -101,12 +102,8 @@ CrossEntropy(const std::vector<std::string> &properties) {
 std::unique_ptr<Optimizer>
 createOptimizer(const std::string &type,
                 const std::vector<std::string> &properties) {
-  std::unique_ptr<Optimizer> optimizer = nntrainer::createOptimizer(type);
-
-  if (optimizer->setProperty(properties) != ML_ERROR_NONE)
-    throw std::invalid_argument("Set properties failed for optimizer");
-
-  return optimizer;
+  auto ac = nntrainer::AppContext::Global();
+  return ac.createObject<Optimizer>(type, properties);
 }
 
 /**

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -15,15 +15,15 @@
 #include <iostream>
 #include <sstream>
 
+#include <adam.h>
 #include <app_context.h>
 #include <nntrainer_log.h>
+#include <sgd.h>
 #include <util_func.h>
 
 namespace nntrainer {
 
 std::mutex factory_mutex;
-
-AppContext AppContext::instance;
 
 /**
  * @brief initiate global context
@@ -37,11 +37,22 @@ static void init_global_context_nntrainer(void) __attribute__((constructor));
  */
 static void fini_global_context_nntrainer(void) __attribute__((destructor));
 
-static void init_global_context_nntrainer(void) {}
+static void init_global_context_nntrainer(void) {
+  using OptType = ml::train::OptimizerType;
+
+  auto &ac = AppContext::Global();
+  ac.registerFactory(ml::train::createOptimizer<SGD>, SGD::type, OptType::SGD);
+  ac.registerFactory(ml::train::createOptimizer<Adam>);
+  ac.registerFactory(AppContext::unknownFactory<ml::train::Optimizer>,
+                     "unknown", OptType::UNKNOWN);
+}
 
 static void fini_global_context_nntrainer(void) {}
 
-AppContext &AppContext::Global() { return AppContext::instance; }
+AppContext &AppContext::Global() {
+  static AppContext instance;
+  return instance;
+}
 
 static const std::string func_tag = "[AppContext::setWorkingDirectory] ";
 

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -106,7 +106,7 @@ public:
    * @brief Factory register function, use this function to register custom
    * object
    *
-   * @tparam T object to create
+   * @tparam T object to create. Currently Optimizer is supported
    * @param factory factory function that creates std::unique_ptr<T>
    * @param key key to access the factory, if key is empty, try to find key by
    * calling factory({})->getType();
@@ -150,6 +150,14 @@ public:
     return assigned_int_key;
   }
 
+  /**
+   * @brief Create an Object from the integer key
+   *
+   * @tparam T Type of Object, currently, Only optimizer is supported
+   * @param int_key integer key
+   * @param props property
+   * @return PtrType<T> unique pointer to the object
+   */
   template <typename T>
   PtrType<T> createObject(const int int_key, const PropsType &props = {}) {
     auto &index = std::get<IndexType<T>>(factory_map);
@@ -166,6 +174,14 @@ public:
     return createObject<T>(entry->second, props);
   }
 
+  /**
+   * @brief Create an Object from the string key
+   *
+   * @tparam T Type of object, currently, only optimizer is supported
+   * @param key integer key
+   * @param props property
+   * @return PtrType<T> unique pointer to the object
+   */
   template <typename T>
   PtrType<T> createObject(const std::string &key, const PropsType &props = {}) {
     auto &index = std::get<IndexType<T>>(factory_map);
@@ -195,8 +211,6 @@ public:
   }
 
 private:
-  static AppContext instance;
-
   FactoryMap<ml::train::Optimizer> factory_map;
   std::string working_path_base;
 };

--- a/nntrainer/optimizers/adam.h
+++ b/nntrainer/optimizers/adam.h
@@ -90,9 +90,9 @@ public:
    */
   double getEpsilon() { return epsilon; }
 
-private:
   static const std::string type;
 
+private:
   /**
    * @brief Internal Tensors for adam Optimizer
    */

--- a/nntrainer/optimizers/sgd.h
+++ b/nntrainer/optimizers/sgd.h
@@ -42,7 +42,6 @@ public:
    */
   const std::string getType() const { return SGD::type; }
 
-private:
   static const std::string type;
 };
 } /* namespace nntrainer */


### PR DESCRIPTION
- ~**#728** [AppContext] Add AppContext~
- ~**#745** [AppContext] Add registerer,invoke factory methods~
- [AppContext] Register Default ops at the begining
```
**Changes proposed in this PR:**
- Register default optimizer at the beginning of the load

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```