### PR TITLE
[application] SimpleShot application update for V2

### DIFF
--- a/Applications/SimpleShot/layers/centering.cpp
+++ b/Applications/SimpleShot/layers/centering.cpp
@@ -67,9 +67,6 @@ void CenteringLayer::forwarding(nntrainer::RunLayerContext &context,
   auto &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
   auto &input_ = context.getInput(SINGLE_INOUT_IDX);
 
-  std::cout << input_.getDim();
-  std::cout << hidden_.getDim();
-  std::cout << mean_feature_vector.getDim();
   input_.add(mean_feature_vector, hidden_, -1);
 }
 

--- a/Applications/SimpleShot/layers/centering.h
+++ b/Applications/SimpleShot/layers/centering.h
@@ -16,11 +16,9 @@
 #define __CENTERING_H__
 #include <string>
 
-/// @todo migrate these to API
-#include <layer_internal.h>
-#include <manager.h>
-
-#include <tensor.h>
+#include <layer_context.h>
+#include <layer_devel.h>
+#include <node_exporter.h>
 
 namespace simpleshot {
 namespace layers {
@@ -30,12 +28,12 @@ namespace layers {
  * subtraction from mean feature vector
  *
  */
-class CenteringLayer : public nntrainer::LayerV1 {
+class CenteringLayer : public nntrainer::Layer {
 public:
   /**
    * @brief Construct a new Centering Layer object
    */
-  CenteringLayer() : LayerV1() {}
+  CenteringLayer() : Layer() {}
 
   /**
    * @brief Construct a new Centering Layer object
@@ -62,40 +60,20 @@ public:
    */
   ~CenteringLayer() {}
 
-  using nntrainer::LayerV1::setProperty;
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
-   * @brief     set Property of layer,
-   * feature_path: feature *.bin that contains mean feature vector that will be
-   * used for the model.
-   * @param[in] values values of property
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
-  int setProperty(std::vector<std::string> values) override;
+  void forwarding(nntrainer::RunLayerContext &context, bool training) override;
 
   /**
-   * @brief initializing nntrainer
-   *
-   * @return int ML_ERROR_NONE if success
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
-  int initialize(nntrainer::Manager &manager) override;
-
-  /**
-   * @brief nntrainer forwarding function
-   */
-  void forwarding(bool training = true) override;
-
-  /**
-   * @brief     calc the derivative to be passed to the previous layer
-   */
-  void calcDerivative() override;
-
-  /**
-   * @brief     read layer Weight & Bias data from file
-   * @param[in] file input file stream
-   */
-  void read(std::ifstream &file) override;
+  void calcDerivative(nntrainer::RunLayerContext &context) override;
 
   /**
    * @copydoc bool supportBackwarding() const
@@ -103,11 +81,20 @@ public:
   bool supportBackwarding() const override { return false; };
 
   /**
-   * @brief Get the Type object
-   *
-   * @return const std::string
+   * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
    */
-  const std::string getType() const override { return CenteringLayer::type; }
+  void exportTo(nntrainer::Exporter &exporter,
+                const nntrainer::ExportMethods &method) const override {}
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  const std::string getType() const override { return CenteringLayer::type; };
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
 
   inline static const std::string type = "centering";
 

--- a/Applications/SimpleShot/layers/l2norm.h
+++ b/Applications/SimpleShot/layers/l2norm.h
@@ -16,11 +16,9 @@
 #define __L2NORM__H_
 #include <string>
 
-/// @todo migrate these to API
-#include <layer_internal.h>
-#include <manager.h>
-
-#include <tensor.h>
+#include <layer_context.h>
+#include <layer_devel.h>
+#include <node_exporter.h>
 
 namespace simpleshot {
 namespace layers {
@@ -29,13 +27,13 @@ namespace layers {
  * @brief Layer class that l2normalizes a feature vector
  *
  */
-class L2NormLayer : public nntrainer::LayerV1 {
+class L2NormLayer : public nntrainer::Layer {
 public:
   /**
    * @brief Construct a new L2norm Layer object
    * that normlizes given feature with l2norm
    */
-  L2NormLayer() : LayerV1() {}
+  L2NormLayer() : Layer() {}
 
   /**
    *  @brief  Move constructor.
@@ -55,36 +53,41 @@ public:
    */
   ~L2NormLayer() {}
 
-  using nntrainer::LayerV1::setProperty;
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
-   * @brief initializing nntrainer
-   *
-   * @return int ML_ERROR_NONE if success
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
-  int initialize(nntrainer::Manager &manager) override;
+  void forwarding(nntrainer::RunLayerContext &context, bool training) override;
 
   /**
-   * @brief nntrainer forwarding function
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
-  void forwarding(bool training = true) override;
-
-  /**
-   * @brief     calc the derivative to be passed to the previous layer
-   */
-  void calcDerivative() override;
-
-  /**
-   * @brief Get the Type object
-   *
-   * @return const std::string
-   */
-  const std::string getType() const override { return L2NormLayer::type; }
+  void calcDerivative(nntrainer::RunLayerContext &context) override;
 
   /**
    * @copydoc bool supportBackwarding() const
    */
   bool supportBackwarding() const override { return false; };
+
+  /**
+   * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
+   */
+  void exportTo(nntrainer::Exporter &exporter,
+                const nntrainer::ExportMethods &method) const override {}
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  const std::string getType() const override { return L2NormLayer::type; };
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
 
   inline static const std::string type = "l2norm";
 };

--- a/Applications/SimpleShot/layers/l2norm.h
+++ b/Applications/SimpleShot/layers/l2norm.h
@@ -12,8 +12,8 @@
  *
  */
 
-#ifndef __L2NORM__H_
-#define __L2NORM__H_
+#ifndef __L2NORM_H__
+#define __L2NORM_H__
 #include <string>
 
 #include <layer_context.h>

--- a/Applications/SimpleShot/meson.build
+++ b/Applications/SimpleShot/meson.build
@@ -23,7 +23,7 @@ if get_option('enable-test')
     sources: simpleshot_sources,
     include_directories: simpleshot_inc,
   )
-  subdir('test')
+  # subdir('test')
 endif
 
 test('app_simpleshot_sample', e, args: [

--- a/Applications/SimpleShot/meson.build
+++ b/Applications/SimpleShot/meson.build
@@ -23,7 +23,7 @@ if get_option('enable-test')
     sources: simpleshot_sources,
     include_directories: simpleshot_inc,
   )
-  # subdir('test')
+  subdir('test')
 endif
 
 test('app_simpleshot_sample', e, args: [

--- a/Applications/SimpleShot/task_runner.cpp
+++ b/Applications/SimpleShot/task_runner.cpp
@@ -126,7 +126,7 @@ std::unique_ptr<ml::train::Model> createModel(const std::string &backbone,
                                               const std::string &variant = "UN",
                                               const int num_classes = 5) {
   auto model = ml::train::createModel(ml::train::ModelType::NEURAL_NET,
-                                      {"loss=mse", "batch_size=1", "epochs=1"});
+                                      {"batch_size=1", "epochs=1"});
 
   LayerHandle backbone_layer = ml::train::layer::BackboneTFLite(
     {"name=backbone", "modelfile=" + getModelFilePath(backbone, app_path),

--- a/Applications/SimpleShot/test/meson.build
+++ b/Applications/SimpleShot/test/meson.build
@@ -1,8 +1,9 @@
 test_target = [
-  'simpleshot_utils_test.cpp',
-  'simpleshot_centering_test.cpp',
-  'simpleshot_l2norm_test.cpp',
-  'simpleshot_centroid_knn.cpp'
+  # 'simpleshot_utils_test.cpp',
+  # 'simpleshot_centering_test.cpp',
+  # 'simpleshot_l2norm_test.cpp',
+  # 'simpleshot_centroid_knn.cpp',
+  'simpleshot_layer_common_tests.cpp'
 ]
 
 exe = executable(
@@ -11,7 +12,9 @@ exe = executable(
       simpleshot_test_dep,
       nntrainer_dep,
       nntrainer_ccapi_dep,
-      nntrainer_testutil_dep],
+      nntrainer_testutil_dep,
+      nntrainer_layer_common_standalone_tests_dep
+      ],
   install: get_option('enable-test'),
   install_dir: application_install_dir
 )

--- a/Applications/SimpleShot/test/simpleshot_centering_test.cpp
+++ b/Applications/SimpleShot/test/simpleshot_centering_test.cpp
@@ -38,7 +38,7 @@ TEST(centering, simple_functions) {
   app_context.registerFactory(nntrainer::createLayer<CenteringLayer>);
 
   auto lnode =
-    nntrainer::createLayerNode(app_context.createObject<nntrainer::LayerV1>(
+    nntrainer::createLayerNode(app_context.createObject<nntrainer::Layer>(
       "centering", {"feature_path=feature.bin", "input_shape=1:1:4"}));
   auto &c = lnode->getObject();
 

--- a/Applications/SimpleShot/test/simpleshot_centroid_knn.cpp
+++ b/Applications/SimpleShot/test/simpleshot_centroid_knn.cpp
@@ -29,7 +29,7 @@ TEST(centroid_knn, simple_functions) {
   app_context.registerFactory(nntrainer::createLayer<CentroidKNN>);
 
   auto lnode =
-    nntrainer::createLayerNode(app_context.createObject<nntrainer::LayerV1>(
+    nntrainer::createLayerNode(app_context.createObject<nntrainer::Layer>(
       "centroid_knn", {"num_class=5", "input_shape=1:1:3"}));
   auto &c = lnode->getObject();
 

--- a/Applications/SimpleShot/test/simpleshot_l2norm_test.cpp
+++ b/Applications/SimpleShot/test/simpleshot_l2norm_test.cpp
@@ -29,7 +29,7 @@ TEST(l2norm, simple_functions) {
   app_context.registerFactory(nntrainer::createLayer<L2NormLayer>);
 
   auto lnode =
-    nntrainer::createLayerNode(app_context.createObject<nntrainer::LayerV1>(
+    nntrainer::createLayerNode(app_context.createObject<nntrainer::Layer>(
       "l2norm", {"input_shape=1:1:4"}));
   auto &c = lnode->getObject();
 

--- a/Applications/SimpleShot/test/simpleshot_layer_common_tests.cpp
+++ b/Applications/SimpleShot/test/simpleshot_layer_common_tests.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_layers_pooling.cpp
+ * @date 13 July 2021
+ * @brief Simpleshot Layers Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include <centering.h>
+#include <centroid_knn.h>
+#include <l2norm.h>
+#include <layers_common_tests.h>
+
+auto semantic_activation_l2norm = LayerSemanticsParamType(
+  nntrainer::createLayer<simpleshot::layers::L2NormLayer>,
+  simpleshot::layers::L2NormLayer::type, {}, 0, false);
+
+auto semantic_activation_centroid_knn = LayerSemanticsParamType(
+  nntrainer::createLayer<simpleshot::layers::CentroidKNN>,
+  simpleshot::layers::CentroidKNN::type, {"num_class=1"}, 0, false);
+
+auto semantic_activation_centering = LayerSemanticsParamType(
+  nntrainer::createLayer<simpleshot::layers::CenteringLayer>,
+  simpleshot::layers::CenteringLayer::type,
+  {"feature_path=../Applications/SimpleShot/backbones/"
+   "conv4_60classes_feature_vector.bin"},
+  0, false);
+
+INSTANTIATE_TEST_CASE_P(L2NormLayer, LayerSemantics,
+                        ::testing::Values(semantic_activation_l2norm));
+
+INSTANTIATE_TEST_CASE_P(CentroidKNN, LayerSemantics,
+                        ::testing::Values(semantic_activation_centroid_knn));
+
+INSTANTIATE_TEST_CASE_P(CenteringLayer, LayerSemantics,
+                        ::testing::Values(semantic_activation_centering));

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -15,5 +15,5 @@ subdir('Custom')
 subdir('ProductRatings/jni')
 
 if get_option('enable-tflite-backbone')
-# subdir('SimpleShot')
+  subdir('SimpleShot')
 endif


### PR DESCRIPTION
SimpleShot application update for layer V2 design.
This includes updating the three implemented layers - centering, l2norm, and centroid_knn.
Further, task_runner has been updated to use only 1 loss kind of layer.

Unittests of layers have not been enabled, they will be enabled with unittest_layers.

Signed-off-by: Parichay Kapoor <kparichay@gmail.com>