### PR TITLE
[blas/neon] NEON fp16 functions for Android(ARM)

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -134,8 +134,17 @@ static void scopy_FP16(const unsigned int N, const _FP16 *X, const int incX,
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
+#ifdef USE__FP16
+  if (incX == 1 && incY == 1) {
+    nntrainer::neon::scopy_neon_fp16(N, X, Y);
+  } else {
+    for (unsigned int i = 0; i < N; ++i)
+      Y[i * incy] = X[i * incx];
+  }
+#else
   for (unsigned int i = 0; i < N; ++i)
     Y[i * incy] = X[i * incx];
+#endif
 }
 
 void sscal(const unsigned int N, const float alpha, _FP16 *X, const int incX) {

--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -212,8 +212,22 @@ static void sgemm_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
 
 static unsigned int isamax_FP16(const unsigned int N, const _FP16 *X,
                                 const int incX) {
-
   unsigned int max_idx = 0;
+
+#ifdef USE__FP16
+  if (incX == 1 && N >= 8) {
+    max_idx = nntrainer::neon::isamax_neon_fp16(N, X);
+  } else {
+    _FP16 max_val = X[0];
+    for (unsigned int n = 1; n < N; n += incX) {
+      _FP16 cur_val = (X[n] >= 0) ? X[n] : -1 * X[n];
+      if (cur_val > max_val) {
+        max_val = cur_val;
+        max_idx = n;
+      }
+    }
+  }
+#else
   _FP16 max_val = X[0];
   for (unsigned int n = 1; n < N; n += incX) {
     _FP16 cur_val = (X[n] >= 0) ? X[n] : -1 * X[n];
@@ -222,6 +236,7 @@ static unsigned int isamax_FP16(const unsigned int N, const _FP16 *X,
       max_idx = n;
     }
   }
+#endif
 
   return max_idx;
 }

--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -141,8 +141,17 @@ static void scopy_FP16(const unsigned int N, const _FP16 *X, const int incX,
 void sscal(const unsigned int N, const float alpha, _FP16 *X, const int incX) {
   unsigned int incx = abs(incX);
 
+#ifdef USE__FP16
+  if (incX == 1) {
+    nntrainer::neon::sscal_neon_fp16(N, X, alpha);
+  } else {
+    for (unsigned int i = 0; i < N; ++i)
+      X[i * incx] = static_cast<_FP16>(alpha) * X[i * incx];
+  }
+#else
   for (unsigned int i = 0; i < N; ++i)
     X[i * incx] = static_cast<_FP16>(alpha) * X[i * incx];
+#endif
 }
 
 static _FP16 snrm2_FP16(const unsigned int N, const _FP16 *X, const int incX) {

--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -149,13 +149,24 @@ static _FP16 snrm2_FP16(const unsigned int N, const _FP16 *X, const int incX) {
   unsigned int incx = abs(incX);
   _FP16 sum = 0;
   _FP16 tmp;
-#pragma omp parallel for private(tmp) reduction(+ : sum)
+#ifdef USE__FP16
+  if (incX == 1) {
+    sum = nntrainer::neon::snrm2_neon_fp16(N, X);
+  } else {
+    for (unsigned int i = 0; i < N; i++) {
+      tmp = X[i * incx];
+      sum += tmp * tmp;
+    }
+  }
+#else
   for (unsigned int i = 0; i < N; i++) {
     tmp = X[i * incx];
     sum += tmp * tmp;
   }
+#endif
   return static_cast<_FP16>(sqrt(sum));
 }
+
 static void sgemm_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
                        CBLAS_TRANSPOSE TransB, const unsigned int M,
                        const unsigned int N, const unsigned int K,
@@ -297,7 +308,7 @@ static float snrm2_raw(const unsigned int N, const float *X, const int incX) {
   unsigned int incx = abs(incX);
   float sum = 0.0f;
   float tmp;
-#pragma omp parallel for private(tmp) reduction(+ : sum)
+
   for (unsigned int i = 0; i < N; i++) {
     tmp = X[i * incx];
     sum += tmp * tmp;

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -617,7 +617,6 @@ __fp16 sdot_neon_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y) {
 
   return ret;
 }
-#endif
 
 __fp16 snrm2_neon_fp16(const unsigned int N, const __fp16 *X) {
 
@@ -693,5 +692,27 @@ void sscal_neon_fp16(const unsigned int N, __fp16 *X, const float alpha) {
   for (; idx < N; idx++)
     X[idx] = alpha * X[idx];
 }
+
+void scopy_neon_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y) {
+
+  unsigned int idx = 0;
+
+  // processing batch of 8
+  for (; (N - idx) >= 8; idx += 8) {
+    float16x8_t batch = vld1q_f16(&X[idx]);
+    vst1q_f16(&Y[idx], batch);
+  }
+
+  // processing remaining batch of 4
+  for (; (N - idx) >= 4; idx += 4) {
+    float16x4_t batch = vld1_f16(&X[idx]);
+    vst1_f16(&Y[idx], batch);
+  }
+
+  // pocessing remaining values
+  for (; idx < N; idx++)
+    Y[idx] = X[idx];
+}
+#endif
 
 } // namespace nntrainer::neon

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -665,4 +665,33 @@ __fp16 snrm2_neon_fp16(const unsigned int N, const __fp16 *X) {
   return ret;
 }
 
+void sscal_neon_fp16(const unsigned int N, __fp16 *X, const float alpha) {
+  const float16x8_t v_alphaX8 = vmovq_n_f16(alpha);
+  const float16x4_t v_alphaX4 = vmov_n_f16(alpha);
+
+  unsigned int idx = 0;
+
+  // processing batch of 8
+  for (; (N - idx) >= 8; idx += 8) {
+    float16x8_t x = vld1q_f16(&X[idx]);
+
+    // alpha*X -> X
+    float16x8_t mulacc = vmulq_f16(v_alphaX8, x);
+    vst1q_f16(&X[idx], mulacc);
+  }
+
+  // processing remaining batch of 4
+  for (; (N - idx) >= 4; idx += 4) {
+    float16x4_t x = vld1_f16(&X[idx]);
+
+    // alpha*X -> X
+    float16x4_t mulacc = vmul_f16(v_alphaX4, x);
+    vst1_f16(&X[idx], mulacc);
+  }
+
+  // pocessing remaining values
+  for (; idx < N; idx++)
+    X[idx] = alpha * X[idx];
+}
+
 } // namespace nntrainer::neon

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -117,6 +117,13 @@ void sscal_neon_fp16(const unsigned int N, __fp16 *X, const float alpha);
  * @param[in] Y __fp16 * for Vector Y
  */
 void scopy_neon_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y);
+
+/**
+ * @brief     isamax function with neon: index of firt maxima
+ * @param[in] N number of elements in X
+ * @param[in] X __fp16 * for Vector X
+ */
+unsigned int isamax_neon_fp16(const unsigned int N, const __fp16 *X);
 #endif
 
 } // namespace nntrainer::neon

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -94,7 +94,6 @@ void saxpy_neon_fp16(const unsigned int N, const float alpha, const __fp16 *X,
  * @param[in] Y __fp16 * for Vector Y
  */
 __fp16 sdot_neon_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y);
