### PR TITLE
[swap_device] change lseek return type from int to off_t @open sesame 12/20 15:37

### DIFF
--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -75,9 +75,6 @@ void CachePool::allocate() {
   NNTR_THROW_IF(pool_size == 0, std::runtime_error)
     << "Allocating memory pool with size 0";
 
-  NNTR_THROW_IF(swap_device->isOperating(), std::runtime_error)
-    << "Cache pool is already allocated";
-
   swap_device->start(pool_size);
 }
 
@@ -110,7 +107,7 @@ std::shared_ptr<MemoryData<float>> CachePool::getMemory(unsigned int id) {
   NNTR_THROW_IF(!swap_device->isOperating(), std::invalid_argument)
     << "Allocate memory before allocation";
 
-  int offset = getMemoryOffset().at(id - 1);
+  off_t offset = getMemoryOffset().at(id - 1);
   size_t len = getMemorySize().at(id - 1);
   auto exe_order = getMemoryExecOrder().at(id - 1);
   auto mem_data = std::make_shared<MemoryData<float>>(
@@ -126,8 +123,8 @@ std::shared_ptr<MemoryData<float>> CachePool::getMemory(unsigned int id) {
     ords.append(std::to_string(o));
     ords.append(" ");
   }
-  ml_logd("[%d] exe_order(%s), offset: 0x%x, len: %zu", id, ords.c_str(),
-          offset, len);
+  ml_logd("[%d] exe_order(%s), offset: %llu, len: %zu", id, ords.c_str(),
+          (long long unsigned int)offset, len);
 
   return mem_data;
 }

--- a/nntrainer/tensor/cache_pool.h
+++ b/nntrainer/tensor/cache_pool.h
@@ -33,7 +33,7 @@ public:
    *
    */
   explicit CacheElem(std::shared_ptr<SwapDevice> dev, unsigned int mem_id,
-                     int off, size_t len,
+                     off_t off, size_t len,
                      std::shared_ptr<MemoryData<float>> data,
                      std::vector<unsigned int> order) :
     device(dev),
@@ -95,7 +95,7 @@ private:
   std::shared_ptr<SwapDevice> device; /**< swap device */
   bool active;                        /**< element is loaded */
   unsigned int id;                    /**< memory id */
-  int offset;                         /**< element offset from swap device */
+  off_t offset;                       /**< element offset from swap device */
   size_t length;                      /**< element size */
   std::shared_ptr<MemoryData<float>> mem_data; /**< allocated memory data */
   std::vector<unsigned int> exe_order;         /**< execution order */

--- a/nntrainer/tensor/swap_device.h
+++ b/nntrainer/tensor/swap_device.h
@@ -81,7 +81,7 @@ public:
    * @return The pointer of the swap space
    *
    */
-  void *getBuffer(int offset, size_t size);
+  void *getBuffer(off_t offset, size_t size);
 
   /**
    * @brief Deallocate and put data
@@ -121,7 +121,7 @@ private:
   std::map<void *, std::pair<void *, size_t>>
     mapped; /**< <pointer, <orig_pointer, size>> */
 #else
-  std::map<void *, std::pair<int, ssize_t>>
+  std::map<void *, std::pair<off_t, ssize_t>>
     allocated; /**< <pointer, <offset, size>> */
 #endif
 };


### PR DESCRIPTION
 - Return value of lseek is offset of requested position. The 4byte int type cannot represent more than 3GB so any request more than 3GB offset cause overflow.

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>