### PR TITLE
Fix indent in the SPDX identifier

### DIFF
--- a/Applications/Embedding/Tensorflow/embedding.py
+++ b/Applications/Embedding/Tensorflow/embedding.py
@@ -3,12 +3,12 @@
 #
 # Copyright (C) 2021 Jijoong Moon <jijoong.moon@samsung.com>
 #
-# @file	embedding.py
-# @date	15 March 2021
-# @brief	This is Simple Embedding Layer Training Example
-# @see		https://github.com/nnstreamer/nntrainer
-# @author	Jijoong Moon <jijoong.moon@samsung.com>
-# @bug		No known bugs except for NYI items
+# @file	  embedding.py
+# @date	  15 March 2021
+# @brief  This is Simple Embedding Layer Training Example
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Jijoong Moon <jijoong.moon@samsung.com>
+# @bug    No known bugs except for NYI items
 #
 #
 

--- a/Applications/Embedding/jni/main.cpp
+++ b/Applications/Embedding/jni/main.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2021 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	main.cpp
- * @date	10 March 2021
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Binary Logistic Regression Example
+ * @file   main.cpp
+ * @date   10 March 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Binary Logistic Regression Example
  *
  *              Trainig set (embedding_input.txt) : 4 colume data + result (1.0
  * or 0.0) Configuration file : ../../res/Embedding.ini

--- a/Applications/KNN/jni/main.cpp
+++ b/Applications/KNN/jni/main.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	main.cpp
- * @date	21 August 2020
- * @brief	This is KNN example.
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   main.cpp
+ * @date   21 August 2020
+ * @brief  This is KNN example.
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/Applications/KNN/jni/main_sample.cpp
+++ b/Applications/KNN/jni/main_sample.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	main.cpp for K Nearest Neighbor
- * @date	04 December 2019
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Transfer Learning Example with KNN
+ * @file   main.cpp for K Nearest Neighbor
+ * @date   04 December 2019
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Transfer Learning Example with KNN
  *
  *              Inputs : Three Categories ( Happy, Sad, Soso ) with
  *                       5 pictures for each category

--- a/Applications/MNIST/PyTorch/main.py
+++ b/Applications/MNIST/PyTorch/main.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 #
-# @file	main.py
-# @date	6 Dec 2020
-# @brief	This is Simple MNIST Classification Example using PyTorch
-# @see		https://github.com/nnstreamer/nntrainer
-# @author	Parichay Kapoor <pk.kapoor@samsung.com>
-# @bug		No known bugs except for NYI items
+# @file   main.py
+# @date   6 Dec 2020
+# @brief  This is Simple MNIST Classification Example using PyTorch
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Parichay Kapoor <pk.kapoor@samsung.com>
+# @bug    No known bugs except for NYI items
 
 # This code is based on official PyTorch examples repo - examples/mnist/main.py
 

--- a/Applications/MNIST/Tensorflow/Training_Keras.py
+++ b/Applications/MNIST/Tensorflow/Training_Keras.py
@@ -3,12 +3,12 @@
 #
 # Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
 #
-# @file	mnist_Keras.py
-# @date	13 July 2020
-# @brief	This is Simple Classification Example using Keras
-# @see		https://github.com/nnstreamer/nntrainer
-# @author	Jijoong Moon <jijoong.moon@samsung.com>
-# @bug		No known bugs except for NYI items
+# @file   mnist_Keras.py
+# @date   13 July 2020
+# @brief  This is Simple Classification Example using Keras
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Jijoong Moon <jijoong.moon@samsung.com>
+# @bug    No known bugs except for NYI items
 #
 # mnist example
 # inputlayer -> conv2d (5x5) 6 filters -> pooling2d 2x2 (valid) -> conv2d (5x5) 12 filters ->

--- a/Applications/MNIST/Tensorflow/dataset.py
+++ b/Applications/MNIST/Tensorflow/dataset.py
@@ -3,12 +3,12 @@
 #
 # Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
 #
-# @file	dataset.py
-# @date	15 July 2020
-# @brief	This is for mnist input generation
-# @see		https://github.com/nnstreamer/nntrainer
-# @author	Jijoong Moon <jijoong.moon@samsung.com>
-# @bug		No known bugs except for NYI items
+# @file	  dataset.py
+# @date	  15 July 2020
+# @brief  This is for mnist input generation
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Jijoong Moon <jijoong.moon@samsung.com>
+# @bug    No known bugs except for NYI items
 #
 #
 

