### PR TITLE
[graph] More refactors for graph + bug fix @open sesame 04/01 11:12

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -59,6 +59,13 @@ int NetworkGraph::compile(const LossType loss_type) {
   status = checkCompiledGraph();
   NN_RETURN_STATUS();
 
+  /**
+   * Now that graph is compiled, remove all edges to save memory.
+   * NodeList is kept for now for O(1) access of layers by idx.
+   */
+  for (unsigned int i = 0; i < adj.size(); ++i)
+    adj[i].resize(1);
+
   compiled = true;
 
   return status;
@@ -100,7 +107,7 @@ void NetworkGraph::addLayerNode(std::shared_ptr<Layer> layer) {
 }
 
 LayerNode &NetworkGraph::getLayerNode(unsigned int ith) {
-  if (ith >= adj.size())
+  if (ith >= size())
     throw std::invalid_argument("Exceed total number of layer");
 
   if (adj[ith].front().index != ith)

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -82,13 +82,23 @@ public:
    * @brief getter of number of nodes
    * @param[out] number of nodes
    */
-  unsigned int size() const { return adj.size(); }
+  unsigned int size() const {
+    if (!compiled)
+      return adj.size();
+    else
+      return Sorted.size();
+  }
 
   /**
    * @brief get if the graph is empty
    * @param[out] true if empty, else false
    */
-  bool empty() const { return adj.empty(); }
+  bool empty() const {
+    if (!compiled)
+      return adj.empty();
+    else
+      return Sorted.empty();
+  }
 
   /**
    * @brief     Swap function for the class


### PR DESCRIPTION
**Commit 1:** [graph] Update setting output layers in graph + bug fix 
Update setting output layers in graph to a unified location.
The graph is first made with just input layers.
Output layers are set at the end for the completeness at
one go than adding at each realization to avoid more errors.

Also, added a bug fix where the last layer in  the model
is not the last layer in the ini file. Now the last layer
is not the last layer in the adj but the layer without any
output_layers.

**Commit 2**: [graph] Remove graph edges after compile
This patch removes edges from the graph after compiling to
save the memory. This graph can be reconstructed by adding those edges
again from the information in the layers themselves.

See also #986

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>