### PR TITLE
[tensorfilter] Update tensor filter to use ccapi

### DIFF
--- a/nnstreamer/tensor_filter/meson.build
+++ b/nnstreamer/tensor_filter/meson.build
@@ -13,7 +13,7 @@ gst_dep = dependency('gstreamer-'+gst_api_version)
 
 nntrainer_prefix = get_option('prefix')
 
-nnstreamer_filter_nntrainer_deps = [glib_dep, gmodule_dep, gst_dep, nntrainer_dep, nnstreamer_dep]
+nnstreamer_filter_nntrainer_deps = [glib_dep, gmodule_dep, gst_dep, nntrainer_ccapi_dep, nnstreamer_dep]
 
 nnstreamer_libdir = nntrainer_prefix / get_option('libdir')
 subplugin_install_prefix = nnstreamer_libdir / 'nnstreamer'

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -21,7 +21,6 @@
 #include <sstream>
 #include <unistd.h>
 
-#include <neuralnet.h>
 #include <nntrainer_error.h>
 
 #include "tensor_filter_nntrainer.hh"
@@ -38,8 +37,6 @@
 #ifndef DBG
 #define DBG FALSE
 #endif
-
-#define NUM_DIM 4
 
 static const gchar *nntrainer_accl_support[] = {NULL};
 
@@ -63,20 +60,20 @@ struct gNewDeletor {
 };
 
 static std::unique_ptr<GstTensorInfo, gNewDeletor>
-to_nnst_tensor_dim(const nntrainer::TensorDim &dim) {
+to_nnst_tensor_dim(const ml::train::TensorDim &dim) {
   auto info =
     std::unique_ptr<GstTensorInfo, gNewDeletor>(g_new(GstTensorInfo, 1));
   gst_tensor_info_init(info.get());
 
   info->type = _NNS_FLOAT32;
-  for (unsigned int i = 0; i < NUM_DIM; ++i) {
-    info->dimension[i] = dim.getTensorDim(NUM_DIM - i - 1);
+  for (unsigned int i = 0; i < ml::train::TensorDim::MAXDIM; ++i) {
+    info->dimension[i] = dim.getTensorDim(ml::train::TensorDim::MAXDIM - i - 1);
   }
 
   return info;
 }
 
-static nntrainer::TensorDim to_nntr_tensor_dim(const GstTensorInfo *info) {
+static ml::train::TensorDim to_nntr_tensor_dim(const GstTensorInfo *info) {
   const tensor_dim &d = info->dimension;
   return {d[3], d[2], d[1], d[0]};
 }
@@ -97,7 +94,7 @@ void NNTrainerInference::loadModel() {
 #if (DBG)
   gint64 start_time = g_get_real_time();
 #endif
-  model = std::make_unique<nntrainer::NeuralNetwork>();
+  model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
   model->loadFromConfig(model_config);
 #if (DBG)
   gint64 stop_time = g_get_real_time();

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.hh
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.hh
@@ -23,7 +23,7 @@
 #include <nnstreamer_plugin_api.h>
 #include <nnstreamer_plugin_api_filter.h>
 
-#include <neuralnet.h>
+#include <model.h>
 #include <tensor_dim.h>
 
 /**
@@ -76,7 +76,7 @@ public:
    *
    * @return const std::vector<nntrainer::TensorDim> input dimensions
    */
-  const std::vector<nntrainer::TensorDim> getInputDimension() {
+  const std::vector<ml::train::TensorDim> getInputDimension() {
     return model->getInputDimension();
   }
 
@@ -85,7 +85,7 @@ public:
    *
    * @return const std::vector<nntrainer::TensorDim> output dimensions
    */
-  const std::vector<nntrainer::TensorDim> getOutputDimension() {
+  const std::vector<ml::train::TensorDim> getOutputDimension() {
     return model->getOutputDimension();
   }
 
@@ -102,18 +102,5 @@ private:
   void loadModel();
 
   std::string model_config;
-  ///@todo change this to ccapi
-  /// required method
-  /// model->loadFromConfig              (available)
-  /// model->setProperty                 (available)
-  /// model->compile                     (available)
-  /// model->initialize                  (available)
-  /// model->readModel                   (available)
-  /// model->inference                   (available)
-  /// model->getInputDimension           (n/a)
-  /// model->getOutputDimension          (n/a)
-  /// possibly required for optimization
-  /// model->forwarding                  (n/a)
-  /// model->allocate                    (n/a)
-  std::unique_ptr<nntrainer::NeuralNetwork> model;
+  std::unique_ptr<ml::train::Model> model;
 };


### PR DESCRIPTION
Update nntrainer's tensor filter for nnstreamer to depend only on ccapi
and nntrainer directly and internal headers.

See Also #986
Resolves #696

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>