### PR TITLE
[loss] Allow no loss in the model @open sesame 02/19 17:43

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # ignore build directory
 /build
+/builddir
 
 # jni build files
 iniparser/

--- a/docs/configuration-ini.md
+++ b/docs/configuration-ini.md
@@ -46,6 +46,7 @@ Start with "[Model]"
      * mse : mean squared error
      * cross : cross entropy
         Only allowed with sigmoid and softmax activation function
+     * none : no loss for the model (this model will only support inference)
 
 6. ```save_path = <string>```
 

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -450,7 +450,8 @@ int NetworkGraph::setGraphNode(std::vector<std::shared_ptr<Layer>> &layers,
     }
   }
 
-  if (layers.back()->getType() != LossLayer::type) {
+  if (layers.back()->getType() != LossLayer::type &&
+      loss_type != LossType::LOSS_NONE) {
     status = addLossLayer(loss_type);
     NN_RETURN_STATUS();
   }

--- a/nntrainer/layers/loss_layer.cpp
+++ b/nntrainer/layers/loss_layer.cpp
@@ -94,6 +94,10 @@ void LossLayer::forwarding(bool training) {
     throw std::runtime_error(
       "Error: Cross Entropy not supported without softmax or sigmoid.");
   }
+  case LossType::LOSS_NONE: {
+    hidden_ = y;
+    break;
+  }
   case LossType::LOSS_UNKNOWN:
     /** intended */
   default: { throw std::runtime_error("Error: Unknown loss_type."); }
@@ -157,6 +161,8 @@ void LossLayer::calcDerivative() {
   case LossType::LOSS_ENTROPY:
     throw std::runtime_error(
       "Error: Cross Entropy not supported without softmax or sigmoid.");
+  case LossType::LOSS_NONE:
+    throw std::runtime_error("Error: No loss provided for training.");
   case LossType::LOSS_UNKNOWN:
     /** intended */
   default:

--- a/nntrainer/layers/loss_layer.h
+++ b/nntrainer/layers/loss_layer.h
@@ -30,6 +30,7 @@ enum class LossType {
                          */
   LOSS_ENTROPY_SOFTMAX, /** Cross Entropy amalgamated with softmax for stability
                          */
+  LOSS_NONE,            /** No loss for this model */
   LOSS_UNKNOWN          /** Unknown */
 };
 

--- a/nntrainer/models/model_loader.cpp
+++ b/nntrainer/models/model_loader.cpp
@@ -60,7 +60,7 @@ int ModelLoader::loadModelConfigIni(dictionary *ini, NeuralNetwork &model) {
     iniparser_getstring(ini, "Model:Type", unknown), TOKEN_MODEL);
   model.epochs = iniparser_getint(ini, "Model:Epochs", model.epochs);
   model.loss_type = (LossType)parseType(
-    iniparser_getstring(ini, "Model:Loss", unknown), TOKEN_LOSS);
+    iniparser_getstring(ini, "Model:Loss", none), TOKEN_LOSS);
   const std::string &save_path =
     iniparser_getstring(ini, "Model:Save_path", unknown);
   if (save_path != unknown) {

--- a/nntrainer/models/model_loader.h
+++ b/nntrainer/models/model_loader.h
@@ -146,6 +146,7 @@ private:
   static bool fileTfLite(const std::string &filename);
 
   const char *unknown = "Unknown";
+  const char *none = "none";
 
   AppContext app_context;
 };

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -155,9 +155,8 @@ int NeuralNetwork::compile() {
   model_graph.topologicalSort();
 
   auto &sorted = model_graph.getSorted();
-  if (sorted.empty() ||
-      !istrequal(sorted.back().layer->getType(), LossLayer::type)) {
-    ml_loge("last layer is not loss layer");
+  if (sorted.empty()) {
+    ml_loge("Empty model");
     return ML_ERROR_INVALID_PARAMETER;
   }
 
@@ -366,6 +365,9 @@ void NeuralNetwork::backwarding(int iteration) {
    */
   auto iter_begin = model_graph.getBackwardingBeginIter();
   auto iter_end = model_graph.getBackwardingEndIter();
+
+  if (iter_begin->layer->getType() != LossLayer::type)
+    throw std::runtime_error("Error: no loss provided for training.");
 
   for (auto iter = iter_begin; iter != iter_end - 1; iter++) {
     backwarding(iter->layer, iteration, true);

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -93,7 +93,7 @@ public:
     epoch_idx(0),
     iter(0),
     loss(0.0f),
-    loss_type(LossType::LOSS_UNKNOWN),
+    loss_type(LossType::LOSS_NONE),
     weight_initializer(WeightInitializer::WEIGHT_UNKNOWN),
     net_type(NetType::UNKNOWN),
     manager(std::make_shared<Manager>()),

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -71,8 +71,9 @@ unsigned int parseType(std::string ll, InputType t) {
    * @brief     Loss Function String from configure file
    *            "mse"  : Mean Squared Error
    *            "caterogical" : Categorical Cross Entropy
+   *            "none" : No Loss attached to the model
    */
-  std::array<std::string, 2> loss_string = {"mse", "cross"};
+  std::array<std::string, 3> loss_string = {"mse", "cross", "none"};
 
   /**
    * @brief     Model Type String from configure file

--- a/test/test_models/models/mnist_inf.ini
+++ b/test/test_models/models/mnist_inf.ini
@@ -1,11 +1,66 @@
 # Network Section : Network
 [Model]
 Type = NeuralNetwork	# Network Type : Regression, KNN, NeuralNetwork
-Optimizer = adam 	# adam (Adamtive Moment Estimation)
-Loss = cross  		# Loss function : mse (mean squared error)
 Save_Path = "../test_models/models/model.bin"  	# model path to save / read
-batch_size = 1		# batch size
+# loss = none           # This also works
+batch_size = 1         # batch size
 
 [mnist]
 backbone = "../test_models/models/mnist.ini"
 Input_Shape = 1:28:28
+
+# Original Model
+# [inputlayer]
+# Type = input
+# Input_Shape = 1:28:28
+#
+# [conv2d_c1_layer]
+# Type = conv2d
+# input_layers=inputlayer
+# kernel_size = 5,5
+# bias_initializer=zeros
+# Activation=sigmoid
+# weight_initializer = xavier_uniform
+# filters = 6
+# stride = 1,1
+# padding = 0,0
+#
+# [pooling2d_p1]
+# Type=pooling2d
+# input_layers=conv2d_c1_layer
+# pool_size = 2,2
+# stride =2,2
+# padding = 0,0
+# pooling = average
+#
+# [conv2d_c2_layer]
+# Type = conv2d
+# input_layers=pooling2d_p1
+# kernel_size = 5,5
+# bias_initializer=zeros
+# Activation=sigmoid
+# weight_initializer = xavier_uniform
+# filters = 12
+# stride = 1,1
+# padding = 0,0
+#
+# [pooling2d_p2]
+# Type=pooling2d
+# input_layers=conv2d_c2_layer
+# pool_size = 2,2
+# stride =2,2
+# padding = 0,0
+# pooling = average
+#
+# [flatten]
+# Type=flatten
+# input_layers=pooling2d_p2
+#
+# [outputlayer]
+# Type = fully_connected
+# input_layers=flatten
+# Unit = 10		# Output Layer Dimension ( = Weight Width )
+# weight_initializer = xavier_uniform
+# bias_initializer = zeros
+##### Remove activation for feature extraction
+# Activation = softmax

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -303,7 +303,7 @@ INSTANTIATE_TEST_CASE_P(
 
   /**< half negative: init fail cases (1 positive and 4 negative cases) */
     mkIniTc("unknown_loss_n", {nw_adam + "loss = unknown", input, out+"input_layers=inputlayer"}, COMPFAIL | INITFAIL),
-    mkIniTc("activation_very_first_n", {nw_sgd, act_relu, input+"input_layers=activation_relu", out+"input_layers=inputlayer"}, COMPFAIL| INITFAIL),
+    mkIniTc("activation_very_first_n", {nw_sgd, act_relu, input+"input_layers=activation_relu", out+"input_layers=inputlayer"}, COMPFAIL | INITFAIL),
     mkIniTc("bnlayer_very_first_n", {nw_sgd, batch_normal, input+"input_layers=bn", out+"input_layers=inputlayer"}, COMPFAIL | INITFAIL),
     mkIniTc("act_layer_after_act_n", {nw_sgd, input, act_relu+"input_layers=inputlayer", out+"input_layers=activation_relu"}, INITFAIL),
     mkIniTc("act_layer_after_act_bn_n", {nw_sgd, input, act_relu+"input_layers=inputlayer", batch_normal+"input_layers=activation_relu", out+"input_layers=bn" }, INITFAIL),
@@ -323,7 +323,7 @@ INSTANTIATE_TEST_CASE_P(
     mkIniTc("wrong_opt_type_n", {nw_adam + "Optimizer = wrong_opt", input, out+"input_layers=inputlayer"}, ALLFAIL),
     mkIniTc("adam_minus_lr_n", {nw_adam + "Learning_rate = -0.1", input, out+"input_layers=inputlayer"}, ALLFAIL),
     mkIniTc("sgd_minus_lr_n", {nw_sgd + "Learning_rate = -0.1", input, out+"input_layers=inputlayer"}, ALLFAIL),
-    mkIniTc("no_loss_n", {nw_adam + "-loss", input, out+"input_layers=inputlayer"}, COMPFAIL | INITFAIL),
+    mkIniTc("no_loss_p", {nw_adam + "-loss", input, out+"input_layers=inputlayer"}, SUCCESS),
     mkIniTc("unknown_layer_type_n", {nw_adam, input + "Type = asdf", out+"input_layers=inputlayer"}, ALLFAIL),
     mkIniTc("unknown_layer_type2_n", {nw_adam, input, out + "Type = asdf"+"input_layers=inputlayer", I(out, "outlayer", "")}, ALLFAIL),
 


### PR DESCRIPTION
Allow setting no loss in the model
This allows inferencing a model, and creating submodels
with backbones to infer some particular output features

Updated existing unittest with no loss to succeed
and added more unittests to validate that models run successfully
without loss

See Also #927

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>