### PR TITLE
[ Layer ] Parallelization along batch direction @open sesame 07/12 13:23

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -4,6 +4,8 @@
 /usr/include/nntrainer/common_properties.h
 /usr/include/nntrainer/base_properties.h
 /usr/include/nntrainer/node_exporter.h
+/usr/include/nntrainer/profiler.h
+/usr/include/nntrainer/nntr_threads.h
 # tensor headers
 /usr/include/nntrainer/tensor.h
 /usr/include/nntrainer/tensor_wrap_specs.h

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -204,6 +204,7 @@ NNTRAINER_SRCS := $(NNTRAINER_ROOT)/nntrainer/models/neuralnet.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/profiler.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/node_exporter.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/utils/base_properties.cpp \
+                  $(NNTRAINER_ROOT)/nntrainer/utils/nntr_threads.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/ini_interpreter.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/flatten_realizer.cpp \
                   $(NNTRAINER_ROOT)/nntrainer/compiler/activation_realizer.cpp \

--- a/meson.build
+++ b/meson.build
@@ -156,6 +156,9 @@ if get_option('enable-blas')
   endif
 endif
 
+extra_defines += '-DNNTR_NUM_THREADS=@0@'.format(get_option('nntr-num-threads'))
+message('set nntrainer num threads=@0@'.format(get_option('nntr-num-threads')))
+
 openmp_dep = dummy_dep
 if get_option('enable-openmp')
   openmp_dep = dependency('openmp')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,8 +21,8 @@ option('capi-ml-common-actual', type: 'string', value: 'capi-ml-common',
 option('tizen-version-major', type: 'integer', min : 4, max : 9999, value: 9999) # 9999 means "not Tizen"
 option('tizen-version-minor', type: 'integer', min : 0, max : 9999, value: 0)
 option('openblas-num-threads', type: 'integer', min : 0, max : 9999, value: 0)
-#This is for the multi-threading in nntrainer. ( multi-threading along batch direction )
-option('nntr-num-threads', type: 'integer', min : 0, max : 9999, value: 2)
+#This is for the multi-threading in nntrainer
+option('nntr-num-threads', type: 'integer', min : 0, max : 9999, value: 1)
 
 # test related option
 option('reduce-tolerance', type: 'boolean', value: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,6 +21,8 @@ option('capi-ml-common-actual', type: 'string', value: 'capi-ml-common',
 option('tizen-version-major', type: 'integer', min : 4, max : 9999, value: 9999) # 9999 means "not Tizen"
 option('tizen-version-minor', type: 'integer', min : 0, max : 9999, value: 0)
 option('openblas-num-threads', type: 'integer', min : 0, max : 9999, value: 0)
+#This is for the multi-threading in nntrainer. ( multi-threading along batch direction )
+option('nntr-num-threads', type: 'integer', min : 0, max : 9999, value: 2)
 
 # test related option
 option('reduce-tolerance', type: 'boolean', value: true)

--- a/nntrainer/dataset/func_data_producer.cpp
+++ b/nntrainer/dataset/func_data_producer.cpp
@@ -19,20 +19,9 @@
 
 namespace nntrainer {
 
-/**
- * @brief User data props
- *
- */
-class PropsUserData final : public Property<void *> {
-public:
-  static constexpr const char *key = "user_data";
-  PropsUserData(void *user_data) { set(user_data); }
-  using prop_tag = ptr_prop_tag;
-};
-
 FuncDataProducer::FuncDataProducer(datagen_cb datagen_cb, void *user_data_) :
   cb(datagen_cb),
-  user_data_prop(new PropsUserData(user_data_)) {}
+  user_data_prop(new props::PropsUserData(user_data_)) {}
 
 FuncDataProducer::~FuncDataProducer() {}
 

--- a/nntrainer/dataset/func_data_producer.h
+++ b/nntrainer/dataset/func_data_producer.h
@@ -13,8 +13,8 @@
 #ifndef __FUNC_DATA_PRODUCER_H__
 #define __FUNC_DATA_PRODUCER_H__
 
+#include <common_properties.h>
 #include <data_producer.h>
-
 #include <dataset.h>
 
 #include <memory>
@@ -23,7 +23,6 @@
 
 namespace nntrainer {
 
-class PropsUserData;
 class Exporter;
 
 using datagen_cb = ml::train::datagen_cb;
@@ -78,7 +77,7 @@ public:
 
 private:
   datagen_cb cb;
-  std::unique_ptr<PropsUserData> user_data_prop;
+  std::unique_ptr<props::PropsUserData> user_data_prop;
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -240,6 +240,8 @@ WeightRegularizerConstant::WeightRegularizerConstant(float value) :
 WeightDecay::WeightDecay(float value) : BasicRegularizerConstant(value) {}
 BiasDecay::BiasDecay(float value) : BasicRegularizerConstant(value) {}
 
+PropsUserData::PropsUserData(void *user_data) { set(user_data); }
+
 bool BasicRegularizerConstant::isValid(const float &value) const {
   return value >= 0.0f;
 }

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -1167,6 +1167,17 @@ public:
   using prop_tag = uint_prop_tag;                   /**< property type */
 };
 
+/**
+ * @brief User data props
+ *
+ */
+class PropsUserData final : public Property<void *> {
+public:
+  PropsUserData(void *user_data);
+  static constexpr const char *key = "user_data";
+  using prop_tag = ptr_prop_tag;
+};
+
 } // namespace props
 } // namespace nntrainer
 

--- a/nntrainer/utils/meson.build
+++ b/nntrainer/utils/meson.build
@@ -3,13 +3,16 @@ util_sources = [
   'profiler.cpp',
   'ini_wrapper.cpp',
   'node_exporter.cpp',
-  'base_properties.cpp'
+  'base_properties.cpp',
+  'nntr_threads.cpp'
 ]
 
 util_headers = [
   'base_properties.h',
   'node_exporter.h',
   'util_func.h',
+  'profiler.h',
+  'nntr_threads.h'
 ]
 
 foreach s : util_sources

--- a/nntrainer/utils/nntr_threads.cpp
+++ b/nntrainer/utils/nntr_threads.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2022 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file nntr_threads.cpp
+ * @date 07 July 2022
+ * @brief Thread Management for NNTrainer
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <nntr_threads.h>
+
+namespace nntrainer {
+
+ParallelBatch::ParallelBatch(threaded_cb threaded_cb, unsigned int batch_size,
+                             void *user_data_) :
+  cb(threaded_cb),
+  batch(batch_size),
+  num_workers(NNTR_NUM_THREADS > batch ? 1 : NNTR_NUM_THREADS),
+  user_data_prop(new props::PropsUserData(user_data_)) {}
+
+ParallelBatch::~ParallelBatch() {}
+
+void ParallelBatch::run() {
+
+  unsigned int start = 0;
+  unsigned int end = batch;
+
+  unsigned int chunk = (end - start + (num_workers - 1)) / num_workers;
+
+  for (unsigned int i = 0; i < num_workers; ++i) {
+    unsigned int s = start + i * chunk;
+    unsigned int e = s + chunk;
+    if (e > end)
+      e = end;
+    workers.push_back(std::thread(cb, s, e, user_data_prop->get()));
+  }
+
+  for (unsigned int i = 0; i < num_workers; ++i)
+    workers[i].join();
+}
+
+} // namespace nntrainer

--- a/nntrainer/utils/nntr_threads.h
+++ b/nntrainer/utils/nntr_threads.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2022 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file nntr_threads.h
+ * @date 07 July 2022
+ * @brief Thread Management for NNTrainer
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#ifndef __NNTR_THREADS_H__
+#define __NNTR_THREADS_H__
+
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <common_properties.h>
+#include <nntrainer_error.h>
+#include <util_func.h>
+
+typedef void (*loop_cb)(unsigned int start, unsigned int end, void *user_data);
+
+typedef std::function<std::remove_pointer<loop_cb>::type> threaded_cb;
+
+namespace nntrainer {
+
+/**
+ * @brief ParallelBatch class to parallelize along batch direction
+ *
+ */
+class ParallelBatch {
+public:
+  /**
+   * @brief Construct a new ParallelBatch object
+   *
+   */
+  ParallelBatch(threaded_cb threaded_cb, unsigned int batch, void *user_data_);
+
+  /**
+   * @brief Destroy the ParallelBatch object
+   *
+   */
+  ~ParallelBatch();
+
+  /**
+   * @brief Run the workders
+   *
+   */
+  void run();
+
+private:
+  threaded_cb cb;
+  unsigned int batch;
+  unsigned int num_workers;
+  std::vector<std::thread> workers;
+  std::unique_ptr<props::PropsUserData> user_data_prop;
+};
+
+} // namespace nntrainer
+#endif // __NODE_EXPORTER_H__

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -479,6 +479,8 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/common_properties.h
 %{_includedir}/nntrainer/base_properties.h
 %{_includedir}/nntrainer/node_exporter.h
+%{_includedir}/nntrainer/nntr_threads.h
+%{_includedir}/nntrainer/profiler.h
 # tensor headers
 %{_includedir}/nntrainer/tensor.h
 %{_includedir}/nntrainer/tensor_wrap_specs.h


### PR DESCRIPTION
### [ Layers ] Add Parallelization along batch direction

```.This patch demostrate the batch direction parallelization with conv2d
calcDerivatives.
. add the meson option with 'nntr-num-threads' key and int value.
. add extra compile option, NNTR_NUM_THREADS ( default value is 1 )

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

```

### [ Utils ] create NNTrThread Features 

```
.This patch includes the NNTrThreads Features. This will be used for the
Multi-Thread Feature of nntrainer, such as Thread Pool, for loop
multi-threading along batch direction.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

```
Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
