### PR TITLE
[neon] Add padding function in sgemv_neon_fp16

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -102,7 +102,7 @@ static void sgemv_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
 
   if (TransA == CblasTrans) {
 #ifdef USE__FP16
-    if (incX == 1 && incY == 1 && (N % 16 == 0 || N % 8 == 0)) {
+    if (incX == 1 && incY == 1 && N % 4 == 0) {
       nntrainer::neon::sgemv_transpose_neon_fp16(A, X, Y, M, N, alpha, beta);
     } else {
       sgemv_loop_fp16(i, j, N, M);
@@ -112,7 +112,7 @@ static void sgemv_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
 #endif
   } else {
 #ifdef USE__FP16
-    if (incX == 1 && incY == 1 && (N % 16 == 0 || N % 8 == 0)) {
+    if (incX == 1 && incY == 1 && N % 4 == 0) {
       nntrainer::neon::sgemv_neon_fp16(A, X, Y, M, N, alpha, beta);
     } else {
       sgemv_loop_fp16(j, i, M, N);
@@ -650,6 +650,7 @@ void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
 #ifdef BLAS_NUM_THREADS
     openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
+
     return cblas_sgemv(
       order, TransA, M, N, alpha, static_cast<const float *>(A), lda,
       static_cast<const float *>(X), incX, beta, static_cast<float *>(Y), incY);
@@ -678,8 +679,9 @@ void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
 #ifdef BLAS_NUM_THREADS
   openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
-  return cblas_sgemv(order, TransA, M, N, alpha, A, lda, X, incX, beta, Y,
-                     incY);
+  cblas_sgemv(order, TransA, M, N, alpha, A, lda, X, incX, beta, Y, incY);
+  return;
+
 #else
   return sgemv_raw(order, TransA, M, N, alpha, A, lda, X, incX, beta, Y, incY);
 #endif

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -62,6 +62,33 @@ void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
                      uint32_t cols, float alpha, float beta);
 
 /**
+ * @brief     sgemv computation with neon : Y = alpha*A*X + beta*Y using
+ * 0-padding
+ * @param[in] A __fp16 * for Matrix A
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ * @param[in] rows number of A's row
+ * @param[in] cols number of A's columns
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void sgemv_neon_fp16_pad(const __fp16 *A, const __fp16 *X, __fp16 *Y,
+                         uint32_t rows, uint32_t cols, float alpha, float beta);
+
+/**
+ * @brief     sgemv computation with neon : Y = alpha*A*X + beta*Y
+ * @param[in] A __fp16 * for Matrix A
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ * @param[in] rows number of A's row
+ * @param[in] cols number of A's columns
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void sgemv_neon_fp16_fit(const __fp16 *A, const __fp16 *X, __fp16 *Y,
+                         uint32_t rows, uint32_t cols, float alpha, float beta);
+
+/**
  * @brief     transposed sgemv computation with neon
  *            Y = alpha*transpose(A)*X
  * + beta*Y
@@ -76,6 +103,37 @@ void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
 void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
                                uint32_t rows, uint32_t cols, float alpha,
                                float beta);
+/**
+ * @brief     transposed sgemv computation with neon using 0-padding
+ *            Y = alpha*transpose(A)*X
+ * + beta*Y
+ * @param[in] A __fp16 * for Matrix A
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ * @param[in] rows number of A's row
+ * @param[in] cols number of A's columns
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void sgemv_transpose_neon_fp16_pad(const __fp16 *A, const __fp16 *X, __fp16 *Y,
+                                   uint32_t rows, uint32_t cols, float alpha,
+                                   float beta);
+
+/**
+ * @brief     transposed sgemv computation with neon
+ *            Y = alpha*transpose(A)*X
+ * + beta*Y
+ * @param[in] A __fp16 * for Matrix A
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ * @param[in] rows number of A's row
+ * @param[in] cols number of A's columns
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void sgemv_transpose_neon_fp16_fit(const __fp16 *A, const __fp16 *X, __fp16 *Y,
+                                   uint32_t rows, uint32_t cols, float alpha,
+                                   float beta);
 
 /**
  * @brief     saxpy computation with neon: Y = alpha*X + Y

--- a/test/unittest/layers/layers_golden_tests.cpp
+++ b/test/unittest/layers/layers_golden_tests.cpp
@@ -224,7 +224,7 @@ static void compareRunContext(RunLayerContext &rc, std::ifstream &file,
       for (unsigned int idx = 0; idx < total; idx++) {
         auto d1 = t1.getValue<_FP16>(idx);
         auto d2 = t2.getValue<_FP16>(idx);
-        auto float_eq = [skip_cos_sim](_FP16 a, _FP16 b) {
+        auto float_eq = [&](_FP16 a, _FP16 b) {
           if (skip_cos_sim) {
             constexpr auto eps = 1e-1;
             if (a < b)


### PR DESCRIPTION
- Previously, when the Tensor column length is not divisible by 8, we have been applying sgemv_loop, which is not an optimized solution.
- In this PR, I would like to propose adding arbitrary-sized zero-padding to the Tensor to fit in the neon intrinsic SIMD calculation and accelerate the computing process.

- todo : In case of large-columned Tensor we should discuss about better padding-applying strategy.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped