### PR TITLE
[Cifar100] Fix Cifar100 Dataloader @open sesame 08/28 20:44

### DIFF
--- a/Applications/utils/datagen/cifar/cifar_dataloader.cpp
+++ b/Applications/utils/datagen/cifar/cifar_dataloader.cpp
@@ -136,7 +136,7 @@ void Cifar100DataLoader::next(float **input, float **label, bool *last) {
   /// @note below logic assumes a single input and the fine label is used
 
   auto fill_one_sample = [this](float *input_, float *label_, int index) {
-    const size_t error_buflen = 100;
+    const size_t error_buflen = 102;
     char error_buf[error_buflen];
     NNTR_THROW_IF(!file.good(), std::invalid_argument)
       << "file is not good, reason: "
@@ -144,7 +144,10 @@ void Cifar100DataLoader::next(float **input, float **label, bool *last) {
     file.seekg(index * Cifar100DataLoader::SampleSize, std::ios_base::beg);
 
     uint8_t current_label;
+    uint8_t fine_label; // it doesn't need for our application, so abandon it
+    file.read(reinterpret_cast<char *>(&fine_label), sizeof(uint8_t));
     file.read(reinterpret_cast<char *>(&current_label), sizeof(uint8_t));
+
     fillLabel(label_, Cifar100DataLoader::NumClass, current_label);
 
     for (unsigned int i = 0; i < Cifar100DataLoader::ImageSize; ++i) {

--- a/Applications/utils/datagen/cifar/cifar_dataloader.h
+++ b/Applications/utils/datagen/cifar/cifar_dataloader.h
@@ -111,7 +111,7 @@ private:
   inline static constexpr int ImageSize = 3 * 32 * 32;
   inline static constexpr int NumClass = 100;
   inline static constexpr int SampleSize =
-    4 * (3 * 32 * 32 + 100); /**< 1 coarse label, 1 fine label, pixel size */
+    4 * (3 * 32 * 32 + 2); /**< 1 coarse label, 1 fine label, pixel size */
 
   unsigned int batch;
   unsigned int current_iteration;


### PR DESCRIPTION
## In this PR

**Update Cifar100 Dataloader (Cifar100 Dataloader is not compatible with real Cifar100 dataset)**
- now our Cifar100 Dataloader can't load real Cifar100 dataset, cause of mismatch with dataset's shape
- Before : We Assume that Cifar100 dataset's shape ```<100 label><3072 pixel>``` per one image
- After : Actual Cifar100 dataset's shape ```<coarse 1 label><fine 1 label><3072 pixel>``` per one image

cause mismatch with dataset's shape Resnet real dataset example raise error.
After merge this pr we can run and test resnet with real dataset

""""""""""""""""""""""""""""""""""""""""""""""
**Self evaluation:**
_Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped_
""""""""""""""""""""""""""""""""""""""""""""""

Signed-off-by: Donghak PARK <donghak.park@samsung.com>