### PR TITLE
[layer] Enable addition and multiout layer for V2 design

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -101,8 +101,6 @@ public:
    * - pooling : max, average, global_max, global_average
    * - flatten : bool
    * - name : string (type)
-   * - num_inputs : unsigned int (minimum 1)
-   * - num_outputs : unsigned int (minimum 1)
    * - momentum : float,
    * - moving_mean_initializer : string (type),
    * - moving_variance_initializer : string (type),

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -17,7 +17,6 @@
 
 #include <acti_func.h>
 #include <layer_devel.h>
-#include <tensor.h>
 
 namespace nntrainer {
 

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -68,23 +68,4 @@ void AdditionLayer::calcDerivative() {
   }
 }
 
-void AdditionLayer::setProperty(const PropertyType type,
-                                const std::string &value) {
-  int status = ML_ERROR_NONE;
-
-  switch (type) {
-  case PropertyType::num_inputs: {
-    if (!value.empty()) {
-      unsigned int num_inputs;
-      status = setUint(num_inputs, value);
-      throw_status(status);
-      setNumInputs(num_inputs);
-    }
-  } break;
-  default:
-    LayerV1::setProperty(type, value);
-    break;
-  }
-}
-
 } /* namespace nntrainer */

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -86,15 +86,6 @@ public:
    */
   const std::string getType() const override { return AdditionLayer::type; };
 
-  using LayerV1::setProperty;
-
-  /**
-   * @copydoc Layer::setProperty(const PropertyType type, const std::string
-   * &value)
-   */
-  void setProperty(const PropertyType type,
-                   const std::string &value = "") override;
-
   inline static const std::string type = "addition";
 };
 

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -15,8 +15,7 @@
 #define __ADDITION_LAYER_H__
 #ifdef __cplusplus
 
