### PR TITLE
[Tensor Sharing] Make tensor sharing private by default

### DIFF
--- a/nntrainer/layers/grucell.cpp
+++ b/nntrainer/layers/grucell.cpp
@@ -132,12 +132,12 @@ void GRUCellLayer::finalize(InitLayerContext &context) {
   TensorDim hidden_state_dim(max_timestep * batch_size, 1, 1, unit);
   wt_idx[GRUCellParams::hidden_state] = context.requestTensor(
     hidden_state_dim, "hidden_state", Tensor::Initializer::NONE, true,
-    TensorLifespan::ITERATION_LIFESPAN);
+    TensorLifespan::ITERATION_LIFESPAN, false);
 
   TensorDim zrg_dim(max_timestep * batch_size, 1, 1, unit * NUM_GATE);
   wt_idx[GRUCellParams::zrg] =
     context.requestTensor(zrg_dim, "zrg", Tensor::Initializer::NONE, true,
-                          TensorLifespan::ITERATION_LIFESPAN);
+                          TensorLifespan::ITERATION_LIFESPAN, false);
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -174,6 +174,7 @@ public:
    * @param trainable if the tensor is trainable (require gradient or not)
    * @param name name of the tensor
    * @param lifespan lifespan of the tensor
+   * @param private_ if custom tensor should not be shared, and only for soleuse
    * @return unsigned int index of the tensor for its getter
    *
    * @todo Consider providing a guarantee that the returned indices will always
@@ -183,8 +184,10 @@ public:
   requestTensor(const TensorDim &dim, const std::string &name,
                 const Tensor::Initializer init = Tensor::Initializer::NONE,
                 bool trainable = false,
-                TensorLifespan lifespan = TensorLifespan::ITERATION_LIFESPAN) {
-    tensors_spec.emplace_back(dim, init, trainable, prefix + ":" + name,
+                TensorLifespan lifespan = TensorLifespan::ITERATION_LIFESPAN,
+                bool private_ = true) {
+    auto prefix_ = private_ ? this->name : this->prefix;
+    tensors_spec.emplace_back(dim, init, trainable, prefix_ + ":" + name,
                               lifespan);
     return tensors_spec.size() - 1;
   }

--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -133,15 +133,15 @@ void LSTMLayer::finalize(InitLayerContext &context) {
 
   wt_idx[LSTMParams::hidden_state] =
     context.requestTensor(d, "hidden_state", Tensor::Initializer::NONE, true,
-                          TensorLifespan::ITERATION_LIFESPAN);
+                          TensorLifespan::ITERATION_LIFESPAN, false);
   wt_idx[LSTMParams::mem_cell] =
     context.requestTensor(d, "mem_cell", Tensor::Initializer::NONE, true,
-                          TensorLifespan::ITERATION_LIFESPAN);
+                          TensorLifespan::ITERATION_LIFESPAN, false);
 
   d.width(unit * NUM_GATE);
   wt_idx[LSTMParams::fgio] =
     context.requestTensor(d, "fgio", Tensor::Initializer::NONE, true,
-                          TensorLifespan::ITERATION_LIFESPAN);
+                          TensorLifespan::ITERATION_LIFESPAN, false);
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);

--- a/nntrainer/layers/lstmcell.cpp
+++ b/nntrainer/layers/lstmcell.cpp
@@ -131,10 +131,10 @@ void LSTMCellLayer::finalize(InitLayerContext &context) {
   /** hidden dim = [ UnrollLength, 1, Batch, Units ] */
   wt_idx[LSTMParams::hidden_state] =
     context.requestTensor(d, "hidden_state", Tensor::Initializer::NONE, true,
-                          TensorLifespan::ITERATION_LIFESPAN);
+                          TensorLifespan::ITERATION_LIFESPAN, false);
   wt_idx[LSTMParams::mem_cell] =
     context.requestTensor(d, "mem_cell", Tensor::Initializer::NONE, true,
-                          TensorLifespan::ITERATION_LIFESPAN);
+                          TensorLifespan::ITERATION_LIFESPAN, false);
 
   /**
    * TODO: make this independent of time dimension once recurrent realizer
@@ -146,7 +146,7 @@ void LSTMCellLayer::finalize(InitLayerContext &context) {
   d.width(unit * NUM_GATE);
   wt_idx[LSTMParams::fgio] =
     context.requestTensor(d, "fgio", Tensor::Initializer::NONE, true,
-                          TensorLifespan::ITERATION_LIFESPAN);
+                          TensorLifespan::ITERATION_LIFESPAN, false);
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);

--- a/nntrainer/layers/rnncell.cpp
+++ b/nntrainer/layers/rnncell.cpp
@@ -103,7 +103,7 @@ void RNNCellLayer::finalize(InitLayerContext &context) {
   const TensorDim dim(batch_size * max_timestep, 1, 1, unit);
   wt_idx[RNNCellParams::hidden_state] =
     context.requestTensor(dim, "hidden_state", Tensor::Initializer::NONE, true,
-                          TensorLifespan::ITERATION_LIFESPAN);
+                          TensorLifespan::ITERATION_LIFESPAN, false);
 
   if (hidden_state_activation_type.get() == ActivationType::ACT_NONE) {
     hidden_state_activation_type.set(ActivationType::ACT_TANH);


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Tensor Sharing] Make tensor sharing private by default</summary><br />

Add a boolean to tell sharing should be enabled or not for a certian
`requestTensor()`. If this value is off, it means make tensor should be
only used inside the certain tensor (like a local variable) and not
shared.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

