### PR TITLE
 [layer devel] clean up header dependency

### DIFF
--- a/Applications/Custom/mae_loss.cpp
+++ b/Applications/Custom/mae_loss.cpp
@@ -14,6 +14,7 @@
 
 #include <cmath>
 
+#include <iostream>
 #include <tensor.h>
 
 constexpr const float EPSILON_ = 1e-7;

--- a/Applications/Custom/rnnt_loss.cpp
+++ b/Applications/Custom/rnnt_loss.cpp
@@ -14,6 +14,7 @@
 
 #include <cmath>
 
+#include <iostream>
 #include <tensor.h>
 
 constexpr const float EPSILON_ = 1e-7;

--- a/Applications/ReinforcementLearning/Environment/CartPole/cartpole.cpp
+++ b/Applications/ReinforcementLearning/Environment/CartPole/cartpole.cpp
@@ -21,6 +21,7 @@
  *
  */
 #include "cartpole.h"
+#include <iostream>
 #include <stdlib.h>
 
 #define M_PI 3.14159265358979323846

--- a/Applications/ReinforcementLearning/Environment/CartPole/cartpole.h
+++ b/Applications/ReinforcementLearning/Environment/CartPole/cartpole.h
@@ -24,7 +24,7 @@
 #define __CARTPOLE_H__
 
 #include <cmath>
-#include <iostream>
+#include <string>
 #include <vector>
 
 /**

--- a/Applications/Resnet/jni/cifar_dataloader.cpp
+++ b/Applications/Resnet/jni/cifar_dataloader.cpp
@@ -13,6 +13,7 @@
 #include "cifar_dataloader.h"
 
 #include <cstring>
+#include <iostream>
 #include <nntrainer_error.h>
 #include <random>
 

--- a/Applications/TransferLearning/Draw_Classification/jni/main.cpp
+++ b/Applications/TransferLearning/Draw_Classification/jni/main.cpp
@@ -29,6 +29,7 @@
 #define APP_VALIDATE
 #endif
 
+#include <iostream>
 #include <limits.h>
 #include <stdlib.h>
 #include <time.h>

--- a/Applications/utils/jni/bitmap_helpers.cpp
+++ b/Applications/utils/jni/bitmap_helpers.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <iostream>
 
 #include <unistd.h> // NOLINT(build/include_order)
 

--- a/Applications/utils/jni/includes/bitmap_helpers.h
+++ b/Applications/utils/jni/includes/bitmap_helpers.h
@@ -19,7 +19,7 @@ limitations under the License.
 #ifndef TENSORFLOW_CONTRIB_LITE_EXAMPLES_LABEL_IMAGE_BITMAP_HELPERS_H_
 #define TENSORFLOW_CONTRIB_LITE_EXAMPLES_LABEL_IMAGE_BITMAP_HELPERS_H_
 #include <cstdint>
-#include <iostream>
+#include <string>
 namespace tflite {
 namespace label_image {
 uint8_t *read_bmp(const std::string &input_bmp_name, int *width, int *height,

--- a/api/ccapi/include/tensor_dim.h
+++ b/api/ccapi/include/tensor_dim.h
@@ -17,7 +17,7 @@
 #ifdef __cplusplus
 
 #include <array>
-#include <iostream>
+#include <iosfwd>
 
 #include <bitset>
 #include <vector>

--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -45,6 +45,14 @@ static constexpr const char *OPTIMIZER_STR = "optimizer";
 
 namespace nntrainer {
 
+IniGraphInterpreter::IniGraphInterpreter(
+  const AppContext &app_context_,
+  std::function<const std::string(const std::string &)> pathResolver_) :
+  app_context(app_context_),
+  pathResolver(pathResolver_) {}
+
+IniGraphInterpreter::~IniGraphInterpreter() {}
+
 namespace {
 
 /** @todo:

--- a/nntrainer/compiler/ini_interpreter.h
+++ b/nntrainer/compiler/ini_interpreter.h
@@ -13,7 +13,6 @@
 #ifndef __INI_INTERPRETER_H__
 #define __INI_INTERPRETER_H__
 
-#include <iostream>
 #include <memory>
 #include <string>
 
@@ -38,15 +37,13 @@ public:
   IniGraphInterpreter(
     const AppContext &app_context_ = AppContext::Global(),
     std::function<const std::string(const std::string &)> pathResolver_ =
-      [](const std::string &path) { return path; }) :
-    app_context(app_context_),
-    pathResolver(pathResolver_) {}
+      [](const std::string &path) { return path; });
 
   /**
    * @brief Destroy the Ini Graph Interpreter object
    *
    */
-  virtual ~IniGraphInterpreter(){};
+  virtual ~IniGraphInterpreter();
 
   /**
    * @copydoc GraphInterpreter::serialize(const GraphRepresentation

--- a/nntrainer/dataset/databuffer.cpp
+++ b/nntrainer/dataset/databuffer.cpp
@@ -29,6 +29,7 @@
 #include <func_data_producer.h>
 #include <functional>
 #include <iomanip>
+#include <iostream>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -16,7 +16,6 @@
 #define __GRAPH_CORE_H__
 #ifdef __cplusplus
 
-#include <iostream>
 #include <list>
 #include <map>
 #include <memory>

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -15,7 +15,6 @@
 #define __NETWORK_GRAPH_H__
 #ifdef __cplusplus
 
-#include <iostream>
 #include <list>
 #include <map>
 #include <memory>

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -21,7 +21,7 @@
 #include <activation_layer.h>
 #include <blas_interface.h>
 #include <common_properties.h>
-#include <lazy_tensor.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -16,6 +16,8 @@
 #include <nntrainer_log.h>
 #include <util_func.h>
 
+#include <layer_context.h>
+
 namespace nntrainer {
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;

--- a/nntrainer/layers/attention_layer.cpp
+++ b/nntrainer/layers/attention_layer.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <attention_layer.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <bn_layer.h>
+#include <layer_context.h>
 #include <lazy_tensor.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -28,6 +28,7 @@
 #include <functional>
 #include <vector>
 
+#include <common_properties.h>
 #include <layer_devel.h>
 
 namespace nntrainer {

--- a/nntrainer/layers/centroid_knn.cpp
+++ b/nntrainer/layers/centroid_knn.cpp
@@ -18,6 +18,7 @@
 #include <sstream>
 
 #include <centroid_knn.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/nntrainer/layers/centroid_knn.h
+++ b/nntrainer/layers/centroid_knn.h
@@ -16,7 +16,6 @@
 #include <string>
 
 #include <common_properties.h>
-#include <layer_context.h>
 #include <layer_devel.h>
 
 namespace nntrainer {

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -14,6 +14,7 @@
 
 #include <concat_layer.h>
 #include <cstring>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -15,8 +15,9 @@
 #define __CONCAT_LAYER_H__
 #ifdef __cplusplus
 
+#include <common_properties.h>
 #include <layer_devel.h>
-
+#include <tensor_dim.h>
 namespace nntrainer {
 
 /**

--- a/nntrainer/layers/conv1d_layer.cpp
+++ b/nntrainer/layers/conv1d_layer.cpp
@@ -17,6 +17,8 @@
 #include <string>
 
 #include <conv1d_layer.h>
+#include <conv2d_layer.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>
@@ -34,6 +36,8 @@ Conv1DLayer::Conv1DLayer(const std::array<unsigned int, 2> &padding_) :
   wt_idx({0}) {
   conv2d_layer = std::make_unique<Conv2DLayer>();
 }
+
+Conv1DLayer::~Conv1DLayer() {}
 
 void Conv1DLayer::finalize(InitLayerContext &context) {
   if (context.getNumInputs() != 1) {

--- a/nntrainer/layers/conv1d_layer.h
+++ b/nntrainer/layers/conv1d_layer.h
@@ -15,11 +15,13 @@
 #define __CONV1D_LAYER_H_
 #ifdef __cplusplus
 
-#include <conv2d_layer.h>
+#include <common_properties.h>
 #include <layer_impl.h>
 #include <memory.h>
 
 namespace nntrainer {
+
+class Conv2DLayer;
 
 /**
  * @class   Convolution 1D Layer
@@ -35,7 +37,7 @@ public:
   /**
    * @brief     Destructor of Conv 1D Layer
    */
-  ~Conv1DLayer() = default;
+  ~Conv1DLayer();
 
   /**
    *  @brief  Move constructor of Conv 1D Layer.

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -18,11 +18,13 @@
 
 #include <blas_interface.h>
 #include <conv2d_layer.h>
+#include <layer_context.h>
 #include <lazy_tensor.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>
 #include <profiler.h>
+#include <tensor_dim.h>
 #include <util_func.h>
 
 namespace nntrainer {

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -17,6 +17,7 @@
 
 #include <memory.h>
 
+#include <common_properties.h>
 #include <layer_impl.h>
 
 namespace nntrainer {

--- a/nntrainer/layers/dropout.cpp
+++ b/nntrainer/layers/dropout.cpp
@@ -12,8 +12,10 @@
  */
 
 #include <dropout.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
+#include <node_exporter.h>
 #include <util_func.h>
 
 namespace nntrainer {

--- a/nntrainer/layers/dropout.h
+++ b/nntrainer/layers/dropout.h
@@ -17,7 +17,6 @@
 
 #include <common_properties.h>
 #include <layer_devel.h>
-#include <node_exporter.h>
 
 namespace nntrainer {
 

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <embedding.h>
+#include <layer_context.h>
 #include <lazy_tensor.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>

--- a/nntrainer/layers/embedding.h
+++ b/nntrainer/layers/embedding.h
@@ -15,6 +15,7 @@
 #define __EMBEDDING_H__
 #ifdef __cplusplus
 
+#include <common_properties.h>
 #include <layer_impl.h>
 
 namespace nntrainer {

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <fc_layer.h>
+#include <layer_context.h>
 #include <lazy_tensor.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>

--- a/nntrainer/layers/flatten_layer.cpp
+++ b/nntrainer/layers/flatten_layer.cpp
@@ -13,8 +13,10 @@
  */
 
 #include <flatten_layer.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
+#include <node_exporter.h>
 
 namespace nntrainer {
 

--- a/nntrainer/layers/gru.cpp
+++ b/nntrainer/layers/gru.cpp
@@ -28,7 +28,7 @@
 
 #include <cmath>
 #include <gru.h>
-#include <lazy_tensor.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <input_layer.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -25,9 +25,7 @@
 #ifdef __cplusplus
 
 #include <common_properties.h>
-#include <layer_context.h>
 #include <layer_devel.h>
-#include <tensor.h>
 
 namespace nntrainer {
 

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -27,15 +27,14 @@
 #include <string>
 #include <vector>
 
-#include <layer_context.h>
-#include <tensor.h>
-
 namespace ml::train {
 class Layer;
 }
 
 namespace nntrainer {
 
+class InitLayerContext;
+class RunLayerContext;
 class Exporter;
 
 enum class ExportMethods;

--- a/nntrainer/layers/layer_impl.h
+++ b/nntrainer/layers/layer_impl.h
@@ -31,6 +31,13 @@ class InitLayerContext;
 class RunLayerContext;
 class Exporter;
 
+namespace props {
+class WeightRegularizer;
+class WeightRegularizerConstant;
+class WeightInitializer;
+class BiasInitializer;
+} // namespace props
+
 enum class ExportMethods;
 
 /**

--- a/nntrainer/layers/loss/constant_derivative_loss_layer.cpp
+++ b/nntrainer/layers/loss/constant_derivative_loss_layer.cpp
@@ -14,6 +14,8 @@
 
 #include <constant_derivative_loss_layer.h>
 
+#include <layer_context.h>
+
 namespace nntrainer {
 
 static constexpr int SINGLE_INOUT_IDX = 0;
@@ -21,7 +23,7 @@ static constexpr int SINGLE_INOUT_IDX = 0;
 static constexpr float value = 1.0f;
 
 ConstantDerivativeLossLayer::ConstantDerivativeLossLayer() : LossLayer() {}
-ConstantDerivativeLossLayer::~ConstantDerivativeLossLayer() = default;
+ConstantDerivativeLossLayer::~ConstantDerivativeLossLayer(){};
 
 void ConstantDerivativeLossLayer::forwarding(RunLayerContext &context,
                                              bool training) {

--- a/nntrainer/layers/loss/cross_entropy_loss_layer.h
+++ b/nntrainer/layers/loss/cross_entropy_loss_layer.h
@@ -16,6 +16,7 @@
 #ifdef __cplusplus
 
 #include <loss_layer.h>
+#include <nntrainer_error.h>
 
 namespace nntrainer {
 

--- a/nntrainer/layers/loss/cross_entropy_sigmoid_loss_layer.cpp
+++ b/nntrainer/layers/loss/cross_entropy_sigmoid_loss_layer.cpp
@@ -16,6 +16,7 @@
 #include <cross_entropy_sigmoid_loss_layer.h>
 
 #include <acti_func.h>
+#include <layer_context.h>
 #include <lazy_tensor.h>
 #include <util_func.h>
 

--- a/nntrainer/layers/loss/cross_entropy_softmax_loss_layer.cpp
+++ b/nntrainer/layers/loss/cross_entropy_softmax_loss_layer.cpp
@@ -16,6 +16,7 @@
 #include <cross_entropy_softmax_loss_layer.h>
 
 #include <acti_func.h>
+#include <layer_context.h>
 #include <lazy_tensor.h>
 #include <util_func.h>
 

--- a/nntrainer/layers/loss/loss_layer.cpp
+++ b/nntrainer/layers/loss/loss_layer.cpp
@@ -11,9 +11,13 @@
  *
  */
 
+#include <layer_context.h>
 #include <loss_layer.h>
 
 namespace nntrainer {
+void LossLayer::finalize(InitLayerContext &context) {
+  context.setOutputDimensions(context.getInputDimensions());
+}
 
 void LossLayer::updateLoss(RunLayerContext &context, const Tensor &l) {
   float loss_sum = 0.0f;

--- a/nntrainer/layers/loss/loss_layer.h
+++ b/nntrainer/layers/loss/loss_layer.h
@@ -17,6 +17,8 @@
 
 #include <layer_devel.h>
 
+#include <tensor.h>
+
 namespace nntrainer {
 
 /**
@@ -33,9 +35,7 @@ public:
   /**
    * @copydoc Layer::finalize(InitLayerContext &context)
    */
-  virtual void finalize(InitLayerContext &context) override {
-    context.setOutputDimensions(context.getInputDimensions());
-  }
+  virtual void finalize(InitLayerContext &context) override;
 
   /**
    * @copydoc Layer::setProperty(const std::vector<std::string> &values)

--- a/nntrainer/layers/loss/mse_loss_layer.cpp
+++ b/nntrainer/layers/loss/mse_loss_layer.cpp
@@ -11,6 +11,7 @@
  *
  */
 
+#include <layer_context.h>
 #include <lazy_tensor.h>
 #include <mse_loss_layer.h>
 

--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -12,7 +12,7 @@
  */
 
 #include <cmath>
-#include <lazy_tensor.h>
+#include <layer_context.h>
 #include <lstm.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>

--- a/nntrainer/layers/lstmcell.cpp
+++ b/nntrainer/layers/lstmcell.cpp
@@ -12,7 +12,7 @@
  */
 
 #include <cmath>
-#include <lazy_tensor.h>
+#include <layer_context.h>
 #include <lstmcell.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>

--- a/nntrainer/layers/multiout_layer.cpp
+++ b/nntrainer/layers/multiout_layer.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <cstring>
+#include <layer_context.h>
 #include <multiout_layer.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>

--- a/nntrainer/layers/nnstreamer_layer.cpp
+++ b/nntrainer/layers/nnstreamer_layer.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 
 #include <common_properties.h>
+#include <layer_context.h>
 #include <nnstreamer_layer.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
@@ -60,8 +61,7 @@ NNStreamerLayer::NNStreamerLayer() :
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
-int NNStreamerLayer::nnst_info_to_tensor_dim(ml_tensors_info_h &out_res,
-                                             TensorDim &dim) {
+static int nnst_info_to_tensor_dim(ml_tensors_info_h &out_res, TensorDim &dim) {
   int status = ML_ERROR_NONE;
   unsigned int count;
   ml_tensor_type_e type;

--- a/nntrainer/layers/nnstreamer_layer.h
+++ b/nntrainer/layers/nnstreamer_layer.h
@@ -98,15 +98,6 @@ private:
    * @brief     release the layer resources
    */
   void release() noexcept;
-
-  /**
-   * @brief    convert nnstreamer's tensor_info to nntrainer's tensor_dim
-   * @param[in] out_res nnstreamer's tensor_info
-   * @param[out] dim nntrainer's tensor_dim
-   * @retval 0 on success, -errno on failure
-   */
-  static int nnst_info_to_tensor_dim(ml_tensors_info_h &out_res,
-                                     TensorDim &dim);
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/permute_layer.cpp
+++ b/nntrainer/layers/permute_layer.cpp
@@ -13,8 +13,10 @@
 #include <string>
 #include <tuple>
 
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
+#include <node_exporter.h>
 #include <permute_layer.h>
 #include <tensor.h>
 #include <tensor_dim.h>

--- a/nntrainer/layers/permute_layer.h
+++ b/nntrainer/layers/permute_layer.h
@@ -19,7 +19,7 @@
 
 #include <base_properties.h>
 #include <layer_devel.h>
-#include <node_exporter.h>
+
 namespace nntrainer {
 
 namespace props {

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -14,13 +14,13 @@
 #include <cstring>
 #include <limits>
 
-#include <lazy_tensor.h>
+#include <common_properties.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>
 #include <pooling2d_layer.h>
 #include <util_func.h>
-
 namespace nntrainer {
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
@@ -403,6 +403,14 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
       }
     }
   }
+}
+
+void Pooling2DLayer::setBatch(RunLayerContext &context, unsigned int batch) {
+  context.updateTensor(pool_helper_idx, batch);
+  props::PoolingTypeInfo::Enum pooling_type =
+    std::get<props::PoolingType>(pooling2d_props).get();
+  if (pooling_type == props::PoolingTypeInfo::Enum::global_max)
+    pool_helper_size.resize(batch * context.getInput(0).channel());
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <base_properties.h>
+#include <common_properties.h>
 #include <layer_devel.h>
 
 namespace nntrainer {
@@ -105,13 +106,7 @@ public:
   /**
    * @copydoc Layer::setBatch(RunLayerContext &context, unsigned int batch)
    */
-  void setBatch(RunLayerContext &context, unsigned int batch) override {
-    context.updateTensor(pool_helper_idx, batch);
-    props::PoolingTypeInfo::Enum pooling_type =
-      std::get<props::PoolingType>(pooling2d_props).get();
-    if (pooling_type == props::PoolingTypeInfo::Enum::global_max)
-      pool_helper_size.resize(batch * context.getInput(0).channel());
-  }
+  void setBatch(RunLayerContext &context, unsigned int batch) override;
 
 private:
   std::array<unsigned int, POOLING2D_DIM * 2> padding;

--- a/nntrainer/layers/preprocess_flip_layer.cpp
+++ b/nntrainer/layers/preprocess_flip_layer.cpp
@@ -13,6 +13,8 @@
 
 #include <random>
 
+#include <common_properties.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/nntrainer/layers/preprocess_flip_layer.h
+++ b/nntrainer/layers/preprocess_flip_layer.h
@@ -17,6 +17,7 @@
 
 #include <random>
 
+#include <common_properties.h>
 #include <layer_devel.h>
 
 namespace nntrainer {

--- a/nntrainer/layers/preprocess_l2norm_layer.cpp
+++ b/nntrainer/layers/preprocess_l2norm_layer.cpp
@@ -16,9 +16,10 @@
 #include <regex>
 #include <sstream>
 
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
-
+#include <node_exporter.h>
 #include <preprocess_l2norm_layer.h>
 
 namespace nntrainer {

--- a/nntrainer/layers/preprocess_l2norm_layer.h
+++ b/nntrainer/layers/preprocess_l2norm_layer.h
@@ -17,9 +17,7 @@
 #define __PREPROCESS_L2NORM_LAYER_H__
 #include <string>
 
-#include <layer_context.h>
 #include <layer_devel.h>
-#include <node_exporter.h>
 
 namespace nntrainer {
 

--- a/nntrainer/layers/preprocess_translate_layer.cpp
+++ b/nntrainer/layers/preprocess_translate_layer.cpp
@@ -14,6 +14,7 @@
 
 #include <random>
 
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/nntrainer/layers/preprocess_translate_layer.h
+++ b/nntrainer/layers/preprocess_translate_layer.h
@@ -21,6 +21,7 @@
 #include <opencv2/highgui/highgui.hpp>
 #endif
 
+#include <common_properties.h>
 #include <layer_devel.h>
 
 namespace nntrainer {

--- a/nntrainer/layers/reshape_layer.cpp
+++ b/nntrainer/layers/reshape_layer.cpp
@@ -12,11 +12,11 @@
  * @todo Update flatten to work in-place properly.
  */
 
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>
 #include <reshape_layer.h>
-
 namespace nntrainer {
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;

--- a/nntrainer/layers/rnn.cpp
+++ b/nntrainer/layers/rnn.cpp
@@ -12,7 +12,7 @@
  */
 
 #include <cmath>
-#include <lazy_tensor.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/nntrainer/layers/rnncell.cpp
+++ b/nntrainer/layers/rnncell.cpp
@@ -13,7 +13,7 @@
 
 #include <cmath>
 
-#include <lazy_tensor.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/nntrainer/layers/split_layer.cpp
+++ b/nntrainer/layers/split_layer.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <cstring>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/nntrainer/layers/split_layer.h
+++ b/nntrainer/layers/split_layer.h
@@ -17,7 +17,9 @@
 #define __SPLIT_LAYER_H__
 #ifdef __cplusplus
 
+#include <common_properties.h>
 #include <layer_devel.h>
+#include <tensor_dim.h>
 
 namespace nntrainer {
 

--- a/nntrainer/layers/tflite_layer.cpp
+++ b/nntrainer/layers/tflite_layer.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <base_properties.h>
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/nntrainer/layers/tflite_layer.h
+++ b/nntrainer/layers/tflite_layer.h
@@ -16,10 +16,15 @@
 #ifdef __cplusplus
 
 #include <layer_devel.h>
+#include <vector>
 
 #include <tensorflow/contrib/lite/interpreter.h>
 #include <tensorflow/contrib/lite/kernels/register.h>
 #include <tensorflow/contrib/lite/model.h>
+
+namespace ml::train {
+class TensorDim;
+}
 
 namespace nntrainer {
 
@@ -88,7 +93,7 @@ private:
    * @param is_output check if output
    */
   void setDimensions(const std::vector<int> &tensor_idx_list,
-                     std::vector<TensorDim> &dim, bool is_output);
+                     std::vector<ml::train::TensorDim> &dim, bool is_output);
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/time_dist.cpp
+++ b/nntrainer/layers/time_dist.cpp
@@ -11,6 +11,7 @@
  *
  */
 
+#include <layer_context.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <time_dist.h>

--- a/nntrainer/layers/time_dist.h
+++ b/nntrainer/layers/time_dist.h
@@ -16,6 +16,7 @@
 #ifdef __cplusplus
 
 #include <layer_devel.h>
+#include <weight.h>
 
 namespace nntrainer {
 

--- a/nntrainer/models/dynamic_training_optimization.h
+++ b/nntrainer/models/dynamic_training_optimization.h
@@ -45,6 +45,9 @@
 
 namespace nntrainer {
 
+class Weight;
+class Var_Grad;
+
 /**
  * @class   DynamicTraining Optimization
  * @brief   Dynamic Training Optimization

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <cstring>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 
 #include <databuffer.h>

--- a/nntrainer/utils/ini_wrapper.cpp
+++ b/nntrainer/utils/ini_wrapper.cpp
@@ -14,6 +14,7 @@
 
 #include <regex>
 
+#include <iostream>
 #include <nntrainer_error.h>
 #include <util_func.h>
 
@@ -122,6 +123,13 @@ void IniWrapper::save_ini(const std::string &ini_name) const {
   for (auto &it : sections) {
     it.print(out);
     out << std::endl;
+  }
+}
+
+void IniWrapper::erase_ini() const noexcept {
+  if (remove(getIniName().c_str())) {
+    std::cerr << "remove ini " << getIniName()
+              << "failed, reason: " << strerror(errno);
   }
 }
 

--- a/nntrainer/utils/ini_wrapper.h
+++ b/nntrainer/utils/ini_wrapper.h
@@ -15,7 +15,7 @@
 
 #include <cstring>
 #include <fstream>
-#include <iostream>
+#include <iosfwd>
 #include <map>
 #include <string>
 #include <vector>
@@ -369,12 +369,7 @@ public:
    * @brief erase ini
    *
    */
-  void erase_ini() const noexcept {
-    if (remove(getIniName().c_str())) {
-      std::cerr << "remove ini " << getIniName()
-                << "failed, reason: " << strerror(errno);
-    }
-  }
+  void erase_ini() const noexcept;
 
   /**
    * @brief operator<< to print information to outstream

--- a/nntrainer/utils/profiler.h
+++ b/nntrainer/utils/profiler.h
@@ -42,7 +42,7 @@
 
 #include <chrono>
 #include <future>
-#include <iostream>
+#include <iosfwd>
 #include <mutex>
 #include <string>
 #include <unordered_map>

--- a/test/unittest/layers/layers_standalone_common_tests.cpp
+++ b/test/unittest/layers/layers_standalone_common_tests.cpp
@@ -12,7 +12,10 @@
 
 #include <layers_common_tests.h>
 
+#include <layer_context.h>
 #include <layer_devel.h>
+#include <nntrainer_error.h>
+#include <tensor_dim.h>
 
 constexpr unsigned SAMPLE_TRIES = 10;
 
@@ -36,8 +39,8 @@ TEST_P(LayerSemantics, DISABLED_setPropertiesValidInvalidOnly_n) {
 }
 
 TEST_P(LayerSemantics, finalizeValidate_p) {
-  nntrainer::TensorDim in_dim({1, 1, 1, 1});
-  std::vector<nntrainer::TensorDim> input_dims(num_inputs, in_dim);
+  ml::train::TensorDim in_dim({1, 1, 1, 1});
+  std::vector<ml::train::TensorDim> input_dims(num_inputs, in_dim);
   nntrainer::InitLayerContext init_context =
     nntrainer::InitLayerContext(input_dims, 1, false, "layer");
   EXPECT_EQ(init_context.validate(), true);
@@ -77,8 +80,8 @@ TEST_P(LayerSemantics, gettersValidate_p) {
 }
 
 TEST_P(LayerSemantics, setBatchValidate_p) {
-  nntrainer::TensorDim in_dim({1, 1, 1, 1});
-  std::vector<nntrainer::TensorDim> input_dims(num_inputs, in_dim);
+  ml::train::TensorDim in_dim({1, 1, 1, 1});
+  std::vector<ml::train::TensorDim> input_dims(num_inputs, in_dim);
   nntrainer::InitLayerContext init_context =
     nntrainer::InitLayerContext(input_dims, 1, false, "layer");
   EXPECT_EQ(init_context.validate(), true);


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Build] Use iosfwd instead of iostream</summary><br />

This patch changes <iostream> to iosfwd when it is not really needed

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary> [layer devel] clean up header dependency</summary><br />

This patch clean up header dependency related to layer devel which
is being included in so many places and does not need layer_context to
be included in it's translation unit

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

