### PR TITLE
[graph] Graph core cleanup

### DIFF
--- a/nntrainer/graph/graph_core.cpp
+++ b/nntrainer/graph/graph_core.cpp
@@ -160,7 +160,7 @@ void GraphCore::ensureName(GraphNode &node, const std::string &prefix,
     }
   }
 
-  std::set<std::string>::iterator iter;
+  std::unordered_set<std::string>::iterator iter;
   std::string name;
   if (orig_name_empty) {
     orig_name = node.getType();

--- a/nntrainer/graph/graph_core.cpp
+++ b/nntrainer/graph/graph_core.cpp
@@ -102,6 +102,9 @@ void GraphCore::topologicalSort() {
     Sorted.push_back(dfs_stack.top());
     dfs_stack.pop();
   }
+
+  if (Sorted.size() != node_list.size())
+    throw std::runtime_error("Internal error in topologicalSort");
 }
 
 const std::shared_ptr<GraphNode> &
@@ -114,19 +117,6 @@ GraphCore::getNode(const std::string &name) const {
   std::stringstream ss;
   ss << "Cannot find graph node: " << name;
   throw std::invalid_argument(ss.str());
-}
-
-std::vector<std::shared_ptr<GraphNode>> GraphCore::getNodes() const {
-  std::vector<std::shared_ptr<GraphNode>> ret;
-  if (!Sorted.empty()) {
-    std::transform(Sorted.begin(), Sorted.end(), std::back_inserter(ret),
-                   [](auto const &elem) { return elem; });
-  } else {
-    std::transform(node_list.begin(), node_list.end(), std::back_inserter(ret),
-                   [](auto const &elem) { return elem; });
-  }
-
-  return ret;
 }
 
 void GraphCore::addNode(std::shared_ptr<GraphNode> node, bool ensure_name) {

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -121,34 +121,6 @@ public:
   template <
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
-  inline graph_iterator<T> begin() {
-    if (Sorted.empty())
-      return graph_iterator<T>(&(*node_list.begin()));
-    else
-      return graph_iterator<T>(&(*Sorted.begin()));
-  }
-
-  /**
-   * @brief     get end iterator for the forwarding
-   * @retval    iterator marking the end of forwarding
-   */
-  template <
-    typename T = GraphNode,
-    std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
-  inline graph_iterator<T> end() {
-    if (Sorted.empty())
-      return graph_iterator<T>(&(*node_list.end()));
-    else
-      return graph_iterator<T>(&(*Sorted.end()));
-  }
-
-  /**
-   * @brief     get begin iterator for the forwarding
-   * @retval    const iterator marking the begin of forwarding
-   */
-  template <
-    typename T = GraphNode,
-    std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
   inline graph_const_iterator<T> cbegin() const {
     if (Sorted.empty())
       return graph_const_iterator<T>(&(*node_list.cbegin()));

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -20,8 +20,8 @@
 #include <list>
 #include <map>
 #include <memory>
-#include <set>
 #include <stack>
+#include <unordered_set>
 #include <vector>
 
 #include <graph_node.h>
@@ -201,19 +201,13 @@ public:
    * @retval    Graph Object copyed
    */
   GraphCore &copy(GraphCore &from) {
+    node_list.resize(from.node_list.size());
     if (this != &from) {
-      // FIXME: this assumes elements already in nodes/adj, solve that
-      // for (unsigned int i = 0; i < adj.size(); i++)
-      //   adj[i].front()->getObject()->copy(from.adj[i].front()->getObject());
+      // or (unsigned int i = 0; i < node_list.size(); i++)
+      //  node_list[i]->copy(from.node_list[i]);
     }
     return *this;
   }
-
-  /**
-   * @brief     make adjancency list for the current graph
-   */
-  void
-  makeAdjacencyList(std::vector<std::list<std::shared_ptr<GraphNode>>> &adj);
 
   /**
    * @brief     Ensure that node has a name.
@@ -252,8 +246,7 @@ private:
   std::vector<std::shared_ptr<GraphNode>> Sorted; /**< Ordered Node List  */
   bool sorted; /** if the node_list is sorted */
 
-  /// TODO: update with unordered_set
-  std::set<std::string>
+  std::unordered_set<std::string>
     node_names;       /**< Set containing all the names of nodes in the model */
   int def_name_count; /**< Count assigned to node names declared by default */
 
@@ -269,22 +262,16 @@ private:
                       std::stack<std::shared_ptr<GraphNode>> &Stack);
 
   /**
-   * @brief     make connection for the given node idx
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  void connectGraph(unsigned int adj_idx);
-
-  /**
-   * @brief     set output connections for all the nodes
-   */
-  void setOutputLayers();
-
-  /**
    * @brief Add given GraphNode to the Graph
    * @param[in] node shared_ptr of GraphNode
    */
   void addGraphNode(std::shared_ptr<GraphNode> node);
+
+  /**
+   * @brief     make adjancency list for the current graph
+   */
+  void
+  makeAdjacencyList(std::vector<std::list<std::shared_ptr<GraphNode>>> &adj);
 };
 
 } // namespace nntrainer

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -50,23 +50,13 @@ public:
    * @brief getter of number of nodes
    * @param[out] number of nodes
    */
-  unsigned int size() const {
-    if (Sorted.empty())
-      return adj.size();
-    else
-      return Sorted.size();
-  }
+  unsigned int size() const { return node_list.size(); }
 
   /**
    * @brief get if the graph is empty
    * @param[out] true if empty, else false
    */
-  bool empty() const {
-    if (Sorted.empty())
-      return adj.empty();
-    else
-      return Sorted.empty();
-  }
+  bool empty() const { return node_list.empty(); }
 
   /**
    * @brief     Swap function for the class
@@ -74,7 +64,6 @@ public:
   friend void swap(GraphCore &lhs, GraphCore &rhs) {
     using std::swap;
 
-    swap(lhs.adj, rhs.adj);
     swap(lhs.node_list, rhs.node_list);
     swap(lhs.Sorted, rhs.Sorted);
     swap(lhs.node_names, rhs.node_names);
@@ -85,7 +74,7 @@ public:
    * @brief     reset the graph
    */
   void reset() {
-    adj.clear();
+    node_list.clear();
     Sorted.clear();
     node_names.clear();
     def_name_count = 0;
@@ -221,24 +210,10 @@ public:
   }
 
   /**
-   * @brief add Edge between graph nodes
-   * @param[in] ith Node index : From
-   * @param[in] node GraphNode object to be added : To
+   * @brief     make adjancency list for the current graph
    */
-  void addEdge(unsigned int ith, const std::shared_ptr<GraphNode> &node);
-
-  /**
-   * @brief     make connection between nodes
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int connectGraph();
-
-  /**
-   * @brief     remove all the edges from the graph
-   *
-   */
-  void removeEdges();
+  void
+  makeAdjacencyList(std::vector<std::list<std::shared_ptr<GraphNode>>> &adj);
 
   /**
    * @brief     Ensure that node has a name.
@@ -272,10 +247,6 @@ public:
   }
 
 private:
-  /// TODO: make this when needed. Till then, keep only nodelist
-  std::vector<std::list<std::shared_ptr<GraphNode>>>
-    adj; /**< adjacency list for graph */
-
   std::vector<std::shared_ptr<GraphNode>>
     node_list;                                    /**< Unordered Node List  */
   std::vector<std::shared_ptr<GraphNode>> Sorted; /**< Ordered Node List  */
@@ -292,8 +263,10 @@ private:
    * @param[in] visited temp list
    * @param[in] stack for Node list to visit.
    */
