### PR TITLE
[unittest] backbone property name update

### DIFF
--- a/test/unittest/layers/unittest_layers_nnstreamer.cpp
+++ b/test/unittest/layers/unittest_layers_nnstreamer.cpp
@@ -19,7 +19,7 @@
 auto semantic_nnstreamer = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::NNStreamerLayer>,
   nntrainer::NNStreamerLayer::type,
-  {"modelfile=../test/test_models/models/add.tflite"}, 0, false);
+  {"model_path=../test/test_models/models/add.tflite"}, 0, false);
 
 INSTANTIATE_TEST_CASE_P(NNStreamer, LayerSemantics,
                         ::testing::Values(semantic_nnstreamer));

--- a/test/unittest/layers/unittest_layers_tflite.cpp
+++ b/test/unittest/layers/unittest_layers_tflite.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_tflite = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::TfLiteLayer>, nntrainer::TfLiteLayer::type,
-  {"modelfile=../test/test_models/models/add.tflite"}, 0, false);
+  {"model_path=../test/test_models/models/add.tflite"}, 0, false);
 
 INSTANTIATE_TEST_CASE_P(TfLite, LayerSemantics,
                         ::testing::Values(semantic_tflite));


### PR DESCRIPTION
Update backbone property name for the layers unittests.
This patch fixes failing unittests for main.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>