### PR TITLE
[ TEST ] disable app draw classification if nnstreamer is disabled

### DIFF
--- a/Applications/TransferLearning/Draw_Classification/jni/meson.build
+++ b/Applications/TransferLearning/Draw_Classification/jni/meson.build
@@ -29,5 +29,8 @@ e = executable('nntrainer_training',
 nntrainer_filter_env = environment()
 nntrainer_filter_env.set('GTEST_OUTPUT', 'xml:@0@/@1@.xml'.format(meson.build_root(), 'app_draw_classification'))
 nntrainer_filter_env.set('NNSTREAMER_FILTERS', meson.build_root() / 'nnstreamer' / 'tensor_filter')
-test('app_draw_classification', e, env: nntrainer_filter_env,
-  args: [nntr_draw_resdir / 'Training.ini', nntr_draw_resdir], timeout: 150)
+
+if get_option('enable-nnstreamer-tensor-filter')
+   test('app_draw_classification', e, env: nntrainer_filter_env,
+     args: [nntr_draw_resdir / 'Training.ini', nntr_draw_resdir], timeout: 150)
+endif


### PR DESCRIPTION
This patch disable the test when the nnstreamer is
disabled. Prerequisite of this test is nnstreamer is enabled.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>