### PR TITLE
[Tensor] rearrange methods

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -59,19 +59,6 @@
     if (tensor.uninitialized())           \
       tensor = Tensor(__VA_ARGS__);       \
   } while (0);
-
-/** do clone of this, perform the operation and return the output */
-#define CLONE_OP_I(op, ...)                        \
-  do {                                             \
-    Tensor clone = this->clone();                  \
-    if (clone.op(__VA_ARGS__) != ML_ERROR_NONE) {  \
-      std::stringstream ss;                        \
-      ss << "Error: op " << __func__ << " failed"; \
-      throw std::invalid_argument(ss.str());       \
-    }                                              \
-    return clone;                                  \
-  } while (0);
-
 namespace nntrainer {
 
 /**
@@ -238,77 +225,6 @@ Tensor &Tensor::multiply(float const &value, Tensor &out) const {
   return apply(f, out);
 }
 
-int Tensor::divide_i(float const &value) {
-  if (value == 0.0f) {
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-  this->divide(value, *this);
-  return ML_ERROR_NONE;
-}
-
-Tensor Tensor::divide(float const &value) const {
-  Tensor t;
-  return divide(value, t);
-}
-
-Tensor &Tensor::divide(float const &value, Tensor &out) const {
-  auto f = std::bind(std::divides<float>(), std::placeholders::_1, value);
-  /// @todo add unittest
-  if (value == 0.0f) {
-    std::stringstream ss;
-    ss << "[Tensor] divide by value failed, value: " << value;
-    throw std::invalid_argument(ss.str().c_str());
-  }
-  return apply(f, out);
-}
-
-int Tensor::add_i(float const &value) {
-  this->add(value, *this);
-  return ML_ERROR_NONE;
-}
-
-Tensor Tensor::add(float const &value) const {
-  Tensor t;
-  return add(value, t);
-}
-
-Tensor &Tensor::add(float const &value, Tensor &out) const {
-  /// @todo add unittest
-  auto f = std::bind(std::plus<float>(), std::placeholders::_1, value);
-  return apply(f, out);
-}
-
-int Tensor::subtract_i(float const &value) {
-  this->subtract(value, *this);
-  return ML_ERROR_NONE;
-}
-
-Tensor Tensor::subtract(float const &value) const {
-  Tensor t;
-  return subtract(value, t);
-}
-
-Tensor &Tensor::subtract(float const &value, Tensor &out) const {
-  /// @todo add unittest
-  auto f = std::bind(std::minus<float>(), std::placeholders::_1, value);
-  return apply(f, out);
-}
-
-int Tensor::pow_i(float exponent) {
-  pow(exponent, *this);
-  return ML_ERROR_NONE;
-}
-
-Tensor Tensor::pow(float exponent) const {
-  Tensor t;
-  return pow(exponent, t);
-}
-
-Tensor &Tensor::pow(float exponent, Tensor &out) const {
-  auto f = [exponent](float in) { return powf(in, exponent); };
-  return apply(f, out);
-}
-
 int Tensor::multiply_i(Tensor const &m) {
   try {
     this->multiply(m, *this);
@@ -340,6 +256,30 @@ Tensor &Tensor::multiply(Tensor const &m, Tensor &output) const {
   return output;
 }
 
+int Tensor::divide_i(float const &value) {
+  if (value == 0.0f) {
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+  this->divide(value, *this);
+  return ML_ERROR_NONE;
+}
+
+Tensor Tensor::divide(float const &value) const {
+  Tensor t;
+  return divide(value, t);
+}
+
+Tensor &Tensor::divide(float const &value, Tensor &out) const {
+  auto f = std::bind(std::divides<float>(), std::placeholders::_1, value);
+  /// @todo add unittest
+  if (value == 0.0f) {
+    std::stringstream ss;
+    ss << "[Tensor] divide by value failed, value: " << value;
+    throw std::invalid_argument(ss.str().c_str());
+  }
+  return apply(f, out);
+}
+
 int Tensor::divide_i(Tensor const &m) {
   try {
     this->divide(m, *this);
@@ -369,6 +309,22 @@ Tensor &Tensor::divide(Tensor const &m, Tensor &output) const {
 
   apply_broadcast(m, f, output);
   return output;
+}
+
+int Tensor::add_i(float const &value) {
+  this->add(value, *this);
+  return ML_ERROR_NONE;
+}
+
+Tensor Tensor::add(float const &value) const {
+  Tensor t;
+  return add(value, t);
+}
+
+Tensor &Tensor::add(float const &value, Tensor &out) const {
+  /// @todo add unittest
+  auto f = std::bind(std::plus<float>(), std::placeholders::_1, value);
+  return apply(f, out);
 }
 
 int Tensor::add_i(Tensor const &m, float const alpha) {
@@ -410,12 +366,43 @@ Tensor &Tensor::add(Tensor const &m, Tensor &out, float const alpha) const {
   return out;
 }
 
+int Tensor::subtract_i(float const &value) {
+  this->subtract(value, *this);
+  return ML_ERROR_NONE;
+}
+
+Tensor Tensor::subtract(float const &value) const {
+  Tensor t;
+  return subtract(value, t);
+}
+
+Tensor &Tensor::subtract(float const &value, Tensor &out) const {
+  /// @todo add unittest
+  auto f = std::bind(std::minus<float>(), std::placeholders::_1, value);
+  return apply(f, out);
+}
+
 int Tensor::subtract_i(Tensor const &m) { return add_i(m, -1); }
 
 Tensor Tensor::subtract(Tensor const &m) const { return add(m, -1); }
 
 Tensor &Tensor::subtract(Tensor const &m, Tensor &out) const {
   return add(m, out, -1);
+}
+
+int Tensor::pow_i(float exponent) {
+  pow(exponent, *this);
+  return ML_ERROR_NONE;
+}
+
+Tensor Tensor::pow(float exponent) const {
+  Tensor t;
+  return pow(exponent, t);
+}
+
+Tensor &Tensor::pow(float exponent, Tensor &out) const {
+  auto f = [exponent](float in) { return powf(in, exponent); };
+  return apply(f, out);
 }
 
 Tensor Tensor::getBatchSlice(unsigned int offset, unsigned int size) const {
@@ -891,7 +878,8 @@ void Tensor::reshape(const TensorDim &d) {
 
 void Tensor::fill(const Tensor &from, bool initialize) {
   if (initialize && this->uninitialized()) {
-    return this->copy(from);
+    this->copy(from);
+    return;
   }
 
   if (!from.is_contiguous || !is_contiguous) {

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -251,7 +251,7 @@ public:
    * @param[in] value multiplier
    * @retval    Calculated Tensor
    */
-  Tensor multiply(float const &value);
+  Tensor multiply(float const &value) const;
 
   /**
    * @brief     multiply value element by element
@@ -259,7 +259,29 @@ public:
    * @param[out] out out tensor to store the result
    * @retval    Calculated Tensor
    */
-  Tensor multiply(float const &value, Tensor &out) const;
+  Tensor &multiply(float const &value, Tensor &out) const;
+
+  /**
+   * @brief     Multiply Tensor Elementwise
+   * @param[in] m Tensor to be multiplied
+   * @retval    #ML_ERROR_NONE successful
+   */
+  int multiply_i(Tensor const &m);
+
+  /**
+   * @brief     Multiply Tensor Element by Element ( Not the MxM )
+   * @param[in] m Tensor to be multiplied
+   * @retval    Calculated Tensor
+   */
+  Tensor multiply(Tensor const &m) const;
+
+  /**
+   * @brief     Multiply Tensor Element by Element ( Not the MxM )
+   * @param[in] m Tensor to be multiplied
+   * @param[out] output Tensor to store the result
+   * @retval    Calculated Tensor
+   */
+  Tensor &multiply(Tensor const &m, Tensor &output) const;
 
   /**
    * @brief     Divide value element by element immediately
@@ -274,7 +296,60 @@ public:
    * @param[in] value Divisor
    * @retval    Calculated Tensor
    */
-  Tensor divide(float const &value);
+  Tensor divide(float const &value) const;
+
+  /**
+   * @brief     Divide value element by element
+   * @param[in] value Divisor
+   * @param[out] out out parameter to store the result
+   * @retval    Calculated Tensor
+   */
+  Tensor divide(float const &value, Tensor &out) const;
+
+  /**
+   * @brief     divide Tensor Elementwise
+   * @param[in] m Tensor to be multiplied
+   * @retval    #ML_ERROR_NONE successful
+   */
+  int divide_i(Tensor const &m);
+
+  /**
+   * @brief     Divide Tensor Element by Element
+   * @param[in] m Divisor Tensor
+   * @retval    Calculated Tensor
+   */
+  Tensor divide(Tensor const &m) const;
+
+  /**
+   * @brief     divide Tensor Elementwise
+   * @param[in] m Tensor to be multiplied
+   * @param[out] output Tensor to store the result
+   * @retval    Calculated Tensor
+   */
+  Tensor &divide(Tensor const &m, Tensor &output) const;
+
+  /**
+   * @brief Add Tensor Element immediately to target tensor without mem copy
+   * @param[in] value value to be added
+   * @retval #ML_ERROR_NONE  Successful
+   * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter
+   */
+  int add_i(float const &value);
+
+  /**
+   * @brief     Add value Element by Element
+   * @param[in] value value to be added
+   * @retval    Calculated Tensor
+   */
+  Tensor add(float const &value) const;
+
+  /**
+   * @brief     Add Tensor Element by Element
+   * @param[in] value value to be added
+   * @param[out] out Tensor to save output without allocating new memory
+   * @retval    Calculated Tensor
+   */
+  Tensor &add(float const &value, Tensor &out) const;
 
   /**
    * @brief Add Tensor Element by Element without mem copy
@@ -298,30 +373,30 @@ public:
    * @param[out] m Tensor to be out
    * @retval    Calculated Tensor
    */
-  Tensor add(Tensor const &m, Tensor &out, float const alpha = 1) const;
+  Tensor &add(Tensor const &m, Tensor &out, float const alpha = 1) const;
 
   /**
-   * @brief Add Tensor Element immediately to target tensor without mem copy
-   * @param[in] value value to be added
+   * @brief     memcpyless version of subtract
+   * @param[in] value value to subtract
    * @retval #ML_ERROR_NONE  Successful
    * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter
    */
-  int add_i(float const &value);
+  int subtract_i(float const &value);
 
   /**
-   * @brief     Add value Element by Element
-   * @param[in] value value to be added
+   * @brief     subtract value Element by Element
+   * @param[in] value value to be subtracted
    * @retval    Calculated Tensor
    */
-  Tensor add(float const &value);
+  Tensor subtract(float const &value) const;
 
   /**
-   * @brief     Add Tensor Element by Element
+   * @brief     Subtract Tensor Element by Element
    * @param[in] value value to be added
-   * @param[in] out Tensor to save output without allocating new memory
+   * @param[out] out Tensor to save output without allocating new memory
    * @retval    Calculated Tensor
    */
-  Tensor add(float const &value, Tensor &out) const;
+  Tensor &subtract(float const &value, Tensor &out) const;
 
   /**
    * @brief     memcpyless version of subtract
@@ -339,60 +414,35 @@ public:
   Tensor subtract(Tensor const &m) const;
 
   /**
-   * @brief     memcpyless version of subtract
-   * @param[in] value value to subtract
-   * @retval #ML_ERROR_NONE  Successful
-   * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter
-   */
-  int subtract_i(float const &value);
-
-  /**
-   * @brief     subtract value Element by Element
-   * @param[in] value value to be subtracted
+   * @brief     Subtract Tensor Element by Element
+   * @param[in] m Tensor to be added
+   * @param[out] m Tensor to be out
    * @retval    Calculated Tensor
    */
-  Tensor subtract(float const &value);
+  Tensor &subtract(Tensor const &m, Tensor &out) const;
 
   /**
-   * @brief     Multiply Tensor Elementwise
-   * @param[in] m Tensor to be multiplied
-   * @retval    #ML_ERROR_NONE successful
+   * @brief Tensor power elementwise
+   *
+   * @param exponent exponent
+   * @return int ML_ERROR_NONE if successful
    */
-  int multiply_i(Tensor const &m);
-
-  /**
-   * @brief     Multiply Tensor Element by Element ( Not the MxM )
-   * @param[in] m Tensor to be multiplied
-   * @retval    Calculated Tensor
-   */
-  Tensor multiply(Tensor const &m) const;
-
-  Tensor &multiply(Tensor const &m, Tensor &output) const;
-
-  /**
-   * @brief     divide Tensor Elementwise
-   * @param[in] m Tensor to be multiplied
-   * @retval    #ML_ERROR_NONE successful
-   */
-  int divide_i(Tensor const &m);
-
-  /**
-   * @brief     Divide Tensor Element by Element
-   * @param[in] m Divisor Tensor
-   * @retval    Calculated Tensor
-   */
-  Tensor divide(Tensor const &m) const;
-
-  Tensor &divide(Tensor const &m, Tensor &output) const;
+  int pow_i(float exponent);
 
   /**
    * @brief    Tensor power Element by Element
-   * @param[in] float Divisor Tensor
+   * @param[in] exponent exponent
    * @retval Calculated Tensor
    */
-  Tensor pow(float m) const;
+  Tensor pow(float exponent) const;
 
-  int pow_i(float m);
+  /**
+   * @brief    Tensor power Element by Element
+   * @param[in] exponent exponent
+   * @param[out] out out to store the result
+   * @retval Calculated Tensor
+   */
+  Tensor &pow(float exponent, Tensor &out) const;
 
   /**
    * @brief     Dot Product of Tensor ( equal MxM )
@@ -538,6 +588,14 @@ public:
   void setZero();
 
   /**
+   * @brief Apply instantly to the element
+   *
+   * @param f function to apply
+   * @return int ML_ERROR_NONE if successful
+   */
+  int apply_i(std::function<float(float)> f);
+
+  /**
    * @brief     Apply function element by element
    * @param[in] *function function pointer applied
    * @retval    Tensor
@@ -567,8 +625,6 @@ public:
    */
   Tensor &apply(std::function<Tensor &(Tensor, Tensor &)> f,
                 Tensor &output) const;
-
-  int apply_i(std::function<float(float)> f);
 
   /**
    * @brief     Print element


### PR DESCRIPTION
- ~**#857** [Tensor] Add outplace method for arithmetic ops~
- [Tensor/Clean] Relocate tensor methods
```
This patch rearranges arithmetic methods while adding some missing
outplace operation signature.

Order is

1. inplace -> outplace -> outplace (with allocated memory)
2. multiply -> divide -> add -> subtract
3. scalar -> tensor

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
- [Tensor] Rearrange methods 
```
- Add missing out param methods
- Change way it is delegated for some methods
- Rename s/operator_/apply_broadcast
- Assure dimension checks
- remove `operator_i` and `operator_i_util`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```