### PR TITLE
[Tensor] Quantized Tensor (Int 4) with Scale

### DIFF
--- a/api/ccapi/include/tensor_dim.h
+++ b/api/ccapi/include/tensor_dim.h
@@ -48,10 +48,11 @@ public:
   enum class Format { NCHW, NHWC };
 
   /**
-   * @brief Tensor Data Type. Currently QINT8, FP16 & FP32 Support
+   * @brief Tensor Data Type. Currently QINT4, QINT8, FP16 & FP32 Support
    *
    */
   enum class DataType {
+    QINT4, /** quantized int 4*/
     QINT8, /** quantized int 8*/
     FP16,  /** half precision */
     FP32   /** single precision */
@@ -94,7 +95,7 @@ public:
    * @brief     Creator of TensorDim with Format & DataType
    *
    * @param fm format NCHW | HNWC
-   * @param fm DataType QINT8 | FP16 | FP32
+   * @param fm DataType QINT4 | QINT8 | FP16 | FP32
    * @param eff_dim_flag_ effective dimension flag (1 means it's effective)
    * @param dyn_dim_flag_ dynamic dimension flag (1 means it's unspecified)
    */
@@ -158,7 +159,7 @@ public:
    * @param h height
    * @param w width
    * @param fm format NCHW | HNWC
-   * @param d_type Data Type QINT8 | FP16 | FP32
+   * @param d_type Data Type QINT4 | QINT8 | FP16 | FP32
    * @param eff_dim_flag_ dimension bit flag to calculate the dynamic
    * dimension, rightmost is width
    */
@@ -187,7 +188,7 @@ public:
    *
    * @param shape shape of format
    * @param fm format NCHW | HNWC
-   * @param d_type data type QINT8 | FP16 | FP32
+   * @param d_type data type QINT4 | QINT8 | FP16 | FP32
    */
   TensorDim(const std::string &shape, TensorDim::Format fm,
             TensorDim::DataType d_type = TensorDim::DataType::FP32);

--- a/nntrainer/tensor/tensor_dim.cpp
+++ b/nntrainer/tensor/tensor_dim.cpp
@@ -125,6 +125,8 @@ uint TensorDim::getDataTypeSize() const {
     return sizeof(float);
   case TensorDim::DataType::QINT8:
     return sizeof(int8_t);
+  case TensorDim::DataType::QINT4:
+    return sizeof(int8_t);
   default:
     return sizeof(float);
   }
@@ -344,6 +346,8 @@ std::ostream &operator<<(std::ostream &out, TensorDim const &d) {
     type_ = "FP16";
   } else if (d.getDataType() == ml::train::TensorDim::DataType::QINT8) {
     type_ = "QINT8";
+  } else if (d.getDataType() == ml::train::TensorDim::DataType::QINT4) {
+    type_ = "QINT4";
   }
 
   std::string format_ =

--- a/test/unittest/unittest_nntrainer_tensor_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_fp16.cpp
@@ -5847,6 +5847,361 @@ TEST(nntrainer_Tensor, TensorPaddedValue_p) {
   }
 }
 
+/**
+ * @brief dequantize FP16 tensor
+ */
+TEST(nntrainer_Tensor, dequantize_01_n) {
+  int batch = 1;
+  int channel = 3;
+  int height = 4;
+  int width = 5;
+
+  nntrainer::Tensor input(batch, channel, height, width,
+                          nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+  input.setScaleFactors({1.5, 1.0, 0.5}, 1);
+
+  nntrainer::Tensor output(batch, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+
+  EXPECT_THROW({ input.dequantize(output); }, std::invalid_argument);
+}
+
+/**
+ * @brief dequantize tensor with different dimension
+ */
+TEST(nntrainer_Tensor, dequantize_02_n) {
+  int batch = 1;
+  int channel = 3;
+  int height = 4;
+  int width = 5;
+
+  nntrainer::Tensor input(
+    batch + 1, channel, height + 1, width + 1,
+    {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+  input.setScaleFactors({1.5, 1.0, 0.5}, 1);
+
+  nntrainer::Tensor output(batch, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+
+  EXPECT_THROW({ input.dequantize(output); }, std::invalid_argument);
+}
+
+/**
+ * @brief dequantize tensor with no scale factors
+ */
+TEST(nntrainer_Tensor, dequantize_03_n) {
+  int batch = 1;
+  int channel = 3;
+  int height = 4;
+  int width = 5;
+
+  nntrainer::Tensor input(
+    batch, channel, height, width,
+    {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor output(batch, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+
+  EXPECT_THROW({ input.dequantize(output); }, std::invalid_argument);
+}
+
+/**
+ * @brief dequantize qint8 tensor to fp16
+ */
+TEST(nntrainer_Tensor, dequantize_04_p) {
+  int batch = 1;
+  int channel = 3;
+  int height = 4;
+  int width = 5;
+
+  nntrainer::Tensor input(
+    batch, channel, height, width,
+    {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
+  input.setScaleFactors({1.5, 1.0, 0.5}, 1);
+
+  nntrainer::Tensor output;
+
+  EXPECT_NO_THROW({ output = input.dequantize(nntrainer::Tdatatype::FP16); });
+
+  _FP16 answer_data[] = {
+    static_cast<_FP16>(1.5), static_cast<_FP16>(1.5), static_cast<_FP16>(1.5),
+    static_cast<_FP16>(1.5), static_cast<_FP16>(1.5), static_cast<_FP16>(3),
+    static_cast<_FP16>(3),   static_cast<_FP16>(3),   static_cast<_FP16>(3),
+    static_cast<_FP16>(3),   static_cast<_FP16>(4.5), static_cast<_FP16>(4.5),
+    static_cast<_FP16>(4.5), static_cast<_FP16>(4.5), static_cast<_FP16>(4.5),
+    static_cast<_FP16>(6),   static_cast<_FP16>(6),   static_cast<_FP16>(6),
+    static_cast<_FP16>(6),   static_cast<_FP16>(6),   static_cast<_FP16>(6),
+    static_cast<_FP16>(6),   static_cast<_FP16>(6),   static_cast<_FP16>(6),
+    static_cast<_FP16>(6),   static_cast<_FP16>(7),   static_cast<_FP16>(7),
+    static_cast<_FP16>(7),   static_cast<_FP16>(7),   static_cast<_FP16>(7),
+    static_cast<_FP16>(8),   static_cast<_FP16>(8),   static_cast<_FP16>(8),
+    static_cast<_FP16>(8),   static_cast<_FP16>(8),   static_cast<_FP16>(9),
+    static_cast<_FP16>(9),   static_cast<_FP16>(9),   static_cast<_FP16>(9),
+    static_cast<_FP16>(9),   static_cast<_FP16>(5.5), static_cast<_FP16>(5.5),
+    static_cast<_FP16>(5.5), static_cast<_FP16>(5.5), static_cast<_FP16>(5.5),
+    static_cast<_FP16>(6),   static_cast<_FP16>(6),   static_cast<_FP16>(6),
+    static_cast<_FP16>(6),   static_cast<_FP16>(6),   static_cast<_FP16>(6.5),
+    static_cast<_FP16>(6.5), static_cast<_FP16>(6.5), static_cast<_FP16>(6.5),
+    static_cast<_FP16>(6.5), static_cast<_FP16>(7),   static_cast<_FP16>(7),
+    static_cast<_FP16>(7),   static_cast<_FP16>(7),   static_cast<_FP16>(7)};
+
+  nntrainer::Tensor answer(ml::train::TensorDim(batch, channel, height, width,
+                                                {nntrainer::Tformat::NCHW,
+                                                 nntrainer::Tdatatype::FP16}),
+                           answer_data);
+
+  EXPECT_EQ(output, answer);
+}
+
+/**
+ * @brief dequantize qint8 tensor to fp16
+ */
+TEST(nntrainer_Tensor, dequantize_05_p) {
+  size_t batch = 1;
+  size_t channel = 3;
+  size_t height = 4;
+  size_t width = 5;
+
+  nntrainer::Tensor input(
+    {batch,
+     channel,
+     height,
+     width,
+     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8}},
+    true, nntrainer::Tensor::Initializer::ONES);
+  nntrainer::Tensor output(batch, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+
+  // Dequantize by channel
+  EXPECT_NO_THROW(input.setScaleFactors({-2, 2, 4}, 1));
+  EXPECT_NO_THROW({ input.dequantize(output); });
+
+  _FP16 answer_data_1[] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
+                           -2, -2, -2, -2, -2, -2, -2, -2, 2,  2,  2,  2,
+                           2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+                           2,  2,  2,  2,  4,  4,  4,  4,  4,  4,  4,  4,
+                           4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4};
+
+  nntrainer::Tensor answer1(ml::train::TensorDim(batch, channel, height, width,
+                                                 {nntrainer::Tformat::NCHW,
+                                                  nntrainer::Tdatatype::FP16}),
+                            answer_data_1);
+
+  EXPECT_EQ(output, answer1);
+
+  // Dequantize by height
+  EXPECT_NO_THROW(input.setScaleFactors({-4.2, -2, 2, 4.8}, 2));
+  EXPECT_NO_THROW({ input.dequantize(output); });
+
+  _FP16 answer_data_2[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(-2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4.8),
+                           static_cast<_FP16>(4.8),  static_cast<_FP16>(4.8),
+                           static_cast<_FP16>(4.8),  static_cast<_FP16>(4.8),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(-2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4.8),
+                           static_cast<_FP16>(4.8),  static_cast<_FP16>(4.8),
+                           static_cast<_FP16>(4.8),  static_cast<_FP16>(4.8),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(-2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4.8),
+                           static_cast<_FP16>(4.8),  static_cast<_FP16>(4.8),
+                           static_cast<_FP16>(4.8),  static_cast<_FP16>(4.8)};
+  nntrainer::Tensor answer2(ml::train::TensorDim(batch, channel, height, width,
+                                                 {nntrainer::Tformat::NCHW,
+                                                  nntrainer::Tdatatype::FP16}),
+                            answer_data_2);
+
+  EXPECT_EQ(output, answer2);
+
+  // Dequantize by width
+  EXPECT_NO_THROW(input.setScaleFactors({-4.2, -2, 2, 4, -8}, 3));
+  EXPECT_NO_THROW({ input.dequantize(output); });
+
+  _FP16 answer_data_3[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-8),   static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(2),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(-8),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-8),   static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(2),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(-8),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-8),   static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(2),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(-8),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-8),   static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(2),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(-8),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-8),   static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(2),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(-8),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-8),   static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(2),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(-8)};
+
+  nntrainer::Tensor answer3(ml::train::TensorDim(batch, channel, height, width,
+                                                 {nntrainer::Tformat::NCHW,
+                                                  nntrainer::Tdatatype::FP16}),
+                            answer_data_3);
+
+  EXPECT_EQ(output, answer3);
+}
+
+/**
+ * @brief dequantize qint4 tensor
+ */
+TEST(nntrainer_Tensor, dequantize_06_p) {
+  size_t batch = 1;
+  size_t channel = 3;
+  size_t height = 4;
+  size_t width = 5;
+
+  nntrainer::Tensor input(
+    {batch,
+     channel,
+     height,
+     width,
+     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT4}},
+    true, nntrainer::Tensor::Initializer::ONES);
+  nntrainer::Tensor output(batch, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+
+  // Dequantize by channel
+  EXPECT_NO_THROW(input.setScaleFactors({-2, 2, 4}, 1));
+  EXPECT_NO_THROW({ input.dequantize(output); });
+
+  _FP16 answer_data_1[] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
+                           -2, -2, -2, -2, -2, -2, -2, -2, 2,  2,  2,  2,
+                           2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+                           2,  2,  2,  2,  4,  4,  4,  4,  4,  4,  4,  4,
+                           4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4};
+
+  nntrainer::Tensor answer1(ml::train::TensorDim(batch, channel, height, width,
+                                                 {nntrainer::Tformat::NCHW,
+                                                  nntrainer::Tdatatype::FP16}),
+                            answer_data_1);
+
+  EXPECT_EQ(output, answer1);
+
+  // Dequantize by height
+  EXPECT_NO_THROW(input.setScaleFactors({-4.2, -2, 2, 4}, 2));
+  EXPECT_NO_THROW({ input.dequantize(output); });
+
+  _FP16 answer_data_2[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(-2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(-2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(-2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(4)};
+  nntrainer::Tensor answer2(ml::train::TensorDim(batch, channel, height, width,
+                                                 {nntrainer::Tformat::NCHW,
+                                                  nntrainer::Tdatatype::FP16}),
+                            answer_data_2);
+
+  EXPECT_EQ(output, answer2);
+
+  // Dequantize by width
+  EXPECT_NO_THROW(input.setScaleFactors({-4.2, -2, 2, 4, -8}, 3));
+  EXPECT_NO_THROW({ input.dequantize(output); });
+
+  _FP16 answer_data_3[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-8),   static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(2),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(-8),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-8),   static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(2),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(-8),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-8),   static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(2),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(-8),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-8),   static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(2),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(-8),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-8),   static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(2),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(-8),
+                           static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
+                           static_cast<_FP16>(2),    static_cast<_FP16>(4),
+                           static_cast<_FP16>(-8),   static_cast<_FP16>(-4.2),
+                           static_cast<_FP16>(-2),   static_cast<_FP16>(2),
+                           static_cast<_FP16>(4),    static_cast<_FP16>(-8)};
+
+  nntrainer::Tensor answer3(ml::train::TensorDim(batch, channel, height, width,
+                                                 {nntrainer::Tformat::NCHW,
+                                                  nntrainer::Tdatatype::FP16}),
+                            answer_data_3);
+
+  EXPECT_EQ(output, answer3);
+}
+
 GTEST_API_ int main(int argc, char **argv) {
   int result = -1;
 

--- a/test/unittest/unittest_nntrainer_tensor_nhwc.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_nhwc.cpp
@@ -4688,7 +4688,7 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setScaleFactors({1.5, 1.0, 0.5});
+  input.setScaleFactors({1.5, 1.0, 0.5}, 1);
 
   nntrainer::Tensor output(
     batch, channel, height, width,
@@ -4710,7 +4710,7 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setScaleFactors({1.5, 1.0, 0.5});
+  input.setScaleFactors({1.5, 1.0, 0.5}, 1);
 
   nntrainer::Tensor output(
     batch, channel, height, width,
@@ -4732,7 +4732,7 @@ TEST(nntrainer_Tensor, dequantize_03_p) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
-  input.setScaleFactors({1.5, 1.0, 0.5});
+  input.setScaleFactors({1.5, 1.0, 0.5}, 1);
 
   nntrainer::Tensor output;
   output.getDim().setFormat(nntrainer::Tformat::NHWC);
@@ -4766,7 +4766,7 @@ TEST(nntrainer_Tensor, dequantize_04_p) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
-  input.setScaleFactors({1.5, 1.0, 0.5});
+  input.setScaleFactors({1.5, 1.0, 0.5}, 1);
 
   nntrainer::Tensor output(
     batch, channel, height, width,
@@ -4779,6 +4779,38 @@ TEST(nntrainer_Tensor, dequantize_04_p) {
                          3,   7, 6,   3,   7, 6,   4.5, 8, 6.5, 4.5, 8, 6.5,
                          4.5, 8, 6.5, 4.5, 8, 6.5, 4.5, 8, 6.5, 6,   9, 7,
                          6,   9, 7,   6,   9, 7,   6,   9, 7,   6,   9, 7};
+
+  nntrainer::Tensor answer(ml::train::TensorDim(batch, channel, height, width,
+                                                {nntrainer::Tformat::NHWC,
+                                                 nntrainer::Tdatatype::FP32}),
+                           answer_data);
+
+  EXPECT_EQ(output, answer);
+}
+
+/**
+ * @brief dequantize nhwc qint4 tensor
+ */
+TEST(nntrainer_Tensor, dequantize_05_p) {
+  size_t batch = 1;
+  size_t channel = 10;
+  size_t height = 2;
+  size_t width = 1;
+
+  nntrainer::Tensor input(
+    {batch,
+     channel,
+     height,
+     width,
+     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT4}},
+    true, nntrainer::Tensor::Initializer::ONES);
+  input.setScaleFactors({-8, -6, -4, -2, -1, 1, 2, 4, 6, 7}, 1);
+  nntrainer::Tensor output;
+
+  EXPECT_NO_THROW({ output = input.dequantize(nntrainer::Tdatatype::FP32); });
+
+  float answer_data[] = {-8, -6, -4, -2, -1, 1, 2, 4, 6, 7,
+                         -8, -6, -4, -2, -1, 1, 2, 4, 6, 7};
 
   nntrainer::Tensor answer(ml::train::TensorDim(batch, channel, height, width,
                                                 {nntrainer::Tformat::NHWC,

--- a/test/unittest/unittest_nntrainer_tensor_pool.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool.cpp
@@ -438,7 +438,7 @@ TEST(TensorPool, validate_memory) {
 /**
  * @brief qint8 tensors reuse fp32 tensor memory space
  */
-TEST(TensorPool, validate_memory_reuse_p) {
+TEST(TensorPool, validate_memory_reuse_01_p) {
   // |--------- t1 ---------|
   // |-t2-||-t3-||-t4-||-t5-|
   nntrainer::TensorPool pool;
@@ -479,6 +479,67 @@ TEST(TensorPool, validate_memory_reuse_p) {
     t5 = pool.request("t5",
                       nntrainer::TensorDim({4}, {nntrainer::Tformat::NCHW,
                                                  nntrainer::Tdatatype::QINT8}),
+                      {1}, nntrainer::TensorLifespan::BACKWARD_FUNC_LIFESPAN));
+  EXPECT_NE(t5, nullptr);
+  EXPECT_FALSE(t5->isAllocated());
+
+  EXPECT_NO_THROW(pool.finalize(nntrainer::OptimizedV1Planner(), 0, 2));
+  EXPECT_EQ(pool.minMemoryRequirement(), t1->bytes());
+
+  EXPECT_NO_THROW(pool.allocate());
+
+  EXPECT_EQ(t1->getAddress<float>(0), (float *)t2->getAddress<int8_t>(0));
+  EXPECT_EQ(t1->getAddress<float>(1), (float *)t3->getAddress<int8_t>(0));
+  EXPECT_EQ(t1->getAddress<float>(2), (float *)t4->getAddress<int8_t>(0));
+  EXPECT_EQ(t1->getAddress<float>(3), (float *)t5->getAddress<int8_t>(0));
+
+  EXPECT_NO_THROW(pool.deallocate());
+}
+
+/**
+ * @brief qint4 tensors reuse fp32 tensor memory space
+ */
+TEST(TensorPool, validate_memory_reuse_02_p) {
+  // |--------- t1 ---------|
+  // |-t2-||-t3-||-t4-||-t5-|
+  nntrainer::TensorPool pool;
+  nntrainer::Tensor *t1 = nullptr, *t2 = nullptr, *t3 = nullptr, *t4 = nullptr,
+                    *t5 = nullptr;
+
+  EXPECT_NO_THROW(
+    t1 = pool.request("t1", nntrainer::TensorDim({4}), {0},
+                      nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN));
+  EXPECT_NE(t1, nullptr);
+  EXPECT_FALSE(t1->isAllocated());
+
+  EXPECT_NO_THROW(
+    t2 = pool.request("t2",
+                      nntrainer::TensorDim({8}, {nntrainer::Tformat::NCHW,
+                                                 nntrainer::Tdatatype::QINT4}),
+                      {1}, nntrainer::TensorLifespan::BACKWARD_FUNC_LIFESPAN));
+  EXPECT_NE(t2, nullptr);
+  EXPECT_FALSE(t2->isAllocated());
+
+  EXPECT_NO_THROW(
+    t3 = pool.request("t3",
+                      nntrainer::TensorDim({7}, {nntrainer::Tformat::NCHW,
+                                                 nntrainer::Tdatatype::QINT4}),
+                      {1}, nntrainer::TensorLifespan::BACKWARD_FUNC_LIFESPAN));
+  EXPECT_NE(t3, nullptr);
+  EXPECT_FALSE(t3->isAllocated());
+
+  EXPECT_NO_THROW(
+    t4 = pool.request("t4",
+                      nntrainer::TensorDim({8}, {nntrainer::Tformat::NCHW,
+                                                 nntrainer::Tdatatype::QINT4}),
+                      {1}, nntrainer::TensorLifespan::BACKWARD_FUNC_LIFESPAN));
+  EXPECT_NE(t4, nullptr);
+  EXPECT_FALSE(t4->isAllocated());
+
+  EXPECT_NO_THROW(
+    t5 = pool.request("t5",
+                      nntrainer::TensorDim({7}, {nntrainer::Tformat::NCHW,
+                                                 nntrainer::Tdatatype::QINT4}),
                       {1}, nntrainer::TensorLifespan::BACKWARD_FUNC_LIFESPAN));
   EXPECT_NE(t5, nullptr);
   EXPECT_FALSE(t5->isAllocated());


### PR DESCRIPTION
- Quantized Tensor is now available with Int 4 with scale.
- Two Int 4 values use one Int 8 which each use 4 bits
- Dequantization is performed by multiplying scaling factors with given index (b, c, h, w).
- Only read (getValueQint4), write (setValue), and dequantization operations are allowed.
    
**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped