### PR TITLE
[Ahub] Fix Ahub issue @open sesame 09/20 12:27

### DIFF
--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -12,9 +12,9 @@ subdir('Resnet/jni')
 subdir('YOLO/jni')
 subdir('ReinforcementLearning/DeepQ/jni')
 subdir('TransferLearning/CIFAR_Classification/jni')
-if enable_capi
-  subdir('TransferLearning/Draw_Classification/jni')
-endif
+# if enable_capi
+#   subdir('TransferLearning/Draw_Classification/jni')
+# endif
 subdir('Custom')
 subdir('ProductRatings/jni')
 subdir('AlexNet/jni')

--- a/nntrainer/compiler/multiout_realizer.cpp
+++ b/nntrainer/compiler/multiout_realizer.cpp
@@ -57,7 +57,7 @@ MultioutRealizer::realize(const GraphRepresentation &reference) {
     std::vector<std::shared_ptr<LayerNode>> /**< created node */>
     multiout_nodes;
 
-  for (auto con : connections) {
+  for (auto &con : connections) {
     unsigned freq = freq_map[con];
     /// @note freq < 1 should never happen as the map entry is not created.
     /// but if it happens multiout realizer is not interested in checking if it
@@ -102,7 +102,7 @@ MultioutRealizer::realize(const GraphRepresentation &reference) {
   for (auto &node : processed) {
     ret.push_back(node);
     auto ranges = multiout_nodes[node->getName()];
-    for (auto it : ranges) {
+    for (auto &it : ranges) {
       ret.push_back(it);
     }
   }

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -50,7 +50,7 @@ public:
     optimize_memory(true),
     exec_mode(ExecutionMode::TRAIN),
     tensor_format("NCHW"),
-    tensor_dtype(split("FP32-FP32", std::regex("\\-"))) {}
+    tensor_dtype(split("FP32-FP32", getRegex("\\-"))) {}
 
   /**
    * @brief     Constructor of NeuralNetwork Graph Class
@@ -72,7 +72,7 @@ public:
     optimize_memory(true),
     exec_mode(ExecutionMode::TRAIN),
     tensor_format(tensor_format_),
-    tensor_dtype(split(tensor_dtype_, std::regex("\\-"))) {}
+    tensor_dtype(split(tensor_dtype_, getRegex("\\-"))) {}
 
   /**
    * @brief   Destructor of the NeuralNetwork Graph class

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -70,7 +70,7 @@ void InputLayer::finalize(InitLayerContext &context) {
 
   std::vector<TensorDim> output_dims = context.getInputDimensions();
 
-  for (auto d : output_dims)
+  for (auto &d : output_dims)
     d.setTensorType({context.getFormat(), context.getActivationDataType()});
 
   context.setOutputDimensions(output_dims);

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -113,6 +113,13 @@ public:
   const std::vector<TensorDim> &getInputDimensions() const { return input_dim; }
 
   /**
+   * @brief Get the Mutable Input Dimensions object
+   *
+   * @return std::vector<TensorDim>& Input dimensions
+   */
+  std::vector<TensorDim> &getMutableInputDimensions() { return input_dim; }
+
+  /**
    * @brief Set Data Type for Input Dimensions
    *
    * @param ty data type to set

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -118,7 +118,7 @@ public:
    * @param ty data type to set
    */
   void setInputDataType(TensorDim::DataType ty) {
-    for (auto d : input_dim)
+    for (auto &d : input_dim)
       d.setDataType(ty);
   }
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -523,7 +523,7 @@ LayerNode::finalize(const std::vector<TensorDim> &input_dims,
       NNTR_THROW_IF(input_dims != actual_prop_dims, std::invalid_argument)
         << "calculated input dimension is different from given input_shape "
            "property";
-      for (auto d : actual_prop_dims) {
+      for (auto &d : actual_prop_dims) {
         d.setDataType(
           str_converter<enum_class_prop_tag, nntrainer::TensorDataTypeInfo>::
             from_string(tensor_type[2]));
@@ -545,7 +545,7 @@ LayerNode::finalize(const std::vector<TensorDim> &input_dims,
       << prop_dims.size();
     actual_input_dims =
       std::vector<TensorDim>(prop_dims.begin(), prop_dims.end());
-    for (auto d : actual_input_dims) {
+    for (auto &d : actual_input_dims) {
       /// Input Tensor type of input layer needs to be float.
       d.setDataType(
         str_converter<enum_class_prop_tag,

--- a/nntrainer/layers/loss/loss_layer.cpp
+++ b/nntrainer/layers/loss/loss_layer.cpp
@@ -18,7 +18,7 @@ namespace nntrainer {
 void LossLayer::finalize(InitLayerContext &context) {
   std::vector<TensorDim> input_dim = context.getInputDimensions();
   std::vector<TensorDim> output_dim = input_dim;
-  for (auto d : output_dim)
+  for (auto &d : output_dim)
     d.setDataType(
       str_converter<enum_class_prop_tag,
                     nntrainer::TensorDataTypeInfo>::from_string("FP32"));

--- a/nntrainer/nntrainer_logger.cpp
+++ b/nntrainer/nntrainer_logger.cpp
@@ -78,7 +78,7 @@ Logger::Logger() : ts_type(NNTRAINER_LOG_TIMESTAMP_SEC) {
      << std::setw(2) << now.tm_sec << ".out";
   outputstream.open(ss.str(), std::ios_base::app);
   if (!outputstream.good()) {
-    char buf[256];
+    char buf[256] = {0,};
     std::string cur_path = std::string(buf);
     std::string err_msg =
       "Unable to initialize the Logger on path(" + cur_path + ")";

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -515,17 +515,6 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
       __fp16 x = alpha * X[i];
 
       for (unsigned int j = 0; j < cols; j += 8) {
-        __fp16 *__restrict y = &Y[j];
-
-        float16x8_t y0_7 = vld1q_f16(&Y[j]);
-        float16x8_t wvec0_7 = vld1q_f16(&A[i * cols + j]);
-
-        y0_7 = vfmaq_n_f16(y0_7, wvec0_7, x);
-
-        float16x8_t wvec0_7;
-        const __fp16 *__restrict w;
-
-        w = &A[i * cols + j];
 
         float16x8_t y0_7 = vld1q_f16(&Y[j]);
         float16x8_t wvec0_7 = vld1q_f16(&A[i * cols + j]);

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -134,7 +134,7 @@ public:
     enable_optimizations(true),
     swap_lookahead(0),
     tensor_format("NCHW"),
-    tensor_dtype(split("FP32-FP32", std::regex("\\-"))) {}
+    tensor_dtype(split("FP32-FP32", getRegex("\\-"))) {}
 
   /**
    * @brief     Constructor of Manager
@@ -147,7 +147,7 @@ public:
     enable_optimizations(true),
     swap_lookahead(lookahead),
     tensor_format(tensor_format_),
-    tensor_dtype(split(tensor_dtype_, std::regex("\\-"))) {}
+    tensor_dtype(split(tensor_dtype_, getRegex("\\-"))) {}
 
   /**
    * @brief Construct a new Manager object (deleted)

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -2649,8 +2649,8 @@ void Tensor::print(std::ostream &out) const {
         }
         out << "-------" << std::endl;
       }
-      out.copyfmt(init);
     }
+    out.copyfmt(init);
   } else if (getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
     const _FP16 *data = getData<_FP16>();
@@ -2696,8 +2696,8 @@ void Tensor::print(std::ostream &out) const {
         }
         out << "-------" << std::endl;
       }
-      out.copyfmt(init);
     }
+    out.copyfmt(init);
 #else
     throw std::invalid_argument("Error: enable-fp16 is not enabled");
 #endif
@@ -2878,6 +2878,7 @@ void Tensor::print_(std::ostream &out, uint opt) const {
       out << getData<float>()[i] << ", ";
     }
   }
+  out.copyfmt(init);
 }
 
 std::ostream &operator<<(std::ostream &out, Tensor const &m) {

--- a/nntrainer/utils/util_func.cpp
+++ b/nntrainer/utils/util_func.cpp
@@ -189,6 +189,7 @@ std::vector<std::string> split(const std::string &s, const std::regex &reg) {
     str.erase(std::remove(str.begin(), str.end(), char_to_remove[i]),
               str.end());
   }
+
   std::regex_token_iterator<std::string::iterator> end;
   std::regex_token_iterator<std::string::iterator> iter(str.begin(), str.end(),
                                                         reg, -1);
@@ -225,6 +226,18 @@ tm *getLocaltime(tm *tp) {
 #else
   return localtime_r(&t, tp);
 #endif
+}
+
+std::regex getRegex(const std::string &str) {
+  std::regex result;
+
+  try {
+    result = std::regex(str);
+  } catch (const std::regex_error &e) {
+    ml_loge("regex_error caught: %s", e.what());
+  }
+
+  return result;
 }
 
 } // namespace nntrainer

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -300,6 +300,13 @@ char *getRealpath(const char *name, char *resolved);
  */
 tm *getLocaltime(tm *tp);
 
+/**
+ * @brief Create and return std::regex with the received string
+ * @param str String in regular expression form
+ * @return std::regex
+ */
+std::regex getRegex(const std::string &str);
+
 } /* namespace nntrainer */
 
 #endif /* __cplusplus */

--- a/test/unittest/compiler/compiler_test_util.cpp
+++ b/test/unittest/compiler/compiler_test_util.cpp
@@ -41,7 +41,7 @@ void graphEqual(const nntrainer::GraphRepresentation &lhs,
   if (lhs.size() == rhs.size()) {
     auto lhs_iter = lhs.cbegin();
     auto rhs_iter = rhs.cbegin();
-    while(lhs_iter != lhs.cend() || rhs_iter != rhs.cend()) {
+    while(lhs_iter != lhs.cend() && rhs_iter != rhs.cend()) {
       auto lhs = *lhs_iter;
       auto rhs = *rhs_iter;
       is_node_equal(*lhs.get(), *rhs.get());

--- a/test/unittest/layers/layers_golden_tests.cpp
+++ b/test/unittest/layers/layers_golden_tests.cpp
@@ -70,7 +70,7 @@ createInitContext(Layer *layer, const std::string &input_shape_str,
                            "golden_test", "", 0.0, tensor_type);
   layer->finalize(context);
 
-  for (auto dim : context.getInputDimensions()) {
+  for (auto &dim : context.getMutableInputDimensions()) {
     if (tensor_type[2] == "fp16") {
       dim.setDataType(ml::train::TensorDim::DataType::FP16);
     }


### PR DESCRIPTION
- Fixed the part where buf is not initialized and used in nntrainer_logger.cpp. 
Array initialized with ascii 0 ('\0').

- changed 'auto' to 'auto &'

- The 'initialized' variable receives a pointer via malloc.
If malloc fails, it will be null.
However, since the exception is not handled, calling initialize[i] points to null + i.
Exception handling has been added to prevent this problem.

- Restore does not work as expected after changing ostream type.
Added because there is no code to restore the variable out.
Changed the code where the nesting depth was set incorrectly to the correct location.

- Previously, nntrainer only supported fp32. nntrainer didn't need to change the data type, but it needs to be changed to support fp16.
If the tensor type is fp16, get input_dim of InitLayerContext through getInputDimentions and call setDataType. 
For getInputDimentions, return a const object. Added getMutableInputDimentions function because return object of getInputDimentions cannot be modified.

- The second argument of tensor_dtype is used as std::regex(string).
But it didn't include handling for std::regex_error.
created a getRegex() function because it is used in a similar form in other codes. 
The getRegex() function takes a string and retrun a std::regex object.