### PR TITLE
[unittest] add negative unittest

### DIFF
--- a/test/unittest/datasets/data_producer_common_tests.cpp
+++ b/test/unittest/datasets/data_producer_common_tests.cpp
@@ -60,7 +60,7 @@ void DataProducerSemantics::SetUp() {
   }
 }
 
-TEST_P(DataProducerSemantics, finalize_pn) {
+TEST_P(DataProducerSemantics, finalize_p_n) {
   if (result == DataProducerSemanticsExpectedResult::FAIL_AT_FINALIZE) {
     EXPECT_ANY_THROW(producer->finalize(input_dims, label_dims));
   } else {
@@ -68,7 +68,7 @@ TEST_P(DataProducerSemantics, finalize_pn) {
   }
 }
 
-TEST_P(DataProducerSemantics, error_once_or_not_pn) {
+TEST_P(DataProducerSemantics, error_once_or_not_p_n) {
   if (result == DataProducerSemanticsExpectedResult::FAIL_AT_FINALIZE) {
     return; // skip this test
   }
@@ -85,7 +85,7 @@ TEST_P(DataProducerSemantics, error_once_or_not_pn) {
   }
 }
 
-TEST_P(DataProducerSemantics, fetch_one_epoch_or_10_iteration_pn) {
+TEST_P(DataProducerSemantics, fetch_one_epoch_or_10_iteration_p_n) {
   if (result != DataProducerSemanticsExpectedResult::SUCCESS) {
     return; // skip this test
   }

--- a/test/unittest/datasets/unittest_databuffer.cpp
+++ b/test/unittest/datasets/unittest_databuffer.cpp
@@ -65,6 +65,11 @@ TEST(DataBuffer, fetchIteration_p) {
   }
 }
 
+TEST(DataBuffer, fetchWithoutProducer_n) {
+  nntrainer::DataBuffer db(nullptr);
+  EXPECT_THROW(db.fetch(), std::runtime_error);
+}
+
 TEST(DataBuffer, fetchWithoutStart_n) {
   std::unique_ptr<nntrainer::DataProducer> prod =
     std::make_unique<nntrainer::RandomDataOneHotProducer>();

--- a/test/unittest/layers/unittest_layer_node.cpp
+++ b/test/unittest/layers/unittest_layer_node.cpp
@@ -2,7 +2,7 @@
 /**
  * Copyright (C) 2020 Parichay Kapoor <pk.kapoor@samsung.com>
  *
- * @file        unittest_nntrainer_layers.cpp
+ * @file        unittest_layer_node.cpp
  * @date        02 July 2021
  * @brief       Unit test utility for layer node
  * @see         https://github.com/nnstreamer/nntrainer
@@ -12,17 +12,43 @@
 
 #include <gtest/gtest.h>
 
-#include <fc_layer.h>
+#include <identity_layer.h>
 #include <layer_node.h>
 #include <nntrainer_error.h>
 #include <tensor_dim.h>
 #include <var_grad.h>
 
 /**
+ * @brief createLayerNode with unknown layer type
+ */
+TEST(nntrainer_LayerNode, createLayerNode_01_n) {
+  EXPECT_THROW(nntrainer::createLayerNode(ml::train::LayerType::LAYER_UNKNOWN),
+               std::invalid_argument);
+}
+
+/**
+ * @brief createLayerNode with unknown layer string
+ */
+TEST(nntrainer_LayerNode, createLayerNode_02_n) {
+  EXPECT_THROW(nntrainer::createLayerNode("unknown_layer"),
+               std::invalid_argument);
+}
+
+/**
+ * @brief createLayerNode with empty string
+ */
+TEST(nntrainer_LayerNode, createLayerNode_03_n) {
+  EXPECT_THROW(nntrainer::createLayerNode(""), std::invalid_argument);
+}
+
+/**
  * @brief test distribute property
  */
 TEST(nntrainer_LayerNode, setDistribute_01_p) {
-  auto lnode = nntrainer::createLayerNode(nntrainer::FullyConnectedLayer::type);
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
 
   EXPECT_EQ(false, lnode->getDistribute());
 
@@ -35,55 +61,350 @@ TEST(nntrainer_LayerNode, setDistribute_01_p) {
  * @brief test flatten property
  */
 TEST(nntrainer_LayerNode, setFlatten_01_p) {
-  auto lnode = nntrainer::createLayerNode(nntrainer::FullyConnectedLayer::type);
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
   EXPECT_NO_THROW(lnode->setProperty({"flatten=true"}));
 }
 
 /**
- * @brief test finalize with wrong context
+ * @brief finalize with empty input shape and input dimension
  */
 TEST(nntrainer_LayerNode, finalize_01_n) {
-  auto lnode = nntrainer::createLayerNode(nntrainer::FullyConnectedLayer::type);
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
   EXPECT_ANY_THROW(lnode->finalize());
 }
 
 /**
- * @brief test finalize with wrong context
+ * @brief finalize with empty input info
  */
 TEST(nntrainer_LayerNode, finalize_02_n) {
-  auto lnode = nntrainer::createLayerNode(nntrainer::FullyConnectedLayer::type);
-  lnode->setProperty({"name=abc"});
-  EXPECT_ANY_THROW(lnode->finalize());
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+  EXPECT_NO_THROW(lnode->setProperty({"name=abc"}));
+
+  EXPECT_THROW(lnode->finalize(), std::invalid_argument);
 }
 
 /**
- * @brief test finalize with wrong context
+ * @brief finalize with empty name
  */
 TEST(nntrainer_LayerNode, finalize_03_n) {
-  auto lnode = nntrainer::createLayerNode(nntrainer::FullyConnectedLayer::type);
-  lnode->setProperty({"input_shape=1:1:1"});
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+  EXPECT_NO_THROW(lnode->setProperty({"input_shape=1:1:1"}));
+
   EXPECT_ANY_THROW(lnode->finalize());
 }
 
 /**
- * @brief test finalize with right context
+ * @brief finalize
  */
 TEST(nntrainer_LayerNode, finalize_04_p) {
-  auto lnode = nntrainer::createLayerNode(nntrainer::FullyConnectedLayer::type);
-  lnode->setProperty({"input_shape=1:1:1", "name=abc", "unit=4"});
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+  EXPECT_NO_THROW(lnode->setProperty({"input_shape=1:1:1", "name=abc"}));
   EXPECT_NO_THROW(lnode->finalize());
 }
 
 /**
- * @brief test double finalize
+ * @brief finalize twice
  */
 TEST(nntrainer_LayerNode, finalize_05_n) {
-  auto lnode = nntrainer::createLayerNode(nntrainer::FullyConnectedLayer::type);
-  lnode->setProperty({"input_shape=1:1:1", "name=abc", "unit=4"});
-  EXPECT_NO_THROW(lnode->finalize());
+  std::unique_ptr<nntrainer::LayerNode> lnode;
   nntrainer::Var_Grad input = nntrainer::Var_Grad(
     nntrainer::TensorDim({1, 1, 1, 1}), nntrainer::Tensor::Initializer::NONE,
     true, false, "dummy");
-  lnode->configureRunContext({}, {&input}, {}, {});
-  EXPECT_ANY_THROW(lnode->finalize());
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+  EXPECT_NO_THROW(lnode->setProperty({"input_shape=1:1:1", "name=abc"}));
+  EXPECT_NO_THROW(lnode->finalize());
+  EXPECT_NO_THROW(lnode->configureRunContext({}, {&input}, {}, {}));
+  EXPECT_THROW(lnode->finalize(), std::runtime_error);
+}
+
+/**
+ * @brief getRunContext for empty run_context
+ */
+TEST(nntrainer_LayerNode, getRunContext_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getRunContext(), std::runtime_error);
+}
+
+/**
+ * @brief getInputDimensions for empty run_context
+ */
+TEST(nntrainer_LayerNode, getInputDimensions_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getInputDimensions(), std::runtime_error);
+}
+
+/**
+ * @brief getOutputDimensions for empty run_context
+ */
+TEST(nntrainer_LayerNode, getOutputDimensions_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getOutputDimensions(), std::runtime_error);
+}
+
+/**
+ * @brief getNumInputs for empty run_context
+ */
+TEST(nntrainer_LayerNode, getNumInputs_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getNumInputs(), std::runtime_error);
+}
+
+/**
+ * @brief getInput for empty run_context
+ */
+TEST(nntrainer_LayerNode, getInput_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getInput(0), std::runtime_error);
+}
+
+/**
+ * @brief getInputGrad for empty run_context
+ */
+TEST(nntrainer_LayerNode, getInputGrad_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getInputGrad(0), std::runtime_error);
+}
+
+/**
+ * @brief getNumOutputs for empty run_context
+ */
+TEST(nntrainer_LayerNode, getNumOutputs_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getNumOutputs(), std::runtime_error);
+}
+
+/**
+ * @brief getOutput for empty run_context
+ */
+TEST(nntrainer_LayerNode, getOutput_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getOutput(0), std::runtime_error);
+}
+
+/**
+ * @brief getOutputGrad for empty run_context
+ */
+TEST(nntrainer_LayerNode, getOutputGrad_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getOutputGrad(0), std::runtime_error);
+}
+
+/**
+ * @brief getNumWeights for empty run_context
+ */
+TEST(nntrainer_LayerNode, getNumWeights) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getNumWeights(), std::runtime_error);
+}
+
+/**
+ * @brief getWeights for empty run_context
+ */
+TEST(nntrainer_LayerNode, getWeights_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getWeights(), std::runtime_error);
+}
+
+/**
+ * @brief setWeights for empty run_context
+ */
+TEST(nntrainer_LayerNode, setWeights_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+  const std::vector<float *> weights({new float});
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+  EXPECT_THROW(lnode->setWeights(weights), std::runtime_error);
+}
+
+/**
+ * @brief setWeights with non matched size of weights
+ */
+TEST(nntrainer_LayerNode, setWeights_02_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+  nntrainer::Weight weight =
+    nntrainer::Weight(nntrainer::TensorDim({1, 1, 1, 1}),
+                      nntrainer::Tensor::Initializer::XAVIER_UNIFORM,
+                      nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, 0.0f,
+                      true, false, "weight");
+  float *float_ptr[2];
+  const std::vector<float *> new_weights({float_ptr[0], float_ptr[1]});
+  nntrainer::Var_Grad input = nntrainer::Var_Grad(
+    nntrainer::TensorDim({1, 1, 1, 1}), nntrainer::Tensor::Initializer::NONE,
+    true, false, "dummy");
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+  EXPECT_NO_THROW(lnode->setProperty({"input_shape=1:1:1", "name=abc"}));
+  EXPECT_NO_THROW(lnode->configureRunContext({&weight}, {&input}, {}, {}));
+
+  EXPECT_THROW(lnode->setWeights(new_weights), std::runtime_error);
+}
+
+/**
+ * @brief getWeight for empty run_context
+ */
+TEST(nntrainer_LayerNode, getWeight_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getWeight(0), std::runtime_error);
+}
+
+/**
+ * @brief getWeightObject for empty run_context
+ */
+TEST(nntrainer_LayerNode, getWeightObject_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getWeightObject(0), std::runtime_error);
+}
+
+/**
+ * @brief getWeightName for empty run_context
+ */
+TEST(nntrainer_LayerNode, getWeightName_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getWeightName(0), std::runtime_error);
+}
+
+/**
+ * @brief getWeightWrapper for empty run_context
+ */
+TEST(nntrainer_LayerNode, getWeightWrapper_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->getWeightWrapper(0), std::runtime_error);
+}
+
+/**
+ * @brief getWeightGrad for empty run_context
+ */
+TEST(nntrainer_LayerNode, getWeightGrad_01_n) {
+  auto lnode = nntrainer::createLayerNode(nntrainer::IdentityLayer::type);
+  EXPECT_THROW(lnode->getWeightGrad(0), std::runtime_error);
+}
+
+/**
+ * @brief clearOptVar for empty run_context
+ */
+TEST(nntrainer_LayerNode, clearOptVar_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->clearOptVar(), std::runtime_error);
+}
+
+/**
+ * @brief read for empty run_context
+ */
+TEST(nntrainer_LayerNode, read_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+  std::ifstream ifstream("filename", std::ios_base::in | std::ios_base::binary);
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->read(ifstream), std::runtime_error);
+}
+
+/**
+ * @brief save for empty run_context
+ */
+TEST(nntrainer_LayerNode, save_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+  std::ofstream ofstream("filename", std::ios_base::in | std::ios_base::binary);
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->save(ofstream), std::runtime_error);
+}
+
+/**
+ * @brief setBatch for empty run_context
+ */
+TEST(nntrainer_LayerNode, setBatch_01_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+
+  EXPECT_THROW(lnode->setBatch(0), std::invalid_argument);
 }

