### PR TITLE
[API] add ml_train_model_get_weight api

### DIFF
--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -630,6 +630,32 @@ int ml_train_model_get_layer(ml_train_model_h model, const char *layer_name,
                              ml_train_layer_h *layer);
 
 /**
+ * @brief Gets weight tensors and information of the layer.
+ * @details Use this function to get weight tensors and information of the
+ * layer. destroy @a info with @c ml_tensors_info_destroy() after use. destroy
+ * @a weight with @c ml_tensors_data_destory() after use.
+ * @since_tizen 7.5
+ * @remarks @a model must be compiled before calling this function.
+ * @remarks the returned @a info @a weights are newly created so it does not
+ * reflect future changes in the model
+ * @remarks On returning error, info must not be destroyed with
+ * ml_tensors_info_destory()
+ *
+ * @param[in] model The NNTrainer model handle.
+ * @param[in] layer_name The name of the layer handle.
+ * @param[out] weight The weight tensors handle.
+ * @param[out] info The weights information handle.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ * @retval #ML_ERROR_OUT_OF_MEMORY Failed to allocate required memory.
+ */
+int ml_train_model_get_weight(ml_train_model_h model, const char *layer_name,
+                              ml_tensors_data_h *weight,
+                              ml_tensors_info_h *info);
+
+/**
  * @}
  */
 #ifdef __cplusplus

--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <string>
+#include <tensor_dim.h>
 #include <vector>
 
 #include <common.h>
@@ -70,7 +71,8 @@ enum LayerType {
     ML_TRAIN_LAYER_TYPE_LAYER_NORMALIZATION, /**< Layer Normalization Layer type
                                               */
   LAYER_POSITIONAL_ENCODING =
-    ML_TRAIN_LAYER_TYPE_POSITIONAL_ENCODING, /**< Positional Encoding Layer type */
+    ML_TRAIN_LAYER_TYPE_POSITIONAL_ENCODING, /**< Positional Encoding Layer type
+                                              */
   LAYER_PREPROCESS_FLIP =
     ML_TRAIN_LAYER_TYPE_PREPROCESS_FLIP, /**< Preprocess flip Layer type */
   LAYER_PREPROCESS_TRANSLATE =
@@ -175,6 +177,14 @@ public:
   virtual const std::string getName() const noexcept = 0;
 
   /**
+   * @brief Get the Weight object name
+   *
+   * @param idx Identifier of the weight
+   * @return const std::string &Name of the weight
+   */
+  virtual const std::string &getWeightName(unsigned int idx) = 0;
+
+  /**
    * @brief     Get weight data of the layer
    * @retval    weight data of the layer
    * @note      nntrainer assign the vector and if there is no weights, the size
@@ -182,6 +192,17 @@ public:
    * @note      layer needs to be finalized before called.
    */
   virtual const std::vector<float *> getWeights() = 0;
+
+  /**
+   * @brief     Get weight data of the layer
+   * @retval    weights : float * arrary to store weight data
+   * @retval    weights_dim : TensorDim for each weights
+   * @note      nntrainer assign the vector and if there is no weights, the size
+   * of vector is zero
+   * @note      layer needs to be finalized before called.
+   */
+  virtual void getWeights(std::vector<float *> &weights,
+                          std::vector<ml::train::TensorDim> &weights_dim) = 0;
 
   /**
    * @brief     Set weight data of the layer

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -530,6 +530,28 @@ public:
   }
 
   /**
+   * @brief     Get weight data of the layer
+   * @param[out]    weights : float * arrary to store weight data
+   * @param[out]    weights_dim : TensorDim for each weights
+   * @note      nntrainer assign the vector and if there is no weights, the size
+   * of vector is zero
+   * @note      layer needs to be finalized before called.
+   */
+  void getWeights(std::vector<float *> &weights,
+                  std::vector<TensorDim> &weight_dim) override {
+    NNTR_THROW_IF(!run_context, std::runtime_error)
+      << __func__ << " layer needs to be finalized first!";
+
+    std::vector<int *> weights_dim;
+    for (unsigned int idx = 0; idx < getNumWeights(); ++idx) {
+      TensorDim d = getWeight(idx).getDim();
+      weights.emplace_back(getWeight(idx).getData());
+      weight_dim.emplace_back(d);
+    }
+    return;
+  }
+
+  /**
    * @brief     Set weight data of the layer
    * @note      Size of vector must be the same with number of weights.
    * @note      layer needs to be finalized before called.

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -867,6 +867,62 @@ TEST(nntrainer_capi_nnmodel, getLayer_04_n) {
 }
 
 /**
+ * @brief Neural Network Model Get Weight  Test
+ */
+TEST(nntrainer_capi_nnmodel, getWeight_01) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+  const unsigned int MAXDIM = 4;
+
+  ml_tensors_info_h weight_info;
+  ml_tensors_data_h weights;
+  unsigned int num_weights;
+  unsigned int dim[2][MAXDIM];
+  unsigned int weight_dim_expected[2][MAXDIM] = {{1, 1, 62720, 10},
+                                                 {1, 1, 1, 10}};
+
+  ScopedIni s("capi_test_get_weight_01",
+              {model_base, optimizer, dataset, inputlayer, outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_compile(handle, NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status =
+    ml_train_model_get_weight(handle, "outputlayer", &weights, &weight_info);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_tensors_info_get_count(weight_info, &num_weights);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  EXPECT_EQ(num_weights, 2ul);
+
+  for (unsigned int idx = 0; idx < num_weights; ++idx) {
+    ml_tensors_info_get_tensor_dimension(weight_info, idx, dim[idx]);
+    for (unsigned int i = 0; i < MAXDIM; ++i) {
+      EXPECT_EQ(dim[idx][i], weight_dim_expected[idx][i]);
+    }
+  }
+
+  status = ml_tensors_info_destroy(weight_info);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  float *t;
+  size_t size = 627200 * sizeof(float);
+
+  status = ml_tensors_data_get_tensor_data(weights, 0, (void **)&t, &size);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_tensors_data_destroy(weights);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
  * @brief Neural Network Model Get Layer Test
  */
 TEST(nntrainer_capi_nnmodel, getLayer_05_n) {
@@ -1102,7 +1158,7 @@ TEST(nntrainer_capi_nnmodel, train_with_file_01_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Compare training statistics */
-  nntrainer_capi_model_comp_metrics(model, 2.182019, 2.223670, 22.9167);
+  nntrainer_capi_model_comp_metrics(model, 2.11176, 2.21936, 16.6667);
 
   status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -1186,7 +1242,7 @@ TEST(nntrainer_capi_nnmodel, train_with_generator_01_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Compare training statistics */
-  nntrainer_capi_model_comp_metrics(model, 2.17419004, 1.94411003, 66.66670227);
+  nntrainer_capi_model_comp_metrics(model, 2.20755, 1.98047, 58.3333);
 
   status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);


### PR DESCRIPTION
This patch add the
``` c
ml_train_model_get_weight(ml_train_model_h model, const
char *layer_name, ml_tensors_data_h *weight, ml_tensors_info_h *info)
```

Now, developers are able to get the weight data & weight information.

ml_train_layer_get_weight will be added later.

Resolves: #2045

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>