### PR TITLE
[Conv] Improve im2col performance @open sesame 12/29 15:57

### DIFF
--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -17,6 +17,7 @@
 
 #include <layer_internal.h>
 #include <manager.h>
+#include <memory.h>
 #include <tensor.h>
 
 namespace nntrainer {
@@ -153,28 +154,36 @@ private:
    * @param[in] in input tensor
    * @param[in] outdim output tensor dimension
    * @param[out] out output data
-   * @param[in] channel_mode loop with channel first
+   * @param[in] channel_mode loop with channel first,
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int conv2d_gemm(const float *mkernel, TensorDim kdim, float *in,
+  int conv2d_gemm(const float *mkernel, TensorDim kdim, const float *in,
                   TensorDim outdim, float *out, bool channel_mode,
                   float beta_dgemm = 0.0f);
 
   /**
    * @brief     reform the data to 2d matrix
-   * @param[in] in_padded padded input data
+   * a region is sampled considering @a padding, @a mstride of unit @a kdim
+   * Each region is mapped to one column,
+   * if channel mode, kernel channel is considered part of kernel feature
+   * if not, kernel channel is consider part of output dimension
+   *
+   * @param[in] in input data
    * @param[in] kdim kernel dimesion for define number of row
-   * @param[out] inCol reformed data
-   * @param[in] outdim output dimension
+   * @param[in] padding padding information
    * @param[in] mstride stride value : x, y direction
    * @param[in] channel_mode loop with channel first
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @return Tensor im2col tensor
    */
-  int im2col(Tensor in_padded, TensorDim kdim, float *inCol, TensorDim outdim,
-             const std::array<unsigned int, CONV2D_DIM> &mstride,
-             bool channel_mode);
+  Tensor im2col(const Tensor &in, const TensorDim &kdim,
+                const std::array<unsigned int, CONV2D_DIM> &padding,
+                const std::array<unsigned int, CONV2D_DIM> &mstride,
+                bool channel_mode);
+
+  int im2col_(Tensor in_padded, TensorDim kdim, float *in_col, TensorDim outdim,
+              const std::array<unsigned int, CONV2D_DIM> &mstride,
+              bool channel_mode);
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -141,20 +141,6 @@ bool Tensor::operator==(const Tensor &rhs) const {
   return true;
 }
 
-float Tensor::getValue(unsigned int batch, unsigned int c, unsigned int h,
-                       unsigned int w) const {
-  return getData()[getIndex(batch, c, h, w)];
-}
-
-void Tensor::setValue(unsigned int batch, unsigned int c, unsigned int h,
-                      unsigned int w, float value) {
-  if (!is_contiguous) {
-    throw std::runtime_error("cannot set value of non-contiguous tensor");
-  }
-
-  getData()[getIndex(batch, c, h, w)] = value;
-}
-
 template <typename T> void Tensor::setDist(T dist) {
   float *data = getData();
   unsigned int len = length();
@@ -920,7 +906,7 @@ void Tensor::setValue(float val) {
   std::fill(data, data + length(), val);
 }
 
-void Tensor::setZero() { setValue(0); }
+void Tensor::setZero() { sscal(length(), 0, getData(), 1); }
 
 std::vector<unsigned int> Tensor::argmax() const {
   const float *data = getData();

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -216,9 +216,9 @@ public:
    * @param pw padding width
    * @return float value
    */
-  float getValuePadded(unsigned int b, unsigned int c, unsigned int h,
-                       unsigned int w, unsigned int ph, unsigned int pw,
-                       float pad_value = 0) const EXCEPT_WHEN_DEBUG {
+  float getValuePaddedVirtual(unsigned int b, unsigned int c, unsigned int h,
+                              unsigned int w, unsigned int ph, unsigned int pw,
+                              float pad_value = 0) const EXCEPT_WHEN_DEBUG {
 #if DEBUG
     unsigned int padded_h = 2 * ph + h;
     unsigned int padded_w = 2 * pw + w;

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -100,6 +100,22 @@ TEST(nntrainer_Tensor, TensorWrap_n) {
   EXPECT_THROW(nntrainer::Tensor::Map(dat, {}), std::invalid_argument);
 }
 
+TEST(nntrainer_Tensor, TensorPaddedValue_p) {
+  nntrainer::Tensor a = ranged(1, 1, 3, 3);
+  float default_padded = -1;
+
+  for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < 5; ++j) {
+      float expected = default_padded;
+      if (1 <= i && i <= 3 && 1 <= j && j <= 3) {
+        expected = (i - 1) * 3 + (j - 1);
+      }
+      float actual = a.getValuePadded(0, 0, i, j, 1, 1, default_padded);
+      EXPECT_FLOAT_EQ(actual, expected);
+    }
+  }
+}
+
 TEST(nntrainer_Tensor, Tensor_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::Tensor tensor = nntrainer::Tensor(1, 2, 3);

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -110,7 +110,7 @@ TEST(nntrainer_Tensor, TensorPaddedValue_p) {
       if (1 <= i && i <= 3 && 1 <= j && j <= 3) {
         expected = (i - 1) * 3 + (j - 1);
       }
-      float actual = a.getValuePadded(0, 0, i, j, 1, 1, default_padded);
+      float actual = a.getValuePaddedVirtual(0, 0, i, j, 1, 1, default_padded);
       EXPECT_FLOAT_EQ(actual, expected);
     }
   }


### PR DESCRIPTION
- ~**#818** [Profiler] Change profiler specs~
- ~**#834** [Fix] Assign default value for max_deriv size~
- [Tensor] Optimize accessor
```
This patch...
- inlines some accessor with noexcept specifier to boost up
- Add getValuePadded to reduce memory copy to make a padded tensor

see also #825

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Cc: Parichay Kapoor <pk.kappor@samsung.com>
Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```

- [Conv] Optimize im2col
```
This patch optimize im2col by...

- Add padding as a argument instead of passing pad value
- Skip creating padded tensor and assignment for padded index
- Refactor variable names for clarity

See also #824

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
