### PR TITLE
[tensor] Tensor operations change style

### DIFF
--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -85,17 +85,20 @@ public:
 
   /**
    * @brief       Calculate softmax for Tensor Type
-   * @param[in] t Tensor
+   * @param[in] x Tensor
+   * @param[out] output output Tensor
    * @retval      Tensor
    */
-  static Tensor softmax(Tensor const &x);
+  static Tensor softmax(Tensor const &x, Tensor &output);
 
   /**
    * @brief     derivative softmax function for Tensor Type
    * @param[in] x Tensor
+   * @param[out] output output Tensor
+   * @param[in] derivative derivative Tensor from next layer
    * @retVal    Tensor
    */
-  static Tensor softmaxPrime(Tensor const &x,
+  static Tensor softmaxPrime(Tensor const &x, Tensor &output,
                              Tensor const &derivative = Tensor());
 
   /**
@@ -149,36 +152,37 @@ public:
   static const std::string type;
 
 private:
-  std::function<Tensor(Tensor const &)> _act_fn;
-  std::function<Tensor(Tensor const &, Tensor const &)> _act_prime_fn;
+  std::function<Tensor(Tensor const &, Tensor &)> _act_fn;
+  std::function<Tensor(Tensor const &, Tensor &, Tensor const &)> _act_prime_fn;
 
   /**
    * @brief setActivation by custom activation function
    * @note  apply derivative as this activation_prime_fn does not utilize
    * derivative
-   * @param[in] std::function<Tensor(Tensor const &)> activation_fn activation
-   *            function to be used
-   * @param[in] std::function<Tensor(Tensor const &)> activation_prime_fn
-   *            activation_prime_function to be used
+   * @param[in] std::function<Tensor(Tensor const &, Tensor &)> activation_fn
+   * activation function to be used
+   * @param[in] std::function<Tensor(Tensor const &, Tensor &)>
+   * activation_prime_fn activation_prime_function to be used
    * @retval #ML_ERROR_NONE when successful
    */
   int setActivation(
-    std::function<Tensor(Tensor const &)> const &activation_fn,
-    std::function<Tensor(Tensor const &)> const &activation_prime_fn);
+    std::function<Tensor(Tensor const &, Tensor &)> const &activation_fn,
+    std::function<Tensor(Tensor const &, Tensor &)> const &activation_prime_fn);
 
   /**
    * @brief setActivation by custom activation function
    * @note  derivative not applied here as this activation_prime_fn applies
    * derivative itself
-   * @param[in] std::function<Tensor(Tensor const &)> activation_fn activation
-   *            function to be used
-   * @param[in] std::function<Tensor(Tensor const &, Tensor const &)>
+   * @param[in] std::function<Tensor(Tensor const &, Tensor &)> activation_fn
+   * activation function to be used
+   * @param[in] std::function<Tensor(Tensor const &, Tensor &, Tensor const &)>
    * activation_prime_fn activation_prime_function to be used
    * @retval #ML_ERROR_NONE when successful
    */
-  int setActivation(std::function<Tensor(Tensor const &)> const &activation_fn,
-                    std::function<Tensor(Tensor const &, Tensor const &)> const
-                      &activation_prime_fn);
+  int setActivation(
+    std::function<Tensor(Tensor const &, Tensor &)> const &activation_fn,
+    std::function<Tensor(Tensor const &, Tensor &, Tensor const &)> const
+      &activation_prime_fn);
 
   /**
    * @brief setActivation by custom activation function

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -82,7 +82,7 @@ sharedConstTensors FullyConnectedLayer::forwarding(sharedConstTensors in) {
   Tensor &bias = weightAt(static_cast<int>(FCParams::bias)).getVariableRef();
 
   input = *in[0];
-  hidden = input.dot(weight);
+  hidden = input.dot(weight, hidden);
   hidden.add_i(bias);
 
   if (weight_regularizer == WeightRegularizerType::l2norm) {
@@ -108,10 +108,10 @@ FullyConnectedLayer::backwarding(sharedConstTensors derivative, int iteration) {
   Tensor &djdw = weightAt(weight_idx).getGradientRef();
   Tensor &djdb = weightAt(bias_idx).getGradientRef();
 
-  Tensor ret = derivative[0]->dot(weight, false, true);
+  ret_derivative = derivative[0]->dot(weight, ret_derivative, false, true);
   djdb = derivative[0]->sum(0);
 
-  djdw = input.dot(*derivative[0], true, false);
+  djdw = input.dot(*derivative[0], djdw, true, false);
   if (isWeightRegularizerL2Norm())
     djdw.add_i(weight, weight_regularizer_constant);
   djdw = djdw.sum(0);
@@ -120,6 +120,6 @@ FullyConnectedLayer::backwarding(sharedConstTensors derivative, int iteration) {
     opt->apply_gradients(weight_list, num_weights, iteration);
   }
 
-  return {MAKE_SHARED_TENSOR(std::move(ret))};
+  return {MAKE_SHARED_TENSOR(ret_derivative)};
 }
 } /* namespace nntrainer */

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -307,6 +307,7 @@ protected:
    *            forwading result
    */
   Tensor hidden;
