### PR TITLE
[graph] Graph cleanup and prepare for memory optimization

### DIFF
--- a/nntrainer/graph/graph_core.cpp
+++ b/nntrainer/graph/graph_core.cpp
@@ -114,7 +114,6 @@ void GraphCore::ensureName(GraphNode &node, const std::string &prefix_,
                            const std::string &postfix_, bool force_rename) {
   auto to_lower = [](const std::string &str) -> std::string {
     std::string ret = str;
-    ;
     std::transform(ret.begin(), ret.end(), ret.begin(),
                    [](unsigned char c) { return std::tolower(c); });
     return ret;

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -21,6 +21,7 @@
 #include <map>
 #include <memory>
 #include <stack>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -65,6 +66,7 @@ public:
     using std::swap;
 
     swap(lhs.node_list, rhs.node_list);
+    swap(lhs.node_map, rhs.node_map);
     swap(lhs.Sorted, rhs.Sorted);
     swap(lhs.node_names, rhs.node_names);
     swap(lhs.def_name_count, rhs.def_name_count);
@@ -75,6 +77,7 @@ public:
    */
   void reset() {
     node_list.clear();
+    node_map.clear();
     Sorted.clear();
     node_names.clear();
     def_name_count = 0;
@@ -261,6 +264,7 @@ private:
   std::vector<std::shared_ptr<GraphNode>> output_list;
   std::vector<std::shared_ptr<GraphNode>>
     node_list;                                    /**< Unordered Node List  */
+  std::unordered_map<std::string, int> node_map;  /**< Unordered Node map  */
   std::vector<std::shared_ptr<GraphNode>> Sorted; /**< Ordered Node List  */
   bool sorted; /** if the node_list is sorted */
 
@@ -290,6 +294,14 @@ private:
    */
   void
   makeAdjacencyList(std::vector<std::list<std::shared_ptr<GraphNode>>> &adj);
+
+  /**
+   * @brief     Get index of the node with given name
+   *
+   * @param     name Name of the node
+   * @return    internal index of the node
+   */
+  unsigned int getNodeIdx(const std::string &name);
 };
 
 } // namespace nntrainer

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -32,18 +32,6 @@ public:
   virtual ~GraphNode() = default;
 
   /**
-   * @brief     Get index of the node
-   *
-   */
-  virtual size_t getIndex() const = 0;
-
-  /**
-   * @brief     Set index of the node
-   *
-   */
-  virtual void setIndex(size_t) = 0;
-
-  /**
    * @brief     Get the Name of the underlying object
    *
    * @return std::string Name of the underlying object

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -98,15 +98,6 @@ public:
   }
 
   /**
-   * @brief getter of LayerNode with index number
-   * @param[in] index
-   * @ret LayerNode
-   */
-  std::shared_ptr<LayerNode> getLayerNode(unsigned int ith) const {
-    return std::static_pointer_cast<LayerNode>(graph.getNode(ith));
-  }
-
-  /**
    * @brief getter of Sorted LayerNode with index number
    * @param[in] index
    * @ret LayerNode

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -118,9 +118,8 @@ createLayerNode(std::unique_ptr<nntrainer::Layer> &&layer,
   return lnode;
 }
 
-LayerNode::LayerNode(std::unique_ptr<nntrainer::Layer> &&l, size_t idx) :
+LayerNode::LayerNode(std::unique_ptr<nntrainer::Layer> &&l) :
   layer(std::move(l)),
-  index(idx),
   finalized(false),
   activation_type(ActivationType::ACT_NONE),
   layer_node_props(new PropsType(props::Name(), props::Flatten(),

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -59,14 +59,14 @@ public:
   /**
    * @brief Default constructor
    */
-  LayerNode() : LayerNode(nullptr, 0) {}
+  LayerNode() : LayerNode(nullptr) {}
 
   /**
    * @brief Constructor of LayerNode class for v2
    * @param l layer to wrap with, the ownership is transferred to layer node
    *
    */
-  LayerNode(std::unique_ptr<nntrainer::Layer> &&l, size_t idx = 0);
+  LayerNode(std::unique_ptr<nntrainer::Layer> &&l);
 
   /**
    * @brief     Destructor of LayerNode Class
@@ -109,19 +109,6 @@ public:
   /**
    * Support all the interface requirements by nntrainer::GraphNode
    */
-
-  /**
-   * @brief     Get index of the node
-   *
-   * @return    Index of the node
-   */
-  size_t getIndex() const { return index; }
-
-  /**
-   * @brief     Set the index for the node
-   * @param     idx Index for the node
-   */
-  void setIndex(size_t idx) { index = idx; }
 
   /**
    * @brief     set name of layer
@@ -363,7 +350,17 @@ public:
    * @param layers Name of the layers
    */
   void setInputLayers(const std::vector<std::string> &layers) {
-    input_layers = layers;
+    auto to_lower = [](const std::string &str) -> std::string {
+      std::string ret = str;
+      ;
+      std::transform(ret.begin(), ret.end(), ret.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
+      return ret;
+    };
+
+    input_layers.reserve(layers.size());
+    for (auto const &name : layers)
+      input_layers.push_back(to_lower(name));
     resizeInputDimensions(input_layers.size());
   }
 
@@ -587,9 +584,6 @@ private:
   std::unique_ptr<nntrainer::Layer>
     layer; /**< The actual object in the graph node */
 
-  // TODO: possibly remove, two identifiers for the same node (name and
-  // index) can lead to issues later
-  size_t index;   /**< index of each node */
   bool finalized; /**< if the layer node has been finalized */
 
   std::vector<std::string> input_layers;  /**< input layer names */

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -352,7 +352,6 @@ public:
   void setInputLayers(const std::vector<std::string> &layers) {
     auto to_lower = [](const std::string &str) -> std::string {
       std::string ret = str;
-      ;
       std::transform(ret.begin(), ret.end(), ret.begin(),
                      [](unsigned char c) { return std::tolower(c); });
       return ret;


### PR DESCRIPTION
This patch provides graph cleanup and preparation for memory optimizations:
- Remove layerv2 initialize code for network graph.
- Currently each graph node has two identifiers - name and idx - where
both were unique. This patch removes the idx as the indentifier.
The corresponding functions are also removed.
In order to support fast fetching of nodes, graphcore has a map nodes.
- This change revealed a bug with the names in the code. As ini does not
allow case sensitive names, the names from the ini are changed to lower
case. However, input_layers property names were allowed to be
case-sensitive. Further names set by the API were also case sensitive.
This patch forces all such names to be case-insensitive to lowercase.
- Update the check for checking if a given node is input node.
The check uses in-degree for the node to be 0.

See Also #1127

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>