### PR TITLE
[Wait for #2102][Application] Add Simple Layer Tensorflow Examples

### DIFF
--- a/Applications/Layers/Tensorflow/Conv.py
+++ b/Applications/Layers/Tensorflow/Conv.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023 DongHak Park <donghak.park@samsung.com>
+#
+# @file   main.cpp
+# @date   01 Feb 2023
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Donghak Park <donghak.park@samsung.com>
+# @bug	  No known bugs except for NYI items
+# @brief  This is Conv Example for Tensorflow (with Dummy Dataset)
+
+import tensorflow as tf
+import numpy as np
+
+print("Tensorflow Verison : ", tf.__version__)
+print("Keras Version      : ", tf.keras.__version__)
+
+IMG_SIZE = 224
+OUTPUT_SIZE = 10
+
+
+class Model(tf.Module):
+
+    def __init__(self):
+        self.model = tf.keras.models.Sequential(
+            [
+                tf.keras.layers.Input(shape=(IMG_SIZE, IMG_SIZE, 3)),
+                tf.keras.layers.Conv2D(
+                    3, kernel_size=(3, 3), padding="same", name="conv", strides=(2, 2)
+                ),
+            ]
+        )
+
+        self.model.compile(
+            loss=tf.keras.losses.MeanSquaredError(), optimizer="sgd")
+
+
+m = Model()
+m.model.summary()
+
+np.random.seed(1234)
+
+NUM_EPOCHS = 100
+BATCH_SIZE = 64
+
+for i in range(NUM_EPOCHS):
+    x_train = np.random.randint(0, 255, (64, IMG_SIZE, IMG_SIZE, 3))
+    y_train = np.random.randint(0, 1, (64, 112, 112, 3)).astype(np.float32)
+    x_train = (x_train / 255.0).astype(np.float32)
+    result = m.model.fit(x_train, y_train, batch_size=BATCH_SIZE)
+print("----------Training END--------------")

--- a/Applications/Layers/Tensorflow/LSTM.py
+++ b/Applications/Layers/Tensorflow/LSTM.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023 DongHak Park <donghak.park@samsung.com>
+#
+# @file   main.cpp
+# @date   01 Feb 2023
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Donghak Park <donghak.park@samsung.com>
+# @bug	  No known bugs except for NYI items
+# @brief  This is LSTM Example for Tensorflow (with Dummy Dataset)
+
+import tensorflow as tf
+import numpy as np
+
+print("Tensorflow Verison : ", tf.__version__)
+print("Keras Version      : ", tf.keras.__version__)
+
+IMG_SIZE = 224 * 224 * 3
+OUTPUT_SIZE = 10
+
+
+class Model(tf.Module):
+
+    def __init__(self):
+        self.model = tf.keras.models.Sequential(
+            [
+                tf.keras.layers.Input(shape=(1, IMG_SIZE)),
+                tf.keras.layers.LSTM(
+                    OUTPUT_SIZE,
+                    name="lstm",
+                ),
+            ]
+        )
+
+        self.model.compile(
+            loss=tf.keras.losses.MeanSquaredError(), optimizer="sgd")
+
+
+m = Model()
+m.model.summary()
+np.random.seed(1234)
+
+NUM_EPOCHS = 100
+BATCH_SIZE = 64
+
+
+print("-----TRIANING STRAT-----")
+for i in range(NUM_EPOCHS):
+    x_train = np.random.randint(0, 255, (64, 1, IMG_SIZE))
+    y_train = np.random.randint(0, 1, (64, OUTPUT_SIZE)).astype(np.float32)
+    x_train = (x_train / 255.0).astype(np.float32)
+    result = m.model.fit(x_train, y_train, batch_size=BATCH_SIZE)

--- a/Applications/Layers/Tensorflow/Linear.py
+++ b/Applications/Layers/Tensorflow/Linear.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023 DongHak Park <donghak.park@samsung.com>
+#
+# @file   main.cpp
+# @date   01 Feb 2023
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Donghak Park <donghak.park@samsung.com>
+# @bug	  No known bugs except for NYI items
+# @brief  This is Linear Example for Tensorflow (with Dummy Dataset)
+
+import tensorflow as tf
+import numpy as np
+
+print("Tensorflow Verison : ", tf.__version__)
+print("Keras Version      : ", tf.keras.__version__)
+
+IMG_SIZE = 224 * 224 * 3
+OUTPUT_SIZE = 300
+
+
+class Model(tf.Module):
+
+    def __init__(self):
+        self.model = tf.keras.models.Sequential(
+            [
+                tf.keras.layers.Input(shape=(IMG_SIZE,)),
+                tf.keras.layers.Dense(OUTPUT_SIZE, name="dense"),
+            ]
+        )
+
+        self.model.compile(
+            loss=tf.keras.losses.MeanSquaredError(), optimizer="sgd")
+
+
+m = Model()
+m.model.summary()
+
+NUM_EPOCHS = 10
+BATCH_SIZE = 64
+
+np.random.seed(1234)
+
+for i in range(NUM_EPOCHS):
+    x_train = np.random.randint(0, 255, (64, IMG_SIZE))
+    y_train = np.random.randint(0, 1, (64, OUTPUT_SIZE)).astype(np.float32)
+    x_train = (x_train / 255.0).astype(np.float32)
+    result = m.model.fit(x_train, y_train, batch_size=BATCH_SIZE)
+print("----------Training END--------------")

--- a/Applications/Layers/Tensorflow/Model_A_Conv.py
+++ b/Applications/Layers/Tensorflow/Model_A_Conv.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023 DongHak Park <donghak.park@samsung.com>
+#
+# @file   main.cpp
+# @date   01 Feb 2023
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Donghak Park <donghak.park@samsung.com>
+# @bug	  No known bugs except for NYI items
+# @brief  This is Model_A_Conv Example for Tensorflow (with Dummy Dataset)
+# @brief  -> Conv -> Conv -> Conv ->
+
+import tensorflow as tf
+import numpy as np
+
+print("Tensorflow Verison : ", tf.__version__)
+print("Keras Version      : ", tf.keras.__version__)
+
+IMG_SIZE = 224
+OUTPUT_SIZE = 10
+
+
+class Model(tf.Module):
+
+    def __init__(self):
+        self.model = tf.keras.models.Sequential(
+            [
+                tf.keras.layers.Input(shape=(IMG_SIZE, IMG_SIZE, 3)),
+                tf.keras.layers.Conv2D(
+                    3, kernel_size=(3, 3), padding="same", name="conv1", strides=(2, 2)
+                ),
+                tf.keras.layers.Conv2D(
+                    3, kernel_size=(3, 3), padding="same", name="conv2", strides=(2, 2)
+                ),
+                tf.keras.layers.Conv2D(
+                    3, kernel_size=(3, 3), padding="same", name="conv3", strides=(2, 2)
+                ),
+            ]
+        )
+
+        self.model.compile(
+            loss=tf.keras.losses.MeanSquaredError(), optimizer="sgd")
+
+
+m = Model()
+m.model.summary()
+np.random.seed(1234)
+
+NUM_EPOCHS = 100
+BATCH_SIZE = 64
+
+for i in range(NUM_EPOCHS):
+    x_train = np.random.randint(0, 255, (64, IMG_SIZE, IMG_SIZE, 3))
+    y_train = np.random.randint(0, 1, (64, 28, 28, 3)).astype(np.float32)
+    x_train = (x_train / 255.0).astype(np.float32)
+    result = m.model.fit(x_train, y_train, batch_size=BATCH_SIZE)
+print("----------Training END--------------")

--- a/Applications/Layers/Tensorflow/Model_A_Linear.py
+++ b/Applications/Layers/Tensorflow/Model_A_Linear.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023 DongHak Park <donghak.park@samsung.com>
+#
+# @file   main.cpp
+# @date   01 Feb 2023
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Donghak Park <donghak.park@samsung.com>
+# @bug	  No known bugs except for NYI items
+# @brief  This is Model_A_Linear Example for Tensorflow (with Dummy Dataset)
+# @brief  -> FC -> FC -> FC ->
+
+import tensorflow as tf
+import numpy as np
+
+print("Tensorflow Verison : ", tf.__version__)
+print("Keras Version      : ", tf.keras.__version__)
+
+NUM_EPOCHS = 10
+BATCH_SIZE = 2048
+IMG_SIZE = 784
+OUTPUT_SIZE = 100
+
+
+class Model(tf.Module):
+
+    def __init__(self):
+        self.model = tf.keras.models.Sequential(
+            [
+                tf.keras.layers.Input(shape=(IMG_SIZE,)),
+                tf.keras.layers.Dense(4096, name="dense1"),
+                tf.keras.layers.Dense(2048, name="dense2"),
+                tf.keras.layers.Dense(OUTPUT_SIZE, name="dense3"),
+            ]
+        )
+
+        self.model.compile(
+            loss=tf.keras.losses.MeanSquaredError(), optimizer="sgd")
+
+
+m = Model()
+m.model.summary()
+np.random.seed(1234)
+
+for i in range(NUM_EPOCHS):
+    x_train = np.random.randint(0, 255, (BATCH_SIZE, IMG_SIZE))
+    y_train = np.random.randint(
+        0, 1, (BATCH_SIZE, OUTPUT_SIZE)).astype(np.float32)
+    x_train = (x_train / 255.0).astype(np.float32)
+    result = m.model.fit(x_train, y_train, batch_size=BATCH_SIZE)
+print("----------Training END--------------")

--- a/Applications/Layers/Tensorflow/Model_C_Conv.py
+++ b/Applications/Layers/Tensorflow/Model_C_Conv.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023 DongHak Park <donghak.park@samsung.com>
+#
+# @file   main.cpp
+# @date   01 Feb 2023
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Donghak Park <donghak.park@samsung.com>
+# @bug	  No known bugs except for NYI items
+# @brief  This is Model_C_Conv Example for Tensorflow (with Dummy Dataset)
+# @brief  -> Conv -> RELU -> Flatten ->
+
+import tensorflow as tf
+import numpy as np
+
+print("Tensorflow Verison : ", tf.__version__)
+print("Keras Version      : ", tf.keras.__version__)
+
+NUM_EPOCHS = 100
+BATCH_SIZE = 64
+IMG_SIZE = 224
+OUTPUT_SIZE = 10
+
+
+class Model(tf.Module):
+
+    def __init__(self):
+        self.model = tf.keras.models.Sequential(
+            [
+                tf.keras.layers.Input(shape=(IMG_SIZE, IMG_SIZE, 3)),
+                tf.keras.layers.Conv2D(
+                    3,
+                    kernel_size=(3, 3),
+                    padding="same",
+                    name="conv1",
+                    strides=(2, 2),
+                    activation="relu",
+                ),
+                tf.keras.layers.Flatten(),
+            ]
+        )
+
+        self.model.compile(
+            loss=tf.keras.losses.MeanSquaredError(), optimizer="sgd")
+
+
+m = Model()
+m.model.summary()
+np.random.seed(1234)
+
+
+for i in range(NUM_EPOCHS):
+    x_train = np.random.randint(0, 255, (64, IMG_SIZE, IMG_SIZE, 3))
+    y_train = np.random.randint(0, 1, (64, 37632)).astype(np.float32)
+    x_train = (x_train / 255.0).astype(np.float32)
+    result = m.model.fit(x_train, y_train, batch_size=BATCH_SIZE)
+print("----------Training END--------------")

--- a/Applications/Layers/Tensorflow/Model_C_Linear.py
+++ b/Applications/Layers/Tensorflow/Model_C_Linear.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2023 DongHak Park <donghak.park@samsung.com>
+#
+# @file   main.cpp
+# @date   01 Feb 2023
+# @see    https://github.com/nnstreamer/nntrainer
+# @author Donghak Park <donghak.park@samsung.com>
+# @bug	  No known bugs except for NYI items
+# @brief  This is Model_C_Linear Example for Tensorflow (with Dummy Dataset)
+# @brief  -> FC -> RELU -> Flatten ->
+
+import tensorflow as tf
+import numpy as np
+
+print("Tensorflow Verison : ", tf.__version__)
+print("Keras Version      : ", tf.keras.__version__)
+
+NUM_EPOCHS = 100
+BATCH_SIZE = 64
+IMG_SIZE = 224 * 224 * 3
+OUTPUT_SIZE = 10
+
+
+class Model(tf.Module):
+
+    def __init__(self):
+        self.model = tf.keras.models.Sequential(
+            [
+                tf.keras.layers.Input(shape=(IMG_SIZE,)),
+                tf.keras.layers.Dense(10, name="dense1", activation="relu"),
+                tf.keras.layers.Flatten(),
+            ]
+        )
+
+        self.model.compile(
+            loss=tf.keras.losses.MeanSquaredError(), optimizer="sgd")
+
+
+m = Model()
+m.model.summary()
+np.random.seed(1234)
+
+for i in range(NUM_EPOCHS):
+    x_train = np.random.randint(0, 255, (64, IMG_SIZE))
+    y_train = np.random.randint(0, 1, (64, OUTPUT_SIZE)).astype(np.float32)
+    x_train = (x_train / 255.0).astype(np.float32)
+    result = m.model.fit(x_train, y_train, batch_size=BATCH_SIZE)
+print("----------Training END--------------")


### PR DESCRIPTION
Add Simple Tensorflow Examples with Dummy Data
- Linear
- Conv
- LSTM
- Model_A_Linear
- Model_A_Conv
- Model_C_Linear
- Model_C_Conv

It has same Layer with NNtrainer example that has same name

Signed-off-by: DongHak Park <donghak.park@samsung.com>