### PR TITLE
[layer] enable identity layer to support inplace

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -495,6 +495,14 @@ ReduceMean(const std::vector<std::string> &properties = {}) {
 }
 
 /**
+ * @brief Helper function to create Identity layer
+ */
+inline std::unique_ptr<Layer>
+Identity(const std::vector<std::string> &properties = {}) {
+  return createLayer(LayerType::LAYER_IDENTITY, properties);
+}
+
+/**
  * @brief Helper function to create activation layer
  */
 inline std::unique_ptr<Layer>


### PR DESCRIPTION
 - For now identity layer is not considered for support inplace in network graph.
 - This commit will enable identity layer to support inplace.

Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>