### PR TITLE
[planner] Add optimized v1 planner 

### DIFF
--- a/Applications/Resnet/jni/meson.build
+++ b/Applications/Resnet/jni/meson.build
@@ -21,7 +21,6 @@ e = executable('nntrainer_resnet18',
   install_dir: application_install_dir
 )
 
-
 if get_option('enable-long-test')
   testenv = environment()
   testenv.set('OPENBLAS_NUM_THREADS', '4')

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -426,6 +426,9 @@ void NetworkGraph::setBatchSize(unsigned int batch_size) {
     return;
 
   this->batch_size = batch_size;
+  if (!input_list.empty() and input_list[0]->getDim().batch() == batch_size)
+    return;
+
   auto allocated = tensor_manager->isAllocated();
 
   if (allocated)

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -441,7 +441,8 @@ void NetworkGraph::setBatchSize(unsigned int batch_size) {
         tensor_manager->setBatchSize(ts.getName(), ts.getDim().batch());
         if (context.tensorHasGradient(idx)) {
           auto const &ts_grad = context.getTensorGrad(idx);
-          tensor_manager->setBatchSize(ts_grad.getName(), ts.getDim().batch());
+          tensor_manager->setBatchSize(ts_grad.getName(),
+                                       ts_grad.getDim().batch());
         }
       }
     }

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -279,8 +279,13 @@ public:
        * and pass that as the max_exec_order ensuring that all tensors with
        * usage less than the max_exec_order are allocated.
        */
+#ifdef ENABLE_TEST
+      tensor_manager->allocateTensors(
+        std::get<2>((*(cbegin()))->getExecutionOrder()));
+#else
       tensor_manager->allocateTensors(
         std::get<1>((*(cbegin()))->getExecutionOrder()));
+#endif
   }
 
   /**

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -272,13 +272,13 @@ public:
       tensor_manager->allocateTensors(
         std::get<0>((*(cend() - 1))->getExecutionOrder()));
     else
-      /** @todo update this to skip non-trainable layers */
-      /**
-       * get the order of execution/usage order for the backwarding of the first
-       * layer (as that will be the last layer to executed in the backwarding)
-       * and pass that as the max_exec_order ensuring that all tensors with
-       * usage less than the max_exec_order are allocated.
-       */
+    /** @todo update this to skip non-trainable layers */
+    /**
+     * get the order of execution/usage order for the backwarding of the first
+     * layer (as that will be the last layer to executed in the backwarding)
+     * and pass that as the max_exec_order ensuring that all tensors with
+     * usage less than the max_exec_order are allocated.
+     */
 #ifdef ENABLE_TEST
       tensor_manager->allocateTensors(
         std::get<2>((*(cbegin()))->getExecutionOrder()));

