### PR TITLE
[layer] Add initial support for attention layer

### DIFF
--- a/Applications/Custom/LayerPlugin/layer_plugin_mae_loss_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_mae_loss_test.cpp
@@ -25,7 +25,7 @@ INSTANTIATE_TEST_CASE_P(
 
 auto semantic_mae =
   LayerSemanticsParamType(nntrainer::createLayer<custom::MaeLossLayer>,
-                          custom::MaeLossLayer::type, {}, 0, false);
+                          custom::MaeLossLayer::type, {}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(MaeLossLayer, LayerSemantics,
                         ::testing::Values(semantic_mae));

--- a/Applications/Custom/LayerPlugin/layer_plugin_pow_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_pow_test.cpp
@@ -25,7 +25,7 @@ INSTANTIATE_TEST_CASE_P(PowLayer, LayerPluginCommonTest,
 
 auto semantic_pow =
   LayerSemanticsParamType(nntrainer::createLayer<custom::PowLayer>,
-                          custom::PowLayer::type, {}, 0, false);
+                          custom::PowLayer::type, {}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(PowLayer, LayerSemantics,
                         ::testing::Values(semantic_pow));

--- a/Applications/Custom/LayerPlugin/layer_plugin_rnnt_loss_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_rnnt_loss_test.cpp
@@ -25,7 +25,7 @@ INSTANTIATE_TEST_CASE_P(
 
 auto semantic_rnnt =
   LayerSemanticsParamType(nntrainer::createLayer<custom::RNNTLossLayer>,
-                          custom::RNNTLossLayer::type, {}, 0, false);
+                          custom::RNNTLossLayer::type, {}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(RNNTLossLayer, LayerSemantics,
                         ::testing::Values(semantic_rnnt));

--- a/Applications/SimpleShot/test/simpleshot_layer_common_tests.cpp
+++ b/Applications/SimpleShot/test/simpleshot_layer_common_tests.cpp
@@ -21,18 +21,18 @@
 /// @todo move below test to the main repo
 auto semantic_activation_l2norm = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::PreprocessL2NormLayer>,
-  nntrainer::PreprocessL2NormLayer::type, {}, 0, false);
+  nntrainer::PreprocessL2NormLayer::type, {}, 0, false, 1);
 
 auto semantic_activation_centroid_knn = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::CentroidKNN>, nntrainer::CentroidKNN::type,
-  {"num_class=1"}, 0, false);
+  {"num_class=1"}, 0, false, 1);
 
 auto semantic_activation_centering = LayerSemanticsParamType(
   nntrainer::createLayer<simpleshot::layers::CenteringLayer>,
   simpleshot::layers::CenteringLayer::type,
   {"feature_path=../Applications/SimpleShot/backbones/"
    "conv4_60classes_feature_vector.bin"},
-  0, false);
+  0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(L2NormLayer, LayerSemantics,
                         ::testing::Values(semantic_activation_l2norm));

