### PR TITLE
[layer_node] handle deprecated property

### DIFF
--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -67,6 +67,12 @@ void InputLayer::setProperty(const std::string &type_str,
     status = setBoolean(standardization, value);
     throw_status(status);
   } break;
+  case PropertyType::weight_initializer: {
+    ml_logw("Deprecated property: %s", type_str.c_str());
+  } break;
+  case PropertyType::bias_initializer: {
+    ml_logw("Deprecated property: %s", type_str.c_str());
+  } break;
   default:
     std::string msg =
       "[InputLayer] Unknown Layer Property Key for value " + std::string(value);

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -128,6 +128,7 @@ public:
     return_sequences = 34,
     hidden_state_activation = 35,
     dropout = 36,
+    num_inputs = 37,
     unknown
   };
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -228,6 +228,10 @@ bool LayerNode::setProperty(const std::string &key, const std::string &value) {
     setInputLayers(split_layers);
     break;
   }
+  case PropertyType::num_inputs: {
+    ml_logw("Deprecated property: %s", key.c_str());
+    break;
+  }
   default:
     return false;
   }

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -218,6 +218,7 @@ unsigned int parseType(std::string ll, InputType t) {
  * return_sequences = 34
  * hidden_state_activation = 35
  * dropout = 36
+ * num_inputs = 37
  *
  * InputLayer has 0, 1, 2, 3 properties.
  * FullyConnectedLayer has 1, 4, 6, 7, 8, 9 properties.
@@ -225,7 +226,7 @@ unsigned int parseType(std::string ll, InputType t) {
  * Pooling2DLayer has 12, 13, 14, 15 properties.
  * BatchNormalizationLayer has 0, 1, 5, 6, 7 properties.
  */
-static std::array<std::string, 38> property_string = {
+static std::array<std::string, 39> property_string = {
   "input_shape",
   "normalization",
   "standardization",
@@ -263,6 +264,7 @@ static std::array<std::string, 38> property_string = {
   "return_sequences",
   "hidden_state_activation",
   "dropout",
+  "num_inputs",
   "unknown"};
 
 unsigned int parseLayerProperty(std::string property) {


### PR DESCRIPTION
 - Handle deprecated property num_inputs, weight_initialize, bias_initialize

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>