### PR TITLE
[layer] add supportInPlace() as an interface for the layer

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -36,13 +36,6 @@
 
 namespace nntrainer {
 
-/**
- * @todo Make inPlace as a static property of the layer and a state to verify if
- * this layer is working in-place
- */
-static const std::vector<std::string> in_place_layers = {
-  ActivationLayer::type, BatchNormalizationLayer::type};
-
 int NetworkGraph::compile(const LossType loss_type) {
   int status = ML_ERROR_NONE;
 
@@ -691,15 +684,19 @@ void NetworkGraph::addLayer(std::shared_ptr<LayerNode> layer) {
   graph.addNode(layer);
 }
 
-void NetworkGraph::inPlaceOptimize(const std::string &layer_type,
-                                   Manager &manager) {
+void NetworkGraph::inPlaceOptimize(Manager &manager) {
   for (auto iter = cbegin(); iter != cend(); iter++) {
     auto layer_node = *iter;
     auto &l = layer_node->getObject();
     std::string l_type = l->getType();
 
-    if (l_type == layer_type &&
-        l->getActivationType() != ActivationType::ACT_SOFTMAX) {
+    /**
+     * @todo concat/multi-output layer can be made in-place but with special
+     * handling where these layers can become no-op.
+     * consider this optimization for later
+     */
+
+    if (l->supportInPlace()) {
       /** @note assumes layer to be optimized is only for single in/out tensor
        */
       if (l->input_layers.size() != 1)
@@ -716,20 +713,12 @@ void NetworkGraph::inPlaceOptimize(const std::string &layer_type,
       if (loc == prev_layer->output_layers.size())
         throw std::runtime_error("Internal error in the formed graph.");
 
+      /** Previous layer cannot be input layer for in-place layer */
       if (prev_layer->getType() == InputLayer::type)
         continue;
 
-      /** check if previous layer was also in-place */
-      bool prev_layer_in_place = false;
-      for (auto const &in_place_layer : in_place_layers) {
-        if (prev_layer->getType() == in_place_layer) {
-          prev_layer_in_place = true;
-          break;
-        }
-      }
-
       /** Two layers cant work in-place consecutively */
-      if (prev_layer_in_place)
+      if (prev_layer->supportInPlace())
         continue;
 
       /** Share tensor with next layer */
@@ -742,7 +731,7 @@ void NetworkGraph::inPlaceOptimize(const std::string &layer_type,
          * With batch normalization, neither input nor output of the layer are
          * requried for calculatin gradient and derivative. Just input
          * derivative is required. In this scenraio, L2 is assumed to be batch
-         * normaliztion layer, and L1 is assumed to be a non-in-place layer.
+         * normalization layer, and L1 is assumed to be a non-in-place layer.
          * Hence, L1 layer's output and L2 layer's input var_grad are modified.
          */
         auto &inplace_shared_vg_ptr = l->net_hidden[0];
@@ -781,11 +770,6 @@ void NetworkGraph::inPlaceOptimize(const std::string &layer_type,
       manager.untrackLayerInOuts(prev_layer->getName());
     }
   }
-}
-
-void NetworkGraph::inPlaceOptimize(Manager &manager) {
-  for (auto const &layer_type : in_place_layers)
-    inPlaceOptimize(layer_type, manager);
 }
 
 int NetworkGraph::initialize(std::shared_ptr<Manager> manager) {

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -245,6 +245,7 @@ public:
 
   /**
    * @brief     Optimize the graph memory utilization for in-place operations
+   * @param     manager Memory manager
    */
   void inPlaceOptimize(Manager &manager);
 
@@ -401,13 +402,6 @@ private:
    * @brief Calculate the number of non-trainable layers at the start
    */
   void countNonTrainableLayersAtBegin();
-
-  /**
-   * @brief Update graph to remove redundant memory for in-place layer
-   * @param layer_type Type of the layer which will work in-place
-   * @note This optimization has no performance overhead.
-   */
-  void inPlaceOptimize(const std::string &layer_type, Manager &manager);
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/acti_func.cpp
+++ b/nntrainer/layers/acti_func.cpp
@@ -78,6 +78,7 @@ int ActiFunc::setActivation(
  * @param[in] ActivationType ActivationType ActivationType to be set
  */
 void ActiFunc::setActiFunc(ActivationType acti_type) {
+  activation_type = acti_type;
 
   switch (acti_type) {
   case ActivationType::ACT_TANH:
@@ -105,6 +106,14 @@ void ActiFunc::run_fn(Tensor const &x, Tensor &output) { _act_fn(x, output); }
 
 Tensor &ActiFunc::run_prime_fn(Tensor &in, Tensor &ret, Tensor const &deriv) {
   return _act_prime_fn(in, ret, deriv);
+}
+
+bool ActiFunc::supportInPlace() const {
+  bool support_in_place = true;
+  if (activation_type == ActivationType::ACT_SOFTMAX)
+    support_in_place = false;
+
+  return support_in_place;
 }
 
 Tensor &ActiFunc::softmax(Tensor const &t, Tensor &output) {

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -75,6 +75,11 @@ public:
   Tensor &run_prime_fn(Tensor &in, Tensor &ret, Tensor const &deriv);
 
   /**
+   * @copydoc Layer::supportInPlace()
+   */
+  bool supportInPlace() const;
+
+  /**
    * @brief       Calculate softmax for Tensor Type
    * @param[in] x Tensor
    * @param[out] output output Tensor
@@ -140,8 +145,6 @@ public:
    */
   static float no_op_prime(float x);
 
-  static const std::string type;
-
   /**
    * @brief setActivation by custom activation function
    * @note  apply derivative as this activation_prime_fn does not utilize
@@ -188,6 +191,9 @@ public:
 private:
   std::function<Tensor &(Tensor const &, Tensor &)> _act_fn;
   std::function<Tensor &(Tensor &, Tensor &, Tensor const &)> _act_prime_fn;
+
+  ActivationType
+    activation_type; /**< type of the activaiton represented by this */
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -55,13 +55,13 @@ public:
    * @brief     Read Activation layer params. This is essentially noops for now.
    * @param[in] file input stream file
    */
-  void read(std::ifstream &file) override{/* noop */};
+  void read(std::ifstream &file) override{/** noop */};
 
   /**
    * @brief     Save Activation layer params. This is essentially noops for now.
    * @param[in] file output stream file
    */
-  void save(std::ofstream &file) override{/* noop */};
+  void save(std::ofstream &file) override{/** noop */};
 
   /**
    * @copydoc Layer::forwarding(bool training)
@@ -84,6 +84,11 @@ public:
    * @copydoc Layer::getType()
    */
   const std::string getType() const override { return ActivationLayer::type; };
+
+  /**
+   * @copydoc Layer::supportInPlace()
+   */
+  bool supportInPlace() const override { return acti_func.supportInPlace(); }
 
   /**
    * @brief       Calculate softmax for Tensor Type
@@ -154,9 +159,8 @@ public:
   static const std::string type;
 
 private:
-  ActiFunc acti_func;
-
-  Tensor backup_hidden;
+  ActiFunc
+    acti_func; /**< activation function designating the activation operation */
 
   /**
    * @brief setActivation by custom activation function

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -110,6 +110,11 @@ public:
     return BatchNormalizationLayer::type;
   }
 
+  /**
+   * @copydoc Layer::supportInPlace()
+   */
+  bool supportInPlace() const override { return true; }
+
   using Layer::setProperty;
 
   /**

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -600,6 +600,15 @@ public:
    */
   virtual void setActivation(ActivationType activation);
 
+  /**
+   * @brief   If the current layer can support in-place
+   *
+   * @return  true if inplace, else false
+   * @details all layers default to out of place execution
+   * @note all layers default to out of place execution
+   */
+  virtual bool supportInPlace() const { return false; }
+
 protected:
   /**
    * @brief   Print Options when printing layer info


### PR DESCRIPTION
Support inPlace() as an interface for the layer.
If returns true, manager can set its inputs/outputs to be
the same memory location, but not necessarily.
Corresponding graph code is also updated.

Resolves #867

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>