### PR TITLE
[fixes] Add bug fixes found with address sanitizer

### DIFF
--- a/nntrainer/layers/nnstreamer_layer.cpp
+++ b/nntrainer/layers/nnstreamer_layer.cpp
@@ -62,18 +62,9 @@ int NNStreamerLayer::nnst_info_to_tensor_dim(ml_tensors_info_h &out_res,
   return status;
 }
 
-NNStreamerLayer::~NNStreamerLayer() {
-  try {
-    finalizeError(ML_ERROR_NONE);
-  } catch (std::exception &e) {
-    std::cerr << "failed in destructor, reason: " << e.what();
-  }
-}
+NNStreamerLayer::~NNStreamerLayer() { release(); }
 
-void NNStreamerLayer::finalizeError(int status) {
-  if (status == ML_ERROR_NONE)
-    return;
-
+void NNStreamerLayer::release() noexcept {
   if (in_res) {
     ml_tensors_info_destroy(in_res);
     in_res = nullptr;
@@ -98,6 +89,13 @@ void NNStreamerLayer::finalizeError(int status) {
     ml_single_close(single);
     single = nullptr;
   }
+}
+
+void NNStreamerLayer::finalizeError(int status) {
+  if (status == ML_ERROR_NONE)
+    return;
+
+  release();
 
   if (status != ML_ERROR_NONE)
     throw std::invalid_argument(

--- a/nntrainer/layers/nnstreamer_layer.h
+++ b/nntrainer/layers/nnstreamer_layer.h
@@ -99,6 +99,11 @@ private:
   void finalizeError(int status);
 
   /**
+   * @brief     release the layer resources
+   */
+  void release() noexcept;
+
+  /**
    * @brief    convert nnstreamer's tensor_info to nntrainer's tensor_dim
    * @param[in] out_res nnstreamer's tensor_info
    * @param[out] dim nntrainer's tensor_dim

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -1085,6 +1085,9 @@ TEST(nntrainer_capi_nnmodel, get_input_output_dimension_03_n) {
             ML_ERROR_INVALID_PARAMETER);
   EXPECT_EQ(ml_train_model_get_output_tensors_info(handle, &output_info),
             ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
 TEST(nntrainer_capi_nnmodel, get_input_output_dimension_04_n) {
@@ -1112,6 +1115,7 @@ TEST(nntrainer_capi_nnmodel, get_input_output_dimension_05_n) {
 
   status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
+  handle = NULL;
 
   EXPECT_EQ(ml_train_model_get_input_tensors_info(handle, &input_info),
             ML_ERROR_INVALID_PARAMETER);


### PR DESCRIPTION
This patch adds bug fixes after adding fixes related to address
sanitzer:
- NNStreamerLayer wasnt freeing resources upon destruction
- accessing released model handle in capi unittest
- not releasing model handle before end of unittest

See Also #1480

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>