### PR TITLE
[trivial] fix ahub issues

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1496,7 +1496,7 @@ std::ostream &operator<<(std::ostream &out, Tensor const &m) {
   return out;
 }
 
-void Tensor::copy(const float *buf) noexcept {
+void Tensor::copy(const float *buf) {
   NNTR_THROW_IF(!contiguous, std::invalid_argument)
     << getName() << "Tensor is not contiguous, cannot copy.";
 

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -29,8 +29,8 @@
 #include <array>
 #include <functional>
 #include <memory>
-#include <vector>
 #include <stdexcept>
+#include <vector>
 
 #include <tensor_dim.h>
 
@@ -1403,7 +1403,7 @@ private:
    *
    * @param buf buffer to copy from
    */
-  void copy(const float *buf) noexcept;
+  void copy(const float *buf);
 
   /**
    * @brief Update destination tensor to share memory with source tensor

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -632,8 +632,8 @@ TEST(nntrainer_ccapi, model_copy_02_p) {
 
   // Run after set the weights again
   EXPECT_NO_THROW(c_model->train());
-  delete w_one;
-  delete b_one;
+  delete[] w_one;
+  delete[] b_one;
 }
 
 /**

--- a/test/unittest/unittest_util_func.cpp
+++ b/test/unittest/unittest_util_func.cpp
@@ -81,7 +81,7 @@ TEST(nntrainer_util_func, checkedRead_n) {
 
 TEST(nntrainer_util_func, checkedWrite_n) {
   std::ofstream file("!@/not good file");
-  char array[5];
+  char array[5] = "abcd";
 
   EXPECT_THROW(nntrainer::checkedWrite(file, array, 5), std::runtime_error);
 }
@@ -94,7 +94,7 @@ TEST(nntrainer_util_func, readString_n) {
 
 TEST(nntrainer_util_func, writeString_n) {
   std::ofstream file("!@/not good file");
-  std::string str;
+  std::string str = "abcd";
 
   EXPECT_THROW(nntrainer::writeString(file, str), std::runtime_error);
 }


### PR DESCRIPTION
 - Remove noexcept in copy function cause it throws when data is non contiguous
 - Initialize char array
 - Delete array not element("[]" was missing)

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>