### PR TITLE
[GitAction] Fix Labeler on review commented

### DIFF
--- a/.github/workflows/Upload.yml
+++ b/.github/workflows/Upload.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: review_count
         env:
-          PR_NUMBER: ${{ github.event.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           IS_CONTAIN: ${{ contains(github.event.pull_request.labels.*.name, 'Need Review') }}
         id: review_count
         run: |

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -36,8 +36,9 @@ jobs:
         run: unzip pr_number.zip
 
       - name: Remove label if approved review >= 3
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             let fs = require('fs');
             let issue_number = Number(fs.readFileSync('./pr_number'));
@@ -45,18 +46,18 @@ jobs:
             let is_contain = String(fs.readFileSync('./contain_bool')).trim();
 
             if ((review >= 3) && (is_contain==String("true"))) {
-            await github.issues.removeLabel({
+            await github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,
               name : "Need Review"
             })
             }
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Make label if approved review < 3
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             let fs = require('fs');
             let issue_number = Number(fs.readFileSync('./pr_number'));
@@ -64,11 +65,10 @@ jobs:
             let is_contain = String(fs.readFileSync('./contain_bool')).trim();
 
             if ((review < 3) && (is_contain==String("false"))) {
-            await github.issues.addLabels({
+            await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,
               labels: ["Need Review"]
             })
             }
-          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Problem
- on Review commented, Review Approved There is error on http api
- it can't call issue's number because event num only valid if it run's by pull request it self

For solve this problem
- change api ```github.event.number``` to ```github.event.pull_request.number```
- change script version and some trivial part