### PR TITLE
[ Compiler ] add loss layer realizer

### DIFF
--- a/nntrainer/compiler/loss_realizer.cpp
+++ b/nntrainer/compiler/loss_realizer.cpp
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2022 seongwoo <mhs4670go@naver.com>
+ *
+ * @file loss_realizer.h
+ * @date 4 May 2022
+ * @brief NNTrainer graph realizer which remove loss layer for inference
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author seongwoo <mhs4670go@naver.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <algorithm>
+#include <cassert>
+#include <connection.h>
+#include <layer_node.h>
+#include <loss_realizer.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+namespace nntrainer {
+
+static constexpr size_t SINGLE_IN_IDX = 0;
+
+GraphRepresentation
+LossRealizer::realize(const GraphRepresentation &reference) {
+  /// @todo support more loss layers
+  /// @note Some layers need to consider not removing all semantics.
+  /// For example, When CrossEntropySigmoidLossLayer needs to be removed,
+  /// sigmoid computation shouldn't be removed.
+  static const std::set<std::string> loss_type = {"mse"};
+  std::unordered_map<std::string, LayerNode *> existing_nodes;
+  std::vector<LayerNode *> loss_layers;
+
+  std::transform(
+    reference.begin(), reference.end(),
+    std::inserter(existing_nodes, existing_nodes.end()),
+    [](auto &node) { return std::pair(node->getName(), node.get()); });
+
+  for (auto &node : reference) {
+    if (loss_type.find(node->getType()) != loss_type.end()) {
+      loss_layers.push_back(node.get());
+    }
+  }
+
+  for (auto iter = loss_layers.begin(); iter != loss_layers.end(); ++iter) {
+    auto loss_node = (*iter);
+    assert(loss_node->getNumInputConnections() == 1);
+    auto &input_name = loss_node->getInputConnectionName(SINGLE_IN_IDX);
+    auto input_node = existing_nodes.at(input_name);
+    for (unsigned int i = 0; i < input_node->getNumOutputConnections(); ++i) {
+      if (istrequal(loss_node->getName(),
+                    input_node->getOutputConnection(i)->getName())) {
+        /// Assume that loss layers don't have output connections
+        assert(loss_node->getOutputConnections().size() == 0);
+        input_node->setOutputLayers({});
+      }
+    }
+  }
+
+  GraphRepresentation processed;
+  for (auto &node : reference) {
+    if (loss_type.find(node->getType()) == loss_type.end()) {
+      processed.push_back(node);
+    }
+  }
+
+  return processed;
+}
+
+} // namespace nntrainer

--- a/nntrainer/compiler/loss_realizer.h
+++ b/nntrainer/compiler/loss_realizer.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2022 seongwoo <mhs4670go@naver.com>
+ *
+ * @file loss_realizer.h
+ * @date 4 May 2022
+ * @brief NNTrainer graph realizer which remove loss layer for inference
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author seongwoo <mhs4670go@naver.com>
+ * @bug No known bugs except for NYI items
+ */
+#ifndef __LOSS_REALIZER_H__
+#define __LOSS_REALIZER_H__
+
+#include <vector>
+
+#include <realizer.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Graph realizer class which removes loss layer from the graph
+ * @note This assumes the number of input / output connection of loss layer == 1
+ *
+ */
+class LossRealizer final : public GraphRealizer {
+public:
+  /**
+   * @brief Construct a new Loss Realizer object
+   *
+   */
+  LossRealizer() = default;
+
+  /**
+   * @brief Destroy the Graph Realizer object
+   *
+   */
+  ~LossRealizer() = default;
+
+  /**
+   * @brief graph realizer creates a shallow copied graph based on the reference
+   * @note loss realizer removes loss layers from GraphRepresentation
+   * @param reference GraphRepresenstaion to be realized
+   *
+   */
+  GraphRepresentation realize(const GraphRepresentation &reference) override;
+};
+
+} // namespace nntrainer
+
+#endif // __LOSS_REALIZER_H__

