### PR TITLE
[Backbone/CAPI] Implement backbone layer creation

### DIFF
--- a/Applications/SimpleShot/task_runner.cpp
+++ b/Applications/SimpleShot/task_runner.cpp
@@ -129,7 +129,7 @@ std::unique_ptr<ml::train::Model> createModel(const std::string &backbone,
                                       {"batch_size=1", "epochs=1"});
 
   LayerHandle backbone_layer = ml::train::layer::BackboneTFLite(
-    {"name=backbone", "modelfile=" + getModelFilePath(backbone, app_path),
+    {"name=backbone", "model_path=" + getModelFilePath(backbone, app_path),
      "input_shape=32:32:3", "trainable=false"});
   model->addLayer(backbone_layer);
 

--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -33,35 +33,41 @@ namespace train {
  * @brief     Enumeration of layer type
  */
 enum LayerType {
-  LAYER_IN = ML_TRAIN_LAYER_TYPE_INPUT, /** Input Layer type */
-  LAYER_FC = ML_TRAIN_LAYER_TYPE_FC,    /** Fully Connected Layer type */
-  LAYER_BN = ML_TRAIN_LAYER_TYPE_BN,    /** Batch Normalization Layer type */
-  LAYER_CONV2D = ML_TRAIN_LAYER_TYPE_CONV2D, /** Convolution 2D Layer type */
-  LAYER_POOLING2D = ML_TRAIN_LAYER_TYPE_POOLING2D, /** Pooling 2D Layer type */
-  LAYER_FLATTEN = ML_TRAIN_LAYER_TYPE_FLATTEN,     /** Flatten Layer type */
+  LAYER_IN = ML_TRAIN_LAYER_TYPE_INPUT, /**< Input Layer type */
+  LAYER_FC = ML_TRAIN_LAYER_TYPE_FC,    /**< Fully Connected Layer type */
+  LAYER_BN = ML_TRAIN_LAYER_TYPE_BN,    /**< Batch Normalization Layer type */
+  LAYER_CONV2D = ML_TRAIN_LAYER_TYPE_CONV2D, /**< Convolution 2D Layer type */
+  LAYER_POOLING2D = ML_TRAIN_LAYER_TYPE_POOLING2D, /**< Pooling 2D Layer type */
+  LAYER_FLATTEN = ML_TRAIN_LAYER_TYPE_FLATTEN,     /**< Flatten Layer type */
   LAYER_ACTIVATION =
-    ML_TRAIN_LAYER_TYPE_ACTIVATION,              /** Activation Layer type */
-  LAYER_ADDITION = ML_TRAIN_LAYER_TYPE_ADDITION, /** Addition Layer type */
-  LAYER_CONCAT = ML_TRAIN_LAYER_TYPE_CONCAT,     /** Concat Layer type */
-  LAYER_MULTIOUT = ML_TRAIN_LAYER_TYPE_MULTIOUT, /** Multi Output Layer type */
-  LAYER_PREPROCESS_FLIP,            /** Preprocess flip Layer type */
-  LAYER_PREPROCESS_TRANSLATE,       /** Preprocess translate Layer type */
-  LAYER_BACKBONE_NNSTREAMER,        /** Backbone using NNStreamer */
-  LAYER_BACKBONE_TFLITE,            /** Backbone using TFLite */
-  LAYER_EMBEDDING,                  /** Embedding Layer type */
-  LAYER_RNN,                        /** RNN Layer type */
-  LAYER_LSTM,                       /** LSTM Layer type */
-  LAYER_SPLIT,                      /** Splite Layer type */
-  LAYER_GRU,                        /** GRU Layer type */
-  LAYER_TIME_DIST,                  /** Time Distributed Layer type */
-  LAYER_PERMUTE,                    /** Permute layer */
-  LAYER_DROPOUT,                    /** DropOut Layer type */
-  LAYER_LOSS_MSE = 500,             /** Mean Squared Error Loss Layer type */
-  LAYER_LOSS_CROSS_ENTROPY_SIGMOID, /** Cross Entropy with Sigmoid Loss Layer
+    ML_TRAIN_LAYER_TYPE_ACTIVATION,              /**< Activation Layer type */
+  LAYER_ADDITION = ML_TRAIN_LAYER_TYPE_ADDITION, /**< Addition Layer type */
+  LAYER_CONCAT = ML_TRAIN_LAYER_TYPE_CONCAT,     /**< Concat Layer type */
+  LAYER_MULTIOUT = ML_TRAIN_LAYER_TYPE_MULTIOUT, /**< Multi Output Layer type */
+  LAYER_EMBEDDING = ML_TRAIN_LAYER_TYPE_EMBEDDING, /**< Embedding Layer type */
+  LAYER_RNN = ML_TRAIN_LAYER_TYPE_RNN,             /**< RNN Layer type */
+  LAYER_LSTM = ML_TRAIN_LAYER_TYPE_LSTM,           /**< LSTM Layer type */
+  LAYER_SPLIT = ML_TRAIN_LAYER_TYPE_SPLIT,         /**< Splite Layer type */
+  LAYER_GRU = ML_TRAIN_LAYER_TYPE_GRU,             /**< GRU Layer type */
+  LAYER_PERMUTE = ML_TRAIN_LAYER_TYPE_PERMUTE,     /**< Permute layer */
+  LAYER_DROPOUT = ML_TRAIN_LAYER_TYPE_DROPOUT,     /**< DropOut Layer type */
+  LAYER_BACKBONE_NNSTREAMER =
+    ML_TRAIN_LAYER_TYPE_BACKBONE_NNSTREAMER, /**< Backbone using NNStreamer */
+  LAYER_CENTROID_KNN =
+    ML_TRAIN_LAYER_TYPE_CENTROID_KNN, /**< Centroid KNN Layer */
+  LAYER_TIME_DIST,                    /**< Time Distributed Layer type */
+  LAYER_PREPROCESS_FLIP =
+    ML_TRAIN_LAYER_TYPE_PREPROCESS_FLIP, /**< Preprocess flip Layer type */
+  LAYER_PREPROCESS_TRANSLATE =
+    ML_TRAIN_LAYER_TYPE_PREPROCESS_TRANSLATE, /**< Preprocess translate Layer
+                                                 type */
+  LAYER_BACKBONE_TFLITE,                      /**< Backbone using TFLite */
+  LAYER_LOSS_MSE = 500,             /**< Mean Squared Error Loss Layer type */
+  LAYER_LOSS_CROSS_ENTROPY_SIGMOID, /**< Cross Entropy with Sigmoid Loss Layer
                                        type */
-  LAYER_LOSS_CROSS_ENTROPY_SOFTMAX, /** Cross Entropy with Softmax Loss Layer
+  LAYER_LOSS_CROSS_ENTROPY_SOFTMAX, /**< Cross Entropy with Softmax Loss Layer
                                        type */
-  LAYER_UNKNOWN = ML_TRAIN_LAYER_TYPE_UNKNOWN /** Unknown */
+  LAYER_UNKNOWN = ML_TRAIN_LAYER_TYPE_UNKNOWN /**< Unknown */
 };
 
 /**

--- a/nntrainer/layers/nnstreamer_layer.h
+++ b/nntrainer/layers/nnstreamer_layer.h
@@ -19,7 +19,11 @@
 #include <nnstreamer-single.h>
 #include <nnstreamer.h>
 
+#include <tuple>
+
 namespace nntrainer {
+
+class PropsNNSModelPath;
 
 /**
  * @class   NNStreamerLayer
@@ -30,16 +34,7 @@ public:
   /**
    * @brief     Constructor of NNStreamer Layer
    */
-  NNStreamerLayer(std::string model = "") :
-    Layer(),
-    modelfile(model),
-    single(nullptr),
-    in_res(nullptr),
-    out_res(nullptr),
-    in_data_cont(nullptr),
-    out_data_cont(nullptr),
-    in_data(nullptr),
-    out_data(nullptr) {}
+  NNStreamerLayer();
 
   /**
    * @brief     Destructor of NNStreamer Layer
@@ -75,7 +70,7 @@ public:
   /**
    * @copydoc Layer::supportBackwarding()
    */
-  bool supportBackwarding() const { return false; }
+  bool supportBackwarding() const override { return false; }
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
@@ -86,7 +81,8 @@ public:
   inline static const std::string type = "backbone_nnstreamer";
 
 private:
-  std::string modelfile;
+  using PropsType = std::tuple<PropsNNSModelPath>;
+  std::unique_ptr<PropsType> nnstreamer_layer_props;
   ml_single_h single;
   ml_tensors_info_h in_res, out_res;
   ml_tensors_data_h in_data_cont, out_data_cont;
@@ -111,16 +107,6 @@ private:
    */
   static int nnst_info_to_tensor_dim(ml_tensors_info_h &out_res,
                                      TensorDim &dim);
-
-  /**
-   * @brief setProperty by type and value separated
-   * @param[in] type property type to be passed
-   * @param[in] value value to be passed
-   * @exception exception::not_supported     when property type is not valid for
-   * the particular layer
-   * @exception std::invalid_argument invalid argument
-   */
-  void setProperty(const std::string &type_str, const std::string &value);
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/tflite_layer.h
+++ b/nntrainer/layers/tflite_layer.h
@@ -23,6 +23,8 @@
 
 namespace nntrainer {
 
+class PropsTflModelPath;
+
 /**
  * @class   TfLiteLayer
  * @brief   Tensorflow Lite layer
@@ -32,16 +34,12 @@ public:
   /**
    * @brief     Constructor of NNStreamer Layer
    */
-  TfLiteLayer(std::string model = "") :
-    Layer(),
-    modelfile(model),
-    interpreter(nullptr),
-    model(nullptr) {}
+  TfLiteLayer();
 
   /**
    * @brief     Destructor of NNStreamer Layer
    */
-  ~TfLiteLayer() = default;
+  ~TfLiteLayer();
 
   /**
    * @copydoc Layer::finalize(InitLayerContext &context)
@@ -77,7 +75,8 @@ public:
   inline static const std::string type = "backbone_tflite";
 
 private:
-  std::string modelfile;
+  using PropsType = std::tuple<PropsTflModelPath>;
+  std::unique_ptr<PropsType> tfl_layer_props;
   std::unique_ptr<tflite::Interpreter> interpreter;
   std::unique_ptr<tflite::FlatBufferModel> model;
 


### PR DESCRIPTION
- [Backbone/CAPI] Implement backbone layer creation

```
**Changes proposed in this PR:**
- Connect enum to nnstreamer backbone
- Change `model_file` property to `model_path` for generality
- Add handling for when model_file property is loaded from interpretation

Resolves #1072

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Cc: Inki Dae <inki.dae@samsung.com>
Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```