### PR TITLE
[activation] add swish activation function @open sesame 02/28 16:20

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -522,6 +522,14 @@ ReLU(const std::vector<std::string> &properties = {}) {
 }
 
 /**
+ * @brief Helper function to create swish activation layer
+ */
+inline std::unique_ptr<Layer>
+Swish(const std::vector<std::string> &properties = {}) {
+  return Activation("Activation=swish", properties);
+}
+
+/**
  * @brief Helper function to create Tanh layer
  */
 inline std::unique_ptr<Layer>

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -57,6 +57,19 @@ public:
   /**
    * @brief run prime function
    *
+   * @param[in] input input
+   * @param[in] output output
+   * @param[out] outgoing_derivative outgoing derivative
+   * @param[in] incoming_derivative incoming derivative
+   * @retVal    Tensor
+   */
+  Tensor &run_prime_fn(Tensor &input, Tensor &output,
+                       Tensor &outgoing_derivative,
+                       Tensor const &incoming_derivative);
+
+  /**
+   * @brief run prime function
+   *
    * @param[in] output output
    * @param[out] outgoing_derivative outgoing derivative
    * @param[in] incoming_derivative incoming derivative
@@ -159,6 +172,24 @@ public:
   static float leakyReluPrime(float x);
 
   /**
+   * @brief     swish activation function
+   * @param[in] t_in input tensor
+   * @param[in] t_out output tensor
+   */
+  static Tensor &swish(Tensor const &t_in, Tensor &t_out);
+
+  /**
+   * @brief     derivative swish function
+   * @param[in] t_in input tensor
+   * @param[in] t_out output tensor
+   * @param[in] outgoing_derivative outgoing derivative
+   * @param[in] incoming_derivative incoming derivative
+   */
+  static Tensor &swishPrime(Tensor const &t_in, Tensor const &t_out,
+                            Tensor &outgoing_derivative,
+                            Tensor const &incoming_derivative = Tensor());
+
+  /**
    * @brief setActivation by custom activation function
    * @note  apply derivative as this activation_prime_fn does not utilize
    * derivative
@@ -189,6 +220,19 @@ public:
 
   /**
    * @brief setActivation by custom activation function
+   * @note  derivative not applied here as this activation_prime_fn applies
+   * derivative itself
+   * @param[in] activation_fn activation function to be used
+   * @param[in] activtion_prime_fn activation prime function to be used
+   * @retval #ML_ERROR_NONE when successful
+   */
+  int setActivation(
+    std::function<Tensor &(Tensor const &, Tensor &)> const &activation_fn,
+    std::function<Tensor &(Tensor const &, Tensor const &, Tensor &,
+                           Tensor const &)> const &activation_prime_fn);
+
+  /**
+   * @brief setActivation by custom activation function
    * @note  apply derivative as this activation_prime_fn does not utilize
    * derivative
    * @param[in] std::function<float(float const &)> activation_fn activation
@@ -202,6 +246,20 @@ public:
     std::function<float(float const)> const &activation_prime_fn);
 
   /**
+   * @brief setActivation by custom activation function
+   * @note  apply derivative as this activation_prime_fn does not utilize
+   * derivative
+   * @param[in] std::function<float(float const)> activation_fn activation
+   * function to be used
+   * @param[in] std::function<float(float const, float const)>
+   * activation_prime_fn activation_prime_function to be used
+   * @retval #ML_ERROR_NONE when successful
+   */
+  int setActivation(
+    std::function<float(float const)> const &activation_fn,
+    std::function<float(float const, float const)> const &activation_prime_fn);
+
+  /**
    * @brief   Notify that this layer will execute in-place
    *
    * @param val True if execute in-place, else false
@@ -210,7 +268,8 @@ public:
 
 private:
   std::function<Tensor &(Tensor const &, Tensor &)> _act_fn;
-  std::function<Tensor &(Tensor &, Tensor &, Tensor const &)> _act_prime_fn;
+  std::function<Tensor &(Tensor const &, Tensor &, Tensor &, Tensor const &)>
+    _act_prime_fn; /**< prime function with input and output*/
 
   ActivationType
     activation_type; /**< type of the activation represented by this */

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -69,9 +69,10 @@ void ActivationLayer::forwarding(RunLayerContext &context, bool training) {
 void ActivationLayer::calcDerivative(RunLayerContext &context) {
   const Tensor &deriv = context.getIncomingDerivative(SINGLE_INOUT_IDX);
   Tensor &ret = context.getOutgoingDerivative(SINGLE_INOUT_IDX);
+  Tensor &in = context.getInput(SINGLE_INOUT_IDX);
   Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
 
-  acti_func.run_prime_fn(out, ret, deriv);
+  acti_func.run_prime_fn(in, out, ret, deriv);
 }
 
 void ActivationLayer::exportTo(Exporter &exporter,

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -33,6 +33,7 @@ enum class ActivationType {
   ACT_TANH,       /**< tanh */
   ACT_SIGMOID,    /**< sigmoid */
   ACT_RELU,       /**< ReLU */
+  ACT_SWISH,      /**< Swish */
   ACT_SOFTMAX,    /**< softmax */
   ACT_LEAKY_RELU, /**< Leaky ReLU */
   ACT_NONE,       /**< no op */
@@ -803,12 +804,12 @@ public:
 struct ActivationTypeInfo {
   using Enum = nntrainer::ActivationType;
   static constexpr std::initializer_list<Enum> EnumList = {
-    Enum::ACT_TANH,    Enum::ACT_SIGMOID,    Enum::ACT_RELU,
-    Enum::ACT_SOFTMAX, Enum::ACT_LEAKY_RELU, Enum::ACT_NONE,
-    Enum::ACT_UNKNOWN};
+    Enum::ACT_TANH,       Enum::ACT_SIGMOID, Enum::ACT_RELU, Enum::ACT_SOFTMAX,
+    Enum::ACT_LEAKY_RELU, Enum::ACT_SWISH,   Enum::ACT_NONE, Enum::ACT_UNKNOWN};
 
-  static constexpr const char *EnumStr[] = {
-    "tanh", "sigmoid", "relu", "softmax", "leaky_relu", "none", "unknown"};
+  static constexpr const char *EnumStr[] = {"tanh",    "sigmoid",    "relu",
+                                            "softmax", "leaky_relu", "swish",
+                                            "none",    "unknown"};
 };
 
 /**

--- a/test/unittest/layers/unittest_layers_activation.cpp
+++ b/test/unittest/layers/unittest_layers_activation.cpp
@@ -21,6 +21,11 @@ auto semantic_activation_relu = LayerSemanticsParamType(
   nntrainer::ActivationLayer::type, {"activation=relu"},
   LayerCreateSetPropertyOptions::AVAILABLE_FROM_APP_CONTEXT, false, 1);
 
+auto semantic_activation_swish = LayerSemanticsParamType(
+  nntrainer::createLayer<nntrainer::ActivationLayer>,
+  nntrainer::ActivationLayer::type, {"activation=swish"},
+  LayerCreateSetPropertyOptions::AVAILABLE_FROM_APP_CONTEXT, false, 1);
+
 auto semantic_activation_sigmoid = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::ActivationLayer>,
   nntrainer::ActivationLayer::type, {"activation=sigmoid"},
@@ -41,9 +46,8 @@ auto semantic_activation_none = LayerSemanticsParamType(
   nntrainer::ActivationLayer::type, {"activation=none"},
   LayerCreateSetPropertyOptions::AVAILABLE_FROM_APP_CONTEXT, false, 1);
 
-GTEST_PARAMETER_TEST(Activation, LayerSemantics,
-                     ::testing::Values(semantic_activation_relu,
-                                       semantic_activation_sigmoid,
-                                       semantic_activation_softmax,
-                                       semantic_activation_tanh,
-                                       semantic_activation_none));
+GTEST_PARAMETER_TEST(
+  Activation, LayerSemantics,
+  ::testing::Values(semantic_activation_relu, semantic_activation_swish,
+                    semantic_activation_sigmoid, semantic_activation_softmax,
+                    semantic_activation_tanh, semantic_activation_none));

--- a/test/unittest/unittest_nntrainer_activations.cpp
+++ b/test/unittest/unittest_nntrainer_activations.cpp
@@ -289,6 +289,65 @@ TEST(nntrainer_activation, reluPrime_01_p) {
   }
 }
 
+TEST(nntrainer_activation, swish_01_p) {
+  int batch = 3;
+  int channel = 1;
+  int height = 1;
+  int width = 10;
+  float answer[30] = {
+    -0.16052495, -0.12766725, -0.0900332,  -0.04750208, 0,
+    0.05249792,  0.10996679,  0.17233276,  0.23947506,  0.31122968,
+    -0.24802041, -0.21260624, -0.16052495, -0.0900332,  0,
+    0.10996679,  0.23947506,  0.3873938,   0.5519796,   0.73105854,
+    -0.27777028, -0.26014543, -0.21260624, -0.12766725, 0,
+    0.17233276,  0.3873938,   0.6398545,   0.9222298,   1.2263616};
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
+
+  nntrainer::Tensor results(batch, channel, height, width);
+  results = nntrainer::ActiFunc::swish(input, results);
+
+  float *data = results.getData();
+  ASSERT_NE(nullptr, data);
+  float *indata = input.getData();
+  ASSERT_NE(nullptr, indata);
+
+  for (int i = 0; i < batch * height * width; ++i) {
+    EXPECT_NEAR(data[i], answer[i], tolerance);
+  }
+}
+
+TEST(nntrainer_activation, swishPrime_01_p) {
+
+  int batch = 3;
+  int channel = 1;
+  int height = 1;
+  int width = 10;
+  float answer[30] = {
+    0.30520803, 0.35221997, 0.40066269, 0.45008320, 0.50000000, 0.54991674,
+    0.59933728, 0.64778000, 0.69479191, 0.73996115, 0.13889773, 0.21707317,
+    0.30520803, 0.40066269, 0.50000000, 0.59933728, 0.69479191, 0.78292680,
+    0.86110222, 0.92767054, 0.01800188, 0.10410020, 0.21707317, 0.35221997,
+    0.50000000, 0.64778000, 0.78292680, 0.89589977, 0.98199815, 1.04129410};
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
+
+  nntrainer::Tensor results(batch, channel, height, width);
+  nntrainer::ActiFunc::swish(input, results);
+
+  nntrainer::Tensor prime_results(batch, channel, height, width);
+  nntrainer::ActiFunc::swishPrime(input, results, prime_results);
+
+  float *data = prime_results.getData();
+  ASSERT_NE(nullptr, data);
+
+  for (int i = 0; i < batch * height * width; ++i) {
+    EXPECT_NEAR(data[i], answer[i], tolerance);
+  }
+}
+
 /**
  * @brief Main gtest
  */


### PR DESCRIPTION
Added the swish activation function.

It needs input of activation and output of activation
to calculate derivative value.

So, I overload run_prime_fn function to use
input and output for calculating derivative.

- add swish activation
- add test case about swish activation function

**Issue**
Currently, this swish activation function is NOT SUPPORTED
in RNN, LSTM, GRU and Attention layers. 

I opened issue about it : #2118
I will resolve this problem later. 

**Self evaluation:**
1. Build test: [x]Passed []Failed []Skipped
2. Run test: [x]Passed []Failed []Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>