### PR TITLE
[Docs] Generate nntrainer docs

### DIFF
--- a/Applications/KNN/README.md
+++ b/Applications/KNN/README.md
@@ -1,26 +1,29 @@
+---
+title: KNN
+...
+
 # Learning with Feature Extractor (KNN)
 
 Here is some toy example which is distinguish simple images.
 The Mobile ssd V2 tensor flow lite model is used for the feature extractor and Nearest Neighbor is used for the classifier. All the training and testing is done on the Galaxy S8.
 
-![image](/docs/images/08b09a80-ef29-11e9-8303-475fd75f4b83.png?raw=true)
+<img src="../../docs/images/08b09a80-ef29-11e9-8303-475fd75f4b83.png" width="640">
 
 Happy(^^), sad(TT), soso(ㅡㅡ) classes are used and prepare 5 images for the training and two images for the test set each as below.
 
-![image](/docs/images/a73cfb80-ef29-11e9-9ae9-0d6531538eaf.png?raw=true)
+<img src="../..//docs/images/a73cfb80-ef29-11e9-9ae9-0d6531538eaf.png" width="640">
 
 After remove the fully connected layer of mobile ssd v2, 128 features are extracted. The features from first training set data is below.
 
-![image](/docs/images/0997fb00-ef2e-11e9-90a3-51c27bf4013f.png?raw=true)
-
+<img src="../../docs/images/0997fb00-ef2e-11e9-90a3-51c27bf4013f.png" width="640">
 
 Simple euclidean distance is calculated and the result is quite good. All the test set is collected.
 
-![image](/docs/images/87103b00-ef2f-11e9-9c1a-83da0faafb63.png?raw=true)
+<img src="../../docs/images/87103b00-ef2f-11e9-9c1a-83da0faafb63.png" width="640">
 
 Due to the simplicity of this toy example, all the test results are collect.
 
 There are two more random pictures which little bit differ from right image. As you can see, it is little bit hard to tell which class it is. First image could be classified as "happy" but the red zone is across with sad and the variance is quite small. Second image is more confused. Cause the smallest distance is all over the classes.
 May be should be define the threshold which is not implemented yet.
 
-![image](/docs/images/33552000-ef36-11e9-88f6-ea6a35ccdf6b.png?raw=true)
+<img src="../../docs/images/33552000-ef36-11e9-88f6-ea6a35ccdf6b.png" width="640">

--- a/Applications/README.md
+++ b/Applications/README.md
@@ -1,0 +1,5 @@
+---
+title: Applications
+...
+
+# Applications

--- a/docs/coding-convention.md
+++ b/docs/coding-convention.md
@@ -1,3 +1,7 @@
+---
+title: Coding Convention
+...
+
 # Coding Convention
 
 ## C headers (.h)
@@ -9,7 +13,7 @@ Except the two, you are required to follow the general coding styles mandated by
 ## C/C++ files (.cpp, .c)
 
 Use .h for headers and .cpp / .c for source.
