### PR TITLE
[layer] Support in-place batch normalization

### DIFF
--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -219,9 +219,6 @@ void Conv2DLayer::calcDerivative(sharedConstTensors derivatives) {
    */
   using uint = unsigned int;
 
-  if (net_input[0]->var.uninitialized())
-    net_input[0]->var = Tensor(input.getDim());
-
   TensorDim kdim(in_dim.channel(), filter_size, kernel_size[0], kernel_size[1]);
 
   uint kernel_total_size = kernel_size[0] * kernel_size[1];


### PR DESCRIPTION
Support in-place batch normalization where the batch normalization
input/output is not stored and is over-written by the next layer.

This patch removes the input/output memory requirement when using
batch normalization layer.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>