### PR TITLE
[layer context] Add interfaces for setBatch 

### DIFF
--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -148,6 +148,28 @@ public:
    */
   const std::vector<TensorSpec> &getTensorsSpec() const { return tensors_spec; }
 
+  /**
+   * @brief Set the batch for the init context
+   *
+   * @param batch Updated batch size
+   */
+  void setBatch(unsigned int batch) {
+    for (auto &dim : input_dim)
+      dim.batch(batch);
+    for (auto &dim : output_dim)
+      dim.batch(batch);
+  }
+
+  /**
+   * @brief Update the dimensions for a requested tensor
+   *
+   * @param idx index of the tensor (identifier)
+   * @param batch Updated batch size
+   */
+  void updateTensorSpec(unsigned int idx, unsigned int batch) {
+    std::get<0>(tensors_spec[idx]).batch(batch);
+  }
+
 private:
   std::vector<TensorDim> input_dim;  /**< Input dimensions for the layer */
   std::vector<TensorDim> output_dim; /**< Output dimensions for the layer */
@@ -299,6 +321,28 @@ public:
    * @return unsigned int number of weight tensors
    */
   unsigned int getNumWeights() const { return weights.size(); }
+
+  /**
+   * @brief Set the batch for the run context
+   *
+   * @param batch Update batch size
+   */
+  void setBatch(unsigned int batch) {
+    for (auto &vg : inputs)
+      vg->setBatchSize(batch);
+    for (auto &vg : outputs)
+      vg->setBatchSize(batch);
+  }
+
+  /**
+   * @brief Update the dimensions for a requested tensor
+   *
+   * @param idx index of the tensor (identifier)
+   * @param batch Updated batch size
+   */
+  void updateTensors(unsigned int idx, unsigned int batch) {
+    tensors[idx]->setBatchSize(batch);
+  }
 
 private:
   std::tuple<props::Name> props; /**< props of the layer */

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -330,10 +330,13 @@ void LayerNode::calcGradient() { layer->calcGradient(run_context); }
  * @brief Set the batch for the layer
  */
 void LayerNode::setBatch(unsigned int batch) {
-  if (finalized)
+  if (finalized) {
+    run_context.setBatch(batch);
     layer->setBatch(run_context, batch);
-  else
+  } else {
+    init_context.setBatch(batch);
     layer->setBatch(init_context, batch);
+  }
 }
 
 /**

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -212,7 +212,6 @@ public:
 
   /**
    * @brief Set the batch for the layer
-   * @param     context Context of the layer
    * @param     batch Batch value to be set
    * @details Update the run context based on the updated batch size if required
    */

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -29,8 +29,10 @@ public:
   /**
    * @brief Specification of the Var_Grad
    *
+   * @details The tuple values are dimension, trainable property, and the name
+   * of the Var_Grad object.
    */
-  typedef std::tuple<const TensorDim, bool, const std::string> Spec;
+  typedef std::tuple<TensorDim, bool, const std::string> Spec;
 
   /**
    * @brief Var_Grad default constructor

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -54,9 +54,11 @@ public:
   /**
    * @brief Specification of the Weight
    *
+   * @details The tuple values are dimension, initializer, regularizer,
+   * regularizer_constant, trainable property amd name of the Weight object.
    */
   typedef std::tuple<TensorDim, WeightInitializer, WeightRegularizer, float,
-                     bool, std::string>
+                     bool, const std::string>
     Spec;
 
   /**


### PR DESCRIPTION
Add interfaces to layer context required by layer developer
when they override setBatch()

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>