### PR TITLE
[Tensor] Read quantized tensor from a binary file

### DIFF
--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1416,8 +1416,7 @@ public:
    */
   size_t bytes() const {
     if (getDataType() == Tdatatype::QINT4) {
-      return (dim.batch() + 1) * (dim.channel() + 1) * (dim.height() + 1) *
-             (dim.width() + 1) / 16 * dim.getDataTypeSize();
+      return (size() * dim.getDataTypeSize() + 1) / 2;
     }
     return size() * dim.getDataTypeSize();
   }
@@ -1671,8 +1670,9 @@ public:
   /**
    * @brief     Read the Tensor from file
    * @param[in] file input file stream
+   * @param[in] s_type scale factor data type
    */
-  void read(std::ifstream &file);
+  void read(std::ifstream &file, Tdatatype s_type = Tdatatype::FP32);
 
   /**
    * @brief     return argument index which value is max by batch

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -4422,7 +4422,6 @@ TEST(nntrainer_Tensor, dequantize_04_n) {
 
   input.setScaleFactors({2.0, 1.5, 1.0, 0.5});
   input.setZeroPoints({2, 3, 4, 5});
-  std::cout << "before" << std::endl;
   EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
   EXPECT_NO_THROW({ input.dequantize<float>(output, 2); });
 }


### PR DESCRIPTION
This patch adds functionality to read quantized tensors from a binary file. Details are as follows.

- Read the tensor in the following order (axis, scale factors, zero points, and values).
- `Tensor::read` takes an extra argument of datatype to identify the datatype of scale factors and read exact bytes.
- Fix QINT4 tensor print segfault issue.

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped