### PR TITLE
[dist/tizen] Enable base unittests for tizen build @open sesame 12/29 15:57

### DIFF
--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -276,7 +276,7 @@ cp label.dat build
 tar xzf unittest_layers.tar.gz -C build
 
 # independent unittests of nntrainer
-# bash %{test_script} ./test
+bash %{test_script} ./test
 
 export NNSTREAMER_CONF=$(pwd)/test/nnstreamer_filter_nntrainer/nnstreamer-test.ini
 export NNSTREAMER_FILTERS=$(pwd)/build/nnstreamer/tensor_filter


### PR DESCRIPTION
Enable nntrainer unittests for tizen build
Not sure why or when this got commented
but lets enable it

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>