### PR TITLE
[ccapi] include common header in meson

### DIFF
--- a/api/ccapi/meson.build
+++ b/api/ccapi/meson.build
@@ -10,6 +10,7 @@ ccapi_src = []
 ccapi_src += meson.current_source_dir() / 'src' / 'factory.cpp'
 
 ccapi_headers = []
+ccapi_headers += meson.current_source_dir() / 'include' / 'common.h'
 ccapi_headers += meson.current_source_dir() / 'include' / 'dataset.h'
 ccapi_headers += meson.current_source_dir() / 'include' / 'layer.h'
 ccapi_headers += meson.current_source_dir() / 'include' / 'model.h'

--- a/debian/ccapi-ml-training-dev.install
+++ b/debian/ccapi-ml-training-dev.install
@@ -1,3 +1,4 @@
+/usr/include/nntrainer/common.h
 /usr/include/nntrainer/model.h
 /usr/include/nntrainer/layer.h
 /usr/include/nntrainer/optimizer.h

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -523,6 +523,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_libdir}/libccapi-nntrainer.so
 
 %files -n ccapi-machine-learning-training-devel
+%{_includedir}/nntrainer/common.h
 %{_includedir}/nntrainer/model.h
 %{_includedir}/nntrainer/layer.h
 %{_includedir}/nntrainer/optimizer.h


### PR DESCRIPTION
 - Newly created common header file was missing in meson build

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>