### PR TITLE
[model] Support freeing memory with train and inference

### DIFF
--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -148,7 +148,7 @@ int NNTrainerInference::run(const GstTensorMemory *input,
   std::shared_ptr<const nntrainer::Tensor> o;
 
   try {
-    o = model->inference({MAKE_SHARED_TENSOR(X)})[0];
+    o = model->inference({MAKE_SHARED_TENSOR(X)}, false)[0];
   } catch (std::exception &e) {
     ml_loge("%s %s", typeid(e).name(), e.what());
     return -2;

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -514,7 +514,8 @@ bool NeuralNetwork::validateInput(sharedConstTensors X) {
   return true;
 }
 
-sharedConstTensors NeuralNetwork::inference(sharedConstTensors X) {
+sharedConstTensors NeuralNetwork::inference(sharedConstTensors X,
+                                            bool free_mem) {
   if (batch_size != X[0]->batch()) {
     /**
      * Note that inference resets batch_size of the previous train configuration
@@ -549,6 +550,15 @@ sharedConstTensors NeuralNetwork::inference(sharedConstTensors X) {
                            .layer->net_hidden[i]
                            ->getVariable()));
   }
+
+  if (free_mem)
+    /**
+     * Free the memory needed for training before exiting.
+     * Note that this does not free the weights for the model.
+     * Weights of the model will be freed when the model is destroyed.
+     */
+    manager->deallocateTensors(false);
+
   return out;
 }
 

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -162,13 +162,20 @@ public:
   int initialize();
 
   /**
-   * @brief     Assign Graph Memory. This should be called after initialize.
-   * @TODO      Consider to move Network Graph Class
+   * @brief     Allocate memory for the model. This should be called after initialize.
    * @param[in] trainable Assign memory for inference or train mode
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int assignMem(bool trainable = true);
+  int allocate(bool trainable = true);
+
+  /**
+   * @brief     Deallocate memory for the model.
+   * @param[in] trainable Assign memory for inference or train mode
+   * @retval #ML_ERROR_NONE Successful.
+   * @note This does not free the model graph but only the weight tensors, and input/output/gradient/derivative tensors if any.
+   */
+  int deallocate();
 
   /**
    * @brief     Update graph to make batch normalization in-place

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -162,7 +162,8 @@ public:
   int initialize();
 
   /**
-   * @brief     Allocate memory for the model. This should be called after initialize.
+   * @brief     Allocate memory for the model. This should be called after
+   * initialize.
    * @param[in] trainable Assign memory for inference or train mode
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
@@ -173,7 +174,8 @@ public:
    * @brief     Deallocate memory for the model.
    * @param[in] trainable Assign memory for inference or train mode
    * @retval #ML_ERROR_NONE Successful.
-   * @note This does not free the model graph but only the weight tensors, and input/output/gradient/derivative tensors if any.
+   * @note This does not free the model graph but only the weight tensors, and
+   * input/output/gradient/derivative tensors if any.
    */
   int deallocate();
 
@@ -254,7 +256,7 @@ public:
    * @param[in] X input tensor
    * @retval shared_ptr<const Tensor>
    */
-  sharedConstTensors inference(sharedConstTensors X);
+  sharedConstTensors inference(sharedConstTensors X, bool free_mem = true);
 
   /**
    * @brief     Run NeuralNetwork train with callback function by user

--- a/test/unittest/unittest_nntrainer_graph.cpp
+++ b/test/unittest/unittest_nntrainer_graph.cpp
@@ -88,7 +88,7 @@ TEST_P(nntrainerGraphTest, loadConfig) {
     EXPECT_EQ(status, ML_ERROR_NONE);
   }
 
-  status = NN.assignMem();
+  status = NN.allocate();
   if (failAtLoad()) {
     EXPECT_NE(status, ML_ERROR_NONE);
   } else {

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -322,7 +322,7 @@ GraphWatcher::GraphWatcher(const std::string &config, const bool opt) :
     throw std::invalid_argument("initiation failed");
   };
 
-  if (nn.assignMem()) {
+  if (nn.allocate()) {
     throw std::invalid_argument("assign Memory failed");
   };
 

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -384,7 +384,7 @@ void GraphWatcher::compareFor(const std::string &reference,
    * This inference is to ensure that inference runs with/without optimizations
    * for various kinds of models
    */
-  EXPECT_NO_THROW(nn.inference(input));
+  EXPECT_NO_THROW(nn.inference(input, false));
 }
 
 void GraphWatcher::validateFor(const std::string &reference,
@@ -405,7 +405,11 @@ void GraphWatcher::validateFor(const std::string &reference,
    * This inference is to ensure that inference runs with/without optimizations
    * for various kinds of models
    */
-  EXPECT_NO_THROW(nn.inference(input));
+  EXPECT_NO_THROW(nn.inference(input, false));
+  /** run inference again which frees the memory */
+  EXPECT_NO_THROW(nn.inference(input, true));
+  /** run inference again which will force to allocate memory again */
+  EXPECT_NO_THROW(nn.inference(input, true));
 }
 
 std::array<nntrainer::Tensor, 2>


### PR DESCRIPTION
**Commit 1:** [neuralnet] Support deallocate of tensors 
Support deallocate and allocation of tensors from the neuralnet.

Also perform the deallocation of tensors after each train run.
Once a training is performed, the memory associated for that training
except the weights variables will be freed.

The memory associated with inference will not be freed until freed manually.
This will require calling deallocate() with the model object.
Note that calling a train() after inference() will free the inference memory
and the train will allocate its own memory which will be freed at the end
of the training.

**Commit 2:** [model] Free memory for inference 
Support freeing memory for inference with free_mem argument in inference
This defaults to true.

See Also #965  #974

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>