### PR TITLE
[Recurrent] Add input seqeuncing mechanism

### DIFF
--- a/nntrainer/compiler/recurrent_realizer.h
+++ b/nntrainer/compiler/recurrent_realizer.h
@@ -29,6 +29,7 @@ namespace nntrainer {
 namespace props {
 class UnrollFor;
 class AsSequence;
+class InputIsSequence;
 class OutputLayer;
 class RecurrentInput;
 class RecurrentOutput;
@@ -86,12 +87,15 @@ public:
   GraphRepresentation realize(const GraphRepresentation &reference) override;
 
 private:
-  using PropTypes =
-    std::tuple<std::vector<props::RecurrentInput>,
-               std::vector<props::RecurrentOutput>,
-               std::vector<props::AsSequence>, props::UnrollFor>;
+  using PropTypes = std::tuple<std::vector<props::RecurrentInput>,
+                               std::vector<props::RecurrentOutput>,
+                               std::vector<props::AsSequence>, props::UnrollFor,
+                               std::vector<props::InputIsSequence>>;
 
   std::unordered_set<std::string> input_layers; /**< external input layers */
+  std::unordered_set<std::string>
+    sequenced_input; /**< external input layers which should be prefixed to /0 ~
+                        $(unroll_for)-1 */
   std::vector<std::pair<std::string /**< connection name*/,
                         unsigned /**< max idx requested */>>
     end_info; /**< final end layers id */

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -1021,7 +1021,7 @@ void NetworkGraph::requestOptimizerVariable(
   std::function<std::vector<TensorDim>(const TensorDim &)> cb,
   bool request_only_trainable) {
   for (auto const &w : tensor_manager->getWeights()) {
-    if (!w->isDependent() && w->hasGradient()) {
+    if (w->isGradientLastAccess() && w->hasGradient()) {
       const TensorDim &dim = w->getDim();
       std::vector<TensorDim> dims = cb(dim);
       w->setOptimizerVariables(tensor_manager->requestWeightOptimizerVariables(

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -585,6 +585,17 @@ public:
 };
 
 /**
+ * @brief Identifiers to locate an **input** connection which should be
+ * sequenced for the connection
+ *
+ */
+class InputIsSequence : public Name {
+public:
+  static constexpr const char *key = "input_is_sequence";
+  using prop_tag = str_prop_tag;
+};
+
+/**
  * @brief ResetAfter property, apply reset gate after matrix multiplication if
  * this property is true. Apply before the multiplication if false. Used in gru,
  * grucell.


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Recurrent] Add input seqeuncing mechanism</summary><br />

As some kind of recurrent model requires input layer it self to be
changed along the sequence, this patch proposes a simple mechanism to
add time stamp suffix for the input layers as well

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

