### PR TITLE
[ Compiler ] add batch norm layer realizer

### DIFF
--- a/nntrainer/compiler/bn_realizer.cpp
+++ b/nntrainer/compiler/bn_realizer.cpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2022 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file bn_realizer.cpp
+ * @date 13 April 2022
+ * @brief NNTrainer graph realizer which remove batch normalization layer for
+ * inference
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <bn_realizer.h>
+#include <connection.h>
+#include <layer_node.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+
+#include <algorithm>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace nntrainer {
+BnRealizer::BnRealizer() {}
+
+BnRealizer::~BnRealizer() {}
+
+GraphRepresentation BnRealizer::realize(const GraphRepresentation &reference) {
+  std::unordered_map<std::string, LayerNode *> existing_nodes;
+
+  std::transform(
+    reference.begin(), reference.end(),
+    std::inserter(existing_nodes, existing_nodes.end()),
+    [](auto &node) { return std::pair(node->getName(), node.get()); });
+
+  // NYI
+
+  return reference;
+}
+
+} // namespace nntrainer

--- a/nntrainer/compiler/bn_realizer.h
+++ b/nntrainer/compiler/bn_realizer.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2022 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file bn_realizer.h
+ * @date 13 April 2022
+ * @brief NNTrainer graph realizer which remove batch normalization layer for
+ * inference
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#ifndef __BN_REALIZER_H__
+#define __BN_REALIZER_H__
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <connection.h>
+#include <realizer.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Graph realizer class which removes batch normalization layer from the
+ * graph
+ * @note This assumes the number of input / output connection of batch
+ * normalization layer == 1
+ *
+ */
+class BnRealizer final : public GraphRealizer {
+public:
+  /**
+   * @brief Construct a new BN Realizer object
+   *
+   */
+  BnRealizer();
+
+  /**
+   * @brief Destroy the Graph Realizer object
+   *
+   */
+  ~BnRealizer();
+
+  /**
+   * @brief graph realizer creates a shallow copied graph based on the reference
+   * @note bn realizer removes batch normalization layers from
+   * GraphRepresentation
+   * @throw std::invalid_argument if graph is ill formed
+   *
+   */
+  GraphRepresentation realize(const GraphRepresentation &reference) override;
+};
+
+} // namespace nntrainer
+
+#endif // __BN_REALIZER_H__

--- a/nntrainer/compiler/meson.build
+++ b/nntrainer/compiler/meson.build
@@ -8,6 +8,7 @@ compiler_sources = [
   'input_realizer.cpp',
   'previous_input_realizer.cpp',
   'multiout_realizer.cpp',
+  'bn_realizer.cpp',
 ]
 
 compiler_headers = []


### PR DESCRIPTION
This patch includes skeleton code for bn realizer which removes the
batch normalization layer for inference

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>