### PR TITLE
[ Recurrent ] Implement Dropout for Recurrent Net

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -116,6 +116,7 @@ public:
    * - return_sequences : bool (type) - used only in lstm
    * - distribute : bool
    * - hidden_state_activation : string (type) - used only in lstm
+   * - drop_out : float (type) - drop out rate
    */
   /**
    * @brief     set Property of layer

--- a/nntrainer/layers/gru.cpp
+++ b/nntrainer/layers/gru.cpp
@@ -161,6 +161,12 @@ void GRULayer::setProperty(const PropertyType type, const std::string &value) {
       throw_status(status);
     }
     break;
+  case PropertyType::dropout:
+    if (!value.empty()) {
+      status = setFloat(dropout_rate, value);
+      throw_status(status);
+    }
+    break;
   default:
     LayerV1::setProperty(type, value);
     break;
@@ -207,6 +213,10 @@ void GRULayer::forwarding(bool training) {
     for (unsigned int t = 0; t < islice.height(); ++t) {
       Tensor xs =
         islice.getSharedDataTensor({islice.width()}, t * islice.width());
+
+      if (dropout_rate > 0.0 && training) {
+        xs.multiply_i(xs.dropout_mask(dropout_rate));
+      }
       hs = oslice.getSharedDataTensor({oslice.width()}, t * oslice.width());
       Tensor zrg_t =
         zrg_.getSharedDataTensor({unit * NUM_GATE}, unit * t * NUM_GATE);

--- a/nntrainer/layers/gru.h
+++ b/nntrainer/layers/gru.h
@@ -34,12 +34,13 @@ public:
     unsigned int unit_ = 0,
     ActivationType hidden_state_activation_type_ = ActivationType::ACT_NONE,
     ActivationType recurrent_activation_type_ = ActivationType::ACT_NONE,
-    bool sequence = false, Args... args) :
+    bool sequence = false, float dropout = 0.0, Args... args) :
     LayerV1(args...),
     unit(unit_),
     hidden_state_activation_type(hidden_state_activation_type_),
     recurrent_activation_type(recurrent_activation_type_),
-    return_sequences(sequence){};
+    return_sequences(sequence),
+    dropout_rate(dropout){};
 
   /**
    * @brief     Destructor of GRULayer
@@ -162,6 +163,11 @@ private:
    * @brief     variable to set return sequences
    */
   bool return_sequences;
+
+  /**
+   * @brief     drop out rate
+   */
+  float dropout_rate;
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -248,6 +248,7 @@ public:
    *            36. split_dimension : string (type)
    *            37. return_sequences :  bool (type) - lstm
    *            39. hidden_state_activation :  string (type) - lstm
+   *            40. dropout :  float (type) - drop out rate
    */
   enum class PropertyType {
     input_shape = 0,
@@ -289,6 +290,7 @@ public:
     split_dimension = 36,
     return_sequences = 37,
     hidden_state_activation = 38,
+    dropout = 39,
     unknown
   };
 

--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -146,6 +146,12 @@ void LSTMLayer::setProperty(const PropertyType type, const std::string &value) {
       throw_status(status);
     }
     break;
+  case PropertyType::dropout:
+    if (!value.empty()) {
+      status = setFloat(dropout_rate, value);
+      throw_status(status);
+    }
+    break;
   default:
     LayerV1::setProperty(type, value);
     break;
@@ -194,6 +200,11 @@ void LSTMLayer::forwarding(bool training) {
     for (unsigned int t = 0; t < islice.height(); ++t) {
       Tensor xs =
         islice.getSharedDataTensor({islice.width()}, t * islice.width());
+
+      if (dropout_rate > 0.0 && training) {
+        xs.multiply_i(xs.dropout_mask(dropout_rate));
+      }
+
       hs = oslice.getSharedDataTensor({oslice.width()}, t * oslice.width());
       cs = cell.getSharedDataTensor({cell.width()}, t * cell.width());
       Tensor fgio_t =

--- a/nntrainer/layers/lstm.h
+++ b/nntrainer/layers/lstm.h
@@ -34,12 +34,13 @@ public:
     unsigned int unit_ = 0,
     ActivationType hidden_state_activation_type_ = ActivationType::ACT_NONE,
     ActivationType recurrent_activation_type_ = ActivationType::ACT_NONE,
-    bool sequence = false, Args... args) :
+    bool sequence = false, float dropout = 0.0, Args... args) :
     LayerV1(args...),
     unit(unit_),
     hidden_state_activation_type(hidden_state_activation_type_),
     recurrent_activation_type(recurrent_activation_type_),
-    return_sequences(sequence){};
+    return_sequences(sequence),
+    dropout_rate(dropout){};
 
   /**
    * @brief     Destructor of LSTMLayer
@@ -172,6 +173,11 @@ private:
    * @brief     variable to set return sequences
    */
   bool return_sequences;
