### PR TITLE
[Recurrent] Support connection for recurrents

### DIFF
--- a/nntrainer/compiler/recurrent_realizer.h
+++ b/nntrainer/compiler/recurrent_realizer.h
@@ -22,6 +22,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include <connection.h>
 namespace nntrainer {
 
 namespace props {
@@ -94,7 +95,7 @@ private:
   std::unordered_set<std::string>
     sequenced_return_layers; /**< sequenced return layers, subset of end_layers
                               */
-  std::unordered_map<std::string, std::string>
+  std::unordered_map<Connection, Connection>
     recurrent_info;                           /**< final output layers id */
   std::unique_ptr<PropTypes> recurrent_props; /**< recurrent properties */
 };

--- a/nntrainer/compiler/recurrent_realizer.h
+++ b/nntrainer/compiler/recurrent_realizer.h
@@ -25,7 +25,7 @@ namespace nntrainer {
 
 namespace props {
 class UnrollFor;
-class ReturnSequences;
+class AsSequence;
 class OutputLayer;
 class RecurrentInput;
 class RecurrentOutput;
@@ -83,8 +83,9 @@ public:
   GraphRepresentation realize(const GraphRepresentation &reference) override;
 
 private:
-  using PropTypes = std::tuple<props::RecurrentInput, props::RecurrentOutput,
-                               props::ReturnSequences, props::UnrollFor>;
+  using PropTypes =
+    std::tuple<props::RecurrentInput, props::RecurrentOutput,
+               std::vector<props::AsSequence>, props::UnrollFor>;
 
   std::unordered_set<std::string> input_layers; /**< external input layers */
   std::vector<std::string> end_layers;          /**< final output layers id */

--- a/nntrainer/compiler/recurrent_realizer.h
+++ b/nntrainer/compiler/recurrent_realizer.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -84,12 +85,18 @@ public:
 
 private:
   using PropTypes =
-    std::tuple<props::RecurrentInput, props::RecurrentOutput,
+    std::tuple<std::vector<props::RecurrentInput>,
+               std::vector<props::RecurrentOutput>,
                std::vector<props::AsSequence>, props::UnrollFor>;
 
   std::unordered_set<std::string> input_layers; /**< external input layers */
   std::vector<std::string> end_layers;          /**< final output layers id */
-  std::unique_ptr<PropTypes> recurrent_props;   /**< recurrent properties */
+  std::unordered_set<std::string>
+    sequenced_return_layers; /**< sequenced return layers, subset of end_layers
+                              */
+  std::unordered_map<std::string, std::string>
+    recurrent_info;                           /**< final output layers id */
+  std::unique_ptr<PropTypes> recurrent_props; /**< recurrent properties */
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -543,6 +543,17 @@ public:
 };
 
 /**
+ * @brief Identifiers to locate a connection which should be returned as whole
+ * used in recurrent realizer
+ *
+ */
+class AsSequence : public Name {
+public:
+  static constexpr const char *key = "as_sequence";
+  using prop_tag = str_prop_tag;
+};
+
+/**
  * @brief Number of class
  * @todo deprecate this
  */

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -113,12 +113,14 @@ TEST(RecurrentRealizer, recurrent_return_sequence_single_p) {
   realizeAndEqual(r, before, expected);
 }
 
-TEST(DISABLED_RecurrentRealizer, recurrent_multi_inout_p) {
-
-  RecurrentRealizer r({"unroll_for=3", "return_sequences=fc_out",
-                       "recurrent_input=lstm,source3_dummy",
-                       "recurrent_output=fc_out,output_dummy"},
-                      {"source", "source2", "source3"}, {"fc_out"});
+TEST(RecurrentRealizer, recurrent_multi_inout_p) {
+  RecurrentRealizer r(
+    {
+      "unroll_for=3",
+      "recurrent_input=lstm,source3_dummy",
+      "recurrent_output=fc_out,output_dummy",
+    },
+    {"source", "source2", "source3"}, {"fc_out"});
 
   /// @note for below graph,
   /// 1. fc_out feds back to lstm
@@ -151,33 +153,132 @@ TEST(DISABLED_RecurrentRealizer, recurrent_multi_inout_p) {
 
     /// timestep 1
     {"lstm",
-     {"name=lstm/1", "input_layers=fc_out/0", "max_timestep=3", "timestep=1"}},
-    {"concat", {"name=source2_dummy/1", "input_layers=source2"}},
-    {"concat", {"name=source3_dummy/1", "input_layers=output_dummy/0"}},
+     {"name=lstm/1", "input_layers=fc_out/0", "shared_from=lstm/0",
+      "max_timestep=3", "timestep=1"}},
+    {"concat",
+     {"name=source2_dummy/1", "shared_from=source2_dummy/0",
+      "input_layers=source2"}},
+    {"concat",
+     {"name=source3_dummy/1", "shared_from=source3_dummy/0",
+      "input_layers=output_dummy/0"}},
     {"addition",
-     {"name=add/1", "input_layers=lstm/1,source2_dummy/1,source3_dummy/1"}},
-    {"split", {"name=split/1", "input_layers=add/1"}},
-    {"concat", {"name=output_dummy/1", "input_layers=split/1(1)"}},
-    {"fully_connected", {"name=fc_out/1", "input_layers=split/1(0)"}},
+     {"name=add/1", "input_layers=lstm/1,source2_dummy/1,source3_dummy/1",
+      "shared_from=add/0"}},
+    {"split", {"name=split/1", "input_layers=add/1", "shared_from=split/0"}},
+    {"concat",
+     {"name=output_dummy/1", "input_layers=split/1(1)",
+      "shared_from=output_dummy/0"}},
+    {"fully_connected",
+     {"name=fc_out/1", "input_layers=split/1(0)", "shared_from=fc_out/0"}},
 
     /// timestep 2
     {"lstm",
-     {"name=lstm/2", "input_layers=fc_out/1", "max_timestep=3", "timestep=2"}},
-    {"concat", {"name=source2_dummy/2", "input_layers=source2"}},
-    {"concat", {"name=source3_dummy/2", "input_layers=output_dummy/1"}},
+     {"name=lstm/2", "input_layers=fc_out/1", "shared_from=lstm/0",
+      "max_timestep=3", "timestep=2"}},
+    {"concat",
+     {"name=source2_dummy/2", "shared_from=source2_dummy/0",
+      "input_layers=source2"}},
+    {"concat",
+     {"name=source3_dummy/2", "shared_from=source3_dummy/0",
+      "input_layers=output_dummy/1"}},
     {"addition",
-     {"name=add/2", "input_layers=lstm/2,source2_dummy/2,source3_dummy/2"}},
-    {"split", {"name=split/2", "input_layers=add/2"}},
-    {"concat", {"name=output_dummy/2", "input_layers=split/2(1)"}},
-    {"fully_connected", {"name=fc_out", "input_layers=split/2(0)"}},
+     {"name=add/2", "input_layers=lstm/2,source2_dummy/2,source3_dummy/2",
+      "shared_from=add/0"}},
+    {"split", {"name=split/2", "input_layers=add/2", "shared_from=split/0"}},
+    {"concat",
+     {"name=output_dummy/2", "input_layers=split/2(1)",
+      "shared_from=output_dummy/0"}},
+    {"fully_connected",
+     {"name=fc_out", "input_layers=split/2(0)", "shared_from=fc_out/0"}},
   };
 
   realizeAndEqual(r, before, expected);
 }
 
-TEST(DISABLED_RecurrentRealizer, recurrent_multi_inout_return_seq_p) {
-  /// NYI, just for specification
-  EXPECT_TRUE(false);
+TEST(RecurrentRealizer, recurrent_multi_inout_return_seq_p) {
+  RecurrentRealizer r(
+    {
+      "unroll_for=3",
+      "recurrent_input=lstm,source3_dummy",
+      "as_sequence=fc_out",
+      "recurrent_output=fc_out,output_dummy",
+    },
+    {"source", "source2", "source3"}, {"fc_out"});
+
+  /// @note for below graph,
+  /// 1. fc_out feds back to lstm
+  /// 2. ouput_dummy feds back to source2_dummy
+  /// ========================================================
+  /// lstm        -------- addition - split ---- fc_out
+  /// source2_dummy   --/                  \-----output_dummy
+  /// source3_dummy    /
+  std::vector<LayerRepresentation> before = {
+    {"lstm", {"name=lstm", "input_layers=source"}},
+    {"concat", {"name=source2_dummy", "input_layers=source2"}},
+    {"concat", {"name=source3_dummy", "input_layers=source3"}},
+    {"addition", {"name=add", "input_layers=lstm,source2_dummy,source3_dummy"}},
+    {"split", {"name=split", "input_layers=add"}},
+    {"concat", {"name=output_dummy", "input_layers=split(1)"}},
+    {"fully_connected", {"name=fc_out", "input_layers=split(0)"}},
+  };
+
+  std::vector<LayerRepresentation> expected = {
+    /// timestep 0
+    {"lstm",
+     {"name=lstm/0", "input_layers=source", "max_timestep=3", "timestep=0"}},
+    {"concat", {"name=source2_dummy/0", "input_layers=source2"}},
+    {"concat", {"name=source3_dummy/0", "input_layers=source3"}},
+    {"addition",
+     {"name=add/0", "input_layers=lstm/0,source2_dummy/0,source3_dummy/0"}},
+    {"split", {"name=split/0", "input_layers=add/0"}},
+    {"concat", {"name=output_dummy/0", "input_layers=split/0(1)"}},
+    {"fully_connected", {"name=fc_out/0", "input_layers=split/0(0)"}},
+
+    /// timestep 1
+    {"lstm",
+     {"name=lstm/1", "input_layers=fc_out/0", "shared_from=lstm/0",
+      "max_timestep=3", "timestep=1"}},
+    {"concat",
+     {"name=source2_dummy/1", "shared_from=source2_dummy/0",
+      "input_layers=source2"}},
+    {"concat",
+     {"name=source3_dummy/1", "shared_from=source3_dummy/0",
+      "input_layers=output_dummy/0"}},
+    {"addition",
+     {"name=add/1", "input_layers=lstm/1,source2_dummy/1,source3_dummy/1",
+      "shared_from=add/0"}},
+    {"split", {"name=split/1", "input_layers=add/1", "shared_from=split/0"}},
+    {"concat",
+     {"name=output_dummy/1", "input_layers=split/1(1)",
+      "shared_from=output_dummy/0"}},
+    {"fully_connected",
+     {"name=fc_out/1", "input_layers=split/1(0)", "shared_from=fc_out/0"}},
+
+    /// timestep 2
+    {"lstm",
+     {"name=lstm/2", "input_layers=fc_out/1", "shared_from=lstm/0",
+      "max_timestep=3", "timestep=2"}},
+    {"concat",
+     {"name=source2_dummy/2", "shared_from=source2_dummy/0",
+      "input_layers=source2"}},
+    {"concat",
+     {"name=source3_dummy/2", "shared_from=source3_dummy/0",
+      "input_layers=output_dummy/1"}},
+    {"addition",
+     {"name=add/2", "input_layers=lstm/2,source2_dummy/2,source3_dummy/2",
+      "shared_from=add/0"}},
+    {"split", {"name=split/2", "input_layers=add/2", "shared_from=split/0"}},
+    {"concat",
+     {"name=output_dummy/2", "input_layers=split/2(1)",
+      "shared_from=output_dummy/0"}},
+    {"fully_connected",
+     {"name=fc_out/2", "input_layers=split/2(0)", "shared_from=fc_out/0"}},
+
+    /// return seq
+    {"concat", {"name=fc_out", "input_layers=fc_out/0,fc_out/1,fc_out/2"}},
+  };
+
+  realizeAndEqual(r, before, expected);
 }
 
 TEST(DISABLED_RecurrentRealizer,

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -59,9 +59,9 @@ TEST(FlattenRealizer, flatten_p) {
 
 TEST(RecurrentRealizer, recurrent_no_return_sequence_p) {
 
-  RecurrentRealizer r({"unroll_for=3", "return_sequences=false",
-                       "recurrent_input=fc_in", "recurrent_output=fc_out"},
-                      {"source"}, {"fc_out"});
+  RecurrentRealizer r(
+    {"unroll_for=3", "recurrent_input=fc_in", "recurrent_output=fc_out"},
+    {"source"}, {"fc_out"});
 
   std::vector<LayerRepresentation> before = {
     {"fully_connected", {"name=fc_in", "input_layers=source"}},
@@ -75,17 +75,17 @@ TEST(RecurrentRealizer, recurrent_no_return_sequence_p) {
     {"fully_connected",
      {"name=fc_out/1", "input_layers=fc_in/1", "shared_from=fc_out/0"}},
     {"fully_connected",
-     {"name=fc_in", "input_layers=fc_out/1", "shared_from=fc_in/0"}},
+     {"name=fc_in/2", "input_layers=fc_out/1", "shared_from=fc_in/0"}},
     {"fully_connected",
-     {"name=fc_out", "input_layers=fc_in", "shared_from=fc_out/0"}},
+     {"name=fc_out", "input_layers=fc_in/2", "shared_from=fc_out/0"}},
   };
 
   realizeAndEqual(r, before, expected);
 }
 
-TEST(DISABLED_RecurrentRealizer, recurrent_return_sequence_single_p) {
+TEST(RecurrentRealizer, recurrent_return_sequence_single_p) {
 
-  RecurrentRealizer r({"unroll_for=3", "return_sequences=fc_out",
+  RecurrentRealizer r({"unroll_for=3", "as_sequence=fc_out",
                        "recurrent_input=lstm", "recurrent_output=fc_out"},
                       {"source"}, {"fc_out"});
 

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -281,15 +281,119 @@ TEST(RecurrentRealizer, recurrent_multi_inout_return_seq_p) {
   realizeAndEqual(r, before, expected);
 }
 
-TEST(DISABLED_RecurrentRealizer,
-     recurrent_multi_inout_using_connection_return_seq_p) {
-  /// NYI, just for specification
-  EXPECT_TRUE(false);
+TEST(RecurrentRealizer, recurrent_multi_inout_using_connection_return_seq_p) {
+
+  RecurrentRealizer r(
+    {
+      "unroll_for=3",
+      "as_sequence=fc_out",
+      "recurrent_input=lstm,add(2)",
+      "recurrent_output=fc_out,split(1)",
+    },
+    {"source", "source2", "source3"}, {"fc_out"});
+
+  /// @note for below graph,
+  /// 1. fc_out feds back to lstm
+  /// 2. ouput_dummy feds back to source2_dummy
+  /// ========================================================
+  /// lstm        -------- addition - split ---- fc_out (to_lstm)
+  /// source2_dummy   --/                  \----- (to addition 3)
+  std::vector<LayerRepresentation> before = {
+    {"lstm", {"name=lstm", "input_layers=source"}},
+    {"addition", {"name=add", "input_layers=lstm,source2,source3"}},
+    {"split", {"name=split", "input_layers=add"}},
+    {"fully_connected", {"name=fc_out", "input_layers=split(0)"}},
+  };
+
+  std::vector<LayerRepresentation> expected = {
+    /// timestep 0
+    {"lstm",
+     {"name=lstm/0", "input_layers=source", "max_timestep=3", "timestep=0"}},
+    {"addition", {"name=add/0", "input_layers=lstm/0,source2,source3"}},
+    {"split", {"name=split/0", "input_layers=add/0"}},
+    {"fully_connected", {"name=fc_out/0", "input_layers=split/0(0)"}},
+
+    /// timestep 1
+    {"lstm",
+     {"name=lstm/1", "input_layers=fc_out/0", "shared_from=lstm/0",
+      "max_timestep=3", "timestep=1"}},
+    {"addition",
+     {"name=add/1", "input_layers=lstm/1,source2,split/0(1)",
+      "shared_from=add/0"}},
+    {"split", {"name=split/1", "input_layers=add/1", "shared_from=split/0"}},
+    {"fully_connected",
+     {"name=fc_out/1", "input_layers=split/1(0)", "shared_from=fc_out/0"}},
+
+    /// timestep 2
+    {"lstm",
+     {"name=lstm/2", "input_layers=fc_out/1", "shared_from=lstm/0",
+      "max_timestep=3", "timestep=2"}},
+    {"addition",
+     {"name=add/2", "input_layers=lstm/2,source2,split/1(1)",
+      "shared_from=add/0"}},
+    {"split", {"name=split/2", "input_layers=add/2", "shared_from=split/0"}},
+    {"fully_connected",
+     {"name=fc_out/2", "input_layers=split/2(0)", "shared_from=fc_out/0"}},
+    {"concat", {"name=fc_out", "input_layers=fc_out/0,fc_out/1,fc_out/2"}},
+  };
+
+  realizeAndEqual(r, before, expected);
 }
 
-TEST(DISABLED_RecurrentRealizer, recurrent_multi_inout_using_connection_p) {
-  /// NYI, just for specification
-  EXPECT_TRUE(false);
+TEST(RecurrentRealizer, recurrent_multi_inout_using_connection_p) {
+  RecurrentRealizer r(
+    {
+      "unroll_for=3",
+      "recurrent_input=lstm,add(2)",
+      "recurrent_output=fc_out,split(1)",
+    },
+    {"source", "source2", "source3"}, {"fc_out"});
+
+  /// @note for below graph,
+  /// 1. fc_out feds back to lstm
+  /// 2. ouput_dummy feds back to source2_dummy
+  /// ========================================================
+  /// lstm        -------- addition - split ---- fc_out (to_lstm)
+  /// source2_dummy   --/                  \----- (to addition 3)
+  std::vector<LayerRepresentation> before = {
+    {"lstm", {"name=lstm", "input_layers=source"}},
+    {"addition", {"name=add", "input_layers=lstm,source2,source3"}},
+    {"split", {"name=split", "input_layers=add"}},
+    {"fully_connected", {"name=fc_out", "input_layers=split(0)"}},
+  };
+
+  std::vector<LayerRepresentation> expected = {
+    /// timestep 0
+    {"lstm",
+     {"name=lstm/0", "input_layers=source", "max_timestep=3", "timestep=0"}},
+    {"addition", {"name=add/0", "input_layers=lstm/0,source2,source3"}},
+    {"split", {"name=split/0", "input_layers=add/0"}},
+    {"fully_connected", {"name=fc_out/0", "input_layers=split/0(0)"}},
+
+    /// timestep 1
+    {"lstm",
+     {"name=lstm/1", "input_layers=fc_out/0", "shared_from=lstm/0",
+      "max_timestep=3", "timestep=1"}},
+    {"addition",
+     {"name=add/1", "input_layers=lstm/1,source2,split/0(1)",
+      "shared_from=add/0"}},
+    {"split", {"name=split/1", "input_layers=add/1", "shared_from=split/0"}},
+    {"fully_connected",
+     {"name=fc_out/1", "input_layers=split/1(0)", "shared_from=fc_out/0"}},
+
+    /// timestep 2
+    {"lstm",
+     {"name=lstm/2", "input_layers=fc_out/1", "shared_from=lstm/0",
+      "max_timestep=3", "timestep=2"}},
+    {"addition",
+     {"name=add/2", "input_layers=lstm/2,source2,split/1(1)",
+      "shared_from=add/0"}},
+    {"split", {"name=split/2", "input_layers=add/2", "shared_from=split/0"}},
+    {"fully_connected",
+     {"name=fc_out", "input_layers=split/2(0)", "shared_from=fc_out/0"}},
+  };
+
+  realizeAndEqual(r, before, expected);
 }
 
 TEST(RemapRealizer, remap_p) {

--- a/test/unittest/models/unittest_models_recurrent.cpp
+++ b/test/unittest/models/unittest_models_recurrent.cpp
@@ -98,7 +98,6 @@ std::unique_ptr<NeuralNetwork> makeFC() {
                              ml::train::ReferenceLayersType::RECURRENT,
                              {
                                "unroll_for=2",
-                               "return_sequences=false",
                                "recurrent_input=a1",
                                "recurrent_output=a2",
                              });
@@ -130,7 +129,6 @@ std::unique_ptr<NeuralNetwork> makeFCClipped() {
                              ml::train::ReferenceLayersType::RECURRENT,
                              {
                                "unroll_for=2",
-                               "return_sequences=false",
                                "recurrent_input=a1",
                                "recurrent_output=a2",
                              });
@@ -160,7 +158,7 @@ static std::unique_ptr<NeuralNetwork> makeSingleLSTM() {
                              ml::train::ReferenceLayersType::RECURRENT,
                              {
                                "unroll_for=2",
-                               "return_sequences=true",
+                               "as_sequence=a1",
                                "recurrent_input=a1",
                                "recurrent_output=a1",
                              });
@@ -191,7 +189,7 @@ static std::unique_ptr<NeuralNetwork> makeStackedLSTM() {
                              ml::train::ReferenceLayersType::RECURRENT,
                              {
                                "unroll_for=2",
-                               "return_sequences=true",
+                               "as_sequence=a2",
                                "recurrent_input=a1",
                                "recurrent_output=a2",
                              });
@@ -221,7 +219,7 @@ static std::unique_ptr<NeuralNetwork> makeSingleLSTMCell() {
                              ml::train::ReferenceLayersType::RECURRENT,
                              {
                                "unroll_for=2",
-                               "return_sequences=true",
+                               "as_sequence=a1",
                                "recurrent_input=a1",
                                "recurrent_output=a1",
                              });
@@ -252,7 +250,7 @@ static std::unique_ptr<NeuralNetwork> makeStackedLSTMCell() {
                              ml::train::ReferenceLayersType::RECURRENT,
                              {
                                "unroll_for=2",
-                               "return_sequences=true",
+                               "as_sequence=a2",
                                "recurrent_input=a1",
                                "recurrent_output=a2",
                              });
@@ -282,7 +280,7 @@ static std::unique_ptr<NeuralNetwork> makeSingleRNNCell() {
                              {"a1"}, ml::train::ReferenceLayersType::RECURRENT,
                              {
                                "unroll_for=2",
-                               "return_sequences=true",
+                               "as_sequence=a1",
                                "recurrent_input=a1",
                                "recurrent_output=a1",
                              });
@@ -313,7 +311,7 @@ static std::unique_ptr<NeuralNetwork> makeStackedRNNCell() {
                              {"a2"}, ml::train::ReferenceLayersType::RECURRENT,
                              {
                                "unroll_for=2",
-                               "return_sequences=true",
+                               "as_sequence=a2",
                                "recurrent_input=a1",
                                "recurrent_output=a2",
                              });
@@ -343,7 +341,7 @@ static std::unique_ptr<NeuralNetwork> makeSingleGRUCell() {
                              {"a1"}, ml::train::ReferenceLayersType::RECURRENT,
                              {
                                "unroll_for=2",
-                               "return_sequences=true",
+                               "as_sequence=a1",
                                "recurrent_input=a1",
                                "recurrent_output=a1",
                              });
@@ -374,7 +372,7 @@ static std::unique_ptr<NeuralNetwork> makeStackedGRUCell() {
                              {"a2"}, ml::train::ReferenceLayersType::RECURRENT,
                              {
                                "unroll_for=2",
-                               "return_sequences=true",
+                               "as_sequence=a2",
                                "recurrent_input=a1",
                                "recurrent_output=a2",
                              });

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -990,7 +990,7 @@ TEST(nntrainerModels, loadFromLayersRecurrent_p) {
                             {"fc2"}, ml::train::ReferenceLayersType::RECURRENT,
                             {
                               "unroll_for=3",
-                              "return_sequences=true",
+                              "as_sequence=fc2",
                               "recurrent_input=fc1",
                               "recurrent_output=fc2",
                             });


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Clean] Prepare remap realizer for further changes</summary><br />

This patch add comments and terms(idx -> time_idx) inside remap realizer
to prepare further changes

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Test] Update multiout support specification</summary><br />

This patch updates multiout support specification.

Patch planned: 1. support return sequence with layer name
               2. support multiple input, output layers
               3. support multiple input, output connections

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Recurrent] Support multiple sequence</summary><br />

This patch updates recurrent realizer to suupporting multiple sequence with layer name not boolean
with `as_sequence` property

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Recurrent] recurrent using zero connection</summary><br />

This patch implements multi inout recurrent using zero connection

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Recurrent] Support connection for recurrents</summary><br />

This patch support connection for recurrent input, outputs

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

