### PR TITLE
[DEBIAN] fix nnstreamer single dev dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: gcc-9 | gcc-8 | gcc-7 (>=7.5),
  libcurl3-gnutls-dev | libcurl4-gnutls-dev | libcurl3-openssl-dev |
  libcurl4-openssl-dev | libcurl3-nns-dev | libcurl4-nns-dev, libgtest-dev,
  libflatbuffers-dev, flatbuffers-compiler, libglib2.0-dev, nnstreamer-tensorflow2-lite,
- nnstreamer-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev,
+ ml-inference-single-api-dev nnstreamer-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  ml-api-common-dev, ml-inference-api-dev
 Standards-Version: 3.9.6


### PR DESCRIPTION
This patch includes the ml-inference-single-api-dev.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>