### PR TITLE
[graph] Bug fix for no loss

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -327,8 +327,7 @@ int NetworkGraph::addLossLayer(const LossType loss_type) {
     return status;
 
   if (loss_type == LossType::LOSS_NONE) {
-    status = ML_ERROR_INVALID_PARAMETER;
-    NN_RETURN_STATUS();
+    return ML_ERROR_NONE;
   }
 
   LossType updated_loss_type = loss_type;

--- a/nntrainer/layers/loss_layer.h
+++ b/nntrainer/layers/loss_layer.h
@@ -26,11 +26,11 @@ namespace nntrainer {
 enum class LossType {
   LOSS_MSE,             /** Mean Squared Error */
   LOSS_ENTROPY,         /** Cross Entropy */
+  LOSS_NONE,            /** No loss for this model */
   LOSS_ENTROPY_SIGMOID, /** Cross Entropy amalgamated with sigmoid for stability
                          */
   LOSS_ENTROPY_SOFTMAX, /** Cross Entropy amalgamated with softmax for stability
                          */
-  LOSS_NONE,            /** No loss for this model */
   LOSS_UNKNOWN          /** Unknown */
 };
 


### PR DESCRIPTION
Added bug fix for handling the scenario when there is no loss
specified. The issue was the difference in ordering of the loss
types in the parser and loss type enums.
This patch fixes it. Further, graph now simply returns if no loss found.

Resolves #1055

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>