### PR TITLE
[tensor] Update tensor operation signature

### DIFF
--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -63,8 +63,8 @@ void ActivationLayer::calcDerivative(sharedConstTensors derivative) {
 }
 
 int ActivationLayer::setActivation(
-  std::function<Tensor(Tensor const &, Tensor &)> const &activation_fn,
-  std::function<Tensor(Tensor const &, Tensor &, Tensor const &)> const
+  std::function<Tensor &(Tensor const &, Tensor &)> const &activation_fn,
+  std::function<Tensor &(Tensor const &, Tensor &, Tensor const &)> const
     &activation_prime_fn) {
   _act_fn = activation_fn;
   _act_prime_fn = activation_prime_fn;
@@ -73,11 +73,12 @@ int ActivationLayer::setActivation(
 }
 
 int ActivationLayer::setActivation(
-  std::function<Tensor(Tensor const &, Tensor &)> const &activation_fn,
-  std::function<Tensor(Tensor const &, Tensor &)> const &activation_prime_fn) {
+  std::function<Tensor &(Tensor const &, Tensor &)> const &activation_fn,
+  std::function<Tensor &(Tensor const &, Tensor &)> const
+    &activation_prime_fn) {
   _act_fn = activation_fn;
   _act_prime_fn = [activation_prime_fn](Tensor const &x, Tensor &ret_derivative,
-                                        Tensor const &derivative) {
+                                        Tensor const &derivative) -> Tensor & {
     ret_derivative = activation_prime_fn(x, ret_derivative);
     ret_derivative.multiply_i(derivative);
 
@@ -90,11 +91,11 @@ int ActivationLayer::setActivation(
 int ActivationLayer::setActivation(
   std::function<float(float const)> const &activation_fn,
   std::function<float(float const)> const &activation_prime_fn) {
-  _act_fn = [activation_fn](Tensor const &x, Tensor &hidden) {
+  _act_fn = [activation_fn](Tensor const &x, Tensor &hidden) -> Tensor & {
     return x.apply(activation_fn, hidden);
   };
   _act_prime_fn = [activation_prime_fn](Tensor const &x, Tensor &ret_derivative,
-                                        Tensor const &derivative) {
+                                        Tensor const &derivative) -> Tensor & {
     ret_derivative = x.apply(activation_prime_fn, ret_derivative);
     ret_derivative.multiply_i(derivative);
 
@@ -134,7 +135,7 @@ void ActivationLayer::setActivation(ActivationType acti_type) {
   }
 }
 
-Tensor ActivationLayer::softmax(Tensor const &t, Tensor &output) {
+Tensor &ActivationLayer::softmax(Tensor const &t, Tensor &output) {
   /**
    * shiftx_logit = logit - max_batch(logit)
    * softmax = exp(shiftx_logit) / (sum(exp(shiftx_logit)))
@@ -174,8 +175,8 @@ Tensor ActivationLayer::softmax(Tensor const &t, Tensor &output) {
   return output;
 }
 
-Tensor ActivationLayer::softmaxPrime(Tensor const &x, Tensor &output,
-                                     Tensor const &derivative) {
+Tensor &ActivationLayer::softmaxPrime(Tensor const &x, Tensor &output,
+                                      Tensor const &derivative) {
   unsigned int batch = x.batch();
   unsigned int channel = x.channel();
   unsigned int height = x.height();

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -89,7 +89,7 @@ public:
    * @param[out] output output Tensor
    * @retval      Tensor
    */
-  static Tensor softmax(Tensor const &x, Tensor &output);
+  static Tensor &softmax(Tensor const &x, Tensor &output);
 
   /**
    * @brief     derivative softmax function for Tensor Type
@@ -98,8 +98,8 @@ public:
    * @param[in] derivative derivative Tensor from next layer
    * @retVal    Tensor
    */
-  static Tensor softmaxPrime(Tensor const &x, Tensor &output,
-                             Tensor const &derivative = Tensor());
+  static Tensor &softmaxPrime(Tensor const &x, Tensor &output,
+                              Tensor const &derivative = Tensor());
 
   /**
    * @brief     sigmoid activation function
@@ -152,8 +152,9 @@ public:
   static const std::string type;
 
 private:
-  std::function<Tensor(Tensor const &, Tensor &)> _act_fn;
-  std::function<Tensor(Tensor const &, Tensor &, Tensor const &)> _act_prime_fn;
+  std::function<Tensor &(Tensor const &, Tensor &)> _act_fn;
+  std::function<Tensor &(Tensor const &, Tensor &, Tensor const &)>
+    _act_prime_fn;
 
   /**
    * @brief setActivation by custom activation function
@@ -166,8 +167,9 @@ private:
    * @retval #ML_ERROR_NONE when successful
    */
   int setActivation(
-    std::function<Tensor(Tensor const &, Tensor &)> const &activation_fn,
-    std::function<Tensor(Tensor const &, Tensor &)> const &activation_prime_fn);
+    std::function<Tensor &(Tensor const &, Tensor &)> const &activation_fn,
+    std::function<Tensor &(Tensor const &, Tensor &)> const
+      &activation_prime_fn);
 
   /**
    * @brief setActivation by custom activation function
@@ -180,8 +182,8 @@ private:
    * @retval #ML_ERROR_NONE when successful
    */
   int setActivation(
-    std::function<Tensor(Tensor const &, Tensor &)> const &activation_fn,
-    std::function<Tensor(Tensor const &, Tensor &, Tensor const &)> const
+    std::function<Tensor &(Tensor const &, Tensor &)> const &activation_fn,
+    std::function<Tensor &(Tensor const &, Tensor &, Tensor const &)> const
       &activation_prime_fn);
 
   /**

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -270,7 +270,7 @@ public:
    */
   Tensor multiply(Tensor const &m) const;
 
-  Tensor multiply(Tensor const &m, Tensor &output) const;
+  Tensor &multiply(Tensor const &m, Tensor &output) const;
 
   /**
    * @brief     divide Tensor Elementwise
@@ -286,7 +286,7 @@ public:
    */
   Tensor divide(Tensor const &m) const;
 
-  Tensor divide(Tensor const &m, Tensor &output) const;
+  Tensor &divide(Tensor const &m, Tensor &output) const;
 
   /**
    * @brief    Tensor power Element by Element
@@ -318,8 +318,8 @@ public:
    * @param[in] trans_m Transpose m
    * @retval    Calculated Tensor
    */
-  Tensor dot(Tensor const &m, Tensor &output, bool trans = false,
-             bool trans_m = false) const;
+  Tensor &dot(Tensor const &m, Tensor &output, bool trans = false,
+              bool trans_m = false) const;
 
   /**
    * @brief     Transpose Tensor
@@ -357,7 +357,7 @@ public:
    * @param[in] alpha Scale the sum by this value
    * @retval    Calculated Tensor
    */
-  Tensor sum(Tensor &output, unsigned int axis, float alpha = 1.0) const;
+  Tensor &sum(Tensor &output, unsigned int axis, float alpha = 1.0) const;
 
   /**
    * @brief sum all the Tensor by multiple axes
@@ -414,13 +414,13 @@ public:
    * @brief     Normalize the Tensor elements
    * @retval    Calculated Tensor
    */
-  Tensor normalization(Tensor &output) const;
+  Tensor &normalization(Tensor &output) const;
 
   /**
    * @brief     Standardize the Tensor elements
    * @retval    Calculated Tensor
    */
-  Tensor standardization(Tensor &output) const;
+  Tensor &standardization(Tensor &output) const;
 
   /**
    * @brief     Normalize the Tensor elements in-place
@@ -452,7 +452,7 @@ public:
    * @param[out] output output tensor
    * @retval    Tensor
    */
-  Tensor apply(std::function<float(float)> f, Tensor &output) const;
+  Tensor &apply(std::function<float(float)> f, Tensor &output) const;
 
   /**
    * @brief     Apply function to Tensor
@@ -467,7 +467,8 @@ public:
    * @param[out] output output tensor
    * @retval    Tensor
    */
-  Tensor apply(std::function<Tensor(Tensor, Tensor &)> f, Tensor &output) const;
+  Tensor &apply(std::function<Tensor &(Tensor, Tensor &)> f,
+                Tensor &output) const;
 
   int apply_i(std::function<float(float)> f);
 
@@ -724,6 +725,8 @@ private:
   std::shared_ptr<float> data;
 
   template <typename T> void setDist(T dist);
+
+  void copy(const float *buf);
 };
 
 /**

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -16,11 +16,9 @@
 
 namespace nntrainer {
 
-Var_Grad::Var_Grad(const Var_Grad &rhs) :
-  trainable(rhs.trainable),
-  name(rhs.name) {
+Var_Grad::Var_Grad(const Var_Grad &rhs) : name(rhs.name) {
   var = rhs.var.clone();
-  if (rhs.trainable)
+  if (rhs.getTrainable())
     grad = rhs.grad.clone();
 }
 
@@ -31,15 +29,25 @@ Var_Grad &Var_Grad::operator=(const Var_Grad &rhs) {
 }
 
 Var_Grad::Var_Grad(const TensorDim &dim, bool train, const std::string &name) :
-  trainable(train),
   name(name) {
   var = Tensor(dim);
 
   grad = Tensor();
-  if (trainable) {
+  if (train) {
     grad = Tensor(dim);
   }
   resetGradient();
+}
+
+void Var_Grad::setTrainable(bool train) {
+  if (train == getTrainable())
+    return;
+
+  if (train) {
+    grad = Tensor(var.getDim());
+  } else {
+    grad = Tensor();
+  }
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -20,7 +20,8 @@ Var_Grad::Var_Grad(const Var_Grad &rhs) :
   trainable(rhs.trainable),
   name(rhs.name) {
   var = rhs.var.clone();
-  grad = rhs.grad.clone();
+  if (rhs.trainable)
+    grad = rhs.grad.clone();
 }
 
 Var_Grad &Var_Grad::operator=(const Var_Grad &rhs) {

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -27,8 +27,9 @@ class Var_Grad {
 public:
   /**
    * @brief Var_Grad default constructor
+   * @note Default variable is not trainable as gradient is 0 dim tensor
    */
-  Var_Grad() : trainable(false) {}
+  Var_Grad() = default;
 
   /**
    * @brief Construct a new Var_Grad object
@@ -50,7 +51,6 @@ public:
     using std::swap;
 
     swap(lhs.var, rhs.var);
-    swap(lhs.trainable, rhs.trainable);
     swap(lhs.grad, rhs.grad);
     swap(lhs.name, rhs.name);
   }
@@ -98,7 +98,13 @@ public:
    * @return true if trainable
    * @return false is not trainable
    */
-  bool getTrainable() { return trainable; }
+  bool getTrainable() const { return !grad.uninitialized(); }
+
+  /**
+   * @brief set if the Var_Grad is trainable
+   * @param train true if trainable, else false
+   */
+  void setTrainable(bool train);
 
   /**
    * @brief Get the name of the Var_Grad
@@ -145,7 +151,6 @@ protected:
 
   Tensor var;       /**< variable to be updated and used */
   Tensor grad;      /**< gradient for the variable */
-  bool trainable;   /**< if this variable is trainable */
   std::string name; /**< name of the parameter */
 };
 


### PR DESCRIPTION
Update tensor operation signature to return Tensor reference as a retval
than a tensor itself. This avoid creating dummy tensors as a return (which might have been
optimized by the compiler but lets do manually as the input is also a reference).

This patch also update `Tensor::copy/clone` to not allocate new tensor memory 
if already allocated and same size which did happen in many cases.

Resolves #670

@zhoonit thanks for this suggestion.

Note that this is the last patch for the tensor signature. Please suggest any more signature changes, if any. After this patch, signature is finalized and more functions will be updated later as per needed. Important core functions have already been updated.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>