### PR TITLE
Move weight regularization @open sesame 02/02 20:01

### DIFF
--- a/Applications/SimpleShot/layers/centroid_knn.cpp
+++ b/Applications/SimpleShot/layers/centroid_knn.cpp
@@ -4,12 +4,12 @@
  *
  * @file   centroid_knn.cpp
  * @date   09 Jan 2021
- * @details  This file contains the simple nearest neighbor layer, this layer
- * takes centroid and calculate l2 distance
+ * @brief  This file contains the simple nearest neighbor layer
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug    No known bugs except for NYI items
  *
+ * @details This layer takes centroid and calculate l2 distance
  */
 
 #include <iostream>
@@ -88,16 +88,18 @@ int CentroidKNN::initialize(nntrainer::Manager &manager) {
   if (weights.empty()) {
     weights.reserve(2);
     weights.emplace_back(map_dim, nntrainer::WeightInitializer::WEIGHT_ZEROS,
-                         false, "centroidNN:map");
+                         nntrainer::WeightRegularizer::NONE, 1.0f, false,
+                         "centroidNN:map");
     weights.emplace_back(samples_seen,
-                         nntrainer::WeightInitializer::WEIGHT_ZEROS, false,
+                         nntrainer::WeightInitializer::WEIGHT_ZEROS,
+                         nntrainer::WeightRegularizer::NONE, 1.0f, false,
                          "centroidNN:num_samples");
     manager.trackWeights(weights);
   } else {
     weights[0].reset(map_dim, nntrainer::WeightInitializer::WEIGHT_ZEROS,
-                     false);
+                     nntrainer::WeightRegularizer::NONE, 1.0f, false);
     weights[1].reset(samples_seen, nntrainer::WeightInitializer::WEIGHT_ZEROS,
-                     false);
+                     nntrainer::WeightRegularizer::NONE, 1.0f, false);
   }
 
   return ML_ERROR_NONE;

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -62,18 +62,26 @@ int BatchNormalizationLayer::initialize(Manager &manager) {
   weights.clear();
   if (weights.empty()) {
     weights.reserve(4);
-    weights.emplace_back(dim, initializers[BNParams::mu], false,
+    weights.emplace_back(dim, initializers[BNParams::mu],
+                         WeightRegularizer::NONE, 1.0f, false,
                          "BN::moving_mean");
-    weights.emplace_back(dim, initializers[BNParams::var], false,
+    weights.emplace_back(dim, initializers[BNParams::var],
+                         WeightRegularizer::NONE, 1.0f, false,
                          "BN::moving_variance");
-    weights.emplace_back(dim, initializers[BNParams::gamma], true, "BN::gamma");
-    weights.emplace_back(dim, initializers[BNParams::beta], true, "BN::beta");
+    weights.emplace_back(dim, initializers[BNParams::gamma],
+                         WeightRegularizer::NONE, 1.0f, true, "BN::gamma");
+    weights.emplace_back(dim, initializers[BNParams::beta],
+                         WeightRegularizer::NONE, 1.0f, true, "BN::beta");
     manager.trackWeights(weights);
   } else {
-    weights[BNParams::mu].reset(dim, initializers[BNParams::mu], false);
-    weights[BNParams::var].reset(dim, initializers[BNParams::var], false);
-    weights[BNParams::gamma].reset(dim, initializers[BNParams::gamma], true);
-    weights[BNParams::beta].reset(dim, initializers[BNParams::beta], true);
+    weights[BNParams::mu].reset(dim, initializers[BNParams::mu],
+                                WeightRegularizer::NONE, 1.0f, false);
+    weights[BNParams::var].reset(dim, initializers[BNParams::var],
+                                 WeightRegularizer::NONE, 1.0f, false);
+    weights[BNParams::gamma].reset(dim, initializers[BNParams::gamma],
+                                   WeightRegularizer::NONE, 1.0f, true);
+    weights[BNParams::beta].reset(dim, initializers[BNParams::beta],
+                                  WeightRegularizer::NONE, 1.0f, true);
   }
 
   return status;

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -357,9 +357,6 @@ void Conv2DLayer::calcGradient() {
   }
   delK.reshape(out_dim);
   delBias = derivative.sum({0, 2, 3});
-
-  /// calculate regularization based gradient for weight only
-  weightAt(ConvParams::weight).calcRegularizationGradient();
 }
 
 void Conv2DLayer::copy(std::shared_ptr<Layer> l) {

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -126,8 +126,6 @@ void FullyConnectedLayer::calcGradient() {
 
   djdb = derivative_.sum(0);
   djdw = net_input[0]->getVariableRef().dot(derivative_, djdw, true, false);
-
-  weightAt(weight_idx).calcRegularizationGradient();
 }
 
 void FullyConnectedLayer::scaleSize(float scalesize) noexcept {

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -232,8 +232,8 @@ void Layer::setProperty(const PropertyType type, const std::string &value) {
   case PropertyType::weight_regularizer:
     if (!value.empty()) {
       weight_regularizer =
-        (WeightRegularizerType)parseType(value, TOKEN_WEIGHT_REGULARIZER);
-      if (weight_regularizer == WeightRegularizerType::unknown) {
+        (WeightRegularizer)parseType(value, TOKEN_WEIGHT_REGULARIZER);
+      if (weight_regularizer == WeightRegularizer::UNKNOWN) {
         throw std::invalid_argument("[Layer] Unknown Weight decay");
       }
     }

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -63,14 +63,13 @@ public:
   /**
    * @brief     Constructor of Layer Class
    */
-  Layer(
-    ActivationType activation_type_ = ActivationType::ACT_NONE,
-    WeightRegularizerType weight_regularizer_ = WeightRegularizerType::unknown,
-    const float weight_regularizer_constant_ = 1.0f,
-    WeightInitializer weight_initializer_ =
-      WeightInitializer::WEIGHT_XAVIER_UNIFORM,
-    WeightInitializer bias_initializer_ = WeightInitializer::WEIGHT_ZEROS,
-    bool trainable_ = true, bool flatten_ = false) :
+  Layer(ActivationType activation_type_ = ActivationType::ACT_NONE,
+        WeightRegularizer weight_regularizer_ = WeightRegularizer::NONE,
+        const float weight_regularizer_constant_ = 1.0f,
+        WeightInitializer weight_initializer_ =
+          WeightInitializer::WEIGHT_XAVIER_UNIFORM,
+        WeightInitializer bias_initializer_ = WeightInitializer::WEIGHT_ZEROS,
+        bool trainable_ = true, bool flatten_ = false) :
     name(std::string()),
     loss(0.0f),
     activation_type(activation_type_),
@@ -389,13 +388,6 @@ protected:
   std::string name;
 
   /**
-   * @brief     check if current layer's weight decay type is l2norm
-   * @return    bool is weightdecay type is L2 Norm
-   */
-  bool isWeightRegularizerL2Norm() {
-    return weight_regularizer == WeightRegularizerType::l2norm;
-  }
-  /**
    * @brief     Input Tensor
    */
   Tensor input;
@@ -428,7 +420,7 @@ protected:
 
   ActivationType activation_type;
 
-  WeightRegularizerType weight_regularizer;
+  WeightRegularizer weight_regularizer;
 
   float weight_regularizer_constant;
 
@@ -518,14 +510,6 @@ private:
    * Layer::print()
    */
   virtual void printMetric(std::ostream &out);
-
-  /**
-   * @brief     set weight decay parameters
-   * @param[in] w struct for weight decay
-   */
-  void setWeightRegularizer(WeightRegularizerType type) {
-    weight_regularizer = type;
-  }
 
   /**
    * @brief  set Weight Initialization Type

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -136,7 +136,7 @@ public:
   virtual void applyGradient(unsigned int iteration,
                              std::shared_ptr<Optimizer> optimizer) {
     if (optimizer)
-      optimizer->apply_gradients(weights, iteration);
+      optimizer->applyGradients(weights, iteration);
   }
 
   /**

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -638,9 +638,10 @@ int NeuralNetwork::train_run() {
           std::rethrow_exception(std::current_exception());
         }
         std::cout << "#" << epoch_idx << "/" << epochs;
+        float loss = getLoss();
         data_buffer->displayProgress(count++, nntrainer::BufferType::BUF_TRAIN,
-                                     getLoss());
-        training.loss += getLoss();
+                                     loss);
+        training.loss += loss;
       } else {
         data_buffer->clear(nntrainer::BufferType::BUF_TRAIN);
         break;

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -351,7 +351,7 @@ void NeuralNetwork::backwarding(std::shared_ptr<Layer> layer, int iteration,
     layer->calcDerivative();
 
   if (apply_gradient)
-    opt->apply_gradients(layer->getWeightsRef(), iteration);
+    opt->applyGradients(layer->getWeightsRef(), iteration);
 }
 
 /**

--- a/nntrainer/optimizers/adam.cpp
+++ b/nntrainer/optimizers/adam.cpp
@@ -51,9 +51,8 @@ double Adam::getLearningRate(int iteration) {
   return ll;
 }
 
-void Adam::apply_gradient(Weight &weight, double updated_lr, int iteration) {
+void Adam::applyGradient(Weight &weight, double updated_lr, int iteration) {
 
-  Tensor &x = weight.getVariableRef();
   Tensor &x_grad = weight.getGradientRef();
 
   // This is implementation of adam from original paper.
@@ -89,7 +88,7 @@ void Adam::apply_gradient(Weight &weight, double updated_lr, int iteration) {
 
   x_grad = wv.apply(sqrtEps, x_grad);
   x_grad.multiply_i(wm);
-  x.add_i(x_grad, -updated_lr);
+  weight.applyGradient(updated_lr);
 }
 
 void Adam::setProperty(const PropertyType type, const std::string &value) {

--- a/nntrainer/optimizers/adam.h
+++ b/nntrainer/optimizers/adam.h
@@ -36,10 +36,10 @@ public:
     epsilon(ep) {}
 
   /**
-   * @copydoc apply_gradient(Weight &weight, int tensor_idx, double updated_lr,
+   * @copydoc applyGradient(Weight &weight, int tensor_idx, double updated_lr,
    * int iteration)
    */
-  void apply_gradient(Weight &weight, double updated_lr, int iteration);
+  void applyGradient(Weight &weight, double updated_lr, int iteration);
 
   /**
    * @copydoc Optimizer::getType()

--- a/nntrainer/optimizers/optimizer.cpp
+++ b/nntrainer/optimizers/optimizer.cpp
@@ -46,8 +46,8 @@ double Optimizer::getLearningRate(int iteration) {
   return ll;
 }
 
-void Optimizer::apply_gradients(std::vector<Weight> &weight_list,
-                                int iteration) {
+void Optimizer::applyGradients(std::vector<Weight> &weight_list,
+                               int iteration) {
 
   if (weight_list.empty())
     return;
@@ -61,7 +61,7 @@ void Optimizer::apply_gradients(std::vector<Weight> &weight_list,
     /** calculate regularization gradient before applying the gradient */
     weight.calcRegularizationGradient();
 
-    apply_gradient(weight, ll, iteration);
+    applyGradient(weight, ll, iteration);
   }
 }
 

--- a/nntrainer/optimizers/optimizer.cpp
+++ b/nntrainer/optimizers/optimizer.cpp
@@ -58,6 +58,9 @@ void Optimizer::apply_gradients(std::vector<Weight> &weight_list,
     if (!weight.getTrainable())
       continue;
 
+    /** calculate regularization gradient before applying the gradient */
+    weight.calcRegularizationGradient();
+
     apply_gradient(weight, ll, iteration);
   }
 }

--- a/nntrainer/optimizers/optimizer_internal.h
+++ b/nntrainer/optimizers/optimizer_internal.h
@@ -108,7 +108,7 @@ public:
    * @param[in] params Weight list
    * @param[in] iteration nth epoch number
    */
-  void apply_gradients(std::vector<Weight> &params, int iteration);
+  void applyGradients(std::vector<Weight> &params, int iteration);
 
   /**
    * @brief     Read Training optimizer paramters from file
@@ -176,8 +176,8 @@ private:
    * @param[in] iteration nth epoch number
    * @note weight which is called upon can be assumed to be trainable
    */
-  virtual void apply_gradient(Weight &weight, double updated_lr,
-                              int iteration) = 0;
+  virtual void applyGradient(Weight &weight, double updated_lr,
+                             int iteration) = 0;
 };
 
 } /* namespace nntrainer */

--- a/nntrainer/optimizers/sgd.cpp
+++ b/nntrainer/optimizers/sgd.cpp
@@ -18,9 +18,7 @@ namespace nntrainer {
 const std::string SGD::type = "sgd";
 
 void SGD::apply_gradient(Weight &weight, double updated_lr, int iteration) {
-  Tensor &x = weight.getVariableRef();
-  const Tensor &x_grad = weight.getGradientRef();
-  x.add_i(x_grad, -updated_lr);
+  weight.applyGradient(updated_lr);
 }
 
 } // namespace nntrainer

--- a/nntrainer/optimizers/sgd.cpp
+++ b/nntrainer/optimizers/sgd.cpp
@@ -17,7 +17,7 @@ namespace nntrainer {
 
 const std::string SGD::type = "sgd";
 
-void SGD::apply_gradient(Weight &weight, double updated_lr, int iteration) {
+void SGD::applyGradient(Weight &weight, double updated_lr, int iteration) {
   weight.applyGradient(updated_lr);
 }
 

--- a/nntrainer/optimizers/sgd.h
+++ b/nntrainer/optimizers/sgd.h
@@ -31,10 +31,10 @@ public:
   SGD(float lr = 0.0001f, Args... args) : Optimizer(lr, args...) {}
 
   /**
-   * @copydoc apply_gradient(Weight &weight, double updated_lr,
+   * @copydoc applyGradient(Weight &weight, double updated_lr,
    * int iteration)
    */
-  void apply_gradient(Weight &weight, double updated_lr, int iteration);
+  void applyGradient(Weight &weight, double updated_lr, int iteration);
 
   /**
    * @copydoc Optimizer::getType()

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -16,12 +16,17 @@
 
 namespace nntrainer {
 
-Weight::Weight(const TensorDim &dim, const WeightInitializer init, bool train,
+Weight::Weight(const TensorDim &dim, const WeightInitializer init,
+               const WeightRegularizer reg, const float reg_const, bool train,
                bool alloc_now_, std::string name) :
   Var_Grad(dim, train, alloc_now_, name),
-  initializer(init) {
+  initializer(init),
+  regularizer(reg),
+  regularizer_constant(reg_const) {
   if (initializer == WeightInitializer::WEIGHT_UNKNOWN)
     throw std::invalid_argument("Weight initializer unknown");
+  if (regularizer == WeightRegularizer::UNKNOWN)
+    throw std::invalid_argument("Weight regularizer unknown");
 }
 
 void Weight::initializeVariable(const Tensor &preallocated) {

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -240,6 +240,13 @@ public:
       grad->add_i(*var.get(), regularizer_constant);
   }
 
+  /**
+   * @brief     Apply the gradient to the weight
+   */
+  void applyGradient(double lr) {
+    var->add_i(*grad.get(), -lr);
+  }
+
 private:
   WeightInitializer initializer; /**< initializer for this variable */
   WeightRegularizer regularizer; /**< regularizer for this variable */

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -83,7 +83,8 @@ public:
     const TensorDim &dim,
     const WeightInitializer init = WeightInitializer::WEIGHT_XAVIER_UNIFORM,
     const WeightRegularizer reg = WeightRegularizer::NONE,
-    const float reg_const = 1.0f, bool train = true, bool alloc_now = true, std::string name = "");
+    const float reg_const = 1.0f, bool train = true, bool alloc_now = true,
+    std::string name = "");
 
   /**
    * @copydoc var_grad::initializeVariable(const Tensor &)
@@ -243,9 +244,7 @@ public:
   /**
    * @brief     Apply the gradient to the weight
    */
-  void applyGradient(double lr) {
-    var->add_i(*grad.get(), -lr);
-  }
+  void applyGradient(double lr) { var->add_i(*grad.get(), -lr); }
 
 private:
   WeightInitializer initializer; /**< initializer for this variable */

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -110,12 +110,11 @@ unsigned int parseType(std::string ll, InputType t) {
     "xavier_normal", "xavier_uniform", "he_normal",    "he_uniform"};
 
   /**
-   * @brief     Weight Decay String from configure file
+   * @brief     Weight Regularization String from configure file
    *            "L2Norm"  : squared norm regularization
-   *            "Regression" : Regression
+   *            "None" : none
    */
-  std::array<std::string, 2> weight_regularizer_string = {"l2norm",
-                                                          "regression"};
+  std::array<std::string, 2> weight_regularizer_string = {"l2norm", "none"};
 
   /**
    * @brief     Weight Decay String from configure file
@@ -182,7 +181,7 @@ unsigned int parseType(std::string ll, InputType t) {
         return (i);
       }
     }
-    ret = (unsigned int)WeightRegularizerType::unknown;
+    ret = (unsigned int)WeightRegularizer::UNKNOWN;
     break;
   case TOKEN_PADDING:
     for (i = 0; i < padding_string.size(); i++) {


### PR DESCRIPTION
**Commit 1**: [weight/layer] Move weight regularization out of layers
Move weight regularization out of layers to weights
and remove same code from the all the layers.
Loss and grads from weight regularization is done by the
weight itself.

**Commit 2**: [weight] Move apply gradient to weight
Move apply gradient which will just add the gradient
to the variable multiplied with the gradient.

**Commit 3**: [optimizer] Update to camelcase
Update apply_gradient(s) to applyGradient(s)

Resolves #762 #774

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>