### PR TITLE
[layer] Move distribute to LayerNode

### DIFF
--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -133,20 +133,8 @@ section2layer<PlainLayer>(dictionary *ini, const std::string &sec_name,
     << FUNC_TAG << "section type is invalid for section name: " << sec_name;
 
   auto properties = section2properties(ini, sec_name);
-  std::shared_ptr<Layer> nntr_layer = ac.createObject<Layer>(layer_type);
 
-  if (nntr_layer->getDistribute()) {
-    ml_logd("This %s layer is going to distributed", sec_name.c_str());
-    std::shared_ptr<Layer> dist_layer =
-      nntrainer::createLayer(TimeDistLayer::type);
-    std::dynamic_pointer_cast<TimeDistLayer>(dist_layer)
-      ->setDistLayer(nntr_layer);
-
-    nntr_layer = dist_layer;
-  }
-
-  auto layer = createLayerNode(nntr_layer, properties);
-
+  auto layer = createLayerNode(ac.createObject<Layer>(layer_type), properties);
   return layer;
 }
 

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -35,7 +35,7 @@ public:
    * @brief     Get index of the node
    *
    */
-  virtual size_t getIndex() = 0;
+  virtual size_t getIndex() const = 0;
 
   /**
    * @brief     Set index of the node

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -323,35 +323,35 @@ private:
 
   /**
    * @brief     check and add Multi Input Layer : addition or concat Layer
-   * @param[in] current layer
+   * @param[in] in_node layernode
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int realizeMultiInputType(Layer &current);
+  int realizeMultiInputType(const std::shared_ptr<LayerNode> &in_node);
 
   /**
    * @brief     check and add Multi output Layer : output Layer
-   * @param[in] current layer
+   * @param[in] in_node layernode
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int realizeMultiOutputType(Layer &current);
+  int realizeMultiOutputType(const std::shared_ptr<LayerNode> &in_node);
 
   /**
    * @brief     Realize act type to layer and insert it to layers
-   * @param[in] current layer
+   * @param[in] in_node layernode
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int realizeActivationType(Layer &current);
+  int realizeActivationType(const std::shared_ptr<LayerNode> &in_node);
 
   /**
    * @brief     Realize flatten type to layer and insert it to layers
-   * @param[in] current layer
+   * @param[in] in_node layernode
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int realizeFlattenType(Layer &current);
+  int realizeFlattenType(const std::shared_ptr<LayerNode> &in_node);
 
   /**
    * @brief     adding loss layer at last position

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -86,7 +86,6 @@ void Layer::copy(std::shared_ptr<Layer> l) {
   this->weight_regularizer_constant = l->weight_regularizer_constant;
   this->weight_initializer = l->weight_initializer;
   this->trainable = l->trainable;
-  this->distribute = l->distribute;
 }
 
 sharedConstTensors Layer::forwarding_with_val(sharedConstTensors input,
@@ -282,12 +281,6 @@ void Layer::setProperty(const PropertyType type, const std::string &value) {
       throw_status(status);
     }
     break;
-  case PropertyType::distribute:
-    if (!value.empty()) {
-      status = setBoolean(distribute, value);
-      throw_status(status);
-    }
-    break;
   default:
     std::string msg =
       "[Layer] Unknown Layer Property Key for value " + std::string(value);
@@ -335,7 +328,6 @@ void Layer::printPropertiesMeta(std::ostream &out) {
 
 void Layer::printProperties(std::ostream &out) {
   out << "Trainable: " << trainable << std::endl;
-  out << "Distributed: " << distribute << std::endl;
   printIfValid(out, PropertyType::weight_regularizer,
                static_cast<int>(weight_regularizer));
   printIfValid(out, PropertyType::weight_regularizer_constant,

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -63,8 +63,7 @@ public:
         WeightInitializer weight_initializer_ =
           WeightInitializer::WEIGHT_XAVIER_UNIFORM,
         WeightInitializer bias_initializer_ = WeightInitializer::WEIGHT_ZEROS,
-        bool trainable_ = true, bool flatten_ = false,
-        bool distribute_ = false) :
+        bool trainable_ = true) :
     layer_props(props::Name()),
     loss(0.0f),
     activation_type(activation_type_),
@@ -72,8 +71,7 @@ public:
     weight_regularizer_constant(weight_regularizer_constant_),
     weight_initializer(weight_initializer_),
     bias_initializer(bias_initializer_),
-    trainable(trainable_),
-    distribute(distribute_) {
+    trainable(trainable_) {
     setNumInputs(1);
     setNumOutputs(1);
   }
@@ -293,8 +291,9 @@ public:
   /**
    * @brief     Activation Type Getter
    * @retval    Activation Type.
+   * @todo      This function will soon be removed
    */
