### PR TITLE
[manager] Add check in manager for multiple init and allocate

### DIFF
--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -134,13 +134,18 @@ Manager::Manager(bool enable_gradient_memory_opt_,
   max_derivative_size(0),
   max_shared_inout(0),
   weights_initialized(false),
+  tensors_initialized(false),
+  weights_allocated(false),
+  tensors_allocated(false),
   enable_gradient_memory_opt(enable_gradient_memory_opt_),
   enable_derivative_memory_opt(enable_derivative_memory_opt_),
   enable_activation_memory_opt(enable_activation_memory_opt_),
   enable_inference_inout_memory_opt(enable_inference_inout_memory_opt_),
   use_shared_memory(false) {}
 
-Manager::~Manager() {}
+Manager::~Manager() {
+  // TODO: deallocate everything associated
+}
 
 /**
  * @brief     Add weight to be tracked and updated with nntrainer
@@ -250,6 +255,7 @@ void Manager::initializeWeights() {
     for (auto &w : l_w) {
       Weight &weight = w.get();
       auto dim = weight.getDim();
+      /** This will allocate memory for weights right now */
       Tensor weight_prealloc = allocate_weight(dim, weight_offset);
       Tensor grad_prealloc = Tensor();
 
@@ -259,6 +265,7 @@ void Manager::initializeWeights() {
   }
 
   weights_initialized = true;
+  weights_allocated = true;
 }
 
 void Manager::allocateWeights() {
@@ -268,6 +275,8 @@ void Manager::allocateWeights() {
       weight.allocateVariable();
     }
   }
+
+  weights_allocated = true;
 }
 
 void Manager::allocateGradients() {
@@ -507,6 +516,8 @@ void Manager::initializeTensors(bool trainable) {
     }
     use_first_last = 1 - use_first_last;
   }
+
+  tensors_initialized = true;
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -249,33 +249,21 @@ public:
    * @brief Allocate memory for all the managed tensors
    */
   void allocateTensors() {
-    /// Weights are allocated while initializing
-    if (!weights_initialized)
+    if (!weights_allocated)
       allocateWeights();
-    allocateGradients();
-    allocateInOuts();
-    allocateDerivatives();
+
+    if (!tensors_allocated) {
+      allocateGradients();
+      allocateInOuts();
+      allocateDerivatives();
+      tensors_allocated = true;
+    }
   }
 
   /**
    * @brief Allocate memory for all the managed weights
    */
   void allocateWeights();
-
-  /**
-   * @brief Allocate memory for all the managed gradients
-   */
-  void allocateGradients();
-
-  /**
-   * @brief Allocate memory for all the managed layers inputs and outputs
-   */
-  void allocateInOuts();
-
-  /**
-   * @brief Allocate memory for all the managed layer derivatives
-   */
-  void allocateDerivatives();
 
 private:
   // TODO: ensure that names of these weights are unique
@@ -287,7 +275,11 @@ private:
   unsigned int max_grad_size; /**< max trainable weight required by a layer */
   unsigned int max_derivative_size; /**< max derivative required by a layer */
   unsigned int max_shared_inout;    /**< max memory for in/outs for inference */
+
   bool weights_initialized; /**< track if weights have been initialized */
+  bool tensors_initialized; /**< track if other tensors have been initialized */
+  bool weights_allocated; /**< track if weights have been allocated */
+  bool tensors_allocated; /**< track if other tensors have been allocated */
 
   /**< Inputs/outputs of all the layer in the model */
   std::vector<std::vector<std::shared_ptr<Var_Grad>>> in_outs;
@@ -349,6 +341,21 @@ private:
    * @param[in] is_weight true if weight, else false meaning its gradient
    */
   AllocFunc getAllocFunc(bool is_weight);
+
+  /**
+   * @brief Allocate memory for all the managed gradients
+   */
+  void allocateGradients();
+
+  /**
+   * @brief Allocate memory for all the managed layers inputs and outputs
+   */
+  void allocateInOuts();
+
+  /**
+   * @brief Allocate memory for all the managed layer derivatives
+   */
+  void allocateDerivatives();
 };
 
 } // namespace nntrainer


### PR DESCRIPTION
Add a check in the manager to avoid multiple initializations of the same
variables and their allocations. This happens when inference/train is called
multiple times on the same model.

This patch adds a check inside the manager which does not re-init or allocate
if it is already initialized/allocated.

See Also #965 #974

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>