### PR TITLE
[Debian] Fix the debian package dependency @open sesame 04/07 20:08

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Description: Training Neural Network Models on Devices.
 Package: nntrainer-dev
 Architecture: any
 Multi-Arch: same
-Depends: nntrainer
+Depends: nntrainer, ccapi-ml-training-dev, capi-ml-training-dev
 Description: NNtrainer development package
  This is development package for nntrainer.
 


### PR DESCRIPTION
nntrainer-dev depends on ccapi-ml-training-dev and capi-ml-training-dev.
This PR add these dependency for nntrainer-dev

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped