### PR TITLE
[neuralnet] adjust epoch_idx when stop_cb is called

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -822,8 +822,11 @@ int NeuralNetwork::train_run(std::function<bool(void *userdata)> stop_cb) {
   };
 
   auto epochs = getEpochs();
-  for (epoch_idx = epoch_idx + 1; epoch_idx <= epochs && !stop_cb(nullptr);
-       ++epoch_idx) {
+  for (epoch_idx = epoch_idx + 1; epoch_idx <= epochs; ++epoch_idx) {
+    if (stop_cb(nullptr)) {
+      --epoch_idx;
+      break;
+    }
     training = run_epoch(train_buffer.get(), true, train_for_iteration,
                          update_train_stat, train_epoch_end);
     if (valid_buffer) {


### PR DESCRIPTION
 - Assume that stop_cb immediately called so reduce current epoch_idx by 1

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>