### PR TITLE
[Application] handle getcwd return null pointer @open sesame 09/15 16:46

### DIFF
--- a/Applications/SimpleShot/task_runner.cpp
+++ b/Applications/SimpleShot/task_runner.cpp
@@ -104,7 +104,9 @@ const std::string getcwd_() {
   const size_t bufsize = 4096;
   char buffer[bufsize];
 
-  return getcwd(buffer, bufsize);
+  char *cwd = getcwd(buffer, bufsize);
+  std::string ret = (cwd == NULL) ? "" : std::string(cwd);
+  return ret;
 }
 } // namespace
 


### PR DESCRIPTION
 - Handle when getcwd return NULL to prevent dereference null pointer