### PR TITLE
(Wait for #2055) [SWAP] Add CacheLoader class @open sesame 11/17 16:55

### DIFF
--- a/nntrainer/tensor/cache_elem.cpp
+++ b/nntrainer/tensor/cache_elem.cpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2022 Jiho Chu <jiho.chu@samsung.com>
+ *
+ * @file   cache_elem.cpp
+ * @date   28 Nov 2022
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jiho Chu <jiho.chu@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Cache elem class
+ *
+ */
+
+#include "cache_elem.h"
+
+#include <stdexcept>
+#include <vector>
+
+#include <profiler.h>
+
+namespace nntrainer {
+
+namespace {
+
+std::map<CachePolicy, std::string> policyToStr = {
+  {WRITE_BACK, "WRITE_BACK"},           {NO_WRITE_BACK, "NO_WRITE_BACK"},
+  {READ_CONSIST, "READ_CONSIST"},       {NO_READ_CONSIST, "NO_READ_CONSIST"},
+  {ALWAYS_SYNCED, "ALWAYS_SYNCED"},     {TEMPORAL, "TEMPORAL"},
+  {FIRST_LAST_SKIP, "FIRST_LAST_SKIP"}, {ITERATION_CONSIST, "ITER_CONSIST"}};
+
+inline bool checkAllocOnly(CachePolicy policy, CacheElem::Options opt) {
+  return ((policy & CachePolicy::NO_READ_CONSIST) ||
+          ((opt & CacheElem::Options::FIRST_ACCESS) &&
+           (policy & CachePolicy::FIRST_LAST_SKIP)));
+}
+
+inline bool checkDeallocOnly(CachePolicy policy, CacheElem::Options opt) {
+  return ((policy & CachePolicy::NO_READ_CONSIST) ||
+          ((opt & CacheElem::Options::LAST_ACCESS) &&
+           (policy & CachePolicy::FIRST_LAST_SKIP)));
+}
+
+} // namespace
+
+void CacheElem::swapIn(Options opt) {
+  std::lock_guard<std::mutex> lock(device_mutex);
+
+  opt = static_cast<Options>(opt | initial_opt);
+  bool alloc_only = checkAllocOnly(policy, opt);
+  void *buf = device->getBuffer(offset, length, alloc_only);
+
+  initial_opt = Options::NONE;
+  mem_data->setAddr((float *)buf);
+  mem_data->setValid(true);
+  active = true;
+
+#ifdef PROFILE
+  std::string msg("CacheElem(");
+  msg += device->getDevicePath() + ") #" + std::to_string(id);
+  PROFILE_CACHE_ALLOC(buf, length, msg, policyToStr[policy], !alloc_only);
+#endif
+}
+
+void CacheElem::swapOut(Options opt) {
+  std::lock_guard<std::mutex> lock(device_mutex);
+  bool dealloc_only = checkDeallocOnly(policy, opt);
+  void *buf = (void *)mem_data->getAddr();
+  device->putBuffer(buf, dealloc_only);
+  mem_data->setAddr(nullptr);
+  mem_data->setValid(false);
+  active = false;
+
+#ifdef PROFILE
+  PROFILE_CACHE_DEALLOC(buf, policyToStr[policy], !dealloc_only);
+#endif
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/cache_elem.h
+++ b/nntrainer/tensor/cache_elem.h
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2022 Jiho Chu <jiho.chu@samsung.com>
+ *
+ * @file   cache_elem.h
+ * @date   28 Nov 2022
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jiho Chu <jiho.chu@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Cache elem class
+ *
+ */
+
+#ifndef __CACHE_ELEM_H__
+#define __CACHE_ELEM_H__
+
+#include <list>
+#include <mutex>
+
+#include <memory_data.h>
+#include <swap_device.h>
+
+namespace nntrainer {
+
+enum CachePolicy {
+  WRITE_BACK = 0b0001,      /**< invalidate will write to device */
+  NO_WRITE_BACK = 0b0010,   /**< invalidate will not write to device */
+  READ_CONSIST = 0b0100,    /**< validate will read from device */
+  NO_READ_CONSIST = 0b1000, /**< validate will not read from device */
+  ALWAYS_SYNCED =
+    (READ_CONSIST | WRITE_BACK), /**< Always synchronized with device */
+  TEMPORAL = (NO_READ_CONSIST |
+              NO_WRITE_BACK), /**< Will not be synchronized with device */
+  FIRST_LAST_SKIP = 0b10000,
+  /**< Will skip first read and last write */
+  ITERATION_CONSIST = (FIRST_LAST_SKIP | ALWAYS_SYNCED),
+  /**< Will skip first read and last write. other behaviors will be same as
+     ALWAYS_SYNCED */
+};
+
+/**
+ * @class   CacheElem
+ * @brief   Cache element containing swap address
+ */
+class CacheElem {
+public:
+  enum Options {
+    NONE = 0b0000,         /**< No option */
+    FIRST_ACCESS = 0x0001, /**< First Access */
+    LAST_ACCESS = 0x0010,  /**< Last Access */
+  };
+
+  /**
+   * @brief CacheElem default constructor
+   *
+   */
+  explicit CacheElem(std::shared_ptr<SwapDevice> dev, unsigned int mem_id,
+                     size_t off, size_t len,
+                     std::shared_ptr<MemoryData<float>> data,
+                     CachePolicy pol = CachePolicy::ALWAYS_SYNCED) :
+    initial_opt(Options::FIRST_ACCESS),
+    device(dev),
+    active(false),
+    id(mem_id),
+    offset(off),
+    length(len),
+    policy(pol),
+    mem_data(data) {}
+
+  /**
+   * @brief CacheElem destructor
+   *
+   */
+  virtual ~CacheElem() {}
+
+  /**
+   * @brief load data from swap device
+   *
+   * @param alloc_only only allocate buffer without reading data
+   */
+  void swapIn(Options opt = Options::NONE);
+
+  /**
+   * @brief unload data to swap device
+   *
+   * @param dealloc_only only deallocate buffer without writing data
+   */
+  void swapOut(Options opt = Options::NONE);
+
+  /**
+   * @brief unload data to swap device
+   *
+   * @return active status
+   */
+  bool isActive() const { return active; }
+
+  /**
+   * @brief get length of cache element
+   *
+   * @return length of cache element in byte
+   */
+  size_t getLength() const { return length; }
+
+  /**
+   * @brief get id of cache element
+   *
+   * @return cache element id
+   */
+  unsigned int getId() const { return id; }
+
+  /**
+   * @brief reset access count
+   *
+   */
+  void reset() { initial_opt = Options::FIRST_ACCESS; }
+
+private:
+  Options initial_opt;                /**< accessed */
+  std::mutex device_mutex;            /**< protect device */
+  std::shared_ptr<SwapDevice> device; /**< swap device */
+  bool active;                        /**< element is loaded */
+  unsigned int id;                    /**< memory id */
+  size_t offset;                      /**< element offset from swap device */
+  size_t length;                      /**< element size */
+  CachePolicy policy;                 /**< cache policy */
+  std::shared_ptr<MemoryData<float>> mem_data; /**< allocated memory data */
+};
+
+} // namespace nntrainer
+
+#endif /** __CACHE_ELEM_H__ */

--- a/nntrainer/tensor/cache_loader.cpp
+++ b/nntrainer/tensor/cache_loader.cpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2022 Jiho Chu <jiho.chu@samsung.com>
+ *
+ * @file   cache_loader.cpp
+ * @date   10 Nov 2022
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jiho Chu <jiho.chu@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Cache loader class
+ *
+ */
+
+#include "cache_loader.h"
+#include "ml-api-common.h"
+#include "task.h"
+#include "task_executor.h"
+
+#include <cache_pool.h>
+#include <climits>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+
+namespace nntrainer {
+
+CacheLoader::CacheLoader(std::shared_ptr<CachePool> cache_pool) :
+  pool(cache_pool),
+  task_executor(nullptr) {}
+
+CacheLoader::~CacheLoader() {
+  if (task_executor)
+    delete task_executor;
+}
+
+void CacheLoader::init() {
+  if (task_executor)
+    return;
+
+  task_executor = new TaskExecutor(pool->getName());
+}
+
+void CacheLoader::finish() {
+  delete task_executor;
+  task_executor = nullptr;
+}
+
+void CacheLoader::load(unsigned int order) { pool->loadExec(order); }
+
+int CacheLoader::loadAsync(unsigned int order,
+                           TaskExecutor::CompleteCallback complete) {
+  return loadAsync(order, complete, LONG_MAX);
+}
+
+int CacheLoader::loadAsync(unsigned int order,
+                           TaskExecutor::CompleteCallback complete,
+                           long timeout_ms) {
+  if (!task_executor) {
+    ml_loge("init is needed");
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
+  Task::Work work = [&](std::atomic_bool &running, void *data) {
+    unsigned int exe_order = (unsigned int)(std::uintptr_t)data;
+
+    pool->flushExcept({exe_order - 1, exe_order});
+    pool->loadExec(exe_order);
+
+    return ML_ERROR_NONE;
+  };
+
+  auto task =
+    std::make_shared<TaskAsync<>>(work, (void *)(std::uintptr_t)order);
+  task->setTimeout(timeout_ms);
+
+  return task_executor->run(task, complete);
+}
+
+int CacheLoader::cancelAsync(int id) {
+  try {
+    task_executor->cancel(id);
+  } catch (const std::exception &e) {
+    ml_loge("CacheLoader(%s): failed to cancel(%d): %s",
+            pool->getName().c_str(), id, e.what());
+    return ML_ERROR_UNKNOWN;
+  }
+
+  return ML_ERROR_NONE;
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/cache_loader.h
+++ b/nntrainer/tensor/cache_loader.h
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2022 Jiho Chu <jiho.chu@samsung.com>
+ *
+ * @file   cache_loader.h
+ * @date   10 Nov 2022
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jiho Chu <jiho.chu@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Cache loader class
+ *
+ */
+
+#ifndef __CACHE_LOADER_H__
+#define __CACHE_LOADER_H__
+
+#include <algorithm>
+#include <atomic>
+#include <functional>
+#include <future>
+#include <map>
+
+#include <cache_pool.h>
+#include <task_executor.h>
+
+namespace nntrainer {
+
+/**
+ * @class   CacheLoader
+ * @brief   Cache loader from swap device
+ */
+class CacheLoader {
+public:
+  /**
+   * @brief CacheLoader default constructor
+   *
+   */
+  explicit CacheLoader(std::shared_ptr<CachePool> cache_pool);
+
+  /**
+   * @brief CacheLoader destructor
+   *
+   */
+  virtual ~CacheLoader();
+
+  /**
+   * @brief initialize loader
+   */
+  virtual void init();
+
+  /**
+   * @brief finish loader
+   *
+   */
+  virtual void finish();
+
+  /**
+   * @brief Load cache data with execution order
+   *
+   * @param order execution order
+   */
+  virtual void load(unsigned int order);
+
+  /**
+   * @brief Load cache data asynchronously with execution order
+   *
+   * @param order execution order
+   * @param complete complete callback
+   * @return async task id
+   */
+  virtual int loadAsync(unsigned int order,
+                        TaskExecutor::CompleteCallback callback);
+
+  /**
+   * @brief Load cache data asynchronously with execution order
+   *
+   * @param order execution order
+   * @param complete complete callback
+   * @param timeout timeout time in ms
+   * @return async task id
+   * @note timeout_ms does not work now.
+   */
+  virtual int loadAsync(unsigned int order,
+                        TaskExecutor::CompleteCallback callback,
+                        long timeout_ms);
+
+  /**
+   * @brief Cancel async task
+   *
+   * @param id task id
+   * @return 0 on success, otherwise negative error
+   */
+  virtual int cancelAsync(int id);
+
+private:
+  std::shared_ptr<CachePool> pool; /**< cache pool */
+  TaskExecutor *task_executor;     /**< task executor */
+};
+
+} // namespace nntrainer
+
+#endif /** __CACHE_LOADER_H__ */

--- a/nntrainer/tensor/memory_data.h
+++ b/nntrainer/tensor/memory_data.h
@@ -14,6 +14,8 @@
 #ifndef __MEMORY_DATA_H__
 #define __MEMORY_DATA_H__
 
+#include <functional>
+
 namespace nntrainer {
 
 using MemoryDataValidateCallback = std::function<void(unsigned int)>;

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -27,7 +27,8 @@ namespace nntrainer {
  */
 unsigned int MemoryPool::requestMemory(size_t bytes, unsigned int start_time,
                                        unsigned int end_time,
-                                       std::vector<unsigned int> exec_order) {
+                                       std::vector<unsigned int> exec_order,
+                                       TensorLifespan lifespan) {
   if (bytes == 0)
     throw std::invalid_argument("Requesting memory of 0 size");
 

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -25,6 +25,7 @@
 
 #include <memory_data.h>
 #include <memory_planner.h>
+#include <tensor_wrap_specs.h>
 
 namespace nntrainer {
 
@@ -52,6 +53,8 @@ public:
    * @param bytes The size of the memory requested in bytes
    * @param start_time The start of the validity interval of this memory
    * @param end_time The end of the validity interval of this memory
+   * @param exec_order execution orders of this memory
+   * @param lifespan lifespan of memory
    *
    * @return The token to get the pointer for this memory after allocation
    * @note start_time is inclusive, but end_time is exclusive
@@ -59,7 +62,8 @@ public:
    */
   virtual unsigned int requestMemory(
     size_t bytes, unsigned int start_time, unsigned int end_time,
-    std::vector<unsigned int> exec_order = std::vector<unsigned int>());
+    std::vector<unsigned int> exec_order = std::vector<unsigned int>(),
+    TensorLifespan lifespan = TensorLifespan::MAX_LIFESPAN);
 
   /**
    * @brief Plan the layout with memory planner
@@ -195,7 +199,7 @@ private:
   std::vector<std::vector<unsigned int>>
     memory_exec_order; /**< execution order for the requested memory */
 
-  void *mem_pool;   /**< memory pool allocated at once */
+  void *mem_pool; /**< memory pool allocated at once */
 
   size_t pool_size; /**< memory requirement for this pool */
 

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -1,5 +1,6 @@
 tensor_sources = [
   'blas_interface.cpp',
+  'cache_elem.cpp',
   'cache_pool.cpp',
   'lazy_tensor.cpp',
   'manager.cpp',

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -1,6 +1,7 @@
 tensor_sources = [
   'blas_interface.cpp',
   'cache_elem.cpp',
+  'cache_loader.cpp',
   'cache_pool.cpp',
   'lazy_tensor.cpp',
   'manager.cpp',

--- a/nntrainer/tensor/swap_device.h
+++ b/nntrainer/tensor/swap_device.h
@@ -77,19 +77,20 @@ public:
    *
    * @param offset Requested offset of swap device file
    * @param size Requested size.
+   * @param alloc_only only allocate buffer without reading data
    *
    * @return The pointer of the swap space
    *
    */
-  void *getBuffer(off_t offset, size_t size);
+  void *getBuffer(off_t offset, size_t size, bool alloc_only = false);
 
   /**
    * @brief Deallocate and put data
    *
    * @param ptr The pointer obtained from getBuffer
-   *
+   * @param dealloc_only only deallocate buffer without writing data
    */
-  void putBuffer(void *ptr);
+  void putBuffer(void *ptr, bool dealloc_only = false);
 
   /**
    * @brief Close device

--- a/nntrainer/tensor/task.h
+++ b/nntrainer/tensor/task.h
@@ -152,14 +152,14 @@ public:
    *
    * @param time timeout in T
    */
-  virtual void setTimeout(int time) { timeout = T(time); }
+  virtual void setTimeout(int64_t time) { timeout = T(time); }
 
   /**
    * @brief Get timeout
    *
    * @param time timeout in T
    */
-  virtual int getTimeout(void) const { return timeout.count(); }
+  virtual int64_t getTimeout(void) const { return timeout.count(); }
 
   /**
    * @brief Set priority

--- a/test/unittest/memory/meson.build
+++ b/test/unittest/memory/meson.build
@@ -7,6 +7,7 @@ nntrainer_memory_tests_dep = declare_dependency(
 test_target = [
   'unittest_memory_planner.cpp',
   'unittest_memory_pool.cpp',
+  'unittest_cache_loader.cpp',
   'unittest_cache_pool.cpp'
 ]
 

--- a/test/unittest/memory/unittest_cache_loader.cpp
+++ b/test/unittest/memory/unittest_cache_loader.cpp
@@ -1,0 +1,636 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2022 Jiho Chu <jiho.chu@samsung.com>
+ *
+ * @file unittest_cache_loader.cpp
+ * @date 14 Nov 2022
+ * @brief Cache Loader Test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Jiho Chu <jiho.chu@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include "optimized_v1_planner.h"
+#include "task_executor.h"
+#include <cstring>
+
+#include <future>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cache_loader.h>
+#include <cache_pool.h>
+#include <nntrainer_test_util.h>
+
+/**
+ * @brief Cache loader test class
+ */
+class CacheLoaderTest : public ::testing::Test {
+public:
+  void SetUp(void) {
+    pool = std::make_shared<nntrainer::CachePool>("tmp pool");
+    loader = new nntrainer::CacheLoader(pool);
+    loader->init();
+  }
+
+  void TearDown(void) {
+    loader->finish();
+    delete loader;
+  }
+
+  std::shared_ptr<nntrainer::CachePool> pool;
+  nntrainer::CacheLoader *loader;
+};
+
+/**
+ * @brief creation and destruction
+ */
+TEST_F(CacheLoaderTest, create_destroy) {}
+
+/**
+ * @brief load synchronously
+ */
+TEST_F(CacheLoaderTest, load_01_p) {
+  std::shared_ptr<nntrainer::MemoryData<float>> mem;
+  auto idx = pool->requestMemory(4, 1, 5, {1, 2, 3, 4, 5});
+  EXPECT_NO_THROW(pool->planLayout(nntrainer::OptimizedV1Planner()));
+  EXPECT_NO_THROW(pool->allocate());
+  EXPECT_EQ(pool->size(), 4);
+  EXPECT_NO_THROW(mem = pool->getMemory(idx));
+  EXPECT_NE(mem, nullptr);
+  EXPECT_EQ(mem->getAddr(), nullptr);
+
+  // Check memory loading for each execution order
+  loader->load(1);
+  EXPECT_NE(mem->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(2);
+  EXPECT_NE(mem->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(3);
+  EXPECT_NE(mem->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(4);
+  EXPECT_NE(mem->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(5);
+  EXPECT_NE(mem->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(6);
+  EXPECT_EQ(mem->getAddr(), nullptr);
+  pool->flush();
+}
+
+/**
+ * @brief load synchronously multiple
+ */
+TEST_F(CacheLoaderTest, load_02_p) {
+  std::shared_ptr<nntrainer::MemoryData<float>> mem1, mem2, mem3;
+  auto idx1 = pool->requestMemory(4, 1, 5, {1, 2, 3, 4, 5});
+  auto idx2 = pool->requestMemory(4, 3, 8, {3, 4, 5, 6, 7, 8});
+  auto idx3 = pool->requestMemory(4, 2, 4, {2, 3, 4});
+  EXPECT_NO_THROW(pool->planLayout(nntrainer::OptimizedV1Planner()));
+  EXPECT_NO_THROW(pool->allocate());
+  EXPECT_EQ(pool->size(), 12);
+  EXPECT_NO_THROW(mem1 = pool->getMemory(idx1));
+  EXPECT_NO_THROW(mem2 = pool->getMemory(idx2));
+  EXPECT_NO_THROW(mem3 = pool->getMemory(idx3));
+  EXPECT_NE(mem1, nullptr);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_NE(mem2, nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_NE(mem3, nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  // Check memory loading for each execution order
+  loader->load(1);
+  EXPECT_NE(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(2);
+  EXPECT_NE(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_NE(mem3->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(3);
+  EXPECT_NE(mem1->getAddr(), nullptr);
+  EXPECT_NE(mem2->getAddr(), nullptr);
+  EXPECT_NE(mem3->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(4);
+  EXPECT_NE(mem1->getAddr(), nullptr);
+  EXPECT_NE(mem2->getAddr(), nullptr);
+  EXPECT_NE(mem3->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(5);
+  EXPECT_NE(mem1->getAddr(), nullptr);
+  EXPECT_NE(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(6);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_NE(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(7);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_NE(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(8);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_NE(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+  pool->flush();
+
+  loader->load(9);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+  pool->flush();
+}
+
+/**
+ * @brief load asynchronously
+ */
+TEST_F(CacheLoaderTest, load_async_01_p) {
+  std::shared_ptr<nntrainer::MemoryData<float>> mem;
+  auto idx = pool->requestMemory(4, 1, 5, {1, 2, 3, 4, 5});
+  EXPECT_NO_THROW(pool->planLayout(nntrainer::OptimizedV1Planner()));
+  EXPECT_NO_THROW(pool->allocate());
+  EXPECT_EQ(pool->size(), 4);
+  EXPECT_NO_THROW(mem = pool->getMemory(idx));
+  EXPECT_NE(mem, nullptr);
+  EXPECT_EQ(mem->getAddr(), nullptr);
+
+  std::promise<void> p;
+  auto future = p.get_future();
+  auto complete = [&p, &mem](int id,
+                             nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_NE(mem->getAddr(), nullptr);
+    p.set_value();
+  };
+
+  // Check memory loading for each execution order
+  int id = loader->loadAsync(1, complete);
+  EXPECT_EQ(mem->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+}
+
+/**
+ * @brief load asynchronously
+ */
+TEST_F(CacheLoaderTest, load_async_02_p) {
+  std::shared_ptr<nntrainer::MemoryData<float>> mem1, mem2, mem3;
+  auto idx1 = pool->requestMemory(4, 1, 5, {1, 2, 3, 4, 5});
+  auto idx2 = pool->requestMemory(4, 3, 8, {3, 4, 5, 6, 7, 8});
+  auto idx3 = pool->requestMemory(4, 2, 4, {2, 3, 4});
+  EXPECT_NO_THROW(pool->planLayout(nntrainer::OptimizedV1Planner()));
+  EXPECT_NO_THROW(pool->allocate());
+  EXPECT_EQ(pool->size(), 12);
+  EXPECT_NO_THROW(mem1 = pool->getMemory(idx1));
+  EXPECT_NO_THROW(mem2 = pool->getMemory(idx2));
+  EXPECT_NO_THROW(mem3 = pool->getMemory(idx3));
+  EXPECT_NE(mem1, nullptr);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_NE(mem2, nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_NE(mem3, nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  // Check memory loading for execution order(1)
+  auto p = new std::promise<void>;
+  auto future = p->get_future();
+  auto complete1 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_NE(mem1->getAddr(), nullptr);
+    EXPECT_EQ(mem2->getAddr(), nullptr);
+    EXPECT_EQ(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  int id = loader->loadAsync(1, complete1);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(2)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete2 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_NE(mem1->getAddr(), nullptr);
+    EXPECT_EQ(mem2->getAddr(), nullptr);
+    EXPECT_NE(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(2, complete2);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(3)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete3 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_NE(mem1->getAddr(), nullptr);
+    EXPECT_NE(mem2->getAddr(), nullptr);
+    EXPECT_NE(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(3, complete3);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(4)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete4 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_NE(mem1->getAddr(), nullptr);
+    EXPECT_NE(mem2->getAddr(), nullptr);
+    EXPECT_NE(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(4, complete4);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(5)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete5 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_NE(mem1->getAddr(), nullptr);
+    EXPECT_NE(mem2->getAddr(), nullptr);
+    EXPECT_EQ(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(5, complete5);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(6)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete6 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_EQ(mem1->getAddr(), nullptr);
+    EXPECT_NE(mem2->getAddr(), nullptr);
+    EXPECT_EQ(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(6, complete6);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(7)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete7 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_EQ(mem1->getAddr(), nullptr);
+    EXPECT_NE(mem2->getAddr(), nullptr);
+    EXPECT_EQ(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(7, complete7);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(8)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete8 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_EQ(mem1->getAddr(), nullptr);
+    EXPECT_NE(mem2->getAddr(), nullptr);
+    EXPECT_EQ(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(8, complete8);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(9)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete9 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_EQ(mem1->getAddr(), nullptr);
+    EXPECT_EQ(mem2->getAddr(), nullptr);
+    EXPECT_EQ(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(9, complete9);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+}
+
+/**
+ * @brief load asynchronously (discontinous order)
+ */
+TEST_F(CacheLoaderTest, load_async_03_p) {
+  std::shared_ptr<nntrainer::MemoryData<float>> mem1, mem2, mem3;
+  auto idx1 = pool->requestMemory(4, 1, 5, {1, 2, 5});
+  auto idx2 = pool->requestMemory(4, 3, 8, {3, 4, 7, 8});
+  auto idx3 = pool->requestMemory(4, 2, 4, {2, 3, 4});
+  EXPECT_NO_THROW(pool->planLayout(nntrainer::OptimizedV1Planner()));
+  EXPECT_NO_THROW(pool->allocate());
+  EXPECT_EQ(pool->size(), 12);
+  EXPECT_NO_THROW(mem1 = pool->getMemory(idx1));
+  EXPECT_NO_THROW(mem2 = pool->getMemory(idx2));
+  EXPECT_NO_THROW(mem3 = pool->getMemory(idx3));
+  EXPECT_NE(mem1, nullptr);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_NE(mem2, nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_NE(mem3, nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  // Check memory loading for execution order(1)
+  auto p = new std::promise<void>;
+  auto future = p->get_future();
+  auto complete1 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_NE(mem1->getAddr(), nullptr);
+    EXPECT_EQ(mem2->getAddr(), nullptr);
+    EXPECT_EQ(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  int id = loader->loadAsync(1, complete1);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(2)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete2 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_NE(mem1->getAddr(), nullptr);
+    EXPECT_EQ(mem2->getAddr(), nullptr);
+    EXPECT_NE(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(2, complete2);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(3)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete3 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_EQ(mem1->getAddr(), nullptr);
+    EXPECT_NE(mem2->getAddr(), nullptr);
+    EXPECT_NE(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(3, complete3);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(4)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete4 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_EQ(mem1->getAddr(), nullptr);
+    EXPECT_NE(mem2->getAddr(), nullptr);
+    EXPECT_NE(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(4, complete4);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(5)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete5 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_NE(mem1->getAddr(), nullptr);
+    EXPECT_EQ(mem2->getAddr(), nullptr);
+    EXPECT_EQ(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(5, complete5);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(6)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete6 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_EQ(mem1->getAddr(), nullptr);
+    EXPECT_EQ(mem2->getAddr(), nullptr);
+    EXPECT_EQ(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(6, complete6);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(7)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete7 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_EQ(mem1->getAddr(), nullptr);
+    EXPECT_NE(mem2->getAddr(), nullptr);
+    EXPECT_EQ(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(7, complete7);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(8)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete8 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_EQ(mem1->getAddr(), nullptr);
+    EXPECT_NE(mem2->getAddr(), nullptr);
+    EXPECT_EQ(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(8, complete8);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+
+  // Check memory loading for execution order(9)
+  p = new std::promise<void>;
+  future = p->get_future();
+
+  auto complete9 = [&](int id, nntrainer::TaskExecutor::CompleteStatus status) {
+    EXPECT_EQ(status, nntrainer::TaskExecutor::SUCCESS);
+    EXPECT_EQ(mem1->getAddr(), nullptr);
+    EXPECT_EQ(mem2->getAddr(), nullptr);
+    EXPECT_EQ(mem3->getAddr(), nullptr);
+    p->set_value();
+  };
+
+  id = loader->loadAsync(9, complete9);
+  EXPECT_NE(id, 0);
+  EXPECT_EQ(mem1->getAddr(), nullptr);
+  EXPECT_EQ(mem2->getAddr(), nullptr);
+  EXPECT_EQ(mem3->getAddr(), nullptr);
+
+  future.wait();
+  pool->flush();
+  delete p;
+}
+
+/**
+ * TODO: cancel and timeout logic test
+ */

--- a/test/unittest/models/models_golden_test.h
+++ b/test/unittest/models/models_golden_test.h
@@ -19,6 +19,7 @@
 
 #include <functional>
 #include <ini_wrapper.h>
+#include <neuralnet.h>
 #include <tensor_dim.h>
 
 inline constexpr const char *DIM_UNUSED = "1:1:1";
@@ -71,6 +72,7 @@ protected:
    *
    */
   nntrainerModelTest() :
+    props({"memory_swap=false"}),
     iteration(0),
     name(""),
     options(ModelTestOption::NO_THROW_RUN) {}
@@ -109,7 +111,9 @@ protected:
    * @return std::unique_ptr<nntrainer::NeuralNetwork> created model
    */
   std::unique_ptr<nntrainer::NeuralNetwork> createModel() {
-    return nn_creator();
+    auto nn = nn_creator();
+    nn->setProperty(props);
+    return nn;
   }
 
   /**
@@ -174,6 +178,8 @@ protected:
   void validate(bool opt,
                 std::function<std::unique_ptr<nntrainer::NeuralNetwork>()>
                   creator = nullptr);
+
+  std::vector<std::string> props; /**< property to be initially set */
 
 private:
   /**


### PR DESCRIPTION
This patch adds cache loader class.

Cache loader supports loading cache elements methods in both synchoronous and
asynchronous manners. Asynchoronous methods are using task executor, and
loods whole cache elements with execution orders in other thread.

Signed-off-by: Jiho Chu <jiho.chu@samsung.com>