### PR TITLE
[graph] Add graph core class 

### DIFF
--- a/nntrainer/graph/graph_core.cpp
+++ b/nntrainer/graph/graph_core.cpp
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file    network_graph.h
+ * @date    12 May 2020
+ * @see     https://github.com/nnstreamer/nntrainer
+ * @author  Jijoong Moon <jijoong.moon@samsung.com>
+ * @author  Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug     No known bugs except for NYI items
+ * @brief   This is Graph Core Class for Neural Network
+ *
+ */
+
+#include <algorithm>
+#include <sstream>
+
+#include <graph_core.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+
+namespace nntrainer {
+
+void GraphCore::removeEdges() {
+  /**
+   * remove all edges to save memory.
+   * NodeList is kept for now for O(1) access of nodes by idx.
+   */
+  for (unsigned int i = 0; i < adj.size(); ++i) {
+    /**
+     * As this resize is guaranteed to not insert new elements, create a
+     * default element needed by resize.
+     */
+    adj[i].resize(1);
+  }
+}
+
+void GraphCore::addGraphNode(std::shared_ptr<GraphNode> node) {
+  node->setIndex(adj.size());
+  adj.push_back(std::list<std::shared_ptr<GraphNode>>({node}));
+}
+
+std::shared_ptr<GraphNode> &GraphCore::getGraphNode(unsigned int ith) {
+  if (ith >= size())
+    throw std::invalid_argument("Exceed total number of nodes");
+
+  if (adj[ith].front()->getIndex() != ith)
+    throw std::runtime_error("Graph internal index mismatch");
+
+  return adj[ith].front();
+}
+
+std::shared_ptr<GraphNode> &GraphCore::getSortedGraphNode(unsigned int ith) {
+  if (ith >= getSorted().size())
+    throw std::invalid_argument("Exceed total number of nodes");
+
+  return getSorted()[ith];
+}
+
+void GraphCore::topologicalSortUtil(
+  unsigned int ith, std::vector<bool> &visited,
+  std::stack<std::shared_ptr<GraphNode>> &Stack) {
+  visited[ith] = true;
+
+  std::list<std::shared_ptr<GraphNode>>::iterator i;
+  for (i = adj[ith].begin(); i != adj[ith].end(); ++i) {
+    auto index = (*i)->getIndex();
+    if (!visited[index])
+      topologicalSortUtil(index, visited, Stack);
+  }
+
+  Stack.push(getGraphNode(ith));
+}
+
+void GraphCore::topologicalSort() {
+  std::stack<std::shared_ptr<GraphNode>> Stack;
+  std::vector<bool> visited(adj.size());
+  Sorted.clear();
+
+  std::fill(visited.begin(), visited.end(), false);
+
+  // Quite likely this is not needed - verify this
+  // TODO : After make node list of graph, we have to find root. (That means it
+  // should be the only one input for now.). Need to support multiple input and
+  // support search.
+
+  for (unsigned int i = 0; i < adj.size(); ++i) {
+    if (visited[i] == false) {
+      topologicalSortUtil(i, visited, Stack);
+    }
+  }
+
+  while (Stack.empty() == false) {
+    Sorted.push_back(Stack.top());
+    Stack.pop();
+  }
+}
+
+std::shared_ptr<GraphNode> &GraphCore::getGraphNode(const std::string &name) {
+  for (auto &lnode_list : adj) {
+    auto &lnode = lnode_list.front();
+    if (lnode->getName() == name)
+      return lnode;
+  }
+
+  std::stringstream ss;
+  ss << "Cannot find graph node: " << name;
+  throw std::invalid_argument(ss.str());
+}
+
+void GraphCore::addEdge(unsigned int ith, std::shared_ptr<GraphNode> &node) {
+  if (ith >= adj.size())
+    throw std::invalid_argument("Exceed total number of nodes");
+
+  adj[ith].push_back(node);
+}
+
+std::vector<std::shared_ptr<GraphNode>> GraphCore::getGraphNodes() const {
+  std::vector<std::shared_ptr<GraphNode>> ret;
+  if (!Sorted.empty()) {
+    std::transform(Sorted.begin(), Sorted.end(), std::back_inserter(ret),
+                   [](auto const &elem) { return elem; });
+  } else {
+    std::transform(adj.begin(), adj.end(), std::back_inserter(ret),
+                   [](auto const &elem) { return elem.front(); });
+  }
+
+  return ret;
+}
+
+void GraphCore::addNode(std::shared_ptr<GraphNode> node) {
+  /** Ensure that the node has a name and is unique */
+  ensureName(node);
+
+  /** Insert the node to the graph */
+  addGraphNode(node);
+}
+
+const std::vector<std::shared_ptr<GraphNode>> &GraphCore::getSorted() const {
+  if (Sorted.empty())
+    throw std::runtime_error("Cannot get sorted graph before topologicalSort");
+
+  return Sorted;
+}
+
+std::vector<std::shared_ptr<GraphNode>> &GraphCore::getSorted() {
+  if (Sorted.empty())
+    throw std::runtime_error("Cannot get sorted graph before topologicalSort");
+
+  return Sorted;
+}
+
+void GraphCore::ensureName(std::shared_ptr<GraphNode> &node,
+                           const std::string &prefix,
+                           const std::string &postfix, bool force_rename) {
+  std::string orig_name = node->getName();
+  bool orig_name_empty = orig_name.empty();
+  /** If node already has name which is unique and valid, and force is
+   * disabled, then nothing to do.
+   */
+  if (!orig_name_empty && !force_rename &&
+      node_names.end() == node_names.find(orig_name)) {
+    node_names.insert(orig_name);
+    return;
+  }
+
+  /** If just prefix with node name makes it unique - directly set the name */
+  if (!orig_name_empty) {
+    std::string direct_name = prefix + orig_name + postfix;
+    if (node_names.find(direct_name) == node_names.end()) {
+      node->setName(direct_name);
+      node_names.insert(direct_name);
+      return;
+    }
+  }
+
+  std::set<std::string>::iterator iter;
+  std::string name;
+  if (orig_name_empty) {
+    orig_name = node->getType();
+  }
+
+  std::string direct_name = prefix + orig_name + postfix;
+
+  do {
+    name = direct_name + std::to_string(def_name_count++);
+    iter = node_names.find(name);
+  } while (iter != node_names.end());
+
+  node->setName(name);
+  node_names.insert(name);
+}
+
+} /* namespace nntrainer */

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file    network_graph.h
+ * @date    12 May 2020
+ * @see     https://github.com/nnstreamer/nntrainer
+ * @author  Jijoong Moon <jijoong.moon@samsung.com>
+ * @author  Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug     No known bugs except for NYI items
+ * @brief   This is Graph Core Class for Neural Network
+ *
+ */
+
+#ifndef __GRAPH_CORE_H__
+#define __GRAPH_CORE_H__
+#ifdef __cplusplus
+
+#include <iostream>
+#include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <stack>
+#include <vector>
+
+#include <graph_node.h>
+
+namespace nntrainer {
+
+/**
+ * @class   Graph Core Class
+ * @brief   Graph Core Class which provides core graph functionalities
+ */
+class GraphCore {
+
+public:
+  /**
+   * @brief     Iterators to traverse the GraphCore object
+   */
+  typedef typename std::vector<std::shared_ptr<GraphNode>>::const_iterator
+    const_iterator;
+  typedef
+    typename std::vector<std::shared_ptr<GraphNode>>::const_reverse_iterator
+      const_reverse_iterator;
+
+  /**
+   * @brief     Constructor of Graph Core Class
+   */
+  GraphCore() : def_name_count(0) {}
+
+  /**
+   * @brief Add the given node into Graph
+   * @param[in] node shared_ptr of node
+   */
+  void addNode(std::shared_ptr<GraphNode> node);
+
+  /**
+   * @brief getter of number of nodes
+   * @param[out] number of nodes
+   */
+  unsigned int size() const {
+    if (Sorted.empty())
+      return adj.size();
+    else
+      return Sorted.size();
+  }
+
+  /**
+   * @brief get if the graph is empty
+   * @param[out] true if empty, else false
+   */
+  bool empty() const {
+    if (Sorted.empty())
+      return adj.empty();
+    else
+      return Sorted.empty();
+  }
+
+  /**
+   * @brief     Swap function for the class
+   */
+  friend void swap(GraphCore &lhs, GraphCore &rhs) {
+    using std::swap;
+
+    swap(lhs.adj, rhs.adj);
+    swap(lhs.Sorted, rhs.Sorted);
+  }
+
+  /**
+   * @brief     reset the graph
+   */
+  void reset() {
+    adj.clear();
+    Sorted.clear();
+  }
+
+  /**
+   * @brief getter of GraphNode with index number
+   * @param[in] index
+   * @ret GraphNode
+   */
+  std::shared_ptr<GraphNode> &getGraphNode(unsigned int ith);
+
+  /**
+   * @brief getter of Sorted GraphNode with index number
+   * @param[in] index
+   * @ret GraphNode
+   */
+  std::shared_ptr<GraphNode> &getSortedGraphNode(unsigned int ith);
+
+  /**
+   * @brief getter of GraphNode with node name
+   * @param[in] node name
+   * @retval GraphNode
+   */
+  std::shared_ptr<GraphNode> &getGraphNode(const std::string &name);
+
+  /**
+   * @brief getter all the node nodes in the model
+   * @retval node nodes
+   * @note these node nodes will be in sorted order if the model is compiled,
+   * otherwise the order is the order of addition of node nodes in the model.
+   * TODO: deprecate this
+   */
+  std::vector<std::shared_ptr<GraphNode>> getGraphNodes() const;
+
+  /**
+   * @brief     join passed graph into the existing graph model
+   * @param[in] graph graph to be added/to extend
+   * @param[in] prefix prefix added to names of nodes from this graph
+   * @note It is assumed that this model is valid by itself
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   *
+   * @todo rename to addnodes
+   */
+  void extendGraph(std::vector<std::shared_ptr<GraphNode>> graph,
+                   std::string &prefix);
+
+  /**
+   * @brief     getter of ordered graph
+   * @retval    ordered GraphNode list
+   * TODO: deprecate this
+   */
+  const std::vector<std::shared_ptr<GraphNode>> &getSorted() const;
+
+  /**
+   * @brief     getter of ordered graph
+   * @retval    ordered GraphNode list
+   * TODO: deprecate this
+   */
+  std::vector<std::shared_ptr<GraphNode>> &getSorted();
+
+  /**
+   * @brief     get begin iterator for the forwarding
+   * @retval    const iterator marking the begin of forwarding
+   */
+  inline const_iterator cbegin() { return Sorted.cbegin(); }
+
+  /**
+   * @brief     get end iterator for the forwarding
+   * @retval    const iterator marking the emd of forwarding
+   */
+  inline const_iterator cend() { return Sorted.cend(); }
+
+  /**
+   * @brief     get begin iterator for the backwarding
+   * @retval    const reverse iterator marking the begin of backwarding
+   */
+  inline const_reverse_iterator crbegin() { return Sorted.crbegin(); }
+
+  /**
+   * @brief     get end iterator for the backwarding
+   * @retval    const reverse iterator marking the end of backwarding
+   */
+  inline const_reverse_iterator crend() { return Sorted.crend(); }
+
+  /**
+   * @brief Sorting and Define order to calculate : Depth First Search
+   */
+  void topologicalSort();
+
+  /**
+   * @brief     Copy the graph
+   * @param[in] from Graph Object to copy
+   * @retval    Graph Object copyed
+   */
+  GraphCore &copy(GraphCore &from) {
+    // if (this != &from) {
+    //   // FIXME: this assumes elements already in nodes/adj, solve that
+    //   for (unsigned int i = 0; i < adj.size(); i++)
+    //     adj[i].front()->getObject()->copy(from.adj[i].front()->getObject());
+    // }
+    return *this;
+  }
+
+  /**
+   * @brief add Edge between graph nodes
+   * @param[in] ith Node index : From
+   * @param[in] node GraphNode object to be added : To
+   */
+  void addEdge(unsigned int ith, std::shared_ptr<GraphNode> &node);
+
+  /**
+   * @brief     make connection between nodes
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int connectGraph();
+
+  /**
+   * @brief     remove all the edges from the graph
+   *
+   */
+  void removeEdges();
+
+  /**
+   * @brief     Ensure that node has a name.
+   * @param[in] node GraphNode whose name is to be ensured to be valid
+   * @param[in] prefix Prefix to be attached to the node name
+   * @param[in] postfix Postfix to be attached to the node name
+   * @param[in] force_rename If the node must be forcefully rename
+   * @details   Ensures that the node has a unique and a valid name. A valid
+   * name pre-assigned to the node can be changed if force_rename is enabled.
+   */
+  void ensureName(std::shared_ptr<GraphNode> &node,
+                  const std::string &prefix = "",
+                  const std::string &postfix = "", bool force_rename = false);
+
+private:
+  std::vector<std::list<std::shared_ptr<GraphNode>>>
+    adj; /**< adjacency list for graph */
+  std::vector<std::shared_ptr<GraphNode>> Sorted; /**< Ordered Node List  */
+  std::set<std::string>
+    node_names;       /**< Set containing all the names of nodes in the model */
+  int def_name_count; /**< Count assigned to node names declared by default */
+
+  /**
+   * @brief     topological sort
+   * @param[in] ith index of GraphNode
+   * @param[in] visited temp list
+   * @param[in] stack for Node list to visit.
+   */
+  void topologicalSortUtil(unsigned int ith, std::vector<bool> &visited,
+                           std::stack<std::shared_ptr<GraphNode>> &Stack);
+
+  /**
+   * @brief     make connection for the given node idx
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  void connectGraph(unsigned int adj_idx);
+
+  /**
+   * @brief     set output connections for all the nodes
+   */
+  void setOutputLayers();
+
+  /**
+   * @brief Add given GraphNode to the Graph
+   * @param[in] node shared_ptr of GraphNode
+   */
+  void addGraphNode(std::shared_ptr<GraphNode> node);
+};
+
+} // namespace nntrainer
+
+#endif /* __cplusplus */
+#endif /* __NETWORK_GRAPH_H__ */

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -40,7 +40,7 @@ public:
    * @brief     Set index of the node
    *
    */
