### PR TITLE
[nnstreamer] Set dim value as 1 when nnstreamer give 0 value

### DIFF
--- a/nntrainer/layers/nnstreamer_layer.cpp
+++ b/nntrainer/layers/nnstreamer_layer.cpp
@@ -86,7 +86,7 @@ static int nnst_info_to_tensor_dim(ml_tensors_info_h &out_res, TensorDim &dim) {
     return status;
 
   for (size_t i = 0; i < ml::train::TensorDim::MAXDIM; i++)
-    dim.setTensorDim(i, dim_[i]);
+    dim.setTensorDim(i, dim_[i] > 0 ? dim_[i] : 1);
 
   /* reverse the dimension as nnstreamer stores dimension in reverse way */
   dim.reverse();


### PR DESCRIPTION
- Recently nnstreamer set 0 for padded value of dimensions.
- Let dimension value 1 for nntrainer when nns give 0.

REF: https://github.com/nnstreamer/nnstreamer/pull/4111