### PR TITLE
[dataset] split train / val / test databuffer @open sesame 07/15 15:00

### DIFF
--- a/Applications/Custom/LayerClient/jni/main.cpp
+++ b/Applications/Custom/LayerClient/jni/main.cpp
@@ -79,13 +79,14 @@ static int ini_model_run(const std::string &ini_path) {
   std::shared_ptr<ml::train::Dataset> dataset;
   try {
     dataset = ml::train::createDataset(ml::train::DatasetType::GENERATOR,
-                                       constant_generator_cb, nullptr, nullptr);
+                                       constant_generator_cb);
   } catch (...) {
     std::cerr << "creating dataset failed";
     return 1;
   }
 
-  if (model->setDataset(dataset) != 0) {
+  if (model->setDataset(ml::train::DatasetDataUsageType::DATA_TRAIN, dataset) !=
+      0) {
     std::cerr << "failed to set datatset";
     return 1;
   }
@@ -124,13 +125,14 @@ int api_model_run() {
 
   try {
     dataset = ml::train::createDataset(ml::train::DatasetType::GENERATOR,
-                                       constant_generator_cb, nullptr, nullptr);
+                                       constant_generator_cb);
   } catch (...) {
     std::cerr << "creating dataset failed";
     return 1;
   }
 
-  if (model->setDataset(dataset) != 0) {
+  if (model->setDataset(ml::train::DatasetDataUsageType::DATA_TRAIN, dataset) !=
+      0) {
     std::cerr << "failed to set datatset";
     return 1;
   }

--- a/Applications/LogisticRegression/jni/main.cpp
+++ b/Applications/LogisticRegression/jni/main.cpp
@@ -170,10 +170,9 @@ int main(int argc, char *argv[]) {
 
   srand(time(NULL));
 
-  std::shared_ptr<nntrainer::DataBufferFromCallback> DB =
-    std::make_shared<nntrainer::DataBufferFromCallback>();
-  DB->setGeneratorFunc(nntrainer::DatasetDataUsageType::DATA_TRAIN,
-                       getBatch_train);
+  auto data_train = std::make_shared<nntrainer::DataBufferFromCallback>();
+  data_train->setGeneratorFunc(ml::train::DatasetDataUsageType::DATA_TRAIN,
+                               getBatch_train);
 
   /**
    * @brief     Create NN
@@ -195,7 +194,7 @@ int main(int argc, char *argv[]) {
   }
 
   if (training) {
-    NN.setDataBuffer((DB));
+    NN.setDataBuffer(ml::train::DatasetDataUsageType::DATA_TRAIN, data_train);
 
     try {
       NN.train();

--- a/Applications/MNIST/jni/main.cpp
+++ b/Applications/MNIST/jni/main.cpp
@@ -285,10 +285,12 @@ int main(int argc, char *argv[]) {
   /**
    * @brief     Data buffer Create & Initialization
    */
-  std::shared_ptr<ml::train::Dataset> dataset;
+  std::shared_ptr<ml::train::Dataset> dataset_train, dataset_val;
   try {
-    dataset = createDataset(ml::train::DatasetType::GENERATOR, getBatch_train,
-                            getBatch_val);
+    dataset_train =
+      createDataset(ml::train::DatasetType::GENERATOR, getBatch_train);
+    dataset_val =
+      createDataset(ml::train::DatasetType::GENERATOR, getBatch_val);
   } catch (std::exception &e) {
     std::cerr << "Error creating dataset" << e.what() << std::endl;
     return 1;
@@ -310,7 +312,9 @@ int main(int argc, char *argv[]) {
     model->compile();
     model->initialize();
     model->readModel();
-    model->setDataset(dataset);
+    model->setDataset(ml::train::DatasetDataUsageType::DATA_TRAIN,
+                      dataset_train);
+    model->setDataset(ml::train::DatasetDataUsageType::DATA_VAL, dataset_val);
   } catch (std::exception &e) {
     std::cerr << "Error during init " << e.what() << std::endl;
     return 1;

--- a/Applications/ProductRatings/jni/main.cpp
+++ b/Applications/ProductRatings/jni/main.cpp
@@ -173,10 +173,12 @@ int main(int argc, char *argv[]) {
 
   srand(time(NULL));
 
-  std::shared_ptr<ml::train::Dataset> dataset;
+  std::shared_ptr<ml::train::Dataset> dataset_train, dataset_val;
   try {
-    dataset = createDataset(ml::train::DatasetType::GENERATOR, getBatch_train,
-                            getBatch_train);
+    dataset_train =
+      createDataset(ml::train::DatasetType::GENERATOR, getBatch_train);
+    dataset_val =
+      createDataset(ml::train::DatasetType::GENERATOR, getBatch_train);
   } catch (std::exception &e) {
     std::cerr << "Error creating dataset" << e.what() << std::endl;
     return 1;
@@ -218,7 +220,8 @@ int main(int argc, char *argv[]) {
   }
 
   if (training) {
-    NN.setDataset(dataset);
+    NN.setDataset(ml::train::DatasetDataUsageType::DATA_TRAIN, dataset_train);
+    NN.setDataset(ml::train::DatasetDataUsageType::DATA_VAL, dataset_val);
     try {
       NN.train({"batch_size=" + std::to_string(batch_size)});
     } catch (std::exception &e) {

--- a/Applications/SimpleShot/task_runner.cpp
+++ b/Applications/SimpleShot/task_runner.cpp
@@ -241,18 +241,27 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  std::shared_ptr<ml::train::Dataset> train_dataset;
+  std::shared_ptr<ml::train::Dataset> train_dataset, valid_dataset;
   try {
-    train_dataset = ml::train::createDataset(
-      ml::train::DatasetType::FILE,
-      {"train_data=" + train_path, "val_data=" + val_path});
+    train_dataset = ml::train::createDataset(ml::train::DatasetType::FILE,
+                                             train_path.c_str());
+    valid_dataset =
+      ml::train::createDataset(ml::train::DatasetType::FILE, val_path.c_str());
+
   } catch (...) {
     std::cerr << "creating dataset failed";
     return 1;
   }
 
-  if (model->setDataset(train_dataset)) {
-    std::cerr << "failed to set dataset" << std::endl;
+  if (model->setDataset(ml::train::DatasetDataUsageType::DATA_TRAIN,
+                        train_dataset)) {
+    std::cerr << "failed to set train dataset" << std::endl;
+    return 1;
+  };
+
+  if (model->setDataset(ml::train::DatasetDataUsageType::DATA_VAL,
+                        valid_dataset)) {
+    std::cerr << "failed to set valid dataset" << std::endl;
     return 1;
   };
 

--- a/Applications/TransferLearning/CIFAR_Classification/jni/main_func.cpp
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/main_func.cpp
@@ -273,10 +273,12 @@ int main(int argc, char *argv[]) {
   /**
    * @brief     Data buffer Create & Initialization
    */
-  std::shared_ptr<ml::train::Dataset> dataset;
+  std::shared_ptr<ml::train::Dataset> dataset_train, dataset_val;
   try {
-    dataset = createDataset(ml::train::DatasetType::GENERATOR, getBatch_train,
-                            getBatch_val);
+    dataset_train =
+      createDataset(ml::train::DatasetType::GENERATOR, getBatch_train);
+    dataset_val =
+      createDataset(ml::train::DatasetType::GENERATOR, getBatch_val);
   } catch (...) {
     std::cerr << "Error creating dataset" << std::endl;
     return 1;
@@ -306,7 +308,8 @@ int main(int argc, char *argv[]) {
     std::cerr << "Error during readModel, reason: " << e.what() << std::endl;
     return 1;
   }
-  model->setDataset(dataset);
+  model->setDataset(ml::train::DatasetDataUsageType::DATA_TRAIN, dataset_train);
+  model->setDataset(ml::train::DatasetDataUsageType::DATA_VAL, dataset_val);
 
   /**
    * @brief     Neural Network Train & validation

--- a/Applications/TransferLearning/Draw_Classification/jni/main.cpp
+++ b/Applications/TransferLearning/Draw_Classification/jni/main.cpp
@@ -454,7 +454,7 @@ int main(int argc, char *argv[]) {
   try {
     loadAllData(data_path, inputVector, labelVector);
   } catch (...) {
-    std::cout << "Failed loading input images." << std::endl;
+    std::cerr << "Failed loading input images." << std::endl;
 #if defined(__TIZEN__)
     set_feature_state(NOT_CHECKED_YET);
 #endif
@@ -471,8 +471,10 @@ int main(int argc, char *argv[]) {
 #endif
     return 1;
   }
-  if (status != ML_ERROR_NONE)
+  if (status != ML_ERROR_NONE) {
+    std::cerr << "failed train model\n";
     return 1;
+  }
 
   /** Test the trained model */
   try {
@@ -484,8 +486,10 @@ int main(int argc, char *argv[]) {
 #endif
     return 1;
   }
-  if (status != ML_ERROR_NONE)
+  if (status != ML_ERROR_NONE) {
+    std::cerr << "Failed testing model\n";
     return 1;
+  }
 
 #if defined(__TIZEN__)
   set_feature_state(NOT_CHECKED_YET);

--- a/Applications/VGG/jni/main.cpp
+++ b/Applications/VGG/jni/main.cpp
@@ -399,12 +399,12 @@ int main(int argc, char *argv[]) {
   for (unsigned int i = 0; i < count_val.remain; ++i)
     count_val.duplication[i] = i;
 
-  std::shared_ptr<nntrainer::DataBufferFromCallback> DB =
-    std::make_shared<nntrainer::DataBufferFromCallback>();
-  DB->setGeneratorFunc(nntrainer::DatasetDataUsageType::DATA_TRAIN,
-                       getBatch_train_file);
-  DB->setGeneratorFunc(nntrainer::DatasetDataUsageType::DATA_VAL,
-                       getBatch_val_file);
+  auto db_train = std::make_shared<nntrainer::DataBufferFromCallback>();
+  db_train->setGeneratorFunc(ml::train::DatasetDataUsageType::DATA_TRAIN,
+                             getBatch_train_file);
+  auto db_valid = std::make_shared<nntrainer::DataBufferFromCallback>();
+  db_valid->setGeneratorFunc(ml::train::DatasetDataUsageType::DATA_VAL,
+                             getBatch_val_file);
 
   /**
    * @brief     Neural Network Create & Initialization
@@ -427,7 +427,8 @@ int main(int argc, char *argv[]) {
 
   try {
     NN.readModel();
-    NN.setDataBuffer((DB));
+    NN.setDataBuffer(ml::train::DatasetDataUsageType::DATA_TRAIN, db_train);
+    NN.setDataBuffer(ml::train::DatasetDataUsageType::DATA_VAL, db_valid);
     NN.train();
     training_loss = NN.getTrainingLoss();
     validation_loss = NN.getValidationLoss();

--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -25,6 +25,7 @@
 #ifndef __NNTRAINER_INTERNAL_H__
 #define __NNTRAINER_INTERNAL_H__
 
+#include <array>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -101,7 +102,7 @@ typedef struct {
  */
 typedef struct {
   uint magic;
-  std::shared_ptr<ml::train::Dataset> dataset;
+  std::array<std::shared_ptr<ml::train::Dataset>, 3> dataset;
   bool in_use;
   std::mutex m;
 } ml_train_dataset;

--- a/api/ccapi/include/dataset.h
+++ b/api/ccapi/include/dataset.h
@@ -98,16 +98,13 @@ createDataset(DatasetType type,
 /**
  * @brief Factory creator with constructor for dataset
  */
-std::unique_ptr<Dataset> createDataset(DatasetType type, const char *train_file,
-                                       const char *valid_file = nullptr,
-                                       const char *test_file = nullptr);
+std::unique_ptr<Dataset> createDataset(DatasetType type, const char *file);
 
 /**
  * @brief Factory creator with constructor for dataset
  */
-std::unique_ptr<Dataset> createDataset(DatasetType type, datagen_cb train,
-                                       datagen_cb valid = nullptr,
-                                       datagen_cb test = nullptr);
+std::unique_ptr<Dataset> createDataset(DatasetType type, datagen_cb cb,
+                                       void *user_data = nullptr);
 
 } // namespace train
 } // namespace ml

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -153,11 +153,13 @@ public:
 
   /**
    * @brief     Run Model train with callback function by user
+   * @param[in] usage usage of the dataset
    * @param[in] dataset set the dataset
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int setDataset(std::shared_ptr<Dataset> dataset) = 0;
+  virtual int setDataset(const ml::train::DatasetDataUsageType &usage,
+                         std::shared_ptr<Dataset> dataset) = 0;
 
   /**
    * @brief     add layer into neural network model

--- a/api/ccapi/src/factory.cpp
+++ b/api/ccapi/src/factory.cpp
@@ -139,18 +139,16 @@ createDataset(DatasetType type, const std::vector<std::string> &properties) {
 /**
  * @brief Factory creator with constructor for dataset
  */
-std::unique_ptr<Dataset> createDataset(DatasetType type, const char *train_file,
-                                       const char *valid_file,
-                                       const char *test_file) {
-  return nntrainer::createDataBuffer(type, train_file, valid_file, test_file);
+std::unique_ptr<Dataset> createDataset(DatasetType type, const char *file) {
+  return nntrainer::createDataBuffer(type, file);
 }
 
 /**
  * @brief Factory creator with constructor for dataset
  */
-std::unique_ptr<Dataset> createDataset(DatasetType type, datagen_cb train,
-                                       datagen_cb valid, datagen_cb test) {
-  return nntrainer::createDataBuffer(type, train, valid, test);
+std::unique_ptr<Dataset> createDataset(DatasetType type, datagen_cb cb,
+                                       void *user_data) {
+  return nntrainer::createDataBuffer(type, cb, user_data);
 }
 
 } // namespace train

--- a/nntrainer/dataset/databuffer.cpp
+++ b/nntrainer/dataset/databuffer.cpp
@@ -510,7 +510,8 @@ int DataBuffer::setProperty(const PropertyType type, std::string &value) {
   return status;
 }
 
-int DataBuffer::setGeneratorFunc(DatasetDataUsageType type, datagen_cb func) {
+int DataBuffer::setGeneratorFunc(DatasetDataUsageType type, datagen_cb func,
+                                 void *user_data) {
   return ML_ERROR_NOT_SUPPORTED;
 }
 

--- a/nntrainer/dataset/databuffer.h
+++ b/nntrainer/dataset/databuffer.h
@@ -186,10 +186,12 @@ public:
    * @brief     set function pointer for each type
    * @param[in] type Buffer Type
    * @param[in] call back function pointer
+   * @param[in] user_data user_data of the callback
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int setGeneratorFunc(DatasetDataUsageType type, datagen_cb func);
+  virtual int setGeneratorFunc(DatasetDataUsageType type, datagen_cb func,
+                               void *user_data = nullptr);
 
   /**
    * @brief     set train data file name

--- a/nntrainer/dataset/databuffer_factory.cpp
+++ b/nntrainer/dataset/databuffer_factory.cpp
@@ -38,34 +38,18 @@ std::unique_ptr<DataBuffer> createDataBuffer(DatasetType type) {
  * @brief Factory creator with constructor for dataset
  */
 std::unique_ptr<DataBuffer> createDataBuffer(DatasetType type,
-                                             const char *train_file,
-                                             const char *valid_file,
-                                             const char *test_file) {
+                                             const char *file) {
   if (type != DatasetType::FILE)
     throw std::invalid_argument(
       "Cannot create dataset with files with the given dataset type");
 
   std::unique_ptr<DataBuffer> dataset = createDataBuffer(type);
 
-  NNTR_THROW_IF(train_file == nullptr ||
+  NNTR_THROW_IF(file == nullptr ||
                   dataset->setDataFile(DatasetDataUsageType::DATA_TRAIN,
-                                       train_file) != ML_ERROR_NONE,
+                                       file) != ML_ERROR_NONE,
                 std::invalid_argument)
-    << "invalid train file, path: " << (train_file ? train_file : "null");
-
-  if (valid_file) {
-    NNTR_THROW_IF(dataset->setDataFile(DatasetDataUsageType::DATA_VAL,
-                                       valid_file) != ML_ERROR_NONE,
-                  std::invalid_argument)
-      << "invalid valid file, path: " << (valid_file ? valid_file : "null");
-  }
-
-  if (test_file) {
-    NNTR_THROW_IF(dataset->setDataFile(DatasetDataUsageType::DATA_TEST,
-                                       test_file) != ML_ERROR_NONE,
-                  std::invalid_argument)
-      << "invalid test file, path: " << (test_file ? test_file : "null");
-  }
+    << "invalid train file, path: " << (file ? file : "null");
 
   return dataset;
 }
@@ -73,26 +57,17 @@ std::unique_ptr<DataBuffer> createDataBuffer(DatasetType type,
 /**
  * @brief Factory creator with constructor for dataset
  */
-std::unique_ptr<DataBuffer> createDataBuffer(DatasetType type, datagen_cb train,
-                                             datagen_cb valid,
-                                             datagen_cb test) {
+std::unique_ptr<DataBuffer> createDataBuffer(DatasetType type, datagen_cb cb,
+                                             void *user_data) {
   if (type != DatasetType::GENERATOR)
     throw std::invalid_argument("Cannot create dataset with generator "
                                 "callbacks with the given dataset type");
 
   std::unique_ptr<DataBuffer> dataset = createDataBuffer(type);
 
-  if (dataset->setGeneratorFunc(DatasetDataUsageType::DATA_TRAIN, train) !=
-      ML_ERROR_NONE)
+  if (dataset->setGeneratorFunc(DatasetDataUsageType::DATA_TRAIN, cb,
+                                user_data) != ML_ERROR_NONE)
     throw std::invalid_argument("Invalid train data generator");
-
-  if (valid && dataset->setGeneratorFunc(DatasetDataUsageType::DATA_VAL,
-                                         valid) != ML_ERROR_NONE)
-    throw std::invalid_argument("Invalid valid data generator");
-
-  if (test && dataset->setGeneratorFunc(DatasetDataUsageType::DATA_TEST,
-                                        test) != ML_ERROR_NONE)
-    throw std::invalid_argument("Invalid test data generator");
 
   return dataset;
 }

--- a/nntrainer/dataset/databuffer_factory.h
+++ b/nntrainer/dataset/databuffer_factory.h
@@ -27,16 +27,13 @@ std::unique_ptr<DataBuffer> createDataBuffer(DatasetType type);
  * @brief Factory creator with constructor for databuffer with files
  */
 std::unique_ptr<DataBuffer> createDataBuffer(DatasetType type,
-                                             const char *train_file,
-                                             const char *valid_file = nullptr,
-                                             const char *test_file = nullptr);
+                                             const char *file);
 
 /**
  * @brief Factory creator with constructor for databuffer with callbacks
  */
-std::unique_ptr<DataBuffer> createDataBuffer(DatasetType type, datagen_cb train,
-                                             datagen_cb valid = nullptr,
-                                             datagen_cb test = nullptr);
+std::unique_ptr<DataBuffer> createDataBuffer(DatasetType type, datagen_cb cb,
+                                             void *user_data = nullptr);
 
 } /* namespace nntrainer */
 

--- a/nntrainer/dataset/databuffer_func.cpp
+++ b/nntrainer/dataset/databuffer_func.cpp
@@ -86,7 +86,7 @@ int DataBufferFromCallback::init() {
 }
 
 int DataBufferFromCallback::setGeneratorFunc(DatasetDataUsageType type,
-                                             datagen_cb func) {
+                                             datagen_cb func, void *user_data) {
 
   int status = ML_ERROR_NONE;
   switch (type) {
@@ -94,6 +94,7 @@ int DataBufferFromCallback::setGeneratorFunc(DatasetDataUsageType type,
     if (!func)
       return ML_ERROR_INVALID_PARAMETER;
     callback_train = func;
+    this->user_data = user_data;
     if (func)
       validation[0] = true;
     break;

--- a/nntrainer/dataset/databuffer_func.h
+++ b/nntrainer/dataset/databuffer_func.h
@@ -65,7 +65,8 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int setGeneratorFunc(DatasetDataUsageType type, datagen_cb func);
+  int setGeneratorFunc(DatasetDataUsageType type, datagen_cb func,
+                       void *user_data = nullptr) override;
 
   /**
    * @brief     Update Data Buffer ( it is for child thread )

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -24,6 +24,7 @@
 #define __NEURALNET_H__
 #ifdef __cplusplus
 
+#include <array>
 #include <map>
 #include <memory>
 #include <vector>
@@ -32,7 +33,6 @@
 #endif
 
 #include <app_context.h>
-#include <databuffer.h>
 #include <dynamic_training_optimization.h>
 #include <layer_node.h>
 #include <manager.h>
@@ -44,6 +44,12 @@
 #include <model.h>
 #include <nntrainer-api-common.h>
 
+namespace ml::train {
+class DataSet;
+enum class DatasetType;
+enum class DatasetDataUsageType;
+} // namespace ml::train
+
 namespace nntrainer {
 
 /**
@@ -51,6 +57,9 @@ namespace nntrainer {
  */
 using NetType = ml::train::ModelType;
 
+class DataBuffer;
+using DatasetType = ml::train::DatasetType;
+using DatasetDataUsageType = ml::train::DatasetDataUsageType;
 /**
  * @brief     Statistics from running or training a model
  */
@@ -89,7 +98,7 @@ public:
     weight_initializer(WeightInitializer::WEIGHT_UNKNOWN),
     net_type(NetType::UNKNOWN),
     manager(std::make_shared<Manager>()),
-    data_buffer(nullptr),
+    data_buffers({nullptr, nullptr, nullptr}),
     continue_train(false),
     initialized(false),
     compiled(false),
@@ -269,21 +278,23 @@ public:
 
   /**
    * @brief     Run NeuralNetwork train with callback function by user
+   * @param[in] dt datatype (usage) where it should be
    * @param[in] dataset set the dataset
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int setDataset(std::shared_ptr<ml::train::Dataset> dataset) {
-    return setDataBuffer(std::static_pointer_cast<DataBuffer>(dataset));
-  }
+  int setDataset(const DatasetDataUsageType &dt,
+                 std::shared_ptr<ml::train::Dataset> dataset);
 
   /**
    * @brief     Run NeuralNetwork train with callback function by user
+   * @param[in] dt datatype (usage) where it should be
    * @param[in] databuffer set the databuffer
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int setDataBuffer(std::shared_ptr<DataBuffer> data_buffer);
+  int setDataBuffer(const DatasetDataUsageType &dt,
+                    std::shared_ptr<DataBuffer> data_buffer);
 
   /**
    * @brief     add layer into neural network model
@@ -511,7 +522,8 @@ private:
 
   std::shared_ptr<Manager> manager; /**< nntrainer manager */
 
-  std::shared_ptr<DataBuffer> data_buffer; /**< Data Buffer to get Input */
+  std::array<std::shared_ptr<DataBuffer>, 3>
+    data_buffers; /**< Data Buffers to get Input */
 
   bool continue_train; /**< Continue train from the previous state of
    optimizer and iterations */
@@ -575,7 +587,7 @@ private:
     swap(lhs.save_path, rhs.save_path);
     swap(lhs.opt, rhs.opt);
     swap(lhs.net_type, rhs.net_type);
-    swap(lhs.data_buffer, rhs.data_buffer);
+    swap(lhs.data_buffers, rhs.data_buffers);
     swap(lhs.continue_train, rhs.continue_train);
     swap(lhs.initialized, rhs.initialized);
     swap(lhs.model_graph, rhs.model_graph);

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -23,6 +23,7 @@
 #include <array>
 #include <assert.h>
 #include <cstring>
+#include <databuffer.h>
 #include <iostream>
 #include <layer_internal.h>
 #include <neuralnet.h>

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -204,7 +204,7 @@ TEST(nntrainer_ccapi, train_with_config_01_p) {
   EXPECT_NO_THROW(model->train());
 
   EXPECT_NEAR(model->getTrainingLoss(), 4.434051, tolerance);
-  EXPECT_NEAR(model->getValidationLoss(), 2.9646113, tolerance);
+  EXPECT_NEAR(model->getValidationLoss(), 2.910938, tolerance);
 }
 
 /**
@@ -237,12 +237,21 @@ TEST(nntrainer_ccapi, train_dataset_with_file_01_p) {
        "beta1=0.002", "beta2=0.001", "epsilon=1e-7"}));
   EXPECT_NO_THROW(model->setOptimizer(optimizer));
 
-  EXPECT_NO_THROW(dataset = ml::train::createDataset(
-                    ml::train::DatasetType::FILE,
-                    getTestResPath("trainingSet.dat").c_str(),
-                    getTestResPath("valSet.dat").c_str(), nullptr));
+  EXPECT_NO_THROW(
+    dataset = ml::train::createDataset(
+      ml::train::DatasetType::FILE, getTestResPath("trainingSet.dat").c_str()));
   EXPECT_EQ(dataset->setProperty({"buffer_size=100"}), ML_ERROR_NONE);
-  EXPECT_EQ(model->setDataset(dataset), ML_ERROR_NONE);
+  EXPECT_EQ(
+    model->setDataset(ml::train::DatasetDataUsageType::DATA_TRAIN, dataset),
+    ML_ERROR_NONE);
+
+  EXPECT_NO_THROW(
+    dataset = ml::train::createDataset(ml::train::DatasetType::FILE,
+                                       getTestResPath("valSet.dat").c_str()));
+  EXPECT_EQ(dataset->setProperty({"buffer_size=100"}), ML_ERROR_NONE);
+  EXPECT_EQ(
+    model->setDataset(ml::train::DatasetDataUsageType::DATA_VAL, dataset),
+    ML_ERROR_NONE);
 
   EXPECT_EQ(model->setProperty({"loss=cross", "batch_size=16", "epochs=2",
                                 "save_path=model.bin"}),
@@ -251,8 +260,8 @@ TEST(nntrainer_ccapi, train_dataset_with_file_01_p) {
   EXPECT_EQ(model->initialize(), ML_ERROR_NONE);
   EXPECT_NO_THROW(model->train());
 
-  EXPECT_NEAR(model->getTrainingLoss(), 2.1934659, tolerance);
-  EXPECT_NEAR(model->getValidationLoss(), 2.2051108, tolerance);
+  EXPECT_NEAR(model->getTrainingLoss(), 2.1866805, tolerance);
+  EXPECT_NEAR(model->getValidationLoss(), 2.18779993, tolerance);
 }
 
 /**
@@ -285,11 +294,19 @@ TEST(nntrainer_ccapi, train_dataset_with_generator_01_p) {
        "beta1=0.002", "beta2=0.001", "epsilon=1e-7"}));
   EXPECT_NO_THROW(model->setOptimizer(optimizer));
 
-  EXPECT_NO_THROW(
-    dataset = ml::train::createDataset(ml::train::DatasetType::GENERATOR,
-                                       getBatch_train, getBatch_val, nullptr));
+  EXPECT_NO_THROW(dataset = ml::train::createDataset(
+                    ml::train::DatasetType::GENERATOR, getBatch_train));
   EXPECT_EQ(dataset->setProperty({"buffer_size=100"}), ML_ERROR_NONE);
-  EXPECT_EQ(model->setDataset(dataset), ML_ERROR_NONE);
+  EXPECT_EQ(
+    model->setDataset(ml::train::DatasetDataUsageType::DATA_TRAIN, dataset),
+    ML_ERROR_NONE);
+
+  EXPECT_NO_THROW(dataset = ml::train::createDataset(
+                    ml::train::DatasetType::GENERATOR, getBatch_val));
+  EXPECT_EQ(dataset->setProperty({"buffer_size=100"}), ML_ERROR_NONE);
+  EXPECT_EQ(
+    model->setDataset(ml::train::DatasetDataUsageType::DATA_VAL, dataset),
+    ML_ERROR_NONE);
 
   EXPECT_EQ(model->setProperty({"loss=cross", "batch_size=16", "epochs=2",
                                 "save_path=model.bin"}),
@@ -332,12 +349,21 @@ TEST(nntrainer_ccapi, train_batch_size_update_after) {
        "beta1=0.002", "beta2=0.001", "epsilon=1e-7"}));
   EXPECT_NO_THROW(model->setOptimizer(optimizer));
 
-  EXPECT_NO_THROW(dataset = ml::train::createDataset(
-                    ml::train::DatasetType::FILE,
-                    getTestResPath("trainingSet.dat").c_str(),
-                    getTestResPath("valSet.dat").c_str(), nullptr));
+  EXPECT_NO_THROW(
+    dataset = ml::train::createDataset(
+      ml::train::DatasetType::FILE, getTestResPath("trainingSet.dat").c_str()));
   EXPECT_EQ(dataset->setProperty({"buffer_size=100"}), ML_ERROR_NONE);
-  EXPECT_EQ(model->setDataset(dataset), ML_ERROR_NONE);
+  EXPECT_EQ(
+    model->setDataset(ml::train::DatasetDataUsageType::DATA_TRAIN, dataset),
+    ML_ERROR_NONE);
+
+  EXPECT_NO_THROW(
+    dataset = ml::train::createDataset(ml::train::DatasetType::FILE,
+                                       getTestResPath("valSet.dat").c_str()));
+  EXPECT_EQ(dataset->setProperty({"buffer_size=100"}), ML_ERROR_NONE);
+  EXPECT_EQ(
+    model->setDataset(ml::train::DatasetDataUsageType::DATA_VAL, dataset),
+    ML_ERROR_NONE);
 
   EXPECT_EQ(model->setProperty({"loss=cross", "batch_size=16", "epochs=1"}),
             ML_ERROR_NONE);
@@ -364,8 +390,8 @@ TEST(nntrainer_ccapi, train_batch_size_update_after) {
   EXPECT_EQ(model->setProperty({"batch_size=4"}), ML_ERROR_NONE);
   EXPECT_NO_THROW(model->train());
 
-  EXPECT_NEAR(model->getTrainingLoss(), 1.9613363, tolerance);
-  EXPECT_NEAR(model->getValidationLoss(), 2.1835098, tolerance);
+  EXPECT_NEAR(model->getTrainingLoss(), 1.928810, tolerance);
+  EXPECT_NEAR(model->getValidationLoss(), 2.17899, tolerance);
 }
 
 /**

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -349,7 +349,7 @@ TEST(nntrainer_capi_nnmodel, train_01_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Compare training statistics */
-  nntrainer_capi_model_comp_metrics(handle, 4.01373, 3.55134, 10.4167);
+  nntrainer_capi_model_comp_metrics(handle, 4.01373, 3.50392, 10.4167);
 
   status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -745,7 +745,7 @@ TEST(nntrainer_capi_nnmodel, train_with_file_01_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Compare training statistics */
-  nntrainer_capi_model_comp_metrics(model, 2.13067, 2.19975, 20.8333);
+  nntrainer_capi_model_comp_metrics(model, 2.12599992, 2.200589, 20.8333);
 
   status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);


### PR DESCRIPTION
- [dataset] Clean up dataset enums

```
`nntrainer::DataType` and `nntrainer::BufferType` is duplicated from
ccapi which was adding complication. This patch simply alternate those
types ccapi `DatasetType` / `DatasetDataUsageType`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [dataset] split train / val / test databuffer

```
This patch splits train / val / test dataset.

It is also possible to set dataset separately from the model.

**Major Changes**
1. `auto dataset = createDataset(train_cb, val_cb, test_cb)` -> `auto
dataset_train = createDataset(train_cb)`
1. `NN.setDataset(dataset);` -> `NN.setDataset(DATA_TRAIN,
dataset_train)`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [dataset] Clean up dataset enums

```
`nntrainer::DataType` and `nntrainer::BufferType` is duplicated from
ccapi which was adding complication. This patch simply alternate those
types ccapi `DatasetType` / `DatasetDataUsageType`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```