### PR TITLE
[ Dataset ] Add Directory Dataset Producer @open sesame 03/24 20:22

### DIFF
--- a/api/ccapi/include/dataset.h
+++ b/api/ccapi/include/dataset.h
@@ -40,6 +40,7 @@ typedef std::function<std::remove_pointer<ml_train_datagen_cb>::type>
 enum class DatasetType {
   GENERATOR, /** Dataset with generators */
   FILE,      /** Dataset with files */
+  DIR,       /** Dataset with directory */
   UNKNOWN    /** Unknown dataset type */
 };
 

--- a/nntrainer/dataset/dir_data_producers.cpp
+++ b/nntrainer/dataset/dir_data_producers.cpp
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2023 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   dir_data_producers.h
+ * @date   24 Feb 2023
+ * @brief  This file contains dir data producers, reading from the files in
+ * directory
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#include <dir_data_producers.h>
+#include <filesystem>
+
+#include <memory>
+#include <numeric>
+#include <random>
+#include <sys/stat.h>
+#include <vector>
+
+#include <common_properties.h>
+#include <nntrainer_error.h>
+#include <node_exporter.h>
+#include <util_func.h>
+
+/**
+ * @brief this function helps to read the image
+ * currently only bmp image is supported and extend the image type will be
+ * remain as TODO. ( BGR --> RGB )
+ * @param     path file path
+ * @param     inputs float data for image pixel
+ * @param     width width
+ * @param     height height
+ */
+static void readImage(const std::string path, float *input, uint width,
+                      uint height) {
+  FILE *f = fopen(path.c_str(), "rb");
+
+  if (f == nullptr)
+    throw std::invalid_argument("Cannot open file: " + path);
+
+  unsigned char info[54];
+  size_t result = fread(info, sizeof(unsigned char), 54, f);
+  NNTR_THROW_IF(result != 54, std::invalid_argument)
+    << "Cannot read bmp header";
+
+  uint w = *(int *)&info[18];
+  uint h = *(int *)&info[22];
+
+  size_t row_padded = (width * 3 + 3) & (~3);
+  unsigned char *data = new unsigned char[row_padded];
+
+  for (uint i = 0; i < height; i++) {
+    result = fread(data, sizeof(unsigned char), row_padded, f);
+    NNTR_THROW_IF(result != row_padded, std::invalid_argument)
+      << "Cannot read bmp pixel data";
+
+    for (uint j = 0; j < width; j++) {
+
+      input[height * i + j] = (float)data[j * 3 + 2];
+
+      input[(height * width) + height * i + j] = (float)data[j * 3 + 1];
+
+      input[(height * width) * 2 + height * i + j] = (float)data[j * 3];
+    }
+  }
+
+  delete[] data;
+  fclose(f);
+}
+
+namespace nntrainer {
+
+DirDataProducer::DirDataProducer() :
+  dir_data_props(new Props()),
+  num_class(0),
+  num_data_total(0) {}
+
+DirDataProducer::DirDataProducer(const std::string &dir_path) :
+  dir_data_props(new Props(props::DirPath(dir_path))),
+  num_class(0),
+  num_data_total(0) {}
+
+DirDataProducer::~DirDataProducer() {}
+
+const std::string DirDataProducer::getType() const {
+  return DirDataProducer::type;
+}
+
+bool DirDataProducer::isMultiThreadSafe() const {
+  /// @todo make this true, it is needed to test multiple worker scenario
+  return false;
+}
+
+void DirDataProducer::setProperty(const std::vector<std::string> &properties) {
+  auto left = loadProperties(properties, *dir_data_props);
+  NNTR_THROW_IF(!left.empty(), std::invalid_argument)
+    << "There are unparsed properties, size: " << left.size();
+}
+
+DataProducer::Generator
+DirDataProducer::finalize(const std::vector<TensorDim> &input_dims,
+                          const std::vector<TensorDim> &label_dims,
+                          void *user_data) {
+
+  auto dir_path = std::get<props::DirPath>(*dir_data_props).get();
+
+  for (const auto &entry : std::filesystem::directory_iterator(dir_path))
+    class_names.push_back(entry.path());
+
+  num_class = class_names.size();
+
+  size_t id = 0;
+  size_t num_data = 0;
+  for (auto c_name : class_names) {
+    num_data = 0;
+    std::filesystem::directory_iterator itr(c_name);
+    while (itr != std::filesystem::end(itr)) {
+      const std::filesystem::directory_entry &entry = *itr;
+      std::string p = std::filesystem::absolute(entry.path()).string();
+      if (p.compare(".") && p.compare("..")) {
+        num_data++;
+        data_list.push_back(std::make_pair(id, p));
+      }
+      itr++;
+    }
+
+    id++;
+    num_data_total += num_data;
+  }
+
+  /// @todo expand this to non onehot case
+  NNTR_THROW_IF(std::any_of(label_dims.begin(), label_dims.end(),
+                            [](const TensorDim &dim) {
+                              return dim.channel() != 1 || dim.height() != 1;
+                            }),
+                std::invalid_argument)
+    << "Label dimension containing channel or height not allowed";
+
+  auto sz = size(input_dims, label_dims);
+
+  NNTR_THROW_IF(sz == 0, std::invalid_argument)
+    << "size is zero, dataproducer does not provide anything";
+
+  return [sz, input_dims, this](unsigned int idx, std::vector<Tensor> &inputs,
+                                std::vector<Tensor> &labels) {
+    NNTR_THROW_IF(idx >= sz, std::range_error)
+      << "given index is out of bound, index: " << idx << " size: " << sz;
+
+    std::string file_name = data_list[idx].second;
+
+    readImage(file_name, inputs[0].getData(), input_dims[0].width(),
+              input_dims[0].height());
+
+    unsigned int c_id = data_list[idx].first;
+
+    std::memset(labels[0].getData(), 0.0, num_class * sizeof(float));
+
+    labels[0].getData()[c_id] = 1.0;
+
+    return idx == sz - 1;
+  };
+}
+
+unsigned int
+DirDataProducer::size(const std::vector<TensorDim> &input_dims,
+                      const std::vector<TensorDim> &label_dims) const {
+
+  return num_data_total;
+}
+
+} // namespace nntrainer