-  ActivationType getActivationType() { return this->activation_type; }
+  virtual ActivationType getActivationType() { return this->activation_type; }
 
   /**
    * @brief     Copy Layer
@@ -351,18 +350,6 @@ public:
    * @retval train to enable/disable train
    */
   virtual bool getTrainable() noexcept { return trainable; }
-
-  /**
-   * @brief     set distribute for this layer
-   * @param[in] dist to enable/disable distribute
-   */
-  virtual void setDistribute(bool dist) { distribute = dist; }
-
-  /**
-   * @brief     get distribute for this layer
-   * @retval dist to enable/disable distribute
-   */
-  virtual bool getDistribute() noexcept { return distribute; }
 
   /**
    * @brief     get all weights of the layer
@@ -601,6 +588,14 @@ public:
     return output_layers;
   }
 
+  /**
+   * @brief     Activation Setter
+   * @param[in] activation activation type
+   * @throw std::invalid_argument when ActivationType is unknown
+   * @todo      This function will soon be removed
+   */
+  virtual void setActivation(ActivationType activation);
+
 protected:
   /**
    * @brief   Print Options when printing layer info
@@ -666,24 +661,11 @@ protected:
    */
   bool trainable;
 
-  // TODO: remove this from here
-  /**
-   * @brief     making this true will iterating along with time distribution
-   */
-  bool distribute;
-
   /**
    * @brief     weight_list in this layer. This contains all weights of the
    * layer.
    */
   std::vector<Weight> weights;
-
-  /**
-   * @brief     Activation Setter
-   * @param[in] activation activation type
-   * @throw std::invalid_argument when ActivationType is unknown
-   */
-  virtual void setActivation(ActivationType activation);
 
 private:
   // TODO: remove this from here

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -36,11 +36,7 @@ public:
    * @brief     Constructor of LayerNode class
    *
    */
-  LayerNode(std::shared_ptr<nntrainer::Layer> l, size_t idx = 0) :
-    layer(l),
-    index(idx),
-    flatten(false),
-    activation_type(ActivationType::ACT_NONE) {}
+  LayerNode(std::shared_ptr<nntrainer::Layer> l, size_t idx = 0);
 
   /**
    * @brief     Destructor of LayerNode Class
@@ -62,7 +58,7 @@ public:
    *
    * @return const std::string type representation
    */
-  const std::string getType() const { return layer->getType(); }
+  const std::string getType() const;
 
   /**
    * @brief     set Property of layer
@@ -92,7 +88,7 @@ public:
    * @note      This name might be changed once this layer is added to the model
    * to keep the name unique to the model
    */
-  const std::string getName() const noexcept { return layer->getName(); }
+  const std::string getName() const noexcept { return getLayer()->getName(); }
 
   /**
    * @brief     Get name of the layer
@@ -102,7 +98,7 @@ public:
    * @note      This name might be changed once this layer is added to the model
    * to keep the name unique to the model
    */
-  std::string getName() noexcept { return layer->getName(); }
+  std::string getName() noexcept { return getLayer()->getName(); }
 
   /**
    * Support all the interface requirements by GraphNode<nntrainer::Layer>
@@ -112,26 +108,26 @@ public:
    * @brief     Get underlying object
    *
    */
-  std::shared_ptr<nntrainer::Layer> &getObject() { return layer; }
+  std::shared_ptr<nntrainer::Layer> &getObject();
 
   /**
    * @brief     Get underlying object
    *
    */
-  const std::shared_ptr<nntrainer::Layer> &getObject() const { return layer; }
+  const std::shared_ptr<nntrainer::Layer> &getObject() const;
 
   /**
    * @brief     Get index of the node
    *
    */
-  size_t getIndex() { return index; }
+  size_t getIndex() const { return index; }
 
   /**
    * @brief     Get the trainable property of the underlying object
    *
    * @return boolean true if trainable, else false
    */
-  bool getTrainable() noexcept { return layer->getTrainable(); }
+  bool getTrainable() const noexcept;
 
   /**
    * Support interfaces for the properties intercepted from layer
@@ -141,7 +137,25 @@ public:
    * @brief     get if the output of this layer must be flatten
    * @retval    flatten value
    */
-  bool getFlatten() { return flatten; }
+  bool getFlatten() const { return flatten; }
+
+  /**
+   * @brief     get distribute for this layer
+   * @retval dist to enable/disable distribute
+   */
+  bool getDistribute() const noexcept { return distribute; }
+
+  /**
+   * @brief     get distribute for this layer
+   * @retval dist to enable/disable distribute
+   */
+  std::string getDistLayerType() const;
+
+  /**
+   * @brief     Activation Type Getter
+   * @retval    Activation Type.
+   */
+  ActivationType getActivationType();
 
 #ifdef PROFILE
   int event_key;
