### PR TITLE
[Fix] Setting batch after finalize/initialize

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -13,7 +13,6 @@
  */
 
 #include <cmath>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -262,10 +261,12 @@ void NetworkGraph::setBatchSize(unsigned int batch_size) {
     deallocateTensors();
 
   for (auto iter = cbegin(); iter != cend(); iter++) {
-    (*iter)->setBatch(batch_size);
     if ((*iter)->isFinalized()) {
+      /// resize tensors spec
+      /// @todo remove below, if cutsom tensor needs to change dimension
+      /// according to the tensor, it must be done explicitly, or at least have
+      /// a property to control the behavior
       const RunLayerContext &context = (*iter)->getRunContext();
-      // resize tensors spec
       for (unsigned int idx = 0; idx < context.getNumTensors(); idx++) {
         auto const &ts = context.getTensor(idx);
         tensor_manager->setBatchSize(ts.getName(), ts.getDim().batch());
@@ -275,6 +276,8 @@ void NetworkGraph::setBatchSize(unsigned int batch_size) {
                                        ts_grad.getDim().batch());
         }
       }
+      /// override setting batch as per request
+      (*iter)->setBatch(batch_size);
     }
   }
   /// resize input and output spec
@@ -688,7 +691,7 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
 
   /**
    * Request manager for either a pre-allocated input as output or a newly
-   * allocated input. This is necesary for manager to know when this output
+   * allocated input. This is neccesary for manager to know when this output
    * node is going to be used with in-place optimizations.
    */
   const std::vector<Var_Grad *> &outputs =

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -126,7 +126,7 @@ void BatchNormalizationLayer::finalize(InitLayerContext &context) {
    * as the output of this layer need not be stored all the time.
    */
   wt_idx[BNParams::t_full] =
-    context.requestTensor(in_dim, "tesnor_full", Tensor::Initializer::NONE,
+    context.requestTensor(in_dim, "tensor_full", Tensor::Initializer::NONE,
                           false, TensorLifespan::BACKWARD_FUNC_LIFESPAN);
   /**
    * caches variance + epsilon as well.
@@ -256,6 +256,18 @@ void BatchNormalizationLayer::setBatch(RunLayerContext &context,
                                        unsigned int batch) {
   context.updateTensor(wt_idx[BNParams::deviation], batch);
   context.updateTensor(wt_idx[BNParams::t_full], batch);
+
+  /// reset divider
+  divider = 1;
+  auto input_dim = context.getInput(0).getDim();
+  for (auto axis : axes_to_reduce) {
+    if (axis == 0) {
+      /// @note input dim batch is not updated, it will be more sensible we
+      /// update batch before any node comes to this spot
+      divider *= batch;
+    }
+    divider *= input_dim.getTensorDim(axis);
+  }
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/grucell.cpp
+++ b/nntrainer/layers/grucell.cpp
@@ -409,7 +409,11 @@ void GRUCellLayer::setBatch(RunLayerContext &context, unsigned int batch) {
   context.updateTensor(wt_idx[GRUCellParams::hidden_state],
                        max_timestep * batch);
   context.updateTensor(wt_idx[GRUCellParams::zrg], max_timestep * batch);
-  context.updateTensor(wt_idx[GRUCellParams::dropout_mask], batch);
+
+  const float dropout_rate = std::get<props::DropOutRate>(grucell_props);
+  if (dropout_rate > epsilon) {
+    context.updateTensor(wt_idx[GRUCellParams::dropout_mask], batch);
+  }
 }
 
 } // namespace nntrainer

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -611,20 +611,10 @@ void LayerNode::calcGradient() {
  * @brief Set the batch for the layer
  */
 void LayerNode::setBatch(unsigned int batch) {
-  /** @todo we won't going to need Layer::setBatch(InitLayerContext), remove it
-   */
-  if (hasInputShapeProperty()) {
-    auto &input_shapes =
-      std::get<std::vector<props::InputShape>>(*layer_node_props);
-    for (auto &input_shape : input_shapes) {
-      input_shape.get().batch(batch);
-    }
-  }
+  NNTR_THROW_IF(!run_context, std::invalid_argument)
+    << " setting batch not supported before initialization";
 
-  if (run_context) {
-    run_context->setBatch(batch);
-    getLayer()->setBatch(*run_context, batch);
-  }
+  getLayer()->setBatch(*run_context, batch);
 }
 
 /**

--- a/nntrainer/layers/lstmcell.cpp
+++ b/nntrainer/layers/lstmcell.cpp
@@ -378,7 +378,11 @@ void LSTMCellLayer::setBatch(RunLayerContext &context, unsigned int batch) {
   context.updateTensor(wt_idx[LSTMParams::hidden_state], batch * max_timestep);
   context.updateTensor(wt_idx[LSTMParams::mem_cell], batch * max_timestep);
   context.updateTensor(wt_idx[LSTMParams::fgio], batch * max_timestep);
-  context.updateTensor(wt_idx[LSTMParams::dropout_mask], batch);
+
+  const float dropout_rate = std::get<props::DropOutRate>(lstm_props);
+  if (dropout_rate > epsilon) {
+    context.updateTensor(wt_idx[LSTMParams::dropout_mask], batch);
+  }
 }
 
 } // namespace nntrainer

--- a/nntrainer/layers/rnncell.cpp
+++ b/nntrainer/layers/rnncell.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <cmath>
+#include <common_properties.h>
 
 #include <layer_context.h>
 #include <nntrainer_error.h>
@@ -248,7 +249,12 @@ void RNNCellLayer::setBatch(RunLayerContext &context, unsigned int batch) {
   const unsigned int max_timestep = std::get<props::MaxTimestep>(rnncell_props);
   context.updateTensor(wt_idx[RNNCellParams::hidden_state],
                        batch * max_timestep);
-  context.updateTensor(wt_idx[RNNCellParams::dropout_mask], batch);
+
+  const float dropout_rate = std::get<props::DropOutRate>(rnncell_props);
+  if (dropout_rate > epsilon) {
+    /// @note default value of wt_idx[dropout_mask] is 0
+    context.updateTensor(wt_idx[RNNCellParams::dropout_mask], batch);
+  }
 }
 
 } // namespace nntrainer

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -159,9 +159,6 @@ int NeuralNetwork::initialize() {
 
   ml_logd("initializing neural network, layer size: %d", n_layers);
 
-  model_graph.setBatchSize(
-    std::get<props::TrainingBatchSize>(model_flex_props));
-
   auto &input_conn_prop =
     std::get<std::vector<props::InputConnection>>(model_props);
   auto &label_layer_prop =
@@ -180,6 +177,9 @@ int NeuralNetwork::initialize() {
     input_conn,
     std::vector<Connection>(label_layers.begin(), label_layers.end()));
   NN_RETURN_STATUS();
+
+  model_graph.setBatchSize(
+    std::get<props::TrainingBatchSize>(model_flex_props));
 
   // initialize optimizer and related variables
   if (opt) {


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Fix] Setting batch after finalize/initialize</summary><br />

This patch delays setting batch after finalize/initialize.

Setting batch must be done after runcontext has made, the reason is that
we have semantics that finalize should be independent of batch size, but
if batch size is set before output_dims batch must be set according to
input_dims batch, which is not desirable.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

