### PR TITLE
[graph/model] Support for multi-label/input for the model

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -402,6 +402,12 @@ void NetworkGraph::setBatchSize(unsigned int batch_size) {
 
   if (allocated)
     allocateTensors(exec_mode);
+
+  /** update input and label dimensions */
+  for (unsigned int idx = 0; idx < input_list.size(); idx++)
+    input_dims[idx] = tensor_manager->getTensor(input_list[idx])->getDim();
+  for (unsigned int idx = 0; idx < label_list.size(); idx++)
+    label_dims[idx] = tensor_manager->getTensor(label_list[idx])->getDim();
 }
 
 void NetworkGraph::applyGradientsOnLastAccess(
@@ -834,6 +840,7 @@ int NetworkGraph::initialize(
       << num_label;
 
     /// @todo implement and use getLabel(0) instead.
+    output_list.push_back(node->getOutput(0).getName());
     label_list.push_back(node->getOutputGrad(0).getName());
     label_dims.push_back(node->getOutputDimensions()[0]);
   };
@@ -925,6 +932,16 @@ void NetworkGraph::setInputsLabels(sharedConstTensors &inputs,
                  [](auto const &val) { return *val.get(); });
 
   setInputsLabels(ins, labs);
+}
+
+std::vector<Tensor> NetworkGraph::getOutputTensors() const {
+  std::vector<Tensor> output_tensors;
+  output_tensors.reserve(output_list.size());
+
+  for (auto const &name : output_list)
+    output_tensors.push_back(*tensor_manager->getTensor(name));
+
+  return output_tensors;
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -370,6 +370,14 @@ public:
    */
   void setInputsLabels(sharedConstTensors &inputs, sharedConstTensors &labels);
 
+  /**
+   * @brief Get the Output Tensors list for the graph
+   *
+   * @return std::vector<Tensor> List of output tensors
+   * @note this tensor list is analogous to the label list
+   */
+  std::vector<Tensor> getOutputTensors() const;
+
 private:
   std::map<std::string, std::string> sub_in_out; /** This is map to identify
                    input and output layer name of subgraph */
@@ -384,10 +392,11 @@ private:
 
   /// @note *_list and *_dims must be synced at all times. Consider put it as a
   /// structure
-  std::vector<std::string> label_list; /**< identifier for the model labels */
-  std::vector<std::string> input_list; /**< identifier for the model inputs */
-  std::vector<TensorDim> label_dims;   /**< graph label dimensions */
-  std::vector<TensorDim> input_dims;   /**< graph input dimensions */
+  std::vector<std::string> label_list;  /**< identifier for the model labels */
+  std::vector<std::string> input_list;  /**< identifier for the model inputs */
+  std::vector<std::string> output_list; /**< identifier for the model outputs */
+  std::vector<TensorDim> label_dims;    /**< graph label dimensions */
+  std::vector<TensorDim> input_dims;    /**< graph input dimensions */
 
   ExecutionMode exec_mode; /**< execution mode with which the graph has been
                               currently set or previously set */

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -349,6 +349,20 @@ public:
     tensor_pool.setExternalTensor(name, t);
   }
 
+  /**
+   * @brief Get the tensor of the given name
+   *
+   * @return ptr to the tensor with the given
+   * @throws if no tensor is found with the given name
+   */
+  Tensor *getTensor(const std::string &name) {
+    try {
+      return tensor_pool.getTensor(name);
+    } catch (...) {
+      return weight_pool.getTensor(name);
+    }
+  }
+
 private:
   /** @todo: merge this list to one */
   std::vector<std::unique_ptr<Weight>>


### PR DESCRIPTION
This patch adds the support for mutli-label while training the model.
- Multi labels/inputs are now allowed for the model by taking the
dimensions from the graph than the first and last nodes
- Outputs are now also taken from the graph for validation

Another bug fix is added related to setBatch. The caches input and label
dimensions were not updated when batchsize was updated in the network
graph. This patch updates the bug for updating the batch size in the
network graph.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>