### PR TITLE
[layercontext] Minor bugfix for layer context

### DIFF
--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -188,7 +188,6 @@ public:
                   const std::vector<Var_Grad *> &in,
                   const std::vector<Var_Grad *> &out,
                   const std::vector<Var_Grad *> &t) :
-    trainable(false),
     weights(w),
     inputs(in),
     outputs(out),


### PR DESCRIPTION
Minor bugfix for layer context
Removes the extra trainable parameter from layer context

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>