--- a/Applications/MNIST/jni/main.cpp
+++ b/Applications/MNIST/jni/main.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	main.cpp
- * @date	01 July 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is MNIST Example with
+ * @file   main.cpp
+ * @date   01 July 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is MNIST Example with
  *
  * Input 28x28
  * Conv2D 5 x 5 : 6 filters, stride 1x1, padding=0,0

--- a/Applications/SimpleShot/task_runner.cpp
+++ b/Applications/SimpleShot/task_runner.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
- * @file	task_runner.cpp
- * @date	08 Jan 2021
- * @brief	task runner for the simpleshot demonstration
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jihoon Lee <jhoon.it.lee@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   task_runner.cpp
+ * @date   08 Jan 2021
+ * @brief  task runner for the simpleshot demonstration
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
  */
 
 #include <fstream>

--- a/Applications/SimpleShot/test/simpleshot_centering_test.cpp
+++ b/Applications/SimpleShot/test/simpleshot_centering_test.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
- * @file	simpleshot_centering_test.cpp
- * @date	08 Jan 2021
- * @brief	test for simpleshot centering layer
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jihoon Lee <jhoon.it.lee@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   simpleshot_centering_test.cpp
+ * @date   08 Jan 2021
+ * @brief  test for simpleshot centering layer
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
  */
 
 #include <gtest/gtest.h>

--- a/Applications/SimpleShot/test/simpleshot_centroid_knn.cpp
+++ b/Applications/SimpleShot/test/simpleshot_centroid_knn.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
- * @file	simpleshot_centroid_knn.cpp
- * @date	08 Jan 2021
- * @brief	test for simpleshot centering layer
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jihoon Lee <jhoon.it.lee@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   simpleshot_centroid_knn.cpp
+ * @date   08 Jan 2021
+ * @brief  test for simpleshot centering layer
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
  */
 
 #include <gtest/gtest.h>

--- a/Applications/SimpleShot/test/simpleshot_l2norm_test.cpp
+++ b/Applications/SimpleShot/test/simpleshot_l2norm_test.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
- * @file	simpleshot_l2norm_test.cpp
- * @date	08 Jan 2021
- * @brief	test for simpleshot l2norm layer
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jihoon Lee <jhoon.it.lee@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   simpleshot_l2norm_test.cpp
+ * @date   08 Jan 2021
+ * @brief  test for simpleshot l2norm layer
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug	   No known bugs except for NYI items
  */
 
 #include <gtest/gtest.h>

--- a/Applications/SimpleShot/test/simpleshot_utils_test.cpp
+++ b/Applications/SimpleShot/test/simpleshot_utils_test.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
- * @file	simpleshot_utils_test.cpp
- * @date	08 Jan 2021
- * @brief	test for simpleshot utils
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jihoon Lee <jhoon.it.lee@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   simpleshot_utils_test.cpp
+ * @date   08 Jan 2021
+ * @brief  test for simpleshot utils
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
  */
 
 #include <gtest/gtest.h>

--- a/Applications/VGG/PyTorch/main.py
+++ b/Applications/VGG/PyTorch/main.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 #
-# @file	main.py
-# @date	08 Dec 2020
-# @brief	This is VGG16 Example using PyTorch
-# @see		https://github.com/nnstreamer/nntrainer
-# @author	Parichay Kapoor <pk.kapoor@samsung.com>
-# @bug		No known bugs except for NYI items
+# @file	  main.py
+# @date	  08 Dec 2020
+# @brief  This is VGG16 Example using PyTorch
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Parichay Kapoor <pk.kapoor@samsung.com>
+# @bug    No known bugs except for NYI items
 #
 # This is based on official pytorch examples
 

--- a/Applications/VGG/Tensorflow/dataset.py
+++ b/Applications/VGG/Tensorflow/dataset.py
@@ -3,12 +3,12 @@
 #
 # Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
 #
-# @file	dataset.py
-# @date	15 July 2020
-# @brief	This is for mnist input generation
-# @see		https://github.com/nnstreamer/nntrainer
-# @author	Jijoong Moon <jijoong.moon@samsung.com>
-# @bug		No known bugs except for NYI items
+# @file	  dataset.py
+# @date	  15 July 2020
+# @brief  This is for mnist input generation
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Jijoong Moon <jijoong.moon@samsung.com>
+# @bug    No known bugs except for NYI items
 #
 #
 

