### PR TITLE
[CAPI] Add mapping to newly added enum

### DIFF
--- a/api/capi/src/nntrainer_util.cpp
+++ b/api/capi/src/nntrainer_util.cpp
@@ -13,6 +13,18 @@
 #include <nntrainer_error.h>
 #include <nntrainer_internal.h>
 
+#include <activation_layer.h>
+#include <addition_layer.h>
+#include <bn_layer.h>
+#include <concat_layer.h>
+#include <conv2d_layer.h>
+#include <fc_layer.h>
+#include <flatten_layer.h>
+#include <input_layer.h>
+#include <loss_layer.h>
+#include <output_layer.h>
+#include <pooling2d_layer.h>
+
 /**
  * @brief Convert nntrainer API optimizer type to neural network optimizer type
  */
@@ -43,6 +55,22 @@ const std::string ml_layer_to_nntrainer_type(ml_train_layer_type_e type) {
     return nntrainer::FullyConnectedLayer::type;
   case ML_TRAIN_LAYER_TYPE_INPUT:
     return nntrainer::InputLayer::type;
+  case ML_TRAIN_LAYER_TYPE_BN:
+    return nntrainer::BatchNormalizationLayer::type;
+  case ML_TRAIN_LAYER_TYPE_CONV2D:
+    return nntrainer::Conv2DLayer::type;
+  case ML_TRAIN_LAYER_TYPE_POOLING2D:
+    return nntrainer::Pooling2DLayer::type;
+  case ML_TRAIN_LAYER_TYPE_FLATTEN:
+    return nntrainer::FlattenLayer::type;
+  case ML_TRAIN_LAYER_TYPE_ACTIVATION:
+    return nntrainer::ActivationLayer::type;
+  case ML_TRAIN_LAYER_TYPE_ADDITION:
+    return nntrainer::AdditionLayer::type;
+  case ML_TRAIN_LAYER_TYPE_CONCAT:
+    return nntrainer::ConcatLayer::type;
+  case ML_TRAIN_LAYER_TYPE_MULTIOUT:
+    return nntrainer::OutputLayer::type;
   case ML_TRAIN_LAYER_TYPE_UNKNOWN:
   /// fall through intended
   default:

--- a/test/tizen_capi/unittest_tizen_capi_layer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_layer.cpp
@@ -220,6 +220,80 @@ TEST(nntrainer_capi_nnlayer, setproperty_10_n) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
+/*** since tizen 6.5 ***/
+
+/**
+ * @brief CapiLayerPropertyTester
+ * @tparam ml_train_layer_type_e layer type to create
+ * @tparam const char * valid property
+ * @tparam bool if setting property should success or fail
+ */
+class nntrainerCapiLayerTester
+  : public ::testing::TestWithParam<std::tuple<
+      ml_train_layer_type_e, const std::vector<const char *>, bool>> {};
+
+/**
+ * @brief layer creating and setting property, this is eithr positive or
+ * negative
+ */
+TEST_P(nntrainerCapiLayerTester, layer_create_and_set_property) {
+  auto param = GetParam();
+  auto type = std::get<0>(param);
+  auto props = std::get<1>(param);
+  auto should_success = std::get<2>(param);
+
+  ml_train_layer_h handle;
+  int status;
+  status = ml_train_layer_create(&handle, type);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = 0;
+  for (auto &i : props) {
+    std::cout << i << std::endl;
+    int ret = ml_train_layer_set_property(handle, i, NULL);
+    if (ret != ML_ERROR_NONE) {
+      std::cerr << "setting property failed at: " << i << '\n';
+    }
+    status += ret;
+  }
+  EXPECT_TRUE((status == ML_ERROR_NONE) == should_success);
+
+  status = ml_train_layer_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+static std::tuple<ml_train_layer_type_e, const std::vector<const char *>, bool>
+mkTc(ml_train_layer_type_e type, const std::vector<const char *> &vec,
+     bool success) {
+  return std::make_tuple(type, vec, success);
+}
+
+INSTANTIATE_TEST_CASE_P(
+  CapiPropertyTest, nntrainerCapiLayerTester,
+  ::testing::Values(
+    mkTc(ML_TRAIN_LAYER_TYPE_BN,
+         {"name=bn", "epsilon=0.001", "moving_mean_initializer=zeros",
+          "moving_variance_initializer=ones", "gamma_initializer=zeros",
+          "beta_initializer=ones", "momentum=0.9"},
+         true),
+    mkTc(ML_TRAIN_LAYER_TYPE_BN, {"name=bn", "epsilon=no_float"}, false),
+    mkTc(ML_TRAIN_LAYER_TYPE_CONV2D,
+         {"filters=3", "kernel_size=2, 2", "stride=1,1", "padding=0, 0"}, true),
+    mkTc(ML_TRAIN_LAYER_TYPE_CONV2D, {"kernel_size=string"}, false),
+    mkTc(ML_TRAIN_LAYER_TYPE_POOLING2D, {"pooling=max", "pool_size=1, 1"},
+         true),
+    mkTc(ML_TRAIN_LAYER_TYPE_POOLING2D, {"pooling=undef", "pool_size=1, 1"},
+         false),
+    mkTc(ML_TRAIN_LAYER_TYPE_FLATTEN, {"name=flat"}, true),
+    mkTc(ML_TRAIN_LAYER_TYPE_ACTIVATION, {"activation=relu"}, true),
+    mkTc(ML_TRAIN_LAYER_TYPE_ACTIVATION, {"activation=undef"}, false),
+    mkTc(ML_TRAIN_LAYER_TYPE_ADDITION, {"num_inputs=2"}, true),
+    mkTc(ML_TRAIN_LAYER_TYPE_ADDITION, {"num_inputs=0"}, false),
+    mkTc(ML_TRAIN_LAYER_TYPE_CONCAT, {"num_inputs=2"}, true),
+    mkTc(ML_TRAIN_LAYER_TYPE_CONCAT, {"num_inputs=0"}, false),
+    mkTc(ML_TRAIN_LAYER_TYPE_MULTIOUT, {"num_outputs=0"}, false),
+    mkTc(ML_TRAIN_LAYER_TYPE_MULTIOUT, {"num_outputs=2"}, true)));
+
 /**
  * @brief Main gtest
  */


### PR DESCRIPTION
This patch adds mapping to newly added enum and corresponding test

Please note that tct will be added based on this PR.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
