### PR TITLE
Fix/svace issue 210323

### DIFF
--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -46,9 +46,16 @@ static const gchar *nntrainer_accl_support[] = {NULL};
 void init_filter_nntrainer(void) __attribute__((constructor));
 void fini_filter_nntrainer(void) __attribute__((destructor));
 
-static std::unique_ptr<GstTensorInfo>
+struct gNewDeletor {
+    template <typename T>
+    void operator()(T* ptr) const {
+        g_free(ptr);
+    }
+};
+
+static std::unique_ptr<GstTensorInfo, gNewDeletor>
 to_nnst_tensor_dim(const nntrainer::TensorDim &dim) {
-  auto info = std::unique_ptr<GstTensorInfo>(g_new(GstTensorInfo, 1));
+  auto info = std::unique_ptr<GstTensorInfo, gNewDeletor>(g_new(GstTensorInfo, 1));
   gst_tensor_info_init(info.get());
 
   info->type = _NNS_FLOAT32;


### PR DESCRIPTION
[tensor_filter_nntrainer] Set custom deleter to unique_ptr

g_new() should match with g_malloc instread delete
Refer to https://developer.gnome.org/glib/stable/glib-Memory-Allocation.html
It handles HEAP_INCOMPATIBLE.FREE issue
resolves: 458008, 458009
