### PR TITLE
[networkgraph] Network graph updated for Layer V2

### DIFF
--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -262,8 +262,10 @@ public:
    * @param init_context Init layer context to create run context
    * @param run_context Run layer context to be created
    */
-  static void updateRunContext(std::shared_ptr<Manager> &manager,
-                               const std::shared_ptr<LayerNode> &lnode);
+  static std::vector<Var_Grad *>
+  updateRunContext(std::shared_ptr<Manager> &manager,
+                   const std::shared_ptr<LayerNode> &lnode,
+                   const std::vector<Var_Grad *> &inputs);
 
 private:
   std::map<std::string, std::string> sub_in_out; /** This is map to identify

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -61,6 +61,13 @@ public:
   InitLayerContext() = default;
 
   /**
+   * @brief Construct a new Init Layer Context object
+   *
+   * @param dim Input dimensions for the layer
+   */
+  InitLayerContext(const std::vector<TensorDim> &dim) : input_dim(dim) {}
+
+  /**
    * @brief Get the Input Dimensions object
    *
    * @return const std::vector<TensorDim>& Input dimensions

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -578,9 +578,8 @@ public:
    * @param[in] i axis
    */
   void setInputDimension(const TensorDim &d, unsigned int i) {
-    if (i > MAXDIM)
-      throw std::invalid_argument(
-        "axis must be greater than 0 and less then MAX_DIM : 4");
+    if (i >= getNumInputs())
+      throw std::out_of_range("Setting dimensions out of bounds");
     input_dim[i] = d;
   }
 


### PR DESCRIPTION
Network graph updated to work with LayerV2
This involves settings input dimension in InitContext, and setting
up RunContext for each layer before their execution.

Further, some helper functions are also added in LayerNode.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>