### PR TITLE
[Meson] Adjust header files @open sesame 04/27 16:42

### DIFF
--- a/nntrainer.pc.in
+++ b/nntrainer.pc.in
@@ -6,4 +6,5 @@ Name : nntrainer
 Version : @VERSION@
 Description: Software Framework for Training Neural Network on Device
 Libs: -L${libdir} -lnntrainer
+Requires: capi-ml-common
 Cflags: -I${includedir}/nntrainer

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include <layer_internal.h>
+#include <loss_layer.h>
 
 namespace nntrainer {
 

--- a/nntrainer/layers/meson.build
+++ b/nntrainer/layers/meson.build
@@ -22,7 +22,9 @@ layer_sources = [
 
 layer_headers = [
   'layer_factory.h',
-  'layer_internal.h'
+  'layer_internal.h',
+  'acti_func.h',
+  'loss_layer.h'
 ]
 
 layer_deps = []

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -4,7 +4,7 @@ nntrainer_inc = [
 ]
 
 nntrainer_sources = []
-nntrainer_headers = ['app_context.h']
+nntrainer_headers = ['app_context.h', 'nntrainer_error.h', 'nntrainer_log.h', 'nntrainer_logger.h']
 
 # Dependencies
 nntrainer_base_deps=[

--- a/nntrainer/models/meson.build
+++ b/nntrainer/models/meson.build
@@ -5,7 +5,8 @@ model_sources = [
 ]
 
 model_headers = [
-  'neuralnet.h'
+  'neuralnet.h',
+  'dynamic_training_optimization.h'
 ]
 
 foreach s : model_sources

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -26,13 +26,20 @@
 #include <fstream>
 #include <sstream>
 
+#include <activation_layer.h>
+#include <bn_layer.h>
+#include <conv2d_layer.h>
 #include <databuffer_file.h>
 #include <databuffer_func.h>
+#include <fc_layer.h>
+#include <flatten_layer.h>
+#include <input_layer.h>
 #include <model_loader.h>
 #include <neuralnet.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <parse_util.h>
+#include <pooling2d_layer.h>
 #include <profiler.h>
 #include <unordered_set>
 #include <util_func.h>

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -31,22 +31,15 @@
 #include <chrono>
 #endif
 
-#include <activation_layer.h>
 #include <app_context.h>
-#include <bn_layer.h>
-#include <conv2d_layer.h>
 #include <databuffer.h>
 #include <dynamic_training_optimization.h>
-#include <fc_layer.h>
-#include <flatten_layer.h>
-#include <input_layer.h>
 #include <layer_internal.h>
 #include <loss_layer.h>
 #include <manager.h>
 #include <ml-api-common.h>
 #include <network_graph.h>
 #include <optimizer_devel.h>
-#include <pooling2d_layer.h>
 #include <tensor.h>
 
 #include <model.h>

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <activation_layer.h>
 #include <bn_layer.h>
 #include <input_layer.h>
 #include <layer.h>


### PR DESCRIPTION
1. Include some header files to nntrainer_headers in meson to provide to users when install it.
2. Adust header files to handle following issues caused by 1.

Self evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>