### PR TITLE
Gtest update

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -230,7 +230,10 @@ sharedConstTensors NeuralNetwork::forwarding(sharedConstTensors input,
     NNTR_THROW_IF(label.size() != layer.net_hidden.size(),
                   std::invalid_argument)
       << "label size does not match with the layer requirements"
-      << " layer: " << layer.getName() << " label size: " << label.size()
+      // TODO: update this to use layer node after #986
+      // << " layer: " << layer.getName() << " label size: " << label.size()
+      << " layer: "
+      << " label size: " << label.size()
       << " requirements size: " << layer.net_hidden.size();
 
     for (unsigned int i = 0; i < layer.net_hidden.size(); i++) {

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -350,13 +350,9 @@ INSTANTIATE_TEST_CASE_P(
     mkIniTc("no_labelSet_n", {nw_base, adam, dataset + "-LabelData", input, out+"input_layers=inputlayer"}, ALLFAIL),
 
     mkIniTc("backbone_filemissing_n", {nw_base, adam, dataset + "-LabelData", input, out+"input_layers=inputlayer"}, ALLFAIL)
-/// #if gtest_version <= 1.7.0
-));
-/// #else gtest_version > 1.8.0
-// ), [](const testing::TestParamInfo<nntrainerIniTest::ParamType>& info){
-//  return std::get<0>(info.param);
-// });
-/// #end if */
+), [](const testing::TestParamInfo<nntrainerIniTest::ParamType>& info){
+ return std::get<0>(info.param);
+});
 // clang-format on
 
 /**

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -1242,13 +1242,9 @@ INSTANTIATE_TEST_CASE_P(
     mkModelTc(rnn_return_sequences, "1:1:2:1", 10),
     mkModelTc(rnn_return_sequence_with_batch, "2:1:2:1", 10),
     mkModelTc(multi_rnn_return_sequence, "1:1:1:1", 10)
-// / #if gtest_version <= 1.7.0
-));
-/// #else gtest_version > 1.8.0
-// ), [](const testing::TestParamInfo<nntrainerModelTest::ParamType>& info){
-//  return std::get<0>(info.param).getName();
-// });
-/// #end if */
+), [](const testing::TestParamInfo<nntrainerModelTest::ParamType>& info){
+ return std::get<0>(info.param).getName();
+});
 // clang-format on
 
 /**


### PR DESCRIPTION
1. [unittests] Update unittests for new gtest version …
Remove gtest version check comments and update unittests for the new
gtest versions.

2. [neuralnet] Neural network bugfix 
Two PRs merged have caused main branch to fail.
This patch provides temporary fix.
Proper fix  will be done with layer_v2.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>