### PR TITLE
[split layer] Initialize class member bugfix

### DIFF
--- a/nntrainer/layers/split_layer.h
+++ b/nntrainer/layers/split_layer.h
@@ -34,7 +34,8 @@ public:
   template <typename... Args>
   SplitLayer(unsigned int split_dim = 1, Args... args) :
     Layer(args...),
-    split_dimension(split_dim) {}
+    split_dimension(split_dim),
+    leading_helper_dim(1) {}
 
   /**
    * @brief     Destructor of Split Layer


### PR DESCRIPTION
Split layer has class member leading_helper_dim
which remains uninitialized and results in bugs
when setBatchSize() is called before initialization of the layer.

This patch fixes the bug.

Resolves #1279

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>

cc. @zhoonit 