### PR TITLE
[pkg] Reduce error tolerance for all builds @open sesame 06/08 10:52

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,11 @@
 ROOT_DIR:=$(shell pwd)
 export DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 export DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
+ifdef unit_test
+	export ENABLE_REDUCE_TOLERANCE ?= true
+else
+	export ENABLE_REDUCE_TOLERANCE ?= false
+endif
 
 %:
 	dh $@ --parallel
@@ -27,7 +32,8 @@ override_dh_auto_configure:
 	mkdir -p build
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc \
 		--libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nntrainer/bin \
-		--includedir=include -Dinstall-app=true build
+		--includedir=include -Dinstall-app=true -Ddebian-build=true \
+		-Dreduce-tolerance=$(ENABLE_REDUCE_TOLERANCE) build
 
 override_dh_auto_build:
 	ninja -C build

--- a/meson.build
+++ b/meson.build
@@ -133,6 +133,10 @@ if get_option('enable-test')
   add_project_arguments('-DENABLE_TEST=1', language:['c','cpp'])
 endif
 
+if get_option('reduce-tolerance')
+  add_project_arguments('-DREDUCE_TOLERANCE=1', language:['c', 'cpp'])
+endif
+
 libm_dep = cxx.find_library('m') # cmath library
 libdl_dep = cxx.find_library('dl') # DL library
 thread_dep = dependency('threads') # pthread for tensorflow-lite

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,3 +21,6 @@ option('capi-ml-inference-actual', type: 'string', value: 'capi-ml-inference',
         description: 'backward compatible dependency name of capi-ml-inference')
 option('capi-ml-common-actual', type: 'string', value: 'capi-ml-common',
         description: 'backward compatible dependency name of capi-ml-common')
+
+# detect build os
+option('reduce-tolerance', type: 'boolean', value: true)

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -264,6 +264,12 @@ NNSteamer tensor filter static package for nntrainer to support inference.
 %define enable_tflite_backbone -Denable-tflite-backbone=false
 %define enable_profile -Denable-profile=false
 %define capi_ml_pkg_dep_resolution -Dcapi-ml-inference-actual=%{?capi_ml_inference_pkg_name} -Dcapi-ml-common-actual=%{?capi_ml_common_pkg_name}
+%define enable_reduce_tolerance -Dreduce-tolerance=true
+
+# enable full tolerance on the CI
+%if 0%{?unit_test}
+%define enable_reduce_tolerance -Dreduce-tolerance=false
+%endif
 
 %if %{with tizen}
 %define enable_tizen -Denable-tizen=true
@@ -324,7 +330,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} \
       %{enable_tizen_feature_check} %{enable_cblas} %{enable_ccapi} \
       %{enable_gym} %{enable_nnstreamer_tensor_filter} %{enable_profile} \
       %{enable_nnstreamer_backbone} %{enable_tflite_backbone} \
-      %{capi_ml_pkg_dep_resolution} build
+      %{capi_ml_pkg_dep_resolution} %{enable_reduce_tolerance} build
 
 ninja -C build %{?_smp_mflags}
 

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -37,7 +37,12 @@
 #include <parse_util.h>
 #include <tensor.h>
 
+/** tolerance is reduced for packaging, but CI runs at full tolerance */
+#ifdef REDUCE_TOLERANCE
+#define tolerance 1.0e-4
+#else
 #define tolerance 1.0e-5
+#endif
 
 /** Enum values to get model accuracy and loss. Sync with internal CAPI header
  */


### PR DESCRIPTION
Reduce error tolerance for release builds to succeed build on launchpad and tizen builds.
The default error tolerance is only reduced for all release builds for all tests that use defined tolerance.
However, the CI will run at original tolerance for all the builds and will ensure that
values are matched with original precision.

The tolerance has to be reduced because different os
have different versions and implementations of the blas
which results in minor difference in the results of the float
operations. However, when the difference is accumulated over
a range of operations, the unittests fail to match the
exact values.

See Also #1251

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>