### PR TITLE
[graph/ini] Support for default input_layers

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -78,6 +78,16 @@ void NetworkGraph::updateConnectionName(const std::string &from,
   }
 }
 
+void NetworkGraph::addDefaultInputLayers() {
+  for (unsigned int i = 1; i < adj.size(); ++i) {
+    auto &layer = adj[i].front().layer;
+    auto &prev_layer = adj[i - 1].front().layer;
+    if (layer->input_layers.size() == 0) {
+      layer->input_layers.push_back(prev_layer->getName());
+    }
+  }
+}
+
 void NetworkGraph::addLayerNode(std::shared_ptr<Layer> layer) {
   std::list<LayerNode> l;
   std::unique_ptr<LayerNode> node = std::make_unique<LayerNode>();
@@ -505,6 +515,8 @@ int NetworkGraph::checkCompiledGraph() {
 int NetworkGraph::realizeGraph() {
 
   int status = ML_ERROR_NONE;
+
+  addDefaultInputLayers();
 
   setOutputLayers();
 

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -338,9 +338,14 @@ private:
   int addLossLayer(const LossType loss_type);
 
   /**
-   * @brief     set Multi Output Layer
+   * @brief     set output connections for all the layers
    */
   void setOutputLayers();
+
+  /**
+   * @brief     set default input layer connections
+   */
+  void addDefaultInputLayers();
 
   /**
    * @brief     Ensure that layer has a name.

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -596,10 +596,10 @@ INI fc_sigmoid_mse(
   "fc_sigmoid_mse",
   {nn_base + "learning_rate=1 | optimizer=sgd | loss=mse | batch_size = 3",
    I("input") + input_base + "input_shape = 1:1:3",
-   I("dense") + fc_base + "unit = 5" + "input_layers=input",
-   I("act") + sigmoid_base + "input_layers=dense",
-   I("dense_1") + fc_base + "unit = 10" + "input_layers=act",
-   I("act_1") + softmax_base + "input_layers=dense_1"});
+   I("dense") + fc_base + "unit = 5",
+   I("act") + sigmoid_base,
+   I("dense_1") + fc_base + "unit = 10",
+   I("act_1") + softmax_base});
 
 INI fc_sigmoid_cross =
   INI("fc_sigmoid_cross") + fc_sigmoid_mse + "model/loss=cross";
@@ -608,9 +608,9 @@ INI fc_relu_mse(
   "fc_relu_mse",
   {nn_base + "Learning_rate=0.1 | Optimizer=sgd | Loss=mse | batch_size = 3",
    I("input") + input_base + "input_shape = 1:1:3",
-   I("dense") + fc_base + "unit = 10" + "input_layers=input",
-   I("act") + relu_base + "input_layers=dense",
-   I("dense_1") + fc_base + "unit = 2" + "input_layers=act",
+   I("dense") + fc_base + "unit = 10",
+   I("act") + relu_base,
+   I("dense_1") + fc_base + "unit = 2",
    I("act_1") + sigmoid_base + "input_layers=dense" + "input_layers=dense_1"});
 
 INI fc_bn_sigmoid_cross(
@@ -648,11 +648,11 @@ INI conv_1x1(
   {
     nn_base + "learning_rate=0.1 | optimizer=sgd | loss=cross | batch_size=3",
     I("input") + input_base + "input_shape=2:4:5",
-    I("conv2d_c1_layer") + conv_base + "kernel_size=1,1 | filters=4" +"input_layers=input",
-    I("act_1") + sigmoid_base +"input_layers=conv2d_c1_layer",
-    I("flatten", "type=flatten")+"input_layers=act_1" ,
-    I("outputlayer") + fc_base + "unit = 10" +"input_layers=flatten",
-    I("act_2") + softmax_base +"input_layers=outputlayer"
+    I("conv2d_c1_layer") + conv_base + "kernel_size=1,1 | filters=4",
+    I("act_1") + sigmoid_base,
+    I("flatten", "type=flatten") ,
+    I("outputlayer") + fc_base + "unit = 10",
+    I("act_2") + softmax_base
   }
 );
 


### PR DESCRIPTION
This patch adds support for default input_layers
If no input_layers is specified, the layer above
the current layer in the ini file or the previously
adding layer in the model becomes the input layer for the current layer.
However, this connection is only made if the current layer
has no input layers.

Resolves #1046

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>