### PR TITLE
[Graph] set trainable only if trainable

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -223,7 +223,9 @@ void NetworkGraph::markNodesForBackwarding() {
     if (lnode->getTrainable() ||
         must_support_backwarding.find(lnode->getName()) !=
           must_support_backwarding.end()) {
-      lnode->needsCalcGradient(true);
+      if (lnode->getTrainable()) {
+        lnode->needsCalcGradient(true);
+      }
 #ifdef ENABLE_TEST
       if (lnode->supportBackwarding() && !optimize_memory) {
         lnode->needsCalcDerivative(true);


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Graph] set trainable only if trainable</summary><br />

This patch fixes bug that needsCalcGradient is set true when it
shouldn't be

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

