### PR TITLE
[ CCAPI ] add copy model configuration & get/set Weight of layer @open sesame 05/06 15:07

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -164,6 +164,22 @@ public:
    * to keep the name unique to the model
    */
   virtual const std::string getName() const noexcept = 0;
+
+  /**
+   * @brief     Get weight data of the layer
+   * @retval    weight data of the layer
+   * @note      nntrainer assign the vector and if there is no weights, the size
+   * of vector is zero
+   * @note      layer needs to be finalized before called.
+   */
+  virtual const std::vector<float *> getWeights() = 0;
+
+  /**
+   * @brief     Set weight data of the layer
+   * @note      Size of vector must be the same with number of weights.
+   * @note      layer needs to be finalized before called.
+   */
+  virtual void setWeights(const std::vector<float *>) = 0;
 };
 
 /**

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -298,6 +298,11 @@ public:
 std::unique_ptr<Model>
 createModel(ModelType type, const std::vector<std::string> &properties = {});
 
+/**
+ * @brief creator by copying the configuration of other model
+ */
+std::unique_ptr<Model> copyConfiguration(Model &from);
+
 } // namespace train
 } // namespace ml
 

--- a/api/ccapi/src/factory.cpp
+++ b/api/ccapi/src/factory.cpp
@@ -75,6 +75,17 @@ std::unique_ptr<Model> createModel(ModelType type,
 }
 
 /**
+ * @brief creator by copying the configuration of other model
+ */
+std::unique_ptr<Model> copyConfiguration(Model &from) {
+  std::unique_ptr<nntrainer::NeuralNetwork> model =
+    std::make_unique<nntrainer::NeuralNetwork>();
+  nntrainer::NeuralNetwork &f = dynamic_cast<nntrainer::NeuralNetwork &>(from);
+  model->copyConfiguration(f);
+  return model;
+}
+
+/**
  * @brief Factory creator with constructor for dataset
  */
 std::unique_ptr<Dataset>

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -161,8 +161,8 @@ public:
   GraphCore &copy(GraphCore &from) {
     node_list.resize(from.node_list.size());
     if (this != &from) {
-      // or (unsigned int i = 0; i < node_list.size(); i++)
-      //  node_list[i]->copy(from.node_list[i]);
+      //      for (unsigned int i = 0; i < node_list.size(); ++i)
+      //        node_list[i]->copy(from.node_list[i]);
     }
     return *this;
   }

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -188,6 +188,20 @@ void LayerNode::setProperty(const std::vector<std::string> &properties) {
   }
 }
 
+void LayerNode::setWeights(const std::vector<float *> weights) {
+  NNTR_THROW_IF(!run_context, std::runtime_error)
+    << __func__ << " layer needs to be finalized first!";
+
+  NNTR_THROW_IF(getNumWeights() != weights.size(), std::runtime_error)
+    << __func__ << " Number of Weights dismatch!";
+
+  // Needs Deep copy
+  for (unsigned int idx = 0; idx < getNumWeights(); ++idx) {
+    Tensor &w = getWeight(idx);
+    std::copy(weights[idx], weights[idx] + w.size(), w.getData());
+  }
+}
+
 const unsigned LayerNode::getInputConnectionIndex(unsigned nth) const {
   auto &input_conns =
     std::get<std::vector<props::InputConnection>>(*layer_node_props);

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -512,6 +512,31 @@ public:
   }
 
   /**
+   * @brief     Get weight data of the layer
+   * @retval    weight data of the layer
+   * @note      nntrainer assign the vector and if there is no weights, the size
+   * of vector is zero
+   * @note      layer needs to be finalized before called.
+   */
+  const std::vector<float *> getWeights() {
+    NNTR_THROW_IF(!run_context, std::runtime_error)
+      << __func__ << " layer needs to be finalized first!";
+
+    std::vector<float *> weights;
+    for (unsigned int idx = 0; idx < getNumWeights(); ++idx) {
+      weights.emplace_back(getWeight(idx).getData());
+    }
+    return weights;
+  }
+
+  /**
+   * @brief     Set weight data of the layer
+   * @note      Size of vector must be the same with number of weights.
+   * @note      layer needs to be finalized before called.
+   */
+  void setWeights(const std::vector<float *> weights);
+
+  /**
    * @brief Get the Input tensor object
    *
    * @param idx Identifier of the input

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -101,7 +101,12 @@ public:
   /**
    * @brief     Constructor of NeuralNetwork Class
    */
-  NeuralNetwork(AppContext app_context_ = AppContext(AppContext::Global()));
+  NeuralNetwork();
+
+  /**
+   * @brief     Constructor of NeuralNetwork Class
+   */
+  NeuralNetwork(AppContext app_context_);
 
   /**
    * @brief     Destructor of NeuralNetwork Class
@@ -251,8 +256,20 @@ public:
    * @brief     Copy Neural Network
    * @param[in] from NeuralNetwork Object to copy
    * @retval    NeuralNewtork Object copyed
+   * @todo Need to implement the copy of graph core
    */
   NeuralNetwork &copy(NeuralNetwork &from);
+
+  /**
+   * @brief     Copy Neural Network Configuration
+   * @param[in] from NeuralNetwork Object to copy
+   * @retval    NeuralNewtork Object copyed
+   * @note This does not copy the context of neural network model. It only
+   * copies the configuration of the network model. Therefore, it needs the
+   * compile and initialization to run the model. Also if you need the
+   * initialized the weight, load call is required.
+   */
+  NeuralNetwork &copyConfiguration(NeuralNetwork &from);
 
   /**
    * @brief     Run NeuralNetwork train

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -651,7 +651,7 @@ TEST(nntrainer_capi_nnmodel, getLayer_03_n) {
 /**
  * @brief Neural Network Model Get Layer Test
  */
-TEST(nntrainer_capi_nnmodel, getLayer_04_n) {
+TEST(nntrainer_capi_nnmodel, getLayer_04_p) {
   int status = ML_ERROR_NONE;
 
   ml_train_model_h model;
@@ -666,7 +666,7 @@ TEST(nntrainer_capi_nnmodel, getLayer_04_n) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_train_model_get_layer(model, "inputlayer", &get_layer);
-  EXPECT_EQ(status, ML_ERROR_NOT_SUPPORTED);
+  EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);


### PR DESCRIPTION
This patch enables the API for the copy model configuration and
get/set Weight Tensor data with vector of float pointer.

sementics of this APIs are:
  . copyConfigurarion(ml::train::Model &from)
  . std::vector<float*> getWeights()
  . void setWeights(const std::vector<float*>)

This is only copy the model configuration, it reauires the compile and
initialization before train.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>