### PR TITLE
[Fix] Prevent creating multiout for split

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -29,6 +29,7 @@
 #include <parse_util.h>
 #include <profiler.h>
 #include <rnn.h>
+#include <split_layer.h>
 #include <time_dist.h>
 
 #define LNODE(x) std::static_pointer_cast<LayerNode>(x)
@@ -508,7 +509,7 @@ int NetworkGraph::realizeGraph() {
 
   for (unsigned int i = 0; i < num_nodes; ++i) {
     Layer &l = *LNODE(node_list[i])->getObject();
-    if (l.getType() != OutputLayer::type) {
+    if (l.getType() != OutputLayer::type && l.getType() != SplitLayer::type) {
       status = realizeMultiOutputType(l);
       NN_RETURN_STATUS();
     }

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -2534,7 +2534,7 @@ TEST_F(nntrainer_SplitLayer, init_01_p) {
     auto in_dim = layer.getInputDimension();
     auto out_dim = layer.getOutputDimension();
 
-    int val_at_split_dim = in_dim[0].getTensorDim(idx);
+    unsigned int val_at_split_dim = in_dim[0].getTensorDim(idx);
     EXPECT_EQ(out_dim.size(), val_at_split_dim);
 
     out_dim_expect = in_dim[0];


### PR DESCRIPTION
- [Fix] Prevent creating multiout for split

```
This patch make an exception for split layer to not create multiout
layer. While fixing trivial build error of sign compare

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```