### PR TITLE
[Tools] Fix bug that translayer cannot detect bn

### DIFF
--- a/test/input_gen/transLayer.py
+++ b/test/input_gen/transLayer.py
@@ -139,11 +139,12 @@ class ChannelLastTransLayer(AbstractTransLayer):
 
 CHANNEL_LAST_LAYERS = (K.layers.Conv2D, K.layers.AveragePooling2D)
 
+
 ##
 # @brief A factory function to attach translayer to existing layer
 # if nothing should be attached, it does not attach the layer
 def attach_trans_layer(layer):
-    if isinstance(layer, K.layers.BatchNormalization):
+    if isinstance(layer, (K.layers.BatchNormalization, K.layers.normalization_v2.BatchNormalization)):
         return BatchNormTransLayer(layer)
 
     if isinstance(layer, CHANNEL_LAST_LAYERS):


### PR DESCRIPTION
For batchnormalization in tf 2.3 it is not detected in transLayer, so
added new type to detect batch normalization layer

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
