### PR TITLE
[tensor] Add checks for external tensors

### DIFF
--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -204,6 +204,13 @@ public:
       throw std::invalid_argument(
         "Cannot set external tensor for non-zero lifespan");
 
+    if (t.size() == 0 && t.getData())
+      throw std::invalid_argument(
+        "Error: setting invalid external tensor size 0 for " + name);
+    if (t.size() != 0 && t.size() < spec.tensor->size())
+      throw std::invalid_argument(
+        "Error: setting external tensor of smaller size for " + name);
+
     spec.tensor->setData(t.getData());
   }
 


### PR DESCRIPTION
This patch adds checks while setting the external tensors:
- ensure that the external tensor size is more than the required memory
- if the tensor size is 0, its data must be null

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>