### PR TITLE
[Fix warning] Add override specifier

### DIFF
--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -48,19 +48,19 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @brief     Read Activation layer params. This is essentially noops for now.
    * @param[in] file input stream file
    */
-  void read(std::ifstream &file){/* noop */};
+  void read(std::ifstream &file) override{/* noop */};
 
   /**
    * @brief     Save Activation layer params. This is essentially noops for now.
    * @param[in] file output stream file
    */
-  void save(std::ofstream &file){/* noop */};
+  void save(std::ofstream &file) override{/* noop */};
 
   /**
    * @copydoc Layer::forwarding(bool training)
@@ -70,19 +70,19 @@ public:
   /**
    * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative();
+  void calcDerivative() override;
 
   /**
    * @brief setActivation by preset ActivationType
    *
    * @param[in] ActivationType
    */
-  void setActivation(ActivationType acti_type);
+  void setActivation(ActivationType acti_type) override;
 
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const { return ActivationLayer::type; };
+  const std::string getType() const override { return ActivationLayer::type; };
 
   /**
    * @brief       Calculate softmax for Tensor Type

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -57,19 +57,19 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @brief     Read Weight & Bias Data from file
    * @param[in] file input stream file
    */
-  void read(std::ifstream &file){};
+  void read(std::ifstream &file) override{};
 
   /**
    * @brief     Save Weight & Bias Data to file
    * @param[in] file output stream file
    */
-  void save(std::ofstream &file){};
+  void save(std::ofstream &file) override{};
 
   /**
    * @copydoc Layer::forwarding(bool training)
@@ -79,12 +79,12 @@ public:
   /**
    * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative();
+  void calcDerivative() override;
 
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const { return AdditionLayer::type; };
+  const std::string getType() const override { return AdditionLayer::type; };
 
   using Layer::setProperty;
 
@@ -92,7 +92,8 @@ public:
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)
    */
-  void setProperty(const PropertyType type, const std::string &value = "");
+  void setProperty(const PropertyType type,
+                   const std::string &value = "") override;
 
   static const std::string type;
 };

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -83,30 +83,32 @@ public:
   /**
    * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative();
+  void calcDerivative() override;
 
   /**
    * @copydoc Layer::calcGradient()
    */
-  void calcGradient();
+  void calcGradient() override;
 
   /**
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l);
+  void copy(std::shared_ptr<Layer> l) override;
 
   /**
    * @brief     initialize layer
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const { return BatchNormalizationLayer::type; }
+  const std::string getType() const override {
+    return BatchNormalizationLayer::type;
+  }
 
   using Layer::setProperty;
 
@@ -114,7 +116,8 @@ public:
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)
    */
-  void setProperty(const PropertyType type, const std::string &value = "");
+  void setProperty(const PropertyType type,
+                   const std::string &value = "") override;
 
   static const std::string type;
 

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -57,19 +57,19 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @brief     Read Weight & Bias Data from file
    * @param[in] file input stream file
    */
-  void read(std::ifstream &file){};
+  void read(std::ifstream &file) override{};
 
   /**
    * @brief     Save Weight & Bias Data to file
    * @param[in] file output stream file
    */
-  void save(std::ofstream &file){};
+  void save(std::ofstream &file) override{};
 
   /**
    * @copydoc Layer::forwarding(bool training)
@@ -79,18 +79,19 @@ public:
   /**
    * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative();
+  void calcDerivative() override;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)
    */
-  void setProperty(const PropertyType type, const std::string &value = "");
+  void setProperty(const PropertyType type,
+                   const std::string &value = "") override;
 
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const { return ConcatLayer::type; };
+  const std::string getType() const override { return ConcatLayer::type; };
 
   static const std::string type;
 };

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -70,7 +70,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @copydoc Layer::forwarding(bool training)
@@ -80,18 +80,18 @@ public:
   /**
    * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative();
+  void calcDerivative() override;
 
   /**
    * @copydoc Layer::calcGradient()
    */