--- a/Applications/VGG/Tensorflow/vgg_keras.py
+++ b/Applications/VGG/Tensorflow/vgg_keras.py
@@ -3,12 +3,12 @@
 #
 # Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
 #
-# @file	vgg_keras.py
-# @date	08 Oct 2020
-# @brief	This is VGG16 Example using Keras
-# @see		https://github.com/nnstreamer/nntrainer
-# @author	Jijoong Moon <jijoong.moon@samsung.com>
-# @bug		No known bugs except for NYI items
+# @file	  vgg_keras.py
+# @date	  08 Oct 2020
+# @brief  This is VGG16 Example using Keras
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Jijoong Moon <jijoong.moon@samsung.com>
+# @bug    No known bugs except for NYI items
 #
 # vgg example : filter size is reduced.
 # conv3_16 - conv3_16, max_pooling, conv3_32 - conv3_32, max_pooling, conv3_64 - conv3_64 - conv3_64, max_pooling,

--- a/Applications/VGG/gen_input/convert.py
+++ b/Applications/VGG/gen_input/convert.py
@@ -3,12 +3,12 @@
 #
 # Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
 #
-# @file	convert.py
-# @date	12 Oct 2020
-# @brief	This is script to convert cifar100 data set for vgg model
-# @see		https://github.com/nnstreamer/nntrainer
-# @author	Jijoong Moon <jijoong.moon@samsung.com>
-# @bug		No known bugs except for NYI items
+# @file	  convert.py
+# @date	  12 Oct 2020
+# @brief  This is script to convert cifar100 data set for vgg model
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Jijoong Moon <jijoong.moon@samsung.com>
+# @bug    No known bugs except for NYI items
 #
 # python3 convert.py path_for_cifar100 [train | val]
 #  - trainingSet.dat for training : 100 images x 100 classes

--- a/Applications/VGG/jni/main.cpp
+++ b/Applications/VGG/jni/main.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	main.cpp
- * @date	05 Oct 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is VGG Example with
+ * @file   main.cpp
+ * @date   05 Oct 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ * @brief  This is VGG Example with
  *
  */
 

--- a/api/capi/include/platform/ml-api-common.h
+++ b/api/capi/include/platform/ml-api-common.h
@@ -4,13 +4,13 @@
  * Copyright (C) 2020 MyungJoo Ham <myungjoo.ham@samsung.com>
  */
 /**
- * @file	ml-api-common.h
- * @date	07 May 2020
- * @brief	Dummy ML-API Common Header from nnstreamer. Relicensed by authors.
- * @see		https://github.com/nnstreamer/nnstreamer
- * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @file   ml-api-common.h
+ * @date   07 May 2020
+ * @brief  Dummy ML-API Common Header from nnstreamer. Relicensed by authors.
+ * @see    https://github.com/nnstreamer/nnstreamer
+ * @author MyungJoo Ham <myungjoo.ham@samsung.com>
  * @author Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @bug    No known bugs except for NYI items
  *
  * @details
  *      More entries might be migrated from nnstreamer.h if

--- a/api/ccapi/include/dataset.h
+++ b/api/ccapi/include/dataset.h
@@ -3,13 +3,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	dataset.h
- * @date	14 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is dataset interface for c++ API
+ * @file   dataset.h
+ * @date   14 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ * @brief  This is dataset interface for c++ API
  *
  * @note This is experimental API and not stable.
  */

--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	layer.h
- * @date	14 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is layers interface for c++ API
+ * @file   layer.h
+ * @date   14 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ * @brief  This is layers interface for c++ API
  *
  * @note This is experimental API and not stable.
  */

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	model.h
- * @date	14 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is model interface for c++ API
+ * @file   model.h
+ * @date   14 October 2020
+ * @see	   https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ * @brief  This is model interface for c++ API
  *
  * @note This is experimental API and not stable.
  */

--- a/api/ccapi/include/optimizer.h
+++ b/api/ccapi/include/optimizer.h
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	optimizer.h
- * @date	14 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is optimizers interface for c++ API
+ * @file   optimizer.h
+ * @date   14 October 2020
+ * @see	   https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is optimizers interface for c++ API
  *
  * @note This is experimental API and not stable.
  */

