### PR TITLE
[fc/tensor] Update fc layer bias derivative to in-place

### DIFF
--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -127,8 +127,8 @@ void FullyConnectedLayer::calcGradient() {
 
   Tensor &derivative_ = net_hidden[0]->getGradientRef();
 
-  djdb = derivative_.sum(0);
-  djdw = net_input[0]->getVariableRef().dot(derivative_, djdw, true, false);
+  derivative_.sum({0, 1, 2}, djdb);
+  net_input[0]->getVariableRef().dot(derivative_, djdw, true, false);
 }
 
 void FullyConnectedLayer::scaleSize(float scalesize) noexcept {

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -606,9 +606,9 @@ Tensor Tensor::sum_by_batch() {
  */
 Tensor Tensor::sum(unsigned int axis, float alpha) const {
   Tensor ret;
-  return sum(ret, axis, alpha);
+  return sum(axis, ret, alpha);
 }
-Tensor &Tensor::sum(Tensor &ret, unsigned int axis, float alpha) const {
+Tensor &Tensor::sum(unsigned int axis, Tensor &ret, float alpha) const {
   const float *data = getData();
 
   if (axis >= 4)
@@ -676,15 +676,27 @@ Tensor &Tensor::sum(Tensor &ret, unsigned int axis, float alpha) const {
 }
 
 Tensor Tensor::sum(const std::vector<unsigned int> &axes, float alpha) const {
+  Tensor ret;
+  return sum(axes, ret, alpha);
+}
+
+Tensor &Tensor::sum(const std::vector<unsigned int> &axes, Tensor &output,
+                    float alpha) const {
   if (axes.empty())
     throw std::invalid_argument("empty axes given");
 
-  Tensor ret = this->sum(axes[0], alpha);
+  if (axes.size() == 1) {
+    this->sum(axes[0], output, alpha);
+  } else {
+    Tensor ret = this->sum(axes[0], alpha);
 
-  for (unsigned int i = 1; i < axes.size(); ++i)
-    ret = ret.sum(axes[i]);
+    for (unsigned int i = 1; i < axes.size() - 1; ++i)
+      ret = ret.sum(axes[i]);
 
-  return ret;
+    ret.sum(axes.back(), output);
+  }
+
+  return output;
 }
 
 Tensor Tensor::dot(Tensor const &m, bool trans, bool trans_m) const {

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -538,12 +538,12 @@ public:
    *            1 : channel direction
    *            2 : height direction
    *            3 : width direction
-   * @param[out] output output tensor
    * @param[in] axis Axis to calculate sum along
+   * @param[out] output output tensor
    * @param[in] alpha Scale the sum by this value
    * @retval    Calculated Tensor
    */
-  Tensor &sum(Tensor &output, unsigned int axis, float alpha = 1.0) const;
+  Tensor &sum(unsigned int axis, Tensor &output, float alpha = 1.0) const;
 
   /**
    * @brief sum all the Tensor by multiple axes
@@ -554,6 +554,16 @@ public:
    */
   Tensor sum(const std::vector<unsigned int> &axes, float alpha = 1.0) const;
 
+  /**
+   * @brief sum all the Tensor by multiple axes
+   *
+   * @param axes axes to sum along
+   * @param[out] output output tensor
+   * @param alpha Scale the sum by this value
+   * @return Tensor
+   */
+  Tensor &sum(const std::vector<unsigned int> &axes, Tensor &output,
+              float alpha = 1.0) const;
   /**
    * @brief     Averaging the Tensor elements according to the axis
    *            0 : batch direction

--- a/nntrainer/utils/base_properties.cpp
+++ b/nntrainer/utils/base_properties.cpp
@@ -13,8 +13,8 @@
 #include <parse_util.h>
 #include <tensor_dim.h>
 
-#include <sstream>
 #include <regex>
+#include <sstream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Update tensor sum to support in-place sum when done over
multiple dimensions.
Also update arguments order to have output tensor as a latter
argument.

Make bias derivative in-place for fc layer

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>

resolves #1202 