+
+  /**
+   * @brief     drop out rate
+   */
+  float dropout_rate;
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/rnn.cpp
+++ b/nntrainer/layers/rnn.cpp
@@ -122,6 +122,12 @@ void RNNLayer::setProperty(const PropertyType type, const std::string &value) {
       throw_status(status);
     }
     break;
+  case PropertyType::dropout:
+    if (!value.empty()) {
+      status = setFloat(dropout_rate, value);
+      throw_status(status);
+    }
+    break;
   default:
     LayerV1::setProperty(type, value);
     break;
@@ -159,6 +165,10 @@ void RNNLayer::forwarding(bool training) {
     for (unsigned int t = 0; t < islice.height(); ++t) {
       Tensor xs =
         islice.getSharedDataTensor({islice.width()}, t * islice.width());
+
+      if (dropout_rate > 0.0 && training) {
+        xs.multiply_i(xs.dropout_mask(dropout_rate));
+      }
 
       hs = oslice.getSharedDataTensor({oslice.width()}, t * oslice.width());
       if (t > 0) {

--- a/nntrainer/layers/rnn.h
+++ b/nntrainer/layers/rnn.h
@@ -33,11 +33,12 @@ public:
   RNNLayer(
     unsigned int unit_ = 0,
     ActivationType hidden_state_activation_type_ = ActivationType::ACT_NONE,
-    bool sequence = false, Args... args) :
+    bool sequence = false, float dropout = 0.0, Args... args) :
     LayerV1(args...),
     unit(unit_),
     hidden_state_activation_type(hidden_state_activation_type_),
-    return_sequences(sequence){};
+    return_sequences(sequence),
+    dropout_rate(dropout){};
 
   /**
    * @brief     Destructor of RNNLayer
@@ -125,6 +126,11 @@ private:
    * @brief     opiont for return sequence
    */
   bool return_sequences;
+
+  /**
+   * @brief     drop out rate
+   */
+  float dropout_rate;
 
   /**
    * @brief     hidden variable for rnn

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -870,6 +870,24 @@ Tensor Tensor::transpose(const std::string &direction) const {
   return result;
 }
 
+Tensor Tensor::dropout_mask(float dropout) const {
+  Tensor result(dim);
+  result.setValue(1.0);
+  Tensor rand_temp(dim);
+  rand_temp.setRandUniform(0.0, 1.0);
+  float scale = 1.0 / (1 - dropout);
+
+  float *mask = result.getData();
+  float *random = rand_temp.getData();
+  for (unsigned int i = 0; i < length(); ++i) {
+    if (random[i] >= dropout)
+      mask[i] = mask[i] * scale;
+    else
+      mask[i] = 0.0;
+  }
+  return result;
+}
+
 int Tensor::apply_i(std::function<float(float)> f) {
   float *data = getData();
 

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -515,6 +515,13 @@ public:
   Tensor &transpose(const std::string &direction, Tensor &out) const;
 
   /**
+   * @brief Calculate Drop Out Mask : x * 1.0/(1.0-rate)
+   * @param dropout drop out rate
+   * @retval Tensor& reference of drop out mask
+   */
+  Tensor dropout_mask(float dropout) const;
+
+  /**
    * @brief     sum all the Tensor elements according to the batch
    * @retval    Calculated Tensor(batch, 1, 1, 1)
    */

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -258,6 +258,7 @@ unsigned int parseType(std::string ll, InputType t) {
  * split_dimension = 36
  * return_sequences = 37
  * hidden_state_activation = 38
+ * dropout = 39
  *
  * InputLayer has 0, 1, 2, 3 properties.
  * FullyConnectedLayer has 1, 4, 6, 7, 8, 9 properties.
@@ -265,7 +266,7 @@ unsigned int parseType(std::string ll, InputType t) {
  * Pooling2DLayer has 12, 13, 14, 15 properties.
  * BatchNormalizationLayer has 0, 1, 5, 6, 7 properties.
  */
-static std::array<std::string, 40> property_string = {
+static std::array<std::string, 41> property_string = {
   "input_shape",
   "normalization",
   "standardization",
@@ -305,6 +306,7 @@ static std::array<std::string, 40> property_string = {
   "split_dimension",
   "return_sequences",
   "hidden_state_activation",
+  "dropout",
   "unknown"};
 
 unsigned int parseLayerProperty(std::string property) {


### PR DESCRIPTION
In this commit, drop out for recurrent network is intrduced.
dropout property is introduced and if the element value of random
tensor is smaller than dropout rate, then it will be set zero.
The element which is not set zero, then it will scale with
1.0/(1.0-dropout).

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>