### PR TITLE
[CAPI] Add ml_train_layer_set_property_with_single_param() internally

### DIFF
--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -355,6 +355,25 @@ int ml_train_model_compile_with_single_param(ml_train_model_h model,
 int ml_train_model_run_with_single_param(ml_train_model_h model,
                                          const char *single_param);
 
+/**
+ * @brief Sets the neural network layer Property with single param.
+ * @details Use this function to set neural network layer Property.
+ * @since_tizen 7.0
+ * API to solve va_list issue of Dllimport of C# interop.
+ * The input format of single_param must be 'key = value' format, and it
+ * received as shown in the example below. delimiter is '|'. e.g)
+ * ml_train_layer_set_property_with_single_param(layer,
+ * "unit=10|activation=softmax")
+ * @param[in] layer The NNTrainer layer handle.
+ * @param[in] single_param Property values.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ */
+int ml_train_layer_set_property_with_single_param(ml_train_layer_h layer,
+                                                  const char *single_param);
+
 #if defined(__TIZEN__)
 /**
  * @brief Checks whether machine_learning.training feature is enabled or not.

--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -314,7 +314,7 @@ int ml_train_model_insert_layer(ml_train_model_h model, ml_train_layer_h layer,
                                 const char *output_layer_names[]);
 
 /**
- * @brief Compiles and finalizes the neural network model with the params.
+ * @brief Compiles and finalizes the neural network model with single param.
  * @details Use this function to initialize neural network model. Various
  * @since_tizen 7.0
  * hyperparameter before compile the model can be set. Once compiled,
@@ -336,7 +336,7 @@ int ml_train_model_compile_with_single_param(ml_train_model_h model,
                                              const char *single_param);
 
 /**
- * @brief Trains the neural network model with params.
+ * @brief Trains the neural network model with single param.
  * @details Use this function to train the compiled neural network model with
  * the passed training hyperparameters. This function will return once the
  * training, along with requested validation and testing, is completed.

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -739,6 +739,13 @@ int ml_train_layer_set_property(ml_train_layer_h layer, ...) {
   return status;
 }
 
+int ml_train_layer_set_property_with_single_param(ml_train_layer_h layer,
+                                                  const char *single_param) {
+  ML_TRAIN_VERIFY_VALID_HANDLE(layer);
+
+  return ml_train_layer_set_property(layer, single_param, NULL);
+}
+
 int ml_train_optimizer_create(ml_train_optimizer_h *optimizer,
                               ml_train_optimizer_type_e type) {
   int status = ML_ERROR_NONE;

--- a/test/tizen_capi/unittest_tizen_capi_layer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_layer.cpp
@@ -232,6 +232,54 @@ TEST(nntrainer_capi_nnlayer, setproperty_11_n) {
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
+/**
+ * @brief Neural Network Layer Set Property Test (positive test)
+ */
+TEST(nntrainer_capi_nnlayer, setproperty_with_single_param_01_p) {
+  ml_train_layer_h handle;
+  int status;
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_INPUT);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_layer_set_property_with_single_param(
+    handle, "input_shape=1:1:6270 | normalization=true | standardization=true");
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_layer_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Layer Set Property Test (negative test )
+ */
+TEST(nntrainer_capi_nnlayer, setproperty_with_single_param_02_n) {
+  ml_train_layer_h handle;
+  int status;
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_INPUT);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_layer_set_property_with_single_param(
+    handle, "input_shape=1:1:6270, normalization=true, standardization=true");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_layer_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Layer Set Property Test (negative test )
+ */
+TEST(nntrainer_capi_nnlayer, setproperty_with_single_param_03_n) {
+  ml_train_layer_h handle;
+  int status;
+  status = ml_train_layer_create(&handle, ML_TRAIN_LAYER_TYPE_INPUT);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_layer_set_property_with_single_param(
+    handle, "input_shape=1:1:6270 ! normalization=true ! standardization=true");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_layer_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
 /*** since tizen 6.5 ***/
 
 /**


### PR DESCRIPTION
## Dependency of the PR
* N/A
## Commits to be reviewed in this PR

<details><summary>[CAPI]Modify model_compile_with_single_param() and ml_train_model_run_with_single_param() </summary></br>
Modified the internal APIs created as a C# va_list issue since capi can receive
single string in the form "key=value | key=value" and all objects have loadProperties
in setProperty which can split it with '|'.
so, the original code was reverted and added new code related call capi directly.

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyunil <hyunil46.park@samsung.com>

</details>
<details><summary>[CAPI] Add ml_train_layer_set_property_with_single_param() internally for C# DllImport </summary></br>
ml_train_layer_set_property() has a va_list and this is a problem with DllImport in C#.
va_list must be passed dynamically for each architect, this is not guaranteed to
work for some architects. This api receive param as a single string from C# DllImport.

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyunil <hyunil46.park@samsung.com>
</details>

<details><summary>[CAPI] Add unittest related to setProperty for layer </summary></br>
    
- Add unittest for ml_train_layer_set_property_with_single_param()
  
**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Hyunil <hyunil46.park@samsung.com>
</details>
