### PR TITLE
[Dataset] Implement samplewise producer for random

### DIFF
--- a/nntrainer/dataset/random_data_producers.cpp
+++ b/nntrainer/dataset/random_data_producers.cpp
@@ -78,6 +78,11 @@ const std::string RandomDataOneHotProducer::getType() const {
   return RandomDataOneHotProducer::type;
 }
 
+bool RandomDataOneHotProducer::isMultiThreadSafe() const {
+  /// @todo make this true, it is needed to test multiple worker scenario
+  return false;
+}
+
 unsigned int
 RandomDataOneHotProducer::size(const std::vector<TensorDim> &input_dims,
                                const std::vector<TensorDim> &label_dims) const {
@@ -168,5 +173,71 @@ RandomDataOneHotProducer::finalize(const std::vector<TensorDim> &input_dims,
 
     return DataProducer::Iteration(false, inputs, labels);
   };
+}
+
+DataProducer::Generator_sample RandomDataOneHotProducer::finalize_sample(
+  const std::vector<TensorDim> &input_dims,
+  const std::vector<TensorDim> &label_dims) {
+  /** check if the given producer is ready to finalize */
+  nntrainer::PropsMin min_;
+  nntrainer::PropsMax max_;
+  std::tie(min_, max_, std::ignore) = *rd_one_hot_props;
+
+  /// @todo expand this to non onehot case
+  NNTR_THROW_IF(std::any_of(label_dims.begin(), label_dims.end(),
+                            [](const TensorDim &dim) {
+                              return dim.channel() != 1 || dim.height() != 1;
+                            }),
+                std::invalid_argument)
+    << "Label dimension containing channel or height not allowed";
+
+  NNTR_THROW_IF(min_.get() > max_.get(), std::invalid_argument)
+    << "Min value is bigger then max value, min: " << min_.get()
+    << "max: " << max_.get();
+
+  /// @todo move this to higher order component
+  NNTR_THROW_IF(size(input_dims, label_dims) == 0, std::invalid_argument)
+    << "size is zero, dataproducer does not provide anything";
+
+  /** prepare states for the generator */
+  std::vector<std::uniform_int_distribution<unsigned int>> label_chooser_;
+  label_chooser_.reserve(label_dims.size());
+  std::transform(label_dims.begin(), label_dims.end(),
+                 std::back_inserter(label_chooser_),
+                 [this](const TensorDim &label_dim) {
+                   return std::uniform_int_distribution<unsigned int>(
+                     0, label_dim.width() - 1);
+                 });
+
+  std::mt19937 rng;
+  rng.seed(getSeed());
+  auto sz = size(input_dims, input_dims);
+
+  /** DataProducer::Generator_sample */
+  return [rng, sz, input_dims, label_dims, min_ = min_.get(), max_ = max_.get(),
+          current_iteration = 0ULL, label_chooser = std::move(label_chooser_)](
+           unsigned int idx, std::vector<Tensor *> &inputs,
+           std::vector<Tensor *> &labels) mutable -> bool {
+    auto populate_input = [&](Tensor *t) { t->setRandUniform(min_, max_); };
+
+    auto populate_label =
+      [&](Tensor *t, std::uniform_int_distribution<unsigned int> &label_dist_) {
+        t->setZero();
+        t->setValue(0, 0, 0, label_dist_(rng), 1);
+        return t;
+      };
+
+    std::for_each(inputs.begin(), inputs.end(), populate_input);
+    std::transform(labels.begin(), labels.end(), label_chooser.begin(),
+                   labels.begin(), populate_label);
+
+    return idx == sz - 1;
+  };
+}
+
+unsigned int RandomDataOneHotProducer::size_sample(
+  const std::vector<TensorDim> &input_dims,
+  const std::vector<TensorDim> &label_dims) const {
+  return std::get<PropsNumSamples>(*rd_one_hot_props).get();
 }
 } // namespace nntrainer