--- a/api/ccapi/src/factory.cpp
+++ b/api/ccapi/src/factory.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	factory.cpp
- * @date	14 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is implementaion for factory builder interface for c++ API
+ * @file   factory.cpp
+ * @date   14 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is implementaion for factory builder interface for c++ API
  */
 
 #include <memory>

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -4,12 +4,12 @@
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  */
 /**
- * @file	tensor_filter_nntrainer.cc
- * @date	09 Sept 2020
- * @brief	nntrainer inference module for tensor_filter gstreamer plugin
- * @see		http://github.com/nnstreamer/nnstreamer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   tensor_filter_nntrainer.cc
+ * @date   09 Sept 2020
+ * @brief  nntrainer inference module for tensor_filter gstreamer plugin
+ * @see    http://github.com/nnstreamer/nnstreamer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  * This is the per-NN-framework plugin (e.g) tensorflow-lite) for tensor_filter.
  * Fill in "GstTensorFilterFramework" for tensor_filter.h/c

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.hh
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.hh
@@ -4,13 +4,13 @@
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  */
 /**
- * @file	tensor_filter_nntrainer.hh
- * @date	09 Sept 2020
- * @brief	nntrainer inference module for tensor_filter gstreamer plugin header
- * @note  The clas has been exposed from tensor_filter_nntrainer.cc to unittest
- * @see		http://github.com/nnstreamer/nnstreamer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   tensor_filter_nntrainer.hh
+ * @date   09 Sept 2020
+ * @brief  nntrainer inference module for tensor_filter gstreamer plugin header
+ * @note   The clas has been exposed from tensor_filter_nntrainer.cc to unittest
+ * @see    http://github.com/nnstreamer/nnstreamer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  * This is the per-NN-framework plugin (e.g) tensorflow-lite) for tensor_filter.
  * Fill in "GstTensorFilterFramework" for tensor_filter.h/c

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -2,11 +2,11 @@
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
- * @file	 app_context.cpp
- * @date	 10 November 2020
- * @brief	 This file contains app context related functions and classes that
+ * @file   app_context.cpp
+ * @date   10 November 2020
+ * @brief  This file contains app context related functions and classes that
  * manages the global configuration of the current environment
- * @see		 https://github.com/nnstreamer/nntrainer
+ * @see    https://github.com/nnstreamer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug	   No known bugs except for NYI items
  *

--- a/nntrainer/dataset/databuffer_factory.cpp
+++ b/nntrainer/dataset/databuffer_factory.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	databuffer_factory.cpp
- * @date	11 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is the databuffer factory.
+ * @file   databuffer_factory.cpp
+ * @date   11 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the databuffer factory.
  */
 
 #include <databuffer_factory.h>

--- a/nntrainer/dataset/databuffer_factory.h
+++ b/nntrainer/dataset/databuffer_factory.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	databuffer_factory.h
- * @date	19 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is the layer factory.
+ * @file   databuffer_factory.h
+ * @date   19 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the layer factory.
  */
 
 #ifndef __DATABUFFER_FACTORY_H__

--- a/nntrainer/dataset/databuffer_util.h
+++ b/nntrainer/dataset/databuffer_util.h
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	databuffer_util.h
- * @date	12 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Databuffer utility file.
+ * @file   databuffer_util.h
+ * @date   12 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Databuffer utility file.
  *
  */
 

