### PR TITLE
[Utils] Add Memory profile feature to Profiler

### DIFF
--- a/Applications/MNIST/jni/main.cpp
+++ b/Applications/MNIST/jni/main.cpp
@@ -222,8 +222,9 @@ int main(int argc, char *argv[]) {
   }
 
 #ifdef PROFILE
-  nntrainer::profile::GenericProfileListener listener(
-    &nntrainer::profile::Profiler::Global());
+  auto listener =
+    std::make_shared<nntrainer::profile::GenericProfileListener>();
+  nntrainer::profile::Profiler::Global().subscribe(listener);
 #endif
 
   const std::vector<std::string> args(argv + 1, argv + argc);
@@ -301,7 +302,7 @@ int main(int argc, char *argv[]) {
   }
 
 #ifdef PROFILE
-  std::cout << listener;
+  std::cout << *listener;
 #endif
 
 #if defined(APP_VALIDATE)

--- a/meson.build
+++ b/meson.build
@@ -262,6 +262,7 @@ if get_option('enable-tflite-interpreter')
   extra_defines += '-DENABLE_TFLITE_INTERPRETER=1'
 endif
 
+gmock_dep = dependency('gmock', static: true, required: false)
 gtest_dep = dependency('gtest', static: true, main: false, required: false)
 gtest_main_dep = dependency('gtest', static: true, main: true, required: false)
 

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -332,9 +332,9 @@ void NetworkGraph::applyGradients(
 sharedConstTensors NetworkGraph::forwarding(bool training) const {
   for (auto iter = cbegin(); iter != cend(); iter++) {
     auto const &ln = *iter;
-    START_PROFILE(profile_keys.at(ln->getType()));
+    PROFILE_TIME_START(profile_keys.at(ln->getType()));
     ln->forwarding(training);
-    END_PROFILE(profile_keys.at(ln->getType()));
+    PROFILE_TIME_END(profile_keys.at(ln->getType()));
   }
 
   sharedConstTensors out;
@@ -371,9 +371,9 @@ void NetworkGraph::backwarding(
 
   for (auto iter = iter_begin; iter != iter_end; iter++) {
     auto &ln = *iter;
-    START_PROFILE(profile_keys.at(ln->getType()));
+    PROFILE_TIME_START(profile_keys.at(ln->getType()));
     backwarding_op(ln, iteration);
-    END_PROFILE(profile_keys.at(ln->getType()));
+    PROFILE_TIME_END(profile_keys.at(ln->getType()));
   }
 
   /** perform clipping of the gradients by global norm if any */
@@ -828,7 +828,7 @@ int NetworkGraph::initialize(const std::vector<Connection> &model_input_names,
 
     if (profile_keys.find(lnode->getType()) == profile_keys.end()) {
       int event_key = 0;
-      REGISTER_EVENT(lnode->getType(), event_key);
+      PROFILE_TIME_REGISTER_EVENT(event_key, lnode->getType());
       profile_keys[lnode->getType()] = event_key;
     }
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -577,9 +577,11 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims) {
   };
 #endif
 
-  REGISTER_EVENT(profile_name(FORWARD_SUFFIX), forward_event_key);
-  REGISTER_EVENT(profile_name(CALC_DERIV_SUFFIX), calc_deriv_event_key);
-  REGISTER_EVENT(profile_name(CALC_GRAD_SUFFIX), calc_grad_event_key);
+  PROFILE_TIME_REGISTER_EVENT(forward_event_key, profile_name(FORWARD_SUFFIX));
+  PROFILE_TIME_REGISTER_EVENT(calc_deriv_event_key,
+                              profile_name(CALC_DERIV_SUFFIX));
+  PROFILE_TIME_REGISTER_EVENT(calc_grad_event_key,
+                              profile_name(CALC_GRAD_SUFFIX));
 
   return init_context;
 }
@@ -589,9 +591,9 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims) {
  */
 void LayerNode::forwarding(bool training) {
   loss->set(run_context->getRegularizationLoss());
-  START_PROFILE(forward_event_key);
+  PROFILE_TIME_START(forward_event_key);
   layer->forwarding(*run_context, training);
-  END_PROFILE(forward_event_key);
+  PROFILE_TIME_END(forward_event_key);
 
 #ifdef DEBUG
   if (!run_context->validate(getNumInputConnections() == 0, !requireLabel()))
@@ -608,9 +610,9 @@ void LayerNode::forwarding(bool training) {
  * @brief     calc the derivative to be passed to the previous layer
  */
 void LayerNode::calcDerivative() {
-  START_PROFILE(calc_deriv_event_key);
+  PROFILE_TIME_START(calc_deriv_event_key);
   layer->calcDerivative(*run_context);
-  END_PROFILE(calc_deriv_event_key);
+  PROFILE_TIME_END(calc_deriv_event_key);
 
 #ifdef DEBUG
   if (!run_context->validate(getNumInputConnections() == 0, !requireLabel()))
@@ -623,10 +625,10 @@ void LayerNode::calcDerivative() {
  * @brief     Calculate the derivative of a layer
  */
 void LayerNode::calcGradient() {
-  START_PROFILE(calc_grad_event_key);
+  PROFILE_TIME_START(calc_grad_event_key);
   if (needs_calc_gradient)
     layer->calcGradient(*run_context);
-  END_PROFILE(calc_grad_event_key);
+  PROFILE_TIME_END(calc_grad_event_key);
 
 #ifdef DEBUG
   if (!run_context->validate(getNumInputConnections() == 0, !requireLabel()))

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -558,9 +558,11 @@ sharedConstTensors NeuralNetwork::inference(sharedConstTensors X,
 
   allocate(ExecutionMode::INFERENCE);
 
-  START_PROFILE(profile::NN_FORWARD);
+  int nn_foward;
+  PROFILE_TIME_REGISTER_EVENT(nn_foward, "nn_forward");
+  PROFILE_TIME_START(nn_foward);
   out = forwarding(X, label, false);
-  END_PROFILE(profile::NN_FORWARD);
+  PROFILE_TIME_END(nn_foward);
 
   if (free_mem)
     /**

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -10,12 +10,13 @@
  * @brief  This is Memory Pool Class
  */
 
+#include <limits>
 #include <numeric>
 #include <vector>
-#include <limits>
 
 #include <memory_pool.h>
 #include <nntrainer_error.h>
+#include <profiler.h>
 
 namespace nntrainer {
 
@@ -90,6 +91,14 @@ void MemoryPool::allocate() {
   if (mem_pool == nullptr)
     throw std::runtime_error(
       "Failed to allocate memory: " + std::to_string(pool_size) + "bytes");
+
+#ifdef PROFILE
+  static long long seq = 0;
+
+  std::string msg("MemoryPool #");
+  msg.append(std::to_string(seq++));
+  PROFILE_MEM_ALLOC(mem_pool, pool_size, msg);
+#endif
 }
 
 /**
@@ -108,8 +117,10 @@ void *MemoryPool::getMemory(unsigned int idx) {
  *
  */
 void MemoryPool::deallocate() {
-  if (mem_pool != nullptr)
+  if (mem_pool != nullptr) {
     free(mem_pool);
+    PROFILE_MEM_DEALLOC(mem_pool);
+  }
 
   mem_pool = nullptr;
 }

--- a/nntrainer/utils/profiler.h
+++ b/nntrainer/utils/profiler.h
@@ -12,50 +12,91 @@
  */
 #ifndef __PROFILER_H__
 #define __PROFILER_H__
-#ifndef PROFILE
-
-#define START_PROFILE(event_key)
-#define END_PROFILE(event_key)
-#define REGISTER_EVENT(event_key, ret)
-
-#else
-
-#define START_PROFILE(event_key)                         \
-  do {                                                   \
-    auto &prof = nntrainer::profile::Profiler::Global(); \
-    prof.start(event_key);                               \
-  } while (0);
-
-#define END_PROFILE(event_key)                           \
-  do {                                                   \
-    auto &prof = nntrainer::profile::Profiler::Global(); \
-    prof.end(event_key);                                 \
-  } while (0);
-
-#define REGISTER_EVENT(event_str, ret)                   \
-  do {                                                   \
-    auto &prof = nntrainer::profile::Profiler::Global(); \
-    ret = prof.registerEvent(event_str);                 \
-  } while (0);
-
-#endif /** PROFILE */
 
 #include <chrono>
 #include <future>
 #include <iosfwd>
+#include <list>
 #include <mutex>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+using timepoint = std::chrono::time_point<std::chrono::steady_clock>;
+
+#ifndef PROFILE
+
+#define PROFILE_TIME_START(event_key)
+#define PROFILE_TIME_END(event_key)
+#define PROFILE_TIME_REGISTER_EVENT(event_key, event_str)
+#define PROFILE_MEM_ALLOC(ptr, size, str)
+#define PROFILE_MEM_DEALLOC(ptr)
+
+#else /** PROFILE */
+
+#define PROFILE_TIME_START(event_key) \
+  nntrainer::profile::Profiler::Global().start(event_key)
+
+#define PROFILE_TIME_END(event_key) \
+  nntrainer::profile::Profiler::Global().end(event_key)
+
+#define PROFILE_TIME_REGISTER_EVENT(event_key, event_str)                 \
+  do {                                                                    \
+    event_key =                                                           \
+      nntrainer::profile::Profiler::Global().registerTimeItem(event_str); \
+  } while (0)
+
+#define PROFILE_MEM_ALLOC(ptr, size, str) \
+  nntrainer::profile::Profiler::Global().alloc(ptr, size, str)
+
+#define PROFILE_MEM_DEALLOC(ptr) \
+  nntrainer::profile::Profiler::Global().dealloc(ptr)
+
+#endif /** PROFILE */
+
 namespace nntrainer {
+
 namespace profile {
 
-typedef enum {
-  NN_FORWARD = 1 /**< Neuralnet single inference without loss calculation */,
-} EVENT;
+enum PROFILE_EVENT {
+  EVENT_TIME_START = 0,
+  EVENT_TIME_END = 1,
+  EVENT_MEM_ALLOC = 2,
+  EVENT_MEM_DEALLOC = 3,
+};
+
+/**
+ * @brief Data for each profile event
+ *
+ */
+struct ProfileEventData {
+public:
+  /**
+   * @brief Construct a new ProfileEventData struct
+   *
+   */
+  ProfileEventData(int item, size_t size, std::string str,
+                   std::chrono::microseconds dur) :
+    time_item(item),
+    total_alloc_size(size),
+    event_str(str),
+    duration(dur) {}
+
+  /* for time profile */
+  int time_item;
+
+  /* for memory profile */
+  size_t total_alloc_size;
+
+  /* common data */
+  std::string event_str;
+  std::chrono::microseconds duration;
+};
 
 class Profiler;
+
 /**
  * @brief Generic profile listener class to attach to a profiler,
  * this can be inherited to create a custom profile listener
@@ -65,41 +106,38 @@ public:
   /**
    * @brief Construct a new Profile Listener object
    *
-   * @param profiler_ profiler that this listener is bound to. Unsubscribe will
-   * be called when destruction
-   * @param events events for this profiler to listen to
    */
-  ProfileListener(Profiler *profiler_, std::vector<int> events);
+  explicit ProfileListener() = default;
 
   /**
    * @brief Destroy the Base Profile Listener object
    *
    */
-  virtual ~ProfileListener() noexcept;
+  virtual ~ProfileListener() noexcept = default;
 
   /**
    * @brief A callback function to be called from a profiler
    *
-   * @param event event key to store the result
-   * @param value time value from the profiler
+   * @param event event type
+   * @param data event data
    */
-  virtual void onNotify(const int event,
-                        const std::chrono::microseconds &value) = 0;
+  virtual void notify(PROFILE_EVENT event,
+                      const std::shared_ptr<ProfileEventData> data) = 0;
 
   /**
    * @brief resets the listener to the inital state for a particular key
    *
-   * @param event event which profiler should notice
+   * @param time_item time item which will be reset
    */
-  virtual void reset(const int event) = 0;
+  virtual void reset(const int time_item, const std::string &str) = 0;
 
   /**
    * @brief get the latest result of a event
    *
-   * @param event event to query the result
+   * @param time_item time item to query the result
    * @return const std::chrono::microseconds
    */
-  virtual const std::chrono::microseconds result(const int event) = 0;
+  virtual const std::chrono::microseconds result(const int time_item) = 0;
 
   /**
    * @brief report the result
@@ -107,9 +145,6 @@ public:
    * @param out outstream object to make a report
    */
   virtual void report(std::ostream &out) const = 0;
-
-protected:
-  Profiler *profiler;
 };
 
 /**
@@ -121,18 +156,12 @@ public:
   /**
    * @brief Construct a new GenericProfile Listener object
    *
-   * @param profiler profiler that this listener is bound to. pass null if empty
-   * @param warmups_ ignore first @a warmups_ records when making report
+   * @param warmups_ ignore first @a warmups_ records when making time report
    */
-  GenericProfileListener(Profiler *profiler, std::vector<int> events = {},
-                         int warmups_ = 0) :
-    ProfileListener(profiler, events),
+  explicit GenericProfileListener(int warmups_ = 0) :
+    ProfileListener(),
     start_time(std::chrono::steady_clock::now()),
-    warmups(warmups_) {
-    for (auto &event : events) {
-      reset(event);
-    }
-  }
+    warmups(warmups_) {}
 
   /**
    * @brief Destroy the Generic Profile Listener object
@@ -141,16 +170,18 @@ public:
   virtual ~GenericProfileListener() = default;
 
   /**
-   * @copydoc ProfileListener::onNotify(const int event, const
-   * std::chrono::microseconds &value)
+   * @brief A callback function to be called from a profiler
+   *
+   * @param event event type
+   * @param data event data
    */
-  virtual void onNotify(const int event,
-                        const std::chrono::microseconds &value) override;
+  virtual void notify(PROFILE_EVENT event,
+                      const std::shared_ptr<ProfileEventData> data) override;
 
   /**
-   * @copydoc ProfileListener::reset(const int event)
+   * @copydoc ProfileListener::reset(const int time_item)
    */
-  virtual void reset(const int event) override;
+  virtual void reset(const int time_item, const std::string &str) override;
 
   /**
    * @copydoc ProfileListener::result(const int event)
@@ -163,6 +194,22 @@ public:
   virtual void report(std::ostream &out) const override;
 
 private:
+  /**
+   * @brief Called when time event occurs
+   *
+   */
+  void onNotifyTimeEvent(PROFILE_EVENT event, const int time_item,
+                         const std::string &str,
+                         const std::chrono::microseconds &duration);
+
+  /**
+   * @brief Called when memory event occurs
+   *
+   */
+  void onNotifyMemoryEvent(PROFILE_EVENT event, const size_t total_alloc_size,
+                           const std::string &str,
+                           const std::chrono::microseconds &duration);
+
   std::chrono::time_point<std::chrono::steady_clock> start_time;
   unsigned int warmups;
 
@@ -179,11 +226,11 @@ private:
                                      unsigned int /** CNT */>>
     time_taken;
 
-  /**
-   * @brief iterator for the time_taken
-   *
-   */
-  decltype(time_taken)::iterator time_iter;
+  std::list<
+    std::tuple<PROFILE_EVENT, size_t, std::string, std::chrono::microseconds>>
+    mem_taken;
+
+  std::unordered_map<int, std::string> names;
 };
 
 /**
@@ -207,7 +254,7 @@ public:
    * @brief Construct a new Profiler object
    *
    */
-  Profiler() {}
+  Profiler() : total_size(0) {}
 
   /**
    * @brief Deleted constructor
@@ -218,27 +265,41 @@ public:
 
   /**
    *
-   * @brief Get Global app context.
+   * @brief Get Global Profiler
    *
-   * @return AppContext&
+   * @return Profiler&
    */
   static Profiler &Global();
 
   /**
-   * @brief start profile
+   * @brief start time profile
    *
-   * @param key to record the profile result. Either designated key from enum
-   * or arbitrary key can be used
+   * @param time_item time item to be recorded
    */
-  void start(const int &key);
+  void start(const int time_item);
 
   /**
-   * @brief end profile and notify to the listeners
+   * @brief end time profile and notify to the listeners
    *
-   * @param key to record the profile result. Either designated key from enum
-   * or arbitrary key can be used
+   * @param time_item time item to be finished
    */
-  void end(const int &key);
+  void end(const int time_item);
+
+  /**
+   * @brief trace memory allocation
+   *
+   * @param ptr allocated memory pointer
+   * @param size amount of allocated memory
+   * @param str information string
+   */
+  void alloc(const void *ptr, size_t size, const std::string &str);
+
+  /**
+   * @brief trace memory de-allocation
+   *
+   * @param ptr de-allocated memory pointer
+   */
+  void dealloc(const void *ptr);
 
   /**
    * @brief subscribe a listener to the profiler
@@ -249,15 +310,15 @@ public:
    * to all events
    * @throw std::invalid_argument if listener is already registered
    */
-  void subscribe(ProfileListener *listener,
-                 const std::vector<int> &events = {});
+  void subscribe(std::shared_ptr<ProfileListener> listener,
+                 const std::set<int> &time_item = {});
 
   /**
    * @brief unsubscribe a listener from the profiler
    *
    * @param listener listener to unsubscribe
    */
-  void unsubscribe(ProfileListener *listener);
+  void unsubscribe(std::shared_ptr<ProfileListener> listener);
 
   /**
    * @brief registerEvent to record.
@@ -265,14 +326,7 @@ public:
    *
    * @return int return NEGATIVE integer to distinguish from reserved events
    */
-  int registerEvent(const std::string &name);
-
-  /**
-   * @brief get string representation of an event
-   *
-   * @return std::string name
-   */
-  std::string eventToStr(const int event);
+  int registerTimeItem(const std::string &name);
 
 private:
   /**
@@ -281,31 +335,32 @@ private:
    * @param event event to notify
    * @param value measured value from the profiler
    */
-  void notify(const int &event, const std::chrono::microseconds &value);
+  void notifyListeners(PROFILE_EVENT event,
+                       const std::shared_ptr<ProfileEventData> data);
 
-  std::unordered_set<ProfileListener *>
-    all_registered_listeners; /**< prevent registering listener twice */
+  std::unordered_set<std::shared_ptr<ProfileListener>>
+    listeners; /**< event listeners */
 
-  std::unordered_set<ProfileListener *>
-    all_event_listeners; /**< listeners listen to every events */
+  std::unordered_map<int, std::string>
+    time_item_names; /**< registered item names (time_item, string) */
+  std::unordered_map<int, timepoint>
+    time_item_times; /**< registered time items (time_item, time) */
+  std::unordered_map<int, std::set<std::shared_ptr<ProfileListener>>>
+    time_item_listeners;
+  /**< registered listeners for each itemtems (time_item, listeners) */
 
-  std::unordered_map<int, std::unordered_set<ProfileListener *>>
-    event_listeners; /**< listeners for an events */
+  std::unordered_map<const void *, std::tuple<size_t, timepoint, std::string>>
+    allocates; /**< allocated memory information (ptr, (size, time, info) */
 
-  std::unordered_map<int, std::chrono::time_point<std::chrono::steady_clock>>
-    start_time; /**< start_time of the clock */
+  std::atomic<std::size_t> total_size; /**< total allocated memory size */
 
-  std::vector<std::string>
-    custom_events; /**< integer indexed custom events. Actual key is negative to
-                      avoid clashing */
-
-  std::mutex event_registration_mutex; /**< protect custom event registration */
-
-  std::mutex subscription_mutex; /**< protect sub/unsub routine to
-                                             gaurantee invarient */
+  std::mutex listeners_mutex; /**< protect listeners */
+  std::mutex allocates_mutex; /**< protect allocates */
+  std::mutex registr_mutex;   /**< protect custom event registration */
 };
 
 } // namespace profile
+
 } // namespace nntrainer
 
 #endif /** __PROFILER_H__ */

--- a/test/meson.build
+++ b/test/meson.build
@@ -17,6 +17,7 @@ nntrainer_testutil_dep = declare_dependency(
 )
 
 nntrainer_test_deps = [
+  gmock_dep,
   gtest_dep,
   nntrainer_dep,
   nntrainer_testutil_dep
@@ -24,6 +25,7 @@ nntrainer_test_deps = [
 
 # this is depedency is for the gtest with main included
 nntrainer_test_main_deps = [
+  gmock_dep,
   gtest_main_dep,
   nntrainer_dep,
   nntrainer_testutil_dep


### PR DESCRIPTION
This patch implement memory profiling feature.

Profile is refactored to handle memory statics information.
Unnecessary dependency from ProfileListener to Profile
class is removed, and inner information is redesigned to handle
both time and memory profiling.

For the memory profile, below infomation is managed:

event: ALLOC | DEALLOC
current size: total allocated memory size
info: user friendly tag for the analysis
duration: time interval between alloc and dealloc

Signed-off-by: Jiho Chu <jiho.chu@samsung.com>