### PR TITLE
[FullyConnected] Added NHWC support for FC_Layer inference part.

### DIFF
--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -66,7 +66,7 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
   context.setEffDimFlagInputDimension(0, 0b1001);
   context.setDynDimFlagInputDimension(0, 0b1000);
 
-  bool is_nchw = (getTensorType() == Tformat::NCHW) ? true : false;
+  bool is_nchw = (getTensorType() == Tformat::NCHW);
   /** set output dimensions */
   auto const &in_dim = context.getInputDimensions()[0];
   output_dims[0] = in_dim;

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -255,11 +255,9 @@ public:
    * @param     Tensor Type : NCHW or NHWC
    */
   void setTensorType(const std::string &values) {
-    if (values.compare("NCHW") || values.compare("nchw")) {
-      tensor_type = ml::train::TensorDim::Format::NCHW;
-    } else {
-      tensor_type = ml::train::TensorDim::Format::NHWC;
-    }
+    tensor_type = (values.compare("NCHW") == 0 || values.compare("nchw") == 0)
+                    ? ml::train::TensorDim::Format::NCHW
+                    : ml::train::TensorDim::Format::NHWC;
   }
 
   /**

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -249,9 +249,10 @@ void LayerNode::setOutputConnection(unsigned nth, const std::string &name,
 }
 
 void LayerNode::setTensorType(const std::string &type_) {
-  TensorDim::Format type = (type_.compare("NCHW") || type_.compare("nchw"))
-                             ? TensorDim::Format::NCHW
-                             : TensorDim::Format::NHWC;
+  TensorDim::Format type =
+    (type_.compare("NCHW") == 0 || type_.compare("nchw") == 0)
+      ? TensorDim::Format::NCHW
+      : TensorDim::Format::NHWC;
   getLayer()->setTensorType(type);
 }
 

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -927,7 +927,7 @@ std::vector<Tensor> Tensor::split(std::vector<size_t> sizes, int axis) {
     ret_dims[i].setTensorDim(axis, sizes[i]);
   }
 
-  bool is_format_nchw = (dim.getFormat() == Tformat::NCHW) ? true : false;
+  bool is_format_nchw = (dim.getFormat() == Tformat::NCHW);
 
   auto iter_value = [this, is_format_nchw](
                       std::array<size_t, 4> &loc,
@@ -1022,7 +1022,7 @@ Tensor Tensor::cat(const std::vector<Tensor> &tensors, int axis) {
     << "given tensor vector is empty";
 
   auto ref_dim = tensors.front().getDim();
-  bool is_format_nchw = (ref_dim.getFormat() == Tformat::NCHW) ? true : false;
+  bool is_format_nchw = (ref_dim.getFormat() == Tformat::NCHW);
   ref_dim.setTensorDim(axis, 1);
   NNTR_THROW_IF(!std::all_of(tensors.begin(), tensors.end(),
                              [&ref_dim, axis](const Tensor &t) {
@@ -1611,7 +1611,7 @@ Tensor &Tensor::transpose(const std::string &direction, Tensor &out) const {
 
   SL = dim.batch(), SI = dim.channel(), SJ = dim.height(), SK = dim.width();
 
-  bool is_format_nchw = (getFormat() == Tformat::NCHW) ? true : false;
+  bool is_format_nchw = (getFormat() == Tformat::NCHW);
 
   inptr = getData();
   outptr = out.getData();

--- a/test/unittest/layers/layers_golden_tests.cpp
+++ b/test/unittest/layers/layers_golden_tests.cpp
@@ -50,6 +50,10 @@ static InitLayerContext createInitContext(Layer *layer,
   std::vector<shape_parser_> parsed;
   from_string(input_shape_str, parsed);
 
+  for (auto &p : parsed) {
+    p.get().setFormat(layer->getTensorType());
+  }
+
   InitLayerContext context({parsed.begin(), parsed.end()}, {true}, false,
                            "golden_test");
   layer->finalize(context);

--- a/test/unittest/layers/unittest_layers_fully_connected.cpp
+++ b/test/unittest/layers/unittest_layers_fully_connected.cpp
@@ -38,6 +38,30 @@ auto fc_basic_no_decay = LayerGoldenTestParamType(
   {"unit=5", "weight_decay=0.0", "bias_decay=0.0"}, "3:1:1:10",
   "fc_plain.nnlayergolden", LayerGoldenTestParamOptions::DEFAULT, "nchw");
 
+auto fc_basic_plain_nhwc = LayerGoldenTestParamType(
+  nntrainer::createLayer<nntrainer::FullyConnectedLayer>, {"unit=5"},
+  "3:10:1:1", "fc_plain.nnlayergolden",
+  LayerGoldenTestParamOptions::SKIP_CALC_DERIV |
+    LayerGoldenTestParamOptions::SKIP_CALC_GRAD,
+  "nhwc");
+
+auto fc_basic_single_batch_nhwc = LayerGoldenTestParamType(
+  nntrainer::createLayer<nntrainer::FullyConnectedLayer>, {"unit=4"},
+  "1:10:1:1", "fc_single_batch.nnlayergolden",
+  LayerGoldenTestParamOptions::SKIP_CALC_DERIV |
+    LayerGoldenTestParamOptions::SKIP_CALC_GRAD,
+  "nhwc");
+
+auto fc_basic_no_decay_nhwc = LayerGoldenTestParamType(
+  nntrainer::createLayer<nntrainer::FullyConnectedLayer>,
+  {"unit=5", "weight_decay=0.0", "bias_decay=0.0"}, "3:10:1:1",
+  "fc_plain.nnlayergolden",
+  LayerGoldenTestParamOptions::SKIP_CALC_DERIV |
+    LayerGoldenTestParamOptions::SKIP_CALC_GRAD,
+  "nhwc");
+
 GTEST_PARAMETER_TEST(FullyConnected, LayerGoldenTest,
                      ::testing::Values(fc_basic_plain, fc_basic_single_batch,
-                                       fc_basic_no_decay));
+                                       fc_basic_no_decay, fc_basic_plain_nhwc,
+                                       fc_basic_single_batch_nhwc,
+                                       fc_basic_no_decay_nhwc));


### PR DESCRIPTION
This PR contains changes from the commits in [PR#2238](https://github.com/nnstreamer/nntrainer/pull/2238) and [PR#2240](https://github.com/nnstreamer/nntrainer/pull/2240) since these are required to evaluate the end to end working by the tests

Commit b57f0b222a6027b174575c60bc05fc7f759c6362 is the one that contains the newly added changes.

**Self evaluation:**
    1. Build test:   [X]Passed [ ]Failed [ ]Skipped
    2. Run test:     [X]Passed [ ]Failed [ ]Skipped