### PR TITLE
[TensorDim] Fix TensorDim constructor

### DIFF
--- a/api/ccapi/include/tensor_dim.h
+++ b/api/ccapi/include/tensor_dim.h
@@ -142,12 +142,51 @@ public:
    * @param c channel
    * @param h height
    * @param w width
-   * @param fm format NCHW | HNWC
+   * @param t_type format NCHW | HNWC , dataType FP32 | FP16
    * @param eff_dim_flag_ dimension bit flag to calculate the dynamic
    * dimension, rightmost is width
    */
   TensorDim(size_t b, size_t c, size_t h, size_t w,
             TensorType t_type_ = TensorType(),
+            const std::bitset<MAXDIM> &eff_dim_flag_ = 0b1111,
+            const std::bitset<MAXDIM> &dyn_dim_flag_ = 0b0000);
+
+  /**
+   * @brief Construct a new Tensor Dim object
+   *
+   * @param c channel
+   * @param h height
+   * @param w width
+   * @param t_type format NCHW | HNWC , dataType FP32 | FP16
+   * @param eff_dim_flag_ dimension bit flag to calculate the dynamic
+   * dimension, rightmost is width
+   */
+  TensorDim(size_t c, size_t h, size_t w, TensorType t_type_ = TensorType(),
+            const std::bitset<MAXDIM> &eff_dim_flag_ = 0b1111,
+            const std::bitset<MAXDIM> &dyn_dim_flag_ = 0b0000);
+
+  /**
+   * @brief Construct a new Tensor Dim object
+   *
+   * @param h height
+   * @param w width
+   * @param t_type format NCHW | HNWC , dataType FP32 | FP16
+   * @param eff_dim_flag_ dimension bit flag to calculate the dynamic
+   * dimension, rightmost is width
+   */
+  TensorDim(size_t h, size_t w, TensorType t_type_ = TensorType(),
+            const std::bitset<MAXDIM> &eff_dim_flag_ = 0b1111,
+            const std::bitset<MAXDIM> &dyn_dim_flag_ = 0b0000);
+
+  /**
+   * @brief Construct a new Tensor Dim object
+   *
+   * @param w width
+   * @param t_type format NCHW | HNWC , dataType FP32 | FP16
+   * @param eff_dim_flag_ dimension bit flag to calculate the dynamic
+   * dimension, rightmost is width
+   */
+  TensorDim(size_t w, TensorType t_type_ = TensorType(),
             const std::bitset<MAXDIM> &eff_dim_flag_ = 0b1111,
             const std::bitset<MAXDIM> &dyn_dim_flag_ = 0b0000);
 

--- a/nntrainer/tensor/tensor_dim.cpp
+++ b/nntrainer/tensor/tensor_dim.cpp
@@ -59,6 +59,39 @@ TensorDim::TensorDim(std::initializer_list<size_t> dims, TensorType t_type_) :
   }
 }
 
+TensorDim::TensorDim(size_t d3, TensorType t_type_,
+                     const std::bitset<MAXDIM> &eff_dim_flag_,
+                     const std::bitset<MAXDIM> &dyn_dim_flag_) :
+  TensorDim(t_type_, eff_dim_flag_, dyn_dim_flag_) {
+
+  setTensorDim(3, d3);
+  feature_len = d3;
+  len = feature_len;
+}
+
+TensorDim::TensorDim(size_t d2, size_t d3, TensorType t_type_,
+                     const std::bitset<MAXDIM> &eff_dim_flag_,
+                     const std::bitset<MAXDIM> &dyn_dim_flag_) :
+  TensorDim(t_type_, eff_dim_flag_, dyn_dim_flag_) {
+
+  setTensorDim(2, d2);
+  setTensorDim(3, d3);
+  feature_len = d2 * d3;
+  len = feature_len;
+}
+
+TensorDim::TensorDim(size_t d1, size_t d2, size_t d3, TensorType t_type_,
+                     const std::bitset<MAXDIM> &eff_dim_flag_,
+                     const std::bitset<MAXDIM> &dyn_dim_flag_) :
+  TensorDim(t_type_, eff_dim_flag_, dyn_dim_flag_) {
+
+  setTensorDim(1, d1);
+  setTensorDim(2, d2);
+  setTensorDim(3, d3);
+  feature_len = d1 * d2 * d3;
+  len = feature_len;
+}
+
 TensorDim::TensorDim(const std::array<size_t, 3> &shapes, TensorType t_type_) :
   TensorDim({shapes[0], shapes[1], shapes[2]}, t_type_) {}
 

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -37,6 +37,17 @@ TEST(nntrainer_TensorDim, ctor_initializer_p) {
   EXPECT_EQ(nntrainer::TensorDim(b, c, h, w), t);
 }
 
+TEST(nntrainer_TensorDim, default_constructor_1_sized_dimShapes_p) {
+  unsigned int b = 3;
+  unsigned int c = 2;
+  unsigned int h = 4;
+  unsigned int w = 5;
+
+  EXPECT_EQ(nntrainer::TensorDim(c), nntrainer::TensorDim(1, 1, 1, c));
+  EXPECT_EQ(nntrainer::TensorDim(1, 1, w, c), nntrainer::TensorDim(w, c));
+  EXPECT_EQ(nntrainer::TensorDim(1, h, w, c), nntrainer::TensorDim(h, w, c));
+}
+
 TEST(nntrianer_TensorDim, effective_dimension_p) {
   nntrainer::TensorDim t(3, 2, 4, 5, nntrainer::Tformat::NCHW,
                          nntrainer::Tdatatype::FP32);

--- a/test/unittest/unittest_nntrainer_tensor_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_fp16.cpp
@@ -92,6 +92,31 @@ TEST(nntrainer_Tensor, Tensor_03_fp16_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
+TEST(nntrainer_Tensor, default_constructor_with_tensor_type_fp16_p) {
+  unsigned int b = 3;
+  unsigned int c = 2;
+  unsigned int h = 4;
+  unsigned int w = 5;
+
+  nntrainer::TensorDim::TensorType tensor_type = {
+    nntrainer::TensorDim::Format::NCHW, nntrainer::TensorDim::DataType::FP16};
+
+  nntrainer::TensorDim t = {w, tensor_type};
+  EXPECT_EQ(nntrainer::TensorDim(1, 1, 1, w, tensor_type), t);
+  EXPECT_EQ(nntrainer::TensorDim(w, tensor_type), t);
+
+  t = {h, w, tensor_type};
+  EXPECT_EQ(nntrainer::TensorDim(1, 1, h, w, tensor_type), t);
+  EXPECT_EQ(nntrainer::TensorDim(h, w, tensor_type), t);
+
+  t = {c, h, w, tensor_type};
+  EXPECT_EQ(nntrainer::TensorDim(1, c, h, w, tensor_type), t);
+  EXPECT_EQ(nntrainer::TensorDim(c, h, w, tensor_type), t);
+
+  t = {b, h, w, c, tensor_type};
+  EXPECT_EQ(nntrainer::TensorDim(b, h, w, c, tensor_type), t);
+}
+
 TEST(nntrainer_Tensor, multiply_i_01_fp16_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;

--- a/test/unittest/unittest_nntrainer_tensor_nhwc.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_nhwc.cpp
@@ -29,15 +29,42 @@ TEST(nntrainer_TensorDim, ctor_initializer_nhwc_p) {
 
   nntrainer::TensorDim t = {c};
   EXPECT_EQ(nntrainer::TensorDim(1, 1, 1, c), t);
+  EXPECT_EQ(nntrainer::TensorDim(c), t);
 
   t = {w, c};
   EXPECT_EQ(nntrainer::TensorDim(1, 1, w, c), t);
+  EXPECT_EQ(nntrainer::TensorDim(w, c), t);
 
   t = {h, w, c};
   EXPECT_EQ(nntrainer::TensorDim(1, h, w, c), t);
+  EXPECT_EQ(nntrainer::TensorDim(h, w, c), t);
 
   t = {b, h, w, c};
   EXPECT_EQ(nntrainer::TensorDim(b, h, w, c), t);
+}
+
+TEST(nntrainer_TensorDim, default_constructor_with_tensor_type_nhwc_p) {
+  unsigned int b = 3;
+  unsigned int c = 2;
+  unsigned int h = 4;
+  unsigned int w = 5;
+
+  nntrainer::TensorDim::TensorType tensor_type = {NHWC_, FP32_};
+
+  nntrainer::TensorDim t = {c, tensor_type};
+  EXPECT_EQ(nntrainer::TensorDim(1, 1, 1, c, tensor_type), t);
+  EXPECT_EQ(nntrainer::TensorDim(c, tensor_type), t);
+
+  t = {w, c, tensor_type};
+  EXPECT_EQ(nntrainer::TensorDim(1, 1, w, c, tensor_type), t);
+  EXPECT_EQ(nntrainer::TensorDim(w, c, tensor_type), t);
+
+  t = {h, w, c, tensor_type};
+  EXPECT_EQ(nntrainer::TensorDim(1, h, w, c, tensor_type), t);
+  EXPECT_EQ(nntrainer::TensorDim(h, w, c, tensor_type), t);
+
+  t = {b, h, w, c, tensor_type};
+  EXPECT_EQ(nntrainer::TensorDim(b, h, w, c, tensor_type), t);
 }
 
 TEST(nntrianer_TensorDim, effective_dimension_nhwc_p) {


### PR DESCRIPTION
- Previously, there were lack of default constructors for 1-batch, 1-channel, 1-height, 1-width with currently added TensorType option (regardless of format).
- Since there are a lot of codes using such case in FP32 implementation, I had no choice but have to explicitly feed the tensor_type (which contains the fp16 info) to the previously defined tensor.
- For clean code, I would like to propose a new default constructor for better construction of TensorDim instance.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped