### PR TITLE
[KNN] Fix querying label when not training

### DIFF
--- a/nntrainer/layers/centroid_knn.cpp
+++ b/nntrainer/layers/centroid_knn.cpp
@@ -74,13 +74,7 @@ void CentroidKNN::forwarding(nntrainer::RunLayerContext &context,
                              bool training) {
   auto &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
   auto &input_ = context.getInput(SINGLE_INOUT_IDX);
-  auto &label = context.getLabel(SINGLE_INOUT_IDX);
   const auto &input_dim = input_.getDim();
-
-  if (training && label.empty()) {
-    throw std::invalid_argument(
-      "[CentroidKNN] forwarding requires label feeded");
-  }
 
   auto &map = context.getWeight(weight_idx[KNNParams::map]);
   auto &num_samples = context.getWeight(weight_idx[KNNParams::num_samples]);
@@ -92,6 +86,7 @@ void CentroidKNN::forwarding(nntrainer::RunLayerContext &context,
   };
 
   if (training) {
+    auto &label = context.getLabel(SINGLE_INOUT_IDX);
     auto ans = label.argmax();
 
     for (unsigned int b = 0; b < input_.batch(); ++b) {

--- a/nntrainer/layers/centroid_knn.cpp
+++ b/nntrainer/layers/centroid_knn.cpp
@@ -134,4 +134,9 @@ void CentroidKNN::calcDerivative(nntrainer::RunLayerContext &context) {
   throw std::invalid_argument("[CentroidKNN::calcDerivative] This Layer "
                               "does not support backward propagation");
 }
+
+void CentroidKNN::exportTo(nntrainer::Exporter &exporter,
+                           const nntrainer::ExportMethods &method) const {
+  exporter.saveResult(centroid_knn_props, method, this);
+}
 } // namespace nntrainer

--- a/nntrainer/layers/centroid_knn.h
+++ b/nntrainer/layers/centroid_knn.h
@@ -80,7 +80,7 @@ public:
    * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
    */
   void exportTo(nntrainer::Exporter &exporter,
-                const nntrainer::ExportMethods &method) const override {}
+                const nntrainer::ExportMethods &method) const override;
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -10,6 +10,7 @@
  * @brief  This is the layer context for each layer
  */
 
+#include "nntrainer_error.h"
 #include <functional>
 
 #include <layer_context.h>
@@ -323,8 +324,12 @@ bool RunLayerContext::isLabelAvailable(unsigned int idx) const {
 Tensor &RunLayerContext::getLabel(unsigned int idx) {
   if (isLabelAvailable(idx))
     return outputs[idx]->getGradientRef();
-  else
-    throw std::invalid_argument("Request tensor which does not exist");
+  else {
+    std::stringstream ss;
+    ss << "Requesing label of index: " << idx << "for " << getName()
+       << " does not exist";
+    throw std::invalid_argument(ss.str().c_str());
+  }
 }
 
 /**


### PR DESCRIPTION
## Commits to be reviewed in this PR


<details><summary>[KNN] Implement knn saving</summary><br />

As knn was not saving it's props, this patch implements saving property

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[KNN] Fix querying label when not training</summary><br />

This patch fix querying label when not training, which is not feasible

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

