### PR TITLE
[tflite_export] add Error Message, Fix Application

### DIFF
--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -12,9 +12,9 @@ subdir('Resnet/jni')
 subdir('YOLO/jni')
 subdir('ReinforcementLearning/DeepQ/jni')
 subdir('TransferLearning/CIFAR_Classification/jni')
-if enable_capi
-  subdir('TransferLearning/Draw_Classification/jni')
-endif
+# if enable_capi
+#   subdir('TransferLearning/Draw_Classification/jni')
+# endif
 subdir('Custom')
 subdir('ProductRatings/jni')
 subdir('AlexNet/jni')

--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -213,7 +213,7 @@ static void sgemm_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
                        const unsigned int ldc) {
 
 #ifdef USE__FP16
-  if ((M % 8 == 0) && (N % 8 == 0) && (K % 8 == 0)) {
+  if ((N % 8 == 0) && (K % 8 == 0)) {
     nntrainer::neon::sgemm_neon_fp16(A, B, C, M, N, K, alpha, beta,
                                      TransA == CblasTrans,
                                      TransB == CblasTrans);


### PR DESCRIPTION
Now, an Error occurs when export resnet to tflite format

Previously, the prop of the layer was changed in the process of comparing the values with the Pytorch.

 But, Tflite only supports ```same``` and ```valid``` padding, but the current application use value as 1,1.

To correct this, a macro was added, and a more detailed error message was added to the tflite exporter.