### PR TITLE
[Spec] Add flatbuffers-devel BuildRequires as default

### DIFF
--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -46,10 +46,6 @@
 
 %endif # 0%{tizen_version_major}%{tizen_version_minor} >= 65
 
-%if 0%{tizen_version_major}%{tizen_version_minor} < 65
-BuildRequires: flatbuffers-devel
-%endif
-
 Name:		nntrainer
 Summary:	Software framework for training neural networks
 Version:	0.3.0
@@ -73,6 +69,7 @@ BuildRequires:	iniparser-devel >= 4.1
 BuildRequires:	gtest-devel
 BuildRequires:	python3
 BuildRequires:	python3-numpy
+BuildRequires:	flatbuffers-devel
 
 BuildRequires:	%{capi_machine_learning_common}-devel
 BuildRequires:	%{capi_machine_learning_inference}-devel


### PR DESCRIPTION
The compiler module always uses flatc command but 'flatbuffers-devel'
dependency is added in case of the Tizen version is lower than 6.5.
Because of this reason, the buildbreak issue occurs when building for
Tizen 7.0. This patch fixes this bug.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>