### PR TITLE
[ini/save] Save Optimizer Section

### DIFF
--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -21,7 +21,6 @@
 #include <layer_node.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
-#include <node_exporter.h>
 #include <parse_util.h>
 #include <time_dist.h>
 #include <util_func.h>
@@ -260,18 +259,8 @@ void IniGraphInterpreter::serialize(const GraphRepresentation &representation,
        iter++) {
     const auto &ln = *iter;
 
-    IniSection s(ln->getName());
+    IniSection s = IniSection::FromExportable(ln->getName(), *ln);
     s.setEntry("type", ln->getType());
-
-    Exporter e;
-    ln->exportTo(e, ExportMethods::METHOD_STRINGVECTOR);
-
-    const auto key_val_pairs =
-      e.getResult<ExportMethods::METHOD_STRINGVECTOR>();
-
-    for (const auto &pair : *key_val_pairs) {
-      s.setEntry(pair.first, pair.second);
-    }
 
     sections.push_back(s);
   }

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -423,7 +423,10 @@ void NeuralNetwork::saveModelIni(const std::string &file_path) {
   IniSection model_section = IniSection::FromExportable("model", *this);
   model_section.setEntry("type", "NeuralNetwork");
 
-  IniWrapper wrapper("model_saver", {model_section});
+  IniSection optimizer_section = IniSection::FromExportable("optimizer", *opt);
+  optimizer_section.setEntry("type", opt->getType());
+
+  IniWrapper wrapper("model_saver", {model_section, optimizer_section});
   wrapper.save_ini(file_path);
 
   IniGraphInterpreter interpreter;

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -420,17 +420,8 @@ void NeuralNetwork::saveModelIni(const std::string &file_path) {
        "permitted, path: "
     << file_path;
 
-  IniSection model_section("model");
+  IniSection model_section = IniSection::FromExportable("model", *this);
   model_section.setEntry("type", "NeuralNetwork");
-
-  Exporter e;
-  e.saveResult(model_props, ExportMethods::METHOD_STRINGVECTOR, this);
-  e.saveResult(model_flex_props, ExportMethods::METHOD_STRINGVECTOR, this);
-
-  const auto key_val_pairs = e.getResult<ExportMethods::METHOD_STRINGVECTOR>();
-  for (const auto &pair : *key_val_pairs) {
-    model_section.setEntry(pair.first, pair.second);
-  }
 
   IniWrapper wrapper("model_saver", {model_section});
   wrapper.save_ini(file_path);
@@ -834,6 +825,12 @@ void NeuralNetwork::printPreset(std::ostream &out, unsigned int preset) {
   }
 
   print(out, flags, layer_preset);
+}
+
+void NeuralNetwork::exportTo(Exporter &exporter,
+                             const ExportMethods &method) const {
+  exporter.saveResult(model_props, method, this);
+  exporter.saveResult(model_flex_props, method, this);
 }
 
 void NeuralNetwork::print(std::ostream &out, unsigned int flags,

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -53,6 +53,9 @@ enum class DatasetModeType;
 
 namespace nntrainer {
 
+class Exporter;
+enum class ExportMethods;
+
 /**
  * @brief     Enumeration of Network Type
  */
@@ -352,6 +355,15 @@ public:
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
   int getLayer(const char *name, NodeType *layer);
+
+  /**
+   * @brief this function helps exporting the layer in a predefined format,
+   * while workarounding issue caused by templated function type eraser
+   *
+   * @param     exporter exporter that conatins exporting logic
+   * @param     method enum value to identify how it should be exported to
+   */
+  void exportTo(Exporter &exporter, const ExportMethods &method) const;
 
   /**
    * @brief     get input dimension of neural network

--- a/nntrainer/optimizers/adam.h
+++ b/nntrainer/optimizers/adam.h
@@ -101,7 +101,7 @@ public:
   /**
    * @copydoc Optimizer::setProperty(const std::vector<std::string> &values)
    */
-  virtual void setProperty(const std::vector<std::string> &values) override;
+  void setProperty(const std::vector<std::string> &values) override;
 
 private:
   std::tuple<PropsB1, PropsB2, PropsEpsilon> adam_props;

--- a/nntrainer/optimizers/adam.h
+++ b/nntrainer/optimizers/adam.h
@@ -14,9 +14,43 @@
 #define __ADAM_H__
 #ifdef __cplusplus
 
+#include <tuple>
+
+#include <base_properties.h>
 #include <optimizer_impl.h>
 
 namespace nntrainer {
+
+/**
+ * @brief Beta 1 props
+ *
+ */
+class PropsB1 : public Property<double> {
+public:
+  static constexpr const char *key = "beta1"; /**< unique key to access */
+  using prop_tag = double_prop_tag;           /**< property type */
+};
+
+/**
+ * @brief Beta 2 props
+ *
+ */
+class PropsB2 : public Property<double> {
+public:
+  static constexpr const char *key = "beta2"; /**< unique key to access */
+  using prop_tag = double_prop_tag;           /**< property type */
+};
+
+/**
+ * @brief epsilon props
+ * @todo move this to common props
+ *
+ */
+class PropsEpsilon : public Property<double> {
+public:
+  static constexpr const char *key = "epsilon"; /**< unique key to access */
+  using prop_tag = double_prop_tag;             /**< property type */
+};
 
 /**
  * @class   Adam optimizer class
@@ -25,15 +59,16 @@ namespace nntrainer {
 class Adam : public OptimizerImpl {
 public:
   /**
-   * @brief     Constructor of Optimizer Class
+   * @brief Construct a new Adam object
+   *
    */
-  template <typename... Args>
-  Adam(float lr = 0.001f, double b1 = 0.9f, double b2 = 0.999f,
-       double ep = 1.0e-7f, Args... args) :
-    OptimizerImpl(lr, args...),
-    beta1(b1),
-    beta2(b2),
-    epsilon(ep) {}
+  Adam();
+
+  /**
+   * @brief Destroy the Adam object
+   *
+   */
+  ~Adam();
 
   /**
    * @copydoc applyGradient(RunOptimizerContext &context)
@@ -56,32 +91,20 @@ public:
   std::vector<TensorDim> getOptimizerVariableDim(const TensorDim &dim) override;
 
   /**
-   * @brief get beta1
+   * @copydoc Optimizer::exportTo(Exporter &exporter, const ExportMethods&
+   * method)
    */
-  double getBeta1() { return beta1; };
-
-  /**
-   * @brief get beta2
-   */
-  double getBeta2() { return beta2; };
-
-  /**
-   * @brief get epsilon
-   */
-  double getEpsilon() { return epsilon; }
+  void exportTo(Exporter &exporter, const ExportMethods &method) const override;
 
   inline static const std::string type = "adam";
 
-private:
-  double beta1;   /** momentum for grad */
-  double beta2;   /** momentum for grad**2 */
-  double epsilon; /** epsilon to protect overflow */
-
   /**
-   * @copydoc LayerImpl::setProperty(const std::string &key,
-                           const std::string &value)
+   * @copydoc Optimizer::setProperty(const std::vector<std::string> &values)
    */
-  void setProperty(const std::string &key, const std::string &value);
+  virtual void setProperty(const std::vector<std::string> &values) override;
+
+private:
+  std::tuple<PropsB1, PropsB2, PropsEpsilon> adam_props;
 };
 } /* namespace nntrainer */
 

--- a/nntrainer/optimizers/optimizer_devel.h
+++ b/nntrainer/optimizers/optimizer_devel.h
@@ -24,6 +24,9 @@
 
 namespace nntrainer {
 
+class Exporter;
+enum class ExportMethods;
+
 /**
  * @class   Optimizer Base class for optimizers
  * @brief   Base class for all optimizers
@@ -59,31 +62,14 @@ public:
   virtual void setProperty(const std::vector<std::string> &values);
 
   /**
-   * @brief     Default allowed properties
-   * Available for all optimizers
-   * - learning_rate : float
+   * @brief this function helps exporting the optimizer in a predefined format,
+   * while workarounding issue caused by templated function type eraser
    *
-   * Available for SGD and Adam optimizers
-   * - decay_rate : float,
-   * - decay_steps : float,
-   *
-   * Available for Adam optimizer
-   * - beta1 : float,
-   * - beta2 : float,
-   * - epsilon : float,
-   *
-   * @todo: convert to string
+   * @param     exporter exporter that conatins exporting logic
+   * @param     method enum value to identify how it should be exported to
    */
-  enum class PropertyType {
-    learning_rate = 0,
-    decay_rate = 1,
-    decay_steps = 2,
-    beta1 = 3,
-    beta2 = 4,
-    epsilon = 5,
-    continue_train = 6,
-    unknown = 7,
-  };
+  virtual void exportTo(Exporter &exporter, const ExportMethods &method) const {
+  }
 
   /**
    * @brief     finalize optimizer.

--- a/nntrainer/optimizers/optimizer_impl.h
+++ b/nntrainer/optimizers/optimizer_impl.h
@@ -16,9 +16,43 @@
 #define __OPTIMIZER_IMPL_H__
 #ifdef __cplusplus
 
+#include <tuple>
+
+#include <base_properties.h>
 #include <optimizer_devel.h>
 
 namespace nntrainer {
+
+/**
+ * @brief Learning Rate props
+ *
+ */
+class PropsLR : public Property<float> {
+public:
+  static constexpr const char *key =
+    "learning_rate";               /**< unique key to access */
+  using prop_tag = float_prop_tag; /**< property type */
+};
+
+/**
+ * @brief Decay rate property
+ *
+ */
+class PropsDecayRate : public Property<float> {
+public:
+  static constexpr const char *key = "decay_rate"; /**< unique key to access */
+  using prop_tag = float_prop_tag;                 /**< property type */
+};
+
+/**
+ * @brief decay steps property
+ *
+ */
+class PropsDecaySteps : public PositiveIntegerProperty {
+public:
+  static constexpr const char *key = "decay_steps"; /**< unique key to access */
+  using prop_tag = uint_prop_tag;                   /**< property type */
+};
 
 /**
  * @class   Optimizer Base class for optimizers
@@ -28,15 +62,10 @@ class OptimizerImpl : public Optimizer {
 
 public:
   /**
-   * @brief     Default Constructor of Optimizer Class
+   * @brief Construct a new Optimizer Impl object
+   *
    */
-  OptimizerImpl(float lr, float decay_rate = 1.0f, unsigned int decay_steps = 0,
-                float continue_train = false) :
-    Optimizer(),
-    learning_rate(lr),
-    decay_rate(decay_rate),
-    decay_steps(decay_steps),
-    continue_train(continue_train) {}
+  OptimizerImpl();
 
   /**
    * @brief  copy constructor
@@ -60,25 +89,7 @@ public:
    * @brief  Move assignment operator.
    * @parma[in] rhs OptimizerImpl to be moved.
    */
-  OptimizerImpl &operator=(OptimizerImpl &&rhs) = default;
-
-  /**
-   * @brief     get Learning Rate
-   * @retval    Learning rate in float
-   */
-  float getLearningRate() const { return learning_rate; };
-
-  /**
-   * @brief     get Decay Rate for learning rate decay
-   * @retval    decay rate
-   */
-  float getDecayRate() const { return decay_rate; };
-
-  /**
-   * @brief     get Decay Steps for learning rate decay
-   * @retval    decay steps
-   */
-  float getDecaySteps() const { return decay_steps; };
+  OptimizerImpl &operator=(OptimizerImpl &&rhs) noexcept = default;
 
   /**
    * @brief     get Learning Rate for the given iteration
@@ -88,9 +99,15 @@ public:
   double getLearningRate(size_t iteration) const;
 
   /**
-   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   * @copydoc Optimizer::setProperty(const std::vector<std::string> &values)
    */
   virtual void setProperty(const std::vector<std::string> &values);
+
+  /**
+   * @copydoc Optimizer::exportTo(Exporter &exporter, const ExportMethods&
+   * method)
+   */
+  void exportTo(Exporter &exporter, const ExportMethods &method) const override;
 
   /**
    * @brief     Get dimension of extra variables if the optimizer needs any.
@@ -103,22 +120,7 @@ public:
   }
 
 protected:
-  float learning_rate;      /**< learning rate */
-  float decay_rate;         /** decay rate for learning rate */
-  unsigned int decay_steps; /** decay steps for learning rate */
-  bool continue_train; /** Continue training with previous tensors for adam */
-
-  /**
-   * @brief setProperty individually
-   * @note By passing empty string, this can validate if @a type is valid
-   * @param[in] key key to be passed as string
-   * @param[in] value value to be passed, if empty string is passed, do nothing
-   * but throws error when @a type is invalid
-   * @exception exception::not_supported     when string type is not valid for
-   * the particular layer
-   * @exception std::invalid_argument invalid argument
-   */
-  virtual void setProperty(const std::string &key, const std::string &value);
+  std::tuple<PropsLR, PropsDecayRate, PropsDecaySteps> optimizer_impl_props;
 };
 
 } /* namespace nntrainer */

--- a/nntrainer/optimizers/sgd.cpp
+++ b/nntrainer/optimizers/sgd.cpp
@@ -15,6 +15,8 @@
 
 namespace nntrainer {
 
+SGD::SGD() { setProperty({"learning_rate=0.0001"}); }
+
 void SGD::applyGradient(RunOptimizerContext &context) {
   context.applyGradient(getLearningRate(context.getIteration()));
 }

--- a/nntrainer/optimizers/sgd.h
+++ b/nntrainer/optimizers/sgd.h
@@ -25,10 +25,10 @@ namespace nntrainer {
 class SGD : public OptimizerImpl {
 public:
   /**
-   * @brief     Constructor of Optimizer Class
+   * @brief Construct a new SGD object
+   *
    */
-  template <typename... Args>
-  SGD(float lr = 0.0001f, Args... args) : OptimizerImpl(lr, args...) {}
+  SGD();
 
   /**
    * @copydoc applyGradient(RunOptimizerContext &context)

--- a/nntrainer/utils/base_properties.cpp
+++ b/nntrainer/utils/base_properties.cpp
@@ -86,6 +86,18 @@ float str_converter<float_prop_tag, float>::from_string(
 }
 
 template <>
+std::string
+str_converter<double_prop_tag, double>::to_string(const double &value) {
+  return std::to_string(value);
+}
+
+template <>
+double
+str_converter<double_prop_tag, double>::from_string(const std::string &value) {
+  return std::stod(value);
+}
+
+template <>
 std::string str_converter<dimension_prop_tag, TensorDim>::to_string(
   const TensorDim &dimension) {
   std::stringstream ss;

--- a/nntrainer/utils/base_properties.cpp
+++ b/nntrainer/utils/base_properties.cpp
@@ -88,7 +88,9 @@ float str_converter<float_prop_tag, float>::from_string(
 template <>
 std::string
 str_converter<double_prop_tag, double>::to_string(const double &value) {
-  return std::to_string(value);
+  std::ostringstream ss;
+  ss << value;
+  return ss.str();
 }
 
 template <>

--- a/nntrainer/utils/base_properties.h
+++ b/nntrainer/utils/base_properties.h
@@ -99,6 +99,12 @@ struct dimension_prop_tag {};
 struct float_prop_tag {};
 
 /**
+ * @brief property is treated as double
+ *
+ */
+struct double_prop_tag {};
+
+/**
  * @brief property is treated as string
  *
  */
@@ -426,6 +432,20 @@ std::string str_converter<float_prop_tag, float>::to_string(const float &value);
 template <>
 float str_converter<float_prop_tag, float>::from_string(
   const std::string &value);
+
+/**
+ * @copydoc template <typename Tag, typename DataType> struct str_converter
+ */
+template <>
+std::string
+str_converter<double_prop_tag, double>::to_string(const double &value);
+
+/**
+ * @copydoc template <typename Tag, typename DataType> struct str_converter
+ */
+template <>
+double
+str_converter<double_prop_tag, double>::from_string(const std::string &value);
 
 /**
  * @brief convert dispatcher (to string)

--- a/nntrainer/utils/ini_wrapper.h
+++ b/nntrainer/utils/ini_wrapper.h
@@ -77,11 +77,13 @@ public:
   IniSection() : section_name(""), entry{} {};
 
   /**
-   * @brief Construct a new Ini Section object which implements object::exportTo
+   * @brief Construct a new Ini Section object from which implements
+   * object::exportTo
    *
    * @tparam Exportable object with member object::exportTo
    * @param section_name section name
    * @param exportable exportable object
+   * @return IniSection created section
    */
   template <typename Exportable>
   static IniSection FromExportable(const std::string &section_name,
@@ -93,7 +95,7 @@ public:
       e.getResult<ExportMethods::METHOD_STRINGVECTOR>();
 
     if (!key_val_pairs) {
-      throw std::invalid_argument("returend pairs are nullptr!");
+      throw std::invalid_argument("returned pairs are nullptr!");
     }
 
     for (const auto &pair : *key_val_pairs) {

--- a/nntrainer/utils/ini_wrapper.h
+++ b/nntrainer/utils/ini_wrapper.h
@@ -16,8 +16,9 @@
 #include <iostream>
 #include <map>
 #include <string>
-
 #include <vector>
+
+#include <node_exporter.h>
 
 #ifndef __INI_WRAPPER_H__
 #define __INI_WRAPPER_H__
@@ -74,6 +75,32 @@ public:
    *
    */
   IniSection() : section_name(""), entry{} {};
+
+  /**
+   * @brief Construct a new Ini Section object which implements object::exportTo
+   *
+   * @tparam Exportable object with member object::exportTo
+   * @param section_name section name
+   * @param exportable exportable object
+   */
+  template <typename Exportable>
+  static IniSection FromExportable(const std::string &section_name,
+                                   const Exportable &exportable) {
+    IniSection s(section_name);
+    Exporter e;
+    exportable.exportTo(e, ExportMethods::METHOD_STRINGVECTOR);
+    const auto key_val_pairs =
+      e.getResult<ExportMethods::METHOD_STRINGVECTOR>();
+
+    if (!key_val_pairs) {
+      throw std::invalid_argument("returend pairs are nullptr!");
+    }
+
+    for (const auto &pair : *key_val_pairs) {
+      s.setEntry(pair.first, pair.second);
+    }
+    return s;
+  }
 
   /**
    * @brief Default destructor for the Ini Section object

--- a/nntrainer/utils/parse_util.cpp
+++ b/nntrainer/utils/parse_util.cpp
@@ -285,34 +285,6 @@ unsigned int parseLayerProperty(std::string property) {
 
 std::string propToStr(unsigned int type) { return property_string[type]; }
 
-unsigned int parseOptProperty(std::string property) {
-  unsigned int i;
-
-  /**
-   * @brief     Optimizer Properties
-   * learning_rate = 0,
-   * decay_rate = 1,
-   * decay_steps = 2
-   * beta1 = 3,
-   * beta2 = 4,
-   * epsilon = 5,
-   */
-  std::array<std::string, 7> property_string = {
-    "learning_rate", "decay_rate", "decay_steps", "beta1", "beta2", "epsilon"};
-
-  for (i = 0; i < property_string.size(); i++) {
-    unsigned int size = (property_string[i].size() > property.size())
-                          ? property_string[i].size()
-                          : property.size();
-
-    if (!strncasecmp(property_string[i].c_str(), property.c_str(), size)) {
-      return (i);
-    }
-  }
-
-  return (unsigned int)Optimizer::PropertyType::unknown;
-}
-
 int setUint(unsigned int &val, const std::string &str) {
   int status = ML_ERROR_NONE;
   try {

--- a/nntrainer/utils/parse_util.h
+++ b/nntrainer/utils/parse_util.h
@@ -76,13 +76,6 @@ std::string propToStr(const unsigned int type);
  */
 unsigned int parseType(std::string ll, InputType t);
 
-/**
- * @brief     Parsing Optimizer Property
- * @param[in] property string to be parsed
- * @retval    int enumerated type
- */
-unsigned int parseOptProperty(std::string property);
-
 } /* namespace nntrainer */
 
 #endif /* __cplusplus */


### PR DESCRIPTION
- [ini/save] Save Optimizer Section

```
This patch saves optimizer section to ini.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [Optimizer] Refactor to use props

```
This patch refactors optimizer families to use properties while removing
some unused functions and constructors

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [IniWrapper] Add factory method

```
This patch adds a function to create ini section directly from
exportable which implements .exportTo to reduce overlapping codes

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```