### PR TITLE
[layers] flatten layer consider target_shape

### DIFF
--- a/nntrainer/layers/reshape_layer.cpp
+++ b/nntrainer/layers/reshape_layer.cpp
@@ -34,8 +34,6 @@ void ReshapeLayer::finalize(InitLayerContext &context) {
       "Reshape layer must be provided with target shape");
   TensorDim out_dim = target_shape.get();
 
-  /** flatten sets the dimension to 1 to indicate to flatten the rest of the
-   * dimensions */
   if ((int)out_dim.getDataLen() == -1) {
     out_dim.height(1);
     out_dim.channel(1);

--- a/nntrainer/layers/reshape_layer.h
+++ b/nntrainer/layers/reshape_layer.h
@@ -90,7 +90,7 @@ public:
 
   inline static const std::string type = "reshape";
 
-private:
+protected:
   std::tuple<props::TargetShape>
     reshape_props; /**< reshape properties : target_shape after reshape */
 };


### PR DESCRIPTION
This patch makes a flatten layer consider target_shape and use it during exporting.

FYI, flatten layer exports to `Reshape` operator in tflite. That is why the flatten layer needs to know about target shape.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Related: #1879 
Signed-off-by: seongwoo <mhs4670go@naver.com>