### PR TITLE
[optimizer] no request vars for non-trainable weights

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -1015,4 +1015,18 @@ std::vector<Tensor> NetworkGraph::getOutputTensors() const {
   return output_tensors;
 }
 
+void NetworkGraph::requestOptimizerVariable(
+  std::function<std::vector<TensorDim>(const TensorDim &)> cb,
+  bool request_only_trainable) {
+  for (auto const &w : tensor_manager->getWeights()) {
+    if (!w->isDependent() && w->hasGradient()) {
+      const TensorDim &dim = w->getDim();
+      std::vector<TensorDim> dims = cb(dim);
+      w->setOptimizerVariables(tensor_manager->requestWeightOptimizerVariables(
+        dims, w->getName(), TensorLifespan::MAX_LIFESPAN,
+        Tensor::Initializer::ZEROS));
+    }
+  }
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -309,18 +309,7 @@ public:
    */
   void requestOptimizerVariable(
     std::function<std::vector<TensorDim>(const TensorDim &)> cb,
-    bool request_only_trainable = true) {
-    for (auto const &w : tensor_manager->getWeights()) {
-      if (!w->isDependent()) {
-        const TensorDim &dim = w->getDim();
-        std::vector<TensorDim> dims = cb(dim);
-        w->setOptimizerVariables(
-          tensor_manager->requestWeightOptimizerVariables(
-            dims, w->getName(), TensorLifespan::MAX_LIFESPAN,
-            Tensor::Initializer::ZEROS));
-      }
-    }
-  }
+    bool request_only_trainable = true);
 
   /**
    * @brief Feed inputs and labels to the graph


### PR DESCRIPTION
optimizer is requesting variables for non-trainable weights, but it
should not.
This patch provides the corresponding fix.

Resolves #1806

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>