### PR TITLE
[inputs] remove multi input realization

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -125,29 +125,6 @@ void NetworkGraph::countNonTrainableLayersAtBegin() {
   skip_non_trainable_layers = graph.size();
 }
 
-int NetworkGraph::realizeMultiInputType(
-  const std::shared_ptr<LayerNode> &in_node) {
-  int status = ML_ERROR_NONE;
-  /**
-   * Multi-input works with time distribution layer by itself
-   *
-   */
-  if (in_node->getNumInputConnections() <= 1)
-    return ML_ERROR_NONE;
-
-  // TODO: this can be addition or concat layer - add support
-  std::shared_ptr<LayerNode> lnode = createLayerNode(AdditionLayer::type);
-  graph.ensureName(*lnode, in_node->getName());
-
-  lnode->setInputLayers(in_node->getInputLayers());
-  in_node->setInputLayers({lnode->getName()});
-  /** output layers for layer obj will be set in setOutputLayers() */
-
-  graph.addNode(lnode, false);
-
-  return status;
-}
-
 int NetworkGraph::realizeFlattenType(
   const std::shared_ptr<LayerNode> &in_node) {
   if (in_node->getType() == FlattenLayer::type) {
@@ -378,12 +355,6 @@ int NetworkGraph::realizeGraph() {
         status = ML_ERROR_INVALID_PARAMETER;
         NN_RETURN_STATUS();
       }
-    }
-
-    if (lnode->getType() != AdditionLayer::type &&
-        lnode->getType() != ConcatLayer::type) {
-      status = realizeMultiInputType(lnode);
-      NN_RETURN_STATUS();
     }
 
     if (lnode->getType() != ActivationLayer::type) {

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -423,14 +423,6 @@ private:
   int realizeGraph();
 
   /**
-   * @brief     check and add Multi Input Layer : addition or concat Layer
-   * @param[in] in_node layernode
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int realizeMultiInputType(const std::shared_ptr<LayerNode> &in_node);
-
-  /**
    * @brief     check and add Multi output Layer : output Layer
    * @param[in] in_node layernode
    * @retval #ML_ERROR_NONE Successful.


### PR DESCRIPTION
## Commits to be reviewed in this PR


<details><summary>[inputs] remove multi input realization</summary><br />

This patch removes multiinput realization behavior for now, this is not
used else where so it's fine to remove

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

