### PR TITLE
[spec] add backward competibility under tizen 6

### DIFF
--- a/api/capi/capi-nntrainer.pc.in
+++ b/api/capi/capi-nntrainer.pc.in
@@ -8,5 +8,6 @@ Name: tizen-api-nntrainer
 Description: NNTrainer API for Tizen
 Version: @VERSION@
 Requires:
+# Requires: capi-ml-common
 Libs: -L${libdir} -lcapi-nntrainer
 Cflags: -I${includedir}/nntrainer

--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -1,14 +1,6 @@
 capi_inc = []
 capi_inc += include_directories('include')
 capi_inc += include_directories('..')
-
-# pc file is not present for 'ml-api-common' yet
-if cxx.has_header('nnstreamer/ml-api-common.h', required: false)
-  capi_inc += include_directories ('/usr/include/nnstreamer')
-else
-  capi_inc += include_directories ('include/platform')
-endif
-
 capi_src = []
 capi_src += meson.current_source_dir() / 'src' / 'nntrainer.cpp'
 capi_src += meson.current_source_dir() / 'src' / 'nntrainer_util.cpp'

--- a/api/ccapi/ccapi-nntrainer.pc.in
+++ b/api/ccapi/ccapi-nntrainer.pc.in
@@ -8,5 +8,6 @@ Name: ccapi-nntrainer
 Description: NNTrainer cc API
 Version: @VERSION@
 Requires:
+# Requires: capi-ml-common-devel
 Libs: -L${libdir} -lccapi-nntrainer
 Cflags: -I${includedir}/nntrainer

--- a/api/ccapi/meson.build
+++ b/api/ccapi/meson.build
@@ -2,12 +2,6 @@ ccapi_inc = []
 ccapi_inc += include_directories('include')
 ccapi_inc += include_directories('..')
 
-# pc file is not present for 'ml-api-common' yet
-if cxx.has_header('nnstreamer/ml-api-common.h', required: false)
-  ccapi_inc += include_directories ('/usr/include/nnstreamer')
-else
-  ccapi_inc += include_directories ('../capi/include/platform')
-endif
 
 ccapi_src = []
 ccapi_src += meson.current_source_dir() / 'src' / 'factory.cpp'

--- a/meson.build
+++ b/meson.build
@@ -137,7 +137,16 @@ endif
 nnstreamer_capi_dep = dependency('capi-nnstreamer', required:false)
 if nnstreamer_capi_dep.found()
   add_project_arguments('-DNNSTREAMER_AVAILABLE=1', language:['c','cpp'])
+  # accessing this variable when dep_.not_found() remains hard error on purpose
+  supported_nnstreamer_capi = nnstreamer_capi_dep.version().version_compare('>=1.7.0')
+  if not supported_nnstreamer_capi
+    add_project_arguments('-DUNSUPPORTED_NNSTREAMER=1', language:['c','cpp'])
+    warning('capi-nnstreamer version is too old, we do not know if it works with older nnstreamer version')
+  endif
 endif
+
+# todo: change this to a capi-ml-common after #nnstreamer/3014
+ml_api_common_dep = dependency('capi-nnstreamer', required:true)
 
 if get_option('enable-nnstreamer-backbone')
   add_project_arguments('-DENABLE_NNSTREAMER_BACKBONE=1', language:['c','cpp'])
@@ -172,12 +181,12 @@ if get_option('enable-app')
 endif
 
 if get_option('enable-test')
-   subdir('test')
+  subdir('test')
 endif
 
 if get_option('enable-nnstreamer-tensor-filter')
-   nnstreamer_dep = dependency('nnstreamer', required: true)
-   subdir('nnstreamer/tensor_filter')
+  nnstreamer_dep = dependency('nnstreamer', required: true)
+  subdir('nnstreamer/tensor_filter')
 endif
 
 if get_option('enable-android')

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -6,17 +6,11 @@ nntrainer_inc = [
 nntrainer_sources = []
 nntrainer_headers = ['app_context.h']
 
-# pc file is not present for 'ml-api-common' yet
-if cxx.has_header('nnstreamer/ml-api-common.h', required: false)
-  nntrainer_inc += include_directories ('/usr/include/nnstreamer')
-else
-  nntrainer_inc += include_directories ('../api/capi/include/platform')
-endif
-
 # Dependencies
 nntrainer_base_deps=[
   blas_dep,
   iniparser_dep,
+  ml_api_common_dep,
   libm_dep,
   libdl_dep,
   thread_dep

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -32,7 +32,12 @@ BuildRequires:	iniparser-devel
 BuildRequires:	gtest-devel
 BuildRequires:	python3
 BuildRequires:	python3-numpy
+
+%if 0%{tizen_version_major} >= 6
 BuildRequires:	capi-ml-common-devel
+%else
+BuildRequires:  capi-nnstreamer-devel
+%endif
 
 %if 0%{?unit_test}
 BuildRequires:	ssat >= 1.1.0
@@ -104,6 +109,7 @@ Summary:	Development package for custom nntrainer developers
 Requires:	nntrainer = %{version}-%{release}
 Requires:	iniparser-devel
 Requires:	openblas-devel
+Requires: capi-ml-common-devel
 
 %description devel
 Development package for custom nntrainer developers.
@@ -256,6 +262,12 @@ CXXFLAGS=`echo $CXXFLAGS | sed -e "s|-std=gnu++11||"`
 %if 0%{?testcoverage}
 CXXFLAGS="${CXXFLAGS} -fprofile-arcs -ftest-coverage"
 CFLAGS="${CFLAGS} -fprofile-arcs -ftest-coverage"
+%endif
+
+# Add backward competibility for tizen < 6
+%if 0%{tizen_version_major} < 6
+ln -sf %{_includedir}/nnstreamer/nnstreamer.h %{_includedir}/nnstreamer/ml-api-common.h
+ln -sf %{_libdir}/pkgconfig/capi-nnstreamer.pc %{_libdir}/pkgconfig/capi-ml-common.pc
 %endif
 
 mkdir -p build


### PR DESCRIPTION
- [meson] Clean up ml-api-common dependency
```
This patch cleans up the ml-api-common dependency.
If it is seems to be stable with multiple platform, we can remove
`api/capi/include/platform/ml-api-common.h`. let's keep it for now

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
- [spec] add backward competibility under tizen 6
```
Since `ml-error-common` redclares error enum inside nnstreamer in tizen
5.5. This patch workarounds the issue by making a fake ml-api-error.h

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```