### PR TITLE
[Weight] Cleanup train argument for initialize gradient

### DIFF
--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -300,7 +300,7 @@ void Manager::initializeGradients() {
         grad_prealloc = allocate_grad(dim, grad_offset);
         grad_offset += dim.getDataLen();
       }
-      weight.initializeGradient(grad_prealloc, true);
+      weight.initializeGradient(grad_prealloc);
     }
   }
 }

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -35,8 +35,8 @@ void Var_Grad::initializeVariable(const Tensor &preallocated) {
   }
 }
 
-void Var_Grad::initializeGradient(const Tensor &preallocated, bool gtrain) {
-  if (!preallocated.uninitialized() && gtrain) {
+void Var_Grad::initializeGradient(const Tensor &preallocated) {
+  if (!preallocated.uninitialized()) {
     /**
      * Making a new tensor is intentional here as this tensor is not shared
      * with other layers but the internal memory is.

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -101,7 +101,8 @@ public:
                           const Tensor &grad_preallocated = Tensor(),
                           bool gtrain = true) {
     initializeVariable(var_preallocated);
-    initializeGradient(grad_preallocated, gtrain);
+    if (gtrain)
+      initializeGradient(grad_preallocated);
   }
 
   /**
@@ -113,10 +114,8 @@ public:
   /**
    * @brief Initialize the gradient for the variable
    * @param preallocated if initialized, use this tensor for gradient memory
-   * @param gtrain If all the variables should be trainable
    */
-  virtual void initializeGradient(const Tensor &preallocated = Tensor(),
-                                  bool gtrain = true);
+  virtual void initializeGradient(const Tensor &preallocated = Tensor());
 
   /**
    * @brief Allocate and initialize the variable and grad

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -69,10 +69,10 @@ void Weight::runVariableInitializer() {
   }
 }
 
-void Weight::initializeGradient(const Tensor &preallocated, bool gtrain) {
+void Weight::initializeGradient(const Tensor &preallocated) {
   // Use self variable to initialize itself
-  Var_Grad::initializeGradient(preallocated, gtrain);
-  if (gtrain && alloc_now)
+  Var_Grad::initializeGradient(preallocated);
+  if (alloc_now)
     allocateOptimizerVariables();
 }
 

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -84,10 +84,9 @@ public:
   void initializeVariable(const Tensor &preallocated = Tensor());
 
   /**
-   * @copydoc var_grad::initializeGradient(const Tensor &, bool)
+   * @copydoc var_grad::initializeGradient(const Tensor &)
    */
-  void initializeGradient(const Tensor &preallocated = Tensor(),
-                          bool gtrain = true);
+  void initializeGradient(const Tensor &preallocated = Tensor());
 
   /**
    * @brief Swap for weight


### PR DESCRIPTION
Cleanup train argument for initialize gradient
This argument was needed when weights and gradient were initialized together
But now, the caller must call initializeGradient only when its trainable

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>