### PR TITLE
[graph] Skip backwarding for non-trainable layers

### DIFF
--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -45,7 +45,10 @@ public:
   /**
    * @brief     Constructor of NeuralNetwork Graph Class
    */
-  NetworkGraph() : num_node(0), def_name_count(0){};
+  NetworkGraph() :
+    num_node(0),
+    def_name_count(0),
+    skip_non_trainable_layers(0) {}
 
   /**
    * @brief add Edges between graph nodes
@@ -232,6 +235,14 @@ private:
   std::vector<std::shared_ptr<NetBuffers>>
     netBuffers;       /**< List of Buffers used to calculate layer */
   int def_name_count; /**< Count assigned to layer names declared by default */
+  unsigned int
+    skip_non_trainable_layers; /**< denotes the number of non-trainable layers
+                                  at the start of the graph */
+
+  /**
+   * @brief Calculate the number of non-trainable layers at the start
+   */
+  void countNonTrainableLayersAtBegin();
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -120,13 +120,13 @@ public:
    * @param[in] in List of Derivative Tensor from the next layer
    * @retval    Derivative List of Tensor for the previous layer
    */
-  virtual void calcDerivative(sharedConstTensors in) = 0;
+  virtual void calcDerivative(sharedConstTensors in = {}) = 0;
 
   /**
    * @brief     Calculate the derivative of a layer
    * @param[in] in List of Derivative Tensor from the next layer
    */
-  virtual void calcGradient(sharedConstTensors in){};
+  virtual void calcGradient(sharedConstTensors in = {}){};
 
   /**
    * @brief     Apply the gradient for the layer

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -235,6 +235,7 @@ int NeuralNetwork::initialize() {
   }
 
   setBatchSize(batch_size);
+
   initialized = true;
   return status;
 }


### PR DESCRIPTION
This patch skips the backwarding for the non-trainable layers.
    Further, the last trainable layer skips calcDerivative as well.
    This results in much fewer calculations as well as more importantly, reduced memory.
    
See also #732
    
**Self evaluation:**
    1. Build test: [x]Passed [ ]Failed [ ]Skipped
    2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>