### PR TITLE
[Recurrent] Support connection for as_sequence

### DIFF
--- a/nntrainer/compiler/recurrent_realizer.h
+++ b/nntrainer/compiler/recurrent_realizer.h
@@ -20,6 +20,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <connection.h>
@@ -91,7 +92,9 @@ private:
                std::vector<props::AsSequence>, props::UnrollFor>;
 
   std::unordered_set<std::string> input_layers; /**< external input layers */
-  std::vector<Connection> end_conns;            /**< final output layers id */
+  std::vector<std::pair<std::string /**< connection name*/,
+                        unsigned /**< max idx requested */>>
+    end_info; /**< final end layers id */
   std::unordered_set<Connection>
     sequenced_return_conns; /**< sequenced return conns, subset of end_conns
                              */

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -1088,8 +1088,9 @@ TEST(nntrainerModels, loadFromLayersRecurrent_p) {
                             });
 
   std::vector<std::string> expected_node_names = {
-    "recurrent/fc1/0", "recurrent/fc2/0", "recurrent/fc1/1", "recurrent/fc2/1",
-    "recurrent/fc1/2", "recurrent/fc2/2", "recurrent/fc2"};
+    "recurrent/fc1/0",        "recurrent/fc2/0", "recurrent/fc1/1",
+    "recurrent/fc2/1",        "recurrent/fc1/2", "recurrent/fc2/2",
+    "recurrent/fc2/concat_0", "recurrent/fc2"};
   std::vector<std::string> expected_input_layers = {
     "out_source" /**< input added with external_input */,
     "recurrent/fc1/0",
@@ -1098,10 +1099,13 @@ TEST(nntrainerModels, loadFromLayersRecurrent_p) {
     "recurrent/fc2/1",
     "recurrent/fc1/2",
     "recurrent/fc2/0" /**< out source's first input */,
+    "recurrent/fc2/concat_0", /**< identity's input */
   };
 
   auto graph = nn.getFlatGraph();
   for (unsigned int i = 0; i < graph.size(); ++i) {
+    /// comment below intended
+    // std::cout << *graph.at(i);
     EXPECT_EQ(graph.at(i)->getName(), expected_node_names.at(i)) << "at " << i;
     EXPECT_EQ(graph.at(i)->getInputConnectionName(0),
               expected_input_layers.at(i))


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Recurrent] Support connection for as_sequence</summary><br />

This patch enables recurrent realizer to consume support connection
residing in as_sequence parameter

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