--- a/nntrainer/delegate.h
+++ b/nntrainer/delegate.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	delegate.h
- * @date	7 Aug 2020
- * @brief	This is Delegate Class for the Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   delegate.h
+ * @date   7 Aug 2020
+ * @brief  This is Delegate Class for the Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  * @note This class is experimental and subject to major modifications.
  *

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	graph_node.h
- * @date	1 April 2021
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is the graph node interface for c++ API
+ * @file   graph_node.h
+ * @date   1 April 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the graph node interface for c++ API
  */
 
 #ifndef __GRAPH_NODE_H__

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	addition_layer.cpp
- * @date	30 July 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Addition Layer Class for Neural Network
+ * @file   addition_layer.cpp
+ * @date   30 July 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Addition Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	addition_layer.h
- * @date	30 July 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Addition Layer Class for Neural Network
+ * @file   addition_layer.h
+ * @date   30 July 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Addition Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	concat_layer.cpp
- * @date	27 Oct 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Concat Layer Class for Neural Network
+ * @file   concat_layer.cpp
+ * @date   27 Oct 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Concat Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	concat_layer.h
- * @date	27 Oct 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Concat Layer Class for Neural Network
+ * @file   concat_layer.h
+ * @date   27 Oct 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Concat Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	conv2d_layer.h
- * @date	02 June 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Jihoon Lee <jhoon.it.lee@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Convolution Layer Class for Neural Network
+ * @file   conv2d_layer.h
+ * @date   02 June 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Convolution Layer Class for Neural Network
  *
  */
 #include <algorithm>

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	conv2d_layer.h
- * @date	01 June 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Convolution Layer Class for Neural Network
+ * @file   conv2d_layer.h
+ * @date   01 June 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Convolution Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	embedding.cpp
- * @date	04 March 2021
- * @brief	This is Embedding Layer Class of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   embedding.cpp
+ * @date   04 March 2021
+ * @brief  This is Embedding Layer Class of Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/layers/embedding.h
+++ b/nntrainer/layers/embedding.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2021 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	embedding.h
- * @date	04 March 2021
- * @brief	This is Embedding Layer Class of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   embedding.h
+ * @date   04 March 2021
+ * @brief  This is Embedding Layer Class of Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	fc_layer.h
- * @date	14 May 2020
- * @brief	This is Fully Connected Layer Class of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   fc_layer.h
+ * @date   14 May 2020
+ * @brief  This is Fully Connected Layer Class of Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/layers/flatten_layer.cpp
+++ b/nntrainer/layers/flatten_layer.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	flatten_layer.cpp
- * @date	16 June 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Flatten Layer Class for Neural Network
+ * @file   flatten_layer.cpp
+ * @date   16 June 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ * @brief  This is Flatten Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/flatten_layer.h
+++ b/nntrainer/layers/flatten_layer.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	flatten_layer.h
- * @date	16 June 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Flatten Layer Class for Neural Network
+ * @file   flatten_layer.h
+ * @date   16 June 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Flatten Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/layer_factory.cpp
+++ b/nntrainer/layers/layer_factory.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	optimizer_factory.cpp
- * @date	11 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is the layer factory.
+ * @file   optimizer_factory.cpp
+ * @date   11 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the layer factory.
  */
 
 #include <layer_factory.h>

--- a/nntrainer/layers/layer_factory.h
+++ b/nntrainer/layers/layer_factory.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	layer_factory.h
- * @date	7 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is the layer factory.
+ * @file   layer_factory.h
+ * @date   7 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the layer factory.
  */
 
 #ifndef __LAYER_FACTORY_H__

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	graph_node.h
- * @date	1 April 2021
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is the graph node interface for c++ API
+ * @file   graph_node.h
+ * @date   1 April 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the graph node interface for c++ API
  */
 
 #ifndef __LAYER_NODE_H__

--- a/nntrainer/layers/loss_layer.h
+++ b/nntrainer/layers/loss_layer.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	loss_layer.h
- * @date	12 June 2020
- * @brief	This is Loss Layer Class of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   loss_layer.h
+ * @date   12 June 2020
+ * @brief  This is Loss Layer Class of Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	lstm.cpp
- * @date	17 March 2021
- * @brief	This is Long Short-Term Memory Layer Class of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   lstm.cpp
+ * @date   17 March 2021
+ * @brief  This is Long Short-Term Memory Layer Class of Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/layers/lstm.h
+++ b/nntrainer/layers/lstm.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2021 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	lstm.h
- * @date	31 March 2021
- * @brief	This is Long Short-Term Memory Layer Class of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   lstm.h
+ * @date   31 March 2021
+ * @brief  This is Long Short-Term Memory Layer Class of Neural Network
+ * @see	   https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/layers/nnstreamer_layer.cpp
+++ b/nntrainer/layers/nnstreamer_layer.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	nnstreamer_layer.cpp
- * @date	26 October 2020
- * @brief	This is class to encapsulate nnstreamer as a layer of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   nnstreamer_layer.cpp
+ * @date   26 October 2020
+ * @brief  This is class to encapsulate nnstreamer as a layer of Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug	   No known bugs except for NYI items
  *
  * @todo: provide input/output dimensions to nnstreamer for certain frameworks
  * @todo: support transposing the data to support NCHW nntrainer data to NHWC

