### PR TITLE
[layer] Embedding layer new property + bug fix @open sesame 11/29 16:00

### DIFF
--- a/Applications/ProductRatings/jni/main.cpp
+++ b/Applications/ProductRatings/jni/main.cpp
@@ -82,10 +82,11 @@ bool getData(std::ifstream &F, float *input, float *label, unsigned int id) {
     return false;
 
   std::istringstream buffer(temp);
-  float x;
+  uint *input_int = (uint *)input;
+  uint x;
   for (unsigned int j = 0; j < feature_size; ++j) {
     buffer >> x;
-    input[j] = x;
+    input_int[j] = x;
   }
   buffer >> x;
   label[0] = x;
@@ -130,6 +131,7 @@ int getSample_train(float **outVec, float **outLabel, bool *last,
 
   return 0;
 }
+
 /**
  * @brief     create NN
  *            back propagation of NN

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -493,6 +493,18 @@ public:
 };
 
 /**
+ * @brief Zero idx mask property for embedding where the value of embedding
+ * will be zero
+ *
+ */
+class ZeroIdxMask : public nntrainer::Property<uint> {
+public:
+  static constexpr const char *key =
+    "zero_idx_mask";              /**< unique key to access */
+  using prop_tag = uint_prop_tag; /**< property type */
+};
+
+/**
  * @brief DropOutRate property, this defines drop out specification of layer
  *
  */

--- a/nntrainer/layers/embedding.h
+++ b/nntrainer/layers/embedding.h
@@ -94,7 +94,7 @@ public:
   inline static const std::string type = "embedding";
 
 private:
-  std::tuple<props::InDim, props::OutDim> embedding_props;
+  std::tuple<props::InDim, props::OutDim, props::ZeroIdxMask> embedding_props;
   unsigned int weight_idx;
 };
 } // namespace nntrainer

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1189,24 +1189,6 @@ std::ostream &operator<<(std::ostream &out, Tensor const &m) {
   return out;
 }
 
-float *Tensor::getAddress(unsigned int i) {
-  if (i > getIndex(batch(), channel(), height(), width())) {
-    ml_loge("Error: Index out of bounds");
-    return nullptr;
-  }
-
-  return &getData()[i];
-}
-
-const float *Tensor::getAddress(unsigned int i) const {
-  if (i > getIndex(batch(), channel(), height(), width())) {
-    ml_loge("Error: Index out of bounds");
-    return nullptr;
-  }
-
-  return &getData()[i];
-}
-
 void Tensor::copy(const float *buf) noexcept {
   NNTR_THROW_IF(!contiguous, std::invalid_argument)
     << getName() << "Tensor is not contiguous, cannot copy.";

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -849,14 +849,6 @@ public:
   }
 
   /**
-   * @brief     Get int interpretable tensor
-   *
-   * @todo      This is a temporary workout. Remove this once multiple datatypes
-   * are supported.
-   */
-  template <typename T> const int *getData() const { return (int *)data.get(); }
-
-  /**
    * @brief     Fill the Tensor elements with value
    * @param[in] value value to be stored
    */
@@ -1068,28 +1060,42 @@ public:
    * @brief     i data index
    * @retval    address of ith data
    */
-  float *getAddress(unsigned int i);
+  template <typename T = float> T *getAddress(unsigned int i) {
+    if (i > getIndex(batch(), channel(), height(), width())) {
+      return nullptr;
+    }
+
+    return &getData<T>()[i];
+  }
 
   /**
    * @brief     i data index
    * @retval    address of ith data
    */
-  const float *getAddress(unsigned int i) const;
+  template <typename T = float> const T *getAddress(unsigned int i) const {
+    if (i > getIndex(batch(), channel(), height(), width())) {
+      return nullptr;
+    }
 
-  /**
-   * @brief    get address of n-d data
-   */
-  float *getAddress(unsigned int b, unsigned int c, unsigned int h,
-                    unsigned int w) {
-    return getAddress(getIndex(b, c, h, w));
+    return &getData<T>()[i];
   }
 
   /**
    * @brief    get address of n-d data
    */
-  const float *getAddress(unsigned int b, unsigned int c, unsigned int h,
-                          unsigned int w) const {
-    return getAddress(getIndex(b, c, h, w));
+  template <typename T = float>
+  T *getAddress(unsigned int b, unsigned int c, unsigned int h,
+                unsigned int w) {
+    return getAddress<T>(getIndex(b, c, h, w));
+  }
+
+  /**
+   * @brief    get address of n-d data
+   */
+  template <typename T = float>
+  const T *getAddress(unsigned int b, unsigned int c, unsigned int h,
+                      unsigned int w) const {
+    return getAddress<T>(getIndex(b, c, h, w));
   }
 
   /**


### PR DESCRIPTION
- Embedding layer should assume that the input data is written in int
format than in float data. Reading data as float can lead to wrong
values when typecasting to int if std::lround() is not properly used.
Further, as other frameworks require using integer data for embedding,
its best if follow the same input formats.
- Embedding layer support zero mask index which if set will pass zero
values for that particular index in the forward propagation and will not
be updated with gradient.
Further minor updates to tensor related to getting tensor values.

resolves #1729

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>