### PR TITLE
[adam] Reduce temporary memory allocation

### DIFF
--- a/nntrainer/optimizers/adam.cpp
+++ b/nntrainer/optimizers/adam.cpp
@@ -54,7 +54,7 @@ double Adam::getLearningRate(int iteration) {
 void Adam::apply_gradient(Weight &weight, double updated_lr, int iteration) {
 
   Tensor &x = weight.getVariableRef();
-  const Tensor &x_grad = weight.getGradientRef();
+  Tensor &x_grad = weight.getGradientRef();
 
   // This is implementation of adam from original paper.
   // This is not deleted intentionally.
@@ -87,10 +87,9 @@ void Adam::apply_gradient(Weight &weight, double updated_lr, int iteration) {
   wv.multiply_i(beta2);
   wv.add_i(x_grad.multiply(x_grad), 1.0f - beta2);
 
-  Tensor divider;
-  divider = wv.apply(sqrtEps, divider);
-  divider.multiply_i(wm);
-  x.add_i(divider, -updated_lr);
+  x_grad = wv.apply(sqrtEps, x_grad);
+  x_grad.multiply_i(wm);
+  x.add_i(x_grad, -updated_lr);
 }
 
 void Adam::setProperty(const PropertyType type, const std::string &value) {

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -733,12 +733,11 @@ protected:
     EXPECT_EQ(status, ML_ERROR_NONE);
     status = loss_layer->setLoss(type);
     EXPECT_EQ(status, ML_ERROR_NONE);
+    loss_type = type;
 
-    ;
     loss_layer->setInputBuffers(
       manager.trackLayerInputs(loss_layer->getType(), loss_layer->getName(),
                                loss_layer->getInputDimension()));
-    ;
     loss_layer->setOutputBuffers(
       manager.trackLayerOutputs(loss_layer->getType(), loss_layer->getName(),
                                 loss_layer->getOutputDimension()));
@@ -848,9 +847,14 @@ protected:
   void matchUpdatedWeightsGradients() {
     std::vector<nntrainer::Weight> params = layer.getWeights();
 
+    bool match_grads = true;
+    if (loss_type != nntrainer::LossType::LOSS_UNKNOWN)
+      match_grads = false;
+
     /** Match gradients and updated weights */
     for (int idx = 0; idx < 2; ++idx) {
-      matchOutput(params[idx].getGradient(), grad[idx]);
+      if (match_grads)
+        matchOutput(params[idx].getGradient(), grad[idx]);
       matchOutput(params[idx].getVariable(), new_w[idx]);
     }
   }
@@ -859,6 +863,7 @@ protected:
   std::vector<nntrainer::Tensor> new_w;
   std::vector<nntrainer::Tensor> grad;
   std::vector<std::shared_ptr<nntrainer::Layer>> layers;
+  nntrainer::LossType loss_type = nntrainer::LossType::LOSS_UNKNOWN;
 };
 
 /**


### PR DESCRIPTION
Reduce temporary memory allocation for adam
This is done by reusing gradient memory to calculate the final
update which is to be applied for the weight.

This reduces temporary memory allocations, which were being every epoch
for each weight, but also reduces peak memory usage.

Resolves #917

This has a side effect that the after `applyGradient()`, `getGradient()` will return
the `update` to be applied to the weight than the gradient itself.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>