### PR TITLE
[loader] Change semantics of path in ini

### DIFF
--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -145,6 +145,20 @@ std::vector<std::string> getPluginPaths() {
   return ret;
 }
 
+/**
+ * @brief Get the Full Path from given string
+ * @details path is resolved in the following order
+ * 1) if @a path is absolute, return path
+ * ----------------------------------------
+ * 2) if @a base == "" && @a path == "", return "."
+ * 3) if @a base == "" && @a path != "", return @a path
+ * 4) if @a base != "" && @a path == "", return @a base
+ * 5) if @a base != "" && @a path != "", return @a base + "/" + path
+ *
+ * @param path path to calculate from base
+ * @param base base path
+ * @return const std::string
+ */
 const std::string getFullPath(const std::string &path,
                               const std::string &base) {
   /// if path is absolute, return path

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -84,6 +84,20 @@ public:
   void setWorkingDirectory(const std::string &base);
 
   /**
+   * @brief unset working directory
+   *
+   */
+  void unsetWorkingDirectory() { working_path_base = ""; }
+
+  /**
+   * @brief query if the appcontext has working directory set
+   *
+   * @return true working path base is set
+   * @return false working path base is not set
+   */
+  bool hasWorkingDirectory() { return !working_path_base.empty(); }
+
+  /**
    * @brief register a layer factory from a shared library
    * plugin must have **extern "C" LayerPluggable *ml_train_layer_pluggable**
    * defined else error

--- a/nntrainer/models/model_loader.h
+++ b/nntrainer/models/model_loader.h
@@ -15,6 +15,8 @@
 #define __MODEL_LOADER_H__
 #ifdef __cplusplus
 
+#include <memory>
+
 #include <app_context.h>
 #include <iniparser.h>
 #include <neuralnet.h>
@@ -31,7 +33,8 @@ public:
    * @brief     Constructor of the model loader
    */
   ModelLoader(const AppContext &app_context_ = AppContext::Global()) :
-    app_context(app_context_) {}
+    app_context(app_context_),
+    model_file_context(nullptr) {}
 
   /**
    * @brief     Destructor of the model loader
@@ -145,10 +148,29 @@ private:
    */
   static bool fileTfLite(const std::string &filename);
 
+  /**
+   * @brief resolvePath to absolute path written in a model description
+   *
+   * @note  if path is absolute path, return path.
+   *        if app_context has working directory set, resolve from app_context
+   *        if not, resolve path assuming model_path is the current directory.
+   *        The behavior relys on the semantics of getWorkingPath();
+   * @param path path to resolve
+   * @return const std::string resolved path.
+   */
+  const std::string resolvePath(const std::string &path) {
+    auto app_context_resolved_path = app_context.getWorkingPath(path);
+    return model_file_context->getWorkingPath(app_context_resolved_path);
+  }
+
   const char *unknown = "Unknown";
   const char *none = "none";
 
   AppContext app_context;
+  std::unique_ptr<AppContext>
+    model_file_context; /**< model_file specific context which is
+           referred to as if app_context cannot
+           resolve some given configuration */
 };
 
 } /* namespace nntrainer */

--- a/test/test_models/models/mnist.ini
+++ b/test/test_models/models/mnist.ini
@@ -6,7 +6,7 @@ Epochs = 1500		# Epochs
 Optimizer = adam 	# adam (Adamtive Moment Estimation)
 Loss = cross  		# Loss function : mse (mean squared error)
                         #                       cross ( for cross entropy )
-Save_Path = "../test_models/models/model.bin"  	# model path to save / read
+Save_Path = "model.bin"  	# model path to save / read
 batch_size = 32		# batch size
 beta1 = 0.9 		# beta 1 for adam
 beta2 = 0.999	# beta 2 for adam

--- a/test/test_models/models/mnist_inf.ini
+++ b/test/test_models/models/mnist_inf.ini
@@ -1,12 +1,12 @@
 # Network Section : Network
 [Model]
 Type = NeuralNetwork	# Network Type : Regression, KNN, NeuralNetwork
-Save_Path = "../test_models/models/model.bin"  	# model path to save / read
+Save_Path = "model.bin"  	# model path to save / read
 # loss = none           # This also works
 batch_size = 1         # batch size
 
 [mnist]
-backbone = "../test_models/models/mnist.ini"
+backbone = "mnist.ini"
 Input_Shape = 1:28:28
 
 # Original Model


### PR DESCRIPTION
Ini description is expected to be somewhat determinisitic.

But paths inside ini is not deterministic. For example, if you have
save_path=model.bin,

if A application trains it and B application try to use it, reading the
same ini does not gaurantee B to read to the weights from A.

It is because A and B can have diffrent working path.

To make it consistent, this patch changes semantics of paths' in ini.

1. if model.appcontext.hasWorkingDirectory(), path inside ini are interpreted from
the workingDirectory
2. else, it is interpreted **relative to where ini is located at.**

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
