### PR TITLE
[Layer/props] Convert name to props

### DIFF
--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -10,6 +10,8 @@
  * @bug No known bugs except for NYI items
  */
 
+#include <string>
+
 #include <base_properties.h>
 
 #ifndef __COMMON_PROPERTIES_H__
@@ -17,6 +19,18 @@
 
 namespace nntrainer {
 namespace props {
+
+/**
+ * @brief Name property, name is an identifier of an object
+ *
+ */
+class Name : public nntrainer::Property<std::string> {
+public:
+  Name(const std::string &value = "") :
+    nntrainer::Property<std::string>(value) {} /**< default value if any */
+  static constexpr const char *key = "name";   /**< unique key to access */
+  using prop_tag = str_prop_tag;               /**< property type */
+};
 
 /**
  * @brief unit property, unit is used to measure how many weights are there

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -70,7 +70,8 @@ int FullyConnectedLayer::initialize(Manager &manager) {
   return status;
 }
 
-void FullyConnectedLayer::export_to(Exporter &exporter, ExportMethods method) {
+void FullyConnectedLayer::export_to(Exporter &exporter,
+                                    ExportMethods method) const {
   Layer::export_to(exporter, method);
   exporter.save_result(fc_props, method);
 }

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -84,9 +84,9 @@ public:
   /**
    * @copydoc Layer::export_to(Exporter &exporter, ExportMethods method)
    */
-  void
-  export_to(Exporter &exporter,
-            ExportMethods method = ExportMethods::METHOD_STRINGVECTOR) override;
+  void export_to(
+    Exporter &exporter,
+    ExportMethods method = ExportMethods::METHOD_STRINGVECTOR) const override;
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -153,6 +153,14 @@ void Layer::save(std::ofstream &file) {
 int Layer::setProperty(std::vector<std::string> values) {
   int status = ML_ERROR_NONE;
 
+  try {
+    values = loadProperties(values, layer_props);
+  } catch (std::invalid_argument &e) {
+    ml_loge("parsing property failed, reason: %s", e.what());
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
+  /// @todo: deprecate this in favor of loadProperties
   for (unsigned int i = 0; i < values.size(); ++i) {
     std::string key;
     std::string value;
@@ -297,7 +305,7 @@ int Layer::setName(std::string name_) {
   if (name_.empty())
     return ML_ERROR_INVALID_PARAMETER;
 
-  name = name_;
+  std::get<props::Name>(layer_props).set(name_);
   return ML_ERROR_NONE;
 }
 

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -25,9 +25,11 @@
 
 #include <memory>
 #include <set>
+#include <tuple>
 #include <vector>
 
 #include <acti_func.h>
+#include <common_properties.h>
 #include <layer.h>
 #include <manager.h>
 #include <node_exporter.h>
@@ -60,7 +62,7 @@ public:
         WeightInitializer bias_initializer_ = WeightInitializer::WEIGHT_ZEROS,
         bool trainable_ = true, bool flatten_ = false,
         bool distribute_ = false) :
-    name(std::string()),
+    layer_props(props::Name()),
     loss(0.0f),
     activation_type(activation_type_),
     weight_regularizer(weight_regularizer_),
@@ -313,7 +315,9 @@ public:
    */
   virtual void
   export_to(Exporter &exporter,
-            ExportMethods method = ExportMethods::METHOD_STRINGVECTOR){};
+            ExportMethods method = ExportMethods::METHOD_STRINGVECTOR) const {
+    exporter.save_result(layer_props, ExportMethods::METHOD_STRINGVECTOR);
+  };
 
   /**
    * @brief  get the loss value added by this layer
@@ -365,7 +369,9 @@ public:
   /**
    * @brief     Get name of the layer
    */
-  virtual std::string getName() noexcept { return name; }
+  virtual std::string getName() noexcept {
+    return std::get<props::Name>(layer_props).get();
+  }
 
   /**
    * @brief Preset modes for printing summary for the layer
@@ -558,10 +564,7 @@ protected:
     // clang-format on
   } PrintOption;
 
-  /**
-   * @brief     Name of the layer (works as the identifier)
-   */
-  std::string name;
+  std::tuple<props::Name> layer_props; /**< supported properties of layer */
 
   /**
    * @brief     Input Tensors

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -182,8 +182,8 @@ iterate_prop(Callable &&c, std::tuple<Ts...> &tup) {
  */
 template <typename... Ts>
 std::vector<std::string>
-load_properties(const std::vector<std::string> &string_vector,
-                std::tuple<Ts...> &props) {
+loadProperties(const std::vector<std::string> &string_vector,
+               std::tuple<Ts...> &props) {
 
   std::vector<std::pair<std::string, std::string>> left;
   left.reserve(string_vector.size());

--- a/test/unittest/unittest_properties.cpp
+++ b/test/unittest/unittest_properties.cpp
@@ -128,17 +128,19 @@ TEST(BasicProperty, valid_p) {
     layer.export_to(e);
 
     auto result = e.get_result<nntrainer::ExportMethods::METHOD_STRINGVECTOR>();
-    auto pair = std::pair<std::string, std::string>("unit", "1");
-    EXPECT_EQ(result[0], pair);
+    auto pair0 = std::pair<std::string, std::string>("name", "");
+    EXPECT_EQ(result[0], pair0);
+    auto pair1 = std::pair<std::string, std::string>("unit", "1");
+    EXPECT_EQ(result[1], pair1);
   }
 
   { /**< load from layer */
     auto props = std::make_tuple(NumBanana(), QualityOfBanana());
 
     auto v =
-      nntrainer::load_properties({"num_banana=2", "quality_banana=thisisgood",
-                                  "num_banana=42", "not_used=key"},
-                                 props);
+      nntrainer::loadProperties({"num_banana=2", "quality_banana=thisisgood",
+                                 "num_banana=42", "not_used=key"},
+                                props);
 
     EXPECT_EQ(v, std::vector<std::string>{"not_used=key"});
     EXPECT_EQ(std::get<0>(props).get(), 42);


### PR DESCRIPTION
- [Layer/props] Convert name to props. 

```
**Changes proposed in this PR:**
- Convert name to props
- Add std::string specialization for property

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```