### PR TITLE
[utils] add getLocaltime function @open sesame 12/20 19:20

### DIFF
--- a/nntrainer/nntrainer_logger.cpp
+++ b/nntrainer/nntrainer_logger.cpp
@@ -31,6 +31,7 @@
 #include <stdarg.h>
 #include <stdexcept>
 #include <unistd.h>
+#include <util_func.h>
 
 namespace nntrainer {
 
@@ -67,15 +68,14 @@ Logger::Cleanup::~Cleanup() {
 Logger::~Logger() { outputstream.close(); }
 
 Logger::Logger() {
-  struct tm lt;
-  time_t t = time(0);
-  struct tm *now = localtime_r(&t, &lt);
+  struct tm now;
+  getLocaltime(&now);
   std::stringstream ss;
-  ss << logfile_name << std::dec << (now->tm_year + 1900) << std::setfill('0')
-     << std::setw(2) << (now->tm_mon + 1) << std::setfill('0') << std::setw(2)
-     << now->tm_mday << std::setfill('0') << std::setw(2) << now->tm_hour
-     << std::setfill('0') << std::setw(2) << now->tm_min << std::setfill('0')
-     << std::setw(2) << now->tm_sec << ".out";
+  ss << logfile_name << std::dec << (now.tm_year + 1900) << std::setfill('0')
+     << std::setw(2) << (now.tm_mon + 1) << std::setfill('0') << std::setw(2)
+     << now.tm_mday << std::setfill('0') << std::setw(2) << now.tm_hour
+     << std::setfill('0') << std::setw(2) << now.tm_min << std::setfill('0')
+     << std::setw(2) << now.tm_sec << ".out";
   outputstream.open(ss.str(), std::ios_base::app);
   if (!outputstream.good()) {
     char buf[256];
@@ -90,9 +90,8 @@ Logger::Logger() {
 void Logger::log(const std::string &message,
                  const nntrainer_loglevel loglevel) {
   std::lock_guard<std::mutex> guard(smutex);
-  time_t t = time(0);
-  struct tm lt;
-  struct tm *now = localtime_r(&t, &lt);
+  struct tm now;
+  getLocaltime(&now);
   std::stringstream ss;
   switch (loglevel) {
   case NNTRAINER_LOG_INFO:
@@ -111,11 +110,11 @@ void Logger::log(const std::string &message,
     break;
   }
 
-  ss << std::dec << (now->tm_year + 1900) << '-' << std::setfill('0')
-     << std::setw(2) << (now->tm_mon + 1) << '-' << std::setfill('0')
-     << std::setw(2) << now->tm_mday << ' ' << std::setfill('0') << std::setw(2)
-     << now->tm_hour << ':' << std::setfill('0') << std::setw(2) << now->tm_min
-     << ':' << std::setfill('0') << std::setw(2) << now->tm_sec << ']';
+  ss << std::dec << (now.tm_year + 1900) << '-' << std::setfill('0')
+     << std::setw(2) << (now.tm_mon + 1) << '-' << std::setfill('0')
+     << std::setw(2) << now.tm_mday << ' ' << std::setfill('0') << std::setw(2)
+     << now.tm_hour << ':' << std::setfill('0') << std::setw(2) << now.tm_min
+     << ':' << std::setfill('0') << std::setw(2) << now.tm_sec << ']';
 
   outputstream << ss.str() << " " << message << std::endl;
 }

--- a/nntrainer/utils/util_func.cpp
+++ b/nntrainer/utils/util_func.cpp
@@ -209,4 +209,14 @@ char *getRealpath(const char *name, char *resolved) {
 #endif
 }
 
+tm *getLocaltime(tm *tp) {
+  time_t t = time(0);
+#ifdef _WIN32
+  localtime_s(tp, &t);
+  return tp;
+#else
+  return localtime_r(&t, tp);
+#endif
+}
+
 } // namespace nntrainer

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -281,6 +281,15 @@ template <typename T, typename C = int> T enum_class_or(T e1, T e2) {
  */
 char *getRealpath(const char *name, char *resolved);
 
+/**
+ * @brief Get local time in tm struct format
+ *
+ * @param tp variable to store the result values
+ *
+ * @return tm struct
+ */
+tm *getLocaltime(tm *tp);
+
 } /* namespace nntrainer */
 
 #endif /* __cplusplus */


### PR DESCRIPTION
Because windows doesn't support "localtime_r" function, the "getLocaltime" function was added to use the "localtime_s" function in windows and the "localtime_r" function in linux.

**Self evaluation:**
1. Build test: [x]Passed []Failed []Skipped
2. Run test: [x]Passed []Failed []Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.net>