### PR TITLE
[Manager] Add shared memory allocation strategy @open sesame 12/16 17:54

### DIFF
--- a/Applications/Custom/LayerClient/jni/Android.mk
+++ b/Applications/Custom/LayerClient/jni/Android.mk
@@ -57,7 +57,7 @@ LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_layer_client_example
-LOCAL_LDLIBS := -llog
+LOCAL_LDLIBS := -llog -landroid
 
 LOCAL_SRC_FILES := main.cpp pow.cpp
 

--- a/Applications/Custom/LayerClient/jni/Application.mk
+++ b/Applications/Custom/LayerClient/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI = arm64-v8a
-APP_STL = c++_shared
-APP_PLATFORM=android-24
+APP_ABI := arm64-v8a
+APP_STL := c++_shared
+APP_PLATFORM := android-29

--- a/Applications/KNN/jni/Android.mk
+++ b/Applications/KNN/jni/Android.mk
@@ -66,7 +66,7 @@ LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := knn_sample
-LOCAL_LDLIBS := -llog
+LOCAL_LDLIBS := -llog -landroid
 
 LOCAL_SRC_FILES := main_sample.cpp
 

--- a/Applications/KNN/jni/Application.mk
+++ b/Applications/KNN/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI = arm64-v8a
-APP_STL = c++_shared
-APP_PLATFORM=android-24
+APP_ABI := arm64-v8a
+APP_STL := c++_shared
+APP_PLATFORM := android-29

--- a/Applications/LogisticRegression/jni/Android.mk
+++ b/Applications/LogisticRegression/jni/Android.mk
@@ -38,7 +38,7 @@ LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_logistic
-LOCAL_LDLIBS := -llog
+LOCAL_LDLIBS := -llog -landroid
 
 LOCAL_SRC_FILES := main.cpp
 

--- a/Applications/LogisticRegression/jni/Application.mk
+++ b/Applications/LogisticRegression/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI = arm64-v8a
-APP_STL = c++_shared
-APP_PLATFORM=android-24
+APP_ABI := arm64-v8a
+APP_STL := c++_shared
+APP_PLATFORM := android-29

--- a/Applications/MNIST/jni/Android.mk
+++ b/Applications/MNIST/jni/Android.mk
@@ -39,7 +39,7 @@ LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_mnist
-LOCAL_LDLIBS := -llog
+LOCAL_LDLIBS := -llog -landroid
 
 LOCAL_SRC_FILES := main.cpp
 

--- a/Applications/MNIST/jni/Application.mk
+++ b/Applications/MNIST/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI = arm64-v8a
-APP_STL = c++_shared
-APP_PLATFORM=android-24
+APP_ABI := arm64-v8a
+APP_STL := c++_shared
+APP_PLATFORM := android-29

--- a/Applications/ReinforcementLearning/DeepQ/jni/Android.mk
+++ b/Applications/ReinforcementLearning/DeepQ/jni/Android.mk
@@ -41,7 +41,7 @@ LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_deepq
-LOCAL_LDLIBS := -llog
+LOCAL_LDLIBS := -llog -landroid
 
 LOCAL_SRC_FILES := main.cpp $(ENVDIR)/CartPole/cartpole.cpp
 

--- a/Applications/ReinforcementLearning/DeepQ/jni/Application.mk
+++ b/Applications/ReinforcementLearning/DeepQ/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI = arm64-v8a
-APP_STL = c++_shared
-APP_PLATFORM=android-24
+APP_ABI := arm64-v8a
+APP_STL := c++_shared
+APP_PLATFORM := android-29

--- a/Applications/TransferLearning/CIFAR_Classification/jni/Android.mk
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/Android.mk
@@ -79,7 +79,7 @@ LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_classification
-LOCAL_LDLIBS := -llog
+LOCAL_LDLIBS := -llog -landroid
 
 LOCAL_SRC_FILES := main.cpp
 
@@ -102,7 +102,7 @@ LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_classification_func
-LOCAL_LDLIBS := -llog
+LOCAL_LDLIBS := -llog -landroid
 
 LOCAL_SRC_FILES := main_func.cpp
 

