### PR TITLE
[ Wait for #2266] enable W16A16 for picoGPT Application

### DIFF
--- a/Applications/Android/PicoGPTJNI/app/src/main/res/layout/activity_main.xml
+++ b/Applications/Android/PicoGPTJNI/app/src/main/res/layout/activity_main.xml
@@ -32,7 +32,7 @@
           android:layout_height="186dp"
           android:orientation="horizontal"
           android:padding="10dp"
-          android:text="Alan Turing theorized that computers would one day become " />
+          android:text="Alan Turing theorized that computers would one day become" />
 
     </LinearLayout>
 

--- a/Applications/PicoGPT/jni/Android.mk
+++ b/Applications/PicoGPT/jni/Android.mk
@@ -43,12 +43,12 @@ LOCAL_ARM_NEON := true
 LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib
 LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/$(TARGET_ARCH_ABI)/
 LOCAL_CXXFLAGS += -std=c++17 -frtti
-LOCAL_CFLAGS += -pthread -fexceptions -fopenmp
-LOCAL_LDFLAGS += -fexceptions
+LOCAL_CFLAGS += -pthread -fexceptions -fopenmp -static-openmp
+LOCAL_LDFLAGS += -fexceptions -fopenmp -static-openmp
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_pico_gpt
-LOCAL_LDLIBS := -llog -landroid -fopenmp
+LOCAL_LDLIBS := -llog -landroid -fopenmp -static-openmp
 
 LOCAL_SRC_FILES := main.cpp
 

--- a/Applications/PicoGPT/jni/main.cpp
+++ b/Applications/PicoGPT/jni/main.cpp
@@ -386,6 +386,10 @@ int main(int argc, char *argv[]) {
     delete v;
   }
 
+  for (auto v : output_bufs) {
+    delete v;
+  }
+
   std::cout << std::endl;
   return 0;
 }

--- a/Applications/PicoGPT/jni/main.cpp
+++ b/Applications/PicoGPT/jni/main.cpp
@@ -40,6 +40,7 @@ const unsigned int MAX_TOKEN_LEN = 10 + NUM_TOKENS_TO_GENERATE;
 
 bool swap = false;
 bool optimize = false;
+// bool optimize = true;
 bool optimize_attention = false;
 
 #if defined(ENABLE_ENCODER)
