### PR TITLE
[Props] Add Name validator and unittest

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -122,6 +122,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/lstm.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/time_dist.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/acti_func.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/layers/common_properties.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/graph/network_graph.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/optimizer_devel.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/optimizer_impl.cpp \

--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file   common_properties.cpp
+ * @date   14 May 2021
+ * @brief  This file contains implementation of common properties widely used
+ * across layers
+ * @see	   https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+#include <common_properties.h>
+
+#include <nntrainer_error.h>
+#include <parse_util.h>
+
+#include <regex>
+#include <vector>
+
+namespace nntrainer {
+namespace props {
+bool Name::isValid(const std::string &v) const {
+
+  static std::regex allowed("[a-zA-Z0-9][-_./a-zA-Z0-9]*");
+  return std::regex_match(v, allowed);
+}
+
+} // namespace props
+
+} // namespace nntrainer

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -2,12 +2,13 @@
 /**
  * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
- * @file common_properties.h
- * @date 09 April 2021
- * @brief This file contains list of common properties widely used across layers
- * @see	https://github.com/nnstreamer/nntrainer
+ * @file   common_properties.h
+ * @date   09 April 2021
+ * @brief  This file contains list of common properties widely used across
+ * layers
+ * @see	   https://github.com/nnstreamer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
- * @bug No known bugs except for NYI items
+ * @bug    No known bugs except for NYI items
  */
 
 #include <string>
@@ -30,6 +31,15 @@ public:
     nntrainer::Property<std::string>(value) {} /**< default value if any */
   static constexpr const char *key = "name";   /**< unique key to access */
   using prop_tag = str_prop_tag;               /**< property type */
+
+  /**
+   * @brief name validator
+   *
+   * @param v string to validate
+   * @return true if it contains alphanumeric and/or '-', '_', '/'
+   * @return false if it is empty or contains non-valid character
+   */
+  bool isValid(const std::string &v) const override;
 };
 
 /**

--- a/nntrainer/layers/meson.build
+++ b/nntrainer/layers/meson.build
@@ -20,7 +20,8 @@ layer_sources = [
   'rnn.cpp',
   'acti_func.cpp',
   'lstm.cpp',
-  'time_dist.cpp'
+  'time_dist.cpp',
+  'common_properties.cpp'
 ]
 
 layer_headers = [

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -35,7 +35,8 @@ test_target = [
   'unittest_nntrainer_models',
   'unittest_nntrainer_graph',
   'unittest_nntrainer_appcontext',
-  'unittest_properties',
+  'unittest_base_properties',
+  'unittest_common_properties'
 ]
 
 if get_option('enable-profile')

--- a/test/unittest/unittest_base_properties.cpp
+++ b/test/unittest/unittest_base_properties.cpp
@@ -2,7 +2,7 @@
 /**
  * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
- * @file unittest_properties.h
+ * @file unittest_base_properties.h
  * @date 09 April 2021
  * @brief This file contains test and specification of properties and exporter
  * @see	https://github.com/nnstreamer/nntrainer

--- a/test/unittest/unittest_common_properties.cpp
+++ b/test/unittest/unittest_common_properties.cpp
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file unittest_common_properties.h
+ * @date 15 May 2021
+ * @brief This file contains test and specification of properties and exporter
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <gtest/gtest.h>
+
+#include <common_properties.h>
+
+/// @todo change this to typed param test
+/// <type, list of string, value pair, list of invalid string, value pair>
+TEST(NameProperty, setPropertyValid_p) {
+  nntrainer::props::Name n;
+  EXPECT_NO_THROW(n.set("layer"));
+  EXPECT_EQ(n.get(), "layer");
+
+  EXPECT_NO_THROW(n.set("layer-"));
+  EXPECT_EQ(n.get(), "layer-");
+
+  EXPECT_NO_THROW(n.set("laye-r"));
+  EXPECT_EQ(n.get(), "laye-r");
+
+  EXPECT_NO_THROW(n.set("layer/a"));
+  EXPECT_EQ(n.get(), "layer/a");
+
+  EXPECT_NO_THROW(n.set("laye__r"));
+  EXPECT_EQ(n.get(), "laye__r");
+}
+
+TEST(NameProperty, forbiddenString_01_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set("layer "), std::invalid_argument);
+}
+
+TEST(NameProperty, forbiddenString_02_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set("layer layer"), std::invalid_argument);
+}
+
+TEST(NameProperty, forbiddenString_03_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set(" layer"), std::invalid_argument);
+}
+
+TEST(NameProperty, forbiddenString_04_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set("layer,"), std::invalid_argument);
+}
+
+TEST(NameProperty, forbiddenString_05_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set("lay,er"), std::invalid_argument);
+}
+
+TEST(NameProperty, forbiddenString_06_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set("lay, er"), std::invalid_argument);
+}
+
+TEST(NameProperty, forbiddenString_07_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set(",layer"), std::invalid_argument);
+}
+
+TEST(NameProperty, forbiddenString_08_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set("layer+"), std::invalid_argument);
+}
+
+TEST(NameProperty, forbiddenString_09_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set("la+ yer"), std::invalid_argument);
+}
+
+TEST(NameProperty, forbiddenString_10_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set("lay+er"), std::invalid_argument);
+}
+
+TEST(NameProperty, forbiddenString_11_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set("+layer"), std::invalid_argument);
+}
+
+TEST(NameProperty, forbiddenString_12_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set("+ layer"), std::invalid_argument);
+}
+
+TEST(NameProperty, mustStartWithAlphaNumeric_01_n) {
+  nntrainer::props::Name n;
+  EXPECT_THROW(n.set("+layer"), std::invalid_argument);
+}
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error duing IniGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error duing RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}


### PR DESCRIPTION
- [Props] Add Name validator and unittest

```
**Changes proposed in this PR:**
- Add name validator
- Add source file for `common_properties`
- Change name of `unittest_properties.cpp` ->
`unittest_base_properties.cpp`
- Add `unittest_common_properties.cpp`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```