### PR TITLE
[model] Update Layer with LayerNode

### DIFF
--- a/Applications/Custom/LayerClient/jni/main.cpp
+++ b/Applications/Custom/LayerClient/jni/main.cpp
@@ -199,7 +199,7 @@ int main(int argc, char *argv[]) {
     /// registerFactory excepts a function that returns unique_ptr<Layer> from
     /// std::vector<std::string> ml::train::createLayer<T> is a templated
     /// function for generic usage
-    app_context.registerFactory(ml::train::createLayer<custom::PowLayer>);
+    app_context.registerFactory(nntrainer::createLayer<custom::PowLayer>);
   } catch (std::invalid_argument &e) {
     std::cerr << "failed to register factory, reason: " << e.what()
               << std::endl;

--- a/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
@@ -19,7 +19,7 @@
 
 #include <app_context.h>
 #include <layer.h>
-#include <layer_node.h>
+#include <layer_internal.h>
 
 const char *NNTRAINER_PATH = std::getenv("NNTRAINER_PATH");
 

--- a/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
@@ -19,7 +19,7 @@
 
 #include <app_context.h>
 #include <layer.h>
-#include <layer_internal.h>
+#include <layer_node.h>
 
 const char *NNTRAINER_PATH = std::getenv("NNTRAINER_PATH");
 
@@ -30,7 +30,7 @@ TEST(AppContext, DlRegisterOpen_p) {
 
   ac.registerLayer("libpow_layer.so", NNTRAINER_PATH);
 
-  auto layer = ac.createObject<ml::train::Layer>("pow");
+  auto layer = ac.createObject<nntrainer::Layer>("pow");
 
   EXPECT_EQ(layer->getType(), "pow");
 }
@@ -50,7 +50,7 @@ TEST(AppContext, DlRegisterDirectory_p) {
 
   ac.registerLayerFromDirectory(NNTRAINER_PATH);
 
-  auto layer = ac.createObject<ml::train::Layer>("pow");
+  auto layer = ac.createObject<nntrainer::Layer>("pow");
 
   EXPECT_EQ(layer->getType(), "pow");
 }
@@ -65,11 +65,10 @@ TEST(AppContext, DlRegisterDirectory_n) {
 TEST(AppContext, DefaultEnvironmentPath_p) {
   /// as NNTRAINER_PATH is fed to the test, this should success without an
   /// error
-  auto l = ml::train::createLayer("pow");
+  std::shared_ptr<ml::train::Layer> l = ml::train::createLayer("pow");
   EXPECT_EQ(l->getType(), "pow");
 
-  std::unique_ptr<nntrainer::Layer> layer(
-    static_cast<nntrainer::Layer *>(l.release()));
+  auto layer = nntrainer::getLayerDevel(l);
 
   std::ifstream input_file("does_not_exist");
   EXPECT_NO_THROW(layer->read(input_file));

--- a/Applications/Custom/pow.cpp
+++ b/Applications/Custom/pow.cpp
@@ -21,6 +21,9 @@ namespace custom {
 const std::string PowLayer::type = "pow";
 namespace PowUtil {
 
+/**
+ * @brief Entry structure for handling properties
+ */
 struct Entry {
   std::string key;
   std::string value;
@@ -136,13 +139,13 @@ void PowLayer::calcDerivative() {
 
 #ifdef PLUGGABLE
 
-ml::train::Layer *create_pow_layer() {
+nntrainer::Layer *create_pow_layer() {
   auto layer = new PowLayer();
   std::cout << "power created\n";
   return layer;
 }
 
-void destory_pow_layer(ml::train::Layer *layer) {
+void destory_pow_layer(nntrainer::Layer *layer) {
   std::cout << "power deleted\n";
   delete layer;
 }

--- a/Applications/Embedding/jni/main.cpp
+++ b/Applications/Embedding/jni/main.cpp
@@ -19,13 +19,13 @@
 #include <iostream>
 #include <sstream>
 #include <stdlib.h>
-#include <tensor.h>
 #include <time.h>
 
 #include <dataset.h>
-#include <layer_node.h>
+#include <layer_internal.h>
 #include <ml-api-common.h>
 #include <neuralnet.h>
+#include <tensor.h>
 
 std::string data_file;
 

--- a/Applications/Embedding/jni/main.cpp
+++ b/Applications/Embedding/jni/main.cpp
@@ -15,15 +15,17 @@
  */
 
 #include <cmath>
-#include <dataset.h>
 #include <fstream>
 #include <iostream>
-#include <ml-api-common.h>
-#include <neuralnet.h>
 #include <sstream>
 #include <stdlib.h>
 #include <tensor.h>
 #include <time.h>
+
+#include <dataset.h>
+#include <layer_node.h>
+#include <ml-api-common.h>
+#include <neuralnet.h>
 
 std::string data_file;
 
@@ -181,8 +183,10 @@ int main(int argc, char *argv[]) {
    */
   std::vector<std::vector<float>> inputVector, outputVector;
   nntrainer::NeuralNetwork NN;
-  std::shared_ptr<nntrainer::Layer> layer;
-  std::shared_ptr<nntrainer::Layer> layer_fc;
+  std::shared_ptr<ml::train::Layer> layer;
+  std::shared_ptr<ml::train::Layer> layer_fc;
+  std::shared_ptr<nntrainer::Layer> layer_;
+  std::shared_ptr<nntrainer::Layer> layer_fc_;
   std::string name = "embedding";
   std::string fc_name = "outputlayer";
   nntrainer::Tensor weight;
@@ -205,7 +209,10 @@ int main(int argc, char *argv[]) {
     NN.getLayer(name.c_str(), &layer);
     NN.getLayer(fc_name.c_str(), &layer_fc);
 
-    weight = layer->getWeights()[0].getVariable();
+    layer_ = nntrainer::getLayerDevel(layer);
+    layer_fc_ = nntrainer::getLayerDevel(layer_fc);
+
+    weight = layer_->getWeights()[0].getVariable();
     weight.print(std::cout);
 
   } catch (...) {
@@ -226,11 +233,11 @@ int main(int argc, char *argv[]) {
     // std::string name = "embedding";
     // NN.getLayer(name.c_str(), &layer);
 
-    weight = layer->getWeights()[0].getVariable();
+    weight = layer_->getWeights()[0].getVariable();
     weight.print(std::cout);
 
     nntrainer::Tensor golden(1, 1, 15, 8);
-    
+
     try {
       loadFile("embedding_weight_golden.out", golden);
       golden.print(std::cout);
@@ -238,7 +245,8 @@ int main(int argc, char *argv[]) {
       nntrainer::Tensor weight_out_fc(1, 1, 32, 1);
       loadFile("fc_weight_golden.out", weight_out_fc);
       weight_out_fc.print(std::cout);
-      weight_fc = layer_fc->getWeights()[0].getVariable();
+
+      weight_fc = layer_fc_->getWeights()[0].getVariable();
       weight_fc.print(std::cout);
     } catch (...) {
       std::cerr << "Error during loadFile\n";

--- a/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
+++ b/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
@@ -514,7 +514,7 @@ int main(int argc, char **argv) {
         writeFile << "mainNet Loss : " << mainNet.getLoss()
                   << " : targetNet Loss : " << targetNet.getLoss() << "\n";
         std::cout << "\n\n =================== TRAINIG & COPY NET "
-                    "==================\n\n";
+                     "==================\n\n";
         std::cout << "mainNet Loss : ";
         std::cout.width(15);
         std::cout << mainNet.getLoss() << "\n targetNet Loss : ";

--- a/Applications/SimpleShot/task_runner.cpp
+++ b/Applications/SimpleShot/task_runner.cpp
@@ -223,11 +223,11 @@ int main(int argc, char **argv) {
 
   try {
     app_context.registerFactory(
-      ml::train::createLayer<simpleshot::layers::CenteringLayer>);
+      nntrainer::createLayer<simpleshot::layers::CenteringLayer>);
     app_context.registerFactory(
-      ml::train::createLayer<simpleshot::layers::L2NormLayer>);
+      nntrainer::createLayer<simpleshot::layers::L2NormLayer>);
     app_context.registerFactory(
-      ml::train::createLayer<simpleshot::layers::CentroidKNN>);
+      nntrainer::createLayer<simpleshot::layers::CentroidKNN>);
   } catch (std::exception &e) {
     std::cerr << "registering factory failed: " << e.what();
     return 1;

--- a/Applications/SimpleShot/test/simpleshot_centering_test.cpp
+++ b/Applications/SimpleShot/test/simpleshot_centering_test.cpp
@@ -16,7 +16,7 @@
 #include <memory>
 
 #include <app_context.h>
-#include <layer_node.h>
+#include <layer_internal.h>
 #include <manager.h>
 #include <nntrainer_test_util.h>
 

--- a/Applications/SimpleShot/test/simpleshot_centering_test.cpp
+++ b/Applications/SimpleShot/test/simpleshot_centering_test.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 
 #include <app_context.h>
+#include <layer_node.h>
 #include <manager.h>
 #include <nntrainer_test_util.h>
 
@@ -34,12 +35,12 @@ TEST(centering, simple_functions) {
   file.close();
 
   auto &app_context = nntrainer::AppContext::Global();
-  app_context.registerFactory(ml::train::createLayer<CenteringLayer>);
+  app_context.registerFactory(nntrainer::createLayer<CenteringLayer>);
 
-  auto c = app_context.createObject<ml::train::Layer>(
+  auto c = app_context.createObject<nntrainer::Layer>(
     "centering", {"feature_path=feature.bin", "input_shape=1:1:4"});
 
-  std::unique_ptr<CenteringLayer> layer(
+  std::shared_ptr<CenteringLayer> layer(
     static_cast<CenteringLayer *>(c.release()));
 
   nntrainer::Manager manager;

--- a/Applications/SimpleShot/test/simpleshot_centroid_knn.cpp
+++ b/Applications/SimpleShot/test/simpleshot_centroid_knn.cpp
@@ -25,9 +25,9 @@ namespace layers {
 
 TEST(centroid_knn, simple_functions) {
   auto &app_context = nntrainer::AppContext::Global();
-  app_context.registerFactory(ml::train::createLayer<CentroidKNN>);
+  app_context.registerFactory(nntrainer::createLayer<CentroidKNN>);
 
-  auto c = app_context.createObject<ml::train::Layer>(
+  auto c = app_context.createObject<nntrainer::Layer>(
     "centroid_knn", {"num_class=5", "input_shape=1:1:3"});
 
   std::unique_ptr<CentroidKNN> layer(static_cast<CentroidKNN *>(c.release()));

--- a/Applications/SimpleShot/test/simpleshot_l2norm_test.cpp
+++ b/Applications/SimpleShot/test/simpleshot_l2norm_test.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 
 #include <app_context.h>
+#include <layer_node.h>
 #include <manager.h>
 #include <nntrainer_test_util.h>
 
@@ -25,13 +26,12 @@ namespace layers {
 
 TEST(l2norm, simple_functions) {
   auto &app_context = nntrainer::AppContext::Global();
-  app_context.registerFactory(ml::train::createLayer<L2NormLayer>);
+  app_context.registerFactory(nntrainer::createLayer<L2NormLayer>);
 
   auto c =
-    app_context.createObject<ml::train::Layer>("l2norm", {"input_shape=1:1:4"});
+    app_context.createObject<nntrainer::Layer>("l2norm", {"input_shape=1:1:4"});
 
-  std::unique_ptr<nntrainer::Layer> layer(
-    static_cast<nntrainer::Layer *>(c.release()));
+  std::unique_ptr<L2NormLayer> layer(static_cast<L2NormLayer *>(c.release()));
 
   nntrainer::Manager manager;
   manager.setInferenceInOutMemoryOptimization(false);

--- a/Applications/SimpleShot/test/simpleshot_l2norm_test.cpp
+++ b/Applications/SimpleShot/test/simpleshot_l2norm_test.cpp
@@ -15,7 +15,7 @@
 #include <memory>
 
 #include <app_context.h>
-#include <layer_node.h>
+#include <layer_internal.h>
 #include <manager.h>
 #include <nntrainer_test_util.h>
 

--- a/api/ccapi/src/factory.cpp
+++ b/api/ccapi/src/factory.cpp
@@ -41,7 +41,12 @@ std::unique_ptr<Layer> createLayer(const LayerType &type,
 std::unique_ptr<Layer> createLayer(const std::string &type,
                                    const std::vector<std::string> &properties) {
   auto &ac = nntrainer::AppContext::Global();
-  return ac.createObject<Layer>(type, properties);
+  std::shared_ptr<nntrainer::Layer> nntr_layer =
+    ac.createObject<nntrainer::Layer>(type, properties);
+  std::unique_ptr<nntrainer::LayerNode> layer =
+    std::make_unique<nntrainer::LayerNode>(nntr_layer);
+
+  return layer;
 }
 
 std::unique_ptr<Optimizer>
@@ -58,7 +63,9 @@ createOptimizer(const OptimizerType &type,
 static std::unique_ptr<Layer>
 createLoss(nntrainer::LossType type,
            const std::vector<std::string> &properties) {
-  std::unique_ptr<Layer> layer = nntrainer::createLoss(type);
+  std::shared_ptr<nntrainer::Layer> nntr_layer = nntrainer::createLoss(type);
+  std::unique_ptr<nntrainer::LayerNode> layer =
+    std::make_unique<nntrainer::LayerNode>(nntr_layer);
 
   if (layer->setProperty(properties) != ML_ERROR_NONE)
     throw std::invalid_argument("Set properties failed for layer");

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -102,6 +102,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/tensor_dim.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/blas_interface.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/layer.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/layers/layer_node.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/layer_factory.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/input_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/output_layer.cpp \

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -197,56 +197,56 @@ static void add_default_object(AppContext &ac) {
                      "unknown", OptType::UNKNOWN);
 
   using LayerType = ml::train::LayerType;
-  ac.registerFactory(ml::train::createLayer<InputLayer>, InputLayer::type,
+  ac.registerFactory(nntrainer::createLayer<InputLayer>, InputLayer::type,
                      LayerType::LAYER_IN);
-  ac.registerFactory(ml::train::createLayer<FullyConnectedLayer>,
+  ac.registerFactory(nntrainer::createLayer<FullyConnectedLayer>,
                      FullyConnectedLayer::type, LayerType::LAYER_FC);
-  ac.registerFactory(ml::train::createLayer<BatchNormalizationLayer>,
+  ac.registerFactory(nntrainer::createLayer<BatchNormalizationLayer>,
                      BatchNormalizationLayer::type, LayerType::LAYER_BN);
-  ac.registerFactory(ml::train::createLayer<Conv2DLayer>, Conv2DLayer::type,
+  ac.registerFactory(nntrainer::createLayer<Conv2DLayer>, Conv2DLayer::type,
                      LayerType::LAYER_CONV2D);
-  ac.registerFactory(ml::train::createLayer<Pooling2DLayer>,
+  ac.registerFactory(nntrainer::createLayer<Pooling2DLayer>,
                      Pooling2DLayer::type, LayerType::LAYER_POOLING2D);
-  ac.registerFactory(ml::train::createLayer<FlattenLayer>, FlattenLayer::type,
+  ac.registerFactory(nntrainer::createLayer<FlattenLayer>, FlattenLayer::type,
                      LayerType::LAYER_FLATTEN);
-  ac.registerFactory(ml::train::createLayer<ActivationLayer>,
+  ac.registerFactory(nntrainer::createLayer<ActivationLayer>,
                      ActivationLayer::type, LayerType::LAYER_ACTIVATION);
-  ac.registerFactory(ml::train::createLayer<AdditionLayer>, AdditionLayer::type,
+  ac.registerFactory(nntrainer::createLayer<AdditionLayer>, AdditionLayer::type,
                      LayerType::LAYER_ADDITION);
-  ac.registerFactory(ml::train::createLayer<OutputLayer>, OutputLayer::type,
+  ac.registerFactory(nntrainer::createLayer<OutputLayer>, OutputLayer::type,
                      LayerType::LAYER_MULTIOUT);
-  ac.registerFactory(ml::train::createLayer<ConcatLayer>, ConcatLayer::type,
+  ac.registerFactory(nntrainer::createLayer<ConcatLayer>, ConcatLayer::type,
                      LayerType::LAYER_CONCAT);
-  ac.registerFactory(ml::train::createLayer<LossLayer>, LossLayer::type,
+  ac.registerFactory(nntrainer::createLayer<LossLayer>, LossLayer::type,
                      LayerType::LAYER_LOSS);
-  ac.registerFactory(ml::train::createLayer<PreprocessFlipLayer>,
+  ac.registerFactory(nntrainer::createLayer<PreprocessFlipLayer>,
                      PreprocessFlipLayer::type,
                      LayerType::LAYER_PREPROCESS_FLIP);
-  ac.registerFactory(ml::train::createLayer<PreprocessTranslateLayer>,
+  ac.registerFactory(nntrainer::createLayer<PreprocessTranslateLayer>,
                      PreprocessTranslateLayer::type,
                      LayerType::LAYER_PREPROCESS_TRANSLATE);
 #ifdef ENABLE_NNSTREAMER_BACKBONE
-  ac.registerFactory(ml::train::createLayer<NNStreamerLayer>,
+  ac.registerFactory(nntrainer::createLayer<NNStreamerLayer>,
                      NNStreamerLayer::type,
                      LayerType::LAYER_BACKBONE_NNSTREAMER);
 #endif
 #ifdef ENABLE_TFLITE_BACKBONE
-  ac.registerFactory(ml::train::createLayer<TfLiteLayer>, TfLiteLayer::type,
+  ac.registerFactory(nntrainer::createLayer<TfLiteLayer>, TfLiteLayer::type,
                      LayerType::LAYER_BACKBONE_TFLITE);
 #endif
-  ac.registerFactory(ml::train::createLayer<EmbeddingLayer>,
+  ac.registerFactory(nntrainer::createLayer<EmbeddingLayer>,
                      EmbeddingLayer::type, LayerType::LAYER_EMBEDDING);
 
-  ac.registerFactory(ml::train::createLayer<RNNLayer>, RNNLayer::type,
+  ac.registerFactory(nntrainer::createLayer<RNNLayer>, RNNLayer::type,
                      LayerType::LAYER_RNN);
 
-  ac.registerFactory(ml::train::createLayer<LSTMLayer>, LSTMLayer::type,
+  ac.registerFactory(nntrainer::createLayer<LSTMLayer>, LSTMLayer::type,
                      LayerType::LAYER_LSTM);
 
-  ac.registerFactory(ml::train::createLayer<TimeDistLayer>, TimeDistLayer::type,
+  ac.registerFactory(nntrainer::createLayer<TimeDistLayer>, TimeDistLayer::type,
                      LayerType::LAYER_TIME_DIST);
 
-  ac.registerFactory(AppContext::unknownFactory<ml::train::Layer>, "unknown",
+  ac.registerFactory(AppContext::unknownFactory<nntrainer::Layer>, "unknown",
                      LayerType::LAYER_UNKNOWN);
 }
 
@@ -338,15 +338,15 @@ int AppContext::registerLayer(const std::string &library_path,
     << func_tag << "custom layer must specify type name, but it is empty";
   pluggable->destroyfunc(layer);
 
-  FactoryType<ml::train::Layer> factory_func =
+  FactoryType<nntrainer::Layer> factory_func =
     [pluggable](const PropsType &prop) {
-      std::unique_ptr<ml::train::Layer> layer =
+      std::unique_ptr<nntrainer::Layer> layer =
         std::make_unique<internal::PluggedLayer>(pluggable);
 
       return layer;
     };
 
-  return registerFactory<ml::train::Layer>(factory_func, type);
+  return registerFactory<nntrainer::Layer>(factory_func, type);
 }
 
 std::vector<int>

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -65,7 +65,10 @@ public:
 
   template <typename... Ts> using FactoryMap = std::tuple<IndexType<Ts>...>;
 
-  AppContext(){};
+  /**
+   * @brief   Default constructor
+   */
+  AppContext() = default;
 
   /**
    *
@@ -133,6 +136,19 @@ public:
    */
   const std::string getWorkingPath(const std::string &path = "");
 
+  /**
+   * @brief Factory register function, use this function to register custom
+   * object
+   *
+   * @tparam T object to create. Currently Optimizer, Layer is supported
+   * @param factory factory function that creates std::unique_ptr<T>
+   * @param key key to access the factory, if key is empty, try to find key by
+   * calling factory({})->getType();
+   * @param int_key key to access the factory by integer, if it is -1(default),
+   * the function automatically unsigned the key and return
+   * @return const int unique integer value to access the current factory
+   * @throw invalid argument when key and/or int_key is already taken
+   */
   template <typename T>
   const int registerFactory(const PtrFactoryType<T> factory,
                             const std::string &key = "",
@@ -262,7 +278,7 @@ public:
   }
 
 private:
-  FactoryMap<ml::train::Optimizer, ml::train::Layer> factory_map;
+  FactoryMap<ml::train::Optimizer, nntrainer::Layer> factory_map;
   std::string working_path_base;
 };
 

--- a/nntrainer/dataset/databuffer_func.h
+++ b/nntrainer/dataset/databuffer_func.h
@@ -49,7 +49,7 @@ public:
   /**
    * @brief     Destructor
    */
-  ~DataBufferFromCallback(){};
+  ~DataBufferFromCallback() = default;
 
   /**
    * @brief     Initialize Buffer

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -404,9 +404,8 @@ int NetworkGraph::addLossLayer(const LossType loss_type) {
       return ML_ERROR_NOT_SUPPORTED;
     }
 
-    /// TODO: the last entry in adj and sorted are not same
-    adj.pop_back();
     Sorted.pop_back();
+    adj.erase(adj.begin() + last_node->getIndex());
 
     switch (last_node->getObject()->getActivationType()) {
     case ActivationType::ACT_SIGMOID:
@@ -421,11 +420,13 @@ int NetworkGraph::addLossLayer(const LossType loss_type) {
     }
   }
 
-  /// @note this assumes that loss layer only supports single input
   last_node = Sorted.back();
 
-  /// TODO: need to find all the nodes whose entry matches with node remove and
-  /// update them all
+  /**
+   * Remove all the connections for the current lasy layer as it will now only
+   * connect with the new loss layer to be added.
+   * @note this assumes that loss layer only supports single input
+   */
   if (updated_loss_type == LossType::LOSS_ENTROPY_SIGMOID ||
       updated_loss_type == LossType::LOSS_ENTROPY_SOFTMAX)
     adj[last_node->getIndex()].resize(1);

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -24,6 +24,7 @@
 #include <sstream>
 
 #include <layer_internal.h>
+#include <layer_node.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <parse_util.h>
@@ -414,5 +415,9 @@ void Layer::print(std::ostream &out, unsigned int flags) {
     printMetric(out);
   }
 };
+
+std::shared_ptr<Layer> getLayerDevel(std::shared_ptr<ml::train::Layer> l) {
+  return std::static_pointer_cast<LayerNode>(l)->getObject();
+}
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -759,6 +759,14 @@ std::unique_ptr<Layer> createLayer(const std::vector<std::string> &props = {}) {
   return ptr;
 }
 
+/**
+ * @brief   Get Layer devel from ml::train::Layer
+ *
+ * @param   l Layer object
+ * @return  Layer devel object
+ */
+std::shared_ptr<Layer> getLayerDevel(std::shared_ptr<ml::train::Layer> l);
+
 } // namespace nntrainer
 
 #endif /* __cplusplus */

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   layer_node.cpp
+ * @date   1 April 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the layer node for network graph
+ */
+
+#include <layer_node.h>
+
+namespace nntrainer {
+
+std::shared_ptr<Layer> getLayerDevel(std::shared_ptr<ml::train::Layer> l) {
+  std::shared_ptr<LayerNode> lnode = std::static_pointer_cast<LayerNode>(l);
+
+  std::shared_ptr<Layer> &layer = lnode->getObject();
+
+  return layer;
+}
+
+}; // namespace nntrainer

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -12,14 +12,4 @@
 
 #include <layer_node.h>
 
-namespace nntrainer {
-
-std::shared_ptr<Layer> getLayerDevel(std::shared_ptr<ml::train::Layer> l) {
-  std::shared_ptr<LayerNode> lnode = std::static_pointer_cast<LayerNode>(l);
-
-  std::shared_ptr<Layer> &layer = lnode->getObject();
-
-  return layer;
-}
-
-}; // namespace nntrainer
+namespace nntrainer {}; // namespace nntrainer

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -2,12 +2,12 @@
 /**
  * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file   graph_node.h
+ * @file   layer_node.h
  * @date   1 April 2021
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  This is the graph node interface for c++ API
+ * @brief  This is the layer node for network graph
  */
 
 #ifndef __LAYER_NODE_H__
@@ -26,10 +26,15 @@ namespace nntrainer {
 class LayerNode : public ml::train::Layer, public GraphNode {
 public:
   /**
+   * @brief     Default constructor
+   */
+  LayerNode() : LayerNode(nullptr) {}
+
+  /**
    * @brief     Constructor of LayerNode class
    *
    */
-  LayerNode(std::shared_ptr<nntrainer::Layer> l, size_t idx) :
+  LayerNode(std::shared_ptr<nntrainer::Layer> l, size_t idx = 0) :
     layer(l),
     index(idx),
     flatten(false),
@@ -40,6 +45,11 @@ public:
    *
    */
   ~LayerNode() = default;
+
+  /**
+   * @brief     Set the index for the node
+   */
+  void setIndex(size_t idx) { index = idx; }
 
   /**
    * Support all the interface requirements by ml::train::Layer
@@ -109,6 +119,7 @@ public:
 #endif
 
 private:
+  // TODO: make this unique_ptr once getObject API is removed
   std::shared_ptr<nntrainer::Layer>
     layer;      /**< The actual object in the graph node */
   size_t index; /**< index of each node */
@@ -119,6 +130,14 @@ private:
   ActivationType
     activation_type; /**< activation applied to the output of this node */
 };
+
+/**
+ * @brief   Get Layer devel from ml::train::Layer
+ *
+ * @param   l Layer object
+ * @return  Layer devel object
+ */
+std::shared_ptr<Layer> getLayerDevel(std::shared_ptr<ml::train::Layer> l);
 
 } // namespace nntrainer
 #endif // __LAYER_NODE_H__

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -131,13 +131,5 @@ private:
     activation_type; /**< activation applied to the output of this node */
 };
 
-/**
- * @brief   Get Layer devel from ml::train::Layer
- *
- * @param   l Layer object
- * @return  Layer devel object
- */
-std::shared_ptr<Layer> getLayerDevel(std::shared_ptr<ml::train::Layer> l);
-
 } // namespace nntrainer
 #endif // __LAYER_NODE_H__

--- a/nntrainer/layers/meson.build
+++ b/nntrainer/layers/meson.build
@@ -11,6 +11,7 @@ layer_sources = [
   'output_layer.cpp',
   'layer.cpp',
   'layer_factory.cpp',
+  'layer_node.cpp',
   'loss_layer.cpp',
   'pooling2d_layer.cpp',
   'preprocess_flip_layer.cpp',

--- a/nntrainer/layers/plugged_layer.h
+++ b/nntrainer/layers/plugged_layer.h
@@ -37,7 +37,7 @@ public:
   PluggedLayer(const nntrainer::LayerPluggable *pluggable) :
     /// @todo we won't need dynamic pointer cast here after api is fully
     /// implemented
-    layerImpl(dynamic_cast<nntrainer::Layer *>(pluggable->createfunc())),
+    layerImpl(pluggable->createfunc()),
     destroy_func(pluggable->destroyfunc) {
     NNTR_THROW_IF(layerImpl == nullptr, std::invalid_argument)
       << "either create_func_ failed or cannot dynamic cast to layer_internal";

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -40,7 +40,7 @@
 #include <fc_layer.h>
 #include <flatten_layer.h>
 #include <input_layer.h>
-#include <layer_internal.h>
+#include <layer_node.h>
 #include <loss_layer.h>
 #include <manager.h>
 #include <ml-api-common.h>
@@ -78,8 +78,8 @@ class NeuralNetwork : public ml::train::Model {
   friend class ModelLoader; /** access private members of ModelLoader */
 
 public:
-  using NodeType = std::shared_ptr<Layer>; /** Type of a Node */
-  using GraphType = std::vector<NodeType>; /** actual graph type */
+  using NodeType = std::shared_ptr<LayerNode>; /** Type of a Node */
+  using GraphType = std::vector<NodeType>;     /** actual graph type */
   using FlatGraphType =
     std::vector<NodeType>; /** topological sorted, iterable 1-D list of nodes */
   using NetworkGraphType = nntrainer::NetworkGraph;
@@ -301,7 +301,7 @@ public:
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
   int addLayer(std::shared_ptr<ml::train::Layer> layer) {
-    return addLayer(std::static_pointer_cast<Layer>(layer));
+    return addLayer(std::static_pointer_cast<LayerNode>(layer));
   }
 
   /**
@@ -371,7 +371,7 @@ public:
    * @note these layers will be in sorted order if the model is compiled,
    * otherwise the order is the order of addition of layers in the model.
    */
-  FlatGraphType getFlatGraph() { return model_graph.getLayers(); }
+  FlatGraphType getFlatGraph() { return model_graph.getLayerNodes(); }
 
   /**
    * @brief     get network graph

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -34,6 +34,7 @@ makeGraph(const std::vector<LayerReprentation> &layer_reps) {
   auto graph = std::make_shared<nntrainer::GraphRepresentation>();
 
   for (const auto &layer_representation : layer_reps) {
+    /// @todo Use unique_ptr here
     std::shared_ptr<nntrainer::Layer> nntr_layer =
       ac.createObject<nntrainer::Layer>(layer_representation.first,
                                         layer_representation.second);

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -34,9 +34,12 @@ makeGraph(const std::vector<LayerReprentation> &layer_reps) {
   auto graph = std::make_shared<nntrainer::GraphRepresentation>();
 
   for (const auto &layer_representation : layer_reps) {
-    std::shared_ptr<ml::train::Layer> layer = ac.createObject<ml::train::Layer>(
-      layer_representation.first, layer_representation.second);
-    graph->addLayer(std::static_pointer_cast<nntrainer::Layer>(layer));
+    std::shared_ptr<nntrainer::Layer> nntr_layer =
+      ac.createObject<nntrainer::Layer>(layer_representation.first,
+                                        layer_representation.second);
+    std::shared_ptr<nntrainer::LayerNode> layer =
+      std::make_unique<nntrainer::LayerNode>(nntr_layer);
+    graph->addLayer(layer);
   }
 
   return graph;
@@ -59,8 +62,8 @@ auto ini_interpreter =
  */
 static void graphEqual(const nntrainer::GraphRepresentation &lhs,
                        const nntrainer::GraphRepresentation &rhs) {
-  auto layers = lhs.getLayers();
-  auto ref_layers = rhs.getLayers();
+  const auto &layers = lhs.getLayerNodes();
+  const auto &ref_layers = rhs.getLayerNodes();
   EXPECT_EQ(layers.size(), ref_layers.size());
 
   auto is_node_equal = [](const nntrainer::Layer &l,
@@ -79,7 +82,7 @@ static void graphEqual(const nntrainer::GraphRepresentation &lhs,
 
   if (layers.size() == ref_layers.size()) {
     for (unsigned int i = 0; i < layers.size(); ++i) {
-      is_node_equal(*layers[i], *ref_layers[i]);
+      is_node_equal(*layers[i]->getObject(), *ref_layers[i]->getObject());
     }
   }
 }

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -454,14 +454,16 @@ TEST(nntrainerIniTest, backbone_p_05) {
   EXPECT_EQ(flat_backbone.size(), flat_direct.size());
 
   for (size_t idx = 0; idx < flat_backbone.size(); idx++) {
-    EXPECT_EQ(flat_backbone[idx]->getType(), flat_direct[idx]->getType());
-    EXPECT_EQ(flat_backbone[idx]->getInputDimension(),
-              flat_direct[idx]->getInputDimension());
-    EXPECT_EQ(flat_backbone[idx]->getOutputDimension(),
-              flat_direct[idx]->getOutputDimension());
-    EXPECT_EQ(flat_backbone[idx]->getActivationType(),
-              flat_direct[idx]->getActivationType());
-    EXPECT_EQ(flat_backbone[idx]->getName(), flat_direct[idx]->getName());
+    auto &backbone_layer = flat_backbone[idx]->getObject();
+    auto &direct_layer = flat_direct[idx]->getObject();
+    EXPECT_EQ(backbone_layer->getType(), direct_layer->getType());
+    EXPECT_EQ(backbone_layer->getInputDimension(),
+              direct_layer->getInputDimension());
+    EXPECT_EQ(backbone_layer->getOutputDimension(),
+              direct_layer->getOutputDimension());
+    EXPECT_EQ(backbone_layer->getActivationType(),
+              direct_layer->getActivationType());
+    EXPECT_EQ(backbone_layer->getName(), direct_layer->getName());
   }
 }
 

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -385,7 +385,7 @@ GraphWatcher::GraphWatcher(const std::string &config, const bool opt) :
   std::vector<NodeType> graph = model_graph.getSorted();
 
   for (auto it = graph.begin(); it != graph.end() - 1; ++it) {
-    nodes.push_back(NodeWatcher((*it)));
+    nodes.push_back(NodeWatcher(*it));
   }
 
   loss_node = NodeWatcher(graph.back());


### PR DESCRIPTION
Update API to create LayerNode instead of Layer
Internally updated implementation to use this as LayerNode
and extract layer from inside it when needed.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>