### PR TITLE
[NEURALNET] Refine forwarding operation @open sesame 03/03 16:35

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -344,19 +344,15 @@ void NetworkGraph::applyGradients(
   }
 }
 
-sharedConstTensors
-NetworkGraph::forwarding(bool training,
-                         std::function<bool(void *userdata)> stop_cb) {
+sharedConstTensors NetworkGraph::forwarding(
+  bool training,
+  std::function<void(std::shared_ptr<LayerNode>, bool)> forwarding_op,
+  std::function<bool(void *userdata)> stop_cb) {
   for (auto iter = cbegin(); iter != cend() && !stop_cb(nullptr); iter++) {
-    auto const &ln = *iter;
+    auto &ln = *iter;
+
     PROFILE_TIME_START(profile_keys.at(ln->getType()));
-    PROFILE_MEM_ANNOTATE("Forwarding for layer: " + ln->getName());
-
-    auto f = std::get<0>(ln->getExecutionOrder());
-    flushCacheExcept(f);
-
-    ln->forwarding(training);
-
+    forwarding_op(*iter, training);
     PROFILE_TIME_END(profile_keys.at(ln->getType()));
   }
 

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -170,9 +170,12 @@ public:
    * @param[in] training true if forwarding is on training
    * @retval output tensors
    */
-  sharedConstTensors forwarding(bool training = false,
-                                std::function<bool(void *userdata)> stop_cb =
-                                  [](void *user_data) { return false; });
+  sharedConstTensors forwarding(
+    bool training = false,
+    std::function<void(std::shared_ptr<LayerNode>, bool)> forwarding_op =
+      [](std::shared_ptr<LayerNode>, bool) {},
+    std::function<bool(void *userdata)> stop_cb =
+      [](void *user_data) { return false; });
 
   /**
    * @brief     backwarding the network graph


### PR DESCRIPTION
This patch refines forwading operation in neural network class.

The code depth is not matched for forward and backward operations. For backwarding operation, there is backwarding_op and it pasded to the graph, which can handle the operation.
To keep same depth for forwarding, this patch adds forwarding_op function, and passed to the graph class.

Releated Issue:
\#2108