--- a/nntrainer/layers/nnstreamer_layer.h
+++ b/nntrainer/layers/nnstreamer_layer.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	nnstreamer_layer.h
- * @date	26 October 2020
- * @brief	This is class to encapsulate nnstreamer as a layer of Neural Network
- * @see	https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug	no known bugs except for NYI items
+ * @file   nnstreamer_layer.h
+ * @date   26 October 2020
+ * @brief  This is class to encapsulate nnstreamer as a layer of Neural Network
+ * @see	   https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	pooling2d_layer.cpp
- * @date	12 June 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is 2 Dimensional Pooling Layer Class for Neural Network
+ * @file   pooling2d_layer.cpp
+ * @date   12 June 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is 2 Dimensional Pooling Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	pooling2d_layer.h
- * @date	12 June 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is 2 Dimensional Pooling Layer Class for Neural Network
+ * @file   pooling2d_layer.h
+ * @date   12 June 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is 2 Dimensional Pooling Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/preprocess_flip_layer.cpp
+++ b/nntrainer/layers/preprocess_flip_layer.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	preprocess_flip_layer.cpp
- * @date	20 January 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Preprocess Random Flip Layer Class for Neural Network
+ * @file   preprocess_flip_layer.cpp
+ * @date   20 January 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Preprocess Random Flip Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/preprocess_flip_layer.h
+++ b/nntrainer/layers/preprocess_flip_layer.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	preprocess_flip_layer.h
- * @date	20 January 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Preprocess Random Flip Layer Class for Neural Network
+ * @file   preprocess_flip_layer.h
+ * @date   20 January 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Preprocess Random Flip Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/preprocess_translate_layer.cpp
+++ b/nntrainer/layers/preprocess_translate_layer.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	preprocess_layer.cpp
- * @date	31 December 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Preprocess Translate Layer Class for Neural Network
+ * @file   preprocess_layer.cpp
+ * @date   31 December 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Preprocess Translate Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/preprocess_translate_layer.h
+++ b/nntrainer/layers/preprocess_translate_layer.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	preprocess_layer.h
- * @date	31 December 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Preprocess Translate Layer Class for Neural Network
+ * @file   preprocess_layer.h
+ * @date   31 December 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Preprocess Translate Layer Class for Neural Network
  *
  */
 

--- a/nntrainer/layers/rnn.cpp
+++ b/nntrainer/layers/rnn.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	rnn.cpp
- * @date	17 March 2021
- * @brief	This is Recurrent Layer Class of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   rnn.cpp
+ * @date   17 March 2021
+ * @brief  This is Recurrent Layer Class of Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/layers/rnn.h
+++ b/nntrainer/layers/rnn.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2021 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	rnn.h
- * @date	17 March 2021
- * @brief	This is Recurrent Layer Class of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   rnn.h
+ * @date   17 March 2021
+ * @brief  This is Recurrent Layer Class of Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/layers/tflite_layer.cpp
+++ b/nntrainer/layers/tflite_layer.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	tflite_layer.cpp
- * @date	26 October 2020
- * @brief	This is class to encapsulate tflite as a layer of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   tflite_layer.cpp
+ * @date   26 October 2020
+ * @brief  This is class to encapsulate tflite as a layer of Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
  */
 
 #include <nntrainer_error.h>

--- a/nntrainer/layers/tflite_layer.h
+++ b/nntrainer/layers/tflite_layer.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	tflite_layer.h
- * @date	3 November 2020
- * @brief	This is class to encapsulate tflite as a layer of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   tflite_layer.h
+ * @date   3 November 2020
+ * @brief  This is class to encapsulate tflite as a layer of Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/layers/time_dist.cpp
+++ b/nntrainer/layers/time_dist.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	time_dist.cpp
- * @date	01 April 2021
- * @brief	This is Time Distributed Layer Class of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   time_dist.cpp
+ * @date   01 April 2021
+ * @brief  This is Time Distributed Layer Class of Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/layers/time_dist.h
+++ b/nntrainer/layers/time_dist.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	time_dist.h
- * @date	01 April 2021
- * @brief	This is Time Distributed Layer Class of Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   time_dist.h
+ * @date   01 April 2021
+ * @brief  This is Time Distributed Layer Class of Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/models/model_loader.h
+++ b/nntrainer/models/model_loader.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	model_loader.h
- * @date	5 August 2020
- * @brief	This is model loader class for the Neural Network
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   model_loader.h
+ * @date   5 August 2020
+ * @brief  This is model loader class for the Neural Network
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/optimizers/adam.cpp
+++ b/nntrainer/optimizers/adam.cpp
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	adam.cpp
- * @date	6 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is the Adam optimizer.
+ * @file   adam.cpp
+ * @date   6 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the Adam optimizer.
  */
 
 #include <cmath>

