### PR TITLE
[meson] enable when tflite related meson option is off @open sesame 12/20 13:50

### DIFF
--- a/Applications/TransferLearning/meson.build
+++ b/Applications/TransferLearning/meson.build
@@ -1,0 +1,7 @@
+if get_option('enable-tflite-backbone')
+  subdir('CIFAR_Classification/jni')
+endif
+
+if enable_capi
+  subdir('Draw_Classification/jni')
+endif

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -2,7 +2,6 @@ nntr_app_resdir = nntrainer_resdir / 'app'
 run_command('mkdir', '-p', nntr_app_resdir)
 
 subdir('utils')
-subdir('KNN/jni')
 subdir('LogisticRegression/jni')
 if enable_ccapi
   subdir('MNIST/jni')
@@ -10,13 +9,11 @@ endif
 subdir('VGG/jni')
 subdir('Resnet/jni')
 subdir('ReinforcementLearning/DeepQ/jni')
-subdir('TransferLearning/CIFAR_Classification/jni')
-if enable_capi
-  subdir('TransferLearning/Draw_Classification/jni')
-endif
+subdir('TransferLearning')
 subdir('Custom')
 subdir('ProductRatings/jni')
 subdir('AlexNet/jni')
 if get_option('enable-tflite-backbone')
+  subdir('KNN/jni')
   subdir('SimpleShot')
 endif

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -9,26 +9,28 @@
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug No known bugs except for NYI items
  */
-#include <node_exporter.h>
 
-#ifdef ENABLE_TFLITE_INTERPRETER
 #include <activation_layer.h>
 #include <bitset>
 #include <common_properties.h>
 #include <fc_layer.h>
 #include <map>
 #include <node_exporter.h>
+
+#ifdef ENABLE_TFLITE_INTERPRETER
 #include <tf_schema_generated.h>
 #include <tflite_opnode.h>
 #endif
 
 namespace {
 
+#ifdef ENABLE_TFLITE_INTERPRETER
 tflite::Padding tflite_padding(const std::string &padding) {
   std::map<std::string, tflite::Padding> m = {{"same", tflite::Padding_SAME},
                                               {"valid", tflite::Padding_VALID}};
   return m[padding];
 }
+#endif
 
 } // namespace
 
@@ -37,11 +39,26 @@ namespace nntrainer {
 constexpr const unsigned int CONV2D_DIM = 2;
 constexpr const unsigned int POOLING2D_DIM = 2;
 
+#ifdef ENABLE_TFLITE_INTERPRETER
+
 /**
  * @brief Construct a new Exporter object
  *
  */
-Exporter::Exporter() : fbb(nullptr), stored_result(nullptr), is_exported(false) {}
+Exporter::Exporter() :
+  fbb(nullptr),
+  stored_result(nullptr),
+  is_exported(false) {}
+
+#else
+
+/**
+ * @brief Construct a new Exporter object
+ *
+ */
+Exporter::Exporter() : stored_result(nullptr), is_exported(false) {}
+
+#endif
 
 #ifdef ENABLE_TFLITE_INTERPRETER
 /**

--- a/test/meson.build
+++ b/test/meson.build
@@ -46,9 +46,7 @@ if get_option('enable-nnstreamer-tensor-filter') and nnstreamer_test_dep.found()
   subdir('nnstreamer')
 endif
 
-if get_option('enable-tflite-interpreter') or get_option('enable-nnstreamer-tensor-filter')
-  run_command('cp','-lr',
-    meson.current_source_dir() / 'test_models/',
-    nntrainer_test_resdir
-  )
-endif
+run_command('cp','-lr',
+  meson.current_source_dir() / 'test_models/',
+  nntrainer_test_resdir
+)

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -129,6 +129,26 @@ auto fc1 = LayerRepresentation("fully_connected", {"name=fc1", "unit=2"});
 auto flatten = LayerRepresentation("flatten", {"name=flat"});
 
 /**
+ * @brief make ini test case from given parameter
+ */
+static std::tuple<nntrainer::GraphRepresentation, const char *,
+                  std::shared_ptr<nntrainer::GraphInterpreter>>
+mkTc(nntrainer::GraphRepresentation graph, const char *file,
+     std::shared_ptr<nntrainer::GraphInterpreter> interpreter) {
+  return std::make_tuple(graph, file, interpreter);
+}
+
+// clang-format off
+GTEST_PARAMETER_TEST(nntrainerAutoInterpreterTest, nntrainerInterpreterTest,
+                        ::testing::Values(
+  mkTc(makeGraph({fc0, flatten}), "simple_fc.ini", ini_interpreter),
+  mkTc(makeGraph({fc0, flatten}), "simple_fc_backbone.ini", ini_interpreter)
+));
+// clang-format on
+
+#ifdef ENABLE_TFLITE_INTERPRETER
+
+/**
  * TODO: update tflite interpreter after the change of semantics that tensors
  * are different between input and output of a layer but the underlying data
  * is same. Once the interpreter is updated, this test can be enabled.
@@ -277,24 +297,6 @@ TEST(nntrainerInterpreterTflite, part_of_resnet_0) {
               << "failed, reason: " << strerror(errno);
   }
 }
-
-/**
- * @brief make ini test case from given parameter
- */
-static std::tuple<nntrainer::GraphRepresentation, const char *,
-                  std::shared_ptr<nntrainer::GraphInterpreter>>
-mkTc(nntrainer::GraphRepresentation graph, const char *file,
-     std::shared_ptr<nntrainer::GraphInterpreter> interpreter) {
-  return std::make_tuple(graph, file, interpreter);
-}
-
-// clang-format off
-GTEST_PARAMETER_TEST(nntrainerAutoInterpreterTest, nntrainerInterpreterTest,
-                        ::testing::Values(
-  mkTc(makeGraph({fc0, flatten}), "simple_fc.ini", ini_interpreter),
-  mkTc(makeGraph({fc0, flatten}), "simple_fc_backbone.ini", ini_interpreter)
-));
-// clang-format on
 
 /**
  * @brief Fully Connected Layer weights transpose(NCHW -> NHWC) unittest
@@ -719,3 +721,5 @@ TEST(nntrainerInterpreterTflite, flatten_test) {
               << "failed, reason: " << strerror(errno);
   }
 }
+
+#endif


### PR DESCRIPTION
 - An applications that needs tflite to run is will not going to be build if option is unset.
 - Tflite interpreter unittest will be working only if tflite option is set.
 - Added default exporter constructor in case of tflite option is unset.

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>