### PR TITLE
[Props] Separate base_propeties to a source

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -132,6 +132,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/parse_util.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/profiler.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/node_exporter.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/utils/base_properties.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/ini_interpreter.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/tflite_interpreter.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/app_context.cpp

--- a/nntrainer/utils/base_properties.cpp
+++ b/nntrainer/utils/base_properties.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file base_properties.cpp
+ * @date 03 May 2021
+ * @brief Convenient property type definition for automated serialization
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <base_properties.h>
+
+#include <string>
+
+namespace nntrainer {
+
+template <>
+std::string
+str_converter<str_prop_tag, std::string>::to_string(const std::string &value) {
+  return value;
+}
+
+template <>
+std::string str_converter<str_prop_tag, std::string>::from_string(
+  const std::string &value) {
+  return value;
+}
+
+template <>
+std::string str_converter<int_prop_tag, int>::to_string(const int &value) {
+  return std::to_string(value);
+}
+
+template <>
+int str_converter<int_prop_tag, int>::from_string(const std::string &value) {
+  return std::stoi(value);
+}
+
+template <>
+std::string str_converter<uint_prop_tag, unsigned int>::to_string(
+  const unsigned int &value) {
+  return std::to_string(value);
+}
+
+template <>
+unsigned int str_converter<uint_prop_tag, unsigned int>::from_string(
+  const std::string &value) {
+  return std::stoul(value);
+}
+} // namespace nntrainer

--- a/nntrainer/utils/meson.build
+++ b/nntrainer/utils/meson.build
@@ -3,7 +3,8 @@ util_sources = [
   'util_func.cpp',
   'profiler.cpp',
   'ini_wrapper.cpp',
-  'node_exporter.cpp'
+  'node_exporter.cpp',
+  'base_properties.cpp'
 ]
 
 util_headers = [


### PR DESCRIPTION
- [Props] Separate base_propeties to a source

```
This patch separate base_properties into some specialization to source
file

The purpose is to save compile time and redundant doxygen, and clean up
length header.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```