### PR TITLE
[Test] Add macro to check if backbone is enabled @open sesame 12/16 14:30

### DIFF
--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -78,11 +78,15 @@ TEST(ccapi_layer, construct_02_p) {
   EXPECT_NO_THROW(layer = ml::train::layer::MultiOut());
   EXPECT_EQ(layer->getType(), "output");
 
+#ifdef ENABLE_NNSTREAMER_BACKBONE
   EXPECT_NO_THROW(layer = ml::train::layer::BackboneNNStreamer());
   EXPECT_EQ(layer->getType(), "backbone_nnstreamer");
+#endif
 
+#ifdef ENABLE_TFLITE_BACKBONE
   EXPECT_NO_THROW(layer = ml::train::layer::BackboneTFLite());
   EXPECT_EQ(layer->getType(), "backbone_tflite");
+#endif
 
   EXPECT_NO_THROW(layer = ml::train::layer::ReLU());
   EXPECT_EQ(layer->getType(), "activation");


### PR DESCRIPTION
When backbone is not enabled, test fails because backbone is not enabled
This patch adds a define in the test so that test can pass when backbone
is not enabled

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

resolves #803 