### PR TITLE
[manager] Add execution-order and lifespan of tensors

### DIFF
--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -86,9 +86,9 @@ void BatchNormalizationLayer::finalize(InitLayerContext &context) {
     context.requestWeight(dim, bnparams_beta, WeightRegularizer::NONE, 1.0f,
                           context.getName() + ":beta", true);
 
-  wt_idx[BNParams::deviation] =
-    context.requestTensor(in_dim, context.getName() + ":deviation",
-                          Tensor::Initializer::NONE, false, ITERATION_LIFESPAN);
+  wt_idx[BNParams::deviation] = context.requestTensor(
+    in_dim, context.getName() + ":deviation", Tensor::Initializer::NONE, false,
+    TensorLifespan::ITERATION_LIFESPAN);
 }
 
 void BatchNormalizationLayer::setProperty(

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -340,10 +340,10 @@ void Conv2DLayer::finalize(InitLayerContext &context) {
   wt_idx[ConvParams::im2col_result] = context.requestTensor(
     calcIm2ColOutputDim(in_dim, dim, padding, stride, {1, 1}),
     context.getName() + ":im2col", Tensor::Initializer::NONE, false,
-    ITERATION_LIFESPAN);
+    TensorLifespan::ITERATION_LIFESPAN);
   wt_idx[ConvParams::col2im_result] = context.requestTensor(
     calcCol2ImOutputDim(out_dim, dim), context.getName() + ":col2im",
-    Tensor::Initializer::NONE, false, BACKWARD_FUNC_LIFESPAN);
+    Tensor::Initializer::NONE, false, TensorLifespan::BACKWARD_FUNC_LIFESPAN);
 }
 
 void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {

--- a/nntrainer/layers/dropout.cpp
+++ b/nntrainer/layers/dropout.cpp
@@ -26,9 +26,9 @@ void DropOutLayer::finalize(InitLayerContext &context) {
 
   mask_idx.reserve(input_dims.size());
   for (auto &t : input_dims) {
-    mask_idx.push_back(context.requestTensor(t, context.getName() + ":Mask",
-                                             Tensor::Initializer::NONE, false,
-                                             ITERATION_LIFESPAN));
+    mask_idx.push_back(context.requestTensor(
+      t, context.getName() + ":Mask", Tensor::Initializer::NONE, false,
+      TensorLifespan::ITERATION_LIFESPAN));
   }
 }
 

--- a/nntrainer/layers/gru.cpp
+++ b/nntrainer/layers/gru.cpp
@@ -101,7 +101,7 @@ void GRULayer::finalize(InitLayerContext &context) {
   if (dropout_rate > epsilon) {
     wt_idx[GRUParams::dropout_mask] = context.requestTensor(
       output_dim, "GRU:dropout_mask", Tensor::Initializer::NONE, false,
-      ITERATION_LIFESPAN);
+      TensorLifespan::ITERATION_LIFESPAN);
   }
 
   if (!return_sequences) {
@@ -139,21 +139,21 @@ void GRULayer::finalize(InitLayerContext &context) {
   TensorDim d = input_dim;
   d.width(unit);
 
-  wt_idx[GRUParams::hidden_state] =
-    context.requestTensor(d, context.getName() + ":hidden_state",
-                          Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
+  wt_idx[GRUParams::hidden_state] = context.requestTensor(
+    d, context.getName() + ":hidden_state", Tensor::Initializer::NONE, true,
+    TensorLifespan::ITERATION_LIFESPAN);
 
   d.width(unit * NUM_GATE);
-  wt_idx[GRUParams::zrg] =
-    context.requestTensor(d, context.getName() + ":zrg",
-                          Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
+  wt_idx[GRUParams::zrg] = context.requestTensor(
+    d, context.getName() + ":zrg", Tensor::Initializer::NONE, true,
+    TensorLifespan::ITERATION_LIFESPAN);
 
   TensorDim h_dim = TensorDim();
   h_dim.setTensorDim(3, unit);
   h_dim.batch(input_dim.batch());
   wt_idx[GRUParams::h_prev] = context.requestTensor(
     h_dim, context.getName() + ":h_prev", Tensor::Initializer::NONE, false,
-    FORWARD_FUNC_LIFESPAN);
+    TensorLifespan::FORWARD_FUNC_LIFESPAN);
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -175,7 +175,7 @@ public:
   requestTensor(const TensorDim &dim, const std::string &name,
                 const Tensor::Initializer init = Tensor::Initializer::NONE,
                 bool trainable = false,
-                TensorLifespan lifespan = ITERATION_LIFESPAN) {
+                TensorLifespan lifespan = TensorLifespan::ITERATION_LIFESPAN) {
     tensors_spec.emplace_back(dim, init, trainable, name, lifespan);
     return tensors_spec.size() - 1;
   }

--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -86,7 +86,7 @@ void LSTMLayer::finalize(InitLayerContext &context) {
   if (dropout_rate > epsilon) {
     wt_idx[LSTMParams::dropout_mask] = context.requestTensor(
       output_dim, context.getName() + ":dropout_mask",
-      Tensor::Initializer::NONE, false, ITERATION_LIFESPAN);
+      Tensor::Initializer::NONE, false, TensorLifespan::ITERATION_LIFESPAN);
   }
 
   if (!return_sequences) {
@@ -124,17 +124,17 @@ void LSTMLayer::finalize(InitLayerContext &context) {
   TensorDim d = input_dim;
   d.width(unit);
 
-  wt_idx[LSTMParams::hidden_state] =
-    context.requestTensor(d, context.getName() + ":hidden_state",
-                          Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
-  wt_idx[LSTMParams::mem_cell] =
-    context.requestTensor(d, context.getName() + ":mem_cell",
-                          Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
+  wt_idx[LSTMParams::hidden_state] = context.requestTensor(
+    d, context.getName() + ":hidden_state", Tensor::Initializer::NONE, true,
+    TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[LSTMParams::mem_cell] = context.requestTensor(
+    d, context.getName() + ":mem_cell", Tensor::Initializer::NONE, true,
+    TensorLifespan::ITERATION_LIFESPAN);
 
   d.width(unit * NUM_GATE);
-  wt_idx[LSTMParams::fgio] =
-    context.requestTensor(d, context.getName() + ":fgio",
-                          Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
+  wt_idx[LSTMParams::fgio] = context.requestTensor(
+    d, context.getName() + ":fgio", Tensor::Initializer::NONE, true,
+    TensorLifespan::ITERATION_LIFESPAN);
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -120,12 +120,12 @@ void Pooling2DLayer::finalize(InitLayerContext &context) {
   if (pooling_type == props::PoolingTypeInfo::Enum::global_max) {
     pool_helper_idx = context.requestTensor(
       in_dim, context.getName() + ":helper_idx", Tensor::Initializer::NONE,
-      false, ITERATION_LIFESPAN);
+      false, TensorLifespan::ITERATION_LIFESPAN);
     pool_helper_size.resize(in_dim.batch() * in_dim.channel());
   } else {
     pool_helper_idx = context.requestTensor(
       out_dim, context.getName() + ":helper_idx", Tensor::Initializer::NONE,
-      false, ITERATION_LIFESPAN);
+      false, TensorLifespan::ITERATION_LIFESPAN);
   }
 }
 

--- a/nntrainer/layers/rnn.cpp
+++ b/nntrainer/layers/rnn.cpp
@@ -69,7 +69,7 @@ void RNNLayer::finalize(InitLayerContext &context) {
   if (dropout_rate > epsilon) {
     wt_idx[RNNParams::dropout_mask] = context.requestTensor(
       output_dim, context.getName() + ":dropout_mask",
-      Tensor::Initializer::NONE, false, ITERATION_LIFESPAN);
+      Tensor::Initializer::NONE, false, TensorLifespan::ITERATION_LIFESPAN);
   }
 
   if (!return_sequences) {
@@ -108,9 +108,9 @@ void RNNLayer::finalize(InitLayerContext &context) {
   // TODO : We could control with something like #define test to save memory
   TensorDim d = input_dim;
   d.width(unit);
-  wt_idx[RNNParams::hidden_state] =
-    context.requestTensor(d, context.getName() + ":hidden_state",
-                          Tensor::Initializer::NONE, true, ITERATION_LIFESPAN);
+  wt_idx[RNNParams::hidden_state] = context.requestTensor(
+    d, context.getName() + ":hidden_state", Tensor::Initializer::NONE, true,
+    TensorLifespan::ITERATION_LIFESPAN);
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);

--- a/nntrainer/tensor/tensor_wrap_specs.h
+++ b/nntrainer/tensor/tensor_wrap_specs.h
@@ -34,19 +34,20 @@ enum class WeightRegularizer {
  * @brief define the lifespan of the given tensor to reduce peak memory
  *
  */
-enum TensorLifespan {
-  FORWARD_FUNC_LIFESPAN,  /**< tensor must not be reset before during the
+enum class TensorLifespan {
+  ZERO_LIFESPAN = 0b0, /**< tensor with no lifespan, will not be allocated */
+  FORWARD_FUNC_LIFESPAN = 0b01,  /**< tensor must not be reset before during the
                             forward function call, eg. temporary tensors
                             needed during forward operations */
-  BACKWARD_FUNC_LIFESPAN, /**< tensor must not be reset before during the
+  BACKWARD_FUNC_LIFESPAN = 0b10, /**< tensor must not be reset before during the
                             backward function call, eg. temporary tensors
                             needed during backward operations */
-  ITERATION_LIFESPAN,     /**< tensor must not be reset until the owning layer
-                            finishes its execution in the current iteration,
-                            eg. hidden memory/cells of RNN */
-  EPOCH_LIFESPAN,         /**< tensor must not be reset before the epoch ends */
-  MAX_LIFESPAN, /**< tensor must not be reset until the end of the model
-                  execution, eg. layer weights */
+  ITERATION_LIFESPAN = 0b11,     /**< tensor must not be reset until the owning
+                            layer     finishes its execution in the current
+                            iteration,     eg. hidden memory/cells of RNN */
+  EPOCH_LIFESPAN = 0b111, /**< tensor must not be reset before the epoch ends */
+  MAX_LIFESPAN = 0b1111,  /**< tensor must not be reset until the end of the
+                   model  execution, eg. layer weights */
 };
 
 /**

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -180,11 +180,18 @@ public:
   void needsGradient(bool ng);
 
   /**
-   * @brief Get the name of the Var_Grad
+   * @brief Get the name of the variable
    *
-   * @return std::string name
+   * @return std::string name of the variable
    */
   const std::string &getName() const { return var->getName(); }
+
+  /**
+   * @brief Get the name of the gradient
+   *
+   * @return std::string name of the gradient
+   */
+  const std::string &getGradientName() const { return grad->getName(); }
 
   /**
    * @brief Get the variable tensor

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -22,6 +22,7 @@
 
 #ifndef __UTIL_FUNC_H__
 #define __UTIL_FUNC_H__
+
 #ifdef __cplusplus
 
 #include <cstring>
@@ -30,6 +31,7 @@
 
 #include <nntrainer_error.h>
 #include <tensor.h>
+
 namespace nntrainer {
 
 #define NN_RETURN_STATUS()         \
@@ -237,6 +239,38 @@ std::vector<std::string> split(const std::string &s, const std::regex &reg);
  * @retval false if string is case-insensitive not equal
  */
 bool istrequal(const std::string &a, const std::string &b);
+
+/**
+ * @brief Perform INT_LOGICAL_AND operation on enum class value
+ *
+ * @param e1 enum value
+ * @param e2 enum value
+ *
+ * @return enum value after performing AND operation
+ */
+template <typename T, typename C = int>
+bool enum_class_logical_and(T e1, T e2) {
+  C i1 = static_cast<int>(e1);
+  C i2 = static_cast<int>(e2);
+
+  return (i1 & i2) != 0;
+}
+
+/**
+ * @brief Perform INT_OR operation on enum class value
+ *
+ * @param e1 enum value
+ * @param e2 enum value
+ *
+ * @return enum value after performing AND operation
+ */
+template <typename T, typename C = int> T enum_class_or(T e1, T e2) {
+  C i1 = static_cast<int>(e1);
+  C i2 = static_cast<int>(e2);
+
+  return static_cast<T>(i1 | i2);
+}
+
 } /* namespace nntrainer */
 
 #endif /* __cplusplus */

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -246,7 +246,7 @@ bool istrequal(const std::string &a, const std::string &b);
  * @param e1 enum value
  * @param e2 enum value
  *
- * @return enum value after performing AND operation
+ * @return enum value after performing logical AND operation
  */
 template <typename T, typename C = int>
 bool enum_class_logical_and(T e1, T e2) {
@@ -262,7 +262,7 @@ bool enum_class_logical_and(T e1, T e2) {
  * @param e1 enum value
  * @param e2 enum value
  *
- * @return enum value after performing AND operation
+ * @return enum value after performing OR operation
  */
 template <typename T, typename C = int> T enum_class_or(T e1, T e2) {
   C i1 = static_cast<int>(e1);


### PR DESCRIPTION
Note: number of commits for this PR = 2

This patch adds the execution order and lifespan of all the requested tensors in the manager.
- Create a lifetime and usage list for all the tensors which have been
requested by the manager in the form of weights/inputs/outputs/trainable
tensors.
A tensor name based map is used as each tensor has the name identifier.
Further, the restriction of the name to be unique is added for the
tensors which are requested by the manager.
TensorLifespan enum values are updated to be of the form of bit wise
enabling. This allows checking and upgrading lifespan of an existing
tensor.
- Add the constraint of the output tensors of a node with the input
tensors of the next nodes. This allows memory pool to understand the
manager that these two inputs/outputs must use the same tensor and
enables tensor sharing.
This is acheieved by requesting already creating tensors with the given
name.

See Also #1127 

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>