--- a/Applications/TransferLearning/CIFAR_Classification/jni/Application.mk
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI = arm64-v8a
-APP_STL = c++_shared
-APP_PLATFORM=android-24
+APP_ABI := arm64-v8a
+APP_STL := c++_shared
+APP_PLATFORM := android-29

--- a/Applications/TransferLearning/Draw_Classification/jni/Android.mk
+++ b/Applications/TransferLearning/Draw_Classification/jni/Android.mk
@@ -59,7 +59,7 @@ LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_training
-LOCAL_LDLIBS := -llog
+LOCAL_LDLIBS := -llog -landroid
 
 LOCAL_SRC_FILES := main.cpp
 

--- a/Applications/TransferLearning/Draw_Classification/jni/Application.mk
+++ b/Applications/TransferLearning/Draw_Classification/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI = arm64-v8a
-APP_STL = c++_shared
-APP_PLATFORM=android-24
+APP_ABI := arm64-v8a
+APP_STL := c++_shared
+APP_PLATFORM := android-29

--- a/Applications/VGG/jni/Android.mk
+++ b/Applications/VGG/jni/Android.mk
@@ -46,7 +46,7 @@ LOCAL_LDFLAGS += -fexceptions
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_vgg
-LOCAL_LDLIBS := -llog
+LOCAL_LDLIBS := -llog -landroid
 
 LOCAL_SRC_FILES := main.cpp
 

--- a/Applications/VGG/jni/Application.mk
+++ b/Applications/VGG/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI = arm64-v8a
-APP_STL = c++_shared
-APP_PLATFORM=android-24
+APP_ABI := arm64-v8a
+APP_STL := c++_shared
+APP_PLATFORM := android-29

--- a/Applications/utils/jni/Android.mk
+++ b/Applications/utils/jni/Android.mk
@@ -18,7 +18,7 @@ LOCAL_CXXFLAGS      += -std=c++14 -frtti -fexceptions
 LOCAL_LDFLAGS       += -fuse-ld=bfd
 LOCAL_MODULE_TAGS   := optional
 
-LOCAL_LDLIBS        := -llog
+LOCAL_LDLIBS        := -llog -landroid
 
 LOCAL_MODULE        := app_utils
 LOCAL_SRC_FILES     := $(UTILS_SRCS)

--- a/Applications/utils/jni/Application.mk
+++ b/Applications/utils/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI = arm64-v8a
-APP_STL = c++_shared
-APP_PLATFORM=android-24
+APP_ABI := arm64-v8a
+APP_STL := c++_shared
+APP_PLATFORM := android-29

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -146,7 +146,7 @@ LOCAL_CXXFLAGS      += -std=c++14 -frtti -fexceptions
 LOCAL_LDFLAGS       += -fuse-ld=bfd
 LOCAL_MODULE_TAGS   := optional
 
-LOCAL_LDLIBS        := -llog
+LOCAL_LDLIBS        := -llog -landroid
 
 LOCAL_MODULE        := nntrainer
 LOCAL_SRC_FILES     := $(NNTRAINER_SRCS) $(INIPARSER_SRCS)
@@ -195,7 +195,7 @@ LOCAL_CXXFLAGS      += -std=c++14 -frtti -fexceptions
 LOCAL_LDFLAGS       += -fuse-ld=bfd
 LOCAL_MODULE_TAGS   := optional
 
-LOCAL_LDLIBS        := -llog
+LOCAL_LDLIBS        := -llog -landroid
 
 LOCAL_MODULE        := capi-nntrainer
 LOCAL_SRC_FILES     := $(CAPI_NNTRAINER_SRCS)
@@ -226,7 +226,7 @@ LOCAL_CXXFLAGS      += -std=c++14 -frtti -fexceptions
 LOCAL_LDFLAGS       += -fuse-ld=bfd
 LOCAL_MODULE_TAGS   := optional
 
-LOCAL_LDLIBS        := -llog
+LOCAL_LDLIBS        := -llog -landroid
 
 LOCAL_MODULE        := ccapi-nntrainer
 LOCAL_SRC_FILES     := $(CCAPI_NNTRAINER_SRCS)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,4 +1,4 @@
 APP_ABI           := arm64-v8a
 LIBCXX_USE_GABIXX := true
 APP_STL           := c++_shared
