### PR TITLE
[layer] Simplify naming scheme for requested tensors 

### DIFF
--- a/nntrainer/layers/attention_layer.cpp
+++ b/nntrainer/layers/attention_layer.cpp
@@ -49,13 +49,13 @@ void AttentionLayer::finalize(InitLayerContext &context) {
 
   auto weights_dim = query_dim;
   weights_dim.width(value_dim.height());
-  wt_idx[AttentionParams::weights] = context.requestTensor(
-    weights_dim, context.getName() + ":weights", Tensor::Initializer::NONE,
-    false, TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[AttentionParams::weights] =
+    context.requestTensor(weights_dim, "weights", Tensor::Initializer::NONE,
+                          false, TensorLifespan::ITERATION_LIFESPAN);
 
-  wt_idx[AttentionParams::score] = context.requestTensor(
-    weights_dim, context.getName() + ":score", Tensor::Initializer::NONE, false,
-    TensorLifespan::FORWARD_FUNC_LIFESPAN);
+  wt_idx[AttentionParams::score] =
+    context.requestTensor(weights_dim, "score", Tensor::Initializer::NONE,
+                          false, TensorLifespan::FORWARD_FUNC_LIFESPAN);
 
   context.setOutputDimensions({query_dim});
 }

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -97,52 +97,48 @@ void BatchNormalizationLayer::finalize(InitLayerContext &context) {
     }
   }
 
-  wt_idx[BNParams::mu] =
-    context.requestWeight(dim, bnparams_mu, WeightRegularizer::NONE, 1.0f,
-                          context.getName() + ":moving_mean", false);
-  wt_idx[BNParams::var] =
-    context.requestWeight(dim, bnparams_var, WeightRegularizer::NONE, 1.0f,
-                          context.getName() + ":moving_variance", false);
-  wt_idx[BNParams::gamma] =
-    context.requestWeight(dim, bnparams_gamma, WeightRegularizer::NONE, 1.0f,
-                          context.getName() + ":gamma", true);
-  wt_idx[BNParams::beta] =
-    context.requestWeight(dim, bnparams_beta, WeightRegularizer::NONE, 1.0f,
-                          context.getName() + ":beta", true);
+  wt_idx[BNParams::mu] = context.requestWeight(
+    dim, bnparams_mu, WeightRegularizer::NONE, 1.0f, "moving_mean", false);
+  wt_idx[BNParams::var] = context.requestWeight(
+    dim, bnparams_var, WeightRegularizer::NONE, 1.0f, "moving_variance", false);
+  wt_idx[BNParams::gamma] = context.requestWeight(
+    dim, bnparams_gamma, WeightRegularizer::NONE, 1.0f, "gamma", true);
+  wt_idx[BNParams::beta] = context.requestWeight(
+    dim, bnparams_beta, WeightRegularizer::NONE, 1.0f, "beta", true);
 
   /**
    * caches the deviation -> input - avg(input)
    * @todo check if avoiding this storage and adding dependency on input (no
    * more in-place calculation) can save memory during memory optimization.
    */
