### PR TITLE
[tensor] Power Tensor::apply() with c++17 parallel execution

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 (>=7.5),
  libflatbuffers-dev, flatbuffers-compiler, libglib2.0-dev, nnstreamer-tensorflow2-lite,
  nnstreamer-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
- ml-api-common-dev, ml-inference-api-dev
+ ml-api-common-dev, ml-inference-api-dev, libtbb-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnstreamer/nntrainer
 

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,7 @@ extra_defines = ['-DMIN_CPP_VERSION=201703L']
 
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')
+compiler_version = cxx.version()
 
 if get_option('platform') == 'tizen'
   # Pass __TIZEN__ to the compiler
@@ -135,6 +136,14 @@ endif
 openmp_dep = dummy_dep
 if get_option('enable-openmp')
   openmp_dep = dependency('openmp')
+endif
+
+tbb_dep = dependency('tbb', required: false)
+# parallel execution is only enabled since gcc9
+if tbb_dep.found() and compiler_version.version_compare('>=9')
+  add_project_arguments('-DENABLE_PARALLEL=1', language:['c', 'cpp'])
+else
+  message('Parallel execution not enabled')
 endif
 
 if get_option('enable-profile')

--- a/nntrainer/layers/acti_func.cpp
+++ b/nntrainer/layers/acti_func.cpp
@@ -19,6 +19,10 @@
 #include <iostream>
 #include <vector>
 
+#ifdef ENABLE_PARALLEL
+#include <execution>
+#endif
+
 #include <acti_func.h>
 #include <blas_interface.h>
 #include <lazy_tensor.h>
