### PR TITLE
[manager] Bug fix using tensor map

### DIFF
--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -272,10 +272,10 @@ void Manager::initializeGradients() {
       Weight &weight = w.get();
       auto dim = weight.getDim();
       Tensor grad_prealloc = Tensor();
-      if (weight.getTrainable())
+      if (weight.getTrainable()) {
         grad_prealloc = allocate_grad(dim, grad_offset);
-
-      grad_offset += dim.getDataLen();
+        grad_offset += dim.getDataLen();
+      }
       weight.initializeGrad(grad_prealloc, true);
     }
   }

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -195,8 +195,9 @@ Manager::AllocFunc Manager::getAllocFunc(bool is_weight) {
       }
       size_t byte_size = weight_size * sizeof(float);
       memory = std::make_unique<MMapedMemory>(byte_size, true);
-      return [&memory](const TensorDim &dim, size_t offset) {
-        return Tensor::Map(memory->typedBuffer<float>(), dim, offset);
+      return [&memory, byte_size](const TensorDim &dim, size_t offset) {
+        return Tensor::Map(memory->typedBuffer<float>(), byte_size, dim,
+                           offset);
       };
     };
 

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -89,8 +89,7 @@ public:
   Manager(bool enable_gradient_memory_opt_ = true,
           bool enable_derivative_memory_opt_ = true,
           bool enable_activation_memory_opt_ = true,
-          bool enable_inference_inout_memory_opt_ = true,
-          bool use_shared_memory_ = true);
+          bool enable_inference_inout_memory_opt_ = true);
 
   Manager(const Manager &) = default;
 

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -92,10 +92,16 @@ Tensor::Tensor(const TensorDim &d, const float *buf) : Tensor() {
   }
 }
 
-Tensor Tensor::Map(float *buf, const TensorDim &d, int offset) {
+Tensor Tensor::Map(float *buf, unsigned int size, const TensorDim &d,
+                   int offset) {
   if (d.getDataLen() == 0 || buf == nullptr) {
     throw std::invalid_argument(
       "[Tensor::Map] empty tensor dim is not allowed");
+  }
+
+  if (d.getDataLen() + offset > size) {
+    throw std::invalid_argument(
+      "Creating shared tensor of size bigger than tensor memory.");
   }
 
   Tensor tmp;
@@ -107,10 +113,16 @@ Tensor Tensor::Map(float *buf, const TensorDim &d, int offset) {
   return tmp;
 }
 
-Tensor Tensor::Map(std::shared_ptr<float> buf, const TensorDim &d, int offset) {
+Tensor Tensor::Map(std::shared_ptr<float> buf, unsigned int size,
+                   const TensorDim &d, int offset) {
   if (d.getDataLen() == 0 || buf == nullptr) {
     throw std::invalid_argument(
       "[Tensor::Map] empty tensor dim is not allowed");
+  }
+
+  if (d.getDataLen() + offset > size) {
+    throw std::invalid_argument(
+      "Creating shared tensor of size bigger than tensor memory.");
   }
 
   Tensor tmp;

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -73,6 +73,8 @@ public:
    * @param offset offset to be used from current
    * @return Tensor object
    * @throws std::invalid_argument if buf is null
+   *
+   * @note This method is unsafe as it does not check buf size.
    */
   static Tensor Map(float *buf, const TensorDim &d, int offset = 0);
 
@@ -85,6 +87,8 @@ public:
    * @param offset offset to be used
    * @return Tensor object
    * @throws std::invalid_argument if buf is null
+   *
+   * @note This method is unsafe as it does not check buf size.
    */
   static Tensor Map(std::shared_ptr<float> buf, const TensorDim &d,
                     int offset = 0);

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -68,30 +68,29 @@ public:
    * @brief Construct a new Tensor object from a buffer
    * This will not copy buffer to a new tensor but directly uses it
    *
-   * @param d tensor dim
    * @param buf buffer
+   * @param size buffer size in bytes
+   * @param d tensor dim
    * @param offset offset to be used from current
    * @return Tensor object
    * @throws std::invalid_argument if buf is null
-   *
-   * @note This method is unsafe as it does not check buf size.
    */
-  static Tensor Map(float *buf, const TensorDim &d, int offset = 0);
+  static Tensor Map(float *buf, unsigned int size, const TensorDim &d,
+                    int offset = 0);
 
   /**
    * @brief Construct a new Tensor object from a buffer
    * This will shared the buf
    *
-   * @param d tensor dim
    * @param buf buffer
+   * @param size buffer size in bytes
+   * @param d tensor dim
    * @param offset offset to be used
    * @return Tensor object
    * @throws std::invalid_argument if buf is null
-   *
-   * @note This method is unsafe as it does not check buf size.
    */
-  static Tensor Map(std::shared_ptr<float> buf, const TensorDim &d,
-                    int offset = 0);
+  static Tensor Map(std::shared_ptr<float> buf, unsigned int size,
+                    const TensorDim &d, int offset = 0);
 
   /**
    * @brief     Constructor of Tensor

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -82,7 +82,7 @@ TEST(nntrainer_Tensor, TensorWrap_p) {
   float dat[] = {1, 2, 3};
 
   {
-    nntrainer::Tensor a = nntrainer::Tensor::Map(dat, {3});
+    nntrainer::Tensor a = nntrainer::Tensor::Map(dat, 3, {3});
     /// check if a.getData() has same address with dat
     EXPECT_EQ(dat, a.getData());
     {
@@ -95,9 +95,14 @@ TEST(nntrainer_Tensor, TensorWrap_p) {
   EXPECT_FLOAT_EQ(dat[2], 3);
 }
 
-TEST(nntrainer_Tensor, TensorWrap_n) {
+TEST(nntrainer_Tensor, TensorWrap_01_n) {
   float dat[] = {1, 2, 3};
-  EXPECT_THROW(nntrainer::Tensor::Map(dat, {}), std::invalid_argument);
+  EXPECT_THROW(nntrainer::Tensor::Map(dat, 3, {}), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, TensorWrap_02_n) {
+  float dat[] = {1, 2, 3};
+  EXPECT_THROW(nntrainer::Tensor::Map(dat, 3, {4}), std::invalid_argument);
 }
 
 TEST(nntrainer_Tensor, TensorPaddedValue_p) {


### PR DESCRIPTION
Commit 1: [manager] Disable user_shared_memory 
Disable user_shared_memory to as NNAPI is not required to be supported.
It is further needed to decouple tensor structure allocation and its
internal memory allocation.


Commit 2: [manager] bug fix for Tensor::map
This patch exposes a bug from Tensor::Map
where the offset is not checked when assigning the data.

Commit 3: [tensor] Update interface for tensor::map …

Update interface for tensor::map to include the size of the original
buffer to ensure that the buffer contains enough memory required
by the tensor shape wrapping around the memory.
Added another negative unittest for it.

Resolves #892

This is because of the bug in manager for batch normalization layer.