### PR TITLE
[layer_node] bugfix/validate init_context

### DIFF
--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -223,10 +223,24 @@ static void add_default_object(AppContext &ac) {
                      ActivationLayer::type, LayerType::LAYER_ACTIVATION);
   ac.registerFactory(nntrainer::createLayer<AdditionLayer>, AdditionLayer::type,
                      LayerType::LAYER_ADDITION);
-  ac.registerFactory(nntrainer::createLayer<MultiOutLayer>, MultiOutLayer::type,
-                     LayerType::LAYER_MULTIOUT);
   ac.registerFactory(nntrainer::createLayer<ConcatLayer>, ConcatLayer::type,
                      LayerType::LAYER_CONCAT);
+  ac.registerFactory(nntrainer::createLayer<MultiOutLayer>, MultiOutLayer::type,
+                     LayerType::LAYER_MULTIOUT);
+  ac.registerFactory(nntrainer::createLayer<EmbeddingLayer>,
+                     EmbeddingLayer::type, LayerType::LAYER_EMBEDDING);
+  ac.registerFactory(nntrainer::createLayer<RNNLayer>, RNNLayer::type,
+                     LayerType::LAYER_RNN);
+  ac.registerFactory(nntrainer::createLayer<LSTMLayer>, LSTMLayer::type,
+                     LayerType::LAYER_LSTM);
+  ac.registerFactory(nntrainer::createLayer<SplitLayer>, SplitLayer::type,
+                     LayerType::LAYER_SPLIT);
+  ac.registerFactory(nntrainer::createLayer<GRULayer>, GRULayer::type,
+                     LayerType::LAYER_GRU);
+  ac.registerFactory(nntrainer::createLayer<PermuteLayer>, PermuteLayer::type,
+                     LayerType::LAYER_PERMUTE);
+  ac.registerFactory(nntrainer::createLayer<DropOutLayer>, DropOutLayer::type,
+                     LayerType::LAYER_DROPOUT);
 
 #ifdef ENABLE_NNSTREAMER_BACKBONE
   ac.registerFactory(nntrainer::createLayer<NNStreamerLayer>,
@@ -237,22 +251,6 @@ static void add_default_object(AppContext &ac) {
   ac.registerFactory(nntrainer::createLayer<TfLiteLayer>, TfLiteLayer::type,
                      LayerType::LAYER_BACKBONE_TFLITE);
 #endif
-  ac.registerFactory(nntrainer::createLayer<EmbeddingLayer>,
-                     EmbeddingLayer::type, LayerType::LAYER_EMBEDDING);
-  ac.registerFactory(nntrainer::createLayer<RNNLayer>, RNNLayer::type,
-                     LayerType::LAYER_RNN);
-  ac.registerFactory(nntrainer::createLayer<LSTMLayer>, LSTMLayer::type,
-                     LayerType::LAYER_LSTM);
-  ac.registerFactory(nntrainer::createLayer<GRULayer>, GRULayer::type,
-                     LayerType::LAYER_GRU);
-  ac.registerFactory(nntrainer::createLayer<DropOutLayer>, DropOutLayer::type,
-                     LayerType::LAYER_DROPOUT);
-  ac.registerFactory(nntrainer::createLayer<TimeDistLayer>, TimeDistLayer::type,
-                     LayerType::LAYER_TIME_DIST);
-  ac.registerFactory(nntrainer::createLayer<SplitLayer>, SplitLayer::type,
-                     LayerType::LAYER_SPLIT);
-  ac.registerFactory(nntrainer::createLayer<PermuteLayer>, PermuteLayer::type,
-                     LayerType::LAYER_PERMUTE);
   ac.registerFactory(nntrainer::createLayer<CentroidKNN>, CentroidKNN::type,
                      LayerType::LAYER_CENTROID_KNN);
 
@@ -267,12 +265,15 @@ static void add_default_object(AppContext &ac) {
   /** register losses */
   ac.registerFactory(nntrainer::createLayer<MSELossLayer>, MSELossLayer::type,
                      LayerType::LAYER_LOSS_MSE);
-  ac.registerFactory(nntrainer::createLayer<CrossEntropySoftmaxLossLayer>,
-                     CrossEntropySoftmaxLossLayer::type,
-                     LayerType::LAYER_LOSS_CROSS_ENTROPY_SOFTMAX);
   ac.registerFactory(nntrainer::createLayer<CrossEntropySigmoidLossLayer>,
                      CrossEntropySigmoidLossLayer::type,
                      LayerType::LAYER_LOSS_CROSS_ENTROPY_SIGMOID);
+  ac.registerFactory(nntrainer::createLayer<CrossEntropySoftmaxLossLayer>,
+                     CrossEntropySoftmaxLossLayer::type,
+                     LayerType::LAYER_LOSS_CROSS_ENTROPY_SOFTMAX);
+
+  ac.registerFactory(nntrainer::createLayer<TimeDistLayer>, TimeDistLayer::type,
+                     LayerType::LAYER_TIME_DIST);
 
   ac.registerFactory(AppContext::unknownFactory<nntrainer::Layer>, "unknown",
                      LayerType::LAYER_UNKNOWN);

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -54,7 +54,7 @@ void AdditionLayer::calcDerivative(RunLayerContext &context) {
 
 void AdditionLayer::setProperty(const std::vector<std::string> &values) {
   if (!values.empty()) {
-    std::string msg = "[FlattenLayer] Unknown Layer Properties count " +
+    std::string msg = "[AdditionLayer] Unknown Layer Properties count " +
                       std::to_string(values.size());
     throw exception::not_supported(msg);
   }

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -489,8 +489,10 @@ void LayerNode::print(std::ostream &out, unsigned int flags) {
   }
 
   if (flags & PRINT_SHAPE_INFO) {
-    out << "======shape information: " << std::endl;
-    printShapeInfo(out);
+    if (init_context.validate()) {
+      out << "======shape information: " << std::endl;
+      printShapeInfo(out);
+    }
   }
 
   if (flags & PRINT_PROP_META) {
@@ -504,12 +506,14 @@ void LayerNode::print(std::ostream &out, unsigned int flags) {
   }
 
   if (flags & PRINT_WEIGHTS) {
-    out << "======weights: " << std::endl;
-    for (unsigned int idx = 0; idx < init_context.getNumWeights(); idx++) {
-      out << '[' << std::get<5>(init_context.getWeightsSpec()[idx]) << ']'
-          << std::endl;
-      if (run_context.readyToUse())
-        out << run_context.getWeight(idx);
+    if (init_context.validate()) {
+      out << "======weights: " << std::endl;
+      for (unsigned int idx = 0; idx < init_context.getNumWeights(); idx++) {
+        out << '[' << std::get<5>(init_context.getWeightsSpec()[idx]) << ']'
+            << std::endl;
+        if (run_context.readyToUse())
+          out << run_context.getWeight(idx);
+      }
     }
   }
 

--- a/nntrainer/layers/multiout_layer.cpp
+++ b/nntrainer/layers/multiout_layer.cpp
@@ -50,7 +50,7 @@ void MultiOutLayer::calcDerivative(RunLayerContext &context) {
 
 void MultiOutLayer::setProperty(const std::vector<std::string> &values) {
   if (!values.empty()) {
-    std::string msg = "[FlattenLayer] Unknown Layer Properties count " +
+    std::string msg = "[MultioutLayer] Unknown Layer Properties count " +
                       std::to_string(values.size());
     throw exception::not_supported(msg);
   }


### PR DESCRIPTION
 - Validate init_context before using the init_context in print function
 - Reorder adding default layer object to appcontext based on LayerType enum
 - Correct typo

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>