### PR TITLE
[Fix] Add missing header

### DIFF
--- a/nntrainer/nntrainer_logger.cpp
+++ b/nntrainer/nntrainer_logger.cpp
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <ctime>
 #include <iomanip>
+#include <iostream>
 #include <mutex>
 #include <nntrainer_logger.h>
 #include <sstream>


### PR DESCRIPTION
- [Fix] Add missing header

```
This patch adds missing header for logger when `enable_logging=false`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```