### PR TITLE
[Semantics] InitContext NumOutput is hint

### DIFF
--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -27,11 +27,6 @@ ConcatLayer::ConcatLayer() : Layer(), leading_helper_dim(1) {}
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
 void ConcatLayer::finalize(InitLayerContext &context) {
-  if (context.getNumOutputs() != 1) {
-    throw std::invalid_argument(
-      "Error: only a single output is supported with concat layer");
-  }
-
   auto &concat_dimension_prop = std::get<props::ConcatDimension>(concat_props);
   /** for backward compatibility, default concat dimension will be channel */
   /// @todo this is hacky way to force concat dimension to width if channel

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -14,10 +14,22 @@
 #include <functional>
 
 #include <layer_context.h>
+#include <stdexcept>
 #include <var_grad.h>
 #include <weight.h>
 
 namespace nntrainer {
+void InitLayerContext::setOutputDimensions(
+  const std::vector<TensorDim> &out_dim) {
+  NNTR_THROW_IF(out_dim.size() < num_requested_out, std::invalid_argument)
+    << "number of output dimension set is smaller than the number of out "
+       "tensor slots "
+       "requested, num output dimensions: "
+    << output_dim.size() << " slots to fill: " << num_requested_out
+    << " context name: " << name;
+  output_dim = out_dim;
+}
+
 RunLayerContext::RunLayerContext(const std::string &name, bool trainable,
                                  float l, bool in_place_,
                                  const std::vector<Weight *> &w,

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -42,14 +42,14 @@ public:
    *
    * @param dim Input dimensions for the layer
    */
-  InitLayerContext(const std::vector<TensorDim> &dim, unsigned int num_out,
+  InitLayerContext(const std::vector<TensorDim> &dim, unsigned int num_req_out,
                    bool in_place_, const std::string &n = "",
                    const std::string &prefix_ = "",
                    const float max_norm = 0.0) :
     input_dim(dim),
     in_place(in_place_),
     clip_by_global_norm(max_norm),
-    num_outputs(num_out),
+    num_requested_out(num_req_out),
     name(n),
     prefix(prefix_) {
     NNTR_THROW_IF(!validate(), std::invalid_argument)
@@ -78,7 +78,7 @@ public:
    *
    * @return unsigned int number of inputs
    */
-  unsigned int getNumOutputs() const { return num_outputs; }
+  unsigned int getNumRequestedOutputs() const { return num_requested_out; }
 
   /**
    * @brief Get the Input Dimensions object
@@ -124,11 +124,7 @@ public:
    *
    * @param out_dim the output dimension to set to
    */
-  void setOutputDimensions(const std::vector<TensorDim> &out_dim) {
-    if (out_dim.size() != num_outputs)
-      throw std::invalid_argument("Mismatch number of outputs");
-    output_dim = out_dim;
-  }
+  void setOutputDimensions(const std::vector<TensorDim> &out_dim);
 
   /**
    * @brief Request a new weight for the layer
@@ -292,9 +288,10 @@ private:
     tensors_spec; /**< Specification for the var_grad (trainable/non-trainable
                      variables) */
 
-  unsigned int num_outputs; /**< number of outputs for the layer */
-  std::string name;         /**< name of the layer */
-  std::string prefix;       /**< prefix of the layer */
+  unsigned int
+    num_requested_out; /**< number of requested outputs for the layer */
+  std::string name;    /**< name of the layer */
+  std::string prefix;  /**< prefix of the layer */
 };
 
 /**

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -748,11 +748,7 @@ public:
   bool needs_calc_gradient; /**< cache if this layer needs to do calcGradient */
 
   std::vector<std::unique_ptr<Connection>>
-    output_connections;                      /**< output layer names */
-  unsigned effective_output_connection_size; /**< effective output connection
-                                                size, this skips not connected
-                                                slot, so this number can be
-                                                diffrent from num_outputs() */
+    output_connections; /**< output layer names */
 
   std::unique_ptr<RunLayerContext>
     run_context; /**< context required for running/execution of the layer. This

--- a/nntrainer/layers/mol_attention_layer.cpp
+++ b/nntrainer/layers/mol_attention_layer.cpp
@@ -149,7 +149,7 @@ void MoLAttentionLayer::finalize(InitLayerContext &context) {
     context.requestTensor(state_dim, "dstate", Tensor::Initializer::NONE, false,
                           TensorLifespan::BACKWARD_FUNC_LIFESPAN);
 
-  if (context.getNumOutputs() == 2)
+  if (context.getNumRequestedOutputs() == 2)
     context.setOutputDimensions({query_dim, state_dim});
   else
     context.setOutputDimensions({query_dim});

--- a/nntrainer/layers/multiout_layer.cpp
+++ b/nntrainer/layers/multiout_layer.cpp
@@ -23,7 +23,7 @@ namespace nntrainer {
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
 void MultiOutLayer::finalize(InitLayerContext &context) {
-  std::vector<TensorDim> out_dims(context.getNumOutputs());
+  std::vector<TensorDim> out_dims(context.getNumRequestedOutputs());
   const TensorDim &in_dim = context.getInputDimensions()[0];
 
   std::fill(out_dims.begin(), out_dims.end(), in_dim);

--- a/nntrainer/layers/split_layer.cpp
+++ b/nntrainer/layers/split_layer.cpp
@@ -44,14 +44,14 @@ void SplitLayer::finalize(InitLayerContext &context) {
    * 3. axis = 3, output_dim = [b,c,h,1], num_outputs = w
    */
   const TensorDim &in_dim = context.getInputDimensions()[0];
-  if (in_dim.getTensorDim(split_dimension) != context.getNumOutputs())
+  if (in_dim.getTensorDim(split_dimension) != context.getNumRequestedOutputs())
     throw std::invalid_argument(
       "Split dimension cannot be split into given number of outputs");
 
   TensorDim d = in_dim;
   d.setTensorDim(split_dimension, 1);
 
-  std::vector<TensorDim> output_dim(context.getNumOutputs());
+  std::vector<TensorDim> output_dim(context.getNumRequestedOutputs());
   for (auto &out_dim : output_dim) {
     out_dim = d;
   }

--- a/nntrainer/layers/time_dist.cpp
+++ b/nntrainer/layers/time_dist.cpp
@@ -121,7 +121,7 @@ void TimeDistLayer::finalize(InitLayerContext &context) {
    */
   TensorDim dist_dim = input_dim;
   dist_dim.height(1);
-  InitLayerContext dist_context({dist_dim}, context.getNumOutputs(),
+  InitLayerContext dist_context({dist_dim}, context.getNumRequestedOutputs(),
                                 context.executeInPlace(), context.getName());
 
   // During forwarding and backwarding, it set the input and output buffer of

--- a/test/unittest/layers/layers_dependent_common_tests.cpp
+++ b/test/unittest/layers/layers_dependent_common_tests.cpp
@@ -51,13 +51,12 @@ TEST_P(LayerSemantics, finalizeValidateLayerNode_p) {
   props.push_back(input_shape);
   props.push_back(input_layers);
   lnode->setProperty(props);
+  lnode->setOutputLayers({"dummy"});
 
   EXPECT_NO_THROW(lnode->setProperty(valid_properties));
 
   if (!must_fail) {
     nntrainer::InitLayerContext init_context = lnode->finalize();
-    EXPECT_EQ(init_context.getOutputDimensions().size(),
-              init_context.getNumOutputs());
 
     for (auto const &dim : init_context.getOutputDimensions())
       EXPECT_GT(dim.getDataLen(), size_t(0));
@@ -98,6 +97,7 @@ TEST_P(LayerSemantics, setBatchValidateLayerNode_p) {
   props.push_back(input_shape);
   props.push_back(input_layers);
   lnode->setProperty(props);
+  lnode->setOutputLayers({"dummy"});
 
   EXPECT_NO_THROW(lnode->setProperty(valid_properties));
 

--- a/test/unittest/layers/layers_standalone_common_tests.cpp
+++ b/test/unittest/layers/layers_standalone_common_tests.cpp
@@ -51,9 +51,6 @@ TEST_P(LayerSemantics, finalizeValidate_p) {
   if (!must_fail) {
     EXPECT_NO_THROW(layer->finalize(init_context));
 
-    EXPECT_EQ(init_context.getOutputDimensions().size(),
-              init_context.getNumOutputs());
-
     for (auto const &dim : init_context.getOutputDimensions())
       EXPECT_GT(dim.getDataLen(), size_t(0));
     for (auto const &ws : init_context.getWeightsSpec())


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Semantics] InitContext NumOutput is hint</summary><br />

This patch changes init context num output to be a hint how many outputs
has to be allocated. Layers may or may not depend on this information.
What Layer must gaurantee is that number of acutal outputs must be
bigger than the init context num output requested, this fixes dangling,
unused variable issue

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

resolves #1797