### PR TITLE
[app] Set env to run the app test

### DIFF
--- a/Applications/TransferLearning/Draw_Classification/jni/meson.build
+++ b/Applications/TransferLearning/Draw_Classification/jni/meson.build
@@ -26,4 +26,6 @@ e = executable('nntrainer_training',
   install_dir: application_install_dir
 )
 
-test('app_draw_classification', e, args: [nntr_draw_resdir / 'Training.ini', nntr_draw_resdir], timeout: 60)
+nntrainer_filter_env = 'NNSTREAMER_FILTERS=' + meson.build_root() + '/nnstreamer/tensor_filter'
+test('app_draw_classification', e, env: nntrainer_filter_env,
+  args: [nntr_draw_resdir / 'Training.ini', nntr_draw_resdir], timeout: 100)


### PR DESCRIPTION
Set environment variable in meson to run the application test
This patch solves the failing app_draw_classification in ninja test

See also #995

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>

cc. @zhoonit thanks for the help.