### PR TITLE
[Release] NNTrainer 0.4.0 Release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nntrainer (0.4.0) unstable; urgency=medium
+
+  * 0.4.0 released
+
+ -- jijoongmoon <jijoong.moon@samsung.com>  Mon, 26 Sep 2022 14:26:13 +0900
+
 nntrainer (0.3.0) unstable; urgency=medium
 
   * 0.3.0 released

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('nntrainer', 'c', 'cpp',
-  version: '0.3.0',
+  version: '0.4.0',
   license: ['apache-2.0'],
   meson_version: '>=0.50.0',
   default_options: [

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -48,7 +48,7 @@
 
 Name:		nntrainer
 Summary:	Software framework for training neural networks
-Version:	0.3.0
+Version:	0.4.0
 Release:	0
 Packager:	Jijoong Moon <jijoong.moon@samsung.com>
 License:	Apache-2.0
@@ -575,6 +575,8 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %endif
 
 %changelog
+* Mon Sep 26 2022 Jijoong Moon <jijoong.moon@samsung.com>
+- Release of 0.4.0
 * Fri Sep 24 2021 Jijoong Moon <jijoong.moon@samsung.com>
 - Release of 0.3.0
 * Wed Jun 02 2021 Jijoong Moon <jijoong.moon@samsung.com>


### PR DESCRIPTION
NNTrainer v0.4.0 is released.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>