### PR TITLE
[ MESON ] fix bug when meson test

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -40,9 +40,11 @@ endif
 
 if get_option('enable-nnstreamer-tensor-filter')
   subdir('nnstreamer')
-  run_command('cp', '-lr',
+endif
+
+if get_option('enable-tflite-interpreter') or get_option('enable-nnstreamer-tensor-filter')
+  run_command('cp','-lr',
     meson.current_source_dir() / 'test_models/',
     nntrainer_test_resdir
   )
-
 endif


### PR DESCRIPTION
This patch cp the golden data for enable-tflite-interpreter when do
meson test.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>