### PR TITLE
[Layer] Add checkpoint property

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -12,6 +12,7 @@
  * @todo    Support multi-input graph.
  */
 
+#include "common_properties.h"
 #include "graph_node.h"
 #include "tensor.h"
 #include <cmath>
@@ -44,6 +45,8 @@
 #include <time_dist.h>
 #include <tracer.h>
 #include <util_func.h>
+
+#include <iostream>
 
 #define LNODE(x) std::static_pointer_cast<LayerNode>(x)
 
@@ -84,6 +87,7 @@ int NetworkGraph::compile(const std::string &loss_type) {
   status = checkCompiledGraph();
   NN_RETURN_STATUS();
 
+  setCheckPoints();
   compiled = true;
 
   return status;
@@ -114,6 +118,26 @@ void NetworkGraph::setExecutionOrder() {
    * clipping.
    */
   graph_exec_end = std::get<3>((*(cbegin()))->getExecutionOrder());
+}
+
+void NetworkGraph::setCheckPoints() {
+  for (auto iter = cbegin(); iter != cend(); iter++) {
+    auto &node = *iter;
+    auto idx = iter - cbegin();
+
+    if (node->getType() == ActivationLayer::type) {
+      auto &prev_node = *(iter - 1);
+      if (prev_node->getCheckPoint().get() == CheckPointType::CHECKPOINTED) {
+        node->setCheckPoint(CheckPointType::CHECKPOINTED);
+        prev_node->setCheckPoint(CheckPointType::NONCHECK_UNLOAD);
+        continue;
+      }
+    }
+
+    node->setCheckPoint(idx % (checkpoint_len + 1) == 0
+                          ? CheckPointType::CHECKPOINTED
+                          : CheckPointType::NONCHECK_UNLOAD);
+  }
 }
 
 void NetworkGraph::addLayerNode(std::unique_ptr<Layer> layer) {
@@ -794,10 +818,9 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
   if (lnode->getType() == RNNCellLayer::type or
       lnode->getType() == LSTMCellLayer::type or
       lnode->getType() == GRUCellLayer::type) {
-    std::for_each(
-      out_specs.begin(), out_specs.end(), [this](VarGradSpecV2 &spec) {
-        spec.variable_spec.ls = TensorLifespan::FORWARD_GRAD_LIFESPAN;
-      });
+    std::for_each(out_specs.begin(), out_specs.end(), [](VarGradSpecV2 &spec) {
+      spec.variable_spec.ls = TensorLifespan::FORWARD_GRAD_LIFESPAN;
+    });
   }
 
   const std::vector<Var_Grad *> &outputs = tensor_manager->requestTensors(

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -45,6 +45,7 @@ public:
     compiled(false),
     batch_size(0),
     graph_exec_end(0),
+    checkpoint_len(0),
     backward_iter_end(nullptr),
     forward_iter_end(nullptr),
     optimize_memory(true),
@@ -58,7 +59,7 @@ public:
    * @param[in] swap_path memory swap file path when the swap is enabled
    */
   NetworkGraph(bool enable_swap, const std::string &swap_path = "",
-               unsigned int lookahead = 0,
+               unsigned int lookahead = 0, unsigned int checkpoint_length = 0,
                const std::string &tensor_format_ = "NCHW",
                const std::string &tensor_dtype_ = "FP32-FP32") :
     tensor_manager(std::make_shared<Manager>(enable_swap, swap_path, lookahead,
@@ -67,6 +68,7 @@ public:
     compiled(false),
     batch_size(0),
     graph_exec_end(0),
+    checkpoint_len(checkpoint_length),
     backward_iter_end(nullptr),
     forward_iter_end(nullptr),
     optimize_memory(true),
@@ -415,6 +417,8 @@ private:
   unsigned int batch_size;     /**< current batch_size */
   unsigned int graph_exec_end; /**< Inclusive, last execution order of the
                                   given graph */
+  unsigned int checkpoint_len; /**< checkpoint length */
+
   LayerNode
     *backward_iter_end;        /**< inclusive end node of the valid backward
                                   execution when initialized, nodes after this node
@@ -519,6 +523,11 @@ private:
    * is expected to be called right after calcGradient().
    */
   void setExecutionOrder();
+
+  /**
+   * @brief Set the checkpoint for all the nodes in the graph
+   */
+  void setCheckPoints();
 
   /**
    * @brief Set external data to the given tensors with name

--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -343,6 +343,8 @@ ReturnAttentionWeight::ReturnAttentionWeight(
   set(value);
 }
 
+CheckPoint::CheckPoint(CheckPointType value) { set(value); }
+
 } // namespace props
 
 template <>

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -41,6 +41,18 @@ enum class ActivationType {
   ACT_UNKNOWN     /**< unknown */
 };
 
+/**
+ * @brief     Enumeration of checkpoint type
+ * @note      Upon changing this enum, CheckPointTypeInfo must be changed
+ * accordingly
+ */
+enum class CheckPointType {
+  CHECKPOINTED,       /**< unknown */
+  NONCHECK_UNLOAD,    /**< unknown */
+  NONCHECK_LOAD,      /**< unknown */
+  CHECKPOINT_UNKNOWN, /**< unknown */
+};
+
 namespace props {
 
 /**
@@ -1302,8 +1314,7 @@ public:
 
 /**
  * @brief Decay rate property
- *
- */
+ * */
 class DecayRate : public Property<float> {
 public:
   static constexpr const char *key = "decay_rate"; /**< unique key to access */
@@ -1329,6 +1340,29 @@ public:
   PropsUserData(void *user_data);
   static constexpr const char *key = "user_data";
   using prop_tag = ptr_prop_tag;
+};
+
+/**
+ * @brief     Enumeration of activation function type
+ */
+struct CheckPointStateInfo {
+  using Enum = nntrainer::CheckPointType;
+  static constexpr std::initializer_list<Enum> EnumList = {
+    Enum::CHECKPOINTED, Enum::NONCHECK_UNLOAD, Enum::NONCHECK_LOAD,
+    Enum::CHECKPOINT_UNKNOWN};
+  static constexpr const char *EnumStr[] = {"checkpointed", "unloaded",
+                                            "loaded", "unknown"};
+};
+
+/**
+ * @brief Checkpoint props
+ *
+ */
+class CheckPoint final : public EnumProperty<CheckPointStateInfo> {
+public:
+  static constexpr const char *key = "checkpoint";
+  using prop_tag = enum_class_prop_tag;
+  CheckPoint(CheckPointType value = CheckPointType::CHECKPOINTED);
 };
 
 } // namespace props

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -10,6 +10,7 @@
  * @brief  This is the layer context for each layer
  */
 
+#include "common_properties.h"
 #include "nntrainer_error.h"
 #include <functional>
 #include <memory>
@@ -139,7 +140,8 @@ RunLayerContext::RunLayerContext(const std::string &name, bool trainable,
                                  const std::vector<Weight *> &w,
                                  const std::vector<Var_Grad *> &in,
                                  const std::vector<Var_Grad *> &out,
-                                 const std::vector<Var_Grad *> &t) :
+                                 const std::vector<Var_Grad *> &t,
+                                 CheckPointType checkpoint) :
   loss(l),
   in_place(in_place_),
   weights(w),
@@ -148,6 +150,7 @@ RunLayerContext::RunLayerContext(const std::string &name, bool trainable,
   tensors(t) {
   std::get<props::Name>(props).set(name);
   std::get<props::Trainable>(props).set(trainable);
+  std::get<props::CheckPoint>(props).set(checkpoint);
   NNTR_THROW_IF(!readyToUse(), std::invalid_argument)
     << "run context is not ready to use upon creation";
 

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -382,7 +382,8 @@ public:
                   bool in_place_, const std::vector<Weight *> &w,
                   const std::vector<Var_Grad *> &in,
                   const std::vector<Var_Grad *> &out,
-                  const std::vector<Var_Grad *> &t);
+                  const std::vector<Var_Grad *> &t,
+                  CheckPointType checkpoint = CheckPointType::CHECKPOINTED);
 
   /**
    * @brief Get the Weight tensor object
@@ -726,6 +727,15 @@ public:
   bool getTrainable() const { return std::get<props::Trainable>(props); }
 
   /**
+   * @brief   get trainable by the layer
+   *
+   * @return trainable of the layer
+   */
+  const props::CheckPoint &getCheckPoint() const {
+    return std::get<props::CheckPoint>(props);
+  }
+
+  /**
    * @brief   check if run context is set and is ready to use
    *
    * @return true if ready, else false
@@ -750,8 +760,9 @@ public:
   bool executeInPlace() const { return in_place; }
 
 private:
-  std::tuple<props::Name, props::Trainable> props; /**< props of the layer */
-  float loss;                                      /**< loss of the layer */
+  std::tuple<props::Name, props::Trainable, props::CheckPoint>
+    props;       /**< props of the layer */
+  float loss;    /**< loss of the layer */
   bool in_place; /**< if the layer is expected to run in-place */
 
   std::vector<Weight *> weights;   /**< weights of the layer */

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -24,6 +24,7 @@
 #ifndef __LAYER_NODE_H__
 #define __LAYER_NODE_H__
 
+#include "common_properties.h"
 #include <memory>
 #include <tuple>
 #include <vector>
@@ -619,6 +620,16 @@ public:
   }
 
   /**
+   * @brief Get the checkpoint property
+   */
+  void setCheckPoint(props::CheckPoint checkpoint);
+
+  /**
+   * @brief Get the checkpoint property
+   */
+  const props::CheckPoint getCheckPoint() const;
+
+  /**
    * @brief     read layer Weight & Bias data from file
    * @param file input file stream
    * @param bool read optimizer variables
@@ -720,6 +731,7 @@ public:
    * @param inputs inputs
    * @param outputs outputs
    * @param tensors tensors
+   * @param checkpoint checkpoint type
    */
   void configureRunContext(const std::vector<Weight *> &weights,
                            const std::vector<Var_Grad *> &inputs,
@@ -845,10 +857,11 @@ will also contain the properties of the layer. The properties will be copied
 upon final creation. Editing properties of the layer after init will not the
 properties in the context/graph unless intended. */
 
-  using PropsType = std::tuple<props::Name, props::Distribute, props::Trainable,
-                               std::vector<props::InputConnection>,
-                               std::vector<props::InputShape>,
-                               props::SharedFrom, props::ClipGradByGlobalNorm>;
+  using PropsType =
+    std::tuple<props::Name, props::Distribute, props::Trainable,
+               std::vector<props::InputConnection>,
+               std::vector<props::InputShape>, props::SharedFrom,
+               props::ClipGradByGlobalNorm, props::CheckPoint>;
 
   using RealizationPropsType = std::tuple<props::Flatten, props::Activation>;
   /** these realization properties results in addition of new layers, hence

--- a/nntrainer/models/model_common_properties.cpp
+++ b/nntrainer/models/model_common_properties.cpp
@@ -36,4 +36,7 @@ MemorySwapPath::MemorySwapPath(const std::string &value) { set(value); }
 MemorySwapLookahead::MemorySwapLookahead(const unsigned int &value) {
   set(value);
 }
+
+CheckPointLen::CheckPointLen(const unsigned int &value) { set(value); }
+
 } // namespace nntrainer::props

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -202,7 +202,27 @@ public:
   ModelTensorDataType(ModelTensorDataTypeInfo::Enum value =
                         ModelTensorDataTypeInfo::Enum::W32A32) {
     set(value);
-  };
+  }
+};
+
+/**  
+ * @brief check point length property
+ *
+ * @note this is checkpoint distance property, nodes in network graph
+ * are checkpointed in every CheckPointLen, others are uncheckpointed.
+ */
+class CheckPointLen : public Property<unsigned int> {
+public:
+  static constexpr const char *key =
+    "checkpoint_len";            /**< unique key to access */
+  using prop_tag = uint_prop_tag; /**< property type */
+
+  /**
+   * @brief Constructor
+   *
+   * @param value value to set, defaults to current directory
+   */
+  CheckPointLen(const unsigned int &value = 0);
 };
 
 } // namespace nntrainer::props

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -70,7 +70,8 @@ NeuralNetwork::NeuralNetwork() :
     props::Epochs(), props::TrainingBatchSize(), props::SavePath(),
     props::ContinueTrain(), props::SaveBestPath(), props::MemoryOptimization(),
     props::MemorySwap(), props::MemorySwapPath(), props::MemorySwapLookahead(),
-    props::TensorFormat(), props::ModelTensorDataType()),
+    props::TensorFormat(), props::ModelTensorDataType(),
+    props::CheckPointLen()),
   load_path(std::string()),
   epoch_idx(0),
   iter(0),
