### PR TITLE
[Spec] Exclude generated coverage items

### DIFF
--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -405,13 +405,18 @@ find . -name "CMakeCXXCompilerId*.gcda" -delete
 #find . -path "/build/*.j
 
 # Generate report
-lcov -t 'NNTrainer Unit Test Coverage' -o unittest.info -c -d . -b %{_builddir}/%{name}-%{version}/build --include "*/nntrainer/*" --include "*/api/*" --exclude "*/tensorflow/*" --exclude "*/nntrainer_logger.cpp"
-
-# Exclude generated files
-lcov -r unittest.info "*/test/*" "*/meson*/*" -o unittest-filtered.info
+lcov -t 'NNTrainer Unit Test Coverage' -o unittest.info -c -d . -b %{_builddir}/%{name}-%{version}/build \
+    --include "*/nntrainer/*" \
+    --include "*/api/*" \
+    --exclude "*/tensorflow*" \
+    --exclude "*/Applications/*" \
+    --exclude "*/test/*" \
+    --exclude "*/meson*/*" \
+    --exclude "*/nntrainer_logger.cpp" \
+    --exclude "*/tf_schema_generated.h"
 
 # Visualize the report
-genhtml -o result unittest-filtered.info -t "nntrainer %{version}-%{release} ${VCS}" --ignore-errors source -p ${RPM_BUILD_DIR}
+genhtml -o result unittest.info -t "nntrainer %{version}-%{release} ${VCS}" --ignore-errors source -p ${RPM_BUILD_DIR}
 
 mkdir -p %{buildroot}%{_datadir}/nntrainer/unittest/
 cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/

--- a/test/unittest/datasets/unittest_databuffer.cpp
+++ b/test/unittest/datasets/unittest_databuffer.cpp
@@ -26,6 +26,7 @@ TEST(DataBuffer, getGenerator_p) {
   auto [generator, size] = db.getGenerator({{3, 1, 1, 2}}, {{3, 1, 1, 1}});
 
   EXPECT_EQ(size, 3u);
+  EXPECT_NE(generator, nullptr);
 }
 
 TEST(DataBuffer, fetchIteration_p) {


### PR DESCRIPTION
- [Spec] Exclude generated coverage items

```
This patch excludes generated coverage items from daily coverage report

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```