### PR TITLE
[Props] Add concept of empty to property

### DIFF
--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -23,9 +23,8 @@
 namespace nntrainer {
 namespace props {
 bool Name::isValid(const std::string &v) const {
-
   static std::regex allowed("[a-zA-Z0-9][-_./a-zA-Z0-9]*");
-  return std::regex_match(v, allowed);
+  return !v.empty() && std::regex_match(v, allowed);
 }
 
 ConnectionSpec::ConnectionSpec(const std::vector<props::Name> &layer_ids_,

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -27,10 +27,20 @@ namespace props {
  */
 class Name : public nntrainer::Property<std::string> {
 public:
-  Name(const std::string &value = "") :
-    nntrainer::Property<std::string>(value) {} /**< default value if any */
-  static constexpr const char *key = "name";   /**< unique key to access */
-  using prop_tag = str_prop_tag;               /**< property type */
+  /**
+   * @brief Construct a new Name object without a default value
+   *
+   */
+  Name() : nntrainer::Property<std::string>() {}
+
+  /**
+   * @brief Construct a new Name object with a default value
+   *
+   * @param value value to contrusct the property
+   */
+  Name(const std::string &value) : nntrainer::Property<std::string>(value) {}
+  static constexpr const char *key = "name"; /**< unique key to access */
+  using prop_tag = str_prop_tag;             /**< property type */
 
   /**
    * @brief name validator
@@ -48,7 +58,7 @@ public:
  */
 class Unit : public nntrainer::Property<unsigned int> {
 public:
-  Unit(unsigned int value = 0) :
+  Unit(unsigned int value = 1) :
     nntrainer::Property<unsigned int>(value) {} /**< default value if any */
   static constexpr const char *key = "unit";    /**< unique key to access */
   using prop_tag = uint_prop_tag;               /**< property type */
@@ -64,10 +74,6 @@ class ConnectionSpec {
 public:
   static std::string NoneType;
 
-  /**
-   * @brief Construct a new Connection Spec object
-   */
-  ConnectionSpec() = default;
   /**
    * @brief Construct a new Connection Spec object
    *
@@ -148,7 +154,18 @@ struct connection_prop_tag {};
  */
 class InputSpec : public nntrainer::Property<ConnectionSpec> {
 public:
-  InputSpec(const ConnectionSpec &value = ConnectionSpec()) :
+  /**
+   * @brief Construct a new Input Spec object
+   *
+   */
+  InputSpec() : nntrainer::Property<ConnectionSpec>() {}
+
+  /**
+   * @brief Construct a new Input Spec object
+   *
+   * @param value default value of a input spec
+   */
+  InputSpec(const ConnectionSpec &value) :
     nntrainer::Property<ConnectionSpec>(value) {} /**< default value if any */
   static constexpr const char *key =
     "input_layers";                     /**< unique key to access */

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -91,7 +91,8 @@ public:
    * to keep the name unique to the model
    */
   const std::string getName() const noexcept {
-    return std::get<props::Name>(props).get();
+    auto &name = std::get<props::Name>(props);
+    return name.empty() ? "" : name.get();
   }
 
   /**
@@ -102,7 +103,10 @@ public:
    * @note      This name might be changed once this layer is added to the model
    * to keep the name unique to the model
    */
-  std::string getName() noexcept { return std::get<props::Name>(props).get(); }
+  std::string getName() noexcept {
+    auto &name = std::get<props::Name>(props);
+    return name.empty() ? "" : name.get();
+  }
 
   /**
    * Support all the interface requirements by GraphNode<nntrainer::Layer>

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -126,8 +126,10 @@ public:
        * @param index index of the current property
        */
       auto callable = [this](auto &&prop, size_t index) {
-        std::string key = getPropKey(prop);
-        stored_result->emplace_back(key, to_string(prop));
+        if (!prop.empty()) {
+          std::string key = getPropKey(prop);
+          stored_result->emplace_back(std::move(key), to_string(prop));
+        }
       };
       iterate_prop(callable, props);
     } break;

--- a/test/unittest/unittest_base_properties.cpp
+++ b/test/unittest/unittest_base_properties.cpp
@@ -49,7 +49,8 @@ public:
  */
 class QualityOfBanana : public nntrainer::Property<std::string> {
 public:
-  QualityOfBanana(const char *value = "") : Property<std::string>(value) {}
+  QualityOfBanana() : nntrainer::Property<std::string>() {}
+  QualityOfBanana(const char *value) : Property<std::string>(value) {}
   static constexpr const char *key = "quality_banana";
   using prop_tag = nntrainer::str_prop_tag;
 
@@ -194,9 +195,6 @@ TEST(BasicProperty, valid_p) {
 
     auto pair = std::pair<std::string, std::string>("num_banana", "1");
     EXPECT_EQ(result->at(0), pair);
-
-    auto pair2 = std::pair<std::string, std::string>("quality_banana", "");
-    EXPECT_EQ(result->at(1), pair2);
   }
 
   { /**< export from layer */
@@ -205,12 +203,9 @@ TEST(BasicProperty, valid_p) {
     nntrainer::Exporter e;
     lnode.export_to(e);
 
-    auto result =
-      std::move(e.getResult<nntrainer::ExportMethods::METHOD_STRINGVECTOR>());
-    auto pair0 = std::pair<std::string, std::string>("name", "");
-    EXPECT_EQ(result->at(0), pair0);
+    auto result = e.getResult<nntrainer::ExportMethods::METHOD_STRINGVECTOR>();
     auto pair1 = std::pair<std::string, std::string>("unit", "1");
-    EXPECT_EQ(result->at(1), pair1);
+    EXPECT_EQ(result->at(0), pair1);
   }
 
   { /**< load from layer */


### PR DESCRIPTION
- [Props] Add concept of empty to property

This patch adds empty concept to property instead of having insensible
value inside a property as a default

before this patch,
```cpp
auto a = Property<int>();
EXPECT_EQ(a.get(), -1); // let's assume -1 is default value which might not be sensible.
```
after this patch

```cpp
auto a = Property<int>();
EXPECT_THROW(a.get(), std::invalid_argument);
EXPECT_TRUE(a.empty());
```

so underlying value remains always null or valid.

Now, it became natural to distinguish mandatory props and non-mandatory
props

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>