### PR TITLE
[typo] Fix typo

### DIFF
--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -188,7 +188,7 @@ public:
 
   /**
    * @brief     get begin iterator for the graph
-   * @retval    const reverse iterator
+   * @retval    const iterator
    */
   graph_const_iterator<LayerNode> cbegin() const {
     return graph.cbegin<LayerNode>();


### PR DESCRIPTION
fix the typo error in network_graph.h

the cbegin function returns a forward const iterator. 
so, removed \'reverse\' from retval description.

Signed-off-by: SeoHyungjun <hyungjun.seo@samsung.com>