### PR TITLE
[time_dist] setProperty for time distribution layer

### DIFF
--- a/nntrainer/layers/time_dist.h
+++ b/nntrainer/layers/time_dist.h
@@ -118,6 +118,17 @@ public:
    */
   void transposeInOut();
 
+  using Layer::setProperty;
+
+  /**
+   * @copydoc Layer::setProperty(const PropertyType type, const std::string
+   * &value)
+   */
+  void setProperty(const PropertyType type,
+                   const std::string &value = "") override {
+    dist_layer->setProperty(type, value);
+  }
+
   /**
    * @copydoc Layer::getType()
    */


### PR DESCRIPTION
Added setProperty for time distribution layer, which passes
the properties to its underlying layer.

Resolves #1189

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>