### PR TITLE
[batchnorm] Optimize batch norm for memory and speed @open sesame 09/28 18:42

### DIFF
--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -113,14 +113,11 @@ public:
   inline static const std::string type = "batch_normalization";
 
 private:
-  Tensor cvar; /**< training variance saved in bn_layer::forwarding and used in
-                    bn_layer::calcDerivative */
-  Tensor invstd; /**<  inversed training std for backward pass */
-
-  int axis; /**< Target axis, axis inferred at initialize when -1 */
+  int axis;      /**< Target axis, axis inferred at initialize when -1 */
+  float divider; /**< size of the axes of the reduced */
 
   std::vector<unsigned int> axes_to_reduce; /**< target axes to reduce */
-  std::array<unsigned int, 5> wt_idx; /**< indices of the weights and tensors */
+  std::array<unsigned int, 9> wt_idx; /**< indices of the weights and tensors */
   std::tuple<props::Epsilon, props::BNPARAMS_MU_INIT, props::BNPARAMS_VAR_INIT,
              props::BNPARAMS_BETA_INIT, props::BNPARAMS_GAMMA_INIT,
              props::Momentum>

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -15,8 +15,8 @@
 #include <weight.h>
 
 namespace nntrainer {
-RunLayerContext::RunLayerContext(const std::string &name, float l,
-                                 const std::vector<Weight *> &w,
+RunLayerContext::RunLayerContext(const std::string &name, bool trainable,
+                                 float l, const std::vector<Weight *> &w,
                                  const std::vector<Var_Grad *> &in,
                                  const std::vector<Var_Grad *> &out,
                                  const std::vector<Var_Grad *> &t) :
@@ -26,6 +26,7 @@ RunLayerContext::RunLayerContext(const std::string &name, float l,
   outputs(out),
   tensors(t) {
   std::get<props::Name>(props).set(name);
+  std::get<props::Trainable>(props).set(trainable);
   NNTR_THROW_IF(!readyToUse(), std::invalid_argument)
     << "run context is not ready to use upon creation";
 }

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -295,6 +295,9 @@ private:
  * structures with memory allocated or support to allocate any new memory, but
  * rather only support storing specifications based on which memory will be
  * allocated later.
+ *
+ * @todo Check the caller of the getTensor() and set restrictions on the tensors
+ * to be accessed based on which function is requesting it.
  */
 class RunLayerContext {
 public:
@@ -307,7 +310,7 @@ public:
    * @param out outputs of the layer
    * @param t extra tensors of the layer
    */
-  RunLayerContext(const std::string &name, float l,
+  RunLayerContext(const std::string &name, bool trainable, float l,
                   const std::vector<Weight *> &w,
                   const std::vector<Var_Grad *> &in,
                   const std::vector<Var_Grad *> &out,
@@ -557,6 +560,13 @@ public:
   const std::string &getName() const { return std::get<props::Name>(props); }
 
   /**
+   * @brief   get trainable by the layer
+   *
+   * @return trainable of the layer
+   */
+  bool getTrainable() const { return std::get<props::Trainable>(props); }
+
+  /**
    * @brief   check if run context is set and is ready to use
    *
    * @return true if ready, else false
@@ -564,8 +574,8 @@ public:
   bool readyToUse() const;
 
 private:
-  std::tuple<props::Name> props; /**< props of the layer */
-  float loss;                    /**< loss of the layer */
+  std::tuple<props::Name, props::Trainable> props; /**< props of the layer */
+  float loss;                                      /**< loss of the layer */
 
   std::vector<Weight *> weights;   /**< weights of the layer */
   std::vector<Var_Grad *> inputs;  /**< inputs of the layer */

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -481,7 +481,8 @@ void LayerNode::calcDerivative() {
  */
 void LayerNode::calcGradient() {
   START_PROFILE(calc_grad_event_key);
-  layer->calcGradient(*run_context);
+  if (getTrainable())
+    layer->calcGradient(*run_context);
   END_PROFILE(calc_grad_event_key);
 }
 
@@ -539,8 +540,8 @@ void LayerNode::configureRunContext(const std::vector<Weight *> &weights,
                                     const std::vector<Var_Grad *> &inputs,
                                     const std::vector<Var_Grad *> &outputs,
                                     const std::vector<Var_Grad *> &tensors) {
-  run_context = std::make_unique<RunLayerContext>(getName(), 0.0f, weights,
-                                                  inputs, outputs, tensors);
+  run_context = std::make_unique<RunLayerContext>(
+    getName(), getTrainable(), 0.0f, weights, inputs, outputs, tensors);
 }
 
 /**

--- a/nntrainer/layers/time_dist.cpp
+++ b/nntrainer/layers/time_dist.cpp
@@ -248,9 +248,9 @@ void TimeDistLayer::forwarding(RunLayerContext &context, bool training) {
       out_var.initializeGradient(label_iter);
     }
 
-    RunLayerContext dist_context(context.getName(), context.getLoss(),
-                                 getWeightsForContext(), {&in_var}, {&out_var},
-                                 getTensorsForContext());
+    RunLayerContext dist_context(context.getName(), context.getTrainable(),
+                                 context.getLoss(), getWeightsForContext(),
+                                 {&in_var}, {&out_var}, getTensorsForContext());
 
     dist_layer->forwarding(dist_context, training);
   }
@@ -294,9 +294,9 @@ void TimeDistLayer::calcDerivative(RunLayerContext &context) {
     out_var.initializeGradient(d_iter);
     out_var.initializeVariable(hval_iter);
 
-    RunLayerContext dist_context(context.getName(), context.getLoss(),
-                                 getWeightsForContext(), {&in_var}, {&out_var},
-                                 getTensorsForContext());
+    RunLayerContext dist_context(context.getName(), context.getTrainable(),
+                                 context.getLoss(), getWeightsForContext(),
+                                 {&in_var}, {&out_var}, getTensorsForContext());
 
     dist_layer->calcDerivative(dist_context);
   }
@@ -346,9 +346,9 @@ void TimeDistLayer::calcGradient(RunLayerContext &context) {
     in_var.initializeVariable(in_iter);
     out_var.initializeGradient(d_iter);
 
-    RunLayerContext dist_context(context.getName(), context.getLoss(),
-                                 getWeightsForContext(), {&in_var}, {&out_var},
-                                 getTensorsForContext());
+    RunLayerContext dist_context(context.getName(), context.getTrainable(),
+                                 context.getLoss(), getWeightsForContext(),
+                                 {&in_var}, {&out_var}, getTensorsForContext());
 
     dist_layer->calcGradient(dist_context);
   }
@@ -389,9 +389,9 @@ void TimeDistLayer::setBatch(RunLayerContext &context, unsigned int batch) {
     fillWeightsFromContext(context);
     fillTensorsFromContext(context);
 
-    RunLayerContext dist_context(context.getName(), context.getLoss(),
-                                 getWeightsForContext(), {&in_var}, {&out_var},
-                                 getTensorsForContext());
+    RunLayerContext dist_context(context.getName(), context.getTrainable(),
+                                 context.getLoss(), getWeightsForContext(),
+                                 {&in_var}, {&out_var}, getTensorsForContext());
 
     dist_layer->setBatch(dist_context, batch);
 

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1180,20 +1180,36 @@ void Tensor::read(std::ifstream &file) {
  * @brief Calculate average value according to the axis.
  */
 Tensor Tensor::average(unsigned int axis) const {
+  Tensor t;
+  return average(axis, t);
+}
+
+/**
+ * @brief Calculate average value according to the axis.
+ */
+Tensor &Tensor::average(unsigned int axis, Tensor &output) const {
   if (axis >= TensorDim::MAXDIM)
     throw std::out_of_range(
       "negative axis or axis more then MAXDIM is invalid");
 
   unsigned int axis_size = dim.getDim()[axis];
   if (axis_size == 1)
-    return this->clone();
+    output.copy(*this);
+  else
+    this->sum(axis, output, 1.0 / ((float)axis_size));
 
-  return this->sum(axis, 1.0 / ((float)axis_size));
+  return output;
 }
 
 Tensor Tensor::average(const std::vector<unsigned int> &axes) const {
+  Tensor t;
+  return average(axes, t);
+}
+
+Tensor &Tensor::average(const std::vector<unsigned int> &axes,
+                        Tensor &output) const {
   if (axes.empty())
-    return this->average();
+    return this->average(output);
 
   TensorDim ret_shape;
   for (const auto &idx : axes) {
@@ -1203,7 +1219,7 @@ Tensor Tensor::average(const std::vector<unsigned int> &axes) const {
     ret_shape.setTensorDim(idx, dim.getTensorDim(idx));
   }
 
-  return this->sum(axes, 1.0 / (float)ret_shape.getDataLen());
+  return this->sum(axes, output, 1.0 / (float)ret_shape.getDataLen());
 }
 
 /**
@@ -1213,6 +1229,15 @@ Tensor Tensor::average() const {
   Tensor result = *this;
   result.reshape({1, 1, 1, dim.getDataLen()});
   return result.average(3);
+}
+
+/**
+ * @brief Calculate average value according to the axis.
+ */
+Tensor &Tensor::average(Tensor &output) const {
+  Tensor result = *this;
+  result.reshape({1, 1, 1, dim.getDataLen()});
+  return result.average(3, output);
 }
 
 void Tensor::setValue(float val) {

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -597,6 +597,7 @@ public:
    */
   Tensor &sum(const std::vector<unsigned int> &axes, Tensor &output,
               float alpha = 1.0) const;
+
   /**
    * @brief     Averaging the Tensor elements according to the axis
    *            0 : batch direction
@@ -606,6 +607,12 @@ public:
    * @retval    Calculated Tensor
    */
   Tensor average(unsigned int axis) const;
+  /**
+   * @brief     Averaging the Tensor elements according to the axis
+   *
+   * @retval    Calculated Tensor
+   */
+  Tensor &average(unsigned int axis, Tensor &output) const;
 
   /**
    * @brief average all the Tensor by multiple axes
@@ -616,10 +623,25 @@ public:
   Tensor average(const std::vector<unsigned int> &axes) const;
 
   /**
+   * @brief average all the Tensor by multiple axes
+   *
+   * @param axes axes to sum along
+   * @param output output tensor
+   * @return Tensor
+   */
+  Tensor &average(const std::vector<unsigned int> &axes, Tensor &output) const;
+
+  /**
    * @brief     Averaging the Tensor elements by all axis
    * @retval    Calculated Tensor
    */
   Tensor average() const;
+
+  /**
+   * @brief     Averaging the Tensor elements by all axis
+   * @retval    Calculated Tensor
+   */
+  Tensor &average(Tensor &output) const;
 
   /**
    * @brief     Anchor a starting point to defer following evaluation

--- a/test/unittest/layers/layers_golden_tests.cpp
+++ b/test/unittest/layers/layers_golden_tests.cpp
@@ -131,8 +131,8 @@ static RunLayerContext prepareRunContext(const TensorPacks &packs) {
   };
 
   auto rc =
-    RunLayerContext("golden", 0.0f, create_view(weights), create_view(ins),
-                    create_view(outs), create_view(tensors));
+    RunLayerContext("golden", true, 0.0f, create_view(weights),
+                    create_view(ins), create_view(outs), create_view(tensors));
 
   auto num_outputs = rc.getNumOutputs();
 


### PR DESCRIPTION
- This patch optimizes batch normalization implementation.
Reduces the temporary memory allocation and provide speedup for the
layer execution. With this patch, resnet18 runtime improves by approx
5%.
  - update the tensor usage method to give the output tensor. Although the methods where already allocated output can be passed were available, they were not being used. This patch adds the corresponding support.
- This patch optimizes batch norm layer and tries to share the
calculations performed in calcGradient and calcDerivative.
    - reuse dbeta and dgamma calculations
    - reduce number of required temporary variables
    - create all the required tensor variables with context
    - add support for checking if the layer is trainable or not via run
    context
    - support average operation with the output tensor already allocated
    - this patch reduces as much as memory as possible without sacrificing
    speed. more memory optimization is possible at the expense of speed but
    has been ommitted for now.

See also  #1591

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>

resolves #1598