### PR TITLE
[memory] Introduce memory pool and planner

### DIFF
--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -817,7 +817,7 @@ Manager::requestWeights(const GraphNode &node,
 }
 
 /**
- * @brief     Create weight4 with the given spec
+ * @brief     Create weights with the given spec
  *
  */
 std::vector<Var_Grad *>

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include <graph_node.h>
+#include <memory_pool.h>
 #include <var_grad.h>
 #include <weight.h>
 
@@ -444,6 +445,7 @@ private:
     tensor_exec_order; /**< stores the order/location at which a given tensor is
                         going to be executed when the network is forwarded and
                         backwarded */
+  // std::unordered_map<Tensor &, unsigned int> tensor_map;
 
   /**< Weights of all the layer in the model to be managed */
   std::vector<std::vector<std::reference_wrapper<Weight>>> weights;

--- a/nntrainer/tensor/memory_planner.h
+++ b/nntrainer/tensor/memory_planner.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   memory_planner.h
+ * @date   10 August 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is interface for the Memory Planner
+ *
+ */
+
+#ifndef __MEMORY_PLANNER_H__
+#define __MEMORY_PLANNER_H__
+
+#include <vector>
+
+namespace nntrainer {
+
+/**
+ * @class   MemoryPlanner
+ * @brief   Memory Planner provides the plan/strategy to allocate the memory
+ */
+class MemoryPlanner {
+public:
+  /**
+   * @brief MemoryPlanner destructor
+   *
+   */
+  virtual ~MemoryPlanner();
+
+  /**
+   * @brief Plan the layout for the memory allocation
+   *
+   * @param[in] memory_size The size of the various memories
+   * @param[in] memory_validity The validity of the various memories
+   * @param[out] memory_offset The offset of each memory from the base of the
+   * allocated memory
+   * @return The total memory required as per this strategy
+   *
+   * @details The minimum offset will be 0, and the maximum offset will be less
+   * than the sum of the memory_size vector.
+   */
+  virtual size_t planLayout(
+    const std::vector<size_t> &memory_size,
+    const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
+    std::vector<size_t> &memory_offset) = 0;
+};
+
+} // namespace nntrainer
+
+#endif /** __MEMORY_PLANNER_H__ */

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   memory_pool.h
+ * @date   10 August 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Memory Pool Class for
+ *
+ * @todo   Support an external allocator for different backends
+ */
+
+#ifndef __MEMORY_POOL_H__
+#define __MEMORY_POOL_H__
+
+#include <vector>
+
+#include <memory_planner.h>
+
+namespace nntrainer {
+
+/**
+ * @class   MemoryPool
+ * @brief   Memory Pool provides a common pool for all the tensor memory
+ */
+class MemoryPool {
+public:
+  /**
+   * @brief MemoryPool default constructor
+   *
+   */
+  MemoryPool() : mem_pool(nullptr), pool_size(0), min_pool_size(0) {}
+
+  /**
+   * @brief Request Memory from memory pool
+   *
+   * @param bytes The size of the memory requested in bytes
+   * @param start_time The start of the validity interval of this memory
+   * @param end_time The end of the validity interval of this memory
+   *
+   * @return The token to get the pointer for this memory after allocation
+   */
+  unsigned int requestMemory(size_t bytes, unsigned int start_time,
+                             unsigned int end_time);
+
+  /**
+   * @brief Planner the layout with memory planner
+   *
+   * @param planner The memory planner to be used for finalizing the layout
+   *
+   * @return The total memory requirement using this memory planner
+   * @return The efficiency of the memory layer with the given memory planner
+   *
+   * @details The efficiency of the planner is calculated as the ratio of the
+   * theoretical minimum memory requirement divided by the memory requirement
+   * given by the memory planner.
+   *
+   * @details planLayout can be called multiple times as this does not perform
+   * any allocation but rather just plans the layout and stores the layout.
+   * Subsequent call to this function will overwrite any existing layout.
+   */
+  double planLayout(const MemoryPlanner &planner);
+
+  /**
+   * @brief Do the allocation of memory
+   *
+   */
+  void allocate();
+
+  /**
+   * @brief Get the allocated memory
+   *
+   * @param token The token received from the requestMemory
+   *
+   * @return The pointer of the memory
+   *
+   * @details This function will throw if called before allocation.
+   */
+  void *getMemory(unsigned int idx);
+
+  /**
+   * @brief Free all the allocated memory
+   *
+   */
+  void free();
+
+  /**
+   * @brief Get the maximum real memory requirement
+   *
+   * @return The real memory requirement with this strategy
+   */
+  size_t size();
+
+  /**
+   * @brief Get the minimum theoretical memory requirement
+   *
+   * @return The theoretical memory requirement with this strategy
+   */
+  size_t minMemReq();
+
+private:
+  /**
+   * @brief Validate the provided layout so that no two memories to be used at
+   * overlap interval has overlapping memories
+   */
+  bool validateLayout();
+
+  std::vector<size_t> memory_size; /**< various sizes memory requested */
+  std::vector<std::pair<unsigned int, unsigned int>>
+    memory_validity; /**< validity intervals for each requested memory */
+  std::vector<size_t> memory_offset; /**< offsets for the memory requested */
+
+  void *mem_pool;   /**< memory pool allocated at once */
+  size_t pool_size; /**< memory requirement for this pool */
+
+  size_t min_pool_size; /**< minimum theoretical memory requirement */
+};
+
+} // namespace nntrainer
+
+#endif /** __MEMORY_POOL_H__ */

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -50,7 +50,6 @@ public:
    *
    * @param planner The memory planner to be used for finalizing the layout
    *
-   * @return The total memory requirement using this memory planner
    * @return The efficiency of the memory layer with the given memory planner
    *
    * @details The efficiency of the planner is calculated as the ratio of the


### PR DESCRIPTION
- Simplify weight and gradient allocation out to the most basic strategy
so that the memory optimization can be applied on it.
With this patch, the memory for gradient is not shared anymore till the
memory optimization is implemented.
- This patch introduces memory planner interface which will provide a
layout plan given the various memories required by the model.
Different memory allocations plans/strategies will be implemented by
extending this class with the given interface.
- This patch introduces memory pool for tensors. All the tensors requiring
memory can ask memory pool for their memory. The memory pool collects
all the requirements, uses the provided memory planner to plan a memory
layout, allocates the required memory, and then finally returns the
allocated memory to the requesters.

There are certain limitations to this memory pool:
1. All the memory must be requested before layout planning and
allocation.
2. There is no support for freeing selectively allocated tensors
3. In order to request support for more tensors and their memories,
all previously allocated memory has to be freed.
4. MemoryPool for now allocates all its required memory in a single
block. Support for breaking the required memory into smaller blocks is
left a TODO for later (this can be useful for devices without IOMMU).

See Also #1127

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>