### PR TITLE
[MemoryPool] Add memory pool implementation with unittests

### DIFF
--- a/nntrainer/tensor/basic_planner.cpp
+++ b/nntrainer/tensor/basic_planner.cpp
@@ -30,8 +30,10 @@ size_t BasicPlanner::planLayout(
   const std::vector<size_t> &memory_size,
   const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
   std::vector<size_t> &memory_offset) const {
+
   memory_offset.resize(memory_size.size());
   size_t csum = 0;
+
   for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
 
 #ifdef DEBUG

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -24,6 +24,9 @@ namespace nntrainer {
  */
 unsigned int MemoryPool::requestMemory(size_t bytes, unsigned int start_time,
                                        unsigned int end_time) {
+  if (bytes == 0)
+    throw std::invalid_argument("Requesting memory of 0 size");
+
   if (mem_pool != nullptr)
     throw std::invalid_argument(
       "Deallocate memory pool before requesting more memory");
@@ -79,9 +82,13 @@ void MemoryPool::allocate() {
   if (pool_size == 0)
     throw std::runtime_error("Allocating memory pool with size 0");
 
+  if (mem_pool != nullptr)
+    throw std::runtime_error("Memory pool is already allocated");
+
   mem_pool = malloc(pool_size);
   if (mem_pool == nullptr)
-    throw std::runtime_error("Allocation memory failed");
+    throw std::runtime_error(
+      "Failed to allocate memory: " + std::to_string(pool_size) + "bytes");
 }
 
 /**
@@ -102,6 +109,8 @@ void *MemoryPool::getMemory(unsigned int idx) {
 void MemoryPool::deallocate() {
   if (mem_pool != nullptr)
     free(mem_pool);
+
+  mem_pool = nullptr;
 }
 
 /**
@@ -165,7 +174,7 @@ template <typename T> static bool overlap(T s1, T e1, T s2, T e2) {
     throw std::invalid_argument("Invalid range for intervals in MemoryPool");
 #endif
 
-  return !(e1 <= s2 || e2 <= s1)
+  return !(e1 <= s2 || e2 <= s1);
 }
 
 /**

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -9,7 +9,7 @@
  * @bug    No known bugs except for NYI items
  * @brief  This is Memory Pool Class
  *
- * @todo   Support an external allocator for different backends
+ * @todo   Support an external allocator for different backends and alignment
  * @todo   Support releaseMemory(token) - this need not release actual memory
  * until deallocate
  * @todo   Support maximum memory size for the memory pool as an argument

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -7,9 +7,13 @@
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  This is Memory Pool Class for
+ * @brief  This is Memory Pool Class
  *
  * @todo   Support an external allocator for different backends
+ * @todo   Support releaseMemory(token) - this need not release actual memory
+ * until deallocate
+ * @todo   Support maximum memory size for the memory pool as an argument
+ * @todo support late memory request without optimization
  */
 
 #ifndef __MEMORY_POOL_H__
@@ -84,28 +88,63 @@ public:
    * @brief Free all the allocated memory
    *
    */
-  void free();
+  void deallocate();
 
   /**
    * @brief Get the maximum real memory requirement
    *
-   * @return The real memory requirement with this strategy
+   * @return The real memory requirement with this strategy in bytes
    */
   size_t size();
 
   /**
    * @brief Get the minimum theoretical memory requirement
    *
-   * @return The theoretical memory requirement with this strategy
+   * @return The theoretical memory requirement with this strategy in bytes
    */
-  size_t minMemReq();
+  size_t minMemoryRequirement();
 
 private:
+  /**
+   * @brief Validate the provided layout
+   */
+  bool validateLayout();
+
+  /**
+   * @brief Validate the provided layout does not overflow outside the given
+   * size of the memory pool
+   */
+  bool validateOverflow();
+
   /**
    * @brief Validate the provided layout so that no two memories to be used at
    * overlap interval has overlapping memories
    */
-  bool validateLayout();
+  bool validateOverlap();
+
+  /**
+   * @brief Calculate the minimum memory requirement for the given memory
+   * requests
+   *
+   * @returns the minimum memory requirement in bytes
+   *
+   * @note This will be theoretical minimum memory requirement ensuring that the
+   * memory usages at the same time do not overlap with their validity. This
+   * does not consider about the fragmentation which comes from the actual
+   * memory layout.
+   */
+  size_t calcMinMemoryRequirement();
+
+  /**
+   * @brief Get sorted permuation for the memory requests
+   *
+   * @return sorted permutation
+   *
+   * @details Performs sorting based on the memory overlap using memory offset
+   * as the start and the memory offset + memory size as the end of the
+   * interval.
+   */
+  std::vector<unsigned int> getSortedPermutation();
 
   std::vector<size_t> memory_size; /**< various sizes memory requested */
   std::vector<std::pair<unsigned int, unsigned int>>

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -6,7 +6,8 @@ tensor_sources = [
   'tensor_dim.cpp',
   'var_grad.cpp',
   'weight.cpp',
-  'basic_planner.cpp'
+  'basic_planner.cpp',
+  'memory_pool.cpp'
 ]
 
 tensor_headers = [

--- a/test/unittest/memory/memory_planner_validate.cpp
+++ b/test/unittest/memory/memory_planner_validate.cpp
@@ -10,9 +10,10 @@
  * @brief  Tests for memory planning
  */
 
-#include <bitset>
 #include <random>
 #include <vector>
+
+#include <gtest/gtest.h>
 
 #include <basic_planner.h>
 #include <memory_planner_validate.h>

--- a/test/unittest/memory/memory_planner_validate.h
+++ b/test/unittest/memory/memory_planner_validate.h
@@ -7,7 +7,6 @@
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug    No known bugs except for NYI items
- memory_planner_validate.h
  */
 
 #ifndef __MEMORY_PLANNER_VALIDATE_H__

--- a/test/unittest/memory/meson.build
+++ b/test/unittest/memory/meson.build
@@ -1,6 +1,6 @@
 memory_test_inc = include_directories('./')
 
-nntrainer_memory_planner_tests_lib = shared_library(
+nntrainer_memory_planner_tests_lib = static_library(
   'nntrainer_memory_planner_validation',
   'memory_planner_validate.cpp',
   dependencies: [nntrainer_dep, gtest_dep], # nntrainer_devel_dep
@@ -15,8 +15,10 @@ nntrainer_memory_tests_dep = declare_dependency(
 test_target = [
   'memory_planner_validate.cpp',
   'unittest_memory_planner.cpp',
+  'unittest_memory_pool.cpp'
 ]
 
+# memory unittests
 exe = executable(
   'unittest_memory', test_target,
   dependencies: [

--- a/test/unittest/memory/unittest_memory_planner.cpp
+++ b/test/unittest/memory/unittest_memory_planner.cpp
@@ -4,7 +4,7 @@
  *
  * @file unittest_memory_planning.cpp
  * @date 11 August 2021
- * @brief Activation Layer Test
+ * @brief Memory Planner Test
  * @see	https://github.com/nnstreamer/nntrainer
  * @author Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug No known bugs except for NYI items

--- a/test/unittest/memory/unittest_memory_pool.cpp
+++ b/test/unittest/memory/unittest_memory_pool.cpp
@@ -1,0 +1,544 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_memory_pool.cpp
+ * @date 11 August 2021
+ * @brief Memory Pool Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <basic_planner.h>
+#include <memory_planner_validate.h>
+#include <memory_pool.h>
+
+constexpr unsigned int MEM_BYTES = 128;
+constexpr unsigned int MEM_QUANT = 100;
+constexpr unsigned int INTERVAL_SIZE = 5;
+
+/**
+ * @brief creation and destruction
+ */
+TEST(MemoryPool, create_destroy) { EXPECT_NO_THROW(nntrainer::MemoryPool()); }
+
+/**
+ * @brief request 0 sized memory
+ */
+TEST(MemoryPool, request_mem_01_n) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_THROW(pool.requestMemory(0, 1, 2), std::invalid_argument);
+}
+
+/**
+ * @brief request memory when starts after it ends
+ */
+TEST(MemoryPool, request_mem_02_n) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_THROW(pool.requestMemory(1, 3, 2), std::invalid_argument);
+}
+
+/**
+ * @brief request memory with 0 valid time
+ */
+TEST(MemoryPool, request_mem_03_n) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_THROW(pool.requestMemory(1, 4, 4), std::invalid_argument);
+}
+
+/**
+ * @brief request memory
+ */
+TEST(MemoryPool, request_mem_04_p) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_NO_THROW(pool.requestMemory(1, 4, 5));
+}
+
+/**
+ * @brief plan layout
+ */
+TEST(MemoryPool, plan_layout_01_n) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_THROW(pool.planLayout(nntrainer::BasicPlanner()), std::runtime_error);
+}
+
+/**
+ * @brief plan layout
+ */
+TEST(MemoryPool, plan_layout_02_p) {
+  nntrainer::MemoryPool pool;
+
+  pool.requestMemory(1, 4, 5);
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+}
+
+/**
+ * @brief plan layout
+ */
+TEST(MemoryPool, plan_layout_03_p) {
+  nntrainer::MemoryPool pool;
+
+  pool.requestMemory(1, 4, 5);
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+  EXPECT_EQ(1u, pool.size());
+
+  pool.requestMemory(1, 4, 5);
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+  EXPECT_EQ(2u, pool.size());
+}
+
+/**
+ * @brief deallocate
+ */
+TEST(MemoryPool, deallocate_01_p) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief allocate
+ */
+TEST(MemoryPool, allocate_01_n) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_THROW(pool.allocate(), std::runtime_error);
+
+  pool.requestMemory(1, 4, 5);
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+  EXPECT_EQ(1u, pool.size());
+
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief allocate
+ */
+TEST(MemoryPool, allocate_02_p) {
+  nntrainer::MemoryPool pool;
+
+  pool.requestMemory(1, 4, 5);
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+  EXPECT_EQ(1u, pool.size());
+
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief allocate
+ */
+TEST(MemoryPool, allocate_03_n) {
+  nntrainer::MemoryPool pool;
+
+  pool.requestMemory(1, 4, 5);
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+  EXPECT_EQ(1u, pool.size());
+
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_THROW(pool.allocate(), std::runtime_error);
+
+  EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief allocate
+ */
+TEST(MemoryPool, allocate_04_n) {
+  nntrainer::MemoryPool pool;
+
+  pool.requestMemory(3, 4, 5);
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+  EXPECT_EQ(3u, pool.size());
+
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_NO_THROW(pool.deallocate());
+
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief size of the pool
+ */
+TEST(MemoryPool, size_01_p) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_EQ(pool.size(), 0u);
+}
+
+/**
+ * @brief size of the pool
+ */
+TEST(MemoryPool, size_02_p) {
+  nntrainer::MemoryPool pool;
+
+  pool.requestMemory(1, 4, 5);
+  EXPECT_EQ(pool.size(), 0u);
+}
+
+/**
+ * @brief size of the pool
+ */
+TEST(MemoryPool, size_03_p) {
+  nntrainer::MemoryPool pool;
+
+  pool.requestMemory(1, 4, 5);
+  EXPECT_EQ(pool.size(), 0u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.size(), 1u);
+
+  pool.allocate();
+  EXPECT_EQ(pool.size(), 1u);
+
+  EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief min requirement
+ */
+TEST(MemoryPool, min_mem_req_01_p) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_EQ(pool.minMemoryRequirement(), 0u);
+}
+
+/**
+ * @brief min requirement
+ */
+TEST(MemoryPool, min_mem_req_02_p) {
+  nntrainer::MemoryPool pool;
+
+  pool.requestMemory(1, 4, 5);
+  EXPECT_EQ(pool.minMemoryRequirement(), 1u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 1u);
+}
+
+/**
+ * @brief min requirement
+ */
+TEST(MemoryPool, min_mem_req_03_p) {
+  nntrainer::MemoryPool pool;
+
+  pool.requestMemory(1, 4, 5);
+  EXPECT_EQ(pool.minMemoryRequirement(), 1u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 1u);
+
+  /** exact overlap */
+  pool.requestMemory(2, 4, 5);
+  EXPECT_EQ(pool.minMemoryRequirement(), 3u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 3u);
+
+  /** ending overlap */
+  pool.requestMemory(3, 2, 5);
+  EXPECT_EQ(pool.minMemoryRequirement(), 6u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 6u);
+
+  /** start overlap */
+  pool.requestMemory(4, 4, 8);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 10u);
+
+  /** complete overlap */
+  pool.requestMemory(5, 1, 10);
+  EXPECT_EQ(pool.minMemoryRequirement(), 15u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 15u);
+}
+
+/**
+ * @brief min requirement
+ */
+TEST(MemoryPool, min_mem_req_04_p) {
+  nntrainer::MemoryPool pool;
+
+  pool.requestMemory(1, 5, 10);
+  EXPECT_EQ(pool.minMemoryRequirement(), 1u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 1u);
+
+  /** partial overlap */
+  pool.requestMemory(2, 1, 8);
+  EXPECT_EQ(pool.minMemoryRequirement(), 3u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 3u);
+
+  /** ending overlap */
+  pool.requestMemory(3, 7, 12);
+  EXPECT_EQ(pool.minMemoryRequirement(), 6u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 6u);
+}
+
+/**
+ * @brief min requirement
+ */
+TEST(MemoryPool, min_mem_req_05_p) {
+  nntrainer::MemoryPool pool;
+
+  pool.requestMemory(1, 5, 10);
+  EXPECT_EQ(pool.minMemoryRequirement(), 1u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 1u);
+
+  /** partial overlap */
+  pool.requestMemory(2, 1, 8);
+  EXPECT_EQ(pool.minMemoryRequirement(), 3u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 3u);
+
+  /** ending overlap with matching ends */
+  pool.requestMemory(3, 8, 12);
+  EXPECT_EQ(pool.minMemoryRequirement(), 4u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 4u);
+}
+
+/**
+ * @brief min requirement
+ */
+TEST(MemoryPool, min_mem_req_06_p) {
+  nntrainer::MemoryPool pool;
+
+  pool.requestMemory(1, 5, 10);
+  EXPECT_EQ(pool.minMemoryRequirement(), 1u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 1u);
+
+  /** partial overlap */
+  pool.requestMemory(2, 1, 5);
+  EXPECT_EQ(pool.minMemoryRequirement(), 2u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 2u);
+
+  /** ending overlap with matching ends */
+  pool.requestMemory(3, 10, 12);
+  EXPECT_EQ(pool.minMemoryRequirement(), 3u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 3u);
+
+  /** ending overlap with matching ends */
+  pool.requestMemory(1, 12, 13);
+  EXPECT_EQ(pool.minMemoryRequirement(), 3u);
+
+  pool.planLayout(nntrainer::BasicPlanner());
+  EXPECT_EQ(pool.minMemoryRequirement(), 3u);
+}
+
+/**
+ * @brief get memory
+ */
+TEST(MemoryPool, get_memory_01_n) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_THROW(pool.getMemory(1), std::invalid_argument);
+}
+
+/**
+ * @brief get memory
+ */
+TEST(MemoryPool, get_memory_02_n) {
+  nntrainer::MemoryPool pool;
+
+  auto idx = pool.requestMemory(1, 4, 5);
+  EXPECT_THROW(pool.getMemory(idx), std::invalid_argument);
+}
+
+/**
+ * @brief get memory
+ */
+TEST(MemoryPool, get_memory_03_n) {
+  nntrainer::MemoryPool pool;
+
+  auto idx = pool.requestMemory(1, 4, 5);
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_ANY_THROW(pool.getMemory(idx + 1));
+
+  EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief get memory
+ */
+TEST(MemoryPool, get_memory_04_p) {
+  nntrainer::MemoryPool pool;
+  void *mem;
+
+  auto idx = pool.requestMemory(1, 4, 5);
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_NO_THROW(mem = pool.getMemory(idx));
+  EXPECT_NE(mem, nullptr);
+
+  EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief validate memory full overlap
+ */
+TEST_P(MemoryPlannerValidate, validate_memory_full_overlap) {
+  nntrainer::MemoryPool pool;
+  std::mt19937 rng;
+  std::uniform_int_distribution<size_t> dist(1, MEM_BYTES);
+  std::uniform_int_distribution<unsigned int> dist_interval(1, INTERVAL_SIZE);
+
+  std::vector<unsigned int> tokens(MEM_QUANT);
+  std::vector<size_t> memory_size(MEM_QUANT);
+  std::vector<void *> ptrs(MEM_QUANT);
+
+  for (unsigned int idx = 0; idx < MEM_QUANT; idx++) {
+    memory_size[idx] = dist(rng);
+    unsigned int start = 1;
+    unsigned int end = start + dist_interval(rng);
+    EXPECT_NO_THROW(tokens[idx] =
+                      pool.requestMemory(memory_size[idx], start, end));
+  }
+
+  EXPECT_NO_THROW(pool.planLayout(*planner.get()));
+  EXPECT_EQ(pool.size(),
+            std::accumulate(memory_size.begin(), memory_size.end(), 0u));
+  EXPECT_NO_THROW(pool.allocate());
+
+  for (unsigned int idx = 0; idx < MEM_QUANT; idx++)
+    EXPECT_NO_THROW(ptrs[idx] = pool.getMemory(tokens[idx]));
+
+  /** write data to memory */
+  for (unsigned int idx = 0; idx < MEM_QUANT; idx++)
+    memset(ptrs[idx], idx, memory_size[idx]);
+
+  /** verify data in memory */
+  for (unsigned int idx = 0; idx < MEM_QUANT; idx++) {
+    std::vector<unsigned char> golden(memory_size[idx], idx);
+    memcmp(ptrs[idx], &golden[0], memory_size[idx]);
+  }
+
+  pool.deallocate();
+}
+
+/**
+ * @brief validate memory no overlap
+ */
+TEST_P(MemoryPlannerValidate, validate_memory_no_overlap) {
+  nntrainer::MemoryPool pool;
+  std::mt19937 rng;
+  std::uniform_int_distribution<size_t> dist(1, MEM_BYTES);
+  std::uniform_int_distribution<unsigned int> dist_interval(1, INTERVAL_SIZE);
+
+  std::vector<unsigned int> tokens(MEM_QUANT);
+  std::vector<size_t> memory_size(MEM_QUANT);
+  std::vector<void *> ptrs(MEM_QUANT);
+
+  unsigned int prev_idx = 0;
+  for (unsigned int idx = 0; idx < MEM_QUANT; idx++) {
+    memory_size[idx] = dist(rng);
+    unsigned int start = prev_idx;
+    unsigned int end = start + dist_interval(rng);
+    EXPECT_NO_THROW(tokens[idx] =
+                      pool.requestMemory(memory_size[idx], start, end));
+    prev_idx = end;
+  }
+
+  EXPECT_NO_THROW(pool.planLayout(*planner.get()));
+  EXPECT_EQ(pool.size(),
+            std::accumulate(memory_size.begin(), memory_size.end(), 0u));
+  EXPECT_NO_THROW(pool.allocate());
+
+  for (unsigned int idx = 0; idx < MEM_QUANT; idx++)
+    EXPECT_NO_THROW(ptrs[idx] = pool.getMemory(tokens[idx]));
+
+  /** write data to memory */
+  for (unsigned int idx = 0; idx < MEM_QUANT; idx++)
+    memset(ptrs[idx], idx, memory_size[idx]);
+
+  /** verify data in memory */
+  for (unsigned int idx = 0; idx < MEM_QUANT; idx++) {
+    std::vector<unsigned char> golden(memory_size[idx], idx);
+    memcmp(ptrs[idx], &golden[0], memory_size[idx]);
+  }
+
+  pool.deallocate();
+}
+
+/**
+ * @brief validate memory partial overlap
+ */
+TEST_P(MemoryPlannerValidate, validate_memory_partial_overlap) {
+  nntrainer::MemoryPool pool;
+  std::mt19937 rng;
+  std::uniform_int_distribution<size_t> dist(1, MEM_BYTES);
+  std::uniform_int_distribution<unsigned int> dist_interval(1, INTERVAL_SIZE);
+  std::uniform_int_distribution<unsigned int> dist_interval_start(1, 100);
+
+  std::vector<unsigned int> tokens(MEM_QUANT);
+  std::vector<size_t> memory_size(MEM_QUANT);
+  std::vector<void *> ptrs(MEM_QUANT);
+
+  for (unsigned int idx = 0; idx < MEM_QUANT; idx++) {
+    memory_size[idx] = dist(rng);
+    unsigned int start = dist_interval_start(rng);
+    unsigned int end = start + dist_interval(rng);
+    EXPECT_NO_THROW(tokens[idx] =
+                      pool.requestMemory(memory_size[idx], start, end));
+  }
+
+  EXPECT_NO_THROW(pool.planLayout(*planner.get()));
+  EXPECT_EQ(pool.size(),
+            std::accumulate(memory_size.begin(), memory_size.end(), 0u));
+  EXPECT_NO_THROW(pool.allocate());
+
+  for (unsigned int idx = 0; idx < MEM_QUANT; idx++)
+    EXPECT_NO_THROW(ptrs[idx] = pool.getMemory(tokens[idx]));
+
+  /** write data to memory */
+  for (unsigned int idx = 0; idx < MEM_QUANT; idx++)
+    memset(ptrs[idx], idx, memory_size[idx]);
+
+  /** verify data in memory */
+  for (unsigned int idx = 0; idx < MEM_QUANT; idx++) {
+    std::vector<unsigned char> golden(memory_size[idx], idx);
+    memcmp(ptrs[idx], &golden[0], memory_size[idx]);
+  }
+
+  pool.deallocate();
+}


### PR DESCRIPTION
This patch adds memory pool implementation with its unittests which uses the basic planner as the planner
- This patch provides implementation for memory pool which uses a memory
planner to plan the layout of the memory and provides efficiency of the
given planner.
- This patch adds unittests for memory pool for its public APIs.
Further, memory validation is added for the requested memories and
those tests will be added for each planner. This ensures that the
memories returned by each planner do not overlap, and remain valid while
usage.
Fixes corresponding to the unittests are also added.

See ALso #1127

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>