### PR TITLE
[AppContext] Integrate layer-devel @open sesame 06/22 16:38

### DIFF
--- a/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
@@ -28,7 +28,7 @@ TEST(AppContext, DlRegisterOpen_p) {
     << "NNTRAINER_PATH environment value must be set";
   auto ac = nntrainer::AppContext();
 
-  ac.registerLayer("libpow_layer.so", NNTRAINER_PATH);
+  ac.registerLayerV1("libpow_layer.so", NNTRAINER_PATH);
 
   auto layer = ac.createObject<nntrainer::LayerV1>("pow");
 
@@ -40,7 +40,7 @@ TEST(AppContext, DlRegisterWrongPath_n) {
     << "NNTRAINER_PATH environment value must be set";
   auto ac = nntrainer::AppContext();
 
-  EXPECT_THROW(ac.registerLayer("wrong_name.so"), std::invalid_argument);
+  EXPECT_THROW(ac.registerLayerV1("wrong_name.so"), std::invalid_argument);
 }
 
 TEST(AppContext, DlRegisterDirectory_p) {
@@ -68,7 +68,7 @@ TEST(AppContext, DefaultEnvironmentPath_p) {
   std::shared_ptr<ml::train::Layer> l = ml::train::createLayer("pow");
   EXPECT_EQ(l->getType(), "pow");
 
-  auto layer = nntrainer::getLayerDevel(l);
+  auto layer = nntrainer::getLayerV1Devel(l);
 
   std::ifstream input_file("does_not_exist");
   EXPECT_NO_THROW(layer->read(input_file));

--- a/Applications/Custom/pow.cpp
+++ b/Applications/Custom/pow.cpp
@@ -151,8 +151,8 @@ void destory_pow_layer(nntrainer::LayerV1 *layer) {
 }
 
 extern "C" {
-nntrainer::LayerPluggable ml_train_layer_pluggable{create_pow_layer,
-                                                   destory_pow_layer};
+nntrainer::LayerV1Pluggable ml_train_layerv1_pluggable{create_pow_layer,
+                                                       destory_pow_layer};
 }
 
 #endif

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -316,8 +316,8 @@ const std::string AppContext::getWorkingPath(const std::string &path) {
   return getFullPath(path, working_path_base);
 }
 
-int AppContext::registerLayer(const std::string &library_path,
-                              const std::string &base_path) {
+int AppContext::registerLayerV1(const std::string &library_path,
+                                const std::string &base_path) {
   const std::string full_path = getFullPath(library_path, base_path);
 
   void *handle = dlopen(full_path.c_str(), RTLD_LAZY | RTLD_LOCAL);
@@ -326,9 +326,9 @@ int AppContext::registerLayer(const std::string &library_path,
   NNTR_THROW_IF(handle == nullptr, std::invalid_argument)
     << func_tag << "open plugin failed, reason: " << error_msg;
 
-  nntrainer::LayerPluggable *pluggable =
-    reinterpret_cast<nntrainer::LayerPluggable *>(
-      dlsym(handle, "ml_train_layer_pluggable"));
+  nntrainer::LayerV1Pluggable *pluggable =
+    reinterpret_cast<nntrainer::LayerV1Pluggable *>(
+      dlsym(handle, "ml_train_layerv1_pluggable"));
 
   error_msg = dlerror();
   auto close_dl = [handle] { dlclose(handle); };
@@ -408,7 +408,7 @@ AppContext::registerPluggableFromDirectory(const std::string &base_path) {
     if (endswith(entry->d_name, solib_suffix)) {
       if (endswith(entry->d_name, layerlib_suffix)) {
         try {
-          int key = registerLayer(entry->d_name, base_path);
+          int key = registerLayerV1(entry->d_name, base_path);
           keys.emplace_back(key);
         } catch (std::exception &e) {
           closedir(dir);

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <layer_devel.h>
 #include <layer_internal.h>
 #include <optimizer.h>
 
@@ -104,6 +105,7 @@ public:
    * @brief register a layer factory from a shared library
    * plugin must have **extern "C" LayerPluggable *ml_train_layer_pluggable**
    * defined else error
+   * @note change ml_train_layerv1_pluggable to ml_train_layer_pluggable
    *
    * @param library_path a file name of the library
    * @param base_path    base path to make a full path (optional)
@@ -111,8 +113,8 @@ public:
    * @throws std::invalid_parameter if library_path is invalid or library is
    * invalid
    */
-  int registerLayer(const std::string &library_path,
-                    const std::string &base_path = "");
+  int registerLayerV1(const std::string &library_path,
+                      const std::string &base_path = "");
 
   /**
    * @brief register a optimizer factory from a shared library
@@ -292,7 +294,8 @@ public:
   }
 
 private:
-  FactoryMap<ml::train::Optimizer, nntrainer::LayerV1> factory_map;
+  FactoryMap<ml::train::Optimizer, nntrainer::LayerV1, nntrainer::Layer>
+    factory_map;
   std::string working_path_base;
 };
 

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -363,7 +363,7 @@ void LayerV1::print(std::ostream &out, unsigned int flags) {
   }
 };
 
-std::shared_ptr<LayerV1> getLayerDevel(std::shared_ptr<ml::train::Layer> l) {
+std::shared_ptr<LayerV1> getLayerV1Devel(std::shared_ptr<ml::train::Layer> l) {
   return std::static_pointer_cast<LayerNode>(l)->getObject();
 }
 

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -727,22 +727,22 @@ std::ostream &operator<<(std::ostream &out, T &l) {
   return out;
 }
 
-using CreateLayerFunc = nntrainer::LayerV1 *(*)();
-using DestroyLayerFunc = void (*)(nntrainer::LayerV1 *);
+using CreateLayerV1Func = nntrainer::LayerV1 *(*)();
+using DestroyLayerV1Func = void (*)(nntrainer::LayerV1 *);
 
 /**
  * @brief  Layer Pluggable struct that enables pluggable layer
  *
  */
 typedef struct {
-  CreateLayerFunc createfunc;   /**< create layer function */
-  DestroyLayerFunc destroyfunc; /**< destory function */
-} LayerPluggable;
+  CreateLayerV1Func createfunc;   /**< create layer function */
+  DestroyLayerV1Func destroyfunc; /**< destory function */
+} LayerV1Pluggable;
 
 /**
  * @brief pluggable layer must have this structure defined
  */
-extern "C" LayerPluggable ml_train_layer_pluggable;
+extern "C" LayerV1Pluggable ml_train_layerv1_pluggable;
 
 /**
  * @brief General Layer Factory function to register Layer
@@ -768,7 +768,7 @@ createLayer(const std::vector<std::string> &props = {}) {
  * @param   l Layer object
  * @return  Layer devel object
  */
-std::shared_ptr<LayerV1> getLayerDevel(std::shared_ptr<ml::train::Layer> l);
+std::shared_ptr<LayerV1> getLayerV1Devel(std::shared_ptr<ml::train::Layer> l);
 
 } // namespace nntrainer
 

--- a/nntrainer/layers/plugged_layer.h
+++ b/nntrainer/layers/plugged_layer.h
@@ -34,7 +34,7 @@ public:
    *
    * @param pluggable LayerPluggable structure from the symbol
    */
-  PluggedLayer(const nntrainer::LayerPluggable *pluggable) :
+  PluggedLayer(const nntrainer::LayerV1Pluggable *pluggable) :
     /// @todo we won't need dynamic pointer cast here after api is fully
     /// implemented
     layerImpl(pluggable->createfunc()),
@@ -248,7 +248,7 @@ private:
   /// @todo: migrate to ml::train::Layer
   // ml::train::Layer *layerImpl;
   nntrainer::LayerV1 *layerImpl;
-  nntrainer::DestroyLayerFunc destroy_func;
+  nntrainer::DestroyLayerV1Func destroy_func;
 };
 } // namespace internal
 } // namespace nntrainer

--- a/test/unittest/layers/layers_common_tests.cpp
+++ b/test/unittest/layers/layers_common_tests.cpp
@@ -12,6 +12,7 @@
 
 #include <layers_common_tests.h>
 
+#include <app_context.h>
 #include <layer_devel.h>
 
 constexpr unsigned SAMPLE_TRIES = 10;
@@ -27,7 +28,16 @@ void LayerSemantics::SetUp() {
 
 void LayerSemantics::TearDown() {}
 
-TEST_P(LayerSemantics, createFromAppContext_pn) {}
+TEST_P(LayerSemantics, createFromAppContext_pn) {
+  auto ac = nntrainer::AppContext::Global(); /// copy intended
+  if (~(options & LayerCreateSetPropertyOptions::AVAILABLE_FROM_APP_CONTEXT)) {
+    EXPECT_THROW(ac.createObject<nntrainer::Layer>(expected_type),
+                 std::invalid_argument);
+    ac.registerFactory<nntrainer::Layer>(std::get<0>(GetParam()));
+  }
+  EXPECT_EQ(ac.createObject<nntrainer::Layer>(expected_type)->getType(),
+            expected_type);
+}
 
 TEST_P(LayerSemantics, setProperties_p) {
   /// @todo check if setProperties does not collide with layerNode designated

--- a/test/unittest/layers/layers_common_tests.h
+++ b/test/unittest/layers/layers_common_tests.h
@@ -12,6 +12,8 @@
 #ifndef __LAYERS_COMMON_TESTS_H__
 #define __LAYERS_COMMON_TESTS_H__
 
+#include <gtest/gtest.h>
+
 #include <functional>
 #include <memory>
 #include <string>


### PR DESCRIPTION
- [AppContext] Integrate layer-devel

```
This patch integrates layer devel to appcontext and plugin features.

From this patch, having it is able to include LayerV1 and Layer at the
same time.

Also adding a test

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```