### PR TITLE
[Test/Util] use exit in script @open sesame 04/01 11:12

### DIFF
--- a/packaging/run_unittests.sh
+++ b/packaging/run_unittests.sh
@@ -18,7 +18,7 @@ run_entry() {
 if [ -f "$1" ]; then
     echo $1
     run_entry $1
-    return $?
+    exit $?
 elif [ -d "$1" ]; then
     testlist=$(find $1 -type f -executable -name "unittest_*")
     for t in ${testlist}; do


### PR DESCRIPTION
'return' in script is not available, call 'exit' instead.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>

resolves #1052 