### PR TITLE
[wait for nnst/#3152] [tizen/pkg] Update tizen packaging file

### DIFF
--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -49,8 +49,8 @@ Version:	0.1.1
 Release:	0
 Packager:	Jijoong Moon <jijoong.moon@sansumg.com>
 License:	Apache-2.0
-Source0:	nntrainer-%{version}.tar.gz
-Source1001:	nntrainer.manifest
+Source0:	%{name}-%{version}.tar.gz
+Source1001:	%{name}.manifest
 %if %{with tizen}
 Source1002:     capi-machine-learning-training.manifest
 %endif
@@ -118,7 +118,7 @@ BuildRequires:	python
 %endif #nnstreamer_filter
 %endif  # tizen
 
-Requires:	nntrainer-core = %{version}-%{release}
+Requires:	%{name}-core = %{version}-%{release}
 
 %if  0%{?nnstreamer_filter}
 Requires:	nnstreamer-nntrainer = %{version}-%{release}
@@ -140,7 +140,7 @@ NNtrainer is Software Framework for Training Neural Network Models on Devices.
 
 %package devel
 Summary:	Development package for custom nntrainer developers
-Requires:	nntrainer = %{version}-%{release}
+Requires:	%{name} = %{version}-%{release}
 Requires:	iniparser-devel
 Requires:	openblas-devel
 Requires:	%{capi_machine_learning_common}-devel
@@ -157,7 +157,7 @@ Static library package of nntrainer-devel
 
 %package applications
 Summary:	NNTrainer Examples
-Requires:	nntrainer = %{version}-%{release}
+Requires:	%{name} = %{version}-%{release}
 Requires:	iniparser
 Requires:	%{capi_machine_learning_inference}
 Requires:	nnstreamer-tensorflow-lite


### PR DESCRIPTION
Updated tizen packaging file to use %{name} macro instead of the
string in requires and provides configurations.
This is has not been added to the name of the files intentionally.

See Also https://github.com/nnstreamer/nnstreamer/pull/3152

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>

cc. @again4you @myungjoo 