### PR TITLE
[Serializer] Add exporter to export node

### DIFF
--- a/Applications/Custom/LayerClient/jni/Android.mk
+++ b/Applications/Custom/LayerClient/jni/Android.mk
@@ -16,6 +16,7 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 	$(NNTRAINER_ROOT)/nntrainer/dataset \
 	$(NNTRAINER_ROOT)/nntrainer/models \
 	$(NNTRAINER_ROOT)/nntrainer/layers \
+	$(NNTRAINER_ROOT)/nntrainer/utils \
 	$(NNTRAINER_ROOT)/nntrainer/optimizers \
 	$(NNTRAINER_ROOT)/nntrainer/tensor \
 	$(NNTRAINER_ROOT)/api \

--- a/Applications/Embedding/jni/Android.mk
+++ b/Applications/Embedding/jni/Android.mk
@@ -20,6 +20,7 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer/include \
 	$(NNTRAINER_ROOT)/nntrainer/models \
 	$(NNTRAINER_ROOT)/nntrainer/layers \
 	$(NNTRAINER_ROOT)/nntrainer/graph \
+	$(NNTRAINER_ROOT)/nntrainer/utils \
 	$(NNTRAINER_ROOT)/nntrainer/optimizers \
 	$(NNTRAINER_ROOT)/nntrainer/tensor \
 

--- a/Applications/LogisticRegression/jni/Android.mk
+++ b/Applications/LogisticRegression/jni/Android.mk
@@ -18,6 +18,7 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 	$(NNTRAINER_ROOT)/nntrainer/graph \
 	$(NNTRAINER_ROOT)/nntrainer/optimizers \
 	$(NNTRAINER_ROOT)/nntrainer/tensor \
+	$(NNTRAINER_ROOT)/nntrainer/utils \
 	$(NNTRAINER_ROOT)/api \
 	$(NNTRAINER_ROOT)/api/ccapi/include \
 	$(NNTRAINER_ROOT)/api/capi/include/platform

--- a/Applications/ReinforcementLearning/DeepQ/jni/Android.mk
+++ b/Applications/ReinforcementLearning/DeepQ/jni/Android.mk
@@ -18,6 +18,7 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 	$(NNTRAINER_ROOT)/nntrainer/graph \
 	$(NNTRAINER_ROOT)/nntrainer/optimizers \
 	$(NNTRAINER_ROOT)/nntrainer/tensor \
+	$(NNTRAINER_ROOT)/nntrainer/utils \
 	$(NNTRAINER_ROOT)/api \
 	$(NNTRAINER_ROOT)/api/ccapi/include \
 	$(NNTRAINER_ROOT)/api/capi/include/platform

--- a/Applications/TransferLearning/CIFAR_Classification/jni/Android.mk
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/Android.mk
@@ -18,6 +18,7 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 	$(NNTRAINER_ROOT)/nntrainer/layers \
 	$(NNTRAINER_ROOT)/nntrainer/optimizers \
 	$(NNTRAINER_ROOT)/nntrainer/tensor \
+	$(NNTRAINER_ROOT)/nntrainer/utils \
 	$(NNTRAINER_ROOT)/api \
 	$(NNTRAINER_ROOT)/api/ccapi/include \
 	$(NNTRAINER_ROOT)/api/capi/include/platform

--- a/Applications/TransferLearning/Draw_Classification/jni/Android.mk
+++ b/Applications/TransferLearning/Draw_Classification/jni/Android.mk
@@ -18,6 +18,7 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 	$(NNTRAINER_ROOT)/nntrainer/graph \
 	$(NNTRAINER_ROOT)/nntrainer/tensor \
 	$(NNTRAINER_ROOT)/nntrainer/optimizers \
+	$(NNTRAINER_ROOT)/nntrainer/utils \
 	$(NNTRAINER_ROOT)/api \
 	$(NNTRAINER_ROOT)/api/ccapi/include \
 	$(NNTRAINER_ROOT)/api/capi/include \

--- a/Applications/VGG/jni/Android.mk
+++ b/Applications/VGG/jni/Android.mk
@@ -18,6 +18,7 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 	$(NNTRAINER_ROOT)/nntrainer/layers \
 	$(NNTRAINER_ROOT)/nntrainer/optimizers \
 	$(NNTRAINER_ROOT)/nntrainer/tensor \
