### PR TITLE
[ Graph ] remove grad mem buffer for backwarding

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -542,10 +542,11 @@ void NetworkGraph::backwarding(sharedConstTensors output, int iteration) {
   }
 
   /** The last trainable layer need not calculate the derivatives */
+  // Oder is matter here. 1. calcGradient 2.Derivative & Gradient
+  Sorted[skip_non_trainable_layers + 1].layer->calcGradient();
 #ifdef ENABLE_TEST
   Sorted[skip_non_trainable_layers + 1].layer->calcDerivative();
 #endif
-  Sorted[skip_non_trainable_layers + 1].layer->calcGradient();
   Sorted[skip_non_trainable_layers + 1].layer->applyGradient(iteration);
 }
 

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -155,6 +155,8 @@ private:
   std::function<Tensor(Tensor const &, Tensor &)> _act_fn;
   std::function<Tensor(Tensor const &, Tensor &, Tensor const &)> _act_prime_fn;
 
+  Tensor backup_hidden;
+
   /**
    * @brief setActivation by custom activation function
    * @note  apply derivative as this activation_prime_fn does not utilize

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -47,8 +47,8 @@ void AdditionLayer::forwarding(sharedConstTensors in) {
 
   for (unsigned int idx = 0; idx < num_inputs; ++idx) {
     if (in_dim != net_input[idx]->var.getDim())
-      throw std::runtime_error("Error: addition layer requires same "
-                               "shape from all input layers");
+      throw std::invalid_argument("Error: addition layer requires same "
+                                  "shape from all input layers");
     hidden_.add_i(net_input[idx]->var);
   }
 }
@@ -56,7 +56,7 @@ void AdditionLayer::forwarding(sharedConstTensors in) {
 void AdditionLayer::calcDerivative(sharedConstTensors derivative) {
 
   for (unsigned int i = 0; i < num_inputs; ++i) {
-    net_input[i]->grad = net_hidden[0]->grad;
+    net_input[i]->var = net_hidden[0]->var;
   }
 }
 

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -158,7 +158,7 @@ void BatchNormalizationLayer::forwarding(sharedConstTensors in) {
 void BatchNormalizationLayer::calcDerivative(sharedConstTensors derivative) {
 
   Tensor &gamma = weightAt(static_cast<int>(BNParams::gamma)).getVariableRef();
-  Tensor &deriv = net_hidden[0]->grad;
+  Tensor &deriv = net_hidden[0]->var;
 
   int N = 1;
   for (auto &axis : axes_to_reduce) {
@@ -171,7 +171,7 @@ void BatchNormalizationLayer::calcDerivative(sharedConstTensors derivative) {
   dx_2.subtract_i(deviation.divide(cvar).multiply(
     deviation.multiply(deriv).sum(axes_to_reduce)));
 
-  Tensor &dx = net_input[0]->grad;
+  Tensor &dx = net_input[0]->var;
   dx = dx_2.multiply(dx_1, dx);
   dx.divide_i(N);
 }
@@ -180,7 +180,7 @@ void BatchNormalizationLayer::calcGradient(sharedConstTensors derivative) {
 
   Tensor &dgamma = weightAt(static_cast<int>(BNParams::gamma)).getGradientRef();
   Tensor &dbeta = weightAt(static_cast<int>(BNParams::beta)).getGradientRef();
-  Tensor &deriv = net_hidden[0]->grad;
+  Tensor &deriv = net_hidden[0]->var;
 
   dbeta = deriv.sum(axes_to_reduce);
   Tensor dev = deviation.multiply(invstd);

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -89,15 +89,15 @@ void ConcatLayer::forwarding(sharedConstTensors in) {
 }
 
 void ConcatLayer::calcDerivative(sharedConstTensors derivative) {
-  TensorDim d = net_hidden[0]->grad.getDim();
+  TensorDim d = net_hidden[0]->var.getDim();
 
   unsigned int position = 0;
   for (unsigned int idx = 0; idx < num_inputs; ++idx) {
     TensorDim in_dim = input_dim[idx];
 
     for (unsigned int b = 0; b < in_dim.batch(); ++b) {
-      memcpy(net_input[idx]->grad.getAddress(b * in_dim.getFeatureLen()),
-             net_hidden[0]->grad.getAddress(b * d.getFeatureLen() + position),
+      memcpy(net_input[idx]->var.getAddress(b * in_dim.getFeatureLen()),
+             net_hidden[0]->var.getAddress(b * d.getFeatureLen() + position),
              in_dim.getFeatureLen() * sizeof(float));
     }
     position += in_dim.getFeatureLen();

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -147,7 +147,7 @@ void Conv2DLayer::calcDerivative(sharedConstTensors derivatives) {
   int status = ML_ERROR_NONE;
   TensorDim &in_dim = input_dim[0];
 
-  Tensor &derivative = net_hidden[0]->grad;
+  Tensor &derivative = net_hidden[0]->var;
   Tensor &filter_kernel = weightAt(ConvParams::weight).getVariableRef();
 
   std::array<unsigned int, CONV2D_DIM> same_pad;
@@ -198,12 +198,12 @@ void Conv2DLayer::calcDerivative(sharedConstTensors derivatives) {
   using uint = unsigned int;
   bool no_padding = padding[0] == 0 && padding[1] == 0;
 
-  if (net_input[0]->grad.uninitialized())
-    net_input[0]->grad = Tensor(input.getDim());
+  if (net_input[0]->var.uninitialized())
+    net_input[0]->var = Tensor(input.getDim());
 
   Tensor ret;
   if (no_padding)
-    ret = net_input[0]->grad;
+    ret = net_input[0]->var;
   else
     ret =
       Tensor(in_dim.batch(), in_dim.channel(), in_dim.height() + padding[0] * 2,
@@ -247,14 +247,14 @@ void Conv2DLayer::calcDerivative(sharedConstTensors derivatives) {
   }
 
   if (!no_padding)
-    strip_pad(ret, padding.data(), net_input[0]->grad);
+    strip_pad(ret, padding.data(), net_input[0]->var);
 }
 
 void Conv2DLayer::calcGradient(sharedConstTensors derivatives) {
   TensorDim &in_dim = input_dim[0];
 
   Tensor &filter_kernel = weightAt(ConvParams::weight).getVariableRef();
-  Tensor &derivative = net_hidden[0]->grad;
+  Tensor &derivative = net_hidden[0]->var;
   Tensor &input_ = net_input[0]->var;
 
   Tensor &delK = weightAt(ConvParams::weight).getGradientRef();

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -104,8 +104,8 @@ void FullyConnectedLayer::copy(std::shared_ptr<Layer> l) {
 void FullyConnectedLayer::calcDerivative(sharedConstTensors derivative) {
   unsigned int weight_idx = static_cast<int>(FCParams::weight);
   Tensor &weight = weightAt(weight_idx).getVariableRef();
-  Tensor &derivative_ = net_hidden[0]->grad;
-  Tensor &ret_ = net_input[0]->grad;
+  Tensor &derivative_ = net_hidden[0]->var;
+  Tensor &ret_ = net_input[0]->var;
 
   ret_ = derivative_.dot(weight, ret_, false, true);
 }
@@ -117,7 +117,7 @@ void FullyConnectedLayer::calcGradient(sharedConstTensors derivative) {
   Tensor &djdw = weightAt(weight_idx).getGradientRef();
   Tensor &djdb = weightAt(bias_idx).getGradientRef();
 
-  Tensor &derivative_ = net_hidden[0]->grad;
+  Tensor &derivative_ = net_hidden[0]->var;
 
   djdb = derivative_.sum(0);
   djdw = net_input[0]->var.dot(derivative_, djdw, true, false);

--- a/nntrainer/layers/flatten_layer.cpp
+++ b/nntrainer/layers/flatten_layer.cpp
@@ -48,9 +48,9 @@ void FlattenLayer::forwarding(sharedConstTensors in) {
 }
 
 void FlattenLayer::calcDerivative(sharedConstTensors in) {
-  Tensor temp = net_hidden[0]->grad;
-  temp.reshape(net_input[0]->grad.getDim());
-  net_input[0]->grad = temp;
+  Tensor temp = net_hidden[0]->var;
+  temp.reshape(net_input[0]->var.getDim());
+  net_input[0]->var = temp;
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -72,7 +72,7 @@ std::vector<Tensor> Layer::getOutputs() {
 std::vector<Tensor> Layer::getDerivatives() {
   std::vector<Tensor> ret;
   for (unsigned int i = 0; i < num_inputs; ++i) {
-    ret.push_back(net_input[i]->grad);
+    ret.push_back(net_input[i]->var);
   }
   return ret;
 }
@@ -103,7 +103,7 @@ void Layer::copy(std::shared_ptr<Layer> l) {
 sharedConstTensors Layer::forwarding_with_val(sharedConstTensors input) {
 
   for (unsigned int i = 0; i < num_inputs; ++i) {
-    net_input[i]->var = *input[i];
+    net_input[i]->var = input[i]->clone();
   }
 
   if (num_outputs != net_hidden.size())
@@ -125,7 +125,7 @@ sharedConstTensors Layer::backwarding_with_val(int iteration,
                                                sharedConstTensors in) {
 
   for (unsigned int i = 0; i < num_outputs; ++i) {
-    net_hidden[i]->grad = *deriv[i];
+    net_hidden[i]->var = deriv[i]->clone();
   }
 
   if (num_inputs != net_input.size())
@@ -142,7 +142,7 @@ sharedConstTensors Layer::backwarding_with_val(int iteration,
   nntrainer::sharedConstTensors out;
 
   for (unsigned int i = 0; i < num_inputs; ++i) {
-    out.push_back(MAKE_SHARED_TENSOR(net_input[i]->grad));
+    out.push_back(MAKE_SHARED_TENSOR(net_input[i]->var));
   }
 
   return out;

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -37,6 +37,8 @@ namespace nntrainer {
 
 struct NetBuffers {
   Tensor var;
+  /* TODO : We could remove this. for now, We are not allocate memory. This
+   * exists only for the unittest.  */
   Tensor grad;
 };
 

