### PR TITLE
[meson] Set meson buildtype to release

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,8 @@ project('nntrainer', 'c', 'cpp',
     'werror=true',
     'warning_level=1',
     'c_std=gnu89',
-    'cpp_std=c++14'
+    'cpp_std=c++14',
+    'buildtype=release'
   ]
 )
 add_project_arguments('-DMIN_CPP_VERSION=201402', language:['c','cpp'])
@@ -37,7 +38,6 @@ warning_flags = [
   '-Wvla',
   '-Wpointer-arith',
   '-Wno-error=varargs',
-  '-O2',
   '-ftree-vectorize'
 ]
 


### PR DESCRIPTION
Setting -O optimization manually gives meson warnings.
```
meson.build:59: WARNING: Consider using the built-in optimization level instead of using "-O2".
```

Instead update meson buildtype to release
This sets debug to 0 and optimization to level 3.

Note that this patch increases the optimization level of the library from 2 to 3.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>