### PR TITLE
[layernode/impl] Add properties to Layer Node and Impl 

### DIFF
--- a/nntrainer/layers/layer_impl.cpp
+++ b/nntrainer/layers/layer_impl.cpp
@@ -4,7 +4,7 @@
  *
  * @file   layer_impl.h
  * @date   21 June 2021
- * @brief  This is base Optimizer implementation class
+ * @brief  This is base layer implementation class
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug    No known bugs except for NYI items
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include <common_properties.h>
+#include <layer_internal.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>
@@ -35,6 +36,65 @@ void LayerImpl::finalize(InitLayerContext &context) {
 
 void LayerImpl::setProperty(const std::vector<std::string> &values) {
   loadProperties(values, *layer_impl_props);
+
+  /// @todo: deprecate this in favor of loadProperties
+  for (unsigned int i = 0; i < values.size(); ++i) {
+    std::string key;
+    std::string value;
+    std::stringstream ss;
+
+    if (getKeyValue(values[i], key, value) != ML_ERROR_NONE) {
+      throw std::invalid_argument("Error parsing the property: " + values[i]);
+    }
+
+    if (value.empty()) {
+      ss << "value is empty: key: " << key << ", value: " << value;
+      throw std::invalid_argument(ss.str());
+    }
+
+    /// @note this calls derived setProperty if available
+    setProperty(key, value);
+  }
+}
+
+void LayerImpl::setProperty(const std::string &type_str,
+                            const std::string &value) {
+  int status = ML_ERROR_NONE;
+  LayerV1::PropertyType type =
+    static_cast<LayerV1::PropertyType>(parseLayerProperty(type_str));
+
+  switch (type) {
+  case LayerV1::PropertyType::weight_regularizer:
+    if (!value.empty()) {
+      weight_regularizer =
+        (WeightRegularizer)parseType(value, TOKEN_WEIGHT_REGULARIZER);
+      if (weight_regularizer == WeightRegularizer::UNKNOWN) {
+        throw std::invalid_argument("[Layer] Unknown Weight decay");
+      }
+    }
+    break;
+  case LayerV1::PropertyType::weight_regularizer_constant:
+    if (!value.empty()) {
+      status = setFloat(weight_regularizer_constant, value);
+      throw_status(status);
+    }
+    break;
+  case LayerV1::PropertyType::weight_initializer:
+    if (!value.empty()) {
+      weight_initializer =
+        (WeightInitializer)parseType(value, TOKEN_WEIGHT_INIT);
+    }
+    break;
+  case LayerV1::PropertyType::bias_initializer:
+    if (!value.empty()) {
+      bias_initializer = (WeightInitializer)parseType(value, TOKEN_WEIGHT_INIT);
+    }
+    break;
+  default:
+    std::string msg =
+      "[Layer] Unknown Layer Property Key for value " + std::string(value);
+    throw exception::not_supported(msg);
+  }
 }
 
 void LayerImpl::exportTo(Exporter &exporter,

--- a/nntrainer/layers/layer_impl.h
+++ b/nntrainer/layers/layer_impl.h
@@ -9,12 +9,18 @@
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug    No known bugs except for NYI items
  *
+ * @details LayerImpl forms the base class for all the layer with weights and
+ * bias parameters. LayerImpl provides parsing of properties like Weight/bias
+ * initializer and regularizers. LayerImpl also provides checks for double calls
+ * to finalize function.
+ *
  */
 #ifndef __LAYER_IMPL_H__
 #define __LAYER_IMPL_H__
 #ifdef __cplusplus
 
 #include <layer_devel.h>
+#include <weight.h>
 
 #include <memory>
 #include <tuple>
@@ -52,7 +58,7 @@ public:
   /**
    * @brief     finalize the layer
    * @throw     nntrainer::not_supported if try to initialize twice
-   * @copydoc   Layer::fianlize(InitLayerContext &context)
+   * @copydoc   Layer::finalize(InitLayerContext &context)
    */
   virtual void finalize(InitLayerContext &context) override;
 
@@ -68,9 +74,24 @@ public:
                         const ExportMethods &method) const override;
 
 private:
+  /**
+   * @brief setProperty by type and value separated
+   * @param[in] type property type to be passed
+   * @param[in] value value to be passed
+   * @exception exception::not_supported     when property type is not valid for
+   * the particular layer
+   * @exception std::invalid_argument invalid argument
+   */
+  virtual void setProperty(const std::string &type, const std::string &value);
+
   bool finalized; /**< check if finalized */
   std::unique_ptr<std::tuple<props::Trainable>>
     layer_impl_props; /**< layer_impl_props */
+
+  WeightRegularizer weight_regularizer; /**< weight regularizer */
+  float weight_regularizer_constant;    /**< weight regularizer constant */
+  WeightInitializer weight_initializer; /**< initializer for the weights */
+  WeightInitializer bias_initializer;   /**< initializer for the bias */
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -10,6 +10,15 @@
  * @brief  This is the layer node for network graph
  *
  * @todo   Add printPreset support
+ *
+ * @details LayerNode provides a node wrapper around the Layer class to form a
+ * GraphNode. Each layer is wrapped with LayerNode in order to add it to a
+ * graph. Each LayerNode contains only 1 layer inside. LayerNode also intercepts
+ * certain properties of the layer which are either related to graph related
+ * connections (input_layers, output_layers, activation, flatten, distribute,
+ * name) or essential for the description of the layer (trainable, input_dims)
+ * iself. These properties, if needed by the layer object, are provided access
+ * to via LayerContext.
  */
 
 #ifndef __LAYER_NODE_H__
@@ -77,11 +86,11 @@ private:
    * @todo  deprecate this
    *
    * @param layer_v2 layer v2
-   * @param layer_v1 layer v1
+   * @param layerv1 layer v1
    * @param idx      idx
    */
   LayerNode(std::unique_ptr<nntrainer::Layer> &&layer_v2,
-            std::shared_ptr<nntrainer::LayerV1> layer_v1, size_t idx = 0);
+            std::shared_ptr<nntrainer::LayerV1> layerv1, size_t idx = 0);
 
 public:
   /**


### PR DESCRIPTION
1. Add input_dim property to layer node
2. Add weights/bias related properties such as initializer, regularizer,
etc to LayerImpl. This creates a differentiating factor of LayerImpl
from LayerDevel as LayerImpl provides a base class for layers with
weights/bias properties loaded.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
