### PR TITLE
[Feature check] Add tizen 6.5 compatibility

### DIFF
--- a/api/capi/src/nntrainer-capi-tizen-feature-check.cpp
+++ b/api/capi/src/nntrainer-capi-tizen-feature-check.cpp
@@ -28,6 +28,39 @@ extern "C" {
  */
 #define ML_TRAIN_FEATURE_PATH "tizen.org/feature/machine_learning.training"
 
+/// please note that this is a improvised measure for nnstreamer/api#110
+/// proper way will need exposing this particular function in ml-api side
+#if (TIZENVERSION >= 7) && (TIZENVERSION < 9999)
+
+/**
+ * @brief tizen set feature state from ml api side
+ *
+ * @param state -1 NOT checked yet, 0 supported, 1 not supported
+ * @return int 0 if success
+ */
+int _ml_tizen_set_feature_state(int state);
+#define ml_api_set_feature_state(...) _ml_tizen_set_feature_state(__VA_ARGS__)
+
+#elif (TIZENVERSION >= 6) && (TIZENVERSION < 9999)
+
+/**
+ * @brief tizen set feature state from ml api side
+ *
+ * @param state -1 NOT checked yet, 0 supported, 1 not supported
+ * @return int 0 if success
+ */
+int ml_tizen_set_feature_state(int state);
+#define ml_api_set_feature_state(...) ml_tizen_set_feature_state(__VA_ARGS__)
+
+#elif (TIZENVERSION <= 5)
+
+#warning Tizen version under 5 does not support setting features for unittest
+#define ml_api_set_feature_state(...)
+
+#else /* TIZENVERSION */
+#error Tizen version is not defined.
+#endif /* TIZENVERSION */
+
 /**
  * @brief Internal struct to control tizen feature support
  * (machine_learning.training). -1: Not checked yet, 0: Not supported, 1:
@@ -46,23 +79,13 @@ typedef struct _feature_info_s {
 
 static feature_info_s feature_info;
 
-/// please note that this is a improvised measure for nnstreamer/api#110
-/// proper way will need exposing this particular function in ml-api side
-/**
- * @brief tizen set feature state from ml api side
- *
- * @param state -1 NOT checked yet, 0 supported, 1 not supported
- * @return int 0 if success
- */
-int _ml_tizen_set_feature_state(int state);
-
 /**
  * @brief Set the feature status of machine_learning.training.
  */
 void ml_train_tizen_set_feature_state(feature_state_t state) {
   pthread_mutex_lock(&feature_info.mutex);
 
-  _ml_tizen_set_feature_state((int)state);
+  ml_api_set_feature_state((int)state);
 
   /**
    * Update feature status

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,8 @@ cxx = meson.get_compiler('cpp')
 if get_option('platform') == 'tizen'
   # Pass __TIZEN__ to the compiler
   add_project_arguments('-D__TIZEN__=1', language:['c','cpp'])
+  add_project_arguments('-DTIZENVERSION=@0@'.format(get_option('tizen-version-major')), language: ['c', 'cpp'])
+  add_project_arguments('-DTIZENVERSIONMINOR=@0@'.format(get_option('tizen-version-minor')), language: ['c', 'cpp'])
 
   if get_option('enable-tizen-feature-check')
     add_project_arguments('-D__FEATURE_CHECK_SUPPORT__', language: ['c', 'cpp'])

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,6 +19,8 @@ option('capi-ml-inference-actual', type: 'string', value: 'capi-ml-inference',
         description: 'backward compatible dependency name of capi-ml-inference')
 option('capi-ml-common-actual', type: 'string', value: 'capi-ml-common',
         description: 'backward compatible dependency name of capi-ml-common')
+option('tizen-version-major', type: 'integer', min : 4, max : 9999, value: 9999) # 9999 means "not Tizen"
+option('tizen-version-minor', type: 'integer', min : 0, max : 9999, value: 0)
 
 # test related option
 option('reduce-tolerance', type: 'boolean', value: true)

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -268,7 +268,7 @@ NNSteamer tensor filter static package for nntrainer to support inference.
 
 ## Define build options
 %define platform -Dplatform=tizen
-%define enable_tizen_feature_check -Denable-tizen-feature-check=true
+%define enable_tizen_feature_check -Denable-tizen-feature-check=true -Dtizen-version-major=0%{?tizen_version_major} -Dtizen-version-minor=0%{?tizen_version_minor}
 %define install_app -Dinstall-app=true
 %define enable_ccapi -Denable-ccapi=false
 %define enable_nnstreamer_backbone -Denable-nnstreamer-backbone=false


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Feature check] Add tizen 6.5 compatibility</summary><br />

As prefix has been added to the `ml_tizen_set_feature_state` for tizen
7.0 this patch makes backward compatible to the old tizen version

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

