### PR TITLE
[Optimizer] Prevent weight allocation for dependent nodes

### DIFF
--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -350,11 +350,14 @@ public:
     std::function<std::vector<TensorDim>(const TensorDim &)> cb,
     bool request_only_trainable = true) {
     for (auto const &w : tensor_manager->getWeights()) {
-      const TensorDim &dim = w->getDim();
-      std::vector<TensorDim> dims = cb(dim);
-      w->setOptimizerVariables(tensor_manager->requestWeightOptimizerVariables(
-        dims, w->getName(), TensorLifespan::MAX_LIFESPAN,
-        Tensor::Initializer::ZEROS));
+      if (!w->isDependent()) {
+        const TensorDim &dim = w->getDim();
+        std::vector<TensorDim> dims = cb(dim);
+        w->setOptimizerVariables(
+          tensor_manager->requestWeightOptimizerVariables(
+            dims, w->getName(), TensorLifespan::MAX_LIFESPAN,
+            Tensor::Initializer::ZEROS));
+      }
     }
   }
 


### PR DESCRIPTION
## Commits to be reviewed in this PR


<details><summary>[Optimizer] Prevent weight allocation for dependent nodes</summary><br />

This patch prevents optimizer weight allocation for dependent nodes

Resolves #1671

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

