### PR TITLE
[graph/manager] bug fix + Enable memory v1 optimizations 

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -142,6 +142,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/tensor_pool.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/memory_pool.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/basic_planner.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/tensor/optimized_v1_planner.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/tensor/blas_interface.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/layer_node.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/layer_context.cpp \

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -77,7 +77,7 @@ void NetworkGraph::setExecutionOrder() {
     auto &node = *iter;
     auto order_idx = iter - cbegin();
     auto forward_order = order_idx;
-    auto calc_gradient_order = max_count - ((order_idx+1) * 2);
+    auto calc_gradient_order = max_count - ((order_idx + 1) * 2);
     /** calc derivative is called right after calc_gradient */
     auto calc_derivative_order = calc_gradient_order + 1;
     node->setExecutionOrder(

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -71,13 +71,13 @@ int NetworkGraph::compile(const std::string &loss_type) {
 }
 
 void NetworkGraph::setExecutionOrder() {
-  auto node_count = graph.size();
+  auto max_count = graph.size() * 3;
   /** @todo: remove backwarding count for non-trainble layers */
   for (auto iter = cbegin(); iter != cend(); iter++) {
     auto &node = *iter;
     auto order_idx = iter - cbegin();
     auto forward_order = order_idx;
-    auto calc_gradient_order = (node_count * 3) - (order_idx * 2) + 1;
+    auto calc_gradient_order = max_count - ((order_idx+1) * 2);
     /** calc derivative is called right after calc_gradient */
     auto calc_derivative_order = calc_gradient_order + 1;
     node->setExecutionOrder(

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -309,6 +309,15 @@ public:
   void deallocateWeights() { tensor_manager->deallocateWeights(); }
 
   /**
+   * @brief     Enable the memory optimizations for the network
+   *
+   * @param val true to enable, else false
+   */
+  void setMemoryOptimizations(bool val) {
+    tensor_manager->setOptimizations(val);
+  }
+
+  /**
    * @brief     Create optimizer variable for every weights
    *
    * @param cb  Call back function which will return vector of dimension

--- a/nntrainer/layers/flatten_layer.cpp
+++ b/nntrainer/layers/flatten_layer.cpp
@@ -9,6 +9,7 @@
  * @bug	   No known bugs except for NYI items
  * @brief  This is Flatten Layer Class for Neural Network
  *
+ * @todo Update flatten to work in-place properly.
  */
 
 #include <flatten_layer.h>
@@ -47,8 +48,9 @@ void FlattenLayer::forwarding(RunLayerContext &context, bool training) {
   Tensor temp = context.getInput(SINGLE_INOUT_IDX);
   Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
 
-  temp.reshape(out.getDim());
-  out = temp;
+  auto const &shape = out.getDim();
+  out.copy(temp);
+  out.reshape(shape);
 }
 
 void FlattenLayer::calcDerivative(RunLayerContext &context) {
@@ -60,8 +62,9 @@ void FlattenLayer::calcDerivative(RunLayerContext &context) {
   Tensor temp = context.getIncomingDerivative(SINGLE_INOUT_IDX);
   Tensor &ret_derivative = context.getOutgoingDerivative(SINGLE_INOUT_IDX);
 
-  temp.reshape(ret_derivative.getDim());
-  ret_derivative = temp;
+  auto const &shape = ret_derivative.getDim();
+  ret_derivative.copy(temp);
+  ret_derivative.reshape(shape);
 }
 
 void FlattenLayer::setProperty(const std::vector<std::string> &values) {

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -278,6 +278,20 @@ public:
                                  unsigned int batch);
 
   /**
+   * @brief     Enable the memory optimizations for the network
+   *
+   */
+  void enableMemoryOptimizations() { model_graph.setMemoryOptimizations(true); }
+
+  /**
+   * @brief     Enable the memory optimizations for the network
+   *
+   */
+  void disableMemoryOptimizations() {
+    model_graph.setMemoryOptimizations(false);
+  }
+
+  /**
    * @brief     Run NeuralNetwork train with callback function by user
    * @param[in] dt datatype (mode) where it should be
    * @param[in] dataset set the dataset

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -129,7 +129,7 @@ MMapedMemory::~MMapedMemory() noexcept {
 
 void Manager::allocateWeights(unsigned int max_exec_order_) {
   if (!weight_pool.isAllocated()) {
-    weight_pool.finalize(BasicPlanner(), 0, max_exec_order_);
+    finalizeTensorPool(weight_pool, 0, max_exec_order_);
     weight_pool.allocate();
   }
 }
@@ -143,7 +143,7 @@ void Manager::allocateTensors(unsigned int max_exec_order_) {
   allocateWeights(max_exec_order_);
 
   if (!tensor_pool.isAllocated()) {
-    tensor_pool.finalize(BasicPlanner(), 0, max_exec_order_);
+    finalizeTensorPool(tensor_pool, 0, max_exec_order_);
     if (tensor_pool.minMemoryRequirement() > 0)
       tensor_pool.allocate();
   }
@@ -519,6 +519,14 @@ std::vector<Weight *> Manager::getWeights() {
   }
 
   return all_weights;
+}
+
+void Manager::finalizeTensorPool(TensorPool &pool, unsigned int start,
+                                 unsigned int end) {
+  if (enable_optimizations)
+    pool.finalize(OptimizedV1Planner(), start, end);
+  else
+    pool.finalize(BasicPlanner(), start, end);
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -111,7 +111,7 @@ public:
   /**
    * @brief     Constructor of Manager
    */
-  Manager() = default;
+  Manager() : enable_optimizations(true) {}
 
   /**
    * @brief Construct a new Manager object (deleted)
@@ -289,6 +289,13 @@ public:
    */
   void deallocateWeights();
 
+  /**
+   * @brief Set optimizations for manager
+   *
+   * @param val true to enable, else false
+   */
+  void setOptimizations(bool val) { enable_optimizations = val; }
+
 private:
   /** @todo: merge this list to one */
   std::vector<std::unique_ptr<Weight>>
@@ -302,6 +309,18 @@ private:
 
   TensorPool weight_pool; /**< tensor pool to request tensors */
   TensorPool tensor_pool; /**< tensor pool to request tensors */
+
+  bool enable_optimizations; /**< to enable memory optimizations */
+
+  /**
+   * @brief Finalize the given tensor pool
+   *
+   * @param pool Tensor pool to finalize
+   * @param start Start execution order
+   * @param end End execution order
+   */
+  void finalizeTensorPool(TensorPool &pool, unsigned int start,
+                          unsigned int end);
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -71,7 +71,7 @@ double MemoryPool::planLayout(const MemoryPlanner &planner) {
   if (pool_size < min_pool_size || !validateLayout())
     throw std::runtime_error("Planned layout is not feasible");
 
-  return double(pool_size) / double(min_pool_size);
+  return double(min_pool_size) / double(pool_size);
 }
 
 /**

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -115,7 +115,7 @@ void TensorPool::finalize(const MemoryPlanner &planner,
     if (validity_end < start_order || validity_start > end_order)
       continue;
     validity_start = std::max(validity_start, start_order);
-    validity_end = std::max(validity_end, end_order);
+    validity_end = std::min(validity_end, end_order);
 
     /**
      * 3. requestMemory for all the tensors and set their tokens

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <memory_pool.h>
+#include <nntrainer_log.h>
 #include <tensor.h>
 #include <tensor_pool.h>
 #include <tensor_wrap_specs.h>
@@ -132,8 +133,10 @@ void TensorPool::finalize(const MemoryPlanner &planner,
   }
 
   /** 4. finalizeLayout for the memory pool. */
-  if (bytes_requested > 0)
-    mem_pool.planLayout(planner);
+  if (bytes_requested > 0) {
+    double efficiency = mem_pool.planLayout(planner);
+    ml_logd("Memory layout efficiency = %lf", efficiency);
+  }
 }
 
 /**

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -383,6 +383,8 @@ GraphWatcher::GraphWatcher(const std::string &config, const bool opt) :
 
   /** Disable memory optimization as memory being matched for each layer
    */
+  if (!opt)
+    nn.disableMemoryOptimizations();
 
   if (nn.loadFromConfig(config)) {
     throw std::invalid_argument("load from config failed!");


### PR DESCRIPTION
- Flatten layer in-place implementation manipulates the tensor stored in
its input and output. This violates the execution order usage of the
tensors and does not work with the memory planning setup.
This patch makes flatten layer to work out-of-place with a copy.
There will soon be a patch to make flatten work in-place with proper
method.
- Added bug fix in the execution order calculation where some of the
execution values were being missed in the previous implementation.
- Optimized v1 planner is updated to reuse expired allocations which are
not at the top the sorted list. This is a heuristic which works well for
training memory usage scenario.
The unittest is also updated to be more generic when checking the
interval overlap with the allocations.
-This patch adds the corresponding bug fixes:
  - end validity for each requested tensor is fixed
  - execution order for requestInputs and requestOutputs are fixed
  - output is specially handled for activation layer as it uses output in
derivative calculation
  - gradient of the weights is kept valid for calcDerivative as well
because gradients are applied to weights after calcDerivative.
- This patch adds interface to enable memory optimizations with the neural
network. Enabling the interface changes the planner being used for the
memory allocation.
With this patch, OptimizedV1Planner is put to use when enabling
optimizations.
Unittest of models is updated to disable optimizations in the
non-optimized test cases.

See Also #1127
The memory usage comparison with this patch is noted at https://github.com/nnstreamer/nntrainer/issues/1127#issuecomment-911320879

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>