### PR TITLE
[Dataset] Implement data getter

### DIFF
--- a/nntrainer/dataset/data_producers.h
+++ b/nntrainer/dataset/data_producers.h
@@ -49,8 +49,8 @@ public:
    */
   using Generator = std::function<Iteration(void)>;
 
-  constexpr inline static unsigned long long SIZE_UNDEFINED =
-    std::numeric_limits<unsigned long long>::max();
+  constexpr inline static unsigned int SIZE_UNDEFINED =
+    std::numeric_limits<unsigned int>::max();
 
   /**
    * @brief Destroy the Data Loader object
@@ -94,9 +94,8 @@ public:
    *
    * @return size calculated size
    */
-  virtual unsigned long long
-  size(const std::vector<TensorDim> &input_dims,
-       const std::vector<TensorDim> &label_dims) const {
+  virtual unsigned int size(const std::vector<TensorDim> &input_dims,
+                            const std::vector<TensorDim> &label_dims) const {
     return SIZE_UNDEFINED;
   }
 };

--- a/nntrainer/dataset/random_data_producers.cpp
+++ b/nntrainer/dataset/random_data_producers.cpp
@@ -52,19 +52,21 @@ public:
 
 /**
  * @brief Props containing number of samples
+ * A random data producer has theoretical size. number of samples is used to set
+ * theoretical size of the random data producer's data size
  *
  */
