### PR TITLE
[test/bug] Bug fix for layers unittest

### DIFF
--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -34,7 +34,7 @@ public:
   /**
    * @brief Var_Grad default destructor
    */
-  virtual ~Var_Grad() {}
+  virtual ~Var_Grad() = default;
 
   /**
    * @brief Construct a new Var_Grad object
@@ -46,20 +46,6 @@ public:
    */
   explicit Var_Grad(const TensorDim &dim, bool train = true,
                     bool alloc_now = false, const std::string &name = "");
-
-  /**
-   * @brief Swap for Var_Grad
-   *
-   * @param lhs Swap to
-   * @param rhs Swap from
-   */
-  friend void swap(Var_Grad &lhs, Var_Grad &rhs) noexcept {
-    using std::swap;
-
-    swap(lhs.var, rhs.var);
-    swap(lhs.grad, rhs.grad);
-    swap(lhs.name, rhs.name);
-  }
 
   /**
    * @brief Copy constructor for Var_Grad
@@ -280,18 +266,6 @@ public:
    * @brief Deallocate memory for the gradient
    */
   void deallocateGradient() { grad->deallocate(); }
-
-  /**
-   * @bried Update the variable to use the given tensor
-   * @param t Tensor to update with
-   */
-  void updateVariable(Tensor &t) { var = std::shared_ptr<Tensor>(&t); }
-
-  /**
-   * @bried Update the gradient to use the given tensor
-   * @param t Tensor to update with
-   */
-  void updateGradient(Tensor &t) { grad = std::shared_ptr<Tensor>(&t); }
 
   /**
    * @bried Update the variable to use the variable from the given param

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -106,8 +106,8 @@ protected:
   virtual void prepareLayer(){};
 
   virtual void resetLayer() {
-    layer = LayerType();
     manager.reset();
+    layer = LayerType();
   }
 
   virtual void setInputDim(const std::string &dimension) {


### PR DESCRIPTION
This patch adds bug fix for layers unittest
resetLayer() used to first free the layer and then call reset on the manager.
Freeing the layer used to free the memory of the weights, which left
the reference_wrapper for the weights in the manager in an undefined state.

This patch changes the order. Further, this patch removes some unsafe
practices from the var_grad.

This is a hotfix. The inability to check the validity of the weights in the manager
will be handled separately.

Resolves #1027

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>