### PR TITLE
meson: dependency on ml-api should be optional @open sesame 03/31 17:58

### DIFF
--- a/Applications/MNIST/jni/main.cpp
+++ b/Applications/MNIST/jni/main.cpp
@@ -39,7 +39,6 @@
 #endif
 
 #include <dataset.h>
-#include <ml-api-common.h>
 #include <model.h>
 
 #ifdef PROFILE
@@ -193,7 +192,7 @@ int getSample(float **outVec, float **outLabel, bool *last, void *user_data) {
     std::shuffle(data->idxes.begin(), data->idxes.end(), data->rng);
   }
 
-  return ML_ERROR_NONE;
+  return 0;
 }
 
 #if defined(APP_VALIDATE)

--- a/Applications/ProductRatings/jni/main.cpp
+++ b/Applications/ProductRatings/jni/main.cpp
@@ -21,7 +21,6 @@
 #include <sstream>
 
 #include <dataset.h>
-#include <ml-api-common.h>
 #include <neuralnet.h>
 #include <tensor.h>
 
@@ -182,18 +181,18 @@ int main(int argc, char *argv[]) {
 
   try {
     auto status = NN.loadFromConfig(config);
-    if (status != ML_ERROR_NONE) {
+    if (status != 0) {
       std::cerr << "Error during loading" << std::endl;
       return 1;
     }
 
     status = NN.compile();
-    if (status != ML_ERROR_NONE) {
+    if (status != 0) {
       std::cerr << "Error during compile" << std::endl;
       return 1;
     }
     status = NN.initialize();
-    if (status != ML_ERROR_NONE) {
+    if (status != 0) {
       std::cerr << "Error during initialize" << std::endl;
       return 1;
     }

--- a/Applications/Resnet/jni/main.cpp
+++ b/Applications/Resnet/jni/main.cpp
@@ -238,12 +238,12 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
   model->setOptimizer(std::move(optimizer));
 
   int status = model->compile();
-  if (status != ML_ERROR_NONE) {
+  if (status) {
     throw std::invalid_argument("model compilation failed!");
   }
 
   status = model->initialize();
-  if (status != ML_ERROR_NONE) {
+  if (status) {
     throw std::invalid_argument("model initialization failed!");
   }
 

--- a/Applications/TransferLearning/CIFAR_Classification/jni/main_func.cpp
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/main_func.cpp
@@ -35,7 +35,6 @@
 #include <time.h>
 
 #include <dataset.h>
-#include <ml-api-common.h>
 #include <model.h>
 
 #include <bitmap_helpers.h>
@@ -190,7 +189,7 @@ int getBatch(float **outVec, float **outLabel, bool *last, bool is_val) {
       dupl[i] = false;
     }
     *last = true;
-    return ML_ERROR_NONE;
+    return 0;
   }
 
   count = 0;
@@ -209,7 +208,7 @@ int getBatch(float **outVec, float **outLabel, bool *last, bool is_val) {
   }
 
   *last = false;
-  return ML_ERROR_NONE;
+  return 0;
 }
 
 /**

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -4,14 +4,16 @@ run_command('mkdir', '-p', nntr_app_resdir)
 subdir('utils/jni')
 subdir('KNN/jni')
 subdir('LogisticRegression/jni')
-if get_option('enable-ccapi')
+if enable_ccapi
   subdir('MNIST/jni')
 endif
 subdir('VGG/jni')
 subdir('Resnet/jni')
 subdir('ReinforcementLearning/DeepQ/jni')
 subdir('TransferLearning/CIFAR_Classification/jni')
-subdir('TransferLearning/Draw_Classification/jni')
+if enable_capi
+  subdir('TransferLearning/Draw_Classification/jni')
+endif
 subdir('Custom')
 subdir('ProductRatings/jni')
 

--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -29,7 +29,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include <ml-api-common.h>
 #include <nnstreamer.h>
 #include <nntrainer-api-common.h>
 

--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -9,7 +9,7 @@ capi_inc_abs = [
 capi_src = []
 capi_src += meson.current_source_dir() / 'src' / 'nntrainer.cpp'
 
-if not nnstreamer_capi_dep.found() and get_option('platform') != 'android'
+if not nnstreamer_capi_dep.found() and get_option('platform') == 'tizen'
   error('nnstreamer capi dependency not found for tizen')
 endif
 

--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -23,7 +23,6 @@
 #include <string>
 #include <vector>
 
-#include <ml-api-common.h>
 #include <nntrainer-api-common.h>
 
 namespace ml {

--- a/api/ccapi/include/optimizer.h
+++ b/api/ccapi/include/optimizer.h
@@ -21,7 +21,6 @@
 #include <string>
 #include <vector>
 
-#include <ml-api-common.h>
 #include <nntrainer-api-common.h>
 
 namespace ml {

--- a/api/meson.build
+++ b/api/meson.build
@@ -1,10 +1,15 @@
 if get_option('enable-ccapi')
+  enable_ccapi = true
   subdir('ccapi')
 endif
 
-if get_option('enable-capi')
+if get_option('enable-capi').enabled()
   if not get_option('enable-ccapi')
     error('enable-ccapi must be set for capi as well')
   endif
+  enable_capi = true
+  subdir('capi')
+elif get_option('enable-capi').auto() and get_option('enable-ccapi') and nnstreamer_capi_dep.found()
+  enable_capi = true
   subdir('capi')
 endif

--- a/debian/rules
+++ b/debian/rules
@@ -38,6 +38,10 @@ override_dh_auto_configure:
 		-Dreduce-tolerance=$(ENABLE_REDUCE_TOLERANCE) \
 		-Denable-debug=$(ENABLE_DEBUG) \
 		-Dml-api-support=enabled -Denable-nnstreamer-tensor-filter=true \
+                -Denable-nnstreamer-backbone=true \
+                -Dcapi-ml-common-actual=capi-ml-common \
+                -Dcapi-ml-inference-actual=capi-ml-inference \
+                -Denable-capi=enabled \
 		build
 
 override_dh_auto_build:

--- a/debian/rules
+++ b/debian/rules
@@ -36,7 +36,9 @@ override_dh_auto_configure:
 		--libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nntrainer/bin \
 		--includedir=include -Dinstall-app=true \
 		-Dreduce-tolerance=$(ENABLE_REDUCE_TOLERANCE) \
-		-Denable-debug=$(ENABLE_DEBUG) build
+		-Denable-debug=$(ENABLE_DEBUG) \
+		-Dml-api-support=enabled -Denable-nnstreamer-tensor-filter=true \
+		build
 
 override_dh_auto_build:
 	ninja -C build

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -318,8 +318,8 @@ CAPI_NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 LOCAL_SHARED_LIBRARIES := ccapi-nntrainer ml-api-inference nntrainer
 
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions
+LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -DML_API_COMMON=1
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid -fopenmp

--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -60,8 +60,8 @@ LOCAL_C_INCLUDES    := @MESON_NNTRAINER_INCS@ @MESON_ML_API_COMMON_ROOT@/include
 LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions
+LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ -DML_API_COMMON=1
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
@@ -82,8 +82,8 @@ LOCAL_C_INCLUDES    := @MESON_CCAPI_NNTRAINER_INCS@ @MESON_ML_API_COMMON_ROOT@/i
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
 
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions
+LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ -DML_API_COMMON=1
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
@@ -100,8 +100,8 @@ LOCAL_C_INCLUDES    := @MESON_CAPI_NNTRAINER_INCS@
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
 
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions
+LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ -DML_API_COMMON=1
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp

--- a/meson.build
+++ b/meson.build
@@ -54,6 +54,7 @@ warning_c_flags = [
   '-Wno-error=varargs'
 ]
 
+
 foreach extra_arg : warning_flags
   if cc.has_argument (extra_arg)
     add_project_arguments([extra_arg], language: 'c')
@@ -106,10 +107,30 @@ nntrainer_conf.set('EXEC_PREFIX', nntrainer_bindir)
 nntrainer_conf.set('LIB_INSTALL_DIR', nntrainer_libdir)
 nntrainer_conf.set('PLUGIN_INSTALL_PREFIX', nntrainer_libdir / 'nntrainer')
 nntrainer_conf.set('INCLUDE_INSTALL_DIR', nntrainer_includedir / '..')
-nntrainer_conf.set('CAPI_ML_COMMON_DEP', get_option('capi-ml-common-actual'))
 
 dummy_dep = dependency('', required: false)
 found_dummy_dep = declare_dependency() # dummy dep to use if found
+
+# if ml-api-support is disabled, enable dummy common api interfaces and disable related dependencies.
+ml_api_common_dep = dependency(get_option('capi-ml-common-actual'), required : get_option('ml-api-support').enabled())
+nnstreamer_capi_dep = dummy_dep
+if (ml_api_common_dep.found())
+  nntrainer_conf.set('CAPI_ML_COMMON_DEP', get_option('capi-ml-common-actual'))
+  extra_defines += '-DML_API_COMMON=1'
+
+  nnstreamer_capi_dep = dependency(get_option('capi-ml-inference-actual'), required : true)
+  extra_defines += '-DNNSTREAMER_AVAILABLE=1'
+  # accessing this variable when dep_.not_found() remains hard error on purpose
+  supported_nnstreamer_capi = nnstreamer_capi_dep.version().version_compare('>=1.7.0')
+  if not supported_nnstreamer_capi
+    extra_defines += '-DUNSUPPORTED_NNSTREAMER=1'
+    warning('capi-nnstreamer version is too old, we do not know if it works with older nnstreamer version')
+  endif
+else
+  nntrainer_conf.set('CAPI_ML_COMMON_DEP', '')
+  extra_defines += '-DML_API_COMMON=0'
+endif
+
 
 blas_dep = dummy_dep
 # Dependencies
@@ -202,22 +223,7 @@ if not iniparser_dep.found()
   endif
 endif
 
-nnstreamer_capi_dep = dependency(get_option('capi-ml-inference-actual'), required:false)
-if nnstreamer_capi_dep.found()
-  extra_defines += '-DNNSTREAMER_AVAILABLE=1'
-  # accessing this variable when dep_.not_found() remains hard error on purpose
-  supported_nnstreamer_capi = nnstreamer_capi_dep.version().version_compare('>=1.7.0')
-  if not supported_nnstreamer_capi
-    extra_defines += '-DUNSUPPORTED_NNSTREAMER=1'
-    warning('capi-nnstreamer version is too old, we do not know if it works with older nnstreamer version')
-  endif
-endif
-
-ml_api_common_dep = dummy_dep
-
-if get_option('platform') != 'android'
-  ml_api_common_dep = dependency(get_option('capi-ml-common-actual'), required: true)
-else
+if get_option('platform') == 'android'
   message('preparing ml api')
   run_command(meson.source_root() / 'jni' / 'prepare_ml-api.sh', meson.build_root() / 'ml-api-inference', check: true)
   ml_api_common_root = meson.build_root() / 'ml-api-inference'
@@ -303,6 +309,8 @@ endforeach
 # Build nntrainer
 subdir('nntrainer')
 
+enable_capi = false
+enable_ccapi = false
 # Build api
 subdir('api')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,12 +2,12 @@ option('platform', type: 'combo', choices: ['none', 'tizen', 'yocto', 'android']
 option('enable-app', type: 'boolean', value: true)
 option('install-app', type: 'boolean', value: true)
 option('use_gym', type: 'boolean', value: false)
-option('enable-capi', type: 'boolean', value: true)
+option('enable-capi', type: 'feature', value: 'auto')
 option('enable-ccapi', type: 'boolean', value: true)
 option('enable-test', type: 'boolean', value: true)
 option('enable-logging', type: 'boolean', value: true)
 option('enable-tizen-feature-check', type: 'boolean', value: true)
-option('enable-nnstreamer-backbone', type: 'boolean', value: true)
+option('enable-nnstreamer-backbone', type: 'boolean', value: false)
 option('enable-tflite-backbone', type: 'boolean', value: true)
 option('enable-profile', type: 'boolean', value: false)
 option('enable-debug', type: 'boolean', value: false)
@@ -15,9 +15,9 @@ option('enable-tflite-interpreter', type: 'boolean', value: true)
 
 # dependency conflict resolution
 option('capi-ml-inference-actual', type: 'string', value: 'capi-ml-inference',
-        description: 'backward compatible dependency name of capi-ml-inference')
+        description: 'backward compatible dependency name of capi-ml-inference. ignored if ml-api-support is disabled.')
 option('capi-ml-common-actual', type: 'string', value: 'capi-ml-common',
-        description: 'backward compatible dependency name of capi-ml-common')
+        description: 'backward compatible dependency name of capi-ml-common. ignored if ml-api-support is disabled.')
 option('tizen-version-major', type: 'integer', min : 4, max : 9999, value: 9999) # 9999 means "not Tizen"
 option('tizen-version-minor', type: 'integer', min : 0, max : 9999, value: 0)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,8 +7,6 @@ option('enable-ccapi', type: 'boolean', value: true)
 option('enable-test', type: 'boolean', value: true)
 option('enable-logging', type: 'boolean', value: true)
 option('enable-tizen-feature-check', type: 'boolean', value: true)
-option('enable-nnstreamer-tensor-filter', type: 'boolean', value: true)
-option('nnstreamer-subplugin-install-path', type: 'string', value: '/usr/lib/nnstreamer') # where nnstreamer subplugin should be installed
 option('enable-nnstreamer-backbone', type: 'boolean', value: true)
 option('enable-tflite-backbone', type: 'boolean', value: true)
 option('enable-profile', type: 'boolean', value: false)
@@ -32,3 +30,10 @@ option('enable-blas', type: 'boolean', value: true)
 option('enable-cublas', type: 'boolean', value: false)
 option('enable-openmp', type: 'boolean', value: true)
 
+# ml-api dependency (to enable, install capi-inference from github.com/nnstreamer/api )
+# To inter-operate with nnstreamer and ML-API packages, you need to enable this.
+# If this is disabled, related options (capi-ml-*) are ignored.
+option('ml-api-support', type: 'feature', value: 'auto')
+# @todo : make them use 'feature' and depend on ml-api-support
+option('enable-nnstreamer-tensor-filter', type: 'boolean', value: false)
+option('nnstreamer-subplugin-install-path', type: 'string', value: '/usr/lib/nnstreamer') # where nnstreamer subplugin should be installed

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -39,7 +39,6 @@
 #include <dynamic_training_optimization.h>
 #include <execution_mode.h>
 #include <layer_node.h>
-#include <ml-api-common.h>
 #include <model_common_properties.h>
 #include <network_graph.h>
 #include <optimizer_devel.h>
@@ -47,6 +46,7 @@
 
 #include <model.h>
 #include <nntrainer-api-common.h>
+#include <nntrainer_error.h>
 
 namespace ml::train {
 class DataSet;

--- a/nntrainer/nntrainer_error.h
+++ b/nntrainer/nntrainer_error.h
@@ -13,7 +13,6 @@
 #ifndef __NNTRAINER_ERROR_H__
 #define __NNTRAINER_ERROR_H__
 
-#include <ml-api-common.h>
 #if defined(__TIZEN__)
 #include <tizen_error.h>
 #define ML_ERROR_BAD_ADDRESS TIZEN_ERROR_BAD_ADDRESS
@@ -35,6 +34,36 @@
 #define NNTR_THROW_IF_CLEANUP(pred, err, cleanup_func) \
   if ((pred))                                          \
     nntrainer::exception::ErrorNotification<err> { cleanup_func }
+
+#if ML_API_COMMON
+#include <ml-api-common.h>
+#else
+/**
+ @ref:
+ https://gitlab.freedesktop.org/dude/gst-plugins-base/commit/89095e7f91cfbfe625ec2522da49053f1f98baf8
+ */
+#if !defined(ESTRPIPE)
+#define ESTRPIPE EPIPE
+#endif /* !defined(ESTRPIPE) */
+
+#define _ERROR_UNKNOWN (-1073741824LL)
+#define TIZEN_ERROR_TIMED_OUT (TIZEN_ERROR_UNKNOWN + 1)
+#define TIZEN_ERROR_NOT_SUPPORTED (TIZEN_ERROR_UNKNOWN + 2)
+#define TIZEN_ERROR_PERMISSION_DENIED (-EACCES)
+#define TIZEN_ERROR_OUT_OF_MEMORY (-ENOMEM)
+typedef enum {
+  ML_ERROR_NONE = 0,                    /**< Success! */
+  ML_ERROR_INVALID_PARAMETER = -EINVAL, /**< Invalid parameter */
+  ML_ERROR_TRY_AGAIN =
+    -EAGAIN, /**< The pipeline is not ready, yet (not negotiated, yet) */
+  ML_ERROR_UNKNOWN = _ERROR_UNKNOWN,         /**< Unknown error */
+  ML_ERROR_TIMED_OUT = (_ERROR_UNKNOWN + 1), /**< Time out */
+  ML_ERROR_NOT_SUPPORTED =
+    (_ERROR_UNKNOWN + 2),               /**< The feature is not supported */
+  ML_ERROR_PERMISSION_DENIED = -EACCES, /**< Permission denied */
+  ML_ERROR_OUT_OF_MEMORY = -ENOMEM,     /**< Out of memory (Since 6.0) */
+} ml_error_e;
+#endif
 
 namespace nntrainer {
 

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -365,7 +365,9 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} \
       %{enable_gym} %{enable_nnstreamer_tensor_filter} %{enable_profile} \
       %{enable_nnstreamer_backbone} %{enable_tflite_backbone} \
       %{enable_tflite_interpreter} %{capi_ml_pkg_dep_resolution} \
-      %{enable_reduce_tolerance} %{configure_subplugin_install_path} %{enable_debug}  build
+      %{enable_reduce_tolerance} %{configure_subplugin_install_path} %{enable_debug} \
+      -Dml-api-support=enabled -Denable-nnstreamer-tensor-filter=true \
+      build
 
 ninja -C build %{?_smp_mflags}
 

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -367,6 +367,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} \
       %{enable_tflite_interpreter} %{capi_ml_pkg_dep_resolution} \
       %{enable_reduce_tolerance} %{configure_subplugin_install_path} %{enable_debug} \
       -Dml-api-support=enabled -Denable-nnstreamer-tensor-filter=true \
+      -Denable-capi=enabled \
       build
 
 ninja -C build %{?_smp_mflags}

--- a/test/ccapi/meson.build
+++ b/test/ccapi/meson.build
@@ -11,4 +11,4 @@ exec = executable(
   install_dir: application_install_dir
 )
 
-test('unittest_ccapi', exec, timeout: 120, args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), target))
+test('unittest_ccapi', exec, timeout: 120, args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), 'unittest_ccapi'))

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -16,10 +16,10 @@
 #include <dataset.h>
 #include <ini_wrapper.h>
 #include <layer.h>