-  void calcGradient();
+  void calcGradient() override;
 
   /**
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l);
+  void copy(std::shared_ptr<Layer> l) override;
 
   /* TO DO : support keras type of padding */
   /* enum class PaddingType { */
@@ -104,7 +104,7 @@ public:
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const { return Conv2DLayer::type; };
+  const std::string getType() const override { return Conv2DLayer::type; };
 
   using Layer::setProperty;
 
@@ -112,14 +112,15 @@ public:
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)
    */
-  void setProperty(const PropertyType type, const std::string &value = "");
+  void setProperty(const PropertyType type,
+                   const std::string &value = "") override;
 
   static const std::string type;
 
   /**
    * @copydoc Layer::scaleSize(float scalesize)
    */
-  void scaleSize(float scalesize) noexcept;
+  void scaleSize(float scalesize) noexcept override;
 
 private:
   unsigned int filter_size;

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -59,30 +59,32 @@ public:
   /**
    * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative();
+  void calcDerivative() override;
 
   /**
    * @copydoc Layer::calcGradient()
    */
-  void calcGradient();
+  void calcGradient() override;
 
   /**
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l);
+  void copy(std::shared_ptr<Layer> l) override;
 
   /**
    * @brief     initialize layer
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const { return FullyConnectedLayer::type; };
+  const std::string getType() const override {
+    return FullyConnectedLayer::type;
+  };
 
   using Layer::setProperty;
 
@@ -90,14 +92,15 @@ public:
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)
    */
-  void setProperty(const PropertyType type, const std::string &value = "");
+  void setProperty(const PropertyType type,
+                   const std::string &value = "") override;
 
   static const std::string type;
 
   /**
    * @copydoc Layer::scaleSize(float scalesize)
    */
-  void scaleSize(float scalesize) noexcept;
+  void scaleSize(float scalesize) noexcept override;
 
 private:
   unsigned int unit;

--- a/nntrainer/layers/flatten_layer.h
+++ b/nntrainer/layers/flatten_layer.h
@@ -55,19 +55,19 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @brief     Read Weight & Bias Data from file
    * @param[in] file input stream file
    */
-  void read(std::ifstream &file){};
+  void read(std::ifstream &file) override{};
 
   /**
    * @brief     Save Weight & Bias Data to file
    * @param[in] file output stream file
    */
-  void save(std::ofstream &file){};
+  void save(std::ofstream &file) override{};
 
   /**
    * @copydoc Layer::forwarding(bool training)
@@ -77,12 +77,12 @@ public:
   /**
    * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative();
+  void calcDerivative() override;
 
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const { return FlattenLayer::type; };
+  const std::string getType() const override { return FlattenLayer::type; };
 
   static const std::string type;
 };

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -67,12 +67,12 @@ public:
   /**
    * @brief     No Weight data for this Input Layer
    */
-  void read(std::ifstream &file){};
+  void read(std::ifstream &file) override{};
 
   /**
    * @brief     No Weight data for this Input Layer
    */
-  void save(std::ofstream &file){};
+  void save(std::ofstream &file) override{};
 
   /**
    * @copydoc Layer::forwarding(bool training)
@@ -81,24 +81,24 @@ public:
   /**
    * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative();
+  void calcDerivative() override;
 
   /**
    * @brief     Initializer of Input Layer
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @copydoc Layer::setTrainable(bool train)
    */
-  void setTrainable(bool train);
+  void setTrainable(bool train) override;
 
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const { return InputLayer::type; };
+  const std::string getType() const override { return InputLayer::type; };
 
   using Layer::setProperty;
 
@@ -106,7 +106,8 @@ public:
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)
    */
-  void setProperty(const PropertyType type, const std::string &value = "");
+  void setProperty(const PropertyType type,
+                   const std::string &value = "") override;
 
   static const std::string type;
 

--- a/nntrainer/layers/loss_layer.h
+++ b/nntrainer/layers/loss_layer.h
@@ -60,37 +60,37 @@ public:
   /**
    * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative();
+  void calcDerivative() override;
 
   /**
    * @brief     read layer Weight & Bias data from file
    * @param[in] file input file stream
    */