--- a/nntrainer/dataset/dir_data_producers.h
+++ b/nntrainer/dataset/dir_data_producers.h
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2023 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   dir_data_producers.h
+ * @date   24 Feb 2023
+ * @brief  This file contains dir data producers, reading from the files in
+ * directory
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+#ifndef __DIR_DATA_PRODUCER_H__
+#define __DIR_DATA_PRODUCER_H__
+
+#include <data_producer.h>
+
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace nntrainer {
+
+namespace props {
+class DirPath;
+}
+
+/**
+ * @brief DirDataProducer which generates a onehot vector as a label
+ *
+ */
+class DirDataProducer final : public DataProducer {
+public:
+  /**
+   * @brief Construct a new Dir Data Producer object
+   *
+   */
+  DirDataProducer();
+
+  /**
+   * @brief Construct a new Dir Data Producer object
+   *
+   */
+  DirDataProducer(const std::string &dir_path);
+
+  /**
+   * @brief Destroy the Dir Data Producer object
+   *
+   */
+  ~DirDataProducer();
+
+  inline static const std::string type = "dir";
+
+  /**
+   * @copydoc DataProducer::getType()
+   */
+  const std::string getType() const override;
+
+  /**
+   * @copydoc DataProducer::isMultiThreadSafe()
+   */
+  bool isMultiThreadSafe() const override;
+
+  /**
+   * @copydoc DataProducer::setProeprty(const std::vector<std::string>
+   * &properties)
+   */
+  void setProperty(const std::vector<std::string> &properties) override;
+
+  /**
+   * @copydoc DataProducer::finalize(const std::vector<TensorDim>, const
+   * std::vector<TensorDim>)
+   */
+  DataProducer::Generator finalize(const std::vector<TensorDim> &input_dims,
+                                   const std::vector<TensorDim> &label_dims,
+                                   void *user_data = nullptr) override;
+
+  /**
+   * @copydoc DataProducer::finalize_sample(const std::vector<TensorDim>, const
+   * std::vector<TensorDim>, void *)
+   */
+  unsigned int size(const std::vector<TensorDim> &input_dims,
+                    const std::vector<TensorDim> &label_dims) const override;
+
+private:
+  using Props = std::tuple<props::DirPath>;
+  std::unique_ptr<Props> dir_data_props;
+  unsigned int num_class;
+  size_t num_data_total;
+  std::vector<std::pair<unsigned int, std::string>> data_list;
+  std::vector<std::string> class_names;
+};
+
+} // namespace nntrainer
+
+#endif // __DIR_DATA_PRODUCER_H__

