### PR TITLE
[Test/Scaffolding] Prepare test for the new layer

### DIFF
--- a/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
@@ -30,7 +30,7 @@ TEST(AppContext, DlRegisterOpen_p) {
 
   ac.registerLayer("libpow_layer.so", NNTRAINER_PATH);
 
-  auto layer = ac.createObject<nntrainer::Layer>("pow");
+  auto layer = ac.createObject<nntrainer::LayerV1>("pow");
 
   EXPECT_EQ(layer->getType(), "pow");
 }
@@ -50,7 +50,7 @@ TEST(AppContext, DlRegisterDirectory_p) {
 
   ac.registerPluggableFromDirectory(NNTRAINER_PATH);
 
-  auto layer = ac.createObject<nntrainer::Layer>("pow");
+  auto layer = ac.createObject<nntrainer::LayerV1>("pow");
 
   EXPECT_EQ(layer->getType(), "pow");
 }

--- a/Applications/Custom/pow.cpp
+++ b/Applications/Custom/pow.cpp
@@ -88,7 +88,7 @@ int PowLayer::setProperty(std::vector<std::string> values) {
   }
 
   /// unhandled values are passed to the layer_internal.h
-  return nntrainer::Layer::setProperty(unhandled_values);
+  return nntrainer::LayerV1::setProperty(unhandled_values);
 }
 
 int PowLayer::initialize(nntrainer::Manager &manager) {
@@ -139,13 +139,13 @@ void PowLayer::calcDerivative() {
 
 #ifdef PLUGGABLE
 
-nntrainer::Layer *create_pow_layer() {
+nntrainer::LayerV1 *create_pow_layer() {
   auto layer = new PowLayer();
   std::cout << "power created\n";
   return layer;
 }
 
-void destory_pow_layer(nntrainer::Layer *layer) {
+void destory_pow_layer(nntrainer::LayerV1 *layer) {
   std::cout << "power deleted\n";
   delete layer;
 }

--- a/Applications/Custom/pow.h
+++ b/Applications/Custom/pow.h
@@ -15,7 +15,7 @@
 #ifndef __POW_LAYER_H__
 #define __POW_LAYER_H__
 
-/// @todo migrate these to API
+/// @todo migrate these to API(#987)
 #include <layer_internal.h>
 #include <manager.h>
 
@@ -23,26 +23,29 @@
 
 namespace custom {
 
-/// @todo inherit this to API
-// class PowLayer : public ml::train::Layer {
-class PowLayer : public nntrainer::Layer {
+/**
+ * @brief layer class that calculates f(x) = x ^ exponent (exponent is
+ * configurable by PowLayer::setProperty)
+ *
+ */
+class PowLayer : public nntrainer::LayerV1 {
 public:
   /**
    * @brief Construct a new Pow Layer object that does elementwise power
    *
-   * @param exponent_ exponent
+   * @param exponent_ exponentLayerV1
    */
-  PowLayer(float exponent_ = 1) : Layer(), exponent(exponent_) {}
+  PowLayer(float exponent_ = 1) : LayerV1(), exponent(exponent_) {}
 
-  /**
+  /**LayerV1
    * @brief Destroy the Pow Layer object
    *
    */
   ~PowLayer() {}
 
-  using nntrainer::Layer::setProperty;
+  using nntrainer::LayerV1::setProperty;
 
-  /**
+  /**LayerV1
    * @brief     set Property of layer, currently only "exponent is accepted"
    * @param[in] values values of property
    * @retval #ML_ERROR_NONE Successful.

--- a/Applications/SimpleShot/layers/centering.cpp
+++ b/Applications/SimpleShot/layers/centering.cpp
@@ -28,7 +28,7 @@ namespace layers {
 const std::string CenteringLayer::type = "centering";
 
 CenteringLayer::CenteringLayer(const std::string &feature_path_) :
-  Layer(),
+  LayerV1(),
   feature_path(feature_path_) {}
 
 int CenteringLayer::setProperty(std::vector<std::string> values) {
@@ -52,7 +52,7 @@ int CenteringLayer::setProperty(std::vector<std::string> values) {
     }
   }
 
-  return nntrainer::Layer::setProperty(unhandled_values);
+  return nntrainer::LayerV1::setProperty(unhandled_values);
 }
 
 int CenteringLayer::initialize(nntrainer::Manager &manager) {

--- a/Applications/SimpleShot/layers/centering.h
+++ b/Applications/SimpleShot/layers/centering.h
@@ -29,13 +29,13 @@ namespace layers {
  * @brief centering layer that centers the feature
  *
  */
-class CenteringLayer : public nntrainer::Layer {
+class CenteringLayer : public nntrainer::LayerV1 {
 public:
   /**
    * @brief Construct a new Centering Layer object that does elementwise
    * subtraction from mean feature vector
    */
-  CenteringLayer() : Layer() {}
+  CenteringLayer() : LayerV1() {}
 
   /**
    * @brief Construct a new Centering Layer object
@@ -62,7 +62,7 @@ public:
    */
   ~CenteringLayer() {}
 
-  using nntrainer::Layer::setProperty;
+  using nntrainer::LayerV1::setProperty;
 
   /**
    * @brief     set Property of layer,

--- a/Applications/SimpleShot/layers/centroid_knn.cpp
+++ b/Applications/SimpleShot/layers/centroid_knn.cpp
@@ -62,7 +62,7 @@ int CentroidKNN::setProperty(std::vector<std::string> values) {
     }
   }
 
-  return nntrainer::Layer::setProperty(unhandled_values);
+  return nntrainer::LayerV1::setProperty(unhandled_values);
 }
 
 int CentroidKNN::initialize(nntrainer::Manager &manager) {

--- a/Applications/SimpleShot/layers/centroid_knn.h
+++ b/Applications/SimpleShot/layers/centroid_knn.h
@@ -29,13 +29,13 @@ namespace layers {
  * @brief Centroid KNN layer which takes centroid and do k-nearest neighbor
  * classification
  */
-class CentroidKNN : public nntrainer::Layer {
+class CentroidKNN : public nntrainer::LayerV1 {
 public:
   /**
    * @brief Construct a new NearestNeighbors Layer object that does elementwise
    * subtraction from mean feature vector
    */
-  CentroidKNN() : Layer(), num_class(0) {}
+  CentroidKNN() : LayerV1(), num_class(0) {}
 
   /**
    *  @brief  Move constructor.
@@ -55,7 +55,7 @@ public:
    */
   ~CentroidKNN() {}
 
-  using nntrainer::Layer::setProperty;
+  using nntrainer::LayerV1::setProperty;
 
   /**
    * @brief     set Property of layer,

--- a/Applications/SimpleShot/layers/l2norm.h
+++ b/Applications/SimpleShot/layers/l2norm.h
@@ -29,13 +29,13 @@ namespace layers {
  * @brief This layer l2 normalize the feature
  *
  */
-class L2NormLayer : public nntrainer::Layer {
+class L2NormLayer : public nntrainer::LayerV1 {
 public:
   /**
    * @brief Construct a new L2norm Layer object
    * that normlizes given feature with l2norm
    */
-  L2NormLayer() : Layer() {}
+  L2NormLayer() : LayerV1() {}
 
   /**
    *  @brief  Move constructor.
@@ -55,7 +55,7 @@ public:
    */
   ~L2NormLayer() {}
 
-  using nntrainer::Layer::setProperty;
+  using nntrainer::LayerV1::setProperty;
 
   /**
    * @brief initializing nntrainer

--- a/Applications/SimpleShot/test/simpleshot_centering_test.cpp
+++ b/Applications/SimpleShot/test/simpleshot_centering_test.cpp
@@ -38,7 +38,7 @@ TEST(centering, simple_functions) {
   app_context.registerFactory(nntrainer::createLayer<CenteringLayer>);
 
   auto lnode =
-    nntrainer::createLayerNode(app_context.createObject<nntrainer::Layer>(
+    nntrainer::createLayerNode(app_context.createObject<nntrainer::LayerV1>(
       "centering", {"feature_path=feature.bin", "input_shape=1:1:4"}));
   auto &c = lnode->getObject();
 

--- a/Applications/SimpleShot/test/simpleshot_centroid_knn.cpp
+++ b/Applications/SimpleShot/test/simpleshot_centroid_knn.cpp
@@ -29,7 +29,7 @@ TEST(centroid_knn, simple_functions) {
   app_context.registerFactory(nntrainer::createLayer<CentroidKNN>);
 
   auto lnode =
-    nntrainer::createLayerNode(app_context.createObject<nntrainer::Layer>(
+    nntrainer::createLayerNode(app_context.createObject<nntrainer::LayerV1>(
       "centroid_knn", {"num_class=5", "input_shape=1:1:3"}));
   auto &c = lnode->getObject();
 

--- a/Applications/SimpleShot/test/simpleshot_l2norm_test.cpp
+++ b/Applications/SimpleShot/test/simpleshot_l2norm_test.cpp
@@ -29,7 +29,7 @@ TEST(l2norm, simple_functions) {
   app_context.registerFactory(nntrainer::createLayer<L2NormLayer>);
 
   auto lnode =
-    nntrainer::createLayerNode(app_context.createObject<nntrainer::Layer>(
+    nntrainer::createLayerNode(app_context.createObject<nntrainer::LayerV1>(
       "l2norm", {"input_shape=1:1:4"}));
   auto &c = lnode->getObject();
 

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -252,7 +252,7 @@ static void add_default_object(AppContext &ac) {
   ac.registerFactory(nntrainer::createLayer<PermuteLayer>, PermuteLayer::type,
                      LayerType::LAYER_PERMUTE);
 
-  ac.registerFactory(AppContext::unknownFactory<nntrainer::Layer>, "unknown",
+  ac.registerFactory(AppContext::unknownFactory<nntrainer::LayerV1>, "unknown",
                      LayerType::LAYER_UNKNOWN);
 }
 
@@ -344,15 +344,15 @@ int AppContext::registerLayer(const std::string &library_path,
     << func_tag << "custom layer must specify type name, but it is empty";
   pluggable->destroyfunc(layer);
 
-  FactoryType<nntrainer::Layer> factory_func =
+  FactoryType<nntrainer::LayerV1> factory_func =
     [pluggable](const PropsType &prop) {
-      std::unique_ptr<nntrainer::Layer> layer =
+      std::unique_ptr<nntrainer::LayerV1> layer =
         std::make_unique<internal::PluggedLayer>(pluggable);
 
       return layer;
     };
 
-  return registerFactory<nntrainer::Layer>(factory_func, type);
+  return registerFactory<nntrainer::LayerV1>(factory_func, type);
 }
 
 int AppContext::registerOptimizer(const std::string &library_path,

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -292,7 +292,7 @@ public:
   }
 
 private:
-  FactoryMap<ml::train::Optimizer, nntrainer::Layer> factory_map;
+  FactoryMap<ml::train::Optimizer, nntrainer::LayerV1> factory_map;
   std::string working_path_base;
 };
 

--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -134,7 +134,8 @@ section2layer<PlainLayer>(dictionary *ini, const std::string &sec_name,
 
   auto properties = section2properties(ini, sec_name);
 
-  auto layer = createLayerNode(ac.createObject<Layer>(layer_type), properties);
+  auto layer =
+    createLayerNode(ac.createObject<LayerV1>(layer_type), properties);
   return layer;
 }
 

--- a/nntrainer/compiler/ini_interpreter.h
+++ b/nntrainer/compiler/ini_interpreter.h
@@ -41,6 +41,10 @@ public:
     app_context(app_context_),
     pathResolver(pathResolver_) {}
 
+  /**
+   * @brief Destroy the Ini Graph Interpreter object
+   *
+   */
   virtual ~IniGraphInterpreter(){};
 
   /**
@@ -63,8 +67,8 @@ private:
    * @param section section name
    * @return std::shared_ptr<Layer> layer
    */
-  std::shared_ptr<Layer> loadLayerConfig(dictionary *ini,
-                                         const std::string &section);
+  std::shared_ptr<LayerV1> loadLayerConfig(dictionary *ini,
+                                           const std::string &section);
 
   /**
    * @brief Create a Layer From Backbone Config
@@ -73,8 +77,8 @@ private:
    * @param section section name
    * @return std::shared_ptr<Layer> layer
    */
-  std::shared_ptr<Layer> loadBackboneConfigIni(dictionary *ini,
-                                               const std::string &section);
+  std::shared_ptr<LayerV1> loadBackboneConfigIni(dictionary *ini,
+                                                 const std::string &section);
 
   AppContext app_context;
   std::function<const std::string(std::string)> pathResolver;

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -88,7 +88,7 @@ void NetworkGraph::addDefaultInputLayers() {
   }
 }
 
-void NetworkGraph::addLayerNode(std::shared_ptr<Layer> layer) {
+void NetworkGraph::addLayerNode(std::shared_ptr<LayerV1> layer) {
   graph.addNode(std::make_unique<LayerNode>(layer, graph.size()));
 }
 
@@ -115,7 +115,7 @@ int NetworkGraph::realizeMultiInputType(
 
   // TODO: this can be addition or concat layer - add support
   std::shared_ptr<LayerNode> lnode = createLayerNode(AdditionLayer::type);
-  std::shared_ptr<Layer> layer = lnode->getObject();
+  std::shared_ptr<LayerV1> layer = lnode->getObject();
   graph.ensureName(*lnode, in_node->getName());
 
   lnode->setInputLayers(in_node->getInputLayers());
@@ -137,7 +137,7 @@ int NetworkGraph::realizeFlattenType(
   }
 
   std::shared_ptr<LayerNode> lnode = createLayerNode(FlattenLayer::type);
-  std::shared_ptr<Layer> layer = lnode->getObject();
+  std::shared_ptr<LayerV1> layer = lnode->getObject();
   graph.ensureName(*lnode, in_node->getName());
 
   lnode->setInputLayers({in_node->getName()});
@@ -151,7 +151,7 @@ int NetworkGraph::realizeFlattenType(
 
 int NetworkGraph::realizeActivationType(
   const std::shared_ptr<LayerNode> &in_node) {
-  Layer &current = *in_node->getObject();
+  LayerV1 &current = *in_node->getObject();
   int status = ML_ERROR_NONE;
 
   ActivationType act = current.getActivationType();
@@ -179,7 +179,7 @@ int NetworkGraph::realizeActivationType(
     lnode->setProperty({"distribute=true"});
   }
 
-  std::shared_ptr<Layer> layer = lnode->getObject();
+  std::shared_ptr<LayerV1> layer = lnode->getObject();
   layer->setActivation(act);
 
   lnode->setInputLayers({in_node->getName()});
@@ -203,7 +203,7 @@ int NetworkGraph::realizeMultiOutputType(
     return ML_ERROR_NONE;
 
   std::shared_ptr<LayerNode> lnode = createLayerNode(OutputLayer::type);
-  std::shared_ptr<Layer> layer = lnode->getObject();
+  std::shared_ptr<LayerV1> layer = lnode->getObject();
   graph.ensureName(*lnode, in_node->getName());
 
   lnode->setInputLayers({in_node->getName()});
@@ -261,7 +261,7 @@ int NetworkGraph::addLossLayer(const LossType loss_type) {
 
   auto const &updated_last_node = getSortedLayerNode(graph.size() - 1);
 
-  std::shared_ptr<Layer> layer = nntrainer::createLayer(LossLayer::type);
+  std::shared_ptr<LayerV1> layer = nntrainer::createLayer(LossLayer::type);
   std::shared_ptr<LayerNode> lnode = std::make_shared<LayerNode>(layer);
   status =
     std::dynamic_pointer_cast<LossLayer>(layer)->setLoss(updated_loss_type);
@@ -399,7 +399,7 @@ int NetworkGraph::realizeGraph() {
 
   for (unsigned int i = 0; i < num_nodes; ++i) {
     auto const &lnode = LNODE(node_list[i]);
-    Layer &l = *lnode->getObject();
+    LayerV1 &l = *lnode->getObject();
     ml_logd("layer name: %s", lnode->getName().c_str());
 
     /** If a layer does not has input nodes, then it must have input dimension

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -130,7 +130,7 @@ public:
    * @param[in] layer name
    * @retval Layer
    */
-  std::shared_ptr<Layer> getLayer(const std::string &layer_name) {
+  std::shared_ptr<LayerV1> getLayer(const std::string &layer_name) {
     return getLayerNode(layer_name)->getObject();
   }
 
@@ -390,14 +390,15 @@ private:
    * @details   Ensures that the layer has a unique and a valid name. A valid
    * name pre-assigned to the layer can be changed if force_rename is enabled.
    */
-  void ensureName(std::shared_ptr<Layer> layer, const std::string &prefix = "",
+  void ensureName(std::shared_ptr<LayerV1> layer,
+                  const std::string &prefix = "",
                   const std::string &postfix = "", bool force_rename = false);
 
   /**
    * @brief Create new LayerNode and add into Graph
    * @param[in] layer shared_ptr of Layer
    */
-  void addLayerNode(std::shared_ptr<Layer> layer);
+  void addLayerNode(std::shared_ptr<LayerV1> layer);
 
   /**
    * @brief update input_layers, output_layers node name

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -92,7 +92,7 @@ int ActivationLayer::setActivation(
  * @param[in] ActivationType ActivationType ActivationType to be set
  */
 void ActivationLayer::setActivation(ActivationType acti_type) {
-  Layer::setActivation(acti_type);
+  LayerV1::setActivation(acti_type);
 
   acti_func.setActiFunc(acti_type);
 }

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -25,7 +25,7 @@ namespace nntrainer {
  * @class   Activation Layer
  * @brief   Activation Layer
  */
-class ActivationLayer : public Layer {
+class ActivationLayer : public LayerV1 {
 
 public:
   /**
@@ -33,7 +33,7 @@ public:
    */
   template <typename... Args>
   ActivationLayer(ActivationType at = ActivationType::ACT_NONE, Args... args) :
-    Layer(args...) {
+    LayerV1(args...) {
     setTrainable(false);
     setActivation(at);
   }

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -84,7 +84,7 @@ void AdditionLayer::setProperty(const PropertyType type,
     }
   } break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -24,13 +24,13 @@ namespace nntrainer {
  * @class   Addition Layer
  * @brief   Addition Layer
  */
-class AdditionLayer : public Layer {
+class AdditionLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Addition Layer
    */
   template <typename... Args>
-  AdditionLayer(unsigned int num_inputs_ = 1, Args... args) : Layer(args...) {
+  AdditionLayer(unsigned int num_inputs_ = 1, Args... args) : LayerV1(args...) {
     setNumInputs(num_inputs_);
   }
 
@@ -86,7 +86,7 @@ public:
    */
   const std::string getType() const override { return AdditionLayer::type; };
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -130,7 +130,7 @@ void BatchNormalizationLayer::setProperty(const PropertyType type,
     }
     break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }
@@ -201,8 +201,8 @@ void BatchNormalizationLayer::calcGradient() {
   dgamma = dev.sum(axes_to_reduce);
 }
 
-void BatchNormalizationLayer::copy(std::shared_ptr<Layer> l) {
-  Layer::copy(l);
+void BatchNormalizationLayer::copy(std::shared_ptr<LayerV1> l) {
+  LayerV1::copy(l);
 
   std::shared_ptr<BatchNormalizationLayer> from =
     std::static_pointer_cast<BatchNormalizationLayer>(l);

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -37,7 +37,7 @@ namespace nntrainer {
  * @class   BatchNormalizationLayer
  * @brief   Batch Noramlization Layer
  */
-class BatchNormalizationLayer : public Layer {
+class BatchNormalizationLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Batch Noramlization Layer
@@ -51,7 +51,7 @@ public:
     WeightInitializer gamma_initializer = WeightInitializer::WEIGHT_ONES,
     WeightInitializer beta_initializer = WeightInitializer::WEIGHT_ONES,
     Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     epsilon(epsilon),
     momentum(momentum),
     axis(axis),
@@ -94,7 +94,7 @@ public:
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l) override;
+  void copy(std::shared_ptr<LayerV1> l) override;
 
   /**
    * @brief     initialize layer
@@ -115,7 +115,7 @@ public:
    */
   bool supportInPlace() const override { return true; }
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -126,7 +126,7 @@ void ConcatLayer::setProperty(const PropertyType type,
     }
   } break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -24,13 +24,13 @@ namespace nntrainer {
  * @class   Concat Layer
  * @brief   Concat Layer
  */
-class ConcatLayer : public Layer {
+class ConcatLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Concat Layer
    */
   template <typename... Args>
-  ConcatLayer(unsigned int num_inputs_ = 1, Args... args) : Layer(args...) {
+  ConcatLayer(unsigned int num_inputs_ = 1, Args... args) : LayerV1(args...) {
     setNumInputs(num_inputs_);
   }
 
@@ -81,7 +81,7 @@ public:
    */
   void calcDerivative() override;
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -453,8 +453,8 @@ void Conv2DLayer::calcGradient() {
   delBias = derivative.sum({0, 2, 3});
 }
 
-void Conv2DLayer::copy(std::shared_ptr<Layer> l) {
-  Layer::copy(l);
+void Conv2DLayer::copy(std::shared_ptr<LayerV1> l) {
+  LayerV1::copy(l);
 
   std::shared_ptr<Conv2DLayer> from = std::static_pointer_cast<Conv2DLayer>(l);
   this->filter_size = from->filter_size;
@@ -539,7 +539,7 @@ void Conv2DLayer::setProperty(const PropertyType type,
     }
     break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -28,7 +28,7 @@ constexpr const unsigned int CONV2D_DIM = 2;
  * @class   Convolution 2D Layer
  * @brief   Convolution 2D Layer
  */
-class Conv2DLayer : public Layer {
+class Conv2DLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Conv 2D Layer
@@ -40,7 +40,7 @@ public:
               const std::array<unsigned int, CONV2D_DIM> &padding_ = {0, 0},
               bool normalization_ = false, bool standardization_ = false,
               Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     filter_size(filter_size_),
     kernel_size(kernel_size_),
     stride(stride_),
@@ -91,7 +91,7 @@ public:
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l) override;
+  void copy(std::shared_ptr<LayerV1> l) override;
 
   /* TO DO : support keras type of padding */
   /* enum class PaddingType { */
@@ -106,7 +106,7 @@ public:
    */
   const std::string getType() const override { return Conv2DLayer::type; };
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -90,7 +90,7 @@ void EmbeddingLayer::setProperty(const PropertyType type,
     }
   } break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }
@@ -127,8 +127,8 @@ void EmbeddingLayer::forwarding(bool training) {
     weightAt(static_cast<int>(EmbeddingParams::weight)).getRegularizationLoss();
 }
 
-void EmbeddingLayer::copy(std::shared_ptr<Layer> l) {
-  Layer::copy(l);
+void EmbeddingLayer::copy(std::shared_ptr<LayerV1> l) {
+  LayerV1::copy(l);
 
   std::shared_ptr<EmbeddingLayer> from =
     std::static_pointer_cast<EmbeddingLayer>(l);

--- a/nntrainer/layers/embedding.h
+++ b/nntrainer/layers/embedding.h
@@ -24,7 +24,7 @@ namespace nntrainer {
  * @class   EmbeddingLayer
  * @brief   EmbeddingLayer
  */
-class EmbeddingLayer : public Layer {
+class EmbeddingLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Embedding Layer
@@ -32,7 +32,7 @@ public:
   template <typename... Args>
   EmbeddingLayer(unsigned int in_dim_ = 0, unsigned int out_dim_ = 0,
                  unsigned int in_length_ = 0, Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     in_dim(in_dim_),
     out_dim(out_dim_),
     in_length(in_length_) {}
@@ -73,7 +73,7 @@ public:
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l) override;
+  void copy(std::shared_ptr<LayerV1> l) override;
 
   /**
    * @brief     initialize layer
@@ -87,7 +87,7 @@ public:
    */
   const std::string getType() const override { return EmbeddingLayer::type; };
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -75,7 +75,7 @@ int FullyConnectedLayer::initialize(Manager &manager) {
 
 void FullyConnectedLayer::export_to(Exporter &exporter,
                                     ExportMethods method) const {
-  Layer::export_to(exporter, method);
+  LayerV1::export_to(exporter, method);
   exporter.saveResult(fc_props, method, this);
 }
 
@@ -86,7 +86,7 @@ void FullyConnectedLayer::setProperty(const PropertyType type,
     from_string(value, std::get<props::Unit>(fc_props));
   } break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }
@@ -104,8 +104,8 @@ void FullyConnectedLayer::forwarding(bool training) {
   loss = weightAt(static_cast<int>(FCParams::weight)).getRegularizationLoss();
 }
 
-void FullyConnectedLayer::copy(std::shared_ptr<Layer> l) {
-  Layer::copy(l);
+void FullyConnectedLayer::copy(std::shared_ptr<LayerV1> l) {
+  LayerV1::copy(l);
 
   std::shared_ptr<FullyConnectedLayer> from =
     std::static_pointer_cast<FullyConnectedLayer>(l);

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -26,14 +26,14 @@ namespace nntrainer {
  * @class   FullyConnecedLayer
  * @brief   fully connected layer
  */
-class FullyConnectedLayer : public Layer {
+class FullyConnectedLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Fully Connected Layer
    */
   template <typename... Args>
   FullyConnectedLayer(unsigned int unit_ = 0, Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     fc_props(props::Unit(unit_)) {}
 
   /**
@@ -72,7 +72,7 @@ public:
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l) override;
+  void copy(std::shared_ptr<LayerV1> l) override;
 
   /**
    * @brief     initialize layer
@@ -95,7 +95,7 @@ public:
     return FullyConnectedLayer::type;
   };
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/flatten_layer.h
+++ b/nntrainer/layers/flatten_layer.h
@@ -24,12 +24,12 @@ namespace nntrainer {
  * @class   Flatten Layer
  * @brief   Flatten Layer
  */
-class FlattenLayer : public Layer {
+class FlattenLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Flatten Layer
    */
-  template <typename... Args> FlattenLayer(Args... args) : Layer(args...) {
+  template <typename... Args> FlattenLayer(Args... args) : LayerV1(args...) {
     setTrainable(false);
   }
 

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -48,7 +48,7 @@ void InputLayer::setProperty(const PropertyType type,
     }
     break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }
@@ -79,7 +79,7 @@ void InputLayer::setTrainable(bool train) {
   if (train)
     throw exception::not_supported("Input layer does not support training");
 
-  Layer::setTrainable(false);
+  LayerV1::setTrainable(false);
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -33,7 +33,7 @@ namespace nntrainer {
  * @class   Input Layer
  * @brief   Just Handle the Input of Network
  */
-class InputLayer : public Layer {
+class InputLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of InputLayer
@@ -41,7 +41,7 @@ public:
   template <typename... Args>
   InputLayer(bool normalization = false, bool standardization = false,
              Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     normalization(false),
     standardization(false) {
     trainable = false;
@@ -100,7 +100,7 @@ public:
    */
   const std::string getType() const override { return InputLayer::type; };
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -32,14 +32,14 @@
 
 namespace nntrainer {
 
-void Layer::setActivation(ActivationType acti) {
+void LayerV1::setActivation(ActivationType acti) {
   if (acti == ActivationType::ACT_UNKNOWN) {
     throw std::invalid_argument("Error:have to specify activation function");
   }
   activation_type = acti;
 }
 
-int Layer::checkValidation() {
+int LayerV1::checkValidation() {
   int status = ML_ERROR_NONE;
 
   if (activation_type == ActivationType::ACT_UNKNOWN) {
@@ -50,7 +50,7 @@ int Layer::checkValidation() {
   return status;
 }
 
-void Layer::setBatch(unsigned int batch) {
+void LayerV1::setBatch(unsigned int batch) {
   for (unsigned int idx = 0; idx < getNumInputs(); ++idx)
     input_dim[idx].setTensorDim(0, batch);
 
@@ -58,7 +58,7 @@ void Layer::setBatch(unsigned int batch) {
     output_dim[idx].setTensorDim(0, batch);
 }
 
-std::vector<Tensor> Layer::getOutputs() {
+std::vector<Tensor> LayerV1::getOutputs() {
   std::vector<Tensor> ret;
   for (unsigned int i = 0; i < getNumOutputs(); ++i) {
     ret.push_back(net_hidden[i]->getVariableRef());
@@ -66,7 +66,7 @@ std::vector<Tensor> Layer::getOutputs() {
   return ret;
 }
 
-std::vector<Tensor> Layer::getDerivatives() {
+std::vector<Tensor> LayerV1::getDerivatives() {
   std::vector<Tensor> ret;
   for (unsigned int i = 0; i < getNumInputs(); ++i) {
     ret.push_back(net_input[i]->getGradientRef());
@@ -74,7 +74,7 @@ std::vector<Tensor> Layer::getDerivatives() {
   return ret;
 }
 
-void Layer::copy(std::shared_ptr<Layer> l) {
+void LayerV1::copy(std::shared_ptr<LayerV1> l) {
   for (auto const &w : l->weights)
     weights.push_back(w.clone());
 
@@ -88,9 +88,9 @@ void Layer::copy(std::shared_ptr<Layer> l) {
   this->trainable = l->trainable;
 }
 
-sharedConstTensors Layer::forwarding_with_val(sharedConstTensors input,
-                                              sharedConstTensors label,
-                                              bool training) {
+sharedConstTensors LayerV1::forwarding_with_val(sharedConstTensors input,
+                                                sharedConstTensors label,
+                                                bool training) {
 
   if (getNumInputs() != input.size()) {
     std::stringstream ss;
@@ -120,7 +120,7 @@ sharedConstTensors Layer::forwarding_with_val(sharedConstTensors input,
   return out;
 }
 
-sharedConstTensors Layer::backwarding_with_val(sharedConstTensors label) {
+sharedConstTensors LayerV1::backwarding_with_val(sharedConstTensors label) {
 
   for (unsigned int i = 0; i < getNumOutputs(); ++i) {
     net_hidden[i]->getGradientRef() = label[i]->clone();
@@ -137,19 +137,19 @@ sharedConstTensors Layer::backwarding_with_val(sharedConstTensors label) {
   return out;
 }
 
-void Layer::read(std::ifstream &file) {
+void LayerV1::read(std::ifstream &file) {
   for (auto &weight : weights) {
     weight.getVariableRef().read(file);
   }
 }
 
-void Layer::save(std::ofstream &file) {
+void LayerV1::save(std::ofstream &file) {
   for (auto &weight : weights) {
     weight.getVariableRef().save(file);
   }
 }
 
-int Layer::setProperty(std::vector<std::string> values) {
+int LayerV1::setProperty(std::vector<std::string> values) {
   int status = ML_ERROR_NONE;
 
   try {
@@ -186,7 +186,7 @@ int Layer::setProperty(std::vector<std::string> values) {
   return status;
 }
 
-void Layer::setProperty(const PropertyType type, const std::string &value) {
+void LayerV1::setProperty(const PropertyType type, const std::string &value) {
   int status = ML_ERROR_NONE;
 
   switch (type) {
@@ -259,8 +259,8 @@ void Layer::setProperty(const PropertyType type, const std::string &value) {
 }
 
 template <typename T>
-void Layer::printIfValid(std::ostream &out, const PropertyType type,
-                         const T target) {
+void LayerV1::printIfValid(std::ostream &out, const PropertyType type,
+                           const T target) {
   try {
     setProperty(type);
   } catch (exception::not_supported &e) {
@@ -271,7 +271,7 @@ void Layer::printIfValid(std::ostream &out, const PropertyType type,
       << std::endl;
 }
 
-void Layer::printShapeInfo(std::ostream &out) {
+void LayerV1::printShapeInfo(std::ostream &out) {
   for (unsigned int idx = 0; idx < getNumInputs(); ++idx) {
     out << "input " << input_dim[idx];
     for (unsigned int i = 0; i < weights.size(); i++)
@@ -282,13 +282,13 @@ void Layer::printShapeInfo(std::ostream &out) {
   }
 }
 
-void Layer::printPropertiesMeta(std::ostream &out) {
+void LayerV1::printPropertiesMeta(std::ostream &out) {
   printIfValid(
     out, PropertyType::activation,
     static_cast<std::underlying_type<ActivationType>::type>(activation_type));
 }
 
-void Layer::printProperties(std::ostream &out) {
+void LayerV1::printProperties(std::ostream &out) {
   out << "Trainable: " << trainable << std::endl;
   printIfValid(out, PropertyType::weight_regularizer,
                static_cast<int>(weight_regularizer));
@@ -296,13 +296,13 @@ void Layer::printProperties(std::ostream &out) {
                weight_regularizer_constant);
 }
 
-void Layer::printMetric(std::ostream &out) {
+void LayerV1::printMetric(std::ostream &out) {
   if (loss > 0) {
     out << "Weight regularization loss: " << loss;
   }
 }
 
-void Layer::printPreset(std::ostream &out, PrintPreset preset) {
+void LayerV1::printPreset(std::ostream &out, PrintPreset preset) {
   unsigned int flags = 0;
   switch (preset) {
   case PrintPreset::PRINT_ALL:
@@ -322,7 +322,7 @@ void Layer::printPreset(std::ostream &out, PrintPreset preset) {
   print(out, flags);
 }
 
-void Layer::print(std::ostream &out, unsigned int flags) {
+void LayerV1::print(std::ostream &out, unsigned int flags) {
   /** @todo properly move print to LayerNode */
   if (flags & PRINT_INST_INFO) {
     out << "===================";
@@ -363,7 +363,7 @@ void Layer::print(std::ostream &out, unsigned int flags) {
   }
 };
 
-std::shared_ptr<Layer> getLayerDevel(std::shared_ptr<ml::train::Layer> l) {
+std::shared_ptr<LayerV1> getLayerDevel(std::shared_ptr<ml::train::Layer> l) {
   return std::static_pointer_cast<LayerNode>(l)->getObject();
 }
 

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -19,23 +19,31 @@
  * @bug		No known bugs except for NYI items
  *
  */
-#ifndef __LAYER_H__
-#define __LAYER_H__
+#ifndef __LAYER_DEVEL_H__
+#define __LAYER_DEVEL_H__
 #ifdef __cplusplus
 
 #include <memory>
+#include <string>
 #include <vector>
 
-#include <layer_context.h>
-#include <node_exporter.h>
+namespace ml::train {
+class Layer;
+}
 
 namespace nntrainer {
+
+class InitContext;
+class RunContext;
+class Exporter;
+
+enum class ExportMethods;
 
 /**
  * @class   Layer Base class for layers
  * @brief   Base class for all layers
  *
- * @details nntrainer::Layer inherits ml::train::Layer but has been ommitted to
+ * @details nntrainer::Layer inherits ml::train::Layer but has been omitted to
  * disallow static_cast between nntrainer::Layer and ml::train::Layer objects.
  */
 class Layer {
@@ -104,7 +112,7 @@ public:
    * @note this shouldn't be virtual, this became virtual to support custom
    * layer. should be reverted after layer.h can fully support custom layer
    */
-  virtual int setProperty(std::vector<std::string> values);
+  virtual int setProperty(const std::vector<std::string> &values);
 
   /**
    * @brief this function helps exporting the layer in a predefined format,
@@ -113,9 +121,8 @@ public:
    * @param[in] exporter exporter that conatins exporting logic
    * @param[in] method enum value to identify how it should be exported to
    */
-  virtual void
-  export_to(Exporter &exporter,
-            ExportMethods method = ExportMethods::METHOD_STRINGVECTOR) const {}
+  virtual void exportTo(Exporter &exporter,
+                        const ExportMethods &method) const {};
 
   /**
    * @brief Set the batch for the layer
@@ -124,7 +131,7 @@ public:
    * @details Update the initialize context based on the updated batch size if
    * required
    */
-  virtual void setBatch(InitContext context, unsigned int batch) {}
+  virtual void setBatch(InitContext &context, unsigned int batch) {}
 
   /**
    * @brief Set the batch for the layer
@@ -132,7 +139,7 @@ public:
    * @param[in] batch Batch value to be set
    * @details Update the run context based on the updated batch size if required
    */
-  virtual void setBatch(RunContext context, unsigned int batch) {}
+  virtual void setBatch(RunContext &context, unsigned int batch) {}
 
   /**
    * @brief   If the current layer can support in-place
@@ -153,15 +160,16 @@ public:
   virtual bool requireLabel() const { return false; }
 };
 
-/**
- * @brief   Overriding output stream for layers and it's derived class
- */
-template <typename T, typename std::enable_if_t<
-                        std::is_base_of<Layer, T>::value, T> * = nullptr>
-std::ostream &operator<<(std::ostream &out, T &l) {
-  l.printPreset(out, Layer::PrintPreset::PRINT_SUMMARY);
-  return out;
-}
+/// @todo Decide where to put and how to implement(#986)
+// /**
+//  * @brief   Overriding output stream for layers and it's derived class
+//  */
+// template <typename T, typename std::enable_if_t<
+//                         std::is_base_of<Layer, T>::value, T> * = nullptr>
+// std::ostream &operator<<(std::ostream &out, T &l) {
+//   // l.printPreset(out, Layer::PrintPreset::PRINT_SUMMARY);
+//   return out;
+// }
 
 using CreateLayerFunc = nntrainer::Layer *(*)();
 using DestroyLayerFunc = void (*)(nntrainer::Layer *);
@@ -199,6 +207,7 @@ std::unique_ptr<Layer> createLayer(const std::vector<std::string> &props = {}) {
 
 /**
  * @brief   Get Layer devel from ml::train::Layer
+ * @todo    deprecate this(#986)
  *
  * @param   l Layer object
  * @return  Layer devel object
@@ -208,4 +217,4 @@ std::shared_ptr<Layer> getLayerDevel(std::shared_ptr<ml::train::Layer> l);
 } // namespace nntrainer
 
 #endif /* __cplusplus */
-#endif /* __LAYER_H__ */
+#endif /* __LAYER_DEVEL_H__ */

--- a/nntrainer/layers/layer_factory.cpp
+++ b/nntrainer/layers/layer_factory.cpp
@@ -89,7 +89,7 @@ const std::string layerGetStrType(const LayerType &type) {
   throw std::runtime_error("Control should not reach here");
 }
 
-std::unique_ptr<Layer> createLayer(const LayerType &type) {
+std::unique_ptr<LayerV1> createLayer(const LayerType &type) {
   const std::string &s = layerGetStrType(type);
 
   return createLayer(s);
@@ -98,7 +98,7 @@ std::unique_ptr<Layer> createLayer(const LayerType &type) {
 /**
  * @brief Factory creator with constructor
  */
-std::unique_ptr<Layer> createLayer(const std::string &type) {
+std::unique_ptr<LayerV1> createLayer(const std::string &type) {
 
   if (istrequal(type, InputLayer::type))
     return std::make_unique<InputLayer>();
@@ -148,7 +148,7 @@ std::unique_ptr<Layer> createLayer(const std::string &type) {
 /**
  * @brief Factory creator with constructor
  */
-std::unique_ptr<Layer> createLoss(LossType type) {
+std::unique_ptr<LayerV1> createLoss(LossType type) {
   return std::make_unique<LossLayer>(type);
 }
 

--- a/nntrainer/layers/layer_factory.h
+++ b/nntrainer/layers/layer_factory.h
@@ -32,12 +32,12 @@ const std::string layerGetStrType(const LayerType &type);
 /**
  * @brief Layer factory creator with constructor
  */
-std::unique_ptr<Layer> createLayer(const std::string &type);
+std::unique_ptr<LayerV1> createLayer(const std::string &type);
 
 /**
  * @brief Loss Layer Factory creator with constructor
  */
-std::unique_ptr<Layer> createLoss(LossType type);
+std::unique_ptr<LayerV1> createLoss(LossType type);
 
 } /* namespace nntrainer */
 

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -47,7 +47,7 @@ namespace nntrainer {
  * @details nntrainer::Layer inherits ml::train::Layer but has been ommitted to
  * disallow static_cast between nntrainer::Layer and ml::train::Layer objects.
  */
-class Layer {
+class LayerV1 {
 
   /** model classes can call private methods which arent exposed to public */
   friend class NeuralNetwork;
@@ -57,13 +57,13 @@ public:
   /**
    * @brief     Constructor of Layer Class
    */
-  Layer(ActivationType activation_type_ = ActivationType::ACT_NONE,
-        WeightRegularizer weight_regularizer_ = WeightRegularizer::NONE,
-        const float weight_regularizer_constant_ = 1.0f,
-        WeightInitializer weight_initializer_ =
-          WeightInitializer::WEIGHT_XAVIER_UNIFORM,
-        WeightInitializer bias_initializer_ = WeightInitializer::WEIGHT_ZEROS,
-        bool trainable_ = true) :
+  LayerV1(ActivationType activation_type_ = ActivationType::ACT_NONE,
+          WeightRegularizer weight_regularizer_ = WeightRegularizer::NONE,
+          const float weight_regularizer_constant_ = 1.0f,
+          WeightInitializer weight_initializer_ =
+            WeightInitializer::WEIGHT_XAVIER_UNIFORM,
+          WeightInitializer bias_initializer_ = WeightInitializer::WEIGHT_ZEROS,
+          bool trainable_ = true) :
     layer_props(),
     loss(0.0f),
     activation_type(activation_type_),
@@ -79,19 +79,19 @@ public:
   /**
    * @brief     Destructor of Layer Class
    */
-  virtual ~Layer() = default;
+  virtual ~LayerV1() = default;
 
   /**
    *  @brief  Move constructor of Layer.
    *  @param[in] Layer &&
    */
-  Layer(Layer &&rhs) noexcept = default;
+  LayerV1(LayerV1 &&rhs) noexcept = default;
 
   /**
    * @brief  Move assignment operator.
    * @parma[in] rhs Layer to be moved.
    */
-  virtual Layer &operator=(Layer &&rhs) = default;
+  virtual LayerV1 &operator=(LayerV1 &&rhs) = default;
 
   /**
    * @brief Get the layer type
@@ -316,7 +316,7 @@ public:
    * @brief     Copy Layer
    * @param[in] l Layer to be copied
    */
-  virtual void copy(std::shared_ptr<Layer> l);
+  virtual void copy(std::shared_ptr<LayerV1> l);
 
   /**
    * @brief     check hyper parameter for the layer
@@ -722,14 +722,14 @@ private:
  * @brief   Overriding output stream for layers and it's derived class
  */
 template <typename T, typename std::enable_if_t<
-                        std::is_base_of<Layer, T>::value, T> * = nullptr>
+                        std::is_base_of<LayerV1, T>::value, T> * = nullptr>
 std::ostream &operator<<(std::ostream &out, T &l) {
-  l.printPreset(out, Layer::PrintPreset::PRINT_SUMMARY);
+  l.printPreset(out, LayerV1::PrintPreset::PRINT_SUMMARY);
   return out;
 }
 
-using CreateLayerFunc = nntrainer::Layer *(*)();
-using DestroyLayerFunc = void (*)(nntrainer::Layer *);
+using CreateLayerFunc = nntrainer::LayerV1 *(*)();
+using DestroyLayerFunc = void (*)(nntrainer::LayerV1 *);
 
 /**
  * @brief  Layer Pluggable struct that enables pluggable layer
@@ -752,9 +752,10 @@ extern "C" LayerPluggable ml_train_layer_pluggable;
  * @return std::unique_ptr<ml::train::Layer> created object
  */
 template <typename T,
-          std::enable_if_t<std::is_base_of<Layer, T>::value, T> * = nullptr>
-std::unique_ptr<Layer> createLayer(const std::vector<std::string> &props = {}) {
-  std::unique_ptr<Layer> ptr = std::make_unique<T>();
+          std::enable_if_t<std::is_base_of<LayerV1, T>::value, T> * = nullptr>
+std::unique_ptr<LayerV1>
+createLayer(const std::vector<std::string> &props = {}) {
+  std::unique_ptr<LayerV1> ptr = std::make_unique<T>();
 
   if (ptr->setProperty(props) != ML_ERROR_NONE) {
     throw std::invalid_argument("Set properties failed for layer");
@@ -768,7 +769,7 @@ std::unique_ptr<Layer> createLayer(const std::vector<std::string> &props = {}) {
  * @param   l Layer object
  * @return  Layer devel object
  */
-std::shared_ptr<Layer> getLayerDevel(std::shared_ptr<ml::train::Layer> l);
+std::shared_ptr<LayerV1> getLayerDevel(std::shared_ptr<ml::train::Layer> l);
 
 } // namespace nntrainer
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -19,7 +19,7 @@
 
 namespace nntrainer {
 
-LayerNode::LayerNode(std::shared_ptr<nntrainer::Layer> l, size_t idx) :
+LayerNode::LayerNode(std::shared_ptr<nntrainer::LayerV1> l, size_t idx) :
   layer(l),
   index(idx),
   flatten(false),
@@ -37,14 +37,14 @@ std::unique_ptr<LayerNode>
 createLayerNode(const std::string &type,
                 const std::vector<std::string> &properties) {
   auto &ac = nntrainer::AppContext::Global();
-  return createLayerNode(ac.createObject<nntrainer::Layer>(type), properties);
+  return createLayerNode(ac.createObject<nntrainer::LayerV1>(type), properties);
 }
 
 /**
  * @brief Layer factory creator with constructor
  */
 std::unique_ptr<LayerNode>
-createLayerNode(std::shared_ptr<nntrainer::Layer> layer,
+createLayerNode(std::shared_ptr<nntrainer::LayerV1> layer,
                 const std::vector<std::string> &properties) {
   auto lnode = std::make_unique<LayerNode>(layer);
   if (lnode->setProperty(properties) != ML_ERROR_NONE)
@@ -75,7 +75,7 @@ int LayerNode::setProperty(std::vector<std::string> properties) {
 
     try {
       /// @note this calls derived setProperty if available
-      setProperty(static_cast<nntrainer::Layer::PropertyType>(type), value);
+      setProperty(static_cast<nntrainer::LayerV1::PropertyType>(type), value);
     } catch (...) {
       remainder.push_back(properties[i]);
     }
@@ -85,10 +85,10 @@ int LayerNode::setProperty(std::vector<std::string> properties) {
   return status;
 }
 
-void LayerNode::setProperty(const nntrainer::Layer::PropertyType type,
+void LayerNode::setProperty(const nntrainer::LayerV1::PropertyType type,
                             const std::string &value) {
   int status = ML_ERROR_NONE;
-  using PropertyType = nntrainer::Layer::PropertyType;
+  using PropertyType = nntrainer::LayerV1::PropertyType;
 
   switch (type) {
   case PropertyType::name:
@@ -108,8 +108,8 @@ void LayerNode::setProperty(const nntrainer::Layer::PropertyType type,
       throw_status(status);
       if (distribute) {
         auto &ac = nntrainer::AppContext::Global();
-        std::shared_ptr<nntrainer::Layer> dlayer =
-          ac.createObject<nntrainer::Layer>(TimeDistLayer::type);
+        std::shared_ptr<nntrainer::LayerV1> dlayer =
+          ac.createObject<nntrainer::LayerV1>(TimeDistLayer::type);
         std::dynamic_pointer_cast<TimeDistLayer>(dlayer)->setDistLayer(layer);
         layer = dlayer;
       }
@@ -171,9 +171,11 @@ ActivationType LayerNode::getActivationType() {
 
 const std::string LayerNode::getType() const { return getLayer()->getType(); }
 
-std::shared_ptr<nntrainer::Layer> &LayerNode::getObject() { return getLayer(); }
+std::shared_ptr<nntrainer::LayerV1> &LayerNode::getObject() {
+  return getLayer();
+}
 
-const std::shared_ptr<nntrainer::Layer> &LayerNode::getObject() const {
+const std::shared_ptr<nntrainer::LayerV1> &LayerNode::getObject() const {
   return getLayer();
 }
 
@@ -181,14 +183,14 @@ bool LayerNode::getTrainable() const noexcept {
   return getLayer()->getTrainable();
 }
 
-const std::shared_ptr<nntrainer::Layer> &LayerNode::getLayer() const {
+const std::shared_ptr<nntrainer::LayerV1> &LayerNode::getLayer() const {
   if (distribute)
     return std::dynamic_pointer_cast<TimeDistLayer>(layer)->getDistLayer();
   else
     return layer;
 }
 
-std::shared_ptr<nntrainer::Layer> &LayerNode::getLayer() {
+std::shared_ptr<nntrainer::LayerV1> &LayerNode::getLayer() {
   if (distribute)
     return std::dynamic_pointer_cast<TimeDistLayer>(layer)->getDistLayer();
   else

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -273,7 +273,7 @@ public:
 private:
   // TODO: make this unique_ptr once getObject API is removed
   std::shared_ptr<nntrainer::LayerV1>
-    layer;      /**< The actual object in the graph node */
+    layer; /**< The actual object in the graph node */
   // TODO: possibly remove, two identifiers for the same  node (name and index)
   // can lead to issues later
   size_t index; /**< index of each node */

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -38,7 +38,7 @@ public:
    * @brief     Constructor of LayerNode class
    *
    */
-  LayerNode(std::shared_ptr<nntrainer::Layer> l, size_t idx = 0);
+  LayerNode(std::shared_ptr<nntrainer::LayerV1> l, size_t idx = 0);
 
   /**
    * @brief     Destructor of LayerNode Class
@@ -112,13 +112,13 @@ public:
    * @brief     Get underlying object
    *
    */
-  std::shared_ptr<nntrainer::Layer> &getObject();
+  std::shared_ptr<nntrainer::LayerV1> &getObject();
 
   /**
    * @brief     Get underlying object
    *
    */
-  const std::shared_ptr<nntrainer::Layer> &getObject() const;
+  const std::shared_ptr<nntrainer::LayerV1> &getObject() const;
 
   /**
    * @brief     Get index of the node
@@ -272,8 +272,8 @@ public:
 
 private:
   // TODO: make this unique_ptr once getObject API is removed
-  std::shared_ptr<nntrainer::Layer>
-    layer; /**< The actual object in the graph node */
+  std::shared_ptr<nntrainer::LayerV1>
+    layer;      /**< The actual object in the graph node */
   // TODO: possibly remove, two identifiers for the same  node (name and index)
   // can lead to issues later
   size_t index; /**< index of each node */
@@ -311,7 +311,7 @@ private:
    * the particular layer
    * @exception std::invalid_argument invalid argument
    */
-  void setProperty(const nntrainer::Layer::PropertyType type,
+  void setProperty(const nntrainer::LayerV1::PropertyType type,
                    const std::string &value = "");
 
   /**
@@ -320,7 +320,7 @@ private:
    * @details this is layer inside the distribution layer if this layer node
    * is distributed.
    */
-  const std::shared_ptr<nntrainer::Layer> &getLayer() const;
+  const std::shared_ptr<nntrainer::LayerV1> &getLayer() const;
 
   /**
    * @brief   Get the effective layer managed by this layer node
@@ -328,7 +328,7 @@ private:
    * @details this is layer inside the distribution layer if this layer node
    * is distributed.
    */
-  std::shared_ptr<nntrainer::Layer> &getLayer();
+  std::shared_ptr<nntrainer::LayerV1> &getLayer();
 };
 
 /**
@@ -348,7 +348,7 @@ createLayerNode(const std::string &type,
  * @params[in] properties Properties of the layer
  */
 std::unique_ptr<LayerNode>
-createLayerNode(std::shared_ptr<nntrainer::Layer> layer,
+createLayerNode(std::shared_ptr<nntrainer::LayerV1> layer,
                 const std::vector<std::string> &properties = {});
 
 } // namespace nntrainer

--- a/nntrainer/layers/loss_layer.cpp
+++ b/nntrainer/layers/loss_layer.cpp
@@ -117,8 +117,8 @@ void LossLayer::updateLoss(const Tensor &l) {
   loss = loss_sum / (float)l.batch();
 }
 
-void LossLayer::copy(std::shared_ptr<Layer> l) {
-  Layer::copy(l);
+void LossLayer::copy(std::shared_ptr<LayerV1> l) {
+  LayerV1::copy(l);
 
   std::shared_ptr<LossLayer> from = std::static_pointer_cast<LossLayer>(l);
   this->loss_type = from->loss_type;

--- a/nntrainer/layers/loss_layer.h
+++ b/nntrainer/layers/loss_layer.h
@@ -38,14 +38,14 @@ enum class LossType {
  * @class   LossLayer
  * @brief   loss layer
  */
-class LossLayer : public Layer {
+class LossLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Loss Layer
    */
   template <typename... Args>
   LossLayer(LossType loss_type_ = LossType::LOSS_UNKNOWN, Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     loss_type(loss_type_) {}
 
   /**
@@ -79,7 +79,7 @@ public:
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l) override;
+  void copy(std::shared_ptr<LayerV1> l) override;
 
   /**
    * @brief     initialize layer

--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -149,7 +149,7 @@ void LSTMLayer::setProperty(const PropertyType type, const std::string &value) {
     }
     break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
   }
@@ -250,8 +250,8 @@ void LSTMLayer::forwarding(bool training) {
   }
 }
 
-void LSTMLayer::copy(std::shared_ptr<Layer> l) {
-  Layer::copy(l);
+void LSTMLayer::copy(std::shared_ptr<LayerV1> l) {
+  LayerV1::copy(l);
 
   std::shared_ptr<LSTMLayer> from = std::static_pointer_cast<LSTMLayer>(l);
   this->unit = from->unit;

--- a/nntrainer/layers/lstm.h
+++ b/nntrainer/layers/lstm.h
@@ -24,7 +24,7 @@ namespace nntrainer {
  * @class   LSTMLayer
  * @brief   LSTMLayer
  */
-class LSTMLayer : public Layer {
+class LSTMLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of LSTMLayer
@@ -35,7 +35,7 @@ public:
     ActivationType hidden_state_activation_type_ = ActivationType::ACT_NONE,
     ActivationType recurrent_activation_type_ = ActivationType::ACT_NONE,
     bool sequence = false, Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     unit(unit_),
     hidden_state_activation_type(hidden_state_activation_type_),
     recurrent_activation_type(recurrent_activation_type_),
@@ -85,7 +85,7 @@ public:
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l) override;
+  void copy(std::shared_ptr<LayerV1> l) override;
 
   /**
    * @brief     initialize layer
@@ -106,7 +106,7 @@ public:
    */
   void setRecurrentActivation(ActivationType activation);
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/nnstreamer_layer.cpp
+++ b/nntrainer/layers/nnstreamer_layer.cpp
@@ -149,7 +149,7 @@ void NNStreamerLayer::setTrainable(bool train) {
     throw exception::not_supported(
       "NNStreamer layer does not support training");
 
-  Layer::setTrainable(false);
+  LayerV1::setTrainable(false);
 }
 
 void NNStreamerLayer::setProperty(const PropertyType type,
@@ -160,7 +160,7 @@ void NNStreamerLayer::setProperty(const PropertyType type,
       modelfile = value;
   } break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }
@@ -195,8 +195,8 @@ void NNStreamerLayer::forwarding(bool training) {
             hidden_.getData());
 }
 
-void NNStreamerLayer::copy(std::shared_ptr<Layer> l) {
-  Layer::copy(l);
+void NNStreamerLayer::copy(std::shared_ptr<LayerV1> l) {
+  LayerV1::copy(l);
 
   std::shared_ptr<NNStreamerLayer> from =
     std::static_pointer_cast<NNStreamerLayer>(l);

--- a/nntrainer/layers/nnstreamer_layer.h
+++ b/nntrainer/layers/nnstreamer_layer.h
@@ -26,13 +26,13 @@ namespace nntrainer {
  * @class   NNStreamerLayer
  * @brief   nnstreamer layer
  */
-class NNStreamerLayer : public Layer {
+class NNStreamerLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of NNStreamer Layer
    */
   NNStreamerLayer(std::string model = "") :
-    Layer(),
+    LayerV1(),
     modelfile(model),
     single(nullptr),
     in_res(nullptr),
@@ -62,7 +62,7 @@ public:
   /**
    * @copydoc Layer::copy(std::shared_ptr<layer> l)
    */
-  void copy(std::shared_ptr<Layer> l);
+  void copy(std::shared_ptr<LayerV1> l);
 
   /**
    * @copydoc Layer::initialize()
@@ -79,7 +79,7 @@ public:
    */
   const std::string getType() const { return NNStreamerLayer::type; };
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/output_layer.cpp
+++ b/nntrainer/layers/output_layer.cpp
@@ -75,7 +75,7 @@ void OutputLayer::setProperty(const PropertyType type,
     }
   } break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }

--- a/nntrainer/layers/output_layer.h
+++ b/nntrainer/layers/output_layer.h
@@ -24,13 +24,13 @@ namespace nntrainer {
  * @class   Output Layer
  * @brief   Output Layer
  */
-class OutputLayer : public Layer {
+class OutputLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Output Layer
    */
   template <typename... Args>
-  OutputLayer(unsigned int num_output_ = 1, Args... args) : Layer(args...) {
+  OutputLayer(unsigned int num_output_ = 1, Args... args) : LayerV1(args...) {
     setNumOutputs(num_output_);
   }
 

--- a/nntrainer/layers/permute_layer.cpp
+++ b/nntrainer/layers/permute_layer.cpp
@@ -90,8 +90,8 @@ void PermuteLayer::calcDerivative() {
   hidden_grad.transpose(rdirection_str, input_grad);
 }
 
-void PermuteLayer::copy(std::shared_ptr<Layer> l) {
-  Layer::copy(l);
+void PermuteLayer::copy(std::shared_ptr<LayerV1> l) {
+  LayerV1::copy(l);
 
   std::shared_ptr<PermuteLayer> from =
     std::static_pointer_cast<PermuteLayer>(l);
@@ -103,14 +103,14 @@ void PermuteLayer::copy(std::shared_ptr<Layer> l) {
 }
 
 void PermuteLayer::export_to(Exporter &exporter, ExportMethods method) const {
-  Layer::export_to(exporter, method);
+  LayerV1::export_to(exporter, method);
   exporter.saveResult(std::forward_as_tuple(direction), method);
 }
 
 int PermuteLayer::setProperty(std::vector<std::string> values) {
   try {
     auto left_values = loadProperties(values, std::forward_as_tuple(direction));
-    Layer::setProperty(left_values);
+    LayerV1::setProperty(left_values);
   } catch (std::invalid_argument &e) {
     ml_loge("[PermuteLayer] failed to set property, reason: %s", e.what());
     return ML_ERROR_INVALID_PARAMETER;

--- a/nntrainer/layers/permute_layer.h
+++ b/nntrainer/layers/permute_layer.h
@@ -46,7 +46,7 @@ public:
  * @class   PermuteLayer
  * @brief   Permute layer to transpose a tensor
  */
-class PermuteLayer : public Layer {
+class PermuteLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Permute Layer
@@ -54,7 +54,7 @@ public:
    */
   template <typename... Args>
   PermuteLayer(Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     direction(),
     reverse_direction() {}
 
@@ -89,7 +89,7 @@ public:
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l) override;
+  void copy(std::shared_ptr<LayerV1> l) override;
 
   /**
    * @brief     initialize layer
@@ -112,7 +112,7 @@ public:
 
   static const std::string type;
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(std::vector<std::string> values);

--- a/nntrainer/layers/plugged_layer.h
+++ b/nntrainer/layers/plugged_layer.h
@@ -27,7 +27,7 @@ namespace internal {
  * @brief PluggedLayer to wrap a layer from shared object file
  *
  */
-class PluggedLayer : public nntrainer::Layer {
+class PluggedLayer : public nntrainer::LayerV1 {
 public:
   /**
    * @brief Construct a new Plugged Layer object
@@ -140,7 +140,7 @@ public:
   /**
    * @copydoc Layer::copy(std::shared_ptr<Layer> l)
    */
-  void copy(std::shared_ptr<Layer> l) override { layerImpl->copy(l); }
+  void copy(std::shared_ptr<LayerV1> l) override { layerImpl->copy(l); }
 
   /**
    * @copydoc Layer::setTrainable(bool train)
@@ -247,7 +247,7 @@ public:
 private:
   /// @todo: migrate to ml::train::Layer
   // ml::train::Layer *layerImpl;
-  nntrainer::Layer *layerImpl;
+  nntrainer::LayerV1 *layerImpl;
   nntrainer::DestroyLayerFunc destroy_func;
 };
 } // namespace internal

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -100,7 +100,7 @@ int Pooling2DLayer::initialize(Manager &manager) {
 }
 
 void Pooling2DLayer::setBatch(unsigned int batch) {
-  Layer::setBatch(batch);
+  LayerV1::setBatch(batch);
   if (pooling_type == PoolingType::max) {
     max_idx.reserve(batch * output_dim[0].getFeatureLen());
   } else if (pooling_type == PoolingType::global_max) {
@@ -247,8 +247,8 @@ int Pooling2DLayer::setSize(int *size, PropertyType type) {
   return status;
 }
 
-void Pooling2DLayer::copy(std::shared_ptr<Layer> l) {
-  Layer::copy(l);
+void Pooling2DLayer::copy(std::shared_ptr<LayerV1> l) {
+  LayerV1::copy(l);
 
   std::shared_ptr<Pooling2DLayer> from =
     std::static_pointer_cast<Pooling2DLayer>(l);
@@ -306,7 +306,7 @@ void Pooling2DLayer::setProperty(const PropertyType type,
     }
     break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -27,7 +27,7 @@ namespace nntrainer {
  * @class   Pooling 2D Layer
  * @brief   Pooling 2D Layer
  */
-class Pooling2DLayer : public Layer {
+class Pooling2DLayer : public LayerV1 {
 public:
   enum class PoolingType {
     max = 0,
@@ -47,7 +47,7 @@ public:
     const std::array<unsigned int, POOLING2D_DIM> &stride_ = {1, 1},
     const std::array<unsigned int, POOLING2D_DIM> &padding_ = {0, 0},
     Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     pool_size(pool_size_),
     stride(stride_),
     padding(padding_),
@@ -103,9 +103,12 @@ public:
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l) override;
+  void copy(std::shared_ptr<LayerV1> l) override;
 
-  /* TO DO : support keras type of padding */
+  /**
+   * @brief Padding Type
+   *
+   */
   enum class PaddingType {
     full = 0,
     same = 1,
@@ -118,7 +121,7 @@ public:
    */
   const std::string getType() const override { return Pooling2DLayer::type; };
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/preprocess_flip_layer.cpp
+++ b/nntrainer/layers/preprocess_flip_layer.cpp
@@ -54,7 +54,7 @@ void PreprocessFlipLayer::setProperty(const PropertyType type,
     }
     break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }
@@ -116,7 +116,7 @@ void PreprocessFlipLayer::setTrainable(bool train) {
     throw exception::not_supported(
       "Preprocessing layer does not support training");
 
-  Layer::setTrainable(false);
+  LayerV1::setTrainable(false);
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/preprocess_flip_layer.h
+++ b/nntrainer/layers/preprocess_flip_layer.h
@@ -26,14 +26,14 @@ namespace nntrainer {
  * @class   Preprocess FLip Layer
  * @brief   Preprocess FLip Layer
  */
-class PreprocessFlipLayer : public Layer {
+class PreprocessFlipLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Preprocess FLip Layer
    */
   template <typename... Args>
   PreprocessFlipLayer(Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     flipdirection(FlipDirection::horizontal_and_vertical) {
     trainable = false;
   }
@@ -78,7 +78,7 @@ public:
    */
   void setTrainable(bool train) override;
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/preprocess_translate_layer.cpp
+++ b/nntrainer/layers/preprocess_translate_layer.cpp
@@ -72,7 +72,7 @@ void PreprocessTranslateLayer::setProperty(const PropertyType type,
     }
     break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }
@@ -137,7 +137,7 @@ void PreprocessTranslateLayer::setTrainable(bool train) {
     throw exception::not_supported(
       "Preprocessing layer does not support training");
 
-  Layer::setTrainable(false);
+  LayerV1::setTrainable(false);
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/preprocess_translate_layer.h
+++ b/nntrainer/layers/preprocess_translate_layer.h
@@ -30,14 +30,14 @@ namespace nntrainer {
  * @class   PreprocessTranslate Layer
  * @brief   Preprocess Translate Layer
  */
-class PreprocessTranslateLayer : public Layer {
+class PreprocessTranslateLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Preprocess Translate Layer
    */
   template <typename... Args>
   PreprocessTranslateLayer(Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     translation_factor(0.0),
     epsilon(1e-5) {
     trainable = false;
@@ -90,7 +90,7 @@ public:
     return PreprocessTranslateLayer::type;
   }
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/rnn.cpp
+++ b/nntrainer/layers/rnn.cpp
@@ -92,8 +92,8 @@ int RNNLayer::initialize(Manager &manager) {
   // TODO : We could control with something like #define test to save memory
   hidden = std::make_shared<Var_Grad>(d, true, true, "RNN:temp_hidden");
 
-  if (Layer::activation_type == ActivationType::ACT_NONE) {
-    Layer::activation_type = ActivationType::ACT_TANH;
+  if (LayerV1::activation_type == ActivationType::ACT_NONE) {
+    LayerV1::activation_type = ActivationType::ACT_TANH;
     acti_func.setActiFunc(activation_type);
   }
 
@@ -114,7 +114,7 @@ void RNNLayer::setProperty(const PropertyType type, const std::string &value) {
   case PropertyType::activation:
     if (!value.empty()) {
       ActivationType acti_type = (ActivationType)parseType(value, TOKEN_ACTI);
-      Layer::activation_type = acti_type;
+      LayerV1::activation_type = acti_type;
       acti_func.setActiFunc(acti_type);
     }
     break;
@@ -125,7 +125,7 @@ void RNNLayer::setProperty(const PropertyType type, const std::string &value) {
     }
     break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
   }
@@ -196,8 +196,8 @@ void RNNLayer::forwarding(bool training) {
   }
 }
 
-void RNNLayer::copy(std::shared_ptr<Layer> l) {
-  Layer::copy(l);
+void RNNLayer::copy(std::shared_ptr<LayerV1> l) {
+  LayerV1::copy(l);
 
   std::shared_ptr<RNNLayer> from = std::static_pointer_cast<RNNLayer>(l);
   this->unit = from->unit;

--- a/nntrainer/layers/rnn.h
+++ b/nntrainer/layers/rnn.h
@@ -24,14 +24,14 @@ namespace nntrainer {
  * @class   RNNLayer
  * @brief   RNNLayer
  */
-class RNNLayer : public Layer {
+class RNNLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of RNNLayer
    */
   template <typename... Args>
   RNNLayer(unsigned int unit_ = 0, bool sequence = false, Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     unit(unit_),
     return_sequences(sequence){};
 
@@ -71,7 +71,7 @@ public:
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l) override;
+  void copy(std::shared_ptr<LayerV1> l) override;
 
   /**
    * @brief     initialize layer
@@ -85,7 +85,7 @@ public:
    */
   const std::string getType() const override { return RNNLayer::type; };
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/split_layer.cpp
+++ b/nntrainer/layers/split_layer.cpp
@@ -100,7 +100,7 @@ int SplitLayer::initialize(Manager &manager) {
 }
 
 void SplitLayer::setBatch(unsigned int batch) {
-  Layer::setBatch(batch);
+  LayerV1::setBatch(batch);
   input_reshape_helper.batch(batch * leading_helper_dim);
   output_reshape_helper.batch(batch * leading_helper_dim);
 }
@@ -169,7 +169,7 @@ void SplitLayer::setProperty(const PropertyType type,
     }
   } break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }

--- a/nntrainer/layers/split_layer.h
+++ b/nntrainer/layers/split_layer.h
@@ -26,14 +26,14 @@ namespace nntrainer {
  * @class   Split Layer
  * @brief   Split Layer
  */
-class SplitLayer : public Layer {
+class SplitLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Split Layer
    */
   template <typename... Args>
   SplitLayer(unsigned int split_dim = 1, Args... args) :
-    Layer(args...),
+    LayerV1(args...),
     split_dimension(split_dim),
     leading_helper_dim(1) {}
 
@@ -89,7 +89,7 @@ public:
    */
   void setBatch(unsigned int batch) override;
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string

--- a/nntrainer/layers/tflite_layer.cpp
+++ b/nntrainer/layers/tflite_layer.cpp
@@ -80,7 +80,7 @@ void TfLiteLayer::setTrainable(bool train) {
   if (train)
     throw exception::not_supported("TfLite layer does not support training");
 
-  Layer::setTrainable(false);
+  LayerV1::setTrainable(false);
 }
 
 void TfLiteLayer::setProperty(const PropertyType type,
@@ -91,7 +91,7 @@ void TfLiteLayer::setProperty(const PropertyType type,
       modelfile = value;
   } break;
   default:
-    Layer::setProperty(type, value);
+    LayerV1::setProperty(type, value);
     break;
   }
 }
@@ -138,8 +138,8 @@ void TfLiteLayer::forwarding(bool training) {
 #endif
 }
 
-void TfLiteLayer::copy(std::shared_ptr<Layer> l) {
-  Layer::copy(l);
+void TfLiteLayer::copy(std::shared_ptr<LayerV1> l) {
+  LayerV1::copy(l);
 
   std::shared_ptr<TfLiteLayer> from = std::static_pointer_cast<TfLiteLayer>(l);
   this->modelfile = from->modelfile;

--- a/nntrainer/layers/tflite_layer.h
+++ b/nntrainer/layers/tflite_layer.h
@@ -28,13 +28,13 @@ namespace nntrainer {
  * @class   TfLiteLayer
  * @brief   Tensorflow Lite layer
  */
-class TfLiteLayer : public Layer {
+class TfLiteLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of NNStreamer Layer
    */
   TfLiteLayer(std::string model = "") :
-    Layer(),
+    LayerV1(),
     modelfile(model),
     interpreter(nullptr),
     model(nullptr) {
@@ -59,7 +59,7 @@ public:
   /**
    * @copydoc Layer::copy(std::shared_ptr<layer> l)
    */
-  void copy(std::shared_ptr<Layer> l) override;
+  void copy(std::shared_ptr<LayerV1> l) override;
 
   /**
    * @copydoc Layer::initialize()
@@ -76,7 +76,7 @@ public:
    */
   const std::string getType() const override { return TfLiteLayer::type; };
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
@@ -92,6 +92,13 @@ private:
   std::unique_ptr<tflite::Interpreter> interpreter;
   std::unique_ptr<tflite::FlatBufferModel> model;
 
+  /**
+   * @brief Set the Dimensions object
+   *
+   * @param tensor_idx_list tensor index list
+   * @param dim dimension
+   * @param is_output check if output
+   */
   void setDimensions(const std::vector<int> &tensor_idx_list,
                      std::vector<TensorDim> &dim, bool is_output);
 };

--- a/nntrainer/layers/time_dist.cpp
+++ b/nntrainer/layers/time_dist.cpp
@@ -197,17 +197,17 @@ void TimeDistLayer::forwarding(bool training) {
   hidden_.copy(transposeTensor(out));
 }
 
-void TimeDistLayer::copy(std::shared_ptr<Layer> l) {
-  Layer::copy(l);
+void TimeDistLayer::copy(std::shared_ptr<LayerV1> l) {
+  LayerV1::copy(l);
 
   std::shared_ptr<TimeDistLayer> from =
     std::static_pointer_cast<TimeDistLayer>(l);
   this->dist_layer = from->dist_layer;
 }
 
-void TimeDistLayer::setDistLayer(std::shared_ptr<Layer> l) {
+void TimeDistLayer::setDistLayer(std::shared_ptr<LayerV1> l) {
   dist_layer = l;
-  Layer::setActivation(l->getActivationType());
+  LayerV1::setActivation(l->getActivationType());
 };
 
 void TimeDistLayer::calcDerivative() {

--- a/nntrainer/layers/time_dist.h
+++ b/nntrainer/layers/time_dist.h
@@ -23,12 +23,12 @@ namespace nntrainer {
  * @class   TimeDistLayer
  * @brief   Time Distribution Layer
  */
-class TimeDistLayer : public Layer {
+class TimeDistLayer : public LayerV1 {
 public:
   /**
    * @brief     Constructor of Time Distribution Layer
    */
-  template <typename... Args> TimeDistLayer(Args... args) : Layer(args...) {
+  template <typename... Args> TimeDistLayer(Args... args) : LayerV1(args...) {
     for (unsigned int i = 0; i < 4; ++i) {
       positions[i] = nullptr;
     }
@@ -70,7 +70,7 @@ public:
    * @brief     copy layer
    * @param[in] l layer to copy
    */
-  void copy(std::shared_ptr<Layer> l) override;
+  void copy(std::shared_ptr<LayerV1> l) override;
 
   /**
    * @brief     initialize layer
@@ -83,7 +83,7 @@ public:
    * @brief     set distribute layer
    * @param[in] l layer to distribute along time
    */
-  void setDistLayer(std::shared_ptr<Layer> l);
+  void setDistLayer(std::shared_ptr<LayerV1> l);
 
   /**
    * @brief     get distribute layer type
@@ -95,7 +95,7 @@ public:
    * @brief     get distribute layer
    * @retval dist_layer std::shared_ptr<Layer>
    */
-  std::shared_ptr<Layer> &getDistLayer() { return dist_layer; };
+  std::shared_ptr<LayerV1> &getDistLayer() { return dist_layer; };
 
   /**
    * @brief     get transposed Tensor according to time iteration axis
@@ -118,7 +118,7 @@ public:
    */
   void transposeInOut();
 
-  using Layer::setProperty;
+  using LayerV1::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
@@ -144,7 +144,7 @@ private:
   /**
    * @brief Layer to be distributed through time
    */
-  std::shared_ptr<Layer> dist_layer;
+  std::shared_ptr<LayerV1> dist_layer;
 
   /**
    * @brief pointer value of each input/output tensors to compare position

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -251,7 +251,7 @@ sharedConstTensors NeuralNetwork::forwarding(sharedConstTensors input,
   return forwarding(training);
 }
 
-void NeuralNetwork::backwarding(std::shared_ptr<Layer> layer, int iteration,
+void NeuralNetwork::backwarding(std::shared_ptr<LayerV1> layer, int iteration,
                                 bool calc_derivative) {
   /**
    * Do not change this order:
@@ -786,7 +786,7 @@ void NeuralNetwork::printPreset(std::ostream &out, unsigned int preset) {
   if (preset > ML_TRAIN_SUMMARY_TENSOR)
     return;
 
-  Layer::PrintPreset layer_preset = Layer::PrintPreset::PRINT_NONE;
+  LayerV1::PrintPreset layer_preset = LayerV1::PrintPreset::PRINT_NONE;
 
   ///@todo match flags with preset
   unsigned int flags = PRINT_INST_INFO | PRINT_GRAPH_INFO | PRINT_PROP |
@@ -794,11 +794,11 @@ void NeuralNetwork::printPreset(std::ostream &out, unsigned int preset) {
 
   switch (preset) {
   case ML_TRAIN_SUMMARY_TENSOR:
-    layer_preset = Layer::PrintPreset::PRINT_ALL;
+    layer_preset = LayerV1::PrintPreset::PRINT_ALL;
     break;
   case ML_TRAIN_SUMMARY_LAYER:
-    layer_preset = initialized ? Layer::PrintPreset::PRINT_SUMMARY
-                               : Layer::PrintPreset::PRINT_SUMMARY_META;
+    layer_preset = initialized ? LayerV1::PrintPreset::PRINT_SUMMARY
+                               : LayerV1::PrintPreset::PRINT_SUMMARY_META;
     break;
   case ML_TRAIN_SUMMARY_MODEL:
     break;
@@ -810,7 +810,7 @@ void NeuralNetwork::printPreset(std::ostream &out, unsigned int preset) {
 }
 
 void NeuralNetwork::print(std::ostream &out, unsigned int flags,
-                          Layer::PrintPreset layerPrintPreset) {
+                          LayerV1::PrintPreset layerPrintPreset) {
   if (flags & PRINT_INST_INFO) {
     out << "===================";
     printInstance(out, this);

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -542,9 +542,9 @@ private:
    * @param[in] flags bit combination of Neuralnet::PrintOption
    * @param[in] Layer::PrintPreset print preset when to print layer properties
    */
-  void print(
-    std::ostream &out, unsigned int flags = 0,
-    Layer::PrintPreset layerPrintPreset = Layer::PrintPreset::PRINT_SUMMARY);
+  void print(std::ostream &out, unsigned int flags = 0,
+             LayerV1::PrintPreset layerPrintPreset =
+               LayerV1::PrintPreset::PRINT_SUMMARY);
 
   /**
    * @brief     Set Loss
@@ -626,7 +626,7 @@ private:
    * @param[in] calc_derivative If the derivative for previous layer must be
    * calculated
    */
-  void backwarding(std::shared_ptr<Layer> layer, int iteration,
+  void backwarding(std::shared_ptr<LayerV1> layer, int iteration,
                    bool calc_derivative);
 };
 

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -46,7 +46,7 @@ Exporter::getResult<ExportMethods::METHOD_TFLITE>() noexcept {
 }
 
 template <>
-void Exporter::saveTflResult(const std::tuple<> &props, const Layer *self) {
+void Exporter::saveTflResult(const std::tuple<> &props, const LayerV1 *self) {
   createIfNull(tf_node);
 }
 

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -203,13 +203,13 @@ class Name;
 class Unit;
 } // namespace props
 
-class Layer;
+class LayerV1;
 /**
  * @copydoc template <typename PropsType, typename NodeType> void
  * Exporter::saveTflResult(const PropsType &props, const NodeType *self);
  */
 template <>
-void Exporter::saveTflResult(const std::tuple<> &props, const Layer *self);
+void Exporter::saveTflResult(const std::tuple<> &props, const LayerV1 *self);
 
 class LayerNode;
 /**

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -320,7 +320,7 @@ unsigned int parseLayerProperty(std::string property) {
     }
   }
 
-  return (unsigned int)Layer::PropertyType::unknown;
+  return (unsigned int)LayerV1::PropertyType::unknown;
 }
 
 std::string propToStr(unsigned int type) { return property_string[type]; }

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -37,7 +37,7 @@ makeGraph(const std::vector<LayerReprentation> &layer_reps) {
   for (const auto &layer_representation : layer_reps) {
     /// @todo Use unique_ptr here
     std::shared_ptr<nntrainer::LayerNode> layer = createLayerNode(
-      ac.createObject<nntrainer::Layer>(layer_representation.first),
+      ac.createObject<nntrainer::LayerV1>(layer_representation.first),
       layer_representation.second);
     graph->addLayer(layer);
   }
@@ -64,8 +64,8 @@ static void graphEqual(const nntrainer::GraphRepresentation &lhs,
                        const nntrainer::GraphRepresentation &rhs) {
   EXPECT_EQ(lhs.size(), rhs.size());
 
-  auto is_node_equal = [](const nntrainer::Layer &l,
-                          const nntrainer::Layer &r) {
+  auto is_node_equal = [](const nntrainer::LayerV1 &l,
+                          const nntrainer::LayerV1 &r) {
     nntrainer::Exporter lhs_export;
     nntrainer::Exporter rhs_export;
 

--- a/test/unittest/layers/layers_common_tests.cpp
+++ b/test/unittest/layers/layers_common_tests.cpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file layer_common_tests.cpp
+ * @date 15 June 2021
+ * @brief Common test for nntrainer layers (Param Tests)
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <layers_common_tests.h>
+
+TEST_P(LayerGoldenTest, HelloWorld) { EXPECT_TRUE(true); }
+
+TEST_P(LayerCreateDestroyTest, HelloWorld) { EXPECT_TRUE(true); }

--- a/test/unittest/layers/layers_common_tests.h
+++ b/test/unittest/layers/layers_common_tests.h
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file layer_common_tests.h
+ * @date 15 June 2021
+ * @brief Common test for nntrainer layers (Param Tests)
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#ifndef __LAYERS_COMMON_TESTS_H__
+#define __LAYERS_COMMON_TESTS_H__
+
+#include <gtest/gtest.h>
+
+/**
+ * @brief LayerCreateDestroyTest
+ * @note NYI
+ *
+ * parameters required
+ * 1. type
+ * 2. a set of valid properties
+ * 3. a set of invalid properties
+ */
+class LayerCreateDestroyTest : public ::testing::TestWithParam<const char *> {
+public:
+  /**
+   * @brief SetUp test cases here
+   *
+   */
+  virtual void SetUp(){};
+
+  /**
+   * @brief do here if any memory needs to be released
+   *
+   */
+  virtual void TearDown(){};
+};
+
+/**
+ * @brief Golden Layer Test with designated format
+ * @note NYI
+ *
+ * 1. type
+ * 2. properties for the layer
+ * 3. batch size
+ * 4. golden file name
+ */
+class LayerGoldenTest : public ::testing::TestWithParam<const char *> {
+public:
+  /**
+   * @brief SetUp test cases here
+   *
+   */
+  virtual void SetUp(){};
+
+  /**
+   * @brief do here if any memory needs to be released
+   *
+   */
+  virtual void TearDown(){};
+};
+
+#endif // __LAYERS_COMMON_TESTS_H__

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -1,0 +1,18 @@
+test_target = [
+  'layers_common_tests.cpp',
+  'unittest_layers_fully_connected.cpp',
+]
+
+exe = executable(
+  'unittest_layers', test_target,
+  dependencies: [
+    nntrainer_test_main_deps,
+  ],
+  install: get_option('enable-test'),
+  install_dir: application_install_dir
+)
+
+# @todo delete v2 once migration is done
+test('unittest_layers_v2', exe,
+  args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), 'unittest_layers_v2')
+)

--- a/test/unittest/layers/unittest_layers_fully_connected.cpp
+++ b/test/unittest/layers/unittest_layers_fully_connected.cpp
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file unittest_layer_fully_connected.cpp
+ * @date 15 June 2021
+ * @brief Fully Connected Layer Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include <layers_common_tests.h>
+
+INSTANTIATE_TEST_CASE_P(
+  FullyConnected, LayerCreateDestroyTest,
+  ::testing::Values(
+    "golden1") /**< format of type, properties, num_batch, golden file name */);
+
+INSTANTIATE_TEST_CASE_P(
+  FullyConnected, LayerGoldenTest,
+  ::testing::Values(
+    "golden1") /**< format of type, properties, num_batch, golden file name */);

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -54,4 +54,7 @@ foreach target: test_target
   test(target, exe, args: ['--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), target)] )
 endforeach
 
+unittest_inc = include_directories('.')
+
 subdir('compiler')
+subdir('layers')

--- a/test/unittest/unittest_nntrainer_appcontext.cpp
+++ b/test/unittest/unittest_nntrainer_appcontext.cpp
@@ -144,7 +144,7 @@ public:
  *
  * @todo solidify the api signature
  */
-class CustomLayer : public nntrainer::Layer {
+class CustomLayer : public nntrainer::LayerV1 {
 public:
   static const std::string type;
 

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -260,7 +260,7 @@ TEST_F(nntrainer_InputLayer, initialize_01_p) {
 
 TEST_F(nntrainer_InputLayer, set_property_01_n) {
   EXPECT_THROW(
-    layer.setProperty(nntrainer::Layer::PropertyType::input_shape, "0:3:2:1"),
+    layer.setProperty(nntrainer::LayerV1::PropertyType::input_shape, "0:3:2:1"),
     std::invalid_argument);
 }
 
@@ -907,7 +907,7 @@ protected:
   sharedTensor label;
   std::vector<nntrainer::Tensor> new_w;
   std::vector<nntrainer::Tensor> grad;
-  std::vector<std::shared_ptr<nntrainer::Layer>> layers;
+  std::vector<std::shared_ptr<nntrainer::LayerV1>> layers;
   nntrainer::LossType loss_type = nntrainer::LossType::LOSS_UNKNOWN;
 };
 
@@ -1363,7 +1363,7 @@ protected:
 
 TEST_F(nntrainer_Conv2DLayer, print_01_p) {
   std::stringstream ss, ss2;
-  layer.printPreset(ss, nntrainer::Layer::PrintPreset::PRINT_ALL);
+  layer.printPreset(ss, nntrainer::LayerV1::PrintPreset::PRINT_ALL);
   ss2 << layer;
   EXPECT_GT(ss.str().size(), 100u);
   EXPECT_GT(ss2.str().size(), 100u);
@@ -2083,13 +2083,13 @@ TEST(nntrainer_LossLayer, setProperty_through_vector_n) {
 TEST(nntrainer_LossLayer, setProperty_individual_01_n) {
   nntrainer::LossLayer layer;
   EXPECT_THROW(
-    layer.setProperty(nntrainer::Layer::PropertyType::filters, "1:2"),
+    layer.setProperty(nntrainer::LayerV1::PropertyType::filters, "1:2"),
     nntrainer::exception::not_supported);
 }
 
 TEST(nntrainer_LossLayer, setProperty_individual_02_n) {
   nntrainer::LossLayer layer;
-  EXPECT_THROW(layer.setProperty(nntrainer::Layer::PropertyType::filters,
+  EXPECT_THROW(layer.setProperty(nntrainer::LayerV1::PropertyType::filters,
                                  "invalid_string"),
                nntrainer::exception::not_supported);
 }

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -1257,7 +1257,7 @@ INSTANTIATE_TEST_CASE_P(
  */
 TEST(nntrainerModels, read_save_01_n) {
   nntrainer::NeuralNetwork NN;
-  std::shared_ptr<nntrainer::Layer> layer =
+  std::shared_ptr<nntrainer::LayerV1> layer =
     nntrainer::createLayer(nntrainer::InputLayer::type);
   layer->setProperty(
     {"input_shape=1:1:62720", "normalization=true", "bias_initializer=zeros"});


### PR DESCRIPTION
- [Test/Scaffolding] Prepare test for the new layer

```
For now, layer test is too cluttered so that it is not agile enought to
make any change.

This PR mainly separates the tests into two parts to make the test
scallable itself.

1. Layer only test leaving inside `unittest_layers_{layer_name}`
2. Common tests like setProperty, golden_test in `layers_common_tests.h`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [Refactor] s/Layer/LayerV1

```
Change class name of layer to layerV1 to prepare migration
This should pass CI test.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [API/Devel] Retouch devel header

```
**Changes proposed in this PR:**
- Change function sinature to exploit forward declaration
- s/export_to/exportTo
- Change header guard to be unique

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```