### PR TITLE
[Props] Add base properties test

### DIFF
--- a/nntrainer/utils/base_properties.h
+++ b/nntrainer/utils/base_properties.h
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file base_properties.h
+ * @date 08 April 2021
+ * @brief Convenient property type definition for automated serialization
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#ifndef __BASE_PROPERTIES_H__
+#define __BASE_PROPERTIES_H__
+
+/** base and predefined structures */
+
+namespace nntrainer {
+
+/**
+ * @brief property tag to specialize functions based on this
+ *
+ * @tparam T property type
+ */
+template <typename T> struct prop_tag { using type = typename T::prop_tag; };
+
+struct int_prop_tag {};       /**< property is treated as integer */
+struct vector_prop_tag {};    /**< property is treated as vector, eg) 1,2,3 */
+struct dimension_prop_tag {}; /**< property is treated as dimension, eg 1:2:3 */
+struct double_prop_tag {};    /**< property is treated as double */
+struct str_prop_tag {};       /**< property is treated as string */
+
+/**
+ * @brief base property class, inherit this to make a convinient property
+ *
+ * @tparam T
+ */
+template <typename T> class Property {
+
+public:
+  /**
+   * @brief Destroy the Property object
+   *
+   */
+  virtual ~Property() = default;
+
+  /**
+   * @brief get the underlying data
+   *
+   * @return const T& data
+   */
+  const T &get() const { return value; }
+
+  /**
+   * @brief get the underlying data
+   *
+   * @return T& data
+   */
+  T &get() { return value; }
+
+  /**
+   * @brief set the underlying data
+   *
+   * @param v value to set
+   * @throw std::invalid_argument if argument is not valid
+   */
+  void set(const T &v) {
+    if (!is_valid(v)) {
+      throw std::invalid_argument("argument is not valid");
+    }
+    value = v;
+  }
+
+  /**
+   * @brief check if given value is valid
+   *
+   * @param v value to check
+   * @return true if valid
+   * @return false if not valid
+   */
+  virtual bool is_valid(const T &v) { return true; }
+
+private:
+  T value; /**< underlying data */
+};
+
+/**
+ * @brief meta function to cast tag to it's base
+ * @code below is the test spec for the cast
+ *
+ * struct custom_tag: int_prop_tag {};
+ *
+ * using tag_type = tag_cast<custom_tag, vector_prop_tag>::type
+ * static_assert(<std::is_save_v<tag_type, custom_tag> == false);
+ *
+ * using tag_type = tag_cast<custom_tag, int_prop_tag>::type
+ * static_assert(<std::is_save_v<tag_type, int_prop_tag> == true);
+ *
+ * using tag_type = tag_cast<custom_tag, vector_prop_tag, int_prop_tag>::type
+ * static_assert(std::is_same_v<tag_type, int_prop_tag> == true);
+ *
+ * @tparam Tags First tag: tag to be casted, rest tags: candidates
+ */
+template <typename... Tags> struct tag_cast;
+
+/**
+ * @brief base case of tag_cast, if nothing matches return @a Tag
+ *
+ * @tparam Tag Tag to be casted
+ * @tparam Others empty parameter pack
+ */
+template <typename Tag, typename... Others> struct tag_cast<Tag, Others...> {
+  using type = Tag;
+};
+
+/**
+ * @brief normal case of the tag cast
+ *
+ * @tparam Tag tag to be casted
+ * @tparam BaseTag candidates to cast the tag
+ * @tparam Others pending candidates to be compared
+ */
+template <typename Tag, typename BaseTag, typename... Others>
+struct tag_cast<Tag, BaseTag, Others...> {
+  using type = std::conditional_t<std::is_base_of<BaseTag, Tag>::value, BaseTag,
+                                  typename tag_cast<Tag, Others...>::type>;
+};
+
+/**
+ * @brief property to string converter.
+ * This structure defines how to convert to convert from/to string
+ *
+ * @tparam Tag tag type for the converter
+ */
+template <typename Tag> struct str_converter {};
+
+/**
+ * @copydoc template<typename Tag> struct_converter;
+ */
+template <> struct str_converter<str_prop_tag> {
+  static std::string to_string(const std::string &value) { return value; }
+
+  static std::string from_string(const std::string &str) { return str; }
+};
+
+/**
+ * @copydoc template<typename Tag> struct_converter;
+ */
+template <> struct str_converter<int_prop_tag> {
+  static std::string to_string(const int value) {
+    return std::to_string(value);
+  }
+
+  static int from_string(const std::string &value) { return std::stoi(value); }
+};
+
+/** convert dispatcher */
+template <typename T> std::string to_string(const T &property) {
+  using tag_type = typename tag_cast<typename prop_tag<T>::type,
+                                     vector_prop_tag, int_prop_tag>::type;
+  return str_converter<tag_type>::to_string(property.get());
+}
+
+template <typename T> void from_string(const std::string &str, T &property) {
+  using tag_type =
+    typename tag_cast<typename prop_tag<T>::type, int_prop_tag>::type;
+  property.set(str_converter<tag_type>::from_string(str));
+}
+
+} // namespace nntrainer
+
+#endif // __BASE_PROPERTIES_H__

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -34,7 +34,8 @@ test_target = [
   'unittest_nntrainer_modelfile',
   'unittest_nntrainer_models',
   'unittest_nntrainer_graph',
-  'unittest_nntrainer_appcontext'
+  'unittest_nntrainer_appcontext',
+  'unittest_properties',
 ]
 
 if get_option('enable-profile')

