### PR TITLE
[ Unit Test ] remove mse loss layer  in makeCompiledGraph @open sesame 05/04 10:00

### DIFF
--- a/test/nntrainer_test_util.cpp
+++ b/test/nntrainer_test_util.cpp
@@ -242,8 +242,7 @@ nntrainer::GraphRepresentation makeCompiledGraph(
     model_graph.addLayer(layer);
   }
 
-  // Compile with loss
-  model_graph.compile("mse");
+  model_graph.compile("");
 
   graph_rep.clear();
   for (auto &node : model_graph.getLayerNodes()) {


### PR DESCRIPTION
This patch remove the mse loss layer in makeCompiledGraph

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>