### PR TITLE
[Fix] handle edge case for countNonTrainable

### DIFF
--- a/Applications/SimpleShot/meson.build
+++ b/Applications/SimpleShot/meson.build
@@ -25,3 +25,10 @@ if get_option('enable-test')
   )
   subdir('test')
 endif
+
+test('app_simpleshot_sample', e, args: [
+  'conv4',
+  'L2N',
+  'tractor:turtle:squirrel:willow_tree:sunflower_20shot_seed:456_train.dat','tractor:turtle:squirrel:willow_tree:sunflower_seed:456_test.dat',
+  meson.current_source_dir()
+], timeout: 60)

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -141,9 +141,10 @@ void NetworkGraph::countNonTrainableLayersAtBegin() {
   for (auto iter = Sorted.cbegin(); iter != Sorted.cend(); iter++) {
     if ((*iter).layer->getTrainable()) {
       skip_non_trainable_layers = iter - Sorted.cbegin();
-      break;
+      return;
     }
   }
+  skip_non_trainable_layers = Sorted.size();
 }
 
 void NetworkGraph::topologicalSort() {
@@ -636,7 +637,7 @@ std::vector<TensorDim> NetworkGraph::getOutputDimension() const {
 std::vector<std::shared_ptr<Layer>>
 NetworkGraph::getUnsortedLayers(const std::string &input_layer,
                                 const std::string &output_layer) const {
-  /// @FIXME: this won't work if input, output layers are not in order
+  /// @fixme: this won't work if input, output layers are not in order
   /// Further, this function must be removed. There should be rather
   /// getAllNames and getLayerByName instead of getUnsortedLayers.
 

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -671,7 +671,7 @@ int NeuralNetwork::train_run() {
         } catch (...) {
           data_buffer->clear(nntrainer::BufferType::BUF_TRAIN);
           ml_loge("Error: training error in #%d/%d.", epoch_idx, epochs);
-          std::rethrow_exception(std::current_exception());
+          throw;
         }
         std::cout << "#" << epoch_idx << "/" << epochs;
         float loss = getLoss();


### PR DESCRIPTION
- [Fix] handle edge case for countNonTrainable 

```
**Changes proposed in this PR:**
- Handle edge case when every layer is non trainable
for `countNonTrainableLayersAtBegin`
- Trivial code cleans on simpleshot task_runner / neuralnetwork

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

resolves #1135 