### PR TITLE
[ModelLoader] Use vector when creating layer

### DIFF
--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -183,6 +183,8 @@ int Layer::setProperty(std::vector<std::string> values) {
     unsigned int type = parseLayerProperty(key);
 
     if (value.empty()) {
+      ml_logd("value is empty for layer: %s, key: %s, value: %s",
+              getName().c_str(), key.c_str(), value.c_str());
       return ML_ERROR_INVALID_PARAMETER;
     }
 
@@ -190,6 +192,8 @@ int Layer::setProperty(std::vector<std::string> values) {
       /// @note this calls derived setProperty if available
       setProperty(static_cast<PropertyType>(type), value);
     } catch (...) {
+      ml_logd("value or key is not valid for layer: %s, key: %s, value: %s",
+              getName().c_str(), key.c_str(), value.c_str());
       return ML_ERROR_INVALID_PARAMETER;
     }
   }

--- a/nntrainer/models/model_loader.h
+++ b/nntrainer/models/model_loader.h
@@ -15,6 +15,7 @@
 #define __MODEL_LOADER_H__
 #ifdef __cplusplus
 
+#include <app_context.h>
 #include <iniparser.h>
 #include <neuralnet.h>
 
@@ -29,7 +30,8 @@ public:
   /**
    * @brief     Constructor of the model loader
    */
-  ModelLoader() {}
+  ModelLoader(const AppContext &app_context_ = AppContext::Global()) :
+    app_context(app_context_) {}
 
   /**
    * @brief     Destructor of the model loader
@@ -144,6 +146,8 @@ private:
   static bool fileTfLite(const std::string &filename);
 
   const char *unknown = "Unknown";
+
+  AppContext app_context;
 };
 
 } /* namespace nntrainer */

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -50,7 +50,7 @@ int NeuralNetwork::loadFromConfig(std::string config) {
     return ML_ERROR_INVALID_PARAMETER;
   }
 
-  ModelLoader loader;
+  ModelLoader loader(app_context);
   NeuralNetwork tempNet(*this);
   int status = loader.loadFromConfig(config, tempNet);
   if (status != ML_ERROR_NONE) {

--- a/test/unittest/unittest_nntrainer_internal.cpp
+++ b/test/unittest/unittest_nntrainer_internal.cpp
@@ -83,11 +83,11 @@ TEST(nntrainer_NeuralNetwork, load_config_03_n) {
   RESET_CONFIG("./test.ini");
   replaceString("Input_Shape = 1:1:62720", "Input_Shape = 1:1:0", "./test.ini",
                 config_str);
+
   nntrainer::NeuralNetwork NN;
 
-  /**< C++ exception with description "[TensorDim] Trying to assign value of 0
-   * to tensor dim" thrown in the test body. */
-  EXPECT_THROW(NN.loadFromConfig("./test.ini"), std::invalid_argument);
+  int status = NN.loadFromConfig("./test.ini");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
 /**


### PR DESCRIPTION
- ~**#746** [AppContext] Register Default ops at the begining~
- ~**#753** [AppContext] Fix key is case sensitive~
- ~**#753** [Layer] Add built-in ops to the context~
- [ModelLoader] Use vector<string> when creating layer
```
When creating a layer from an ini, enum based properties were used.
This prevents adding a new properties without changing the api header.

This patch moves to setting layer properties to vector<string>
to enable setting properties without changing the api header, eventually
 enabling custom properties in custom layer.

**Semantics Change propesed in this PR**
Ini won't ignore the properties that is not supported since model_loader
would not know if it is supported or not

See also #716

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```