### PR TITLE
[Competibility] Change test reference tolerance @open sesame 04/22 18:25

### DIFF
--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -201,7 +201,11 @@ TEST(nntrainer_ccapi, train_with_config_01_p) {
   EXPECT_NO_THROW(model->train());
 
   EXPECT_FLOAT_EQ(model->getTrainingLoss(), 4.434051);
+#ifdef __i586__
+  EXPECT_NEAR(model->getValidationLoss(), 2.9646113, 1.0e-5);
+#else
   EXPECT_FLOAT_EQ(model->getValidationLoss(), 2.9646113);
+#endif
 }
 
 /**


### PR DESCRIPTION
- [Competibility] Change test reference value 

```
This patch change tolerance for the `model->getValidationLoss` which
affects in i586

resolves #1125

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```