### PR TITLE
[fixes] Fixes to layer and graph @open sesame 11/19 10:10

### DIFF
--- a/nntrainer/compiler/slice_realizer.cpp
+++ b/nntrainer/compiler/slice_realizer.cpp
@@ -9,6 +9,7 @@
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug No known bugs except for NYI items
  */
+
 #include <layer_node.h>
 #include <slice_realizer.h>
 
@@ -33,19 +34,15 @@ SliceRealizer::realize(const GraphRepresentation &reference) {
       to_be_added(false) {}
     std::shared_ptr<LayerNode> node; /**< set this if not visited */
     bool is_visited;                 /**< set this if visited */
-    bool to_be_added;                   /**< set this if it is to be added */
+    bool to_be_added;                /**< set this if it is to be added */
     std::vector<std::string> children;
-    std::vector<std::string> path;
-    /**< path is the tracing result from start to current node
-      eg) if traversal has started from a -> b -> c -> d.
-      The path has {"a", "b", "c", "d"} */
 
     LayerNode *operator->() { return node.get(); }
   };
 
   /** @note mp has to be ordered map to keep the ordering of the nodes in the
    * graph */
-  std::map<std::string, NodeInfo> mp; /// map point
+  std::unordered_map<std::string, NodeInfo> mp; /// map point
 
   std::transform(
     reference.begin(), reference.end(), std::inserter(mp, mp.end()),
@@ -86,61 +83,69 @@ SliceRealizer::realize(const GraphRepresentation &reference) {
   }
 
   if (cur_end_layers.empty()) {
-    throw std::runtime_error("No start layer is found, graph has a loop.");
+    throw std::runtime_error("No end layer is found, graph has a loop.");
   }
 
-  std::vector<std::string> dfs_stack(cur_start_layers.rbegin(),
-                                     cur_start_layers.rend());
+  std::vector<std::string> dfs_stack;
 
+  /** if the give node is the end node in the graph */
   auto is_end_node = [&cur_end_layers](const std::string &name) {
     auto iter = cur_end_layers.find(name);
     return iter != cur_end_layers.end();
   };
 
+  /** add node to be included to subgraph */
   auto update_processed = [&mp](const std::string &name) {
     auto &node_info = mp.at(name);
     node_info.to_be_added = true;
   };
 
-  while (!dfs_stack.empty()) {
-    auto &node_info = mp.at(dfs_stack.back());
-    dfs_stack.pop_back();
+  /** dfs function to perform depth-first search recursively with tracking */
+  std::function<void(const std::string &name)> dfs =
+    [&dfs, &mp, &dfs_stack, &is_end_node,
+     &update_processed](const std::string &name) {
+      auto &node_info = mp.at(name);
+      /** if node already added or end node, add the current stack to be added
+       * to the subgraph */
+      if (node_info.to_be_added || is_end_node(name)) {
+        std::for_each(dfs_stack.begin(), dfs_stack.end(), update_processed);
+        update_processed(name);
+      }
 
-    /** if end node or added, add the current stack */
-    if (node_info.to_be_added || is_end_node(node_info->getName())) {
-      node_info.to_be_added = true;
-      std::for_each(node_info.path.begin(), node_info.path.end(),
-                    update_processed);
-    }
+      /** if node is visited, return */
+      if (node_info.is_visited) {
+        return;
+      }
 
-    /** if already visited, skip */
-    if (node_info.is_visited) {
-      continue;
-    }
+      node_info.is_visited = true;
+      dfs_stack.push_back(name);
+      /** run dfs on all the children */
+      for (auto const &child : node_info.children) {
+        dfs(child);
+      }
+      dfs_stack.pop_back();
+    };
 
-    auto &path = node_info.path;
-    node_info.is_visited = true;
-    path.push_back(node_info->getName());
-
-    auto &children = node_info.children;
-    std::for_each(children.begin(), children.end(),
-                  [&path, &mp](const auto &name) { mp.at(name).path = path; });
-
-    dfs_stack.insert(dfs_stack.end(), children.begin(), children.end());
+  /** run dfs from all the starting layers */
+  for (auto &name : cur_start_layers) {
+    dfs(name);
   }
 
-  GraphRepresentation processed;
-  for (auto &node : mp) {
-    if (node.second.to_be_added) {
-      processed.push_back(node.second.node);
+  /** created the subgraph */
+  GraphRepresentation subgraph;
+  /** @note: iterate over reference than over mp to ensure the correct ordering
+   * of layers */
+  for (auto &node : reference) {
+    if (mp[node->getName()].to_be_added) {
+      subgraph.push_back(node);
     }
   }
 
-  NNTR_THROW_IF(processed.empty(), std::invalid_argument)
+  NNTR_THROW_IF(subgraph.empty(), std::invalid_argument)
     << "After slice, there is no node left, please check if configuration is "
        "correct";
 
-  return processed;
+  return subgraph;
 }
 
 } // namespace nntrainer

--- a/nntrainer/compiler/slice_realizer.cpp
+++ b/nntrainer/compiler/slice_realizer.cpp
@@ -30,10 +30,10 @@ SliceRealizer::realize(const GraphRepresentation &reference) {
     NodeInfo(std::shared_ptr<LayerNode> node) :
       node(node),
       is_visited(false),
-      is_added(false) {}
+      to_be_added(false) {}
     std::shared_ptr<LayerNode> node; /**< set this if not visited */
     bool is_visited;                 /**< set this if visited */
-    bool is_added;                   /**< set this if added */
+    bool to_be_added;                   /**< set this if it is to be added */
     std::vector<std::string> children;
     std::vector<std::string> path;
     /**< path is the tracing result from start to current node
@@ -43,7 +43,10 @@ SliceRealizer::realize(const GraphRepresentation &reference) {
     LayerNode *operator->() { return node.get(); }
   };
 
-  std::unordered_map<std::string, NodeInfo> mp; /// map point
+  /** @note mp has to be ordered map to keep the ordering of the nodes in the
+   * graph */
+  std::map<std::string, NodeInfo> mp; /// map point
+
   std::transform(
     reference.begin(), reference.end(), std::inserter(mp, mp.end()),
     [](std::shared_ptr<LayerNode> node) {
@@ -53,22 +56,7 @@ SliceRealizer::realize(const GraphRepresentation &reference) {
   auto cur_start_layers = start_layers;
   auto cur_end_layers = end_layers;
 
-  if (start_layers.empty()) {
-    for (auto &node : reference) {
-      if (node->getNumInputConnections() == 0) {
-        cur_start_layers.push_back(node->getName());
-      }
-    }
-  }
-
-  if (end_layers.empty()) {
-    for (auto &node : mp) {
-      if (node.second.children.size() == 0) {
-        cur_end_layers.insert(node.first);
-      }
-    }
-  }
-
+  /** setup children before filling in the end layers */
   std::for_each(reference.begin(), reference.end(),
                 [&mp](std::shared_ptr<LayerNode> node) {
                   auto node_name = node->getName();
@@ -77,15 +65,29 @@ SliceRealizer::realize(const GraphRepresentation &reference) {
                   };
                 });
 
-  GraphRepresentation processed;
-
-  auto update_processed = [&processed, &mp](const std::string &name) {
-    auto &node_info = mp.at(name);
-    if (!node_info.is_added) {
-      processed.push_back(node_info.node);
-      node_info.is_added = true;
+  if (cur_start_layers.empty()) {
+    for (auto &node : mp) {
+      if (node.second.node->getNumInputConnections() == 0) {
+        cur_start_layers.push_back(node.second.node->getName());
+      }
     }
-  };
+  }
+
+  if (cur_end_layers.empty()) {
+    for (auto &node : mp) {
+      if (node.second.children.size() == 0) {
+        cur_end_layers.insert(node.first);
+      }
+    }
+  }
+
+  if (cur_start_layers.empty()) {
+    throw std::runtime_error("No start layer is found, graph has a loop.");
+  }
+
+  if (cur_end_layers.empty()) {
+    throw std::runtime_error("No start layer is found, graph has a loop.");
+  }
 
   std::vector<std::string> dfs_stack(cur_start_layers.rbegin(),
                                      cur_start_layers.rend());
@@ -95,23 +97,43 @@ SliceRealizer::realize(const GraphRepresentation &reference) {
     return iter != cur_end_layers.end();
   };
 
+  auto update_processed = [&mp](const std::string &name) {
+    auto &node_info = mp.at(name);
+    node_info.to_be_added = true;
+  };
+
   while (!dfs_stack.empty()) {
     auto &node_info = mp.at(dfs_stack.back());
-    auto &path = node_info.path;
-    path.push_back(node_info->getName());
-    if (is_end_node(node_info->getName())) {
-      std::for_each(path.begin(), path.end(), update_processed);
+    dfs_stack.pop_back();
+
+    /** if end node or added, add the current stack */
+    if (node_info.to_be_added || is_end_node(node_info->getName())) {
+      node_info.to_be_added = true;
+      std::for_each(node_info.path.begin(), node_info.path.end(),
+                    update_processed);
     }
 
-    dfs_stack.pop_back();
+    /** if already visited, skip */
+    if (node_info.is_visited) {
+      continue;
+    }
+
+    auto &path = node_info.path;
     node_info.is_visited = true;
+    path.push_back(node_info->getName());
 
     auto &children = node_info.children;
     std::for_each(children.begin(), children.end(),
                   [&path, &mp](const auto &name) { mp.at(name).path = path; });
 
-    /// @todo: stop inserting to the dfs stack if children->isAdded == true
-    dfs_stack.insert(dfs_stack.end(), children.rbegin(), children.rend());
+    dfs_stack.insert(dfs_stack.end(), children.begin(), children.end());
+  }
+
+  GraphRepresentation processed;
+  for (auto &node : mp) {
+    if (node.second.to_be_added) {
+      processed.push_back(node.second.node);
+    }
   }
 
   NNTR_THROW_IF(processed.empty(), std::invalid_argument)

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -194,4 +194,10 @@ void ConcatLayer::setProperty(const std::vector<std::string> &values) {
          std::to_string(values.size());
 }
 
+void ConcatLayer::exportTo(Exporter &exporter,
+                           const ExportMethods &method) const {
+  Layer::exportTo(exporter, method);
+  exporter.saveResult(concat_props, method, this);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -68,6 +68,11 @@ public:
   const std::string getType() const override { return ConcatLayer::type; };
 
   /**
+   * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
+   */
+  void exportTo(Exporter &exporter, const ExportMethods &method) const override;
+
+  /**
    * @copydoc Layer::supportBackwarding()
    */
   bool supportBackwarding() const override { return true; }

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -163,10 +163,10 @@ TEST(SliceRealizer, slice_p) {
   std::vector<LayerRepresentation> after = {
     {"fully_connected", {"name=a1"}},
     {"fully_connected", {"name=b1", "input_layers=a1"}},
+    {"fully_connected", {"name=b2", "input_layers=a2"}},
     {"fully_connected", {"name=c1", "input_layers=b1,b2"}},
     {"fully_connected", {"name=d1", "input_layers=c1"}},
     {"fully_connected", {"name=d2", "input_layers=c1"}},
-    {"fully_connected", {"name=b2", "input_layers=a2"}},
   };
 
   SliceRealizer r({"a1", "b1", "b2"}, {"a1", "d1", "d2"});

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -123,7 +123,7 @@ TEST(RemapRealizer, remap_p) {
   realizeAndEqual(r, {input1}, {expected1});
 }
 
-TEST(SliceRealizer, slice_p) {
+TEST(SliceRealizer, slice_01_p) {
   /**
    * graph architecture
    *
@@ -170,6 +170,40 @@ TEST(SliceRealizer, slice_p) {
   };
 
   SliceRealizer r({"a1", "b1", "b2"}, {"a1", "d1", "d2"});
+
+  realizeAndEqual(r, before, after);
+}
+
+TEST(SliceRealizer, slice_02_p) {
+  /**
+   * graph architecture
+   *
+   * a1----
+   *  |   |
+   * b1   |
+   *  \  /
+   *   c1
+   */
+  std::vector<LayerRepresentation> before = {
+    {"fully_connected", {"name=a1"}},
+    {"fully_connected", {"name=b1", "input_layers=a1"}},
+    {"concat", {"name=c1", "input_layers=a1, b1"}},
+  };
+
+  /**
+   * a1----
+   *  |   |
+   * b1   |
+   *  \  /
+   *   c1
+   */
+  std::vector<LayerRepresentation> after = {
+    {"fully_connected", {"name=a1"}},
+    {"fully_connected", {"name=b1", "input_layers=a1"}},
+    {"concat", {"name=c1", "input_layers=a1, b1"}},
+  };
+
+  SliceRealizer r({"a1"}, {"c1"});
 
   realizeAndEqual(r, before, after);
 }

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -942,6 +942,7 @@ TEST(nntrainerModels, loadFromLayersBackbone_p) {
   nn.addWithReferenceLayers(reference, "backbone", {}, {"fc1"}, {"fc2"},
                             ml::train::ReferenceLayersType::BACKBONE, {});
 
+  nn.compile();
   auto graph = nn.getFlatGraph();
   for (unsigned int i = 0; i < graph.size(); ++i) {
     EXPECT_EQ(graph.at(i)->getName(), "backbone/" + reference.at(i)->getName());


### PR DESCRIPTION
- Concat layer has properties which were not being saved. This patch adds
the corresponding support.
- Below bugs have been fixed for the slice realizer:
  - end layers were being added using children which were not set yet
  - the dfs_stack never ignored nodes which had already been visited which
was leading to infinite loop
  - an invalid graph given with loops would be stuck in infinite loop in
the DFS
- Slice realizer was storing the path for each node from the start nodes
to themselves. This can be big, and also comes with a overhead of
storing and copying these paths for each node.
This patch updates the implementation of the dfs to a recursive approach
which maintains the stack of the nodes in the memory which represents
the path till now.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>