### PR TITLE
[compiler] Revisit tflite interpreter

### DIFF
--- a/Applications/Resnet/jni/main.cpp
+++ b/Applications/Resnet/jni/main.cpp
@@ -195,7 +195,7 @@ std::vector<LayerHandle> createResnet18Graph() {
 /// @todo update createResnet18 to be more generic
 ModelHandle createResnet18() {
   ModelHandle model = ml::train::createModel(ml::train::ModelType::NEURAL_NET,
-                                             {withKey("loss", "cross")});
+                                             {withKey("loss", "mse")});
 
   for (auto layer : createResnet18Graph()) {
     model->addLayer(layer);
@@ -258,6 +258,9 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
                     std::move(dataset_valid));
 
   model->train();
+
+  model->exports(ml::train::ExportMethods::METHOD_TFLITE, "resnet_test.tflite");
+
 #if defined(ENABLE_TEST)
   training_loss = model->getTrainingLoss();
   validation_loss = model->getValidationLoss();

--- a/nntrainer/compiler/tflite_opnode.cpp
+++ b/nntrainer/compiler/tflite_opnode.cpp
@@ -25,6 +25,7 @@ TfOpNode::TfOpNode() :
   is_input(false),
   is_output(false),
   node_owned_variable(),
+  /// @todo distinguish between uninitialized and ADD operator.
   op_type(tflite::BuiltinOperator_ADD),
   builtin_ops(),
   builtin_option_type(tflite::BuiltinOptions_NONE){};
@@ -32,6 +33,33 @@ TfOpNode::TfOpNode() :
 void TfOpNode::setLayerNode(const LayerNode &layer) {
   is_input = layer.getNumInputConnections() == 0;
   is_output = layer.getNumOutputConnections() == 0;
+  /// @todo support more loss layers
+  static const std::set<std::string> loss_type = {"mse", "cross"};
+  /** set to graph output node if output connection of the node includes loss
+   *layer string
+   *  @note this is workaround because it cannot be guaranteed that a loss layer
+   *always has a loss type in its name.
+   *
+   *  There are two ways to pass `GraphRepresentation` parameters to `serialize`
+   *method.
+   *
+   *  1. with loss layer at the end of the graph
+   *  2. wihtout loss layer but last node has loss layer output connection
+   *
+   *  Loss layer of the first case is removed by `LossRealizer` and the previous
+   *layer of the loss layer is set as the output node. And, the below logic is
+   *for the second case.
+   **/
+  /// aussume that loss layers have single output
+  if (layer.getNumOutputConnections() == 1) {
+    for (auto loss : loss_type) {
+      if (layer.getOutputConnections()[0].find(loss) != std::string::npos) {
+        is_output = true;
+      }
+    }
+  }
+  /// @todo support more virtual nodes
+  is_virtual = layer.getType() == "multiout";
 
   auto &context = layer.getRunContext();
   auto create_variables = [](auto tensor_getter, unsigned size) {
@@ -43,10 +71,31 @@ void TfOpNode::setLayerNode(const LayerNode &layer) {
     return v;
   };
 
+  /**
+   * Q1) Why convert from NCHW to NHWC?
+   * A1) the tflite uses NHWC format; nntrainer uses NCHW
+   *
+   * Q2) Why are only output tensors reshaped?
+   * A2) the tflite needs only one tensor between nodes. Therefore,
+   *basically, outputs are used for tflite tensors
+   **/
+  auto create_variables_with_NCHW_to_NHWC = [](auto tensor_getter,
+                                               unsigned size) {
+    Variables v;
+    v.reserve(size);
+    for (unsigned i = 0; i < size; ++i) {
+      Tensor *tensor = const_cast<Tensor *>(tensor_getter(i));
+      tensor->reshape(TensorDim{tensor->batch(), tensor->height(),
+                                tensor->width(), tensor->channel()});
+      v.push_back(tensor);
+    }
+    return v;
+  };
+
   inputs = create_variables(
     [&context](unsigned idx) { return &context.getInput(idx); },
     context.getNumInputs());
-  outputs = create_variables(
+  outputs = create_variables_with_NCHW_to_NHWC(
     [&context](unsigned idx) { return &context.getOutput(idx); },
     context.getNumOutputs());
   weights = create_variables(
@@ -61,12 +110,20 @@ void TfOpNode::setLayerNode(const LayerNode &layer) {
 
 void TfOpNode::setWeightTransformFn(TransformFn fn) { weight_transform = fn; }
 
+void TfOpNode::setInputTransformFn(TransformFn fn) { input_transform = fn; }
+
 void TfOpNode::finalize() {
   auto transform_if = [this](TransformFn &fn, Variables &v) {
     if (fn) {
       auto result = fn(v);
-      NNTR_THROW_IF(result.size() != v.size(), std::invalid_argument)
-        << "result size must match with given variable size";
+      v.resize(result.size());
+      /// basically, result.size() == v.size() except InputLayer because a
+      /// Transpose operator is added for converting nchw to nhwc
+      /// @todo comment out below codes. TfOpNode needs to have LayerNode
+      /// pointer
+      // NNTR_THROW_IF(dynamic_cast<InputLayer>(layer_ptr->getLayer()) ==
+      // nulltpr && result.size() != v.size(), std::invalid_argument)
+      //   << "result size must match with given variable size";
       node_owned_variable.insert(node_owned_variable.end(), result.begin(),
                                  result.end());
       std::transform(node_owned_variable.end() - result.size(),
@@ -76,15 +133,22 @@ void TfOpNode::finalize() {
   };
 
   transform_if(weight_transform, weights);
+  transform_if(input_transform, inputs);
 }
 
-flatbuffers::Offset<void>
-TfOpNode::getBuiltinOps(flatbuffers::FlatBufferBuilder &f) const {
+flatbuffers::Offset<void> TfOpNode::getBuiltinOps() const {
   switch (op_type) {
+  case tflite::BuiltinOperator_ADD:
+  case tflite::BuiltinOperator_AVERAGE_POOL_2D:
+  case tflite::BuiltinOperator_CONV_2D:
   case tflite::BuiltinOperator_FULLY_CONNECTED:
-    return tflite::CreateFullyConnectedOptions(f).Union();
-  default:
+  case tflite::BuiltinOperator_RELU:
+  case tflite::BuiltinOperator_RESHAPE:
+  case tflite::BuiltinOperator_SOFTMAX:
+  case tflite::BuiltinOperator_TRANSPOSE:
     return builtin_ops;
+  default:
+    throw std::runtime_error{"Unsupproted operator"};
   }
 }
 

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -12,20 +12,47 @@
 #include <node_exporter.h>
 
 #ifdef ENABLE_TFLITE_INTERPRETER
+#include <activation_layer.h>
+#include <bitset>
 #include <common_properties.h>
 #include <fc_layer.h>
+#include <map>
 #include <node_exporter.h>
 #include <tf_schema_generated.h>
 #include <tflite_opnode.h>
 #endif
 
+namespace {
+
+tflite::Padding tflite_padding(const std::string &padding) {
+  std::map<std::string, tflite::Padding> m = {{"same", tflite::Padding_SAME},
+                                              {"valid", tflite::Padding_VALID}};
+  return m[padding];
+}
+
+} // namespace
+
 namespace nntrainer {
+
+constexpr const unsigned int CONV2D_DIM = 2;
+constexpr const unsigned int POOLING2D_DIM = 2;
 
 /**
  * @brief Construct a new Exporter object
  *
  */
 Exporter::Exporter() : stored_result(nullptr), is_exported(false) {}
+
+#ifdef ENABLE_TFLITE_INTERPRETER
+/**
+ * @brief Construct a new Exporter object with flatbuffer builder
+ *
+ */
+Exporter::Exporter(flatbuffers::FlatBufferBuilder *fbb) :
+  fbb(fbb),
+  stored_result(nullptr),
+  is_exported(false) {}
+#endif
 
 /**
  * @brief Destroy the Exporter object
@@ -81,24 +108,197 @@ void Exporter::saveTflResult(const std::tuple<props::Unit> &props,
   auto weight_transform = [](std::vector<const Tensor *> &weights) {
     std::vector<Tensor> new_weights;
     new_weights.reserve(weights.size());
-
-    // std::cerr << "weights! " << weights.size() << ' ' <<
-    // new_weights.capacity() << std::endl; std::transform(weights.begin(),
-    // weights.end(),
-    //                std::back_inserter(new_weights),
-    //                [](const Tensor *t) { return t->clone(); });
-    // std::cerr << "22\n";
     new_weights.push_back(weights[0]->transpose("0:2:1"));
     new_weights.push_back(*weights[1]);
-    // std::cerr << "33\n";
     return new_weights;
   };
   tf_node->setWeightTransformFn(weight_transform);
 
   tf_node->setOpType(tflite::BuiltinOperator_FULLY_CONNECTED);
-  /// we probably going to need flatbuffer inside exporter regarding this
+  auto options = tflite::CreateFullyConnectedOptions(*fbb).Union();
   tf_node->setBuiltinOptions(tflite::BuiltinOptions_FullyConnectedOptions,
+                             options);
+}
+
+template <>
+void Exporter::saveTflResult(const std::tuple<props::Activation> &props,
+                             const ActivationLayer *self) {
+  createIfNull(tf_node);
+
+  auto activation = std::get<props::Activation>(props);
+  switch (activation.get()) {
+  case ActivationType::ACT_RELU: {
+    tf_node->setOpType(tflite::BuiltinOperator_RELU);
+    tf_node->setBuiltinOptions(tflite::BuiltinOptions_NONE,
+                               flatbuffers::Offset<void>() /** no options **/);
+    break;
+  }
+  case ActivationType::ACT_SOFTMAX: {
+    tf_node->setOpType(tflite::BuiltinOperator_SOFTMAX);
+    auto optinos = tflite::CreateSoftmaxOptions(*fbb, 1.0).Union();
+    tf_node->setBuiltinOptions(tflite::BuiltinOptions_SoftmaxOptions, optinos);
+    break;
+  }
+  default:
+    throw std::runtime_error{"Unsupported activation type"};
+  }
+}
+
+template <>
+void Exporter::saveTflResult(
+  const std::tuple<props::FilterSize, std::array<props::KernelSize, CONV2D_DIM>,
+                   std::array<props::Stride, CONV2D_DIM>, props::Padding2D>
+    &props,
+  const Conv2DLayer *self) {
+  createIfNull(tf_node);
+
+  auto weight_transform = [](std::vector<const Tensor *> &old_weights) {
+    std::vector<Tensor> new_weights;
+
+    auto &filter_weight = *old_weights[0];
+    // tflite filter has shape format {channel_out, height, width, channel_in}
+    Tensor filter(filter_weight.transpose("1:2:0"));
+    new_weights.push_back(filter);
+
+    auto &bias_weight = *old_weights[1];
+    TensorDim bias_dim{std::bitset<4>(0b0001)};
+    bias_dim.setTensorDim(
+      3 /** index **/,
+      bias_weight
+        .channel() /** value **/); // effective dimension = {bias->channel()}
+    Tensor bias(bias_dim);
+    bias.copyData(bias_weight.transpose("1:2:0"));
+    bias.setName(bias_weight.getName());
+
+    new_weights.push_back(bias);
+
+    return new_weights;
+  };
+  tf_node->setWeightTransformFn(weight_transform);
+
+  tf_node->setOpType(tflite::BuiltinOperator_CONV_2D);
+
+  auto strides = std::get<std::array<props::Stride, CONV2D_DIM>>(props);
+  assert(strides.size() == CONV2D_DIM);
+  auto padding = std::get<props::Padding2D>(props).get();
+  assert(padding == "same" || padding == "valid");
+  auto options = tflite::CreateConv2DOptions(*fbb, tflite_padding(padding),
+                                             strides.at(0), strides.at(1))
+                   .Union();
+  tf_node->setBuiltinOptions(tflite::BuiltinOptions_Conv2DOptions, options);
+}
+
+template <>
+void Exporter::saveTflResult(
+  const std::tuple<props::Normalization, props::Standardization> &props,
+  const InputLayer *self) {
+  createIfNull(tf_node);
+  // input layer exports to Transpose operator (NCHW -> NHWC)
+  tf_node->setOpType(tflite::BuiltinOperator_TRANSPOSE);
+  tf_node->setBuiltinOptions(tflite::BuiltinOptions_TransposeOptions,
                              flatbuffers::Offset<void>());
+
+  auto input_transform = [](std::vector<const Tensor *> &inputs) {
+    std::vector<Tensor> new_inputs;
+    assert(inputs.size() == 1);
+    new_inputs.reserve(inputs.size() + 1 /** perm **/);
+    new_inputs.push_back(*inputs[0]);
+    // create "perm" tensor for Transpose operator
+    TensorDim perm_dim{std::bitset<4>(0b0001)};
+    perm_dim.setTensorDim(3 /** index **/,
+                          4 /** value **/); // effective dimension = {4}
+    new_inputs.emplace_back(perm_dim);
+    auto &perm = new_inputs.back();
+    perm.setName("nntrainer_internal_perm");
+    perm.setValueInt(0, 0 /** N **/);
+    perm.setValueInt(1, 2 /** H **/);
+    perm.setValueInt(2, 3 /** W **/);
+    perm.setValueInt(3, 1 /** C **/);
+    return new_inputs;
+  };
+  tf_node->setInputTransformFn(input_transform);
+
+  assert(tf_node->getOutputs().size() == 1);
+  auto output_tensor = const_cast<Tensor *>(tf_node->getOutputs()[0]);
+  // Transpose op needs buffer
+  output_tensor->allocate();
+}
+
+template <>
+void Exporter::saveTflResult(
+  const std::tuple<props::PoolingType, std::vector<props::PoolSize>,
+                   std::array<props::Stride, POOLING2D_DIM>, props::Padding2D>
+    &props,
+  const Pooling2DLayer *self) {
+  createIfNull(tf_node);
+
+  auto poolingType = std::get<props::PoolingType>(props);
+  auto strides = std::get<std::array<props::Stride, POOLING2D_DIM>>(props);
+  assert(strides.size() == POOLING2D_DIM);
+  auto poolSize = std::get<std::vector<props::PoolSize>>(props);
+  assert(poolSize.size() == POOLING2D_DIM);
+  auto padding = std::get<props::Padding2D>(props).get();
+  assert(padding == "same" || padding == "valid");
+
+  switch (poolingType.get()) {
+  case props::PoolingTypeInfo::Enum::average: {
+    tf_node->setOpType(tflite::BuiltinOperator_AVERAGE_POOL_2D);
+    auto options =
+      tflite::CreatePool2DOptions(*fbb, tflite_padding(padding), strides.at(0),
+                                  strides.at(1), poolSize.at(0), poolSize.at(1))
+        .Union();
+    tf_node->setBuiltinOptions(tflite::BuiltinOptions_Pool2DOptions, options);
+    break;
+  }
+  default:
+    throw std::runtime_error{"Unsupported poolings type"};
+  }
+}
+
+template <>
+void Exporter::saveTflResult(const std::tuple<props::TargetShape> &props,
+                             const ReshapeLayer *self) {
+  createIfNull(tf_node);
+
+  tf_node->setOpType(tflite::BuiltinOperator_RESHAPE);
+  auto targetShape = std::get<props::TargetShape>(props).get();
+  std::vector<int32_t> new_shape_vec = {
+    static_cast<int32_t>(targetShape.batch()),
+    static_cast<int32_t>(targetShape.height()),
+    static_cast<int32_t>(targetShape.width()),
+    static_cast<int32_t>(targetShape.channel())};
+  auto new_shape = fbb->CreateVector(new_shape_vec);
+  auto options = tflite::CreateReshapeOptions(*fbb, new_shape).Union();
+  tf_node->setBuiltinOptions(tflite::BuiltinOptions_ReshapeOptions, options);
+}
+
+template <>
+void Exporter::saveTflResult(const std::tuple<props::TargetShape> &props,
+                             const FlattenLayer *self) {
+  createIfNull(tf_node);
+
+  tf_node->setOpType(tflite::BuiltinOperator_RESHAPE);
+  auto targetShape = std::get<props::TargetShape>(props).get();
+
+  /// @todo new shape should be 2 rank {batch, channel * height * width}
+  std::vector<int32_t> new_shape_vec = {
+    static_cast<int32_t>(targetShape.batch()),
+    static_cast<int32_t>(targetShape.height()),
+    static_cast<int32_t>(targetShape.width()),
+    static_cast<int32_t>(targetShape.channel())};
+  auto new_shape = fbb->CreateVector(new_shape_vec);
+  auto options = tflite::CreateReshapeOptions(*fbb, new_shape).Union();
+  tf_node->setBuiltinOptions(tflite::BuiltinOptions_ReshapeOptions, options);
+}
+
+template <>
+void Exporter::saveTflResult(const std::tuple<> &props,
+                             const AdditionLayer *self) {
+  createIfNull(tf_node);
+
+  tf_node->setOpType(tflite::BuiltinOperator_ADD);
+  auto options = tflite::CreateAddOptions(*fbb).Union();
+  tf_node->setBuiltinOptions(tflite::BuiltinOptions_AddOptions, options);
 }
 #endif
 


### PR DESCRIPTION
This patch revisits tflite interpreter.

1. Refactor the way of exporting tflite binary.
2. Support operators included in Resnet network.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Related: #1879 
Signed-off-by: seongwoo <mhs4670go@naver.com>