### PR TITLE
[Wait for #1542] [LayerNode] Change context to be RAII

### DIFF
--- a/Applications/Custom/LayerPlugin/layer_plugin_common_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_common_test.cpp
@@ -46,8 +46,8 @@ TEST_P(LayerPluginCommonTest, DefaultEnvironmentPath_p) {
   auto lnode = std::static_pointer_cast<nntrainer::LayerNode>(l);
 
   EXPECT_THROW(lnode->setProperty({"invalid_values"}), std::invalid_argument);
-  EXPECT_EQ(lnode->getOutputDimensions().size(), size_t(0));
-  EXPECT_EQ(lnode->getInputDimensions().size(), size_t(0));
+  EXPECT_THROW(lnode->getOutputDimensions(), std::runtime_error);
+  EXPECT_THROW(lnode->getInputDimensions(), std::runtime_error);
 }
 
 TEST_P(LayerPluginCommonTest, DefaultEnvironmentPathLayerNotExist_n) {

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -248,13 +248,12 @@ public:
   /**
    * @brief Create run layer context from the given init layer context
    *
-   * @param init_context Init layer context to create run context
-   * @param run_context Run layer context to be created
+   * @param lnode layer node to finalize and set run context
+   * @param prev_inputs previous input information
    */
-  static std::vector<Var_Grad *>
-  updateRunContext(std::shared_ptr<Manager> &manager,
-                   const std::shared_ptr<LayerNode> &lnode,
-                   const std::vector<Var_Grad *> &inputs);
+  std::vector<Var_Grad *>
+  finalizeContext(const std::shared_ptr<LayerNode> &lnode,
+                  const std::vector<Var_Grad *> &prev_inputs);
 
   /** Interface for manager */
 

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -15,6 +15,20 @@
 #include <weight.h>
 
 namespace nntrainer {
+RunLayerContext::RunLayerContext(const std::string &name, float l,
+                                 const std::vector<Weight *> &w,
+                                 const std::vector<Var_Grad *> &in,
+                                 const std::vector<Var_Grad *> &out,
+                                 const std::vector<Var_Grad *> &t) :
+  loss(l),
+  weights(w),
+  inputs(in),
+  outputs(out),
+  tensors(t) {
+  std::get<props::Name>(props).set(name);
+  NNTR_THROW_IF(!readyToUse(), std::invalid_argument)
+    << "run context is not ready to use upon creation";
+}
 
 /**
  * @brief Get the Weight tensor object

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -40,19 +40,17 @@ public:
   /**
    * @brief Construct a new Init Layer Context object
    *
-   */
-  InitLayerContext() : InitLayerContext({}, 1) {}
-
-  /**
-   * @brief Construct a new Init Layer Context object
-   *
    * @param dim Input dimensions for the layer
    */
   InitLayerContext(const std::vector<TensorDim> &dim, unsigned int num_out,
-                   const std::string &n = "") :
+                   const std::string &n) :
     input_dim(dim),
     num_outputs(num_out),
-    name(n) {}
+    name(n) {
+    NNTR_THROW_IF(!validate(), std::invalid_argument)
+      << "Invalid init context name: " << name
+      << " num inputs: " << getNumInputs();
+  }
 
   /**
    * @brief   get name by the layer
@@ -269,8 +267,9 @@ public:
       }
     }
 
-    if (name.empty())
+    if (name.empty()) {
       return false;
+    }
 
     return true;
   }
@@ -301,20 +300,6 @@ class RunLayerContext {
 public:
   /**
    * @brief Construct a new Run Layer Context object
-   *
-   */
-  RunLayerContext() : loss(0.0) {}
-
-  /**
-   * @brief Construct a new Run Layer Context object
-   *
-   */
-  RunLayerContext(const std::string &name) : RunLayerContext() {
-    std::get<props::Name>(props).set(name);
-  }
-
-  /**
-   * @brief Construct a new Run Layer Context object
    * @todo  Include properties like name/trainable later
    *
    * @param w weights of the layer
@@ -326,14 +311,7 @@ public:
                   const std::vector<Weight *> &w,
                   const std::vector<Var_Grad *> &in,
                   const std::vector<Var_Grad *> &out,
-                  const std::vector<Var_Grad *> &t) :
-    loss(l),
-    weights(w),
-    inputs(in),
-    outputs(out),
-    tensors(t) {
-    std::get<props::Name>(props).set(name);
-  }
+                  const std::vector<Var_Grad *> &t);
 
   /**
    * @brief Get the Weight tensor object

--- a/nntrainer/layers/time_dist.cpp
+++ b/nntrainer/layers/time_dist.cpp
@@ -120,7 +120,7 @@ void TimeDistLayer::finalize(InitLayerContext &context) {
    */
   TensorDim dist_dim = input_dim;
   dist_dim.height(1);
-  InitLayerContext dist_context({dist_dim}, context.getNumOutputs());
+  InitLayerContext dist_context({dist_dim}, context.getNumOutputs(), getType());
 
   // During forwarding and backwarding, it set the input and output buffer of
   // dist_layer properly
@@ -407,7 +407,8 @@ void TimeDistLayer::setBatch(RunLayerContext &context, unsigned int batch) {
 void TimeDistLayer::setBatch(InitLayerContext &context, unsigned int batch) {
   TensorDim input_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
   input_dim.height(1);
-  InitLayerContext dist_context({input_dim}, context.getNumOutputs());
+  InitLayerContext dist_context({input_dim}, context.getNumOutputs(),
+                                getType());
 
   TensorDim output_dim = context.getOutputDimensions()[0];
   // input_dim.height is number of time iteration

--- a/test/unittest/layers/layers_dependent_common_tests.cpp
+++ b/test/unittest/layers/layers_dependent_common_tests.cpp
@@ -47,9 +47,7 @@ TEST_P(LayerSemantics, finalizeValidateLayerNode_p) {
   EXPECT_NO_THROW(lnode->setProperty(valid_properties));
 
   if (!must_fail) {
-    EXPECT_NO_THROW(lnode->finalize());
-
-    auto &init_context = lnode->getInitContext();
+    nntrainer::InitLayerContext init_context = lnode->finalize();
     EXPECT_EQ(init_context.getOutputDimensions().size(),
               init_context.getNumOutputs());
 
@@ -87,9 +85,6 @@ TEST_P(LayerSemantics, setBatchValidateLayerNode_p) {
 
   if (!must_fail) {
     EXPECT_NO_THROW(lnode->finalize());
-    auto &init_context = lnode->getInitContext();
-    EXPECT_NO_THROW(
-      lnode->setBatch(init_context.getInputDimensions()[0].batch() + 10));
   } else {
     EXPECT_THROW(lnode->finalize(), nntrainer::exception::not_supported);
   }


### PR DESCRIPTION
**[Pending commit: #1542]**


- [LayerNode] Change context to be RAII

```
This patch refactors context to be RAII to make layer node properties
dumb.

**Changes**
- init context is removed
   - layer node instead created and returned from layerNode::finalize(input_dims)
   - remove dependency to input dimension before initialize
   - layerNode now has input_shapes instead of setting directly from initContext
   - runcontext is used to query things
   - fix multiple bugs regarding the validity of layer node

- networkGraph::updateRunContext() -> finalizeContext() now
finalizes inside this function for brevity
- layerNode::updateRunContext() -> configureContext() to make it RAIIer.
- minor code cleans in networkGraph::initialize

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [Trivial] Fix gcc warning (sign compare)

```
This patch fixes gcc warning of sign compare from tests

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```