### PR TITLE
[Tensor] Handle copy edge case

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -858,7 +858,7 @@ void Tensor::copy(const Tensor &from) {
     throw std::runtime_error("Cannot copy non-contiguous tensor");
   }
 
-  if (length() == from.length()) {
+  if (from.length() != 0 && length() == from.length()) {
     reshape(from.getDim());
     copy(from.getData());
   } else {

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -2118,27 +2118,6 @@ TEST_F(nntrainer_AdditionLayer, setProperty_02_n) {
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
-TEST_F(nntrainer_AdditionLayer, forwarding_01_n) {
-  setProperty("num_inputs=1");
-
-  sharedTensor input = std::shared_ptr<nntrainer::Tensor>(
-    new nntrainer::Tensor[1], std::default_delete<nntrainer::Tensor[]>());
-  nntrainer::Tensor &in = *input;
-
-  in = nntrainer::Tensor();
-
-  nntrainer::Manager manager;
-  manager.setInferenceInOutMemoryOptimization(false);
-  layer.setInputBuffers(manager.trackLayerInputs(
-    layer.getType(), layer.getName(), layer.getInputDimension()));
-  layer.setOutputBuffers(manager.trackLayerOutputs(
-    layer.getType(), layer.getName(), layer.getOutputDimension()));
-
-  manager.initializeTensors(true);
-
-  EXPECT_THROW(layer.forwarding_with_val({input}), std::invalid_argument);
-}
-
 /*
  *Disabled until input_layer keyward is enabled.
  */


### PR DESCRIPTION
When copying uninitialized tensor to another unintialized tensor,
tensor::copy tried to reshape uninitialized dimension.

This patch fixes the issue.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
