### PR TITLE
[optimization] Bug fix for in-place layer optimization

### DIFF
--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -247,7 +247,13 @@ void NodeWatcher::forward(int iteration, NodeWatcher &next_node) {
 
   std::vector<nntrainer::Tensor> out = node.layer->getOutputs();
 
-  if (next_node.node.layer->getType() != nntrainer::ActivationLayer::type)
+  /**
+   * @todo Do not veify if the layer is operting in-place by checking its
+   * property
+   */
+  if (next_node.node.layer->getType() != nntrainer::ActivationLayer::type &&
+      next_node.node.layer->getType() !=
+        nntrainer::BatchNormalizationLayer::type)
     verify(out[0], expected_output, err_msg + " at output");
 }
 


### PR DESCRIPTION
Inplace layer optimization is performed for multiple layers - activation and batch normalization layers
and this list will increase with data augmentation etc.
However, the in-place layers cannot work correctly consecutively if these layers are trainable.
They can work perfectly is they dont need to pass the derivative back.

For now, this patch limits two consecutive layers to be in-place.
This will be made generic later dependent on the trainable and inPlace property of the layer.

See also #871

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>