### PR TITLE
[Padding] Add padding verification

### DIFF
--- a/test/unittest/unittest_common_properties.cpp
+++ b/test/unittest/unittest_common_properties.cpp
@@ -186,6 +186,55 @@ TEST(InputSpecProperty, trailingOperator_n_02) {
   EXPECT_THROW(nntrainer::from_string("A+B++", actual), std::invalid_argument);
 }
 
+TEST(Padding2D, setPropertyValid_p) {
+  nntrainer::props::Padding2D p;
+  EXPECT_NO_THROW(p.set("same"));
+  EXPECT_EQ(p.get(), "same");
+
+  EXPECT_NO_THROW(p.set("Same"));
+  EXPECT_EQ(p.get(), "Same");
+
+  EXPECT_NO_THROW(p.set("valid"));
+  EXPECT_EQ(p.get(), "valid");
+
+  EXPECT_NO_THROW(p.set("1"));
+  EXPECT_EQ(p.get(), "1");
+
+  EXPECT_NO_THROW(p.set("0"));
+  EXPECT_EQ(p.get(), "0");
+
+  EXPECT_NO_THROW(p.set("1, 2"));
+  EXPECT_EQ(p.get(), "1, 2");
+
+  EXPECT_NO_THROW(p.set("1, 2, 3, 4"));
+  EXPECT_EQ(p.get(), "1, 2, 3, 4");
+}
+
+TEST(Padding2D, randomString_01_n) {
+  nntrainer::props::Padding2D p;
+  EXPECT_THROW(p.set("seme"), std::invalid_argument);
+}
+
+TEST(Padding2D, randomString_02_n) {
+  nntrainer::props::Padding2D p;
+  EXPECT_THROW(p.set("velid"), std::invalid_argument);
+}
+
+TEST(Padding2D, given_padding_of_three_n) {
+  nntrainer::props::Padding2D p;
+  EXPECT_THROW(p.set("1, 2, 3"), std::invalid_argument);
+}
+
+TEST(Padding2D, given_padding_is_negative_01_n) {
+  nntrainer::props::Padding2D p;
+  EXPECT_THROW(p.set("-1"), std::invalid_argument);
+}
+
+TEST(Padding2D, given_padding_is_negative_02_n) {
+  nntrainer::props::Padding2D p;
+  EXPECT_THROW(p.set("-1, 1"), std::invalid_argument);
+}
+
 /**
  * @brief Main gtest
  */


### PR DESCRIPTION
- [Padding] Add padding verification

```
This patch implements `Padding2D::isValid` and tests respectively.

Padding2D property is valid when
1. string is "valid" or "same"
2. comma seperated, non-integer value of size 1, 2, 4

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```