### PR TITLE
[conv] Remove standardization and normalization

### DIFF
--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -81,14 +81,6 @@ sharedConstTensors Conv2DLayer::forwarding(sharedConstTensors in) {
   TensorDim &in_dim = input_dim[0];
   TensorDim &out_dim = output_dim[0];
 
-  if (normalization) {
-    input = input.normalization();
-  }
-
-  if (standardization) {
-    input = input.standardization();
-  }
-
   TensorDim hidden_dim = output_dim[0];
   hidden = Tensor(hidden_dim);
   hidden.setZero();
@@ -457,18 +449,6 @@ void Conv2DLayer::setProperty(const PropertyType type,
   case PropertyType::padding:
     if (!value.empty()) {
       status = getValues(CONV2D_DIM, value, (int *)(padding.data()));
-      throw_status(status);
-    }
-    break;
-  case PropertyType::normalization:
-    if (!value.empty()) {
-      status = setBoolean(normalization, value);
-      throw_status(status);
-    }
-    break;
-  case PropertyType::standardization:
-    if (!value.empty()) {
-      status = setBoolean(standardization, value);
       throw_status(status);
     }
     break;

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -999,7 +999,6 @@ protected:
                   "weight_regularizer=l2norm |"
                   "weight_regularizer_constant= 0.005 |"
                   "weight_initializer=xavier_uniform |"
-                  "normalization=true |"
                   "filters=12 | kernel_size= 5,5 | stride=3,3 | padding=1,1");
 
     EXPECT_EQ(status, ML_ERROR_NONE);


### PR DESCRIPTION
Remove support for standardization and normalization from convolution operations
These operations do not support backwarding for now, and cannot be forwarded with conv2d layer for this reason
For now, this is only supported with input layer which is never backwarded

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>