@@ -88,7 +89,8 @@ NeuralNetwork::NeuralNetwork(AppContext app_context_) :
     props::Epochs(), props::TrainingBatchSize(), props::SavePath(),
     props::ContinueTrain(), props::SaveBestPath(), props::MemoryOptimization(),
     props::MemorySwap(), props::MemorySwapPath(), props::MemorySwapLookahead(),
-    props::TensorFormat(), props::ModelTensorDataType()),
+    props::TensorFormat(), props::ModelTensorDataType(),
+    props::CheckPointLen()),
   load_path(std::string()),
   epoch_idx(0),
   iter(0),
@@ -179,8 +181,11 @@ int NeuralNetwork::compile() {
   const std::string tensor_type =
     to_string(std::get<props::ModelTensorDataType>(model_flex_props));
 
-  model_graph = NetworkGraph(memory_swap, memory_swap_path, lookahead,
-                             tensor_format, tensor_type);
+  unsigned int checkpoint_len =
+    std::get<props::CheckPointLen>(model_flex_props);
+  model_graph =
+    NetworkGraph(memory_swap, memory_swap_path, lookahead, checkpoint_len,
+                 tensor_format, tensor_type);
 
   model_graph.setMemoryOptimizations(
     std::get<props::MemoryOptimization>(model_flex_props));

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -557,7 +557,8 @@ private:
                props::ContinueTrain, props::SaveBestPath,
                props::MemoryOptimization, props::MemorySwap,
                props::MemorySwapPath, props::MemorySwapLookahead,
-               props::TensorFormat, props::ModelTensorDataType>;
+               props::TensorFormat, props::ModelTensorDataType,
+               props::CheckPointLen>;
   using RigidPropTypes =
     std::tuple<props::LossType, std::vector<props::InputConnection>,
                std::vector<props::LabelLayer>, props::ClipGradByGlobalNorm>;

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -93,7 +93,7 @@ void Exporter::saveTflResult(
   const std::tuple<props::Name, props::Distribute, props::Trainable,
                    std::vector<props::InputConnection>,
                    std::vector<props::InputShape>, props::SharedFrom,
-                   props::ClipGradByGlobalNorm> &props,
+                   props::ClipGradByGlobalNorm, props::CheckPoint> &props,
   const LayerNode *self) {
   createIfNull(tf_node);
   tf_node->setLayerNode(*self);

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -245,7 +245,7 @@ void Exporter::saveTflResult(
   const std::tuple<props::Name, props::Distribute, props::Trainable,
                    std::vector<props::InputConnection>,
                    std::vector<props::InputShape>, props::SharedFrom,
-                   props::ClipGradByGlobalNorm> &props,
+                   props::ClipGradByGlobalNorm, props::CheckPoint> &props,
   const LayerNode *self);
 
 class BatchNormalizationLayer;


### PR DESCRIPTION
This patch adds CheckPoint property to layer node.
Default value is checkpointed, which can store the layer data for the
backward step. laoded and unloaded state are for unchecked nodes. The
data would be unloaded from memory, and reloaded when it's needed when
the backward step.

Signed-off-by: Jiho Chu <jiho.chu@samsung.com>