### PR TITLE
[subplugin] Add constructing nntrainer and InputTensorsInfo class @open sesame 11/11 10:50

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -372,6 +372,15 @@ if get_option('enable-nnstreamer-tensor-filter')
   endif
 endif
 
+if get_option('enable-nnstreamer-tensor-trainer')
+  if get_option('platform') == 'android'
+    warning('android nnstreamer-filter is not yet supported, building nnstreamer-filter skipped')
+  else
+    nnstreamer_dep = dependency('nnstreamer', required: true)
+    subdir('nnstreamer/tensor_trainer')
+  endif
+endif
+
 if get_option('platform') == 'android'
   subdir('jni')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -42,3 +42,5 @@ option('ml-api-support', type: 'feature', value: 'auto')
 # @todo : make them use 'feature' and depend on ml-api-support
 option('enable-nnstreamer-tensor-filter', type: 'boolean', value: false)
 option('nnstreamer-subplugin-install-path', type: 'string', value: '/usr/lib/nnstreamer') # where nnstreamer subplugin should be installed
+option('enable-nnstreamer-tensor-trainer', type: 'boolean', value: false)
+option('nnstreamer-subplugin-install-path', type: 'string', value: '/usr/lib/nnstreamer') # where nnstreamer subplugin should be installed

--- a/nnstreamer/tensor_trainer/meson.build
+++ b/nnstreamer/tensor_trainer/meson.build
@@ -1,0 +1,36 @@
+trainer_subplugin_sources = ['tensor_trainer_nntrainer.cc']
+
+nnstreamer_trainer_nntrainer_sources = []
+foreach s : trainer_subplugin_sources
+  nnstreamer_trainer_nntrainer_sources += meson.current_source_dir() / s
+endforeach
+
+# TODO: remove gstreamer dependency by updating nnstreamer_plugin_api.h
+gst_api_version = '1.0'
+glib_dep = dependency('glib-2.0')
+gmodule_dep = dependency('gmodule-2.0')
+gst_dep = dependency('gstreamer-'+gst_api_version)
+
+nntrainer_prefix = get_option('prefix')
+
+nnstreamer_trainer_nntrainer_deps = [glib_dep, gmodule_dep, gst_dep, nntrainer_ccapi_dep, nnstreamer_dep]
+
+nnstreamer_libdir = nntrainer_prefix / get_option('libdir')
+subplugin_install_prefix = get_option('nnstreamer-subplugin-install-path')
+trainer_subplugin_install_dir = subplugin_install_prefix / 'trainer'
+
+shared_library('nnstreamer_trainer_nntrainer',
+  nnstreamer_trainer_nntrainer_sources,
+  dependencies: nnstreamer_trainer_nntrainer_deps,
+  include_directories: [nntrainer_inc, '.'], # '.' shouldn't be installed
+  install: true,
+  install_dir: trainer_subplugin_install_dir
+)
+
+static_library('nnstreamer_trainer_nntrainer',
+  nnstreamer_trainer_nntrainer_sources,
+  dependencies: nnstreamer_trainer_nntrainer_deps,
+  include_directories: [nntrainer_inc, '.'], # '.' shouldn't be installed
+  install: true,
+  install_dir: nnstreamer_libdir
+)

--- a/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.cc
+++ b/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.cc
@@ -22,12 +22,15 @@
 #include "ml-api-common.h"
 #include "nnstreamer.h"
 #include "nnstreamer_plugin_api.h"
+#include "nnstreamer_plugin_api_filter.h"
 #include "tensor_trainer_nntrainer.hh"
 
 #include <iostream>
-#define cout_log(x)
-std::cout << __FILE__ << ":" << __LINE__ << ":" << __func__ << ":" << #x << ":"
-          << x << std::endl;
+
+#define UNUSED(expr) \
+  do {               \
+    (void)(expr);    \
+  } while (0)
 
 /**
  * @brief startup constructor
@@ -39,19 +42,107 @@ void init_subplugin_nntrainer(void) __attribute__((constructor));
  */
 void fini_subplugin_nntrainer(void) __attribute__((destructor));
 
+static void nntrainer_model_destructor(const GstTensorFilterProperties *prop,
+                                       void **private_data) {
+  NNTrainer::NNTrainerTrain *nntrainer =
+    static_cast<NNTrainer::NNTrainerTrain *>(*private_data);
+
+  if (!nntrainer)
+    return;
+  delete nntrainer;
+  *private_data = NULL;
+}
+
+#if 0 /** To avoid build errors : defined but not used */
+static void nntrainer_model_train(const GstTensorFilterProperties *prop,
+                                  void **private_data) {
+  NNTrainer::NNTrainerTrain *nntrainer =
+    static_cast<NNTrainer::NNTrainerTrain *>(*private_data);
+  if (!nntrainer) {
+    std::cerr << "Failed get model" << std::endl;
+  }
+
+  try {
+    nntrainer->trainModel();
+  } catch (std::exception &e) {
+    std::cerr << "Error" << typeid(e).name() << "," << e.what() << std::endl;
+  }
+}
+#endif
+
+void NNTrainer::NNTrainerTrain::trainModel() {
+  try {
+    model->train();
+    training_loss = model->getTrainingLoss();
+    validation_loss = model->getValidationLoss();
+  } catch (std::exception &e) {
+    std::cerr << "Error" << typeid(e).name() << "," << e.what() << std::endl;
+  }
+}
+
+void NNTrainer::NNTrainerTrain::createModel() {
+
+  try {
+    model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+    model->load(model_config,
+                ml::train::ModelFormat::MODEL_FORMAT_INI_WITH_BIN);
+  } catch (std::exception &e) {
+    std::cerr << "Failed loading model configuration file" << typeid(e).name()
+              << e.what() << std::endl;
+  }
+
+  try {
+    model->compile();
+    model->initialize();
+    model->setDataset(ml::train::DatasetModeType::MODE_TRAIN, dataset_train);
+    model->setDataset(ml::train::DatasetModeType::MODE_VALID, dataset_valid);
+  } catch (std::exception &e) {
+    std::cerr << "Error" << typeid(e).name() << "," << e.what() << std::endl;
+  }
+}
+
+NNTrainer::NNTrainerTrain::NNTrainerTrain(const std::string &_model_config) :
+  model_config(_model_config) {
+  createModel();
+}
+
+static int
+nntrainer_model_construct_with_conf(const GstTensorFilterProperties *prop,
+                                    void **private_data) {
+
+  NNTrainer::NNTrainerTrain *nntrainer =
+    static_cast<NNTrainer::NNTrainerTrain *>(*private_data);
+  if (!nntrainer)
+    nntrainer_model_destructor(prop, private_data);
+
+  try {
+    nntrainer =
+      new NNTrainer::NNTrainerTrain("/home/hyunil/nnstreamer/mnist.ini");
+  } catch (std::exception &e) {
+    std::cerr << "Error" << typeid(e).name() << "," << e.what() << std::endl;
+  }
+
+  return 0;
+}
+
+static int nntrainer_model_construct(const GstTensorFilterProperties *prop,
+                                     void **private_data) {
+  int status = nntrainer_model_construct_with_conf(prop, private_data);
+
+  return status;
+}
+
 static gchar subplugin_name[] = "nntrainer";
 
 /** GstTensorFilterFramework will be changed */
 static GstTensorFilterFramework NNS_Trainer_support_nntrainer = {
   .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
-  .open = NULL,  //.constructr
-  .close = NULL, //.destructor
-  //.train = NULL
+  .open = nntrainer_model_construct, //.construct = nntrainer_model_construct,
+  .close =
+    nntrainer_model_destructor, //.destructor = nntrainer_model_destructor,
+  //.train = nntrainer_model_train
 };
 
-/** member function and variable of NNS_Trainer_support_nntrainer will be
- * changed
- */
 void init_subplugin_nntrainer(void) {
   NNS_Trainer_support_nntrainer.name = subplugin_name;
   NNS_Trainer_support_nntrainer.allow_in_place = FALSE;

--- a/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.cc
+++ b/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.cc
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * NNStreamer tensor_trainer subplugin for nntrainer
+ * Copyright (C) 2022 Hyunil Park <hyunil46.park@samsung.com>
+ */
+/**
+ * @file   tensor_trainer_nntrainer.cc
+ * @date   07 November 2022
+ * @brief  NNStreamer tensor_trainer subplugin
+ * @see    http://github.com/nnstreamer/nnstreamer
+ * @author Hyunil Park <hyunil46.park@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <algorithm>
+#include <limits>
+#include <sstream>
+#include <unistd.h>
+
+#include <nntrainer_error.h>
+
+#include "ml-api-common.h"
+#include "nnstreamer.h"
+#include "nnstreamer_plugin_api.h"
+#include "tensor_trainer_nntrainer.hh"
+
+#include <iostream>
+#define cout_log(x)
+std::cout << __FILE__ << ":" << __LINE__ << ":" << __func__ << ":" << #x << ":"
+          << x << std::endl;
+
+/**
+ * @brief startup constructor
+ */
+void init_subplugin_nntrainer(void) __attribute__((constructor));
+
+/**
+ * @brief startdown destructor
+ */
+void fini_subplugin_nntrainer(void) __attribute__((destructor));
+
+static gchar subplugin_name[] = "nntrainer";
+
+/** GstTensorFilterFramework will be changed */
+static GstTensorFilterFramework NNS_Trainer_support_nntrainer = {
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
+  .open = NULL,  //.constructr
+  .close = NULL, //.destructor
+  //.train = NULL
+};
+
+/** member function and variable of NNS_Trainer_support_nntrainer will be
+ * changed
+ */
+void init_subplugin_nntrainer(void) {
+  NNS_Trainer_support_nntrainer.name = subplugin_name;
+  NNS_Trainer_support_nntrainer.allow_in_place = FALSE;
+  NNS_Trainer_support_nntrainer.allocate_in_invoke = TRUE;
+  NNS_Trainer_support_nntrainer.run_without_model = FALSE;
+  NNS_Trainer_support_nntrainer.verify_model_path = FALSE;
+  NNS_Trainer_support_nntrainer.invoke_NN = NULL;
+  NNS_Trainer_support_nntrainer.destroyNotify = NULL;
+  NNS_Trainer_support_nntrainer.checkAvailability = NULL;
+  NNS_Trainer_support_nntrainer.getInputDimension = NULL;
+  NNS_Trainer_support_nntrainer.getOutputDimension = NULL;
+  NNS_Trainer_support_nntrainer.setInputDimension = NULL;
+  /* nnstreamer_filter_probe function will be changed */
+  nnstreamer_filter_probe(&NNS_Trainer_support_nntrainer);
+}
+
+void fini_subplugin_nntrainer(void) {
+  /* nnstreamer_filter_exit function will be changed */
+  nnstreamer_filter_exit(NNS_Trainer_support_nntrainer.name);
+}

--- a/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.hh
+++ b/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.hh
@@ -1,0 +1,115 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * NNStreamer tensor_trainer subplugin for nntrainer
+ * Copyright (C) 2022 Hyunil Park <hyunil46.park@samsung.com>
+ */
+/**
+ * @file   tensor_trainer_nntrainer.hh
+ * @date   07 November 2022
+ * @brief  NNStreamer tensor_trainer subplugin header
+ * @see    http://github.com/nnstreamer/nnstreamer
+ * @author Hyunil Park <hyunil46.park@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <model.h>
+#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_filter.h>
+#include <vector>
+
+namespace NNTrainer {
+
+class InputTensorsInfo;
+
+/**
+ * @brief NNTrainer interface for nnstreamer trainer subplugin
+ */
+class NNTrainerTrain {
+public:
+  /**
+   * @brief Construct a new NNTrainerTrain object
+   */
+  NNTrainerTrain(const std::string &_model_config);
+
+  /**
+   * @brief Destroy the NNTrainerTrain object
+   * @param _model_config model configuration file path
+   */
+  ~NNTrainerTrain() = default;
+
+  /**
+   * @brief Set the Batch Size
+   * @param _batch_size batch size
+   */
+  void setBatchSize(unsigned int _batch_size) { batch_size = _batch_size; }
+
+  /**
+   * @brief Set the number of train data
+   * @param _num_of_train_data number of train data
+   */
+  void setNumberOfTrainData(unsigned int _num_of_train_data) {
+    num_of_train_data = _num_of_train_data;
+  }
+
+  /**
+   * @brief Set the number of validation data
+   * @param _num_of_valid_data number of validation data
+   */
+  void setNumberOfValidData(unsigned int _num_of_valid_data) {
+    num_of_valid_data = _num_of_valid_data;
+  }
+
+  /**
+   * @brief Set the number of label list
+   * @param _num_of_label_list number of label list
+   */
+  void setNumberOfLabelList(unsigned int _num_of_label_list) {
+    num_of_label_list = _num_of_label_list;
+  }
+
+  /**
+   * @brief Set the number of input list
+   * @param _num_of_label_list number of input list
+   */
+  void setNumberOfInputList(unsigned int _num_of_input_list) {
+    num_of_input_list = _num_of_input_list;
+  }
+
+  /**
+   * @brief create model
+   */
+  void createModel();
+  /**
+   * @brief send input data to NNTrainerTrain
+   * @param input input tensor memory imported input and label
+   */
+  void sendTensorData(const GstTensorMemory *input);
+
+  std::unique_ptr<NNTrainer::InputTensorsInfo> train_data, valid_data;
+
+private:
+  unsigned int batch_size;
+  unsigned int num_of_train_data;
+  unsigned int num_of_valid_data;
+  unsigned int num_of_label_list;
+  unsigned int num_of_input_list;
+
+  std::string model_config;
+  std::unique_ptr<ml::train::Model> model;
+};
+
+/**
+ * @brief Input tensors data and information
+ */
+class InputTensorsInfo {
+public:
+  InputTensorsInfo(unsigned int num_of_samples, unsigned int num_of_inputs,
+                   unsigned num_of_labels);
+  unsigned int count;
+  unsigned int num_of_samples;
+  unsigned int num_of_inputs;
+  unsigned int num_of_labels;
+  std::vector<float *> inputs;
+  std::vector<float *> labels;
+};
+} // namespace NNTrainer

--- a/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.hh
+++ b/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.hh
@@ -79,6 +79,12 @@ public:
    * @brief create model
    */
   void createModel();
+
+  /**
+   * @brief train model
+   */
+  void trainModel();
+
   /**
    * @brief send input data to NNTrainerTrain
    * @param input input tensor memory imported input and label
@@ -86,6 +92,8 @@ public:
   void sendTensorData(const GstTensorMemory *input);
 
   std::unique_ptr<NNTrainer::InputTensorsInfo> train_data, valid_data;
+  std::shared_ptr<ml::train::Dataset> dataset_train, dataset_valid;
+  float training_loss, validation_loss;
 
 private:
   unsigned int batch_size;
@@ -112,4 +120,15 @@ public:
   std::vector<float *> inputs;
   std::vector<float *> labels;
 };
+
+InputTensorsInfo::InputTensorsInfo(unsigned int _num_of_samples,
+                                   unsigned int _num_of_inputs,
+                                   unsigned int _num_of_labels) :
+  count(0),
+  num_of_samples(_num_of_samples),
+  num_of_inputs(_num_of_inputs),
+  num_of_labels(_num_of_labels) {
+  inputs.reserve(num_of_samples * num_of_inputs);
+  labels.reserve(num_of_samples * num_of_labels);
+}
 } // namespace NNTrainer


### PR DESCRIPTION
[subplugin] Add constructing nntrainer and InputTensorsInfo class

    - Construct nntrainer with config file
    - Deconstruct nntrainer
    - Load model config
    - Compile, initialize and setDataset
    - Add InputTensorsInfo to construct dataset memory

    **Self evaluation:**
    1. Build test:   [X]Passed [ ]Failed [ ]Skipped
    2. Run test:     [ ]Passed [ ]Failed [X]Skipped

    Signed-off-by: hyunil park <hyunil46.park@samsung.com>
