### PR TITLE
[mem-opt] Inference memory optimizations

### DIFF
--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -55,14 +55,6 @@ int Pooling2DLayer::initialize(Manager &manager) {
     out_dim.width(in_dim.channel());
   }
 
-  if (pooling_type == PoolingType::max) {
-    max_idx.resize(out_dim.getDataLen());
-  }
-
-  if (pooling_type == PoolingType::global_max) {
-    max_idx_global.resize(out_dim.getDataLen());
-  }
-
   return status;
 }
 
@@ -75,6 +67,12 @@ void Pooling2DLayer::forwarding() {
 
   if (hidden_.uninitialized()) {
     hidden_ = Tensor(hidden_dim);
+  }
+
+  if (pooling_type == PoolingType::max) {
+    max_idx.resize(output_dim[0].getDataLen());
+  } else if (pooling_type == PoolingType::global_max) {
+    max_idx_global.resize(output_dim[0].getDataLen());
   }
 
   for (unsigned int b = 0; b < in_dim.batch(); ++b) {
@@ -180,16 +178,6 @@ int Pooling2DLayer::setSize(int *size, PropertyType type) {
     break;
   }
   return status;
-}
-
-void Pooling2DLayer::setBatch(unsigned int batch) {
-  Layer::setBatch(batch);
-
-  if (pooling_type == PoolingType::max) {
-    max_idx.resize(output_dim[0].getDataLen());
-  } else if (pooling_type == PoolingType::global_max) {
-    max_idx_global.resize(output_dim[0].getDataLen());
-  }
 }
 
 void Pooling2DLayer::copy(std::shared_ptr<Layer> l) {

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -100,11 +100,6 @@ public:
   void calcDerivative();
 
   /**
-   * @copydoc Layer::setBatch(unsigned int batch)
-   */
-  void setBatch(unsigned int batch);
-
-  /**
    * @brief     copy layer
    * @param[in] l layer to copy
    */

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -257,7 +257,8 @@ int NeuralNetwork::initialize() {
       l.setInputBuffers(in_out);
     }
   }
-  setBatchSize(batch_size);
+  setBatchSize();
+
   // Allocate and initialize weights
   manager->initializeWeights();
 

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -258,12 +258,12 @@ int NeuralNetwork::initialize() {
     }
   }
   setBatchSize(batch_size);
+  // Allocate and initialize weights
+  manager->initializeWeights();
 
   if (in_place_optimization) {
     model_graph.inPlaceOptimize(*manager);
   }
-
-  manager->initialize();
 
   initialized = true;
   return status;
@@ -474,7 +474,7 @@ sharedConstTensors NeuralNetwork::inference(sharedConstTensors X) {
 
 int NeuralNetwork::assignMem(bool trainable) {
   // TODO: directly replace this
-  manager->initializeInOuts(trainable);
+  manager->initializeTensors(trainable);
   return ML_ERROR_NONE;
 }
 

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -414,6 +414,11 @@ public:
     manager->setInferenceInOutMemoryOptimization(opt);
   }
 
+  /**
+   * @brief     Update batch size of the model as well as its layers/dataset
+   */
+  void setBatchSize() { setBatchSize(batch_size); }
+
 /// @todo Make a more common class have this
 /// Maybe appcontext can have this?
 #ifdef PROFILE

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -245,7 +245,7 @@ void Manager::initializeWeights() {
       Tensor grad_prealloc = Tensor();
 
       weight_offset += dim.getDataLen();
-      weight.initializeWeight(weight_prealloc, false);
+      weight.initializeWeight(weight_prealloc);
     }
   }
 

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -256,6 +256,7 @@ private:
   size_t max_grad_size;       /**< max trainable weight required by a layer */
   size_t max_derivative_size; /**< max derivative required by a layer */
   size_t max_shared_inout;    /**< max memory for in/outs for inference */
