### PR TITLE
[ BUILD ] fix binary size of libnntrainer with android build script @open sesame 06/22 21:21

### DIFF
--- a/jni/meson.build
+++ b/jni/meson.build
@@ -47,8 +47,6 @@ else
   error('ml api common dep is needed for the android build')
 endif
 
-
-
 configure_file(input: 'Android.mk.in', output: 'Android.mk',
   configuration: and_conf
 )
@@ -62,19 +60,15 @@ configure_file(input: 'Application.mk', output: 'Application.mk',
 # below is list of file that meson acknowledges this is the output of custom target so that
 # this has to be installed by meson
 outputs= [
-  'libc++_shared.so',
-  'libcapi-nntrainer.so',
-  'libccapi-nntrainer.so',
-  'libnntrainer.so'
+  'arm64-v8a'
 ]
 
 
 ndk_build = find_program('ndk-build', required : true)
 
 ndk_args = {
-  'TARGET_OUT': meson.current_build_dir(),
+  'NDK_LIBS_OUT': meson.current_build_dir(),
 }
-
 num_threads = run_command('grep', '-c', '^processor', '/proc/cpuinfo').stdout().strip()
 message('num processor are: ' + num_threads)
 

--- a/meson.build
+++ b/meson.build
@@ -81,7 +81,7 @@ if get_option('platform') != 'android'
 else
   nntrainer_prefix = meson.build_root() / 'android_build_result'
   # @todo arch has to be option
-  nntrainer_libdir = nntrainer_prefix / 'lib' / 'arm64-v8a'
+  nntrainer_libdir = nntrainer_prefix / 'lib'
   nntrainer_includedir = nntrainer_prefix / 'include' / 'nntrainer'
   nntrainer_bindir = nntrainer_prefix / 'bin'
   nntrainer_confdir = nntrainer_prefix / 'conf'


### PR DESCRIPTION
This patch fix the wrong size of nntrainer library, libnntrainer.so,
when using the android build script.

- change the ndk-build options with NDK_LIBS_OUT

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>