### PR TITLE
[applications] Enable working applications with v2

### DIFF
--- a/Applications/ProductRatings/res/product_ratings_model.ini
+++ b/Applications/ProductRatings/res/product_ratings_model.ini
@@ -26,14 +26,12 @@ input_layers = split
 Type = embedding
 in_dim = 6          # in dim must be more than len(set(user ids)) + 1
 out_dim = 5
-in_length = 1
 
 [product_embed]
 input_layers = split
 Type = embedding
 in_dim = 6          # in dim must be more than len(set(product ids)) + 1
 out_dim = 5
-in_length = 1
 
 [concat]
 input_layers = user_embed, product_embed

--- a/Applications/TransferLearning/CIFAR_Classification/jni/main.cpp
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/main.cpp
@@ -421,10 +421,19 @@ int main(int argc, char *argv[]) {
    * @brief     Neural Network Create & Initialization
    */
   nntrainer::NeuralNetwork NN;
+  int status = ML_ERROR_NONE;
   try {
-    NN.loadFromConfig(config);
-    NN.compile();
-    NN.initialize();
+    status = NN.loadFromConfig(config);
+    if (status != ML_ERROR_NONE)
+      return status;
+
+    status = NN.compile();
+    if (status != ML_ERROR_NONE)
+      return status;
+
+    status = NN.initialize();
+    if (status != ML_ERROR_NONE)
+      return status;
   } catch (...) {
     std::cerr << "Error during init" << std::endl;
     return 1;

--- a/Applications/TransferLearning/CIFAR_Classification/res/Classification.ini
+++ b/Applications/TransferLearning/CIFAR_Classification/res/Classification.ini
@@ -25,7 +25,6 @@ LabelData="label.dat"
 [inputlayer]
 Type = input
 Input_Shape = 1:1:62720	# Input Layer Dimension
-Bias_initializer = zeros	# Zero Bias
 Normalization = true
 
 [outputlayer]

--- a/Applications/TransferLearning/CIFAR_Classification/res/Classification_new.ini
+++ b/Applications/TransferLearning/CIFAR_Classification/res/Classification_new.ini
@@ -17,7 +17,6 @@ Decay_steps = 1000       # decay step for the exponential decayed learning rate
 [inputlayer]
 Type = InputLayer
 HiddenSize = 62720	# Input Layer Dimension
-Bias_initializer = zeros	# Zero Bias
 
 [fc1layer]
 Type = FullyConnectedLayer

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -10,10 +10,10 @@ endif
 subdir('VGG/jni')
 subdir('ReinforcementLearning/DeepQ/jni')
 subdir('TransferLearning/CIFAR_Classification/jni')
-subdir('TransferLearning/Draw_Classification/jni')
-subdir('Custom')
+# subdir('TransferLearning/Draw_Classification/jni')
+# subdir('Custom')
 subdir('ProductRatings/jni')
 
 if get_option('enable-tflite-backbone')
-  subdir('SimpleShot')
+# subdir('SimpleShot')
 endif

--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -114,7 +114,6 @@ public:
    * - random_translate
    * - in_dim : int ( input dimension for embedding layer )
    * - out_dim : int ( output dimesion for embedding layer )
-   * - in_length : int ( input length for embedding layer )
    * - recurrent_activation : string (type) - used only in lstm
    * - return_sequences : bool (type) - used only in lstm
    * - distribute : bool

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,7 @@
 option('enable-tizen', type: 'boolean', value: false)
 option('enable-blas', type: 'boolean', value: true)
 option('enable-cublas', type: 'boolean', value: false)
-option('enable-app', type: 'boolean', value: false)
+option('enable-app', type: 'boolean', value: true)
 option('install-app', type: 'boolean', value: true)
 option('use_gym', type: 'boolean', value: false)
 option('enable-capi', type: 'boolean', value: true)

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -21,92 +21,98 @@
 
 namespace nntrainer {
 
-int ConcatLayer::initialize(Manager &manager) {
-  int status = ML_ERROR_NONE;
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
+void ConcatLayer::finalize(InitLayerContext &context) {
   unsigned int channel = 0;
 
-  if (getNumInputs() == 0) {
-    ml_loge("Error: number of inputs are not initialized");
-    return ML_ERROR_INVALID_PARAMETER;
-  }
+  auto const &input_dims = context.getInputDimensions();
+  const TensorDim &input_dim_0 = input_dims[SINGLE_INOUT_IDX];
+  channel += input_dim_0.channel();
+  for (unsigned int idx = 1; idx < context.getNumInputs(); ++idx) {
+    const TensorDim &dim = input_dims[idx];
 
-  const TensorDim &d = input_dim[0];
-  channel += d.channel();
-  for (unsigned int idx = 1; idx < getNumInputs(); ++idx) {
-    const TensorDim &dim = input_dim[idx];
-
-    for (unsigned int i = 2; i < d.rank(); ++i) {
-      if (d[i] != dim[i])
+    for (unsigned int i = 2; i < input_dim_0.rank(); ++i) {
+      if (input_dim_0[i] != dim[i])
         throw std::runtime_error("Error: concat layer requires same "
                                  "shape from  all input layers");
     }
-    channel += input_dim[idx].channel();
+    channel += dim.channel();
   }
 
-  output_dim[0] = input_dim[0];
-  output_dim[0].channel(channel);
+  TensorDim output_dim = input_dim_0;
+  output_dim.channel(channel);
 
-  return status;
+  context.setOutputDimensions({output_dim});
 }
 
-void ConcatLayer::forwarding(bool training) {
-  Tensor &hidden_ = net_hidden[0]->getVariableRef();
+void ConcatLayer::forwarding(RunLayerContext &context, bool training) {
+  Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
+  const TensorDim &output_dim = hidden_.getDim();
 
 #ifdef DEBUG
+  const TensorDim &input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
   unsigned int channel = 0;
-  const TensorDim &d = net_input[0]->getDim();
-  channel += d.channel();
-  for (unsigned int idx = 1; idx < getNumInputs(); ++idx) {
-    const TensorDim &dim = net_input[idx]->getDim();
+  channel += input_dim.channel();
+  for (unsigned int idx = 1; idx < context.getNumInputs(); ++idx) {
+    const TensorDim &dim = context.getInput(idx).getDim();
 
-    for (unsigned int i = 2; i < d.rank(); ++i) {
-      if (d[i] != dim[i])
+    for (unsigned int i = 2; i < input_dim.rank(); ++i) {
+      if (input_dim[i] != dim[i])
         throw std::runtime_error("Error: concat layer requires same "
                                  "shape from  all input layers");
     }
-    channel += input_dim[idx].channel();
+    channel += dim.channel();
   }
 
-  if (channel != output_dim[0].channel())
+  if (channel != output_dim.channel())
     throw std::runtime_error(
       "Error: Sum of channel of input layers is not same with output channel");
 #endif
 
-  unsigned int f_size = output_dim[0].getFeatureLen();
+  unsigned int f_size = output_dim.getFeatureLen();
 
   /**
    * @todo avoid copy by creating input here as a shared_tensor of the output
    * here and then this layer can be in_place as well
    */
-  for (unsigned int b = 0; b < input_dim[0].batch(); ++b) {
+  for (unsigned int b = 0; b < output_dim.batch(); ++b) {
     unsigned int position = 0;
-    for (unsigned int idx = 0; idx < getNumInputs(); ++idx) {
-      TensorDim in_dim = net_input[idx]->getDim();
-      memcpy(
-        hidden_.getAddress(b * f_size + position),
-        net_input[idx]->getVariable().getAddress(b * in_dim.getFeatureLen()),
-        in_dim.getFeatureLen() * sizeof(float));
+    for (unsigned int idx = 0; idx < context.getNumInputs(); ++idx) {
+      Tensor &input_ = context.getInput(idx);
+      TensorDim in_dim = input_.getDim();
+      memcpy(hidden_.getAddress(b * f_size + position),
+             input_.getAddress(b * in_dim.getFeatureLen()),
+             in_dim.getFeatureLen() * sizeof(float));
       position += in_dim.getFeatureLen();
     }
   }
 }
 
-void ConcatLayer::calcDerivative() {
-  TensorDim d = net_hidden[0]->getDim();
+void ConcatLayer::calcDerivative(RunLayerContext &context) {
+  Tensor &derivative_ = context.getIncomingDerivative(SINGLE_INOUT_IDX);
+  TensorDim d = derivative_.getDim();
 
   unsigned int position = 0;
-  for (unsigned int idx = 0; idx < getNumInputs(); ++idx) {
-    TensorDim in_dim = input_dim[idx];
+  for (unsigned int idx = 0; idx < context.getNumInputs(); ++idx) {
+    Tensor &ret_ = context.getOutgoingDerivative(idx);
+    TensorDim in_dim = ret_.getDim();
 
     for (unsigned int b = 0; b < in_dim.batch(); ++b) {
       // TODO: replace with tensor::copy/fill
-      memcpy(
-        net_input[idx]->getGradient().getAddress(b * in_dim.getFeatureLen()),
-        net_hidden[0]->getGradient().getAddress(b * d.getFeatureLen() +
-                                                position),
-        in_dim.getFeatureLen() * sizeof(float));
+      memcpy(ret_.getAddress(b * in_dim.getFeatureLen()),
+             derivative_.getAddress(b * d.getFeatureLen() + position),
+             in_dim.getFeatureLen() * sizeof(float));
     }
     position += in_dim.getFeatureLen();
+  }
+}
+
+void ConcatLayer::setProperty(const std::vector<std::string> &values) {
+  if (!values.empty()) {
+    std::string msg = "[ConcatLayer] Unknown Layer Properties count " +
+                      std::to_string(values.size());
+    throw exception::not_supported(msg);
   }
 }
 

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -15,8 +15,7 @@
 #define __CONCAT_LAYER_H__
 #ifdef __cplusplus
 
-#include <layer_internal.h>
-#include <tensor.h>
+#include <layer_devel.h>
 
 namespace nntrainer {
 
@@ -24,15 +23,12 @@ namespace nntrainer {
  * @class   Concat Layer
  * @brief   Concat Layer
  */
-class ConcatLayer : public LayerV1 {
+class ConcatLayer : public Layer {
 public:
   /**
    * @brief     Constructor of Concat Layer
    */
-  template <typename... Args>
-  ConcatLayer(unsigned int num_inputs_ = 1, Args... args) : LayerV1(args...) {
-    setNumInputs(num_inputs_);
-  }
+  ConcatLayer() : Layer() {}
 
   /**
    * @brief     Destructor of Concat Layer
@@ -52,39 +48,35 @@ public:
   ConcatLayer &operator=(ConcatLayer &&rhs) = default;
 
   /**
-   * @brief     initialize layer
-   * @param[in] last last layer
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @copydoc Layer::finalize(InitLayerContext &context)
    */
-  int initialize(Manager &manager) override;
+  void finalize(InitLayerContext &context) override;
 
   /**
-   * @brief     Read Weight & Bias Data from file
-   * @param[in] file input stream file
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
-  void read(std::ifstream &file) override{};
+  void forwarding(RunLayerContext &context, bool training) override;
 
   /**
-   * @brief     Save Weight & Bias Data to file
-   * @param[in] file output stream file
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
-  void save(std::ofstream &file) override{};
-
-  /**
-   * @copydoc Layer::forwarding(bool training)
-   */
-  void forwarding(bool training = true) override;
-
-  /**
-   * @copydoc Layer::calcDerivative()
-   */
-  void calcDerivative() override;
+  void calcDerivative(RunLayerContext &context) override;
 
   /**
    * @copydoc Layer::getType()
    */
   const std::string getType() const override { return ConcatLayer::type; };
+
+  /**
+   * @copydoc Layer::supportBackwarding()
+   */
+  bool supportBackwarding() const { return true; }
+
+  /**
+   * @copydoc Layer::setProperty(const PropertyType type, const std::string
+   * &value)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
 
   inline static const std::string type = "concat";
 };

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -38,7 +38,7 @@ void EmbeddingLayer::finalize(InitLayerContext &context) {
 
   TensorDim output_dim = input_dim;
 
-  output_dim.height(in_length);
+  output_dim.height(input_dim.width());
   output_dim.width(out_dim);
   context.setOutputDimensions({output_dim});
 
@@ -89,10 +89,6 @@ void EmbeddingLayer::setProperty(const std::string &type_str,
     status = setUint(out_dim, value);
     throw_status(status);
   } break;
-  case PropertyType::in_length: {
-    status = setUint(in_length, value);
-    throw_status(status);
-  } break;
   default:
     LayerImpl::setProperty(type_str, value);
     break;
@@ -107,7 +103,7 @@ void EmbeddingLayer::forwarding(RunLayerContext &context, bool training) {
   for (unsigned int b = 0; b < input_.batch(); ++b) {
     float *in_data = input_.getAddress(b * input_.getDim().getFeatureLen());
 
-    for (unsigned int i = 0; i < in_length; ++i) {
+    for (unsigned int i = 0; i < input_.width(); ++i) {
       if (in_data[i] > in_dim) {
         throw std::invalid_argument("input word index is greater than in_dim");
       }
@@ -149,7 +145,7 @@ void EmbeddingLayer::calcGradient(RunLayerContext &context) {
   for (unsigned int b = 0; b < input_.batch(); ++b) {
     float *in_data = input_.getAddress(b * input_.getDim().getFeatureLen());
 
-    for (unsigned int i = 0; i < in_length; ++i) {
+    for (unsigned int i = 0; i < input_.width(); ++i) {
       // Assume padding is 0 and index always start from 1.
       // If in_data[i] - 1 < 0, then it skips.
       if (in_data[i] - 1 < 0)

--- a/nntrainer/layers/embedding.h
+++ b/nntrainer/layers/embedding.h
@@ -28,12 +28,10 @@ public:
   /**
    * @brief     Constructor of Embedding Layer
    */
-  EmbeddingLayer(unsigned int in_dim_ = 0, unsigned int out_dim_ = 0,
-                 unsigned int in_length_ = 0) :
+  EmbeddingLayer(unsigned int in_dim_ = 0, unsigned int out_dim_ = 0) :
     LayerImpl(),
     in_dim(in_dim_),
     out_dim(out_dim_),
-    in_length(in_length_),
     weight_idx(0) {}
 
   /**
@@ -104,7 +102,6 @@ public:
 private:
   unsigned int in_dim;
   unsigned int out_dim;
-  unsigned int in_length;
   unsigned int weight_idx;
 
   /**

--- a/nntrainer/layers/layer_internal.h
+++ b/nntrainer/layers/layer_internal.h
@@ -239,12 +239,11 @@ public:
    *            28. random_translate
    *            29. in_dim : int ( input dimension for embedding layer )
    *            30. out_dim : int ( output dimesion for embedding layer )
-   *            31. in_length : int ( input length for embedding layer )
-   *            32. recurrent_activation :  string (type) - lstm
-   *            33. distribute : bool
-   *            34. split_dimension : string (type)
-   *            35. return_sequences :  bool (type) - lstm
-   *            36. hidden_state_activation :  string (type) - lstm
+   *            31. recurrent_activation :  string (type) - lstm
+   *            32. distribute : bool
+   *            33. split_dimension : string (type)
+   *            34. return_sequences :  bool (type) - lstm
+   *            35. hidden_state_activation :  string (type) - lstm
    */
   enum class PropertyType {
     input_shape = 0,
@@ -278,12 +277,11 @@ public:
     random_translate = 28,
     in_dim = 29,
     out_dim = 30,
-    in_length = 31,
-    recurrent_activation = 32,
-    distribute = 33,
-    split_dimension = 34,
-    return_sequences = 35,
-    hidden_state_activation = 36,
+    recurrent_activation = 31,
+    distribute = 32,
+    split_dimension = 33,
+    return_sequences = 34,
+    hidden_state_activation = 35,
     unknown
   };
 

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -222,12 +222,11 @@ unsigned int parseType(std::string ll, InputType t) {
  * random_translate = 28
  * in_dim = 29
  * out_dim = 30
- * in_length = 31
- * recurrent_activation = 32
- * distribute = 33
- * split_dimension = 34
- * return_sequences = 35
- * hidden_state_activation = 36
+ * recurrent_activation = 31
+ * distribute = 32
+ * split_dimension = 33
+ * return_sequences = 34
+ * hidden_state_activation = 35
  *
  * InputLayer has 0, 1, 2, 3 properties.
  * FullyConnectedLayer has 1, 4, 6, 7, 8, 9 properties.
@@ -235,7 +234,7 @@ unsigned int parseType(std::string ll, InputType t) {
  * Pooling2DLayer has 12, 13, 14, 15 properties.
  * BatchNormalizationLayer has 0, 1, 5, 6, 7 properties.
  */
-static std::array<std::string, 38> property_string = {
+static std::array<std::string, 37> property_string = {
   "input_shape",
   "normalization",
   "standardization",
@@ -267,7 +266,6 @@ static std::array<std::string, 38> property_string = {
   "random_translate",
   "in_dim",
   "out_dim",
-  "in_length",
   "recurrent_activation",
   "distribute",
   "split_dimension",

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -16,6 +16,7 @@ test_target = [
   'unittest_layers_lstm.cpp',
   'unittest_layers_gru.cpp',
   'unittest_layers_preprocess.cpp',
+  'unittest_layers_split.cpp',
 ]
 
 exe = executable(

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -18,6 +18,7 @@ test_target = [
   'unittest_layers_preprocess.cpp',
   'unittest_layers_split.cpp',
   'unittest_layers_embedding.cpp',
+  'unittest_layers_concat.cpp',
 ]
 
 exe = executable(

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -17,6 +17,7 @@ test_target = [
   'unittest_layers_gru.cpp',
   'unittest_layers_preprocess.cpp',
   'unittest_layers_split.cpp',
+  'unittest_layers_embedding.cpp',
 ]
 
 exe = executable(

--- a/test/unittest/layers/unittest_layers_concat.cpp
+++ b/test/unittest/layers/unittest_layers_concat.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_concat =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::ConcatLayer>,
-                          nntrainer::ConcatLayer::type, {}, {}, 0, false);
+                          nntrainer::ConcatLayer::type, {}, 0, false);
 
 INSTANTIATE_TEST_CASE_P(Concat, LayerSemantics,
                         ::testing::Values(semantic_concat));

--- a/test/unittest/layers/unittest_layers_concat.cpp
+++ b/test/unittest/layers/unittest_layers_concat.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_layers_concat.cpp
+ * @date 7 July 2021
+ * @brief Concat Layer Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include <concat_layer.h>
+#include <layers_common_tests.h>
+
+auto semantic_concat =
+  LayerSemanticsParamType(nntrainer::createLayer<nntrainer::ConcatLayer>,
+                          nntrainer::ConcatLayer::type, {}, {}, 0, false);
+
+INSTANTIATE_TEST_CASE_P(Concat, LayerSemantics,
+                        ::testing::Values(semantic_concat));

--- a/test/unittest/layers/unittest_layers_embedding.cpp
+++ b/test/unittest/layers/unittest_layers_embedding.cpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_layers_embedding.cpp
+ * @date 12 June 2021
+ * @brief Embedding Layer Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include <embedding.h>
+#include <layers_common_tests.h>
+
+auto semantic_embedding = LayerSemanticsParamType(
+  nntrainer::createLayer<nntrainer::EmbeddingLayer>,
+  nntrainer::EmbeddingLayer::type, {"in_length=1", "out_dim=1", "in_dim=1"}, {},
+  0, false);
+
+INSTANTIATE_TEST_CASE_P(Embedding, LayerSemantics,
+                        ::testing::Values(semantic_embedding));

--- a/test/unittest/layers/unittest_layers_embedding.cpp
+++ b/test/unittest/layers/unittest_layers_embedding.cpp
@@ -18,8 +18,7 @@
 
 auto semantic_embedding = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::EmbeddingLayer>,
-  nntrainer::EmbeddingLayer::type, {"in_length=1", "out_dim=1", "in_dim=1"}, {},
-  0, false);
+  nntrainer::EmbeddingLayer::type, {"out_dim=1", "in_dim=1"}, 0, false);
 
 INSTANTIATE_TEST_CASE_P(Embedding, LayerSemantics,
                         ::testing::Values(semantic_embedding));

--- a/test/unittest/layers/unittest_layers_split.cpp
+++ b/test/unittest/layers/unittest_layers_split.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_layers_fully_connected.cpp
+ * @date 12 June 2021
+ * @brief Split Layer Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include <layers_common_tests.h>
+#include <split_layer.h>
+
+auto semantic_split =
+  LayerSemanticsParamType(nntrainer::createLayer<nntrainer::SplitLayer>,
+                          nntrainer::SplitLayer::type, {}, {}, 0, false);
+
+INSTANTIATE_TEST_CASE_P(Split, LayerSemantics,
+                        ::testing::Values(semantic_split));

--- a/test/unittest/layers/unittest_layers_split.cpp
+++ b/test/unittest/layers/unittest_layers_split.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_split =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::SplitLayer>,
-                          nntrainer::SplitLayer::type, {}, {}, 0, false);
+                          nntrainer::SplitLayer::type, {}, 0, false);
 
 INSTANTIATE_TEST_CASE_P(Split, LayerSemantics,
                         ::testing::Values(semantic_split));

--- a/test/unittest/unittest_nntrainer_layers.cpp
+++ b/test/unittest/unittest_nntrainer_layers.cpp
@@ -2251,8 +2251,7 @@ protected:
 
   virtual void prepareLayer() {
     int status = setProperty("in_dim=50 |"
-                             "out_dim=8 |"
-                             "in_length=12");
+                             "out_dim=8");
     EXPECT_EQ(status, ML_ERROR_NONE);
     setBatch(3);
   }


### PR DESCRIPTION
Enable working applications with v2. This is done by also enabling split, concat and embedding layer for the V2 design.
Adding some minor updates to the applications to match with the v2 implementation.

An extra property from embedding layer was also removed to work with the new LayerV2 semantics.

resolves #1229

Signed-off-by: Parichay Kapoor <kparichay@gmail.com>