### PR TITLE
[Release] NNTrainer v0.5.1 Release @open sesame 09/18 10:37

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nntrainer (0.5.1) unstable; urgency=medium
+
+  * 0.5.1 released
+
+ -- jijoongmoon <jijoong.moon@samsung.com>  Tue, 12 Sep 2023 10:37:24 +0900
+
 nntrainer (0.5.0) unstable; urgency=medium
 
   * 0.5.0 released

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('nntrainer', 'c', 'cpp',
-  version: '0.5.0',
+  version: '0.5.1',
   license: ['apache-2.0'],
   meson_version: '>=0.50.0',
   default_options: [

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -49,7 +49,7 @@
 
 Name:		nntrainer
 Summary:	Software framework for training neural networks
-Version:	0.5.0
+Version:	0.5.1
 Release:	0
 Packager:	Jijoong Moon <jijoong.moon@samsung.com>
 License:	Apache-2.0
@@ -630,6 +630,8 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %endif
 
 %changelog
+* Tue Sep 12 2023 Jijoong Moon <jijoong.moon@samsung.com>
+- Release of 0.5.1
 * Tue Apr 04 2023 Jijoong Moon <jijoong.moon@samsung.com>
 - Release of 0.5.0
 * Mon Sep 26 2022 Jijoong Moon <jijoong.moon@samsung.com>


### PR DESCRIPTION
NNTrainer v0.5.1 is released.

Resolves:

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>