### PR TITLE
[manager] Use memory pool for weights

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -139,6 +139,8 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/var_grad.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/weight.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/tensor_dim.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/tensor/memory_pool.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/tensor/basic_planner.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/blas_interface.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/layer_node.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/layer_context.cpp \

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -475,6 +475,8 @@ private:
   std::unordered_map<std::string, int>
     name_map; /**< map from output name to its location */
 
+  MemoryPool pool; /**< memory pool for the tensors */
+
   /**< Weights of all the layer in the model to be managed */
   std::vector<std::vector<std::reference_wrapper<Weight>>> weights;
 
@@ -641,6 +643,16 @@ private:
    * @param lifespan The lifespan to be expanded to
    */
   inline void expandLifespan(const std::string &name, TensorLifespan lifespan);
+
+  /**
+   * @brief     Get validity for the given tensor
+   *
+   * @param name Name of the tensor
+   * @return validity for the given tensor
+   * @details the validity will be created using the lifespan and execution
+   * order
+   */
+  std::pair<unsigned int, unsigned int> getValidity(const std::string &name);
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1035,6 +1035,18 @@ public:
    */
   const std::string &getName() const { return name; }
 
+  /**
+   * @brief Set the memory buffer for the tensor
+   *
+   * @param buf the memory buffer
+   * @param init intialize the buffer
+   */
+  void setData(void *buf, bool init = false) {
+    data = std::shared_ptr<float>((float *)buf, [](void *) {});
+    if (init)
+      initialize();
+  }
+
   static constexpr float epsilon = 1e-5;
 
 private:


### PR DESCRIPTION
This patch updates the use of memory pool for the weights of the model.
Correspondingly a pool object is added to the manager.
The pool is allocated in the weights allocation.

See also #1127

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>