### PR TITLE
[Layer] Add requireLabel() function

### DIFF
--- a/Applications/SimpleShot/layers/centroid_knn.h
+++ b/Applications/SimpleShot/layers/centroid_knn.h
@@ -25,8 +25,10 @@
 namespace simpleshot {
 namespace layers {
 
-/// @todo inherit this to API
-// class CentroidKNN : public ml::train::Layer {
+/**
+ * @brief Centroid KNN layer which takes centroid and do k-nearest neighbor
+ * classification
+ */
 class CentroidKNN : public nntrainer::Layer {
 public:
   /**
@@ -75,6 +77,11 @@ public:
    * returns distance vector of shape (num_class, )
    */
   void forwarding(bool training = true) override;
+
+  /**
+   * @copydoc Layer::requireLabel()
+   */
+  bool requireLabel() const override { return true; }
 
   /**
    * @brief     calc the derivative to be passed to the previous layer

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -125,6 +125,19 @@ public:
   virtual void calcDerivative() = 0;
 
   /**
+   * @brief  check if this layer requires label to be passed
+   * @note   if requireLabel() == true means, for now, that it is endpoint of a
+   * graph(numOutlayers == 0). label will be fed to the gradient of hidden if
+   * requireLabel is true
+   * @todo   If we get to have a use case for requireLabel(true) but in the
+   * middle of a graph, change the semantics
+   *
+   * @return true requires a label when training
+   * @return false does not require a label
+   */
+  virtual bool requireLabel() const { return false; }
+
+  /**
    * @brief     Calculate the derivative of a layer
    */
   virtual void calcGradient(){};

--- a/nntrainer/layers/loss_layer.h
+++ b/nntrainer/layers/loss_layer.h
@@ -89,6 +89,11 @@ public:
   int initialize(Manager &manager) override;
 
   /**
+   * @copydoc Layer::requireLabel()
+   */
+  bool requireLabel() const override { return true; }
+
+  /**
    * @copydoc Layer::getType()
    */
   const std::string getType() const override { return LossLayer::type; };


### PR DESCRIPTION
- [Layer] Add requireLabel() function

```
Add a simple function `Layer::requireLayer()`.
This function is used to detect if a certain layer requires a layer.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```