### PR TITLE
[api/pkg] Link with nntrainer in api pkgconfig 

### DIFF
--- a/api/capi/capi-ml-training.pc.in
+++ b/api/capi/capi-ml-training.pc.in
@@ -8,5 +8,7 @@ Name: capi-ml-training
 Description: NNTrainer API for Tizen
 Version: @VERSION@
 Requires: @CAPI_ML_COMMON_DEP@
+Requires.private: nntrainer
 Libs: -L${libdir} -lcapi-nntrainer
 Cflags: -I${includedir}/nntrainer
+Libs.private: -L${libdir} -lnntrainer

--- a/api/capi/capi-ml-training.pc.in
+++ b/api/capi/capi-ml-training.pc.in
@@ -7,7 +7,6 @@ includedir=@INCLUDE_INSTALL_DIR@
 Name: capi-ml-training
 Description: NNTrainer API for Tizen
 Version: @VERSION@
-Requires:
-# Requires: capi-ml-common
+Requires: @CAPI_ML_COMMON_DEP@
 Libs: -L${libdir} -lcapi-nntrainer
 Cflags: -I${includedir}/nntrainer

--- a/api/ccapi/ccapi-ml-training.pc.in
+++ b/api/ccapi/ccapi-ml-training.pc.in
@@ -7,7 +7,6 @@ includedir=@INCLUDE_INSTALL_DIR@
 Name: ccapi-ml-training
 Description: NNTrainer cc API
 Version: @VERSION@
-Requires:
-# Requires: capi-ml-common-devel
+Requires: @CAPI_ML_COMMON_DEP@
 Libs: -L${libdir} -lccapi-nntrainer
 Cflags: -I${includedir}/nntrainer

--- a/api/ccapi/ccapi-ml-training.pc.in
+++ b/api/ccapi/ccapi-ml-training.pc.in
@@ -8,5 +8,7 @@ Name: ccapi-ml-training
 Description: NNTrainer cc API
 Version: @VERSION@
 Requires: @CAPI_ML_COMMON_DEP@
+Requires.private: nntrainer
 Libs: -L${libdir} -lccapi-nntrainer
 Cflags: -I${includedir}/nntrainer
+Libs.private: -L${libdir} -lnntrainer

--- a/meson.build
+++ b/meson.build
@@ -95,6 +95,7 @@ nntrainer_conf.set('EXEC_PREFIX', nntrainer_bindir)
 nntrainer_conf.set('LIB_INSTALL_DIR', nntrainer_libdir)
 nntrainer_conf.set('PLUGIN_INSTALL_PREFIX', nntrainer_libdir / 'nntrainer')
 nntrainer_conf.set('INCLUDE_INSTALL_DIR', nntrainer_includedir)
+nntrainer_conf.set('CAPI_ML_COMMON_DEP', get_option('capi-ml-common-actual'))
 
 dummy_dep = dependency('', required: false)
 


### PR DESCRIPTION
API pkgconfig does not link with nntrianer.so
This patch adds that linking.

Resolves #1254 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>