### PR TITLE
[Dev] Expose app context header

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -13,6 +13,8 @@
 /usr/include/nntrainer/layer_context.h
 /usr/include/nntrainer/layer_devel.h
 /usr/include/nntrainer/layer_impl.h
+# custom layer kits
+/usr/include/nntrainer/app_context.h
 # optimizer headers
 /usr/include/nntrainer/optimizer_context.h
 /usr/include/nntrainer/optimizer_devel.h

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -21,8 +21,10 @@
 #include <iniparser.h>
 
 #include <app_context.h>
+#include <layer.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
+#include <optimizer.h>
 #include <util_func.h>
 
 #include <adam.h>
@@ -480,5 +482,59 @@ AppContext::registerPluggableFromDirectory(const std::string &base_path) {
 
   return keys;
 }
+
+template <typename T>
+const int AppContext::registerFactory(const FactoryType<T> factory,
+                                      const std::string &key,
+                                      const int int_key) {
+  static_assert(isSupported<T>::value,
+                "given type is not supported for current app context");
+
+  auto &index = std::get<IndexType<T>>(factory_map);
+  auto &str_map = std::get<StrIndexType<T>>(index);
+  auto &int_map = std::get<IntIndexType>(index);
+
+  std::string assigned_key = key == "" ? factory({})->getType() : key;
+
+  std::transform(assigned_key.begin(), assigned_key.end(), assigned_key.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+
+  const std::lock_guard<std::mutex> lock(factory_mutex);
+  if (str_map.find(assigned_key) != str_map.end()) {
+    std::stringstream ss;
+    ss << "cannot register factory with already taken key: " << key;
+    throw std::invalid_argument(ss.str().c_str());
+  }
+
+  if (int_key != -1 && int_map.find(int_key) != int_map.end()) {
+    std::stringstream ss;
+    ss << "cannot register factory with already taken int key: " << int_key;
+    throw std::invalid_argument(ss.str().c_str());
+  }
+
+  int assigned_int_key = int_key == -1 ? str_map.size() + 1 : int_key;
+
+  str_map[assigned_key] = factory;
+  int_map[assigned_int_key] = assigned_key;
+
+  ml_logd("factory has registered with key: %s, int_key: %d",
+          assigned_key.c_str(), assigned_int_key);
+
+  return assigned_int_key;
+}
+
+/**
+ * @copydoc const int AppContext::registerFactory
+ */
+template const int AppContext::registerFactory<ml::train::Optimizer>(
+  const FactoryType<ml::train::Optimizer> factory, const std::string &key,
+  const int int_key);
+
+/**
+ * @copydoc const int AppContext::registerFactory
+ */
+template const int AppContext::registerFactory<nntrainer::Layer>(
+  const FactoryType<nntrainer::Layer> factory, const std::string &key,
+  const int int_key);
 
 } // namespace nntrainer

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -14,6 +14,7 @@ nntrainer_inc_abs = [
 nntrainer_sources = []
 nntrainer_headers = [
    meson.current_source_dir() / 'nntrainer_error.h',
+   meson.current_source_dir() / 'app_context.h',
 ]
 
 # Dependencies

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -458,6 +458,8 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/layer_context.h
 %{_includedir}/nntrainer/layer_devel.h
 %{_includedir}/nntrainer/layer_impl.h
+# custom layer kits
+%{_includedir}/nntrainer/app_context.h
 # optimizer headers
 %{_includedir}/nntrainer/optimizer_context.h
 %{_includedir}/nntrainer/optimizer_devel.h


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Dev] Expose app context header</summary><br />

This patch exposes app context header to make custom layer deployable.
Please note that this is a temporary measure and we might want to use
diffrent abstraction for this.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Header] Remove nntrainer_log.h from app_context.h</summary><br />

This patch removes nntrainer_log.h from app_context.h and implement
additional safecheck

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