-  void topologicalSortUtil(unsigned int ith, std::vector<bool> &visited,
-                           std::stack<std::shared_ptr<GraphNode>> &Stack);
+  void
+  topologicalSortUtil(std::vector<std::list<std::shared_ptr<GraphNode>>> &adj,
+                      unsigned int ith, std::vector<bool> &visited,
+                      std::stack<std::shared_ptr<GraphNode>> &Stack);
 
   /**
    * @brief     make connection for the given node idx

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -102,15 +102,6 @@ public:
   const std::shared_ptr<GraphNode> &getNode(const std::string &name) const;
 
   /**
-   * @brief getter all the node nodes in the model
-   * @retval node nodes
-   * @note these node nodes will be in sorted order if the model is compiled,
-   * otherwise the order is the order of addition of node nodes in the model.
-   * TODO: deprecate this
-   */
-  std::vector<std::shared_ptr<GraphNode>> getNodes() const;
-
-  /**
    * @brief     join passed graph into the existing graph model
    * @param[in] graph graph to be added/to extend
    * @param[in] prefix prefix added to names of nodes from this graph
@@ -126,13 +117,15 @@ public:
   /**
    * @brief     get begin iterator for the forwarding
    * @retval    const iterator marking the begin of forwarding
-   * TODO:      iterate over node_list if sorted is not available
    */
   template <
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
   inline graph_iterator<T> begin() {
-    return graph_iterator<T>(&(*Sorted.begin()));
+    if (Sorted.empty())
+      return graph_iterator<T>(&(*node_list.begin()));
+    else
+      return graph_iterator<T>(&(*Sorted.begin()));
   }
 
   /**
@@ -143,7 +136,10 @@ public:
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
   inline graph_iterator<T> end() {
-    return graph_iterator<T>(&(*Sorted.end()));
+    if (Sorted.empty())
+      return graph_iterator<T>(&(*node_list.end()));
+    else
+      return graph_iterator<T>(&(*Sorted.end()));
   }
 
   /**
@@ -154,7 +150,10 @@ public:
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
   inline graph_const_iterator<T> cbegin() const {
-    return graph_const_iterator<T>(&(*Sorted.cbegin()));
+    if (Sorted.empty())
+      return graph_const_iterator<T>(&(*node_list.cbegin()));
+    else
+      return graph_const_iterator<T>(&(*Sorted.cbegin()));
   }
 
   /**
@@ -165,7 +164,10 @@ public:
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
   inline graph_const_iterator<T> cend() const {
-    return graph_const_iterator<T>(&(*Sorted.cend()));
+    if (Sorted.empty())
+      return graph_const_iterator<T>(&(*node_list.cend()));
+    else
+      return graph_const_iterator<T>(&(*Sorted.cend()));
   }
 
   /**

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -90,7 +90,8 @@ public:
  *
  * @note    GraphNodeType is to enable for both GraphNode and const GraphNode
  */
