### PR TITLE
Fix/1857: Fix portability issues.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,8 @@ warning_flags = [
   '-Wpointer-arith',
   '-Wno-error=varargs',
   '-Wdefaulted-function-deleted',
-  '-ftree-vectorize'
+  '-ftree-vectorize',
+  '-Wno-unused-variable'
 ]
 
 warning_c_flags = [

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -12,6 +12,7 @@
 
 #include <numeric>
 #include <vector>
+#include <limits>
 
 #include <memory_pool.h>
 #include <nntrainer_error.h>

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -30,6 +30,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include <stdexcept>
 
 #include <tensor_dim.h>
 

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -5,6 +5,7 @@ layer_common_test_dependent_files = files('layers_dependent_common_tests.cpp')
 nntrainer_layer_common_standalone_tests_lib = shared_library(
   'nntrainer_layer_common_standalone_tests',
   'layers_standalone_common_tests.cpp',
+  cpp_args : '-Wno-maybe-uninitialized',
   dependencies: [nntrainer_dep, gtest_dep], # nntrainer_devel_dep
   include_directories: layer_common_test_inc
 )
@@ -17,6 +18,7 @@ nntrainer_layer_common_standalone_tests_dep = declare_dependency(
 nntrainer_layer_common_dependent_tests_lib = shared_library(
   'nntrainer_layer_common_dependent_tests',
   'layers_dependent_common_tests.cpp',
+  cpp_args : '-Wno-maybe-uninitialized',
   dependencies: [nntrainer_dep, gtest_dep], # nntrainer_devel_dep
   include_directories: layer_common_test_inc
 )
@@ -80,6 +82,7 @@ exe = executable(
   dependencies: [
     nntrainer_test_main_deps,
   ],
+  cpp_args : '-Wno-maybe-uninitialized',
   install: get_option('enable-test'),
   install_dir: application_install_dir
 )

--- a/test/unittest/memory/meson.build
+++ b/test/unittest/memory/meson.build
@@ -3,6 +3,7 @@ memory_test_inc = include_directories('./')
 nntrainer_memory_planner_tests_lib = static_library(
   'nntrainer_memory_planner_validation',
   'memory_planner_validate.cpp',
+  cpp_args : '-Wno-maybe-uninitialized',
   dependencies: [nntrainer_dep, gtest_dep], # nntrainer_devel_dep
   include_directories: memory_test_inc
 )
@@ -24,6 +25,7 @@ exe = executable(
   dependencies: [
     nntrainer_test_main_deps
   ],
+  cpp_args : '-Wno-maybe-uninitialized',
   install: get_option('enable-test'),
   install_dir: application_install_dir
 )

--- a/test/unittest/memory/unittest_memory_pool.cpp
+++ b/test/unittest/memory/unittest_memory_pool.cpp
@@ -402,7 +402,7 @@ TEST(MemoryPool, get_memory_03_n) {
  */
 TEST(MemoryPool, get_memory_04_p) {
   nntrainer::MemoryPool pool;
-  void *mem;
+  void *mem = nullptr;
 
   auto idx = pool.requestMemory(1, 4, 5);
   EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));


### PR DESCRIPTION
This is a series of fixes for portability with gcc-7.5 and gcc-11 in Ubuntu.

Fixes #1857
---

commit 7114500876d436ce7a5f45ad509270500b9f5350 (HEAD -> fix/1857, origin/fix/1857)
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Wed Mar 16 16:56:56 2022 +0900

    Portability: unittest uninit vars.
    
    1. gtest code has maybe-uninitialized warnings. Suppress it.
    2. maybe-unitialized warning from unittest code fixed.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 8c2c4a831f58a672f3afa30b292dac355dca2e8d
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Wed Mar 16 16:39:44 2022 +0900

    Portability: g++-11 has different std policy.
    
    It requires stdexcept and limits for std::invalid_arguments and std::numeric_limits.
    
    Fixes #1857
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 4573106e9c22ab14315444c619f9022536367bb4
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Wed Mar 16 16:38:00 2022 +0900

    Portability: gcc structured binding declaration error
    
    gcc-7 does not comply with c++-17 fully with structured binding declaration.
    This allows maybe-unused globally as a workaround.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
