### PR TITLE
Enable Saving props by delimiter '|'

### DIFF
--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -10,6 +10,7 @@
  * @bug No known bugs except for NYI items
  */
 #include <memory>
+#include <regex>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -289,11 +290,17 @@ iterate_prop(Callable &&c, std::tuple<Ts...> &tup) {
 template <typename Tuple>
 std::vector<std::string>
 loadProperties(const std::vector<std::string> &string_vector, Tuple &&props) {
+  std::vector<std::string> string_vector_splited;
+  string_vector_splited.reserve(string_vector.size());
+  for (auto &item : string_vector) {
+    auto splited = split(item, std::regex("\\|"));
+    string_vector_splited.insert(string_vector_splited.end(), splited.begin(),
+                                 splited.end());
+  }
 
   std::vector<std::pair<std::string, std::string>> left;
-  left.reserve(string_vector.size());
-
-  std::transform(string_vector.begin(), string_vector.end(),
+  left.reserve(string_vector_splited.size());
+  std::transform(string_vector_splited.begin(), string_vector_splited.end(),
                  std::back_inserter(left), [](const std::string &property) {
                    std::string key, value;
                    int status = getKeyValue(property, key, value);

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -819,8 +819,8 @@ TEST(nntrainer_capi_nnmodel, train_with_generator_01_p) {
   status = ml_train_model_compile(model, "loss=cross", "batch_size=16", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_train_model_run(model, "epochs=2",
-                              "save_path=capi_tizen_model.bin", NULL);
+  status = ml_train_model_run(
+    model, "epochs=2 | save_path=capi_tizen_model.bin", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Compare training statistics */

--- a/test/tizen_capi/unittest_tizen_capi_layer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_layer.cpp
@@ -70,11 +70,10 @@ TEST(nntrainer_capi_nnlayer, setproperty_01_p) {
   status = ml_train_layer_set_property(handle, "input_shape=1:1:6270", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_train_layer_set_property(handle, "normalization=true", NULL);
+  status = ml_train_layer_set_property(
+    handle, "normalization=true | standardization=true", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_train_layer_set_property(handle, "standardization=true", NULL);
-  EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
@@ -90,11 +89,10 @@ TEST(nntrainer_capi_nnlayer, setproperty_02_p) {
   status = ml_train_layer_set_property(handle, "unit=10", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_train_layer_set_property(handle, "bias_initializer=zeros", NULL);
+  status = ml_train_layer_set_property(
+    handle, "bias_initializer=zeros | activation=sigmoid", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_train_layer_set_property(handle, "activation =sigmoid", NULL);
-  EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_train_layer_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }

--- a/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
@@ -93,7 +93,7 @@ TEST(nntrainer_capi_nnopt, setOptimizer_02_p) {
   status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_train_optimizer_set_property(
-    handle, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
+    handle, "learning_rate=0.0001 | decay_rate=0.96", "decay_steps=1000",
     "beta1=0.002", "beta2=0.001", "epsilon=1e-7", NULL);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_train_optimizer_destroy(handle);

--- a/test/unittest/unittest_base_properties.cpp
+++ b/test/unittest/unittest_base_properties.cpp
@@ -349,7 +349,7 @@ TEST(BasicProperty, valid_p) {
       std::make_tuple(NumBanana(), QualityOfBanana(), DimensionOfBanana());
 
     auto v = nntrainer::loadProperties(
-      {"num_banana=2", "quality_banana=thisisgood", "num_banana=42",
+      {"num_banana=2 | quality_banana=thisisgood | num_banana=42",
        "banana_size=2:2:3", "not_used=key"},
       props);
 


### PR DESCRIPTION
- Enable Saving props by delimiter '|'

```
This patch enables saving properties by delimiter '|'

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Cc: Inki Dae <inki.dae@samsung.com>
Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```