-template <typename LayerNodeType, typename GraphNodeType>
+template <typename LayerNodeType, typename LayerNodePtrType,
+          typename GraphNodeType>
 class GraphNodeIterator
   : public std::iterator<std::random_access_iterator_tag, GraphNodeType> {
   GraphNodeType *p; /** underlying object of GraphNode */
@@ -105,11 +106,11 @@ public:
    * @note    value_type, pointer and reference are different from standard
    * iterator
    */
-  typedef std::shared_ptr<LayerNodeType> value_type;
+  typedef LayerNodePtrType value_type;
   typedef std::random_access_iterator_tag iterator_category;
   typedef std::ptrdiff_t difference_type;
-  typedef std::shared_ptr<LayerNodeType> *pointer;
-  typedef std::shared_ptr<LayerNodeType> &reference;
+  typedef LayerNodePtrType *pointer;
+  typedef LayerNodePtrType &reference;
 
   /**
    * @brief Construct a new Graph Node Iterator object
@@ -305,28 +306,31 @@ public:
  */
 template <class LayerNodeType>
 using graph_iterator =
-  GraphNodeIterator<LayerNodeType, std::shared_ptr<GraphNode>>;
+  GraphNodeIterator<LayerNodeType, std::shared_ptr<LayerNodeType>,
+                    std::shared_ptr<GraphNode>>;
 
 /**
  * @brief     Iterators to traverse the graph
  */
 template <class LayerNodeType>
-using graph_reverse_iterator = GraphNodeReverseIterator<
-  GraphNodeIterator<LayerNodeType, std::shared_ptr<GraphNode>>>;
+using graph_reverse_iterator = GraphNodeReverseIterator<GraphNodeIterator<
+  LayerNodeType, std::shared_ptr<LayerNodeType>, std::shared_ptr<GraphNode>>>;
 
 /**
  * @brief     Iterators to traverse the graph
  */
 template <class LayerNodeType>
 using graph_const_iterator =
-  GraphNodeIterator<const LayerNodeType, const std::shared_ptr<GraphNode>>;
+  GraphNodeIterator<LayerNodeType, const std::shared_ptr<LayerNodeType>,
+                    const std::shared_ptr<GraphNode>>;
 
 /**
  * @brief     Iterators to traverse the graph
  */
 template <class LayerNodeType>
 using graph_const_reverse_iterator = GraphNodeReverseIterator<
-  GraphNodeIterator<const LayerNodeType, const std::shared_ptr<GraphNode>>>;
+  GraphNodeIterator<LayerNodeType, const std::shared_ptr<LayerNodeType>,
+                    const std::shared_ptr<GraphNode>>>;
 
 } // namespace nntrainer
 #endif // __GRAPH_NODE_H__

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -83,15 +83,15 @@ public:
 };
 
 /**
- * @brief   Iterator for GraphNode which return LayerNode object upon realize
+ * @brief   Iterator for GraphNode which return const
+ * std::shared_ptr<LayerNodeType> object upon realize
  *
  * @note    This does not include the complete list of required functions. Add
  * them as per need.
  *
  * @note    GraphNodeType is to enable for both GraphNode and const GraphNode
  */
