### PR TITLE
[ TensorDim ] Add tensor format in TensorDim

### DIFF
--- a/api/ccapi/include/tensor_dim.h
+++ b/api/ccapi/include/tensor_dim.h
@@ -34,6 +34,11 @@ public:
   static constexpr const size_t MAXDIM = 4;
 
   /**
+   * @brief     Tensor Formant : Default is NCHW
+   */
+  enum class Format { NCHW, NHWC };
+
+  /**
    * @brief Get the Num Dim object
    *
    * @return unsigned int fixed value of MAXDIM
@@ -43,27 +48,32 @@ public:
   /**
    * @brief Construct a new Tensor Dim object
    *
+   * @param fm format NCHW | HNWC
    * @param eff_dim_flag_ effective dimension flag (1 means it's effective)
    * @param dyn_dim_flag_ dynamic dimension flag (1 means it's unspecified)
    */
-  explicit TensorDim(const std::bitset<MAXDIM> &eff_dim_flag_ = 0b1111,
+  explicit TensorDim(Format fm = Format::NCHW,
+                     const std::bitset<MAXDIM> &eff_dim_flag_ = 0b1111,
                      const std::bitset<MAXDIM> &dyn_dim_flag_ = 0b0000);
 
   /**
    * @brief Construct a new Tensor Dim object
    *
    * @param dims std::initialize_list
+   * @param fm format NCHW | HNWC
    *
-   * formats of {w}, {h, w}, {c, h, w}, {b, c, h, w} are accepted
+   * formats of {w}, {h, w}, {c, h, w}, {b, c, h, w} for the NCHW are accepted
+   * formats of {c}, {w, c}, {h, w, c}, {b, h, w, c} for the NHWC are accepted
    */
-  TensorDim(std::initializer_list<size_t> dims);
+  TensorDim(std::initializer_list<size_t> dims, Format fm = Format::NCHW);
 
   /**
    * @brief Construct a new Tensor Dim object without batch dimension
    *
    * @param shapes shapes without batch dimension
+   * @param fm format NCHW | HNWC
    */
-  TensorDim(const std::array<size_t, 3> &shapes);
+  TensorDim(const std::array<size_t, 3> &shapes, Format fm = Format::NCHW);
 
   /**
    * @brief Construct a new Tensor Dim object
@@ -72,10 +82,11 @@ public:
    * @param c channel
    * @param h height
    * @param w width
+   * @param fm format NCHW | HNWC
    * @param eff_dim_flag_ dimension bit flag to calculate the dynamic
    * dimension, rightmost is width
    */
-  TensorDim(size_t b, size_t c, size_t h, size_t w,
+  TensorDim(size_t b, size_t c, size_t h, size_t w, Format fm = Format::NCHW,
             const std::bitset<MAXDIM> &eff_dim_flag_ = 0b1111,
             const std::bitset<MAXDIM> &dyn_dim_flag_ = 0b0000);
 
@@ -89,9 +100,10 @@ public:
   /**
    * @brief Construct a new Tensor Dim object
    *
-   * @param shape shape of format N:C:H:W
+   * @param shape shape of format
+   * @param fm format NCHW | HNWC
    */
-  TensorDim(const std::string &shape);
+  TensorDim(const std::string &shape, Format fm = Format::NCHW);
 
   /**
    * @brief Destroy the Tensor Dim object
@@ -275,10 +287,11 @@ public:
   /**
    * @brief Set the Tensor Dim object
    *
-   * @param input_shape input_shape of format `N:C:H:W`
+   * @param input_shape input_shape
+   * @param fm NCHW | NHWC
    * @return int ML_ERROR_NONE if successs
    */
-  int setTensorDim(const std::string &input_shape);
+  int setTensorDim(const std::string &input_shape, Format fm = Format::NCHW);
 
   /**
    * @brief copy assign a dimension
@@ -366,12 +379,26 @@ public:
    */
   bool is_dynamic() const;
 
+  /**
+   * @brief getFormat
+   *
+   */
+  TensorDim::Format getFormat() const { return format; };
+
+  /**
+   * @brief setFormat
+   *
+   */
+  void setFormat(TensorDim::Format fm) { format = fm; };
+
 private:
   /**
    * @brief reset length
    *
    */
   void resetLen();
+
+  Format format;
 
   std::bitset<MAXDIM> eff_dim_flag; /**< dimension bit flag to define effective
           dimension size */

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -73,8 +73,11 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
   context.setOutputDimensions(output_dims);
 
   /** set weight specifications */
-  TensorDim bias_dim(1, 1, 1, unit, 0b0001);
-  TensorDim weight_dim(1, 1, in_dim.width(), unit, 0b0011);
+  // @todo : This NCHW format setting is just temporal, it needs to be set by
+  // global configuration
+  TensorDim bias_dim(1, 1, 1, unit, ml::train::TensorDim::Format::NCHW, 0b0001);
+  TensorDim weight_dim(1, 1, in_dim.width(), unit,
+                       ml::train::TensorDim::Format::NCHW, 0b0011);
 
   weight_idx[FCParams::weight] = context.requestWeight(
     weight_dim, weight_initializer, weight_regularizer,

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -158,7 +158,8 @@ void Exporter::saveTflResult(
     new_weights.push_back(filter);
 
     auto &bias_weight = *old_weights[1];
-    TensorDim bias_dim{std::bitset<4>(0b0001)};
+    TensorDim bias_dim{ml::train::TensorDim::Format::NCHW,
+                       std::bitset<4>(0b0001)};
     bias_dim.setTensorDim(
       3 /** index **/,
       bias_weight
@@ -201,7 +202,10 @@ void Exporter::saveTflResult(
     new_inputs.reserve(inputs.size() + 1 /** perm **/);
     new_inputs.push_back(*inputs[0]);
     // create "perm" tensor for Transpose operator
-    TensorDim perm_dim{std::bitset<4>(0b0001)};
+    // @todo : This NCHW format setting is just temporal, it needs to be set by
+    //  global configuration
+    TensorDim perm_dim{ml::train::TensorDim::Format::NCHW,
+                       std::bitset<4>(0b0001)};
     perm_dim.setTensorDim(3 /** index **/,
                           4 /** value **/); // effective dimension = {4}
     new_inputs.emplace_back(perm_dim);


### PR DESCRIPTION
In order to support Channel Last & Channel First at the same time, we need to define the Tensor Format in TensorDim Class.

According to the format of tensorDim, it return proper value for the APIs such as bacch(), channel(), height() and width().

The default format is Channel First as it is now.

If nothing is provided when a Tensor is constructured, then it is set NCHW.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped