### PR TITLE
[Trivial] Fix svace and coverity issue

### DIFF
--- a/nntrainer/compiler/tflite_interpreter.cpp
+++ b/nntrainer/compiler/tflite_interpreter.cpp
@@ -359,14 +359,15 @@ TfOpNodes buildOpNodes(const GraphRepresentation &representation,
     tf_node->arity(layer_node_inputs.size());
     for (size_t index = 0; index < layer_node_inputs.size(); index++) {
       auto input_layer_name = layer_node_inputs[index];
-      auto input_layer_node =
-        std::find_if(
-          representation.begin(), representation.end(),
-          [&input_layer_name](std::shared_ptr<nntrainer::LayerNode> node) {
-            return istrequal(node.get()->getName(), input_layer_name);
-          })
-          ->get();
-      tf_node->setArg(index, layer_to_tf.find(input_layer_node)->second);
+      auto input_later_node_iterator = std::find_if(
+        representation.begin(), representation.end(),
+        [&input_layer_name](std::shared_ptr<nntrainer::LayerNode> node) {
+          return istrequal(node.get()->getName(), input_layer_name);
+        });
+      if (input_later_node_iterator != representation.end()) {
+        auto input_layer_node = input_later_node_iterator->get();
+        tf_node->setArg(index, layer_to_tf.find(input_layer_node)->second);
+      }
     }
   }
 

--- a/nntrainer/compiler/tflite_opnode.cpp
+++ b/nntrainer/compiler/tflite_opnode.cpp
@@ -25,6 +25,7 @@ TfOpNode::TfOpNode() :
   weight_transform(nullptr),
   is_input(false),
   is_output(false),
+  is_virtual(false),
   need_reorder_weight(false),
   node_owned_variable(),
   /// @todo distinguish between uninitialized and ADD operator.

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -41,7 +41,7 @@ constexpr const unsigned int POOLING2D_DIM = 2;
  * @brief Construct a new Exporter object
  *
  */
-Exporter::Exporter() : stored_result(nullptr), is_exported(false) {}
+Exporter::Exporter() : fbb(nullptr), stored_result(nullptr), is_exported(false) {}
 
 #ifdef ENABLE_TFLITE_INTERPRETER
 /**


### PR DESCRIPTION
- Add `is_virtual` to default constructor of `TfOpNode` in tflite_opnode.cpp
- Add `fbb` to default constructor of `Exporter` in node_exporter.cpp
- Add a conditional statement to work only if the `result of find_if()` is not the end of the iterator
to solve the `INVALIDATE_ITERATOR` issue in tflite_interpreter.cpp

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped