### PR TITLE
[Manager] Manager to use TensorPool for all requests

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -724,10 +724,6 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
   if (lnode->requireLabel())
     label_list.insert(label_list.end(), outputs.begin(), outputs.end());
 
-  /**
-   * @note must use existing properties like name/trainable of run_context to
-   * create the new run_context
-   */
   lnode->configureRunContext(
     // TODO: update weights spec for trainable based on layer trainable prop
     tensor_manager->requestWeights(gnode, init_context.getWeightsSpec()),

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -293,6 +293,15 @@ public:
    * @brief Allocate and initialize the weight variable
    */
   void initializeWeights() {
+    /**
+     * get the order of execution/usage order for the forwarding of the last
+     * layer and pass that as the max_exec_order ensuring that all weights with
+     * usage less than the max_exec_order are allocated.
+     *
+     * @note usage order of backwarding is not considered because weight has a
+     * separate memory pool for now. Later, if it shares pool with other
+     * tensors, then this must max of backward usage order.
+     */
     tensor_manager->initializeWeights(
       std::get<0>((*(cend() - 1))->getExecutionOrder()));
   }
@@ -303,10 +312,21 @@ public:
    */
   void initializeTensors(bool training) {
     if (!training)
+      /**
+       * get the order of execution/usage order for the forwarding of the last
+       * layer and pass that as the max_exec_order ensuring that all tensors
+       * with usage less than the max_exec_order are allocated.
+       */
       tensor_manager->initializeTensors(
         training, std::get<0>((*(cend() - 1))->getExecutionOrder()));
     else
       /** @todo update this to skip non-trainable layers */
+      /**
+       * get the order of execution/usage order for the backwarding of the first
+       * layer (as that will be the last layer to executed in the backwarding)
+       * and pass that as the max_exec_order ensuring that all tensors with
+       * usage less than the max_exec_order are allocated.
+       */
       tensor_manager->initializeTensors(
         training, std::get<1>((*(cbegin()))->getExecutionOrder()));
   }

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -465,6 +465,10 @@ void LayerNode::forwarding(bool training) {
   START_PROFILE(forward_event_key);
   layer->forwarding(*run_context, training);
   END_PROFILE(forward_event_key);
+
+  /** add loss only for loss layers */
+  if (requireLabel())
+    loss->set(*loss + run_context->getLoss());
 }
 
 /**
@@ -527,13 +531,7 @@ bool LayerNode::requireLabel() const { return getLayer()->requireLabel(); }
  * @brief     get loss for the layer
  * @return    loss of the layer
  */
-float LayerNode::getLoss() const {
-  /** add loss only for loss layers */
-  if (requireLabel())
-    loss->set(*loss + run_context->getLoss());
-
-  return *loss;
-}
+float LayerNode::getLoss() const { return *loss; }
 
 void LayerNode::configureRunContext(const std::vector<Weight *> &weights,
                                     const std::vector<Var_Grad *> &inputs,

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -107,13 +107,6 @@ public:
   ~NeuralNetwork();
 
   /**
-   * @brief     Set labels to the layers which require the label
-   * @todo      Set label with multiple labels
-   * @param     label label
-   */
-  void setLabels(sharedConstTensors label);
-
-  /**
    * @brief     Get Loss from the previous ran batch of data
    * @retval    loss value
    */

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -850,9 +850,20 @@ Manager::requestInputs(const GraphNode &node,
       );
     }
 
-    inputs_v2.emplace_back(std::make_unique<Var_Grad>(var, grad));
+    /**
+     * TODO: This a temporary fix to handle external tensors due to rebase.
+     * This is properly fixed with #1544 using
+     * context.requestExternallyAllocatedTensor().
+     */
+    if (var && grad)
+      inputs_v2.emplace_back(std::make_unique<Var_Grad>(var, grad));
+    else
+      inputs_v2.emplace_back(std::make_unique<Var_Grad>(
+        dim, Tensor::Initializer::NONE, true, false,
+        node.getName() + std::string(":input") + std::to_string(idx)));
   }
 
+  ret.reserve(inputs_dim.size());
   std::transform(inputs_v2.begin() + current_size, inputs_v2.end(),
                  std::back_inserter(ret),
                  [](auto const &elem) { return elem.get(); });

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -383,12 +383,16 @@ public:
   void untrackLayerInOuts(const std::string &layer_name);
 
   /**
-   * @brief Initialize the inputs/outputs/derivatives/gradients for the layers
-   * @param[in] training If true, initialize derivates/gradients, else, do not.
-   * @note The memory allocation strategy varies based on the training. The
-   * memory allocated for inference mode is not compatible with training, and
-   * will require full allocation than reusing memory allocated with inference
-   * mode.
+   * @brief Initialize the all the requested tensors
+   *
+   * @param[in] training If model will be training or not
+   * @param[in] max_exec_order The maximum order of execution to determine
+   * memory layout
+   *
+   * @note Any requested tensor which is not used inside the max_exec_order is
+   * not initialized and will not be allocated. The initialization uses a memory
+   * planner to plan the layout of all the tensors which are used at least once
+   * before the max_exec_order.
    */
   void initializeTensors(bool training, unsigned int max_exec_order);
 

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -188,6 +188,31 @@ public:
    * @brief     Create tensors with the given spec
    *
    * @param node Graph node to extract node identifiers/info
+   * @param tensors_spec Specficiation for the tensors
+   *
+   * @return created tensors list
+   */
+  std::vector<Tensor *> requestWeightOptimizerVariables(
+    const std::vector<TensorDim> &dims, const std::string &name,
+    const TensorLifespan &lifespan,
+    Tensor::Initializer initializer = Tensor::Initializer::NONE) {
+    auto const &exec_order = weight_pool.getExecutionOrder(name);
+
+    std::vector<Tensor *> ret;
+    ret.reserve(dims.size());
+
+    for (unsigned int idx = 0; idx < dims.size(); idx++)
+      ret.push_back(tensor_pool.requestTensor(
+        dims[idx], exec_order, lifespan, name + ":opt" + std::to_string(idx),
+        initializer));
+
+    return ret;
+  }
+
+  /**
+   * @brief     Create tensors with the given spec
+   *
+   * @param node Graph node to extract node identifiers/info
    * @param inputs_dim Specficiation for the tensors
    * @param outputs_name Name of the already requested output tensors
    *
@@ -288,7 +313,7 @@ public:
    * @note This only allocates weights and does not handle training related
    * memory for weights
    */
-  void initializeWeights();
+  void initializeWeights(unsigned int max_exec_order);
 
   /**
    * @brief Reset the manager state
@@ -365,7 +390,7 @@ public:
    * will require full allocation than reusing memory allocated with inference
    * mode.
    */
-  void initializeTensors(bool training);
+  void initializeTensors(bool training, unsigned int max_exec_order);
 
   /**
    * @brief   Check if the manager has allocated tensors
@@ -611,12 +636,12 @@ private:
   /**
    * @brief Initialize the tensors for inference mode
    */
-  void initializeTensorsInference();
+  void initializeTensorsInference(unsigned int);
 
   /**
    * @brief Initialize the tensors for training mode
    */
-  void initializeTensorsTrain();
+  void initializeTensorsTrain(unsigned int);
 
   /**
    * @brief     Create tensors with the given spec

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -287,4 +287,16 @@ size_t MemoryPool::calcMinMemoryRequirement() {
   return *std::max_element(interval_req.begin(), interval_req.end());
 }
 
+void MemoryPool::clear() {
+  if (mem_pool != nullptr)
+    throw std::invalid_argument("Cannot clear allocated memory pool");
+
+  memory_size.clear();
+  memory_validity.clear();
+  memory_offset.clear();
+
+  pool_size = 0;
+  min_pool_size = 0;
+}
+
 } // namespace nntrainer

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -104,6 +104,12 @@ public:
    */
   size_t minMemoryRequirement();
 
+  /**
+   * @brief Clear the memory pool
+   *
+   */
+  void clear();
+
 private:
   /**
    * @brief Validate the provided layout

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -87,6 +87,7 @@ Tensor *TensorPool::requestPrerequestedTensor(
  */
 void TensorPool::finalize(const MemoryPlanner &planner,
                           unsigned int start_order, unsigned int end_order) {
+  mem_pool.clear();
   unsigned int bytes_requested = 0;
   for (auto &spec : pool) {
     spec.token = 0;

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -77,6 +77,9 @@ public:
    * @note returns empty tensor which will be filled when allocate is called.
    * @note we assume that the caller checks if the exec_order and lifespan are
    * compatible.
+   *
+   * @note This interface is separated from requestTensor to reduce bugs related
+   * to unintentional tensor sharing.
    */
   Tensor *requestPrerequestedTensor(
     const TensorDim &dim, const std::vector<unsigned int> &exec_order,

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -37,7 +37,7 @@ Var_Grad::Var_Grad(const TensorDim &dim, const Tensor::Initializer init,
 
 void Var_Grad::initializeVariable(const Tensor &preallocated) {
   if (!preallocated.empty()) {
-    var->makeSharedDataTensor(preallocated);
+    var = std::make_shared<Tensor>(preallocated);
     /** intentionally not initialized tensor memory for shared tensors */
   }
 }
@@ -48,7 +48,7 @@ void Var_Grad::initializeGradient(const Tensor &preallocated) {
      * Making a new tensor is intentional here as this tensor is not shared
      * with other layers but the internal memory is.
      */
-    grad->makeSharedDataTensor(preallocated);
+    grad = std::make_shared<Tensor>(preallocated);
     /** intentionally not initialized tensor memory for shared tensors */
   }
   /**

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -101,7 +101,12 @@ public:
    */
   explicit Var_Grad(Tensor *v, Tensor *g) :
     var(std::shared_ptr<Tensor>(v, [](void *) {})),
-    grad(std::shared_ptr<Tensor>(g, [](void *) {})) {}
+    grad(std::shared_ptr<Tensor>(g, [](void *) {})) {
+    if (!v)
+      var = std::make_shared<Tensor>();
+    if (!g)
+      grad = std::make_shared<Tensor>();
+  }
 
   /**
    * @brief Copy constructor for Var_Grad

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -30,19 +30,4 @@ Weight::Weight(const TensorDim &dim, const Tensor::Initializer init,
     throw std::invalid_argument("Weight regularizer unknown");
 }
 
-void Weight::initializeGradient(const Tensor &preallocated) {
-  // Use self variable to initialize itself
-  Var_Grad::initializeGradient(preallocated);
-  if (var->isAllocated())
-    allocateOptimizerVariables();
-}
-
-void Weight::allocateOptimizerVariables() {
-  // Allocate optimizer parameters
-  for (auto const &dim : opt_vars_dim) {
-    opt_vars.emplace_back(dim);
-    opt_vars.back().setZero();
-  }
-}
-
 } // namespace nntrainer

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -111,11 +111,6 @@ public:
     regularizer_constant(reg_const) {}
 
   /**
-   * @copydoc var_grad::initializeGradient(const Tensor &)
-   */
-  void initializeGradient(const Tensor &preallocated = Tensor());
-
-  /**
    * @brief Swap for weight
    *
    * @param lhs Swap to
@@ -194,18 +189,14 @@ public:
   /**
    * @brief Clear optimizer variables
    */
-  void clearOptimizerVariables() {
-    opt_vars.clear();
-    opt_vars_dim.clear();
-  }
+  void clearOptimizerVariables() { opt_vars.clear(); }
 
   /**
    * @brief Add optimizer variables
    * @param dim Optimizer variable dimension
    */
-  void addOptimizerVariable(const TensorDim &dim) {
-    opt_vars_dim.emplace_back(dim);
-    // TODO: Move this out when an optimizer does not initialize with 0.
+  void setOptimizerVariables(std::vector<Tensor *> tensors) {
+    opt_vars = tensors;
   }
 
   /**
@@ -213,7 +204,7 @@ public:
    * @param idx Index of the optimizer variable to get
    * @retval Reference of the optimizer variable
    */
-  Tensor &getOptimizerVariableRef(unsigned int idx) { return opt_vars[idx]; }
+  Tensor &getOptimizerVariableRef(unsigned int idx) { return *opt_vars[idx]; }
 
   /**
    * @brief Allocate and initialize the weight variable, if needed
@@ -223,10 +214,7 @@ public:
   /**
    * @brief Allocate and initialize the weight gradient, if needed
    */
-  void allocateGradient() {
-    Var_Grad::allocateGradient();
-    allocateOptimizerVariables();
-  }
+  void allocateGradient() { Var_Grad::allocateGradient(); }
 
   /**
    * @brief     check if weight regularizer type is l2norm
@@ -262,10 +250,7 @@ public:
   /**
    * @brief Deallocate memory for the gradient of the weight
    */
-  void deallocateGradient() {
-    Var_Grad::deallocateGradient();
-    opt_vars.clear();
-  }
+  void deallocateGradient() { Var_Grad::deallocateGradient(); }
 
   /**
    * @brief Deallocate the weight gardient and variable
@@ -275,22 +260,11 @@ public:
     deallocateVariable();
   }
 
-  /**
-   * @brief Allocate optimizer related variables for the given weights
-   */
-  void allocateOptimizerVariables();
-
-  /**
-   * @brief Allocate optimizer related variables for the given weights
-   */
-  void deallocateOptimizerVariables() { opt_vars.clear(); }
-
 private:
   WeightRegularizer regularizer; /**< regularizer for this variable */
   float regularizer_constant;    /**< constant factor for regularization */
 
-  std::vector<Tensor> opt_vars;        /**< optimizer variables */
-  std::vector<TensorDim> opt_vars_dim; /**< optimizer variables dimensions */
+  std::vector<Tensor *> opt_vars; /**< optimizer variables */
 };
 
 } // namespace nntrainer

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -485,7 +485,11 @@ void GraphWatcher::validateFor(const nntrainer::TensorDim &label_shape) {
   label_tensor->setRandNormal();
   nntrainer::sharedConstTensors label = {label_tensor};
 
-  EXPECT_NO_THROW(nn.forwarding(input, label));
+  if (loss_nodes.size()) {
+    EXPECT_NO_THROW(nn.forwarding(input, label));
+  } else {
+    EXPECT_NO_THROW(nn.forwarding(input, {}));
+  }
 
   if (loss_nodes.size()) {
     EXPECT_NO_THROW(nn.backwarding(label, 0));


### PR DESCRIPTION
This patch updates manager to use TensorPool for all of its requests.
Other changes are as listed below:
- NetworkGraph now caches the inputs and labels Var_Grads which can
directly by the model before execution.
- setLabels and setInputs in the model have been updated. Further,
manual setting of inputs and labels has been removed.
- Introduce clear in memory pool to clear any allocations and requests
- TensorPool clears any requests made before making more requests in
finalize
- models unittest updated to not pass label when loss is not given in
the model. Passing label without loss in the model now results in error
- Manager updated to use tensor pool for all the memory requests. The
allocation, initialization and deallocation has been correspondingly simplified

Much needed cleanup will be done soon.

See Also #1127

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>