-  void read(std::ifstream &file) {}
+  void read(std::ifstream &file) override {}
 
   /**
    * @brief     save layer Weight & Bias data from file
    * @param[in] file output file stream
    */
-  void save(std::ofstream &file) {}
+  void save(std::ofstream &file) override {}
 
   /**
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l);
+  void copy(std::shared_ptr<Layer> l) override;
 
   /**
    * @brief     initialize layer
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const { return LossLayer::type; };
+  const std::string getType() const override { return LossLayer::type; };
 
   /**
    * @brief     set loss function

--- a/nntrainer/layers/output_layer.h
+++ b/nntrainer/layers/output_layer.h
@@ -57,19 +57,19 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @brief     Read Weight & Bias Data from file
    * @param[in] file input stream file
    */
-  void read(std::ifstream &file){};
+  void read(std::ifstream &file) override{};
 
   /**
    * @brief     Save Weight & Bias Data to file
    * @param[in] file output stream file
    */
-  void save(std::ofstream &file){};
+  void save(std::ofstream &file) override{};
 
   /**
    * @copydoc Layer::forwarding(bool training)
@@ -78,18 +78,19 @@ public:
   /**
    * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative();
+  void calcDerivative() override;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)
    */
-  void setProperty(const PropertyType type, const std::string &value = "");
+  void setProperty(const PropertyType type,
+                   const std::string &value = "") override;
 
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const { return OutputLayer::type; };
+  const std::string getType() const override { return OutputLayer::type; };
 
   static const std::string type;
 };

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -75,19 +75,19 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @brief     Read Weight & Bias Data from file
    * @param[in] file input stream file
    */
-  void read(std::ifstream &file){};
+  void read(std::ifstream &file) override{};
 
   /**
    * @brief     Save Weight & Bias Data to file
    * @param[in] file output stream file
    */
-  void save(std::ofstream &file){};
+  void save(std::ofstream &file) override{};
 
   /**
    * @copydoc Layer::forwarding(bool training)
@@ -97,13 +97,13 @@ public:
   /**
    * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative();
+  void calcDerivative() override;
 
   /**
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l);
+  void copy(std::shared_ptr<Layer> l) override;
 
   /* TO DO : support keras type of padding */
   enum class PaddingType {
@@ -116,7 +116,7 @@ public:
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const { return Pooling2DLayer::type; };
+  const std::string getType() const override { return Pooling2DLayer::type; };
 
   using Layer::setProperty;
 
@@ -124,7 +124,8 @@ public:
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)
    */
-  void setProperty(const PropertyType type, const std::string &value = "");
+  void setProperty(const PropertyType type,
+                   const std::string &value = "") override;
 
   static const std::string type;
 

--- a/nntrainer/layers/preprocess_flip_layer.h
+++ b/nntrainer/layers/preprocess_flip_layer.h
@@ -59,7 +59,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @copydoc Layer::forwarding()

--- a/nntrainer/layers/preprocess_translate_layer.h
+++ b/nntrainer/layers/preprocess_translate_layer.h
@@ -94,7 +94,8 @@ public:
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)
    */
-  void setProperty(const PropertyType type, const std::string &value = "");
+  void setProperty(const PropertyType type,
+                   const std::string &value = "") override;
 
   static const std::string type;
 

--- a/nntrainer/layers/tflite_layer.h
+++ b/nntrainer/layers/tflite_layer.h
@@ -54,27 +54,27 @@ public:
   /**
    * @copydoc Layer::calcDerivative()
    */
-  void calcDerivative();
+  void calcDerivative() override;
 
   /**
    * @copydoc Layer::copy(std::shared_ptr<layer> l)
    */
-  void copy(std::shared_ptr<Layer> l);
+  void copy(std::shared_ptr<Layer> l) override;
 
   /**
    * @copydoc Layer::initialize()
    */
-  int initialize(Manager &manager);
+  int initialize(Manager &manager) override;
 
   /**
    * @copydoc Layer::setTrainable(bool train)
    */
