### PR TITLE
[CAPI] Add ml_train_model_get_layer to internal

### DIFF
--- a/api/capi/include/nntrainer-tizen-internal.h
+++ b/api/capi/include/nntrainer-tizen-internal.h
@@ -8,6 +8,7 @@
  * @note   This header is designed to be used only in Tizen
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug    No known bugs except for NYI items
  *
  */
@@ -20,6 +21,25 @@
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+/**
+ * @brief Get neural network layer from the model with the given name.
+ * @details Use this function to get already created Neural Network Layer. The
+ * returned layer must not be deleted as it is owned by the model.
+ * @since_tizen 6.x
+ * @remark This works only for layers added by the API, and does not currently
+ * support layers supported for layers created by the ini.
+ * @remark The modification through ml_trin_layer_set_property() after compiling
+ * the model by calling `ml_train_model_compile()` strictly restricted.
+ * @param[in] model The NNTrainer model handler from the given description.
+ * @param[in] layer_name Name of the already created layer.
+ * @param[out] layer The NNTrainer Layer handler from the given description.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ */
+int ml_train_model_get_layer(ml_train_model_h model, const char *layer_name,
+                             ml_train_layer_h *layer);
 
 /**
  * @brief Save the model


### PR DESCRIPTION
- [CAPI] Add ml_train_model_get_layer to internal

```
This patch adds ml_train_model_get_layer to internal api

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```