### PR TITLE
[model] Update batch size check

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -298,7 +298,8 @@ sharedConstTensors NeuralNetwork::forwarding(bool training) {
 sharedConstTensors NeuralNetwork::forwarding(sharedConstTensors input,
                                              sharedConstTensors label,
                                              bool training) {
-  if (input[0]->getDim().batch() > batch_size)
+  if (input[0]->batch() != batch_size ||
+      (!label.empty() && label[0]->batch() != batch_size))
     throw std::logic_error("Error: mismatch in batchsize for data and model.");
 
   auto &first_layer = model_graph.getSortedLayerNode(0).layer;


### PR DESCRIPTION
Update batch size check to exactly match with the model
This is because batch size is used by certain layers for calculation and
running an input with wrong batch (with correct memory allocations) can result
in wrong output.

This is independent of the running a batch size 16 with memory allocated for
bigger batch size. That will still work with this patch as long as batch size
is set correctly for the model, and memory allocated is at least big enough
to handle this batch size.

See also #888

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>

cc. @zhoonit thanks for making #888 clearer in person.