### PR TITLE
[ini_export] Fix LR_scheduler ini export

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -101,7 +101,7 @@ NeuralNetwork::NeuralNetwork(AppContext app_context_) :
 
 int NeuralNetwork::loadFromConfig(const std::string &config) {
   if (loadedFromConfig == true) {
-    ml_loge("can not do loadFromConfig twice");
+    ml_loge("cannot do loadFromConfig twice");
     return ML_ERROR_INVALID_PARAMETER;
   }
 
@@ -647,6 +647,9 @@ void NeuralNetwork::saveModelIni(const std::string &file_path) {
       sections.push_back(s);
     }
   };
+
+  add_section_if_any("LearningRateScheduler", opt->getLearningRateScheduler(),
+                     [](const auto &obj) { return static_cast<bool>(obj); });
 
   add_section_if_any("optimizer", opt,
                      [](const auto &obj) { return static_cast<bool>(obj); });

--- a/nntrainer/optimizers/optimizer_wrapped.cpp
+++ b/nntrainer/optimizers/optimizer_wrapped.cpp
@@ -83,7 +83,6 @@ void OptimizerWrapped::applyGradient(RunOptimizerContext &context) {
 void OptimizerWrapped::exportTo(Exporter &exporter,
                                 const ml::train::ExportMethods &method) const {
   optimizer->exportTo(exporter, method);
-  lr_sched->exportTo(exporter, method);
 }
 
 void OptimizerWrapped::finalize() {


### PR DESCRIPTION
## In this PR

**When exporting the model, the Optimizer and LR Scheduler should be exported separately, but solve the problem that does not**

Now when exporting a model that using LR Scheduler, Optimizer and LR Scheduler are not divided separately, and there is an issue in which the property of LR Scheduler is written in the Property of Optimizer.

So, This make Syntax error when loading the model. and this patch fix this issue.

**Now**
```.ini
[optimizer]
beta1 = 0.9
beta2 = 0.999
epsilon = 1e-07
iteration = 4,6,15
learning_rate = 0.000100,0.000090,0.000070,0.000050
torch_ref = false
type = adam
```

**This fetch**
```.ini
[Optimizer]
Type = adam
beta1 = 0.9                       
beta2 = 0.999                   
epsilon = 1e-7                  

[LearningRateScheduler]
type=step
iteration = 4,6,15
learning_rate = 0.000100,0.000090,0.000070,0.000050
```

related issue : close #2296 

""""""""""""""""""""""""""""""""""""""""""""""
**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped_
""""""""""""""""""""""""""""""""""""""""""""""

Signed-off-by: Donghak PARK <donghak.park@samsung.com>