### PR TITLE
[ccapi/nntrainer] Add getters for `ml::train::Model` states

### DIFF
--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -280,6 +280,24 @@ public:
   virtual float getLoss() = 0;
 
   /**
+   * @brief returns compilation state of a network
+   * @retval initialized value
+   */
+  virtual bool getCompiled() const = 0;
+
+  /**
+   * @brief returns initialization state of a network
+   * @retval initialized value
+   */
+  virtual bool getInitialized() const = 0;
+
+  /**
+   * @brief returns loadedFromConfig state of a network
+   * @retval loadedFromConfig value
+   */
+  virtual bool getLoadedFromConfig() const = 0;
+
+  /**
    * @brief     Get Loss from the previous epoch of training data
    * @retval    loss value
    */

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -120,6 +120,24 @@ public:
   float getLoss() override;
 
   /**
+   * @brief returns compilation state of a network
+   * @retval initialized value
+   */
+  bool getCompiled() const override { return compiled; }
+
+  /**
+   * @brief returns initialization state of a network
+   * @retval initialized value
+   */
+  bool getInitialized() const override { return initialized; }
+
+  /**
+   * @brief returns loadedFromConfig state of a network
+   * @retval loadedFromConfig value
+   */
+  bool getLoadedFromConfig() const override { return loadedFromConfig; }
+
+  /**
    * @brief     Get Loss from the previous epoch of training data
    * @retval    loss value
    */


### PR DESCRIPTION
### **Dependency of the PR**
### **Commits to be reviewed in this PR**

<details>
<summary> [ccapi/nntrainer] Add getters for compiled, initialized and loadedFromConfig </summary>
  
  ## Changed
  1. Added getter for a `nntrainer::NeuralNetwork::compiled` variable.
  2. Added getter for a `nntrainer::NeuralNetwork::initialized` variable.
  3. Added getter for a `nntrainer::NeuralNetwork::loadedFromConfig` variable.
</details>
