### PR TITLE
[optimizer] Make optimizer independent of weight

### DIFF
--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -792,7 +792,10 @@ int ml_train_optimizer_set_property(ml_train_optimizer_h optimizer, ...) {
     opt = nnopt->optimizer;
   }
 
-  returnable f = [&]() { return opt->setProperty(arg_list); };
+  returnable f = [&]() {
+    opt->setProperty(arg_list);
+    return ML_ERROR_NONE;
+  };
 
   status = nntrainer_exception_boundary(f);
 

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -711,7 +711,10 @@ int ml_train_layer_set_property(ml_train_layer_h layer, ...) {
     l = nnlayer->layer;
   }
 
-  returnable f = [&]() { return l->setProperty(arg_list); };
+  returnable f = [&]() {
+    l->setProperty(arg_list);
+    return ML_ERROR_NONE;
+  };
   status = nntrainer_exception_boundary(f);
 
   return status;

--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -129,7 +129,7 @@ public:
    * @details   This function accepts vector of properties in the format -
    *  { std::string property_name, void * property_val, ...}
    */
-  virtual int setProperty(std::vector<std::string> values) = 0;
+  virtual void setProperty(const std::vector<std::string> &values) = 0;
 
   /**
    * @brief     Get name of the layer
@@ -166,9 +166,7 @@ template <typename T,
 std::unique_ptr<Layer> createLayer(const std::vector<std::string> &props = {}) {
   std::unique_ptr<Layer> ptr = std::make_unique<T>();
 
-  if (ptr->setProperty(props) != ML_ERROR_NONE) {
-    throw std::invalid_argument("Set properties failed for layer");
-  }
+  ptr->setProperty(props);
   return ptr;
 }
 

--- a/api/ccapi/include/optimizer.h
+++ b/api/ccapi/include/optimizer.h
@@ -71,12 +71,10 @@ public:
   /**
    * @brief     set Optimizer Parameters
    * @param[in] values Optimizer Parameter list
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    * @details   This function accepts vector of properties in the format -
    *  { std::string property_name, void * property_val, ...}
    */
-  virtual int setProperty(std::vector<std::string> values) = 0;
+  virtual void setProperty(const std::vector<std::string> &values) = 0;
 };
 
 /**
@@ -105,9 +103,7 @@ std::unique_ptr<Optimizer>
 createOptimizer(const std::vector<std::string> &props = {}) {
   std::unique_ptr<Optimizer> ptr = std::make_unique<T>();
 
-  if (ptr->setProperty(props) != ML_ERROR_NONE) {
-    throw std::invalid_argument("Set properties failed for optimizer");
-  }
+  ptr->setProperty(props);
   return ptr;
 }
 

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -171,6 +171,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/layer_impl.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/graph/network_graph.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/graph/graph_core.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/optimizers/optimizer_context.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/optimizer_devel.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/optimizer_impl.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/adam.cpp \

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -58,7 +58,7 @@ public:
    * @note name of each node in the graph must be unique, and caller must ensure
    * that
    */
-  virtual int setName(const std::string &name) = 0;
+  virtual void setName(const std::string &name) = 0;
 
   /**
    * @brief     Get the Type of the underlying object

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -93,10 +93,8 @@ public:
    * @details   This function accepts vector of properties in the format -
    *  { std::string property_name=property_val, ...}
    *
-   *  @todo update to new signature: void setProperty(const
-   * std::vector<std::string> &values)
    */
-  int setProperty(std::vector<std::string> properties) override;
+  void setProperty(const std::vector<std::string> &properties) override;
 
   /**
    * @brief     Get name of the layer
@@ -129,12 +127,8 @@ public:
    * @brief     set name of layer
    *
    * @param[in] name Name of the layer
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   *
-   * @todo update to new signature void setName(const std::string &name)
    */
-  int setName(const std::string &name) { return setProperty({"name=" + name}); }
+  void setName(const std::string &name) { setProperty({"name=" + name}); }
 
   /**
    * @brief     Get the input connections for this node

--- a/nntrainer/models/dynamic_training_optimization.cpp
+++ b/nntrainer/models/dynamic_training_optimization.cpp
@@ -17,6 +17,7 @@
 #include <dynamic_training_optimization.h>
 #include <tensor.h>
 #include <util_func.h>
+#include <weight.h>
 
 namespace nntrainer {
 DynamicTrainingOptimization::DynamicTrainingOptimization(int threshold_,

--- a/nntrainer/models/model_loader.cpp
+++ b/nntrainer/models/model_loader.cpp
@@ -180,8 +180,15 @@ int ModelLoader::loadModelConfigIni(dictionary *ini, NeuralNetwork &model) {
     }
   }
 
-  status = model.opt->setProperty(optimizer_prop);
-  NN_RETURN_STATUS();
+  try {
+    model.opt->setProperty(optimizer_prop);
+  } catch (std::exception &e) {
+    ml_loge("%s %s", typeid(e).name(), e.what());
+    return ML_ERROR_INVALID_PARAMETER;
+  } catch (...) {
+    ml_loge("Settings properties to optimizer failed.");
+    return ML_ERROR_INVALID_PARAMETER;
+  }
 
   return status;
 }

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -175,7 +175,7 @@ int NeuralNetwork::initialize() {
 
   // initialize optimizer and related variables
   if (opt) {
-    opt->initialize();
+    opt->finalize();
     std::function<std::vector<TensorDim>(const TensorDim &)> cb =
       [this](const TensorDim &dim) {
         return opt->getOptimizerVariableDim(dim);

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -31,6 +31,7 @@
 #include <neuralnet.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
+#include <optimizer_context.h>
 #include <parse_util.h>
 #include <profiler.h>
 #include <time_dist.h>
@@ -295,11 +296,13 @@ void NeuralNetwork::backwarding(std::shared_ptr<LayerNode> node, int iteration,
   if (apply_gradient && node->getTrainable()) {
     // TODO: ask network_graph for weights of node and then remove
     // getWeightObject() interface from layer_context
+    RunOptimizerContext opt_context;
     for (unsigned int idx = 0; idx < node->getNumWeights(); idx++) {
       auto &weight = node->getWeightObject(idx);
       if (weight.hasGradient()) {
         weight.calcRegularizationGradient();
-        opt->applyGradient(weight, iteration);
+        opt_context = RunOptimizerContext(&weight, iteration);
+        opt->applyGradient(opt_context);
       }
     }
   }

--- a/nntrainer/optimizers/adam.cpp
+++ b/nntrainer/optimizers/adam.cpp
@@ -40,9 +40,9 @@ double Adam::getLearningRate(size_t iteration) const {
   return ll;
 }
 
-void Adam::applyGradient(Weight &weight, int iteration) {
+void Adam::applyGradient(RunOptimizerContext &context) {
 
-  Tensor &x_grad = weight.getGradientRef();
+  Tensor &x_grad = context.getGradient();
 
   // This is implementation of adam from original paper.
   // This is not deleted intentionally.
@@ -66,8 +66,8 @@ void Adam::applyGradient(Weight &weight, int iteration) {
     return 1 / (sqrtDouble(f) + this->epsilon);
   };
 
-  Tensor &wm = weight.getOptimizerVariableRef(AdamParams::wm);
-  Tensor &wv = weight.getOptimizerVariableRef(AdamParams::wv);
+  Tensor &wm = context.getOptimizerVariable(AdamParams::wm);
+  Tensor &wv = context.getOptimizerVariable(AdamParams::wv);
 
   wm.multiply_i(beta1);
   wm.add_i(x_grad, 1.0f - beta1);
@@ -77,7 +77,7 @@ void Adam::applyGradient(Weight &weight, int iteration) {
 
   x_grad = wv.apply(sqrtEps, x_grad);
   x_grad.multiply_i(wm);
-  weight.applyGradient(getLearningRate(iteration));
+  context.applyGradient(getLearningRate(context.getIteration()));
 }
 
 void Adam::setProperty(const std::string &key, const std::string &value) {

--- a/nntrainer/optimizers/adam.h
+++ b/nntrainer/optimizers/adam.h
@@ -36,9 +36,9 @@ public:
     epsilon(ep) {}
 
   /**
-   * @copydoc applyGradient(Weight &weight, int iteration)
+   * @copydoc applyGradient(RunOptimizerContext &context)
    */
-  void applyGradient(Weight &weight, int iteration);
+  void applyGradient(RunOptimizerContext &context);
 
   /**
    * @copydoc Optimizer::getType()
@@ -49,12 +49,6 @@ public:
    * @copydoc   getLearningRate(int iteration)
    */
   double getLearningRate(size_t iteration) const;
