### PR TITLE
[Layer] Support batch computation for l2norm layer

### DIFF
--- a/Applications/SimpleShot/task_runner.cpp
+++ b/Applications/SimpleShot/task_runner.cpp
@@ -149,8 +149,8 @@ std::unique_ptr<ml::train::Model> createModel(const std::string &backbone,
         "centering", {"name=center",
                       "feature_path=" + getFeatureFilePath(backbone, app_path),
                       "trainable=false"});
-      LayerHandle l2 =
-        ml::train::createLayer("l2norm", {"name=l2norm", "trainable=false"});
+      LayerHandle l2 = ml::train::createLayer(
+        "preprocess_l2norm", {"name=l2norm", "trainable=false"});
       v.push_back(centering);
       v.push_back(l2);
     } else {

--- a/nntrainer/layers/preprocess_l2norm_layer.cpp
+++ b/nntrainer/layers/preprocess_l2norm_layer.cpp
@@ -40,9 +40,14 @@ void PreprocessL2NormLayer::finalize(InitLayerContext &context) {
 void PreprocessL2NormLayer::forwarding(RunLayerContext &context,
                                        bool training) {
   auto &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
+
   auto &input_ = context.getInput(SINGLE_INOUT_IDX);
 
-  input_.multiply(1 / input_.l2norm(), hidden_);
+  for (uint b = 0; b < input_.batch(); ++b) {
+    auto input_slice = input_.getBatchSlice(b, 1);
+    auto hidden_slice = hidden_.getBatchSlice(b, 1);
+    input_slice.multiply(1 / input_slice.l2norm(), hidden_slice);
+  }
 }
 
 void PreprocessL2NormLayer::calcDerivative(RunLayerContext &context) {

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -34,6 +34,7 @@ static std::string lstm_base = "type = lstm";
 static std::string gru_base = "type = gru";
 static std::string pooling_base = "type = pooling2d | padding = 0,0";
 static std::string preprocess_flip_base = "type = preprocess_flip";
+static std::string preprocess_l2norm_base = "type = preprocess_l2norm";
 static std::string preprocess_translate_base = "type = preprocess_translate";
 static std::string mse_base = "type = mse";
 static std::string cross_base = "type = cross";
@@ -485,6 +486,19 @@ INI preprocess_translate(
     I("act_3") + softmax_base +"input_layers=outputlayer"
   }
 );
+
+INI preprocess_l2norm_validate(
+  "preprocess_l2norm_validate",
+  {
+    nn_base + "loss=cross | batch_size=3",
+    sgd_base + "learning_rate = 0.1",
+    I("input") + input_base + "input_shape=1:1:20",
+    I("preprocess_l2norm") + preprocess_l2norm_base + "input_layers=input",
+    I("outputlayer") + fc_base + "unit = 10" +"input_layers=preprocess_l2norm",
+    I("act_3") + softmax_base +"input_layers=outputlayer"
+  }
+);
+
 
 INI mnist_conv_cross_one_input = INI("mnist_conv_cross_one_input") + mnist_conv_cross + "model/batch_size=1";
 
@@ -989,6 +1003,8 @@ GTEST_PARAMETER_TEST(
       mkModelIniTc(preprocess_translate, "3:1:1:10", 10, ModelTestOption::NO_THROW_RUN),
   #endif
       mkModelIniTc(preprocess_flip_validate, "3:1:1:10", 10, ModelTestOption::NO_THROW_RUN),
+
+      mkModelIniTc(preprocess_l2norm_validate, "3:1:1:10", 10, ModelTestOption::NO_THROW_RUN),
 
       /**< Addition test */
       mkModelIniTc(addition_resnet_like, "3:1:1:10", 10, ModelTestOption::COMPARE), // Todo: Enable option to ALL


### PR DESCRIPTION
This PR enables the l2norm preprocessor layer to support batch computation.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped