### PR TITLE
[layer] LayerV1 cleanup from LayerNode

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -91,10 +91,6 @@ void NetworkGraph::addDefaultInputLayers() {
   }
 }
 
-void NetworkGraph::addLayerNode(std::shared_ptr<LayerV1> layer) {
-  graph.addNode(std::make_unique<LayerNode>(layer, graph.size()));
-}
-
 void NetworkGraph::addLayerNode(std::unique_ptr<Layer> layer) {
   graph.addNode(std::make_unique<LayerNode>(std::move(layer), graph.size()));
 }

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -23,8 +23,8 @@
 #include <vector>
 
 #include <graph_core.h>
-#include <layer_internal.h>
 #include <layer_node.h>
+#include <manager.h>
 
 namespace nntrainer {
 
@@ -358,12 +358,6 @@ private:
    */
   void ensureName(std::shared_ptr<Layer> layer, const std::string &prefix = "",
                   const std::string &postfix = "", bool force_rename = false);
-
-  /**
-   * @brief Create new LayerNode and add into Graph
-   * @param[in] layer shared_ptr of Layer
-   */
-  void addLayerNode(std::shared_ptr<LayerV1> layer);
 
   /**
    * @brief Create new LayerNode and add into Graph

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -186,6 +186,13 @@ public:
   }
 
   /**
+   * @brief Get the number of requested weights
+   *
+   * @return The current number of requested weights
+   */
+  unsigned int getNumWeights() const { return weights_spec.size(); }
+
+  /**
    * @brief Get the current tensors spec
    *
    * @return The current tensors spec

--- a/nntrainer/layers/layer_impl.cpp
+++ b/nntrainer/layers/layer_impl.cpp
@@ -23,7 +23,12 @@
 
 namespace nntrainer {
 
-LayerImpl::LayerImpl() : layer_impl_props(std::make_unique<std::tuple<>>()) {}
+LayerImpl::LayerImpl() :
+  layer_impl_props(std::make_unique<std::tuple<>>()),
+  weight_regularizer(WeightRegularizer::NONE),
+  weight_regularizer_constant(1.0f),
+  weight_initializer(WeightInitializer::WEIGHT_XAVIER_UNIFORM),
+  bias_initializer(WeightInitializer::WEIGHT_ZEROS) {}
 
 void LayerImpl::setProperty(const std::vector<std::string> &values) {
   loadProperties(values, *layer_impl_props);

--- a/nntrainer/layers/time_dist.h
+++ b/nntrainer/layers/time_dist.h
@@ -15,6 +15,7 @@
 #define __TIME_DIST_H__
 #ifdef __cplusplus
 
+#include <layer_internal.h>
 #include <tensor.h>
 
 namespace nntrainer {

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -36,6 +36,8 @@
 #include <nntrainer_log.h>
 #include <rnn.h>
 
+static constexpr bool LAYER_V2 = true;
+
 namespace nntrainer {
 MMapedMemory::MMapedMemory(size_t size, bool allocate_fd_) :
   fd(-1),

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -118,7 +118,10 @@ public:
    * if the owner of these tensors free the tensors.
    */
   explicit Weight(const Tensor &v, const Tensor &g, const std::string &n = "") :
-    Var_Grad(v, g, n) {}
+    Var_Grad(v, g, n),
+    initializer(WeightInitializer::WEIGHT_XAVIER_UNIFORM),
+    regularizer(WeightRegularizer::NONE),
+    regularizer_constant(1.0f) {}
 
   /**
    * @copydoc var_grad::initializeVariable(const Tensor &)

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -76,8 +76,9 @@ void Exporter::saveTflResult(
   const LayerNode *self) {
   createIfNull(tf_node);
   tf_node->setInOut(*self);
-  tf_node->setInputs(self->getObject()->getInputRef());
-  tf_node->setOutputs(self->getObject()->getOutputRef());
+  /** TODO: update to use run_context format for set inputs/outputs */
+  // tf_node->setInputs(self->getObject()->getInputRef());
+  // tf_node->setOutputs(self->getObject()->getOutputRef());
 
   saveTflWeights(tf_node.get(), self->getRunContext(), "0:2:1");
 }


### PR DESCRIPTION
Remove LayerNode dependence on LayerV1.
Further, NetworkGraph dependence on LayerV1 is also removed.

Some More bugfixes in the patch:
- Add initialization for the missing variables for LayerImpl class
- Add missing initialization in constructor for the weight class