+  Tensor ret_derivative; /** derivative to be returned to previous layer */
 
   /**
    * @brief     Dimension of input activation

--- a/nntrainer/optimizers/adam.cpp
+++ b/nntrainer/optimizers/adam.cpp
@@ -98,7 +98,9 @@ void Adam::apply_gradient(Weight &weight, int tensor_idx, double updated_lr,
   wv.multiply_i(beta2);
   wv.add_i(x_grad.multiply(x_grad), 1.0f - beta2);
 
-  x.add_i(wm.divide(wv.apply(sqrtEps)), -updated_lr);
+  Tensor divider;
+  divider = wv.apply(sqrtEps, divider);
+  x.add_i(wm.divide(divider), -updated_lr);
 }
 
 void Adam::setProperty(const PropertyType type, const std::string &value) {

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -416,11 +416,27 @@ public:
   Tensor apply(std::function<float(float)> f) const;
 
   /**
+   * @brief     Apply function element by element
+   * @param[in] *function function pointer applied
+   * @param[out] output output tensor
+   * @retval    Tensor
+   */
+  Tensor apply(std::function<float(float)> f, Tensor &output) const;
+
+  /**
    * @brief     Apply function to Tensor
    * @param[in] *function function pointer applied
    * @retval    Tensor
    */
   Tensor apply(std::function<Tensor(Tensor)> f) const;
+
+  /**
+   * @brief     Apply function to Tensor
+   * @param[in] *function function pointer applied
+   * @param[out] output output tensor
+   * @retval    Tensor
+   */
+  Tensor apply(std::function<Tensor(Tensor, Tensor &)> f, Tensor &output) const;
 
   Tensor apply_i(std::function<int(const Tensor &)> f) const;
 
@@ -436,6 +452,12 @@ public:
    * @retval    unsigned int length of the current _data
    */
   unsigned int length() const { return dim.getDataLen(); }
+
+  /**
+   * @brief     Get if the tensor has not been initialized
+   * @retval    true if not initialized
+   */
+  bool uninitialized() const { return length() == 0; }
 
   /**
    * @brief     Get size of the data
@@ -479,6 +501,16 @@ public:
    * @param[in] from Tensor to be copied
    */
   void copy(const Tensor &from);
