### PR TITLE
Load layer plugin from directories @open sesame 03/02 16:11

### DIFF
--- a/Applications/Custom/LayerClient/jni/meson.build
+++ b/Applications/Custom/LayerClient/jni/meson.build
@@ -8,7 +8,7 @@ layer_client_sources = [
 ini_in_path = res_path / 'custom_layer_client.ini'
 ini_out_path = meson.build_root() / 'custom_layer_client.ini'
 
-run_command('cp', ini_in_path, ini_out_path)
+run_command('cp', '-lr', res_path, nntr_app_resdir / 'LayerClient')
 
 e = executable('layer_client',
   layer_client_sources,

--- a/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
@@ -19,22 +19,55 @@
 #include <app_context.h>
 #include <layer.h>
 
-const char *RES_PATH = std::getenv("RES_PATH");
+const char *NNTRAINER_PATH = std::getenv("NNTRAINER_PATH");
 
 TEST(AppContext, DlRegisterOpen_p) {
-  ASSERT_NE(RES_PATH, nullptr) << "RES_PATH environment value must be set";
-  auto &ac = nntrainer::AppContext::Global();
+  ASSERT_NE(NNTRAINER_PATH, nullptr)
+    << "NNTRAINER_PATH environment value must be set";
+  auto ac = nntrainer::AppContext();
 
-  ac.registerLayerPlugin("libpow_layer.so", RES_PATH);
+  ac.registerLayer("libpow_layer.so", NNTRAINER_PATH);
 
-  auto layer = ml::train::createLayer("pow");
+  auto layer = ac.createObject<ml::train::Layer>("pow");
 
   EXPECT_EQ(layer->getType(), "pow");
 }
 
 TEST(AppContext, DlRegisterWrongPath_n) {
-  ASSERT_NE(RES_PATH, nullptr) << "RES_PATH environment value must be set";
-  auto &ac = nntrainer::AppContext::Global();
+  ASSERT_NE(NNTRAINER_PATH, nullptr)
+    << "NNTRAINER_PATH environment value must be set";
+  auto ac = nntrainer::AppContext();
 
-  EXPECT_THROW(ac.registerLayerPlugin("wrong_name.so"), std::invalid_argument);
+  EXPECT_THROW(ac.registerLayer("wrong_name.so"), std::invalid_argument);
+}
+
+TEST(AppContext, DlRegisterDirectory_p) {
+  ASSERT_NE(NNTRAINER_PATH, nullptr)
+    << "NNTRAINER_PATH environment value must be set";
+  auto ac = nntrainer::AppContext();
+
+  ac.registerLayerFromDirectory(NNTRAINER_PATH);
+
+  auto layer = ac.createObject<ml::train::Layer>("pow");
+
+  EXPECT_EQ(layer->getType(), "pow");
+}
+
+TEST(AppContext, DlRegisterDirectory_n) {
+  auto ac = nntrainer::AppContext();
+
+  EXPECT_THROW(ac.registerLayerFromDirectory("wrong path"),
+               std::invalid_argument);
+}
+
+TEST(AppContext, DefaultEnvironmentPath_p) {
+  /// as NNTRAINER_PATH is fed to the test, this should success without an
+  /// error
+  auto layer = ml::train::createLayer("pow");
+  EXPECT_EQ(layer->getType(), "pow");
+}
+
+TEST(AppContext, DefaultEnvironmentPath_n) {
+  /// pow2 does not exist
+  EXPECT_THROW(ml::train::createLayer("pow2"), std::invalid_argument);
 }

--- a/Applications/Custom/LayerPlugin/meson.build
+++ b/Applications/Custom/LayerPlugin/meson.build
@@ -25,6 +25,6 @@ if get_option('enable-test')
 )
 
 testenv = environment()
-testenv.set('RES_PATH', meson.current_build_dir())
+testenv.set('NNTRAINER_PATH', meson.current_build_dir())
 test('app_plugin_test', exe, env: testenv)
 endif

--- a/debian/nntrainer.install
+++ b/debian/nntrainer.install
@@ -1,1 +1,2 @@
 /usr/lib/*/*.so
+/etc/nntrainer.ini

--- a/meson.build
+++ b/meson.build
@@ -72,7 +72,7 @@ nntrainer_prefix = get_option('prefix')
 nntrainer_libdir = nntrainer_prefix / get_option('libdir')
 nntrainer_bindir = nntrainer_prefix / get_option('bindir')
 nntrainer_includedir = nntrainer_prefix / get_option('includedir')
-nntrainer_inidir = get_option('sysconfdir')
+nntrainer_confdir = get_option('sysconfdir')
 application_install_dir = nntrainer_bindir / 'applications'
 
 # handle resources
@@ -92,6 +92,7 @@ nntrainer_conf.set('VERSION', meson.project_version())
 nntrainer_conf.set('PREFIX', nntrainer_prefix)
 nntrainer_conf.set('EXEC_PREFIX', nntrainer_bindir)
 nntrainer_conf.set('LIB_INSTALL_DIR', nntrainer_libdir)
+nntrainer_conf.set('PLUGIN_INSTALL_PREFIX', nntrainer_libdir / 'nntrainer')
 nntrainer_conf.set('INCLUDE_INSTALL_DIR', nntrainer_includedir)
 
 dummy_dep = dependency('', required: false)
@@ -185,6 +186,21 @@ endif
 configure_file(input: 'nntrainer.pc.in', output: 'nntrainer.pc',
   install_dir: nntrainer_libdir / 'pkgconfig',
   configuration: nntrainer_conf
+)
+
+# Install conf
+configure_file(
+  input: 'nntrainer.ini.in',
+  output: 'nntrainer.ini',
+  install_dir: nntrainer_confdir,
+  configuration: nntrainer_conf
+)
+nntrainer_conf_abs_path = get_option('prefix') / nntrainer_confdir / 'nntrainer.ini'
+message('NNTRAINER_CONF_PATH=@0@'.format(nntrainer_conf_abs_path))
+
+add_project_arguments(
+  '-DNNTRAINER_CONF_PATH="@0@"'.format(nntrainer_conf_abs_path),
+  language: ['c', 'cpp']
 )
 
 # Build nntrainer

--- a/nntrainer.ini.in
+++ b/nntrainer.ini.in
@@ -1,0 +1,8 @@
+#######################
+# nntrainer conf file #
+#######################
+
+# default plugin paths, below path is searched and registered when the library is being loaded.
+[plugins]
+# path to search for layers
+layer=@PLUGIN_INSTALL_PREFIX@/layers

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -94,8 +94,16 @@ public:
    * @throws std::invalid_parameter if library_path is invalid or library is
    * invalid
    */
-  int registerLayerPlugin(const std::string &library_path,
-                          const std::string &base_path = "");
+  int registerLayer(const std::string &library_path,
+                    const std::string &base_path = "");
+
+  /**
+   * @brief register Layer from a directory.
+   *
+   * @param base_path a directory path to search layer's
+   * @return std::vector<int> list of integer key to create a layer
+   */
+  std::vector<int> registerLayerFromDirectory(const std::string &base_path);
 
   /**
    * @brief Get Working Path from a relative or representation of a path

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -99,6 +99,8 @@ public:
 
   /**
    * @brief register Layer from a directory.
+   * @note if you have a clashing type with already registered layer, it will
+   * throw from `registerFactory` function
    *
    * @param base_path a directory path to search layer's
    * @return std::vector<int> list of integer key to create a layer

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -383,6 +383,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %defattr(-,root,root,-)
 %license LICENSE
 %{_libdir}/libnntrainer.so
+%{_sysconfdir}/nntrainer.ini
 
 %files devel
 %{_includedir}/nntrainer/databuffer.h


### PR DESCRIPTION
This patch mainly adds the functionality to add `.so` from a directory (by api, environment variable, and configuration ini)

- ~**#894** [Fix] Resolve static init order fiasco~
- ~**#896** [Util] Add gtest style throw macro~
- ~**#908** [API] Add layer pluggable definition~
- ~**#908** [Pluggable] Add layer wrapper for plugged layer~
- ~**#908** [AppContext] Add register plugin function~
- ~**#908** [Test] Add test to create layer from an example~
- [AppContext] Default Path loader
```
Add appcontext default path loader.

**Changes proposed in this PR:**
- add `AppContext::registerLayerFromDirectory`
- call `add_extension_object` routine for `AppContext::Global()`. The
routine searches the directory of `NNTRAINER_PATH` and from
`nntrainer.ini`(installing ini in upcoming PR)

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
- [Conf] Add default conf nntrainer.ini
```
This patch adds nntrainer.ini (defaulted to be `/etc/nntrainer.ini`)
The path is defaulted to be '/etc/nntrainer.ini' but it is subjected to
change by changing `--sysconfdir=''` and `--prefix`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```
