### PR TITLE
[Chore] s/since/Since/

### DIFF
--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -29,14 +29,14 @@ extern "C" {
 typedef enum {
   ML_TRAIN_LAYER_TYPE_INPUT = 0,  /**< Input Layer */
   ML_TRAIN_LAYER_TYPE_FC,         /**< Fully Connected Layer */
-  ML_TRAIN_LAYER_TYPE_BN,         /**< Batch Normalization Layer (since 6.5) */
-  ML_TRAIN_LAYER_TYPE_CONV2D,     /**< Convolution 2D Layer (since 6.5) */
-  ML_TRAIN_LAYER_TYPE_POOLING2D,  /**< Pooling 2D Layer (since 6.5) */
-  ML_TRAIN_LAYER_TYPE_FLATTEN,    /**< Flatten Layer (since 6.5) */
-  ML_TRAIN_LAYER_TYPE_ACTIVATION, /**< Activation Layer (since 6.5) */
-  ML_TRAIN_LAYER_TYPE_ADDITION,   /**< Addition Layer (since 6.5) */
-  ML_TRAIN_LAYER_TYPE_CONCAT,     /**< Concat Layer (since 6.5) */
-  ML_TRAIN_LAYER_TYPE_MULTIOUT,   /**< MultiOut Layer (since 6.5) */
+  ML_TRAIN_LAYER_TYPE_BN,         /**< Batch Normalization Layer (Since 6.5) */
+  ML_TRAIN_LAYER_TYPE_CONV2D,     /**< Convolution 2D Layer (Since 6.5) */
+  ML_TRAIN_LAYER_TYPE_POOLING2D,  /**< Pooling 2D Layer (Since 6.5) */
+  ML_TRAIN_LAYER_TYPE_FLATTEN,    /**< Flatten Layer (Since 6.5) */
+  ML_TRAIN_LAYER_TYPE_ACTIVATION, /**< Activation Layer (Since 6.5) */
+  ML_TRAIN_LAYER_TYPE_ADDITION,   /**< Addition Layer (Since 6.5) */
+  ML_TRAIN_LAYER_TYPE_CONCAT,     /**< Concat Layer (Since 6.5) */
+  ML_TRAIN_LAYER_TYPE_MULTIOUT,   /**< MultiOut Layer (Since 6.5) */
   ML_TRAIN_LAYER_TYPE_UNKNOWN = 999 /**< Unknown Layer */
 } ml_train_layer_type_e;
 


### PR DESCRIPTION
From tizen convention since should be Since, this patch resolves the
issue

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
