### PR TITLE
[Trivial] Fix svace issue @open sesame 12/20 15:37

### DIFF
--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -1286,7 +1286,10 @@ int ml_train_model_get_weight(ml_train_model_h model, const char *layer_name,
   for (unsigned int i = 0; i < dims.size(); ++i) {
     status = ml_tensors_data_set_tensor_data(
       *weight, i, w[i], dims[i].getDataLen() * sizeof(float));
-    return status;
+    if (status != ML_ERROR_NONE) {
+	    ml_tensors_data_destroy(weight);
+      return status;
+    }
   }
 
   return status;

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -189,7 +189,7 @@ static int ml_train_dataset_create(ml_train_dataset_h *dataset,
 template <typename... Args>
 static int ml_train_dataset_add_(ml_train_dataset_h dataset,
                                  ml_train_dataset_mode_e mode,
-                                 ml::train::DatasetType type, Args &&...args) {
+                                 ml::train::DatasetType type, Args &&... args) {
   check_feature_state();
   std::shared_ptr<ml::train::Dataset> underlying_dataset;
 
@@ -1085,20 +1085,20 @@ int ml_train_model_get_input_tensors_info(ml_train_model_h model,
 
   status = ml_tensors_info_set_count(*info, dims.size());
   if (status != ML_ERROR_NONE) {
-    ml_tensors_info_destroy(info);
+    ml_tensors_info_destroy(*info);
     return status;
   }
 
   for (unsigned int i = 0; i < dims.size(); ++i) {
     status = ml_tensors_info_set_tensor_type(*info, i, ML_TENSOR_TYPE_FLOAT32);
     if (status != ML_ERROR_NONE) {
-      ml_tensors_info_destroy(info);
+      ml_tensors_info_destroy(*info);
       return status;
     }
 
     status = ml_tensors_info_set_tensor_dimension(*info, i, dims[i].getDim());
     if (status != ML_ERROR_NONE) {
-      ml_tensors_info_destroy(info);
+      ml_tensors_info_destroy(*info);
       return status;
     }
   }
@@ -1143,20 +1143,20 @@ int ml_train_model_get_output_tensors_info(ml_train_model_h model,
 
   status = ml_tensors_info_set_count(*info, dims.size());
   if (status != ML_ERROR_NONE) {
-    ml_tensors_info_destroy(info);
+    ml_tensors_info_destroy(*info);
     return status;
   }
 
   for (unsigned int i = 0; i < dims.size(); ++i) {
     status = ml_tensors_info_set_tensor_type(*info, i, ML_TENSOR_TYPE_FLOAT32);
     if (status != ML_ERROR_NONE) {
-      ml_tensors_info_destroy(info);
+      ml_tensors_info_destroy(*info);
       return status;
     }
 
     status = ml_tensors_info_set_tensor_dimension(*info, i, dims[i].getDim());
     if (status != ML_ERROR_NONE) {
-      ml_tensors_info_destroy(info);
+      ml_tensors_info_destroy(*info);
       return status;
     }
   }
@@ -1253,33 +1253,33 @@ int ml_train_model_get_weight(ml_train_model_h model, const char *layer_name,
 
   status = ml_tensors_info_set_count(*info, dims.size());
   if (status != ML_ERROR_NONE) {
-    ml_tensors_info_destroy(info);
+    ml_tensors_info_destroy(*info);
     return status;
   }
 
   for (unsigned int i = 0; i < dims.size(); ++i) {
     status = ml_tensors_info_set_tensor_type(*info, i, ML_TENSOR_TYPE_FLOAT32);
     if (status != ML_ERROR_NONE) {
-      ml_tensors_info_destroy(info);
+      ml_tensors_info_destroy(*info);
       return status;
     }
 
     status = ml_tensors_info_set_tensor_dimension(*info, i, dims[i].getDim());
     if (status != ML_ERROR_NONE) {
-      ml_tensors_info_destroy(info);
+      ml_tensors_info_destroy(*info);
       return status;
     }
 
     status = ml_tensors_info_set_tensor_name(*info, i, weight_name[i].c_str());
     if (status != ML_ERROR_NONE) {
-      ml_tensors_info_destroy(info);
+      ml_tensors_info_destroy(*info);
       return status;
     }
   }
 
   status = ml_tensors_data_create(*info, weight);
   if (status != ML_ERROR_NONE) {
-    ml_tensors_data_destroy(weight);
+    ml_tensors_data_destroy(*weight);
     return status;
   }
 

--- a/api/capi/src/nntrainer.cpp
+++ b/api/capi/src/nntrainer.cpp
@@ -189,7 +189,7 @@ static int ml_train_dataset_create(ml_train_dataset_h *dataset,
 template <typename... Args>
 static int ml_train_dataset_add_(ml_train_dataset_h dataset,
                                  ml_train_dataset_mode_e mode,
-                                 ml::train::DatasetType type, Args &&... args) {
+                                 ml::train::DatasetType type, Args &&...args) {
   check_feature_state();
   std::shared_ptr<ml::train::Dataset> underlying_dataset;
 
@@ -1287,7 +1287,7 @@ int ml_train_model_get_weight(ml_train_model_h model, const char *layer_name,
     status = ml_tensors_data_set_tensor_data(
       *weight, i, w[i], dims[i].getDataLen() * sizeof(float));
     if (status != ML_ERROR_NONE) {
-	    ml_tensors_data_destroy(weight);
+      ml_tensors_data_destroy(*weight);
       return status;
     }
   }

--- a/nntrainer/tensor/task_executor.cpp
+++ b/nntrainer/tensor/task_executor.cpp
@@ -49,8 +49,9 @@ void TaskExecutor::clean(void) {
   for (auto it = tasks.begin(); it != tasks.end();) {
     auto running = std::get<std::atomic_bool>(it->second).load();
     if (running == false)
-      tasks.erase(it);
-    it++;
+      it = tasks.erase(it);
+    else
+      it++;
   }
 }
 


### PR DESCRIPTION
- Added variable \'cur\' used for erase.
Current position is stored in cur, and the increment operation is performed on the iterator.
If an erase is required, cur is deleted and the iterator is unaffected.

- The for loop runs only once due to a return.
To resolve this issue, we added a conditional statement to run return when it is not ML_ERROR_NONE.

- The parameters of the functions \'ml_tensors_data_destroy\' and \'ml_tensors_info_destroy\' are both of the types \'ml_tensors_data_h\'.
However, several code are using address values.
Added dereference operator to match parameter type.

Signed-off-by: SeoHyungjun <hyungjun.seo@samsung.com>