### PR TITLE
[activation] Overwrite derivative in softmax

### DIFF
--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -49,20 +49,21 @@ public:
   /**
    * @brief run function
    *
-   * @param[in] x : input
+   * @param[in] input : input
    * @param[out] output : output
    */
-  void run_fn(Tensor const &x, Tensor &output);
+  void run_fn(Tensor const &input, Tensor &output);
 
   /**
    * @brief run prime function
    *
-   * @param[in] in : input
-   * @param[out] ret : output
-   * @param[in] deriv : derivative
+   * @param[in] output output
+   * @param[out] outgoing_derivative outgoing derivative
+   * @param[in] incoming_derivative incoming derivative
    * @retVal    Tensor
    */
-  Tensor &run_prime_fn(Tensor &in, Tensor &ret, Tensor const &deriv);
+  Tensor &run_prime_fn(Tensor &output, Tensor &outgoing_derivative,
+                       Tensor const &incoming_derivative);
 
   /**
    * @copydoc Layer::supportInPlace()
@@ -71,21 +72,21 @@ public:
 
   /**
    * @brief       Calculate softmax for Tensor Type
-   * @param[in] x Tensor
+   * @param[in] input input Tensor
    * @param[out] output output Tensor
    * @retval      Tensor
    */
-  static Tensor &softmax(Tensor const &x, Tensor &output);
+  static Tensor &softmax(Tensor const &input, Tensor &output);
 
   /**
-   * @brief     derivative softmax function for Tensor Type
-   * @param[in] x Tensor
-   * @param[out] output output Tensor
-   * @param[in] derivative derivative Tensor from next layer
+   * @brief     Calculate derivative of softmax function
+   * @param[in] output output tensor
+   * @param[out] outgoing_derivative result of calculated derivative of softmax
+   * @param[in] incoming_derivative incoming derivative tensor from next layer
    * @retVal    Tensor
    */
-  static Tensor &softmaxPrime(Tensor const &x, Tensor &output,
-                              Tensor const &derivative = Tensor());
+  static Tensor &softmaxPrime(Tensor const &output, Tensor &outgoing_derivative,
+                              Tensor const &incoming_derivative = Tensor());
 
   /**
    * @brief     sigmoid activation function

--- a/nntrainer/layers/attention_layer.cpp
+++ b/nntrainer/layers/attention_layer.cpp
@@ -18,7 +18,7 @@
 
 namespace nntrainer {
 
-AttentionLayer::AttentionLayer() {
+AttentionLayer::AttentionLayer() : sm(ActivationType::ACT_SOFTMAX) {
   wt_idx.fill(std::numeric_limits<unsigned>::max());
 }
 
@@ -26,7 +26,7 @@ AttentionLayer::~AttentionLayer() {}
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
-enum AttentionParams { query = 0, value = 1, key = 2, score, weights };
+enum AttentionParams { query = 0, value = 1, key = 2, weights };
 
 void AttentionLayer::finalizeCommon(InitLayerContext &context) {
   if (context.getNumInputs() < 2 || context.getNumInputs() > 3)
@@ -55,8 +55,6 @@ void AttentionLayer::finalizeCommon(InitLayerContext &context) {
 void AttentionLayer::finalize(InitLayerContext &context) {
   finalizeCommon(context);
 
-  sm.setActiFunc(ActivationType::ACT_SOFTMAX);
-
   auto const &all_dims = context.getInputDimensions();
   auto const &query_dim = all_dims[AttentionParams::query];
   auto const &value_dim = all_dims[AttentionParams::value];
@@ -66,10 +64,6 @@ void AttentionLayer::finalize(InitLayerContext &context) {
   wt_idx[AttentionParams::weights] =
     context.requestTensor(weights_dim, "weights", Tensor::Initializer::NONE,
                           false, TensorLifespan::ITERATION_LIFESPAN);
-
-  wt_idx[AttentionParams::score] =
-    context.requestTensor(weights_dim, "score", Tensor::Initializer::NONE,
-                          false, TensorLifespan::FORWARD_FUNC_LIFESPAN);
 
   context.setOutputDimensions({query_dim});
 }
@@ -81,11 +75,10 @@ void AttentionLayer::forwarding(RunLayerContext &context, bool training) {
 
   Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
   Tensor &weights = context.getTensor(wt_idx[AttentionParams::weights]);
-  Tensor &score = context.getTensor(wt_idx[AttentionParams::score]);
 
-  query.dotBatched(key, score, false, true); /** dot 1 */
-  sm.run_fn(score, weights);                 /** softmax */
-  weights.dotBatched(value, output);         /** dot 2 */
+  query.dotBatched(key, weights, false, true); /** dot 1 */
+  sm.run_fn(weights, weights);                 /** softmax */
+  weights.dotBatched(value, output);           /** dot 2 */
 }
 
 void AttentionLayer::calcDerivative(RunLayerContext &context) {
@@ -111,12 +104,11 @@ void AttentionLayer::calcDerivative(RunLayerContext &context) {
   weights.dot_batched_deriv_wrt_2(dvalue, derivative);
 
   /** derivative for softmax */
-  Tensor dscore;
-  sm.run_prime_fn(weights, dscore, dweight);
+  sm.run_prime_fn(weights, dweight, dweight);
 
   /** derivative for dot 1 */
-  dquery.dot_batched_deriv_wrt_1(key, dscore, false, true);
-  query.dot_batched_deriv_wrt_2(dkey, dscore, false, true,
+  dquery.dot_batched_deriv_wrt_1(key, dweight, false, true);
+  query.dot_batched_deriv_wrt_2(dkey, dweight, false, true,
                                 context.getNumInputs() == 2);
 }
 
@@ -129,7 +121,6 @@ void AttentionLayer::setProperty(const std::vector<std::string> &values) {
 }
 
 void AttentionLayer::setBatch(RunLayerContext &context, unsigned int batch) {
-  context.updateTensor(wt_idx[AttentionParams::score], batch);
   context.updateTensor(wt_idx[AttentionParams::weights], batch);
 }
 

--- a/nntrainer/layers/attention_layer.h
+++ b/nntrainer/layers/attention_layer.h
@@ -104,7 +104,7 @@ protected:
 
 private:
   ActiFunc sm;                        /** softmax activation operation */
-  std::array<unsigned int, 5> wt_idx; /**< indices of the weights and tensors */
+  std::array<unsigned int, 4> wt_idx; /**< indices of the weights and tensors */
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/multi_head_attention_layer.h
+++ b/nntrainer/layers/multi_head_attention_layer.h
@@ -108,7 +108,7 @@ private:
     multi_head_attention_props; /**< multi_head_attention layer properties */
 
   ActiFunc sm; /** softmax activation operation */
-  std::array<unsigned int, 16>
+  std::array<unsigned int, 14>
     weight_idx; /**< indices of the weights and tensors */
 
   /**


### PR DESCRIPTION
Commit 1:     [mol attention] adjust tensor lifespan to save memory
    
     - Modify tensor lifespan of fc_out to FORWARD_FUNC_LIFESPAN
     - remove unused enum updated_state
     - Change param enum name from AttentionParams to MoLAttentionParams
    
    Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>

Commit 2:     [activation] revise softmaxPrime to overwrite incoming derivative
    
     - Revise softmaxPrime to overwrite incoming derivative by using additional temp memory
     - Remove attention_score tensor in attention/multi_head_attention layer
     - Reuse temporary tensor for softmax in mol attention layer
    
    close #1986
    
    Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>