### PR TITLE
[Wait for #1882] [ Interpreter ] add batch normalziation realizer @open sesame 04/26 10:37

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -213,6 +213,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/remap_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/slice_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/input_realizer.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/compiler/bn_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/app_context.cpp
 
 ifeq ($(ENABLE_TFLITE_INTERPRETER), 1)

--- a/nntrainer/compiler/tflite_interpreter.cpp
+++ b/nntrainer/compiler/tflite_interpreter.cpp
@@ -21,6 +21,7 @@
 
 #include <tf_schema_generated.h>
 
+#include <bn_realizer.h>
 #include <fc_layer.h>
 #include <layer_node.h>
 #include <nntrainer_error.h>
@@ -430,10 +431,15 @@ buildSubGraphs(const TfOpNodes &nodes, const TfOpIdxMap &map,
 void TfliteInterpreter::serialize(const GraphRepresentation &representation,
                                   const std::string &out) {
   /// @todo check if graph is finalized & initialized and ready to serialize.
+
+  /// 0. remove batch normalization layer in GraphRepresentation
+  BnRealizer realizer({});
+  GraphRepresentation graph = realizer.realize(representation);
+
   /// 1. The graph must have weights, input dims, output dims set
   flatbuffers::FlatBufferBuilder fbb;
 
-  auto opNodes = buildOpNodes(representation);
+  auto opNodes = buildOpNodes(graph);
   TfOpIdxMap map(opNodes); /// build TfOpIdxMap from opNodes
 
   auto opcodes = buildOperatorCodes(map, fbb);

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -223,9 +223,10 @@ void LayerNode::setOutputConnection(unsigned nth, const std::string &name,
   }
 
   auto &con = output_connections[nth];
-  NNTR_THROW_IF(con, std::invalid_argument)
-    << "cannot override connection, this slot is reserved for "
-    << con->toString();
+  // Should be override connection for the batch normalization realizer
+  // NNTR_THROW_IF(con, std::invalid_argument)
+  //   << "cannot override connection, this slot is reserved for "
+  //   << con->toString();
 
   con = std::make_unique<Connection>(name, index);
 }

--- a/nntrainer/optimizers/adam.h
+++ b/nntrainer/optimizers/adam.h
@@ -84,7 +84,7 @@ public:
    * @copydoc Optimizer::getDefaultLearningRate()
    *
    */
-  double getDefaultLearningRate() const { return 0.001; }
+  double getDefaultLearningRate() const override { return 0.001; }
 
   /**
    * @copydoc applyGradient(RunOptimizerContext &context)

--- a/nntrainer/optimizers/sgd.h
+++ b/nntrainer/optimizers/sgd.h
@@ -34,17 +34,17 @@ public:
    * @copydoc Optimizer::getDefaultLearningRate()
    *
    */
-  double getDefaultLearningRate() const { return 0.0001; }
+  double getDefaultLearningRate() const override { return 0.0001; }
 
   /**
    * @copydoc applyGradient(RunOptimizerContext &context)
    */
-  void applyGradient(RunOptimizerContext &context);
+  void applyGradient(RunOptimizerContext &context) override;
 
   /**
    * @copydoc Optimizer::getType()
    */
-  const std::string getType() const { return SGD::type; }
+  const std::string getType() const override { return SGD::type; }
 
   /**
    * @copydoc Optimizer::getOptimizerVariableDim(const TensorDim &dim)

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -208,6 +208,15 @@ nntrainer::GraphRepresentation
 makeGraph(const std::vector<LayerRepresentation> &layer_reps);
 
 /**
+ * @brief make graph of a representation after compile
+ *
+ * @param layer_reps layer representation (pair of type, properties)
+ * @return nntrainer::GraphRepresentation synthesized graph representation
+ */
+nntrainer::GraphRepresentation
+makeGraph_V2(const std::vector<LayerRepresentation> &layer_reps);
+
+/**
  * @brief read tensor after reading tensor size
  *
  * @param t tensor to fill

--- a/test/nntrainer_test_util.cpp
+++ b/test/nntrainer_test_util.cpp
@@ -218,6 +218,30 @@ makeGraph(const std::vector<LayerRepresentation> &layer_reps) {
   return graph_rep;
 }
 
+nntrainer::GraphRepresentation
+makeGraph_V2(const std::vector<LayerRepresentation> &layer_reps) {
+  static auto &ac = nntrainer::AppContext::Global();
+
+  nntrainer::GraphRepresentation graph_rep;
+  auto model_graph = nntrainer::NetworkGraph();
+  for (auto &layer_representation : layer_reps) {
+    std::shared_ptr<nntrainer::LayerNode> layer = nntrainer::createLayerNode(
+      ac.createObject<nntrainer::Layer>(layer_representation.first),
+      layer_representation.second);
+    model_graph.addLayer(layer);
+  }
+  // compile with loss
+  model_graph.compile("mse");
+
+  for (auto &node : model_graph.getLayerNodes()) {
+    graph_rep.push_back(node);
+  }
+
+  // remove loss layer
+  graph_rep.pop_back();
+  return graph_rep;
+}
+
 void sizeCheckedReadTensor(nntrainer::Tensor &t, std::ifstream &file,
                            const std::string &error_msg) {
   unsigned int sz = 0;


### PR DESCRIPTION
This patch removes the batch normalization layers with bn_realizer in
the GraphRepresentation for TfliteInterperter which is for the
inference.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
