### PR TITLE
[CAPI] Add set property with single param for optimizer

### DIFF
--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -374,6 +374,25 @@ int ml_train_model_run_with_single_param(ml_train_model_h model,
 int ml_train_layer_set_property_with_single_param(ml_train_layer_h layer,
                                                   const char *single_param);
 
+/**
+ * @brief Sets the neural network optimizer property with singgle param.
+ * @details Use this function to set neural network optimizer property.
+ * @since_tizen 7.0
+ * API to solve va_list issue of Dllimport of C# interop.
+ * The input format of single_param must be 'key = value' format, and it
+ * received as shown in the example below. delimiter is '|'. e.g)
+ * ml_train_optimizer_set_property_with_single_param(optimizer,
+ * "beta1=0.002 | beta2=0.001 | epsilon=1e-7");
+ * @param[in] optimizer The NNTrainer optimizer handle.
+ * @param[in] single_param Property values.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ */
+int ml_train_optimizer_set_property_with_single_param(
+  ml_train_optimizer_h optimizer, const char *single_param);
+
 #if defined(__TIZEN__)
 /**
  * @brief Checks whether machine_learning.training feature is enabled or not.

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -831,6 +831,13 @@ int ml_train_optimizer_set_property(ml_train_optimizer_h optimizer, ...) {
   return status;
 }
 
+int ml_train_optimizer_set_property_with_single_param(
+  ml_train_optimizer_h optimizer, const char *single_param) {
+  ML_TRAIN_VERIFY_VALID_HANDLE(optimizer);
+
+  return ml_train_optimizer_set_property(optimizer, single_param, NULL);
+}
+
 int ml_train_dataset_create(ml_train_dataset_h *dataset) {
   return ml_train_dataset_create(dataset, ml::train::DatasetType::UNKNOWN,
                                  nullptr, nullptr, nullptr);

--- a/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
@@ -152,6 +152,51 @@ TEST(nntrainer_capi_nnopt, setOptimizer_05_n) {
 }
 
 /**
+ * @brief Neural Network Optimizer Set Property Test (positive test)
+ */
+TEST(nntrainer_capi_nnopt, setOptimizer_with_single_param_06_p) {
+  ml_train_optimizer_h handle;
+  int status;
+  status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_optimizer_set_property_with_single_param(
+    handle, "beta1=0.002 | beta2=0.001 | epsilon=1e-7");
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_optimizer_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Optimizer Set Property Test (negative test)
+ */
+TEST(nntrainer_capi_nnopt, setOptimizer_with_single_param_07_n) {
+  ml_train_optimizer_h handle;
+  int status;
+  status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_optimizer_set_property_with_single_param(
+    handle, "beta1=0.002, beta2=0.001, epsilon=1e-7");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_optimizer_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Optimizer Set Property Test (negative test)
+ */
+TEST(nntrainer_capi_nnopt, setOptimizer_with_single_param_08_n) {
+  ml_train_optimizer_h handle;
+  int status;
+  status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_optimizer_set_property_with_single_param(
+    handle, "beta1=0.002 ! beta2=0.001 ! epsilon=1e-7");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_optimizer_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
  * @brief Main gtest
  */
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Dependency of the PR
*N/A
## Commits to be reviewed in this PR  
<details><summary> [CAPI] Add set property with single param for optimizer</summary><br/>
    
    Add ml_train_optimizer_set_property_with_single_param().
    ml_train_optimizer_set_property() has a va_list and this is a problem with DllImport in C#.
    va_list must be passed dynamically for each architect, this is not guaranteed to
    work for some architects. This api receive param as a single string from C# DllImport.
    
    **Self evaluation:**
    1. Build test:   [X]Passed [ ]Failed [ ]Skipped
    2. Run test:     [X]Passed [ ]Failed [ ]Skipped
    
    Signed-off-by: Hyunil <hyunil46.park@samsung.com>
</details>
<details><summary>[TEST] Add unittest related to setProperty for optimizer</summary><br/>
    
    - Add unittest for ml_train_optimizer_set_property_with_single_param()
    
    **Self evaluation:**
    1. Build test:   [X]Passed [ ]Failed [ ]Skipped
    2. Run test:     [X]Passed [ ]Failed [ ]Skipped
</details>