-#include <ml-api-common.h>
 #include <model.h>
 #include <nntrainer_test_util.h>
 #include <optimizer.h>
+#include <nntrainer_error.h>
 
 static const std::string getTestResPath(const std::string &file) {
   return getResPath(file, {"test"});

--- a/test/meson.build
+++ b/test/meson.build
@@ -29,13 +29,13 @@ nntrainer_test_main_deps = [
   nntrainer_testutil_dep
 ]
 
-if get_option('enable-capi')
+if enable_capi
   subdir('tizen_capi')
-  subdir('unittest')
 endif
 
-if get_option('enable-ccapi')
+if enable_ccapi
   subdir('ccapi')
+  subdir('unittest')
 endif
 
 if get_option('enable-nnstreamer-tensor-filter')

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -1,7 +1,11 @@
 unittest_nntrainer_deps = [
   nntrainer_test_deps,
-  nntrainer_capi_dep, # so that feature_state can be overridden
+  nntrainer_ccapi_dep
 ] # if unittest-wide dep is added, this is the place to add
+
+if get_option('platform') == 'tizen'
+  unittest_nntrainer_deps += [ nntrainer_capi_dep ] # so that feature_state can be overridden
+endif
 
 # test material need to be unzipped from "(project_home)/packaging/"
 unzip_target = [

--- a/test/unittest/models/meson.build
+++ b/test/unittest/models/meson.build
@@ -16,8 +16,7 @@ exe = executable(
   test_target,
   include_directories: include_directories('.'),
   dependencies: [
-    nntrainer_test_main_deps,
-    nntrainer_capi_dep
+    nntrainer_test_main_deps, nntrainer_ccapi_dep
   ],
   install: get_option('enable-test'),
   install_dir: application_install_dir

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -14,7 +14,9 @@
 
 #include <neuralnet.h>
 #include <nntrainer-api-common.h>
+#ifdef __TIZEN__
 #include <nntrainer_internal.h>
+#endif /* __TIZEN__ */
 
 #include <app_context.h>
 #include <ini_wrapper.h>


### PR DESCRIPTION
Users should be able to build nntrainer in a system without
ML-API and nnstreamer by default.

ML-API and nnstreamer dependency should only be mandated
in related systems (a few embedded systems).

Let's keep it "auto" so that most external users can forget
about nnstreamer and ML-API.

Addresses #1853

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

