### PR TITLE
[tensor] Reduce overall memory overhead

### DIFF
--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -81,14 +81,6 @@ sharedConstTensors Conv2DLayer::forwarding(sharedConstTensors in) {
   TensorDim &in_dim = input_dim[0];
   TensorDim &out_dim = output_dim[0];
 
-  if (normalization) {
-    input = input.normalization();
-  }
-
-  if (standardization) {
-    input = input.standardization();
-  }
-
   TensorDim hidden_dim = output_dim[0];
   if (hidden.uninitialized()) {
     hidden = Tensor(hidden_dim);
@@ -454,18 +446,6 @@ void Conv2DLayer::setProperty(const PropertyType type,
   case PropertyType::padding:
     if (!value.empty()) {
       status = getValues(CONV2D_DIM, value, (int *)(padding.data()));
-      throw_status(status);
-    }
-    break;
-  case PropertyType::normalization:
-    if (!value.empty()) {
-      status = setBoolean(normalization, value);
-      throw_status(status);
-    }
-    break;
-  case PropertyType::standardization:
-    if (!value.empty()) {
-      status = setBoolean(standardization, value);
       throw_status(status);
     }
     break;

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -114,7 +114,6 @@ FullyConnectedLayer::backwarding(sharedConstTensors derivative, int iteration) {
   djdw = input.dot(*derivative[0], djdw, true, false);
   if (isWeightRegularizerL2Norm())
     djdw.add_i(weight, weight_regularizer_constant);
-  djdw = djdw.sum(0);
 
   if (trainable) {
     opt->apply_gradients(weight_list, num_weights, iteration);

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -58,9 +58,9 @@ sharedConstTensors InputLayer::forwarding(sharedConstTensors in) {
 
   hidden = input;
   if (normalization)
-    hidden = hidden.normalization();
+    hidden.normalization_i();
   if (standardization)
-    hidden = hidden.standardization();
+    hidden.standardization_i();
 
   return {MAKE_SHARED_TENSOR(hidden)};
 }

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -476,6 +476,9 @@ int NeuralNetwork::train_run() {
     iter = 0;
   }
 
+  sharedTensor in = MAKE_SHARED_TENSOR(getInputDimension()[0]);
+  sharedTensor label = MAKE_SHARED_TENSOR(getOutputDimension()[0]);
+
   for (epoch_idx = epoch_idx + 1; epoch_idx <= epochs; ++epoch_idx) {
     training.loss = 0.0f;
     status = data_buffer->run(nntrainer::BufferType::BUF_TRAIN);
@@ -493,9 +496,6 @@ int NeuralNetwork::train_run() {
     }
 
     int count = 0;
-
-    sharedTensor in = MAKE_SHARED_TENSOR(getInputDimension()[0]);
-    sharedTensor label = MAKE_SHARED_TENSOR(getOutputDimension()[0]);
 
     while (true) {
       if (data_buffer->getDataFromBuffer(nntrainer::BufferType::BUF_TRAIN,

--- a/nntrainer/optimizers/adam.cpp
+++ b/nntrainer/optimizers/adam.cpp
@@ -98,6 +98,7 @@ void Adam::apply_gradient(Weight &weight, int tensor_idx, double updated_lr,
   wv.multiply_i(beta2);
   wv.add_i(x_grad.multiply(x_grad), 1.0f - beta2);
 
+  // TODO: combine this operation to reduce from two temp allocations to one
   Tensor divider;
   divider = wv.apply(sqrtEps, divider);
   x.add_i(wm.divide(divider), -updated_lr);

--- a/nntrainer/optimizers/adam.cpp
+++ b/nntrainer/optimizers/adam.cpp
@@ -86,7 +86,7 @@ void Adam::apply_gradient(Weight &weight, int tensor_idx, double updated_lr,
   // x.add_i(wm.divide(denom), -ll / biasCorrection1);
 
   std::function<double(double)> sqrtEps = [&](double f) {
-    return sqrtDouble(f) + this->epsilon;
+    return 1 / (sqrtDouble(f) + this->epsilon);
   };
 
   Tensor &wm = weight_mv[tensor_idx].first;
@@ -98,10 +98,10 @@ void Adam::apply_gradient(Weight &weight, int tensor_idx, double updated_lr,
   wv.multiply_i(beta2);
   wv.add_i(x_grad.multiply(x_grad), 1.0f - beta2);
 
-  // TODO: combine this operation to reduce from two temp allocations to one
   Tensor divider;
   divider = wv.apply(sqrtEps, divider);
-  x.add_i(wm.divide(divider), -updated_lr);
+  divider.multiply_i(wm);
+  x.add_i(divider, -updated_lr);
 }
 
 void Adam::setProperty(const PropertyType type, const std::string &value) {

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -383,7 +383,9 @@ Tensor Tensor::sum_by_batch() {
  */
 Tensor Tensor::sum(unsigned int axis, float alpha) const {
   Tensor ret;
-
+  return sum(ret, axis, alpha);
+}
+Tensor Tensor::sum(Tensor &ret, unsigned int axis, float alpha) const {
   const float *data = getData();
 
   if (axis >= 4)
@@ -394,7 +396,7 @@ Tensor Tensor::sum(unsigned int axis, float alpha) const {
 
   switch (axis) {
   case 0: {
-    ret = Tensor(1, dim.channel(), dim.height(), dim.width());
+    CREATE_IF_EMPTY_DIMS(ret, 1, dim.channel(), dim.height(), dim.width());
     unsigned int feat_len = dim.getFeatureLen();
     unsigned int batch = dim.batch();
     Tensor ones(1, 1, 1, batch);
@@ -403,7 +405,7 @@ Tensor Tensor::sum(unsigned int axis, float alpha) const {
           ones.getData(), 1, 0.0, ret.getData(), 1);
   } break;
   case 1: {
-    ret = Tensor(dim.batch(), 1, dim.height(), dim.width());
+    CREATE_IF_EMPTY_DIMS(ret, dim.batch(), 1, dim.height(), dim.width());
     unsigned int feat_len = dim.height() * dim.width();
     unsigned int channel = dim.channel();
     Tensor ones(1, 1, 1, channel);
@@ -416,7 +418,7 @@ Tensor Tensor::sum(unsigned int axis, float alpha) const {
     }
   } break;
   case 2: {
-    ret = Tensor(dim.batch(), dim.channel(), 1, dim.width());
+    CREATE_IF_EMPTY_DIMS(ret, dim.batch(), dim.channel(), 1, dim.width());
     unsigned int width = dim.width();
     unsigned int height = dim.height();
     Tensor ones(1, 1, 1, height);
@@ -433,7 +435,7 @@ Tensor Tensor::sum(unsigned int axis, float alpha) const {
     }
   } break;
   case 3: {
-    ret = Tensor(dim.batch(), dim.channel(), dim.height(), 1);
+    CREATE_IF_EMPTY_DIMS(ret, dim.batch(), dim.channel(), dim.height(), 1);
     unsigned int m = ret.dim.getDataLen();
     unsigned int n = dim.width();
     Tensor ones(1, 1, 1, n);

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -341,6 +341,19 @@ public:
   Tensor sum(unsigned int axis, float alpha = 1.0) const;
 
   /**
+   * @brief     sum all the Tensor elements according to the axis
+   *            0 : batch direction
+   *            1 : channel direction
+   *            2 : height direction
+   *            3 : width direction
+   * @param[out] output output tensor
+   * @param[in] axis Axis to calculate sum along
+   * @param[in] alpha Scale the sum by this value
+   * @retval    Calculated Tensor
+   */
+  Tensor sum(Tensor &output, unsigned int axis, float alpha = 1.0) const;
+
+  /**
    * @brief sum all the Tensor by multiple axes
    *
    * @param axes axes to sum along

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -395,13 +395,25 @@ public:
    * @brief     Normalize the Tensor elements
    * @retval    Calculated Tensor
    */
-  Tensor normalization() const;
+  Tensor normalization(Tensor &output) const;
 
   /**
    * @brief     Standardize the Tensor elements
    * @retval    Calculated Tensor
    */
-  Tensor standardization() const;
+  Tensor standardization(Tensor &output) const;
+
+  /**
+   * @brief     Normalize the Tensor elements in-place
+   * @retval    Calculated Tensor
+   */
+  void normalization_i();
+
+  /**
+   * @brief     Standardize the Tensor elements in-place
+   * @retval    Calculated Tensor
+   */
+  void standardization_i();
 
   /**
    * @brief     Fill the Tensor elements with zero

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -999,7 +999,6 @@ protected:
                   "weight_regularizer=l2norm |"
                   "weight_regularizer_constant= 0.005 |"
                   "weight_initializer=xavier_uniform |"
-                  "normalization=true |"
                   "filters=12 | kernel_size= 5,5 | stride=3,3 | padding=1,1");
 
     EXPECT_EQ(status, ML_ERROR_NONE);


### PR DESCRIPTION
Reduce overall tensor memory overhead
    - standardization and normalization now take in-place
    - input and label tensor in train are now allocated only once externally and reused for each epoch
    that being used in each epoch
    - add_i does not allocate new memory now
    - removed support for normalization and standardization for conv layer
    
See also #670 #732

**Self evaluation:**
    1. Build test: [x]Passed [ ]Failed [ ]Skipped
    2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>