### PR TITLE
[layer] refactor inputs/outputs for layer

### DIFF
--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -78,12 +78,6 @@ public:
   unsigned int getNumNode() { return num_node; }
 
   /**
-   * @brief initialize net_input and net_hidden of each layer
-   *        according to num_input and num_output
-   */
-  void setNumNetBufferSize();
-
-  /**
    * @brief getter of LayerNode with index number
    * @param[in] index
    * @ret LayerNode

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -24,12 +24,12 @@ const std::string AdditionLayer::type = "addition";
 
 int AdditionLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
-  if (num_inputs == 0) {
+  if (getNumInputs() == 0) {
     ml_loge("Error: number of inputs are not initialized");
     return ML_ERROR_INVALID_PARAMETER;
   }
 
-  for (unsigned int idx = 0; idx < num_inputs; ++idx) {
+  for (unsigned int idx = 0; idx < getNumInputs(); ++idx) {
     if (input_dim[idx].getDataLen() == 1) {
       ml_logw("Warning: the length of previous layer dimension is one");
     }
@@ -46,7 +46,7 @@ void AdditionLayer::forwarding(bool training) {
   TensorDim &in_dim = input_dim[0];
 
   /** @todo check possibility for in-place of addition layer */
-  for (unsigned int idx = 0; idx < num_inputs; ++idx) {
+  for (unsigned int idx = 0; idx < getNumInputs(); ++idx) {
     if (in_dim != net_input[idx]->getDim())
       throw std::invalid_argument("Error: addition layer requires same "
                                   "shape from all input layers");
@@ -56,7 +56,7 @@ void AdditionLayer::forwarding(bool training) {
 
 void AdditionLayer::calcDerivative() {
 
-  for (unsigned int i = 0; i < num_inputs; ++i) {
+  for (unsigned int i = 0; i < getNumInputs(); ++i) {
     net_input[i]->getGradientRef() = net_hidden[0]->getGradientRef();
   }
 }
@@ -68,10 +68,10 @@ void AdditionLayer::setProperty(const PropertyType type,
   switch (type) {
   case PropertyType::num_inputs: {
     if (!value.empty()) {
+      unsigned int num_inputs;
       status = setUint(num_inputs, value);
       throw_status(status);
-      if (num_inputs < 1)
-        throw std::invalid_argument("Minimum number of inputs must be 1");
+      setNumInputs(num_inputs);
     }
   } break;
   default:

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -30,8 +30,8 @@ public:
    * @brief     Constructor of Addition Layer
    */
   template <typename... Args>
-  AdditionLayer(unsigned int num_inputs_ = 0, Args... args) : Layer(args...) {
-    num_inputs = num_inputs_;
+  AdditionLayer(unsigned int num_inputs_ = 1, Args... args) : Layer(args...) {
+    setNumInputs(num_inputs_);
   }
 
   /**

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -40,7 +40,7 @@ enum BNParams { mu, var, gamma, beta };
 int BatchNormalizationLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
 
-  if (num_inputs != 1) {
+  if (getNumInputs() != 1) {
     throw std::invalid_argument(
       "Only one input is allowed for batch normalization layer");
   }

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -27,14 +27,14 @@ int ConcatLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
   unsigned int channel = 0;
 
-  if (num_inputs == 0) {
+  if (getNumInputs() == 0) {
     ml_loge("Error: number of inputs are not initialized");
     return ML_ERROR_INVALID_PARAMETER;
   }
 
   const TensorDim &d = input_dim[0];
   channel += d.channel();
-  for (unsigned int idx = 1; idx < num_inputs; ++idx) {
+  for (unsigned int idx = 1; idx < getNumInputs(); ++idx) {
     const TensorDim &dim = input_dim[idx];
 
     for (unsigned int i = 2; i < d.rank(); ++i) {
@@ -58,7 +58,7 @@ void ConcatLayer::forwarding(bool training) {
   unsigned int channel = 0;
   const TensorDim &d = net_input[0]->getDim();
   channel += d.channel();
-  for (unsigned int idx = 1; idx < num_inputs; ++idx) {
+  for (unsigned int idx = 1; idx < getNumInputs(); ++idx) {
     const TensorDim &dim = net_input[idx]->getDim();
 
     for (unsigned int i = 2; i < d.rank(); ++i) {
@@ -82,7 +82,7 @@ void ConcatLayer::forwarding(bool training) {
    */
   for (unsigned int b = 0; b < input_dim[0].batch(); ++b) {
     unsigned int position = 0;
-    for (unsigned int idx = 0; idx < num_inputs; ++idx) {
+    for (unsigned int idx = 0; idx < getNumInputs(); ++idx) {
       TensorDim in_dim = net_input[idx]->getDim();
       memcpy(
         hidden_.getAddress(b * f_size + position),
@@ -97,7 +97,7 @@ void ConcatLayer::calcDerivative() {
   TensorDim d = net_hidden[0]->getDim();
 
   unsigned int position = 0;
-  for (unsigned int idx = 0; idx < num_inputs; ++idx) {
+  for (unsigned int idx = 0; idx < getNumInputs(); ++idx) {
     TensorDim in_dim = input_dim[idx];
 
     for (unsigned int b = 0; b < in_dim.batch(); ++b) {
@@ -118,10 +118,10 @@ void ConcatLayer::setProperty(const PropertyType type,
   switch (type) {
   case PropertyType::num_inputs: {
     if (!value.empty()) {
+      unsigned int num_inputs;
       status = setUint(num_inputs, value);
       throw_status(status);
-      if (num_inputs < 1)
-        throw std::invalid_argument("Minimum number of inputs must be 1");
+      setNumInputs(num_inputs);
     }
   } break;
   default:

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -30,8 +30,8 @@ public:
    * @brief     Constructor of Concat Layer
    */
   template <typename... Args>
-  ConcatLayer(unsigned int num_inputs_ = 0, Args... args) : Layer(args...) {
-    num_inputs = num_inputs_;
+  ConcatLayer(unsigned int num_inputs_ = 1, Args... args) : Layer(args...) {
+    setNumInputs(num_inputs_);
   }
 
   /**

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -325,7 +325,7 @@ int Conv2DLayer::initialize(Manager &manager) {
 void Conv2DLayer::forwarding(bool training) {
   int status = ML_ERROR_NONE;
 
-  if (num_inputs != 1)
+  if (getNumInputs() != 1)
     throw std::invalid_argument("Convolution layer only takes one input");
 
   Tensor &input_ = net_input[0]->getVariableRef();

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -27,7 +27,7 @@ enum EmbeddingParams { weight };
 
 int EmbeddingLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
-  if (num_inputs != 1) {
+  if (getNumInputs() != 1) {
     throw std::invalid_argument("Embedding layer takes only one input");
   }
 

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -38,7 +38,7 @@ enum FCParams { weight, bias };
 int FullyConnectedLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
 
-  if (num_inputs != 1) {
+  if (getNumInputs() != 1) {
     throw std::invalid_argument("Fully connected layer takes only one input");
   }
 

--- a/nntrainer/layers/flatten_layer.cpp
+++ b/nntrainer/layers/flatten_layer.cpp
@@ -23,7 +23,7 @@ namespace nntrainer {
 const std::string FlattenLayer::type = "flatten";
 
 int FlattenLayer::initialize(Manager &manager) {
-  if (num_inputs != 1) {
+  if (getNumInputs() != 1) {
     throw std::invalid_argument("input_shape keyword is only for one input");
   }
 

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -78,11 +78,9 @@ public:
     weight_initializer(weight_initializer_),
     bias_initializer(bias_initializer_),
     flatten(flatten_),
-    trainable(trainable_),
-    num_inputs(1),
-    num_outputs(1) {
-    input_dim.resize(1);
-    output_dim.resize(1);
+    trainable(trainable_) {
+    setNumInputs(1);
+    setNumOutputs(1);
   }
 
   /**
@@ -328,8 +326,11 @@ public:
    * @note This does not affect the number of inputs/outputs
    */
   virtual void resetDimension() {
+    unsigned int num_inputs = input_dim.size();
     input_dim.clear();
     input_dim.resize(num_inputs);
+
+    unsigned int num_outputs = output_dim.size();
     output_dim.clear();
     output_dim.resize(num_outputs);
   }
@@ -361,10 +362,23 @@ public:
    */
   virtual int initialize(Manager &manager) = 0;
 
-#ifdef ENABLE_TEST
-  virtual unsigned int getNumInputs() { return num_inputs; }
-  virtual unsigned int getNumOutputs() { return num_outputs; }
-#endif
+  virtual unsigned int getNumInputs() { return input_dim.size(); }
+
+  virtual unsigned int getNumOutputs() { return output_dim.size(); }
+
+  void setNumInputs(unsigned int size) {
+    if (size < 1)
+      throw std::invalid_argument("Minimum number of inputs must be 1");
+    input_dim.resize(size);
+    net_input.resize(size);
+  }
+
+  void setNumOutputs(unsigned int size) {
+    if (size < 1)
+      throw std::invalid_argument("Minimum number of outputs must be 1");
+    output_dim.resize(size);
+    net_hidden.resize(size);
+  }
 
 protected:
   /**
@@ -388,18 +402,9 @@ protected:
   std::string name;
 
   /**
-   * @brief     Input Tensor
+   * @brief     Input and Output Tensors
    */
-  Tensor input;
-
   std::vector<std::shared_ptr<Var_Grad>> net_input;
-
-  /**
-   * @brief     Hidden Layer Tensor which store the
-   *            forwading result
-   */
-  Tensor hidden;
-  Tensor ret_derivative; /** derivative to be returned to previous layer */
 
   std::vector<std::shared_ptr<Var_Grad>> net_hidden;
 
@@ -445,16 +450,6 @@ protected:
   std::vector<Weight> weights;
 
   /**
-   * @brief   Number of inputs this layer will requries/will operate on
-   */
-  unsigned int num_inputs;
-
-  /**
-   * @brief   Numer of outputs this layer will produce
-   */
-  unsigned int num_outputs;
-
-  /**
    * @brief     Activation Setter
    * @param[in] activation activation type
    * @throw std::invalid_argument when ActivationType is unknown
@@ -472,11 +467,13 @@ private:
    */
   static int def_name_count;
 
+  // TODO: remove this from here
   /**
    * @brief     input layer names
    */
   std::vector<std::string> input_layers;
 
+  // TODO: remove this from here
   /**
    * @brief     output layer names
    */

--- a/nntrainer/layers/output_layer.cpp
+++ b/nntrainer/layers/output_layer.cpp
@@ -26,18 +26,16 @@ const std::string OutputLayer::type = "output";
 int OutputLayer::initialize(Manager &manager) {
   int status = ML_ERROR_NONE;
 
-  if (num_inputs == 0) {
+  if (getNumInputs() == 0) {
     ml_loge("Error: number of inputs are not initialized");
     return ML_ERROR_INVALID_PARAMETER;
   }
 
-  output_dim.clear();
-
   // TODO : get output dimensions and set accordingly.
   //        for now, it's just copy of input dim.
 
-  for (unsigned int idx = 0; idx < num_outputs; ++idx) {
-    output_dim.push_back(input_dim[0]);
+  for (unsigned int idx = 0; idx < getNumOutputs(); ++idx) {
+    output_dim[idx] = input_dim[0];
   }
 
   return status;
@@ -45,7 +43,7 @@ int OutputLayer::initialize(Manager &manager) {
 
 void OutputLayer::forwarding(bool training) {
   Tensor &input_ = net_input[0]->getVariableRef();
-  for (unsigned int idx = 0; idx < num_outputs; ++idx) {
+  for (unsigned int idx = 0; idx < getNumOutputs(); ++idx) {
     net_hidden[idx]->getVariableRef() = input_;
   }
 }
@@ -54,7 +52,7 @@ void OutputLayer::calcDerivative() {
 
   Tensor &ret = net_input[0]->getGradientRef();
 
-  for (unsigned int idx = 0; idx < num_outputs; ++idx) {
+  for (unsigned int idx = 0; idx < getNumOutputs(); ++idx) {
     ret.add_i(net_hidden[idx]->getGradientRef());
   }
 }
@@ -66,10 +64,10 @@ void OutputLayer::setProperty(const PropertyType type,
   switch (type) {
   case PropertyType::num_outputs: {
     if (!value.empty()) {
+      unsigned int num_outputs;
       status = setUint(num_outputs, value);
       throw_status(status);
-      if (num_outputs < 1)
-        throw std::invalid_argument("Minimum number of outputs must be 1");
+      setNumOutputs(num_outputs);
     }
   } break;
   default:

--- a/nntrainer/layers/output_layer.h
+++ b/nntrainer/layers/output_layer.h
@@ -31,7 +31,7 @@ public:
    */
   template <typename... Args>
   OutputLayer(unsigned int num_output_ = 1, Args... args) : Layer(args...) {
-    num_outputs = num_output_;
+    setNumOutputs(num_output_);
   }
 
   /**

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -184,7 +184,6 @@ int NeuralNetwork::initialize() {
 
   ml_logd("initializing neural network, layer size: %d", n_layers);
 
-  model_graph.setNumNetBufferSize();
   opt->initialize();
 
   setBatchSize();
@@ -540,7 +539,8 @@ sharedConstTensors NeuralNetwork::inference(sharedConstTensors X,
   }
 
   for (unsigned int i = 0;
-       i < model_graph.Sorted[model_graph.Sorted.size() - 1].layer->num_outputs;
+       i <
+       model_graph.Sorted[model_graph.Sorted.size() - 1].layer->getNumOutputs();
        ++i) {
     out.push_back(
       MAKE_SHARED_TENSOR(model_graph.Sorted[model_graph.Sorted.size() - 1]

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -1933,14 +1933,6 @@ TEST(nntrainer_LossLayer, setLoss_02_n) {
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
-TEST(nntrainer_LossLayer, DISABLED_forward_nolabel_n) {
-  nntrainer::LossLayer layer;
-  nntrainer::Tensor a = constant(1.0, 1, 1, 1, 1);
-  layer.setProperty({"input_shape=1:1:1:1"});
-  EXPECT_THROW(layer.forwarding_with_val({MAKE_SHARED_TENSOR(a)}),
-               std::invalid_argument);
-}
-
 TEST(nntrainer_LossLayer, forward_loss_unknown_n) {
   nntrainer::LossLayer layer;
   nntrainer::Tensor a = constant(1.0, 1, 1, 1, 1);

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -1933,7 +1933,7 @@ TEST(nntrainer_LossLayer, setLoss_02_n) {
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
-TEST(nntrainer_LossLayer, forward_nolabel_n) {
+TEST(nntrainer_LossLayer, DISABLED_forward_nolabel_n) {
   nntrainer::LossLayer layer;
   nntrainer::Tensor a = constant(1.0, 1, 1, 1, 1);
   layer.setProperty({"input_shape=1:1:1:1"});
@@ -2143,11 +2143,11 @@ TEST_F(nntrainer_AdditionLayer, initialize_01_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
-TEST_F(nntrainer_AdditionLayer, initialize_02_n) {
+TEST_F(nntrainer_AdditionLayer, initialize_02_p) {
   nntrainer::AdditionLayer layer;
   layer.setProperty({"input_shape=1:1:1:1"});
   status = layer.initialize(manager);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
 TEST_F(nntrainer_AdditionLayer, checkValidation_01_p) {


### PR DESCRIPTION
Refactor layer to properly handle the number of inputs
and outputs, which is maintained across the in/out dimensions,
in/out data.
This is not maintained for in/out layers as these properties will move
out of layers in the next commit.

Also added bugfix in output_layer which used to clear the output dimension
rendering the num outputs 0 for sometime.

NetworkGraph setNumNetBufferSize is also removed as the above
refactoring handles it at the layer level.

See Also #986

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>