### PR TITLE
[TensorPool] Check tensor type in view

### DIFF
--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -62,6 +62,13 @@ Tensor *TensorPool::view(const std::string &name, const std::string &reference,
                          const std::vector<unsigned int> &exec_order,
                          TensorLifespan lifespan, const size_t offset) {
   auto &spec = getSourceSpec(reference);
+
+  NNTR_THROW_IF(spec.tensor->getDataType() != dim.getDataType() ||
+                  spec.tensor->getFormat() != dim.getFormat(),
+                std::invalid_argument)
+    << "view tensor type != source tensor type, view tensor type: " << dim
+    << " source tensor: " << spec.tensor->getDim();
+
   unsigned adjusted_offset = std::visit(
     [](const auto &s) {
       using T = std::decay_t<decltype(s)>;


### PR DESCRIPTION
This PR enables the TensorPool view to filter call from different tensor type.

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped