### PR TITLE
[CAPI] Add ml_train_model_compile_with_params() internally for C# DllImport

### DIFF
--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -334,6 +334,27 @@ int ml_train_model_insert_layer(ml_train_model_h model, ml_train_layer_h layer,
  * 9")
  */
 int ml_train_model_compile_with_single_param(ml_train_model_h model,
+                                             const char *single_param);
+
+/**
+ * @brief Trains the neural network model with params.
+ * @details Use this function to train the compiled neural network model with
+ * the passed training hyperparameters. This function will return once the
+ * training, along with requested validation and testing, is completed.
+ * @since_tizen 7.0
+ * @param[in] model The NNTrainer model handle.
+ * @param[in] single_param Hyperparameters for train model.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ * API to solve va_list issue of Dllimport of C# interop.
+ * The input format of single_param must be 'key = value' format, and it
+ * received as shown in the example below. delimiter is '|'. e.g)
+ * ml_train_model_run_with_single_param(model, "epochs=2 | batch_size=16")
+ */
+int ml_train_model_run_with_single_param(ml_train_model_h model,
+                                         const char *single_param);
 
 #if defined(__TIZEN__)
 /**

--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -321,17 +321,16 @@ int ml_train_model_insert_layer(ml_train_model_h model, ml_train_layer_h layer,
  * any modification to the properties of model or layers/dataset/optimizer in
  * the model will be restricted. Further, addition of layers or changing the
  * optimizer/dataset of the model will not be permitted.
+ * API to solve va_list issue of Dllimport of C# interop.
+ * The input format of single_param must be 'key = value' format, and it
+ * received as shown in the example below. delimiter is '|'. e.g)
+ * ml_train_model_compile_with_single_param(model, "loss=cross|batch_size=9")
  * @param[in] model The NNTrainer model handle.
  * @param[in] single_param hyperparameters for compiling the model
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
- * @details API to solve va_list issue of Dllimport of C# interop.
- * The input format of single_param must be 'key = value' format, and it
- * received as shown in the example below. delimiter is '|'. e.g)
- * ml_train_model_compile_with_single_param(model, "loss = cross`batch_size =
- * 9")
  */
 int ml_train_model_compile_with_single_param(ml_train_model_h model,
                                              const char *single_param);
@@ -342,16 +341,16 @@ int ml_train_model_compile_with_single_param(ml_train_model_h model,
  * the passed training hyperparameters. This function will return once the
  * training, along with requested validation and testing, is completed.
  * @since_tizen 7.0
+ * API to solve va_list issue of Dllimport of C# interop.
+ * The input format of single_param must be 'key = value' format, and it
+ * received as shown in the example below. delimiter is '|'. e.g)
+ * ml_train_model_run_with_single_param(model, "epochs=2|batch_size=16")
  * @param[in] model The NNTrainer model handle.
  * @param[in] single_param Hyperparameters for train model.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
- * API to solve va_list issue of Dllimport of C# interop.
- * The input format of single_param must be 'key = value' format, and it
- * received as shown in the example below. delimiter is '|'. e.g)
- * ml_train_model_run_with_single_param(model, "epochs=2 | batch_size=16")
  */
 int ml_train_model_run_with_single_param(ml_train_model_h model,
                                          const char *single_param);

--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -313,6 +313,28 @@ int ml_train_model_insert_layer(ml_train_model_h model, ml_train_layer_h layer,
                                 const char *input_layer_names[],
                                 const char *output_layer_names[]);
 
+/**
+ * @brief Compiles and finalizes the neural network model with the params.
+ * @details Use this function to initialize neural network model. Various
+ * @since_tizen 7.0
+ * hyperparameter before compile the model can be set. Once compiled,
+ * any modification to the properties of model or layers/dataset/optimizer in
+ * the model will be restricted. Further, addition of layers or changing the
+ * optimizer/dataset of the model will not be permitted.
+ * @param[in] model The NNTrainer model handle.
+ * @param[in] single_param hyperparameters for compiling the model
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ * @details API to solve va_list issue of Dllimport of C# interop.
+ * The input format of single_param must be 'key = value' format, and it
+ * received as shown in the example below. delimiter is '|'. e.g)
+ * ml_train_model_compile_with_single_param(model, "loss = cross`batch_size =
+ * 9")
+ */
+int ml_train_model_compile_with_single_param(ml_train_model_h model,
+
 #if defined(__TIZEN__)
 /**
  * @brief Checks whether machine_learning.training feature is enabled or not.

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -290,10 +290,10 @@ int ml_train_model_construct_with_conf(const char *model_conf,
   return status;
 }
 
-static std::vector<std::string> split_param(std::string singgle_param,
+static std::vector<std::string> split_param(std::string single_param,
                                             char delimiter) {
   std::vector<std::string> param_list;
-  std::stringstream sstream(singgle_param);
+  std::stringstream sstream(single_param);
   std::string param;
 
   while (std::getline(sstream, param, delimiter))
@@ -387,6 +387,43 @@ static int nntrainer_model_run(ml_train_model_h model,
   status = nntrainer_exception_boundary(f);
 
   return status;
+}
+
+int ml_train_model_run_with_single_param(ml_train_model_h model,
+                                         const char *single_param) {
+
+  std::vector<std::string> param_list;
+
+  check_feature_state();
+  ML_TRAIN_VERIFY_VALID_HANDLE(model);
+
+  if (single_param)
+    param_list = split_param(single_param, '|');
+
+  return nntrainer_model_run(model, param_list);
+}
+
+int ml_train_model_run(ml_train_model_h model, ...) {
+  int status = ML_ERROR_NONE;
+  ml_train_model *nnmodel;
+  const char *data;
+  std::shared_ptr<ml::train::Model> m;
+
+  check_feature_state();
+
+  ML_TRAIN_VERIFY_VALID_HANDLE(model);
+
+  std::vector<std::string> arg_list;
+  va_list arguments;
+  va_start(arguments, model);
+
+  while ((data = va_arg(arguments, const char *))) {
+    arg_list.push_back(data);
+  }
+
+  va_end(arguments);
+
+  return nntrainer_model_run(model, arg_list);
 }
 
 int ml_train_model_destroy(ml_train_model_h model) {

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -327,8 +327,8 @@ loadProperties(const std::vector<std::string> &string_vector, Tuple &&props) {
                    std::string key, value;
                    int status = getKeyValue(property, key, value);
                    NNTR_THROW_IF(status != ML_ERROR_NONE, std::invalid_argument)
-                     << "parsing property failed, original format: "
-                     << property;
+                     << "parsing property failed, original format: \""
+                     << property << "\"";
                    return std::make_pair(key, value);
                  });
 

--- a/nntrainer/utils/util_func.cpp
+++ b/nntrainer/utils/util_func.cpp
@@ -130,8 +130,10 @@ int getKeyValue(const std::string &input_str, std::string &key,
                                           input_trimmed.end(), words_regex);
   auto words_end = std::sregex_iterator();
   int nwords = std::distance(words_begin, words_end);
+
   if (nwords != 2) {
-    ml_loge("Error: input string must be 'key = value' format, %s given",
+    ml_loge("Error: input string must be 'key = value' format "
+            "(e.g.{\"key1=value1\",\"key2=value2\"}), \"%s\" given",
             input_trimmed.c_str());
     return ML_ERROR_INVALID_PARAMETER;
   }

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -151,6 +151,25 @@ TEST(nntrainer_capi_nnmodel, compile_01_p) {
 /**
  * @brief Neural Network Model Compile Test
  */
+TEST(nntrainer_capi_nnmodel, compile_with_single_param_01_p) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+
+  ScopedIni s("capi_test_compile_with_single_param_01_p",
+              {model_base, optimizer, dataset, inputlayer, outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status =
+    ml_train_model_compile_with_single_param(handle, "loss=cross|epochs=2");
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Model Compile Test
+ */
 TEST(nntrainer_capi_nnmodel, construct_conf_01_n) {
   ml_train_model_h handle = NULL;
   int status = ML_ERROR_NONE;
@@ -328,6 +347,62 @@ TEST(nntrainer_capi_nnmodel, compile_06_n) {
 }
 
 /**
+ * @brief Neural Network Model Compile Test
+ */
+TEST(nntrainer_capi_nnmodel, compile_with_single_param_01_n) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+
+  ScopedIni s("capi_test_compile_with_single_param_01_n",
+              {model_base, optimizer, dataset, inputlayer, outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status =
+    ml_train_model_compile_with_single_param(handle, "loss=cross epochs=2");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Model Compile Test
+ */
+TEST(nntrainer_capi_nnmodel, compile_with_single_param_02_n) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+
+  ScopedIni s("capi_test_compile_with_single_param_02_n",
+              {model_base, optimizer, dataset, inputlayer, outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status =
+    ml_train_model_compile_with_single_param(handle, "loss=cross,epochs=2");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Model Compile Test
+ */
+TEST(nntrainer_capi_nnmodel, compile_with_single_param_03_n) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+
+  ScopedIni s("capi_test_compile_with_single_param_02_n",
+              {model_base, optimizer, dataset, inputlayer, outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status =
+    ml_train_model_compile_with_single_param(handle, "loss=cross!epochs=2");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+/**
  * @brief Neural Network Model Train Test
  */
 TEST(nntrainer_capi_nnmodel, train_01_p) {
@@ -348,7 +423,35 @@ TEST(nntrainer_capi_nnmodel, train_01_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Compare training statistics */
-  nntrainer_capi_model_comp_metrics(handle, 4.330389, 3.6865699, 10.4167);
+  nntrainer_capi_model_comp_metrics(handle, 3.911289, 2.933979, 10.4167);
+
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Model Train Test
+ */
+TEST(nntrainer_capi_nnmodel, train_with_single_param_01_p) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+
+  ScopedIni s(
+    "capi_test_train_with_single_param_01_p",
+    {model_base, optimizer, dataset + "-BufferSize", inputlayer, outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_compile(handle, NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status =
+    ml_train_model_run_with_single_param(handle, "epochs=2|batch_size=16");
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  /** Compare training statistics */
+  nntrainer_capi_model_comp_metrics(handle, 3.67021, 3.26736, 10.4167);
 
   status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -379,6 +482,81 @@ TEST(nntrainer_capi_nnmodel, train_03_n) {
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_train_model_run(handle, "loss=cross", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Model Train Test
+ */
+TEST(nntrainer_capi_nnmodel, train_with_single_param_01_n) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+
+  ScopedIni s(
+    "capi_test_train_with_single_param_01_n",
+    {model_base, optimizer, dataset + "-BufferSize", inputlayer, outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_compile(handle, NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_run_with_single_param(
+    handle, "epochs=2 batch_size=16 save_path=capi_tizen_model.bin");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Model Train Test
+ */
+TEST(nntrainer_capi_nnmodel, train_with_single_param_02_n) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+
+  ScopedIni s(
+    "capi_test_train_with_single_param_02_n",
+    {model_base, optimizer, dataset + "-BufferSize", inputlayer, outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_compile(handle, NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_run_with_single_param(
+    handle, "epochs=2,batch_size=16,save_path=capi_tizen_model.bin");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Model Train Test
+ */
+TEST(nntrainer_capi_nnmodel, train_with_single_param_03_n) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+
+  ScopedIni s(
+    "capi_test_train_with_single_param_02_n",
+    {model_base, optimizer, dataset + "-BufferSize", inputlayer, outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_compile(handle, NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_run_with_single_param(
+    handle, "epochs=2!batch_size=16!save_path=capi_tizen_model.bin");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
   status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
@@ -924,7 +1102,7 @@ TEST(nntrainer_capi_nnmodel, train_with_file_01_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Compare training statistics */
-  nntrainer_capi_model_comp_metrics(model, 2.111340, 2.209510, 16.6667);
+  nntrainer_capi_model_comp_metrics(model, 2.182019, 2.223670, 22.9167);
 
   status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -1008,7 +1186,7 @@ TEST(nntrainer_capi_nnmodel, train_with_generator_01_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Compare training statistics */
-  nntrainer_capi_model_comp_metrics(model, 2.2063899, 1.983489, 64.583297);
+  nntrainer_capi_model_comp_metrics(model, 2.17419004, 1.94411003, 66.66670227);
 
   status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);


### PR DESCRIPTION
[CAPI] Add internal API for C# DllImport

- ml_train_model_compile() and  ml_train_model_run() has a va_list and this is a problem with DllImport in C#, va_list must be passed dynamically for each architect, this is not guaranteed to work for some architects. so C# will pass the model compile params as a single string