### PR TITLE
[BUILD] fix supported gmock version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -262,7 +262,7 @@ if get_option('enable-tflite-interpreter')
   extra_defines += '-DENABLE_TFLITE_INTERPRETER=1'
 endif
 
-gmock_dep = dependency('gmock', static: true, required: false)
+gmock_dep = dependency('gmock', static: true, main: false, required: false)
 gtest_dep = dependency('gtest', static: true, main: false, required: false)
 gtest_main_dep = dependency('gtest', static: true, main: true, required: false)
 

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -51,7 +51,9 @@ test_target = [
 ]
 
 if get_option('enable-profile')
-  test_target += [['unittest_nntrainer_profiler', []]]
+  if gmock_dep.version().version_compare('>=1.10.0')
+    test_target += [['unittest_nntrainer_profiler', []]]
+  endif
 endif
 
 foreach target: test_target


### PR DESCRIPTION
google mock API is changed from 1.10.0,
and it does not support MOCK_METHOD under 1.10.0 version.
'profiler' test is only enabled for proper gmock.

Signed-off-by: Jiho Chu <jiho.chu@samsung.com>