### PR TITLE
[rpm/tizen] Support 6.0 build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -145,7 +145,7 @@ if not iniparser_dep.found()
   endif
 endif
 
-nnstreamer_capi_dep = dependency('capi-ml-inference', required:false)
+nnstreamer_capi_dep = dependency(get_option('capi-ml-inference-actual'), required:false)
 if nnstreamer_capi_dep.found()
   add_project_arguments('-DNNSTREAMER_AVAILABLE=1', language:['c','cpp'])
   # accessing this variable when dep_.not_found() remains hard error on purpose
@@ -156,7 +156,7 @@ if nnstreamer_capi_dep.found()
   endif
 endif
 
-ml_api_common_dep = dependency('capi-ml-common', required:true)
+ml_api_common_dep = dependency(get_option('capi-ml-common-actual'), required:true)
 
 if get_option('enable-nnstreamer-backbone')
   add_project_arguments('-DENABLE_NNSTREAMER_BACKBONE=1', language:['c','cpp'])

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,3 +14,9 @@ option('enable-nnstreamer-backbone', type: 'boolean', value: true)
 option('enable-tflite-backbone', type: 'boolean', value: true)
 option('enable-android', type: 'boolean', value: false)
 option('enable-profile', type: 'boolean', value: false)
+
+# dependency conflict resolution
+option('capi-ml-inference-actual', type: 'string', value: 'capi-ml-inference',
+        description: 'backward compatible dependency name of capi-ml-inference')
+option('capi-ml-common-actual', type: 'string', value: 'capi-ml-common',
+        description: 'backward compatible dependency name of capi-ml-common')


### PR DESCRIPTION
This patch resolves dependency name by given distro version.

Tested building on 6.5 and 6.0 latest snapshot.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Cc: Sangjung Woo <sangjung.woo@samsung.com>
Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

resolves #973 