### PR TITLE
[Tensor] Add erf operation to Tensor @open sesame 09/15 10:43

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -3258,6 +3258,31 @@ std::vector<unsigned int> Tensor::argmax() const {
   return result;
 }
 
+int Tensor::erf_i() {
+  erf(*this);
+  return ML_ERROR_NONE;
+}
+
+Tensor Tensor::erf() const {
+  Tensor t;
+  return erf(t);
+}
+
+Tensor &Tensor::erf(Tensor &out) const {
+  if (dim.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    auto f = [](float in) { return std::erf(in); };
+    apply<float>(f, out);
+  } else if (dim.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    auto f = [](_FP16 in) { return std::erf(in); };
+    apply<_FP16>(f, out);
+#else
+    throw std::invalid_argument("Error: enable-fp16 is not enabled");
+#endif
+  }
+  return out;
+}
+
 float Tensor::l2norm() const {
   NNTR_THROW_IF(!contiguous, std::invalid_argument)
     << getName() << " is not contiguous, cannot get l2norm.";


### PR DESCRIPTION
Added gaussian error function(erf) to Tensor
and unittest for this.

It was already added pr #2208,
but it is deleted in pr #2238 (I don't know why it is deleted).

So, I restored that function for our tensor operation.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped