### PR TITLE
[trivial] modify flatten_realizer script for consistent codes

### DIFF
--- a/nntrainer/compiler/flatten_realizer.cpp
+++ b/nntrainer/compiler/flatten_realizer.cpp
@@ -54,21 +54,20 @@ FlattenRealizer::realize(const GraphRepresentation &reference) {
       processed.push_back(std::move(flatten_node));
     }
   }
-  RemapRealizer remap_others([&remap_table](std::string &name, unsigned &idx) {
-    if (auto iter = remap_table.find(name); iter != remap_table.end()) {
-      name = iter->second;
-    }
-  });
-
-  RemapRealizer recover_temp(
-    [&recovery_table](std::string &name, unsigned &idx) {
+  processed =
+    RemapRealizer([&remap_table](std::string &name, unsigned &idx) {
+      if (auto iter = remap_table.find(name); iter != remap_table.end()) {
+        name = iter->second;
+      }
+    })
+      .realize(processed);
+  processed =
+    RemapRealizer([&recovery_table](std::string &name, unsigned &idx) {
       if (auto iter = recovery_table.find(name); iter != recovery_table.end()) {
         name = iter->second;
       }
-    });
-
-  processed = remap_others.realize(processed);
-  processed = recover_temp.realize(processed);
+    })
+      .realize(processed);
 
   return processed;
 }


### PR DESCRIPTION
modify "flatten_realizer.cpp" script for consistent codes of "flatten_realizer.cpp" and "activation_realizer.cpp".

"flatten_realizer" and "activation realizer" contain exactly same implementation but written in slightly different ways.

It's a very trivial matter, but I thought it would be better to write the same implementation in the same code, so I modified it.

**Self evaluation:**
1. Build test: [x]Passed []Failed []Skipped
2. Run test: [x]Passed []Failed []Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>