-template <typename LayerNodeType, typename LayerNodePtrType,
-          typename GraphNodeType>
+template <typename LayerNodeType, typename GraphNodeType>
 class GraphNodeIterator
   : public std::iterator<std::random_access_iterator_tag, GraphNodeType> {
   GraphNodeType *p; /** underlying object of GraphNode */
@@ -106,11 +106,11 @@ public:
    * @note    value_type, pointer and reference are different from standard
    * iterator
    */
-  typedef LayerNodePtrType value_type;
+  typedef const std::shared_ptr<LayerNodeType> value_type;
   typedef std::random_access_iterator_tag iterator_category;
   typedef std::ptrdiff_t difference_type;
-  typedef LayerNodePtrType *pointer;
-  typedef LayerNodePtrType &reference;
+  typedef const std::shared_ptr<LayerNodeType> *pointer;
+  typedef const std::shared_ptr<LayerNodeType> &reference;
 
   /**
    * @brief Construct a new Graph Node Iterator object
@@ -305,32 +305,15 @@ public:
  * @brief     Iterators to traverse the graph
  */
 template <class LayerNodeType>
-using graph_iterator =
-  GraphNodeIterator<LayerNodeType, std::shared_ptr<LayerNodeType>,
-                    std::shared_ptr<GraphNode>>;
-
-/**
- * @brief     Iterators to traverse the graph
- */
-template <class LayerNodeType>
-using graph_reverse_iterator = GraphNodeReverseIterator<GraphNodeIterator<
-  LayerNodeType, std::shared_ptr<LayerNodeType>, std::shared_ptr<GraphNode>>>;
-
-/**
- * @brief     Iterators to traverse the graph
- */
-template <class LayerNodeType>
 using graph_const_iterator =
-  GraphNodeIterator<LayerNodeType, const std::shared_ptr<LayerNodeType>,
-                    const std::shared_ptr<GraphNode>>;
+  GraphNodeIterator<LayerNodeType, const std::shared_ptr<GraphNode>>;
 
 /**
  * @brief     Iterators to traverse the graph
  */
 template <class LayerNodeType>
 using graph_const_reverse_iterator = GraphNodeReverseIterator<
-  GraphNodeIterator<LayerNodeType, const std::shared_ptr<LayerNodeType>,
-                    const std::shared_ptr<GraphNode>>>;
+  GraphNodeIterator<LayerNodeType, const std::shared_ptr<GraphNode>>>;
 
 } // namespace nntrainer
 #endif // __GRAPH_NODE_H__

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -68,6 +68,13 @@ public:
   virtual const std::string getType() const = 0;
 
   /**
+   * @brief     Get the input connections for this node
+   *
+   * @return list of name of the nodes which form input connections
+   */
+  virtual const std::vector<std::string> &getInputConnections() const = 0;
+
+  /**
    * @brief     Copy the graph
    * @param[in] from Graph Object to copy
    * @retval    Graph Object copyed

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -62,7 +62,6 @@ int NetworkGraph::compile(const LossType loss_type) {
 
 void NetworkGraph::updateConnectionName(const std::string &from,
                                         const std::string &to) {
-
   const std::vector<std::shared_ptr<GraphNode>> &node_list = graph.getNodes();
   for (unsigned int i = 0; i < node_list.size(); ++i) {
     auto &layer = node_list[i];

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -62,10 +62,11 @@ int NetworkGraph::compile(const LossType loss_type) {
 
 void NetworkGraph::updateConnectionName(const std::string &from,
                                         const std::string &to) {
-  for (auto const &gnode : graph) {
-    if (istrequal(gnode->getName(), to))
+  for (auto iter = cbegin(); iter != cend(); iter++) {
+    auto &lnode = *iter;
+    if (istrequal(lnode->getName(), to))
       continue;
-    LNODE(gnode)->updateInputLayers(from, to);
+    lnode->updateInputLayers(from, to);
   }
 }
 
@@ -289,10 +290,10 @@ int NetworkGraph::addLossLayer(const LossType loss_type) {
 void NetworkGraph::setOutputLayers() {
 
   size_t last_layer_count = 0;
-  for (auto const gnode_idx : graph) {
-    auto layer_idx = LNODE(gnode_idx);
-    for (auto const gnode_i : graph) {
-      auto layer_i = LNODE(gnode_i);
+  for (auto iter_idx = cbegin(); iter_idx != cend(); iter_idx++) {
+    auto &layer_idx = *iter_idx;
+    for (auto iter_i = cbegin(); iter_i != cend(); iter_i++) {
+      auto &layer_i = *iter_i;
       if (istrequal(layer_i->getName(), layer_idx->getName()))
         continue;
       for (unsigned int j = 0; j < layer_i->getNumInputs(); ++j) {
@@ -329,8 +330,8 @@ void NetworkGraph::setOutputLayers() {
       "Error: Multiple last layers in the model not supported");
   }
 
-  for (auto const &gnode : graph) {
-    if (LNODE(gnode)->getNumOutputs() == 0)
+  for (auto iter = cbegin(); iter != cend(); iter++) {
+    if ((*iter)->getNumOutputs() == 0)
       throw std::runtime_error("There is un-connected node");
   }
 }
@@ -449,8 +450,8 @@ int NetworkGraph::realizeGraph() {
 }
 
 void NetworkGraph::setBatchSize(unsigned int batch_size) {
-  for (auto const &node : graph) {
-    LNODE(node)->getObject()->setBatch(batch_size);
+  for (auto iter = cbegin(); iter != cend(); iter++) {
+    (*iter)->getObject()->setBatch(batch_size);
   }
 }
 

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -45,9 +45,6 @@ int NetworkGraph::compile(const LossType loss_type) {
   status = realizeGraph();
   NN_RETURN_STATUS();
 
-  status = connectGraph();
-  NN_RETURN_STATUS();
-
   graph.topologicalSort();
 
   countNonTrainableLayersAtBegin();
@@ -58,8 +55,6 @@ int NetworkGraph::compile(const LossType loss_type) {
   status = checkCompiledGraph();
   NN_RETURN_STATUS();
 
-  /** Save memory by removing edges once it has been compiled */
-  graph.removeEdges();
   compiled = true;
 
   return status;
