### PR TITLE
[network] Bug fix for trainable with supportBackwarding

### DIFF
--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -419,10 +419,17 @@ private:
 
   /**
    * @brief     check if the compiled graph is of correct form.
-   * @retval #ML_ERROR_NONE graph is ready to compile
-   * @retval #ML_ERROR_INVALID_PARAMETER not ready to compile.
+   * @retval #ML_ERROR_NONE graph is compiled correctly
+   * @retval #ML_ERROR_INVALID_PARAMETER did not compile correctly
    */
   int checkCompiledGraph();
+
+  /**
+   * @brief     check if the initialized graph is of correct form.
+   * @retval #ML_ERROR_NONE graph is initialized correctly
+   * @retval #ML_ERROR_INVALID_PARAMETER did not initialize correctly
+   */
+  int checkInitializedGraph();
 
   /**
    * @brief     Realize Graph Nodes

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -104,11 +104,8 @@ void EmbeddingLayer::forwarding(RunLayerContext &context, bool training) {
 }
 
 void EmbeddingLayer::calcDerivative(RunLayerContext &context) {
-  // Uncomment this after fixing issues backwarding of first layer. (Issues
-  // #1017)
-  // throw exception::not_supported(
-  //   "calcDerivative for Embedding layer is not supported");
-  return; // intended
+  throw exception::not_supported(
+    "calcDerivative for Embedding layer is not supported");
 }
 
 void EmbeddingLayer::calcGradient(RunLayerContext &context) {

--- a/nntrainer/layers/embedding.h
+++ b/nntrainer/layers/embedding.h
@@ -81,7 +81,7 @@ public:
   /**
    * @copydoc Layer::supportBackwarding()
    */
-  bool supportBackwarding() const { return true; }
+  bool supportBackwarding() const { return false; }
 
   using Layer::setProperty;
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -242,7 +242,15 @@ ActivationType LayerNode::getActivationToBeRealized() const {
 const std::string LayerNode::getType() const { return getLayer()->getType(); }
 
 bool LayerNode::getTrainable() const {
-  return std::get<props::Trainable>(*layer_node_props);
+  if (run_context)
+    /**
+     * if a layer does not contain any weights, it will be treated as a
+     * non-trainable layer.
+     */
+    return std::get<props::Trainable>(*layer_node_props) &
+           (run_context->getNumWeights() > 0);
+  else
+    return std::get<props::Trainable>(*layer_node_props);
 }
 
 bool LayerNode::getFlatten() const {

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -297,14 +297,14 @@ void NeuralNetwork::backwarding(int iteration) {
 
   auto iter = iter_begin;
   for (; iter != iter_end - 1; iter++) {
-    backwarding(*iter, iteration, true);
+    backwarding(*iter, iteration, (*iter)->supportBackwarding());
   }
 
   /**
    * The last trainable layer need not calculate the derivatives
    */
 #ifdef ENABLE_TEST
-  backwarding(*iter, iteration, true);
+  backwarding(*iter, iteration, (*iter)->supportBackwarding());
 #else
   backwarding(*iter, iteration, false);
 #endif


### PR DESCRIPTION
This patch resolves the bug for calling calcDerivative on layer which
do not support backwaring.
The issue rises from the assumption that there will be no layer
requiring backwarding after the last non-trainable layer. But this is
not valid for multi-input scenario. With multi-input, there can be over
two input layers where they both do not support backwarding but the rest of
the model can be trainable.

This patch changes this error check. Below are the updated semantics:
1. After initialization of the graph, a check is added to ensure that
for each trainable layer, all the layers all of ahead must support
backwarding, so that the trainable layer can be trained. If any layer
ahead of it does not support backwarding, error is thrown.
2. A layer is only trainable if its trainable property is set to true
(defaults to true) and contains at least 1 weight. If a layer does not
contain any weights, the layer is treated as non-trainable.
3. When backwarding the model, backwarding is called only for layers
which support backwarding, and skipped for layers which donot.

The updated semantics ensure the dependency of the flow of the
derivatives and allows mixture of layers which support and do not
support backwarding.

Resolves #1017

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>