### PR TITLE
[CAPI] Add check if model is null to ml_train_model_get_summary()

### DIFF
--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -435,6 +435,8 @@ int ml_train_model_get_summary(ml_train_model_h model,
 
   check_feature_state();
 
+  ML_TRAIN_VERIFY_VALID_HANDLE(model);
+
   if (summary == nullptr) {
     ml_loge("summary pointer is null");
     return ML_ERROR_INVALID_PARAMETER;


### PR DESCRIPTION
- Check if model is null or not before checking in ml_train_model_get_summary_util()

Self evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyunil <hyunil46.park@samsung.com>