### PR TITLE
[ini] Implement model save

### DIFF
--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -553,6 +553,8 @@ int ml_train_dataset_set_property_for_mode(ml_train_dataset_h dataset,
  * configurations. Unless stated otherwise, ml_train_model_compile() has to
  * be called upon the @a model before calling this function.
  * @since_tizen 6.5
+ * @remarks Saved ini, if any, is not guaranteed to be identical to the original
+ * ini that maybe used to load the model.
  * @remarks If you want to access only internal storage by using this function,
  * you should add privilege %http://tizen.org/privilege/mediastorage. Or, if you
  * want to access only external storage by using this function, you should add

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -135,7 +135,7 @@ public:
    * @details   This function accepts vector of properties in the format -
    *  { std::string property_name, void * property_val, ...}
    */
-  virtual int train(std::vector<std::string> values = {}) = 0;
+  virtual int train(const std::vector<std::string> &values = {}) = 0;
 
   /**
    * @brief     Run Model train with callback function by user
@@ -185,10 +185,12 @@ public:
   /**
    * @brief     Run the inference of the model
    * @param[in] input inputs as a list of each input data
+   * @param[in] batch batch size of current input
    * @retval list of output as float *
    * @note The output memory must not be freed by the caller
    */
-  virtual std::vector<float *> inference(std::vector<float *> &input) = 0;
+  virtual std::vector<float *> inference(std::vector<float *> &input,
+                                         unsigned int batch) = 0;
 
   /**
    * @brief     Summarize the model

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -124,6 +124,7 @@ include $(CLEAR_VARS)
 
 NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/models/model_loader.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/models/model_common_properties.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/models/dynamic_training_optimization.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/dataset/iteration_queue.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/dataset/databuffer.cpp \

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.hh
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.hh
@@ -65,11 +65,7 @@ public:
    *
    * @param batch batch size
    */
-  void setBatchSize(unsigned int batch) {
-    std::stringstream ss;
-    ss << "batch_size=" << batch;
-    model->setProperty({ss.str()});
-  }
+  void setBatchSize(unsigned int batch) { batch_size = batch; }
 
   /**
    * @brief Get the Input Dimension object
@@ -100,6 +96,8 @@ public:
 
 private:
   void loadModel();
+
+  unsigned int batch_size;
 
   std::string model_config;
   std::unique_ptr<ml::train::Model> model;

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -424,6 +424,7 @@ int NetworkGraph::realizeGraph() {
 }
 
 void NetworkGraph::setBatchSize(unsigned int batch_size) {
+  this->batch_size = batch_size;
   for (auto iter = cbegin(); iter != cend(); iter++) {
     (*iter)->setBatch(batch_size);
   }
@@ -454,6 +455,8 @@ std::vector<TensorDim> NetworkGraph::getInputDimension() const {
     << "[NetworkGraph] the graph has no node!";
   return getSortedLayerNode(0)->getInputDimensions();
 }
+
+unsigned int NetworkGraph::getBatchSize() const { return batch_size; }
 
 std::vector<TensorDim> NetworkGraph::getOutputDimension() const {
   NNTR_THROW_IF(this->empty(), std::invalid_argument)

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -32,6 +32,7 @@
 #include <rnn.h>
 #include <split_layer.h>
 #include <time_dist.h>
+#include <util_func.h>
 
 #define LNODE(x) std::static_pointer_cast<LayerNode>(x)
 

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -42,7 +42,8 @@ public:
     tensor_manager(std::make_shared<Manager>()),
     graph(),
     skip_non_trainable_layers(0),
-    compiled(false) {}
+    compiled(false),
+    batch_size(0) {}
 
   /**
    * @brief     Compile the graph
@@ -217,6 +218,13 @@ public:
   std::vector<TensorDim> getInputDimension() const;
 
   /**
+   * @brief Get the Batch Size object of current model
+   *
+   * @return unsigned int
+   */
+  unsigned int getBatchSize() const;
+
+  /**
    * @brief     Optimize the graph memory utilization for in-place operations
    */
   void inPlaceOptimize();
@@ -345,6 +353,7 @@ private:
     skip_non_trainable_layers; /**< denotes the number of non-trainable layers
                                   at the start of the graph */
   bool compiled;               /**< if the model graph is compiled */
+  unsigned int batch_size;     /**< current batch_size */
 
   /**
    * @brief     topological sort

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -25,6 +25,7 @@
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <parse_util.h>
+#include <util_func.h>
 
 namespace nntrainer {
 

--- a/nntrainer/layers/layer_impl.cpp
+++ b/nntrainer/layers/layer_impl.cpp
@@ -20,7 +20,7 @@
 #include <nntrainer_log.h>
 #include <node_exporter.h>
 #include <parse_util.h>
-
+#include <util_func.h>
 namespace nntrainer {
 
 LayerImpl::LayerImpl() :

--- a/nntrainer/models/meson.build
+++ b/nntrainer/models/meson.build
@@ -1,7 +1,8 @@
 model_sources = [
   'model_loader.cpp',
   'neuralnet.cpp',
-  'dynamic_training_optimization.cpp'
+  'model_common_properties.cpp',
+  'dynamic_training_optimization.cpp',
 ]
 
 model_headers = []

--- a/nntrainer/models/model_common_properties.cpp
+++ b/nntrainer/models/model_common_properties.cpp
@@ -23,7 +23,7 @@ bool LossType::isValid(const std::string &value) const {
   return istrequal(value, "cross") || istrequal(value, "mse");
 }
 
-BatchSize::BatchSize(unsigned int value) { set(value); }
+TrainingBatchSize::TrainingBatchSize(unsigned int value) { set(value); }
 
 ContinueTrain::ContinueTrain(bool value) { set(value); }
 

--- a/nntrainer/models/model_common_properties.cpp
+++ b/nntrainer/models/model_common_properties.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file   model_common_properties.cpp
+ * @date   27 Aug 2021
+ * @brief  This file contains common properties for model
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+#include <model_common_properties.h>
+
+#include <nntrainer_log.h>
+#include <util_func.h>
+
+namespace nntrainer::props {
+Epochs::Epochs(unsigned int value) { set(value); }
+
+bool LossType::isValid(const std::string &value) const {
+  ml_logw("Model loss property is deprecated, use loss layer directly instead");
+  return istrequal(value, "cross") || istrequal(value, "mse");
+}
+
+BatchSize::BatchSize(unsigned int value) { set(value); }
+
+ContinueTrain::ContinueTrain(bool value) { set(value); }
+
+} // namespace nntrainer::props

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -66,7 +66,7 @@ public:
  * @brief model batch size property
  *
  */
-class BatchSize : public PositiveIntegerProperty {
+class TrainingBatchSize : public PositiveIntegerProperty {
 public:
   static constexpr const char *key = "batch_size"; /**< unique key to access */
   using prop_tag = uint_prop_tag;                  /**< property type */
@@ -76,7 +76,7 @@ public:
    *
    * @param value value to set, defaults to 1
    */
-  BatchSize(unsigned int value = 1);
+  TrainingBatchSize(unsigned int value = 1);
 };
 
 /**

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file   model_common_properties.h
+ * @date   27 Aug 2021
+ * @brief  This file contains common properties for model
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+#ifndef __MODEL_COMMON_PROPERTIES_H__
+#define __MODEL_COMMON_PROPERTIES_H__
+
+#include <base_properties.h>
+
+#ifdef __cplusplus
+namespace nntrainer::props {
+
+/**
+ * @brief model epoch property
+ *
+ */
+class Epochs : public PositiveIntegerProperty {
+public:
+  static constexpr const char *key = "epochs"; /**< unique key to access */
+  using prop_tag = uint_prop_tag;              /**< property type */
+  /**
+   * @brief Construct a new Epochs object
+   *
+   * @param value value to set
+   */
+  Epochs(unsigned int value = 1);
+};
+
+/**
+ * @brief model loss property (deprecated)
+ *
+ */
+class LossType : public Property<std::string> {
+public:
+  static constexpr const char *key = "loss"; /**< unique key to access */
+  using prop_tag = str_prop_tag;             /**< property type */
+
+  /**
+   * @brief check if valid
+   *
+   * @param value value to check
+   * @return bool true if valid
+   */
+  bool isValid(const std::string &value) const override;
+};
+
+/**
+ * @brief model save path property
+ *
+ */
+class SavePath : public Property<std::string> {
+public:
+  static constexpr const char *key = "save_path"; /**< unique key to access */
+  using prop_tag = str_prop_tag;                  /**< property type */
+};
+
+/**
+ * @brief model batch size property
+ *
+ */
+class BatchSize : public PositiveIntegerProperty {
+public:
+  static constexpr const char *key = "batch_size"; /**< unique key to access */
+  using prop_tag = uint_prop_tag;                  /**< property type */
+
+  /**
+   * @brief Construct a new Batch Size object
+   *
+   * @param value value to set, defaults to 1
+   */
+  BatchSize(unsigned int value = 1);
+};
+
+/**
+ * @brief model continue property
+ *
+ */
+class ContinueTrain : public Property<bool> {
+public:
+  static constexpr const char *key =
+    "continue_train";             /**< unique key to access */
+  using prop_tag = bool_prop_tag; /**< property type */
+
+  /**
+   * @brief Constructor
+   *
+   * @param value value to set, defaults to false
+   */
+  ContinueTrain(bool value = false);
+};
+
+} // namespace nntrainer::props
+
+#endif
+
+#endif // __MODEL_COMMON_PROPERTIES_H__

--- a/nntrainer/models/model_loader.cpp
+++ b/nntrainer/models/model_loader.cpp
@@ -109,7 +109,7 @@ int ModelLoader::loadModelConfigIni(dictionary *ini, NeuralNetwork &model) {
   const std::string &save_path =
     iniparser_getstring(ini, "Model:Save_path", unknown);
   if (save_path != unknown) {
-    model.setSavePath(resolvePath(save_path));
+    model.setProperty({"save_path=" + resolvePath(save_path)});
   }
 
   /**

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -490,14 +490,11 @@ public:
 
 private:
   using FlexiblePropTypes =
-    std::tuple<props::Epochs, props::BatchSize, props::SavePath>;
+    std::tuple<props::Epochs, props::TrainingBatchSize, props::SavePath, props::ContinueTrain>;
   using RigidPropTypes = std::tuple<props::LossType>;
 
   RigidPropTypes model_props;         /**< model props */
   FlexiblePropTypes model_flex_props; /**< model train props */
-  props::ContinueTrain
-    continue_train; /**< true if epochs and iteration should be retained during
-                       separate model run */
   std::string load_path; /**< path to load weights when initialize  */
 
   /**

--- a/nntrainer/utils/base_properties.cpp
+++ b/nntrainer/utils/base_properties.cpp
@@ -18,6 +18,9 @@
 #include <vector>
 
 namespace nntrainer {
+bool PositiveIntegerProperty::isValid(const unsigned int &value) const {
+  return value > 0;
+}
 
 template <>
 std::string

--- a/nntrainer/utils/base_properties.h
+++ b/nntrainer/utils/base_properties.h
@@ -149,7 +149,7 @@ public:
    * @param rhs right side to copy from
    */
   Property(const Property &rhs) {
-    if (this != &rhs) {
+    if (this != &rhs && rhs.value) {
       value = std::make_unique<T>(*rhs.value);
     }
   }
@@ -161,7 +161,7 @@ public:
    * @return Property& this
    */
   Property &operator=(const Property &rhs) {
-    if (this != &rhs) {
+    if (this != &rhs && rhs.value) {
       value = std::make_unique<T>(*rhs.value);
     }
     return *this;
@@ -254,6 +254,26 @@ private:
   std::unique_ptr<T> value; /**< underlying data */
 };
 
+/**
+ * @brief abstract class for positive integer
+ *
+ */
+class PositiveIntegerProperty : public Property<unsigned int> {
+public:
+  /**
+   * @brief Destroy the Positive Integer Property object
+   *
+   */
+  virtual ~PositiveIntegerProperty() = default;
+
+  /**
+   * @brief isValid override, check if value > 0
+   *
+   * @param value value to check
+   * @retval true if value > 0
+   */
+  virtual bool isValid(const unsigned int &value) const override;
+};
 /**
  * @brief meta function to cast tag to it's base
  * @code below is the test spec for the cast

--- a/nntrainer/utils/ini_wrapper.cpp
+++ b/nntrainer/utils/ini_wrapper.cpp
@@ -12,9 +12,11 @@
  */
 #include <ini_wrapper.h>
 
+#include <regex>
+
 #include <nntrainer_error.h>
 #include <parse_util.h>
-#include <regex>
+#include <util_func.h>
 
 namespace nntrainer {
 
@@ -116,15 +118,12 @@ void IniWrapper::updateSections(const Sections &sections_) {
 void IniWrapper::save_ini() { save_ini(getIniName()); }
 
 void IniWrapper::save_ini(const std::string &ini_name) {
-  std::ofstream out(ini_name.c_str(), std::ios_base::out);
-  NNTR_THROW_IF(!out.good(), std::runtime_error) << "cannot open ini";
+  auto out = checkedOpenStream<std::ofstream>(ini_name, std::ios_base::app);
 
   for (auto &it : sections) {
     it.print(out);
     out << std::endl;
   }
-
-  out.close();
 }
 
 } // namespace nntrainer

--- a/nntrainer/utils/ini_wrapper.h
+++ b/nntrainer/utils/ini_wrapper.h
@@ -336,6 +336,7 @@ public:
    * @param ini_name ini name to svae
    */
   void save_ini(const std::string &ini_name);
+
   /**
    * @brief erase ini
    *

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -296,11 +296,9 @@ unsigned int parseOptProperty(std::string property) {
    * beta1 = 3,
    * beta2 = 4,
    * epsilon = 5,
-   * continue_train = 6,
    */
   std::array<std::string, 7> property_string = {
-    "learning_rate", "decay_rate", "decay_steps",   "beta1",
-    "beta2",         "epsilon",    "continue_train"};
+    "learning_rate", "decay_rate", "decay_steps", "beta1", "beta2", "epsilon"};
 
   for (i = 0; i < property_string.size(); i++) {
     unsigned int size = (property_string[i].size() > property.size())
@@ -313,33 +311,6 @@ unsigned int parseOptProperty(std::string property) {
   }
 
   return (unsigned int)Optimizer::PropertyType::unknown;
-}
-
-unsigned int parseNetProperty(std::string property) {
-  unsigned int i;
-
-  /**
-   * @brief     Network Properties
-   * loss_val = 0,
-   * loss = 1,
-   * batch_size = 2,
-   * epochs = 3,
-   * save_path = 4
-   */
-  std::array<std::string, 5> property_string = {
-    "loss_val", "loss", "batch_size", "epochs", "save_path"};
-
-  for (i = 0; i < property_string.size(); i++) {
-    unsigned int size = (property_string[i].size() > property.size())
-                          ? property_string[i].size()
-                          : property.size();
-
-    if (!strncasecmp(property_string[i].c_str(), property.c_str(), size)) {
-      return (i);
-    }
-  }
-
-  return (unsigned int)NeuralNetwork::PropertyType::unknown;
 }
 
 int setUint(unsigned int &val, const std::string &str) {

--- a/nntrainer/utils/parse_util.h
+++ b/nntrainer/utils/parse_util.h
@@ -35,13 +35,6 @@
 
 namespace nntrainer {
 
-#define NN_RETURN_STATUS()         \
-  do {                             \
-    if (status != ML_ERROR_NONE) { \
-      return status;               \
-    }                              \
-  } while (0)
-
 /**
  * @brief     Enumeration for input configuration file parsing
  *            0. MODEL   ( Model Token )
@@ -61,28 +54,6 @@ typedef enum {
   TOKEN_UNKNOWN
 } InputType;
 
-/**
- * @brief convert integer based status to throw
- *
- * @param status status to throw
- */
-inline void throw_status(int status) {
-  switch (status) {
-  case ML_ERROR_NONE:
-    break;
-  case ML_ERROR_INVALID_PARAMETER:
-    throw std::invalid_argument("invalid argument from c style throw");
-  case ML_ERROR_OUT_OF_MEMORY:
-    throw std::bad_alloc();
-  case ML_ERROR_TIMED_OUT:
-    throw std::runtime_error("Timed out from c style throw");
-  case ML_ERROR_PERMISSION_DENIED:
-    throw std::runtime_error("permission denied from c style throw");
-  case ML_ERROR_UNKNOWN:
-  default:
-    throw std::runtime_error("unknown error from c style throw");
-  }
-}
 /**
  * @brief     Parsing Layer Property
  * @param[in] property string to be parsed

--- a/nntrainer/utils/parse_util.h
+++ b/nntrainer/utils/parse_util.h
@@ -112,20 +112,6 @@ unsigned int parseType(std::string ll, InputType t);
  */
 unsigned int parseOptProperty(std::string property);
 
-/**
- * @brief     Parsing Network Property
- * @param[in] property string to be parsed
- * @retval    int enumerated type
- */
-unsigned int parseNetProperty(std::string property);
-
-/**
- * @brief     Parsing Data Buffer Property
- * @param[in] property string to be parsed
- * @retval    int enumerated type
- */
-unsigned int parseDataProperty(std::string property);
-
 } /* namespace nntrainer */
 
 #endif /* __cplusplus */

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -31,6 +31,36 @@
 #include <tensor.h>
 namespace nntrainer {
 
+#define NN_RETURN_STATUS()         \
+  do {                             \
+    if (status != ML_ERROR_NONE) { \
+      return status;               \
+    }                              \
+  } while (0)
+
+/**
+ * @brief convert integer based status to throw
+ *
+ * @param status status to throw
+ */
+inline void throw_status(int status) {
+  switch (status) {
+  case ML_ERROR_NONE:
+    break;
+  case ML_ERROR_INVALID_PARAMETER:
+    throw std::invalid_argument("invalid argument from c style throw");
+  case ML_ERROR_OUT_OF_MEMORY:
+    throw std::bad_alloc();
+  case ML_ERROR_TIMED_OUT:
+    throw std::runtime_error("Timed out from c style throw");
+  case ML_ERROR_PERMISSION_DENIED:
+    throw std::runtime_error("permission denied from c style throw");
+  case ML_ERROR_UNKNOWN:
+  default:
+    throw std::runtime_error("unknown error from c style throw");
+  }
+}
+
 /**
  * @brief     get the seed
  * @return    seed

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -413,12 +413,12 @@ TEST(nntrainer_ccapi, save_ini_p) {
   EXPECT_EQ(model->compile(), ML_ERROR_NONE);
   EXPECT_EQ(model->initialize(), ML_ERROR_NONE);
   auto saved_ini_name = s.getIniName() + "_saved";
-  model->save(saved_ini_name, ml::train::ModelFormat::MODEL_FORMAT_INI);
-
   if (remove(saved_ini_name.c_str())) {
     std::cerr << "remove ini " << saved_ini_name
               << "failed, reason: " << strerror(errno);
   }
+
+  model->save(saved_ini_name, ml::train::ModelFormat::MODEL_FORMAT_INI);
 }
 
 /**

--- a/test/unittest/memory/memory_planner_validate.cpp
+++ b/test/unittest/memory/memory_planner_validate.cpp
@@ -50,7 +50,7 @@ static bool validateNoOverlap(const std::vector<size_t> &memory_size,
 
   /** This ensures that there are no unnecessary gaps in between */
   EXPECT_EQ(mem_overlap.size(),
-            std::accumulate(mem_overlap.begin(), mem_overlap.end(), 0));
+            std::accumulate(mem_overlap.begin(), mem_overlap.end(), 0u));
 
   return true;
 }
@@ -102,7 +102,7 @@ TEST_P(MemoryPlannerValidate, full_overlap) {
     planner->planLayout(memory_size, memory_validity, memory_offset);
 
   EXPECT_EQ(pool_size,
-            std::accumulate(memory_size.begin(), memory_size.end(), 0));
+            std::accumulate(memory_size.begin(), memory_size.end(), 0u));
   EXPECT_TRUE(validateNoOverlap(memory_size, memory_offset, pool_size));
   EXPECT_TRUE(validateOverflow(memory_size, memory_offset, pool_size));
 }
@@ -131,7 +131,7 @@ TEST_P(MemoryPlannerValidate, none_overlap) {
   EXPECT_TRUE(validateOverflow(memory_size, memory_offset, pool_size));
   if (planner->getType() == nntrainer::BasicPlanner::type) {
     EXPECT_EQ(pool_size,
-              std::accumulate(memory_size.begin(), memory_size.end(), 0));
+              std::accumulate(memory_size.begin(), memory_size.end(), 0u));
     EXPECT_TRUE(validateNoOverlap(memory_size, memory_offset, pool_size));
   } else {
     EXPECT_EQ(pool_size,
@@ -167,7 +167,7 @@ TEST_P(MemoryPlannerValidate, partial_overlap) {
   EXPECT_TRUE(validateOverflow(memory_size, memory_offset, pool_size));
   if (planner->getType() == nntrainer::BasicPlanner::type) {
     EXPECT_EQ(pool_size,
-              std::accumulate(memory_size.begin(), memory_size.end(), 0));
+              std::accumulate(memory_size.begin(), memory_size.end(), 0u));
     EXPECT_TRUE(validateNoOverlap(memory_size, memory_offset, pool_size));
   } else {
     EXPECT_EQ(pool_size,


### PR DESCRIPTION
- [ini] Implement model save

```
This patch implements model section save in ini format

**Side Changes proposed in this PR:**
- Move `THROW_STATUS` and `RETURN_STATUS` to util_func.h

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [ini] Migrate to properties for model

```
This patch migrate to properties for neuralnet

**Semantic Changes**
- NeuralNetwork::batch_size does not change when actual batchsize change
from neuralnetwork instead, model graph keeps batch size separately.

**Changes proposed in this PR:**
- Move members to props in model
- Move inline declaration to declaration for some functions
- Remove unused member/functions from parse_util / neuralnet

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [ini] Prepare model properties

```
This patch prepare model properties in `model_common_properties`

**Additional Changes proposed in this PR:**
- Add PositiveIntegerProperty base class
- Fix copy assignment/ctor in base_properties

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```