### PR TITLE
[FIX] memory leak for weights of the model

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -236,7 +236,9 @@ int NeuralNetwork::initialize() {
 /**
  * @brief     free layers
  */
-NeuralNetwork::~NeuralNetwork() = default;
+NeuralNetwork::~NeuralNetwork() {
+  model_graph.deallocateTensors(true);
+}
 
 /**
  * @brief     forward propagation using layers object which has layer


### PR DESCRIPTION
The weight memory was not freed after the model is destroyed.

Tensor memory can be changed its state(deallocated/allocated) while
model is alive, but the alloccated weights' memory for the model
is maintained (not freed). So, it need to be freed explicitly when
the model destroys.

Signed-off-by: Jiho Chu <jiho.chu@samsung.com>