-  // virtual void setIndex(size_t) = 0;
+  virtual void setIndex(size_t) = 0;
 
   /**
    * @brief     Get the Name of the underlying object
@@ -54,30 +54,10 @@ public:
    * @brief     Set the Name of the underlying object
    *
    * @param[in] std::string Name for the underlying object
-   * @note name of each node in the graph must be unique
-   *
-   * @todo make it work with setProperty
+   * @note name of each node in the graph must be unique, and caller must ensure
+   * that
    */
-  // virtual int setName(std::string name) = 0;
-
-  /**
-   * @brief     Get the trainable property of the underlying object
-   *
-   * @return boolean true if trainable, else false
-   */
-  virtual bool getTrainable() noexcept = 0;
-
-  /**
-   * @brief     Set the properties for the node
-   *
-   * @param[in] properties properties of the node
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   *
-   * @note this shouldn't be virtual, this became virtual to support custom
-   * layer. should be reverted after layer.h can fully support custom layer
-   */
-  virtual int setProperty(std::vector<std::string> properties) = 0;
+  virtual int setName(const std::string &name) = 0;
 
   /**
    * @brief     Get the Type of the underlying object
@@ -85,6 +65,13 @@ public:
    * @return const std::string type representation
    */
   virtual const std::string getType() const = 0;
+
+  /**
+   * @brief     Copy the graph
+   * @param[in] from Graph Object to copy
+   * @retval    Graph Object copyed
+   */
+  // virtual GraphNode &copy(const GraphNode &from) = 0;
 };
 
 } // namespace nntrainer

--- a/nntrainer/graph/meson.build
+++ b/nntrainer/graph/meson.build
@@ -1,5 +1,6 @@
 layer_sources = [
   'network_graph.cpp',
+  'graph_core.cpp'
 ]
 
 layer_headers = [

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -11,8 +11,8 @@
  *
  */
 
-#ifndef __NETWORK_GRAPH_H_
-#define __NETWORK_GRAPH_H_
+#ifndef __NETWORK_GRAPH_H__
+#define __NETWORK_GRAPH_H__
 #ifdef __cplusplus
 
 #include <iostream>

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -69,11 +69,20 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    * @details   This function accepts vector of properties in the format -
-   *  { std::string property_name, void * property_val, ...}
+   *  { std::string property_name=property_val, ...}
    */
   int setProperty(std::vector<std::string> properties) {
     return layer->setProperty(properties);
   }
+
+  /**
+   * @brief     set name of layer
+   *
+   * @param[in] name Name of the layer
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   */
+  int setName(const std::string &name) { return setProperty({"name=" + name}); }
 
   /**
    * @brief     Get name of the layer


### PR DESCRIPTION
Add graph core class
This is mainly separating the existing implementation of core part
of the graph from NetworkGraph.
This patch does not contain new implementation but mostly contain
borrowed implementation from existing graph.

See Also #1176

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>