### PR TITLE
[Wait for #1733] [nn] Attach activation realizer

### DIFF
--- a/Applications/ProductRatings/res/product_ratings_model.ini
+++ b/Applications/ProductRatings/res/product_ratings_model.ini
@@ -18,17 +18,17 @@ Type = input
 input_shape = 1:1:2 # channel:height:width
 
 [split]
-Type = split
+Type = split # @todo remove split layer here
 axis = 3 # split by width
 
 [user_embed]
-input_layers = split
+input_layers = split(0)
 Type = embedding
 in_dim = 6          # in dim must be more than len(set(user ids)) + 1
 out_dim = 5
 
 [product_embed]
-input_layers = split
+input_layers = split(1)
 Type = embedding
 in_dim = 6          # in dim must be more than len(set(product ids)) + 1
 out_dim = 5

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -198,6 +198,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/flatten_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/recurrent_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/previous_input_realizer.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/compiler/multiout_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/remap_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/slice_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/input_realizer.cpp \

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -196,6 +196,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/base_properties.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/ini_interpreter.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/flatten_realizer.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/compiler/activation_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/recurrent_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/previous_input_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/multiout_realizer.cpp \

--- a/nntrainer/compiler/activation_realizer.cpp
+++ b/nntrainer/compiler/activation_realizer.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file activation_realizer.cpp
+ * @date 23 November 2021
+ * @brief NNTrainer graph realizer which realizes activation!=none to actual
+ * activation node
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include "nntrainer_error.h"
+#include <activation_realizer.h>
+
+#include <activation_layer.h>
+#include <layer_node.h>
+#include <stdexcept>
+
+namespace nntrainer {
+
+ActivationRealizer::~ActivationRealizer() {}
+
+GraphRepresentation
+ActivationRealizer::realize(const GraphRepresentation &reference) {
+  GraphRepresentation processed;
+  processed.reserve(reference.size());
+
+  for (auto &node : reference) {
+    processed.push_back(node);
+    if (node->getType() == ActivationLayer::type) {
+      /// realizing activation type not allowed because there is no good way to
+      /// tell between 1. it is activation layer, 2. activation layer wants
+      /// realization for now. later, we should have relu, sigmoid kind as layer
+      /// type to resolve this matter, this is checked
+      /// node->getActivationToBeRealized() but explicitly stated in order to
+      /// make it robust, plus we might want to change the behavior
+      continue;
+    }
+
+    if (auto act = node->getActivationToBeRealized();
+        act != ActivationType::ACT_NONE) {
+      NNTR_THROW_IF(act == ActivationType::ACT_UNKNOWN, std::invalid_argument)
+        << "unknown activation type for layer: " << node->getName();
+
+      auto layer_name = node->getName();
+      props::Activation act_prop;
+      act_prop.set(act);
+      node->setProperty({"activation=none"});
+      node->setProperty({"name=" + layer_name + "/activation_realized"});
+
+      auto act_node =
+        createLayerNode("activation", {"name=" + layer_name,
+                                       "activation=" + to_string(act_prop)});
+      act_node->setProperty({"input_layers=" + node->getName()});
+      processed.push_back(std::move(act_node));
+    }
+  }
+
+  return processed;
+}
+} // namespace nntrainer

--- a/nntrainer/compiler/activation_realizer.h
+++ b/nntrainer/compiler/activation_realizer.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file activation_realizer.h
+ * @date 23 November 2021
+ * @brief NNTrainer graph realizer which realizes activation!=none to actual
+ * activation node
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#ifndef __ACTIVATION_REALIZER_H__
+#define __ACTIVATION_REALIZER_H__
+
+#include <memory>
+#include <vector>
+
+#include <realizer.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Graph realizer which realizes activation
+ *
+ */
+class ActivationRealizer final : public GraphRealizer {
+public:
+  /**
+   * @brief Destroy the Graph Realizer object
+   *
+   */
+  ~ActivationRealizer();
+
+  /**
+   * @brief graph realizer creates a new graph based on the reference
+   *
+   */
+  GraphRepresentation realize(const GraphRepresentation &reference) override;
+};
+
+} // namespace nntrainer
+
+#endif // __ACTIVATION_REALIZER_H__

