### PR TITLE
[Fix/graph] fix index after removing node

### DIFF
--- a/nntrainer/graph/graph_core.cpp
+++ b/nntrainer/graph/graph_core.cpp
@@ -182,8 +182,16 @@ void GraphCore::ensureName(GraphNode &node, const std::string &prefix,
 
 void GraphCore::removeLastNode() {
   auto last_node = Sorted.back();
+
   Sorted.pop_back();
-  adj.erase(adj.begin() + last_node->getIndex());
+
+  /// fix index after last node has been deleted.
+  auto after = adj.erase(adj.begin() + last_node->getIndex());
+  auto after_index = last_node->getIndex();
+
+  for (; after != adj.end(); ++after) {
+    after->front()->setIndex(after_index++);
+  }
 
   /**
    * Remove all the connections for the current last layer as it will now only


### PR DESCRIPTION
- [Fix/graph] fix index after removing node

```
**Changes proposed in this PR:**
- After removing last node, adj node after the target node becomes not
correct, this patch fixes the issue

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```