-APP_PLATFORM      := android-24
+APP_PLATFORM      := android-29

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -254,7 +254,7 @@ int NeuralNetwork::initialize() {
       }
     }
 
-    status = l.initialize(manager);
+    status = l.initialize(*manager);
     NN_RETURN_STATUS();
 
     opt->addOptimizerVariable(l.getWeightsRef());
@@ -272,7 +272,7 @@ int NeuralNetwork::initialize() {
   if (in_place_bn_layer_optimization)
     inPlaceBatchNormOptimization();
 
-  manager.initialize();
+  manager->initialize();
 
   initialized = true;
   return status;

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -95,6 +95,7 @@ public:
     loss_type(LossType::LOSS_UNKNOWN),
     weight_initializer(WeightInitializer::WEIGHT_UNKNOWN),
     net_type(NetType::UNKNOWN),
+    manager(std::make_shared<Manager>()),
     data_buffer(nullptr),
     continue_train(false),
     initialized(false),
@@ -369,7 +370,7 @@ public:
    * @note This optimization has no performance overhead.
    */
   void setGradientMemoryOptimization(bool opt) {
-    manager.setGradientMemoryOptimization(opt);
+    manager->setGradientMemoryOptimization(opt);
   }
 
   /**
@@ -483,7 +484,7 @@ private:
 
   GraphType layers; /**< vector for store layer pointers */
 
-  Manager manager; /**< nntrainer manager */
+  std::shared_ptr<Manager> manager; /**< nntrainer manager */
 
   std::shared_ptr<DataBuffer> data_buffer; /**< Data Buffer to get Input */
 
@@ -572,6 +573,7 @@ private:
     swap(lhs.layer_names, rhs.layer_names);
     swap(lhs.def_name_count, rhs.def_name_count);
     swap(lhs.loadedFromConfig, rhs.loadedFromConfig);
+    swap(lhs.manager, rhs.manager);
   }
 
   /**

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -2,27 +2,53 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	manager.cpp
- * @date	2 Dec 2020
- * @brief	This is NNtrainer manager for all weights, i/o and intermediate
+ * @file   manager.cpp
+ * @date   2 Dec 2020
+ * @brief  This is NNtrainer manager for all weights, i/o and intermediate
  * tensors
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 
+#ifdef __ANDROID__
+#include <android/sharedmem.h>
+#endif
+
+#include <cassert>
+#include <fcntl.h>
 #include <functional>
+#include <limits>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <vector>
 
 #include <manager.h>
+#include <nntrainer_log.h>
 
 namespace nntrainer {
+
+Manager::Manager(bool enable_gradient_memory_opt_, bool use_shared_memory_) :
+  total_weight_size(0),
+  total_grad_size(0),
+  max_grad_size(0),
+  enable_gradient_memory_opt(enable_gradient_memory_opt_),
+  use_shared_memory(use_shared_memory_),
+  fd(-1),
+  buf(nullptr),
+  buf_size(0) {}
+
+Manager::~Manager() { releaseSharedMemory(); }
 
 /**
  * @brief     Add weight to be tracked and updated with nntrainer
  */
 void Manager::trackWeight(std::reference_wrapper<Weight> w) {
+  /// @warning this does not track the weight size etcs.. This might break when
+  /// use_shared_memory = true
   std::vector<std::reference_wrapper<Weight>> temp = {w};
   weights.emplace_back(temp);
 }
