### PR TITLE
[dataset] Remove label data

### DIFF
--- a/Applications/SimpleShot/task_runner.cpp
+++ b/Applications/SimpleShot/task_runner.cpp
@@ -219,7 +219,6 @@ int main(int argc, char **argv) {
   std::string method = argv[2];
   std::string train_path = app_path + "/tasks/" + argv[3];
   std::string val_path = app_path + "/tasks/" + argv[4];
-  std::string label_path = app_path + "/tasks/labels.dat";
 
   try {
     app_context.registerFactory(
@@ -244,10 +243,9 @@ int main(int argc, char **argv) {
 
   std::shared_ptr<ml::train::Dataset> train_dataset;
   try {
-    train_dataset = ml::train::createDataset(ml::train::DatasetType::FILE,
-                                             {"train_data=" + train_path,
-                                              "val_data=" + val_path,
-                                              "label_data=" + label_path});
+    train_dataset = ml::train::createDataset(
+      ml::train::DatasetType::FILE,
+      {"train_data=" + train_path, "val_data=" + val_path});
   } catch (...) {
     std::cerr << "creating dataset failed";
     return 1;

--- a/Applications/SimpleShot/tasks/labels.dat
+++ b/Applications/SimpleShot/tasks/labels.dat
@@ -1,5 +1,0 @@
-tractor
-turtle
-squirrel
-willow_tree
-sunflower

--- a/api/ccapi/include/dataset.h
+++ b/api/ccapi/include/dataset.h
@@ -46,13 +46,11 @@ enum class DatasetType {
 
 /**
  * @brief     Enumeration of data type
- * @todo      deperecate data label
  */
 enum class DatasetDataType {
   DATA_TRAIN = ML_TRAIN_DATASET_DATA_USAGE_TRAIN, /** data for training */
   DATA_VAL = ML_TRAIN_DATASET_DATA_USAGE_VALID,   /** data for validation */
   DATA_TEST = ML_TRAIN_DATASET_DATA_USAGE_TEST,   /** data for test */
-  DATA_LABEL,                                     /** label names */
   DATA_UNKNOWN                                    /** data not known */
 };
 

--- a/nntrainer/dataset/databuffer.cpp
+++ b/nntrainer/dataset/databuffer.cpp
@@ -301,13 +301,8 @@ bool DataBuffer::getDataFromBuffer(BufferType type, float *out, float *label) {
 
 int DataBuffer::setClassNum(unsigned int num) {
   int status = ML_ERROR_NONE;
-  if (num <= 0) {
+  if (num == 0) {
     ml_loge("Error: number of class should be bigger than 0");
-    SET_VALIDATION(false);
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-  if (class_num != 0 && class_num != num) {
-    ml_loge("Error: number of class should be same with number of label label");
     SET_VALIDATION(false);
     return ML_ERROR_INVALID_PARAMETER;
   }

--- a/nntrainer/dataset/databuffer.h
+++ b/nntrainer/dataset/databuffer.h
@@ -50,8 +50,7 @@ typedef enum {
     (int)ml::train::DatasetDataType::DATA_TRAIN, /** data for training */
   DATA_VAL =
     (int)ml::train::DatasetDataType::DATA_VAL, /** data for validation */
-  DATA_TEST = (int)ml::train::DatasetDataType::DATA_TEST,   /** data for test */
-  DATA_LABEL = (int)ml::train::DatasetDataType::DATA_LABEL, /** label names */
+  DATA_TEST = (int)ml::train::DatasetDataType::DATA_TEST, /** data for test */
   DATA_UNKNOWN =
     (int)ml::train::DatasetDataType::DATA_UNKNOWN /** data not known */
 } DataType;
@@ -246,13 +245,16 @@ public:
    */
   virtual int setDataFile(DataType type, std::string path);
 
+  /**
+   * @brief property type of databuffer
+   *
+   */
   enum class PropertyType {
     train_data = 0,
     val_data = 1,
     test_data = 2,
-    label_data = 3,
-    buffer_size = 4,
-    unknown = 5
+    buffer_size = 3,
+    unknown = 4
   };
 
 protected:

--- a/nntrainer/dataset/databuffer_file.cpp
+++ b/nntrainer/dataset/databuffer_file.cpp
@@ -293,24 +293,6 @@ int DataBufferFromDataFile::setDataFile(DataType type, std::string path) {
     }
     test_name = path;
   } break;
-  case DATA_LABEL: {
-    std::string data;
-    validation[type] = true;
-    if (!data_file.good()) {
-      ml_loge("Error: Cannot open label file");
-      SET_VALIDATION(false);
-      return ML_ERROR_INVALID_PARAMETER;
-    }
-    while (data_file >> data) {
-      labels.push_back(data);
-    }
-    if (class_num != 0 && class_num != labels.size()) {
-      ml_loge("Error: number of label should be same with number class number");
-      SET_VALIDATION(false);
-      return ML_ERROR_INVALID_PARAMETER;
-    }
-    class_num = labels.size();
-  } break;
   case DATA_UNKNOWN:
   default:
     ml_loge("Error: Not Supported Data Type");
@@ -386,9 +368,6 @@ int DataBufferFromDataFile::setProperty(const PropertyType type,
     break;
   case PropertyType::test_data:
     status = this->setDataFile(DATA_TEST, value);
-    break;
-  case PropertyType::label_data:
-    status = this->setDataFile(DATA_LABEL, value);
     break;
   default:
     status = DataBuffer::setProperty(type, value);

--- a/nntrainer/models/model_loader.cpp
+++ b/nntrainer/models/model_loader.cpp
@@ -224,8 +224,10 @@ int ModelLoader::loadDatasetConfigIni(dictionary *ini, NeuralNetwork &model) {
   NN_RETURN_STATUS();
   status = parse_and_set("DataSet:TestData", DATA_TEST, false);
   NN_RETURN_STATUS();
-  status = parse_and_set("Dataset:LabelData", DATA_LABEL, true);
-  NN_RETURN_STATUS();
+  const char *path = iniparser_getstring(ini, "Dataset:LabelData", NULL);
+  if (path != NULL) {
+    ml_logi("setting labelData is deprecated!, it is essentially noop now!");
+  }
 
   status = model.data_buffer->setBatchSize(model.batch_size);
   NN_RETURN_STATUS();

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -383,11 +383,10 @@ unsigned int parseDataProperty(std::string property) {
    * train_data = 0,
    * val_data = 1,
    * test_data = 2,
-   * label_data = 3,
-   * buffer_size = 4
+   * buffer_size = 3
    */
-  std::array<std::string, 5> property_string = {
-    "train_data", "val_data", "test_data", "label_data", "buffer_size"};
+  std::array<std::string, 5> property_string = {"train_data", "val_data",
+                                                "test_data", "buffer_size"};
 
   for (i = 0; i < property_string.size(); i++) {
     unsigned int size = (property_string[i].size() > property.size())

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -241,9 +241,7 @@ TEST(nntrainer_ccapi, train_dataset_with_file_01_p) {
                     ml::train::DatasetType::FILE,
                     getTestResPath("trainingSet.dat").c_str(),
                     getTestResPath("valSet.dat").c_str(), nullptr));
-  EXPECT_EQ(dataset->setProperty(
-              {"label_data=" + getTestResPath("label.dat"), "buffer_size=100"}),
-            ML_ERROR_NONE);
+  EXPECT_EQ(dataset->setProperty({"buffer_size=100"}), ML_ERROR_NONE);
   EXPECT_EQ(model->setDataset(dataset), ML_ERROR_NONE);
 
   EXPECT_EQ(model->setProperty({"loss=cross", "batch_size=16", "epochs=2",
@@ -338,9 +336,7 @@ TEST(nntrainer_ccapi, train_batch_size_update_after) {
                     ml::train::DatasetType::FILE,
                     getTestResPath("trainingSet.dat").c_str(),
                     getTestResPath("valSet.dat").c_str(), nullptr));
-  EXPECT_EQ(dataset->setProperty(
-              {"label_data=" + getTestResPath("label.dat"), "buffer_size=100"}),
-            ML_ERROR_NONE);
+  EXPECT_EQ(dataset->setProperty({"buffer_size=100"}), ML_ERROR_NONE);
   EXPECT_EQ(model->setDataset(dataset), ML_ERROR_NONE);
 
   EXPECT_EQ(model->setProperty({"loss=cross", "batch_size=16", "epochs=1"}),

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -731,9 +731,7 @@ TEST(nntrainer_capi_nnmodel, train_with_file_01_p) {
     getTestResPath("valSet.dat").c_str(), NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  const std::string label_prop = "label_data=" + getTestResPath("label.dat");
-  status = ml_train_dataset_set_property(dataset, label_prop.c_str(),
-                                         "buffer_size=100", NULL);
+  status = ml_train_dataset_set_property(dataset, "buffer_size=100", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_train_model_set_dataset(model, dataset);

--- a/test/tizen_capi/unittest_tizen_capi_dataset.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_dataset.cpp
@@ -151,15 +151,13 @@ TEST(nntrainer_capi_dataset, set_dataset_property_02_p) {
   std::string train_prop = "train_data=" + getTestResPath("trainingSet.dat");
   std::string val_prop = "val_data=" + getTestResPath("valSet.dat");
   std::string test_prop = "test_data=" + getTestResPath("testSet.dat");
-  std::string label_prop = "label_data=" + getTestResPath("label.dat");
 
   /** Multiple properties */
   status = ml_train_dataset_set_property(dataset, val_prop.c_str(),
                                          test_prop.c_str(), NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_train_dataset_set_property(dataset, label_prop.c_str(),
-                                         "buffer_size=100", NULL);
+  status = ml_train_dataset_set_property(dataset, "buffer_size=100", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Overwrite properties */

--- a/test/unittest/unittest_databuffer_file.cpp
+++ b/test/unittest/unittest_databuffer_file.cpp
@@ -89,9 +89,6 @@ TEST(nntrainer_DataBuffer, init_01_p) {
   status = data_buffer.setDataFile(nntrainer::DATA_TEST,
                                    getTestResPath("testSet.dat"));
   EXPECT_EQ(status, ML_ERROR_NONE);
-  status =
-    data_buffer.setDataFile(nntrainer::DATA_LABEL, getTestResPath("label.dat"));
-  EXPECT_EQ(status, ML_ERROR_NONE);
   status = data_buffer.setFeatureSize(dim);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = data_buffer.init();
@@ -142,32 +139,6 @@ TEST(nntrainer_DataBuffer, setDataFile_02_n) {
 }
 
 /**
- * @brief Data Buffer set train Data file
- */
-TEST(nntrainer_DataBuffer, setDataFile_03_p) {
-  int status = ML_ERROR_NONE;
-  nntrainer::DataBufferFromDataFile data_buffer;
-  status = data_buffer.setClassNum(10);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-  status =
-    data_buffer.setDataFile(nntrainer::DATA_LABEL, getTestResPath("label.dat"));
-  EXPECT_EQ(status, ML_ERROR_NONE);
-}
-
-/**
- * @brief Data Buffer set train Data file
- */
-TEST(nntrainer_DataBuffer, setDataFile_04_n) {
-  int status = ML_ERROR_NONE;
-  nntrainer::DataBufferFromDataFile data_buffer;
-  status = data_buffer.setClassNum(3);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-  status =
-    data_buffer.setDataFile(nntrainer::DATA_LABEL, getTestResPath("label.dat"));
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-}
-
-/**
  * @brief Data buffer clear all
  */
 TEST(nntrainer_DataBuffer, clear_01_p) {
@@ -187,9 +158,6 @@ TEST(nntrainer_DataBuffer, clear_01_p) {
   ASSERT_EQ(status, ML_ERROR_NONE);
   status = data_buffer.setDataFile(nntrainer::DATA_TEST,
                                    getTestResPath("testSet.dat"));
-  ASSERT_EQ(status, ML_ERROR_NONE);
-  status =
-    data_buffer.setDataFile(nntrainer::DATA_LABEL, getTestResPath("label.dat"));
   ASSERT_EQ(status, ML_ERROR_NONE);
   status = data_buffer.setFeatureSize(dim);
   ASSERT_EQ(status, ML_ERROR_NONE);

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -192,8 +192,7 @@ static nntrainer::IniSection sgd("Optimizer", "Type = sgd |"
 static nntrainer::IniSection dataset("DataSet", "BufferSize = 100 |"
                                                 "TrainData = trainingSet.dat | "
                                                 "TestData = testSet.dat |"
-                                                "ValidData = valSet.dat |"
-                                                "LabelData = label.dat");
+                                                "ValidData = valSet.dat");
 
 static nntrainer::IniSection batch_normal("bn",
                                           "Type = batch_normalization |"
@@ -340,14 +339,14 @@ INSTANTIATE_TEST_CASE_P(
     mkIniTc("unknown_layer_type2_n", {nw_base, adam, input, out + "Type = asdf"+"input_layers=inputlayer", I(out, "outlayer", "")}, ALLFAIL),
 
   /**< negative: little bit of tweeks to check determinancy (5 negative cases) */
-    mkIniTc("wrong_nw_dataset_n", {nw_base, adam, input, out+"input_layers=inputlayer", dataset + "-LabelData"}, ALLFAIL),
-    mkIniTc("wrong_nw_dataset2_n", {nw_base, adam, dataset + "-LabelData", input, out+"input_layers=inputlayer"}, ALLFAIL),
+    mkIniTc("wrong_nw_dataset_n", {nw_base, adam, input, out+"input_layers=inputlayer", dataset + "-TrainData"}, ALLFAIL),
+    mkIniTc("wrong_nw_dataset2_n", {nw_base, adam, dataset + "-TrainData", input, out+"input_layers=inputlayer"}, ALLFAIL),
 
   /**< negative: dataset is not complete (5 negative cases) */
-    mkIniTc("no_trainingSet_n", {nw_base, adam, dataset + "-TrainData", input, out+"input_layers=inputlayer"}, ALLFAIL),
-    mkIniTc("no_labelSet_n", {nw_base, adam, dataset + "-LabelData", input, out+"input_layers=inputlayer"}, ALLFAIL),
+    mkIniTc("no_trainingSet_n", {nw_base, adam, dataset + "-TrainData", input, out+"input_layers=inputlayer"}, ALLFAIL)
 
-    mkIniTc("backbone_filemissing_n", {nw_base, adam, dataset + "-LabelData", input, out+"input_layers=inputlayer"}, ALLFAIL)
+    /// @todo: correct below
+    // mkIniTc("backbone_filemissing_n", {nw_base, adam, dataset + "-LabelData", input, out+"input_layers=inputlayer"}, ALLFAIL)
 ), [](const testing::TestParamInfo<nntrainerIniTest::ParamType>& info){
  return std::get<0>(info.param);
 });


### PR DESCRIPTION
- [dataset] Remove label data

```
Before this patch, label.dat was only used to get number of classes,
unfortunately, it was clashing with how databuffer_generator is getting
the number of classes and creating some inconsistency. This patch fixes
the issue by deprecating label data.

* Checked TCT and there is no critical issue that makes tests fail with
this PR.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```