### PR TITLE
Load Optimizer Variables @open sesame 3/8 11:35

### DIFF
--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -415,7 +415,7 @@ void LayerNode::exportTo(Exporter &exporter,
   layer->exportTo(exporter, method);
 }
 
-void LayerNode::read(std::ifstream &file, bool opt_var) {
+void LayerNode::read(std::ifstream &file, bool opt_var, bool load_opt_var) {
   NNTR_THROW_IF(!run_context, std::runtime_error)
     << __func__ << " layer needs to be finalized first!";
   if (opt_var) {
@@ -425,7 +425,12 @@ void LayerNode::read(std::ifstream &file, bool opt_var) {
         if (run_context->weightHasGradient(i)) {
           for (unsigned int j = 0; j < run_context->getNumWeightOptVar(i);
                ++j) {
-            run_context->getWeightOptVar(i, j).read(file);
+            if (load_opt_var) {
+              run_context->getWeightOptVar(i, j).read(file);
+            } else {
+              file.seekg(run_context->getWeightOptVar(i, j).bytes(),
+                         std::ios::cur);
+            }
           }
         }
       }

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -573,8 +573,10 @@ public:
    * @brief     read layer Weight & Bias data from file
    * @param file input file stream
    * @param bool read optimizer variables
+   * @param bool load optimizer variables
    */
-  void read(std::ifstream &file, bool opt_var = false);
+  void read(std::ifstream &file, bool opt_var = false,
+            bool load_opt_var = true);
 
   /**
    * @brief     save layer Weight & Bias data from file

--- a/nntrainer/optimizers/adam.cpp
+++ b/nntrainer/optimizers/adam.cpp
@@ -22,14 +22,16 @@
 
 namespace nntrainer {
 
-Adam::Adam() : adam_props(PropsB1(), PropsB2(), PropsEpsilon(), TorchRef()) {
+Adam::Adam() :
+  adam_props(PropsB1(), PropsB2(), PropsEpsilon(), TorchRef(), LoadVar()) {
   /** default properties */
   setProperty({"learning_rate=0.001"});
-  auto &[b1, b2, eps, torch_ref] = adam_props;
+  auto &[b1, b2, eps, torch_ref, load_mv] = adam_props;
   b1.set(0.9f);
   b2.set(0.999f);
   eps.set(1.0e-7f);
   torch_ref.set(false);
+  load_mv.set(true);
 }
 
 Adam::~Adam() {}
@@ -75,8 +77,8 @@ void Adam::applyGradient(RunOptimizerContext &context) {
   // This is implementation of adam from original paper.
   // This is not deleted intentionally.
   unsigned int iteration = context.getIteration();
-  float biasCorrection1 = 1 - pow(beta1, iteration + 1);
-  float biasCorrection2 = 1 - pow(beta2, iteration + 1);
+  float biasCorrection1 = 1.0f - pow(beta1, iteration + 1);
+  float biasCorrection2 = 1.0f - pow(beta2, iteration + 1);
   Tensor &wm = context.getOptimizerVariable(AdamParams::wm);
   Tensor &wv = context.getOptimizerVariable(AdamParams::wv);
 
@@ -88,7 +90,7 @@ void Adam::applyGradient(RunOptimizerContext &context) {
 
   if (torch_ref) {
     Tensor denom = wv.apply(sqrtFloat);
-    denom.divide_i(sqrtFloat(biasCorrection2));
+    denom.divide_i(sqrtDouble(biasCorrection2));
     denom.add_i(epsilon);
     wm.divide(denom, x_grad);
 

--- a/nntrainer/optimizers/adam.h
+++ b/nntrainer/optimizers/adam.h
@@ -63,6 +63,16 @@ public:
 };
 
 /**
+ * @brief load momentum
+ *
+ */
+class LoadVar : public Property<bool> {
+public:
+  static constexpr const char *key = "load_var"; /**< unique key to access */
+  using prop_tag = bool_prop_tag;                /**< property type */
+};
+
+/**
  * @class   Adam optimizer class
  * @brief   Adam optimizer
  */
@@ -113,8 +123,13 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
+  /**
+   * @copydoc Optimizer::is_load_var()
+   */
+  bool is_load_var() { return std::get<LoadVar>(adam_props).get(); }
+
 private:
-  std::tuple<PropsB1, PropsB2, PropsEpsilon, TorchRef> adam_props;
+  std::tuple<PropsB1, PropsB2, PropsEpsilon, TorchRef, LoadVar> adam_props;
 };
 } /* namespace nntrainer */
 

--- a/nntrainer/optimizers/optimizer_devel.cpp
+++ b/nntrainer/optimizers/optimizer_devel.cpp
@@ -30,7 +30,19 @@ void Optimizer::setProperty(const std::vector<std::string> &values) {
 }
 
 void Optimizer::read(std::ifstream &file) {
-  std::string loaded_type = readString(file);
+  std::string loaded_type;
+  unsigned int opt_type = ml::train::OptimizerType::UNKNOWN;
+  checkedRead(file, (char *)&opt_type, sizeof(opt_type));
+  switch (opt_type) {
+  case ml::train::OptimizerType::ADAM:
+    loaded_type = "adam";
+    break;
+  case ml::train::OptimizerType::SGD:
+    loaded_type = "sgd";
+    break;
+  default:
+    break;
+  }
 
   if (loaded_type != getType()) {
     throw std::runtime_error(
@@ -38,6 +50,13 @@ void Optimizer::read(std::ifstream &file) {
   }
 }
 
-void Optimizer::save(std::ofstream &file) { writeString(file, getType()); }
+void Optimizer::save(std::ofstream &file) {
+  unsigned int opt_type = ml::train::OptimizerType::UNKNOWN;
+  if (istrequal(getType(), "adam"))
+    opt_type = ml::train::OptimizerType::ADAM;
+  if (istrequal(getType(), "sgd"))
+    opt_type = ml::train::OptimizerType::SGD;
+  file.write((char *)&opt_type, sizeof(opt_type));
+}
 
 } // namespace nntrainer

--- a/nntrainer/optimizers/optimizer_devel.h
+++ b/nntrainer/optimizers/optimizer_devel.h
@@ -89,6 +89,11 @@ public:
   virtual void save(std::ofstream &file);
 
   /**
+   * @brief     get the option of loading optimizer variables
+   */
+  virtual bool is_load_var() { return false; };
+
+  /**
    * @brief     Get dimension of extra variables if the optimizer needs any.
    * @param dim Dimension of tensor to be added as a optimizer variable
    * @return    Vector of dimensions


### PR DESCRIPTION
In this PR,
 1. new property of adam optimizer, "laod_var" is added to set loading
    momentum variables
 2. update the read and save binary file
    using  ml::train::OptimizerType
 3. update read in layer_node to skip the optimizer variables if
    load_var is set as "false"
 4. is_laod_var() is added in optimizer_devel

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>