### PR TITLE
[Propose][GitAction] Review Request Auto labeler @open sesame 02/21 13:48 

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,56 @@
+# @author : Donghak Park <donghak.park@samsung.com>
+# @file   : labeler.yml
+# @date   : 15 Feb 2023
+
+name: Auto Need-Review labeler
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+  pull_request_review:
+    types: [edited, dismissed, submitted]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: review_count
+        id: review_count
+        run: |
+          review=$(curl -s -H "Accept: application/vnd.github.black-cat-preview+json" \
+          https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+          | jq '[ .[] | select(.state=="APPROVED") ] | length')
+          echo "Number of approved review_count: $review"
+          echo "::set-output name=review::$review"
+          echo "REVIEW=$review" >> $GITHUB_OUTPUT
+
+      
+      - name: DEBUG
+        run: |
+          echo "Number of Approved review_count : ${{ steps.review_count.outputs.REVIEW }}"
+
+      - name: Make label if approved review < 3
+        if: ${{ steps.review_count.outputs.REVIEW < 3 && !contains(github.event.pull_request.labels.*.name, 'Need Review') }}
+        uses: actions/github-script@v4
+        with:
+          script: |
+            github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["Need Review"]
+            })
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove label if approved review >= 3
+        if: ${{ steps.review_count.outputs.REVIEW >= 3 && contains(github.event.pull_request.labels.*.name, 'Need Review') }}
+        uses: actions/github-script@v4
+        with:
+          script: |
+            github.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name : ["Need Review"]
+            })
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Create Review Request Auto labeler
- this git action yml will automatically label "Need Review" when cretae PR
- when it edit or reopen it will automatically make label
- and It also remove when approved review exceed 3

For this we need ```secrets.GITHUB_TOKEN```

For Test this branch should be upstream's branch that why I made gitaction-review branch : after merge i will remove this branch asap