--- a/nntrainer/compiler/flatten_realizer.cpp
+++ b/nntrainer/compiler/flatten_realizer.cpp
@@ -2,7 +2,7 @@
 /**
  * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
  *
- * @file flatten_realizer.h
+ * @file flatten_realizer.cpp
  * @date 09 October 2021
  * @brief NNTrainer graph realizer which realizes flatten=true to actual node
  * @see	https://github.com/nnstreamer/nntrainer

--- a/nntrainer/compiler/meson.build
+++ b/nntrainer/compiler/meson.build
@@ -1,5 +1,6 @@
 compiler_sources = [
   'ini_interpreter.cpp',
+  'activation_realizer.cpp',
   'flatten_realizer.cpp',
   'recurrent_realizer.cpp',
   'remap_realizer.cpp',

--- a/nntrainer/compiler/meson.build
+++ b/nntrainer/compiler/meson.build
@@ -5,7 +5,8 @@ compiler_sources = [
   'remap_realizer.cpp',
   'slice_realizer.cpp',
   'input_realizer.cpp',
-  'previous_input_realizer.cpp'
+  'previous_input_realizer.cpp',
+  'multiout_realizer.cpp',
 ]
 
 compiler_headers = []

--- a/nntrainer/compiler/multiout_realizer.cpp
+++ b/nntrainer/compiler/multiout_realizer.cpp
@@ -9,16 +9,99 @@
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug No known bugs except for NYI items
  */
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include <common_properties.h>
 #include <compiler_fwd.h>
+#include <layer_node.h>
 #include <multiout_realizer.h>
+#include <remap_realizer.h>
 
 namespace nntrainer {
 MultioutRealizer::~MultioutRealizer() {}
 
 GraphRepresentation
 MultioutRealizer::realize(const GraphRepresentation &reference) {
+  GraphRepresentation processed(reference.begin(), reference.end());
+
+  std::unordered_multiset<std::string> freq_map;
+  std::unordered_set<std::string> node_names;
+  std::unordered_set<std::string> connection_names;
+
+  /// 1. build frequency map and connection names
+  for (auto &node : reference) {
+    NNTR_THROW_IF(node_names.count(node->getName()), std::invalid_argument)
+      << "node name clashes: " << node->getName();
+    node_names.emplace(node->getName());
+
+    for (unsigned int i = 0, num_nodes = node->getNumInputConnections();
+         i < num_nodes; ++i) {
+      props::InputConnection c(props::Connection(
+        node->getInputConnectionName(i), node->getInputConnectionIndex(i)));
+      auto uniq_name = to_string(c);
+      connection_names.emplace(uniq_name);
+      freq_map.emplace(uniq_name);
+    }
+  }
+
+  /// 2. for each connection names, if a connection is referenced multiple
+  /// times, create multioutput node and remap to multi output node index
+  std::unordered_multimap<std::string /**< original id */,
+                          std::shared_ptr<LayerNode> /**< created node */>
+    multiout_nodes;
+
+  for (auto &con_name : connection_names) {
+    props::InputConnection con;
+    from_string(con_name, con);
+    if (freq_map.count(con_name) <= 1) {
+      continue;
+    }
+
+    std::string id = con.get().getName();
+    auto idx = con.get().getIndex();
+
+    std::stringstream ss;
+    /// {connection_name}/generated_out_{index}
+    ss << id << "/generated_out_" << idx;
+    while (node_names.count(ss.str()) != 0) {
+      ss << "_";
+    }
+    auto multiout_name = ss.str();
+
+    multiout_nodes.emplace(
+      id, createLayerNode(
+            "multiout", {"name=" + multiout_name, "input_layers=" + con_name}));
+    node_names.emplace(multiout_name);
+
+    unsigned input_count = 0;
+    RemapRealizer remapper([&id, &multiout_name, idx,
+                            &input_count](std::string &id_, unsigned &idx_) {
+      if (id_ == id && idx_ == idx) {
+        id_ = multiout_name;
+        idx_ = input_count++;
+      }
+    });
+
+    processed = remapper.realize(processed);
+  }
+
+  /// 3. insert multiout_nodes close to the original node to make the
+  /// realization more sensible
   GraphRepresentation ret;
-  return GraphRepresentation();
+  ret.reserve(processed.size());
+  for (auto &node : processed) {
+    ret.push_back(node);
+    auto ranges = multiout_nodes.equal_range(node->getName());
+    for (auto it = ranges.first; it != ranges.second; ++it) {
+      ret.push_back(it->second);
+    }
+  }
+
+  return ret;
 }
 
 } // namespace nntrainer

