### PR TITLE
[Layer] Add built-in ops to the context @open sesame 11/30 11:08

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include <ml-api-common.h>
 #include <nntrainer-api-common.h>
 
 namespace ml {
@@ -362,6 +363,23 @@ std::unique_ptr<Layer>
 CrossEntropy(const std::vector<std::string> &properties = {});
 
 } // namespace loss
+
+/**
+ * @brief General Layer Factory function to register Layer
+ *
+ * @param props property representation
+ * @return std::unique_ptr<ml::train::Layer> created object
+ */
+template <typename T,
+          std::enable_if_t<std::is_base_of<Layer, T>::value, T> * = nullptr>
+std::unique_ptr<Layer> createLayer(const std::vector<std::string> &props = {}) {
+  std::unique_ptr<Layer> ptr = std::make_unique<T>();
+
+  if (ptr->setProperty(props) != ML_ERROR_NONE) {
+    throw std::invalid_argument("Set properties failed for layer");
+  }
+  return ptr;
+}
 
 } // namespace train
 } // namespace ml

--- a/api/ccapi/src/factory.cpp
+++ b/api/ccapi/src/factory.cpp
@@ -40,12 +40,8 @@ std::unique_ptr<Layer> createLayer(const LayerType &type,
  */
 std::unique_ptr<Layer> createLayer(const std::string &type,
                                    const std::vector<std::string> &properties) {
-  std::unique_ptr<Layer> layer = nntrainer::createLayer(type);
-
-  if (layer->setProperty(properties) != ML_ERROR_NONE)
-    throw std::invalid_argument("Set properties failed for layer");
-
-  return layer;
+  auto &ac = nntrainer::AppContext::Global();
+  return ac.createObject<Layer>(type, properties);
 }
 
 std::unique_ptr<Optimizer>
@@ -102,7 +98,7 @@ CrossEntropy(const std::vector<std::string> &properties) {
 std::unique_ptr<Optimizer>
 createOptimizer(const std::string &type,
                 const std::vector<std::string> &properties) {
-  auto ac = nntrainer::AppContext::Global();
+  auto &ac = nntrainer::AppContext::Global();
   return ac.createObject<Optimizer>(type, properties);
 }
 

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -2,11 +2,11 @@
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
- * @file	 app_context.h
- * @date	 10 November 2020
- * @brief	 This file contains app context related functions and classes that
+ * @file   app_context.h
+ * @date   10 November 2020
+ * @brief  This file contains app context related functions and classes that
  * manages the global configuration of the current environment
- * @see		 https://github.com/nnstreamer/nntrainer
+ * @see    https://github.com/nnstreamer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug    No known bugs except for NYI items
  *
@@ -107,7 +107,7 @@ public:
    * @brief Factory register function, use this function to register custom
    * object
    *
-   * @tparam T object to create. Currently Optimizer is supported
+   * @tparam T object to create. Currently Optimizer, Layer is supported
    * @param factory factory function that creates std::unique_ptr<T>
    * @param key key to access the factory, if key is empty, try to find key by
    * calling factory({})->getType();
@@ -222,7 +222,7 @@ public:
   }
 
 private:
-  FactoryMap<ml::train::Optimizer> factory_map;
+  FactoryMap<ml::train::Optimizer, ml::train::Layer> factory_map;
   std::string working_path_base;
 };
 

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -15,6 +15,7 @@
 #ifndef __APP_CONTEXT_H__
 #define __APP_CONTEXT_H__
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -124,7 +125,11 @@ public:
     auto &str_map = std::get<StrIndexType<T>>(index);
     auto &int_map = std::get<IntIndexType>(index);
 
-    const std::string &assigned_key = key == "" ? factory({})->getType() : key;
+    std::string assigned_key = key == "" ? factory({})->getType() : key;
+
+    std::transform(assigned_key.begin(), assigned_key.end(),
+                   assigned_key.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
 
     const std::lock_guard<std::mutex> lock(factory_mutex);
     if (str_map.find(assigned_key) != str_map.end()) {
@@ -187,11 +192,17 @@ public:
     auto &index = std::get<IndexType<T>>(factory_map);
     auto &str_map = std::get<StrIndexType<T>>(index);
 
-    const auto &entry = str_map.find(key);
+    std::string lower_key;
+    lower_key.resize(key.length());
+
+    std::transform(key.begin(), key.end(), lower_key.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+
+    const auto &entry = str_map.find(lower_key);
 
     if (entry == str_map.end()) {
       std::stringstream ss;
-      ss << "Key is not found for the object. Key: " << key;
+      ss << "Key is not found for the object. Key: " << lower_key;
       throw exception::not_supported(ss.str().c_str());
     }
 

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -21,7 +21,7 @@
 #include <optimizer.h>
 
 /**
- * @brief Neural Network Model Contruct Test
+ * @brief Neural Network Model Construct Test
  */
 TEST(ccapi_model, construct_01_n) {
   EXPECT_THROW(ml::train::createModel(ml::train::ModelType::UNKNOWN),
@@ -32,14 +32,14 @@ TEST(ccapi_model, construct_01_n) {
 }
 
 /**
- * @brief Neural Network Model Contruct Test
+ * @brief Neural Network Model Construct Test
  */
 TEST(ccapi_model, construct_02_p) {
   EXPECT_NO_THROW(ml::train::createModel(ml::train::ModelType::NEURAL_NET));
 }
 
 /**
- * @brief Neural Network Layer Contruct Test
+ * @brief Neural Network Layer Construct Test
  */
 TEST(ccapi_layer, construct_01_n) {
   EXPECT_THROW(ml::train::createLayer("unknown type"), std::invalid_argument);

--- a/test/unittest/unittest_nntrainer_appcontext.cpp
+++ b/test/unittest/unittest_nntrainer_appcontext.cpp
@@ -122,6 +122,32 @@ public:
   void checkValidation() {}
 };
 
+/// @todo solidify the api signature
+class CustomLayer : public ml::train::Layer {
+public:
+  static const std::string type;
+
+  int setProperty(std::vector<std::string> values) { return 1; }
+
+  void setProperty(const PropertyType type, const std::string &value = "") {}
+
+  int checkValidation() { return 1; }
+
+  float getLoss() { return 0.0f; }
+
+  void setTrainable(bool train) {}
+
+  bool getFlatten() { return true; }
+
+  std::string getName() noexcept { return ""; }
+
+  const std::string getType() const { return CustomLayer::type; }
+
+  void printPreset(std::ostream &out, PrintPreset preset) {}
+};
+
+const std::string CustomLayer::type = "identity_layer";
+
 using AC = nntrainer::AppContext;
 
 AC::PtrType<ml::train::Optimizer>
@@ -131,6 +157,7 @@ createCustomOptimizer(const AC::PropsType &v) {
   return p;
 }
 
+/// @todo change this to TEST_P to add other types of object
 TEST(nntrainerAppContextObjs, RegisterCreateCustomOptimizer_p) {
 
   // register without key in this case, getType() will be called and used


### PR DESCRIPTION
- ~**#745** [AppContext] Add registerer,invoke factory methods~
- ~**#746** [AppContext] Register Default ops at the begining~
- [AppContext] Fix key is case sensitive
```
In current semantics, type key should be case insensitive however case
was sensitive, this patch fixes the issue.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
- [Layer] Add built-in ops to the context
```
**Changes proposed in this PR:**
- Add default layers to the global context

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```