### PR TITLE
[Tensor] Dequantize tensor in forwarding FC layer 

### DIFF
--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -376,7 +376,7 @@ public:
    *
    * @return TensorDim::Format NCHW or NHWC
    */
-  std::array<const std::string, 3> getTensorType() {
+  std::array<std::string, 3> getTensorType() {
 
     return {tensor_format, tensor_dtype[0], tensor_dtype[1]};
   };

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -36,10 +36,12 @@ static void suffixSpec(VarGradSpecV2 &spec, unsigned int idx) {
   }
 }
 
-InitLayerContext::InitLayerContext(
-  const std::vector<TensorDim> &dim, const std::vector<bool> &req_out_connected,
-  bool in_place_, const std::string &n, const std::string &prefix_,
-  const float max_norm, std::array<const std::string, 3> tensor_type_) :
+InitLayerContext::InitLayerContext(const std::vector<TensorDim> &dim,
+                                   const std::vector<bool> &req_out_connected,
+                                   bool in_place_, const std::string &n,
+                                   const std::string &prefix_,
+                                   const float max_norm,
+                                   std::array<std::string, 3> tensor_type_) :
   input_dim(dim),
   in_place(in_place_),
   clip_by_global_norm(max_norm),
@@ -152,6 +154,16 @@ RunLayerContext::RunLayerContext(const std::string &name, bool trainable,
 
   if (!validate())
     throw std::invalid_argument("Creating invalid run context");
+}
+
+/**
+ * @brief Get the Weight tensor object
+ *
+ * @param idx Identifier of the weight
+ * @return Tensor& Reference to the weight tensor
+ */
+Tensor &RunLayerContext::getWeight(unsigned int idx) const {
+  return weights[idx]->getVariableRef();
 }
 
 /**

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -52,8 +52,8 @@ public:
                    const std::vector<bool> &req_out_connected, bool in_place_,
                    const std::string &n = "", const std::string &prefix_ = "",
                    const float max_norm = 0.0,
-                   std::array<const std::string, 3> tensor_type_ = {
-                     "NCHW", "FP32", "FP32"});
+                   std::array<std::string, 3> tensor_type_ = {"NCHW", "FP32",
+                                                              "FP32"});
   /**
    * @brief   get Tensor Format of Layer
    *
@@ -177,10 +177,10 @@ public:
                              const Tensor::Initializer init,
                              const WeightRegularizer reg, const float reg_const,
                              const float decay, const std::string &name,
-                             bool trainable = true) {
+                             bool trainable = true, unsigned int out_axis = 3) {
     weights_spec.emplace_back(dim, init, reg, reg_const, decay,
                               clip_by_global_norm, trainable,
-                              prefix + ":" + name);
+                              prefix + ":" + name, out_axis);
     return weights_spec.size() - 1;
   }
 
@@ -346,7 +346,7 @@ private:
   /**< a bool vector to tell if requested out is actually connected to others */
   std::string name;   /**< name of the layer */
   std::string prefix; /**< prefix of the layer */
-  std::array<const std::string, 3> tensor_type;
+  std::array<std::string, 3> tensor_type;
 };
 
 /**
@@ -402,9 +402,7 @@ public:
    * @param idx Identifier of the weight
    * @return Tensor& Reference to the weight tensor
    */
-  template <typename T = float> Tensor &getWeight(unsigned int idx) const {
-    return weights[idx]->getVariableRef();
-  }
+  Tensor &getWeight(unsigned int idx) const;
 
   /**
    * @brief Get the Weight Gradient tensor object

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -496,13 +496,12 @@ void LayerNode::clearOptVar() {
 /**
  * @brief     Finalize creating the layer node
  */
