### PR TITLE
[capi] add learning rate scheduler related api

### DIFF
--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -393,6 +393,12 @@ int ml_train_optimizer_destroy(ml_train_optimizer_h optimizer);
  * @retval #ML_ERROR_NONE Successful.
  * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ * @note For now the properties for Exponential learning rate
+ * scheduler(decay_rate, decay_steps) can be set using
+ * ml_train_optimizer_set_property for backward compatibility. But
+ * ml_train_optimizer_set_property will not support to set decay_rate,
+ * decay_steps properties from tizen 8.0. Use ml_train_lr_scheduler_set_property
+ * instead.
  */
 int ml_train_optimizer_set_property(ml_train_optimizer_h optimizer, ...);
 

--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -52,25 +52,31 @@ extern "C" {
  */
 
 /**
- * @brief A handle of an NNTrainer model.
+ * @brief A handle of a NNTrainer model.
  * @since_tizen 6.0
  */
 typedef void *ml_train_model_h;
 
 /**
- * @brief A handle of an NNTrainer layer.
+ * @brief A handle of a NNTrainer layer.
  * @since_tizen 6.0
  */
 typedef void *ml_train_layer_h;
 
 /**
- * @brief A handle of an NNTrainer optimizer.
+ * @brief A handle of a NNTrainer optimizer.
  * @since_tizen 6.0
  */
 typedef void *ml_train_optimizer_h;
 
 /**
- * @brief A handle of an NNTrainer dataset.
+ * @brief A handle of a NNTrainer learning rate scheduler.
+ * @since_tizen 7.5
+ */
+typedef void *ml_train_lr_scheduler_h;
+
+/**
+ * @brief A handle of a NNTrainer dataset.
  * @since_tizen 6.0
  */
 typedef void *ml_train_dataset_h;
@@ -389,6 +395,71 @@ int ml_train_optimizer_destroy(ml_train_optimizer_h optimizer);
  * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
  */
 int ml_train_optimizer_set_property(ml_train_optimizer_h optimizer, ...);
+
+/**
+ * @brief Sets the learning rate scheduler for the optimizer.
+ * @details Use this function to set learning rate scheduler. This transfers
+ * the ownership of the scheduler to the optimizer. No need to destroy the
+ * optimizer if it is to a model.
+ * @since_tizen 7.5
+ * @remarks Unsets the previously set lr_scheduler, if any. The previously set
+ * lr_scheduler must be freed using ml_train_lr_scheduler_destroy().
+ * @param[in] optimizer The NNTrainer optimizer handle.
+ * @param[in] lr_scheduler The NNTrainer lr scheduler handle.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ */
+int ml_train_optimizer_set_lr_scheduler(ml_train_optimizer_h optimizer,
+                                        ml_train_lr_scheduler_h lr_scheduler);
+
+/**
+ * @brief Creates a learning rate scheduler for optimizer.
+ * @details Use this function to create learning rate scheduler for optimizer.
+ * If not set to a optimizer, @a lr_sheduler should be released using
+ * ml_train_lr_scheduler_destroy(). If set to a optimizer, @a lr_scheduler is
+ * available until optimizer is released.
+ * @since_tizen 7.5
+ * @remarks If the function succeeds, @a lr_scheduler must be released using
+ * ml_train_lr_scheduler_destroy(), if not set to a optimizer. If set to a
+ * optimizer, @a lr_scheduler is available until the optimizer is released.
+ * @param[out] lr_scheduler The NNTrainer learning rate scheduler handle.
+ * @param[in] type The NNTrainer learning rate scheduler type.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ */
+int ml_train_lr_scheduler_create(ml_train_lr_scheduler_h *lr_scheduler,
+                                 ml_train_lr_scheduler_type_e type);
+
+/**
+ * @brief Frees the learning rate scheduler.
+ * @details Use this function to destroy learning rate scheduler. Fails if
+ * learning rate scheduler is owned by a optimizer.
+ * @since_tizen 7.5
+ * @param[in] lr_scheduler The NNTrainer learning rate scheduler handle.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ */
+int ml_train_lr_scheduler_destroy(ml_train_lr_scheduler_h lr_scheduler);
+
+/**
+ * @brief Sets the learning rate scheduler property.
+ * @details Use this function to set learning rate scheduler property.
+ * @since_tizen 7.5
+ * @param[in] lr_scheduler The NNTrainer learning rate scheduler handle.
+ * @param[in]  ... Property values with NULL for termination.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Invalid parameter.
+ */
+int ml_train_lr_scheduler_set_property(ml_train_lr_scheduler_h lr_scheduler,
+                                       ...);
 
 /**
  * @deprecated Deprecated since 6.5. Use ml_train_dataset_create() instead.

--- a/api/ccapi/include/optimizer.h
+++ b/api/ccapi/include/optimizer.h
@@ -138,9 +138,9 @@ SGD(const std::vector<std::string> &properties = {}) {
 } // namespace optimizer
 
 /**
- * @brief     Enumeration of learning type
+ * @brief     Enumeration of learning rate scheduler type
  */
-enum LearningRateType {
+enum LearningRateSchedulerType {
   CONSTANT = 0, /**< constant */
   EXPONENTIAL,  /**< exponentially decay */
   STEP          /**< step wise decay */
@@ -194,7 +194,7 @@ public:
  * @brief Factory creator with constructor for learning rate scheduler type
  */
 std::unique_ptr<ml::train::LearningRateScheduler>
-createLearningRateScheduler(const LearningRateType &type,
+createLearningRateScheduler(const LearningRateSchedulerType &type,
                             const std::vector<std::string> &properties = {});
 
 /**
@@ -228,7 +228,8 @@ namespace learning_rate {
  */
 inline std::unique_ptr<LearningRateScheduler>
 Constant(const std::vector<std::string> &properties = {}) {
-  return createLearningRateScheduler(LearningRateType::CONSTANT, properties);
+  return createLearningRateScheduler(LearningRateSchedulerType::CONSTANT,
+                                     properties);
 }
 
 /**
@@ -236,7 +237,8 @@ Constant(const std::vector<std::string> &properties = {}) {
  */
 inline std::unique_ptr<LearningRateScheduler>
 Exponential(const std::vector<std::string> &properties = {}) {
-  return createLearningRateScheduler(LearningRateType::EXPONENTIAL, properties);
+  return createLearningRateScheduler(LearningRateSchedulerType::EXPONENTIAL,
+                                     properties);
 }
 
 /**
@@ -244,7 +246,8 @@ Exponential(const std::vector<std::string> &properties = {}) {
  */
 inline std::unique_ptr<LearningRateScheduler>
 Step(const std::vector<std::string> &properties = {}) {
-  return createLearningRateScheduler(LearningRateType::STEP, properties);
+  return createLearningRateScheduler(LearningRateSchedulerType::STEP,
+                                     properties);
 }
 
 } // namespace learning_rate

--- a/api/ccapi/include/optimizer.h
+++ b/api/ccapi/include/optimizer.h
@@ -141,9 +141,10 @@ SGD(const std::vector<std::string> &properties = {}) {
  * @brief     Enumeration of learning rate scheduler type
  */
 enum LearningRateSchedulerType {
-  CONSTANT = 0, /**< constant */
-  EXPONENTIAL,  /**< exponentially decay */
-  STEP          /**< step wise decay */
+  CONSTANT = ML_TRAIN_LR_SCHEDULER_TYPE_CONSTANT, /**< constant */
+  EXPONENTIAL =
+    ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL, /**< exponentially decay */
+  STEP = ML_TRAIN_LR_SCHEDULER_TYPE_STEP    /**< step wise decay */
 };
 
 /**

--- a/api/ccapi/include/optimizer.h
+++ b/api/ccapi/include/optimizer.h
@@ -83,8 +83,8 @@ public:
    *
    * @param lrs the learning rate scheduler object
    */
-  virtual void setLearningRateScheduler(
-    std::unique_ptr<ml::train::LearningRateScheduler> &&lrs) = 0;
+  virtual int setLearningRateScheduler(
+    std::shared_ptr<ml::train::LearningRateScheduler> lrs) = 0;
 };
 
 /**

--- a/api/ccapi/src/factory.cpp
+++ b/api/ccapi/src/factory.cpp
@@ -122,7 +122,7 @@ createDataset(DatasetType type, datagen_cb cb, void *user_data,
  * @brief Factory creator with constructor for learning rate scheduler type
  */
 std::unique_ptr<ml::train::LearningRateScheduler>
-createLearningRateScheduler(const LearningRateType &type,
+createLearningRateScheduler(const LearningRateSchedulerType &type,
                             const std::vector<std::string> &properties) {
   auto &ac = nntrainer::AppContext::Global();
   return ac.createObject<ml::train::LearningRateScheduler>(type, properties);

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -88,6 +88,17 @@ typedef enum {
 } ml_train_optimizer_type_e;
 
 /**
+ * @brief Enumeration for the learning rate scheduler type of NNTrainer.
+ * @since_tizen 7.5
+ */
+typedef enum {
+  ML_TRAIN_LR_SCHEDULER_TYPE_CONSTANT = 0,    /**< Constant lr scheduler */
+  ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL = 1, /**< Exponentially lr scheduler */
+  ML_TRAIN_LR_SCHEDULER_TYPE_STEP = 2,        /**< Step lr scheduler */
+  ML_TRAIN_LR_SCHEDULER_TYPE_UNKNOWN = 999    /**< Unknown lr scheduler */
+} ml_train_lr_scheduler_type_e;
+
+/**
  * @brief Dataset generator callback function for train/valid/test data.
  *
  * @details The user of the API must provide this callback function to supply

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -230,7 +230,7 @@ static void add_default_object(AppContext &ac) {
   ac.registerFactory(AppContext::unknownFactory<nntrainer::Optimizer>,
                      "unknown", OptType::UNKNOWN);
 
-  using LRType = LearningRateType;
+  using LRType = LearningRateSchedulerType;
   ac.registerFactory(
     ml::train::createLearningRateScheduler<ConstantLearningRateScheduler>,
     ConstantLearningRateScheduler::type, LRType::CONSTANT);

--- a/nntrainer/optimizers/lr_scheduler.h
+++ b/nntrainer/optimizers/lr_scheduler.h
@@ -26,7 +26,7 @@ class Exporter;
 /**
  * @brief     Enumeration of optimizer type
  */
-enum LearningRateType {
+enum LearningRateSchedulerType {
   CONSTANT = 0, /**< constant */
   EXPONENTIAL,  /**< exponentially decay */
   STEP          /**< step wise decay */

--- a/nntrainer/optimizers/optimizer_wrapped.cpp
+++ b/nntrainer/optimizers/optimizer_wrapped.cpp
@@ -16,6 +16,7 @@
 #include <common_properties.h>
 #include <lr_scheduler_constant.h>
 #include <lr_scheduler_exponential.h>
+#include <nntrainer_log.h>
 #include <node_exporter.h>
 #include <optimizer_wrapped.h>
 
@@ -99,6 +100,9 @@ void OptimizerWrapped::finalize() {
   /** if lr_sched not set, make lr_sched from properties */
   if (!lr_sched) {
     if (!props_empty) {
+      ml_logw(
+        "Either decay_rate or decay_steps properties are set in optimizer. "
+        "Please set these properties in learning rate scheduler");
       lr_sched = std::make_unique<ExponentialLearningRateScheduler>();
       if (!props_dr.empty())
         lr_sched->setProperty({"decay_rate=" + std::to_string(props_dr.get())});
@@ -109,6 +113,9 @@ void OptimizerWrapped::finalize() {
       lr_sched = std::make_unique<ConstantLearningRateScheduler>();
     }
     lr_sched->setProperty({"learning_rate=" + std::to_string(props_lr.get())});
+  } else if (lr_sched && !props_lr.empty()) {
+    ml_logw("Learning rate property is set in both optimizer and learning rate "
+            "scheduler. The value which is set in Optimizer will be ignored.");
   }
 
   lr_sched->finalize();

--- a/nntrainer/optimizers/optimizer_wrapped.cpp
+++ b/nntrainer/optimizers/optimizer_wrapped.cpp
@@ -124,11 +124,11 @@ OptimizerWrapped::getOptimizerVariableDim(const TensorDim &dim) {
   return optimizer->getOptimizerVariableDim(dim);
 }
 
-void OptimizerWrapped::setLearningRateScheduler(
-  std::unique_ptr<ml::train::LearningRateScheduler> &&lrs) {
-  nntrainer::LearningRateScheduler *ptr =
-    static_cast<nntrainer::LearningRateScheduler *>(lrs.release());
-  lr_sched = std::unique_ptr<nntrainer::LearningRateScheduler>(ptr);
+int OptimizerWrapped::setLearningRateScheduler(
+  std::shared_ptr<ml::train::LearningRateScheduler> lrs) {
+  lr_sched = std::static_pointer_cast<nntrainer::LearningRateScheduler>(lrs);
+
+  return ML_ERROR_NONE;
 }
 
 nntrainer::LearningRateScheduler *OptimizerWrapped::getLearningRateScheduler() {

--- a/nntrainer/optimizers/optimizer_wrapped.h
+++ b/nntrainer/optimizers/optimizer_wrapped.h
@@ -153,6 +153,7 @@ private:
   std::shared_ptr<nntrainer::LearningRateScheduler>
     lr_sched; /**< the underlying learning rate scheduler */
 
+  /** @todo remove DecayRate, DecaySteps*/
   std::tuple<props::LearningRate, props::DecayRate, props::DecaySteps>
     props; /**< lr scheduler props for backward compatibility */
 };

--- a/nntrainer/optimizers/optimizer_wrapped.h
+++ b/nntrainer/optimizers/optimizer_wrapped.h
@@ -85,8 +85,8 @@ public:
    *
    * @param lrs the learning rate scheduler object
    */
-  void setLearningRateScheduler(
-    std::unique_ptr<ml::train::LearningRateScheduler> &&lrs) override;
+  int setLearningRateScheduler(
+    std::shared_ptr<ml::train::LearningRateScheduler> lrs) override;
 
   /**
    * Support all the interface requirements by nntrainer::Optimizer
@@ -150,7 +150,7 @@ public:
 
 private:
   std::unique_ptr<OptimizerCore> optimizer; /**< the underlying optimizer */
-  std::unique_ptr<nntrainer::LearningRateScheduler>
+  std::shared_ptr<nntrainer::LearningRateScheduler>
     lr_sched; /**< the underlying learning rate scheduler */
 
   std::tuple<props::LearningRate, props::DecayRate, props::DecaySteps>

--- a/test/tizen_capi/meson.build
+++ b/test/tizen_capi/meson.build
@@ -3,7 +3,7 @@ unittest_tizen_deps = [
   nntrainer_test_deps,
 ]
 
-unittest_name_list = ['', '_layer', '_optimizer', '_dataset']
+unittest_name_list = ['', '_layer', '_optimizer', '_lr_scheduler', '_dataset']
 unittest_prefix = 'unittest_tizen_capi'
 
 foreach test_name : unittest_name_list

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -151,54 +151,9 @@ TEST(nntrainer_capi_nnmodel, compile_01_p) {
 /**
  * @brief Neural Network Model Compile Test
  */
-TEST(nntrainer_capi_nnmodel, compile_with_single_param_01_p) {
-  ml_train_model_h handle = NULL;
-  int status = ML_ERROR_NONE;
-
-  ScopedIni s("capi_test_compile_with_single_param_01_p",
-              {model_base, optimizer, dataset, inputlayer, outputlayer});
-
-  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-  status =
-    ml_train_model_compile_with_single_param(handle, "loss=cross|epochs=2");
-  EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_train_model_destroy(handle);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-}
-
-/**
- * @brief Neural Network Model Compile Test
- */
-TEST(nntrainer_capi_nnmodel, construct_conf_01_n) {
-  ml_train_model_h handle = NULL;
-  int status = ML_ERROR_NONE;
-  std::string config_file = "/test/cannot_find.ini";
-  status = ml_train_model_construct_with_conf(config_file.c_str(), &handle);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-}
-
-/**
- * @brief Neural Network Model Compile Test
- */
-TEST(nntrainer_capi_nnmodel, construct_conf_02_n) {
-  ml_train_model_h handle = NULL;
-  int status = ML_ERROR_NONE;
-
-  ScopedIni s("capi_test_compile_03_n",
-              {model_base, optimizer, dataset, inputlayer + "Input_Shape=1:1:0",
-               outputlayer});
-
-  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-}
-
-/**
- * @brief Neural Network Model Compile Test
- */
 TEST(nntrainer_capi_nnmodel, compile_02_n) {
   int status = ML_ERROR_NONE;
-  std::string config_file = "./test_compile_03_n.ini";
+  std::string config_file = "./test_compile_02_n.ini";
   status = ml_train_model_compile(NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
@@ -206,7 +161,7 @@ TEST(nntrainer_capi_nnmodel, compile_02_n) {
 /**
  * @brief Neural Network Model Optimizer Test
  */
-TEST(nntrainer_capi_nnmodel, compile_05_p) {
+TEST(nntrainer_capi_nnmodel, compile_03_p) {
   int status = ML_ERROR_NONE;
 
   ml_train_model_h model;
@@ -271,7 +226,7 @@ TEST(nntrainer_capi_nnmodel, compile_05_p) {
 /**
  * @brief Neural Network Model Optimizer Test
  */
-TEST(nntrainer_capi_nnmodel, compile_06_n) {
+TEST(nntrainer_capi_nnmodel, compile_04_n) {
   int status = ML_ERROR_NONE;
 
   ml_train_model_h model;
@@ -349,18 +304,44 @@ TEST(nntrainer_capi_nnmodel, compile_06_n) {
 /**
  * @brief Neural Network Model Compile Test
  */
-TEST(nntrainer_capi_nnmodel, compile_with_single_param_01_n) {
+TEST(nntrainer_capi_nnmodel, construct_conf_01_n) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+  std::string config_file = "/test/cannot_find.ini";
+  status = ml_train_model_construct_with_conf(config_file.c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+/**
+ * @brief Neural Network Model Compile Test
+ */
+TEST(nntrainer_capi_nnmodel, construct_conf_02_n) {
   ml_train_model_h handle = NULL;
   int status = ML_ERROR_NONE;
 
-  ScopedIni s("capi_test_compile_with_single_param_01_n",
+  ScopedIni s("capi_test_construct_conf_02_n",
+              {model_base, optimizer, dataset, inputlayer + "Input_Shape=1:1:0",
+               outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+/**
+ * @brief Neural Network Model Compile Test
+ */
+TEST(nntrainer_capi_nnmodel, compile_with_single_param_01_p) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+
+  ScopedIni s("capi_test_compile_with_single_param_01_p",
               {model_base, optimizer, dataset, inputlayer, outputlayer});
 
   status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status =
-    ml_train_model_compile_with_single_param(handle, "loss=cross epochs=2");
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+    ml_train_model_compile_with_single_param(handle, "loss=cross|epochs=2");
+  EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
@@ -378,7 +359,7 @@ TEST(nntrainer_capi_nnmodel, compile_with_single_param_02_n) {
   status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
   status =
-    ml_train_model_compile_with_single_param(handle, "loss=cross,epochs=2");
+    ml_train_model_compile_with_single_param(handle, "loss=cross epochs=2");
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
   status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -391,7 +372,26 @@ TEST(nntrainer_capi_nnmodel, compile_with_single_param_03_n) {
   ml_train_model_h handle = NULL;
   int status = ML_ERROR_NONE;
 
-  ScopedIni s("capi_test_compile_with_single_param_02_n",
+  ScopedIni s("capi_test_compile_with_single_param_03_n",
+              {model_base, optimizer, dataset, inputlayer, outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status =
+    ml_train_model_compile_with_single_param(handle, "loss=cross,epochs=2");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Model Compile Test
+ */
+TEST(nntrainer_capi_nnmodel, compile_with_single_param_04_n) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+
+  ScopedIni s("capi_test_compile_with_single_param_04_n",
               {model_base, optimizer, dataset, inputlayer, outputlayer});
 
   status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
@@ -432,6 +432,35 @@ TEST(nntrainer_capi_nnmodel, train_01_p) {
 /**
  * @brief Neural Network Model Train Test
  */
+TEST(nntrainer_capi_nnmodel, train_02_n) {
+  int status = ML_ERROR_NONE;
+  status = ml_train_model_run(NULL, NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+/**
+ * @brief Neural Network Model Train Test
+ */
+TEST(nntrainer_capi_nnmodel, train_03_n) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+  ScopedIni s("capi_test_train_03_n",
+              {model_base + "batch_size = 16", optimizer,
+               dataset + "-BufferSize", inputlayer, outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_model_compile(handle, NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_model_run(handle, "loss=cross", NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Model Train Test
+ */
 TEST(nntrainer_capi_nnmodel, train_with_single_param_01_p) {
   ml_train_model_h handle = NULL;
   int status = ML_ERROR_NONE;
@@ -451,61 +480,7 @@ TEST(nntrainer_capi_nnmodel, train_with_single_param_01_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   /** Compare training statistics */
-  nntrainer_capi_model_comp_metrics(handle, 3.67021, 3.26736, 10.4167);
-
-  status = ml_train_model_destroy(handle);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-}
-
-/**
- * @brief Neural Network Model Train Test
- */
-TEST(nntrainer_capi_nnmodel, train_02_n) {
-  int status = ML_ERROR_NONE;
-  status = ml_train_model_run(NULL, NULL);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-}
-
-/**
- * @brief Neural Network Model Train Test
- */
-TEST(nntrainer_capi_nnmodel, train_03_n) {
-  ml_train_model_h handle = NULL;
-  int status = ML_ERROR_NONE;
-  ScopedIni s("capi_test_train_01_p",
-              {model_base + "batch_size = 16", optimizer,
-               dataset + "-BufferSize", inputlayer, outputlayer});
-
-  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_train_model_compile(handle, NULL);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-  status = ml_train_model_run(handle, "loss=cross", NULL);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-  status = ml_train_model_destroy(handle);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-}
-
-/**
- * @brief Neural Network Model Train Test
- */
-TEST(nntrainer_capi_nnmodel, train_with_single_param_01_n) {
-  ml_train_model_h handle = NULL;
-  int status = ML_ERROR_NONE;
-
-  ScopedIni s(
-    "capi_test_train_with_single_param_01_n",
-    {model_base, optimizer, dataset + "-BufferSize", inputlayer, outputlayer});
-
-  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-
-  status = ml_train_model_compile(handle, NULL);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-
-  status = ml_train_model_run_with_single_param(
-    handle, "epochs=2 batch_size=16 save_path=capi_tizen_model.bin");
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  nntrainer_capi_model_comp_metrics(handle, 3.77080, 3.18020, 10.4167);
 
   status = ml_train_model_destroy(handle);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -529,7 +504,7 @@ TEST(nntrainer_capi_nnmodel, train_with_single_param_02_n) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_train_model_run_with_single_param(
-    handle, "epochs=2,batch_size=16,save_path=capi_tizen_model.bin");
+    handle, "epochs=2 batch_size=16 save_path=capi_tizen_model.bin");
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 
   status = ml_train_model_destroy(handle);
@@ -544,7 +519,32 @@ TEST(nntrainer_capi_nnmodel, train_with_single_param_03_n) {
   int status = ML_ERROR_NONE;
 
   ScopedIni s(
-    "capi_test_train_with_single_param_02_n",
+    "capi_test_train_with_single_param_03_n",
+    {model_base, optimizer, dataset + "-BufferSize", inputlayer, outputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_compile(handle, NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_run_with_single_param(
+    handle, "epochs=2,batch_size=16,save_path=capi_tizen_model.bin");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_model_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Neural Network Model Train Test
+ */
+TEST(nntrainer_capi_nnmodel, train_with_single_param_04_n) {
+  ml_train_model_h handle = NULL;
+  int status = ML_ERROR_NONE;
+
+  ScopedIni s(
+    "capi_test_train_with_single_param_04_n",
     {model_base, optimizer, dataset + "-BufferSize", inputlayer, outputlayer});
 
   status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &handle);
@@ -706,13 +706,13 @@ TEST(nntrainer_capi_nnmodel, addLayer_05_n) {
 /**
  * @brief Neural Network Model Add layer test
  */
-TEST(nntrainer_capi_nnmodel, addLayer_07_n) {
+TEST(nntrainer_capi_nnmodel, addLayer_06_n) {
   int status = ML_ERROR_NONE;
 
   ml_train_model_h model = NULL;
   ml_train_layer_h layer = NULL;
 
-  ScopedIni s("capi_test_addLayer_07_n",
+  ScopedIni s("capi_test_addLayer_06_n",
               {model_base, optimizer, dataset, inputlayer, outputlayer});
 
   status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &model);
@@ -867,6 +867,46 @@ TEST(nntrainer_capi_nnmodel, getLayer_04_n) {
 }
 
 /**
+ * @brief Neural Network Model Get Layer Test
+ */
+TEST(nntrainer_capi_nnmodel, getLayer_05_n) {
+  int status = ML_ERROR_NONE;
+
+  ml_train_model_h model;
+  ml_train_layer_h get_layer;
+
+  std::string default_name = "inputlayer", modified_name = "renamed_inputlayer";
+  char *default_summary, *modified_summary = nullptr;
+
+  ScopedIni s("getLayer_05_p", {model_base, inputlayer});
+
+  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &model);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status =
+    ml_train_model_get_summary(model, ML_TRAIN_SUMMARY_MODEL, &default_summary);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  std::string default_summary_str(default_summary);
+  EXPECT_NE(default_summary_str.find(default_name), std::string::npos);
+  free(default_summary);
+
+  status = ml_train_model_get_layer(model, default_name.c_str(), &get_layer);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_layer_set_property(get_layer,
+                                       ("name=" + modified_name).c_str(), NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  ///@todo need to fix bug (Unable to get renamed layer)
+  status = ml_train_model_get_layer(model, modified_name.c_str(), &get_layer);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_model_destroy(model);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
  * @brief Neural Network Model Get Weight  Test
  */
 TEST(nntrainer_capi_nnmodel, getWeight_01) {
@@ -919,46 +959,6 @@ TEST(nntrainer_capi_nnmodel, getWeight_01) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_tensors_data_destroy(weights);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-}
-
-/**
- * @brief Neural Network Model Get Layer Test
- */
-TEST(nntrainer_capi_nnmodel, getLayer_05_n) {
-  int status = ML_ERROR_NONE;
-
-  ml_train_model_h model;
-  ml_train_layer_h get_layer;
-
-  std::string default_name = "inputlayer", modified_name = "renamed_inputlayer";
-  char *default_summary, *modified_summary = nullptr;
-
-  ScopedIni s("getLayer_02_p", {model_base, inputlayer});
-
-  status = ml_train_model_construct_with_conf(s.getIniName().c_str(), &model);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-
-  status =
-    ml_train_model_get_summary(model, ML_TRAIN_SUMMARY_MODEL, &default_summary);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-
-  std::string default_summary_str(default_summary);
-  EXPECT_NE(default_summary_str.find(default_name), std::string::npos);
-  free(default_summary);
-
-  status = ml_train_model_get_layer(model, default_name.c_str(), &get_layer);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-
-  status = ml_train_layer_set_property(get_layer,
-                                       ("name=" + modified_name).c_str(), NULL);
-  EXPECT_EQ(status, ML_ERROR_NONE);
-
-  ///@todo need to fix bug (Unable to get renamed layer)
-  status = ml_train_model_get_layer(model, modified_name.c_str(), &get_layer);
-  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
-
-  status = ml_train_model_destroy(model);
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -168,6 +168,7 @@ TEST(nntrainer_capi_nnmodel, compile_03_p) {
   ml_train_layer_h layers[2];
   ml_train_layer_h get_layer;
   ml_train_optimizer_h optimizer;
+  ml_train_lr_scheduler_h lr_scheduler;
 
   status = ml_train_model_construct(&model);
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -208,9 +209,20 @@ TEST(nntrainer_capi_nnmodel, compile_03_p) {
   status = ml_train_optimizer_create(&optimizer, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
-  status = ml_train_optimizer_set_property(
-    optimizer, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
-    "beta1=0.002", "beta2=0.001", "epsilon=1e-7", NULL);
+  status = ml_train_optimizer_set_property(optimizer, "beta1=0.002",
+                                           "beta2=0.001", "epsilon=1e-7", NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_lr_scheduler_create(&lr_scheduler,
+                                        ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_lr_scheduler_set_property(
+    lr_scheduler, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
+    NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_optimizer_set_lr_scheduler(optimizer, lr_scheduler);
   EXPECT_EQ(status, ML_ERROR_NONE);
 
   status = ml_train_model_set_optimizer(model, optimizer);

--- a/test/tizen_capi/unittest_tizen_capi_lr_scheduler.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_lr_scheduler.cpp
@@ -1,0 +1,376 @@
+/**
+ * Copyright (C) 2023 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @file        unittest_tizen_capi_lr_scheduler.cpp
+ * @date        13 April 2023
+ * @brief       Unit test utility for learning rate scheduler.
+ * @see         https://github.com/nnstreamer/nntrainer
+ * @author      Hyeonseok Lee <hs89.lee@samsung.com>
+ * @bug         No known bugs
+ */
+#include <gtest/gtest.h>
+
+#include <nntrainer.h>
+#include <nntrainer_internal.h>
+#include <nntrainer_test_util.h>
+
+/**
+ * @brief Learning rate scheduler Create / Destruct Test (positive test)
+ */
+TEST(nntrainer_capi_lr_scheduler, create_destruct_01_p) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status =
+    ml_train_lr_scheduler_create(&handle, ML_TRAIN_LR_SCHEDULER_TYPE_CONSTANT);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler Create / Destruct Test (positive test)
+ */
+TEST(nntrainer_capi_lr_scheduler, create_destruct_02_p) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status = ml_train_lr_scheduler_create(&handle,
+                                        ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler Create / Destruct Test (positive test)
+ */
+TEST(nntrainer_capi_lr_scheduler, create_destruct_03_p) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status =
+    ml_train_lr_scheduler_create(&handle, ML_TRAIN_LR_SCHEDULER_TYPE_STEP);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler Create / Destruct Test (negative test)
+ */
+TEST(nntrainer_capi_lr_scheduler, create_destruct_04_n) {
+  ml_train_lr_scheduler_h handle = NULL;
+  int status;
+  status = ml_train_lr_scheduler_destroy(&handle);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+/**
+ * @brief Learning rate scheduler Create / Destruct Test (negative test)
+ */
+TEST(nntrainer_capi_lr_scheduler, create_destruct_05_n) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status =
+    ml_train_lr_scheduler_create(&handle, ML_TRAIN_LR_SCHEDULER_TYPE_UNKNOWN);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+/**
+ * @brief Learning rate scheduler Create / Destruct Test (negative test)
+ */
+TEST(nntrainer_capi_lr_scheduler, create_destruct_06_n) {
+  ml_train_optimizer_h opt_handle;
+  ml_train_lr_scheduler_h lr_sched_handle;
+  int status;
+  status = ml_train_optimizer_create(&opt_handle, ML_TRAIN_OPTIMIZER_TYPE_SGD);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_lr_scheduler_create(&lr_sched_handle,
+                                        ML_TRAIN_LR_SCHEDULER_TYPE_CONSTANT);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_optimizer_set_lr_scheduler(opt_handle, lr_sched_handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_lr_scheduler_destroy(lr_sched_handle);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_optimizer_destroy(opt_handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler Create / Destruct Test (negative test)
+ */
+TEST(nntrainer_capi_lr_scheduler, create_destruct_07_n) {
+  int status = ML_ERROR_NONE;
+
+  ml_train_model_h model;
+  ml_train_optimizer_h optimizer;
+  ml_train_lr_scheduler_h lr_scheduler;
+
+  status = ml_train_model_construct(&model);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_optimizer_create(&optimizer, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_optimizer_set_property(optimizer, "beta1=0.002",
+                                           "beta2=0.001", "epsilon=1e-7", NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_lr_scheduler_create(&lr_scheduler,
+                                        ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_lr_scheduler_set_property(
+    lr_scheduler, "learning_rate=0.0001", "decay_rate=0.96", "decay_steps=1000",
+    NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_model_set_optimizer(model, optimizer);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_optimizer_set_lr_scheduler(optimizer, lr_scheduler);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_lr_scheduler_destroy(lr_scheduler);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+
+  status = ml_train_model_destroy(model);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler set Property Test (positive test)
+ */
+TEST(nntrainer_capi_lr_scheduler, setProperty_01_p) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status =
+    ml_train_lr_scheduler_create(&handle, ML_TRAIN_LR_SCHEDULER_TYPE_CONSTANT);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status =
+    ml_train_lr_scheduler_set_property(handle, "learning_rate=0.001", NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler set Property Test (positive test)
+ */
+TEST(nntrainer_capi_lr_scheduler, setProperty_02_p) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status = ml_train_lr_scheduler_create(&handle,
+                                        ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_set_property(
+    handle, "learning_rate=0.001", "decay_rate=0.9", "decay_steps=2", NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler set Property Test (positive test)
+ */
+TEST(nntrainer_capi_lr_scheduler, setProperty_03_p) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status =
+    ml_train_lr_scheduler_create(&handle, ML_TRAIN_LR_SCHEDULER_TYPE_STEP);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_set_property(
+    handle, "learning_rate=0.01, 0.001", "iteration=100", NULL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler set Property Test (negative test)
+ */
+TEST(nntrainer_capi_lr_scheduler, setProperty_04_n) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status =
+    ml_train_lr_scheduler_create(&handle, ML_TRAIN_LR_SCHEDULER_TYPE_CONSTANT);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_set_property(handle, "learning_rate=0.001",
+                                              "iteration=10", NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler set Property Test (negative test)
+ */
+TEST(nntrainer_capi_lr_scheduler, setProperty_05_n) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status =
+    ml_train_lr_scheduler_create(&handle, ML_TRAIN_LR_SCHEDULER_TYPE_CONSTANT);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_set_property(handle, "learning_rate=0.001",
+                                              "decay_rate=0.9", NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler set Property Test (negative test)
+ */
+TEST(nntrainer_capi_lr_scheduler, setProperty_06_n) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status =
+    ml_train_lr_scheduler_create(&handle, ML_TRAIN_LR_SCHEDULER_TYPE_CONSTANT);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_set_property(handle, "learning_rate=0.001",
+                                              "decay_steps=2", NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler set Property Test (negative test)
+ */
+TEST(nntrainer_capi_lr_scheduler, setProperty_07_n) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status = ml_train_lr_scheduler_create(&handle,
+                                        ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_set_property(handle, "learning_rate=0.001",
+                                              "iteration=100", NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler set Property Test (negative test)
+ */
+TEST(nntrainer_capi_lr_scheduler, setProperty_08_n) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status =
+    ml_train_lr_scheduler_create(&handle, ML_TRAIN_LR_SCHEDULER_TYPE_STEP);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_set_property(handle, "learning_rate=0.001",
+                                              "decay_rate=0.9", NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler set Property Test (negative test)
+ */
+TEST(nntrainer_capi_lr_scheduler, setProperty_09_n) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status =
+    ml_train_lr_scheduler_create(&handle, ML_TRAIN_LR_SCHEDULER_TYPE_STEP);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_set_property(handle, "learning_rate=0.001",
+                                              "decay_steps=2", NULL);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler set Property Test (positive test)
+ */
+TEST(nntrainer_capi_lr_scheduler, setProperty_with_single_param_01_p) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status = ml_train_lr_scheduler_create(&handle,
+                                        ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_set_property_with_single_param(
+    handle, "learning_rate=0.001 | decay_rate=0.9 | decay_steps=2");
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler set Property Test (negative test)
+ */
+TEST(nntrainer_capi_lr_scheduler, setProperty_with_single_param_02_n) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status = ml_train_lr_scheduler_create(&handle,
+                                        ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_set_property_with_single_param(
+    handle, "learning_rate=0.001, decay_rate=0.9, decay_steps=2");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Learning rate scheduler set Property Test (negative test)
+ */
+TEST(nntrainer_capi_lr_scheduler, setProperty_with_single_param_03_n) {
+  ml_train_lr_scheduler_h handle;
+  int status;
+  status = ml_train_lr_scheduler_create(&handle,
+                                        ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+  status = ml_train_lr_scheduler_set_property_with_single_param(
+    handle, "learning_rate=0.001 ! decay_rate=0.9 ! decay_steps=2");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_lr_scheduler_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error duing IniGoogleTest" << std::endl;
+    return 0;
+  }
+
+  /** ignore tizen feature check while running the testcases */
+  set_feature_state(ML_FEATURE, SUPPORTED);
+  set_feature_state(ML_FEATURE_INFERENCE, SUPPORTED);
+  set_feature_state(ML_FEATURE_TRAINING, SUPPORTED);
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error duing RUN_ALL_TSETS()" << std::endl;
+  }
+
+  /** reset tizen feature check state */
+  set_feature_state(ML_FEATURE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_INFERENCE, NOT_CHECKED_YET);
+  set_feature_state(ML_FEATURE_TRAINING, NOT_CHECKED_YET);
+
+  return result;
+}

--- a/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
@@ -72,7 +72,7 @@ TEST(nntrainer_capi_nnopt, create_delete_04_n) {
 /**
  * @brief Neural Network Optimizer set Property Test (positive test)
  */
-TEST(nntrainer_capi_nnopt, setOptimizer_01_p) {
+TEST(nntrainer_capi_nnopt, setProperty_01_p) {
   ml_train_optimizer_h handle;
   int status;
   status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
@@ -87,7 +87,7 @@ TEST(nntrainer_capi_nnopt, setOptimizer_01_p) {
 /**
  * @brief Neural Network Optimizer Set Property Test (positive test)
  */
-TEST(nntrainer_capi_nnopt, setOptimizer_02_p) {
+TEST(nntrainer_capi_nnopt, setProperty_02_p) {
   ml_train_optimizer_h handle;
   int status;
   status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
@@ -103,7 +103,7 @@ TEST(nntrainer_capi_nnopt, setOptimizer_02_p) {
 /**
  * @brief Neural Network Optimizer Set Property Test (negative test)
  */
-TEST(nntrainer_capi_nnopt, setOptimizer_03_n) {
+TEST(nntrainer_capi_nnopt, setProperty_03_n) {
   ml_train_optimizer_h handle;
   int status;
   status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
@@ -118,7 +118,7 @@ TEST(nntrainer_capi_nnopt, setOptimizer_03_n) {
 /**
  * @brief Neural Network Optimizer Set Property Test (negative test)
  */
-TEST(nntrainer_capi_nnopt, setOptimizer_04_n) {
+TEST(nntrainer_capi_nnopt, setProperty_04_n) {
   ml_train_optimizer_h handle = NULL;
   int status;
 
@@ -131,7 +131,7 @@ TEST(nntrainer_capi_nnopt, setOptimizer_04_n) {
 /**
  * @brief Neural Network Optimizer Set Property Test (negative test)
  */
-TEST(nntrainer_capi_nnopt, setOptimizer_05_n) {
+TEST(nntrainer_capi_nnopt, setProperty_05_n) {
   ml_train_optimizer_h handle = NULL;
   int status;
   status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
@@ -143,7 +143,7 @@ TEST(nntrainer_capi_nnopt, setOptimizer_05_n) {
 /**
  * @brief Neural Network Optimizer Set Property Test (positive test)
  */
-TEST(nntrainer_capi_nnopt, setOptimizer_with_single_param_06_p) {
+TEST(nntrainer_capi_nnopt, setProperty_with_single_param_01_p) {
   ml_train_optimizer_h handle;
   int status;
   status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
@@ -158,7 +158,7 @@ TEST(nntrainer_capi_nnopt, setOptimizer_with_single_param_06_p) {
 /**
  * @brief Neural Network Optimizer Set Property Test (negative test)
  */
-TEST(nntrainer_capi_nnopt, setOptimizer_with_single_param_07_n) {
+TEST(nntrainer_capi_nnopt, setProperty_with_single_param_02_n) {
   ml_train_optimizer_h handle;
   int status;
   status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);
@@ -173,7 +173,7 @@ TEST(nntrainer_capi_nnopt, setOptimizer_with_single_param_07_n) {
 /**
  * @brief Neural Network Optimizer Set Property Test (negative test)
  */
-TEST(nntrainer_capi_nnopt, setOptimizer_with_single_param_08_n) {
+TEST(nntrainer_capi_nnopt, setProperty_with_single_param_03_n) {
   ml_train_optimizer_h handle;
   int status;
   status = ml_train_optimizer_create(&handle, ML_TRAIN_OPTIMIZER_TYPE_ADAM);

--- a/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
@@ -186,6 +186,28 @@ TEST(nntrainer_capi_nnopt, setProperty_with_single_param_03_n) {
 }
 
 /**
+ * @brief Set learning rate scheduler to Neural Network Optimizer Test (positive
+ * test)
+ */
+TEST(nntrainer_capi_nnopt, set_lr_scheduler_01_p) {
+  ml_train_optimizer_h opt_handle;
+  ml_train_lr_scheduler_h lr_sched_handle;
+  int status;
+  status = ml_train_optimizer_create(&opt_handle, ML_TRAIN_OPTIMIZER_TYPE_SGD);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_lr_scheduler_create(&lr_sched_handle,
+                                        ML_TRAIN_LR_SCHEDULER_TYPE_CONSTANT);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_optimizer_set_lr_scheduler(opt_handle, lr_sched_handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  status = ml_train_optimizer_destroy(opt_handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+/**
  * @brief Main gtest
  */
 int main(int argc, char **argv) {


### PR DESCRIPTION
Commit 1:     [ccapi] rename LearningRateType enum name to LearningRateSchedulerType
    
     - rename enum name LearningRateType to LearningRateSchedulerType for more detailed info
    
    Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>

Commit 2:     [ccapi] change setLearningRateScheduler function prototype
    
     - Change return type from void to int.
       Capi will call this function so it should be return status.
     - Change learning rate scheduler pointer from unique_ptr to shared_ptr
    
    Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>

Commit 3:     [capi] add learning rate scheduler related api
    
     - Added learning rate scheduler create/destroy/set property api
     - Added set learning rate scheduler to optimizer
     - Added ml_train_lr_scheduler_type_e enum
     - Fix some comments
    
    Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>

Commit 4:     [test] reorder tizen capi unittest
    
     - Reorder unittest for sequential order
    
    Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>

Commit 5:     [capi] add unittest for learning rate scheduler
    
     - Added learning rate scheduler related unittest
    
    Signed-off-by: hyeonseok lee <hs89.lee@samsung.com>