### PR TITLE
[model] Move layers out of model

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -584,7 +584,7 @@ NetworkGraph::getGraph(const std::string &input_layer,
 }
 
 void NetworkGraph::extendGraph(std::vector<std::shared_ptr<Layer>> graph,
-                               std::string prefix) {
+                               std::string &prefix) {
 
   /**
    * The input_layers for graph[0] here is provided to the backbone by the ini

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -178,7 +178,7 @@ public:
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
   void extendGraph(std::vector<std::shared_ptr<Layer>> graph,
-                   std::string prefix);
+                   std::string &prefix);
 
   /**
    * @brief     Ensure that layer has a name


### PR DESCRIPTION
Move layers from model to graph.
This places all the graph related elements in the graph
and easy to extend and reason about model.
This shows the redundancy in the graph which shall be handled in
upcoming PRs.

Remove friendship between classes as it makes extending the interface
difficult. Some friendships exist which will be removed in upcoming
PRs.

See Also #986

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>