### PR TITLE
[layers/manager] Set tensor to usage mapping

### DIFF
--- a/Applications/SimpleShot/layers/centroid_knn.cpp
+++ b/Applications/SimpleShot/layers/centroid_knn.cpp
@@ -71,13 +71,15 @@ void CentroidKNN::finalize(nntrainer::InitLayerContext &context) {
   /// samples seen for the current run to calculate the centroid
   auto samples_seen = nntrainer::TensorDim({num_class});
 
-  weight_idx[KNNParams::map] = context.requestWeight(
-    map_dim, nntrainer::Tensor::Initializer::ZEROS,
-    nntrainer::WeightRegularizer::NONE, 1.0f, "centroidNN:map", false);
+  weight_idx[KNNParams::map] =
+    context.requestWeight(map_dim, nntrainer::Tensor::Initializer::ZEROS,
+                          nntrainer::WeightRegularizer::NONE, 1.0f,
+                          context.getName() + ":map", false);
 
-  weight_idx[KNNParams::num_samples] = context.requestWeight(
-    samples_seen, nntrainer::Tensor::Initializer::ZEROS,
-    nntrainer::WeightRegularizer::NONE, 1.0f, "centroidNN:num_samples", false);
+  weight_idx[KNNParams::num_samples] =
+    context.requestWeight(samples_seen, nntrainer::Tensor::Initializer::ZEROS,
+                          nntrainer::WeightRegularizer::NONE, 1.0f,
+                          context.getName() + ":num_samples", false);
 }
 
 void CentroidKNN::forwarding(nntrainer::RunLayerContext &context,

--- a/nntrainer/graph/graph_core.cpp
+++ b/nntrainer/graph/graph_core.cpp
@@ -89,6 +89,8 @@ void GraphCore::topologicalSort() {
 
   while (dfs_stack.empty() == false) {
     Sorted.push_back(dfs_stack.top());
+    Sorted.back()->setExecLoc(
+      {Sorted.size(), (node_list.size() * 2) - Sorted.size() + 1});
     dfs_stack.pop();
   }
 

--- a/nntrainer/graph/graph_core.cpp
+++ b/nntrainer/graph/graph_core.cpp
@@ -89,8 +89,6 @@ void GraphCore::topologicalSort() {
 
   while (dfs_stack.empty() == false) {
     Sorted.push_back(dfs_stack.top());
-    Sorted.back()->setExecLoc(
-      {Sorted.size(), (node_list.size() * 2) - Sorted.size() + 1});
     dfs_stack.pop();
   }
 

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -27,6 +27,20 @@ namespace nntrainer {
 class GraphNode {
 public:
   /**
+   * @brief Provides the time/order at which the node will be executed.
+   * @details This time will be finalized once the graph has been calculated.
+   * The three times given indicate the order with which the below three
+   * operations for each node are executed:
+   * 1. Forwarding
+   * 2. calcGradient
+   * 3. calcDerivative
+   * One constraint the three times is that they must be sorted in ascending
+   * order. This ensures that the operations are executed in the order of their
+   * listing.
+   */
+  typedef std::tuple<unsigned int, unsigned int, unsigned int> ExecutionOrder;
+
+  /**
    * @brief     Destructor of Layer Class
    */
   virtual ~GraphNode() = default;
@@ -76,16 +90,16 @@ public:
    * @details   The two values represents the value for forward and backward
    * respectively
    */
-  virtual std::pair<unsigned int, unsigned int> getExecLoc() const = 0;
+  virtual ExecutionOrder getExecutionOrder() const = 0;
 
   /**
    * @brief     set the execution order/location of this node
    *
-   * @param     exec_loc the execution order/location of this node
+   * @param     exec_order the execution order/location of this node
    * @details   The two values represents the value for forward and backward
    * respectively
    */
-  virtual void setExecLoc(std::pair<unsigned int, unsigned int> exec_loc) = 0;
+  virtual void setExecutionOrder(ExecutionOrder exec_order_) = 0;
 };
 
 /**

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -70,11 +70,22 @@ public:
   virtual const std::vector<std::string> &getOutputConnections() const = 0;
 
   /**
-   * @brief     Copy the graph
-   * @param[in] from Graph Object to copy
-   * @retval    Graph Object copyed
+   * @brief     get the execution order/location of this node
+   *
+   * @retval    the execution order/location of this node
+   * @details   The two values represents the value for forward and backward
+   * respectively
    */
-  // virtual GraphNode &copy(const GraphNode &from) = 0;
+  virtual std::pair<unsigned int, unsigned int> getExecLoc() const = 0;
+
+  /**
+   * @brief     set the execution order/location of this node
+   *
+   * @param     exec_loc the execution order/location of this node
+   * @details   The two values represents the value for forward and backward
+   * respectively
+   */
+  virtual void setExecLoc(std::pair<unsigned int, unsigned int> exec_loc) = 0;
 };
 
 /**

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -464,6 +464,16 @@ private:
    * match and merging loss layers with activation layers if needed.
    */
   void finalizeLossLayer();
+
+  /**
+   * @brief Set the order of execution for all the nodes in the graph
+   *
+   * @details This sets the order of execution using the order from the
+   * topological sort. The order of forwarding matches the topological sort. The
+   * order for backwarding is in the exact reverse order. The calcDerivative()
+   * is expected to be called right after calcGradient().
+   */
+  void setExecutionOrder();
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -60,22 +60,22 @@ void BatchNormalizationLayer::finalize(InitLayerContext &context) {
       axes_to_reduce.push_back(i);
   }
 
-  wt_idx[BNParams::mu] = context.requestWeight(dim, initializers[BNParams::mu],
-                                               WeightRegularizer::NONE, 1.0f,
-                                               "BN::moving_mean", false);
+  wt_idx[BNParams::mu] = context.requestWeight(
+    dim, initializers[BNParams::mu], WeightRegularizer::NONE, 1.0f,
+    context.getName() + ":moving_mean", false);
   wt_idx[BNParams::var] = context.requestWeight(
     dim, initializers[BNParams::var], WeightRegularizer::NONE, 1.0f,
     "BN::moving_variance", false);
-  wt_idx[BNParams::gamma] =
-    context.requestWeight(dim, initializers[BNParams::gamma],
-                          WeightRegularizer::NONE, 1.0f, "BN::gamma", true);
-  wt_idx[BNParams::beta] =
-    context.requestWeight(dim, initializers[BNParams::beta],
-                          WeightRegularizer::NONE, 1.0f, "BN::beta", true);
+  wt_idx[BNParams::gamma] = context.requestWeight(
+    dim, initializers[BNParams::gamma], WeightRegularizer::NONE, 1.0f,
+    context.getName() + ":gamma", true);
+  wt_idx[BNParams::beta] = context.requestWeight(
+    dim, initializers[BNParams::beta], WeightRegularizer::NONE, 1.0f,
+    context.getName() + ":beta", true);
 
   wt_idx[BNParams::deviation] =
-    context.requestTensor(in_dim, "BN::deviation", Tensor::Initializer::NONE,
-                          false, ITERATION_LIFESPAN);
+    context.requestTensor(in_dim, context.getName() + ":deviation",
+                          Tensor::Initializer::NONE, false, ITERATION_LIFESPAN);
 }
 
 void BatchNormalizationLayer::setProperty(

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -288,12 +288,12 @@ void Conv2DLayer::finalize(InitLayerContext &context) {
 
   padding = std::get<props::Padding2D>(conv_props).compute(in_dim, dim);
 
-  wt_idx[ConvParams::weight] =
-    context.requestWeight(dim, weight_initializer, weight_regularizer,
-                          weight_regularizer_constant, "Conv2d:filter", true);
+  wt_idx[ConvParams::weight] = context.requestWeight(
+    dim, weight_initializer, weight_regularizer, weight_regularizer_constant,
+    context.getName() + ":filter", true);
   wt_idx[ConvParams::bias] =
     context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                          1.0f, "Conv2d:bias", true);
+                          1.0f, context.getName() + ":bias", true);
 
   /// we don't have same padding for now but later, same padding don't apply
   /// when kernel size is even in current implementation (we need to handle
@@ -325,10 +325,11 @@ void Conv2DLayer::finalize(InitLayerContext &context) {
   }
 
   wt_idx[ConvParams::im2col_result] = context.requestTensor(
-    calcIm2ColOutputDim(in_dim, dim, padding, stride, {1, 1}), "Conv2d:im2col",
-    Tensor::Initializer::NONE, false, ITERATION_LIFESPAN);
+    calcIm2ColOutputDim(in_dim, dim, padding, stride, {1, 1}),
+    context.getName() + ":im2col", Tensor::Initializer::NONE, false,
+    ITERATION_LIFESPAN);
   wt_idx[ConvParams::col2im_result] = context.requestTensor(
-    calcCol2ImOutputDim(out_dim, dim), "Conv2d:col2im",
+    calcCol2ImOutputDim(out_dim, dim), context.getName() + ":col2im",
     Tensor::Initializer::NONE, false, BACKWARD_FUNC_LIFESPAN);
 }
 

--- a/nntrainer/layers/dropout.cpp
+++ b/nntrainer/layers/dropout.cpp
@@ -27,8 +27,9 @@ void DropOutLayer::finalize(InitLayerContext &context) {
 
   mask_idx.reserve(input_dims.size());
   for (auto &t : input_dims) {
-    mask_idx.push_back(context.requestTensor(
-      t, "DropoutMask", Tensor::Initializer::NONE, false, ITERATION_LIFESPAN));
+    mask_idx.push_back(context.requestTensor(t, context.getName() + ":Mask",
+                                             Tensor::Initializer::NONE, false,
+                                             ITERATION_LIFESPAN));
   }
 }
 

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -46,9 +46,9 @@ void EmbeddingLayer::finalize(InitLayerContext &context) {
   dim.width(out_dim);
   dim.batch(1);
 
-  weight_idx =
-    context.requestWeight(dim, weight_initializer, weight_regularizer,
-                          weight_regularizer_constant, "Embedding", true);
+  weight_idx = context.requestWeight(
+    dim, weight_initializer, weight_regularizer, weight_regularizer_constant,
+    context.getName() + ":Embedding", true);
 }
 
 void EmbeddingLayer::setProperty(const std::vector<std::string> &values) {

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -59,12 +59,13 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
   TensorDim bias_dim(1, 1, 1, unit, 0b0001);
   TensorDim weight_dim(1, 1, in_dim.width(), unit, 0b0011);
 
-  weight_idx[FCParams::weight] =
-    context.requestWeight(weight_dim, weight_initializer, weight_regularizer,
-                          weight_regularizer_constant, "FC:weight", true);
+  weight_idx[FCParams::weight] = context.requestWeight(
+    weight_dim, weight_initializer, weight_regularizer,
+    weight_regularizer_constant, context.getName() + ":weight", true);
 
-  weight_idx[FCParams::bias] = context.requestWeight(
-    bias_dim, bias_initializer, WeightRegularizer::NONE, 1.0f, "FC:bias", true);
+  weight_idx[FCParams::bias] =
+    context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
+                          1.0f, context.getName() + ":bias", true);
 }
 
 void FullyConnectedLayer::exportTo(Exporter &exporter,

--- a/nntrainer/layers/gru.cpp
+++ b/nntrainer/layers/gru.cpp
@@ -103,32 +103,34 @@ void GRULayer::finalize(InitLayerContext &context) {
   // weight_initializer can be set sepeartely. weight_xh initializer,
   // weight_hh initializer kernel initializer & recurrent_initializer in keras
   // for now, it is set same way.
-  wt_idx[GRUParams::weight_xh] =
-    context.requestWeight(dim_xh, weight_initializer, weight_regularizer,
-                          weight_regularizer_constant, "GRU:weight_xh", true);
-  wt_idx[GRUParams::weight_hh] =
-    context.requestWeight(dim_hh, weight_initializer, weight_regularizer,
-                          weight_regularizer_constant, "GRU:weight_hh", true);
+  wt_idx[GRUParams::weight_xh] = context.requestWeight(
+    dim_xh, weight_initializer, weight_regularizer, weight_regularizer_constant,
+    context.getName() + ":weight_xh", true);
+  wt_idx[GRUParams::weight_hh] = context.requestWeight(
+    dim_hh, weight_initializer, weight_regularizer, weight_regularizer_constant,
+    context.getName() + ":weight_hh", true);
   wt_idx[GRUParams::bias_h] =
     context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                          1.0f, "GRU:bias_h", true);
+                          1.0f, context.getName() + ":bias_h", true);
 
   TensorDim d = input_dim;
   d.width(unit);
 
