### PR TITLE
[Application] Save model trained from pytorch as nntrainer model format @open sesame 03/08 07:58

### DIFF
--- a/tools/pyutils/torchconverter.py
+++ b/tools/pyutils/torchconverter.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+##
+# Copyright (C) 2021 Jihoon Lee <jhoon.it.lee@samsung.com>
+#
+# @file transLayer_v2.py
+# @date 19 October 2021
+# @brief Rewrite parameters in the order consistent with nntrainer for the torch model
+# @author Jihoon lee <jhoon.it.lee@samsung.com>
+
+import torch
+import os
+from collections.abc import Iterable
+
+__all__ = ["params_translated"]
+
+# type to parameter mapper containing (classes, function)
+handler_book = []
+
+##
+# Decorater to register class mapping to a function.
+# This is to imitate function overloadding
+def register_for_(classes):
+    for already_registered_classes, _ in handler_book:
+        if not isinstance(classes, Iterable):
+            classes = (classes, )
+
+        for cls_ in classes:
+            if isinstance(cls_, already_registered_classes):
+                raise ValueError("class is already registered %s" % cls_.__name__)
+
+    def wrapper(func):
+        handler_book.append((classes, func))
+        return func
+
+    return wrapper
+
+
+def default_translate_(model):
+    yield from model.named_parameters(recurse=False)
+
+@register_for_(torch.nn.Linear)
+def fc_translate(model):
+    params = [(name, tensor.detach()) for name, tensor in model.named_parameters()]
+    def transpose_(weight):
+        return (weight[0], weight[1].transpose(1, 0))
+    if len(params) == 2:
+        new_params = [transpose_(params[0]), params[1]]
+    else:
+        new_params = [transpose_(params[0])]
+    yield from new_params
+
+@register_for_((torch.nn.BatchNorm1d, torch.nn.BatchNorm2d))
+def bn_translate(model):
+    gamma, beta = [(name, tensor.detach()) for name, tensor in model.named_parameters()]
+    mu, var, _ = [(name, tensor.detach()) for name, tensor in model.named_buffers()]
+    yield from [mu, var, gamma, beta]
+
+@register_for_(torch.nn.LayerNorm)
+def layer_normalization_translate(model):
+    gamma, beta = [(name, tensor.detach()) for name, tensor in model.named_parameters()]
+    yield from [gamma, beta]
+
+@register_for_((torch.nn.LSTM))
+def lstm_translate(model):
+    params = [(name, tensor.detach()) for name, tensor in model.named_parameters()]
+    # [hidden, input] -> [input, hidden]
+    def transpose_(weight):
+        return (weight[0], weight[1].transpose(1, 0))
+
+    new_params = [transpose_(params[0]), transpose_(params[1]), params[2], params[3]]
+    if model.bidirectional:
+        reverse_params = [transpose_(params[4]), transpose_(params[5]), params[6], params[7]]
+        new_params += reverse_params
+
+    yield from new_params
+
+@register_for_((torch.nn.RNNCell, torch.nn.LSTMCell))
+def rnn_lstm_translate(model):
+    params = [(name, tensor.detach()) for name, tensor in model.named_parameters()]
+    # [hidden, input] -> [input, hidden]
+    def transpose_(weight):
+        return (weight[0], weight[1].transpose(1, 0))
+
+    new_params = [transpose_(params[0]), transpose_(params[1]), params[2], params[3]]
+    yield from new_params
+
+@register_for_((torch.nn.GRUCell))
+def gru_translate(model):
+    params = [(name, tensor.detach()) for name, tensor in model.named_parameters()]
+
+    # [hidden, input] -> [input, hidden]
+    def transpose_(weight):
+        return (weight[0], weight[1].transpose(1, 0))
+
+    # resetgate, inputgate, newgate -> inputgate, resetgate, newgate
+    def reorder_weights(params):
+        reordered_weights = []
+        for (name, weight) in params: # param = ("name", weight)
+            weight = weight.hsplit(3)
+            reordered_weights.append((name, torch.hstack((weight[1], weight[0], weight[2])))) # reorder
+        return reordered_weights
+
+    transposed_params = [transpose_(params[0]), transpose_(params[1]), params[2], params[3]]
+    new_params = reorder_weights(transposed_params)
+
+    yield from new_params
+
+@register_for_((torch.nn.MultiheadAttention))
+def multi_head_attention_translate(model):
+    def transpose_(weight):
+        return (weight[0], weight[1].transpose(1, 0))
+
+    params = [(name, tensor.detach()) for name, tensor in model.named_parameters()]
+
+    getParamByName = lambda name: list(filter(lambda param: param[0] == name, params))[0]
+
+    if model._qkv_same_embed_dim:
+        in_proj_weight = getParamByName('in_proj_weight')
+        w_q, w_k, w_v = in_proj_weight[1].chunk(3)
+        q_proj_weight = ('q_proj_weight', w_q)
+        k_proj_weight = ('k_proj_weight', w_k)
+        v_proj_weight = ('v_proj_weight', w_v)
+    else:
+        q_proj_weight = getParamByName('q_proj_weight')
+        k_proj_weight = getParamByName('k_proj_weight')
+        v_proj_weight = getParamByName('v_proj_weight')
+
+    if model.in_proj_bias is not None:
+        in_proj_bias = getParamByName('in_proj_bias')
+        w_q, w_k, w_v = in_proj_bias[1].chunk(3)
+        q_proj_bias = ('q_proj_bias', w_q)
+        k_proj_bias = ('k_proj_bias', w_k)
+        v_proj_bias = ('v_proj_bias', w_v)
+
+    out_proj_weight = getParamByName('out_proj.weight')
+
+    if model.in_proj_bias is not None:
+        out_proj_bias = getParamByName('out_proj.bias')
+
+    if model.in_proj_bias is None:
+        new_params = [transpose_(q_proj_weight), transpose_(k_proj_weight), transpose_(v_proj_weight), transpose_(out_proj_weight)]
+    else:
+        new_params = [transpose_(q_proj_weight), q_proj_bias, transpose_(k_proj_weight), k_proj_bias, transpose_(v_proj_weight), v_proj_bias, transpose_(out_proj_weight), out_proj_bias]
+
+    yield from new_params
+
+@register_for_(torch.nn.TransformerEncoderLayer)
+def transformer_encoder_translate(model):
+    self_attn, linear1, dropout1, linear2, norm1, norm2, dropout2, dropout3 = [child for name, child in model.named_children()]
+    modules = [self_attn, norm1, linear1, linear2, norm2]
+    ret = []
+
+    for module in modules:
+        for registered_classes, fn in handler_book:
+            if isinstance(module, registered_classes):
+                module = fn(module)
+                module = list((n, t) for n, t in module)
+                ret += module
+                break
+    yield from ret
+
+@register_for_(torch.nn.TransformerDecoderLayer)
+def transformer_decoder_translate(model):
+    self_attn, multihead_attn, linear1, dropout1, linear2, norm1, norm2, norm3, dropout2, dropout3, dropout4 = [child for name, child in model.named_children()]
+    modules = [self_attn, norm1, multihead_attn, norm2, linear1, linear2, norm3]
+    ret = []
+
+    for module in modules:
+        for registered_classes, fn in handler_book:
+            if isinstance(module, registered_classes):
+                module = fn(module)
+                module = list((n, t) for n, t in module)
+                ret += module
+                break
+    yield from ret
+
+def translate(model):
+    for child in model.children():
+        for registered_classes, fn in handler_book:
+            if isinstance(child, registered_classes):
+                yield from fn(child)
+                break
+        else: # default case
+            yield from translate(child)
+    yield from default_translate_(model)
+
+def save_bin(model, name):
+    file_name = './' + name + ".bin"
+    if os.path.isfile(file_name):
+        print("Warning: the file %s is being truncated and overwritten" % file_name)
+
+    with open(file_name, 'wb') as f:
+        param_list = list(t for _, t in params_translated(model))
+
+        for param in param_list:            
+            param.detach().cpu().numpy().tofile(f)
+
+
+params_translated = translate
+


### PR DESCRIPTION
I modified resnet example to save model trained from pytorch as nntrainer binary model format.
"translayer_v2.py" is renamed to "torchconverter.py" and moved to tools folder so that it can be used for common modules.

- the pytorch resnet example model is modified to be the same as the nntrainer resnet example model.

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>