--- a/nntrainer/compiler/meson.build
+++ b/nntrainer/compiler/meson.build
@@ -9,6 +9,7 @@ compiler_sources = [
   'previous_input_realizer.cpp',
   'multiout_realizer.cpp',
   'bn_realizer.cpp',
+  'loss_realizer.cpp',
 ]
 
 compiler_headers = []

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -213,11 +213,13 @@ makeGraph(const std::vector<LayerRepresentation> &layer_reps);
  *
  * @param layer_reps layer representation (pair of type, properties)
  * @param realizers GraphRealizers to modify graph before compile
+ * @param loss_layer loss layer to compile with
  * @return nntrainer::GraphRepresentation synthesized graph representation
  */
 nntrainer::GraphRepresentation makeCompiledGraph(
   const std::vector<LayerRepresentation> &layer_reps,
-  std::vector<std::unique_ptr<nntrainer::GraphRealizer>> &realizers);
+  std::vector<std::unique_ptr<nntrainer::GraphRealizer>> &realizers,
+  const std::string &loss_layer = "");
 
 /**
  * @brief read tensor after reading tensor size

--- a/test/nntrainer_test_util.cpp
+++ b/test/nntrainer_test_util.cpp
@@ -221,7 +221,8 @@ makeGraph(const std::vector<LayerRepresentation> &layer_reps) {
 
 nntrainer::GraphRepresentation makeCompiledGraph(
   const std::vector<LayerRepresentation> &layer_reps,
-  std::vector<std::unique_ptr<nntrainer::GraphRealizer>> &realizers) {
+  std::vector<std::unique_ptr<nntrainer::GraphRealizer>> &realizers,
+  const std::string &loss_layer) {
   static auto &ac = nntrainer::AppContext::Global();
 
   nntrainer::GraphRepresentation graph_rep;
@@ -242,7 +243,7 @@ nntrainer::GraphRepresentation makeCompiledGraph(
     model_graph.addLayer(layer);
   }
 
-  model_graph.compile("");
+  model_graph.compile(loss_layer);
 
   graph_rep.clear();
   for (auto &node : model_graph.getLayerNodes()) {

--- a/test/unittest/compiler/unittest_realizer.cpp
+++ b/test/unittest/compiler/unittest_realizer.cpp
@@ -18,6 +18,7 @@
 #include <connection.h>
 #include <flatten_realizer.h>
 #include <input_realizer.h>
+#include <loss_realizer.h>
 #include <multiout_realizer.h>
 #include <previous_input_realizer.h>
 #include <realizer.h>
@@ -832,5 +833,27 @@ TEST(BnRealizer, bn_realizer_resblock_p) {
   std::vector<std::unique_ptr<nntrainer::GraphRealizer>> realizers;
   realizers.emplace_back(new nntrainer::MultioutRealizer());
   BnRealizer r;
+  compileAndRealizeAndEqual(r, realizers, before, after);
+}
+
+TEST(LossRealizer, loss_realizer_p) {
+  /// realization without identifying custom input
+  std::vector<LayerRepresentation> before = {
+    {"fully_connected", {"name=fc1"}},
+    {"activation", {"name=ac1", "activation=relu", "input_layers=fc1"}},
+    {"fully_connected", {"name=fc2", "input_layers=ac1"}},
+    {"activation", {"name=ac2", "activation=relu", "input_layers=fc2"}},
+    {"fully_connected", {"name=fc3", "input_layers=ac2"}},
+    {"mse", {"name=loss", "input_layers=fc3"}},
+  };
+  std::vector<LayerRepresentation> after = {
+    {"fully_connected", {"name=fc1"}},
+    {"activation", {"name=ac1", "activation=relu", "input_layers=fc1"}},
+    {"fully_connected", {"name=fc2", "input_layers=ac1"}},
+    {"activation", {"name=ac2", "activation=relu", "input_layers=fc2"}},
+    {"fully_connected", {"name=fc3", "input_layers=ac2"}},
+  };
+  LossRealizer r;
+  std::vector<std::unique_ptr<nntrainer::GraphRealizer>> realizers;
   compileAndRealizeAndEqual(r, realizers, before, after);
 }


### PR DESCRIPTION
This patch includes loss realizer implementation and tests which removes the loss layer for exports.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Related: #1879 
Signed-off-by: seongwoo <mhs4670go@naver.com>