### PR TITLE
[IniSerializer] Add `serialize` to ini

### DIFF
--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -21,6 +21,7 @@
 #include <layer_factory.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
+#include <node_exporter.h>
 #include <parse_util.h>
 #include <time_dist.h>
 #include <util_func.h>
@@ -275,12 +276,21 @@ void IniGraphInterpreter::serialize(
     IniSection s(layer->getName());
     s.setEntry("type", layer->getType());
 
-    /// @todo: implement export a property
-    std::cout << layer->getName() << std::endl;
+    Exporter e;
+    layer->export_to(e);
+
+    const auto key_val_pairs =
+      e.get_result<ExportMethods::METHOD_STRINGVECTOR>();
+
+    for (const auto &pair : key_val_pairs) {
+      s.setEntry(pair.first, pair.second);
+    }
+
+    sections.push_back(s);
   }
 
   auto ini = IniWrapper(out, sections);
-  ini.save_ini();
+  ini.save_ini(out);
 }
 
 std::shared_ptr<GraphRepresentation>

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -724,7 +724,7 @@ NetworkGraph::getUnsortedLayers(const std::string &input_layer,
   return ret;
 }
 
-std::vector<std::shared_ptr<Layer>> NetworkGraph::getLayers() {
+std::vector<std::shared_ptr<Layer>> NetworkGraph::getLayers() const {
   std::vector<std::shared_ptr<Layer>> ret;
   if (compiled) {
     std::transform(Sorted.begin(), Sorted.end(), std::back_inserter(ret),

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -151,7 +151,7 @@ public:
    * @note these layers will be in sorted order if the model is compiled,
    * otherwise the order is the order of addition of layers in the model.
    */
-  std::vector<std::shared_ptr<Layer>> getLayers();
+  std::vector<std::shared_ptr<Layer>> getLayers() const;
 
   /**
    * @brief     join passed graph into the existing graph model

--- a/nntrainer/utils/ini_wrapper.cpp
+++ b/nntrainer/utils/ini_wrapper.cpp
@@ -113,8 +113,10 @@ void IniWrapper::updateSections(const Sections &sections_) {
   }
 }
 
-void IniWrapper::save_ini() {
-  std::ofstream out(getIniName().c_str(), std::ios_base::out);
+void IniWrapper::save_ini() { save_ini(getIniName()); }
+
+void IniWrapper::save_ini(const std::string &ini_name) {
+  std::ofstream out(ini_name.c_str(), std::ios_base::out);
   NNTR_THROW_IF(!out.good(), std::runtime_error) << "cannot open ini";
 
   for (auto &it : sections) {

--- a/nntrainer/utils/ini_wrapper.h
+++ b/nntrainer/utils/ini_wrapper.h
@@ -305,9 +305,16 @@ public:
   std::string getName() const { return name; }
 
   /**
-   * @brief save ini to a file
+   * @brief save ini to a file, (getIniName() is used to save)
    */
   void save_ini();
+
+  /**
+   * @brief save ini by ini_name
+   *
+   * @param ini_name ini name to svae
+   */
+  void save_ini(const std::string &ini_name);
   /**
    * @brief erase ini
    *


### PR DESCRIPTION
- [IniSerializer] Add `serialize` to ini 

```
**Changes proposed in this PR:**
- implements ini interpreter::serialize
- add corresponding test (reference shoud be equal to
serialize->deserialized graph)
- Fix some const correctness

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```