### PR TITLE
[Fix] upstream build fail

### DIFF
--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -69,8 +69,6 @@ exe = executable(
   'unittest_layers', test_target,
   dependencies: [
     nntrainer_test_main_deps,
-    nntrainer_layer_common_standalone_tests_dep,
-    nntrainer_layer_common_dependent_tests_dep
   ],
   install: get_option('enable-test'),
   install_dir: application_install_dir

--- a/test/unittest/layers/unittest_layers_preprocess_flip.cpp
+++ b/test/unittest/layers/unittest_layers_preprocess_flip.cpp
@@ -20,5 +20,5 @@ auto semantic_flip = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::PreprocessFlipLayer>,
   nntrainer::PreprocessFlipLayer::type, {}, 0, false);
 
-INSTANTIATE_TEST_CASE_P(Preprocess, LayerSemantics,
+INSTANTIATE_TEST_CASE_P(PreprocessFlip, LayerSemantics,
                         ::testing::Values(semantic_flip));

--- a/test/unittest/layers/unittest_layers_preprocess_translate.cpp
+++ b/test/unittest/layers/unittest_layers_preprocess_translate.cpp
@@ -21,5 +21,5 @@ auto semantic_translate = LayerSemanticsParamType(
   nntrainer::PreprocessTranslateLayer::type, {"random_translate=0.1"}, 0,
   false);
 
-INSTANTIATE_TEST_CASE_P(Preprocess, LayerSemantics,
+INSTANTIATE_TEST_CASE_P(PreprocessTranslate, LayerSemantics,
                         ::testing::Values(semantic_translate));


### PR DESCRIPTION
- [Fix] upstream build fail

```
This patch fixes upstream build fail from overlapping test suite name

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```