### PR TITLE
[model] Optimize model input/output @open sesame 12/29 15:57

### DIFF
--- a/Applications/Custom/LayerClient/jni/pow.cpp
+++ b/Applications/Custom/LayerClient/jni/pow.cpp
@@ -100,7 +100,7 @@ int PowLayer::initialize(nntrainer::Manager &manager) {
   return 0;
 }
 
-void PowLayer::forwarding(nntrainer::sharedConstTensors in) {
+void PowLayer::forwarding() {
 #ifdef DEBUG
   /// intended here to demonstrate that PowLayer::forwarding is being called
   std::cout << "pow layer forward is called\n";
@@ -117,7 +117,7 @@ void PowLayer::forwarding(nntrainer::sharedConstTensors in) {
 #endif
 }
 
-void PowLayer::calcDerivative(nntrainer::sharedConstTensors in) {
+void PowLayer::calcDerivative() {
 /// intended here to demonstrate that PowLayer::backwarding is being called
 #ifdef DEBUG
   std::cout << "pow layer backward is called\n";

--- a/Applications/Custom/LayerClient/jni/pow.h
+++ b/Applications/Custom/LayerClient/jni/pow.h
@@ -59,17 +59,13 @@ public:
 
   /**
    * @brief nntrainer forwarding function
-   *
-   * @param in input tensors
    */
-  void forwarding(nntrainer::sharedConstTensors in = {});
+  void forwarding();
 
   /**
    * @brief     calc the derivative to be passed to the previous layer
-   * @param[in] in List of Derivative Tensor from the next layer
-   * @retval    Derivative List of Tensor for the previous layer
    */
-  void calcDerivative(nntrainer::sharedConstTensors in = {});
+  void calcDerivative();
 
   /**
    * @brief Get the Type object

--- a/Applications/VGG/jni/main.cpp
+++ b/Applications/VGG/jni/main.cpp
@@ -286,8 +286,8 @@ int getBatch_train_file(float **outVec, float **outLabel, bool *last,
   unsigned int count = 0;
   int data_size = num_train;
 
-  std::string filename = "vgg_trainingSet.dat";
-  std::ifstream F(filename, std::ios::in | std::ios::binary);
+  // std::string filename = "vgg_trainingSet.dat";
+  // std::ifstream F(filename, std::ios::in | std::ios::binary);
 
   if (data_size * num_class - train_count < batch_size) {
     *last = true;
@@ -300,10 +300,10 @@ int getBatch_train_file(float **outVec, float **outLabel, bool *last,
     std::vector<float> o;
     std::vector<float> l;
 
-    o.resize(feature_size);
-    l.resize(num_class);
+    o.resize(feature_size, 0);
+    l.resize(num_class, 0);
 
-    getData(F, o, l, i);
+    // getData(F, o, l, i);
 
     for (unsigned int j = 0; j < feature_size; ++j)
       outVec[0][count * feature_size + j] = o[j];
@@ -312,7 +312,7 @@ int getBatch_train_file(float **outVec, float **outLabel, bool *last,
     count++;
   }
 
-  F.close();
+  // F.close();
   *last = false;
   train_count += batch_size;
   return ML_ERROR_NONE;
@@ -334,8 +334,8 @@ int getBatch_val_file(float **outVec, float **outLabel, bool *last,
   unsigned int count = 0;
   int data_size = num_val;
 
-  std::string filename = "vgg_valSet.dat";
-  std::ifstream F(filename, std::ios::in | std::ios::binary);
+  // std::string filename = "vgg_valSet.dat";
+  // std::ifstream F(filename, std::ios::in | std::ios::binary);
 
   if (data_size * num_class - val_count < batch_size) {
     *last = true;
@@ -351,7 +351,7 @@ int getBatch_val_file(float **outVec, float **outLabel, bool *last,
     o.resize(feature_size);
     l.resize(num_class);
 
-    getData(F, o, l, i);
+    // getData(F, o, l, i);
 
     for (unsigned int j = 0; j < feature_size; ++j)
       outVec[0][count * feature_size + j] = o[j];
@@ -360,7 +360,7 @@ int getBatch_val_file(float **outVec, float **outLabel, bool *last,
     count++;
   }
 
-  F.close();
+  // F.close();
   *last = false;
   val_count += batch_size;
   return ML_ERROR_NONE;

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -190,7 +190,7 @@ public:
    * @param[in] input data
    * @retval output tensors
    */
-  sharedConstTensors forwarding(sharedConstTensors input);
+  sharedConstTensors forwarding();
 
   /**
    * @brief     getter of ordered graph

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -46,13 +46,13 @@ int ActivationLayer::initialize(Manager &manager) {
   return ML_ERROR_NONE;
 }
 
-void ActivationLayer::forwarding(sharedConstTensors in) {
+void ActivationLayer::forwarding() {
   Tensor &hidden_ = net_hidden[0]->getVariableRef();
   /// @note @a _act_fn is expected to work out of place and not modify @a input
   _act_fn(net_input[0]->getVariableRef(), hidden_);
 }
 
-void ActivationLayer::calcDerivative(sharedConstTensors derivative) {
+void ActivationLayer::calcDerivative() {
   Tensor &deriv = net_hidden[0]->getGradientRef();
   Tensor &ret = net_input[0]->getGradientRef();
   Tensor &in = net_hidden[0]->getVariableRef();

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -62,14 +62,14 @@ public:
   void save(std::ofstream &file){/* noop */};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in);
+  void forwarding();
 
   /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
+   * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
    * @brief setActivation by preset ActivationType

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -41,7 +41,7 @@ int AdditionLayer::initialize(Manager &manager) {
   return status;
 }
 
-void AdditionLayer::forwarding(sharedConstTensors in) {
+void AdditionLayer::forwarding() {
   Tensor &hidden_ = net_hidden[0]->getVariableRef();
   TensorDim &in_dim = input_dim[0];
 
@@ -53,7 +53,7 @@ void AdditionLayer::forwarding(sharedConstTensors in) {
   }
 }
 
-void AdditionLayer::calcDerivative(sharedConstTensors derivative) {
+void AdditionLayer::calcDerivative() {
 
   for (unsigned int i = 0; i < num_inputs; ++i) {
     net_input[i]->getGradientRef() = net_hidden[0]->getGradientRef();

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -72,14 +72,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in);
+  void forwarding();
 
   /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
+   * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -125,7 +125,7 @@ void BatchNormalizationLayer::setProperty(const PropertyType type,
   }
 }
 
-void BatchNormalizationLayer::forwarding(sharedConstTensors in) {
+void BatchNormalizationLayer::forwarding() {
   Tensor &mu = weightAt(BNParams::mu).getVariableRef();
   Tensor &var = weightAt(BNParams::var).getVariableRef();
   Tensor &gamma = weightAt(BNParams::gamma).getVariableRef();
@@ -159,7 +159,7 @@ void BatchNormalizationLayer::forwarding(sharedConstTensors in) {
   hidden_.add_i(beta);
 }
 
-void BatchNormalizationLayer::calcDerivative(sharedConstTensors derivative) {
+void BatchNormalizationLayer::calcDerivative() {
 
   Tensor &gamma = weightAt(BNParams::gamma).getVariableRef();
   Tensor &deriv = net_hidden[0]->getGradientRef();
@@ -180,7 +180,7 @@ void BatchNormalizationLayer::calcDerivative(sharedConstTensors derivative) {
   dx.divide_i(N);
 }
 
-void BatchNormalizationLayer::calcGradient(sharedConstTensors derivative) {
+void BatchNormalizationLayer::calcGradient() {
 
   Tensor &dgamma = weightAt(BNParams::gamma).getGradientRef();
   Tensor &dbeta = weightAt(BNParams::beta).getGradientRef();

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -76,19 +76,19 @@ public:
   BatchNormalizationLayer &operator=(BatchNormalizationLayer &&rhs) = default;
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in);
+  void forwarding();
 
   /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
+   * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
-   * @copydoc Layer::calcGradient(sharedConstTensors in)
+   * @copydoc Layer::calcGradient()
    */
-  void calcGradient(sharedConstTensors in);
+  void calcGradient();
 
   /**
    * @brief     copy layer

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -51,7 +51,7 @@ int ConcatLayer::initialize(Manager &manager) {
   return status;
 }
 
-void ConcatLayer::forwarding(sharedConstTensors in) {
+void ConcatLayer::forwarding() {
   Tensor &hidden_ = net_hidden[0]->getVariableRef();
 
 #ifdef DEBUG
@@ -89,7 +89,7 @@ void ConcatLayer::forwarding(sharedConstTensors in) {
   }
 }
 
-void ConcatLayer::calcDerivative(sharedConstTensors derivative) {
+void ConcatLayer::calcDerivative() {
   TensorDim d = net_hidden[0]->getDim();
 
   unsigned int position = 0;

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -72,14 +72,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in);
+  void forwarding();
 
   /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
+   * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -71,7 +71,7 @@ int Conv2DLayer::initialize(Manager &manager) {
   return status;
 }
 
-void Conv2DLayer::forwarding(sharedConstTensors in) {
+void Conv2DLayer::forwarding() {
   int status = ML_ERROR_NONE;
 
   if (num_inputs != 1)
@@ -159,7 +159,7 @@ void Conv2DLayer::forwarding(sharedConstTensors in) {
   }
 }
 
-void Conv2DLayer::calcDerivative(sharedConstTensors derivatives) {
+void Conv2DLayer::calcDerivative() {
 
   int status = ML_ERROR_NONE;
   TensorDim &in_dim = input_dim[0];
@@ -268,7 +268,7 @@ void Conv2DLayer::calcDerivative(sharedConstTensors derivatives) {
   }
 }
 
-void Conv2DLayer::calcGradient(sharedConstTensors derivatives) {
+void Conv2DLayer::calcGradient() {
   TensorDim &in_dim = input_dim[0];
 
   Tensor &filter_kernel = weightAt(ConvParams::weight).getVariableRef();

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -72,19 +72,19 @@ public:
   int initialize(Manager &manager);
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in);
+  void forwarding();
 
   /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
+   * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
-   * @copydoc Layer::calcGradient(sharedConstTensors in)
+   * @copydoc Layer::calcGradient()
    */
-  void calcGradient(sharedConstTensors in);
+  void calcGradient();
 
   /**
    * @brief     copy layer

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -82,7 +82,7 @@ void FullyConnectedLayer::setProperty(const PropertyType type,
   }
 }
 
-void FullyConnectedLayer::forwarding(sharedConstTensors in) {
+void FullyConnectedLayer::forwarding() {
   Tensor &weight =
     weightAt(static_cast<int>(FCParams::weight)).getVariableRef();
   Tensor &bias = weightAt(static_cast<int>(FCParams::bias)).getVariableRef();
@@ -105,7 +105,7 @@ void FullyConnectedLayer::copy(std::shared_ptr<Layer> l) {
   this->unit = from->unit;
 }
 
-void FullyConnectedLayer::calcDerivative(sharedConstTensors derivative) {
+void FullyConnectedLayer::calcDerivative() {
   unsigned int weight_idx = static_cast<int>(FCParams::weight);
   Tensor &weight = weightAt(weight_idx).getVariableRef();
   Tensor &derivative_ = net_hidden[0]->getGradientRef();
@@ -114,7 +114,7 @@ void FullyConnectedLayer::calcDerivative(sharedConstTensors derivative) {
   ret_ = derivative_.dot(weight, ret_, false, true);
 }
 
-void FullyConnectedLayer::calcGradient(sharedConstTensors derivative) {
+void FullyConnectedLayer::calcGradient() {
   unsigned int weight_idx = static_cast<int>(FCParams::weight);
   unsigned int bias_idx = static_cast<int>(FCParams::bias);
   Tensor &weight = weightAt(weight_idx).getVariableRef();

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -52,19 +52,19 @@ public:
   FullyConnectedLayer &operator=(FullyConnectedLayer &&rhs) = default;
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in);
+  void forwarding();
 
   /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
+   * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
-   * @copydoc Layer::calcGradient(sharedConstTensors in)
+   * @copydoc Layer::calcGradient()
    */
-  void calcGradient(sharedConstTensors in);
+  void calcGradient();
 
   /**
    * @brief     copy layer

--- a/nntrainer/layers/flatten_layer.cpp
+++ b/nntrainer/layers/flatten_layer.cpp
@@ -41,13 +41,13 @@ int FlattenLayer::initialize(Manager &manager) {
   return status;
 }
 
-void FlattenLayer::forwarding(sharedConstTensors in) {
+void FlattenLayer::forwarding() {
   Tensor temp = net_input[0]->getVariableRef();
   temp.reshape(net_hidden[0]->getDim());
   net_hidden[0]->getVariableRef() = temp;
 }
 
-void FlattenLayer::calcDerivative(sharedConstTensors in) {
+void FlattenLayer::calcDerivative() {
   Tensor temp = net_hidden[0]->getGradientRef();
   temp.reshape(net_input[0]->getDim());
   net_input[0]->getGradientRef() = temp;

--- a/nntrainer/layers/flatten_layer.h
+++ b/nntrainer/layers/flatten_layer.h
@@ -68,14 +68,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in);
+  void forwarding();
 
   /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
+   * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -53,9 +53,9 @@ void InputLayer::setProperty(const PropertyType type,
   }
 }
 
-void InputLayer::forwarding(sharedConstTensors in) {
+void InputLayer::forwarding() {
   Tensor &hidden_ = net_hidden[0]->getVariableRef();
-  hidden_ = *in[0];
+  hidden_ = net_input[0]->getVariableRef();
 
   if (normalization)
     hidden_.normalization_i();
@@ -63,7 +63,7 @@ void InputLayer::forwarding(sharedConstTensors in) {
     hidden_.standardization_i();
 }
 
-void InputLayer::calcDerivative(sharedConstTensors in) {
+void InputLayer::calcDerivative() {
   throw exception::not_supported(
     "calcDerivative for input layer is not supported");
 }

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -75,14 +75,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in);
+  void forwarding();
 
   /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
+   * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
    * @brief     Initializer of Input Layer

--- a/nntrainer/layers/loss_layer.h
+++ b/nntrainer/layers/loss_layer.h
@@ -53,23 +53,14 @@ public:
   ~LossLayer(){};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in = {});
+  void forwarding();
 
   /**
-   * @brief     Forward Propagation of a layer
-   * @param[in] in List of Input Tensors taken by this layer
-   * @param[in] label List of Label Tensors for the model
-   * @retval    List of Input Tensors as it is.
+   * @copydoc Layer::calcDerivative()
    */
-  sharedConstTensors forwarding(sharedConstTensors in,
-                                sharedConstTensors label);
-
-  /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
-   */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
    * @brief     read layer Weight & Bias data from file

--- a/nntrainer/layers/nnstreamer_layer.cpp
+++ b/nntrainer/layers/nnstreamer_layer.cpp
@@ -165,9 +165,9 @@ void NNStreamerLayer::setProperty(const PropertyType type,
   }
 }
 
-void NNStreamerLayer::forwarding(sharedConstTensors in) {
+void NNStreamerLayer::forwarding() {
   size_t data_size;
-  Tensor input = *in[0];
+  Tensor &input = net_input[0]->getVariableRef();
   Tensor &hidden_ = net_hidden[0]->getVariableRef();
 
   std::copy(input.getData(), input.getData() + input.length(),
@@ -203,7 +203,7 @@ void NNStreamerLayer::copy(std::shared_ptr<Layer> l) {
   this->modelfile = from->modelfile;
 }
 
-void NNStreamerLayer::calcDerivative(sharedConstTensors derivative) {
+void NNStreamerLayer::calcDerivative() {
   throw exception::not_supported(
     "calcDerivative is not supported for nnstreamer layer");
 }

--- a/nntrainer/layers/nnstreamer_layer.h
+++ b/nntrainer/layers/nnstreamer_layer.h
@@ -50,14 +50,14 @@ public:
   ~NNStreamerLayer();
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in);
+  void forwarding();
 
   /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
+   * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
    * @copydoc Layer::copy(std::shared_ptr<layer> l)

--- a/nntrainer/layers/output_layer.cpp
+++ b/nntrainer/layers/output_layer.cpp
@@ -43,14 +43,14 @@ int OutputLayer::initialize(Manager &manager) {
   return status;
 }
 
-void OutputLayer::forwarding(sharedConstTensors in) {
+void OutputLayer::forwarding() {
   Tensor &input_ = net_input[0]->getVariableRef();
   for (unsigned int idx = 0; idx < num_outputs; ++idx) {
     net_hidden[idx]->getVariableRef() = input_;
   }
 }
 
-void OutputLayer::calcDerivative(sharedConstTensors derivative) {
+void OutputLayer::calcDerivative() {
 
   Tensor &ret = net_input[0]->getGradientRef();
 

--- a/nntrainer/layers/output_layer.h
+++ b/nntrainer/layers/output_layer.h
@@ -72,14 +72,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in);
+  void forwarding();
 
   /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
+   * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -66,7 +66,7 @@ int Pooling2DLayer::initialize(Manager &manager) {
   return status;
 }
 
-void Pooling2DLayer::forwarding(sharedConstTensors in) {
+void Pooling2DLayer::forwarding() {
   Tensor &input_ = net_input[0]->getVariableRef();
   Tensor &hidden_ = net_hidden[0]->getVariableRef();
 
@@ -85,7 +85,7 @@ void Pooling2DLayer::forwarding(sharedConstTensors in) {
   }
 }
 
-void Pooling2DLayer::calcDerivative(sharedConstTensors derivative) {
+void Pooling2DLayer::calcDerivative() {
   unsigned int batch = input_dim[0].batch();
   unsigned int channel = input_dim[0].channel();
   unsigned int height = input_dim[0].height();

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -90,14 +90,14 @@ public:
   void save(std::ofstream &file){};
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in);
+  void forwarding();
 
   /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
+   * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
    * @copydoc Layer::setBatch(unsigned int batch)

--- a/nntrainer/layers/tflite_layer.cpp
+++ b/nntrainer/layers/tflite_layer.cpp
@@ -96,14 +96,14 @@ void TfLiteLayer::setProperty(const PropertyType type,
   }
 }
 
-void TfLiteLayer::forwarding(sharedConstTensors in) {
+void TfLiteLayer::forwarding() {
 #ifdef DEBUG
   std::vector<TensorDim> dims;
-  if (in.size() != input_dim.size())
+  if (net_input.size() != input_dim.size())
     throw std::invalid_argument("Provided number of input dimensions mismatch");
 
   for (int idx = 0; idx < dims.size(); idx++) {
-    if (in[idx].getDim() != input_dim[idx])
+    if (net_input[idx]->getDim() != input_dim[idx])
       throw std::invalid_argument("Input dimensions mismatch");
   }
 #endif
@@ -111,8 +111,9 @@ void TfLiteLayer::forwarding(sharedConstTensors in) {
   sharedConstTensors out;
 
   auto in_indices = interpreter->inputs();
-  for (size_t idx = 0; idx < in.size(); idx++)
-    interpreter->tensor(in_indices[idx])->data.raw = (char *)in[idx]->getData();
+  for (size_t idx = 0; idx < net_input.size(); idx++)
+    interpreter->tensor(in_indices[idx])->data.raw =
+      (char *)net_input[idx]->getVariableRef().getData();
 
   auto out_indices = interpreter->outputs();
   out.resize(out_indices.size());
@@ -136,7 +137,7 @@ void TfLiteLayer::copy(std::shared_ptr<Layer> l) {
   this->modelfile = from->modelfile;
 }
 
-void TfLiteLayer::calcDerivative(sharedConstTensors derivative) {
+void TfLiteLayer::calcDerivative() {
   throw exception::not_supported(
     "calcDerivative is not supported for tflite layer");
 }

--- a/nntrainer/layers/tflite_layer.h
+++ b/nntrainer/layers/tflite_layer.h
@@ -47,14 +47,14 @@ public:
   ~TfLiteLayer() = default;
 
   /**
-   * @copydoc Layer::forwarding(sharedConstTensors in)
+   * @copydoc Layer::forwarding()
    */
-  void forwarding(sharedConstTensors in);
+  void forwarding();
 
   /**
-   * @copydoc Layer::calcDerivative(sharedConstTensors in)
+   * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative(sharedConstTensors in);
+  void calcDerivative();
 
   /**
    * @copydoc Layer::copy(std::shared_ptr<layer> l)

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -308,9 +308,9 @@ NeuralNetwork::~NeuralNetwork() {
 /**
  * @brief     forward propagation using layers object which has layer
  */
-sharedConstTensors NeuralNetwork::forwarding(sharedConstTensors input) {
-  sharedConstTensors X = model_graph.forwarding(input);
-  return X;
+sharedConstTensors NeuralNetwork::forwarding() {
+  return model_graph.forwarding();
+  // model_graph.Sorted.back().layer->forwarding();
 }
 
 /**
@@ -318,14 +318,21 @@ sharedConstTensors NeuralNetwork::forwarding(sharedConstTensors input) {
  */
 sharedConstTensors NeuralNetwork::forwarding(sharedConstTensors input,
                                              sharedConstTensors label) {
-  sharedConstTensors X;
   if (input[0]->getDim().batch() > batch_size)
     throw std::logic_error("Error: mismatch in batchsize for data and model.");
-  X = forwarding(input);
-  X = std::static_pointer_cast<LossLayer>(model_graph.Sorted.back().layer)
-        ->forwarding(X, label);
 
-  return X;
+  auto &first_layer = model_graph.getSortedLayerNode(0).layer;
+  auto &last_layer =
+    model_graph.getSortedLayerNode(model_graph.getSorted().size() - 1).layer;
+
+  if (label.empty())
+    last_layer->net_hidden.clear();
+  else
+    last_layer->net_hidden[0]->getGradientRef() = *label[0].get();
+
+  first_layer->net_input[0]->getVariableRef() = *input[0].get();
+
+  return forwarding();
 }
 
 /**
@@ -333,8 +340,7 @@ sharedConstTensors NeuralNetwork::forwarding(sharedConstTensors input,
  *            Call backwarding function of layer in reverse order
  *            No need to call at first Input Layer (No data to be updated)
  */
-void NeuralNetwork::backwarding(sharedConstTensors label, int iteration) {
-
+void NeuralNetwork::backwarding(int iteration) {
   /**
    * last layer backwarding is run out of this loop
    */
@@ -342,11 +348,7 @@ void NeuralNetwork::backwarding(sharedConstTensors label, int iteration) {
   auto iter_end = model_graph.getBackwardingEndIter();
   for (auto iter = iter_begin; iter != iter_end - 1; iter++) {
     auto layer = iter->layer;
-    if (istrequal(layer->getType(), nntrainer::LossLayer::type)) {
-      layer->backwarding(label);
-    } else {
-      layer->backwarding();
-    }
+    layer->backwarding();
     opt->apply_gradients(layer->getWeightsRef(), iteration);
   }
 
@@ -358,11 +360,24 @@ void NeuralNetwork::backwarding(sharedConstTensors label, int iteration) {
    * 2. calcDerivative
    * 3. applyGradient
    */
-  last_layer->calcGradient(label);
+  last_layer->calcGradient();
 #ifdef ENABLE_TEST
-  last_layer->calcDerivative(label);
+  last_layer->calcDerivative();
 #endif
   opt->apply_gradients(last_layer->getWeightsRef(), iteration);
+}
+
+/**
+ * @brief     back propagation
+ *            Call backwarding function of layer in reverse order
+ *            No need to call at first Input Layer (No data to be updated)
+ */
+void NeuralNetwork::backwarding(sharedConstTensors label, int iteration) {
+  auto &loss_layer =
+    model_graph.getSortedLayerNode(model_graph.getSorted().size() - 1).layer;
+  loss_layer->net_hidden[0]->getGradientRef() = *label[0].get();
+
+  backwarding(iteration);
 }
 
 float NeuralNetwork::getLoss() {
@@ -530,8 +545,13 @@ int NeuralNetwork::train_run() {
     iter = 0;
   }
 
-  sharedTensor in = MAKE_SHARED_TENSOR(getInputDimension()[0]);
-  sharedTensor label = MAKE_SHARED_TENSOR(getOutputDimension()[0]);
+  auto &first_layer = model_graph.getSortedLayerNode(0).layer;
+  auto &last_layer =
+    model_graph.getSortedLayerNode(model_graph.getSorted().size() - 1).layer;
+
+  auto &output = last_layer->net_hidden[0]->getVariableRef();
+  auto &label = last_layer->net_hidden[0]->getGradientRef();
+  auto &in = first_layer->net_input[0]->getVariableRef();
 
   for (epoch_idx = epoch_idx + 1; epoch_idx <= epochs; ++epoch_idx) {
     training.loss = 0.0f;
@@ -553,10 +573,10 @@ int NeuralNetwork::train_run() {
 
     while (true) {
       if (data_buffer->getDataFromBuffer(nntrainer::BufferType::BUF_TRAIN,
-                                         in->getData(), label->getData())) {
+                                         in.getData(), label.getData())) {
         try {
-          forwarding({in}, {label});
-          backwarding({label}, iter++);
+          forwarding();
+          backwarding(iter++);
         } catch (...) {
           data_buffer->clear(nntrainer::BufferType::BUF_TRAIN);
           ml_loge("Error: training error in #%d/%d.", epoch_idx, epochs);
@@ -594,10 +614,10 @@ int NeuralNetwork::train_run() {
 
       while (true) {
         if (data_buffer->getDataFromBuffer(nntrainer::BufferType::BUF_VAL,
-                                           in->getData(), label->getData())) {
-          sharedConstTensors Y = forwarding({in}, {label});
-          auto model_out = Y[0]->argmax();
-          auto label_out = label->argmax();
+                                           in.getData(), label.getData())) {
+          forwarding();
+          auto model_out = output.argmax();
+          auto label_out = label.argmax();
           for (unsigned int b = 0; b < batch_size; b++) {
             if (model_out[b] == label_out[b])
               right++;

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -187,7 +187,12 @@ public:
    * @param[in] input List of Input Tensors taken by the neural network
    * @retval    List of Output Tensors
    */
-  sharedConstTensors forwarding(sharedConstTensors input);
+  // sharedConstTensors forwarding(sharedConstTensors input);
+
+  /**
+   * @brief     Forward Propagation of the neural network
+   */
+  sharedConstTensors forwarding();
 
   /**
    * @brief     Forward Propagation of the neural network
@@ -196,15 +201,20 @@ public:
    * @retval    List of Output Tensors
    */
   sharedConstTensors forwarding(sharedConstTensors input,
-                                sharedConstTensors label);
+                                sharedConstTensors label = {});
 
   /**
    * @brief     Backward Propagation of the neural network
-   * @param[in] input List of Input Tensors taken by the neural network
    * @param[in] label List of Label Tensors for the model
    * @param[in] iteration Iteration Number for the optimizer
    */
   void backwarding(sharedConstTensors label, int iteration);
+
+  /**
+   * @brief     Backward Propagation of the neural network
+   * @param[in] iteration Iteration Number for the optimizer
+   */
+  void backwarding(int iteration);
 
   /**
    * @brief     save model and training parameters into file

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -289,10 +289,12 @@ void Manager::initializeInOuts(bool trainable) {
     shared_deriv = Tensor(max_derivative_size);
 
   size_t count = 0;
-  for (auto &l_io : in_outs) {
+  for (unsigned int idx = 0; idx < in_outs.size(); idx++) {
+    auto &l_io = in_outs[idx];
     size_t offset = 0;
+    bool is_last_layer = idx == in_outs.size() - 1;
     for (auto &io : l_io) {
-      if (enable_derivative_memory_opt) {
+      if (enable_derivative_memory_opt && !is_last_layer) {
         if (is_act_type[count] && enable_activation_memory_opt) {
           io->initialize(
             Tensor(), shared_deriv.getSharedDataTensor(io->getDim(), offset));
@@ -301,7 +303,10 @@ void Manager::initializeInOuts(bool trainable) {
           io->initializeShared();
         }
       } else {
-        io->initialize(Tensor(), Tensor(), trainable);
+        if (is_last_layer)
+          io->initialize(Tensor(), Tensor(), true);
+        else
+          io->initialize(Tensor(), Tensor(), trainable);
       }
     }
     count += 1;

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -556,7 +556,8 @@ protected:
                                nntrainer::LossLayer::type)) {
         std::shared_ptr<nntrainer::LossLayer> loss_layer =
           std::static_pointer_cast<nntrainer::LossLayer>(layers.back());
-        EXPECT_NO_THROW(out = loss_layer->forwarding({out}, {label})[0]);
+        EXPECT_NO_THROW(out =
+                          loss_layer->forwarding_with_val({out}, {label})[0]);
       } else {
         EXPECT_NO_THROW(out = layers.back()->forwarding_with_val({out})[0]);
       }
@@ -582,7 +583,7 @@ protected:
     if (layers.size() && nntrainer::istrequal(layers.back()->getType(),
                                               nntrainer::LossLayer::type)) {
       if (with_loss) {
-        EXPECT_NO_THROW(layers.back()->backwarding({label}));
+        EXPECT_NO_THROW(layers.back()->backwarding_with_val({label}));
         back_out = MAKE_SHARED_TENSOR(layers.back()->getDerivatives()[0]);
       } else {
         back_out = def_derivative;
@@ -593,11 +594,11 @@ protected:
     }
 
     for (; idx >= 0; --idx)
-      EXPECT_NO_THROW(back_out = layers[idx]->backwarding_with_val(
-                        1, {back_out}, {}, opt)[0]);
+      EXPECT_NO_THROW(
+        back_out = layers[idx]->backwarding_with_val(1, {back_out}, opt)[0]);
 
     EXPECT_NO_THROW(back_out =
-                      layer.backwarding_with_val(1, {back_out}, {}, opt)[0]);
+                      layer.backwarding_with_val(1, {back_out}, opt)[0]);
     matchOutput(*back_out.get(), file_dx);
 
     loadUpdatedWeightsGradients(file_uw, file_g);
@@ -660,7 +661,7 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch, forwarding_backwarding_00_p) {
 
   nntrainer::Tensor result;
   EXPECT_NO_THROW(result = *layer.backwarding_with_val(
-                    1, {MAKE_SHARED_TENSOR(derivatives)}, {}, opt)[0]);
+                    1, {MAKE_SHARED_TENSOR(derivatives)}, opt)[0]);
 
   matchOutput(result, "tc_fc_1_goldenFCGradientAdam.out");
 
@@ -946,8 +947,8 @@ TEST_F(nntrainer_BatchNormalizationLayer, forward_backward_training_01_p) {
   nntrainer::Tensor backward_in(layer.getOutputDimension()[0]);
   loadFile("tc_bn_fc_1_goldenBNLayerBackwardDxIn.out", backward_in);
 
-  nntrainer::Tensor backward_result = *layer.backwarding_with_val(
-    1, {MAKE_SHARED_TENSOR(backward_in)}, {}, opt)[0];
+  nntrainer::Tensor backward_result =
+    *layer.backwarding_with_val(1, {MAKE_SHARED_TENSOR(backward_in)}, opt)[0];
 
   matchOutput(backward_result, "tc_bn_fc_1_goldenBNLayerBackwardDx.out");
 }
@@ -985,8 +986,8 @@ TEST_F(nntrainer_BatchNormalizationLayer_Conv, forward_backward_training_01_p) {
   nntrainer::Tensor backward_in(layer.getOutputDimension()[0]);
   loadFile("tc_bn_conv_1_goldenBNLayerBackwardDxIn.out", backward_in);
 
-  nntrainer::Tensor backward_result = *layer.backwarding_with_val(
-    1, {MAKE_SHARED_TENSOR(backward_in)}, {}, opt)[0];
+  nntrainer::Tensor backward_result =
+    *layer.backwarding_with_val(1, {MAKE_SHARED_TENSOR(backward_in)}, opt)[0];
 
   matchOutput(backward_result, "tc_bn_conv_1_goldenBNLayerBackwardDx.out");
 }
@@ -1027,8 +1028,8 @@ TEST_F(nntrainer_BatchNormalizationLayer_Conv2,
   nntrainer::Tensor backward_in(layer.getOutputDimension()[0]);
   loadFile("tc_bn_conv_2_goldenBNLayerBackwardDxIn.out", backward_in);
 
-  nntrainer::Tensor backward_result = *layer.backwarding_with_val(
-    1, {MAKE_SHARED_TENSOR(backward_in)}, {}, opt)[0];
+  nntrainer::Tensor backward_result =
+    *layer.backwarding_with_val(1, {MAKE_SHARED_TENSOR(backward_in)}, opt)[0];
 
   matchOutput(backward_result, "tc_bn_conv_2_goldenBNLayerBackwardDx.out");
 }
@@ -1163,7 +1164,7 @@ TEST_F(nntrainer_Conv2DLayer, backwarding_01_p) {
   }
 
   EXPECT_NO_THROW(result = *layer.backwarding_with_val(
-                    1, {MAKE_SHARED_TENSOR(derivatives)}, {}, opt)[0]);
+                    1, {MAKE_SHARED_TENSOR(derivatives)}, opt)[0]);
 
   auto param_data = layer.getWeights();
   const float *weight_grad = param_data[0].getGradient().getData();
@@ -1200,7 +1201,7 @@ TEST_F(nntrainer_Conv2DLayer, backwarding_02_p) {
     derivatives.getData()[i] = 1.0;
   }
   EXPECT_NO_THROW(result = *layer.backwarding_with_val(
-                    1, {MAKE_SHARED_TENSOR(derivatives)}, {}, opt)[0]);
+                    1, {MAKE_SHARED_TENSOR(derivatives)}, opt)[0]);
 
   auto param_data = layer.getWeights();
   const float *weight_grad = param_data[0].getGradient().getData();
@@ -1219,7 +1220,7 @@ TEST_F(nntrainer_Conv2DLayer, backwarding_02_p) {
     EXPECT_NO_THROW(out =
                       *layer.forwarding_with_val({MAKE_SHARED_TENSOR(in)})[0]);
     EXPECT_NO_THROW(result = *layer.backwarding_with_val(
-                      0, {MAKE_SHARED_TENSOR(derivatives)}, {}, opt)[0]);
+                      0, {MAKE_SHARED_TENSOR(derivatives)}, opt)[0]);
   }
 
   /// @fixme: the output value of this test is around +/- 1.0e+07 which can't
@@ -1305,10 +1306,10 @@ TEST_F(nntrainer_Conv2DLayer, DISABLED_backwarding_03_p) {
 
   nntrainer::Tensor result2;
   EXPECT_NO_THROW(result2 = *layer2.backwarding_with_val(
-                    1, {MAKE_SHARED_TENSOR(derivatives)}, {}, opt)[0]);
+                    1, {MAKE_SHARED_TENSOR(derivatives)}, opt)[0]);
 
   EXPECT_NO_THROW(result = *layer1.backwarding_with_val(
-                    1, {MAKE_SHARED_TENSOR(result2)}, {}, opt)[0]);
+                    1, {MAKE_SHARED_TENSOR(result2)}, opt)[0]);
 
   /** Compare second conv */
   auto param_data = layer2.getWeights();
@@ -1352,7 +1353,7 @@ TEST_F(nntrainer_Conv2DLayer, backwarding_04_p) {
     derivatives.getData()[i] = 1.0;
   }
   EXPECT_NO_THROW(result = *layer.backwarding_with_val(
-                    1, {MAKE_SHARED_TENSOR(derivatives)}, {}, opt)[0]);
+                    1, {MAKE_SHARED_TENSOR(derivatives)}, opt)[0]);
 
   auto param_data = layer.getWeights();
   const float *weight_grad = param_data[0].getGradient().getData();
@@ -1496,8 +1497,8 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_01_p) {
     grad.getData()[i] = 1.0;
   }
 
-  EXPECT_NO_THROW(in = *layer.backwarding_with_val(
-                    1, {MAKE_SHARED_TENSOR(grad)}, {}, opt)[0]);
+  EXPECT_NO_THROW(
+    in = *layer.backwarding_with_val(1, {MAKE_SHARED_TENSOR(grad)}, opt)[0]);
 
   matchOutput(in, "tc_pooling2d_1_goldenPooling2DmaxGrad.out");
 }
@@ -1518,7 +1519,7 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_02_p) {
     grad->getData()[i] = 1.0;
   }
 
-  EXPECT_NO_THROW(in = *layer.backwarding_with_val(1, {grad}, {}, opt)[0]);
+  EXPECT_NO_THROW(in = *layer.backwarding_with_val(1, {grad}, opt)[0]);
 
   matchOutput(in, "tc_pooling2d_1_goldenPooling2DaverageGrad.out");
 }
@@ -1540,8 +1541,8 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_03_p) {
     grad.getData()[i] = 1.0;
   }
 
-  EXPECT_NO_THROW(in = *layer.backwarding_with_val(
-                    1, {MAKE_SHARED_TENSOR(grad)}, {}, opt)[0]);
+  EXPECT_NO_THROW(
+    in = *layer.backwarding_with_val(1, {MAKE_SHARED_TENSOR(grad)}, opt)[0]);
 
   matchOutput(in, "tc_pooling2d_1_goldenPooling2Dglobal_maxGrad.out");
 }
@@ -1562,8 +1563,8 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_04_p) {
     grad.getData()[i] = 1.0;
   }
 
-  EXPECT_NO_THROW(in = *layer.backwarding_with_val(
-                    1, {MAKE_SHARED_TENSOR(grad)}, {}, opt)[0]);
+  EXPECT_NO_THROW(
+    in = *layer.backwarding_with_val(1, {MAKE_SHARED_TENSOR(grad)}, opt)[0]);
 
   matchOutput(in, "tc_pooling2d_1_goldenPooling2Dglobal_averageGrad.out");
 }
@@ -1622,7 +1623,7 @@ TEST_F(nntrainer_FlattenLayer, backwarding_01_p) {
   loadFile("tc_pooling2d_1_goldenPooling2Dmax.out", out);
 
   EXPECT_NO_THROW(
-    in = *layer.backwarding_with_val(1, {MAKE_SHARED_TENSOR(out)}, {}, opt)[0]);
+    in = *layer.backwarding_with_val(1, {MAKE_SHARED_TENSOR(out)}, opt)[0]);
   EXPECT_EQ(in.getDim(), nntrainer::TensorDim(1, 2, 4, 4));
 
   matchOutput(in, "tc_pooling2d_1_goldenPooling2Dmax.out");
@@ -1641,7 +1642,7 @@ TEST_F(nntrainer_FlattenLayer, backwarding_02_p) {
   loadFile("tc_pooling2d_2_goldenPooling2Dmax.out", out);
 
   EXPECT_NO_THROW(
-    in = *layer.backwarding_with_val(1, {MAKE_SHARED_TENSOR(out)}, {}, opt)[0]);
+    in = *layer.backwarding_with_val(1, {MAKE_SHARED_TENSOR(out)}, opt)[0]);
   EXPECT_EQ(in.getDim(), nntrainer::TensorDim(2, 2, 4, 4));
 
   matchOutput(in, "tc_pooling2d_2_goldenPooling2Dmax.out");
@@ -1670,7 +1671,9 @@ TEST(nntrainer_LossLayer, setLoss_02_n) {
 TEST(nntrainer_LossLayer, forward_nolabel_n) {
   nntrainer::LossLayer layer;
   nntrainer::Tensor a = constant(1.0, 1, 1, 1, 1);
-  EXPECT_THROW(layer.forwarding({MAKE_SHARED_TENSOR(a)}), std::runtime_error);
+  layer.setProperty({"input_shape=1:1:1:1"});
+  EXPECT_THROW(layer.forwarding_with_val({MAKE_SHARED_TENSOR(a)}),
+               std::invalid_argument);
 }
 
 TEST(nntrainer_LossLayer, forward_loss_unknown_n) {
@@ -1686,7 +1689,7 @@ TEST(nntrainer_LossLayer, forward_loss_unknown_n) {
 
   manager.initializeInOuts(true);
   EXPECT_THROW(
-    layer.forwarding({MAKE_SHARED_TENSOR(a)}, {MAKE_SHARED_TENSOR(b)}),
+    layer.forwarding_with_val({MAKE_SHARED_TENSOR(a)}, {MAKE_SHARED_TENSOR(b)}),
     std::runtime_error);
 }
 
@@ -1701,7 +1704,8 @@ TEST(nntrainer_LossLayer, backward_loss_unknown_n) {
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
   manager.initializeInOuts(true);
-  EXPECT_THROW(layer.backwarding({MAKE_SHARED_TENSOR(a)}), std::runtime_error);
+  EXPECT_THROW(layer.backwarding_with_val({MAKE_SHARED_TENSOR(a)}),
+               std::runtime_error);
 }
 
 TEST(nntrainer_LossLayer, forward_loss_forward_entropy_n) {
@@ -1718,7 +1722,7 @@ TEST(nntrainer_LossLayer, forward_loss_forward_entropy_n) {
 
   manager.initializeInOuts(true);
   EXPECT_THROW(
-    layer.forwarding({MAKE_SHARED_TENSOR(a)}, {MAKE_SHARED_TENSOR(b)}),
+    layer.forwarding_with_val({MAKE_SHARED_TENSOR(a)}, {MAKE_SHARED_TENSOR(b)}),
     std::runtime_error);
 }
 
@@ -1734,7 +1738,8 @@ TEST(nntrainer_LossLayer, backward_loss_backward_entropy_n) {
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
   manager.initializeInOuts(true);
-  EXPECT_THROW(layer.backwarding({MAKE_SHARED_TENSOR(a)}), std::runtime_error);
+  EXPECT_THROW(layer.backwarding_with_val({MAKE_SHARED_TENSOR(a)}),
+               std::runtime_error);
 }
 
 /**

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -261,7 +261,7 @@ NodeWatcher::lossForward(nntrainer::sharedConstTensors pred,
 
   nntrainer::sharedConstTensors out =
     std::static_pointer_cast<nntrainer::LossLayer>(node.layer)
-      ->forwarding(pred, answer);
+      ->forwarding_with_val(pred, answer);
 
   return out;
 }


### PR DESCRIPTION
Optimize models extra input/output memory allocation counting towards peak memory allocation.
Memory is allocated with for input of input layer and output/gradient of output layer.
However, that memory is never used as train_run() allocates new buffer and passes it to the
input layer/loss layer.
This patch takes the already allocted memory from input/loss layer to be used to collect input/label data.

This patch also removes the extra parameters from forwarding/backwarding and with corresponding
with_val functions. Further, two types of forwarding in loss layer has been merged to just 1 function.
Now, loss layer and input layer does not need to be distinguished and can be treated as a regular layer.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>