-#include <layer_internal.h>
-#include <tensor.h>
+#include <layer_devel.h>
 
 namespace nntrainer {
 
@@ -24,15 +23,12 @@ namespace nntrainer {
  * @class   Addition Layer
  * @brief   Addition Layer
  */
-class AdditionLayer : public LayerV1 {
+class AdditionLayer : public Layer {
 public:
   /**
    * @brief     Constructor of Addition Layer
    */
-  template <typename... Args>
-  AdditionLayer(unsigned int num_inputs_ = 1, Args... args) : LayerV1(args...) {
-    setNumInputs(num_inputs_);
-  }
+  AdditionLayer() : Layer() {}
 
   /**
    * @brief     Destructor of Addition Layer
@@ -52,34 +48,35 @@ public:
   AdditionLayer &operator=(AdditionLayer &&rhs) = default;
 
   /**
-   * @brief     initialize layer
-   * @param[in] last last layer
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @copydoc Layer::finalize(InitLayerContext &context)
    */
-  int initialize(Manager &manager) override;
+  void finalize(InitLayerContext &context) override;
 
   /**
-   * @brief     Read Weight & Bias Data from file
-   * @param[in] file input stream file
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
-  void read(std::ifstream &file) override{};
+  void forwarding(RunLayerContext &context, bool training) override;
 
   /**
-   * @brief     Save Weight & Bias Data to file
-   * @param[in] file output stream file
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
-  void save(std::ofstream &file) override{};
+  void calcDerivative(RunLayerContext &context) override;
 
   /**
-   * @copydoc Layer::forwarding(bool training)
+   * @copydoc bool supportBackwarding() const
    */
-  void forwarding(bool training = true) override;
+  bool supportBackwarding() const override { return true; };
 
   /**
-   * @copydoc Layer::calcDerivative()
+   * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
    */
-  void calcDerivative() override;
+  void exportTo(Exporter &exporter,
+                const ExportMethods &method) const override {}
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -110,23 +110,4 @@ void ConcatLayer::calcDerivative() {
   }
 }
 
-void ConcatLayer::setProperty(const PropertyType type,
-                              const std::string &value) {
-  int status = ML_ERROR_NONE;
-
-  switch (type) {
-  case PropertyType::num_inputs: {
-    if (!value.empty()) {
-      unsigned int num_inputs;
-      status = setUint(num_inputs, value);
-      throw_status(status);
-      setNumInputs(num_inputs);
-    }
-  } break;
-  default:
-    LayerV1::setProperty(type, value);
-    break;
-  }
-}
-
 } /* namespace nntrainer */

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -81,15 +81,6 @@ public:
    */
   void calcDerivative() override;
 
-  using LayerV1::setProperty;
-
-  /**
-   * @copydoc Layer::setProperty(const PropertyType type, const std::string
-   * &value)
-   */
-  void setProperty(const PropertyType type,
-                   const std::string &value = "") override;
-
   /**
    * @copydoc Layer::getType()
    */

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -57,14 +57,16 @@ public:
    * @brief Construct a new Init Layer Context object
    *
    */
-  InitLayerContext() = default;
+  InitLayerContext() : InitLayerContext({}, 1) {}
 
   /**
    * @brief Construct a new Init Layer Context object
    *
    * @param dim Input dimensions for the layer
    */
-  InitLayerContext(const std::vector<TensorDim> &dim) : input_dim(dim) {}
+  InitLayerContext(const std::vector<TensorDim> &dim, unsigned int num_out) :
+    input_dim(dim),
+    num_outputs(num_out) {}
 
   /**
    * @brief Get the number of inputs for the layer
@@ -72,6 +74,13 @@ public:
    * @return unsigned int number of inputs
    */
   unsigned int getNumInputs() const { return input_dim.size(); }
+
+  /**
+   * @brief Get the number of inputs for the layer
+   *
+   * @return unsigned int number of inputs
+   */
+  unsigned int getNumOutputs() const { return num_outputs; }
 
   /**
    * @brief Get the Input Dimensions object
@@ -116,6 +125,8 @@ public:
    * @param out_dim the output dimension to set to
    */
   void setOutputDimensions(const std::vector<TensorDim> &out_dim) {
+    if (out_dim.size() != num_outputs)
+      throw std::invalid_argument("Mismatch number of outputs");
     output_dim = out_dim;
   }
 
@@ -231,6 +242,8 @@ private:
   std::vector<TensorSpec>
     tensors_spec; /**< Specification for the var_grad (trainable/non-trainable
                      variables) */
+
+  unsigned int num_outputs; /**< number of outputs for the layer */
 };
 
 /**

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -226,27 +226,25 @@ public:
    *            15. pooling : max, average, global_max, global_average
    *            16. flatten : bool
    *            17. name : string (type)
-   *            18. num_inputs : unsigned int (minimum 1)
-   *            19. num_outputs : unsigned int (minimum 1)
-   *            20. momentum : float,
-   *            21. moving_mean_initializer : string (type),
-   *            22. moving_variance_initializer : string (type),
-   *            23. gamma_initializer : string (type),
-   *            24. beta_initializer" : string (type)
-   *            25. modelfile : model file for loading config for backbone layer
-   *            26. input_layers : string (type)
-   *            27. output_layers : string (type)
-   *            28. trainable :
-   *            29. flip_direction
-   *            30. random_translate
-   *            31. in_dim : int ( input dimension for embedding layer )
-   *            32. out_dim : int ( output dimesion for embedding layer )
-   *            33. in_length : int ( input length for embedding layer )
-   *            34. recurrent_activation :  string (type) - lstm
-   *            35. distribute : bool
-   *            36. split_dimension : string (type)
-   *            37. return_sequences :  bool (type) - lstm
-   *            39. hidden_state_activation :  string (type) - lstm
+   *            18. momentum : float,
+   *            19. moving_mean_initializer : string (type),
+   *            20. moving_variance_initializer : string (type),
+   *            21. gamma_initializer : string (type),
+   *            22. beta_initializer" : string (type)
+   *            23. modelfile : model file for loading config for backbone layer
+   *            24. input_layers : string (type)
+   *            25. output_layers : string (type)
+   *            26. trainable :
+   *            27. flip_direction
+   *            28. random_translate
+   *            29. in_dim : int ( input dimension for embedding layer )
+   *            30. out_dim : int ( output dimesion for embedding layer )
+   *            31. in_length : int ( input length for embedding layer )
+   *            32. recurrent_activation :  string (type) - lstm
+   *            33. distribute : bool
+   *            34. split_dimension : string (type)
+   *            35. return_sequences :  bool (type) - lstm
+   *            36. hidden_state_activation :  string (type) - lstm
    */
   enum class PropertyType {
     input_shape = 0,
@@ -267,27 +265,25 @@ public:
     pooling = 15,
     flatten = 16,
     name = 17,
-    num_inputs = 18,
-    num_outputs = 19,
-    momentum = 20,
-    moving_mean_initializer = 21,
-    moving_variance_initializer = 22,
-    gamma_initializer = 23,
-    beta_initializer = 24,
-    modelfile = 25, /** model file for loading config for backbone layer */
-    input_layers = 26,
-    output_layers = 27,
-    trainable = 28,
-    flip_direction = 29,
-    random_translate = 30,
-    in_dim = 31,
-    out_dim = 32,
-    in_length = 33,
-    recurrent_activation = 34,
-    distribute = 35,
-    split_dimension = 36,
-    return_sequences = 37,
-    hidden_state_activation = 38,
+    momentum = 18,
+    moving_mean_initializer = 19,
+    moving_variance_initializer = 20,
+    gamma_initializer = 21,
+    beta_initializer = 22,
+    modelfile = 23, /** model file for loading config for backbone layer */
+    input_layers = 24,
+    output_layers = 25,
+    trainable = 26,
+    flip_direction = 27,
+    random_translate = 28,
+    in_dim = 29,
+    out_dim = 30,
+    in_length = 31,
+    recurrent_activation = 32,
+    distribute = 33,
+    split_dimension = 34,
+    return_sequences = 35,
+    hidden_state_activation = 36,
     unknown
   };
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -210,7 +210,7 @@ bool LayerNode::setProperty(const std::string &key, const std::string &value) {
       in_dim.batch(cache_batch_size);
       throw_status(status);
 
-      init_context = InitLayerContext(input_dim);
+      init_context = InitLayerContext(input_dim, init_context.getNumOutputs());
     }
   } break;
   case PropertyType::activation: {

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -334,12 +334,7 @@ public:
    * @brief     Get number of outputs
    * @retval    number of outputs
    */
-  unsigned int getNumOutputs() const {
-    if (finalized)
-      return init_context.getOutputDimensions().size();
-    else
-      return getNumOutputConnections();
-  }
+  unsigned int getNumOutputs() const { return init_context.getNumOutputs(); }
 
   /**
    * @brief Get the number of weights
@@ -407,6 +402,8 @@ public:
    */
   void addOutputLayers(const std::string &out_layer) {
     output_layers.push_back(out_layer);
+    init_context =
+      InitLayerContext(init_context.getInputDimensions(), output_layers.size());
     if (layerv1)
       layerv1->setNumOutputs(output_layers.size());
   }
@@ -430,6 +427,8 @@ public:
    */
   void setOutputLayers(const std::vector<std::string> &layers) {
     output_layers = layers;
+    init_context = InitLayerContext(init_context.getInputDimensions(),
+                                    std::max(output_layers.size(), 1ul));
     if (layerv1)
       layerv1->setNumOutputs(layers.size());
   }
@@ -682,7 +681,7 @@ public:
     std::vector<TensorDim> input_dim = init_context.getInputDimensions();
     if (input_dim[idx] != dim) {
       input_dim[idx] = dim;
-      init_context = InitLayerContext(input_dim);
+      init_context = InitLayerContext(input_dim, init_context.getNumOutputs());
     }
   }
 
