### PR TITLE
[model] Read and save after init

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -429,6 +429,9 @@ NeuralNetwork &NeuralNetwork::copy(NeuralNetwork &from) {
  *            save training parameters from the optimizer
  */
 void NeuralNetwork::saveModel() {
+  if (!initialized)
+    throw std::runtime_error("Cannot save the model before initialize.");
+
   if (save_path == std::string()) {
     return;
   }
@@ -452,6 +455,9 @@ void NeuralNetwork::saveModel() {
  *            read training parameters from the optimizer if continuing train
  */
 void NeuralNetwork::readModel() {
+  if (!initialized)
+    throw std::runtime_error("Cannot save the model before initialize.");
+
   if (save_path == std::string()) {
     return;
   }

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -20,6 +20,7 @@
 #include <bn_layer.h>
 #include <input_layer.h>
 #include <layer.h>
+#include <layer_factory.h>
 #include <loss_layer.h>
 #include <neuralnet.h>
 #include <weight.h>
@@ -774,6 +775,27 @@ INSTANTIATE_TEST_CASE_P(
 // });
 /// #end if */
 // clang-format on
+
+/**
+ * @brief Read or save the model before initialize
+ */
+TEST(nntrainerModels, read_save_01_n) {
+  nntrainer::NeuralNetwork NN;
+  std::shared_ptr<nntrainer::Layer> layer =
+    nntrainer::createLayer(nntrainer::InputLayer::type);
+  layer->setProperty(
+    {"input_shape=1:1:62720", "normalization=true", "bias_initializer=zeros"});
+
+  EXPECT_NO_THROW(NN.addLayer(layer));
+
+  EXPECT_THROW(NN.readModel(), std::runtime_error);
+  EXPECT_THROW(NN.saveModel(), std::runtime_error);
+
+  EXPECT_EQ(NN.compile(), ML_ERROR_NONE);
+
+  EXPECT_THROW(NN.readModel(), std::runtime_error);
+  EXPECT_THROW(NN.saveModel(), std::runtime_error);
+}
 
 /**
  * @brief Main gtest


### PR DESCRIPTION
Add a check in model to read and save after init only
Added a corresponding unittest for the negative case

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>