### PR TITLE
[CAPI] Propose save/load api @open sesame 07/05 16:40

### DIFF
--- a/api/capi/include/nntrainer-tizen-internal.h
+++ b/api/capi/include/nntrainer-tizen-internal.h
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file   nntrainer-tizen-internal.h
+ * @date   30 June 2021
+ * @brief  NNTrainer CAPI header for tizen interanl api.
+ * @note   This header is designed to be used only in Tizen
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __NNTRAINER_TIZEN_INTERNAL_H__
+#define __NNTRAINER_TIZEN_INTERNAL_H__
+
+#include <nntrainer.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * @brief Save the model
+ * @details Use this function to save the current model. @a format
+ * describes various formats in which various selections of the
+ * parameters of the models can be saved. Some formats may save
+ * parameters required for training. Some other formats may save model
+ * configurations. Unless stated otherwise, @a ml_train_model_compile() has to
+ * be called upon the @a model before calling this function.
+ * @see @a ml_train_model_format_e to check which part of the model is
+ * saved
+ * @note This function overrides the existing file without any notification.
+ *
+ * @since_tizen 6.5
+ * @param[in] model The NNTrainer model handle to save
+ * @param[in] file_path File path to save the file.
+ * @param[in] format Format flag to determine which format should be used to
+ * save
+ * @return @c 0 on success, Otherwise a negative error value
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_INVALID_PARAMETER The given @a file_path is
+ * invalid or @a model is not compiled.
+ */
+int ml_train_model_save(ml_train_model_h model, const char *file_path,
+                        ml_train_model_format_e format);
+
+/**
+ * @brief Load the model
+ * @details Use this function to load the current model. @a format
+ * describes various formats in which various selections of the
+ * parameters of the models can be loaded. Some formats may load
+ * parameters required for training. Some other formats may load model
+ * configurations. Unless stated otherwise, @a ml_train_model_compile() has to
+ * be called upon the @a model before calling this function.
+ *
+ * @see @a ml_train_model_format_e to check which part of the model is
+ * loaded
+ *
+ * @since_tizen 6.5
+ * @param[in] model The NNTrainer model handle to load.
+ * @param[in] file_path File path to load the file.
+ * @param[in] format Format flag to determine which format should be used to
+ * loaded
+ * @return @c 0 on success, Otherwise a negative error value
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_INVALID_PARAMETER The given @a file_path is
+ * invalid or @a model is not in valid state to load.
+ */
+int ml_train_model_load(ml_train_model_h model, const char *file_path,
+                        ml_train_model_format_e format);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif // __NNTRAINER_TIZEN_INTERNAL_H__

--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -16,6 +16,10 @@ capi_headers = []
 capi_headers += meson.current_source_dir() / 'include' / 'nntrainer.h'
 capi_headers += meson.current_source_dir() / '..' / 'nntrainer-api-common.h'
 
+if get_option('enable-tizen')
+  capi_headers += meson.current_source_dir() / 'include' / 'nntrainer-tizen-internal.h'
+endif
+
 capi_deps = [
   nntrainer_ccapi_dep,
   nnstreamer_capi_dep,

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -19,6 +19,7 @@
 #if __cplusplus >= MIN_CPP_VERSION
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <nntrainer-api-common.h>
@@ -38,6 +39,21 @@ enum class ModelType {
   KNN,        /** k Nearest Neighbor */
   NEURAL_NET, /** Neural Network */
   UNKNOWN     /** Unknown */
+};
+
+/**
+ * @brief Model saving options
+ *
+ */
+enum class ModelFormat {
+  MODEL_FORMAT_BIN =
+    ML_TRAIN_MODEL_FORMAT_BIN, /**< raw bin file saves parameters required
+for inference and training without any configurations*/
+
+  /** Comment intended */
+  // MODEL_FORMAT_INI = 1, /**< ini file with save_path defined */
+  // MODEL_FORMAT_INI_WITH_BIN = 2, /**< ini file with save_path
+  // defined */
 };
 
 /**
@@ -95,13 +111,35 @@ public:
 
   /**
    * @brief     save model and training parameters into file
+   * @todo      deprecate this
    */
-  virtual void saveModel() = 0;
+  [[deprecated("use saveModel(const std::string &path_prefix, "
+               "ModelFormat format)")]] virtual void
+  saveModel() = 0;
+
+  /**
+   * @brief  load model states and training parameters from a file
+   * @param file_path file_path to save the model, if full path is not
+   * given, it should be saved inside working directory
+   * @param format format to save parameters
+   */
+  virtual void save(const std::string &file_path,
+                    ModelFormat format = ModelFormat::MODEL_FORMAT_BIN){};
 
   /**
    * @brief     read model and training parameters from file
+   * @todo      deprecate this
    */
   virtual void readModel() = 0;
+
+  /**
+   * @brief  load model with regard to the format
+   * @param file_path file_path to save the model, if full path is not
+   * given, it should be saved inside working directory
+   * @param format format to save parameters
+   */
+  virtual void load(const std::string &file_path,
+                    ModelFormat format = ModelFormat::MODEL_FORMAT_BIN){};
 
   /**
    * @brief     Run Model training and validation

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -164,6 +164,16 @@ typedef enum {
 } ml_train_summary_type_e;
 
 /**
+ * @brief Enumeration for the neural network
+ *
+ */
+typedef enum {
+  ML_TRAIN_MODEL_FORMAT_BIN =
+    0, /**< raw bin file saves parameters required for inference and training
+          without any configurations*/
+} ml_train_model_format_e;
+
+/**
  * @}
  */
 #ifdef __cplusplus

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -214,6 +214,13 @@ Requires:        capi-machine-learning-training-devel = %{version}-%{release}
 %description -n capi-machine-learning-training-devel-static
 Static library of capi-machine-learning-training-devel package.
 
+%package tizen-internal-devel
+Summary:	Tizen internal headers for Tizen Machine Learning Training API
+Group:		Machine Learning/ML Framework
+Requires:	capi-machine-learning-training-devel = %{version}-%{release}
+%description tizen-internal-devel
+Tizen internal headers for Tizen Machine Learning Training API.
+
 %if 0%{?support_ccapi}
 %package -n ccapi-machine-learning-training
 Summary:         Tizen Native API for NNTrainer
@@ -471,6 +478,9 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 
 %files -n capi-machine-learning-training-devel-static
 %{_libdir}/libcapi-nntrainer.a
+
+%files tizen-internal-devel
+%{_includedir}/nntrainer/nntrainer-tizen-internal.h
 
 %if 0%{?support_ccapi}
 %files -n ccapi-machine-learning-training


### PR DESCRIPTION
- [CAPI] Propose save/load api

```
**Motivations**
1. Fine grained api required to save and load

**Changes proposed in this PR:**
- Add function to model.h  / `save`, `load`
- Mark `readModel()` deprecated (later remove...)
- Mark `saveModel()` to change `exportTo`
- Add `ModelSaveLoadFormat`
- Create capi-machine-learning-training-tizen-internal for internal api
support

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```