### PR TITLE
[ Network Graph ] Temporal Fix in getInputGrad

### DIFF
--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -274,9 +274,18 @@ const Tensor &RunLayerContext::getInput(unsigned int idx) const {
  * @return Tensor& Reference to the input grad tensor
  */
 Tensor &RunLayerContext::getInputGrad(unsigned int idx) {
-  if (!inputs[idx]->hasGradient())
-    throw std::invalid_argument(
-      "Requesting gradient for a non-trainable tensor.");
+  if (!inputs[idx]->hasGradient()) {
+    //
+    // TODO: This is temporal fixes. We need to find way to handle
+    //       the getInputGrad for multiple inputs ( input 1: Input Layer,
+    //       input 2: Normal Input ). In this situation, if we enable
+    //       inPlaceOptimization, it will fail.
+    //
+    // throw std::invalid_argument(
+    //   "Requesting gradient for a non-trainable tensor.");
+    //
+    return Tensor(inputs[idx]->getDim());
+  }
   return inputs[idx]->getGradientRef();
 }
 


### PR DESCRIPTION
When we turn on the inPlaceOptimization, it will fail if we have
mulitiple inputs: input layer ( can be inplace operatation ), normal
layers. Then, we are not allocate the grad between input layer and
this layer and it cause the error during calcDeriviate which requires
the grad tensor of input layer.

This patch fix this temporally by creating tensor buffer it reqruies.

and it includes modification of mem_check script to generate proper
output.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>