### PR TITLE
[hotfix] Enable zoneout lstmcell unittest

### DIFF
--- a/test/unittest/models/unittest_models_recurrent.cpp
+++ b/test/unittest/models/unittest_models_recurrent.cpp
@@ -283,7 +283,7 @@ static std::unique_ptr<NeuralNetwork> makeSingleZoneoutLSTMCell() {
                              ml::train::ReferenceLayersType::RECURRENT,
                              {
                                "unroll_for=2",
-                               "return_sequences=true",
+                               "as_sequence=a1",
                                "recurrent_input=a1",
                                "recurrent_output=a1",
                              });
@@ -319,7 +319,7 @@ static std::unique_ptr<NeuralNetwork> makeStackedZoneoutLSTMCell() {
                              ml::train::ReferenceLayersType::RECURRENT,
                              {
                                "unroll_for=2",
-                               "return_sequences=true",
+                               "as_sequence=a2",
                                "recurrent_input=a1",
                                "recurrent_output=a2",
                              });


### PR DESCRIPTION
 - Fix broken zoneout lstmcell unittest

Self evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>