### PR TITLE
[ Trivial ] Fix the "Deprecated-declarations" error @open sesame 07/04 13:50

### DIFF
--- a/Applications/Custom/LayerPlugin/layer_plugin_mae_loss_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_mae_loss_test.cpp
@@ -19,13 +19,13 @@
 #include <layers_common_tests.h>
 #include <mae_loss.h>
 
-INSTANTIATE_TEST_CASE_P(
-  MaeLossLayer, LayerPluginCommonTest,
-  ::testing::Values(std::make_tuple("libmae_loss_layer.so", "mae_loss")));
+GTEST_PARAMETER_TEST(MaeLossLayer, LayerPluginCommonTest,
+                     ::testing::Values(std::make_tuple("libmae_loss_layer.so",
+                                                       "mae_loss")));
 
 auto semantic_mae =
   LayerSemanticsParamType(nntrainer::createLayer<custom::MaeLossLayer>,
                           custom::MaeLossLayer::type, {}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(MaeLossLayer, LayerSemantics,
-                        ::testing::Values(semantic_mae));
+GTEST_PARAMETER_TEST(MaeLossLayer, LayerSemantics,
+                     ::testing::Values(semantic_mae));

--- a/Applications/Custom/LayerPlugin/layer_plugin_pow_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_pow_test.cpp
@@ -19,13 +19,12 @@
 #include <layers_common_tests.h>
 #include <pow.h>
 
-INSTANTIATE_TEST_CASE_P(PowLayer, LayerPluginCommonTest,
-                        ::testing::Values(std::make_tuple("libpow_layer.so",
-                                                          "pow")));
+GTEST_PARAMETER_TEST(PowLayer, LayerPluginCommonTest,
+                     ::testing::Values(std::make_tuple("libpow_layer.so",
+                                                       "pow")));
 
 auto semantic_pow =
   LayerSemanticsParamType(nntrainer::createLayer<custom::PowLayer>,
                           custom::PowLayer::type, {}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(PowLayer, LayerSemantics,
-                        ::testing::Values(semantic_pow));
+GTEST_PARAMETER_TEST(PowLayer, LayerSemantics, ::testing::Values(semantic_pow));

--- a/Applications/Custom/LayerPlugin/layer_plugin_rnnt_loss_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_rnnt_loss_test.cpp
@@ -19,13 +19,13 @@
 #include <layers_common_tests.h>
 #include <rnnt_loss.h>
 
-INSTANTIATE_TEST_CASE_P(
-  RNNTLossLayer, LayerPluginCommonTest,
-  ::testing::Values(std::make_tuple("librnnt_loss_layer.so", "rnnt_loss")));
+GTEST_PARAMETER_TEST(RNNTLossLayer, LayerPluginCommonTest,
+                     ::testing::Values(std::make_tuple("librnnt_loss_layer.so",
+                                                       "rnnt_loss")));
 
 auto semantic_rnnt =
   LayerSemanticsParamType(nntrainer::createLayer<custom::RNNTLossLayer>,
                           custom::RNNTLossLayer::type, {}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(RNNTLossLayer, LayerSemantics,
-                        ::testing::Values(semantic_rnnt));
+GTEST_PARAMETER_TEST(RNNTLossLayer, LayerSemantics,
+                     ::testing::Values(semantic_rnnt));

--- a/Applications/SimpleShot/test/simpleshot_layer_common_tests.cpp
+++ b/Applications/SimpleShot/test/simpleshot_layer_common_tests.cpp
@@ -34,11 +34,11 @@ auto semantic_activation_centering = LayerSemanticsParamType(
    "conv4_60classes_feature_vector.bin"},
   0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(L2NormLayer, LayerSemantics,
-                        ::testing::Values(semantic_activation_l2norm));
+GTEST_PARAMETER_TEST(L2NormLayer, LayerSemantics,
+                     ::testing::Values(semantic_activation_l2norm));
 
-INSTANTIATE_TEST_CASE_P(CentroidKNN, LayerSemantics,
-                        ::testing::Values(semantic_activation_centroid_knn));
+GTEST_PARAMETER_TEST(CentroidKNN, LayerSemantics,
+                     ::testing::Values(semantic_activation_centroid_knn));
 
-INSTANTIATE_TEST_CASE_P(CenteringLayer, LayerSemantics,
-                        ::testing::Values(semantic_activation_centering));
+GTEST_PARAMETER_TEST(CenteringLayer, LayerSemantics,
+                     ::testing::Values(semantic_activation_centering));

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ The following dependencies are needed to compile/build/run.
 * libiniparser
 * libjsoncpp >=0.6.0 ( if you wand to use open AI )
 * libcurl3 >=7.47 ( if you wand to use open AI )
-* libgtest ( for testing )
+* libgtest >=1.10 ( for testing )
 
 ## Install via PPA repository (Debian/Ubuntu)
 

--- a/meson.build
+++ b/meson.build
@@ -177,8 +177,16 @@ if get_option('enable-logging')
   extra_defines += '-D__LOGGING__=1'
 endif
 
+gmock_dep = dependency('gmock', static: true, main: false, required: false)
+gtest_dep = dependency('gtest', static: true, main: false, required: false)
+gtest_main_dep = dependency('gtest', static: true, main: true, required: false)
+
+
 if get_option('enable-test') # and get_option('platform') != 'android'
   extra_defines += '-DENABLE_TEST=1'
+  if gtest_dep.version().version_compare('<1.10.0')
+     extra_defines += '-DGTEST_BACKPORT=1'
+  endif
 endif
 
 if get_option('reduce-tolerance')
@@ -261,10 +269,6 @@ endif
 if get_option('enable-tflite-interpreter')
   extra_defines += '-DENABLE_TFLITE_INTERPRETER=1'
 endif
-
-gmock_dep = dependency('gmock', static: true, main: false, required: false)
-gtest_dep = dependency('gtest', static: true, main: false, required: false)
-gtest_main_dep = dependency('gtest', static: true, main: true, required: false)
 
 opencv_dep = dummy_dep
 

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -52,6 +52,13 @@
 #define ML_TRAIN_SUMMARY_MODEL_VALID_LOSS 102
 #define ML_TRAIN_SUMMARY_MODEL_VALID_ACCURACY 103
 
+/** Gtest compatibility for parameterize google test API  */
+#ifdef GTEST_BACKPORT
+#define GTEST_PARAMETER_TEST INSTANTIATE_TEST_CASE_P
+#else
+#define GTEST_PARAMETER_TEST INSTANTIATE_TEST_SUITE_P
+#endif
+
 /**
  * @brief This class wraps IniWrapper. This generates real ini file when
  * construct, and remove real ini file when destroy

--- a/test/tizen_capi/unittest_tizen_capi_layer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_layer.cpp
@@ -327,7 +327,7 @@ mkTc(ml_train_layer_type_e type, const std::vector<const char *> &vec,
   return std::make_tuple(type, vec, success);
 }
 
-INSTANTIATE_TEST_CASE_P(
+GTEST_PARAMETER_TEST(
   CapiPropertyTest, nntrainerCapiLayerTester,
   ::testing::Values(
     mkTc(ML_TRAIN_LAYER_TYPE_BN,

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -210,7 +210,7 @@ mkTc(nntrainer::GraphRepresentation graph, const char *file,
 }
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(nntrainerAutoInterpreterTest, nntrainerInterpreterTest,
+GTEST_PARAMETER_TEST(nntrainerAutoInterpreterTest, nntrainerInterpreterTest,
                         ::testing::Values(
   mkTc(makeGraph({fc0, flatten}), "simple_fc.ini", ini_interpreter),
   mkTc(makeGraph({fc0, flatten}), "simple_fc_backbone.ini", ini_interpreter)

--- a/test/unittest/datasets/unittest_func_data_producer.cpp
+++ b/test/unittest/datasets/unittest_func_data_producer.cpp
@@ -16,6 +16,13 @@
 #include <func_data_producer.h>
 #include <tensor.h>
 
+/** Gtest compatibility for parameterize google test API  */
+#ifdef GTEST_BACKPORT
+#define GTEST_PARAMETER_TEST INSTANTIATE_TEST_CASE_P
+#else
+#define GTEST_PARAMETER_TEST INSTANTIATE_TEST_SUITE_P
+#endif
+
 namespace {
 std::vector<nntrainer::TensorDim> input_shapes = {{1, 2, 4, 5}, {1, 2, 3, 4}};
 std::vector<nntrainer::TensorDim> label_shapes = {{1, 1, 1, 10}, {1, 1, 1, 2}};
@@ -111,6 +118,5 @@ auto func_nullptr = DataProducerSemanticsParamType(
   createNullSampleProducer, {}, input_shapes, label_shapes, nullptr,
   DataProducerSemanticsExpectedResult::FAIL_AT_FINALIZE);
 
-INSTANTIATE_TEST_CASE_P(Func, DataProducerSemantics,
-                        ::testing::Values(func_success, func_error,
-                                          func_nullptr));
+GTEST_PARAMETER_TEST(Func, DataProducerSemantics,
+                     ::testing::Values(func_success, func_error, func_nullptr));

--- a/test/unittest/datasets/unittest_iteration_queue.cpp
+++ b/test/unittest/datasets/unittest_iteration_queue.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <future>
+#include <nntrainer_test_util.h>
 #include <thread>
 #include <tuple>
 #include <vector>
@@ -568,11 +569,11 @@ IterQueueTestParamType single_slot_single_batch = {
   {{1, 2, 4, 5}, {1, 4, 5, 7}} /** input_dims*/,
   {{1, 1, 1, 8}, {1, 1, 1, 2}} /** label_dims */};
 
-INSTANTIATE_TEST_CASE_P(IterQueue, IterQueueScenarios,
-                        ::testing::Values(multi_slot_multi_batch,
-                                          single_slot_multi_batch,
-                                          multi_slot_single_batch,
-                                          single_slot_single_batch));
+GTEST_PARAMETER_TEST(IterQueue, IterQueueScenarios,
+                     ::testing::Values(multi_slot_multi_batch,
+                                       single_slot_multi_batch,
+                                       multi_slot_single_batch,
+                                       single_slot_single_batch));
 
 TEST(IterQueue, constructEmptySlots_n) {
   EXPECT_ANY_THROW(nntrainer::IterationQueue(0, {{1}}, {{1}}));

--- a/test/unittest/datasets/unittest_random_data_producers.cpp
+++ b/test/unittest/datasets/unittest_random_data_producers.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 
 #include <data_producer_common_tests.h>
+#include <nntrainer_test_util.h>
 #include <random_data_producers.h>
 
 DataProducerValidatorType random_onehot_validator(float min, float max) {
@@ -70,7 +71,7 @@ auto random_onehot_invalid_label_shape = DataProducerSemanticsParamType(
   {{1, 1, 2, 10}}, nullptr,
   DataProducerSemanticsExpectedResult::FAIL_AT_FINALIZE);
 
-INSTANTIATE_TEST_CASE_P(
+GTEST_PARAMETER_TEST(
   RandomOneHot, DataProducerSemantics,
   ::testing::Values(random_onehot_success_one_batch,
                     random_onehot_success_multi_batch_will_be_ignored,

--- a/test/unittest/datasets/unittest_raw_file_data_producer.cpp
+++ b/test/unittest/datasets/unittest_raw_file_data_producer.cpp
@@ -53,5 +53,5 @@ auto batch_too_big = DataProducerSemanticsParamType(
   {{50000, 1, 1, 10}}, nullptr,
   DataProducerSemanticsExpectedResult::FAIL_AT_FINALIZE);
 
-INSTANTIATE_TEST_CASE_P(RawFile, DataProducerSemantics,
-                        ::testing::Values(training_set, valSet, testSet));
+GTEST_PARAMETER_TEST(RawFile, DataProducerSemantics,
+                     ::testing::Values(training_set, valSet, testSet));

--- a/test/unittest/layers/layers_common_tests.h
+++ b/test/unittest/layers/layers_common_tests.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <layer_devel.h>
+#include <nntrainer_test_util.h>
 
 typedef enum {
   AVAILABLE_FROM_APP_CONTEXT =

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -1,4 +1,4 @@
-layer_common_test_inc = include_directories('./')
+layer_common_test_inc = [ include_directories('./', '../../include') ]
 layer_common_test_standalone_files = files('layers_standalone_common_tests.cpp')
 layer_common_test_dependent_files = files('layers_dependent_common_tests.cpp')
 

--- a/test/unittest/layers/unittest_layers_activation.cpp
+++ b/test/unittest/layers/unittest_layers_activation.cpp
@@ -36,9 +36,9 @@ auto semantic_activation_none = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::ActivationLayer>,
   nntrainer::ActivationLayer::type, {"activation=none"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Activation, LayerSemantics,
-                        ::testing::Values(semantic_activation_relu,
-                                          semantic_activation_sigmoid,
-                                          semantic_activation_softmax,
-                                          semantic_activation_tanh,
-                                          semantic_activation_none));
+GTEST_PARAMETER_TEST(Activation, LayerSemantics,
+                     ::testing::Values(semantic_activation_relu,
+                                       semantic_activation_sigmoid,
+                                       semantic_activation_softmax,
+                                       semantic_activation_tanh,
+                                       semantic_activation_none));

--- a/test/unittest/layers/unittest_layers_addition.cpp
+++ b/test/unittest/layers/unittest_layers_addition.cpp
@@ -24,6 +24,6 @@ auto semantic_addition_multi =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::AdditionLayer>,
                           nntrainer::AdditionLayer::type, {}, 0, false, 2);
 
-INSTANTIATE_TEST_CASE_P(Addition, LayerSemantics,
-                        ::testing::Values(semantic_addition,
-                                          semantic_addition_multi));
+GTEST_PARAMETER_TEST(Addition, LayerSemantics,
+                     ::testing::Values(semantic_addition,
+                                       semantic_addition_multi));

--- a/test/unittest/layers/unittest_layers_attention.cpp
+++ b/test/unittest/layers/unittest_layers_attention.cpp
@@ -20,8 +20,8 @@ auto semantic_attention =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::AttentionLayer>,
                           nntrainer::AttentionLayer::type, {}, 0, false, 2);
 
-INSTANTIATE_TEST_CASE_P(Attention, LayerSemantics,
-                        ::testing::Values(semantic_attention));
+GTEST_PARAMETER_TEST(Attention, LayerSemantics,
+                     ::testing::Values(semantic_attention));
 
 auto attention_shared_kv = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::AttentionLayer>, {}, "1:1:5:7,1:1:3:7",
@@ -37,7 +37,7 @@ auto attention_batched = LayerGoldenTestParamType(
   "2:1:5:7,2:1:3:7,2:1:3:7", "attention_batched.nnlayergolden",
   LayerGoldenTestParamOptions::DEFAULT);
 
-INSTANTIATE_TEST_CASE_P(Attention, LayerGoldenTest,
-                        ::testing::Values(attention_shared_kv,
-                                          attention_shared_kv_batched,
-                                          attention_batched));
+GTEST_PARAMETER_TEST(Attention, LayerGoldenTest,
+                     ::testing::Values(attention_shared_kv,
+                                       attention_shared_kv_batched,
+                                       attention_batched));

--- a/test/unittest/layers/unittest_layers_batch_normalization.cpp
+++ b/test/unittest/layers/unittest_layers_batch_normalization.cpp
@@ -20,8 +20,8 @@ auto semantic_bn = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::BatchNormalizationLayer>,
   nntrainer::BatchNormalizationLayer::type, {}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(BatchNormalization, LayerSemantics,
-                        ::testing::Values(semantic_bn));
+GTEST_PARAMETER_TEST(BatchNormalization, LayerSemantics,
+                     ::testing::Values(semantic_bn));
 
 auto bn_inference_option = LayerGoldenTestParamOptions::SKIP_CALC_GRAD |
                            LayerGoldenTestParamOptions::SKIP_CALC_DERIV |
@@ -43,8 +43,8 @@ auto bn_basic_width_inference = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::BatchNormalizationLayer>, {}, "2:1:1:10",
   "bn_width_inference.nnlayergolden", bn_inference_option);
 
-INSTANTIATE_TEST_CASE_P(BatchNormalization, LayerGoldenTest,
-                        ::testing::Values(bn_basic_channels_training,
-                                          bn_basic_channels_inference,
-                                          bn_basic_width_training,
-                                          bn_basic_width_inference));
+GTEST_PARAMETER_TEST(BatchNormalization, LayerGoldenTest,
+                     ::testing::Values(bn_basic_channels_training,
+                                       bn_basic_channels_inference,
+                                       bn_basic_width_training,
+                                       bn_basic_width_inference));

--- a/test/unittest/layers/unittest_layers_concat.cpp
+++ b/test/unittest/layers/unittest_layers_concat.cpp
@@ -20,8 +20,8 @@ auto semantic_concat =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::ConcatLayer>,
                           nntrainer::ConcatLayer::type, {}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Concat, LayerSemantics,
-                        ::testing::Values(semantic_concat));
+GTEST_PARAMETER_TEST(Concat, LayerSemantics,
+                     ::testing::Values(semantic_concat));
 
 auto concat_dim3 = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::ConcatLayer>, {"axis=3"},
@@ -38,6 +38,5 @@ auto concat_dim1 = LayerGoldenTestParamType(
   "2:2:3:3, 2:3:3:3", "concat_dim1.nnlayergolden",
   LayerGoldenTestParamOptions::DEFAULT);
 
-INSTANTIATE_TEST_CASE_P(Concat, LayerGoldenTest,
-                        ::testing::Values(concat_dim3, concat_dim2,
-                                          concat_dim1));
+GTEST_PARAMETER_TEST(Concat, LayerGoldenTest,
+                     ::testing::Values(concat_dim3, concat_dim2, concat_dim1));

--- a/test/unittest/layers/unittest_layers_convolution1d.cpp
+++ b/test/unittest/layers/unittest_layers_convolution1d.cpp
@@ -20,8 +20,8 @@ auto semantic_conv1d = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::Conv1DLayer>, nntrainer::Conv1DLayer::type,
   {"filters=1", "kernel_size=1", "padding=1"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Convolution1D, LayerSemantics,
-                        ::testing::Values(semantic_conv1d));
+GTEST_PARAMETER_TEST(Convolution1D, LayerSemantics,
+                     ::testing::Values(semantic_conv1d));
 
 auto conv1d_sb_minimum = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::Conv1DLayer>,
@@ -139,7 +139,7 @@ auto conv1d_mb_1x1_kernel =
                            "3:2:1:5", "conv1d_mb_1x1_kernel.nnlayergolden",
                            LayerGoldenTestParamOptions::DEFAULT);
 
-INSTANTIATE_TEST_CASE_P(
+GTEST_PARAMETER_TEST(
   Convolution1D, LayerGoldenTest,
   ::testing::Values(conv1d_sb_minimum, conv1d_mb_minimum, conv1d_sb_same_remain,
                     conv1d_mb_same_remain, conv1d_sb_same_uneven_remain_1,

--- a/test/unittest/layers/unittest_layers_convolution2d.cpp
+++ b/test/unittest/layers/unittest_layers_convolution2d.cpp
@@ -20,8 +20,8 @@ auto semantic_conv2d = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::Conv2DLayer>, nntrainer::Conv2DLayer::type,
   {"filters=1", "kernel_size=1,1", "padding=1,1"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Convolution2D, LayerSemantics,
-                        ::testing::Values(semantic_conv2d));
+GTEST_PARAMETER_TEST(Convolution2D, LayerSemantics,
+                     ::testing::Values(semantic_conv2d));
 
 auto conv2d_sb_minimum = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::Conv2DLayer>,
@@ -139,7 +139,7 @@ auto conv2d_mb_1x1_kernel =
                            "3:2:5:5", "conv2d_mb_1x1_kernel.nnlayergolden",
                            LayerGoldenTestParamOptions::DEFAULT);
 
-INSTANTIATE_TEST_CASE_P(
+GTEST_PARAMETER_TEST(
   Convolution2D, LayerGoldenTest,
   ::testing::Values(conv2d_sb_minimum, conv2d_mb_minimum, conv2d_sb_same_remain,
                     conv2d_mb_same_remain, conv2d_sb_same_uneven_remain_1,

--- a/test/unittest/layers/unittest_layers_dropout.cpp
+++ b/test/unittest/layers/unittest_layers_dropout.cpp
@@ -20,8 +20,8 @@ auto semantic_dropout =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::DropOutLayer>,
                           nntrainer::DropOutLayer::type, {}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Dropout, LayerSemantics,
-                        ::testing::Values(semantic_dropout));
+GTEST_PARAMETER_TEST(Dropout, LayerSemantics,
+                     ::testing::Values(semantic_dropout));
 
 auto dropout_inference_option =
   LayerGoldenTestParamOptions::SKIP_CALC_GRAD |
@@ -48,8 +48,7 @@ auto dropout_100_training = LayerGoldenTestParamType(
   "2:3:2:3", "dropout_100_training.nnlayergolden",
   LayerGoldenTestParamOptions::DEFAULT);
 
-INSTANTIATE_TEST_CASE_P(Dropout, LayerGoldenTest,
-                        ::testing::Values(dropout_20_training,
-                                          dropout_0_training,
-                                          dropout_100_training,
-                                          dropout_20_inference));
+GTEST_PARAMETER_TEST(Dropout, LayerGoldenTest,
+                     ::testing::Values(dropout_20_training, dropout_0_training,
+                                       dropout_100_training,
+                                       dropout_20_inference));

--- a/test/unittest/layers/unittest_layers_embedding.cpp
+++ b/test/unittest/layers/unittest_layers_embedding.cpp
@@ -20,5 +20,5 @@ auto semantic_embedding = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::EmbeddingLayer>,
   nntrainer::EmbeddingLayer::type, {"out_dim=1", "in_dim=1"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Embedding, LayerSemantics,
-                        ::testing::Values(semantic_embedding));
+GTEST_PARAMETER_TEST(Embedding, LayerSemantics,
+                     ::testing::Values(semantic_embedding));

--- a/test/unittest/layers/unittest_layers_flatten.cpp
+++ b/test/unittest/layers/unittest_layers_flatten.cpp
@@ -20,5 +20,5 @@ auto semantic_flatten =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::FlattenLayer>,
                           nntrainer::FlattenLayer::type, {}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Flatten, LayerSemantics,
-                        ::testing::Values(semantic_flatten));
+GTEST_PARAMETER_TEST(Flatten, LayerSemantics,
+                     ::testing::Values(semantic_flatten));

--- a/test/unittest/layers/unittest_layers_fully_connected.cpp
+++ b/test/unittest/layers/unittest_layers_fully_connected.cpp
@@ -21,8 +21,8 @@ auto semantic_fc = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::FullyConnectedLayer>,
   nntrainer::FullyConnectedLayer::type, {"unit=1"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(FullyConnected, LayerSemantics,
-                        ::testing::Values(semantic_fc));
+GTEST_PARAMETER_TEST(FullyConnected, LayerSemantics,
+                     ::testing::Values(semantic_fc));
 
 auto fc_basic_plain = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::FullyConnectedLayer>, {"unit=5"},
@@ -36,6 +36,6 @@ auto fc_basic_no_decay = LayerGoldenTestParamType(
   {"unit=5", "weight_decay=0.0", "bias_decay=0.0"}, "3:1:1:10",
   "fc_plain.nnlayergolden", LayerGoldenTestParamOptions::DEFAULT);
 
-INSTANTIATE_TEST_CASE_P(FullyConnected, LayerGoldenTest,
-                        ::testing::Values(fc_basic_plain, fc_basic_single_batch,
-                                          fc_basic_no_decay));
+GTEST_PARAMETER_TEST(FullyConnected, LayerGoldenTest,
+                     ::testing::Values(fc_basic_plain, fc_basic_single_batch,
+                                       fc_basic_no_decay));

--- a/test/unittest/layers/unittest_layers_gru.cpp
+++ b/test/unittest/layers/unittest_layers_gru.cpp
@@ -20,7 +20,7 @@ auto semantic_gru = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::GRULayer>, nntrainer::GRULayer::type,
   {"unit=1", "integrate_bias=true", "reset_after=false"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(GRU, LayerSemantics, ::testing::Values(semantic_gru));
+GTEST_PARAMETER_TEST(GRU, LayerSemantics, ::testing::Values(semantic_gru));
 
 auto gru_single_step = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::GRULayer>,
@@ -101,7 +101,7 @@ auto gru_reset_after_multi_step_seq_act = LayerGoldenTestParamType(
   "3:1:4:7", "gru_reset_after_multi_step_seq_act.nnlayergolden",
   LayerGoldenTestParamOptions::DEFAULT);
 
-INSTANTIATE_TEST_CASE_P(
+GTEST_PARAMETER_TEST(
   GRU, LayerGoldenTest,
   ::testing::Values(gru_single_step, gru_multi_step, gru_single_step_seq,
                     gru_multi_step_seq, gru_multi_step_seq_act_orig,

--- a/test/unittest/layers/unittest_layers_grucell.cpp
+++ b/test/unittest/layers/unittest_layers_grucell.cpp
@@ -21,8 +21,8 @@ auto semantic_grucell = LayerSemanticsParamType(
   nntrainer::GRUCellLayer::type,
   {"unit=1", "integrate_bias=false", "reset_after=true"}, 0, false, 2);
 
-INSTANTIATE_TEST_CASE_P(GRUCell, LayerSemantics,
-                        ::testing::Values(semantic_grucell));
+GTEST_PARAMETER_TEST(GRUCell, LayerSemantics,
+                     ::testing::Values(semantic_grucell));
 
 auto grucell_single_step = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::GRUCellLayer>,
@@ -42,7 +42,7 @@ auto grucell_single_step_act = LayerGoldenTestParamType(
   "3:1:1:7,3:1:1:5", "grucell_single_step_act.nnlayergolden",
   LayerGoldenTestParamOptions::DEFAULT);
 
-INSTANTIATE_TEST_CASE_P(GRUCell, LayerGoldenTest,
-                        ::testing::Values(grucell_single_step,
-                                          grucell_reset_after_single_step,
-                                          grucell_single_step_act));
+GTEST_PARAMETER_TEST(GRUCell, LayerGoldenTest,
+                     ::testing::Values(grucell_single_step,
+                                       grucell_reset_after_single_step,
+                                       grucell_single_step_act));

--- a/test/unittest/layers/unittest_layers_impl.cpp
+++ b/test/unittest/layers/unittest_layers_impl.cpp
@@ -55,10 +55,9 @@ public:
 
 auto semantic_tc = LayerSemanticsParamType(nntrainer::createLayer<MockLayer>,
                                            MockLayer::type, {}, 0, false, 1);
-INSTANTIATE_TEST_CASE_P(LayerImpl, LayerSemantics,
-                        ::testing::Values(semantic_tc));
+GTEST_PARAMETER_TEST(LayerImpl, LayerSemantics, ::testing::Values(semantic_tc));
 
-// INSTANTIATE_TEST_CASE_P(
+// GTEST_PARAMETER_TEST(
 //   LayerImpl, LayerGoldenTest,
 //   ::testing::Values(
 //     "test") /**< format of type, properties, num_batch, golden file name */);

--- a/test/unittest/layers/unittest_layers_input.cpp
+++ b/test/unittest/layers/unittest_layers_input.cpp
@@ -20,5 +20,4 @@ auto semantic_input =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::InputLayer>,
                           nntrainer::InputLayer::type, {}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Input, LayerSemantics,
-                        ::testing::Values(semantic_input));
+GTEST_PARAMETER_TEST(Input, LayerSemantics, ::testing::Values(semantic_input));

--- a/test/unittest/layers/unittest_layers_loss.cpp
+++ b/test/unittest/layers/unittest_layers_loss.cpp
@@ -35,8 +35,7 @@ auto semantic_loss_cross = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::CrossEntropyLossLayer>,
   nntrainer::CrossEntropyLossLayer::type, {}, 0, true, 1);
 
-INSTANTIATE_TEST_CASE_P(LossCross, LayerSemantics,
-                        ::testing::Values(semantic_loss_cross,
-                                          semantic_loss_mse,
-                                          semantic_loss_cross_softmax,
-                                          semantic_loss_cross_sigmoid));
+GTEST_PARAMETER_TEST(LossCross, LayerSemantics,
+                     ::testing::Values(semantic_loss_cross, semantic_loss_mse,
+                                       semantic_loss_cross_softmax,
+                                       semantic_loss_cross_sigmoid));

--- a/test/unittest/layers/unittest_layers_lstm.cpp
+++ b/test/unittest/layers/unittest_layers_lstm.cpp
@@ -20,7 +20,7 @@ auto semantic_lstm =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::LSTMLayer>,
                           nntrainer::LSTMLayer::type, {"unit=1"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(LSTM, LayerSemantics, ::testing::Values(semantic_lstm));
+GTEST_PARAMETER_TEST(LSTM, LayerSemantics, ::testing::Values(semantic_lstm));
 
 auto lstm_single_step = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::LSTMLayer>,
@@ -56,9 +56,9 @@ auto lstm_multi_step_seq_act = LayerGoldenTestParamType(
   "3:1:4:7", "lstm_multi_step_seq_act.nnlayergolden",
   LayerGoldenTestParamOptions::DEFAULT);
 
-INSTANTIATE_TEST_CASE_P(LSTM, LayerGoldenTest,
-                        ::testing::Values(lstm_single_step, lstm_multi_step,
-                                          lstm_single_step_seq,
-                                          lstm_multi_step_seq,
-                                          lstm_multi_step_seq_act_orig,
-                                          lstm_multi_step_seq_act));
+GTEST_PARAMETER_TEST(LSTM, LayerGoldenTest,
+                     ::testing::Values(lstm_single_step, lstm_multi_step,
+                                       lstm_single_step_seq,
+                                       lstm_multi_step_seq,
+                                       lstm_multi_step_seq_act_orig,
+                                       lstm_multi_step_seq_act));

--- a/test/unittest/layers/unittest_layers_lstmcell.cpp
+++ b/test/unittest/layers/unittest_layers_lstmcell.cpp
@@ -20,13 +20,13 @@ auto semantic_lstmcell = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::LSTMCellLayer>,
   nntrainer::LSTMCellLayer::type, {"unit=1"}, 0, false, 3);
 
-INSTANTIATE_TEST_CASE_P(LSTMCell, LayerSemantics,
-                        ::testing::Values(semantic_lstmcell));
+GTEST_PARAMETER_TEST(LSTMCell, LayerSemantics,
+                     ::testing::Values(semantic_lstmcell));
 
 auto lstmcell_single_step = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::LSTMCellLayer>,
   {"unit=5", "integrate_bias=true"}, "3:1:1:7,3:1:1:5,3:1:1:5",
   "lstmcell_single_step.nnlayergolden", LayerGoldenTestParamOptions::DEFAULT);
 
-INSTANTIATE_TEST_CASE_P(LSTMCell, LayerGoldenTest,
-                        ::testing::Values(lstmcell_single_step));
+GTEST_PARAMETER_TEST(LSTMCell, LayerGoldenTest,
+                     ::testing::Values(lstmcell_single_step));

--- a/test/unittest/layers/unittest_layers_mol_attention.cpp
+++ b/test/unittest/layers/unittest_layers_mol_attention.cpp
@@ -20,5 +20,5 @@ auto semantic_mol_attention = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::MoLAttentionLayer>,
   nntrainer::MoLAttentionLayer::type, {"unit=5", "mol_k=1"}, 0, false, 3);
 
-INSTANTIATE_TEST_CASE_P(MoLAttention, LayerSemantics,
-                        ::testing::Values(semantic_mol_attention));
+GTEST_PARAMETER_TEST(MoLAttention, LayerSemantics,
+                     ::testing::Values(semantic_mol_attention));

--- a/test/unittest/layers/unittest_layers_multiout.cpp
+++ b/test/unittest/layers/unittest_layers_multiout.cpp
@@ -20,5 +20,5 @@ auto semantic_output =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::MultiOutLayer>,
                           nntrainer::MultiOutLayer::type, {}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Output, LayerSemantics,
-                        ::testing::Values(semantic_output));
+GTEST_PARAMETER_TEST(Output, LayerSemantics,
+                     ::testing::Values(semantic_output));

--- a/test/unittest/layers/unittest_layers_nnstreamer.cpp
+++ b/test/unittest/layers/unittest_layers_nnstreamer.cpp
@@ -21,5 +21,5 @@ auto semantic_nnstreamer = LayerSemanticsParamType(
   nntrainer::NNStreamerLayer::type,
   {"model_path=../test/test_models/models/add.tflite"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(NNStreamer, LayerSemantics,
-                        ::testing::Values(semantic_nnstreamer));
+GTEST_PARAMETER_TEST(NNStreamer, LayerSemantics,
+                     ::testing::Values(semantic_nnstreamer));

--- a/test/unittest/layers/unittest_layers_permute.cpp
+++ b/test/unittest/layers/unittest_layers_permute.cpp
@@ -20,5 +20,5 @@ auto semantic_permute = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::PermuteLayer>,
   nntrainer::PermuteLayer::type, {"direction=3,2,1"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Permute, LayerSemantics,
-                        ::testing::Values(semantic_permute));
+GTEST_PARAMETER_TEST(Permute, LayerSemantics,
+                     ::testing::Values(semantic_permute));

--- a/test/unittest/layers/unittest_layers_pooling2d.cpp
+++ b/test/unittest/layers/unittest_layers_pooling2d.cpp
@@ -34,8 +34,8 @@ auto semantic_pooling2d_global_max = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::Pooling2DLayer>,
   nntrainer::Pooling2DLayer::type, {"pooling=global_max"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Pooling2DMax, LayerSemantics,
-                        ::testing::Values(semantic_pooling2d_max,
-                                          semantic_pooling2d_avg,
-                                          semantic_pooling2d_global_max,
-                                          semantic_pooling2d_global_avg));
+GTEST_PARAMETER_TEST(Pooling2DMax, LayerSemantics,
+                     ::testing::Values(semantic_pooling2d_max,
+                                       semantic_pooling2d_avg,
+                                       semantic_pooling2d_global_max,
+                                       semantic_pooling2d_global_avg));

--- a/test/unittest/layers/unittest_layers_preprocess_flip.cpp
+++ b/test/unittest/layers/unittest_layers_preprocess_flip.cpp
@@ -20,5 +20,5 @@ auto semantic_flip = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::PreprocessFlipLayer>,
   nntrainer::PreprocessFlipLayer::type, {}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(PreprocessFlip, LayerSemantics,
-                        ::testing::Values(semantic_flip));
+GTEST_PARAMETER_TEST(PreprocessFlip, LayerSemantics,
+                     ::testing::Values(semantic_flip));

--- a/test/unittest/layers/unittest_layers_preprocess_translate.cpp
+++ b/test/unittest/layers/unittest_layers_preprocess_translate.cpp
@@ -21,5 +21,5 @@ auto semantic_translate = LayerSemanticsParamType(
   nntrainer::PreprocessTranslateLayer::type, {"random_translate=0.1"}, 0, false,
   1);
 
-INSTANTIATE_TEST_CASE_P(PreprocessTranslate, LayerSemantics,
-                        ::testing::Values(semantic_translate));
+GTEST_PARAMETER_TEST(PreprocessTranslate, LayerSemantics,
+                     ::testing::Values(semantic_translate));

--- a/test/unittest/layers/unittest_layers_reduce_mean.cpp
+++ b/test/unittest/layers/unittest_layers_reduce_mean.cpp
@@ -24,6 +24,6 @@ auto semantic_reduce_mean = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::ReduceMeanLayer>,
   nntrainer::ReduceMeanLayer::type, {"axis=1"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(ReduceMean, LayerSemantics,
-                        ::testing::Values(semantic_reduce_mean,
-                                          semantic_reduce_mean_all));
+GTEST_PARAMETER_TEST(ReduceMean, LayerSemantics,
+                     ::testing::Values(semantic_reduce_mean,
+                                       semantic_reduce_mean_all));

--- a/test/unittest/layers/unittest_layers_reshape.cpp
+++ b/test/unittest/layers/unittest_layers_reshape.cpp
@@ -20,5 +20,5 @@ auto semantic_reshape = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::ReshapeLayer>,
   nntrainer::ReshapeLayer::type, {"target_shape=-1"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Reshape, LayerSemantics,
-                        ::testing::Values(semantic_reshape));
+GTEST_PARAMETER_TEST(Reshape, LayerSemantics,
+                     ::testing::Values(semantic_reshape));

--- a/test/unittest/layers/unittest_layers_rnn.cpp
+++ b/test/unittest/layers/unittest_layers_rnn.cpp
@@ -20,12 +20,11 @@ auto semantic_rnn =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::RNNLayer>,
                           nntrainer::RNNLayer::type, {"unit=1"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(RNN, LayerSemantics, ::testing::Values(semantic_rnn));
+GTEST_PARAMETER_TEST(RNN, LayerSemantics, ::testing::Values(semantic_rnn));
 
 auto rnn_single_step = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::RNNLayer>,
   {"unit=5", "return_sequences=false", "integrate_bias=true"}, "3:1:1:7",
   "rnn_single_step.nnlayergolden", LayerGoldenTestParamOptions::DEFAULT);
 
-INSTANTIATE_TEST_CASE_P(RNN, LayerGoldenTest,
-                        ::testing::Values(rnn_single_step));
+GTEST_PARAMETER_TEST(RNN, LayerGoldenTest, ::testing::Values(rnn_single_step));

--- a/test/unittest/layers/unittest_layers_rnncell.cpp
+++ b/test/unittest/layers/unittest_layers_rnncell.cpp
@@ -20,13 +20,13 @@ auto semantic_rnncell = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::RNNCellLayer>,
   nntrainer::RNNCellLayer::type, {"unit=1"}, 0, false, 2);
 
-INSTANTIATE_TEST_CASE_P(RNNCell, LayerSemantics,
-                        ::testing::Values(semantic_rnncell));
+GTEST_PARAMETER_TEST(RNNCell, LayerSemantics,
+                     ::testing::Values(semantic_rnncell));
 
 auto rnncell_single_step = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::RNNCellLayer>,
   {"unit=5", "integrate_bias=true"}, "3:1:1:7,3:1:1:5",
   "rnncell_single_step.nnlayergolden", LayerGoldenTestParamOptions::DEFAULT);
 
-INSTANTIATE_TEST_CASE_P(RNNCell, LayerGoldenTest,
-                        ::testing::Values(rnncell_single_step));
+GTEST_PARAMETER_TEST(RNNCell, LayerGoldenTest,
+                     ::testing::Values(rnncell_single_step));

--- a/test/unittest/layers/unittest_layers_split.cpp
+++ b/test/unittest/layers/unittest_layers_split.cpp
@@ -20,5 +20,4 @@ auto semantic_split =
   LayerSemanticsParamType(nntrainer::createLayer<nntrainer::SplitLayer>,
                           nntrainer::SplitLayer::type, {"axis=3"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(Split, LayerSemantics,
-                        ::testing::Values(semantic_split));
+GTEST_PARAMETER_TEST(Split, LayerSemantics, ::testing::Values(semantic_split));

--- a/test/unittest/layers/unittest_layers_tflite.cpp
+++ b/test/unittest/layers/unittest_layers_tflite.cpp
@@ -20,5 +20,5 @@ auto semantic_tflite = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::TfLiteLayer>, nntrainer::TfLiteLayer::type,
   {"model_path=../test/test_models/models/add.tflite"}, 0, false, 1);
 
-INSTANTIATE_TEST_CASE_P(TfLite, LayerSemantics,
-                        ::testing::Values(semantic_tflite));
+GTEST_PARAMETER_TEST(TfLite, LayerSemantics,
+                     ::testing::Values(semantic_tflite));

--- a/test/unittest/memory/unittest_memory_planner.cpp
+++ b/test/unittest/memory/unittest_memory_planner.cpp
@@ -15,10 +15,11 @@
 #include <memory_planner_validate.h>
 
 #include <basic_planner.h>
+#include <nntrainer_test_util.h>
 #include <optimized_v1_planner.h>
 
-INSTANTIATE_TEST_CASE_P(BasicPlanner, MemoryPlannerValidate,
-                        ::testing::Values(nntrainer::BasicPlanner::type));
+GTEST_PARAMETER_TEST(BasicPlanner, MemoryPlannerValidate,
+                     ::testing::Values(nntrainer::BasicPlanner::type));
 
-INSTANTIATE_TEST_CASE_P(OptimizedV1Planner, MemoryPlannerValidate,
-                        ::testing::Values(nntrainer::OptimizedV1Planner::type));
+GTEST_PARAMETER_TEST(OptimizedV1Planner, MemoryPlannerValidate,
+                     ::testing::Values(nntrainer::OptimizedV1Planner::type));

--- a/test/unittest/models/unittest_models.cpp
+++ b/test/unittest/models/unittest_models.cpp
@@ -97,7 +97,7 @@ static std::unique_ptr<NeuralNetwork> makeMolAttentionMasked() {
   return nn;
 }
 
-INSTANTIATE_TEST_CASE_P(
+GTEST_PARAMETER_TEST(
   model, nntrainerModelTest,
   ::testing::ValuesIn({
     mkModelIniTc(reduce_mean_last, DIM_UNUSED, NOT_USED_,

--- a/test/unittest/models/unittest_models_multiout.cpp
+++ b/test/unittest/models/unittest_models_multiout.cpp
@@ -173,7 +173,7 @@ static std::unique_ptr<NeuralNetwork> split_and_join_dangle() {
   return nn;
 }
 
-INSTANTIATE_TEST_CASE_P(
+GTEST_PARAMETER_TEST(
   multiInoutModels, nntrainerModelTest,
   ::testing::ValuesIn({
     mkModelTc_V2(split_and_join, "split_and_join", ModelTestOption::ALL_V2),

--- a/test/unittest/models/unittest_models_recurrent.cpp
+++ b/test/unittest/models/unittest_models_recurrent.cpp
@@ -607,7 +607,7 @@ static std::unique_ptr<NeuralNetwork> makeStackedGRUCellFC() {
   return nn;
 }
 
-INSTANTIATE_TEST_CASE_P(
+GTEST_PARAMETER_TEST(
   recurrentModels, nntrainerModelTest,
   ::testing::ValuesIn({
     mkModelIniTc(fc_unroll_single, DIM_UNUSED, NOT_USED_,

--- a/test/unittest/unittest_common_properties.cpp
+++ b/test/unittest/unittest_common_properties.cpp
@@ -13,6 +13,7 @@
 
 #include <common_properties.h>
 #include <connection.h>
+#include <nntrainer_test_util.h>
 #include <tensor_dim.h>
 
 #include <array>
@@ -66,11 +67,10 @@ TEST_P(NameTest, forbiddenSuffix_n) {
   EXPECT_THROW(n.set("name" + suffix), std::invalid_argument);
 }
 
-INSTANTIATE_TEST_CASE_P(ForbiddenSuffixTests, NameTest,
-                        ::testing::Values("!", "@", "#", "$", "%", "^", "&",
-                                          "*", "=", "+0", "(0)", "{0}", "[0]",
-                                          "<0>", ";", ":", ",", "?", " ",
-                                          " layer"));
+GTEST_PARAMETER_TEST(ForbiddenSuffixTests, NameTest,
+                     ::testing::Values("!", "@", "#", "$", "%", "^", "&", "*",
+                                       "=", "+0", "(0)", "{0}", "[0]", "<0>",
+                                       ";", ":", ",", "?", " ", " layer"));
 
 TEST(NameProperty, mustStartWithAlphaNumeric_01_n) {
   nntrainer::props::Name n;

--- a/test/unittest/unittest_nntrainer_graph.cpp
+++ b/test/unittest/unittest_nntrainer_graph.cpp
@@ -238,14 +238,13 @@ mkIniTc(const char *name, const nntrainer::IniWrapper::Sections vec, int flag) {
   return std::make_tuple(name, vec, flag);
 }
 
-INSTANTIATE_TEST_CASE_P(
-  nntrainerIniAutoTests, nntrainerGraphTest,
-  ::testing::Values(mkIniTc("basic_p",
-                            {nw_base, sgd, input, conv2d8, conv2d9, pooling2,
-                             out0, conv2d10, conv2d11, addition0, out1,
-                             conv2d12, conv2d13, addition1, conv2d14, pooling3,
-                             fclayer0, fclayer1},
-                            SUCCESS)));
+GTEST_PARAMETER_TEST(nntrainerIniAutoTests, nntrainerGraphTest,
+                     ::testing::Values(mkIniTc(
+                       "basic_p",
+                       {nw_base, sgd, input, conv2d8, conv2d9, pooling2, out0,
+                        conv2d10, conv2d11, addition0, out1, conv2d12, conv2d13,
+                        addition1, conv2d14, pooling3, fclayer0, fclayer1},
+                       SUCCESS)));
 
 int main(int argc, char **argv) {
   int result = -1;

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -351,7 +351,7 @@ mkIniTc(const char *name, const nntrainer::IniWrapper::Sections vec, int flag) {
 /// which sums up to 6 * 2 = 12 positive tests and 9 * 2 + (6 + 9) * 3 = 63
 /// negative tests
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+GTEST_PARAMETER_TEST(
   nntrainerIniAutoTests_p, nntrainerIniTest, ::testing::Values(
   /**< positive: basic valid scenarios (2 positive and 3 negative cases) */
      mkIniTc("basic_p", {nw_base_mse, adam, input + "-Activation", out+"input_layers=inputlayer" + "-Activation"}, SUCCESS),
@@ -391,7 +391,7 @@ INSTANTIATE_TEST_CASE_P(
  return std::get<0>(info.param);
 });
 
-INSTANTIATE_TEST_CASE_P(
+GTEST_PARAMETER_TEST(
   nntrainerIniAutoTests_n, nntrainerIniTest, ::testing::Values(
   /**< half negative: init fail cases (1 positive and 4 negative cases) */
     mkIniTc("cross_with_relu_n", {nw_base_cross, sgd, input, out+"input_layers=inputlayer", act_relu+"input_layers=fclayer" }, COMPFAIL | INITFAIL),

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -23,6 +23,7 @@
 #include <neuralnet.h>
 
 #include <models_golden_test.h>
+#include <nntrainer_test_util.h>
 
 static nntrainer::IniSection nn_base("model", "type = NeuralNetwork");
 static std::string input_base = "type = input";
@@ -940,7 +941,7 @@ auto mkResNet18Tc(const unsigned int iteration,
     nntrainer::IniWrapper("ResNet18", layers), nntrainer::TensorDim({batch_size, 1,1, num_class}), iteration, options);
 }
 
-INSTANTIATE_TEST_CASE_P(
+GTEST_PARAMETER_TEST(
   nntrainerModelAutoTests, nntrainerModelTest, ::testing::ValuesIn(
     {
       mkModelIniTc(fc_sigmoid_mse, "3:1:1:10", 10, ModelTestOption::ALL),


### PR DESCRIPTION
This patch updates 'INSTANTIATE_TEST_CASE_P' which will be deprecated
with 'INISTATIATE_TEST_SUITE_P'.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>