### PR TITLE
[layer] Share gradient weights for all the layers @open sesame 12/07 09:04

### DIFF
--- a/Applications/Custom/LayerClient/jni/pow.cpp
+++ b/Applications/Custom/LayerClient/jni/pow.cpp
@@ -89,7 +89,7 @@ int PowLayer::setProperty(std::vector<std::string> values) {
   return nntrainer::Layer::setProperty(unhandled_values);
 }
 
-int PowLayer::initialize() {
+int PowLayer::initialize(nntrainer::Manager &manager) {
   // setting output dimension from input dimension
   output_dim[0] = input_dim[0];
 

--- a/Applications/Custom/LayerClient/jni/pow.h
+++ b/Applications/Custom/LayerClient/jni/pow.h
@@ -17,6 +17,8 @@
 
 /// @todo migrate these to API
 #include <layer_internal.h>
+#include <manager.h>
+
 #include <tensor.h>
 
 namespace custom {
@@ -53,7 +55,7 @@ public:
    *
    * @return int ML_ERROR_NONE if success
    */
-  int initialize();
+  int initialize(nntrainer::Manager &manager);
 
   /**
    * @brief nntrainer forwarding function

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -61,6 +61,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/dataset/databuffer_file.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/tensor.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/lazy_tensor.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/tensor/manager.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/var_grad.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/weight.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/tensor_dim.cpp \

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -16,12 +16,13 @@
 #ifdef __cplusplus
 
 #include <iostream>
-#include <layer_internal.h>
 #include <list>
-#include <loss_layer.h>
 #include <memory>
 #include <stack>
 #include <vector>
+
+#include <layer_internal.h>
+#include <loss_layer.h>
 
 namespace nntrainer {
 

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -39,7 +39,7 @@ const std::string ActivationLayer::type = "activation";
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
  */
-int ActivationLayer::initialize() {
+int ActivationLayer::initialize(Manager &manager) {
 
   output_dim = input_dim;
 

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -47,7 +47,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @brief     Read Activation layer params. This is essentially noops for now.

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -22,7 +22,7 @@ namespace nntrainer {
 
 const std::string AdditionLayer::type = "addition";
 
-int AdditionLayer::initialize() {
+int AdditionLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
   if (num_inputs == 0) {
     ml_loge("Error: number of inputs are not initialized");

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -57,7 +57,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @brief     Read Weight & Bias Data from file

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -59,19 +59,17 @@ int BatchNormalizationLayer::initialize(Manager &manager) {
       axes_to_reduce.push_back(i);
   }
 
-  setNumWeights(4);
-  weightAt(BNParams::mu) =
-    std::move(Weight(dim, initializers[BNParams::mu], false, "BN:moving_mean"));
-  ///@todo shift var to std to save computation
-  weightAt(BNParams::var) = std::move(
-    Weight(dim, initializers[BNParams::var], false, "BN:moving_variance"));
-  weightAt(BNParams::gamma) =
-    std::move(Weight(dim, initializers[BNParams::gamma], true, "BN:gamma"));
-  weightAt(BNParams::beta) =
-    std::move(Weight(dim, initializers[BNParams::beta], true, "BN:beta"));
-
-  manager.trackWeights({weightAt(BNParams::mu), weightAt(BNParams::var),
-                        weightAt(BNParams::gamma), weightAt(BNParams::beta)});
+  weights.clear();
+  if (weights.empty()) {
+    weights.reserve(4);
+    weights.push_back(createWeight(manager, dim, initializers[BNParams::mu], false, "BN::moving_mean"));
+    weights.push_back(createWeight(manager, dim, initializers[BNParams::var], false, "BN::moving_variance"));
+    weights.push_back(createWeight(manager, dim, initializers[BNParams::gamma], true, "BN::gamma"));
+    weights.push_back(createWeight(manager, dim, initializers[BNParams::beta], true, "BN::beta"));
+  } else {
+    for (size_t idx = 0; idx < weights.size(); idx ++)
+      weights[idx].reset(dim, initializers[idx], weights[idx].getTrainable());
+  }
 
   return status;
 }

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -62,13 +62,18 @@ int BatchNormalizationLayer::initialize(Manager &manager) {
   weights.clear();
   if (weights.empty()) {
     weights.reserve(4);
-    weights.push_back(createWeight(manager, dim, initializers[BNParams::mu], false, "BN::moving_mean"));
-    weights.push_back(createWeight(manager, dim, initializers[BNParams::var], false, "BN::moving_variance"));
-    weights.push_back(createWeight(manager, dim, initializers[BNParams::gamma], true, "BN::gamma"));
-    weights.push_back(createWeight(manager, dim, initializers[BNParams::beta], true, "BN::beta"));
+    weights.emplace_back(dim, initializers[BNParams::mu], false,
+                         "BN::moving_mean");
+    weights.emplace_back(dim, initializers[BNParams::var], false,
+                         "BN::moving_variance");
+    weights.emplace_back(dim, initializers[BNParams::gamma], true, "BN::gamma");
+    weights.emplace_back(dim, initializers[BNParams::beta], true, "BN::beta");
+    manager.trackWeights(weights);
   } else {
-    for (size_t idx = 0; idx < weights.size(); idx ++)
-      weights[idx].reset(dim, initializers[idx], weights[idx].getTrainable());
+    weights[BNParams::mu].reset(dim, initializers[BNParams::mu], false);
+    weights[BNParams::var].reset(dim, initializers[BNParams::var], false);
+    weights[BNParams::gamma].reset(dim, initializers[BNParams::gamma], true);
+    weights[BNParams::beta].reset(dim, initializers[BNParams::beta], true);
   }
 
   return status;

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -101,7 +101,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -23,7 +23,7 @@ namespace nntrainer {
 
 const std::string ConcatLayer::type = "concat";
 
-int ConcatLayer::initialize() {
+int ConcatLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
   unsigned int channel = 0;
 

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -57,7 +57,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @brief     Read Weight & Bias Data from file

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -50,13 +50,14 @@ int Conv2DLayer::initialize(Manager &manager) {
     TensorDim(filter_size, in_dim.channel(), kernel_size[0], kernel_size[1]);
   TensorDim bias_dim = TensorDim(1, filter_size, 1, 1);
 
-  setNumWeights(2);
-  weightAt(ConvParams::weight) =
-    Weight(dim, weight_initializer, true, kernelPrefix);
-  weightAt(ConvParams::bias) =
-    Weight(bias_dim, bias_initializer, true, biasPrefix);
-  manager.trackWeights(
-    {weightAt(ConvParams::weight), weightAt(ConvParams::bias)});
+  if (weights.empty()) {
+    weights.reserve(2);
+    weights.push_back(createWeight(manager, dim, weight_initializer, true, kernelPrefix));
+    weights.push_back(createWeight(manager, bias_dim, bias_initializer, true, biasPrefix));
+  } else {
+    for (auto &weight : weights)
+      weight.reset(weight.getVariable().getDim(), weight_initializer, true);
+  }
 
   // this output_dim should be the same with dimension of hidden
   out_dim.batch(in_dim.batch());

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -29,7 +29,7 @@ const std::string Conv2DLayer::type = "conv2d";
 
 enum ConvParams { weight, bias };
 
-int Conv2DLayer::initialize() {
+int Conv2DLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
 
   if (input_dim.size() != 1 || output_dim.size() != 1) {
@@ -49,12 +49,14 @@ int Conv2DLayer::initialize() {
   TensorDim dim =
     TensorDim(filter_size, in_dim.channel(), kernel_size[0], kernel_size[1]);
   TensorDim bias_dim = TensorDim(1, filter_size, 1, 1);
-  setNumWeights(2);
 
+  setNumWeights(2);
   weightAt(ConvParams::weight) =
     Weight(dim, weight_initializer, true, kernelPrefix);
   weightAt(ConvParams::bias) =
     Weight(bias_dim, bias_initializer, true, biasPrefix);
+  manager.trackWeights(
+    {weightAt(ConvParams::weight), weightAt(ConvParams::bias)});
 
   // this output_dim should be the same with dimension of hidden
   out_dim.batch(in_dim.batch());

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -52,11 +52,12 @@ int Conv2DLayer::initialize(Manager &manager) {
 
   if (weights.empty()) {
     weights.reserve(2);
-    weights.push_back(createWeight(manager, dim, weight_initializer, true, kernelPrefix));
-    weights.push_back(createWeight(manager, bias_dim, bias_initializer, true, biasPrefix));
+    weights.emplace_back(dim, weight_initializer, true, kernelPrefix);
+    weights.emplace_back(bias_dim, bias_initializer, true, biasPrefix);
+    manager.trackWeights(weights);
   } else {
-    for (auto &weight : weights)
-      weight.reset(weight.getVariable().getDim(), weight_initializer, true);
+    weights[ConvParams::weight].reset(dim, weight_initializer, true);
+    weights[ConvParams::bias].reset(bias_dim, bias_initializer, true);
   }
 
   // this output_dim should be the same with dimension of hidden

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -16,6 +16,7 @@
 #ifdef __cplusplus
 
 #include <layer_internal.h>
+#include <manager.h>
 #include <tensor.h>
 
 namespace nntrainer {
@@ -68,7 +69,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @copydoc Layer::forwarding(sharedConstTensors in)

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -54,11 +54,12 @@ int FullyConnectedLayer::initialize(Manager &manager) {
 
   if (weights.empty()) {
     weights.reserve(2);
-    weights.push_back(createWeight(manager, dim, weight_initializer, true, "FC:weight"));
-    weights.push_back(createWeight(manager, bias_dim, bias_initializer, true, "FC:bias"));
+    weights.emplace_back(dim, weight_initializer, true, "FC:weight");
+    weights.emplace_back(bias_dim, bias_initializer, true, "FC:bias");
+    manager.trackWeights(weights);
   } else {
-    for (auto &weight : weights)
-      weight.reset(weight.getVariable().getDim(), weight_initializer, true);
+    weights[FCParams::weight].reset(dim, weight_initializer, true);
+    weights[FCParams::bias].reset(bias_dim, bias_initializer, true);
   }
 
   return status;

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -52,12 +52,14 @@ int FullyConnectedLayer::initialize(Manager &manager) {
   dim.height(input_dim[0].width());
   dim.batch(1);
 
-  setNumWeights(2);
-  weightAt(FCParams::weight) =
-    Weight(dim, weight_initializer, true, "FC:weight");
-  weightAt(FCParams::bias) =
-    Weight(bias_dim, bias_initializer, true, "FC::bias");
-  manager.trackWeights({weightAt(FCParams::weight), weightAt(FCParams::bias)});
+  if (weights.empty()) {
+    weights.reserve(2);
+    weights.push_back(createWeight(manager, dim, weight_initializer, true, "FC:weight"));
+    weights.push_back(createWeight(manager, bias_dim, bias_initializer, true, "FC:bias"));
+  } else {
+    for (auto &weight : weights)
+      weight.reset(weight.getVariable().getDim(), weight_initializer, true);
+  }
 
   return status;
 }

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -33,9 +33,9 @@ namespace nntrainer {
 
 const std::string FullyConnectedLayer::type = "fully_connected";
 
-enum class FCParams { weight, bias };
+enum FCParams { weight, bias };
 
-int FullyConnectedLayer::initialize() {
+int FullyConnectedLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
 
   if (num_inputs != 1) {
@@ -53,10 +53,11 @@ int FullyConnectedLayer::initialize() {
   dim.batch(1);
 
   setNumWeights(2);
-  weightAt(static_cast<int>(FCParams::weight)) =
-    std::move(Weight(dim, weight_initializer, true, "FC:weight"));
-  weightAt(static_cast<int>(FCParams::bias)) =
-    std::move(Weight(bias_dim, bias_initializer, true, "FC:bias"));
+  weightAt(FCParams::weight) =
+    Weight(dim, weight_initializer, true, "FC:weight");
+  weightAt(FCParams::bias) =
+    Weight(bias_dim, bias_initializer, true, "FC::bias");
+  manager.trackWeights({weightAt(FCParams::weight), weightAt(FCParams::bias)});
 
   return status;
 }

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -77,7 +77,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/flatten_layer.cpp
+++ b/nntrainer/layers/flatten_layer.cpp
@@ -22,7 +22,7 @@ namespace nntrainer {
 
 const std::string FlattenLayer::type = "flatten";
 
-int FlattenLayer::initialize() {
+int FlattenLayer::initialize(Manager &manager) {
   if (num_inputs != 1) {
     throw std::invalid_argument("input_shape keyword is only for one input");
   }

--- a/nntrainer/layers/flatten_layer.h
+++ b/nntrainer/layers/flatten_layer.h
@@ -53,7 +53,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @brief     Read Weight & Bias Data from file

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -68,7 +68,7 @@ void InputLayer::calcDerivative(sharedConstTensors in) {
     "calcDerivative for input layer is not supported");
 }
 
-int InputLayer::initialize() {
+int InputLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
   output_dim = input_dim;
 

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -87,7 +87,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -327,7 +327,7 @@ void Layer::printShapeInfo(std::ostream &out) {
   for (unsigned int idx = 0; idx < num_inputs; ++idx) {
     out << "input " << input_dim[idx];
     for (unsigned int i = 0; i < num_weights; i++)
-      out << "inner" << i << " " << weightAt(i).var.getDim();
+      out << "inner" << i << " " << weightAt(i).getVariable().getDim();
   }
   for (unsigned int idx = 0; idx < num_outputs; ++idx) {
     out << "output " << output_dim[idx];

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -78,7 +78,7 @@ std::vector<Tensor> Layer::getDerivatives() {
 }
 
 void Layer::copy(std::shared_ptr<Layer> l) {
-  for(auto const &w : weights)
+  for (auto const &w : weights)
     weights.push_back(w.clone());
 
   // TODO: fix this #630

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include <layer.h>
+#include <manager.h>
 #include <optimizer_internal.h>
 #include <tensor.h>
 #include <tensor_dim.h>
@@ -476,6 +477,8 @@ protected:
                                 use setNumWeights() to avoid
                                 setting parameters twice */
 
+  std::vector<std::shared_ptr<Weight>> weights;
+
   /**
    * @brief   Number of inputs this layer will requries/will operate on
    */
@@ -578,7 +581,7 @@ private:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int initialize() = 0;
+  virtual int initialize(Manager &manager) = 0;
 
   /**
    * @brief Set the input dimension

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -90,7 +90,6 @@ public:
     bias_initializer(bias_initializer_),
     flatten(flatten_),
     trainable(trainable_),
-    num_weights(0),
     num_inputs(1),
     num_outputs(1) {
     input_dim.resize(1);
@@ -257,7 +256,7 @@ public:
    * @brief     get all weights of the layer
    * @retval    vector of all params
    */
-  std::shared_ptr<Weight> getWeights() { return weight_list; }
+  std::vector<Weight> getWeights() { return weights; }
 
   /**
    * @brief     get if the output of this layer must be flatten
@@ -289,11 +288,7 @@ public:
    * @exception std::out_of_range for index out of range
    */
   Weight &weightAt(const unsigned int position) {
-    if (position >= num_weights) {
-      throw std::out_of_range("index out of range");
-    }
-
-    return weight_list.get()[position];
+    return weights[position];
   }
 
   /**
@@ -301,7 +296,7 @@ public:
    *
    * @return unsigned int number of weights
    */
-  unsigned int getNumWeights() { return num_weights; }
+  unsigned int getNumWeights() { return weights.size(); }
 
   /**
    * @brief Set the batch for the layer
@@ -448,36 +443,10 @@ protected:
   bool trainable;
 
   /**
-   * @brief     reserve memory for @a weight_list and set @a num_weights
-   * @exception std::invalid_argument when num_weights is already set and
-   * shouldn't be changed again.
+   * @brief     weight_list in this layer. This contains all weights of the
+   * layer.
    */
-  void setNumWeights(unsigned int psize) {
-    if (psize == num_weights)
-      return;
-
-    if (num_weights > 0) {
-      throw std::invalid_argument("param size can't be set once it is set");
-    }
-
-    num_weights = psize;
-    weight_list = std::shared_ptr<Weight>(new Weight[num_weights],
-                                          std::default_delete<Weight[]>());
-  }
-
-  /**
-   * @brief     weight_list in this layer. This contains trainable weights of
-   * layers.
-   */
-  std::shared_ptr<Weight> weight_list;
-
-  unsigned int num_weights; /**< length of weights.
-                                This shouldn't be changed
-                                after initiation
-                                use setNumWeights() to avoid
-                                setting parameters twice */
-
-  std::vector<std::shared_ptr<Weight>> weights;
+  std::vector<Weight> weights;
 
   /**
    * @brief   Number of inputs this layer will requries/will operate on

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -287,9 +287,7 @@ public:
    * @brief     get data alias at param position.
    * @exception std::out_of_range for index out of range
    */
-  Weight &weightAt(const unsigned int position) {
-    return weights[position];
-  }
+  Weight &weightAt(const unsigned int position) { return weights[position]; }
 
   /**
    * @brief Get the number of weights

--- a/nntrainer/layers/loss_layer.cpp
+++ b/nntrainer/layers/loss_layer.cpp
@@ -35,7 +35,7 @@ namespace nntrainer {
 
 const std::string LossLayer::type = "loss";
 
-int LossLayer::initialize() {
+int LossLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
 
   output_dim = input_dim;

--- a/nntrainer/layers/loss_layer.h
+++ b/nntrainer/layers/loss_layer.h
@@ -94,7 +94,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/nnstreamer_layer.cpp
+++ b/nntrainer/layers/nnstreamer_layer.cpp
@@ -93,7 +93,7 @@ int NNStreamerLayer::finalizeError(int status) {
   return status;
 }
 
-int NNStreamerLayer::initialize() {
+int NNStreamerLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
   TensorDim in_dim;
 

--- a/nntrainer/layers/nnstreamer_layer.h
+++ b/nntrainer/layers/nnstreamer_layer.h
@@ -65,7 +65,7 @@ public:
   /**
    * @copydoc Layer::initialize()
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @copydoc Layer::setTrainable(bool train)

--- a/nntrainer/layers/output_layer.cpp
+++ b/nntrainer/layers/output_layer.cpp
@@ -23,7 +23,7 @@ namespace nntrainer {
 
 const std::string OutputLayer::type = "output";
 
-int OutputLayer::initialize() {
+int OutputLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
 
   if (num_inputs == 0) {

--- a/nntrainer/layers/output_layer.h
+++ b/nntrainer/layers/output_layer.h
@@ -57,7 +57,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @brief     Read Weight & Bias Data from file

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -26,7 +26,7 @@ namespace nntrainer {
 
 const std::string Pooling2DLayer::type = "pooling2d";
 
-int Pooling2DLayer::initialize() {
+int Pooling2DLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
 
   if (input_dim.size() != 1 || output_dim.size() != 1) {

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -75,7 +75,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @brief     Read Weight & Bias Data from file

--- a/nntrainer/layers/tflite_layer.cpp
+++ b/nntrainer/layers/tflite_layer.cpp
@@ -41,7 +41,7 @@ void TfLiteLayer::setDimensions(const std::vector<int> &tensor_idx_list,
   }
 }
 
-int TfLiteLayer::initialize() {
+int TfLiteLayer::initialize(Manager &manager) {
   tflite::ops::builtin::BuiltinOpResolver resolver;
 
   model = tflite::FlatBufferModel::BuildFromFile(modelfile.c_str());

--- a/nntrainer/layers/tflite_layer.h
+++ b/nntrainer/layers/tflite_layer.h
@@ -64,7 +64,7 @@ public:
   /**
    * @copydoc Layer::initialize()
    */
-  int initialize();
+  int initialize(Manager &manager);
 
   /**
    * @copydoc Layer::setTrainable(bool train)

--- a/nntrainer/manager.h
+++ b/nntrainer/manager.h
@@ -50,7 +50,7 @@ public:
    *
    * @param ws  Weights to be tracked
    */
-  void trackWeights(std::vector<Weight> ws) {
+  void trackWeights(std::vector<Weight> &ws) {
     weights.reserve(weights.size() + ws.size());
     weights.insert(weights.end(), ws.begin(), ws.end());
   }

--- a/nntrainer/manager.h
+++ b/nntrainer/manager.h
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file	manager.h
+ * @date	30 Nov 2020
+ * @brief	This is NNtrainer manager for all weights, i/o and intermediate
+ * tensors
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#ifndef __MANAGER_H__
+#define __MANAGER_H__
+#ifdef __cplusplus
+
+#include <vector>
+
+#include <weight.h>
+
+namespace nntrainer {
+
+/**
+ * @class   Manager
+ * @brief   manager of nntrainer
+ */
+class Manager {
+public:
+  /**
+   * @brief     Constructor of Manager
+   */
+  Manager() {}
+
+  /**
+   * @brief     Destructor of Manager
+   */
+  ~Manager() {}
+
+  /**
+   * @brief     Add weight to be tracked and updated with nntrainer
+   *
+   * @param w   Weight to be tracked
+   */
+  void trackWeight(Weight w) { weights.push_back(w); }
+
+  /**
+   * @brief     Add weights to be tracked and updated with nntrainer
+   *
+   * @param ws  Weights to be tracked
+   */
+  void trackWeights(std::vector<Weight> ws) {
+    weights.reserve(weights.size() + ws.size());
+    weights.insert(weights.end(), ws.begin(), ws.end());
+  }
+
+  /**
+   * @brief     Get weights tracked with nntrainer
+   *
+   * @retval    list of weights
+   */
+  std::vector<Weight> getWeights() { return weights; }
+
+private:
+  // TODO: ensure that names of these weights are unique
+  std::vector<Weight> weights;
+};
+
+/**
+ * @brief Helper func for weight creation which are tracked by nntrainer
+ *
+ * @retval create weight
+ */
+template <typename... Args>
+Weight createWeight(Manager &manager, Args... args) {
+  Weight w = Weight(args...);
+  manager.trackWeight(w);
+  return w;
+}
+
+} // namespace nntrainer
+
+#endif /* __cplusplus */
+#endif /* __MANAGER_H__ */

--- a/nntrainer/manager.h
+++ b/nntrainer/manager.h
@@ -16,6 +16,7 @@
 #define __MANAGER_H__
 #ifdef __cplusplus
 
+#include <functional>
 #include <vector>
 
 #include <weight.h>
@@ -31,7 +32,7 @@ public:
   /**
    * @brief     Constructor of Manager
    */
-  Manager() {}
+  Manager() : enable_gradient_memory_opt(true) {}
 
   /**
    * @brief     Destructor of Manager
@@ -43,7 +44,9 @@ public:
    *
    * @param w   Weight to be tracked
    */
-  void trackWeight(Weight w) { weights.push_back(w); }
+  void trackWeight(std::reference_wrapper<Weight> w) {
+    weights.emplace_back(w);
+  }
 
   /**
    * @brief     Add weights to be tracked and updated with nntrainer
@@ -52,32 +55,55 @@ public:
    */
   void trackWeights(std::vector<Weight> &ws) {
     weights.reserve(weights.size() + ws.size());
-    weights.insert(weights.end(), ws.begin(), ws.end());
+    for (auto &w : ws)
+      weights.emplace_back(std::ref(w));
   }
 
   /**
    * @brief     Get weights tracked with nntrainer
    *
-   * @retval    list of weights
+   * @retval    list of weight references
    */
-  std::vector<Weight> getWeights() { return weights; }
+  std::vector<std::reference_wrapper<Weight>> getWeightRefs() {
+    return weights;
+  }
+
+  /**
+   * @brief Enable gradient memory sharing based optimization
+   * @param opt True to enable, else false
+   */
+  void setGradientMemoryOptimization(bool opt) {
+    enable_gradient_memory_opt = opt;
+  }
+
+  /**
+   * @brief Allocate and initialize the weight variable
+   */
+  void initialize() {
+    for (auto &weight : weights)
+      weight.get().initialize();
+  }
+
+  void reset() { weights.clear(); }
 
 private:
   // TODO: ensure that names of these weights are unique
-  std::vector<Weight> weights;
+  std::vector<std::reference_wrapper<Weight>> weights;
+
+  bool enable_gradient_memory_opt; /**< share memory among all the gradients */
 };
 
-/**
- * @brief Helper func for weight creation which are tracked by nntrainer
- *
- * @retval create weight
- */
-template <typename... Args>
-Weight createWeight(Manager &manager, Args... args) {
-  Weight w = Weight(args...);
-  manager.trackWeight(w);
-  return w;
-}
+// /**
+//  * @brief Helper func for weight creation which are tracked by nntrainer
+//  *
+//  * @retval create weight
+//  */
+// template <typename... Args>
+// Weight createWeight(Manager &manager, Args... args) {
+//   Weight w = Weight(args...);
+//   manager.trackWeight(std::forward<Args...>args);
+//   return ;
+// }
 
 } // namespace nntrainer
 

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -236,6 +236,8 @@ int NeuralNetwork::initialize() {
 
   setBatchSize(batch_size);
 
+  manager.initialize();
+
   initialized = true;
   return status;
 }

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -216,7 +216,7 @@ int NeuralNetwork::initialize() {
       }
     }
 
-    status = l.initialize();
+    status = l.initialize(manager);
     NN_RETURN_STATUS();
 
     if (istrequal(cur_type, BatchNormalizationLayer::type) ||

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -38,6 +38,7 @@
 #include <input_layer.h>
 #include <layer_internal.h>
 #include <loss_layer.h>
+#include <manager.h>
 #include <ml-api-common.h>
 #include <network_graph.h>
 #include <optimizer_internal.h>
@@ -381,6 +382,8 @@ private:
   NetType net_type; /**< Network Type */
 
   GraphType layers; /**< vector for store layer pointers */
+
+  Manager manager; /**< nntrainer manager */
 
   std::shared_ptr<DataBuffer> data_buffer; /**< Data Buffer to get Input */
 

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -346,6 +346,14 @@ public:
    */
   void printPreset(std::ostream &out, unsigned int preset);
 
+  /**
+   * @brief Enable gradient memory sharing based optimization
+   * @param opt True to enable, else false
+   */
+  void setGradientMemoryOptimization(bool opt) {
+    manager.setGradientMemoryOptimization(opt);
+  }
+
 private:
   /**
    * @brief   Print Options when printing layer info

--- a/nntrainer/optimizers/adam.cpp
+++ b/nntrainer/optimizers/adam.cpp
@@ -24,15 +24,12 @@ namespace nntrainer {
 
 const std::string Adam::type = "adam";
 
-int Adam::initialize(std::shared_ptr<Weight> weight_list,
-                     unsigned int num_weights, bool set_tensor) {
+int Adam::initialize(std::vector<Weight> &weight_list, bool set_tensor) {
   int status = ML_ERROR_NONE;
   weight_mv.clear();
 
   if (set_tensor) {
-    for (unsigned int i = 0; i < num_weights; ++i) {
-      Weight &w = weight_list.get()[i];
-
+    for (auto const &w : weight_list) {
       // TODO: only trainable weights must be sent to optimizer
       if (!w.getTrainable())
         continue;

--- a/nntrainer/optimizers/adam.h
+++ b/nntrainer/optimizers/adam.h
@@ -59,11 +59,9 @@ public:
   void setProperty(const PropertyType type, const std::string &value = "");
 
   /**
-   * @copydoc Optimizer::initialize(std::shared_ptr<Weight> params, unsigned int
-   num_weights, bool setTensor)
+   * @copydoc Optimizer::initialize(std::vector<Weight> params, bool setTensor)
    */
-  int initialize(std::shared_ptr<Weight> params, unsigned int num_weights,
-                 bool setTensor);
+  int initialize(std::vector<Weight> &params, bool setTensor);
 
   /**
    * @copydoc read(std::ifstream &file)

--- a/nntrainer/optimizers/optimizer.cpp
+++ b/nntrainer/optimizers/optimizer.cpp
@@ -48,7 +48,8 @@ double Optimizer::getLearningRate(int iteration) {
   return ll;
 }
 
-void Optimizer::apply_gradients(std::vector<Weight> &weight_list, int iteration) {
+void Optimizer::apply_gradients(std::vector<Weight> &weight_list,
+                                int iteration) {
 
   double ll = getLearningRate(iteration);
 

--- a/nntrainer/optimizers/optimizer.cpp
+++ b/nntrainer/optimizers/optimizer.cpp
@@ -34,8 +34,7 @@
 
 namespace nntrainer {
 
-int Optimizer::initialize(std::shared_ptr<Weight> weight_list,
-                          unsigned int num_weights, bool set_tensor) {
+int Optimizer::initialize(std::vector<Weight> &weight_list, bool set_tensor) {
   return ML_ERROR_NONE;
 }
 
@@ -49,15 +48,12 @@ double Optimizer::getLearningRate(int iteration) {
   return ll;
 }
 
-void Optimizer::apply_gradients(std::shared_ptr<Weight> weight_list,
-                                unsigned int num_weights, int iteration) {
+void Optimizer::apply_gradients(std::vector<Weight> &weight_list, int iteration) {
 
   double ll = getLearningRate(iteration);
 
   int idx = 0;
-  for (unsigned int i = 0; i < num_weights; ++i) {
-    Weight &weight = weight_list.get()[i];
-
+  for (auto &weight : weight_list) {
     if (!weight.getTrainable())
       continue;
 

--- a/nntrainer/optimizers/optimizer_internal.h
+++ b/nntrainer/optimizers/optimizer_internal.h
@@ -105,11 +105,9 @@ public:
   /**
    * @brief     apply gradient to weight_list
    * @param[in] params Weight list
-   * @param[in] num_weights size of the array
    * @param[in] iteration nth epoch number
    */
-  void apply_gradients(std::shared_ptr<Weight> params, unsigned int num_weights,
-                       int iteration);
+  void apply_gradients(std::vector<Weight> &params, int iteration);
 
   /**
    * @brief     Read Training optimizer paramters from file
@@ -165,8 +163,7 @@ private:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int initialize(std::shared_ptr<Weight> params,
-                         unsigned int num_weights, bool setTensor);
+  virtual int initialize(std::vector<Weight> &params, bool setTensor);
 
   /**
    * @brief     apply gradient to the given weight

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file	manager.cpp
+ * @date	2 Dec 2020
+ * @brief	This is NNtrainer manager for all weights, i/o and intermediate
+ * tensors
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#include <functional>
+#include <vector>
+
+#include <manager.h>
+
+namespace nntrainer {
+
+/**
+ * @brief     Add weight to be tracked and updated with nntrainer
+ */
+void Manager::trackWeight(std::reference_wrapper<Weight> w) {
+  std::vector<std::reference_wrapper<Weight>> temp = {w};
+  weights.emplace_back(temp);
+}
+
+/**
+ * @brief     Add weights to be tracked and updated with nntrainer
+ */
+void Manager::trackWeights(std::vector<Weight> &ws) {
+  std::vector<std::reference_wrapper<Weight>> layer_weights;
+  layer_weights.reserve(ws.size());
+
+  size_t weight_size = 0;
+
+  for (auto &w : ws) {
+    layer_weights.emplace_back(std::ref(w));
+    if (w.getTrainable())
+      weight_size += w.getDim().getDataLen();
+  }
+
+  weights.push_back(layer_weights);
+
+  max_weight_size = std::max(max_weight_size, weight_size);
+}
+
+/**
+ * @brief Allocate and initialize the weight variable
+ */
+void Manager::initialize() {
+  Tensor shared_grad;
+  if (max_weight_size > 0 && enable_gradient_memory_opt)
+    shared_grad = Tensor(max_weight_size);
+
+  for (auto &l_w : weights) {
+    size_t offset = 0;
+    for (auto &w : l_w) {
+      Weight &weight = w.get();
+      if (weight.getTrainable() && enable_gradient_memory_opt) {
+        weight.initialize(
+          shared_grad.getSharedDataTensor(weight.getDim(), offset));
+        offset += weight.getDim().getDataLen();
+      } else {
+        weight.initialize();
+      }
+    }
+  }
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -28,11 +28,12 @@ namespace nntrainer {
  * @brief   manager of nntrainer
  */
 class Manager {
+
 public:
   /**
    * @brief     Constructor of Manager
    */
-  Manager() : enable_gradient_memory_opt(true) {}
+  Manager() : max_weight_size(0), enable_gradient_memory_opt(true) {}
 
   /**
    * @brief     Destructor of Manager
@@ -44,27 +45,21 @@ public:
    *
    * @param w   Weight to be tracked
    */
-  void trackWeight(std::reference_wrapper<Weight> w) {
-    weights.emplace_back(w);
-  }
+  void trackWeight(std::reference_wrapper<Weight> w);
 
   /**
    * @brief     Add weights to be tracked and updated with nntrainer
    *
    * @param ws  Weights to be tracked
    */
-  void trackWeights(std::vector<Weight> &ws) {
-    weights.reserve(weights.size() + ws.size());
-    for (auto &w : ws)
-      weights.emplace_back(std::ref(w));
-  }
+  void trackWeights(std::vector<Weight> &ws);
 
   /**
    * @brief     Get weights tracked with nntrainer
    *
    * @retval    list of weight references
    */
-  std::vector<std::reference_wrapper<Weight>> getWeightRefs() {
+  std::vector<std::vector<std::reference_wrapper<Weight>>> getWeightRefs() {
     return weights;
   }
 
@@ -79,31 +74,25 @@ public:
   /**
    * @brief Allocate and initialize the weight variable
    */
-  void initialize() {
-    for (auto &weight : weights)
-      weight.get().initialize();
-  }
+  void initialize();
 
-  void reset() { weights.clear(); }
+  /**
+   * @brief Reset the manager state
+   */
+  void reset() {
+    weights.clear();
+    max_weight_size = 0;
+  }
 
 private:
   // TODO: ensure that names of these weights are unique
-  std::vector<std::reference_wrapper<Weight>> weights;
+  /**< Weights all the layer in the model to be managed */
+  std::vector<std::vector<std::reference_wrapper<Weight>>> weights;
+
+  size_t max_weight_size; /**< max weight required by a layer */
 
   bool enable_gradient_memory_opt; /**< share memory among all the gradients */
 };
-
-// /**
-//  * @brief Helper func for weight creation which are tracked by nntrainer
-//  *
-//  * @retval create weight
-//  */
-// template <typename... Args>
-// Weight createWeight(Manager &manager, Args... args) {
-//   Weight w = Weight(args...);
-//   manager.trackWeight(std::forward<Args...>args);
-//   return ;
-// }
 
 } // namespace nntrainer
 

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -1,6 +1,7 @@
 tensor_sources = [
   'blas_interface.cpp',
   'lazy_tensor.cpp',
+  'manager.cpp',
   'tensor.cpp',
   'tensor_dim.cpp',
   'var_grad.cpp',
@@ -8,6 +9,7 @@ tensor_sources = [
 ]
 
 tensor_headers = [
+  'manager.h',
   'tensor.h',
   'tensor_dim.h',
   'weight.h',

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -265,11 +265,22 @@ int Tensor::pow_i(float exponent) {
 }
 
 Tensor Tensor::getBatchSlice(unsigned int offset, unsigned int size) const {
+  TensorDim dim_ = dim;
+  dim_.batch(size);
+
+  return getSharedDataTensor(dim_, offset * this->dim.getFeatureLen());
+}
+
+Tensor Tensor::getSharedDataTensor(const TensorDim dim_,
+                                   unsigned int offset) const {
   Tensor ret = *this;
 
-  ret.dim.batch(size);
-  ret.data = std::shared_ptr<float>(
-    this->data, this->data.get() + offset * this->dim.getFeatureLen());
+  if (dim_.getDataLen() + offset > dim.getDataLen())
+    throw std::invalid_argument(
+      "Creating shared tensor of size bigger than tensor memory.");
+
+  ret.dim = dim_;
+  ret.data = std::shared_ptr<float>(this->data, this->data.get() + offset);
 
   return ret;
 }

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -536,13 +536,26 @@ public:
 
   /**
    * @brief Get slice of the tensor, sliced by batch
-   * @param[in] offset offset to start the slice
+   * @param[in] offset offset in batch to start the slice
    * @param[in] size size of the slice
    * @retval slice of this tensor
    * @note This function provides a slice of this tensor, and does not create a
    * copy
    */
   Tensor getBatchSlice(unsigned int offset, unsigned int size) const;
+
+  /**
+   * @brief Get new tensor which shares memory with current tensor but different
+   * shape
+   *
+   * @param dim new dimension to be set for this tensor
+   * @param offset offset to be used from the start of the data in bytes
+   * @note The new tensor will share the same data as the current tensor but
+   * will have different size.
+   * @note New size added with offset must be less than the size of the original
+   * tensor.
+   */
+  Tensor getSharedDataTensor(const TensorDim dim, unsigned int offset) const;
 
   /**
    * @brief     Convient wrapper for inplace copy of @a this.

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -24,14 +24,22 @@ Var_Grad::Var_Grad(const TensorDim &dim, bool train, const std::string &name) :
   grad = std::make_shared<Tensor>();
 }
 
-void Var_Grad::initialize() {
+void Var_Grad::initialize(const Tensor &grad_shared) {
   var = std::make_shared<Tensor>(dim);
 
-  grad = std::make_shared<Tensor>();
-  if (trainable) {
-    grad = std::make_shared<Tensor>(dim);
+  if (!grad_shared.uninitialized()) {
+    /**
+     * Making a new tensor is intentional here as this tensor is not shared
+     * with other layers but the internal memory is.
+     */
+    grad = std::make_shared<Tensor>(grad_shared);
+  } else {
+    grad = std::make_shared<Tensor>();
+    if (trainable) {
+      grad = std::make_shared<Tensor>(dim);
+    }
+    resetGradient();
   }
-  resetGradient();
 }
 
 void Var_Grad::setTrainable(bool train) {

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -16,37 +16,22 @@
 
 namespace nntrainer {
 
-Var_Grad::Var_Grad(const Var_Grad &rhs) : name(rhs.name) {
-  var = rhs.var.clone();
-  if (rhs.getTrainable())
-    grad = rhs.grad.clone();
-}
-
-Var_Grad &Var_Grad::operator=(const Var_Grad &rhs) {
-  Var_Grad temp(rhs);
-  swap(temp, *this);
-  return *this;
-}
-
 Var_Grad::Var_Grad(const TensorDim &dim, bool train, const std::string &name) :
+  trainable(train),
   name(name) {
-  var = Tensor(dim);
+  var = std::make_shared<Tensor>(dim);
 
-  grad = Tensor();
-  if (train) {
-    grad = Tensor(dim);
+  grad = std::make_shared<Tensor>();
+  if (trainable) {
+    grad = std::make_shared<Tensor>(dim);
   }
   resetGradient();
 }
 
 void Var_Grad::setTrainable(bool train) {
-  if (train == getTrainable())
-    return;
-
-  if (train) {
-    grad = Tensor(var.getDim());
-  } else {
-    grad = Tensor();
+  trainable = train;
+  if (trainable && grad->uninitialized()) {
+    grad = std::make_shared<Tensor>(var->getDim());
   }
 }
 

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -17,8 +17,14 @@
 namespace nntrainer {
 
 Var_Grad::Var_Grad(const TensorDim &dim, bool train, const std::string &name) :
+  dim(dim),
   trainable(train),
   name(name) {
+  var = std::make_shared<Tensor>();
+  grad = std::make_shared<Tensor>();
+}
+
+void Var_Grad::initialize() {
   var = std::make_shared<Tensor>(dim);
 
   grad = std::make_shared<Tensor>();

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -93,7 +93,7 @@ public:
   /**
    * @brief Allocate and initialize the weight variable
    */
-  virtual void initialize();
+  virtual void initialize(const Tensor &grad_shared = Tensor());
 
   /**
    * @brief Get the TensorDim

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -91,11 +91,16 @@ public:
   Var_Grad &operator=(Var_Grad &&rhs) = default;
 
   /**
+   * @brief Allocate and initialize the weight variable
+   */
+  virtual void initialize();
+
+  /**
    * @brief Get the TensorDim
    *
    * @return TensorDim Dimension
    */
-  TensorDim getDim() const { return var->getDim(); }
+  TensorDim getDim() const { return dim; }
 
   /**
    * @brief Get if the Var_Grad is trainable
@@ -161,9 +166,12 @@ public:
    * @note New dimension must maintain the shape of the variable
    */
 
-  void reset (const TensorDim &dim, bool train) {
-    var->reshape(dim);
-    grad->reshape(dim);
+  void reset(const TensorDim &tdim, bool train) {
+    dim = tdim;
+    if (!var->uninitialized())
+      var->reshape(dim);
+    if (!grad->uninitialized())
+      grad->reshape(dim);
     trainable = train;
     resetGradient();
   }
@@ -183,6 +191,7 @@ protected:
    */
   Tensor &getGradientRef() { return *grad.get(); }
 
+  TensorDim dim;                /**< dimension of the tensor */
   std::shared_ptr<Tensor> var;  /**< variable to be updated and used */
   std::shared_ptr<Tensor> grad; /**< gradient for the variable */
   bool trainable;               /**< if this variable is trainable */

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -144,13 +144,29 @@ public:
    *
    * @return Cloned copy
    */
-  virtual Var_Grad clone() const {
+  Var_Grad clone() const {
     Var_Grad vg(*this);
     vg.var = std::make_shared<Tensor>(this->var->clone());
     vg.grad = std::make_shared<Tensor>(this->grad->clone());
 
     return vg;
   };
+
+  /**
+   * @brief Reset the weight
+   *
+   * @param dim Variable and gradient tensor dimension
+   * @param train If the variable is trainable
+   *
+   * @note New dimension must maintain the shape of the variable
+   */
+
+  void reset (const TensorDim &dim, bool train) {
+    var->reshape(dim);
+    grad->reshape(dim);
+    trainable = train;
+    resetGradient();
+  }
 
 protected:
   /**

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -23,10 +23,12 @@ Weight::Weight(const TensorDim &dim, const WeightInitializer init, bool train,
   if (initializer == WeightInitializer::WEIGHT_UNKNOWN)
     throw std::invalid_argument("Weight initializer unknown");
 
-  initializeWeight();
+  // initialize();
 }
 
-void Weight::initializeWeight() {
+void Weight::initialize() {
+  Var_Grad::initialize();
+
   Tensor &var_ref = getVariableRef();
   const TensorDim dim = var_ref.getDim();
 

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -22,12 +22,10 @@ Weight::Weight(const TensorDim &dim, const WeightInitializer init, bool train,
   initializer(init) {
   if (initializer == WeightInitializer::WEIGHT_UNKNOWN)
     throw std::invalid_argument("Weight initializer unknown");
-
-  // initialize();
 }
 
-void Weight::initialize() {
-  Var_Grad::initialize();
+void Weight::initialize(const Tensor &grad_shared) {
+  Var_Grad::initialize(grad_shared);
 
   Tensor &var_ref = getVariableRef();
   const TensorDim dim = var_ref.getDim();

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -16,15 +16,6 @@
 
 namespace nntrainer {
 
-Weight::Weight(const Weight &rhs) :
-  Var_Grad(static_cast<const Var_Grad &>(rhs)),
-  initializer(rhs.initializer) {}
-
-Weight &Weight::operator=(const Weight &rhs) {
-  Weight temp(rhs);
-  swap(temp, *this);
-  return *this;
-}
 Weight::Weight(const TensorDim &dim, const WeightInitializer init, bool train,
                std::string name) :
   Var_Grad(dim, train, name),
@@ -36,35 +27,37 @@ Weight::Weight(const TensorDim &dim, const WeightInitializer init, bool train,
 }
 
 void Weight::initializeWeight() {
-  const TensorDim dim = var.getDim();
+  Tensor &var_ref = getVariableRef();
+  const TensorDim dim = var_ref.getDim();
 
   switch (initializer) {
   case WeightInitializer::WEIGHT_ZEROS:
-    var.setZero();
+    var_ref.setZero();
     break;
   case WeightInitializer::WEIGHT_ONES:
-    var.setValue(1.0f);
+    var_ref.setValue(1.0f);
     break;
   case WeightInitializer::WEIGHT_LECUN_NORMAL:
-    var.setRandNormal(0.0f, sqrtFloat(1.0f / dim.height()));
+    var_ref.setRandNormal(0.0f, sqrtFloat(1.0f / dim.height()));
     break;
   case WeightInitializer::WEIGHT_XAVIER_NORMAL:
-    var.setRandNormal(0.0f, sqrtFloat(2.0f / (dim.width() + dim.height())));
+    var_ref.setRandNormal(0.0f, sqrtFloat(2.0f / (dim.width() + dim.height())));
     break;
   case WeightInitializer::WEIGHT_HE_NORMAL:
-    var.setRandNormal(0.0f, sqrtFloat(2.0f / (dim.height())));
+    var_ref.setRandNormal(0.0f, sqrtFloat(2.0f / (dim.height())));
     break;
   case WeightInitializer::WEIGHT_LECUN_UNIFORM:
-    var.setRandUniform(-1.0f * sqrtFloat(1.0f / dim.height()),
-                       sqrtFloat(1.0f / dim.height()));
+    var_ref.setRandUniform(-1.0f * sqrtFloat(1.0f / dim.height()),
+                           sqrtFloat(1.0f / dim.height()));
     break;
   case WeightInitializer::WEIGHT_XAVIER_UNIFORM:
-    var.setRandUniform(-1.0f * sqrtFloat(6.0f / (dim.height() + dim.width())),
-                       sqrtFloat(6.0 / (dim.height() + dim.width())));
+    var_ref.setRandUniform(-1.0f *
+                             sqrtFloat(6.0f / (dim.height() + dim.width())),
+                           sqrtFloat(6.0 / (dim.height() + dim.width())));
     break;
   case WeightInitializer::WEIGHT_HE_UNIFORM:
-    var.setRandUniform(-1.0f * sqrtFloat(6.0f / (dim.height())),
-                       sqrtFloat(6.0 / (dim.height())));
+    var_ref.setRandUniform(-1.0f * sqrtFloat(6.0f / (dim.height())),
+                           sqrtFloat(6.0 / (dim.height())));
     break;
   default:
     break;

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -127,11 +127,11 @@ public:
   Weight &operator=(Weight &&rhs) = default;
 
   /**
-   * @bried Clone the currnet object
+   * @brief Clone the currnet object
    *
    * @return Cloned copy
    */
-  Weight clone() {
+  Weight clone() const {
     Weight w(*this);
     if (!var->uninitialized())
       w.var = std::make_shared<Tensor>(this->var->clone());
@@ -139,6 +139,21 @@ public:
       w.grad = std::make_shared<Tensor>(this->grad->clone());
 
     return w;
+  }
+
+  /**
+   * @brief Reset the weight
+   *
+   * @param dim Variable and gradient tensor dimension
+   * @param init Initializer for the tensor
+   * @param train If the variable is trainable
+   *
+   * @note New dimension must maintain the shape of the variable
+   */
+
+  void reset (const TensorDim &dim, const WeightInitializer init, bool train) {
+    Var_Grad::reset(dim, train);
+    initializeWeight();
   }
 
 private:

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -81,7 +81,7 @@ public:
   /**
    * @brief Allocate and initialize the weight variable
    */
-  void initialize();
+  void initialize(const Tensor &grad_shared = Tensor());
 
   /**
    * @brief Swap for weight
@@ -137,7 +137,6 @@ public:
       w.var = std::make_shared<Tensor>(this->var->clone());
     if (!this->grad->uninitialized())
       w.grad = std::make_shared<Tensor>(this->grad->clone());
-
 
     return w;
   }

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -101,7 +101,7 @@ public:
    *
    * @param rhs weight to construct from
    */
-  Weight(const Weight &rhs);
+  Weight(const Weight &rhs) = default;
 
   /**
    * @brief Move constructor for weight
@@ -116,7 +116,7 @@ public:
    * @param rhs copy from
    * @return Weight& Updated weight
    */
-  Weight &operator=(const Weight &rhs);
+  Weight &operator=(const Weight &rhs) = default;
 
   /**
    * @brief move assignment
@@ -125,6 +125,21 @@ public:
    * @return Weight& Updated weight
    */
   Weight &operator=(Weight &&rhs) = default;
+
+  /**
+   * @bried Clone the currnet object
+   *
+   * @return Cloned copy
+   */
+  Weight clone() {
+    Weight w(*this);
+    if (!var->uninitialized())
+      w.var = std::make_shared<Tensor>(this->var->clone());
+    if (!grad->uninitialized())
+      w.grad = std::make_shared<Tensor>(this->grad->clone());
+
+    return w;
+  }
 
 private:
   WeightInitializer initializer; /**< initializer for this variable */

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -81,7 +81,7 @@ public:
   /**
    * @brief Allocate and initialize the weight variable
    */
-  void initializeWeight();
+  void initialize();
 
   /**
    * @brief Swap for weight
@@ -133,10 +133,11 @@ public:
    */
   Weight clone() const {
     Weight w(*this);
-    if (!var->uninitialized())
+    if (!this->var->uninitialized())
       w.var = std::make_shared<Tensor>(this->var->clone());
-    if (!grad->uninitialized())
+    if (!this->grad->uninitialized())
       w.grad = std::make_shared<Tensor>(this->grad->clone());
+
 
     return w;
   }
@@ -151,9 +152,9 @@ public:
    * @note New dimension must maintain the shape of the variable
    */
 
-  void reset (const TensorDim &dim, const WeightInitializer init, bool train) {
+  void reset(const TensorDim &dim, const WeightInitializer init, bool train) {
+    initializer = init;
     Var_Grad::reset(dim, train);
-    initializeWeight();
   }
 
 private:

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -384,6 +384,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/var_grad.h
 %{_includedir}/nntrainer/weight.h
 %{_includedir}/nntrainer/app_context.h
+%{_includedir}/nntrainer/manager.h
 %{_includedir}/nntrainer/network_graph.h
 %{_libdir}/pkgconfig/nntrainer.pc
 

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -77,6 +77,8 @@ protected:
       layer.setOutputBuffer(i, n_buffer);
     }
 
+    manager.initialize();
+
     return status;
   }
 
@@ -93,7 +95,10 @@ protected:
   // anchor point to prepare layer
   virtual void prepareLayer(){};
 
-  virtual void resetLayer() { layer = LayerType(); }
+  virtual void resetLayer() {
+    layer = LayerType();
+    manager.reset();
+  }
 
   virtual void setInputDim(const std::string &dimension) {
     ASSERT_EQ(layer.setProperty({"input_shape=" + dimension}), ML_ERROR_NONE);

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -640,12 +640,12 @@ protected:
   }
 
   void matchUpdatedWeightsGradients() {
-    std::shared_ptr<nntrainer::Weight> params = layer.getWeights();
+    std::vector<nntrainer::Weight> params = layer.getWeights();
 
     /** Match gradients and updated weights */
     for (int idx = 0; idx < 2; ++idx) {
-      matchOutput(params.get()[idx].getGradient(), grad[idx]);
-      matchOutput(params.get()[idx].getVariable(), new_w[idx]);
+      matchOutput(params[idx].getGradient(), grad[idx]);
+      matchOutput(params[idx].getVariable(), new_w[idx]);
     }
   }
 
@@ -680,7 +680,7 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch, forwarding_backwarding_00_p) {
 
   matchOutput(result, "tc_fc_1_goldenFCGradientAdam.out");
 
-  nntrainer::Weight *param_data = layer.getWeights().get();
+  auto param_data = layer.getWeights();
 
   nntrainer::Weight &param = param_data[0];
   nntrainer::Tensor weight = param.getVariable();
@@ -1181,7 +1181,7 @@ TEST_F(nntrainer_Conv2DLayer, backwarding_01_p) {
   EXPECT_NO_THROW(result = *layer.backwarding_with_val(
                     1, {MAKE_SHARED_TENSOR(derivatives)})[0]);
 
-  nntrainer::Weight *param_data = layer.getWeights().get();
+  auto param_data = layer.getWeights();
   const float *weight_grad = param_data[0].getGradient().getData();
   const float *bias_grad = param_data[1].getGradient().getData();
 
@@ -1218,7 +1218,7 @@ TEST_F(nntrainer_Conv2DLayer, backwarding_02_p) {
   EXPECT_NO_THROW(result = *layer.backwarding_with_val(
                     1, {MAKE_SHARED_TENSOR(derivatives)})[0]);
 
-  nntrainer::Weight *param_data = layer.getWeights().get();
+  auto param_data = layer.getWeights();
   const float *weight_grad = param_data[0].getGradient().getData();
   const float *bias_grad = param_data[1].getGradient().getData();
 
@@ -1328,7 +1328,7 @@ TEST_F(nntrainer_Conv2DLayer, DISABLED_backwarding_03_p) {
     result = *layer1.backwarding_with_val(1, {MAKE_SHARED_TENSOR(result2)})[0]);
 
   /** Compare second conv */
-  nntrainer::Weight *param_data = layer2.getWeights().get();
+  auto param_data = layer2.getWeights();
   const float *weight_grad = param_data[0].getGradient().getData();
   const float *bias_grad = param_data[1].getGradient().getData();
 
@@ -1336,7 +1336,7 @@ TEST_F(nntrainer_Conv2DLayer, DISABLED_backwarding_03_p) {
   matchOutput(bias_grad, "tc_conv2d_int_goldenBias2Grad.out");
 
   /** Compare first conv */
-  param_data = layer1.getWeights().get();
+  param_data = layer1.getWeights();
   weight_grad = param_data[0].getGradient().getData();
   bias_grad = param_data[1].getGradient().getData();
 
@@ -1371,7 +1371,7 @@ TEST_F(nntrainer_Conv2DLayer, backwarding_04_p) {
   EXPECT_NO_THROW(result = *layer.backwarding_with_val(
                     1, {MAKE_SHARED_TENSOR(derivatives)})[0]);
 
-  nntrainer::Weight *param_data = layer.getWeights().get();
+  auto param_data = layer.getWeights();
   const float *weight_grad = param_data[0].getGradient().getData();
   const float *bias_grad = param_data[1].getGradient().getData();
 

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -21,6 +21,7 @@
 #include <input_layer.h>
 #include <layer_internal.h>
 #include <loss_layer.h>
+#include <manager.h>
 #include <nntrainer_error.h>
 #include <nntrainer_test_util.h>
 #include <optimizer_factory.h>
@@ -53,7 +54,7 @@ protected:
   }
 
   virtual int reinitialize() {
-    int status = layer.initialize();
+    int status = layer.initialize(manager);
     EXPECT_EQ(status, ML_ERROR_NONE);
 
     in = nntrainer::Tensor(layer.getInputDimension()[0]);
@@ -200,6 +201,7 @@ protected:
   nntrainer::Tensor in;
   nntrainer::Tensor out;
   float local_tolerance = tolerance;
+  nntrainer::Manager manager;
 };
 
 class nntrainer_InputLayer
@@ -360,18 +362,20 @@ TEST_F(nntrainer_FullyConnectedLayer, initialize_01_p) {
  * @brief Fully Connected Layer without setting any parameter
  */
 TEST(nntrainer_FullyConnectedLayer_n, initialize_02_n) {
+  nntrainer::Manager manager;
   nntrainer::FullyConnectedLayer layer;
-  EXPECT_THROW(layer.initialize(), std::invalid_argument);
+  EXPECT_THROW(layer.initialize(manager), std::invalid_argument);
 }
 
 /**
  * @brief Fully Connected Layer without setting unit
  */
 TEST(nntrainer_FullyConnectedLayer_n, initialize_03_n) {
+  nntrainer::Manager manager;
   nntrainer::FullyConnectedLayer layer;
   layer.setProperty({"input_shape=32:1:28:28"});
 
-  EXPECT_THROW(layer.initialize(), std::invalid_argument);
+  EXPECT_THROW(layer.initialize(manager), std::invalid_argument);
 }
 
 /**
@@ -490,7 +494,7 @@ protected:
 
     act_layer->setBatch(layer.getOutputDimension()[0].batch());
 
-    status = act_layer->initialize();
+    status = act_layer->initialize(manager);
     EXPECT_EQ(status, ML_ERROR_NONE);
 
     act_layer->resizeNetInput(act_layer->getNumInputs());
@@ -523,7 +527,7 @@ protected:
 
     loss_layer->setBatch(layer.getOutputDimension()[0].batch());
 
-    status = loss_layer->initialize();
+    status = loss_layer->initialize(manager);
     EXPECT_EQ(status, ML_ERROR_NONE);
     status = loss_layer->setLoss(type);
     EXPECT_EQ(status, ML_ERROR_NONE);
@@ -1264,7 +1268,7 @@ TEST_F(nntrainer_Conv2DLayer, DISABLED_backwarding_03_p) {
                         "kernel_size= 5,5", "stride=1, 1", "padding=0, 0"});
   EXPECT_EQ(status, ML_ERROR_NONE);
   layer1.setBatch(1);
-  status = layer1.initialize();
+  status = layer1.initialize(manager);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   loadFile("tc_conv2d_int_conv2DKernel.in", layer1);
@@ -1285,7 +1289,7 @@ TEST_F(nntrainer_Conv2DLayer, DISABLED_backwarding_03_p) {
   status = layer2.setProperty(
     {"input_shape=" + getDimensionString(layer1.getOutputDimension()[0])});
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = layer2.initialize();
+  status = layer2.initialize(manager);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   loadFile("tc_conv2d_int_conv2DKernel2.in", layer2);
@@ -1777,17 +1781,19 @@ TEST(nntrainer_LossLayer, setProperty_individual_02_n) {
 }
 
 TEST(nntrainer_ActivationLayer, init_01_n) {
+  nntrainer::Manager manager;
   nntrainer::ActivationLayer layer;
-  EXPECT_THROW(layer.initialize(), std::invalid_argument);
+  EXPECT_THROW(layer.initialize(manager), std::invalid_argument);
 }
 
 TEST(nntrainer_ActivationLayer, init_02_p) {
+  nntrainer::Manager manager;
   int status = ML_ERROR_NONE;
   nntrainer::ActivationLayer layer;
 
   status = layer.setProperty({"input_shape=1:1:1:1"});
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status = layer.initialize();
+  status = layer.initialize(manager);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
@@ -1873,7 +1879,7 @@ TEST_F(nntrainer_AdditionLayer, initialize_01_p) {
 TEST_F(nntrainer_AdditionLayer, initialize_02_n) {
   nntrainer::AdditionLayer layer;
   layer.setProperty({"input_shape=1:1:1:1"});
-  status = layer.initialize();
+  status = layer.initialize(manager);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -1884,7 +1890,7 @@ TEST_F(nntrainer_AdditionLayer, checkValidation_01_p) {
 
 TEST_F(nntrainer_AdditionLayer, setProperty_01_p) {
   setProperty("num_inputs=10");
-  status = layer.initialize();
+  status = layer.initialize(manager);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -1265,6 +1265,9 @@ TEST_F(nntrainer_Conv2DLayer, DISABLED_backwarding_03_p) {
                         "padding=0, 0");
 
   loadFile("tc_conv2d_int_conv2DLayer.in", in);
+  nntrainer::Manager manager;
+
+  manager.setGradientMemoryOptimization(false);
 
   nntrainer::Conv2DLayer layer1;
   status =

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -87,7 +87,7 @@ public:
     node.layer->setTrainable(true);
 
     for (unsigned int i = 0; i < num_weights; ++i) {
-      nntrainer::Weight &w = node.layer->weightAt(i);
+      const nntrainer::Weight &w = node.layer->weightAt(i);
       expected_weights.push_back(w.clone());
     }
 
@@ -276,6 +276,11 @@ void NodeWatcher::backward(int iteration, bool should_verify) {
 
 GraphWatcher::GraphWatcher(const std::string &config) {
   nn = nntrainer::NeuralNetwork();
+
+  /** Disable gradient optimization as gradient is being matched for each layer
+   */
+  nn.setGradientMemoryOptimization(false);
+
   if (nn.loadFromConfig(config)) {
     throw std::invalid_argument("load from config failed!");
   };

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -87,8 +87,8 @@ public:
     node.layer->setTrainable(true);
 
     for (unsigned int i = 0; i < num_weights; ++i) {
-      const nntrainer::Weight &w = node.layer->weightAt(i);
-      expected_weights.push_back(w);
+      nntrainer::Weight &w = node.layer->weightAt(i);
+      expected_weights.push_back(w.clone());
     }
 
     expected_output = nntrainer::Tensor(node.layer->getOutputDimension()[0]);


### PR DESCRIPTION
**Commit 1**: [weight/var_grad] Make internal variable as shared_ptr
Internal variables in weights/var_grad, namely, the variable and gradient itself
    are changed to shared_ptr so that weights can be shared without worrying about
    shallow copies.
    
Also changed the copy constructor to not create new Tensor as copy constructor
    of weight will get called and its unnecessary + unintentional overhead.
    As weight is just wrapper over tensor, their copy constructors should follow
    same behavior as tensor which is to not create new memory.
    Added clone as an alternative to create new copy of a given weight.
    
**Commit 2**: [manager] Added nntrainer manager for weights
Added manager to manage all the allocated weights
    This patch also adds manager to the model and passes manager to the
    initialize which allows weights to be added to the manager.

**Commit 3**: [weight] Updated weights to be vector
Updated weights of layer to be vector than a shared_ptr array
    This is for easier management and updating weight internally when
    gradient will share the memory

**Commit 4**: [layers/manager] Register weights with manager
All the weights of the layer are now registered with manager
    Manager allocates memory for these weights and in future
    handle their updates etc

**Commit 5**: [manager] Share gradient memory for all layer
This patch allows sharing the memory for gradient across all the layers
    The maximum size of the gradient is allocated and all layers have unique tensors
    which internally points to this tensor.
    
This optimization feature can be disabled for a model (as done with automated models unittest)
    
Manager is also moved to nntrainer/tensor as manager is managing all the weights (tensors) and will
    in future manage all the inputs/outputs.
    If the functionality of manager is extended, then it can be appropriately moved.
    
See also #774
Resolves #766
    
**Self evaluation:**
    1. Build test: [x]Passed [ ]Failed [ ]Skipped
    2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>