### PR TITLE
[capi] fix comment for tizen release

### DIFF
--- a/api/capi/include/nntrainer.h
+++ b/api/capi/include/nntrainer.h
@@ -397,7 +397,7 @@ int ml_train_optimizer_destroy(ml_train_optimizer_h optimizer);
  * scheduler(decay_rate, decay_steps) can be set using
  * ml_train_optimizer_set_property() for backward compatibility. But
  * ml_train_optimizer_set_property() will not support to set decay_rate,
- * decay_steps properties from tizen 8.0. Use
+ * decay_steps properties from later version. Use
  * ml_train_lr_scheduler_set_property() instead.
  */
 int ml_train_optimizer_set_property(ml_train_optimizer_h optimizer, ...);


### PR DESCRIPTION
The notation for future version has been modified.

- "tizen 8.0" to "later version".