@@ -35,37 +61,148 @@ void Manager::trackWeights(std::vector<Weight> &ws) {
   layer_weights.reserve(ws.size());
 
   size_t weight_size = 0;
+  size_t grad_size = 0;
 
   for (auto &w : ws) {
     layer_weights.emplace_back(std::ref(w));
+    size_t len = w.getDim().getDataLen();
+    weight_size += len;
     if (w.getTrainable())
-      weight_size += w.getDim().getDataLen();
+      grad_size += len;
   }
 
   weights.push_back(layer_weights);
 
-  max_weight_size = std::max(max_weight_size, weight_size);
+  total_weight_size += weight_size;
+  total_grad_size += grad_size;
+  max_grad_size = std::max(max_grad_size, grad_size);
 }
 
 /**
  * @brief Allocate and initialize the weight variable
  */
 void Manager::initialize() {
-  Tensor shared_grad;
-  if (max_weight_size > 0 && enable_gradient_memory_opt)
-    shared_grad = Tensor(max_weight_size);
+  if (total_weight_size == 0) {
+    ml_logw("Nothing done on initialize because there is no weight registered");
+    return;
+  }
+  using AllocFunc = std::function<Tensor(const TensorDim &, size_t)>;
+
+  AllocFunc allocate_none = [](const TensorDim &dim, size_t) {
+    return Tensor();
+  };
+
+  AllocFunc allocate_weight = allocate_none;
+  AllocFunc allocate_grad = allocate_none;
+
+  if (use_shared_memory) {
+    size_t grad_size =
+      enable_gradient_memory_opt ? max_grad_size : total_grad_size;
+    size_t total_size = total_weight_size + grad_size;
+
+    if (total_size >= std::numeric_limits<size_t>::max() / sizeof(float)) {
+      throw std::invalid_argument(
+        "weights exceed maximum size supported for shared memory");
+    }
+
+    size_t weight_bytes_size =
+      (total_weight_size + total_grad_size) * sizeof(float);
+    initializeSharedMemory(weight_bytes_size);
+
+    allocate_grad = allocate_weight = [&](const TensorDim &dim, size_t offset) {
+      return Tensor::Wrap(buf, dim, offset);
+    };
+
+  } else {
+    if (max_grad_size > 0 && enable_gradient_memory_opt) {
+      std::shared_ptr<float> window(new float[max_grad_size],
+                                    std::default_delete<float[]>());
+
+      allocate_grad = [window](const TensorDim &dim, size_t offset) {
+        return Tensor::Wrap(window, dim, offset);
+      };
+    }
+  }
+
+  size_t weight_offset = 0;
+  size_t grad_initial_offset = use_shared_memory ? total_weight_size : 0;
+  size_t grad_offset = grad_initial_offset;
 
   for (auto &l_w : weights) {
-    size_t offset = 0;
+    if (enable_gradient_memory_opt) {
+      grad_offset = grad_initial_offset;
+    }
+
     for (auto &w : l_w) {
       Weight &weight = w.get();
-      if (weight.getTrainable() && enable_gradient_memory_opt) {
-        weight.initialize(
-          shared_grad.getSharedDataTensor(weight.getDim(), offset));
-        offset += weight.getDim().getDataLen();
-      } else {
-        weight.initialize();
-      }
+      auto dim = weight.getDim();
+      Tensor weight_prealloc = allocate_weight(dim, weight_offset);
+      Tensor grad_prealloc =
+        weight.getTrainable() ? allocate_grad(dim, grad_offset) : Tensor();
+
+      weight_offset += dim.getDataLen();
+      grad_offset += dim.getDataLen();
+      weight.initialize(weight_prealloc, grad_prealloc);
+    }
+  }
+}
+
+void Manager::initializeSharedMemory(size_t size) {
+
+#ifdef __ANDROID__
+  /// unfortunately, memfd_create is not supported before android level 30
+  auto fd_ = ASharedMemory_create("", size);
+  if (fd_ < 0) {
+    releaseSharedMemory();
+    throw std::runtime_error("[Manager] creating mem fd failed");
+  }
+
+  if (ASharedMemory_setProt(fd_, PROT_READ | PROT_WRITE) < 0) {
+    releaseSharedMemory();
+    throw std::runtime_error("[Manager] Setting prot failed");
+  }
+
+  auto buf_ = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+#else
+  /// @todo create a file in tmpfs and bind to memfs
+  /// memfd_create is not available for number of platforms so this is commented
+  // auto fd_ = memfd_create("", 0);
+  // if (fd_ < 0) {
+  //   releaseSharedMemory();
+  //   throw std::runtime_error("[Manager] creating mem fd failed");
+  // }
+  // if (ftruncate(fd_, size) < 0) {
+  //   releaseSharedMemory();
+  //   throw std::runtime_error("[Manager] truncating fd failed");
+  // }
+
+  auto fd_ = -1;
+  auto buf_ = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, fd_, 0);
+#endif
+  if (buf_ == MAP_FAILED) {
+    releaseSharedMemory();
+    throw std::runtime_error("[Manager] mmap failed");
+  }
+
+  buf = reinterpret_cast<float *>(buf_);
+  fd = fd_;
+  buf_size = size;
+}
+
+void Manager::releaseSharedMemory() noexcept {
+  if (buf != nullptr) {
+#ifdef DEBUG
+    assert(buf_size > 0);
+#endif
+    if (munmap(buf, buf_size) < 0) {
+      ml_logw("[Manager] munmap failed on destruction please check");
+    }
+  }
+
+  if (fd != -1) {
+    if (close(fd) < 0) {
+      ml_logw("[Manager] closing fd failed on destruction please check");
     }
   }
 }

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	manager.h
- * @date	30 Nov 2020
- * @brief	This is NNtrainer manager for all weights, i/o and intermediate
+ * @file   manager.h
+ * @date   30 Nov 2020
+ * @brief  This is NNtrainer manager for all weights, i/o and intermediate
  * tensors
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug	   No known bugs except for NYI items
  *
  */
 
