### PR TITLE
License Fix / Relicense to Apache-2.0

### DIFF
--- a/api/capi/include/platform/ml-api-common.h
+++ b/api/capi/include/platform/ml-api-common.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-only */
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * NNStreamer API / Tizen Machine-Learning API Common Header
  * Copyright (C) 2020 MyungJoo Ham <myungjoo.ham@samsung.com>
@@ -6,7 +6,7 @@
 /**
  * @file	ml-api-common.h
  * @date	07 May 2020
- * @brief	Dummy ML-API Common Header from nnstreamer
+ * @brief	Dummy ML-API Common Header from nnstreamer. Relicensed by authors.
  * @see		https://github.com/nnstreamer/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @author Jijoong Moon <jijoong.moon@samsung.com>

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-only */
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * GStreamer Tensor_Filter, nntrainer Module
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>

--- a/nntrainer/delegate.h
+++ b/nntrainer/delegate.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0-only
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *

--- a/test/nnstreamer_filter_nntrainer/checkLabel.py
+++ b/test/nnstreamer_filter_nntrainer/checkLabel.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
 ##
-# SPDX-License-Identifier: LGPL-2.1-only
+# SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2018 Samsung Electronics
+# Copyright (C) 2021 Samsung Electronics
 #
 # @file checkLabel.py
-# @brief Check the result label of tensorflow-lite model
+# @brief Check the result label of tensorflow-lite model. Relicensed for nntrainer by authors
 # @author HyoungJoo Ahn <hello.ahn@samsung.com>
 
 import sys

--- a/test/nnstreamer_filter_nntrainer/gen24bBMP.py
+++ b/test/nnstreamer_filter_nntrainer/gen24bBMP.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
 ##
-# SPDX-License-Identifier: LGPL-2.1-only
+# SPDX-License-Identifier: Apache-2.0
 #
 # Copyright (C) 2018 Samsung Electronics
 #
 # @file gen24bBMP.py
-# @brief Generate 24bpp .bmp files for test cases
+# @brief Generate 24bpp .bmp files for test cases. Relicensed for nntrainer by authors.
 # @author MyungJoo Ham <myungjoo.ham@samsung.com>
 
 from __future__ import print_function

--- a/test/nnstreamer_filter_nntrainer/runTest.sh
+++ b/test/nnstreamer_filter_nntrainer/runTest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ##
-## SPDX-License-Identifier: LGPL-2.1-only
+## SPDX-License-Identifier: Apache-2.0
 ##
 ## @file runTest.sh
 ## @author Jijoong Moon <jijoong.moon@samsung.com>


### PR DESCRIPTION
1. Do not use "Apache-2.0-only". It's "Apache-2.0".
2. Relicense files to Apache-2.0. (The author permits; I'm the author.)

CC: @helloahn : You need to explicitly permit this as well.
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>