### PR TITLE
[CAPI] Add set property with single param for dataset

### DIFF
--- a/api/capi/include/nntrainer_internal.h
+++ b/api/capi/include/nntrainer_internal.h
@@ -375,7 +375,7 @@ int ml_train_layer_set_property_with_single_param(ml_train_layer_h layer,
                                                   const char *single_param);
 
 /**
- * @brief Sets the neural network optimizer property with singgle param.
+ * @brief Sets the neural network optimizer property with single param.
  * @details Use this function to set neural network optimizer property.
  * @since_tizen 7.0
  * API to solve va_list issue of Dllimport of C# interop.
@@ -392,6 +392,27 @@ int ml_train_layer_set_property_with_single_param(ml_train_layer_h layer,
  */
 int ml_train_optimizer_set_property_with_single_param(
   ml_train_optimizer_h optimizer, const char *single_param);
+
+/**
+ * @brief Sets the neural network dataset property with single param.
+ * @details Use this function to set dataset property for a specific mode.
+ * API to solve va_list issue of Dllimport of C# interop.
+ * The input format of single_param must be 'key = value' format, and it
+ * received as shown in the example below. delimiter is '|'. e.g)
+ * ml_train_dataset_set_property_for_mode_with_single_param(dataset,
+ * ML_TRAIN_DATASET_MODE_TEST, "key1=value2 | key1=value2");
+ * @since_tizen 7.0
+ * @param[in] dataset The NNTrainer dataset handle.
+ * @param[in] mode The mode to set the property.
+ * @param[in] single_param Property values.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ */
+int ml_train_dataset_set_property_for_mode_with_single_param(
+  ml_train_dataset_h dataset, ml_train_dataset_mode_e mode,
+  const char *single_param);
 
 #if defined(__TIZEN__)
 /**

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -1019,6 +1019,15 @@ int ml_train_dataset_set_property_for_mode(ml_train_dataset_h dataset,
   return status != ML_ERROR_NONE ? ML_ERROR_INVALID_PARAMETER : ML_ERROR_NONE;
 }
 
+int ml_train_dataset_set_property_for_mode_with_single_param(
+  ml_train_dataset_h dataset, ml_train_dataset_mode_e mode,
+  const char *single_param) {
+  ML_TRAIN_VERIFY_VALID_HANDLE(dataset);
+
+  return ml_train_dataset_set_property_for_mode(dataset, mode, single_param,
+                                                NULL);
+}
+
 int ml_train_dataset_destroy(ml_train_dataset_h dataset) {
   int status = ML_ERROR_NONE;
   ml_train_dataset *nndataset;

--- a/test/tizen_capi/unittest_tizen_capi_dataset.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_dataset.cpp
@@ -567,6 +567,61 @@ TEST(nntrainer_capi_dataset, set_dataset_property_for_mode_02_n) {
 }
 
 /**
+ * @brief Neural Network Dataset set Property Test (positive test)
+ */
+TEST(nntrainer_capi_dataset,
+     set_dataset_property_for_mode_with_single_param_03_p) {
+  ml_train_dataset_h dataset;
+  int status = ML_ERROR_NONE;
+
+  status = ml_train_dataset_create(&dataset);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  auto train_data = createTrainData();
+  auto valid_data = createValidData();
+  status = ml_train_dataset_add_generator(dataset, ML_TRAIN_DATASET_MODE_TRAIN,
+                                          getSample, &train_data);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_dataset_set_property_for_mode_with_single_param(
+    dataset, ML_TRAIN_DATASET_MODE_TRAIN, "buffer_size=1");
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_dataset_add_generator(dataset, ML_TRAIN_DATASET_MODE_VALID,
+                                          getSample, &valid_data);
+  status = ml_train_dataset_set_property_for_mode_with_single_param(
+    dataset, ML_TRAIN_DATASET_MODE_VALID, "buffer_size=1");
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_dataset_add_generator(dataset, ML_TRAIN_DATASET_MODE_TEST,
+                                          getSample, &train_data);
+  status = ml_train_dataset_set_property_for_mode_with_single_param(
+    dataset, ML_TRAIN_DATASET_MODE_TEST, "buffer_size=1");
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_dataset_destroy(dataset);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Dataset set Property Test (negative test)
+ */
+TEST(nntrainer_capi_dataset,
+     set_dataset_property_for_mode_with_single_param_04_n) {
+  ml_train_dataset_h dataset;
+  int status = ML_ERROR_NONE;
+
+  status = ml_train_dataset_create(&dataset);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_dataset_set_property_for_mode_with_single_param(
+    dataset, ML_TRAIN_DATASET_MODE_TRAIN, "buffer_size=1");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_dataset_destroy(dataset);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
  * @brief Neural Network Dataset set Property Test (negative test)
  */
 TEST(nntrainer_capi_dataset,


### PR DESCRIPTION
## Dependency of the PR
*N/A
## Commits to be reviewed in this PR  
<details><summary>[CAPI] Add set property with single param for dataset</summary></br>
    
    Add ml_train_dataset_set_property_for_mode_with_single_param().
    ml_train_dataset_set_property_for_mode() has a va_list and this is a problem with DllImport in C#.
    va_list must be passed dynamically for each architect, this is not guaranteed to
    work for some architects. This api receive param as a single string from C# DllImport.
    
    **Self evaluation:**
    1. Build test:   [X]Passed [ ]Failed [ ]Skipped
    2. Run test:     [X]Passed [ ]Failed [ ]Skipped
    
    Signed-off-by: Hyunil <hyunil46.park@samsung.com>
</details>
<details><summary>[TEST] Add unittest related to setProperty for dataset</summary></br>
    
    Add unittest for ml_train_dataset_set_property_for_mode_with_single_param()
    
    **Self evaluation:**
    1. Build test:   [X]Passed [ ]Failed [ ]Skipped
    2. Run test:     [X]Passed [ ]Failed [ ]Skipped
    
    Signed-off-by: Hyunil <hyunil46.park@samsung.com>
</details>