### PR TITLE
[learning-rate-scheduler] New interface for learning rate scheduler 

### DIFF
--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -971,6 +971,37 @@ public:
   using prop_tag = float_prop_tag; /**< property type */
 };
 
+/**
+ * @brief Learning Rate props
+ *
+ */
+class LearningRate : public Property<float> {
+public:
+  static constexpr const char *key =
+    "learning_rate";               /**< unique key to access */
+  using prop_tag = float_prop_tag; /**< property type */
+};
+
+/**
+ * @brief Decay rate property
+ *
+ */
+class DecayRate : public Property<float> {
+public:
+  static constexpr const char *key = "decay_rate"; /**< unique key to access */
+  using prop_tag = float_prop_tag;                 /**< property type */
+};
+
+/**
+ * @brief decay steps property
+ *
+ */
+class DecaySteps : public PositiveIntegerProperty {
+public:
+  static constexpr const char *key = "decay_steps"; /**< unique key to access */
+  using prop_tag = uint_prop_tag;                   /**< property type */
+};
+
 } // namespace props
 } // namespace nntrainer
 

--- a/nntrainer/optimizers/lr_scheduler.h
+++ b/nntrainer/optimizers/lr_scheduler.h
@@ -35,6 +35,16 @@ public:
   virtual ~LearningRateScheduler() = default;
 
   /**
+   * @brief     Finalize creating the learning rate scheduler
+   *
+   * @details   Verify that all the needed properties have been and within the
+   * valid range.
+   * @note      After calling this it is not allowed to
+   * change properties.
+   */
+  virtual void finalize() = 0;
+
+  /**
    * @brief     get Learning Rate for the given iteration
    * @param[in] iteration Iteration for the learning rate
    * @retval    Learning rate in double

--- a/nntrainer/optimizers/lr_scheduler.h
+++ b/nntrainer/optimizers/lr_scheduler.h
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   lr_scheduler.h
+ * @date   09 December 2021
+ * @brief  This is Learning Rate Scheduler interface class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __LEARNING_RATE_SCHEDULER__
+#define __LEARNING_RATE_SCHEDULER__
+#ifdef __cplusplus
+
+#include <string>
+
+namespace nntrainer {
+
+class Exporter;
+enum class ExportMethods;
+
+/**
+ * @class   Learning Rate Schedulers Base class
+ * @brief   Base class for all Learning Rate Schedulers
+ */
+class LearningRateScheduler {
+
+public:
+  /**
+   * @brief     Destructor of learning rate scheduler Class
+   */
+  virtual ~LearningRateScheduler() = default;
+
+  /**
+   * @brief     get Learning Rate for the given iteration
+   * @param[in] iteration Iteration for the learning rate
+   * @retval    Learning rate in double
+   * @detail    the return value of this function and getInitialLearningRate()
+   * may not match for iteration == 0 (warmup can lead to different initial
+   * learning rates).
+   *
+   * @note this is non-const function intentionally.
+   */
+  virtual double getLearningRate(size_t iteration) = 0;
+
+  /**
+   * @brief this function helps exporting the learning rate in a predefined
+   * format, while workarounding issue caused by templated function type eraser
+   *
+   * @param     exporter exporter that conatins exporting logic
+   * @param     method enum value to identify how it should be exported to
+   */
+  virtual void exportTo(Exporter &exporter, const ExportMethods &method) const {
+  }
+
+  /**
+   * @brief     Default allowed properties
+   * Constant Learning rate scheduler
+   * - learning_rate : float
+   *
+   * Exponential Learning rate scheduler
+   * - learning_rate : float
+   * - decay_rate : float,
+   * - decay_steps : float,
+   *
+   * more to be added
+   */
+
+  /**
+   * @brief     set learning rate scheduler properties
+   * @param[in] values learning rate scheduler properties list
+   * @details   This function accepts vector of properties in the format -
+   *  { std::string property_name = std::string property_val, ...}
+   */
+  virtual void setProperty(const std::vector<std::string> &values) = 0;
+
+  /**
+   * @brief     get learning rate scheduler Type
+   * @retval    learning rate scheduler type
+   */
+  virtual const std::string getType() const = 0;
+};
+
+} /* namespace nntrainer */
+
+#endif /* __cplusplus */
+#endif /* __LEARNING_RATE_SCHEDULER__ */

--- a/nntrainer/optimizers/lr_scheduler_constant.cpp
+++ b/nntrainer/optimizers/lr_scheduler_constant.cpp
@@ -24,6 +24,12 @@ namespace nntrainer {
 ConstantLearningRateScheduler::ConstantLearningRateScheduler() :
   lr_props(props::LearningRate()) {}
 
+void ConstantLearningRateScheduler::finalize() {
+  NNTR_THROW_IF(std::get<props::LearningRate>(lr_props).empty(),
+                std::invalid_argument)
+    << "[ConstantLearningRateScheduler] Learning Rate is not set";
+}
+
 void ConstantLearningRateScheduler::setProperty(
   const std::vector<std::string> &values) {
   auto left = loadProperties(values, lr_props);

--- a/nntrainer/optimizers/lr_scheduler_constant.cpp
+++ b/nntrainer/optimizers/lr_scheduler_constant.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   lr_scheduler_constant.cpp
+ * @date   09 December 2021
+ * @brief  This is Constant Learning Rate Scheduler class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#include <cmath>
+
+#include <common_properties.h>
+#include <lr_scheduler_constant.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <node_exporter.h>
+
+namespace nntrainer {
+
+ConstantLearningRateScheduler::ConstantLearningRateScheduler() :
+  lr_props(props::LearningRate()) {}
+
+void ConstantLearningRateScheduler::setProperty(
+  const std::vector<std::string> &values) {
+  auto left = loadProperties(values, lr_props);
+  NNTR_THROW_IF(left.size(), std::invalid_argument)
+    << "[ConstantLearningRateScheduler] There are unparsed properties";
+}
+
+void ConstantLearningRateScheduler::exportTo(
+  Exporter &exporter, const ExportMethods &method) const {
+  exporter.saveResult(lr_props, method, this);
+}
+
+double ConstantLearningRateScheduler::getLearningRate(size_t iteration) {
+  return std::get<props::LearningRate>(lr_props);
+}
+
+} // namespace nntrainer

--- a/nntrainer/optimizers/lr_scheduler_constant.h
+++ b/nntrainer/optimizers/lr_scheduler_constant.h
@@ -41,6 +41,12 @@ public:
   virtual double getLearningRate(size_t iteration) override;
 
   /**
+   * @copydoc LearningRateScheduler::finalize()
+   *
+   */
+  virtual void finalize() override;
+
+  /**
    * @copydoc LearningRateScheduler::exportTo(Exporter &exporter, const
    * ExportMethods& method)
    *

--- a/nntrainer/optimizers/lr_scheduler_constant.h
+++ b/nntrainer/optimizers/lr_scheduler_constant.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   lr_scheduler_constant.h
+ * @date   09 December 2021
+ * @brief  This is Constant Learning Rate Scheduler class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __LEARNING_RATE_SCHEDULER_CONSTANT__
+#define __LEARNING_RATE_SCHEDULER_CONSTANT__
+#ifdef __cplusplus
+
+#include <string>
+
+#include <lr_scheduler.h>
+
+namespace nntrainer {
+
+/**
+ * @class   Constant Learning Rate Scheduler class
+ * @brief   class for constant Learning Rate Schedulers
+ */
+class ConstantLearningRateScheduler : public LearningRateScheduler {
+
+public:
+  /**
+   * @brief Construct a new constant learning rate scheduler object
+   *
+   */
+  ConstantLearningRateScheduler();
+
+  /**
+   * @copydoc LearningRateScheduler::getLearningRate(size_t iteration) const
+   *
+   */
+  virtual double getLearningRate(size_t iteration) override;
+
+  /**
+   * @copydoc LearningRateScheduler::exportTo(Exporter &exporter, const
+   * ExportMethods& method)
+   *
+   */
+  void exportTo(Exporter &exporter, const ExportMethods &method) const override;
+
+  /**
+   * @copydoc LearningRateScheduler::setProperty(const std::vector<std::string>
+   * &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @copydoc LearningRateScheduler::getType() const
+   *
+   */
+  const std::string getType() const override {
+    return ConstantLearningRateScheduler::type;
+  }
+
+  inline static const std::string type = "constant";
+
+private:
+  std::tuple<props::LearningRate> lr_props;
+};
+
+} /* namespace nntrainer */
+
+#endif /* __cplusplus */
+#endif /* __LEARNING_RATE_SCHEDULER_CONSTANT__ */

--- a/nntrainer/optimizers/lr_scheduler_exponential.cpp
+++ b/nntrainer/optimizers/lr_scheduler_exponential.cpp
@@ -24,6 +24,16 @@ namespace nntrainer {
 ExponentialLearningRateScheduler::ExponentialLearningRateScheduler() :
   lr_props(props::DecayRate(), props::DecaySteps()) {}
 
+void ExponentialLearningRateScheduler::finalize() {
+  NNTR_THROW_IF(std::get<props::DecayRate>(lr_props).empty(),
+                std::invalid_argument)
+    << "[ConstantLearningRateScheduler] Decay Rate is not set";
+  NNTR_THROW_IF(std::get<props::DecaySteps>(lr_props).empty(),
+                std::invalid_argument)
+    << "[ConstantLearningRateScheduler] Decay Steps is not set";
+  ConstantLearningRateScheduler::finalize();
+}
+
 void ExponentialLearningRateScheduler::setProperty(
   const std::vector<std::string> &values) {
   auto left = loadProperties(values, lr_props);

--- a/nntrainer/optimizers/lr_scheduler_exponential.cpp
+++ b/nntrainer/optimizers/lr_scheduler_exponential.cpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   lr_scheduler_exponential.cpp
+ * @date   09 December 2021
+ * @brief  This is Exponential Learning Rate Scheduler class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#include <cmath>
+
+#include <common_properties.h>
+#include <lr_scheduler_exponential.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <node_exporter.h>
+
+namespace nntrainer {
+
+ExponentialLearningRateScheduler::ExponentialLearningRateScheduler() :
+  lr_props(props::DecayRate(), props::DecaySteps()) {}
+
+void ExponentialLearningRateScheduler::setProperty(
+  const std::vector<std::string> &values) {
+  auto left = loadProperties(values, lr_props);
+  ConstantLearningRateScheduler::setProperty(left);
+}
+
+void ExponentialLearningRateScheduler::exportTo(
+  Exporter &exporter, const ExportMethods &method) const {
+  ConstantLearningRateScheduler::exportTo(exporter, method);
+  exporter.saveResult(lr_props, method, this);
+}
+
+double ExponentialLearningRateScheduler::getLearningRate(size_t iteration) {
+  auto const &lr = ConstantLearningRateScheduler::getLearningRate(iteration);
+  auto const &[decay_rate, decay_steps] = lr_props;
+
+  return lr * pow(decay_rate, (iteration / (float)decay_steps));
+}
+
+} // namespace nntrainer

--- a/nntrainer/optimizers/lr_scheduler_exponential.h
+++ b/nntrainer/optimizers/lr_scheduler_exponential.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   lr_scheduler_exponential.h
+ * @date   09 December 2021
+ * @brief  This is Exponential Learning Rate Scheduler class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __LEARNING_RATE_SCHEDULER_EXPONENTIAL__
+#define __LEARNING_RATE_SCHEDULER_EXPONENTIAL__
+#ifdef __cplusplus
+
+#include <string>
+
+#include <lr_scheduler_constant.h>
+
+namespace nntrainer {
+
+/**
+ * @class   Constant Learning Rate Scheduler class
+ * @brief   class for constant Learning Rate Schedulers
+ */
+class ExponentialLearningRateScheduler : public ConstantLearningRateScheduler {
+
+public:
+  /**
+   * @brief Construct a new constant learning rate scheduler object
+   *
+   */
+  ExponentialLearningRateScheduler();
+
+  /**
+   * @copydoc LearningRateScheduler::getLearningRate(size_t iteration) const
+   *
+   */
+  virtual double getLearningRate(size_t iteration) override;
+
+  /**
+   * @copydoc LearningRateScheduler::exportTo(Exporter &exporter, const
+   * ExportMethods& method)
+   *
+   */
+  void exportTo(Exporter &exporter, const ExportMethods &method) const override;
+
+  /**
+   * @copydoc LearningRateScheduler::setProperty(const std::vector<std::string>
+   * &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @copydoc LearningRateScheduler::getType() const
+   *
+   */
+  const std::string getType() const override {
+    return ExponentialLearningRateScheduler::type;
+  }
+
+  inline static const std::string type = "exponential";
+
+private:
+  std::tuple<props::DecayRate, props::DecaySteps> lr_props;
+};
+
+} /* namespace nntrainer */
+
+#endif /* __cplusplus */
+#endif /* __LEARNING_RATE_SCHEDULER_EXPONENTIAL__ */

--- a/nntrainer/optimizers/lr_scheduler_exponential.h
+++ b/nntrainer/optimizers/lr_scheduler_exponential.h
@@ -25,7 +25,8 @@ namespace nntrainer {
  * @class   Constant Learning Rate Scheduler class
  * @brief   class for constant Learning Rate Schedulers
  */
-class ExponentialLearningRateScheduler : public ConstantLearningRateScheduler {
+class ExponentialLearningRateScheduler final
+  : public ConstantLearningRateScheduler {
 
 public:
   /**
@@ -38,7 +39,13 @@ public:
    * @copydoc LearningRateScheduler::getLearningRate(size_t iteration) const
    *
    */
-  virtual double getLearningRate(size_t iteration) override;
+  double getLearningRate(size_t iteration) override;
+
+  /**
+   * @copydoc LearningRateScheduler::finalize()
+   *
+   */
+  void finalize() override;
 
   /**
    * @copydoc LearningRateScheduler::exportTo(Exporter &exporter, const

--- a/nntrainer/optimizers/meson.build
+++ b/nntrainer/optimizers/meson.build
@@ -4,7 +4,8 @@ optimizer_sources = [
   'optimizer_impl.cpp',
   'sgd.cpp',
   'optimizer_context.cpp',
-  'lr_scheduler_constant.cpp'
+  'lr_scheduler_constant.cpp',
+  'lr_scheduler_exponential.cpp'
 ]
 
 optimizer_headers = [

--- a/nntrainer/optimizers/meson.build
+++ b/nntrainer/optimizers/meson.build
@@ -3,13 +3,14 @@ optimizer_sources = [
   'optimizer_devel.cpp',
   'optimizer_impl.cpp',
   'sgd.cpp',
-  'optimizer_context.cpp'
+  'optimizer_context.cpp',
+  'lr_scheduler_constant.cpp'
 ]
 
 optimizer_headers = [
   'optimizer_devel.h',
   'optimizer_impl.h',
-  'optimizer_context.h'
+  'optimizer_context.h',
 ]
 
 foreach s : optimizer_sources

--- a/nntrainer/optimizers/optimizer_impl.cpp
+++ b/nntrainer/optimizers/optimizer_impl.cpp
@@ -12,10 +12,11 @@
  *
  */
 
+#include <cmath>
 #include <fstream>
 #include <iostream>
 
-#include <cmath>
+#include <common_properties.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>
@@ -25,7 +26,8 @@
 namespace nntrainer {
 
 OptimizerImpl::OptimizerImpl() :
-  optimizer_impl_props(PropsLR(), PropsDecayRate(), PropsDecaySteps()) {}
+  optimizer_impl_props(props::LearningRate(), props::DecayRate(),
+                       props::DecaySteps()) {}
 
 void OptimizerImpl::setProperty(const std::vector<std::string> &values) {
   auto left = loadProperties(values, optimizer_impl_props);

--- a/nntrainer/optimizers/optimizer_impl.h
+++ b/nntrainer/optimizers/optimizer_impl.h
@@ -18,41 +18,10 @@
 
 #include <tuple>
 
-#include <base_properties.h>
+#include <common_properties.h>
 #include <optimizer_devel.h>
 
 namespace nntrainer {
-
-/**
- * @brief Learning Rate props
- *
- */
-class PropsLR : public Property<float> {
-public:
-  static constexpr const char *key =
-    "learning_rate";               /**< unique key to access */
-  using prop_tag = float_prop_tag; /**< property type */
-};
-
-/**
- * @brief Decay rate property
- *
- */
-class PropsDecayRate : public Property<float> {
-public:
-  static constexpr const char *key = "decay_rate"; /**< unique key to access */
-  using prop_tag = float_prop_tag;                 /**< property type */
-};
-
-/**
- * @brief decay steps property
- *
- */
-class PropsDecaySteps : public PositiveIntegerProperty {
-public:
-  static constexpr const char *key = "decay_steps"; /**< unique key to access */
-  using prop_tag = uint_prop_tag;                   /**< property type */
-};
 
 /**
  * @class   Optimizer Base class for optimizers
@@ -120,7 +89,8 @@ public:
   }
 
 protected:
-  std::tuple<PropsLR, PropsDecayRate, PropsDecaySteps> optimizer_impl_props;
+  std::tuple<props::LearningRate, props::DecayRate, props::DecaySteps>
+    optimizer_impl_props;
 };
 
 } /* namespace nntrainer */


### PR DESCRIPTION
- Move declaration and definition of learning rate related properties out
to common properties from optimizer_impl class.
- Add interface for the learning rate scheduler which all learning rate
schedulers must abide by.
- Support constant learning rate scheduler.
- Support exponential decay learning rate scheduler with decay rate and
decay steps are the controllable properties.

See Also #1776

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>