### PR TITLE
[test] GRU with reset_after=False

### DIFF
--- a/test/input_gen/genLayerTests.py
+++ b/test/input_gen/genLayerTests.py
@@ -27,7 +27,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=FutureWarning)
     import numpy as np
     import tensorflow as tf
-    from tensorflow.python import keras as K
+    import tensorflow.keras as K
 
 ##
 # @brief inpsect if file is created correctly
@@ -104,7 +104,7 @@ if __name__ == "__main__":
                          return_sequences=True,
                          return_state=False)
     record_single(lstm, (3, 1, 7), "lstm_single_step_seq")
-    record_single(lstm, (3, 4, 7), "lstm_multi_step_seq")
+    record_single(lstm, (3, 4, 7), "lstm_multi_step_seq", input_type='float')
 
     lstm = K.layers.LSTM(units=5,
                          recurrent_activation="tanh",
@@ -113,7 +113,7 @@ if __name__ == "__main__":
                          return_state=False)
     record_single(lstm, (3, 4, 7), "lstm_multi_step_seq_act")
 
-    gru = K.layers.GRU(units=5,
+    gru = K.layers.GRU(units=5, reset_after=False,
                          recurrent_activation="sigmoid",
                          activation="tanh",
                          return_sequences=False,
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     record_single(gru, (3, 1, 7), "gru_single_step")
     record_single(gru, (3, 4, 7), "gru_multi_step")
 
-    gru = K.layers.GRU(units=5,
+    gru = K.layers.GRU(units=5, reset_after=False,
                          recurrent_activation="sigmoid",
                          activation="tanh",
                          return_sequences=True,
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     record_single(gru, (3, 1, 7), "gru_single_step_seq")
     record_single(gru, (3, 4, 7), "gru_multi_step_seq", input_type='float')
 
-    gru = K.layers.GRU(units=5,
+    gru = K.layers.GRU(units=5, reset_after=False,
                          recurrent_activation="tanh",
                          activation="sigmoid",
                          return_sequences=True,

--- a/test/input_gen/genModelTests.py
+++ b/test/input_gen/genModelTests.py
@@ -32,7 +32,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=FutureWarning)
     import numpy as np
     import tensorflow as tf
-    from tensorflow.python import keras as K
+    import tensorflow.keras as K
 
 from transLayer import attach_trans_layer as TL
 from transLayer import MultiOutLayer
@@ -436,7 +436,7 @@ if __name__ == "__main__":
             else:
                 ret_array = [a0, a1, a2, a3, a4, b0, o1, o2, o3]
             return ret_array
-            
+
 
         # x -> [a, b] -> c
         x = K.Input(shape=input_shape, name="x")

--- a/test/input_gen/recorder.py
+++ b/test/input_gen/recorder.py
@@ -19,7 +19,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=FutureWarning)
     import numpy as np
     import tensorflow as tf
-    from tensorflow.python import keras as K
+    import tensorflow.keras as K
 
 from transLayer import attach_trans_layer, MultiOutLayer
 

--- a/test/input_gen/transLayer.py
+++ b/test/input_gen/transLayer.py
@@ -13,7 +13,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=FutureWarning)
     import numpy as np
     import tensorflow as tf
-    from tensorflow.python import keras as K
+    import tensorflow.keras as K
 
 import inspect
 from inspect import signature
@@ -24,7 +24,7 @@ from inspect import signature
 # input, output, weights are reinterpreted to be in nntrainer_layer layout
 class AbstractTransLayer(K.layers.Layer):
     def __init__(self, tf_layer, *args, **kwargs):
-        if not isinstance(tf_layer, K.engine.base_layer.Layer):
+        if not isinstance(tf_layer, K.layers.Layer):
             raise ValueError("tf_layer must be type of keras layer")
         super().__init__(*args, **kwargs, name=tf_layer.name + "/translated")
         self.tf_layer = tf_layer
@@ -213,9 +213,8 @@ class MultiOutLayer(IdentityTransLayer):
 # @brief A factory function to attach translayer to existing layer
 # if nothing should be attached, it does not attach the layer
 def attach_trans_layer(layer):
-    if isinstance(
-        layer,
-        (K.layers.BatchNormalization, K.layers.normalization_v2.BatchNormalization),
+    if isinstance(layer,
+        (K.layers.BatchNormalization),
     ):
         return BatchNormTransLayer(layer)
 

--- a/test/unittest/layers/layers_golden_tests.cpp
+++ b/test/unittest/layers/layers_golden_tests.cpp
@@ -153,8 +153,10 @@ static void compareRunContext(RunLayerContext &rc, std::ifstream &file,
   file.seekg(0, std::ios::beg);
   auto compare_percentage_tensors = [](const Tensor &t1, const Tensor &t2,
                                        unsigned int match_percentage) -> bool {
-    if (match_percentage == 100)
+    if (match_percentage == 100) {
+      EXPECT_EQ(t1, t2);
       return t1 == t2;
+    }
 
     if (t1.getDim() != t2.getDim())
       return false;


### PR DESCRIPTION
GRU matches with tf1 but not with tf2.
Tf2 changes the reset_after to True as default, which leads to an extra
bias. This patch forces the reset_after to be always false to enable
matching with tf1 and tf2.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>