### PR TITLE
[tensor/manager] Fix in-place layer optimization bug

### DIFF
--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -68,17 +68,14 @@ int Conv2DLayer::initialize(Manager &manager) {
     ml_logw("Warning: the length of previous layer dimension is one");
   }
 
-  std::string kernelPrefix = "Conv2d:filter";
-  std::string biasPrefix = "Conv2d:bias";
-
   TensorDim dim =
     TensorDim(filter_size, in_dim.channel(), kernel_size[0], kernel_size[1]);
   TensorDim bias_dim = TensorDim(1, filter_size, 1, 1);
 
   if (weights.empty()) {
     weights.reserve(2);
-    weights.emplace_back(dim, weight_initializer, true, false, kernelPrefix);
-    weights.emplace_back(bias_dim, bias_initializer, true, false, biasPrefix);
+    weights.emplace_back(dim, weight_initializer, true, "Conv2d:filter");
+    weights.emplace_back(bias_dim, bias_initializer, true, "Conv2d:bias");
     manager.trackWeights(weights);
   } else {
     weights[ConvParams::weight].reset(dim, weight_initializer, true);

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -77,8 +77,8 @@ int Conv2DLayer::initialize(Manager &manager) {
 
   if (weights.empty()) {
     weights.reserve(2);
-    weights.emplace_back(dim, weight_initializer, true, kernelPrefix);
-    weights.emplace_back(bias_dim, bias_initializer, true, biasPrefix);
+    weights.emplace_back(dim, weight_initializer, true, false, kernelPrefix);
+    weights.emplace_back(bias_dim, bias_initializer, true, false, biasPrefix);
     manager.trackWeights(weights);
   } else {
     weights[ConvParams::weight].reset(dim, weight_initializer, true);

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -185,6 +185,8 @@ int NeuralNetwork::initialize() {
   model_graph.setNumNetBufferSize();
   opt->initialize();
 
+  setBatchSize();
+
   for (unsigned int idx = 0; idx < n_layers; ++idx) {
     bool first = idx == 0;
     auto &lnode = model_graph.getSortedLayerNode(idx);
@@ -257,7 +259,6 @@ int NeuralNetwork::initialize() {
       l.setInputBuffers(in_out);
     }
   }
-  setBatchSize();
 
   // Allocate and initialize weights
   manager->initializeWeights();

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -534,6 +534,8 @@ sharedConstTensors NeuralNetwork::inference(sharedConstTensors X) {
 int NeuralNetwork::assignMem(bool trainable) {
   // TODO: directly replace this
   manager->initializeTensors(trainable);
+
+  manager->allocateTensors();
   return ML_ERROR_NONE;
 }
 

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -189,7 +189,8 @@ Manager::AllocFunc Manager::getAllocFunc(bool is_weight) {
     /// this creates memory and sets to @a memory and returns AllocFunc
     auto get_allocfunc = [](const unsigned int weight_size,
                             std::unique_ptr<MMapedMemory> &memory) {
-      if (weight_size >= std::numeric_limits<unsigned int>::max() / sizeof(float)) {
+      if (weight_size >=
+          std::numeric_limits<unsigned int>::max() / sizeof(float)) {
         throw std::invalid_argument(
           "weights exceed maximum size supported for shared memory");
       }
@@ -213,7 +214,7 @@ Manager::AllocFunc Manager::getAllocFunc(bool is_weight) {
   } else if (!is_weight) {
     /** only for gradients */
     if (max_grad_size > 0 && enable_gradient_memory_opt) {
-      shared_grad = Tensor(TensorDim({(unsigned int)max_grad_size}), nullptr, false);
+      shared_grad = Tensor({(unsigned int)max_grad_size}, nullptr, false);
 
       allocate_func = [this](const TensorDim &dim, unsigned int offset) {
         return shared_grad.getSharedDataTensor(dim, offset);
@@ -436,7 +437,7 @@ void Manager::initializeTensors(bool trainable) {
 
   // Allocate shared derivative memory
   if (max_derivative_size > 0 && enable_activation_memory_opt && trainable)
-    shared_deriv = Tensor(TensorDim({max_derivative_size}), nullptr, false);
+    shared_deriv = Tensor({max_derivative_size}, nullptr, false);
 
   // @todo Do not count memory of the input tensor of the input layer in the
   // estimate of max_shared_inout as it is not used
@@ -444,7 +445,7 @@ void Manager::initializeTensors(bool trainable) {
   // Allocate shared input/output memory for inference
   // @note Memory for label is not allocated here as inference doesnt has label
   if (!trainable && enable_inference_inout_memory_opt)
-    shared_inout = Tensor(TensorDim({max_shared_inout}), nullptr, false);
+    shared_inout = Tensor({max_shared_inout}, nullptr, false);
 
   /**
    * A single buffer (shared_inout) provides memory for inputs and outputs of a

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -246,7 +246,7 @@ void Manager::initializeWeights() {
       Tensor grad_prealloc = Tensor();
 
       weight_offset += dim.getDataLen();
-      weight.initializeWeight(weight_prealloc);
+      weight.initializeVariable(weight_prealloc);
     }
   }
 
@@ -300,7 +300,7 @@ void Manager::initializeGradients() {
         grad_prealloc = allocate_grad(dim, grad_offset);
         grad_offset += dim.getDataLen();
       }
-      weight.initializeGrad(grad_prealloc, true);
+      weight.initializeGradient(grad_prealloc, true);
     }
   }
 }

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -214,7 +214,7 @@ Manager::AllocFunc Manager::getAllocFunc(bool is_weight) {
   } else if (!is_weight) {
     /** only for gradients */
     if (max_grad_size > 0 && enable_gradient_memory_opt) {
-      shared_grad = Tensor({(unsigned int)max_grad_size}, nullptr, false);
+      shared_grad = Tensor(TensorDim({max_grad_size}), false);
 
       allocate_func = [this](const TensorDim &dim, unsigned int offset) {
         return shared_grad.getSharedDataTensor(dim, offset);
@@ -437,7 +437,7 @@ void Manager::initializeTensors(bool trainable) {
 
   // Allocate shared derivative memory
   if (max_derivative_size > 0 && enable_activation_memory_opt && trainable)
-    shared_deriv = Tensor({max_derivative_size}, nullptr, false);
+    shared_deriv = Tensor(TensorDim({max_derivative_size}), false);
 
   // @todo Do not count memory of the input tensor of the input layer in the
   // estimate of max_shared_inout as it is not used
@@ -445,7 +445,7 @@ void Manager::initializeTensors(bool trainable) {
   // Allocate shared input/output memory for inference
   // @note Memory for label is not allocated here as inference doesnt has label
   if (!trainable && enable_inference_inout_memory_opt)
-    shared_inout = Tensor({max_shared_inout}, nullptr, false);
+    shared_inout = Tensor(TensorDim({max_shared_inout}), false);
 
   /**
    * A single buffer (shared_inout) provides memory for inputs and outputs of a

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -245,22 +245,55 @@ public:
         vg->setBatchSize(batch);
   }
 
+  /**
+   * @brief Allocate memory for all the managed tensors
+   */
+  void allocateTensors() {
+    allocateWeights();
+    allocateGradients();
+    allocateInOuts();
+    allocateDerivatives();
+  }
+
+  /**
+   * @brief Allocate memory for all the managed weights
+   */
+  void allocateWeights();
+
+  /**
+   * @brief Allocate memory for all the managed gradients
+   */
+  void allocateGradients();
+
+  /**
+   * @brief Allocate memory for all the managed layers inputs and outputs
+   */
+  void allocateInOuts();
+
+  /**
+   * @brief Allocate memory for all the managed layer derivatives
+   */
+  void allocateDerivatives();
+
 private:
   // TODO: ensure that names of these weights are unique
   /**< Weights of all the layer in the model to be managed */
   std::vector<std::vector<std::reference_wrapper<Weight>>> weights;
 
-  size_t total_weight_size;   /**< total weight size */
-  size_t total_grad_size;     /**< total weight size */
-  size_t max_grad_size;       /**< max trainable weight required by a layer */
-  size_t max_derivative_size; /**< max derivative required by a layer */
-  size_t max_shared_inout;    /**< max memory for in/outs for inference */
+  unsigned int total_weight_size;   /**< total weight size */
+  unsigned int total_grad_size;     /**< total weight size */
+  unsigned int max_grad_size;       /**< max trainable weight required by a layer */
+  unsigned int max_derivative_size; /**< max derivative required by a layer */
+  unsigned int max_shared_inout;    /**< max memory for in/outs for inference */
   bool weights_initialized;   /**< track if weights have been initialized */
 
   /**< Inputs/outputs of all the layer in the model */
   std::vector<std::vector<std::shared_ptr<Var_Grad>>> in_outs;
   std::vector<bool> is_act_type;
   std::vector<bool> is_flat_type;
+  Tensor shared_grad;   /**< Shared tensor containing memory for weight gradients */
+  Tensor shared_inout;  /**< Shared tensor containing memory for input and outputs for inference */
+  Tensor shared_deriv;  /**< Shared tensor containing memory for input and output derivatives */
 
   /**< Optimization related */
   bool enable_gradient_memory_opt; /**< share memory among all the gradients */
@@ -279,7 +312,8 @@ private:
   std::unique_ptr<MMapedMemory> weight_mmaped_memory;
   std::unique_ptr<MMapedMemory> grad_mmaped_memory;
 
-  using AllocFunc = std::function<Tensor(const TensorDim &, size_t)>;
+  /** Alloc function definition */
+  using AllocFunc = std::function<Tensor(const TensorDim &, unsigned int)>;
 
   /**
    * @brief Track the inputs/ouputs of the layer

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -249,7 +249,9 @@ public:
    * @brief Allocate memory for all the managed tensors
    */
   void allocateTensors() {
-    allocateWeights();
+    /// Weights are allocated while initializing
+    if (!weights_initialized)
+      allocateWeights();
     allocateGradients();
     allocateInOuts();
     allocateDerivatives();
@@ -280,20 +282,23 @@ private:
   /**< Weights of all the layer in the model to be managed */
   std::vector<std::vector<std::reference_wrapper<Weight>>> weights;
 
-  unsigned int total_weight_size;   /**< total weight size */
-  unsigned int total_grad_size;     /**< total weight size */
-  unsigned int max_grad_size;       /**< max trainable weight required by a layer */
+  unsigned int total_weight_size; /**< total weight size */
+  unsigned int total_grad_size;   /**< total weight size */
+  unsigned int max_grad_size; /**< max trainable weight required by a layer */
   unsigned int max_derivative_size; /**< max derivative required by a layer */
   unsigned int max_shared_inout;    /**< max memory for in/outs for inference */
-  bool weights_initialized;   /**< track if weights have been initialized */
+  bool weights_initialized; /**< track if weights have been initialized */
 
   /**< Inputs/outputs of all the layer in the model */
   std::vector<std::vector<std::shared_ptr<Var_Grad>>> in_outs;
   std::vector<bool> is_act_type;
   std::vector<bool> is_flat_type;
-  Tensor shared_grad;   /**< Shared tensor containing memory for weight gradients */
-  Tensor shared_inout;  /**< Shared tensor containing memory for input and outputs for inference */
-  Tensor shared_deriv;  /**< Shared tensor containing memory for input and output derivatives */
+  Tensor
+    shared_grad; /**< Shared tensor containing memory for weight gradients */
+  Tensor shared_inout; /**< Shared tensor containing memory for input and
+                          outputs for inference */
+  Tensor shared_deriv; /**< Shared tensor containing memory for input and output
+                          derivatives */
 
   /**< Optimization related */
   bool enable_gradient_memory_opt; /**< share memory among all the gradients */

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -472,6 +472,17 @@ Tensor Tensor::getBatchSlice(unsigned int offset, unsigned int size) const {
 
 void Tensor::createSharedDataTensor(const Tensor &src, Tensor &dest,
                                     unsigned int offset) {
+  /**
+   * - If src already has data allocaed, then directly make dest tensor based on
+   * the src tensor.
+   * - If src.data does not exist (meaning tensor does not memory allocated),
+   * and src.src_tensor does not exist (meaning the src tensor does not depened
+   * on another tensor), then create a SrcSharedTensor around the src.
+   * - If src.src_tensor exists, then use the src.src_tensor to create the
+   *  required SrcSharedTensor to avoid recursive dependency.
+   *
+   * @note src.data and src.src_tensor cannot co-exist.
+   */
   if (src.data)
     dest.data = std::shared_ptr<float>(src.data, src.data.get() + offset);
   else if (!src.src_tensor)

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -89,22 +89,21 @@ static auto rng = [] {
   return rng;
 }();
 
-Tensor::Tensor(const TensorDim &d, const float *buf, bool alloc_now) :
-  Tensor() {
+Tensor::Tensor(const TensorDim &d, const float *buf) : Tensor() {
   if (d.getDataLen() != 0) {
-    if (buf != nullptr && !alloc_now)
-      throw std::invalid_argument(
-        "alloc_now must be true to create a tensor with a buffer");
-
     dim = d;
     strides = d.computeStrides();
 
-    if (alloc_now)
-      allocate();
+    allocate();
 
     if (buf != nullptr)
       copy(buf);
   }
+}
+
+Tensor::Tensor(const TensorDim &d, bool alloc_now) : Tensor(d, nullptr) {
+  if (d.getDataLen() != 0 && alloc_now)
+    allocate();
 }
 
 /**

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -497,6 +497,25 @@ Tensor Tensor::getSharedDataTensor(const TensorDim dim_,
   return ret;
 }
 
+void Tensor::makeSharedDataTensor(const Tensor &src, unsigned int offset) {
+  if (strides != src.strides)
+    throw std::invalid_argument(
+      "Creating shared tensor of different stride than source tensor.");
+
+  if (getDim().getDataLen() + offset > src.getDim().getDataLen())
+    throw std::invalid_argument(
+      "Creating shared tensor of different size or stride than source tensor.");
+
+  /**
+   * In this case, its the caller's responsibility to ensure that allocate() is
+   * called for this function before operating on this tensor.
+   */
+  if (src.data)
+    data = std::shared_ptr<float>(src.data, src.data.get() + offset);
+  else
+    src_tensor = std::make_shared<SrcSharedTensor>(&src, offset);
+}
+
 void Tensor::apply_broadcast(
   Tensor const &m,
   std::function<void(const BroadcastInfo &e, const float *, const float *,

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -209,7 +209,7 @@ public:
   /**
    * @brief    Check if the tensor has memory allocated/assigned/associated
    */
-  bool isAllocated() const { return data == nullptr; }
+  bool isAllocated() const { return data != nullptr; }
 
   /**
    * @brief     return value at specific location
@@ -949,6 +949,20 @@ private:
   template <typename T> void setDist(T dist);
 
   void copy(const float *buf) noexcept;
+
+  /**
+   * @brief Update destination tensor to share memory with source tensor
+   *
+   * @param src src tensor containing the memory
+   * @param dest destination tensor which will share the memory
+   * @param offset offset to be used from the start of the data in bytes
+   * @note The new tensor will share the same data as the current tensor but
+   * can have different size.
+   * @note New size added with offset must be less than the size of the original
+   * tensor.
+   */
+  static void createSharedDataTensor(const Tensor &src, Tensor &dest,
+                                     unsigned int offset);
 }; // namespace nntrainer
 
 /**

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -729,11 +729,24 @@ public:
    * @param dim new dimension to be set for this tensor
    * @param offset offset to be used from the start of the data in bytes
    * @note The new tensor will share the same data as the current tensor but
-   * will have different size.
+   * can have different size.
    * @note New size added with offset must be less than the size of the original
    * tensor.
    */
   Tensor getSharedDataTensor(const TensorDim dim, unsigned int offset) const;
+
+  /**
+   * @brief make this tensor share memory with given tensor
+   *
+   * @param src Source tensor whose memory is to be shared
+   * @param offset offset to be used from the start of the data in bytes
+   * @note This tensor will share the same data as the current tensor but
+   * can have different size.
+   * @note This tensor's size added with offset must be less than the size of
+   * the source tensor.
+   * @note The stride of the source tensor and this tensor must be same.
+   */
+  void makeSharedDataTensor(const Tensor &src, unsigned int offset = 0);
 
   /**
    * @brief     Convient wrapper for inplace copy of @a this.

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -64,11 +64,17 @@ public:
   /**
    * @brief     Constructor of Tensor with dimension/buf
    * @param d Tensor dim for this tensor
-   * @param bug buffer
-   * @alloc_now If the memory of the tensor must be allocated
-   * @throws if buf is not null and allow_now is false
+   * @param buf buffer
+   * @note Memory for this tensor is instantaneously allocated
    */
-  Tensor(const TensorDim &d, const float *buf = nullptr, bool alloc_now = true);
+  Tensor(const TensorDim &d, const float *buf = nullptr);
+
+  /**
+   * @brief     Constructor of Tensor with dimension, possibly lazily
+   * @param d Tensor dim for this tensor
+   * @param alloc_now If the memory of the tensor must be allocated
+   */
+  Tensor(const TensorDim &d, bool alloc_now);
 
   /**
    * @brief Construct a new Tensor object from a buffer
@@ -105,7 +111,8 @@ public:
    * @param[in] height Height of Tensor
    * @param[in] width Width of Tensor
    */
-  Tensor(int batch, int channel, int height, int width) :
+  Tensor(unsigned int batch, unsigned int channel, unsigned int height,
+         unsigned int width) :
     Tensor(TensorDim(batch, channel, height, width)){};
 
   /**
@@ -114,7 +121,7 @@ public:
    * @param[in] height Height of Tensor
    * @param[in] width Width of Tensor
    */
-  Tensor(int channel, int height, int width) :
+  Tensor(unsigned int channel, unsigned int height, unsigned int width) :
     Tensor(1, channel, height, width){};
 
   /**
@@ -122,13 +129,14 @@ public:
    * @param[in] height Height of Tensor
    * @param[in] width Width of Tensor
    */
-  Tensor(int height, int width) : Tensor(1, 1, height, width){};
+  Tensor(unsigned int height, unsigned int width) :
+    Tensor(1, 1, height, width){};
 
   /**
    * @brief     Constructor of Tensor with just width
    * @param[in] width Width of Tensor
    */
-  explicit Tensor(int width) : Tensor(1, 1, 1, width){};
+  explicit Tensor(unsigned int width) : Tensor(1, 1, 1, width){};
 
   /**
    * @brief     Constructor of Tensor

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -16,13 +16,17 @@
 
 namespace nntrainer {
 
-Var_Grad::Var_Grad(const TensorDim &dim, bool train, bool alloc_now_, const std::string &name) :
+Var_Grad::Var_Grad(const TensorDim &dim, bool train, bool alloc_now_,
+                   const std::string &name) :
   dim(dim),
   trainable(train),
   alloc_now(alloc_now_),
   name(name) {
   var = std::make_shared<Tensor>(dim, nullptr, alloc_now);
-  grad = std::make_shared<Tensor>(dim, nullptr, alloc_now);
+  if (trainable)
+    grad = std::make_shared<Tensor>(dim, nullptr, alloc_now);
+  else
+    grad = std::make_shared<Tensor>();
 }
 
 void Var_Grad::initializeWeight(const Tensor &preallocated) {
@@ -38,18 +42,12 @@ void Var_Grad::initializeGrad(const Tensor &preallocated, bool gtrain) {
      * with other layers but the internal memory is.
      */
     grad->makeSharedDataTensor(preallocated);
-  } else {
-    grad = std::make_shared<Tensor>();
-    if (trainable && gtrain) {
-      grad = std::make_shared<Tensor>(dim, nullptr, alloc_now);
-    }
-    resetGradient();
   }
+  if (alloc_now)
+    resetGradient();
 }
 
-void Var_Grad::initializeShared() {
-  grad->makeSharedDataTensor(*var.get());
-}
+void Var_Grad::initializeShared() { grad->makeSharedDataTensor(*var.get()); }
 
 void Var_Grad::setTrainable(bool train) {
   trainable = train;

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -22,9 +22,9 @@ Var_Grad::Var_Grad(const TensorDim &dim, bool train, bool alloc_now_,
   trainable(train),
   alloc_now(alloc_now_),
   name(name) {
-  var = std::make_shared<Tensor>(dim, nullptr, alloc_now);
+  var = std::make_shared<Tensor>(dim, alloc_now);
   if (trainable)
-    grad = std::make_shared<Tensor>(dim, nullptr, alloc_now);
+    grad = std::make_shared<Tensor>(dim, alloc_now);
   else
     grad = std::make_shared<Tensor>();
 }
@@ -53,7 +53,7 @@ void Var_Grad::setTrainable(bool train) {
   trainable = train;
   if (trainable && grad->uninitialized()) {
     bool alloc_now_ = var->isAllocated();
-    grad = std::make_shared<Tensor>(var->getDim(), nullptr, alloc_now_);
+    grad = std::make_shared<Tensor>(var->getDim(), alloc_now_);
   }
 }
 

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -29,13 +29,13 @@ Var_Grad::Var_Grad(const TensorDim &dim, bool train, bool alloc_now_,
     grad = std::make_shared<Tensor>();
 }
 
-void Var_Grad::initializeWeight(const Tensor &preallocated) {
+void Var_Grad::initializeVariable(const Tensor &preallocated) {
   if (!preallocated.uninitialized()) {
     var->makeSharedDataTensor(preallocated);
   }
 }
 
-void Var_Grad::initializeGrad(const Tensor &preallocated, bool gtrain) {
+void Var_Grad::initializeGradient(const Tensor &preallocated, bool gtrain) {
   if (!preallocated.uninitialized() && gtrain) {
     /**
      * Making a new tensor is intentional here as this tensor is not shared

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -93,30 +93,30 @@ public:
   /**
    * @brief Allocate and initialize the weight variable
    *
-   * @param weight_preallocated if initialized, use this tensor for weight
+   * @param var_preallocated if initialized, use this tensor for var
    * @param grad_preallocated if initialized, use this tensor for grad
    * @param gtrain If all the variables should be trainable
    */
-  virtual void initialize(const Tensor &weight_preallocated = Tensor(),
+  virtual void initialize(const Tensor &var_preallocated = Tensor(),
                           const Tensor &grad_preallocated = Tensor(),
                           bool gtrain = true) {
-    initializeWeight(weight_preallocated);
-    initializeGrad(grad_preallocated, gtrain);
+    initializeVariable(var_preallocated);
+    initializeGradient(grad_preallocated, gtrain);
   }
 
   /**
-   * @brief Initialize the variable for the weight
+   * @brief Initialize the variable
    * @param preallocated if initialized, use this tensor for variable memory
    */
-  virtual void initializeWeight(const Tensor &preallocated = Tensor());
+  virtual void initializeVariable(const Tensor &preallocated = Tensor());
 
   /**
-   * @brief Initialize the gradient for the weight
+   * @brief Initialize the gradient for the variable
    * @param preallocated if initialized, use this tensor for gradient memory
    * @param gtrain If all the variables should be trainable
    */
-  virtual void initializeGrad(const Tensor &preallocated = Tensor(),
-                              bool gtrain = true);
+  virtual void initializeGradient(const Tensor &preallocated = Tensor(),
+                                  bool gtrain = true);
 
   /**
    * @brief Allocate and initialize the variable and grad
@@ -167,9 +167,7 @@ public:
   Tensor getGradient() const { return *grad.get(); }
 
   /**
-   * @brief Allocate and initialize the weight variable
-   *
-   * @param dim Dimension for the weight variable
+   * @brief Reset the gradient to 0
    */
   void resetGradient() { grad->setZero(); }
 
@@ -187,7 +185,7 @@ public:
   };
 
   /**
-   * @brief Reset the weight
+   * @brief Reset the variable and gradient
    *
    * @param dim Variable and gradient tensor dimension
    * @param train If the variable is trainable
@@ -255,10 +253,28 @@ public:
     resetGradient();
   }
 
+  /**
+   * @bried Update the variable to use the given tensor
+   * @param t Tensor to update with
+   */
   void updateVariable(Tensor &t) { var = std::shared_ptr<Tensor>(&t); }
+
+  /**
+   * @bried Update the gradient to use the given tensor
+   * @param t Tensor to update with
+   */
   void updateGradient(Tensor &t) { grad = std::shared_ptr<Tensor>(&t); }
 
+  /**
+   * @bried Update the variable to use the variable from the given param
+   * @param vg Var_Grad whose variable must be updated with
+   */
   void updateVariableByVariable(const Var_Grad &vg) { var = vg.var; }
+
+  /**
+   * @bried Update the gradient to use the variable from the given param
+   * @param vg Var_Grad whose variable must be updated with
+   */
   void updateGradientByVariable(const Var_Grad &vg) { grad = vg.var; }
 
 protected:

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -43,7 +43,7 @@ public:
    * @param train If the variable is trainable
    * @param name Name for this Var_Grad
    */
-  Var_Grad(const TensorDim &dim, bool train = true,
+  Var_Grad(const TensorDim &dim, bool train = true, bool alloc_now = true,
            const std::string &name = "");
 
   /**
@@ -242,11 +242,22 @@ public:
    */
   const Tensor &getGradientRef() const { return *grad.get(); }
 
+  /**
+   * @brief Allocate memory for the variable
+   */
+  void allocateVariable() { var->allocate(); }
+
+  /**
+   * @brief Allocate memory for the variable
+   */
+  void allocateGradient() { grad->allocate(); }
+
 protected:
   TensorDim dim;                /**< dimension of the tensor */
   std::shared_ptr<Tensor> var;  /**< variable to be updated and used */
   std::shared_ptr<Tensor> grad; /**< gradient for the variable */
   bool trainable;               /**< if this variable is trainable */
+  bool alloc_now;               /**< if the tensor should be allocated instantly */
   std::string name;             /**< name of the parameter */
 };
 

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -250,15 +250,24 @@ public:
   /**
    * @brief Allocate memory for the variable
    */
-  void allocateGradient() { grad->allocate(); }
+  void allocateGradient() {
+    grad->allocate();
+    resetGradient();
+  }
+
+  void updateVariable(Tensor &t) { var = std::shared_ptr<Tensor>(&t); }
+  void updateGradient(Tensor &t) { grad = std::shared_ptr<Tensor>(&t); }
+
+  void updateVariableByVariable(const Var_Grad &vg) { var = vg.var; }
+  void updateGradientByVariable(const Var_Grad &vg) { grad = vg.var; }
 
 protected:
   TensorDim dim;                /**< dimension of the tensor */
   std::shared_ptr<Tensor> var;  /**< variable to be updated and used */
   std::shared_ptr<Tensor> grad; /**< gradient for the variable */
   bool trainable;               /**< if this variable is trainable */
-  bool alloc_now;               /**< if the tensor should be allocated instantly */
-  std::string name;             /**< name of the parameter */
+  bool alloc_now;   /**< if the tensor should be allocated instantly */
+  std::string name; /**< name of the parameter */
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -24,14 +24,14 @@ Weight::Weight(const TensorDim &dim, const WeightInitializer init, bool train,
     throw std::invalid_argument("Weight initializer unknown");
 }
 
-void Weight::initializeWeight(const Tensor &weights_preallocated) {
-  Var_Grad::initializeWeight(weights_preallocated);
+void Weight::initializeVariable(const Tensor &preallocated) {
+  Var_Grad::initializeVariable(preallocated);
 
   if (alloc_now)
-    initializeVariable();
+    runVariableInitializer();
 }
 
-void Weight::initializeVariable() {
+void Weight::runVariableInitializer() {
   Tensor &var_ref = getVariableRef();
   const TensorDim dim = var_ref.getDim();
 
@@ -69,9 +69,9 @@ void Weight::initializeVariable() {
   }
 }
 
-void Weight::initializeGrad(const Tensor &preallocated, bool gtrain) {
+void Weight::initializeGradient(const Tensor &preallocated, bool gtrain) {
   // Use self variable to initialize itself
-  Var_Grad::initializeGrad(preallocated, gtrain);
+  Var_Grad::initializeGradient(preallocated, gtrain);
   if (gtrain && alloc_now)
     allocateOptimizerVariables();
 }

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -28,7 +28,7 @@ void Weight::initializeWeight(const Tensor &weights_preallocated) {
   Var_Grad::initializeWeight(weights_preallocated);
 
   if (alloc_now)
-    initializeWeight();
+    initializeVariable();
 }
 
 void Weight::initializeVariable() {

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -79,15 +79,15 @@ public:
     bool train = true, bool alloc_now = true, std::string name = "");
 
   /**
-   * @copydoc var_grad::initializeWeight(const Tensor &)
+   * @copydoc var_grad::initializeVariable(const Tensor &)
    */
-  void initializeWeight(const Tensor &preallocated = Tensor());
+  void initializeVariable(const Tensor &preallocated = Tensor());
 
   /**
-   * @copydoc var_grad::initializeGrad(const Tensor &, bool)
+   * @copydoc var_grad::initializeGradient(const Tensor &, bool)
    */
-  void initializeGrad(const Tensor &preallocated = Tensor(),
-                      bool gtrain = true);
+  void initializeGradient(const Tensor &preallocated = Tensor(),
+                          bool gtrain = true);
 
   /**
    * @brief Swap for weight
@@ -211,7 +211,7 @@ private:
   /**
    * @brief Initialize the weight with the initializer
    */
-  void initializeVariable();
+  void runVariableInitializer();
 
   /**
    * @brief Allocate optimizer related variables for the given weights

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -76,7 +76,7 @@ public:
   Weight(
     const TensorDim &dim,
     const WeightInitializer init = WeightInitializer::WEIGHT_XAVIER_UNIFORM,
-    bool train = true, std::string name = "");
+    bool train = true, bool alloc_now = true, std::string name = "");
 
   /**
    * @copydoc var_grad::initializeWeight(const Tensor &)
@@ -185,11 +185,38 @@ public:
    */
   Tensor &getOptimizerVariableRef(unsigned int idx) { return opt_vars[idx]; }
 
+  /**
+   * @brief Allocate and initialize the weight variable, if needed
+   */
+  void allocateVariable() {
+    Var_Grad::allocateVariable();
+    initializeVariable();
+  }
+
+  /**
+   * @brief Allocate and initialize the weight gradient, if needed
+   */
+  void allocateGradient() {
+    Var_Grad::allocateGradient();
+    resetGradient();
+    allocateOptimizerVariables();
+  }
+
 private:
   WeightInitializer initializer; /**< initializer for this variable */
 
   std::vector<Tensor> opt_vars;        /**< optimizer variables */
   std::vector<TensorDim> opt_vars_dim; /**< optimizer variables dimensions */
+
+  /**
+   * @brief Initialize the weight with the initializer
+   */
+  void initializeVariable();
+
+  /**
+   * @brief Allocate optimizer related variables for the given weights
+   */
+  void allocateOptimizerVariables();
 };
 
 } // namespace nntrainer

--- a/test/nnstreamer_filter_nntrainer/runTest.sh
+++ b/test/nnstreamer_filter_nntrainer/runTest.sh
@@ -72,14 +72,14 @@ else
 fi
 
 # Test with mnist model
-PATH_TO_CONFIG="../test_models/models/mnist.ini"
+PATH_TO_CONFIG="../test_models/models/mnist_inf.ini"
 PATH_TO_DATA="../test_models/data/2.png"
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_DATA} ! pngdec ! tensor_converter ! other/tensor,dimension=1:28:28:1 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_transform mode=typecast option=float32 ! tensor_filter framework=nntrainer model=${PATH_TO_CONFIG} input=28:28:1:1 inputtype=float32 output=10 outputtype=float32 ! filesink location=nntrainer.out.1.log" 1 0 0 $PERFORMANCE
 python checkLabel.py nntrainer.out.1.log 2
 testResult $? 1 "Golden test comparison" 0 1
 
-PATH_TO_CONFIG="../test_models/models/mnist.ini"
+PATH_TO_CONFIG="../test_models/models/mnist_inf.ini"
 PATH_TO_DATA="../test_models/data/0.png"
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_DATA} ! pngdec ! tensor_converter ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_transform mode=typecast option=float32 ! tensor_filter framework=nntrainer model=${PATH_TO_CONFIG} input=28:28:1:1 inputtype=float32 output=10:1:1:1 outputtype=float32 ! filesink location=nntrainer.out.2.log" 1 0 0 $PERFORMANCE

--- a/test/test_models/models/mnist_inf.ini
+++ b/test/test_models/models/mnist_inf.ini
@@ -1,0 +1,11 @@
+# Network Section : Network
+[Model]
+Type = NeuralNetwork	# Network Type : Regression, KNN, NeuralNetwork
+Optimizer = adam 	# adam (Adamtive Moment Estimation)
+Loss = cross  		# Loss function : mse (mean squared error)
+Save_Path = "../test_models/models/model.bin"  	# model path to save / read
+batch_size = 1		# batch size
+
+[mnist]
+backbone = "../test_models/models/mnist.ini"
+Input_Shape = 1:28:28

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -71,6 +71,7 @@ protected:
       layer.getType(), layer.getName(), layer.getOutputDimension()));
 
     manager.initializeTensors(true);
+    manager.allocateTensors();
 
     return status;
   }
@@ -162,6 +163,7 @@ protected:
 
     EXPECT_NO_THROW(opt->addOptimizerVariable(layer.getWeightsRef()));
     manager.initializeTensors(true);
+    manager.allocateTensors();
 
     return status;
   }
@@ -716,6 +718,7 @@ protected:
                                 act_layer->getOutputDimension()));
 
     manager.initializeTensors(true);
+    manager.allocateTensors();
     layers.push_back(act_layer);
   }
 
@@ -743,6 +746,7 @@ protected:
                                 loss_layer->getOutputDimension()));
 
     manager.initializeTensors(true);
+    manager.allocateTensors();
     layers.push_back(loss_layer);
 
     if (type == nntrainer::LossType::LOSS_ENTROPY_SOFTMAX) {
@@ -1916,6 +1920,7 @@ TEST(nntrainer_LossLayer, forward_loss_unknown_n) {
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
   manager.initializeTensors(true);
+  manager.allocateTensors();
   EXPECT_THROW(
     layer.forwarding_with_val({MAKE_SHARED_TENSOR(a)}, {MAKE_SHARED_TENSOR(b)}),
     std::runtime_error);
@@ -1933,6 +1938,7 @@ TEST(nntrainer_LossLayer, backward_loss_unknown_n) {
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
   manager.initializeTensors(true);
+  manager.allocateTensors();
   EXPECT_THROW(layer.backwarding_with_val({MAKE_SHARED_TENSOR(a)}),
                std::runtime_error);
 }
@@ -1951,6 +1957,7 @@ TEST(nntrainer_LossLayer, forward_loss_forward_entropy_n) {
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
   manager.initializeTensors(true);
+  manager.allocateTensors();
   EXPECT_THROW(
     layer.forwarding_with_val({MAKE_SHARED_TENSOR(a)}, {MAKE_SHARED_TENSOR(b)}),
     std::runtime_error);
@@ -1969,6 +1976,7 @@ TEST(nntrainer_LossLayer, backward_loss_backward_entropy_n) {
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
   manager.initializeTensors(true);
+  manager.allocateTensors();
   EXPECT_THROW(layer.backwarding_with_val({MAKE_SHARED_TENSOR(a)}),
                std::runtime_error);
 }
@@ -2067,6 +2075,7 @@ TEST(nntrainer_ActivationLayer, forward_backward_01_p) {
   layer.setOutputBuffers(manager.trackLayerOutputs(
     layer.getType(), layer.getName(), layer.getOutputDimension()));
   manager.initializeTensors(true);
+  manager.allocateTensors();
 
   nntrainer::Tensor result;
   EXPECT_NO_THROW(result =
@@ -2144,6 +2153,7 @@ TEST_F(nntrainer_AdditionLayer, DISABLED_forwarding_02_n) {
     layer.getType(), layer.getName(), layer.getOutputDimension()));
 
   manager.initializeTensors(true);
+  manager.allocateTensors();
 
   EXPECT_THROW(layer.forwarding_with_val({input}), std::runtime_error);
 }


### PR DESCRIPTION
**Commit 1**: [tensor] Support late memory allocation for tensors
Support late memory allocation for tensors.
This helps create tensor wrapper elements and allocate memory
later when needed.
This allows finalizing the graph, creating all the tensors and graph
connections for all the layers which can be stored in offline setup
and then loaded directly from file.

This decoupling allows reusing tensors with every call to train
where we can allocate and deallocate memory without having to create
and do tensor management again and again.

In short term, this is necessary for in-place layer optimization.
See Also #879

The implementation requires caching the source tensor when creating
shared tensors as shared tensors cannot be created unless the source
tensor memory has been allocated.

**Commit 2**: In-place bug fix 
This patch applied bug fix for in-place layer optimization.
As in-place layers and other layers manages derivative memory
differently, in-place layers cannot directly re-use the tensors
of their neighboring layers. But rather have to use tensors differently.
This patch applies this bug-fix.
See also #878

**Commit 3:** [Manager] Support lazy memory allocation with manager
Support lazy memory allocation with manager

**Commit 4:** [bug fixes] Update shared mem and in-place opt
Update shared memory and in-place opt to share memory with previous
layers with different strategies based on the type of optimization the
layer is doing for reducing its memory usage.

Added weight and var_grad to create weight/var_grad with lazy
memory allocation.
Update SrcSharedTensor to remove the check is source is allocated
as it cannot be guaranteed.
Bug fix for tensor is allocated

Update nntrainer extension for nnstreamer to use a different
ini file for inference which does not require changing batch size.
Added minor bug fixes to the patch

**Commit 5:** [tensor] Split tensor constructor into 2    
Create a new tensor constructor for lazy allocation
    than adding the lazy allocation feature to the existing one


Resolves #878
See also #876

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>