--- a/nntrainer/optimizers/adam.h
+++ b/nntrainer/optimizers/adam.h
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	adam.h
- * @date	6 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is the Adam optimizer.
+ * @file   adam.h
+ * @date   6 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the Adam optimizer.
  */
 #ifndef __ADAM_H__
 #define __ADAM_H__

--- a/nntrainer/optimizers/optimizer_devel.cpp
+++ b/nntrainer/optimizers/optimizer_devel.cpp
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	optimizer_devel.cpp
- * @date	08 April 2020
- * @brief	This is Optimizer internal interface class
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   optimizer_devel.cpp
+ * @date   08 April 2020
+ * @brief  This is Optimizer internal interface class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/optimizers/optimizer_devel.h
+++ b/nntrainer/optimizers/optimizer_devel.h
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	optimizer_devel.h
- * @date	08 April 2020
- * @brief	This is Optimizer internal interface class
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   optimizer_devel.h
+ * @date   08 April 2020
+ * @brief  This is Optimizer internal interface class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/optimizers/optimizer_factory.cpp
+++ b/nntrainer/optimizers/optimizer_factory.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	optimizer_factory.cpp
- * @date	7 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is the optimizer factory.
+ * @file   optimizer_factory.cpp
+ * @date   7 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the optimizer factory.
  */
 #include <algorithm>
 #include <sstream>

--- a/nntrainer/optimizers/optimizer_factory.h
+++ b/nntrainer/optimizers/optimizer_factory.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	optimizer_factory.h
- * @date	7 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is the optimizer factory.
+ * @file   optimizer_factory.h
+ * @date   7 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the optimizer factory.
  */
 
 #ifndef __OPTIMIZER_FACTORY_H__

--- a/nntrainer/optimizers/optimizer_impl.cpp
+++ b/nntrainer/optimizers/optimizer_impl.cpp
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	optimizer_impl.cpp
- * @date	18 March 2021
- * @brief	This is base Optimizer implementation class
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   optimizer_impl.cpp
+ * @date   18 March 2021
+ * @brief  This is base Optimizer implementation class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/optimizers/optimizer_impl.h
+++ b/nntrainer/optimizers/optimizer_impl.h
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	optimizer_impl.h
- * @date	18 March 2021
- * @brief	This is base Optimizer implementation class
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   optimizer_impl.h
+ * @date   18 March 2021
+ * @brief  This is base Optimizer implementation class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/optimizers/sgd.cpp
+++ b/nntrainer/optimizers/sgd.cpp
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	sgd.cpp
- * @date	6 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is the SGD optimizer.
+ * @file   sgd.cpp
+ * @date   6 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the SGD optimizer.
  */
 
 #include <sgd.h>

--- a/nntrainer/optimizers/sgd.h
+++ b/nntrainer/optimizers/sgd.h
@@ -2,13 +2,13 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	sgd.h
- * @date	6 October 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is the SGD optimizer.
+ * @file   sgd.h
+ * @date   6 October 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the SGD optimizer.
  */
 #ifndef __SGD_H__
 #define __SGD_H__

--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	blas_interface.cpp
- * @date	28 Aug 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is dummy header for blas support
+ * @file   blas_interface.cpp
+ * @date   28 Aug 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is dummy header for blas support
  *
  */
 

--- a/nntrainer/tensor/blas_interface.h
+++ b/nntrainer/tensor/blas_interface.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file	blas_interface.h
- * @date	28 Aug 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is dummy header for blas support
+ * @file   blas_interface.h
+ * @date   28 Aug 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is dummy header for blas support
  *
  */
 

--- a/nntrainer/tensor/lazy_tensor.cpp
+++ b/nntrainer/tensor/lazy_tensor.cpp
@@ -2,12 +2,12 @@
  *
  * Copyright (C) 2020 Jihoon Lee <jihoon.it.lee@samsung.com>
  *
