### PR TITLE
[ln] optimize layer normalization layer input memory

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -28,6 +28,7 @@
 #include <flatten_layer.h>
 #include <input_layer.h>
 #include <layer_node.h>
+#include <layer_normalization_layer.h>
 #include <multiout_layer.h>
 #include <network_graph.h>
 #include <nntrainer_error.h>
@@ -561,7 +562,8 @@ NetworkGraph::canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode) {
    */
   auto io_independent_backwarding =
     [](const std::shared_ptr<LayerNode> &lnode) {
-      return lnode->getType() == BatchNormalizationLayer::type;
+      return (lnode->getType() == BatchNormalizationLayer::type) ||
+             (lnode->getType() == LayerNormalizationLayer::type);
     };
 
   /**
@@ -625,7 +627,8 @@ NetworkGraph::canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode) {
    * memory save they provide and then make them in-place in that order.
    */
   if (lnode->getType() == ActivationLayer::type ||
-      lnode->getType() == BatchNormalizationLayer::type) {
+      lnode->getType() == BatchNormalizationLayer::type ||
+      lnode->getType() == LayerNormalizationLayer::type) {
     for (auto i = 0u, num_node = lnode->getNumInputConnections(); i < num_node;
          ++i) {
       if (getLayerNode(lnode->getInputConnectionName(i))->executeInPlace() ==

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -34,6 +34,7 @@
 #include <bn_layer.h>
 #include <graph_node.h>
 #include <layer_node.h>
+#include <layer_normalization_layer.h>
 #include <manager.h>
 #include <multiout_layer.h>
 #include <nntrainer_log.h>
@@ -498,7 +499,8 @@ Manager::requestInputs(const GraphNode &node,
   /// @todo handle this inside layer
   if (node.getType() == ActivationLayer::type or
       node.getType() == MultiOutLayer::type or
-      node.getType() == BatchNormalizationLayer::type)
+      node.getType() == BatchNormalizationLayer::type or
+      node.getType() == LayerNormalizationLayer::type)
     var_common_spec.ls = TensorLifespan::FORWARD_FUNC_LIFESPAN;
 
   std::vector<Var_Grad *> ret;


### PR DESCRIPTION
 - As bn layer does ln layer also does not need input in backwarding.
 - This commit will make lifespan of ln layer input as FORWARD_FUNC_LIFESPAN.

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>