+  bool weights_initialized;   /**< track if weights have been initialized */
 
   /**< Inputs/outputs of all the layer in the model */
   std::vector<std::vector<std::shared_ptr<Var_Grad>>> in_outs;

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -235,8 +235,9 @@ public:
    */
   void setBatchSize(unsigned int batch) {
     if (!in_outs.empty() && !in_outs[0].empty()) {
-      max_derivative_size /= in_outs[0][0]->getDim().batch();
-      max_shared_inout /= in_outs[0][0]->getDim().batch();
+      unsigned int prev_batch = in_outs[0][0]->getDim().batch();
+      max_derivative_size /= prev_batch;
+      max_shared_inout /= prev_batch;
       max_derivative_size *= batch;
       max_shared_inout *= batch;
     }

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -24,7 +24,7 @@ Var_Grad::Var_Grad(const TensorDim &dim, bool train, const std::string &name) :
   grad = std::make_shared<Tensor>();
 }
 
-void Var_Grad::initializeWeight(const Tensor &preallocated, bool gtrain) {
+void Var_Grad::initializeWeight(const Tensor &preallocated) {
   if (!preallocated.uninitialized()) {
     var = std::make_shared<Tensor>(preallocated);
   } else {

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -24,20 +24,21 @@ Var_Grad::Var_Grad(const TensorDim &dim, bool train, const std::string &name) :
   grad = std::make_shared<Tensor>();
 }
 
-void Var_Grad::initialize(const Tensor &weights_preallocated,
-                          const Tensor &grad_preallocated, bool gtrain) {
-  if (!weights_preallocated.uninitialized()) {
-    var = std::make_shared<Tensor>(weights_preallocated);
+void Var_Grad::initializeWeight(const Tensor &preallocated, bool gtrain) {
+  if (!preallocated.uninitialized()) {
+    var = std::make_shared<Tensor>(preallocated);
   } else {
     var = std::make_shared<Tensor>(dim);
   }
+}
 
-  if (!grad_preallocated.uninitialized() && gtrain) {
+void Var_Grad::initializeGrad(const Tensor &preallocated, bool gtrain) {
+  if (!preallocated.uninitialized() && gtrain) {
     /**
      * Making a new tensor is intentional here as this tensor is not shared
      * with other layers but the internal memory is.
      */
-    grad = std::make_shared<Tensor>(grad_preallocated);
+    grad = std::make_shared<Tensor>(preallocated);
   } else {
     grad = std::make_shared<Tensor>();
     if (trainable && gtrain) {

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -100,17 +100,15 @@ public:
   virtual void initialize(const Tensor &weight_preallocated = Tensor(),
                           const Tensor &grad_preallocated = Tensor(),
                           bool gtrain = true) {
-    initializeWeight(weight_preallocated, gtrain);
+    initializeWeight(weight_preallocated);
     initializeGrad(grad_preallocated, gtrain);
   }
 
   /**
    * @brief Initialize the variable for the weight
    * @param preallocated if initialized, use this tensor for variable memory
-   * @param gtrain If all the variables should be trainable
    */
-  virtual void initializeWeight(const Tensor &preallocated = Tensor(),
-                                bool gtrain = true);
+  virtual void initializeWeight(const Tensor &preallocated = Tensor());
 
   /**
    * @brief Initialize the gradient for the weight

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -99,7 +99,26 @@ public:
    */
   virtual void initialize(const Tensor &weight_preallocated = Tensor(),
                           const Tensor &grad_preallocated = Tensor(),
-                          bool gtrain = true);
+                          bool gtrain = true) {
+    initializeWeight(weight_preallocated, gtrain);
+    initializeGrad(grad_preallocated, gtrain);
+  }
+
+  /**
+   * @brief Initialize the variable for the weight
+   * @param preallocated if initialized, use this tensor for variable memory
+   * @param gtrain If all the variables should be trainable
+   */
+  virtual void initializeWeight(const Tensor &preallocated = Tensor(),
+                                bool gtrain = true);
+
+  /**
+   * @brief Initialize the gradient for the weight
+   * @param preallocated if initialized, use this tensor for gradient memory
+   * @param gtrain If all the variables should be trainable
+   */
+  virtual void initializeGrad(const Tensor &preallocated = Tensor(),
+                              bool gtrain = true);
 
   /**
    * @brief Allocate and initialize the variable and grad

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -24,17 +24,8 @@ Weight::Weight(const TensorDim &dim, const WeightInitializer init, bool train,
     throw std::invalid_argument("Weight initializer unknown");
 }
 
-void Weight::initialize(const Tensor &weights_preallocated,
-                        const Tensor &grad_preallocated, bool gtrain) {
-  Var_Grad::initialize(weights_preallocated, grad_preallocated, gtrain);
-
-  if (gtrain) {
-    // If trainable, allocate optimizer parameters
-    for (auto const &dim : opt_vars_dim) {
-      opt_vars.emplace_back(dim);
-      opt_vars.back().setZero();
-    }
-  }
+void Weight::initializeWeight(const Tensor &weights_preallocated, bool gtrain) {
+  Var_Grad::initializeWeight(weights_preallocated, gtrain);
 
   Tensor &var_ref = getVariableRef();
   const TensorDim dim = var_ref.getDim();
@@ -73,9 +64,9 @@ void Weight::initialize(const Tensor &weights_preallocated,
   }
 }
 
-void Weight::initializeGrad(const Tensor &grad_preallocated, bool gtrain) {
+void Weight::initializeGrad(const Tensor &preallocated, bool gtrain) {
   // Use self variable to initialize itself
-  Var_Grad::initialize(this->getVariableRef(), grad_preallocated, gtrain);
+  Var_Grad::initializeGrad(preallocated, gtrain);
 
   if (gtrain) {
     // If trainable, allocate optimizer parameters

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -25,8 +25,16 @@ Weight::Weight(const TensorDim &dim, const WeightInitializer init, bool train,
 }
 
 void Weight::initialize(const Tensor &weights_preallocated,
-                        const Tensor &grad_preallocated) {
-  Var_Grad::initialize(weights_preallocated, grad_preallocated);
+                        const Tensor &grad_preallocated, bool gtrain) {
+  Var_Grad::initialize(weights_preallocated, grad_preallocated, gtrain);
+
+  if (gtrain) {
+    // If trainable, allocate optimizer parameters
+    for (auto const &dim : opt_vars_dim) {
+      opt_vars.emplace_back(dim);
+      opt_vars.back().setZero();
+    }
+  }
 
   Tensor &var_ref = getVariableRef();
   const TensorDim dim = var_ref.getDim();
@@ -62,6 +70,19 @@ void Weight::initialize(const Tensor &weights_preallocated,
     break;
   default:
     break;
+  }
+}
+
+void Weight::initializeGrad(const Tensor &grad_preallocated, bool gtrain) {
+  // Use self variable to initialize itself
+  Var_Grad::initialize(this->getVariableRef(), grad_preallocated, gtrain);
+
+  if (gtrain) {
+    // If trainable, allocate optimizer parameters
+    for (auto const &dim : opt_vars_dim) {
+      opt_vars.emplace_back(dim);
+      opt_vars.back().setZero();
+    }
   }
 }
 

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -24,8 +24,8 @@ Weight::Weight(const TensorDim &dim, const WeightInitializer init, bool train,
     throw std::invalid_argument("Weight initializer unknown");
 }
 
-void Weight::initializeWeight(const Tensor &weights_preallocated, bool gtrain) {
-  Var_Grad::initializeWeight(weights_preallocated, gtrain);
+void Weight::initializeWeight(const Tensor &weights_preallocated) {
+  Var_Grad::initializeWeight(weights_preallocated);
 
   Tensor &var_ref = getVariableRef();
   const TensorDim dim = var_ref.getDim();

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -82,7 +82,16 @@ public:
    * @copydoc var_grad::initialize(const Tensor &, const Tensor &)
    */
   void initialize(const Tensor &weight_preallocated = Tensor(),
-                  const Tensor &grad_preallocated = Tensor());
+                  const Tensor &grad_preallocated = Tensor(),
+                  bool gtrain = true);
+
+  /**
+   * @brief Initialize the gradient for the weight
+   * @param grad_preallocated if initialized, use this tensor for grad
+   * @param gtrain If all the variables should be trainable
+   */
+  void initializeGrad(const Tensor &grad_preallocated = Tensor(),
+                      bool gtrain = true);
 
   /**
    * @brief Swap for weight
@@ -159,16 +168,18 @@ public:
   /**
    * @brief Clear optimizer variables
    */
-  void clearOptimizerVariables() { opt_vars.clear(); }
+  void clearOptimizerVariables() {
+    opt_vars.clear();
+    opt_vars_dim.clear();
+  }
 
   /**
    * @brief Add optimizer variables
    * @param dim Optimizer variable dimension
    */
   void addOptimizerVariable(const TensorDim &dim) {
-    opt_vars.emplace_back(dim);
+    opt_vars_dim.emplace_back(dim);
     // TODO: Move this out when an optimizer does not initialize with 0.
-    opt_vars.back().setZero();
   }
 
   /**
@@ -181,7 +192,8 @@ public:
 private:
   WeightInitializer initializer; /**< initializer for this variable */
 
-  std::vector<Tensor> opt_vars; /**< optimizer variables */
+  std::vector<Tensor> opt_vars;        /**< optimizer variables */
+  std::vector<TensorDim> opt_vars_dim; /**< optimizer variables dimensions */
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -79,18 +79,15 @@ public:
     bool train = true, std::string name = "");
 
   /**
-   * @copydoc var_grad::initialize(const Tensor &, const Tensor &)
+   * @copydoc var_grad::initializeWeight(const Tensor &, bool)
    */
-  void initialize(const Tensor &weight_preallocated = Tensor(),
-                  const Tensor &grad_preallocated = Tensor(),
-                  bool gtrain = true);
+  void initializeWeight(const Tensor &preallocated = Tensor(),
+                        bool gtrain = true);
 
   /**
-   * @brief Initialize the gradient for the weight
-   * @param grad_preallocated if initialized, use this tensor for grad
-   * @param gtrain If all the variables should be trainable
+   * @copydoc var_grad::initializeGrad(const Tensor &, bool)
    */
-  void initializeGrad(const Tensor &grad_preallocated = Tensor(),
+  void initializeGrad(const Tensor &preallocated = Tensor(),
                       bool gtrain = true);
 
   /**

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -79,10 +79,9 @@ public:
     bool train = true, std::string name = "");
 
   /**
-   * @copydoc var_grad::initializeWeight(const Tensor &, bool)
+   * @copydoc var_grad::initializeWeight(const Tensor &)
    */
-  void initializeWeight(const Tensor &preallocated = Tensor(),
-                        bool gtrain = true);
+  void initializeWeight(const Tensor &preallocated = Tensor());
 
   /**
    * @copydoc var_grad::initializeGrad(const Tensor &, bool)

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -68,8 +68,7 @@ protected:
     layer.setOutputBuffers(manager.trackLayerOutputs(
       layer.getType(), layer.getName(), layer.getOutputDimension()));
 
-    manager.initializeInOuts(true);
-    manager.initialize();
+    manager.initializeTensors(true);
 
     return status;
   }
@@ -160,6 +159,7 @@ protected:
     EXPECT_EQ(status, ML_ERROR_NONE);
 
     EXPECT_NO_THROW(opt->addOptimizerVariable(layer.getWeightsRef()));
+    manager.initializeTensors(true);
 
     return status;
   }
@@ -472,15 +472,6 @@ protected:
     label =
       MAKE_SHARED_TENSOR(nntrainer::Tensor(layer.getOutputDimension()[0]));
 
-    std::vector<nntrainer::Tensor> v;
-
-    for (unsigned int i = 0; i < layer.getNumWeights(); ++i) {
-      v.push_back(layer.weightAt(i).getVariable());
-    }
-
-    loadFile("tc_fc_1_FCLayer.in", in);
-    loadFile("tc_fc_1_FCKernel.in", v);
-    loadFile("tc_fc_1_FCLabel.in", *label);
     layers.clear();
 
     return status;
@@ -506,7 +497,7 @@ protected:
       manager.trackLayerOutputs(act_layer->getType(), act_layer->getName(),
                                 act_layer->getOutputDimension()));
 
-    manager.initializeInOuts(true);
+    manager.initializeTensors(true);
     layers.push_back(act_layer);
   }
 
@@ -534,7 +525,7 @@ protected:
       manager.trackLayerOutputs(loss_layer->getType(), loss_layer->getName(),
                                 loss_layer->getOutputDimension()));
 
-    manager.initializeInOuts(true);
+    manager.initializeTensors(true);
     layers.push_back(loss_layer);
 
     if (type == nntrainer::LossType::LOSS_ENTROPY_SOFTMAX) {
@@ -546,6 +537,15 @@ protected:
   }
 
   void matchForwarding(const char *file) {
+    std::vector<nntrainer::Tensor> v;
+    for (unsigned int i = 0; i < layer.getNumWeights(); ++i) {
+      v.push_back(layer.weightAt(i).getVariable());
+    }
+
+    loadFile("tc_fc_1_FCLayer.in", in);
+    loadFile("tc_fc_1_FCKernel.in", v);
+    loadFile("tc_fc_1_FCLabel.in", *label);
+
     sharedConstTensor out;
     EXPECT_NO_THROW(out =
                       layer.forwarding_with_val({MAKE_SHARED_TENSOR(in)})[0]);
@@ -1692,7 +1692,7 @@ TEST(nntrainer_LossLayer, forward_loss_unknown_n) {
   layer.setOutputBuffers(manager.trackLayerOutputs(
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
-  manager.initializeInOuts(true);
+  manager.initializeTensors(true);
   EXPECT_THROW(
     layer.forwarding_with_val({MAKE_SHARED_TENSOR(a)}, {MAKE_SHARED_TENSOR(b)}),
     std::runtime_error);
@@ -1709,7 +1709,7 @@ TEST(nntrainer_LossLayer, backward_loss_unknown_n) {
   layer.setOutputBuffers(manager.trackLayerOutputs(
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
-  manager.initializeInOuts(true);
+  manager.initializeTensors(true);
   EXPECT_THROW(layer.backwarding_with_val({MAKE_SHARED_TENSOR(a)}),
                std::runtime_error);
 }
@@ -1727,7 +1727,7 @@ TEST(nntrainer_LossLayer, forward_loss_forward_entropy_n) {
   layer.setOutputBuffers(manager.trackLayerOutputs(
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
-  manager.initializeInOuts(true);
+  manager.initializeTensors(true);
   EXPECT_THROW(
     layer.forwarding_with_val({MAKE_SHARED_TENSOR(a)}, {MAKE_SHARED_TENSOR(b)}),
     std::runtime_error);
@@ -1745,7 +1745,7 @@ TEST(nntrainer_LossLayer, backward_loss_backward_entropy_n) {
   layer.setOutputBuffers(manager.trackLayerOutputs(
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
-  manager.initializeInOuts(true);
+  manager.initializeTensors(true);
   EXPECT_THROW(layer.backwarding_with_val({MAKE_SHARED_TENSOR(a)}),
                std::runtime_error);
 }
@@ -1843,7 +1843,7 @@ TEST(nntrainer_ActivationLayer, forward_backward_01_p) {
     layer.getType(), layer.getName(), layer.getInputDimension()));
   layer.setOutputBuffers(manager.trackLayerOutputs(
     layer.getType(), layer.getName(), layer.getOutputDimension()));
-  manager.initializeInOuts(true);
+  manager.initializeTensors(true);
 
   nntrainer::Tensor result;
   EXPECT_NO_THROW(result =
@@ -1916,7 +1916,7 @@ TEST_F(nntrainer_AdditionLayer, forwarding_01_n) {
   layer.setOutputBuffers(manager.trackLayerOutputs(
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
-  manager.initializeInOuts(true);
+  manager.initializeTensors(true);
 
   EXPECT_THROW(layer.forwarding_with_val({input}), std::invalid_argument);
 }
@@ -1941,7 +1941,7 @@ TEST_F(nntrainer_AdditionLayer, DISABLED_forwarding_02_n) {
   layer.setOutputBuffers(manager.trackLayerOutputs(
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
-  manager.initializeInOuts(true);
+  manager.initializeTensors(true);
 
   EXPECT_THROW(layer.forwarding_with_val({input}), std::runtime_error);
 }


### PR DESCRIPTION
Commit 1 : [manager] Donot allocate adam for inference 
Donot allocate adam and gradient memory for weights
when the model is being executed for inference

Commit 2 : [neuralnet] Donot set batchsize in initialize 
Donot set batch size in initialize as that allocates memory for pooling
layer. batch size is not directly set in inference/training itself.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>