### PR TITLE
[CAPI] Move getlayer api to public

### DIFF
--- a/api/capi/include/nntrainer-tizen-internal.h
+++ b/api/capi/include/nntrainer-tizen-internal.h
@@ -22,24 +22,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-/**
- * @brief Get neural network layer from the model with the given name.
- * @details Use this function to get already created Neural Network Layer. The
- * returned layer must not be deleted as it is owned by the model.
- * @since_tizen 6.x
- * @remark This works only for layers added by the API, and does not currently
- * support layers supported for layers created by the ini.
- * @remark The modification through ml_trin_layer_set_property() after compiling
- * the model by calling `ml_train_model_compile()` strictly restricted.
- * @param[in] model The NNTrainer model handler from the given description.
- * @param[in] layer_name Name of the already created layer.
- * @param[out] layer The NNTrainer Layer handler from the given description.
- * @return @c 0 on success. Otherwise a negative error value.
- * @retval #ML_ERROR_NONE Successful.
- * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
- */
-int ml_train_model_get_layer(ml_train_model_h model, const char *layer_name,
-                             ml_train_layer_h *layer);
+/* we leave this file for the future works */
 
 #ifdef __cplusplus
 }

--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -612,6 +612,23 @@ int ml_train_model_load(ml_train_model_h model, const char *file_path,
                         ml_train_model_format_e format);
 
 /**
+ * @brief Get neural network layer from the model with the given name.
+ * @details Use this function to get already created Neural Network Layer. The
+ * returned layer must not be deleted as it is owned by the model.
+ * @since_tizen 6.x
+ * @remark The modification through ml_trin_layer_set_property() after compiling
+ * the model by calling `ml_train_model_compile()` strictly restricted.
+ * @param[in] model The NNTrainer model handler from the given description.
+ * @param[in] layer_name Name of the already created layer.
+ * @param[out] layer The NNTrainer Layer handler from the given description.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ */
+int ml_train_model_get_layer(ml_train_model_h model, const char *layer_name,
+                             ml_train_layer_h *layer);
+
+/**
  * @}
  */
 #ifdef __cplusplus

--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -612,17 +612,19 @@ int ml_train_model_load(ml_train_model_h model, const char *file_path,
                         ml_train_model_format_e format);
 
 /**
- * @brief Get neural network layer from the model with the given name.
+ * @brief Gets neural network layer from the model with the given name.
  * @details Use this function to get already created Neural Network Layer. The
  * returned layer must not be deleted as it is owned by the model.
- * @since_tizen 6.x
- * @remark The modification through ml_trin_layer_set_property() after compiling
- * the model by calling `ml_train_model_compile()` strictly restricted.
+ * @since_tizen 7.0
+ * @remarks The modification through ml_trin_layer_set_property() after
+ * compiling the model by calling `ml_train_model_compile()` strictly
+ * restricted.
  * @param[in] model The NNTrainer model handler from the given description.
  * @param[in] layer_name Name of the already created layer.
  * @param[out] layer The NNTrainer Layer handler from the given description.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
  */
 int ml_train_model_get_layer(ml_train_model_h model, const char *layer_name,

--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -236,20 +236,6 @@ typedef struct {
                                          "dataset")
 
 /**
- * @brief Get neural network layer from the model with the given name.
- * @details Use this function to get already created Neural Network Layer. The
- * returned layer must not be deleted as it is owned by the model.
- * @since_tizen 6.x
- * @param[in] model The NNTrainer model handler from the given description.
- * @param[in] layer_name Name of the already created layer.
- * @param[out] layer The NNTrainer Layer handler from the given description.
- * @return @c 0 on success. Otherwise a negative error value.
- * @retval #ML_ERROR_NONE Successful.
- * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
- */
-int ml_train_model_get_layer(ml_train_model_h model, const char *layer_name,
-                             ml_train_layer_h *layer);
-/**
  * @brief Get all neural network layer names from the model.
  * @details Use this function to get already created Neural Network Layer names.
  * This can be used to obtain layers when model is defined with ini file.

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -186,8 +186,6 @@ static Tensor *requestTensor_(const TensorSpecV2 &spec,
     throw std::logic_error("requestTensor_ should not reach here");
   }
 
-  throw std::logic_error("requestTensor_ should not reach here");
-
   return nullptr;
 }
 


### PR DESCRIPTION
This patch moves the get_layer api to public

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>