### PR TITLE
[tflite_export] add Error Message, Fix Application @open sesame 10/05 15:54

### DIFF
--- a/Applications/Resnet/jni/main.cpp
+++ b/Applications/Resnet/jni/main.cpp
@@ -114,9 +114,13 @@ std::vector<LayerHandle> resnetBlock(const std::string &block_name,
     return createLayer("conv2d", props);
   };
 
-  /** residual path */
+/** residual path */
+#if defined(ENABLE_TFLITE_INTERPRETER)
+  LayerHandle a1 = create_conv("a1", 3, downsample ? 2 : 1, "same", input_name);
+#else
   LayerHandle a1 = create_conv("a1", 3, downsample ? 2 : 1,
                                downsample ? "1,1" : "same", input_name);
+#endif
   LayerHandle a2 =
     createLayer("batch_normalization",
                 {with_name("a2"), withKey("activation", "relu"),
@@ -127,7 +131,11 @@ std::vector<LayerHandle> resnetBlock(const std::string &block_name,
   /** skip path */
   LayerHandle b1 = nullptr;
   if (downsample) {
+#if defined(ENABLE_TFLITE_INTERPRETER)
+    b1 = create_conv("b1", 1, 2, "same", input_name);
+#else
     b1 = create_conv("b1", 1, 2, "0,0", input_name);
+#endif
   }
 
   const std::string skip_name = b1 ? scoped_name("b1") : input_name;

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -197,7 +197,12 @@ void Exporter::saveTflResult(
   auto strides = std::get<std::array<props::Stride, CONV2D_DIM>>(props);
   assert(strides.size() == CONV2D_DIM);
   auto padding = std::get<props::Padding2D>(props).get();
-  assert(padding == "same" || padding == "valid");
+  if (padding != "same" && padding != "valid") {
+    std::ostringstream ss;
+    ss << "Unsupported padding type; \"" << padding
+       << "\" is not supported. Use \"same\" or \"valid\".";
+    throw std::runtime_error(ss.str());
+  }
   auto options = tflite::CreateConv2DOptions(*fbb, tflite_padding(padding),
                                              strides.at(0), strides.at(1))
                    .Union();


### PR DESCRIPTION
Now, an Error occurs when export resnet to tflite format

Previously, the prop of the layer was changed in the process of comparing the values with the Pytorch. But, Tflite only supports ```same``` and ```valid``` padding, but the current application use value as 1,1.

To correct this, a macro was added, and a more detailed error message was added to the tflite exporter.