### PR TITLE
[ini] Implement dataset save/loader

### DIFF
--- a/nntrainer/dataset/data_producer.h
+++ b/nntrainer/dataset/data_producer.h
@@ -23,6 +23,9 @@
 #include <tensor_dim.h>
 namespace nntrainer {
 
+class Exporter;
+enum class ExportMethods;
+
 /**
  * @brief DataProducer interface used to abstract data provider
  *
@@ -103,6 +106,16 @@ public:
   virtual unsigned int size(const std::vector<TensorDim> &input_dims,
                             const std::vector<TensorDim> &label_dims) const {
     return SIZE_UNDEFINED;
+  }
+
+  /**
+   * @brief this function helps exporting the dataproducer in a predefined
+   * format, while workarounding issue caused by templated function type eraser
+   *
+   * @param     exporter exporter that conatins exporting logic
+   * @param     method enum value to identify how it should be exported to
+   */
+  virtual void exportTo(Exporter &exporter, const ExportMethods &method) const {
   }
 
   /**

--- a/nntrainer/dataset/databuffer.cpp
+++ b/nntrainer/dataset/databuffer.cpp
@@ -24,16 +24,14 @@
 #include <base_properties.h>
 #include <cassert>
 #include <climits>
-#include <condition_variable>
 #include <cstring>
 #include <databuffer.h>
+#include <func_data_producer.h>
 #include <functional>
 #include <iomanip>
-#include <mutex>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>
-#include <parse_util.h>
 #include <sstream>
 #include <stdexcept>
 #include <stdio.h>
@@ -228,5 +226,28 @@ void DataBuffer::setProperty(const std::vector<std::string> &values) {
 const std::string DataBuffer::getType() const {
   NNTR_THROW_IF(!producer, std::invalid_argument) << "producer is empty";
   return producer->getType();
+}
+
+void DataBuffer::exportTo(Exporter &exporter,
+                          const ExportMethods &method) const {
+  if (producer) {
+    producer->exportTo(exporter, method);
+  }
+  exporter.saveResult(*db_props, method, this);
+}
+
+bool DataBuffer::isSerializable(const ExportMethods &method) const {
+  if (method != ExportMethods::METHOD_STRINGVECTOR) {
+    return false;
+  }
+  if (!producer) {
+    return false;
+  }
+
+  /// @todo this should be query from producer->isSerializable
+  if (producer->getType() == FuncDataProducer::type) {
+    return false;
+  }
+  return true;
 }
 } /* namespace nntrainer */

--- a/nntrainer/dataset/databuffer.h
+++ b/nntrainer/dataset/databuffer.h
@@ -40,6 +40,9 @@
 
 namespace nntrainer {
 
+class Exporter;
+enum class ExportMethods;
+
 /**
  * @brief     Aliasing from ccapi ml::train
  */
@@ -132,6 +135,24 @@ public:
    * @return const std::string type
    */
   const std::string getType() const;
+
+  /**
+   * @brief this function helps exporting the dataset in a predefined format,
+   * while workarounding issue caused by templated function type eraser
+   *
+   * @param     exporter exporter that conatins exporting logic
+   * @param     method enum value to identify how it should be exported to
+   */
+  void exportTo(Exporter &exporter, const ExportMethods &method) const;
+
+  /**
+   * @brief check if given databuffer is exportable, this is needed because some
+   * data producer, mainly FuncDataProducer, cannot be serialized
+   *
+   * @param method proposed method
+   * @return bool true if serializable
+   */
+  bool isSerializable(const ExportMethods &method) const;
 
 protected:
   std::shared_ptr<DataProducer> producer;

--- a/nntrainer/dataset/func_data_producer.cpp
+++ b/nntrainer/dataset/func_data_producer.cpp
@@ -80,4 +80,8 @@ FuncDataProducer::finalize(const std::vector<TensorDim> &input_dims,
     return last;
   };
 }
+
+void FuncDataProducer::exportTo(Exporter &exporter,
+                                const ExportMethods &method) const {}
+
 } // namespace nntrainer

--- a/nntrainer/dataset/func_data_producer.h
+++ b/nntrainer/dataset/func_data_producer.h
@@ -24,6 +24,8 @@
 namespace nntrainer {
 
 class PropsUserData;
+class Exporter;
+enum class ExportMethods;
 
 using datagen_cb = ml::train::datagen_cb;
 
@@ -67,6 +69,11 @@ public:
   DataProducer::Generator finalize(const std::vector<TensorDim> &input_dims,
                                    const std::vector<TensorDim> &label_dims,
                                    void *user_data = nullptr) override;
+
+  /**
+   * @copydoc DataProducer::exportTo(Exporter &exporter, ExportMethods method)
+   */
+  void exportTo(Exporter &exporter, const ExportMethods &method) const override;
 
 private:
   datagen_cb cb;

--- a/nntrainer/dataset/raw_file_data_producer.cpp
+++ b/nntrainer/dataset/raw_file_data_producer.cpp
@@ -109,4 +109,9 @@ RawFileDataProducer::size(const std::vector<TensorDim> &input_dims,
 
   return file_size / (sample_size * RawFileDataProducer::pixel_size);
 }
+
+void RawFileDataProducer::exportTo(Exporter &exporter,
+                                   const ExportMethods &method) const {
+  exporter.saveResult(*raw_file_props, method, this);
+}
 } // namespace nntrainer

--- a/nntrainer/dataset/raw_file_data_producer.h
+++ b/nntrainer/dataset/raw_file_data_producer.h
@@ -85,6 +85,11 @@ public:
   unsigned int size(const std::vector<TensorDim> &input_dims,
                     const std::vector<TensorDim> &label_dims) const override;
 
+  /**
+   * @copydoc DataProducer::exportTo(Exporter &exporter, ExportMethods method)
+   */
+  void exportTo(Exporter &exporter, const ExportMethods &method) const override;
+
 private:
   std::ifstream file;
   using PropTypes = std::tuple<props::FilePath>;

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -196,7 +196,9 @@ int NetworkGraph::realizeActivationType(
     lnode->setProperty({"distribute=true"});
   }
 
-  lnode->setProperty({"activation=" + ActivationTypeStr[(unsigned int)act]});
+  props::Activation act_prop;
+  act_prop.set(act);
+  lnode->setProperty({"activation=" + to_string(act_prop)});
   in_node->setProperty({"activation=none"});
 
   lnode->setInputLayers({in_node->getName()});
