### PR TITLE
[layer context] Propose layer context and layer_devel

### DIFF
--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   layer_context.h
+ * @date   10 June 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the layer context for each layer
+ */
+
+#ifndef __LAYER_CONTEXT_H__
+#define __LAYER_CONTEXT_H__
+
+#include <memory>
+#include <vector>
+
+#include <common_properties.h>
+#include <tensor.h>
+#include <tensor_dim.h>
+#include <var_grad.h>
+#include <weight.h>
+
+namespace nntrainer {
+
+/**
+ * @class   Layer Context class for all layers
+ * @brief   Class for Layer context
+ *
+ * @details This provides for the layer initialization. This context will not
+ * contain any structures which allow allocation of memory or support to
+ * allocate any new memory, but rather only support storing specifications based
+ * on which memory will be allocated later.
+ */
+class InitLayerContext {
+public:
+  /**
+   * @brief define the lifespan of the given tensor to reduce peak memory
+   *
+   */
+  enum TensorLifespan {
+    FORWARD_FUNC_LIFESPAN,  /**< tensor must not be reset before during the
+                               forward function call, eg. temporary tensors
+                               needed during forward operations */
+    BACKWARD_FUNC_LIFESPAN, /**< tensor must not be reset before during the
+                               backward function call, eg. temporary tensors
+                               needed during backward operations */
+    ITERATION_LIFESPAN,     /**< tensor must not be reset until the owning layer
+                               finishes its execution in the current iteration,
+                               eg. hidden memory/cells of RNN */
+    EPOCH_LIFESPAN, /**< tensor must not be reset before the epoch ends */
+    MAX_LIFESPAN,   /**< tensor must not be reset until the end of the model
+                       execution, eg. layer weights */
+  };
+
+  /**
+   * @brief Construct a new Init Layer Context object
+   *
+   */
+  InitLayerContext() = default;
+
+  /**
+   * @brief Get the Input Dimensions object
+   *
+   * @return const std::vector<TensorDim>& Input dimensions
+   */
+  const std::vector<TensorDim> &getInputDimensions() const { return input_dim; }
+
+  /**
+   * @brief Get the Output Dimensions object
+   *
+   * @return std::vector<TensorDim>& Output dimensions
+   */
+  std::vector<TensorDim> &getOutputDimensions() { return input_dim; }
+
+  /**
+   * @brief Set the Output Dimensions object
+   *
+   * @param out_dim the output dimension to set to
+   */
+  void setOutputDimensions(const std::vector<TensorDim> &out_dim) {
+    output_dim = out_dim;
+  }
+
+  /**
+   * @brief Request a new weight for the layer
+   *
+   * @param dim dimension of the weight
+   * @param init initializer for the weight
+   * @param reg regularizer for the weight
+   * @param reg_const regularization constant for the weight
+   * @param name name of the weight
+   * @param trainable if the weight is trainable (require gradient or not)
+   * @return unsigned int index of the weight for its getter
+   */
+  unsigned int requestWeight(const TensorDim &dim, const WeightInitializer init,
+                             const WeightRegularizer reg, const float reg_const,
+                             std::string name, bool trainable = true) {
+    weights_spec.emplace_back(dim, init, reg, reg_const, trainable, name);
+    return weights_spec.size() - 1;
+  }
+
+  /**
+   * @brief Request a new tensor for the layer
+   *
+   * @param dim dimension of the tensor
+   * @param trainable if the tensor is trainable (require gradient or not)
+   * @param name name of the tensor
+   * @param lifespan lifespan of the tensor
+   * @return unsigned int index of the tensor for its getter
+   */
+  unsigned int requestTensor(const TensorDim &dim, const std::string &name,
+                             bool trainable = false,
+                             TensorLifespan lifespan = ITERATION_LIFESPAN) {
+    tensors_spec.emplace_back(dim, trainable, name);
+    return tensors_spec.size() - 1;
+  }
+
+private:
+  /**
+   * @brief Specification of the weight
+   *
+   */
+  typedef std::tuple<TensorDim, WeightInitializer, WeightRegularizer, float,
+                     bool, std::string>
+    WeightSpec;
+
+  /**
+   * @brief Specification of the tensors
+   *
+   */
+  typedef std::tuple<const TensorDim, bool, const std::string> TensorSpec;
+
+  std::vector<TensorDim> input_dim;  /**< Input dimensions for the layer */
+  std::vector<TensorDim> output_dim; /**< Output dimensions for the layer */
+
+  std::vector<WeightSpec> weights_spec; /**< Specification for the weights */
+  std::vector<TensorSpec>
+    tensors_spec; /**< Specification for the var_grad (trainable/non-trainable
+                     variables) */
+};
+
+/**
+ * @class   Layer Context class for all layers
+ * @brief   Class for Layer context
+ *
+ * @details This provides for the layer executiong. This context will contain
+ * structures with memory allocated or support to allocate any new memory, but
+ * rather only support storing specifications based on which memory will be
+ * allocated later.
+ */
+class RunLayerContext {
+public:
+  /**
+   * @brief Construct a new Run Layer Context object
+   *
+   */
+  RunLayerContext() = default;
+
+  /**
+   * @brief Get the Weight tensor object
+   *
+   * @param idx Identifier of the weight
+   * @return Tensor& Reference to the weight tensor
+   */
+  Tensor &getWeight(unsigned int idx) { return weights[idx]->getVariableRef(); }
+
+  /**
+   * @brief Get the Weight Gradient tensor object
+   *
+   * @param idx Identifier of the weight
+   * @return Tensor& Reference to the weight grad tensor
+   */
+  Tensor &getWeightGrad(unsigned int idx) {
+    if (!weights[idx]->getTrainable())
+      throw std::invalid_argument(
+        "Requesting gradient for a non-trainable weight.");
+    if (!trainable)
+      throw std::invalid_argument(
+        "Requesting gradient for a non-trainable layer.");
+    return weights[idx]->getGradientRef();
+  }
+
+  /**
+   * @brief Get the Output tensor object
+   *
+   * @param idx Identifier of the output
+   * @return Tensor& Reference to the output tensor
+   */
+  Tensor &getOutput(unsigned int idx) { return outputs[idx]->getVariableRef(); }
+
+  /**
+   * @brief Get the Output Grad tensor object
+   *
+   * @param idx Identifier of the output
+   * @return Tensor& Reference to the output grad tensor
+   */
+  Tensor &getOutputGrad(unsigned int idx) {
+    if (!outputs[idx]->getTrainable())
+      throw std::invalid_argument(
+        "Requesting gradient for a non-trainable tensor.");
+    return outputs[idx]->getGradientRef();
+  }
+
+  /**
+   * @brief Get the Input tensor object
+   *
+   * @param idx Identifier of the input
+   * @return Tensor& Reference to the input grad tensor
+   */
+  Tensor &getInput(unsigned int idx) { return inputs[idx]->getVariableRef(); }
+
+  /**
+   * @brief Get the Input Grad tensor object
+   *
+   * @param idx Identifier of the input
+   * @return Tensor& Reference to the input grad tensor
+   */
+  Tensor &getInputGrad(unsigned int idx) {
+    if (!inputs[idx]->getTrainable())
+      throw std::invalid_argument(
+        "Requesting gradient for a non-trainable tensor.");
+    return inputs[idx]->getGradientRef();
+  }
+
+  /**
+   * @brief Get the Tensor object
+   *
+   * @param idx Identifier of the tensor
+   * @return Tensor& Reference to the tensor
+   */
+  Tensor &getTensor(unsigned int idx) { return tensors[idx]->getVariableRef(); }
+
+  /**
+   * @brief Get the Tensor Grad object
+   *
+   * @param idx Identifier of the tensor
+   * @return Tensor& Reference to the tensor grad tensor
+   */
+  Tensor &getTensorGrad(unsigned int idx) {
+    if (!tensors[idx]->getTrainable())
+      throw std::invalid_argument(
+        "Requesting gradient for a non-trainable tensor.");
+    return tensors[idx]->getGradientRef();
+  }
+
+  /**
+   * @brief Get the number of Outputs tensor objects
+   *
+   * @return unsigned int number of output tensors
+   */
+  unsigned int getNumOutputs() { return outputs.size(); }
+
+  /**
+   * @brief Get the number of inputs tensor objects
+   *
+   * @return unsigned int number of input tensors
+   */
+  unsigned int getNumInputs() { return inputs.size(); }
+
+  /**
+   * @brief Get the number of weights tensor objects
+   *
+   * @return unsigned int number of weight tensors
+   */
+  unsigned int getNumWeights() { return weights.size(); }
+
+  /**
+   * @brief Get the if the layer is trainable
+   *
+   * @return bool true if trainable, else false
+   */
+  bool getTrainable() { return trainable; }
+
+private:
+  bool trainable; /**< if the layer is trainable */
+
+  std::vector<Weight *> weights;   /**< weights of the layer */
+  std::vector<Var_Grad *> inputs;  /**< inputs of the layer */
+  std::vector<Var_Grad *> outputs; /**< outputs of the layer */
+  std::vector<Var_Grad *> tensors; /**< tensors of the layer */
+};
+
+} // namespace nntrainer
+#endif // __LAYER_CONTEXT_H__

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -1,0 +1,211 @@
+/**
+ * Copyright (C) 2019 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file	layer_devel.h
+ * @date	10 June 2021
+ * @brief	This is Layer classes of Neural Network
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+#ifndef __LAYER_H__
+#define __LAYER_H__
+#ifdef __cplusplus
+
+#include <memory>
+#include <vector>
+
+#include <layer_context.h>
+#include <node_exporter.h>
+
+namespace nntrainer {
+
+/**
+ * @class   Layer Base class for layers
+ * @brief   Base class for all layers
+ *
+ * @details nntrainer::Layer inherits ml::train::Layer but has been ommitted to
+ * disallow static_cast between nntrainer::Layer and ml::train::Layer objects.
+ */
+class Layer {
+
+public:
+  /**
+   * @brief     Destructor of Layer Class
+   */
+  virtual ~Layer() = default;
+
+  /**
+   * @brief Get the layer type
+   * @return const std::string type representation
+   */
+  virtual const std::string getType() const = 0;
+
+  /**
+   * @brief     Initialize the layer
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @details   Input dimensions will be provided set in the context. This
+   * function must set output dimensions in the given context. Further, context
+   * can be used to request weights for the layer, and any extra tensor required
+   * for the operation of the layer.
+   * @note      No memory allocation must be performed in the initialization
+   * step. Any tensor memory required must be requested to the context which
+   * will be made available during execution of the layer with the context.
+   */
+  virtual int initalize(InitContext &context) = 0;
+
+  /**
+   * @brief     Forward Propagation of a layer
+   * @param[in] context Context of the layer
+   * @param[in] training true if training, false if inference
+   * @note      Output must be set in the output tensors.
+   * @details   context provides access to the weights (if any), inputs,
+   * outputs, and tensors (if any) for the layer. Input and output dimensions
+   * can be access from the inputs/outputs tensors themselves.
+   */
+  virtual void forwarding(RunContext &context, bool training = true) = 0;
+
+  /**
+   * @brief     calc the derivative to be passed to the previous layer
+   * @param[in] context Context of the layer
+   * @note      Return derivatives must be set in input gradient tensors.
+   * @details   context provides access to the weights (if any), inputs,
+   * outputs, and tensors (if any) for the layer. Input and output dimensions
+   * can be access from the inputs/outputs tensors themselves.
+   */
+  virtual void calcDerivative(RunContext &context) = 0;
+
+  /**
+   * @brief     Calculate the derivative of a layer
+   * @details   context provides access to the weights (if any), inputs,
+   * outputs, and tensors (if any) for the layer. Input and output dimensions
+   * can be access from the inputs/outputs tensors themselves.
+   * @note      Gradinets must be set in weight gradient tensors.
+   */
+  virtual void calcGradient(RunContext &context){};
+
+  /**
+   * @brief     set Property of layer
+   * @param[in] values values of property
+   * @retval #ML_ERROR_NONE Successful.
+   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @note this shouldn't be virtual, this became virtual to support custom
+   * layer. should be reverted after layer.h can fully support custom layer
+   */
+  virtual int setProperty(std::vector<std::string> values);
+
+  /**
+   * @brief this function helps exporting the layer in a predefined format,
+   * while workarounding issue caused by templated function type eraser
+   *
+   * @param[in] exporter exporter that conatins exporting logic
+   * @param[in] method enum value to identify how it should be exported to
+   */
+  virtual void
+  export_to(Exporter &exporter,
+            ExportMethods method = ExportMethods::METHOD_STRINGVECTOR) const {}
+
+  /**
+   * @brief Set the batch for the layer
+   * @param[in] context Context of the layer
+   * @param[in] batch Batch value to be set
+   * @details Update the initialize context based on the updated batch size if
+   * required
+   */
+  virtual void setBatch(InitContext context, unsigned int batch) {}
+
+  /**
+   * @brief Set the batch for the layer
+   * @param[in] context Context of the layer
+   * @param[in] batch Batch value to be set
+   * @details Update the run context based on the updated batch size if required
+   */
+  virtual void setBatch(RunContext context, unsigned int batch) {}
+
+  /**
+   * @brief   If the current layer can support in-place
+   *
+   * @return  true if inplace, else false
+   * @details all layers default to out of place execution
+   * @note all layers default to out of place execution
+   */
+  virtual bool supportInPlace() const { return false; }
+
+  /**
+   * @brief  check if this layer requires label to be passed
+   * @note   if requireLabel() == true means, for now, that it is endpoint of a
+   * graph(numOutlayers == 0). label will be fed to the gradient of hidden if
+   * requireLabel is true
+   * @return true if requires a label when training, else false
+   */
+  virtual bool requireLabel() const { return false; }
+};
+
+/**
+ * @brief   Overriding output stream for layers and it's derived class
+ */
+template <typename T, typename std::enable_if_t<
+                        std::is_base_of<Layer, T>::value, T> * = nullptr>
+std::ostream &operator<<(std::ostream &out, T &l) {
+  l.printPreset(out, Layer::PrintPreset::PRINT_SUMMARY);
+  return out;
+}
+
+using CreateLayerFunc = nntrainer::Layer *(*)();
+using DestroyLayerFunc = void (*)(nntrainer::Layer *);
+
+/**
+ * @brief  Layer Pluggable struct that enables pluggable layer
+ *
+ */
+typedef struct {
+  CreateLayerFunc createfunc;   /**< create layer function */
+  DestroyLayerFunc destroyfunc; /**< destory function */
+} LayerPluggable;
+
+/**
+ * @brief pluggable layer must have this structure defined
+ */
+extern "C" LayerPluggable ml_train_layer_pluggable;
+
+/**
+ * @brief General Layer Factory function to register Layer
+ *
+ * @param props property representation
+ * @return std::unique_ptr<ml::train::Layer> created object
+ */
+template <typename T,
+          std::enable_if_t<std::is_base_of<Layer, T>::value, T> * = nullptr>
+std::unique_ptr<Layer> createLayer(const std::vector<std::string> &props = {}) {
+  std::unique_ptr<Layer> ptr = std::make_unique<T>();
+
+  if (ptr->setProperty(props) != ML_ERROR_NONE) {
+    throw std::invalid_argument("Set properties failed for layer");
+  }
+  return ptr;
+}
+
+/**
+ * @brief   Get Layer devel from ml::train::Layer
+ *
+ * @param   l Layer object
+ * @return  Layer devel object
+ */
+std::shared_ptr<Layer> getLayerDevel(std::shared_ptr<ml::train::Layer> l);
+
+} // namespace nntrainer
+
+#endif /* __cplusplus */
+#endif /* __LAYER_H__ */

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -55,13 +55,6 @@ createLayerNode(std::shared_ptr<nntrainer::Layer> layer,
 int LayerNode::setProperty(std::vector<std::string> properties) {
   int status = ML_ERROR_NONE;
 
-  try {
-    properties = loadProperties(properties, props);
-  } catch (std::invalid_argument &e) {
-    ml_loge("parsing property failed, reason: %s", e.what());
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-
   /// @todo: deprecate this in favor of loadProperties
   std::vector<std::string> remainder;
   for (unsigned int i = 0; i < properties.size(); ++i) {

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -17,6 +17,7 @@
 
 #include <graph_node.h>
 #include <layer.h>
+#include <layer_context.h>
 #include <layer_internal.h>
 
 namespace nntrainer {
@@ -179,11 +180,12 @@ private:
   ActivationType
     activation_type; /**< activation applied to the output of this node */
 
-  /**
-   * These properties are set for the layer by the user but are intercepted
-   * and used in the node which forms the basic element of the graph.
-   */
-  std::tuple<> props; /**< properties for the layer node */
+  RunLayerContext
+    run_context; /**< context required for running/execution of the layer. This
+                    will also contain the properties of the layer. */
+  InitLayerContext init_context; /**< context to be built for/while
+                                    initialization of the layer. This will also
+                                    contain the properties of the layer. */
 
   /**
    * @brief setProperty by PropertyType


### PR DESCRIPTION
This patch proposes layer context and layer_devel.
The layer context provides basic necessities for each layer
like inputs, outputs, weights, tensors. Weights are the trainable tensors
required by the layers which can be requested with the context interfaces.
Correspondingly, any other tensor requirements by the layer can also be
requested with the context.

There are two types of context :
1. InitContext - provides context for initialization with input_dimensions
filled. This contains specifications for all the inputs/outputs/weights/tensors
which will be made available during executiong.
2. RunContext - provides allocated weights/inputs/outputs/tensors along with
some of the basic properties of the layer like trainable, etc.

This design allows layer devel to be stateless (derived layer can be stateful with their
own member objects), and behave as layer ops.
Further, this allows dependencies on weights/var_grads as context simplified the interface
with just tensors.
Also, this patch also removes dependency on the manager from layer_devel header.

layer context for each layer is owned by the corresponding LayerNode.
Many of the layer getters like getInputs/Outputs/Weights/etc can now
be moved to LayerNode which does not concern the custom layer writer,
and simplifies the layer operation code as well.

See also #986

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>