### PR TITLE
[Tflite] Implement TfOpNode

### DIFF
--- a/nntrainer/compiler/tflite_interpreter.cpp
+++ b/nntrainer/compiler/tflite_interpreter.cpp
@@ -11,15 +11,19 @@
  */
 #include <tflite_interpreter.h>
 
+#include <algorithm>
 #include <fstream>
 #include <memory>
 #include <string>
 
 #include <tf_schema_generated.h>
 
+#include <fc_layer.h>
 #include <nntrainer_error.h>
 #include <node_exporter.h>
 #include <tensor.h>
+#include <var_grad.h>
+#include <weight.h>
 
 #define UNUSED(x) x __attribute__((unused))
 #define WILL(x) ;
@@ -27,6 +31,7 @@
 static constexpr const char *FUNC_TAG = "[TFLITE INTERPRETER] ";
 
 namespace nntrainer {
+
 namespace {
 /**
  * @brief after finishing building, call this to safe to a file
@@ -56,12 +61,135 @@ void builder2file(const flatbuffers::FlatBufferBuilder &builder,
  *
  */
 class TfOpNode {
-private:
-  std::vector<std::shared_ptr<Var_Grad>> inputs;
-  std::vector<std::shared_ptr<Var_Grad>> outputs;
-  std::vector<std::shared_ptr<Var_Grad>> weights;
+public:
+  using Variables = std::vector<const Var_Grad *>;
 
-  tflite::BuiltinOperator ops_type;
+  TfOpNode() = default;
+
+  /**
+   * @brief Construct a new Tf Op Node object from layer
+   * @note this is a shortcut to skip if layer does not need to be devided or
+   * fused
+   * @param layer layer that is converted to TfOpNode
+   */
+  TfOpNode(const Layer &layer) {
+    setInputs(layer.getInputRef());
+    setOutputs(layer.getOutputRef());
+    setWeights(layer.getWeightsRef());
+    setOpType(layer.getType());
+  }
+
+  /**
+   * @brief Set the Inputs object from layer
+   *
+   * @param inputs_ input to be inserted
+   */
+  void setInputs(const std::vector<std::shared_ptr<Var_Grad>> &inputs_) {
+    inputs.reserve(inputs_.size());
+    std::transform(inputs_.begin(), inputs_.end(), std::back_inserter(inputs),
+                   [](const auto &data) { return data.get(); });
+  }
+
+  /**
+   * @brief Set the Outputs object
+   *
+   * @param outputs_ output to be inserted
+   */
+  void setOutputs(const std::vector<std::shared_ptr<Var_Grad>> &outputs_) {
+    outputs.reserve(outputs_.size());
+    std::transform(outputs_.begin(), outputs_.end(),
+                   std::back_inserter(outputs),
+                   [](const auto &data) { return data.get(); });
+  }
+
+  /**
+   * @brief Set the Weights object
+   *
+   * @param weights_ set weights from the object
+   */
+  void setWeights(const std::vector<Weight> &weights_) {
+    weights.reserve(weights_.size());
+    std::transform(weights_.begin(), weights_.end(),
+                   std::back_inserter(weights),
+                   [](const auto &data) { return &data; });
+  }
+
+  /**
+   * @brief Set the Op Type object
+   * @todo Considering number of alternatives to optimize this, for now it is
+   * just workable.
+   * 1. add and maintain global unordered map
+   * 2. Save information in the appcontext later we can retrieve
+   * 3. let type be an immutable property and let exporter handle this instead
+   * of this method (preferrable)
+   * @param type type to convert
+   */
+  void setOpType(const std::string &type) {
+    if (istrequal(type, FullyConnectedLayer::type)) {
+      setOpType(tflite::BuiltinOperator_FULLY_CONNECTED);
+      return;
+    }
+
+    throw std::invalid_argument("not supported type");
+  }
+
+  /**
+   * @brief Set the Builtin Options object,
+   * @note this can go private, export from a layer and fill this out
+   *
+   * @param builtin_option_type_ builtin option type
+   * @param builtin_ops_ flatbuffer offset of builtin_ops
+   */
+  void setBuiltinOptions(tflite::BuiltinOptions builtin_option_type_,
+                         flatbuffers::Offset<void> &builtin_ops_) {
+    builtin_ops = builtin_ops_;
+    builtin_option_type = builtin_option_type_;
+  }
+
+  /**
+   * @brief Get the Inputs object
+   *
+   * @return Variables& inputs
+   */
+  Variables &getInputs() { return inputs; }
+  const Variables &getInputs() const { return inputs; }
+
+  /**
+   * @brief Get the Outputs object
+   *
+   * @return Variables&
+   */
+  Variables &getOutputs() { return outputs; }
+  const Variables &getOutputs() const { return outputs; }
+
+  /**
+   * @brief Get the Weights object
+   *
+   * @return Variables&
+   */
+  Variables &getWeights() { return weights; }
+  const Variables &getWeights() const { return weights; }
+
+  /**
+   * @brief Get the Op Type object
+   *
+   * @return const tflite::BuiltinOperator
+   */
+  const tflite::BuiltinOperator getOpType() const { return op_type; }
+
+private:
+  /**
+   * @brief Set the Op Type object
+   *
+   * @param op_type_ operation type
+   */
+  void setOpType(tflite::BuiltinOperator op_type_) { op_type = op_type_; }
+
+  Variables inputs;  /**< input variables */
+  Variables outputs; /**< output variables */
+  Variables weights; /**< weight variables */
+
+  tflite::BuiltinOperator op_type;
 
   /// retrieve this from export_to
   flatbuffers::Offset<void> builtin_ops;
@@ -99,8 +227,14 @@ private:
 
 TfOpNodes
 buildOpNodes(std::shared_ptr<const GraphRepresentation> representation) {
-  /** NYI! */
-  return TfOpNodes();
+  TfOpNodes nodes;
+  /// @todo, look ahead of layers to get nodes that can be fused
+  for (const auto &ln : representation->getSorted()) {
+    nodes.emplace_back(*ln->getObject());
+    std::cout << ln->getObject()->getName() << '\n';
+  }
+
+  return nodes;
 }
 
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<tflite::Buffer>>>

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -474,10 +474,35 @@ public:
   virtual std::vector<Tensor> getDerivatives();
 
   /**
+   * @brief Get the Input Ref object
+   *
+   * @return std::vector<std::shared_ptr<Var_Grad>>&
+   */
+  virtual const std::vector<std::shared_ptr<Var_Grad>> &getInputRef() const {
+    return net_input;
+  }
+
+  /**
+   * @brief Get the Output Ref object
+   *
+   * @return std::vector<std::shared_ptr<Var_Grad>>&
+   */
+  virtual const std::vector<std::shared_ptr<Var_Grad>> &getOutputRef() const {
+    return net_hidden;
+  }
+
+  /**
    * @brief Get reference to the weights
    * @retval Reference of the list of weights in the layer
    */
   virtual std::vector<Weight> &getWeightsRef() { return weights; }
+
+  /**
+   * @brief Get the Weights Ref object
+   *
+   * @return const std::vector<Weight>& refs of weights
+   */
+  virtual const std::vector<Weight> &getWeightsRef() const { return weights; }
 
   /**
    * @brief Set the Input Buffers object

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -168,7 +168,9 @@ auto flatten = LayerReprentation("flatten", {"name=flat"});
 #ifdef ENABLE_TFLITE_INTERPRETER
 TEST(flatbuffer, playground) {
   nntrainer::TfliteInterpreter interpreter;
-  interpreter.serialize(nullptr, "test.tflite");
+  auto g = makeGraph({fc0});
+  g->compile(nntrainer::LossType::LOSS_NONE);
+  interpreter.serialize(g, "test.tflite");
 }
 #endif
 /**


### PR DESCRIPTION
- [Tflite] Implement TfOpNode 

```
This patch implements TfOpNode which will be used to deserialize layer
node to a mere chunk of informations. Please note that those methods are
tentative and subject to change wile implementing other methods

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```