### PR TITLE
[resnet/unittest] Add unittest for resnet @open sesame 09/23 13:59

### DIFF
--- a/test/input_gen/recorder.py
+++ b/test/input_gen/recorder.py
@@ -72,7 +72,8 @@ def _rand_like(tensorOrShape, scale=1):
     except AttributeError:
         shape = tensorOrShape
 
-    t = np.random.randint(-10, 10, shape).astype(dtype=np.float32)
+    # for relu based models, range of 0 to x is better than -x to x
+    t = np.random.randint(0, 10, shape).astype(dtype=np.float32)
     return tf.convert_to_tensor(t) * scale
 
 


### PR DESCRIPTION
- This patch adds resnet18 unittest model generation with genModelTests.
Further, the input data range is changed from 0 to x from -x to x as
relu based models work better with 0 to x data range to prevent loss of
information.
- This patch adds resnet models unittest for resnet18.
The verification has been done offline for 2 iterations for the output
of all layers with precision of 1.1e-4.
Derivaitves and gradients have higher error because of relu: when some
value is close to 0, it can be positive or negative with some error (of
the order of e-7). Although this error is way within the error limit.
however, this exacerbates the error in backwarding where derivatives (which
are significant in values) can flow if the relu value was over 0, and
not flow if under zero. This is manageable in smaller models but
difficult to avoid in unittests for larger models.

Other bug fixes in this patch:
- max error reported by unittest_nntrainer_models has been fixed
- error reporting now includes layer type as well
- ModelTestOption MINIMUM has been renamed to NO_THROW_RUN

Resnet unittest is disabled as the golden data exceeds 70MB. This will be enabled when the golden data can be generated at runtime.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>