### PR TITLE
[model] implement save best acc logic

### DIFF
--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -63,6 +63,17 @@ public:
 };
 
 /**
+ * @brief model save path property
+ *
+ */
+class SaveBestPath : public Property<std::string> {
+public:
+  static constexpr const char *key =
+    "save_best_path";            /**< unique key to access */
+  using prop_tag = str_prop_tag; /**< property type */
+};
+
+/**
  * @brief model batch size property
  *
  */

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -502,7 +502,8 @@ public:
 
 private:
   using FlexiblePropTypes =
-    std::tuple<props::Epochs, props::TrainingBatchSize, props::SavePath, props::ContinueTrain>;
+    std::tuple<props::Epochs, props::TrainingBatchSize, props::SavePath,
+               props::ContinueTrain, props::SaveBestPath>;
   using RigidPropTypes = std::tuple<props::LossType>;
 
   RigidPropTypes model_props;         /**< model props */


### PR DESCRIPTION
- [model] implement save best acc logic

```
This patch implements saving best accuracy when training

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```