@@ -33,12 +33,18 @@ public:
   /**
    * @brief     Constructor of Manager
    */
-  Manager() : max_weight_size(0), enable_gradient_memory_opt(true) {}
+  Manager(bool enable_gradient_memory_opt_ = true,
+          bool use_shared_memory_ = true);
+
+  /// @todo copy ctor / assignment ops but leave move ctor / assignment
+  Manager(const Manager &) = default;
+
+  Manager &operator=(const Manager &) = default;
 
   /**
    * @brief     Destructor of Manager
    */
-  ~Manager() {}
+  ~Manager();
 
   /**
    * @brief     Add weight to be tracked and updated with nntrainer
@@ -72,6 +78,15 @@ public:
   }
 
   /**
+   * @brief Get the File descriptor.
+   * Will return -1 except for android
+   * @todo make this available for other platforms
+   *
+   * @return -1 if not applicable, else file descriptor
+   */
+  int getFd() noexcept { return fd; }
+
+  /**
    * @brief Allocate and initialize the weight variable
    */
   void initialize();
@@ -81,17 +96,42 @@ public:
    */
   void reset() {
     weights.clear();
-    max_weight_size = 0;
+    max_grad_size = 0;
+    total_weight_size = 0;
+    total_grad_size = 0;
+    releaseSharedMemory();
   }
 
 private:
+  /**
+   * @brief initialize shared memory, buf_size is set here
+   *
+   * @param size Byte size
+   */
+  void initializeSharedMemory(size_t size);
+
+  /**
+   * @brief release shared memory, if use_sha
+   *
+   */
+  void releaseSharedMemory() noexcept;
+
   // TODO: ensure that names of these weights are unique
   /**< Weights all the layer in the model to be managed */
   std::vector<std::vector<std::reference_wrapper<Weight>>> weights;
 
-  size_t max_weight_size; /**< max weight required by a layer */
+  size_t total_weight_size; /**< total weight size */
+  size_t total_grad_size;   /**< total weight size */
+  size_t max_grad_size;     /**< max trainable weight required by a layer */
 
   bool enable_gradient_memory_opt; /**< share memory among all the gradients */
+
+  /**< shared memory related */
+  bool use_shared_memory; /**< uses shared memory object which is owned by
+                             manager */
+  int fd;                 /**< fd to access the shared_memory  */
+  float *buf;             /**< buffer object when use_shared_memory */
+  size_t buf_size;        /**< buffer size */
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -36,10 +36,10 @@ public:
   Manager(bool enable_gradient_memory_opt_ = true,
           bool use_shared_memory_ = true);
 
-  /// @todo copy ctor / assignment ops but leave move ctor / assignment
-  Manager(const Manager &) = default;
+  ///@todo we can allow move ctor / assignment
+  Manager(const Manager &) = delete;
 
