### PR TITLE
[Fix] Add dstate to mol attention batch

### DIFF
--- a/nntrainer/layers/mol_attention_layer.cpp
+++ b/nntrainer/layers/mol_attention_layer.cpp
@@ -403,6 +403,7 @@ void MoLAttentionLayer::setBatch(RunLayerContext &context, unsigned int batch) {
   context.updateTensor(wt_idx[AttentionParams::prob_right], batch);
   context.updateTensor(wt_idx[AttentionParams::u_neg_div], batch);
   context.updateTensor(wt_idx[AttentionParams::u_pos_div], batch);
+  context.updateTensor(wt_idx[AttentionParams::dstate], batch);
 }
 
 void MoLAttentionLayer::exportTo(Exporter &exporter,


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Fix] Add dstate to mol attention batch</summary><br />

This patch fixes that dstate does not have the batch size updated

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

