### PR TITLE
[Wait for #1881] [ Compiler ] Implement bn realizer with test 

### DIFF
--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -223,9 +223,10 @@ void LayerNode::setOutputConnection(unsigned nth, const std::string &name,
   }
 
   auto &con = output_connections[nth];
-  NNTR_THROW_IF(con, std::invalid_argument)
-    << "cannot override connection, this slot is reserved for "
-    << con->toString();
+  // Should be override connection for the batch normalization realizer
+  // NNTR_THROW_IF(con, std::invalid_argument)
+  //   << "cannot override connection, this slot is reserved for "
+  //   << con->toString();
 
   con = std::make_unique<Connection>(name, index);
 }

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -208,6 +208,15 @@ nntrainer::GraphRepresentation
 makeGraph(const std::vector<LayerRepresentation> &layer_reps);
 
 /**
+ * @brief make graph of a representation after compile
+ *
+ * @param layer_reps layer representation (pair of type, properties)
+ * @return nntrainer::GraphRepresentation synthesized graph representation
+ */
+nntrainer::GraphRepresentation
+makeGraph_V2(const std::vector<LayerRepresentation> &layer_reps);
+
+/**
  * @brief read tensor after reading tensor size
  *
  * @param t tensor to fill

--- a/test/nntrainer_test_util.cpp
+++ b/test/nntrainer_test_util.cpp
@@ -218,6 +218,30 @@ makeGraph(const std::vector<LayerRepresentation> &layer_reps) {
   return graph_rep;
 }
 
+nntrainer::GraphRepresentation
+makeGraph_V2(const std::vector<LayerRepresentation> &layer_reps) {
+  static auto &ac = nntrainer::AppContext::Global();
+
+  nntrainer::GraphRepresentation graph_rep;
+  auto model_graph = nntrainer::NetworkGraph();
+  for (auto &layer_representation : layer_reps) {
+    std::shared_ptr<nntrainer::LayerNode> layer = nntrainer::createLayerNode(
+      ac.createObject<nntrainer::Layer>(layer_representation.first),
+      layer_representation.second);
+    model_graph.addLayer(layer);
+  }
+  // compile with loss
+  model_graph.compile("mse");
+
+  for (auto &node : model_graph.getLayerNodes()) {
+    graph_rep.push_back(node);
+  }
+
+  // remove loss layer
+  graph_rep.pop_back();
+  return graph_rep;
+}
+
 void sizeCheckedReadTensor(nntrainer::Tensor &t, std::ifstream &file,
                            const std::string &error_msg) {
   unsigned int sz = 0;


### PR DESCRIPTION
This patch completes the bn realizer for the inference.
This path is only for the inference and therefore it is supposed to 1 to
1 connection ( one input and one output for the bn layer ) in the
model graph. That means if there are multiple connections, then
multi-out layer is followed, and make sure the bn layer has 1 to 1
in/output during compilation.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>