### PR TITLE
[Manager] Remove alloc for first/last layer during inference

### DIFF
--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -11,6 +11,10 @@
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug	   No known bugs except for NYI items
  *
+ *
+ * @details Manager assumes that the layer inouts are being tracked by the
+ * manager in the order of the execution. If the order is not maintained, then
+ * the optimizations cannot be performed and will result in wrong values.
  */
 
 #ifndef __MANAGER_H__
@@ -432,8 +436,21 @@ private:
    *
    */
   void deallocateDerivatives();
-  void initializeTensors();
+
+  /**
+   * @brief Deinitialize the tensors
+   */
   void deinitializeTensors();
+
+  /**
+   * @brief Initialize the tensors for inference mode
+   */
+  void initializeTensorsInference();
+
+  /**
+   * @brief Initialize the tensors for training mode
+   */
+  void initializeTensorsTrain();
 };
 
 } // namespace nntrainer


### PR DESCRIPTION
Remove the allocation of input of the first layer and label of the last
layer during inference. This is because those tensors are overridden at
the call to inference by the tensors provided externally by the user.
Note that the output of the last layer will still be allocated by the manager.

Also refactor initializeTensors() in manager into two functions
separated for inference and training, along with a couple of bug fixes inside them.

See Also #974 #888

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>

cc. @zhoonit Please check if this resolves the second issue in #888.