--- a/nntrainer/dataset/random_data_producers.h
+++ b/nntrainer/dataset/random_data_producers.h
@@ -52,6 +52,11 @@ public:
   const std::string getType() const override;
 
   /**
+   * @copydoc DataProducer::isMultiThreadSafe()
+   */
+  bool isMultiThreadSafe() const override;
+
+  /**
    * @copydoc DataProducer::size()
    */
   unsigned int size(const std::vector<TensorDim> &input_dims,
@@ -61,15 +66,31 @@ public:
    * @copydoc DataProducer::setProeprty(const std::vector<std::string>
    * &properties)
    */
-  virtual void setProperty(const std::vector<std::string> &properties) override;
+  void setProperty(const std::vector<std::string> &properties) override;
 
   /**
    * @copydoc DataProducer::finalize(const std::vector<TensorDim>, const
    * std::vector<TensorDim>)
    */
-  virtual DataProducer::Generator
+  DataProducer::Generator
   finalize(const std::vector<TensorDim> &input_dims,
            const std::vector<TensorDim> &label_dims) override;
+
+  /**
+   * @copydoc DataProducer::finalize_sample(const std::vector<TensorDim>, const
+   * std::vector<TensorDim>)
+   */
+  DataProducer::Generator_sample
+  finalize_sample(const std::vector<TensorDim> &input_dims,
+                  const std::vector<TensorDim> &label_dims) override;
+
+  /**
+   * @copydoc DataProducer::size_sample(const std::vector<TensorDim>, const
+   * std::vector<TensorDim>)
+   */
+  unsigned int
+  size_sample(const std::vector<TensorDim> &input_dims,
+              const std::vector<TensorDim> &label_dims) const override;
 
 private:
   using Props = std::tuple<PropsMin, PropsMax, PropsNumSamples>;

--- a/test/unittest/datasets/data_producer_common_tests.cpp
+++ b/test/unittest/datasets/data_producer_common_tests.cpp
@@ -13,7 +13,52 @@
 
 #include <algorithm>
 #include <data_producer_common_tests.h>
+#include <memory>
+#include <tuple>
+#include <vector>
 
+static std::tuple<std::vector<nntrainer::Tensor *> /** inputs_view */,
+                  std::vector<nntrainer::Tensor *> /** labels_view */,
+                  std::shared_ptr<std::vector<nntrainer::Tensor>> /** inputs */,
+                  std::shared_ptr<std::vector<nntrainer::Tensor>> /** labels */>
+createSample(const std::vector<nntrainer::TensorDim> &input_dims,
+             const std::vector<nntrainer::TensorDim> &label_dims) {
+  using namespace nntrainer;
+  auto populate_tensor = [](const TensorDim &dim) {
+    Tensor t(dim);
+    t.updateBatch(1);
+    return t;
+  };
+
+  auto populate_view = [](Tensor &t) { return &t; };
+
+  auto inputs = std::make_shared<std::vector<Tensor>>();
+  inputs->reserve(input_dims.size());
+
+  auto labels = std::make_shared<std::vector<Tensor>>();
+  labels->reserve(label_dims.size());
+
+  std::transform(input_dims.begin(), input_dims.end(),
+                 std::back_inserter(*inputs), populate_tensor);
+
+  std::transform(label_dims.begin(), label_dims.end(),
+                 std::back_inserter(*labels), populate_tensor);
+
+  std::vector<Tensor *> input_view;
+  input_view.reserve(input_dims.size());
+  std::transform(inputs->begin(), inputs->end(), std::back_inserter(input_view),
+                 populate_view);
+
+  std::vector<Tensor *> label_view;
+  label_view.reserve(label_dims.size());
+  std::transform(labels->begin(), labels->end(), std::back_inserter(label_view),
+                 populate_view);
+
+  return {input_view, label_view, inputs, labels};
+}
+
+/** batchwise producer tests */
+/// @todo remove this
 void DataProducerSemantics::SetUp() {
   auto [producerFactory, properties, input_dims_, label_dims_, validator_,
         result_] = GetParam();
@@ -100,6 +145,80 @@ TEST_P(DataProducerSemantics, fetch_one_epoch_or_10_iteration_pn) {
       EXPECT_TRUE(validator(ins, labels))
         << "failed last validation after one epoch\n";
       EXPECT_FALSE(last);
+    }
+  }
+}
+
+/********* sample tests **********/
+void DataProducerSemantics_samples::TearDown() {}
+
+void DataProducerSemantics_samples::SetUp() {
+  auto [producerFactory, properties, input_dims_, label_dims_, validator_,
+        result_] = GetParam();
+  producer = producerFactory(properties);
+  input_dims = std::move(input_dims_);
+  label_dims = std::move(label_dims_);
+  result = result_;
+  validator = std::move(validator_);
+
+  if (result != DataProducerSemanticsExpectedResult::SUCCESS) {
+    ASSERT_EQ(validator, nullptr)
+      << "Given expected result of not success, validator must be empty!";
+  }
+}
+
+TEST_P(DataProducerSemantics_samples, finalize_pn) {
+  if (result == DataProducerSemanticsExpectedResult::FAIL_AT_FINALIZE) {
+    EXPECT_ANY_THROW(producer->finalize_sample(input_dims, label_dims));
+  } else {
+    EXPECT_NO_THROW(producer->finalize_sample(input_dims, label_dims));
+  }
+}
+
+TEST_P(DataProducerSemantics_samples, error_once_or_not_pn) {
+  if (result == DataProducerSemanticsExpectedResult::FAIL_AT_FINALIZE) {
+    return; // skip this test
+  }
+
+  auto generator = producer->finalize_sample(input_dims, label_dims);
+  auto sample_data = createSample(input_dims, label_dims);
+
+  if (result == DataProducerSemanticsExpectedResult::FAIL_AT_GENERATOR_CALL) {
+    EXPECT_ANY_THROW(
+      generator(0, std::get<0>(sample_data), std::get<1>(sample_data)));
+  } else {
+    EXPECT_NO_THROW(
+      generator(0, std::get<1>(sample_data), std::get<1>(sample_data)));
+  }
+}
+
+TEST_P(DataProducerSemantics_samples, fetch_one_epoch_or_10_iteration_pn) {
+  if (result != DataProducerSemanticsExpectedResult::SUCCESS) {
+    return; // skip this test
+  }
+
+  auto generator = producer->finalize_sample(input_dims, label_dims);
+  auto sz = producer->size_sample(input_dims, label_dims);
+  bool has_fixed_size = sz != nntrainer::DataProducer::SIZE_UNDEFINED;
+
+  if (!has_fixed_size) {
+    sz = 10;
+  }
+
+  auto [input_view, label_view, inputs, labels] =
+    createSample(input_dims, label_dims);
+  for (unsigned i = 0; i < sz; ++i) {
+    auto last = generator(i, input_view, label_view);
+
+    if (i == sz - 1) {
+      EXPECT_TRUE(last);
+    } else {
+      ASSERT_FALSE(last) << " reached last at iteration: " << i << '\n';
+    }
+
+    if (validator) {
+      ASSERT_TRUE(validator(*inputs, *labels))
+        << " failed validation for iteration: " << i << '\n';
     }
   }
 }

