### PR TITLE
Debian: you don't have debian-build meson option.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -32,7 +32,7 @@ override_dh_auto_configure:
 	mkdir -p build
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc \
 		--libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nntrainer/bin \
-		--includedir=include -Dinstall-app=true -Ddebian-build=true \
+		--includedir=include -Dinstall-app=true \
 		-Dreduce-tolerance=$(ENABLE_REDUCE_TOLERANCE) build
 
 override_dh_auto_build:


### PR DESCRIPTION
Remove unsupported meson build option from debian script.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>