### PR TITLE
[AHub] Fix AHub Defect

### DIFF
--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -430,8 +430,10 @@ TEST(nntrainer_ccapi, save_ini_p) {
   EXPECT_EQ(model->initialize(), ML_ERROR_NONE);
   auto saved_ini_name = s.getIniName() + "_saved";
   if (remove(saved_ini_name.c_str())) {
-    std::cerr << "remove ini " << saved_ini_name
-              << "failed, reason: " << strerror(errno);
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
+    std::cerr << "remove ini " << saved_ini_name << "failed, reason: "
+              << strerror_r(errno, error_buf, error_buflen);
   }
 
   model->save(saved_ini_name, ml::train::ModelFormat::MODEL_FORMAT_INI);

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -110,7 +110,11 @@ TEST_P(nntrainerInterpreterTest, graphSerializeAfterDeserialize) {
 
   graphEqual(g, new_g);
 
-  EXPECT_EQ(remove(out_file_path.c_str()), 0) << strerror(errno);
+  const size_t error_buflen = 100;
+  char error_buf[error_buflen];
+
+  EXPECT_EQ(remove(out_file_path.c_str()), 0)
+    << strerror_r(errno, error_buf, error_buflen);
 }
 
 TEST_P(nntrainerInterpreterTest, deserialize_01_n) {
@@ -196,9 +200,12 @@ TEST(nntrainerInterpreterTflite, simple_fc) {
   EXPECT_EQ(out, ans);
 
   if (remove("test.tflite")) {
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
     std::cerr << "remove ini "
               << "test.tflite"
-              << "failed, reason: " << strerror(errno);
+              << "failed, reason: "
+              << strerror_r(errno, error_buf, error_buflen);
   }
 }
 
@@ -272,9 +279,12 @@ TEST(nntrainerInterpreterTflite, part_of_resnet_0) {
   EXPECT_EQ(out, ans);
 
   if (remove("part_of_resnet.tflite")) {
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
     std::cerr << "remove ini "
               << "part_of_resnet.tflite"
-              << "failed, reason: " << strerror(errno);
+              << "failed, reason: "
+              << strerror_r(errno, error_buf, error_buflen);
   }
 }
 
@@ -405,9 +415,12 @@ TEST(nntrainerInterpreterTflite, simple_flatten) {
   EXPECT_EQ(out, ans);
 
   if (remove("FC_weight_test.tflite")) {
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
     std::cerr << "remove ini "
               << "FC_weight_test.tflite"
-              << "failed, reason: " << strerror(errno);
+              << "failed, reason: "
+              << strerror_r(errno, error_buf, error_buflen);
   }
 }
 
@@ -516,9 +529,12 @@ TEST(nntrainerInterpreterTflite, simple_flatten2) {
   EXPECT_EQ(out, ans);
 
   if (remove("FC_weight_test2.tflite")) {
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
     std::cerr << "remove ini "
               << "FC_weight_test2.tflite"
-              << "failed, reason: " << strerror(errno);
+              << "failed, reason: "
+              << strerror_r(errno, error_buf, error_buflen);
   }
 }
 
@@ -628,9 +644,12 @@ TEST(nntrainerInterpreterTflite, simple_flatten3) {
   EXPECT_EQ(out, ans);
 
   if (remove("FC_weight_test3.tflite")) {
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
     std::cerr << "remove ini "
               << "FC_weight_test3.tflite"
-              << "failed, reason: " << strerror(errno);
+              << "failed, reason: "
+              << strerror_r(errno, error_buf, error_buflen);
   }
 }
 
@@ -714,8 +733,11 @@ TEST(nntrainerInterpreterTflite, flatten_test) {
   EXPECT_EQ(out, ans);
 
   if (remove("flatten_test.tflite")) {
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
     std::cerr << "remove ini "
               << "flatten_test.tflite"
-              << "failed, reason: " << strerror(errno);
+              << "failed, reason: "
+              << strerror_r(errno, error_buf, error_buflen);
   }
 }

--- a/test/unittest/models/models_golden_test.cpp
+++ b/test/unittest/models/models_golden_test.cpp
@@ -110,8 +110,10 @@ TEST_P(nntrainerModelTest, model_test_save_load_compare) {
       new nntrainer::NeuralNetwork());
     nn->load(saved_ini_name, ml::train::ModelFormat::MODEL_FORMAT_INI);
     if (remove(saved_ini_name.c_str())) {
-      std::cerr << "remove ini " << saved_ini_name
-                << "failed, reason: " << strerror(errno);
+      const size_t error_buflen = 100;
+      char error_buf[error_buflen];
+      std::cerr << "remove ini " << saved_ini_name << "failed, reason: "
+                << strerror_r(errno, error_buf, error_buflen);
     }
     return nn;
   };
@@ -140,8 +142,10 @@ TEST_P(nntrainerModelTest, model_test_save_load_verify) {
       new nntrainer::NeuralNetwork());
     nn->load(saved_ini_name, ml::train::ModelFormat::MODEL_FORMAT_INI);
     if (remove(saved_ini_name.c_str())) {
-      std::cerr << "remove ini " << saved_ini_name
-                << "failed, reason: " << strerror(errno);
+      const size_t error_buflen = 100;
+      char error_buf[error_buflen];
+      std::cerr << "remove ini " << saved_ini_name << "failed, reason: "
+                << strerror_r(errno, error_buf, error_buflen);
     }
     return nn;
   };


### PR DESCRIPTION
## In this PR

Fix Ahub Defect
- change ```stderror``` to ```stderror_r```
- stderror makes no guaranteee of thread safety

## Changed File

```nntrainer/test/ccapi/unittest_ccapi.cpp```
```nntrainer/unittest/compiler/unittest_interpreter.cpp```
```nntrainer/unittest/models/models_golden_test.cpp```
