### PR TITLE
[manager] Remove activation input exec order from backwarding

### DIFF
--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -400,6 +400,9 @@ Manager::requestInputs(const GraphNode &node,
   std::vector<unsigned int> var_exec_order(
     {forwarding_order, calcGradient_order});
 
+  if (node.getType() == ActivationLayer::type)
+    var_exec_order = {forwarding_order};
+
   if (node.getType() == MultiOutLayer::type)
     var_exec_order = {forwarding_order};
 

--- a/test/unittest/models/models_test_utils.cpp
+++ b/test/unittest/models/models_test_utils.cpp
@@ -376,7 +376,7 @@ void GraphWatcher::compareFor(const std::string &reference,
 
     auto it = nodes.begin();
     for (; it != nodes.end() - 1; ++it) {
-      it->forward(iteration, !(it + 1)->supportInPlace());
+      it->forward(iteration, it->isOutputNode() | !optimize);
     }
     it->forward(iteration, true);
 

--- a/test/unittest/models/models_test_utils.h
+++ b/test/unittest/models/models_test_utils.h
@@ -133,6 +133,13 @@ public:
    */
   bool needsCalcDerivative() { return node->needsCalcDerivative(); }
 
+  /**
+   * @brief check if the node is an output node
+   *
+   * @return true if output node else false
+   */
+  bool isOutputNode() { return node->getNumOutputConnections() == 0; }
+
 private:
   NodeType node;
   std::vector<nntrainer::Tensor> expected_output;

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -973,7 +973,8 @@ TEST(nntrainerModels, read_save_01_n) {
 
 TEST(nntrainerModels, loadFromLayersBackbone_p) {
   std::vector<std::shared_ptr<ml::train::Layer>> reference;
-  reference.emplace_back(ml::train::layer::FullyConnected({"name=fc1", "input_shape=3:1:2"}));
+  reference.emplace_back(
+    ml::train::layer::FullyConnected({"name=fc1", "input_shape=3:1:2"}));
   reference.emplace_back(
     ml::train::layer::FullyConnected({"name=fc2", "input_layers=fc1"}));
 


### PR DESCRIPTION
This patch removes activation input exec order from backwarding as input
of the activation layer is not used in the backwarding.

This leads to change in the unittests as we cannot check all the
outputs, especially close to the end of the model. So, with optimization
enabled, only the output layer's forwarding is checked.

Resolves #1725

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>