+	$(NNTRAINER_ROOT)/nntrainer/utils \
 	$(NNTRAINER_ROOT)/api \
 	$(NNTRAINER_ROOT)/api/ccapi/include \
 	$(NNTRAINER_ROOT)/api/capi/include/platform

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -194,6 +194,7 @@ CCAPI_NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
                       $(NNTRAINER_ROOT)/nntrainer/tensor \
                       $(NNTRAINER_ROOT)/nntrainer/graph \
                       $(NNTRAINER_ROOT)/nntrainer/optimizers \
+                      $(NNTRAINER_ROOT)/nntrainer/utils \
                       $(NNTRAINER_ROOT)/api \
                       $(NNTRAINER_ROOT)/api/ccapi/include \
                       $(NNTRAINER_ROOT)/api/capi/include/platform

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -144,6 +144,7 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
                       $(NNTRAINER_ROOT)/nntrainer/optimizers \
                       $(NNTRAINER_ROOT)/nntrainer/utils \
                       $(NNTRAINER_ROOT)/nntrainer/graph \
+                      $(NNTRAINER_ROOT)/nntrainer/utils \
                       $(NNTRAINER_ROOT)/nntrainer/compiler \
                       $(NNTRAINER_ROOT)/api \
                       $(NNTRAINER_ROOT)/api/ccapi/include \

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -30,6 +30,7 @@
 #include <acti_func.h>
 #include <layer.h>
 #include <manager.h>
+#include <node_exporter.h>
 #include <optimizer_devel.h>
 #include <tensor.h>
 #include <tensor_dim.h>
@@ -302,6 +303,17 @@ public:
    * @return TensorDim dimension of the input
    */
   virtual std::vector<TensorDim> getInputDimension() { return input_dim; }
+
+  /**
+   * @brief this function helps exporting the layer in a predefined format,
+   * while workarounding issue caused by templated function type eraser
+   *
+   * @param exporter exporter that conatins exporting logic
+   * @param method enum value to identify how it should be exported to
+   */
+  virtual void
+  export_to(const Exporter &exporter,
+            ExportMethods method = ExportMethods::METHOD_STRINGVECTOR){};
 
   /**
    * @brief  get the loss value added by this layer

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file node_exporter.h
+ * @date 08 April 2021
+ * @brief NNTrainer Node exporter
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#ifndef __NODE_EXPORTER_H__
+#define __NODE_EXPORTER_H__
+
+namespace nntrainer {
+enum class ExportMethods {
+  METHOD_STRINGVECTOR = 0, /**< export to a string vector */
+  METHOD_TFLITE = 1,       /**< epxort to tflite */
+  METHOD_UNDEFINED = 999,  /**< undefined */
+};
+
+namespace {
+
+template <ExportMethods method> struct return_type { using type = void; };
+
+template <> struct return_type<ExportMethods::METHOD_STRINGVECTOR> {
+  using type = std::vector<std::pair<std::string, std::string>>;
+};
+} // namespace
+
+/**
+ * @brief Exporter class helps to exports the node information in a predefined
+ * way. because each method will require complete different methods, this class
+ * exploits visitor pattern to make a custom defined saving method
+ *
+ */
+class Exporter {
+public:
+  /**
+   * @brief Construct a new Exporter object
+   *
+   */
+  Exporter() : is_exported(false){};
+
+  /**
+   * @brief this function iterates over the property and process the property in
+   * a designated way.
+   *
+   * @tparam Ts type of elements
+   * @param props tuple that contains properties
+   * @param method method to export
+   */
+  template <typename... Ts>
+  void save_result(std::tuple<Ts...> &props, ExportMethods method) {
+    if (is_exported) {
+      throw std::invalid_argument("This exporter is already used");
+    }
+    /** NYI!! */
+
+    is_exported = true;
+  }
+
+  /**
+   * @brief Get the result object
+   *
+   * @tparam methods method to get
+   * @tparam T appropriate return type regarding the export method
+   * @return T T
+   */
+  template <ExportMethods methods, typename T = return_type<methods>>
+  T get_result() {
+    if (!is_exported) {
+      throw std::invalid_argument("This exporter is not exported anything yet");
+    }
+    /** NYI!! */
+  }
+
+private:
+  bool is_exported;
+};
+
+} // namespace nntrainer
+#endif // __NODE_EXPORTER_H__


### PR DESCRIPTION
This patch adds exporter to export node. This exploits visitor pattern
because, exporting need templated function to be executed, but virtual
functions does not allow templated function.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>