- * @file	lazy_tensor.cpp
- * @date	05 Jun 2020
- * @brief	A lazy evaluation calculator for tensors
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jihoon Lee <jihoon.it.lee@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   lazy_tensor.cpp
+ * @date   05 Jun 2020
+ * @brief  A lazy evaluation calculator for tensors
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jihoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/tensor/lazy_tensor.h
+++ b/nntrainer/tensor/lazy_tensor.h
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 /* Copyright (C) 2020 Jihoon Lee <jihoon.it.lee@samsung.com>
  *
- * @file	lazy_tensor.h
- * @date	05 Jun 2020
- * @brief	A lazy evaluation calculator for tensors
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jihoon Lee <jihoon.it.lee@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   lazy_tensor.h
+ * @date   05 Jun 2020
+ * @brief  A lazy evaluation calculator for tensors
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jihoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/tensor/tensor_dim.cpp
+++ b/nntrainer/tensor/tensor_dim.cpp
@@ -3,12 +3,12 @@
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  */
 /**
- * @file	tensor_dim.cpp
- * @date	22 May 2020
- * @brief	This is Tensor Dimension Class
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   tensor_dim.cpp
+ * @date   22 May 2020
+ * @brief  This is Tensor Dimension Class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/tensor/tensor_dim.h
+++ b/nntrainer/tensor/tensor_dim.h
@@ -3,12 +3,12 @@
  * Copyright (C) 2020 Jijoong Moon <jijoong.moon@samsung.com>
  */
 /**
- * @file	tensor_dim.h
- * @date	22 May 2020
- * @brief	This is Tensor Dimension Class
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jijoong Moon <jijoong.moon@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   tensor_dim.h
+ * @date   22 May 2020
+ * @brief  This is Tensor Dimension Class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	var_grad.cpp
- * @date	13 November 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Var_Grad Class for Neural Network
+ * @file   var_grad.cpp
+ * @date   13 November 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Var_Grad Class for Neural Network
  *
  */
 

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	var_grad.h
- * @date	13 November 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Var_Grad Class for Neural Network
+ * @file   var_grad.h
+ * @date   13 November 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Var_Grad Class for Neural Network
  *
  */
 

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	weight.cpp
- * @date	22 September 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Weight Class for Neural Network
+ * @file   weight.cpp
+ * @date   22 September 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Weight Class for Neural Network
  *
  */
 

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file	weight.h
- * @date	22 September 2020
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Parichay Kapoor <pk.kapoor@samsung.com>
- * @bug		No known bugs except for NYI items
- * @brief	This is Weight Class for Neural Network
+ * @file   weight.h
+ * @date   22 September 2020
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Weight Class for Neural Network
  *
  */
 

--- a/test/unittest/unittest_nntrainer_appcontext.cpp
+++ b/test/unittest/unittest_nntrainer_appcontext.cpp
@@ -2,11 +2,11 @@
 /**
  * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
- * @file	 unittest_app_context.h
- * @date	 9 November 2020
- * @brief	 This file contains app context related functions and classes that
+ * @file   unittest_app_context.h
+ * @date   9 November 2020
+ * @brief  This file contains app context related functions and classes that
  * manages the global configuration of the current environment
- * @see		 https://github.com/nnstreamer/nntrainer
+ * @see    https://github.com/nnstreamer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug    No known bugs except for NYI items
  *

--- a/test/unittest/unittest_nntrainer_lazy_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_lazy_tensor.cpp
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-/* Copyright (C) 2020 Jihoon Lee <jihoon.it.lee@samsung.com>
+/**
+ * Copyright (C) 2020 Jihoon Lee <jihoon.it.lee@samsung.com>
  *
- * @file	unittest_nntrainer_lazy_tensor.cpp
- * @date	05 Jun 2020
- * @brief	A unittest for nntrainer_lazy_tensor
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jihoon Lee <jihoon.it.lee@samsung.com>
- * @bug		No known bugs except for NYI items
- *
+ * @file   unittest_nntrainer_lazy_tensor.cpp
+ * @date   05 Jun 2020
+ * @brief  A unittest for nntrainer_lazy_tensor
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jihoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
  */
 #include <gtest/gtest.h>
 

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2020 Jihoon Lee <jihoon.it.lee@samsung.com>
  *
- * @file	unittest_nntrainer_models.cpp
- * @date	19 Oct 2020
- * @brief	Model multi iteration, itegrated test
- * @see		https://github.com/nnstreamer/nntrainer
- * @author	Jihoon Lee <jihoon.it.lee@samsung.com>
- * @bug		No known bugs except for NYI items
+ * @file   unittest_nntrainer_models.cpp
+ * @date   19 Oct 2020
+ * @brief  Model multi iteration, itegrated test
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jihoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
  *
  */
 #include <algorithm>


### PR DESCRIPTION
Change tab indents to spaces in the SPDX identifier.
Resolves #1083

Signed-off-by: Juyeong Lee <2jy22@naver.com>