### PR TITLE
[model] Allow update batch size

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -123,6 +123,8 @@ int NeuralNetwork::setTrainConfig(std::vector<std::string> values) {
     case PropertyType::batch_size: {
       status = setUint(batch_size, value);
       NN_RETURN_STATUS();
+      if (initialized)
+        setBatchSize();
       /** TODO: increase buffer size if it is smaller than batch size.
        * also if this is set with default batch size, then make it
        * smaller/larger

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -270,6 +270,15 @@ void Manager::allocateWeights() {
   }
 }
 
+void Manager::deallocateWeights() {
+  for (auto &l_w : weights) {
+    for (auto &w : l_w) {
+      Weight &weight = w.get();
+      weight.deallocateVariable();
+    }
+  }
+}
+
 void Manager::allocateGradients() {
   /** Allocate the source tensors for shared memories */
   if (!shared_grad.uninitialized())
@@ -279,6 +288,17 @@ void Manager::allocateGradients() {
     for (auto &w : l_w) {
       Weight &weight = w.get();
       weight.allocateGradient();
+    }
+  }
+}
+
+void Manager::deallocateGradients() {
+  shared_grad.deallocate();
+
+  for (auto &l_w : weights) {
+    for (auto &w : l_w) {
+      Weight &weight = w.get();
+      weight.deallocateGradient();
     }
   }
 }
@@ -419,6 +439,16 @@ void Manager::allocateInOuts() {
   }
 }
 
+void Manager::deallocateInOuts() {
+  shared_inout.deallocate();
+
+  for (auto &l_io : in_outs) {
+    for (auto &io : l_io) {
+      io->deallocateVariable();
+    }
+  }
+}
+
 void Manager::allocateDerivatives() {
   /** Allocate the source tensors for shared memories */
   if (!shared_deriv.uninitialized())
@@ -427,6 +457,16 @@ void Manager::allocateDerivatives() {
   for (auto &l_io : in_outs) {
     for (auto &io : l_io) {
       io->allocateGradient();
+    }
+  }
+}
+
+void Manager::deallocateDerivatives() {
+  shared_deriv.deallocate();
+
+  for (auto &l_io : in_outs) {
+    for (auto &io : l_io) {
+      io->deallocateGradient();
     }
   }
 }

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -240,9 +240,21 @@ public:
       max_derivative_size *= batch;
       max_shared_inout *= batch;
     }
+
+    /**
+     * All the tensors must be deallocated first and then allocated.
+     * Deallocating and allocating tensors one by one can potentially lead to
+     * high requirement of the peak memory requirement.
+     */
+    deallocateInOuts();
+    deallocateDerivatives();
+
     for (auto &in_out : in_outs)
       for (auto &vg : in_out)
         vg->setBatchSize(batch);
+
+    allocateInOuts();
+    allocateDerivatives();
   }
 
   /**
@@ -255,6 +267,18 @@ public:
     allocateGradients();
     allocateInOuts();
     allocateDerivatives();
+  }
+
+  /**
+   * @brief Deallocate memory for all the managed tensors
+   */
+  void deallocateTensors(bool dealloc_weights = false) {
+    if (dealloc_weights)
+      deallocateWeights();
+
+    deallocateGradients();
+    deallocateInOuts();
+    deallocateDerivatives();
   }
 
   /**
@@ -276,6 +300,29 @@ public:
    * @brief Allocate memory for all the managed layer derivatives
    */
   void allocateDerivatives();