@@ -765,7 +764,8 @@ private:
     auto cur_input_dim = init_context.getInputDimensions();
     if (cur_input_dim.size() != size) {
       cur_input_dim.resize(size);
-      init_context = InitLayerContext(cur_input_dim);
+      init_context =
+        InitLayerContext(cur_input_dim, init_context.getNumOutputs());
     }
   }
 };

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -427,8 +427,9 @@ public:
    */
   void setOutputLayers(const std::vector<std::string> &layers) {
     output_layers = layers;
-    init_context = InitLayerContext(init_context.getInputDimensions(),
-                                    std::max(output_layers.size(), 1ul));
+    init_context =
+      InitLayerContext(init_context.getInputDimensions(),
+                       std::max((unsigned int)output_layers.size(), 1u));
     if (layerv1)
       layerv1->setNumOutputs(layers.size());
   }

--- a/nntrainer/layers/output_layer.cpp
+++ b/nntrainer/layers/output_layer.cpp
@@ -59,23 +59,4 @@ void OutputLayer::calcDerivative() {
   }
 }
 
-void OutputLayer::setProperty(const PropertyType type,
-                              const std::string &value) {
-  int status = ML_ERROR_NONE;
-
-  switch (type) {
-  case PropertyType::num_outputs: {
-    if (!value.empty()) {
-      unsigned int num_outputs;
-      status = setUint(num_outputs, value);
-      throw_status(status);
-      setNumOutputs(num_outputs);
-    }
-  } break;
-  default:
-    LayerV1::setProperty(type, value);
-    break;
-  }
-}
-
 } /* namespace nntrainer */

