### PR TITLE
[Util] Add gtest style throw macro @open sesame 02/16 13:03

### DIFF
--- a/test/unittest/unittest_nntrainer_internal.cpp
+++ b/test/unittest/unittest_nntrainer_internal.cpp
@@ -280,6 +280,29 @@ TEST(nntrainer_Layer, initialize_03_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
+TEST(nntrainer_throw_if, throw_invalid_arg_p) {
+  try {
+    NNTR_THROW_IF(1 == 1, std::invalid_argument) << "error msg";
+  } catch (std::invalid_argument &e) {
+    EXPECT_STREQ("error msg", e.what());
+  }
+
+  try {
+    NNTR_THROW_IF(true, std::invalid_argument) << "error msg";
+  } catch (std::invalid_argument &e) {
+    EXPECT_STREQ("error msg", e.what());
+  }
+
+  bool hit = false;
+  auto cleanup = [&hit] { hit = true; };
+  try {
+    NNTR_THROW_IF_CLEANUP(true, std::invalid_argument, cleanup) << "error msg";
+  } catch (std::invalid_argument &e) {
+    EXPECT_STREQ("error msg", e.what());
+    EXPECT_TRUE(hit);
+  }
+}
+
 /**
  * @brief Main gtest
  */


### PR DESCRIPTION
Add gtest style throw macro for productivity.
With this patch, if you have to throw, do in one line

`NNTR_THROW_IF(true, std::invalid_argument) << log << what << ever`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

resolves #895 


v2: Added `NNTR_THROW_IF_CLEANUP(pred, std::invalid_argument, cleanup_func)` to take a cleanup function before throw.