### PR TITLE
[Application] Fix Resnet Application -ENABLE_TFLITE_INTERPRETER CASES

### DIFF
--- a/Applications/Resnet/jni/main.cpp
+++ b/Applications/Resnet/jni/main.cpp
@@ -199,7 +199,7 @@ std::vector<LayerHandle> createResnet18Graph() {
 /// @todo update createResnet18 to be more generic
 ModelHandle createResnet18() {
 /// @todo support "LOSS : cross" for TF_Lite Exporter
-#if defined(ENABLE_TEST)
+#if (defined(ENABLE_TFLITE_INTERPRETER) && !defined(ENABLE_TEST))
   ModelHandle model = ml::train::createModel(ml::train::ModelType::NEURAL_NET,
                                              {withKey("loss", "mse")});
 #else
@@ -270,9 +270,10 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
   model->train();
 
 #if defined(ENABLE_TEST)
-  model->exports(ml::train::ExportMethods::METHOD_TFLITE, "resnet_test.tflite");
   training_loss = model->getTrainingLoss();
   validation_loss = model->getValidationLoss();
+#elif defined(ENABLE_TFLITE_INTERPRETER)
+  model->exports(ml::train::ExportMethods::METHOD_TFLITE, "resnet_test.tflite");
 #endif
 }
 


### PR DESCRIPTION
Now TFLITE Interpreter is not support loss : cross type 

So in Resnet Application we made some macro to make them mse and there was some wrong part

in ResNet Application there was another macro for ENABLE_TEST GTEST's result assume that Application use cross loss

For Correct Result Fix some #if statement

**TODO :  even if fix this situation TEST still failed regardless of tflite export releated code. it seem to be data feeding problem**
```.txt
../Applications/Resnet/jni/main.cpp:233: Failure
Expected equality of these values:
  training_loss
    Which is: 4.3914199
  4.389328

../Applications/Resnet/jni/main.cpp:234: Failure
Expected equality of these values:
  validation_loss
    Which is: 11.514971
  11.611803
```
