### PR TITLE
[Trivial] layer client test was not running

### DIFF
--- a/Applications/Custom/LayerClient/jni/meson.build
+++ b/Applications/Custom/LayerClient/jni/meson.build
@@ -8,7 +8,7 @@ layer_client_sources = [
 
 run_command('cp', '-lr', res_path, nntr_app_resdir / 'LayerClient')
 
-e = executable('layer_client',
+exe = executable('layer_client',
   layer_client_sources,
   include_directories: layer_example_inc,
   dependencies: [app_utils_dep, iniparser_dep, nntrainer_dep, nntrainer_ccapi_dep],


### PR DESCRIPTION
- [Trivial] layer client test was not running

```
This patch changes test variable argument in order for layer client
tests to run

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```