### PR TITLE
[CCAPI] Rearrange enumeration of layer type

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -53,34 +53,39 @@ enum LayerType {
   LAYER_BACKBONE_NNSTREAMER =
     ML_TRAIN_LAYER_TYPE_BACKBONE_NNSTREAMER, /**< Backbone using NNStreamer */
   LAYER_CENTROID_KNN =
-    ML_TRAIN_LAYER_TYPE_CENTROID_KNN, /**< Centroid KNN Layer */
-  LAYER_TIME_DIST,                    /**< Time Distributed Layer type */
+    ML_TRAIN_LAYER_TYPE_CENTROID_KNN,        /**< Centroid KNN Layer */
+  LAYER_CONV1D = ML_TRAIN_LAYER_TYPE_CONV1D, /**< Convolution 1D Layer type */
+  LAYER_LSTMCELL = ML_TRAIN_LAYER_TYPE_LSTMCELL, /**< LSTM Cell Layer type */
+  LAYER_GRUCELL = ML_TRAIN_LAYER_TYPE_GRUCELL,   /**< GRU Cell Layer type */
+  LAYER_RNNCELL = ML_TRAIN_LAYER_TYPE_RNNCELL,   /**< RNN Cell Layer type */
+  LAYER_ZONEOUT_LSTMCELL =
+    ML_TRAIN_LAYER_TYPE_ZONEOUTLSTMCELL, /**< Zoneout LSTM Cell Layer type */
   LAYER_PREPROCESS_FLIP =
     ML_TRAIN_LAYER_TYPE_PREPROCESS_FLIP, /**< Preprocess flip Layer type */
   LAYER_PREPROCESS_TRANSLATE =
     ML_TRAIN_LAYER_TYPE_PREPROCESS_TRANSLATE, /**< Preprocess translate Layer
                                                  type */
   LAYER_PREPROCESS_L2NORM =
-    ML_TRAIN_LAYER_TYPE_PREPROCESS_L2NORM, /**< Preprocess l2norm Layer
-                                                 type */
-  LAYER_BACKBONE_TFLITE,                   /**< Backbone using TFLite */
-  LAYER_ATTENTION,                         /**< Attention Layer type */
-  LAYER_MOL_ATTENTION,                     /**< MoL Attention Layer type */
-  LAYER_CONV1D,                            /**< Convolution 1D Layer type */
-  LAYER_RESHAPE,                           /**< Reshape Layer type */
-  LAYER_RNNCELL,                           /**< RNN Cell Layer type */
-  LAYER_LSTMCELL,                          /**< LSTM Cell Layer type */
-  LAYER_ZONEOUT_LSTMCELL,                  /**< Zoneout LSTM Cell Layer type */
-  LAYER_GRUCELL,                           /**< GRU Cell Layer type */
-  LAYER_REDUCE_MEAN,                       /**< Reduce mean Layer type */
-  LAYER_IDENTITY,                          /**< Identity Layer type */
-  LAYER_LOSS_MSE = 500,             /**< Mean Squared Error Loss Layer type */
-  LAYER_LOSS_CROSS_ENTROPY_SIGMOID, /**< Cross Entropy with Sigmoid Loss Layer
-                                       type */
-  LAYER_LOSS_CROSS_ENTROPY_SOFTMAX, /**< Cross Entropy with Softmax Loss Layer
-                                       type */
-  LAYER_LOSS_CONSTANT_DERIVATIVE,   /**< Synthetic loss layer to feed constant
-                                       derivative */
+    ML_TRAIN_LAYER_TYPE_PREPROCESS_L2NORM, /**< Preprocess l2norm Layer type */
+  LAYER_LOSS_MSE =
+    ML_TRAIN_LAYER_TYPE_LOSS_MSE, /**< Mean Squared Error Loss Layer type */
+  LAYER_LOSS_CROSS_ENTROPY_SIGMOID =
+    ML_TRAIN_LAYER_TYPE_LOSS_CROSS_ENTROPY_SIGMOID, /**< Cross Entropy with
+                                                       Sigmoid Loss Layer type
+                                                     */
+  LAYER_LOSS_CROSS_ENTROPY_SOFTMAX =
+    ML_TRAIN_LAYER_TYPE_LOSS_CROSS_ENTROPY_SOFTMAX, /**< Cross Entropy with
+                                                       Softmax Loss Layer type
+                                                     */
+  LAYER_TIME_DIST,                /**< Time Distributed Layer type */
+  LAYER_BACKBONE_TFLITE,          /**< Backbone using TFLite */
+  LAYER_ATTENTION,                /**< Attention Layer type */
+  LAYER_MOL_ATTENTION,            /**< MoL Attention Layer type */
+  LAYER_RESHAPE,                  /**< Reshape Layer type */
+  LAYER_REDUCE_MEAN,              /**< Reduce mean Layer type */
+  LAYER_IDENTITY,                 /**< Identity Layer type */
+  LAYER_LOSS_CONSTANT_DERIVATIVE, /**< Synthetic loss layer to feed constant
+                                     derivative */
   LAYER_UNKNOWN = ML_TRAIN_LAYER_TYPE_UNKNOWN /**< Unknown */
 };
 

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -48,25 +48,24 @@ typedef enum {
                                               (Since 6.5) */
   ML_TRAIN_LAYER_TYPE_CENTROID_KNN = 18, /**< Centroid KNN Layer (Since 6.5) */
   ML_TRAIN_LAYER_TYPE_CONV1D = 19, /**< Convolution 1D Layer type (Since 7.0) */
+  ML_TRAIN_LAYER_TYPE_LSTMCELL = 20, /**< LSTM Cell Layer type (Since 7.0) */
+  ML_TRAIN_LAYER_TYPE_GRUCELL = 21,  /**< GRU Cell Layer type (Since 7.0) */
+  ML_TRAIN_LAYER_TYPE_RNNCELL = 22,  /**< RNN Cell Layer type (Since 7.0) */
+  ML_TRAIN_LAYER_TYPE_ZONEOUTLSTMCELL =
+    23, /**< ZoneoutLSTM Cell Layer type (Since 7.0) */
   ML_TRAIN_LAYER_TYPE_PREPROCESS_FLIP =
     300, /**< Preprocess flip Layer (Since 6.5) */
-  ML_TRAIN_LAYER_TYPE_PREPROCESS_TRANSLATE = 301, /**< Preprocess translate
-                                               Layer (Since 6.5) */
-  ML_TRAIN_LAYER_TYPE_PREPROCESS_L2NORM = 302, /**< Preprocess L2Normalization
-                                            Layer (Since 6.5) */
+  ML_TRAIN_LAYER_TYPE_PREPROCESS_TRANSLATE =
+    301, /**< Preprocess translate Layer (Since 6.5) */
+  ML_TRAIN_LAYER_TYPE_PREPROCESS_L2NORM =
+    302, /**< Preprocess L2Normalization Layer (Since 6.5) */
   ML_TRAIN_LAYER_TYPE_LOSS_MSE =
     500, /**< Mean Squared Error Loss Layer type (Since 6.5) */
   ML_TRAIN_LAYER_TYPE_LOSS_CROSS_ENTROPY_SIGMOID = 501, /**< Cross Entropy with
                                        Sigmoid Loss Layer type (Since 6.5) */
   ML_TRAIN_LAYER_TYPE_LOSS_CROSS_ENTROPY_SOFTMAX = 502, /**< Cross Entropy with
                                        Softmax Loss Layer type (Since 6.5) */
-  ML_TRAIN_LAYER_TYPE_LSTMCELL = 601, /**< LSTM Cell Layer type (Since 7.0) */
-  ML_TRAIN_LAYER_TYPE_GRUCELL = 602,  /**< GRU Cell Layer type (Since 7.0) */
-  ML_TRAIN_LAYER_TYPE_RNNCELL = 603,  /**< RNN Cell Layer type (Since 7.0) */
-  ML_TRAIN_LAYER_TYPE_ZONEOUTLSTMCELL =
-    604, /**< ZoneoutLSTM Cell Layer type (Since 7.0) */
-
-  ML_TRAIN_LAYER_TYPE_UNKNOWN = 999 /**< Unknown Layer */
+  ML_TRAIN_LAYER_TYPE_UNKNOWN = 999                     /**< Unknown Layer */
 } ml_train_layer_type_e;
 
 /**


### PR DESCRIPTION
- Classified enumeration as neural network, simple transformation and loass layer
- To perform TCT added newly, match position of enumeration between nntrainer-api-common.h and layer.h

**Self evaluation:**
1. Build test:  [X]Passed [ ]Failed [ ]Skipped
2. Run test:    [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyunil <hyunil46.park@samsung.com>