-class PropsDataSize : public Property<unsigned int> {
+class PropsNumSamples : public Property<unsigned int> {
 public:
   /**
    * @brief Construct a new props data size object with a default value
    *
    * @param value default value
    */
-  PropsDataSize(unsigned int value = 512) :
+  PropsNumSamples(unsigned int value = 512) :
     nntrainer::Property<unsigned int>(value) {}
-  static constexpr const char *key = "size"; /**< unique key to access */
-  using prop_tag = uint_prop_tag;            /**< property type */
+  static constexpr const char *key = "num_samples"; /**< unique key to access */
+  using prop_tag = uint_prop_tag;                   /**< property type */
 };
 
 RandomDataOneHotProducer::RandomDataOneHotProducer() :
@@ -76,10 +78,10 @@ const std::string RandomDataOneHotProducer::getType() const {
   return RandomDataOneHotProducer::type;
 }
 
-unsigned long long
+unsigned int
 RandomDataOneHotProducer::size(const std::vector<TensorDim> &input_dims,
                                const std::vector<TensorDim> &label_dims) const {
-  return std::get<PropsDataSize>(*rd_one_hot_props).get();
+  return std::get<PropsNumSamples>(*rd_one_hot_props).get();
 }
 
 void RandomDataOneHotProducer::setProperty(

--- a/nntrainer/dataset/random_data_producers.h
+++ b/nntrainer/dataset/random_data_producers.h
@@ -24,7 +24,7 @@ namespace nntrainer {
 
 class PropsMin;
 class PropsMax;
-class PropsDataSize;
+class PropsNumSamples;
 
 /**
  * @brief RandomDataProducer which generates a onehot vector as a label
@@ -54,9 +54,8 @@ public:
   /**
    * @copydoc DataProducer::size()
    */
-  unsigned long long
-  size(const std::vector<TensorDim> &input_dims,
-       const std::vector<TensorDim> &label_dims) const override;
+  unsigned int size(const std::vector<TensorDim> &input_dims,
+                    const std::vector<TensorDim> &label_dims) const override;
 
   /**
    * @copydoc DataProducer::setProeprty(const std::vector<std::string>
@@ -73,7 +72,7 @@ public:
            const std::vector<TensorDim> &label_dims) override;
 
 private:
-  using Props = std::tuple<PropsMin, PropsMax, PropsDataSize>;
+  using Props = std::tuple<PropsMin, PropsMax, PropsNumSamples>;
   std::unique_ptr<Props> rd_one_hot_props;
 };
 

--- a/nntrainer/dataset/raw_file_data_producer.cpp
+++ b/nntrainer/dataset/raw_file_data_producer.cpp
@@ -33,7 +33,7 @@ const std::string RawFileDataProducer::getType() const {
   return RawFileDataProducer::type;
 }
 
-unsigned long long
+unsigned int
 RawFileDataProducer::size(const std::vector<TensorDim> &input_dims,
                           const std::vector<TensorDim> &label_dims) const {
   auto size_accumulator = [](const unsigned int &a, const TensorDim &b) {

--- a/nntrainer/dataset/raw_file_data_producer.h
+++ b/nntrainer/dataset/raw_file_data_producer.h
@@ -59,9 +59,8 @@ public:
   /**
    * @copydoc DataProducer::size()
    */
-  unsigned long long
-  size(const std::vector<TensorDim> &input_dims,
-       const std::vector<TensorDim> &label_dims) const override;
+  unsigned int size(const std::vector<TensorDim> &input_dims,
+                    const std::vector<TensorDim> &label_dims) const override;
 
   /**
    * @copydoc DataProducer::setProeprty(const std::vector<std::string>

--- a/test/unittest/datasets/meson.build
+++ b/test/unittest/datasets/meson.build
@@ -7,7 +7,8 @@ producer_targets = [
   'unittest_random_data_producers.cpp',
   'unittest_func_data_producer.cpp',
   'unittest_raw_file_data_producer.cpp',
-  'unittest_batch_queue.cpp'
+  'unittest_batch_queue.cpp',
+  'unittest_databuffer.cpp'
 ]
 
 test_target += producer_targets

--- a/test/unittest/datasets/unittest_databuffer.cpp
+++ b/test/unittest/datasets/unittest_databuffer.cpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file unittest_databuffer.cpp
+ * @date 13 July 2021
+ * @brief databuffer unittest
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <gtest/gtest.h>
+
+#include <databuffer.h>
+#include <random_data_producers.h>
+
+#include <memory>
+
+TEST(DataBuffer, batcher_p) {
+  std::unique_ptr<nntrainer::DataProducer> prod =
+    std::make_unique<nntrainer::RandomDataOneHotProducer>();
+
+  nntrainer::DataBuffer db(std::move(prod));
+  db.setProperty({"buffer_size=2", "min=1", "max=2", "num_samples=3"});
+
+  auto generator = db.batcher({{3, 1, 1, 2}}, {{3, 1, 1, 1}});
+  auto [last, inputs, labels] = generator();
+
+  EXPECT_FALSE(last);
+  EXPECT_EQ(inputs.size(), 1u);
+  EXPECT_EQ(inputs[0].getDim(), nntrainer::TensorDim({3, 1, 1, 2}));
+  EXPECT_EQ(labels.size(), 1u);
+  EXPECT_EQ(labels[0].getDim(), nntrainer::TensorDim({3, 1, 1, 1}));
+}
+
+TEST(DataBuffer, fetch_p) {
+  std::unique_ptr<nntrainer::DataProducer> prod =
+    std::make_unique<nntrainer::RandomDataOneHotProducer>();
+
+  nntrainer::DataBuffer db(std::move(prod));
+  db.setProperty({"buffer_size=2", "min=1", "max=2", "num_samples=10"});
+
+  { /// invalidate bq after epoch is finished
+    auto future_bq = db.startFetchWorker({{3, 1, 1, 2}}, {{3, 1, 1, 1}});
+
+    for (unsigned int i = 0; i < 3; ++i) {
+      auto [last, inputs, labels] = *db.fetch();
+
+      EXPECT_FALSE(last);
+      EXPECT_EQ(inputs.size(), 1u);
+      EXPECT_EQ(inputs[0].getDim(), nntrainer::TensorDim({3, 1, 1, 2}));
+      EXPECT_EQ(labels.size(), 1u);
+      EXPECT_EQ(labels[0].getDim(), nntrainer::TensorDim({3, 1, 1, 1}));
+    }
+    auto [last, inputs, labels] = *db.fetch();
+    EXPECT_TRUE(last);
+
+    future_bq.get();
+  }
+
+  { /// invalidate bq during epoch
+    auto future_bq = db.startFetchWorker({{4, 1, 1, 2}}, {{4, 1, 1, 1}});
+    db.fetch();
+    future_bq.get();
+  }
+
+  { /// remainder is over batchsize so return last
+    auto future_bq = db.startFetchWorker({{11, 1, 1, 2}}, {{11, 1, 1, 1}});
+    auto [last, inputs, labels] = *db.fetch();
+    EXPECT_TRUE(last);
+    future_bq.get();
+  }
+}
+
+TEST(DataBuffer, fetchWithoutStart_n) {
+  std::unique_ptr<nntrainer::DataProducer> prod =
+    std::make_unique<nntrainer::RandomDataOneHotProducer>();
+
+  nntrainer::DataBuffer db(std::move(prod));
+  db.setProperty({"buffer_size=2", "min=1", "max=2", "num_samples=3"});
+  EXPECT_THROW(db.fetch(), std::runtime_error);
+}
+
+TEST(DataBuffer, fetchAfterBqIsDeleted_n) {
+  std::unique_ptr<nntrainer::DataProducer> prod =
+    std::make_unique<nntrainer::RandomDataOneHotProducer>();
+
+  nntrainer::DataBuffer db(std::move(prod));
+  db.setProperty({"buffer_size=2", "min=1", "max=2", "num_samples=3"});
+  auto future_bq = db.startFetchWorker({{4, 1, 1, 2}}, {{4, 1, 1, 1}});
+  future_bq.get();
+  EXPECT_THROW(db.fetch(), std::runtime_error);
+}
+
+TEST(DataBuffer, fetchAfterDataEnd_n) {
+  std::unique_ptr<nntrainer::DataProducer> prod =
+    std::make_unique<nntrainer::RandomDataOneHotProducer>();
+
+  nntrainer::DataBuffer db(std::move(prod));
+  db.setProperty({"buffer_size=2", "min=1", "max=2", "num_samples=3"});
+  auto future_bq = db.startFetchWorker({{4, 1, 1, 2}}, {{4, 1, 1, 1}});
+  db.fetch();
+  EXPECT_THROW(db.fetch(), std::runtime_error);
+  future_bq.get();
+}

--- a/test/unittest/datasets/unittest_random_data_producers.cpp
+++ b/test/unittest/datasets/unittest_random_data_producers.cpp
@@ -49,13 +49,13 @@ DataProducerValidatorType random_onehot_validator(float min, float max) {
 }
 auto random_onehot_success = DataProducerSemanticsParamType(
   createDataProducer<nntrainer::RandomDataOneHotProducer>,
-  {"min=0", "max=1", "size=10"}, {{3, 2, 4, 5}}, {{3, 1, 1, 10}},
+  {"min=0", "max=1", "num_samples=10"}, {{3, 2, 4, 5}}, {{3, 1, 1, 10}},
   random_onehot_validator(0, 1), DataProducerSemanticsExpectedResult::SUCCESS);
 
 auto random_onehot_min_over_max = DataProducerSemanticsParamType(
   createDataProducer<nntrainer::RandomDataOneHotProducer>,
-  {"min=2", "max=1", "size=10"}, {{3, 2, 4, 5}}, {{3, 1, 1, 10}}, nullptr,
-  DataProducerSemanticsExpectedResult::FAIL_AT_FINALIZE);
+  {"min=2", "max=1", "num_samples=10"}, {{3, 2, 4, 5}}, {{3, 1, 1, 10}},
+  nullptr, DataProducerSemanticsExpectedResult::FAIL_AT_FINALIZE);
 
 auto random_onehot_invalid_label_shape = DataProducerSemanticsParamType(
   createDataProducer<nntrainer::RandomDataOneHotProducer>, {}, {{3, 2, 4, 5}},


### PR DESCRIPTION
- [Dataset] Implement data getter

```
This patch implements data getter.
There are two types of data getter.

1. queue multiple iterations and get one by one
(`DataBuffer::startFetchWorker()`, `DataBuffer::fetch()`)

2. generate one iteration on the fly (`DataBuffer::batcher()`)

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```