### PR TITLE
[ Property ] Add output_shape property

### DIFF
--- a/nntrainer/dataset/raw_file_data_producer.cpp
+++ b/nntrainer/dataset/raw_file_data_producer.cpp
@@ -46,12 +46,12 @@ RawFileDataProducer::size(const std::vector<TensorDim> &input_dims,
                                 sample_size, size_accumulator);
 
   auto path_prop = std::get<props::FilePath>(*raw_file_props);
-  auto file_size = path_prop.file_size();
 
   /// checking alignment is a good way to make check if a file is valid,
   /// unfortunately, our test dataset does not have this property
   /// (trainingSet.dat, valSet.dat, testSet.dat) after checking, we can
   /// uncomment below line.
+  // auto file_size = path_prop.file_size();
   // NNTR_THROW_IF((file_size % sample_size * RawFileDataProducer::pixel_size !=
   // 0),
   //               std::invalid_argument)

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -56,6 +56,41 @@ public:
 };
 
 /**
+ * @brief Tensor Shape property, TensorShape is an identifier of an object
+ *
+ */
+class TensorShape : public nntrainer::Property<nntrainer::TensorDim> {
+public:
+  /**
+   * @brief Construct a new TensorShape object
+   *
+   */
+  TensorShape() : nntrainer::Property<nntrainer::TensorDim>(){};
+
+  /**
+   * @brief Construct a new TensorShape object
+   * @param value default value of a TensorDim
+   *
+   */
+  TensorShape(const nntrainer::TensorDim &dim) :
+    nntrainer::Property<nntrainer::TensorDim>(dim){};
+
+  static constexpr const char *key =
+    "tensor_shape"; /**< unique key to access */
+
+  using prop_tag = dimension_prop_tag; /**< property type */
+
+  /**
+   * @brief TensorShape validator
+   *
+   * @param v string to validate
+   * @retval true if it contains unsigned int numbers and/or ':'
+   * @retval false if it is empty or contains non-valid character
+   */
+  bool isValid(const std::string &v) const;
+};
+
+/**
  * @brief unit property, unit is used to measure how many weights are there
  *
  */
@@ -68,6 +103,84 @@ public:
 
   bool isValid(const unsigned int &v) const override { return v > 0; }
 };
+
+/**
+ * @brief TensorsSpec property, this defines tensors shape of output
+ *
+ */
+class TensorsSpec {
+public:
+  TensorsSpec(){};
+  /**
+   * @brief Construct a new Tensors Spec object
+   *
+   * @param shapes_ tensors dimension
+   */
+  TensorsSpec(const std::vector<TensorShape> &shapes_) : shapes(shapes_){};
+
+  /**
+   * @brief Construct a new Tensors Spec object
+   *
+   * @param rsh rhs to copy
+   */
+  TensorsSpec(const TensorsSpec &rhs) = default;
+
+  /**
+   * @brief Copy assignment operator
+   *
+   * @param rsh rhs to copy
+   * &return TensorsSpec&
+   */
+  TensorsSpec &operator=(const TensorsSpec &rhs) = default;
+
+  /**
+   * @brief Move Construct Tensors Spec object
+   *
+   * @param rhs rhs to move
+   */
+  TensorsSpec(TensorsSpec &&rhs) noexcept = default;
+
+  /**
+   * @brief Move assign a Tensors spec operator
+   *
+   * @param rhs rhs to move
+   * @return TensorsSpec&
+   */
+  TensorsSpec &operator=(TensorsSpec &&rhs) noexcept = default;
+
+  /**
+   * @brief Get the Tensors Shape Object
+   *
+   * @return const std::vector<TensorShape>
+   */
+  const std::vector<TensorShape> &getTensorsShape() const { return shapes; }
+
+  /**
+   * @brief Get the number of Tensors Shape
+   *
+   * @return size_t the number of Tensors Shape
+   */
+  const size_t getNumTensors() const { return shapes.size(); }
+
+  /**
+   *
+   * @brief operator==
+   *
+   * @param rhs right side to compare
+   * @return true if equal
+   * @return false if not equal
+   */
+  bool operator==(const TensorsSpec &rhs) const;
+
+private:
+  std::vector<TensorShape> shapes;
+};
+
+/**
+ * @brief tensors shape prop tag type
+ *
+ */
+struct tensors_shape_prop_tag {};
 
 /**
  * @brief trainable property, use this to set and check how if certain layer is
@@ -190,6 +303,37 @@ public:
     "input_layers";                     /**< unique key to access */
   using prop_tag = connection_prop_tag; /**< property type */
   bool isValid(const ConnectionSpec &v) const override;
