### PR TITLE
[compat] remove contrib from tf headers @open sesame 01/18 18:09

### DIFF
--- a/Applications/KNN/jni/main_sample.cpp
+++ b/Applications/KNN/jni/main_sample.cpp
@@ -17,10 +17,10 @@
  */
 #include "bitmap_helpers.h"
 #include "math.h"
-#include "tensorflow/contrib/lite/interpreter.h"
-#include "tensorflow/contrib/lite/kernels/register.h"
-#include "tensorflow/contrib/lite/model.h"
-#include "tensorflow/contrib/lite/tools/gen_op_registration.h"
+#include "tensorflow/lite/interpreter.h"
+#include "tensorflow/lite/kernels/register.h"
+#include "tensorflow/lite/model.h"
+#include "tensorflow/lite/tools/gen_op_registration.h"
 #include <fstream>
 #include <iostream>
 #include <stdio.h>

--- a/Applications/TransferLearning/CIFAR_Classification/jni/main.cpp
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/main.cpp
@@ -25,11 +25,11 @@
  */
 
 #include "bitmap_helpers.h"
-#include "tensorflow/contrib/lite/interpreter.h"
-#include "tensorflow/contrib/lite/kernels/register.h"
-#include "tensorflow/contrib/lite/model.h"
-#include "tensorflow/contrib/lite/string_util.h"
-#include "tensorflow/contrib/lite/tools/gen_op_registration.h"
+#include "tensorflow/lite/interpreter.h"
+#include "tensorflow/lite/kernels/register.h"
+#include "tensorflow/lite/model.h"
+#include "tensorflow/lite/string_util.h"
+#include "tensorflow/lite/tools/gen_op_registration.h"
 #include <cmath>
 #include <fstream>
 #include <iomanip>

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -275,17 +275,10 @@ const Tensor &RunLayerContext::getInput(unsigned int idx) const {
  */
 Tensor &RunLayerContext::getInputGrad(unsigned int idx) {
   if (!inputs[idx]->hasGradient()) {
-    //
-    // TODO: This is temporal fixes. We need to find way to handle
-    //       the getInputGrad for multiple inputs ( input 1: Input Layer,
-    //       input 2: Normal Input ). In this situation, if we enable
-    //       inPlaceOptimization, it will fail.
-    //
-    // throw std::invalid_argument(
-    //   "Requesting gradient for a non-trainable tensor.");
-    //
-    return Tensor(inputs[idx]->getDim());
+    throw std::invalid_argument(
+      "Requesting gradient for a non-trainable tensor.");
   }
+
   return inputs[idx]->getGradientRef();
 }
 

--- a/nntrainer/layers/tflite_layer.h
+++ b/nntrainer/layers/tflite_layer.h
@@ -18,9 +18,9 @@
 #include <layer_devel.h>
 #include <vector>
 
-#include <tensorflow/contrib/lite/interpreter.h>
-#include <tensorflow/contrib/lite/kernels/register.h>
-#include <tensorflow/contrib/lite/model.h>
+#include <tensorflow/lite/interpreter.h>
+#include <tensorflow/lite/kernels/register.h>
+#include <tensorflow/lite/model.h>
 
 namespace ml::train {
 class TensorDim;

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -26,9 +26,9 @@
 #ifdef ENABLE_TFLITE_INTERPRETER
 #include <tflite_interpreter.h>
 
-#include <tensorflow/contrib/lite/interpreter.h>
-#include <tensorflow/contrib/lite/kernels/register.h>
-#include <tensorflow/contrib/lite/model.h>
+#include <tensorflow/lite/interpreter.h>
+#include <tensorflow/lite/kernels/register.h>
+#include <tensorflow/lite/model.h>
 #endif
 
 #include <app_context.h>


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[manager] Separate backwarding -> grad, deriv</summary><br />

This patch separate backwaring to grad and deriv for the requestTensors

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[compat] remove contrib from tf headers</summary><br />

This patch remove contrib path from tflite headers as contrib headers is
being removed.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

