### PR TITLE
[layer] mse layer optimize for memory and compute

### DIFF
--- a/nntrainer/layers/loss/mse_loss_layer.cpp
+++ b/nntrainer/layers/loss/mse_loss_layer.cpp
@@ -42,8 +42,8 @@ void MSELossLayer::calcDerivative(RunLayerContext &context) {
   Tensor &y = context.getInput(SINGLE_INOUT_IDX);
 
   y.subtract(y2, ret_derivative);
-  ret_derivative.multiply_i(2);
-  if (ret_derivative.divide_i(y.size()) != ML_ERROR_NONE) {
+  float divider = ((float)y.size()) / 2;
+  if (ret_derivative.divide_i(divider) != ML_ERROR_NONE) {
     throw std::runtime_error(
       "[MSELossLayer::calcDerivative] Error when calculating loss");
   }


### PR DESCRIPTION
- reduce memory usage for mse forwarding.
- optimize mse backwarding calculation by merging multiple and divide into
a single call.
- optimize mse layer to use scaled l2norm instead of manually calculating
the l2norm.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>