+};
+
+/**
+ * @brief OutputSpec property, this defines Output Tensors
+ *
+ */
+class OutputSpec : public nntrainer::Property<TensorsSpec> {
+public:
+  /**
+   * @brief Construct a new Output Spec object
+   *
+   */
+  OutputSpec() : nntrainer::Property<TensorsSpec>() {}
+
+  /**
+   * @brief Construct a new Output Spec object
+   *
+   * @param value default value of a Output spec
+   */
+  OutputSpec(const TensorsSpec &value) :
+    nntrainer::Property<TensorsSpec>(value) {} /**< default value if any */
+  static constexpr const char *key =
+    "output_shape";                        /**< unique key to access */
+  using prop_tag = tensors_shape_prop_tag; /**< property type */
+
+  /**
+   * @brief Check validation
+   *
+   * @param bool true if valid, false if it is not valid
+   */
+  bool isValid(const TensorsSpec &v) const override;
 };
 
 /**

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -89,6 +89,7 @@ public:
    *            34. return_sequences :  bool (type) - lstm
    *            35. hidden_state_activation :  string (type) - lstm
    *            36. dropout : bool
+   *            37. output_shape : bool
    */
   enum class PropertyType {
     input_shape = 0,
@@ -128,6 +129,7 @@ public:
     return_sequences = 34,
     hidden_state_activation = 35,
     dropout = 36,
+    output_shape = 37,
     unknown
   };
 

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -302,6 +302,12 @@ public:
   unsigned int getNumOutputs() const { return init_context.getNumOutputs(); }
 
   /**
+   * @brief     Get number of output tensors
+   * @retval    number of output tensors
+   */
+  unsigned int getNumOutputTensors() const;
+
+  /**
    * @brief Get the number of weights
    *
    * @return unsigned int number of weights
@@ -613,8 +619,9 @@ private:
                     Editing properties of the layer after init will not the
                     properties in the context/graph unless intended. */
 
