### PR TITLE
[model] Bug fix for inference

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -533,9 +533,6 @@ sharedConstTensors NeuralNetwork::inference(sharedConstTensors X) {
     START_PROFILE(profile::NN_FORWARD);
     forwarding(X, {}, false);
     END_PROFILE(profile::NN_FORWARD);
-    /** Forward loss layer without label as well */
-    std::static_pointer_cast<LossLayer>(model_graph.Sorted.back().layer)
-      ->forwarding(false);
   } catch (...) {
     ml_loge("Failed to inference Model");
     return out;


### PR DESCRIPTION
Add bug fix for inference mode where the last layer is run twice.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>