### PR TITLE
Policy based tensor request for tensor pool.

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -981,11 +981,11 @@ void NetworkGraph::setExternalTensors(const std::vector<Tensor> &data,
   /// feed or clear label
   for (unsigned int idx = 0; idx < names.size(); idx++) {
     if (data.empty())
-      tensor_manager->setExternalTensor(names[idx], Tensor());
+      tensor_manager->fillPlaceholder(names[idx], Tensor());
     else if (data.size() == 1)
-      tensor_manager->setExternalTensor(names[idx], data[0]);
+      tensor_manager->fillPlaceholder(names[idx], data[0]);
     else
-      tensor_manager->setExternalTensor(names[idx], data[idx]);
+      tensor_manager->fillPlaceholder(names[idx], data[idx]);
   }
 }
 
@@ -1006,7 +1006,6 @@ void NetworkGraph::setInputsLabels(const std::vector<Tensor> &inputs,
 
   setExternalTensors(inputs, input_list);
   setExternalTensors(labels, label_list);
-  tensor_manager->updateExternalTensors();
 }
 
 void NetworkGraph::setInputsLabels(sharedConstTensors &inputs,

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -332,21 +332,13 @@ public:
   void setOptimizations(bool val) { enable_optimizations = val; }
 
   /**
-   * @brief Update the dependency on external tensors
-   */
-  void updateExternalTensors() {
-    weight_pool.updateExternalTensors();
-    tensor_pool.updateExternalTensors();
-  }
-
-  /**
    * @brief Update externally dependent tensors
    *
    * @param name Name of the tensor
    * @param t External tensor
    */
-  void setExternalTensor(const std::string &name, const Tensor &t) {
-    tensor_pool.setExternalTensor(name, t);
+  void fillPlaceholder(const std::string &name, const Tensor &t) {
+    tensor_pool.fillPlaceholder(name, t);
   }
 
   /**

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -319,12 +319,14 @@ Tensor *TensorPool::view(const std::string &name, const std::string &reference,
                                    Tensor::Initializer::NONE, offset);
 }
 
-Tensor *TensorPool::extend(const std::string &name,
+Tensor *TensorPool::extend(const std::string &name, const TensorDim &dim,
                            const std::vector<unsigned int> &exec_order,
                            TensorLifespan lifespan) {
   NNTR_THROW_IF(!tensorExist(name), std::invalid_argument)
     << " cannot extend tensor which does not exist, name: " << name;
   auto &spec = getSourceSpec(name);
+  NNTR_THROW_IF(dim != spec.tensor->getDim(), std::invalid_argument)
+    << "Cannot extend tensor with different dimension";
   expandLifespan(spec, exec_order, lifespan);
   return getTensor(name);
 }
@@ -343,13 +345,15 @@ Tensor *TensorPool::requestOrExtend(const std::string &name,
       << "tensor dimension mismatch for requestOrExtend name: " << name;
     NNTR_THROW_IF(t->getInitializer() != init, std::invalid_argument)
       << "tensor initializer mismatch for requestOrExtend name: " << name;
-    return extend(name, exec_order, lifespan);
+    return extend(name, dim, exec_order, lifespan);
   } else {
     return request(name, dim, exec_order, lifespan, init);
   }
 }
 
 bool TensorPool::tensorExist(const std::string &name) {
+  /// @todo consider use a helper function to check, eg) something like
+  /// getTensor()
   return name_map.count(name);
 }
 

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -302,10 +302,10 @@ Tensor *TensorPool::placeholder(const std::string &name, const TensorDim &dim) {
   return requestExternallyAllocateTensor(dim, name);
 }
 
-Tensor *TensorPool::create(const std::string &name, const TensorDim &dim,
-                           const std::vector<unsigned int> &exec_order,
-                           TensorLifespan lifespan,
-                           const Tensor::Initializer &init) {
+Tensor *TensorPool::request(const std::string &name, const TensorDim &dim,
+                            const std::vector<unsigned int> &exec_order,
+                            TensorLifespan lifespan,
+                            const Tensor::Initializer &init) {
   /// @todo rename requestTensor -> create
   return requestTensor(dim, exec_order, lifespan, name, init);
 }
@@ -329,23 +329,23 @@ Tensor *TensorPool::extend(const std::string &name,
   return getTensor(name);
 }
 
-Tensor *TensorPool::createOrExtend(const std::string &name,
-                                   const TensorDim &dim,
-                                   const std::vector<unsigned int> &exec_order,
-                                   TensorLifespan lifespan,
-                                   const Tensor::Initializer &init) {
+Tensor *TensorPool::requestOrExtend(const std::string &name,
+                                    const TensorDim &dim,
+                                    const std::vector<unsigned int> &exec_order,
+                                    TensorLifespan lifespan,
+                                    const Tensor::Initializer &init) {
   NNTR_THROW_IF(lifespan == TensorLifespan::UNMANAGED, std::invalid_argument)
     << "unmanaged life span is not supported";
 
   if (tensorExist(name)) {
     Tensor *t = getTensor(name);
     NNTR_THROW_IF(t->getDim() != dim, std::invalid_argument)
-      << "tensor dimension mismatch for createOrExtend name: " << name;
+      << "tensor dimension mismatch for requestOrExtend name: " << name;
     NNTR_THROW_IF(t->getInitializer() != init, std::invalid_argument)
-      << "tensor initializer mismatch for createOrExtend name: " << name;
+      << "tensor initializer mismatch for requestOrExtend name: " << name;
     return extend(name, exec_order, lifespan);
   } else {
-    return create(name, dim, exec_order, lifespan, init);
+    return request(name, dim, exec_order, lifespan, init);
   }
 }
 

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -61,7 +61,7 @@ Tensor *
 TensorPool::requestExternallyAllocateTensor(const TensorDim &dim,
                                             const std::string &name,
                                             const Tensor::Initializer &init) {
-  return requestTensor(dim, {}, TensorLifespan::ZERO_LIFESPAN, name, init);
+  return requestTensor(dim, {}, TensorLifespan::UNMANAGED, name, init);
 }
 
 /**
@@ -96,7 +96,7 @@ Tensor *TensorPool::requestPrerequestedTensor(
    * cannot expand lifespan of zero lifespan tensor
    * it works for externally allocated tensors as well
    */
-  if (spec.lifespan != TensorLifespan::ZERO_LIFESPAN) {
+  if (spec.lifespan != TensorLifespan::UNMANAGED) {
     spec.exec_order.insert(spec.exec_order.end(), exec_order.begin(),
                            exec_order.end());
     spec.lifespan = enum_class_or<TensorLifespan>(spec.lifespan, lifespan);
@@ -125,7 +125,7 @@ void TensorPool::finalize(const MemoryPlanner &planner,
   for (auto &spec : pool) {
     /** do not include dependent tensors in planning layout */
     if (spec.dependent || spec.exec_order.empty() ||
-        spec.lifespan == TensorLifespan::ZERO_LIFESPAN)
+        spec.lifespan == TensorLifespan::UNMANAGED)
       continue;
 
     spec.token = 0;
@@ -232,7 +232,7 @@ void TensorPool::expand_lifespan(const std::string &name,
 
   auto &spec = pool[parent_spec_idx];
 
-  if (spec.lifespan != TensorLifespan::ZERO_LIFESPAN)
+  if (spec.lifespan != TensorLifespan::UNMANAGED)
     throw std::invalid_argument("Cannot extend tensor lifespan from ZERO");
 
   spec.lifespan = enum_class_or<TensorLifespan>(spec.lifespan, lifespan);
@@ -311,7 +311,7 @@ bool TensorPool::isTensorLongTerm(const TensorLifespan &lifespan) {
     [[fallthrough]];
   case TensorLifespan::ITERATION_LIFESPAN:
     [[fallthrough]];
-  case TensorLifespan::ZERO_LIFESPAN:
+  case TensorLifespan::UNMANAGED:
     [[fallthrough]];
   default:
     return false;

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -316,6 +316,16 @@ Tensor *TensorPool::view(const std::string &name, const std::string &reference,
                                    Tensor::Initializer::NONE, offset);
 }
 
+Tensor *TensorPool::extend(const std::string &name,
+                           const std::vector<unsigned int> &exec_order,
+                           TensorLifespan lifespan) {
+  NNTR_THROW_IF(!tensorExist(name), std::invalid_argument)
+    << " cannot extend tensor which does not exist, name: " << name;
+  auto &spec = getSourceSpec(name);
+  expandLifespan(spec, exec_order, lifespan);
+  return getTensor(name);
+}
+
 bool TensorPool::tensorExist(const std::string &name) {
   return name_map.count(name);
 }

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -259,6 +259,23 @@ TensorPool::requestSpec &TensorPool::getSourceSpec(const std::string &name) {
   return pool.at(parent_spec_idx);
 }
 
+Tensor *TensorPool::placeholder(const std::string &name, const TensorDim &dim) {
+  /// @todo rename requestExternallyAllocateTensor -> placeholder
+  return requestExternallyAllocateTensor(dim, name);
+}
+
+Tensor *TensorPool::create(const std::string &name, const TensorDim &dim,
+                           const std::vector<unsigned int> &exec_order,
+                           TensorLifespan lifespan,
+                           const Tensor::Initializer &init) {
+  /// @todo rename requestTensor -> create
+  return requestTensor(dim, exec_order, lifespan, name, init);
+}
+
+bool TensorPool::tensorExist(const std::string &name) {
+  return name_map.count(name);
+}
+
 /**
  * @brief     Check if the lifespan leads to long term valitidy
  *

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -225,6 +225,120 @@ public:
         spec.tensor->setData(pool[spec.token].tensor->getData());
   }
 
+  /**
+   * @brief request placeholder which will be not managed by this tensor pool
+   * but will be managed externally
+   *
+   * @param name Name of the tensor
+   * @param dim Tensor dimension
+   * @return Tensor* ptr to the tensor
+   *
+   * @note returns empty tensor which must be filled by the caller before use.
+   */
+  Tensor *placeholder(const std::string &name, const TensorDim &dim) {
+    return nullptr;
+  }
+
+  /**
+   * @brief     create a new tensor with the given spec.
+   *
+   * @param name Name of this tensor.
+   * @param dim Tensor dimension.
+   * @param exec_order The execution orders for this tensor.
+   * @param lifespan Lifespan of this tensor.
+   * @param init Initializer of the tensor.
+   *
+   * @return ptr to the created tensor
+   *
+   * @note returns empty tensor which will be filled when allocate is called.
+   * @note we assume that the caller checks if the exec_order and lifespan are
+   * compatible.
+   */
+  Tensor *create(const std::string &name, const TensorDim &dim,
+                 const std::vector<unsigned int> &exec_order,
+                 TensorLifespan lifespan,
+                 const Tensor::Initializer &init = Tensor::Initializer::NONE) {
+    return nullptr;
+  }
+
+  /**
+   * @brief     Request tensor which is a view of already requested with the
+   * given spec
+   *
+   * @param name Name of this tensor
+   * @param reference Name of the reference tensor
+   * @param dim Tensor dimensions
+   * @param exec_order The execution orders for this tensors
+   * @param lifespan Lifespan of this tensor
+   * @param offset offset from the reference
+   *
+   * @return ptr to a tensor which is sharing the same data with
+   * reference.
+   *
+   * @note returns a view tensor which will be filled when the source tensor is
+   * allocated.
+   * @note we assume that the caller checks if the exec_order and lifespan are
+   * compatible.
+   *
+   */
+  Tensor *view(const std::string &name, const std::string &reference,
+               const TensorDim &dim,
+               const std::vector<unsigned int> &exec_order,
+               TensorLifespan lifespan, const unsigned int offset = 0) {
+    return nullptr;
+  }
+
+  /**
+   * @brief extend a tensor life as tensor is being shared.
+   *
+   * @param name name of the tensor to extend
+   * @param exec_order exec_order to extend
+   * @param lifespan extended life span
+   * @return Tensor* Tensor* the exact tensor which is being extended.
+   * @note we assume that the caller checks if the exec_order and lifespan are
+   * compatible.
+   */
+  Tensor *extend(const std::string &name,
+                 const std::vector<unsigned int> &exec_order,
+                 TensorLifespan lifespan) {
+    return nullptr;
+  }
+
+  /**
+   * @brief create a new tensor if tensor does not exist else return the tensor
+   * while extending the tensor's life according to the given arguments.
+   *
+   * @param name Name of the tensor
+   * @param dim dimension
+   * @param exec_order exec order
+   * @param lifespan tensor life span
+   * @param init tensor initializer
+   * @return Tensor* ptr to either to the existing tensor or newly created
+   * tensor
+   */
+  Tensor *
+  createOrExtend(const std::string &name, const TensorDim &dim,
+                 const std::vector<unsigned int> &exec_order,
+                 TensorLifespan lifespan,
+                 const Tensor::Initializer &init = Tensor::Initializer::NONE);
+
+  /**
+   * @brief reidentify the source of already created tensor (or view).
+   * @note if @a dest tensor is a view of another tensor, the old source tensor
+   * of the view will become a view of @a new_src.
+   *
+   * @throws std::invalid_argument 1. if the data size required from the
+   * original source tensor is bigger than the new_src + offset. 2. if new_src
+   * is a view. Second restriction can be removed, if this is considered as a
+   * safe behavior.
+   *
+   * @param dest identifier for the dest tensor
+   * @param new_src identifier for the new source tensor
+   * @param offset offset
+   */
+  void reidentifySource(const std::string &dest, const std::string &new_src,
+                        unsigned int offset);
+
 private:
   /**
    * @brief Spec for storing each request of tensor from tensor pool

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -246,13 +246,14 @@ public:
    * @brief extend a tensor life as tensor is being shared.
    *
    * @param name name of the tensor to extend
+   * @param dim dimension of the tensor
    * @param exec_order exec_order to extend
    * @param lifespan extended life span
    * @return Tensor* Tensor* the exact tensor which is being extended.
    * @note we assume that the caller checks if the exec_order and lifespan are
    * compatible.
    */
-  Tensor *extend(const std::string &name,
+  Tensor *extend(const std::string &name, const TensorDim &dim,
                  const std::vector<unsigned int> &exec_order,
                  TensorLifespan lifespan);
 

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -259,6 +259,9 @@ public:
   /**
    * @brief create a new tensor if tensor does not exist else return the tensor
    * while extending the tensor's life according to the given arguments.
+   * @note Created (or extended) tensor is considered identical and managed. It
+   * is invalid to create a tensor with lifespan::UNMANAGED or dimension and
+   * initializer is different unon extension.
    *
    * @param name Name of the tensor
    * @param dim dimension

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -203,7 +203,7 @@ public:
   void setExternalTensor(const std::string &name, const Tensor &t) {
     auto &spec = getSourceSpec(name);
 
-    if (spec.lifespan != TensorLifespan::ZERO_LIFESPAN)
+    if (spec.lifespan != TensorLifespan::UNMANAGED)
       throw std::invalid_argument(
         "Cannot set external tensor for non-zero lifespan");
 

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -212,10 +212,10 @@ public:
    * @note we assume that the caller checks if the exec_order and lifespan are
    * compatible.
    */
-  Tensor *create(const std::string &name, const TensorDim &dim,
-                 const std::vector<unsigned int> &exec_order,
-                 TensorLifespan lifespan,
-                 const Tensor::Initializer &init = Tensor::Initializer::NONE);
+  Tensor *request(const std::string &name, const TensorDim &dim,
+                  const std::vector<unsigned int> &exec_order,
+                  TensorLifespan lifespan,
+                  const Tensor::Initializer &init = Tensor::Initializer::NONE);
 
   /**
    * @brief     Request tensor which is a view of already requested with the
@@ -272,10 +272,10 @@ public:
    * tensor
    */
   Tensor *
-  createOrExtend(const std::string &name, const TensorDim &dim,
-                 const std::vector<unsigned int> &exec_order,
-                 TensorLifespan lifespan,
-                 const Tensor::Initializer &init = Tensor::Initializer::NONE);
+  requestOrExtend(const std::string &name, const TensorDim &dim,
+                  const std::vector<unsigned int> &exec_order,
+                  TensorLifespan lifespan,
+                  const Tensor::Initializer &init = Tensor::Initializer::NONE);
 
   /**
    * @brief reidentify the source of already created tensor (or view).

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -183,14 +183,7 @@ public:
    *
    * @note Update externally dependent tensors data ptrs from their parents
    */
-  void setExternalTensor(const std::string &name, const Tensor &t);
-
-  /**
-   * @brief Update externally dependent tensors
-   *
-   * @note Update externally dependent tensors data ptrs from their parents
-   */
-  void updateExternalTensors();
+  void fillPlaceholder(const std::string &name, const Tensor &t);
 
   /**
    * @brief request placeholder which will be not managed by this tensor pool

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -235,9 +235,7 @@ public:
    *
    * @note returns empty tensor which must be filled by the caller before use.
    */
-  Tensor *placeholder(const std::string &name, const TensorDim &dim) {
-    return nullptr;
-  }
+  Tensor *placeholder(const std::string &name, const TensorDim &dim);
 
   /**
    * @brief     create a new tensor with the given spec.
@@ -257,9 +255,7 @@ public:
   Tensor *create(const std::string &name, const TensorDim &dim,
                  const std::vector<unsigned int> &exec_order,
                  TensorLifespan lifespan,
-                 const Tensor::Initializer &init = Tensor::Initializer::NONE) {
-    return nullptr;
-  }
+                 const Tensor::Initializer &init = Tensor::Initializer::NONE);
 
   /**
    * @brief     Request tensor which is a view of already requested with the
@@ -352,6 +348,15 @@ private:
     unsigned int token; /**< tensor memory token or index to source spec */
     bool dependent;     /**< if dependent on another tensor for memory */
   };
+
+  /**
+   * @brief check if a tensor exist with the given identifier
+   *
+   * @param name name name to check
+   * @retval true if exist
+   * @retval false if do not exist
+   */
+  bool tensorExist(const std::string &name);
 
   /**
    * @brief Get the view of source Spec from the name

--- a/nntrainer/tensor/tensor_wrap_specs.h
+++ b/nntrainer/tensor/tensor_wrap_specs.h
@@ -35,7 +35,7 @@ enum class WeightRegularizer {
  *
  */
 enum class TensorLifespan {
-  ZERO_LIFESPAN = 0b0, /**< tensor with no lifespan, will not be allocated */
+  UNMANAGED = 0b0, /**< tensor with no lifespan, will not be allocated */
   FORWARD_FUNC_LIFESPAN = 0b01,  /**< tensor must not be reset before during the
                             forward function call, eg. temporary tensors
                             needed during forward operations */

--- a/test/unittest/unittest_nntrainer_tensor_pool.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool.cpp
@@ -590,6 +590,75 @@ TEST(TensorPool, view_of_placeholder_out_of_range_n) {
   EXPECT_ANY_THROW(pool.view("t1", "t0", {1}, {0}, max_ls, 11));
 }
 
+TEST(TensorPool, extend_source_p) {
+  nntrainer::TensorPool pool;
+  pool.create("t0", {10}, {0},
+              nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
+  pool.extend("t0", {1}, nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
+
+  auto &exec_order = pool.getExecutionOrder("t0");
+  EXPECT_NE(std::find(exec_order.begin(), exec_order.end(), 0),
+            exec_order.end());
+  EXPECT_NE(std::find(exec_order.begin(), exec_order.end(), 1),
+            exec_order.end());
+}
+
+TEST(TensorPool, extend_view_p) {
+  nntrainer::TensorPool pool;
+  pool.create("t0", {10}, {0},
+              nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
+  pool.view("t1", "t0", {10}, {1},
+            nntrainer::TensorLifespan::BACKWARD_FUNC_LIFESPAN);
+  pool.extend("t1", {2}, max_ls);
+
+  auto &exec_order = pool.getExecutionOrder("t0");
+  EXPECT_NE(std::find(exec_order.begin(), exec_order.end(), 0),
+            exec_order.end());
+  EXPECT_NE(std::find(exec_order.begin(), exec_order.end(), 1),
+            exec_order.end());
+  EXPECT_NE(std::find(exec_order.begin(), exec_order.end(), 2),
+            exec_order.end());
+}
+
+TEST(TensorPool, extend_placeholder_p) {
+  nntrainer::TensorPool pool;
+  pool.placeholder("t0", {10});
+  pool.extend("t0", {2}, max_ls);
+
+  auto &exec_order = pool.getExecutionOrder("t0");
+  EXPECT_EQ(std::find(exec_order.begin(), exec_order.end(), 0),
+            exec_order.end());
+  EXPECT_NE(std::find(exec_order.begin(), exec_order.end(), 2),
+            exec_order.end());
+}
+
+TEST(TensorPool, extend_view_of_placeholder_p) {
+  nntrainer::TensorPool pool;
+  pool.placeholder("t0", {10});
+  pool.view("t1", "t0", {10}, {1},
+            nntrainer::TensorLifespan::BACKWARD_FUNC_LIFESPAN);
+  pool.extend("t1", {2}, max_ls);
+
+  auto &exec_order = pool.getExecutionOrder("t0");
+  EXPECT_EQ(std::find(exec_order.begin(), exec_order.end(), 0),
+            exec_order.end());
+  EXPECT_NE(std::find(exec_order.begin(), exec_order.end(), 1),
+            exec_order.end());
+  EXPECT_NE(std::find(exec_order.begin(), exec_order.end(), 2),
+            exec_order.end());
+}
+
+TEST(TensorPool, extend_out_of_range_n) {
+  nntrainer::TensorPool pool;
+  EXPECT_ANY_THROW(pool.extend("t1", {2}, max_ls));
+}
+
+TEST(TensorPool, extend_unmanged_n) {
+  nntrainer::TensorPool pool;
+  pool.create("t0", {10}, {0}, nntrainer::TensorLifespan::UNMANAGED);
+  EXPECT_ANY_THROW(pool.extend("t1", {2}, max_ls));
+}
+
 /**
  * @brief Main gtest
  */

--- a/test/unittest/unittest_nntrainer_tensor_pool.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool.cpp
@@ -594,7 +594,8 @@ TEST(TensorPool, extend_source_p) {
   nntrainer::TensorPool pool;
   pool.request("t0", {10}, {0},
                nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
-  pool.extend("t0", {1}, nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
+  pool.extend("t0", {10}, {1},
+              nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
 
   auto &exec_order = pool.getExecutionOrder("t0");
   EXPECT_NE(std::find(exec_order.begin(), exec_order.end(), 0),
@@ -609,7 +610,7 @@ TEST(TensorPool, extend_view_p) {
                nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
   pool.view("t1", "t0", {10}, {1},
             nntrainer::TensorLifespan::BACKWARD_FUNC_LIFESPAN);
-  pool.extend("t1", {2}, max_ls);
+  pool.extend("t1", {10}, {2}, max_ls);
 
   auto &exec_order = pool.getExecutionOrder("t0");
   EXPECT_NE(std::find(exec_order.begin(), exec_order.end(), 0),
@@ -623,7 +624,7 @@ TEST(TensorPool, extend_view_p) {
 TEST(TensorPool, extend_placeholder_p) {
   nntrainer::TensorPool pool;
   pool.placeholder("t0", {10});
-  pool.extend("t0", {2}, max_ls);
+  pool.extend("t0", {10}, {2}, max_ls);
 
   auto &exec_order = pool.getExecutionOrder("t0");
   EXPECT_EQ(std::find(exec_order.begin(), exec_order.end(), 0),
@@ -637,7 +638,7 @@ TEST(TensorPool, extend_view_of_placeholder_p) {
   pool.placeholder("t0", {10});
   pool.view("t1", "t0", {10}, {1},
             nntrainer::TensorLifespan::BACKWARD_FUNC_LIFESPAN);
-  pool.extend("t1", {2}, max_ls);
+  pool.extend("t1", {10}, {2}, max_ls);
 
   auto &exec_order = pool.getExecutionOrder("t0");
   EXPECT_EQ(std::find(exec_order.begin(), exec_order.end(), 0),
@@ -650,13 +651,13 @@ TEST(TensorPool, extend_view_of_placeholder_p) {
 
 TEST(TensorPool, extend_out_of_range_n) {
   nntrainer::TensorPool pool;
-  EXPECT_ANY_THROW(pool.extend("t1", {2}, max_ls));
+  EXPECT_ANY_THROW(pool.extend("t1", {10}, {2}, max_ls));
 }
 
 TEST(TensorPool, extend_unmanged_n) {
   nntrainer::TensorPool pool;
   pool.request("t0", {10}, {0}, nntrainer::TensorLifespan::UNMANAGED);
-  EXPECT_ANY_THROW(pool.extend("t1", {2}, max_ls));
+  EXPECT_ANY_THROW(pool.extend("t1", {10}, {2}, max_ls));
 }
 
 TEST(TensorPool, createOrExtend_p) {

--- a/test/unittest/unittest_nntrainer_tensor_pool.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool.cpp
@@ -659,6 +659,42 @@ TEST(TensorPool, extend_unmanged_n) {
   EXPECT_ANY_THROW(pool.extend("t1", {2}, max_ls));
 }
 
+TEST(TensorPool, createOrExtend_p) {
+  nntrainer::TensorPool pool;
+  auto t1 = pool.createOrExtend("t", {10}, {0}, max_ls);
+  auto t2 = pool.createOrExtend("t", {10}, {1}, max_ls);
+
+  auto &exec_order = pool.getExecutionOrder("t");
+  EXPECT_NE(std::find(exec_order.begin(), exec_order.end(), 0),
+            exec_order.end());
+  EXPECT_NE(std::find(exec_order.begin(), exec_order.end(), 1),
+            exec_order.end());
+  EXPECT_EQ(t1, t2);
+  pool.finalize(nntrainer::BasicPlanner(), 0, 2);
+  pool.allocate();
+  EXPECT_EQ(*t1, *t2);
+  pool.deallocate();
+}
+
+TEST(TensorPool, createOrExtend_different_dim_n) {
+  nntrainer::TensorPool pool;
+  pool.createOrExtend("t", {10, 1}, {0}, max_ls);
+  EXPECT_ANY_THROW(pool.createOrExtend("t", {1, 10}, {1}, max_ls));
+}
+
+TEST(TensorPool, createOrExtend_init_n) {
+  nntrainer::TensorPool pool;
+  pool.createOrExtend("t", {10}, {0}, max_ls,
+                      nntrainer::Tensor::Initializer::ONES);
+  EXPECT_ANY_THROW(pool.createOrExtend("t", {10}, {1}, max_ls,
+                                       nntrainer::Tensor::Initializer::ZEROS));
+}
+TEST(TensorPool, createOrExtend_unmanaged_n) {
+  nntrainer::TensorPool pool;
+  EXPECT_ANY_THROW(
+    pool.createOrExtend("t", {10}, {0}, nntrainer::TensorLifespan::UNMANAGED));
+}
+
 /**
  * @brief Main gtest
  */

--- a/test/unittest/unittest_nntrainer_tensor_pool.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool.cpp
@@ -548,8 +548,7 @@ TEST(TensorPool, view_of_placeholder_p) {
   /// t3        :     2 3
   nntrainer::Tensor t_original(t1->getDim());
   t_original.apply_i([i = 0u](float _) mutable { return ++i; });
-  pool.setExternalTensor("t1", t_original);
-  pool.updateExternalTensors();
+  pool.fillPlaceholder("t1", t_original);
 
   testSubset(t1, &t_original);
   testSubset(t1, t2);

--- a/test/unittest/unittest_nntrainer_tensor_pool.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool.cpp
@@ -127,10 +127,9 @@ TEST(TensorPool, request_mem_07_n) {
                                      nntrainer::TensorLifespan::UNMANAGED,
                                      "abc"));
 
-  EXPECT_THROW(pool.requestPrerequestedTensor(
-                 nntrainer::TensorDim({1}), {},
-                 nntrainer::TensorLifespan::UNMANAGED, "abc1", "not_exist"),
-               std::invalid_argument);
+  EXPECT_ANY_THROW(pool.requestPrerequestedTensor(
+    nntrainer::TensorDim({1}), {}, nntrainer::TensorLifespan::UNMANAGED, "abc1",
+    "not_exist"));
 }
 
 /**

--- a/test/unittest/unittest_nntrainer_tensor_pool.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool.cpp
@@ -35,8 +35,7 @@ TEST(TensorPool, request_mem_01_n) {
   nntrainer::TensorPool pool;
 
   EXPECT_THROW(pool.requestTensor(nntrainer::TensorDim(), {},
-                                  nntrainer::TensorLifespan::ZERO_LIFESPAN,
-                                  "abc"),
+                                  nntrainer::TensorLifespan::UNMANAGED, "abc"),
                std::invalid_argument);
 }
 
@@ -47,7 +46,7 @@ TEST(TensorPool, request_mem_02_n) {
   nntrainer::TensorPool pool;
 
   EXPECT_THROW(pool.requestTensor(nntrainer::TensorDim({1}), {},
-                                  nntrainer::TensorLifespan::ZERO_LIFESPAN, ""),
+                                  nntrainer::TensorLifespan::UNMANAGED, ""),
                std::invalid_argument);
 }
 
@@ -58,9 +57,9 @@ TEST(TensorPool, request_mem_03_p) {
   nntrainer::TensorPool pool;
   nntrainer::Tensor *t;
 
-  EXPECT_NO_THROW(
-    t = pool.requestTensor(nntrainer::TensorDim({1}), {},
-                           nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc"));
+  EXPECT_NO_THROW(t = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                                         nntrainer::TensorLifespan::UNMANAGED,
+                                         "abc"));
   EXPECT_NE(t, nullptr);
   EXPECT_FALSE(t->isAllocated());
 }
@@ -72,12 +71,11 @@ TEST(TensorPool, request_mem_04_n) {
   nntrainer::TensorPool pool;
 
   EXPECT_NO_THROW(pool.requestTensor(nntrainer::TensorDim({1}), {},
-                                     nntrainer::TensorLifespan::ZERO_LIFESPAN,
+                                     nntrainer::TensorLifespan::UNMANAGED,
                                      "abc"));
 
   EXPECT_THROW(pool.requestTensor(nntrainer::TensorDim({2}), {},
-                                  nntrainer::TensorLifespan::ZERO_LIFESPAN,
-                                  "abc"),
+                                  nntrainer::TensorLifespan::UNMANAGED, "abc"),
                std::invalid_argument);
 }
 
@@ -88,15 +86,15 @@ TEST(TensorPool, request_mem_05_p) {
   nntrainer::TensorPool pool;
   nntrainer::Tensor *t1, *t2;
 
-  EXPECT_NO_THROW(
-    t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
-                            nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc"));
+  EXPECT_NO_THROW(t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                                          nntrainer::TensorLifespan::UNMANAGED,
+                                          "abc"));
   EXPECT_NE(t1, nullptr);
   EXPECT_FALSE(t1->isAllocated());
 
   EXPECT_NO_THROW(t2 = pool.requestPrerequestedTensor(
                     nntrainer::TensorDim({1}), {},
-                    nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc1", "abc"));
+                    nntrainer::TensorLifespan::UNMANAGED, "abc1", "abc"));
   EXPECT_NE(t2, nullptr);
   EXPECT_FALSE(t2->isAllocated());
 
@@ -110,12 +108,12 @@ TEST(TensorPool, request_mem_06_n) {
   nntrainer::TensorPool pool;
 
   EXPECT_NO_THROW(pool.requestTensor(nntrainer::TensorDim({1}), {},
-                                     nntrainer::TensorLifespan::ZERO_LIFESPAN,
+                                     nntrainer::TensorLifespan::UNMANAGED,
                                      "abc"));
 
   EXPECT_THROW(pool.requestPrerequestedTensor(
                  nntrainer::TensorDim({2}), {},
-                 nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc1", "abc"),
+                 nntrainer::TensorLifespan::UNMANAGED, "abc1", "abc"),
                std::invalid_argument);
 }
 
@@ -126,12 +124,12 @@ TEST(TensorPool, request_mem_07_n) {
   nntrainer::TensorPool pool;
 
   EXPECT_NO_THROW(pool.requestTensor(nntrainer::TensorDim({1}), {},
-                                     nntrainer::TensorLifespan::ZERO_LIFESPAN,
+                                     nntrainer::TensorLifespan::UNMANAGED,
                                      "abc"));
 
   EXPECT_THROW(pool.requestPrerequestedTensor(
                  nntrainer::TensorDim({1}), {},
-                 nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc1", "not_exist"),
+                 nntrainer::TensorLifespan::UNMANAGED, "abc1", "not_exist"),
                std::invalid_argument);
 }
 
@@ -142,9 +140,9 @@ TEST(TensorPool, request_mem_08_p) {
   nntrainer::TensorPool pool;
   nntrainer::Tensor *t1, *t2;
 
-  EXPECT_NO_THROW(
-    t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
-                            nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc"));
+  EXPECT_NO_THROW(t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                                          nntrainer::TensorLifespan::UNMANAGED,
+                                          "abc"));
   EXPECT_NE(t1, nullptr);
   EXPECT_FALSE(t1->isAllocated());
 
@@ -172,12 +170,12 @@ TEST(TensorPool, request_mem_09_n) {
   nntrainer::TensorPool pool;
 
   EXPECT_NO_THROW(pool.requestTensor(nntrainer::TensorDim({1}), {},
-                                     nntrainer::TensorLifespan::ZERO_LIFESPAN,
+                                     nntrainer::TensorLifespan::UNMANAGED,
                                      "abc"));
 
   EXPECT_THROW(pool.requestPrerequestedTensor(
                  nntrainer::TensorDim({1}), {},
-                 nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc", "abc"),
+                 nntrainer::TensorLifespan::UNMANAGED, "abc", "abc"),
                std::invalid_argument);
 }
 
@@ -188,9 +186,9 @@ TEST(TensorPool, set_batch_01_p) {
   nntrainer::TensorPool pool;
   nntrainer::Tensor *t1;
 
-  EXPECT_NO_THROW(
-    t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
-                            nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc"));
+  EXPECT_NO_THROW(t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                                          nntrainer::TensorLifespan::UNMANAGED,
+                                          "abc"));
   EXPECT_NE(t1, nullptr);
   EXPECT_FALSE(t1->isAllocated());
 
@@ -206,9 +204,9 @@ TEST(TensorPool, set_batch_02_n) {
   nntrainer::TensorPool pool;
   nntrainer::Tensor *t1;
 
-  EXPECT_NO_THROW(
-    t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
-                            nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc"));
+  EXPECT_NO_THROW(t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                                          nntrainer::TensorLifespan::UNMANAGED,
+                                          "abc"));
   EXPECT_NE(t1, nullptr);
   EXPECT_FALSE(t1->isAllocated());
 
@@ -223,9 +221,9 @@ TEST(TensorPool, finalize_01_p) {
   nntrainer::TensorPool pool;
   nntrainer::Tensor *t1, *t2;
 
-  EXPECT_NO_THROW(
-    t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
-                            nntrainer::TensorLifespan::ZERO_LIFESPAN, "abc1"));
+  EXPECT_NO_THROW(t1 = pool.requestTensor(nntrainer::TensorDim({1}), {},
+                                          nntrainer::TensorLifespan::UNMANAGED,
+                                          "abc1"));
   EXPECT_NE(t1, nullptr);
   EXPECT_FALSE(t1->isAllocated());
 


### PR DESCRIPTION
## Commits to be reviewed in this PR


<details><summary>[TPool] Add interface to enable extensive sharing</summary><br />

This patch add interface to enable extensive sharing, including
reassigning or tensor pointer sharing (previously discussed as s3
sharing)

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[TPool] implement create/placeholder</summary><br />

This patch implements create/view and its corresponding test.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[tpool] Implement view()</summary><br />

**Changes proposed in this PR:**
- merge updateExternalTensor()
- enable offset for view/placeholder
- corresponding tests
- s/requestSpec/RequestSpec

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Trivial] ZERO_LIFESPAN -> UNMANAGED</summary><br />

This patch renames zero_lifespan to unmanaged.

zero_lifespan suggests it should be extendable but it's precisely not.
So changed name for clarity.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Clean] Separate src spec from dep spec</summary><br />

As source specification and dep specification is being deviated, this
patch prepares for the further code changes with minor clearance.

**Changes proposed in this PR:**
- RequestSpec now has tensor, details
- Detail is `std::variant<SourceDetails, DependencyDetails>`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Tpool] Remove updateExternalTensor</summary><br />

Instead of requesting externally to update external tensor, now syncing
dependency done upon request and renamed to `fillPlaceholder` to align
with incoming changes

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[TP] Implement extend()</summary><br />

This patch implements extend() and corresponding tests

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>Policy based tensor request for tensor pool.</summary><br />

This commit specifically implement createOrExtend().

From this commit, basic tensor pool request will be possible except
`reidentifySource()`.
`reidentifySource()` will come as a separate PR to get better review.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