-  using PropsType = std::tuple<props::Name, props::Flatten, props::Distribute,
-                               props::Trainable, props::Loss>;
+  using PropsType =
+    std::tuple<props::Name, props::Flatten, props::Distribute, props::Trainable,
+               props::Loss, props::OutputSpec>;
   /**
    * These properties are set for the layer by the user but are intercepted
    * and used in the node which forms the basic element of the graph.

--- a/nntrainer/utils/base_properties.cpp
+++ b/nntrainer/utils/base_properties.cpp
@@ -102,8 +102,18 @@ TensorDim str_converter<dimension_prop_tag, TensorDim>::from_string(
     tokens.push_back(token);
   }
 
-  NNTR_THROW_IF(tokens.size() > ml::train::TensorDim::MAXDIM,
-                std::invalid_argument)
+  static std::regex allowed("[1-9:]*");
+  auto check_num_tensors = [](const std::string &value) {
+    auto values = split(value, std::regex("\\s*\\:\\s*"));
+    if (values.size() > TensorDim::MAXDIM || !std::regex_match(value, allowed))
+      return false;
+    return true;
+  };
+
+  NNTR_THROW_IF(!check_num_tensors(value), std::invalid_argument)
+    << "Not allow negative or zero value";
+
+  NNTR_THROW_IF(tokens.size() > TensorDim::MAXDIM, std::invalid_argument)
     << "More than 4 axes is not supported, target string: " << value;
 
   TensorDim target;

--- a/test/unittest/unittest_common_properties.cpp
+++ b/test/unittest/unittest_common_properties.cpp
@@ -250,6 +250,74 @@ TEST(Padding2D, given_padding_is_negative_02_n) {
   EXPECT_THROW(p.set("-1, 1"), std::invalid_argument);
 }
 
+TEST(TensorShapeProperty, setPropertyValid_p) {
+  nntrainer::props::TensorShape n;
+  EXPECT_NO_THROW(from_string("1:1:1:1", n));
+
+  EXPECT_EQ(to_string(n), "1:1:1:1");
+
+  EXPECT_NO_THROW(from_string("1:1", n));
+  EXPECT_EQ(n.get(), nntrainer::TensorDim("1:1"));
+  EXPECT_THROW(from_string(":", n), std::invalid_argument);
+}
+
+TEST(TensorShapeProperty, setPropertyValid_01_n) {
+  nntrainer::props::TensorShape n;
+  EXPECT_THROW(from_string("1:0:0:1", n), std::invalid_argument);
+
+  EXPECT_THROW(from_string("1:-1:1:1", n), std::invalid_argument);
+
+  EXPECT_THROW(from_string("1:-1:1:1", n), std::invalid_argument);
+}
+
+TEST(OutputSpecProperty, setPropertyValid_p) {
+  using namespace nntrainer::props;
+  {
+    OutputSpec expected(
+      TensorsSpec({TensorShape(nntrainer::TensorDim("1:1:1:1")),
+                   TensorShape(nntrainer::TensorDim("2:2:2:2")),
+                   TensorShape(nntrainer::TensorDim("3:3:3:3"))}));
+
+    OutputSpec actual;
+    nntrainer::from_string("1:1:1:1, 2:2:2:2, 3:3:3:3", actual);
+    EXPECT_EQ(actual, expected);
+    EXPECT_EQ("1:1:1:1,2:2:2:2,3:3:3:3", nntrainer::to_string(actual));
+  }
+  {
+    OutputSpec expected(
+      TensorsSpec({TensorShape(nntrainer::TensorDim("1:1:1:1"))}));
+
+    OutputSpec actual;
+    nntrainer::from_string("1:1:1:1", actual);
+    EXPECT_EQ(actual, expected);
+    EXPECT_EQ("1:1:1:1", nntrainer::to_string(actual));
+  }
+}
+
+TEST(OutputSpecProperty, emptyString_n_01) {
+  using namespace nntrainer::props;
+  InputSpec actual;
+  EXPECT_THROW(nntrainer::from_string("", actual), std::invalid_argument);
+}
+
+TEST(OutputSpecProperty, noSeperator_n_01) {
+  using namespace nntrainer::props;
+  OutputSpec actual;
+  EXPECT_THROW(nntrainer::from_string("1:1:1 2:2:2", actual),
+               std::invalid_argument);
+}
+
+TEST(OutputSpecProperty, noSeperator_n_02) {
+  using namespace nntrainer::props;
+  OutputSpec actual;
+  EXPECT_THROW(nntrainer::from_string("1::1,2:2:2", actual),
+               std::invalid_argument);
+  EXPECT_THROW(nntrainer::from_string("1:1:1,2::2", actual),
+               std::invalid_argument);
+  EXPECT_THROW(nntrainer::from_string(",", actual), std::invalid_argument);
+  EXPECT_THROW(nntrainer::from_string("", actual), std::invalid_argument);
+}
+
 /**
  * @brief Main gtest
  */


### PR DESCRIPTION
The output_shape should be defined to set the mutiple tensor output.
The semetic of it might be output_shape="1:1:2:1,1:2:3:3,3:2:1".
In order to set it, we need to define property first.

This commit includes.
  . implementation of TensorShape Property.
  . implementation of TensorsSpec Property.
  . implementation of OutputSpec Property.

Signed-off-by: jijoongmoon <jijoong.moon@samsung.com>