### PR TITLE
[TensorPool] Added TensorPool as a pool of tensors

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -139,6 +139,8 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/var_grad.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/weight.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/tensor_dim.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/tensor/memory_pool.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/tensor/basic_planner.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/blas_interface.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/layer_node.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/layer_context.cpp \

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -475,6 +475,8 @@ private:
   std::unordered_map<std::string, int>
     name_map; /**< map from output name to its location */
 
+  MemoryPool pool; /**< memory pool for the tensors */
+
   /**< Weights of all the layer in the model to be managed */
   std::vector<std::vector<std::reference_wrapper<Weight>>> weights;
 
@@ -641,6 +643,16 @@ private:
    * @param lifespan The lifespan to be expanded to
    */
   inline void expandLifespan(const std::string &name, TensorLifespan lifespan);
+
+  /**
+   * @brief     Get validity for the given tensor
+   *
+   * @param name Name of the tensor
+   * @return validity for the given tensor
+   * @details the validity will be created using the lifespan and execution
+   * order
+   */
+  std::pair<unsigned int, unsigned int> getValidity(const std::string &name);
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -126,7 +126,7 @@ private:
    * @brief Calculate the minimum memory requirement for the given memory
    * requests
    *
-   * @returns the minimum memory requirement in bytes
+   * @return the minimum memory requirement in bytes
    *
    * @note This will be theoretical minimum memory requirement ensuring that the
    * memory usages at the same time do not overlap with their validity. This

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -7,7 +7,8 @@ tensor_sources = [
   'var_grad.cpp',
   'weight.cpp',
   'basic_planner.cpp',
-  'memory_pool.cpp'
+  'memory_pool.cpp',
+  'tensor_pool.cpp'
 ]
 
 tensor_headers = [

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1035,6 +1035,18 @@ public:
    */
   const std::string &getName() const { return name; }
 
+  /**
+   * @brief Set the memory buffer for the tensor
+   *
+   * @param buf the memory buffer
+   * @param init intialize the buffer
+   */
+  void setData(void *buf, bool init = false) {
+    data = std::shared_ptr<float>((float *)buf, [](void *) {});
+    if (init)
+      initialize();
+  }
+
   static constexpr float epsilon = 1e-5;
 
 private:

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   tensor_pool.cpp
+ * @date   19 Aug 2020
+ * @brief  This is TensorPool for all requested tensors
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ *
+ * @todo   add checks for request/updates that finalize is not done
+ * @todo   check before allocate that finalize is done
+ */
+
+#include <memory_pool.h>
+#include <tensor.h>
+#include <tensor_pool.h>
+#include <tensor_wrap_specs.h>
+#include <util_func.h>
+
+namespace nntrainer {
+
+/**
+ * @brief     Request tensor with the given spec
+ *
+ * @note returns empty tensor which will be filled when allocate is called.
+ * @note we assume that the caller checks if the exec_order and lifespan are
+ * compatible.
+ */
+Tensor *TensorPool::requestTensor(const TensorDim dim,
+                                  const std::vector<unsigned int> &exec_order,
+                                  TensorLifespan lifespan,
+                                  const std::string &name) {
+  if (pool.find(name) != pool.end())
+    throw std::invalid_argument("Cannot request tensor with same name");
+
+  if (dim.getDataLen() == 0)
+    throw std::invalid_argument("Cannot request tensor with size 0");
+
+  if (name.empty())
+    throw std::invalid_argument("Cannot request tensor with empty name");
+
+  pool[name] = {
+    std::make_unique<Tensor>(dim, false, Tensor::Initializer::NONE, name),
+    exec_order, lifespan, 0};
+
+  return pool[name].tensor.get();
+}
+
+/**
+ * @brief     Request tensor which has been already requested with the given
+ * spec
+ *
+ * @note returns empty tensor which will be filled when allocate is called.
+ * @note we assume that the caller checks if the exec_order and lifespan are
+ * compatible.
+ */
+Tensor *TensorPool::requestPrerequestedTensor(
+  const TensorDim dim, const std::vector<unsigned int> &exec_order,
+
+  TensorLifespan lifespan, const std::string &name) {
+  if (pool.find(name) == pool.end())
+    throw std::invalid_argument("Requested tensor not found");
+
+  auto &spec = pool[name];
+  if (spec.tensor->getDim() != dim)
+    throw std::invalid_argument("Request tensor dimension mismatch");
+
+  spec.exec_order.insert(spec.exec_order.end(), exec_order.begin(),
+                         exec_order.end());
+  spec.lifespan = enum_class_or<TensorLifespan>(spec.lifespan, lifespan);
+
+  return pool[name].tensor.get();
+}
+
+/**
+ * @brief finalize the requested tensors
+ *
+ * @details finalize the requested tensors, request memory for them and plan
+ * layout for their allocations.
+ */
+void TensorPool::finalize(const MemoryPlanner &planner,
+                          unsigned int start_order, unsigned int end_order) {
+  unsigned int bytes_requested = 0;
+  for (auto &entry : pool) {
+    auto &spec = entry.second;
+
+    if (spec.exec_order.empty())
+      continue;
+
+    /** 1. create the validity ranges for the all the requested tensors */
+    unsigned int validity_start =
+      *std::min_element(spec.exec_order.begin(), spec.exec_order.end());
+    unsigned int validity_end =
+      *std::max_element(spec.exec_order.begin(), spec.exec_order.end());
+
+    /**
+     * use lifespan to update the validity.
+     * if the validity is long term, the tensor must stay valid for the
+     * complete duration.
+     */
+    if (isTensorLongTerm(spec.lifespan)) {
+      validity_start = start_order;
+      validity_end = end_order;
+    }
+
+    /** 2. for each tensor request if it is in the provided range */
+    if (validity_end < start_order || validity_start > end_order)
+      continue;
+    validity_start = std::max(validity_start, start_order);
+    validity_end = std::max(validity_end, end_order);
+
+    /**
+     * 3. requestMemory for all the tensors and set their tokens
+     * @note +1 is to make the validity_end exlusive in the interval range
+     */
+    spec.token = mem_pool.requestMemory(spec.tensor->bytes(), validity_start,
+                                        validity_end + 1);
+    bytes_requested += spec.tensor->bytes();
+  }
+
+  /** 4. finalizeLayout for the memory pool. */
+  if (bytes_requested > 0)
+    mem_pool.planLayout(planner);
+}
+
+/**
+ * @brief Set the batch size for the inputs/outputs of the layers
+ */
+void TensorPool::setBatchSize(const std::string &name, unsigned int batch) {
+  if (pool.find(name) == pool.end())
+    throw std::invalid_argument("Requested tensor not found");
+
+  pool[name].tensor->updateBatch(batch);
+}
+
+/**
+ * @brief Allocate memory for all the managed tensors
+ */
+void TensorPool::allocate() {
+  mem_pool.allocate();
+
+  /** set the pointers using the token for all the tensors */
+  for (auto &entry : pool) {
+    auto &spec = entry.second;
+    spec.tensor->setData(mem_pool.getMemory(spec.token));
+  }
+}
+
+/**
+ * @brief Deallocate memory for all the managed tensors
+ */
+void TensorPool::deallocate() {
+  mem_pool.deallocate();
+
+  /** nullify the data pointers for the tensors */
+  for (auto &entry : pool) {
+    auto &spec = entry.second;
+    spec.tensor->setData(nullptr);
+  }
+}
+
+/**
+ * @brief     Expand the lifespan of the tensor with the given name
+ *
+ */
+void TensorPool::expand_lifespan(const std::string &name,
+                                 TensorLifespan lifespan) {
+  if (pool.find(name) == pool.end())
+    throw std::invalid_argument("Requested tensor not found");
+
+  auto &spec = pool[name];
+  spec.lifespan = enum_class_or<TensorLifespan>(spec.lifespan, lifespan);
+}
+
+/**
+ * @brief     Expand the execution order of the tensor with the given name
+ *
+ */
+void TensorPool::expand_lifespan(const std::string &name,
+                                 const std::vector<unsigned int> &exec_order) {
+  if (pool.find(name) == pool.end())
+    throw std::invalid_argument("Requested tensor not found");
+
+  auto &spec = pool[name];
+  spec.exec_order.insert(spec.exec_order.end(), exec_order.begin(),
+                         exec_order.end());
+}
+
+/**
+ * @brief     Check if the lifespan leads to long term valitidy
+ *
+ */
+bool TensorPool::isTensorLongTerm(const TensorLifespan &lifespan) {
+  switch (lifespan) {
+  case TensorLifespan::EPOCH_LIFESPAN:
+    [[fallthrough]];
+  case TensorLifespan::MAX_LIFESPAN:
+    return true;
+  case TensorLifespan::FORWARD_FUNC_LIFESPAN:
+    [[fallthrough]];
+  case TensorLifespan::BACKWARD_FUNC_LIFESPAN:
+    [[fallthrough]];
+  case TensorLifespan::ITERATION_LIFESPAN:
+    [[fallthrough]];
+  case TensorLifespan::ZERO_LIFESPAN:
+    [[fallthrough]];
+  default:
+    return false;
+  }
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   tensor_pool.h
+ * @date   18 Aug 2021
+ * @brief  This is TensorPool for all requested tensors
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ *
+ */
+
+#ifndef __TENSOR_POOL_H__
+#define __TENSOR_POOL_H__
+#ifdef __cplusplus
+
+#include <functional>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include <memory_pool.h>
+#include <tensor.h>
+#include <tensor_wrap_specs.h>
+
+namespace nntrainer {
+
+/**
+ * @class   TensorPool
+ * @brief   tensor pool of nntrainer
+ */
+class TensorPool {
+
+public:
+  /**
+   * @brief     Constructor of TensorPool
+   */
+  TensorPool() : mem_pool() {}
+
+  /**
+   * @brief     Destructor of TensorPool
+   */
+  ~TensorPool() = default;
+
+  /**
+   * @brief     Request tensor with the given spec
+   *
+   * @param dim Tensor dimensions
+   * @param exec_order The execution orders for this tensors
+   * @param lifespan Lifespan of this tensor
+   * @param name Name of this tensor
+   *
+   * @return ptr to the created tensor
+   *
+   * @note returns empty tensor which will be filled when allocate is called.
+   * @note we assume that the caller checks if the exec_order and lifespan are
+   * compatible.
+   */
+  Tensor *requestTensor(const TensorDim dim,
+                        const std::vector<unsigned int> &exec_order,
+                        TensorLifespan lifespan, const std::string &name);
+
+  /**
+   * @brief     Request tensor which has been already requested with the given
+   * spec
+   *
+   * @param dim Tensor dimensions
+   * @param exec_order The execution orders for this tensors
+   * @param lifespan Lifespan of this tensor
+   * @param name Name of this tensor
+   *
+   * @return ptr to the tensor
+   *
+   * @note returns empty tensor which will be filled when allocate is called.
+   * @note we assume that the caller checks if the exec_order and lifespan are
+   * compatible.
+   */
+  Tensor *requestPreallocatedTensor(const TensorDim dim,
+                                    const std::vector<unsigned int> &exec_order,
+
+                                    TensorLifespan lifespan,
+                                    const std::string &name);
+
+  /**
+   * @brief finalize the requested tensors
+   * @param planner planner to layout the tensor memories
+   * @param start_order start value for the order_exec (inclusive)
+   * @param end_order end value for the order_exec (inclusive)
+   *
+   * @details finalize the requested tensors, request memory for them and plan
+   * layout for their allocations.
+   */
+  void finalize(const MemoryPlanner &planner, unsigned int start_order,
+                unsigned int end_order);
+
+  /**
+   * @brief Set the batch size for the inputs/outputs of the layers
+   */
+  void setBatchSize(const std::string &name, unsigned int batch);
+
+  /**
+   * @brief Allocate memory for all the managed tensors
+   */
+  void allocate();
+
+  /**
+   * @brief Deallocate memory for all the managed tensors
+   */
+  void deallocate();
+
+  /**
+   * @brief     Expand the lifespan of the tensor with the given name
+   *
+   * @param name The name of the tensor
+   * @param lifespan The lifespan to be expanded to
+   */
+  void expand_lifespan(const std::string &name, TensorLifespan lifespan);
+
+  /**
+   * @brief     Expand the execution order of the tensor with the given name
+   *
+   * @param name The name of the tensor
+   * @param exec_order The execution orders
+   */
+  void expand_lifespan(const std::string &name,
+                       const std::vector<unsigned int> &exec_order);
+
+private:
+  struct requestSpec {
+    std::unique_ptr<Tensor> tensor;       /**< tensor object itself */
+    std::vector<unsigned int> exec_order; /**< tensor exec order list */
+    TensorLifespan lifespan;              /**< tensor lifespan */
+    unsigned int token;                   /**< tensor memory token */
+  };
+
+  std::unordered_map<std::string, requestSpec>
+    pool;              /**< list of requested tensors */
+  MemoryPool mem_pool; /**< memory pool for the tensors */
+};
+
+} // namespace nntrainer
+
+#endif /* __cplusplus */
+#endif /* __TENSOR_POOL_H__ */

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -76,7 +76,7 @@ public:
    * @note we assume that the caller checks if the exec_order and lifespan are
    * compatible.
    */
-  Tensor *requestPreallocatedTensor(const TensorDim dim,
+  Tensor *requestPrerequestedTensor(const TensorDim dim,
                                     const std::vector<unsigned int> &exec_order,
 
                                     TensorLifespan lifespan,
@@ -126,7 +126,24 @@ public:
   void expand_lifespan(const std::string &name,
                        const std::vector<unsigned int> &exec_order);
 
+  /**
+   * @brief Get the maximum real memory requirement
+   *
+   * @return The real memory requirement with this strategy in bytes
+   */
+  size_t size() { return mem_pool.size(); }
+
+  /**
+   * @brief Get the minimum theoretical memory requirement
+   *
+   * @return The theoretical memory requirement with this strategy in bytes
+   */
+  size_t minMemoryRequirement() { return mem_pool.minMemoryRequirement(); }
+
 private:
+  /**
+   * @brief Spec for storing each request of tensor from tensor pool
+   */
   struct requestSpec {
     std::unique_ptr<Tensor> tensor;       /**< tensor object itself */
     std::vector<unsigned int> exec_order; /**< tensor exec order list */
@@ -137,6 +154,15 @@ private:
   std::unordered_map<std::string, requestSpec>
     pool;              /**< list of requested tensors */
   MemoryPool mem_pool; /**< memory pool for the tensors */
+
+  /**
+   * @brief     Check if the lifespan leads to long term valitidy
+   *
+   * @param lifespan Lifespan for the tensor
+   *
+   * @return true if the tensor should be valid for long term, else false
+   */
+  bool isTensorLongTerm(const TensorLifespan &lifespan);
 };
 
 } // namespace nntrainer

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -36,7 +36,8 @@ test_target = [
   'unittest_nntrainer_graph',
   'unittest_nntrainer_appcontext',
   'unittest_base_properties',
-  'unittest_common_properties'
+  'unittest_common_properties',
+  'unittest_nntrainer_tensor_pool'
 ]
 
 if get_option('enable-profile')

--- a/test/unittest/unittest_nntrainer_tensor_pool.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool.cpp
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_nntrainer_tensor_pool.cpp
+ * @date 20 August 2021
+ * @brief Tensor Pool Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <basic_planner.h>
+#include <tensor_pool.h>
+
+constexpr unsigned int MEM_BYTES = 128;
+constexpr unsigned int MEM_QUANT = 100;
+constexpr unsigned int INTERVAL_SIZE = 5;
+
+/**
+ * @brief creation and destruction
+ */
+TEST(TensorPool, create_destroy) { EXPECT_NO_THROW(nntrainer::TensorPool()); }
+
+/**
+ * @brief request empty tensor
+ */
+TEST(TensorPool, request_mem_01_n) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_THROW(pool.requestTensor(nntrainer::TensorDim(), {},
+                                  nntrainer::TensorLifespan::ZERO_LIFESPAN,
+                                  "abc"),
+               std::invalid_argument);
+}
+
+/**
+ * @brief request empty name
+ */
+TEST(TensorPool, request_mem_02_n) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_THROW(pool.requestTensor(nntrainer::TensorDim({1}), {},
+                                  nntrainer::TensorLifespan::ZERO_LIFESPAN, ""),
+               std::invalid_argument);
+}
+
+/**
+ * @brief request tensor
+ */
+TEST(TensorPool, request_mem_03_p) {
+  nntrainer::TensorPool pool;
+  nntrainer::Tensor *t;
+
+  EXPECT_NO_THROW(
+    t = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                           nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc"));
+  EXPECT_NE(t, nullptr);
+  EXPECT_FALSE(t->isAllocated());
+}
+
+/**
+ * @brief request already allocated tensor
+ */
+TEST(TensorPool, request_mem_04_n) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_NO_THROW(pool.requestTensor(nntrainer::TensorDim({1}), {},
+                                     nntrainer::TensorLifespan::ZERO_LIFESPAN,
+                                     "abc"));
+
+  EXPECT_THROW(pool.requestTensor(nntrainer::TensorDim({2}), {},
+                                  nntrainer::TensorLifespan::ZERO_LIFESPAN,
+                                  "abc"),
+               std::invalid_argument);
+}
+
+/**
+ * @brief request already allocated tensor
+ */
+TEST(TensorPool, request_mem_05_p) {
+  nntrainer::TensorPool pool;
+  nntrainer::Tensor *t1, *t2;
+
+  EXPECT_NO_THROW(
+    t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                            nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc"));
+  EXPECT_NE(t1, nullptr);
+  EXPECT_FALSE(t1->isAllocated());
+
+  EXPECT_NO_THROW(t2 = pool.requestPrerequestedTensor(
+                    nntrainer::TensorDim({1}), {},
+                    nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc"));
+  EXPECT_NE(t2, nullptr);
+  EXPECT_FALSE(t2->isAllocated());
+
+  EXPECT_EQ(t1, t2);
+}
+
+/**
+ * @brief request already allocated tensor
+ */
+TEST(TensorPool, request_mem_06_n) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_NO_THROW(pool.requestTensor(nntrainer::TensorDim({1}), {},
+                                     nntrainer::TensorLifespan::ZERO_LIFESPAN,
+                                     "abc"));
+
+  EXPECT_THROW(pool.requestPrerequestedTensor(
+                 nntrainer::TensorDim({2}), {},
+                 nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc"),
+               std::invalid_argument);
+}
+
+/**
+ * @brief request already allocated tensor
+ */
+TEST(TensorPool, request_mem_07_n) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_NO_THROW(pool.requestTensor(nntrainer::TensorDim({1}), {},
+                                     nntrainer::TensorLifespan::ZERO_LIFESPAN,
+                                     "abc"));
+
+  EXPECT_THROW(pool.requestPrerequestedTensor(
+                 nntrainer::TensorDim({1}), {},
+                 nntrainer::TensorLifespan::ZERO_LIFESPAN, "not_exist"),
+               std::invalid_argument);
+}
+
+/**
+ * @brief request already allocated tensor
+ */
+TEST(TensorPool, request_mem_08_p) {
+  nntrainer::TensorPool pool;
+  nntrainer::Tensor *t1, *t2;
+
+  EXPECT_NO_THROW(
+    t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                            nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc"));
+  EXPECT_NE(t1, nullptr);
+  EXPECT_FALSE(t1->isAllocated());
+
+  EXPECT_NO_THROW(t2 = pool.requestPrerequestedTensor(
+                    nntrainer::TensorDim({1}), {},
+                    nntrainer::TensorLifespan::MAX_LIFESPAN, "abc"));
+  EXPECT_NE(t2, nullptr);
+  EXPECT_FALSE(t2->isAllocated());
+
+  EXPECT_EQ(t1, t2);
+
+  EXPECT_NO_THROW(t2 = pool.requestPrerequestedTensor(
+                    nntrainer::TensorDim({1}), {},
+                    nntrainer::TensorLifespan::MAX_LIFESPAN, "abc"));
+  EXPECT_NE(t2, nullptr);
+  EXPECT_FALSE(t2->isAllocated());
+
+  EXPECT_EQ(t1, t2);
+}
+
+/**
+ * @brief set batch
+ */
+TEST(TensorPool, set_batch_01_p) {
+  nntrainer::TensorPool pool;
+  nntrainer::Tensor *t1;
+
+  EXPECT_NO_THROW(
+    t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                            nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc"));
+  EXPECT_NE(t1, nullptr);
+  EXPECT_FALSE(t1->isAllocated());
+
+  EXPECT_EQ(t1->batch(), 1);
+  EXPECT_NO_THROW(pool.setBatchSize("abc", 10));
+  EXPECT_EQ(t1->batch(), 10);
+}
+
+/**
+ * @brief set batch
+ */
+TEST(TensorPool, set_batch_02_n) {
+  nntrainer::TensorPool pool;
+  nntrainer::Tensor *t1;
+
+  EXPECT_NO_THROW(
+    t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                            nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc"));
+  EXPECT_NE(t1, nullptr);
+  EXPECT_FALSE(t1->isAllocated());
+
+  EXPECT_THROW(pool.setBatchSize("not_exist", 10), std::invalid_argument);
+  EXPECT_EQ(t1->batch(), 1);
+}
+
+/**
+ * @brief zero size pool as no usage
+ */
+TEST(TensorPool, finalize_01_p) {
+  nntrainer::TensorPool pool;
+  nntrainer::Tensor *t1, *t2;
+
+  EXPECT_NO_THROW(
+    t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                            nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc1"));
+  EXPECT_NE(t1, nullptr);
+  EXPECT_FALSE(t1->isAllocated());
+
+  EXPECT_NO_THROW(
+    t2 = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                            nntrainer::TensorLifespan::MAX_LIFESPAN, "abc2"));
+  EXPECT_NE(t2, nullptr);
+  EXPECT_FALSE(t2->isAllocated());
+
+  EXPECT_NE(t1, t2);
+
+  EXPECT_NO_THROW(pool.finalize(nntrainer::BasicPlanner(), 0, 2));
+  EXPECT_EQ(pool.minMemoryRequirement(), 0);
+
+  EXPECT_FALSE(t1->isAllocated());
+  EXPECT_FALSE(t2->isAllocated());
+}
+
+/**
+ * @brief max lifespan tensors
+ */
+TEST(TensorPool, finalize_02_p) {
+  nntrainer::TensorPool pool;
+  nntrainer::Tensor *t1, *t2;
+
+  EXPECT_NO_THROW(
+    t1 = pool.requestTensor(nntrainer::TensorDim({1}), {0},
+                            nntrainer::TensorLifespan::MAX_LIFESPAN, "abc1"));
+  EXPECT_NE(t1, nullptr);
+
+  EXPECT_FALSE(t1->isAllocated());
+
+  EXPECT_NO_THROW(
+    t2 = pool.requestTensor(nntrainer::TensorDim({1}), {1},
+                            nntrainer::TensorLifespan::MAX_LIFESPAN, "abc2"));
+  EXPECT_NE(t2, nullptr);
+
+  EXPECT_FALSE(t2->isAllocated());
+
+  EXPECT_NE(t1, t2);
+
+  EXPECT_NO_THROW(pool.finalize(nntrainer::BasicPlanner(), 0, 2));
+  EXPECT_EQ(pool.minMemoryRequirement(), t1->bytes() + t2->bytes());
+
+  EXPECT_FALSE(t1->isAllocated());
+  EXPECT_FALSE(t2->isAllocated());
+}
+
+/**
+ * @brief max lifespan tensors
+ */
+TEST(TensorPool, finalize_03_p) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_NO_THROW(pool.finalize(nntrainer::BasicPlanner(), 0, 2));
+}
+
+/**
+ * @brief allocate
+ */
+TEST(TensorPool, allocate_deallocate_01_p) {
+  nntrainer::TensorPool pool;
+  nntrainer::Tensor *t1, *t2;
+
+  EXPECT_NO_THROW(
+    t1 = pool.requestTensor(nntrainer::TensorDim({1}), {0},
+                            nntrainer::TensorLifespan::MAX_LIFESPAN, "abc1"));
+  EXPECT_NE(t1, nullptr);
+  EXPECT_FALSE(t1->isAllocated());
+
+  EXPECT_NO_THROW(
+    t2 = pool.requestTensor(nntrainer::TensorDim({1}), {1},
+                            nntrainer::TensorLifespan::MAX_LIFESPAN, "abc2"));
+  EXPECT_NE(t2, nullptr);
+  EXPECT_FALSE(t2->isAllocated());
+
+  EXPECT_NE(t1, t2);
+
+  EXPECT_NO_THROW(pool.finalize(nntrainer::BasicPlanner(), 0, 2));
+
+  EXPECT_NO_THROW(pool.allocate());
+  EXPECT_TRUE(t1->isAllocated());
+  EXPECT_TRUE(t2->isAllocated());
+
+  EXPECT_NO_THROW(pool.deallocate());
+  EXPECT_FALSE(t1->isAllocated());
+  EXPECT_FALSE(t2->isAllocated());
+}
+
+/**
+ * @brief allocate
+ */
+TEST(TensorPool, allocate_deallocate_02_n) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_THROW(pool.allocate(), std::runtime_error);
+
+  EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief validate memory full overlap
+ */
+TEST(TensorPool, validate_memory) {
+  nntrainer::TensorPool pool;
+  nntrainer::Tensor *t1, *t2;
+
+  EXPECT_NO_THROW(
+    t1 = pool.requestTensor(nntrainer::TensorDim({100}), {0},
+                            nntrainer::TensorLifespan::MAX_LIFESPAN, "abc1"));
+
+  EXPECT_NO_THROW(
+    t2 = pool.requestTensor(nntrainer::TensorDim({100}), {1},
+                            nntrainer::TensorLifespan::MAX_LIFESPAN, "abc2"));
+
+  EXPECT_NO_THROW(pool.finalize(nntrainer::BasicPlanner(), 0, 2));
+  EXPECT_NO_THROW(pool.allocate());
+
+  nntrainer::Tensor g1 = nntrainer::Tensor(nntrainer::TensorDim({100}));
+  g1.setRandNormal();
+  nntrainer::Tensor g2 = nntrainer::Tensor(nntrainer::TensorDim({100}));
+  g2.setRandNormal();
+
+  t1->copy(g1);
+  t2->copy(g2);
+
+  EXPECT_EQ(*t1, g1);
+  EXPECT_EQ(*t2, g2);
+
+  EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Failed to init gtest\n";
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Failed to run test.\n";
+  }
+
+  return result;
+}


### PR DESCRIPTION
- This patch introduces TensorPool which manages the list of all the
tensors with their execution orders and lifespan.
The conversion of lifespan and execution orders to the validity will be
done by the TensorPool.
TensorPool forms the middle ground between memory pool and manager for
easier maintainance.

- Added tensor pool implementation with unittests.
Tensorpool provides the interface where all the requested tensors are
managed at one places ensuring the uniqueness of name with their
lifespan and execution orders.
Corresponding unittests checking the working is added.

This patch aims to reduce the work and data structures from the manager and shift the workload to TensorPool.

Merged already approved #1492 in this PR.

See Also #1127

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>