### PR TITLE
[layer] Support single timestep for lstm

### DIFF
--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -878,6 +878,29 @@ public:
   static constexpr const char *key = "flip_direction";
 };
 
+/**
+ * @brief timestep property, timestep is used to identify for which timestep
+ * should the lstm/gru/rnn layer do the operation for
+ *
+ */
+class Timestep : public PositiveIntegerProperty {
+public:
+  static constexpr const char *key = "timestep"; /**< unique key to access */
+  using prop_tag = uint_prop_tag;                /**< property type */
+};
+
+/**
+ * @brief maximum timestep property, timestep is used to identify for the
+ * maximum time unroll possible for lstm/gru/rnn layer
+ *
+ */
+class MaxTimestep : public PositiveIntegerProperty {
+public:
+  static constexpr const char *key =
+    "max_timestep";               /**< unique key to access */
+  using prop_tag = uint_prop_tag; /**< property type */
+};
+
 } // namespace props
 } // namespace nntrainer
 

--- a/nntrainer/layers/lstm.h
+++ b/nntrainer/layers/lstm.h
@@ -82,7 +82,7 @@ public:
   /**
    * @copydoc Layer::supportBackwarding()
    */
-  bool supportBackwarding() const { return true; }
+  bool supportBackwarding() const override { return true; }
 
   /**
    * @copydoc Layer::setProperty(const PropertyType type, const std::string
@@ -99,11 +99,12 @@ private:
    * RecurrentActivation: activation type for recurrent. default is sigmoid
    * ReturnSequence: option for return sequence
    * DropOutRate: dropout rate
+   * TimeStep: timestep for which lstm should operate
    *
    * */
   std::tuple<props::Unit, props::HiddenStateActivation,
              props::RecurrentActivation, props::ReturnSequences,
-             props::DropOutRate>
+             props::DropOutRate, props::MaxTimestep, props::Timestep>
     lstm_props;
   std::array<unsigned int, 7> wt_idx; /**< indices of the weights */
 


### PR DESCRIPTION
This patch adds support for single timestep for lstm.
This is achieved with two external properties:
1. timestep - provides the current timestep for which lstm will run
2. max_timestep - the maximum timestep till which lstm will run

This patch also verifies that this LSTM implementation already does gradient stacking appropriately.

See Also #1596

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>