### PR TITLE
[Graph] Fix cend function

### DIFF
--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -101,6 +101,9 @@ public:
   /**
    * @brief     get begin iterator for the forwarding
    * @retval    const iterator marking the begin of forwarding
+   * @note      this function should not be used when node_list is empty.
+   * if node_list is empty, end iterator is dereferenced,
+   * This action is undefined behavior.
    */
   template <
     typename T = GraphNode,
@@ -114,16 +117,19 @@ public:
 
   /**
    * @brief     get end iterator for the forwarding
-   * @retval    const iterator marking the emd of forwarding
+   * @retval    const iterator marking the end of forwarding
+   * @note      this function should not be used when node_list is empty.
+   * if node_list is empty, end iterator is dereferenced,
+   * This action is undefined behavior.
    */
   template <
     typename T = GraphNode,
     std::enable_if_t<std::is_base_of<GraphNode, T>::value, T> * = nullptr>
   inline graph_const_iterator<T> cend() const {
     if (Sorted.empty())
-      return graph_const_iterator<T>(&(*node_list.cend()));
+      return graph_const_iterator<T>(&(*node_list.cbegin())) + node_list.size();
     else
-      return graph_const_iterator<T>(&(*Sorted.cend()));
+      return graph_const_iterator<T>(&(*Sorted.cbegin())) + Sorted.size();
   }
 
   /**


### PR DESCRIPTION
- Fix undefined behavior in cend() of \'graph_core.h\'

  The cend() function dereference node_list.cend(). This is undefined
  behavior because it accesses memory in an area that is not actually
  allowed. So changed cend() to operate normally through cbegin() + size.

  However, these changes also include problems. Usually, check that
  node_list is empty, and if it is, it will be treated as an exception.
  if use cbegin() and cend() when node_list is empty, there might be a
  problem. So, Added this caution at @note.

- Fixed a minor typo.

Related : #2086

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeoHyungjun <hyungjun.seo@samsung.com>