### PR TITLE
layer] Create property for axis in batch normalization 

### DIFF
--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -41,7 +41,7 @@ public:
   /**
    * @brief     Constructor of Batch Noramlization Layer
    */
-  BatchNormalizationLayer(int axis_ = -1);
+  BatchNormalizationLayer();
 
   /**
    * @brief     Destructor of BatchNormalizationLayer
@@ -113,14 +113,13 @@ public:
   inline static const std::string type = "batch_normalization";
 
 private:
-  int axis;      /**< Target axis, axis inferred at initialize when -1 */
   float divider; /**< size of the axes of the reduced */
 
   std::vector<unsigned int> axes_to_reduce; /**< target axes to reduce */
   std::array<unsigned int, 9> wt_idx; /**< indices of the weights and tensors */
   std::tuple<props::Epsilon, props::BNPARAMS_MU_INIT, props::BNPARAMS_VAR_INIT,
              props::BNPARAMS_BETA_INIT, props::BNPARAMS_GAMMA_INIT,
-             props::Momentum>
+             props::Momentum, props::Axis>
     bn_props;
 };
 


### PR DESCRIPTION
This patch convert the axis member in batch normalization to a property
to allow setting it externally.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>