### PR TITLE
[Deps] Add iniparser dependency version @open sesame 04/01 11:12

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Jijoong Moon <jijoong.moon@samsung.com>
 Build-Depends: gcc-9 | gcc-8 | gcc-7 (>=7.5),
  python3, python3-dev, python3-numpy,
  pkg-config, cmake, ninja-build, meson (>=0.50), debhelper (>=9), libboost-dev,
- libopenblas-dev, libiniparser-dev, tensorflow-lite-dev, libjsoncpp-dev,
+ libopenblas-dev, libiniparser-dev (>=4.1), tensorflow-lite-dev, libjsoncpp-dev,
  libcurl3-gnutls-dev | libcurl4-gnutls-dev | libcurl3-openssl-dev |
  libcurl4-openssl-dev | libcurl3-nns-dev | libcurl4-nns-dev, libgtest-dev,
  libflatbuffers-dev, libglib2.0-dev, nnstreamer-dev, libgstreamer1.0-dev,

--- a/meson.build
+++ b/meson.build
@@ -135,7 +135,7 @@ endif
 libm_dep = cxx.find_library('m') # cmath library
 libdl_dep = cxx.find_library('dl') # DL library
 thread_dep = dependency('threads') # pthread for tensorflow-lite
-iniparser_dep = dependency('iniparser', required : false) # iniparser
+iniparser_dep = dependency('iniparser', required : false, version : '>=4.1') # iniparser
 if not iniparser_dep.found()
   message('falling back to find libiniparser library and header files')
   libiniparser_dep = cxx.find_library('iniparser')

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -62,7 +62,7 @@ Source2005:	unittest_layers.tar.gz
 
 BuildRequires:	meson >= 0.50.0
 BuildRequires:	openblas-devel
-BuildRequires:	iniparser-devel
+BuildRequires:	iniparser-devel >= 4.1
 BuildRequires:	gtest-devel
 BuildRequires:	python3
 BuildRequires:	python3-numpy
@@ -131,7 +131,7 @@ NNtrainer Meta package for tizen
 
 %package core
 Summary:	Software framework for training neural networks
-Requires:	iniparser
+Requires:	iniparser >= 4.1
 Requires:	libopenblas_pthreads0
 
 %description core
@@ -140,7 +140,6 @@ NNtrainer is Software Framework for Training Neural Network Models on Devices.
 %package devel
 Summary:	Development package for custom nntrainer developers
 Requires:	nntrainer = %{version}-%{release}
-Requires:	iniparser-devel
 Requires:	openblas-devel
 Requires:	%{capi_machine_learning_common}-devel
 
@@ -157,7 +156,6 @@ Static library package of nntrainer-devel
 %package applications
 Summary:	NNTrainer Examples
 Requires:	nntrainer = %{version}-%{release}
-Requires:	iniparser
 Requires:	%{capi_machine_learning_inference}
 Requires:	nnstreamer-tensorflow-lite
 BuildRequires:  nnstreamer-test-devel
@@ -330,7 +328,6 @@ meson test -C build -t 2.0 --print-errorlogs
 %if 0%{?nnstreamer_filter}
 pushd test/nnstreamer
 ssat
-# bash runTest.sh
 popd
 %endif #nnstreamer_filter
 %endif #unit_test


### PR DESCRIPTION
From SRI-D it was reported that iniparser 3.x is not compatible.

This patch adds a version check for the iniparser

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

resolves #1047 
