### PR TITLE
[Node] Add get/set method to manipulate connection

### DIFF
--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -81,7 +81,7 @@ public:
    *
    * @return list of name of the nodes which form output connections
    */
-  virtual const std::vector<std::string> &getOutputConnections() const = 0;
+  virtual const std::vector<std::string> getOutputConnections() const = 0;
 
   /**
    * @brief     get the execution order/location of this node

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -138,65 +138,75 @@ public:
 };
 
 /**
- * @brief RAII class to define the connection spec
+ * @brief RAII class to define the connection
  *
  */
-class ConnectionSpec {
+class Connection {
 public:
-  static std::string NoneType;
-
   /**
-   * @brief Construct a new Connection Spec object
+   * @brief Construct a new Connection object
    *
-   * @param layer_ids_ layer ids that will be an operand
-   * @param op_type_ operator type
+   * @param layer_name layer identifier
    */
-  ConnectionSpec(const std::vector<Name> &layer_ids_,
-                 const std::string &op_type_ = ConnectionSpec::NoneType);
+  Connection(const std::string &layer_name, unsigned int idx);
 
   /**
-   * @brief Construct a new Connection Spec object
+   * @brief Construct a new Connection object
    *
    * @param rhs rhs to copy
    */
-  ConnectionSpec(const ConnectionSpec &rhs);
+  Connection(const Connection &rhs);
 
   /**
    * @brief Copy assignment operator
    *
    * @param rhs rhs to copy
-   * @return ConnectionSpec&
+   * @return Connection&
    */
-  ConnectionSpec &operator=(const ConnectionSpec &rhs);
+  Connection &operator=(const Connection &rhs);
 
   /**
-   * @brief Move Construct Connection Spec object
+   * @brief Move Construct Connection object
    *
    * @param rhs rhs to move
    */
-  ConnectionSpec(ConnectionSpec &&rhs) noexcept;
+  Connection(Connection &&rhs) noexcept;
 
   /**
-   * @brief Move assign a connection spec operator
+   * @brief Move assign a connection operator
    *
    * @param rhs rhs to move
-   * @return ConnectionSpec&
+   * @return Connection&
    */
-  ConnectionSpec &operator=(ConnectionSpec &&rhs) noexcept;
+  Connection &operator=(Connection &&rhs) noexcept;
 
   /**
-   * @brief Get the Op Type object
+   * @brief Get the index
    *
-   * @return const std::string& op_type (read-only)
+   * @return unsigned index
    */
-  const std::string &getOpType() const { return op_type; }
+  const unsigned getIndex() const { return index; }
 
   /**
-   * @brief Get the Layer Ids object
+   * @brief Get the index
    *
-   * @return const std::vector<Name>& vector of layer ids (read-only)
+   * @return unsigned index
    */
-  const std::vector<Name> &getLayerIds() const { return layer_ids; }
+  unsigned &getIndex() { return index; }
+
+  /**
+   * @brief Get the Layer name object
+   *
+   * @return const Name& name of layer
+   */
+  const Name &getName() const { return name; }
+
+  /**
+   * @brief Get the Layer name object
+   *
+   * @return Name& name of layer
+   */
+  Name &getName() { return name; }
 
   /**
    *
@@ -206,11 +216,11 @@ public:
    * @return true if equal
    * @return false if not equal
    */
-  bool operator==(const ConnectionSpec &rhs) const;
+  bool operator==(const Connection &rhs) const noexcept;
 
 private:
-  std::string op_type;
-  std::vector<Name> layer_ids;
+  unsigned index;
+  Name name;
 };
 
 /**
@@ -223,25 +233,23 @@ struct connection_prop_tag {};
  * @brief InputSpec property, this defines connection specification of an input
  *
  */
-class InputSpec : public nntrainer::Property<ConnectionSpec> {
+class InputConnection : public nntrainer::Property<Connection> {
 public:
   /**
    * @brief Construct a new Input Spec object
    *
    */
-  InputSpec() : nntrainer::Property<ConnectionSpec>() {}
+  InputConnection();
 
   /**
    * @brief Construct a new Input Spec object
    *
    * @param value default value of a input spec
    */
-  InputSpec(const ConnectionSpec &value) :
-    nntrainer::Property<ConnectionSpec>(value) {} /**< default value if any */
+  InputConnection(const Connection &value);
   static constexpr const char *key =
     "input_layers";                     /**< unique key to access */
   using prop_tag = connection_prop_tag; /**< property type */
-  bool isValid(const ConnectionSpec &v) const override;
 };
 
 /**

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -31,6 +31,8 @@ namespace nntrainer {
 
 /**
  * @class   Input Layer
+ * @note    input layers requires to be only single input, consider making the
+ * class deal with multiple inputs
  * @brief   Just Handle the Input of Network
  */
 class InputLayer : public Layer {

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -183,6 +183,30 @@ void LayerNode::setProperty(const std::vector<std::string> &properties) {
   }
 }
 
+const unsigned LayerNode::getInputConnectionIndex(unsigned nth) const {
+  auto &input_layers =
+    std::get<std::vector<props::InputConnection>>(*layer_node_props);
+  return input_layers.at(nth).get().getIndex();
+}
+
+const std::string &LayerNode::getInputConnectionName(unsigned nth) const {
+  auto &input_layers =
+    std::get<std::vector<props::InputConnection>>(*layer_node_props);
+  return input_layers.at(nth).get().getName();
+}
+
+void LayerNode::setInputConnectionIndex(unsigned nth, unsigned index) {
+  auto &input_layers =
+    std::get<std::vector<props::InputConnection>>(*layer_node_props);
+  input_layers.at(nth).get().getIndex() = index;
+}
+
+void LayerNode::setInputConnectionName(unsigned nth, const std::string &name) {
+  auto &input_layers =
+    std::get<std::vector<props::InputConnection>>(*layer_node_props);
+  input_layers.at(nth).get().getName() = name;
+}
+
 const std::string LayerNode::getName() const noexcept {
   auto &name = std::get<props::Name>(*layer_node_props);
   return name.empty() ? "" : name.get();

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -50,6 +50,7 @@ class InputLayer;
 class InputShape;
 class Activation;
 class SharedFrom;
+class InputConnection;
 } // namespace props
 
 /**
@@ -717,7 +718,6 @@ private:
                                  calcDerivative */
   bool needs_calc_gradient; /**< cache if this layer needs to do calcGradient */
 
-  std::vector<std::string> input_layers;  /**< input layer names */
   std::vector<std::string> output_layers; /**< output layer names */
 
   std::unique_ptr<RunLayerContext>
@@ -728,8 +728,8 @@ properties in the context/graph unless intended. */
 
   using PropsType =
     std::tuple<props::Name, props::Distribute, props::Trainable,
-               std::vector<props::InputLayer>, std::vector<props::InputShape>,
-               props::SharedFrom>;
+               std::vector<props::InputConnection>,
+               std::vector<props::InputShape>, props::SharedFrom>;
 
   using RealizationPropsType = std::tuple<props::Flatten, props::Activation>;
   /** these realization properties results in addition of new layers, hence

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -131,6 +131,43 @@ public:
   }
 
   /**
+   * @brief Get the Input Connection Index object
+   *
+   * @param nth nth input
+   * @throws if nth is out of range of getNumInputConnection()
+   * @return const unsigned index
+   */
+  const unsigned getInputConnectionIndex(unsigned nth) const;
+
+  /**
+   * @brief Get the Input Connection Name object
+   *
+   * @param nth nth input
+   * @throws if nth is out of range of getNumInputConnection()
+   * @return const std::string& name
+   */
+  const std::string &getInputConnectionName(unsigned nth) const;
+
+  /**
+   * @brief Set the Input Connection Index object
+   *
+   * @param nth nth input
+   * @param index index to set
+   * @throws if nth is out of range of getNumInputConnection()
+   */
+  void setInputConnectionIndex(unsigned nth, unsigned index);
+
+  /**
+   * @brief Get the Input Connection Name object
+   *
+   * @param nth input
+   * @param index index to set
+   * @throws if nth is out of range of getNumInputConnection()
+   * @throws if new identifier is invalid
+   */
+  void setInputConnectionName(unsigned nth, const std::string &name);
+
+  /**
    * @brief     Get the input connections for this node
    *
    * @return list of name of the nodes which form input connections

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -50,6 +50,7 @@ class InputLayer;
 class InputShape;
 class Activation;
 class SharedFrom;
+class Connection;
 class InputConnection;
 } // namespace props
 
@@ -143,7 +144,7 @@ public:
    *
    * @return list of name of the nodes which form output connections
    */
-  const std::vector<std::string> &getOutputConnections() const override {
+  const std::vector<std::string> getOutputConnections() const override {
     return getOutputLayers();
   }
 
@@ -323,7 +324,7 @@ public:
    * @brief     Get number of output connections
    * @retval    number of outputs
    */
-  unsigned int getNumOutputConnections() const { return output_layers.size(); }
+  unsigned int getNumOutputConnections() const;
 
   /**
    * @brief     Get number of inputs
@@ -366,11 +367,9 @@ public:
   /**
    * @brief Get the Output Layers object
    *
-   * @return const std::vector<std::string>&
+   * @return const std::vector<std::string>
    */
-  const std::vector<std::string> &getOutputLayers() const {
-    return output_layers;
-  }
+  const std::vector<std::string> getOutputLayers() const;
 
   /**
    * @brief Update input layers entry name
@@ -400,9 +399,7 @@ public:
    *
    * @param out_layer Name to be added
    */
-  void addOutputLayers(const std::string &out_layer) {
-    output_layers.push_back(out_layer);
-  }
+  void addOutputLayers(const std::string &out_layer);
 
   /**
    * @brief Set the Input Layers object
@@ -416,9 +413,7 @@ public:
    *
    * @param layers Name of the layers
    */
-  void setOutputLayers(const std::vector<std::string> &layers) {
-    output_layers = layers;
-  }
+  void setOutputLayers(const std::vector<std::string> &layers);
 
   /**
    * @brief check if input shape property is set
@@ -718,7 +713,8 @@ private:
                                  calcDerivative */
   bool needs_calc_gradient; /**< cache if this layer needs to do calcGradient */
 
-  std::vector<std::string> output_layers; /**< output layer names */
+  std::unique_ptr<std::vector<props::Connection>>
+    output_layers; /**< output layer names */
 
   std::unique_ptr<RunLayerContext>
     run_context; /**< context required for running/execution of the layer. This

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -55,7 +55,7 @@ void Exporter::saveTflResult(const std::tuple<> &props,
 template <>
 void Exporter::saveTflResult(
   const std::tuple<props::Name, props::Distribute, props::Trainable,
-                   std::vector<props::InputLayer>,
+                   std::vector<props::InputConnection>,
                    std::vector<props::InputShape>, props::SharedFrom> &props,
   const LayerNode *self) {
   createIfNull(tf_node);

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -215,6 +215,7 @@ class WeightRegularizerConstant;
 class WeightInitializer;
 class BiasInitializer;
 class SharedFrom;
+class InputConnection;
 } // namespace props
 
 class LayerNode;
@@ -225,7 +226,7 @@ class LayerNode;
 template <>
 void Exporter::saveTflResult(
   const std::tuple<props::Name, props::Distribute, props::Trainable,
-                   std::vector<props::InputLayer>,
+                   std::vector<props::InputConnection>,
                    std::vector<props::InputShape>, props::SharedFrom> &props,
   const LayerNode *self);
 

--- a/test/unittest/unittest_common_properties.cpp
+++ b/test/unittest/unittest_common_properties.cpp
@@ -101,92 +101,49 @@ TEST(NameProperty, mustStartWithAlphaNumeric_01_n) {
   EXPECT_THROW(n.set("+layer"), std::invalid_argument);
 }
 
-TEST(InputSpecProperty, setPropertyValid_p) {
+TEST(InputConnection, setPropertyValid_p) {
   using namespace nntrainer::props;
   {
-    InputSpec expected(
-      ConnectionSpec({Name("A"), Name("B"), Name("C")}, "concat"));
+    InputConnection expected(Connection("a", 0));
 
-    InputSpec actual;
-    nntrainer::from_string("A, B, C", actual);
+    InputConnection actual;
+    nntrainer::from_string("A", actual);
     EXPECT_EQ(actual, expected);
-    EXPECT_EQ("a,b,c", nntrainer::to_string(actual));
+    EXPECT_EQ("a(0)", nntrainer::to_string(actual));
   }
 
   {
-    InputSpec expected(
-      ConnectionSpec({Name("A"), Name("B"), Name("C")}, "addition"));
+    InputConnection expected(Connection("a", 2));
 
-    InputSpec actual;
-    nntrainer::from_string("A+ B +C", actual);
-    EXPECT_EQ("a+b+c", nntrainer::to_string(actual));
-
+    InputConnection actual;
+    nntrainer::from_string("a(2)", actual);
     EXPECT_EQ(actual, expected);
-  }
-
-  {
-    InputSpec expected(ConnectionSpec({Name("a")}, ConnectionSpec::NoneType));
-
-    InputSpec actual;
-    nntrainer::from_string("a", actual);
-    EXPECT_EQ("a", nntrainer::to_string(actual));
-
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ("a(2)", nntrainer::to_string(actual));
   }
 }
 
-TEST(InputSpecProperty, emptyString_n_01) {
+TEST(InputConnection, emptyString_n_01) {
   using namespace nntrainer::props;
-  InputSpec actual;
+  InputConnection actual;
   EXPECT_THROW(nntrainer::from_string("", actual), std::invalid_argument);
 }
 
-TEST(InputSpecProperty, combinedOperator_n_01) {
+TEST(InputConnection, onlyIndex_n_01) {
   using namespace nntrainer::props;
-  InputSpec actual;
-  EXPECT_THROW(nntrainer::from_string("A,B+C", actual), std::invalid_argument);
+  InputConnection actual;
+  EXPECT_THROW(nntrainer::from_string("[0]", actual), std::invalid_argument);
 }
 
-TEST(InputSpecProperty, combinedOperator_n_02) {
+TEST(InputConnection, invalidFormat_n_01) {
   using namespace nntrainer::props;
-  InputSpec actual;
-  EXPECT_THROW(nntrainer::from_string("A+B,C", actual), std::invalid_argument);
+  InputConnection actual;
+  EXPECT_THROW(nntrainer::from_string("a[0", actual), std::invalid_argument);
 }
 
-TEST(InputSpecProperty, noOperator_n_01) {
+TEST(InputConnection, invalidFormat_n_02) {
   using namespace nntrainer::props;
-  InputSpec actual;
-  EXPECT_THROW(nntrainer::from_string("A B", actual), std::invalid_argument);
-}
-
-TEST(InputSpecProperty, noOperator_n_02) {
-  using namespace nntrainer::props;
-  InputSpec actual;
-  EXPECT_THROW(nntrainer::from_string("A B", actual), std::invalid_argument);
-}
-
-TEST(InputSpecProperty, leadingOperator_n_01) {
-  using namespace nntrainer::props;
-  InputSpec actual;
-  EXPECT_THROW(nntrainer::from_string(",A,B", actual), std::invalid_argument);
-}
-
-TEST(InputSpecProperty, leadingOperator_n_02) {
-  using namespace nntrainer::props;
-  InputSpec actual;
-  EXPECT_THROW(nntrainer::from_string("+A+B", actual), std::invalid_argument);
-}
-
-TEST(InputSpecProperty, trailingOperator_n_01) {
-  using namespace nntrainer::props;
-  InputSpec actual;
-  EXPECT_THROW(nntrainer::from_string("A,B,,", actual), std::invalid_argument);
-}
-
-TEST(InputSpecProperty, trailingOperator_n_02) {
-  using namespace nntrainer::props;
-  InputSpec actual;
-  EXPECT_THROW(nntrainer::from_string("A+B++", actual), std::invalid_argument);
+  InputConnection actual;
+  EXPECT_THROW(nntrainer::from_string("[0", actual), std::invalid_argument);
 }
 
 TEST(Padding2D, setPropertyValid_p) {
@@ -259,14 +216,14 @@ int main(int argc, char **argv) {
   try {
     testing::InitGoogleTest(&argc, argv);
   } catch (...) {
-    std::cerr << "Error duing IniGoogleTest" << std::endl;
+    std::cerr << "Error during IniGoogleTest" << std::endl;
     return 0;
   }
 
   try {
     result = RUN_ALL_TESTS();
   } catch (...) {
-    std::cerr << "Error duing RUN_ALL_TESTS()" << std::endl;
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
   }
 
   return result;


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Connection] Add indexing to connection</summary><br />

This patch revisition connection spec to contain identifier and index to
make use of it.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Node] Replace input layers -> input connection</summary><br />

This patch replace input layers to input connection.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Node] replace output layer string -> connection</summary><br />

This patch replaces output layer from string to connection

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Node] Add get/set method to manipulate connection</summary><br />

This patch add get/set method to input connections for further use

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