-  wt_idx[BNParams::deviation] = context.requestTensor(
-    in_dim, context.getName() + ":deviation", Tensor::Initializer::NONE, false,
-    TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[BNParams::deviation] =
+    context.requestTensor(in_dim, "deviation", Tensor::Initializer::NONE, false,
+                          TensorLifespan::ITERATION_LIFESPAN);
   /** caches the inverse standard deviation */
-  wt_idx[BNParams::invstd] = context.requestTensor(
-    dim, context.getName() + ":invstd", Tensor::Initializer::NONE, false,
-    TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[BNParams::invstd] =
+    context.requestTensor(dim, "invstd", Tensor::Initializer::NONE, false,
+                          TensorLifespan::ITERATION_LIFESPAN);
   /**
    * Temporary tensor to store the full sized tensors in order to allow batch
    * norm to execute in-place. Running in-place leads to same memory footprint
    * for this layer in its backwarding, but reduces the peak memory requirement
    * as the output of this layer need not be stored all the time.
    */
-  wt_idx[BNParams::t_full] = context.requestTensor(
-    in_dim, context.getName() + ":tesnor_full", Tensor::Initializer::NONE,
-    false, TensorLifespan::BACKWARD_FUNC_LIFESPAN);
+  wt_idx[BNParams::t_full] =
+    context.requestTensor(in_dim, "tesnor_full", Tensor::Initializer::NONE,
+                          false, TensorLifespan::BACKWARD_FUNC_LIFESPAN);
   /**
    * caches variance + epsilon as well.
    */
-  wt_idx[BNParams::cvar] = context.requestTensor(
-    dim, context.getName() + ":cvar", Tensor::Initializer::NONE, false,
-    TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[BNParams::cvar] =
+    context.requestTensor(dim, "cvar", Tensor::Initializer::NONE, false,
+                          TensorLifespan::ITERATION_LIFESPAN);
   /**
    * Temporary tensor to store the reduced tensors along the axes_to_reduce.
    */
-  wt_idx[BNParams::t_reduced] = context.requestTensor(
-    dim, context.getName() + ":tensor_reduced", Tensor::Initializer::NONE,
-    false, TensorLifespan::BACKWARD_FUNC_LIFESPAN);
+  wt_idx[BNParams::t_reduced] =
+    context.requestTensor(dim, "tensor_reduced", Tensor::Initializer::NONE,
+                          false, TensorLifespan::BACKWARD_FUNC_LIFESPAN);
 }
 
 void BatchNormalizationLayer::setProperty(

--- a/nntrainer/layers/centroid_knn.cpp
+++ b/nntrainer/layers/centroid_knn.cpp
@@ -61,15 +61,13 @@ void CentroidKNN::finalize(nntrainer::InitLayerContext &context) {
   /// samples seen for the current run to calculate the centroid
   auto samples_seen = nntrainer::TensorDim({num_class});
 
-  weight_idx[KNNParams::map] =
-    context.requestWeight(map_dim, nntrainer::Tensor::Initializer::ZEROS,
-                          nntrainer::WeightRegularizer::NONE, 1.0f,
-                          context.getName() + ":map", false);
+  weight_idx[KNNParams::map] = context.requestWeight(
+    map_dim, nntrainer::Tensor::Initializer::ZEROS,
+    nntrainer::WeightRegularizer::NONE, 1.0f, "map", false);
 
-  weight_idx[KNNParams::num_samples] =
-    context.requestWeight(samples_seen, nntrainer::Tensor::Initializer::ZEROS,
-                          nntrainer::WeightRegularizer::NONE, 1.0f,
-                          context.getName() + ":num_samples", false);
+  weight_idx[KNNParams::num_samples] = context.requestWeight(
+    samples_seen, nntrainer::Tensor::Initializer::ZEROS,
+    nntrainer::WeightRegularizer::NONE, 1.0f, "num_samples", false);
 }
 
 void CentroidKNN::forwarding(nntrainer::RunLayerContext &context,

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -276,12 +276,11 @@ void Conv2DLayer::finalize(InitLayerContext &context) {
   padding = std::get<props::Padding2D>(conv_props)
               .compute(in_dim, dim, {stride[0], stride[1]});
 
-  wt_idx[ConvParams::weight] = context.requestWeight(
-    dim, weight_initializer, weight_regularizer, weight_regularizer_constant,
-    context.getName() + ":filter", true);
-  wt_idx[ConvParams::bias] =
-    context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                          1.0f, context.getName() + ":bias", true);
+  wt_idx[ConvParams::weight] =
+    context.requestWeight(dim, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "filter", true);
+  wt_idx[ConvParams::bias] = context.requestWeight(
+    bias_dim, bias_initializer, WeightRegularizer::NONE, 1.0f, "bias", true);
 
   // this output_dim must be the same with dimension of hidden
   unsigned int eff_in_height = in_dim.height() + padding[0] + padding[1];
@@ -319,7 +318,7 @@ void Conv2DLayer::finalize(InitLayerContext &context) {
    * which will be expensive.
    */
   wt_idx[ConvParams::inter_result] = context.requestTensor(
-    calcCol2ImOutputDim(out_dim, dim), context.getName() + ":inter_result",
+    calcCol2ImOutputDim(out_dim, dim), "inter_result",
     Tensor::Initializer::NONE, false, TensorLifespan::ITERATION_LIFESPAN);
 }
 

--- a/nntrainer/layers/dropout.cpp
+++ b/nntrainer/layers/dropout.cpp
@@ -26,9 +26,9 @@ void DropOutLayer::finalize(InitLayerContext &context) {
 
   mask_idx.reserve(input_dims.size());
   for (auto &t : input_dims) {
-    mask_idx.push_back(context.requestTensor(
-      t, context.getName() + ":Mask", Tensor::Initializer::NONE, false,
-      TensorLifespan::ITERATION_LIFESPAN));
+    mask_idx.push_back(
+      context.requestTensor(t, "Mask", Tensor::Initializer::NONE, false,
+                            TensorLifespan::ITERATION_LIFESPAN));
   }
 }
 

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -61,9 +61,9 @@ void EmbeddingLayer::finalize(InitLayerContext &context) {
   dim.width(out_dim);
   dim.batch(1);
 
-  weight_idx = context.requestWeight(
-    dim, weight_initializer, weight_regularizer, weight_regularizer_constant,
-    context.getName() + ":Embedding", true);
+  weight_idx =
+    context.requestWeight(dim, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "Embedding", true);
 }
 
 void EmbeddingLayer::setProperty(const std::vector<std::string> &values) {

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -66,13 +66,12 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
   TensorDim bias_dim(1, 1, 1, unit, 0b0001);
   TensorDim weight_dim(1, 1, in_dim.width(), unit, 0b0011);
 
-  weight_idx[FCParams::weight] = context.requestWeight(
-    weight_dim, weight_initializer, weight_regularizer,
-    weight_regularizer_constant, context.getName() + ":weight", true);
+  weight_idx[FCParams::weight] =
+    context.requestWeight(weight_dim, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "weight", true);
 
-  weight_idx[FCParams::bias] =
-    context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                          1.0f, context.getName() + ":bias", true);
+  weight_idx[FCParams::bias] = context.requestWeight(
+    bias_dim, bias_initializer, WeightRegularizer::NONE, 1.0f, "bias", true);
 }
 
 void FullyConnectedLayer::exportTo(Exporter &exporter,

--- a/nntrainer/layers/gru.cpp
+++ b/nntrainer/layers/gru.cpp
@@ -126,34 +126,33 @@ void GRULayer::finalize(InitLayerContext &context) {
   // weight_initializer can be set sepeartely. weight_xh initializer,
   // weight_hh initializer kernel initializer & recurrent_initializer in keras
   // for now, it is set same way.
-  wt_idx[GRUParams::weight_xh] = context.requestWeight(
-    dim_xh, weight_initializer, weight_regularizer, weight_regularizer_constant,
-    context.getName() + ":weight_xh", true);
-  wt_idx[GRUParams::weight_hh] = context.requestWeight(
-    dim_hh, weight_initializer, weight_regularizer, weight_regularizer_constant,
-    context.getName() + ":weight_hh", true);
-  wt_idx[GRUParams::bias_h] =
-    context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                          1.0f, context.getName() + ":bias_h", true);
+  wt_idx[GRUParams::weight_xh] =
+    context.requestWeight(dim_xh, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "weight_xh", true);
+  wt_idx[GRUParams::weight_hh] =
+    context.requestWeight(dim_hh, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "weight_hh", true);
+  wt_idx[GRUParams::bias_h] = context.requestWeight(
+    bias_dim, bias_initializer, WeightRegularizer::NONE, 1.0f, "bias_h", true);
 
   TensorDim d = input_dim;
   d.width(unit);
 
-  wt_idx[GRUParams::hidden_state] = context.requestTensor(
-    d, context.getName() + ":hidden_state", Tensor::Initializer::NONE, true,
-    TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[GRUParams::hidden_state] =
+    context.requestTensor(d, "hidden_state", Tensor::Initializer::NONE, true,
+                          TensorLifespan::ITERATION_LIFESPAN);
 
   d.width(unit * NUM_GATE);
-  wt_idx[GRUParams::zrg] = context.requestTensor(
-    d, context.getName() + ":zrg", Tensor::Initializer::NONE, true,
-    TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[GRUParams::zrg] =
+    context.requestTensor(d, "zrg", Tensor::Initializer::NONE, true,
+                          TensorLifespan::ITERATION_LIFESPAN);
 
   TensorDim h_dim = TensorDim();
   h_dim.setTensorDim(3, unit);
   h_dim.batch(input_dim.batch());
-  wt_idx[GRUParams::h_prev] = context.requestTensor(
-    h_dim, context.getName() + ":h_prev", Tensor::Initializer::NONE, false,
-    TensorLifespan::FORWARD_FUNC_LIFESPAN);
+  wt_idx[GRUParams::h_prev] =
+    context.requestTensor(h_dim, "h_prev", Tensor::Initializer::NONE, false,
+                          TensorLifespan::FORWARD_FUNC_LIFESPAN);
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -47,10 +47,13 @@ public:
     input_dim(dim),
     in_place(in_place_),
     num_outputs(num_out),
-    name(n) {
+    name(n),
+    prefix("") {
     NNTR_THROW_IF(!validate(), std::invalid_argument)
       << "Invalid init context name: " << name
       << " num inputs: " << getNumInputs();
+    if (prefix.empty())
+      prefix = name; // default prefix is the name
   }
 
   /**
@@ -143,7 +146,7 @@ public:
                              const WeightRegularizer reg, const float reg_const,
                              const std::string &name, bool trainable = true) {
     weights_spec.emplace_back(dim, init, reg, reg_const, trainable,
-                              getName() + ":" + name);
+                              prefix + ":" + name);
     return weights_spec.size() - 1;
   }
 
@@ -178,7 +181,7 @@ public:
                 const Tensor::Initializer init = Tensor::Initializer::NONE,
                 bool trainable = false,
                 TensorLifespan lifespan = TensorLifespan::ITERATION_LIFESPAN) {
-    tensors_spec.emplace_back(dim, init, trainable, getName() + ":" + name,
+    tensors_spec.emplace_back(dim, init, trainable, prefix + ":" + name,
                               lifespan);
     return tensors_spec.size() - 1;
   }
@@ -284,6 +287,7 @@ private:
 
   unsigned int num_outputs; /**< number of outputs for the layer */
   std::string name;         /**< name of the layer */
+  std::string prefix;       /**< prefix of the layer */
 };
 
 /**

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -142,7 +142,8 @@ public:
                              const Tensor::Initializer init,
                              const WeightRegularizer reg, const float reg_const,
                              const std::string &name, bool trainable = true) {
-    weights_spec.emplace_back(dim, init, reg, reg_const, trainable, name);
+    weights_spec.emplace_back(dim, init, reg, reg_const, trainable,
+                              getName() + ":" + name);
     return weights_spec.size() - 1;
   }
 
@@ -177,7 +178,8 @@ public:
                 const Tensor::Initializer init = Tensor::Initializer::NONE,
                 bool trainable = false,
                 TensorLifespan lifespan = TensorLifespan::ITERATION_LIFESPAN) {
-    tensors_spec.emplace_back(dim, init, trainable, name, lifespan);
+    tensors_spec.emplace_back(dim, init, trainable, getName() + ":" + name,
+                              lifespan);
     return tensors_spec.size() - 1;
   }
 

--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -88,8 +88,8 @@ void LSTMLayer::finalize(InitLayerContext &context) {
 
   if (dropout_rate > epsilon) {
     wt_idx[LSTMParams::dropout_mask] = context.requestTensor(
-      output_dim, context.getName() + ":dropout_mask",
-      Tensor::Initializer::NONE, false, TensorLifespan::ITERATION_LIFESPAN);
+      output_dim, "dropout_mask", Tensor::Initializer::NONE, false,
+      TensorLifespan::ITERATION_LIFESPAN);
   }
 
   if (!return_sequences) {
@@ -114,15 +114,14 @@ void LSTMLayer::finalize(InitLayerContext &context) {
   // weight_initializer can be set sepeartely. weight_xh initializer,
   // weight_hh initializer kernel initializer & recurrent_initializer in keras
   // for now, it is set same way.
-  wt_idx[LSTMParams::weight_xh] = context.requestWeight(
-    dim_xh, weight_initializer, weight_regularizer, weight_regularizer_constant,
-    context.getName() + ":weight_xh", true);
-  wt_idx[LSTMParams::weight_hh] = context.requestWeight(
-    dim_hh, weight_initializer, weight_regularizer, weight_regularizer_constant,
-    context.getName() + ":weight_hh", true);
-  wt_idx[LSTMParams::bias_h] =
-    context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                          1.0f, context.getName() + ":bias_h", true);
+  wt_idx[LSTMParams::weight_xh] =
+    context.requestWeight(dim_xh, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "weight_xh", true);
+  wt_idx[LSTMParams::weight_hh] =
+    context.requestWeight(dim_hh, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "weight_hh", true);
+  wt_idx[LSTMParams::bias_h] = context.requestWeight(
+    bias_dim, bias_initializer, WeightRegularizer::NONE, 1.0f, "bias_h", true);
 
   unsigned int max_timestep = input_dim.height();
   if (!std::get<props::MaxTimestep>(lstm_props).empty())
@@ -134,17 +133,17 @@ void LSTMLayer::finalize(InitLayerContext &context) {
   d.height(max_timestep);
   d.width(unit);
 
-  wt_idx[LSTMParams::hidden_state] = context.requestTensor(
-    d, context.getName() + ":hidden_state", Tensor::Initializer::NONE, true,
-    TensorLifespan::ITERATION_LIFESPAN);
-  wt_idx[LSTMParams::mem_cell] = context.requestTensor(
-    d, context.getName() + ":mem_cell", Tensor::Initializer::NONE, true,
-    TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[LSTMParams::hidden_state] =
+    context.requestTensor(d, "hidden_state", Tensor::Initializer::NONE, true,
+                          TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[LSTMParams::mem_cell] =
+    context.requestTensor(d, "mem_cell", Tensor::Initializer::NONE, true,
+                          TensorLifespan::ITERATION_LIFESPAN);
 
   d.width(unit * NUM_GATE);
-  wt_idx[LSTMParams::fgio] = context.requestTensor(
-    d, context.getName() + ":fgio", Tensor::Initializer::NONE, true,
-    TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[LSTMParams::fgio] =
+    context.requestTensor(d, "fgio", Tensor::Initializer::NONE, true,
+                          TensorLifespan::ITERATION_LIFESPAN);
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);

--- a/nntrainer/layers/lstmcell.cpp
+++ b/nntrainer/layers/lstmcell.cpp
@@ -91,8 +91,8 @@ void LSTMCellLayer::finalize(InitLayerContext &context) {
 
   if (dropout_rate > epsilon) {
     wt_idx[LSTMParams::dropout_mask] = context.requestTensor(
-      output_dim, context.getName() + ":dropout_mask",
-      Tensor::Initializer::NONE, false, TensorLifespan::ITERATION_LIFESPAN);
+      output_dim, "dropout_mask", Tensor::Initializer::NONE, false,
+      TensorLifespan::ITERATION_LIFESPAN);
   }
 
   context.setOutputDimensions({output_dim});
@@ -113,15 +113,14 @@ void LSTMCellLayer::finalize(InitLayerContext &context) {
   // weight_initializer can be set sepeartely. weight_xh initializer,
   // weight_hh initializer kernel initializer & recurrent_initializer in keras
   // for now, it is set same way.
-  wt_idx[LSTMParams::weight_xh] = context.requestWeight(
-    dim_xh, weight_initializer, weight_regularizer, weight_regularizer_constant,
-    context.getName() + ":weight_xh", true);
-  wt_idx[LSTMParams::weight_hh] = context.requestWeight(
-    dim_hh, weight_initializer, weight_regularizer, weight_regularizer_constant,
-    context.getName() + ":weight_hh", true);
-  wt_idx[LSTMParams::bias_h] =
-    context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                          1.0f, context.getName() + ":bias_h", true);
+  wt_idx[LSTMParams::weight_xh] =
+    context.requestWeight(dim_xh, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "weight_xh", true);
+  wt_idx[LSTMParams::weight_hh] =
+    context.requestWeight(dim_hh, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "weight_hh", true);
+  wt_idx[LSTMParams::bias_h] = context.requestWeight(
+    bias_dim, bias_initializer, WeightRegularizer::NONE, 1.0f, "bias_h", true);
 
   unsigned int max_timestep = std::get<props::MaxTimestep>(lstm_props);
 
@@ -132,12 +131,12 @@ void LSTMCellLayer::finalize(InitLayerContext &context) {
   d.width(unit);
 
   /** hidden dim = [ UnrollLength, 1, Batch, Units ] */
-  wt_idx[LSTMParams::hidden_state] = context.requestTensor(
-    d, context.getName() + ":hidden_state", Tensor::Initializer::NONE, true,
-    TensorLifespan::ITERATION_LIFESPAN);
-  wt_idx[LSTMParams::mem_cell] = context.requestTensor(
-    d, context.getName() + ":mem_cell", Tensor::Initializer::NONE, true,
-    TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[LSTMParams::hidden_state] =
+    context.requestTensor(d, "hidden_state", Tensor::Initializer::NONE, true,
+                          TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[LSTMParams::mem_cell] =
+    context.requestTensor(d, "mem_cell", Tensor::Initializer::NONE, true,
+                          TensorLifespan::ITERATION_LIFESPAN);
 
   /**
    * TODO: make this independent of time dimension once recurrent realizer
@@ -147,9 +146,9 @@ void LSTMCellLayer::finalize(InitLayerContext &context) {
    * stored weights in the test
    */
   d.width(unit * NUM_GATE);
-  wt_idx[LSTMParams::fgio] = context.requestTensor(
-    d, context.getName() + ":fgio", Tensor::Initializer::NONE, true,
-    TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[LSTMParams::fgio] =
+    context.requestTensor(d, "fgio", Tensor::Initializer::NONE, true,
+                          TensorLifespan::ITERATION_LIFESPAN);
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -118,14 +118,14 @@ void Pooling2DLayer::finalize(InitLayerContext &context) {
    * // clang-format on
    */
   if (pooling_type == props::PoolingTypeInfo::Enum::global_max) {
-    pool_helper_idx = context.requestTensor(
-      in_dim, context.getName() + ":helper_idx", Tensor::Initializer::NONE,
-      false, TensorLifespan::ITERATION_LIFESPAN);
+    pool_helper_idx =
+      context.requestTensor(in_dim, "helper_idx", Tensor::Initializer::NONE,
+                            false, TensorLifespan::ITERATION_LIFESPAN);
     pool_helper_size.resize(in_dim.batch() * in_dim.channel());
   } else {
-    pool_helper_idx = context.requestTensor(
-      out_dim, context.getName() + ":helper_idx", Tensor::Initializer::NONE,
-      false, TensorLifespan::ITERATION_LIFESPAN);
+    pool_helper_idx =
+      context.requestTensor(out_dim, "helper_idx", Tensor::Initializer::NONE,
+                            false, TensorLifespan::ITERATION_LIFESPAN);
   }
 }
 

--- a/nntrainer/layers/rnn.cpp
+++ b/nntrainer/layers/rnn.cpp
@@ -68,8 +68,8 @@ void RNNLayer::finalize(InitLayerContext &context) {
 
   if (dropout_rate > epsilon) {
     wt_idx[RNNParams::dropout_mask] = context.requestTensor(
-      output_dim, context.getName() + ":dropout_mask",
-      Tensor::Initializer::NONE, false, TensorLifespan::ITERATION_LIFESPAN);
+      output_dim, "dropout_mask", Tensor::Initializer::NONE, false,
+      TensorLifespan::ITERATION_LIFESPAN);
   }
 
   if (!return_sequences) {
@@ -93,24 +93,23 @@ void RNNLayer::finalize(InitLayerContext &context) {
   // weight_hh initializer kernel initializer & recurrent_initializer in keras
   // for now, it is set same way.
 
-  wt_idx[RNNParams::weight_xh] = context.requestWeight(
-    dim_xh, weight_initializer, weight_regularizer, weight_regularizer_constant,
-    context.getName() + ":weight_xh", true);
-  wt_idx[RNNParams::weight_hh] = context.requestWeight(
-    dim_hh, weight_initializer, weight_regularizer, weight_regularizer_constant,
-    context.getName() + ":weight_hh", true);
-  wt_idx[RNNParams::bias_h] =
-    context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                          1.0f, context.getName() + ":bias_h", true);
+  wt_idx[RNNParams::weight_xh] =
+    context.requestWeight(dim_xh, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "weight_xh", true);
+  wt_idx[RNNParams::weight_hh] =
+    context.requestWeight(dim_hh, weight_initializer, weight_regularizer,
+                          weight_regularizer_constant, "weight_hh", true);
+  wt_idx[RNNParams::bias_h] = context.requestWeight(
+    bias_dim, bias_initializer, WeightRegularizer::NONE, 1.0f, "bias_h", true);
 
   // We do not need this if we reuse net_hidden[0]. But if we do, then the unit
   // test will fail. Becuase it modifies the date during gradient calculation
   // TODO : We could control with something like #define test to save memory
   TensorDim d = input_dim;
   d.width(unit);
-  wt_idx[RNNParams::hidden_state] = context.requestTensor(
-    d, context.getName() + ":hidden_state", Tensor::Initializer::NONE, true,
-    TensorLifespan::ITERATION_LIFESPAN);
+  wt_idx[RNNParams::hidden_state] =
+    context.requestTensor(d, "hidden_state", Tensor::Initializer::NONE, true,
+                          TensorLifespan::ITERATION_LIFESPAN);
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);

--- a/nntrainer/layers/time_dist.cpp
+++ b/nntrainer/layers/time_dist.cpp
@@ -217,12 +217,11 @@ void TimeDistLayer::forwarding(RunLayerContext &context, bool training) {
     h_g = transposeTensor(hidden_g);
   }
 
-  Var_Grad in_var(i_dim, Tensor::Initializer::NONE, false, false,
-                  context.getName() + ":input");
+  Var_Grad in_var(i_dim, Tensor::Initializer::NONE, false, false, "input");
   Var_Grad out_var(h_dim, Tensor::Initializer::NONE,
                    dist_layer->requireLabel() &&
                      context.isLabelAvailable(SINGLE_INOUT_IDX),
-                   false, context.getName() + ":output");
+                   false, "output");
 
   fillWeightsFromContext(context);
   fillTensorsFromContext(context);
@@ -273,10 +272,8 @@ void TimeDistLayer::calcDerivative(RunLayerContext &context) {
   TensorDim r_dim = {ret_dim[2], 1, 1, ret_dim[3]};
   TensorDim d_dim = {der_dim[2], 1, 1, der_dim[3]};
 
-  Var_Grad in_var(r_dim, Tensor::Initializer::NONE, true, false,
-                  context.getName() + ":input");
-  Var_Grad out_var(d_dim, Tensor::Initializer::NONE, true, false,
-                   context.getName() + ":output");
+  Var_Grad in_var(r_dim, Tensor::Initializer::NONE, true, false, "input");
+  Var_Grad out_var(d_dim, Tensor::Initializer::NONE, true, false, "output");
 
   fillWeightsFromContext(context);
   fillTensorsFromContext(context);
@@ -341,10 +338,8 @@ void TimeDistLayer::calcGradient(RunLayerContext &context) {
     Tensor d_iter =
       derivative_.getSharedDataTensor(d_dim, i * d_dim.batch() * d_dim.width());
 
-    Var_Grad in_var(i_dim, Tensor::Initializer::NONE, true, false,
-                    context.getName() + ":input");
-    Var_Grad out_var(d_dim, Tensor::Initializer::NONE, true, false,
-                     context.getName() + ":output");
+    Var_Grad in_var(i_dim, Tensor::Initializer::NONE, true, false, "input");
+    Var_Grad out_var(d_dim, Tensor::Initializer::NONE, true, false, "output");
 
     in_var.initializeVariable(in_iter);
     out_var.initializeGradient(d_iter);
@@ -385,10 +380,8 @@ void TimeDistLayer::setBatch(RunLayerContext &context, unsigned int batch) {
     TensorDim i_dim = {in_dim[2], 1, 1, in_dim[3]};
     TensorDim o_dim = {out_dim[2], 1, 1, out_dim[3]};
 
-    Var_Grad in_var(i_dim, Tensor::Initializer::NONE, true, false,
-                    context.getName() + ":input");
-    Var_Grad out_var(o_dim, Tensor::Initializer::NONE, true, false,
-                     context.getName() + ":output");
+    Var_Grad in_var(i_dim, Tensor::Initializer::NONE, true, false, "input");
+    Var_Grad out_var(o_dim, Tensor::Initializer::NONE, true, false, "output");
 
     fillWeightsFromContext(context);
     fillTensorsFromContext(context);


### PR DESCRIPTION
- All layers were required to make unique name for their requests.
This is now rather done by layer context by appending layer name as a
prefix to the requested name.
- This patch allows support for prefix for sharing weight names across
layers, so that layers which should share their weights can do so by
using the same prefix.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>