-  void setTrainable(bool train);
+  void setTrainable(bool train) override;
 
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const { return TfLiteLayer::type; };
+  const std::string getType() const override { return TfLiteLayer::type; };
 
   using Layer::setProperty;
 
@@ -82,7 +82,8 @@ public:
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)
    */
-  void setProperty(const PropertyType type, const std::string &value = "");
+  void setProperty(const PropertyType type,
+                   const std::string &value = "") override;
 
   static const std::string type;
 


### PR DESCRIPTION
Add override specifier to fix some Android build warnings. (Related to #924)
* Warnings about override specifiers are resolved, but there are still some remaining warnings:
```
warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
```
<details>
<summary> full log </summary>

```
Android.mk:19: INIPARSER_ROOT is not defined!
Android.mk:20: INIPARSER SRC is going to be downloaded!
Cloning into 'iniparser'...
~/development/nntrainer/jni ~/development/nntrainer/jni PREPARING ini parser at ./ ~/development/nntrainer/jni
Android.mk:35: BUILDING TFLITE BACKBONE !
Android.mk:40: TENSORFLOW_ROOT is not defined!
Android.mk:41: TENSORFLOW SRC is going to be downloaded!
PREPARING TENSORFLOW 2.3.0 at ./ ~/development/nntrainer/jni ~/development/nntrainer/jni [TENSORFLOW-LITE] Download tensorflow-2.3.0 [TENSORFLOW-LITE] Finish downloading tensorflow-2.3.0 [TENSORFLOW-LITE] untar tensorflow-2.3.0 ~/development/nntrainer/jni
[arm64-v8a] Prebuilt       : libc++_shared.so <= <NDK>/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/
[arm64-v8a] Compile++      : nntrainer <= databuffer_factory.cpp
[arm64-v8a] Compile++      : nntrainer <= databuffer_func.cpp
[arm64-v8a] Compile++      : nntrainer <= dynamic_training_optimization.cpp
In file included from ././../nntrainer/models/dynamic_training_optimization.cpp:17:
In file included from ./../nntrainer/models/dynamic_training_optimization.h:42:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/models/dynamic_training_optimization.cpp:17:
In file included from ./../nntrainer/models/dynamic_training_optimization.h:42:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : capi-nntrainer <= nntrainer_util.cpp
In file included from ././../api/capi/src/nntrainer_util.cpp:14:
In file included from ./../api/capi/include/nntrainer_internal.h:28:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../api/capi/src/nntrainer_util.cpp:14:
In file included from ./../api/capi/include/nntrainer_internal.h:28:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= databuffer.cpp
[arm64-v8a] Compile++      : nntrainer <= databuffer_file.cpp
[arm64-v8a] Compile++      : nntrainer <= var_grad.cpp
[arm64-v8a] Compile++      : nntrainer <= weight.cpp
[arm64-v8a] Compile++      : nntrainer <= blas_interface.cpp
[arm64-v8a] Compile++      : nntrainer <= tflite_layer.cpp
In file included from ././../nntrainer/layers/tflite_layer.cpp:15:
In file included from ./../nntrainer/layers/tflite_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/tflite_layer.cpp:15:
In file included from ./../nntrainer/layers/tflite_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= manager.cpp
In file included from ././../nntrainer/tensor/manager.cpp:32:
In file included from ./../nntrainer/layers/activation_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/tensor/manager.cpp:32:
In file included from ./../nntrainer/layers/activation_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
././../nntrainer/tensor/manager.cpp:103:15: warning: function previously declared with an explicit exception specification redeclared with an implicit exception specification [-Wimplicit-exception-spec-mismatch]
MMapedMemory::~MMapedMemory() {
              ^
./../nntrainer/tensor/manager.h:43:3: note: previous declaration is here
  ~MMapedMemory() noexcept;
  ^
3 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= lazy_tensor.cpp
[arm64-v8a] Compile++      : nntrainer <= tensor.cpp
[arm64-v8a] Compile++      : nntrainer <= input_layer.cpp
In file included from ././../nntrainer/layers/input_layer.cpp:24:
In file included from ./../nntrainer/layers/input_layer.h:27:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/input_layer.cpp:24:
In file included from ./../nntrainer/layers/input_layer.h:27:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= output_layer.cpp
In file included from ././../nntrainer/layers/output_layer.cpp:15:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/output_layer.cpp:15:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= app_context.cpp
In file included from ././../nntrainer/app_context.cpp:25:
In file included from ./../nntrainer/layers/activation_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/app_context.cpp:25:
In file included from ./../nntrainer/layers/activation_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= model_loader.cpp
In file included from ././../nntrainer/models/model_loader.cpp:20:
In file included from ./../nntrainer/layers/layer_factory.h:17:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/models/model_loader.cpp:20:
In file included from ./../nntrainer/layers/layer_factory.h:17:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= fc_layer.cpp
In file included from ././../nntrainer/layers/fc_layer.cpp:24:
In file included from ./../nntrainer/layers/fc_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/fc_layer.cpp:24:
In file included from ./../nntrainer/layers/fc_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= layer_factory.cpp
In file included from ././../nntrainer/layers/layer_factory.cpp:13:
In file included from ./../nntrainer/layers/layer_factory.h:17:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/layer_factory.cpp:13:
In file included from ./../nntrainer/layers/layer_factory.h:17:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= tensor_dim.cpp
[arm64-v8a] Compile++      : nntrainer <= neuralnet.cpp
In file included from ././../nntrainer/models/neuralnet.cpp:30:
In file included from ./../nntrainer/models/model_loader.h:20:
In file included from ./../nntrainer/models/neuralnet.h:34:
In file included from ./../nntrainer/layers/activation_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/models/neuralnet.cpp:30:
In file included from ./../nntrainer/models/model_loader.h:20:
In file included from ./../nntrainer/models/neuralnet.h:34:
In file included from ./../nntrainer/layers/activation_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= bn_layer.cpp
In file included from ././../nntrainer/layers/bn_layer.cpp:25:
In file included from ./../nntrainer/layers/bn_layer.h:31:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/bn_layer.cpp:25:
In file included from ./../nntrainer/layers/bn_layer.h:31:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= loss_layer.cpp
In file included from ././../nntrainer/layers/loss_layer.cpp:24:
In file included from ./../nntrainer/layers/activation_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/loss_layer.cpp:24:
In file included from ./../nntrainer/layers/activation_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= pooling2d_layer.cpp
In file included from ././../nntrainer/layers/pooling2d_layer.cpp:17:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/pooling2d_layer.cpp:17:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= conv2d_layer.cpp
In file included from ././../nntrainer/layers/conv2d_layer.cpp:19:
In file included from ./../nntrainer/layers/conv2d_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/conv2d_layer.cpp:19:
In file included from ./../nntrainer/layers/conv2d_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= flatten_layer.cpp
In file included from ././../nntrainer/layers/flatten_layer.cpp:14:
In file included from ./../nntrainer/layers/flatten_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/flatten_layer.cpp:14:
In file included from ./../nntrainer/layers/flatten_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : capi-nntrainer <= nntrainer.cpp
In file included from ././../api/capi/src/nntrainer.cpp:25:
In file included from ./../nntrainer/layers/layer_factory.h:17:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../api/capi/src/nntrainer.cpp:25:
In file included from ./../nntrainer/layers/layer_factory.h:17:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= layer.cpp
In file included from ././../nntrainer/layers/layer.cpp:24:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/layer.cpp:24:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= addition_layer.cpp
In file included from ././../nntrainer/layers/addition_layer.cpp:14:
In file included from ./../nntrainer/layers/addition_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/addition_layer.cpp:14:
In file included from ./../nntrainer/layers/addition_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= concat_layer.cpp
In file included from ././../nntrainer/layers/concat_layer.cpp:14:
In file included from ./../nntrainer/layers/concat_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/concat_layer.cpp:14:
In file included from ./../nntrainer/layers/concat_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= sgd.cpp
[arm64-v8a] Compile++      : nntrainer <= optimizer.cpp
[arm64-v8a] Compile++      : nntrainer <= preprocess_translate_layer.cpp
In file included from ././../nntrainer/layers/preprocess_translate_layer.cpp:19:
In file included from ./../nntrainer/layers/preprocess_translate_layer.h:24:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/preprocess_translate_layer.cpp:19:
In file included from ./../nntrainer/layers/preprocess_translate_layer.h:24:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Install        : libc++_shared.so => libs/arm64-v8a/libc++_shared.so
[arm64-v8a] Compile        : nntrainer <= dictionary.c
[arm64-v8a] Compile++      : nntrainer <= preprocess_flip_layer.cpp
In file included from ././../nntrainer/layers/preprocess_flip_layer.cpp:19:
In file included from ./../nntrainer/layers/preprocess_flip_layer.h:20:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/preprocess_flip_layer.cpp:19:
In file included from ./../nntrainer/layers/preprocess_flip_layer.h:20:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile        : nntrainer <= iniparser.c
[arm64-v8a] Compile++      : nntrainer <= activation_layer.cpp
In file included from ././../nntrainer/layers/activation_layer.cpp:21:
In file included from ./../nntrainer/layers/activation_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/layers/activation_layer.cpp:21:
In file included from ./../nntrainer/layers/activation_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= adam.cpp
[arm64-v8a] Compile++      : nntrainer <= optimizer_factory.cpp
[arm64-v8a] Compile++      : nntrainer <= util_func.cpp
[arm64-v8a] Compile++      : nntrainer <= profiler.cpp
[arm64-v8a] Compile++      : nntrainer <= network_graph.cpp
In file included from ././../nntrainer/graph/network_graph.cpp:16:
In file included from ./../nntrainer/layers/activation_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/graph/network_graph.cpp:16:
In file included from ./../nntrainer/layers/activation_layer.h:18:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : ccapi-nntrainer <= factory.cpp
In file included from ././../api/ccapi/src/factory.cpp:21:
In file included from ./../nntrainer/layers/layer_factory.h:17:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../api/ccapi/src/factory.cpp:21:
In file included from ./../nntrainer/layers/layer_factory.h:17:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] Compile++      : nntrainer <= parse_util.cpp
In file included from ././../nntrainer/utils/parse_util.cpp:27:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:94:3: warning: explicitly defaulted copy constructor is implicitly deleted [-Wdefaulted-function-deleted]
  Manager(const Manager &) = default;
  ^
./../nntrainer/tensor/manager.h:317:33: note: copy constructor of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy constructor
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy constructor is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
In file included from ././../nntrainer/utils/parse_util.cpp:27:
In file included from ./../nntrainer/layers/layer_internal.h:31:
./../nntrainer/tensor/manager.h:96:12: warning: explicitly defaulted copy assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Manager &operator=(const Manager &) = default;
           ^
./../nntrainer/tensor/manager.h:317:33: note: copy assignment operator of 'Manager' is implicitly deleted because field 'weight_mmaped_memory' has a deleted copy assignment operator
  std::unique_ptr<MMapedMemory> weight_mmaped_memory;
                                ^
/Users/juyeong/Downloads/android-ndk-r21e/sources/cxx-stl/llvm-libc++/include/memory:2488:3: note: copy assignment operator is implicitly deleted because 'unique_ptr<nntrainer::MMapedMemory, std::__ndk1::default_delete<nntrainer::MMapedMemory> >' has a user-declared move constructor
  unique_ptr(unique_ptr&& __u) _NOEXCEPT
  ^
2 warnings generated.
[arm64-v8a] SharedLibrary  : libnntrainer.so
[arm64-v8a] Install        : libnntrainer.so => libs/arm64-v8a/libnntrainer.so
[arm64-v8a] SharedLibrary  : libccapi-nntrainer.so
[arm64-v8a] Install        : libccapi-nntrainer.so => libs/arm64-v8a/libccapi-nntrainer.so
[arm64-v8a] SharedLibrary  : libcapi-nntrainer.so
[arm64-v8a] Install        : libcapi-nntrainer.so => libs/arm64-v8a/libcapi-nntrainer.so
```
</details>

Resolves #798

Signed-off-by: Juyeong Lee <2jy22@naver.com>