### PR TITLE
[Tensor Pool] Add expose/persist concept

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -799,8 +799,7 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
   lnode->configureRunContext(
     // TODO: update weights spec for trainable based on layer trainable prop
     tensor_manager->requestWeights(gnode, init_context.getWeightsSpec(),
-                                   lnode->getTrainable(), shared_weight_names,
-                                   graph_exec_end),
+                                   lnode->getTrainable(), shared_weight_names),
     inputs, outputs,
     tensor_manager->requestTensors(gnode, init_context.getTensorsSpec(),
                                    shared_tensor_names));

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -44,7 +44,9 @@ public:
     graph(),
     compiled(false),
     batch_size(0),
-    max_exec_order(0),
+    graph_exec_end(0),
+    backward_iter_end(nullptr),
+    forward_iter_end(nullptr),
     optimize_memory(true),
     exec_mode(ExecutionMode::TRAIN) {}
 
@@ -344,7 +346,14 @@ private:
   GraphCore graph;             /** core graph object */
   bool compiled;               /**< if the model graph is compiled */
   unsigned int batch_size;     /**< current batch_size */
-  unsigned int max_exec_order; /**< maximum execution order */
+  unsigned int graph_exec_end; /**< Inclusive, last execution order of the
+                                  given graph */
+  LayerNode
+    *backward_iter_end;        /**< inclusive end node of the valid backward
+                                  execution when initialized, nodes after this node
+                                  does not required backwarding thus making it noop */
+  LayerNode *forward_iter_end; /**< inclusive end node of the forward execution
+                                  when initialize */
 
   /// @note *_list and *_dims must be synced at all times. Consider put it as a
   /// structure
@@ -464,11 +473,13 @@ private:
   InPlace canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode);
 
   /**
-   * @brief Set the Max Execution Order
+   * @brief compute optimized backward end. This function calculated the valid
+   * end of the graph backward, if memory_optimize is set, this returns begining
+   * of the backward.
    *
-   * @param skip_optimize Skip trying to optimize the max exec order
+   * @return end of the backward iter;
    */
