### PR TITLE
[Logger] Modify initialization error message of logger instance

### DIFF
--- a/nntrainer/nntrainer_logger.cpp
+++ b/nntrainer/nntrainer_logger.cpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <stdarg.h>
 #include <stdexcept>
+#include <unistd.h>
 
 namespace nntrainer {
 
@@ -77,7 +78,12 @@ Logger::Logger() {
      << std::setw(2) << now->tm_sec << ".out";
   outputstream.open(ss.str(), std::ios_base::app);
   if (!outputstream.good()) {
-    throw std::runtime_error("Unable to initialize the Logger!");
+    char buf[256];
+    char *ret = getcwd(buf, 256);
+    std::string cur_path = std::string(buf);
+    std::string err_msg =
+      "Unable to initialize the Logger on path(" + cur_path + ")";
+    throw std::runtime_error(err_msg);
   }
 }
 


### PR DESCRIPTION
[Logger] Modify initialization error message of logger instance
- Runtime error occurs when an app is executed in a place other
  than the home directory excepted Android and Tizen
- Currently, Android and Tizen don't make logger
- If an user runs an app using nntrainer in a place where
  the logger cannot be initialized, the path is shown for help
- In case of Ubunut, logger unable to initialize on '/usr/bin/',
  /usr/lib/' and etc

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: hyunil park <hyunil46.park@samsung.com>