### PR TITLE
[Android] Delegate option control to android.mk

### DIFF
--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -60,7 +60,7 @@ LOCAL_C_INCLUDES    := @MESON_NNTRAINER_INCS@ @MESON_ML_API_COMMON_ROOT@/include
 LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ -Ofast
+LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@
 LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions
 LOCAL_MODULE_TAGS   := optional
 

--- a/jni/meson.build
+++ b/jni/meson.build
@@ -1,6 +1,16 @@
 and_conf = configuration_data()
 
-and_conf.set('MESON_CFLAGS', ' '.join(extra_defines))
+flags = []
+if get_option('debug')
+    flags += '-g'
+endif
+
+flags += '-O@0@'.format(get_option('optimization'))
+message('compile flags are:' + ' '.join(flags))
+
+flags = extra_defines + flags
+
+and_conf.set('MESON_CFLAGS', ' '.join(flags))
 and_conf.set('MESON_NNTRAINER_SRCS', ' '.join(nntrainer_sources))
 and_conf.set('MESON_NNTRAINER_INCS', ' '.join(nntrainer_inc_abs))
 and_conf.set('MESON_CCAPI_NNTRAINER_SRCS', ' '.join(ccapi_src))


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Android] Delegate option control to android.mk</summary><br />

This patch delegates option control in android mk to meson for debug and
optimized build

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

