### PR TITLE
[Fix] Layer node clone configuration

### DIFF
--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -636,6 +636,8 @@ std::unique_ptr<LayerNode> LayerNode::cloneConfiguration() {
     << "It is prohibited to clone configuration";
   Exporter e;
   exportTo(e, ExportMethods::METHOD_STRINGVECTOR);
+  e.saveResult(*layer_node_props_realization,
+               ExportMethods::METHOD_STRINGVECTOR, this);
   auto props = e.getResult<ExportMethods::METHOD_STRINGVECTOR>();
 
   std::vector<std::string> key_val_props;


### PR DESCRIPTION
## Commits to be reviewed in this PR


<details><summary>[Fix] Layer node clone configuration</summary><br />

layer node clone configuration was not copying realization, this is
fixed with this patch

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

