### PR TITLE
[Utils] Add log timestamp type

### DIFF
--- a/nntrainer/nntrainer_logger.cpp
+++ b/nntrainer/nntrainer_logger.cpp
@@ -67,7 +67,7 @@ Logger::Cleanup::~Cleanup() {
 
 Logger::~Logger() { outputstream.close(); }
 
-Logger::Logger() {
+Logger::Logger() : ts_type(NNTRAINER_LOG_TIMESTAMP_SEC) {
   struct tm now;
   getLocaltime(&now);
   std::stringstream ss;
@@ -90,9 +90,8 @@ Logger::Logger() {
 void Logger::log(const std::string &message,
                  const nntrainer_loglevel loglevel) {
   std::lock_guard<std::mutex> guard(smutex);
-  struct tm now;
-  getLocaltime(&now);
   std::stringstream ss;
+
   switch (loglevel) {
   case NNTRAINER_LOG_INFO:
     ss << "[NNTRAINER INFO  ";
@@ -110,11 +109,24 @@ void Logger::log(const std::string &message,
     break;
   }
 
-  ss << std::dec << (now.tm_year + 1900) << '-' << std::setfill('0')
-     << std::setw(2) << (now.tm_mon + 1) << '-' << std::setfill('0')
-     << std::setw(2) << now.tm_mday << ' ' << std::setfill('0') << std::setw(2)
-     << now.tm_hour << ':' << std::setfill('0') << std::setw(2) << now.tm_min
-     << ':' << std::setfill('0') << std::setw(2) << now.tm_sec << ']';
+  if (ts_type == NNTRAINER_LOG_TIMESTAMP_MS) {
+    static auto start = std::chrono::system_clock::now().time_since_epoch();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch() - start)
+                .count();
+
+    ss << "[ " << ms << " ]";
+  } else if (ts_type == NNTRAINER_LOG_TIMESTAMP_SEC) {
+    struct tm now;
+    getLocaltime(&now);
+
+    ss << std::dec << (now.tm_year + 1900) << '-' << std::setfill('0')
+       << std::setw(2) << (now.tm_mon + 1) << '-' << std::setfill('0')
+       << std::setw(2) << now.tm_mday << ' ' << std::setfill('0')
+       << std::setw(2) << now.tm_hour << ':' << std::setfill('0')
+       << std::setw(2) << now.tm_min << ':' << std::setfill('0') << std::setw(2)
+       << now.tm_sec << ']';
+  }
 
   outputstream << ss.str() << " " << message << std::endl;
 }

--- a/nntrainer/nntrainer_logger.h
+++ b/nntrainer/nntrainer_logger.h
@@ -42,6 +42,14 @@ typedef enum {
   NNTRAINER_LOG_ERROR
 } nntrainer_loglevel;
 
+/**
+ * @brief     Log TimeStamp type
+ */
+typedef enum {
+  NNTRAINER_LOG_TIMESTAMP_SEC = 0,
+  NNTRAINER_LOG_TIMESTAMP_MS,
+} nntrainer_log_timestamp;
+
 namespace nntrainer {
 
 /**
@@ -64,6 +72,11 @@ public:
   void log(const std::string &message,
            const nntrainer_loglevel loglevel = NNTRAINER_LOG_INFO);
 
+  /**
+   * @brief     Set timestamp type
+   */
+  void setTimeStampType(nntrainer_log_timestamp type) { ts_type = type; }
+
 protected:
   /**
    * @brief     Logging instance
@@ -84,6 +97,10 @@ protected:
    * @brief     sure the single logger
    */
   friend class Cleanup;
+
+  /**
+   * @brief     Class to make sure the single logger
+   */
   class Cleanup {
   public:
     ~Cleanup();
@@ -94,13 +111,31 @@ private:
    * @brief     Constructor
    */
   Logger();
+
   /**
    * @brief     Destructor
    */
   virtual ~Logger();
+
+  /**
+   * @brief     Copy Constructor
+   */
   Logger(const Logger &);
+
+  /**
+   * @brief     Assignment operator
+   */
   Logger &operator=(const Logger &);
+
+  /**
+   * @brief     mutex for logging
+   */
   static std::mutex smutex;
+
+  /**
+   * @brief     log timestamp type
+   */
+  nntrainer_log_timestamp ts_type;
 };
 } /* namespace nntrainer */
 


### PR DESCRIPTION
This patch adds types fo log timestamp type.

NNTRAINER_LOG_TIMESTAMP_SEC: year, mon, day, hour, min, sec
NNTRAINER_LOG_TIMESTAMP_MS: milliseconds from log start

Signed-off-by: Jiho Chu <jiho.chu@samsung.com>