@@ -290,7 +285,6 @@ int NetworkGraph::addLossLayer(const LossType loss_type) {
    * for performance.
    */
   graph.addNode(lnode, false);
-  connectGraph(graph.size() - 1);
   graph.addLossToSorted();
 
   return ML_ERROR_NONE;
@@ -459,27 +453,6 @@ int NetworkGraph::realizeGraph() {
   /// @todo add check that input_layers <-> output_layers does match.
 
   return status;
-}
-
-void NetworkGraph::connectGraph(unsigned int adj_idx) {
-
-  std::shared_ptr<LayerNode> node = LNODE(graph.getNode(adj_idx));
-
-  auto &input_layers = node->getInputLayers();
-  for (unsigned int j = 0; j < input_layers.size(); ++j) {
-    if (istrequal(input_layers[j], "__data__"))
-      continue;
-    unsigned int to_node_id = getLayerNode(input_layers[j])->getIndex();
-    graph.addEdge(to_node_id, node);
-  }
-}
-
-int NetworkGraph::connectGraph() {
-  for (unsigned int i = 0; i < graph.size(); ++i) {
-    connectGraph(i);
-  }
-
-  return ML_ERROR_NONE;
 }
 
 void NetworkGraph::setBatchSize(unsigned int batch_size) {

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -173,18 +173,6 @@ public:
    * @brief     get begin iterator for the graph
    * @retval    const reverse iterator
    */
-  graph_iterator<LayerNode> begin() { return graph.begin<LayerNode>(); }
-
-  /**
-   * @brief     get end iterator for the graph
-   * @retval    const reverse iterator
-   */
-  graph_iterator<LayerNode> end() { return graph.end<LayerNode>(); }
-
-  /**
-   * @brief     get begin iterator for the graph
-   * @retval    const reverse iterator
-   */
   graph_const_iterator<LayerNode> cbegin() const {
     return graph.cbegin<LayerNode>();
   }

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -311,20 +311,6 @@ private:
   int checkCompiledGraph();
 
   /**
-   * @brief     make connection between nodes
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int connectGraph();
-
-  /**
-   * @brief     make connection for the given node idx
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  void connectGraph(unsigned int adj_idx);
-
-  /**
    * @brief     Realize Graph Nodes
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -268,7 +268,7 @@ public:
             ExportMethods method = ExportMethods::METHOD_STRINGVECTOR) const {
     exporter.saveResult(props, method, this);
     layer->export_to(exporter, method);
-  };
+  }
 
 #ifdef PROFILE
   int event_key;

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -174,12 +174,21 @@ public:
   unsigned int getNumOutputs() const { return output_layers.size(); }
 
   /**
-   * @brief Get the Input Layers object
+   * @brief     Get the Input Layers object
    *
    * @return const std::vector<std::string>&
    */
   const std::vector<std::string> &getInputLayers() const {
     return input_layers;
+  }
+
+  /**
+   * @brief     Get the input connections for this node
+   *
+   * @return list of name of the nodes which form input connections
+   */
+  const std::vector<std::string> &getInputConnections() const {
+    return getInputLayers();
   }
 
   /**


### PR DESCRIPTION
1. [graph] Make adjacency list lazily
Update graph to make adjacenct list lazily when required
during the topological sort.
Until then, keep the node_list which contains simply all the nodes.

2. [graph] Update node_names to unordered_set
Update node_names storing all the names of the nodes
in the graph for uniqueness to use unordered_set.

3. [graph] Graph iterator for sorted and unsorted 
Updated graph iteartor to run over unsorted list of nodes
if the graph is not yet sorted. If the graph is sorted,
the iterator iterates over sorted nodes.

4. [graph] Remove getNodes for the graph
Remove getNodes() which provided direct access to the data structure
holding the graph. Now, all access is done using the iterators.

5. [graph] Remove non-const iterators
Remove non-const iterators for the graph.
Update the corresponding usages for the graph.

Note: the pattern for (auto const &node : graph) has been
removed as this can begin()/end() in the background.
Workaround for this is to use std::as_const(graph) but this
is only available from c++17, so this patch uses
the basic const iterator for loop pattern.

See Also #986

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>