### PR TITLE
[memory] Memory based optimizations and fixes

### DIFF
--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -78,7 +78,10 @@ int ActivationLayer::setActivation(
   _act_fn = activation_fn;
   _act_prime_fn = [activation_prime_fn](Tensor const &x, Tensor &ret_derivative,
                                         Tensor const &derivative) {
-    return derivative.multiply(activation_prime_fn(x, ret_derivative));
+    ret_derivative = activation_prime_fn(x, ret_derivative);
+    ret_derivative.multiply_i(derivative);
+
+    return ret_derivative;
   };
 
   return ML_ERROR_NONE;
@@ -92,7 +95,10 @@ int ActivationLayer::setActivation(
   };
   _act_prime_fn = [activation_prime_fn](Tensor const &x, Tensor &ret_derivative,
                                         Tensor const &derivative) {
-    return derivative.multiply(x.apply(activation_prime_fn, ret_derivative));
+    ret_derivative = x.apply(activation_prime_fn, ret_derivative);
+    ret_derivative.multiply_i(derivative);
+
+    return ret_derivative;
   };
 
   return ML_ERROR_NONE;

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -144,19 +144,15 @@ void BatchNormalizationLayer::forwarding(sharedConstTensors in) {
 
     cvar.add_i(epsilon);
     invstd = cvar.pow(-0.5f);
-
-    hidden_ = deviation.multiply(invstd, hidden_);
-    hidden_.multiply_i(gamma);
-    hidden_.add_i(beta);
   } else {
     deviation = input_.subtract(mu);
     invstd = var.add(epsilon);
     invstd.pow_i(-0.5f);
-
-    hidden_ = deviation.multiply(invstd, hidden_);
-    hidden_.multiply_i(gamma);
-    hidden_.add_i(beta);
   }
+
+  hidden_ = deviation.multiply(invstd, hidden_);
+  hidden_.multiply_i(gamma);
+  hidden_.add_i(beta);
 }
 
 void BatchNormalizationLayer::calcDerivative(sharedConstTensors derivative) {

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -125,10 +125,9 @@ private:
 
   Tensor deviation; /**< (input - current_average) */
 
-  Tensor x_normalized; /**< normalized axis saved for calcDerivative */
-  float epsilon;       /**< epsilon */
-  float momentum;      /**< momentum */
-  int axis;            /**< Target axis, axis inferred at initialize when -1 */
+  float epsilon;  /**< epsilon */
+  float momentum; /**< momentum */
+  int axis;       /**< Target axis, axis inferred at initialize when -1 */
 
   std::vector<unsigned int> axes_to_reduce;      /**< target axes to reduce */
   std::array<WeightInitializer, 4> initializers; /**< weight initializers */

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -269,7 +269,7 @@ void Layer::setProperty(const PropertyType type, const std::string &value) {
     break;
   case PropertyType::input_layers:
     if (!value.empty()) {
-      std::regex reg("\\,+");
+      static const std::regex reg("\\,+");
       std::vector<std::string> concat_layers = split(value, reg);
 
       num_inputs = concat_layers.size();
@@ -281,7 +281,7 @@ void Layer::setProperty(const PropertyType type, const std::string &value) {
     break;
   case PropertyType::output_layers:
     if (!value.empty()) {
-      std::regex reg("\\,+");
+      static const std::regex reg("\\,+");
       std::vector<std::string> concat_layers = split(value, reg);
 
       num_outputs = concat_layers.size();

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -147,7 +147,7 @@ private:
    * @param[in] in input tensor
    * @retval Tensor outoput tensor
    */
-  Tensor pooling2d(unsigned int batch, Tensor &in);
+  Tensor pooling2d(unsigned int batch, Tensor &in, Tensor &output);
 
   /**
    * @brief     set Pooling Type

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -270,6 +270,8 @@ public:
    */
   Tensor multiply(Tensor const &m) const;
 
+  Tensor multiply(Tensor const &m, Tensor &output) const;
+
   /**
    * @brief     divide Tensor Elementwise
    * @param[in] m Tensor to be multiplied
@@ -284,12 +286,16 @@ public:
    */
   Tensor divide(Tensor const &m) const;
 
+  Tensor divide(Tensor const &m, Tensor &output) const;
+
   /**
    * @brief    Tensor power Element by Element
    * @param[in] float Divisor Tensor
    * @retval Calculated Tensor
    */
   Tensor pow(float m) const;
+
+  int pow_i(float m);
 
   /**
    * @brief     Dot Product of Tensor ( equal MxM )
@@ -463,7 +469,7 @@ public:
    */
   Tensor apply(std::function<Tensor(Tensor, Tensor &)> f, Tensor &output) const;
 
-  Tensor apply_i(std::function<int(const Tensor &)> f) const;
+  int apply_i(std::function<float(float)> f);
 
   /**
    * @brief     Print element
@@ -678,6 +684,13 @@ private:
     const BroadcastInfo &e, int cur_axis = -1, unsigned int offset = 0,
     unsigned int m_offset = 0);
 
+  void operator_util(Tensor const &m,
+                     std::function<void(const BroadcastInfo &e, const float *,
+                                        const float *, float *)>
+                       v_func,
+                     Tensor &output, const BroadcastInfo &e, int cur_axis = -1,
+                     unsigned int offset = 0, unsigned int m_offset = 0) const;
+
   /**
    * @brief Applies the given operator to the tensor with the passed argument
    *
@@ -690,13 +703,19 @@ private:
     Tensor const &m,
     std::function<void(const BroadcastInfo &e, float *, const float *)> v_func);
 
+  void operator_(Tensor const &m,
+                 std::function<void(const BroadcastInfo &e, const float *,
+                                    const float *, float *)>
+                   v_func,
+                 Tensor &output) const;
+
   /**
    * @brief compute Loop info for broadcasting and vectorization
    *
    * @param m target tensor to be calculated against.
    * @return BroadcastInfo Loopinfo needed to run external loop
    */
-  BroadcastInfo computeBroadcastInfo(const Tensor &m);
+  BroadcastInfo computeBroadcastInfo(const Tensor &m) const;
 
   /**< handle the data as a std::shared_ptr<float> type */
   TensorDim dim;

--- a/nntrainer/tensor/tensor_dim.cpp
+++ b/nntrainer/tensor/tensor_dim.cpp
@@ -78,7 +78,7 @@ void TensorDim::setTensorDim(unsigned int idx, unsigned int value) {
 
 int TensorDim::setTensorDim(const std::string &input_shape) {
   int status = ML_ERROR_NONE;
-  const std::regex words_regex("[^\\s.,:;!?]+");
+  static const std::regex words_regex("[^\\s.,:;!?]+");
   auto words_begin =
     std::sregex_iterator(input_shape.begin(), input_shape.end(), words_regex);
   auto words_end = std::sregex_iterator();

--- a/nntrainer/tensor/tensor_dim.cpp
+++ b/nntrainer/tensor/tensor_dim.cpp
@@ -78,7 +78,7 @@ void TensorDim::setTensorDim(unsigned int idx, unsigned int value) {
 
 int TensorDim::setTensorDim(const std::string &input_shape) {
   int status = ML_ERROR_NONE;
-  std::regex words_regex("[^\\s.,:;!?]+");
+  const std::regex words_regex("[^\\s.,:;!?]+");
   auto words_begin =
     std::sregex_iterator(input_shape.begin(), input_shape.end(), words_regex);
   auto words_end = std::sregex_iterator();

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -38,10 +38,10 @@
 
 namespace nntrainer {
 
-int getKeyValue(std::string input_str, std::string &key, std::string &value) {
+int getKeyValue(std::string &input_str, std::string &key, std::string &value) {
   int status = ML_ERROR_NONE;
   std::vector<std::string> list;
-  std::regex words_regex("[^\\s=]+");
+  static const std::regex words_regex("[^\\s=]+");
   input_str.erase(std::remove(input_str.begin(), input_str.end(), ' '),
                   input_str.end());
   auto words_begin =
@@ -434,7 +434,7 @@ int setBoolean(bool &val, std::string str) {
 
 int getValues(int n_str, std::string str, int *value) {
   int status = ML_ERROR_NONE;
-  std::regex words_regex("[^\\s.,:;!?]+");
+  static const std::regex words_regex("[^\\s.,:;!?]+");
   str.erase(std::remove(str.begin(), str.end(), ' '), str.end());
   auto words_begin = std::sregex_iterator(str.begin(), str.end(), words_regex);
   auto words_end = std::sregex_iterator();
@@ -465,7 +465,7 @@ const char *getValues(std::vector<int> values, const char *delimiter) {
   return std::move(vec_str.str().c_str());
 }
 
-std::vector<std::string> split(const std::string &s, std::regex &reg) {
+std::vector<std::string> split(const std::string &s, const std::regex &reg) {
   std::vector<std::string> out;
   char char_to_remove[NUM_SKIP_CHAR] = {' ', '[', ']'};
   std::string str = s;

--- a/nntrainer/utils/parse_util.h
+++ b/nntrainer/utils/parse_util.h
@@ -166,7 +166,7 @@ int setBoolean(bool &val, std::string str);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
  */
-int getKeyValue(std::string input_str, std::string &key, std::string &value);
+int getKeyValue(std::string &input_str, std::string &key, std::string &value);
 
 /**
  * @brief     join vector of int to string with delimiter ","
@@ -184,7 +184,7 @@ int getValues(int n_str, std::string str, int *value);
  * @param[in] reg regular expression to use as delimiter
  * @retval    output string vector
  */
-std::vector<std::string> split(const std::string &s, std::regex &reg);
+std::vector<std::string> split(const std::string &s, const std::regex &reg);
 
 /**
  * @brief     print instance info. as <Type at (address)>

--- a/test/nntrainer_test_util.cpp
+++ b/test/nntrainer_test_util.cpp
@@ -298,7 +298,7 @@ void IniSection::setEntry(const std::string &entry_str) {
 
   std::string key, value;
   for (std::sregex_iterator i = words_begin; i != words_end; ++i) {
-    const std::string &cur = (*i).str();
+    std::string cur = (*i).str();
 
     if (cur[0] == '-') {
       entry.erase(cur.substr(1));


### PR DESCRIPTION
Commit 1: [regex] Make regex static const
Although it is using static string, that memory is always being allocated inside regex
    Making is static const only makes it once for the function lifetime

Commit 2: [activaiton] Reduce temporary memory alloc
Reduce temporary memory allocations by activation layer
    by using the hidden and ret_derivative class variables
    This temporarily increases peak memory but alloc-dealloc is removed
    from every iteration

Commit 3: [pooling] Reduce temporary mem allocations
Reduce temporary memory allocations for pooling
    Remove unnecessary temporary memory allocations which can be
    replaced with a slice view
    Also removed unnecessary setting memory to zero

Commit 4: [tensor] Support multiply/divide with given output
Support multiply/divide with given output tensor
    This reduces temporary allocations for bn layer

Commit 5: [bnlayer] bug fix for inference
Batch normalization bug fix for inference mode
    when add() was used instead of add_i()

Resolves #771 
See also #772

**Self evaluation:**
    1. Build test: [x]Passed [ ]Failed [ ]Skipped
    2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>