### PR TITLE
[#Wait for #2312][Tensor] Optimize dequantize operation    

### DIFF
--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -132,14 +132,7 @@ void FullyConnectedLayer::forwarding(RunLayerContext &context, bool training) {
     unsigned int axis =
       context.getWeightObject(weight_idx[FCParams::weight]).getOutputAxis();
 
-    if (dtype == nntrainer::Tdatatype::FP32)
-      weight.dequantize<float>(weight_, axis);
-    else if (dtype == nntrainer::Tdatatype::FP16)
-#ifdef ENABLE_FP16
-      weight.dequantize<_FP16>(weight_, axis);
-#else
-      ml_loge("%s", "Error: enable-fp16 is not enabled");
-#endif
+    weight.dequantize(weight_, axis);
     input_.dot(weight_, hidden_, false, false);
   } else {
     input_.dot(weight, hidden_, false, false);

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -4359,7 +4359,7 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
 
   nntrainer::Tensor output(batch, channel, height, width);
 
-  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -4380,7 +4380,7 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
 
   nntrainer::Tensor output(batch, channel, height, width);
 
-  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -4399,7 +4399,7 @@ TEST(nntrainer_Tensor, dequantize_03_n) {
 
   nntrainer::Tensor output(batch, channel, height, width);
 
-  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -4422,8 +4422,8 @@ TEST(nntrainer_Tensor, dequantize_04_n) {
 
   input.setScaleFactors({2.0, 1.5, 1.0, 0.5});
   input.setZeroPoints({2, 3, 4, 5});
-  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
-  EXPECT_NO_THROW({ input.dequantize<float>(output, 2); });
+  EXPECT_THROW({ input.dequantize(output, 1); }, std::invalid_argument);
+  EXPECT_NO_THROW({ input.dequantize(output, 2); });
 }
 
 /**
@@ -4446,153 +4446,7 @@ TEST(nntrainer_Tensor, dequantize_05_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
 
-  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
-}
-
-/**
- * @brief dequantize tensor
- */
-TEST(nntrainer_Tensor, dequantize_06_p) {
-  size_t batch = 1;
-  size_t channel = 3;
-  size_t height = 4;
-  size_t width = 5;
-
-  nntrainer::Tensor input(
-    {batch,
-     channel,
-     height,
-     width,
-     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8}},
-    true, nntrainer::Tensor::Initializer::ZEROS);
-  nntrainer::Tensor output(batch, channel, height, width);
-
-  // Dequantize by channel
-  EXPECT_NO_THROW(input.setScaleFactors({2, -2, -4}));
-  EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<float>(output, 1); });
-
-  float answer_data_1[] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-                           -2, -2, -2, -2, -2, -2, -2, -2, 2,  2,  2,  2,
-                           2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-                           2,  2,  2,  2,  4,  4,  4,  4,  4,  4,  4,  4,
-                           4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4};
-
-  nntrainer::Tensor answer1(ml::train::TensorDim(batch, channel, height, width,
-                                                 {nntrainer::Tformat::NCHW,
-                                                  nntrainer::Tdatatype::FP32}),
-                            answer_data_1);
-
-  EXPECT_EQ(output, answer1);
-
-  // Dequantize by height
-  EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4.8}));
-  EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<float>(output, 2); });
-
-  float answer_data_2[] = {
-    -4.2, -4.2, -4.2, -4.2, -4.2, -2,   -2,   -2,   -2,   -2,   2,    2,
-    2,    2,    2,    4.8,  4.8,  4.8,  4.8,  4.8,  -4.2, -4.2, -4.2, -4.2,
-    -4.2, -2,   -2,   -2,   -2,   -2,   2,    2,    2,    2,    2,    4.8,
-    4.8,  4.8,  4.8,  4.8,  -4.2, -4.2, -4.2, -4.2, -4.2, -2,   -2,   -2,
-    -2,   -2,   2,    2,    2,    2,    2,    4.8,  4.8,  4.8,  4.8,  4.8};
-  nntrainer::Tensor answer2(ml::train::TensorDim(batch, channel, height, width,
-                                                 {nntrainer::Tformat::NCHW,
-                                                  nntrainer::Tdatatype::FP32}),
-                            answer_data_2);
-
-  EXPECT_EQ(output, answer2);
-
-  // Dequantize by width
-  EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4, 8}));
-  EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<float>(output, 3); });
-
-  float answer_data_3[] = {
-    -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8,
-    -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8,
-    -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8,
-    -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8};
-
-  nntrainer::Tensor answer3(ml::train::TensorDim(batch, channel, height, width,
-                                                 {nntrainer::Tformat::NCHW,
-                                                  nntrainer::Tdatatype::FP32}),
-                            answer_data_3);
-
-  EXPECT_EQ(output, answer3);
-}
-
-/**
- * @brief dequantize qint4 tensor
- */
-TEST(nntrainer_Tensor, dequantize_08_p) {
-  size_t batch = 1;
-  size_t channel = 3;
-  size_t height = 4;
-  size_t width = 5;
-
-  nntrainer::Tensor input(
-    {batch,
-     channel,
-     height,
-     width,
-     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT4}},
-    true, nntrainer::Tensor::Initializer::ZEROS);
-  nntrainer::Tensor output(batch, channel, height, width);
-
-  // Dequantize by channel
-  EXPECT_NO_THROW(input.setScaleFactors({2, -2, -4}));
-  EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<float>(output, 1); });
-
-  float answer_data_1[] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
-                           -2, -2, -2, -2, -2, -2, -2, -2, 2,  2,  2,  2,
-                           2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-                           2,  2,  2,  2,  4,  4,  4,  4,  4,  4,  4,  4,
-                           4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4};
-
-  nntrainer::Tensor answer1(ml::train::TensorDim(batch, channel, height, width,
-                                                 {nntrainer::Tformat::NCHW,
-                                                  nntrainer::Tdatatype::FP32}),
-                            answer_data_1);
-
-  EXPECT_EQ(output, answer1);
-
-  // Dequantize by height
-  EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4}));
-  EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<float>(output, 2); });
-
-  float answer_data_2[] = {-4.2, -4.2, -4.2, -4.2, -4.2, -2, -2, -2, -2, -2,
-                           2,    2,    2,    2,    2,    4,  4,  4,  4,  4,
-                           -4.2, -4.2, -4.2, -4.2, -4.2, -2, -2, -2, -2, -2,
-                           2,    2,    2,    2,    2,    4,  4,  4,  4,  4,
-                           -4.2, -4.2, -4.2, -4.2, -4.2, -2, -2, -2, -2, -2,
-                           2,    2,    2,    2,    2,    4,  4,  4,  4,  4};
-  nntrainer::Tensor answer2(ml::train::TensorDim(batch, channel, height, width,
-                                                 {nntrainer::Tformat::NCHW,
-                                                  nntrainer::Tdatatype::FP32}),
-                            answer_data_2);
-
-  EXPECT_EQ(output, answer2);
-
-  // Dequantize by width
-  EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4, 8}));
-  EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<float>(output, 3); });
-
-  float answer_data_3[] = {
-    -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8,
-    -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8,
-    -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8,
-    -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8, -4.2, -2, 2, 4, -8};
-
-  nntrainer::Tensor answer3(ml::train::TensorDim(batch, channel, height, width,
-                                                 {nntrainer::Tformat::NCHW,
-                                                  nntrainer::Tdatatype::FP32}),
-                            answer_data_3);
-
-  EXPECT_EQ(output, answer3);
+  EXPECT_THROW({ input.dequantize(output, 1); }, std::invalid_argument);
 }
 
 int main(int argc, char **argv) {

--- a/test/unittest/unittest_nntrainer_tensor_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_fp16.cpp
@@ -5801,14 +5801,16 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
   nntrainer::Tensor input(batch, channel, height, width,
                           nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
-  input.setScaleFactors({1.5, 1.0, 0.5});
+
+  input.setScaleFactors16({static_cast<_FP16>(1.5), static_cast<_FP16>(1.0),
+                           static_cast<_FP16>(0.5)});
   input.setZeroPoints({1, 4, 7});
 
   nntrainer::Tensor output(batch, channel, height, width,
                            nntrainer::Tformat::NCHW,
                            nntrainer::Tdatatype::FP16);
 
-  EXPECT_THROW({ input.dequantize<_FP16>(output, 1); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -5825,14 +5827,15 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
 
-  input.setScaleFactors({1.5, 1.0, 0.5});
+  input.setScaleFactors16({static_cast<_FP16>(1.5), static_cast<_FP16>(1.0),
+                           static_cast<_FP16>(0.5)});
   input.setZeroPoints({1, 4, 7});
 
   nntrainer::Tensor output(batch, channel, height, width,
                            nntrainer::Tformat::NCHW,
                            nntrainer::Tdatatype::FP16);
 
-  EXPECT_THROW({ input.dequantize<_FP16>(output, 1); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -5853,7 +5856,7 @@ TEST(nntrainer_Tensor, dequantize_03_n) {
                            nntrainer::Tformat::NCHW,
                            nntrainer::Tdatatype::FP16);
 
-  EXPECT_THROW({ input.dequantize<_FP16>(output, 1); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -5869,12 +5872,15 @@ TEST(nntrainer_Tensor, dequantize_04_p) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
-  input.setScaleFactors({1.5, 1.0, 0.5});
+
+  input.setScaleFactors16({static_cast<_FP16>(1.5), static_cast<_FP16>(1.0),
+                           static_cast<_FP16>(0.5)});
   input.setZeroPoints({0, 0, 0});
 
-  nntrainer::Tensor output;
+  nntrainer::Tensor output(
+    {1, 3, 4, 5, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}}, true);
 
-  EXPECT_NO_THROW({ output = input.dequantize<_FP16>(1); });
+  EXPECT_NO_THROW({ input.dequantize(output, 1); });
 
   _FP16 answer_data[] = {
     static_cast<_FP16>(1.5), static_cast<_FP16>(1.5), static_cast<_FP16>(1.5),
@@ -5927,9 +5933,10 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
                            nntrainer::Tdatatype::FP16);
 
   // Dequantize by channel
-  EXPECT_NO_THROW(input.setScaleFactors({2, -2, -4}));
+  EXPECT_NO_THROW(input.setScaleFactors16(
+    {static_cast<_FP16>(2), static_cast<_FP16>(-2), static_cast<_FP16>(-4)}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 1); });
+  EXPECT_NO_THROW({ input.dequantize(output, 1); });
 
   _FP16 answer_data_1[] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
                            -2, -2, -2, -2, -2, -2, -2, -2, 2,  2,  2,  2,
@@ -5945,9 +5952,12 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
   EXPECT_EQ(output, answer1);
 
   // Dequantize by height
-  EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4.8}));
+
+  EXPECT_NO_THROW(input.setScaleFactors16(
+    {static_cast<_FP16>(4.2), static_cast<_FP16>(2), static_cast<_FP16>(-2),
+     static_cast<_FP16>(-4.8)}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 2); });
+  EXPECT_NO_THROW({ input.dequantize(output, 2); });
 
   _FP16 answer_data_2[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
                            static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
@@ -5987,9 +5997,11 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
   EXPECT_EQ(output, answer2);
 
   // Dequantize by width
-  EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4, 8}));
+  EXPECT_NO_THROW(input.setScaleFactors16(
+    {static_cast<_FP16>(4.2), static_cast<_FP16>(2), static_cast<_FP16>(-2),
+     static_cast<_FP16>(-4), static_cast<_FP16>(8)}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 3); });
+  EXPECT_NO_THROW({ input.dequantize(output, 3); });
 
   _FP16 answer_data_3[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
                            static_cast<_FP16>(2),    static_cast<_FP16>(4),
@@ -6051,9 +6063,10 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
                            nntrainer::Tdatatype::FP16);
 
   // Dequantize by channel
-  EXPECT_NO_THROW(input.setScaleFactors({2, -2, -4}));
+  EXPECT_NO_THROW(input.setScaleFactors16(
+    {static_cast<_FP16>(2), static_cast<_FP16>(-2), static_cast<_FP16>(-4)}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 1); });
+  EXPECT_NO_THROW({ input.dequantize(output, 1); });
 
   _FP16 answer_data_1[] = {-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2,
                            -2, -2, -2, -2, -2, -2, -2, -2, 2,  2,  2,  2,
@@ -6069,9 +6082,11 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
   EXPECT_EQ(output, answer1);
 
   // Dequantize by height
-  EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4}));
+  EXPECT_NO_THROW(
+    input.setScaleFactors16({static_cast<_FP16>(4.2), static_cast<_FP16>(2),
+                             static_cast<_FP16>(-2), static_cast<_FP16>(-4)}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 2); });
+  EXPECT_NO_THROW({ input.dequantize(output, 2); });
 
   _FP16 answer_data_2[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
                            static_cast<_FP16>(-4.2), static_cast<_FP16>(-4.2),
@@ -6111,9 +6126,11 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
   EXPECT_EQ(output, answer2);
 
   // Dequantize by width
-  EXPECT_NO_THROW(input.setScaleFactors({4.2, 2, -2, -4, 8}));
+  EXPECT_NO_THROW(input.setScaleFactors16(
+    {static_cast<_FP16>(4.2), static_cast<_FP16>(2), static_cast<_FP16>(-2),
+     static_cast<_FP16>(-4), static_cast<_FP16>(8)}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1, 1}));
-  EXPECT_NO_THROW({ input.dequantize<_FP16>(output, 3); });
+  EXPECT_NO_THROW({ input.dequantize(output, 3); });
 
   _FP16 answer_data_3[] = {static_cast<_FP16>(-4.2), static_cast<_FP16>(-2),
                            static_cast<_FP16>(2),    static_cast<_FP16>(4),

--- a/test/unittest/unittest_nntrainer_tensor_nhwc.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_nhwc.cpp
@@ -4695,7 +4695,7 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::FP32});
 
