### PR TITLE
[vargrad/tensor] Tensor names + cleanup 

### DIFF
--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -257,12 +257,10 @@ void Manager::initializeWeights() {
     return;
 
   if (LAYER_V2) {
-    for (auto &l_w : weights_v2) {
-      for (auto &w : l_w) {
-        w->initializeVariable();
-        // tensor_map(&w->getVariableRef(), requestMemory(w.getDim().size(), 0,
-        // MAX));
-      }
+    for (auto &w : weights_v2) {
+      w->initializeVariable();
+      // tensor_map(&w->getVariableRef(), requestMemory(w.getDim().size(), 0,
+      // MAX));
     }
   } else {
     if (total_weight_size == 0) {
@@ -295,10 +293,8 @@ void Manager::allocateWeights() {
     return;
 
   if (LAYER_V2) {
-    for (auto &l_w : weights_v2) {
-      for (auto &w : l_w) {
-        w->allocateVariable();
-      }
+    for (auto &w : weights_v2) {
+      w->allocateVariable();
     }
   } else {
     for (auto &l_w : weights) {
@@ -314,10 +310,8 @@ void Manager::allocateWeights() {
 
 void Manager::deallocateWeights() {
   if (LAYER_V2) {
-    for (auto &l_w : weights_v2) {
-      for (auto &w : l_w) {
-        w->deallocateVariable();
-      }
+    for (auto &w : weights_v2) {
+      w->deallocateVariable();
     }
   } else {
     for (auto &l_w : weights) {
@@ -337,10 +331,8 @@ void Manager::allocateGradients() {
     shared_grad.allocate();
 
   if (LAYER_V2) {
-    for (auto &l_w : weights_v2) {
-      for (auto &w : l_w) {
-        w->allocateGradient();
-      }
+    for (auto &w : weights_v2) {
+      w->allocateGradient();
     }
   } else {
     for (auto &l_w : weights) {
@@ -356,10 +348,8 @@ void Manager::deallocateGradients() {
   shared_grad.deallocate();
 
   if (LAYER_V2) {
-    for (auto &l_w : weights_v2) {
-      for (auto &w : l_w) {
-        w->deallocateGradient();
-      }
+    for (auto &w : weights_v2) {
+      w->deallocateGradient();
     }
   } else {
     for (auto &l_w : weights) {
@@ -376,13 +366,11 @@ void Manager::deallocateGradients() {
  */
 void Manager::initializeGradients() {
   if (LAYER_V2) {
-    for (auto &l_w : weights_v2) {
-      for (auto &w : l_w) {
-        w->initializeGradient();
-        // auto exec_order = tensor_exec_order[w.getName()];
-        // tensor_map(&w->getGradientRef(), requestMemory(w.getDim().size(),
-        //       std::get<1>(exec_order), std::get<2>(exec_order) + 1));
-      }
+    for (auto &w : weights_v2) {
+      w->initializeGradient();
+      // auto exec_order = tensor_exec_order[w.getName()];
+      // tensor_map(&w->getGradientRef(), requestMemory(w.getDim().size(),
+      //       std::get<1>(exec_order), std::get<2>(exec_order) + 1));
     }
   } else {
     if (total_weight_size == 0) {
@@ -520,20 +508,14 @@ void Manager::allocateInOuts() {
     shared_inout.allocate();
 
   if (LAYER_V2) {
-    for (auto &li : inputs_v2) {
-      for (auto &in : li) {
-        in->allocateVariable();
-      }
+    for (auto &in : inputs_v2) {
+      in->allocateVariable();
     }
-    for (auto &lo : outputs_v2) {
-      for (auto &out : lo) {
-        out->allocateVariable();
-      }
+    for (auto &out : outputs_v2) {
+      out->allocateVariable();
     }
-    for (auto &lt : tensors_v2) {
-      for (auto &t : lt) {
-        t->allocateVariable();
-      }
+    for (auto &t : tensors_v2) {
+      t->allocateVariable();
     }
   } else {
     for (auto &l_io : in_outs) {
@@ -548,20 +530,14 @@ void Manager::deallocateInOuts() {
   shared_inout.deallocate();
 
   if (LAYER_V2) {
-    for (auto &li : inputs_v2) {
-      for (auto &in : li) {
-        in->deallocateVariable();
-      }
+    for (auto &in : inputs_v2) {
+      in->deallocateVariable();
     }
-    for (auto &lo : outputs_v2) {
-      for (auto &out : lo) {
-        out->deallocateVariable();
-      }
+    for (auto &out : outputs_v2) {
+      out->deallocateVariable();
     }
-    for (auto &lt : tensors_v2) {
-      for (auto &t : lt) {
-        t->deallocateVariable();
-      }
+    for (auto &t : tensors_v2) {
+      t->deallocateVariable();
     }
   } else {
     for (auto &l_io : in_outs) {
@@ -578,20 +554,14 @@ void Manager::allocateDerivatives() {
     shared_deriv.allocate();
 
   if (LAYER_V2) {
-    for (auto &li : inputs_v2) {
-      for (auto &in : li) {
-        in->allocateGradient();
-      }
+    for (auto &in : inputs_v2) {
+      in->allocateGradient();
     }
-    for (auto &lo : outputs_v2) {
-      for (auto &out : lo) {
-        out->allocateGradient();
-      }
+    for (auto &out : outputs_v2) {
+      out->allocateGradient();
     }
-    for (auto &lt : tensors_v2) {
-      for (auto &t : lt) {
-        t->allocateGradient();
-      }
+    for (auto &t : tensors_v2) {
+      t->allocateGradient();
     }
   } else {
     for (auto &l_io : in_outs) {
@@ -606,20 +576,14 @@ void Manager::deallocateDerivatives() {
   shared_deriv.deallocate();
 
   if (LAYER_V2) {
-    for (auto &li : inputs_v2) {
-      for (auto &in : li) {
-        in->deallocateGradient();
-      }
+    for (auto &in : inputs_v2) {
+      in->deallocateGradient();
     }
-    for (auto &lo : outputs_v2) {
-      for (auto &out : lo) {
-        out->deallocateGradient();
-      }
+    for (auto &out : outputs_v2) {
+      out->deallocateGradient();
     }
-    for (auto &lt : tensors_v2) {
-      for (auto &t : lt) {
-        t->deallocateGradient();
-      }
+    for (auto &t : tensors_v2) {
+      t->deallocateGradient();
     }
   } else {
     for (auto &l_io : in_outs) {
@@ -688,25 +652,19 @@ void Manager::initializeTensorsInference() {
     }
   } else {
     // Inference Mode without optimizations
-    for (auto &layer_outs : outputs_v2) {
-      // TODO:For flatten layer, do not assign new memory
-
-      for (auto &outs : layer_outs) {
-        outs->initialize(Tensor(), Tensor(), false);
-      }
+    for (auto &outs : outputs_v2) {
+      outs->initialize(Tensor(), Tensor(), false);
     }
 
     // Inference Mode without optimizations
-    for (auto &layer_ts : tensors_v2) {
-      for (auto &ts : layer_ts) {
-        ts->initialize(Tensor(), Tensor(), false);
-      }
+    for (auto &ts : tensors_v2) {
+      ts->initialize(Tensor(), Tensor(), false);
     }
 
     // In inference mode, do not allocate the memory for the input of the first
     // layer. These is the first entry in the in_outs. Inference() will override
     // input tensors of the first layer
-    for ([[maybe_unused]] auto &layer_ins : inputs_v2) {
+    for ([[maybe_unused]] auto &ins : inputs_v2) {
       // as inputs_v2 are only set for input layers, this can be skipped all the
       // way
       continue;
@@ -750,24 +708,18 @@ void Manager::initializeTensorsTrain() {
     }
   } else {
     // Training Mode without optimizations
-    for (auto &layer_outs : outputs_v2) {
-      for (auto &outs : layer_outs) {
-        outs->initialize(Tensor(), Tensor(), true);
-      }
+    for (auto &outs : outputs_v2) {
+      outs->initialize(Tensor(), Tensor(), true);
     }
 
     // Training Mode without optimizations
-    for (auto &layer_ts : tensors_v2) {
-      for (auto &ts : layer_ts) {
-        ts->initialize(Tensor(), Tensor(), true);
-      }
+    for (auto &ts : tensors_v2) {
+      ts->initialize(Tensor(), Tensor(), true);
     }
 
     // Training Mode without optimizations
-    for (auto &layer_ins : inputs_v2) {
-      for (auto &ins : layer_ins) {
-        ins->initialize(Tensor(), Tensor(), true);
-      }
+    for (auto &ins : inputs_v2) {
+      ins->initialize(Tensor(), Tensor(), true);
     }
   }
 }
@@ -868,10 +820,8 @@ std::vector<Weight *> Manager::getWeights() {
   std::vector<Weight *> all_weights;
 
   if (LAYER_V2) {
-    for (auto &weight_v2 : weights_v2) {
-      for (auto &w : weight_v2) {
-        all_weights.push_back(w.get());
-      }
+    for (auto &w : weights_v2) {
+      all_weights.push_back(w.get());
     }
   } else {
     throw std::runtime_error("Using deprecated code. Upgrade to LayerV2");

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -432,13 +432,13 @@ private:
   // std::vector<std::unique_ptr<Var_Grad>> tensors; /**< inputs/outputs/tensors
   // for the network */
 
-  std::vector<std::vector<std::unique_ptr<Weight>>>
+  std::vector<std::unique_ptr<Weight>>
     weights_v2; /**< weights for the layers */
-  std::vector<std::vector<std::unique_ptr<Var_Grad>>>
+  std::vector<std::unique_ptr<Var_Grad>>
     inputs_v2; /**< inputs for the layers */
-  std::vector<std::vector<std::unique_ptr<Var_Grad>>>
+  std::vector<std::unique_ptr<Var_Grad>>
     outputs_v2; /**< outputs for the layers */
-  std::vector<std::vector<std::unique_ptr<Var_Grad>>>
+  std::vector<std::unique_ptr<Var_Grad>>
     tensors_v2; /**< extra tensors required by the layers */
 
   std::unordered_map<std::string, GraphNode::ExecutionOrder>
@@ -580,16 +580,16 @@ private:
    * @param layer_objs_list list to store the created tensors
    */
   template <typename T>
-  std::vector<T *> requestTensors(
-    const GraphNode &node, const std::vector<typename T::Spec> &tensors_spec,
-    std::vector<std::vector<std::unique_ptr<T>>> &layer_objs_list) {
+  std::vector<T *>
+  requestTensors(const GraphNode &node,
+                 const std::vector<typename T::Spec> &tensors_spec,
+                 std::vector<std::unique_ptr<T>> &layer_objs_list) {
     std::vector<T *> ret;
-    std::vector<std::unique_ptr<T>> tensors_list;
-    tensors_list.reserve(tensors_spec.size());
+    size_t current_size = layer_objs_list.size();
 
     for (auto const &ts : std::as_const(tensors_spec)) {
-      tensors_list.emplace_back(std::make_unique<T>(ts));
-      auto const &ts_name = tensors_list.back()->getName();
+      layer_objs_list.emplace_back(std::make_unique<T>(ts));
+      auto const &ts_name = layer_objs_list.back()->getName();
       /**
        * @todo maybe requesting tensor with same name should mean reusing the
        * tensor than giving the error
@@ -603,10 +603,9 @@ private:
       tensor_exec_order[ts_name] = node.getExecutionOrder();
     }
 
-    std::transform(tensors_list.begin(), tensors_list.end(),
-                   std::back_inserter(ret),
+    std::transform(layer_objs_list.begin() + current_size,
+                   layer_objs_list.end(), std::back_inserter(ret),
                    [](auto const &elem) { return elem.get(); });
-    layer_objs_list.emplace_back(std::move(tensors_list));
 
     return ret;
   }

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -88,8 +88,9 @@ static auto rng = [] {
   return rng;
 }();
 
-Tensor::Tensor(const TensorDim &d, bool alloc_now, Tensor::Initializer init) :
-  Tensor() {
+Tensor::Tensor(const TensorDim &d, bool alloc_now, Tensor::Initializer init,
+               std::string name_) :
+  Tensor(name_) {
   if (d.getDataLen() != 0) {
     dim = d;
     strides = d.computeStrides();
@@ -557,9 +558,12 @@ void Tensor::createSharedDataTensor(const Tensor &src, Tensor &dest,
 }
 
 Tensor Tensor::getSharedDataTensor(const TensorDim dim_, unsigned int offset,
-                                   bool reset_stride) const {
+                                   bool reset_stride,
+                                   const std::string &name_) const {
   Tensor ret = *this;
   ret.dim = dim_;
+  if (!name_.empty())
+    ret.name = name_;
 
   if (dim_.getDataLen() + offset > dim.getDataLen())
     throw std::invalid_argument(

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -73,11 +73,12 @@ public:
   /**
    * @brief     Basic Constructor of Tensor
    */
-  Tensor() :
+  Tensor(std::string name_ = "") :
     dim(TensorDim()),
     strides(dim.computeStrides()),
     is_contiguous(true),
     initializer(Initializer::NONE),
+    name(name_),
     data(nullptr),
     src_tensor() {}
 
@@ -85,9 +86,11 @@ public:
    * @brief     Constructor of Tensor with dimension, possibly lazily
    * @param d Tensor dim for this tensor
    * @param alloc_now If the memory of the tensor must be allocated
+   * @param init Initializer for the tensor
+   * @param name Name of the tensor
    */
   Tensor(const TensorDim &d, bool alloc_now,
-         Initializer init = Initializer::NONE);
+         Initializer init = Initializer::NONE, std::string name = "");
 
   /**
    * @brief     Constructor of Tensor with dimension/buf
@@ -211,6 +214,7 @@ public:
     std::swap(lhs.is_contiguous, rhs.is_contiguous);
     std::swap(lhs.initializer, rhs.initializer);
     std::swap(lhs.data, rhs.data);
+    std::swap(lhs.name, rhs.name);
   }
 
   /**
@@ -830,7 +834,8 @@ public:
    * tensor.
    */
   Tensor getSharedDataTensor(const TensorDim dim, unsigned int offset,
-                             bool reset_stride = true) const;
+                             bool reset_stride = true,
+                             const std::string &name_ = "") const;
 
   /**
    * @brief make this tensor share memory with given tensor
@@ -1016,6 +1021,20 @@ public:
     return (b * strides[0] + c * strides[1] + h * strides[2] + w * strides[3]);
   }
 
+  /**
+   * @brief   Get name of the tensor
+   *
+   * @return name of the tensor
+   */
+  void setName(const std::string &name_) { name = name_; }
+
+  /**
+   * @brief   Get name of the tensor
+   *
+   * @return name of the tensor
+   */
+  const std::string &getName() const { return name; }
+
   static constexpr float epsilon = 1e-5;
 
 private:
@@ -1024,6 +1043,7 @@ private:
   std::array<unsigned int, TensorDim::MAXDIM> strides;
   bool is_contiguous;
   Tensor::Initializer initializer;
+  std::string name; /**< name of the tensor */
 
   std::shared_ptr<float> data;
 

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -19,10 +19,8 @@
 namespace nntrainer {
 
 Var_Grad::Var_Grad(const TensorDim &dim, const Tensor::Initializer init,
-                   bool ng, bool alloc_now_, const std::string &name) :
-  dim(dim),
-  need_gradient(ng),
-  alloc_now(alloc_now_) {
+                   bool need_gradient, bool alloc_now,
+                   const std::string &name) {
   var = std::make_shared<Tensor>(dim, alloc_now, init, name);
 
   std::string grad_name = name + grad_suffix;
@@ -62,12 +60,11 @@ void Var_Grad::initializeGradient(const Tensor &preallocated) {
 
 void Var_Grad::initializeShared() { grad->makeSharedDataTensor(*var.get()); }
 
-void Var_Grad::needsGradient(bool ng) {
-  need_gradient = ng;
+void Var_Grad::needsGradient(bool need_gradient) {
   if (need_gradient && grad->empty()) {
-    bool alloc_now_ = var->isAllocated();
-    grad = std::make_shared<Tensor>(dim, alloc_now_, Tensor::Initializer::ZEROS,
-                                    grad->getName());
+    grad =
+      std::make_shared<Tensor>(var->getDim(), var->isAllocated(),
+                               Tensor::Initializer::ZEROS, grad->getName());
   }
 }
 

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -22,17 +22,19 @@ Var_Grad::Var_Grad(const TensorDim &dim, const Tensor::Initializer init,
                    bool ng, bool alloc_now_, const std::string &name) :
   dim(dim),
   need_gradient(ng),
-  alloc_now(alloc_now_),
-  name(name) {
-  var = std::make_shared<Tensor>(dim, alloc_now, init);
+  alloc_now(alloc_now_) {
+  var = std::make_shared<Tensor>(dim, alloc_now, init, name);
+
+  std::string grad_name = name + grad_suffix;
   if (need_gradient)
     /**
      * @todo gradient initializer should be none, and then they should be set
      * zero right before using by the user itself.
      */
-    grad = std::make_shared<Tensor>(dim, alloc_now, Tensor::Initializer::ZEROS);
+    grad = std::make_shared<Tensor>(dim, alloc_now, Tensor::Initializer::ZEROS,
+                                    grad_name);
   else
-    grad = std::make_shared<Tensor>();
+    grad = std::make_shared<Tensor>(grad_name);
 }
 
 void Var_Grad::initializeVariable(const Tensor &preallocated) {
@@ -64,8 +66,8 @@ void Var_Grad::needsGradient(bool ng) {
   need_gradient = ng;
   if (need_gradient && grad->empty()) {
     bool alloc_now_ = var->isAllocated();
-    grad =
-      std::make_shared<Tensor>(dim, alloc_now_, Tensor::Initializer::ZEROS);
+    grad = std::make_shared<Tensor>(dim, alloc_now_, Tensor::Initializer::ZEROS,
+                                    grad->getName());
   }
 }
 

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -85,14 +85,12 @@ public:
    */
   explicit Var_Grad(const Tensor &v, const Tensor &g,
                     const std::string &n = "") :
-    dim(v.getDim()),
-    var(std::make_shared<Tensor>(v.getSharedDataTensor(dim, 0, false, n))),
-    grad(std::make_shared<Tensor>(n + grad_suffix)),
-    need_gradient(!g.empty()),
-    alloc_now(v.isAllocated()) {
-    if (need_gradient)
+    var(
+      std::make_shared<Tensor>(v.getSharedDataTensor(v.getDim(), 0, false, n))),
+    grad(std::make_shared<Tensor>(n + grad_suffix)) {
+    if (!g.empty())
       grad = std::make_shared<Tensor>(
-        g.getSharedDataTensor(dim, 0, false, n + grad_suffix));
+        g.getSharedDataTensor(v.getDim(), 0, false, n + grad_suffix));
   }
 
   /**
@@ -165,7 +163,7 @@ public:
    *
    * @return TensorDim Dimension
    */
-  TensorDim getDim() const { return dim; }
+  TensorDim getDim() const { return var->getDim(); }
 
   /**
    * @brief Get if the Var_Grad is need_gradient
@@ -173,7 +171,7 @@ public:
    * @retval true if need_gradient
    * @retval false is not need_gradient
    */
-  bool needsGradient() const { return need_gradient; }
+  bool needsGradient() const { return hasGradient(); }
 
   /**
    * @brief set if the Var_Grad should need gradient
@@ -234,15 +232,15 @@ public:
    *
    * @note New dimension must maintain the shape of the variable
    */
-  void reset(const TensorDim &tdim, Tensor::Initializer init, bool ng) {
-    dim = tdim;
+  void reset(const TensorDim &dim, Tensor::Initializer init, bool ng) {
     if (!var->empty())
       var->reshape(dim);
     var->initialize(init);
 
-    if (!grad->empty())
+    if (ng && !grad->empty())
       grad->reshape(dim);
-    need_gradient = ng;
+    else
+      grad = std::make_shared<Tensor>(grad->getName());
     resetGradient();
   }
 
@@ -252,8 +250,6 @@ public:
    * @param batch batch size
    */
   void setBatchSize(unsigned int batch) {
-    dim.batch(batch);
-
     if (!var->empty())
       var->updateBatch(batch);
     if (!grad->empty())
@@ -343,16 +339,13 @@ public:
    * @note this is can return is the var_grad needs gradient but it not
    * empty
    */
-  bool hasGradient() const { return need_gradient && !grad->empty(); }
+  bool hasGradient() const { return !grad->empty(); }
 
   inline static const std::string grad_suffix = ":grad";
 
 protected:
-  TensorDim dim;                /**< dimension of the tensor */
   std::shared_ptr<Tensor> var;  /**< variable to be updated and used */
   std::shared_ptr<Tensor> grad; /**< gradient for the variable */
-  bool need_gradient;           /**< if this variable needs gradient */
-  bool alloc_now; /**< if the tensor should be allocated instantly */
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -33,7 +33,7 @@ Weight::Weight(const TensorDim &dim, const Tensor::Initializer init,
 void Weight::initializeGradient(const Tensor &preallocated) {
   // Use self variable to initialize itself
   Var_Grad::initializeGradient(preallocated);
-  if (alloc_now)
+  if (var->isAllocated())
     allocateOptimizerVariables();
 }
 


### PR DESCRIPTION
Note: number of commits for this PR = 3
This patch provides cleanup for VarGrad and Manager, and add name to Tensor:

1. Flatten the tensors (weights/inputs/outputs/tensors) list stored in the
manager. It was of the form vector<vector<>> to club the tensors
requested from a layer together. However, this is neither required now
nor is it sufficient. If required later, a mapping from node will be
created.

2. Move name as an identifier to the tensor.
This name has been mvoed from the Var_Grad object.
Var_Grad now does not contain name itself.
The semantics of name for Tensor currently follows from var-grad:
- empty name is allowed
- repititive names are allowed
Restrictions can and will be added over time.

3. This patch cleansup VarGrad implementation, and ends up removing all its
members except the variable and gradient tensors (fitting exactly to its
description).

Resolves nnstreamer#1485 
Resolves nnstreamer#1486
See Also  #1127

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
