### PR TITLE
[Fix/Svace] Add try catch to model-run

### DIFF
--- a/Applications/Custom/LayerClient/jni/main.cpp
+++ b/Applications/Custom/LayerClient/jni/main.cpp
@@ -208,10 +208,15 @@ int main(int argc, char *argv[]) {
 
   const std::string arg(argv[1]);
 
-  if (arg == "model") {
-    return api_model_run();
-  } else {
-    return ini_model_run(arg);
+  try {
+    if (arg == "model") {
+      return api_model_run();
+    } else {
+      return ini_model_run(arg);
+    }
+  } catch (std::invalid_argument &e) {
+    std::cerr << "failed to run the model, reason: " << e.what() << std::endl;
+    return 1;
   }
 
   /// should not reach here


### PR DESCRIPTION
The two functions of the following code may throw
exceptions. Handle them.
```
if (arg == "model") {
  return api_model_run();
} else {
  return ini_model_run(arg);
}
```

This fixes SVACE 457479.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>