### PR TITLE
[ Release ] NNTrainer 0.2.0 Release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,10 @@
-nntrainer (0.1.1) UNRELEASED; urgency=medium
+nntrainer (0.2.0) unstable; urgency=medium
+
+  * 0.2.0 released
+
+ -- jijoongmoon <jijoong.moon@samsung.com>  Wed, 02 Jun 2021 22:14:52 +0900
+
+nntrainer (0.1.1) unstable; urgency=medium
 
   * 0.1.1 released
 

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -45,7 +45,7 @@
 
 Name:		nntrainer
 Summary:	Software framework for training neural networks
-Version:	0.1.1
+Version:	0.2.0
 Release:	0
 Packager:	Jijoong Moon <jijoong.moon@sansumg.com>
 License:	Apache-2.0
@@ -491,6 +491,8 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %endif
 
 %changelog
+* Wed Jun 02 2021 Jijoong Moon <jijoong.moon@samsung.com>
+- Release of 0.2.0
 * Wed Sep 23 2020 Jijoong Moon <jijoong.moon@samsung.com>
 - Release of 0.1.1
 * Mon Aug 10 2020 Jijoong Moon <jijoong.moon@samsung.com>


### PR DESCRIPTION
NNTrainer v1.0.0 is released.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>