### PR TITLE
[Deps] Remove openmp dependency

### DIFF
--- a/Applications/KNN/jni/Android.mk
+++ b/Applications/KNN/jni/Android.mk
@@ -61,8 +61,8 @@ LOCAL_ARM_NEON := true
 LOCAL_CFLAGS += -std=c++14 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib
 LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/arm64-v8a/
 LOCAL_CXXFLAGS += -std=c++14
-LOCAL_CFLAGS += -pthread -fopenmp -fexceptions
-LOCAL_LDFLAGS += -fopenmp -fexceptions
+LOCAL_CFLAGS += -pthread -fexceptions
+LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := knn_sample

--- a/Applications/LogisticRegression/jni/Android.mk
+++ b/Applications/LogisticRegression/jni/Android.mk
@@ -32,8 +32,8 @@ LOCAL_ARM_NEON := true
 LOCAL_CFLAGS += -std=c++14 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib
 LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/$(TARGET_ARCH_ABI)/
 LOCAL_CXXFLAGS += -std=c++14
-LOCAL_CFLAGS += -pthread -fopenmp -fexceptions
-LOCAL_LDFLAGS += -fopenmp -fexceptions
+LOCAL_CFLAGS += -pthread -fexceptions
+LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_logistic

--- a/Applications/MNIST/jni/Android.mk
+++ b/Applications/MNIST/jni/Android.mk
@@ -34,8 +34,8 @@ LOCAL_ARM_NEON := true
 LOCAL_CFLAGS += -std=c++14 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib
 LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/$(TARGET_ARCH_ABI)/
 LOCAL_CXXFLAGS += -std=c++14
-LOCAL_CFLAGS += -pthread -fopenmp -fexceptions
-LOCAL_LDFLAGS += -fopenmp -fexceptions
+LOCAL_CFLAGS += -pthread -fexceptions
+LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_mnist

--- a/Applications/ReinforcementLearning/DeepQ/jni/Android.mk
+++ b/Applications/ReinforcementLearning/DeepQ/jni/Android.mk
@@ -35,8 +35,8 @@ LOCAL_ARM_NEON := true
 LOCAL_CFLAGS += -std=c++14 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib -fexceptions -DUSING_CUSTOM_ENV
 LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/arm64-v8a/
 LOCAL_CXXFLAGS += -std=c++14 -DUSING_CUSTOM_ENV
-LOCAL_CFLAGS += -pthread -fopenmp -fexceptions
-LOCAL_LDFLAGS += -fopenmp -fexceptions
+LOCAL_CFLAGS += -pthread -fexceptions
+LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_deepq

--- a/Applications/TransferLearning/CIFAR_Classification/jni/Android.mk
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/Android.mk
@@ -73,8 +73,8 @@ LOCAL_ARM_NEON := true
 LOCAL_CFLAGS += -std=c++14 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib
 LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/$(TARGET_ARCH_ABI)/
 LOCAL_CXXFLAGS += -std=c++14
-LOCAL_CFLAGS += -pthread -fopenmp -fexceptions
-LOCAL_LDFLAGS += -fopenmp -fexceptions
+LOCAL_CFLAGS += -pthread -fexceptions
+LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_classification
@@ -96,8 +96,8 @@ LOCAL_ARM_NEON := true
 LOCAL_CFLAGS += -std=c++14 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib
 LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/$(TARGET_ARCH_ABI)/
 LOCAL_CXXFLAGS += -std=c++14
-LOCAL_CFLAGS += -pthread -fopenmp -fexceptions
-LOCAL_LDFLAGS += -fopenmp -fexceptions
+LOCAL_CFLAGS += -pthread -fexceptions
+LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_classification_func

--- a/Applications/TransferLearning/Draw_Classification/jni/Android.mk
+++ b/Applications/TransferLearning/Draw_Classification/jni/Android.mk
@@ -53,8 +53,8 @@ LOCAL_ARM_NEON := true
 LOCAL_CFLAGS += -std=c++14 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib
 LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/$(TARGET_ARCH_ABI)/
 LOCAL_CXXFLAGS += -std=c++14
