### PR TITLE
[all] Mixed commits for fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # ignore build directory
 /build
 /builddir
+.cache/
 
 # jni build files
 iniparser/

--- a/nntrainer/compiler/activation_realizer.cpp
+++ b/nntrainer/compiler/activation_realizer.cpp
@@ -17,6 +17,7 @@
 #include <activation_layer.h>
 #include <layer_node.h>
 #include <stdexcept>
+#include <unordered_map>
 
 namespace nntrainer {
 

--- a/nntrainer/compiler/recurrent_realizer.cpp
+++ b/nntrainer/compiler/recurrent_realizer.cpp
@@ -301,16 +301,14 @@ RecurrentRealizer::realize(const GraphRepresentation &reference) {
                               const std::string &con, unsigned unroll_for) {
     GraphRepresentation processed(reference_.begin(), reference_.end());
 
-    for (auto &end : end_layers) {
-      std::vector<props::Name> names;
-      for (unsigned int i = 0; i < unroll_for; ++i) {
-        names.push_back(end + "/" + std::to_string(i));
-      }
-      /// @todo have axis in concat layer
-      auto node = createLayerNode(
-        "concat", {"name=" + end, "input_layers=" + to_string(names)});
-      processed.push_back(std::move(node));
+    std::vector<props::Name> names;
+    for (unsigned int i = 0; i < unroll_for; ++i) {
+      names.push_back(con + "/" + std::to_string(i));
     }
+    /// @todo have axis in concat layer
+    auto node = createLayerNode(
+      "concat", {"name=" + con, "input_layers=" + to_string(names)});
+    processed.push_back(std::move(node));
 
     return processed;
   };

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -960,6 +960,17 @@ public:
   using prop_tag = uint_prop_tag;             /**< property type */
 };
 
+/**
+ * @brief properties for getting the clipping value to clip the gradient by norm
+ *
+ */
+class ClipGradByGlobalNorm : public Property<float> {
+public:
+  static constexpr const char *key =
+    "clip_grad_by_norm";           /**< unique key to access */
+  using prop_tag = float_prop_tag; /**< property type */
+};
+
 } // namespace props
 } // namespace nntrainer
 

--- a/nntrainer/layers/embedding.h
+++ b/nntrainer/layers/embedding.h
@@ -95,7 +95,7 @@ public:
   inline static const std::string type = "embedding";
 
 private:
-  std::tuple<props::InDim, props::OutDim, props::ZeroIdxMask> embedding_props;
+  std::tuple<props::InDim, props::OutDim> embedding_props;
   unsigned int weight_idx;
 };
 } // namespace nntrainer

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -114,17 +114,6 @@ public:
   using prop_tag = str_prop_tag;                    /**< property type */
 };
 
-/**
- * @brief properties for getting the clipping value to clip the gradient by norm
- *
- */
-class ClipGradByGlobalNorm : public Property<float> {
-public:
-  static constexpr const char *key =
-    "clip_grad_by_norm";           /**< unique key to access */
-  using prop_tag = float_prop_tag; /**< property type */
-};
-
 } // namespace props
 
 /**

--- a/nntrainer/layers/mol_attention_layer.h
+++ b/nntrainer/layers/mol_attention_layer.h
@@ -106,7 +106,7 @@ private:
   ActiFunc softmax; /** softmax activation operation */
   ActiFunc tanh;    /** softmax activation operation */
   ActiFunc sigmoid; /** softmax activation operation */
-  std::array<unsigned int, 16>
+  std::array<unsigned int, 17>
     wt_idx; /**< indices of the weights and tensors */
 
   /**

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -58,7 +58,7 @@
 namespace nntrainer {
 
 NeuralNetwork::NeuralNetwork(AppContext app_context_) :
-  model_props(props::LossType(), {}, {}),
+  model_props(props::LossType(), {}, {}, props::ClipGradByGlobalNorm()),
   model_flex_props(props::Epochs(), props::TrainingBatchSize(),
                    props::SavePath(), props::ContinueTrain(),
                    props::SaveBestPath(), props::MemoryOptimization()),
@@ -131,6 +131,10 @@ int NeuralNetwork::compile() {
   model_graph.setMemoryOptimizations(
     std::get<props::MemoryOptimization>(model_flex_props));
   for (auto &node : graph_representation) {
+    if (auto &prop = std::get<props::ClipGradByGlobalNorm>(model_props);
+        !prop.empty()) {
+      node->setProperty({"clip_grad_by_norm=" + to_string(prop)});
+    }
     model_graph.addLayer(node);
   }
 

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -482,7 +482,7 @@ private:
                props::MemoryOptimization>;
   using RigidPropTypes =
     std::tuple<props::LossType, std::vector<props::InputConnection>,
-               std::vector<props::LabelLayer>>;
+               std::vector<props::LabelLayer>, props::ClipGradByGlobalNorm>;
 
   RigidPropTypes model_props;         /**< model props */
   FlexiblePropTypes model_flex_props; /**< model train props */

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -120,7 +120,8 @@ public:
   SrcSharedTensor() : src(nullptr), off(0) {}
 
   SrcSharedTensor(const Tensor *tensor, unsigned int offset) :
-    src(tensor), off(offset) {}
+    src(tensor),
+    off(offset) {}
 
   /**
    * @brief   Get the allocated src tensor

--- a/test/input_gen/recorder_v2.py
+++ b/test/input_gen/recorder_v2.py
@@ -62,7 +62,7 @@ def _rand_like(shapes, scale=1, dtype=None):
 # @param label_dims dimensions to record including batch (list of tuple)
 # @param name golden name
 def record_v2(model, iteration, input_dims, label_dims, name, clip=False,
-              input_dtype=None):
+              input_dtype=None, input_label_reader=None):
     ## file format is as below
     # [<number of iteration(int)> <Iteration> <Iteration>...<Iteration>]
     # Each iteration contains
@@ -77,8 +77,11 @@ def record_v2(model, iteration, input_dims, label_dims, name, clip=False,
     optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
 
     def record_iteration(write_fn):
-        inputs = _rand_like(input_dims, dtype=input_dtype if input_dtype is not None else float)
-        labels = _rand_like(label_dims, dtype=float)
+        if input_label_reader != None:
+            inputs, labels = input_label_reader(input_dims, label_dims)
+        else:
+            inputs = _rand_like(input_dims, dtype=input_dtype if input_dtype is not None else float)
+            labels = _rand_like(label_dims, dtype=float)
         write_fn(inputs)
         write_fn(labels)
         write_fn(list(t for _, t in params_translated(model)))

--- a/test/input_gen/transLayer_v2.py
+++ b/test/input_gen/transLayer_v2.py
@@ -71,7 +71,7 @@ def zoneout_translate(model):
     new_params = [transpose_(params[0]), transpose_(params[1]), bias, hidden_state, cell_state]
     yield from new_params
 
-@register_for_((torch.nn.RNNCell, torch.nn.LSTMCell))
+@register_for_((torch.nn.RNNCell, torch.nn.LSTMCell, torch.nn.LSTM))
 def rnn_lstm_translate(model):
     params = [(name, tensor.detach()) for name, tensor in model.named_parameters()]
     bias = ("bias", params[2][1] + params[3][1])

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -677,10 +677,9 @@ TEST(ActivationRealizer, activation_p) {
   std::vector<LayerRepresentation> after = {
     {"fully_connected", {"name=a"}},
     {"activation", {"name=b", "activation=relu", "input_layers=a"}},
-    {"fully_connected",
-     {"name=c/activation_realized", "input_layers=b", "activation=none"}},
+    {"fully_connected", {"name=c", "input_layers=b", "activation=none"}},
     {"activation",
-     {"name=c", "input_layers=c/activation_realized", "activation=softmax"}},
+     {"name=c/activation_realized", "input_layers=c", "activation=softmax"}},
   };
 
   realizeAndEqual(ar, before, after);

--- a/test/unittest/models/unittest_models_recurrent.cpp
+++ b/test/unittest/models/unittest_models_recurrent.cpp
@@ -259,7 +259,8 @@ static std::unique_ptr<NeuralNetwork> makeStackedLSTMCell() {
   return nn;
 }
 
-static std::unique_ptr<NeuralNetwork> makeSingleZoneoutLSTMCell() {
+[[maybe_unused]] static std::unique_ptr<NeuralNetwork>
+makeSingleZoneoutLSTMCell() {
   std::unique_ptr<NeuralNetwork> nn(new NeuralNetwork());
   nn->setProperty({"batch_size=1"});
 
@@ -292,7 +293,8 @@ static std::unique_ptr<NeuralNetwork> makeSingleZoneoutLSTMCell() {
   return nn;
 }
 
-static std::unique_ptr<NeuralNetwork> makeStackedZoneoutLSTMCell() {
+[[maybe_unused]] static std::unique_ptr<NeuralNetwork>
+makeStackedZoneoutLSTMCell() {
   std::unique_ptr<NeuralNetwork> nn(new NeuralNetwork());
   nn->setProperty({"batch_size=1"});
 
@@ -468,42 +470,42 @@ INSTANTIATE_TEST_CASE_P(
     mkModelTc_V2(makeStackedLSTM, "lstm_stacked", ModelTestOption::COMPARE_V2),
     mkModelTc_V2(makeStackedLSTMCell, "lstm_stacked__1",
                  ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_000_000",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_000_000",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_050_000",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_050_000",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_100_000",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_100_000",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_000_050",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_000_050",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_050_050",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_050_050",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_100_050",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_100_050",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_000_100",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_000_100",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_050_100",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_050_100",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_100_100",
-                 ModelTestOption::COMPARE_V2),
-    mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_100_100",
-                 ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_000_000",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_000_000",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_050_000",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_050_000",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_100_000",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_100_000",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_000_050",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_000_050",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_050_050",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_050_050",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_100_050",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_100_050",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_000_100",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_000_100",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_050_100",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_050_100",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeSingleZoneoutLSTMCell, "zoneout_lstm_single_100_100",
+    //              ModelTestOption::COMPARE_V2),
+    // mkModelTc_V2(makeStackedZoneoutLSTMCell, "zoneout_lstm_stacked_100_100",
+    //              ModelTestOption::COMPARE_V2),
     mkModelTc_V2(makeSingleRNNCell, "rnncell_single__1",
                  ModelTestOption::COMPARE_V2),
     mkModelTc_V2(makeStackedRNNCell, "rnncell_stacked__1",


### PR DESCRIPTION
- concat to not loop over all inputs multiple times.
- gradient accumulation
- support only 1 output in case state update is not used
- bug fix in backwarding
- activation to work out of place
- Bug fix for activaiton realizer to find the realizer where the layer is
looping to itself with name change.
TODO: also do for flatten and other realizers which modified the graph
in similar fashion.
- zoneout lstm bug fix for handling the scenario where mask rate is set to
zero for either hidden or cell.
- Undo earlier changes due to bug in them.
The changes will be proposed again with more unittests.
The changes have been commented for now.
- Add clip gradient norm property for the the model as a simple interface
to set for all the layers.
- support recorder to read data from file than always generating random
data.