### PR TITLE
[ DEBIAN ] Fix gcc version for debian build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: nntrainer
 Section: libs
 Priority: optional
 Maintainer: Jijoong Moon <jijoong.moon@samsung.com>
-Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
+Build-Depends: gcc-9 | gcc-8 | gcc-7 (>=7.5),
  python3, python3-dev, python3-numpy,
  pkg-config, cmake, ninja-build, meson (>=0.50), debhelper (>=9), libboost-dev,
  libopenblas-dev, libiniparser-dev, tensorflow-lite-dev, libjsoncpp-dev,


### PR DESCRIPTION
Set higher gcc version to build debian

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>