### PR TITLE
[SWAP] task executor: Remove stop and clean feature

### DIFF
--- a/nntrainer/tensor/task.h
+++ b/nntrainer/tensor/task.h
@@ -152,14 +152,14 @@ public:
    *
    * @param time timeout in T
    */
-  virtual void setTimeout(int time) { timeout = T(time); }
+  virtual void setTimeout(int64_t time) { timeout = T(time); }
 
   /**
    * @brief Get timeout
    *
    * @param time timeout in T
    */
-  virtual int getTimeout(void) const { return timeout.count(); }
+  virtual int64_t getTimeout(void) const { return timeout.count(); }
 
   /**
    * @brief Set priority


### PR DESCRIPTION
It's changed to use work queue to manage executions. There is some overhead for stop and cancel behaviors, so they are removed temporaly now, due to the performance.

Signed-off-by: Jiho Chu <jiho.chu@samsung.com>