### PR TITLE
[Fix] Reorder error in layernode

### DIFF
--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -30,10 +30,10 @@ public:
    *
    */
   LayerNode(std::shared_ptr<nntrainer::Layer> l, size_t idx) :
-    activation_type(ActivationType::ACT_NONE),
-    flatten(false),
     layer(l),
-    index(idx) {}
+    index(idx),
+    flatten(false),
+    activation_type(ActivationType::ACT_NONE) {}
 
   /**
    * @brief     Destructor of LayerNode Class


### PR DESCRIPTION
- [Fix] Reorder error in layernode 

```
This patch fixes trivial build warning which is treated as error.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

resolves #1147 