### PR TITLE
[pooling] Update to LayerV2 

### DIFF
--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -29,6 +29,7 @@
 namespace nntrainer {
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
+
 namespace {
 
 static TensorDim calcCol2ImOutputDim(const TensorDim &out,

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -29,6 +29,8 @@
 
 namespace nntrainer {
 
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
 void InputLayer::setProperty(const std::vector<std::string> &values) {
   /// @todo: deprecate this in favor of loadProperties
   for (unsigned int i = 0; i < values.size(); ++i) {
@@ -74,8 +76,8 @@ void InputLayer::setProperty(const std::string &type_str,
 }
 
 void InputLayer::forwarding(RunLayerContext &context, bool training) {
-  Tensor &hidden_ = context.getOutput(0);
-  hidden_ = context.getInput(0);
+  Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
+  hidden_ = context.getInput(SINGLE_INOUT_IDX);
 
   if (normalization)
     hidden_.normalization_i();

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -467,7 +467,7 @@ public:
    * @param idx index of the tensor (identifier)
    * @param batch Updated batch size
    */
-  void updateTensors(unsigned int idx, unsigned int batch) {
+  void updateTensor(unsigned int idx, unsigned int batch) {
     tensors[idx]->setBatchSize(batch);
   }
 

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -525,6 +525,22 @@ public:
    */
   const std::string &getName() const { return std::get<props::Name>(props); }
 
+  /**
+   * @brief   check if run context is set and is ready to use
+   *
+   * @return true if ready, else false
+   */
+  bool readyToUse() const {
+    /**
+     * assumption:
+     * 1. there must be atleast 1 input
+     * 2. the setter set everything at once
+     */
+    if (inputs.empty())
+      return false;
+    return !inputs[0]->getVariable().uninitialized();
+  }
+
 private:
   std::tuple<props::Name> props; /**< props of the layer */
   float loss;                    /**< loss of the layer */

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -430,12 +430,16 @@ void LayerNode::setBatch(unsigned int batch) {
   if (layerv1)
     layerv1->setBatch(batch);
   else {
+    run_context.setBatch(batch);
+    init_context.setBatch(batch);
+
     if (finalized) {
-      run_context.setBatch(batch);
-      layer->setBatch(run_context, batch);
-    } else {
-      init_context.setBatch(batch);
-      layer->setBatch(init_context, batch);
+      if (run_context.readyToUse()) {
+        layer->setBatch(run_context, batch);
+      } else {
+        /** run_context has not been created yet */
+        layer->setBatch(init_context, batch);
+      }
     }
   }
 }

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -90,8 +90,14 @@ void Pooling2DLayer::finalize(InitLayerContext &context) {
    * = 12 / 4 = 3
    * // clang-format on
    */
-  pool_helper_idx = context.requestTensor(out_dim, "Pooling2d::helper_idx",
-                                          false, ITERATION_LIFESPAN);
+  if (pooling_type == PoolingType::global_max) {
+    pool_helper_idx = context.requestTensor(in_dim, "Pooling2d::helper_idx",
+                                            false, ITERATION_LIFESPAN);
+    pool_helper_size.resize(in_dim.batch() * in_dim.channel());
+  } else {
+    pool_helper_idx = context.requestTensor(out_dim, "Pooling2d::helper_idx",
+                                            false, ITERATION_LIFESPAN);
+  }
 }
 
 void Pooling2DLayer::forwarding(RunLayerContext &context, bool training) {
@@ -105,7 +111,7 @@ void Pooling2DLayer::forwarding(RunLayerContext &context, bool training) {
     Tensor in_sub = input_.getBatchSlice(b, 1);
     Tensor result = hidden_.getBatchSlice(b, 1);
     Tensor helper = pool_helper.getBatchSlice(b, 1);
-    pooling2d(in_sub, training, result, helper);
+    pooling2d(in_sub, training, result, helper, b);
   }
 }
 
@@ -181,21 +187,20 @@ void Pooling2DLayer::calcDerivative(RunLayerContext &context) {
     }
   } break;
   case PoolingType::global_max: {
-    const int *iter = pool_helper.getData<int>();
     float *deriv_data = deriv.getData();
-    unsigned int outer_loop = batch * channel;
-    for (unsigned int _ = 0; _ < outer_loop; _++) {
-      for (unsigned int i = 0; i < out_map_size; ++i) {
-        float der = *deriv_data / pool_helper.length();
+    for (unsigned int b = 0; b < batch; b++) {
+      for (unsigned int c = 0; c < channel; c++) {
+        const int *iter =
+          pool_helper.getData<int>() + pool_helper.getIndex(b, c, 0, 0);
+        unsigned int helper_size = pool_helper_size[b * channel + c];
+        float der = *deriv_data / helper_size;
 
-        for (unsigned int idx = 0; idx < pool_helper.length(); idx++) {
+        for (unsigned int idx = 0; idx < helper_size; idx++)
           result_data[iter[idx]] += der;
-        }
 
-        iter++;
         deriv_data++;
+        result_data += in_map_size;
       }
-      result_data += in_map_size;
     }
   } break;
   default:
@@ -270,7 +275,7 @@ void Pooling2DLayer::setProperty(const std::string &type_str,
 }
 
 void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
-                               Tensor &pool_helper) {
+                               Tensor &pool_helper, int batch_idx) {
 
   unsigned int channel = in.channel();
   unsigned int pad_height = padding[0];
@@ -292,12 +297,13 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
    * @param start_w (width index pointing the start of the patch)
    * @return result value of pooling
    */
-  std::function<float(const float *, int, int)> pool_fn;
+  std::function<float(const float *, int, int, int)> pool_fn;
 
   unsigned int max_idx_count = 0;
   switch (pooling_type) {
   case PoolingType::max: {
-    pool_fn = [&, this](const float *in_data, int start_h, int start_w) {
+    pool_fn = [&, this](const float *in_data, int channel_idx, int start_h,
+                        int start_w) {
       int end_h = start_h + patch_height;
       int end_w = start_w + patch_width;
 
@@ -329,12 +335,14 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
     break;
   }
   case PoolingType::global_max: {
-    pool_fn = [&, this](const float *in_data, int start_h, int start_w) {
+    pool_fn = [&, this](const float *in_data, int channel_idx, int start_h,
+                        int start_w) {
       int end_h = start_h + patch_height;
       int end_w = start_w + patch_width;
 
       float max_val = std::numeric_limits<float>::lowest();
-      unsigned int orig_max_idx_count = max_idx_count;
+      int *helper_data = pool_helper.getData<int>();
+      helper_data += channel_idx * in_height * in_width;
 
       for (int h = start_h; h < end_h; ++h) {
         for (int w = start_w; w < end_w; ++w) {
@@ -342,22 +350,24 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
           float val = in_data[cur_idx];
           if (max_val < val) {
             max_val = val;
-            max_idx_count = orig_max_idx_count;
+            max_idx_count = 0;
           }
 
           if (training && max_val == val) {
-            pool_helper.setValueInt(max_idx_count++, cur_idx);
+            *(helper_data + max_idx_count++) = cur_idx;
           }
         }
       }
 
+      pool_helper_size[batch_idx * in.channel() + channel_idx] = max_idx_count;
       return max_val;
     };
     break;
   }
   case PoolingType::global_average:
   case PoolingType::average: {
-    pool_fn = [&, this](const float *in_data, int start_h, int start_w) {
+    pool_fn = [&, this](const float *in_data, int channel_idx, int start_h,
+                        int start_w) {
       int end_h = start_h + patch_height;
       int end_w = start_w + patch_width;
       float total = 0.0f;
@@ -399,7 +409,7 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
     const float *in_data_channel_sliced = in_data + i * map_size;
     for (int j = -pad_height; j <= heigth_stride_end; j += stride[0]) {
       for (int k = -pad_width; k <= width_stride_end; k += stride[1]) {
-        float pool_value = pool_fn(in_data_channel_sliced, j, k);
+        float pool_value = pool_fn(in_data_channel_sliced, i, j, k);
         *out_data = pool_value;
         out_data++;
       }

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -24,44 +24,34 @@
 
 namespace nntrainer {
 
-int Pooling2DLayer::initialize(Manager &manager) {
-  int status = ML_ERROR_NONE;
+static constexpr size_t SINGLE_INOUT_IDX = 0;
 
-  if (input_dim.size() != 1 || output_dim.size() != 1) {
-    ml_loge("[Pooling2D] pooling layer only takes one input");
-    return ML_ERROR_INVALID_PARAMETER;
+void Pooling2DLayer::finalize(InitLayerContext &context) {
+  if (context.getNumInputs() != 1) {
+    throw std::invalid_argument(
+      "[Pooling2D] pooling layer only takes one input");
   }
 
-  if (input_dim.size() != 1) {
-    ml_loge("[Pooling2D] pooling layer only accepts number of one layer");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-
-  TensorDim &in_dim = input_dim[0];
-  TensorDim &out_dim = output_dim[0];
-
-  if (in_dim.getDataLen() == 1) {
-    ml_logw("Warning: the length of previous layer dimension is one");
-  }
+  const TensorDim &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  TensorDim out_dim;
 
   if (pooling_type == PoolingType::global_max ||
       pooling_type == PoolingType::global_average) {
     if (pool_size[0] != 0 || pool_size[1] != 0) {
-      ml_loge(
+      throw std::invalid_argument(
         "[Pooling2D] global_max, global_average does not accept pool size");
-      return ML_ERROR_INVALID_PARAMETER;
     }
     pool_size[0] = in_dim.height();
     pool_size[1] = in_dim.width();
 
     if (padding[0] != 0 || padding[1] != 0) {
-      ml_loge("[Pooling2D] global_max, global_average does not accept padding");
-      return ML_ERROR_INVALID_PARAMETER;
+      throw std::invalid_argument(
+        "[Pooling2D] global_max, global_average does not accept padding");
     }
 
     if (stride[0] != 1 || stride[1] != 1) {
-      ml_loge("[Pooling2D] global_max, global_average does not accept stride");
-      return ML_ERROR_INVALID_PARAMETER;
+      throw std::invalid_argument(
+        "[Pooling2D] global_max, global_average does not accept stride");
     }
   }
 
@@ -69,48 +59,45 @@ int Pooling2DLayer::initialize(Manager &manager) {
   unsigned int eff_in_width = in_dim.width() + padding[1] * 2;
 
   if (eff_in_height < pool_size[0] || eff_in_width < pool_size[1]) {
-    ml_loge("[Pooling2D] Failed to initialize: in size + padding is smaller "
-            "than effective kernel");
-    return ML_ERROR_INVALID_PARAMETER;
+    throw std::invalid_argument(
+      "[Pooling2D] Failed to initialize: in size + padding is smaller "
+      "than effective kernel");
   }
 
   unsigned int IM = std::numeric_limits<int>::max();
 
   if (eff_in_height - padding[0] - pool_size[0] > IM ||
       eff_in_width - padding[1] - pool_size[1] > IM) {
-    ml_loge(
+    throw std::invalid_argument(
       "[Pooling2D] Failed to initialize: Calculated patch end is over int max");
-    return ML_ERROR_INVALID_PARAMETER;
   }
 
   out_dim.batch(in_dim.batch());
   out_dim.channel(in_dim.channel());
   out_dim.height((eff_in_height - pool_size[0]) / stride[0] + 1);
   out_dim.width((eff_in_width - pool_size[1]) / stride[1] + 1);
+  context.setOutputDimensions({out_dim});
 
   if (pooling_type == PoolingType::global_max) {
     max_idx_global.reserve(out_dim.batch() * out_dim.getFeatureLen());
   } else {
     max_idx.reserve(in_dim.batch() * out_dim.getFeatureLen());
   }
-
-  return status;
 }
 
-void Pooling2DLayer::setBatch(unsigned int batch) {
-  LayerV1::setBatch(batch);
+void Pooling2DLayer::setBatch(const TensorDim &output_dim, unsigned int batch) {
   if (pooling_type == PoolingType::max) {
-    max_idx.reserve(batch * output_dim[0].getFeatureLen());
+    max_idx.reserve(batch * output_dim.getFeatureLen());
   } else if (pooling_type == PoolingType::global_max) {
-    max_idx_global.resize(batch * output_dim[0].getFeatureLen());
+    max_idx_global.resize(batch * output_dim.getFeatureLen());
   }
 }
 
-void Pooling2DLayer::forwarding(bool training) {
-  Tensor &input_ = net_input[0]->getVariableRef();
-  Tensor &hidden_ = net_hidden[0]->getVariableRef();
+void Pooling2DLayer::forwarding(RunLayerContext &context, bool training) {
+  Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+  Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
 
-  TensorDim &in_dim = input_dim[0];
+  const TensorDim &in_dim = input_.getDim();
 
   if (training) {
     if (pooling_type == PoolingType::global_max) {
@@ -127,18 +114,19 @@ void Pooling2DLayer::forwarding(bool training) {
   }
 }
 
-void Pooling2DLayer::calcDerivative() {
-  unsigned int batch = input_dim[0].batch();
-  unsigned int channel = input_dim[0].channel();
-  int height = input_dim[0].height();
-  int width = input_dim[0].width();
+void Pooling2DLayer::calcDerivative(RunLayerContext &context) {
+  Tensor &deriv = context.getIncomingDerivative(SINGLE_INOUT_IDX);
+  Tensor &result = context.getOutgoingDerivative(SINGLE_INOUT_IDX);
+
+  const TensorDim &in_dim = result.getDim();
+  unsigned int batch = in_dim.batch();
+  unsigned int channel = in_dim.channel();
+  int height = in_dim.height();
+  int width = in_dim.width();
   unsigned int p_height = pool_size[0];
   unsigned int p_width = pool_size[1];
 
   unsigned int J, K;
-
-  Tensor &deriv = net_hidden[0]->getGradientRef();
-  Tensor &result = net_input[0]->getGradientRef();
 
   result.setZero();
   float *result_data = result.getData();
@@ -219,97 +207,73 @@ void Pooling2DLayer::calcDerivative() {
   }
 }
 
-int Pooling2DLayer::setSize(int *size, PropertyType type) {
-  int status = ML_ERROR_NONE;
-  switch (type) {
-  case PropertyType::pool_size:
-    for (int i = 0; i < POOLING2D_DIM; ++i) {
-      pool_size[i] = size[i];
+void Pooling2DLayer::setProperty(const std::vector<std::string> &values) {
+  /// @todo: deprecate this in favor of loadProperties
+  for (unsigned int i = 0; i < values.size(); ++i) {
+    std::string key;
+    std::string value;
+    std::stringstream ss;
+
+    if (getKeyValue(values[i], key, value) != ML_ERROR_NONE) {
+      throw std::invalid_argument("Error parsing the property: " + values[i]);
     }
-    break;
-  case PropertyType::stride:
-    for (int i = 0; i < POOLING2D_DIM; ++i) {
-      stride[i] = size[i];
+
+    if (value.empty()) {
+      ss << "value is empty: key: " << key << ", value: " << value;
+      throw std::invalid_argument(ss.str());
     }
-    break;
-  case PropertyType::padding:
-    for (int i = 0; i < POOLING2D_DIM; ++i) {
-      padding[i] = size[i];
-    }
-    break;
-  default:
-    ml_loge("Error: Unknown Layer Property type");
-    status = ML_ERROR_INVALID_PARAMETER;
-    break;
-  }
-  return status;
-}
 
-void Pooling2DLayer::copy(std::shared_ptr<LayerV1> l) {
-  LayerV1::copy(l);
-
-  std::shared_ptr<Pooling2DLayer> from =
-    std::static_pointer_cast<Pooling2DLayer>(l);
-
-  this->pooling_type = from->pooling_type;
-
-  for (unsigned int i = 0; i < POOLING2D_DIM; ++i) {
-    this->pool_size[i] = from->pool_size[i];
-    this->stride[i] = from->stride[i];
-    this->padding[i] = from->padding[i];
+    /// @note this calls derived setProperty if available
+    setProperty(key, value);
   }
 }
 
-void Pooling2DLayer::setProperty(const PropertyType type,
+void Pooling2DLayer::setProperty(const std::string &type_str,
                                  const std::string &value) {
+  using PropertyType = LayerV1::PropertyType;
   int status = ML_ERROR_NONE;
+  LayerV1::PropertyType type =
+    static_cast<LayerV1::PropertyType>(parseLayerProperty(type_str));
 
   switch (type) {
   case PropertyType::pooling:
-    if (!value.empty()) {
-      pooling_type = (PoolingType)parseType(value, TOKEN_POOLING);
-      if (pooling_type == PoolingType::unknown) {
-        throw std::invalid_argument("[Pooling2d_layer]: Unknown pooling type");
-      }
-      break;
+    pooling_type = (PoolingType)parseType(value, TOKEN_POOLING);
+    if (pooling_type == PoolingType::unknown) {
+      throw std::invalid_argument("[Pooling2d_layer]: Unknown pooling type");
     }
+    break;
   case PropertyType::pool_size:
-    if (!value.empty()) {
-      status = getValues(POOLING2D_DIM, value, (int *)(pool_size.data()));
-      throw_status(status);
-      if (pool_size[0] == 0 || pool_size[1] == 0) {
-        throw std::invalid_argument(
-          "[Pooling2d_layer] pool_size must be greater than 0");
-      }
+    status = getValues(POOLING2D_DIM, value, (int *)(pool_size.data()));
+    throw_status(status);
+    if (pool_size[0] == 0 || pool_size[1] == 0) {
+      throw std::invalid_argument(
+        "[Pooling2d_layer] pool_size must be greater than 0");
     }
     break;
   case PropertyType::stride:
-    if (!value.empty()) {
-      status = getValues(POOLING2D_DIM, value, (int *)(stride.data()));
-      throw_status(status);
-      if (stride[0] == 0 || stride[1] == 0) {
-        throw std::invalid_argument(
-          "[Pooling2d_layer] stride must be greater than 0");
-      }
+    status = getValues(POOLING2D_DIM, value, (int *)(stride.data()));
+    throw_status(status);
+    if (stride[0] == 0 || stride[1] == 0) {
+      throw std::invalid_argument(
+        "[Pooling2d_layer] stride must be greater than 0");
     }
     break;
   case PropertyType::padding:
-    if (!value.empty()) {
-      status = getValues(POOLING2D_DIM, value, (int *)(padding.data()));
-      throw_status(status);
-      if ((int)padding[0] < 0 || (int)padding[1] < 0) {
-        throw std::invalid_argument(
-          "[Pooling2d_layer] padding must be greater than 0");
-      }
+    status = getValues(POOLING2D_DIM, value, (int *)(padding.data()));
+    throw_status(status);
+    if ((int)padding[0] < 0 || (int)padding[1] < 0) {
+      throw std::invalid_argument(
+        "[Pooling2d_layer] padding must be greater than 0");
     }
     break;
   default:
-    LayerV1::setProperty(type, value);
-    break;
+    std::string msg = "[Pooling2DLayer] Unknown Layer Property Key for value " +
+                      std::string(value);
+    throw exception::not_supported(msg);
   }
 }
 
-Tensor Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output) {
+void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output) {
 
   unsigned int channel = in.channel();
   unsigned int pad_height = padding[0];
@@ -451,8 +415,6 @@ Tensor Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output) {
       }
     }
   }
-
-  return output;
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -129,49 +129,32 @@ public:
    * @copydoc Layer::setBatch(InitLayerContext &context, unsigned int batch)
    */
   void setBatch(InitLayerContext &context, unsigned int batch) override {
-    setBatch(context.getOutputDimensions()[0], batch);
+    context.updateTensorSpec(pool_helper_idx, batch);
   }
 
   /**
    * @copydoc Layer::setBatch(RunLayerContext &context, unsigned int batch)
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override {
-    setBatch(context.getOutput(0).getDim(), batch);
+    context.updateTensor(pool_helper_idx, batch);
   }
 
 private:
   std::array<unsigned int, POOLING2D_DIM> pool_size;
   std::array<unsigned int, POOLING2D_DIM> stride;
   std::array<unsigned int, POOLING2D_DIM> padding;
-  std::vector<int>
-    max_idx; /**< in case of max pool, idx that points to the first max item
-                  in case of avearge pol, effective average counter
-                  effective average counter is number of patches actually
-                  counted into when calculating the average
-                  // clang-format off
-                  eg) pooling of below
-                  x x x
-                  x 3 3
-                  x 3 3
-                  = 12 / 4 = 3
-                  // clang-format on
-              */
-  std::vector<std::vector<int>> max_idx_global;
+  unsigned int pool_helper_idx; /**< helper tensor idx */
   PoolingType pooling_type;
 
   /**
    * @brief     calculation convolution
    * @param[in] in input tensor (batch sliced)
    * @param[in] training check if training, if training this will memorize index
+   * @param[in] output output tensor (batch sliced)
+   * @param[in] pool_helper helper tensor (batch sliced)
    */
-  void pooling2d(Tensor &in, bool training, Tensor &output);
-
-  /**
-   * @brief     Helper function to set batch
-   * @param output_dim output dimension
-   * @param batch batch size
-   */
-  void setBatch(const TensorDim &output_dim, unsigned int batch);
+  void pooling2d(Tensor &in, bool training, Tensor &output,
+                 Tensor &pool_helper);
 
   /**
    * @brief setProperty by type and value separated

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -130,6 +130,9 @@ public:
    */
   void setBatch(InitLayerContext &context, unsigned int batch) override {
     context.updateTensorSpec(pool_helper_idx, batch);
+    if (pooling_type == PoolingType::global_max)
+      pool_helper_size.resize(batch *
+                              context.getInputDimensions()[0].channel());
   }
 
   /**
@@ -137,6 +140,8 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override {
     context.updateTensor(pool_helper_idx, batch);
+    if (pooling_type == PoolingType::global_max)
+      pool_helper_size.resize(batch * context.getInput(0).channel());
   }
 
 private:
@@ -144,6 +149,9 @@ private:
   std::array<unsigned int, POOLING2D_DIM> stride;
   std::array<unsigned int, POOLING2D_DIM> padding;
   unsigned int pool_helper_idx; /**< helper tensor idx */
+  std::vector<unsigned int>
+    pool_helper_size; /**< helper size for each elements in the case of
+                         global_max pooling */
   PoolingType pooling_type;
 
   /**
@@ -152,9 +160,10 @@ private:
    * @param[in] training check if training, if training this will memorize index
    * @param[in] output output tensor (batch sliced)
    * @param[in] pool_helper helper tensor (batch sliced)
+   * @param[in] batch_idx idx of the batch
    */
-  void pooling2d(Tensor &in, bool training, Tensor &output,
-                 Tensor &pool_helper);
+  void pooling2d(Tensor &in, bool training, Tensor &output, Tensor &pool_helper,
+                 int batch_idx);
 
   /**
    * @brief setProperty by type and value separated

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -15,20 +15,23 @@
 #define __POOLING2D_LAYER_H__
 #ifdef __cplusplus
 
-#include <layer_internal.h>
-#include <tensor.h>
 #include <vector>
 
-#define POOLING2D_DIM 2
+#include <layer_devel.h>
 
 namespace nntrainer {
+
+constexpr const unsigned int POOLING2D_DIM = 2;
 
 /**
  * @class   Pooling 2D Layer
  * @brief   Pooling 2D Layer
  */
-class Pooling2DLayer : public LayerV1 {
+class Pooling2DLayer : public Layer {
 public:
+  /**
+   * @brief   Pooling operation type class
+   */
   enum class PoolingType {
     max = 0,
     average = 1,
@@ -38,16 +41,25 @@ public:
   };
 
   /**
+   * @brief PaddingType Class
+   * @todo support keras type of padding
+   */
+  enum class PaddingType {
+    full = 0,
+    same = 1,
+    valid = 2,
+    unknown = 3,
+  };
+
+  /**
    * @brief     Constructor of Pooling 2D Layer
    */
-  template <typename... Args>
   Pooling2DLayer(
     PoolingType pooling_type_ = PoolingType::average,
     const std::array<unsigned int, POOLING2D_DIM> &pool_size_ = {0, 0},
     const std::array<unsigned int, POOLING2D_DIM> &stride_ = {1, 1},
-    const std::array<unsigned int, POOLING2D_DIM> &padding_ = {0, 0},
-    Args... args) :
-    LayerV1(args...),
+    const std::array<unsigned int, POOLING2D_DIM> &padding_ = {0, 0}) :
+    Layer(),
     pool_size(pool_size_),
     stride(stride_),
     padding(padding_),
@@ -56,7 +68,7 @@ public:
   /**
    * @brief     Destructor of Pooling 2D Layer
    */
-  ~Pooling2DLayer() {}
+  ~Pooling2DLayer() = default;
 
   /**
    *  @brief  Move constructor of Pooling 2D Layer.
@@ -71,72 +83,61 @@ public:
   Pooling2DLayer &operator=(Pooling2DLayer &&rhs) = default;
 
   /**
-   * @brief     initialize layer
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @copydoc Layer::finalize(InitLayerContext &context)
    */
-  int initialize(Manager &manager) override;
+  void finalize(InitLayerContext &context) override;
 
   /**
-   * @brief     Read Weight & Bias Data from file
-   * @param[in] file input stream file
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
-  void read(std::ifstream &file) override{};
+  void forwarding(RunLayerContext &context, bool training) override;
 
   /**
-   * @brief     Save Weight & Bias Data to file
-   * @param[in] file output stream file
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
-  void save(std::ofstream &file) override{};
+  void calcDerivative(RunLayerContext &context) override;
 
   /**
-   * @copydoc Layer::forwarding(bool training)
+   * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
    */
-  void forwarding(bool training = true) override;
-
-  /**
-   * @copydoc Layer::calcDerivative()
-   */
-  void calcDerivative() override;
-
-  /**
-   * @brief     copy layer
-   * @param[in] l layer to copy
-   */
-  void copy(std::shared_ptr<LayerV1> l) override;
-
-  /**
-   * @brief PaddingType Class
-   * @todo support keras type of padding
-   */
-  enum class PaddingType {
-    full = 0,
-    same = 1,
-    valid = 2,
-    unknown = 3,
-  };
+  void exportTo(Exporter &exporter,
+                const ExportMethods &method) const override {
+    Layer::exportTo(exporter, method);
+  }
 
   /**
    * @copydoc Layer::getType()
    */
   const std::string getType() const override { return Pooling2DLayer::type; };
 
-  using LayerV1::setProperty;
+  /**
+   * @copydoc Layer::supportBackwarding()
+   */
+  bool supportBackwarding() const { return true; }
+
+  using Layer::setProperty;
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)
    */
-  void setProperty(const PropertyType type,
-                   const std::string &value = "") override;
-
-  /**
-   * @brief Set the batch for the layer
-   * @param batch Batch value to be set
-   */
-  void setBatch(unsigned int batch) override;
+  void setProperty(const std::vector<std::string> &values) override;
 
   inline static const std::string type = "pooling2d";
+
+  /**
+   * @copydoc Layer::setBatch(InitLayerContext &context, unsigned int batch)
+   */
+  void setBatch(InitLayerContext &context, unsigned int batch) override {
+    setBatch(context.getOutputDimensions()[0], batch);
+  }
+
+  /**
+   * @copydoc Layer::setBatch(RunLayerContext &context, unsigned int batch)
+   */
+  void setBatch(RunLayerContext &context, unsigned int batch) override {
+    setBatch(context.getOutput(0).getDim(), batch);
+  }
 
 private:
   std::array<unsigned int, POOLING2D_DIM> pool_size;
@@ -162,24 +163,25 @@ private:
    * @brief     calculation convolution
    * @param[in] in input tensor (batch sliced)
    * @param[in] training check if training, if training this will memorize index
-   * @retval Tensor outoput tensor
    */
-  Tensor pooling2d(Tensor &in, bool training, Tensor &output);
+  void pooling2d(Tensor &in, bool training, Tensor &output);
 
   /**
-   * @brief     set Pooling Type
-   * @param[in] t pooling type
+   * @brief     Helper function to set batch
+   * @param output_dim output dimension
+   * @param batch batch size
    */
-  void setPoolingType(PoolingType t) { pooling_type = t; };
+  void setBatch(const TensorDim &output_dim, unsigned int batch);
 
   /**
-   * @brief     set Parameter Size
-   * @param[in] * size : size arrary
-   * @param[in] type : Property type
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @brief setProperty by type and value separated
+   * @param[in] type property type to be passed
+   * @param[in] value value to be passed
+   * @exception exception::not_supported     when property type is not valid for
+   * the particular layer
+   * @exception std::invalid_argument invalid argument
    */
-  int setSize(int *size, PropertyType type);
+  void setProperty(const std::string &type_str, const std::string &value);
 };
 
 } // namespace nntrainer

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -581,6 +581,8 @@ int NeuralNetwork::train(std::vector<std::string> values) {
 int NeuralNetwork::train_run() {
   int status = ML_ERROR_NONE;
 
+  // readModel()
+
   if (!continue_train) {
     epoch_idx = 0;
     iter = 0;

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -714,6 +714,27 @@ public:
   }
 
   /**
+   * @brief     Set the element value
+   * @param[in] offset offset from start location
+   * @param[in] value value to be stored
+   *
+   * @todo      This is a temporary workout. Remove this once multiple datatypes
+   * are supported.
+   */
+  void setValueInt(unsigned int offset, int value) noexcept {
+    int *data_int = (int *)data.get();
+    data_int[offset] = value;
+  }
+
+  /**
+   * @brief     Get int interpretable tensor
+   *
+   * @todo      This is a temporary workout. Remove this once multiple datatypes
+   * are supported.
+   */
+  template <typename T> const int *getData() const { return (int *)data.get(); }
+
+  /**
    * @brief     Fill the Tensor elements with value
    * @param[in] value value to be stored
    */
@@ -876,11 +897,17 @@ public:
 
   /**
    * @brief     return Data pointer of Tensor
-   * @retval    float pointer
+   * @retval    template T pointer (float pointer as default)
    */
-  float *getData() { return data.get(); }
+  template <typename T = float> T *getData() { return (T *)data.get(); }
 
-  const float *getData() const { return data.get(); }
+  /**
+   * @brief     return Data pointer of Tensor
+   * @retval    template T pointer (float pointer as default)
+   */
+  template <typename T = float> const T *getData() const {
+    return (T *)data.get();
+  }
 
   /**
    * @brief     i data index

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -962,10 +962,6 @@ public:
   const std::array<unsigned int, MAXDIM> getStrides() const noexcept {
     return strides;
   }
-
-  static constexpr float epsilon = 1e-5;
-
-private:
   /**
    * @brief Get linear index given the n-d index
    */
@@ -974,6 +970,9 @@ private:
     return (b * strides[0] + c * strides[1] + h * strides[2] + w * strides[3]);
   }
 
+  static constexpr float epsilon = 1e-5;
+
+private:
   struct BroadcastInfo;
 
   /**

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -7,6 +7,7 @@ test_target = [
   'unittest_layers_fully_connected.cpp',
   'unittest_layers_batch_normalization.cpp',
   'unittest_layers_convolution2d.cpp',
+  'unittest_layers_pooling2d.cpp',
   'unittest_layers_flatten.cpp',
 ]
 

--- a/test/unittest/layers/unittest_layers_pooling2d.cpp
+++ b/test/unittest/layers/unittest_layers_pooling2d.cpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_layers_pooling.cpp
+ * @date 6 July 2021
+ * @brief Pooling2d Layer Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include <layers_common_tests.h>
+#include <pooling2d_layer.h>
+
+auto semantic_pooling2d_max =
+  LayerSemanticsParamType(nntrainer::createLayer<nntrainer::Pooling2DLayer>,
+                          nntrainer::Pooling2DLayer::type,
+                          {"pooling=max", "pool_size=1,1"}, {}, 0, false);
+
+INSTANTIATE_TEST_CASE_P(Pooling2DMax, LayerSemantics,
+                        ::testing::Values(semantic_pooling2d_max));
+
+auto semantic_pooling2d_avg =
+  LayerSemanticsParamType(nntrainer::createLayer<nntrainer::Pooling2DLayer>,
+                          nntrainer::Pooling2DLayer::type,
+                          {"pooling=average", "pool_size=1,1"}, {}, 0, false);
+
+INSTANTIATE_TEST_CASE_P(Pooling2DAvg, LayerSemantics,
+                        ::testing::Values(semantic_pooling2d_avg));
+
+auto semantic_pooling2d_global_avg = LayerSemanticsParamType(
+  nntrainer::createLayer<nntrainer::Pooling2DLayer>,
+  nntrainer::Pooling2DLayer::type, {"pooling=global_average"}, {}, 0, false);
+
+INSTANTIATE_TEST_CASE_P(Pooling2DGlobalMax, LayerSemantics,
+                        ::testing::Values(semantic_pooling2d_global_avg));
+
+auto semantic_pooling2d_global_max = LayerSemanticsParamType(
+  nntrainer::createLayer<nntrainer::Pooling2DLayer>,
+  nntrainer::Pooling2DLayer::type, {"pooling=global_max"}, {}, 0, false);
+
+INSTANTIATE_TEST_CASE_P(Pooling2DGlobalAvg, LayerSemantics,
+                        ::testing::Values(semantic_pooling2d_global_max));

--- a/test/unittest/layers/unittest_layers_pooling2d.cpp
+++ b/test/unittest/layers/unittest_layers_pooling2d.cpp
@@ -16,32 +16,25 @@
 #include <layers_common_tests.h>
 #include <pooling2d_layer.h>
 
-auto semantic_pooling2d_max =
-  LayerSemanticsParamType(nntrainer::createLayer<nntrainer::Pooling2DLayer>,
-                          nntrainer::Pooling2DLayer::type,
-                          {"pooling=max", "pool_size=1,1"}, {}, 0, false);
-
-INSTANTIATE_TEST_CASE_P(Pooling2DMax, LayerSemantics,
-                        ::testing::Values(semantic_pooling2d_max));
+auto semantic_pooling2d_max = LayerSemanticsParamType(
+  nntrainer::createLayer<nntrainer::Pooling2DLayer>,
+  nntrainer::Pooling2DLayer::type, {"pooling=max", "pool_size=1,1"}, 0, false);
 
 auto semantic_pooling2d_avg =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::Pooling2DLayer>,
                           nntrainer::Pooling2DLayer::type,
-                          {"pooling=average", "pool_size=1,1"}, {}, 0, false);
-
-INSTANTIATE_TEST_CASE_P(Pooling2DAvg, LayerSemantics,
-                        ::testing::Values(semantic_pooling2d_avg));
+                          {"pooling=average", "pool_size=1,1"}, 0, false);
 
 auto semantic_pooling2d_global_avg = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::Pooling2DLayer>,
-  nntrainer::Pooling2DLayer::type, {"pooling=global_average"}, {}, 0, false);
-
-INSTANTIATE_TEST_CASE_P(Pooling2DGlobalMax, LayerSemantics,
-                        ::testing::Values(semantic_pooling2d_global_avg));
+  nntrainer::Pooling2DLayer::type, {"pooling=global_average"}, 0, false);
 
 auto semantic_pooling2d_global_max = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::Pooling2DLayer>,
-  nntrainer::Pooling2DLayer::type, {"pooling=global_max"}, {}, 0, false);
+  nntrainer::Pooling2DLayer::type, {"pooling=global_max"}, 0, false);
 
-INSTANTIATE_TEST_CASE_P(Pooling2DGlobalAvg, LayerSemantics,
-                        ::testing::Values(semantic_pooling2d_global_max));
+INSTANTIATE_TEST_CASE_P(Pooling2DMax, LayerSemantics,
+                        ::testing::Values(semantic_pooling2d_max,
+                                          semantic_pooling2d_avg,
+                                          semantic_pooling2d_global_max,
+                                          semantic_pooling2d_global_avg));

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -1272,7 +1272,7 @@ INSTANTIATE_TEST_CASE_P(
     mkModelTc(pooling_avg_same_padding_multi_stride, "3:1:1:10", 10),
     mkModelTc(pooling_avg_valid_padding, "3:1:1:10", 10),
     mkModelTc(pooling_global_avg, "3:1:1:10", 10),
-    // mkModelTc(pooling_global_max, "3:1:1:10", 10),
+    mkModelTc(pooling_global_max, "3:1:1:10", 10),
 
     /**< conv pool combined tests */
     mkModelTc(mnist_conv_cross, "3:1:1:10", 10),

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -1262,21 +1262,21 @@ INSTANTIATE_TEST_CASE_P(
     mkModelTc(conv_uneven_strides2, "3:1:1:10", 10),
     mkModelTc(conv_uneven_strides3, "3:1:1:10", 10),
     mkModelTc(conv_same_padding_multi_stride, "3:1:1:10", 10),
-    mkModelTc(conv_no_loss_validate, "3:1:1:10", 1)
+    mkModelTc(conv_no_loss_validate, "3:1:1:10", 1),
 
     /**< single pooling layer test */
-    // mkModelTc(pooling_max_same_padding, "3:1:1:10", 10),
-    // mkModelTc(pooling_max_same_padding_multi_stride, "3:1:1:10", 10),
-    // mkModelTc(pooling_max_valid_padding, "3:1:1:10", 10),
-    // mkModelTc(pooling_avg_same_padding, "3:1:1:10", 10),
-    // mkModelTc(pooling_avg_same_padding_multi_stride, "3:1:1:10", 10),
-    // mkModelTc(pooling_avg_valid_padding, "3:1:1:10", 10),
-    // mkModelTc(pooling_global_avg, "3:1:1:10", 10),
-    // mkModelTc(pooling_global_max, "3:1:1:10", 10),
+    mkModelTc(pooling_max_same_padding, "3:1:1:10", 10),
+    mkModelTc(pooling_max_same_padding_multi_stride, "3:1:1:10", 10),
+    mkModelTc(pooling_max_valid_padding, "3:1:1:10", 10),
+    mkModelTc(pooling_avg_same_padding, "3:1:1:10", 10),
+    mkModelTc(pooling_avg_same_padding_multi_stride, "3:1:1:10", 10),
+    mkModelTc(pooling_avg_valid_padding, "3:1:1:10", 10),
+    mkModelTc(pooling_global_avg, "3:1:1:10", 10),
+    mkModelTc(pooling_global_max, "3:1:1:10", 10),
 
     /**< conv pool combined tests */
-    // mkModelTc(mnist_conv_cross, "3:1:1:10", 10),
-    // mkModelTc(mnist_conv_cross_one_input, "1:1:1:10", 10),
+    mkModelTc(mnist_conv_cross, "3:1:1:10", 10),
+    mkModelTc(mnist_conv_cross_one_input, "1:1:1:10", 10)
 
     /**< augmentation layer */
 #if defined(ENABLE_DATA_AUGMENTATION_OPENCV)

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -1272,7 +1272,7 @@ INSTANTIATE_TEST_CASE_P(
     mkModelTc(pooling_avg_same_padding_multi_stride, "3:1:1:10", 10),
     mkModelTc(pooling_avg_valid_padding, "3:1:1:10", 10),
     mkModelTc(pooling_global_avg, "3:1:1:10", 10),
-    mkModelTc(pooling_global_max, "3:1:1:10", 10),
+    // mkModelTc(pooling_global_max, "3:1:1:10", 10),
 
     /**< conv pool combined tests */
     mkModelTc(mnist_conv_cross, "3:1:1:10", 10),


### PR DESCRIPTION
**Commit 1:**
Update pooling layer to Layerv2 design.
Corresponding unittests for common and models are added and enabled
respectively.

setBatch() for layer node has been updated.
Further, some minor updates have been added to layer context to check if
they are ready to use.

**Commit 2:**
Update pooling layer to use helper tensors.
Instead of using vector memory, pooling layer will now use tensors
managed with the nntrainer.

As the memory is supposed to be integer, this patch currently interprets
float memory as integer memory. Note that no tensor operation is
performed on this memory as it would corrupt the data. Manual reading
and writing of data is done as was done with vector, but memory
management is moved out of the pooling layer with this patch.

This can be done formally when other data types are supported with
tensor class.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>