### PR TITLE
[Wait for #2166] [ Tensor ] Support NHWC for multiply and divide  @open sesame 04/07 20:08

### DIFF
--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -147,23 +147,25 @@ public:
    * @brief     Constructor of Tensor
    * @param[in] d data for the Tensor
    */
-  Tensor(std::vector<std::vector<std::vector<std::vector<float>>>> const &d);
+  Tensor(std::vector<std::vector<std::vector<std::vector<float>>>> const &d,
+         Tformat fm = Tformat::NCHW);
 
   /**
    * @brief     Constructor of Tensor
    * @note      This constructor copies vector again. needs refactoring
    * @param[in] d data for the Tensor
    */
-  Tensor(std::vector<std::vector<std::vector<float>>> const &d) :
-    Tensor(std::vector<std::decay<decltype(d)>::type>{d}){};
+  Tensor(std::vector<std::vector<std::vector<float>>> const &d,
+         Tformat fm = Tformat::NCHW) :
+    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, fm){};
 
   /**
    * @brief     Constructor of Tensor
    * @note      This constructor copies vector again. needs refactoring
    * @param[in] d data for the Tensor with batch size one
    */
-  Tensor(std::vector<std::vector<float>> const &d) :
-    Tensor(std::vector<std::decay<decltype(d)>::type>{d}){};
+  Tensor(std::vector<std::vector<float>> const &d, Tformat fm = Tformat::NCHW) :
+    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, fm){};
 
   /**
    *  @brief  Copy constructor of Tensor.

--- a/nntrainer/tensor/tensor_dim.cpp
+++ b/nntrainer/tensor/tensor_dim.cpp
@@ -303,8 +303,8 @@ std::vector<int> TensorDim::getEffectiveDimension(bool dynamic) const {
 bool TensorDim::is_dynamic() const { return dyn_dim_flag.any(); }
 
 std::ostream &operator<<(std::ostream &out, TensorDim const &d) {
-  out << "Shape: " << d.batch() << ":" << d.channel() << ":" << d.height()
-      << ":" << d.width() << std::endl;
+  out << "Shape: " << d[0] << ":" << d[1] << ":" << d[2] << ":" << d[3]
+      << std::endl;
   return out;
 }
 

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -102,6 +102,20 @@ private:
   nntrainer::IniWrapper ini;
 };
 
+#define GEN_TEST_INPUT_NHWC(input, eqation_i_j_k_l) \
+  do {                                              \
+    for (int i = 0; i < batch; ++i) {               \
+      for (int j = 0; j < height; ++j) {            \
+        for (int k = 0; k < width; ++k) {           \
+          for (int l = 0; l < channel; ++l) {       \
+            float val = eqation_i_j_k_l;            \
+            input.setValue(i, j, k, l, val);        \
+          }                                         \
+        }                                           \
+      }                                             \
+    }                                               \
+  } while (0)
+
 #define GEN_TEST_INPUT(input, eqation_i_j_k_l) \
   do {                                         \
     for (int i = 0; i < batch; ++i) {          \


### PR DESCRIPTION
This PR includes changes of Tensor and TensorDim to support NHWC
computation for multiply and divide. It also includes unittests to
evaluate.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>