### PR TITLE
[neuralnet] fix stop call back to exploit RunStats @open sesame 02/28 16:13

### DIFF
--- a/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
+++ b/Applications/ReinforcementLearning/DeepQ/jni/main.cpp
@@ -61,6 +61,7 @@
  *
  */
 
+#include "model.h"
 #include "neuralnet.h"
 #include "tensor.h"
 #include <fstream>
@@ -345,7 +346,8 @@ int main(int argc, char **argv) {
           return 0;
         }
         try {
-          test = mainNet.forwarding({MAKE_SHARED_TENSOR(in_tensor)})[0];
+          ml::train::RunStats stat;
+          test = mainNet.forwarding(stat, {MAKE_SHARED_TENSOR(in_tensor)})[0];
         } catch (...) {
           std::cerr << "Error while forwarding the network" << std::endl;
           return 0;
@@ -452,7 +454,8 @@ int main(int argc, char **argv) {
          */
         nntrainer::sharedConstTensor Q;
         try {
-          Q = mainNet.forwarding({MAKE_SHARED_TENSOR(q_in)})[0];
+          ml::train::RunStats stat;
+          Q = mainNet.forwarding(stat, {MAKE_SHARED_TENSOR(q_in)})[0];
         } catch (...) {
           std::cerr << "Error during forwarding main network" << std::endl;
           return -1;
@@ -463,7 +466,8 @@ int main(int argc, char **argv) {
          */
         nntrainer::sharedConstTensor NQ;
         try {
-          NQ = targetNet.forwarding({MAKE_SHARED_TENSOR(nq_in)})[0];
+          ml::train::RunStats stat;
+          NQ = targetNet.forwarding(stat, {MAKE_SHARED_TENSOR(nq_in)})[0];
         } catch (...) {
           std::cerr << "Error during forwarding target network" << std::endl;
           return -1;
@@ -499,8 +503,9 @@ int main(int argc, char **argv) {
         nntrainer::Tensor in_tensor;
         try {
           in_tensor = nntrainer::Tensor(inbatch);
-          mainNet.forwarding({MAKE_SHARED_TENSOR(in_tensor)}, {Q});
-          mainNet.backwarding(iter);
+          ml::train::RunStats stat;
+          mainNet.forwarding(stat, {MAKE_SHARED_TENSOR(in_tensor)}, {Q});
+          mainNet.backwarding(iter, stat);
         } catch (...) {
           std::cerr << "Error during backwarding the network" << std::endl;
           return -1;

--- a/Applications/TransferLearning/CIFAR_Classification/jni/main.cpp
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/main.cpp
@@ -40,6 +40,7 @@
 #include <time.h>
 
 #include <app_context.h>
+#include <model.h>
 #include <neuralnet.h>
 #include <tensor.h>
 
@@ -454,7 +455,8 @@ int main(int argc, char *argv[]) {
     nntrainer::Tensor X;
     try {
       X = nntrainer::Tensor({featureVector});
-      NN.forwarding({MAKE_SHARED_TENSOR(X)})[0]->apply(stepFunction);
+      ml::train::RunStats stat;
+      NN.forwarding(stat, {MAKE_SHARED_TENSOR(X)})[0]->apply(stepFunction);
     } catch (...) {
       std::cerr << "Error while forwarding the model" << std::endl;
       return 1;

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -70,6 +70,23 @@ for inference and training without any configurations*/
 };
 
 /**
+ * @brief     Statistics from running or training a model
+ */
+struct RunStats {
+  float accuracy;     /** accuracy of the model */
+  float loss;         /** loss of the model */
+  int num_iterations; /** number of iterations done on this stat */
+  unsigned int
+    num_correct_predictions; /** number of right sample on this run */
+
+  RunStats() :
+    accuracy(0),
+    loss(0),
+    num_iterations(0),
+    num_correct_predictions(0) {}
+};
+
+/**
  * @class   Model Class
  * @brief   Model Class containing configuration, layers, optimizer and dataset
  */
@@ -318,6 +335,11 @@ public:
    */
   virtual void exports(const ExportMethods &method,
                        const std::string file_path) = 0;
+
+  /**
+   * @brief     Get run statistics
+   */
+  virtual std::vector<RunStats> getStatistics() = 0;
 };
 
 /**

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -25,6 +25,7 @@
 #include <graph_core.h>
 #include <layer_node.h>
 #include <manager.h>
+#include <model.h>
 
 namespace nntrainer {
 
@@ -170,9 +171,13 @@ public:
    * @param[in] training true if forwarding is on training
    * @retval output tensors
    */
-  sharedConstTensors forwarding(bool training = false,
-                                std::function<bool(void *userdata)> stop_cb =
-                                  [](void *user_data) { return false; });
+  sharedConstTensors
+  forwarding(ml::train::RunStats &stat, bool training = false,
+             std::function<bool(void *userdata)> stop_cb =
+               [](void *user_data) { return false; },
+             ml::train::StopCallbackCheckpointType stop_cb_checkpoint =
+               ml::train::StopCallbackCheckpointType::NONE,
+             void *user_data = nullptr);
 
   /**
    * @brief     backwarding the network graph
@@ -181,12 +186,14 @@ public:
    * @param[in] apply_grad_clip_op operation for applying the clip gradients
    */
   void backwarding(
-    int iteration,
+    int iteration, ml::train::RunStats &stat,
     std::function<void(std::shared_ptr<LayerNode>, int)> &backwarding_op,
     std::function<void(Weight &, int)> &apply_grad_clip_op,
-    std::function<bool(void *userdata)> stop_cb = [](void *user_data) {
-      return false;
-    }) const;
+    std::function<bool(void *userdata)> stop_cb =
+      [](void *user_data) { return false; },
+    ml::train::StopCallbackCheckpointType stop_cb_checkpoint =
+      ml::train::StopCallbackCheckpointType::NONE,
+    void *user_data = nullptr) const;
 
   /**
    * @brief     get begin iterator for the graph

--- a/nntrainer/models/model_common_properties.cpp
+++ b/nntrainer/models/model_common_properties.cpp
@@ -37,4 +37,9 @@ MemorySwapLookahead::MemorySwapLookahead(const unsigned int &value) {
   set(value);
 }
 
+StopCallbackCheckpoint::StopCallbackCheckpoint(
+  StopCallbackCheckpointInfo::Enum value) {
+  set(value);
+};
+
 } // namespace nntrainer::props

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -14,6 +14,7 @@
 #define __MODEL_COMMON_PROPERTIES_H__
 
 #include <base_properties.h>
+#include <model.h>
 
 #ifdef __cplusplus
 namespace nntrainer::props {
@@ -177,6 +178,44 @@ public:
    * @param value value to set, defaults to current directory
    */
   MemorySwapLookahead(const unsigned int &value = 0);
+};
+
+/**
+ * @brief Enumeration of return attention weight
+ */
+struct StopCallbackCheckpointInfo {
+  using Enum = ml::train::StopCallbackCheckpointType;
+  static constexpr std::initializer_list<Enum> EnumList = {
+    Enum::NONE,
+    Enum::EVERY_FORWARDING_LAYER,
+    Enum::EVERY_BACKWARDING_LAYER,
+    Enum::END_OF_ITERATION,
+    Enum::END_OF_TRAIN_EPOCH,
+    Enum::END_OF_VALIDATION_EPOCH};
+
+  static constexpr const char *EnumStr[] = {"none",
+                                            "every_forwarding_layer",
+                                            "every_backwarding_layer",
+                                            "end_of_iteration",
+                                            "end_of_train_epoch",
+                                            "end_of_validation_epoch"};
+};
+
+/**
+ * @brief StopCallbackCheckpoint, return attention weight
+ */
+class StopCallbackCheckpoint : public EnumProperty<StopCallbackCheckpointInfo> {
+public:
+  static constexpr const char *key =
+    "stop_callback_checkpoint";         /**< unique key to access */
+  using prop_tag = enum_class_prop_tag; /**< property type */
+
+  /**
+   * @brief Construct a new StopCallbackCheckpoint object
+   *
+   */
+  StopCallbackCheckpoint(StopCallbackCheckpointInfo::Enum value =
+                           StopCallbackCheckpointInfo::Enum::NONE);
 };
 
 } // namespace nntrainer::props

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -67,22 +67,6 @@ using NetType = ml::train::ModelType;
 class DataBuffer;
 using DatasetType = ml::train::DatasetType;
 using DatasetModeType = ml::train::DatasetModeType;
-/**
- * @brief     Statistics from running or training a model
- */
-struct RunStats {
-  float accuracy;     /** accuracy of the model */
-  float loss;         /** loss of the model */
-  int num_iterations; /** number of iterations done on this stat */
-  unsigned int
-    num_correct_predictions; /** number of right sample on this run */
-
-  RunStats() :
-    accuracy(0),
-    loss(0),
-    num_iterations(0),
-    num_correct_predictions(0) {}
-};
 
 /**
  * @class   NeuralNetwork Class
@@ -551,6 +535,11 @@ public:
   void exports(const ml::train::ExportMethods &method,
                const std::string file_path) override;
 
+  /**
+   * @brief     Get run statistics
+   */
+  std::vector<ml::train::RunStats> getStatistics() override;
+
 private:
   using FlexiblePropTypes =
     std::tuple<props::Epochs, props::TrainingBatchSize, props::SavePath,
@@ -596,9 +585,9 @@ private:
 
   bool loadedFromConfig; /**< Check if config is loaded to prevent load twice */
 
-  RunStats validation; /** validation statistics of the model */
-  RunStats training;   /** training statistics of the model */
-  RunStats testing;    /** testing statistics of the model */
+  ml::train::RunStats validation; /** validation statistics of the model */
+  ml::train::RunStats training;   /** training statistics of the model */
+  ml::train::RunStats testing;    /** testing statistics of the model */
 
   AppContext app_context; /** Configurations bound to current app */
 

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -33,6 +33,7 @@
 
 #include <compiler_fwd.h>
 #include <ini_wrapper.h>
+#include <model.h>
 #include <neuralnet.h>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>

--- a/test/unittest/unittest_nntrainer_graph.cpp
+++ b/test/unittest/unittest_nntrainer_graph.cpp
@@ -104,7 +104,8 @@ TEST_P(nntrainerGraphTest, loadConfig) {
   nntrainer::Tensor input(batch, channel, height, width);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
-  NN.forwarding({MAKE_SHARED_TENSOR(input)});
+  ml::train::RunStats stat;
+  NN.forwarding(stat, {MAKE_SHARED_TENSOR(input)});
 
   nntrainer::Tensor output(batch, 1, 1, 10);
 
@@ -113,8 +114,9 @@ TEST_P(nntrainerGraphTest, loadConfig) {
   for (int i = 0; i < batch; ++i)
     output.setValue(i, 0, 0, 3, 1.0);
 
-  NN.forwarding({MAKE_SHARED_TENSOR(input)}, {MAKE_SHARED_TENSOR(output)});
-  NN.backwarding(1);
+  NN.forwarding(stat, {MAKE_SHARED_TENSOR(input)},
+                {MAKE_SHARED_TENSOR(output)});
+  NN.backwarding(1, stat);
 }
 
 static nntrainer::IniSection nw_base("model", "Type = NeuralNetwork | "


### PR DESCRIPTION
 - Since RunStats object is made after every epoch only the stop_cb after epoch can be use RunStats

 Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>