### PR TITLE
(Wait for #2200) [GRAPH] load and unload tensor while traning

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -817,10 +817,9 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
   if (lnode->getType() == RNNCellLayer::type or
       lnode->getType() == LSTMCellLayer::type or
       lnode->getType() == GRUCellLayer::type) {
-    std::for_each(
-      out_specs.begin(), out_specs.end(), [](VarGradSpecV2 &spec) {
-        spec.variable_spec.ls = TensorLifespan::FORWARD_GRAD_LIFESPAN;
-      });
+    std::for_each(out_specs.begin(), out_specs.end(), [](VarGradSpecV2 &spec) {
+      spec.variable_spec.ls = TensorLifespan::FORWARD_GRAD_LIFESPAN;
+    });
   }
 
   const std::vector<Var_Grad *> &outputs = tensor_manager->requestTensors(
@@ -877,8 +876,9 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
                                    lnode->getTrainable(), shared_weight_names),
     inputs, outputs,
     tensor_manager->requestTensors(gnode, init_context.getTensorsSpec(),
-                                   lnode->getTrainable(), shared_tensor_names));
-
+                                   lnode->getTrainable(), shared_tensor_names,
+                                   lnode->getCheckPoint().get() ==
+                                     CheckPointType::CHECKPOINTED));
   return outputs;
 }
 

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -45,6 +45,7 @@ public:
     compiled(false),
     batch_size(0),
     graph_exec_end(0),
+    checkpoint_len(0),
     backward_iter_end(nullptr),
     forward_iter_end(nullptr),
     optimize_memory(true),
@@ -58,7 +59,7 @@ public:
    * @param[in] swap_path memory swap file path when the swap is enabled
    */
   NetworkGraph(bool enable_swap, const std::string &swap_path = "",
-               unsigned int lookahead = 0,
+               unsigned int lookahead = 0, unsigned int checkpoint_length = 0,
                const std::string &tensor_format_ = "NCHW",
                const std::string &tensor_dtype_ = "FP32-FP32") :
     tensor_manager(std::make_shared<Manager>(enable_swap, swap_path, lookahead,
@@ -67,6 +68,7 @@ public:
     compiled(false),
     batch_size(0),
     graph_exec_end(0),
+    checkpoint_len(checkpoint_length),
     backward_iter_end(nullptr),
     forward_iter_end(nullptr),
     optimize_memory(true),
@@ -415,6 +417,8 @@ private:
   unsigned int batch_size;     /**< current batch_size */
   unsigned int graph_exec_end; /**< Inclusive, last execution order of the
                                   given graph */
+  unsigned int checkpoint_len; /**< checkpoint length */
+
   LayerNode
     *backward_iter_end;        /**< inclusive end node of the valid backward
                                   execution when initialized, nodes after this node
@@ -519,6 +523,11 @@ private:
    * is expected to be called right after calcGradient().
    */
   void setExecutionOrder();
+
+  /**
+   * @brief Set the checkpoint for all the nodes in the graph
+   */
+  void setCheckPoints();
 
   /**
    * @brief Set external data to the given tensors with name

--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -343,6 +343,8 @@ ReturnAttentionWeight::ReturnAttentionWeight(
   set(value);
 }
 
+CheckPoint::CheckPoint(CheckPointType value) { set(value); }
+
 } // namespace props
 
 template <>

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -41,6 +41,18 @@ enum class ActivationType {
   ACT_UNKNOWN     /**< unknown */
 };
 
+/**
+ * @brief     Enumeration of checkpoint type
+ * @note      Upon changing this enum, CheckPointTypeInfo must be changed
+ * accordingly
+ */
+enum class CheckPointType {
+  CHECKPOINTED,       /**< unknown */
+  NONCHECK_UNLOAD,    /**< unknown */
+  NONCHECK_LOAD,      /**< unknown */
+  CHECKPOINT_UNKNOWN, /**< unknown */
+};
+
 namespace props {
 
 /**
@@ -1302,8 +1314,7 @@ public:
 
 /**
  * @brief Decay rate property
- *
- */
+ * */
 class DecayRate : public Property<float> {
 public:
   static constexpr const char *key = "decay_rate"; /**< unique key to access */
@@ -1329,6 +1340,29 @@ public:
   PropsUserData(void *user_data);
   static constexpr const char *key = "user_data";
   using prop_tag = ptr_prop_tag;
+};
+
+/**
+ * @brief     Enumeration of activation function type
+ */
+struct CheckPointStateInfo {
+  using Enum = nntrainer::CheckPointType;
+  static constexpr std::initializer_list<Enum> EnumList = {
+    Enum::CHECKPOINTED, Enum::NONCHECK_UNLOAD, Enum::NONCHECK_LOAD,
+    Enum::CHECKPOINT_UNKNOWN};
+  static constexpr const char *EnumStr[] = {"checkpointed", "unloaded",
+                                            "loaded", "unknown"};
+};
+
+/**
+ * @brief Checkpoint props
+ *
+ */
+class CheckPoint final : public EnumProperty<CheckPointStateInfo> {
+public:
+  static constexpr const char *key = "checkpoint";
+  using prop_tag = enum_class_prop_tag;
+  CheckPoint(CheckPointType value = CheckPointType::CHECKPOINTED);
 };
 
 } // namespace props

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -144,6 +144,7 @@ RunLayerContext::RunLayerContext(const std::string &name, bool trainable,
                                  CheckPointType checkpoint) :
   loss(l),
   in_place(in_place_),
+  out_used(0),
   weights(w),
   inputs(in),
   outputs(out),

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -10,6 +10,7 @@
  * @brief  This is the layer context for each layer
  */
 
+#include "common_properties.h"
 #include "nntrainer_error.h"
 #include <functional>
 #include <memory>
@@ -139,7 +140,8 @@ RunLayerContext::RunLayerContext(const std::string &name, bool trainable,
                                  const std::vector<Weight *> &w,
                                  const std::vector<Var_Grad *> &in,
                                  const std::vector<Var_Grad *> &out,
-                                 const std::vector<Var_Grad *> &t) :
+                                 const std::vector<Var_Grad *> &t,
+                                 CheckPointType checkpoint) :
   loss(l),
   in_place(in_place_),
   weights(w),
@@ -148,6 +150,7 @@ RunLayerContext::RunLayerContext(const std::string &name, bool trainable,
   tensors(t) {
   std::get<props::Name>(props).set(name);
   std::get<props::Trainable>(props).set(trainable);
+  std::get<props::CheckPoint>(props).set(checkpoint);
   NNTR_THROW_IF(!readyToUse(), std::invalid_argument)
     << "run context is not ready to use upon creation";
 

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -382,7 +382,8 @@ public:
                   bool in_place_, const std::vector<Weight *> &w,
                   const std::vector<Var_Grad *> &in,
                   const std::vector<Var_Grad *> &out,
-                  const std::vector<Var_Grad *> &t);
+                  const std::vector<Var_Grad *> &t,
+                  CheckPointType checkpoint = CheckPointType::CHECKPOINTED);
 
   /**
    * @brief Get the Weight tensor object
@@ -726,6 +727,15 @@ public:
   bool getTrainable() const { return std::get<props::Trainable>(props); }
 
   /**
+   * @brief   get trainable by the layer
+   *
+   * @return trainable of the layer
+   */
+  const props::CheckPoint &getCheckPoint() const {
+    return std::get<props::CheckPoint>(props);
+  }
+
+  /**
    * @brief   check if run context is set and is ready to use
    *
    * @return true if ready, else false
@@ -750,8 +760,9 @@ public:
   bool executeInPlace() const { return in_place; }
 
 private:
-  std::tuple<props::Name, props::Trainable> props; /**< props of the layer */
-  float loss;                                      /**< loss of the layer */
+  std::tuple<props::Name, props::Trainable, props::CheckPoint>
+    props;       /**< props of the layer */
+  float loss;    /**< loss of the layer */
   bool in_place; /**< if the layer is expected to run in-place */
 
   std::vector<Weight *> weights;   /**< weights of the layer */

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -112,6 +112,9 @@ public:
    */
   const std::vector<TensorDim> &getInputDimensions() const { return input_dim; }
 
+  /**
+   * @brief Set Input Data type
+   */
   void setInputDataType(TensorDim::DataType ty) {
     for (auto d : input_dim)
       d.setDataType(ty);
@@ -355,7 +358,7 @@ public:
    * @brief Construct a new Run Layer Context object
    *
    */
-  RunLayerContext() : loss(0.0), in_place(false) {}
+  RunLayerContext() : loss(0.0), in_place(false), out_used(0) {}
 
   /**
    * @brief Construct a new Run Layer Context object
@@ -736,6 +739,25 @@ public:
   }
 
   /**
+   * @brief   get trainable by the layer
+   *
+   * @param checkpoint checkpoint property
+   */
+  void setCheckPoint(const props::CheckPoint &checkpoint) {
+    std::get<props::CheckPoint>(props) = checkpoint;
+  }
+
+  /**
+   * @brief   get output used count
+   */
+  unsigned int getUsedCount() const { return out_used; }
+
+  /**
+   * @brief   set output used count
+   */
+  void setUsedCount(unsigned int count) { out_used = count; }
+
+  /**
    * @brief   check if run context is set and is ready to use
    *
    * @return true if ready, else false
@@ -764,6 +786,7 @@ private:
     props;       /**< props of the layer */
   float loss;    /**< loss of the layer */
   bool in_place; /**< if the layer is expected to run in-place */
+  int out_used;  /**< number of times the output is used */
 
   std::vector<Weight *> weights;   /**< weights of the layer */
   std::vector<Var_Grad *> inputs;  /**< inputs of the layer */

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -347,8 +347,10 @@ bool LayerNode::getTrainable() const {
 }
 
 void LayerNode::setCheckPoint(props::CheckPoint chekcpoint) {
-  // run_context's property can be set only while finalize.
-  std::get<props::CheckPoint>(*layer_node_props) = chekcpoint;
+  if (run_context)
+    run_context->setCheckPoint(chekcpoint);
+  else
+    std::get<props::CheckPoint>(*layer_node_props) = chekcpoint;
 }
 
 const props::CheckPoint LayerNode::getCheckPoint() const {
@@ -356,6 +358,18 @@ const props::CheckPoint LayerNode::getCheckPoint() const {
     return run_context->getCheckPoint();
   else
     return std::get<props::CheckPoint>(*layer_node_props);
+}
+
+unsigned int LayerNode::getUsedCount() const {
+  if (run_context)
+    return run_context->getUsedCount();
+
+  return 0;
+}
+
+void LayerNode::setUsedCount(unsigned int count) {
+  if (run_context)
+    run_context->setUsedCount(count);
 }
 
 bool LayerNode::getFlatten() const {
@@ -511,10 +525,10 @@ void LayerNode::clearOptVar() {
 InitLayerContext
 LayerNode::finalize(const std::vector<TensorDim> &input_dims,
                     std::array<const std::string, 3> tensor_type) {
-  // auto get_tensor_datatype = [](const std::string ty) -> TensorDim::DataType {
-  // 			       return from_string(ty);
+  // auto get_tensor_datatype = [](const std::string ty) -> TensorDim::DataType
+  // { 			       return from_string(ty);
   // };
-  
+
   if (run_context)
     throw std::runtime_error(
       "Trying to finalizing a layer which is already finalized in layer: " +

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -630,6 +630,16 @@ public:
   const props::CheckPoint getCheckPoint() const;
 
   /**
+   * @brief Get the checkpoint property
+   */
+  void setUsedCount(unsigned int count);
+
+  /**
+   * @brief Get the checkpoint property
+   */
+  unsigned int getUsedCount() const;
+
+  /**
    * @brief     read layer Weight & Bias data from file
    * @param file input file stream
    * @param bool read optimizer variables

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -24,6 +24,7 @@
 #ifndef __LAYER_NODE_H__
 #define __LAYER_NODE_H__
 
+#include "common_properties.h"
 #include <memory>
 #include <tuple>
 #include <vector>
@@ -619,6 +620,16 @@ public:
   }
 
   /**
+   * @brief Get the checkpoint property
+   */
+  void setCheckPoint(props::CheckPoint checkpoint);
+
+  /**
+   * @brief Get the checkpoint property
+   */
+  const props::CheckPoint getCheckPoint() const;
+
+  /**
    * @brief     read layer Weight & Bias data from file
    * @param file input file stream
    * @param bool read optimizer variables
@@ -720,6 +731,7 @@ public:
    * @param inputs inputs
    * @param outputs outputs
    * @param tensors tensors
+   * @param checkpoint checkpoint type
    */
   void configureRunContext(const std::vector<Weight *> &weights,
                            const std::vector<Var_Grad *> &inputs,
@@ -845,10 +857,11 @@ will also contain the properties of the layer. The properties will be copied
 upon final creation. Editing properties of the layer after init will not the
 properties in the context/graph unless intended. */
 
-  using PropsType = std::tuple<props::Name, props::Distribute, props::Trainable,
-                               std::vector<props::InputConnection>,
-                               std::vector<props::InputShape>,
-                               props::SharedFrom, props::ClipGradByGlobalNorm>;
+  using PropsType =
+    std::tuple<props::Name, props::Distribute, props::Trainable,
+               std::vector<props::InputConnection>,
+               std::vector<props::InputShape>, props::SharedFrom,
+               props::ClipGradByGlobalNorm, props::CheckPoint>;
 
   using RealizationPropsType = std::tuple<props::Flatten, props::Activation>;
   /** these realization properties results in addition of new layers, hence

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -815,6 +815,22 @@ public:
    */
   bool needsCalcGradient() { return needs_calc_gradient; }
 
+  /**
+   * @brief   Get the effective layer managed by this layer node
+   *
+   * @details this is layer inside the distribution layer if this layer node
+   * is distributed.
+   */
+  const nntrainer::Layer *getLayer() const;
+
+  /**
+   * @brief   Get the effective layer managed by this layer node
+   *
+   * @details this is layer inside the distribution layer if this layer node
+   * is distributed.
+   */
+  nntrainer::Layer *getLayer();
+
 private:
   /**
    * @brief     Get the Input Layers object
@@ -880,22 +896,6 @@ properties in the context/graph unless intended. */
   float regularization_loss;
   ExecutionOrder exec_order; /**< order/location of execution for this node
                                    in forward and backwarding operations */
-
-  /**
-   * @brief   Get the effective layer managed by this layer node
-   *
-   * @details this is layer inside the distribution layer if this layer node
-   * is distributed.
-   */
-  const nntrainer::Layer *getLayer() const;
-
-  /**
-   * @brief   Get the effective layer managed by this layer node
-   *
-   * @details this is layer inside the distribution layer if this layer node
-   * is distributed.
-   */
-  nntrainer::Layer *getLayer();
 
   /**
    * @brief anchor point to override if PRINT_SHAPE_INFO is enabled for

--- a/nntrainer/models/model_common_properties.cpp
+++ b/nntrainer/models/model_common_properties.cpp
@@ -36,4 +36,7 @@ MemorySwapPath::MemorySwapPath(const std::string &value) { set(value); }
 MemorySwapLookahead::MemorySwapLookahead(const unsigned int &value) {
   set(value);
 }
+
+CheckPointLen::CheckPointLen(const unsigned int &value) { set(value); }
+
 } // namespace nntrainer::props

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -202,7 +202,27 @@ public:
   ModelTensorDataType(ModelTensorDataTypeInfo::Enum value =
                         ModelTensorDataTypeInfo::Enum::W32A32) {
     set(value);
-  };
+  }
+};
+
+/**  
+ * @brief check point length property
+ *
+ * @note this is checkpoint distance property, nodes in network graph
+ * are checkpointed in every CheckPointLen, others are uncheckpointed.
+ */
+class CheckPointLen : public Property<unsigned int> {
+public:
+  static constexpr const char *key =
+    "checkpoint_len";            /**< unique key to access */
+  using prop_tag = uint_prop_tag; /**< property type */
+
+  /**
+   * @brief Constructor
+   *
+   * @param value value to set, defaults to current directory
+   */
+  CheckPointLen(const unsigned int &value = 0);
 };
 
 } // namespace nntrainer::props

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -70,7 +70,8 @@ NeuralNetwork::NeuralNetwork() :
     props::Epochs(), props::TrainingBatchSize(), props::SavePath(),
     props::ContinueTrain(), props::SaveBestPath(), props::MemoryOptimization(),
     props::MemorySwap(), props::MemorySwapPath(), props::MemorySwapLookahead(),
-    props::TensorFormat(), props::ModelTensorDataType()),
+    props::TensorFormat(), props::ModelTensorDataType(),
+    props::CheckPointLen()),
   load_path(std::string()),
   epoch_idx(0),
   iter(0),
@@ -88,7 +89,8 @@ NeuralNetwork::NeuralNetwork(AppContext app_context_) :
     props::Epochs(), props::TrainingBatchSize(), props::SavePath(),
     props::ContinueTrain(), props::SaveBestPath(), props::MemoryOptimization(),
     props::MemorySwap(), props::MemorySwapPath(), props::MemorySwapLookahead(),
-    props::TensorFormat(), props::ModelTensorDataType()),
+    props::TensorFormat(), props::ModelTensorDataType(),
+    props::CheckPointLen()),
   load_path(std::string()),
   epoch_idx(0),
   iter(0),
@@ -179,8 +181,11 @@ int NeuralNetwork::compile() {
   const std::string tensor_type =
     to_string(std::get<props::ModelTensorDataType>(model_flex_props));
 
-  model_graph = NetworkGraph(memory_swap, memory_swap_path, lookahead,
-                             tensor_format, tensor_type);
+  unsigned int checkpoint_len =
+    std::get<props::CheckPointLen>(model_flex_props);
+  model_graph =
+    NetworkGraph(memory_swap, memory_swap_path, lookahead, checkpoint_len,
+                 tensor_format, tensor_type);
 
   model_graph.setMemoryOptimizations(
     std::get<props::MemoryOptimization>(model_flex_props));

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -557,7 +557,8 @@ private:
                props::ContinueTrain, props::SaveBestPath,
                props::MemoryOptimization, props::MemorySwap,
                props::MemorySwapPath, props::MemorySwapLookahead,
-               props::TensorFormat, props::ModelTensorDataType>;
+               props::TensorFormat, props::ModelTensorDataType,
+               props::CheckPointLen>;
   using RigidPropTypes =
     std::tuple<props::LossType, std::vector<props::InputConnection>,
                std::vector<props::LabelLayer>, props::ClipGradByGlobalNorm>;

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -472,12 +472,19 @@ public:
    * @brief flush cache data except the order
    *
    * @param order except execution order
-   * @param lookahead preloading size
    * @note preloading loads execution order data asynchronously,
    *       for lookahead size. If new flush request arrives,
    *       it waits previous preloading is completed and invokes new one.
    */
   void flushCacheExcept(unsigned int order);
+
+  /**
+   * @brief reclaim temp data
+   */
+  void reclaim(unsigned int id) {
+    tensor_pool.reclaimTemp(id);
+    weight_pool.reclaimTemp(id);
+  }
 
 private:
   /** @todo: merge this list to one */

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -19,6 +19,7 @@
 
 #ifndef __MANAGER_H__
 #define __MANAGER_H__
+#include "common_properties.h"
 #include "tensor.h"
 #include "tensor_wrap_specs.h"
 #ifdef __cplusplus
@@ -31,6 +32,7 @@
 
 #include <basic_planner.h>
 #include <graph_node.h>
+#include <layer_node.h>
 #include <tensor_pool.h>
 #include <var_grad.h>
 #include <weight.h>
@@ -209,7 +211,8 @@ public:
    */
   std::vector<Var_Grad *> requestTensors(
     const GraphNode &node, const std::vector<Var_Grad::Spec> &tensors_spec,
-    bool trainable, const std::vector<std::string> &shared_names = {});
+    bool trainable, const std::vector<std::string> &shared_names = {},
+    bool is_temporary = false);
 
   /**
    * @brief     Create tensors with the given spec
@@ -242,7 +245,8 @@ public:
    */
   std::vector<Var_Grad *>
   requestInputs(const GraphNode &node, const std::vector<TensorDim> &inputs_dim,
-                const std::vector<std::string> &outputs_name = {});
+                const std::vector<std::string> &outputs_name = {},
+                const std::vector<bool> is_temporary = {});
 
   /**
    * @brief     Get all the weights which match the above condition
@@ -442,7 +446,8 @@ public:
                           TensorGroupType identify_as,
                           const GraphNode::ExecutionOrder &exec_order,
                           const std::string &scope = "",
-                          bool expose_var = false, bool expose_grad = false);
+                          bool expose_var = false, bool expose_grad = false,
+                          bool is_temporary = false);
 
   /**
    * @brief request vector of tensors with variable + gradient specification
@@ -458,10 +463,12 @@ public:
    * valid max_exec_order when allocation happens
    * @return Tensor* tensor
    */
-  std::vector<Var_Grad *> requestTensors(
-    const std::vector<VarGradSpecV2> &specs, TensorGroupType identify_as,
-    const GraphNode::ExecutionOrder &exec_order, const std::string &scope = "",
-    bool expose_var = false, bool expose_grad = false);
+  std::vector<Var_Grad *>
+  requestTensors(const std::vector<VarGradSpecV2> &specs,
+                 TensorGroupType identify_as,
+                 const GraphNode::ExecutionOrder &exec_order,
+                 const std::string &scope = "", bool expose_var = false,
+                 bool expose_grad = false, bool is_temporary = false);
 
   /**
    * @brief flush cache data
@@ -481,10 +488,7 @@ public:
   /**
    * @brief reclaim temp data
    */
-  void reclaim(unsigned int id) {
-    tensor_pool.reclaimTemp(id);
-    weight_pool.reclaimTemp(id);
-  }
+  bool reclaim(std::shared_ptr<LayerNode> layer, bool is_forwarding = true);
 
 private:
   /** @todo: merge this list to one */

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -86,7 +86,7 @@ public:
    * any allocation but rather just plans the layout and stores the layout.
    * Subsequent call to this function will overwrite any existing layout.
    */
-  double planLayout(const MemoryPlanner &planner);
+  virtual double planLayout(const MemoryPlanner &planner);
 
   /**
    * @brief Do the allocation of memory
@@ -116,14 +116,14 @@ public:
    *
    * @return The real memory requirement with this strategy in bytes
    */
-  size_t size();
+  virtual size_t size();
 
   /**
    * @brief Get the minimum theoretical memory requirement
    *
    * @return The theoretical memory requirement with this strategy in bytes
    */
-  size_t minMemoryRequirement();
+  virtual size_t minMemoryRequirement();
 
   /**
    * @brief Clear the memory pool

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -17,6 +17,7 @@ tensor_sources = [
   'optimized_v2_planner.cpp',
   'optimized_v3_planner.cpp',
   'task_executor.cpp',
+  'temp_pool.cpp',
 ]
 
 tensor_headers = [

--- a/nntrainer/tensor/temp_pool.cpp
+++ b/nntrainer/tensor/temp_pool.cpp
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2023 Jiho Chu <jiho.chu@samsung.com>
+ *
+ * @file   temp_pool.cpp
+ * @date   03 April 2023
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jiho Chu <jiho.chu@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Temporal data pool class inherited from memory pool
+ *
+ */
+
+#include "temp_pool.h"
+
+#include <limits>
+#include <malloc.h>
+#include <memory>
+#include <numeric>
+#include <stdexcept>
+#include <vector>
+
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <profiler.h>
+
+namespace {
+
+const unsigned int TEMPPOOL_INIT_ID = 0x10000;
+
+} // namespace
+
+namespace nntrainer {
+
+TempPool::TempPool() : allocated(false), next_id(TEMPPOOL_INIT_ID) {}
+
+TempPool::~TempPool() {
+  try {
+    deallocate();
+  } catch (...) {
+    ml_loge("Failed deallocate");
+  }
+}
+
+void TempPool::allocate() { allocated = true; }
+
+void TempPool::deallocate() {
+  reclaimAll();
+  allocated = false;
+}
+
+unsigned int TempPool::requestMemory(size_t bytes, unsigned int start_time,
+                                     unsigned int end_time,
+                                     std::vector<unsigned int> exec_order,
+                                     TensorLifespan lifespan, bool is_wgrad) {
+  next_id++;
+  data_size[next_id.load()] = bytes;
+
+  for (auto &order : exec_order) {
+    exec_orders[order].push_back(next_id.load());
+  }
+
+  return next_id.load();
+}
+
+double TempPool::planLayout(const MemoryPlanner &planner) {
+
+  // @todo: plan layout before allocating memory
+  return 1.0;
+}
+
+static unsigned int alloced = 0;
+static unsigned int max_alloced = 0;
+std::shared_ptr<MemoryData> TempPool::getMemory(unsigned int id) {
+  data[id] = std::make_shared<MemoryData>(
+    id,
+    [&](unsigned int id) {
+      data[id]->setAddr((float *)(new char[data_size[id]]()));
+      data[id]->setValid(true);
+
+      alloced += data_size[id];
+      max_alloced = std::max(max_alloced, alloced);
+    },
+    [&](unsigned int id) {
+      alloced -= data_size[id];
+      delete[] data[id]->getAddr();
+      data[id]->setValid(false);
+#ifndef __ANDROID__
+      malloc_trim(0);
+#endif
+    });
+
+  return data[id];
+}
+
+size_t TempPool::minMemoryRequirement() {
+  size_t total = 0;
+
+  for (auto &[id, dsize] : data_size)
+    total += dsize;
+
+  return total;
+}
+
+size_t TempPool::size() { return minMemoryRequirement(); }
+
+void TempPool::clear() {
+  next_id.store(TEMPPOOL_INIT_ID);
+  data.clear();
+  data_size.clear();
+  exec_orders.clear();
+}
+
+void TempPool::reclaim(unsigned int exec_order) {
+  for (auto &id : exec_orders[exec_order]) {
+    data[id]->invalidate();
+  }
+}
+
+void TempPool::reclaimAll() {
+  ml_logd("temp pool: max alloc size: %d", max_alloced);
+  for (auto &[id, d] : data)
+    d->invalidate();
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/temp_pool.h
+++ b/nntrainer/tensor/temp_pool.h
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2023 Jiho Chu <jiho.chu@samsung.com>
+ *
+ * @file   temp_pool.h
+ * @date   03 April 2023
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jiho Chu <jiho.chu@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Temporal data pool class inherited from memory pool
+ *
+ */
+
+#ifndef __TEMP_POOL_H__
+#define __TEMP_POOL_H__
+
+#include <atomic>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include <cache_elem.h>
+#include <memory_pool.h>
+#include <swap_device.h>
+
+namespace nntrainer {
+
+/**
+ * @class   TempPool
+ * @brief   Temporal data memory
+ */
+class TempPool : public MemoryPool {
+public:
+  /**
+   * @brief TempPool default constructor
+   *
+   * @param name name of the cache pool
+   */
+  explicit TempPool();
+
+  /**
+   * @brief MemoryPool destructor
+   *
+   */
+  virtual ~TempPool();
+
+  /**
+   * @brief Do the allocation of cache
+   *
+   */
+  virtual void allocate();
+
+  /**
+   * @brief Free all the allocated cache
+   *
+   */
+  virtual void deallocate();
+
+  /**
+   * @brief Request Memory from memory pool
+   * @note start_time is inclusive, but end_time is exclusive
+   */
+  virtual unsigned int requestMemory(
+    size_t bytes, unsigned int start_time, unsigned int end_time,
+    std::vector<unsigned int> exec_order = std::vector<unsigned int>(),
+    TensorLifespan lifespan = TensorLifespan::MAX_LIFESPAN,
+    bool is_wgrad = false);
+
+  /**
+   * @brief Get the allocated cache
+   *
+   * @param id The token received from the requestMemory
+   *
+   * @return The pointer of the cache
+   *
+   * @details This function will throw if called before allocation.
+   */
+  virtual std::shared_ptr<MemoryData> getMemory(unsigned int id);
+
+  /**
+   * @brief Plan the layout with memory planner
+   */
+  virtual double planLayout(const MemoryPlanner &planner);
+
+  /**
+   * @brief Is the cache pool allocated
+   *
+   * @return true if the memory is allocated, else false
+   */
+  virtual bool isAllocated() const { return allocated; }
+
+  /**
+   * @brief Reclaim temp memory
+   *
+   * @param exec_order The execution order of the graph
+   */
+  virtual void reclaim(unsigned int exec_order);
+
+  /**
+   * @brief Reclaim all temp memory
+   */
+  virtual void reclaimAll();
+
+  /**
+   * @brief Get the maximum real memory requirement
+   */
+  virtual size_t size();
+
+  /**
+   * @brief Clear the memory pool
+   *
+   */
+  virtual void clear();
+
+  /**
+   * @brief Get the minimum memory requirement
+   */
+  virtual size_t minMemoryRequirement();
+
+private:
+  bool allocated;           /**< is the memory allocated */
+  std::atomic_uint next_id; /**< The next id to be used */
+  std::unordered_map<unsigned int, std::shared_ptr<MemoryData>>
+    data; /**< memoty id to the memory data */
+  std::unordered_map<unsigned int, size_t>
+    data_size; /**< memory id to requested memroy size */
+  std::unordered_map<unsigned int, std::vector<unsigned int>>
+    exec_orders; /**< The execution order to memory id */
+};
+
+} // namespace nntrainer
+
+#endif /** __CACHE_POOL_H__ */

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -93,7 +93,7 @@ void Exporter::saveTflResult(
   const std::tuple<props::Name, props::Distribute, props::Trainable,
                    std::vector<props::InputConnection>,
                    std::vector<props::InputShape>, props::SharedFrom,
-                   props::ClipGradByGlobalNorm> &props,
+                   props::ClipGradByGlobalNorm, props::CheckPoint> &props,
   const LayerNode *self) {
   createIfNull(tf_node);
   tf_node->setLayerNode(*self);

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -245,7 +245,7 @@ void Exporter::saveTflResult(
   const std::tuple<props::Name, props::Distribute, props::Trainable,
                    std::vector<props::InputConnection>,
                    std::vector<props::InputShape>, props::SharedFrom,
-                   props::ClipGradByGlobalNorm> &props,
+                   props::ClipGradByGlobalNorm, props::CheckPoint> &props,
   const LayerNode *self);
 
 class BatchNormalizationLayer;


### PR DESCRIPTION
This patch is for checkpoint tensor load/unload.

For forward step, used unchecked node's tensors are reclaimed after
used. These reclaimed tensors are reloaded while backward step if it's
needed. And then, it will be unloaded, too.

Signed-off-by: Jiho Chu <jiho.chu@samsung.com>