### PR TITLE
[layer] Support disable bias for fc and conv

### DIFF
--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -107,6 +107,21 @@ public:
 };
 
 /**
+ * @brief BiasInitializer Initialization Enumeration Information
+ *
+ */
+class DisableBias : public nntrainer::Property<bool> {
+public:
+  /**
+   * @brief Construct a DisableBias object
+   *
+   */
+  DisableBias(bool val = false) : nntrainer::Property<bool>(val) {}
+  using prop_tag = bool_prop_tag;
+  static constexpr const char *key = "disable_bias";
+};
+
+/**
  * @brief Normalization property, normalize the input to be in range [0, 1] if
  * true
  *

--- a/nntrainer/layers/layer_impl.cpp
+++ b/nntrainer/layers/layer_impl.cpp
@@ -26,7 +26,8 @@ LayerImpl::LayerImpl() :
   layer_impl_props(
     std::make_unique<
       std::tuple<props::WeightRegularizer, props::WeightRegularizerConstant,
-                 props::WeightInitializer, props::BiasInitializer>>()) {}
+                 props::WeightInitializer, props::BiasInitializer,
+                 props::DisableBias>>()) {}
 
 void LayerImpl::setProperty(const std::vector<std::string> &values) {
   auto remain_props = loadProperties(values, *layer_impl_props);

--- a/nntrainer/layers/layer_impl.h
+++ b/nntrainer/layers/layer_impl.h
@@ -36,6 +36,7 @@ class WeightRegularizer;
 class WeightRegularizerConstant;
 class WeightInitializer;
 class BiasInitializer;
+class DisableBias;
 } // namespace props
 
 enum class ExportMethods;
@@ -82,9 +83,9 @@ public:
                         const ExportMethods &method) const override;
 
 protected:
-  std::unique_ptr<
-    std::tuple<props::WeightRegularizer, props::WeightRegularizerConstant,
-               props::WeightInitializer, props::BiasInitializer>>
+  std::unique_ptr<std::tuple<
+    props::WeightRegularizer, props::WeightRegularizerConstant,
+    props::WeightInitializer, props::BiasInitializer, props::DisableBias>>
     layer_impl_props; /**< layer_impl_props */
 };
 

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -66,7 +66,8 @@ void Exporter::saveTflResult(
 template <>
 void Exporter::saveTflResult(
   const std::tuple<props::WeightRegularizer, props::WeightRegularizerConstant,
-                   props::WeightInitializer, props::BiasInitializer> &props,
+                   props::WeightInitializer, props::BiasInitializer,
+                   props::DisableBias> &props,
   const LayerImpl *self) { /// layer impl has nothing to serialize so do nothing
 }
 

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -216,6 +216,7 @@ class BiasInitializer;
 class SharedFrom;
 class InputConnection;
 class ClipGradByGlobalNorm;
+class DisableBias;
 } // namespace props
 
 class LayerNode;
@@ -240,7 +241,8 @@ class LayerImpl;
 template <>
 void Exporter::saveTflResult(
   const std::tuple<props::WeightRegularizer, props::WeightRegularizerConstant,
-                   props::WeightInitializer, props::BiasInitializer> &props,
+                   props::WeightInitializer, props::BiasInitializer,
+                   props::DisableBias> &props,
   const LayerImpl *self);
 
 class FullyConnectedLayer;


### PR DESCRIPTION
- Add disable bias property for the layer impl class.
- This patch enables disable bias for fully connected and convolution layer.

Support for disable bias in other classes extending layer impl class will be done later.
See Also #1769

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>