### PR TITLE
[Recorder] Add multiout equivalent in transLayer @open sesame 06/09 15:12

### DIFF
--- a/test/input_gen/recorder.py
+++ b/test/input_gen/recorder.py
@@ -21,7 +21,7 @@ with warnings.catch_warnings():
     import tensorflow as tf
     from tensorflow.python import keras as K
 
-from transLayer import attach_trans_layer
+from transLayer import attach_trans_layer, MultiOutLayer
 
 __all__ = ["record"]
 
@@ -174,6 +174,9 @@ def train_step(model, optimizer, loss_fn, initial_input, label, writer_fn, **kwa
         loss = loss_fn(label, outp[-1])
 
     for layer in iter_model(model):
+        if isinstance(layer, MultiOutLayer):
+            continue
+
         layer_output = outputs[layer.name]
         layer_input = inputs[layer.name]
 


### PR DESCRIPTION
- [Recorder] Add multiout equivalent in transLayer

```
When getting gradient from `gradientTape` it adds all derivatives of the
dependent layer. While this behavior is true, we need to measure to what
extent each layer contributed to the layer.

This patch adds a multiout layer which consists of some stublayer that
seperates derivatives one by one.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```