### PR TITLE
[Profiler] Add event registerator

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -23,6 +23,7 @@
 #include <nntrainer_log.h>
 #include <output_layer.h>
 #include <parse_util.h>
+#include <profiler.h>
 
 namespace nntrainer {
 
@@ -511,9 +512,13 @@ sharedConstTensors NetworkGraph::forwarding(sharedConstTensors input) {
     LayerNode &layer_node = Sorted[i];
     // TODO : Need to fix. Input Layer is not the only one which can take input.
     if (istrequal(layer_node.layer->getType(), InputLayer::type)) {
+      START_PROFILE(layer_node.event_key);
       layer_node.layer->forwarding(input);
+      END_PROFILE(layer_node.event_key);
     } else {
+      START_PROFILE(layer_node.event_key);
       layer_node.layer->forwarding();
+      END_PROFILE(layer_node.event_key);
     }
   }
 

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -32,6 +32,9 @@ namespace nntrainer {
 struct LayerNode {
   std::shared_ptr<Layer> layer;
   unsigned int index;
+#ifdef PROFILE
+  int event_key;
+#endif
 };
 
 /**
@@ -248,7 +251,6 @@ private:
   unsigned int
     skip_non_trainable_layers; /**< denotes the number of non-trainable layers
                                   at the start of the graph */
-
   /**
    * @brief Calculate the number of non-trainable layers at the start
    */

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -216,7 +216,8 @@ int NeuralNetwork::initialize() {
 
   for (unsigned int idx = 0; idx < n_layers; ++idx) {
     bool first = idx == 0;
-    Layer &l = *model_graph.getSortedLayerNode(idx).layer;
+    auto &lnode = model_graph.getSortedLayerNode(idx);
+    Layer &l = *lnode.layer;
     ml_logd("layer name : %s", l.getName().c_str());
     const std::string &cur_type = l.getType();
 
@@ -257,6 +258,7 @@ int NeuralNetwork::initialize() {
     status = l.initialize(manager);
     NN_RETURN_STATUS();
 
+    REGISTER_EVENT(l.getName(), lnode.event_key)
     opt->addOptimizerVariable(l.getWeightsRef());
   }
 

--- a/nntrainer/utils/profiler.cpp
+++ b/nntrainer/utils/profiler.cpp
@@ -244,7 +244,7 @@ std::string Profiler::eventToStr(const int event) {
   /// custom events
   else if (event < 0) {
     std::lock_guard<std::mutex> lk(event_registration_mutex);
-    int actual_idx = -event + 1;
+    int actual_idx = -event - 1;
 
     if (actual_idx > static_cast<int>(custom_events.size()) - 1) {
       std::stringstream ss;
@@ -260,8 +260,12 @@ std::string Profiler::eventToStr(const int event) {
 int Profiler::registerEvent(const std::string &name) {
   std::lock_guard<std::mutex> lk(event_registration_mutex);
   custom_events.push_back(name);
+  int key = -custom_events.size();
 
-  return -custom_events.size();
+  ml_logd("[Profiler] Event registered, event name: %s event key: %d",
+          name.c_str(), key);
+
+  return key;
 }
 
 } // namespace profile

--- a/test/unittest/unittest_nntrainer_profiler.cpp
+++ b/test/unittest/unittest_nntrainer_profiler.cpp
@@ -35,7 +35,7 @@ public:
 
   void reset(const int event) override { hit = false; }
 
-  void report(std::ostream &out) const override {
+  virtual void report(std::ostream &out) const override {
     out << (hit ? "hit" : "no hit");
   }
 
@@ -97,14 +97,21 @@ TEST(Profiler, profilePositiveTests_p) {
   /// measure that are not registered for event listener
   all_listener->reset(EVENT::NN_FORWARD);
   event_listener->reset(EVENT::NN_FORWARD);
-  prof.start(EVENT::TEMP);
-  prof.end(EVENT::TEMP);
+  prof.start(-1);
+  prof.end(-1);
 
   /// Check if notified on event profiler does not hit
   {
     std::stringstream ss;
     event_listener->report(ss);
     EXPECT_EQ(ss.str(), "no hit");
+  }
+
+  /// register a event key to profiler and check event to str
+  {
+    int key = prof.registerEvent("hello_world");
+    EXPECT_LT(key, 0);
+    EXPECT_EQ(prof.eventToStr(key), "hello_world");
   }
 
   /// unsubscribe event_listener


### PR DESCRIPTION
- [Profiler] Add event registerator
```
Profiler can now dynamically register event and send it to
profileListenr as of this patch with fixing few bugs

resolves #814

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
- [Profiler] Apply ops level profiler
```
This patch attaches ops level profiler

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
Resolves #814 