### PR TITLE
[Bug] Fix build error in yolo with fp16 @open sesame 09/15 16:02

### DIFF
--- a/Applications/YOLO/jni/yolo_v2_loss.cpp
+++ b/Applications/YOLO/jni/yolo_v2_loss.cpp
@@ -179,7 +179,7 @@ calc_iou(nntrainer::Tensor &bbox1_x1, nntrainer::Tensor &bbox1_y1,
     intersection_width.apply_i<float>(nntrainer::ActiFunc::relu<float>);
   } else if (type_intersection_width == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-    intersection_width.apply_i<_FP16>(nntrainer::ActiFunc::relu<float>);
+    intersection_width.apply_i<_FP16>(nntrainer::ActiFunc::relu<_FP16>);
 #else
     throw std::runtime_error("Not supported data type");
 #endif
@@ -567,10 +567,10 @@ void YoloV2LossLayer::forwarding(nntrainer::RunLayerContext &context,
   bbox_w_pred_anchor.multiply_i(anchors_w);
   auto type_bbox_w_pred_anchor = bbox_w_pred_anchor.getDataType();
   if (type_bbox_w_pred_anchor == ml::train::TensorDim::DataType::FP32) {
-    bbox_w_pred_anchor.apply_i<float>(nntrainer::sqrtFloat);
+    bbox_w_pred_anchor.apply_i<float>(nntrainer::sqrtFloat<float>);
   } else if (type_bbox_w_pred_anchor == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-    bbox_w_pred_anchor.apply_i<_FP16>(nntrainer::sqrtFloat);
+    bbox_w_pred_anchor.apply_i<_FP16>(nntrainer::sqrtFloat<_FP16>);
 #else
     throw std::runtime_error("Not supported data type");
 #endif
@@ -579,10 +579,10 @@ void YoloV2LossLayer::forwarding(nntrainer::RunLayerContext &context,
   bbox_h_pred_anchor.multiply_i(anchors_h);
   auto type_bbox_h_pred_anchor = bbox_h_pred_anchor.getDataType();
   if (type_bbox_h_pred_anchor == ml::train::TensorDim::DataType::FP32) {
-    bbox_h_pred_anchor.apply_i<float>(nntrainer::sqrtFloat);
+    bbox_h_pred_anchor.apply_i<float>(nntrainer::sqrtFloat<float>);
   } else if (type_bbox_h_pred_anchor == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-    bbox_h_pred_anchor.apply_i<_FP16>(nntrainer::sqrtFloat);
+    bbox_h_pred_anchor.apply_i<_FP16>(nntrainer::sqrtFloat<_FP16>);
 #else
     throw std::runtime_error("Not supported data type");
 #endif
@@ -808,10 +808,10 @@ unsigned int YoloV2LossLayer::find_responsible_anchors(float bbox_ratio) {
   nntrainer::Tensor similarity = anchors_ratio.subtract(bbox_ratio);
   auto data_type = similarity.getDataType();
   if (data_type == ml::train::TensorDim::DataType::FP32) {
-    similarity.apply_i<float>(nntrainer::absFloat);
+    similarity.apply_i<float>(nntrainer::absFloat<float>);
   } else if (data_type == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-    similarity.apply_i<_FP16>(nntrainer::absFloat);
+    similarity.apply_i<_FP16>(nntrainer::absFloat<_FP16>);
 #else
     throw std::runtime_error("Not supported data type");
 #endif

--- a/nntrainer/optimizers/adam.cpp
+++ b/nntrainer/optimizers/adam.cpp
@@ -86,7 +86,7 @@ void Adam::applyGradient(RunOptimizerContext &context) {
   wv.add_i(x_grad.multiply(x_grad), 1.0f - beta2);
 
   if (torch_ref) {
-    Tensor denom = wv.apply<float>(sqrtFloat);
+    Tensor denom = wv.apply<float>(sqrtFloat<float>);
     denom.divide_i(sqrtFloat(biasCorrection2));
     denom.add_i(epsilon);
     wm.divide(denom, x_grad);

--- a/nntrainer/utils/util_func.cpp
+++ b/nntrainer/utils/util_func.cpp
@@ -36,11 +36,7 @@ namespace nntrainer {
 
 static std::uniform_real_distribution<float> dist(-0.5, 0.5);
 
-float sqrtFloat(float x) { return sqrt(x); };
-
 double sqrtDouble(double x) { return sqrt(x); };
-
-float absFloat(float x) { return abs(x); };
 
 float logFloat(float x) { return log(x + 1.0e-20); }
 

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -81,7 +81,9 @@ static auto rng = [] {
  * @brief     sqrt function for float type
  * @param[in] x float
  */
-float sqrtFloat(float x);
+template <typename T = float> T sqrtFloat(T x) {
+  return static_cast<T>(sqrt((float)x));
+}
 
 /**
  * @brief    sqrt function for dobuld type
@@ -95,7 +97,9 @@ double sqrtDouble(double x);
  * @brief     abs function for float type
  * @param[in] x float
  */
-float absFloat(float x);
+template <typename T = float> T absFloat(T x) {
+  return static_cast<T>(abs((float)x));
+}
 
 /**
  * @brief     log function for float type

--- a/test/unittest/unittest_nntrainer_tensor_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_fp16.cpp
@@ -103,14 +103,12 @@ TEST(nntrainer_Tensor, multiply_i_01_fp16_p) {
                           nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
 
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.print(std::cout);
 
   nntrainer::Tensor original;
   original.copy(input);
 
   status = input.multiply_i(2.0);
   EXPECT_EQ(status, ML_ERROR_NONE);
-  input.print(std::cout);
 
   _FP16 *data = original.getData<_FP16>();
   ASSERT_NE(nullptr, data);


### PR DESCRIPTION
This patch fixes the build error in yolo_v2_loss with fp16 enabled. The following works are done.
- Template sqrtFloat and absFloat
- Remove unnecessary print in the fp16 unit test

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped