### PR TITLE
[loss/unittest] Proper support for loss as layer

### DIFF
--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -383,6 +383,14 @@ private:
    * @brief Calculate the number of non-trainable layers at the start
    */
   void countNonTrainableLayersAtBegin();
+
+  /**
+   * @brief finalize already added loss layers
+   *
+   * @details This involves verify if the requirements of the added loss layers
+   * match and merging loss layers with activation layers if needed.
+   */
+  void finalizeLossLayer();
 };
 
 } // namespace nntrainer

--- a/nntrainer/utils/ini_wrapper.h
+++ b/nntrainer/utils/ini_wrapper.h
@@ -281,6 +281,17 @@ public:
   }
 
   /**
+   * @brief update a single section using operator+=
+   *
+   * @param string format of `sectionkey / propkey=val | propkey=val| ..`
+   * @return IniWrapper& ini wrapper
+   */
+  IniWrapper &operator+=(const IniSection &section_) {
+    sections.push_back(section_);
+    return *this;
+  }
+
+  /**
    * @brief update a single section using operator +
    *
    * @param rhs string representatioin to merge
@@ -288,6 +299,16 @@ public:
    */
   IniWrapper operator+(const std::string &rhs) const {
     return IniWrapper(*this) += rhs;
+  }
+
+  /**
+   * @brief update a single section using operator +
+   *
+   * @param rhs string representatioin to merge
+   * @return IniWrapper ini wrapper
+   */
+  IniWrapper operator+(const IniSection &section_) const {
+    return IniWrapper(*this) += section_;
   }
 
   /**

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -211,6 +211,14 @@ static nntrainer::IniSection dataset("DataSet", "BufferSize = 100 |"
                                                 "ValidData = valSet.dat |"
                                                 "LabelData = label.dat");
 
+static nntrainer::IniSection loss_cross("loss", "Type = cross");
+
+static nntrainer::IniSection loss_cross_softmax("loss", "Type = cross_softmax");
+
+static nntrainer::IniSection loss_cross_sigmoid("loss", "Type = cross_sigmoid");
+
+static nntrainer::IniSection loss_mse("loss", "Type = mse");
+
 static nntrainer::IniSection batch_normal("bn",
                                           "Type = batch_normalization |"
                                           "momentum = 1.2 |"
@@ -327,6 +335,14 @@ INSTANTIATE_TEST_CASE_P(
     mkIniTc("no_bufferSize_p", {nw_base_cross, adam, dataset + "-BufferSize", input, out+"input_layers=inputlayer"}, SUCCESS),
     mkIniTc("buffer_size_smaller_than_batch_size_p", {nw_base_cross, adam, dataset + "BufferSize=26", input, out+"input_layers=inputlayer"}, SUCCESS),
     mkIniTc("buffer_size_smaller_than_batch_size2_p", {nw_base_cross, adam, input, out+"input_layers=inputlayer", dataset + "BufferSize=26"}, SUCCESS),
+    mkIniTc("loss_layer1_p", {nw_base, adam, input + "-Activation", out + "-Activation", loss_mse}, SUCCESS),
+    mkIniTc("loss_layer2_p", {nw_base, adam, input + "-Activation", out, loss_mse}, SUCCESS),
+    mkIniTc("loss_layer3_n", {nw_base, adam, input + "-Activation", out + "-Activation", loss_cross}, INITFAIL | COMPFAIL),
+    mkIniTc("loss_layer4_p", {nw_base, adam, input + "-Activation", out, loss_cross}, SUCCESS),
+    mkIniTc("loss_layer5_p", {nw_base, adam, input + "-Activation", out + "-Activation", loss_cross_sigmoid}, SUCCESS),
+    mkIniTc("loss_layer6_p", {nw_base, adam, input + "-Activation", out, loss_cross_sigmoid}, SUCCESS),
+    mkIniTc("loss_layer7_p", {nw_base, adam, input + "-Activation", out + "-Activation", loss_cross_softmax}, SUCCESS),
+    mkIniTc("loss_layer8_p", {nw_base, adam, input + "-Activation", out, loss_cross_softmax}, SUCCESS),
 
   /**< half negative: init fail cases (1 positive and 4 negative cases) */
     mkIniTc("unknown_loss_n", {nw_base_cross + "loss = unknown", adam, input, out+"input_layers=inputlayer"}, COMPFAIL | INITFAIL),

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -656,6 +656,9 @@ using INI = nntrainer::IniWrapper;
  * Activation = softmax
  */
 // clang-format off
