### PR TITLE
[Exporter] move builtin options for tflite into tflite_opnode

### DIFF
--- a/nntrainer/compiler/tflite_interpreter.cpp
+++ b/nntrainer/compiler/tflite_interpreter.cpp
@@ -376,13 +376,12 @@ buildOperators(const TfOpNodes &nodes, const TfOpIdxMap &map,
 
     auto fb_inputs = fbb.CreateVector(inputs);
     auto fb_outputs = fbb.CreateVector(outputs);
-    /// @todo: this will need to move to exporter
-    auto fb_options = tflite::CreateFullyConnectedOptions(fbb);
+    auto fb_options = node.getBuiltinOps(fbb);
 
     tflite::OperatorBuilder builder(fbb);
     builder.add_opcode_index(op_code);
     builder.add_builtin_options_type(node.getOptionType());
-    builder.add_builtin_options(fb_options.Union());
+    builder.add_builtin_options(fb_options);
     builder.add_inputs(fb_inputs);
     builder.add_outputs(fb_outputs);
     return builder.Finish();

--- a/nntrainer/compiler/tflite_opnode.cpp
+++ b/nntrainer/compiler/tflite_opnode.cpp
@@ -78,6 +78,16 @@ void TfOpNode::finalize() {
   transform_if(weight_transform, weights);
 }
 
+flatbuffers::Offset<void>
+TfOpNode::getBuiltinOps(flatbuffers::FlatBufferBuilder &f) const {
+  switch (op_type) {
+  case tflite::BuiltinOperator_FULLY_CONNECTED:
+    return tflite::CreateFullyConnectedOptions(f).Union();
+  default:
+    return builtin_ops;
+  }
+}
+
 void TfOpNode::setBuiltinOptions(
   tflite::BuiltinOptions builtin_option_type_,
   const flatbuffers::Offset<void> &builtin_ops_) {

--- a/nntrainer/compiler/tflite_opnode.h
+++ b/nntrainer/compiler/tflite_opnode.h
@@ -154,6 +154,14 @@ public:
     return builtin_option_type;
   }
 
+  /**
+   * @brief Get the Op Options object
+   * @param f Flatbuffer Builder
+   * @retval const tflite::Offset<void>
+   */
+  flatbuffers::Offset<void>
+  getBuiltinOps(flatbuffers::FlatBufferBuilder &f) const;
+
 private:
   Variables inputs;  /**< input variables */
   Variables outputs; /**< output variables */


### PR DESCRIPTION
This patch add getter of Flatbuffer builtin options in TfOpNodes.
More case will be added to get the builtin options.

Resolves:

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>