### PR TITLE
[RecurrentRealizer] Modify to have connection

### DIFF
--- a/nntrainer/compiler/input_realizer.h
+++ b/nntrainer/compiler/input_realizer.h
@@ -16,18 +16,17 @@
 #include <string>
 #include <vector>
 
+#include <connection.h>
 #include <realizer.h>
 
 namespace nntrainer {
 
 /**
  * @brief Graph realizer class which remaps input from start -> input layers
- * @note This class find orphaned identifer in order from start_layers and
- * change the identifier to input_layers. If start_layers does not have any
- * input layers, push single input identifier, if start_layers have
- * input_layers, check if the given input layer exists starting from the first
- * input layers, if not exist, change to the given input layer in order. In case
- * of start_layer contains n input_layers to be replaced.
+ * @note This class overwrites input conns to the location of start conns.
+ * This requires each start location have the slot for input connection.
+ * @note When number of input connection == 0 for a start connection of index
+ * zero, this pushes input connection to the slot
  *
  */
 class InputRealizer final : public GraphRealizer {
@@ -35,11 +34,11 @@ public:
   /**
    * @brief Construct a new Input Realizer object
    *
-   * @param start_layers start layers
-   * @param input_layers input layers
+   * @param start_conns start layers
+   * @param input_conns input layers
    */
-  InputRealizer(const std::vector<std::string> &start_layers,
-                const std::vector<std::string> &input_layers);
+  InputRealizer(const std::vector<Connection> &start_conns,
+                const std::vector<Connection> &input_conns);
 
   /**
    * @brief Destroy the Graph Realizer object
@@ -57,8 +56,8 @@ public:
   GraphRepresentation realize(const GraphRepresentation &reference) override;
 
 private:
-  std::vector<std::string> start_layers;
-  std::vector<std::string> input_layers;
+  std::vector<Connection> start_conns;
+  std::vector<Connection> input_conns;
 };
 
 } // namespace nntrainer

--- a/nntrainer/compiler/recurrent_realizer.h
+++ b/nntrainer/compiler/recurrent_realizer.h
@@ -50,16 +50,16 @@ public:
    * steps, where steps > 0
    *
    * @param properties
-   *        unroll_for = <int> // define timestep of unrolloing
+   *        unroll_for = <int> // define timestep of unrolling
    *        return_sequences = <bool> // return sequences
    *        recurrent_inputs = <vector<std::string>> // start of the loop
    *        recurrent_ouptuts = <vector<std::string>> // end of the loop
-   * @param input_layers input layer from outer side
-   * @param end_layers end layers (output of the internal graph)
+   * @param input_conns input conns from outer side
+   * @param end_conns end connections (output of the internal graph)
    */
   RecurrentRealizer(const std::vector<std::string> &properties,
-                    const std::vector<std::string> &input_layers,
-                    const std::vector<std::string> &end_layers);
+                    const std::vector<Connection> &input_conns,
+                    const std::vector<Connection> &end_conns);
 
   /**
    * @brief Construct a new Recurrent Realizer object
@@ -91,10 +91,10 @@ private:
                std::vector<props::AsSequence>, props::UnrollFor>;
 
   std::unordered_set<std::string> input_layers; /**< external input layers */
-  std::vector<std::string> end_layers;          /**< final output layers id */
-  std::unordered_set<std::string>
-    sequenced_return_layers; /**< sequenced return layers, subset of end_layers
-                              */
+  std::vector<Connection> end_conns;            /**< final output layers id */
+  std::unordered_set<Connection>
+    sequenced_return_conns; /**< sequenced return conns, subset of end_conns
+                             */
   std::unordered_map<Connection, Connection>
     recurrent_info;                           /**< final output layers id */
   std::unique_ptr<PropTypes> recurrent_props; /**< recurrent properties */

--- a/nntrainer/compiler/slice_realizer.cpp
+++ b/nntrainer/compiler/slice_realizer.cpp
@@ -10,6 +10,8 @@
  * @bug No known bugs except for NYI items
  */
 
+#include <connection.h>
+#include <iterator>
 #include <layer_node.h>
 #include <slice_realizer.h>
 
@@ -17,10 +19,19 @@
 
 namespace nntrainer {
 
-SliceRealizer::SliceRealizer(const std::vector<std::string> &start_layers,
-                             const std::vector<std::string> &end_layers) :
-  start_layers(start_layers),
-  end_layers(end_layers.begin(), end_layers.end()) {}
+SliceRealizer::SliceRealizer(const std::vector<Connection> &start_layers,
+                             const std::vector<Connection> &end_layers) {
+  /// discard index information as it is not needed as it is not really needed
+  this->start_layers.reserve(start_layers.size());
+
+  std::transform(start_layers.begin(), start_layers.end(),
+                 std::back_inserter(this->start_layers),
+                 [](const Connection &c) { return c.getName(); });
+
+  std::transform(end_layers.begin(), end_layers.end(),
+                 std::inserter(this->end_layers, this->end_layers.begin()),
+                 [](const Connection &c) { return c.getName(); });
+}
 
 SliceRealizer::~SliceRealizer() {}
 

--- a/nntrainer/compiler/slice_realizer.h
+++ b/nntrainer/compiler/slice_realizer.h
@@ -21,6 +21,8 @@
 
 namespace nntrainer {
 
+class Connection;
+
 /**
  * @brief Graph realizer class which slice graph representation
  *
@@ -30,11 +32,11 @@ public:
   /**
    * @brief Construct a new Slice Realizer object
    *
-   * @param start_layers start layers
-   * @param end_layers end layers
+   * @param start_connections start layers
+   * @param end_connections end layers
    */
-  SliceRealizer(const std::vector<std::string> &start_layers,
-                const std::vector<std::string> &end_layers);
+  SliceRealizer(const std::vector<Connection> &start_connections,
+                const std::vector<Connection> &end_connections);
 
   /**
    * @brief Destroy the Graph Realizer object

--- a/nntrainer/graph/connection.h
+++ b/nntrainer/graph/connection.h
@@ -35,9 +35,9 @@ public:
    * @brief Construct a new Connection object from string representation
    * string representation is format of {layer_name, idx};
    *
-   * @param string_representation string format of {layer_name}({idx})
+   * @param str_repr string format of {layer_name}({idx})
    */
-  explicit Connection(const std::string &string_representation);
+  explicit Connection(const std::string &str_repr);
 
   /**
    * @brief Construct a new Connection object

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -578,10 +578,10 @@ public:
  * used in recurrent realizer
  *
  */
-class AsSequence : public Name {
+class AsSequence : public Property<Connection> {
 public:
   static constexpr const char *key = "as_sequence";
-  using prop_tag = str_prop_tag;
+  using prop_tag = connection_prop_tag;
 };
 
 /**

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -934,15 +934,6 @@ void NeuralNetwork::addWithReferenceLayers(
     nodes.push_back(node->cloneConfiguration());
   }
 
-  auto normalize = [](const std::vector<std::string> &names) {
-    std::vector<props::Name> prop_names(names.begin(), names.end());
-    return std::vector<std::string>(prop_names.begin(), prop_names.end());
-  };
-
-  auto input_layers_ = normalize(input_layers);
-  auto start_layers_ = normalize(start_layers);
-  auto end_layers_ = normalize(end_layers);
-
   auto start_conns =
     std::vector<Connection>(start_layers.begin(), start_layers.end());
   auto input_conns =
@@ -955,20 +946,20 @@ void NeuralNetwork::addWithReferenceLayers(
   realizers.emplace_back(new PreviousInputRealizer(start_conns));
   realizers.emplace_back(new SliceRealizer(start_conns, end_conns));
 
-  if (!input_layers_.empty()) {
+  if (!input_conns.empty()) {
     realizers.emplace_back(new InputRealizer(start_conns, input_conns));
   }
 
   if (type == ml::train::ReferenceLayersType::RECURRENT) {
     realizers.emplace_back(
-      new RecurrentRealizer(type_properties, input_layers_, end_layers_));
+      new RecurrentRealizer(type_properties, input_conns, end_conns));
   }
 
   if (!scope.empty()) {
     realizers.emplace_back(
-      new RemapRealizer([&scope, &input_layers_](std::string &name) {
-        for (auto &i : input_layers_) {
-          if (i == name) {
+      new RemapRealizer([&scope, &input_conns](std::string &name) {
+        for (auto &i : input_conns) {
+          if (i.getName() == name) {
             return;
           }
         }

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -945,7 +945,8 @@ void NeuralNetwork::addWithReferenceLayers(
 
   auto start_conns =
     std::vector<Connection>(start_layers.begin(), start_layers.end());
-
+  auto input_conns =
+    std::vector<Connection>(input_layers.begin(), input_layers.end());
   auto end_conns =
     std::vector<Connection>(end_layers.begin(), end_layers.end());
 
@@ -955,7 +956,7 @@ void NeuralNetwork::addWithReferenceLayers(
   realizers.emplace_back(new SliceRealizer(start_conns, end_conns));
 
   if (!input_layers_.empty()) {
-    realizers.emplace_back(new InputRealizer(start_layers_, input_layers_));
+    realizers.emplace_back(new InputRealizer(start_conns, input_conns));
   }
 
   if (type == ml::train::ReferenceLayersType::RECURRENT) {

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -943,13 +943,16 @@ void NeuralNetwork::addWithReferenceLayers(
   auto start_layers_ = normalize(start_layers);
   auto end_layers_ = normalize(end_layers);
 
-  auto start_conns_ =
+  auto start_conns =
     std::vector<Connection>(start_layers.begin(), start_layers.end());
+
+  auto end_conns =
+    std::vector<Connection>(end_layers.begin(), end_layers.end());
 
   std::vector<std::unique_ptr<GraphRealizer>> realizers;
 
-  realizers.emplace_back(new PreviousInputRealizer(start_conns_));
-  realizers.emplace_back(new SliceRealizer(start_layers_, end_layers_));
+  realizers.emplace_back(new PreviousInputRealizer(start_conns));
+  realizers.emplace_back(new SliceRealizer(start_conns, end_conns));
 
   if (!input_layers_.empty()) {
     realizers.emplace_back(new InputRealizer(start_layers_, input_layers_));

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -464,7 +464,18 @@ TEST(SliceRealizer, slice_01_p) {
     {"fully_connected", {"name=d2", "input_layers=c1"}},
   };
 
-  SliceRealizer r({"a1", "b1", "b2"}, {"a1", "d1", "d2"});
+  using C = Connection;
+  SliceRealizer r(
+    {
+      C("a1"),
+      C("b1"),
+      C("b2"),
+    },
+    {
+      C("a1"),
+      C("d1"),
+      C("d2"),
+    });
 
   realizeAndEqual(r, before, after);
 }
@@ -498,7 +509,7 @@ TEST(SliceRealizer, slice_02_p) {
     {"concat", {"name=c1", "input_layers=a1, b1"}},
   };
 
-  SliceRealizer r({"a1"}, {"c1"});
+  SliceRealizer r({Connection("a1")}, {Connection("c1")});
 
   realizeAndEqual(r, before, after);
 }

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -58,10 +58,11 @@ TEST(FlattenRealizer, flatten_p) {
 }
 
 TEST(RecurrentRealizer, recurrent_no_return_sequence_p) {
+  using C = Connection;
 
   RecurrentRealizer r(
     {"unroll_for=3", "recurrent_input=fc_in", "recurrent_output=fc_out"},
-    {"source"}, {"fc_out"});
+    {C("source")}, {C("fc_out")});
 
   std::vector<LayerRepresentation> before = {
     {"fully_connected", {"name=fc_in", "input_layers=source"}},
@@ -84,10 +85,10 @@ TEST(RecurrentRealizer, recurrent_no_return_sequence_p) {
 }
 
 TEST(RecurrentRealizer, recurrent_return_sequence_single_p) {
-
+  using C = Connection;
   RecurrentRealizer r({"unroll_for=3", "as_sequence=fc_out",
                        "recurrent_input=lstm", "recurrent_output=fc_out"},
-                      {"source"}, {"fc_out"});
+                      {C("source")}, {C("fc_out")});
 
   std::vector<LayerRepresentation> before = {
     {"lstm", {"name=lstm", "input_layers=source"}},
@@ -114,13 +115,14 @@ TEST(RecurrentRealizer, recurrent_return_sequence_single_p) {
 }
 
 TEST(RecurrentRealizer, recurrent_multi_inout_p) {
+  using C = Connection;
   RecurrentRealizer r(
     {
       "unroll_for=3",
       "recurrent_input=lstm,source3_dummy",
       "recurrent_output=fc_out,output_dummy",
     },
-    {"source", "source2", "source3"}, {"fc_out"});
+    {C("source"), C("source2"), C("source3")}, {C("fc_out")});
 
   /// @note for below graph,
   /// 1. fc_out feds back to lstm
@@ -196,6 +198,7 @@ TEST(RecurrentRealizer, recurrent_multi_inout_p) {
 }
 
 TEST(RecurrentRealizer, recurrent_multi_inout_return_seq_p) {
+  using C = Connection;
   RecurrentRealizer r(
     {
       "unroll_for=3",
@@ -203,7 +206,7 @@ TEST(RecurrentRealizer, recurrent_multi_inout_return_seq_p) {
       "as_sequence=fc_out",
       "recurrent_output=fc_out,output_dummy",
     },
-    {"source", "source2", "source3"}, {"fc_out"});
+    {C("source"), C("source2"), C("source3")}, {C("fc_out")});
 
   /// @note for below graph,
   /// 1. fc_out feds back to lstm
@@ -282,7 +285,7 @@ TEST(RecurrentRealizer, recurrent_multi_inout_return_seq_p) {
 }
 
 TEST(RecurrentRealizer, recurrent_multi_inout_using_connection_return_seq_p) {
-
+  using C = Connection;
   RecurrentRealizer r(
     {
       "unroll_for=3",
@@ -290,7 +293,7 @@ TEST(RecurrentRealizer, recurrent_multi_inout_using_connection_return_seq_p) {
       "recurrent_input=lstm,add(2)",
       "recurrent_output=fc_out,split(1)",
     },
-    {"source", "source2", "source3"}, {"fc_out"});
+    {C("source"), C("source2"), C("source3")}, {C("fc_out")});
 
   /// @note for below graph,
   /// 1. fc_out feds back to lstm
@@ -341,13 +344,14 @@ TEST(RecurrentRealizer, recurrent_multi_inout_using_connection_return_seq_p) {
 }
 
 TEST(RecurrentRealizer, recurrent_multi_inout_using_connection_p) {
+  using C = Connection;
   RecurrentRealizer r(
     {
       "unroll_for=3",
       "recurrent_input=lstm,add(2)",
       "recurrent_output=fc_out,split(1)",
     },
-    {"source", "source2", "source3"}, {"fc_out"});
+    {C("source"), C("source2"), C("source3")}, {C("fc_out")});
 
   /// @note for below graph,
   /// 1. fc_out feds back to lstm


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Realizer] Change slice realizer to get connection</summary><br />

This patch change slice realizer to get connection

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Realizer] Change input connection semantics</summary><br />

Input connection semantic changed to be more intuitive by mapping
connection one to one

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[RecurrentRealizer] Modify to have connection</summary><br />

This patch modifies recurrent realizer to have connetion

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

