### PR TITLE
[Loss] Fix loss layer were allocating a new mem @open sesame 02/19 18:25

### DIFF
--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -281,11 +281,11 @@ void NodeWatcher::backward(int iteration, bool verify_deriv, bool verify_grad) {
   std::vector<nntrainer::Tensor> out = node.layer->getDerivatives();
 
   if (verify_grad) {
-    verifyGrad(err_msg);
+    verifyGrad(err_msg + " grad");
   }
 
   if (verify_deriv) {
-    verify(out[0], expected_dx, err_msg);
+    verify(out[0], expected_dx, err_msg + " deriv");
   }
 
   verifyWeight(err_msg);


### PR DESCRIPTION
- [Tensor/Clean] Relocate tensor methods
- [Tensor] rearrange methods
- [Loss] Fix loss layer were allocating a new mem
```
As allocation is managed in `manager`, layer shouldn't be allocate a new
memory that are managed by memory.
However, loss layer was allocating a new memory. This patch fixes the issue.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
Cc: Parichay Kapoor <pk.kapoor@samsung.com>
```