### PR TITLE
[API/Graph] Update graph node and layer objects

### DIFF
--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file	graph_node.h
+ * @date	1 April 2021
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is the graph node interface for c++ API
+ */
+
+#ifndef __GRAPH_NODE_H__
+#define __GRAPH_NODE_H__
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace nntrainer {
+
+/**
+ * @class   Layer Base class for the graph node
+ * @brief   Base class for all layers
+ */
+class GraphNode {
+public:
+  /**
+   * @brief     Destructor of Layer Class
+   */
+  virtual ~GraphNode() = default;
+
+  /**
+   * @brief     Get index of the node
+   *
+   */
+  virtual size_t getIndex() = 0;
+
+  /**
+   * @brief     Set index of the node
+   *
+   */
+  // virtual void setIndex(size_t) = 0;
+
+  /**
+   * @brief     Get the Name of the underlying object
+   *
+   * @return std::string Name of the underlying object
+   * @note name of each node in the graph must be unique
+   */
+  virtual std::string getName() noexcept = 0;
+
+  /**
+   * @brief     Set the Name of the underlying object
+   *
+   * @param[in] std::string Name for the underlying object
+   * @note name of each node in the graph must be unique
+   *
+   * @todo make it work with setProperty
+   */
+  // virtual int setName(std::string name) = 0;
+
+  /**
+   * @brief     Get the trainable property of the underlying object
+   *
+   * @return boolean true if trainable, else false
+   */
+  virtual bool getTrainable() noexcept = 0;
+
+  /**
+   * @brief     Set the properties for the node
+   *
+   * @param[in] properties properties of the node
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   *
+   * @note this shouldn't be virtual, this became virtual to support custom
+   * layer. should be reverted after layer.h can fully support custom layer
+   */
+  virtual int setProperty(std::vector<std::string> properties) = 0;
+
+  /**
+   * @brief     Get the Type of the underlying object
+   *
+   * @return const std::string type representation
+   */
+  virtual const std::string getType() const = 0;
+};
+
+} // namespace nntrainer
+#endif // __GRAPH_NODE_H__

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -499,6 +499,7 @@ protected:
    */
   float loss;
 
+  // TODO: remove this from here
   ActivationType activation_type;
 
   WeightRegularizer weight_regularizer;
@@ -509,6 +510,7 @@ protected:
 
   WeightInitializer bias_initializer; /** initializer for bias */
 
+  // TODO: remove this from here
   /**
    * @brief   Output of this layer should be flattened
    */

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file	graph_node.h
+ * @date	1 April 2021
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug		No known bugs except for NYI items
+ * @brief	This is the graph node interface for c++ API
+ */
+
+#ifndef __LAYER_NODE_H__
+#define __LAYER_NODE_H__
+
+#include <graph_node.h>
+#include <layer.h>
+#include <layer_internal.h>
+
+namespace nntrainer {
+
+/**
+ * @class   LayerNode class
+ * @brief   layer node class for the graph
+ */
+class LayerNode : public ml::train::Layer, public GraphNode {
+public:
+  /**
+   * @brief     Constructor of LayerNode class
+   *
+   */
+  LayerNode(std::shared_ptr<nntrainer::Layer> l, size_t idx) :
+    layer(l),
+    index(idx) {}
+
+  /**
+   * @brief     Destructor of LayerNode Class
+   *
+   */
+  ~LayerNode() = default;
+
+  /**
+   * Support all the interface requirements by ml::train::Layer
+   */
+
+  /**
+   * @brief Get the layer type
+   *
+   * @return const std::string type representation
+   */
+  const std::string getType() const { return layer->getType(); }
+
+  /**
+   * @brief     set Property of layer
+   *
+   * @param[in] properties values of property
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @details   This function accepts vector of properties in the format -
+   *  { std::string property_name, void * property_val, ...}
+   */
+  int setProperty(std::vector<std::string> properties) {
+    return layer->setProperty(properties);
+  }
+
+  /**
+   * @brief     Get name of the layer
+   *
+   * @retval    name of the layer
+   * @note      This name is unique to this layer in a model
+   * @Note      This name might be changed once this layer is added to the model
+   * to keep the name unique to the model
+   */
+  std::string getName() noexcept { return layer->getName(); }
+
+  /**
+   * Support all the interface requirements by GraphNode<nntrainer::Layer>
+   */
+
+  /**
+   * @brief     Get underlying object
+   *
+   */
+  std::shared_ptr<nntrainer::Layer> &getObject() { return layer; }
+
+  /**
+   * @brief     Get underlying object
+   *
+   */
+  const std::shared_ptr<nntrainer::Layer> &getObject() const { return layer; }
+
+  /**
+   * @brief     Get index of the node
+   *
+   */
+  size_t getIndex() { return index; }
+
+  /**
+   * @brief     Get the trainable property of the underlying object
+   *
+   * @return boolean true if trainable, else false
+   */
+  bool getTrainable() noexcept { return layer->getTrainable(); }
+
+#ifdef PROFILE
+  int event_key;
+#endif
+
+private:
+  std::shared_ptr<nntrainer::Layer>
+    layer;      /**< The actual object in the graph node */
+  size_t index; /**< index of each node */
+
+  std::vector<std::string> input_layers;  /**< input layer names */
+  std::vector<std::string> output_layers; /**< output layer names */
+  bool flatten; /**< flatten the output of this node */
+  ActivationType
+    activation_type; /**< activation applied to the output of this node */
+};
+
+} // namespace nntrainer
+#endif // __LAYER_NODE_H__


### PR DESCRIPTION
**Commit 1** :  [Graph] Add interface for graph node
Add interface for the graph node.
Graph will use this interface.

**Commit 2:** [graph] Add node the graph of layers
Create class for the graph of layers which will represent nodes
This class also represents the object which will be created with APIs from now.
The actual class object resides inside this layer node object.

Properties for this layer node will be intercepted by the layer node object,
and properties of the graph node will be set in the layer node.
Others will be passed down to the layer node.

See Aso #986

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>