--- a/nntrainer/tensor/basic_planner.cpp
+++ b/nntrainer/tensor/basic_planner.cpp
@@ -2,7 +2,7 @@
 /**
  * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file   basic_planner.h
+ * @file   basic_planner.cpp
  * @date   11 August 2021
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Parichay Kapoor <pk.kapoor@samsung.com>

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -38,6 +38,12 @@ public:
   MemoryPool() : mem_pool(nullptr), pool_size(0), min_pool_size(0) {}
 
   /**
+   * @brief MemoryPool destructor
+   *
+   */
+  ~MemoryPool() { deallocate(); }
+
+  /**
    * @brief Request Memory from memory pool
    *
    * @param bytes The size of the memory requested in bytes

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -8,7 +8,8 @@ tensor_sources = [
   'weight.cpp',
   'basic_planner.cpp',
   'memory_pool.cpp',
-  'tensor_pool.cpp'
+  'tensor_pool.cpp',
+  'optimized_v1_planner.cpp'
 ]
 
 tensor_headers = [

--- a/nntrainer/tensor/optimized_v1_planner.cpp
+++ b/nntrainer/tensor/optimized_v1_planner.cpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   optimized_v1_planner.cpp
+ * @date   3 September 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Optimized V1 Memory Planner
+ *
+ */
+
+#include <algorithm>
+#include <queue>
+#include <vector>
+
+#include <optimized_v1_planner.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Memory Request data structure clubbing all the requests
+ *
+ */
+struct MemoryRequest {
+  unsigned int start; /**< start of the validity (inclusive) */
+  unsigned int end;   /**< end of the validity (exclusive) */
+  unsigned int loc;   /**< index/location of the this request */
+  size_t size;        /**< size of the request */
+  size_t offset;      /**< offset for this request */
+
+  /**
+   * @brief Constructor for the Memory Request
+   *
+   */
+  MemoryRequest(size_t s, std::pair<unsigned int, unsigned int> valid,
+                unsigned int idx) :
+    start(valid.first),
+    end(valid.second),
+    loc(idx),
+    size(s),
+    offset(0) {}
+};
+
+/**
+ * @copydoc MemoryPlanner::planLayout(
+ * const std::vector<size_t> &memory_size,
+ * const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
+ * std::vector<size_t> &memory_offset);
+ *
+ * @details The optimized v1 memory planner assigns memory to the requests whose
+ * validity starts first.
+ * The requested memories are sorted based on the ascending order of the start
+ * timestamps, and descending order using the end timestamps. The
+ * sorted memories are given increasing offset based on the memory size.
+ * At the end of each timestamp, invalid memories are freed, and offset updated
+ * for reuse. This planner allocates overlapping memory for all the required
+ * memories.
+ *
+ */
+size_t OptimizedV1Planner::planLayout(
+  const std::vector<size_t> &memory_size,
+  const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
+  std::vector<size_t> &memory_offset) const {
+
+  /** create memory requests structure array for easier management */
+  std::vector<MemoryRequest> requests;
+  requests.reserve(memory_size.size());
+
+  for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
+    requests.emplace_back(memory_size[idx], memory_validity[idx], idx);
+  }
+
+  /**
+   * sort the memory requests with ascending order of start time first, and
+   * then end time
+   */
+  std::sort(requests.begin(), requests.end(),
+            [](auto const &v1, auto const &v2) -> int {
+              if (v1.start == v2.start)
+                return v1.end < v2.end;
+              return v1.start < v2.start;
+              /** TODO: try this */
+              //   if (v1.end == v2.end)
+              //     return v1.start < v2.start;
+              //   return v1.end > v2.end;
+            });
+
+  /** all the memories in use sorted by their assigned offset */
+  auto cmp = [](const MemoryRequest *v1, const MemoryRequest *v2) -> bool {
+    return v1->offset < v2->offset;
+  };
+  std::priority_queue<MemoryRequest *, std::vector<MemoryRequest *>,
+                      decltype(cmp)>
+    pq(cmp);
+
+  /** iterate over the sorted requests and start allocation of the requests */
+  size_t memory_req = 0;
+  for (auto &req : requests) {
+    /** remove expired memories and update offset */
+    while (!pq.empty() && pq.top()->end <= req.start)
+      pq.pop();
+
+    /** get the offset based on the max valid offset */
+    size_t offset = 0;
+    if (!pq.empty())
+      offset = pq.top()->offset + pq.top()->size;
+
+    /** assign offset to the new request and push to queue */
+    req.offset = offset;
+    memory_req = std::max(memory_req, req.offset + req.size);
+    pq.push(&req);
+  }
+
+  /** set the memory offset in the return array */
+  memory_offset.resize(memory_size.size());
+  for (auto const &req : requests)
+    memory_offset[req.loc] = req.offset;
+
+  return memory_req;
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/optimized_v1_planner.h
+++ b/nntrainer/tensor/optimized_v1_planner.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   optimzied_v1_planner.h
+ * @date   2 September 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Optimized V1 Memory Planner
+ *
+ * @note This planner has been design to give reduced memory usage for training
+ * and might not perform very well for inference.
+ *
+ * @details The principle for this planner is to give memory to the requests in
+ * the order of the start of their validity.
+ * This takes advantage of the pattern that the outputs of the layer nodes
+ * allocated during forwarding are also used during backwarding as well.
+ *
+ * If two memory requests have the same start time, then the memory request with
+ * higher end is allocated first. This is to minimize the fragmentation once the
+ * memory is being freed.
+ *
+ * The assigned memories are cached, and once their validity is finished, they
+ * are freed and reused for the next allocations.
+ */
+
+#ifndef __OPTIMIZED_V1_PLANNER_H_
+#define __OPTIMIZED_V1_PLANNER_H_
+
+#include <vector>
+
+#include <memory_planner.h>
+
+namespace nntrainer {
+
+/**
+ * @class   OptimizedV1Planner
+ * @brief   Optimized V1 Memory Planner provides the optimized plan for memory
+ * layout
+ * @details optimized planner performs sharing of overlapping memory sharing
+ * upto certain extent
+ */
+class OptimizedV1Planner : public MemoryPlanner {
+public:
+  /**
+   * @brief OptimizedV1Planner destructor
+   *
+   */
+  OptimizedV1Planner() = default;
+
+  /**
+   * @copydoc MemoryPlanner::planLayout(
+   * const std::vector<size_t> &memory_size,
+   * const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
+   * std::vector<size_t> &memory_offset);
+   *
+   */
+  size_t planLayout(
+    const std::vector<size_t> &memory_size,
+    const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
+    std::vector<size_t> &memory_offset) const;
+
+  /**
+   * @copydoc MemoryPlanner::getType() const
+   *
+   */
+  const std::string &getType() const { return type; }
+
+  inline static const std::string type = "optimized_v1_planner";
+};
+
+} // namespace nntrainer
+
+#endif /** __OPTIMIZED_V1_PLANNER_H_ */

