### PR TITLE
[Debian] Disable debug on normal package build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,10 +18,10 @@ export DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 export DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 ifdef unit_test
 	export ENABLE_REDUCE_TOLERANCE ?= false
-	export ENABLE_DEBUG?= false
+	export ENABLE_DEBUG?= true
 else
 	export ENABLE_REDUCE_TOLERANCE ?= true
-	export ENABLE_DEBUG?= true
+	export ENABLE_DEBUG?= false
 endif
 
 %:


### PR DESCRIPTION
## Commits to be reviewed in this PR


<details><summary>[Debian] Disable debug on normal package build</summary><br />

This patch disable debug on normal package build

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