-#endif
 
 /**
  * @brief     snrm2 computation with neon: Euclidean norm
@@ -110,6 +109,15 @@ __fp16 snrm2_neon_fp16(const unsigned int N, const __fp16 *X);
  * @param[in] alpha float number
  */
 void sscal_neon_fp16(const unsigned int N, __fp16 *X, const float alpha);
+
+/**
+ * @brief     copy function with neon: Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ */
+void scopy_neon_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y);
+#endif
 
 } // namespace nntrainer::neon
 

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -96,6 +96,14 @@ void saxpy_neon_fp16(const unsigned int N, const float alpha, const __fp16 *X,
 __fp16 sdot_neon_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y);
 #endif
 
+/**
+ * @brief     sdot computation with neon: sum of all X * Y
+ * @param[in] N number of elements in Y
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ */
+__fp16 snrm2_neon_fp16(const unsigned int N, const __fp16 *X);
+
 } // namespace nntrainer::neon
 
 #endif /* __cplusplus */

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -97,12 +97,19 @@ __fp16 sdot_neon_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y);
 #endif
 
 /**
- * @brief     sdot computation with neon: sum of all X * Y
- * @param[in] N number of elements in Y
+ * @brief     snrm2 computation with neon: Euclidean norm
+ * @param[in] N number of elements in X
  * @param[in] X __fp16 * for Vector X
- * @param[in] Y __fp16 * for Vector Y
  */
 __fp16 snrm2_neon_fp16(const unsigned int N, const __fp16 *X);
+
+/**
+ * @brief     sscal computation with neon: X = alpha * X
+ * @param[in] N number of elements in X
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] alpha float number
+ */
+void sscal_neon_fp16(const unsigned int N, __fp16 *X, const float alpha);
 
 } // namespace nntrainer::neon
 

