### PR TITLE
[neon/sgemm] Partial accumulation using both fp16 and fp32 intrinsics

### DIFF
--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -197,7 +197,7 @@ void sgemm_neon_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C,
+void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
                              uint32_t M, uint32_t N, uint32_t K, float alpha,
                              float beta);
 /**
@@ -212,7 +212,7 @@ void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, __fp16 *C,
+void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
                             uint32_t M, uint32_t N, uint32_t K, float alpha,
                             float beta);
 /**
@@ -227,7 +227,7 @@ void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, __fp16 *C,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, __fp16 *C,
+void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
                             uint32_t M, uint32_t N, uint32_t K, float alpha,
                             float beta);
 /**
@@ -242,7 +242,7 @@ void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, __fp16 *C,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, __fp16 *C,
+void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
                              uint32_t M, uint32_t N, uint32_t K, float alpha,
                              float beta, uint32_t idx);
 #endif


### PR DESCRIPTION
**SGEMM** modifications made:

- Used mixed precision accumulations using both fp16 and fp32 intrinsics to enhance performance.
- Modified function calls to inline calls to reduce register spilling.
- Temporary fp32 storage used to enhance accuracy.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped