### PR TITLE
[Graph] Update network graph to use graph core

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -124,6 +124,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/acti_func.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/common_properties.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/graph/network_graph.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/graph/graph_core.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/optimizer_devel.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/optimizer_impl.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/adam.cpp \

--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -273,7 +273,9 @@ void IniGraphInterpreter::serialize(
   const std::string &out) {
 
   std::vector<IniSection> sections;
-  for (const auto &ln : representation->getSorted()) {
+  for (auto iter = representation->cbegin(); iter != representation->cend();
+       iter++) {
+    const auto &ln = *iter;
     const auto &layer = ln->getObject();
 
     IniSection s(layer->getName());

--- a/nntrainer/compiler/tflite_interpreter.cpp
+++ b/nntrainer/compiler/tflite_interpreter.cpp
@@ -358,7 +358,9 @@ buildOpNodes(std::shared_ptr<const GraphRepresentation> representation) {
   TfOpNodes nodes;
   /// @todo, look ahead of layers to get nodes that can be fused
   /// we will need to have a dedicated builder
-  for (const auto &ln : representation->getSorted()) {
+  for (auto iter = representation->cbegin(); iter != representation->cend();
+       iter++) {
+    const auto &ln = *iter;
     nodes.emplace_back(*ln->getObject());
   }
 

--- a/nntrainer/graph/graph_core.cpp
+++ b/nntrainer/graph/graph_core.cpp
@@ -102,7 +102,6 @@ const std::shared_ptr<GraphNode> &
 GraphCore::getNode(const std::string &name) const {
   for (auto &lnode_list : adj) {
     auto &lnode = lnode_list.front();
-    /// TODO: make this name checking case sensitive
     if (istrequal(lnode->getName(), name))
       return lnode;
   }
@@ -149,8 +148,7 @@ void GraphCore::ensureName(GraphNode &node, const std::string &prefix,
   /** If node already has name which is unique and valid, and force is
    * disabled, then nothing to do.
    */
-  if (!orig_name_empty && !force_rename &&
-      node_names.end() == node_names.find(orig_name)) {
+  if (!orig_name_empty && !force_rename && !verifyNode(orig_name)) {
     node_names.insert(orig_name);
     return;
   }
@@ -158,7 +156,7 @@ void GraphCore::ensureName(GraphNode &node, const std::string &prefix,
   /** If just prefix with node name makes it unique - directly set the name */
   if (!orig_name_empty) {
     std::string direct_name = prefix + orig_name + postfix;
-    if (node_names.find(direct_name) == node_names.end()) {
+    if (!verifyNode(direct_name)) {
       node.setName(direct_name);
       node_names.insert(direct_name);
       return;
@@ -181,5 +179,20 @@ void GraphCore::ensureName(GraphNode &node, const std::string &prefix,
   node.setName(name);
   node_names.insert(name);
 }
+
+void GraphCore::removeLastNode() {
+  auto last_node = Sorted.back();
+  Sorted.pop_back();
+  adj.erase(adj.begin() + last_node->getIndex());
+
+  /**
+   * Remove all the connections for the current last layer as it will now only
+   */
+  /// TODO: sorted.back() is not necessarily the previous layer
+  last_node = Sorted.back();
+  adj[last_node->getIndex()].resize(1);
+}
+
+void GraphCore::addLossToSorted() { Sorted.push_back(adj.back().front()); }
 
 } /* namespace nntrainer */

--- a/nntrainer/graph/graph_core.cpp
+++ b/nntrainer/graph/graph_core.cpp
@@ -51,11 +51,12 @@ const std::shared_ptr<GraphNode> &GraphCore::getNode(unsigned int ith) const {
   return adj[ith].front();
 }
 
-const std::shared_ptr<GraphNode> &GraphCore::getSortedNode(unsigned int ith) const {
-  if (ith >= getSorted().size())
+const std::shared_ptr<GraphNode> &
+GraphCore::getSortedNode(unsigned int ith) const {
+  if (ith >= Sorted.size())
     throw std::invalid_argument("Exceed total number of nodes");
 
-  return getSorted()[ith];
+  return Sorted[ith];
 }
 
 void GraphCore::topologicalSortUtil(
@@ -97,7 +98,8 @@ void GraphCore::topologicalSort() {
   }
 }
 
-const std::shared_ptr<GraphNode> &GraphCore::getNode(const std::string &name) const {
+const std::shared_ptr<GraphNode> &
+GraphCore::getNode(const std::string &name) const {
   for (auto &lnode_list : adj) {
     auto &lnode = lnode_list.front();
     /// TODO: make this name checking case sensitive
@@ -138,20 +140,6 @@ void GraphCore::addNode(std::shared_ptr<GraphNode> node, bool ensure_name) {
 
   /** Insert the node to the graph */
   addGraphNode(node);
-}
-
-const std::vector<std::shared_ptr<GraphNode>> &GraphCore::getSorted() const {
-  if (Sorted.empty())
-    throw std::runtime_error("Cannot get sorted graph before topologicalSort");
-
-  return Sorted;
-}
-
-std::vector<std::shared_ptr<GraphNode>> &GraphCore::getSorted() {
-  if (Sorted.empty())
-    throw std::runtime_error("Cannot get sorted graph before topologicalSort");
-
-  return Sorted;
 }
 
 void GraphCore::ensureName(GraphNode &node, const std::string &prefix,

--- a/nntrainer/graph/graph_core.cpp
+++ b/nntrainer/graph/graph_core.cpp
@@ -41,7 +41,7 @@ void GraphCore::addGraphNode(std::shared_ptr<GraphNode> node) {
   adj.push_back(std::list<std::shared_ptr<GraphNode>>({node}));
 }
 
-std::shared_ptr<GraphNode> &GraphCore::getNode(unsigned int ith) {
+const std::shared_ptr<GraphNode> &GraphCore::getNode(unsigned int ith) const {
   if (ith >= size())
     throw std::invalid_argument("Exceed total number of nodes");
 
@@ -51,7 +51,7 @@ std::shared_ptr<GraphNode> &GraphCore::getNode(unsigned int ith) {
   return adj[ith].front();
 }
 
-std::shared_ptr<GraphNode> &GraphCore::getSortedNode(unsigned int ith) {
+const std::shared_ptr<GraphNode> &GraphCore::getSortedNode(unsigned int ith) const {
   if (ith >= getSorted().size())
     throw std::invalid_argument("Exceed total number of nodes");
 
@@ -97,7 +97,7 @@ void GraphCore::topologicalSort() {
   }
 }
 
-std::shared_ptr<GraphNode> &GraphCore::getNode(const std::string &name) {
+const std::shared_ptr<GraphNode> &GraphCore::getNode(const std::string &name) const {
   for (auto &lnode_list : adj) {
     auto &lnode = lnode_list.front();
     /// TODO: make this name checking case sensitive

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -95,23 +95,22 @@ public:
    * @brief getter of GraphNode with index number
    * @param[in] index
    * @ret GraphNode
-   * TODO: make this func const
    */
-  std::shared_ptr<GraphNode> &getNode(unsigned int ith);
+  const std::shared_ptr<GraphNode> &getNode(unsigned int ith) const;
 
   /**
    * @brief getter of Sorted GraphNode with index number
    * @param[in] index
    * @ret GraphNode
    */
-  std::shared_ptr<GraphNode> &getSortedNode(unsigned int ith);
+  const std::shared_ptr<GraphNode> &getSortedNode(unsigned int ith) const;
 
   /**
    * @brief getter of GraphNode with node name
    * @param[in] node name
    * @retval GraphNode
    */
-  std::shared_ptr<GraphNode> &getNode(const std::string &name);
+  const std::shared_ptr<GraphNode> &getNode(const std::string &name) const;
 
   /**
    * @brief getter all the node nodes in the model
@@ -156,8 +155,8 @@ public:
   template <
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
-  inline graph_iterator<T const> cbegin() {
-    return graph_iterator<T const>(&Sorted[0]);
+  inline graph_iterator<T const> cbegin() const {
+    return graph_iterator<T const>(&(*Sorted.cbegin()));
   }
 
   /**
@@ -167,8 +166,8 @@ public:
   template <
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
-  inline graph_iterator<T const> cend() {
-    return graph_iterator<T const>((&Sorted.back()) + 1);
+  inline graph_iterator<T const> cend() const {
+    return graph_iterator<T const>(&(*Sorted.cend()));
   }
 
   /**
@@ -178,7 +177,7 @@ public:
   template <
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
-  inline graph_reverse_iterator<T const> crbegin() {
+  inline graph_reverse_iterator<T const> crbegin() const {
     return graph_reverse_iterator<T const>(cend<T>());
   }
 
@@ -189,7 +188,7 @@ public:
   template <
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
-  inline graph_reverse_iterator<T const> crend() {
+  inline graph_reverse_iterator<T const> crend() const {
     return graph_reverse_iterator<T const>(cbegin<T>());
   }
 

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -137,12 +137,35 @@ public:
   /**
    * @brief     get begin iterator for the forwarding
    * @retval    const iterator marking the begin of forwarding
+   * TODO:      iterate over node_list if sorted is not available
    */
   template <
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
-  inline graph_iterator<T const> cbegin() const {
-    return graph_iterator<T const>(&(*Sorted.cbegin()));
+  inline graph_iterator<T> begin() {
+    return graph_iterator<T>(&(*Sorted.begin()));
+  }
+
+  /**
+   * @brief     get end iterator for the forwarding
+   * @retval    iterator marking the end of forwarding
+   */
+  template <
+    typename T = GraphNode,
+    std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
+  inline graph_iterator<T> end() {
+    return graph_iterator<T>(&(*Sorted.end()));
+  }
+
+  /**
+   * @brief     get begin iterator for the forwarding
+   * @retval    const iterator marking the begin of forwarding
+   */
+  template <
+    typename T = GraphNode,
+    std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
+  inline graph_const_iterator<T> cbegin() const {
+    return graph_const_iterator<T>(&(*Sorted.cbegin()));
   }
 
   /**
@@ -152,8 +175,8 @@ public:
   template <
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
-  inline graph_iterator<T const> cend() const {
-    return graph_iterator<T const>(&(*Sorted.cend()));
+  inline graph_const_iterator<T> cend() const {
+    return graph_const_iterator<T>(&(*Sorted.cend()));
   }
 
   /**
@@ -163,8 +186,8 @@ public:
   template <
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
-  inline graph_reverse_iterator<T const> crbegin() const {
-    return graph_reverse_iterator<T const>(cend<T>());
+  inline graph_const_reverse_iterator<T> crbegin() const {
+    return graph_const_reverse_iterator<T>(cend<T>());
   }
 
   /**
@@ -174,8 +197,8 @@ public:
   template <
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
-  inline graph_reverse_iterator<T const> crend() const {
-    return graph_reverse_iterator<T const>(cbegin<T>());
+  inline graph_const_reverse_iterator<T> crend() const {
+    return graph_const_reverse_iterator<T>(cbegin<T>());
   }
 
   /**
@@ -229,34 +252,36 @@ public:
   void ensureName(GraphNode &node, const std::string &prefix = "",
                   const std::string &postfix = "", bool force_rename = false);
 
-  void remove_last_node() {
-    auto last_node = Sorted.back();
-    Sorted.pop_back();
-    adj.erase(adj.begin() + last_node->getIndex());
+  /**
+   * @brief     Remove last node from the sorted list
+   */
+  void removeLastNode();
 
-    /**
-     * Remove all the connections for the current lasy layer as it will now only
-     */
-    last_node = Sorted.back();
-    adj[last_node->getIndex()].resize(1);
-  }
+  /**
+   * @brief     Add last node (loss node) to the last of the sorted
+   */
+  void addLossToSorted();
 
-  void addLossToSorted() { Sorted.push_back(adj.back().front()); }
-
-  bool verifyNode(const std::string &name) {
+  /**
+   * @brief     Verify if the node exists
+   */
+  inline bool verifyNode(const std::string &name) {
     if (node_names.find(name) == node_names.end())
       return false;
     return true;
   }
 
 private:
+  /// TODO: make this when needed. Till then, keep only nodelist
   std::vector<std::list<std::shared_ptr<GraphNode>>>
     adj; /**< adjacency list for graph */
-  std::vector<std::shared_ptr<GraphNode>> node_list; /**< Ordered Node List  */
 
+  std::vector<std::shared_ptr<GraphNode>>
+    node_list;                                    /**< Unordered Node List  */
   std::vector<std::shared_ptr<GraphNode>> Sorted; /**< Ordered Node List  */
   bool sorted; /** if the node_list is sorted */
 
+  /// TODO: update with unordered_set
   std::set<std::string>
     node_names;       /**< Set containing all the names of nodes in the model */
   int def_name_count; /**< Count assigned to node names declared by default */

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -135,20 +135,6 @@ public:
                    std::string &prefix);
 
   /**
-   * @brief     getter of ordered graph
-   * @retval    ordered GraphNode list
-   * TODO: deprecate this
-   */
-  const std::vector<std::shared_ptr<GraphNode>> &getSorted() const;
-
-  /**
-   * @brief     getter of ordered graph
-   * @retval    ordered GraphNode list
-   * TODO: deprecate this
-   */
-  std::vector<std::shared_ptr<GraphNode>> &getSorted();
-
-  /**
    * @brief     get begin iterator for the forwarding
    * @retval    const iterator marking the begin of forwarding
    */

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -13,6 +13,7 @@
 #ifndef __GRAPH_NODE_H__
 #define __GRAPH_NODE_H__
 
+#include <iterator>
 #include <memory>
 #include <string>
 #include <vector>
@@ -73,6 +74,229 @@ public:
    */
   // virtual GraphNode &copy(const GraphNode &from) = 0;
 };
+
+/**
+ * @brief   Iterator for GraphNode which return LayerNode object upon realize
+ *
+ * @note    This does not include the complete list of required functions. Add
+ * them as per need.
+ */
+template <typename T>
+class GraphNodeIterator : public std::iterator<std::random_access_iterator_tag,
+                                               std::shared_ptr<GraphNode>> {
+  std::shared_ptr<GraphNode> *p; /** underlying object of GraphNode */
+
+public:
+  /**
+   * @brief   iterator_traits types definition
+   *
+   * @note    these are not requried to be explicitly defined now, but maintains
+   *          forward compatibility for c++17 and later
+   *
+   * @note    valute_type, pointer and reference are different from standard
+   * iterator
+   */
+  typedef std::shared_ptr<T> value_type;
+  typedef std::random_access_iterator_tag iterator_category;
+  typedef std::ptrdiff_t difference_type;
+  typedef std::shared_ptr<T> *pointer;
+  typedef std::shared_ptr<T> &reference;
+
+  /**
+   * @brief Construct a new Graph Node Iterator object
+   *
+   * @param x underlying object of GraphNode
+   */
+  GraphNodeIterator(std::shared_ptr<GraphNode> *x) : p(x) {}
+
+  /**
+   * @brief reference operator
+   *
+   * @return value_type
+   * @note this is different from standard iterator
+   */
+  value_type operator*() const { return std::static_pointer_cast<T>(*p); }
+
+  /**
+   * @brief pointer operator
+   *
+   * @return value_type
+   * @note this is different from standard iterator
+   */
+  value_type operator->() const { return std::static_pointer_cast<T>(*p); }
+
+  /**
+   * @brief == comparison operator override
+   *
+   * @param lhs iterator lhs
+   * @param rhs iterator rhs
+   * @return true if match
+   * @return false if mismatch
+   */
+  friend bool operator==(GraphNodeIterator const &lhs,
+                         GraphNodeIterator const &rhs) {
+    return lhs.p == rhs.p;
+  }
+
+  /**
+   * @brief != comparison operator override
+   *
+   * @param lhs iterator lhs
+   * @param rhs iterator rhs
+   * @return true if mismatch
+   * @return false if match
+   */
+  friend bool operator!=(GraphNodeIterator const &lhs,
+                         GraphNodeIterator const &rhs) {
+    return lhs.p != rhs.p;
+  }
+
+  /**
+   * @brief override for ++ operator
+   *
+   * @return GraphNodeIterator&
+   */
+  GraphNodeIterator &operator++() {
+    p += 1;
+    return *this;
+  }
+
+  /**
+   * @brief override for operator++
+   *
+   * @return GraphNodeIterator
+   */
+  GraphNodeIterator operator++(int) {
+    GraphNodeIterator temp(p);
+    p += 1;
+    return temp;
+  }
+
+  /**
+   * @brief override for -- operator
+   *
+   * @return GraphNodeIterator&
+   */
+  GraphNodeIterator &operator--() {
+    p -= 1;
+    return *this;
+  }
+
+  /**
+   * @brief override for operator--
+   *
+   * @return GraphNodeIterator
+   */
+  GraphNodeIterator operator--(int) {
+    GraphNodeIterator temp(p);
+    p -= 1;
+    return temp;
+  }
+
+  /**
+   * @brief override for subtract operator
+   *
+   * @param offset offset to subtract
+   * @return GraphNodeIterator
+   */
+  GraphNodeIterator operator-(const difference_type offset) const {
+    return GraphNodeIterator(p - offset);
+  }
+
+  /**
+   * @brief override for subtract operator
+   *
+   * @param other iterator to subtract
+   * @return difference_type
+   */
+  difference_type operator-(const GraphNodeIterator &other) const {
+    return p - other.p;
+  }
+
+  /**
+   * @brief override for subtract and return result operator
+   *
+   * @param offset offset to subtract
+   * @return GraphNodeIterator&
+   */
+  GraphNodeIterator &operator-=(const difference_type offset) {
+    p -= offset;
+    return *this;
+  }
+
+  /**
+   * @brief override for add operator
+   *
+   * @param offset offset to add
+   * @return GraphNodeIterator
+   */
+  GraphNodeIterator operator+(const difference_type offset) const {
+    return GraphNodeIterator(p + offset);
+  }
+
+  /**
+   * @brief override for add and return result operator
+   *
+   * @param offset offset to add
+   * @return GraphNodeIterator&
+   */
+  GraphNodeIterator &operator+=(const difference_type offset) {
+    p += offset;
+    return *this;
+  }
+};
+
+/**
+ * @brief   Reverse Iterator for GraphNode which return LayerNode object upon
+ * realize
+ *
+ * @note    This just extends GraphNodeIterator and is limited by its
+ * functionality.
+ */
+template <typename T_iterator>
+class GraphNodeReverseIterator : public std::reverse_iterator<T_iterator> {
+public:
+  /**
+   * @brief Construct a new Graph Node Reverse Iterator object
+   *
+   * @param iter Iterator
+   */
+  explicit GraphNodeReverseIterator(T_iterator iter) :
+    std::reverse_iterator<T_iterator>(iter) {}
+
+  /**
+   *  @brief reference operator
+   *
+   * @return T_iterator::value_type
+   * @note this is different from standard iterator
+   */
+  typename T_iterator::value_type operator*() const {
+    auto temp = std::reverse_iterator<T_iterator>::current - 1;
+    return *temp;
+  }
+
+  /**
+   *  @brief pointer operator
+   *
+   * @return T_iterator::value_type
+   * @note this is different from standard iterator
+   */
+  typename T_iterator::value_type operator->() const {
+    auto temp = std::reverse_iterator<T_iterator>::current - 1;
+    return *temp;
+  }
+};
+
+/**
+ * @brief     Iterators to traverse the graph
+ */
+template <class T> using graph_iterator = GraphNodeIterator<T>;
+
+/**
+ * @brief     Iterators to traverse the graph
+ */
+template <class T>
+using graph_reverse_iterator = GraphNodeReverseIterator<GraphNodeIterator<T>>;
 
 } // namespace nntrainer
 #endif // __GRAPH_NODE_H__

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -80,11 +80,13 @@ public:
  *
  * @note    This does not include the complete list of required functions. Add
  * them as per need.
+ *
+ * @note    GraphNodeType is to enable for both GraphNode and const GraphNode
  */
-template <typename T>
-class GraphNodeIterator : public std::iterator<std::random_access_iterator_tag,
-                                               std::shared_ptr<GraphNode>> {
-  const std::shared_ptr<GraphNode> *p; /** underlying object of GraphNode */
+template <typename LayerNodeType, typename GraphNodeType>
+class GraphNodeIterator
+  : public std::iterator<std::random_access_iterator_tag, GraphNodeType> {
+  GraphNodeType *p; /** underlying object of GraphNode */
 
 public:
   /**
@@ -93,21 +95,21 @@ public:
    * @note    these are not requried to be explicitly defined now, but maintains
    *          forward compatibility for c++17 and later
    *
-   * @note    valute_type, pointer and reference are different from standard
+   * @note    value_type, pointer and reference are different from standard
    * iterator
    */
-  typedef std::shared_ptr<T> value_type;
+  typedef std::shared_ptr<LayerNodeType> value_type;
   typedef std::random_access_iterator_tag iterator_category;
   typedef std::ptrdiff_t difference_type;
-  typedef std::shared_ptr<T> *pointer;
-  typedef std::shared_ptr<T> &reference;
+  typedef std::shared_ptr<LayerNodeType> *pointer;
+  typedef std::shared_ptr<LayerNodeType> &reference;
 
   /**
    * @brief Construct a new Graph Node Iterator object
    *
    * @param x underlying object of GraphNode
    */
-  GraphNodeIterator(const std::shared_ptr<GraphNode> *x) : p(x) {}
+  GraphNodeIterator(GraphNodeType *x) : p(x) {}
 
   /**
    * @brief reference operator
@@ -115,7 +117,9 @@ public:
    * @return value_type
    * @note this is different from standard iterator
    */
-  value_type operator*() const { return std::static_pointer_cast<T>(*p); }
+  value_type operator*() const {
+    return std::static_pointer_cast<LayerNodeType>(*p);
+  }
 
   /**
    * @brief pointer operator
@@ -123,7 +127,9 @@ public:
    * @return value_type
    * @note this is different from standard iterator
    */
-  value_type operator->() const { return std::static_pointer_cast<T>(*p); }
+  value_type operator->() const {
+    return std::static_pointer_cast<LayerNodeType>(*p);
+  }
 
   /**
    * @brief == comparison operator override
@@ -290,13 +296,30 @@ public:
 /**
  * @brief     Iterators to traverse the graph
  */
-template <class T> using graph_iterator = GraphNodeIterator<T>;
+template <class LayerNodeType>
+using graph_iterator =
+  GraphNodeIterator<LayerNodeType, std::shared_ptr<GraphNode>>;
 
 /**
  * @brief     Iterators to traverse the graph
  */
-template <class T>
-using graph_reverse_iterator = GraphNodeReverseIterator<GraphNodeIterator<T>>;
+template <class LayerNodeType>
+using graph_reverse_iterator = GraphNodeReverseIterator<
+  GraphNodeIterator<LayerNodeType, std::shared_ptr<GraphNode>>>;
+
+/**
+ * @brief     Iterators to traverse the graph
+ */
+template <class LayerNodeType>
+using graph_const_iterator =
+  GraphNodeIterator<const LayerNodeType, const std::shared_ptr<GraphNode>>;
+
+/**
+ * @brief     Iterators to traverse the graph
+ */
+template <class LayerNodeType>
+using graph_const_reverse_iterator = GraphNodeReverseIterator<
+  GraphNodeIterator<const LayerNodeType, const std::shared_ptr<GraphNode>>>;
 
 } // namespace nntrainer
 #endif // __GRAPH_NODE_H__

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -84,7 +84,7 @@ public:
 template <typename T>
 class GraphNodeIterator : public std::iterator<std::random_access_iterator_tag,
                                                std::shared_ptr<GraphNode>> {
-  std::shared_ptr<GraphNode> *p; /** underlying object of GraphNode */
+  const std::shared_ptr<GraphNode> *p; /** underlying object of GraphNode */
 
 public:
   /**
@@ -107,7 +107,7 @@ public:
    *
    * @param x underlying object of GraphNode
    */
-  GraphNodeIterator(std::shared_ptr<GraphNode> *x) : p(x) {}
+  GraphNodeIterator(const std::shared_ptr<GraphNode> *x) : p(x) {}
 
   /**
    * @brief reference operator

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -110,10 +110,9 @@ void NetworkGraph::addLayerNode(std::shared_ptr<Layer> layer) {
 }
 
 void NetworkGraph::countNonTrainableLayersAtBegin() {
-  for (auto iter = graph.cbegin<LayerNode>(); iter != graph.cend<LayerNode>();
-       iter++) {
+  for (auto iter = cbegin(); iter != cend(); iter++) {
     if ((*iter)->getObject()->getTrainable()) {
-      skip_non_trainable_layers = iter - graph.cbegin<LayerNode>();
+      skip_non_trainable_layers = iter - cbegin();
       return;
     }
   }
@@ -290,7 +289,7 @@ int NetworkGraph::addLossLayer(const LossType loss_type) {
       return ML_ERROR_NOT_SUPPORTED;
     }
 
-    graph.remove_last_node();
+    graph.removeLastNode();
 
     switch (last_layer_node->getObject()->getActivationType()) {
     case ActivationType::ACT_SIGMOID:
@@ -435,8 +434,7 @@ int NetworkGraph::checkCompiledGraph() {
   }
 
   /** Dimension of input layers must be known */
-  for (auto iter = graph.cbegin<LayerNode>(); iter != graph.cend<LayerNode>();
-       iter++) {
+  for (auto iter = cbegin(); iter != cend(); iter++) {
     auto lnode = (*iter);
     if (lnode->getObject()->getType() == InputLayer::type) {
       if (lnode->getObject()->getInputDimension().size() == 0) {
@@ -683,8 +681,7 @@ void NetworkGraph::addLayer(std::shared_ptr<LayerNode> layer) {
 
 void NetworkGraph::inPlaceOptimize(const std::string &layer_type,
                                    Manager &manager) {
-  for (auto iter = graph.cbegin<LayerNode>(); iter != graph.cend<LayerNode>();
-       iter++) {
+  for (auto iter = cbegin(); iter != cend(); iter++) {
     auto layer_node = *iter;
     auto &l = layer_node->getObject();
     std::string l_type = l->getType();

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -544,7 +544,8 @@ sharedConstTensors NetworkGraph::forwarding(bool training) const {
   }
 
   std::vector<sharedConstTensor> out;
-  for (auto const &nh : getSortedLayerNode(graph.size()-1)->getObject()->net_hidden)
+  for (auto const &nh :
+       getSortedLayerNode(graph.size() - 1)->getObject()->net_hidden)
     out.push_back(MAKE_SHARED_TENSOR(nh->getVariable()));
 
   return out;
@@ -559,7 +560,9 @@ std::vector<TensorDim> NetworkGraph::getInputDimension() const {
 std::vector<TensorDim> NetworkGraph::getOutputDimension() const {
   NNTR_THROW_IF(this->empty(), std::invalid_argument)
     << "[NetworkGraph] the graph has no node!";
-  return getSortedLayerNode(graph.size()-1)->getObject()->getOutputDimension();
+  return getSortedLayerNode(graph.size() - 1)
+    ->getObject()
+    ->getOutputDimension();
 }
 
 std::vector<std::shared_ptr<LayerNode>>
@@ -680,7 +683,8 @@ void NetworkGraph::addLayer(std::shared_ptr<LayerNode> layer) {
 
 void NetworkGraph::inPlaceOptimize(const std::string &layer_type,
                                    Manager &manager) {
-  for (auto iter = graph.cbegin<LayerNode>(); iter != graph.cend<LayerNode>(); iter++) {
+  for (auto iter = graph.cbegin<LayerNode>(); iter != graph.cend<LayerNode>();
+       iter++) {
     auto layer_node = *iter;
     auto &l = layer_node->getObject();
     std::string l_type = l->getType();
@@ -778,24 +782,12 @@ void NetworkGraph::inPlaceOptimize(Manager &manager) {
     inPlaceOptimize(layer_type, manager);
 }
 
-const std::vector<std::shared_ptr<LayerNode>> NetworkGraph::getSorted() const {
-  if (!compiled)
-    throw std::runtime_error("Cannot get sorted graph before compiling graph");
-
-  auto const &sorted = graph.getSorted();
-  std::vector<std::shared_ptr<LayerNode>> ret;
-  std::transform(sorted.begin(), sorted.end(), std::back_inserter(ret),
-                 [](auto const &elem) { return LNODE(elem); });
-
-  return ret;
-}
-
 int NetworkGraph::initialize(std::shared_ptr<Manager> manager) {
   int status = ML_ERROR_NONE;
 
-  for (unsigned int idx = 0; idx < Sorted.size(); ++idx) {
+  for (unsigned int idx = 0; idx < graph.size(); ++idx) {
     bool first = idx == 0;
-    auto &lnode = getSortedLayerNode(idx);
+    auto const &lnode = getSortedLayerNode(idx);
     auto &lptr = lnode->getObject();
     ml_logd("layer name : %s", lptr->getName().c_str());
     std::string cur_type;

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -170,30 +170,32 @@ public:
   sharedConstTensors forwarding(bool training = false) const;
 
   /**
-   * @brief     getter of ordered graph
-   * @retval    ordered LayerNode list
+   * @brief     get begin iterator for the graph
+   * @retval    const reverse iterator
    */
-  const std::vector<std::shared_ptr<LayerNode>> getSorted() const;
-
   graph_iterator<const LayerNode> cbegin() const {
     return graph.cbegin<LayerNode>();
   }
 
+  /**
+   * @brief     get end iterator for the graph
+   * @retval    const iterator
+   */
   graph_iterator<const LayerNode> cend() const {
     return graph.cend<LayerNode>();
   }
 
   /**
-   * @brief     get begin iterator for the backwarding
-   * @retval    const reverse iterator marking the begin of backwarding
+   * @brief     get reverse begin iterator for the graph
+   * @retval    const reverse iterator
    */
   graph_reverse_iterator<const LayerNode> crbegin() const {
     return graph.crbegin<LayerNode>();
   }
 
   /**
-   * @brief     get end iterator for the backwarding
-   * @retval    const reverse iterator marking the end of backwarding
+   * @brief     get reverse end iterator for the graph
+   * @retval    const reverse iterator
    */
   graph_reverse_iterator<const LayerNode> crend() const {
     return graph.crend<LayerNode>();

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -173,7 +173,19 @@ public:
    * @brief     get begin iterator for the graph
    * @retval    const reverse iterator
    */
-  graph_iterator<const LayerNode> cbegin() const {
+  graph_iterator<LayerNode> begin() { return graph.begin<LayerNode>(); }
+
+  /**
+   * @brief     get end iterator for the graph
+   * @retval    const reverse iterator
+   */
+  graph_iterator<LayerNode> end() { return graph.end<LayerNode>(); }
+
+  /**
+   * @brief     get begin iterator for the graph
+   * @retval    const reverse iterator
+   */
+  graph_const_iterator<LayerNode> cbegin() const {
     return graph.cbegin<LayerNode>();
   }
 
@@ -181,7 +193,7 @@ public:
    * @brief     get end iterator for the graph
    * @retval    const iterator
    */
-  graph_iterator<const LayerNode> cend() const {
+  graph_const_iterator<LayerNode> cend() const {
     return graph.cend<LayerNode>();
   }
 
@@ -189,7 +201,7 @@ public:
    * @brief     get reverse begin iterator for the graph
    * @retval    const reverse iterator
    */
-  graph_reverse_iterator<const LayerNode> crbegin() const {
+  graph_const_reverse_iterator<LayerNode> crbegin() const {
     return graph.crbegin<LayerNode>();
   }
 
@@ -197,7 +209,7 @@ public:
    * @brief     get reverse end iterator for the graph
    * @retval    const reverse iterator
    */
-  graph_reverse_iterator<const LayerNode> crend() const {
+  graph_const_reverse_iterator<LayerNode> crend() const {
     return graph.crend<LayerNode>();
   }
 
@@ -205,7 +217,7 @@ public:
    * @brief     get begin iterator for the backwarding
    * @retval    const reverse iterator marking the begin of backwarding
    */
-  graph_reverse_iterator<const LayerNode> getBackwardingBeginIter() const {
+  graph_const_reverse_iterator<LayerNode> getBackwardingBeginIter() const {
     return crbegin();
   }
 
@@ -213,7 +225,7 @@ public:
    * @brief     get end iterator for the backwarding
    * @retval    const reverse iterator marking the end of backwarding
    */
-  graph_reverse_iterator<const LayerNode> getBackwardingEndIter() const {
+  graph_const_reverse_iterator<LayerNode> getBackwardingEndIter() const {
     auto iter = crend();
     iter -= skip_non_trainable_layers;
     return iter;

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -103,7 +103,7 @@ public:
    * @param[in] index
    * @ret LayerNode
    */
-  std::shared_ptr<LayerNode> getLayerNode(unsigned int ith) {
+  std::shared_ptr<LayerNode> getLayerNode(unsigned int ith) const {
     return std::static_pointer_cast<LayerNode>(graph.getNode(ith));
   }
 
@@ -112,7 +112,7 @@ public:
    * @param[in] index
    * @ret LayerNode
    */
-  std::shared_ptr<LayerNode> getSortedLayerNode(unsigned int ith) {
+  std::shared_ptr<LayerNode> getSortedLayerNode(unsigned int ith) const {
     return std::static_pointer_cast<LayerNode>(graph.getSortedNode(ith));
   }
 
@@ -121,7 +121,7 @@ public:
    * @param[in] layer name
    * @retval LayerNode
    */
-  std::shared_ptr<LayerNode> getLayerNode(const std::string &layer_name) {
+  std::shared_ptr<LayerNode> getLayerNode(const std::string &layer_name) const {
     return std::static_pointer_cast<LayerNode>(graph.getNode(layer_name));
   }
 
@@ -167,7 +167,7 @@ public:
    * @param[in] training true if forwarding is on training
    * @retval output tensors
    */
-  sharedConstTensors forwarding(bool training = false);
+  sharedConstTensors forwarding(bool training = false) const;
 
   /**
    * @brief     getter of ordered graph
@@ -175,11 +175,19 @@ public:
    */
   const std::vector<std::shared_ptr<LayerNode>> getSorted() const;
 
+  graph_iterator<const LayerNode> cbegin() const {
+    return graph.cbegin<LayerNode>();
+  }
+
+  graph_iterator<const LayerNode> cend() const {
+    return graph.cend<LayerNode>();
+  }
+
   /**
    * @brief     get begin iterator for the backwarding
    * @retval    const reverse iterator marking the begin of backwarding
    */
-  graph_reverse_iterator<const LayerNode> getBackwardingBeginIter() {
+  graph_reverse_iterator<const LayerNode> crbegin() const {
     return graph.crbegin<LayerNode>();
   }
 
@@ -187,8 +195,24 @@ public:
    * @brief     get end iterator for the backwarding
    * @retval    const reverse iterator marking the end of backwarding
    */
-  graph_reverse_iterator<const LayerNode> getBackwardingEndIter() {
-    graph_reverse_iterator<const LayerNode> iter = graph.crend<LayerNode>();
+  graph_reverse_iterator<const LayerNode> crend() const {
+    return graph.crend<LayerNode>();
+  }
+
+  /**
+   * @brief     get begin iterator for the backwarding
+   * @retval    const reverse iterator marking the begin of backwarding
+   */
+  graph_reverse_iterator<const LayerNode> getBackwardingBeginIter() const {
+    return crbegin();
+  }
+
+  /**
+   * @brief     get end iterator for the backwarding
+   * @retval    const reverse iterator marking the end of backwarding
+   */
+  graph_reverse_iterator<const LayerNode> getBackwardingEndIter() const {
+    auto iter = crend();
     iter -= skip_non_trainable_layers;
     return iter;
   }

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -10,6 +10,16 @@
  * @brief  This is the layer node for network graph
  */
 
+#include <layer_factory.h>
 #include <layer_node.h>
 
-namespace nntrainer {}; // namespace nntrainer
+namespace nntrainer {
+
+/**
+ * @brief Layer factory creator with constructor
+ */
+std::unique_ptr<LayerNode> createLayerNode(const std::string &type) {
+  return std::make_unique<LayerNode>(createLayer(type));
+}
+
+}; // namespace nntrainer

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -140,5 +140,10 @@ private:
     activation_type; /**< activation applied to the output of this node */
 };
 
+/**
+ * @brief LayerNode creator with constructor
+ */
+std::unique_ptr<LayerNode> createLayerNode(const std::string &type);
+
 } // namespace nntrainer
 #endif // __LAYER_NODE_H__

--- a/nntrainer/models/model_loader.cpp
+++ b/nntrainer/models/model_loader.cpp
@@ -354,7 +354,7 @@ int ModelLoader::loadFromIni(std::string ini_file, NeuralNetwork &model,
     model.model_graph = *ini_interpreter->deserialize(ini_file);
     ml_logd("parsing graph finished");
 
-    if (model.getFlatGraph().empty()) {
+    if (model.empty()) {
       ml_loge("there is no layer section in the ini file");
       status = ML_ERROR_INVALID_PARAMETER;
     }

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -162,7 +162,7 @@ int NeuralNetwork::initialize() {
     return ML_ERROR_NOT_SUPPORTED;
   }
 
-  unsigned int n_layers = (unsigned int)model_graph.getSorted().size();
+  unsigned int n_layers = (unsigned int)model_graph.size();
 
   ml_logd("initializing neural network, layer size: %d", n_layers);
 
@@ -223,7 +223,7 @@ sharedConstTensors NeuralNetwork::forwarding(sharedConstTensors input,
 
   auto &first_layer = model_graph.getSortedLayerNode(0)->getObject();
   auto &last_layer =
-    model_graph.getSortedLayerNode(model_graph.getSorted().size() - 1)
+    model_graph.getSortedLayerNode(model_graph.size() - 1)
       ->getObject();
 
   /// @note centroid_knn layer needs to be the last layer, currently it is
@@ -332,7 +332,7 @@ void NeuralNetwork::backwarding(int iteration) {
  */
 void NeuralNetwork::backwarding(sharedConstTensors label, int iteration) {
   auto &loss_layer =
-    model_graph.getSortedLayerNode(model_graph.getSorted().size() - 1)
+    model_graph.getSortedLayerNode(model_graph.size() - 1)
       ->getObject();
   loss_layer->net_hidden[0]->getGradientRef() = *label[0].get();
 
@@ -488,7 +488,7 @@ sharedConstTensors NeuralNetwork::inference(sharedConstTensors X,
   forwarding(X, {}, false);
   END_PROFILE(profile::NN_FORWARD);
 
-  auto &last_layer = model_graph.getSorted().back()->getObject();
+  auto &last_layer = model_graph.getSortedLayerNode(model_graph.size() - 1)->getObject();
   for (unsigned int i = 0; i < last_layer->getNumOutputs(); ++i) {
     out.push_back(MAKE_SHARED_TENSOR(last_layer->net_hidden[i]->getVariable()));
   }
@@ -574,7 +574,7 @@ int NeuralNetwork::train_run() {
 
   auto &first_layer = model_graph.getSortedLayerNode(0)->getObject();
   auto &last_layer =
-    model_graph.getSortedLayerNode(model_graph.getSorted().size() - 1)
+    model_graph.getSortedLayerNode(model_graph.size() - 1)
       ->getObject();
 
   auto &output = last_layer->net_hidden[0]->getVariableRef();

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -374,6 +374,12 @@ public:
   FlatGraphType getFlatGraph() { return model_graph.getLayerNodes(); }
 
   /**
+   * @brief get if the model is empty
+   * @param[out] true if empty, else false
+   */
+  bool empty() const { return model_graph.empty(); }
+
+  /**
    * @brief     get network graph
    * @retval NetowrkGraphType
    */

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -63,9 +63,7 @@ auto ini_interpreter =
  */
 static void graphEqual(const nntrainer::GraphRepresentation &lhs,
                        const nntrainer::GraphRepresentation &rhs) {
-  const auto &layers = lhs.getLayerNodes();
-  const auto &ref_layers = rhs.getLayerNodes();
-  EXPECT_EQ(layers.size(), ref_layers.size());
+  EXPECT_EQ(lhs.size(), rhs.size());
 
   auto is_node_equal = [](const nntrainer::Layer &l,
                           const nntrainer::Layer &r) {
@@ -81,9 +79,11 @@ static void graphEqual(const nntrainer::GraphRepresentation &lhs,
       rhs_export.get_result<nntrainer::ExportMethods::METHOD_STRINGVECTOR>());
   };
 
-  if (layers.size() == ref_layers.size()) {
-    for (unsigned int i = 0; i < layers.size(); ++i) {
-      is_node_equal(*layers[i]->getObject(), *ref_layers[i]->getObject());
+  if (lhs.size() == rhs.size()) {
+    auto lhs_iter = lhs.cbegin();
+    auto rhs_iter = rhs.cbegin();
+    for (; lhs_iter != lhs.cend(), rhs_iter != rhs.cend(); lhs_iter++, rhs_iter++) {
+      is_node_equal(*lhs_iter->getObject(), *rhs_iter->getObject());
     }
   }
 }

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -82,7 +82,8 @@ static void graphEqual(const nntrainer::GraphRepresentation &lhs,
   if (lhs.size() == rhs.size()) {
     auto lhs_iter = lhs.cbegin();
     auto rhs_iter = rhs.cbegin();
-    for (; lhs_iter != lhs.cend(), rhs_iter != rhs.cend(); lhs_iter++, rhs_iter++) {
+    for (; lhs_iter != lhs.cend(), rhs_iter != rhs.cend();
+         lhs_iter++, rhs_iter++) {
       is_node_equal(*lhs_iter->getObject(), *rhs_iter->getObject());
     }
   }

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -807,7 +807,7 @@ TEST(nntrainerIniTest, backbone_p_20) {
   EXPECT_EQ(NN.loadFromConfig(backbone.getIniName()), ML_ERROR_NONE);
   EXPECT_EQ(NN.compile(), ML_ERROR_NONE);
   EXPECT_EQ(NN.initialize(), ML_ERROR_NONE);
-  EXPECT_EQ(NN.getNetworkGraph().getSorted().size(), 6u);
+  EXPECT_EQ(NN.getNetworkGraph().size(), 6u);
 }
 
 /**

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -44,7 +44,7 @@ static const std::string getModelsPath(const std::string &file_name) {
  * Watcher Classes                                      *
  ********************************************************/
 
-using NodeType = std::shared_ptr<nntrainer::LayerNode>;
+using NodeType = std::shared_ptr<const nntrainer::LayerNode>;
 using FlatGraphType = nntrainer::NeuralNetwork::FlatGraphType;
 using NetworkGraphType = nntrainer::NetworkGraph;
 
@@ -382,13 +382,13 @@ GraphWatcher::GraphWatcher(const std::string &config, const bool opt) :
 
   NetworkGraphType model_graph = nn.getNetworkGraph();
 
-  std::vector<NodeType> graph = model_graph.getSorted();
-
-  for (auto it = graph.begin(); it != graph.end() - 1; ++it) {
-    nodes.push_back(NodeWatcher(*it));
+  for (auto it = model_graph.cbegin(); it != model_graph.cend() - 1; ++it) {
+    auto const &lnode = *it;
+    nodes.push_back(NodeWatcher(lnode));
   }
 
-  loss_node = NodeWatcher(graph.back());
+  loss_node =
+    NodeWatcher(model_graph.getSortedLayerNode(model_graph.size() - 1));
 }
 
 void GraphWatcher::compareFor(const std::string &reference,


### PR DESCRIPTION
Migrate neural network independent and generic sections of the graph
to graph core. This is not yet complete and will be done over a few commits.
This will cleanup NetworkGraph class and will allow optimizations to
be done on the GraphCore/NetworkGraph class easily, and simplify
the classes as well.

Now, graph related structures can move out from layer to layer node.

Cleanup graph usage
Graph remove support for getNodes() but rather
use iterators to iterator over the graph.
Add non-const iterators for the graph.
Most of the locations use const-iterators.
This will be updated when layer_node is updated to use its
properties than layer.


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
