### PR TITLE
[app_context] Resolve build issue with gcc5

### DIFF
--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -106,7 +106,8 @@ static void add_default_object(AppContext &ac) {
 
 AppContext &AppContext::Global() {
   static AppContext instance;
-  std::call_once(global_app_context_init_flag, add_default_object, instance);
+  std::call_once(global_app_context_init_flag, add_default_object,
+                 std::ref(instance));
   return instance;
 }
 


### PR DESCRIPTION
This solves the build issue for gcc5 when using std::call_once
Original code calls bind with copy of the argument to the function
and fails are reference is expected with gcc5

This patch adds a std::ref explicitly to make this work with gcc5

Resolves #932

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>