--- a/test/unittest/unittest_properties.cpp
+++ b/test/unittest/unittest_properties.cpp
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file unittest_properties.h
+ * @date 09 April 2021
+ * @brief This file contains test and specification of properties
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <gtest/gtest.h>
+
+#include <base_properties.h>
+#include <util_func.h>
+
+namespace { /**< define a property for testing */
+
+/**
+ * @brief banana property tag for example
+ *
+ */
+struct banana_prop_tag : nntrainer::int_prop_tag {};
+
+/**
+ * @brief Number of banana property
+ *
+ */
+class NumBanana : public nntrainer::Property<int> {
+public:
+  NumBanana() { set(1); }                          /**< default value if any */
+  static constexpr const char *key = "num_banana"; /**< unique key to access */
+  using prop_tag = banana_prop_tag;                /**< property type */
+
+  bool is_valid(const int &v) override { return v >= 0; }
+};
+
+/**
+ * @brief QualityOfBanana property for example, this has to end with "good"
+ *
+ */
+class QualityOfBanana : public nntrainer::Property<std::string> {
+public:
+  static constexpr const char *key = "quality_banana";
+  using prop_tag = nntrainer::str_prop_tag;
+
+  bool is_valid(const std::string &v) override {
+    /// assuming quality of banana property must ends with word "good";
+    return nntrainer::endswith(v, "good");
+  }
+};
+} // namespace
+
+TEST(BasicProperty, tagCast) {
+  EXPECT_EQ(1, 1); /**< this is to prevent no assert tc from TCM */
+
+  { /**< tag_cast simple cast */
+    using T =
+      nntrainer::tag_cast<banana_prop_tag, nntrainer::int_prop_tag>::type;
+    ::testing::StaticAssertTypeEq<T, nntrainer::int_prop_tag>();
+  }
+
+  { /**< tag_cast ranged cast */
+    using T = nntrainer::tag_cast<banana_prop_tag, nntrainer::vector_prop_tag,
+                                  nntrainer::int_prop_tag>::type;
+    ::testing::StaticAssertTypeEq<T, nntrainer::int_prop_tag>();
+  }
+
+  { /**< tag_cast does not have appropriate candidates */
+    using T = nntrainer::tag_cast<banana_prop_tag, int, std::string>::type;
+    ::testing::StaticAssertTypeEq<T, banana_prop_tag>();
+  }
+}
+
+TEST(BasicProperty, valid_p) {
+  { /** set -> get / to_string */
+    NumBanana b;
+    b.set(123);
+    EXPECT_EQ(b.get(), 123);
+    EXPECT_EQ(nntrainer::to_string(b), "123");
+
+    QualityOfBanana q;
+    q.set("this is good");
+    EXPECT_EQ(q.get(), "this is good");
+    EXPECT_EQ(nntrainer::to_string(q), "this is good");
+  }
+
+  { /**< from_string -> get / to_string */
+    NumBanana b;
+    nntrainer::from_string("3", b);
+    EXPECT_EQ(b.get(), 3);
+    EXPECT_EQ(nntrainer::to_string(b), "3");
+
+    QualityOfBanana q;
+    nntrainer::from_string("this is good", q);
+    EXPECT_EQ(q.get(), "this is good");
+    EXPECT_EQ(nntrainer::to_string(q), "this is good");
+  }
+}
+
+TEST(BasicProperty, setNotValid_01_n) {
+  NumBanana b;
+  EXPECT_THROW(b.set(-1), std::invalid_argument);
+}
+
+TEST(BasicProperty, setNotValid_02_n) {
+  QualityOfBanana q;
+  EXPECT_THROW(q.set("invalid_str"), std::invalid_argument);
+}
+
+TEST(BasicProperty, fromStringNotValid_01_n) {
+  NumBanana b;
+  EXPECT_THROW(nntrainer::from_string("not integer", b), std::invalid_argument);
+}
+
+TEST(BasicProperty, fromStringNotValid_02_n) {
+  NumBanana b;
+  EXPECT_THROW(nntrainer::from_string("-1", b), std::invalid_argument);
+}
+
+TEST(BasicProperty, fromStringNotValid_03_n) {
+  QualityOfBanana q;
+  EXPECT_THROW(nntrainer::from_string("invalid_str", q), std::invalid_argument);
+}
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error duing IniGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error duing RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}


### PR DESCRIPTION
- [Test/Props] Add basic property tests 

```
This patch adds basic property test to demonstrate specification and
cover some test cases

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [Props] Add base properties 

```
Add base properties to be used for the property implementation

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```