--- a/nntrainer/layers/output_layer.cpp
+++ b/nntrainer/layers/output_layer.cpp
@@ -21,41 +21,39 @@
 
 namespace nntrainer {
 
-int OutputLayer::initialize(Manager &manager) {
-  int status = ML_ERROR_NONE;
+static constexpr size_t SINGLE_INOUT_IDX = 0;
 
-  if (getNumInputs() == 0) {
-    ml_loge("Error: number of inputs are not initialized");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
+void OutputLayer::finalize(InitLayerContext &context) {
+  std::vector<TensorDim> out_dims(context.getNumOutputs());
+  const TensorDim &in_dim = context.getInputDimensions()[0];
 
-  // TODO : get output dimensions and set accordingly.
-  //        for now, it's just copy of input dim.
-
-  for (unsigned int idx = 0; idx < getNumOutputs(); ++idx) {
-    output_dim[idx] = input_dim[0];
-  }
-
-  return status;
+  std::fill(out_dims.begin(), out_dims.end(), in_dim);
+  context.setOutputDimensions(out_dims);
 }
 
-void OutputLayer::forwarding(bool training) {
-  Tensor &input_ = net_input[0]->getVariableRef();
-  for (unsigned int idx = 0; idx < getNumOutputs(); ++idx) {
-    net_hidden[idx]->getVariableRef() = input_;
+void OutputLayer::forwarding(RunLayerContext &context, bool training) {
+  const Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+  for (unsigned int idx = 0; idx < context.getNumOutputs(); ++idx) {
+    context.getOutput(idx) = input_;
   }
 }
 
-void OutputLayer::calcDerivative() {
-
-  Tensor &ret = net_input[0]->getGradientRef();
-
-  for (unsigned int idx = 0; idx < getNumOutputs(); ++idx) {
+void OutputLayer::calcDerivative(RunLayerContext &context) {
+  Tensor &ret = context.getOutgoingDerivative(SINGLE_INOUT_IDX);
+  for (unsigned int idx = 0; idx < context.getNumOutputs(); ++idx) {
     if (idx == 0) {
-      ret.fill(net_hidden[idx]->getGradientRef(), false);
+      ret.copy(context.getIncomingDerivative(idx));
     } else {
-      ret.add_i(net_hidden[idx]->getGradientRef());
+      ret.add_i(context.getIncomingDerivative(idx));
     }
+  }
+}
+
+void OutputLayer::setProperty(const std::vector<std::string> &values) {
+  if (!values.empty()) {
+    std::string msg = "[FlattenLayer] Unknown Layer Properties count " +
+                      std::to_string(values.size());
+    throw exception::not_supported(msg);
   }
 }
 

--- a/nntrainer/layers/output_layer.h
+++ b/nntrainer/layers/output_layer.h
@@ -9,14 +9,14 @@
  * @bug         No known bugs except for NYI items
  * @brief       This is Multi Output Layer Class for Neural Network
  *
+ * @todo        Support inplace for this layer
  */
 
 #ifndef __OUTPUT_LAYER_H__
 #define __OUTPUT_LAYER_H__
 #ifdef __cplusplus
 
-#include <layer_internal.h>
-#include <tensor.h>
+#include <layer_devel.h>
 
 namespace nntrainer {
 
@@ -24,20 +24,17 @@ namespace nntrainer {
  * @class   Output Layer
  * @brief   Output Layer
  */
-class OutputLayer : public LayerV1 {
+class OutputLayer : public Layer {
 public:
   /**
    * @brief     Constructor of Output Layer
    */
-  template <typename... Args>
-  OutputLayer(unsigned int num_output_ = 1, Args... args) : LayerV1(args...) {
-    setNumOutputs(num_output_);
-  }
+  OutputLayer() : Layer() {}
 
   /**
    * @brief     Destructor of Output Layer
    */
-  ~OutputLayer(){};
+  ~OutputLayer() = default;
 
   /**
    *  @brief  Move constructor of OutputLayer.
@@ -52,33 +49,35 @@ public:
   OutputLayer &operator=(OutputLayer &&rhs) = default;
 
   /**
-   * @brief     initialize layer
-   * @param[in] last last layer
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @copydoc Layer::finalize(InitLayerContext &context)
    */
-  int initialize(Manager &manager) override;
+  void finalize(InitLayerContext &context) override;
 
   /**
-   * @brief     Read Weight & Bias Data from file
-   * @param[in] file input stream file
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
-  void read(std::ifstream &file) override{};
+  void forwarding(RunLayerContext &context, bool training) override;
 
   /**
-   * @brief     Save Weight & Bias Data to file
-   * @param[in] file output stream file
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
-  void save(std::ofstream &file) override{};
+  void calcDerivative(RunLayerContext &context) override;
 
   /**
-   * @copydoc Layer::forwarding(bool training)
+   * @copydoc bool supportBackwarding() const
    */
-  void forwarding(bool training = true) override;
+  bool supportBackwarding() const override { return true; };
+
   /**
-   * @copydoc Layer::calcDerivative()
+   * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
    */
-  void calcDerivative() override;
+  void exportTo(Exporter &exporter,
+                const ExportMethods &method) const override {}
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/output_layer.h
+++ b/nntrainer/layers/output_layer.h
@@ -84,7 +84,7 @@ public:
    */
   const std::string getType() const override { return OutputLayer::type; };
 
-  inline static const std::string type = "output";
+  inline static const std::string type = "multiout";
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/output_layer.h
+++ b/nntrainer/layers/output_layer.h
@@ -81,13 +81,6 @@ public:
   void calcDerivative() override;
 
   /**
-   * @copydoc Layer::setProperty(const PropertyType type, const std::string
-   * &value)
-   */
-  void setProperty(const PropertyType type,
-                   const std::string &value = "") override;
-
-  /**
    * @copydoc Layer::getType()
    */
   const std::string getType() const override { return OutputLayer::type; };

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -209,27 +209,25 @@ unsigned int parseType(std::string ll, InputType t) {
  * pooling = 15
  * flatten = 16
  * name = 17
- * num_inputs = 18
- * num_outputs = 19
- * momentum = 20
- * moving_mean_initializer = 21
- * moving_variance_initializer = 22
- * gamma_initializer = 23
- * beta_initializer = 24
- * modelfile = 25
- * input_layers = 26
- * output_layers = 27
- * trainable = 28
- * flip_direction = 29
- * random_tranlate = 30
- * in_dim = 31
- * out_dim = 32
- * in_length = 33
- * recurrent_activation = 34
- * distribute = 35
- * split_dimension = 36
- * return_sequences = 37
- * hidden_state_activation = 38
+ * momentum = 18
+ * moving_mean_initializer = 19
+ * moving_variance_initializer = 20
+ * gamma_initializer = 21
+ * beta_initializer = 22
+ * modelfile = 23
+ * input_layers = 24
+ * output_layers = 25
+ * trainable = 26
+ * flip_direction = 27
+ * random_translate = 28
+ * in_dim = 29
+ * out_dim = 30
+ * in_length = 31
+ * recurrent_activation = 32
+ * distribute = 33
+ * split_dimension = 34
+ * return_sequences = 35
+ * hidden_state_activation = 36
  *
  * InputLayer has 0, 1, 2, 3 properties.
  * FullyConnectedLayer has 1, 4, 6, 7, 8, 9 properties.
@@ -237,7 +235,7 @@ unsigned int parseType(std::string ll, InputType t) {
  * Pooling2DLayer has 12, 13, 14, 15 properties.
  * BatchNormalizationLayer has 0, 1, 5, 6, 7 properties.
  */
-static std::array<std::string, 40> property_string = {
+static std::array<std::string, 38> property_string = {
   "input_shape",
   "normalization",
   "standardization",
@@ -256,8 +254,6 @@ static std::array<std::string, 40> property_string = {
   "pooling",
   "flatten",
   "name",
-  "num_inputs",
-  "num_outputs",
   "momentum",
   "moving_mean_initializer",
   "moving_variance_initializer",

--- a/test/tizen_capi/unittest_tizen_capi_layer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_layer.cpp
@@ -286,13 +286,7 @@ INSTANTIATE_TEST_CASE_P(
          false),
     mkTc(ML_TRAIN_LAYER_TYPE_FLATTEN, {"name=flat"}, true),
     mkTc(ML_TRAIN_LAYER_TYPE_ACTIVATION, {"activation=relu"}, true),
-    mkTc(ML_TRAIN_LAYER_TYPE_ACTIVATION, {"activation=undef"}, false),
-    mkTc(ML_TRAIN_LAYER_TYPE_ADDITION, {"num_inputs=2"}, true),
-    mkTc(ML_TRAIN_LAYER_TYPE_ADDITION, {"num_inputs=0"}, false),
-    mkTc(ML_TRAIN_LAYER_TYPE_CONCAT, {"num_inputs=2"}, true),
-    mkTc(ML_TRAIN_LAYER_TYPE_CONCAT, {"num_inputs=0"}, false),
-    mkTc(ML_TRAIN_LAYER_TYPE_MULTIOUT, {"num_outputs=0"}, false),
-    mkTc(ML_TRAIN_LAYER_TYPE_MULTIOUT, {"num_outputs=2"}, true)));
+    mkTc(ML_TRAIN_LAYER_TYPE_ACTIVATION, {"activation=undef"}, false)));
 
 /**
  * @brief Main gtest

--- a/test/unittest/layers/layers_dependent_common_tests.cpp
+++ b/test/unittest/layers/layers_dependent_common_tests.cpp
@@ -42,13 +42,16 @@ TEST_P(LayerSemantics, setPropertiesInvalid_n) {
 TEST_P(LayerSemantics, finalizeOutputValidateLayerNode_p) {
   auto lnode = nntrainer::createLayerNode(expected_type);
   lnode->setProperty({"input_shape=1:1:1", "name=test"});
+  // /** purpose is to set number of outputs to 1 */
+  // lnode->setOutputLayers({"dummy"});
   EXPECT_NO_THROW(lnode->setProperty(valid_properties));
 
   if (!must_fail) {
     EXPECT_NO_THROW(lnode->finalize());
 
     auto &init_context = lnode->getInitContext();
-    EXPECT_GT(init_context.getOutputDimensions().size(), 0);
+    EXPECT_EQ(init_context.getOutputDimensions().size(),
+              init_context.getNumOutputs());
 
     for (auto const &dim : init_context.getOutputDimensions())
       EXPECT_GT(dim.getDataLen(), 0);

--- a/test/unittest/layers/layers_standalone_common_tests.cpp
+++ b/test/unittest/layers/layers_standalone_common_tests.cpp
@@ -44,7 +44,7 @@ TEST_P(LayerSemantics, setPropertiesValidInvalidOnly_n) {}
 TEST_P(LayerSemantics, finalizeOutputValidate_p) {
   nntrainer::TensorDim in_dim({1, 1, 1, 1});
   nntrainer::InitLayerContext init_context =
-    nntrainer::InitLayerContext({in_dim});
+    nntrainer::InitLayerContext({in_dim}, 1);
   EXPECT_EQ(init_context.validate(), true);
 
   // set necessary properties only
@@ -53,7 +53,8 @@ TEST_P(LayerSemantics, finalizeOutputValidate_p) {
   if (!must_fail) {
     EXPECT_NO_THROW(layer->finalize(init_context));
 
-    EXPECT_GT(init_context.getOutputDimensions().size(), 0);
+    EXPECT_EQ(init_context.getOutputDimensions().size(),
+              init_context.getNumOutputs());
 
     for (auto const &dim : init_context.getOutputDimensions())
       EXPECT_GT(dim.getDataLen(), 0);

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -10,6 +10,7 @@ test_target = [
   'unittest_layers_pooling2d.cpp',
   'unittest_layers_flatten.cpp',
   'unittest_layers_activation.cpp',
+  'unittest_layers_addition.cpp',
 ]
 
 exe = executable(

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -11,6 +11,7 @@ test_target = [
   'unittest_layers_flatten.cpp',
   'unittest_layers_activation.cpp',
   'unittest_layers_addition.cpp',
+  'unittest_layers_multiout.cpp',
 ]
 
 exe = executable(

--- a/test/unittest/layers/unittest_layers_addition.cpp
+++ b/test/unittest/layers/unittest_layers_addition.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_layers_fully_connected.cpp
+ * @date 7 July 2021
+ * @brief Addition Layer Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include <addition_layer.h>
+#include <layers_common_tests.h>
+
+auto semantic_addition =
+  LayerSemanticsParamType(nntrainer::createLayer<nntrainer::AdditionLayer>,
+                          nntrainer::AdditionLayer::type, {}, {}, 0, false);
+
+INSTANTIATE_TEST_CASE_P(Addition, LayerSemantics,
+                        ::testing::Values(semantic_addition));

--- a/test/unittest/layers/unittest_layers_addition.cpp
+++ b/test/unittest/layers/unittest_layers_addition.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_addition =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::AdditionLayer>,
-                          nntrainer::AdditionLayer::type, {}, {}, 0, false);
+                          nntrainer::AdditionLayer::type, {}, 0, false);
 
 INSTANTIATE_TEST_CASE_P(Addition, LayerSemantics,
                         ::testing::Values(semantic_addition));

--- a/test/unittest/layers/unittest_layers_addition.cpp
+++ b/test/unittest/layers/unittest_layers_addition.cpp
@@ -2,7 +2,7 @@
 /**
  * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file unittest_layers_fully_connected.cpp
+ * @file unittest_layers_addition.cpp
  * @date 7 July 2021
  * @brief Addition Layer Test
  * @see	https://github.com/nnstreamer/nntrainer

--- a/test/unittest/layers/unittest_layers_multiout.cpp
+++ b/test/unittest/layers/unittest_layers_multiout.cpp
@@ -2,7 +2,7 @@
 /**
  * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file unittest_layers_output.cpp
+ * @file unittest_layers_multiout.cpp
  * @date 7 July 2021
  * @brief Output Layer Test
  * @see	https://github.com/nnstreamer/nntrainer
@@ -18,7 +18,7 @@
 
 auto semantic_output =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::OutputLayer>,
-                          nntrainer::OutputLayer::type, {}, {}, 0, false);
+                          nntrainer::OutputLayer::type, {}, 0, false);
 
 INSTANTIATE_TEST_CASE_P(Output, LayerSemantics,
                         ::testing::Values(semantic_output));

--- a/test/unittest/layers/unittest_layers_multiout.cpp
+++ b/test/unittest/layers/unittest_layers_multiout.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_layers_output.cpp
+ * @date 7 July 2021
+ * @brief Output Layer Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include <layers_common_tests.h>
+#include <output_layer.h>
+
+auto semantic_output =
+  LayerSemanticsParamType(nntrainer::createLayer<nntrainer::OutputLayer>,
+                          nntrainer::OutputLayer::type, {}, {}, 0, false);
+
+INSTANTIATE_TEST_CASE_P(Output, LayerSemantics,
+                        ::testing::Values(semantic_output));

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -33,7 +33,7 @@ test_target = [
   'unittest_databuffer_file',
   'unittest_nntrainer_modelfile',
   'unittest_nntrainer_models',
-  # 'unittest_nntrainer_graph',
+  'unittest_nntrainer_graph',
   'unittest_nntrainer_appcontext',
   'unittest_base_properties',
   'unittest_common_properties'

--- a/test/unittest/unittest_nntrainer_graph.cpp
+++ b/test/unittest/unittest_nntrainer_graph.cpp
@@ -152,7 +152,7 @@ static nntrainer::IniSection pooling2("pooling2", "Type = pooling2d |"
                                                   "padding = 0, 0 |"
                                                   "pooling=max");
 
-static nntrainer::IniSection out0("out0", "Type = output |"
+static nntrainer::IniSection out0("out0", "Type = multiout |"
                                           "input_layers = pooling2");
 
 static nntrainer::IniSection conv2d10("conv2d10", "Type = conv2d |"
@@ -177,7 +177,7 @@ static nntrainer::IniSection addition0("addition0",
                                        "Type=addition |"
                                        "input_layers = conv2d11, out0 ");
 
-static nntrainer::IniSection out1("out1", "Type = output |"
+static nntrainer::IniSection out1("out1", "Type = multiout |"
                                           "input_layers = addition0");
 
 static nntrainer::IniSection conv2d12("conv2d12", "Type = conv2d |"

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -2179,7 +2179,6 @@ class nntrainer_AdditionLayer
   : public nntrainer_abstractLayer<nntrainer::AdditionLayer> {
 protected:
   virtual void prepareLayer() {
-    setProperty("num_inputs=1");
     setInputDim("3:28:28");
     setBatch(32);
   }
@@ -2202,21 +2201,8 @@ TEST_F(nntrainer_AdditionLayer, checkValidation_01_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
-TEST_F(nntrainer_AdditionLayer, setProperty_01_p) {
-  setProperty("num_inputs=10");
-  status = layer.initialize(manager);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-}
-
-TEST_F(nntrainer_AdditionLayer, setProperty_02_n) {
-  status = layer.setProperty({"num_inputs=0"});
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-}
-
 // Disabled until input_layer keyward is enabled.
 TEST_F(nntrainer_AdditionLayer, DISABLED_forwarding_02_n) {
-  setProperty("num_inputs=2");
-
   sharedTensor input = std::shared_ptr<nntrainer::Tensor>(
     new nntrainer::Tensor[1], std::default_delete<nntrainer::Tensor[]>());
   nntrainer::Tensor &in = *input;
@@ -2237,8 +2223,6 @@ TEST_F(nntrainer_AdditionLayer, DISABLED_forwarding_02_n) {
 }
 
 TEST_F(nntrainer_AdditionLayer, DISABLED_forwarding_03_p) {
-  setProperty("num_inputs=2");
-
   sharedTensor input = std::shared_ptr<nntrainer::Tensor>(
     new nntrainer::Tensor[2], std::default_delete<nntrainer::Tensor[]>());
   nntrainer::Tensor &in = *input;

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -1305,7 +1305,7 @@ INSTANTIATE_TEST_CASE_P(
 
     /**< conv pool combined tests */
     mkModelTc(mnist_conv_cross, "3:1:1:10", 10),
-    mkModelTc(mnist_conv_cross_one_input, "1:1:1:10", 10)
+    mkModelTc(mnist_conv_cross_one_input, "1:1:1:10", 10),
 
     /**< augmentation layer */
 #if defined(ENABLE_DATA_AUGMENTATION_OPENCV)
@@ -1314,7 +1314,7 @@ INSTANTIATE_TEST_CASE_P(
     // mkModelTc(preprocess_flip_validate, "3:1:1:10", 10),
 
     /**< Addition test */
-    // mkModelTc(addition_resnet_like, "3:1:1:10", 10),
+    mkModelTc(addition_resnet_like, "3:1:1:10", 10)
 
     /// #1192 time distribution inference bug
     // mkModelTc(fc_softmax_mse_distribute_validate, "3:1:5:3", 1),


### PR DESCRIPTION
Update addition and multioutput layer for V2 design.
Add corresponding unittests.

Enable graph unittests which creates resnet like model for testing.
Enable correspoding resnet like add in models unittest.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>