### PR TITLE
[Fix/pkgconfig] Fix nntrainer include dir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -102,7 +102,7 @@ nntrainer_conf.set('PREFIX', nntrainer_prefix)
 nntrainer_conf.set('EXEC_PREFIX', nntrainer_bindir)
 nntrainer_conf.set('LIB_INSTALL_DIR', nntrainer_libdir)
 nntrainer_conf.set('PLUGIN_INSTALL_PREFIX', nntrainer_libdir / 'nntrainer')
-nntrainer_conf.set('INCLUDE_INSTALL_DIR', nntrainer_includedir)
+nntrainer_conf.set('INCLUDE_INSTALL_DIR', nntrainer_includedir / '..')
 nntrainer_conf.set('CAPI_ML_COMMON_DEP', get_option('capi-ml-common-actual'))
 
 dummy_dep = dependency('', required: false)


### PR DESCRIPTION
## Commits to be reviewed in this PR


<details><summary>[Fix/pkgconfig] Fix nntrainer include dir</summary><br />

This patch fixes pkg config nntrainer include directory for the pkg.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

