### PR TITLE
[ Tensor ] allow to have inc 0 for broadcasting for raw computation

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -34,7 +34,7 @@ namespace nntrainer {
 
 static void saxpy_raw(const unsigned int N, const float alpha, const float *X,
                       const int incX, float *Y, const int incY) {
-  if (incX <= 0 or incY <= 0)
+  if (incX < 0 or incY < 0)
     throw std::invalid_argument(
       "Error: negative inc not supported without cblas");
   for (unsigned int i = 0; i < N; ++i)


### PR DESCRIPTION
This PR allows to have 0 for incX and incY in tensor raw compuation to enable broadcasting tensor operation.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped