### PR TITLE
[Wait for #2311] [blas/neon] Use inter-fp32 value in dimension shrinking computation in neon

### DIFF
--- a/nntrainer/tensor/blas_interface.h
+++ b/nntrainer/tensor/blas_interface.h
@@ -6,6 +6,7 @@
  * @date   28 Aug 2020
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Sungsik Kong <ss.kong@samsung.com>
  * @bug    No known bugs except for NYI items
  * @brief  This is dummy header for blas support
  *
@@ -35,77 +36,251 @@ enum CBLAS_TRANSPOSE {
 #include <helper_functions.h>
 #endif
 
+#include <cstdint>
 #include <tensor_dim.h>
-
 namespace nntrainer {
 
 #ifdef ENABLE_FP16
+/**
+ * @brief     sscal computation : X = alpha * X
+ * @param[in] N number of elements in X
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] alpha float number
+ */
 void sscal(const unsigned int N, const float alpha, _FP16 *X, const int incX);
+
+/**
+ * @brief     snrm2 computation : Euclidean norm
+ * @param[in] N number of elements in X
+ * @param[in] X __fp16 * for Vector X
+ */
 _FP16 snrm2(const int N, const _FP16 *X, const int incX);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ */
 void scopy(const unsigned int N, const _FP16 *X, const int incX, _FP16 *Y,
-           const int intY);
+           const int incY);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X uint8_t * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ */
+void scopy(const unsigned int N, const uint8_t *X, const int incX, _FP16 *Y,
+           const int incY);
+
+/**
+ * @brief     sdot computation : sum of all X * Y
+ * @param[in] N number of elements in Y
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ */
 _FP16 sdot(const unsigned int N, const _FP16 *X, const unsigned int incX,
-            const _FP16 *Y, const unsigned int incY);
+           const _FP16 *Y, const unsigned int incY);
+
+/**
+ * @brief     saxpy computation : Y = alpha*X + Y
+ * @param[in] N number of elements in Y
+ * @param[in] alpha float number
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ */
 void saxpy(const unsigned int N, const float alpha, const _FP16 *X,
            const int incX, _FP16 *Y, const int incY);
+
+/**
+ * @brief     sgemm computation : Y = alpha*op(A)*op(B) + beta*C,
+ * where op(X) is one of X or X**T
+ * @param[in] A __fp16 * for Matrix A
+ * @param[in] B __fp16 * for Matrix B
+ * @param[in] C __fp16 * for Matrix C
+ * @param[in] M number of op(A)'s and C's row
+ * @param[in] N number of op(B)'s and C's columns
+ * @param[in] K number of op(A)'s and columns and op(B)'s rows
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
 void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
            const unsigned int M, const unsigned int N, const unsigned int K,
            const float alpha, const _FP16 *A, const unsigned int lda,
            const _FP16 *B, const unsigned int ldb, const float beta, _FP16 *C,
            const unsigned int ldc);
+/**
+ * @brief     sgemv computation : Y = alpha*A*X + beta*Y
+ * @param[in] A float * for Matrix A
+ * @param[in] X float * for Vector X
+ * @param[in] Y float * for Vector Y
+ * @param[in] rows number of A's row
+ * @param[in] cols number of A's columns
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
 void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
            const unsigned int N, const float alpha, const _FP16 *A,
            const unsigned int lda, const _FP16 *X, const int incX,
            const float beta, _FP16 *Y, const int incY);
+/**
+ * @brief     elementwise vector multiplication : Z = X ⊙ Y
+ * @param[in] N  length of the vector
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ * @param[in] Z __fp16 * for Vector Z
+ */
+void ewvm(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z);
+
+/**
+ * @brief     elementwise vector addition : Z = X + Y
+ * @param[in] N  length of the vector
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ * @param[in] Z __fp16 * for Vector Z
+ */
+void ewva(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z);
+
+/**
+ * @brief     isamax function : index of first maxima
+ * @param[in] N number of elements in X
+ * @param[in] X __fp16 * for Vector X
+ */
 unsigned int isamax(const unsigned int N, const _FP16 *X, const int incX);
 #endif
-
+/**
+ * @brief     sscal computation : X = alpha * X
+ * @param[in] N number of elements in X
+ * @param[in] X void * for Vector X
+ * @param[in] alpha float number
+ */
 void sscal(const unsigned int N, const float alpha, void *X, const int incX,
            ml::train::TensorDim::DataType d_type);
-
+/**
+ * @brief     sscal computation : X = alpha * X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] alpha float number
+ */
 void sscal(const unsigned int N, const float alpha, float *X, const int incX);
-
+/**
+ * @brief     snrm2 computation : Euclidean norm
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ */
 float snrm2(const int N, const float *X, const int incX);
-
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X void * for Vector X
+ * @param[in] Y void * for Vector Y
+ */
 void scopy(const unsigned int N, const void *X, const int incX, void *Y,
            const int incY, ml::train::TensorDim::DataType d_type);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
 void scopy(const unsigned int N, const float *X, const int incX, float *Y,
            const int intY);
-
+/**
+ * @brief     sdot computation : sum of all X * Y
+ * @param[in] N number of elements in Y
+ * @param[in] X float * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
 float sdot(const unsigned int N, const float *X, const unsigned int incX,
            const float *Y, const unsigned int incY);
-
+/**
+ * @brief     saxpy computation : Y = alpha*X + Y
+ * @param[in] N number of elements in Y
+ * @param[in] alpha float number
+ * @param[in] X void * for Vector X
+ * @param[in] Y void * for Vector Y
+ */
 void saxpy(const unsigned int N, const float alpha, const void *X,
            const int incX, void *Y, const int incY,
            ml::train::TensorDim::DataType d_type);
+/**
+ * @brief     saxpy computation : Y = alpha*X + Y
+ * @param[in] N number of elements in Y
+ * @param[in] alpha float number
+ * @param[in] X float * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
 void saxpy(const unsigned int N, const float alpha, const float *X,
            const int incX, float *Y, const int incY);
-
+/**
+ * @brief     sgemm computation  : Y = alpha*op(A)*op(B) + beta*C,
+ * where op(X) is one of X or X**T
+ * @param[in] A void * for Matrix A
+ * @param[in] B void * for Matrix B
+ * @param[in] C void * for Matrix C
+ * @param[in] M number of op(A)'s and C's row
+ * @param[in] N number of op(B)'s and C's columns
+ * @param[in] K number of op(A)'s and columns and op(B)'s rows
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
 void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
            const unsigned int M, const unsigned int N, const unsigned int K,
            const float alpha, const void *A, const unsigned int lda,
            const void *B, const unsigned int ldb, const float beta, void *C,
            const unsigned int ldc, ml::train::TensorDim::DataType d_type);
-
+/**
+ * @brief     sgemm computation  : Y = alpha*op(A)*op(B) + beta*C,
+ * where op(X) is one of X or X**T
+ * @param[in] A float * for Matrix A
+ * @param[in] B float * for Matrix B
+ * @param[in] C float * for Matrix C
+ * @param[in] M number of op(A)'s and C's row
+ * @param[in] N number of op(B)'s and C's columns
+ * @param[in] K number of op(A)'s and columns and op(B)'s rows
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
 void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
            const unsigned int M, const unsigned int N, const unsigned int K,
            const float alpha, const float *A, const unsigned int lda,
            const float *B, const unsigned int ldb, const float beta, float *C,
            const unsigned int ldc);
-
+/**
+ * @brief     sgemv computation  : Y = alpha*A*X + beta*Y
+ * @param[in] A void * for Matrix A
+ * @param[in] X void * for Vector X
+ * @param[in] Y void * for Vector Y
+ * @param[in] rows number of A's row
+ * @param[in] cols number of A's columns
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
 void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
            const unsigned int N, const float alpha, const void *A,
            const unsigned int lda, const void *X, const int incX,
            const float beta, void *Y, const int incY,
            ml::train::TensorDim::DataType d_type);
-
+/**
+ * @brief     sgemv computation  : Y = alpha*A*X + beta*Y
+ * @param[in] A float * for Matrix A
+ * @param[in] X float * for Vector X
+ * @param[in] Y float * for Vector Y
+ * @param[in] rows number of A's row
+ * @param[in] cols number of A's columns
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
 void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
            const unsigned int N, const float alpha, const float *A,
            const unsigned int lda, const float *X, const int incX,
            const float beta, float *Y, const int incY);
-
+/**
+ * @brief     isamax function : index of first maxima
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ */
 unsigned int isamax(const unsigned int N, const float *X, const int incX);
-
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __BLAS_INTERFACE_H__ */

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -5,6 +5,7 @@
  * @date   4 Aug 2022
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Sungsik Kong <ss.kong@samsung.com>
  * @bug    No known bugs except for NYI items
  * @brief  This is header for blas neon implementation
  *
@@ -60,6 +61,26 @@ void sgemv_transpose_neon(const float *A, const float *X, float *Y,
  */
 void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
                      uint32_t cols, float alpha, float beta);
+
+/**
+ * @brief     elementwise vector multiplication with neon : Z = X ⊙ Y
+ * @param[in] N  length of the vector
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ * @param[in] Z __fp16 * for Vector Z
+ */
+void elementwise_vector_multiplication_neon_fp16(const unsigned N,
+                                                 const __fp16 *X,
+                                                 const __fp16 *Y, __fp16 *Z);
+/**
+ * @brief     elementwise vector addition with neon : Z = X + Y
+ * @param[in] N  length of the vector
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ * @param[in] Z __fp16 * for Vector Z
+ */
+void elementwise_vector_addition_neon_fp16(const unsigned N, const __fp16 *X,
+                                           const __fp16 *Y, __fp16 *Z);
 
 /**
  * @brief     transposed sgemv computation with neon
@@ -119,7 +140,31 @@ void sscal_neon_fp16(const unsigned int N, __fp16 *X, const float alpha);
 void scopy_neon_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y);
 
 /**
- * @brief     isamax function with neon: index of firt maxima
+ * @brief     copy function with neon: Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y uint8_t * for Vector Y
+ */
+void scopy_neon_int4_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
+
+/**
+ * @brief     copy function with neon: Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ */
+void scopy_neon_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y);
+
+/**
+ * @brief     copy function with neon: Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
+void scopy_neon_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y);
+
+/**
+ * @brief     isamax function with neon: index of first maxima
  * @param[in] N number of elements in X
  * @param[in] X __fp16 * for Vector X
  */
