### PR TITLE
[Test/Prepare] Add layer semantics test

### DIFF
--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -67,6 +67,22 @@ public:
 };
 
 /**
+ * @brief trainable property, use this to set and check how if certain layer is
+ * trainable
+ *
+ */
+class Trainable : public nntrainer::Property<bool> {
+public:
+  /**
+   * @brief Construct a new Trainable object
+   *
+   */
+  Trainable(bool val = true) : nntrainer::Property<bool>(val) {}
+  static constexpr const char *key = "trainable";
+  using prop_tag = bool_prop_tag;
+};
+
+/**
  * @brief RAII class to define the connection spec
  *
  */

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -206,9 +206,6 @@ public:
     if (!weights[idx]->getTrainable())
       throw std::invalid_argument(
         "Requesting gradient for a non-trainable weight.");
-    if (!trainable)
-      throw std::invalid_argument(
-        "Requesting gradient for a non-trainable layer.");
     return weights[idx]->getGradientRef();
   }
 
@@ -296,16 +293,8 @@ public:
    */
   unsigned int getNumWeights() const { return weights.size(); }
 
-  /**
-   * @brief Get the if the layer is trainable
-   *
-   * @return bool true if trainable, else false
-   */
-  bool getTrainable() { return trainable; }
-
 private:
   std::tuple<props::Name> props; /**< props of the layer */
-  bool trainable;                /**< if the layer is trainable */
 
   std::vector<Weight *> weights;   /**< weights of the layer */
   std::vector<Var_Grad *> inputs;  /**< inputs of the layer */

--- a/nntrainer/layers/layer_impl.cpp
+++ b/nntrainer/layers/layer_impl.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <vector>
 
+#include <common_properties.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>
@@ -23,7 +24,7 @@ namespace nntrainer {
 
 LayerImpl::LayerImpl() :
   finalized(false),
-  layer_impl_props(std::make_unique<std::tuple<>>()) {}
+  layer_impl_props(std::make_unique<std::tuple<props::Trainable>>()) {}
 
 void LayerImpl::finalize(InitContext &context) {
   NNTR_THROW_IF(finalized, nntrainer::exception::not_supported)
@@ -32,7 +33,9 @@ void LayerImpl::finalize(InitContext &context) {
   finalized = true;
 }
 
-void LayerImpl::setProperty(const std::vector<std::string> &values) {}
+void LayerImpl::setProperty(const std::vector<std::string> &values) {
+  loadProperties(values, *layer_impl_props);
+}
 
 void LayerImpl::exportTo(Exporter &exporter,
                          const ExportMethods &method) const {}

--- a/nntrainer/layers/layer_impl.h
+++ b/nntrainer/layers/layer_impl.h
@@ -26,6 +26,11 @@ class RunContext;
 class Exporter;
 
 enum class ExportMethods;
+
+namespace props {
+class Trainable;
+}
+
 /**
  * @class   An abstract class to ease developing a layer
  * @brief   An abstract class for all layers
@@ -63,8 +68,9 @@ public:
                         const ExportMethods &method) const override;
 
 private:
-  bool finalized;                                 /**< check if finalized */
-  std::unique_ptr<std::tuple<>> layer_impl_props; /**< layer_impl_props */
+  bool finalized; /**< check if finalized */
+  std::unique_ptr<std::tuple<props::Trainable>>
+    layer_impl_props; /**< layer_impl_props */
 };
 
 } // namespace nntrainer

--- a/test/unittest/layers/layers_common_tests.cpp
+++ b/test/unittest/layers/layers_common_tests.cpp
@@ -12,6 +12,32 @@
 
 #include <layers_common_tests.h>
 
-TEST_P(LayerGoldenTest, HelloWorld) { EXPECT_TRUE(true); }
+#include <layer_devel.h>
 
-TEST_P(LayerCreateDestroyTest, HelloWorld) { EXPECT_TRUE(true); }
+constexpr unsigned SAMPLE_TRIES = 10;
+
+LayerSemantics::~LayerSemantics() {}
+
+void LayerSemantics::SetUp() {
+  auto f = std::get<0>(GetParam());
+  layer = std::move(f({}));
+  std::tie(std::ignore, expected_type, valid_properties, invalid_properties,
+           options) = GetParam();
+}
+
+void LayerSemantics::TearDown() {}
+
+TEST_P(LayerSemantics, createFromAppContext_pn) {}
+
+TEST_P(LayerSemantics, setProperties_p) {
+  /// @todo check if setProperties does not collide with layerNode designated
+  /// properties
+}
+
+TEST_P(LayerSemantics, setPropertiesValidWithInvalid_n) {}
+
+TEST_P(LayerSemantics, setPropertiesValidInvalidOnly_n) {}
+
+TEST_P(LayerSemantics, finalizeTwice_p) {}
+
+TEST_P(LayerGoldenTest, HelloWorld) { EXPECT_TRUE(true); }

--- a/test/unittest/layers/layers_common_tests.h
+++ b/test/unittest/layers/layers_common_tests.h
@@ -12,30 +12,68 @@
 #ifndef __LAYERS_COMMON_TESTS_H__
 #define __LAYERS_COMMON_TESTS_H__
 
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
+namespace nntrainer {
+class Layer;
+}
+
+typedef enum {
+  AVAILABLE_FROM_APP_CONTEXT =
+    1 << 0, /**< set if layer is available from app context */
+} LayerCreateSetPropertyOptions;
+
+using LayerFactoryType = std::function<std::unique_ptr<nntrainer::Layer>(
+  const std::vector<std::string> &)>;
+
+using LayerSemanticsParamType =
+  std::tuple<LayerFactoryType /** layer factory */,
+             std::string /** Type of Layer */,
+             std::vector<std::string> /** Valid Properties */,
+             std::vector<std::string> /** Invalid Properties */,
+             unsigned int /** Options */
+             >;
+
 /**
- * @brief LayerCreateDestroyTest
- * @note NYI
- *
- * parameters required
- * 1. type
- * 2. a set of valid properties
- * 3. a set of invalid properties
+ * @brief LayerSemantics
+ * @note  This test suite includes
+ * @see   layers_common_test.cpp for details
+ * 1. Layer Creation
+ * 2. SetProperties
+ * 3. Semantics of Layer (eg) finalize twice is prohibited)
  */
-class LayerCreateDestroyTest : public ::testing::TestWithParam<const char *> {
+class LayerSemantics
+  : public ::testing::TestWithParam<LayerSemanticsParamType> {
 public:
+  /**
+   * @brief Destroy the Layer Semantics object
+   *
+   */
+  virtual ~LayerSemantics();
+
   /**
    * @brief SetUp test cases here
    *
    */
-  virtual void SetUp(){};
+  virtual void SetUp();
 
   /**
    * @brief do here if any memory needs to be released
    *
    */
-  virtual void TearDown(){};
+  virtual void TearDown();
+
+protected:
+  std::unique_ptr<nntrainer::Layer> layer;
+  std::string expected_type;
+  std::vector<std::string> valid_properties;
+  std::vector<std::string> invalid_properties;
+  unsigned int options;
 };
 
 /**

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -1,5 +1,6 @@
 test_target = [
   'layers_common_tests.cpp',
+  'unittest_layers_impl.cpp',
   'unittest_layers_fully_connected.cpp',
 ]
 

--- a/test/unittest/layers/unittest_layers_fully_connected.cpp
+++ b/test/unittest/layers/unittest_layers_fully_connected.cpp
@@ -15,10 +15,11 @@
 
 #include <layers_common_tests.h>
 
-INSTANTIATE_TEST_CASE_P(
-  FullyConnected, LayerCreateDestroyTest,
-  ::testing::Values(
-    "golden1") /**< format of type, properties, num_batch, golden file name */);
+// INSTANTIATE_TEST_CASE_P(
+//   FullyConnected, LayerSemantics,
+//   ::testing::Values(
+//     "golden1") /**< format of type, properties, num_batch, golden file name
+//     */);
 
 INSTANTIATE_TEST_CASE_P(
   FullyConnected, LayerGoldenTest,

--- a/test/unittest/layers/unittest_layers_impl.cpp
+++ b/test/unittest/layers/unittest_layers_impl.cpp
@@ -12,23 +12,47 @@
 #include <tuple>
 
 #include <gtest/gtest.h>
-
 #include <layers_common_tests.h>
 
+#include <layer_context.h>
 #include <layer_impl.h>
+#include <string>
 
 namespace {
+
+using namespace nntrainer;
 /**
  * @brief Minimal implementation of layer impl to test layer impl itself
  *
  */
-class MockLayer : public nntrainer::LayerImpl {};
+class MockLayer final : public LayerImpl {
+public:
+  ~MockLayer() = default;
+
+  inline static const std::string type = "mock_";
+  const std::string getType() const override { return type; }
+  void finalize(InitContext &context) override { LayerImpl::finalize(context); }
+  void forwarding(RunContext &context, bool training = true) override {
+    /** do nothing */
+  }
+  void calcDerivative(RunContext &context) override { /** do nothing */
+  }
+
+  void setProperty(const std::vector<std::string> &values) override {
+    LayerImpl::setProperty(values);
+  }
+
+  void exportTo(Exporter &exporter,
+                const ExportMethods &method) const override {
+    LayerImpl::exportTo(exporter, method);
+  }
+};
 } // namespace
 
-INSTANTIATE_TEST_CASE_P(
-  LayerImpl, LayerCreateDestroyTest,
-  ::testing::Values(
-    "test") /**< format of type, properties, num_batch, golden file name */);
+auto semantic_tc = LayerSemanticsParamType(nntrainer::createLayer<MockLayer>,
+                                           MockLayer::type, {}, {}, 0);
+INSTANTIATE_TEST_CASE_P(LayerImpl, LayerSemantics,
+                        ::testing::Values(semantic_tc));
 
 INSTANTIATE_TEST_CASE_P(
   LayerImpl, LayerGoldenTest,


### PR DESCRIPTION
- [Test/Prepare] Add layer semantics test

```
For layer_v2, there will be more structured way to access tests.
This patch adds a skeleton for layer semantics test.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [Layer] Add trainable prop

```
This patch add trainable property to layer

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [Properties] Add float and boolean cases

```
Add float and boolean case to be used later.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [Props] Add concept of empty to property

```
This patch adds empty concept to property instead of having insensible
value inside a property as a default

before this patch,
```cpp
auto a = Property<int>();
EXPECT_EQ(a.get(), -1); // let's assume -1 is default value which might not be sensible.
```
after this patch

```cpp
auto a = Property<int>();
EXPECT_THROW(a.get(), std::invalid_argument);
EXPECT_TRUE(a.empty());
```

so underlying value remains always null or valid.

Now, it became natural to distinguish mandatory props and non-mandatory
props

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```