### PR TITLE
[activation] Update implementation for in-place 

### DIFF
--- a/Applications/MNIST/jni/main.cpp
+++ b/Applications/MNIST/jni/main.cpp
@@ -89,7 +89,6 @@ std::string data_path;
 
 float training_loss = 0.0;
 float validation_loss = 0.0;
-float last_batch_loss = 0.0;
 
 std::string filename = "mnist_trainingSet.dat";
 
@@ -241,9 +240,8 @@ int getBatch_val(float **outVec, float **outLabel, bool *last,
 
 #if defined(APP_VALIDATE)
 TEST(MNIST_training, verify_accuracy) {
-  // EXPECT_FLOAT_EQ(training_loss, 2.3230426);
-  // EXPECT_FLOAT_EQ(validation_loss, 2.3045228);
-  // EXPECT_FLOAT_EQ(last_batch_loss, 2.2880380153656006);
+  EXPECT_FLOAT_EQ(training_loss, 2.3031187);
+  EXPECT_FLOAT_EQ(validation_loss, 2.2951343);
 }
 #endif
 

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -41,8 +41,14 @@ class ActiFunc {
 public:
   /**
    * @brief     Constructor of ActiFunc
+   *
+   * @todo      Update in_place to true after manager supports it
    */
-  ActiFunc(ActivationType at = ActivationType::ACT_NONE) { setActiFunc(at); }
+  ActiFunc(ActivationType at = ActivationType::ACT_NONE,
+           bool in_place_ = false) :
+    in_place(in_place_) {
+    setActiFunc(at);
+  }
 
   /**
    * @brief     Destructor of ActiFunc
@@ -194,6 +200,7 @@ private:
 
   ActivationType
     activation_type; /**< type of the activaiton represented by this */
+  bool in_place;     /**< if this class should operate in_place */
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/gru.h
+++ b/nntrainer/layers/gru.h
@@ -38,7 +38,9 @@ public:
     LayerV1(args...),
     unit(unit_),
     hidden_state_activation_type(hidden_state_activation_type_),
+    acti_func(hidden_state_activation_type, true),
     recurrent_activation_type(recurrent_activation_type_),
+    recurrent_acti_func(recurrent_activation_type, true),
     return_sequences(sequence),
     dropout_rate(dropout){};
 

--- a/nntrainer/layers/lstm.h
+++ b/nntrainer/layers/lstm.h
@@ -38,7 +38,9 @@ public:
     LayerV1(args...),
     unit(unit_),
     hidden_state_activation_type(hidden_state_activation_type_),
+    acti_func(hidden_state_activation_type, true),
     recurrent_activation_type(recurrent_activation_type_),
+    recurrent_acti_func(recurrent_activation_type, true),
     return_sequences(sequence),
     dropout_rate(dropout){};
 

--- a/nntrainer/layers/rnn.h
+++ b/nntrainer/layers/rnn.h
@@ -37,6 +37,7 @@ public:
     LayerV1(args...),
     unit(unit_),
     hidden_state_activation_type(hidden_state_activation_type_),
+    acti_func(hidden_state_activation_type, true),
     return_sequences(sequence),
     dropout_rate(dropout){};
 

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -109,7 +109,7 @@ public:
    * @brief     Constructor of Manager
    */
   Manager(bool enable_gradient_memory_opt_ = true,
-          bool enable_derivative_memory_opt_ = true,
+          bool enable_derivative_memory_opt_ = false,
           bool enable_activation_memory_opt_ = false,
           bool enable_inference_inout_memory_opt_ = false);
 


### PR DESCRIPTION
Update implementation to handle in-place and non-inplace scenarios.
With new memory scheme coming in, in-place activation optimization and
derivative optimization is disabled. This patch updates the activation
function implementations to work for in-place and non-in-place
scenarios.
RNN, LSTM and GRU use activation functions internally with always
in-place settings. So, both the modes are supported.
This patch specifically convers the activation function scenario.
The generic support of in-place will be done when manager is updated.

This resolves the MNIST training bug.

Update MNIST application benchmark values based on the updated weight
initialization.

Resolves #1422

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>