### PR TITLE
[Fix] Prevent connect input layer when in the middle

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -99,7 +99,10 @@ void NetworkGraph::addDefaultInputLayers() {
   for (auto iter = cbegin() + 1; iter != cend(); iter++) {
     auto layer = *iter;
     auto prev_layer = *(iter - 1);
-    if (layer->getNumInputConnections() == 0) {
+    if (layer->getNumInputConnections() == 0 &&
+        !layer->hasInputShapeProperty()) {
+      ml_logd("default input added %s->%s", prev_layer->getName().c_str(),
+              layer->getName().c_str());
       layer->addInputLayers(prev_layer->getName());
     }
   }
@@ -816,8 +819,8 @@ int NetworkGraph::initialize() {
     return node->getInputConnections().empty();
   };
 
-  std::vector<Var_Grad *> inputs = {};
   for (unsigned int idx = 0; idx < graph.size(); ++idx) {
+    std::vector<Var_Grad *> inputs = {};
     auto const &lnode = getSortedLayerNode(idx);
     ml_logd("layer name : %s", lnode->getName().c_str());
 


### PR DESCRIPTION
## Commits to be reviewed in this PR


<details><summary>[Fix] Prevent connect input layer when in the middle</summary><br />

This patch update network graph to prevent making connections when input
layer is in the middle

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

