### PR TITLE
[batch norm] reduce batch norm memory utilization further

### DIFF
--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -117,7 +117,7 @@ private:
   float divider; /**< size of the axes of the reduced */
 
   std::vector<unsigned int> axes_to_reduce; /**< target axes to reduce */
-  std::array<unsigned int, 9> wt_idx; /**< indices of the weights and tensors */
+  std::array<unsigned int, 8> wt_idx; /**< indices of the weights and tensors */
   std::tuple<props::Epsilon, props::BNPARAMS_MU_INIT, props::BNPARAMS_VAR_INIT,
              props::BNPARAMS_BETA_INIT, props::BNPARAMS_GAMMA_INIT,
              props::Momentum>


### PR DESCRIPTION
- Reduce the memory comsumption of batch norm for forwarding by re-using
the output tensor as temporary memory than requesting new memory.
- Remove the extra full size extra memory requirement as the cost of the
reduced memory. The difference in memory requirmement can be
significant. Earlier memory requirement was b*c*h*w vs now it is just c
where the assumption is that batch norm if is normalizing along
axis=channel.

This is achieved by reordering of the operations.
Note: this change has no performance impact.

Resolves #1591

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>