### PR TITLE
[sub-plugin] Add function to load an existing model

### DIFF
--- a/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.hh
+++ b/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.hh
@@ -106,6 +106,8 @@ public:
                                           NNStreamer(tensor_trainer) */
   std::string model_config;
   std::string model_save_path; /**< Model is finally stored */
+  std::string model_load_path; /**< Path to load an exisiting model to use for
+                                  training a new model */
 
   ml::train::RunStats train_stats;
   ml::train::RunStats valid_stats;


### PR DESCRIPTION
An existing model registered in model_load_path is used when training a new model.

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped