### PR TITLE
Fix/set acti func in rnn base layer

### DIFF
--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.cc
@@ -79,6 +79,7 @@ static ml::train::TensorDim to_nntr_tensor_dim(const GstTensorInfo *info) {
 }
 
 NNTrainerInference::NNTrainerInference(const std::string &model_config_) :
+  batch_size(1),
   model_config(model_config_) {
   loadModel();
   model->compile();

--- a/nntrainer/layers/gru.cpp
+++ b/nntrainer/layers/gru.cpp
@@ -157,13 +157,13 @@ void GRULayer::finalize(InitLayerContext &context) {
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);
-    acti_func.setActiFunc(hidden_state_activation_type.get());
   }
+  acti_func.setActiFunc(hidden_state_activation_type.get());
 
   if (recurrent_activation_type.get() == ActivationType::ACT_NONE) {
     recurrent_activation_type.set(ActivationType::ACT_SIGMOID);
-    recurrent_acti_func.setActiFunc(recurrent_activation_type.get());
   }
+  recurrent_acti_func.setActiFunc(recurrent_activation_type.get());
 }
 
 void GRULayer::setProperty(const std::vector<std::string> &values) {

--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -138,13 +138,13 @@ void LSTMLayer::finalize(InitLayerContext &context) {
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);
-    acti_func.setActiFunc(hidden_state_activation_type.get());
   }
+  acti_func.setActiFunc(hidden_state_activation_type.get());
 
   if (recurrent_activation_type.get() == ActivationType::ACT_NONE) {
     recurrent_activation_type.set(ActivationType::ACT_SIGMOID);
-    recurrent_acti_func.setActiFunc(recurrent_activation_type.get());
   }
