### PR TITLE
[manager] Manage memory allocation and de-allocation

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -277,6 +277,7 @@ int NeuralNetwork::initialize() {
  * @brief     free layers
  */
 NeuralNetwork::~NeuralNetwork() {
+  manager.reset();
   layers.erase(layers.begin(), layers.end());
 
   if (data_buffer) {

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -134,13 +134,18 @@ Manager::Manager(bool enable_gradient_memory_opt_,
   max_derivative_size(0),
   max_shared_inout(0),
   weights_initialized(false),
+  tensors_initialized(false),
+  weights_allocated(false),
+  tensors_allocated(false),
   enable_gradient_memory_opt(enable_gradient_memory_opt_),
   enable_derivative_memory_opt(enable_derivative_memory_opt_),
   enable_activation_memory_opt(enable_activation_memory_opt_),
   enable_inference_inout_memory_opt(enable_inference_inout_memory_opt_),
   use_shared_memory(false) {}
 
-Manager::~Manager() {}
+Manager::~Manager() {
+  // TODO: deallocate everything associated
+}
 
 /**
  * @brief     Add weight to be tracked and updated with nntrainer
@@ -250,6 +255,7 @@ void Manager::initializeWeights() {
     for (auto &w : l_w) {
       Weight &weight = w.get();
       auto dim = weight.getDim();
+      /** This will allocate memory for weights right now */
       Tensor weight_prealloc = allocate_weight(dim, weight_offset);
       Tensor grad_prealloc = Tensor();
 
@@ -259,6 +265,7 @@ void Manager::initializeWeights() {
   }
 
   weights_initialized = true;
+  weights_allocated = true;
 }
 
 void Manager::allocateWeights() {
@@ -268,6 +275,8 @@ void Manager::allocateWeights() {
       weight.allocateVariable();
     }
   }
+
+  weights_allocated = true;
 }
 
 void Manager::deallocateWeights() {
@@ -547,6 +556,8 @@ void Manager::initializeTensors(bool trainable) {
     }
     use_first_last = 1 - use_first_last;
   }
+
+  tensors_initialized = true;
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -143,9 +143,10 @@ Manager::Manager(bool enable_gradient_memory_opt_,
   enable_inference_inout_memory_opt(enable_inference_inout_memory_opt_),
   use_shared_memory(false) {}
 
-Manager::~Manager() {
-  // TODO: deallocate everything associated
-}
+/**
+ * @brief Destructor
+ */
+Manager::~Manager() { reset(); }
 
 /**
  * @brief     Add weight to be tracked and updated with nntrainer
@@ -286,6 +287,8 @@ void Manager::deallocateWeights() {
       weight.deallocateVariable();
     }
   }
+
+  weights_allocated = false;
 }
 
 void Manager::allocateGradients() {

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -261,12 +261,15 @@ public:
    * @brief Allocate memory for all the managed tensors
    */
   void allocateTensors() {
-    /// Weights are allocated while initializing
-    if (!weights_initialized)
+    if (!weights_allocated)
       allocateWeights();
-    allocateGradients();
-    allocateInOuts();
-    allocateDerivatives();
+
+    if (!tensors_allocated) {
+      allocateGradients();
+      allocateInOuts();
+      allocateDerivatives();
+      tensors_allocated = true;
+    }
   }
 
   /**
@@ -334,7 +337,11 @@ private:
   unsigned int max_grad_size; /**< max trainable weight required by a layer */
   unsigned int max_derivative_size; /**< max derivative required by a layer */
   unsigned int max_shared_inout;    /**< max memory for in/outs for inference */
+
   bool weights_initialized; /**< track if weights have been initialized */
+  bool tensors_initialized; /**< track if other tensors have been initialized */
+  bool weights_allocated; /**< track if weights have been allocated */
+  bool tensors_allocated; /**< track if other tensors have been allocated */
 
   /**< Inputs/outputs of all the layer in the model */
   std::vector<std::vector<std::shared_ptr<Var_Grad>>> in_outs;
@@ -396,6 +403,21 @@ private:
    * @param[in] is_weight true if weight, else false meaning its gradient
    */
   AllocFunc getAllocFunc(bool is_weight);
+
+  /**
+   * @brief Allocate memory for all the managed gradients
+   */
+  void allocateGradients();
+
+  /**
+   * @brief Allocate memory for all the managed layers inputs and outputs
+   */
+  void allocateInOuts();
+
+  /**
+   * @brief Allocate memory for all the managed layer derivatives
+   */
+  void allocateDerivatives();
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -173,8 +173,6 @@ public:
    */
   void reset() {
     deallocateTensors(true);
-    weights_allocated = false;
-    tensors_allocated = false;
 
     total_weight_size = 0;
     total_grad_size = 0;

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -244,7 +244,7 @@ public:
   void allocateVariable() { var->allocate(); }
 
   /**
-   * @brief Allocate memory for the variable
+   * @brief Allocate memory for the gradient
    */
   void allocateGradient() {
     grad->allocate();
@@ -273,7 +273,7 @@ public:
   void deallocateVariable() { var->deallocate(); }
 
   /**
-   * @brief Deallocate memory for the variable
+   * @brief Deallocate memory for the gradient
    */
   void deallocateGradient() { grad->deallocate(); }
 

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -254,6 +254,14 @@ public:
     opt_vars.clear();
   }
 
+  /**
+   * @brief Deallocate the weight gardient and variable
+   */
+  void deallocate() {
+    deallocateGradient();
+    deallocateVariable();
+  }
+
 private:
   WeightInitializer initializer; /**< initializer for this variable */
   WeightRegularizer regularizer; /**< regularizer for this variable */

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -371,9 +371,9 @@ TEST(nntrainer_ccapi, train_batch_size_update_after) {
   EXPECT_EQ(model->setProperty({"batch_size=4"}), ML_ERROR_NONE);
   EXPECT_NO_THROW(model->train());
 
-  EXPECT_FLOAT_EQ(model->getTrainingLoss(), 1.9582682);
-  EXPECT_FLOAT_EQ(model->getValidationLoss(), 2.1831701);
-  EXPECT_FLOAT_EQ(model->getLoss(), 2.1985414);
+  EXPECT_FLOAT_EQ(model->getTrainingLoss(), 1.9613363);
+  EXPECT_FLOAT_EQ(model->getValidationLoss(), 2.1835098);
+  EXPECT_FLOAT_EQ(model->getLoss(), 2.1977143);
 }
 
 /**

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -76,9 +76,6 @@ protected:
     layer.setOutputBuffers(manager.trackLayerOutputs(
       layer.getType(), layer.getName(), layer.getOutputDimension()));
 
-    manager.initializeTensors(true);
-    manager.allocateTensors();
-
     return status;
   }
 
@@ -168,10 +165,13 @@ protected:
     EXPECT_EQ(status, ML_ERROR_NONE);
 
     EXPECT_NO_THROW(opt->addOptimizerVariable(layer.getWeightsRef()));
-    manager.initializeTensors(true);
-    manager.allocateTensors();
 
     return status;
+  }
+
+  void allocateMemory() {
+    manager.initializeTensors(true);
+    manager.allocateTensors();
   }
 
   template <typename T> void saveFile(const char *filename, T &t) {
@@ -723,8 +723,6 @@ protected:
       manager.trackLayerOutputs(act_layer->getType(), act_layer->getName(),
                                 act_layer->getOutputDimension()));
 
-    manager.initializeTensors(true);
-    manager.allocateTensors();
     layers.push_back(act_layer);
   }
 
@@ -751,8 +749,6 @@ protected:
       manager.trackLayerOutputs(loss_layer->getType(), loss_layer->getName(),
                                 loss_layer->getOutputDimension()));
 
-    manager.initializeTensors(true);
-    manager.allocateTensors();
     layers.push_back(loss_layer);
 
     if (type == nntrainer::LossType::LOSS_ENTROPY_SOFTMAX) {
@@ -884,6 +880,7 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch, forwarding_backwarding_00_p) {
   std::vector<float> bias_data;
 
   setOptimizer(nntrainer::OptType::ADAM, "learning_rate=1.0");
+  allocateMemory();
 
   sharedConstTensor out;
 
@@ -917,8 +914,9 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch, forwarding_backwarding_00_p) {
  */
 TEST_F(nntrainer_FullyConnectedLayer_TFmatch,
        forwarding_backwarding_loss_00_p) {
-  setOptimizer(nntrainer::OptType::ADAM, "learning_rate=0.0001");
   addLoss(nntrainer::LossType::LOSS_ENTROPY_SOFTMAX);
+  setOptimizer(nntrainer::OptType::ADAM, "learning_rate=0.0001");
+  allocateMemory();
 
   matchForwarding("tc_fc_1_goldenFCResultSoftmaxCrossAdam.out");
 
@@ -933,6 +931,7 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch,
 TEST_F(nntrainer_FullyConnectedLayer_TFmatch, forwarding_backwarding_01_p) {
 
   setOptimizer(nntrainer::OptType::SGD, "learning_rate=1.0");
+  allocateMemory();
 
   /** Verify forwarding and backwarding without loss */
   matchForwarding("tc_fc_1_goldenFCResultActNone.out");
@@ -951,6 +950,7 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch, forwarding_backwarding_02_p) {
   addActivation(nntrainer::ActivationType::ACT_SIGMOID);
   addLoss(nntrainer::LossType::LOSS_MSE);
   setOptimizer(nntrainer::OptType::SGD, "learning_rate=1.0");
+  allocateMemory();
 
   /** Verify forwarding value */
   matchForwarding("tc_fc_1_goldenFCResultSigmoidMse.out");
@@ -972,6 +972,7 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch, forwarding_backwarding_03_p) {
   addActivation(nntrainer::ActivationType::ACT_SOFTMAX);
   addLoss(nntrainer::LossType::LOSS_MSE);
   setOptimizer(nntrainer::OptType::SGD, "learning_rate=1.0");
+  allocateMemory();
 
   /** Verify forwarding value */
   matchForwarding("tc_fc_1_goldenFCResultSoftmaxMse.out");
@@ -992,6 +993,7 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch, forwarding_backwarding_04_p) {
 
   addLoss(nntrainer::LossType::LOSS_MSE);
   setOptimizer(nntrainer::OptType::SGD, "learning_rate=1.0");
+  allocateMemory();
 
   /** Verify forwarding value */
   matchForwarding("tc_fc_1_goldenFCResultActNone.out");
@@ -1025,6 +1027,7 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch, forwarding_backwarding_05_p) {
   addActivation(nntrainer::ActivationType::ACT_SIGMOID);
   addLoss(nntrainer::LossType::LOSS_MSE);
   setOptimizer(nntrainer::OptType::SGD, "learning_rate=1.0");
+  allocateMemory();
 
   /** Verify forwarding value */
   matchForwarding("tc_fc_1_goldenFCResultSigmoidMse.out");
@@ -1046,6 +1049,7 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch, forwarding_backwarding_06_p) {
   addActivation(nntrainer::ActivationType::ACT_SOFTMAX);
   addLoss(nntrainer::LossType::LOSS_MSE);
   setOptimizer(nntrainer::OptType::SGD, "learning_rate=1.0");
+  allocateMemory();
 
   /** Verify forwarding value */
   matchForwarding("tc_fc_1_goldenFCResultSoftmaxMse.out");
@@ -1067,6 +1071,7 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch, forwarding_backwarding_07_p) {
 
   addLoss(nntrainer::LossType::LOSS_ENTROPY_SIGMOID);
   setOptimizer(nntrainer::OptType::SGD, "learning_rate=1.0");
+  allocateMemory();
 
   /** Verify forwarding value */
   matchForwarding("tc_fc_1_goldenFCResultSigmoidCross.out");
@@ -1088,6 +1093,7 @@ TEST_F(nntrainer_FullyConnectedLayer_TFmatch, forwarding_backwarding_08_p) {
 
   addLoss(nntrainer::LossType::LOSS_ENTROPY_SOFTMAX);
   setOptimizer(nntrainer::OptType::SGD, "learning_rate=1.0");
+  allocateMemory();
 
   /** Verify forwarding value */
   matchForwarding("tc_fc_1_goldenFCResultSoftmaxCross.out");
@@ -1176,6 +1182,7 @@ TEST_F(nntrainer_BatchNormalizationLayer, forward_backward_training_01_p) {
   layer.setTrainable(true);
   sharedConstTensor forward_result;
 
+  allocateMemory();
   EXPECT_NO_THROW(forward_result =
                     layer.forwarding_with_val({MAKE_SHARED_TENSOR(in)})[0]);
   matchOutput(*forward_result, "tc_bn_fc_1_goldenBNResultForward.out");
@@ -1215,6 +1222,7 @@ protected:
 TEST_F(nntrainer_BatchNormalizationLayer_Conv, forward_backward_training_01_p) {
   layer.setTrainable(true);
   sharedConstTensor forward_result;
+  allocateMemory();
 
   forward_result = layer.forwarding_with_val({MAKE_SHARED_TENSOR(in)})[0];
   matchOutput(*forward_result, "tc_bn_conv_1_goldenBNResultForward.out");
@@ -1257,6 +1265,7 @@ TEST_F(nntrainer_BatchNormalizationLayer_Conv2,
        forward_backward_training_01_p) {
   layer.setTrainable(true);
   sharedConstTensor forward_result;
+  allocateMemory();
 
   forward_result = layer.forwarding_with_val({MAKE_SHARED_TENSOR(in)})[0];
   matchOutput(*forward_result, "tc_bn_conv_2_goldenBNResultForward.out");
@@ -1313,6 +1322,7 @@ TEST_F(nntrainer_Conv2DLayer, initialize_01_p) {
  * @brief Convolution 2D Layer save and read and save
  */
 TEST_F(nntrainer_Conv2DLayer, save_read_01_p) {
+  allocateMemory();
   saveFile("save.bin", layer);
   saveFile("save1.bin", layer);
 
@@ -1342,6 +1352,7 @@ TEST_F(nntrainer_Conv2DLayer, forwarding_01_p) {
                "bias_initializer = zeros |"
                "weight_initializer=xavier_uniform |"
                "filters=2 | kernel_size=3,3 | stride=1, 1 | padding=0,0");
+  allocateMemory();
 
   ASSERT_EQ(in.getDim(), nntrainer::TensorDim(1, 3, 7, 7));
   ASSERT_EQ(out.getDim(), nntrainer::TensorDim(1, 2, 5, 5));
@@ -1365,6 +1376,7 @@ TEST_F(nntrainer_Conv2DLayer, forwarding_02_p) {
                  "weight_initializer=xavier_uniform |"
                  "filters=3 | kernel_size=3,3 | stride=1, 1 | padding=0,0",
                  2);
+  allocateMemory();
 
   ASSERT_EQ(in.getDim(), nntrainer::TensorDim(2, 3, 7, 7));
   ASSERT_EQ(out.getDim(), nntrainer::TensorDim(2, 3, 5, 5));
@@ -1391,6 +1403,7 @@ TEST_F(nntrainer_Conv2DLayer, backwarding_01_p) {
   loadFile("tc_conv2d_1_conv2DLayer.in", in);
   loadFile("tc_conv2d_1_conv2DKernel.in", layer);
   setOptimizer(nntrainer::OptType::SGD, "learning_rate=1.0");
+  allocateMemory();
 
   EXPECT_NO_THROW(out =
                     *layer.forwarding_with_val({MAKE_SHARED_TENSOR(in)})[0]);
@@ -1429,6 +1442,7 @@ TEST_F(nntrainer_Conv2DLayer, backwarding_02_p) {
   loadFile("tc_conv2d_2_conv2DKernel.in", layer);
 
   setOptimizer(nntrainer::OptType::SGD, "learning_rate=1.0");
+  allocateMemory();
 
   EXPECT_NO_THROW(out =
                     *layer.forwarding_with_val({MAKE_SHARED_TENSOR(in)})[0]);
@@ -1522,6 +1536,7 @@ TEST_F(nntrainer_Conv2DLayer, DISABLED_backwarding_03_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   setOptimizer(nntrainer::OptType::SGD, "learning_rate=1.0");
+  allocateMemory();
 
   nntrainer::Tensor derivatives(1, 12, 24, 24);
 
@@ -1583,6 +1598,8 @@ TEST_F(nntrainer_Conv2DLayer, backwarding_04_p) {
   loadFile("tc_conv2d_3_conv2DKernel.in", layer);
 
   setOptimizer(nntrainer::OptType::SGD, "learning_rate=1.0");
+  allocateMemory();
+
   EXPECT_NO_THROW(out =
                     *layer.forwarding_with_val({MAKE_SHARED_TENSOR(in)})[0]);
 
@@ -1639,6 +1656,7 @@ TEST_F(nntrainer_Pooling2DLayer, forwarding_01_p) {
   setProperty("pool_size=2,2 | stride=1,1 | padding=0,0 | pooling=max");
 
   reinitialize();
+  allocateMemory();
 
   loadFile("tc_pooling2d_1.in", in);
 
@@ -1653,6 +1671,7 @@ TEST_F(nntrainer_Pooling2DLayer, forwarding_02_p) {
   setProperty("pool_size=2,2 | stride=1,1 | padding=0,0 | pooling=average");
 
   reinitialize();
+  allocateMemory();
 
   loadFile("tc_pooling2d_1.in", in);
 
@@ -1667,6 +1686,7 @@ TEST_F(nntrainer_Pooling2DLayer, forwarding_03_p) {
   setInputDim("2:5:5");
   setProperty("pooling=global_max");
   reinitialize();
+  allocateMemory();
 
   loadFile("tc_pooling2d_1.in", in);
 
@@ -1681,6 +1701,7 @@ TEST_F(nntrainer_Pooling2DLayer, forwarding_04_p) {
   setInputDim("2:5:5");
   setProperty("pooling=global_average");
   reinitialize();
+  allocateMemory();
 
   loadFile("tc_pooling2d_1.in", in);
 
@@ -1696,6 +1717,7 @@ TEST_F(nntrainer_Pooling2DLayer, forwarding_05_p) {
   setBatch(2);
   setProperty("pooling=global_max");
   reinitialize();
+  allocateMemory();
 
   loadFile("tc_pooling2d_2.in", in);
   EXPECT_NO_THROW(out =
@@ -1709,6 +1731,7 @@ TEST_F(nntrainer_Pooling2DLayer, forwarding_06_p) {
   setBatch(2);
   setProperty("pooling=global_average");
   reinitialize();
+  allocateMemory();
 
   loadFile("tc_pooling2d_2.in", in);
 
@@ -1723,6 +1746,7 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_01_p) {
   setProperty("pool_size=2,2 | stride=1,1 | padding=0,0 | pooling=max");
 
   reinitialize();
+  allocateMemory();
   loadFile("tc_pooling2d_1.in", in);
 
   EXPECT_NO_THROW(out =
@@ -1745,6 +1769,7 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_02_p) {
   setInputDim("2:5:5");
   setProperty("pool_size=2,2 | stride=1,1 | padding=0,0 | pooling=average");
   reinitialize();
+  allocateMemory();
   loadFile("tc_pooling2d_1.in", in);
 
   EXPECT_NO_THROW(out =
@@ -1766,6 +1791,7 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_03_p) {
   setInputDim("2:5:5");
   setProperty("pool_size=2,2 | stride=1,1 | padding=0,0 | pooling=global_max");
   reinitialize();
+  allocateMemory();
 
   loadFile("tc_pooling2d_1.in", in);
 
@@ -1789,6 +1815,7 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_04_p) {
   setProperty(
     "pool_size=2,2 | stride=1,1 | padding=0,0 | pooling=global_average");
   reinitialize();
+  allocateMemory();
   loadFile("tc_pooling2d_1.in", in);
 
   EXPECT_NO_THROW(out =

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -762,9 +762,13 @@ INSTANTIATE_TEST_CASE_P(
     mkModelTc(conv_same_padding_multi_stride, "3:1:1:10", 10),
     mkModelTc(conv_no_loss_validate, "3:1:1:10", 1),
     mkModelTc(conv_none_loss_validate, "3:1:1:10", 1)
-), [](const testing::TestParamInfo<nntrainerModelTest::ParamType>& info){
- return std::get<0>(info.param).getName();
-});
+// / #if gtest_version <= 1.7.0
+));
+/// #else gtest_version > 1.8.0
+// ), [](const testing::TestParamInfo<nntrainerModelTest::ParamType>& info){
+//  return std::get<0>(info.param).getName();
+// });
+/// #end if */
 // clang-format on
 
 /**


### PR DESCRIPTION
**Commit 1**: [manager] Add check in manager for multiple init and allocate 
Add a check in the manager to avoid multiple initializations of the same
variables and their allocations. This happens when inference/train is called
multiple times on the same model.

This patch adds a check inside the manager which does not re-init or allocate
if it is already initialized/allocated.

**Commit 2:** [manager] Support deallocation of memory
Create a proper support for deallocation of memory by the manager which
for now will be done with destruction of manager or the model itself.

This frees all the memory involved in the model for inference or training.

**Commit 3:** [manager] Check on re-initialize
Add a check on re-initialize for the ccapi unittest
As re-initialize is removed, the memory intialization is also updated
which changes the final loss values

See Also #974 #975
This limits the excessive memory consumption by inference mode as reported in #974

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>