### PR TITLE
[application] Add resnet18 tensorflow + update application @open sesame 09/23 13:59

### DIFF
--- a/Applications/Resnet/jni/meson.build
+++ b/Applications/Resnet/jni/meson.build
@@ -3,10 +3,20 @@ resnet_sources = [
   'cifar_dataloader.cpp'
 ]
 
+resnet_dependencies = [app_utils_dep,
+  iniparser_dep,
+  nntrainer_dep,
+  nntrainer_ccapi_dep
+]
+
+if get_option('enable-test')
+  resnet_dependencies += [gtest_dep]
+endif
+
 e = executable('nntrainer_resnet18',
   resnet_sources,
   include_directories: '.',
-  dependencies: [app_utils_dep, iniparser_dep, nntrainer_dep, nntrainer_ccapi_dep],
+  dependencies: resnet_dependencies,
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
@@ -14,6 +24,6 @@ e = executable('nntrainer_resnet18',
 
 if get_option('enable-long-test')
   testenv = environment()
-  testenv.set('OPENBLAS_NUM_THREADS', 1)
-  test('app_resnet18', e, args: ['fake', '1', '512'], env: testenv, timeout: 300)
+  testenv.set('OPENBLAS_NUM_THREADS', '4')
+  test('app_resnet18', e, args: ['fake', '1', '128', '1'], env: testenv, timeout: 300)
 endif

--- a/Applications/Resnet/tensorflow/resnet18.py
+++ b/Applications/Resnet/tensorflow/resnet18.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+##
+# Copyright (C) 2020 Jihoon Lee <jhoon.it.lee@samsung.com>
+#
+# @file resnet18.py.py
+# @date 02 November 2020
+# @brief Resnet 18 model file
+# @author Jihoon lee <jhoon.it.lee@samsung.com>
+# @author Parichay Kapoor <pk.kapoor@samsung.com>
+# @note tested with tensorflow 2.6
+
+
+import random
+import os
+import sys
+
+import numpy as np
+import tensorflow as tf
+
+from tensorflow.keras.layers import Input, Conv2D, BatchNormalization, ReLU, \
+    Add, AveragePooling2D, Flatten, Dense
+from tensorflow.keras.optimizers import Adam
+import tensorflow.keras.backend as K
+
+sys.path.insert(1, "../../../test/input_gen")
+from transLayer import attach_trans_layer as TL
+
+# Fix the seeds across frameworks
+SEED = 412349
+random.seed(SEED)
+tf.compat.v1.set_random_seed(SEED)
+np.random.seed(SEED)
+os.environ['TF_DETERMINISTIC_OPS'] = '1'
+
+# enable to verify values of the model layer by layer
+DEBUG = False
+
+def resnet_block(x, filters, kernel_size, downsample = False):
+    y = TL(Conv2D(kernel_size=kernel_size,
+               strides= (1 if not downsample else 2),
+               filters=filters,
+               padding="same"))(x)
+    y = TL(BatchNormalization())(y)
+    y = TL(ReLU())(y)
+    y = TL(Conv2D(kernel_size=kernel_size,
+               strides=1,
+               filters=filters,
+               padding="same"))(y)
+    # y = TL(BatchNormalization())(y)
+
+    if downsample:
+        x = TL(Conv2D(kernel_size=1,
+                   strides=2,
+                   filters=filters,
+                   padding="same"))(x)
+        # x = TL(BatchNormalization())(x)
+    out = Add()([y, x])
+    out = TL(BatchNormalization())(out)
+    return ReLU()(out)
+
+
+def Resnet18(input_shape):
+    img = Input(shape=input_shape)
+    x = TL(Conv2D(64, kernel_size=3, strides=1, padding='same',
+                  bias_initializer='zeros',
+                  kernel_initializer='glorot_uniform'))(img)
+    x = TL(BatchNormalization())(x)
+    x = ReLU()(x)
+    x = resnet_block(x, 64, 3, False)
+    x = resnet_block(x, 64, 3, False)
+    x = resnet_block(x, 128, 3, True)
+    x = resnet_block(x, 128, 3, False)
+    x = resnet_block(x, 256, 3, True)
+    x = resnet_block(x, 256, 3, False)
+    x = resnet_block(x, 512, 3, True)
+    x = resnet_block(x, 512, 3, False)
+    x = TL(AveragePooling2D(4))(x)
+    x = Flatten()(x)
+    x = Dense(100)(x)
+    x = tf.keras.layers.Softmax()(x)
+
+    return tf.keras.models.Model(inputs=img, outputs=x)
+
+
+if __name__ == '__main__':
+    tf.config.run_functions_eagerly(True)
+
+    model = Resnet18(input_shape=(3, 32, 32))
+
+    # Fixed LR schedule for now
+    opt = Adam(learning_rate=0.001)
+    model.compile(
+        optimizer=opt,
+        loss='categorical_crossentropy',
+        metrics=['categorical_accuracy'],
+        run_eagerly=True
+    )
+    model.summary()
+
+    (x_train, y_train), (x_test, y_test) = tf.keras.datasets.cifar100.load_data()
+
+    x_train = np.transpose(x_train.astype('float32'), (0, 3, 1, 2))
+    x_test = np.transpose(x_test.astype('float32'), (0, 3, 1, 2))
+    x_train /= 255.0
+    x_test /= 255.0
+
+    y_train = tf.keras.utils.to_categorical(y_train, 100)
+    y_test = tf.keras.utils.to_categorical(y_test, 100)
+
+    def write_fn(*items, filename='./resnet.bin'):
+        with open(filename, 'wb') as f:
+            for item in items:
+                try:
+                    item.numpy().tofile(f)
+                except AttributeError:
+                    pass
+            return items
+
+    initial_weights = []
+    for layer in model.layers:
+        # print(layer.name)
+        initial_weights += layer.weights.copy()
+
+    write_fn(*initial_weights, './resnet_initial.bin')
+
+    if DEBUG:
+        input = tf.reshape(tf.convert_to_tensor(x_train[0]), [1,3,32,32])
+
+        # run with training mode
+        output = model.call(input)
+        # run each layer with training mode
+        K.set_learning_phase(1)
+        for layer in model.layers:
+            l_out = K.function(model.layers[0].input, layer.output)([input])
+            if (len(l_out.shape) > 2):
+                print(layer.name, l_out[0][0][0])
+            else:
+                print(layer.name, l_out[0])
+
+    model.fit(
+        x = x_train,
+        y = y_train,
+        epochs = 60,
+        verbose = 1,
+        validation_data=(x_test, y_test),
+        batch_size=128,
+    )
+
+    final_weights = []
+    for layer in model.layers:
+        # print(layer.name)
+        final_weights += layer.weights.copy()
+
+    write_fn(*final_weights)

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -740,9 +740,9 @@ Tensor Tensor::sum(const std::vector<unsigned int> &axes, float alpha) const {
   return sum(axes, ret, alpha);
 }
 
-void Tensor::merge_axis(unsigned int axis1, unsigned int axis2) {
+void Tensor::mergeAxis(unsigned int axis1, unsigned int axis2) {
   if (axis2 != axis1 + 1)
-    throw std::invalid_argument("Axis to be merged must be continuous.");
+    throw std::invalid_argument("axis2 must be axis1 + 1 for merging.");
 
   dim.setTensorDim(axis2, dim.getTensorDim(axis1) * dim.getTensorDim(axis2));
   dim.setTensorDim(axis1, 1);
@@ -761,7 +761,7 @@ Tensor &Tensor::sum(const std::vector<unsigned int> &axes, Tensor &output,
     std::vector<unsigned int> new_axes = {axes[0]};
     for (unsigned int i = 1; i < axes.size(); ++i) {
       if (axes[i] == axes[i - 1] + 1) {
-        new_reshaped.merge_axis(axes[i - 1], axes[i]);
+        new_reshaped.mergeAxis(axes[i - 1], axes[i]);
         new_axes.back() = axes[i];
       } else {
         new_axes.push_back(axes[i]);

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -214,6 +214,8 @@ bool Tensor::operator==(const Tensor &rhs) const {
   const float *rdata = rhs.getData();
 
   for (size_t i = 0; i < len; ++i) {
+    /** not checking sign change is intentional to avoid float calculation
+     * errors around 0 */
     if (std::isnan(data[i]) || std::isnan(rdata[i]) ||
         std::fabs(data[i] - rdata[i]) > epsilon)
       return false;
@@ -738,6 +740,14 @@ Tensor Tensor::sum(const std::vector<unsigned int> &axes, float alpha) const {
   return sum(axes, ret, alpha);
 }
 
+void Tensor::merge_axis(unsigned int axis1, unsigned int axis2) {
+  if (axis2 != axis1 + 1)
+    throw std::invalid_argument("Axis to be merged must be continuous.");
+
+  dim.setTensorDim(axis2, dim.getTensorDim(axis1) * dim.getTensorDim(axis2));
+  dim.setTensorDim(axis1, 1);
+}
+
 Tensor &Tensor::sum(const std::vector<unsigned int> &axes, Tensor &output,
                     float alpha) const {
   if (axes.empty())
@@ -746,12 +756,22 @@ Tensor &Tensor::sum(const std::vector<unsigned int> &axes, Tensor &output,
   if (axes.size() == 1) {
     this->sum(axes[0], output, alpha);
   } else {
-    Tensor ret = this->sum(axes[0], alpha);
+    /** club axes together */
+    Tensor new_reshaped = *this;
+    std::vector<unsigned int> new_axes = {axes[0]};
+    for (unsigned int i = 1; i < axes.size(); ++i) {
+      if (axes[i] == axes[i - 1] + 1) {
+        new_reshaped.merge_axis(axes[i - 1], axes[i]);
+        new_axes.back() = axes[i];
+      } else {
+        new_axes.push_back(axes[i]);
+      }
+    }
 
-    for (unsigned int i = 1; i < axes.size() - 1; ++i)
+    Tensor ret = new_reshaped.sum(new_axes[0]);
+    for (unsigned int i = 1; i < new_axes.size() - 1; ++i)
       ret = ret.sum(axes[i]);
-
-    ret.sum(axes.back(), output);
+    ret.sum(new_axes.back(), output, alpha);
   }
 
   return output;

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1127,7 +1127,7 @@ private:
    * @param axis1 first axis to merge
    * @param axis2 second axis to merge
    */
-  void merge_axis(unsigned int axis1, unsigned int axis2);
+  void mergeAxis(unsigned int axis1, unsigned int axis2);
 }; // namespace nntrainer
 
 /**

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1120,6 +1120,14 @@ private:
     deallocate();
     allocate();
   }
+
+  /**
+   * @brief Merge the given two axis for tensor at second axis inplace
+   *
+   * @param axis1 first axis to merge
+   * @param axis2 second axis to merge
+   */
+  void merge_axis(unsigned int axis1, unsigned int axis2);
 }; // namespace nntrainer
 
 /**


### PR DESCRIPTION
- Add resnet18 tensorflow version to match against nntrainer.
- Update resnet application to match tensorflow implementation.
- This patch reduces the number of operations required for tensor sum by
accumulating the consecutive axes in order to increase the precision of
the operation.
- This patch adds test check on the training of the resnet application.
This test can be enabled with enable-long-test and enable-test.

Note: reduction of operations for sum was intended to reduce the number of operations to result in higher precision but can very well result in speedup as well.

resolves #904
Resolves #1533

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>