### PR TITLE
[addition] Bug fix addition layer calcDerivative

### DIFF
--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -61,7 +61,12 @@ void AdditionLayer::forwarding(bool training) {
 void AdditionLayer::calcDerivative() {
 
   for (unsigned int i = 0; i < getNumInputs(); ++i) {
-    net_input[i]->getGradientRef() = net_hidden[0]->getGradientRef();
+    /**
+     * TODO: replace this with tensor assignment during optimization.
+     * Tensor assignement needs to make sure that the previous connected layers
+     * are not inplace
+     */
+    net_input[i]->getGradientRef().copy(net_hidden[0]->getGradientRef());
   }
 }
 

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -101,6 +101,7 @@ void ConcatLayer::calcDerivative() {
     TensorDim in_dim = input_dim[idx];
 
     for (unsigned int b = 0; b < in_dim.batch(); ++b) {
+      // TODO: replace with tensor::copy/fill
       memcpy(
         net_input[idx]->getGradient().getAddress(b * in_dim.getFeatureLen()),
         net_hidden[0]->getGradient().getAddress(b * d.getFeatureLen() +


### PR DESCRIPTION
Bug fix for addition layer calcDerivative().
addition layer assign the same tensor derivative memory back to its
other layers. If the other layers connecting with addition layers are
inplace, then this can lead to wrong results.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>

cc. @zhoonit 