### PR TITLE
[deb/pkg] Update lower tolerance bug + increase timeouts

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -17,9 +17,9 @@ ROOT_DIR:=$(shell pwd)
 export DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 export DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 ifdef unit_test
-	export ENABLE_REDUCE_TOLERANCE ?= true
-else
 	export ENABLE_REDUCE_TOLERANCE ?= false
+else
+	export ENABLE_REDUCE_TOLERANCE ?= true
 endif
 
 %:

--- a/test/ccapi/meson.build
+++ b/test/ccapi/meson.build
@@ -11,4 +11,4 @@ exec = executable(
   install_dir: application_install_dir
 )
 
-test('unittest_ccapi', exec, timeout: 60, args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), target))
+test('unittest_ccapi', exec, timeout: 120, args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), target))

--- a/test/tizen_capi/meson.build
+++ b/test/tizen_capi/meson.build
@@ -17,5 +17,5 @@ foreach test_name : unittest_name_list
     install_dir: application_install_dir
   )
 
-  test(unittest_name, exec, args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), unittest_name))
+  test(unittest_name, exec, timeout: 60, args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), unittest_name))
 endforeach


### PR DESCRIPTION
Inverse the check for lower error tolerance for debian build
Also increase timeouts for nntrainer capi/ccapi unittests
as they timeout for armhf architecture on launchpad.

See also #1251

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>