### PR TITLE
[meson] Disable enable-debug by default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,7 +14,7 @@ option('enable-nnstreamer-backbone', type: 'boolean', value: true)
 option('enable-tflite-backbone', type: 'boolean', value: true)
 option('enable-android', type: 'boolean', value: false)
 option('enable-profile', type: 'boolean', value: false)
-option('enable-debug', type: 'boolean', value: true)
+option('enable-debug', type: 'boolean', value: false)
 option('enable-tflite-interpreter', type: 'boolean', value: true)
 
 # dependency conflict resolution


### PR DESCRIPTION
This patch sets enable-debug to false by default which was enabled
mistakenly by #1607.
enable-debug is set to true for ubuntu and tizen build in CI only with
unit_test set to true in the CI by setting the meson build config in the packaging.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>