--- a/test/unittest/unittest_nntrainer_tensor_neon_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_neon_fp16.cpp
@@ -132,9 +132,6 @@ TEST(nntrainer_Tensor, l2norm) {
   nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
     nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
 
-  // conditions for fp16 sdot call:
-  // this->(batch * channel * height) = arg->(width) = 1;
-
   size_t width = 23;
 
   __fp16 a_data[] = {0,   1.2, 2, 3.4, 4.1, 5.3, 2.9, 2.1, 1.4, 1.6, 0, 2.7,
@@ -246,6 +243,43 @@ TEST(nntrainer_Tensor, copy) {
 
   EXPECT_IN_RANGE(mseErrorNeon, 0, epsilon);
   EXPECT_IN_RANGE(cosSimNeon, 0.99, 1);
+}
+
+TEST(nntrainer_Tensor, max_abs) {
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp16 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16};
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  size_t width = 25;
+
+  __fp16 a_data[] = {0,   1.2, 2,   3.4, 4.1, 5.3, 2.9, 2.1, 1.4,
+                     1.6, 0,   2.7, 2.3, 1,   2,   1.1, 3.1, 1.1,
+                     2.8, 3.2, 2,   3.6, 1,   2.8, 7.9};
+  nntrainer::Tensor input(
+    nntrainer::TensorDim(1, 1, 1, width, t_type_nchw_fp16), a_data);
+
+  float a_data_fp32[] = {0,   1.2, 2,   3.4, 4.1, 5.3, 2.9, 2.1, 1.4,
+                         1.6, 0,   2.7, 2.3, 1,   2,   1.1, 3.1, 1.1,
+                         2.8, 3.2, 2,   3.6, 1,   2.8, 7.9};
+  nntrainer::Tensor input_fp32(
+    nntrainer::TensorDim(1, 1, 1, width, t_type_nchw_fp32), a_data_fp32);
+
+  __fp16 result_neon;
+  float result_fp32;
+
+  // NEON fp16
+  result_neon = input.max_abs();
+
+  // fp32
+  result_fp32 = input_fp32.max_abs();
+
+  // absolute error
+  const float epsilon = 1e-2;
+
+  EXPECT_NEAR(result_neon, result_fp32, epsilon);
 }
 
 GTEST_API_ int main(int argc, char **argv) {

--- a/test/unittest/unittest_nntrainer_tensor_neon_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_neon_fp16.cpp
@@ -124,6 +124,44 @@ TEST(nntrainer_Tensor, dot) {
   EXPECT_IN_RANGE((float)cosSimNeon, 0.99, 1);
 }
 
+TEST(nntrainer_Tensor, l2norm) {
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp16 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16};
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  // conditions for fp16 sdot call:
+  // this->(batch * channel * height) = arg->(width) = 1;
+
+  size_t width = 23;
+
+  __fp16 a_data[] = {0,  1.2, 2, 3.4, 4.1, 5.3, 2.9, 2.1, 1.4, 1.6, 0, 2.7,
+                     2.3, 1, 2, 1.1, 3.1, 1.1, 2.8, 3.2, 2, 3.6, 1};
+  nntrainer::Tensor input(
+    nntrainer::TensorDim(1, 1, 1, width, t_type_nchw_fp16), a_data);
+
+  float a_data_fp32[] = {0,  1.2, 2, 3.4, 4.1, 5.3, 2.9, 2.1, 1.4, 1.6, 0, 2.7,
+                     2.3, 1, 2, 1.1, 3.1, 1.1, 2.8, 3.2, 2, 3.6, 1};
+  nntrainer::Tensor input_fp32(
+    nntrainer::TensorDim(1, 1, 1, width, t_type_nchw_fp32), a_data_fp32);
+
+  __fp16 result_neon;
+  float result_fp32;
+
+  // NEON fp16
+  result_neon = input.l2norm();
+
+  // fp32
+  result_fp32 = input_fp32.l2norm();
+
+  // absolute error
+  const float epsilon = 1e-2;
+
+  EXPECT_NEAR(result_neon, result_fp32, epsilon);
+}
+
 GTEST_API_ int main(int argc, char **argv) {
   int result = -1;
 


### PR DESCRIPTION
## Commits to be reviewed in this PR

<details><summary>   Add NEON fp16 function for snrm2    </summary><br />

Enable neon snrm2 function for Android (ARM) fp16 computation. Add unit test for fp16 snrm2 function in Android(ARM).

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

</details>
<details><summary>   Add NEON fp16 function for sscal    </summary><br />

Enable neon sscal function for Android (ARM) fp16 computation. Add unit test for fp16 sscal function in Android(ARM).
Modified snrm2 function brief.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

</details>
<details><summary>   Add NEON fp16 function for scopy    </summary><br />

Enable neon scopy function for Android (ARM) fp16 computation. Add unit test for fp16 scopy function in Android(ARM).
Modified sscal unit test name to match with tensor name.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

</details>
<details><summary>   Add NEON fp16 function for isamax    </summary><br />

Enable neon isamax function for Android (ARM) fp16 computation. Add unit test for fp16 isamax function in Android(ARM).

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

</details>

Signed-off-by:s-debadri <s.debadri@samsung.com>
