### PR TITLE
[ccapi] Add ccapi for model inference

### DIFF
--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -203,7 +203,7 @@ public:
    * @retval list of output as float *
    * @note The output memory must not be freed by the caller
    */
-  virtual std::vector<float *> inference(std::vector<float *> input) = 0;
+  virtual std::vector<float *> inference(std::vector<float *> &input) = 0;
 
   /**
    * @brief     Summarize the model

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -198,6 +198,14 @@ public:
   // virtual std::vector<TensorDim> getOutputDimension() = 0;
 
   /**
+   * @brief     Run the inference of the model
+   * @param[in] input inputs as a list of each input data
+   * @retval list of output as float *
+   * @note The output memory must not be freed by the caller
+   */
+  virtual std::vector<float *> inference(std::vector<float *> input) = 0;
+
+  /**
    * @brief     Summarize the model
    * @param out std::ostream to get the model summary
    * @param verbosity verbosity of the summary

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -104,15 +104,10 @@ int NNTrainerInference::run(const GstTensorMemory *input,
   nntrainer::sharedConstTensors inputs;
   inputs.reserve(input_dims.size());
 
-  const GstTensorMemory *input_mem = input;
-  unsigned int offset = 0;
-  for (auto &id : input_dims) {
+  for (size_t idx = 0; idx < input_dims.size(); idx ++)
     // do not allocate new, but instead use tensor::Map
     inputs.emplace_back(MAKE_SHARED_TENSOR(nntrainer::Tensor::Map(
-      static_cast<float *>(input_mem->data), input_mem->size, id, offset)));
-    input_mem++;
-    offset += input_mem->size;
-  }
+      static_cast<float *>(input[idx].data), input[idx].size, input_dims[idx], 0)));
 
   nntrainer::sharedConstTensors outputs;
 

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.hh
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.hh
@@ -23,6 +23,10 @@
 #include <nnstreamer_plugin_api.h>
 #include <nnstreamer_plugin_api_filter.h>
 
+#include <neuralnet.h>
+#include <tensor.h>
+#include <tensor_dim.h>
+
 /**
  * @brief	Internal data structure for nntrainer
  */
@@ -113,7 +117,7 @@ private:
   /// model->compile                     (available)
   /// model->initialize                  (available)
   /// model->readModel                   (available)
-  /// model->inference                   (n/a)
+  /// model->inference                   (available)
   /// model->getInputDimension           (n/a)
   /// model->getOutputDimension          (n/a)
   /// possibly required for optimization

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.hh
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.hh
@@ -24,7 +24,6 @@
 #include <nnstreamer_plugin_api_filter.h>
 
 #include <neuralnet.h>
-#include <tensor.h>
 #include <tensor_dim.h>
 
 /**
@@ -99,13 +98,6 @@ public:
    */
   int run(const GstTensorMemory *input, GstTensorMemory *output);
 
-  /**
-   * @brief free output tensor
-   *
-   * @param data reference to the output data to free
-   */
-  void freeOutputTensor(void *data);
-
 private:
   void loadModel();
 
@@ -124,5 +116,4 @@ private:
   /// model->forwarding                  (n/a)
   /// model->allocate                    (n/a)
   std::unique_ptr<nntrainer::NeuralNetwork> model;
-  std::map<void *, std::shared_ptr<nntrainer::Tensor>> outputTensorMap;
 };

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -531,6 +531,28 @@ sharedConstTensors NeuralNetwork::inference(sharedConstTensors X,
   return out;
 }
 
+std::vector<float *> NeuralNetwork::inference(std::vector<float *> input) {
+  sharedConstTensors input_tensors;
+  auto const &in_dim = getInputDimension();
+
+  input_tensors.reserve(input.size());
+  for (unsigned int idx = 0; idx < in_dim.size(); idx++) {
+    input_tensors.emplace_back(MAKE_SHARED_TENSOR(
+      Tensor::Map(input[idx], in_dim[idx].getDataLen(), in_dim[idx], 0)));
+  }
+
+  sharedConstTensors output_tensors = inference(input_tensors, false);
+  std::vector<float *> output;
+  output.reserve(output_tensors.size());
+
+  for (auto &out : output_tensors) {
+    auto out_t = *out.get();
+    output.push_back(out_t.getData());
+  }
+
+  return output;
+}
+
 int NeuralNetwork::setDataset(const DatasetDataUsageType &usage,
                               std::shared_ptr<ml::train::Dataset> dataset) {
   return setDataBuffer(usage, std::static_pointer_cast<DataBuffer>(dataset));

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -531,7 +531,7 @@ sharedConstTensors NeuralNetwork::inference(sharedConstTensors X,
   return out;
 }
 
-std::vector<float *> NeuralNetwork::inference(std::vector<float *> input) {
+std::vector<float *> NeuralNetwork::inference(std::vector<float *> &input) {
   sharedConstTensors input_tensors;
   auto const &in_dim = getInputDimension();
 

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -284,6 +284,14 @@ public:
   sharedConstTensors inference(sharedConstTensors X, bool free_mem = true);
 
   /**
+   * @brief     Run the inference of the model
+   * @param[in] input inputs as a list of each input data
+   * @retval list of output as float *
+   * @note The output memory must not be freed by the caller
+   */
+  std::vector<float *> inference(std::vector<float *> input);
+
+  /**
    * @brief     Run NeuralNetwork train with callback function by user
    * @param[in] dt datatype (usage) where it should be
    * @param[in] dataset set the dataset

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -289,7 +289,7 @@ public:
    * @retval list of output as float *
    * @note The output memory must not be freed by the caller
    */
-  std::vector<float *> inference(std::vector<float *> input);
+  std::vector<float *> inference(std::vector<float *> &input);
 
   /**
    * @brief     Run NeuralNetwork train with callback function by user


### PR DESCRIPTION
1. Add model inference to the c++ API using the vector of float ptrs as
inputs and outputs.
2. This patch adds bugfix for the nnstreamer's tensorfilter of nntrainer.
- include proper headers required by the tensor filter header
- use the correct offset for the multi-input scenario
3. Remove tensor filter implementations dependency on nntrianer::Tensor.

Resolves #1442

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>