### PR TITLE
Weight decay fix

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -299,6 +299,7 @@ void NeuralNetwork::backwarding(int iteration) {
       model_graph.applyGradients(
         node.get(), [iteration, opt_ = opt.get()](Weight &w) {
           w.calcRegularizationGradient();
+          w.calcWeightDecayGradient();
           RunOptimizerContext opt_context(&w, iteration);
           opt_->applyGradient(opt_context);
         });

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -308,6 +308,8 @@ void NeuralNetwork::backwarding(int iteration) {
 
   std::function<void(Weight &, int)> apply_grad_clip_op =
     [opt_ = opt.get()](Weight &w, int iteration) -> void {
+    w.calcRegularizationGradient();
+    w.calcWeightDecayGradient();
     RunOptimizerContext opt_context(&w, iteration);
     opt_->applyGradient(opt_context);
   };

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -234,7 +234,7 @@ public:
   }
 
   /**
-   * @brief     Calculate gradient from the regularizaiton of the weight
+   * @brief     Calculate gradient from the regularization of the weight
    */
   void calcRegularizationGradient() {
     if (isWeightRegularizerL2Norm())
@@ -242,14 +242,17 @@ public:
   }
 
   /**
-   * @brief     Apply the gradient to the weight
+   * @brief     Calculate gradient from the decay of the weight
    */
-  void applyGradient(double lr) {
+  void calcWeightDecayGradient() {
     if (isWeightDecay())
       applyWeightDecay();
-
-    var->add_i(*grad.get(), -lr);
   }
+
+  /**
+   * @brief     Apply the gradient to the weight
+   */
+  void applyGradient(double lr) { var->add_i(*grad.get(), -lr); }
 
   /**
    * @brief Check if the gradient is supposed to be clipped by global norm with


### PR DESCRIPTION
- weight decay should be applied before calling the optimizer
this was not detected earlier as it was tested with sgd
- Enable weighte regularization and decay with weiht clipping.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>