-  Manager &operator=(const Manager &) = default;
+  Manager &operator=(const Manager &) = delete;
 
   /**
    * @brief     Destructor of Manager

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -92,10 +92,10 @@ Tensor::Tensor(const TensorDim &d, const float *buf) : Tensor() {
   }
 }
 
-Tensor Tensor::Wrap(float *buf, const TensorDim &d, int offset) {
+Tensor Tensor::Map(float *buf, const TensorDim &d, int offset) {
   if (d.getDataLen() == 0 || buf == nullptr) {
     throw std::invalid_argument(
-      "[Tensor::Wrap] empty tensor dim is not allowed");
+      "[Tensor::Map] empty tensor dim is not allowed");
   }
 
   Tensor tmp;
@@ -107,11 +107,10 @@ Tensor Tensor::Wrap(float *buf, const TensorDim &d, int offset) {
   return tmp;
 }
 
-Tensor Tensor::Wrap(std::shared_ptr<float> buf, const TensorDim &d,
-                    int offset) {
+Tensor Tensor::Map(std::shared_ptr<float> buf, const TensorDim &d, int offset) {
   if (d.getDataLen() == 0 || buf == nullptr) {
     throw std::invalid_argument(
-      "[Tensor::Wrap] empty tensor dim is not allowed");
+      "[Tensor::Map] empty tensor dim is not allowed");
   }
 
   Tensor tmp;

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -92,6 +92,35 @@ Tensor::Tensor(const TensorDim &d, const float *buf) : Tensor() {
   }
 }
 
+Tensor Tensor::Wrap(float *buf, const TensorDim &d, int offset) {
+  if (d.getDataLen() == 0 || buf == nullptr) {
+    throw std::invalid_argument(
+      "[Tensor::Wrap] empty tensor dim is not allowed");
+  }
+
+  Tensor tmp;
+  tmp.dim = d;
+  tmp.strides = d.computeStrides();
+  /// Tensor does not own the memory
+  tmp.data = std::shared_ptr<float>(buf + offset, [](void *) {});
+
+  return tmp;
+}
+
+Tensor Tensor::Wrap(std::shared_ptr<float> buf, const TensorDim &d,
+                    int offset) {
+  if (d.getDataLen() == 0 || buf == nullptr) {
+    throw std::invalid_argument(
+      "[Tensor::Wrap] empty tensor dim is not allowed");
+  }
+
+  Tensor tmp;
+  tmp.dim = d;
+  tmp.data = std::shared_ptr<float>(buf, buf.get() + offset);
+
+  return tmp;
+}
+
 bool Tensor::operator==(const Tensor &rhs) const {
   if (this->dim != rhs.dim)
     return false;

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -68,7 +68,7 @@ public:
    * @return Tensor object
    * @throws std::invalid_argument if buf is null
    */
-  static Tensor Wrap(float *buf, const TensorDim &d, int offset = 0);
+  static Tensor Map(float *buf, const TensorDim &d, int offset = 0);
 
   /**
    * @brief Construct a new Tensor object from a buffer
@@ -80,8 +80,8 @@ public:
    * @return Tensor object
    * @throws std::invalid_argument if buf is null
    */
-  static Tensor Wrap(std::shared_ptr<float> buf, const TensorDim &d,
-                     int offset = 0);
+  static Tensor Map(std::shared_ptr<float> buf, const TensorDim &d,
+                    int offset = 0);
 
   /**
    * @brief     Constructor of Tensor

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -59,6 +59,31 @@ public:
   Tensor(const TensorDim &d, const float *buf = nullptr);
 
   /**
+   * @brief Construct a new Tensor object from a buffer
+   * This will not copy buffer to a new tensor but directly uses it
+   *
+   * @param d tensor dim
+   * @param buf buffer
+   * @param offset offset to be used from current
+   * @return Tensor object
+   * @throws std::invalid_argument if buf is null
+   */
+  static Tensor Wrap(float *buf, const TensorDim &d, int offset = 0);
+
+  /**
+   * @brief Construct a new Tensor object from a buffer
+   * This will shared the buf
+   *
+   * @param d tensor dim
+   * @param buf buffer
+   * @param offset offset to be used
+   * @return Tensor object
+   * @throws std::invalid_argument if buf is null
+   */
+  static Tensor Wrap(std::shared_ptr<float> buf, const TensorDim &d,
+                     int offset = 0);
+
+  /**
    * @brief     Constructor of Tensor
    * @param[in] batch Batch of Tensor
    * @param[in] channel Channel of Tensor

--- a/nntrainer/tensor/tensor_dim.h
+++ b/nntrainer/tensor/tensor_dim.h
@@ -33,6 +33,28 @@ public:
     feature_len = 0;
   }
 
+  /**
+   * @brief Construct a new Tensor Dim object
+   *
+   * @param dims std::initialize_list
+   *
+   * formats of {w}, {h, w}, {c, h, w}, {b, c, h, w} are accepted
+   */
+  TensorDim(std::initializer_list<unsigned int> dims) : TensorDim() {
+    int shift_size = MAXDIM - dims.size();
+
+    if (shift_size < 0) {
+      throw std::invalid_argument("[TensorDim] max dimension is 4");
+    }
+
+    unsigned int cnt = 0;
+
+    for (auto &i : dims) {
+      setTensorDim(shift_size + cnt, i);
+      cnt += 1;
+    }
+  }
+
   TensorDim(unsigned int b, unsigned int c, unsigned int h, unsigned int w) :
     TensorDim() {
     setTensorDim(0, b);

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -24,15 +24,20 @@ Var_Grad::Var_Grad(const TensorDim &dim, bool train, const std::string &name) :
   grad = std::make_shared<Tensor>();
 }
 
