### PR TITLE
[layer] Enable time dist layer for V2

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -163,14 +163,14 @@ int NetworkGraph::realizeActivationType(
     return ML_ERROR_NONE;
   }
 
-  if (in_node->getType() == ActivationLayer::type) {
-    ml_loge("It is not allowed to realize ativation layer, possibly layer is "
-            "added right after activation");
+  if (act == ActivationType::ACT_UNKNOWN) {
+    ml_loge("cannot realize unknown activation type");
     return ML_ERROR_INVALID_PARAMETER;
   }
 
-  if (act == ActivationType::ACT_UNKNOWN) {
-    ml_loge("cannot realize unknown activation type");
+  if (in_node->getType() == ActivationLayer::type) {
+    ml_loge("It is not allowed to realize activation layer, possibly layer is "
+            "added right after activation");
     return ML_ERROR_INVALID_PARAMETER;
   }
 

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -152,6 +152,20 @@ public:
   }
 
   /**
+   * @brief Request a new weight for the layer
+   *
+   * @param spec tensor spec
+   * @return unsigned int index of the weight for its getter
+   *
+   * @todo Consider providing a guarantee that the returned indices will always
+   * start from 0 and will always be incremental.
+   */
+  unsigned int requestWeight(const Weight::Spec &spec) {
+    weights_spec.emplace_back(spec);
+    return weights_spec.size() - 1;
+  }
+
+  /**
    * @brief Request a new tensor for the layer
    *
    * @param dim dimension of the tensor
@@ -177,6 +191,20 @@ public:
   typedef Var_Grad::Spec TensorSpec;
 
   /**
+   * @brief Request a new tensor for the layer
+   *
+   * @param spec tensor spec
+   * @return unsigned int index of the tensor for its getter
+   *
+   * @todo Consider providing a guarantee that the returned indices will always
+   * start from 0 and will always be incremental.
+   */
+  unsigned int requestTensor(const TensorSpec &spec) {
+    tensors_spec.emplace_back(spec);
+    return tensors_spec.size() - 1;
+  }
+
+  /**
    * @brief Get the current weights spec
    *
    * @return The current weights spec
@@ -198,6 +226,13 @@ public:
    * @return The current tensors spec
    */
   const std::vector<TensorSpec> &getTensorsSpec() const { return tensors_spec; }
+
+  /**
+   * @brief Get the number of requested tensors objects
+   *
+   * @return unsigned int number of requested tensors
+   */
+  unsigned int getNumTensors() const { return tensors_spec.size(); }
 
   /**
    * @brief Set the batch for the init context
@@ -449,6 +484,26 @@ public:
   }
 
   /**
+   * @brief check if the tensor has gradient
+   *
+   * @param idx Identifier of the tensor
+   * @return true if tensor has gradient, else false
+   */
+  bool tensorHasGradient(unsigned int idx) const {
+    return tensors[idx]->hasGradient();
+  }
+
+  /**
+   * @brief Get the tensor name
+   *
+   * @param idx Identifier of the tensor
+   * @return name of the tensor
+   */
+  const std::string &getTensorName(unsigned int idx) const {
+    return tensors[idx]->getName();
+  }
+
+  /**
    * @brief Get the number of Outputs tensor objects
    *
    * @return unsigned int number of output tensors
@@ -468,6 +523,13 @@ public:
    * @return unsigned int number of weight tensors
    */
   unsigned int getNumWeights() const { return weights.size(); }
+
+  /**
+   * @brief Get the number of requested tensors objects
+   *
+   * @return unsigned int number of requested tensors
+   */
+  unsigned int getNumTensors() const { return tensors.size(); }
 
   /**
    * @brief Set the batch for the run context

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -264,12 +264,6 @@ public:
   ActivationType getActivationToBeRealized() const noexcept;
 
   /**
-   * @brief     get distribute for this layer
-   * @retval dist to enable/disable distribute
-   */
-  std::string getDistLayerType() const;
-
-  /**
    * @brief     Activation Type Getter
    * @retval    Activation Type.
    */

--- a/nntrainer/tensor/tensor_dim.h
+++ b/nntrainer/tensor/tensor_dim.h
@@ -151,6 +151,27 @@ public:
   }
 
   /**
+   * @brief Get the Dim Flag to retrieve effective dimension
+   * @note eg) if dimension 4:1:10:1 should be squeezed to 4:10,
+   *       set this to 0b1010, rightmost is width
+   *
+   * @return dim_flag_ dimension bit to calculate, rightmost is width
+   */
+  const std::bitset<MAXDIM> &getEffDimFlag() const { return eff_dim_flag; }
+
+  /**
+   * @brief Get the dynamic Dim Flag to retrieve dynamic dimension (that can
+   * change during running)
+   * @note eg) if dimension 4:1:10:1 should be squeezed to dynamic to batch,
+   *       set this to 0b1000, rightmost is width
+   * @note when setting dynamic dimension, the calculation must remain
+   * independent of the dynamic dimension. Please check this :)
+   *
+   * @return dim_flag_ dimension bit to calculate, rightmost is width
+   */
+  const std::bitset<MAXDIM> &getDynDimFlag() const { return dyn_dim_flag; }
+
+  /**
    * @brief  swap variable of Conv2D Layer
    * @parma[out] lhs Optimizer
    * @parma[in] rhs Optimizer

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -329,32 +329,32 @@ mkIniTc(const char *name, const nntrainer::IniWrapper::Sections vec, int flag) {
 INSTANTIATE_TEST_CASE_P(
   nntrainerIniAutoTests, nntrainerIniTest, ::testing::Values(
   /**< positive: basic valid scenarios (2 positive and 3 negative cases) */
