### PR TITLE
[layer] Support MoL attention layer forwarding

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -66,6 +66,7 @@ enum LayerType {
                                                  type */
   LAYER_BACKBONE_TFLITE,                   /**< Backbone using TFLite */
   LAYER_ATTENTION,                         /**< Attention Layer type */
+  LAYER_MOL_ATTENTION,                     /**< MoL Attention Layer type */
   LAYER_CONV1D,                            /**< Convolution 1D Layer type */
   LAYER_RESHAPE,                           /**< Reshape Layer type */
   LAYER_RNNCELL,                           /**< RNN Cell Layer type */

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -163,6 +163,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/reshape_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/addition_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/attention_layer.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/layers/mol_attention_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/concat_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/preprocess_flip_layer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/layers/preprocess_translate_layer.cpp \

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -47,6 +47,7 @@
 #include <input_layer.h>
 #include <lstm.h>
 #include <lstmcell.h>
+#include <mol_attention_layer.h>
 #include <mse_loss_layer.h>
 #include <multiout_layer.h>
 #include <nntrainer_error.h>
@@ -256,6 +257,8 @@ static void add_default_object(AppContext &ac) {
                      LayerType::LAYER_DROPOUT);
   ac.registerFactory(nntrainer::createLayer<AttentionLayer>,
                      AttentionLayer::type, LayerType::LAYER_ATTENTION);
+  ac.registerFactory(nntrainer::createLayer<MoLAttentionLayer>,
+                     MoLAttentionLayer::type, LayerType::LAYER_MOL_ATTENTION);
 
 #ifdef ENABLE_NNSTREAMER_BACKBONE
   ac.registerFactory(nntrainer::createLayer<NNStreamerLayer>,

--- a/nntrainer/layers/acti_func.cpp
+++ b/nntrainer/layers/acti_func.cpp
@@ -156,7 +156,7 @@ Tensor &ActiFunc::softmax(Tensor const &t, Tensor &output) {
   float *dp;
   float *rp;
 
-  /** TODO: fix this check */
+  /** TODO: support strided operations */
   if (t.size() == output.size() && t.getStrides() != output.getStrides())
     throw std::invalid_argument(
       "Softmax does not support operating on strided tensors");
@@ -194,7 +194,7 @@ Tensor &ActiFunc::softmax(Tensor const &t, Tensor &output) {
 
 Tensor &ActiFunc::softmaxPrime(Tensor const &x, Tensor &output,
                                Tensor const &derivative) {
-  /** TODO: fix this check */
+  /** TODO: support strided operations */
   if ((x.size() == output.size() && x.getStrides() != output.getStrides()) ||
       (x.size() == derivative.size() &&
        x.getStrides() != derivative.getStrides()))

--- a/nntrainer/layers/acti_func.cpp
+++ b/nntrainer/layers/acti_func.cpp
@@ -156,6 +156,11 @@ Tensor &ActiFunc::softmax(Tensor const &t, Tensor &output) {
   float *dp;
   float *rp;
 
+  /** TODO: fix this check */
+  if (t.size() == output.size() && t.getStrides() != output.getStrides())
+    throw std::invalid_argument(
+      "Softmax does not support operating on strided tensors");
+
   Tensor divisor = t.clone();
 
   dp = divisor.getData();
@@ -189,6 +194,13 @@ Tensor &ActiFunc::softmax(Tensor const &t, Tensor &output) {
 
 Tensor &ActiFunc::softmaxPrime(Tensor const &x, Tensor &output,
                                Tensor const &derivative) {
+  /** TODO: fix this check */
+  if ((x.size() == output.size() && x.getStrides() != output.getStrides()) ||
+      (x.size() == derivative.size() &&
+       x.getStrides() != derivative.getStrides()))
+    throw std::invalid_argument(
+      "SoftmaxPrime does not support operating on strided tensors");
+
   unsigned int batch = x.batch();
   unsigned int channel = x.channel();
   unsigned int height = x.height();

--- a/nntrainer/layers/attention_layer.cpp
+++ b/nntrainer/layers/attention_layer.cpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file   attention_layer.h
+ * @file   attention_layer.cpp
  * @date   1 October 2021
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Parichay Kapoor <pk.kapoor@samsung.com>
@@ -25,14 +25,11 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 
 enum AttentionParams { query = 0, value = 1, key = 2, score, weights };
 
-void AttentionLayer::finalize(InitLayerContext &context) {
+void AttentionLayer::finalizeCommon(InitLayerContext &context) {
   if (context.getNumInputs() < 2 || context.getNumInputs() > 3)
     throw std::runtime_error("Attention layer needs 2-3 inputs.");
 
-  sm.setActiFunc(ActivationType::ACT_SOFTMAX);
-
   auto const &all_dims = context.getInputDimensions();
-  auto const &query_dim = all_dims[AttentionParams::query];
   auto const &value_dim = all_dims[AttentionParams::value];
 
   wt_idx[AttentionParams::query] = AttentionParams::query;
@@ -46,6 +43,16 @@ void AttentionLayer::finalize(InitLayerContext &context) {
 
     wt_idx[AttentionParams::key] = AttentionParams::key;
   }
+}
+
+void AttentionLayer::finalize(InitLayerContext &context) {
+  finalizeCommon(context);
+
+  sm.setActiFunc(ActivationType::ACT_SOFTMAX);
+
+  auto const &all_dims = context.getInputDimensions();
+  auto const &query_dim = all_dims[AttentionParams::query];
+  auto const &value_dim = all_dims[AttentionParams::value];
 
   auto weights_dim = query_dim;
   weights_dim.width(value_dim.height());

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -1019,6 +1019,16 @@ public:
   using prop_tag = dimension_prop_tag; /**< property type */
 };
 
+/**
+ * @brief K property, K is the size of the three projections in MoL attention
+ *
+ */
+class MoL_K : public PositiveIntegerProperty {
+public:
+  static constexpr const char *key = "K"; /**< unique key to access */
+  using prop_tag = uint_prop_tag;            /**< property type */
+};
+
 } // namespace props
 } // namespace nntrainer
 

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -1025,8 +1025,8 @@ public:
  */
 class MoL_K : public PositiveIntegerProperty {
 public:
-  static constexpr const char *key = "K"; /**< unique key to access */
-  using prop_tag = uint_prop_tag;         /**< property type */
+  static constexpr const char *key = "MoL_K"; /**< unique key to access */
+  using prop_tag = uint_prop_tag;             /**< property type */
 };
 
 } // namespace props

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -1026,7 +1026,7 @@ public:
 class MoL_K : public PositiveIntegerProperty {
 public:
   static constexpr const char *key = "K"; /**< unique key to access */
-  using prop_tag = uint_prop_tag;            /**< property type */
+  using prop_tag = uint_prop_tag;         /**< property type */
 };
 
 } // namespace props

--- a/nntrainer/layers/meson.build
+++ b/nntrainer/layers/meson.build
@@ -6,6 +6,7 @@ layer_sources = [
   'activation_layer.cpp',
   'addition_layer.cpp',
   'attention_layer.cpp',
+  'mol_attention_layer.cpp',
   'concat_layer.cpp',
   'bn_layer.cpp',
   'conv2d_layer.cpp',

--- a/nntrainer/layers/mol_attention_layer.cpp
+++ b/nntrainer/layers/mol_attention_layer.cpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   mol_attention_layer.cpp
+ * @date   11 November 2021
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is MoL Attention Layer Class for Neural Network
+ *
+ */
+
+#include <mol_attention_layer.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+
+namespace nntrainer {
+
+MoLAttentionLayer::MoLAttentionLayer() : wt_idx({0}) {}
+
+MoLAttentionLayer::~MoLAttentionLayer() {}
+
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
+enum AttentionParams { query = 0, value = 1, key = 2, score, weights };
+
+void MoLAttentionLayer::finalize(InitLayerContext &context) {
+  finalizeCommon(context);
+  /** NYI */
+}
+
+void MoLAttentionLayer::forwarding(RunLayerContext &context, bool training) {
+  /** NYI */
+}
+
+void MoLAttentionLayer::calcDerivative(RunLayerContext &context) { /** NYI */ }
+
+void MoLAttentionLayer::setProperty(const std::vector<std::string> &values) {
+  /** NYI */
+}
+
+void MoLAttentionLayer::setBatch(RunLayerContext &context, unsigned int batch) {
+  /** NYI */
+}
+
+} /* namespace nntrainer */

--- a/nntrainer/layers/mol_attention_layer.cpp
+++ b/nntrainer/layers/mol_attention_layer.cpp
@@ -12,6 +12,8 @@
  */
 
 #include <cmath>
+
+#include <layer_context.h>
 #include <mol_attention_layer.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
@@ -123,14 +125,7 @@ void MoLAttentionLayer::forwarding(RunLayerContext &context, bool training) {
   Tensor scores = integral_scaled.sum(3);
   scores.reshape(TensorDim({scores.batch(), 1, 1, scores.height()}));
 
-  for (unsigned int b = 0; b < batch; b++) {
-    /** @todo try using transpose to speedup the operation */
-    Tensor value_b = value.getBatchSlice(b, 1);
-    Tensor score_b = scores.getBatchSlice(b, 1);
-    Tensor output_b = output.getBatchSlice(b, 1);
-
-    score_b.dot(value_b, output_b);
-  }
+  scores.dotBatched(value, output);
 }
 
 void MoLAttentionLayer::calcDerivative(RunLayerContext &context) { /** NYI */

--- a/nntrainer/layers/mol_attention_layer.cpp
+++ b/nntrainer/layers/mol_attention_layer.cpp
@@ -14,6 +14,7 @@
 #include <mol_attention_layer.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
+#include <node_exporter.h>
 
 namespace nntrainer {
 
@@ -37,7 +38,8 @@ void MoLAttentionLayer::forwarding(RunLayerContext &context, bool training) {
 void MoLAttentionLayer::calcDerivative(RunLayerContext &context) { /** NYI */ }
 
 void MoLAttentionLayer::setProperty(const std::vector<std::string> &values) {
-  /** NYI */
+  auto remain_props = loadProperties(values, mol_props);
+  AttentionLayer::setProperty(remain_props);
 }
 
 void MoLAttentionLayer::setBatch(RunLayerContext &context, unsigned int batch) {

--- a/nntrainer/layers/mol_attention_layer.cpp
+++ b/nntrainer/layers/mol_attention_layer.cpp
@@ -11,6 +11,7 @@
  *
  */
 
+#include <cmath>
 #include <mol_attention_layer.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
@@ -24,18 +25,103 @@ MoLAttentionLayer::~MoLAttentionLayer() {}
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
-enum AttentionParams { query = 0, value = 1, key = 2, score, weights };
+enum AttentionParams { query = 0, value = 1, state = 2, mlp_w, mlp_proj_w };
 
 void MoLAttentionLayer::finalize(InitLayerContext &context) {
-  finalizeCommon(context);
-  /** NYI */
+  if (context.getNumInputs() != 3)
+    throw std::runtime_error("MoL Attention layer needs 3 inputs.");
+
+  auto const &all_dims = context.getInputDimensions();
+  auto const &query_dim = all_dims[AttentionParams::query];
+
+  wt_idx[AttentionParams::query] = AttentionParams::query;
+  wt_idx[AttentionParams::value] = AttentionParams::value;
+  wt_idx[AttentionParams::state] = AttentionParams::state;
+
+  softmax.setActiFunc(ActivationType::ACT_SOFTMAX);
+  tanh.setActiFunc(ActivationType::ACT_TANH);
+  sigmoid.setActiFunc(ActivationType::ACT_SIGMOID);
+
+  auto unit = std::get<props::Unit>(mol_props).get();
+  auto mol_k = std::get<props::MoL_K>(mol_props).get();
+
+  TensorDim mlp_w_dim = {query_dim.width(), unit};
+  wt_idx[AttentionParams::mlp_w] =
+    context.requestWeight(mlp_w_dim, Tensor::Initializer::XAVIER_UNIFORM,
+                          WeightRegularizer::NONE, 0.0, "mlp_w", true);
+
+  TensorDim mlp_proj_w_dim = {unit, 3 * mol_k};
+  wt_idx[AttentionParams::mlp_proj_w] =
+    context.requestWeight(mlp_proj_w_dim, Tensor::Initializer::XAVIER_UNIFORM,
+                          WeightRegularizer::NONE, 0.0, "mlp_proj_w", true);
+
+  context.setOutputDimensions({query_dim});
 }
 
 void MoLAttentionLayer::forwarding(RunLayerContext &context, bool training) {
-  /** NYI */
+  Tensor &query = context.getInput(wt_idx[AttentionParams::query]);
+  Tensor &value = context.getInput(wt_idx[AttentionParams::value]);
+  Tensor &state = context.getInput(wt_idx[AttentionParams::state]);
+
+  Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+  Tensor &mlp_w = context.getWeight(wt_idx[AttentionParams::mlp_w]);
+  Tensor &mlp_proj_w = context.getWeight(wt_idx[AttentionParams::mlp_proj_w]);
+
+  const TensorDim &input_dim = query.getDim();
+  unsigned int batch = input_dim.batch();
+  auto mol_k = std::get<props::MoL_K>(mol_props).get();
+
+  Tensor mlp_out = query.dot(mlp_w);
+
+  Tensor mlp_tanh;
+  tanh.run_fn(mlp_out, mlp_tanh);
+
+  Tensor mlp_proj_out = mlp_tanh.dot(mlp_proj_w);
+
+  /** @note kappa_hat, beta_hat, alpha_hat are strided */
+  Tensor kappa_hat = mlp_proj_out.getSharedDataTensor({batch, mol_k}, 0, false);
+  Tensor beta_hat =
+    mlp_proj_out.getSharedDataTensor({batch, mol_k}, mol_k, false);
+  Tensor alpha_hat =
+    mlp_proj_out.getSharedDataTensor({batch, mol_k}, mol_k * 2, false);
+
+  Tensor kappa = kappa_hat.apply(static_cast<float (*)(float)>(&std::exp));
+  Tensor beta = beta_hat.apply(static_cast<float (*)(float)>(&std::exp));
+
+  Tensor alpha;
+  /** @todo support stride for softmax */
+  softmax.run_fn(alpha_hat, alpha);
+
+  Tensor m = state.add(kappa);
+
+  /** @todo cache u_pos */
+  Tensor u_pos = Tensor(TensorDim({batch, 1, value.height() / mol_k, mol_k}));
+  float *u_pos_data = u_pos.getData();
+  for (unsigned int idx = 0; idx < u_pos.size(); idx++) {
+    u_pos_data[idx] = ((float)idx) + 1.0 + 0.5;
+  }
+
+  /** @todo cache u_neg */
+  Tensor u_neg = Tensor(TensorDim({batch, 1, value.height() / mol_k, mol_k}));
+  float *u_neg_data = u_neg.getData();
+  for (unsigned int idx = 0; idx < u_neg.size(); idx++) {
+    u_neg_data[idx] = ((float)idx) + 1.0 - 0.5;
+  }
+
+  Tensor integral_left, integral_right;
+  /** @todo support stride for divide */
+  sigmoid.run_fn(u_pos.subtract(state).divide(beta.add(1e-8f)), integral_left);
+  sigmoid.run_fn(u_neg.subtract(state).divide(beta.add(1e-8f)), integral_right);
+  Tensor integral = integral_left.subtract(integral_right);
+
+  Tensor integral_scaled = alpha.multiply(integral);
+  Tensor scores = integral_scaled.sum(2);
+
+  scores.dot(value, output);
 }
 
-void MoLAttentionLayer::calcDerivative(RunLayerContext &context) { /** NYI */ }
+void MoLAttentionLayer::calcDerivative(RunLayerContext &context) { /** NYI */
+}
 
 void MoLAttentionLayer::setProperty(const std::vector<std::string> &values) {
   auto remain_props = loadProperties(values, mol_props);

--- a/nntrainer/layers/mol_attention_layer.h
+++ b/nntrainer/layers/mol_attention_layer.h
@@ -2,51 +2,50 @@
 /**
  * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file   attention_layer.h
- * @date   1 October 2021
+ * @file   mol_attention_layer.h
+ * @date   11 November 2021
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Parichay Kapoor <pk.kapoor@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  This is Attention Layer Class for Neural Network
+ * @brief  This is MoL Attention Layer Class for Neural Network
  *
  */
 
-#ifndef __ATTENTION_LAYER_H__
-#define __ATTENTION_LAYER_H__
+#ifndef __MOL_ATTENTION_LAYER_H__
+#define __MOL_ATTENTION_LAYER_H__
 #ifdef __cplusplus
 
-#include <acti_func.h>
-#include <layer_devel.h>
+#include <attention_layer.h>
 
 namespace nntrainer {
 
 /**
- * @class   Attention Layer
- * @brief   Attention Layer
+ * @class   MoL Attention Layer
+ * @brief   Mixture of Logistics Attention Layer
  */
-class AttentionLayer : public Layer {
+class MoLAttentionLayer : public AttentionLayer {
 public:
   /**
-   * @brief     Constructor of Attention Layer
+   * @brief     Constructor of MoL Attention Layer
    */
-  AttentionLayer();
+  MoLAttentionLayer();
 
   /**
-   * @brief     Destructor of Attention Layer
+   * @brief     Destructor of MoL Attention Layer
    */
-  ~AttentionLayer();
+  ~MoLAttentionLayer();
 
   /**
-   *  @brief  Move constructor of AttentionLayer.
-   *  @param[in] AttentionLayer &&
+   *  @brief  Move constructor of MoLAttentionLayer.
+   *  @param[in] MoLAttentionLayer &&
    */
-  AttentionLayer(AttentionLayer &&rhs) noexcept = default;
+  MoLAttentionLayer(MoLAttentionLayer &&rhs) noexcept = default;
 
   /**
    * @brief  Move assignment operator.
-   * @parma[in] rhs AttentionLayer to be moved.
+   * @parma[in] rhs MoLAttentionLayer to be moved.
    */
-  AttentionLayer &operator=(AttentionLayer &&rhs) = default;
+  MoLAttentionLayer &operator=(MoLAttentionLayer &&rhs) = default;
 
   /**
    * @copydoc Layer::finalize(InitLayerContext &context)
@@ -82,24 +81,16 @@ public:
   /**
    * @copydoc Layer::getType()
    */
-  const std::string getType() const override { return AttentionLayer::type; };
+  const std::string getType() const override {
+    return MoLAttentionLayer::type;
+  };
 
   /**
    * @copydoc Layer::setBatch(RunLayerContext &context, unsigned int batch)
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "attention";
-
-protected:
-  /**
-   * @brief     Finalize the attention layer with the given context
-   * @param[in] context InitLayerContext
-   *
-   * @note This function provides the basic finalize details which can be shared
-   * with derived classes as well
-   */
-  void finalizeCommon(InitLayerContext &context);
+  inline static const std::string type = "mol_attention";
 
 private:
   ActiFunc sm;                        /** softmax activation operation */
@@ -109,4 +100,4 @@ private:
 } // namespace nntrainer
 
 #endif /* __cplusplus */
-#endif /* __ATTENTION_LAYER_H__ */
+#endif /* __MOL_ATTENTION_LAYER_H__ */

--- a/nntrainer/layers/mol_attention_layer.h
+++ b/nntrainer/layers/mol_attention_layer.h
@@ -94,9 +94,12 @@ public:
 
 private:
   std::tuple<props::Unit, props::MoL_K>
-    mol_props; /**< mol attention layer properties : unit - number of output neurons */
+    mol_props; /**< mol attention layer properties : unit - number of output
+                  neurons */
 
-  ActiFunc sm;                        /** softmax activation operation */
+  ActiFunc softmax;                   /** softmax activation operation */
+  ActiFunc tanh;                      /** softmax activation operation */
+  ActiFunc sigmoid;                   /** softmax activation operation */
   std::array<unsigned int, 5> wt_idx; /**< indices of the weights and tensors */
 };
 

--- a/nntrainer/layers/mol_attention_layer.h
+++ b/nntrainer/layers/mol_attention_layer.h
@@ -93,6 +93,9 @@ public:
   inline static const std::string type = "mol_attention";
 
 private:
+  std::tuple<props::Unit, props::MoL_K>
+    mol_props; /**< mol attention layer properties : unit - number of output neurons */
+
   ActiFunc sm;                        /** softmax activation operation */
   std::array<unsigned int, 5> wt_idx; /**< indices of the weights and tensors */
 };

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -869,6 +869,23 @@ Tensor &Tensor::sum(const std::vector<unsigned int> &axes, Tensor &output,
   return output;
 }
 
+Tensor &Tensor::dotBatched(Tensor const &m, Tensor &result, bool trans,
+                           bool trans_m, float beta) const {
+  if (!result.isAllocated())
+    throw std::invalid_argument(
+      "Output tensor must be preallocated for dotBatched operation");
+  for (unsigned int b = 0; b < batch(); b++) {
+    /** @todo try using transpose to speedup the operation */
+    const Tensor this_b = this->getBatchSlice(b, 1);
+    Tensor m_b = m.getBatchSlice(b, 1);
+    Tensor result_b = result.getBatchSlice(b, 1);
+
+    this_b.dot(m_b, result_b, trans, trans_m, beta);
+  }
+
+  return result;
+}
+
 Tensor Tensor::dot(Tensor const &m, bool trans, bool trans_m) const {
   Tensor output;
   dot(m, output, trans, trans_m);

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -577,6 +577,14 @@ public:
               bool trans_m = false, float beta = 0.0f) const;
 
   /**
+   * @copydoc Tensor::dot(Tensor const &m, Tensor &output, bool trans,
+              bool trans_m, float beta) const
+   * @details performs dot operation over a batch of inputs
+   */
+  Tensor &dotBatched(Tensor const &m, Tensor &result, bool trans = false,
+                     bool trans_m = false, float beta = 0.0f) const;
+
+  /**
    * @brief     Transpose Tensor
    * @param[in] direction to transpose ex) 0:2:1
    * @retval    Calculated Tensor

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -55,6 +55,7 @@ test_target = [
   'unittest_layers_attention.cpp',
   'unittest_layers_dropout.cpp',
   'unittest_layers_reshape.cpp',
+  'unittest_layers_mol_attention.cpp',
 ]
 
 if get_option('enable-tflite-backbone')

--- a/test/unittest/layers/unittest_layers_mol_attention.cpp
+++ b/test/unittest/layers/unittest_layers_mol_attention.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file unittest_layers_mol_attention.cpp
+ * @date 26 November 2021
+ * @brief MoL Attention Layer Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include <layers_common_tests.h>
+#include <mol_attention_layer.h>
+
+auto semantic_mol_attention = LayerSemanticsParamType(
+  nntrainer::createLayer<nntrainer::MoLAttentionLayer>,
+  nntrainer::MoLAttentionLayer::type, {"unit=5", "mol_k=4"}, 0, false, 3);
+
+INSTANTIATE_TEST_CASE_P(MoLAttention, LayerSemantics,
+                        ::testing::Values(semantic_mol_attention));

--- a/test/unittest/models/models_test_utils.cpp
+++ b/test/unittest/models/models_test_utils.cpp
@@ -400,9 +400,14 @@ void GraphWatcher::compareFor(const std::string &reference,
 }
 
 void GraphWatcher::validateFor(const nntrainer::TensorDim &label_shape) {
-  auto in_tensor = MAKE_SHARED_TENSOR(nn->getInputDimension()[0]);
-  in_tensor->setRandNormal();
-  nntrainer::sharedConstTensors input = {in_tensor};
+  sharedConstTensors input;
+  for (auto const &dim : nn->getInputDimension()) {
+    auto in_tensor = MAKE_SHARED_TENSOR(dim);
+    in_tensor->setRandNormal();
+    input.push_back(in_tensor);
+  }
+
+  // nntrainer::sharedConstTensors input = {in_tensor};
 
   auto label_tensor = MAKE_SHARED_TENSOR(label_shape);
   label_tensor->setRandNormal();

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -741,6 +741,15 @@ INI multiout_model(
   }
 );
 
+INI mol_attention(
+  "mol_attention",
+  {nn_base + "batch_size = 3",
+   sgd_base + "learning_rate = 1",
+   I("in0") + input_base + "input_shape = 1:1:256",
+   I("in1") + input_base + "input_shape = 1:84:256",
+   I("in2") + input_base + "input_shape = 1:1:5", // this shape should match mol_k
+   I("mol") + "type=mol_attention" + "unit = 128" + "mol_k=5" + "input_layers=in0,in1,in2"});
+
 /**
  * @brief helper function to make model testcase
  *
@@ -873,6 +882,7 @@ INSTANTIATE_TEST_CASE_P(
       mkModelIniTc(preprocess_translate, "3:1:1:10", 10, ModelTestOption::NO_THROW_RUN),
   #endif
       mkModelIniTc(preprocess_flip_validate, "3:1:1:10", 10, ModelTestOption::NO_THROW_RUN),
+      mkModelIniTc(mol_attention, "3:1:1:128", 2, ModelTestOption::NO_THROW_RUN),
 
       /**< Addition test */
       mkModelIniTc(addition_resnet_like, "3:1:1:10", 10, ModelTestOption::COMPARE), // Todo: Enable option to ALL


### PR DESCRIPTION
- This patch prepares scaffolding for MoL Attention Layer.
Attention layer has also been updated for MoLAttentionLayer to extend
AttentionLayer.
- This patch provides support for all the properties required for MoL
attention layer.
- This patch provides the forwarding implementation for the mol attention
layer. New underlying requirements have been added with this which
requires more tensor operations to support strided operations like
softmax which will be supported soon.
- add basic validation unittests + forwarding fix for mol
attention layer.
Further a validation test for mol layer is also added for larger size,
and nntrainer model is fixed to support multiple inputs.
- Add support for batched dot operaiton. Provide cleanup for both the
attention layers.\

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>