### PR TITLE
[Spec] Change nntrainer install dir

### DIFF
--- a/debian/nnstreamer-nntrainer.install
+++ b/debian/nnstreamer-nntrainer.install
@@ -1,1 +1,1 @@
-/usr/lib/*/nnstreamer/filters/libnnstreamer_filter_nntrainer.so
+/usr/lib/nnstreamer/filters/libnnstreamer_filter_nntrainer.so

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,6 +8,7 @@ option('enable-test', type: 'boolean', value: true)
 option('enable-logging', type: 'boolean', value: true)
 option('enable-tizen-feature-check', type: 'boolean', value: true)
 option('enable-nnstreamer-tensor-filter', type: 'boolean', value: true)
+option('nnstreamer-subplugin-install-path', type: 'string', value: '/usr/lib/nnstreamer') # where nnstreamer subplugin should be installed
 option('enable-nnstreamer-backbone', type: 'boolean', value: true)
 option('enable-tflite-backbone', type: 'boolean', value: true)
 option('enable-profile', type: 'boolean', value: false)

--- a/nnstreamer/tensor_filter/meson.build
+++ b/nnstreamer/tensor_filter/meson.build
@@ -16,7 +16,7 @@ nntrainer_prefix = get_option('prefix')
 nnstreamer_filter_nntrainer_deps = [glib_dep, gmodule_dep, gst_dep, nntrainer_ccapi_dep, nnstreamer_dep]
 
 nnstreamer_libdir = nntrainer_prefix / get_option('libdir')
-subplugin_install_prefix = nnstreamer_libdir / 'nnstreamer'
+subplugin_install_prefix = get_option('nnstreamer-subplugin-install-path')
 filter_subplugin_install_dir = subplugin_install_prefix / 'filters'
 
 shared_library('nnstreamer_filter_nntrainer',

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -1,6 +1,7 @@
 # Execute gbs with --define "testcoverage 1" in case that you must get unittest coverage statistics
 %define         use_cblas 1
 %define         nnstreamer_filter 1
+%define         nnstreamer_subplugin_path /usr/lib/nnstreamer
 %define         use_gym 0
 %define         support_ccapi 1
 %define         support_nnstreamer_backbone 1
@@ -9,6 +10,7 @@
 %define         nntrainerapplicationdir %{_libdir}/nntrainer/bin
 %define         gen_input $(pwd)/test/input_gen/genInput.py
 %define         support_data_augmentation_opencv 1
+%define         configure_subplugin_install_path -Dnnstreamer-subplugin-install-path=%{nnstreamer_subplugin_path}
 
 %bcond_with tizen
 
@@ -353,7 +355,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} \
       %{enable_gym} %{enable_nnstreamer_tensor_filter} %{enable_profile} \
       %{enable_nnstreamer_backbone} %{enable_tflite_backbone} \
       %{enable_tflite_interpreter} %{capi_ml_pkg_dep_resolution} \
-      %{enable_reduce_tolerance} %{enable_debug} build
+      %{enable_reduce_tolerance} %{configure_subplugin_install_path} %{enable_debug}  build
 
 ninja -C build %{?_smp_mflags}
 
@@ -514,7 +516,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %manifest nntrainer.manifest
 %defattr(-,root,root,-)
 %license LICENSE
-%{_libdir}/nnstreamer/filters/libnnstreamer_filter_nntrainer.so
+%{nnstreamer_subplugin_path}/filters/libnnstreamer_filter_nntrainer.so
 
 %files -n nnstreamer-nntrainer-devel-static
 %manifest nntrainer.manifest


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Spec] Change nntrainer install dir</summary><br />

This patch change nntrainer install dir to /usr/prefix/*,
see also https://github.com/nnstreamer/nnstreamer/issues/3560

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

