### PR TITLE
[CAPI] Add attention, mol attention and multi head attention to CAPI @open sesame 08/30 14:47

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -60,6 +60,12 @@ enum LayerType {
   LAYER_RNNCELL = ML_TRAIN_LAYER_TYPE_RNNCELL,   /**< RNN Cell Layer type */
   LAYER_ZONEOUT_LSTMCELL =
     ML_TRAIN_LAYER_TYPE_ZONEOUTLSTMCELL, /**< Zoneout LSTM Cell Layer type */
+  LAYER_ATTENTION = ML_TRAIN_LAYER_TYPE_ATTENTION, /**< Attention Layer type */
+  LAYER_MOL_ATTENTION =
+    ML_TRAIN_LAYER_TYPE_MOL_ATTENTION, /**< MoL Attention Layer type */
+  LAYER_MULTI_HEAD_ATTENTION =
+    ML_TRAIN_LAYER_TYPE_MULTI_HEAD_ATTENTION, /**< Multi Head Attention Layer
+                                                 type */
   LAYER_PREPROCESS_FLIP =
     ML_TRAIN_LAYER_TYPE_PREPROCESS_FLIP, /**< Preprocess flip Layer type */
   LAYER_PREPROCESS_TRANSLATE =
@@ -79,9 +85,6 @@ enum LayerType {
                                                      */
   LAYER_TIME_DIST,                /**< Time Distributed Layer type */
   LAYER_BACKBONE_TFLITE,          /**< Backbone using TFLite */
-  LAYER_ATTENTION,                /**< Attention Layer type */
-  LAYER_MOL_ATTENTION,            /**< MoL Attention Layer type */
-  LAYER_MULTI_HEAD_ATTENTION,     /**< Multi Head Attention Layer type */
   LAYER_RESHAPE,                  /**< Reshape Layer type */
   LAYER_REDUCE_MEAN,              /**< Reduce mean Layer type */
   LAYER_IDENTITY,                 /**< Identity Layer type */


### PR DESCRIPTION
[CAPI] Add attention, mol attention and multi head attention to CAPI
- Add LAYER_ATTENTION
- Add LAYER_MOL_ATTENTION
- Add LAYER_MULTI_HEAD_ATTENTION

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: hyunil park <hyunil46.park@samsung.com>