### PR TITLE
[fixes] Few minor fixes

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -376,6 +376,14 @@ Attention(const std::vector<std::string> &properties = {}) {
 }
 
 /**
+ * @brief Helper function to create Permute Layer
+ */
+inline std::unique_ptr<Layer>
+Permute(const std::vector<std::string> &properties = {}) {
+  return createLayer(LayerType::LAYER_PERMUTE, properties);
+}
+
+/**
  * @brief Helper function to create activation layer
  */
 inline std::unique_ptr<Layer>

--- a/nntrainer/layers/permute_layer.cpp
+++ b/nntrainer/layers/permute_layer.cpp
@@ -57,7 +57,7 @@ void PermuteLayer::finalize(InitLayerContext &context) {
 
     /*** @todo deprecate this */
     direction_str = buildTrasposeString(direction);
-    rdirection_str = buildTrasposeString(direction);
+    rdirection_str = buildTrasposeString(reverse_direction);
   };
 
   initiate_direction();

--- a/nntrainer/layers/reshape_layer.cpp
+++ b/nntrainer/layers/reshape_layer.cpp
@@ -40,6 +40,9 @@ void ReshapeLayer::finalize(InitLayerContext &context) {
     out_dim.height(1);
     out_dim.channel(1);
     out_dim.width(in_dim.getFeatureLen());
+  } else if (out_dim.getFeatureLen() != in_dim.getFeatureLen()) {
+    throw std::invalid_argument(
+      "Target and input size mismatch for reshape layer");
   }
 
   out_dim.batch(in_dim.batch());


### PR DESCRIPTION
- Add shape mismatch check in reshape layer.
- Permute layer backward bug in the calculation of the reverse
direction of the permute is fixed.
- Add missing layer constructor for permute.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>