### PR TITLE
[conv2d] Refactor conv2d layer

### DIFF
--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -138,8 +138,6 @@ void Conv2DLayer::forwarding(sharedConstTensors in) {
   loss = 0.0f;
   if (weight_regularizer == WeightRegularizerType::l2norm) {
     loss += weight_regularizer_constant * 0.5f * (filter_kernel.l2norm());
-    // TODO: remove this average
-    loss /= filter_size;
   }
 }
 

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -163,7 +163,8 @@ private:
                   TensorDim outdim,
                   const std::array<unsigned int, CONV2D_DIM> &stride,
                   const std::array<unsigned int, CONV2D_DIM> &pad, float *out,
-                  unsigned int osize, bool channel_mode);
+                  unsigned int osize, bool channel_mode,
+                  float beta_dgemm = 0.0f);
 
   /**
    * @brief     reform the data to 2d matrix

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -146,33 +146,6 @@ private:
   int setFilter(int f);
 
   /**
-   * @brief     set normalization
-   * @param[in] enable boolean
-   */
-  void setNormalization(bool enable) { this->normalization = enable; };
-
-  /**
-   * @brief     set standardization
-   * @param[in] enable boolean
-   */
-  void setStandardization(bool enable) { this->standardization = enable; };
-
-  /**
-   * @brief     calculation convolution
-   * @param[in] in input tensor data
-   * @param[in] indim input tensor dimension
-   * @param[in] kernel convolution kernel data
-   * @param[in] kdim convolution kernel dimension
-   * @param[in] out output
-   * @param[in] stride stride value : x, y direction
-   * @param[in] bias bias data
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int conv2d(float *in, TensorDim indim, const float *kernel, TensorDim kdim,
-             float *out, unsigned int const *stride, float bias);
-
-  /**
    * @brief     calculation convolution with cblas_*gemm
    * @param[in] mkernel kernel data
    * @param[in] kdim kernel data demension

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -53,8 +53,10 @@ int FullyConnectedLayer::initialize() {
   dim.batch(1);
 
   setNumWeights(2);
-  weightAt(0) = std::move(Weight(dim, weight_initializer, true, "FC:weight"));
-  weightAt(1) = std::move(Weight(bias_dim, bias_initializer, true, "FC:bias"));
+  weightAt(static_cast<int>(FCParams::weight)) =
+    std::move(Weight(dim, weight_initializer, true, "FC:weight"));
+  weightAt(static_cast<int>(FCParams::bias)) =
+    std::move(Weight(bias_dim, bias_initializer, true, "FC:bias"));
 
   return status;
 }

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -618,6 +618,22 @@ public:
   const float *getAddress(unsigned int i) const;
 
   /**
+   * @brief    get address of n-d data
+   */
+  float *getAddress(unsigned int b, unsigned int c, unsigned int h,
+                    unsigned int w) {
+    return getAddress(getIndex(b, c, h, w));
+  }
+
+  /**
+   * @brief    get address of n-d data
+   */
+  const float *getAddress(unsigned int b, unsigned int c, unsigned int h,
+                          unsigned int w) const {
+    return getAddress(getIndex(b, c, h, w));
+  }
+
+  /**
    * @brief     set Tensor Dim
    * @param[in] d TensorDim
    * @note      Throws std::invalid_argument if size mismatch

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -116,6 +116,7 @@ protected:
   void matchOutput(const float *result, const char *expected) {
     nntrainer::Tensor golden;
     loadFile(expected, golden);
+    /** FIXME: golden.length() is possibly 0 many times, verify and fix this */
     matchOutput(result, golden.getData(), golden.length());
   }
 


### PR DESCRIPTION
**Commit 1: **

Conv2d layer has some issues #761
    This patch addresses some of them:
    - Weight is now independent of the filter size. Different filter
    weights have now been combined. This has resulted in easier addressing of weights
    - Above combining of weights also reduced many mem-copies of weights to bring it in a particular shape
    - Moved to use getSlice() to get access to some data than creating copies
    
Now, all layers have fixed number of weights.

**Commit 2:**

Regularization loss for conv2d layer took average over output filters
    than adding it up. This patch fixes it.
    
**Commit 3:**

This patch provides more optimizations for conv2d
    by avoiding more memcopies and operations along with modification
    to internal interface of conv2d_gemm operation

Resolves #761
    
**Self evaluation:**
    1. Build test: [x]Passed [ ]Failed [ ]Skipped
    2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>