### PR TITLE
[layer] Update RNN to layerv2

### DIFF
--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -47,15 +47,13 @@ void init_filter_nntrainer(void) __attribute__((constructor));
 void fini_filter_nntrainer(void) __attribute__((destructor));
 
 struct gNewDeletor {
-    template <typename T>
-    void operator()(T* ptr) const {
-        g_free(ptr);
-    }
+  template <typename T> void operator()(T *ptr) const { g_free(ptr); }
 };
 
 static std::unique_ptr<GstTensorInfo, gNewDeletor>
 to_nnst_tensor_dim(const nntrainer::TensorDim &dim) {
-  auto info = std::unique_ptr<GstTensorInfo, gNewDeletor>(g_new(GstTensorInfo, 1));
+  auto info =
+    std::unique_ptr<GstTensorInfo, gNewDeletor>(g_new(GstTensorInfo, 1));
   gst_tensor_info_init(info.get());
 
   info->type = _NNS_FLOAT32;

--- a/nntrainer/compiler/meson.build
+++ b/nntrainer/compiler/meson.build
@@ -6,7 +6,7 @@ compiler_headers = []
 
 if get_option('enable-tflite-interpreter')
   if not tflite_dep.found()
-    error('Tensorflow-Lite dependency not found')
+    error('Tensorflow2-Lite dependency not found')
   endif
   if not flatc_prog.found()
     error('flatc executable not found')
@@ -35,4 +35,3 @@ endforeach
 foreach h : compiler_headers
   nntrainer_headers += meson.current_source_dir() / h
 endforeach
-

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -102,8 +102,8 @@ void FullyConnectedLayer::calcGradient(RunLayerContext &context) {
   Tensor &djdw = context.getWeightGrad(weight_idx[FCParams::weight]);
   Tensor &djdb = context.getWeightGrad(weight_idx[FCParams::bias]);
 
-  Tensor &derivative_ = context.getIncomingDerivative(0);
-  Tensor &input_ = context.getInput(0);
+  Tensor &derivative_ = context.getIncomingDerivative(SINGLE_INOUT_IDX);
+  Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
 
   derivative_.sum({0, 1, 2}, djdb);
   input_.dot(derivative_, djdw, true, false);

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -16,9 +16,7 @@
 #ifdef __cplusplus
 
 #include <common_properties.h>
-#include <layer_context.h>
 #include <layer_impl.h>
-#include <tensor.h>
 
 namespace nntrainer {
 

--- a/nntrainer/layers/rnn.cpp
+++ b/nntrainer/layers/rnn.cpp
@@ -22,6 +22,8 @@
 
 namespace nntrainer {
 
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
 // - weight_xh ( input to hidden )
 //  : [1, 1, input_size, unit (hidden_size) ]
 // - weight_hh ( hidden to hidden )
@@ -30,59 +32,57 @@ namespace nntrainer {
 //  : [1, 1, 1, unit (hidden_size)]
 enum RNNParams { weight_xh, weight_hh, bias_h };
 
-int RNNLayer::initialize(Manager &manager) {
-  int status = ML_ERROR_NONE;
-  if (getNumInputs() != 1) {
+void RNNLayer::finalize(InitLayerContext &context) {
+  auto unit = std::get<props::Unit>(props).get();
+
+  if (context.getNumInputs() != 1) {
     throw std::invalid_argument("RNN layer takes only one input");
   }
 
-  // input_dim = [ batch, 1, time_iterantion, feature_size ]
+  TensorDim output_dim;
+  const TensorDim &input_dim = context.getInputDimensions()[0];
+
+  // input_dim = [ batch, 1, time_iteration, feature_size ]
   // outut_dim = [ batch, 1, time_iteration, hidden_size ( unit ) ]
-  output_dim[0] = input_dim[0];
-  output_dim[0].width(unit);
+  output_dim = input_dim;
+  output_dim.width(unit);
 
   if (!return_sequences) {
-    output_dim[0].height(1);
+    output_dim.height(1u);
   }
+
+  context.setOutputDimensions({output_dim});
 
   TensorDim bias_dim = TensorDim();
   bias_dim.setTensorDim(3, unit);
 
-  TensorDim dim_xh = output_dim[0];
-  dim_xh.height(input_dim[0].width());
+  TensorDim dim_xh = output_dim;
+  dim_xh.height(input_dim.width());
   dim_xh.batch(1);
 
-  TensorDim dim_hh = output_dim[0];
+  TensorDim dim_hh = output_dim;
   dim_hh.height(unit);
   dim_hh.batch(1);
 
-  if (weights.empty()) {
-    weights.reserve(3);
-    // weight_initializer can be set sepeartely. weight_xh initializer,
-    // weight_hh initializer kernel initializer & recurrent_initializer in keras
-    // for now, it is set same way.
-    weights.emplace_back(dim_xh, weight_initializer, weight_regularizer,
-                         weight_regularizer_constant, true, "RNN:weight_xh");
-    weights.emplace_back(dim_hh, weight_initializer, weight_regularizer,
-                         weight_regularizer_constant, true, "RNN:weight_hh");
-    weights.emplace_back(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                         1.0f, true, "RNN:bias_h");
-    manager.trackWeights(weights);
-  } else {
-    weights[RNNParams::weight_xh].reset(dim_xh, weight_initializer,
-                                        weight_regularizer,
-                                        weight_regularizer_constant, true);
-    weights[RNNParams::weight_hh].reset(dim_hh, weight_initializer,
-                                        weight_regularizer,
-                                        weight_regularizer_constant, true);
-    weights[RNNParams::bias_h].reset(bias_dim, bias_initializer,
-                                     WeightRegularizer::NONE, 1.0f, true);
-  }
+  // weight_initializer can be set sepeartely. weight_xh initializer,
+  // weight_hh initializer kernel initializer & recurrent_initializer in keras
+  // for now, it is set same way.
 
-  bias_dim.batch(input_dim[0].batch());
+  weight_idx[RNNParams::weight_xh] =
+    context.requestWeight(dim_xh, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "RNN:weight_xh", true);
+  weight_idx[RNNParams::weight_hh] =
+    context.requestWeight(dim_hh, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "RNN:weight_hh", true);
+  weight_idx[RNNParams::bias_h] =
+    context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
+                          1.0f, "RNN:bias_h", true);
+
+  // override setBatch for this
+  bias_dim.batch(input_dim.batch());
   h_prev = Tensor(bias_dim);
 
-  TensorDim d = input_dim[0];
+  TensorDim d = input_dim;
   d.width(unit);
 
   // We do not need this if we reuse net_hidden[0]. But if we do, then the unit
@@ -94,48 +94,64 @@ int RNNLayer::initialize(Manager &manager) {
     hidden_state_activation_type = ActivationType::ACT_TANH;
     acti_func.setActiFunc(hidden_state_activation_type);
   }
-
-  return status;
 }
 
-void RNNLayer::setProperty(const PropertyType type, const std::string &value) {
+void RNNLayer::setProperty(const std::vector<std::string> &values) {
+  /// @todo: deprecate this in favor of loadProperties
+  auto remain_props = loadProperties(values, props);
+  for (unsigned int i = 0; i < remain_props.size(); ++i) {
+    std::string key;
+    std::string value;
+    std::stringstream ss;
+
+    if (getKeyValue(remain_props[i], key, value) != ML_ERROR_NONE) {
+      throw std::invalid_argument("Error parsing the property: " +
+                                  remain_props[i]);
+    }
+
+    if (value.empty()) {
+      ss << "value is empty: key: " << key << ", value: " << value;
+      throw std::invalid_argument(ss.str());
+    }
+
+    /// @note this calls derived setProperty if available
+    setProperty(key, value);
+  }
+}
+
+void RNNLayer::setProperty(const std::string &type_str,
+                           const std::string &value) {
+  using PropertyType = LayerV1::PropertyType;
   int status = ML_ERROR_NONE;
+  LayerV1::PropertyType type =
+    static_cast<LayerV1::PropertyType>(parseLayerProperty(type_str));
+
   // TODO : Add return_state property & api to get the hidden input
   switch (type) {
-  case PropertyType::unit: {
-    if (!value.empty()) {
-      status = setUint(unit, value);
-      throw_status(status);
-      output_dim[0].width(unit);
-    }
-    break;
-  case PropertyType::hidden_state_activation:
-    if (!value.empty()) {
-      ActivationType acti_type = (ActivationType)parseType(value, TOKEN_ACTI);
-      hidden_state_activation_type = acti_type;
-      acti_func.setActiFunc(acti_type);
-    }
-    break;
-  case PropertyType::return_sequences:
-    if (!value.empty()) {
-      status = setBoolean(return_sequences, value);
-      throw_status(status);
-    }
-    break;
+  case PropertyType::hidden_state_activation: {
+    ActivationType acti_type = (ActivationType)parseType(value, TOKEN_ACTI);
+    hidden_state_activation_type = acti_type;
+    acti_func.setActiFunc(acti_type);
+  } break;
+  case PropertyType::return_sequences: {
+    status = setBoolean(return_sequences, value);
+    throw_status(status);
+  } break;
   default:
-    LayerV1::setProperty(type, value);
+    LayerImpl::setProperty(type_str, value);
     break;
-  }
   }
 }
 
-void RNNLayer::forwarding(bool training) {
-  Tensor &weight_xh =
-    weightAt(static_cast<int>(RNNParams::weight_xh)).getVariableRef();
-  Tensor &weight_hh =
-    weightAt(static_cast<int>(RNNParams::weight_hh)).getVariableRef();
-  Tensor &bias_h =
-    weightAt(static_cast<int>(RNNParams::bias_h)).getVariableRef();
+void RNNLayer::exportTo(Exporter &exporter, const ExportMethods &method) const {
+  LayerImpl::exportTo(exporter, method);
+  exporter.saveResult(props, method, this);
+}
+
+void RNNLayer::forwarding(RunLayerContext &context, bool training) {
+  Tensor &weight_xh = context.getWeight(weight_idx[RNNParams::weight_xh]);
+  Tensor &weight_hh = context.getWeight(weight_idx[RNNParams::weight_hh]);
+  Tensor &bias_h = context.getWeight(weight_idx[RNNParams::bias_h]);
 
   hidden->getVariableRef().setZero();
 
@@ -145,14 +161,15 @@ void RNNLayer::forwarding(bool training) {
   h_prev.setZero();
 
   Tensor &hidden_ = hidden->getVariableRef();
-  Tensor &input_ = net_input[0]->getVariableRef();
+  Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+  const TensorDim &input_dim = input_.getDim();
 
   Tensor temp;
   Tensor hs_prev;
   Tensor hs;
 
   // TODO : check merge b and t index
-  for (unsigned int b = 0; b < input_dim[0].batch(); ++b) {
+  for (unsigned int b = 0; b < input_dim.batch(); ++b) {
     Tensor islice = input_.getBatchSlice(b, 1);
     Tensor oslice = hidden_.getBatchSlice(b, 1);
 
@@ -181,72 +198,60 @@ void RNNLayer::forwarding(bool training) {
       h_prev.getBatchSlice(b, 1).copy(hs);
   }
 
+  Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
   if (!return_sequences) {
     TensorDim d = hidden_.getDim();
-    for (unsigned int b = 0; b < input_dim[0].batch(); ++b) {
+    for (unsigned int b = 0; b < input_dim.batch(); ++b) {
       float *data = hidden_.getAddress(b * d.width() * d.height() +
                                        (d.height() - 1) * d.width());
-      float *rdata = net_hidden[0]->getVariableRef().getAddress(b * d.width());
+      float *rdata = output.getAddress(b * d.width());
       std::copy(data, data + d.width(), rdata);
     }
   } else {
-    net_hidden[0]->getVariableRef().copy(hidden_);
+    output.copy(hidden_);
   }
 }
 
-void RNNLayer::copy(std::shared_ptr<LayerV1> l) {
-  LayerV1::copy(l);
-
-  std::shared_ptr<RNNLayer> from = std::static_pointer_cast<RNNLayer>(l);
-  this->unit = from->unit;
-  this->hidden_state_activation_type = from->hidden_state_activation_type;
-  this->return_sequences = from->return_sequences;
-  this->acti_func = from->acti_func;
-}
-
-void RNNLayer::calcDerivative() {
+void RNNLayer::calcDerivative(RunLayerContext &context) {
   Tensor &derivative_ = hidden->getGradientRef();
-  Tensor &weight =
-    weightAt(static_cast<int>(RNNParams::weight_xh)).getVariableRef();
-  Tensor &ret_ = net_input[0]->getGradientRef();
+  Tensor &weight = context.getWeight(weight_idx[RNNParams::weight_xh]);
+  Tensor &ret_ = context.getOutgoingDerivative(SINGLE_INOUT_IDX);
 
   derivative_.dot(weight, ret_, false, true);
 }
 
-void RNNLayer::calcGradient() {
-  Tensor &djdw_x =
-    weightAt(static_cast<int>(RNNParams::weight_xh)).getGradientRef();
-  Tensor &djdw_h =
-    weightAt(static_cast<int>(RNNParams::weight_hh)).getGradientRef();
-  Tensor &djdb_h =
-    weightAt(static_cast<int>(RNNParams::bias_h)).getGradientRef();
-  Tensor &weight_hh =
-    weightAt(static_cast<int>(RNNParams::weight_hh)).getVariableRef();
+void RNNLayer::calcGradient(RunLayerContext &context) {
+  Tensor &djdw_x = context.getWeightGrad(weight_idx[RNNParams::weight_xh]);
+  Tensor &djdw_h = context.getWeightGrad(weight_idx[RNNParams::weight_hh]);
+  Tensor &djdb_h = context.getWeightGrad(weight_idx[RNNParams::bias_h]);
+  Tensor &weight_hh = context.getWeight(weight_idx[RNNParams::weight_hh]);
 
   djdw_x.setZero();
   djdw_h.setZero();
   djdb_h.setZero();
 
   Tensor &derivative_ = hidden->getGradientRef();
+  Tensor &incoming_deriv = context.getOutputGrad(SINGLE_INOUT_IDX);
+  Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+  const TensorDim &input_dim = input_.getDim();
 
   if (!return_sequences) {
     TensorDim d = derivative_.getDim();
-    for (unsigned int b = 0; b < input_dim[0].batch(); ++b) {
+    for (unsigned int b = 0; b < input_dim.batch(); ++b) {
       float *data = derivative_.getAddress(b * d.width() * d.height() +
                                            (d.height() - 1) * d.width());
-      float *rdata = net_hidden[0]->getGradientRef().getAddress(b * d.width());
+      float *rdata = incoming_deriv.getAddress(b * d.width());
       std::copy(rdata, rdata + d.width(), data);
     }
   } else {
-    derivative_.copy(net_hidden[0]->getGradientRef());
+    derivative_.copy(incoming_deriv);
   }
 
   Tensor &hidden_ = hidden->getVariableRef();
 
-  Tensor &input_ = net_input[0]->getVariableRef();
   Tensor dh_nx = Tensor(TensorDim(1, 1, 1, derivative_.width()));
 
-  for (unsigned int b = 0; b < input_dim[0].batch(); ++b) {
+  for (unsigned int b = 0; b < input_dim.batch(); ++b) {
     Tensor deriv_t = derivative_.getBatchSlice(b, 1);
     Tensor xs_t = input_.getBatchSlice(b, 1);
     Tensor hs_t = hidden_.getBatchSlice(b, 1);

--- a/nntrainer/layers/rnn.h
+++ b/nntrainer/layers/rnn.h
@@ -15,8 +15,9 @@
 #define __RNN_H__
 #ifdef __cplusplus
 
-#include <layer_internal.h>
-#include <tensor.h>
+#include <acti_func.h>
+#include <common_properties.h>
+#include <layer_impl.h>
 
 namespace nntrainer {
 
@@ -24,25 +25,23 @@ namespace nntrainer {
  * @class   RNNLayer
  * @brief   RNNLayer
  */
-class RNNLayer : public LayerV1 {
+class RNNLayer : public LayerImpl {
 public:
   /**
    * @brief     Constructor of RNNLayer
    */
-  template <typename... Args>
   RNNLayer(
-    unsigned int unit_ = 0,
     ActivationType hidden_state_activation_type_ = ActivationType::ACT_NONE,
-    bool sequence = false, Args... args) :
-    LayerV1(args...),
-    unit(unit_),
+    bool ret_sequence = false) :
+    LayerImpl(),
+    props(props::Unit()),
     hidden_state_activation_type(hidden_state_activation_type_),
-    return_sequences(sequence){};
+    return_sequences(ret_sequence){};
 
   /**
    * @brief     Destructor of RNNLayer
    */
-  ~RNNLayer(){};
+  ~RNNLayer() = default;
 
   /**
    *  @brief  Move constructor.
@@ -57,54 +56,52 @@ public:
   RNNLayer &operator=(RNNLayer &&rhs) = default;
 
   /**
-   * @copydoc Layer::forwarding(bool training)
+   * @copydoc Layer::finalize(InitLayerContext &context)
    */
-  void forwarding(bool training = true) override;
+  void finalize(InitLayerContext &context) override;
 
   /**
-   * @copydoc Layer::calcDerivative()
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
-  void calcDerivative() override;
+  void forwarding(RunLayerContext &context, bool training) override;
 
   /**
-   * @copydoc Layer::calcGradient()
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
-  void calcGradient() override;
+  void calcDerivative(RunLayerContext &context) override;
 
   /**
-   * @brief     copy layer
-   * @param[in] l layer to copy
+   * @copydoc Layer::calcGradient(RunLayerContext &context)
    */
-  void copy(std::shared_ptr<LayerV1> l) override;
+  void calcGradient(RunLayerContext &context) override;
 
   /**
-   * @brief     initialize layer
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
    */
-  int initialize(Manager &manager) override;
+  void exportTo(Exporter &exporter, const ExportMethods &method) const override;
 
   /**
    * @copydoc Layer::getType()
    */
   const std::string getType() const override { return RNNLayer::type; };
 
-  using LayerV1::setProperty;
+  /**
+   * @copydoc Layer::supportBackwarding()
+   */
+  bool supportBackwarding() const { return true; }
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
    * &value)
    */
-  void setProperty(const PropertyType type,
-                   const std::string &value = "") override;
+  void setProperty(const std::vector<std::string> &values) override;
 
   inline static const std::string type = "rnn";
 
 private:
-  /**
-   * @brief     hidden state size
-   */
-  unsigned int unit;
+  std::tuple<props::Unit>
+    props; /**< rnn layer properties : unit - number of output neurons */
+  std::array<unsigned int, 3> weight_idx; /**< indices of the weights */
 
   /**
    * @brief     activation type for recurrent : default is tanh
@@ -130,6 +127,16 @@ private:
    * @brief     hidden variable for rnn
    */
   std::shared_ptr<Var_Grad> hidden;
+
+  /**
+   * @brief setProperty by type and value separated
+   * @param[in] type property type to be passed
+   * @param[in] value value to be passed
+   * @exception exception::not_supported     when property type is not valid for
+   * the particular layer
+   * @exception std::invalid_argument invalid argument
+   */
+  void setProperty(const std::string &type, const std::string &value);
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/rnn.h
+++ b/nntrainer/layers/rnn.h
@@ -101,7 +101,7 @@ public:
 private:
   std::tuple<props::Unit>
     props; /**< rnn layer properties : unit - number of output neurons */
-  std::array<unsigned int, 3> weight_idx; /**< indices of the weights */
+  std::array<unsigned int, 4> wt_idx; /**< indices of the weights */
 
   /**
    * @brief     activation type for recurrent : default is tanh
@@ -114,19 +114,9 @@ private:
   ActiFunc acti_func;
 
   /**
-   * @brief     To save hidden state variable ( batch, 1, 1, unit )
-   */
-  Tensor h_prev;
-
-  /**
    * @brief     opiont for return sequence
    */
   bool return_sequences;
-
-  /**
-   * @brief     hidden variable for rnn
-   */
-  std::shared_ptr<Var_Grad> hidden;
 
   /**
    * @brief setProperty by type and value separated

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -12,6 +12,7 @@ test_target = [
   'unittest_layers_activation.cpp',
   'unittest_layers_addition.cpp',
   'unittest_layers_multiout.cpp',
+  'unittest_layers_rnn.cpp',
 ]
 
 exe = executable(

--- a/test/unittest/layers/unittest_layers_rnn.cpp
+++ b/test/unittest/layers/unittest_layers_rnn.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_layers_rnn.cpp
+ * @date 8 July 2021
+ * @brief RNN Layer Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include <layers_common_tests.h>
+#include <rnn.h>
+
+auto semantic_rnn =
+  LayerSemanticsParamType(nntrainer::createLayer<nntrainer::RNNLayer>,
+                          nntrainer::RNNLayer::type, {"unit=1"}, {}, 0, false);
+
+INSTANTIATE_TEST_CASE_P(RNN, LayerSemantics, ::testing::Values(semantic_rnn));

--- a/test/unittest/layers/unittest_layers_rnn.cpp
+++ b/test/unittest/layers/unittest_layers_rnn.cpp
@@ -18,6 +18,6 @@
 
 auto semantic_rnn =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::RNNLayer>,
-                          nntrainer::RNNLayer::type, {"unit=1"}, {}, 0, false);
+                          nntrainer::RNNLayer::type, {"unit=1"}, 0, false);
 
 INSTANTIATE_TEST_CASE_P(RNN, LayerSemantics, ::testing::Values(semantic_rnn));

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -1314,7 +1314,7 @@ INSTANTIATE_TEST_CASE_P(
     // mkModelTc(preprocess_flip_validate, "3:1:1:10", 10),
 
     /**< Addition test */
-    mkModelTc(addition_resnet_like, "3:1:1:10", 10)
+    mkModelTc(addition_resnet_like, "3:1:1:10", 10),
 
     /// #1192 time distribution inference bug
     // mkModelTc(fc_softmax_mse_distribute_validate, "3:1:5:3", 1),
@@ -1325,11 +1325,11 @@ INSTANTIATE_TEST_CASE_P(
     // mkModelTc(lstm_return_sequence_with_batch, "2:1:2:1", 10),
     // mkModelTc(multi_lstm_return_sequence, "1:1:1:1", 10),
     // mkModelTc(multi_lstm_return_sequence_with_batch, "2:1:1:1", 10),
-    // mkModelTc(rnn_basic, "1:1:1:1", 10),
-    // mkModelTc(rnn_return_sequences, "1:1:2:1", 10),
-    // mkModelTc(rnn_return_sequence_with_batch, "2:1:2:1", 10),
-    // mkModelTc(multi_rnn_return_sequence, "1:1:1:1", 10),
-    // mkModelTc(multi_rnn_return_sequence_with_batch, "2:1:1:1", 10),
+    mkModelTc(rnn_basic, "1:1:1:1", 10),
+    mkModelTc(rnn_return_sequences, "1:1:2:1", 10),
+    mkModelTc(rnn_return_sequence_with_batch, "2:1:2:1", 10),
+    mkModelTc(multi_rnn_return_sequence, "1:1:1:1", 10),
+    mkModelTc(multi_rnn_return_sequence_with_batch, "2:1:1:1", 10)
     // mkModelTc(gru_basic, "1:1:1:1", 10),
     // mkModelTc(gru_return_sequence, "1:1:2:1", 10),
     // mkModelTc(gru_return_sequence_with_batch, "2:1:2:1", 10),


### PR DESCRIPTION
Update RNN to layerv2 design.
Corresponding unittests have been added and enabled.

Cleanup RNN implementation.
Reduce usage of temporary allocated memory and reuse existing memory as much as possible.
Further, request hidden state memory from context than creating by self.

Signed-off-by: Parichay Kapoor <kparichay@gmail.com>