### PR TITLE
[Trivial] Fix svace and coverity issue @open sesame 02/21 14:35

### DIFF
--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -130,7 +130,7 @@ public:
   /**
    * @brief     Constructor of Manager
    */
-  Manager() : enable_optimizations(true) {}
+  Manager() : enable_optimizations(true), swap_lookahead(0) {}
 
   /**
    * @brief     Constructor of Manager

--- a/nntrainer/utils/profiler.h
+++ b/nntrainer/utils/profiler.h
@@ -107,6 +107,7 @@ public:
     time_item(item),
     alloc_current(cur),
     alloc_total(total),
+    cache_swap(false),
     event_str(str),
     duration(dur) {}
 


### PR DESCRIPTION
- add swap_lookahead to default constuctor of Manager
- add cache_swap to default constructor of ProfileEventData

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped