### PR TITLE
[wait for #1210] [split/test] Added unittests for split layer 

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -52,6 +52,7 @@ enum LayerType {
   LAYER_EMBEDDING,            /** Embedding Layer type */
   LAYER_RNN,                  /** RNN Layer type */
   LAYER_LSTM,                 /** LSTM Layer type */
+  LAYER_SPLIT,                /** Splite Layer type */
   LAYER_TIME_DIST,            /** Time Distributed Layer type */
   LAYER_UNKNOWN = ML_TRAIN_LAYER_TYPE_UNKNOWN /** Unknown */
 };

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -122,6 +122,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/lstm.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/time_dist.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/acti_func.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/layers/split_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/common_properties.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/graph/network_graph.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/graph/graph_core.cpp \

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -47,6 +47,7 @@
 #include <preprocess_flip_layer.h>
 #include <preprocess_translate_layer.h>
 #include <rnn.h>
+#include <split_layer.h>
 #include <time_dist.h>
 
 #ifdef ENABLE_TFLITE_BACKBONE
@@ -236,16 +237,14 @@ static void add_default_object(AppContext &ac) {
 #endif
   ac.registerFactory(nntrainer::createLayer<EmbeddingLayer>,
                      EmbeddingLayer::type, LayerType::LAYER_EMBEDDING);
-
   ac.registerFactory(nntrainer::createLayer<RNNLayer>, RNNLayer::type,
                      LayerType::LAYER_RNN);
-
   ac.registerFactory(nntrainer::createLayer<LSTMLayer>, LSTMLayer::type,
                      LayerType::LAYER_LSTM);
-
   ac.registerFactory(nntrainer::createLayer<TimeDistLayer>, TimeDistLayer::type,
                      LayerType::LAYER_TIME_DIST);
-
+  ac.registerFactory(nntrainer::createLayer<SplitLayer>, SplitLayer::type,
+                     LayerType::LAYER_SPLIT);
   ac.registerFactory(AppContext::unknownFactory<nntrainer::Layer>, "unknown",
                      LayerType::LAYER_UNKNOWN);
 }

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -81,6 +81,8 @@ public:
    */
   void calcDerivative() override;
 
+  using Layer::setProperty;
+
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)

--- a/nntrainer/layers/layer_factory.cpp
+++ b/nntrainer/layers/layer_factory.cpp
@@ -27,6 +27,7 @@
 #include <parse_util.h>
 #include <pooling2d_layer.h>
 #include <rnn.h>
+#include <split_layer.h>
 #include <time_dist.h>
 
 #ifdef ENABLE_TFLITE_BACKBONE
@@ -77,6 +78,8 @@ const std::string layerGetStrType(const LayerType &type) {
     return EmbeddingLayer::type;
   case LayerType::LAYER_TIME_DIST:
     return TimeDistLayer::type;
+  case LayerType::LAYER_SPLIT:
+    return SplitLayer::type;
   case LayerType::LAYER_UNKNOWN:
     /** fallthrough intended */
   default:

--- a/nntrainer/layers/split_layer.cpp
+++ b/nntrainer/layers/split_layer.cpp
@@ -101,7 +101,7 @@ void SplitLayer::forwarding(bool training) {
   input_.reshape(input_reshape_helper);
 
   for (unsigned int idx = 0; idx < getNumOutputs(); idx++) {
-    Tensor &output_ = net_hidden[0]->getVariableRef();
+    Tensor &output_ = net_hidden[idx]->getVariableRef();
     output_.reshape(output_reshape_helper);
 
     for (unsigned int batch = 0; batch < input_.batch(); batch++) {
@@ -109,7 +109,7 @@ void SplitLayer::forwarding(bool training) {
         input_.getAddress(batch, 0, idx, 0), input_reshape_helper.width(),
         {1, 1, 1, input_reshape_helper.width()});
       Tensor dest_tensor = Tensor::Map(
-        output_.getAddress(batch, 0, idx, 0), output_reshape_helper.width(),
+        output_.getAddress(batch, 0, 0, 0), output_reshape_helper.width(),
         {1, 1, 1, output_reshape_helper.width()});
       dest_tensor.copy(source_tensor);
     }
@@ -126,7 +126,7 @@ void SplitLayer::calcDerivative() {
   input_.reshape(input_reshape_helper);
 
   for (unsigned int idx = 0; idx < getNumOutputs(); idx++) {
-    Tensor &output_ = net_hidden[0]->getGradientRef();
+    Tensor &output_ = net_hidden[idx]->getGradientRef();
     output_.reshape(output_reshape_helper);
 
     for (unsigned int batch = 0; batch < input_.batch(); batch++) {
@@ -134,7 +134,7 @@ void SplitLayer::calcDerivative() {
                                        input_reshape_helper.width(),
                                        {1, 1, 1, input_reshape_helper.width()});
       const Tensor source_tensor = Tensor::Map(
-        output_.getAddress(batch, 0, idx, 0), output_reshape_helper.width(),
+        output_.getAddress(batch, 0, 0, 0), output_reshape_helper.width(),
         {1, 1, 1, output_reshape_helper.width()});
       dest_tensor.copy(source_tensor);
     }

--- a/nntrainer/layers/split_layer.h
+++ b/nntrainer/layers/split_layer.h
@@ -32,12 +32,9 @@ public:
    * @brief     Constructor of Split Layer
    */
   template <typename... Args>
-  SplitLayer(unsigned int num_output_, unsigned int split_dim = 1,
-             Args... args) :
+  SplitLayer(unsigned int split_dim = 1, Args... args) :
     Layer(args...),
-    split_dimension(split_dim) {
-    setNumOutputs(num_output_);
-  }
+    split_dimension(split_dim) {}
 
   /**
    * @brief     Destructor of Split Layer
@@ -85,6 +82,8 @@ public:
    * @copydoc Layer::calcDerivative()
    */
   void calcDerivative() override;
+
+  using Layer::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string


### PR DESCRIPTION
Added unittests for split layer covering initialization,
forwarding and backwarding. Corresponding bug fixes are
also added.
This has revealed an issue with concat layer #1226
which will be resolved soon.

Resolves #1208

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>