### PR TITLE
[Svace] Fix Ahub issues

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -103,6 +103,7 @@ Tensor::Tensor(const TensorDim &d, bool alloc_now, Tensor::Initializer init,
     dim = d;
     strides = d.computeStrides();
     initializer = init;
+    output_axis = 3;
     if (alloc_now)
       allocate();
   }

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -2032,7 +2032,7 @@ public:
       throw std::invalid_argument("Error: No scale factors");
     }
 
-    int idx;
+    int idx = 0;
     for (unsigned int b = 0; b < batch(); ++b) {
       for (unsigned int c = 0; c < channel(); ++c) {
         for (unsigned int h = 0; h < height(); ++h) {


### PR DESCRIPTION
Added exception handling when malloc fails.

The value of the idx variable has been changed to be initialized when declared.

In the tensor constructor, output_axis was changed to be initialized to 3.