+
+  /**
+   * @brief Get slice of the tensor, sliced by batch
+   * @param[in] offset offset to start the slice
+   * @param[in] size size of the slice
+   * @retval slice of this tensor
+   * @note This function provides a slice of this tensor, and does not create a
+   * copy
+   */
+  Tensor getBatchSlice(unsigned int offset, unsigned int size) const;
 
   /**
    * @brief     Convient wrapper for inplace copy of @a this.

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -303,6 +303,19 @@ public:
   Tensor dot(Tensor const &m, bool trans = false, bool trans_m = false) const;
 
   /**
+   * @brief     Dot Product of Tensor ( equal MxM )
+   * @details   This applies dot of the last dimension of this and second-last
+   * dimension of passed tensor m.
+   * @param[in] m Tensor
+   * @param[in] output output Tensor
+   * @param[in] trans Transpose
+   * @param[in] trans_m Transpose m
+   * @retval    Calculated Tensor
+   */
+  Tensor dot(Tensor const &m, Tensor &output, bool trans = false,
+             bool trans_m = false) const;
+
+  /**
    * @brief     Transpose Tensor
    * @param[in] direction to transpose ex) 0:2:1
    * @retval    Calculated Tensor

--- a/nntrainer/utils/util_func.cpp
+++ b/nntrainer/utils/util_func.cpp
@@ -92,9 +92,12 @@ Tensor zero_pad(int batch, Tensor const &in, unsigned int const *padding) {
 }
 
 // This is strip pad and return original tensor
-Tensor strip_pad(Tensor const &in, unsigned int const *padding) {
-  Tensor output(in.batch(), in.channel(), in.height() - padding[0] * 2,
-                in.width() - padding[1] * 2);
+Tensor strip_pad(Tensor const &in, unsigned int const *padding,
+                 Tensor &output) {
+  if (output.uninitialized()) {
+    output = Tensor(in.batch(), in.channel(), in.height() - padding[0] * 2,
+                    in.width() - padding[1] * 2);
+  }
   output.setZero();
 
   for (unsigned int i = 0; i < in.batch(); ++i) {

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -72,9 +72,10 @@ Tensor zero_pad(int batch, Tensor const &in, unsigned int const *padding);
  * @brief     strip padding
  * @param[in] x input
  * @param[in] padding 2D padding size
+ * @param[in] output output tensor
  * @retVal Tensor output tensor without padding
  */
-Tensor strip_pad(Tensor const &in, unsigned int const *padding);
+Tensor strip_pad(Tensor const &in, unsigned int const *padding, Tensor &output);
 
 /**
  * @brief     rotate 180 dgree

--- a/test/unittest/unittest_nntrainer_activations.cpp
+++ b/test/unittest/unittest_nntrainer_activations.cpp
@@ -44,7 +44,7 @@ TEST(nntrainer_activation, softmax_01_p) {
 
   GEN_TEST_INPUT(T, (i * (width) + l + 1));
 
-  Results = T.apply(nntrainer::ActivationLayer::softmax);
+  Results = T.apply(nntrainer::ActivationLayer::softmax, Results);
   float *data = Results.getData();
   ASSERT_NE(nullptr, data);
 
@@ -63,14 +63,16 @@ TEST(nntrainer_activation, softmax_prime_01_p) {
   nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, (i * (width) + k + 1));
 
-  nntrainer::Tensor softmax_result =
-    input.apply(nntrainer::ActivationLayer::softmax);
+  nntrainer::Tensor softmax_result;
+  softmax_result =
+    input.apply(nntrainer::ActivationLayer::softmax, softmax_result);
 
   float *data = softmax_result.getData();
   ASSERT_NE(nullptr, data);
 
-  nntrainer::Tensor softmax_prime_result =
-    nntrainer::ActivationLayer::softmaxPrime(softmax_result);
+  nntrainer::Tensor softmax_prime_result;
+  softmax_prime_result = nntrainer::ActivationLayer::softmaxPrime(
+    softmax_result, softmax_prime_result);
 
   data = softmax_prime_result.getData();
   ASSERT_NE(nullptr, data);


### PR DESCRIPTION
**Commit1:**
Update tensor op signature for dot
    Further, fc layer has been updated based on this signature
    
**Commit2:**
This patch updates tensor signature to include output for apply
    Correspondingly, activation layer and loss layer have been updated.
    
More changes in the patch
    - Convolution layer has been updated to reuse its output derivative.
    - added a getBatchSlice() which provides a slice of the original tensor by batch
    and avoids creating a copy everytime

Note : Using a class like Weight for inputs/outputs has been inteniontionally skipped to limit the size of this patch. Further, the `ret_derivative` is not created as a vector, will be done when extended to a new class. 

See also #670 #732

**Self evaluation:**
    1. Build test: [x]Passed [ ]Failed [ ]Skipped
    2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>