### PR TITLE
[layer] bug fix for array initializer

### DIFF
--- a/nntrainer/layers/attention_layer.cpp
+++ b/nntrainer/layers/attention_layer.cpp
@@ -18,7 +18,9 @@
 
 namespace nntrainer {
 
-AttentionLayer::AttentionLayer() : wt_idx({0}) {}
+AttentionLayer::AttentionLayer() {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 AttentionLayer::~AttentionLayer() {}
 

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -48,10 +48,11 @@ enum BNParams {
 BatchNormalizationLayer::BatchNormalizationLayer() :
   Layer(),
   divider(0),
-  wt_idx({0}),
   bn_props(props::Epsilon(), props::BNPARAMS_MU_INIT(),
            props::BNPARAMS_VAR_INIT(), props::BNPARAMS_BETA_INIT(),
-           props::BNPARAMS_GAMMA_INIT(), props::Momentum(), props::Axis()) {}
+           props::BNPARAMS_GAMMA_INIT(), props::Momentum(), props::Axis()) {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 /// @todo add multiple axis support
 void BatchNormalizationLayer::finalize(InitLayerContext &context) {

--- a/nntrainer/layers/centroid_knn.cpp
+++ b/nntrainer/layers/centroid_knn.cpp
@@ -31,10 +31,9 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 
 enum KNNParams { map, num_samples };
 
-CentroidKNN::CentroidKNN() :
-  Layer(),
-  centroid_knn_props(props::NumClass()),
-  weight_idx({0}) {}
+CentroidKNN::CentroidKNN() : Layer(), centroid_knn_props(props::NumClass()) {
+  weight_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 CentroidKNN::~CentroidKNN() {}
 

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -107,7 +107,7 @@ public:
 };
 
 /**
- * @brief BiasInitializer Initialization Enumeration Information
+ * @brief DisableBias to disable the bias
  *
  */
 class DisableBias : public nntrainer::Property<bool> {

--- a/nntrainer/layers/conv1d_layer.cpp
+++ b/nntrainer/layers/conv1d_layer.cpp
@@ -32,8 +32,8 @@ Conv1DLayer::Conv1DLayer(const std::array<unsigned int, 2> &padding_) :
   LayerImpl(),
   padding(padding_),
   conv_props(props::FilterSize(), props::KernelSize(), props::Stride(),
-             props::Padding2D()),
-  wt_idx({0}) {
+             props::Padding2D()) {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
   conv2d_layer = std::make_unique<Conv2DLayer>();
 }
 

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -248,8 +248,9 @@ Conv2DLayer::Conv2DLayer(
   LayerImpl(),
   padding(padding_),
   conv_props(props::FilterSize(), std::array<props::KernelSize, CONV2D_DIM>(),
-             std::array<props::Stride, CONV2D_DIM>(), props::Padding2D()),
-  wt_idx({0}) {}
+             std::array<props::Stride, CONV2D_DIM>(), props::Padding2D()) {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 void Conv2DLayer::finalize(InitLayerContext &context) {
   if (context.getNumInputs() != 1) {

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -28,7 +28,7 @@ enum EmbeddingParams { weight };
 EmbeddingLayer::EmbeddingLayer() :
   LayerImpl(),
   embedding_props(props::InDim(), props::OutDim()),
-  weight_idx(0) {}
+  weight_idx(std::numeric_limits<unsigned>::max()) {}
 
 void EmbeddingLayer::finalize(InitLayerContext &context) {
   if (context.getNumInputs() != 1) {

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -36,6 +36,12 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 
 enum FCParams { weight, bias };
 
+FullyConnectedLayer::FullyConnectedLayer() :
+  LayerImpl(),
+  fc_props(props::Unit()) {
+  weight_idx.fill(std::numeric_limits<unsigned>::max());
+}
+
 void FullyConnectedLayer::finalize(InitLayerContext &context) {
   auto &weight_regularizer =
     std::get<props::WeightRegularizer>(*layer_impl_props);

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -29,10 +29,7 @@ public:
   /**
    * @brief     Constructor of Fully Connected Layer
    */
-  FullyConnectedLayer() :
-    LayerImpl(),
-    fc_props(props::Unit()),
-    weight_idx({0}) {}
+  FullyConnectedLayer();
 
   /**
    * @brief     Destructor of Fully Connected Layer

--- a/nntrainer/layers/gru.cpp
+++ b/nntrainer/layers/gru.cpp
@@ -53,10 +53,11 @@ GRULayer::GRULayer() :
   gru_props(props::Unit(), props::HiddenStateActivation(),
             props::RecurrentActivation(), props::ReturnSequences(),
             props::DropOutRate()),
-  wt_idx({0}),
   acti_func(ActivationType::ACT_NONE, true),
   recurrent_acti_func(ActivationType::ACT_NONE, true),
-  epsilon(1e-3) {}
+  epsilon(1e-3) {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 // - weight_xh ( input to hidden )
 //  : [1, 1, input_size, unit (hidden_size) x NUM_GATE] -> z, r, g
@@ -435,7 +436,10 @@ void GRULayer::setBatch(RunLayerContext &context, unsigned int batch) {
   context.updateTensor(wt_idx[GRUParams::hidden_state], batch);
   context.updateTensor(wt_idx[GRUParams::zrg], batch);
   context.updateTensor(wt_idx[GRUParams::h_prev], batch);
-  context.updateTensor(wt_idx[GRUParams::dropout_mask], batch);
+
+  if (std::get<props::DropOutRate>(gru_props).get() > epsilon) {
+    context.updateTensor(wt_idx[GRUParams::dropout_mask], batch);
+  }
 }
 
 } // namespace nntrainer

--- a/nntrainer/layers/grucell.cpp
+++ b/nntrainer/layers/grucell.cpp
@@ -61,10 +61,11 @@ GRUCellLayer::GRUCellLayer() :
   grucell_props(props::Unit(), props::HiddenStateActivation(),
                 props::RecurrentActivation(), props::DropOutRate(),
                 props::MaxTimestep(), props::Timestep()),
-  wt_idx({0}),
   acti_func(ActivationType::ACT_NONE, true),
   recurrent_acti_func(ActivationType::ACT_NONE, true),
-  epsilon(1e-3) {}
+  epsilon(1e-3) {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 // - weight_xh ( input to hidden )
 //  : [1, 1, input_size, unit (hidden_size) x NUM_GATE] -> z, r, g

--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -38,10 +38,11 @@ LSTMLayer::LSTMLayer() :
   lstm_props(props::Unit(), props::HiddenStateActivation(),
              props::RecurrentActivation(), props::ReturnSequences(),
              props::DropOutRate(), props::MaxTimestep(), props::Timestep()),
-  wt_idx({0}),
   acti_func(ActivationType::ACT_NONE, true),
   recurrent_acti_func(ActivationType::ACT_NONE, true),
-  epsilon(1e-3) {}
+  epsilon(1e-3) {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 // - weight_xh ( input to hidden )
 //  : [1, 1, input_size, unit (hidden_size) x NUM_GATE] -> f, g, i, o
@@ -507,7 +508,10 @@ void LSTMLayer::setBatch(RunLayerContext &context, unsigned int batch) {
   context.updateTensor(wt_idx[LSTMParams::hidden_state], batch);
   context.updateTensor(wt_idx[LSTMParams::mem_cell], batch);
   context.updateTensor(wt_idx[LSTMParams::fgio], batch);
-  context.updateTensor(wt_idx[LSTMParams::dropout_mask], batch);
+
+  if (std::get<props::DropOutRate>(lstm_props).get() > epsilon) {
+    context.updateTensor(wt_idx[LSTMParams::dropout_mask], batch);
+  }
 }
 
 } // namespace nntrainer

--- a/nntrainer/layers/lstmcell.cpp
+++ b/nntrainer/layers/lstmcell.cpp
@@ -53,8 +53,9 @@ LSTMCellLayer::LSTMCellLayer() :
   LayerImpl(),
   lstmcell_props(props::Unit(), props::DropOutRate(), props::MaxTimestep(),
                  props::Timestep()),
-  wt_idx({0}),
-  epsilon(1e-3) {}
+  epsilon(1e-3) {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 void LSTMCellLayer::finalize(InitLayerContext &context) {
   NNTR_THROW_IF(std::get<props::Unit>(lstmcell_props).empty(),

--- a/nntrainer/layers/lstmcell_core.cpp
+++ b/nntrainer/layers/lstmcell_core.cpp
@@ -253,9 +253,10 @@ LSTMCellCoreLayer::LSTMCellCoreLayer() :
   lstmcell_core_props(
     props::Unit(), props::HiddenStateActivation() = ActivationType::ACT_TANH,
     props::RecurrentActivation() = ActivationType::ACT_SIGMOID),
-  wt_idx({0}),
   acti_func(ActivationType::ACT_NONE, true),
-  recurrent_acti_func(ActivationType::ACT_NONE, true) {}
+  recurrent_acti_func(ActivationType::ACT_NONE, true) {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 void LSTMCellCoreLayer::finalize(InitLayerContext &context) {
   NNTR_THROW_IF(std::get<props::Unit>(lstmcell_core_props).empty(),

--- a/nntrainer/layers/mol_attention_layer.cpp
+++ b/nntrainer/layers/mol_attention_layer.cpp
@@ -25,8 +25,9 @@ MoLAttentionLayer::MoLAttentionLayer() :
   helper_exec(false),
   softmax(ActivationType::ACT_SOFTMAX, false),
   tanh(ActivationType::ACT_TANH, false),
-  sigmoid(ActivationType::ACT_SIGMOID, false),
-  wt_idx({std::numeric_limits<unsigned>::max()}) {}
+  sigmoid(ActivationType::ACT_SIGMOID, false) {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 MoLAttentionLayer::~MoLAttentionLayer() {}
 

--- a/nntrainer/layers/rnn.cpp
+++ b/nntrainer/layers/rnn.cpp
@@ -35,9 +35,10 @@ RNNLayer::RNNLayer() :
   LayerImpl(),
   rnn_props(props::Unit(), props::HiddenStateActivation(),
             props::ReturnSequences(), props::DropOutRate()),
-  wt_idx({0}),
   acti_func(ActivationType::ACT_NONE, true),
-  epsilon(1e-3) {}
+  epsilon(1e-3) {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 void RNNLayer::finalize(InitLayerContext &context) {
   auto &weight_regularizer =
@@ -267,7 +268,10 @@ void RNNLayer::calcGradient(RunLayerContext &context) {
 
 void RNNLayer::setBatch(RunLayerContext &context, unsigned int batch) {
   context.updateTensor(wt_idx[RNNParams::hidden_state], batch);
-  context.updateTensor(wt_idx[RNNParams::dropout_mask], batch);
+
+  if (std::get<props::DropOutRate>(rnn_props).get() > epsilon) {
+    context.updateTensor(wt_idx[RNNParams::dropout_mask], batch);
+  }
 }
 
 } // namespace nntrainer

--- a/nntrainer/layers/rnncell.cpp
+++ b/nntrainer/layers/rnncell.cpp
@@ -34,9 +34,10 @@ RNNCellLayer::RNNCellLayer() :
   LayerImpl(),
   rnncell_props(props::Unit(), props::HiddenStateActivation(),
                 props::DropOutRate(), props::MaxTimestep(), props::Timestep()),
-  wt_idx({0}),
   acti_func(ActivationType::ACT_NONE, true),
-  epsilon(1e-3) {}
+  epsilon(1e-3) {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 void RNNCellLayer::finalize(InitLayerContext &context) {
   const nntrainer::WeightRegularizer weight_regularizer =

--- a/nntrainer/layers/zoneout_lstmcell.cpp
+++ b/nntrainer/layers/zoneout_lstmcell.cpp
@@ -64,8 +64,9 @@ ZoneoutLSTMCellLayer::ZoneoutLSTMCellLayer() :
   zoneout_lstmcell_props(props::Unit(), HiddenStateZoneOutRate(),
                          CellStateZoneOutRate(), Test(), props::MaxTimestep(),
                          props::Timestep()),
-  wt_idx({0}),
-  epsilon(1e-3) {}
+  epsilon(1e-3) {
+  wt_idx.fill(std::numeric_limits<unsigned>::max());
+}
 
 bool ZoneoutLSTMCellLayer::HiddenStateZoneOutRate::isValid(
   const float &value) const {


### PR DESCRIPTION
Bug fix for array initializer storing the indices of the requested
weight so that accessing weights not requested always causes error.

resolves #1773

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>