+
+// TODO: update some models to use loss at the end as a layer
+// and check for all cases
 INI fc_sigmoid_mse(
   "fc_sigmoid_mse",
   {nn_base + "loss=mse | batch_size = 3",

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -519,7 +519,9 @@ protected:
     auto param = GetParam();
 
     ini = std::get<0>(param);
+    /// remove the test number after double __
     name = ini.getName();
+    name = name.substr(0, name.find("__"));
     std::cout << "starting test case : " << name << "\n\n";
 
     label_dim = std::get<1>(param);
@@ -609,6 +611,9 @@ static std::string gru_base = "type = gru";
 static std::string pooling_base = "type = pooling2d | padding = 0,0";
 static std::string preprocess_flip_base = "type = preprocess_flip";
 static std::string preprocess_translate_base = "type = preprocess_translate";
+static std::string mse_base = "type = mse";
+static std::string cross_base = "type = cross";
+static std::string cross_softmax_base = "type = cross_softmax";
 
 static std::string adam_base = "optimizer=adam | beta1 = 0.9 | beta2 = 0.999 | "
                                "epsilon = 1e-7";
@@ -659,21 +664,33 @@ using INI = nntrainer::IniWrapper;
 
 // TODO: update some models to use loss at the end as a layer
 // and check for all cases
-INI fc_sigmoid_mse(
-  "fc_sigmoid_mse",
-  {nn_base + "loss=mse | batch_size = 3",
+
+INI fc_sigmoid_baseline(
+  "fc_sigmoid",
+  {nn_base + "batch_size = 3",
    sgd_base + "learning_rate = 1",
    I("input") + input_base + "input_shape = 1:1:3",
    I("dense") + fc_base + "unit = 5",
    I("act") + sigmoid_base,
-   I("dense_1") + fc_base + "unit = 10",
-   I("act_1") + softmax_base});
+   I("dense_1") + fc_base + "unit = 10"});
+
+INI fc_sigmoid_mse =
+  INI("fc_sigmoid_mse") + fc_sigmoid_baseline + softmax_base + "model/loss=mse";
+
+INI fc_sigmoid_mse__1 =
+  INI("fc_sigmoid_mse__1") + fc_sigmoid_baseline + softmax_base +  I("loss", mse_base);
 
 INI fc_sigmoid_cross =
-  INI("fc_sigmoid_cross") + fc_sigmoid_mse + "model/loss=cross";
+  INI("fc_sigmoid_cross") + fc_sigmoid_baseline + softmax_base + "model/loss=cross";
 
-INI fc_relu_mse(
-  "fc_relu_mse",
+INI fc_sigmoid_cross__1 =
+  INI("fc_sigmoid_cross__1") + fc_sigmoid_baseline + softmax_base + I("loss", cross_base);
+
+INI fc_sigmoid_cross__2 =
+  INI("fc_sigmoid_cross__2") + fc_sigmoid_baseline + I("loss", cross_softmax_base);
+
+INI fc_relu_baseline(
+  "fc_relu",
   {nn_base + "Loss=mse | batch_size = 3",
    sgd_base + "learning_rate = 0.1",
    I("input") + input_base + "input_shape = 1:1:3",
@@ -681,6 +698,12 @@ INI fc_relu_mse(
    I("act") + relu_base,
    I("dense_1") + fc_base + "unit = 2",
    I("act_1") + sigmoid_base + "input_layers=dense" + "input_layers=dense_1"});
+
+INI fc_relu_mse =
+  INI("fc_relu_mse") + fc_relu_baseline + "model/loss=mse";
+
+INI fc_relu_mse__1 =
+  INI("fc_relu_mse__1") + fc_relu_baseline + I("loss", mse_base);
 
 INI fc_bn_sigmoid_cross(
   "fc_bn_sigmoid_cross",
@@ -1264,8 +1287,11 @@ INI multi_gru_return_sequence_with_batch(
 INSTANTIATE_TEST_CASE_P(
   nntrainerModelAutoTests, nntrainerModelTest, ::testing::Values(
     mkModelTc(fc_sigmoid_mse, "3:1:1:10", 1),
+    mkModelTc(fc_sigmoid_mse__1, "3:1:1:10", 1),
     mkModelTc(fc_sigmoid_cross, "3:1:1:10", 1),
+    mkModelTc(fc_sigmoid_cross__1, "3:1:1:10", 1),
     mkModelTc(fc_relu_mse, "3:1:1:2", 1),
+    mkModelTc(fc_relu_mse__1, "3:1:1:2", 1),
     mkModelTc(fc_bn_sigmoid_cross, "3:1:1:10", 10),
     mkModelTc(fc_bn_sigmoid_mse, "3:1:1:10", 10)
     // mkModelTc(mnist_conv_cross, "3:1:1:10", 10),


### PR DESCRIPTION
Support for loss as a layer with the API has been done.
However, the verification of this feature was missing.
This patch ensures that the added loss layer is verified and its
required conditions checked before finalizing the graph.

Add loss layer unittests for various loss configurations to be
supported. These tests do not ensure correct graph formation.
This will be done soon with models unittest.

Add golden tests for loss layer added as a layer.
    This patch modified the existing models test architecture to be
    described where layer is added externally.
    
More will be added ones more models tests are enabled.


Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
cc. @zhoonit 