### PR TITLE
[Wait for #2078] [Execution Order] Set execution order properly for Opt Variables.

### DIFF
--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -39,7 +39,8 @@ public:
    * This ensures that the operations are executed in the order of their
    * listing.
    */
-  typedef std::tuple<unsigned int, unsigned int, unsigned int, unsigned int> ExecutionOrder;
+  typedef std::tuple<unsigned int, unsigned int, unsigned int, unsigned int>
+    ExecutionOrder;
 
   /**
    * @brief     Destructor of Layer Class
@@ -69,6 +70,13 @@ public:
    * @return const std::string type representation
    */
   virtual const std::string getType() const = 0;
+
+  /**
+   * @brief     Get the trainable parameter
+   *
+   * @return bool true / false
+   */
+  virtual bool getTrainable() const = 0;
 
   /**
    * @brief     Get the input connections for this node

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -1111,7 +1111,7 @@ void NetworkGraph::requestOptimizerVariable(
       std::vector<TensorDim> dims = cb(dim);
       w->setOptimizerVariables(tensor_manager->requestWeightOptimizerVariables(
         dims, w->getName(), TensorLifespan::MAX_LIFESPAN,
-        Tensor::Initializer::ZEROS));
+        w->isGradientClipByGlobalNorm(), Tensor::Initializer::ZEROS));
     }
   }
 }

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -312,7 +312,7 @@ public:
    */
   void allocateWeights() {
     tensor_manager->allocateWeights(
-      std::get<0>((*(cend() - 1))->getExecutionOrder()));
+      std::get<2>(backward_iter_end->getExecutionOrder()));
   }
 
   /**

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -234,7 +234,7 @@ public:
    */
   static VarGradSpecV2
   outSpec(const TensorDim &dim, const std::string &name = "out",
-          TensorLifespan ls = TensorLifespan::FORWARD_GRAD_LIFESPAN,
+          TensorLifespan ls = TensorLifespan::FORWARD_FUNC_LIFESPAN,
           TensorLifespan grad_ls = TensorLifespan::BACKWARD_FUNC_LIFESPAN);
 
   /**

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -329,29 +329,29 @@ void NeuralNetwork::backwarding(int iteration,
     PROFILE_MEM_ANNOTATE("CalcGradient: " + node->getName());
 
     bool apply_gradient = true;
+    if (node->getTrainable()) {
+      /** If gradient optimization mode, then calculate gradient first */
+      if (dynamic_training_opt.isGradientMode())
+        node->calcGradient();
 
-    /** If gradient optimization mode, then calculate gradient first */
-    if (dynamic_training_opt.isGradientMode())
-      node->calcGradient();
+      /**
+       * If optimization off, or gradient must be applied, then this will be true
+       * @todo This apply gradient should be passed to the each weight and later
+       * be queried when updating gradient at once. (after moving apply_gradient
+       * out of this function)
+       *
+       */
+      // auto &layer = node->getObject();
+      // apply_gradient = dynamic_training_opt.checkIfApply(
+      //   layer->getWeightsRef(), layer->net_input[0], layer->net_hidden[0], opt,
+      //   iteration);
 
-    /**
-     * If optimization off, or gradient must be applied, then this will be
-     * true
-     * @todo This apply gradient should be passed to the each weight and later
-     * be queried when updating gradient at once. (after moving apply_gradient
-     * out of this function)
-     *
-     */
-    // auto &layer = node->getObject();
-    // apply_gradient = dynamic_training_opt.checkIfApply(
-    //   layer->getWeightsRef(), layer->net_input[0], layer->net_hidden[0],
-    //   opt, iteration);
-
-    /** If gradient must be applied and its not gradient mode, calculate
-     * gradient
-     */
-    if (!dynamic_training_opt.isGradientMode() && apply_gradient)
-      node->calcGradient();
+      /** If gradient must be applied and its not gradient mode, calculate
+       * gradient
+       */
+      if (!dynamic_training_opt.isGradientMode() && apply_gradient)
+        node->calcGradient();
+    }
 
     model_graph.flushCacheExcept(std::get<2>(node->getExecutionOrder()));
     PROFILE_MEM_ANNOTATE("CalcDerivative: " + node->getName());

