### PR TITLE
[SWAP] Fix cache pool policy

### DIFF
--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -56,7 +56,7 @@ convertTensorLifespanToCachePolicy(const TensorLifespan lifespan) {
     policy = CachePolicy::TEMPORAL;
     break;
   case TensorLifespan::CALC_GRAD_DERIV_LIFESPAN:
-    policy = CachePolicy::TEMPORAL;
+    policy = CachePolicy::ITERATION_CONSIST;
     break;
   case TensorLifespan::CALC_GRAD_DERIV_AGRAD_LIFESPAN:
     policy = CachePolicy::ITERATION_CONSIST;
@@ -65,7 +65,7 @@ convertTensorLifespanToCachePolicy(const TensorLifespan lifespan) {
     policy = CachePolicy::ITERATION_CONSIST;
     break;
   case TensorLifespan::FORWARD_GRAD_AGRAD_LIFESPAN:
-    policy = CachePolicy::ITERATION_CONSIST;
+    policy = CachePolicy::ALWAYS_SYNCED;
     break;
   case TensorLifespan::FORWARD_DERIV_LIFESPAN:
     policy = CachePolicy::ALWAYS_SYNCED;


### PR DESCRIPTION
calculating gradient and derivative for a tensor are operated
in a different layer. So, invalidation of data between each
calculation can be possible. It fixes to keep data instead of
throwing away.

Signed-off-by: Jiho Chu <jiho.chu@samsung.com>