### PR TITLE
[Conv] rework convolution ops @open sesame 02/15 19:17

### DIFF
--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -121,6 +121,27 @@ public:
    */
   void scaleSize(float scalesize) noexcept;
 
+  /**
+   * @brief     reform the data to 2d matrix
+   * a region is sampled considering @a padding, @a mstride of unit @a kdim
+   * Each region is mapped to one column,
+   * if channel mode, kernel channel is considered part of kernel feature
+   * if not, kernel channel is consider part of output dimension
+   *
+   * @param[in] in input data
+   * @param[in] kdim kernel dimesion for define number of row
+   * @param[in] padding padding information
+   * @param[in] mstride stride value : x, y direction
+   * @param[in] channel_mode loop with channel first
+   * @param[out] out out tensor to put, if uninitialized, allocate a new tensor
+   * and set padding
+   * @note if out is initialized tensor, setting padding is skipped.
+   */
+  static void im2col(const Tensor &in, const TensorDim &kdim,
+                     const std::array<unsigned int, CONV2D_DIM> &padding,
+                     const std::array<unsigned int, CONV2D_DIM> &mstride,
+                     bool channel_mode, Tensor &out);
+
 private:
   unsigned int filter_size;
   std::array<unsigned int, CONV2D_DIM> kernel_size;
@@ -146,27 +167,6 @@ private:
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
   int setFilter(int f);
-
-  /**
-   * @brief     reform the data to 2d matrix
-   * a region is sampled considering @a padding, @a mstride of unit @a kdim
-   * Each region is mapped to one column,
-   * if channel mode, kernel channel is considered part of kernel feature
-   * if not, kernel channel is consider part of output dimension
-   *
-   * @param[in] in input data
-   * @param[in] kdim kernel dimesion for define number of row
-   * @param[in] padding padding information
-   * @param[in] mstride stride value : x, y direction
-   * @param[in] channel_mode loop with channel first
-   * @param[out] out out tensor to put, if uninitialized, allocate a new tensor
-   * and set padding
-   * @note if out is initialized tensor, setting padding is skipped.
-   */
-  void im2col(const Tensor &in, const TensorDim &kdim,
-              const std::array<unsigned int, CONV2D_DIM> &padding,
-              const std::array<unsigned int, CONV2D_DIM> &mstride,
-              bool channel_mode, Tensor &out);
 };
 
 } // namespace nntrainer

--- a/nntrainer/nntrainer_error.h
+++ b/nntrainer/nntrainer_error.h
@@ -24,12 +24,69 @@
 #define ML_ERROR_RESULT_OUT_OF_RANGE (-ERANGE)
 #endif
 
+#include <functional>
+#include <sstream>
 #include <stdexcept>
+
+#define NNTR_THROW_IF(pred, err) \
+  if ((pred))                    \
+  nntrainer::exception::internal::ErrorNotification<err>()
+
+#define NNTR_THROW_IF_CLEANUP(pred, err, cleanup_func) \
+  if ((pred))                                          \
+  nntrainer::exception::internal::ErrorNotification<err>(cleanup_func)
+
 namespace nntrainer {
 
 /// @note underscore_case is used for ::exception to keep in accordance with
 /// std::exception
 namespace exception {
+
+namespace internal {
+
+/**
+ * @brief Error Notification class, error is thrown when the class is destroyed.
+ * DO NOT use this outside as this contains throwing destructor.
+ *
+ * @tparam Err Error type that except cstring as an argument.
+ */
+template <typename Err,
+          typename std::enable_if_t<std::is_base_of<std::exception, Err>::value,
+                                    Err> * = nullptr>
+class ErrorNotification {
+public:
+  /**
+   * @brief Construct a new Error Notification object
+   *
+   */
+  explicit ErrorNotification() : cleanup_func([] {}) {}
+
+  explicit ErrorNotification(std::function<void()> cleanup_func_) :
+    cleanup_func(cleanup_func_) {}
+
+  /**
+   * @brief Destroy the Error Notification object, Error is thrown when
+   * destroying this
+   *
+   */
+  ~ErrorNotification() noexcept(false) {
+    cleanup_func();
+    throw Err(ss.str().c_str());
+  }
+
+  template <typename T>
+  friend ErrorNotification<Err> &&operator<<(ErrorNotification<Err> &&out,
+                                             T &&e) {
+    out.ss << e;
+    return std::move(out);
+  }
+
+private:
+  std::stringstream ss;
+  std::function<void()> cleanup_func;
+};
+
+} // namespace internal
 
 /**
  * @brief derived class of invalid argument to represent specific functionality

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -800,6 +800,24 @@ Tensor &Tensor::dot(Tensor const &m, Tensor &result, bool trans, bool trans_m,
   return result;
 }
 
+Tensor Tensor::convTransFlip() const {
+
+  Tensor ret(TensorDim({channel(), batch(), height(), width()}));
+
+  for (unsigned int b = 0; b < ret.batch(); ++b) {
+    for (unsigned int c = 0; c < ret.channel(); ++c) {
+      for (unsigned int h = 0; h < ret.height(); ++h) {
+        for (unsigned int w = 0; w < ret.width(); ++w) {
+          ret.setValue(b, c, h, w,
+                       getValue(c, b, height() - h - 1, width() - w - 1));
+        }
+      }
+    }
+  }
+
+  return ret;
+}
+
 Tensor Tensor::transpose(std::string direction) const {
   unsigned int SL, SI, SJ, SK;
   int dir[MAXDIM - 1];

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -500,6 +500,12 @@ public:
               bool trans_m = false, float beta = 0.0f) const;
 
   /**
+   * @brief transpose batch and channel and
+   * flip the given Tensor horizontal and vertical
+   */
+  Tensor convTransFlip() const;
+
+  /**
    * @brief     Transpose Tensor
    * @param[in] direction to transpose ex) 0:2:1
    * @retval    Calculated Tensor

--- a/test/unittest/unittest_nntrainer_internal.cpp
+++ b/test/unittest/unittest_nntrainer_internal.cpp
@@ -280,6 +280,29 @@ TEST(nntrainer_Layer, initialize_03_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
+TEST(nntrainer_throw_if, throw_invalid_arg_p) {
+  try {
+    NNTR_THROW_IF(1 == 1, std::invalid_argument) << "error msg";
+  } catch (std::invalid_argument &e) {
+    EXPECT_STREQ("error msg", e.what());
+  }
+
+  try {
+    NNTR_THROW_IF(true, std::invalid_argument) << "error msg";
+  } catch (std::invalid_argument &e) {
+    EXPECT_STREQ("error msg", e.what());
+  }
+
+  bool hit = false;
+  auto cleanup = [&hit] { hit = true; };
+  try {
+    NNTR_THROW_IF_CLEANUP(true, std::invalid_argument, cleanup) << "error msg";
+  } catch (std::invalid_argument &e) {
+    EXPECT_STREQ("error msg", e.what());
+    EXPECT_TRUE(hit);
+  }
+}
+
 /**
  * @brief Main gtest
  */


### PR DESCRIPTION
- [Util] Add gtest style throw macro
- [Conv] rework convolution ops
```
This patch reworks convolutions to prepare for the multistride backwarding support by

1. Adding conv_op for default use

In effect, this patch..

1. removes padding from calcDerivative
2. removes im2kernel memcopy but instead adopted convFlip
2. cleaner and more abstract view of operations

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
```