### PR TITLE
[Fix] Assign default value for max_deriv size @open sesame 12/29 15:57

### DIFF
--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -120,13 +120,16 @@ MMapedMemory::~MMapedMemory() {
   ml_logd("[MMapedMemory] buf released");
 }
 
-Manager::Manager(bool enable_gradient_memory_opt_, bool use_shared_memory_) :
+Manager::Manager(bool enable_gradient_memory_opt_,
+                 bool enable_derivative_memory_opt_,
+                 bool enable_activation_memory_opt_, bool use_shared_memory_) :
   total_weight_size(0),
   total_grad_size(0),
   max_grad_size(0),
+  max_derivative_size(0),
   enable_gradient_memory_opt(enable_gradient_memory_opt_),
-  enable_derivative_memory_opt(true),
-  enable_activation_memory_opt(true),
+  enable_derivative_memory_opt(enable_derivative_memory_opt_),
+  enable_activation_memory_opt(enable_activation_memory_opt_),
   use_shared_memory(use_shared_memory_) {}
 
 Manager::~Manager() {}

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -87,6 +87,8 @@ public:
    * @brief     Constructor of Manager
    */
   Manager(bool enable_gradient_memory_opt_ = true,
+          bool enable_derivative_memory_opt_ = true,
+          bool enable_activation_memory_opt_ = true,
           bool use_shared_memory_ = true);
 
   Manager(const Manager &) = default;


### PR DESCRIPTION
This patch initialize max_dervative_size to avoid unexpected termination

resolves #834

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
