### PR TITLE
[layers] Split backwarding into smaller functions

### DIFF
--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -52,8 +52,7 @@ void ActivationLayer::forwarding(sharedConstTensors in) {
   _act_fn(net_input[0]->var, hidden_);
 }
 
-void ActivationLayer::backwarding(int iteration,
-                                  sharedConstTensors derivative) {
+void ActivationLayer::calcDerivative(sharedConstTensors derivative) {
   Tensor &deriv = net_hidden[0]->grad;
   Tensor &ret = net_input[0]->grad;
 

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -67,9 +67,9 @@ public:
   void forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
 
   /**
    * @brief setActivation by preset ActivationType

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -53,7 +53,8 @@ void AdditionLayer::forwarding(sharedConstTensors in) {
   }
 }
 
-void AdditionLayer::backwarding(int iteration, sharedConstTensors derivative) {
+void AdditionLayer::calcDerivative(sharedConstTensors derivative) {
+
   for (unsigned int i = 0; i < num_inputs; ++i) {
     net_input[i]->grad = net_hidden[0]->grad;
   }

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -77,9 +77,9 @@ public:
   void forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -81,9 +81,14 @@ public:
   void forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
+
+  /**
+   * @copydoc Layer::calcGradient(sharedConstTensors in)
+   */
+  void calcGradient(sharedConstTensors in);
 
   /**
    * @brief     copy layer
@@ -115,12 +120,12 @@ public:
 
 private:
   Tensor cvar; /**< training variance saved in bn_layer::forwarding and used in
-                    bn_layer::backwarding */
+                    bn_layer::calcDerivative */
   Tensor invstd; /**<  inversed training std for backward pass */
 
   Tensor deviation; /**< (input - current_average) */
 
-  Tensor x_normalized; /**< normalized axis saved for backwarding */
+  Tensor x_normalized; /**< normalized axis saved for calcDerivative */
   float epsilon;       /**< epsilon */
   float momentum;      /**< momentum */
   int axis;            /**< Target axis, axis inferred at initialize when -1 */

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -88,7 +88,7 @@ void ConcatLayer::forwarding(sharedConstTensors in) {
   }
 }
 
-void ConcatLayer::backwarding(int iteration, sharedConstTensors derivative) {
+void ConcatLayer::calcDerivative(sharedConstTensors derivative) {
   TensorDim d = net_hidden[0]->grad.getDim();
 
   unsigned int position = 0;

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -77,9 +77,9 @@ public:
   void forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -76,9 +76,14 @@ public:
   void forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
+
+  /**
+   * @copydoc Layer::calcGradient(sharedConstTensors in)
+   */
+  void calcGradient(sharedConstTensors in);
 
   /**
    * @brief     copy layer

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -57,9 +57,14 @@ public:
   void forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
+
+  /**
+   * @copydoc Layer::calcGradient(sharedConstTensors in)
+   */
+  void calcGradient(sharedConstTensors in);
 
   /**
    * @brief     copy layer

--- a/nntrainer/layers/flatten_layer.cpp
+++ b/nntrainer/layers/flatten_layer.cpp
@@ -47,7 +47,7 @@ void FlattenLayer::forwarding(sharedConstTensors in) {
   net_hidden[0]->var = temp;
 }
 
-void FlattenLayer::backwarding(int iteration, sharedConstTensors in) {
+void FlattenLayer::calcDerivative(sharedConstTensors in) {
   Tensor temp = net_hidden[0]->grad;
   temp.reshape(net_input[0]->grad.getDim());
   net_input[0]->grad = temp;

--- a/nntrainer/layers/flatten_layer.h
+++ b/nntrainer/layers/flatten_layer.h
@@ -73,9 +73,9 @@ public:
   void forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -63,7 +63,10 @@ void InputLayer::forwarding(sharedConstTensors in) {
     hidden_.standardization_i();
 }
 
-void InputLayer::backwarding(int iteration, sharedConstTensors in) {}
+void InputLayer::calcDerivative(sharedConstTensors in) {
+  throw exception::not_supported(
+    "calcDerivative for input layer is not supported");
+}
 
 int InputLayer::initialize() {
   int status = ML_ERROR_NONE;

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -78,9 +78,9 @@ public:
   void forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
 
   /**
    * @brief     Initializer of Input Layer

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -164,6 +164,12 @@ void Layer::save(std::ofstream &file) {
     opt->save(file);
 }
 
+void Layer::applyGradient(unsigned int iteration) {
+  if (trainable && num_weights > 0) {
+    opt->apply_gradients(weight_list, num_weights, iteration);
+  }
+}
+
 int Layer::setProperty(std::vector<std::string> values) {
   int status = ML_ERROR_NONE;
 

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -116,12 +116,34 @@ public:
   virtual sharedConstTensors forwarding_with_val(sharedConstTensors input);
 
   /**
-   * @brief     Back Propagation of a layer
+   * @brief     calc the derivative to be passed to the previous layer
    * @param[in] in List of Derivative Tensor from the next layer
-   * @param[in] iteration Iteration value for the Optimizer
    * @retval    Derivative List of Tensor for the previous layer
    */
-  virtual void backwarding(int iteration, sharedConstTensors in = {}) = 0;
+  virtual void calcDerivative(sharedConstTensors in) = 0;
+
+  /**
+   * @brief     Calculate the derivative of a layer
+   * @param[in] in List of Derivative Tensor from the next layer
+   */
+  virtual void calcGradient(sharedConstTensors in){};
+
+  /**
+   * @brief     Apply the gradient for the layer
+   * @param[in] iteration Iteration value for the Optimizer
+   */
+  virtual void applyGradient(unsigned int iteration);
+
+  /**
+   * @brief     Back Propagate the derivative to the previous layer
+   * @param[in] in List of Derivative Tensor from the next layer
+   * @retval    Derivative List of Tensor for the previous layer
+   */
+  virtual void backwarding(int iteration, sharedConstTensors in = {}) {
+    calcGradient(in);
+    calcDerivative(in);
+    applyGradient(iteration);
+  }
 
   virtual sharedConstTensors backwarding_with_val(int iteration,
                                                   sharedConstTensors deriv,

--- a/nntrainer/layers/loss_layer.cpp
+++ b/nntrainer/layers/loss_layer.cpp
@@ -135,7 +135,7 @@ void LossLayer::copy(std::shared_ptr<Layer> l) {
   this->loss_type = from->loss_type;
 }
 
-void LossLayer::backwarding(int iteration, sharedConstTensors derivative) {
+void LossLayer::calcDerivative(sharedConstTensors derivative) {
   Tensor &ret_derivative = net_input[0]->grad;
   Tensor y2 = *derivative[0];
   Tensor &y = net_input[0]->var;

--- a/nntrainer/layers/loss_layer.h
+++ b/nntrainer/layers/loss_layer.h
@@ -67,9 +67,9 @@ public:
                                 sharedConstTensors label);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
 
   /**
    * @brief     read layer Weight & Bias data from file

--- a/nntrainer/layers/nnstreamer_layer.cpp
+++ b/nntrainer/layers/nnstreamer_layer.cpp
@@ -203,9 +203,8 @@ void NNStreamerLayer::copy(std::shared_ptr<Layer> l) {
   this->modelfile = from->modelfile;
 }
 
-void NNStreamerLayer::backwarding(int iteration,
-                                  sharedConstTensors derivative) {
+void NNStreamerLayer::calcDerivative(sharedConstTensors derivative) {
   throw exception::not_supported(
-    "Backwarding is not supported for nnstreamer layer");
+    "calcDerivative is not supported for nnstreamer layer");
 }
 } /* namespace nntrainer */

--- a/nntrainer/layers/nnstreamer_layer.h
+++ b/nntrainer/layers/nnstreamer_layer.h
@@ -53,9 +53,9 @@ public:
   void forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
 
   /**
    * @copydoc Layer::copy(std::shared_ptr<layer> l)

--- a/nntrainer/layers/output_layer.cpp
+++ b/nntrainer/layers/output_layer.cpp
@@ -50,7 +50,7 @@ void OutputLayer::forwarding(sharedConstTensors in) {
   }
 }
 
-void OutputLayer::backwarding(int iteration, sharedConstTensors derivative) {
+void OutputLayer::calcDerivative(sharedConstTensors derivative) {
 
   Tensor &ret = net_input[0]->grad;
 

--- a/nntrainer/layers/output_layer.h
+++ b/nntrainer/layers/output_layer.h
@@ -77,9 +77,9 @@ public:
   void forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -83,8 +83,7 @@ void Pooling2DLayer::forwarding(sharedConstTensors in) {
   }
 }
 
-void Pooling2DLayer::backwarding(int iteration,
-                                 sharedConstTensors derivatives) {
+void Pooling2DLayer::calcDerivative(sharedConstTensors derivative) {
   unsigned int batch = input_dim[0].batch();
   unsigned int channel = input_dim[0].channel();
   unsigned int height = input_dim[0].height();

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -95,9 +95,9 @@ public:
   void forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
 
   /**
    * @copydoc Layer::setBatch(unsigned int batch)

--- a/nntrainer/layers/tflite_layer.cpp
+++ b/nntrainer/layers/tflite_layer.cpp
@@ -136,8 +136,8 @@ void TfLiteLayer::copy(std::shared_ptr<Layer> l) {
   this->modelfile = from->modelfile;
 }
 
-void TfLiteLayer::backwarding(int iteration, sharedConstTensors derivative) {
+void TfLiteLayer::calcDerivative(sharedConstTensors derivative) {
   throw exception::not_supported(
-    "Backwarding is not supported for tflite layer");
+    "calcDerivative is not supported for tflite layer");
 }
 } /* namespace nntrainer */

--- a/nntrainer/layers/tflite_layer.h
+++ b/nntrainer/layers/tflite_layer.h
@@ -52,9 +52,9 @@ public:
   void forwarding(sharedConstTensors in);
 
   /**
-   * @copydoc Layer::backwarding(sharedConstTensors in, int iteration)
+   * @copydoc Layer::calcDerivative(sharedConstTensors in)
    */
-  void backwarding(int iteration, sharedConstTensors in);
+  void calcDerivative(sharedConstTensors in);
 
   /**
    * @copydoc Layer::copy(std::shared_ptr<layer> l)

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <input_layer.h>
 #include <layer.h>
 #include <neuralnet.h>
 #include <weight.h>
@@ -163,6 +164,12 @@ public:
    * @param in input file stream
    */
   void read(std::ifstream &in);
+
+  /**
+   * @brief get Node type
+   *
+   * @return LayerType
+   */
 
 private:
   NodeType node;


### PR DESCRIPTION
Split layer backwarding into smaller functions for optimization purposes
    - calcDerivative() - calculate the derivative to be passed to previous layers
      this function must be implemented by all derived layers
    - calcGradient() - calculate the gradient for the weights of the layer
    - applyGradient() - apply the gradients to the weights of the layer
    
Also, now input->backwarding() throws than just silently not doing anything.
    
**Self evaluation:**
    1. Build test: [x]Passed [ ]Failed [ ]Skipped
    2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>