--- a/nntrainer/tensor/basic_planner.cpp
+++ b/nntrainer/tensor/basic_planner.cpp
@@ -31,8 +31,8 @@ namespace nntrainer {
 size_t BasicPlanner::planLayout(
   const std::vector<size_t> &memory_size,
   const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
-  std::vector<size_t> &memory_offset,
-  std::vector<bool> &memory_is_wgrad) const {
+  std::vector<size_t> &memory_offset, std::vector<bool> &memory_is_wgrad,
+  size_t n_wgrad) const {
 
   memory_offset.resize(memory_size.size());
   size_t csum = 0;

--- a/nntrainer/tensor/basic_planner.cpp
+++ b/nntrainer/tensor/basic_planner.cpp
@@ -20,7 +20,8 @@ namespace nntrainer {
  * @copydoc MemoryPlanner::planLayout(
  * const std::vector<size_t> &memory_size,
  * const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
- * std::vector<size_t> &memory_offset);
+ * std::vector<size_t> &memory_offset,
+ * std::vector<bool> &memory_is_wgrad);
  *
  * @details The basic memory planner does not incorporate any memory sharing.
  * This planner allocates independent memory for all the required memories
@@ -30,7 +31,8 @@ namespace nntrainer {
 size_t BasicPlanner::planLayout(
   const std::vector<size_t> &memory_size,
   const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
-  std::vector<size_t> &memory_offset) const {
+  std::vector<size_t> &memory_offset,
+  std::vector<bool> &memory_is_wgrad) const {
 
   memory_offset.resize(memory_size.size());
   size_t csum = 0;

--- a/nntrainer/tensor/basic_planner.h
+++ b/nntrainer/tensor/basic_planner.h
@@ -38,13 +38,15 @@ public:
    * @copydoc MemoryPlanner::planLayout(
    * const std::vector<size_t> &memory_size,
    * const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
-   * std::vector<size_t> &memory_offset);
+   * std::vector<size_t> &memory_offset,
+   * std::vector<bool> &memory_is_wgrad);
    *
    */
   size_t planLayout(
     const std::vector<size_t> &memory_size,
     const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
-    std::vector<size_t> &memory_offset) const;
+    std::vector<size_t> &memory_offset,
+    std::vector<bool> &memory_is_wgrad) const;
 
   /**
    * @copydoc MemoryPlanner::getType() const

--- a/nntrainer/tensor/basic_planner.h
+++ b/nntrainer/tensor/basic_planner.h
@@ -45,8 +45,8 @@ public:
   size_t planLayout(
     const std::vector<size_t> &memory_size,
     const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
-    std::vector<size_t> &memory_offset,
-    std::vector<bool> &memory_is_wgrad) const;
+    std::vector<size_t> &memory_offset, std::vector<bool> &memory_is_wgrad,
+    size_t n_wgrad = 0) const;
 
   /**
    * @copydoc MemoryPlanner::getType() const

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -360,6 +360,12 @@ std::vector<Weight *> Manager::requestWeights(
   std::vector<unsigned int> default_var_exec_order(
     {forwarding_order, calcDerivative_order});
 
+  /**
+   *  TODO: This needs to be fixed. calcDerivative does not needs the gradient.
+   *  However, current implementation of loss needs the gradient computation.
+   *  and therefore, if we remove the calcDerivative order, then tests fails.
+   */
+
   TensorLifespan var_ls = TensorLifespan::MAX_LIFESPAN;
   TensorLifespan grad_ls = TensorLifespan::BACKWARD_FUNC_LIFESPAN;
 
@@ -384,8 +390,10 @@ std::vector<Weight *> Manager::requestWeights(
      * order with the max exec order where it will be used for clipping and then
      * applied to the weight.
      */
-    if (Weight::isGradientClipByGlobalNorm(clip_by_global_norm))
+    if (Weight::isGradientClipByGlobalNorm(clip_by_global_norm)) {
       grad_exec_order.push_back(TensorPool::PERSIST_END_ORDER);
+      var_exec_order.push_back(TensorPool::PERSIST_END_ORDER);
+    }
 
     Tensor *var = nullptr, *grad = nullptr;
     bool is_dependent = !shared_names.empty();
@@ -622,18 +630,26 @@ bool Manager::isSecondLastAccess(const std::string &name,
  */
 std::vector<Tensor *> Manager::requestWeightOptimizerVariables(
   const std::vector<TensorDim> &dims, const std::string &name,
-  const TensorLifespan &lifespan, Tensor::Initializer initializer) {
+  const TensorLifespan &lifespan, bool is_grad_clip,
+  Tensor::Initializer initializer) {
   auto const exec_order = weight_pool.getExecutionOrder(name);
 
   std::vector<Tensor *> ret;
   ret.reserve(dims.size());
 
+  std::vector<unsigned int> exec;
+  exec.reserve(1);
+  if (is_grad_clip) {
+    exec.emplace_back(TensorPool::PERSIST_END_ORDER);
+  } else {
+    exec.emplace_back(getMinMaxTensorExecutionOrder(name, true).second);
+  }
+
   /// @note this is assuming weight optimizer variables is treated as weight, if
   /// not, there is room to optimize below behavior
   for (unsigned int idx = 0; idx < dims.size(); idx++)
     ret.push_back(weight_pool.request(name + ":opt" + std::to_string(idx),
-                                      dims[idx], exec_order, lifespan,
-                                      initializer));
+                                      dims[idx], exec, lifespan, initializer));
 
   return ret;
 }

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -354,8 +354,8 @@ void Manager::initializeTensorsTrain(unsigned int max_exec_order_) {
 std::vector<Weight *> Manager::requestWeights(
   const GraphNode &node, const std::vector<Weight::Spec> &weights_spec,
   bool trainable, const std::vector<std::string> &shared_names) {
-  const auto [forwarding_order, calcGradient_order, calcDerivative_order, applyGradient_order] =
-    node.getExecutionOrder();
+  const auto [forwarding_order, calcGradient_order, calcDerivative_order,
+              applyGradient_order] = node.getExecutionOrder();
 
   std::vector<unsigned int> default_var_exec_order(
     {forwarding_order, calcDerivative_order});
@@ -450,8 +450,8 @@ std::vector<Weight *> Manager::requestWeights(
 std::vector<Var_Grad *> Manager::requestTensors(
   const GraphNode &node, const std::vector<Var_Grad::Spec> &tensors_spec,
   bool trainable, const std::vector<std::string> &shared_names) {
-  const auto [forwarding_order, calcGradient_order, calcDerivative_order, applyGradient_order] =
-    node.getExecutionOrder();
+  const auto [forwarding_order, calcGradient_order, calcDerivative_order,
+              applyGradient_order] = node.getExecutionOrder();
 
   std::vector<Var_Grad *> ret;
   size_t current_size = tensors_v2.size();
@@ -478,7 +478,8 @@ std::vector<Var_Grad *> Manager::requestTensors(
       grad_exec_order.push_back(calcDerivative_order);
     }
 
-    if (trainable && enum_class_logical_and(tspan, TensorLifespan::CALC_AGRAD_LIFESPAN)) {
+    if (trainable &&
+        enum_class_logical_and(tspan, TensorLifespan::CALC_AGRAD_LIFESPAN)) {
       var_exec_order.push_back(applyGradient_order);
       grad_exec_order.push_back(applyGradient_order);
     }
@@ -662,7 +663,6 @@ Manager::getWeights(const std::function<bool(const Weight *)> &condition) {
     if (!condition || condition(w.get()))
       conditional_weights.push_back(w.get());
   }
-
   return conditional_weights;
 }
 

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -397,6 +397,10 @@ std::vector<Weight *> Manager::requestWeights(
                                         var_ls, t_initializer);
 
       if (trainable && need_gradient) {
+        /** We cannot use the tensor schedulding for weight gradient if the
+         * weight is shared. Weight Sharing means, the gradient is not temporal
+         * for each layer anymore and it is hard to overwritten.
+         */
         grad = tensor_pool.requestOrExtend(shared_name + Var_Grad::grad_suffix,
                                            dim, grad_exec_order, grad_ls,
                                            Tensor::Initializer::ZEROS);
@@ -406,10 +410,18 @@ std::vector<Weight *> Manager::requestWeights(
       var =
         weight_pool.request(name, dim, var_exec_order, var_ls, t_initializer);
 
-      if (trainable && need_gradient)
+      if (trainable && need_gradient) {
+        /** is_wgrad is the index which is true when it is the gradient tensor
+         * of weight. If it is true, memory planner schedule based on it to
+         * reduce the memory.
+         */
+        bool is_wgrad = true;
+        if (Weight::isGradientClipByGlobalNorm(clip_by_global_norm))
+          is_wgrad = false;
         grad = tensor_pool.request(name + Var_Grad::grad_suffix, dim,
                                    grad_exec_order, grad_ls,
-                                   Tensor::Initializer::ZEROS);
+                                   Tensor::Initializer::ZEROS, is_wgrad);
+      }
     }
 
     weights_v2.emplace_back(std::make_unique<Weight>(

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -214,7 +214,7 @@ public:
    */
   std::vector<Tensor *> requestWeightOptimizerVariables(
     const std::vector<TensorDim> &dims, const std::string &name,
-    const TensorLifespan &lifespan,
+    const TensorLifespan &lifespan, bool is_grad_clip,
     Tensor::Initializer initializer = Tensor::Initializer::NONE);
 
   /**

--- a/nntrainer/tensor/memory_planner.h
+++ b/nntrainer/tensor/memory_planner.h
@@ -47,8 +47,8 @@ public:
   virtual size_t planLayout(
     const std::vector<size_t> &memory_size,
     const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
-    std::vector<size_t> &memory_offset,
-    std::vector<bool> &memory_is_wgrad) const = 0;
+    std::vector<size_t> &memory_offset, std::vector<bool> &memory_is_wgrad,
+    size_t n_wgrad) const = 0;
 
   /**
    * @brief Get type of the planner

--- a/nntrainer/tensor/memory_planner.h
+++ b/nntrainer/tensor/memory_planner.h
@@ -38,6 +38,7 @@ public:
    * @param[in] memory_validity The validity of the various memories
    * @param[out] memory_offset The offset of each memory from the base of the
    * allocated memory
+   * @param[in] memory_is_wgrad The index for identification of weight gradient
    * @return The total memory required as per this strategy
    *
    * @details The minimum offset will be 0, and the maximum offset will be less
@@ -46,7 +47,8 @@ public:
   virtual size_t planLayout(
     const std::vector<size_t> &memory_size,
     const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
-    std::vector<size_t> &memory_offset) const = 0;
+    std::vector<size_t> &memory_offset,
+    std::vector<bool> &memory_is_wgrad) const = 0;
 
   /**
    * @brief Get type of the planner

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -44,6 +44,8 @@ unsigned int MemoryPool::requestMemory(size_t bytes, unsigned int start_time,
   memory_validity.push_back({start_time, end_time});
   memory_exec_order.push_back(exec_order);
   memory_is_wgrad.push_back(is_wgrad);
+  if (is_wgrad)
+    n_wgrad++;
 
   /** invalidate min_pool_size if already there */
   min_pool_size = 0;
@@ -75,7 +77,7 @@ double MemoryPool::planLayout(const MemoryPlanner &planner) {
     min_pool_size = calcMinMemoryRequirement();
 
   pool_size = planner.planLayout(memory_size, memory_validity, memory_offset,
-                                 memory_is_wgrad);
+                                 memory_is_wgrad, n_wgrad);
   if (pool_size < min_pool_size || !validateLayout())
     throw std::runtime_error("Planned layout is not feasible");
 
@@ -323,6 +325,7 @@ void MemoryPool::clear() {
 
   pool_size = 0;
   min_pool_size = 0;
+  n_wgrad = 0;
 }
 
 /**

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -55,6 +55,7 @@ public:
    * @param end_time The end of the validity interval of this memory
    * @param exec_order execution orders of this memory
    * @param lifespan lifespan of memory
+   * @param is_wgrad check if the tensor is weight gradient
    *
    * @return The token to get the pointer for this memory after allocation
    * @note start_time is inclusive, but end_time is exclusive
@@ -63,7 +64,8 @@ public:
   virtual unsigned int requestMemory(
     size_t bytes, unsigned int start_time, unsigned int end_time,
     std::vector<unsigned int> exec_order = std::vector<unsigned int>(),
-    TensorLifespan lifespan = TensorLifespan::MAX_LIFESPAN);
+    TensorLifespan lifespan = TensorLifespan::MAX_LIFESPAN,
+    bool is_wgrad = false);
 
   /**
    * @brief Plan the layout with memory planner
@@ -198,6 +200,9 @@ private:
   std::vector<size_t> memory_offset; /**< offsets for the memory requested */
   std::vector<std::vector<unsigned int>>
     memory_exec_order; /**< execution order for the requested memory */
+
+  std::vector<bool>
+    memory_is_wgrad; /**< index for identification of weight gradient */
 
   void *mem_pool; /**< memory pool allocated at once */
 

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -39,7 +39,11 @@ public:
    * @brief MemoryPool default constructor
    *
    */
-  explicit MemoryPool() : mem_pool(nullptr), pool_size(0), min_pool_size(0) {}
+  explicit MemoryPool() :
+    mem_pool(nullptr),
+    pool_size(0),
+    min_pool_size(0),
+    n_wgrad(0) {}
 
   /**
    * @brief MemoryPool destructor
@@ -209,6 +213,8 @@ private:
   size_t pool_size; /**< memory requirement for this pool */
 
   size_t min_pool_size; /**< minimum theoretical memory requirement */
+
+  size_t n_wgrad;
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -14,6 +14,7 @@ tensor_sources = [
   'swap_device.cpp',
   'tensor_pool.cpp',
   'optimized_v1_planner.cpp',
+  'optimized_v2_planner.cpp',
   'task_executor.cpp',
 ]
 

--- a/nntrainer/tensor/optimized_v1_planner.cpp
+++ b/nntrainer/tensor/optimized_v1_planner.cpp
@@ -48,6 +48,17 @@ struct MemoryRequest {
 };
 
 /**
+ * @brief Memory Request data structure clubbing for the weight gradient
+ * requests
+ */
+struct WGradMemoryRequest {
+  MemoryRequest *mem_req;
+  std::vector<std::pair<unsigned int, unsigned int>> start_end;
+
+  WGradMemoryRequest(MemoryRequest *req) : mem_req(req) {}
+};
+
+/**
  * @brief check if validate interval is overlapping in a very naive way.
  *
  * @param memory_validity validity
@@ -130,6 +141,7 @@ struct MemoryRequest {
 size_t OptimizedV1Planner::planLayout(
   const std::vector<size_t> &memory_size,
   const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
+
   std::vector<size_t> &memory_offset, std::vector<bool> &memory_is_wgrad,
   size_t n_wgrad) const {
 
@@ -215,6 +227,65 @@ size_t OptimizedV1Planner::planLayout(
       new_grad_size += req.size;
     }
 #endif
+  }
+
+  if (wgrad_requests.size()) {
+    /** TODO: We donot need to start from memory_req. We might find proper
+     * offset considering execution order */
+    size_t last_offset = memory_req;
+
+    /* sort the memory request with ascending order of size */
+    std::sort(
+      wgrad_requests.begin(), wgrad_requests.end(),
+      [](auto const &v1, auto const &v2) -> int { return v1.size > v2.size; });
+
+    std::vector<WGradMemoryRequest> wgrad_sorted_req;
+
+    bool replace_and_fill = false;
+    for (auto &req : wgrad_requests) {
+      for (unsigned int idx = 0; idx < wgrad_sorted_req.size(); idx++) {
+        auto const sr = wgrad_sorted_req[idx];
+        bool merge = true;
+        if (sr.mem_req->size >= req.size) {
+          for (auto &interval : sr.start_end) {
+            if ((interval.first < req.start && interval.first < req.end &&
+                 req.end < interval.second) ||
+                (req.start > interval.first && req.start < interval.second &&
+                 req.end > interval.second) ||
+                (req.start == interval.first && req.end == interval.second)) {
+              merge = false;
+              break;
+            }
+          }
+        }
+
+        if (merge) {
+          req.offset = sr.mem_req->offset;
+          memory_offset[req.loc] = req.offset;
+          replace_and_fill = true;
+          wgrad_sorted_req[idx].start_end.push_back(
+            std::make_pair(req.start, req.end));
+          break;
+        } else {
+          replace_and_fill = false;
+        }
+      }
+      if (replace_and_fill) {
+        continue;
+      }
+
+      size_t offset = last_offset;
+      if (!wgrad_sorted_req.empty())
+        offset = wgrad_sorted_req.back().mem_req->offset +
+                 wgrad_sorted_req.back().mem_req->size;
+
+      req.offset = offset;
+      memory_offset[req.loc] = offset;
+      memory_req = std::max(memory_req, req.offset + req.size);
+      wgrad_sorted_req.push_back(WGradMemoryRequest(&req));
+      wgrad_sorted_req.back().start_end.push_back(
+        std::make_pair(req.start, req.end));
+    }
   }
 
   //   validateIntervalOverlap(memory_validity, memory_size, memory_offset,

--- a/nntrainer/tensor/optimized_v1_planner.cpp
+++ b/nntrainer/tensor/optimized_v1_planner.cpp
@@ -48,17 +48,6 @@ struct MemoryRequest {
 };
 
 /**
- * @brief Memory Request data structure clubbing for the weight gradient
- * requests
- */
-struct WGradMemoryRequest {
-  MemoryRequest *mem_req;
-  std::vector<std::pair<unsigned int, unsigned int>> start_end;
-
-  WGradMemoryRequest(MemoryRequest *req) : mem_req(req) {}
-};
-
-/**
  * @brief check if validate interval is overlapping in a very naive way.
  *
  * @param memory_validity validity
@@ -227,65 +216,6 @@ size_t OptimizedV1Planner::planLayout(
       new_grad_size += req.size;
     }
 #endif
-  }
-
-  if (wgrad_requests.size()) {
-    /** TODO: We donot need to start from memory_req. We might find proper
-     * offset considering execution order */
-    size_t last_offset = memory_req;
-
-    /* sort the memory request with ascending order of size */
-    std::sort(
-      wgrad_requests.begin(), wgrad_requests.end(),
-      [](auto const &v1, auto const &v2) -> int { return v1.size > v2.size; });
-
-    std::vector<WGradMemoryRequest> wgrad_sorted_req;
-
-    bool replace_and_fill = false;
-    for (auto &req : wgrad_requests) {
-      for (unsigned int idx = 0; idx < wgrad_sorted_req.size(); idx++) {
-        auto const sr = wgrad_sorted_req[idx];
-        bool merge = true;
-        if (sr.mem_req->size >= req.size) {
-          for (auto &interval : sr.start_end) {
-            if ((interval.first < req.start && interval.first < req.end &&
-                 req.end < interval.second) ||
-                (req.start > interval.first && req.start < interval.second &&
-                 req.end > interval.second) ||
-                (req.start == interval.first && req.end == interval.second)) {
-              merge = false;
-              break;
-            }
-          }
-        }
-
-        if (merge) {
-          req.offset = sr.mem_req->offset;
-          memory_offset[req.loc] = req.offset;
-          replace_and_fill = true;
-          wgrad_sorted_req[idx].start_end.push_back(
-            std::make_pair(req.start, req.end));
-          break;
-        } else {
-          replace_and_fill = false;
-        }
-      }
-      if (replace_and_fill) {
-        continue;
-      }
-
-      size_t offset = last_offset;
-      if (!wgrad_sorted_req.empty())
-        offset = wgrad_sorted_req.back().mem_req->offset +
-                 wgrad_sorted_req.back().mem_req->size;
-
-      req.offset = offset;
-      memory_offset[req.loc] = offset;
-      memory_req = std::max(memory_req, req.offset + req.size);
-      wgrad_sorted_req.push_back(WGradMemoryRequest(&req));
-      wgrad_sorted_req.back().start_end.push_back(
-        std::make_pair(req.start, req.end));
-    }
   }
 
   //   validateIntervalOverlap(memory_validity, memory_size, memory_offset,

--- a/nntrainer/tensor/optimized_v1_planner.h
+++ b/nntrainer/tensor/optimized_v1_planner.h
@@ -53,13 +53,15 @@ public:
    * @copydoc MemoryPlanner::planLayout(
    * const std::vector<size_t> &memory_size,
    * const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
-   * std::vector<size_t> &memory_offset);
+   * std::vector<size_t> &memory_offset,
+   * std::vector<bool> &memory_is_wgrad);
    *
    */
   size_t planLayout(
     const std::vector<size_t> &memory_size,
     const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
-    std::vector<size_t> &memory_offset) const;
+    std::vector<size_t> &memory_offset,
+    std::vector<bool> &memory_is_wgrad) const;
 
   /**
    * @copydoc MemoryPlanner::getType() const

--- a/nntrainer/tensor/optimized_v2_planner.cpp
+++ b/nntrainer/tensor/optimized_v2_planner.cpp
@@ -233,10 +233,12 @@ size_t OptimizedV2Planner::planLayout(
     std::vector<WGradMemoryRequest> wgrad_sorted_req;
 
     bool replace_and_fill = false;
+#ifdef DEBUG
     unsigned int new_grad_cnt = 0;
     unsigned int reused_grad_cnt = 0;
     size_t new_grad_size = 0;
     size_t reused_grad_size = 0;
+#endif
     for (auto &req : wgrad_requests) {
       for (unsigned int idx = 0; idx < wgrad_sorted_req.size(); idx++) {
         auto const sr = wgrad_sorted_req[idx];
@@ -260,8 +262,10 @@ size_t OptimizedV2Planner::planLayout(
           replace_and_fill = true;
           wgrad_sorted_req[idx].start_end.push_back(
             std::make_pair(req.start, req.end));
+#ifdef DEBUG
           reused_grad_size += req.size;
           reused_grad_cnt++;
+#endif
           break;
         } else {
           replace_and_fill = false;
@@ -282,15 +286,11 @@ size_t OptimizedV2Planner::planLayout(
       wgrad_sorted_req.push_back(WGradMemoryRequest(&req));
       wgrad_sorted_req.back().start_end.push_back(
         std::make_pair(req.start, req.end));
+#ifdef DEBUG
       new_grad_cnt++;
       new_grad_size += req.size;
+#endif
     }
-
-    ml_logd("Total Requested Memory(OPTV2): %lf MiB>>>>>>>> \n - new mem for "
-            "gradient = %d, "
-            "(%lf MiB) & reused mem for gradient = %d (%lf MiB)\n",
-            memory_req / 1024, new_grad_cnt, new_grad_size / 1024,
-            reused_grad_cnt, reused_grad_size / 1024);
   }
 
   //   validateIntervalOverlap(memory_validity, memory_size, memory_offset,

--- a/nntrainer/tensor/optimized_v2_planner.cpp
+++ b/nntrainer/tensor/optimized_v2_planner.cpp
@@ -1,23 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ * Copyright (C) 2022 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * @file   optimized_v1_planner.cpp
- * @date   3 September 2021
+ * @file   optimized_v2_planner.cpp
+ * @date   29 December 2022
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  This is Optimized V1 Memory Planner
+ * @brief  This is Optimized V2 Memory Planner
  *
  */
 
 #include <algorithm>
 #include <memory>
 #include <nntrainer_error.h>
+#include <nntrainer_log.h>
 #include <stdexcept>
 #include <vector>
 
-#include <optimized_v1_planner.h>
+#include <optimized_v2_planner.h>
 
 namespace nntrainer {
 
@@ -43,6 +45,17 @@ struct MemoryRequest {
     loc(idx),
     size(s),
     offset(0) {}
+};
+
+/**
+ * @brief Memory Request data structure clubbing for the weight gradient
+ * requests
+ */
+struct WGradMemoryRequest {
+  MemoryRequest *mem_req;
+  std::vector<std::pair<unsigned int, unsigned int>> start_end;
+
+  WGradMemoryRequest(MemoryRequest *req) : mem_req(req) {}
 };
 
 /**
@@ -125,18 +138,31 @@ struct MemoryRequest {
  * memories.
  *
  */
-size_t OptimizedV1Planner::planLayout(
+size_t OptimizedV2Planner::planLayout(
   const std::vector<size_t> &memory_size,
   const std::vector<std::pair<unsigned int, unsigned int>> &memory_validity,
   std::vector<size_t> &memory_offset, std::vector<bool> &memory_is_wgrad,
   size_t n_wgrad) const {
 
+  std::vector<MemoryRequest> wgrad_requests;
+  wgrad_requests.reserve(n_wgrad);
+
   /** create memory requests structure array for easier management */
   std::vector<MemoryRequest> requests;
-  requests.reserve(memory_size.size());
-
-  for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
-    requests.emplace_back(memory_size[idx], memory_validity[idx], idx);
+  requests.reserve(memory_size.size() - n_wgrad);
+  if (n_wgrad) {
+    for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
+      if (!memory_is_wgrad[idx]) {
+        requests.emplace_back(memory_size[idx], memory_validity[idx], idx);
+      } else {
+        wgrad_requests.emplace_back(memory_size[idx], memory_validity[idx],
+                                    idx);
+      }
+    }
+  } else {
+    for (unsigned int idx = 0; idx < memory_size.size(); idx++) {
+      requests.emplace_back(memory_size[idx], memory_validity[idx], idx);
+    }
   }
 
   /**
@@ -194,8 +220,82 @@ size_t OptimizedV1Planner::planLayout(
     sorted_req.push_back(&req);
   }
 
+  if (wgrad_requests.size()) {
+    /** TODO: We donot need to start from memeory_req. We might find proper
+     * offset considering execution order */
+    size_t last_offset = memory_req;
+
+    /* sort the memory request with ascending order of size */
+    std::sort(
+      wgrad_requests.begin(), wgrad_requests.end(),
+      [](auto const &v1, auto const &v2) -> int { return v1.size > v2.size; });
+
+    std::vector<WGradMemoryRequest> wgrad_sorted_req;
+
+    bool replace_and_fill = false;
+    unsigned int new_grad_cnt = 0;
+    unsigned int reused_grad_cnt = 0;
+    size_t new_grad_size = 0;
+    size_t reused_grad_size = 0;
+    for (auto &req : wgrad_requests) {
+      for (unsigned int idx = 0; idx < wgrad_sorted_req.size(); idx++) {
+        auto const sr = wgrad_sorted_req[idx];
+        bool merge = true;
+        if (sr.mem_req->size >= req.size) {
+          for (auto &interval : sr.start_end) {
+            if ((interval.first < req.start && interval.first < req.end &&
+                 req.end < interval.second) ||
+                (req.start > interval.first && req.start < interval.second &&
+                 req.end > interval.second) ||
+                (req.start == interval.first && req.end == interval.second)) {
+              merge = false;
+              break;
+            }
+          }
+        }
+
+        if (merge) {
+          req.offset = sr.mem_req->offset;
+          memory_offset[req.loc] = req.offset;
+          replace_and_fill = true;
+          wgrad_sorted_req[idx].start_end.push_back(
+            std::make_pair(req.start, req.end));
+          reused_grad_size += req.size;
+          reused_grad_cnt++;
+          break;
+        } else {
+          replace_and_fill = false;
+        }
+      }
+      if (replace_and_fill) {
+        continue;
+      }
+
+      size_t offset = last_offset;
+      if (!wgrad_sorted_req.empty())
+        offset = wgrad_sorted_req.back().mem_req->offset +
+                 wgrad_sorted_req.back().mem_req->size;
+
+      req.offset = offset;
+      memory_offset[req.loc] = offset;
+      memory_req = std::max(memory_req, req.offset + req.size);
+      wgrad_sorted_req.push_back(WGradMemoryRequest(&req));
+      wgrad_sorted_req.back().start_end.push_back(
+        std::make_pair(req.start, req.end));
+      new_grad_cnt++;
+      new_grad_size += req.size;
+    }
+
+    ml_logd("Total Requested Memory(OPTV2): %lf MiB>>>>>>>> \n - new mem for "
+            "gradient = %d, "
+            "(%lf MiB) & reused mem for gradient = %d (%lf MiB)\n",
+            memory_req / 1024, new_grad_cnt, new_grad_size / 1024,
+            reused_grad_cnt, reused_grad_size / 1024);
+  }
+
   //   validateIntervalOverlap(memory_validity, memory_size, memory_offset,
   //   memory_req);
+
   return memory_req;
 }
 

--- a/nntrainer/tensor/optimized_v2_planner.h
+++ b/nntrainer/tensor/optimized_v2_planner.h
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Copyright (C) 2021 Parichay Kapoor <pk.kapoor@samsung.com>
+ * Copyright (C) 2022 Jijoong.Moon <jijoong.moon@samsung.com>
  *
- * @file   optimzied_v1_planner.h
- * @date   2 September 2021
+ * @file   optimzied_v2_planner.h
+ * @date   29 December 2022
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Parichay Kapoor <pk.kapoor@samsung.com>
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  This is Optimized V1 Memory Planner
+ * @brief  This is Optimized V2 Memory Planner
  *
  * @note This planner has been design to give reduced memory usage for training
  * and might not perform very well for inference.
@@ -25,8 +26,8 @@
  * are freed and reused for the next allocations.
  */
 
-#ifndef __OPTIMIZED_V1_PLANNER_H_
-#define __OPTIMIZED_V1_PLANNER_H_
+#ifndef __OPTIMIZED_V2_PLANNER_H_
+#define __OPTIMIZED_V2_PLANNER_H_
 
 #include <vector>
 
@@ -35,19 +36,19 @@
 namespace nntrainer {
 
 /**
- * @class   OptimizedV1Planner
- * @brief   Optimized V1 Memory Planner provides the optimized plan for memory
+ * @class   OptimizedV2Planner
+ * @brief   Optimized V2 Memory Planner provides the optimized plan for memory
  * layout
  * @details optimized planner performs sharing of overlapping memory sharing
  * upto certain extent
  */
-class OptimizedV1Planner : public MemoryPlanner {
+class OptimizedV2Planner : public MemoryPlanner {
 public:
   /**
    * @brief OptimizedV1Planner destructor
    *
    */
-  OptimizedV1Planner() = default;
+  OptimizedV2Planner() = default;
 
   /**
    * @copydoc MemoryPlanner::planLayout(
@@ -69,9 +70,9 @@ public:
    */
   const std::string &getType() const { return type; }
 
-  inline static const std::string type = "optimized_v1_planner";
+  inline static const std::string type = "optimized_v2_planner";
 };
 
 } // namespace nntrainer
 
-#endif /** __OPTIMIZED_V1_PLANNER_H_ */
+#endif /** __OPTIMIZED_V2_PLANNER_H_ */

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -33,9 +33,10 @@ namespace nntrainer {
 Tensor *TensorPool::request(const std::string &name, const TensorDim &dim,
                             const std::vector<unsigned int> &exec_order,
                             TensorLifespan lifespan,
-                            const Tensor::Initializer &init) {
+                            const Tensor::Initializer &init,
+                            bool is_weight_grad) {
   return registerRequestSpec(
-    {std::make_unique<Tensor>(dim, false, init, name),
+    {is_weight_grad, std::make_unique<Tensor>(dim, false, init, name),
      TensorPool::SourceDetails{0, lifespan, exec_order, {}}});
 }
 
@@ -89,8 +90,12 @@ Tensor *TensorPool::view(const std::string &name, const std::string &reference,
   /** @note in case of view of view, internal datastructure saves the src to
    * view index, not view to view reference in order to flatten depth */
   auto parent_idx = name_map.at(spec.tensor->getName());
+
+  /** @note default is_weight_grad for view is false. view is for the
+   * activation. */
   return registerRequestSpec(
-    {std::make_unique<Tensor>(dim, false, Tensor::Initializer::NONE, name),
+    {false,
+     std::make_unique<Tensor>(dim, false, Tensor::Initializer::NONE, name),
      TensorPool::DependentDetails{parent_idx, adjusted_offset}});
 }
 
@@ -156,7 +161,7 @@ void TensorPool::finalize(const MemoryPlanner &planner,
      */
     details->token = mem_pool->requestMemory(
       spec.tensor->bytes(), validity_start, validity_end + 1,
-      details->exec_order, details->lifespan);
+      details->exec_order, details->lifespan, spec.is_weight_grad);
 #ifdef DEBUG
     if (details->token == 0)
       throw std::runtime_error("Received invalid token from memory pool");
@@ -321,6 +326,7 @@ Tensor *TensorPool::extend(const std::string &name, const TensorDim &dim,
   auto &spec = getSourceSpec(name);
   NNTR_THROW_IF(dim != spec.tensor->getDim(), std::invalid_argument)
     << "Cannot extend tensor with different dimension";
+  spec.is_weight_grad = false;
   expandLifespan(spec, exec_order, lifespan);
   return getTensor(name);
 }

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -160,6 +160,7 @@ public:
    * @param exec_order The execution orders for this tensor.
    * @param lifespan Lifespan of this tensor.
    * @param init Initializer of the tensor.
+   * @param is_weight_grad Identification of weight gradient
    *
    * @return ptr to the created tensor
    *
@@ -170,7 +171,8 @@ public:
   Tensor *request(const std::string &name, const TensorDim &dim,
                   const std::vector<unsigned int> &exec_order,
                   TensorLifespan lifespan,
-                  const Tensor::Initializer &init = Tensor::Initializer::NONE);
+                  const Tensor::Initializer &init = Tensor::Initializer::NONE,
+                  bool is_weight_grad = false);
 
   /**
    * @brief     Request tensor which is a view of already requested with the
@@ -314,6 +316,7 @@ private:
    * @todo move tensor initialization from tensor class to RequestSpec
    */
   struct RequestSpec {
+    bool is_weight_grad;            /**< identification of weight gradient */
     std::unique_ptr<Tensor> tensor; /**< tensor object itself */
     std::variant<SourceDetails, DependentDetails>
       details; /**< additional information by its kind */

--- a/test/unittest/memory/unittest_memory_planner.cpp
+++ b/test/unittest/memory/unittest_memory_planner.cpp
@@ -168,7 +168,7 @@ TEST_P(MemoryPlannerValidate, full_overlap) {
 
   std::vector<bool> memory_is_wgrad;
   size_t pool_size = planner->planLayout(memory_size, memory_validity,
-                                         memory_offset, memory_is_wgrad);
+                                         memory_offset, memory_is_wgrad, 0);
 
   EXPECT_EQ(pool_size,
             std::accumulate(memory_size.begin(), memory_size.end(), 0u));
@@ -196,7 +196,7 @@ TEST_P(MemoryPlannerValidate, none_overlap) {
   std::vector<size_t> memory_offset;
   std::vector<bool> memory_is_wgrad;
   size_t pool_size = planner->planLayout(memory_size, memory_validity,
-                                         memory_offset, memory_is_wgrad);
+                                         memory_offset, memory_is_wgrad, 0);
 
   EXPECT_TRUE(validateOverflow(memory_size, memory_offset, pool_size));
   if (planner->getType() == nntrainer::BasicPlanner::type) {
@@ -233,7 +233,7 @@ TEST_P(MemoryPlannerValidate, partial_overlap) {
   std::vector<size_t> memory_offset;
   std::vector<bool> memory_is_wgrad;
   size_t pool_size = planner->planLayout(memory_size, memory_validity,
-                                         memory_offset, memory_is_wgrad);
+                                         memory_offset, memory_is_wgrad, 0);
 
   EXPECT_TRUE(validateOverflow(memory_size, memory_offset, pool_size));
   if (planner->getType() == nntrainer::BasicPlanner::type) {

--- a/test/unittest/memory/unittest_memory_planner.cpp
+++ b/test/unittest/memory/unittest_memory_planner.cpp
@@ -166,8 +166,9 @@ TEST_P(MemoryPlannerValidate, full_overlap) {
                                                                      {1, 2});
   std::vector<size_t> memory_offset;
 
-  size_t pool_size =
-    planner->planLayout(memory_size, memory_validity, memory_offset);
+  std::vector<bool> memory_is_wgrad;
+  size_t pool_size = planner->planLayout(memory_size, memory_validity,
+                                         memory_offset, memory_is_wgrad);
 
   EXPECT_EQ(pool_size,
             std::accumulate(memory_size.begin(), memory_size.end(), 0u));
@@ -193,8 +194,9 @@ TEST_P(MemoryPlannerValidate, none_overlap) {
   }
 
   std::vector<size_t> memory_offset;
-  size_t pool_size =
-    planner->planLayout(memory_size, memory_validity, memory_offset);
+  std::vector<bool> memory_is_wgrad;
+  size_t pool_size = planner->planLayout(memory_size, memory_validity,
+                                         memory_offset, memory_is_wgrad);
 
   EXPECT_TRUE(validateOverflow(memory_size, memory_offset, pool_size));
   if (planner->getType() == nntrainer::BasicPlanner::type) {
@@ -229,8 +231,9 @@ TEST_P(MemoryPlannerValidate, partial_overlap) {
                std::default_random_engine(0));
 
   std::vector<size_t> memory_offset;
-  size_t pool_size =
-    planner->planLayout(memory_size, memory_validity, memory_offset);
+  std::vector<bool> memory_is_wgrad;
+  size_t pool_size = planner->planLayout(memory_size, memory_validity,
+                                         memory_offset, memory_is_wgrad);
 
   EXPECT_TRUE(validateOverflow(memory_size, memory_offset, pool_size));
   if (planner->getType() == nntrainer::BasicPlanner::type) {


### PR DESCRIPTION
This patch includes the proper assignment of exectuion order for
optimizer variables, e.g., M and V for adam optimizer.
Only apply gradient requies optimizer variables.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>