### PR TITLE
[graph_node] remove deprecated stl iterator

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,13 +34,16 @@ warning_flags = [
   '-Wformat-security',
   '-Winit-self',
   '-Waddress',
-  '-Wno-multichar',
   '-Wvla',
   '-Wpointer-arith',
-  '-Wno-error=varargs',
   '-Wdefaulted-function-deleted',
   '-ftree-vectorize',
-  '-Wno-unused-variable'
+  '-Wno-error=varargs',
+  '-Wno-multichar',
+  '-Wno-unused-variable',
+  '-Wno-unused-result',
+  '-Wno-array-bounds',
+  '-Wno-maybe-uninitialized'
 ]
 
 warning_c_flags = [

--- a/nnstreamer/tensor_filter/tensor_filter_nntrainer.hh
+++ b/nnstreamer/tensor_filter/tensor_filter_nntrainer.hh
@@ -16,6 +16,7 @@
  * Fill in "GstTensorFilterFramework" for tensor_filter.h/c
  *
  */
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -121,9 +121,7 @@ public:
  * @note    GraphNodeType is to enable for both GraphNode and const GraphNode
  */
 template <typename LayerNodeType, typename GraphNodeType>
-class GraphNodeIterator
-  : public std::iterator<std::random_access_iterator_tag, GraphNodeType,
-                         std::ptrdiff_t, GraphNodeType *, GraphNodeType &> {
+class GraphNodeIterator {
   GraphNodeType *p; /** underlying object of GraphNode */
 
 public:

--- a/nntrainer/layers/attention_layer.h
+++ b/nntrainer/layers/attention_layer.h
@@ -15,6 +15,8 @@
 #define __ATTENTION_LAYER_H__
 #ifdef __cplusplus
 
+#include <limits>
+
 #include <acti_func.h>
 #include <layer_devel.h>
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -247,7 +247,7 @@ void LayerNode::setOutputConnection(unsigned nth, const std::string &name,
   con = std::make_unique<Connection>(name, index);
 }
 
-void LayerNode::setTensorType(const std::string type_) {
+void LayerNode::setTensorType(const std::string &type_) {
   TensorDim::Format type = (type_.compare("NCHW") || type_.compare("nchw"))
                              ? TensorDim::Format::NCHW
                              : TensorDim::Format::NHWC;

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -806,7 +806,7 @@ public:
    *
    * @param type NCHW : NHWC
    */
-  void setTensorType(const std::string type_ = "NCHW");
+  void setTensorType(const std::string &type_ = "NCHW");
 
 private:
   /**

--- a/test/unittest/unittest_base_properties.cpp
+++ b/test/unittest/unittest_base_properties.cpp
@@ -315,8 +315,7 @@ TEST(BasicProperty, valid_p) {
     nntrainer::Exporter e;
     e.saveResult(props, ml::train::ExportMethods::METHOD_STRINGVECTOR);
 
-    auto result =
-      std::move(e.getResult<ml::train::ExportMethods::METHOD_STRINGVECTOR>());
+    auto result = e.getResult<ml::train::ExportMethods::METHOD_STRINGVECTOR>();
 
     auto pair = std::pair<std::string, std::string>("num_banana", "1");
     EXPECT_EQ(result->at(0), pair);


### PR DESCRIPTION
 - Remove inheriting the stl iterator as this is deprecated in c++17
 - Added no-* warning flags. These flags should be removed.