### PR TITLE
[vgg] Added pytorch model for vgg16

### DIFF
--- a/Applications/VGG/PyTorch/main.py
+++ b/Applications/VGG/PyTorch/main.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# @file	main.py
+# @date	08 Dec 2020
+# @brief	This is VGG16 Example using PyTorch
+# @see		https://github.com/nnstreamer/nntrainer
+# @author	Parichay Kapoor <pk.kapoor@samsung.com>
+# @bug		No known bugs except for NYI items
+#
+# This is based on official pytorch examples
+
+'''Train CIFAR100 with PyTorch.'''
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import torch.nn.functional as F
+import torch.backends.cudnn as cudnn
+
+import torchvision
+import torchvision.transforms as transforms
+
+import os
+import argparse
+import sys
+
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+# Data
+print('==> Preparing data..')
+transform_train = transforms.Compose([
+    transforms.RandomCrop(32, padding=4),
+    transforms.RandomHorizontalFlip(),
+    transforms.ToTensor(),
+    transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+])
+
+transform_test = transforms.Compose([
+    transforms.ToTensor(),
+    transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+])
+
+trainset = torchvision.datasets.CIFAR100(
+        root='./data', train=True, download=True, transform=transform_train)
+trainloader = torch.utils.data.DataLoader(
+        trainset, batch_size=128, shuffle=True, num_workers=4)
+
+testset = torchvision.datasets.CIFAR100(
+        root='./data', train=False, download=True, transform=transform_test)
+testloader = torch.utils.data.DataLoader(
+        testset, batch_size=128, shuffle=False, num_workers=4)
+
+# Model
+
+cfg = {'VGG16': [64, 64, 'M', 128, 128, 'M', 256, 256, 256, 'M', 512, 512, 512, 'M', 512, 512, 512, 'M']}
+class VGG(nn.Module):
+    def __init__(self, vgg_name):
+        super(VGG, self).__init__()
+        self.features = self._make_layers(cfg[vgg_name])
+        self.classifier = nn.Sequential(nn.Linear(512, 256), nn.BatchNorm1d(256),
+            nn.ReLU(inplace=True), nn.Linear(256, 100))
+
+    def forward(self, x):
+        out = self.features(x)
+        out = out.view(out.size(0), -1)
+        out = self.classifier(out)
+        return out
+
+    def _make_layers(self, cfg):
+        layers = []
+        in_channels = 3
+        for x in cfg:
+            if x == 'M':
+                layers += [nn.MaxPool2d(kernel_size=2, stride=2)]
+            else:
+                layers += [nn.Conv2d(in_channels, x, kernel_size=3, padding=1),
+                        nn.ReLU(inplace=True)]
+                in_channels = x
+        layers += [nn.AvgPool2d(kernel_size=1, stride=1)]
+        return nn.Sequential(*layers)
+
+print('Building model..')
+net = VGG('VGG16')
+net = net.to(device)
+if device == 'cuda':
+    net = torch.nn.DataParallel(net)
+    cudnn.benchmark = True
+
+criterion = nn.CrossEntropyLoss()
+optimizer = optim.Adam(net.parameters(), lr=1e-3, weight_decay=5e-4)
+
+# Training
+def train(epoch):
+    print('\nEpoch: %d' % epoch)
+    net.train()
+    train_loss = 0
+    correct = 0
+    total = 0
+    for batch_idx, (inputs, targets) in enumerate(trainloader):
+        inputs, targets = inputs.to(device), targets.to(device)
+        optimizer.zero_grad()
+        outputs = net(inputs)
+        loss = criterion(outputs, targets)
+        loss.backward()
+        optimizer.step()
+
+        train_loss += loss.item()
+        _, predicted = outputs.max(1)
+        total += targets.size(0)
+        correct += predicted.eq(targets).sum().item()
+
+    print('Loss: %.3f | Acc: %.3f%% (%d/%d)'
+            % (train_loss/(batch_idx+1), 100.*correct/total, correct, total))
+
+def test(epoch):
+    net.eval()
+    test_loss = 0
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for batch_idx, (inputs, targets) in enumerate(testloader):
+            inputs, targets = inputs.to(device), targets.to(device)
+            outputs = net(inputs)
+            loss = criterion(outputs, targets)
+
+            test_loss += loss.item()
+            _, predicted = outputs.max(1)
+            total += targets.size(0)
+            correct += predicted.eq(targets).sum().item()
+
+        print('Loss: %.3f | Acc: %.3f%% (%d/%d)'
+                % (test_loss/(batch_idx+1), 100.*correct/total, correct, total))
+
+    # Save checkpoint.
+    state = {'net': net.state_dict(),
+            'acc': acc,
+            'epoch': epoch,
+    }
+    if not os.path.isdir('checkpoint'):
+        os.mkdir('checkpoint')
+    torch.save(state, './checkpoint/ckpt.pth')
+
+if __name__ == '__main__':
+    for epoch in range(1):
+        train(epoch)
+    # test(epoch)

--- a/Applications/VGG/Tensorflow/vgg_keras.py
+++ b/Applications/VGG/Tensorflow/vgg_keras.py
@@ -5,7 +5,7 @@
 #
 # @file	vgg_keras.py
 # @date	08 Oct 2020
-# @brief	This is VGG Example using Keras
+# @brief	This is VGG16 Example using Keras
 # @see		https://github.com/nnstreamer/nntrainer
 # @author	Jijoong Moon <jijoong.moon@samsung.com>
 # @bug		No known bugs except for NYI items
