### PR TITLE
[LOG] print output dim instead of input dim in model summary  @open sesame 06/13 14:48

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -1200,7 +1200,7 @@ void NeuralNetwork::print(std::ostream &out, unsigned int flags,
 
     out << std::string(total_col_size, '=') << '\n';
     print_graph_layer_info(
-      out, {"Layer name", "Layer type", "Input dimension", "Input layer"});
+      out, {"Layer name", "Layer type", "Output dimension", "Input layer"});
     out << std::string(total_col_size, '=') << '\n';
     if (compiled) {
       props::GenericShape dim_property;
@@ -1208,10 +1208,10 @@ void NeuralNetwork::print(std::ostream &out, unsigned int flags,
       for (auto iter = model_graph.cbegin(); iter != model_graph.cend();
            iter++) {
         std::string first_dim;
-        if (iter->getInputDimensions().empty()) {
+        if (iter->getOutputDimensions().empty()) {
           first_dim = "";
         } else {
-          dim_property.set(iter->getInputDimensions()[0]);
+          dim_property.set(iter->getOutputDimensions()[0]);
           first_dim = to_string(dim_property);
         }
         const std::vector<std::string> &input_layer_names =


### PR DESCRIPTION
When we print the model architecture using summarize method, nntrainer prints input dimension of each layer.

But, tensorflow and pytorch are printing output dimmension of each layer in the summary, thus it is inconvenient to compare each layer with tf and torch models.

Thus, I suggest to print output dimension of each layer instead of input dimension in the model summary.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped