### PR TITLE
[Context] Propergate properties to model @open sesame 10/25 13:37

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -78,6 +78,7 @@ if get_option('platform') != 'android'
   nntrainer_includedir = nntrainer_prefix / get_option('includedir') / 'nntrainer'
   nntrainer_confdir = get_option('sysconfdir')
   application_install_dir = nntrainer_bindir / 'applications'
+  nntrainer_swapdir = '/tmp'
 else
   nntrainer_prefix = meson.build_root() / 'android_build_result'
   # @todo arch has to be option
@@ -86,6 +87,18 @@ else
   nntrainer_bindir = nntrainer_prefix / 'bin'
   nntrainer_confdir = nntrainer_prefix / 'conf'
   application_install_dir = nntrainer_prefix / 'examples'
+  nntrainer_swapdir = '/data/local/tmp'
+endif
+
+# handle swap options
+if get_option('enable-memory-swap')
+  nntrainer_enable_swap = 'true'
+else
+  nntrainer_enable_swap = 'false'
+endif
+
+if get_option('memory-swap-path') != ''
+  nntrainer_swapdir = get_option('memory-swap-path')
 endif
 
 # handle resources
@@ -107,6 +120,8 @@ nntrainer_conf.set('EXEC_PREFIX', nntrainer_bindir)
 nntrainer_conf.set('LIB_INSTALL_DIR', nntrainer_libdir)
 nntrainer_conf.set('PLUGIN_INSTALL_PREFIX', nntrainer_libdir / 'nntrainer')
 nntrainer_conf.set('INCLUDE_INSTALL_DIR', nntrainer_includedir / '..')
+nntrainer_conf.set('MEMORY_SWAP', nntrainer_enable_swap)
+nntrainer_conf.set('MEMORY_SWAP_PATH', nntrainer_swapdir)
 
 dummy_dep = dependency('', required: false)
 found_dummy_dep = declare_dependency() # dummy dep to use if found

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,6 +12,8 @@ option('enable-tflite-backbone', type: 'boolean', value: true)
 option('enable-profile', type: 'boolean', value: false)
 option('enable-debug', type: 'boolean', value: false)
 option('enable-tflite-interpreter', type: 'boolean', value: true)
+option('enable-memory-swap', type: 'boolean', value: false)
+option('memory-swap-path', type: 'string', value: '')
 
 # dependency conflict resolution
 option('capi-ml-inference-actual', type: 'string', value: 'capi-ml-inference',

--- a/nntrainer.ini.in
+++ b/nntrainer.ini.in
@@ -6,3 +6,10 @@
 [plugins]
 # path to search for layers
 layer=@PLUGIN_INSTALL_PREFIX@/layers
+
+[swap]
+# enable memory swap feature
+memory_swap = @MEMORY_SWAP@
+
+# path to save swap file
+memory_swap_path = @MEMORY_SWAP_PATH@

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -155,6 +155,14 @@ public:
   const std::string getWorkingPath(const std::string &path = "");
 
   /**
+   * @brief Get memory swap file path from configuration file
+   * @return memory swap path.
+   * If memory swap path is not presented in configuration file, it returns
+   * empty string
+   */
+  const std::vector<std::string> getProperties(void);
+
+  /**
    * @brief Factory register function, use this function to register custom
    * object
    *

--- a/nntrainer/models/model_loader.cpp
+++ b/nntrainer/models/model_loader.cpp
@@ -446,6 +446,16 @@ int ModelLoader::loadFromIni(std::string ini_file, NeuralNetwork &model,
 }
 
 /**
+ * @brief     load all properties from context
+ */
+int ModelLoader::loadFromContext(NeuralNetwork &model) {
+  auto props = app_context.getProperties();
+  model.setTrainConfig(props);
+
+  return ML_ERROR_NONE;
+}
+
+/**
  * @brief     load all of model and dataset from given config file
  */
 int ModelLoader::loadFromConfig(std::string config, NeuralNetwork &model) {

--- a/nntrainer/models/model_loader.h
+++ b/nntrainer/models/model_loader.h
@@ -44,6 +44,12 @@ public:
   ~ModelLoader() {}
 
   /**
+   * @brief     load all properties from context
+   * @param[in/out] model model to be loaded
+   */
+  int loadFromContext(NeuralNetwork &model);
+
+  /**
    * @brief     load all of model and dataset from given config file
    * @param[in] config config file path
    * @param[in/out] model model to be loaded

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -105,7 +105,13 @@ int NeuralNetwork::loadFromConfig(const std::string &config) {
 
   ModelLoader loader(app_context);
   NeuralNetwork tempNet(*this);
-  int status = loader.loadFromConfig(config, tempNet);
+
+  int status = loader.loadFromContext(tempNet);
+  if (status != ML_ERROR_NONE) {
+    return status;
+  }
+
+  status = loader.loadFromConfig(config, tempNet);
   if (status != ML_ERROR_NONE) {
     return status;
   }
@@ -160,7 +166,8 @@ int NeuralNetwork::compile() {
   }
 
   bool memory_swap = std::get<props::MemorySwap>(model_flex_props);
-	const std::string memory_swap_path = std::get<props::MemorySwapPath>(model_flex_props);
+  const std::string memory_swap_path =
+    std::get<props::MemorySwapPath>(model_flex_props);
   model_graph = NetworkGraph(memory_swap, memory_swap_path);
 
   model_graph.setMemoryOptimizations(


### PR DESCRIPTION
This patch is for app properties propergation.
App properties is described in global configuration file (ini),
and the properties are under section, which only have a meaning for
human readability. It means section deos not have any real role for
behavior. Propergated properties can be used in anywhere in the network.
In this patch include 'memmory_swap' and 'memory_swap_path' which is
used for Model flex properties.

Signed-off-by: Jiho Chu <jiho.chu@samsung.com>