### PR TITLE
[ Trivial ] Fix Android build error in CIFAR_Classificaiton

### DIFF
--- a/Applications/TransferLearning/CIFAR_Classification/jni/Android.mk
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/Android.mk
@@ -11,7 +11,7 @@ ifndef NNTRAINER_ROOT
 NNTRAINER_ROOT := $(LOCAL_PATH)/../../../..
 endif
 
- ML_API_COMMON_INCLUDES := ${NNTRAINER_ROOT}/ml_api_common/include
+ ML_API_COMMON_INCLUDES := ${NNTRAINER_ROOT}/jni/ml_api_common/include
 NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 	$(NNTRAINER_ROOT)/nntrainer/dataset \
 	$(NNTRAINER_ROOT)/nntrainer/models \


### PR DESCRIPTION
Fix build error in CIFAR_Classification Applicatin for android

fix ML_API_COMMON_INCLUDES path

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>