### PR TITLE
[tflite] Update dependency from tflite to tf2lite 

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Jijoong Moon <jijoong.moon@samsung.com>
 Build-Depends: gcc-9 | gcc-8 | gcc-7 (>=7.5),
  python3, python3-numpy,
  pkg-config, cmake, ninja-build, meson (>=0.50), debhelper (>=9),
- libopenblas-dev, libiniparser-dev (>=4.1), tensorflow-lite-dev, libjsoncpp-dev,
+ libopenblas-dev, libiniparser-dev (>=4.1), tensorflow2-lite-dev, libjsoncpp-dev,
  libcurl3-gnutls-dev | libcurl4-gnutls-dev | libcurl3-openssl-dev |
  libcurl4-openssl-dev | libcurl3-nns-dev | libcurl4-nns-dev, libgtest-dev,
  libflatbuffers-dev, libglib2.0-dev, nnstreamer-dev, libgstreamer1.0-dev,

--- a/meson.build
+++ b/meson.build
@@ -164,7 +164,7 @@ if get_option('enable-nnstreamer-backbone')
   add_project_arguments('-DENABLE_NNSTREAMER_BACKBONE=1', language:['c','cpp'])
 endif
 
-tflite_dep = dependency('tensorflow-lite', required: false)
+tflite_dep = dependency('tensorflow2-lite', required: false)
 if get_option('enable-tflite-backbone')
   add_project_arguments('-DENABLE_TFLITE_BACKBONE=1', language:['c','cpp'])
 endif

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -96,15 +96,15 @@ BuildRequires:	pkgconfig(capi-base-common)
 BuildRequires:	pkgconfig(dlog)
 
 %if 0%{?support_nnstreamer_backbone}
-BuildRequires: nnstreamer-tensorflow-lite
+BuildRequires: nnstreamer-tensorflow2-lite
 BuildRequires: %{capi_machine_learning_inference}-devel
 
-Requires:	nnstreamer-tensorflow-lite
+Requires:	nnstreamer-tensorflow2-lite
 Requires:	%{capi_machine_learning_inference}
 %endif # support_nnstreamer_backbone
 
 %if 0%{?support_tflite_backbone}
-BuildRequires: tensorflow-lite-devel
+BuildRequires: tensorflow2-lite-devel
 %endif # support_tflite_backbone
 
 %define enable_nnstreamer_tensor_filter -Denable-nnstreamer-tensor-filter=false
@@ -161,10 +161,10 @@ Static library package of nntrainer-devel
 Summary:	NNTrainer Examples
 Requires:	nntrainer = %{version}-%{release}
 Requires:	%{capi_machine_learning_inference}
-Requires:	nnstreamer-tensorflow-lite
+Requires:	nnstreamer-tensorflow2-lite
 BuildRequires:  nnstreamer-test-devel
-BuildRequires:	nnstreamer-tensorflow-lite
-BuildRequires:	tensorflow-lite-devel
+BuildRequires:	nnstreamer-tensorflow2-lite
+BuildRequires:	tensorflow2-lite-devel
 BuildRequires:	pkgconfig(jsoncpp)
 BuildRequires:	pkgconfig(libcurl)
 BuildRequires:	pkgconfig(dlog)


### PR DESCRIPTION
Update dependency from tensorflow-lite to tensorflow2-lite.
This is done for Tizen and Debian build. It has already been done for Android.

Tensorflow2-lite header is dependent on flatbuffer, so flatbuffers-devel
is additionally added as a build-dependency.

Resolves #1244

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>

cc. @myungjoo 