### PR TITLE
[model] Change the default value of parameter in inference function @open sesame 12/20 16:40

### DIFF
--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -311,18 +311,20 @@ public:
   /**
    * @brief     Run NeuralNetwork inference
    * @param[in] X input tensor
+   * @param[in] free_mem true to free memory. used only in training mode.
    * @retval shared_ptr<const Tensor>
    */
-  sharedConstTensors inference(sharedConstTensors X, bool free_mem = true);
+  sharedConstTensors inference(sharedConstTensors X, bool free_mem = false);
 
   /**
    * @brief     Run NeuralNetwork inference
    * @param[in] X input tensor
    * @param[in] label label tensor
+   * @param[in] free_mem true to free memory. used only in training mode.
    * @retval shared_ptr<const Tensor>
    */
   sharedConstTensors inference(sharedConstTensors X, sharedConstTensors label,
-                               bool free_mem = true);
+                               bool free_mem = false);
 
   /**
    * @brief     Run the inference of the model
@@ -553,7 +555,8 @@ private:
   using FlexiblePropTypes =
     std::tuple<props::Epochs, props::TrainingBatchSize, props::SavePath,
                props::ContinueTrain, props::SaveBestPath,
-               props::MemoryOptimization, props::MemorySwap, props::MemorySwapPath>;
+               props::MemoryOptimization, props::MemorySwap,
+               props::MemorySwapPath>;
   using RigidPropTypes =
     std::tuple<props::LossType, std::vector<props::InputConnection>,
                std::vector<props::LabelLayer>, props::ClipGradByGlobalNorm>;


### PR DESCRIPTION
Change the default value of the "free_mem" parameter to false 
in the inference function.

Since the "free memory" option can be used only when the model 
is in the training mode, the desired results may not be obtained 
if the "free_mem" parameter is set to true when we run inference
without training the model.

Therefore, it is better to set "free_mem" option to true only when
this option is needed.

**Self evaluation:**
1. Build test: [x]Passed []Failed []Skipped
2. Run test: [x]Passed []Failed []Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.net>