### PR TITLE
[dataset/unittest] Bug fix for segmentation fault

### DIFF
--- a/test/tizen_capi/unittest_tizen_capi_dataset.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_dataset.cpp
@@ -23,7 +23,7 @@ static const std::string getTestResPath(const std::string &filename) {
  * @brief Neural Network Dataset Create / Destroy Test (negative test)
  */
 TEST(nntrainer_capi_dataset, create_destroy_01_n) {
-  ml_train_dataset_h dataset;
+  ml_train_dataset_h dataset = nullptr;
   int status;
   status = ml_train_dataset_create_with_file(&dataset, NULL, NULL, NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
@@ -36,7 +36,7 @@ TEST(nntrainer_capi_dataset, create_destroy_01_n) {
  * @brief Neural Network Dataset Create / Destroy Test (negative test)
  */
 TEST(nntrainer_capi_dataset, create_destroy_02_n) {
-  ml_train_dataset_h dataset;
+  ml_train_dataset_h dataset = nullptr;
   int status;
   status =
     ml_train_dataset_create_with_file(&dataset, "nofile.txt", NULL, NULL);
@@ -50,7 +50,7 @@ TEST(nntrainer_capi_dataset, create_destroy_02_n) {
  * @brief Neural Network Dataset Create / Destroy Test (negative test)
  */
 TEST(nntrainer_capi_dataset, create_destroy_03_n) {
-  ml_train_dataset_h dataset;
+  ml_train_dataset_h dataset = nullptr;
   int status;
   status = ml_train_dataset_create_with_generator(&dataset, NULL, NULL, NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);


### PR DESCRIPTION
The unittest gives segmentation fault when trying to close a dataset
object which has not been opened successfully.
Initializing the object to false solves the issue.

This unittest before the patch fails for debug mode in meson.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>