-
-  /**
-   * @copydoc setProperty(const std::string &key,
-                           const std::string &value)
-   */
-  void setProperty(const std::string &key, const std::string &value);
 
   /**
    * @copydoc Optimizer::getOptimizerVariableDim(const TensorDim &dim)
@@ -82,6 +76,12 @@ private:
   double beta1;   /** momentum for grad */
   double beta2;   /** momentum for grad**2 */
   double epsilon; /** epsilon to protect overflow */
+
+  /**
+   * @copydoc LayerImpl::setProperty(const std::string &key,
+                           const std::string &value)
+   */
+  void setProperty(const std::string &key, const std::string &value);
 };
 } /* namespace nntrainer */
 

--- a/nntrainer/optimizers/meson.build
+++ b/nntrainer/optimizers/meson.build
@@ -2,7 +2,8 @@ optimizer_sources = [
   'adam.cpp',
   'optimizer_devel.cpp',
   'optimizer_impl.cpp',
-  'sgd.cpp'
+  'sgd.cpp',
+  'optimizer_context.cpp'
 ]
 
 optimizer_headers = [

--- a/nntrainer/optimizers/optimizer_context.cpp
+++ b/nntrainer/optimizers/optimizer_context.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   optimizer_context.h
+ * @date   30 July 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the layer context for each layer
+ */
+
+#include <optimizer_context.h>
+#include <weight.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Get the Weight tensor object
+ */
+Tensor &RunOptimizerContext::getWeight() const {
+  return weight->getVariableRef();
+}
+
+/**
+ * @brief Get the Weight Gradient tensor object
+ */
+Tensor &RunOptimizerContext::getGradient() const {
+  return weight->getGradientRef();
+}
+
+/**
+ * @brief Get the optimizer variable associated to this weight
+ */
+Tensor &RunOptimizerContext::getOptimizerVariable(unsigned int idx) const {
+  return weight->getOptimizerVariableRef(idx);
+}
+
+/**
+ * @brief   Apply the gradient with the given learning rate
+ */
+void RunOptimizerContext::applyGradient(double lr) const {
+  weight->applyGradient(lr);
+}
+} // namespace nntrainer

--- a/nntrainer/optimizers/optimizer_context.h
+++ b/nntrainer/optimizers/optimizer_context.h
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   optimizer_context.h
+ * @date   30 July 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the optimizer context for each optimizer
+ */
+
+#ifndef __OPTIMIZER_CONTEXT_H__
+#define __OPTIMIZER_CONTEXT_H__
+
+#include <memory>
+#include <vector>
+
+#include <tensor.h>
+
+namespace nntrainer {
+
+class Weight;
+
+/**
+ * @class   Op Context class for all optimizers
+ * @brief   Class for Optimizer context
+ *
+ * @details This provides for the optimizer execution.
+ */
+class RunOptimizerContext {
+public:
+  /**
+   * @brief Construct a new Run Optimizer Context object
+   *
+   */
+  RunOptimizerContext(Weight *w = nullptr, size_t iter = 0) :
+    weight(w),
+    iteration(iter) {}
+
+  /**
+   * @brief Get the Weight tensor object
+   *
+   * @return Tensor& Reference to the weight tensor
+   */
+  Tensor &getWeight() const;
+
+  /**
+   * @brief Get the Weight Gradient tensor object
+   *
+   * @return Tensor& Reference to the weight grad tensor
+   */
+  Tensor &getGradient() const;
+
+  /**
+   * @brief Get the optimizer variable associated to this weight
+   *
+   * @param idx Identifier of the associated weight
+   * @return Tensor& Reference to the optimizer variable
+   */
+  Tensor &getOptimizerVariable(unsigned int idx) const;
+
+  /**
+   * @brief   Check if run context is set and is ready to use
+   *
+   * @return true if ready, else false
+   */
+  bool readyToUse() const { return weight != nullptr; }
+
+  /**
+   * @brief   Apply the gradient with the given learning rate
+   *
+   * @param lr learning rate
+   */
+  void applyGradient(double lr) const;
+
+  /**
+   * @brief   Get the current iteration value
+   *
+   * @return iteration value
+   */
+  size_t getIteration() const { return iteration; }
+
+private:
+  Weight *weight;   /**< weights for the optimizer */
+  size_t iteration; /**< iteration number */
+};
+
+} // namespace nntrainer
+#endif // __OPTIMIZER_CONTEXT_H__

--- a/nntrainer/optimizers/optimizer_devel.cpp
+++ b/nntrainer/optimizers/optimizer_devel.cpp
@@ -15,60 +15,19 @@
 #include <fstream>
 #include <iostream>
 
-#include <nntrainer_log.h>
+#include <nntrainer_error.h>
 #include <optimizer_devel.h>
 #include <parse_util.h>
 #include <util_func.h>
 
 namespace nntrainer {
 
-int Optimizer::setProperty(std::vector<std::string> values) {
-  int status = ML_ERROR_NONE;
-
-  for (unsigned int i = 0; i < values.size(); ++i) {
-    std::string key;
-    std::string value;
-
-    status = getKeyValue(values[i], key, value);
-    NN_RETURN_STATUS();
-
-    if (value.empty()) {
-      return ML_ERROR_INVALID_PARAMETER;
-    }
-
-    try {
-      /// @note this calls derived setProperty if available
-      setProperty(key, value);
-    } catch (...) {
-      return ML_ERROR_INVALID_PARAMETER;
-    }
+void Optimizer::setProperty(const std::vector<std::string> &values) {
+  if (!values.empty()) {
+    std::string msg = "[OptimizerDevel] Unknown properties count " +
+                      std::to_string(values.size());
+    throw exception::not_supported(msg);
   }
-
-  try {
-    checkValidation();
-  } catch (...) {
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-  return status;
-}
-
-void Optimizer::checkValidation() const {
-  if (getLearningRate() <= 0.0f)
-    throw std::invalid_argument("Learning rate must be positive");
-}
-
-void Optimizer::setProperty(const std::string &key, const std::string &value) {
-  int status = ML_ERROR_NONE;
-  unsigned int type = parseOptProperty(key);
-
-  switch (type) {
-  default:
-    ml_loge("Error: Unknown Optimizer Property Key");
-    status = ML_ERROR_INVALID_PARAMETER;
-    break;
-  }
-
-  throw_status(status);
 }
 
 void Optimizer::read(std::ifstream &file) {

--- a/nntrainer/optimizers/optimizer_devel.h
+++ b/nntrainer/optimizers/optimizer_devel.h
@@ -86,9 +86,9 @@ public:
   };
 
   /**
-   * @brief     initialize optimizer.
+   * @brief     finalize optimizer.
    */
-  virtual void initialize(){};
+  virtual void finalize(){};
 
   /**
    * @brief     Read Training optimizer paramters from file

--- a/nntrainer/optimizers/optimizer_devel.h
+++ b/nntrainer/optimizers/optimizer_devel.h
@@ -19,8 +19,8 @@
 #include <memory>
 
 #include <optimizer.h>
+#include <optimizer_context.h>
 #include <tensor.h>
-#include <weight.h>
 
 namespace nntrainer {
 
@@ -48,18 +48,15 @@ public:
 
   /**
    * @brief     apply gradient to weight
-   * @param[in] params Weight
-   * @param[in] iteration nth epoch number
+   * @param[in] context Optimizer context
    */
-  virtual void applyGradient(Weight &param, int iteration) = 0;
+  virtual void applyGradient(RunOptimizerContext &context) = 0;
 
   /**
    * @brief     set Optimizer Parameters
    * @param[in] values Optimizer Parameter list
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int setProperty(std::vector<std::string> values);
+  virtual void setProperty(const std::vector<std::string> &values);
 
   /**
    * @brief     Default allowed properties
@@ -89,24 +86,9 @@ public:
   };
 
   /**
-   * @brief setProperty individually
-   * @note By passing empty string, this can validate if @a type is valid
-   * @param[in] key key to be passed as string
-   * @param[in] value value to be passed, if empty string is passed, do nothing
-   * but throws error when @a type is invalid
-   * @exception exception::not_supported     when string type is not valid for
-   * the particular layer
-   * @exception std::invalid_argument invalid argument
-   */
-  virtual void setProperty(const std::string &key,
-                           const std::string &value) = 0;
-
-  /**
    * @brief     initialize optimizer.
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int initialize() = 0;
+  virtual void initialize(){};
 
   /**
    * @brief     Read Training optimizer paramters from file
@@ -119,11 +101,6 @@ public:
    * @param[in] file output stream file
    */
   virtual void save(std::ofstream &file);
-
-  /**
-   * @brief     validate the optimizer
-   */
-  virtual void checkValidation() const;
 
   /**
    * @brief     Get dimension of extra variables if the optimizer needs any.

--- a/nntrainer/optimizers/optimizer_impl.cpp
+++ b/nntrainer/optimizers/optimizer_impl.cpp
@@ -24,7 +24,26 @@
 
 namespace nntrainer {
 
-int OptimizerImpl::initialize() { return ML_ERROR_NONE; }
+void OptimizerImpl::setProperty(const std::vector<std::string> &values) {
+  /// @todo: deprecate this in favor of loadProperties
+  for (unsigned int i = 0; i < values.size(); ++i) {
+    std::string key;
+    std::string value;
+    std::stringstream ss;
+
+    if (getKeyValue(values[i], key, value) != ML_ERROR_NONE) {
+      throw std::invalid_argument("Error parsing the property: " + values[i]);
+    }
+
+    if (value.empty()) {
+      ss << "value is empty: key: " << key << ", value: " << value;
+      throw std::invalid_argument(ss.str());
+    }
+
+    /// @note this calls derived setProperty if available
+    setProperty(key, value);
+  }
+}
 
 void OptimizerImpl::setProperty(const std::string &key,
                                 const std::string &value) {
@@ -45,8 +64,7 @@ void OptimizerImpl::setProperty(const std::string &key,
     status = setBoolean(continue_train, value);
     break;
   default:
-    Optimizer::setProperty(key, value);
-    status = ML_ERROR_NONE;
+    status = ML_ERROR_INVALID_PARAMETER;
     break;
   }
 
@@ -62,4 +80,5 @@ double OptimizerImpl::getLearningRate(size_t iteration) const {
 
   return ll;
 }
+
 } // namespace nntrainer

--- a/nntrainer/optimizers/optimizer_impl.h
+++ b/nntrainer/optimizers/optimizer_impl.h
@@ -88,23 +88,9 @@ public:
   double getLearningRate(size_t iteration) const;
 
   /**
-   * @brief setProperty individually
-   * @note By passing empty string, this can validate if @a type is valid
-   * @param[in] key key to be passed as string
-   * @param[in] value value to be passed, if empty string is passed, do nothing
-   * but throws error when @a type is invalid
-   * @exception exception::not_supported     when string type is not valid for
-   * the particular layer
-   * @exception std::invalid_argument invalid argument
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
    */
-  virtual void setProperty(const std::string &key, const std::string &value);
-
-  /**
-   * @brief     initialize optimizer.
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  virtual int initialize();
+  virtual void setProperty(const std::vector<std::string> &values);
 
   /**
    * @brief     Get dimension of extra variables if the optimizer needs any.
@@ -121,6 +107,18 @@ protected:
   float decay_rate;         /** decay rate for learning rate */
   unsigned int decay_steps; /** decay steps for learning rate */
   bool continue_train; /** Continue training with previous tensors for adam */
+
+  /**
+   * @brief setProperty individually
+   * @note By passing empty string, this can validate if @a type is valid
+   * @param[in] key key to be passed as string
+   * @param[in] value value to be passed, if empty string is passed, do nothing
+   * but throws error when @a type is invalid
+   * @exception exception::not_supported     when string type is not valid for
+   * the particular layer
+   * @exception std::invalid_argument invalid argument
+   */
+  virtual void setProperty(const std::string &key, const std::string &value);
 };
 
 } /* namespace nntrainer */

--- a/nntrainer/optimizers/plugged_optimizer.h
+++ b/nntrainer/optimizers/plugged_optimizer.h
@@ -83,11 +83,10 @@ public:
 
   /**
    * @brief     apply gradient to weight
-   * @param[in] params Weight
-   * @param[in] iteration nth epoch number
+   * @param[in] context Optimizer context
    */
-  void applyGradient(Weight &param, int iteration) override {
-    optimizer_devel->applyGradient(param, iteration);
+  void applyGradient(RunOptimizerContext &context) override {
+    optimizer_devel->applyGradient(context);
   }
 
   /**
@@ -96,22 +95,8 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int setProperty(std::vector<std::string> values) override {
-    return optimizer_devel->setProperty(values);
-  }
-
-  /**
-   * @brief setProperty individually
-   * @note By passing empty string, this can validate if @a type is valid
-   * @param[in] key key to be passed as string
-   * @param[in] value value to be passed, if empty string is passed, do nothing
-   * but throws error when @a type is invalid
-   * @exception exception::not_supported     when string type is not valid for
-   * the particular layer
-   * @exception std::invalid_argument invalid argument
-   */
-  void setProperty(const std::string &key, const std::string &value) override {
-    optimizer_devel->setProperty(key, value);
+  void setProperty(const std::vector<std::string> &values) override {
+    optimizer_devel->setProperty(values);
   }
 
   /**
@@ -119,7 +104,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize() override { return optimizer_devel->initialize(); }
+  void initialize() override { optimizer_devel->initialize(); }
 
   /**
    * @brief     Read Training optimizer paramters from file
@@ -132,11 +117,6 @@ public:
    * @param[in] file output stream file
    */
   void save(std::ofstream &file) override { optimizer_devel->save(file); }
-
-  /**
-   * @brief     validate the optimizer
-   */
-  void checkValidation() const override { optimizer_devel->checkValidation(); }
 
   /**
    * @brief     Get dimension of extra variables if the optimizer needs any.

--- a/nntrainer/optimizers/plugged_optimizer.h
+++ b/nntrainer/optimizers/plugged_optimizer.h
@@ -100,11 +100,9 @@ public:
   }
 
   /**
-   * @brief     initialize optimizer.
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
+   * @brief     finalize optimizer.
    */
-  void initialize() override { optimizer_devel->initialize(); }
+  void finalize() override { optimizer_devel->finalize(); }
 
   /**
    * @brief     Read Training optimizer paramters from file

--- a/nntrainer/optimizers/sgd.cpp
+++ b/nntrainer/optimizers/sgd.cpp
@@ -15,8 +15,8 @@
 
 namespace nntrainer {
 
-void SGD::applyGradient(Weight &weight, int iteration) {
-  weight.applyGradient(getLearningRate(iteration));
+void SGD::applyGradient(RunOptimizerContext &context) {
+  context.applyGradient(getLearningRate(context.getIteration()));
 }
 
 } // namespace nntrainer

--- a/nntrainer/optimizers/sgd.h
+++ b/nntrainer/optimizers/sgd.h
@@ -31,9 +31,9 @@ public:
   SGD(float lr = 0.0001f, Args... args) : OptimizerImpl(lr, args...) {}
 
   /**
-   * @copydoc applyGradient(Weight &weight, int iteration)
+   * @copydoc applyGradient(RunOptimizerContext &context)
    */
-  void applyGradient(Weight &weight, int iteration);
+  void applyGradient(RunOptimizerContext &context);
 
   /**
    * @copydoc Optimizer::getType()

--- a/test/unittest/unittest_nntrainer_appcontext.cpp
+++ b/test/unittest/unittest_nntrainer_appcontext.cpp
@@ -106,20 +106,14 @@ public:
 
   double getLearningRate(size_t iteration) const override { return 1.0f; }
 
-  int setProperty(std::vector<std::string> values) override { return 1; }
-
-  int initialize() override { return 0; }
+  void setProperty(const std::vector<std::string> &values) override {}
 
   std::vector<nntrainer::TensorDim>
   getOptimizerVariableDim(const nntrainer::TensorDim &dim) override {
     return std::vector<nntrainer::TensorDim>();
   }
 
-  void setProperty(const std::string &key, const std::string &value) override {}
-
-  void checkValidation() const override {}
-
-  void applyGradient(nntrainer::Weight &weight, int iteration) override {}
+  void applyGradient(nntrainer::RunOptimizerContext &context) override {}
 };
 
 /**
@@ -131,8 +125,6 @@ public:
   /** Minimal custom optimizer example which define only necessary functions */
   const std::string getType() const override { return "identity_optimizer"; }
 
-  int initialize() override { return 0; }
-
   double getLearningRate(size_t iteration) const override { return 1.0f; }
 
   std::vector<nntrainer::TensorDim>
@@ -140,7 +132,7 @@ public:
     return std::vector<nntrainer::TensorDim>();
   }
 
-  void applyGradient(nntrainer::Weight &weight, int iteration) override {}
+  void applyGradient(nntrainer::RunOptimizerContext &context) override {}
 };
 
 /**


### PR DESCRIPTION
Cleanup optimizer interface where some extra interfaces have been
removed, and arguments interface has been updated.
Further, the dependency on weight header has been removed, and added an
optimizer context interface which provides an interface to weight
related tensors required by the optimizer.

Update the interface for the layer.h setProperty.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>