### PR TITLE
[Docs] Remove unnecessary HTML link for feature/privilege.

### DIFF
--- a/api/capi/doc/nntrainer_doc.h
+++ b/api/capi/doc/nntrainer_doc.h
@@ -39,8 +39,8 @@
  *
  * @section CAPI_ML_NNTRAINER_TRAIN_FEATURE Related Features
  * This function is related with the following features:\n
- *  - http://tizen.org/feature/machine_learning\n
- *  - http://tizen.org/feature/machine_learning.training\n
+ *  - %http://tizen.org/feature/machine_learning\n
+ *  - %http://tizen.org/feature/machine_learning.training\n
  *
  * It is recommended to probe features in your application for reliability.\n
  * You can check if a device supports the related features for this function by


### PR DESCRIPTION
This patch removes the unnecessary HTML link for feature/privilege. It
is just cherry-picking of the below PR.
* https://github.com/nnstreamer/nntrainer/pull/809

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed []Skipped
2. Run test: []Passed [ ]Failed [X]Skipped

#### Related Issue
* https://code.sec.samsung.net/confluence/pages/viewpage.action?pageId=197150692