### PR TITLE
Fix inappropriate SPDX license tag

### DIFF
--- a/Applications/Resnet/res/resnet18.ini
+++ b/Applications/Resnet/res/resnet18.ini
@@ -1,5 +1,5 @@
-#
-# SPDX-License_Identifier: Apache-2.0
+##
+# SPDX-License-Identifier: Apache-2.0
 # @file resnet18.ini
 # @author Jijoong Moon <jijoong.moon@samsung.com>
 # @date Jan 27 2021


### PR DESCRIPTION
SPDX-License_Identifier --> SPDX-License-Identifier

Added one more # to the first line for doxygen.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>