@@ -41,9 +41,9 @@ np.random.seed(SEED)
 batch_size =128
 Learning = True
 Test = False
-num_epoch = 1500
+num_epoch = 1
 DEBUG = True
-USE_FIT = False
+USE_FIT = True
 
 def save(filename, *data):
     with open(filename, 'ab+') as outfile:
@@ -74,31 +74,27 @@ def datagen(x_data, y_data, batch_size):
 def create_model():
     model = models.Sequential()
     model.add(tf.keras.Input(shape=(32, 32, 3)))
-    model.add(Conv2D(16, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
-    model.add(Conv2D(16, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
-    model.add(MaxPooling2D(pool_size=(2,2)))
-    model.add(Conv2D(32, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
-    model.add(Conv2D(32, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
-    model.add(MaxPooling2D(pool_size=(2,2)))
-    model.add(Conv2D(64, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
     model.add(Conv2D(64, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
     model.add(Conv2D(64, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
     model.add(MaxPooling2D(pool_size=(2,2)))
     model.add(Conv2D(128, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
     model.add(Conv2D(128, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
-    model.add(Conv2D(128, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
     model.add(MaxPooling2D(pool_size=(2,2)))
-    model.add(Conv2D(128, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
-    model.add(Conv2D(128, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
-    model.add(Conv2D(128, (3,3), padding='same', bias_initializer=initializers.Zeros()))
-    model.add(BatchNormalization())
-    model.add(Activation('relu'))
+    model.add(Conv2D(256, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
+    model.add(Conv2D(256, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
+    model.add(Conv2D(256, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
     model.add(MaxPooling2D(pool_size=(2,2)))
+    model.add(Conv2D(512, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
+    model.add(Conv2D(512, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
+    model.add(Conv2D(512, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
+    model.add(MaxPooling2D(pool_size=(2,2)))
+    model.add(Conv2D(512, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
+    model.add(Conv2D(512, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
+    model.add(Conv2D(512, (3,3), padding='same', activation='relu', bias_initializer=initializers.Zeros()))
+    model.add(MaxPooling2D(pool_size=(2,2)))
+
     model.add(Flatten())
-    model.add(layers.Dense(128, bias_initializer=initializers.Zeros()))
-    model.add(BatchNormalization())
-    model.add(Activation('relu'))
-    model.add(layers.Dense(128, bias_initializer=initializers.Zeros()))
+    model.add(layers.Dense(256, bias_initializer=initializers.Zeros()))
     model.add(BatchNormalization())
     model.add(Activation('relu'))
     model.add(layers.Dense(100, bias_initializer=initializers.Zeros()))

--- a/Applications/VGG/res/vgg.ini
+++ b/Applications/VGG/res/vgg.ini
@@ -9,7 +9,7 @@
 [Model]
 Type = NeuralNetwork	# Network Type : Regression, KNN, NeuralNetwork
 Learning_rate = 1e-4 	# Learning Rate
-Epochs = 1500		# Epochs
+Epochs = 1		# Epochs
 Optimizer = adam 	# Optimizer : sgd (stochastic gradien decent),
  	    		#             adam (Adamtive Moment Estimation)
 Loss = cross  		# Loss function : mse (mean squared error)
@@ -195,25 +195,15 @@ Type = conv2d
 input_layers = conv2d_c12_layer
 kernel_size = 3,3
 bias_initializer=zeros
+Activation=relu
 weight_initializer = xavier_uniform
 filters = 512
 stride = 1,1
 padding = 1,1
 
-[bn_normalization_b1_layer]
-Type = batch_normalization
-input_layers = conv2d_c13_layer
-epsilon = 1.0e-6
-momentum = 0.9
-Activation=relu
-beta_initializer = zeros
-gamma_initializer = ones
-moving_mean_initializer = zeros
-moving_variance_initializer = ones
-
 [pooling2d_p5_layer]
 Type=pooling2d
-input_layers = bn_normalization_b1_layer
+input_layers = conv2d_c13_layer
 pool_size = 2,2
 stride =2,2
 padding = 0,0
@@ -241,27 +231,9 @@ gamma_initializer = ones
 moving_mean_initializer = zeros
 moving_variance_initializer = ones
 
-[fc_f2_layer]
-Type = fully_connected
-input_layers = bn_normalization_b2_layer
-Unit = 256
-weight_initializer = xavier_uniform
-bias_initializer = zeros
-
-[bn_normalization_b3_layer]
-Type = batch_normalization
-input_layers = fc_f2_layer
-epsilon = 1.0e-6
-momentum = 0.9
-Activation = relu
-beta_initializer = zeros
-gamma_initializer = ones
-moving_mean_initializer = zeros
-moving_variance_initializer = ones
-
 [fc_f3_layer]
 Type = fully_connected
-input_layers = bn_normalization_b3_layer
+input_layers = bn_normalization_b2_layer
 Unit = 100		# Output Layer Dimension ( = Weight Width )
 weight_initializer = xavier_uniform
 bias_initializer = zeros


### PR DESCRIPTION
Added pytorch model for vgg16
    This is to benchmark against tf and nntrainer
    
Update the nntrainer and tensorflow to use official VGG16 model architecture
    The FC layers setup is different as the cifar100 dataset has just 100 output classes
    than 1000 classes of the imagenet.
    Further, the number of epochs are reduced to 1.
    When training, this can be increased appropriately.

**Self evaluation:**
    1. Build test: [x]Passed [ ]Failed [ ]Skipped
    2. Run test: [x]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>