--- a/test/unittest/datasets/data_producer_common_tests.h
+++ b/test/unittest/datasets/data_producer_common_tests.h
@@ -48,9 +48,37 @@ using DataProducerSemanticsParamType =
 
 /**
  * @brief Dataset Producer Semantics Tests
- *
+ * @todo remove this
  */
 class DataProducerSemantics
+  : public ::testing::TestWithParam<DataProducerSemanticsParamType> {
+public:
+  /**
+   * @brief SetUp test cases here
+   *
+   */
+  virtual void SetUp();
+
+  /**
+   * @brief do here if any memory needs to be released
+   *
+   */
+  virtual void TearDown();
+
+protected:
+  std::unique_ptr<nntrainer::DataProducer>
+    producer;                                   /**< producer to be tested */
+  std::vector<nntrainer::TensorDim> input_dims; /**< input dims */
+  std::vector<nntrainer::TensorDim> label_dims; /**< output dims */
+  DataProducerValidatorType validator;          /**< result validator */
+  DataProducerSemanticsExpectedResult result;   /**< expected result */
+};
+
+/**
+ * @brief Dataset Producer Semantics Tests
+ * @todo remove suffix
+ */
+class DataProducerSemantics_samples
   : public ::testing::TestWithParam<DataProducerSemanticsParamType> {
 public:
   /**

--- a/test/unittest/datasets/unittest_random_data_producers.cpp
+++ b/test/unittest/datasets/unittest_random_data_producers.cpp
@@ -47,6 +47,7 @@ DataProducerValidatorType random_onehot_validator(float min, float max) {
 
   return f;
 }
+
 auto random_onehot_success = DataProducerSemanticsParamType(
   createDataProducer<nntrainer::RandomDataOneHotProducer>,
   {"min=0", "max=1", "num_samples=10"}, {{3, 2, 4, 5}}, {{3, 1, 1, 10}},
@@ -65,3 +66,32 @@ auto random_onehot_invalid_label_shape = DataProducerSemanticsParamType(
 INSTANTIATE_TEST_CASE_P(RandomOneHot, DataProducerSemantics,
                         ::testing::Values(random_onehot_success,
                                           random_onehot_min_over_max));
+
+auto random_onehot_success_sample_one_batch = DataProducerSemanticsParamType(
+  createDataProducer<nntrainer::RandomDataOneHotProducer>,
+  {"min=0", "max=1", "num_samples=10"}, {{1, 2, 4, 5}}, {{1, 1, 1, 10}},
+  random_onehot_validator(0, 1), DataProducerSemanticsExpectedResult::SUCCESS);
+
+auto random_onehot_success_multi_batch_will_be_ignored =
+  DataProducerSemanticsParamType(
+    createDataProducer<nntrainer::RandomDataOneHotProducer>,
+    {"min=0", "max=1", "num_samples=10"}, {{3, 2, 4, 5}}, {{3, 1, 1, 10}},
+    random_onehot_validator(0, 1),
+    DataProducerSemanticsExpectedResult::SUCCESS);
+
+auto random_onehot_min_over_max_sample = DataProducerSemanticsParamType(
+  createDataProducer<nntrainer::RandomDataOneHotProducer>,
+  {"min=2", "max=1", "num_samples=10"}, {{1, 2, 4, 5}}, {{1, 1, 1, 10}},
+  nullptr, DataProducerSemanticsExpectedResult::FAIL_AT_FINALIZE);
+
+auto random_onehot_invalid_label_shape_sample = DataProducerSemanticsParamType(
+  createDataProducer<nntrainer::RandomDataOneHotProducer>, {}, {{1, 2, 4, 5}},
+  {{1, 1, 2, 10}}, nullptr,
+  DataProducerSemanticsExpectedResult::FAIL_AT_FINALIZE);
+
+INSTANTIATE_TEST_CASE_P(
+  RandomOneHot, DataProducerSemantics_samples,
+  ::testing::Values(random_onehot_success_sample_one_batch,
+                    random_onehot_success_multi_batch_will_be_ignored,
+                    random_onehot_min_over_max_sample,
+                    random_onehot_invalid_label_shape_sample));


### PR DESCRIPTION
- [Dataset] Implement samplewise producer for random

```
This patch implements samplewise producer for random and its
corresponding test abstraction

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```