### PR TITLE
Register learning rate schedulers with app_context and unittests

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -196,6 +196,8 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/optimizer_impl.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/adam.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/optimizers/sgd.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/optimizers/lr_scheduler_constant.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/optimizers/lr_scheduler_exponential.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/util_func.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/ini_wrapper.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/profiler.cpp \

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -49,6 +49,8 @@
 #include <grucell.h>
 #include <identity_layer.h>
 #include <input_layer.h>
+#include <lr_scheduler_constant.h>
+#include <lr_scheduler_exponential.h>
 #include <lstm.h>
 #include <lstmcell.h>
 #include <mol_attention_layer.h>
@@ -217,6 +219,14 @@ static void add_default_object(AppContext &ac) {
                      OptType::ADAM);
   ac.registerFactory(AppContext::unknownFactory<ml::train::Optimizer>,
                      "unknown", OptType::UNKNOWN);
+
+  using LRType = LearningRateType;
+  ac.registerFactory(
+    nntrainer::createLearningRateScheduler<ConstantLearningRateScheduler>,
+    ConstantLearningRateScheduler::type, LRType::CONSTANT);
+  ac.registerFactory(
+    nntrainer::createLearningRateScheduler<ExponentialLearningRateScheduler>,
+    ExponentialLearningRateScheduler::type, LRType::EXPONENTIAL);
 
   using LayerType = ml::train::LayerType;
   ac.registerFactory(nntrainer::createLayer<InputLayer>, InputLayer::type,
@@ -546,5 +556,13 @@ template const int AppContext::registerFactory<ml::train::Optimizer>(
 template const int AppContext::registerFactory<nntrainer::Layer>(
   const FactoryType<nntrainer::Layer> factory, const std::string &key,
   const int int_key);
+
+/**
+ * @copydoc const int AppContext::registerFactory
+ */
+template const int
+AppContext::registerFactory<nntrainer::LearningRateScheduler>(
+  const FactoryType<nntrainer::LearningRateScheduler> factory,
+  const std::string &key, const int int_key);
 
 } // namespace nntrainer

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -28,6 +28,7 @@
 
 #include <layer.h>
 #include <layer_devel.h>
+#include <lr_scheduler.h>
 #include <optimizer.h>
 
 #include <nntrainer_error.h>
@@ -263,7 +264,9 @@ public:
   }
 
 private:
-  FactoryMap<ml::train::Optimizer, nntrainer::Layer> factory_map;
+  FactoryMap<ml::train::Optimizer, nntrainer::Layer,
+             nntrainer::LearningRateScheduler>
+    factory_map;
   std::string working_path_base;
 
   template <typename Args, typename T> struct isSupportedHelper;
@@ -297,6 +300,14 @@ extern template const int AppContext::registerFactory<ml::train::Optimizer>(
 extern template const int AppContext::registerFactory<nntrainer::Layer>(
   const FactoryType<nntrainer::Layer> factory, const std::string &key,
   const int int_key);
+
+/**
+ * @copydoc const int AppContext::registerFactory
+ */
+extern template const int
+AppContext::registerFactory<nntrainer::LearningRateScheduler>(
+  const FactoryType<nntrainer::LearningRateScheduler> factory,
+  const std::string &key, const int int_key);
 
 namespace plugin {}
 

--- a/nntrainer/optimizers/lr_scheduler.h
+++ b/nntrainer/optimizers/lr_scheduler.h
@@ -23,6 +23,14 @@ class Exporter;
 enum class ExportMethods;
 
 /**
+ * @brief     Enumeration of optimizer type
+ */
+enum LearningRateType {
+  CONSTANT = 0, /** constant */
+  EXPONENTIAL   /** exponentially decay */
+};
+
+/**
  * @class   Learning Rate Schedulers Base class
  * @brief   Base class for all Learning Rate Schedulers
  */
@@ -93,6 +101,22 @@ public:
    */
   virtual const std::string getType() const = 0;
 };
+
+/**
+ * @brief General LR Scheduler Factory function to create LR Scheduler
+ *
+ * @param props property representation
+ * @return std::unique_ptr<nntrainer::LearningRateScheduler> created object
+ */
+template <typename T,
+          std::enable_if_t<std::is_base_of<LearningRateScheduler, T>::value, T>
+            * = nullptr>
+std::unique_ptr<LearningRateScheduler>
+createLearningRateScheduler(const std::vector<std::string> &props = {}) {
+  std::unique_ptr<LearningRateScheduler> ptr = std::make_unique<T>();
+  ptr->setProperty(props);
+  return ptr;
+}
 
 } /* namespace nntrainer */
 

--- a/nntrainer/optimizers/lr_scheduler_constant.h
+++ b/nntrainer/optimizers/lr_scheduler_constant.h
@@ -17,6 +17,7 @@
 
 #include <string>
 
+#include <common_properties.h>
 #include <lr_scheduler.h>
 
 namespace nntrainer {

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -42,6 +42,7 @@ test_target = [
   ['unittest_base_properties', []],
   ['unittest_common_properties', []],
   ['unittest_nntrainer_tensor_pool', []],
+  ['unittest_nntrainer_lr_scheduler', []],
 ]
 
 if get_option('enable-profile')

--- a/test/unittest/unittest_nntrainer_lr_scheduler.cpp
+++ b/test/unittest/unittest_nntrainer_lr_scheduler.cpp
@@ -91,6 +91,30 @@ TEST(lr_constant, prop_03_p) {
  * @brief test set and get learning rate
  *
  */
+TEST(lr_constant, final_01_n) {
+  auto &ac = nntrainer::AppContext::Global();
+  auto lr = ac.createObject<nntrainer::LearningRateScheduler>("constant");
+
+  /** fails as learning rate property is not set */
+  EXPECT_ANY_THROW(lr->finalize());
+}
+
+/**
+ * @brief test set and get learning rate
+ *
+ */
+TEST(lr_constant, final_02_p) {
+  auto &ac = nntrainer::AppContext::Global();
+  auto lr = ac.createObject<nntrainer::LearningRateScheduler>("constant");
+
+  EXPECT_NO_THROW(lr->setProperty({"learning_rate=1.0"}));
+  EXPECT_NO_THROW(lr->finalize());
+}
+
+/**
+ * @brief test set and get learning rate
+ *
+ */
 TEST(lr_exponential, prop_01_n) {
   auto &ac = nntrainer::AppContext::Global();
   auto lr = ac.createObject<nntrainer::LearningRateScheduler>("exponential");
@@ -107,12 +131,15 @@ TEST(lr_exponential, prop_02_p) {
   auto lr = ac.createObject<nntrainer::LearningRateScheduler>("exponential");
 
   EXPECT_NO_THROW(lr->setProperty({"learning_rate=1.0"}));
+  EXPECT_ANY_THROW(lr->finalize());
   EXPECT_ANY_THROW(lr->getLearningRate(0));
 
   EXPECT_NO_THROW(lr->setProperty({"decay_steps=1"}));
+  EXPECT_ANY_THROW(lr->finalize());
   EXPECT_ANY_THROW(lr->getLearningRate(0));
 
   EXPECT_NO_THROW(lr->setProperty({"decay_rate=0.9"}));
+  EXPECT_NO_THROW(lr->finalize());
   EXPECT_NO_THROW(lr->getLearningRate(0));
 
   EXPECT_FLOAT_EQ(lr->getLearningRate(0), 1.0f);

--- a/test/unittest/unittest_nntrainer_lr_scheduler.cpp
+++ b/test/unittest/unittest_nntrainer_lr_scheduler.cpp
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ *
+ * @file   unittest_nntrainer_lr_scheduler.cpp
+ * @date   09 December 2021
+ * @brief  This is unittests for learning rate schedulers
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#include <fstream>
+#include <gtest/gtest.h>
+
+#include <lr_scheduler.h>
+#include <lr_scheduler_constant.h>
+#include <lr_scheduler_exponential.h>
+#include <nntrainer_error.h>
+
+#include "nntrainer_test_util.h"
+
+/**
+ * @brief test constructing lr scheduler
+ *
+ */
+TEST(lr_constant, ctor_initializer_01_p) {
+  EXPECT_NO_THROW(nntrainer::createLearningRateScheduler<
+                  nntrainer::ConstantLearningRateScheduler>({}));
+}
+
+/**
+ * @brief test constructing lr scheduler
+ *
+ */
+TEST(lr_constant, ctor_initializer_02_p) {
+  auto &ac = nntrainer::AppContext::Global();
+  EXPECT_NO_THROW(
+    ac.createObject<nntrainer::LearningRateScheduler>("constant"));
+}
+
+/**
+ * @brief test constructing lr scheduler
+ *
+ */
+TEST(lr_constant, ctor_initializer_03_n) {
+  auto &ac = nntrainer::AppContext::Global();
+  EXPECT_ANY_THROW(ac.createObject<nntrainer::LearningRateScheduler>("random"));
+}
+
+/**
+ * @brief test set and get learning rate
+ *
+ */
+TEST(lr_constant, prop_01_n) {
+  auto &ac = nntrainer::AppContext::Global();
+  auto lr = ac.createObject<nntrainer::LearningRateScheduler>("constant");
+
+  /** fails as learning rate property is not set */
+  EXPECT_ANY_THROW(lr->getLearningRate(0));
+}
+
+/**
+ * @brief test set and get learning rate
+ *
+ */
+TEST(lr_constant, prop_02_n) {
+  auto &ac = nntrainer::AppContext::Global();
+  auto lr = ac.createObject<nntrainer::LearningRateScheduler>("constant");
+
+  EXPECT_ANY_THROW(lr->setProperty({"random=1.0"}));
+}
+
+/**
+ * @brief test set and get learning rate
+ *
+ */
+TEST(lr_constant, prop_03_p) {
+  auto &ac = nntrainer::AppContext::Global();
+  auto lr = ac.createObject<nntrainer::LearningRateScheduler>("constant");
+
+  EXPECT_NO_THROW(lr->setProperty({"learning_rate=1.0"}));
+
+  EXPECT_NO_THROW(lr->getLearningRate(0));
+  EXPECT_FLOAT_EQ(lr->getLearningRate(0), lr->getLearningRate(100));
+  EXPECT_FLOAT_EQ(lr->getLearningRate(10), 1.0f);
+}
+
+/**
+ * @brief test set and get learning rate
+ *
+ */
+TEST(lr_exponential, prop_01_n) {
+  auto &ac = nntrainer::AppContext::Global();
+  auto lr = ac.createObject<nntrainer::LearningRateScheduler>("exponential");
+
+  EXPECT_ANY_THROW(lr->getLearningRate(0));
+}
+
+/**
+ * @brief test set and get learning rate
+ *
+ */
+TEST(lr_exponential, prop_02_p) {
+  auto &ac = nntrainer::AppContext::Global();
+  auto lr = ac.createObject<nntrainer::LearningRateScheduler>("exponential");
+
+  EXPECT_NO_THROW(lr->setProperty({"learning_rate=1.0"}));
+  EXPECT_ANY_THROW(lr->getLearningRate(0));
+
+  EXPECT_NO_THROW(lr->setProperty({"decay_steps=1"}));
+  EXPECT_ANY_THROW(lr->getLearningRate(0));
+
+  EXPECT_NO_THROW(lr->setProperty({"decay_rate=0.9"}));
+  EXPECT_NO_THROW(lr->getLearningRate(0));
+
+  EXPECT_FLOAT_EQ(lr->getLearningRate(0), 1.0f);
+  EXPECT_FLOAT_EQ(lr->getLearningRate(1), 1.0 * std::pow(0.9f, 1));
+  EXPECT_FLOAT_EQ(lr->getLearningRate(3), 1.0 * std::pow(0.9f, 3));
+}
+
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error duing InitGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error duing RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}


### PR DESCRIPTION
- register learning rate scheduler with the app context and regiter its
type factories.
- Add unittests for the constant and exponential learning rate schedulers.

See Also #1776

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>