### PR TITLE
[Fix] coverity, svace issues

### DIFF
--- a/Applications/Custom/LayerClient/jni/main.cpp
+++ b/Applications/Custom/LayerClient/jni/main.cpp
@@ -219,6 +219,9 @@ int main(int argc, char *argv[]) {
   } catch (std::invalid_argument &e) {
     std::cerr << "failed to run the model, reason: " << e.what() << std::endl;
     return 1;
+  } catch (std::regex_error &e) {
+    std::cerr << "failed to run the model, reaseon: " << e.what() << std::endl;
+    return 1;
   }
 
   /// should not reach here

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -132,7 +132,7 @@ void FullyConnectedLayer::calcGradient() {
   net_input[0]->getVariableRef().dot(derivative_, djdw, true, false);
 }
 
-void FullyConnectedLayer::scaleSize(float scalesize) noexcept {
+void FullyConnectedLayer::scaleSize(float scalesize) {
   auto &unit = std::get<props::Unit>(fc_props).get();
   unit = (unsigned int)(scalesize * (float)unit);
   unit = std::max(unit, 1u);

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -109,7 +109,7 @@ public:
   /**
    * @copydoc Layer::scaleSize(float scalesize)
    */
-  void scaleSize(float scalesize) noexcept override;
+  void scaleSize(float scalesize) override;
 
 private:
   std::tuple<props::Unit> fc_props;

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -431,7 +431,7 @@ public:
    * if the layer has already been initialized. It is recommended to re-init the
    * whole model as the neighboring layers will also need re-initialization.
    */
-  virtual void scaleSize(float scalesize) noexcept {}
+  virtual void scaleSize(float scalesize) {}
 
   /**
    * @brief Resets the input and output dimension for the layer

--- a/nntrainer/utils/ini_wrapper.cpp
+++ b/nntrainer/utils/ini_wrapper.cpp
@@ -18,7 +18,7 @@
 
 namespace nntrainer {
 
-IniSection::IniSection(const std::string &name) : section_name(name) {}
+IniSection::IniSection(const std::string &name) : section_name(name), entry{} {}
 
 IniSection::IniSection(const std::string &section_name,
                        const std::string &entry_str) :

--- a/nntrainer/utils/ini_wrapper.h
+++ b/nntrainer/utils/ini_wrapper.h
@@ -73,7 +73,7 @@ public:
    * @brief Default constructor for the Ini Section object
    *
    */
-  IniSection() = default;
+  IniSection() : section_name(""), entry{} {};
 
   /**
    * @brief Default destructor for the Ini Section object

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -24,7 +24,7 @@ namespace nntrainer {
  * @brief Construct a new Exporter object
  *
  */
-Exporter::Exporter() = default;
+Exporter::Exporter() : stored_result(nullptr), is_exported(false){};
 
 /**
  * @brief Destroy the Exporter object

--- a/test/unittest/layers/layers_common_tests.cpp
+++ b/test/unittest/layers/layers_common_tests.cpp
@@ -30,7 +30,7 @@ void LayerSemantics::TearDown() {}
 
 TEST_P(LayerSemantics, createFromAppContext_pn) {
   auto ac = nntrainer::AppContext::Global(); /// copy intended
-  if (~(options & LayerCreateSetPropertyOptions::AVAILABLE_FROM_APP_CONTEXT)) {
+  if (!(options & LayerCreateSetPropertyOptions::AVAILABLE_FROM_APP_CONTEXT)) {
     EXPECT_THROW(ac.createObject<nntrainer::Layer>(expected_type),
                  std::invalid_argument);
     ac.registerFactory<nntrainer::Layer>(std::get<0>(GetParam()));


### PR DESCRIPTION
Coverity
1. Deleted noexception keyword where throw exception can occured.
2. Initialze member variable in constructor
3. Correct bitwise operation

resolves: 1238192, 1238193, 1238195, 1238196, 1238298

Svace
1. Catch unhandled throw

resolve: 464062

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>