+
+  /**
+   * @brief Deallocate memory for all the weights
+   */
+  void deallocateWeights();
+
+  /**
+   * @brief Deallocate memory for all the gradients of the weights
+   *
+   */
+  void deallocateGradients();
+
+  /**
+   * @brief Deallocate memory for all the input and output tensors
+   *
+   */
+  void deallocateInOuts();
+
+  /**
+   * @brief Deallocate memory for all the inputs and outputs derivative tensors
+   *
+   */
+  void deallocateDerivatives();
 
 private:
   // TODO: ensure that names of these weights are unique

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -156,7 +156,6 @@ void Tensor::allocate() {
     data = std::shared_ptr<float>(src_tensor->tensor()->data,
                                   src_tensor->tensor()->data.get() +
                                     src_tensor->offset());
-    src_tensor = nullptr;
   } else {
     /// allocate new memory for the tensor data
     data = std::shared_ptr<float>(new float[dim.getDataLen()],
@@ -486,7 +485,8 @@ void Tensor::createSharedDataTensor(const Tensor &src, Tensor &dest,
    * - If src.src_tensor exists, then use the src.src_tensor to create the
    *  required SrcSharedTensor to avoid recursive dependency.
    *
-   * @note src.data and src.src_tensor cannot co-exist.
+   * @note src.data and src.src_tensor CAN co-exist. src.src_tensor is stored
+   * if the batch size of src is updated and needs reallocation.
    */
   if (src.data)
     dest.data = std::shared_ptr<float>(src.data, src.data.get() + offset);

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -254,7 +254,7 @@ public:
   /*
    * @brief Allocate memory for the variable and gradient
    */
-  void alllocate() {
+  void allocate() {
     allocateVariable();
     allocateGradient();
   }

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -203,12 +203,11 @@ public:
 
   void setBatchSize(unsigned int batch) {
     dim.batch(batch);
-    /** @note This will shape when changing batch size with initialized
-     * variables */
+
     if (!var->uninitialized())
-      var->reshape(dim);
+      var->updateBatch(batch);
     if (!grad->uninitialized())
-      grad->reshape(dim);
+      grad->updateBatch(batch);
   }
 
   /**
@@ -251,6 +250,32 @@ public:
     grad->allocate();
     resetGradient();
   }
+
+  /*
+   * @brief Allocate memory for the variable and gradient
+   */
+  void alllocate() {
+    allocateVariable();
+    allocateGradient();
+  }
+
+  /*
+   * @brief Deallocate memory for the variable and gradient
+   */
+  void deallocate() {
+    deallocateVariable();
+    deallocateGradient();
+  }
+
+  /**
+   * @brief Deallocate memory for the variable
+   */
+  void deallocateVariable() { var->deallocate(); }
+
+  /**
+   * @brief Deallocate memory for the variable
+   */
+  void deallocateGradient() { grad->deallocate(); }
 
   /**
    * @bried Update the variable to use the given tensor

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -246,6 +246,14 @@ public:
    */
   void applyGradient(double lr) { var->add_i(*grad.get(), -lr); }
 
+  /**
+   * @brief Deallocate memory for the gradient of the weight
+   */
+  void deallocateGradient() {
+    Var_Grad::deallocateGradient();
+    opt_vars.clear();
+  }
+
 private:
   WeightInitializer initializer; /**< initializer for this variable */
   WeightRegularizer regularizer; /**< regularizer for this variable */

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -307,6 +307,75 @@ TEST(nntrainer_ccapi, train_dataset_with_generator_01_p) {
 }
 
 /**
+ * @brief Neural Network Model Training
+ */
+TEST(nntrainer_ccapi, train_batch_size_update_after) {
+  std::unique_ptr<ml::train::Model> model;
+  std::shared_ptr<ml::train::Layer> layer;
+  std::shared_ptr<ml::train::Optimizer> optimizer;
+  std::shared_ptr<ml::train::Dataset> dataset;
+
+  EXPECT_NO_THROW(model =
+                    ml::train::createModel(ml::train::ModelType::NEURAL_NET));
+
+  EXPECT_NO_THROW(layer = ml::train::layer::Input({"input_shape=1:1:62720",
+                                                   "normalization=true",
+                                                   "bias_initializer=zeros"}));
+  EXPECT_NO_THROW(model->addLayer(layer));
+
+  EXPECT_NO_THROW(
+    layer = ml::train::layer::FullyConnected(
+      {"unit= 10", "activation=softmax", "bias_initializer=zeros",
+       "weight_regularizer=l2norm", "weight_regularizer_constant=0.005",
+       "weight_initializer=xavier_uniform",
+       "input_layers=" + layer->getName()}));
+  EXPECT_NO_THROW(model->addLayer(layer));
+
+  EXPECT_NO_THROW(
+    optimizer = ml::train::optimizer::Adam(
+      {"learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
+       "beta1=0.002", "beta2=0.001", "epsilon=1e-7"}));
+  EXPECT_NO_THROW(model->setOptimizer(optimizer));
+
+  EXPECT_NO_THROW(
+    dataset = ml::train::createDataset(
+      ml::train::DatasetType::FILE, "trainingSet.dat", "valSet.dat", nullptr));
+  EXPECT_EQ(dataset->setProperty({"label_data=label.dat", "buffer_size=100"}),
+            ML_ERROR_NONE);
+  EXPECT_EQ(model->setDataset(dataset), ML_ERROR_NONE);
+
+  EXPECT_EQ(model->setProperty({"loss=cross", "batch_size=16", "epochs=1",
+                                "save_path=model.bin"}),
+            ML_ERROR_NONE);
+
+  /** Update batch size after compile */
+  EXPECT_EQ(model->compile(), ML_ERROR_NONE);
+  EXPECT_EQ(model->setProperty({"batch_size=128"}), ML_ERROR_NONE);
+
+  /** Update batch size after initialize */
+  EXPECT_EQ(model->initialize(), ML_ERROR_NONE);
+  EXPECT_EQ(model->setProperty({"batch_size=8"}), ML_ERROR_NONE);
+
+  EXPECT_NO_THROW(model->train());
+
+  /** Update batch size after train */
+  EXPECT_EQ(model->setProperty({"batch_size=16"}), ML_ERROR_NONE);
+  EXPECT_NO_THROW(model->train());
+
+  /** Update batch size after train */
+  EXPECT_EQ(model->setProperty({"batch_size=32"}), ML_ERROR_NONE);
+  EXPECT_NO_THROW(model->train());
+
+  /** Update batch size after train */
+  EXPECT_EQ(model->setProperty({"batch_size=4"}), ML_ERROR_NONE);
+  EXPECT_NO_THROW(model->train());
+
+  EXPECT_FLOAT_EQ(model->getTrainingLoss(), 1.9582682);
+  EXPECT_FLOAT_EQ(model->getValidationLoss(), 2.1831701);
+  EXPECT_FLOAT_EQ(model->getLoss(), 2.1985414);
+}
+
+/**
  * @brief Main gtest
  */
 int main(int argc, char **argv) {

--- a/test/nnstreamer_filter_nntrainer/runTest.sh
+++ b/test/nnstreamer_filter_nntrainer/runTest.sh
@@ -72,14 +72,14 @@ else
 fi
 
 # Test with mnist model
-PATH_TO_CONFIG="../test_models/models/mnist_inf.ini"
+PATH_TO_CONFIG="../test_models/models/mnist.ini"
 PATH_TO_DATA="../test_models/data/2.png"
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_DATA} ! pngdec ! tensor_converter ! other/tensor,dimension=1:28:28:1 ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_transform mode=typecast option=float32 ! tensor_filter framework=nntrainer model=${PATH_TO_CONFIG} input=28:28:1:1 inputtype=float32 output=10 outputtype=float32 ! filesink location=nntrainer.out.1.log" 1 0 0 $PERFORMANCE
 python checkLabel.py nntrainer.out.1.log 2
 testResult $? 1 "Golden test comparison" 0 1
 
-PATH_TO_CONFIG="../test_models/models/mnist_inf.ini"
+PATH_TO_CONFIG="../test_models/models/mnist.ini"
 PATH_TO_DATA="../test_models/data/0.png"
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_DATA} ! pngdec ! tensor_converter ! tensor_transform mode=transpose option=1:2:0:3 ! tensor_transform mode=typecast option=float32 ! tensor_filter framework=nntrainer model=${PATH_TO_CONFIG} input=28:28:1:1 inputtype=float32 output=10:1:1:1 outputtype=float32 ! filesink location=nntrainer.out.2.log" 1 0 0 $PERFORMANCE


### PR DESCRIPTION
Commit 1: [tensor] Allow updating batch size after allocation 
Allow updating batch size after memory allocation for tensor.
If previously allocated memory is first set to null and then allocated again
with the new batch size. As tensors share memory, the previously allocated
might not be freed when set to null and can lead to high peak memory usage.
It is recommended to free the memory for all tensors whose batch size is changing
first, update batch size and then allocate again to keep the peak memory requirement
at check.

As the memory is allowed to be re-allocated, the src_tensor for a tensor is not
reset anymore after memory allocation. When reallocating, the src_tensor is used
again in order to maintain the memory management done once duing initialization.

This patch also sets appropriate interface in Var_Grad and Weight classes as well.

Commit 2: [model] Allow updating batch size after allocation
Allow updating the batch size after memory allocation has been done
This allows changing the batch size for training anytime.

Further, it allows changing the batch size from training to inference and back
which is demonstrated with MNIST example in nnstreamer element of nntrainer.
The model file starts with batch size of 32, which is changed to 1 for inference.

Also added another unittest in cpp-api which sets different batch size in different
stages of the model, after initialization, after compile, after train and trains multiple times
with different batch sizes to validate that the training works.

Resolve #914

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>