@@ -297,7 +299,6 @@ int NetworkGraph::addLossLayer(const std::string &loss_type_) {
 }
 
 void NetworkGraph::setOutputLayers() {
-
   for (auto iter_idx = cbegin(); iter_idx != cend(); iter_idx++) {
     auto &layer_idx = *iter_idx;
     for (auto iter_i = cbegin(); iter_i != cend(); iter_i++) {
@@ -354,15 +355,14 @@ int NetworkGraph::checkCompiledGraph() {
 }
 
 int NetworkGraph::realizeGraph() {
-
   int status = ML_ERROR_NONE;
 
   addDefaultInputLayers();
 
   /**
    * invariant: the new realized nodes are added to the end,
-   * otherwise this iteration becomes invalid. So, every iteration must be fresh
-   * iterator as vector resize invalidates all the iterators.
+   * otherwise this iteration becomes invalid. So, every iteration must be
+   * fresh iterator as vector resize invalidates all the iterators.
    */
   for (unsigned int i = 0; i < graph.size(); ++i) {
     auto const &lnode = LNODE(*(cbegin() + i));
@@ -511,7 +511,6 @@ std::vector<std::shared_ptr<LayerNode>> NetworkGraph::getLayerNodes() const {
 
 void NetworkGraph::extendGraph(std::vector<std::shared_ptr<LayerNode>> ex_graph,
                                std::string &prefix) {
-
   if (compiled)
     throw std::runtime_error("Cannot modify graph after compile");
 

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -16,21 +16,10 @@
 #define __ACTI_FUNC_H__
 #ifdef __cplusplus
 
+#include <common_properties.h>
 #include <tensor.h>
 
 namespace nntrainer {
-
-/**
- * @brief     Enumeration of activation function type
- */
-enum class ActivationType {
-  ACT_TANH,    /** tanh */
-  ACT_SIGMOID, /** sigmoid */
-  ACT_RELU,    /** ReLU */
-  ACT_SOFTMAX, /** softmax */
-  ACT_NONE,    /** no op */
-  ACT_UNKNOWN  /** unknown */
-};
 
 /**
  * @brief     Activation enum to string map

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -15,10 +15,17 @@
 #define __ACTIVATION_LAYER_H__
 #ifdef __cplusplus
 
+#include <memory>
+
 #include <acti_func.h>
 #include <layer_devel.h>
 
 namespace nntrainer {
+
+namespace props {
+class ActivationType;
+
+} // namespace props
 
 /**
  * @class   Activation Layer
@@ -30,9 +37,7 @@ public:
   /**
    * @brief     Constructor of Activation Layer
    */
-  ActivationLayer() : Layer() {
-    acti_func.setActiFunc(ActivationType::ACT_NONE);
-  }
+  ActivationLayer();
 
   /**
    * @brief     Destructor of Activation Layer
@@ -62,8 +67,7 @@ public:
   /**
    * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
    */
-  void exportTo(Exporter &exporter,
-                const ExportMethods &method) const override {}
+  void exportTo(Exporter &exporter, const ExportMethods &method) const override;
 
   /**
    * @copydoc Layer::getType()
@@ -83,61 +87,11 @@ public:
   inline static const std::string type = "activation";
 
 private:
-  ActiFunc
-    acti_func; /**< activation function designating the activation operation */
+  using PropTypes = std::tuple<props::Activation>;
 
-  /**
-   * @brief setActivation by custom activation function
-   * @note  apply derivative as this activation_prime_fn does not utilize
-   * derivative
-   * @param[in] std::function<Tensor(Tensor const &, Tensor &)> activation_fn
-   * activation function to be used
-   * @param[in] std::function<Tensor(Tensor const &, Tensor &)>
-   * activation_prime_fn activation_prime_function to be used
-   * @retval #ML_ERROR_NONE when successful
-   */
-  int setActivation(
-    std::function<Tensor &(Tensor const &, Tensor &)> const &activation_fn,
-    std::function<Tensor &(Tensor &, Tensor &)> const &activation_prime_fn);
+  std::unique_ptr<PropTypes> activation_props; /**< activation props */
 
-  /**
-   * @brief setActivation by custom activation function
-   * @note  derivative not applied here as this activation_prime_fn applies
-   * derivative itself
-   * @param[in] std::function<Tensor(Tensor const &, Tensor &)> activation_fn
-   * activation function to be used
-   * @param[in] std::function<Tensor(Tensor const &, Tensor &, Tensor const &)>
-   * activation_prime_fn activation_prime_function to be used
-   * @retval #ML_ERROR_NONE when successful
-   */
-  int setActivation(
-    std::function<Tensor &(Tensor const &, Tensor &)> const &activation_fn,
-    std::function<Tensor &(Tensor &, Tensor &, Tensor const &)> const
-      &activation_prime_fn);
-
-  /**
-   * @brief setActivation by custom activation function
-   * @note  apply derivative as this activation_prime_fn does not utilize
-   * derivative
-   * @param[in] std::function<float(float const &)> activation_fn activation
-   *            function to be used
-   * @param[in] std::function<float(float const &)> activation_prime_fn
-   *            activation_prime_function to be used
-   * @retval #ML_ERROR_NONE when successful
-   */
-  int setActivation(
-    std::function<float(float const)> const &activation_fn,
-    std::function<float(float const)> const &activation_prime_fn);
-
-  /**
-   * @brief setProperty by type and value separated
-   * @param[in] type property type to be passed
-   * @param[in] value value to be passed
-   * @exception exception::not_supported     when property type is not valid for
-   * the particular layer
-   * @exception std::invalid_argument invalid argument
-   */
-  void setProperty(const std::string &type, const std::string &value);
+  ActiFunc acti_func; /**< activation function from activation type */
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -22,11 +22,6 @@
 
 namespace nntrainer {
 
-namespace props {
-class ActivationType;
-
-} // namespace props
-
 /**
  * @class   Activation Layer
  * @brief   Activation Layer

--- a/nntrainer/layers/centroid_knn.h
+++ b/nntrainer/layers/centroid_knn.h
@@ -11,7 +11,6 @@
  * @bug    No known bugs except for NYI items
  *
  */
-
 #ifndef __CENTROID_KNN_H__
 #define __CENTROID_KNN_H__
 #include <string>

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -10,17 +10,30 @@
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug    No known bugs except for NYI items
  */
-
-#include <string>
-
-#include <array>
-#include <base_properties.h>
-#include <fstream>
-
 #ifndef __COMMON_PROPERTIES_H__
 #define __COMMON_PROPERTIES_H__
 
+#include <array>
+#include <fstream>
+#include <string>
+
+#include <base_properties.h>
+
 namespace nntrainer {
+
+/**
+ * @brief     Enumeration of activation function type
+ * @note      Upon changing this enum, ActivationTypeInfo must be changed
+ * accordingly
+ */
+enum class ActivationType {
+  ACT_TANH,    /** tanh */
+  ACT_SIGMOID, /** sigmoid */
+  ACT_RELU,    /** ReLU */
+  ACT_SOFTMAX, /** softmax */
+  ACT_NONE,    /** no op */
+  ACT_UNKNOWN  /** unknown */
+};
 
 namespace props {
 
@@ -315,6 +328,30 @@ public:
    * @copydoc nntrainer::Property<unsigned int>::isValid(const unsigned int &v);
    */
   bool isValid(const unsigned int &v) const override;
+};
+
+/******** below section is for enumerations ***************/
+/**
+ * @brief     Enumeration of activation function type
+ */
+struct ActivationTypeInfo {
+  using Enum = nntrainer::ActivationType;
+  static constexpr std::initializer_list<Enum> EnumList = {
+    Enum::ACT_TANH,    Enum::ACT_SIGMOID, Enum::ACT_RELU,
+    Enum::ACT_SOFTMAX, Enum::ACT_NONE,    Enum::ACT_UNKNOWN};
+
+  static constexpr const char *EnumStr[] = {"tanh",    "sigmoid", "relu",
+                                            "softmax", "none",    "unknown"};
+};
+
+/**
+ * @brief Activation Enumeration Information
+ *
+ */
+class Activation final : public EnumProperty<ActivationTypeInfo> {
+public:
+  using prop_tag = enum_class_prop_tag;
+  static constexpr const char *key = "activation";
 };
 } // namespace props
 } // namespace nntrainer

--- a/nntrainer/utils/base_properties.h
+++ b/nntrainer/utils/base_properties.h
@@ -9,6 +9,9 @@
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug No known bugs except for NYI items
  */
+#ifndef __BASE_PROPERTIES_H__
+#define __BASE_PROPERTIES_H__
+
 #include <array>
 #include <memory>
 #include <regex>
@@ -19,9 +22,6 @@
 #include <nntrainer_error.h>
 #include <props_util.h>
 #include <tensor_dim.h>
-
-#ifndef __BASE_PROPERTIES_H__
-#define __BASE_PROPERTIES_H__
 
 /** base and predefined structures */
 

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -409,6 +409,13 @@ TEST(nntrainer_ccapi, save_ini_p) {
   model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
   ScopedIni s("simple_ini", {model_base + "batch_size = 16", optimizer,
                              dataset + "-BufferSize", inputlayer, outputlayer});
+
+  std::shared_ptr<ml::train::Dataset> dataset = ml::train::createDataset(
+    ml::train::DatasetType::FILE, getTestResPath("trainingSet.dat").c_str());
+  EXPECT_NO_THROW(dataset->setProperty({"buffer_size=100"}));
+  EXPECT_EQ(model->setDataset(ml::train::DatasetModeType::MODE_TRAIN, dataset),
+            ML_ERROR_NONE);
+
   EXPECT_EQ(model->loadFromConfig(s.getIniName()), ML_ERROR_NONE);
   EXPECT_EQ(model->compile(), ML_ERROR_NONE);
   EXPECT_EQ(model->initialize(), ML_ERROR_NONE);


### PR DESCRIPTION
- [ini] Implement dataset save/loader

```
This patch implements dataset saver/loader.
This patch propose sections "train_set", "valid_set", "test_set". Just
like optimizer.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```

- [Props] Implement activation property

```
This patch implements activation property by enum

**Additional changes**
- TimeDistribute property is now handled at finalize()

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```