### PR TITLE
[Recurrent] Add timestep property to recurrent layers

### DIFF
--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -648,7 +648,17 @@ public:
  */
 class OutputLayer : public Name {
 public:
+  /**
+   * @brief Construct a new Output Layer object
+   *
+   */
   OutputLayer();
+
+  /**
+   * @brief Construct a new Output Layer object
+   *
+   * @param name name to set
+   */
   OutputLayer(const std::string &name);
   static constexpr const char *key = "output_layers";
   using prop_tag = str_prop_tag;
@@ -932,7 +942,7 @@ public:
  * should the lstm/gru/rnn layer do the operation for
  *
  */
-class Timestep : public PositiveIntegerProperty {
+class Timestep : public Property<unsigned> {
 public:
   static constexpr const char *key = "timestep"; /**< unique key to access */
   using prop_tag = uint_prop_tag;                /**< property type */

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -81,24 +81,28 @@ TEST(RecurrentRealizer, recurrent_return_sequence_p) {
 
   RecurrentRealizer r({"unroll_for=3", "return_sequences=true",
                        "input_layers=initial_source", "output_layers=fc_out",
-                       "recurrent_input=fc_in", "recurrent_output=fc_out"},
+                       "recurrent_input=lstm", "recurrent_output=fc_out"},
                       {"out_source"});
 
   std::vector<LayerRepresentation> before = {
-    {"fully_connected", {"name=fc_in", "input_layers=initial_source"}},
-    {"fully_connected", {"name=fc_out", "input_layers=fc_in"}}};
+    {"lstm", {"name=lstm", "input_layers=initial_source"}},
+    {"fully_connected", {"name=fc_out", "input_layers=lstm"}}};
 
   std::vector<LayerRepresentation> expected = {
-    {"fully_connected", {"name=fc_in/0", "input_layers=out_source"}},
-    {"fully_connected", {"name=fc_out/0", "input_layers=fc_in/0"}},
+    {"lstm",
+     {"name=lstm/0", "input_layers=out_source", "max_timestep=3",
+      "timestep=0"}},
+    {"fully_connected", {"name=fc_out/0", "input_layers=lstm/0"}},
+    {"lstm",
+     {"name=lstm/1", "input_layers=fc_out/0", "shared_from=lstm/0",
+      "max_timestep=3", "timestep=1"}},
     {"fully_connected",
-     {"name=fc_in/1", "input_layers=fc_out/0", "shared_from=fc_in/0"}},
+     {"name=fc_out/1", "input_layers=lstm/1", "shared_from=fc_out/0"}},
+    {"lstm",
+     {"name=lstm/2", "input_layers=fc_out/1", "shared_from=lstm/0",
+      "max_timestep=3", "timestep=2"}},
     {"fully_connected",
-     {"name=fc_out/1", "input_layers=fc_in/1", "shared_from=fc_out/0"}},
-    {"fully_connected",
-     {"name=fc_in/2", "input_layers=fc_out/1", "shared_from=fc_in/0"}},
-    {"fully_connected",
-     {"name=fc_out/2", "input_layers=fc_in/2", "shared_from=fc_out/0"}},
+     {"name=fc_out/2", "input_layers=lstm/2", "shared_from=fc_out/0"}},
     {"concat", {"name=fc_out", "input_layers=fc_out/0,fc_out/1,fc_out/2"}},
   };
 


### PR DESCRIPTION
## Commits to be reviewed in this PR


<details><summary>[Recurrent] Add timestep property to recurrent layers</summary><br />

This patch creates recurrent layer setting property support to the
recurrent wrapper.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