--- a/nntrainer/compiler/multiout_realizer.cpp
+++ b/nntrainer/compiler/multiout_realizer.cpp
@@ -28,9 +28,8 @@ GraphRepresentation
 MultioutRealizer::realize(const GraphRepresentation &reference) {
   GraphRepresentation processed(reference.begin(), reference.end());
 
-  std::unordered_multiset<std::string> freq_map;
   std::unordered_set<std::string> node_names;
-  std::unordered_set<std::string> connection_names;
+  std::unordered_map<std::string, unsigned> freq_map;
 
   /// 1. build frequency map and connection names
   for (auto &node : reference) {
@@ -43,8 +42,8 @@ MultioutRealizer::realize(const GraphRepresentation &reference) {
       props::InputConnection c(props::Connection(
         node->getInputConnectionName(i), node->getInputConnectionIndex(i)));
       auto uniq_name = to_string(c);
-      connection_names.emplace(uniq_name);
-      freq_map.emplace(uniq_name);
+      [[maybe_unused]] auto [iter, result] = freq_map.try_emplace(uniq_name, 0);
+      iter->second++;
     }
   }
 
@@ -54,10 +53,10 @@ MultioutRealizer::realize(const GraphRepresentation &reference) {
                           std::shared_ptr<LayerNode> /**< created node */>
     multiout_nodes;
 
-  for (auto &con_name : connection_names) {
+  for (auto &[con_name, freq] : freq_map) {
     props::InputConnection con;
     from_string(con_name, con);
-    if (freq_map.count(con_name) <= 1) {
+    if (freq <= 1) {
       continue;
     }
 

--- a/nntrainer/compiler/multiout_realizer.cpp
+++ b/nntrainer/compiler/multiout_realizer.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file multiout_realizer.h
+ * @date 17 November 2021
+ * @brief NNTrainer graph realizer which realizes multiout to actual node
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <compiler_fwd.h>
+#include <multiout_realizer.h>
+
+namespace nntrainer {
+MultioutRealizer::~MultioutRealizer() {}
+
+GraphRepresentation
+MultioutRealizer::realize(const GraphRepresentation &reference) {
+  GraphRepresentation ret;
+  return GraphRepresentation();
+}
+
+} // namespace nntrainer

--- a/nntrainer/compiler/multiout_realizer.h
+++ b/nntrainer/compiler/multiout_realizer.h
@@ -21,6 +21,8 @@ namespace nntrainer {
 
 /**
  * @brief Add multiout layer when a certain input is referenced multiple times
+ * @note after multiout realizer, it is guaranteed that input_layer only refers
+ * to a single connection
  *
  */
 class MultioutRealizer final : public GraphRealizer {

--- a/nntrainer/compiler/multiout_realizer.h
+++ b/nntrainer/compiler/multiout_realizer.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+ *
+ * @file multiout_realizer.h
+ * @date 17 November 2021
+ * @brief NNTrainer graph realizer which realizes multiout to actual node
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#ifndef __MULTIOUT_REALIZER_H__
+#define __MULTIOUT_REALIZER_H__
+
+#include <memory>
+#include <vector>
+
+#include <realizer.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Add multiout layer when a certain input is referenced multiple times
+ *
+ */
+class MultioutRealizer final : public GraphRealizer {
+public:
+  /**
+   * @brief Destroy the Graph Realizer object
+   *
+   */
+  ~MultioutRealizer();
+
+  /**
+   * @brief graph realizer creates a new graph based on the reference
+   *
+   */
+  GraphRepresentation realize(const GraphRepresentation &reference) override;
+};
+
+} // namespace nntrainer
+
+#endif // __MULTIOUT_REALIZER_H__

--- a/nntrainer/compiler/remap_realizer.cpp
+++ b/nntrainer/compiler/remap_realizer.cpp
@@ -4,7 +4,7 @@
  *
  * @file remap_realizer.h
  * @date 12 October 2021
- * @brief NNTrainer graph realizer which realizes identifer to a new identifier
+ * @brief NNTrainer graph realizer which realizes identifier to a new identifier
  * @see	https://github.com/nnstreamer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug No known bugs except for NYI items
@@ -15,8 +15,18 @@
 namespace nntrainer {
 
 RemapRealizer::RemapRealizer(
+  std::function<void(std::string &, unsigned &)> remap_connection_function) :
+  remap_fn(nullptr),
+  remap_connection_fn(remap_connection_function) {
+  if (!remap_connection_fn) {
+    throw std::invalid_argument("remap function is not given!");
+  }
+}
+
+RemapRealizer::RemapRealizer(
   std::function<void(std::string &)> remap_function) :
-  remap_fn(remap_function) {
+  remap_fn(remap_function),
+  remap_connection_fn(nullptr) {
   if (!remap_fn) {
     throw std::invalid_argument("remap function is not given!");
   }
@@ -30,7 +40,8 @@ RemapRealizer::realize(const GraphRepresentation &reference) {
 
   for (auto &node : processed) {
     /// @note while remap realization, the graph is invalid.
-    node->remapIdentifiers(remap_fn);
+    remap_connection_fn ? node->remapConnections(remap_connection_fn)
+                        : node->remapIdentifiers(remap_fn);
   }
   return processed;
 }

--- a/nntrainer/compiler/remap_realizer.h
+++ b/nntrainer/compiler/remap_realizer.h
@@ -28,7 +28,28 @@ namespace nntrainer {
  */
 class RemapRealizer final : public GraphRealizer {
 public:
-  RemapRealizer(std::function<void(std::string &)> remap_function);
+  /**
+   * @brief Construct a new Remap Realizer object (connection mode)
+   *
+   * @param remap_connection_function remap connection function, with this
+   * constructor, only connections will be remapped eg) if you are inserting a
+   * new layer node in between, only connections need remapping
+   */
+  RemapRealizer(
+    std::function<void(std::string & /**< identifier */,
+                       unsigned & /**< index of a connection, remapping
+                                     identifier should not modify this */)>
+      remap_connection_function);
+
+  /**
+   * @brief Construct a new Remap Realizer object (identifier mode)
+   *
+   * @param remap_function remap function, with this constructor, all
+   * identifiers whereever it is used will be remapped
+   */
+  RemapRealizer(
+    std::function<void(std::string & /**< identifier */)> remap_function);
+
   /**
    * @brief Destroy the Graph Realizer object
    *
@@ -43,6 +64,7 @@ public:
 
 private:
   std::function<void(std::string &)> remap_fn;
+  std::function<void(std::string &, unsigned &)> remap_connection_fn;
 };
 
 } // namespace nntrainer

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -99,19 +99,6 @@ public:
   const std::shared_ptr<GraphNode> &getNode(const std::string &name) const;
 
   /**
-   * @brief     join passed graph into the existing graph model
-   * @param[in] graph graph to be added/to extend
-   * @param[in] prefix prefix added to names of nodes from this graph
-   * @note It is assumed that this model is valid by itself
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   *
-   * @todo rename to addnodes
-   */
-  void extendGraph(std::vector<std::shared_ptr<GraphNode>> graph,
-                   std::string &prefix);
-
-  /**
    * @brief     get begin iterator for the forwarding
    * @retval    const iterator marking the begin of forwarding
    */

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -143,34 +143,6 @@ int NetworkGraph::realizeActivationType(
   return status;
 }
 
-int NetworkGraph::realizeMultiOutputType(
-  const std::shared_ptr<LayerNode> &in_node) {
-  int status = ML_ERROR_NONE;
-  /**
-   * Multi-input works with time distribution layer by itself
-   *
-   */
-
-  if (in_node->getNumOutputConnections() <= 1)
-    return ML_ERROR_NONE;
-
-  std::shared_ptr<LayerNode> lnode = createLayerNode(MultiOutLayer::type);
-  graph.ensureName(*lnode, in_node->getName());
-
-  lnode->setInputLayers({in_node->getName()});
-  lnode->setOutputLayers(in_node->getOutputLayers());
-
-  in_node->setOutputLayers({lnode->getName()});
-
-  for (unsigned int i = 0; i < in_node->getNumOutputConnections(); ++i) {
-    updateConnectionName(in_node->getName(), lnode->getName());
-  }
-
-  graph.addNode(lnode, false);
-
-  return status;
-}
-
 int NetworkGraph::addLossLayer(const std::string &loss_type_) {
   for (unsigned int i = 0; i < graph.getNumOutputNodes(); ++i) {
     auto output_layer_node = LNODE(graph.getOutputNode(i));
@@ -352,19 +324,6 @@ int NetworkGraph::realizeGraph() {
     return ML_ERROR_INVALID_PARAMETER;
   }
 
-  /**
-   * invariant: the new realized nodes are added to the end,
-   * otherwise this iteration becomes invalid. So, every iteration must be
-   * fresh iterator as vector resize invalidates all the iterators.
-   */
-  for (unsigned int i = 0; i < graph.size(); ++i) {
-    auto const &lnode = LNODE(*(cbegin() + i));
-    if (lnode->getType() != MultiOutLayer::type &&
-        lnode->getType() != SplitLayer::type) {
-      status = realizeMultiOutputType(lnode);
-      NN_RETURN_STATUS();
-    }
-  }
   /// @todo add check that input_layers <-> output_layers does match.
   /// @todo check whether graph has a cycle or graph is seperated to subgraph
 

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -127,19 +127,6 @@ public:
   std::vector<std::shared_ptr<LayerNode>> getLayerNodes() const;
 
   /**
-   * @brief     join passed graph into the existing graph model
-   * @param[in] graph graph to be added/to extend
-   * @param[in] prefix prefix added to names of layers from this graph
-   * @note It is assumed that this model is valid by itself
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   *
-   * @todo rename to addLayers
-   */
-  void extendGraph(std::vector<std::shared_ptr<LayerNode>> graph,
-                   std::string &prefix);
-
-  /**
    * @brief     set batch size
    * @param[in] batch size
    */
@@ -408,13 +395,6 @@ private:
   void markNodesForBackwarding();
 
   /**
-   * @brief     Realize Graph Nodes
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int realizeGraph();
-
-  /**
    * @brief     adding loss layer at last position
    * @param[in] loss_type loss type
    * @retval #ML_ERROR_NONE Successful.
@@ -444,14 +424,6 @@ private:
    * @param[in] layer shared_ptr of Layer
    */
   void addLayerNode(std::unique_ptr<Layer> layer);
-
-  /**
-   * @brief update input_layers, output_layers node name
-   *
-   * @param from update name from @a from
-   * @param to update name to @a to
-   */
-  void updateConnectionName(const std::string &from, const std::string &to);
 
   /**
    * @brief finalize already added loss layers

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -415,14 +415,6 @@ private:
   int realizeGraph();
 
   /**
-   * @brief     check and add Multi output Layer : output Layer
-   * @param[in] in_node layernode
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int realizeMultiOutputType(const std::shared_ptr<LayerNode> &in_node);
-
-  /**
    * @brief     Realize act type to layer and insert it to layers
    * @param[in] in_node layernode
    * @retval #ML_ERROR_NONE Successful.

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -415,14 +415,6 @@ private:
   int realizeGraph();
 
   /**
-   * @brief     Realize act type to layer and insert it to layers
-   * @param[in] in_node layernode
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int realizeActivationType(const std::shared_ptr<LayerNode> &in_node);
-
-  /**
    * @brief     adding loss layer at last position
    * @param[in] loss_type loss type
    * @retval #ML_ERROR_NONE Successful.

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -328,25 +328,6 @@ nntrainer::Layer *LayerNode::getLayer() {
     return layer.get();
 }
 
-void LayerNode::updateInputLayers(const std::string &from,
-                                  const std::string &to) {
-  auto &input_layers =
-    std::get<std::vector<props::InputConnection>>(*layer_node_props);
-  for (auto &input_layer : input_layers) {
-    if (istrequal(input_layer.get().getName(), from)) {
-      input_layer.set({to, 0});
-    }
-  }
-}
-
-void LayerNode::updateInputLayers(const unsigned int idx,
-                                  const std::string &to) {
-  auto &input_layers =
-    std::get<std::vector<props::InputConnection>>(*layer_node_props);
-
-  input_layers.at(idx).set({to, 0});
-}
-
 void LayerNode::addInputLayers(const std::string &in_layer) {
   auto &input_layers =
     std::get<std::vector<props::InputConnection>>(*layer_node_props);

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -409,22 +409,6 @@ public:
   const std::vector<std::string> getOutputLayers() const;
 
   /**
-   * @brief Update input layers entry name
-   *
-   * @param from The name to be updated
-   * @param to The name to be updated to
-   */
-  void updateInputLayers(const std::string &from, const std::string &to);
-
-  /**
-   * @brief Update the input layers name at the given idx
-   *
-   * @param idx The index at which layer name must be updated
-   * @param to The name to be updated to
-   */
-  void updateInputLayers(const unsigned int idx, const std::string &to);
-
-  /**
    * @brief Add name to the input layers
    *
    * @param in_layer Name to be added

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -699,6 +699,14 @@ public:
   void remapIdentifiers(std::function<void(std::string &)> remap_fn);
 
   /**
+   * @brief remap connections(input, output layers ) inside layer node
+   *
+   * @param remap_fn function to remap
+   */
+  void
+  remapConnections(std::function<void(std::string &, unsigned &)> remap_fn);
+
+  /**
    * @brief create the same node with same properties and types
    *
    * @note this must be done before finalize() as finalize has some potential to

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -33,6 +33,7 @@
 #include <ini_wrapper.h>
 #include <input_realizer.h>
 #include <model_loader.h>
+#include <multiout_realizer.h>
 #include <neuralnet.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
@@ -133,6 +134,7 @@ int NeuralNetwork::compile() {
   std::vector<std::unique_ptr<GraphRealizer>> realizers;
 
   realizers.emplace_back(new PreviousInputRealizer(input_layers));
+  realizers.emplace_back(new MultioutRealizer());
   realizers.emplace_back(new FlattenRealizer());
 
   for (auto &realizer : realizers) {

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <sstream>
 
+#include <activation_realizer.h>
 #include <databuffer.h>
 #include <flatten_realizer.h>
 #include <ini_interpreter.h>
@@ -136,6 +137,7 @@ int NeuralNetwork::compile() {
   realizers.emplace_back(new PreviousInputRealizer(input_layers));
   realizers.emplace_back(new MultioutRealizer());
   realizers.emplace_back(new FlattenRealizer());
+  realizers.emplace_back(new ActivationRealizer());
 
   for (auto &realizer : realizers) {
     rep = realizer->realize(rep);

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -826,18 +826,6 @@ int NeuralNetwork::addLayer(NodeType layer) {
   return status;
 }
 
-int NeuralNetwork::extendGraph(GraphType graph, std::string prefix) {
-  if (initialized) {
-    return ML_ERROR_NOT_SUPPORTED;
-  }
-
-  if (graph.size() == 0)
-    return ML_ERROR_NONE;
-
-  model_graph.extendGraph(graph, prefix);
-  return ML_ERROR_NONE;
-}
-
 NeuralNetwork::GraphType
 NeuralNetwork::getUnsortedLayers(const std::string &input_layer,
                                  const std::string &output_layer) {

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -319,16 +319,6 @@ public:
   int addLayer(NodeType layer);
 
   /**
-   * @brief     join passed graph into the existing graph model
-   * @param[in] graph graph to be added/to extend
-   * @param[in] prefix prefix added to names of layers from this graph
-   * @note It is assumed that this model is valid by itself
-   * @retval #ML_ERROR_NONE Successful.
-   * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
-   */
-  int extendGraph(GraphType graph, std::string prefix = "");
-
-  /**
    * @brief     set optimizer for the neural network model
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -17,6 +17,7 @@
 #include <flatten_realizer.h>
 #include <input_realizer.h>
 #include <previous_input_realizer.h>
+#include <multiout_realizer.h>
 #include <realizer.h>
 #include <recurrent_realizer.h>
 #include <remap_realizer.h>
@@ -297,4 +298,11 @@ TEST(PreviousInputRealizer, user_not_identifying_first_input_n) {
   };
   PreviousInputRealizer r({});
   EXPECT_ANY_THROW(realizeAndEqual(r, before, {}));
+}
+TEST(MultioutRealizer, multiout_p) {
+  std::vector<LayerRepresentation> before = {};
+  std::vector<LayerRepresentation> after = {};
+
+  MultioutRealizer r;
+  realizeAndEqual(r, before, after);
 }

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -16,8 +16,8 @@
 
 #include <flatten_realizer.h>
 #include <input_realizer.h>
-#include <previous_input_realizer.h>
 #include <multiout_realizer.h>
+#include <previous_input_realizer.h>
 #include <realizer.h>
 #include <recurrent_realizer.h>
 #include <remap_realizer.h>
@@ -124,6 +124,14 @@ TEST(RemapRealizer, remap_p) {
     {"name=scoped/layer1", "flatten=true", "input_layers=scoped/1,scoped/2"}};
 
   realizeAndEqual(r, {input1}, {expected1});
+  RemapRealizer r2(
+    [](std::string &name, unsigned &_) { name = "scoped/" + name; });
+
+  LayerRepresentation expected2 = {
+    "fully_connected",
+    {"name=layer1", "flatten=true", "input_layers=scoped/1,scoped/2"}};
+
+  realizeAndEqual(r2, {input1}, {expected2});
 }
 
 TEST(SliceRealizer, slice_01_p) {


### PR DESCRIPTION
## Dependency of the PR


- **[Pending commit: #1733]**


## Commits to be reviewed in this PR


<details><summary>[Realizer] Implement activation realizer</summary><br />

This patch implement activation realizer

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Test] Activation realizer test</summary><br />

This patch implement activation realizer

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[nn] Attach activation realizer</summary><br />

This patch attach activation realizer

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Clean] Remove unused function</summary><br />

remove unused function before adaption multioutput.

Main reason for the clean is that the functions are not used but
hard to maintain for the incoming change of adapting multi output

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

