### PR TITLE
[weights] Bug fix + lazy allocation

### DIFF
--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -63,15 +63,17 @@ int BatchNormalizationLayer::initialize(Manager &manager) {
   if (weights.empty()) {
     weights.reserve(4);
     weights.emplace_back(dim, initializers[BNParams::mu],
-                         WeightRegularizer::NONE, 1.0f, false, true,
+                         WeightRegularizer::NONE, 1.0f, false, false,
                          "BN::moving_mean");
     weights.emplace_back(dim, initializers[BNParams::var],
-                         WeightRegularizer::NONE, 1.0f, false, true,
+                         WeightRegularizer::NONE, 1.0f, false, false,
                          "BN::moving_variance");
     weights.emplace_back(dim, initializers[BNParams::gamma],
-                         WeightRegularizer::NONE, 1.0f, true, true, "BN::gamma");
+                         WeightRegularizer::NONE, 1.0f, true, false,
+                         "BN::gamma");
     weights.emplace_back(dim, initializers[BNParams::beta],
-                         WeightRegularizer::NONE, 1.0f, true, true, "BN::beta");
+                         WeightRegularizer::NONE, 1.0f, true, false,
+                         "BN::beta");
     manager.trackWeights(weights);
   } else {
     weights[BNParams::mu].reset(dim, initializers[BNParams::mu],

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -63,15 +63,15 @@ int BatchNormalizationLayer::initialize(Manager &manager) {
   if (weights.empty()) {
     weights.reserve(4);
     weights.emplace_back(dim, initializers[BNParams::mu],
-                         WeightRegularizer::NONE, 1.0f, false,
+                         WeightRegularizer::NONE, 1.0f, false, true,
                          "BN::moving_mean");
     weights.emplace_back(dim, initializers[BNParams::var],
-                         WeightRegularizer::NONE, 1.0f, false,
+                         WeightRegularizer::NONE, 1.0f, false, true,
                          "BN::moving_variance");
     weights.emplace_back(dim, initializers[BNParams::gamma],
-                         WeightRegularizer::NONE, 1.0f, true, "BN::gamma");
+                         WeightRegularizer::NONE, 1.0f, true, true, "BN::gamma");
     weights.emplace_back(dim, initializers[BNParams::beta],
-                         WeightRegularizer::NONE, 1.0f, true, "BN::beta");
+                         WeightRegularizer::NONE, 1.0f, true, true, "BN::beta");
     manager.trackWeights(weights);
   } else {
     weights[BNParams::mu].reset(dim, initializers[BNParams::mu],

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -286,9 +286,10 @@ int Conv2DLayer::initialize(Manager &manager) {
   if (weights.empty()) {
     weights.reserve(2);
     weights.emplace_back(dim, weight_initializer, weight_regularizer,
-                         weight_regularizer_constant, true, true, "Conv2d:filter");
+                         weight_regularizer_constant, true, false,
+                         "Conv2d:filter");
     weights.emplace_back(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                         1.0f, true, true, "Conv2d:bias");
+                         1.0f, true, false, "Conv2d:bias");
     manager.trackWeights(weights);
   } else {
     weights[ConvParams::weight].reset(dim, weight_initializer,

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -286,9 +286,9 @@ int Conv2DLayer::initialize(Manager &manager) {
   if (weights.empty()) {
     weights.reserve(2);
     weights.emplace_back(dim, weight_initializer, weight_regularizer,
-                         weight_regularizer_constant, true, "Conv2d:filter");
+                         weight_regularizer_constant, true, true, "Conv2d:filter");
     weights.emplace_back(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                         1.0f, true, "Conv2d:bias");
+                         1.0f, true, true, "Conv2d:bias");
     manager.trackWeights(weights);
   } else {
     weights[ConvParams::weight].reset(dim, weight_initializer,

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -55,9 +55,9 @@ int FullyConnectedLayer::initialize(Manager &manager) {
   if (weights.empty()) {
     weights.reserve(2);
     weights.emplace_back(dim, weight_initializer, weight_regularizer,
-                         weight_regularizer_constant, true, true, "FC:weight");
+                         weight_regularizer_constant, true, false, "FC:weight");
     weights.emplace_back(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                         1.0f, true, true, "FC:bias");
+                         1.0f, true, false, "FC:bias");
     manager.trackWeights(weights);
   } else {
     weights[FCParams::weight].reset(dim, weight_initializer, weight_regularizer,

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -55,9 +55,9 @@ int FullyConnectedLayer::initialize(Manager &manager) {
   if (weights.empty()) {
     weights.reserve(2);
     weights.emplace_back(dim, weight_initializer, weight_regularizer,
-                         weight_regularizer_constant, true, "FC:weight");
+                         weight_regularizer_constant, true, true, "FC:weight");
     weights.emplace_back(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                         1.0f, true, "FC:bias");
+                         1.0f, true, true, "FC:bias");
     manager.trackWeights(weights);
   } else {
     weights[FCParams::weight].reset(dim, weight_initializer, weight_regularizer,

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -263,6 +263,7 @@ int NeuralNetwork::initialize() {
 
   // Allocate and initialize weights
   manager->initializeWeights();
+  manager->allocateWeights();
 
   if (in_place_optimization) {
     model_graph.inPlaceOptimize(*manager);

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -41,10 +41,11 @@ public:
    *
    * @param dim Variable and gradient tensor dimension
    * @param train If the variable is trainable
+   * @param alloc_now The memory for the var_grad tensors be allocated upon init
    * @param name Name for this Var_Grad
    */
-  Var_Grad(const TensorDim &dim, bool train = true, bool alloc_now = true,
-           const std::string &name = "");
+  explicit Var_Grad(const TensorDim &dim, bool train = true,
+                    bool alloc_now = false, const std::string &name = "");
 
   /**
    * @brief Swap for Var_Grad
@@ -168,7 +169,10 @@ public:
   /**
    * @brief Reset the gradient to 0
    */
-  void resetGradient() { grad->setZero(); }
+  void resetGradient() {
+    if (grad->isAllocated())
+      grad->setZero();
+  }
 
   /**
    * @bried Clone the currnet object

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -76,14 +76,16 @@ public:
    * @param dim Variable and gradient tensor dimension
    * @param init Initializer for the weight
    * @param reg Regularizer for the weight
+   * @param reg_const Constant multiplier for regularizer
    * @param train If the variable is trainable
+   * @param alloc_now The memory for the weight tensors be allocated upon init
    * @param name Name for this weight
    */
-  Weight(
+  explicit Weight(
     const TensorDim &dim,
     const WeightInitializer init = WeightInitializer::WEIGHT_XAVIER_UNIFORM,
     const WeightRegularizer reg = WeightRegularizer::NONE,
-    const float reg_const = 1.0f, bool train = true, bool alloc_now = true,
+    const float reg_const = 1.0f, bool train = true, bool alloc_now = false,
     std::string name = "");
 
   /**
@@ -203,7 +205,7 @@ public:
    */
   void allocateVariable() {
     Var_Grad::allocateVariable();
-    initializeVariable();
+    runVariableInitializer();
   }
 
   /**

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -62,12 +62,15 @@ protected:
     manager.setInPlaceActivationOptimization(false);
     manager.setInferenceInOutMemoryOptimization(false);
     prepareLayer();
-    reinitialize();
+    initialize();
   }
 
-  virtual int reinitialize() {
+  virtual int initialize() {
     int status = layer.initialize(manager);
     EXPECT_EQ(status, ML_ERROR_NONE);
+
+    manager.initializeWeights();
+    manager.allocateWeights();
 
     in = nntrainer::Tensor(layer.getInputDimension()[0]);
     out = nntrainer::Tensor(layer.getOutputDimension()[0]);
@@ -80,12 +83,21 @@ protected:
     return status;
   }
 
+  virtual int reinitialize() {
+    resetLayer();
+    prepareLayer();
+    status = initialize();
+    EXPECT_EQ(status, ML_ERROR_NONE);
+    return status;
+  }
+
   virtual int reinitialize(const std::string str, int batch_size = 1) {
     resetLayer();
+    prepareLayer();
     int status = setProperty(str);
     EXPECT_EQ(status, ML_ERROR_NONE);
     setBatch(batch_size);
-    status = reinitialize();
+    status = initialize();
     EXPECT_EQ(status, ML_ERROR_NONE);
     return status;
   }
@@ -694,8 +706,8 @@ class nntrainer_FullyConnectedLayer_TFmatch
 protected:
   typedef nntrainer_abstractLayer<nntrainer::FullyConnectedLayer> super;
 
-  virtual int reinitialize() {
-    int status = super::reinitialize();
+  virtual int initialize() {
+    int status = super::initialize();
     label =
       MAKE_SHARED_TENSOR(nntrainer::Tensor(layer.getOutputDimension()[0]));
 
@@ -1656,7 +1668,7 @@ TEST_F(nntrainer_Pooling2DLayer, forwarding_01_p) {
   setInputDim("2:5:5");
   setProperty("pool_size=2,2 | stride=1,1 | padding=0,0 | pooling=max");
 
-  reinitialize();
+  initialize();
   allocateMemory();
 
   loadFile("tc_pooling2d_1.in", in);
@@ -1671,7 +1683,7 @@ TEST_F(nntrainer_Pooling2DLayer, forwarding_02_p) {
   setInputDim("2:5:5");
   setProperty("pool_size=2,2 | stride=1,1 | padding=0,0 | pooling=average");
 
-  reinitialize();
+  initialize();
   allocateMemory();
 
   loadFile("tc_pooling2d_1.in", in);
@@ -1686,7 +1698,7 @@ TEST_F(nntrainer_Pooling2DLayer, forwarding_03_p) {
   resetLayer();
   setInputDim("2:5:5");
   setProperty("pooling=global_max");
-  reinitialize();
+  initialize();
   allocateMemory();
 
   loadFile("tc_pooling2d_1.in", in);
@@ -1701,7 +1713,7 @@ TEST_F(nntrainer_Pooling2DLayer, forwarding_04_p) {
   resetLayer();
   setInputDim("2:5:5");
   setProperty("pooling=global_average");
-  reinitialize();
+  initialize();
   allocateMemory();
 
   loadFile("tc_pooling2d_1.in", in);
@@ -1717,7 +1729,7 @@ TEST_F(nntrainer_Pooling2DLayer, forwarding_05_p) {
   setInputDim("2:5:5");
   setBatch(2);
   setProperty("pooling=global_max");
-  reinitialize();
+  initialize();
   allocateMemory();
 
   loadFile("tc_pooling2d_2.in", in);
@@ -1731,7 +1743,7 @@ TEST_F(nntrainer_Pooling2DLayer, forwarding_06_p) {
   setInputDim("2:5:5");
   setBatch(2);
   setProperty("pooling=global_average");
-  reinitialize();
+  initialize();
   allocateMemory();
 
   loadFile("tc_pooling2d_2.in", in);
@@ -1746,7 +1758,7 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_01_p) {
   setInputDim("2:5:5");
   setProperty("pool_size=2,2 | stride=1,1 | padding=0,0 | pooling=max");
 
-  reinitialize();
+  initialize();
   allocateMemory();
   loadFile("tc_pooling2d_1.in", in);
 
@@ -1769,7 +1781,7 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_02_p) {
   resetLayer();
   setInputDim("2:5:5");
   setProperty("pool_size=2,2 | stride=1,1 | padding=0,0 | pooling=average");
-  reinitialize();
+  initialize();
   allocateMemory();
   loadFile("tc_pooling2d_1.in", in);
 
@@ -1791,7 +1803,7 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_03_p) {
   resetLayer();
   setInputDim("2:5:5");
   setProperty("pool_size=2,2 | stride=1,1 | padding=0,0 | pooling=global_max");
-  reinitialize();
+  initialize();
   allocateMemory();
 
   loadFile("tc_pooling2d_1.in", in);
@@ -1815,7 +1827,7 @@ TEST_F(nntrainer_Pooling2DLayer, backwarding_04_p) {
   setInputDim("2:5:5");
   setProperty(
     "pool_size=2,2 | stride=1,1 | padding=0,0 | pooling=global_average");
-  reinitialize();
+  initialize();
   allocateMemory();
   loadFile("tc_pooling2d_1.in", in);
 
@@ -1865,7 +1877,7 @@ TEST_F(nntrainer_FlattenLayer, forwarding_01_p) {
 TEST_F(nntrainer_FlattenLayer, forwarding_02_p) {
   setInputDim("2:4:4");
   setBatch(2);
-  reinitialize();
+  initialize();
 
   EXPECT_EQ(out.getDim(), nntrainer::TensorDim(2, 1, 1, 32));
 
@@ -1900,7 +1912,7 @@ TEST_F(nntrainer_FlattenLayer, backwarding_01_p) {
 TEST_F(nntrainer_FlattenLayer, backwarding_02_p) {
   setInputDim("2:4:4");
   setBatch(2);
-  reinitialize();
+  initialize();
 
   EXPECT_EQ(out.getDim(), nntrainer::TensorDim(2, 1, 1, 32));
 


### PR DESCRIPTION
Commit 1: [layers] Weight creation bug fix
The name of the weight being passed as string was being interpreted as a string
for the variable alloc_now. This patch fixes it by passing the arguments
appropriately.

Commit 2: [Weights] Split weight variable init and allocSplit the initialization and memory allocation for weights
3 exposed bugs with this has been resolved:
- manager does not allow tracking var_grads once initialized
- resetGradient confirms the allocation is done before accessing the memory
- allocateVariable() calls the correct initializer now

Further, the logic of reinitialize in unittest for layers has been
split into two parts - initialize and reinitialize where
reinitialize will reset layer and manager and then call initialize.

Resolves #974

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>