### PR TITLE
[Profiler] Change profiler specs

### DIFF
--- a/nntrainer/utils/profiler.h
+++ b/nntrainer/utils/profiler.h
@@ -84,7 +84,7 @@ public:
    * @param value time value from the profiler
    */
   virtual void onNotify(const int event,
-                        const std::chrono::milliseconds &value) = 0;
+                        const std::chrono::microseconds &value) = 0;
 
   /**
    * @brief resets the listener to the inital state for a particular key
@@ -97,9 +97,9 @@ public:
    * @brief get the latest result of a event
    *
    * @param event event to query the result
-   * @return const std::chrono::milliseconds
+   * @return const std::chrono::microseconds
    */
-  virtual const std::chrono::milliseconds result(const int event) = 0;
+  virtual const std::chrono::microseconds result(const int event) = 0;
 
   /**
    * @brief report the result
@@ -137,10 +137,10 @@ public:
 
   /**
    * @copydoc ProfileListener::onNotify(const int event, const
-   * std::chrono::milliseconds &value)
+   * std::chrono::microseconds &value)
    */
   virtual void onNotify(const int event,
-                        const std::chrono::milliseconds &value) override;
+                        const std::chrono::microseconds &value) override;
 
   /**
    * @copydoc ProfileListener::reset(const int event)
@@ -150,7 +150,7 @@ public:
   /**
    * @copydoc ProfileListener::result(const int event)
    */
-  virtual const std::chrono::milliseconds result(const int event) override;
+  virtual const std::chrono::microseconds result(const int event) override;
 
   /**
    * @copydoc ProfileListener::report(std::ostream &out)
@@ -166,10 +166,10 @@ private:
   static constexpr int SUM = 3;
   static constexpr int CNT = 4;
 
-  std::unordered_map<int, std::tuple<std::chrono::milliseconds, /** CUR */
-                                     std::chrono::milliseconds, /** MIN */
-                                     std::chrono::milliseconds, /** MAX */
-                                     std::chrono::milliseconds, /** SUM */
+  std::unordered_map<int, std::tuple<std::chrono::microseconds, /** CUR */
+                                     std::chrono::microseconds, /** MIN */
+                                     std::chrono::microseconds, /** MAX */
+                                     std::chrono::microseconds, /** SUM */
                                      unsigned int /** CNT */>>
     time_taken;
 
@@ -260,7 +260,7 @@ private:
    * @param event event to notify
    * @param value measured value from the profiler
    */
-  void notify(const int &event, const std::chrono::milliseconds &value);
+  void notify(const int &event, const std::chrono::microseconds &value);
 
   std::unordered_set<ProfileListener *>
     all_registered_listeners; /**< prevent registering listener twice */

--- a/test/unittest/unittest_nntrainer_profiler.cpp
+++ b/test/unittest/unittest_nntrainer_profiler.cpp
@@ -29,7 +29,7 @@ public:
   ~MockProfileListener(){};
 
   void onNotify(const int event,
-                const std::chrono::milliseconds &value) override {
+                const std::chrono::microseconds &value) override {
     hit = true;
   }
 
@@ -39,8 +39,8 @@ public:
     out << (hit ? "hit" : "no hit");
   }
 
-  const std::chrono::milliseconds result(const int event) override {
-    return std::chrono::milliseconds();
+  const std::chrono::microseconds result(const int event) override {
+    return std::chrono::microseconds();
   };
 
 private:
@@ -52,12 +52,12 @@ TEST(GenericProfileListener, listenerBasicScenario_p) {
   GenericProfileListener listener{nullptr};
 
   /// assuming library-side code is calling onNotify
-  listener.onNotify(EVENT::NN_FORWARD, std::chrono::milliseconds{10});
-  listener.onNotify(EVENT::NN_FORWARD, std::chrono::milliseconds{100});
-  listener.onNotify(EVENT::NN_FORWARD, std::chrono::milliseconds{50});
+  listener.onNotify(EVENT::NN_FORWARD, std::chrono::microseconds{10});
+  listener.onNotify(EVENT::NN_FORWARD, std::chrono::microseconds{100});
+  listener.onNotify(EVENT::NN_FORWARD, std::chrono::microseconds{50});
 
   auto result = listener.result(EVENT::NN_FORWARD);
-  EXPECT_EQ(result, std::chrono::milliseconds{50});
+  EXPECT_EQ(result, std::chrono::microseconds{50});
 
   std::cout << listener;
 }


### PR DESCRIPTION
- ~**#815** [Profiler] Add event registerator~
- ~**#815** [Profiler] Apply ops level profiler~
- [Profiler] Change profiler specs
```
- Profiler time unit is changed: milli -> microsecond
- Now report is ordered by key

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```