### PR TITLE
[NNStreamer] Remove rank check temporary @open sesame 04/07 10:02

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -37,8 +37,9 @@ override_dh_auto_configure:
 		--includedir=include -Dinstall-app=true \
 		-Dreduce-tolerance=$(ENABLE_REDUCE_TOLERANCE) \
 		-Denable-debug=$(ENABLE_DEBUG) \
-		-Dml-api-support=enabled -Denable-nnstreamer-tensor-filter=enabled \
-				-Denable-nnstreamer-tensor-trainer=enabled \
+		-Dml-api-support=enabled \
+		-Denable-nnstreamer-tensor-filter=enabled \
+		-Denable-nnstreamer-tensor-trainer=enabled \
                 -Denable-nnstreamer-backbone=true \
                 -Dcapi-ml-common-actual=capi-ml-common \
                 -Dcapi-ml-inference-actual=capi-ml-inference \

--- a/meson.build
+++ b/meson.build
@@ -369,6 +369,7 @@ endif
 
 if get_option('platform') != 'android'
   nnstreamer_dep = dependency('nnstreamer')
+  message('building nnstreamer')
   subdir('nnstreamer')
 else
   warning('android nnstreamer-filter and nnstreamer-trainer are not yet supported, building them is skipped')

--- a/nnstreamer/meson.build
+++ b/nnstreamer/meson.build
@@ -1,4 +1,5 @@
 if get_option('enable-nnstreamer-tensor-filter').enabled()
+  message('building nstreamer tensor_filter')
   subdir('tensor_filter')
 endif
 if get_option('enable-nnstreamer-tensor-trainer').enabled()

--- a/nntrainer/layers/nnstreamer_layer.cpp
+++ b/nntrainer/layers/nnstreamer_layer.cpp
@@ -81,12 +81,15 @@ static int nnst_info_to_tensor_dim(ml_tensors_info_h &out_res, TensorDim &dim) {
   if (type != ML_TENSOR_TYPE_FLOAT32)
     return ML_ERROR_NOT_SUPPORTED;
 
-  if (ML_TENSOR_RANK_LIMIT > ml::train::TensorDim::MAXDIM)
-    return ML_ERROR_NOT_SUPPORTED;
-
   status = ml_tensors_info_get_tensor_dimension(out_res, 0, dim_);
   if (status != ML_ERROR_NONE)
     return status;
+
+  if (ML_TENSOR_RANK_LIMIT > ml::train::TensorDim::MAXDIM) {
+    for (uint i = ml::train::TensorDim::MAXDIM; i < ML_TENSOR_RANK_LIMIT; i++)
+      if (dim_[i] > 1)
+        return ML_ERROR_NOT_SUPPORTED;
+  }
 
   for (size_t i = 0; i < ml::train::TensorDim::MAXDIM; i++)
     dim.setTensorDim(i, dim_[i]);


### PR DESCRIPTION
There was a changes in nnstreamer to extend max rank limit to 16. So we need to remove rank limit check until they give current rank.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped