### PR TITLE
[Windows] Modify for Windows porting

### DIFF
--- a/api/ccapi/include/common.h
+++ b/api/ccapi/include/common.h
@@ -19,6 +19,17 @@
 
 #include <nntrainer-api-common.h>
 
+/**
+ * @brief Defining Macros for Exporting Dynamic Library in Windows.
+ * @note Macro is meaningful only if platform is windows.
+ */
+#ifdef _WIN32
+#define ML_API __declspec(dllexport)
+#else
+#define ML_API
+#endif
+
+
 namespace ml {
 namespace train {
 

--- a/api/ccapi/include/dataset.h
+++ b/api/ccapi/include/dataset.h
@@ -80,7 +80,7 @@ public:
  * @param properties property representations
  * @return std::unique_ptr<Dataset> created dataset
  */
-std::unique_ptr<Dataset>
+ML_API std::unique_ptr<Dataset>
 createDataset(DatasetType type,
               const std::vector<std::string> &properties = {});
 
@@ -92,7 +92,7 @@ createDataset(DatasetType type,
  * @param properties property representations
  * @return std::unique_ptr<Dataset> created dataset
  */
-std::unique_ptr<Dataset>
+ML_API std::unique_ptr<Dataset>
 createDataset(DatasetType type, const char *path,
               const std::vector<std::string> &properties = {});
 
@@ -105,7 +105,7 @@ createDataset(DatasetType type, const char *path,
  * @param properties property representations
  * @return std::unique_ptr<Dataset> created dataset
  */
-std::unique_ptr<Dataset>
+ML_API std::unique_ptr<Dataset>
 createDataset(DatasetType type, datagen_cb cb, void *user_data = nullptr,
               const std::vector<std::string> &properties = {});
 } // namespace train

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -12,7 +12,9 @@
  *
  */
 #include <dirent.h>
+#ifndef _WIN32
 #include <dlfcn.h>
+#endif
 #include <iostream>
 #include <sstream>
 #include <string>

--- a/nntrainer/compiler/remap_realizer.h
+++ b/nntrainer/compiler/remap_realizer.h
@@ -15,6 +15,9 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#ifdef _WIN32
+#include <string>
+#endif
 
 #include <realizer.h>
 

--- a/nntrainer/dataset/databuffer.cpp
+++ b/nntrainer/dataset/databuffer.cpp
@@ -39,6 +39,9 @@
 #include <stdlib.h>
 #include <thread>
 #include <util_func.h>
+#ifdef _WIN32
+#include <numeric>
+#endif
 
 namespace nntrainer {
 

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -85,8 +85,8 @@ static void col2im(const Tensor &col_matrix, const TensorDim &kdim,
   int w_stride_end = im_eff_width - eff_k_width - pl;
 
   unsigned col_w = 0;
-  for (int hs = -pt; hs <= h_stride_end; hs += hstride) {
-    for (int ws = -pl; ws <= w_stride_end; ws += wstride) {
+  for (int hs = -1 * pt; hs <= h_stride_end; hs += hstride) {
+    for (int ws = -1 * pl; ws <= w_stride_end; ws += wstride) {
       unsigned col_h = 0;
       int patch_height_end = hs + eff_k_height;
       int patch_width_end = ws + eff_k_width;

--- a/nntrainer/layers/pooling2d_layer.cpp
+++ b/nntrainer/layers/pooling2d_layer.cpp
@@ -204,9 +204,9 @@ void Pooling2DLayer::calcDerivative(RunLayerContext &context) {
     for (unsigned int b = 0; b < batch; ++b) {
       for (unsigned int i = 0; i < channel; ++i) {
         J = 0;
-        for (int j = -pt; j <= heigth_stride_end; j += stride[0]) {
+        for (int j = -1 * pt; j <= heigth_stride_end; j += stride[0]) {
           K = 0;
-          for (int k = -pl; k <= width_stride_end; k += stride[1]) {
+          for (int k = -1 * pl; k <= width_stride_end; k += stride[1]) {
             float del = deriv.getValue(b, i, J, K) / *iter;
             int patch_height_end =
               std::min(static_cast<int>(j + p_height), height);
@@ -399,8 +399,8 @@ void Pooling2DLayer::pooling2d(Tensor &in, bool training, Tensor &output,
   int width_stride_end = width - patch_width - pl;
   for (unsigned int i = 0; i < channel; ++i) {
     const float *in_data_channel_sliced = in_data + i * map_size;
-    for (int j = -pt; j <= height_stride_end; j += stride[0]) {
-      for (int k = -pl; k <= width_stride_end; k += stride[1]) {
+    for (int j = -1 * pt; j <= height_stride_end; j += stride[0]) {
+      for (int k = -1 * pl; k <= width_stride_end; k += stride[1]) {
         float pool_value = pool_fn(in_data_channel_sliced, i, j, k);
         *out_data = pool_value;
         out_data++;

--- a/nntrainer/models/dynamic_training_optimization.cpp
+++ b/nntrainer/models/dynamic_training_optimization.cpp
@@ -13,6 +13,9 @@
 
 #include <random>
 #include <vector>
+#ifdef _WIN32
+#include <numeric>
+#endif
 
 #include <dynamic_training_optimization.h>
 #include <optimizer_wrapped.h>

--- a/nntrainer/nntrainer_log.h
+++ b/nntrainer/nntrainer_log.h
@@ -52,6 +52,33 @@
 #define ml_logd(...) \
   __android_log_print(ANDROID_LOG_DEBUG, TAG_NAME, __VA_ARGS__)
 
+#elif defined(_WIN32)
+#include <nntrainer_logger.h>
+
+#if !defined(ml_logi)
+#define ml_logi(format, ...)                                            \
+  __nntrainer_log_print(NNTRAINER_LOG_INFO, "(%s:%s:%d) " format, __FILE__, \
+                        __func__, __LINE__, __VA_ARGS__)
+#endif
+
+#if !defined(ml_logw)
+#define ml_logw(format, ...)                                            \
+  __nntrainer_log_print(NNTRAINER_LOG_WARN, "(%s:%s:%d) " format, __FILE__, \
+                        __func__, __LINE__, __VA_ARGS__)
+#endif
+
+#if !defined(ml_loge)
+#define ml_loge(format, ...)                                             \
+  __nntrainer_log_print(NNTRAINER_LOG_ERROR, "(%s:%s:%d) " format, __FILE__, \
+                        __func__, __LINE__, __VA_ARGS__)
+#endif
+
+#if !defined(ml_logd)
+#define ml_logd(format, ...)                                             \
+  __nntrainer_log_print(NNTRAINER_LOG_DEBUG, "(%s:%s:%d) " format, __FILE__, \
+                        __func__, __LINE__, __VA_ARGS__)
+#endif
+
 #else /* Linux distro */
 #include <nntrainer_logger.h>
 

--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -91,6 +91,10 @@ std::atomic_int pool_id = 0;
 
 } // namespace
 
+#ifdef _WIN32
+#define getpid _getpid
+#endif
+
 CachePool::CachePool(const std::string &n) :
   name(n),
   swap_device(std::make_shared<SwapDevice>(n + "_" + std::to_string(getpid()) +

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -24,10 +24,15 @@
 #include <functional>
 #include <limits>
 #include <stdexcept>
-#include <sys/mman.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <vector>
+#ifndef _WIN32
+#include <sys/mman.h>
+#include <unistd.h>
+#else
+#include <io.h>
+#include <tools/mman_win32/mman.h>
+#endif
 
 #include <activation_layer.h>
 #include <basic_planner.h>
@@ -358,8 +363,8 @@ void Manager::initializeTensorsTrain(unsigned int max_exec_order_) {
 std::vector<Weight *> Manager::requestWeights(
   const GraphNode &node, const std::vector<Weight::Spec> &weights_spec,
   bool trainable, const std::vector<std::string> &shared_names) {
-  const auto [forwarding_order, calcGradient_order, calcDerivative_order, applyGradient_order] =
-    node.getExecutionOrder();
+  const auto [forwarding_order, calcGradient_order, calcDerivative_order,
+              applyGradient_order] = node.getExecutionOrder();
 
   std::vector<unsigned int> default_var_exec_order(
     {forwarding_order, calcDerivative_order});
@@ -434,8 +439,8 @@ std::vector<Weight *> Manager::requestWeights(
 std::vector<Var_Grad *> Manager::requestTensors(
   const GraphNode &node, const std::vector<Var_Grad::Spec> &tensors_spec,
   bool trainable, const std::vector<std::string> &shared_names) {
-  const auto [forwarding_order, calcGradient_order, calcDerivative_order, applyGradient_order] =
-    node.getExecutionOrder();
+  const auto [forwarding_order, calcGradient_order, calcDerivative_order,
+              applyGradient_order] = node.getExecutionOrder();
 
   std::vector<Var_Grad *> ret;
   size_t current_size = tensors_v2.size();
@@ -462,7 +467,8 @@ std::vector<Var_Grad *> Manager::requestTensors(
       grad_exec_order.push_back(calcDerivative_order);
     }
 
-    if (trainable && enum_class_logical_and(tspan, TensorLifespan::CALC_AGRAD_LIFESPAN)) {
+    if (trainable &&
+        enum_class_logical_and(tspan, TensorLifespan::CALC_AGRAD_LIFESPAN)) {
       var_exec_order.push_back(applyGradient_order);
       grad_exec_order.push_back(applyGradient_order);
     }

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -115,6 +115,10 @@ MMapedMemory::~MMapedMemory() noexcept {
   assert(buf_size > 0 && fd > 0);
 #endif
 
+#ifdef _WIN32
+#define close _close
+#endif
+
   if (fd != -1) {
     if (close(fd) < 0) {
       ml_logw("[MMapedMemory] closing fd failed on destruction please check");

--- a/nntrainer/tensor/swap_device.cpp
+++ b/nntrainer/tensor/swap_device.cpp
@@ -17,7 +17,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
+#ifndef _WIN32
 #include <unistd.h>
+#else
+#include <BaseTsd.h>
+#include <io.h>
+typedef SSIZE_T ssize_t;
+typedef int mode_t;
+#endif
 
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
@@ -137,7 +144,7 @@ void SwapDevice::putBuffer(void *ptr, bool dealloc_only) {
   free(ptr);
   allocated.erase(ptr);
 
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && !defined(_WIN32)
   malloc_trim(0);
 #endif
 

--- a/nntrainer/tensor/swap_device.h
+++ b/nntrainer/tensor/swap_device.h
@@ -18,11 +18,16 @@
 #include <map>
 #include <memory>
 #include <string>
+#ifndef _WIN32
 #include <sys/mman.h>
+#include <unistd.h>
+#else
+#include <io.h>
+#include <tools/mman_win32/mman.h>
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <system_error>
-#include <unistd.h>
 #include <utility>
 
 /* Uncomment this to use mmap for swap data */


### PR DESCRIPTION
**Modify grammar that is not available in Visual Studio**

- The original variable is unsigned int type. It is impossible to put a minus sign. So changed it to multiplying by -1.

- Visual Studio determines the Variable Argument(args...) in the macro as error. Change 'args...' and '#args' to '...' and '_VA_ARGS__' specified in C99.

- POSIX names for getpid and close are deprecated. Use compatible _getpid and _close in ISO C and C++.

- Add dllexport to use function of nntrainer.dll in application

**Add header and data type for windows**

- In visual studio, must add a string header to use std::string. On Linux, can use it without a string header.

- In Windows, can use io.h instead of unistd.h.

- dlfcn.h is a header for linux.

- Need numeric.h to use accumulate and iota.

- ssize_t and mode_t are not defined in windows. Map SSIZE_T to ssize_t (SSIZE_T is defined in BaseTsd.h). Map int to mode_t.

- Disable malloc_trim in windows.

- Add two submodules to use the code of mman and iniparser.

**Update submodule iniparser**

 - Add header and data type for windows

**Submodule iniparser and mman were added for testing. I will add windows-resource repository later (ex. nnstreamer-android-resource for Android) and remove it.**

Related : #2031

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeoHyungjun <hyungjun.seo@samsung.com>