--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -65,6 +65,7 @@ enum LayerType {
     ML_TRAIN_LAYER_TYPE_PREPROCESS_L2NORM, /**< Preprocess l2norm Layer
                                                  type */
   LAYER_BACKBONE_TFLITE,                   /**< Backbone using TFLite */
+  LAYER_ATTENTION,                         /**< Attention Layer type */
   LAYER_LOSS_MSE = 500,             /**< Mean Squared Error Loss Layer type */
   LAYER_LOSS_CROSS_ENTROPY_SIGMOID, /**< Cross Entropy with Sigmoid Loss Layer
                                        type */

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -158,6 +158,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/activation_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/flatten_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/addition_layer.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/layers/attention_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/concat_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/preprocess_flip_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/preprocess_translate_layer.cpp \

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -30,6 +30,7 @@
 
 #include <activation_layer.h>
 #include <addition_layer.h>
+#include <attention_layer.h>
 #include <bn_layer.h>
 #include <centroid_knn.h>
 #include <concat_layer.h>
@@ -241,6 +242,8 @@ static void add_default_object(AppContext &ac) {
                      LayerType::LAYER_PERMUTE);
   ac.registerFactory(nntrainer::createLayer<DropOutLayer>, DropOutLayer::type,
                      LayerType::LAYER_DROPOUT);
+  ac.registerFactory(nntrainer::createLayer<AttentionLayer>,
+                     AttentionLayer::type, LayerType::LAYER_ATTENTION);
 
 #ifdef ENABLE_NNSTREAMER_BACKBONE
   ac.registerFactory(nntrainer::createLayer<NNStreamerLayer>,

--- a/nntrainer/layers/attention_layer.cpp
+++ b/nntrainer/layers/attention_layer.cpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   attention_layer.h
+ * @date   1 October 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Attention Layer Class for Neural Network
+ *
+ */
+
+#include <attention_layer.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+
+namespace nntrainer {
+
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
+enum AttentionParams { query = 0, value = 1 };
+
+void AttentionLayer::finalize(InitLayerContext &context) {
+  if (context.getNumInputs() != 2)
+    throw std::runtime_error(
+      "Attention layer does not support exclusive keys.");
+
+  sm.setActiFunc(ActivationType::ACT_SOFTMAX);
+
+  auto const &all_shapes = context.getInputDimensions();
+  auto const &query_shape = all_shapes[AttentionParams::query];
+
+  context.setOutputDimensions({query_shape});
+}
+
+void AttentionLayer::forwarding(RunLayerContext &context, bool training) {
+  Tensor &query = context.getInput(AttentionParams::query);
+  Tensor &value = context.getInput(AttentionParams::value);
+
+  Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+  Tensor distribution;
+
+  Tensor score = query.dot(value, false, true);
+  sm.run_fn(score, distribution);
+  distribution.dot(value, output);
+}
+
+void AttentionLayer::calcDerivative(RunLayerContext &context) {
+  /**
+   * Not yet implemented
+   */
+}
+
+void AttentionLayer::setProperty(const std::vector<std::string> &values) {
+  if (!values.empty()) {
+    std::string msg = "[AttentionLayer] Unknown Layer Properties count " +
+                      std::to_string(values.size());
+    throw exception::not_supported(msg);
+  }
+}
+
+} /* namespace nntrainer */

--- a/nntrainer/layers/attention_layer.h
+++ b/nntrainer/layers/attention_layer.h
@@ -87,7 +87,8 @@ public:
   inline static const std::string type = "attention";
 
 private:
-  ActiFunc sm; /** softmax activation operation */
+  ActiFunc sm;                        /** softmax activation operation */
+  std::array<unsigned int, 4> wt_idx; /**< indices of the weights and tensors */
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/attention_layer.h
+++ b/nntrainer/layers/attention_layer.h
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   attention_layer.h
+ * @date   1 October 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is Attention Layer Class for Neural Network
+ *
+ */
+
+#ifndef __ATTENTION_LAYER_H__
+#define __ATTENTION_LAYER_H__
+#ifdef __cplusplus
+
+#include <acti_func.h>
+#include <layer_devel.h>
+
+namespace nntrainer {
+
+/**
+ * @class   Attention Layer
+ * @brief   Attention Layer
+ */
+class AttentionLayer : public Layer {
+public:
+  /**
+   * @brief     Constructor of Attention Layer
+   */
+  AttentionLayer() : Layer() {}
+
+  /**
+   * @brief     Destructor of Attention Layer
+   */
+  ~AttentionLayer() {}
+
+  /**
+   *  @brief  Move constructor of AttentionLayer.
+   *  @param[in] AttentionLayer &&
+   */
+  AttentionLayer(AttentionLayer &&rhs) noexcept = default;
+
+  /**
+   * @brief  Move assignment operator.
+   * @parma[in] rhs AttentionLayer to be moved.
+   */
+  AttentionLayer &operator=(AttentionLayer &&rhs) = default;
+
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  void finalize(InitLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
+   */
+  void forwarding(RunLayerContext &context, bool training) override;
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  void calcDerivative(RunLayerContext &context) override;
+
+  /**
+   * @copydoc bool supportBackwarding() const
+   */
+  bool supportBackwarding() const override { return true; };
+
+  /**
+   * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
+   */
+  void exportTo(Exporter &exporter,
+                const ExportMethods &method) const override {}
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  const std::string getType() const override { return AttentionLayer::type; };
+
+  inline static const std::string type = "attention";
+
+private:
+  ActiFunc sm; /** softmax activation operation */
+};
+
+} // namespace nntrainer
+
+#endif /* __cplusplus */
+#endif /* __ATTENTION_LAYER_H__ */

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -379,6 +379,8 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims) {
 
   std::vector<TensorDim> actual_input_dims;
   auto &prop_dims = std::get<std::vector<props::InputShape>>(*layer_node_props);
+  auto &prop_in_layers =
+    std::get<std::vector<props::InputLayer>>(*layer_node_props);
 
   /** prepare input dimensions */
   if (!input_dims.empty()) {
@@ -396,7 +398,9 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims) {
       << "if input dims not given, input shapes must be given by the user as "
          "property";
     /// arguably, below check can go away
-    NNTR_THROW_IF(prop_dims.size() != 1, std::invalid_argument)
+    NNTR_THROW_IF((prop_dims.size() != prop_in_layers.size()) &&
+                    (prop_dims.size() != 1 || !prop_in_layers.empty()),
+                  std::invalid_argument)
       << "input shapes must be one if connection is not given but given "
          "dimesions size of: "
       << prop_dims.size();
@@ -404,7 +408,7 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims) {
       std::vector<TensorDim>(prop_dims.begin(), prop_dims.end());
   }
 
-  NNTR_THROW_IF(input_dims.size() < getNumInputConnections(),
+  NNTR_THROW_IF(actual_input_dims.size() < getNumInputConnections(),
                 std::invalid_argument)
     << "number of input dimensions must be equal or larger "
     << "than number of input connections, node name: " << getName()

--- a/nntrainer/layers/meson.build
+++ b/nntrainer/layers/meson.build
@@ -4,6 +4,7 @@ nntrainer_inc += include_directories('loss')
 layer_sources = [
   'activation_layer.cpp',
   'addition_layer.cpp',
+  'attention_layer.cpp',
   'concat_layer.cpp',
   'bn_layer.cpp',
   'conv2d_layer.cpp',

--- a/test/unittest/layers/layers_common_tests.h
+++ b/test/unittest/layers/layers_common_tests.h
@@ -34,7 +34,8 @@ using LayerSemanticsParamType =
   std::tuple<LayerFactoryType /** layer factory */,
              std::string /** Type of Layer */,
              std::vector<std::string> /** Necessary Properties */,
-             unsigned int /** Options */, bool /** fail or succeed */
+             unsigned int /** Options */, bool /** fail or succeed */,
+             unsigned int /** number of inputs */
              >;
 
 /**
@@ -61,8 +62,10 @@ public:
   virtual void SetUp() {
     auto f = std::get<0>(GetParam());
     layer = std::move(f({}));
-    std::tie(std::ignore, expected_type, valid_properties, options, must_fail) =
-      GetParam();
+    std::tie(std::ignore, expected_type, valid_properties, options, must_fail,
+             num_inputs) = GetParam();
+
+    num_inputs = std::max(1u, num_inputs);
   }
 
   /**
@@ -77,6 +80,7 @@ protected:
   std::vector<std::string> valid_properties;
   unsigned int options;
   bool must_fail;
+  unsigned int num_inputs;
 };
 
 typedef enum {

--- a/test/unittest/layers/layers_dependent_common_tests.cpp
+++ b/test/unittest/layers/layers_dependent_common_tests.cpp
@@ -41,9 +41,17 @@ TEST_P(LayerSemantics, setPropertiesInvalid_n) {
 
 TEST_P(LayerSemantics, finalizeValidateLayerNode_p) {
   auto lnode = nntrainer::createLayerNode(expected_type);
-  lnode->setProperty({"input_shape=1:1:1", "name=test"});
-  // /** purpose is to set number of outputs to 1 */
-  // lnode->setOutputLayers({"dummy"});
+  std::vector<std::string> props = {"name=test"};
+  std::string input_shape = "input_shape=1:1:1";
+  std::string input_layers = "input_layers=a";
+  for (auto idx = 1u; idx < num_inputs; idx++) {
+    input_shape += ",1:1:1";
+    input_layers += ",a";
+  }
+  props.push_back(input_shape);
+  props.push_back(input_layers);
+  lnode->setProperty(props);
+
   EXPECT_NO_THROW(lnode->setProperty(valid_properties));
 
   if (!must_fail) {
@@ -80,7 +88,17 @@ TEST_P(LayerSemantics, gettersValidateLayerNode_p) {
 
 TEST_P(LayerSemantics, setBatchValidateLayerNode_p) {
   auto lnode = nntrainer::createLayerNode(expected_type);
-  lnode->setProperty({"input_shape=1:1:1", "name=test"});
+  std::vector<std::string> props = {"name=test"};
+  std::string input_shape = "input_shape=1:1:1";
+  std::string input_layers = "input_layers=a";
+  for (auto idx = 1u; idx < num_inputs; idx++) {
+    input_shape += ",1:1:1";
+    input_layers += ",a";
+  }
+  props.push_back(input_shape);
+  props.push_back(input_layers);
+  lnode->setProperty(props);
+
   EXPECT_NO_THROW(lnode->setProperty(valid_properties));
 
   if (!must_fail) {

--- a/test/unittest/layers/layers_standalone_common_tests.cpp
+++ b/test/unittest/layers/layers_standalone_common_tests.cpp
@@ -37,8 +37,9 @@ TEST_P(LayerSemantics, DISABLED_setPropertiesValidInvalidOnly_n) {
 
 TEST_P(LayerSemantics, finalizeValidate_p) {
   nntrainer::TensorDim in_dim({1, 1, 1, 1});
+  std::vector<nntrainer::TensorDim> input_dims(num_inputs, in_dim);
   nntrainer::InitLayerContext init_context =
-    nntrainer::InitLayerContext({in_dim}, 1, "layer");
+    nntrainer::InitLayerContext(input_dims, 1, "layer");
   EXPECT_EQ(init_context.validate(), true);
 
   // set necessary properties only
@@ -77,9 +78,10 @@ TEST_P(LayerSemantics, gettersValidate_p) {
 
 TEST_P(LayerSemantics, setBatchValidate_p) {
   nntrainer::TensorDim in_dim({1, 1, 1, 1});
+  std::vector<nntrainer::TensorDim> input_dims(num_inputs, in_dim);
   nntrainer::InitLayerContext init_context =
-    nntrainer::InitLayerContext({in_dim}, 1, "layer");
-  init_context.validate();
+    nntrainer::InitLayerContext(input_dims, 1, "layer");
+  EXPECT_EQ(init_context.validate(), true);
 
   // set necessary properties only
   EXPECT_NO_THROW(layer->setProperty(valid_properties));

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -49,6 +49,7 @@ test_target = [
   'unittest_layers_embedding.cpp',
   'unittest_layers_concat.cpp',
   'unittest_layers_permute.cpp',
+  'unittest_layers_attention.cpp',
 ]
 
 if get_option('enable-tflite-backbone')

--- a/test/unittest/layers/unittest_layers_activation.cpp
+++ b/test/unittest/layers/unittest_layers_activation.cpp
@@ -18,23 +18,23 @@
 
 auto semantic_activation_relu = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::ActivationLayer>,
-  nntrainer::ActivationLayer::type, {"activation=relu"}, 0, false);
+  nntrainer::ActivationLayer::type, {"activation=relu"}, 0, false, 1);
 
 auto semantic_activation_sigmoid = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::ActivationLayer>,
-  nntrainer::ActivationLayer::type, {"activation=sigmoid"}, 0, false);
+  nntrainer::ActivationLayer::type, {"activation=sigmoid"}, 0, false, 1);
 
 auto semantic_activation_softmax = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::ActivationLayer>,
-  nntrainer::ActivationLayer::type, {"activation=softmax"}, 0, false);
+  nntrainer::ActivationLayer::type, {"activation=softmax"}, 0, false, 1);
 
 auto semantic_activation_tanh = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::ActivationLayer>,
-  nntrainer::ActivationLayer::type, {"activation=tanh"}, 0, false);
+  nntrainer::ActivationLayer::type, {"activation=tanh"}, 0, false, 1);
 
 auto semantic_activation_none = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::ActivationLayer>,
-  nntrainer::ActivationLayer::type, {"activation=none"}, 0, false);
+  nntrainer::ActivationLayer::type, {"activation=none"}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(Activation, LayerSemantics,
                         ::testing::Values(semantic_activation_relu,

--- a/test/unittest/layers/unittest_layers_addition.cpp
+++ b/test/unittest/layers/unittest_layers_addition.cpp
@@ -18,7 +18,12 @@
 
 auto semantic_addition =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::AdditionLayer>,
-                          nntrainer::AdditionLayer::type, {}, 0, false);
+                          nntrainer::AdditionLayer::type, {}, 0, false, 1);
+
+auto semantic_addition_multi =
+  LayerSemanticsParamType(nntrainer::createLayer<nntrainer::AdditionLayer>,
+                          nntrainer::AdditionLayer::type, {}, 0, false, 2);
 
 INSTANTIATE_TEST_CASE_P(Addition, LayerSemantics,
-                        ::testing::Values(semantic_addition));
+                        ::testing::Values(semantic_addition,
+                                          semantic_addition_multi));

--- a/test/unittest/layers/unittest_layers_attention.cpp
+++ b/test/unittest/layers/unittest_layers_attention.cpp
@@ -2,7 +2,7 @@
 /**
  * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file unittest_layers_addition.cpp
+ * @file unittest_layers_attention.cpp
  * @date 1 October 2021
  * @brief Attention Layer Test
  * @see	https://github.com/nnstreamer/nntrainer
@@ -20,5 +20,5 @@ auto semantic_attention =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::AttentionLayer>,
                           nntrainer::AttentionLayer::type, {}, 0, false, 2);
 
-INSTANTIATE_TEST_CASE_P(Addition, LayerSemantics,
+INSTANTIATE_TEST_CASE_P(Attention, LayerSemantics,
                         ::testing::Values(semantic_attention));

--- a/test/unittest/layers/unittest_layers_attention.cpp
+++ b/test/unittest/layers/unittest_layers_attention.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_layers_addition.cpp
+ * @date 1 October 2021
+ * @brief Attention Layer Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include <attention_layer.h>
+#include <layers_common_tests.h>
+
+auto semantic_attention =
+  LayerSemanticsParamType(nntrainer::createLayer<nntrainer::AttentionLayer>,
+                          nntrainer::AttentionLayer::type, {}, 0, false, 2);
+
+INSTANTIATE_TEST_CASE_P(Addition, LayerSemantics,
+                        ::testing::Values(semantic_attention));

--- a/test/unittest/layers/unittest_layers_batch_normalization.cpp
+++ b/test/unittest/layers/unittest_layers_batch_normalization.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_bn = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::BatchNormalizationLayer>,
-  nntrainer::BatchNormalizationLayer::type, {}, 0, false);
+  nntrainer::BatchNormalizationLayer::type, {}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(BatchNormalization, LayerSemantics,
                         ::testing::Values(semantic_bn));

--- a/test/unittest/layers/unittest_layers_concat.cpp
+++ b/test/unittest/layers/unittest_layers_concat.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_concat =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::ConcatLayer>,
-                          nntrainer::ConcatLayer::type, {}, 0, false);
+                          nntrainer::ConcatLayer::type, {}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(Concat, LayerSemantics,
                         ::testing::Values(semantic_concat));

--- a/test/unittest/layers/unittest_layers_convolution2d.cpp
+++ b/test/unittest/layers/unittest_layers_convolution2d.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_conv2d = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::Conv2DLayer>, nntrainer::Conv2DLayer::type,
-  {"filters=1", "kernel_size=1,1", "padding=1,1"}, 0, false);
+  {"filters=1", "kernel_size=1,1", "padding=1,1"}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(Convolution2D, LayerSemantics,
                         ::testing::Values(semantic_conv2d));

--- a/test/unittest/layers/unittest_layers_embedding.cpp
+++ b/test/unittest/layers/unittest_layers_embedding.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_embedding = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::EmbeddingLayer>,
-  nntrainer::EmbeddingLayer::type, {"out_dim=1", "in_dim=1"}, 0, false);
+  nntrainer::EmbeddingLayer::type, {"out_dim=1", "in_dim=1"}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(Embedding, LayerSemantics,
                         ::testing::Values(semantic_embedding));

--- a/test/unittest/layers/unittest_layers_flatten.cpp
+++ b/test/unittest/layers/unittest_layers_flatten.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_flatten =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::FlattenLayer>,
-                          nntrainer::FlattenLayer::type, {}, 0, false);
+                          nntrainer::FlattenLayer::type, {}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(Flatten, LayerSemantics,
                         ::testing::Values(semantic_flatten));

--- a/test/unittest/layers/unittest_layers_fully_connected.cpp
+++ b/test/unittest/layers/unittest_layers_fully_connected.cpp
@@ -19,7 +19,7 @@
 
 auto semantic_fc = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::FullyConnectedLayer>,
-  nntrainer::FullyConnectedLayer::type, {"unit=1"}, 0, false);
+  nntrainer::FullyConnectedLayer::type, {"unit=1"}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(FullyConnected, LayerSemantics,
                         ::testing::Values(semantic_fc));

--- a/test/unittest/layers/unittest_layers_gru.cpp
+++ b/test/unittest/layers/unittest_layers_gru.cpp
@@ -18,6 +18,6 @@
 
 auto semantic_gru =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::GRULayer>,
-                          nntrainer::GRULayer::type, {"unit=1"}, 0, false);
+                          nntrainer::GRULayer::type, {"unit=1"}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(GRU, LayerSemantics, ::testing::Values(semantic_gru));

--- a/test/unittest/layers/unittest_layers_impl.cpp
+++ b/test/unittest/layers/unittest_layers_impl.cpp
@@ -54,7 +54,7 @@ public:
 } // namespace
 
 auto semantic_tc = LayerSemanticsParamType(nntrainer::createLayer<MockLayer>,
-                                           MockLayer::type, {}, 0, false);
+                                           MockLayer::type, {}, 0, false, 1);
 INSTANTIATE_TEST_CASE_P(LayerImpl, LayerSemantics,
                         ::testing::Values(semantic_tc));
 

--- a/test/unittest/layers/unittest_layers_input.cpp
+++ b/test/unittest/layers/unittest_layers_input.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_input =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::InputLayer>,
-                          nntrainer::InputLayer::type, {}, 0, false);
+                          nntrainer::InputLayer::type, {}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(Input, LayerSemantics,
                         ::testing::Values(semantic_input));

--- a/test/unittest/layers/unittest_layers_loss.cpp
+++ b/test/unittest/layers/unittest_layers_loss.cpp
@@ -21,19 +21,19 @@
 
 auto semantic_loss_cross_sigmoid = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::CrossEntropySigmoidLossLayer>,
-  nntrainer::CrossEntropySigmoidLossLayer::type, {}, 0, false);
+  nntrainer::CrossEntropySigmoidLossLayer::type, {}, 0, false, 1);
 
 auto semantic_loss_cross_softmax = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::CrossEntropySoftmaxLossLayer>,
-  nntrainer::CrossEntropySoftmaxLossLayer::type, {}, 0, false);
+  nntrainer::CrossEntropySoftmaxLossLayer::type, {}, 0, false, 1);
 
 auto semantic_loss_mse =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::MSELossLayer>,
-                          nntrainer::MSELossLayer::type, {}, 0, false);
+                          nntrainer::MSELossLayer::type, {}, 0, false, 1);
 
 auto semantic_loss_cross = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::CrossEntropyLossLayer>,
-  nntrainer::CrossEntropyLossLayer::type, {}, 0, true);
+  nntrainer::CrossEntropyLossLayer::type, {}, 0, true, 1);
 
 INSTANTIATE_TEST_CASE_P(LossCross, LayerSemantics,
                         ::testing::Values(semantic_loss_cross,

--- a/test/unittest/layers/unittest_layers_lstm.cpp
+++ b/test/unittest/layers/unittest_layers_lstm.cpp
@@ -18,6 +18,6 @@
 
 auto semantic_lstm =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::LSTMLayer>,
-                          nntrainer::LSTMLayer::type, {"unit=1"}, 0, false);
+                          nntrainer::LSTMLayer::type, {"unit=1"}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(LSTM, LayerSemantics, ::testing::Values(semantic_lstm));

--- a/test/unittest/layers/unittest_layers_multiout.cpp
+++ b/test/unittest/layers/unittest_layers_multiout.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_output =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::MultiOutLayer>,
-                          nntrainer::MultiOutLayer::type, {}, 0, false);
+                          nntrainer::MultiOutLayer::type, {}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(Output, LayerSemantics,
                         ::testing::Values(semantic_output));

--- a/test/unittest/layers/unittest_layers_nnstreamer.cpp
+++ b/test/unittest/layers/unittest_layers_nnstreamer.cpp
@@ -19,7 +19,7 @@
 auto semantic_nnstreamer = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::NNStreamerLayer>,
   nntrainer::NNStreamerLayer::type,
-  {"model_path=../test/test_models/models/add.tflite"}, 0, false);
+  {"model_path=../test/test_models/models/add.tflite"}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(NNStreamer, LayerSemantics,
                         ::testing::Values(semantic_nnstreamer));

--- a/test/unittest/layers/unittest_layers_permute.cpp
+++ b/test/unittest/layers/unittest_layers_permute.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_permute = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::PermuteLayer>,
-  nntrainer::PermuteLayer::type, {"direction=3,2,1"}, 0, false);
+  nntrainer::PermuteLayer::type, {"direction=3,2,1"}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(Permute, LayerSemantics,
                         ::testing::Values(semantic_permute));

--- a/test/unittest/layers/unittest_layers_pooling2d.cpp
+++ b/test/unittest/layers/unittest_layers_pooling2d.cpp
@@ -16,22 +16,23 @@
 #include <layers_common_tests.h>
 #include <pooling2d_layer.h>
 
-auto semantic_pooling2d_max = LayerSemanticsParamType(
-  nntrainer::createLayer<nntrainer::Pooling2DLayer>,
-  nntrainer::Pooling2DLayer::type, {"pooling=max", "pool_size=1,1"}, 0, false);
+auto semantic_pooling2d_max =
+  LayerSemanticsParamType(nntrainer::createLayer<nntrainer::Pooling2DLayer>,
+                          nntrainer::Pooling2DLayer::type,
+                          {"pooling=max", "pool_size=1,1"}, 0, false, 1);
 
 auto semantic_pooling2d_avg =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::Pooling2DLayer>,
                           nntrainer::Pooling2DLayer::type,
-                          {"pooling=average", "pool_size=1,1"}, 0, false);
+                          {"pooling=average", "pool_size=1,1"}, 0, false, 1);
 
 auto semantic_pooling2d_global_avg = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::Pooling2DLayer>,
-  nntrainer::Pooling2DLayer::type, {"pooling=global_average"}, 0, false);
+  nntrainer::Pooling2DLayer::type, {"pooling=global_average"}, 0, false, 1);
 
 auto semantic_pooling2d_global_max = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::Pooling2DLayer>,
-  nntrainer::Pooling2DLayer::type, {"pooling=global_max"}, 0, false);
+  nntrainer::Pooling2DLayer::type, {"pooling=global_max"}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(Pooling2DMax, LayerSemantics,
                         ::testing::Values(semantic_pooling2d_max,

--- a/test/unittest/layers/unittest_layers_preprocess_flip.cpp
+++ b/test/unittest/layers/unittest_layers_preprocess_flip.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_flip = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::PreprocessFlipLayer>,
-  nntrainer::PreprocessFlipLayer::type, {}, 0, false);
+  nntrainer::PreprocessFlipLayer::type, {}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(PreprocessFlip, LayerSemantics,
                         ::testing::Values(semantic_flip));

--- a/test/unittest/layers/unittest_layers_preprocess_translate.cpp
+++ b/test/unittest/layers/unittest_layers_preprocess_translate.cpp
@@ -18,8 +18,8 @@
 
 auto semantic_translate = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::PreprocessTranslateLayer>,
-  nntrainer::PreprocessTranslateLayer::type, {"random_translate=0.1"}, 0,
-  false);
+  nntrainer::PreprocessTranslateLayer::type, {"random_translate=0.1"}, 0, false,
+  1);
 
 INSTANTIATE_TEST_CASE_P(PreprocessTranslate, LayerSemantics,
                         ::testing::Values(semantic_translate));

--- a/test/unittest/layers/unittest_layers_rnn.cpp
+++ b/test/unittest/layers/unittest_layers_rnn.cpp
@@ -18,6 +18,6 @@
 
 auto semantic_rnn =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::RNNLayer>,
-                          nntrainer::RNNLayer::type, {"unit=1"}, 0, false);
+                          nntrainer::RNNLayer::type, {"unit=1"}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(RNN, LayerSemantics, ::testing::Values(semantic_rnn));

--- a/test/unittest/layers/unittest_layers_split.cpp
+++ b/test/unittest/layers/unittest_layers_split.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_split = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::SplitLayer>, nntrainer::SplitLayer::type,
-  {"split_dimension=3"}, 0, false);
+  {"split_dimension=3"}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(Split, LayerSemantics,
                         ::testing::Values(semantic_split));

--- a/test/unittest/layers/unittest_layers_tflite.cpp
+++ b/test/unittest/layers/unittest_layers_tflite.cpp
@@ -18,7 +18,7 @@
 
 auto semantic_tflite = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::TfLiteLayer>, nntrainer::TfLiteLayer::type,
-  {"model_path=../test/test_models/models/add.tflite"}, 0, false);
+  {"model_path=../test/test_models/models/add.tflite"}, 0, false, 1);
 
 INSTANTIATE_TEST_CASE_P(TfLite, LayerSemantics,
                         ::testing::Values(semantic_tflite));


### PR DESCRIPTION
- This patch adds bug fix for finalize of the layer node. The checks of
the inputs dimensions and input shapes has been fixed when multiple
inputs are expected to be set.
- This patch adds the initial commit for attention layer.
  - add class description
  - add basic forwarding
  This implements the common form of attention layer where key and value
are the same tensor. The other format will be supported soon.
- This patch adds basic unittest for attention layer.
To achieve, the existing tests are modified to support multiple inputs
in the test format.
- This patch adds backwarding for attention layer. Corresponding unittests
will be added in the next patch.

See Also #1599

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>