### PR TITLE
[Ini/Serialize] Implement logic to serialize

### DIFF
--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -13,10 +13,12 @@
  */
 #include <ini_interpreter.h>
 
+#include <sstream>
 #include <vector>
 
 #include <layer.h>
 #include <layer_factory.h>
+#include <ini_wrapper.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <parse_util.h>
@@ -46,9 +48,7 @@ namespace {
 /** @todo:
  *  1. deprecate tag dispatching along with #1072
  *  2. deprecate getMergeableGraph (extendGraph should accept graph itself)
- */
-
-/**
+ *
  * @brief Plain Layer tag
  */
 class PlainLayer {};
@@ -266,7 +266,22 @@ getMergeableGraph(std::shared_ptr<const GraphRepresentation> graph,
 
 void IniGraphInterpreter::serialize(
   std::shared_ptr<const GraphRepresentation> representation,
-  const std::string &out) {}
+  const std::string &out) {
+
+  std::vector<IniSection> sections;
+  for (const auto &ln : representation->getSorted()) {
+    const auto &layer = ln.layer;
+
+    IniSection s(layer->getName());
+    s.setEntry("type", layer->getType());
+
+    /// @todo: implement export a property
+    std::cout << ln.layer->getName() << std::endl;
+  }
+
+  auto ini = IniWrapper(out, sections);
+  ini.save_ini();
+}
 
 std::shared_ptr<GraphRepresentation>
 IniGraphInterpreter::deserialize(const std::string &in) {

--- a/nntrainer/utils/ini_wrapper.cpp
+++ b/nntrainer/utils/ini_wrapper.cpp
@@ -49,6 +49,10 @@ void IniSection::setEntry(const std::map<std::string, std::string> &entry) {
   }
 }
 
+void IniSection::setEntry(const std::string &key, const std::string &value) {
+  entry[key] = value;
+}
+
 void IniSection::setEntry(const std::string &entry_str) {
   // setting property separated by "|"
   std::regex words_regex("[^|]+");
@@ -70,7 +74,7 @@ void IniSection::setEntry(const std::string &entry_str) {
     NNTR_THROW_IF(status != ML_ERROR_NONE, std::invalid_argument)
       << "getKeyValue Failed";
 
-    entry[key] = value;
+    setEntry(key, value);
   }
 }
 

--- a/nntrainer/utils/ini_wrapper.h
+++ b/nntrainer/utils/ini_wrapper.h
@@ -155,6 +155,14 @@ public:
    */
   std::string getName() const { return section_name; }
 
+  /**
+   * @brief Set the Entry object by key and value
+   *
+   * @param key key to update
+   * @param value value to be added
+   */
+  void setEntry(const std::string &key, const std::string &value);
+
 private:
   /**
    * @brief Set the Entry

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -110,6 +110,28 @@ TEST_P(nntrainerInterpreterTest, graphEqual) {
   }
 }
 
+/**
+ * @brief graph serialize after deserialize, compare if they are the same
+ *
+ */
+TEST_P(nntrainerInterpreterTest, graphSerializeAfterDeserialize) {
+  auto g = interpreter->deserialize(file_path);
+
+  auto out_file_path = file_path + ".out";
+
+  /// @todo: change this to something like graph::finalize
+  int status = g->compile(nntrainer::LossType::LOSS_NONE);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  interpreter->serialize(g, out_file_path);
+
+  // auto new_g = interpreter->deserialize(out_file_path);
+
+  /// @todo: enable this
+  /// check if graph is the same
+  // EXPECT_EQ(*g, *new_g);
+  // EXPECT_EQ(remove(out_file_path.c_str()), 0);
+}
+
 auto fc0 = LayerReprentation("fully_connected",
                              {"name=fc0", "unit=1", "input_shape=1:1:100"});
 


### PR DESCRIPTION
- [Ini/Serialize] Implement logic to serialize 

```
This patch implements general concept of serializing a node.

Below is the plan to implement this logic

0. Implement logic to serialize [*]
1. Add export api
2. Add exporter
3. Add export test
4. Implement properties
5. combine with export
6. Add extra test

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```