### PR TITLE
[ BUILD ] add lr_scheduler.h in include dir

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -20,6 +20,7 @@
 /usr/include/nntrainer/optimizer_context.h
 /usr/include/nntrainer/optimizer_devel.h
 /usr/include/nntrainer/optimizer_impl.h
+/usr/include/nntrainer/lr_scheduler.h
 # pkg config and static binary
 /usr/lib/*/pkgconfig/nntrainer.pc
 /usr/lib/*/libnntrainer.a

--- a/nntrainer/optimizers/meson.build
+++ b/nntrainer/optimizers/meson.build
@@ -12,6 +12,7 @@ optimizer_headers = [
   'optimizer_devel.h',
   'optimizer_impl.h',
   'optimizer_context.h',
+  'lr_scheduler.h'
 ]
 
 foreach s : optimizer_sources

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -487,6 +487,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/optimizer_context.h
 %{_includedir}/nntrainer/optimizer_devel.h
 %{_includedir}/nntrainer/optimizer_impl.h
+%{_includedir}/nntrainer/lr_scheduler.h
 %{_libdir}/pkgconfig/nntrainer.pc
 # update this to enable external applications
 # @todo filter out headers that should be hidden, and classifiy in the appropriate place if not


### PR DESCRIPTION
For the dependency of apt_context.h, we need to install lr_scheduler.h
in install include directory.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>