### PR TITLE
[graph] Skip backwarding bug fix + memory optimize

### DIFF
--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -278,32 +278,7 @@ public:
    *
    * @param[in] training If true, initialize derivates/gradients, else, do not.
    */
-  void allocateTensors(ExecutionMode exec_mode_) {
-    exec_mode = exec_mode_;
-    if (exec_mode == ExecutionMode::INFERENCE)
-      /**
-       * get the order of execution/usage order for the forwarding of the last
-       * layer and pass that as the max_exec_order ensuring that all tensors
-       * with usage less than the max_exec_order are allocated.
-       */
-      tensor_manager->allocateTensors(
-        std::get<0>((*(cend() - 1))->getExecutionOrder()));
-    else
-    /** @todo update this to skip non-trainable layers */
-    /**
-     * get the order of execution/usage order for the backwarding of the first
-     * layer (as that will be the last layer to executed in the backwarding)
-     * and pass that as the max_exec_order ensuring that all tensors with
-     * usage less than the max_exec_order are allocated.
-     */
-#ifdef ENABLE_TEST
-      tensor_manager->allocateTensors(
-        std::get<2>((*(cbegin()))->getExecutionOrder()));
-#else
-      tensor_manager->allocateTensors(
-        std::get<1>((*(cbegin()))->getExecutionOrder()));
-#endif
-  }
+  void allocateTensors(ExecutionMode exec_mode_);
 
   /**
    * @brief Deallocate memory for all the managed tensors
@@ -429,11 +404,9 @@ private:
   int checkCompiledGraph();
 
   /**
-   * @brief     check if the initialized graph is of correct form.
-   * @retval #ML_ERROR_NONE graph is initialized correctly
-   * @retval #ML_ERROR_INVALID_PARAMETER did not initialize correctly
+   * @brief     mark nodes required for backwarding.
    */
