### PR TITLE
[Fix] Multiout layer calcDerivative initialize

### DIFF
--- a/nntrainer/layers/output_layer.cpp
+++ b/nntrainer/layers/output_layer.cpp
@@ -53,7 +53,11 @@ void OutputLayer::calcDerivative() {
   Tensor &ret = net_input[0]->getGradientRef();
 
   for (unsigned int idx = 0; idx < getNumOutputs(); ++idx) {
-    ret.add_i(net_hidden[idx]->getGradientRef());
+    if (idx == 0) {
+      ret.fill(net_hidden[idx]->getGradientRef(), false);
+    } else {
+      ret.add_i(net_hidden[idx]->getGradientRef());
+    }
   }
 }
 


### PR DESCRIPTION
- [Fix] Multiout layer calcDerivative initialize 

```
This patch fixes multiout layer to initialize for calcDerivative

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```