### PR TITLE
[Property] Remove if-else statement in DroupOutRate::isValid()

### DIFF
--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -49,12 +49,7 @@ Normalization::Normalization(bool value) { set(value); }
 
 Standardization::Standardization(bool value) { set(value); }
 
-bool DropOutRate::isValid(const float &v) const {
-  if (v < 0.0)
-    return false;
-  else
-    return true;
-}
+bool DropOutRate::isValid(const float &v) const { return v >= 0.0; }
 
 void RandomTranslate::set(const float &value) {
   Property<float>::set(std::abs(value));


### PR DESCRIPTION
[Property] Remove if-else statement in DroupOutRate::isValid()

- Remove if-else statement

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: hyunil park <hyunil46.park@samsung.com>