@@ -58,6 +59,7 @@ std::shared_ptr<ml::train::Model> genModel() {
   model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
   model->setProperty({"batch_size=" + std::to_string(BATCH_SIZE),
                       "memory_optimization=false",
+                      "model_tensor_type=FP16-FP16",
                       swap ? "memory_swap=true" : "memory_swap=false"});
 
   std::shared_ptr<ml::train::Layer> wte_input = ml::train::layer::Input(
@@ -284,7 +286,7 @@ int main(int argc, char *argv[]) {
   std::string text = args[0];
 
   auto model = genModel();
-
+  model->summarize(std::cout, ML_TRAIN_SUMMARY_MODEL);
   try {
     model->compile();
   } catch (const std::exception &e) {
@@ -304,6 +306,10 @@ int main(int argc, char *argv[]) {
   //   std::string train_dataset_file_name = base + "pico_gpt_input.dat";
 
   model->load(weight_file_name, ml::train::ModelFormat::MODEL_FORMAT_BIN);
+
+  // model->save("pico_gpt_fp16.bin");
+
+  // exit(0);
 
   float *wte_input = new float[MAX_TOKEN_LEN];
   float *wpe_input = new float[MAX_TOKEN_LEN];
@@ -376,6 +382,10 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
+  for (auto v : wte_weights_buf) {
+    delete v;
+  }
+
   std::cout << std::endl;
   return 0;
 }

--- a/Applications/PicoGPT/jni/main.cpp
+++ b/Applications/PicoGPT/jni/main.cpp
@@ -27,16 +27,19 @@ const unsigned int BATCH_SIZE = 1;
 const unsigned int NUM_LAYERS = 12;
 const unsigned int NUM_HEADS = 12;
 const unsigned int MODEL_DIM = 768;
-const unsigned int FC_UNIT = 3072; // 768*4
+// @Todo: Need to check
+const unsigned int FC_UNIT = MODEL_DIM * 4;
 
 const unsigned int NUM_VOCAB = 50257;
 const unsigned int NUM_CTX = 1024;
 const unsigned int NUM_TOKENS_TO_GENERATE = 40;
 
-unsigned int init_input_seq_len = 10;
+unsigned int init_input_seq_len;
+// Todo: fix this
 const unsigned int MAX_TOKEN_LEN = 10 + NUM_TOKENS_TO_GENERATE;
 
 bool swap = false;
+bool optimize = false;
 bool optimize_attention = false;
 
 #if defined(ENABLE_ENCODER)
@@ -54,11 +57,11 @@ std::shared_ptr<ml::train::Model> genModel() {
   std::shared_ptr<ml::train::Model> model;
   model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
   model->setProperty({"batch_size=" + std::to_string(BATCH_SIZE),
+                      "memory_optimization=false",
                       swap ? "memory_swap=true" : "memory_swap=false"});
 
   std::shared_ptr<ml::train::Layer> wte_input = ml::train::layer::Input(
-    {"name=wte_input",
-     "input_shape=1:1:" + std::to_string(init_input_seq_len)});
+    {"name=wte_input", "input_shape=1:1:" + std::to_string(MAX_TOKEN_LEN)});
   model->addLayer(wte_input);
 
   std::shared_ptr<ml::train::Layer> wte = ml::train::layer::Embedding(
@@ -67,8 +70,7 @@ std::shared_ptr<ml::train::Model> genModel() {
   model->addLayer(wte);
 
   std::shared_ptr<ml::train::Layer> wpe_input = ml::train::layer::Input(
-    {"name=wpe_input",
-     "input_shape=1:1:" + std::to_string(init_input_seq_len)});
+    {"name=wpe_input", "input_shape=1:1:" + std::to_string(MAX_TOKEN_LEN)});
   model->addLayer(wpe_input);
 
   std::shared_ptr<ml::train::Layer> wpe = ml::train::layer::Embedding(
@@ -94,122 +96,133 @@ std::shared_ptr<ml::train::Model> genModel() {
       {"name=layer" + std::to_string(i) + "/multi_out1"});
     model->addLayer(multiout1);
 
-    std::string concat_input = "";
+    if (optimize) {
+      std::string concat_input = "";
 
-    for (unsigned int j = 0; j < NUM_HEADS; ++j) {
-      std::shared_ptr<ml::train::Layer> multi_head_attention_v_fc =
-        ml::train::layer::FullyConnected(
-          {"name=layer" + std::to_string(i) + "/multi_head_attention/v_fc" +
-             std::to_string(NUM_HEADS - 1 - j),
-           "input_layers=layer" + std::to_string(i) + "/multi_out1(" +
-             std::to_string(2 * NUM_HEADS + j) + ")",
-           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-      model->addLayer(multi_head_attention_v_fc);
-    }
-
-    for (unsigned int j = 0; j < NUM_HEADS; ++j) {
-      std::shared_ptr<ml::train::Layer> multi_head_attention_k_fc =
-        ml::train::layer::FullyConnected(
-          {"name=layer" + std::to_string(i) + "/multi_head_attention/k_fc" +
-             std::to_string(NUM_HEADS - 1 - j),
-           "input_layers=layer" + std::to_string(i) + "/multi_out1(" +
-             std::to_string(NUM_HEADS + j) + ")",
-           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-      model->addLayer(multi_head_attention_k_fc);
-    }
-
-    for (unsigned int j = 0; j < NUM_HEADS; ++j) {
-      std::shared_ptr<ml::train::Layer> multi_head_attention_q_fc =
-        ml::train::layer::FullyConnected(
-          {"name=layer" + std::to_string(i) + "/multi_head_attention/q_fc" +
-             std::to_string(NUM_HEADS - 1 - j),
-           "input_layers=layer" + std::to_string(i) + "/multi_out1(" +
-             std::to_string(j) + ")",
-           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-      model->addLayer(multi_head_attention_q_fc);
-    }
-
-    for (unsigned int j = 0; j < NUM_HEADS; ++j) {
-      if (optimize_attention) {
-        //   std::shared_ptr<ml::train::Layer> multi_head_attention_bwdp1 =
-        //     ml::train::layer::BatchwiseDotproduct(
-        //       {"name=layer" + std::to_string(i) +
-        //          "/multi_head_attention/bwdp1" +
-        //          std::to_string(NUM_HEADS - 1 - j),
-        //        "input_layers=layer" + std::to_string(i) +
-        //          "/multi_head_attention/q_fc" +
-        //          std::to_string(NUM_HEADS - 1 - j) + ",layer" +
-        //          std::to_string(i) + "/multi_head_attention/k_fc" +
-        //          std::to_string(NUM_HEADS - 1 - j),
-        //        "transpose_key=true", "scaled_dot_product=true",
-        //        "activation=softmax"});
-        //   model->addLayer(multi_head_attention_bwdp1);
-
-        //   std::shared_ptr<ml::train::Layer> multi_head_attention_bwdp2 =
-        //     ml::train::layer::BatchwiseDotproduct(
-        //       {"name=layer" + std::to_string(i) +
-        //          "/multi_head_attention/bwdp2" +
-        //          std::to_string(NUM_HEADS - 1 - j),
-        //        "input_layers=layer" + std::to_string(i) +
-        //          "/multi_head_attention/bwdp1" +
-        //          std::to_string(NUM_HEADS - 1 - j) + ",layer" +
-        //          std::to_string(i) + "/multi_head_attention/v_fc" +
-        //          std::to_string(NUM_HEADS - 1 - j)});
-        //   model->addLayer(multi_head_attention_bwdp2);
-
-        //   std::shared_ptr<ml::train::Layer>
-        //     multi_head_attention_attention = ml::train::layer::Identity(
-        //       {"name=layer" + std::to_string(i) +
-        //          "/multi_head_attention/attention" +
-        //          std::to_string(NUM_HEADS - 1 - j),
-        //        "input_layers=layer" + std::to_string(i) +
-        //          "/multi_head_attention/bwdp2" +
-        //          std::to_string(NUM_HEADS - 1 - j)});
-        //   model->addLayer(multi_head_attention_attention);
-      } else {
-        std::shared_ptr<ml::train::Layer> multi_head_attention_attention =
-          ml::train::layer::Attention(
-            {"name=layer" + std::to_string(i) +
-               "/multi_head_attention/attention" +
+      for (unsigned int j = 0; j < NUM_HEADS; ++j) {
+        std::shared_ptr<ml::train::Layer> multi_head_attention_v_fc =
+          ml::train::layer::FullyConnected(
+            {"name=layer" + std::to_string(i) + "/multi_head_attention/v_fc" +
                std::to_string(NUM_HEADS - 1 - j),
-             "input_layers=layer" + std::to_string(i) +
-               "/multi_head_attention/q_fc" +
-               std::to_string(NUM_HEADS - 1 - j) + ",layer" +
-               std::to_string(i) + "/multi_head_attention/v_fc" +
-               std::to_string(NUM_HEADS - 1 - j) + ",layer" +
-               std::to_string(i) + "/multi_head_attention/k_fc" +
-               std::to_string(NUM_HEADS - 1 - j),
-             "scaled_dot_product=true", "causal_mask=true"});
-        model->addLayer(multi_head_attention_attention);
+             "input_layers=layer" + std::to_string(i) + "/multi_out1(" +
+               std::to_string(2 * NUM_HEADS + j) + ")",
+             "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        model->addLayer(multi_head_attention_v_fc);
       }
 
-      concat_input += "layer" + std::to_string(i) +
-                      "/multi_head_attention/attention" + std::to_string(j);
-      if (j != NUM_HEADS - 1) {
-        concat_input += ",";
+      for (unsigned int j = 0; j < NUM_HEADS; ++j) {
+        std::shared_ptr<ml::train::Layer> multi_head_attention_k_fc =
+          ml::train::layer::FullyConnected(
+            {"name=layer" + std::to_string(i) + "/multi_head_attention/k_fc" +
+               std::to_string(NUM_HEADS - 1 - j),
+             "input_layers=layer" + std::to_string(i) + "/multi_out1(" +
+               std::to_string(NUM_HEADS + j) + ")",
+             "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        model->addLayer(multi_head_attention_k_fc);
       }
+
+      for (unsigned int j = 0; j < NUM_HEADS; ++j) {
+        std::shared_ptr<ml::train::Layer> multi_head_attention_q_fc =
+          ml::train::layer::FullyConnected(
+            {"name=layer" + std::to_string(i) + "/multi_head_attention/q_fc" +
+               std::to_string(NUM_HEADS - 1 - j),
+             "input_layers=layer" + std::to_string(i) + "/multi_out1(" +
+               std::to_string(j) + ")",
+             "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        model->addLayer(multi_head_attention_q_fc);
+      }
+
+      for (unsigned int j = 0; j < NUM_HEADS; ++j) {
+        if (optimize_attention) {
+          //   std::shared_ptr<ml::train::Layer> multi_head_attention_bwdp1 =
+          //     ml::train::layer::BatchwiseDotproduct(
+          //       {"name=layer" + std::to_string(i) +
+          //          "/multi_head_attention/bwdp1" +
+          //          std::to_string(NUM_HEADS - 1 - j),
+          //        "input_layers=layer" + std::to_string(i) +
+          //          "/multi_head_attention/q_fc" +
+          //          std::to_string(NUM_HEADS - 1 - j) + ",layer" +
+          //          std::to_string(i) + "/multi_head_attention/k_fc" +
+          //          std::to_string(NUM_HEADS - 1 - j),
+          //        "transpose_key=true", "scaled_dot_product=true",
+          //        "activation=softmax"});
+          //   model->addLayer(multi_head_attention_bwdp1);
+
+          //   std::shared_ptr<ml::train::Layer> multi_head_attention_bwdp2 =
+          //     ml::train::layer::BatchwiseDotproduct(
+          //       {"name=layer" + std::to_string(i) +
+          //          "/multi_head_attention/bwdp2" +
+          //          std::to_string(NUM_HEADS - 1 - j),
+          //        "input_layers=layer" + std::to_string(i) +
+          //          "/multi_head_attention/bwdp1" +
+          //          std::to_string(NUM_HEADS - 1 - j) + ",layer" +
+          //          std::to_string(i) + "/multi_head_attention/v_fc" +
+          //          std::to_string(NUM_HEADS - 1 - j)});
+          //   model->addLayer(multi_head_attention_bwdp2);
+
+          //   std::shared_ptr<ml::train::Layer>
+          //     multi_head_attention_attention = ml::train::layer::Identity(
+          //       {"name=layer" + std::to_string(i) +
+          //          "/multi_head_attention/attention" +
+          //          std::to_string(NUM_HEADS - 1 - j),
+          //        "input_layers=layer" + std::to_string(i) +
+          //          "/multi_head_attention/bwdp2" +
+          //          std::to_string(NUM_HEADS - 1 - j)});
+          //   model->addLayer(multi_head_attention_attention);
+        } else {
+          std::shared_ptr<ml::train::Layer> multi_head_attention_attention =
+            ml::train::layer::Attention(
+              {"name=layer" + std::to_string(i) +
+                 "/multi_head_attention/attention" +
+                 std::to_string(NUM_HEADS - 1 - j),
+               "input_layers=layer" + std::to_string(i) +
+                 "/multi_head_attention/q_fc" +
+                 std::to_string(NUM_HEADS - 1 - j) + ",layer" +
+                 std::to_string(i) + "/multi_head_attention/v_fc" +
+                 std::to_string(NUM_HEADS - 1 - j) + ",layer" +
+                 std::to_string(i) + "/multi_head_attention/k_fc" +
+                 std::to_string(NUM_HEADS - 1 - j),
+               "scaled_dot_product=true", "causal_mask=true"});
+          model->addLayer(multi_head_attention_attention);
+        }
+
+        concat_input += "layer" + std::to_string(i) +
+                        "/multi_head_attention/attention" + std::to_string(j);
+        if (j != NUM_HEADS - 1) {
+          concat_input += ",";
+        }
+      }
+
+      std::shared_ptr<ml::train::Layer> multi_head_attention_concat =
+        ml::train::layer::Concat(
+          {"name=layer" + std::to_string(i) + "/multi_head_attention/concat",
+           "input_layers=" + concat_input, "axis=3"});
+      model->addLayer(multi_head_attention_concat);
+
+      std::shared_ptr<ml::train::Layer> multi_head_attention_fc =
+        ml::train::layer::FullyConnected(
+          {"name=layer" + std::to_string(i) + "/multi_head_attention/fc",
+           "input_layers=layer" + std::to_string(i) +
+             "/multi_head_attention/concat",
+           "unit=" + std::to_string(MODEL_DIM)});
+      model->addLayer(multi_head_attention_fc);
+
+      std::shared_ptr<ml::train::Layer> multi_head_attention =
+        ml::train::layer::Identity(
+          {"name=layer" + std::to_string(i) + "/multi_head_attention",
+           "input_layers=layer" + std::to_string(i) +
+             "/multi_head_attention/fc"});
+      model->addLayer(multi_head_attention);
+    } else {
+      std::shared_ptr<ml::train::Layer> masked_multi_head_attention =
+        ml::train::layer::MultiHeadAttention(
+          {"name=layer" + std::to_string(i) + "/multi_head_attention",
+           "input_layers=layer" + std::to_string(i) + "/multi_out1(0), layer" +
+             std::to_string(i) + "/multi_out1(1), layer" + std::to_string(i) +
+             "/multi_out1(2)",
+           "num_heads=" + std::to_string(NUM_HEADS)});
+      model->addLayer(masked_multi_head_attention);
     }
-
-    std::shared_ptr<ml::train::Layer> multi_head_attention_concat =
-      ml::train::layer::Concat(
-        {"name=layer" + std::to_string(i) + "/multi_head_attention/concat",
-         "input_layers=" + concat_input, "axis=3"});
-    model->addLayer(multi_head_attention_concat);
-
-    std::shared_ptr<ml::train::Layer> multi_head_attention_fc =
-      ml::train::layer::FullyConnected(
-        {"name=layer" + std::to_string(i) + "/multi_head_attention/fc",
-         "input_layers=layer" + std::to_string(i) +
-           "/multi_head_attention/concat",
-         "unit=" + std::to_string(MODEL_DIM)});
-    model->addLayer(multi_head_attention_fc);
-
-    std::shared_ptr<ml::train::Layer> multi_head_attention =
-      ml::train::layer::Identity(
-        {"name=layer" + std::to_string(i) + "/multi_head_attention",
-         "input_layers=layer" + std::to_string(i) +
-           "/multi_head_attention/fc"});
-    model->addLayer(multi_head_attention);
 
     std::shared_ptr<ml::train::Layer> add1 = ml::train::layer::Addition(
       {"name=layer" + std::to_string(i) + "/add1",
@@ -292,9 +305,6 @@ int main(int argc, char *argv[]) {
 
   model->load(weight_file_name, ml::train::ModelFormat::MODEL_FORMAT_BIN);
 
-  // std::ifstream model_file(train_dataset_file_name,
-  //                          std::ios::in | std::ios::binary);
-
   float *wte_input = new float[MAX_TOKEN_LEN];
   float *wpe_input = new float[MAX_TOKEN_LEN];
 
@@ -325,22 +335,19 @@ int main(int argc, char *argv[]) {
     ((uint *)(wpe_input))[i] = i;
   }
 
-  // model_file.read((char *)input, DECODER_INPUT_SIZE * sizeof(float));
+  std::vector<float *> output_bufs;
 
-  for (unsigned int i = init_input_seq_len; i < MAX_TOKEN_LEN; ++i) {
-    std::vector<float *> output_bufs;
+  std::shared_ptr<ml::train::Layer> wte_embedding_layer;
+  model->getLayer("wte", &wte_embedding_layer);
+  const std::vector<float *> wte_weights_buf =
+    wte_embedding_layer->getWeights();
+  nntrainer::Tensor wte_weight =
+    nntrainer::Tensor({NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
 
-    for (unsigned int layer = 0; layer < NUM_LAYERS; ++layer) {
-      for (unsigned int head = 0; head < NUM_HEADS; ++head) {
-        std::shared_ptr<ml::train::Layer> attention_layer;
-        std::string layer_name = "layer" + std::to_string(layer) +
-                                 "/multi_head_attention/attention" +
-                                 std::to_string(NUM_HEADS - 1 - head);
-        model->getLayer(layer_name.c_str(), &attention_layer);
-      }
-    }
-
-    output_bufs = model->inference(BATCH_SIZE, {wte_input, wpe_input}, {});
+  for (unsigned int i = init_input_seq_len;
+       i < init_input_seq_len + NUM_TOKENS_TO_GENERATE; ++i) {
+    output_bufs = model->incremental_inference(
+      BATCH_SIZE, {wte_input, wpe_input}, {}, init_input_seq_len, i - 1);
 
     nntrainer::Tensor output({BATCH_SIZE, 1, i, MODEL_DIM}, output_bufs[0]);
 
@@ -368,14 +375,6 @@ int main(int argc, char *argv[]) {
     std::cerr << decoded_str << " " << std::flush;
 #endif
 
-    std::shared_ptr<ml::train::Layer> wte_input_layer;
-    model->getLayer("wte_input", &wte_input_layer);
-    wte_input_layer->setProperty({"input_shape=1:1:" + std::to_string(i + 1)});
-    std::shared_ptr<ml::train::Layer> wpe_input_layer;
-    model->getLayer("wpe_input", &wpe_input_layer);
-    wpe_input_layer->setProperty({"input_shape=1:1:" + std::to_string(i + 1)});
-
-    model->reinitialize();
   }
   std::cout << std::endl;
   return 0;

--- a/api/ccapi/include/common.h
+++ b/api/ccapi/include/common.h
@@ -33,6 +33,15 @@ enum class ExportMethods {
   METHOD_UNDEFINED = 999,  /**< undefined */
 };
 
+/**
+ * @brief   class telling the execution mode of the model/operation
+ */
+enum class ExecutionMode {
+  TRAIN,     /** Training mode, label is necessary */
+  INFERENCE, /** Inference mode, label is optional */
+  VALIDATE   /** Validate mode, label is necessary */
+};
+
 } // namespace train
 } // namespace ml
 

--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -204,6 +204,28 @@ public:
   virtual void getWeights(std::vector<float *> &weights,
                           std::vector<ml::train::TensorDim> &weights_dim) = 0;
 
+#ifdef ENABLE_FP16
+  /**
+   * @brief     Get weight data of the layer
+   * @retval    weight data of the layer
+   * @note      nntrainer assign the vector and if there is no weights, the size
+   * of vector is zero
+   * @note      layer needs to be finalized before called.
+   */
+  virtual const std::vector<_FP16 *> getFP16Weights() = 0;
+
+  /**
+   * @brief     Get weight data of the layer
+   * @retval    weights : float * arrary to store weight data
+   * @retval    weights_dim : TensorDim for each weights
+   * @note      nntrainer assign the vector and if there is no weights, the size
+   * of vector is zero
+   * @note      layer needs to be finalized before called.
+   */
+  virtual void
+  getFP16Weights(std::vector<_FP16 *> &weights,
+                 std::vector<ml::train::TensorDim> &weights_dim) = 0;
+#endif
   /**
    * @brief     Set weight data of the layer
    * @note      Size of vector must be the same with number of weights.

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -300,6 +300,21 @@ public:
                                          const std::vector<float *> &label) = 0;
 
   /**
+   * @brief     Run the incremental inference of the model
+   * @param[in] batch batch size of current input
+   * @param[in] input inputs as a list of each input data
+   * @param[in] label labels as a list of each label data
+   * @param[in] init_seq_len initial sequence length
+   * @param[in] cur_step current working step index (zero based index)
+   * @retval list of output as float *
+   * @note The output memory must not be freed by the caller
+   */
+  virtual std::vector<float *>
+  incremental_inference(unsigned int batch, const std::vector<float *> &input,
+                        const std::vector<float *> &label,
+                        unsigned int init_seq_len, unsigned int cur_step) = 0;
+
+  /**
    * @brief     Summarize the model
    * @param out std::ostream to get the model summary
    * @param verbosity verbosity of the summary

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -144,7 +144,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int initialize() = 0;
+  virtual int initialize(ExecutionMode exec_mode_ = ExecutionMode::TRAIN) = 0;
 
   /**
    * @brief     Reinitialize Network. This should be called after initialize

--- a/meson.build
+++ b/meson.build
@@ -61,9 +61,12 @@ if get_option('enable-fp16')
      add_project_arguments('-mfp16-format=ieee', language: ['c', 'cpp'])
      extra_defines += '-DENABLE_FP16=1'
      extra_defines += '-DUSE__FP16=1'
+     extra_defines += '-DUSE_NEON=1'
    elif arch == 'aarch64' or arch =='arm'
+     add_project_arguments('-mfp16-format=ieee', language: ['c', 'cpp'])
      extra_defines += '-DENABLE_FP16=1'
      extra_defines += '-DUSE__FP16=1'
+     extra_defines += '-DUSE_NEON=0'
    else
      has_avx512fp16 = cc.has_argument('-mavx512fp16')
      if (has_avx512fp16)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -34,7 +34,7 @@ option('enable-long-test', type: 'boolean', value: false)
 
 # backend options
 option('enable-blas', type: 'boolean', value: true)
-option('enable-fp16', type: 'boolean', value: true)
+option('enable-fp16', type: 'boolean', value: false)
 option('enable-cublas', type: 'boolean', value: false)
 option('enable-openmp', type: 'boolean', value: true)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -34,7 +34,7 @@ option('enable-long-test', type: 'boolean', value: false)
 
 # backend options
 option('enable-blas', type: 'boolean', value: true)
-option('enable-fp16', type: 'boolean', value: false)
+option('enable-fp16', type: 'boolean', value: true)
 option('enable-cublas', type: 'boolean', value: false)
 option('enable-openmp', type: 'boolean', value: true)
 

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -499,6 +499,8 @@ void NetworkGraph::allocateTensors(ExecutionMode exec_mode_) {
      * layer (as that will be the last layer to executed in the backwarding)
      * and pass that as the max_exec_order ensuring that all tensors with
      * usage less than the max_exec_order are allocated.
+     * @todo if model is gradient clipping, we have to add last execution order
+     * + 1
      */
     tensor_manager->allocateTensors(
       std::get<3>(backward_iter_end->getExecutionOrder()));
@@ -1087,9 +1089,12 @@ NetworkGraph::getLayerExecutionOrders(const std::shared_ptr<LayerNode> &lnode) {
 
 #endif // ENABLE_TEST
 
-int NetworkGraph::initialize(const std::vector<Connection> &model_input_names,
+int NetworkGraph::initialize(ExecutionMode mode,
+                             const std::vector<Connection> &model_input_names,
                              const std::vector<Connection> &model_label_names) {
 
+  exec_mode = mode;
+  tensor_manager->setExecutionMode(mode);
   /**
    * this contains the map from node name to its input tensor names
    * @note: these input tensors have already been allocated

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -185,6 +185,21 @@ public:
     void *user_data = nullptr);
 
   /**
+   * @brief     forwarding network graph
+   * @param[in] from start step
+   * @param[in] to end step
+   * @param[in] training true if forwarding is on training
+   * @retval output tensors
+   */
+  sharedConstTensors incremental_forwarding(
+    unsigned int from, unsigned int to, bool training = false,
+    std::function<void(std::shared_ptr<LayerNode>, bool)> forwarding_op =
+      [](std::shared_ptr<LayerNode>, bool) {},
+    std::function<bool(void *userdata)> stop_cb =
+      [](void *user_data) { return false; },
+    void *user_data = nullptr);
+
+  /**
    * @brief     backwarding the network graph
    * @param[in] iteration current iteration number
    * @param[in] backwarding_op operation for the backwarding

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -21,12 +21,13 @@
 #include <stack>
 #include <vector>
 
-#include <execution_mode.h>
 #include <graph_core.h>
 #include <layer_node.h>
 #include <manager.h>
 
 namespace nntrainer {
+
+using ExecutionMode = ml::train::ExecutionMode;
 
 class Connection;
 /**
@@ -299,7 +300,8 @@ public:
    * that can be labels will be identified in the sort order
    * @return int ML_ERROR_NONE if successful
    */
-  int initialize(const std::vector<Connection> &model_input_names = {},
+  int initialize(ExecutionMode mode = ExecutionMode::TRAIN,
+                 const std::vector<Connection> &model_input_names = {},
                  const std::vector<Connection> &model_label_names = {});
 
   /**

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -389,7 +389,7 @@ public:
    */
   template <typename T = float>
   static Tensor &gelu(Tensor const &t_in, Tensor &t_out) {
-    T tmp = static_cast<T>(1 / sqrt(2));
+    double tmp = 1.0 / sqrt(2.0);
     t_in.apply<T>(
       [&](T x) { return static_cast<T>(0.5 * x * (1 + erf(x * tmp))); }, t_out);
     return t_out;

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -95,7 +95,8 @@ void ActivationLayer::incremental_forwarding(RunLayerContext &context,
   Tensor hidden_step = hidden_.getSharedDataTensor(
     hidden_step_dim, from * hidden_dim.width(), true);
   acti_func.run_fn(input_step, hidden_step);
-  // hidden_step.print(std::cout);
+  //std::cout <<"Activation"<< std::endl;
+  //hidden_step.print(std::cout);
 }
 
 void ActivationLayer::calcDerivative(RunLayerContext &context) {

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -43,7 +43,11 @@ void ActivationLayer::finalize(InitLayerContext &context) {
   auto &act = std::get<props::Activation>(*activation_props);
   NNTR_THROW_IF(act.empty(), std::invalid_argument)
     << "activation has not been set!";
-  acti_func.setActiFunc(act.get());
+  if (context.getActivationDataType() == TensorDim::DataType::FP16) {
+    acti_func.setActiFunc<_FP16>(act.get());
+  } else if (context.getActivationDataType() == TensorDim::DataType::FP32) {
+    acti_func.setActiFunc<float>(act.get());
+  }
 
   NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
     << "activation layer, " << context.getName()
@@ -75,19 +79,23 @@ void ActivationLayer::incremental_forwarding(RunLayerContext &context,
   TensorDim input_dim = input_.getDim();
   TensorDim hidden_dim = hidden_.getDim();
 
-  TensorDim input_step_dim = {input_dim.batch(), input_dim.channel(), to - from,
-                              input_dim.width()};
-  TensorDim hidden_step_dim = {hidden_dim.batch(), hidden_dim.channel(),
-                               to - from, hidden_dim.width()};
+  TensorDim input_step_dim = input_dim;
+  TensorDim hidden_step_dim = hidden_dim;
+  input_step_dim.height(to - from);
+  hidden_step_dim.height(to - from);
 
+  /* TensorDim input_step_dim = {input_dim.batch(), input_dim.channel(), to -
+  from, input_dim.width()}; TensorDim hidden_step_dim = {hidden_dim.batch(),
+  hidden_dim.channel(), to - from, hidden_dim.width()};
+ */
   // @todo: set reset stride as false. This implementation only works when batch
   // size is 1
   Tensor input_step =
     input_.getSharedDataTensor(input_step_dim, from * input_dim.width(), true);
   Tensor hidden_step = hidden_.getSharedDataTensor(
     hidden_step_dim, from * hidden_dim.width(), true);
-
   acti_func.run_fn(input_step, hidden_step);
+  // hidden_step.print(std::cout);
 }
 
 void ActivationLayer::calcDerivative(RunLayerContext &context) {

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -66,6 +66,30 @@ void ActivationLayer::forwarding(RunLayerContext &context, bool training) {
   acti_func.run_fn(input_, hidden_);
 }
 
+void ActivationLayer::incremental_forwarding(RunLayerContext &context,
+                                             unsigned int from, unsigned int to,
+                                             bool training) {
+  Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
+  Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+
+  TensorDim input_dim = input_.getDim();
+  TensorDim hidden_dim = hidden_.getDim();
+
+  TensorDim input_step_dim = {input_dim.batch(), input_dim.channel(), to - from,
+                              input_dim.width()};
+  TensorDim hidden_step_dim = {hidden_dim.batch(), hidden_dim.channel(),
+                               to - from, hidden_dim.width()};
+
+  // @todo: set reset stride as false. This implementation only works when batch
+  // size is 1
+  Tensor input_step =
+    input_.getSharedDataTensor(input_step_dim, from * input_dim.width(), true);
+  Tensor hidden_step = hidden_.getSharedDataTensor(
+    hidden_step_dim, from * hidden_dim.width(), true);
+
+  acti_func.run_fn(input_step, hidden_step);
+}
+
 void ActivationLayer::calcDerivative(RunLayerContext &context) {
   const Tensor &deriv = context.getIncomingDerivative(SINGLE_INOUT_IDX);
   Tensor &ret = context.getOutgoingDerivative(SINGLE_INOUT_IDX);

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -50,6 +50,13 @@ public:
   void forwarding(RunLayerContext &context, bool training) override;
 
   /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(RunLayerContext &context, unsigned int from,
+                              unsigned int to, bool training) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(RunLayerContext &context) override;

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -48,8 +48,7 @@ void AdditionLayer::incremental_forwarding(RunLayerContext &context,
   TensorDim hidden_step_dim = hidden_dim;
   hidden_step_dim.height(to - from);
 
-  Tensor hidden_step = hidden_.getSharedDataTensor(
-    hidden_step_dim, from * hidden_dim.width(), true);
+  Tensor hidden_step = hidden_.getSharedDataTensor(hidden_step_dim, 0, true);
 
   /** @todo check possibility for in-place of addition layer */
   for (unsigned int idx = 0; idx < context.getNumInputs(); ++idx) {
@@ -59,16 +58,13 @@ void AdditionLayer::incremental_forwarding(RunLayerContext &context,
     TensorDim input_step_dim = input_dim;
     input_step_dim.height(to - from);
 
-    Tensor input_step = input_.getSharedDataTensor(
-      input_step_dim, from * input_dim.width(), true);
+    Tensor input_step = input_.getSharedDataTensor(input_step_dim, 0, true);
     if (!idx) {
       hidden_step.copy(input_step);
     } else {
       hidden_step.add_i(input_step);
     }
   }
-  //std::cout <<"addition"<< std::endl;
-  //hidden_step.print(std::cout);
 }
 
 void AdditionLayer::calcDerivative(RunLayerContext &context) {

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -67,7 +67,8 @@ void AdditionLayer::incremental_forwarding(RunLayerContext &context,
       hidden_step.add_i(input_step);
     }
   }
-  // hidden_step.print(std::cout);
+  //std::cout <<"addition"<< std::endl;
+  //hidden_step.print(std::cout);
 }
 
 void AdditionLayer::calcDerivative(RunLayerContext &context) {

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -45,8 +45,9 @@ void AdditionLayer::incremental_forwarding(RunLayerContext &context,
                                            bool training) {
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
   TensorDim hidden_dim = hidden_.getDim();
-  TensorDim hidden_step_dim = {hidden_dim.batch(), hidden_dim.channel(),
-                               to - from, hidden_dim.width()};
+  TensorDim hidden_step_dim = hidden_dim;
+  hidden_step_dim.height(to - from);
+
   Tensor hidden_step = hidden_.getSharedDataTensor(
     hidden_step_dim, from * hidden_dim.width(), true);
 
@@ -54,8 +55,10 @@ void AdditionLayer::incremental_forwarding(RunLayerContext &context,
   for (unsigned int idx = 0; idx < context.getNumInputs(); ++idx) {
     const Tensor &input_ = context.getInput(idx);
     TensorDim input_dim = input_.getDim();
-    TensorDim input_step_dim = {input_dim.batch(), input_dim.channel(),
-                                to - from, input_dim.width()};
+
+    TensorDim input_step_dim = input_dim;
+    input_step_dim.height(to - from);
+
     Tensor input_step = input_.getSharedDataTensor(
       input_step_dim, from * input_dim.width(), true);
     if (!idx) {
@@ -64,6 +67,7 @@ void AdditionLayer::incremental_forwarding(RunLayerContext &context,
       hidden_step.add_i(input_step);
     }
   }
+  // hidden_step.print(std::cout);
 }
 
 void AdditionLayer::calcDerivative(RunLayerContext &context) {

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -58,6 +58,13 @@ public:
   void forwarding(RunLayerContext &context, bool training) override;
 
   /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(RunLayerContext &context, unsigned int from,
+                              unsigned int to, bool training) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(RunLayerContext &context) override;

--- a/nntrainer/layers/attention_layer.cpp
+++ b/nntrainer/layers/attention_layer.cpp
@@ -116,6 +116,68 @@ void AttentionLayer::forwarding(RunLayerContext &context, bool training) {
   weights.dotBatched(value, output); /** dot 2 */
 }
 
+void AttentionLayer::incremental_forwarding(RunLayerContext &context,
+                                            unsigned int from, unsigned int to,
+                                            bool training) {
+  Tensor &query = context.getInput(wt_idx[AttentionParams::query]);
+  Tensor &value = context.getInput(wt_idx[AttentionParams::value]);
+  Tensor &key = context.getInput(wt_idx[AttentionParams::key]);
+
+  TensorDim query_dim = query.getDim();
+  TensorDim value_dim = value.getDim();
+  TensorDim key_dim = key.getDim();
+  TensorDim query_step_dim = {query_dim.batch(), query_dim.channel(), to - from,
+                              query_dim.width()};
+  TensorDim value_step_dim = {value_dim.batch(), value_dim.channel(), to,
+                              value_dim.width()};
+  TensorDim key_step_dim = {key_dim.batch(), key_dim.channel(), to,
+                            key_dim.width()};
+  Tensor query_step =
+    query.getSharedDataTensor(query_step_dim, from * query_dim.width(), true);
+  Tensor value_step = value.getSharedDataTensor(value_step_dim, 0, true);
+  Tensor key_step = key.getSharedDataTensor(key_step_dim, 0, true);
+
+  Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+  TensorDim output_dim = output.getDim();
+  TensorDim output_step_dim = {output_dim.batch(), output_dim.channel(),
+                               to - from, output_dim.width()};
+  Tensor output_step = output.getSharedDataTensor(
+    output_step_dim, from * output_dim.width(), true);
+
+  Tensor &weights = context.getTensor(wt_idx[AttentionParams::weights]);
+  TensorDim weights_dim = weights.getDim();
+  TensorDim weights_step_dim = {
+    query_step_dim.batch(), query_step_dim.channel(), query_step_dim.height(),
+    value_step_dim.height()};
+  Tensor weights_step = weights.getSharedDataTensor(
+    weights_step_dim, from * weights_dim.width(), true);
+
+  query_step.dotBatched(key_step, weights_step, false, true); /** dot 1 */
+  if (std::get<props::ScaledDotProduct>(attention_props).get()) {
+    weights_step.multiply_i(1 / sqrt((float)key.getDim().width()));
+  }
+
+  if (std::get<props::CausalMask>(attention_props).get() && !from) {
+    unsigned int mask_size = weights_step.getDim().width();
+    unsigned int mask_dim_height = mask_size;
+    unsigned int mask_dim_width = mask_size;
+
+    Tensor causal_mask(TensorDim{mask_size, mask_size});
+
+    causal_mask.setZero();
+    for (unsigned int i = 0; i < mask_dim_height; ++i) {
+      for (unsigned int j = i + 1; j < mask_dim_width; ++j) {
+        causal_mask.setValue(0, 0, i, j, -1e10);
+      }
+    }
+
+    weights_step.add_i(causal_mask);
+  }
+
+  sm.run_fn(weights_step, weights_step);            /** softmax */
+  weights_step.dotBatched(value_step, output_step); /** dot 2 */
+}
+
 void AttentionLayer::calcDerivative(RunLayerContext &context) {
   const Tensor &derivative = context.getIncomingDerivative(SINGLE_INOUT_IDX);
 

--- a/nntrainer/layers/attention_layer.h
+++ b/nntrainer/layers/attention_layer.h
@@ -61,6 +61,13 @@ public:
   void forwarding(RunLayerContext &context, bool training) override;
 
   /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(RunLayerContext &context, unsigned int from,
+                              unsigned int to, bool training) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(RunLayerContext &context) override;

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -59,6 +59,13 @@ public:
   void forwarding(RunLayerContext &context, bool training) override;
 
   /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(RunLayerContext &context, unsigned int from,
+                              unsigned int to, bool training) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(RunLayerContext &context) override;

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -179,7 +179,8 @@ void EmbeddingLayer::incremental_forwarding(RunLayerContext &context,
 
       // std::copy(weight_data, weight_data + out_dim, out_data);
     }
-    //hidden_.print(std::cout);
+    // std::cout <<"embedding"<< std::endl;
+    // hidden_.print(std::cout);
   }
 }
 

--- a/nntrainer/layers/embedding.h
+++ b/nntrainer/layers/embedding.h
@@ -60,6 +60,13 @@ public:
   void forwarding(RunLayerContext &context, bool training) override;
 
   /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(RunLayerContext &context, unsigned int from,
+                              unsigned int to, bool training) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(RunLayerContext &context) override;

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -146,6 +146,39 @@ void FullyConnectedLayer::forwarding(RunLayerContext &context, bool training) {
   }
 }
 
+void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
+                                                 unsigned int from,
+                                                 unsigned int to,
+                                                 bool training) {
+  Tensor &weight = context.getWeight(weight_idx[FCParams::weight]);
+
+  Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+  Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
+
+  TensorDim input_dim = input_.getDim();
+  TensorDim hidden_dim = hidden_.getDim();
+
+  TensorDim input_step_dim = {input_dim.batch(), input_dim.channel(), to - from,
+                              input_dim.width()};
+  TensorDim hidden_step_dim = {hidden_dim.batch(), hidden_dim.channel(),
+                               to - from, hidden_dim.width()};
+
+  // @todo: set reset stride as false. This implementation only works when batch
+  // size is 1
+  Tensor input_step =
+    input_.getSharedDataTensor(input_step_dim, from * input_dim.width(), true);
+  Tensor hidden_step = hidden_.getSharedDataTensor(
+    hidden_step_dim, from * hidden_dim.width(), true);
+
+  input_step.dot(weight, hidden_step, false, false);
+
+  if (auto &disable_bias = std::get<props::DisableBias>(*layer_impl_props);
+      disable_bias.empty() || disable_bias.get() == false) {
+    Tensor &bias = context.getWeight(weight_idx[FCParams::bias]);
+    hidden_step.add_i(bias);
+  }
+}
+
 void FullyConnectedLayer::calcDerivative(RunLayerContext &context) {
   Tensor &weight = context.getWeight(weight_idx[FCParams::weight]);
 

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -71,6 +71,10 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
   auto const &in_dim = context.getInputDimensions()[0];
   output_dims[0] = in_dim;
   is_nchw ? output_dims[0].width(unit) : output_dims[0].channel(unit);
+
+  output_dims[0].setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+
   context.setOutputDimensions(output_dims);
 
   /** set weight specifications */
@@ -158,10 +162,10 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
   TensorDim input_dim = input_.getDim();
   TensorDim hidden_dim = hidden_.getDim();
 
-  TensorDim input_step_dim = {input_dim.batch(), input_dim.channel(), to - from,
-                              input_dim.width()};
-  TensorDim hidden_step_dim = {hidden_dim.batch(), hidden_dim.channel(),
-                               to - from, hidden_dim.width()};
+  TensorDim input_step_dim = input_dim;
+  TensorDim hidden_step_dim = hidden_dim;
+  input_step_dim.height(to - from);
+  hidden_step_dim.height(to - from);
 
   // @todo: set reset stride as false. This implementation only works when batch
   // size is 1
@@ -177,6 +181,7 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
     Tensor &bias = context.getWeight(weight_idx[FCParams::bias]);
     hidden_step.add_i(bias);
   }
+  // hidden_step.print(std::cout);
 }
 
 void FullyConnectedLayer::calcDerivative(RunLayerContext &context) {

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -181,7 +181,8 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
     Tensor &bias = context.getWeight(weight_idx[FCParams::bias]);
     hidden_step.add_i(bias);
   }
-  // hidden_step.print(std::cout);
+  //std::cout <<"fc_layer"<< std::endl;
+  //hidden_step.print(std::cout);
 }
 
 void FullyConnectedLayer::calcDerivative(RunLayerContext &context) {

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -169,10 +169,8 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
 
   // @todo: set reset stride as false. This implementation only works when batch
   // size is 1
-  Tensor input_step =
-    input_.getSharedDataTensor(input_step_dim, from * input_dim.width(), true);
-  Tensor hidden_step = hidden_.getSharedDataTensor(
-    hidden_step_dim, from * hidden_dim.width(), true);
+  Tensor input_step = input_.getSharedDataTensor(input_step_dim, 0, true);
+  Tensor hidden_step = hidden_.getSharedDataTensor(hidden_step_dim, 0, true);
 
   input_step.dot(weight, hidden_step, false, false);
 
@@ -181,8 +179,6 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
     Tensor &bias = context.getWeight(weight_idx[FCParams::bias]);
     hidden_step.add_i(bias);
   }
-  //std::cout <<"fc_layer"<< std::endl;
-  //hidden_step.print(std::cout);
 }
 
 void FullyConnectedLayer::calcDerivative(RunLayerContext &context) {

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -59,6 +59,13 @@ public:
   void forwarding(RunLayerContext &context, bool training) override;
 
   /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(RunLayerContext &context, unsigned int from,
+                              unsigned int to, bool training) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(RunLayerContext &context) override;

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -54,8 +54,6 @@ void InputLayer::forwarding(RunLayerContext &context, bool training) {
     hidden_.normalization_i();
   if (std::get<props::Standardization>(input_props))
     hidden_.standardization_i();
-  // std::cout <<"input_layer"<< std::endl;
-  // hidden_.print(std::cout);
 }
 
 void InputLayer::calcDerivative(RunLayerContext &context) {
@@ -71,10 +69,6 @@ void InputLayer::exportTo(Exporter &exporter,
 void InputLayer::finalize(InitLayerContext &context) {
 
   std::vector<TensorDim> output_dims = context.getInputDimensions();
-
-  /*   for (auto d : output_dims)
-      d.setTensorType({context.getFormat(), context.getActivationDataType()});
-   */
 
   context.setOutputDimensions(output_dims);
 }

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -54,6 +54,7 @@ void InputLayer::forwarding(RunLayerContext &context, bool training) {
     hidden_.normalization_i();
   if (std::get<props::Standardization>(input_props))
     hidden_.standardization_i();
+  // std::cout <<"input_layer"<< std::endl;
   // hidden_.print(std::cout);
 }
 

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -54,6 +54,7 @@ void InputLayer::forwarding(RunLayerContext &context, bool training) {
     hidden_.normalization_i();
   if (std::get<props::Standardization>(input_props))
     hidden_.standardization_i();
+  // hidden_.print(std::cout);
 }
 
 void InputLayer::calcDerivative(RunLayerContext &context) {
@@ -70,8 +71,9 @@ void InputLayer::finalize(InitLayerContext &context) {
 
   std::vector<TensorDim> output_dims = context.getInputDimensions();
 
-  for (auto &d : output_dims)
-    d.setTensorType({context.getFormat(), context.getActivationDataType()});
+  /*   for (auto d : output_dims)
+      d.setTensorType({context.getFormat(), context.getActivationDataType()});
+   */
 
   context.setOutputDimensions(output_dims);
 }

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -69,7 +69,7 @@ void InitLayerContext::setOutputDimensions(
   for (unsigned i = 0u, sz = out_dim.size(); i < sz; ++i) {
     auto spec = outSpec(out_dim.at(i));
 
-    spec.variable_spec.dim.setFormat(
+/*     spec.variable_spec.dim.setFormat(
       str_converter<enum_class_prop_tag,
                     nntrainer::TensorFormatInfo>::from_string(tensor_type[0]));
     spec.variable_spec.dim.setDataType(
@@ -82,7 +82,7 @@ void InitLayerContext::setOutputDimensions(
     spec.gradient_spec->dim.setDataType(
       str_converter<enum_class_prop_tag, nntrainer::TensorDataTypeInfo>::
         from_string(tensor_type[2]));
-
+ */
     specs.push_back(std::move(spec));
   }
 

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -173,6 +173,24 @@ public:
   virtual void forwarding(RunLayerContext &context, bool training) = 0;
 
   /**
+   * @brief     Incremental forward Propagation of a layer
+   * @param     context Context of the layer
+   * @param     from start step
+   * @param     to end step
+   * @param     training true if training, false if inference
+   *
+   * @note      Output must be set in the output tensors.
+   * @details   context provides access to the weights (if any), inputs,
+   * outputs, and tensors (if any) for the layer. Input and output dimensions
+   * can be access from the inputs/outputs tensors themselves.
+   */
+  virtual void incremental_forwarding(RunLayerContext &context,
+                                      unsigned int from, unsigned int to,
+                                      bool training) {
+    forwarding(context, training);
+  };
+
+  /**
    * @brief     calc the derivative to be passed to the previous layer
    * @param     context Context of the layer
    * @note      Return derivatives must be set in input gradient tensors.

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -728,6 +728,29 @@ void LayerNode::forwarding(bool training) {
 }
 
 /**
+ * @brief     Incremental forward Propagation of a layer
+ */
+void LayerNode::incremental_forwarding(unsigned int from, unsigned int to,
+                                       bool training) {
+  loss->set(run_context->getRegularizationLoss());
+  PROFILE_TIME_START(forward_event_key);
+  layer->incremental_forwarding(*run_context, from, to, training);
+  PROFILE_TIME_END(forward_event_key);
+  TRACE_MEMORY() << getName() + ": F";
+  TRACE_TIME() << getName() + ": F";
+
+#ifdef DEBUG
+  if (!run_context->validate(getNumInputConnections() == 0, !requireLabel()))
+    throw std::runtime_error("Running forwarding() layer " + getName() +
+                             " invalidated the context.");
+#endif
+
+  /** add loss only for loss layers */
+  if (requireLabel())
+    loss->set(*loss + run_context->getLoss());
+}
+
+/**
  * @brief     calc the derivative to be passed to the previous layer
  */
 void LayerNode::calcDerivative() {

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -274,6 +274,19 @@ public:
   void forwarding(bool training = true);
 
   /**
+   * @brief     Incremental forward Propagation of a layer
+   * @param     from start step
+   * @param     to end step
+   * @param     training true if training, false if inference
+   *
+   * @details   context provides access to the weights (if any), inputs,
+   * outputs, and tensors (if any) for the layer. Input and output dimensions
+   * can be access from the inputs/outputs tensors themselves.
+   */
+  void incremental_forwarding(unsigned int from, unsigned int to,
+                              bool training = true);
+
+  /**
    * @brief     calc the derivative to be passed to the previous layer
    *
    * @details   context provides access to the weights (if any), inputs,

--- a/nntrainer/layers/layer_normalization_layer.cpp
+++ b/nntrainer/layers/layer_normalization_layer.cpp
@@ -159,6 +159,86 @@ void LayerNormalizationLayer::forwarding(RunLayerContext &context,
   output.add_i(beta);
 }
 
+void LayerNormalizationLayer::incremental_forwarding(RunLayerContext &context,
+                                                     unsigned int from,
+                                                     unsigned int to,
+                                                     bool training) {
+  const float epsilon =
+    std::get<props::Epsilon>(layer_normalization_props).get();
+
+  const Tensor &input = context.getInput(SINGLE_INOUT_IDX);
+  Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+
+  Tensor &gamma = context.getWeight(wt_idx[LNParams::gamma]);
+  Tensor &beta = context.getWeight(wt_idx[LNParams::beta]);
+
+  Tensor &deviation = context.getTensor(wt_idx[LNParams::deviation]);
+  Tensor &variance = context.getTensor(wt_idx[LNParams::variance]);
+  Tensor &inv_std_dev = context.getTensor(wt_idx[LNParams::inv_std_dev]);
+
+  // @todo: consider NHWC format
+  bool is_height_normalize =
+    std::find(normalize_axes.begin(), normalize_axes.end(), 1) !=
+        normalize_axes.end()
+      ? true
+      : false;
+
+  TensorDim input_dim = input.getDim();
+  TensorDim output_dim = output.getDim();
+  TensorDim normalize_dim = gamma.getDim();
+  TensorDim remain_dim = variance.getDim();
+
+  TensorDim input_step_dim = {input_dim.batch(), input_dim.channel(), to - from,
+                              input_dim.width()};
+  TensorDim output_step_dim = {output_dim.batch(), output_dim.channel(),
+                               to - from, output_dim.width()};
+  TensorDim normalize_step_dim = {
+    normalize_dim.batch(), normalize_dim.channel(),
+    is_height_normalize ? to - from : 1, normalize_dim.width()};
+  TensorDim remain_step_dim = {remain_dim.batch(), remain_dim.channel(),
+                               is_height_normalize ? 1 : to - from,
+                               remain_dim.width()};
+
+  // @todo: set reset stride as false. This implementation only works when batch
+  // size is 1
+  const Tensor input_step = input.getSharedDataTensor(
+    input_step_dim, from * input_step_dim.width(), true);
+  Tensor output_step = output.getSharedDataTensor(
+    output_step_dim, from * output_step_dim.width(), true);
+
+  Tensor gamma_step = gamma.getSharedDataTensor(
+    normalize_step_dim,
+    is_height_normalize ? from * normalize_step_dim.width() : 0, true);
+  Tensor beta_step = beta.getSharedDataTensor(
+    normalize_step_dim,
+    is_height_normalize ? from * normalize_step_dim.width() : 0, true);
+
+  Tensor deviation_step = deviation.getSharedDataTensor(
+    input_step_dim, from * input_step_dim.width(), true);
+  Tensor variance_step = variance.getSharedDataTensor(
+    remain_step_dim, is_height_normalize ? 0 : from * remain_step_dim.width(),
+    true);
+  Tensor inv_std_dev_step = inv_std_dev.getSharedDataTensor(
+    remain_step_dim, is_height_normalize ? 0 : from * remain_step_dim.width(),
+    true);
+
+  Tensor &temp_full_size = output_step;
+  Tensor &temp_norm_size = inv_std_dev_step;
+
+  input_step.average(normalize_axes, temp_norm_size);
+  input_step.subtract(temp_norm_size, deviation_step);
+
+  deviation_step.pow(2.0f, temp_full_size);
+  temp_full_size.average(normalize_axes, variance_step);
+
+  variance_step.add_i(epsilon);
+  variance_step.pow(-0.5f, inv_std_dev_step);
+
+  deviation_step.multiply(inv_std_dev_step, output_step);
+  output_step.multiply_i(gamma_step);
+  output_step.add_i(beta_step);
+}
+
 void LayerNormalizationLayer::calcDerivative(RunLayerContext &context) {
   const bool trainable = context.getTrainable();
 

--- a/nntrainer/layers/layer_normalization_layer.cpp
+++ b/nntrainer/layers/layer_normalization_layer.cpp
@@ -263,7 +263,8 @@ void LayerNormalizationLayer::incremental_forwarding(RunLayerContext &context,
   deviation_step.multiply(inv_std_dev_step, output_step);
   output_step.multiply_i(gamma_step);
   output_step.add_i(beta_step);
-//  output_step.print(std::cout);
+  // std::cout << "layer_normalization_layer" << std::endl;
+  // output_step.print(std::cout);
 }
 
 void LayerNormalizationLayer::calcDerivative(RunLayerContext &context) {

--- a/nntrainer/layers/layer_normalization_layer.h
+++ b/nntrainer/layers/layer_normalization_layer.h
@@ -64,6 +64,13 @@ public:
   void forwarding(RunLayerContext &context, bool training) override;
 
   /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(RunLayerContext &context, unsigned int from,
+                              unsigned int to, bool training) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(RunLayerContext &context) override;

--- a/nntrainer/layers/multi_head_attention_layer.cpp
+++ b/nntrainer/layers/multi_head_attention_layer.cpp
@@ -877,6 +877,7 @@ void MultiHeadAttentionLayer::incremental_forwarding(RunLayerContext &context,
   if (!disable_bias) {
     output_step.add_i(fc_bias);
   }
+  // std::cout <<"multi_head_attention_layer"<< std::endl;
   // output_step.print(std::cout);
 }
 

--- a/nntrainer/layers/multi_head_attention_layer.h
+++ b/nntrainer/layers/multi_head_attention_layer.h
@@ -61,6 +61,13 @@ public:
   void forwarding(RunLayerContext &context, bool training) override;
 
   /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(RunLayerContext &context, unsigned int from,
+                              unsigned int to, bool training) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(RunLayerContext &context) override;
@@ -108,7 +115,7 @@ private:
     multi_head_attention_props; /**< multi_head_attention layer properties */
 
   ActiFunc sm; /** softmax activation operation */
-  std::array<unsigned int, 14>
+  std::array<unsigned int, 16>
     weight_idx; /**< indices of the weights and tensors */
 
   /**

--- a/nntrainer/layers/multiout_layer.cpp
+++ b/nntrainer/layers/multiout_layer.cpp
@@ -57,15 +57,11 @@ void MultiOutLayer::incremental_forwarding(RunLayerContext &context,
       TensorDim output_dim = output.getDim();
       TensorDim output_step_dim = output_dim;
       output_step_dim.height(to - from);
-      /* TensorDim output_step_dim = {output_dim.batch(), output_dim.channel(),
-                                   to - from, output_dim.width()};
-       */
       // @todo: set reset stride as false. This implementation only works when
       // batch size is 1
       Tensor output_step = output.getSharedDataTensor(
         output_step_dim, from * output_dim.width(), true);
       output_step.fill(input_step);
-      // output_step.print(std::cout);
     }
   }
 }

--- a/nntrainer/layers/multiout_layer.cpp
+++ b/nntrainer/layers/multiout_layer.cpp
@@ -45,8 +45,9 @@ void MultiOutLayer::incremental_forwarding(RunLayerContext &context,
   if (!context.executeInPlace()) {
     const Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
     TensorDim input_dim = input_.getDim();
-    TensorDim input_step_dim = {input_dim.batch(), input_dim.channel(),
-                                to - from, input_dim.width()};
+    TensorDim input_step_dim = input_dim;
+    input_step_dim.height(to - from);
+
     Tensor input_step = input_.getSharedDataTensor(
       input_step_dim, from * input_dim.width(), true);
 
@@ -54,13 +55,17 @@ void MultiOutLayer::incremental_forwarding(RunLayerContext &context,
       Tensor &output = context.getOutput(idx);
 
       TensorDim output_dim = output.getDim();
-      TensorDim output_step_dim = {output_dim.batch(), output_dim.channel(),
+      TensorDim output_step_dim = output_dim;
+      output_step_dim.height(to - from);
+      /* TensorDim output_step_dim = {output_dim.batch(), output_dim.channel(),
                                    to - from, output_dim.width()};
+       */
       // @todo: set reset stride as false. This implementation only works when
       // batch size is 1
       Tensor output_step = output.getSharedDataTensor(
         output_step_dim, from * output_dim.width(), true);
       output_step.fill(input_step);
+      // output_step.print(std::cout);
     }
   }
 }

--- a/nntrainer/layers/multiout_layer.h
+++ b/nntrainer/layers/multiout_layer.h
@@ -57,6 +57,13 @@ public:
   void forwarding(RunLayerContext &context, bool training) override;
 
   /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(RunLayerContext &context, unsigned int from,
+                              unsigned int to, bool training) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(RunLayerContext &context) override;

--- a/nntrainer/models/model_common_properties.cpp
+++ b/nntrainer/models/model_common_properties.cpp
@@ -36,4 +36,7 @@ MemorySwapPath::MemorySwapPath(const std::string &value) { set(value); }
 MemorySwapLookahead::MemorySwapLookahead(const unsigned int &value) {
   set(value);
 }
+ModelTensorDataType::ModelTensorDataType(ModelTensorDataTypeInfo::Enum value) {
+  set(value);
+}
 } // namespace nntrainer::props

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -208,9 +208,7 @@ public:
    * @param value value to set, defaults to W32A32
    */
   ModelTensorDataType(ModelTensorDataTypeInfo::Enum value =
-                        ModelTensorDataTypeInfo::Enum::W32A32) {
-    set(value);
-  };
+                        ModelTensorDataTypeInfo::Enum::W32A32);
 };
 
 } // namespace nntrainer::props

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -844,16 +844,17 @@ std::vector<float *> NeuralNetwork::incremental_inference(
   std::vector<float *> output;
   output.reserve(output_tensors.size());
 
+  unsigned int idx = 0;
   for (auto &out : output_tensors) {
     if (out->getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
       auto out_t = *out.get();
       _FP16 *vec_fp16 = out_t.getData<_FP16>();
-      std::vector<float> vec_fp32;
+      float *vec_fp32 = new float[out_t.size()]();
+      output.push_back(vec_fp32);
       for (unsigned int i = 0; i < out_t.size(); ++i) {
-        vec_fp32.push_back(static_cast<float>(vec_fp16[i]));
+        output[idx][i] = static_cast<float>(vec_fp16[i]);
       }
-      output.push_back(vec_fp32.data());
 #else
       throw std::invalid_argument("Errro: enable-fp16 is not set");
 #endif
@@ -861,6 +862,7 @@ std::vector<float *> NeuralNetwork::incremental_inference(
       auto out_t = *out.get();
       output.push_back(out_t.getData());
     }
+    idx++;
   }
 
   return output;

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -779,30 +779,22 @@ sharedConstTensors NeuralNetwork::incremental_inference(
     model_graph.setBatchSize(X[0]->batch());
   }
 
-  bool isInitInference = false;
-  if (init_seq_len == cur_step + 1) {
-    isInitInference = true;
-  }
-
   sharedConstTensors out;
   if (!validateInput(X))
     throw std::invalid_argument("Input validation failed.");
 
-  if (isInitInference) {
+  if (cur_step == 0) {
     allocate(ExecutionMode::INFERENCE);
   }
 
   int nn_foward;
   PROFILE_TIME_REGISTER_EVENT(nn_foward, "nn_forward");
   PROFILE_TIME_START(nn_foward);
-  if (isInitInference) {
-    out = incremental_forwarding(0, init_seq_len, X, label, false);
-  } else {
-    out = incremental_forwarding(cur_step, cur_step + 1, X, label, false);
-  }
+  out = incremental_forwarding(cur_step, cur_step + 1, X, label, false);
+
   PROFILE_TIME_END(nn_foward);
 
-  // @todo: deallocate tensor after incremental inference
+  /** @todo: deallocate tensor after incremental inference **/
 
   /** Clear the set inputs and labels */
   model_graph.setInputsLabels({}, {});

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -200,7 +200,7 @@ int NeuralNetwork::compile() {
   return status;
 }
 
-int NeuralNetwork::initialize() {
+int NeuralNetwork::initialize(ExecutionMode mode) {
   int status = ML_ERROR_NONE;
 
   if (initialized) {
@@ -233,7 +233,7 @@ int NeuralNetwork::initialize() {
   }
 
   status = model_graph.initialize(
-    input_conn,
+    mode, input_conn,
     std::vector<Connection>(label_layers.begin(), label_layers.end()));
   NN_RETURN_STATUS();
 

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -236,6 +236,27 @@ public:
                                 bool training = true);
 
   /**
+   * @brief     Incremental forward Propagation of the neural network
+   */
+  sharedConstTensors
+  incremental_forwarding(unsigned int from, unsigned int to,
+                         bool training = true,
+                         std::function<bool(void *userdata)> stop_cb =
+                           [](void *user_data) { return false; },
+                         void *user_data = nullptr);
+
+  /**
+   * @brief     Incremental forward Propagation of the neural network
+   * @param[in] input List of Input Tensors taken by the neural network
+   * @param[in] label List of Label Tensors for the model
+   * @retval    List of Output Tensors
+   */
+  sharedConstTensors incremental_forwarding(unsigned int from, unsigned int to,
+                                            sharedConstTensors input,
+                                            sharedConstTensors label = {},
+                                            bool training = true);
+
+  /**
    * @brief     Backward Propagation of the neural network
    * @param[in] iteration Iteration Number for the optimizer
    */
@@ -344,6 +365,46 @@ public:
   std::vector<float *> inference(unsigned int batch,
                                  const std::vector<float *> &input,
                                  const std::vector<float *> &label) override;
+
+  /**
+   * @brief     Run NeuralNetwork incremental inference
+   * @param[in] X input tensor
+   * @param[in] init_seq_len initial sequence length
+   * @param[in] cur_step current working step index (zero based index)
+s   * @retval shared_ptr<const Tensor>
+   */
+  sharedConstTensors incremental_inference(sharedConstTensors X,
+                                           unsigned int init_seq_len,
+                                           unsigned int step);
+
+  /**
+   * @brief     Run NeuralNetwork incremental inference
+   * @param[in] X input tensor
+   * @param[in] label label tensor
+   * @param[in] init_seq_len initial sequence length
+   * @param[in] cur_step current working step index (zero based index)
+   * @retval shared_ptr<const Tensor>
+   */
+  sharedConstTensors incremental_inference(sharedConstTensors X,
+                                           sharedConstTensors label,
+                                           unsigned int init_seq_len,
+                                           unsigned int step);
+
+  /**
+   * @brief     Run the incremental inference of the model
+   * @param[in] batch batch size of current input
+   * @param[in] input inputs as a list of each input data
+   * @param[in] label labels as a list of each label data
+   * @param[in] init_seq_len initial sequence length
+   * @param[in] cur_step current working step index (zero based index)
+   * @retval list of output as float *
+   * @note The output memory must not be freed by the caller
+   */
+  std::vector<float *> incremental_inference(unsigned int batch,
+                                             const std::vector<float *> &input,
+                                             const std::vector<float *> &label,
+                                             unsigned int init_seq_len,
+                                             unsigned int step) override;
 
   /**
    * @brief     Run NeuralNetwork train with callback function by user

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -37,7 +37,6 @@
 #include <common_properties.h>
 #include <compiler_fwd.h>
 #include <dynamic_training_optimization.h>
-#include <execution_mode.h>
 #include <layer_node.h>
 #include <model_common_properties.h>
 #include <network_graph.h>
@@ -53,6 +52,7 @@ namespace ml::train {
 class DataSet;
 enum class DatasetType;
 enum class DatasetModeType;
+enum class ExecutionMode;
 } // namespace ml::train
 
 namespace nntrainer {
@@ -63,6 +63,7 @@ class Exporter;
  * @brief     Enumeration of Network Type
  */
 using NetType = ml::train::ModelType;
+using ExecutionMode = ml::train::ExecutionMode;
 
 class DataBuffer;
 using DatasetType = ml::train::DatasetType;
@@ -177,7 +178,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize() override;
+  int initialize(ExecutionMode mode = ExecutionMode::TRAIN) override;
 
   /**
    * @brief     Reinitialize Network. This should be called after initialize

--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -15,7 +15,7 @@
 #include <blas_interface.h>
 #include <nntrainer_error.h>
 
-#ifdef USE__FP16
+#if (defined USE__FP16 && defined USE_NEON)
 #include <blas_neon.h>
 #endif
 
@@ -80,7 +80,7 @@ static void saxpy_FP16(const unsigned int N, const float alpha, const _FP16 *X,
     throw std::invalid_argument(
       "Error: negative inc not supported without cblas");
 
-#ifdef USE__FP16
+#if (defined USE__FP16 && USE_NEON)
   // USE__FP16 is defined when platform is android
   if (incX == 1 && incY == 1) {
     nntrainer::neon::saxpy_neon_fp16(N, alpha, X, Y);
@@ -102,13 +102,13 @@ static void sgemv_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
   unsigned int incx = abs(incX);
 
   if (TransA == CblasTrans) {
-#ifdef USE__FP16
+#if (defined USE__FP16 && USE_NEON)
     nntrainer::neon::sgemv_transpose_neon_fp16(A, X, Y, M, N, alpha, beta);
 #else
     sgemv_loop_fp16(i, j, N, M);
 #endif
   } else {
-#ifdef USE__FP16
+#if (defined USE__FP16 && USE_NEON)
     nntrainer::neon::sgemv_neon_fp16(A, X, Y, M, N, alpha, beta);
 #else
     sgemv_loop_fp16(j, i, M, N);
@@ -125,7 +125,7 @@ static _FP16 sdot_FP16(const unsigned int N, const _FP16 *X,
 
   _FP16 ret = 0;
 
-#ifdef USE__FP16
+#if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
     ret = nntrainer::neon::sdot_neon_fp16(N, X, Y);
   } else {
@@ -146,7 +146,7 @@ static void scopy_FP16(const unsigned int N, const _FP16 *X, const int incX,
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
-#ifdef USE__FP16
+#if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
     nntrainer::neon::scopy_neon_fp16(N, X, Y);
   } else {
@@ -164,7 +164,7 @@ static void scopy_INT4(const unsigned int N, const uint8_t *X, const int incX,
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
-#ifdef USE__FP16
+#if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
     nntrainer::neon::scopy_neon_int4_to_fp16(N, X, Y);
   } else {
@@ -181,7 +181,7 @@ static void scopy_INT4(const unsigned int N, const uint8_t *X, const int incX,
 
 static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                       _FP16 *Z) {
-#ifdef USE__FP16
+#if (defined USE__FP16 && USE_NEON)
   nntrainer::neon::elementwise_vector_multiplication_neon_fp16(N, X, Y, Z);
 #else
   for (unsigned int i = 0; i < N; ++i)
@@ -191,7 +191,7 @@ static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
 
 static void ewva_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                       _FP16 *Z) {
-#ifdef USE__FP16
+#if (defined USE__FP16 && USE_NEON)
   nntrainer::neon::elementwise_vector_addition_neon_fp16(N, X, Y, Z);
 #else
   for (unsigned int i = 0; i < N; ++i)
@@ -201,7 +201,7 @@ static void ewva_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
 void sscal(const unsigned int N, const float alpha, _FP16 *X, const int incX) {
   unsigned int incx = abs(incX);
 
-#ifdef USE__FP16
+#if (defined USE__FP16 && USE_NEON)
   if (incX == 1) {
     nntrainer::neon::sscal_neon_fp16(N, X, alpha);
   } else {
@@ -218,7 +218,7 @@ static _FP16 snrm2_FP16(const unsigned int N, const _FP16 *X, const int incX) {
   unsigned int incx = abs(incX);
   _FP16 sum = 0;
   _FP16 tmp;
-#ifdef USE__FP16
+#if (defined USE__FP16 && USE_NEON)
   if (incX == 1) {
     sum = nntrainer::neon::snrm2_neon_fp16(N, X);
   } else {
@@ -244,7 +244,7 @@ static void sgemm_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
                        const unsigned int ldb, const float beta, _FP16 *C,
                        const unsigned int ldc) {
 
-#ifdef USE__FP16
+#if (defined USE__FP16 && USE_NEON)
   nntrainer::neon::sgemm_neon_fp16(A, B, C, M, N, K, alpha, beta,
                                    TransA == CblasTrans, TransB == CblasTrans);
 #else
@@ -256,7 +256,7 @@ static unsigned int isamax_FP16(const unsigned int N, const _FP16 *X,
                                 const int incX) {
   unsigned int max_idx = 0;
 
-#ifdef USE__FP16
+#if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && N >= 8) {
     max_idx = nntrainer::neon::isamax_neon_fp16(N, X);
   } else {

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -476,6 +476,7 @@ std::vector<Var_Grad *> Manager::requestTensors(
 
   std::vector<Var_Grad *> ret;
   size_t current_size = tensors_v2.size();
+  bool is_train_mode = (exec_mode == ExecutionMode::TRAIN) ? true : false;
 
   for (unsigned int i = 0; i < tensors_spec.size(); ++i) {
     auto const &[dim, t_init, need_grad, name, tspan] = tensors_spec.at(i);
@@ -488,18 +489,19 @@ std::vector<Var_Grad *> Manager::requestTensors(
       var_exec_order.push_back(forwarding_order);
 
     /** usage for tensors gradient in backwarding */
-    if (trainable &&
+    if (trainable && is_train_mode &&
         enum_class_logical_and(tspan, TensorLifespan::CALC_GRAD_LIFESPAN)) {
       var_exec_order.push_back(calcGradient_order);
       grad_exec_order.push_back(calcGradient_order);
     }
 
-    if (enum_class_logical_and(tspan, TensorLifespan::CALC_DERIV_LIFESPAN)) {
+    if (is_train_mode &&
+        enum_class_logical_and(tspan, TensorLifespan::CALC_DERIV_LIFESPAN)) {
       var_exec_order.push_back(calcDerivative_order);
       grad_exec_order.push_back(calcDerivative_order);
     }
 
-    if (trainable &&
+    if (trainable && is_train_mode &&
         enum_class_logical_and(tspan, TensorLifespan::CALC_AGRAD_LIFESPAN)) {
       var_exec_order.push_back(applyGradient_order);
       grad_exec_order.push_back(applyGradient_order);

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -30,13 +30,18 @@
 #include <vector>
 
 #include <basic_planner.h>
+#include <common.h>
 #include <graph_node.h>
 #include <tensor_pool.h>
 #include <var_grad.h>
 #include <weight.h>
 
-namespace nntrainer {
+namespace ml::train {
+enum class ExecutionMode;
+}
 
+namespace nntrainer {
+using ExecutionMode = ml::train::ExecutionMode;
 /**
  * @class MMappedMemory
  * @brief Memory Handler, that has mmaped memory with a file descriptor
@@ -484,6 +489,13 @@ public:
    */
   void reinitialize();
 
+  /**
+   * @brief     set Execution Mode
+   */
+  void setExecutionMode(ExecutionMode mode = ExecutionMode::TRAIN) {
+    exec_mode = mode;
+  };
+
 private:
   /** @todo: merge this list to one */
   std::vector<std::unique_ptr<Weight>> weights_v2; /**< weights for the layers
@@ -516,6 +528,8 @@ private:
   std::string tensor_format;
 
   std::vector<std::string> tensor_dtype;
+
+  ExecutionMode exec_mode;
 
   /**
    * @brief Finalize the given tensor pool

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -28,7 +28,9 @@ tensor_headers = [
 arch = target_machine.cpu_family()
 
 if get_option('platform') == 'android' or arch == 'aarch64' or arch =='arm'
+if get_option('platform') != 'tizen'
   tensor_sources += 'blas_neon.cpp'
+endif  
 endif
 
 foreach s : tensor_sources

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -2608,7 +2608,7 @@ void Tensor::print(std::ostream &out) const {
     out << "data addr: " << data << '\n';
     out << dim;
 
-    if (len > 100) {
+    if (len > 1000000) {
       out << '[' << data[0] << ' ' << data[1] << ' ' << data[2] << " ... "
           << data[len - 3] << ' ' << data[len - 2] << ' ' << data[len - 1]
           << ']' << std::endl;
@@ -2617,6 +2617,8 @@ void Tensor::print(std::ostream &out) const {
 
     std::ios init(NULL);
     init.copyfmt(out);
+    float max_ = 0.0;
+    float min_ = 10000000;
     if (getFormat() == Tformat::NCHW) {
       for (unsigned int k = 0; k < batch(); k++) {
         for (unsigned int l = 0; l < channel(); l++) {
@@ -2654,7 +2656,7 @@ void Tensor::print(std::ostream &out) const {
     out << "data addr: " << data << '\n';
     out << dim;
 
-    if (len > 100) {
+    if (len > 10000000) {
       out << '[' << (float)data[0] << ' ' << (float)data[1] << ' '
           << (float)data[2] << " ... " << (float)data[len - 3] << ' '
           << (float)data[len - 2] << ' ' << (float)data[len - 1] << ']'
@@ -2671,12 +2673,19 @@ void Tensor::print(std::ostream &out) const {
             for (unsigned int j = 0; j < width(); j++) {
               out << std::setw(10) << std::setprecision(10)
                   << (float)this->getValue<_FP16>(k, l, i, j) << " ";
+              if (std::isinf((float)this->getValue<_FP16>(k, l, i, j)))
+                out << "INF or NAN " << k << ":" << l << ":" << i << ":" << j
+                    << std::endl;
+              if ((float)this->getValue<_FP16>(k, l, i, j) < min_)
+                min_ = (float)this->getValue<_FP16>(k, l, i, j);
+              if ((float)this->getValue<_FP16>(k, l, i, j) > max_)
+                max_ = (float)this->getValue<_FP16>(k, l, i, j);
             }
             out << std::endl;
           }
           out << std::endl;
         }
-        out << "-------" << std::endl;
+        out << "-------" << min_ << " & " << max_ << std::endl;
       }
     } else {
       for (unsigned int k = 0; k < batch(); k++) {
@@ -2995,9 +3004,9 @@ void Tensor::copy(const Tensor &from) {
   if (from.size() != 0 && size() == from.size() &&
       getDataType() == from.getDataType()) {
     reshape(from.getDim());
-    if (getDataType() == ml::train::TensorDim::DataType::FP32) {
+    if (from.getDataType() == ml::train::TensorDim::DataType::FP32) {
       copy(from.getData());
-    } else if (getDataType() == ml::train::TensorDim::DataType::FP16) {
+    } else if (from.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
       copy(from.getData<_FP16>());
 #else
@@ -3006,8 +3015,17 @@ void Tensor::copy(const Tensor &from) {
     }
 
   } else {
-    Tensor t = Tensor(from.getDim(), from.getData());
-    swap(t, *this);
+    if (from.getDataType() == ml::train::TensorDim::DataType::FP32) {
+      Tensor t = Tensor(from.getDim(), from.getData<float>());
+      swap(t, *this);
+    } else if (from.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+      Tensor t = Tensor(from.getDim(), from.getData<_FP16>());
+      swap(t, *this);
+#else
+      throw std::invalid_argument("Error: enable-fp16 is not enabled");
+#endif
+    }
   }
 }
 
@@ -3023,7 +3041,15 @@ void Tensor::copyData(const Tensor &from) {
   if (getDataType() != from.getDataType())
     throw std::invalid_argument("Data type of tensor to copy must match");
 
-  copy(from.getData());
+  if (getDataType() == ml::train::TensorDim::DataType::FP32) {
+    copy(from.getData<float>());
+  } else if (getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    copy(from.getData<_FP16>());
+#else
+    throw std::invalid_argument("Error: enable-fp16 is not enabled");
+#endif
+  }
 }
 
 Tensor Tensor::clone() const {
@@ -3043,7 +3069,12 @@ void Tensor::reshape(const TensorDim &d) {
        "\nfrom "
     << getDim() << " to " << d;
 
-  dim = d;
+  // dim = d;
+  dim.batch(d.batch());
+  dim.channel(d.channel());
+  dim.height(d.height());
+  dim.width(d.width());
+
   strides = d.computeStrides();
 }
 
@@ -3069,7 +3100,15 @@ void Tensor::fill(const Tensor &from, bool alloc) {
     throw std::invalid_argument("[Tensor::fill] buffer size must be the same");
   }
 
-  this->copy(from.getData());
+  if (this->getDataType() == ml::train::TensorDim::DataType::FP32) {
+    this->copy(from.getData<float>());
+  } else if (this->getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    this->copy(from.getData<_FP16>());
+#else
+    throw std::invalid_argument("Error: enable-fp16 is not enabled");
+#endif
+  }
 }
 
 void Tensor::save(std::ostream &file) {
@@ -3082,6 +3121,14 @@ void Tensor::save(std::ostream &file) {
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedWrite(file, (char *)getData(), sz, "[Tensor::save] operation failed");
+  // std::vector<_FP16>temp (size());
+  // for(unsigned int i=0;i<size();++i){
+  //   temp[i]=static_cast<_FP16>(getData()[i]);
+  // }
+
+  // checkedWrite(file, (char *)temp.data(),
+  // static_cast<std::streamsize>(size()*sizeof(_FP16)), "[Tensor::save]
+  // operation failed");
   putData();
 }
 

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -2666,6 +2666,8 @@ void Tensor::print(std::ostream &out) const {
 
     std::ios init(NULL);
     init.copyfmt(out);
+    float max_ = 0.0;
+    float min_ = 10000000;
     if (getFormat() == Tformat::NCHW) {
       for (unsigned int k = 0; k < batch(); k++) {
         for (unsigned int l = 0; l < channel(); l++) {

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -46,6 +46,20 @@
 
 %endif # 0%{tizen_version_major}%{tizen_version_minor} >= 65
 
+%define enable_fp16 0
+%ifarch %arm aarch64
+%define enable_fp16 1
+# x64/x86 requires GCC >= 12 for fp16 support.
+%endif
+
+## Float16 support
+%if 0%{?enable_fp16}
+%define fp16_support -Denable-fp16=true
+%else
+%define fp16_support -Denable-fp16=false
+%endif
+
+
 Name:		nntrainer
 Summary:	Software framework for training neural networks
 Version:	0.5.0
@@ -400,6 +414,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} \
       %{enable_reduce_tolerance} %{configure_subplugin_install_path} %{enable_debug} \
       -Dml-api-support=enabled -Denable-nnstreamer-tensor-filter=enabled \
       -Denable-nnstreamer-tensor-trainer=enabled -Denable-capi=enabled \
+      %{fp16_support} \
       build
 
 ninja -C build %{?_smp_mflags}

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -46,20 +46,6 @@
 
 %endif # 0%{tizen_version_major}%{tizen_version_minor} >= 65
 
-%define enable_fp16 0
-%ifarch %arm aarch64
-%define enable_fp16 1
-# x64/x86 requires GCC >= 12 for fp16 support.
-%endif
-
-## Float16 support
-%if 0%{?enable_fp16}
-%define fp16_support -Denable-fp16=true
-%else
-%define fp16_support -Denable-fp16=false
-%endif
-
-
 Name:		nntrainer
 Summary:	Software framework for training neural networks
 Version:	0.5.0
@@ -414,7 +400,6 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} \
       %{enable_reduce_tolerance} %{configure_subplugin_install_path} %{enable_debug} \
       -Dml-api-support=enabled -Denable-nnstreamer-tensor-filter=enabled \
       -Denable-nnstreamer-tensor-trainer=enabled -Denable-capi=enabled \
-      %{fp16_support} \
       build
 
 ninja -C build %{?_smp_mflags}


### PR DESCRIPTION
### This PR includes fixes to run picoGPT application with

-   enable memory optimization options: to reduce memory creation during inference
-   adding FP16-FP16 options in model properties
-   remove unnecessary computation during the incremental_inference.
     : This will start with just one input at a time and accumulate the computation result in cache buffer
      at Multi_head attention layer. 
-   All tensor computation is conducted with NEON/SIMD implementation except GEMM.
-   Some fixes to compute the FP16
     : In layer normalization computation, it includes the variance computation which includes the pow operation.
       It is quite often to overflow and this pr includes by-pass implementation. 