### PR TITLE
[QuickFix] Disable contiguous check on add_i

### DIFF
--- a/nntrainer/layers/grucell.cpp
+++ b/nntrainer/layers/grucell.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Copyright (C) 2020 hyeonseok lee <hs89.lee@samsung.com>
+ * Copyright (C) 2021 hyeonseok lee <hs89.lee@samsung.com>
  *
  * @file   grucell.cpp
  * @date   28 Oct 2021
@@ -34,6 +34,8 @@
 #include <nntrainer_log.h>
 #include <node_exporter.h>
 #include <util_func.h>
+
+#include <layer_context.h>
 
 namespace nntrainer {
 

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -295,7 +295,7 @@ private:
  * @class   Layer Context class for all layers
  * @brief   Class for Layer context
  *
- * @details This provides for the layer executiong. This context will contain
+ * @details This provides for the layer executing. This context will contain
  * structures with memory allocated or support to allocate any new memory, but
  * rather only support storing specifications based on which memory will be
  * allocated later.

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -124,6 +124,12 @@ int NeuralNetwork::compile() {
     rep.push_back(*iter);
   }
 
+  if (input_layers.empty()) {
+    if (!rep.empty()) {
+      input_layers.emplace_back(rep.front()->getName());
+    }
+  }
+
   std::vector<std::unique_ptr<GraphRealizer>> realizers;
 
   realizers.emplace_back(new PreviousInputRealizer(input_layers));

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -120,7 +120,8 @@ public:
   SrcSharedTensor() : src(nullptr), off(0) {}
 
   SrcSharedTensor(const Tensor *tensor, unsigned int offset) :
-    src(tensor), off(offset) {}
+    src(tensor),
+    off(offset) {}
 
   /**
    * @brief   Get the allocated src tensor
@@ -600,8 +601,9 @@ int Tensor::add_i(Tensor const &m, float const alpha) {
     saxpy(e.buffer_size, alpha, m_buf, e.strides[3], out_buf, strides[3]);
   };
 
-  NNTR_THROW_IF(!contiguous || !m.contiguous, std::invalid_argument)
-    << getName() << " is not contiguous, cannot add";
+  /// @todo: enable this after add_strided supports broadcast
+  // NNTR_THROW_IF(!contiguous || !m.contiguous, std::invalid_argument)
+  //   << getName() << " is not contiguous, cannot add";
 
   try {
     apply_broadcast(m, f, *this);


### PR DESCRIPTION
    [QuickFix] Disable contiguous check on add_i
    
     - For now disable contiguous check of tensor on add_i
        since the add_strided does not support broadcast.
    
    Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>