### PR TITLE
[tensor] Bug fix for dropout mask generation

### DIFF
--- a/nntrainer/layers/dropout.cpp
+++ b/nntrainer/layers/dropout.cpp
@@ -46,7 +46,7 @@ void DropOutLayer::forwarding(RunLayerContext &context, bool training) {
     /** @todo make this in-place */
     if (training && rate_ > epsilon) {
       Tensor &mask_ = context.getTensor(mask_idx[i]);
-      mask_ = input_.dropout_mask(rate_);
+      mask_.dropout_mask(rate_);
       input_.multiply(mask_, output_);
     } else {
       output_.fill(input_);

--- a/nntrainer/layers/gru.cpp
+++ b/nntrainer/layers/gru.cpp
@@ -212,9 +212,10 @@ void GRULayer::forwarding(RunLayerContext &context, bool training) {
       Tensor xs =
         islice.getSharedDataTensor({islice.width()}, t * islice.width());
 
-      if (dropout_rate > 0.0 && training) {
-        xs.multiply_i(xs.dropout_mask(dropout_rate));
-      }
+      /** @todo verify this dropout working */
+      // if (dropout_rate > 0.0 && training) {
+      //   xs.multiply_i(xs.dropout_mask(dropout_rate));
+      // }
       hs = oslice.getSharedDataTensor({oslice.width()}, t * oslice.width());
       Tensor zrg_t =
         zrg_.getSharedDataTensor({unit * NUM_GATE}, unit * t * NUM_GATE);
@@ -265,7 +266,7 @@ void GRULayer::forwarding(RunLayerContext &context, bool training) {
                          .getBatchSlice(b, 1);
         Tensor msk =
           mask_.getSharedDataTensor({mask_.width()}, t * mask_.width());
-        msk = hs.dropout_mask(dropout_rate);
+        msk.dropout_mask(dropout_rate);
         hs.multiply_i(msk);
       }
     }

--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -262,7 +262,7 @@ void LSTMLayer::forwarding(RunLayerContext &context, bool training) {
                          .getBatchSlice(b, 1);
         Tensor msk =
           mask_.getSharedDataTensor({mask_.width()}, t * mask_.width());
-        msk = hs.dropout_mask(dropout_rate);
+        msk.dropout_mask(dropout_rate);
         hs.multiply_i(msk);
       }
     }

--- a/nntrainer/layers/rnn.cpp
+++ b/nntrainer/layers/rnn.cpp
@@ -172,7 +172,7 @@ void RNNLayer::forwarding(RunLayerContext &context, bool training) {
                          .getBatchSlice(b, 1);
         Tensor msk =
           mask_.getSharedDataTensor({mask_.width()}, t * mask_.width());
-        msk = hs.dropout_mask(dropout_rate);
+        msk.dropout_mask(dropout_rate);
         hs.multiply_i(msk);
       }
     }

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -953,20 +953,21 @@ Tensor Tensor::transpose(const std::string &direction) const {
 
 Tensor Tensor::dropout_mask(float dropout) const {
   Tensor result(dim);
-  result.setValue(1.0);
-  Tensor rand_temp(dim);
-  rand_temp.setRandUniform(0.0, 1.0);
-  float scale = 1.0 / (1 - dropout);
-
-  float *mask = result.getData();
-  float *random = rand_temp.getData();
-  for (unsigned int i = 0; i < size(); ++i) {
-    if (random[i] >= dropout)
-      mask[i] = mask[i] * scale;
-    else
-      mask[i] = 0.0;
-  }
+  result.dropout_mask(dropout);
   return result;
+}
+
+void Tensor::dropout_mask(float dropout) {
+  setRandUniform(0.0, 1.0);
+  float scale = 1.0 / (1 - dropout);
+  float *data_ = getData();
+
+  for (unsigned int i = 0; i < size(); ++i) {
+    if (data_[i] >= dropout)
+      data_[i] = scale;
+    else
+      data_[i] = 0.0;
+  }
 }
 
 int Tensor::apply_i(std::function<float(float)> f) {

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -554,6 +554,12 @@ public:
   Tensor dropout_mask(float dropout) const;
 
   /**
+   * @brief Calculate Drop Out Mask : x * 1.0/(1.0-rate) inplace
+   * @param dropout drop out rate
+   */
+  void dropout_mask(float dropout);
+
+  /**
    * @brief     sum all the Tensor elements according to the batch
    * @retval    Calculated Tensor(batch, 1, 1, 1)
    */


### PR DESCRIPTION
This patch adds fix for dropout mask generation. It was being
out-of-place which was leading to not using the tensor memory already
allocated. This patch adds the interface to use the already allocated
tensor and use it.
This patch further saves memory while generating dropout mask itself as
well.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>