+  recurrent_acti_func.setActiFunc(recurrent_activation_type.get());
 }
 
 void LSTMLayer::setProperty(const std::vector<std::string> &values) {

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -53,8 +53,11 @@ void Pooling2DLayer::finalize(InitLayerContext &context) {
 
   if (pooling_type == props::PoolingTypeInfo::Enum::global_max ||
       pooling_type == props::PoolingTypeInfo::Enum::global_average) {
-    NNTR_THROW_IF(!pool_size.empty(), std::invalid_argument)
-      << "[Pooling2D] global_max, global_average does not accept pool size";
+    if (!pool_size.empty()) {
+      ml_logw(
+        "[Pooling2D] global_max, global_average does not accept pool size");
+      pool_size.clear();
+    }
     pool_size.emplace_back(props::PoolSize(in_dim.height()));
     pool_size.emplace_back(props::PoolSize(in_dim.width()));
   }

--- a/nntrainer/layers/rnn.cpp
+++ b/nntrainer/layers/rnn.cpp
@@ -114,8 +114,8 @@ void RNNLayer::finalize(InitLayerContext &context) {
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);
-    acti_func.setActiFunc(hidden_state_activation_type.get());
   }
+  acti_func.setActiFunc(hidden_state_activation_type.get());
 
   if (!acti_func.supportInPlace())
     throw exception::not_supported(

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -1407,31 +1407,31 @@ INSTANTIATE_TEST_CASE_P(
       mkModelTc(fc_bn_sigmoid_mse, "3:1:1:10", 10, ModelTestOption::ALL),
 
       /**< single conv2d layer test */
-      mkModelTc(conv_1x1, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(conv_input_matches_kernel, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(conv_basic, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(conv_same_padding, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(conv_multi_stride, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(conv_uneven_strides, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(conv_uneven_strides2, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(conv_uneven_strides3, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(conv_bn, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(conv_same_padding_multi_stride, "3:1:1:10", 10, ModelTestOption::COMPARE),
+      mkModelTc(conv_1x1, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(conv_input_matches_kernel, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(conv_basic, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(conv_same_padding, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(conv_multi_stride, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(conv_uneven_strides, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(conv_uneven_strides2, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(conv_uneven_strides3, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(conv_bn, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(conv_same_padding_multi_stride, "3:1:1:10", 10, ModelTestOption::ALL),
       mkModelTc(conv_no_loss, "3:1:1:10", 1, ModelTestOption::MINIMUM),
 
       /**< single pooling layer test */
-      mkModelTc(pooling_max_same_padding, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(pooling_max_same_padding_multi_stride, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(pooling_max_valid_padding, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(pooling_avg_same_padding, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(pooling_avg_same_padding_multi_stride, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(pooling_avg_valid_padding, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(pooling_global_avg, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(pooling_global_max, "3:1:1:10", 10, ModelTestOption::COMPARE),
+      mkModelTc(pooling_max_same_padding, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(pooling_max_same_padding_multi_stride, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(pooling_max_valid_padding, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(pooling_avg_same_padding, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(pooling_avg_same_padding_multi_stride, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(pooling_avg_valid_padding, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(pooling_global_avg, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(pooling_global_max, "3:1:1:10", 10, ModelTestOption::ALL),
 
       /**< conv pool combined tests */
-      mkModelTc(mnist_conv_cross, "3:1:1:10", 10, ModelTestOption::COMPARE),
-      mkModelTc(mnist_conv_cross_one_input, "1:1:1:10", 10, ModelTestOption::COMPARE),
+      mkModelTc(mnist_conv_cross, "3:1:1:10", 10, ModelTestOption::ALL),
+      mkModelTc(mnist_conv_cross_one_input, "1:1:1:10", 10, ModelTestOption::ALL),
 
       /**< augmentation layer */
   #if defined(ENABLE_DATA_AUGMENTATION_OPENCV)
@@ -1440,30 +1440,30 @@ INSTANTIATE_TEST_CASE_P(
       mkModelTc(preprocess_flip_validate, "3:1:1:10", 10, ModelTestOption::MINIMUM),
 
       /**< Addition test */
-      mkModelTc(addition_resnet_like, "3:1:1:10", 10, ModelTestOption::COMPARE),
+      mkModelTc(addition_resnet_like, "3:1:1:10", 10, ModelTestOption::COMPARE), // Todo: Enable option to ALL
 
       /// #1192 time distribution inference bug
       mkModelTc(fc_softmax_mse_distribute, "3:1:5:3", 1, ModelTestOption::MINIMUM),
       mkModelTc(fc_softmax_cross_distribute, "3:1:5:3", 1, ModelTestOption::MINIMUM),
       mkModelTc(fc_sigmoid_cross_distribute, "3:1:5:3", 1, ModelTestOption::MINIMUM),
-      mkModelTc(lstm_basic, "1:1:1:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(lstm_return_sequence, "1:1:2:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(lstm_return_sequence_with_batch, "2:1:2:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(multi_lstm_return_sequence, "1:1:1:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(multi_lstm_return_sequence_with_batch, "2:1:1:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(rnn_basic, "1:1:1:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(rnn_return_sequences, "1:1:2:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(rnn_return_sequence_with_batch, "2:1:2:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(multi_rnn_return_sequence, "1:1:1:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(multi_rnn_return_sequence_with_batch, "2:1:1:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(gru_basic, "1:1:1:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(gru_return_sequence, "1:1:2:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(gru_return_sequence_with_batch, "2:1:2:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(multi_gru_return_sequence, "1:1:1:1", 10, ModelTestOption::COMPARE),
-      mkModelTc(multi_gru_return_sequence_with_batch, "2:1:1:1", 10, ModelTestOption::COMPARE),
+      mkModelTc(lstm_basic, "1:1:1:1", 10, ModelTestOption::ALL),
+      mkModelTc(lstm_return_sequence, "1:1:2:1", 10, ModelTestOption::ALL),
+      mkModelTc(lstm_return_sequence_with_batch, "2:1:2:1", 10, ModelTestOption::ALL),
+      mkModelTc(multi_lstm_return_sequence, "1:1:1:1", 10, ModelTestOption::ALL),
+      mkModelTc(multi_lstm_return_sequence_with_batch, "2:1:1:1", 10, ModelTestOption::ALL),
+      mkModelTc(rnn_basic, "1:1:1:1", 10, ModelTestOption::ALL),
+      mkModelTc(rnn_return_sequences, "1:1:2:1", 10, ModelTestOption::ALL),
+      mkModelTc(rnn_return_sequence_with_batch, "2:1:2:1", 10, ModelTestOption::ALL),
+      mkModelTc(multi_rnn_return_sequence, "1:1:1:1", 10, ModelTestOption::ALL),
+      mkModelTc(multi_rnn_return_sequence_with_batch, "2:1:1:1", 10, ModelTestOption::ALL),
+      mkModelTc(gru_basic, "1:1:1:1", 10, ModelTestOption::ALL),
+      mkModelTc(gru_return_sequence, "1:1:2:1", 10, ModelTestOption::ALL),
+      mkModelTc(gru_return_sequence_with_batch, "2:1:2:1", 10, ModelTestOption::ALL),
+      mkModelTc(multi_gru_return_sequence, "1:1:1:1", 10, ModelTestOption::ALL),
+      mkModelTc(multi_gru_return_sequence_with_batch, "2:1:1:1", 10, ModelTestOption::ALL),
 
       /**< multi output test */
-      mkModelTc(multiple_output_model, "3:1:1:10", 10, ModelTestOption::COMPARE)
+      mkModelTc(multiple_output_model, "3:1:1:10", 10, ModelTestOption::COMPARE) // Todo: Enable option to ALL
     }
 ), [](const testing::TestParamInfo<nntrainerModelTest::ParamType>& info){
  return std::get<0>(info.param).getName();

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -536,7 +536,10 @@ class nntrainerModelTest
                  ModelTestOption /**< Options which test to run */>> {
 
 protected:
-  nntrainerModelTest() : iteration(0), name("") {}
+  nntrainerModelTest() :
+    iteration(0),
+    name(""),
+    options(ModelTestOption::MINIMUM) {}
   virtual void SetUp() {
     auto param = GetParam();
 


### PR DESCRIPTION
Commit 1: [layer] bugfix in set acti_func of rnn, lstm, gru
 - Set acti_func, recurrent_acti_func in finalize

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>

Commit 2: [ahub] Init uninit member variable
 - Initialize uninit member variable

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>

Commit 3: [unittest] Enable model_test_save_load_compare unittest
 - Except addition_resnet_like, multiple_output_model which contain
   multiout layer cause cannot assure the order of layer

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>