--- a/nntrainer/layers/loss_layer.cpp
+++ b/nntrainer/layers/loss_layer.cpp
@@ -136,7 +136,7 @@ void LossLayer::copy(std::shared_ptr<Layer> l) {
 }
 
 void LossLayer::calcDerivative(sharedConstTensors derivative) {
-  Tensor &ret_derivative = net_input[0]->grad;
+  Tensor &ret_derivative = net_input[0]->var;
   Tensor y2 = *derivative[0];
   Tensor &y = net_input[0]->var;
   Tensor ret;

--- a/nntrainer/layers/output_layer.cpp
+++ b/nntrainer/layers/output_layer.cpp
@@ -52,10 +52,10 @@ void OutputLayer::forwarding(sharedConstTensors in) {
 
 void OutputLayer::calcDerivative(sharedConstTensors derivative) {
 
-  Tensor &ret = net_input[0]->grad;
+  Tensor &ret = net_input[0]->var;
 
   for (unsigned int idx = 0; idx < num_outputs; ++idx) {
-    ret.add_i(net_hidden[idx]->grad);
+    ret.add_i(net_hidden[idx]->var);
   }
 }
 

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -94,8 +94,9 @@ void Pooling2DLayer::calcDerivative(sharedConstTensors derivative) {
   unsigned int p_size = p_height * p_width;
 
   unsigned int J, K;
-  Tensor &deriv = net_hidden[0]->grad;
-  Tensor &result = net_input[0]->grad;
+
+  Tensor &deriv = net_hidden[0]->var;
+  Tensor &result = net_input[0]->var;
 
   result.setZero();
   float *out = result.getData();

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -422,7 +422,6 @@ int NeuralNetwork::assignMem() {
       for (unsigned int i = 0; i < l.input_layers.size(); ++i) {
 
         l.net_input[i]->var = Tensor(l.getInputDimension()[i]);
-        l.net_input[i]->grad = Tensor(l.getInputDimension()[i]);
       }
     }
   }
@@ -430,8 +429,6 @@ int NeuralNetwork::assignMem() {
   for (unsigned int i = 0; i < model_graph.Sorted.back().layer->num_outputs;
        ++i) {
     model_graph.Sorted.back().layer->net_hidden[i]->var =
-      Tensor(model_graph.Sorted.back().layer->getOutputDimension()[i]);
-    model_graph.Sorted.back().layer->net_hidden[i]->grad =
       Tensor(model_graph.Sorted.back().layer->getOutputDimension()[i]);
   }
 

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -66,7 +66,6 @@ protected:
       std::shared_ptr<nntrainer::NetBuffers> n_buffer =
         std::make_unique<nntrainer::NetBuffers>();
       n_buffer->var = nntrainer::Tensor(layer.getInputDimension()[i]);
-      n_buffer->grad = nntrainer::Tensor(layer.getInputDimension()[i]);
       layer.setInputBuffer(i, n_buffer);
     }
 
@@ -74,7 +73,6 @@ protected:
       std::shared_ptr<nntrainer::NetBuffers> n_buffer =
         std::make_unique<nntrainer::NetBuffers>();
       n_buffer->var = nntrainer::Tensor(layer.getOutputDimension()[i]);
-      n_buffer->grad = nntrainer::Tensor(layer.getOutputDimension()[i]);
       layer.setOutputBuffer(i, n_buffer);
     }
 
@@ -502,7 +500,6 @@ protected:
       std::shared_ptr<nntrainer::NetBuffers> n_buffer =
         std::make_unique<nntrainer::NetBuffers>();
       n_buffer->var = nntrainer::Tensor(act_layer->getInputDimension()[i]);
-      n_buffer->grad = nntrainer::Tensor(act_layer->getInputDimension()[i]);
       act_layer->setInputBuffer(i, n_buffer);
     }
 