@@ -179,9 +183,15 @@ Tensor &ActiFunc::softmax(Tensor const &t, Tensor &output) {
 
   for (unsigned int k = 0; k < fixed_dim; k++) {
     int index = k * feat_len;
+#ifdef ENABLE_PARALLEL
+    std::transform(
+      std::execution::par_unseq, rp + index, rp + index + feat_len, rp + index,
+      std::bind(std::divides<float>(), std::placeholders::_1, sum.getValue(k)));
+#else
     std::transform(
       rp + index, rp + index + feat_len, rp + index,
       std::bind(std::divides<float>(), std::placeholders::_1, sum.getValue(k)));
+#endif
   }
 
   return output;

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -24,7 +24,8 @@ nntrainer_base_deps=[
   libm_dep,
   libdl_dep,
   thread_dep,
-  openmp_dep
+  openmp_dep,
+  tbb_dep
 ]
 
 if get_option('platform') == 'tizen'

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -738,37 +738,80 @@ public:
    * @brief Apply instantly to the element
    *
    * @param f function to apply
+   * @param[in] unseq_par can be unsequentially parallelized, otherwise will be
+   * sequentially parallelized
+   *
    * @return int ML_ERROR_NONE if successful
+   *
+   * @note apply is expected to run in parallel and caller must ensure that the
+   * operations to be performed are independent
    */
-  int apply_i(std::function<float(float)> f);
+  int apply_i(std::function<float(float)> f, bool unseq_par = true);
 
   /**
    * @brief     Apply function element by element
+   *
    * @param[in] *function function pointer applied
+   * @param[in] unseq_par can be unsequentially parallelized, otherwise will be
+   * sequentially parallelized
+   *
    * @retval    Tensor
+   *
+   * @note apply is expected to run in parallel and caller must ensure that the
+   * operations to be performed are independent
    */
-  Tensor apply(std::function<float(float)> f) const;
+  Tensor apply(std::function<float(float)> f, bool unseq_par = true) const;
 
   /**
    * @brief     Apply function element by element
+   *
+   * @param[in] *function function pointer applied
+   * @param[in] unseq_par can be unsequentially parallelized, otherwise will be
+   * sequentially parallelized
+   *
+   * @retval    Tensor
+   *
+   * @note apply is expected to run in parallel and caller must ensure that the
+   * operations to be performed are independent
+   */
+  Tensor applySequential(std::function<float(float)> f) const;
+
+  /**
+   * @brief     Apply function element by element
+   *
    * @param[in] *function function pointer applied
    * @param[out] output output tensor
+   * @param[in] unseq_par can be unsequentially parallelized, otherwise will be
+   * sequentially parallelized
+   *
    * @retval    Tensor
+   *
+   * @note apply is expected to run in parallel and caller must ensure that the
+   * operations to be performed are independent
    */
-  Tensor &apply(std::function<float(float)> f, Tensor &output) const;
+  Tensor &apply(std::function<float(float)> f, Tensor &output,
+                bool unseq_par = true) const;
 
   /**
    * @brief     Apply function to Tensor
+   *
    * @param[in] *function function pointer applied
    * @retval    Tensor
+   *
+   * @note apply is expected to run in parallel and caller must ensure that the
+   * operations to be performed are independent
    */
   Tensor apply(std::function<Tensor(Tensor)> f) const;
 
   /**
    * @brief     Apply function to Tensor
+   *
    * @param[in] *function function pointer applied
    * @param[out] output output tensor
    * @retval    Tensor
+   *
+   * @note apply is expected to run in parallel and caller must ensure that the
+   * operations to be performed are independent
    */
   Tensor &apply(std::function<Tensor &(Tensor, Tensor &)> f,
                 Tensor &output) const;
@@ -1251,6 +1294,22 @@ private:
    * @param axis2 second axis to merge
    */
   void mergeAxis(unsigned int axis1, unsigned int axis2);
+
+  /**
+   * @brief     Apply function element by element
+   *
+   * @param[in] *function function pointer applied
+   * @param[out] output output tensor
+   * @param[in] unseq_par can be unsequentially parallelized, otherwise will be
+   * sequentially parallelized
+   *
+   * @retval    Tensor
+   *
+   * @note apply is expected to run in parallel and caller must ensure that the
+   * operations to be performed are independent
+   */
+  Tensor &apply(std::function<float(float)> f, Tensor &output, bool parallel,
+                bool unseq) const;
 }; // namespace nntrainer
 
 /**

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -67,6 +67,8 @@ BuildRequires:	iniparser-devel >= 4.1
 BuildRequires:	gtest-devel
 BuildRequires:	python3
 BuildRequires:	python3-numpy
+# for c++17 parallel execution
+BuildRequires:	libtbb-devel
 
 BuildRequires:	%{capi_machine_learning_common}-devel
 BuildRequires:	%{capi_machine_learning_inference}-devel

--- a/test/nntrainer_test_util.cpp
+++ b/test/nntrainer_test_util.cpp
@@ -169,7 +169,7 @@ nntrainer::Tensor ranged(unsigned int batch, unsigned int channel,
                          unsigned int height, unsigned int width) {
   nntrainer::Tensor t(batch, channel, height, width);
   unsigned int i = 0;
-  return t.apply([&](float in) { return i++; });
+  return t.applySequential([&](float in) { return i++; });
 }
 
 nntrainer::Tensor randUniform(unsigned int batch, unsigned int channel,

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -1697,7 +1697,7 @@ TEST(nntrainer_Tensor, average_p) {
   EXPECT_EQ(actual, expected);
 
   int idx = 0;
-  t = t.apply([&](float in) { return idx++ % 2; });
+  t = t.applySequential([&](float in) { return idx++ % 2; });
 
   actual = t.average();
   expected = constant(0.5, 1, 1, 1, 1);
@@ -1708,20 +1708,20 @@ TEST(nntrainer_Tensor, average_axis_p) {
   nntrainer::Tensor t = constant(1.0, 2, 2, 2, 2);
   int idx = 0;
   std::function<float(float)> f = [&](float in) { return idx++ % 2; };
-  t = t.apply(f);
+  t = t.applySequential(f);
 
   nntrainer::Tensor actual, expected;
 
   actual = t.average(0);
-  expected = constant(0, 1, 2, 2, 2).apply(f);
+  expected = constant(0, 1, 2, 2, 2).applySequential(f);
   EXPECT_EQ(actual, expected);
 
   actual = t.average(1);
-  expected = constant(0, 2, 1, 2, 2).apply(f);
+  expected = constant(0, 2, 1, 2, 2).applySequential(f);
   EXPECT_EQ(actual, expected);
 
   actual = t.average(2);
-  expected = constant(0, 2, 2, 1, 2).apply(f);
+  expected = constant(0, 2, 2, 1, 2).applySequential(f);
   EXPECT_EQ(actual, expected);
 
   actual = t.average(3);


### PR DESCRIPTION
This patch enables the speedup of Tensor::apply() with c++17 parallel
sequential and unsequential mode of execution.
This helps speed up all the activation funcations and various other
operations as well.
For reference, with this patch, unittest_tizen_capi takes 5.7sec to
finish compared to 7.2sec earlier. Similarily, unittest_nntrainer_models
takes 3.75sec compared to 4.88sec. The performance improvement depends
on the model architecture and operations used in it.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>