-    mkIniTc("basic_p", {nw_base_mse, adam, input + "-Activation", out+"input_layers=inputlayer" + "-Activation"}, SUCCESS),
-    mkIniTc("basic2_p", {nw_base_mse, sgd, input + "-Activation", out+"input_layers=inputlayer" + "-Activation"}, SUCCESS),
-    mkIniTc("basic3_p", {nw_base + "loss=cross_sigmoid", adam, input + "-Activation", out+"input_layers=inputlayer" + "-Activation"}, SUCCESS),
-    mkIniTc("basic4_p", {nw_base + "loss=cross_softmax", adam, input + "-Activation", out+"input_layers=inputlayer" + "-Activation"}, SUCCESS),
-    mkIniTc("basic5_p", {nw_base_cross, adam, input, out+"input_layers=inputlayer"}, SUCCESS),
-    mkIniTc("basic6_p", {nw_base_cross, sgd, input, out+"input_layers=inputlayer"}, SUCCESS),
-    mkIniTc("basic_act_p", {nw_base_cross, sgd, input + "-Activation", act_relu+"input_layers=inputlayer", out+"input_layers=activation_relu" }, SUCCESS),
-    mkIniTc("basic_bn_p", {nw_base_cross, sgd, input + "-Activation", batch_normal+"input_layers=inputlayer", act_relu+"input_layers=bn", out+"input_layers=activation_relu" }, SUCCESS),
-    mkIniTc("basic_bn2_p", {nw_base_cross, sgd, input + "-Activation", batch_normal + "Activation = relu"+"input_layers=inputlayer", out+"input_layers=bn" }, SUCCESS),
-    mkIniTc("basic_dataset_p", {nw_base_cross, adam, dataset, input, out+"input_layers=inputlayer"}, SUCCESS),
-    mkIniTc("basic_dataset2_p", {nw_base_cross, sgd, input, out+"input_layers=inputlayer", dataset}, SUCCESS),
-    mkIniTc("basic_dataset3_p", {dataset, nw_base_cross, sgd, input, out+"input_layers=inputlayer"}, SUCCESS),
-    mkIniTc("basic_conv2d_p", {nw_base_cross, adam, conv2d + "input_shape = 1:10:10"}, SUCCESS),
-    mkIniTc("no_testSet_p", {nw_base_cross, adam, dataset + "-TestData", input, out+"input_layers=inputlayer"}, SUCCESS),
-    mkIniTc("no_validSet_p", {nw_base_cross, adam, dataset + "-ValidData", input, out+"input_layers=inputlayer"}, SUCCESS),
-    mkIniTc("no_bufferSize_p", {nw_base_cross, adam, dataset + "-BufferSize", input, out+"input_layers=inputlayer"}, SUCCESS),
-    mkIniTc("buffer_size_smaller_than_batch_size_p", {nw_base_cross, adam, dataset + "BufferSize=26", input, out+"input_layers=inputlayer"}, SUCCESS),
-    mkIniTc("buffer_size_smaller_than_batch_size2_p", {nw_base_cross, adam, input, out+"input_layers=inputlayer", dataset + "BufferSize=26"}, SUCCESS),
-    mkIniTc("loss_layer1_p", {nw_base, adam, input + "-Activation", out + "-Activation", loss_mse}, SUCCESS),
-    mkIniTc("loss_layer2_p", {nw_base, adam, input + "-Activation", out, loss_mse}, SUCCESS),
-    mkIniTc("loss_layer3_n", {nw_base, adam, input + "-Activation", out + "-Activation", loss_cross}, INITFAIL | COMPFAIL),
-    mkIniTc("loss_layer4_p", {nw_base, adam, input + "-Activation", out, loss_cross}, SUCCESS),
-    mkIniTc("loss_layer5_p", {nw_base, adam, input + "-Activation", out + "-Activation", loss_cross_sigmoid}, SUCCESS),
-    mkIniTc("loss_layer6_p", {nw_base, adam, input + "-Activation", out, loss_cross_sigmoid}, SUCCESS),
-    mkIniTc("loss_layer7_p", {nw_base, adam, input + "-Activation", out + "-Activation", loss_cross_softmax}, SUCCESS),
-    mkIniTc("loss_layer8_p", {nw_base, adam, input + "-Activation", out, loss_cross_softmax}, SUCCESS),
+     mkIniTc("basic_p", {nw_base_mse, adam, input + "-Activation", out+"input_layers=inputlayer" + "-Activation"}, SUCCESS),
+     mkIniTc("basic2_p", {nw_base_mse, sgd, input + "-Activation", out+"input_layers=inputlayer" + "-Activation"}, SUCCESS),
+     mkIniTc("basic3_p", {nw_base + "loss=cross_sigmoid", adam, input + "-Activation", out+"input_layers=inputlayer" + "-Activation"}, SUCCESS),
+     mkIniTc("basic4_p", {nw_base + "loss=cross_softmax", adam, input + "-Activation", out+"input_layers=inputlayer" + "-Activation"}, SUCCESS),
+     mkIniTc("basic5_p", {nw_base_cross, adam, input, out+"input_layers=inputlayer"}, SUCCESS),
+     mkIniTc("basic6_p", {nw_base_cross, sgd, input, out+"input_layers=inputlayer"}, SUCCESS),
+     mkIniTc("basic_act_p", {nw_base_cross, sgd, input + "-Activation", act_relu+"input_layers=inputlayer", out+"input_layers=activation_relu" }, SUCCESS),
+     mkIniTc("basic_bn_p", {nw_base_cross, sgd, input + "-Activation", batch_normal+"input_layers=inputlayer", act_relu+"input_layers=bn", out+"input_layers=activation_relu" }, SUCCESS),
+     mkIniTc("basic_bn2_p", {nw_base_cross, sgd, input + "-Activation", batch_normal + "Activation = relu"+"input_layers=inputlayer", out+"input_layers=bn" }, SUCCESS),
+     mkIniTc("basic_dataset_p", {nw_base_cross, adam, dataset, input, out+"input_layers=inputlayer"}, SUCCESS),
+     mkIniTc("basic_dataset2_p", {nw_base_cross, sgd, input, out+"input_layers=inputlayer", dataset}, SUCCESS),
+     mkIniTc("basic_dataset3_p", {dataset, nw_base_cross, sgd, input, out+"input_layers=inputlayer"}, SUCCESS),
+     mkIniTc("basic_conv2d_p", {nw_base_cross, adam, conv2d + "input_shape = 1:10:10"}, SUCCESS),
+     mkIniTc("no_testSet_p", {nw_base_cross, adam, dataset + "-TestData", input, out+"input_layers=inputlayer"}, SUCCESS),
+     mkIniTc("no_validSet_p", {nw_base_cross, adam, dataset + "-ValidData", input, out+"input_layers=inputlayer"}, SUCCESS),
+     mkIniTc("no_bufferSize_p", {nw_base_cross, adam, dataset + "-BufferSize", input, out+"input_layers=inputlayer"}, SUCCESS),
+     mkIniTc("buffer_size_smaller_than_batch_size_p", {nw_base_cross, adam, dataset + "BufferSize=26", input, out+"input_layers=inputlayer"}, SUCCESS),
+     mkIniTc("buffer_size_smaller_than_batch_size2_p", {nw_base_cross, adam, input, out+"input_layers=inputlayer", dataset + "BufferSize=26"}, SUCCESS),
+     mkIniTc("loss_layer1_p", {nw_base, adam, input + "-Activation", out + "-Activation", loss_mse}, SUCCESS),
+     mkIniTc("loss_layer2_p", {nw_base, adam, input + "-Activation", out, loss_mse}, SUCCESS),
+     mkIniTc("loss_layer3_n", {nw_base, adam, input + "-Activation", out + "-Activation", loss_cross}, INITFAIL | COMPFAIL),
+     mkIniTc("loss_layer4_p", {nw_base, adam, input + "-Activation", out, loss_cross}, SUCCESS),
+     mkIniTc("loss_layer5_p", {nw_base, adam, input + "-Activation", out + "-Activation", loss_cross_sigmoid}, SUCCESS),
+     mkIniTc("loss_layer6_p", {nw_base, adam, input + "-Activation", out, loss_cross_sigmoid}, SUCCESS),
+     mkIniTc("loss_layer7_p", {nw_base, adam, input + "-Activation", out + "-Activation", loss_cross_softmax}, SUCCESS),
+     mkIniTc("loss_layer8_p", {nw_base, adam, input + "-Activation", out, loss_cross_softmax}, SUCCESS),
 
   /**< half negative: init fail cases (1 positive and 4 negative cases) */
     mkIniTc("unknown_loss_n", {nw_base_cross + "loss = unknown", adam, input, out+"input_layers=inputlayer"}, COMPFAIL | INITFAIL),