@@ -510,7 +507,6 @@ protected:
       std::shared_ptr<nntrainer::NetBuffers> n_buffer =
         std::make_unique<nntrainer::NetBuffers>();
       n_buffer->var = nntrainer::Tensor(act_layer->getOutputDimension()[i]);
-      n_buffer->grad = nntrainer::Tensor(act_layer->getOutputDimension()[i]);
       act_layer->setOutputBuffer(i, n_buffer);
     }
 
@@ -539,7 +535,6 @@ protected:
       std::shared_ptr<nntrainer::NetBuffers> n_buffer =
         std::make_unique<nntrainer::NetBuffers>();
       n_buffer->var = nntrainer::Tensor(loss_layer->getInputDimension()[i]);
-      n_buffer->grad = nntrainer::Tensor(loss_layer->getInputDimension()[i]);
       loss_layer->setInputBuffer(i, n_buffer);
     }
 
@@ -547,7 +542,6 @@ protected:
       std::shared_ptr<nntrainer::NetBuffers> n_buffer =
         std::make_unique<nntrainer::NetBuffers>();
       n_buffer->var = nntrainer::Tensor(loss_layer->getOutputDimension()[i]);
-      n_buffer->grad = nntrainer::Tensor(loss_layer->getOutputDimension()[i]);
       loss_layer->setOutputBuffer(i, n_buffer);
     }
 
@@ -1230,11 +1224,15 @@ TEST_F(nntrainer_Conv2DLayer, backwarding_02_p) {
   matchOutput(result, "tc_conv2d_2_goldenInputGrad.out");
   matchOutput(bias_grad, "tc_conv2d_2_goldenBiasGrad.out");
 
+  for (unsigned int i = 0; i < derivatives.getDim().getDataLen(); ++i) {
+    derivatives.getData()[i] = 1.0;
+  }
+
   for (int i = 0; i < 4; i++) {
     EXPECT_NO_THROW(out =
                       *layer.forwarding_with_val({MAKE_SHARED_TENSOR(in)})[0]);
     EXPECT_NO_THROW(result = *layer.backwarding_with_val(
-                      1, {MAKE_SHARED_TENSOR(derivatives)})[0]);
+                      0, {MAKE_SHARED_TENSOR(derivatives)})[0]);
   }
 
   /// @fixme: the output value of this test is around +/- 1.0e+07 which can't


### PR DESCRIPTION
This PR includes,
  . remove grad memory buffer in n_buffes for graph. We do not need
  this because we could use var memory buffer of n_buffers to
  backwarding.
  . For MNIST, memory consumption is reduced 3.5 to 2.6

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>