### PR TITLE
[layer] Update getTrainable with supportBackwarding

### DIFF
--- a/Applications/SimpleShot/layers/centering.h
+++ b/Applications/SimpleShot/layers/centering.h
@@ -98,12 +98,9 @@ public:
   void read(std::ifstream &file) override;
 
   /**
-   * @brief get boolean if the function is trainable
-   *
-   * @retval true trainable
-   * @retval false not trainable
+   * @copydoc bool supportBackwarding() const
    */
-  bool getTrainable() noexcept override { return false; }
+  bool supportBackwarding() const override { return false; };
 
   /**
    * @brief Get the Type object

--- a/Applications/SimpleShot/layers/centroid_knn.h
+++ b/Applications/SimpleShot/layers/centroid_knn.h
@@ -97,12 +97,9 @@ public:
   const std::string getType() const override { return CentroidKNN::type; }
 
   /**
-   * @brief get boolean if the function is trainable
-   *
-   * @retval true trainable
-   * @retval false not trainable
+   * @copydoc bool supportBackwarding() const
    */
-  bool getTrainable() noexcept override { return false; }
+  bool supportBackwarding() const override { return false; };
 
   inline static const std::string type = "centroid_knn";
 

--- a/Applications/SimpleShot/layers/l2norm.h
+++ b/Applications/SimpleShot/layers/l2norm.h
@@ -82,12 +82,9 @@ public:
   const std::string getType() const override { return L2NormLayer::type; }
 
   /**
-   * @brief get boolean if the function is trainable
-   *
-   * @retval true trainable
-   * @retval false not trainable
+   * @copydoc bool supportBackwarding() const
    */
-  bool getTrainable() noexcept override { return false; }
+  bool supportBackwarding() const override { return false; };
 
   inline static const std::string type = "l2norm";
 };

--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -207,8 +207,8 @@ getMergeableGraph(std::shared_ptr<const GraphRepresentation> graph,
   // bool preload =
   //   iniparser_getboolean(ini, (sec_name + ":Preload").c_str(), true);
 
-  bool trainable =
-    iniparser_getboolean(ini, (sec_name + ":Trainable").c_str(), false);
+  const std::string &trainable =
+    iniparser_getstring(ini, (sec_name + ":Trainable").c_str(), "false");
   double scale_size =
     iniparser_getdouble(ini, (sec_name + ":ScaleSize").c_str(), 1.0);
 
@@ -217,11 +217,11 @@ getMergeableGraph(std::shared_ptr<const GraphRepresentation> graph,
     << "backbone cannot have non-positive scale_size. Current scale size: "
     << scale_size;
 
-  for (auto &layer : g) {
-    layer->getObject()->setTrainable(trainable);
-    layer->getObject()->resetDimension();
+  for (auto &lnode : g) {
+    lnode->setProperty({"trainable=" + trainable});
+    lnode->getObject()->resetDimension();
     if (scale_size != 1) {
-      layer->getObject()->scaleSize(scale_size);
+      lnode->getObject()->scaleSize(scale_size);
     }
     /** TODO #361: this needs update in model file to be of dictionary format */
     // if (preload) {

--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -208,7 +208,7 @@ getMergeableGraph(std::shared_ptr<const GraphRepresentation> graph,
   //   iniparser_getboolean(ini, (sec_name + ":Preload").c_str(), true);
 
   const std::string &trainable =
-    iniparser_getstring(ini, (sec_name + ":Trainable").c_str(), "false");
+    iniparser_getstring(ini, (sec_name + ":Trainable").c_str(), "true");
   double scale_size =
     iniparser_getdouble(ini, (sec_name + ":ScaleSize").c_str(), 1.0);
 

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -86,7 +86,9 @@ void NetworkGraph::addLayerNode(std::shared_ptr<LayerV1> layer) {
 
 void NetworkGraph::countNonTrainableLayersAtBegin() {
   for (auto iter = cbegin(); iter != cend(); iter++) {
-    if ((*iter)->getObject()->getTrainable()) {
+    // TODO: check if getTrainable() was set and if trainable weights exist,
+    // then throw
+    if ((*iter)->getTrainable() && (*iter)->supportBackwarding()) {
       skip_non_trainable_layers = iter - cbegin();
       return;
     }

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -34,7 +34,6 @@ public:
   template <typename... Args>
   ActivationLayer(ActivationType at = ActivationType::ACT_NONE, Args... args) :
     LayerV1(args...) {
-    setTrainable(false);
     acti_func.setActiFunc(at);
   }
 

--- a/nntrainer/layers/flatten_layer.h
+++ b/nntrainer/layers/flatten_layer.h
@@ -29,9 +29,7 @@ public:
   /**
    * @brief     Constructor of Flatten Layer
    */
-  template <typename... Args> FlattenLayer(Args... args) : LayerV1(args...) {
-    setTrainable(false);
-  }
+  template <typename... Args> FlattenLayer(Args... args) : LayerV1(args...) {}
 
   /**
    * @brief     Destructor of Flatten Layer

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -73,11 +73,4 @@ int InputLayer::initialize(Manager &manager) {
   return status;
 }
 
-void InputLayer::setTrainable(bool train) {
-  if (train)
-    throw exception::not_supported("Input layer does not support training");
-
-  LayerV1::setTrainable(false);
-}
-
 } /* namespace nntrainer */

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -43,9 +43,7 @@ public:
              Args... args) :
     LayerV1(args...),
     normalization(false),
-    standardization(false) {
-    trainable = false;
-  }
+    standardization(false) {}
 
   /**
    * @brief     Destructor of InputLayer
@@ -91,9 +89,9 @@ public:
   int initialize(Manager &manager) override;
 
   /**
-   * @copydoc Layer::setTrainable(bool train)
+   * @copydoc bool supportBackwarding() const
    */
-  void setTrainable(bool train) override;
+  bool supportBackwarding() const override { return false; };
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -68,7 +68,6 @@ void LayerV1::copy(std::shared_ptr<LayerV1> l) {
   this->weight_regularizer = l->weight_regularizer;
   this->weight_regularizer_constant = l->weight_regularizer_constant;
   this->weight_initializer = l->weight_initializer;
-  this->trainable = l->trainable;
 }
 
 sharedConstTensors LayerV1::forwarding_with_val(sharedConstTensors input,
@@ -223,12 +222,6 @@ void LayerV1::setProperty(const PropertyType type, const std::string &value) {
       bias_initializer = (WeightInitializer)parseType(value, TOKEN_WEIGHT_INIT);
     }
     break;
-  case PropertyType::trainable:
-    if (!value.empty()) {
-      status = setBoolean(trainable, value);
-      throw_status(status);
-    }
-    break;
   default:
     std::string msg =
       "[Layer] Unknown Layer Property Key for value " + std::string(value);
@@ -267,7 +260,7 @@ void LayerV1::printPropertiesMeta(std::ostream &out) {
 }
 
 void LayerV1::printProperties(std::ostream &out) {
-  out << "Trainable: " << trainable << std::endl;
+  // out << "Trainable: " << trainable << std::endl;
   printIfValid(out, PropertyType::weight_regularizer,
                static_cast<int>(weight_regularizer));
   printIfValid(out, PropertyType::weight_regularizer_constant,

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -232,7 +232,7 @@ public:
    * @return Tensor& Reference to the weight grad tensor
    */
   Tensor &getWeightGrad(unsigned int idx) {
-    if (!weights[idx]->getTrainable())
+    if (!weights[idx]->hasGradient())
       throw std::invalid_argument(
         "Requesting gradient for a non-trainable weight.");
     return weights[idx]->getGradientRef();
@@ -245,7 +245,7 @@ public:
    * @return float Value of the loss
    */
   float getWeightRegularizationLoss(unsigned int idx) const {
-    if (weights[idx]->getTrainable())
+    if (weights[idx]->hasGradient())
       return weights[idx]->getRegularizationLoss();
 
     return 0;
@@ -266,7 +266,7 @@ public:
    * @return Tensor& Reference to the output grad tensor
    */
   Tensor &getOutputGrad(unsigned int idx) {
-    if (!outputs[idx]->getTrainable())
+    if (!outputs[idx]->hasGradient())
       throw std::invalid_argument(
         "Requesting gradient for a non-trainable tensor.");
     return outputs[idx]->getGradientRef();
@@ -287,7 +287,7 @@ public:
    * @return Tensor& Reference to the input grad tensor
    */
   Tensor &getInputGrad(unsigned int idx) {
-    if (!inputs[idx]->getTrainable())
+    if (!inputs[idx]->hasGradient())
       throw std::invalid_argument(
         "Requesting gradient for a non-trainable tensor.");
     return inputs[idx]->getGradientRef();
@@ -308,7 +308,7 @@ public:
    * @return Tensor& Reference to the tensor grad tensor
    */
   Tensor &getTensorGrad(unsigned int idx) {
-    if (!tensors[idx]->getTrainable())
+    if (!tensors[idx]->hasGradient())
       throw std::invalid_argument(
         "Requesting gradient for a non-trainable tensor.");
     return tensors[idx]->getGradientRef();

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -158,6 +158,14 @@ public:
    * @return true if requires a label when training, else false
    */
   virtual bool requireLabel() const { return false; }
+
+  /**
+   * @brief  check if this layer supports backwarding
+   * @note   support backwarding primarily means that the layer can process the
+   * derivatives and return back the gradients to the previous layer.
+   * @return true if supports backwarding, else false
+   */
+  virtual bool supportBackwarding() const = 0;
 };
 
 /// @todo Decide where to put and how to implement(#986)

--- a/nntrainer/layers/layer_impl.cpp
+++ b/nntrainer/layers/layer_impl.cpp
@@ -25,7 +25,7 @@ namespace nntrainer {
 
 LayerImpl::LayerImpl() :
   finalized(false),
-  layer_impl_props(std::make_unique<std::tuple<props::Trainable>>()) {}
+  layer_impl_props(std::make_unique<std::tuple<>>()) {}
 
 void LayerImpl::finalize(InitLayerContext &context) {
   NNTR_THROW_IF(finalized, nntrainer::exception::not_supported)

--- a/nntrainer/layers/layer_impl.h
+++ b/nntrainer/layers/layer_impl.h
@@ -33,10 +33,6 @@ class Exporter;
 
 enum class ExportMethods;
 
-namespace props {
-class Trainable;
-}
-
 /**
  * @class   An abstract class to ease developing a layer
  * @brief   An abstract class for all layers
@@ -84,9 +80,8 @@ private:
    */
   virtual void setProperty(const std::string &type, const std::string &value);
 
-  bool finalized; /**< check if finalized */
-  std::unique_ptr<std::tuple<props::Trainable>>
-    layer_impl_props; /**< layer_impl_props */
+  bool finalized;                                 /**< check if finalized */
+  std::unique_ptr<std::tuple<>> layer_impl_props; /**< layer_impl_props */
 
   WeightRegularizer weight_regularizer; /**< weight regularizer */
   float weight_regularizer_constant;    /**< weight regularizer constant */

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -57,19 +57,18 @@ public:
   /**
    * @brief     Constructor of Layer Class
    */
-  LayerV1(WeightRegularizer weight_regularizer_ = WeightRegularizer::NONE,
-          const float weight_regularizer_constant_ = 1.0f,
-          WeightInitializer weight_initializer_ =
-            WeightInitializer::WEIGHT_XAVIER_UNIFORM,
-          WeightInitializer bias_initializer_ = WeightInitializer::WEIGHT_ZEROS,
-          bool trainable_ = true) :
+  LayerV1(
+    WeightRegularizer weight_regularizer_ = WeightRegularizer::NONE,
+    const float weight_regularizer_constant_ = 1.0f,
+    WeightInitializer weight_initializer_ =
+      WeightInitializer::WEIGHT_XAVIER_UNIFORM,
+    WeightInitializer bias_initializer_ = WeightInitializer::WEIGHT_ZEROS) :
     layer_props(),
     loss(0.0f),
     weight_regularizer(weight_regularizer_),
     weight_regularizer_constant(weight_regularizer_constant_),
     weight_initializer(weight_initializer_),
-    bias_initializer(bias_initializer_),
-    trainable(trainable_) {
+    bias_initializer(bias_initializer_) {
     setNumInputs(1);
     setNumOutputs(1);
   }
@@ -349,17 +348,12 @@ public:
   virtual float getLoss() { return loss; }
 
   /**
-   * @brief     set trainable for this layer
-   * @param[in] train to enable/disable train
+   * @brief  check if this layer supports backwarding
+   * @note   support backwarding primarily means that the layer can process the
+   * derivatives and return back the gradients to the previous layer.
+   * @return true if supports backwarding, else false
    */
-  virtual void setTrainable(bool train) { trainable = train; }
-
-  /**
-   * @brief     get trainable for this layer
-   * @retval train to enable/disable train
-   */
-  virtual bool getTrainable() noexcept { return trainable; }
-
+  virtual bool supportBackwarding() const { return true; };
   /**
    * @brief     get all weights of the layer
    * @retval    vector of all params
@@ -639,11 +633,6 @@ protected:
    * @brief initializer for bias
    */
   WeightInitializer bias_initializer;
-
-  /**
-   * @brief     making this false will skip updating this layer variables
-   */
-  bool trainable;
 
   /**
    * @brief     weight_list in this layer. This contains all weights of the

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -20,6 +20,7 @@
 
 #include <base_properties.h>
 #include <common_properties.h>
+
 namespace nntrainer {
 
 namespace props {
@@ -64,8 +65,8 @@ LayerNode::LayerNode(std::unique_ptr<nntrainer::Layer> &&layer_v2,
   index(idx),
   finalized(false),
   activation_type(ActivationType::ACT_NONE),
-  layer_node_props(
-    new PropsType(props::Name(), props::Flatten(), props::Distribute())) {
+  layer_node_props(new PropsType(props::Name(), props::Flatten(),
+                                 props::Distribute(), props::Trainable())) {
   if (layerv1 && layerv1->getType() == TimeDistLayer::type) {
     std::get<props::Distribute>(*layer_node_props).set(true);
   } else if (layer && layer->getType() == TimeDistLayer::type) {
@@ -121,9 +122,10 @@ int LayerNode::setProperty(std::vector<std::string> properties) {
     }
   }
 
-  /// @todo: deprecate this in favor of loadProperties
   std::vector<std::string> remainder;
+  /// @todo: deprecate this in favor of loadProperties
   for (unsigned int i = 0; i < left_properties.size(); ++i) {
+
     std::string key;
     std::string value;
 
@@ -240,7 +242,7 @@ const std::shared_ptr<nntrainer::LayerV1> &LayerNode::getObject() const {
 }
 
 bool LayerNode::getTrainable() const noexcept {
-  return getLayer()->getTrainable();
+  return std::get<props::Trainable>(*layer_node_props);
 }
 
 bool LayerNode::getFlatten() const noexcept {

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -263,6 +263,19 @@ public:
    *
    * @return boolean true if trainable, else false
    */
+  bool supportBackwarding() const noexcept {
+    return getLayer()->supportBackwarding();
+  }
+
+  /**
+   * Support interfaces for the properties intercepted from layer
+   */
+
+  /**
+   * @brief     Get the trainable property of the underlying object
+   *
+   * @return boolean true if trainable, else false
+   */
   bool getTrainable() const noexcept;
 
   /**
@@ -609,7 +622,8 @@ private:
                     Editing properties of the layer after init will not the
                     properties in the context/graph unless intended. */
 
-  using PropsType = std::tuple<props::Name, props::Flatten, props::Distribute>;
+  using PropsType = std::tuple<props::Name, props::Flatten, props::Distribute,
+                               props::Trainable>;
   /**
    * These properties are set for the layer by the user but are intercepted
    * and used in the node which forms the basic element of the graph.

--- a/nntrainer/layers/nnstreamer_layer.cpp
+++ b/nntrainer/layers/nnstreamer_layer.cpp
@@ -142,14 +142,6 @@ int NNStreamerLayer::initialize(Manager &manager) {
   return status;
 }
 
-void NNStreamerLayer::setTrainable(bool train) {
-  if (train)
-    throw exception::not_supported(
-      "NNStreamer layer does not support training");
-
-  LayerV1::setTrainable(false);
-}
-
 void NNStreamerLayer::setProperty(const PropertyType type,
                                   const std::string &value) {
   switch (type) {

--- a/nntrainer/layers/nnstreamer_layer.h
+++ b/nntrainer/layers/nnstreamer_layer.h
@@ -40,9 +40,7 @@ public:
     in_data_cont(nullptr),
     out_data_cont(nullptr),
     in_data(nullptr),
-    out_data(nullptr) {
-    trainable = false;
-  }
+    out_data(nullptr) {}
 
   /**
    * @brief     Destructor of NNStreamer Layer
@@ -70,9 +68,9 @@ public:
   int initialize(Manager &manager);
 
   /**
-   * @copydoc Layer::setTrainable(bool train)
+   * @copydoc bool supportBackwarding() const
    */
-  void setTrainable(bool train);
+  bool supportBackwarding() const override { return false; };
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/plugged_layer.h
+++ b/nntrainer/layers/plugged_layer.h
@@ -143,14 +143,9 @@ public:
   void copy(std::shared_ptr<LayerV1> l) override { layerImpl->copy(l); }
 
   /**
-   * @copydoc Layer::setTrainable(bool train)
+   * @copydoc bool supportBackwarding() const
    */
-  void setTrainable(bool train) override { layerImpl->setTrainable(train); }
-
-  /**
-   * @copydoc Layer::getTrainable()
-   */
-  bool getTrainable() noexcept override { return layerImpl->getTrainable(); }
+  bool supportBackwarding() const override { return false; };
 
   /**
    * @copydoc Layer::getWeights()

--- a/nntrainer/layers/plugged_layer.h
+++ b/nntrainer/layers/plugged_layer.h
@@ -145,7 +145,9 @@ public:
   /**
    * @copydoc bool supportBackwarding() const
    */
-  bool supportBackwarding() const override { return false; };
+  bool supportBackwarding() const override {
+    return layerImpl->supportBackwarding();
+  };
 
   /**
    * @copydoc Layer::getWeights()

--- a/nntrainer/layers/preprocess_flip_layer.cpp
+++ b/nntrainer/layers/preprocess_flip_layer.cpp
@@ -109,12 +109,4 @@ void PreprocessFlipLayer::calcDerivative() {
     "calcDerivative for preprocess layer is not supported");
 }
 
-void PreprocessFlipLayer::setTrainable(bool train) {
-  if (train)
-    throw exception::not_supported(
-      "Preprocessing layer does not support training");
-
-  LayerV1::setTrainable(false);
-}
-
 } /* namespace nntrainer */

--- a/nntrainer/layers/preprocess_flip_layer.h
+++ b/nntrainer/layers/preprocess_flip_layer.h
@@ -34,9 +34,7 @@ public:
   template <typename... Args>
   PreprocessFlipLayer(Args... args) :
     LayerV1(args...),
-    flipdirection(FlipDirection::horizontal_and_vertical) {
-    trainable = false;
-  }
+    flipdirection(FlipDirection::horizontal_and_vertical) {}
 
   /**
    * @brief     Destructor of Preprocess FLip Layer
@@ -74,9 +72,9 @@ public:
   void calcDerivative() override;
 
   /**
-   * @copydoc Layer::setTrainable(bool train)
+   * @copydoc bool supportBackwarding() const
    */
-  void setTrainable(bool train) override;
+  bool supportBackwarding() const override { return false; };
 
   using LayerV1::setProperty;
 

--- a/nntrainer/layers/preprocess_translate_layer.cpp
+++ b/nntrainer/layers/preprocess_translate_layer.cpp
@@ -130,12 +130,4 @@ void PreprocessTranslateLayer::calcDerivative() {
     "calcDerivative for preprocess layer is not supported");
 }
 
-void PreprocessTranslateLayer::setTrainable(bool train) {
-  if (train)
-    throw exception::not_supported(
-      "Preprocessing layer does not support training");
-
-  LayerV1::setTrainable(false);
-}
-
 } /* namespace nntrainer */

--- a/nntrainer/layers/preprocess_translate_layer.h
+++ b/nntrainer/layers/preprocess_translate_layer.h
@@ -39,9 +39,7 @@ public:
   PreprocessTranslateLayer(Args... args) :
     LayerV1(args...),
     translation_factor(0.0),
-    epsilon(1e-5) {
-    trainable = false;
-  }
+    epsilon(1e-5) {}
 
   /**
    * @brief     Destructor of Preprocess Translate Layer
@@ -79,9 +77,9 @@ public:
   void calcDerivative() override;
 
   /**
-   * @copydoc Layer::setTrainable(bool train)
+   * @copydoc bool supportBackwarding() const
    */
-  void setTrainable(bool train) override;
+  bool supportBackwarding() const override { return false; };
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/tflite_layer.cpp
+++ b/nntrainer/layers/tflite_layer.cpp
@@ -74,13 +74,6 @@ int TfLiteLayer::initialize(Manager &manager) {
   return ML_ERROR_NONE;
 }
 
-void TfLiteLayer::setTrainable(bool train) {
-  if (train)
-    throw exception::not_supported("TfLite layer does not support training");
-
-  LayerV1::setTrainable(false);
-}
-
 void TfLiteLayer::setProperty(const PropertyType type,
                               const std::string &value) {
   switch (type) {

--- a/nntrainer/layers/tflite_layer.h
+++ b/nntrainer/layers/tflite_layer.h
@@ -37,9 +37,7 @@ public:
     LayerV1(),
     modelfile(model),
     interpreter(nullptr),
-    model(nullptr) {
-    trainable = false;
-  }
+    model(nullptr) {}
 
   /**
    * @brief     Destructor of NNStreamer Layer
@@ -67,9 +65,9 @@ public:
   int initialize(Manager &manager) override;
 
   /**
-   * @copydoc Layer::setTrainable(bool train)
+   * @copydoc bool supportBackwarding() const
    */
-  void setTrainable(bool train) override;
+  bool supportBackwarding() const override { return false; };
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/models/dynamic_training_optimization.cpp
+++ b/nntrainer/models/dynamic_training_optimization.cpp
@@ -64,7 +64,7 @@ bool DynamicTrainingOptimization::checkIfApply(
   if (iteration < skip_n_iterations)
     return true;
 
-  if (!weight.getTrainable() || weight.getGradientRef().uninitialized())
+  if (!weight.hasGradient() || weight.getGradientRef().uninitialized())
     return true;
 
   float reduced_ratio = calc_ratio_op(weight, input, output, reduce_op);

--- a/nntrainer/models/execution_mode.h
+++ b/nntrainer/models/execution_mode.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   execution_mode.h
+ * @date   25 June 2020
+ * @see	   https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ * @brief  This is mode of executions
+ *
+ */
+
+#ifndef __EXECUTION_MODE_H__
+#define __EXECUTION_MODE_H__
+
+namespace nntrainer {
+
+/**
+ * @brief   class telling the execution mode of the model/operation
+ */
+enum class ExecutionMode {
+  TRAIN,     /** Training mode, label is necessary */
+  INFERENCE, /** Inference mode, label is optional */
+  VALIDATE   /** Validate mode, label is necessary */
+}
+
+}; // namespace nntrainer
+
+#endif // __EXECUTION_MODE_H__

--- a/nntrainer/optimizers/optimizer_devel.cpp
+++ b/nntrainer/optimizers/optimizer_devel.cpp
@@ -31,7 +31,7 @@ void Optimizer::applyGradients(std::vector<Weight> &weight_list,
   double ll = getLearningRate(iteration);
 
   for (auto &weight : weight_list) {
-    if (!weight.getTrainable())
+    if (!weight.hasGradient())
       continue;
 
     /** calculate regularization gradient before applying the gradient */

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -179,7 +179,7 @@ void Manager::trackWeights(std::vector<Weight> &ws) {
     layer_weights.emplace_back(std::ref(w));
     unsigned int len = w.getDim().getDataLen();
     weight_size += len;
-    if (w.getTrainable())
+    if (w.needsGradient())
       grad_size += len;
   }
 
@@ -392,7 +392,7 @@ void Manager::initializeGradients() {
       Weight &weight = w.get();
       auto dim = weight.getDim();
       Tensor grad_prealloc = Tensor();
-      if (weight.getTrainable()) {
+      if (weight.needsGradient()) {
         grad_prealloc = allocate_grad(dim, grad_offset);
         grad_offset += dim.getDataLen();
       }
@@ -784,7 +784,7 @@ void Manager::requestOptimizerVariable(
   if (LAYER_V2) {
     for (auto &weight_v2 : weights_v2) {
       for (auto &w : weight_v2) {
-        if (request_only_trainable && !w->getTrainable()) {
+        if (request_only_trainable && !w->needsGradient()) {
           continue;
         }
 
@@ -798,7 +798,7 @@ void Manager::requestOptimizerVariable(
     for (auto &weight : weights) {
       for (auto &rw_w : weight) {
         auto &w = rw_w.get();
-        if (request_only_trainable && !w.getTrainable()) {
+        if (request_only_trainable && !w.needsGradient()) {
           continue;
         }
 

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -18,14 +18,14 @@
 
 namespace nntrainer {
 
-Var_Grad::Var_Grad(const TensorDim &dim, bool train, bool alloc_now_,
+Var_Grad::Var_Grad(const TensorDim &dim, bool ng, bool alloc_now_,
                    const std::string &name) :
   dim(dim),
-  trainable(train),
+  need_gradient(ng),
   alloc_now(alloc_now_),
   name(name) {
   var = std::make_shared<Tensor>(dim, alloc_now);
-  if (trainable)
+  if (need_gradient)
     grad = std::make_shared<Tensor>(dim, alloc_now);
   else
     grad = std::make_shared<Tensor>();
@@ -51,9 +51,9 @@ void Var_Grad::initializeGradient(const Tensor &preallocated) {
 
 void Var_Grad::initializeShared() { grad->makeSharedDataTensor(*var.get()); }
 
-void Var_Grad::setTrainable(bool train) {
-  trainable = train;
-  if (trainable && grad->uninitialized()) {
+void Var_Grad::needsGradient(bool ng) {
+  need_gradient = ng;
+  if (need_gradient && grad->uninitialized()) {
     bool alloc_now_ = var->isAllocated();
     grad = std::make_shared<Tensor>(var->getDim(), alloc_now_);
   }

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -47,7 +47,7 @@ enum class WeightInitializer {
 
 /**
  * @class   Weight
- * @brief   Weight with gradient, and its corresponding trainable property
+ * @brief   Weight with gradient, and its corresponding need_gradient property
  */
 class Weight : public Var_Grad {
 public:
@@ -55,7 +55,7 @@ public:
    * @brief Specification of the Weight
    *
    * @details The tuple values are dimension, initializer, regularizer,
-   * regularizer_constant, trainable property amd name of the Weight object.
+   * regularizer_constant, need_gradient property amd name of the Weight object.
    */
   typedef std::tuple<TensorDim, WeightInitializer, WeightRegularizer, float,
                      bool, const std::string>
@@ -77,7 +77,7 @@ public:
    * @param init Initializer for the weight
    * @param reg Regularizer for the weight
    * @param reg_const Constant multiplier for regularizer
-   * @param train If the variable is trainable
+   * @param ng If the variable needs gradient
    * @param alloc_now The memory for the weight tensors be allocated upon init
    * @param name Name for this weight
    */
@@ -85,7 +85,7 @@ public:
     const TensorDim &dim,
     const WeightInitializer init = WeightInitializer::WEIGHT_XAVIER_UNIFORM,
     const WeightRegularizer reg = WeightRegularizer::NONE,
-    const float reg_const = 1.0f, bool train = true, bool alloc_now = false,
+    const float reg_const = 1.0f, bool ng = true, bool alloc_now = false,
     std::string name = "");
 
   /**
@@ -98,7 +98,7 @@ public:
            std::get<1>(spec), // WeightInitializer
            std::get<2>(spec), // WeightRegularizer
            std::get<3>(spec), // WeightRegularizerConstant
-           std::get<4>(spec), // Trainable
+           std::get<4>(spec), // need_gradient
            false,
            std::get<5>(spec) // Name
     ) {}
@@ -118,7 +118,7 @@ public:
    *
    * @param lhs Swap to
    * @param rhs Swap from
-   * @note Only swap gradient if trainable
+   * @note Only swap gradient if need gradient
    */
   friend void swap(Weight &lhs, Weight &rhs) noexcept {
     using std::swap;
@@ -178,17 +178,17 @@ public:
    * @param dim Variable and gradient tensor dimension
    * @param init Initializer for the weight
    * @param reg Regularizer for the weight
-   * @param train If the variable is trainable
+   * @param ng If the variable needs gradient
    *
    * @note New dimension must maintain the shape of the variable
    */
   void reset(const TensorDim &dim, const WeightInitializer init,
-             const WeightRegularizer reg, const float reg_const, bool train) {
+             const WeightRegularizer reg, const float reg_const, bool ng) {
     initializer = init;
     regularizer = reg;
     regularizer_constant = reg_const;
 
-    Var_Grad::reset(dim, train);
+    Var_Grad::reset(dim, ng);
   }
 
   /**

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -52,7 +52,8 @@ void Exporter::saveTflResult(const std::tuple<> &props, const LayerV1 *self) {
 
 template <>
 void Exporter::saveTflResult(
-  const std::tuple<props::Name, props::Flatten, props::Distribute> &props,
+  const std::tuple<props::Name, props::Flatten, props::Distribute,
+                   props::Trainable> &props,
   const LayerNode *self) {
   createIfNull(tf_node);
   tf_node->setInOut(*self);

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -205,6 +205,7 @@ class Name;
 class Unit;
 class Flatten;
 class Distribute;
+class Trainable;
 } // namespace props
 
 class LayerV1;
@@ -222,7 +223,8 @@ class LayerNode;
  */
 template <>
 void Exporter::saveTflResult(
-  const std::tuple<props::Name, props::Flatten, props::Distribute> &props,
+  const std::tuple<props::Name, props::Flatten, props::Distribute,
+                   props::Trainable> &props,
   const LayerNode *self);
 
 class FullyConnectedLayer;

--- a/test/unittest/layers/unittest_layers_impl.cpp
+++ b/test/unittest/layers/unittest_layers_impl.cpp
@@ -48,6 +48,8 @@ public:
                 const ExportMethods &method) const override {
     LayerImpl::exportTo(exporter, method);
   }
+
+  bool supportBackwarding() const override { return true; }
 };
 } // namespace
 

--- a/test/unittest/unittest_base_properties.cpp
+++ b/test/unittest/unittest_base_properties.cpp
@@ -255,7 +255,7 @@ TEST(BasicProperty, valid_p) {
 
     auto result = e.getResult<nntrainer::ExportMethods::METHOD_STRINGVECTOR>();
     auto pair1 = std::pair<std::string, std::string>("unit", "1");
-    EXPECT_EQ(result->at(0), pair1);
+    EXPECT_EQ(result->at(1), pair1);
   }
 
   { /**< load from layer */

--- a/test/unittest/unittest_nntrainer_appcontext.cpp
+++ b/test/unittest/unittest_nntrainer_appcontext.cpp
@@ -160,8 +160,6 @@ public:
 
   float getLoss() override { return 0.0f; }
 
-  void setTrainable(bool train) override {}
-
   const std::string getType() const override { return CustomLayer::type; }
 };
 

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -475,7 +475,7 @@ TEST(nntrainerIniTest, backbone_p_06) {
   /** default trainable is false */
   auto graph = NN.getFlatGraph();
   for (auto &layer : graph)
-    EXPECT_EQ(layer->getTrainable(), false);
+    EXPECT_EQ(layer->getTrainable(), true);
 }
 
 /**

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -287,7 +287,7 @@ void NodeWatcher::read(std::ifstream &in) {
   std::for_each(expected_dx.begin(), expected_dx.end(), read_);
 
   for (auto &i : expected_weights) {
-    if (i.getTrainable()) {
+    if (i.hasGradient()) {
       // std::cout << "weight-" << i.getName() << ": " << i.getDim();
       i.getGradientRef().read(in);
     }
@@ -309,7 +309,7 @@ void NodeWatcher::verifyWeight(const std::string &error_msg) {
 void NodeWatcher::verifyGrad(const std::string &error_msg) {
   for (unsigned int i = 0; i < expected_weights.size(); ++i) {
     auto weight = node->getObject()->weightAt(i);
-    if (weight.getTrainable()) {
+    if (weight.hasGradient()) {
       verify(node->getWeightGrad(i), expected_weights[i].getGradient(),
              error_msg + " at grad " + std::to_string(i));
     }

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -116,7 +116,7 @@ public:
   NodeWatcher(const NodeType &node) : node(node) {
     unsigned int num_weights = node->getNumWeights();
     try {
-      node->getObject()->setTrainable(true);
+      node->setProperty({"trainable=true"});
     } catch (...) {
       std::cout << "Cannot set layer " << node->getType() << " trainable";
     }


### PR DESCRIPTION
This patch introduces supportBackwarding.
Currently getTrainable does two jobs -
1. check if the layer is trainable
2. check if the layer can do backwarding

Now, the two is separated.
Further, the trainable property has been moved to LayerNode.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>