### PR TITLE
[Doc] Fix tizen reference link

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -146,7 +146,7 @@ ninja -C build install
 
 ## Build on Tizen
 
-Get GBS from <https://source.tizen.org/documentation/reference/git-build-system/usage/gbs-build>
+Get GBS from <https://docs.tizen.org/platform/developing/building/>
 
 First install the required packages.
 


### PR DESCRIPTION
## In this PR

Tizen reference link has been changed.
So, updated getting-started.md with the lastest link.

previous : https://source.tizen.org/documentation/reference/git-build-system/usage/gbs-build
updated :  https://docs.tizen.org/platform/developing/building


Thanks to this PR, I knew. **https://github.com/nnstreamer/nnstreamer/pull/4170**

================================
 **Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

================================

Signed-off-by: Donghak PARK <donghak.park@samsung.com>