### PR TITLE
[ Fix ] bug fixes in tensor_pool and resnet

### DIFF
--- a/Applications/Resnet/jni/cifar_dataloader.cpp
+++ b/Applications/Resnet/jni/cifar_dataloader.cpp
@@ -85,11 +85,9 @@ void RandomDataLoader::next(float **input, float **label, bool *last) {
 
   auto fill_label = [this](float *label, unsigned int batch,
                            unsigned int length) {
-    for (unsigned int i = 0; i < batch; ++i) {
-      unsigned int generated_label = label_dist(rng);
-      fillLabel(label, length, generated_label);
-      label += length;
-    }
+    unsigned int generated_label = label_dist(rng);
+    fillLabel(label, length, generated_label);
+    label += length;
   };
 
   if (updateIteration(iteration, iteration_for_one_epoch)) {
@@ -99,7 +97,7 @@ void RandomDataLoader::next(float **input, float **label, bool *last) {
 
   float **cur_input_tensor = input;
   for (unsigned int i = 0; i < input_shapes.size(); ++i) {
-    fill_input(*cur_input_tensor, input_shapes.at(i).getDataLen());
+    fill_input(*cur_input_tensor, input_shapes.at(i).getFeatureLen());
     cur_input_tensor++;
   }
 

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -146,8 +146,7 @@ void Manager::allocateTensors(unsigned int max_exec_order_) {
 
   if (!tensor_pool.isAllocated()) {
     finalizeTensorPool(tensor_pool, 0, max_exec_order_);
-    if (tensor_pool.minMemoryRequirement() > 0)
-      tensor_pool.allocate();
+    tensor_pool.allocate();
   }
 }
 

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -169,6 +169,8 @@ void TensorPool::setBatchSize(const std::string &name, unsigned int batch) {
  * @brief Allocate memory for all the managed tensors
  */
 void TensorPool::allocate() {
+  if (minMemoryRequirement() == 0)
+    return;
   mem_pool.allocate();
 
   /** set the pointers using the token for all the tensors */

--- a/test/unittest/unittest_nntrainer_tensor_pool.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool.cpp
@@ -298,7 +298,7 @@ TEST(TensorPool, allocate_deallocate_01_p) {
 TEST(TensorPool, allocate_deallocate_02_n) {
   nntrainer::TensorPool pool;
 
-  EXPECT_THROW(pool.allocate(), std::runtime_error);
+  EXPECT_NO_THROW(pool.allocate());
 
   EXPECT_NO_THROW(pool.deallocate());
 }
@@ -439,7 +439,7 @@ TEST(TensorPool, placeholder_p) {
   pool.placeholder("a", {10});
   pool.placeholder("b", {10});
   pool.finalize(nntrainer::BasicPlanner(), 0, 2);
-  EXPECT_ANY_THROW(pool.allocate()); // allocating size of 0
+  EXPECT_NO_THROW(pool.allocate());
 }
 
 TEST(TensorPool, placeholder_clashing_name_n) {


### PR DESCRIPTION
There were bugs releate with,
  . Tensor_pool try to allocate even if there is no need
  . Resnet in RandomData generate batch size data

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>