### PR TITLE
[MemoryPlanner] Basic memory planner with unittests

### DIFF
--- a/nntrainer/tensor/basic_planner.cpp
+++ b/nntrainer/tensor/basic_planner.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   basic_planner.h
+ * @date   11 August 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Naive Memory Planner
+ *
+ */
+
+#include <basic_planner.h>
+
+namespace nntrainer {
+
+/**
+ * @copydoc MemoryPlanner::planLayout(
+ * const std::vector<size_t> &memory_size,
+ * const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
+ * std::vector<size_t> &memory_offset);
+ *
+ * @details The basic memory planner does not incorporate any memory sharing.
+ * This planner allocates independent memory for all the required memories
+ * without considering their memory validity.
+ */
+size_t BasicPlanner::planLayout(
+  const std::vector<size_t> &memory_size,
+  const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
+  std::vector<size_t> &memory_offset) {
+  size_t csum = 0;
+  for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
+
+#ifdef DEBUG
+    /** skip any memory requirement, if validity is less than 1 */
+    if (memory_validity[idx].second <= memory_validity[idx].first)
+      throw std::runtime_error("Memory requested for non-valid duration.");
+#endif
+
+    memory_offset[idx] = csum;
+    csum += memory_size[idx];
+  }
+
+  return csum;
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/basic_planner.cpp
+++ b/nntrainer/tensor/basic_planner.cpp
@@ -24,11 +24,13 @@ namespace nntrainer {
  * @details The basic memory planner does not incorporate any memory sharing.
  * This planner allocates independent memory for all the required memories
  * without considering their memory validity.
+ *
  */
 size_t BasicPlanner::planLayout(
   const std::vector<size_t> &memory_size,
   const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
-  std::vector<size_t> &memory_offset) {
+  std::vector<size_t> &memory_offset) const {
+  memory_offset.resize(memory_size.size());
   size_t csum = 0;
   for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
 

--- a/nntrainer/tensor/basic_planner.h
+++ b/nntrainer/tensor/basic_planner.h
@@ -26,24 +26,33 @@ namespace nntrainer {
  * @details Basic planner performs no memory optimization and provides no memory
  * sharing
  */
-class BasicPlanner {
+class BasicPlanner : public MemoryPlanner {
 public:
   /**
    * @brief BasicPlanner destructor
    *
    */
-  BasicPlanner() = default;
+  ~BasicPlanner() = default;
 
   /**
    * @copydoc MemoryPlanner::planLayout(
    * const std::vector<size_t> &memory_size,
    * const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
    * std::vector<size_t> &memory_offset);
+   *
    */
   size_t planLayout(
     const std::vector<size_t> &memory_size,
     const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
-    std::vector<size_t> &memory_offset);
+    std::vector<size_t> &memory_offset) const;
+
+  /**
+   * @copydoc MemoryPlanner::getType() const
+   *
+   */
+  const std::string &getType() const { return type; }
+
+  inline static const std::string type = "basic_planner";
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/basic_planner.h
+++ b/nntrainer/tensor/basic_planner.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   basic_planner.h
+ * @date   11 August 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Naive Memory Planner
+ *
+ */
+
+#ifndef __BASIC_PLANNER_H__
+#define __BASIC_PLANNER_H__
+
+#include <vector>
+
+#include <memory_planner.h>
+
+namespace nntrainer {
+
+/**
+ * @class   BasicPlanner
+ * @brief   Basic Memory Planner provides the basic plan for memory layout
+ * @details Basic planner performs no memory optimization and provides no memory
+ * sharing
+ */
+class BasicPlanner {
+public:
+  /**
+   * @brief BasicPlanner destructor
+   *
+   */
+  BasicPlanner() = default;
+
+  /**
+   * @copydoc MemoryPlanner::planLayout(
+   * const std::vector<size_t> &memory_size,
+   * const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
+   * std::vector<size_t> &memory_offset);
+   */
+  size_t planLayout(
+    const std::vector<size_t> &memory_size,
+    const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
+    std::vector<size_t> &memory_offset);
+};
+
+} // namespace nntrainer
+
+#endif /** __BASIC_PLANNER_H__ */

--- a/nntrainer/tensor/memory_planner.h
+++ b/nntrainer/tensor/memory_planner.h
@@ -14,6 +14,7 @@
 #ifndef __MEMORY_PLANNER_H__
 #define __MEMORY_PLANNER_H__
 
+#include <string>
 #include <vector>
 
 namespace nntrainer {
@@ -28,7 +29,7 @@ public:
    * @brief MemoryPlanner destructor
    *
    */
-  virtual ~MemoryPlanner();
+  virtual ~MemoryPlanner() = default;
 
   /**
    * @brief Plan the layout for the memory allocation
@@ -45,7 +46,14 @@ public:
   virtual size_t planLayout(
     const std::vector<size_t> &memory_size,
     const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
-    std::vector<size_t> &memory_offset) = 0;
+    std::vector<size_t> &memory_offset) const = 0;
+
+  /**
+   * @brief Get type of the planner
+   *
+   * @return The type of the planner
+   */
+  virtual const std::string &getType() const = 0;
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   memory_pool.cpp
+ * @date   11 August 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Memory Pool Class
+ */
+
+#include <numeric>
+#include <vector>
+
+#include <memory_pool.h>
+#include <nntrainer_error.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Request Memory from memory pool
+ * @note start_time is inclusive, but end_time is exclusive
+ */
+unsigned int MemoryPool::requestMemory(size_t bytes, unsigned int start_time,
+                                       unsigned int end_time) {
+  if (mem_pool != nullptr)
+    throw std::invalid_argument(
+      "Deallocate memory pool before requesting more memory");
+
+  if (end_time <= start_time)
+    throw std::invalid_argument(
+      "Invalid validity range for the requested memory");
+
+  memory_size.push_back(bytes);
+  memory_validity.push_back({start_time, end_time});
+
+  /** invalidate min_pool_size if already there */
+  min_pool_size = 0;
+
+  return memory_size.size() - 1;
+}
+
+/**
+ * @brief Planner the layout with memory planner
+ *
+ * @details The efficiency of the planner is calculated as the ratio of the
+ * theoretical minimum memory requirement divided by the memory requirement
+ * given by the memory planner.
+ *
+ * @details planLayout can be called multiple times as this does not perform
+ * any allocation but rather just plans the layout and stores the layout.
+ * Subsequent call to this function will overwrite any existing layout.
+ */
+double MemoryPool::planLayout(const MemoryPlanner &planner) {
+  if (mem_pool != nullptr)
+    /** mem_pool must be deallocated when planLayout is being called */
+    throw std::runtime_error("Planning memory layout after allocation");
+
+  if (memory_size.empty())
+    throw std::runtime_error("Planning memory layout for empty pool");
+
+  /** calculate min_pool_size if not already calculated */
+  if (min_pool_size == 0)
+    min_pool_size = calcMinMemoryRequirement();
+
+  pool_size = planner.planLayout(memory_size, memory_validity, memory_offset);
+  if (pool_size < min_pool_size || !validateLayout())
+    throw std::runtime_error("Planned layout is not feasible");
+
+  return double(pool_size) / double(min_pool_size);
+}
+
+/**
+ * @brief Do the allocation of memory
+ *
+ */
+void MemoryPool::allocate() {
+  if (pool_size == 0)
+    throw std::runtime_error("Allocating memory pool with size 0");
+
+  mem_pool = malloc(pool_size);
+  if (mem_pool == nullptr)
+    throw std::runtime_error("Allocation memory failed");
+}
+
+/**
+ * @brief Get the allocated memory
+ *
+ */
+void *MemoryPool::getMemory(unsigned int idx) {
+  if (mem_pool == nullptr)
+    throw std::invalid_argument("Getting memory before allocation");
+
+  return static_cast<char *>(mem_pool) + memory_offset.at(idx);
+}
+
+/**
+ * @brief Free all the allocated memory
+ *
+ */
+void MemoryPool::deallocate() {
+  if (mem_pool != nullptr)
+    free(mem_pool);
+}
+
+/**
+ * @brief Get the maximum real memory requirement
+ *
+ */
+size_t MemoryPool::size() { return pool_size; }
+
+/**
+ * @brief Get the minimum theoretical memory requirement
+ *
+ */
+size_t MemoryPool::minMemoryRequirement() {
+  if (memory_size.size() && min_pool_size == 0)
+    min_pool_size = calcMinMemoryRequirement();
+
+  return min_pool_size;
+}
+
+/**
+ * @brief Validate the provided layout so that no two memories to be used at
+ * overlap interval has overlapping memories
+ */
+bool MemoryPool::validateLayout() {
+  if (memory_offset.size() != memory_size.size())
+    return false;
+
+  if (memory_size.empty())
+    return pool_size == 0;
+
+  return validateOverflow() && validateOverlap();
+}
+
+/**
+ * @brief Validate the provided layout does not overflow outside the given
+ * size of the memory pool
+ */
+bool MemoryPool::validateOverflow() {
+  for (unsigned int idx = 0; idx < memory_size.size(); idx++)
+    if (memory_offset[idx] + memory_size[idx] > pool_size)
+      return false;
+
+  return true;
+}
+
+/**
+ * @brief check if the two given intervals overlap
+ *
+ * @param s1 start of interval 1
+ * @param e1 end of interval 1
+ * @param s2 start of interval 2
+ * @param e2 end of interval 2
+ *
+ * @return true if overlap else false
+ *
+ * @note overlap check assumes are start is inclusive and end is exclusive
+ */
+template <typename T> static bool overlap(T s1, T e1, T s2, T e2) {
+#if DEBUG
+  if (e1 <= s1 || e2 <= s2)
+    throw std::invalid_argument("Invalid range for intervals in MemoryPool");
+#endif
+
+  return !(e1 <= s2 || e2 <= s1)
+}
+
+/**
+ * @brief Validate the provided layout so that no two memories to be used at
+ * overlap interval has overlapping memories
+ */
+bool MemoryPool::validateOverlap() {
+  /** get sorted permutation */
+  std::vector<unsigned int> perm = getSortedPermutation();
+
+  /** iterate over sorted array view and check overlap of memories */
+  size_t len = perm.size();
+  for (unsigned int i = 0; i < len; i++) {
+    unsigned int idx = perm[i];
+    size_t mem_start = memory_offset[idx], mem_size = memory_size[idx];
+    unsigned int valid_start = memory_validity[idx].first,
+                 valid_end = memory_validity[idx].second;
+    for (unsigned int match = idx + 1; match < len; match++) {
+      if (overlap(mem_start, mem_start + mem_size, memory_offset[match],
+                  memory_offset[match] + memory_size[match])) {
+        /**
+         * if the memories given to two requests overlap, then their valid
+         * range should not overlap
+         */
+        if (overlap(valid_start, valid_end, memory_validity[match].first,
+                    memory_validity[match].second))
+          return false;
+      } else {
+        /**
+         * as the list memories are sorted by offset, we can safely assume that
+         * memory allocations after idx will not overlap as well
+         */
+        break;
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * @brief Get sorted permuation for the memory requests
+ *
+ * @details Performs sorting based on the memory overlap using memory offset
+ * as the start and the memory offset + memory size as the end of the interval.
+ */
+std::vector<unsigned int> MemoryPool::getSortedPermutation() {
+  std::vector<unsigned int> perm(memory_size.size());
+  std::iota(perm.begin(), perm.end(), 0);
+  /** sorted by memory_offset first and then memory_offset + memory_size next */
+  std::sort(perm.begin(), perm.end(), [&](auto const &idx1, auto const &idx2) {
+    if (memory_offset[idx1] == memory_offset[idx2])
+      return memory_size[idx1] < memory_size[idx2];
+
+    return memory_offset[idx1] < memory_offset[idx2];
+  });
+
+  return perm;
+}
+
+/**
+ * @brief Calculate the minimum memory requirement for the given memory requests
+ *
+ * @note This will be theoretical minimum memory requirement ensuring that the
+ * memory usages at the same time do not overlap with their validity. This does
+ * not consider about the fragmentation which comes from the actual memory
+ * layout.
+ */
+size_t MemoryPool::calcMinMemoryRequirement() {
+  auto max_interval =
+    *std::max_element(memory_validity.begin(), memory_validity.end(),
+                      [](auto const &val1, auto const &val2) {
+                        return val1.second < val2.second;
+                      });
+  unsigned int last_interval = max_interval.second;
+
+  std::vector<size_t> interval_req(last_interval + 1, 0);
+  /**
+   * @note This method fills requirement for each value in the interval. This is
+   * efficient for the current use case as there is going to be atleast 1 new
+   * memory request for each interval because each interval is mapped to a node
+   * in the graph.
+   */
+  for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
+    for (unsigned int interval = memory_validity[idx].first;
+         interval < memory_validity[idx].second; interval++) {
+      interval_req[interval] += memory_size[idx];
+    }
+  }
+
+  return *std::max_element(interval_req.begin(), interval_req.end());
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -41,6 +41,7 @@ public:
    * @param end_time The end of the validity interval of this memory
    *
    * @return The token to get the pointer for this memory after allocation
+   * @note start_time is inclusive, but end_time is exclusive
    */
   unsigned int requestMemory(size_t bytes, unsigned int start_time,
                              unsigned int end_time);

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -5,7 +5,8 @@ tensor_sources = [
   'tensor.cpp',
   'tensor_dim.cpp',
   'var_grad.cpp',
-  'weight.cpp'
+  'weight.cpp',
+  'basic_planner.cpp'
 ]
 
 tensor_headers = [

--- a/test/unittest/layers/unittest_layers_activation.cpp
+++ b/test/unittest/layers/unittest_layers_activation.cpp
@@ -36,7 +36,7 @@ auto semantic_activation_none = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::ActivationLayer>,
   nntrainer::ActivationLayer::type, {"activation=none"}, 0, false);
 
-INSTANTIATE_TEST_CASE_P(ActivationNone, LayerSemantics,
+INSTANTIATE_TEST_CASE_P(Activation, LayerSemantics,
                         ::testing::Values(semantic_activation_relu,
                                           semantic_activation_sigmoid,
                                           semantic_activation_softmax,

--- a/test/unittest/memory/memory_planner_validate.cpp
+++ b/test/unittest/memory/memory_planner_validate.cpp
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   memory_planner_validate.h
+ * @date   11 August 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Tests for memory planning
+ */
+
+#include <bitset>
+#include <random>
+#include <vector>
+
+#include <basic_planner.h>
+#include <memory_planner_validate.h>
+
+constexpr unsigned int MEM_BYTES = 50;
+constexpr unsigned int MEM_QUANT = 100;
+constexpr unsigned int INTERVAL_SIZE = 5;
+
+void MemoryPlannerValidate::SetUp() {
+  plan_type = GetParam();
+
+  planner = nullptr;
+  if (plan_type == nntrainer::BasicPlanner::type)
+    planner = std::make_unique<nntrainer::BasicPlanner>();
+  else
+    throw std::invalid_argument("Invalid planner type");
+}
+
+/**
+ * @brief Validate the provided layout does not overlap
+ */
+static bool validateNoOverlap(const std::vector<size_t> &memory_size,
+                              const std::vector<size_t> &memory_offset,
+                              unsigned int size) {
+  std::vector<bool> mem_overlap(size, false);
+  for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
+    for (unsigned int mem = memory_offset[idx];
+         mem < memory_offset[idx] + memory_size[idx]; mem++) {
+      EXPECT_FALSE(mem_overlap[mem]);
+      if (mem_overlap[mem])
+        return false;
+      mem_overlap[mem] = true;
+    }
+  }
+
+  /** This ensures that there are no unnecessary gaps in between */
+  EXPECT_EQ(mem_overlap.size(),
+            std::accumulate(mem_overlap.begin(), mem_overlap.end(), 0));
+
+  return true;
+}
+
+/**
+ * @brief Validate the provided layout does completely overlap
+ */
+static bool validateAllOverlap(const std::vector<size_t> &memory_size,
+                               const std::vector<size_t> &memory_offset) {
+  for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
+    EXPECT_EQ(memory_offset[idx], memory_offset[0]);
+  }
+
+  return true;
+}
+
+/**
+ * @brief Validate the provided layout does not overflow outside the given
+ * size
+ */
+static bool validateOverflow(const std::vector<size_t> &memory_size,
+                             const std::vector<size_t> &memory_offset,
+                             size_t pool_size) {
+  for (unsigned int idx = 0; idx < memory_size.size(); idx++)
+    if (memory_offset[idx] + memory_size[idx] > pool_size)
+      return false;
+
+  return true;
+}
+
+/**
+ * @brief Test memory planning with full overlap of requested memories
+ * @details validityIsFullOverlapping - validify is the full overlapping memory
+ * requests handled correctly.
+ */
+TEST_P(MemoryPlannerValidate, full_overlap) {
+  std::mt19937 rng;
+  std::uniform_int_distribution<size_t> dist(1, MEM_BYTES);
+
+  std::vector<size_t> memory_size(MEM_QUANT);
+  for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
+    memory_size[idx] = dist(rng);
+  }
+  std::vector<std::pair<unsigned int, unsigned int>> memory_validity(MEM_QUANT,
+                                                                     {1, 2});
+  std::vector<size_t> memory_offset;
+
+  size_t pool_size =
+    planner->planLayout(memory_size, memory_validity, memory_offset);
+
+  EXPECT_EQ(pool_size,
+            std::accumulate(memory_size.begin(), memory_size.end(), 0));
+  EXPECT_TRUE(validateNoOverlap(memory_size, memory_offset, pool_size));
+  EXPECT_TRUE(validateOverflow(memory_size, memory_offset, pool_size));
+}
+
+/**
+ * @brief Test memory planning with no overlap of requested memories
+ */
+TEST_P(MemoryPlannerValidate, none_overlap) {
+  std::mt19937 rng;
+  std::uniform_int_distribution<size_t> dist(1, MEM_BYTES);
+
+  std::vector<size_t> memory_size(MEM_QUANT);
+  for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
+    memory_size[idx] = dist(rng);
+  }
+
+  std::vector<std::pair<unsigned int, unsigned int>> memory_validity(MEM_QUANT);
+  for (unsigned int idx = 0; idx < memory_validity.size(); idx++) {
+    memory_validity[idx] = {idx, idx + 1};
+  }
+
+  std::vector<size_t> memory_offset;
+  size_t pool_size =
+    planner->planLayout(memory_size, memory_validity, memory_offset);
+
+  EXPECT_TRUE(validateOverflow(memory_size, memory_offset, pool_size));
+  if (planner->getType() == nntrainer::BasicPlanner::type) {
+    EXPECT_EQ(pool_size,
+              std::accumulate(memory_size.begin(), memory_size.end(), 0));
+    EXPECT_TRUE(validateNoOverlap(memory_size, memory_offset, pool_size));
+  } else {
+    EXPECT_EQ(pool_size,
+              *std::max_element(memory_size.begin(), memory_size.end()));
+    EXPECT_TRUE(validateAllOverlap(memory_size, memory_offset));
+  }
+}
+
+/**
+ * @brief Test memory planning with partial overlap of requested memories
+ */
+TEST_P(MemoryPlannerValidate, partial_overlap) {
+  std::mt19937 rng;
+  std::uniform_int_distribution<size_t> dist(1, MEM_BYTES);
+  std::uniform_int_distribution<unsigned int> dist_interval(1, INTERVAL_SIZE);
+
+  std::vector<size_t> memory_size(MEM_QUANT);
+  for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
+    memory_size[idx] = dist(rng);
+  }
+
+  std::vector<std::pair<unsigned int, unsigned int>> memory_validity(MEM_QUANT);
+  for (unsigned int idx = 0; idx < memory_validity.size(); idx++) {
+    memory_validity[idx] = {idx, idx + dist_interval(rng)};
+  }
+  std::shuffle(memory_validity.begin(), memory_validity.end(),
+               std::default_random_engine(0));
+
+  std::vector<size_t> memory_offset;
+  size_t pool_size =
+    planner->planLayout(memory_size, memory_validity, memory_offset);
+
+  EXPECT_TRUE(validateOverflow(memory_size, memory_offset, pool_size));
+  if (planner->getType() == nntrainer::BasicPlanner::type) {
+    EXPECT_EQ(pool_size,
+              std::accumulate(memory_size.begin(), memory_size.end(), 0));
+    EXPECT_TRUE(validateNoOverlap(memory_size, memory_offset, pool_size));
+  } else {
+    EXPECT_EQ(pool_size,
+              *std::max_element(memory_size.begin(), memory_size.end()));
+    // EXPECT_TRUE(validateIntervalOverlap(memory_size, memory_offset));
+  }
+}

--- a/test/unittest/memory/memory_planner_validate.h
+++ b/test/unittest/memory/memory_planner_validate.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   memory_planner_validate.h
+ * @date   11 August 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ memory_planner_validate.h
+ */
+
+#ifndef __MEMORY_PLANNER_VALIDATE_H__
+#define __MEMORY_PLANNER_VALIDATE_H__
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include <memory_planner.h>
+
+/**
+ * @class MemoryPlannerValidate
+ * @brief Memory planning validation
+ */
+class MemoryPlannerValidate : public ::testing::TestWithParam<std::string> {
+public:
+  /**
+   * @brief Destructor
+   *
+   */
+  virtual ~MemoryPlannerValidate() {}
+
+  /**
+   * @brief SetUp test cases here
+   *
+   */
+  virtual void SetUp();
+
+  /**
+   * @brief Release test resources
+   *
+   */
+  virtual void TearDown() {}
+
+protected:
+  std::unique_ptr<nntrainer::MemoryPlanner> planner;
+  std::string plan_type;
+};
+
+#endif // __MEMORY_PLANNER_VALIDATE_H__

--- a/test/unittest/memory/meson.build
+++ b/test/unittest/memory/meson.build
@@ -1,0 +1,31 @@
+memory_test_inc = include_directories('./')
+
+nntrainer_memory_planner_tests_lib = shared_library(
+  'nntrainer_memory_planner_validation',
+  'memory_planner_validate.cpp',
+  dependencies: [nntrainer_dep, gtest_dep], # nntrainer_devel_dep
+  include_directories: memory_test_inc
+)
+
+nntrainer_memory_tests_dep = declare_dependency(
+  link_with: nntrainer_memory_planner_tests_lib,
+  include_directories: memory_test_inc
+  )
+
+test_target = [
+  'unittest_memory_planner.cpp',
+]
+
+exe = executable(
+  'unittest_memory', test_target,
+  dependencies: [
+    nntrainer_test_main_deps,
+    nntrainer_memory_tests_dep
+  ],
+  install: get_option('enable-test'),
+  install_dir: application_install_dir
+)
+
+test('unittest_memory', exe,
+  args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), 'unittest_memory')
+)

--- a/test/unittest/memory/unittest_memory_planner.cpp
+++ b/test/unittest/memory/unittest_memory_planner.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_memory_planning.cpp
+ * @date 11 August 2021
+ * @brief Activation Layer Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory_planner_validate.h>
+
+#include <basic_planner.h>
+
+INSTANTIATE_TEST_CASE_P(BasicPlanner, MemoryPlannerValidate,
+                        ::testing::Values(nntrainer::BasicPlanner::type));

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -55,6 +55,7 @@ endforeach
 
 unittest_inc = include_directories('.')
 
+subdir('memory')
 subdir('compiler')
 subdir('layers')
 subdir('datasets')


### PR DESCRIPTION
Add support for a basic memory planner along with its unittests:
- This patch adds support for the basic memory planner.
The basic memory planner does not provide any memory sharing, and
results in all tensors being allocated in separate memories.
This forms the baseline for memory allocation.
Other memory planners will be enhancement over this.
- This patch adds unittests for the memory planner.
The unittests covers some of the extreme scenarios for memory planning
and ensures that the constraints are satisfied.
Note that these tests do not test the efficient of the planning but the
validity of the planned layout.
Corresponding bug fixes are also added.

See Also #1127

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>