### PR TITLE
[Exporter] Add exporter test to prop test

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -91,6 +91,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/dataset/databuffer_factory.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/dataset/databuffer_func.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/dataset/databuffer_file.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/compiler/ini_interpreter.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/tensor.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/lazy_tensor.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/manager.cpp \
@@ -128,8 +129,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/ini_wrapper.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/parse_util.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/profiler.cpp \
-                  $(NNTRAINER_ROOT)/nntrainer/utils/profiler.cpp \
-                  $(NNTRAINER_ROOT)/nntrainer/compiler/node_exporter.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/utils/node_exporter.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/app_context.cpp
 
 # Add tflite backbone building

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -128,7 +128,8 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/ini_wrapper.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/parse_util.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/profiler.cpp \
-                  $(NNTRAINER_ROOT)/nntrainer/compiler/ini_interpreter.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/utils/profiler.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/compiler/node_exporter.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/app_context.cpp
 
 # Add tflite backbone building

--- a/nntrainer/utils/meson.build
+++ b/nntrainer/utils/meson.build
@@ -3,6 +3,7 @@ util_sources = [
   'util_func.cpp',
   'profiler.cpp',
   'ini_wrapper.cpp',
+  'node_exporter.cpp'
 ]
 
 util_headers = [

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -1,0 +1,15 @@
+#include <node_exporter.h>
+
+namespace nntrainer {
+
+template <>
+const std::vector<std::pair<std::string, std::string>> &
+Exporter::get_result<ExportMethods::METHOD_STRINGVECTOR>() {
+  if (!is_exported) {
+    throw std::invalid_argument("This exporter is not exported anything yet");
+  }
+
+  return stored_result;
+}
+
+} // namespace nntrainer

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -1,12 +1,22 @@
 #include <node_exporter.h>
-
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file node_exporter.cpp
+ * @date 09 April 2021
+ * @brief NNTrainer Node exporter
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
 namespace nntrainer {
 
 template <>
 const std::vector<std::pair<std::string, std::string>> &
 Exporter::get_result<ExportMethods::METHOD_STRINGVECTOR>() {
   if (!is_exported) {
-    throw std::invalid_argument("This exporter is not exported anything yet");
+    throw std::invalid_argument("This exporter has not exported anything yet");
   }
 
   return stored_result;

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -14,10 +14,17 @@
 #include <utility>
 #include <vector>
 
+#include <nntrainer_error.h>
+
 #ifndef __NODE_EXPORTER_H__
 #define __NODE_EXPORTER_H__
 
 namespace nntrainer {
+
+/**
+ * @brief Defines Export Method to be called with
+ *
+ */
 enum class ExportMethods {
   METHOD_STRINGVECTOR = 0, /**< export to a string vector */
   METHOD_TFLITE = 1,       /**< epxort to tflite */
@@ -26,8 +33,18 @@ enum class ExportMethods {
 
 namespace {
 
+/**
+ * @brief meta function that return return_type when a method is being called
+ *
+ * @tparam method returned when certain method is being called
+ */
 template <ExportMethods method> struct return_type { using type = void; };
 
+/**
+ * @brief meta function to check return type when the method is string vector
+ *
+ * @tparam specialized so not given
+ */
 template <> struct return_type<ExportMethods::METHOD_STRINGVECTOR> {
   using type = std::vector<std::pair<std::string, std::string>>;
 };
@@ -56,11 +73,22 @@ public:
    * @param method method to export
    */
   template <typename... Ts>
-  void save_result(std::tuple<Ts...> &props, ExportMethods method) {
-    if (is_exported) {
-      throw std::invalid_argument("This exporter is already used");
+  void save_result(const std::tuple<Ts...> &props, ExportMethods method) {
+    switch (method) {
+    case ExportMethods::METHOD_STRINGVECTOR: {
+      auto callable = [this](auto &&prop, size_t index) {
+        std::string key = std::remove_reference_t<decltype(prop)>::key;
+        stored_result.emplace_back(key, to_string(prop));
+      };
+      iterate_prop(callable, props);
+    } break;
+    case ExportMethods::METHOD_TFLITE:
+    /// fall thorugh intended (NYI!!)
+    case ExportMethods::METHOD_UNDEFINED:
+    /// fall thorugh intended
+    default:
+      throw exception::not_supported("given method is not supported yet");
     }
-    /** NYI!! */
 
     is_exported = true;
   }
@@ -72,16 +100,51 @@ public:
    * @tparam T appropriate return type regarding the export method
    * @return T T
    */
-  template <ExportMethods methods, typename T = return_type<methods>>
-  T get_result() {
-    if (!is_exported) {
-      throw std::invalid_argument("This exporter is not exported anything yet");
-    }
-    /** NYI!! */
-  }
+  template <ExportMethods methods,
+            typename T = typename return_type<methods>::type>
+  const T &get_result();
 
 private:
-  bool is_exported;
+  /**
+   * @brief base case of iterate_prop, iterate_prop iterates the given tuple
+   *
+   * @tparam I size of tuple(automated)
+   * @tparam Callable generic lambda to be called during iteration
+   * @tparam Ts types from tuple
+   * @param c callable gerneric labmda
+   * @param tup tuple to be iterated
+   * @return void
+   */
+  template <size_t I = 0, typename Callable, typename... Ts>
+  typename std::enable_if<I == sizeof...(Ts), void>::type
+  iterate_prop(Callable &&c, const std::tuple<Ts...> &tup) {
+    // end of recursion;
+  }
+
+  /**
+   * @brief base case of iterate_prop, iterate_prop iterates the given tuple
+   *
+   * @tparam I size of tuple(automated)
+   * @tparam Callable generic lambda to be called during iteration
+   * @tparam Ts types from tuple
+   * @param c callable gerneric labmda
+   * @param tup tuple to be iterated
+   * @return not used
+   */
+  template <size_t I = 0, typename Callable, typename... Ts>
+  typename std::enable_if<(I < sizeof...(Ts)), void>::type
+  iterate_prop(Callable &&c, const std::tuple<Ts...> &tup) {
+    c(std::get<I>(tup), I);
+
+    iterate_prop<I + 1>(c, tup);
+  }
+
+  std::vector<std::pair<std::string, std::string>>
+    stored_result; /**< stored result */
+
+  /// consider changing this to a promise / future if there is a async function
+  /// involved to `save_result`
+  bool is_exported; /**< boolean to check if exported */
 };
 
 } // namespace nntrainer

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
  * @file node_exporter.h
- * @date 08 April 2021
+ * @date 09 April 2021
  * @brief NNTrainer Node exporter
  * @see	https://github.com/nnstreamer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
@@ -75,7 +75,16 @@ public:
   template <typename... Ts>
   void save_result(const std::tuple<Ts...> &props, ExportMethods method) {
     switch (method) {
+
     case ExportMethods::METHOD_STRINGVECTOR: {
+
+      /**
+       * @brief function to pass to the iterate_prop, this saves the property to
+       * stored_result
+       *
+       * @param prop property property to pass
+       * @param index index of the current property
+       */
       auto callable = [this](auto &&prop, size_t index) {
         std::string key = std::remove_reference_t<decltype(prop)>::key;
         stored_result.emplace_back(key, to_string(prop));

--- a/test/unittest/unittest_properties.cpp
+++ b/test/unittest/unittest_properties.cpp
@@ -4,14 +4,18 @@
  *
  * @file unittest_properties.h
  * @date 09 April 2021
- * @brief This file contains test and specification of properties
+ * @brief This file contains test and specification of properties and exporter
  * @see	https://github.com/nnstreamer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug No known bugs except for NYI items
  */
 #include <gtest/gtest.h>
 
+#include <utility>
+
 #include <base_properties.h>
+#include <nntrainer_error.h>
+#include <node_exporter.h>
 #include <util_func.h>
 
 namespace { /**< define a property for testing */
@@ -72,29 +76,49 @@ TEST(BasicProperty, tagCast) {
   }
 }
 
+/// @todo convert this to typed param test
 TEST(BasicProperty, valid_p) {
-  { /** set -> get / to_string */
+  { /** set -> get / to_string, int*/
     NumBanana b;
     b.set(123);
     EXPECT_EQ(b.get(), 123);
     EXPECT_EQ(nntrainer::to_string(b), "123");
+  }
 
+  { /**< from_string -> get / to_string, int*/
+    NumBanana b;
+    nntrainer::from_string("3", b);
+    EXPECT_EQ(b.get(), 3);
+    EXPECT_EQ(nntrainer::to_string(b), "3");
+  }
+
+  { /** set -> get / to_string, string*/
     QualityOfBanana q;
     q.set("this is good");
     EXPECT_EQ(q.get(), "this is good");
     EXPECT_EQ(nntrainer::to_string(q), "this is good");
   }
 
-  { /**< from_string -> get / to_string */
-    NumBanana b;
-    nntrainer::from_string("3", b);
-    EXPECT_EQ(b.get(), 3);
-    EXPECT_EQ(nntrainer::to_string(b), "3");
-
+  { /**< from_string -> get / to_string, string prop */
     QualityOfBanana q;
     nntrainer::from_string("this is good", q);
     EXPECT_EQ(q.get(), "this is good");
     EXPECT_EQ(nntrainer::to_string(q), "this is good");
+  }
+
+  { /**< exporter test */
+    auto props = std::make_tuple(NumBanana(), QualityOfBanana());
+
+    nntrainer::Exporter e;
+    e.save_result(props, nntrainer::ExportMethods::METHOD_STRINGVECTOR);
+
+    auto result = e.get_result<nntrainer::ExportMethods::METHOD_STRINGVECTOR>();
+
+    auto pair = std::pair<std::string, std::string>("num_banana", "1");
+    EXPECT_EQ(result[0], pair);
+
+    auto pair2 = std::pair<std::string, std::string>("quality_banana", "");
+    EXPECT_EQ(result[1], pair2);
   }
 }
 
@@ -121,6 +145,25 @@ TEST(BasicProperty, fromStringNotValid_02_n) {
 TEST(BasicProperty, fromStringNotValid_03_n) {
   QualityOfBanana q;
   EXPECT_THROW(nntrainer::from_string("invalid_str", q), std::invalid_argument);
+}
+
+TEST(Exporter, invalidMethods_n) {
+  auto props = std::make_tuple(NumBanana(), QualityOfBanana());
+
+  nntrainer::Exporter e;
+  EXPECT_THROW(e.save_result(props, nntrainer::ExportMethods::METHOD_UNDEFINED),
+               nntrainer::exception::not_supported);
+}
+
+TEST(Exporter, notExported_n) {
+  auto props = std::make_tuple(NumBanana(), QualityOfBanana());
+
+  nntrainer::Exporter e;
+  /// intended comment
+  // e.save_result(props, nntrainer::ExportMethods::METHOD_STRINGVECTOR);
+
+  EXPECT_THROW(e.get_result<nntrainer::ExportMethods::METHOD_STRINGVECTOR>(),
+               std::invalid_argument);
 }
 
 /**


### PR DESCRIPTION
- [Exporter] Add exporter test to prop test 

```
This patch adds exporter test to prop test to ensure that it is working
fine.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [Exporter] Add string vector exporter 

```
This patch adds string vector exporter implementation

Exporter will iterate through props (`iterate_props`) and will pass a
generic lambda to be called.

Later, We can retrieve the result by `get_result` if needed.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```