### PR TITLE
debian: fix occasional debuild error

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -58,3 +58,6 @@ override_dh_install:
 
 override_dh_missing:
 	dh_missing --fail-missing
+
+override_dh_clean:
+	dh_clean $@


### PR DESCRIPTION
Sometimes, debuild has errors with dh_clean:

```
dh_clean: error: find .  \( \( \
		\( -path .\*/.git -o -path .\*/.svn -o -path .\*/.bzr -o -path .\*/.hg -o -path .\*/CVS -o -path .\*/.pc -o -path .\*/_darcs \) -prune -o -type f -a \
	        \( -name '#*#' -o -name '.*~' -o -name '*~' -o -name DEADJOE \
		 -o -name '*.orig' -o -name '*.rej' -o -name '*.bak' \
		 -o -name '.*.orig' -o -name .*.rej -o -name '.SUMS' \
		 -o -name TAGS -o \( -path '*/.deps/*' -a -name '*.P' \) \
		\) -exec rm -f {} + \) -o \
		\( -type d -a -name autom4te.cache -prune -exec rm -rf {} + \) \) returned exit code 1
make: *** [debian/rules:28: clean] Error 25
```

Override dh_clean to avoid this.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>