### PR TITLE
[Tflite] Fix tf shape building @open sesame 05/24 16:44

### DIFF
--- a/nntrainer/compiler/tflite_interpreter.cpp
+++ b/nntrainer/compiler/tflite_interpreter.cpp
@@ -414,39 +414,6 @@ buildOperatorCodes(const TfOpIdxMap &map, flatbuffers::FlatBufferBuilder &fbb) {
   return fbb.CreateVector(fb_op_codes);
 }
 
-/**
- * @brief get Serialized Tensor shape
- * @note when building tensorshape, the tensor shape must be final, when we
- * reach here it, the tensordim should be final which means if transpose is
- * needed, it should be done already.
- * @param dim Tensor dimension to convert
- * @param type tflite Tensor type
- * @param effective_dimension bitflag of valid 'nchw' dimension, ex) 0b1011
- * means,nhw is effective
- * @param is_signature check if the given dimension is regarded as a tensor
- * signature
- * @return flatbuffers::Offset<flatbuffers::Vector<int32_t>>
- */
-flatbuffers::Offset<flatbuffers::Vector<int32_t>>
-buildTensorShape(const TensorDim &dim, flatbuffers::FlatBufferBuilder &fbb,
-                 int effective_dimension, bool is_signature = false) {
-  std::vector<int32_t> fb_dimension;
-
-  /// batch dimension is always considered with signature
-  if ((effective_dimension >> 3) & 1) {
-    fb_dimension.push_back(is_signature ? -1 : dim.batch());
-  }
-
-  for (unsigned int i = 1; i < MAXDIM; ++i) {
-    if (((effective_dimension >> (MAXDIM - i - 1)) & 1) == 0) {
-      continue;
-    }
-    fb_dimension.push_back(dim.getTensorDim(i));
-  }
-
-  return fbb.CreateVector(fb_dimension);
-}
-
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<tflite::Tensor>>>
 buildTensors(const TfOpIdxMap &map, flatbuffers::FlatBufferBuilder &fbb) {
   /// @todo: the actual (suqeezed) tensor dimension must be known before coming
@@ -458,18 +425,16 @@ buildTensors(const TfOpIdxMap &map, flatbuffers::FlatBufferBuilder &fbb) {
   fb_tensors.reserve(variables.size());
 
   auto create_tensor = [&fbb, &buffer_map](const Var_Grad *var) {
-    /// @fixme: There is a fixed assumption that effective_dimension is 0b1001,
-    /// this is not true, this should be supported inherently from TensorDim
-    /// class.
-    int FIX_ME_FLAG = 0b1001;
-    auto shape = buildTensorShape(var->getDim(), fbb, FIX_ME_FLAG, false);
+    bool need_shape_signature = var->getDim().is_dynamic();
+    std::vector<int32_t> eff_dim = var->getDim().getEffectiveDimension();
+    auto shape = fbb.CreateVector(eff_dim);
 
-    /// in *.tflite spec, there is tensor dimension and tensor signature
-    /// dimension the only difference is that tensor signature dimension gets
-    /// the value of -1 which denotes the size is unspecified. Mostly, batch
-    /// dimension has the signature of -1, we don't have such concept yet so
-    /// this is handled by boolean for now
-    auto shape_sig = buildTensorShape(var->getDim(), fbb, FIX_ME_FLAG, true);
+    decltype(shape) shape_sig;
+    if (need_shape_signature) {
+      std::vector<int32_t> dyn_dim = var->getDim().getEffectiveDimension(true);
+      shape_sig = fbb.CreateVector(dyn_dim);
+    }
+
     auto name = fbb.CreateString(var->getName());
     auto tensor = var->getVariableRef();
 
@@ -481,8 +446,11 @@ buildTensors(const TfOpIdxMap &map, flatbuffers::FlatBufferBuilder &fbb) {
     tflite::TensorBuilder builder(fbb);
     builder.add_name(name);
     builder.add_buffer(buffer_idx);
+    builder.add_type(tflite::TensorType_FLOAT32);
     builder.add_shape(shape);
-    builder.add_shape_signature(shape_sig);
+    if (need_shape_signature) {
+      builder.add_shape_signature(shape_sig);
+    }
     return builder.Finish();
   };
 

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -2096,13 +2096,6 @@ TEST(nntrainer_LossLayer, setProperty_individual_02_n) {
                nntrainer::exception::not_supported);
 }
 
-TEST(nntrainer_ActivationLayer, init_01_n) {
-  nntrainer::Manager manager{true, false};
-  manager.setInferenceInOutMemoryOptimization(false);
-  nntrainer::ActivationLayer layer;
-  EXPECT_THROW(layer.initialize(manager), std::invalid_argument);
-}
-
 TEST(nntrainer_ActivationLayer, init_02_p) {
   nntrainer::Manager manager{true, false};
   manager.setInferenceInOutMemoryOptimization(false);

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -37,6 +37,34 @@ TEST(nntrainer_TensorDim, ctor_initializer_p) {
   EXPECT_EQ(nntrainer::TensorDim(b, c, h, w), t);
 }
 
+TEST(nntrianer_TensorDim, effective_dimension_p) {
+  nntrainer::TensorDim t(3, 2, 4, 5);
+  EXPECT_EQ(t.getEffectiveDimension(), std::vector<int>({3, 2, 4, 5}));
+
+  t.setEffDimFlag(0b1101);
+  EXPECT_EQ(t.getEffectiveDimension(), std::vector<int>({3, 2, 5}));
+
+  t.setEffDimFlag(0b0011);
+  EXPECT_EQ(t.getEffectiveDimension(), std::vector<int>({4, 5}));
+
+  t.setEffDimFlag(0b1111);
+  EXPECT_EQ(t.getEffectiveDimension(), std::vector<int>({3, 2, 4, 5}));
+
+  t.setEffDimFlag(0b1100);
+  EXPECT_EQ(t.getEffectiveDimension(), std::vector<int>({3, 2}));
+
+  t.setDynDimFlag(0b1100);
+  EXPECT_EQ(t.getEffectiveDimension(true), std::vector<int>({-1, -1}));
+
+  auto copied_t = t;
+  EXPECT_EQ(copied_t.getEffectiveDimension(), std::vector<int>({3, 2}));
+  EXPECT_EQ(copied_t.getEffectiveDimension(true), std::vector<int>({-1, -1}));
+
+  auto moved_t = std::move(copied_t);
+  EXPECT_EQ(moved_t.getEffectiveDimension(), std::vector<int>({3, 2}));
+  EXPECT_EQ(moved_t.getEffectiveDimension(true), std::vector<int>({-1, -1}));
+}
+
 TEST(nntrainer_TensorDim, ctor_initializer_n) {
   EXPECT_THROW(nntrainer::TensorDim t({1, 2, 3, 4, 5}), std::invalid_argument);
 }


### PR DESCRIPTION
```
This patch fixes tf shape building, by adding `eff_dim_flag` and
`dyn_dim_flag`.

`eff_dim_flag` checks which dimension are actually used so that to be
squeezed.
`dyn_dim_flag` checks which dimension should be set to -1 (meaning it is
not fixed)

With those flag set, our tensor dim is able to convert to the dimension
representation that supports `-1` and not fixed size

Those fixes are apply to fc layer for now

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- ~**[Pending MERGES - #1155]** Merge branch '"'"'@dox/tensordim'"'"' into @1067/tf_interpreter/10_base~