### PR TITLE
[Wait for #1954][ Layer ] Conv2d Gradient Computation with Multi-Threads @open sesame 08/01 07:49

### DIFF
--- a/nntrainer/layers/acti_func.cpp
+++ b/nntrainer/layers/acti_func.cpp
@@ -255,7 +255,10 @@ float ActiFunc::sigmoidPrime(float x) {
   return x * (1.0f - x);
 }
 
-float ActiFunc::tanhFloat(float x) { return (float)tanh(x); }
+float ActiFunc::tanhFloat(float x) {
+  // return (float)tanh(x); Using sigmoid implementaion for latency reason.
+  return 2.0 * sigmoid(2.0 * x) - 1.0;
+}
 
 float ActiFunc::tanhPrime(float x) {
   // float th = (float)tanh(x);

--- a/nntrainer/utils/nntr_threads.cpp
+++ b/nntrainer/utils/nntr_threads.cpp
@@ -15,6 +15,12 @@
 
 namespace nntrainer {
 
+ParallelBatch::ParallelBatch(unsigned int batch_size) :
+  cb(nullptr),
+  batch(batch_size),
+  num_workers(NNTR_NUM_THREADS > batch ? 1 : NNTR_NUM_THREADS),
+  user_data_prop(new props::PropsUserData(nullptr)){};
+
 ParallelBatch::ParallelBatch(threaded_cb threaded_cb_, unsigned int batch_size,
                              void *user_data_) :
   cb(threaded_cb_),
@@ -25,6 +31,10 @@ ParallelBatch::ParallelBatch(threaded_cb threaded_cb_, unsigned int batch_size,
 ParallelBatch::~ParallelBatch() {}
 
 void ParallelBatch::run() {
+
+  if (!cb) {
+    throw std::invalid_argument("nntrainer threads: callback is not defined");
+  }
 
   unsigned int start = 0;
   unsigned int end = batch;
@@ -41,6 +51,11 @@ void ParallelBatch::run() {
 
   std::for_each(workers.begin(), workers.end(),
                 std::mem_fn(&std::thread::join));
+}
+
+void ParallelBatch::setCallback(threaded_cb threaded_cb_, void *user_data_) {
+  cb = threaded_cb_;
+  user_data_prop = std::make_unique<props::PropsUserData>(user_data_);
 }
 
 } // namespace nntrainer

--- a/nntrainer/utils/nntr_threads.h
+++ b/nntrainer/utils/nntr_threads.h
@@ -34,6 +34,14 @@ class ParallelBatch {
 public:
   /**
    * @brief Construct a new ParallelBatch object
+   * @param unsigned int total number of batch
+   *
+   */
+
+  ParallelBatch(unsigned int batch);
+
+  /**
+   * @brief Construct a new ParallelBatch object
    * @param threaded_cb the function run in thread
    * @param unsigned int total number of batch
    * @param void* user data for the threaded callback function
@@ -52,6 +60,13 @@ public:
    *
    */
   void run();
+
+  /**
+   * @brief set the thread callback function
+   * @param Threadedcb the function run in thread
+   * @param void* user data for the threaded callback function
+   */
+  void setCallback(threaded_cb t_cb, void *user_data);
 
   /**
    * @brief return the number of workders


### PR DESCRIPTION
### [ Layer ] Conv2d Gradient Computation with Multi-Threads
```
. This patch includes multi-threading for gradient computation of conv2d
layer.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped
```
### [ Activation ] improve tanh computaion
```
This patch improves the computation of tanh.
Rather than calling tanh fuction, it is faster when
sigmoid is used.

tanh(x) = 2.0*sigmoid(2.0*x) -1.0;

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped
```
Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