@@ -746,7 +746,7 @@ TEST(nntrainerIniTest, DISABLED_backbone_based_on_working_directory_p) {
 /**
  * @brief Ini file unittest with distributed layer
  */
-TEST(nntrainerIniTest, DISABLED_distribute_p_01) {
+TEST(nntrainerIniTest, distribute_p_01) {
   ScopedIni s{
     "distribute_p1",
     {nw_base_cross, adam,

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -1317,9 +1317,9 @@ INSTANTIATE_TEST_CASE_P(
     mkModelTc(addition_resnet_like, "3:1:1:10", 10),
 
     /// #1192 time distribution inference bug
-    // mkModelTc(fc_softmax_mse_distribute_validate, "3:1:5:3", 1),
-    // mkModelTc(fc_softmax_cross_distribute_validate, "3:1:5:3", 1),
-    // mkModelTc(fc_sigmoid_cross_distribute_validate, "3:1:5:3", 1)
+    mkModelTc(fc_softmax_mse_distribute_validate, "3:1:5:3", 1),
+    mkModelTc(fc_softmax_cross_distribute_validate, "3:1:5:3", 1),
+    mkModelTc(fc_sigmoid_cross_distribute_validate, "3:1:5:3", 1),
     mkModelTc(lstm_basic, "1:1:1:1", 10),
     mkModelTc(lstm_return_sequence, "1:1:2:1", 10),
     mkModelTc(lstm_return_sequence_with_batch, "2:1:2:1", 10),


### PR DESCRIPTION
Enable time dist layer for LayerV2 design.
This patch tries to simulate the InitContext and the RunContext inside
the time dist layer so that proper shapes of variables can be passed to
the internal layer. Further, context changing function calls are
replicated on the actual InitContext/RunContext by detecting changes and
making those function calls again.

LayerNode was updated to ensure that a layer is not getting distributed
again and again.
Some more getter APIs were added for TensorDim and LayerContext.

Unittests related to distribute have also been enabled with this patch.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>