### PR TITLE
[meson] Enable tflite-interpreter by default

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 (>=7.5),
  libopenblas-dev, libiniparser-dev (>=4.1), tensorflow2-lite-dev, libjsoncpp-dev,
  libcurl3-gnutls-dev | libcurl4-gnutls-dev | libcurl3-openssl-dev |
  libcurl4-openssl-dev | libcurl3-nns-dev | libcurl4-nns-dev, libgtest-dev,
- libflatbuffers-dev, libglib2.0-dev, nnstreamer-dev, libgstreamer1.0-dev,
+ libflatbuffers-dev, flatbuffers-compiler, libglib2.0-dev, nnstreamer-dev, libgstreamer1.0-dev,
  libgstreamer-plugins-base1.0-dev, gstreamer1.0-tools, gstreamer1.0-plugins-base,
  gstreamer1.0-plugins-good, ml-api-common-dev, ml-inference-api-dev
 Standards-Version: 3.9.6

--- a/meson.build
+++ b/meson.build
@@ -186,6 +186,7 @@ endif
 if opencv_dep.found()
   add_project_arguments('-DENABLE_DATA_AUGMENTATION_OPENCV=1', language:['c','cpp'])
 endif
+flatc_prog = find_program('flatc', required: false)
 
 # Install .pc
 configure_file(input: 'nntrainer.pc.in', output: 'nntrainer.pc',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,7 +14,7 @@ option('enable-nnstreamer-backbone', type: 'boolean', value: true)
 option('enable-tflite-backbone', type: 'boolean', value: true)
 option('enable-android', type: 'boolean', value: false)
 option('enable-profile', type: 'boolean', value: false)
-option('enable-tflite-interpreter', type: 'boolean', value: false)
+option('enable-tflite-interpreter', type: 'boolean', value: true)
 
 # dependency conflict resolution
 option('capi-ml-inference-actual', type: 'string', value: 'capi-ml-inference',

--- a/nntrainer/compiler/meson.build
+++ b/nntrainer/compiler/meson.build
@@ -5,15 +5,23 @@ compiler_sources = [
 compiler_headers = []
 
 if get_option('enable-tflite-interpreter')
-  flatc = find_program('flatc', required: true)
+  if not tflite_dep.found()
+    error('Tensorflow-Lite dependency not found')
+  endif
+  if not flatc_prog.found()
+    error('flatc executable not found')
+  endif
+
   add_project_arguments('-DENABLE_TFLITE_INTERPRETER=1', language:['c','cpp'])
 
   flat_header = custom_target('tflite-schema',
                                input: 'tf_schema.fbs',
                                output: 'tf_schema_generated.h',
-                               command: [flatc, '-c', '@INPUT@'])
+                               command: [flatc_prog, '-o', '@CURRENT_SOURCE_DIR@', '-c', '@INPUT@'])
 
-  nntrainer_sources += flat_header
+  flat_header_dep = declare_dependency(sources : [flat_header])
+
+  nntrainer_base_deps += flat_header_dep
   compiler_sources += [
     'tflite_interpreter.cpp',
     'tflite_opnode.cpp'

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -5,6 +5,7 @@
 %define         support_ccapi 1
 %define         support_nnstreamer_backbone 1
 %define         support_tflite_backbone 1
+%define         support_tflite_interpreter 1
 %define         nntrainerapplicationdir %{_libdir}/nntrainer/bin
 %define         gen_input $(pwd)/test/input_gen/genInput.py
 %define         support_data_augmentation_opencv 1
@@ -47,7 +48,7 @@ Name:		nntrainer
 Summary:	Software framework for training neural networks
 Version:	0.2.0
 Release:	0
-Packager:	Jijoong Moon <jijoong.moon@sansumg.com>
+Packager:	Jijoong Moon <jijoong.moon@samsung.com>
 License:	Apache-2.0
 Source0:	nntrainer-%{version}.tar.gz
 Source1001:	nntrainer.manifest
@@ -106,6 +107,10 @@ Requires:	%{capi_machine_learning_inference}
 %if 0%{?support_tflite_backbone}
 BuildRequires: tensorflow2-lite-devel
 %endif # support_tflite_backbone
+
+%if 0%{?support_tflite_interpreter}
+BuildRequires: tensorflow2-lite-devel
+%endif # support_tflite_interpreter
 
 %define enable_nnstreamer_tensor_filter -Denable-nnstreamer-tensor-filter=false
 
@@ -262,6 +267,7 @@ NNSteamer tensor filter static package for nntrainer to support inference.
 %define enable_ccapi -Denable-ccapi=false
 %define enable_nnstreamer_backbone -Denable-nnstreamer-backbone=false
 %define enable_tflite_backbone -Denable-tflite-backbone=false
+%define enable_tflite_interpreter -Denable-tflite-interpreter=false
 %define enable_profile -Denable-profile=false
 %define capi_ml_pkg_dep_resolution -Dcapi-ml-inference-actual=%{?capi_ml_inference_pkg_name} -Dcapi-ml-common-actual=%{?capi_ml_common_pkg_name}
 %define enable_reduce_tolerance -Dreduce-tolerance=true
@@ -294,6 +300,10 @@ NNSteamer tensor filter static package for nntrainer to support inference.
 
 %if 0%{?unit_test}
 %define enable_profile -Denable-profile=true
+%endif
+
+%if 0%{?support_tflite_interpreter}
+%define enable_tflite_interpreter -Denable-tflite-interpreter=true
 %endif
 
 %prep
@@ -330,7 +340,8 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} \
       %{enable_tizen_feature_check} %{enable_cblas} %{enable_ccapi} \
       %{enable_gym} %{enable_nnstreamer_tensor_filter} %{enable_profile} \
       %{enable_nnstreamer_backbone} %{enable_tflite_backbone} \
-      %{capi_ml_pkg_dep_resolution} %{enable_reduce_tolerance} build
+      %{enable_tflite_interpreter} %{capi_ml_pkg_dep_resolution} \
+      %{enable_reduce_tolerance} build
 
 ninja -C build %{?_smp_mflags}
 


### PR DESCRIPTION
Enable tflite-interpreter by default as tflite layer is
already enabled.
Also move flatc dependency out to the main meson.build

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>