-You have to use clang-format with the given [.clang-format](../.clang-format) file
+You have to use clang-format with the given [.clang-format](https://github.com/nnstreamer/nntrainer/blob/main/.clang-format) file
 
 
 ## Other files

--- a/docs/configuration-ini.md
+++ b/docs/configuration-ini.md
@@ -1,3 +1,7 @@
+---
+title: Configuration ini
+...
+
 # Writing Configuration File
 
 NNTrainer requires network configuration file which includes network layers and hyper-parameters. The format of configuration file is iniparser format which is commonly used. Keywords are not case sensitive and the line start with '#' will be ignored.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,3 +1,7 @@
+---
+title: Contribution
+...
+
 # How to Contribute
 
 ## Coding Convention
@@ -6,9 +10,9 @@ Consistent code conventions are important for several reasons:
 * To make it easy to debug the code, with both a system call tracer and GNU debuggers. It should be easy to set breakpoints, view locals, and display and view data structures.
 * To attempt to improve code quality through consistency, and requiring patterns that are less likely to result in bugs either initially, or after code modification.
 
-For more information, please refer to [coding-convention.md](coding-convention.md).
+For more information, please refer to [coding-convention.md](docs/coding-convention.md).
 
-For C/C++ code, you may apply clang-format with the given [.clang-format](../.clang-format) file.
+For C/C++ code, you may apply clang-format with the given [.clang-format](https://github.com/nnstreamer/nntrainer/blob/main/.clang-format) file.
 For C/C++ header files, we do not require strict style rules, but it is recommended to apply such rules.
 
 We do not have explicit and strict styling rules for other programming languages, yet.
@@ -36,7 +40,7 @@ The submitter has the first responsibility of keeping the created PR clean and n
 A PR is required to meet the following criteria.
 * It has passed all the tests defined for TAOS-CI.
     - This includes unit tests and integration tests in various platforms and different static analysis tools.
-    - Note that one of the tests includes the "Signed-off-by" check, which means that the author has agreed with [Code of Conduct](../CODE_OF_CONDUCT.md). You may need to refer to later section.
+    - Note that one of the tests includes the "Signed-off-by" check, which means that the author has agreed with [Code of Conduct](CODE_OF_CONDUCT.md). You may need to refer to later section.
 * At least TWO committers (reviewers with voting rights) have approved the PR.
     - This is a necessary condition, not sufficient.
     - If the PR touches sensitive codes or may affect wide ranges of components, reviewers will wait for other reviewers to back them up.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,7 @@
+---
+title: Getting Started
+...
+
 # Getting Started
 
 ## Prerequisites

--- a/docs/hotdoc/gen-hotdoc.sh
+++ b/docs/hotdoc/gen-hotdoc.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This is to create the nntrainer documents (https://nntrainer.github.io/).
+# Our documentation uses hotdoc, you should usually refer to here: http://hotdoc.github.io/ .
+# Run this script on the root path of the NNTrainer.
+
+echo "Generate NNTrainer documents"
+
+v=$( grep -w version: meson.build | perl -pe 'if(($v)=/([0-9]+([.][0-9]+)+)/){print"$v\n";exit}$_=""' )
+deps_file_path="$(pwd)/docs/NNTrainer.deps"
+
+echo "NNTrainer version: $v"
+echo "Dependencies file path: $deps_file_path"
+
+hotdoc run -i index.md -o docs/NNTrainer-doc --sitemap=docs/hotdoc/sitemap.txt --deps-file-dest=$deps_file_path \
+           --html-extra-theme=docs/hotdoc/theme/extra --project-name=NNTrainer --project-version=$v

--- a/docs/hotdoc/index.md
+++ b/docs/hotdoc/index.md
@@ -1,0 +1,8 @@
+---
+title: Documents
+...
+
+# NNTrainer Documents
+
+The following sections introduce a series of tutorials designed to help
+you learn how to use NNtrainer.

--- a/docs/hotdoc/sitemap.txt
+++ b/docs/hotdoc/sitemap.txt
@@ -1,0 +1,11 @@
+index.md
+	docs/hotdoc/index.md
+		docs/getting-started.md
+		docs/how-to-run-examples.md
+		docs/how-to-use-testcases.md
+		docs/configuration-ini.md
+		docs/coding-convention.md
+		docs/contributing.md
+		CODE_OF_CONDUCT.md
+	Applications/README.md
+		Applications/KNN/README.md

--- a/docs/hotdoc/theme/extra/css/extra_frontend.css
+++ b/docs/hotdoc/theme/extra/css/extra_frontend.css
@@ -1,0 +1,52 @@
+h1, h2, h2, h3, h4, h5 {
+	font-weight: 300;
+}
+
+.hotdoc-navbar-brand {
+	font-weight: 700;
+	text-transform: uppercase;
+	font-size: 70%;
+	color: black;
+}
+
+.page-header {
+	text-align: center;
+	font-weight: 300;
+	padding: 100px 15px;
+}
+
+.page-header h1, .page-header h2 {
+	margin-bottom: 1em;
+}
+
+.page-header p {
+	margin-left: auto;
+	margin-right: auto;
+	max-width: 80%;
+	font-size: 18px;
+}
+
+.btn-xl {
+	padding: 15px 30px;
+}
+
+.toned-row {
+	background-color: #dfdfdf;
+	margin: 3em -15px 3em -15px;
+	padding: 3em;
+	text-align: center;
+
+}
+
+.toned-row a.icon {
+	display: inline-block;
+	width: 92px;
+	height: 92px;
+	background-repeat: no-repeat;
+	background-position: center;
+	background-size: 64px;
+	padding-top: 92px;
+	cursor: pointer;
+	font-size: 90%;
+	transition: 500ms color ease-in-out;
+}

--- a/docs/hotdoc/theme/extra/templates/navbar_links.html
+++ b/docs/hotdoc/theme/extra/templates/navbar_links.html
@@ -1,0 +1,18 @@
+@require(page)
+
+<li class="dropdown">
+    <a class="dropdown-toggle" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        API References<span class="caret"></span>
+    </a>
+	<ul class="dropdown-menu" id="modules-menu">
+		@for tup in (("docs/hotdoc/index.html","NNTrainer doc"),):
+			<li>
+				<a href="@tup[0]">@tup[1]</a>
+			</li>
+		@end
+</li>
+
+<li>
+	<a href="docs/hotdoc/index.html">Documents</a>
+</li>
+

--- a/docs/how-to-run-examples.md
+++ b/docs/how-to-run-examples.md
@@ -1,3 +1,7 @@
+---
+title: How to run examples
+...
+
 # How to run examples
 
 ## Preparing NNTrainer for execution

--- a/docs/how-to-use-testcases.md
+++ b/docs/how-to-use-testcases.md
@@ -1,3 +1,8 @@
+---
+title: How to run Test Cases
+...
+
+
 # How to run Test Cases
 
 - Use the built library

--- a/index.md
+++ b/index.md
@@ -1,0 +1,17 @@
+---
+full-width: true
+title: NNTrainer
+render-subpages: false
+...
+
+<div class="container">
+<div class="page-header">
+    <h1>NNTrainer: Software Framework for training Neural Network models on devices.</h1>
+    <p>
+NNTrainer is an Open Source Project. The aim of the NNtrainer is to develop a Software Framework to train neural network models on embedded devices which have relatively limited resources.
+
+Rather than training whole layers of a network, NNtrainer trains only one or a few layers of the layers added after a feature extractor.
+    </p>
+    <a class="btn btn-default btn-xl page-scroll" href="docs/hotdoc/index.html" data-hotdoc-relative-link=true>Get Started</a>
+</div>
+</div>


### PR DESCRIPTION
Generate nntrainer docs.
See: https://nntrainer.github.io/
The modifications can be reflected in this repository: https://github.com/nntrainer/nntrainer.github.io

 - Sub-documents such as Application/* need to be added
 - The table and others need to be modified according to the hotdoc rule.

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>