### PR TITLE
[Layer] Add const to the layer::getName()

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -133,7 +133,7 @@ public:
    * @note      This name might be changed once this layer is added to the model
    * to keep the name unique to the model
    */
-  virtual std::string getName() noexcept = 0;
+  virtual const std::string getName() const noexcept = 0;
 };
 
 /**

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -49,7 +49,7 @@ public:
    * @return std::string Name of the underlying object
    * @note name of each node in the graph must be unique
    */
-  virtual std::string getName() noexcept = 0;
+  virtual const std::string getName() const noexcept = 0;
 
   /**
    * @brief     Set the Name of the underlying object

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -90,19 +90,9 @@ public:
    * @note      This name might be changed once this layer is added to the model
    * to keep the name unique to the model
    */
-  const std::string getName() const noexcept {
+  const std::string getName() const noexcept override {
     return std::get<props::Name>(props).get();
   }
-
-  /**
-   * @brief     Get name of the layer
-   *
-   * @retval    name of the layer
-   * @note      This name is unique to this layer in a model
-   * @note      This name might be changed once this layer is added to the model
-   * to keep the name unique to the model
-   */
-  std::string getName() noexcept { return std::get<props::Name>(props).get(); }
 
   /**
    * Support all the interface requirements by GraphNode<nntrainer::Layer>


### PR DESCRIPTION
- [Layer] Add const to the layer::getName()

```
getName() is independent of const, so this patch adds const to
layer::getName();

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```