### PR TITLE
[nn] Apply previous input realizer

### DIFF
--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -167,6 +167,13 @@ public:
    * @note This method does add the provided layers itself but adds a deep copy
    * of the passed layers to the model. The layers passed to this function can
    * be reused later.
+   * @note @a reference is a set of layers connected each other to form a part
+   * or whole graph which can be loaded to a model and can be run.
+   * More specifically, the graph with a non cyclic, directed graph with all
+   * node has either incoming or outgoing connection defined when considering
+   * non-input layer is directly connected to the previous layer. 'input
+   * layer' is defined as a layer that has no incoming connection and
+   * (identified as @a start_layers or input shape is specified explicitly).
    *
    * @param reference a group of layers being referred to.
    * @param type type of reference layers

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -196,6 +196,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/ini_interpreter.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/flatten_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/recurrent_realizer.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/compiler/previous_input_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/remap_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/slice_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/input_realizer.cpp \

--- a/nntrainer/compiler/flatten_realizer.cpp
+++ b/nntrainer/compiler/flatten_realizer.cpp
@@ -33,6 +33,7 @@ FlattenRealizer::realize(const GraphRepresentation &reference) {
         createLayerNode(FlattenLayer::type, {"name=" + layer_name});
       node->setProperty({"flatten=false"});
       node->setProperty({"name=" + layer_name + "/flatten_realized"});
+      flatten_node->setProperty({"input_layers=" + node->getName()});
       processed.push_back(std::move(flatten_node));
     }
   }

--- a/nntrainer/compiler/meson.build
+++ b/nntrainer/compiler/meson.build
@@ -4,7 +4,8 @@ compiler_sources = [
   'recurrent_realizer.cpp',
   'remap_realizer.cpp',
   'slice_realizer.cpp',
-  'input_realizer.cpp'
+  'input_realizer.cpp',
+  'previous_input_realizer.cpp'
 ]
 
 compiler_headers = []

--- a/nntrainer/compiler/previous_input_realizer.cpp
+++ b/nntrainer/compiler/previous_input_realizer.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file previous_input_realizer.cpp
+ * @date 18 November 2021
+ * @brief NNTrainer graph realizer which connects input to previous one if empty
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <compiler_fwd.h>
+#include <memory>
+#include <vector>
+
+#include <previous_input_realizer.h>
+
+namespace nntrainer {
+
+PreviousInputRealizer::PreviousInputRealizer(
+  const std::vector<std::string> &identified_input) {}
+
+PreviousInputRealizer::~PreviousInputRealizer() {}
+
+GraphRepresentation
+PreviousInputRealizer::realize(const GraphRepresentation &reference) {
+  return GraphRepresentation();
+}
+
+} // namespace nntrainer

--- a/nntrainer/compiler/previous_input_realizer.cpp
+++ b/nntrainer/compiler/previous_input_realizer.cpp
@@ -9,22 +9,64 @@
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug No known bugs except for NYI items
  */
+#include <algorithm>
 #include <compiler_fwd.h>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 
+#include <layer_node.h>
+#include <nntrainer_log.h>
 #include <previous_input_realizer.h>
 
 namespace nntrainer {
 
 PreviousInputRealizer::PreviousInputRealizer(
-  const std::vector<std::string> &identified_input) {}
+  const std::vector<std::string> &identified_inputs_) :
+  identified_inputs(identified_inputs_) {}
 
 PreviousInputRealizer::~PreviousInputRealizer() {}
 
 GraphRepresentation
 PreviousInputRealizer::realize(const GraphRepresentation &reference) {
-  return GraphRepresentation();
+  GraphRepresentation processed(reference.begin(), reference.end());
+
+  /**
+   * @brief for node has input connection, below function determines if the node
+   * should be input node or add input_layers from previous layer
+   *
+   */
+  auto is_actually_an_input_node = [this](const LayerNode &node) {
+    return node.hasInputShapeProperty() or
+           std::any_of(identified_inputs.begin(), identified_inputs.end(),
+                       [&node](auto &name) { return node.getName() == name; });
+  };
+
+  for (auto iter = processed.begin(); iter != processed.end(); ++iter) {
+    auto &node = *iter;
+    if (node->getNumInputConnections() != 0) {
+      continue;
+    }
+
+    if (is_actually_an_input_node(*node)) {
+      continue;
+    }
+
+    NNTR_THROW_IF(iter == processed.begin(), std::invalid_argument)
+      << "First node must be identified as an input if it is qualified to be "
+         "input, name: "
+      << node->getName();
+
+    auto &prev_node = *(iter - 1);
+    ml_logi(
+      "%s is identified as a non-input node and default input layer(%s) is "
+      "being set ",
+      node->getName().c_str(), prev_node->getName().c_str());
+
+    node->setInputLayers({prev_node->getName()});
+  }
+
+  return processed;
 }
 
 } // namespace nntrainer

--- a/nntrainer/compiler/previous_input_realizer.h
+++ b/nntrainer/compiler/previous_input_realizer.h
@@ -30,10 +30,10 @@ public:
   /**
    * @brief Construct a new Previous Input Realizer object
    *
-   * @param identified_input node that is identified as an input, this must not
+   * @param identified_inputs node that is identified as an input, this must not
    * connect to other nodes automatically
    */
-  PreviousInputRealizer(const std::vector<std::string> &identified_input);
+  PreviousInputRealizer(const std::vector<std::string> &identified_inputs);
 
   /**
    * @brief Destroy the Graph Realizer object
@@ -46,6 +46,9 @@ public:
    *
    */
   GraphRepresentation realize(const GraphRepresentation &reference) override;
+
+private:
+  std::vector<std::string> identified_inputs; /**< inputs are identified */
 };
 
 } // namespace nntrainer

--- a/nntrainer/compiler/previous_input_realizer.h
+++ b/nntrainer/compiler/previous_input_realizer.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file previous_input_realizer.h
+ * @date 18 November 2021
+ * @brief NNTrainer graph realizer which connects input to previous one if empty
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#ifndef __PREVIOUS_INPUT_REALIZER_H__
+#define __PREVIOUS_INPUT_REALIZER_H__
+
+#include <memory>
+#include <vector>
+
+#include <realizer.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Add default inputs if input connection is empty.
+ * if a node is identified as input with @a identified_input by user or a node
+ * has input_shape property, adding input behavior is skipped
+ *
+ */
+class PreviousInputRealizer final : public GraphRealizer {
+public:
+  /**
+   * @brief Construct a new Previous Input Realizer object
+   *
+   * @param identified_input node that is identified as an input, this must not
+   * connect to other nodes automatically
+   */
+  PreviousInputRealizer(const std::vector<std::string> &identified_input);
+
+  /**
+   * @brief Destroy the Graph Realizer object
+   *
+   */
+  ~PreviousInputRealizer();
+
+  /**
+   * @brief graph realizer creates a new graph based on the reference
+   *
+   */
+  GraphRepresentation realize(const GraphRepresentation &reference) override;
+};
+
+} // namespace nntrainer
+
+#endif // __PREVIOUS_INPUT_REALIZER_H__

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -96,19 +96,6 @@ void NetworkGraph::updateConnectionName(const std::string &from,
   }
 }
 
-void NetworkGraph::addDefaultInputLayers() {
-  for (auto iter = cbegin() + 1; iter != cend(); iter++) {
-    auto layer = *iter;
-    auto prev_layer = *(iter - 1);
-    if (layer->getNumInputConnections() == 0 &&
-        !layer->hasInputShapeProperty()) {
-      ml_logd("default input added %s->%s", prev_layer->getName().c_str(),
-              layer->getName().c_str());
-      layer->addInputLayers(prev_layer->getName());
-    }
-  }
-}
-
 void NetworkGraph::addLayerNode(std::unique_ptr<Layer> layer) {
   graph.addNode(std::make_unique<LayerNode>(std::move(layer)));
 }
