### PR TITLE
[ini] Implement input layers property @open sesame 09/08 14:17

### DIFF
--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -74,7 +74,7 @@ public:
    *
    * @return list of name of the nodes which form input connections
    */
-  virtual const std::vector<std::string> &getInputConnections() const = 0;
+  virtual const std::vector<std::string> getInputConnections() const = 0;
 
   /**
    * @brief     Get the output connections for this node

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -719,6 +719,7 @@ int NetworkGraph::initialize() {
      */
     if (!is_input_node(lnode)) {
       auto &input_layers = lnode->getInputLayers();
+      lnode->resizeInputDimensions(input_layers.size());
       for (unsigned int i = 0; i < input_layers.size(); ++i) {
         auto in_layer_node = getLayerNode(input_layers[i]);
 

--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -23,6 +23,21 @@
 
 namespace nntrainer {
 namespace props {
+
+Name::Name() : nntrainer::Property<std::string>() {}
+
+Name::Name(const std::string &value) { set(value); }
+
+void Name::set(const std::string &value) {
+  auto to_lower = [](const std::string &str) {
+    std::string ret = str;
+    std::transform(ret.begin(), ret.end(), ret.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return ret;
+  };
+  nntrainer::Property<std::string>::set(to_lower(value));
+}
+
 bool Name::isValid(const std::string &v) const {
   static std::regex allowed("[a-zA-Z0-9][-_./a-zA-Z0-9]*");
   return !v.empty() && std::regex_match(v, allowed);

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -34,16 +34,24 @@ public:
    * @brief Construct a new Name object without a default value
    *
    */
-  Name() : nntrainer::Property<std::string>() {}
+  Name();
 
   /**
    * @brief Construct a new Name object with a default value
    *
    * @param value value to contrusct the property
    */
-  Name(const std::string &value) : nntrainer::Property<std::string>(value) {}
+  Name(const std::string &value);
+
   static constexpr const char *key = "name"; /**< unique key to access */
   using prop_tag = str_prop_tag;             /**< property type */
+
+  /**
+   * @brief Name setter
+   *
+   * @param value value to set
+   */
+  void set(const std::string &value) override;
 
   /**
    * @brief name validator
@@ -59,14 +67,10 @@ public:
  * @brief unit property, unit is used to measure how many weights are there
  *
  */
-class Unit : public nntrainer::Property<unsigned int> {
+class Unit : public PositiveIntegerProperty {
 public:
-  Unit(unsigned int value = 1) :
-    nntrainer::Property<unsigned int>(value) {} /**< default value if any */
-  static constexpr const char *key = "unit";    /**< unique key to access */
-  using prop_tag = uint_prop_tag;               /**< property type */
-
-  bool isValid(const unsigned int &v) const override { return v > 0; }
+  static constexpr const char *key = "unit"; /**< unique key to access */
+  using prop_tag = uint_prop_tag;            /**< property type */
 };
 
 /**

--- a/test/unittest/unittest_common_properties.cpp
+++ b/test/unittest/unittest_common_properties.cpp
@@ -110,7 +110,7 @@ TEST(InputSpecProperty, setPropertyValid_p) {
     InputSpec actual;
     nntrainer::from_string("A, B, C", actual);
     EXPECT_EQ(actual, expected);
-    EXPECT_EQ("A,B,C", nntrainer::to_string(actual));
+    EXPECT_EQ("a,b,c", nntrainer::to_string(actual));
   }
 
   {
@@ -119,17 +119,17 @@ TEST(InputSpecProperty, setPropertyValid_p) {
 
     InputSpec actual;
     nntrainer::from_string("A+ B +C", actual);
-    EXPECT_EQ("A+B+C", nntrainer::to_string(actual));
+    EXPECT_EQ("a+b+c", nntrainer::to_string(actual));
 
     EXPECT_EQ(actual, expected);
   }
 
   {
-    InputSpec expected(ConnectionSpec({Name("A")}, ConnectionSpec::NoneType));
+    InputSpec expected(ConnectionSpec({Name("a")}, ConnectionSpec::NoneType));
 
     InputSpec actual;
-    nntrainer::from_string("A", actual);
-    EXPECT_EQ("A", nntrainer::to_string(actual));
+    nntrainer::from_string("a", actual);
+    EXPECT_EQ("a", nntrainer::to_string(actual));
 
     EXPECT_EQ(actual, expected);
   }


### PR DESCRIPTION
- [ini] Implement input layers property

```
This patch implements input layers property while decoupling input
dimensions from input layers as much as possible
to make the property dumb.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```