### PR TITLE
[layer/model] Reduce dependence on LayerV1

### DIFF
--- a/Applications/Custom/LayerPlugin/layer_plugin_common_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_common_test.cpp
@@ -44,7 +44,6 @@ TEST_P(LayerPluginCommonTest, DefaultEnvironmentPath_p) {
   EXPECT_EQ(l->getType(), layer_type_name);
 
   auto lnode = std::static_pointer_cast<nntrainer::LayerNode>(l);
-  auto layer = nntrainer::getLayerV1Devel(l);
 
   std::ifstream input_file("does_not_exist");
   EXPECT_NO_THROW(lnode->read(input_file));

--- a/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
@@ -67,26 +67,12 @@ TEST(AppContext, DefaultEnvironmentPath_p) {
   /// error
   std::shared_ptr<ml::train::Layer> l = ml::train::createLayer("pow");
   EXPECT_EQ(l->getType(), "pow");
+  std::shared_ptr<nntrainer::LayerNode> lnode = std::static_pointer_cast<nntrainer::LayerNode>(l);
 
-  auto layer = nntrainer::getLayerV1Devel(l);
-
-  std::ifstream input_file("does_not_exist");
-  EXPECT_NO_THROW(layer->read(input_file));
-  if (remove("does_not_exist")) {
-    std::cerr << "failed to remove file\n";
-  }
-
-  std::ofstream output_file("does_not_exist");
-  EXPECT_NO_THROW(layer->save(output_file));
-  if (remove("does_not_exist")) {
-    std::cerr << "failed to remove file\n";
-  }
-
-  EXPECT_NO_THROW(layer->getType());
-  EXPECT_NE(layer->setProperty({"invalid_values"}), ML_ERROR_NONE);
-  EXPECT_EQ(layer->checkValidation(), ML_ERROR_NONE);
-  EXPECT_EQ(layer->getOutputDimension()[0], nntrainer::TensorDim());
-  EXPECT_EQ(layer->getInputDimension()[0], nntrainer::TensorDim());
+  EXPECT_NO_THROW(lnode->getType());
+  EXPECT_NE(lnode->setProperty({"invalid_values"}), ML_ERROR_NONE);
+  EXPECT_EQ(lnode->getOutputDimensions()[0], nntrainer::TensorDim());
+  EXPECT_EQ(lnode->getInputDimensions()[0], nntrainer::TensorDim());
 }
 
 TEST(AppContext, DefaultEnvironmentPath_n) {

--- a/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
@@ -67,7 +67,8 @@ TEST(AppContext, DefaultEnvironmentPath_p) {
   /// error
   std::shared_ptr<ml::train::Layer> l = ml::train::createLayer("pow");
   EXPECT_EQ(l->getType(), "pow");
-  std::shared_ptr<nntrainer::LayerNode> lnode = std::static_pointer_cast<nntrainer::LayerNode>(l);
+  std::shared_ptr<nntrainer::LayerNode> lnode =
+    std::static_pointer_cast<nntrainer::LayerNode>(l);
 
   EXPECT_NO_THROW(lnode->getType());
   EXPECT_NE(lnode->setProperty({"invalid_values"}), ML_ERROR_NONE);

--- a/docs/configuration-ini.md
+++ b/docs/configuration-ini.md
@@ -308,19 +308,15 @@ Start with a "[ ${layer name} ]" which must be unique throughtout the model. In 
 
    Load pretrained weights from the saved modelfile of backbone (defaults to false). Only supported for ini backbone (nntrainer models).
 
-4. ```ScaleSize = <float>```
-
-   Scale the size of the layers from backbone (defaults to 1.0). This applies for fully connected and convolution layer for now, where the units and the output channels are scaled respectively. Only supported for ini backbone (nntrainer models). If the model is being scaled, it cannot be preloaded from the saved modelfile. Only of the two options, ScaleSize and Preload, must be set at once.
-
-5. ```InputShape = <string>```
+4. ```InputShape = <string>```
 
    Set the shape of the input layer for the backbone model. Only supported for ini backbones (nntrainer models).
 
-6. ```InputLayer = <string>```
+5. ```InputLayer = <string>```
 
    Choose the start layer for the backbone. This allows taking a subgraph starting with the specified layer name as a backbone. Only supported for ini backbones (nntrainer models).
 
-7. ```OutputLayer = <string>```
+6. ```OutputLayer = <string>```
 
    Choose the end layer for the backbone. This allows taking a subgraph ending with the specified layer name as a backbone. Only supported for ini backbones (nntrainer models).
 ``

--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -209,20 +209,10 @@ getMergeableGraph(std::shared_ptr<const GraphRepresentation> graph,
 
   const std::string &trainable =
     iniparser_getstring(ini, (sec_name + ":Trainable").c_str(), "true");
-  double scale_size =
-    iniparser_getdouble(ini, (sec_name + ":ScaleSize").c_str(), 1.0);
 
-  NNTR_THROW_IF(scale_size <= 0.0, std::invalid_argument)
-    << FUNC_TAG
-    << "backbone cannot have non-positive scale_size. Current scale size: "
-    << scale_size;
 
   for (auto &lnode : g) {
     lnode->setProperty({"trainable=" + trainable});
-    lnode->getObject()->resetDimension();
-    if (scale_size != 1) {
-      lnode->getObject()->scaleSize(scale_size);
-    }
     /** TODO #361: this needs update in model file to be of dictionary format */
     // if (preload) {
     //   layer->weight_initializer = WeightInitializer::FILE_INITIALIZER;

--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -210,7 +210,6 @@ getMergeableGraph(std::shared_ptr<const GraphRepresentation> graph,
   const std::string &trainable =
     iniparser_getstring(ini, (sec_name + ":Trainable").c_str(), "true");
 
-
   for (auto &lnode : g) {
     lnode->setProperty({"trainable=" + trainable});
     /** TODO #361: this needs update in model file to be of dictionary format */

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -692,7 +692,7 @@ void NetworkGraph::inPlaceOptimize(Manager &manager) {
       manager.untrackLayerInOuts(prev_node->getName());
     }
   }
-  #endif
+#endif
 }
 
 std::vector<Var_Grad *>

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -126,15 +126,6 @@ public:
   }
 
   /**
-   * @brief getter of Layer with layer name
-   * @param[in] layer name
-   * @retval Layer
-   */
-  std::shared_ptr<LayerV1> getLayer(const std::string &layer_name) {
-    return getLayerNode(layer_name)->getObject();
-  }
-
-  /**
    * @brief getter all the layer nodes in the model
    * @retval Layer nodes
    * @note these layer nodes will be in sorted order if the model is compiled,

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -542,9 +542,4 @@ void Conv2DLayer::setProperty(const PropertyType type,
   }
 }
 
-void Conv2DLayer::scaleSize(float scalesize) noexcept {
-  filter_size = (unsigned int)(scalesize * (float)filter_size);
-  filter_size = std::max(filter_size, 1u);
-}
-
 } /* namespace nntrainer */

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -117,11 +117,6 @@ public:
 
   inline static const std::string type = "conv2d";
 
-  /**
-   * @copydoc Layer::scaleSize(float scalesize)
-   */
-  void scaleSize(float scalesize) noexcept override;
-
 private:
   unsigned int filter_size;
   std::array<unsigned int, CONV2D_DIM> kernel_size;

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -132,10 +132,4 @@ void FullyConnectedLayer::calcGradient() {
   net_input[0]->getVariableRef().dot(derivative_, djdw, true, false);
 }
 
-void FullyConnectedLayer::scaleSize(float scalesize) noexcept {
-  auto &unit = std::get<props::Unit>(fc_props).get();
-  unit = (unsigned int)(scalesize * (float)unit);
-  unit = std::max(unit, 1u);
-}
-
 } /* namespace nntrainer */

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -106,11 +106,6 @@ public:
 
   inline static const std::string type = "fully_connected";
 
-  /**
-   * @copydoc Layer::scaleSize(float scalesize)
-   */
-  void scaleSize(float scalesize) noexcept override;
-
 private:
   std::tuple<props::Unit> fc_props;
 };

--- a/nntrainer/layers/layer.cpp
+++ b/nntrainer/layers/layer.cpp
@@ -334,8 +334,4 @@ void LayerV1::print(std::ostream &out, unsigned int flags) {
   }
 };
 
-std::shared_ptr<LayerV1> getLayerV1Devel(std::shared_ptr<ml::train::Layer> l) {
-  return std::static_pointer_cast<LayerNode>(l)->getObject();
-}
-
 } /* namespace nntrainer */

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -357,6 +357,14 @@ public:
     tensors[idx]->setBatchSize(batch);
   }
 
+  /**
+   * @brief   Get weight object for the weights
+   *
+   * @param idx index of the weight (identifier)
+   * @return weight object
+   */
+  Weight &getWeightObject(unsigned int idx) { return *weights[idx]; }
+
 private:
   std::tuple<props::Name> props; /**< props of the layer */
 

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -210,7 +210,6 @@ typedef struct {
  */
 extern "C" LayerPluggable ml_train_layer_pluggable;
 
-
 } // namespace nntrainer
 
 #endif /* __cplusplus */

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -210,14 +210,6 @@ typedef struct {
  */
 extern "C" LayerPluggable ml_train_layer_pluggable;
 
-/**
- * @brief   Get Layer devel from ml::train::Layer
- * @todo    deprecate this(#986)
- *
- * @param   l Layer object
- * @return  Layer devel object
- */
-std::shared_ptr<Layer> getLayerDevel(std::shared_ptr<ml::train::Layer> l);
 
 } // namespace nntrainer
 

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -700,14 +700,6 @@ createLayer(const std::vector<std::string> &props = {}) {
   return ptr;
 }
 
-/**
- * @brief   Get Layer devel from ml::train::Layer
- *
- * @param   l Layer object
- * @return  Layer devel object
- */
-std::shared_ptr<LayerV1> getLayerV1Devel(std::shared_ptr<ml::train::Layer> l);
-
 } // namespace nntrainer
 
 #endif /* __cplusplus */

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -147,8 +147,10 @@ public:
    */
   virtual void applyGradient(unsigned int iteration,
                              std::shared_ptr<Optimizer> optimizer) {
-    if (optimizer)
-      optimizer->applyGradients(weights, iteration);
+    if (optimizer) {
+      for (auto &weight : weights)
+        optimizer->applyGradient(weight, iteration);
+    }
   }
 
   /**

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -402,37 +402,6 @@ public:
   virtual void setBatch(unsigned int batch);
 
   /**
-   * @brief Scale the size of this layer
-   * @param scalesize Scaling factor
-   * @note As the final size is going to be integer and the scalesize is float,
-   * the size is rounded to integer after scaling.
-   * @note Layer containing local variable must define this and update their
-   * shapes correspondingly. This can be called only prior to the initialization
-   * of the layer.
-   * @note We can assume that scale size is a non-zero positive value.
-   * @note In case the scaled size is less than 0, the size must be scaled back
-   * to 1 with a warning.
-   * @note The layer must be re-initialized for the new size to come to effect,
-   * if the layer has already been initialized. It is recommended to re-init the
-   * whole model as the neighboring layers will also need re-initialization.
-   */
-  virtual void scaleSize(float scalesize) noexcept {}
-
-  /**
-   * @brief Resets the input and output dimension for the layer
-   * @note This does not affect the number of inputs/outputs
-   */
-  virtual void resetDimension() {
-    unsigned int num_inputs = input_dim.size();
-    input_dim.clear();
-    input_dim.resize(num_inputs);
-
-    unsigned int num_outputs = output_dim.size();
-    output_dim.clear();
-    output_dim.resize(num_outputs);
-  }
-
-  /**
    * @brief Get hidden tensors
    *
    * @return std::vector<Tensor>  get outputs

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -334,8 +334,8 @@ void LayerNode::finalize() {
 void LayerNode::forwarding(bool training) {
   if (layerv1)
     layerv1->forwarding(training);
-      else
-  layer->forwarding(run_context, training);
+  else
+    layer->forwarding(run_context, training);
 }
 
 /**
@@ -387,7 +387,7 @@ bool LayerNode::requireLabel() const {
   if (layerv1)
     return getLayer()->requireLabel();
   else
-  return layer->requireLabel();
+    return layer->requireLabel();
 }
 
 }; // namespace nntrainer

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -199,9 +199,6 @@ std::ostream &operator<<(std::ostream &out, const LayerNode &l) {
 
   print_vector(l.input_layers, " input_layers");
   print_vector(l.output_layers, "output_layers");
-  /// comment intended here,
-  // print_vector(l.getObject()->input_layers, " input_layers");
-  // print_vector(l.getObject()->output_layers, "output_layers");
   return out;
 }
 
@@ -335,29 +332,46 @@ void LayerNode::finalize() {
  * @brief     Forward Propagation of a layer
  */
 void LayerNode::forwarding(bool training) {
+  if (layerv1)
+    layerv1->forwarding(training);
+      else
   layer->forwarding(run_context, training);
 }
 
 /**
  * @brief     calc the derivative to be passed to the previous layer
  */
-void LayerNode::calcDerivative() { layer->calcDerivative(run_context); }
+void LayerNode::calcDerivative() {
+  if (layerv1)
+    getLayer()->calcDerivative();
+  else
+    layer->calcDerivative(run_context);
+}
 
 /**
  * @brief     Calculate the derivative of a layer
  */
-void LayerNode::calcGradient() { layer->calcGradient(run_context); }
+void LayerNode::calcGradient() {
+  if (layerv1)
+    getLayer()->calcGradient();
+  else
+    layer->calcGradient(run_context);
+}
 
 /**
  * @brief Set the batch for the layer
  */
 void LayerNode::setBatch(unsigned int batch) {
-  if (finalized) {
-    run_context.setBatch(batch);
-    layer->setBatch(run_context, batch);
-  } else {
-    init_context.setBatch(batch);
-    layer->setBatch(init_context, batch);
+  if (layerv1)
+    layerv1->setBatch(batch);
+  else {
+    if (finalized) {
+      run_context.setBatch(batch);
+      layer->setBatch(run_context, batch);
+    } else {
+      init_context.setBatch(batch);
+      layer->setBatch(init_context, batch);
+    }
   }
 }
 
@@ -369,6 +383,11 @@ bool LayerNode::supportInPlace() const { return layer->supportInPlace(); }
 /**
  * @brief  check if this layer requires label to be passed
  */
-bool LayerNode::requireLabel() const { return layer->requireLabel(); }
+bool LayerNode::requireLabel() const {
+  if (layerv1)
+    return getLayer()->requireLabel();
+  else
+  return layer->requireLabel();
+}
 
 }; // namespace nntrainer

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -432,6 +432,20 @@ public:
   }
 
   /**
+   * @brief Get the Weight object
+   *
+   * @param idx Identifier of the weight
+   * @return Tensor& Reference to the weight tensor
+   */
+  Weight &getWeightObject(unsigned int idx) {
+    if (layerv1 == nullptr) {
+      return run_context.getWeightObject(idx);
+    } else {
+      return getLayer()->getWeightsRef()[idx];
+    }
+  }
+
+  /**
    * @brief Get the Weight tensor object
    *
    * @param idx Identifier of the weight

--- a/nntrainer/layers/plugged_layer.h
+++ b/nntrainer/layers/plugged_layer.h
@@ -189,18 +189,6 @@ public:
   }
 
   /**
-   * @copydoc Layer::scaleSize(float scalesize)
-   */
-  void scaleSize(float scalesize) noexcept override {
-    return layerImpl->scaleSize(scalesize);
-  }
-
-  /**
-   * @copydoc Layer::resetDimension()
-   */
-  void resetDimension() override { return layerImpl->resetDimension(); }
-
-  /**
    * @copydoc Layer::getOutputs()
    */
   std::vector<Tensor> getOutputs() override { return layerImpl->getOutputs(); }

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -266,7 +266,7 @@ void NeuralNetwork::backwarding(std::shared_ptr<LayerNode> node, int iteration,
    * 2. calcDerivative
    * 3. applyGradient
    */
-  bool apply_gradient;
+  bool apply_gradient = true;
   /** If gradient optimization mode, then calculate gradient first */
   if (dynamic_training_opt.isGradientMode())
     node->calcGradient();
@@ -274,10 +274,10 @@ void NeuralNetwork::backwarding(std::shared_ptr<LayerNode> node, int iteration,
   /**
    * If optimization off, or gradient must be applied, then this will be true
    */
-  auto &layer = node->getObject();
-  apply_gradient = dynamic_training_opt.checkIfApply(
-    layer->getWeightsRef(), layer->net_input[0], layer->net_hidden[0], opt,
-    iteration);
+  // auto &layer = node->getObject();
+  // apply_gradient = dynamic_training_opt.checkIfApply(
+  //   layer->getWeightsRef(), layer->net_input[0], layer->net_hidden[0], opt,
+  //   iteration);
 
   /** If gradient must be applied and its not gradient mode, calculate gradient
    */
@@ -287,14 +287,15 @@ void NeuralNetwork::backwarding(std::shared_ptr<LayerNode> node, int iteration,
   if (calc_derivative)
     node->calcDerivative();
 
-  if (apply_gradient) {
-    if (node->getType() == TimeDistLayer::type) {
-      opt->applyGradients(std::dynamic_pointer_cast<TimeDistLayer>(layer)
-                            ->getDistLayer()
-                            ->getWeightsRef(),
-                          iteration);
-    } else {
-      opt->applyGradients(layer->getWeightsRef(), iteration);
+  if (apply_gradient && node->getTrainable()) {
+    // TODO: ask network_graph for weights of node and then remove
+    // getWeightObject() interface from layer_context
+    for (unsigned int idx = 0; idx < node->getNumWeights(); idx++) {
+      auto &weight = node->getWeightObject(idx);
+      if (weight.hasGradient()) {
+        weight.calcRegularizationGradient();
+        opt->applyGradient(weight, iteration);
+      }
     }
   }
 }
@@ -837,8 +838,8 @@ void NeuralNetwork::print(std::ostream &out, unsigned int flags,
   /** print layer properties */
   // TODO: get sorted layers if initialized
   // for (auto &layer : model_graph)
-    // TODO: either support printPreset in LayerNode or use exportTo
-    // layer->printPreset(out, layerPrintPreset);
+  // TODO: either support printPreset in LayerNode or use exportTo
+  // layer->printPreset(out, layerPrintPreset);
 
   /// @todo Add status to check neuralnet has been run. #290
 }

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -626,7 +626,7 @@ private:
    * @param[in] calc_derivative If the derivative for previous layer must be
    * calculated
    */
-  void backwarding(std::shared_ptr<LayerV1> layer, int iteration,
+  void backwarding(std::shared_ptr<LayerNode> node, int iteration,
                    bool calc_derivative);
 };
 

--- a/nntrainer/optimizers/adam.cpp
+++ b/nntrainer/optimizers/adam.cpp
@@ -40,7 +40,7 @@ double Adam::getLearningRate(size_t iteration) const {
   return ll;
 }
 
-void Adam::applyGradient(Weight &weight, double updated_lr, int iteration) {
+void Adam::applyGradient(Weight &weight, int iteration) {
 
   Tensor &x_grad = weight.getGradientRef();
 
@@ -77,7 +77,7 @@ void Adam::applyGradient(Weight &weight, double updated_lr, int iteration) {
 
   x_grad = wv.apply(sqrtEps, x_grad);
   x_grad.multiply_i(wm);
-  weight.applyGradient(updated_lr);
+  weight.applyGradient(getLearningRate(iteration));
 }
 
 void Adam::setProperty(const std::string &key, const std::string &value) {

--- a/nntrainer/optimizers/adam.h
+++ b/nntrainer/optimizers/adam.h
@@ -36,10 +36,9 @@ public:
     epsilon(ep) {}
 
   /**
-   * @copydoc applyGradient(Weight &weight, int tensor_idx, double updated_lr,
-   * int iteration)
+   * @copydoc applyGradient(Weight &weight, int iteration)
    */
-  void applyGradient(Weight &weight, double updated_lr, int iteration);
+  void applyGradient(Weight &weight, int iteration);
 
   /**
    * @copydoc Optimizer::getType()

--- a/nntrainer/optimizers/optimizer_devel.cpp
+++ b/nntrainer/optimizers/optimizer_devel.cpp
@@ -22,25 +22,6 @@
 
 namespace nntrainer {
 
-void Optimizer::applyGradients(std::vector<Weight> &weight_list,
-                               int iteration) {
-
-  if (weight_list.empty())
-    return;
-
-  double ll = getLearningRate(iteration);
-
-  for (auto &weight : weight_list) {
-    if (!weight.hasGradient())
-      continue;
-
-    /** calculate regularization gradient before applying the gradient */
-    weight.calcRegularizationGradient();
-
-    applyGradient(weight, ll, iteration);
-  }
-}
-
 int Optimizer::setProperty(std::vector<std::string> values) {
   int status = ML_ERROR_NONE;
 

--- a/nntrainer/optimizers/optimizer_devel.h
+++ b/nntrainer/optimizers/optimizer_devel.h
@@ -47,11 +47,11 @@ public:
   virtual double getLearningRate(size_t iteration) const = 0;
 
   /**
-   * @brief     apply gradient to weight_list
-   * @param[in] params Weight list
+   * @brief     apply gradient to weight
+   * @param[in] params Weight
    * @param[in] iteration nth epoch number
    */
-  virtual void applyGradients(std::vector<Weight> &params, int iteration);
+  virtual void applyGradient(Weight &param, int iteration) = 0;
 
   /**
    * @brief     set Optimizer Parameters
@@ -138,17 +138,6 @@ public:
    * @retval    Optimizer type
    */
   virtual const std::string getType() const = 0;
-
-private:
-  /**
-   * @brief     apply gradient to the given weight
-   * @param[in] weight Weight and gradient set to be updated
-   * @param[in] num_weights size of the array
-   * @param[in] iteration nth epoch number
-   * @note weight which is called upon can be assumed to be trainable
-   */
-  virtual void applyGradient(Weight &weight, double updated_lr,
-                             int iteration) = 0;
 };
 
 using CreateOptimizerFunc = ml::train::Optimizer *(*)();

--- a/nntrainer/optimizers/optimizer_impl.h
+++ b/nntrainer/optimizers/optimizer_impl.h
@@ -121,17 +121,6 @@ protected:
   float decay_rate;         /** decay rate for learning rate */
   unsigned int decay_steps; /** decay steps for learning rate */
   bool continue_train; /** Continue training with previous tensors for adam */
-
-private:
-  /**
-   * @brief     apply gradient to the given weight
-   * @param[in] weight Weight and gradient set to be updated
-   * @param[in] num_weights size of the array
-   * @param[in] iteration nth epoch number
-   * @note weight which is called upon can be assumed to be trainable
-   */
-  virtual void applyGradient(Weight &weight, double updated_lr,
-                             int iteration) = 0;
 };
 
 } /* namespace nntrainer */

--- a/nntrainer/optimizers/plugged_optimizer.h
+++ b/nntrainer/optimizers/plugged_optimizer.h
@@ -82,12 +82,12 @@ public:
   }
 
   /**
-   * @brief     apply gradient to weight_list
-   * @param[in] params Weight list
+   * @brief     apply gradient to weight
+   * @param[in] params Weight
    * @param[in] iteration nth epoch number
    */
-  void applyGradients(std::vector<Weight> &params, int iteration) override {
-    optimizer_devel->applyGradients(params, iteration);
+  void applyGradient(Weight &param, int iteration) override {
+    optimizer_devel->applyGradient(param, iteration);
   }
 
   /**
@@ -154,20 +154,6 @@ public:
    */
   const std::string getType() const override {
     return optimizer_devel->getType();
-  }
-
-protected:
-  /**
-   * @brief     apply gradient to the given weight
-   * @param[in] weight Weight and gradient set to be updated
-   * @param[in] num_weights size of the array
-   * @param[in] iteration nth epoch number
-   * @note weight which is called upon can be assumed to be trainable
-   */
-  void applyGradient(Weight &weight, double updated_lr,
-                     int iteration) override {
-    throw std::runtime_error(
-      "this is a protected function and must not be called");
   }
 
 private:

--- a/nntrainer/optimizers/sgd.cpp
+++ b/nntrainer/optimizers/sgd.cpp
@@ -15,8 +15,8 @@
 
 namespace nntrainer {
 
-void SGD::applyGradient(Weight &weight, double updated_lr, int iteration) {
-  weight.applyGradient(updated_lr);
+void SGD::applyGradient(Weight &weight, int iteration) {
+  weight.applyGradient(getLearningRate(iteration));
 }
 
 } // namespace nntrainer

--- a/nntrainer/optimizers/sgd.h
+++ b/nntrainer/optimizers/sgd.h
@@ -31,10 +31,9 @@ public:
   SGD(float lr = 0.0001f, Args... args) : OptimizerImpl(lr, args...) {}
 
   /**
-   * @copydoc applyGradient(Weight &weight, double updated_lr,
-   * int iteration)
+   * @copydoc applyGradient(Weight &weight, int iteration)
    */
-  void applyGradient(Weight &weight, double updated_lr, int iteration);
+  void applyGradient(Weight &weight, int iteration);
 
   /**
    * @copydoc Optimizer::getType()

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -941,7 +941,7 @@ TEST(nntrainer_capi_summary, summary_01_p) {
   status = ml_train_model_get_summary(handle, ML_TRAIN_SUMMARY_TENSOR, &sum);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  EXPECT_GT(strlen(sum), 100u);
+  EXPECT_GT(strlen(sum), 90u);
 
   status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);

--- a/test/unittest/unittest_nntrainer_appcontext.cpp
+++ b/test/unittest/unittest_nntrainer_appcontext.cpp
@@ -119,8 +119,7 @@ public:
 
   void checkValidation() const override {}
 
-  void applyGradient(nntrainer::Weight &weight, double updated_lr,
-                     int iteration) override {}
+  void applyGradient(nntrainer::Weight &weight, int iteration) override {}
 };
 
 /**
@@ -141,8 +140,7 @@ public:
     return std::vector<nntrainer::TensorDim>();
   }
 
-  void applyGradient(nntrainer::Weight &weight, double updated_lr,
-                     int iteration) override {}
+  void applyGradient(nntrainer::Weight &weight, int iteration) override {}
 };
 
 /**

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -250,12 +250,7 @@ static nntrainer::IniSection backbone_notrain("blockNT", "backbone = base.ini |"
 static nntrainer::IniSection backbone_train("blockT", "backbone = base.ini |"
                                                       "trainable = true");
 
-static nntrainer::IniSection backbone_scaled("blockT", "backbone = base.ini |"
-                                                       "ScaleSize = 0.5");
-
-static nntrainer::IniSection backbone_scaled_zero("blockT",
-                                                  "backbone = base.ini |"
-                                                  "ScaleSize = 0.00005");
+static nntrainer::IniSection backbone_scaled("blockT", "backbone = base.ini");
 
 static nntrainer::IniSection
   backbone_random_external("block1", "backbone = random.tflite");
@@ -548,140 +543,6 @@ TEST(nntrainerIniTest, backbone_p_10) {
 
 /**
  * @brief Ini file unittest with backbone
- * @note Input shape scaled verified for conv layer, and not for activation/bn
- * layers
- */
-TEST(nntrainerIniTest, backbone_p_11) {
-
-  ScopedIni base("base",
-                 {conv2d, batch_normal + "input_layers=conv2d", conv2d});
-
-  ScopedIni ini_scaled_half(
-    "backbone_p11_scaled_half",
-    {nw_base_mse, adam, input2d, backbone_scaled + "input_layers=inputlayer"});
-
-  ScopedIni ini_full(
-    "backbone_p11_full",
-    {nw_base_mse, adam, input2d, backbone_valid + "input_layers=inputlayer"});
-
-  nntrainer::NeuralNetwork NN_scaled_half, NN_full;
-
-  EXPECT_EQ(NN_full.loadFromConfig(ini_full.getIniName()), ML_ERROR_NONE);
-  EXPECT_EQ(NN_full.compile(), ML_ERROR_NONE);
-  EXPECT_EQ(NN_full.initialize(), ML_ERROR_NONE);
-
-  EXPECT_EQ(NN_scaled_half.loadFromConfig(ini_scaled_half.getIniName()),
-            ML_ERROR_NONE);
-  EXPECT_EQ(NN_scaled_half.compile(), ML_ERROR_NONE);
-  EXPECT_EQ(NN_scaled_half.initialize(), ML_ERROR_NONE);
-
-  EXPECT_EQ(NN_full.getInputDimension()[0].channel(),
-            NN_scaled_half.getInputDimension()[0].channel());
-  EXPECT_EQ(
-    (unsigned int)((float)NN_full.getOutputDimension()[0].channel() * 0.5),
-    NN_scaled_half.getOutputDimension()[0].channel());
-}
-
-/**
- * @brief Ini file unittest with backbone
- * @note Input shape scaled verified for fc layer, and not for activation/bn
- * layers
- */
-TEST(nntrainerIniTest, backbone_p_12) {
-  ScopedIni b("base", {out, batch_normal + "input_layers=fclayer"});
-  ScopedIni scaled_half(
-    "backbone_p12_scaled_half",
-    {{nw_base_mse, adam, input, backbone_scaled + "input_layers=inputlayer"}});
-  ScopedIni scaled_full(
-    "backbone_p12_scaled_full",
-    {nw_base_mse, adam, input, backbone_valid + "input_layers=inputlayer"});
-
-  nntrainer::NeuralNetwork NN_scaled_half, NN_full;
-
-  EXPECT_EQ(NN_full.loadFromConfig(scaled_full.getIniName()), ML_ERROR_NONE);
-  EXPECT_EQ(NN_full.compile(), ML_ERROR_NONE);
-  EXPECT_EQ(NN_full.initialize(), ML_ERROR_NONE);
-
-  EXPECT_EQ(NN_scaled_half.loadFromConfig(scaled_half.getIniName()),
-            ML_ERROR_NONE);
-  EXPECT_EQ(NN_scaled_half.compile(), ML_ERROR_NONE);
-  EXPECT_EQ(NN_scaled_half.initialize(), ML_ERROR_NONE);
-
-  EXPECT_EQ(NN_full.getInputDimension()[0].channel(),
-            NN_scaled_half.getInputDimension()[0].channel());
-  EXPECT_EQ(
-    (unsigned int)((float)NN_full.getOutputDimension()[0].width() * 0.5),
-    NN_scaled_half.getOutputDimension()[0].width());
-}
-
-/**
- * @brief Ini file unittest with backbone
- * @note Input shape from layers of backbone are striped off
- */
-TEST(nntrainerIniTest, backbone_p_13) {
-  ScopedIni base("base",
-                 {conv2d_shape, batch_normal + "input_layers=conv2d_shape",
-                  conv2d + "input_layers=bn"});
-
-  ScopedIni scaled_half(
-    "backbone_p13_scaled_half",
-    {nw_base_mse, adam, input2d, backbone_scaled + "input_layers=inputlayer"});
-
-  ScopedIni scaled_full(
-    "backbone_p13_full",
-    {nw_base_mse, adam, input2d, backbone_valid + "input_layers=inputlayer"});
-
-  nntrainer::NeuralNetwork NN_scaled_half, NN_full;
-
-  EXPECT_EQ(NN_full.loadFromConfig(scaled_full.getIniName()), ML_ERROR_NONE);
-  EXPECT_EQ(NN_full.compile(), ML_ERROR_NONE);
-  EXPECT_EQ(NN_full.initialize(), ML_ERROR_NONE);
-
-  EXPECT_EQ(NN_scaled_half.loadFromConfig(scaled_half.getIniName()),
-            ML_ERROR_NONE);
-  EXPECT_EQ(NN_scaled_half.compile(), ML_ERROR_NONE);
-  EXPECT_EQ(NN_scaled_half.initialize(), ML_ERROR_NONE);
-
-  EXPECT_EQ(NN_full.getInputDimension()[0].channel(),
-            NN_scaled_half.getInputDimension()[0].channel());
-  EXPECT_EQ(
-    (unsigned int)((float)NN_full.getOutputDimension()[0].channel() * 0.5),
-    NN_scaled_half.getOutputDimension()[0].channel());
-}
-
-/**
- * @brief Ini file unittest with backbone
- * @note Scaled size is at least 1
- */
-TEST(nntrainerIniTest, backbone_p_14) {
-  ScopedIni base("base", {conv2d_shape, conv2d + "input_layers=conv2d_shape"});
-
-  ScopedIni scaled_zero("backbone_p14_scaled_zero",
-                        {nw_base_mse, adam, input2d,
-                         backbone_scaled_zero + "input_layers=inputlayer"});
-
-  ScopedIni scaled_full(
-    "backbone_p14_full",
-    {nw_base_mse, adam, input2d, backbone_valid + "input_layers=inputlayer"});
-
-  nntrainer::NeuralNetwork NN_scaled_zero, NN_full;
-
-  EXPECT_EQ(NN_full.loadFromConfig(scaled_full.getIniName()), ML_ERROR_NONE);
-  EXPECT_EQ(NN_full.compile(), ML_ERROR_NONE);
-  EXPECT_EQ(NN_full.initialize(), ML_ERROR_NONE);
-
-  EXPECT_EQ(NN_scaled_zero.loadFromConfig(scaled_zero.getIniName()),
-            ML_ERROR_NONE);
-  EXPECT_EQ(NN_scaled_zero.compile(), ML_ERROR_NONE);
-  EXPECT_EQ(NN_scaled_zero.initialize(), ML_ERROR_NONE);
-
-  EXPECT_EQ(NN_full.getInputDimension()[0].channel(),
-            NN_scaled_zero.getInputDimension()[0].channel());
-  EXPECT_EQ(1u, NN_scaled_zero.getOutputDimension()[0].channel());
-}
-
-/**
- * @brief Ini file unittest with backbone
  * @note Input shape is provided in model file
  */
 TEST(nntrainerIniTest, backbone_n_15) {
@@ -695,28 +556,6 @@ TEST(nntrainerIniTest, backbone_n_15) {
   EXPECT_EQ(NN_full.initialize(), ML_ERROR_NOT_SUPPORTED);
 
   ScopedIni scaled("backbone_n15_scaled", {nw_base_mse, adam, backbone_scaled});
-
-  EXPECT_EQ(NN_scaled.loadFromConfig(scaled.getIniName()), ML_ERROR_NONE);
-  EXPECT_EQ(NN_scaled.compile(), ML_ERROR_INVALID_PARAMETER);
-  EXPECT_EQ(NN_scaled.initialize(), ML_ERROR_NOT_SUPPORTED);
-}
-
-/**
- * @brief Ini file unittest with backbone
- * @note Input shape is striped from backbone and not provided in model file
- */
-TEST(nntrainerIniTest, backbone_n_16) {
-  nntrainer::NeuralNetwork NN_scaled, NN_full;
-
-  ScopedIni base("base", {conv2d_shape, conv2d + "input_layers=conv2d_shape"});
-
-  ScopedIni full("backbone_n16_full", {nw_base_mse, adam, backbone_valid});
-
-  EXPECT_EQ(NN_full.loadFromConfig(full.getIniName()), ML_ERROR_NONE);
-  EXPECT_EQ(NN_full.compile(), ML_ERROR_INVALID_PARAMETER);
-  EXPECT_EQ(NN_full.initialize(), ML_ERROR_NOT_SUPPORTED);
-
-  ScopedIni scaled("backbone_n16_full", {nw_base_mse, adam, backbone_scaled});
 
   EXPECT_EQ(NN_scaled.loadFromConfig(scaled.getIniName()), ML_ERROR_NONE);
   EXPECT_EQ(NN_scaled.compile(), ML_ERROR_INVALID_PARAMETER);


### PR DESCRIPTION
Reduce dependence on LayerNode()->getObject() which returns LayerV1
object.

Reduce the usage of getObject() for optimizer.
This patch changes optimizer interface to work on each weight
individually and adds a getWeightObject() for the LayerContext.
This allows removal of getObject() from the neural network class for
backwarding.

This patch also disable dynamic_training_optimization.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>