@@ -332,8 +319,6 @@ void NetworkGraph::markNodesForBackwarding() {
 
 int NetworkGraph::realizeGraph() {
   int status = ML_ERROR_NONE;
-
-  addDefaultInputLayers();
 
   /**
    * invariant: the new realized nodes are added to the end,

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -445,11 +445,6 @@ private:
   void setOutputLayers();
 
   /**
-   * @brief     set default input layer connections
-   */
-  void addDefaultInputLayers();
-
-  /**
    * @brief     Ensure that layer has a name.
    * @param[in] layer Layer whose name is to be ensured to be valid
    * @param[in] prefix Prefix to be attached to the layer name

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -37,6 +37,7 @@
 #include <nntrainer_log.h>
 #include <node_exporter.h>
 #include <optimizer_context.h>
+#include <previous_input_realizer.h>
 #include <profiler.h>
 #include <recurrent_realizer.h>
 #include <remap_realizer.h>
@@ -103,6 +104,16 @@ int NeuralNetwork::compile() {
                             ? std::string()
                             : std::get<props::LossType>(model_props);
 
+  auto &input_layer_prop =
+    std::get<std::vector<props::InputLayer>>(model_props);
+  /// @note label layer might need to be treated in the similar way as well
+
+  std::vector<std::string> input_layers = {};
+  if (!input_layer_prop.empty()) {
+    input_layers = std::vector<std::string>(input_layer_prop.begin(),
+                                            input_layer_prop.end());
+  }
+
   /// @todo make NetworkGraph compiled at the construction instead of having
   /// graph.compile(), neuralnetwork have ownership of list of layer nodes,
   /// which will be passed at compile time.
@@ -112,8 +123,14 @@ int NeuralNetwork::compile() {
     rep.push_back(*iter);
   }
 
-  FlattenRealizer fr;
-  rep = fr.realize(rep);
+  std::vector<std::unique_ptr<GraphRealizer>> realizers;
+
+  realizers.emplace_back(new PreviousInputRealizer(input_layers));
+  realizers.emplace_back(new FlattenRealizer());
+
+  for (auto &realizer : realizers) {
+    rep = realizer->realize(rep);
+  }
 
   model_graph = NetworkGraph();
   model_graph.setMemoryOptimizations(
@@ -705,7 +722,7 @@ int NeuralNetwork::train_run() {
     forwarding(false);
   };
 
-  auto update_eval_stat = [this, batch_size, &update_train_stat](
+  auto update_eval_stat = [batch_size, &update_train_stat](
                             RunStats &stat, const std::vector<Tensor> &outputs,
                             const std::vector<Tensor> &labels) {
     auto model_out = outputs[0].argmax();
@@ -935,6 +952,8 @@ void NeuralNetwork::addWithReferenceLayers(
   auto end_layers_ = normalize(end_layers);
 
   std::vector<std::unique_ptr<GraphRealizer>> realizers;
+
+  realizers.emplace_back(new PreviousInputRealizer(start_layers));
   realizers.emplace_back(new SliceRealizer(start_layers_, end_layers_));
 
   if (!input_layers_.empty()) {

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -134,8 +134,8 @@ TEST(nntrainerInterpreterTflite, simple_fc) {
                         "bias_initializer=ones", "weight_initializer=ones"});
 
   auto fc1_zeroed = LayerRepresentation(
-    "fully_connected",
-    {"name=fc1", "unit=2", "bias_initializer=ones", "weight_initializer=ones"});
+    "fully_connected", {"name=fc1", "unit=2", "bias_initializer=ones",
+                        "weight_initializer=ones", "input_layers=fc0"});
 
   auto g = makeGraph({fc0_zeroed, fc1_zeroed});
 

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -197,7 +197,7 @@ TEST(InputRealizer, remap_p) {
   realizeAndEqual(r, before, after);
 }
 
-TEST(PreviousInputRealizer, DISABLED_previous_p) {
+TEST(PreviousInputRealizer, previous_p) {
   { /// realization without identifying custom input
     std::vector<LayerRepresentation> before = {
       {"fully_connected", {"name=fc1", "input_shape=1"}}, // model input
@@ -233,7 +233,7 @@ TEST(PreviousInputRealizer, DISABLED_previous_p) {
   }
 }
 
-TEST(PreviousInputRealizer, DISABLED_user_not_identifying_first_input_n) {
+TEST(PreviousInputRealizer, user_not_identifying_first_input_n) {
   /// realization without identifying custom input
   std::vector<LayerRepresentation> before = {
     {"fully_connected", {"name=fc1"}}, // this should be model input but

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -232,6 +232,24 @@ TEST(PreviousInputRealizer, previous_p) {
     PreviousInputRealizer r({"fc1", "fc4"});
     realizeAndEqual(r, before, after);
   }
+  { /// intermediate node is auto input
+    std::vector<LayerRepresentation> before = {
+      {"fully_connected",
+       {"name=fc1", "input_layers=fc2"}},                 // intermediate node
+      {"fully_connected", {"name=fc2", "input_shape=1"}}, // model input
+      {"fully_connected", {"name=fc3"}}, // auto connected to fc3
+      {"fully_connected", {"name=fc4"}}, // auto connected to fc 3
+    };
+
+    std::vector<LayerRepresentation> after = {
+      {"fully_connected", {"name=fc1", "input_layers=fc2"}},
+      {"fully_connected", {"name=fc2", "input_shape=1"}},
+      {"fully_connected", {"name=fc3", "input_layers=fc2"}},
+      {"fully_connected", {"name=fc4", "input_layers=fc3"}},
+    };
+    PreviousInputRealizer r({});
+    realizeAndEqual(r, before, after);
+  }
 }
 
 TEST(PreviousInputRealizer, user_not_identifying_first_input_n) {

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -49,7 +49,8 @@ TEST(FlattenRealizer, flatten_p) {
                                 {"name=layer1", "flatten=true"}};
   LayerRepresentation expected1 = {"fully_connected",
                                    {"name=layer1/flatten_realized"}};
-  LayerRepresentation expected2 = {"flatten", {"name=layer1"}};
+  LayerRepresentation expected2 = {
+    "flatten", {"name=layer1", "input_layers=layer1/flatten_realized"}};
 
   realizeAndEqual(fr, {input1}, {expected1, expected2});
 }

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -16,6 +16,7 @@
 
 #include <flatten_realizer.h>
 #include <input_realizer.h>
+#include <previous_input_realizer.h>
 #include <realizer.h>
 #include <recurrent_realizer.h>
 #include <remap_realizer.h>
@@ -195,4 +196,14 @@ TEST(InputRealizer, remap_p) {
 
   InputRealizer r({"fc1", "fc2", "fc3"}, {"in1", "in2", "in3", "in4"});
   realizeAndEqual(r, before, after);
+}
+
+TEST(PreviousInputRealizer, previous_p) {
+  {
+    std::vector<LayerRepresentation> before = {};
+
+    std::vector<LayerRepresentation> after = {};
+    PreviousInputRealizer r({});
+    realizeAndEqual(r, before, after);
+  }
 }

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -176,7 +176,6 @@ TEST(SliceRealizer, slice_p) {
 }
 
 TEST(InputRealizer, remap_p) {
-
   std::vector<LayerRepresentation> before = {
     {"fully_connected", {"name=fc1"}}, // no input_layers specified
     {"fully_connected",
@@ -198,12 +197,51 @@ TEST(InputRealizer, remap_p) {
   realizeAndEqual(r, before, after);
 }
 
-TEST(PreviousInputRealizer, previous_p) {
-  {
-    std::vector<LayerRepresentation> before = {};
+TEST(PreviousInputRealizer, DISABLED_previous_p) {
+  { /// realization without identifying custom input
+    std::vector<LayerRepresentation> before = {
+      {"fully_connected", {"name=fc1", "input_shape=1"}}, // model input
+      {"fully_connected", {"name=fc2"}}, // auto connected to fc 1
+      {"fully_connected", {"name=fc3", "input_layers=fc1"}},
+      {"fully_connected", {"name=fc4"}}, // auto connected to fc 3
+    };
 
-    std::vector<LayerRepresentation> after = {};
+    std::vector<LayerRepresentation> after = {
+      {"fully_connected", {"name=fc1", "input_shape=1"}},
+      {"fully_connected", {"name=fc2", "input_layers=fc1"}},
+      {"fully_connected", {"name=fc3", "input_layers=fc1"}},
+      {"fully_connected", {"name=fc4", "input_layers=fc3"}},
+    };
     PreviousInputRealizer r({});
     realizeAndEqual(r, before, after);
   }
+  { /// realization identifying fc1, fc4 is input layer
+    std::vector<LayerRepresentation> before = {
+      {"fully_connected", {"name=fc1"}}, // will be identified as model input
+      {"fully_connected", {"name=fc2"}}, // auto connected to fc 1
+      {"fully_connected", {"name=fc3", "input_layers=fc1"}},
+      {"fully_connected", {"name=fc4"}}, // will be identified as model input
+    };
+    std::vector<LayerRepresentation> after = {
+      {"fully_connected", {"name=fc1"}},
+      {"fully_connected", {"name=fc2", "input_layers=fc1"}},
+      {"fully_connected", {"name=fc3", "input_layers=fc1"}},
+      {"fully_connected", {"name=fc4"}},
+    };
+    PreviousInputRealizer r({"fc1", "fc4"});
+    realizeAndEqual(r, before, after);
+  }
+}
+
+TEST(PreviousInputRealizer, DISABLED_user_not_identifying_first_input_n) {
+  /// realization without identifying custom input
+  std::vector<LayerRepresentation> before = {
+    {"fully_connected", {"name=fc1"}}, // this should be model input but
+                                       // nothing has been connected
+    {"fully_connected", {"name=fc2"}}, // auto connected to fc 1
+    {"fully_connected", {"name=fc3", "input_layers=fc1"}},
+    {"fully_connected", {"name=fc4"}}, // auto connected to fc 3
+  };
+  PreviousInputRealizer r({});
+  EXPECT_ANY_THROW(realizeAndEqual(r, before, {}));
 }


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Scaffolding] previous input realizer</summary><br />

This patch implements previous input realizer.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Realizer] Implement previous input realizer test</summary><br />

This patch implement previous input realizer test to demonstrate
specification of previout input realizer

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Realizer] Implement previous input realizer</summary><br />

This patch implement previous input realizer.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Fix] Flatten realizer to not rely on default Layer Addition</summary><br />

As default layer add happens before realizer, flatten layer must not
depend on the layer adding behavior.

This patch fixes flatten realizer to not depend.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[nn] Apply previous input realizer</summary><br />

This patch applies previous input realizer.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

