### PR TITLE
[layer/node] Move input/output layers to LayerNode 

### DIFF
--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -239,15 +239,13 @@ getMergeableGraph(std::shared_ptr<const GraphRepresentation> graph,
   std::string input_shape =
     iniparser_getstring(ini, (sec_name + ":Input_Shape").c_str(), "");
   if (!input_shape.empty()) {
-    g[0]->getObject()->setProperty(Layer::PropertyType::input_shape,
-                                   input_shape);
+    g[0]->setProperty({"input_shape=" + input_shape});
   }
 
   std::string input_layers =
     iniparser_getstring(ini, (sec_name + ":Input_Layers").c_str(), "");
   if (!input_layers.empty()) {
-    g[0]->getObject()->setProperty(Layer::PropertyType::input_layers,
-                                   input_layers);
+    g[0]->setProperty({"input_layers=" + input_layers});
   }
 
   return g;

--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -261,13 +261,12 @@ void IniGraphInterpreter::serialize(
   for (auto iter = representation->cbegin(); iter != representation->cend();
        iter++) {
     const auto &ln = *iter;
-    const auto &layer = ln->getObject();
 
-    IniSection s(layer->getName());
-    s.setEntry("type", layer->getType());
+    IniSection s(ln->getName());
+    s.setEntry("type", ln->getType());
 
     Exporter e;
-    layer->export_to(e);
+    ln->export_to(e);
 
     const auto key_val_pairs =
       e.getResult<ExportMethods::METHOD_STRINGVECTOR>();

--- a/nntrainer/compiler/tflite_interpreter.cpp
+++ b/nntrainer/compiler/tflite_interpreter.cpp
@@ -246,7 +246,7 @@ buildOpNodes(std::shared_ptr<const GraphRepresentation> representation) {
        iter++) {
     const auto &ln = *iter;
     Exporter e;
-    ln->getObject()->export_to(e, ExportMethods::METHOD_TFLITE);
+    ln->export_to(e, ExportMethods::METHOD_TFLITE);
 
     nodes.emplace_back(e.getResult<ExportMethods::METHOD_TFLITE>());
   }

--- a/nntrainer/compiler/tflite_interpreter.cpp
+++ b/nntrainer/compiler/tflite_interpreter.cpp
@@ -22,6 +22,7 @@
 #include <tf_schema_generated.h>
 
 #include <fc_layer.h>
+#include <layer_node.h>
 #include <nntrainer_error.h>
 #include <node_exporter.h>
 #include <tensor.h>

--- a/nntrainer/compiler/tflite_opnode.cpp
+++ b/nntrainer/compiler/tflite_opnode.cpp
@@ -16,7 +16,7 @@
 
 namespace nntrainer {
 
-void TfOpNode::setInOut(const Layer &layer) {
+void TfOpNode::setInOut(const LayerNode &layer) {
   auto &in = layer.getInputLayers();
   is_input = std::find(in.begin(), in.end(), "__data__") != in.end();
 

--- a/nntrainer/compiler/tflite_opnode.h
+++ b/nntrainer/compiler/tflite_opnode.h
@@ -18,7 +18,7 @@
 
 #include <tf_schema_generated.h>
 
-#include <layer_internal.h>
+#include <layer_node.h>
 #include <var_grad.h>
 
 namespace nntrainer {
@@ -42,7 +42,7 @@ public:
    *
    * @param layer layer to check
    */
-  void setInOut(const Layer &layer);
+  void setInOut(const LayerNode &layer);
 
   /**
    * @brief Set the Inputs object from layer

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -349,7 +349,6 @@ void NetworkGraph::setOutputLayers() {
       if (layer_idx->getNumOutputs() == 0) {
         /** No output layer inplies its the last layer */
         layer_idx->setOutputLayers({"__exit__"});
-        ;
         last_layer_count += 1;
       } else {
         /** error for any other layer */

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -80,21 +80,22 @@ void NetworkGraph::updateConnectionName(const std::string &from,
     auto &layer = LNODE(node_list[i])->getObject();
     if (istrequal(layer->getName(), to))
       continue;
-    for (unsigned int j = 0; j < layer->input_layers.size(); ++j) {
-      if (istrequal(layer->input_layers[j], from)) {
-        layer->input_layers[j] = to;
-      }
-    }
+    LNODE(node_list[i])->updateInputLayers(from, to);
+    // for (unsigned int j = 0; j < layer->input_layers.size(); ++j) {
+    //   if (istrequal(layer->input_layers[j], from)) {
+    //     layer->input_layers[j] = to;
+    //   }
+    // }
   }
 }
 
 void NetworkGraph::addDefaultInputLayers() {
   const std::vector<std::shared_ptr<GraphNode>> &node_list = graph.getNodes();
   for (unsigned int i = 1; i < node_list.size(); ++i) {
-    auto &layer = LNODE(node_list[i])->getObject();
-    auto &prev_layer = LNODE(node_list[i - 1])->getObject();
-    if (layer->input_layers.size() == 0) {
-      layer->input_layers.push_back(prev_layer->getName());
+    auto layer = LNODE(node_list[i]);
+    auto prev_layer = LNODE(node_list[i - 1]);
+    if (layer->getInputLayers().size() == 0) {
+      layer->addInputLayers(prev_layer->getName());
     }
   }
 }
@@ -131,15 +132,17 @@ int NetworkGraph::realizeMultiInputType(
   graph.ensureName(*lnode, current.getName());
 
   layer->setNumInputs(current.getNumInputs());
-  layer->input_layers.clear();
-  for (unsigned int i = 0; i < current.input_layers.size(); ++i)
-    layer->input_layers.push_back(current.input_layers[i]);
+  lnode->setInputLayers(in_node->getInputLayers());
+  // layer->input_layers.clear();
+  // for (unsigned int i = 0; i < current.input_layers.size(); ++i)
+  //   layer->input_layers.push_back(current.input_layers[i]);
 
   layer->setNumOutputs(current.getNumOutputs());
 
   current.setNumInputs(layer->getNumOutputs());
-  current.input_layers.clear();
-  current.input_layers.push_back(layer->getName());
+  in_node->setInputLayers({lnode->getName()});
+  // current.input_layers.clear();
+  // current.input_layers.push_back(layer->getName());
   /** output layers for layer obj will be set in setOutputLayers() */
 
   graph.addNode(lnode, false);
@@ -162,8 +165,9 @@ int NetworkGraph::realizeFlattenType(
   graph.ensureName(*lnode, current.getName());
 
   layer->setNumInputs(current.getNumInputs());
-  layer->input_layers.clear();
-  layer->input_layers.push_back(current.getName());
+  lnode->setInputLayers({in_node->getName()});
+  // layer->input_layers.clear();
+  // layer->input_layers.push_back(current.getName());
   layer->setNumOutputs(current.getNumOutputs());
   /** output layers for layer obj will be set in setOutputLayers() */
 
@@ -217,8 +221,9 @@ int NetworkGraph::realizeActivationType(
   layer->setActivation(act);
 
   layer->setNumInputs(current.getNumInputs());
-  layer->input_layers.clear();
-  layer->input_layers.push_back(current.getName());
+  lnode->setInputLayers({in_node->getName()});
+  // layer->input_layers.clear();
+  // layer->input_layers.push_back(current.getName());
   layer->setNumOutputs(current.getNumOutputs());
   /** output layers for layer aobj will be set in setOutputLayers() */
 
@@ -244,22 +249,26 @@ int NetworkGraph::realizeMultiOutputType(
   std::shared_ptr<Layer> layer = lnode->getObject();
   graph.ensureName(*lnode, current.getName());
 
-  layer->input_layers.clear();
-  layer->input_layers.push_back(current.getName());
+  lnode->setInputLayers({in_node->getName()});
+  // layer->input_layers.clear();
+  // layer->input_layers.push_back(current.getName());
   layer->setNumInputs(1);
 
-  layer->output_layers = current.output_layers;
-  layer->setNumOutputs(current.output_layers.size());
+  lnode->setOutputLayers(in_node->getOutputLayers());
+  // layer->output_layers = current.output_layers;
+  layer->setNumOutputs(in_node->getOutputLayers().size());
 
   current.setNumOutputs(1);
-  current.output_layers.clear();
-  current.output_layers.push_back(layer->getName());
+  in_node->setOutputLayers({layer->getName()});
+  // current.output_layers.clear();
+  // current.output_layers.push_back(layer->getName());
 
-  for (unsigned int i = 0; i < current.output_layers.size(); ++i) {
+  for (unsigned int i = 0; i < in_node->getOutputLayers().size(); ++i) {
     updateConnectionName(current.getName(), layer->getName());
   }
 
-  current.setNumOutputs(current.output_layers.size());
+  current.setNumOutputs(in_node->getOutputLayers().size());
+  // current.setNumOutputs(current.output_layers.size());
   graph.addNode(lnode, false);
 
   return status;
@@ -322,18 +331,21 @@ int NetworkGraph::addLossLayer(const LossType loss_type) {
 
   last_layer_node = LNODE(updated_last_node);
   last_layer_node->getObject()->setNumOutputs(1);
-  last_layer_node->getObject()->output_layers.clear();
-  last_layer_node->getObject()->output_layers.push_back(layer->getName());
+  last_layer_node->setOutputLayers({layer->getName()});
+  // last_layer_node->getObject()->output_layers.clear();
+  // last_layer_node->getObject()->output_layers.push_back(layer->getName());
 
   layer->setNumInputs(1);
-  layer->input_layers.clear();
-  layer->input_layers.push_back(input_str);
+  lnode->setInputLayers({input_str});
+  // layer->input_layers.clear();
+  // layer->input_layers.push_back(input_str);
 
   /** Set output layers here as setOutputLayers will not be called after adding
    * loss. */
-  if (layer->output_layers.size() == 0) {
+  if (lnode->getOutputLayers().size() == 0) {
+    lnode->setOutputLayers({"__exit__"});
     layer->setNumOutputs(1);
-    layer->output_layers.push_back("__exit__");
+    // layer->output_layers.push_back("__exit__");
   }
 
   /**
@@ -353,36 +365,42 @@ void NetworkGraph::setOutputLayers() {
 
   size_t last_layer_count = 0;
   for (unsigned int idx = 0; idx < graph.size(); ++idx) {
-    auto &layer_idx = LNODE(node_list[idx])->getObject();
+    auto layer_idx = LNODE(node_list[idx]);
     for (unsigned int i = 0; i < graph.size(); ++i) {
-      auto &layer_i = LNODE(node_list[i])->getObject();
+      auto layer_i = LNODE(node_list[i]);
       if (istrequal(layer_i->getName(), layer_idx->getName()))
         continue;
-      for (unsigned int j = 0; j < layer_i->input_layers.size(); ++j) {
-        if (istrequal(layer_i->input_layers[j], layer_idx->getName())) {
+      for (unsigned int j = 0; j < layer_i->getInputLayers().size(); ++j) {
+        if (istrequal(layer_i->getInputLayers()[j], layer_idx->getName())) {
           bool already_exist = false;
-          for (unsigned int k = 0; k < layer_idx->output_layers.size(); ++k) {
-            if (istrequal(layer_idx->output_layers[k], layer_i->getName())) {
+          for (unsigned int k = 0; k < layer_idx->getOutputLayers().size();
+               ++k) {
+            if (istrequal(layer_idx->getOutputLayers()[k],
+                          layer_i->getName())) {
               already_exist = true;
               break;
             }
           }
 
           if (!already_exist)
-            layer_idx->output_layers.push_back(layer_i->getName());
+            layer_idx->addOutputLayers(layer_i->getName());
         }
       }
     }
 
-    if (layer_idx->getNumOutputs() != layer_idx->output_layers.size()) {
-      if (layer_idx->output_layers.size() == 0) {
+    if (layer_idx->getObject()->getNumOutputs() !=
+        layer_idx->getOutputLayers().size()) {
+      if (layer_idx->getOutputLayers().size() == 0) {
         /** No output layer inplies its the last layer */
-        layer_idx->setNumOutputs(1);
-        layer_idx->output_layers.clear();
-        layer_idx->output_layers.push_back("__exit__");
+        layer_idx->getObject()->setNumOutputs(1);
+        layer_idx->setOutputLayers({"__exit__"});
+        // layer_idx->output_layers.clear();
+        // layer_idx->output_layers.push_back("__exit__");
         last_layer_count += 1;
-      } else if (layer_idx->getNumOutputs() < layer_idx->output_layers.size()) {
-        layer_idx->setNumOutputs(layer_idx->output_layers.size());
+      } else if (layer_idx->getObject()->getNumOutputs() <
+                 layer_idx->getOutputLayers().size()) {
+        layer_idx->getObject()->setNumOutputs(
+          layer_idx->getOutputLayers().size());
       } else {
         /** error for any other layer */
         throw std::logic_error("Graph node has fewer edges than expected.");
@@ -396,7 +414,7 @@ void NetworkGraph::setOutputLayers() {
   }
 
   for (unsigned int idx = 0; idx < graph.size(); ++idx) {
-    if (LNODE(node_list[idx])->getObject()->output_layers.size() == 0)
+    if (LNODE(node_list[idx])->getOutputLayers().size() == 0)
       throw std::runtime_error("There is un-connected node");
   }
 }
@@ -458,7 +476,7 @@ int NetworkGraph::realizeGraph() {
 
     /** If a layer does not has input nodes, then it must have input dimension
      */
-    if (l.input_layers.size() < 1) {
+    if (lnode->getInputLayers().size() < 1) {
       for (unsigned int i = 0; i < l.getInputDimension().size(); ++i) {
         if (l.getInputDimension()[i].getDataLen() == 0) {
           ml_loge("Input Dimension must be set");
@@ -468,8 +486,9 @@ int NetworkGraph::realizeGraph() {
       }
 
       l.setNumInputs(1);
-      l.input_layers.clear();
-      l.input_layers.push_back("__data__");
+      lnode->setInputLayers({"__data__"});
+      // l.input_layers.clear();
+      // l.input_layers.push_back("__data__");
     }
 
     if (l.getType() != AdditionLayer::type &&
@@ -521,11 +540,11 @@ void NetworkGraph::connectGraph(unsigned int adj_idx) {
 
   std::shared_ptr<LayerNode> node = LNODE(graph.getNode(adj_idx));
 
-  for (unsigned int j = 0; j < node->getObject()->input_layers.size(); ++j) {
-    if (istrequal(node->getObject()->input_layers[j], "__data__"))
+  auto &input_layers = node->getInputLayers();
+  for (unsigned int j = 0; j < input_layers.size(); ++j) {
+    if (istrequal(input_layers[j], "__data__"))
       continue;
-    unsigned int to_node_id =
-      getLayerNode(node->getObject()->input_layers[j])->getIndex();
+    unsigned int to_node_id = getLayerNode(input_layers[j])->getIndex();
     graph.addEdge(to_node_id, node);
   }
 }
@@ -643,10 +662,11 @@ void NetworkGraph::extendGraph(std::vector<std::shared_ptr<LayerNode>> ex_graph,
    * This loop intends to connect a new backbone to be added with an old
    * backbone.
    */
-  auto &layer0_in = ex_graph[0]->getObject()->input_layers;
+  auto &layer0_in = ex_graph[0]->getInputLayers();
   for (unsigned int i = 0; i < layer0_in.size(); ++i) {
     if (sub_in_out.find(layer0_in[i]) != sub_in_out.end()) {
-      layer0_in[i] = sub_in_out[layer0_in[i]];
+      ex_graph[0]->updateInputLayers(i, sub_in_out[layer0_in[i]]);
+      // layer0_in[i] = sub_in_out[layer0_in[i]];
     } else if (!graph.verifyNode(layer0_in[i])) {
       throw std::runtime_error("Input layer name for backbone not found.");
     }
@@ -658,16 +678,18 @@ void NetworkGraph::extendGraph(std::vector<std::shared_ptr<LayerNode>> ex_graph,
      * Add prefix to the existing layer name,
      * and ensure it is unique in this new ex_graph
      */
-    auto &layer = layernode->getObject();
+    // auto &layer = layernode->getObject();
     std::string orig_name = prefix + layernode->getName();
     graph.ensureName(*layernode, prefix, "", true);
     sub_in_out.insert(std::make_pair(orig_name, layernode->getName()));
 
-    for (unsigned int i = 0; i < layer->input_layers.size(); ++i) {
-      if (sub_in_out.find(prefix + layer->input_layers[i]) !=
-          sub_in_out.end()) {
-        layer->input_layers[i] = sub_in_out[prefix + layer->input_layers[i]];
-      } else if (!graph.verifyNode(layer->input_layers[i])) {
+    auto &input_layers = layernode->getInputLayers();
+    for (unsigned int i = 0; i < input_layers.size(); ++i) {
+      if (sub_in_out.find(prefix + input_layers[i]) != sub_in_out.end()) {
+        layernode->updateInputLayers(
+          i, sub_in_out[prefix + layernode->getInputLayers()[i]]);
+        // layernode->input_layers[i] = sub_in_out[prefix + input_layers[i]];
+      } else if (!graph.verifyNode(layernode->getInputLayers()[i])) {
         throw std::runtime_error("Input layer name for backbone not found.");
       }
     }
@@ -702,18 +724,21 @@ void NetworkGraph::inPlaceOptimize(const std::string &layer_type,
         l->getActivationType() != ActivationType::ACT_SOFTMAX) {
       /** @note assumes layer to be optimized is only for single in/out tensor
        */
-      if (l->input_layers.size() != 1)
+      if (layer_node->getInputLayers().size() != 1)
         throw std::runtime_error("Internal error in the formed graph");
 
-      auto &prev_layer = getLayerNode(l->input_layers[0])->getObject();
+      auto prev_node = getLayerNode(layer_node->getInputLayers()[0]);
+      auto &prev_layer =
+        getLayerNode(layer_node->getInputLayers()[0])->getObject();
 
       unsigned int loc;
       auto layer_name = l->getName();
-      for (loc = 0; loc < prev_layer->output_layers.size(); ++loc)
-        if (prev_layer->output_layers[loc] == layer_name)
+      auto &output_layers = prev_node->getOutputLayers();
+      for (loc = 0; loc < output_layers.size(); ++loc)
+        if (output_layers[loc] == layer_name)
           break;
 
-      if (loc == prev_layer->output_layers.size())
+      if (loc == output_layers.size())
         throw std::runtime_error("Internal error in the formed graph.");
 
       if (prev_layer->getType() == InputLayer::type)
@@ -811,18 +836,21 @@ int NetworkGraph::initialize(std::shared_ptr<Manager> manager) {
         return ML_ERROR_INVALID_PARAMETER;
       }
 
-      for (unsigned int i = 0; i < lptr->input_layers.size(); ++i) {
-        Layer &in_layer = *getLayerNode(lptr->input_layers[i])->getObject();
+      auto &input_layers = lnode->getInputLayers();
+      for (unsigned int i = 0; i < input_layers.size(); ++i) {
+        auto in_layer_node = getLayerNode(input_layers[i]);
 
         unsigned int location = 0;
-        for (unsigned int j = 0; j < in_layer.output_layers.size(); ++j) {
-          if (in_layer.output_layers[j] == lptr->getName()) {
+        for (unsigned int j = 0; j < in_layer_node->getOutputLayers().size();
+             ++j) {
+          if (in_layer_node->getOutputLayers()[j] == lptr->getName()) {
             location = j;
             break;
           }
         }
 
-        lptr->setInputDimension(in_layer.getOutputDimension()[location], i);
+        lptr->setInputDimension(
+          in_layer_node->getObject()->getOutputDimension()[location], i);
       }
     }
 
@@ -841,20 +869,21 @@ int NetworkGraph::initialize(std::shared_ptr<Manager> manager) {
     /** Connect the output of the previous layers with the input of the current
      * layer */
     if (!first) {
-      for (unsigned int i = 0; i < lptr->input_layers.size(); ++i) {
-        Layer &in_layer = *getLayerNode(lptr->input_layers[i])->getObject();
+      auto &input_layers = lnode->getInputLayers();
+      for (unsigned int i = 0; i < input_layers.size(); ++i) {
+        auto in_layer_node = getLayerNode(input_layers[i]);
 
         unsigned int location = 0;
-        for (unsigned int j = 0; j < in_layer.output_layers.size(); ++j) {
-          if (in_layer.output_layers[j] == lptr->getName()) {
+        for (unsigned int j = 0; j < in_layer_node->getOutputLayers().size();
+             ++j) {
+          if (in_layer_node->getOutputLayers()[j] == lptr->getName()) {
             location = j;
             break;
           }
         }
 
-        lptr->net_input[i] = getLayerNode(lptr->input_layers[i])
-                               ->getObject()
-                               ->net_hidden[location];
+        lptr->net_input[i] =
+          getLayerNode(input_layers[i])->getObject()->net_hidden[location];
       }
     } else {
       auto &in_out = manager->trackLayerInputs(cur_type, lptr->getName(),

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -252,29 +252,6 @@ void Layer::setProperty(const PropertyType type, const std::string &value) {
       bias_initializer = (WeightInitializer)parseType(value, TOKEN_WEIGHT_INIT);
     }
     break;
-  case PropertyType::input_layers:
-    if (!value.empty()) {
-      static const std::regex reg("\\,+");
-      std::vector<std::string> concat_layers = split(value, reg);
-
-      /** TODO : match this with num_inputs property */
-      setNumInputs(concat_layers.size());
-      input_layers.clear();
-      for (unsigned int i = 0; i < getNumInputs(); ++i)
-        input_layers.push_back(concat_layers[i]);
-    }
-    break;
-  case PropertyType::output_layers:
-    if (!value.empty()) {
-      static const std::regex reg("\\,+");
-      std::vector<std::string> concat_layers = split(value, reg);
-
-      setNumOutputs(concat_layers.size());
-      output_layers.clear();
-      for (unsigned int i = 0; i < getNumOutputs(); ++i)
-        output_layers.push_back(concat_layers[i]);
-    }
-    break;
   case PropertyType::trainable:
     if (!value.empty()) {
       status = setBoolean(trainable, value);

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -575,24 +575,6 @@ public:
   }
 
   /**
-   * @brief Get the Input Layers object
-   *
-   * @return const std::vector<std::string>&
-   */
-  const std::vector<std::string> &getInputLayers() const {
-    return input_layers;
-  }
-
-  /**
-   * @brief Get the Output Layers object
-   *
-   * @return const std::vector<std::string>&
-   */
-  const std::vector<std::string> &getOutputLayers() const {
-    return output_layers;
-  }
-
-  /**
    * @brief     Activation Setter
    * @param[in] activation activation type
    * @throw std::invalid_argument when ActivationType is unknown
@@ -672,18 +654,6 @@ protected:
   std::vector<Weight> weights;
 
 private:
-  // TODO: remove this from here
-  /**
-   * @brief     input layer names
-   */
-  std::vector<std::string> input_layers;
-
-  // TODO: remove this from here
-  /**
-   * @brief     output layer names
-   */
-  std::vector<std::string> output_layers;
-
   /**
    * @brief check if @a type is valid and print if prop is valid to @a out
    */

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -330,6 +330,7 @@ public:
    *
    * @param exporter exporter that conatins exporting logic
    * @param method enum value to identify how it should be exported to
+   * @todo remove this when name is moved to layer_node
    */
   virtual void
   export_to(Exporter &exporter,
@@ -539,7 +540,11 @@ public:
   void setNumInputs(unsigned int size) {
     if (size < 1)
       throw std::invalid_argument("Minimum number of inputs must be 1");
-    input_dim.resize(size);
+    if (input_dim.size() != size) {
+      /** clear is intentional to clear any previously set input dimensions */
+      input_dim.clear();
+      input_dim.resize(size);
+    }
     net_input.resize(size);
   }
 
@@ -551,7 +556,11 @@ public:
   void setNumOutputs(unsigned int size) {
     if (size < 1)
       throw std::invalid_argument("Minimum number of outputs must be 1");
-    output_dim.resize(size);
+    if (output_dim.size() != size) {
+      /** clear is intentional to clear any previously set output dimensions */
+      output_dim.clear();
+      output_dim.resize(size);
+    }
     net_hidden.resize(size);
   }
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -119,19 +119,19 @@ void LayerNode::setProperty(const nntrainer::Layer::PropertyType type,
   case PropertyType::input_layers:
     if (!value.empty()) {
       static const std::regex reg("\\,+");
-      std::vector<std::string> concat_layers = split(value, reg);
+      std::vector<std::string> split_layers = split(value, reg);
 
-      layer->setNumInputs(concat_layers.size());
-      input_layers = concat_layers;
+      layer->setNumInputs(split_layers.size());
+      input_layers = split_layers;
     }
     break;
   case PropertyType::output_layers:
     if (!value.empty()) {
       static const std::regex reg("\\,+");
-      std::vector<std::string> concat_layers = split(value, reg);
+      std::vector<std::string> split_layers = split(value, reg);
 
-      layer->setNumOutputs(concat_layers.size());
-      output_layers = concat_layers;
+      layer->setNumOutputs(split_layers.size());
+      output_layers = split_layers;
     }
     break;
   default:

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -116,6 +116,24 @@ void LayerNode::setProperty(const nntrainer::Layer::PropertyType type,
       }
     }
     break;
+  case PropertyType::input_layers:
+    if (!value.empty()) {
+      static const std::regex reg("\\,+");
+      std::vector<std::string> concat_layers = split(value, reg);
+
+      layer->setNumInputs(concat_layers.size());
+      input_layers = concat_layers;
+    }
+    break;
+  case PropertyType::output_layers:
+    if (!value.empty()) {
+      static const std::regex reg("\\,+");
+      std::vector<std::string> concat_layers = split(value, reg);
+
+      layer->setNumOutputs(concat_layers.size());
+      output_layers = concat_layers;
+    }
+    break;
   default:
     throw std::invalid_argument("Unknown property.");
   }
@@ -176,6 +194,22 @@ std::shared_ptr<nntrainer::Layer> &LayerNode::getLayer() {
     return std::dynamic_pointer_cast<TimeDistLayer>(layer)->getDistLayer();
   else
     return layer;
+}
+
+void LayerNode::updateInputLayers(const std::string &from,
+                                  const std::string &to) {
+  for (unsigned int idx = 0; idx < input_layers.size(); ++idx) {
+    if (istrequal(input_layers[idx], from)) {
+      input_layers[idx] = to;
+    }
+  }
+}
+
+void LayerNode::updateInputLayers(const unsigned int idx,
+                                  const std::string &to) {
+  if (idx >= input_layers.size())
+    throw std::out_of_range("Out of range for input_layers");
+  input_layers[idx] = to;
 }
 
 }; // namespace nntrainer

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -255,6 +255,7 @@ public:
   export_to(Exporter &exporter,
             ExportMethods method = ExportMethods::METHOD_STRINGVECTOR) const {
     exporter.saveResult(props, method, this);
+    layer->export_to(exporter, method);
   };
 
 #ifdef PROFILE

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -157,6 +157,76 @@ public:
    */
   ActivationType getActivationType();
 
+  /**
+   * @brief Get the Input Layers object
+   *
+   * @return const std::vector<std::string>&
+   */
+  const std::vector<std::string> &getInputLayers() const {
+    return input_layers;
+  }
+
+  /**
+   * @brief Get the Output Layers object
+   *
+   * @return const std::vector<std::string>&
+   */
+  const std::vector<std::string> &getOutputLayers() const {
+    return output_layers;
+  }
+
+  /**
+   * @brief Update input layers entry name
+   *
+   * @param from The name to be updated
+   * @param to The name to be updated to
+   */
+  void updateInputLayers(const std::string &from, const std::string &to);
+
+  /**
+   * @brief Update the input layers name at the given idx
+   *
+   * @param idx The index at which layer name must be updated
+   * @param to The name to be updated to
+   */
+  void updateInputLayers(const unsigned int idx, const std::string &to);
+
+  /**
+   * @brief Add name to the input layers
+   *
+   * @param in_layer Name to be added
+   */
+  void addInputLayers(const std::string &in_layer) {
+    input_layers.push_back(in_layer);
+  }
+
+  /**
+   * @brief Add name to the output layers
+   *
+   * @param out_layer Name to be added
+   */
+  void addOutputLayers(const std::string &out_layer) {
+    output_layers.push_back(out_layer);
+  }
+
+  /**
+   * @brief Set the Input Layers object
+   *
+   * @param layers Name of the layers
+   */
+  void setInputLayers(const std::vector<std::string> &layers) {
+    input_layers = layers;
+  }
+
+  /**
+   * @brief Set the Output Layers object
+   *
+   * @param layers Name of the layers
+   */
+  void setOutputLayers(const std::vector<std::string> &layers) {
+    output_layers = layers;
+  }
+
 #ifdef PROFILE
   int event_key;
 #endif
@@ -172,6 +242,7 @@ private:
     layer;      /**< The actual object in the graph node */
   size_t index; /**< index of each node */
 
+  /** TODO : move management of num_inputs to layer_node */
   std::vector<std::string> input_layers;  /**< input layer names */
   std::vector<std::string> output_layers; /**< output layer names */
   bool flatten;    /**< flatten the output of this node */

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -18,6 +18,7 @@
 #include <graph_node.h>
 #include <layer.h>
 #include <layer_internal.h>
+#include <node_exporter.h>
 
 namespace nntrainer {
 
@@ -158,6 +159,18 @@ public:
   ActivationType getActivationType();
 
   /**
+   * @brief     Get number of inputs
+   * @retval    number of inputs
+   */
+  unsigned int getNumInputs() const { return input_layers.size(); }
+
+  /**
+   * @brief     Get number of outputs
+   * @retval    number of outputs
+   */
+  unsigned int getNumOutputs() const { return output_layers.size(); }
+
+  /**
    * @brief Get the Input Layers object
    *
    * @return const std::vector<std::string>&
@@ -198,6 +211,7 @@ public:
    */
   void addInputLayers(const std::string &in_layer) {
     input_layers.push_back(in_layer);
+    layer->setNumInputs(input_layers.size());
   }
 
   /**
@@ -207,6 +221,7 @@ public:
    */
   void addOutputLayers(const std::string &out_layer) {
     output_layers.push_back(out_layer);
+    layer->setNumOutputs(output_layers.size());
   }
 
   /**
@@ -216,6 +231,7 @@ public:
    */
   void setInputLayers(const std::vector<std::string> &layers) {
     input_layers = layers;
+    layer->setNumInputs(layers.size());
   }
 
   /**
@@ -225,7 +241,21 @@ public:
    */
   void setOutputLayers(const std::vector<std::string> &layers) {
     output_layers = layers;
+    layer->setNumOutputs(layers.size());
   }
+
+  /**
+   * @brief this function helps exporting the layer in a predefined format,
+   * while workarounding issue caused by templated function type eraser
+   *
+   * @param exporter exporter that conatins exporting logic
+   * @param method enum value to identify how it should be exported to
+   */
+  virtual void
+  export_to(Exporter &exporter,
+            ExportMethods method = ExportMethods::METHOD_STRINGVECTOR) const {
+    exporter.saveResult(props, method, this);
+  };
 
 #ifdef PROFILE
   int event_key;

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -52,8 +52,7 @@ void Exporter::saveTflResult(const std::tuple<props::Name> &props,
 }
 
 template <>
-void Exporter::saveTflResult(const std::tuple<props::Name> &props,
-                             const LayerNode *self) {
+void Exporter::saveTflResult(const std::tuple<> &props, const LayerNode *self) {
   createIfNull(tf_node);
   tf_node->setInOut(*self);
   tf_node->setInputs(self->getObject()->getInputRef());

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -49,9 +49,15 @@ template <>
 void Exporter::saveTflResult(const std::tuple<props::Name> &props,
                              const Layer *self) {
   createIfNull(tf_node);
+}
+
+template <>
+void Exporter::saveTflResult(const std::tuple<props::Name> &props,
+                             const LayerNode *self) {
+  createIfNull(tf_node);
   tf_node->setInOut(*self);
-  tf_node->setInputs(self->getInputRef());
-  tf_node->setOutputs(self->getOutputRef());
+  tf_node->setInputs(self->getObject()->getInputRef());
+  tf_node->setOutputs(self->getObject()->getOutputRef());
 }
 
 template <>

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -207,10 +207,20 @@ class Layer;
 /**
  * @copydoc template <typename PropsType, typename NodeType> void
  * Exporter::saveTflResult(const PropsType &props, const NodeType *self);
+ * @todo remove this when layer is refactored
  */
 template <>
 void Exporter::saveTflResult(const std::tuple<props::Name> &props,
                              const Layer *self);
+
+class LayerNode;
+/**
+ * @copydoc template <typename PropsType, typename NodeType> void
+ * Exporter::saveTflResult(const PropsType &props, const NodeType *self);
+ */
+template <>
+void Exporter::saveTflResult(const std::tuple<props::Name> &props,
+                             const LayerNode *self);
 
 class FullyConnectedLayer;
 /**

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -207,7 +207,6 @@ class Layer;
 /**
  * @copydoc template <typename PropsType, typename NodeType> void
  * Exporter::saveTflResult(const PropsType &props, const NodeType *self);
- * @todo remove this when layer is refactored
  */
 template <>
 void Exporter::saveTflResult(const std::tuple<props::Name> &props,
@@ -219,8 +218,7 @@ class LayerNode;
  * Exporter::saveTflResult(const PropsType &props, const NodeType *self);
  */
 template <>
-void Exporter::saveTflResult(const std::tuple<props::Name> &props,
-                             const LayerNode *self);
+void Exporter::saveTflResult(const std::tuple<> &props, const LayerNode *self);
 
 class FullyConnectedLayer;
 /**


### PR DESCRIPTION
This patch moves input/output layers to LayerNode.
Also, create an interface for accessing/setting input/output layers
from in the LayerNode.

Refactor get/set number of inputs/outputs.
This is now handled by layer_node.
Updating the input/output layers updates the count.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>