### PR TITLE
[API] set default value on createModel function

### DIFF
--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -322,7 +322,8 @@ public:
  * @brief Factory creator with constructor for optimizer
  */
 std::unique_ptr<Model>
-createModel(ModelType type, const std::vector<std::string> &properties = {});
+createModel(ModelType type = ml::train::ModelType::NEURAL_NET,
+            const std::vector<std::string> &properties = {});
 
 /**
  * @brief creator by copying the configuration of other model


### PR DESCRIPTION
the default value of the "type" parameter of the "createModel" function is set to NEURAL_NET.

the createModel function receives the model type as a parameter, but the only value that can be set is NEURAL_NET.
(KNN is also not supported by the createModel function in API)

Thus, it is inefficient to set the parameter value every time because there is no other option.

**Self evaluation:**
1. Build test: [x]Passed []Failed []Skipped
2. Run test: [x]Passed []Failed []Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>