### PR TITLE
[ ARGMAX ] Fix bug about argmax

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -904,7 +904,7 @@ std::vector<unsigned int> Tensor::argmax() const {
   for (unsigned int b = 0; b < batch_size; b++) {
     auto max_iter =
       std::max_element(data + b * feature_len, data + (b + 1) * feature_len);
-    result[b] = std::distance(data, max_iter);
+    result[b] = std::distance(data, max_iter) - (b * feature_len);
   }
 
   return result;


### PR DESCRIPTION
Need to fix to calcuate argmax in tensor

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>