### PR TITLE
[Manager] Manager use TensorPool for Weights

### DIFF
--- a/Applications/VGG/res/vgg_small.ini
+++ b/Applications/VGG/res/vgg_small.ini
@@ -20,7 +20,7 @@ Learning_rate = 1e-2 	# Learning Rate
 beta1 = 0.9 		# beta 1 for adam
 beta2 = 0.999	# beta 2 for adam
 epsilon = 1e-7	# epsilon for adam
-decay_step = 10000
+decay_steps = 10000
 decay_rate = 0.96
 
 # Layer Section : Name

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -139,6 +139,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/var_grad.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/weight.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/tensor_dim.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/tensor/tensor_pool.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/memory_pool.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/basic_planner.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/blas_interface.cpp \

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -422,6 +422,9 @@ int NetworkGraph::realizeGraph() {
 }
 
 void NetworkGraph::setBatchSize(unsigned int batch_size) {
+  if (!input_list.empty() and input_list[0]->getDim().batch() == batch_size)
+    return;
+
   this->batch_size = batch_size;
   auto allocated = tensor_manager->isAllocated();
 

--- a/nntrainer/layers/acti_func.cpp
+++ b/nntrainer/layers/acti_func.cpp
@@ -137,7 +137,7 @@ Tensor &ActiFunc::run_prime_fn(Tensor &in, Tensor &ret, Tensor const &deriv) {
 }
 
 bool ActiFunc::supportInPlace() const {
-  bool support_in_place = true;
+  bool support_in_place = in_place;
   if (activation_type == ActivationType::ACT_SOFTMAX)
     support_in_place = false;
 

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -181,12 +181,35 @@ Tensor &RunLayerContext::getTensor(unsigned int idx) {
 }
 
 /**
+ * @brief Get the Tensor object
+ *
+ * @param idx Identifier of the tensor
+ * @return Tensor& Reference to the tensor
+ */
+const Tensor &RunLayerContext::getTensor(unsigned int idx) const {
+  return tensors[idx]->getVariableRef();
+}
+
+/**
  * @brief Get the Tensor Grad object
  *
  * @param idx Identifier of the tensor
  * @return Tensor& Reference to the tensor grad tensor
  */
 Tensor &RunLayerContext::getTensorGrad(unsigned int idx) {
+  if (!tensors[idx]->hasGradient())
+    throw std::invalid_argument(
+      "Requesting gradient for a non-trainable tensor.");
+  return tensors[idx]->getGradientRef();
+}
+
+/**
+ * @brief Get the Tensor Grad object
+ *
+ * @param idx Identifier of the tensor
+ * @return Tensor& Reference to the tensor grad tensor
+ */
+const Tensor &RunLayerContext::getTensorGrad(unsigned int idx) const {
   if (!tensors[idx]->hasGradient())
     throw std::invalid_argument(
       "Requesting gradient for a non-trainable tensor.");

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -429,12 +429,28 @@ public:
   Tensor &getTensor(unsigned int idx);
 
   /**
+   * @brief Get the Tensor object
+   *
+   * @param idx Identifier of the tensor
+   * @return Tensor& Reference to the tensor
+   */
+  const Tensor &getTensor(unsigned int idx) const;
+
+  /**
    * @brief Get the Tensor Grad object
    *
    * @param idx Identifier of the tensor
    * @return Tensor& Reference to the tensor grad tensor
    */
   Tensor &getTensorGrad(unsigned int idx);
+
+  /**
+   * @brief Get the Tensor Grad object
+   *
+   * @param idx Identifier of the tensor
+   * @return Tensor& Reference to the tensor grad tensor
+   */
+  const Tensor &getTensorGrad(unsigned int idx) const;
 
   /**
    * @brief check if the tensor has gradient

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -561,6 +561,18 @@ public:
   }
 
   /**
+   * @brief   check if run layer context is available
+   *
+   * @retval  bool true if context is available else false
+   */
+  bool isRunContextAvailable() const {
+    if (!run_context)
+      return false;
+
+    return true;
+  }
+
+  /**
    * @brief Set the Run Context object with given tensor packs
    *
    * @param weights weights

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -561,11 +561,11 @@ public:
   }
 
   /**
-   * @brief   check if run layer context is available
+   * @brief   check if layer is finalized
    *
-   * @retval  bool true if context is available else false
+   * @retval  bool true if the layer is finalized else false
    */
-  bool isRunContextAvailable() const {
+  bool isFinalized() const {
     if (!run_context)
       return false;
 

--- a/nntrainer/layers/loss/cross_entropy_sigmoid_loss_layer.cpp
+++ b/nntrainer/layers/loss/cross_entropy_sigmoid_loss_layer.cpp
@@ -26,8 +26,7 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 void CrossEntropySigmoidLossLayer::forwarding(RunLayerContext &context,
                                               bool training) {
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
-  // TODO: try Tensor & - it should work
-  Tensor y = context.getInput(SINGLE_INOUT_IDX);
+  Tensor &y = context.getInput(SINGLE_INOUT_IDX);
 
   // fill the output
   hidden_ = y.apply(ActiFunc::sigmoid, hidden_);

--- a/nntrainer/layers/loss/cross_entropy_softmax_loss_layer.cpp
+++ b/nntrainer/layers/loss/cross_entropy_softmax_loss_layer.cpp
@@ -26,8 +26,7 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 void CrossEntropySoftmaxLossLayer::forwarding(RunLayerContext &context,
                                               bool training) {
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
-  // TODO: try Tensor & - it should work
-  Tensor y = context.getInput(SINGLE_INOUT_IDX);
+  Tensor &y = context.getInput(SINGLE_INOUT_IDX);
 
   // fill the output
   hidden_ = y.apply(ActiFunc::softmax, hidden_);

--- a/nntrainer/layers/loss/mse_loss_layer.cpp
+++ b/nntrainer/layers/loss/mse_loss_layer.cpp
@@ -20,8 +20,7 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 
 void MSELossLayer::forwarding(RunLayerContext &context, bool training) {
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
-  // TODO: try Tensor & - it should work
-  Tensor y = context.getInput(SINGLE_INOUT_IDX);
+  Tensor &y = context.getInput(SINGLE_INOUT_IDX);
   Tensor l;
 
   // fill the output

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -42,7 +42,10 @@ static constexpr bool LAYER_V2 = true;
 
 namespace nntrainer {
 MMapedMemory::MMapedMemory(size_t size, bool allocate_fd_) :
-  fd(-1), buf(nullptr), buf_size(0), allocate_fd(allocate_fd_) {
+  fd(-1),
+  buf(nullptr),
+  buf_size(0),
+  allocate_fd(allocate_fd_) {
 
 #ifndef __ANDROID__
   if (allocate_fd) {
@@ -503,9 +506,6 @@ void Manager::allocateInOuts() {
     for (auto &out : outputs_v2) {
       out->allocateVariable();
     }
-    // for (auto &t : tensors_v2) {
-    //   t->allocateVariable();
-    // }
   } else {
     for (auto &l_io : in_outs) {
       for (auto &io : l_io) {

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -407,7 +407,7 @@ public:
    * @note this only works for tensors_v2 for now
    */
   void setBatchSize(const std::string &name, unsigned int batch) {
-    tensors_v2.at(name_map.at(name))->setBatchSize(batch);
+    tensor_pool.setBatchSize(name, batch);
   }
 
   /**

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -26,6 +26,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <basic_planner.h>
 #include <graph_node.h>
 #include <tensor_pool.h>
 #include <var_grad.h>
@@ -366,6 +367,11 @@ public:
    */
   void initializeTensors(bool training);
 
+  /**
+   * @brief   Check if the manager has allocated tensors
+   *
+   * @return true if tensors allocated, else false
+   */
   bool isAllocated() const { return tensors_allocated; }
 
   /**
@@ -412,11 +418,15 @@ public:
       allocateWeights();
 
     if (!tensors_allocated) {
+      tensor_pool.finalize(BasicPlanner(), 0, max_exec_order);
       if (model_training)
         allocateGradients();
       allocateInOuts();
       if (model_training)
         allocateDerivatives();
+
+      if (tensor_pool.minMemoryRequirement() > 0)
+        tensor_pool.allocate();
       tensors_allocated = true;
     }
   }
@@ -435,6 +445,7 @@ public:
       if (model_training)
         deallocateDerivatives();
 
+      tensor_pool.deallocate();
       tensors_allocated = false;
     }
   }

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -41,7 +41,7 @@ unsigned int MemoryPool::requestMemory(size_t bytes, unsigned int start_time,
   /** invalidate min_pool_size if already there */
   min_pool_size = 0;
 
-  return memory_size.size() - 1;
+  return memory_size.size();
 }
 
 /**
@@ -99,7 +99,7 @@ void *MemoryPool::getMemory(unsigned int idx) {
   if (mem_pool == nullptr)
     throw std::invalid_argument("Getting memory before allocation");
 
-  return static_cast<char *>(mem_pool) + memory_offset.at(idx);
+  return static_cast<char *>(mem_pool) + memory_offset.at(idx - 1);
 }
 
 /**

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1047,6 +1047,13 @@ public:
       initialize();
   }
 
+  /**
+   * @brief Get initializer for the tensor
+   *
+   * @return initializer of the tensor
+   */
+  Tensor::Initializer getInitializer() const { return initializer; }
+
   static constexpr float epsilon = 1e-5;
 
 private:

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -151,13 +151,6 @@ public:
   size_t minMemoryRequirement() { return mem_pool.minMemoryRequirement(); }
 
   /**
-   * @brief Is the tensor pool allocated
-   *
-   * @return true if the tensors are allocated, else false
-   */
-  bool isAllocated() const { return mem_pool.isAllocated(); }
-
-  /**
    * @brief Get the tensor of the given name
    *
    * @return ptr to the tensor with the given

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -57,9 +57,11 @@ public:
    * @note we assume that the caller checks if the exec_order and lifespan are
    * compatible.
    */
-  Tensor *requestTensor(const TensorDim dim,
-                        const std::vector<unsigned int> &exec_order,
-                        TensorLifespan lifespan, const std::string &name);
+  Tensor *
+  requestTensor(const TensorDim &dim,
+                const std::vector<unsigned int> &exec_order,
+                TensorLifespan lifespan, const std::string &name,
+                const Tensor::Initializer &init = Tensor::Initializer::NONE);
 
   /**
    * @brief     Request tensor which has been already requested with the given
@@ -76,11 +78,10 @@ public:
    * @note we assume that the caller checks if the exec_order and lifespan are
    * compatible.
    */
-  Tensor *requestPrerequestedTensor(const TensorDim dim,
-                                    const std::vector<unsigned int> &exec_order,
-
-                                    TensorLifespan lifespan,
-                                    const std::string &name);
+  Tensor *requestPrerequestedTensor(
+    const TensorDim &dim, const std::vector<unsigned int> &exec_order,
+    TensorLifespan lifespan, const std::string &name,
+    const Tensor::Initializer &init = Tensor::Initializer::NONE);
 
   /**
    * @brief finalize the requested tensors
@@ -143,6 +144,7 @@ public:
 private:
   /**
    * @brief Spec for storing each request of tensor from tensor pool
+   * @todo move tensor initialization from tensor class to requestSpec
    */
   struct requestSpec {
     std::unique_ptr<Tensor> tensor;       /**< tensor object itself */

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -128,6 +128,15 @@ public:
                        const std::vector<unsigned int> &exec_order);
 
   /**
+   * @brief     Get execution order for the given tensor
+   *
+   * @return The execution order of the tensor
+   */
+  const std::vector<unsigned int> &getExecutionOrder(const std::string &name) {
+    return pool[name_map.at(name)].exec_order;
+  }
+
+  /**
    * @brief Get the maximum real memory requirement
    *
    * @return The real memory requirement with this strategy in bytes
@@ -141,6 +150,23 @@ public:
    */
   size_t minMemoryRequirement() { return mem_pool.minMemoryRequirement(); }
 
+  /**
+   * @brief Is the tensor pool allocated
+   *
+   * @return true if the tensors are allocated, else false
+   */
+  bool isAllocated() const { return mem_pool.isAllocated(); }
+
+  /**
+   * @brief Get the tensor of the given name
+   *
+   * @return ptr to the tensor with the given
+   * @throws if no tensor is found with the given name
+   */
+  Tensor *getTensor(const std::string &name) {
+    return pool[name_map.at(name)].tensor.get();
+  }
+
 private:
   /**
    * @brief Spec for storing each request of tensor from tensor pool
@@ -153,8 +179,13 @@ private:
     unsigned int token;                   /**< tensor memory token */
   };
 
-  std::unordered_map<std::string, requestSpec>
-    pool;              /**< list of requested tensors */
+  /**
+   * note: unordered_map is not directly used for pool to ensure initialization
+   * of weights
+   */
+  std::vector<requestSpec> pool; /**< list of requested tensors */
+  std::unordered_map<std::string, unsigned int>
+    name_map;          /**< indexing of requested tensors */
   MemoryPool mem_pool; /**< memory pool for the tensors */
 
   /**

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -269,7 +269,7 @@ public:
   void setBatchSize(unsigned int batch) {
     if (!var->empty())
       var->updateBatch(batch);
-    if (!grad->empty())
+    if (grad && !grad->empty())
       grad->updateBatch(batch);
   }
 

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -94,6 +94,16 @@ public:
   }
 
   /**
+   * @brief Construct a new Var_Grad object
+   *
+   * @param v ptr to already created variable tensor
+   * @param g ptr to already created gradient tensor
+   */
+  explicit Var_Grad(Tensor *v, Tensor *g) :
+    var(std::shared_ptr<Tensor>(v, [](void *) {})),
+    grad(std::shared_ptr<Tensor>(g, [](void *) {})) {}
+
+  /**
    * @brief Copy constructor for Var_Grad
    *
    * @param rhs Var_Grad to construct from
@@ -346,7 +356,13 @@ public:
    * @note this is can return is the var_grad needs gradient but it not
    * empty
    */
-  bool hasGradient() const { return !grad->empty(); }
+  bool hasGradient() const {
+    if (!grad)
+      return false;
+    if (var->isAllocated())
+      return grad->isAllocated();
+    return !grad->empty();
+  }
 
   inline static const std::string grad_suffix = ":grad";
 

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -97,6 +97,20 @@ public:
     regularizer_constant(1.0f) {}
 
   /**
+   * @brief Construct a new Weight object
+   *
+   * @param v ptr to already created variable tensor
+   * @param g ptr to already created gradient tensor
+   * @param reg Regularizer for the weight
+   * @param reg_const Constant multiplier for regularizer
+   */
+  explicit Weight(Tensor *v, Tensor *g, const WeightRegularizer reg,
+                  const float reg_const) :
+    Var_Grad(v, g),
+    regularizer(reg),
+    regularizer_constant(reg_const) {}
+
+  /**
    * @copydoc var_grad::initializeGradient(const Tensor &)
    */
   void initializeGradient(const Tensor &preallocated = Tensor());
@@ -261,17 +275,22 @@ public:
     deallocateVariable();
   }
 
+  /**
+   * @brief Allocate optimizer related variables for the given weights
+   */
+  void allocateOptimizerVariables();
+
+  /**
+   * @brief Allocate optimizer related variables for the given weights
+   */
+  void deallocateOptimizerVariables() { opt_vars.clear(); }
+
 private:
   WeightRegularizer regularizer; /**< regularizer for this variable */
   float regularizer_constant;    /**< constant factor for regularization */
 
   std::vector<Tensor> opt_vars;        /**< optimizer variables */
   std::vector<TensorDim> opt_vars_dim; /**< optimizer variables dimensions */
-
-  /**
-   * @brief Allocate optimizer related variables for the given weights
-   */
-  void allocateOptimizerVariables();
 };
 
 } // namespace nntrainer


### PR DESCRIPTION
- This patch adds bugfixes for layers:
1. acti_func in-place support bug
2. batch normalization layer weight name bug
3. loss layers not using tensor reference bug
- This patch updates manager to use TensorPool for its weights and
corresponding weights. Corresponding changes to Var_Grad/Weights and
Tensors are also added.
- setBatchSize() now takes dimensions from user, and then updates the
provides these updates dimensions to the manager. We can possibly remove
setBatch(RunLayerContext), which will be finalized in the next commit.
- Use TensorPool for gradients of the weights.
- This patch makes tensor list in tensorpool ordered.
This ensures that the requested tensors are initialized in the order of
the their requests which is by the order of the sorted graph.
- This patch adds fix when rebase to the main branch.
Due to significant changes to the main branch, certain patches have
been taken from future PRs:
  - from #1539, commit b58c72a has been
cherry picked to solve the issue of tensor shape related with batch size
changes
  - from #1539, memory pool to start giving tokens from 1 instead of 0. token 0 is
treated at a non-requested tensor memory

  These patches might seem a bit out of the way but instead of taking
partial functionality, either full commits have been cherry-picked here
or minor functionality has been manually imported.


See Also #1127

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>