### PR TITLE
[ UTIL ] add frequency data in mem_usage.sh

### DIFF
--- a/Applications/utils/mem_usage.sh
+++ b/Applications/utils/mem_usage.sh
@@ -18,10 +18,19 @@ count=0
 while true; do
     if [ -d "/proc/$process_id" ]; then
 	output=`grep VmHWM /proc/$process_id/status`
-	IFS=' ' read -ra mem_str <<< "$output"
+	read -ra mem_str <<< "$output"
 	count=$((count + 1))
 	mem_usage=$((${mem_str[1]}))
-	outlog="$outlog$count $mem_usage kB\n"
+	cpu_output=""
+	n=`nproc`
+	i=0
+	while [ "$i" -lt $n ]
+	do
+	    cpu_freq=`cat /sys/devices/system/cpu/cpu$i/cpufreq/scaling_cur_freq`
+	    cpu_output="$cpu_output $cpu_freq"
+	    i=$(expr $i + 1)
+	done
+	outlog="$outlog$count $mem_usage kB $cpu_output\n"
 	let mem_peak='mem_usage > mem_peak ? mem_usage : mem_peak'
 	sleep 1s # configure the sleep time if the program does not run long enough
     else


### PR DESCRIPTION
Sometimes, cpu frequency check is required.
This patch includes the cpu frequency logging in mem_usage.sh

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>