-  void setMaxExecutionOrder(bool skip_optimize = false);
+  LayerNode *computeBackwardEnd();
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -154,7 +154,7 @@ static Tensor *requestTensor_(const TensorSpecV2 &spec,
 
   auto [forward, calc_grad, calc_deriv] = exec_order;
 
-  std::vector<unsigned> order;
+  std::vector<unsigned> order = spec.additional_exec_order;
 
   const auto name = scope + ":" + spec.name;
 
@@ -190,7 +190,8 @@ static Tensor *requestTensor_(const TensorSpecV2 &spec,
 Var_Grad *Manager::requestTensor(const VarGradSpecV2 &spec,
                                  TensorGroupType identify_as,
                                  const GraphNode::ExecutionOrder &exec_order,
-                                 const std::string &scope) {
+                                 const std::string &scope, bool expose_var,
+                                 bool expose_grad) {
   NNTR_THROW_IF(identify_as == TensorGroupType::WEIGHT, std::invalid_argument)
     << "requestTensor with var grad spec cannot be identified as weights, use "
        "requestTensor with weight spec instead";
@@ -217,11 +218,13 @@ Var_Grad *Manager::requestTensor(const VarGradSpecV2 &spec,
 
 std::vector<Var_Grad *> Manager::requestTensors(
   const std::vector<VarGradSpecV2> &specs, TensorGroupType identify_as,
-  const GraphNode::ExecutionOrder &exec_order, const std::string &scope) {
+  const GraphNode::ExecutionOrder &exec_order, const std::string &scope,
+  bool expose_var, bool expose_grad) {
   std::vector<Var_Grad *> ret;
   ret.reserve(specs.size());
   for (auto &spec : specs) {
-    ret.push_back(requestTensor(spec, identify_as, exec_order, scope));
+    ret.push_back(requestTensor(spec, identify_as, exec_order, scope,
+                                expose_var, expose_grad));
   }
 
   return ret;

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -172,15 +172,13 @@ public:
    * @param trainable make the weight trainable if true
    * @param shared_names name to refer to when the weights are borrowed from the
    * original source. if not shared pass empty vector
-   * @param max_exec_order the maximum execution order
    *
    * @return created weights list
    */
   std::vector<Weight *>
   requestWeights(const GraphNode &node,
                  const std::vector<Weight::Spec> &weights_spec, bool trainable,
-                 const std::vector<std::string> &shared_names,
-                 const unsigned int max_exec_order);
+                 const std::vector<std::string> &shared_names);
 
   /**
    * @brief     Create tensors with the given spec

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -407,12 +407,17 @@ public:
    * @param identify_as identify as tensor as a group
    * @param exec_order execution order to refer to
    * @param scope common scope to attach in front of current specification name
+   * @param expose_var expose variable tensor out of graph, when allocation,
+   * this tensor will be valid max_exec_order when allocation happens
+   * @param expose_grad expose variable tensor out of graph, this tensor will be
+   * valid max_exec_order when allocation happens
    * @return Tensor* tensor
    */
   Var_Grad *requestTensor(const VarGradSpecV2 &spec,
                           TensorGroupType identify_as,
                           const GraphNode::ExecutionOrder &exec_order,
-                          const std::string &scope = "");
+                          const std::string &scope = "",
+                          bool expose_var = false, bool expose_grad = false);
 
   /**
    * @brief request vector of tensors with variable + gradient specification
@@ -421,11 +426,17 @@ public:
    * @param identify_as identify as tensor as a group
    * @param exec_order execution order to refer to
    * @param scope common scope to attach in front of current specification name
+   * @param expose_var expose variable tensor out of graph, when
+   * allocation, this tensor will be valid max_exec_order when allocation
+   * happens
+   * @param expose_grad expose variable tensor out of graph, this tensor will be
+   * valid max_exec_order when allocation happens
    * @return Tensor* tensor
    */
   std::vector<Var_Grad *> requestTensors(
     const std::vector<VarGradSpecV2> &specs, TensorGroupType identify_as,
-    const GraphNode::ExecutionOrder &exec_order, const std::string &scope = "");
+    const GraphNode::ExecutionOrder &exec_order, const std::string &scope = "",
+    bool expose_var = false, bool expose_grad = false);
 
 private:
   /** @todo: merge this list to one */

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -126,8 +126,14 @@ void TensorPool::finalize(const MemoryPlanner &planner,
 
     unsigned int validity_end = validity_start;
     for (unsigned int idx = 0; idx < details->exec_order.size(); idx++) {
-      if (details->exec_order[idx] <= end_order)
+      if (details->exec_order[idx] == PERSIST_END_ORDER) {
+        validity_end = end_order;
+        break;
+      }
+
+      if (details->exec_order[idx] <= end_order) {
         validity_end = std::max(validity_end, details->exec_order[idx]);
+      }
     }
 
     /**

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -17,6 +17,7 @@
 #ifdef __cplusplus
 
 #include <functional>
+#include <limits>
 #include <memory>
 #include <unordered_map>
 #include <variant>
@@ -35,6 +36,8 @@ namespace nntrainer {
 class TensorPool {
 
 public:
+  static constexpr unsigned PERSIST_END_ORDER =
+    std::numeric_limits<unsigned>::max();
   /**
    * @brief     Constructor of TensorPool
    */

--- a/nntrainer/tensor/tensor_wrap_specs.h
+++ b/nntrainer/tensor/tensor_wrap_specs.h
@@ -125,6 +125,10 @@ struct TensorSpecV2 {
   /** ONLY USED FOR READ_ONLY_VIEW, MAYBE_MODIFYING_VIEW */
   unsigned int offset = 0u;   /**< tensor offset */
   std::string reference_name; /**< reference name */
+
+  /** ONLY FOR THE GRANULAR CONTROL OF LIFE OUTSIDE OF LAYER NODE */
+  /// @todo make this as an opaque information with PIMPL
+  std::vector<unsigned> additional_exec_order = {};
 };
 
 /**


### PR DESCRIPTION
## Dependency of the PR


## Commits to be reviewed in this PR


<details><summary>[Network Graph] Split max_exec_order</summary><br />

This patch split max_exec_order to three part.

1. graph_exec_end: graph execution end
2. backward_iter_end: end node of backward operation
3. forward_iter_end: end node of the forward operation

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[ExecOrder] Add exec order control and fix inference</summary><br />

This patch add exec order control and reduce memory overhead of saving
inference result

exec order cotrol has two part

1. Additional exec order. This enable graph to add some exec order.
2. Expose bit. This enables request to be visible after the end of the
execution.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>



<details><summary>[Tensor Pool] Add expose/persist concept</summary><br />

This patch add expose/persist concept to the tensor pool and manager.

When a tensor is exposed, this means that the tensor is gauranteed to
remain valid max_exec where max_exec is the value passed along allocateTensors(max_exec);

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

</details>

resolves #1832