### PR TITLE
[ CAPI ] change set_feature_state to compatible with tizen api

### DIFF
--- a/Applications/TransferLearning/Draw_Classification/jni/main.cpp
+++ b/Applications/TransferLearning/Draw_Classification/jni/main.cpp
@@ -451,7 +451,9 @@ int main(int argc, char *argv[]) {
   }
 
 #if defined(__TIZEN__)
-  set_feature_state(SUPPORTED);
+  set_feature_state(ML_FEATURE, SUPPORTED);
+  set_feature_state(ML_FEATURE_INFERENCE, SUPPORTED);
+  set_feature_state(ML_FEATURE_TRAINING, SUPPORTED);
 #endif
 
   const std::vector<std::string> args(argv + 1, argv + argc);
@@ -475,7 +477,9 @@ int main(int argc, char *argv[]) {
   } catch (...) {
     std::cerr << "Failed loading input images." << std::endl;
 #if defined(__TIZEN__)
-    set_feature_state(NOT_CHECKED_YET);
+    set_feature_state(ML_FEATURE, NOT_CHECKED_YET);
+    set_feature_state(ML_FEATURE_INFERENCE, NOT_CHECKED_YET);
+    set_feature_state(ML_FEATURE_TRAINING, NOT_CHECKED_YET);
 #endif
     return 1;
   }
@@ -486,7 +490,9 @@ int main(int argc, char *argv[]) {
   } catch (...) {
     std::cerr << "Failed train model\n";
 #if defined(__TIZEN__)
-    set_feature_state(NOT_CHECKED_YET);
+    set_feature_state(ML_FEATURE, NOT_CHECKED_YET);
+    set_feature_state(ML_FEATURE_INFERENCE, NOT_CHECKED_YET);
+    set_feature_state(ML_FEATURE_TRAINING, NOT_CHECKED_YET);
 #endif
     return 1;
   }
@@ -501,7 +507,9 @@ int main(int argc, char *argv[]) {
   } catch (...) {
     std::cerr << "Failed test model\n";
 #if defined(__TIZEN__)
-    set_feature_state(NOT_CHECKED_YET);
+    set_feature_state(ML_FEATURE, NOT_CHECKED_YET);
+    set_feature_state(ML_FEATURE_INFERENCE, NOT_CHECKED_YET);
+    set_feature_state(ML_FEATURE_TRAINING, NOT_CHECKED_YET);
 #endif
     return 1;
   }
@@ -511,7 +519,9 @@ int main(int argc, char *argv[]) {
   }
 
 #if defined(__TIZEN__)
-  set_feature_state(NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_INFERENCE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_TRAINING, NOT_CHECKED_YET);
 #endif
 
 #if defined(APP_VALIDATE)