-void Var_Grad::initialize(const Tensor &grad_shared) {
-  var = std::make_shared<Tensor>(dim);
+void Var_Grad::initialize(const Tensor &weights_preallocated,
+                          const Tensor &grad_preallocated) {
+  if (!weights_preallocated.uninitialized()) {
+    var = std::make_shared<Tensor>(weights_preallocated);
+  } else {
+    var = std::make_shared<Tensor>(dim);
+  }
 
-  if (!grad_shared.uninitialized()) {
+  if (!grad_preallocated.uninitialized()) {
     /**
      * Making a new tensor is intentional here as this tensor is not shared
      * with other layers but the internal memory is.
      */
-    grad = std::make_shared<Tensor>(grad_shared);
+    grad = std::make_shared<Tensor>(grad_preallocated);
   } else {
     grad = std::make_shared<Tensor>();
     if (trainable) {

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -92,8 +92,12 @@ public:
 
   /**
    * @brief Allocate and initialize the weight variable
+   *
+   * @param weight_preallocated if initialized, use this tensor for weight
+   * @param grad_preallocated if initialized, use this tensor for grad
    */
-  virtual void initialize(const Tensor &grad_shared = Tensor());
+  virtual void initialize(const Tensor &weight_preallocated = Tensor(),
+                          const Tensor &grad_preallocated = Tensor());
 
   /**
    * @brief Get the TensorDim

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -24,8 +24,9 @@ Weight::Weight(const TensorDim &dim, const WeightInitializer init, bool train,
     throw std::invalid_argument("Weight initializer unknown");
 }
 
-void Weight::initialize(const Tensor &grad_shared) {
-  Var_Grad::initialize(grad_shared);
+void Weight::initialize(const Tensor &weights_preallocated,
+                        const Tensor &grad_preallocated) {
+  Var_Grad::initialize(weights_preallocated, grad_preallocated);
 
   Tensor &var_ref = getVariableRef();
   const TensorDim dim = var_ref.getDim();

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -79,9 +79,10 @@ public:
     bool train = true, std::string name = "");
 
   /**
-   * @brief Allocate and initialize the weight variable
+   * @copydoc var_grad::initialize(const Tensor &, const Tensor &)
    */
-  void initialize(const Tensor &grad_shared = Tensor());
+  void initialize(const Tensor &weight_preallocated = Tensor(),
+                  const Tensor &grad_preallocated = Tensor());
 
   /**
    * @brief Swap for weight

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -16,6 +16,29 @@
 #include <tensor.h>
 #include <tensor_dim.h>
 
+TEST(nntrainer_TensorDim, ctor_initializer_p) {
+  unsigned int b = 3;
+  unsigned int c = 2;
+  unsigned int h = 4;
+  unsigned int w = 5;
+
+  nntrainer::TensorDim t = {w};
+  EXPECT_EQ(nntrainer::TensorDim(1, 1, 1, w), t);
+
+  t = {h, w};
+  EXPECT_EQ(nntrainer::TensorDim(1, 1, h, w), t);
+
+  t = {c, h, w};
+  EXPECT_EQ(nntrainer::TensorDim(1, c, h, w), t);
+
+  t = {b, c, h, w};
+  EXPECT_EQ(nntrainer::TensorDim(b, c, h, w), t);
+}
+
+TEST(nntrainer_TensorDim, ctor_initializer_n) {
+  EXPECT_THROW(nntrainer::TensorDim t({1, 2, 3, 4, 5}), std::invalid_argument);
+}
+
 TEST(nntrainer_TensorDim, setTensorDim_01_p) {
   int status = ML_ERROR_NONE;
 

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -82,7 +82,7 @@ TEST(nntrainer_Tensor, TensorWrap_p) {
   float dat[] = {1, 2, 3};
 
   {
-    nntrainer::Tensor a = nntrainer::Tensor::Wrap(dat, {3});
+    nntrainer::Tensor a = nntrainer::Tensor::Map(dat, {3});
     /// check if a.getData() has same address with dat
     EXPECT_EQ(dat, a.getData());
     {
@@ -97,7 +97,7 @@ TEST(nntrainer_Tensor, TensorWrap_p) {
 
 TEST(nntrainer_Tensor, TensorWrap_n) {
   float dat[] = {1, 2, 3};
-  EXPECT_THROW(nntrainer::Tensor::Wrap(dat, {}), std::invalid_argument);
+  EXPECT_THROW(nntrainer::Tensor::Map(dat, {}), std::invalid_argument);
 }
 
 TEST(nntrainer_Tensor, Tensor_01_p) {

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -78,6 +78,28 @@ TEST(nntrainer_TensorDim, setTensorDim_04_p) {
   EXPECT_EQ(d.width(), 7);
 }
 
+TEST(nntrainer_Tensor, TensorWrap_p) {
+  float dat[] = {1, 2, 3};
+
+  {
+    nntrainer::Tensor a = nntrainer::Tensor::Wrap(dat, {3});
+    /// check if a.getData() has same address with dat
+    EXPECT_EQ(dat, a.getData());
+    {
+      /// check if b.getData() has same address with data
+      nntrainer::Tensor b = a;
+      EXPECT_EQ(dat, b.getData());
+    }
+  }
+  /// check if dat is accessible after destruction of all the tensor
+  EXPECT_FLOAT_EQ(dat[2], 3);
+}
+
+TEST(nntrainer_Tensor, TensorWrap_n) {
+  float dat[] = {1, 2, 3};
+  EXPECT_THROW(nntrainer::Tensor::Wrap(dat, {}), std::invalid_argument);
+}
+
 TEST(nntrainer_Tensor, Tensor_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::Tensor tensor = nntrainer::Tensor(1, 2, 3);


### PR DESCRIPTION
- ~[Graph] Move assignMem to graph~ Removed by request
```
neuralNetworks::assignMem is graph actually graph related.
This patch moves assignMem to graph.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
- [TensorDim] Add initializer list ctor
```
This patch adds a tensordim
initializer list ctor to easily pass as a functional argument

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
- [Tensor] Add Tensor Wrap method
```
Add Tensor some factory methods
1. burrows external memory and use from
2. create from shared pointer without copy

To restrict unwanted use, those methods are static methods
called `Tensor::Wrap`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
- [Manager] Add memory allocator
```
This patch adds memory allocator(mmap and corresponding shared memory
object) to manager.h

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

[Manager] Add shared memory allocation strategy

Currently, memory allocation is done in tensor but memories are
scattered away and not allocated in the shared memory region while some
hardware accel requires us to pass a shared memory object.

This patch add a strategy that manager owns a memory chunk and lend
memory to a tensor. In this manner, tensor does not own the memory so it
shouldn't be deallocated when Tensor destructs. This will enable to pass
a memory block to hardware accel (eg.NNAPI)

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

- Verified that this patch has no or little impact on PC / Android
with single FC inference pass

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
- [Android] Manage ndk to deal with changes
```
1. Upgrade ndk version to 29
2. Add dependent library
3. Fix syntax for Application.mk

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```

- [Manager/Fix] Disallow copy ctor of manager
```
Since manager is holding a memory, it shouldn't be copied as ownership
becoms not clear. This patch delets copy ctor / assignment ops. While
chainging signature for members and functions that uses manager

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
**Added Commit**
- [Manager] Add MMaped memory
```   
    There was a requirement to separate weight memory region and grad memory
    region.
    To easily separate those two, this patch introduces new abstraction:
    `MMapedMemory` while separating weight and grad mmap
    
    Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```