### PR TITLE
[TestHub] Produce xml output for gtest

### DIFF
--- a/Applications/SimpleShot/test/meson.build
+++ b/Applications/SimpleShot/test/meson.build
@@ -15,5 +15,5 @@ exe = executable(
   install: get_option('enable-test'),
   install_dir: application_install_dir
 )
-test('simpleshot_tests', exe)
+test('simpleshot_tests', exe, args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), 'simpleshot_tests'))
 

--- a/Applications/TransferLearning/Draw_Classification/jni/meson.build
+++ b/Applications/TransferLearning/Draw_Classification/jni/meson.build
@@ -26,6 +26,8 @@ e = executable('nntrainer_training',
   install_dir: application_install_dir
 )
 
-nntrainer_filter_env = 'NNSTREAMER_FILTERS=' + meson.build_root() + '/nnstreamer/tensor_filter'
+nntrainer_filter_env = environment()
+nntrainer_filter_env.set('GTEST_OUTPUT', 'xml:@0@/@1@.xml'.format(meson.build_root(), 'app_draw_classification'))
+nntrainer_filter_env.set('NNSTREAMER_FILTERS', meson.build_root() / 'nnstreamer' / 'tensor_filter')
 test('app_draw_classification', e, env: nntrainer_filter_env,
   args: [nntr_draw_resdir / 'Training.ini', nntr_draw_resdir], timeout: 100)

--- a/test/ccapi/meson.build
+++ b/test/ccapi/meson.build
@@ -11,4 +11,4 @@ exec = executable(
   install_dir: application_install_dir
 )
 
-test('unittest_ccapi', exec)
+test('unittest_ccapi', exec, timeout: 60, args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), target))

--- a/test/tizen_capi/meson.build
+++ b/test/tizen_capi/meson.build
@@ -17,5 +17,5 @@ foreach test_name : unittest_name_list
     install_dir: application_install_dir
   )
 
-  test(unittest_name, exec)
+  test(unittest_name, exec, args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), unittest_name))
 endforeach

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -49,6 +49,6 @@ foreach target: test_target
     install: get_option('enable-test'),
     install_dir: application_install_dir
   )
-  test(target, exe)
+  test(target, exe, args: ['--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), target)] )
 endforeach
 


### PR DESCRIPTION
As xml output is needed for the testhub, this patch add generation for
the meson test

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>