--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -46,6 +46,15 @@
 #if defined(__TIZEN__)
 
 typedef enum {
+  ML_FEATURE = 0,
+  ML_FEATURE_INFERENCE,
+  ML_FEATURE_TRAINING,
+  ML_FEATURE_SERVICE,
+
+  ML_FEATURE_MAX
+} ml_feature_e;
+
+typedef enum {
   NOT_CHECKED_YET = -1,
   NOT_SUPPORTED = 0,
   SUPPORTED = 1
@@ -314,7 +323,8 @@ int ml_tizen_get_feature_enabled(void);
  * @brief Set the feature status of machine_learning.training.
  * This is only used for Unit test.
  */
-void ml_train_tizen_set_feature_state(feature_state_t state);
+void ml_train_tizen_set_feature_state(ml_feature_e feature,
+                                      feature_state_t state);
 #endif /* __TIZEN__ */
 
 #ifdef __cplusplus

--- a/api/capi/src/nntrainer-capi-tizen-feature-check.cpp
+++ b/api/capi/src/nntrainer-capi-tizen-feature-check.cpp
@@ -38,7 +38,7 @@ extern "C" {
  * @param state -1 NOT checked yet, 0 supported, 1 not supported
  * @return int 0 if success
  */
-int _ml_tizen_set_feature_state(int state);
+int _ml_tizen_set_feature_state(ml_feature_e feature, int state);
 #define ml_api_set_feature_state(...) _ml_tizen_set_feature_state(__VA_ARGS__)
 
 #elif (TIZENVERSION >= 6) && (TIZENVERSION < 9999)
@@ -49,7 +49,7 @@ int _ml_tizen_set_feature_state(int state);
  * @param state -1 NOT checked yet, 0 supported, 1 not supported
  * @return int 0 if success
  */
-int ml_tizen_set_feature_state(int state);
+int ml_tizen_set_feature_state(ml_feature_e feature, int state);
 #define ml_api_set_feature_state(...) ml_tizen_set_feature_state(__VA_ARGS__)
 
 #elif (TIZENVERSION <= 5)
@@ -82,10 +82,11 @@ static feature_info_s feature_info;
 /**
  * @brief Set the feature status of machine_learning.training.
  */
-void ml_train_tizen_set_feature_state(feature_state_t state) {
+void ml_train_tizen_set_feature_state(ml_feature_e feature,
+                                      feature_state_t state) {
   pthread_mutex_lock(&feature_info.mutex);
 
-  ml_api_set_feature_state((int)state);
+  ml_api_set_feature_state(feature, (int)state);
 
   /**
    * Update feature status
@@ -117,11 +118,11 @@ int ml_tizen_get_feature_enabled(void) {
     if (0 == ret) {
       if (false == ml_train_supported) {
         ml_loge("machine_learning.training NOT supported");
-        ml_train_tizen_set_feature_state(NOT_SUPPORTED);
+        ml_train_tizen_set_feature_state(ML_FEATURE_TRAINING, NOT_SUPPORTED);
         return ML_ERROR_NOT_SUPPORTED;
       }
 
-      ml_train_tizen_set_feature_state(SUPPORTED);
+      ml_train_tizen_set_feature_state(ML_FEATURE_TRAINING, SUPPORTED);
     } else {
       switch (ret) {
       case SYSTEM_INFO_ERROR_INVALID_PARAMETER:

--- a/test/nnstreamer/test_nnstreamer_single.cpp
+++ b/test/nnstreamer/test_nnstreamer_single.cpp
@@ -31,13 +31,21 @@ protected:
    * @brief SetUp the test case
    *
    */
-  void SetUp() override { set_feature_state(SUPPORTED); }
+  void SetUp() override {
+    set_feature_state(ML_FEATURE, SUPPORTED);
+    set_feature_state(ML_FEATURE_INFERENCE, SUPPORTED);
+    set_feature_state(ML_FEATURE_TRAINING, SUPPORTED);
+  }
 
   /**
    * @brief TearDown the test case
    *
    */
-  void TearDown() override { set_feature_state(NOT_CHECKED_YET); }
+  void TearDown() override {
+    set_feature_state(ML_FEATURE, NOT_CHECKED_YET);
+    set_feature_state(ML_FEATURE_INFERENCE, NOT_CHECKED_YET);
+    set_feature_state(ML_FEATURE_TRAINING, NOT_CHECKED_YET);
+  }
 };
 
 static int singleshot_case(ml_tensors_info_h in_info,

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -1332,7 +1332,9 @@ int main(int argc, char **argv) {
   }
 
   /** ignore tizen feature check while running the testcases */
-  set_feature_state(SUPPORTED);
+  set_feature_state(ML_FEATURE, SUPPORTED);
+  set_feature_state(ML_FEATURE_INFERENCE, SUPPORTED);
+  set_feature_state(ML_FEATURE_TRAINING, SUPPORTED);
 
   try {
     result = RUN_ALL_TESTS();
@@ -1341,7 +1343,9 @@ int main(int argc, char **argv) {
   }
 
   /** reset tizen feature check state */
-  set_feature_state(NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_INFERENCE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_TRAINING, NOT_CHECKED_YET);
 
   return result;
 }

--- a/test/tizen_capi/unittest_tizen_capi_dataset.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_dataset.cpp
@@ -504,7 +504,9 @@ int main(int argc, char **argv) {
   }
 
   /** ignore tizen feature check while running the testcases */
-  set_feature_state(SUPPORTED);
+  set_feature_state(ML_FEATURE, SUPPORTED);
+  set_feature_state(ML_FEATURE_INFERENCE, SUPPORTED);
+  set_feature_state(ML_FEATURE_TRAINING, SUPPORTED);
 
   try {
     result = RUN_ALL_TESTS();
@@ -513,7 +515,9 @@ int main(int argc, char **argv) {
   }
 
   /** reset tizen feature check state */
-  set_feature_state(NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_INFERENCE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_TRAINING, NOT_CHECKED_YET);
 
   return result;
 }

--- a/test/tizen_capi/unittest_tizen_capi_layer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_layer.cpp
@@ -299,7 +299,9 @@ int main(int argc, char **argv) {
   }
 
   /** ignore tizen feature check while running the testcases */
-  set_feature_state(SUPPORTED);
+  set_feature_state(ML_FEATURE, SUPPORTED);
+  set_feature_state(ML_FEATURE_INFERENCE, SUPPORTED);
+  set_feature_state(ML_FEATURE_TRAINING, SUPPORTED);
 
   try {
     result = RUN_ALL_TESTS();
@@ -308,7 +310,9 @@ int main(int argc, char **argv) {
   }
 
   /** reset tizen feature check state */
-  set_feature_state(NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_INFERENCE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_TRAINING, NOT_CHECKED_YET);
 
   return result;
 }

--- a/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
@@ -129,7 +129,9 @@ int main(int argc, char **argv) {
   }
 
   /** ignore tizen feature check while running the testcases */
-  set_feature_state(SUPPORTED);
+  set_feature_state(ML_FEATURE, SUPPORTED);
+  set_feature_state(ML_FEATURE_INFERENCE, SUPPORTED);
+  set_feature_state(ML_FEATURE_TRAINING, SUPPORTED);
 
   try {
     result = RUN_ALL_TESTS();
@@ -138,7 +140,9 @@ int main(int argc, char **argv) {
   }
 
   /** reset tizen feature check state */
-  set_feature_state(NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_INFERENCE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_TRAINING, NOT_CHECKED_YET);
 
   return result;
 }

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -795,7 +795,9 @@ int main(int argc, char **argv) {
 
 #if defined(__TIZEN__)
   /** ignore tizen feature check while running the testcases */
-  set_feature_state(SUPPORTED);
+  set_feature_state(ML_FEATURE, SUPPORTED);
+  set_feature_state(ML_FEATURE_INFERENCE, SUPPORTED);
+  set_feature_state(ML_FEATURE_TRAINING, SUPPORTED);
 #endif
 
   try {
@@ -806,7 +808,9 @@ int main(int argc, char **argv) {
 
 #if defined(__TIZEN__)
   /** reset tizen feature check state */
-  set_feature_state(NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_INFERENCE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_TRAINING, NOT_CHECKED_YET);
 #endif
 
   return result;


### PR DESCRIPTION
This patch make the set_featture_state variable compatible with tizen
ml api. It requires ml feature parameter to set and get, it fixs
accordingly.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>