-  int checkInitializedGraph();
+  void markNodesForBackwarding();
 
   /**
    * @brief     Realize Graph Nodes

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -150,7 +150,8 @@ createLayerNode(std::unique_ptr<nntrainer::Layer> &&layer,
 LayerNode::LayerNode(std::unique_ptr<nntrainer::Layer> &&l) :
   layer(std::move(l)),
   inplace(false),
-  needs_backwarding(false),
+  needs_calc_derivative(false),
+  needs_calc_gradient(false),
   run_context(nullptr),
   layer_node_props(new PropsType(props::Name(), props::Distribute(),
                                  props::Trainable(), {}, {},
@@ -506,7 +507,7 @@ void LayerNode::calcDerivative() {
  */
 void LayerNode::calcGradient() {
   START_PROFILE(calc_grad_event_key);
-  if (getTrainable())
+  if (needs_calc_gradient)
     layer->calcGradient(*run_context);
   END_PROFILE(calc_grad_event_key);
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -150,6 +150,7 @@ createLayerNode(std::unique_ptr<nntrainer::Layer> &&layer,
 LayerNode::LayerNode(std::unique_ptr<nntrainer::Layer> &&l) :
   layer(std::move(l)),
   inplace(false),
+  needs_backwarding(false),
   run_context(nullptr),
   layer_node_props(new PropsType(props::Name(), props::Distribute(),
                                  props::Trainable(), {}, {},

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -662,30 +662,46 @@ public:
   std::unique_ptr<LayerNode> cloneConfiguration();
 
   /**
-   * @brief Set if the layer needs to do backwarding
+   * @brief Set if the layer needs to do derivative calculation
    *
    * @param nb true if the layer needs to do backwarding, else false
    */
-  void needsBackwarding(bool nb) {
+  void needsCalcDerivative(bool nb) {
     NNTR_THROW_IF(nb && !supportBackwarding(), std::invalid_argument)
       << "[Layer] " << getName()
       << " does not support backwarding but is needed";
-    needs_backwarding = nb;
+    needs_calc_derivative = nb;
   }
 
   /**
-   * @brief Get the layer needs to do backwarding
+   * @brief Set if the layer needs to do calculation of gradients
+   *
+   * @param nb true if the layer needs to do backwarding, else false
+   */
+  void needsCalcGradient(bool nb) { needs_calc_gradient = nb; }
+
+  /**
+   * @brief Get the layer needs to do calculation of derivatives
    *
    * @return true if the layer needs to do backwarding, else false
    */
-  bool needsBackwarding() { return needs_backwarding; }
+  bool needsCalcDerivative() { return needs_calc_derivative; }
+
+  /**
+   * @brief Set if the layer needs to do calculation of gradient
+   *
+   * @param nb true if the layer needs to do backwarding, else false
+   */
+  bool needsCalcGradient() { return needs_calc_gradient; }
 
 private:
   std::unique_ptr<nntrainer::Layer>
     layer; /**< The actual object in the graph node */
 
   bool inplace; /**< store if the current layer is going to operate in-place */
-  bool needs_backwarding; /**< cache if this layer needs to do backwarding */
+  bool needs_calc_derivative; /**< cache if this layer needs to do
+                                 calcDerivative */
+  bool needs_calc_gradient; /**< cache if this layer needs to do calcGradient */
 
   std::vector<std::string> input_layers;  /**< input layer names */
   std::vector<std::string> output_layers; /**< output layer names */

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -661,11 +661,31 @@ public:
    */
   std::unique_ptr<LayerNode> cloneConfiguration();
 
+  /**
+   * @brief Set if the layer needs to do backwarding
+   *
+   * @param nb true if the layer needs to do backwarding, else false
+   */
+  void needsBackwarding(bool nb) {
+    NNTR_THROW_IF(nb && !supportBackwarding(), std::invalid_argument)
+      << "[Layer] " << getName()
+      << " does not support backwarding but is needed";
+    needs_backwarding = nb;
+  }
+
+  /**
+   * @brief Get the layer needs to do backwarding
+   *
+   * @return true if the layer needs to do backwarding, else false
+   */
+  bool needsBackwarding() { return needs_backwarding; }
+
 private:
   std::unique_ptr<nntrainer::Layer>
     layer; /**< The actual object in the graph node */
 
   bool inplace; /**< store if the current layer is going to operate in-place */
+  bool needs_backwarding; /**< cache if this layer needs to do backwarding */
 
   std::vector<std::string> input_layers;  /**< input layer names */
   std::vector<std::string> output_layers; /**< output layer names */

--- a/nntrainer/layers/lstmcell.cpp
+++ b/nntrainer/layers/lstmcell.cpp
@@ -355,6 +355,8 @@ void LSTMCellLayer::calcGradient(RunLayerContext &context) {
     dc.multiply_strided(hf, dc_nx);
     Tensor cs_prev = m_cell_.getBatchSlice(start_timestep - 1, 1);
     dc.multiply_strided(cs_prev, dhf);
+  } else {
+    dhf.setZero();
   }
 
   dc.multiply_strided(hg, dhi);

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -237,9 +237,8 @@ void NeuralNetwork::backwarding(int iteration) {
   NNTR_THROW_IF(!opt, std::invalid_argument) << "optimizer is null!";
 #endif
 
-  std::function<void(std::shared_ptr<LayerNode>, int, bool)> backwarding_op =
-    [this](std::shared_ptr<LayerNode> node, int iteration,
-           bool calc_derivative) -> void {
+  std::function<void(std::shared_ptr<LayerNode>, int)> backwarding_op =
+    [this](std::shared_ptr<LayerNode> node, int iteration) -> void {
     /**
      * Do not change this order:
      * 1. calcGradient
@@ -270,7 +269,11 @@ void NeuralNetwork::backwarding(int iteration) {
     if (!dynamic_training_opt.isGradientMode() && apply_gradient)
       node->calcGradient();
 
-    if (calc_derivative)
+#ifdef ENABLE_TEST
+    if (node->supportBackwarding())
+#else
+    if (node->needsBackwarding())
+#endif
       node->calcDerivative();
 
     if (apply_gradient) {

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -269,11 +269,7 @@ void NeuralNetwork::backwarding(int iteration) {
     if (!dynamic_training_opt.isGradientMode() && apply_gradient)
       node->calcGradient();
 
-#ifdef ENABLE_TEST
-    if (node->supportBackwarding())
-#else
-    if (node->needsBackwarding())
-#endif
+    if (node->needsCalcDerivative())
       node->calcDerivative();
 
     if (apply_gradient) {

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1367,7 +1367,12 @@ void Tensor::setValue(float val) {
   std::fill(data, data + size(), val);
 }
 
-void Tensor::setZero() { sscal(size(), 0, getData(), 1); }
+void Tensor::setZero() {
+  if (contiguous)
+    sscal(size(), 0, getData(), 1);
+  else
+    apply_i([](float val) -> float { return 0; });
+}
 
 std::vector<unsigned int> Tensor::argmax() const {
   const float *data = getData();

--- a/test/unittest/models/models_test_utils.cpp
+++ b/test/unittest/models/models_test_utils.cpp
@@ -384,13 +384,8 @@ void GraphWatcher::compareFor(const std::string &reference,
       nn->backwarding(iteration);
 
       for (auto it = nodes.rbegin(); it != nodes.rend(); it++) {
-        if (it == nodes.rend() - 1) {
-          /** check last layer backwarding only when not input layers */
-          if (it->supportBackwarding())
-            it->backward(iteration, true, !optimize);
-        } else {
+        if (it->needsBackwarding())
           it->backward(iteration, !optimize, !optimize);
-        }
       }
     } else {
       EXPECT_THROW(nn->backwarding(iteration), std::runtime_error);

--- a/test/unittest/models/models_test_utils.cpp
+++ b/test/unittest/models/models_test_utils.cpp
@@ -384,7 +384,7 @@ void GraphWatcher::compareFor(const std::string &reference,
       nn->backwarding(iteration);
 
       for (auto it = nodes.rbegin(); it != nodes.rend(); it++) {
-        if (it->needsBackwarding())
+        if (it->needsCalcDerivative())
           it->backward(iteration, !optimize, !optimize);
       }
     } else {

--- a/test/unittest/models/models_test_utils.h
+++ b/test/unittest/models/models_test_utils.h
@@ -127,11 +127,11 @@ public:
   bool supportInPlace() { return node->supportInPlace(); }
 
   /**
-   * @brief support backwarding operation
+   * @brief needs backwarding operation
    *
-   * @return true if support backwarding else false
+   * @return true if needs backwarding else false
    */
-  bool supportBackwarding() { return node->supportBackwarding(); }
+  bool needsBackwarding() { return node->needsBackwarding(); }
 
 private:
   NodeType node;

--- a/test/unittest/models/models_test_utils.h
+++ b/test/unittest/models/models_test_utils.h
@@ -131,7 +131,7 @@ public:
    *
    * @return true if needs backwarding else false
    */
-  bool needsBackwarding() { return node->needsBackwarding(); }
+  bool needsCalcDerivative() { return node->needsCalcDerivative(); }
 
 private:
   NodeType node;


### PR DESCRIPTION
Current implementation assumes that the graph is always linear and skips
the backwarding for contiguous set of layers at the start of the model
which should not do the backwarding.

This patch makes a fix to this issue but allowing layers in the middle
of the sorted graph to skip backwarding.

Resolves #1686
Resolves #1664

Note: this will provide minor speedup for complex models where some more layers backwarding can be skipped.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>