-  wt_idx[GRUParams::hidden_state] = context.requestTensor(
-    d, "GRU:hidden_state", Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
+  wt_idx[GRUParams::hidden_state] =
+    context.requestTensor(d, context.getName() + ":hidden_state",
+                          Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
 
   d.width(unit * NUM_GATE);
-  wt_idx[GRUParams::zrg] = context.requestTensor(
-    d, "GRU:zrg", Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
+  wt_idx[GRUParams::zrg] =
+    context.requestTensor(d, context.getName() + ":zrg",
+                          Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
 
   TensorDim h_dim = TensorDim();
   h_dim.setTensorDim(3, unit);
   h_dim.batch(input_dim.batch());
-  wt_idx[GRUParams::h_prev] =
-    context.requestTensor(h_dim, "GRU:h_prev", Tensor::Initializer::NONE, false,
-                          FORWARD_FUNC_LIFESPAN);
+  wt_idx[GRUParams::h_prev] = context.requestTensor(
+    h_dim, context.getName() + ":h_prev", Tensor::Initializer::NONE, false,
+    FORWARD_FUNC_LIFESPAN);
 
   if (hidden_state_activation_type == ActivationType::ACT_NONE) {
     hidden_state_activation_type = ActivationType::ACT_TANH;

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -27,25 +27,6 @@ class Weight;
 class Var_Grad;
 
 /**
- * @brief define the lifespan of the given tensor to reduce peak memory
- *
- */
-enum TensorLifespan {
-  FORWARD_FUNC_LIFESPAN,  /**< tensor must not be reset before during the
-                            forward function call, eg. temporary tensors
-                            needed during forward operations */
-  BACKWARD_FUNC_LIFESPAN, /**< tensor must not be reset before during the
-                            backward function call, eg. temporary tensors
-                            needed during backward operations */
-  ITERATION_LIFESPAN,     /**< tensor must not be reset until the owning layer
-                            finishes its execution in the current iteration,
-                            eg. hidden memory/cells of RNN */
-  EPOCH_LIFESPAN,         /**< tensor must not be reset before the epoch ends */
-  MAX_LIFESPAN, /**< tensor must not be reset until the end of the model
-                  execution, eg. layer weights */
-};
-
-/**
  * @class   Layer Context class for all layers
  * @brief   Class for Layer context
  *
@@ -73,6 +54,11 @@ public:
     num_outputs(num_out),
     name(n) {}
 
+  /**
+   * @brief   get name by the layer
+   *
+   * @return name of the layer
+   */
   const std::string &getName() const { return name; }
 
   /**
@@ -192,7 +178,7 @@ public:
                 const Tensor::Initializer init = Tensor::Initializer::NONE,
                 bool trainable = false,
                 TensorLifespan lifespan = ITERATION_LIFESPAN) {
-    tensors_spec.emplace_back(dim, init, trainable, name);
+    tensors_spec.emplace_back(dim, init, trainable, name, lifespan);
     return tensors_spec.size() - 1;
   }
 

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -67,9 +67,13 @@ public:
    *
    * @param dim Input dimensions for the layer
    */
-  InitLayerContext(const std::vector<TensorDim> &dim, unsigned int num_out) :
+  InitLayerContext(const std::vector<TensorDim> &dim, unsigned int num_out,
+                   const std::string &n = "") :
     input_dim(dim),
-    num_outputs(num_out) {}
+    num_outputs(num_out),
+    name(n) {}
+
+  const std::string &getName() const { return name; }
 
   /**
    * @brief Get the number of inputs for the layer
@@ -279,6 +283,9 @@ public:
       }
     }
 
+    if (name.empty())
+      return false;
+
     return true;
   }
 
@@ -292,6 +299,7 @@ private:
                      variables) */
 
   unsigned int num_outputs; /**< number of outputs for the layer */
+  std::string name;         /**< name of the layer */
 };
 
 /**

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -351,6 +351,8 @@ void LayerNode::finalize() {
   if (finalized)
     throw std::runtime_error("Finalizing a layer which is already finalized");
 
+  init_context = InitLayerContext(init_context.getInputDimensions(),
+                                  init_context.getNumOutputs(), getName());
   if (!init_context.validate())
     throw std::invalid_argument(
       "Invalid init context for finalizing the layer");

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -124,7 +124,9 @@ LayerNode::LayerNode(std::unique_ptr<nntrainer::Layer> &&l) :
   activation_type(ActivationType::ACT_NONE),
   layer_node_props(new PropsType(props::Name(), props::Flatten(),
                                  props::Distribute(), props::Trainable(),
-                                 props::Loss())), regularization_loss(0.0f), exec_loc({0, 0}) {
+                                 props::Loss())),
+  regularization_loss(0.0f),
+  exec_order({0, 0, 0}) {
   if (layer && layer->getType() == TimeDistLayer::type) {
     std::get<props::Distribute>(*layer_node_props).set(true);
   }

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -124,8 +124,7 @@ LayerNode::LayerNode(std::unique_ptr<nntrainer::Layer> &&l) :
   activation_type(ActivationType::ACT_NONE),
   layer_node_props(new PropsType(props::Name(), props::Flatten(),
                                  props::Distribute(), props::Trainable(),
-                                 props::Loss())),
-  regularization_loss(0.0f) {
+                                 props::Loss())), regularization_loss(0.0f), exec_loc({0, 0}) {
   if (layer && layer->getType() == TimeDistLayer::type) {
     std::get<props::Distribute>(*layer_node_props).set(true);
   }

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -136,6 +136,22 @@ public:
   }
 
   /**
+   * @brief     get the execution order/location of this node
+   *
+   * @retval    the execution order/location of this node
+   */
+  std::pair<unsigned int, unsigned int> getExecLoc() const { return exec_loc; }
+
+  /**
+   * @brief     set the execution order/location of this node
+   *
+   * @param     exec_loc the execution order/location of this node
+   */
+  virtual void setExecLoc(std::pair<unsigned int, unsigned int> exec_loc_) {
+    exec_loc = exec_loc_;
+  }
+
+  /**
    * Support all the interface requirements by nntrainer::Layer
    */
 
@@ -608,6 +624,8 @@ private:
    */
   std::unique_ptr<PropsType> layer_node_props; /**< properties for the node */
   float regularization_loss;
+  std::pair<int, int> exec_loc; /**< order/location of execution for this node
+                                   in forward and backward */
 
   /**
    * @brief setProperty by PropertyType

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -140,15 +140,15 @@ public:
    *
    * @retval    the execution order/location of this node
    */
-  std::pair<unsigned int, unsigned int> getExecLoc() const { return exec_loc; }
+  ExecutionOrder getExecutionOrder() const { return exec_order; }
 
   /**
    * @brief     set the execution order/location of this node
    *
-   * @param     exec_loc the execution order/location of this node
+   * @param     exec_order the execution order/location of this node
    */
-  virtual void setExecLoc(std::pair<unsigned int, unsigned int> exec_loc_) {
-    exec_loc = exec_loc_;
+  void setExecutionOrder(ExecutionOrder exec_order_) {
+    exec_order = exec_order_;
   }
 
   /**
@@ -624,8 +624,8 @@ private:
    */
   std::unique_ptr<PropsType> layer_node_props; /**< properties for the node */
   float regularization_loss;
-  std::pair<int, int> exec_loc; /**< order/location of execution for this node
-                                   in forward and backward */
+  ExecutionOrder exec_order; /**< order/location of execution for this node
+                                   in forward and backwarding operations */
 
   /**
    * @brief setProperty by PropertyType

--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -62,8 +62,8 @@ void LSTMLayer::finalize(InitLayerContext &context) {
 
   if (dropout_rate > epsilon) {
     wt_idx[LSTMParams::dropout_mask] = context.requestTensor(
-      output_dim, "LSTM:dropout_mask", Tensor::Initializer::NONE, false,
-      ITERATION_LIFESPAN);
+      output_dim, context.getName() + ":dropout_mask",
+      Tensor::Initializer::NONE, false, ITERATION_LIFESPAN);
   }
 
   if (!return_sequences) {
@@ -88,28 +88,30 @@ void LSTMLayer::finalize(InitLayerContext &context) {
   // weight_initializer can be set sepeartely. weight_xh initializer,
   // weight_hh initializer kernel initializer & recurrent_initializer in keras
   // for now, it is set same way.
-  wt_idx[LSTMParams::weight_xh] =
-    context.requestWeight(dim_xh, weight_initializer, weight_regularizer,
-                          weight_regularizer_constant, "LSTM:weight_xh", true);
-  wt_idx[LSTMParams::weight_hh] =
-    context.requestWeight(dim_hh, weight_initializer, weight_regularizer,
-                          weight_regularizer_constant, "LSTM:weight_hh", true);
+  wt_idx[LSTMParams::weight_xh] = context.requestWeight(
+    dim_xh, weight_initializer, weight_regularizer, weight_regularizer_constant,
+    context.getName() + ":weight_xh", true);
+  wt_idx[LSTMParams::weight_hh] = context.requestWeight(
+    dim_hh, weight_initializer, weight_regularizer, weight_regularizer_constant,
+    context.getName() + ":weight_hh", true);
   wt_idx[LSTMParams::bias_h] =
     context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                          1.0f, "LSTM:bias_h", true);
+                          1.0f, context.getName() + ":bias_h", true);
 
   TensorDim d = input_dim;
   d.width(unit);
 
   wt_idx[LSTMParams::hidden_state] =
-    context.requestTensor(d, "LSTM:hidden_state", Tensor::Initializer::NONE,
-                          true, ITERATION_LIFESPAN);
-  wt_idx[LSTMParams::mem_cell] = context.requestTensor(
-    d, "LSTM:mem_cell", Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
+    context.requestTensor(d, context.getName() + ":hidden_state",
+                          Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
+  wt_idx[LSTMParams::mem_cell] =
+    context.requestTensor(d, context.getName() + ":mem_cell",
+                          Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
 
   d.width(unit * NUM_GATE);
-  wt_idx[LSTMParams::fgio] = context.requestTensor(
-    d, "LSTM:fgio", Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
+  wt_idx[LSTMParams::fgio] =
+    context.requestTensor(d, context.getName() + ":fgio",
+                          Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
 
   if (hidden_state_activation_type == ActivationType::ACT_NONE) {
     hidden_state_activation_type = ActivationType::ACT_TANH;

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -98,14 +98,14 @@ void Pooling2DLayer::finalize(InitLayerContext &context) {
    * // clang-format on
    */
   if (pooling_type == PoolingType::global_max) {
-    pool_helper_idx = context.requestTensor(in_dim, "Pooling2d::helper_idx",
-                                            Tensor::Initializer::NONE, false,
-                                            ITERATION_LIFESPAN);
+    pool_helper_idx = context.requestTensor(
+      in_dim, context.getName() + ":helper_idx", Tensor::Initializer::NONE,
+      false, ITERATION_LIFESPAN);
     pool_helper_size.resize(in_dim.batch() * in_dim.channel());
   } else {
-    pool_helper_idx = context.requestTensor(out_dim, "Pooling2d::helper_idx",
-                                            Tensor::Initializer::NONE, false,
-                                            ITERATION_LIFESPAN);
+    pool_helper_idx = context.requestTensor(
+      out_dim, context.getName() + ":helper_idx", Tensor::Initializer::NONE,
+      false, ITERATION_LIFESPAN);
   }
 }
 

--- a/nntrainer/layers/rnn.cpp
+++ b/nntrainer/layers/rnn.cpp
@@ -49,8 +49,8 @@ void RNNLayer::finalize(InitLayerContext &context) {
 
   if (dropout_rate > epsilon) {
     wt_idx[RNNParams::dropout_mask] = context.requestTensor(
-      output_dim, "RNN:dropout_mask", Tensor::Initializer::NONE, false,
-      ITERATION_LIFESPAN);
+      output_dim, context.getName() + ":dropout_mask",
+      Tensor::Initializer::NONE, false, ITERATION_LIFESPAN);
   }
 
   if (!return_sequences) {
@@ -74,23 +74,24 @@ void RNNLayer::finalize(InitLayerContext &context) {
   // weight_hh initializer kernel initializer & recurrent_initializer in keras
   // for now, it is set same way.
 
-  wt_idx[RNNParams::weight_xh] =
-    context.requestWeight(dim_xh, weight_initializer, weight_regularizer,
-                          weight_regularizer_constant, "RNN:weight_xh", true);
-  wt_idx[RNNParams::weight_hh] =
-    context.requestWeight(dim_hh, weight_initializer, weight_regularizer,
-                          weight_regularizer_constant, "RNN:weight_hh", true);
+  wt_idx[RNNParams::weight_xh] = context.requestWeight(
+    dim_xh, weight_initializer, weight_regularizer, weight_regularizer_constant,
+    context.getName() + ":weight_xh", true);
+  wt_idx[RNNParams::weight_hh] = context.requestWeight(
+    dim_hh, weight_initializer, weight_regularizer, weight_regularizer_constant,
+    context.getName() + ":weight_hh", true);
   wt_idx[RNNParams::bias_h] =
     context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                          1.0f, "RNN:bias_h", true);
+                          1.0f, context.getName() + ":bias_h", true);
 
   // We do not need this if we reuse net_hidden[0]. But if we do, then the unit
   // test will fail. Becuase it modifies the date during gradient calculation
   // TODO : We could control with something like #define test to save memory
   TensorDim d = input_dim;
   d.width(unit);
-  wt_idx[RNNParams::hidden_state] = context.requestTensor(
-    d, "RNN:hidden_state", Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
+  wt_idx[RNNParams::hidden_state] =
+    context.requestTensor(d, context.getName() + ":hidden_state",
+                          Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
 
   if (hidden_state_activation_type == ActivationType::ACT_NONE) {
     hidden_state_activation_type = ActivationType::ACT_TANH;

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -198,7 +198,15 @@ int NeuralNetwork::initialize() {
 /**
  * @brief     free layers
  */
-NeuralNetwork::~NeuralNetwork() { model_graph.reset(); }
+NeuralNetwork::~NeuralNetwork() {
+  model_graph.reset();
+
+  std::for_each(data_buffers.begin(), data_buffers.end(), [](auto &buffers) {
+    if (buffers) {
+      buffers->clear();
+    }
+  });
+}
 
 void NeuralNetwork::setLabels(sharedConstTensors label) {
   auto fill_label = [&label](auto const &layer_node) {

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -198,15 +198,7 @@ int NeuralNetwork::initialize() {
 /**
  * @brief     free layers
  */
-NeuralNetwork::~NeuralNetwork() {
-  model_graph.reset();
-
-  std::for_each(data_buffers.begin(), data_buffers.end(), [](auto &buffers) {
-    if (buffers) {
-      buffers->clear();
-    }
-  });
-}
+NeuralNetwork::~NeuralNetwork() { model_graph.reset(); }
 
 void NeuralNetwork::setLabels(sharedConstTensors label) {
   auto fill_label = [&label](auto const &layer_node) {

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -829,7 +829,7 @@ Manager::requestInputs(const GraphNode &node,
     inputs_dim.begin(), inputs_dim.end(), std::back_inserter(inputs_spec),
     [&count, &node](auto const &elem) {
       return std::make_tuple(elem, Tensor::Initializer::NONE, true,
-                             node.getName() + std::string("_input") +
+                             node.getName() + std::string(":input") +
                                std::to_string(count++));
     });
   return requestTensors<Var_Grad>(node, inputs_spec, inputs_v2);
@@ -847,7 +847,7 @@ Manager::requestOutputs(const GraphNode &node,
     outputs_dim.begin(), outputs_dim.end(), std::back_inserter(outputs_spec),
     [&count, &node](auto const &elem) {
       return std::make_tuple(elem, Tensor::Initializer::NONE, true,
-                             node.getName() + std::string("_output") +
+                             node.getName() + std::string(":output") +
                                std::to_string(count++));
     });
   return requestTensors<Var_Grad>(node, outputs_spec, outputs_v2);

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -830,7 +830,8 @@ Manager::requestInputs(const GraphNode &node,
     [&count, &node](auto const &elem) {
       return std::make_tuple(elem, Tensor::Initializer::NONE, true,
                              node.getName() + std::string(":input") +
-                               std::to_string(count++));
+                               std::to_string(count++),
+                             ITERATION_LIFESPAN);
     });
   return requestTensors<Var_Grad>(node, inputs_spec, inputs_v2);
 }
@@ -848,7 +849,8 @@ Manager::requestOutputs(const GraphNode &node,
     [&count, &node](auto const &elem) {
       return std::make_tuple(elem, Tensor::Initializer::NONE, true,
                              node.getName() + std::string(":output") +
-                               std::to_string(count++));
+                               std::to_string(count++),
+                             ITERATION_LIFESPAN);
     });
   return requestTensors<Var_Grad>(node, outputs_spec, outputs_v2);
 }

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -440,10 +440,10 @@ private:
   std::vector<std::vector<std::unique_ptr<Var_Grad>>>
     tensors_v2; /**< extra tensors required by the layers */
 
-  std::unordered_map<std::string, std::pair<unsigned int, unsigned int>>
-    tensor_exec_loc; /**< stores the order/location at which a given tensor is
+  std::unordered_map<std::string, GraphNode::ExecutionOrder>
+    tensor_exec_order; /**< stores the order/location at which a given tensor is
                         going to be executed when the network is forwarded and
-                        abackwarded */
+                        backwarded */
 
   /**< Weights of all the layer in the model to be managed */
   std::vector<std::vector<std::reference_wrapper<Weight>>> weights;
@@ -592,12 +592,13 @@ private:
        * @todo maybe requesting tensor with same name should mean reusing the
        * tensor than giving the error
        */
-      if (tensor_exec_loc.find(ts_name) != tensor_exec_loc.end())
+      if (tensor_exec_order.find(ts_name) != tensor_exec_order.end())
         throw std::invalid_argument("Requesting tensor " + ts_name +
                                     " with same name");
       /**
-       * @todo set the exec_loc based on the set lifespan */
-      tensor_exec_loc[ts_name] = node.getExecLoc();
+       * @todo set the exec_order based on the set lifespan from the spec
+       */
+      tensor_exec_order[ts_name] = node.getExecutionOrder();
     }
 
     std::transform(tensors_list.begin(), tensors_list.end(),

--- a/nntrainer/tensor/tensor_wrap_specs.h
+++ b/nntrainer/tensor/tensor_wrap_specs.h
@@ -31,6 +31,25 @@ enum class WeightRegularizer {
 };
 
 /**
+ * @brief define the lifespan of the given tensor to reduce peak memory
+ *
+ */
+enum TensorLifespan {
+  FORWARD_FUNC_LIFESPAN,  /**< tensor must not be reset before during the
+                            forward function call, eg. temporary tensors
+                            needed during forward operations */
+  BACKWARD_FUNC_LIFESPAN, /**< tensor must not be reset before during the
+                            backward function call, eg. temporary tensors
+                            needed during backward operations */
+  ITERATION_LIFESPAN,     /**< tensor must not be reset until the owning layer
+                            finishes its execution in the current iteration,
+                            eg. hidden memory/cells of RNN */
+  EPOCH_LIFESPAN,         /**< tensor must not be reset before the epoch ends */
+  MAX_LIFESPAN, /**< tensor must not be reset until the end of the model
+                  execution, eg. layer weights */
+};
+
+/**
  * @brief Specification of the Weight as a tensor wrapper
  *
  * @details The tuple values are dimension, initializer, regularizer,
@@ -44,9 +63,10 @@ typedef std::tuple<TensorDim, Tensor::Initializer, WeightRegularizer, float,
  * @brief Specification of the Var_Grad (trainable tensor) as a tensor wrapper
  *
  * @details The tuple values are dimension, initializer, need_gradient property,
- * and the name of the tensor object.
+ * the name, and lifespan of the Var_Grad object.
  */
-typedef std::tuple<TensorDim, Tensor::Initializer, bool, const std::string>
+typedef std::tuple<TensorDim, Tensor::Initializer, bool, const std::string,
+                   TensorLifespan>
   VarGradSpec;
 
 } // namespace nntrainer

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -24,7 +24,7 @@ namespace nntrainer {
 
 /**
  * @class   Weight
- * @brief   Weight with gradient, and its corresponding need_gradient property
+ * @brief   Weight extends over Var_Grad with regularization & optimizer updates
  */
 class Weight : public Var_Grad {
 public:

--- a/test/unittest/layers/layers_standalone_common_tests.cpp
+++ b/test/unittest/layers/layers_standalone_common_tests.cpp
@@ -44,7 +44,7 @@ TEST_P(LayerSemantics, setPropertiesValidInvalidOnly_n) {}
 TEST_P(LayerSemantics, finalizeValidate_p) {
   nntrainer::TensorDim in_dim({1, 1, 1, 1});
   nntrainer::InitLayerContext init_context =
-    nntrainer::InitLayerContext({in_dim}, 1);
+    nntrainer::InitLayerContext({in_dim}, 1, "layer");
   EXPECT_EQ(init_context.validate(), true);
 
   // set necessary properties only
@@ -84,7 +84,7 @@ TEST_P(LayerSemantics, gettersValidate_p) {
 TEST_P(LayerSemantics, setBatchValidate_p) {
   nntrainer::TensorDim in_dim({1, 1, 1, 1});
   nntrainer::InitLayerContext init_context =
-    nntrainer::InitLayerContext({in_dim}, 1);
+    nntrainer::InitLayerContext({in_dim}, 1, "layer");
   init_context.validate();
 
   // set necessary properties only


### PR DESCRIPTION
This patch creates a var_grad/weight to usage index mapping for both forwarding and backwarding.
These indexes will be used by the manager and the memory allocator for understanding the overlapping use of tensors.
The changes to achieve are (summarized per commit):
- Move manager from NeuralNetwork class to NetworkGraph class.
Some corresponding minor adjustments are also added.
- Update the layers to make the requested weights and tensors names to be
unique. This done using the layer name with the postfix of the
weights/tensors name making the combination unqiue as layer name is
unique.
InitLayerContext is updated to provide access to the layer name while
finalizing the layer.
- Set default usage time index for all the tensors based on when the layer
is to be run in the sorted list.
The usage time indexes are stored in each GraphNode by the GraphCore.
When creating the sorted list, each layer is updated to store its
order location/index when executed in this sequence for forwarding as
well as backwarding.
- This patch adds the setup to catch lifespan set by the layer developer
when requesting for tensors.
Further, the execution order now consists of 3 values - fowarding,
calcGradient and calcDerivative. The memory optimization will now be
done using the 3 functions to be called in order.

NOTE: the time indexes for variable and gradient will be set individually by the manager. 
The rule followed for this will be that each variable will be made available for forward as well as backward, but gradient will be made available only during backward.

See Also #1127

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