--- a/nntrainer/dataset/meson.build
+++ b/nntrainer/dataset/meson.build
@@ -5,7 +5,8 @@ dataset_sources = [
   'databuffer_factory.cpp',
   'random_data_producers.cpp',
   'func_data_producer.cpp',
-  'raw_file_data_producer.cpp'
+  'raw_file_data_producer.cpp',
+  'dir_data_producers.cpp',
 ]
 
 dataset_headers = [

--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -20,6 +20,7 @@
 
 #include <regex>
 #include <sstream>
+#include <sys/stat.h>
 #include <utility>
 #include <vector>
 
@@ -67,6 +68,13 @@ void FilePath::set(const std::string &v) {
 }
 
 std::ifstream::pos_type FilePath::file_size() { return cached_pos_size; }
+
+bool DirPath::isValid(const std::string &v) const {
+  struct stat dir;
+  return (stat(v.c_str(), &dir) == 0);
+}
+
+void DirPath::set(const std::string &v) { Property<std::string>::set(v); }
 
 ReturnSequences::ReturnSequences(bool value) { set(value); }
 

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -589,6 +589,42 @@ private:
 };
 
 /**
+ * @brief Props containing directory path value
+ *
+ */
+class DirPath : public Property<std::string> {
+public:
+  /**
+   * @brief Construct a new Dir Path object
+   */
+  DirPath() : Property<std::string>() {}
+
+  /**
+   * @brief Construct a new Dir Path object
+   *
+   * @param path path to set
+   */
+  DirPath(const std::string &path) { set(path); }
+  static constexpr const char *key = "dir_path"; /**< unique key to access */
+  using prop_tag = str_prop_tag;                 /**< property type */
+
+  /**
+   * @brief check if given value is valid
+   *
+   * @param v value to check
+   * @return bool true if valid
+   */
+  bool isValid(const std::string &v) const override;
+
+  /**
+   * @brief setter
+   *
+   * @param v value to set
+   */
+  void set(const std::string &v) override;
+};
+
+/**
  * @brief return sequence property, used to check
  * whether return only the last output. Return last output if true.
  *

--- a/tools/package_android.sh
+++ b/tools/package_android.sh
@@ -14,13 +14,15 @@ fi
 pushd $TARGET
 
 if [ ! -d builddir ]; then
-  #default value of openblas num threads is 1 for android
-  meson builddir -Dplatform=android -Dopenblas-num-threads=1
+    #default value of openblas num threads is 1 for android
+    #enable-tflite-interpreter=false is just temporally until ci system is stabel
+  meson builddir -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false
 else
   echo "warning: $TARGET/builddir has already been taken, this script tries to reconfigure and try building"
   pushd builddir
     #default value of openblas num threads is 1 for android
-    meson configure -Dplatform=android -Dopenblas-num-threads=1
+    #enable-tflite-interpreter=false is just temporally until ci system is stabel  
+    meson configure -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false
     meson --wipe
   popd
 fi


### PR DESCRIPTION
This pr includes directory dataset producer for bmp image only.

We can extend the type of image to jpg, png with the proper decoder and add a resizer according to requirements.

C API and unit test cases will be added later PRs.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped