### PR TITLE
[spec/pkg] Bugfix for dependency

### DIFF
--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -158,7 +158,7 @@ This contains corresponding header files and .pc pkgconfig file.
 
 %package devel-static
 Summary:        Static library for nntrainer-devel package
-Requires:       devel = %{version}-%{release}
+Requires:       nntrainer-devel = %{version}-%{release}
 %description devel-static
 Static library package of nntrainer-devel
 
@@ -252,8 +252,8 @@ NNSteamer tensor filter for nntrainer to support inference.
 
 %package -n nnstreamer-nntrainer-devel-static
 Summary: NNStreamer NNTrainer support
-Requires: devel-static = %{version}-%{release}
-Requires:	nnstreamer-nntrainer
+Requires: nntrainer-devel-static = %{version}-%{release}
+Requires:	nnstreamer-nntrainer = %{version}-%{release}
 %description -n nnstreamer-nntrainer-devel-static
 NNSteamer tensor filter static package for nntrainer to support inference.
 %endif #nnstreamer_filter


### PR DESCRIPTION
Some of the packages state the `requires` as wrong names (missing
package name as prefix). This does not show in build and unit/app tests
but fails when using these packages externally as those dependent
`requires` packaging dont exist.
For example, `nntrainer-devel-static` package depends on `devel`
package, and not on `nntrainer-devel`. This patch provides the
corresponding fix.

BEFORE:
```bash
1:57:04 [:~/GBS-ROOT-SNAPSHOT/local/BUILD-ROOTS/scratch.x86_64.0/home/abuild/rpmbuild/RPMS/x86_64] $ rpm -qp nntrainer-devel-static-0.2.0-0.x86_64.rpm --requires
devel = 0.2.0-0   <-------------------------------------------------------
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1

11:59:25 [:~/GBS-ROOT-SNAPSHOT/local/BUILD-ROOTS/scratch.x86_64.0/home/abuild/rpmbuild/RPMS/x86_64] $ rpm -qp nnstreamer-nntrainer-devel-static-0.2.0-0.x86_64.rpm --requires
devel-static = 0.2.0-0  <-------------------------------------------------------
nnstreamer-nntrainer
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
```

AFTER
```bash
12:09:44 ⌂74% [:~/GBS-ROOT-SNAPSHOT/local/BUILD-ROOTS/scratch.x86_64.0/home/abuild/rpmbuild/RPMS/x86_64] $ rpm -qp nntrainer-devel-static-0.2.0-0.x86_64.rpm --requires
nntrainer-devel = 0.2.0-0  <-------------------------------------------------------
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1

12:09:50 ⌂63% [:~/GBS-ROOT-SNAPSHOT/local/BUILD-ROOTS/scratch.x86_64.0/home/abuild/rpmbuild/RPMS/x86_64] 5s $ rpm -qp nnstreamer-nntrainer-devel-static-0.2.0-0.x86_64.rpm --requires
nnstreamer-nntrainer = 0.2.0-0 <-------------------------------------------------------
nntrainer-devel-static = 0.2.0-0 <-------------------------------------------------------
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
```

Resolves #1399

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>