### PR TITLE
[Trivial] Fix NDK warning -Wbraced-scalar-init

### DIFF
--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -312,8 +312,8 @@ void LSTMLayer::calcGradient() {
   Tensor &m_cell_ = mem_cell->getVariableRef();
   Tensor &dm_cell_ = mem_cell->getGradientRef();
 
-  Tensor dh_nx = Tensor({derivative_.width()});
-  Tensor dc_nx = Tensor({derivative_.width()});
+  Tensor dh_nx = Tensor(derivative_.width());
+  Tensor dc_nx = Tensor(derivative_.width());
 
   for (unsigned int b = 0; b < input_dim[0].batch(); ++b) {
     Tensor deriv_t = derivative_.getBatchSlice(b, 1);
@@ -349,9 +349,9 @@ void LSTMLayer::calcGradient() {
         fgio_.getSharedDataTensor({unit * NUM_GATE}, unit * t * NUM_GATE);
 
       if (t == 0) {
-        hs_prev = Tensor({hs_t.width()});
+        hs_prev = Tensor(hs_t.width());
         hs_prev.setZero();
-        cs_prev = Tensor({cs_t.width()});
+        cs_prev = Tensor(cs_t.width());
         cs_prev.setZero();
       } else {
         hs_prev =


### PR DESCRIPTION
- [Trivial] Fix NDK warning -Wbraced-scalar-init

```
This patch fixes trivial NDK warning below

```
././../nntrainer/layers/lstm.cpp:315:25: warning: braces around scalar initializer [-Wbraced-scalar-init]
  Tensor dh_nx = Tensor({derivative_.width()});
                        ^~~~~~~~~~~~~~~~~~~~~
././../nntrainer/layers/lstm.cpp:316:25: warning: braces around scalar initializer [-Wbraced-scalar-init]
  Tensor dc_nx = Tensor({derivative_.width()});
                        ^~~~~~~~~~~~~~~~~~~~~
././../nntrainer/layers/lstm.cpp:352:26: warning: braces around scalar initializer [-Wbraced-scalar-init]
        hs_prev = Tensor({hs_t.width()});
                         ^~~~~~~~~~~~~~
././../nntrainer/layers/lstm.cpp:354:26: warning: braces around scalar initializer [-Wbraced-scalar-init]
        cs_prev = Tensor({cs_t.width()});
```

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```