### PR TITLE
[network] Remove check for double activation

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -753,13 +753,6 @@ int NetworkGraph::initialize(std::shared_ptr<Manager> manager) {
     if (!is_input_node(cur_type, idx)) {
       std::string l_pre_type = getSortedLayerNode(idx - 1)->getType();
 
-      // TODO: move this to checkCompiledGraph
-      if (istrequal(l_pre_type, ActivationLayer::type) &&
-          istrequal(cur_type, ActivationLayer::type)) {
-        ml_loge("double activation is not allowed");
-        return ML_ERROR_INVALID_PARAMETER;
-      }
-
       auto &input_layers = lnode->getInputLayers();
       for (unsigned int i = 0; i < input_layers.size(); ++i) {
         auto in_layer_node = getLayerNode(input_layers[i]);

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -318,8 +318,6 @@ INSTANTIATE_TEST_CASE_P(
     mkIniTc("unknown_loss_n", {nw_base + "loss = unknown", adam, input, out+"input_layers=inputlayer"}, COMPFAIL | INITFAIL),
     mkIniTc("activation_very_first_n", {nw_base, sgd, act_relu, input+"input_layers=activation_relu", out+"input_layers=inputlayer"}, COMPFAIL | INITFAIL),
     mkIniTc("bnlayer_very_first_n", {nw_base, sgd, batch_normal, input+"input_layers=bn", out+"input_layers=inputlayer"}, COMPFAIL | INITFAIL),
-    mkIniTc("act_layer_after_act_n", {nw_base, sgd, input, act_relu+"input_layers=inputlayer", out+"input_layers=activation_relu"}, INITFAIL),
-    mkIniTc("act_layer_after_act_bn_n", {nw_base, sgd, input, act_relu+"input_layers=inputlayer", batch_normal+"input_layers=activation_relu", out+"input_layers=bn" }, INITFAIL),
     mkIniTc("last_act_layer_relu_n", {nw_base, sgd, input, out+"input_layers=inputlayer", act_relu+"input_layers=fclayer" }, COMPFAIL | INITFAIL),
     mkIniTc("last_act_layer_relu2_n", {nw_base, sgd, input, out+"input_layers=inputlayer" + "-Activation", act_relu+"input_layers=fclayer" }, COMPFAIL | INITFAIL),
     mkIniTc("basic_conv2d_n", {nw_base, adam, conv2d + "input_shape = 1:1:62720"}, INITFAIL),


### PR DESCRIPTION
Remove the check for double activation, it is now allowed to have
two activation operations one after the other.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>