-  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
+  EXPECT_THROW({ input.dequantize(output, 1); }, std::invalid_argument);
 }
 
 /**
@@ -4718,115 +4718,7 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
     batch, channel, height, width,
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
 
-  EXPECT_THROW({ input.dequantize<float>(output, 1); }, std::invalid_argument);
-}
-
-/**
- * @brief dequantize nhwc tensor
- */
-TEST(nntrainer_Tensor, dequantize_03_p) {
-  int batch = 1;
-  int channel = 3;
-  int height = 4;
-  int width = 5;
-
-  nntrainer::Tensor input(
-    batch, channel, height, width,
-    {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT8});
-  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
-  input.setScaleFactors({1.5, 1.0, 0.5});
-  input.setZeroPoints({5, 5, 5});
-
-  nntrainer::Tensor output;
-  output.getDim().setFormat(nntrainer::Tformat::NHWC);
-
-  EXPECT_NO_THROW({ output = input.dequantize<float>(1); });
-
-  float answer_data[] = {
-    -6,   1, 3,   -6,   1, 3,   -6,   1, 3,   -6,   1, 3,   -6,   1, 3,
-    -4.5, 2, 3.5, -4.5, 2, 3.5, -4.5, 2, 3.5, -4.5, 2, 3.5, -4.5, 2, 3.5,
-    -3,   3, 4,   -3,   3, 4,   -3,   3, 4,   -3,   3, 4,   -3,   3, 4,
-    -1.5, 4, 4.5, -1.5, 4, 4.5, -1.5, 4, 4.5, -1.5, 4, 4.5, -1.5, 4, 4.5};
-
-  nntrainer::Tensor answer(ml::train::TensorDim(batch, channel, height, width,
-                                                {nntrainer::Tformat::NHWC,
-                                                 nntrainer::Tdatatype::FP32}),
-                           answer_data);
-
-  EXPECT_EQ(output, answer);
-}
-
-/**
- * @brief dequantize nhwc tensor
- */
-TEST(nntrainer_Tensor, dequantize_04_p) {
-  int batch = 1;
-  int channel = 3;
-  int height = 4;
-  int width = 5;
-
-  nntrainer::Tensor input(
-    batch, channel, height, width,
-    {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT8});
-  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
-  input.setScaleFactors({2.5, 2.0, 1.5, 1.0});
-  input.setZeroPoints({8, 8, 8, 8});
-
-  nntrainer::Tensor output(
-    batch, channel, height, width,
-    {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::FP32});
-
-  EXPECT_NO_THROW({ input.dequantize<float>(output, 2); });
-
-  float answer_data[] = {
-    -17.5, -5, 7.5, -17.5, -5, 7.5, -17.5, -5, 7.5, -17.5, -5, 7.5,
-    -17.5, -5, 7.5, -12,   -2, 8,   -12,   -2, 8,   -12,   -2, 8,
-    -12,   -2, 8,   -12,   -2, 8,   -7.5,  0,  7.5, -7.5,  0,  7.5,
-    -7.5,  0,  7.5, -7.5,  0,  7.5, -7.5,  0,  7.5, -4,    1,  6,
-    -4,    1,  6,   -4,    1,  6,   -4,    1,  6,   -4,    1,  6,
-  };
-
-  nntrainer::Tensor answer(ml::train::TensorDim(batch, channel, height, width,
-                                                {nntrainer::Tformat::NHWC,
-                                                 nntrainer::Tdatatype::FP32}),
-                           answer_data);
-
-  EXPECT_EQ(output, answer);
-}
-
-/**
- * @brief dequantize nhwc qint4 tensor
- */
-TEST(nntrainer_Tensor, dequantize_05_p) {
-  size_t batch = 1;
-  size_t channel = 10;
-  size_t height = 2;
-  size_t width = 1;
-
-  nntrainer::Tensor input(
-    {batch,
-     channel,
-     height,
-     width,
-     {nntrainer::Tformat::NHWC, nntrainer::Tdatatype::QINT4}},
-    true, nntrainer::Tensor::Initializer::ZEROS);
-
-  input.setScaleFactors({8, 6, 4, 2, 1, -1, -2, -4, -6, -7});
-  input.setZeroPoints({1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
-
-  nntrainer::Tensor output;
-
-  EXPECT_NO_THROW({ output = input.dequantize<float>(1); });
-
-  float answer_data[] = {-8, -6, -4, -2, -1, 1, 2, 4, 6, 7,
-                         -8, -6, -4, -2, -1, 1, 2, 4, 6, 7};
-
-  nntrainer::Tensor answer(ml::train::TensorDim(batch, channel, height, width,
-                                                {nntrainer::Tformat::NHWC,
-                                                 nntrainer::Tdatatype::FP32}),
-                           answer_data);
-
-  EXPECT_EQ(output, answer);
+  EXPECT_THROW({ input.dequantize(output, 1); }, std::invalid_argument);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
- Perform dequantization by utilizing tensor operations instead of manual calculation.
- Tensor now contains two types of scale factors (FP32, FP16).
- Add flate function that copies tensor values of different data types. This function is temporal and should be later replaced by scopy to fasten up.

#### WTD
- Convert unsigned QINT to signed QINT to minimize computation (i.e., remove subtract)
- Current scopy for the quantized tensor only supports QINT4 to FP16. It needs to support QINT8-FP16, QINT4-FP32, QINT8-FP32



