### PR TITLE
[Android] Add tflite interpreter option

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -3,6 +3,15 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
 ENABLE_TFLITE_BACKBONE := 1
+ENABLE_TFLITE_INTERPRETER := 1
+
+NEED_TF_LITE := 0
+
+ifeq ($(ENABLE_TFLITE_BACKBONE), 1)
+NEED_TF_LITE := 1
+else ifeq ($(ENABLE_TFLITE_INTERPRETER), 1)
+NEED_TF_LITE := 1
+endif
 
 ifndef NNTRAINER_ROOT
 NNTRAINER_ROOT := $(LOCAL_PATH)/..
@@ -31,7 +40,7 @@ include $(CLEAR_VARS)
 NNTRAINER_JNI_ROOT := $(NNTRAINER_ROOT)/jni
 
 # Build tflite if its backbone is enabled
-ifeq ($(ENABLE_TFLITE_BACKBONE),1)
+ifeq ($(NEED_TF_LITE),1)
 $(warning BUILDING TFLITE BACKBONE !)
 TENSORFLOW_VERSION := 2.3.0
 
@@ -62,7 +71,7 @@ LOCAL_EXPORT_LDLIBS := -lEGL -lGLESv2
 
 include $(PREBUILT_STATIC_LIBRARY)
 
-endif #ENABLE_TFLITE_BACKBONE
+endif #NEED_TF_LITE
 
 ifeq ($(ENABLE_BLAS), 1)
 include $(CLEAR_VARS)
@@ -138,9 +147,12 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/node_exporter.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/base_properties.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/ini_interpreter.cpp \
-                  $(NNTRAINER_ROOT)/nntrainer/compiler/tflite_opnode.cpp \
-                  $(NNTRAINER_ROOT)/nntrainer/compiler/tflite_interpreter.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/app_context.cpp
+
+ifeq ($(ENABLE_TFLITE_INTERPRETER), 1)
+NNTRAINER_SRCS += $(NNTRAINER_ROOT)/nntrainer/compiler/tflite_opnode.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/compiler/tflite_interpreter.cpp
+endif #ENABLE_TFLITE_INTERPRETER
 
 # Add tflite backbone building
 ifeq ($(ENABLE_TFLITE_BACKBONE),1)
@@ -183,6 +195,10 @@ ifeq ($(ENABLE_TFLITE_BACKBONE),1)
 LOCAL_STATIC_LIBRARIES += tensorflow-lite
 LOCAL_CFLAGS += -DENABLE_TFLITE_BACKBONE=1
 endif #ENABLE_TFLITE_BACKBONE
+
+ifeq ($(ENABLE_TFLITE_INTERPRETER), 1)
+LOCAL_CFLAGS += -DENABLE_TFLITE_INTERPRETER
+endif #ENABLE_TFLITE_INTERPRETER
 
 # Enable Profile
 ifeq ($(ENABLE_PROFILE), 1)

--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -285,9 +285,9 @@ void IniGraphInterpreter::serialize(
     layer->export_to(e);
 
     const auto key_val_pairs =
-      e.get_result<ExportMethods::METHOD_STRINGVECTOR>();
+      e.getResult<ExportMethods::METHOD_STRINGVECTOR>();
 
-    for (const auto &pair : key_val_pairs) {
+    for (const auto &pair : *key_val_pairs) {
       s.setEntry(pair.first, pair.second);
     }
 

--- a/nntrainer/compiler/tflite_opnode.cpp
+++ b/nntrainer/compiler/tflite_opnode.cpp
@@ -16,14 +16,6 @@
 
 namespace nntrainer {
 
-TfOpNode::TfOpNode(const Layer &layer) : TfOpNode() {
-  setInOut(layer);
-  setInputs(layer.getInputRef());
-  setOutputs(layer.getOutputRef());
-  setWeights(layer.getWeightsRef());
-  setOpType(layer.getType());
-}
-
 void TfOpNode::setInOut(const Layer &layer) {
   auto &in = layer.getInputLayers();
   is_input = std::find(in.begin(), in.end(), "__data__") != in.end();
@@ -51,18 +43,6 @@ void TfOpNode::setWeights(const std::vector<Weight> &weights_) {
   weights.reserve(weights_.size());
   std::transform(weights_.begin(), weights_.end(), std::back_inserter(weights),
                  [](const auto &data) { return &data; });
-}
-
-void TfOpNode::setOpType(const std::string &type) {
-
-  if (istrequal(type, FullyConnectedLayer::type)) {
-    setOpType(tflite::BuiltinOperator_FULLY_CONNECTED);
-    setBuiltinOptions(tflite::BuiltinOptions_FullyConnectedOptions,
-                      flatbuffers::Offset<void>());
-    return;
-  }
-
-  throw std::invalid_argument("not supported type");
 }
 
 void TfOpNode::setBuiltinOptions(

--- a/nntrainer/compiler/tflite_opnode.h
+++ b/nntrainer/compiler/tflite_opnode.h
@@ -38,14 +38,6 @@ public:
   TfOpNode() = default;
 
   /**
-   * @brief Construct a new Tf Op Node object from layer
-   * @note this is a shortcut to skip if layer does not need to be devided or
-   * fused
-   * @param layer layer that is converted to TfOpNode
-   */
-  TfOpNode(const Layer &layer);
-
-  /**
    * @brief Check and set if layer has model in/out
    *
    * @param layer layer to check
@@ -75,15 +67,10 @@ public:
 
   /**
    * @brief Set the Op Type object
-   * @todo Considering number of alternatives to optimize this, for now it is
-   * just workable.
-   * 1. add and maintain global unordered map
-   * 2. Save information in the appcontext later we can retrieve
-   * 3. let type be an immutable property and let exporter handle this instead
-   * of this method (preferrable)
-   * @param type type to convert
+   *
+   * @param op_type_ operation type
    */
-  void setOpType(const std::string &type);
+  void setOpType(tflite::BuiltinOperator op_type_) { op_type = op_type_; }
 
   /**
    * @brief Set the Builtin Options object,
@@ -170,13 +157,6 @@ public:
   }
 
 private:
-  /**
-   * @brief Set the Op Type object
-   *
-   * @param op_type_ operation type
-   */
-  void setOpType(tflite::BuiltinOperator op_type_) { op_type = op_type_; }
-
   Variables inputs;  /**< input variables */
   Variables outputs; /**< output variables */
   Variables weights; /**< weight variables */

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -76,7 +76,7 @@ int FullyConnectedLayer::initialize(Manager &manager) {
 void FullyConnectedLayer::export_to(Exporter &exporter,
                                     ExportMethods method) const {
   Layer::export_to(exporter, method);
-  exporter.save_result(fc_props, method);
+  exporter.saveResult(fc_props, method, this);
 }
 
 void FullyConnectedLayer::setProperty(const PropertyType type,

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -332,7 +332,7 @@ public:
   virtual void
   export_to(Exporter &exporter,
             ExportMethods method = ExportMethods::METHOD_STRINGVECTOR) const {
-    exporter.save_result(layer_props, ExportMethods::METHOD_STRINGVECTOR);
+    exporter.saveResult(layer_props, method, this);
   };
 
   /**

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -9,19 +9,63 @@
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug No known bugs except for NYI items
  */
-
 #include <node_exporter.h>
+
+#ifdef ENABLE_TFLITE_INTERPRETER
+#include <common_properties.h>
+#include <fc_layer.h>
+#include <tf_schema_generated.h>
+#include <tflite_opnode.h>
+#endif
 
 namespace nntrainer {
 
-template <>
-const std::vector<std::pair<std::string, std::string>> &
-Exporter::get_result<ExportMethods::METHOD_STRINGVECTOR>() {
-  if (!is_exported) {
-    throw std::invalid_argument("This exporter has not exported anything yet");
-  }
+/**
+ * @brief Construct a new Exporter object
+ *
+ */
+Exporter::Exporter() = default;
 
-  return stored_result;
+/**
+ * @brief Destroy the Exporter object
+ *
+ */
+Exporter::~Exporter() = default;
+
+template <>
+std::unique_ptr<std::vector<std::pair<std::string, std::string>>>
+Exporter::getResult<ExportMethods::METHOD_STRINGVECTOR>() noexcept {
+  return std::move(stored_result);
 }
+
+#ifdef ENABLE_TFLITE_INTERPRETER
+template <>
+std::unique_ptr<TfOpNode>
+Exporter::getResult<ExportMethods::METHOD_TFLITE>() noexcept {
+  return std::move(tf_node);
+}
+
+template <>
+void Exporter::saveTflResult(const std::tuple<props::Name> &props,
+                             const Layer *self) {
+  createIfNull(tf_node);
+  tf_node->setInOut(*self);
+  tf_node->setInputs(self->getInputRef());
+  tf_node->setOutputs(self->getOutputRef());
+}
+
+template <>
+void Exporter::saveTflResult(const std::tuple<props::Unit> &props,
+                             const FullyConnectedLayer *self) {
+  createIfNull(tf_node);
+
+  tf_node->setWeights(self->getWeightsRef());
+
+  tf_node->setOpType(tflite::BuiltinOperator_FULLY_CONNECTED);
+  /// we probably going to need flatbuffer inside exporter regarding this
+  tf_node->setBuiltinOptions(tflite::BuiltinOptions_FullyConnectedOptions,
+                             flatbuffers::Offset<void>());
+}
+#endif
 
 } // namespace nntrainer

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -9,6 +9,7 @@
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug No known bugs except for NYI items
  */
+#include <memory>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -22,6 +23,12 @@
 #define __NODE_EXPORTER_H__
 
 namespace nntrainer {
+
+/**
+ * @brief Forward declaration of TfOpNode
+ *
+ */
+class TfOpNode;
 
 /**
  * @brief Defines Export Method to be called with
@@ -50,6 +57,28 @@ template <ExportMethods method> struct return_type { using type = void; };
 template <> struct return_type<ExportMethods::METHOD_STRINGVECTOR> {
   using type = std::vector<std::pair<std::string, std::string>>;
 };
+
+/**
+ * @brief meta function to check return type when the method is string vector
+ *
+ * @tparam specialized so not given
+ */
+template <> struct return_type<ExportMethods::METHOD_TFLITE> {
+  using type = TfOpNode;
+};
+
+/**
+ * @brief Create a empty ptr if null
+ *
+ * @tparam T type to create
+ * @param[in/out] ptr ptr to create
+ */
+template <typename T> void createIfNull(std::unique_ptr<T> &ptr) {
+  if (ptr == nullptr) {
+    ptr = std::make_unique<T>();
+  }
+}
+
 } // namespace
 
 /**
@@ -64,37 +93,47 @@ public:
    * @brief Construct a new Exporter object
    *
    */
-  Exporter() : is_exported(false){};
+  Exporter();
+
+  /**
+   * @brief Destroy the Exporter object
+   *
+   */
+  ~Exporter();
 
   /**
    * @brief this function iterates over the property and process the property in
    * a designated way.
    *
    * @tparam Ts type of elements
+   * @tparam NodeType NodeType element
    * @param props tuple that contains properties
    * @param method method to export
+   * @param self this pointer to the layer which is being exported
    */
-  template <typename... Ts>
-  void save_result(const std::tuple<Ts...> &props, ExportMethods method) {
+  template <typename... Ts, typename NodeType = void>
+  void saveResult(const std::tuple<Ts...> &props, ExportMethods method,
+                  const NodeType *self = nullptr) {
     switch (method) {
-
     case ExportMethods::METHOD_STRINGVECTOR: {
+      createIfNull(stored_result);
 
       /**
-       * @brief function to pass to the iterate_prop, this saves the property to
-       * stored_result
+       * @brief function to pass to the iterate_prop, this saves the property
+       * to stored_result
        *
        * @param prop property property to pass
        * @param index index of the current property
        */
       auto callable = [this](auto &&prop, size_t index) {
         std::string key = getPropKey(prop);
-        stored_result.emplace_back(std::move(key), to_string(prop));
+        stored_result->emplace_back(key, to_string(prop));
       };
       iterate_prop(callable, props);
     } break;
     case ExportMethods::METHOD_TFLITE:
-    /// fall thorugh intended (NYI!!)
+      saveTflResult(props, self);
+      break;
     case ExportMethods::METHOD_UNDEFINED:
     /// fall thorugh intended
     default:
@@ -106,23 +145,82 @@ public:
 
   /**
    * @brief Get the result object
+   * @note @a unique_ptr here will be a member of @a this. The ownership is
+   * passed to the caller, thus after getResult, the target member is cleared.
+   * This is intended design choice to mimic single function call, between @a
+   * saveResult and @a getResult
    *
    * @tparam methods method to get
    * @tparam T appropriate return type regarding the export method
-   * @return T T
+   * @return std::unique_ptr<T> predefined return type according to the method.
+   * @retval nullptr not exported
    */
   template <ExportMethods methods,
             typename T = typename return_type<methods>::type>
-  const T &get_result();
+  std::unique_ptr<T> getResult() noexcept;
 
 private:
-  std::vector<std::pair<std::string, std::string>>
+  /**
+   * @brief ProtoType to enable saving result to tfnode
+   *
+   * @tparam PropsType propsType PropsType to receive with self
+   * @tparam NodeType NodeType of current layer.
+   * @param props properties to get with @a self
+   * @param self @a this of the current layer
+   */
+  template <typename PropsType, typename NodeType>
+  void saveTflResult(const PropsType &props, const NodeType *self);
+
+#ifdef ENABLE_TFLITE_INTERPRETER
+  std::unique_ptr<TfOpNode> tf_node; /**< created node from the export */
+#endif
+
+  std::unique_ptr<std::vector<std::pair<std::string, std::string>>>
     stored_result; /**< stored result */
 
   /// consider changing this to a promise / future if there is a async function
-  /// involved to `save_result`
+  /// involved to `saveResult`
   bool is_exported; /**< boolean to check if exported */
 };
+
+/**
+ * @brief ProtoType to enable saving result to tfnode
+ *
+ * @tparam PropsType propsType PropsType to receive with self
+ * @tparam NodeType NodeType of current layer.
+ * @param props properties to get with @a self
+ * @param self @a this of the current layer
+ */
+template <typename PropsType, typename NodeType>
+void Exporter::saveTflResult(const PropsType &props, const NodeType *self) {
+  NNTR_THROW_IF(true, nntrainer::exception::not_supported)
+    << "given node cannot be converted to tfnode";
+}
+
+#ifdef ENABLE_TFLITE_INTERPRETER
+namespace props {
+class Name;
+class Unit;
+} // namespace props
+
+class Layer;
+/**
+ * @copydoc template <typename PropsType, typename NodeType> void
+ * Exporter::saveTflResult(const PropsType &props, const NodeType *self);
+ */
+template <>
+void Exporter::saveTflResult(const std::tuple<props::Name> &props,
+                             const Layer *self);
+
+class FullyConnectedLayer;
+/**
+ * @copydoc template <typename PropsType, typename NodeType> void
+ * Exporter::saveTflResult(const PropsType &props, const NodeType *self);
+ */
+template <>
+void Exporter::saveTflResult(const std::tuple<props::Unit> &props,
+                             const FullyConnectedLayer *self);
+#endif
 
 /**
  * @brief base case of iterate_prop, iterate_prop iterates the given tuple

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -75,8 +75,8 @@ static void graphEqual(const nntrainer::GraphRepresentation &lhs,
 
     /*** fixme, there is one caveat that order matters in this form */
     EXPECT_EQ(
-      lhs_export.get_result<nntrainer::ExportMethods::METHOD_STRINGVECTOR>(),
-      rhs_export.get_result<nntrainer::ExportMethods::METHOD_STRINGVECTOR>());
+      *lhs_export.getResult<nntrainer::ExportMethods::METHOD_STRINGVECTOR>(),
+      *rhs_export.getResult<nntrainer::ExportMethods::METHOD_STRINGVECTOR>());
   };
 
   if (lhs.size() == rhs.size()) {

--- a/test/unittest/unittest_base_properties.cpp
+++ b/test/unittest/unittest_base_properties.cpp
@@ -173,15 +173,16 @@ TEST(BasicProperty, valid_p) {
     auto props = std::make_tuple(NumBanana(), QualityOfBanana());
 
     nntrainer::Exporter e;
-    e.save_result(props, nntrainer::ExportMethods::METHOD_STRINGVECTOR);
+    e.saveResult(props, nntrainer::ExportMethods::METHOD_STRINGVECTOR);
 
-    auto result = e.get_result<nntrainer::ExportMethods::METHOD_STRINGVECTOR>();
+    auto result =
+      std::move(e.getResult<nntrainer::ExportMethods::METHOD_STRINGVECTOR>());
 
     auto pair = std::pair<std::string, std::string>("num_banana", "1");
-    EXPECT_EQ(result[0], pair);
+    EXPECT_EQ(result->at(0), pair);
 
     auto pair2 = std::pair<std::string, std::string>("quality_banana", "");
-    EXPECT_EQ(result[1], pair2);
+    EXPECT_EQ(result->at(1), pair2);
   }
 
   { /**< export from layer */
@@ -189,11 +190,12 @@ TEST(BasicProperty, valid_p) {
     nntrainer::Exporter e;
     layer.export_to(e);
 
-    auto result = e.get_result<nntrainer::ExportMethods::METHOD_STRINGVECTOR>();
+    auto result =
+      std::move(e.getResult<nntrainer::ExportMethods::METHOD_STRINGVECTOR>());
     auto pair0 = std::pair<std::string, std::string>("name", "");
-    EXPECT_EQ(result[0], pair0);
+    EXPECT_EQ(result->at(0), pair0);
     auto pair1 = std::pair<std::string, std::string>("unit", "1");
-    EXPECT_EQ(result[1], pair1);
+    EXPECT_EQ(result->at(1), pair1);
   }
 
   { /**< load from layer */
@@ -316,7 +318,7 @@ TEST(Exporter, invalidMethods_n) {
   auto props = std::make_tuple(NumBanana(), QualityOfBanana());
 
   nntrainer::Exporter e;
-  EXPECT_THROW(e.save_result(props, nntrainer::ExportMethods::METHOD_UNDEFINED),
+  EXPECT_THROW(e.saveResult(props, nntrainer::ExportMethods::METHOD_UNDEFINED),
                nntrainer::exception::not_supported);
 }
 
@@ -325,10 +327,10 @@ TEST(Exporter, notExported_n) {
 
   nntrainer::Exporter e;
   /// intended comment
-  // e.save_result(props, nntrainer::ExportMethods::METHOD_STRINGVECTOR);
+  // e.saveResult(props, nntrainer::ExportMethods::METHOD_STRINGVECTOR);
 
-  EXPECT_THROW(e.get_result<nntrainer::ExportMethods::METHOD_STRINGVECTOR>(),
-               std::invalid_argument);
+  EXPECT_EQ(e.getResult<nntrainer::ExportMethods::METHOD_STRINGVECTOR>(),
+            nullptr);
 }
 
 /**


### PR DESCRIPTION
- [Android] Add tflite interpreter option

```
This patch add tflite interpreter option to ndk build

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [Refactor] Delegate tfNode creation to exporter

```
This patch enables delegating exporting logic to exporter.
Note that this is supposed to be 1:1 mapping, if it has to be m:n
mapping, it should be directly handled by the interpreter, which
actually can see the node.

Also s/`save_result`/`saveResult` and `get_result`/`getResult`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```