@@ -140,6 +185,66 @@ unsigned int isamax_neon_fp16(const unsigned int N, const __fp16 *X);
 void sgemm_neon_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
                      uint32_t N, uint32_t K, float alpha, float beta,
                      bool TransA, bool TransB);
+/**
+ * @brief     sgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * where op(X) is one of X or X**T
+ * @param[in] A __fp16 * for Matrix A
+ * @param[in] B __fp16 * for Matrix B
+ * @param[in] C __fp16 * for Matrix C
+ * @param[in] M number of op(A)'s and C's row
+ * @param[in] N number of op(B)'s and C's columns
+ * @param[in] K number of op(A)'s and columns and op(B)'s rows
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C,
+                             uint32_t M, uint32_t N, uint32_t K, float alpha,
+                             float beta);
+/**
+ * @brief     sgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * where op(X) is one of X or X**T
+ * @param[in] A __fp16 * for Matrix A
+ * @param[in] B __fp16 * for Matrix B
+ * @param[in] C __fp16 * for Matrix C
+ * @param[in] M number of op(A)'s and C's row
+ * @param[in] N number of op(B)'s and C's columns
+ * @param[in] K number of op(A)'s and columns and op(B)'s rows
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, __fp16 *C,
+                            uint32_t M, uint32_t N, uint32_t K, float alpha,
+                            float beta);
+/**
+ * @brief     sgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * where op(X) is one of X or X**T
+ * @param[in] A __fp16 * for Matrix A
+ * @param[in] B __fp16 * for Matrix B
+ * @param[in] C __fp16 * for Matrix C
+ * @param[in] M number of op(A)'s and C's row
+ * @param[in] N number of op(B)'s and C's columns
+ * @param[in] K number of op(A)'s and columns and op(B)'s rows
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, __fp16 *C,
+                            uint32_t M, uint32_t N, uint32_t K, float alpha,
+                            float beta);
+/**
+ * @brief     sgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * where op(X) is one of X or X**T
+ * @param[in] A __fp16 * for Matrix A
+ * @param[in] B __fp16 * for Matrix B
+ * @param[in] C __fp16 * for Matrix C
+ * @param[in] M number of op(A)'s and C's row
+ * @param[in] N number of op(B)'s and C's columns
+ * @param[in] K number of op(A)'s and columns and op(B)'s rows
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, __fp16 *C,
+                             uint32_t M, uint32_t N, uint32_t K, float alpha,
+                             float beta, uint32_t idx);
 #endif
 
 } // namespace nntrainer::neon

--- a/test/unittest/unittest_nntrainer_tensor_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_fp16.cpp
@@ -3851,62 +3851,6 @@ TEST(nntrainer_Tensor, dot_04_n) {
   EXPECT_THROW(nntrainer::Tensor result = input.dot(m), std::runtime_error);
   EXPECT_NO_THROW(nntrainer::Tensor result = input.dot(m, false, true));
 }
-#include <iostream>
-TEST(nntrainer_Tensor, dot_05_p) {
-  int status = ML_ERROR_NONE;
-  int batch = 2;
-  int channel = 3;
-  int height = 4;
-  int width = 5;
-
-  nntrainer::TensorDim::TensorType t_type;
-  t_type.format = nntrainer::Tformat::NCHW;
-  t_type.data_type = nntrainer::Tdatatype::FP16;
-
-  _FP16 ans[2][3][4][24] = {0};
-
-  nntrainer::Tensor input(batch, channel, height, width, t_type);
-  GEN_TEST_INPUT(input, i * (channel * width * height) + j * (height * width) +
-                          k * (width) + l + 1);
-  nntrainer::Tensor weight(batch, channel, height, width, t_type);
-  GEN_TEST_INPUT(weight, i * (channel * width * height) + j * (height * width) +
-                           k * (width) + l + 1);
-  weight.reshape({1, 1, 24, 5, t_type});
-
-  nntrainer::Tensor result = input.dot(weight, false, true);
-
-  for (int b = 0; b < batch; b++) {
-    for (int c = 0; c < channel; c++) {
-      for (int h = 0; h < height; h++) {
-        for (int k = 0; k < batch * channel * height; k++) {
-          ans[b][c][h][k] = 0;
-          for (int w = 0; w < width; w++) {
-            _FP16 val1 = input.getValue<_FP16>(b, c, h, w);
-            _FP16 val2 = weight.getValue<_FP16>(0, 0, k, w);
-            ans[b][c][h][k] += val1 * val2;
-          }
-        }
-      }
-    }
-  }
-
-  for (unsigned int i = 0; i < result.batch(); ++i) {
-    for (unsigned int c = 0; c < result.channel(); ++c) {
-      for (unsigned int j = 0; j < result.height(); ++j) {
-        for (unsigned int k = 0; k < result.width(); ++k) {
-          _FP16 val1 = ans[i][c][j][k];
-          _FP16 val2 = result.getValue<_FP16>(i, c, j, k);
-          if (val1 != val2) {
-            status = ML_ERROR_RESULT_OUT_OF_RANGE;
-            goto end_dot_01_p;
-          }
-        }
-      }
-    }
-  }
-end_dot_01_p:
-  EXPECT_EQ(status, ML_ERROR_NONE);
-}
 
 TEST(nntrainer_Tensor, dot_06_p) {
   int status = ML_ERROR_NONE;


### PR DESCRIPTION
- Previously, sgemm and sgemv in neon intrinsics was depdendent on two conditions
	1. should have 8-divisible column or row
	2. fully work with fp16 variables (which might cause precision loss while being accumulated)
- In this commit, I expect sgemm and sgemv to work like:
	1. support every column length with adaptive-length-compute optimization
	2. use temporal fp32 array to secure cumulative data value especially in large scale Tensor
	3. accelerate converting such fp32 array to fp16 Tensor and vice versa with neon to enhance time performance
	4. consider the number of register to avoid register spilling
- Moreover, with this new logic, we need to get rid of unittest cases that compares full fp16 variables with neon result. From now on, we should only compare our result with fp32 Tensors.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped