### PR TITLE
[Wait for #1883] [ TEST ] add more test cases for batch normalization realizer

### DIFF
--- a/nntrainer/compiler/bn_realizer.cpp
+++ b/nntrainer/compiler/bn_realizer.cpp
@@ -11,7 +11,6 @@
  * @bug No known bugs except for NYI items
  */
 #include <bn_realizer.h>
-#include <remap_realizer.h>
 #include <connection.h>
 #include <layer_node.h>
 #include <nntrainer_error.h>

--- a/nntrainer/compiler/bn_realizer.cpp
+++ b/nntrainer/compiler/bn_realizer.cpp
@@ -11,6 +11,7 @@
  * @bug No known bugs except for NYI items
  */
 #include <bn_realizer.h>
+#include <remap_realizer.h>
 #include <connection.h>
 #include <layer_node.h>
 #include <nntrainer_error.h>

--- a/nntrainer/compiler/bn_realizer.cpp
+++ b/nntrainer/compiler/bn_realizer.cpp
@@ -24,10 +24,6 @@ namespace nntrainer {
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
-BnRealizer::BnRealizer() {}
-
-BnRealizer::~BnRealizer() {}
-
 GraphRepresentation BnRealizer::realize(const GraphRepresentation &reference) {
   std::unordered_map<std::string, LayerNode *> existing_nodes;
   std::vector<LayerNode *> bn_layers;

--- a/nntrainer/compiler/bn_realizer.h
+++ b/nntrainer/compiler/bn_realizer.h
@@ -35,18 +35,19 @@ public:
    * @brief Construct a new BN Realizer object
    *
    */
-  BnRealizer();
+  BnRealizer() = default;
 
   /**
    * @brief Destroy the Graph Realizer object
    *
    */
-  ~BnRealizer();
+  ~BnRealizer() = default;
 
   /**
    * @brief graph realizer creates a shallow copied graph based on the reference
    * @note bn realizer removes batch normalization layers from
    * GraphRepresentation
+   * @param reference GraphRepresenstaion to be realized
    * @throw std::invalid_argument if graph is ill formed
    *
    */

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -36,6 +36,7 @@
 #include <neuralnet.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
+#include <realizer.h>
 #include <tensor.h>
 
 /** tolerance is reduced for packaging, but CI runs at full tolerance */
@@ -211,10 +212,12 @@ makeGraph(const std::vector<LayerRepresentation> &layer_reps);
  * @brief make graph of a representation after compile
  *
  * @param layer_reps layer representation (pair of type, properties)
+ * @param realizers GraphRealizers to modify graph before compile
  * @return nntrainer::GraphRepresentation synthesized graph representation
  */
-nntrainer::GraphRepresentation
-makeGraph_V2(const std::vector<LayerRepresentation> &layer_reps);
+nntrainer::GraphRepresentation makeCompiledGraph(
+  const std::vector<LayerRepresentation> &layer_reps,
+  std::vector<std::unique_ptr<nntrainer::GraphRealizer>> &realizers);
 
 /**
  * @brief read tensor after reading tensor size

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -24,6 +24,7 @@
 #include <recurrent_realizer.h>
 #include <remap_realizer.h>
 #include <slice_realizer.h>
+#include <bn_realizer.h>
 
 #include <compiler_test_util.h>
 #include <nntrainer_test_util.h>
@@ -808,4 +809,5 @@ TEST(BnRealizer, bn_realizer_p) {
   };
   BnRealizer r({});
   compileAndRealizeAndEqual(r, before, after);
+
 }

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -24,7 +24,6 @@
 #include <recurrent_realizer.h>
 #include <remap_realizer.h>
 #include <slice_realizer.h>
-#include <bn_realizer.h>
 
 #include <compiler_test_util.h>
 #include <nntrainer_test_util.h>


### PR DESCRIPTION
This patch adds the test case for batch normalization realizer with
kind of resnet basic block which includes the multiout layer.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>