-InitLayerContext
-LayerNode::finalize(const std::vector<TensorDim> &input_dims,
-                    std::array<const std::string, 3> tensor_type) {
-  // auto get_tensor_datatype = [](const std::string ty) -> TensorDim::DataType {
-  // 			       return from_string(ty);
+InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
+                                     std::array<std::string, 3> tensor_type) {
+  // auto get_tensor_datatype = [](const std::string ty) -> TensorDim::DataType
+  // { 			       return from_string(ty);
   // };
-  
+
   if (run_context)
     throw std::runtime_error(
       "Trying to finalizing a layer which is already finalized in layer: " +

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -244,7 +244,7 @@ public:
    * @note configureRunContext() is expected to called right after this.
    */
   InitLayerContext finalize(const std::vector<TensorDim> &input_dims = {},
-                            std::array<const std::string, 3> tensor_type = {
+                            std::array<std::string, 3> tensor_type = {
                               "NCHW", "FP32", "FP32"});
 
   /**

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -380,8 +380,8 @@ std::vector<Weight *> Manager::requestWeights(
 
   for (unsigned int i = 0; i < weights_spec.size(); ++i) {
     auto &[dim, t_initializer, w_reg, w_reg_const, decay, clip_by_global_norm,
-           need_gradient, name] = weights_spec.at(i);
-    
+           need_gradient, name, axis] = weights_spec.at(i);
+
     std::vector<unsigned int> var_exec_order;
     for (auto order : default_var_exec_order) {
       var_exec_order.push_back(order);

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -103,7 +103,6 @@ Tensor::Tensor(const TensorDim &d, bool alloc_now, Tensor::Initializer init,
     dim = d;
     strides = d.computeStrides();
     initializer = init;
-    output_axis = 3;
     if (alloc_now)
       allocate();
   }
@@ -3531,34 +3530,9 @@ uint8_t Tensor::decode_qint(uint8_t val, bool isHigh) const {
   return val;
 }
 
-void Tensor::setOutputAxis(int axis) {
-  if (axis < 0 || axis > 3) {
-    throw std::invalid_argument("Error: invalid parameter");
-  }
-  output_axis = axis;
-}
-
-int Tensor::getOutputAxis() const { return output_axis; }
-
 void Tensor::setScaleFactors(std::vector<float> scales) {
   if (scales.empty()) {
     throw std::invalid_argument("Error: invalid parameter");
-  }
-
-  if (output_axis == 0 && scales.size() != batch()) {
-    throw std::invalid_argument("Error: scale_factors.size() != batch() ");
-  }
-
-  if (output_axis == 1 && scales.size() != channel()) {
-    throw std::invalid_argument("Error: scale_factors.size() != channel() ");
-  }
-
-  if (output_axis == 2 && scales.size() != height()) {
-    throw std::invalid_argument("Error: scale_factors.size() != height() ");
-  }
-
-  if (output_axis == 3 && scales.size() != width()) {
-    throw std::invalid_argument("Error: scale_factors.size() != width() ");
   }
 
   scale_factors = scales;
@@ -3569,22 +3543,6 @@ std::vector<float> Tensor::getScaleFactors() const { return scale_factors; }
 void Tensor::setZeroPoints(std::vector<uint8_t> zp) {
   if (zp.empty()) {
     throw std::invalid_argument("Error: invalid parameter");
-  }
-
-  if (output_axis == 0 && zp.size() != batch()) {
-    throw std::invalid_argument("Error: zero_points.size() != batch() ");
-  }
-
-  if (output_axis == 1 && zp.size() != channel()) {
-    throw std::invalid_argument("Error: zero_points.size() != channel() ");
-  }
-
-  if (output_axis == 2 && zp.size() != height()) {
-    throw std::invalid_argument("Error: zero_points.size() != height() ");
-  }
-
-  if (output_axis == 3 && zp.size() != width()) {
-    throw std::invalid_argument("Error: zero_points.size() != width() ");
   }
 
   zero_points = zp;

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1998,14 +1998,14 @@ public:
    * @brief     Dequantize Tensor
    * @retval    Dequantized Tensor
    */
-  template <typename T = float> Tensor dequantize() const {
+  template <typename T = float> Tensor dequantize(unsigned int axis) const {
     Tdatatype dtype =
       (typeid(T) == typeid(float)) ? Tdatatype::FP32 : Tdatatype::FP16;
 
     Tensor t =
       Tensor(batch(), channel(), height(), width(), getFormat(), dtype);
 
-    return dequantize<T>(t);
+    return dequantize<T>(t, axis);
   }
 
   /**
@@ -2013,7 +2013,8 @@ public:
    * @param[out] output Tensor to store the result
    * @retval     Dequantized Tensor
    */
-  template <typename T> Tensor &dequantize(Tensor &output) const {
+  template <typename T>
+  Tensor &dequantize(Tensor &output, unsigned int axis) const {
     if (getDataType() == Tdatatype::FP32 || getDataType() == Tdatatype::FP16) {
       throw std::invalid_argument("Error: Tensor cannot be dequantized");
     }

--- a/nntrainer/tensor/tensor_wrap_specs.h
+++ b/nntrainer/tensor/tensor_wrap_specs.h
@@ -42,35 +42,39 @@ enum class TensorLifespan {
                            needed during forward operations */
   CALC_DERIV_LIFESPAN = 0b010,   /**< must be valid during calcDerivative() */
   CALC_GRAD_LIFESPAN = 0b100, /**< tensor must be valid during calcGradient() */
-  CALC_AGRAD_LIFESPAN = 0b1000, /**< tensor must be valid during calcGradient() */
+  CALC_AGRAD_LIFESPAN =
+    0b1000, /**< tensor must be valid during calcGradient() */
   CALC_GRAD_DERIV_LIFESPAN = 0b110, /**< tensor must not be reset before during
                              the calc_grad and clac_deriv call, eg. temporary
                              tensors needed during backward operations */
-  CALC_GRAD_DERIV_AGRAD_LIFESPAN = 0b1110, /**< tensor must not be reset before during
-                             the calc_grad, clac_deriv and apply gradient call,
-                             eg. temporary tensors needed during backward operations */
-  FORWARD_GRAD_LIFESPAN = 0b101,    /**< Forward + grad lifespan */
-  FORWARD_GRAD_AGRAD_LIFESPAN = 0b1101, /**< Forward + grad + apply gradient lifespan */
-  FORWARD_DERIV_LIFESPAN = 0b011,   /**< Forward + deriv lifespan */
+  CALC_GRAD_DERIV_AGRAD_LIFESPAN =
+    0b1110,                      /**< tensor must not be reset before during
+                   the calc_grad, clac_deriv and apply gradient call,
+                   eg. temporary tensors needed during backward operations */
+  FORWARD_GRAD_LIFESPAN = 0b101, /**< Forward + grad lifespan */
+  FORWARD_GRAD_AGRAD_LIFESPAN =
+    0b1101, /**< Forward + grad + apply gradient lifespan */
+  FORWARD_DERIV_LIFESPAN = 0b011, /**< Forward + deriv lifespan */
   BACKWARD_FUNC_LIFESPAN =
-    CALC_GRAD_DERIV_AGRAD_LIFESPAN, /**< Alias of CALC_GRAD_DERIV_AGRAD_LIFESPAN */
+    CALC_GRAD_DERIV_AGRAD_LIFESPAN, /**< Alias of CALC_GRAD_DERIV_AGRAD_LIFESPAN
+                                     */
   ITERATION_LIFESPAN = 0b1111, /**< tensor must not be reset until the owning
                         layer finishes its execution in the current
                         iteration, eg. hidden memory/cells of RNN */
-  EPOCH_LIFESPAN = 0b11111,    /**< tensor must be valid before the epoch ends */
-  MAX_LIFESPAN = 0b111111,     /**< tensor must not be reset until the end of the
-                      model  execution, eg. layer weights */
+  EPOCH_LIFESPAN = 0b11111, /**< tensor must be valid before the epoch ends */
+  MAX_LIFESPAN = 0b111111,  /**< tensor must not be reset until the end of the
+                   model  execution, eg. layer weights */
 };
 
 /**
  * @brief Specification of the Weight as a tensor wrapper
  *
  * @details The tuple values are dimension, initializer, regularizer,
- * regularizer_constant, decay, clip gradient constant, need_gradient property
- * amd name of the tensor object.
+ * regularizer_constant, decay, clip gradient constant, need_gradient property,
+ * name and output axis of the tensor object.
  */
 typedef std::tuple<TensorDim, Tensor::Initializer, WeightRegularizer, float,
-                   float, float, bool, const std::string>
+                   float, float, bool, const std::string, unsigned int>
   WeightSpec;
 
 /**

--- a/nntrainer/tensor/weight.cpp
+++ b/nntrainer/tensor/weight.cpp
@@ -21,12 +21,13 @@ namespace nntrainer {
 Weight::Weight(const TensorDim &dim, const Tensor::Initializer init,
                const WeightRegularizer reg, const float reg_const,
                const float decay_const, const float max_norm, bool train,
-               bool alloc_now_, std::string name) :
+               bool alloc_now_, std::string name, unsigned int axis) :
   Var_Grad(dim, init, train, alloc_now_, name),
   regularizer(reg),
   regularizer_constant(reg_const),
   decay(decay_const),
-  clip_by_global_norm(max_norm) {
+  clip_by_global_norm(max_norm),
+  output_axis(axis) {
   if (init == Tensor::Initializer::NONE)
     throw std::invalid_argument("Weight initializer cannot be none");
   if (regularizer == WeightRegularizer::UNKNOWN)

--- a/test/unittest/layers/layers_golden_tests.cpp
+++ b/test/unittest/layers/layers_golden_tests.cpp
@@ -47,7 +47,7 @@ static const std::string getGoldenPath(const std::string &file_name) {
 
 static InitLayerContext
 createInitContext(Layer *layer, const std::string &input_shape_str,
-                  std::array<const std::string, 3> tensor_type) {
+                  std::array<std::string, 3> tensor_type) {
   struct shape_parser_ : Property<TensorDim> {
     using prop_tag = dimension_prop_tag;
   };

--- a/test/unittest/unittest_nntrainer_tensor_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_fp16.cpp
@@ -5801,7 +5801,6 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
   nntrainer::Tensor input(batch, channel, height, width,
                           nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({1, 4, 7});
 
@@ -5809,7 +5808,7 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
                            nntrainer::Tformat::NCHW,
                            nntrainer::Tdatatype::FP16);
 
-  EXPECT_THROW({ input.dequantize<_FP16>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<_FP16>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -5826,7 +5825,6 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
 
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({1, 4, 7});
 
@@ -5834,7 +5832,7 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
                            nntrainer::Tformat::NCHW,
                            nntrainer::Tdatatype::FP16);
 
-  EXPECT_THROW({ input.dequantize<_FP16>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<_FP16>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -5855,7 +5853,7 @@ TEST(nntrainer_Tensor, dequantize_03_n) {
                            nntrainer::Tformat::NCHW,
                            nntrainer::Tdatatype::FP16);
 
-  EXPECT_THROW({ input.dequantize<_FP16>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<_FP16>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -5871,13 +5869,12 @@ TEST(nntrainer_Tensor, dequantize_04_p) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({0, 0, 0});
 
   nntrainer::Tensor output;
 
-  EXPECT_NO_THROW({ output = input.dequantize<_FP16>(); });
+  EXPECT_NO_THROW({ output = input.dequantize<_FP16>(1); });
 
   _FP16 answer_data[] = {
     static_cast<_FP16>(1.5), static_cast<_FP16>(1.5), static_cast<_FP16>(1.5),
@@ -5930,10 +5927,9 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
                            nntrainer::Tdatatype::FP16);
 
   // Dequantize by channel
-  input.setOutputAxis(1);
   EXPECT_NO_THROW(input.setScaleFactors({2, -2, -4}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output); });
+  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 1); });
 
   _FP16 answer_data_1[] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
                            -2, -2, -2, -2, -2, -2, -2, -2, 2,  2,  2,  2,
@@ -5949,10 +5945,9 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
   EXPECT_EQ(output, answer1);
 
   // Dequantize by height
-  input.setOutputAxis(2);
   EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4.8}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output); });
+  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 2); });
 
   _FP16 answer_data_2[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
                            static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
@@ -5992,10 +5987,9 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
   EXPECT_EQ(output, answer2);
 
   // Dequantize by width
-  input.setOutputAxis(3);
   EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4, 8}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output); });
+  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 3); });
 
   _FP16 answer_data_3[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
                            static_cast<_FP16>(2),    static_cast<_FP16>(4),
@@ -6057,10 +6051,9 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
                            nntrainer::Tdatatype::FP16);
 
   // Dequantize by channel
-  input.setOutputAxis(1);
   EXPECT_NO_THROW(input.setScaleFactors({2, -2, -4}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output); });
+  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 1); });
 
   _FP16 answer_data_1[] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
                            -2, -2, -2, -2, -2, -2, -2, -2, 2,  2,  2,  2,
@@ -6076,10 +6069,9 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
   EXPECT_EQ(output, answer1);
 
   // Dequantize by height
-  input.setOutputAxis(2);
   EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output); });
+  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 2); });
 
   _FP16 answer_data_2[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
                            static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
@@ -6119,10 +6111,9 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
   EXPECT_EQ(output, answer2);
 
   // Dequantize by width
-  input.setOutputAxis(3);
   EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4, 8}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output); });
+  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 3); });
 
   _FP16 answer_data_3[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
                            static_cast<_FP16>(2),    static_cast<_FP16>(4),

--- a/test/unittest/unittest_nntrainer_tensor_nhwc.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_nhwc.cpp
@@ -4688,7 +4688,6 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({1, 0, 3});
 
@@ -4696,7 +4695,7 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::FP32});
 
-  EXPECT_THROW({ input.dequantize<float>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -4712,7 +4711,6 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({1, 0, 3});
 
@@ -4720,7 +4718,7 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
 
-  EXPECT_THROW({ input.dequantize<float>(output); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -4736,14 +4734,13 @@ TEST(nntrainer_Tensor, dequantize_03_p) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
-  input.setOutputAxis(1);
   input.setScaleFactors({1.5, 1.0, 0.5});
   input.setZeroPoints({5, 5, 5});
 
   nntrainer::Tensor output;
   output.getDim().setFormat(nntrainer::Tformat::NHWC);
 
-  EXPECT_NO_THROW({ output = input.dequantize<float>(); });
+  EXPECT_NO_THROW({ output = input.dequantize<float>(1); });
 
   float answer_data[] = {
     -6,   1, 3,   -6,   1, 3,   -6,   1, 3,   -6,   1, 3,   -6,   1, 3,
@@ -4772,7 +4769,6 @@ TEST(nntrainer_Tensor, dequantize_04_p) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
-  input.setOutputAxis(2);
   input.setScaleFactors({2.5, 2.0, 1.5, 1.0});
   input.setZeroPoints({8, 8, 8, 8});
 
@@ -4780,7 +4776,7 @@ TEST(nntrainer_Tensor, dequantize_04_p) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::FP32});
 
-  EXPECT_NO_THROW({ input.dequantize<float>(output); });
+  EXPECT_NO_THROW({ input.dequantize<float>(output, 2); });
 
   float answer_data[] = {
     -17.5, -5, 7.5, -17.5, -5, 7.5, -17.5, -5, 7.5, -17.5, -5, 7.5,
@@ -4815,13 +4811,12 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
      {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT4}},
     true, nntrainer::Tensor::Initializer::ZEROS);
 
-  input.setOutputAxis(1);
   input.setScaleFactors({8, 6, 4, 2, 1, -1, -2, -4, -6, -7});
   input.setZeroPoints({1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
 
   nntrainer::Tensor output;
 
-  EXPECT_NO_THROW({ output = input.dequantize<float>(); });
+  EXPECT_NO_THROW({ output = input.dequantize<float>(1); });
 
   float answer_data[] = {-8, -6, -4, -2, -1, 1, 2, 4, 6, 7,
                          -8, -6, -4, -2, -1, 1, 2, 4, 6, 7};


### PR DESCRIPTION
- FC layer manually dequantizes quantized weight tensor in forwarding instead of automatically dequantizing in getWeight.
- Dequantize function takes the output axis as a parameter instead of the tensor having an axis variable.
- Add output axis in weight spec to identify the direction of scale and zero points multiplication.

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped
