### PR TITLE
[Trivial] Tensor save changes /ofstream/ostream

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1479,7 +1479,7 @@ void Tensor::fill(const Tensor &from, bool alloc) {
   this->copy(from.getData());
 }
 
-void Tensor::save(std::ofstream &file) {
+void Tensor::save(std::ostream &file) {
   NNTR_THROW_IF(!contiguous, std::invalid_argument)
     << getName() << " is not contiguous, cannot save.";
 

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1081,7 +1081,7 @@ public:
    * @brief     Save the Tensor into file
    * @param[in] file output file stream
    */
-  void save(std::ofstream &file);
+  void save(std::ostream &file);
 
   /**
    * @brief     Read the Tensor from file

--- a/nntrainer/utils/util_func.cpp
+++ b/nntrainer/utils/util_func.cpp
@@ -82,7 +82,7 @@ void checkedRead(std::ifstream &file, char *array, std::streamsize size,
   checkFile(file, error_msg);
 }
 
-void checkedWrite(std::ofstream &file, const char *array, std::streamsize size,
+void checkedWrite(std::ostream &file, const char *array, std::streamsize size,
                   const char *error_msg) {
   file.write(array, size);
 

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -134,7 +134,7 @@ void checkedRead(std::ifstream &file, char *array, std::streamsize size,
  * @param error_msg error msg to print when operation fail
  * @throw std::runtime_error if file.fail() is true after write.
  */
-void checkedWrite(std::ofstream &file, const char *array, std::streamsize size,
+void checkedWrite(std::ostream &file, const char *array, std::streamsize size,
                   const char *error_msg = default_error_msg);
 /**
  * @brief read string from a binary file

--- a/test/unittest/unittest_util_func.cpp
+++ b/test/unittest/unittest_util_func.cpp
@@ -80,7 +80,7 @@ TEST(nntrainer_util_func, checkedRead_n) {
 }
 
 TEST(nntrainer_util_func, checkedWrite_n) {
-  std::ofstream file("/not good file");
+  std::ofstream file("!@/not good file");
   char array[5];
 
   EXPECT_THROW(nntrainer::checkedWrite(file, array, 5), std::runtime_error);
@@ -93,7 +93,7 @@ TEST(nntrainer_util_func, readString_n) {
 }
 
 TEST(nntrainer_util_func, writeString_n) {
-  std::ofstream file("/not good file");
+  std::ofstream file("!@/not good file");
   std::string str;
 
   EXPECT_THROW(nntrainer::writeString(file, str), std::runtime_error);


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Trivial] Tensor save changes /ofstream/ostream</summary><br />

There is no reason to limit saving to ofstream. Thus it is changed to
ostream

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

