### PR TITLE
[QuickFix] Check weight access for the last @open sesame 11/19 10:09

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -856,33 +856,41 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
   std::vector<std::string> shared_weight_names;
   std::vector<std::string> shared_tensor_names;
   if (auto shared_node_str = lnode->getSharedFrom(); !shared_node_str.empty()) {
-    auto shared_node = getLayerNode(shared_node_str).get();
-    NNTR_THROW_IF(shared_node == nullptr, std::invalid_argument)
-      << "shared_node requested but it is not registered in the graph, name: "
-      << shared_node_str << " requested from " << lnode->getName();
-    NNTR_THROW_IF(shared_node->getType() != lnode->getType(),
-                  std::invalid_argument)
-      << " shared_node and lnode type mismatch, source node type: "
-      << shared_node->getType() << " depedent node type: " << lnode->getType()
-      << " depedent node name: " << lnode->getName();
-    NNTR_THROW_IF(!shared_node->isFinalized(), std::invalid_argument)
-      << "shared node must be prior to the dependent node and it should be "
-         "finalized beforehand, shared node name: "
-      << shared_node_str << " dependent node name: " << lnode->getName();
-    auto num_weight = shared_node->getNumWeights();
-    shared_weight_names.reserve(num_weight);
-    for (auto i = 0u; i < num_weight; ++i) {
-      shared_weight_names.emplace_back(shared_node->getWeightName(i));
-    }
-
-    auto &rc = shared_node->getRunContext();
+    // auto shared_node = getLayerNode(shared_node_str).get();
+    // NNTR_THROW_IF(shared_node == nullptr, std::invalid_argument)
+    //   << "shared_node requested but it is not registered in the graph, name:
+    //   "
+    //   << shared_node_str << " requested from " << lnode->getName();
+    // NNTR_THROW_IF(shared_node->getType() != lnode->getType(),
+    //               std::invalid_argument)
+    //   << " shared_node and lnode type mismatch, source node type: "
+    //   << shared_node->getType() << " depedent node type: " <<
+    //   lnode->getType()
+    //   << " depedent node name: " << lnode->getName();
+    // NNTR_THROW_IF(!shared_node->isFinalized(), std::invalid_argument)
+    //   << "shared node must be prior to the dependent node and it should be "
+    //      "finalized beforehand, shared node name: "
+    //   << shared_node_str << " dependent node name: " << lnode->getName();
+    // auto num_weight = shared_node->getNumWeights();
+    // shared_weight_names.reserve(num_weight);
+    // for (auto i = 0u; i < num_weight; ++i) {
+    //   shared_weight_names.emplace_back(shared_node->getWeightName(i));
+    // }
+    // auto &rc = node->getRunContext();
 
     /// @fixme tensor should be only shared if context explicitly requested to
     /// do so. This has to be added to the part of tensor spec, other wise it
     /// will break many things
-    auto num_tensors = rc.getNumTensors();
-    for (auto i = 0u; i < num_tensors; ++i) {
-      shared_tensor_names.emplace_back(rc.getTensorName(i));
+    const auto &t_specs = init_context.getTensorsSpec();
+    for (auto i = 0u; i < t_specs.size(); ++i) {
+      shared_tensor_names.emplace_back(std::get<3>(t_specs.at(i)));
+      // std::cout << shared_tensor_names.back() << '\n';
+    }
+
+    const auto &w_specs = init_context.getWeightsSpec();
+    for (auto i = 0u; i < w_specs.size(); ++i) {
+      shared_weight_names.emplace_back(std::get<5>(w_specs.at(i)));
+      // std::cout << shared_weight_names.back() << '\n';
     }
   }
 

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -437,7 +437,7 @@ void NetworkGraph::applyGradientsOnLastAccess(
       continue;
     }
 
-    if (rc.isWeightDependent(i)) {
+    if (!rc.isGradientLastAccess(i)) {
       /// @note instead of checking the last access of the weight, checking
       /// if weights are dependent to others to minimize overhead.
       /// this logic assums that the source of the dependent weight must be
@@ -974,6 +974,7 @@ int NetworkGraph::initialize(
     auto const &lnode = getSortedLayerNode(idx);
     auto &rc = lnode->getRunContext();
     auto first_grad_access = std::get<1>(lnode->getExecutionOrder());
+    auto last_grad_access = std::get<2>(lnode->getExecutionOrder());
     for (unsigned i = 0; i < rc.getNumWeights(); ++i) {
       if (!rc.weightHasGradient(i)) {
         continue;
@@ -981,6 +982,10 @@ int NetworkGraph::initialize(
       if (tensor_manager->isFirstAccess(rc.getWeightGrad(i).getName(),
                                         first_grad_access)) {
         rc.getWeightObject(i).setAsGradientFirstAccess();
+      }
+      if (tensor_manager->isLastAccess(rc.getWeightGrad(i).getName(),
+                                       last_grad_access)) {
+        rc.getWeightObject(i).setAsGradientLastAccess();
       }
     }
   }

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -263,6 +263,10 @@ bool RunLayerContext::isGradientFirstAccess(unsigned int idx) const {
   return weights[idx]->isGradientFirstAccess();
 }
 
+bool RunLayerContext::isGradientLastAccess(unsigned int idx) const {
+  return weights[idx]->isGradientLastAccess();
+}
+
 /**
  * @brief Get the tensor name
  *

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -514,9 +514,17 @@ public:
    * @brief check current graident is first access
    *
    * @param idx index
-   * @return bool true if last access
+   * @return bool true if first access
    */
   bool isGradientFirstAccess(unsigned int idx) const;
+
+  /**
+   * @brief check current graident is last access
+   *
+   * @param idx index
+   * @return bool true if last access
+   */
+  bool isGradientLastAccess(unsigned int idx) const;
 
   /**
    * @brief Get the tensor name

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -511,7 +511,10 @@ public:
   bool isWeightDependent(unsigned int idx) const;
 
   /**
-   * @brief check current graident is first access
+   * @brief check current gradient is first access
+   * @note for now, it equivalent to weight last access, so this value is
+   * accessible for non-trainable weights as well. This is in terms of execution
+   * order.
    *
    * @param idx index
    * @return bool true if first access
@@ -519,7 +522,10 @@ public:
   bool isGradientFirstAccess(unsigned int idx) const;
 
   /**
-   * @brief check current graident is last access
+   * @brief check current gradient is last access
+   * @note for now, it equivalent to weight last access, so this value is
+   * accessible for non-trainable weights as well. This is in terms of execution
+   * order.
    *
    * @param idx index
    * @return bool true if last access

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -43,12 +43,13 @@ public:
    * @param dim Input dimensions for the layer
    */
   InitLayerContext(const std::vector<TensorDim> &dim, unsigned int num_out,
-                   bool in_place_, const std::string &n = "") :
+                   bool in_place_, const std::string &n = "",
+                   const std::string &prefix_ = "") :
     input_dim(dim),
     in_place(in_place_),
     num_outputs(num_out),
     name(n),
-    prefix("") {
+    prefix(prefix_) {
     NNTR_THROW_IF(!validate(), std::invalid_argument)
       << "Invalid init context name: " << name
       << " num inputs: " << getNumInputs();

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -449,9 +449,10 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims) {
     num_outputs = 1;
   }
 
+  auto scope = getSharedFrom().empty() ? getName() : getSharedFrom();
   auto init_context =
     InitLayerContext(actual_input_dims, num_outputs,
-                     executeInPlace() != InPlace::NONE, getName());
+                     executeInPlace() != InPlace::NONE, getName(), scope);
 
   layer->finalize(init_context);
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -361,23 +361,21 @@ void LayerNode::read(std::ifstream &file) {
   NNTR_THROW_IF(!run_context, std::runtime_error)
     << __func__ << " layer needs to be finalized first!";
   for (unsigned int i = 0; i < run_context->getNumWeights(); ++i) {
-    /// @note dependent weights are only be read at the source
-    if (!run_context->isGradientLastAccess(i)) {
-      continue;
+    /// @note shared weights are only be read at the first acecss
+    if (run_context->isGradientLastAccess(i)) {
+      run_context->getWeight(i).read(file);
     }
-    run_context->getWeight(i).read(file);
   }
 }
 
 void LayerNode::save(std::ofstream &file) const {
   NNTR_THROW_IF(!run_context, std::runtime_error)
     << __func__ << " layer needs to be finalized first!";
-  /// @note dependent weights are only be saved at the source
+  /// @note shared weights are only be saved at the first access
   for (unsigned int i = 0; i < run_context->getNumWeights(); ++i) {
-    if (!run_context->isGradientLastAccess(i)) {
-      continue;
+    if (run_context->isGradientLastAccess(i)) {
+      run_context->getWeight(i).save(file);
     }
-    run_context->getWeight(i).save(file);
   }
 }
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -362,7 +362,7 @@ void LayerNode::read(std::ifstream &file) {
     << __func__ << " layer needs to be finalized first!";
   for (unsigned int i = 0; i < run_context->getNumWeights(); ++i) {
     /// @note dependent weights are only be read at the source
-    if (run_context->isWeightDependent(i)) {
+    if (!run_context->isGradientLastAccess(i)) {
       continue;
     }
     run_context->getWeight(i).read(file);
@@ -374,7 +374,7 @@ void LayerNode::save(std::ofstream &file) const {
     << __func__ << " layer needs to be finalized first!";
   /// @note dependent weights are only be saved at the source
   for (unsigned int i = 0; i < run_context->getNumWeights(); ++i) {
-    if (run_context->isWeightDependent(i)) {
+    if (!run_context->isGradientLastAccess(i)) {
       continue;
     }
     run_context->getWeight(i).save(file);

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -527,22 +527,27 @@ Manager::requestOutputs(const GraphNode &node,
 }
 
 std::pair<unsigned int, unsigned int>
-Manager::getMinMaxTensorExecutionOrder(const std::string &name) {
-  auto orders = tensor_pool.getExecutionOrder(name);
+Manager::getMinMaxTensorExecutionOrder(const std::string &name,
+                                       bool is_weight) {
+
+  auto orders = is_weight ? weight_pool.getExecutionOrder(name)
+                          : tensor_pool.getExecutionOrder(name);
   auto [min_, max_] = std::minmax_element(orders.begin(), orders.end());
   return {*min_, *max_};
 }
 
-bool Manager::isFirstAccess(const std::string &name,
-                            unsigned current_execution) {
+bool Manager::isFirstAccess(const std::string &name, unsigned current_execution,
+                            bool is_weight) {
   /// @todo add cache machanism, eg) sort at finalizing requesting
-  return getMinMaxTensorExecutionOrder(name).first == current_execution;
+  return getMinMaxTensorExecutionOrder(name, is_weight).first ==
+         current_execution;
 }
 
-bool Manager::isLastAccess(const std::string &name,
-                           unsigned current_execution) {
+bool Manager::isLastAccess(const std::string &name, unsigned current_execution,
+                           bool is_weight) {
   /// @todo add cache machanism, eg) sort at finalizing requesting
-  return getMinMaxTensorExecutionOrder(name).second == current_execution;
+  return getMinMaxTensorExecutionOrder(name, is_weight).second ==
+         current_execution;
 }
 
 /**

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -232,28 +232,33 @@ public:
    * @brief Get the Min Max of a tensor execution order
    *
    * @param name name of the tensor
+   * @param is_weight check if this should be queried in weight pool
    * @return std::pair<unsigned int, unsigned int>
    */
   std::pair<unsigned int, unsigned int>
-  getMinMaxTensorExecutionOrder(const std::string &name);
+  getMinMaxTensorExecutionOrder(const std::string &name, bool is_weight);
 
   /**
    * @brief check if given execution order is the first access
    *
    * @param name tensor name
    * @param current_execution current execution
+   * @param is_weight check if this should be queried in weight pool
    * @return bool true if given execution order first access
    */
-  bool isFirstAccess(const std::string &name, unsigned current_execution);
+  bool isFirstAccess(const std::string &name, unsigned current_execution,
+                     bool is_weight = false);
 
   /**
    * @brief check if given execution order is the last access
    *
    * @param name tensor name
    * @param current_execution current execution
+   * @param is_weight check if this should be queried in weight pool
    * @return bool ture if given execution order is the last access
    */
-  bool isLastAccess(const std::string &name, unsigned current_execution);
+  bool isLastAccess(const std::string &name, unsigned current_execution,
+                    bool is_weight = false);
 
   /**
    * @brief   Check if the manager has allocated tensors

--- a/nntrainer/tensor/var_grad.cpp
+++ b/nntrainer/tensor/var_grad.cpp
@@ -22,7 +22,8 @@ Var_Grad::Var_Grad(const TensorDim &dim, const Tensor::Initializer init,
                    bool need_gradient, bool alloc_now,
                    const std::string &name) :
   is_dependent(false),
-  is_first_access_gradient(false) {
+  is_first_access_gradient(false),
+  is_last_access_gradient(false) {
   var = std::make_shared<Tensor>(dim, alloc_now, init, name);
 
   std::string grad_name = name + grad_suffix;

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -88,6 +88,7 @@ public:
                     bool is_dependent = false) :
     is_dependent(is_dependent),
     is_first_access_gradient(false),
+    is_last_access_gradient(false),
     var(
       std::make_shared<Tensor>(v.getSharedDataTensor(v.getDim(), 0, false, n))),
     grad(std::make_shared<Tensor>(n + grad_suffix)) {
@@ -106,6 +107,7 @@ public:
   explicit Var_Grad(Tensor *v, Tensor *g, bool is_dependent = false) :
     is_dependent(is_dependent),
     is_first_access_gradient(false),
+    is_last_access_gradient(false),
     var(std::shared_ptr<Tensor>(v, [](void *) {})),
     grad(std::shared_ptr<Tensor>(g, [](void *) {})) {
     if (!v)
@@ -268,6 +270,12 @@ public:
   void setAsGradientFirstAccess() { is_first_access_gradient = true; }
 
   /**
+   * @brief Set the As Gradient Last Access object
+   *
+   */
+  void setAsGradientLastAccess() { is_last_access_gradient = true; }
+
+  /**
    * @brief check if given weight at the last execution order
    * (first access of gradient)
    *
@@ -275,13 +283,23 @@ public:
    */
   bool isGradientFirstAccess() const { return is_first_access_gradient; }
 
+  /**
+   * @brief check if given weight at the first execution order (last access of
+   * gradient)
+   *
+   * @return bool true if last access
+   */
+  bool isGradientLastAccess() const { return is_last_access_gradient; }
+
   inline static const std::string grad_suffix = ":grad";
 
 protected:
   bool is_dependent; /**< check if the weight tensor is burrowed from somewhere
                         thus it is dependent */
-  bool is_first_access_gradient; /**< check if current weight tensor is last
+  bool is_first_access_gradient; /**< check if current weight tensor is first
                                     access */
+  bool is_last_access_gradient;  /**< check if current weight tensor is last
+   access */
 
   std::shared_ptr<Tensor> var;  /**< variable to be updated and used */
   std::shared_ptr<Tensor> grad; /**< gradient for the variable */

--- a/test/unittest/models/models_test_utils.cpp
+++ b/test/unittest/models/models_test_utils.cpp
@@ -113,9 +113,10 @@ public:
       auto const &lnode = *it;
       auto &rc = lnode->getRunContext();
       for (unsigned int i = 0; i < rc.getNumWeights(); ++i) {
-        if (rc.isWeightDependent(i)) {
+        if (!rc.isGradientLastAccess(i)) {
           continue;
         }
+
         Tensor &t = rc.getWeight(i);
         weights.push_back(t);
         expected_weights.push_back(t.clone());
@@ -187,7 +188,7 @@ NodeWatcher::NodeWatcher(const NodeType &node) : node(node) {
   for (unsigned int i = 0; i < num_weights; ++i) {
     // const nntrainer::Weight &w = node->getWeightObject(i);
     // expected_weights.push_back(w.clone());
-    if (!rc.isWeightDependent(i)) {
+    if (!rc.isGradientLastAccess(i)) {
       expected_weights.push_back(node->getWeightWrapper(i).clone());
     }
   }
@@ -206,7 +207,7 @@ NodeWatcher::NodeWatcher() : node(nullptr) {}
 void NodeWatcher::readLayerWeight(std::ifstream &f) {
   auto &rc = node->getRunContext();
   for (unsigned int i = 0; i < node->getNumWeights(); ++i) {
-    if (rc.isWeightDependent(i)) {
+    if (rc.isGradientLastAccess(i)) {
       continue;
     }
     node->getWeight(i).read(f);

--- a/test/unittest/models/models_test_utils.cpp
+++ b/test/unittest/models/models_test_utils.cpp
@@ -188,7 +188,7 @@ NodeWatcher::NodeWatcher(const NodeType &node) : node(node) {
   for (unsigned int i = 0; i < num_weights; ++i) {
     // const nntrainer::Weight &w = node->getWeightObject(i);
     // expected_weights.push_back(w.clone());
-    if (!rc.isGradientLastAccess(i)) {
+    if (rc.isGradientLastAccess(i)) {
       expected_weights.push_back(node->getWeightWrapper(i).clone());
     }
   }
@@ -208,9 +208,8 @@ void NodeWatcher::readLayerWeight(std::ifstream &f) {
   auto &rc = node->getRunContext();
   for (unsigned int i = 0; i < node->getNumWeights(); ++i) {
     if (rc.isGradientLastAccess(i)) {
-      continue;
+      node->getWeight(i).read(f);
     }
-    node->getWeight(i).read(f);
   }
 }
 

--- a/test/unittest/models/unittest_models_recurrent.cpp
+++ b/test/unittest/models/unittest_models_recurrent.cpp
@@ -44,6 +44,20 @@ IniWrapper fc_unroll_single(
     constant_loss,
   });
 
+IniWrapper fc_unroll_single__1(
+  "fc_unroll_single__1",
+  {
+    nn_base,
+    sgd_base + "learning_rate=0.1",
+    IniSection("fc_1") + fc_base +
+      "unit=1 | shared_from = fc_2 |input_shape=1:1:1",
+    IniSection("fc_2") + fc_base + "unit=1 | shared_from = fc_2",
+    IniSection("fc_3") + fc_base + "unit=1 | shared_from = fc_2",
+    IniSection("fc_4") + fc_base + "unit=1 | shared_from = fc_2",
+    IniSection("fc_5") + fc_base + "unit=1 | shared_from = fc_2",
+    constant_loss,
+  });
+
 std::unique_ptr<NeuralNetwork> makeFC() {
   std::unique_ptr<NeuralNetwork> nn(new NeuralNetwork());
   nn->setProperty({"batch_size=1"});
@@ -262,6 +276,8 @@ INSTANTIATE_TEST_CASE_P(
   recurrentModels, nntrainerModelTest,
   ::testing::ValuesIn({
     mkModelIniTc(fc_unroll_single, DIM_UNUSED, NOT_USED_,
+                 ModelTestOption::COMPARE_V2),
+    mkModelIniTc(fc_unroll_single__1, DIM_UNUSED, NOT_USED_,
                  ModelTestOption::COMPARE_V2),
     mkModelTc_V2(makeFC, "fc_unroll_stacked", ModelTestOption::COMPARE_V2),
     mkModelTc_V2(makeSingleLSTM, "lstm_single", ModelTestOption::COMPARE_V2),


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[QuickFix] Add not dependent weight sharing</summary><br />

This patch allows weight sharing regardless of allocation order of
weight sharing

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Weights] Add last access concept</summary><br />

As all weights are shared now, we need last accesss to be deteremined
This patch implements such behavior with a test

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[QuickFix] Check weight access for the last</summary><br />

This patch sets lastGradientAccess and firstGraidentAccess based on the
weight access order for non-trainable tensor.

This is a improviser and must be handled in a correct way.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

