### PR TITLE
[Fix] Update lazy alloc ctor to lazy alloc

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -101,9 +101,14 @@ Tensor::Tensor(const TensorDim &d, const float *buf) : Tensor() {
   }
 }
 
-Tensor::Tensor(const TensorDim &d, bool alloc_now) : Tensor(d, nullptr) {
-  if (d.getDataLen() != 0 && alloc_now)
-    allocate();
+Tensor::Tensor(const TensorDim &d, bool alloc_now) : Tensor() {
+  if (d.getDataLen() != 0) {
+    dim = d;
+    strides = d.computeStrides();
+
+    if (alloc_now)
+      allocate();
+  }
 }
 
 /**


### PR DESCRIPTION
This patch fixes lazy alloc ctor to lazy allocate which were delegated
to eager ctor thus causing allocating tensor twice for the lazy
allocated tensor

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