--- a/test/unittest/memory/memory_planner_validate.cpp
+++ b/test/unittest/memory/memory_planner_validate.cpp
@@ -82,7 +82,21 @@ static bool validateIntervalOverlap(
   const std::vector<size_t> &memory_size,
   const std::vector<size_t> &memory_offset) {
   std::vector<unsigned int> valid_intervals;
+  std::vector<unsigned int> sorted_by_validity(memory_size.size());
+
+  /** sort the intervals by their validity for comparison */
   for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
+    sorted_by_validity[idx] = idx;
+  }
+  std::sort(
+    sorted_by_validity.begin(), sorted_by_validity.end(),
+    [&memory_validity](auto const &idx1, auto const &idx2) -> unsigned int {
+      if (memory_validity[idx1].first == memory_validity[idx2].first)
+        return memory_validity[idx1].second < memory_validity[idx2].second;
+      return memory_validity[idx1].first < memory_validity[idx2].first;
+    });
+
+  for (unsigned int idx : sorted_by_validity) {
     /**
      * intervals which have finished before the start of the current intervals
      * must be popped

--- a/test/unittest/memory/unittest_memory_planner.cpp
+++ b/test/unittest/memory/unittest_memory_planner.cpp
@@ -15,6 +15,10 @@
 #include <memory_planner_validate.h>
 
 #include <basic_planner.h>
+#include <optimized_v1_planner.h>
 
 INSTANTIATE_TEST_CASE_P(BasicPlanner, MemoryPlannerValidate,
                         ::testing::Values(nntrainer::BasicPlanner::type));
+
+INSTANTIATE_TEST_CASE_P(OptimizedV1Planner, MemoryPlannerValidate,
+                        ::testing::Values(nntrainer::OptimizedV1Planner::type));

--- a/test/unittest/memory/unittest_memory_pool.cpp
+++ b/test/unittest/memory/unittest_memory_pool.cpp
@@ -480,8 +480,13 @@ TEST_P(MemoryPlannerValidate, validate_memory_no_overlap) {
   }
 
   EXPECT_NO_THROW(pool.planLayout(*planner.get()));
-  EXPECT_EQ(pool.size(),
-            std::accumulate(memory_size.begin(), memory_size.end(), 0u));
+  if (planner->getType() == nntrainer::BasicPlanner::type) {
+    EXPECT_EQ(pool.size(),
+              std::accumulate(memory_size.begin(), memory_size.end(), 0u));
+  } else {
+    EXPECT_EQ(pool.size(),
+              *std::max_element(memory_size.begin(), memory_size.end()));
+  }
   EXPECT_NO_THROW(pool.allocate());
 
   for (unsigned int idx = 0; idx < MEM_QUANT; idx++)
@@ -523,8 +528,15 @@ TEST_P(MemoryPlannerValidate, validate_memory_partial_overlap) {
   }
 
   EXPECT_NO_THROW(pool.planLayout(*planner.get()));
-  EXPECT_EQ(pool.size(),
-            std::accumulate(memory_size.begin(), memory_size.end(), 0u));
+  if (planner->getType() == nntrainer::BasicPlanner::type) {
+    EXPECT_EQ(pool.size(),
+              std::accumulate(memory_size.begin(), memory_size.end(), 0u));
+  } else {
+    EXPECT_GE(pool.size(),
+              *std::max_element(memory_size.begin(), memory_size.end()));
+    EXPECT_LE(pool.size(),
+              std::accumulate(memory_size.begin(), memory_size.end(), 0u));
+  }
   EXPECT_NO_THROW(pool.allocate());
 
   for (unsigned int idx = 0; idx < MEM_QUANT; idx++)


### PR DESCRIPTION
- This patch adds an optimized v1 planner for memory sharing.
- This planner assigns memory in the order of start of the validity,
and then by decreasing the order of the end of the validity. This matches
the memory use pattern while training the model.
This planner is supposed to work better for training than for inference.
- Also added unit tests for the optimized v1 planner.

Merged changes from #1539 (as it became a trivial PR after rebase):
- This patch enables resnet application with some fixes. tensor allocation for ENABLE_TEST mode updated.

See Also #1127
Resolves #1533

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>