### PR TITLE
[GitAction] Fix Duplicate Approvals @open sesame 04/03 14:45

### DIFF
--- a/.github/workflows/Upload.yml
+++ b/.github/workflows/Upload.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           review=$(curl -s -H "Accept: application/vnd.github.black-cat-preview+json" \
           https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
-          | jq '[ .[] | select(.state=="APPROVED") ] | length')
+          | jq '[ .[] | select(.state=="APPROVED") | .user.login ] | unique | length')
           echo "Number of approved review_count: $review"
           echo "CONTAIN=$IS_CONTAIN"
 


### PR DESCRIPTION
## In this PR
Fix Duplicate Approval
- now git action count all approval
- For example someone Approve PR --> Update PR --> Approve Again then they count 2
- For example CI Approve PR every time they success then gitaction count them all

## Workflow
The given Git Action code performs the following tasks
1. Uses the curl command to call the GitHub REST API and retrieve a list of reviews for the given pull request in the repository.
2. Uses the jq command to filter the reviews based on whether their state is "APPROVED".
3. Extracts the login names of the users who wrote each of the filtered reviews.
4. Uses the unique function to filter out only the unique login names, removing any duplicates.
5. Calculates the length of the resulting list of unique login names, giving the count of unique users who have approved the pull request.

**Therefore, this code removes any duplicate approvals, counting each unique user only once, even if they have approved more than once.**