### PR TITLE
[ ActFunc ] Separate Activation Function from Activation Layer

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -115,6 +115,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/preprocess_translate_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/embedding.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/rnn.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/layers/acti_func.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/graph/network_graph.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/optimizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/adam.cpp \

--- a/nntrainer/layers/acti_func.cpp
+++ b/nntrainer/layers/acti_func.cpp
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file   acti_func.cpp
+ * @date   22 March 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Activation Layer Class for Neural Network
+ *
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <vector>
+
+#include <acti_func.h>
+#include <blas_interface.h>
+#include <lazy_tensor.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <parse_util.h>
+#include <tensor.h>
+#include <util_func.h>
+
+namespace nntrainer {
+
+int ActiFunc::setActivation(
+  std::function<Tensor &(Tensor const &, Tensor &)> const &activation_fn,
+  std::function<Tensor &(Tensor &, Tensor &, Tensor const &)> const
+    &activation_prime_fn) {
+  _act_fn = activation_fn;
+  _act_prime_fn = activation_prime_fn;
+
+  return ML_ERROR_NONE;
+}
+
+int ActiFunc::setActivation(
+  std::function<Tensor &(Tensor const &, Tensor &)> const &activation_fn,
+  std::function<Tensor &(Tensor &, Tensor &)> const &activation_prime_fn) {
+  _act_fn = activation_fn;
+  _act_prime_fn = [activation_prime_fn](Tensor &x, Tensor &ret_derivative,
+                                        Tensor const &derivative) -> Tensor & {
+    x = activation_prime_fn(x, x);
+    ret_derivative = derivative.multiply(x, ret_derivative);
+
+    return ret_derivative;
+  };
+
+  return ML_ERROR_NONE;
+}
+
+int ActiFunc::setActivation(
+  std::function<float(float const)> const &activation_fn,
+  std::function<float(float const)> const &activation_prime_fn) {
+  _act_fn = [activation_fn](Tensor const &x, Tensor &hidden) -> Tensor & {
+    return x.apply(activation_fn, hidden);
+  };
+  _act_prime_fn = [activation_prime_fn](Tensor &x, Tensor &ret_derivative,
+                                        Tensor const &derivative) -> Tensor & {
+    x = x.apply(activation_prime_fn, x);
+    ret_derivative = derivative.multiply(x, ret_derivative);
+
+    return ret_derivative;
+  };
+
+  return ML_ERROR_NONE;
+}
+
+/**
+ * @brief setActiFunc by preset ActivationType
+ *
+ * @param[in] ActivationType ActivationType ActivationType to be set
+ */
+void ActiFunc::setActiFunc(ActivationType acti_type) {
+
+  switch (acti_type) {
+  case ActivationType::ACT_TANH:
+    this->setActivation(tanhFloat, tanhPrime);
+    break;
+  case ActivationType::ACT_SIGMOID:
+    this->setActivation(sigmoid, sigmoidPrime);
+    break;
+  case ActivationType::ACT_SOFTMAX:
+    this->setActivation(softmax, softmaxPrime);
+    break;
+  case ActivationType::ACT_RELU:
+    this->setActivation(relu, reluPrime);
+    break;
+  case ActivationType::ACT_NONE:
+    this->setActivation(no_op, no_op_prime);
+    break;
+  case ActivationType::ACT_UNKNOWN:
+  default:
+    throw std::runtime_error("Error: Not Supported Activation Type");
+  }
+}
+
+void ActiFunc::run_fn(Tensor const &x, Tensor &output) { _act_fn(x, output); }
+
+Tensor &ActiFunc::run_prime_fn(Tensor &in, Tensor &ret, Tensor const &deriv) {
+  return _act_prime_fn(in, ret, deriv);
+}
+
+Tensor &ActiFunc::softmax(Tensor const &t, Tensor &output) {
+  /**
+   * shiftx_logit = logit - max_batch(logit)
+   * softmax = exp(shiftx_logit) / (sum(exp(shiftx_logit)))
+   */
+  unsigned int batch = t.batch();
+  float *dp;
+  float *rp;
+
+  Tensor divisor = t.clone();
+
+  dp = divisor.getData();
+  unsigned int feat_len = t.getDim().getFeatureLen();
+
+  for (unsigned int k = 0; k < batch; k++) {
+    int index = k * feat_len;
+    // find max and subtract it
+    float m = *std::max_element(dp + index, dp + index + feat_len);
+
+    Tensor tmp = Tensor(1, 1, 1, feat_len);
+    tmp.setValue(m);
+    saxpy(feat_len, -1, tmp.getData(), 1, dp + index, 1);
+  }
+
+  // take exp
+  output = divisor.apply(exp_util, output);
+  rp = output.getData();
+  // take sum over batch
+  Tensor sum = output.sum_by_batch();
+
+  for (unsigned int k = 0; k < batch; k++) {
+    int index = k * feat_len;
+    std::transform(rp + index, rp + index + feat_len, rp + index,
+                   std::bind(std::divides<float>(), std::placeholders::_1,
+                             sum.getValue(k, 0, 0, 0)));
+  }
+
+  return output;
+}
+
+Tensor &ActiFunc::softmaxPrime(Tensor const &x, Tensor &output,
+                               Tensor const &derivative) {
+  unsigned int batch = x.batch();
+  unsigned int channel = x.channel();
+  unsigned int height = x.height();
+  unsigned int width = x.width();
+  bool is_derivative = true;
+
+  if (output.uninitialized())
+    output = Tensor(x.getDim());
+
+  const float *xp = x.getData();
+  const float *d = derivative.getData();
+  float *pp = output.getData();
+
+  /** @todo update default tensorDim to be 0 and not 1 */
+  if (derivative.getDim() == TensorDim()) {
+    is_derivative = false;
+  }
+
+  for (unsigned int k = 0; k < batch; ++k) {
+    int K = k * channel * height * width;
+    for (unsigned int c = 0; c < channel; ++c) {
+      int C = K + c * height * width;
+      for (unsigned int i = 0; i < height; ++i) {
+        int I = C + i * width;
+        for (unsigned int j = 0; j < width; ++j) {
+          float sum = 0.0f;
+          for (unsigned int l = 0; l < width; ++l) {
+            float val;
+            if (j == l) {
+              val = xp[I + l] * (1.0f - xp[I + j]);
+            } else {
+              val = -xp[I + l] * xp[I + j];
+            }
+            if (is_derivative)
+              val *= d[I + l];
+            sum += val;
+          }
+          pp[I + j] = sum;
+        }
+      }
+    }
+  }
+  return output;
+}
+
+float ActiFunc::sigmoid(float x) { return 1.0f / (1.0f + exp_util(-x)); }
+
+float ActiFunc::sigmoidPrime(float x) {
+  // float sprime = sigmoid(x);
+  return x * (1.0f - x);
+}
+
+float ActiFunc::tanhFloat(float x) { return (float)tanh(x); }
+
+float ActiFunc::tanhPrime(float x) {
+  // float th = (float)tanh(x);
+  return 1.0f - x * x;
+}
+
+float ActiFunc::relu(float x) {
+  if (x <= 0.0f) {
+    return 0.0f;
+  } else {
+    return x;
+  }
+}
+
+float ActiFunc::reluPrime(float x) {
+  if (x <= 0.0f) {
+    return 0.0f;
+  } else {
+    return 1.0f;
+  }
+}
+
+float ActiFunc::no_op(float x) { return x; }
+
+float ActiFunc::no_op_prime(float x) { return 1.0f; }
+}; // namespace nntrainer

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -2,88 +2,77 @@
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
- * @file   activation_layer.h
- * @date   17 June 2020
+ * @file   acti_func.cpp
+ * @date   22 March 2021
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  This is Activation Layer Class for Neural Network
+ * @brief  This is Activation Function Class for Neural Network
  *
  */
 
-#ifndef __ACTIVATION_LAYER_H__
-#define __ACTIVATION_LAYER_H__
+#ifndef __ACTI_FUNC_H__
+#define __ACTI_FUNC_H__
 #ifdef __cplusplus
 
-#include <acti_func.h>
-#include <layer_internal.h>
 #include <tensor.h>
 
 namespace nntrainer {
 
 /**
- * @class   Activation Layer
- * @brief   Activation Layer
+ * @brief     Enumeration of activation function type
  */
-class ActivationLayer : public Layer {
+enum class ActivationType {
+  ACT_TANH,    /** tanh */
+  ACT_SIGMOID, /** sigmoid */
+  ACT_RELU,    /** ReLU */
+  ACT_SOFTMAX, /** softmax */
+  ACT_NONE,    /** no op */
+  ACT_UNKNOWN  /** unknown */
+};
+
+/**
+ * @class   ActiFunc Class
+ * @brief   ActiFunc Class
+ */
+class ActiFunc {
 
 public:
   /**
-   * @brief     Constructor of Activation Layer
+   * @brief     Constructor of ActiFunc
    */
-  template <typename... Args>
-  ActivationLayer(ActivationType at = ActivationType::ACT_NONE, Args... args) :
-    Layer(args...) {
-    setTrainable(false);
-    setActivation(at);
-  }
+  ActiFunc(ActivationType at = ActivationType::ACT_NONE) { setActiFunc(at); }
 
   /**
-   * @brief     Destructor of Activation Layer
+   * @brief     Destructor of ActiFunc
    */
-  ~ActivationLayer(){};
-
-  /**
-   * @brief     Initialize the layer
-   *
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int initialize(Manager &manager) override;
-
-  /**
-   * @brief     Read Activation layer params. This is essentially noops for now.
-   * @param[in] file input stream file
-   */
-  void read(std::ifstream &file) override{/* noop */};
-
-  /**
-   * @brief     Save Activation layer params. This is essentially noops for now.
-   * @param[in] file output stream file
-   */
-  void save(std::ofstream &file) override{/* noop */};
-
-  /**
-   * @copydoc Layer::forwarding(bool training)
-   */
-  void forwarding(bool training = true) override;
-
-  /**
-   * @copydoc Layer::calcDerivative()
-   */
-  void calcDerivative() override;
+  ~ActiFunc() = default;
 
   /**
    * @brief setActivation by preset ActivationType
    *
    * @param[in] ActivationType
    */
-  void setActivation(ActivationType acti_type) override;
+  void setActiFunc(ActivationType acti_type);
 
   /**
-   * @copydoc Layer::getType()
+   * @brief run function
+   *
+   * @param[in] x : input
+   * @param[out] output : output
    */
-  const std::string getType() const override { return ActivationLayer::type; };
+  void run_fn(Tensor const &x, Tensor &output);
+
+  /**
+   * @brief run prime function
+   *
+   * @param[in] in : input
+   * @param[out] ret : output
+   * @param[in] deriv : derivative
+   * @retVal    Tensor
+   */
+  Tensor &run_prime_fn(Tensor &in, Tensor &ret, Tensor const &deriv);
 
   /**
    * @brief       Calculate softmax for Tensor Type
@@ -153,11 +142,6 @@ public:
 
   static const std::string type;
 
-private:
-  ActiFunc acti_func;
-
-  Tensor backup_hidden;
-
   /**
    * @brief setActivation by custom activation function
    * @note  apply derivative as this activation_prime_fn does not utilize
@@ -200,9 +184,13 @@ private:
   int setActivation(
     std::function<float(float const)> const &activation_fn,
     std::function<float(float const)> const &activation_prime_fn);
+
+private:
+  std::function<Tensor &(Tensor const &, Tensor &)> _act_fn;
+  std::function<Tensor &(Tensor &, Tensor &, Tensor const &)> _act_prime_fn;
 };
 
 } // namespace nntrainer
 
 #endif /* __cplusplus */
-#endif /* __ACTIVATION_LAYER_H__ */
+#endif /* __ACTI_FUNC_H__ */

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -49,7 +49,7 @@ int ActivationLayer::initialize(Manager &manager) {
 void ActivationLayer::forwarding(bool training) {
   Tensor &hidden_ = net_hidden[0]->getVariableRef();
   /// @note @a _act_fn is expected to work out of place and not modify @a input
-  _act_fn(net_input[0]->getVariableRef(), hidden_);
+  acti_func.run_fn(net_input[0]->getVariableRef(), hidden_);
 }
 
 void ActivationLayer::calcDerivative() {
@@ -57,15 +57,14 @@ void ActivationLayer::calcDerivative() {
   Tensor &ret = net_input[0]->getGradientRef();
   Tensor &in = net_hidden[0]->getVariableRef();
 
-  ret = _act_prime_fn(in, ret, deriv);
+  ret = acti_func.run_prime_fn(in, ret, deriv);
 }
 
 int ActivationLayer::setActivation(
   std::function<Tensor &(Tensor const &, Tensor &)> const &activation_fn,
   std::function<Tensor &(Tensor &, Tensor &, Tensor const &)> const
     &activation_prime_fn) {
-  _act_fn = activation_fn;
-  _act_prime_fn = activation_prime_fn;
+  acti_func.setActivation(activation_fn, activation_prime_fn);
 
   return ML_ERROR_NONE;
 }
@@ -73,14 +72,8 @@ int ActivationLayer::setActivation(
 int ActivationLayer::setActivation(
   std::function<Tensor &(Tensor const &, Tensor &)> const &activation_fn,
   std::function<Tensor &(Tensor &, Tensor &)> const &activation_prime_fn) {
-  _act_fn = activation_fn;
-  _act_prime_fn = [activation_prime_fn](Tensor &x, Tensor &ret_derivative,
-                                        Tensor const &derivative) -> Tensor & {
-    x = activation_prime_fn(x, x);
-    ret_derivative = derivative.multiply(x, ret_derivative);
 
-    return ret_derivative;
-  };
+  acti_func.setActivation(activation_fn, activation_prime_fn);
 
   return ML_ERROR_NONE;
 }
@@ -88,16 +81,8 @@ int ActivationLayer::setActivation(
 int ActivationLayer::setActivation(
   std::function<float(float const)> const &activation_fn,
   std::function<float(float const)> const &activation_prime_fn) {
-  _act_fn = [activation_fn](Tensor const &x, Tensor &hidden) -> Tensor & {
-    return x.apply(activation_fn, hidden);
-  };
-  _act_prime_fn = [activation_prime_fn](Tensor &x, Tensor &ret_derivative,
-                                        Tensor const &derivative) -> Tensor & {
-    x = x.apply(activation_prime_fn, x);
-    ret_derivative = derivative.multiply(x, ret_derivative);
 
-    return ret_derivative;
-  };
+  acti_func.setActivation(activation_fn, activation_prime_fn);
 
   return ML_ERROR_NONE;
 }
@@ -110,146 +95,7 @@ int ActivationLayer::setActivation(
 void ActivationLayer::setActivation(ActivationType acti_type) {
   Layer::setActivation(acti_type);
 
-  switch (acti_type) {
-  case ActivationType::ACT_TANH:
-    this->setActivation(tanhFloat, tanhPrime);
-    break;
-  case ActivationType::ACT_SIGMOID:
-    this->setActivation(sigmoid, sigmoidPrime);
-    break;
-  case ActivationType::ACT_SOFTMAX:
-    this->setActivation(softmax, softmaxPrime);
-    break;
-  case ActivationType::ACT_RELU:
-    this->setActivation(relu, reluPrime);
-    break;
-  case ActivationType::ACT_NONE:
-    this->setActivation(no_op, no_op_prime);
-    break;
-  case ActivationType::ACT_UNKNOWN:
-  default:
-    throw std::runtime_error("Error: Not Supported Activation Type");
-  }
+  acti_func.setActiFunc(acti_type);
 }
 
-Tensor &ActivationLayer::softmax(Tensor const &t, Tensor &output) {
-  /**
-   * shiftx_logit = logit - max_batch(logit)
-   * softmax = exp(shiftx_logit) / (sum(exp(shiftx_logit)))
-   */
-  unsigned int batch = t.batch();
-  float *dp;
-  float *rp;
-
-  Tensor divisor = t.clone();
-
-  dp = divisor.getData();
-  unsigned int feat_len = t.getDim().getFeatureLen();
-
-  for (unsigned int k = 0; k < batch; k++) {
-    int index = k * feat_len;
-    // find max and subtract it
-    float m = *std::max_element(dp + index, dp + index + feat_len);
-
-    Tensor tmp = Tensor(1, 1, 1, feat_len);
-    tmp.setValue(m);
-    saxpy(feat_len, -1, tmp.getData(), 1, dp + index, 1);
-  }
-
-  // take exp
-  output = divisor.apply(exp_util, output);
-  rp = output.getData();
-  // take sum over batch
-  Tensor sum = output.sum_by_batch();
-
-  for (unsigned int k = 0; k < batch; k++) {
-    int index = k * feat_len;
-    std::transform(rp + index, rp + index + feat_len, rp + index,
-                   std::bind(std::divides<float>(), std::placeholders::_1,
-                             sum.getValue(k, 0, 0, 0)));
-  }
-
-  return output;
-}
-
-Tensor &ActivationLayer::softmaxPrime(Tensor const &x, Tensor &output,
-                                      Tensor const &derivative) {
-  unsigned int batch = x.batch();
-  unsigned int channel = x.channel();
-  unsigned int height = x.height();
-  unsigned int width = x.width();
-  bool is_derivative = true;
-
-  if (output.uninitialized())
-    output = Tensor(x.getDim());
-
-  const float *xp = x.getData();
-  const float *d = derivative.getData();
-  float *pp = output.getData();
-
-  /** @todo update default tensorDim to be 0 and not 1 */
-  if (derivative.getDim() == TensorDim()) {
-    is_derivative = false;
-  }
-
-  for (unsigned int k = 0; k < batch; ++k) {
-    int K = k * channel * height * width;
-    for (unsigned int c = 0; c < channel; ++c) {
-      int C = K + c * height * width;
-      for (unsigned int i = 0; i < height; ++i) {
-        int I = C + i * width;
-        for (unsigned int j = 0; j < width; ++j) {
-          float sum = 0.0f;
-          for (unsigned int l = 0; l < width; ++l) {
-            float val;
-            if (j == l) {
-              val = xp[I + l] * (1.0f - xp[I + j]);
-            } else {
-              val = -xp[I + l] * xp[I + j];
-            }
-            if (is_derivative)
-              val *= d[I + l];
-            sum += val;
-          }
-          pp[I + j] = sum;
-        }
-      }
-    }
-  }
-  return output;
-}
-
-float ActivationLayer::sigmoid(float x) { return 1.0f / (1.0f + exp_util(-x)); }
-
-float ActivationLayer::sigmoidPrime(float x) {
-  // float sprime = sigmoid(x);
-  return x * (1.0f - x);
-}
-
-float ActivationLayer::tanhFloat(float x) { return (float)tanh(x); }
-
-float ActivationLayer::tanhPrime(float x) {
-  // float th = (float)tanh(x);
-  return 1.0f - x * x;
-}
-
-float ActivationLayer::relu(float x) {
-  if (x <= 0.0f) {
-    return 0.0f;
-  } else {
-    return x;
-  }
-}
-
-float ActivationLayer::reluPrime(float x) {
-  if (x <= 0.0f) {
-    return 0.0f;
-  } else {
-    return 1.0f;
-  }
-}
-
-float ActivationLayer::no_op(float x) { return x; }
-
-float ActivationLayer::no_op_prime(float x) { return 1.0f; }
 }; // namespace nntrainer

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -27,6 +27,7 @@
 #include <set>
 #include <vector>
 
+#include <acti_func.h>
 #include <layer.h>
 #include <manager.h>
 #include <optimizer_internal.h>
@@ -35,18 +36,6 @@
 #include <weight.h>
 
 namespace nntrainer {
-
-/**
- * @brief     Enumeration of activation function type
- */
-enum class ActivationType {
-  ACT_TANH,    /** tanh */
-  ACT_SIGMOID, /** sigmoid */
-  ACT_RELU,    /** ReLU */
-  ACT_SOFTMAX, /** softmax */
-  ACT_NONE,    /** no op */
-  ACT_UNKNOWN  /** unknown */
-};
 
 /**
  * @class   Layer Base class for layers

--- a/nntrainer/layers/loss_layer.cpp
+++ b/nntrainer/layers/loss_layer.cpp
@@ -21,7 +21,7 @@
  *
  */
 
-#include <activation_layer.h>
+#include <acti_func.h>
 #include <cmath>
 #include <layer_internal.h>
 #include <lazy_tensor.h>
@@ -63,7 +63,7 @@ void LossLayer::forwarding(bool training) {
     }
   } break;
   case LossType::LOSS_ENTROPY_SIGMOID: {
-    hidden_ = y.apply(ActivationLayer::sigmoid, hidden_);
+    hidden_ = y.apply(ActiFunc::sigmoid, hidden_);
     if (label_exist) {
       Tensor &y2 = net_hidden[0]->getGradientRef();
       // @todo: change this to apply_i
@@ -74,7 +74,7 @@ void LossLayer::forwarding(bool training) {
                           .apply(static_cast<float (*)(float)>(&std::exp))
                           .add(1.0)
                           .apply(logFloat);
-      mid_term = mid_term.add(y.apply(ActivationLayer::relu));
+      mid_term = mid_term.add(y.apply(ActiFunc::relu));
 
       // y * y2
       Tensor end_term = y2.chain().multiply_i(y).run();
@@ -84,7 +84,7 @@ void LossLayer::forwarding(bool training) {
     }
   } break;
   case LossType::LOSS_ENTROPY_SOFTMAX: {
-    hidden_ = y.apply(ActivationLayer::softmax, hidden_);
+    hidden_ = y.apply(ActiFunc::softmax, hidden_);
     if (label_exist) {
       Tensor &y2 = net_hidden[0]->getGradientRef();
       l = y2.multiply(hidden_.apply(logFloat)).sum_by_batch().multiply(-1);
@@ -141,7 +141,7 @@ void LossLayer::calcDerivative() {
     }
     break;
   case LossType::LOSS_ENTROPY_SIGMOID:
-    y.apply(ActivationLayer::sigmoid, ret_derivative);
+    y.apply(ActiFunc::sigmoid, ret_derivative);
     ret_derivative.subtract_i(y2);
     if (ret_derivative.divide_i(ret_derivative.length()) != ML_ERROR_NONE) {
       throw std::runtime_error(
@@ -151,7 +151,7 @@ void LossLayer::calcDerivative() {
   case LossType::LOSS_ENTROPY_SOFTMAX:
     /// @note y and ret_derivative can be same here, so this has to be out-place
     /// operation
-    y.apply(ActivationLayer::softmax, ret);
+    y.apply(ActiFunc::softmax, ret);
     ret.subtract(y2, ret_derivative);
     if (ret_derivative.divide_i(ret.batch()) != ML_ERROR_NONE) {
       throw std::runtime_error(

--- a/nntrainer/layers/meson.build
+++ b/nntrainer/layers/meson.build
@@ -16,7 +16,8 @@ layer_sources = [
   'preprocess_flip_layer.cpp',
   'preprocess_translate_layer.cpp',
   'embedding.cpp',
-  'rnn.cpp'
+  'rnn.cpp',
+  'acti_func.cpp'
 ]
 
 layer_headers = [

--- a/test/unittest/unittest_nntrainer_activations.cpp
+++ b/test/unittest/unittest_nntrainer_activations.cpp
@@ -44,7 +44,7 @@ TEST(nntrainer_activation, softmax_01_p) {
 
   GEN_TEST_INPUT(T, (i * (width) + l + 1));
 
-  Results = T.apply(nntrainer::ActivationLayer::softmax, Results);
+  Results = T.apply(nntrainer::ActiFunc::softmax, Results);
   float *data = Results.getData();
   ASSERT_NE(nullptr, data);
 
@@ -64,15 +64,14 @@ TEST(nntrainer_activation, softmax_prime_01_p) {
   GEN_TEST_INPUT(input, (i * (width) + k + 1));
 
   nntrainer::Tensor softmax_result;
-  softmax_result =
-    input.apply(nntrainer::ActivationLayer::softmax, softmax_result);
+  softmax_result = input.apply(nntrainer::ActiFunc::softmax, softmax_result);
 
   float *data = softmax_result.getData();
   ASSERT_NE(nullptr, data);
 
   nntrainer::Tensor softmax_prime_result;
-  softmax_prime_result = nntrainer::ActivationLayer::softmaxPrime(
-    softmax_result, softmax_prime_result);
+  softmax_prime_result =
+    nntrainer::ActiFunc::softmaxPrime(softmax_result, softmax_prime_result);
 
   data = softmax_prime_result.getData();
   ASSERT_NE(nullptr, data);
@@ -98,7 +97,7 @@ TEST(nntrainer_activation, sigmoid_01_p) {
   nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
 
-  nntrainer::Tensor Results = input.apply(nntrainer::ActivationLayer::sigmoid);
+  nntrainer::Tensor Results = input.apply(nntrainer::ActiFunc::sigmoid);
 
   float *data = Results.getData();
   ASSERT_NE(nullptr, data);
@@ -128,13 +127,12 @@ TEST(nntrainer_activation, DISABLED_sigmoidPrime_01_p) {
   nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
 
-  nntrainer::Tensor sigmoid_result =
-    input.apply(nntrainer::ActivationLayer::sigmoid);
+  nntrainer::Tensor sigmoid_result = input.apply(nntrainer::ActiFunc::sigmoid);
   float *data = sigmoid_result.getData();
   ASSERT_NE(nullptr, data);
 
   nntrainer::Tensor prime_result =
-    sigmoid_result.apply(nntrainer::ActivationLayer::sigmoidPrime);
+    sigmoid_result.apply(nntrainer::ActiFunc::sigmoidPrime);
   data = prime_result.getData();
   ASSERT_NE(nullptr, data);
 
@@ -161,8 +159,7 @@ TEST(nntrainer_activation, tanhFloat_01_p) {
   nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
 
-  nntrainer::Tensor Results =
-    input.apply(nntrainer::ActivationLayer::tanhFloat);
+  nntrainer::Tensor Results = input.apply(nntrainer::ActiFunc::tanhFloat);
 
   float *data = Results.getData();
   ASSERT_NE(nullptr, data);
@@ -189,13 +186,12 @@ TEST(nntrainer_activation, DISABLED_tanhFloatPrime_01_p) {
   nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
 
-  nntrainer::Tensor tanh_result =
-    input.apply(nntrainer::ActivationLayer::tanhFloat);
+  nntrainer::Tensor tanh_result = input.apply(nntrainer::ActiFunc::tanhFloat);
   float *data = tanh_result.getData();
   ASSERT_NE(nullptr, data);
 
   nntrainer::Tensor prime_result =
-    tanh_result.apply(nntrainer::ActivationLayer::tanhPrime);
+    tanh_result.apply(nntrainer::ActiFunc::tanhPrime);
   data = prime_result.getData();
   ASSERT_NE(nullptr, data);
 
@@ -216,7 +212,7 @@ TEST(nntrainer_activation, relu_01_p) {
   nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
 
-  nntrainer::Tensor Results = input.apply(nntrainer::ActivationLayer::relu);
+  nntrainer::Tensor Results = input.apply(nntrainer::ActiFunc::relu);
 
   float *data = Results.getData();
   ASSERT_NE(nullptr, data);
@@ -239,12 +235,12 @@ TEST(nntrainer_activation, reluPrime_01_p) {
   nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
 
-  nntrainer::Tensor relu_result = input.apply(nntrainer::ActivationLayer::relu);
+  nntrainer::Tensor relu_result = input.apply(nntrainer::ActiFunc::relu);
   float *data = relu_result.getData();
   ASSERT_NE(nullptr, data);
 
   nntrainer::Tensor prime_result =
-    relu_result.apply(nntrainer::ActivationLayer::reluPrime);
+    relu_result.apply(nntrainer::ActiFunc::reluPrime);
   data = prime_result.getData();
   ASSERT_NE(nullptr, data);
 

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -2097,8 +2097,7 @@ TEST(nntrainer_ActivationLayer, forward_backward_01_p) {
   nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
   nntrainer::Tensor expected(batch, channel, height, width);
-  GEN_TEST_INPUT(expected,
-                 nntrainer::ActivationLayer::relu((l - 4) * 0.1 * (i + 1)));
+  GEN_TEST_INPUT(expected, nntrainer::ActiFunc::relu((l - 4) * 0.1 * (i + 1)));
 
   nntrainer::Manager manager;
   manager.setInferenceInOutMemoryOptimization(false);
@@ -2124,8 +2123,8 @@ TEST(nntrainer_ActivationLayer, forward_backward_01_p) {
   EXPECT_NO_THROW(result = *layer.backwarding_with_val(
                     1, {MAKE_SHARED_TENSOR(constant(1.0, 3, 1, 1, 10))})[0]);
   GEN_TEST_INPUT(expected,
-                 nntrainer::ActivationLayer::reluPrime(
-                   nntrainer::ActivationLayer::relu((l - 4) * 0.1 * (i + 1))));
+                 nntrainer::ActiFunc::reluPrime(
+                   nntrainer::ActiFunc::relu((l - 4) * 0.1 * (i + 1))));
   EXPECT_TRUE(result == expected);
 }
 


### PR DESCRIPTION
In order to use Activation function method in other Layer, it is
better to make sepearte the activation function definition and Layer.
In this PR, new ActiFunc Class is introduced and midified the
activation layer to use it.
RNN Layer also use this as an private variable.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>