-LOCAL_CFLAGS += -pthread -fopenmp -fexceptions
-LOCAL_LDFLAGS += -fopenmp -fexceptions
+LOCAL_CFLAGS += -pthread -fexceptions
+LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_training

--- a/Applications/VGG/jni/Android.mk
+++ b/Applications/VGG/jni/Android.mk
@@ -40,8 +40,8 @@ LOCAL_ARM_NEON := true
 LOCAL_CFLAGS += -std=c++14 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib
 LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/$(TARGET_ARCH_ABI)/
 LOCAL_CXXFLAGS += -std=c++14
-LOCAL_CFLAGS += -pthread -fopenmp -fexceptions
-LOCAL_LDFLAGS += -fopenmp -fexceptions
+LOCAL_CFLAGS += -pthread -fexceptions
+LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_vgg

--- a/Applications/utils/jni/Android.mk
+++ b/Applications/utils/jni/Android.mk
@@ -13,9 +13,9 @@ UTILS_SRCS := $(NNTRAINER_APPLICATION)/utils/jni/bitmap_helpers.cpp
 UTILS_INCLUDES := $(NNTRAINER_APPLICATION)/utils/jni/includes
 
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -pthread -fopenmp -fexceptions
+LOCAL_CFLAGS        += -pthread -fexceptions
 LOCAL_CXXFLAGS      += -std=c++14 -frtti -fexceptions
-LOCAL_LDFLAGS       += -fuse-ld=bfd -fopenmp
+LOCAL_LDFLAGS       += -fuse-ld=bfd
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -107,9 +107,9 @@ INIPARSER_SRCS := $(INIPARSER_ROOT)/src/iniparser.c \
 INIPARSER_INCLUDES := $(INIPARSER_ROOT)/src
 
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -pthread -fopenmp -fexceptions
+LOCAL_CFLAGS        += -pthread -fexceptions
 LOCAL_CXXFLAGS      += -std=c++14 -frtti -fexceptions
-LOCAL_LDFLAGS       += -fuse-ld=bfd -fopenmp
+LOCAL_LDFLAGS       += -fuse-ld=bfd
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog
@@ -146,9 +146,9 @@ CAPI_NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 LOCAL_SHARED_LIBRARIES := nntrainer
 
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -pthread -fopenmp -fexceptions
+LOCAL_CFLAGS        += -pthread -fexceptions
 LOCAL_CXXFLAGS      += -std=c++14 -frtti -fexceptions
-LOCAL_LDFLAGS       += -fuse-ld=bfd -fopenmp
+LOCAL_LDFLAGS       += -fuse-ld=bfd
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog
@@ -176,9 +176,9 @@ CCAPI_NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 LOCAL_SHARED_LIBRARIES := nntrainer
 
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -pthread -fopenmp -fexceptions
+LOCAL_CFLAGS        += -pthread -fexceptions
 LOCAL_CXXFLAGS      += -std=c++14 -frtti -fexceptions
-LOCAL_LDFLAGS       += -fuse-ld=bfd -fopenmp
+LOCAL_LDFLAGS       += -fuse-ld=bfd
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog

--- a/meson.build
+++ b/meson.build
@@ -84,7 +84,6 @@ nntrainer_conf.set('LIB_INSTALL_DIR', nntrainer_libdir)
 nntrainer_conf.set('INCLUDE_INSTALL_DIR', nntrainer_includedir)
 
 dummy_dep = dependency('', required: false)
-openmp_dep = dependency('openmp')
 
 blas_dep = dummy_dep
 # Dependencies

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -15,7 +15,6 @@ endif
 
 # Dependencies
 nntrainer_base_deps=[
-  openmp_dep,
   blas_dep,
   iniparser_dep,
   libm_dep,


### PR DESCRIPTION
Openmp is no longer used. It is deleted to reduce memory consumption

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

resolves #758 
