### PR TITLE
[Trivial] Modify for code consistency

### DIFF
--- a/nntrainer/compiler/activation_realizer.cpp
+++ b/nntrainer/compiler/activation_realizer.cpp
@@ -35,6 +35,7 @@ ActivationRealizer::realize(const GraphRepresentation &reference) {
                      std::string /**< layer_name */>
     recovery_table;
   std::vector<LayerNode *> act_nodes;
+
   for (auto &node : reference) {
     processed.push_back(node);
     if (node->getType() == ActivationLayer::type) {

--- a/nntrainer/compiler/flatten_realizer.cpp
+++ b/nntrainer/compiler/flatten_realizer.cpp
@@ -28,10 +28,10 @@ FlattenRealizer::realize(const GraphRepresentation &reference) {
   std::unordered_map<std::string /**< layer_name */,
                      std::string /**< flatten_layer_name */>
     remap_table;
-  std::vector<LayerNode *> flatten_nodes;
   std::unordered_map<std::string /**< temp_layer_name */,
                      std::string /**< layer_name */>
     recovery_table;
+  std::vector<LayerNode *> flatten_nodes;
 
   for (auto &node : reference) {
     /// @note: [node] type=flatten; flatten=true; is awkward but allowed.


### PR DESCRIPTION
The flatten_realizer.cpp and activation_realizer.cpp declare the same local variable. 
However, the actual code order was written differently. 
Minor modifications were made for code consistency.

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeoHyungjun <hyungjun.seo@samsung.com>