--- a/test/unittest/memory/unittest_memory_pool.cpp
+++ b/test/unittest/memory/unittest_memory_pool.cpp
@@ -57,16 +57,29 @@ TEST(MemoryPool, request_mem_03_n) {
 }
 
 /**
+ * @brief request memory after allocate
+ */
+TEST(MemoryPool, request_mem_04_n) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_NO_THROW(pool.requestMemory(1, 4, 5));
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_THROW(pool.requestMemory(1, 5, 6), std::invalid_argument);
+}
+
+/**
  * @brief request memory
  */
-TEST(MemoryPool, request_mem_04_p) {
+TEST(MemoryPool, request_mem_05_p) {
   nntrainer::MemoryPool pool;
 
   EXPECT_NO_THROW(pool.requestMemory(1, 4, 5));
 }
 
 /**
- * @brief plan layout
+ * @brief plan layout without reqeustMemory
  */
 TEST(MemoryPool, plan_layout_01_n) {
   nntrainer::MemoryPool pool;
@@ -75,13 +88,16 @@ TEST(MemoryPool, plan_layout_01_n) {
 }
 
 /**
- * @brief plan layout
+ * @brief plan layout after allocate
  */
-TEST(MemoryPool, plan_layout_02_p) {
+TEST(MemoryPool, plan_layout_02_n) {
   nntrainer::MemoryPool pool;
 
-  pool.requestMemory(1, 4, 5);
+  EXPECT_NO_THROW(pool.requestMemory(1, 4, 5));
   EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_THROW(pool.planLayout(nntrainer::BasicPlanner()), std::runtime_error);
 }
 
 /**
@@ -106,49 +122,41 @@ TEST(MemoryPool, deallocate_01_p) {
   nntrainer::MemoryPool pool;
 
   EXPECT_NO_THROW(pool.deallocate());
+
+  pool.requestMemory(1, 4, 5);
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_NO_THROW(pool.deallocate());
 }
 
 /**
- * @brief allocate
+ * @brief allocate without requestMemory
  */
 TEST(MemoryPool, allocate_01_n) {
   nntrainer::MemoryPool pool;
 
   EXPECT_THROW(pool.allocate(), std::runtime_error);
-
-  pool.requestMemory(1, 4, 5);
-  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
-  EXPECT_EQ(1u, pool.size());
-
-  EXPECT_NO_THROW(pool.allocate());
-
-  EXPECT_NO_THROW(pool.deallocate());
 }
 
 /**
- * @brief allocate
+ * @brief allocate without planLayout
  */
-TEST(MemoryPool, allocate_02_p) {
+TEST(MemoryPool, allocate_02_n) {
   nntrainer::MemoryPool pool;
 
   pool.requestMemory(1, 4, 5);
-  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
-  EXPECT_EQ(1u, pool.size());
-
-  EXPECT_NO_THROW(pool.allocate());
-
-  EXPECT_NO_THROW(pool.deallocate());
+  EXPECT_THROW(pool.allocate(), std::runtime_error);
 }
 
 /**
- * @brief allocate
+ * @brief allocate aftrer allocate
  */
 TEST(MemoryPool, allocate_03_n) {
   nntrainer::MemoryPool pool;
 
   pool.requestMemory(1, 4, 5);
   EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
-  EXPECT_EQ(1u, pool.size());
 
   EXPECT_NO_THROW(pool.allocate());
 
@@ -160,7 +168,7 @@ TEST(MemoryPool, allocate_03_n) {
 /**
  * @brief allocate
  */
-TEST(MemoryPool, allocate_04_n) {
+TEST(MemoryPool, allocate_04_p) {
   nntrainer::MemoryPool pool;
 
   pool.requestMemory(3, 4, 5);
@@ -183,23 +191,6 @@ TEST(MemoryPool, size_01_p) {
   nntrainer::MemoryPool pool;
 
   EXPECT_EQ(pool.size(), 0u);
-}
-
-/**
- * @brief size of the pool
- */
-TEST(MemoryPool, size_02_p) {
-  nntrainer::MemoryPool pool;
-
-  pool.requestMemory(1, 4, 5);
-  EXPECT_EQ(pool.size(), 0u);
-}
-
-/**
- * @brief size of the pool
- */
-TEST(MemoryPool, size_03_p) {
-  nntrainer::MemoryPool pool;
 
   pool.requestMemory(1, 4, 5);
   EXPECT_EQ(pool.size(), 0u);
@@ -220,26 +211,6 @@ TEST(MemoryPool, min_mem_req_01_p) {
   nntrainer::MemoryPool pool;
 
   EXPECT_EQ(pool.minMemoryRequirement(), 0u);
-}
-
-/**
- * @brief min requirement
- */
-TEST(MemoryPool, min_mem_req_02_p) {
-  nntrainer::MemoryPool pool;
-
-  pool.requestMemory(1, 4, 5);
-  EXPECT_EQ(pool.minMemoryRequirement(), 1u);
-
-  pool.planLayout(nntrainer::BasicPlanner());
-  EXPECT_EQ(pool.minMemoryRequirement(), 1u);
-}
-
-/**
- * @brief min requirement
- */
-TEST(MemoryPool, min_mem_req_03_p) {
-  nntrainer::MemoryPool pool;
 
   pool.requestMemory(1, 4, 5);
   EXPECT_EQ(pool.minMemoryRequirement(), 1u);
@@ -278,7 +249,7 @@ TEST(MemoryPool, min_mem_req_03_p) {
 /**
  * @brief min requirement
  */
-TEST(MemoryPool, min_mem_req_04_p) {
+TEST(MemoryPool, min_mem_req_02_p) {
   nntrainer::MemoryPool pool;
 
   pool.requestMemory(1, 5, 10);
@@ -305,7 +276,7 @@ TEST(MemoryPool, min_mem_req_04_p) {
 /**
  * @brief min requirement
  */
-TEST(MemoryPool, min_mem_req_05_p) {
+TEST(MemoryPool, min_mem_req_03_p) {
   nntrainer::MemoryPool pool;
 
   pool.requestMemory(1, 5, 10);
@@ -332,7 +303,7 @@ TEST(MemoryPool, min_mem_req_05_p) {
 /**
  * @brief min requirement
  */
-TEST(MemoryPool, min_mem_req_06_p) {
+TEST(MemoryPool, min_mem_req_04_p) {
   nntrainer::MemoryPool pool;
 
   pool.requestMemory(1, 5, 10);
@@ -412,6 +383,32 @@ TEST(MemoryPool, get_memory_04_p) {
   EXPECT_NE(mem, nullptr);
 
   EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief clear after allocate
+ */
+TEST(MemoryPool, clear_01_n) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_NO_THROW(pool.requestMemory(1, 4, 5));
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_THROW(pool.clear(), std::invalid_argument);
+  EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief clear
+ */
+TEST(MemoryPool, clear_02_p) {
+  nntrainer::MemoryPool pool;
+
+  EXPECT_NO_THROW(pool.requestMemory(1, 4, 5));
+  EXPECT_NO_THROW(pool.planLayout(nntrainer::BasicPlanner()));
+
+  EXPECT_NO_THROW(pool.clear());
 }
 
 /**

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -437,8 +437,8 @@ GTEST_PARAMETER_TEST(
 /**
  * @brief Ini file unittest with backbone with wrong file
  */
-TEST(nntrainerIniTest, backbone_n_01) {
-  ScopedIni s{"backbone_n1", {nw_base_cross, adam, backbone_random}};
+TEST(nntrainerIniTest, backbone_01_n) {
+  ScopedIni s{"backbone_01_n", {nw_base_cross, adam, backbone_random}};
   nntrainer::NeuralNetwork NN;
 
   EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_INVALID_PARAMETER);
@@ -447,9 +447,9 @@ TEST(nntrainerIniTest, backbone_n_01) {
 /**
  * @brief Ini file unittest with backbone with empty backbone
  */
-TEST(nntrainerIniTest, backbone_n_02) {
+TEST(nntrainerIniTest, backbone_02_n) {
   ScopedIni b{"base", {nw_base_cross}};
-  ScopedIni s{"backbone_n2", {nw_base_cross, adam, backbone_valid}};
+  ScopedIni s{"backbone_02_n", {nw_base_cross, adam, backbone_valid}};
   nntrainer::NeuralNetwork NN;
 
   EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_INVALID_PARAMETER);
@@ -458,9 +458,9 @@ TEST(nntrainerIniTest, backbone_n_02) {
 /**
  * @brief Ini file unittest with backbone with normal backbone
  */
-TEST(nntrainerIniTest, backbone_p_03) {
+TEST(nntrainerIniTest, backbone_03_p) {
   ScopedIni b{"base", {nw_base_cross, batch_normal}};
-  ScopedIni s{"backbone_p3", {nw_base_cross, adam, backbone_valid}};
+  ScopedIni s{"backbone_03_p", {nw_base_cross, adam, backbone_valid}};
   nntrainer::NeuralNetwork NN;
 
   EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_NONE);
@@ -469,9 +469,9 @@ TEST(nntrainerIniTest, backbone_p_03) {
 /**
  * @brief Ini file unittest with backbone without model parameters
  */
-TEST(nntrainerIniTest, backbone_p_04) {
+TEST(nntrainerIniTest, backbone_04_p) {
   ScopedIni b{"base", {flatten, conv2d}};
-  ScopedIni s{"backbone_p4", {nw_base_cross, adam, backbone_valid}};
+  ScopedIni s{"backbone_04_p", {nw_base_cross, adam, backbone_valid}};
   nntrainer::NeuralNetwork NN;
 
   EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_NONE);
@@ -480,7 +480,7 @@ TEST(nntrainerIniTest, backbone_p_04) {
 /**
  * @brief Ini file unittest matching model with and without backbone
  */
-TEST(nntrainerIniTest, backbone_p_05) {
+TEST(nntrainerIniTest, backbone_05_p) {
 
   /** Create a backbone.ini */
   ScopedIni b("base", {nw_base_cross, conv2d});
@@ -546,9 +546,9 @@ TEST(nntrainerIniTest, backbone_p_05) {
 /**
  * @brief Ini file unittest matching model with and without trainable
  */
-TEST(nntrainerIniTest, backbone_p_06) {
+TEST(nntrainerIniTest, backbone_06_p) {
   ScopedIni b("base", {flatten, conv2d});
-  ScopedIni s("backbone_p6", {nw_base_cross, adam, backbone_valid});
+  ScopedIni s("backbone_06_p", {nw_base_cross, adam, backbone_valid});
   nntrainer::NeuralNetwork NN;
 
   EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_NONE);
@@ -562,9 +562,9 @@ TEST(nntrainerIniTest, backbone_p_06) {
 /**
  * @brief Ini file unittest matching model with and without trainable
  */
-TEST(nntrainerIniTest, backbone_p_07) {
+TEST(nntrainerIniTest, backbone_07_p) {
   ScopedIni b("base", {conv2d});
-  ScopedIni s("backbone_p7",
+  ScopedIni s("backbone_07_p",
               {nw_base_mse, adam, backbone_notrain, backbone_train});
   nntrainer::NeuralNetwork NN;
 
@@ -579,8 +579,8 @@ TEST(nntrainerIniTest, backbone_p_07) {
 /**
  * @brief Ini file unittest with backbone with normal backbone
  */
-TEST(nntrainerIniTest, backbone_n_08) {
-  ScopedIni s("backbone_n8", {nw_base_mse, adam, backbone_random_external});
+TEST(nntrainerIniTest, backbone_08_n) {
+  ScopedIni s("backbone_08_n", {nw_base_mse, adam, backbone_random_external});
 
   nntrainer::NeuralNetwork NN;
 
@@ -596,8 +596,8 @@ TEST(nntrainerIniTest, backbone_n_08) {
 /**
  * @brief Ini file unittest with backbone with normal backbone
  */
-TEST(nntrainerIniTest, backbone_p_09) {
-  ScopedIni s("backbone_p9",
+TEST(nntrainerIniTest, backbone_09_p) {
+  ScopedIni s("backbone_09_p",
               {nw_base_mse + "-batch_size", adam, backbone_valid_external});
   nntrainer::NeuralNetwork NN;
 
@@ -614,17 +614,18 @@ TEST(nntrainerIniTest, backbone_p_09) {
  * @brief Ini file unittest with backbone
  * @note Input shape is provided in model file
  */
-TEST(nntrainerIniTest, backbone_n_15) {
+TEST(nntrainerIniTest, backbone_15_n) {
   ScopedIni base("base", {conv2d, conv2d});
 
-  ScopedIni full("backbone_n15_scaled", {nw_base_mse, adam, backbone_valid});
+  ScopedIni full("backbone_15_n_scaled", {nw_base_mse, adam, backbone_valid});
 
   nntrainer::NeuralNetwork NN_scaled, NN_full;
   EXPECT_EQ(NN_full.loadFromConfig(full.getIniName()), ML_ERROR_NONE);
   EXPECT_EQ(NN_full.compile(), ML_ERROR_NONE);
   EXPECT_THROW(NN_full.initialize(), std::invalid_argument);
 
-  ScopedIni scaled("backbone_n15_scaled", {nw_base_mse, adam, backbone_scaled});
+  ScopedIni scaled("backbone_15_n_scaled",
+                   {nw_base_mse, adam, backbone_scaled});
 
   EXPECT_EQ(NN_scaled.loadFromConfig(scaled.getIniName()), ML_ERROR_NONE);
   EXPECT_EQ(NN_scaled.compile(), ML_ERROR_NONE);
@@ -634,13 +635,13 @@ TEST(nntrainerIniTest, backbone_n_15) {
  * @brief Ini file unittest with backbone
  * @note Input shape is striped from backbone and not provided in model file
  */
-TEST(nntrainerIniTest, backbone_p_17) {
+TEST(nntrainerIniTest, backbone_17_p) {
   nntrainer::NeuralNetwork NN_scaled, NN_full;
 
   ScopedIni base("base", {conv2d_shape, conv2d + "input_layers=conv2d_shape"});
 
   ScopedIni full(
-    "backbone_p17_full",
+    "backbone_17_p_full",
     {nw_base_mse, adam, input2d, backbone_valid + "input_layers=inputlayer"});
 
   EXPECT_EQ(NN_full.loadFromConfig(full.getIniName()), ML_ERROR_NONE);
@@ -648,7 +649,7 @@ TEST(nntrainerIniTest, backbone_p_17) {
   EXPECT_EQ(NN_full.initialize(), ML_ERROR_NONE);
 
   ScopedIni scaled(
-    "backbone_p17_scaled",
+    "backbone_17_p_scaled",
     {nw_base_mse, adam, input2d, backbone_scaled + "input_layers=inputlayer"});
 
   EXPECT_EQ(NN_scaled.loadFromConfig(scaled.getIniName()), ML_ERROR_NONE);
@@ -660,12 +661,12 @@ TEST(nntrainerIniTest, backbone_p_17) {
  * @brief Ini file unittest with backbone
  * @note Multi Output layer name not found, epmty backbone
  */
-TEST(nntrainerIniTest, backbone_n_18) {
+TEST(nntrainerIniTest, backbone_18_n) {
   nntrainer::NeuralNetwork NN;
 
   ScopedIni base("base", {input2d, conv2d + "input_layers=inputlayer",
                           flatten + "input_layers=conv2d"});
-  ScopedIni backbone("Backbone_n18",
+  ScopedIni backbone("Backbone_18_n",
                      {nw_base_mse, adam, input,
                       backbone_valid_inout + "input_layers=inputlayer"});
 
@@ -677,13 +678,13 @@ TEST(nntrainerIniTest, backbone_n_18) {
  * @brief Ini file unittest with backbone
  * @note Input layer name not found, epmty backbone
  */
-TEST(nntrainerIniTest, backbone_n_19) {
+TEST(nntrainerIniTest, backbone_19_n) {
   nntrainer::NeuralNetwork NN;
 
   ScopedIni base("base", {input2d, conv2d + "input_layers=inputlayer",
                           batch_normal + "input_layers=conv2d"});
 
-  ScopedIni backbone("backbone_n19",
+  ScopedIni backbone("backbone_19_n",
                      {nw_base_mse, adam, input,
                       backbone_valid_inout + "input_layers=inputlayer"});
 
@@ -695,14 +696,14 @@ TEST(nntrainerIniTest, backbone_n_19) {
  * @brief Ini file unittest with backbone
  * @note input and output layer specified are found
  */
-TEST(nntrainerIniTest, backbone_p_20) {
+TEST(nntrainerIniTest, backbone_20_p) {
   nntrainer::NeuralNetwork NN;
 
   ScopedIni base("base",
                  {input2d, conv2d + "input_layers=inputlayer",
                   flatten + "input_layers=conv2d", out + "input_layers=flat"});
 
-  ScopedIni backbone("backbone_p20",
+  ScopedIni backbone("backbone_20_p",
                      {nw_base_mse, adam, input,
                       backbone_valid_inout + "input_layers=inputlayer"});
 
@@ -767,9 +768,9 @@ TEST(nntrainerIniTest, backbone_based_on_working_directory_p) {
 /**
  * @brief Ini file unittest with distributed layer
  */
-TEST(nntrainerIniTest, distribute_p_01) {
+TEST(nntrainerIniTest, distribute_01_p) {
   ScopedIni s{
-    "distribute_p1",
+    "distribute_01_p",
     {nw_base_cross, adam,
      input + "-Activation" + "-Input_Shape" + "Input_Shape = 3:1:10:10",
      out + "distribute=true"}};

--- a/test/unittest/unittest_nntrainer_tensor_pool.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool.cpp
@@ -32,7 +32,7 @@ TEST(TensorPool, create_destroy) { EXPECT_NO_THROW(nntrainer::TensorPool()); }
 /**
  * @brief request empty tensor
  */
-TEST(TensorPool, request_mem_01_n) {
+TEST(TensorPool, request_01_n) {
   nntrainer::TensorPool pool;
 
   EXPECT_THROW(pool.request("abc", nntrainer::TensorDim(), {},
@@ -43,7 +43,7 @@ TEST(TensorPool, request_mem_01_n) {
 /**
  * @brief request empty name
  */
-TEST(TensorPool, request_mem_02_n) {
+TEST(TensorPool, request_02_n) {
   nntrainer::TensorPool pool;
 
   EXPECT_THROW(pool.request("", nntrainer::TensorDim({1}), {},
@@ -52,22 +52,9 @@ TEST(TensorPool, request_mem_02_n) {
 }
 
 /**
- * @brief request tensor
- */
-TEST(TensorPool, request_mem_03_p) {
-  nntrainer::TensorPool pool;
-  nntrainer::Tensor *t;
-
-  EXPECT_NO_THROW(t = pool.request("abc", nntrainer::TensorDim({1}), {},
-                                   nntrainer::TensorLifespan::UNMANAGED));
-  EXPECT_NE(t, nullptr);
-  EXPECT_FALSE(t->isAllocated());
-}
-
-/**
  * @brief request already allocated tensor
  */
-TEST(TensorPool, request_mem_04_n) {
+TEST(TensorPool, request_03_n) {
   nntrainer::TensorPool pool;
 
   EXPECT_NO_THROW(pool.request("abc", nntrainer::TensorDim({1}), {},
@@ -79,9 +66,104 @@ TEST(TensorPool, request_mem_04_n) {
 }
 
 /**
+ * @brief request tensor
+ */
+TEST(TensorPool, request_04_p) {
+  nntrainer::TensorPool pool;
+  nntrainer::Tensor *t;
+
+  EXPECT_NO_THROW(t = pool.request("abc", nntrainer::TensorDim({1}), {},
+                                   nntrainer::TensorLifespan::UNMANAGED));
+  EXPECT_NE(t, nullptr);
+  EXPECT_FALSE(t->isAllocated());
+}
+
+/**
+ * @brief request bigger size for view
+ */
+TEST(TensorPool, view_01_n) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_NO_THROW(pool.request("abc", nntrainer::TensorDim({1}), {},
+                               nntrainer::TensorLifespan::UNMANAGED));
+
+  EXPECT_THROW(pool.view("abc1", "abc", nntrainer::TensorDim({2}), {},
+                         nntrainer::TensorLifespan::UNMANAGED),
+               std::invalid_argument);
+}
+
+/**
+ * @brief request view non existing tensor
+ */
+TEST(TensorPool, view_02_n) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_NO_THROW(pool.request("abc", nntrainer::TensorDim({1}), {},
+                               nntrainer::TensorLifespan::UNMANAGED));
+
+  EXPECT_ANY_THROW(pool.view("abc1", "not_exist", nntrainer::TensorDim({1}), {},
+                             nntrainer::TensorLifespan::UNMANAGED));
+}
+
+/**
+ * @brief request with clashing name
+ */
+TEST(TensorPool, view_03_n) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_NO_THROW(pool.request("abc", nntrainer::TensorDim({1}), {},
+                               nntrainer::TensorLifespan::UNMANAGED));
+
+  EXPECT_THROW(pool.view("abc", "abc", nntrainer::TensorDim({1}), {},
+                         nntrainer::TensorLifespan::UNMANAGED),
+               std::invalid_argument);
+}
+
+/**
+ * @brief view with empty tensor
+ */
+TEST(TensorPool, view_04_n) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_NO_THROW(pool.request("abc", nntrainer::TensorDim({1}), {},
+                               nntrainer::TensorLifespan::UNMANAGED));
+
+  EXPECT_THROW(pool.view("abc1", "abc", nntrainer::TensorDim({}), {},
+                         nntrainer::TensorLifespan::UNMANAGED),
+               std::invalid_argument);
+}
+
+/**
+ * @brief view with empty name
+ */
+TEST(TensorPool, view_05_n) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_NO_THROW(pool.request("abc", nntrainer::TensorDim({1}), {},
+                               nntrainer::TensorLifespan::UNMANAGED));
+
+  EXPECT_THROW(pool.view("", "abc", nntrainer::TensorDim({1}), {},
+                         nntrainer::TensorLifespan::UNMANAGED),
+               std::invalid_argument);
+}
+
+/**
+ * @brief request view of managed tensor
+ */
+TEST(TensorPool, view_06_n) {
+  nntrainer::TensorPool pool;
+
+  EXPECT_NO_THROW(pool.request("abc", nntrainer::TensorDim({1}), {},
+                               nntrainer::TensorLifespan::MAX_LIFESPAN));
+  EXPECT_THROW(pool.view("abc1", "abc", nntrainer::TensorDim({1}), {},
+                         nntrainer::TensorLifespan::UNMANAGED),
+               std::invalid_argument);
+}
+
+/**
  * @brief request already allocated tensor
  */
-TEST(TensorPool, request_mem_05_p) {
+TEST(TensorPool, view_07_p) {
   nntrainer::TensorPool pool;
   nntrainer::Tensor *t1, *t2;
 
@@ -99,36 +181,9 @@ TEST(TensorPool, request_mem_05_p) {
 }
 
 /**
- * @brief request bigger size for view
- */
-TEST(TensorPool, request_mem_06_n) {
-  nntrainer::TensorPool pool;
-
-  EXPECT_NO_THROW(pool.request("abc", nntrainer::TensorDim({1}), {},
-                               nntrainer::TensorLifespan::UNMANAGED));
-
-  EXPECT_THROW(pool.view("abc1", "abc", nntrainer::TensorDim({2}), {},
-                         nntrainer::TensorLifespan::UNMANAGED),
-               std::invalid_argument);
-}
-
-/**
- * @brief request non existing tensor
- */
-TEST(TensorPool, request_mem_07_n) {
-  nntrainer::TensorPool pool;
-
-  EXPECT_NO_THROW(pool.request("abc", nntrainer::TensorDim({1}), {},
-                               nntrainer::TensorLifespan::UNMANAGED));
-
-  EXPECT_ANY_THROW(pool.view("abc1", "not_exist", nntrainer::TensorDim({1}), {},
-                             nntrainer::TensorLifespan::UNMANAGED));
-}
-
-/**
  * @brief request try extending lifespan of unmanaged
  */
-TEST(TensorPool, request_mem_08_p) {
+TEST(TensorPool, view_08_p) {
   nntrainer::TensorPool pool;
   nntrainer::Tensor *t1, *t2;
 
@@ -153,20 +208,6 @@ TEST(TensorPool, request_mem_08_p) {
 }
 
 /**
- * @brief request clashing name
- */
-TEST(TensorPool, request_mem_09_n) {
-  nntrainer::TensorPool pool;
-
-  EXPECT_NO_THROW(pool.request("abc", nntrainer::TensorDim({1}), {},
-                               nntrainer::TensorLifespan::UNMANAGED));
-
-  EXPECT_THROW(pool.view("abc", "abc", nntrainer::TensorDim({1}), {},
-                         nntrainer::TensorLifespan::UNMANAGED),
-               std::invalid_argument);
-}
-
-/**
  * @brief set batch
  */
 TEST(TensorPool, set_batch_01_p) {
@@ -184,7 +225,7 @@ TEST(TensorPool, set_batch_01_p) {
 }
 
 /**
- * @brief set batch
+ * @brief set batch for not exist tensor
  */
 TEST(TensorPool, set_batch_02_n) {
   nntrainer::TensorPool pool;
@@ -197,6 +238,24 @@ TEST(TensorPool, set_batch_02_n) {
 
   EXPECT_THROW(pool.setBatchSize("not_exist", 10), std::invalid_argument);
   EXPECT_EQ(t1->batch(), 1u);
+}
+
+/**
+ * @brief set batch for allocated tensor
+ */
+TEST(TensorPool, set_batch_03_n) {
+  nntrainer::TensorPool pool;
+  nntrainer::Tensor *t1;
+  nntrainer::BasicPlanner basic_planner;
+
+  EXPECT_NO_THROW(
+    t1 = pool.request("abc", nntrainer::TensorDim({1}), {0},
+                      nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN));
+  EXPECT_NE(t1, nullptr);
+  EXPECT_NO_THROW(pool.finalize(basic_planner, 0, 1));
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_THROW(pool.setBatchSize("abc", 10), std::invalid_argument);
 }
 
 /**


### PR DESCRIPTION
Commit 1:     [unittest] rename negative testcase name to _n place at the end
    
     - Since the indicator _p/_n is at the middle of testcase name all of test cases
       are regarded as positive testcases(default). So place indicator at the end.
     - Added '_' right before 'n' to indicate negative testcase.
    
    Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>

Commit 2:     [unittest] added negative testcase
    
     - Added negative testcase
    
    Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>