@@ -160,10 +174,10 @@ private:
 
   std::vector<std::string> input_layers;  /**< input layer names */
   std::vector<std::string> output_layers; /**< output layer names */
-  bool flatten; /**< flatten the output of this node */
+  bool flatten;    /**< flatten the output of this node */
+  bool distribute; /**< to enable itearting along with time distribution */
   ActivationType
     activation_type; /**< activation applied to the output of this node */
-  bool distribute;
 
   /**
    * These properties are set for the layer by the user but are intercepted
@@ -181,8 +195,24 @@ private:
    * the particular layer
    * @exception std::invalid_argument invalid argument
    */
-  virtual void setProperty(const nntrainer::Layer::PropertyType type,
-                           const std::string &value = "");
+  void setProperty(const nntrainer::Layer::PropertyType type,
+                   const std::string &value = "");
+
+  /**
+   * @brief   Get the effective layer managed by this layer node
+   *
+   * @details this is layer inside the distribution layer if this layer node
+   * is distributed.
+   */
+  const std::shared_ptr<nntrainer::Layer> &getLayer() const;
+
+  /**
+   * @brief   Get the effective layer managed by this layer node
+   *
+   * @details this is layer inside the distribution layer if this layer node
+   * is distributed.
+   */
+  std::shared_ptr<nntrainer::Layer> &getLayer();
 };
 
 /**

--- a/nntrainer/layers/time_dist.h
+++ b/nntrainer/layers/time_dist.h
@@ -95,7 +95,7 @@ public:
    * @brief     get distribute layer
    * @retval dist_layer std::shared_ptr<Layer>
    */
-  std::shared_ptr<Layer> getDistLayer() { return dist_layer; };
+  std::shared_ptr<Layer> &getDistLayer() { return dist_layer; };
 
   /**
    * @brief     get transposed Tensor according to time iteration axis
@@ -126,6 +126,10 @@ public:
    */
   void setProperty(const PropertyType type,
                    const std::string &value = "") override {
+    /**
+     * @note assumption: name of the dist_layer is set via setName() and not
+     * with setProperty()
+     */
     dist_layer->setProperty(type, value);
   }
 

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -24,6 +24,7 @@
 #include <flatten_layer.h>
 #include <input_layer.h>
 #include <layer_internal.h>
+#include <layer_node.h>
 #include <loss_layer.h>
 #include <lstm.h>
 #include <manager.h>
@@ -139,7 +140,6 @@ protected:
                    const nntrainer::TensorDim &dim) {
     nntrainer::Tensor golden(dim);
     loadFile(expected, golden);
-    /** FIXME: golden.length() is possibly 0 many times, verify and fix this */
     matchOutput(result, golden.getData(), golden.length());
   }
 
@@ -710,14 +710,6 @@ TEST_F(nntrainer_FullyConnectedLayer, setActivation_01_p) {
 TEST_F(nntrainer_FullyConnectedLayer, setActivation_02_n) {
   status = layer.setProperty({"activation=unknown"});
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-}
-
-/**
- * @brief Fully Connected Layer
- */
-TEST_F(nntrainer_FullyConnectedLayer, setDistribute_01_p) {
-  status = layer.setProperty({"distribute=true"});
-  EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
 /**
@@ -2633,6 +2625,33 @@ TEST_F(nntrainer_SplitLayer, forwarding_backwarding_01_p) {
 
     EXPECT_EQ(*joined_deriv[0].get(), derivative);
   }
+}
+
+/**
+ * @brief Layer Node
+ */
+TEST(nntrainer_LayerNode, setDistribute_01_p) {
+  int status = ML_ERROR_NONE;
+
+  auto lnode = nntrainer::createLayerNode(nntrainer::FullyConnectedLayer::type);
+
+  EXPECT_EQ(false, lnode->getDistribute());
+
+  status = lnode->setProperty({"distribute=true"});
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  EXPECT_EQ(true, lnode->getDistribute());
+}
+
+/**
+ * @brief Layer Node
+ */
+TEST(nntrainer_LayerNode, setFlatten_01_p) {
+  int status = ML_ERROR_NONE;
+
+  auto lnode = nntrainer::createLayerNode(nntrainer::FullyConnectedLayer::type);
+  status = lnode->setProperty({"flatten=true"});
+  EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
 /**


### PR DESCRIPTION
move distribute to LayerNode from layer
Further, the distribute layer is now supposed to be used
as a wrapper of a layer maintained by the LayerNode,
and must not be maintained externally.
Rather, use getDistribute() to check if the node is distributed
and treat the layer as a regular layer.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>