### PR TITLE
[deb/pkg] Increase c-api unittest timeout

### DIFF
--- a/test/tizen_capi/meson.build
+++ b/test/tizen_capi/meson.build
@@ -17,5 +17,5 @@ foreach test_name : unittest_name_list
     install_dir: application_install_dir
   )
 
-  test(unittest_name, exec, timeout: 60, args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), unittest_name))
+  test(unittest_name, exec, timeout: 120, args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), unittest_name))
 endforeach


### PR DESCRIPTION
Increase c-api unittest timeout even further to
pass armhf build on launchpad.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>