### PR TITLE
[Conv2d] Conv2d Padding Fix

### DIFF
--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -404,10 +404,12 @@ public:
    *
    * @param input input dimension
    * @param kernel kernel dimension
+   * @param stride stride
    * @return std::array<unsigned int, 4> list of unsigned padding
    */
-  std::array<unsigned int, 4> compute(const TensorDim &input,
-                                      const TensorDim &kernel);
+  std::array<unsigned int, 4>
+  compute(const TensorDim &input, const TensorDim &kernel,
+          const std::array<unsigned int, 2> &strides);
 };
 
 /**

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -59,8 +59,9 @@ void Pooling2DLayer::finalize(InitLayerContext &context) {
     pool_size.emplace_back(props::PoolSize(in_dim.width()));
   }
 
-  padding = std::get<props::Padding2D>(pooling2d_props)
-              .compute(in_dim, {pool_size[0], pool_size[1]});
+  padding =
+    std::get<props::Padding2D>(pooling2d_props)
+      .compute(in_dim, {pool_size[0], pool_size[1]}, {stride[0], stride[1]});
 
   auto [pt, pb, pl, pr] = padding;
 
@@ -188,8 +189,8 @@ void Pooling2DLayer::calcDerivative(RunLayerContext &context) {
   } break;
   case props::PoolingTypeInfo::Enum::global_average:
   case props::PoolingTypeInfo::Enum::average: {
-    int heigth_stride_end = height - p_height + pb;
-    int width_stride_end = width - p_width + pr;
+    int heigth_stride_end = height - p_height + pt;
+    int width_stride_end = width - p_width + pl;
     const int *iter = pool_helper.getData<int>();
     for (unsigned int b = 0; b < batch; ++b) {
       for (unsigned int i = 0; i < channel; ++i) {
@@ -385,8 +386,8 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
 
   unsigned int map_size = in_height * in_width;
 
-  int heigth_stride_end = height - patch_height - pb;
-  int width_stride_end = width - patch_width - pr;
+  int heigth_stride_end = height - patch_height - pt;
+  int width_stride_end = width - patch_width - pl;
   for (unsigned int i = 0; i < channel; ++i) {
     const float *in_data_channel_sliced = in_data + i * map_size;
     for (int j = -pt; j <= heigth_stride_end; j += stride[0]) {

--- a/test/unittest/unittest_common_properties.cpp
+++ b/test/unittest/unittest_common_properties.cpp
@@ -197,18 +197,18 @@ TEST(Padding2D, setPropertyValid_p) {
   EXPECT_NO_THROW(p.set("Same"));
   EXPECT_EQ(p.get(), "Same");
 
-  EXPECT_EQ(p.compute({32, 32}, {3, 3}),
+  EXPECT_EQ(p.compute({32, 32}, {3, 3}, {1, 1}),
             (std::array<unsigned int, 4>({1, 1, 1, 1})));
 
   EXPECT_NO_THROW(p.set("valid"));
   EXPECT_EQ(p.get(), "valid");
 
-  EXPECT_EQ(p.compute({32, 32}, {3, 3}),
+  EXPECT_EQ(p.compute({32, 32}, {3, 3}, {1, 1}),
             (std::array<unsigned int, 4>({0, 0, 0, 0})));
 
   EXPECT_NO_THROW(p.set("1"));
   EXPECT_EQ(p.get(), "1");
-  EXPECT_EQ(p.compute({32, 32}, {3, 3}),
+  EXPECT_EQ(p.compute({32, 32}, {3, 3}, {1, 1}),
             (std::array<unsigned int, 4>({1, 1, 1, 1})));
 
   EXPECT_NO_THROW(p.set("0"));
@@ -216,12 +216,12 @@ TEST(Padding2D, setPropertyValid_p) {
 
   EXPECT_NO_THROW(p.set("1, 2"));
   EXPECT_EQ(p.get(), "1, 2");
-  EXPECT_EQ(p.compute({32, 32}, {3, 3}),
+  EXPECT_EQ(p.compute({32, 32}, {3, 3}, {1, 1}),
             (std::array<unsigned int, 4>({1, 1, 2, 2})));
 
   EXPECT_NO_THROW(p.set("1, 2, 3, 4"));
   EXPECT_EQ(p.get(), "1, 2, 3, 4");
-  EXPECT_EQ(p.compute({32, 32}, {3, 3}),
+  EXPECT_EQ(p.compute({32, 32}, {3, 3}, {1, 1}),
             (std::array<unsigned int, 4>({1, 2, 3, 4})));
 }
 


### PR DESCRIPTION
- [Conv2d] Conv2d Padding Fix

```
This patch resolves conv2d calculation is crooked in some cases

**Changes proposed in this PR:**
- Conv2d Fix
- Padding::Compute Fix

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Co-authored-by: Parichay Kapoor <pk.kapoor@samsung.com>
Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```