### PR TITLE
[neon] Optimize sgemv 2.0

### DIFF
--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -499,23 +499,21 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
                                uint32_t rows, uint32_t cols, float alpha,
                                float beta) {
   float Y32[cols];
-  const float32x4_t v_beta_32 = vmovq_n_f32(beta);
-
   unsigned int idx = 0;
 
   for (; cols - idx >= 8; idx += 8) {
     float32x4_t y0_3_32 = vcvt_f32_f16(vld1_f16(&Y[idx]));
     float32x4_t y4_7_32 = vcvt_f32_f16(vld1_f16(&Y[idx + 4]));
 
-    y0_3_32 = vmulq_f32(y0_3_32, v_beta_32);
-    y4_7_32 = vmulq_f32(y4_7_32, v_beta_32);
+    y0_3_32 = vmulq_n_f32(y0_3_32, beta);
+    y4_7_32 = vmulq_n_f32(y4_7_32, beta);
 
     vst1q_f32(&Y32[idx], y0_3_32);
     vst1q_f32(&Y32[idx + 4], y4_7_32);
   }
   for (; cols - idx >= 4; idx += 4) {
     float32x4_t y0_3_32 = vcvt_f32_f16(vld1_f16(&Y[idx]));
-    y0_3_32 = vmulq_f32(y0_3_32, v_beta_32);
+    y0_3_32 = vmulq_n_f32(y0_3_32, beta);
     vst1q_f32(&Y32[idx], y0_3_32);
   }
   for (; idx < cols; ++idx) {
@@ -523,79 +521,85 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
   }
   if (rows % 16 == 0) {
     for (unsigned int i = 0; i < rows; i += 16) {
-      float x = alpha * static_cast<float>(X[i]);
-      float x2 = alpha * static_cast<float>(X[i + 1]);
-      float x3 = alpha * static_cast<float>(X[i + 2]);
-      float x4 = alpha * static_cast<float>(X[i + 3]);
-      float x5 = alpha * static_cast<float>(X[i + 4]);
-      float x6 = alpha * static_cast<float>(X[i + 5]);
-      float x7 = alpha * static_cast<float>(X[i + 6]);
-      float x8 = alpha * static_cast<float>(X[i + 7]);
-      float x9 = alpha * static_cast<float>(X[i + 8]);
-      float x10 = alpha * static_cast<float>(X[i + 9]);
-      float x11 = alpha * static_cast<float>(X[i + 10]);
-      float x12 = alpha * static_cast<float>(X[i + 11]);
-      float x13 = alpha * static_cast<float>(X[i + 12]);
-      float x14 = alpha * static_cast<float>(X[i + 13]);
-      float x15 = alpha * static_cast<float>(X[i + 14]);
-      float x16 = alpha * static_cast<float>(X[i + 15]);
+      __fp16 x = alpha * (X[i]);
+      __fp16 x2 = alpha * (X[i + 1]);
+      __fp16 x3 = alpha * (X[i + 2]);
+      __fp16 x4 = alpha * (X[i + 3]);
+      __fp16 x5 = alpha * (X[i + 4]);
+      __fp16 x6 = alpha * (X[i + 5]);
+      __fp16 x7 = alpha * (X[i + 6]);
+      __fp16 x8 = alpha * (X[i + 7]);
+      __fp16 x9 = alpha * (X[i + 8]);
+      __fp16 x10 = alpha * (X[i + 9]);
+      __fp16 x11 = alpha * (X[i + 10]);
+      __fp16 x12 = alpha * (X[i + 11]);
+      __fp16 x13 = alpha * (X[i + 12]);
+      __fp16 x14 = alpha * (X[i + 13]);
+      __fp16 x15 = alpha * (X[i + 14]);
+      __fp16 x16 = alpha * (X[i + 15]);
 
       idx = 0;
+      for (; cols - idx >= 8; idx += 8) {
+        float16x8_t wvec0_7_f16 = vmulq_n_f16(vld1q_f16(&A[i * cols + idx]), x);
+        wvec0_7_f16 =
+          vfmaq_n_f16(wvec0_7_f16, vld1q_f16(&A[(i + 1) * cols + idx]), x2);
+        wvec0_7_f16 =
+          vfmaq_n_f16(wvec0_7_f16, vld1q_f16(&A[(i + 2) * cols + idx]), x3);
+        wvec0_7_f16 =
+          vfmaq_n_f16(wvec0_7_f16, vld1q_f16(&A[(i + 3) * cols + idx]), x4);
+        wvec0_7_f16 =
+          vfmaq_n_f16(wvec0_7_f16, vld1q_f16(&A[(i + 4) * cols + idx]), x5);
+        wvec0_7_f16 =
+          vfmaq_n_f16(wvec0_7_f16, vld1q_f16(&A[(i + 5) * cols + idx]), x6);
+        wvec0_7_f16 =
+          vfmaq_n_f16(wvec0_7_f16, vld1q_f16(&A[(i + 6) * cols + idx]), x7);
+        wvec0_7_f16 =
+          vfmaq_n_f16(wvec0_7_f16, vld1q_f16(&A[(i + 7) * cols + idx]), x8);
+
+        float16x8_t w2vec0_7_f16 =
+          vmulq_n_f16(vld1q_f16(&A[(i + 8) * cols + idx]), x9);
+        w2vec0_7_f16 =
+          vfmaq_n_f16(w2vec0_7_f16, vld1q_f16(&A[(i + 9) * cols + idx]), x10);
+        w2vec0_7_f16 =
+          vfmaq_n_f16(w2vec0_7_f16, vld1q_f16(&A[(i + 10) * cols + idx]), x11);
+        w2vec0_7_f16 =
+          vfmaq_n_f16(w2vec0_7_f16, vld1q_f16(&A[(i + 11) * cols + idx]), x12);
+          w2vec0_7_f16 =
+          vfmaq_n_f16(w2vec0_7_f16, vld1q_f16(&A[(i + 12) * cols + idx]), x13);
+          w2vec0_7_f16 =
+          vfmaq_n_f16(w2vec0_7_f16, vld1q_f16(&A[(i + 13) * cols + idx]), x14);
+          w2vec0_7_f16 =
+          vfmaq_n_f16(w2vec0_7_f16, vld1q_f16(&A[(i + 14) * cols + idx]), x15);
+          w2vec0_7_f16 =
+          vfmaq_n_f16(w2vec0_7_f16, vld1q_f16(&A[(i + 15) * cols + idx]), x16);
+
+
+        float32x4_t y0_3 = vaddq_f32(vld1q_f32(&Y32[idx]),
+                                     vcvt_f32_f16(vget_low_f16(wvec0_7_f16)));
+        y0_3 = vaddq_f32(y0_3, vcvt_f32_f16(vget_low_f16(w2vec0_7_f16)));
+        float32x4_t y4_7 = vaddq_f32(vld1q_f32(&Y32[idx + 4]),
+                                     vcvt_f32_f16(vget_high_f16(wvec0_7_f16)));
+        y4_7 = vaddq_f32(y4_7, vcvt_f32_f16(vget_high_f16(w2vec0_7_f16)));
+
+        vst1q_f32(&Y32[idx], y0_3);
+        vst1q_f32(&Y32[idx + 4], y4_7);
+      }
 
       for (; cols - idx >= 4; idx += 4) {
 
         float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
+        float32x4_t wvec0_3_32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
+        float32x4_t w2vec0_3_32 =
+          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx]));
+        float32x4_t w3vec0_3_32 =
+          vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx]));
+        float32x4_t w4vec0_3_32 =
+          vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx]));
 
-        const __fp16 *__restrict w;
-        const __fp16 *__restrict w2;
-        const __fp16 *__restrict w3;
-        const __fp16 *__restrict w4;
-        const __fp16 *__restrict w5;
-        const __fp16 *__restrict w6;
-        const __fp16 *__restrict w7;
-        const __fp16 *__restrict w8;
-        const __fp16 *__restrict w9;
-        const __fp16 *__restrict w10;
-        const __fp16 *__restrict w11;
-        const __fp16 *__restrict w12;
-        const __fp16 *__restrict w13;
-        const __fp16 *__restrict w14;
-        const __fp16 *__restrict w15;
-        const __fp16 *__restrict w16;
-
-        w = &A[i * cols + idx];
-        w2 = &A[(i + 1) * cols + idx];
-        w3 = &A[(i + 2) * cols + idx];
-        w4 = &A[(i + 3) * cols + idx];
-        w5 = &A[(i + 4) * cols + idx];
-        w6 = &A[(i + 5) * cols + idx];
-        w7 = &A[(i + 6) * cols + idx];
-        w8 = &A[(i + 7) * cols + idx];
-        w9 = &A[(i + 8) * cols + idx];
-        w10 = &A[(i + 9) * cols + idx];
-        w11 = &A[(i + 10) * cols + idx];
-        w12 = &A[(i + 11) * cols + idx];
-        w13 = &A[(i + 12) * cols + idx];
-        w14 = &A[(i + 13) * cols + idx];
-        w15 = &A[(i + 14) * cols + idx];
-        w16 = &A[(i + 15) * cols + idx];
-
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w[0])), x);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w2[0])), x2);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w3[0])), x3);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w4[0])), x4);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w5[0])), x5);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w6[0])), x6);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w7[0])), x7);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w8[0])), x8);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w9[0])), x9);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w10[0])), x10);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w11[0])), x11);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w12[0])), x12);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w13[0])), x13);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w14[0])), x14);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w15[0])), x15);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w16[0])), x16);
+        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
+        y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_32, x2);
+        y0_3 = vfmaq_n_f32(y0_3, w3vec0_3_32, x3);
+        y0_3 = vfmaq_n_f32(y0_3, w4vec0_3_32, x4);
 
         vst1q_f32(&Y32[idx], y0_3);
       }
@@ -609,30 +613,6 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
           vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx]));
         float32x4_t w4vec0_3_32 =
           vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx]));
-        float32x4_t w5vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 4) * cols + idx]));
-        float32x4_t w6vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 5) * cols + idx]));
-        float32x4_t w7vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 6) * cols + idx]));
-        float32x4_t w8vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 7) * cols + idx]));
-        float32x4_t w9vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 8) * cols + idx]));
-        float32x4_t w10vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 9) * cols + idx]));
-        float32x4_t w11vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 10) * cols + idx]));
-        float32x4_t w12vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 11) * cols + idx]));
-        float32x4_t w13vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 12) * cols + idx]));
-        float32x4_t w14vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 13) * cols + idx]));
-        float32x4_t w15vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 14) * cols + idx]));
-        float32x4_t w16vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 15) * cols + idx]));
 
         for (int j = cols - idx; j < 4; ++j) {
           y0_3[j] = 0;
@@ -640,93 +620,73 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
           w2vec0_3_32[j] = 0;
           w3vec0_3_32[j] = 0;
           w4vec0_3_32[j] = 0;
-          w5vec0_3_32[j] = 0;
-          w6vec0_3_32[j] = 0;
-          w7vec0_3_32[j] = 0;
-          w8vec0_3_32[j] = 0;
-          w9vec0_3_32[j] = 0;
-          w10vec0_3_32[j] = 0;
-          w11vec0_3_32[j] = 0;
-          w12vec0_3_32[j] = 0;
-          w13vec0_3_32[j] = 0;
-          w14vec0_3_32[j] = 0;
-          w15vec0_3_32[j] = 0;
-          w16vec0_3_32[j] = 0;
         }
 
         y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
         y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_32, x2);
         y0_3 = vfmaq_n_f32(y0_3, w3vec0_3_32, x3);
         y0_3 = vfmaq_n_f32(y0_3, w4vec0_3_32, x4);
-        y0_3 = vfmaq_n_f32(y0_3, w5vec0_3_32, x5);
-        y0_3 = vfmaq_n_f32(y0_3, w6vec0_3_32, x6);
-        y0_3 = vfmaq_n_f32(y0_3, w7vec0_3_32, x7);
-        y0_3 = vfmaq_n_f32(y0_3, w8vec0_3_32, x8);
-
-        y0_3 = vfmaq_n_f32(y0_3, w9vec0_3_32, x9);
-        y0_3 = vfmaq_n_f32(y0_3, w10vec0_3_32, x10);
-        y0_3 = vfmaq_n_f32(y0_3, w11vec0_3_32, x11);
-        y0_3 = vfmaq_n_f32(y0_3, w12vec0_3_32, x12);
-        y0_3 = vfmaq_n_f32(y0_3, w13vec0_3_32, x13);
-        y0_3 = vfmaq_n_f32(y0_3, w14vec0_3_32, x14);
-        y0_3 = vfmaq_n_f32(y0_3, w15vec0_3_32, x15);
-        y0_3 = vfmaq_n_f32(y0_3, w16vec0_3_32, x16);
 
         vst1q_f32(&Y32[idx], y0_3);
       }
     }
-  } else if (rows % 8 == 0) {
+  } else 
+  if (rows % 8 == 0) {
     for (unsigned int i = 0; i < rows; i += 8) {
-      float x = alpha * static_cast<float>(X[i]);
-      float x2 = alpha * static_cast<float>(X[i + 1]);
-      float x3 = alpha * static_cast<float>(X[i + 2]);
-      float x4 = alpha * static_cast<float>(X[i + 3]);
-      float x5 = alpha * static_cast<float>(X[i + 4]);
-      float x6 = alpha * static_cast<float>(X[i + 5]);
-      float x7 = alpha * static_cast<float>(X[i + 6]);
-      float x8 = alpha * static_cast<float>(X[i + 7]);
+      __fp16 x = alpha * (X[i]);
+      __fp16 x2 = alpha * (X[i + 1]);
+      __fp16 x3 = alpha * (X[i + 2]);
+      __fp16 x4 = alpha * (X[i + 3]);
+      __fp16 x5 = alpha * (X[i + 4]);
+      __fp16 x6 = alpha * (X[i + 5]);
+      __fp16 x7 = alpha * (X[i + 6]);
+      __fp16 x8 = alpha * (X[i + 7]);
 
       idx = 0;
+      for (; cols - idx >= 8; idx += 8) {
+        float16x8_t wvec0_7_f16 = vmulq_n_f16(vld1q_f16(&A[i * cols + idx]), x);
+        wvec0_7_f16 =
+          vfmaq_n_f16(wvec0_7_f16, vld1q_f16(&A[(i + 1) * cols + idx]), x2);
+        wvec0_7_f16 =
+          vfmaq_n_f16(wvec0_7_f16, vld1q_f16(&A[(i + 2) * cols + idx]), x3);
+        wvec0_7_f16 =
+          vfmaq_n_f16(wvec0_7_f16, vld1q_f16(&A[(i + 3) * cols + idx]), x4);
+
+        float16x8_t w2vec0_7_f16 =
+          vmulq_n_f16(vld1q_f16(&A[(i + 4) * cols + idx]), x3);
+        w2vec0_7_f16 =
+          vfmaq_n_f16(w2vec0_7_f16, vld1q_f16(&A[(i + 5) * cols + idx]), x4);
+        w2vec0_7_f16 =
+          vfmaq_n_f16(w2vec0_7_f16, vld1q_f16(&A[(i + 6) * cols + idx]), x5);
+        w2vec0_7_f16 =
+          vfmaq_n_f16(w2vec0_7_f16, vld1q_f16(&A[(i + 7) * cols + idx]), x6);
+
+        float32x4_t y0_3 = vaddq_f32(vld1q_f32(&Y32[idx]),
+                                     vcvt_f32_f16(vget_low_f16(wvec0_7_f16)));
+        y0_3 = vaddq_f32(y0_3, vcvt_f32_f16(vget_low_f16(w2vec0_7_f16)));
+        float32x4_t y4_7 = vaddq_f32(vld1q_f32(&Y32[idx + 4]),
+                                     vcvt_f32_f16(vget_high_f16(wvec0_7_f16)));
+        y4_7 = vaddq_f32(y4_7, vcvt_f32_f16(vget_high_f16(w2vec0_7_f16)));
+
+        vst1q_f32(&Y32[idx], y0_3);
+        vst1q_f32(&Y32[idx + 4], y4_7);
+      }
 
       for (; cols - idx >= 4; idx += 4) {
 
         float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
+        float32x4_t wvec0_3_32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
+        float32x4_t w2vec0_3_32 =
+          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx]));
+        float32x4_t w3vec0_3_32 =
+          vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx]));
+        float32x4_t w4vec0_3_32 =
+          vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx]));
 
-        const __fp16 *__restrict w;
-        const __fp16 *__restrict w2;
-        const __fp16 *__restrict w3;
-        const __fp16 *__restrict w4;
-        const __fp16 *__restrict w5;
-        const __fp16 *__restrict w6;
-        const __fp16 *__restrict w7;
-        const __fp16 *__restrict w8;
-
-        w = &A[i * cols + idx];
-        w2 = &A[(i + 1) * cols + idx];
-        w3 = &A[(i + 2) * cols + idx];
-        w4 = &A[(i + 3) * cols + idx];
-        w5 = &A[(i + 4) * cols + idx];
-        w6 = &A[(i + 5) * cols + idx];
-        w7 = &A[(i + 6) * cols + idx];
-        w8 = &A[(i + 7) * cols + idx];
-
-        float32x4_t w0_3 = vcvt_f32_f16(vld1_f16(&w[0]));
-        float32x4_t w4_7 = vcvt_f32_f16(vld1_f16(&w2[0]));
-        float32x4_t w8_11 = vcvt_f32_f16(vld1_f16(&w3[0]));
-        float32x4_t w12_15 = vcvt_f32_f16(vld1_f16(&w4[0]));
-        float32x4_t w16_19 = vcvt_f32_f16(vld1_f16(&w5[0]));
-        float32x4_t w20_23 = vcvt_f32_f16(vld1_f16(&w6[0]));
-        float32x4_t w24_27 = vcvt_f32_f16(vld1_f16(&w7[0]));
-        float32x4_t w28_31 = vcvt_f32_f16(vld1_f16(&w8[0]));
-
-        y0_3 = vfmaq_n_f32(y0_3, w0_3, x);
-        y0_3 = vfmaq_n_f32(y0_3, w4_7, x2);
-        y0_3 = vfmaq_n_f32(y0_3, w8_11, x3);
-        y0_3 = vfmaq_n_f32(y0_3, w12_15, x4);
-        y0_3 = vfmaq_n_f32(y0_3, w16_19, x5);
-        y0_3 = vfmaq_n_f32(y0_3, w20_23, x6);
-        y0_3 = vfmaq_n_f32(y0_3, w24_27, x7);
-        y0_3 = vfmaq_n_f32(y0_3, w28_31, x8);
+        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
+        y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_32, x2);
+        y0_3 = vfmaq_n_f32(y0_3, w3vec0_3_32, x3);
+        y0_3 = vfmaq_n_f32(y0_3, w4vec0_3_32, x4);
 
         vst1q_f32(&Y32[idx], y0_3);
       }
@@ -740,14 +700,6 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
           vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx]));
         float32x4_t w4vec0_3_32 =
           vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx]));
-        float32x4_t w5vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 4) * cols + idx]));
-        float32x4_t w6vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 5) * cols + idx]));
-        float32x4_t w7vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 6) * cols + idx]));
-        float32x4_t w8vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 7) * cols + idx]));
 
         for (int j = cols - idx; j < 4; ++j) {
           y0_3[j] = 0;
@@ -755,105 +707,39 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
           w2vec0_3_32[j] = 0;
           w3vec0_3_32[j] = 0;
           w4vec0_3_32[j] = 0;
-          w5vec0_3_32[j] = 0;
-          w6vec0_3_32[j] = 0;
-          w7vec0_3_32[j] = 0;
-          w8vec0_3_32[j] = 0;
         }
 
         y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
         y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_32, x2);
         y0_3 = vfmaq_n_f32(y0_3, w3vec0_3_32, x3);
         y0_3 = vfmaq_n_f32(y0_3, w4vec0_3_32, x4);
-        y0_3 = vfmaq_n_f32(y0_3, w5vec0_3_32, x5);
-        y0_3 = vfmaq_n_f32(y0_3, w6vec0_3_32, x6);
-        y0_3 = vfmaq_n_f32(y0_3, w7vec0_3_32, x7);
-        y0_3 = vfmaq_n_f32(y0_3, w8vec0_3_32, x8);
 
         vst1q_f32(&Y32[idx], y0_3);
       }
     }
   } else if (rows % 4 == 0) {
     for (unsigned int i = 0; i < rows; i += 4) {
-      float x = alpha * static_cast<float>(X[i]);
-      float x2 = alpha * static_cast<float>(X[i + 1]);
-      float x3 = alpha * static_cast<float>(X[i + 2]);
-      float x4 = alpha * static_cast<float>(X[i + 3]);
+      __fp16 x = alpha * (X[i]);
+      __fp16 x2 = alpha * (X[i + 1]);
+      __fp16 x3 = alpha * (X[i + 2]);
+      __fp16 x4 = alpha * (X[i + 3]);
 
       idx = 0;
-      for (; cols - idx >= 16; idx += 16) {
-        float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-        float32x4_t y4_7 = vld1q_f32(&Y32[idx + 4]);
-        float32x4_t y8_11 = vld1q_f32(&Y32[idx + 8]);
-        float32x4_t y12_15 = vld1q_f32(&Y32[idx + 12]);
-
-        const __fp16 *__restrict w;
-        const __fp16 *__restrict w2;
-        const __fp16 *__restrict w3;
-        const __fp16 *__restrict w4;
-
-        w = &A[i * cols + idx];
-        w2 = &A[(i + 1) * cols + idx];
-        w3 = &A[(i + 2) * cols + idx];
-        w4 = &A[(i + 3) * cols + idx];
-
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w[0])), x);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w2[0])), x2);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w3[0])), x3);
-        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&w4[0])), x4);
-
-        y4_7 = vfmaq_n_f32(y4_7, vcvt_f32_f16(vld1_f16(&w[4])), x);
-        y4_7 = vfmaq_n_f32(y4_7, vcvt_f32_f16(vld1_f16(&w2[4])), x2);
-        y4_7 = vfmaq_n_f32(y4_7, vcvt_f32_f16(vld1_f16(&w3[4])), x3);
-        y4_7 = vfmaq_n_f32(y4_7, vcvt_f32_f16(vld1_f16(&w4[4])), x4);
-
-        y8_11 = vfmaq_n_f32(y8_11, vcvt_f32_f16(vld1_f16(&w[8])), x);
-        y8_11 = vfmaq_n_f32(y8_11, vcvt_f32_f16(vld1_f16(&w2[8])), x2);
-        y8_11 = vfmaq_n_f32(y8_11, vcvt_f32_f16(vld1_f16(&w3[8])), x3);
-        y8_11 = vfmaq_n_f32(y8_11, vcvt_f32_f16(vld1_f16(&w4[8])), x4);
-
-        y12_15 = vfmaq_n_f32(y12_15, vcvt_f32_f16(vld1_f16(&w[12])), x);
-        y12_15 = vfmaq_n_f32(y12_15, vcvt_f32_f16(vld1_f16(&w2[12])), x2);
-        y12_15 = vfmaq_n_f32(y12_15, vcvt_f32_f16(vld1_f16(&w3[12])), x3);
-        y12_15 = vfmaq_n_f32(y12_15, vcvt_f32_f16(vld1_f16(&w4[12])), x4);
-
-        vst1q_f32(&Y32[idx], y0_3);
-        vst1q_f32(&Y32[idx + 4], y4_7);
-        vst1q_f32(&Y32[idx + 8], y8_11);
-        vst1q_f32(&Y32[idx + 12], y12_15);
-      }
-
       for (; cols - idx >= 8; idx += 8) {
+        float16x8_t wvec0_7_f16 = vmulq_n_f16(vld1q_f16(&A[i * cols + idx]), x);
+        wvec0_7_f16 =
+          vfmaq_n_f16(wvec0_7_f16, vld1q_f16(&A[(i + 1) * cols + idx]), x2);
+        float16x8_t w2vec0_7_f16 =
+          vmulq_n_f16(vld1q_f16(&A[(i + 2) * cols + idx]), x3);
+        w2vec0_7_f16 =
+          vfmaq_n_f16(w2vec0_7_f16, vld1q_f16(&A[(i + 3) * cols + idx]), x4);
 
-        float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-        float32x4_t y4_7 = vld1q_f32(&Y32[idx + 4]);
-
-        float32x4_t wvec0_3_f32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
-        float32x4_t w2vec0_3_f32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx]));
-        float32x4_t w3vec0_3_f32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx]));
-        float32x4_t w4vec0_3_f32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx]));
-
-        float32x4_t wvec3_7_f32 =
-          vcvt_f32_f16(vld1_f16(&A[i * cols + idx + 4]));
-        float32x4_t w2vec3_7_f32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx + 4]));
-        float32x4_t w3vec3_7_f32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx + 4]));
-        float32x4_t w4vec3_7_f32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx + 4]));
-
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_f32, x);
-        y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_f32, x2);
-        y0_3 = vfmaq_n_f32(y0_3, w3vec0_3_f32, x3);
-        y0_3 = vfmaq_n_f32(y0_3, w4vec0_3_f32, x4);
-
-        y4_7 = vfmaq_n_f32(y4_7, wvec3_7_f32, x);
-        y4_7 = vfmaq_n_f32(y4_7, w2vec3_7_f32, x2);
-        y4_7 = vfmaq_n_f32(y4_7, w3vec3_7_f32, x3);
-        y4_7 = vfmaq_n_f32(y4_7, w4vec3_7_f32, x4);
+        float32x4_t y0_3 = vaddq_f32(vld1q_f32(&Y32[idx]),
+                                     vcvt_f32_f16(vget_low_f16(wvec0_7_f16)));
+        y0_3 = vaddq_f32(y0_3, vcvt_f32_f16(vget_low_f16(w2vec0_7_f16)));
+        float32x4_t y4_7 = vaddq_f32(vld1q_f32(&Y32[idx + 4]),
+                                     vcvt_f32_f16(vget_high_f16(wvec0_7_f16)));
+        y4_7 = vaddq_f32(y4_7, vcvt_f32_f16(vget_high_f16(w2vec0_7_f16)));
 
         vst1q_f32(&Y32[idx], y0_3);
         vst1q_f32(&Y32[idx + 4], y4_7);
@@ -905,163 +791,17 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
         vst1q_f32(&Y32[idx], y0_3);
       }
     }
-
-  } else if (rows % 2 == 0) {
-    for (unsigned int i = 0; i < rows; i += 2) {
-      float x = alpha * static_cast<float>(X[i]);
-      float x2 = alpha * static_cast<float>(X[i + 1]);
-
-      idx = 0;
-
-      for (; cols - idx >= 8; idx += 8) {
-
-        float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-        float32x4_t y4_7 = vld1q_f32(&Y32[idx + 4]);
-
-        float32x4_t wvec0_3_f32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
-        float32x4_t w2vec0_3_f32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx]));
-        float32x4_t wvec4_7_f32 =
-          vcvt_f32_f16(vld1_f16(&A[i * cols + idx + 4]));
-        float32x4_t w2vec4_7_f32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx + 4]));
-
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_f32, x);
-        y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_f32, x2);
-        y4_7 = vfmaq_n_f32(y4_7, wvec4_7_f32, x);
-        y4_7 = vfmaq_n_f32(y4_7, w2vec4_7_f32, x2);
-
-        vst1q_f32(&Y32[idx], y0_3);
-        vst1q_f32(&Y32[idx + 4], y4_7);
-      }
-
-      for (; cols - idx >= 4; idx += 4) {
-
-        float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-
-        float32x4_t wvec0_3_32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
-        float32x4_t w2vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx]));
-
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
-        y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_32, x2);
-
-        vst1q_f32(&Y32[idx], y0_3);
-      }
-
-      if (cols != idx) {
-        float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-        float32x4_t wvec0_3_32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
-        float32x4_t w2vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx]));
-
-        for (int j = cols - idx; j < 4; ++j) {
-          y0_3[j] = 0;
-          wvec0_3_32[j] = 0;
-          w2vec0_3_32[j] = 0;
-        }
-
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
-        y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_32, x2);
-
-        vst1q_f32(&Y32[idx], y0_3);
-      }
-    }
-
   } else {
     for (unsigned int i = 0; i < rows; ++i) {
-      float x = alpha * static_cast<float>(X[i]);
+      __fp16 x = alpha * (X[i]);
       idx = 0;
-
-      for (; cols - idx >= 32; idx += 32) {
-
-        float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-        float32x4_t y4_7 = vld1q_f32(&Y32[idx + 4]);
-        float32x4_t y8_11 = vld1q_f32(&Y32[idx + 8]);
-        float32x4_t y12_15 = vld1q_f32(&Y32[idx + 12]);
-        float32x4_t y16_19 = vld1q_f32(&Y32[idx + 16]);
-        float32x4_t y20_23 = vld1q_f32(&Y32[idx + 20]);
-        float32x4_t y24_27 = vld1q_f32(&Y32[idx + 24]);
-        float32x4_t y28_31 = vld1q_f32(&Y32[idx + 28]);
-
-        const __fp16 *__restrict w;
-
-        w = &A[i * cols + idx];
-
-        float32x4_t wvec0_3_f32 = vcvt_f32_f16(vld1_f16(&w[0]));
-        float32x4_t wvec4_7_f32 = vcvt_f32_f16(vld1_f16(&w[4]));
-
-        float32x4_t wvec8_11_f32 = vcvt_f32_f16(vld1_f16(&w[8]));
-        float32x4_t wvec12_15_f32 = vcvt_f32_f16(vld1_f16(&w[12]));
-
-        float32x4_t wvec16_19_f32 = vcvt_f32_f16(vld1_f16(&w[16]));
-        float32x4_t wvec20_23_f32 = vcvt_f32_f16(vld1_f16(&w[20]));
-
-        float32x4_t wvec24_27_f32 = vcvt_f32_f16(vld1_f16(&w[24]));
-        float32x4_t wvec28_31_f32 = vcvt_f32_f16(vld1_f16(&w[28]));
-
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_f32, x);
-        y4_7 = vfmaq_n_f32(y4_7, wvec4_7_f32, x);
-
-        y8_11 = vfmaq_n_f32(y8_11, wvec8_11_f32, x);
-        y12_15 = vfmaq_n_f32(y12_15, wvec12_15_f32, x);
-
-        y16_19 = vfmaq_n_f32(y16_19, wvec16_19_f32, x);
-        y20_23 = vfmaq_n_f32(y20_23, wvec20_23_f32, x);
-
-        y24_27 = vfmaq_n_f32(y24_27, wvec24_27_f32, x);
-        y28_31 = vfmaq_n_f32(y28_31, wvec28_31_f32, x);
-
-        vst1q_f32(&Y32[idx], y0_3);
-        vst1q_f32(&Y32[idx + 4], y4_7);
-        vst1q_f32(&Y32[idx + 8], y8_11);
-        vst1q_f32(&Y32[idx + 12], y12_15);
-        vst1q_f32(&Y32[idx + 16], y16_19);
-        vst1q_f32(&Y32[idx + 20], y20_23);
-        vst1q_f32(&Y32[idx + 24], y24_27);
-        vst1q_f32(&Y32[idx + 28], y28_31);
-      }
-
-      for (; cols - idx >= 16; idx += 16) {
-
-        float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-        float32x4_t y4_7 = vld1q_f32(&Y32[idx + 4]);
-        float32x4_t y8_11 = vld1q_f32(&Y32[idx + 8]);
-        float32x4_t y12_15 = vld1q_f32(&Y32[idx + 12]);
-
-        const __fp16 *__restrict w;
-
-        w = &A[i * cols + idx];
-
-        float32x4_t wvec0_3_f32 = vcvt_f32_f16(vld1_f16(&w[0]));
-        float32x4_t wvec4_7_f32 = vcvt_f32_f16(vld1_f16(&w[4]));
-
-        float32x4_t wvec8_11_f32 = vcvt_f32_f16(vld1_f16(&w[8]));
-        float32x4_t wvec12_15_f32 = vcvt_f32_f16(vld1_f16(&w[12]));
-
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_f32, x);
-        y4_7 = vfmaq_n_f32(y4_7, wvec4_7_f32, x);
-
-        y8_11 = vfmaq_n_f32(y8_11, wvec8_11_f32, x);
-        y12_15 = vfmaq_n_f32(y12_15, wvec12_15_f32, x);
-
-        vst1q_f32(&Y32[idx], y0_3);
-        vst1q_f32(&Y32[idx + 4], y4_7);
-        vst1q_f32(&Y32[idx + 8], y8_11);
-        vst1q_f32(&Y32[idx + 12], y12_15);
-      }
-
       for (; cols - idx >= 8; idx += 8) {
 
-        float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-        float32x4_t y4_7 = vld1q_f32(&Y32[idx + 4]);
-
-        float32x4_t wvec0_3_f32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
-        float32x4_t wvec3_7_f32 =
-          vcvt_f32_f16(vld1_f16(&A[i * cols + idx + 4]));
-
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_f32, x);
-        y4_7 = vfmaq_n_f32(y4_7, wvec3_7_f32, x);
+        float16x8_t wvec0_7_f16 = vmulq_n_f16(vld1q_f16(&A[i * cols + idx]), x);
+        float32x4_t y0_3 = vaddq_f32(vld1q_f32(&Y32[idx]),
+                                     vcvt_f32_f16(vget_low_f16(wvec0_7_f16)));
+        float32x4_t y4_7 = vaddq_f32(vld1q_f32(&Y32[idx + 4]),
+                                     vcvt_f32_f16(vget_high_f16(wvec0_7_f16)));
 
         vst1q_f32(&Y32[idx], y0_3);
         vst1q_f32(&Y32[idx + 4], y4_7);

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -393,25 +393,15 @@ void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
 
     for (unsigned int j = 0; j < rows; ++j) {
       w = &A[j * cols + idx];
-      float16x8_t wvec0_7 = vld1q_f16(&w[0]);
-      float16x8_t wvec8_15 = vld1q_f16(&w[8]);
-      float16x8_t wvec16_23 = vld1q_f16(&w[16]);
-      float16x8_t wvec24_31 = vld1q_f16(&w[24]);
+      float16x8_t y = vmulq_f16(vld1q_f16(&w[0]), x0_7);
+      y = vfmaq_f16(y, vld1q_f16(&w[8]), x8_15);
+      y = vfmaq_f16(y, vld1q_f16(&w[16]), x16_23);
+      y = vfmaq_f16(y, vld1q_f16(&w[24]), x24_31);
 
-      float16x8_t wvec32_39 = vld1q_f16(&w[32]);
-      float16x8_t wvec40_47 = vld1q_f16(&w[40]);
-      float16x8_t wvec48_55 = vld1q_f16(&w[48]);
-      float16x8_t wvec56_63 = vld1q_f16(&w[56]);
-
-      float16x8_t y = vmulq_f16(wvec0_7, x0_7);
-      y = vfmaq_f16(y, wvec8_15, x8_15);
-      y = vfmaq_f16(y, wvec16_23, x16_23);
-      y = vfmaq_f16(y, wvec24_31, x24_31);
-
-      y = vfmaq_f16(y, wvec32_39, x32_39);
-      y = vfmaq_f16(y, wvec40_47, x40_47);
-      y = vfmaq_f16(y, wvec48_55, x48_55);
-      y = vfmaq_f16(y, wvec56_63, x56_63);
+      y = vfmaq_f16(y, vld1q_f16(&w[32]), x32_39);
+      y = vfmaq_f16(y, vld1q_f16(&w[40]), x40_47);
+      y = vfmaq_f16(y, vld1q_f16(&w[48]), x48_55);
+      y = vfmaq_f16(y, vld1q_f16(&w[56]), x56_63);
 
       Y32[j] += vaddvq_f32(vcvt_f32_f16(vget_low_f16(y))) +
                 vaddvq_f32(vcvt_f32_f16(vget_high_f16(y)));
@@ -434,15 +424,10 @@ void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
 
     for (unsigned int j = 0; j < rows; ++j) {
       w = &A[j * cols + idx];
-      float16x8_t wvec0_7 = vld1q_f16(&w[0]);
-      float16x8_t wvec8_15 = vld1q_f16(&w[8]);
-      float16x8_t wvec16_23 = vld1q_f16(&w[16]);
-      float16x8_t wvec24_31 = vld1q_f16(&w[24]);
-
-      float16x8_t y = vmulq_f16(wvec0_7, x0_7);
-      y = vfmaq_f16(y, wvec8_15, x8_15);
-      y = vfmaq_f16(y, wvec16_23, x16_23);
-      y = vfmaq_f16(y, wvec24_31, x24_31);
+      float16x8_t y = vmulq_f16(vld1q_f16(&w[0]), x0_7);
+      y = vfmaq_f16(y, vld1q_f16(&w[8]), x8_15);
+      y = vfmaq_f16(y, vld1q_f16(&w[16]), x16_23);
+      y = vfmaq_f16(y, vld1q_f16(&w[24]), x24_31);
 
       Y32[j] += vaddvq_f32(vcvt_f32_f16(vget_low_f16(y))) +
                 vaddvq_f32(vcvt_f32_f16(vget_high_f16(y)));
@@ -460,11 +445,8 @@ void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
     const __fp16 *__restrict w;
     for (unsigned int j = 0; j < rows; ++j) {
       w = &A[j * cols + idx];
-      float16x8_t wvec0_7 = vld1q_f16(&w[0]);
-      float16x8_t wvec8_15 = vld1q_f16(&w[8]);
-
-      float16x8_t y = vmulq_f16(wvec0_7, x0_7);
-      y = vfmaq_f16(y, wvec8_15, x8_15);
+      float16x8_t y = vmulq_f16(vld1q_f16(&w[0]), x0_7);
+      y = vfmaq_f16(y, vld1q_f16(&w[8]), x8_15);
 
       Y32[j] += vaddvq_f32(vcvt_f32_f16(vget_low_f16(y))) +
                 vaddvq_f32(vcvt_f32_f16(vget_high_f16(y)));
@@ -546,7 +528,6 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
                                float beta) {
   float Y32[cols];
   unsigned int idx = 0;
-
   for (; cols - idx >= 8; idx += 8) {
     float32x4_t y0_3_32 = vcvt_f32_f16(vld1_f16(&Y[idx]));
     float32x4_t y4_7_32 = vcvt_f32_f16(vld1_f16(&Y[idx + 4]));
@@ -562,7 +543,7 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
     y0_3_32 = vmulq_n_f32(y0_3_32, beta);
     vst1q_f32(&Y32[idx], y0_3_32);
   }
-  for (; idx < cols; ++idx) {
+  for (; cols - idx >= 1; idx += 1) {
     Y32[idx] = beta * Y[idx];
   }
   if (rows % 16 == 0) {
@@ -641,38 +622,100 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
         float32x4_t w4vec0_3_32 =
           vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx]));
 
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
-        y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_32, x2);
-        y0_3 = vfmaq_n_f32(y0_3, w3vec0_3_32, x3);
-        y0_3 = vfmaq_n_f32(y0_3, w4vec0_3_32, x4);
+        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&A[i * cols + idx])), x);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx])), x2);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx])), x3);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx])), x4);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 4) * cols + idx])), x5);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 5) * cols + idx])), x6);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 6) * cols + idx])), x7);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 7) * cols + idx])), x8);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 8) * cols + idx])), x9);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 9) * cols + idx])), x10);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 10) * cols + idx])), x11);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 11) * cols + idx])), x12);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 12) * cols + idx])), x13);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 13) * cols + idx])), x14);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 14) * cols + idx])), x15);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 15) * cols + idx])), x16);
 
         vst1q_f32(&Y32[idx], y0_3);
       }
 
-      if (cols != idx) {
-        float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-        float32x4_t wvec0_3_32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
-        float32x4_t w2vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx]));
-        float32x4_t w3vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx]));
-        float32x4_t w4vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx]));
+      if (cols - idx >= 1) {
+        float y0_3_0[4];
 
-        for (int j = cols - idx; j < 4; ++j) {
-          y0_3[j] = 0;
-          wvec0_3_32[j] = 0;
-          w2vec0_3_32[j] = 0;
-          w3vec0_3_32[j] = 0;
-          w4vec0_3_32[j] = 0;
+        float v0[4], v1[4], v2[4], v3[4];
+        float v4[4], v5[4], v6[4], v7[4];
+        float v8[4], v9[4], v10[4], v11[4];
+        float v12[4], v13[4], v14[4], v15[4];
+
+        unsigned int k = 0;
+        for (; k < cols - idx; ++k) {
+          y0_3_0[k] = Y32[idx + k];
+
+          v0[k] = A[i * cols + idx + k];
+          v1[k] = A[(i + 1) * cols + idx + k],
+          v2[k] = A[(i + 2) * cols + idx + k];
+          v3[k] = A[(i + 3) * cols + idx + k],
+          v4[k] = A[(i + 4) * cols + idx + k];
+          v5[k] = A[(i + 5) * cols + idx + k],
+          v6[k] = A[(i + 6) * cols + idx + k];
+          v7[k] = A[(i + 7) * cols + idx + k],
+          v8[k] = A[(i + 8) * cols + idx + k];
+          v9[k] = A[(i + 9) * cols + idx + k],
+          v10[k] = A[(i + 10) * cols + idx + k];
+          v11[k] = A[(i + 11) * cols + idx + k],
+          v12[k] = A[(i + 12) * cols + idx + k];
+          v13[k] = A[(i + 13) * cols + idx + k],
+          v15[k] = A[(i + 15) * cols + idx + k];
+        }
+        for (; k < 4; ++k) {
+          y0_3_0[k] = 0;
+
+          v0[k] = v1[k] = v2[k] = v3[k] = 0;
+          v4[k] = v5[k] = v6[k] = v7[k] = 0;
+          v8[k] = v9[k] = v10[k] = v11[k] = 0;
+          v12[k] = v13[k] = v14[k] = v15[k] = 0;
         }
 
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
-        y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_32, x2);
-        y0_3 = vfmaq_n_f32(y0_3, w3vec0_3_32, x3);
-        y0_3 = vfmaq_n_f32(y0_3, w4vec0_3_32, x4);
+        float32x4_t y0_3 = vld1q_f32(y0_3_0);
 
-        vst1q_f32(&Y32[idx], y0_3);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v0), x);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v1), x2);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v2), x3);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v3), x4);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v4), x5);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v5), x6);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v6), x7);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v7), x8);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v8), x9);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v9), x10);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v10), x11);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v11), x12);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v12), x13);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v13), x14);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v14), x15);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v15), x16);
+
+        for (unsigned int k = 0; k < cols - idx; ++k) {
+          Y32[idx + k] = y0_3[k];
+        }
       }
     }
   } else if (rows % 8 == 0) {
@@ -719,46 +762,63 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
       for (; cols - idx >= 4; idx += 4) {
 
         float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-        float32x4_t wvec0_3_32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
-        float32x4_t w2vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx]));
-        float32x4_t w3vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx]));
-        float32x4_t w4vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx]));
-
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
-        y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_32, x2);
-        y0_3 = vfmaq_n_f32(y0_3, w3vec0_3_32, x3);
-        y0_3 = vfmaq_n_f32(y0_3, w4vec0_3_32, x4);
-
+        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&A[i * cols + idx])), x);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx])), x2);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx])), x3);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx])), x4);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 4) * cols + idx])), x5);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 5) * cols + idx])), x6);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 6) * cols + idx])), x7);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 7) * cols + idx])), x8);
         vst1q_f32(&Y32[idx], y0_3);
       }
 
-      if (cols != idx) {
-        float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-        float32x4_t wvec0_3_32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
-        float32x4_t w2vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx]));
-        float32x4_t w3vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx]));
-        float32x4_t w4vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx]));
+      if (cols - idx >= 1) {
+        float y0_3_0[4];
 
-        for (int j = cols - idx; j < 4; ++j) {
-          y0_3[j] = 0;
-          wvec0_3_32[j] = 0;
-          w2vec0_3_32[j] = 0;
-          w3vec0_3_32[j] = 0;
-          w4vec0_3_32[j] = 0;
+        float v0[4], v1[4], v2[4], v3[4];
+        float v4[4], v5[4], v6[4], v7[4];
+
+        unsigned int k = 0;
+        for (; k < cols - idx; ++k) {
+          y0_3_0[k] = Y32[idx + k];
+
+          v0[k] = A[i * cols + idx + k];
+          v1[k] = A[(i + 1) * cols + idx + k];
+          v2[k] = A[(i + 2) * cols + idx + k];
+          v3[k] = A[(i + 3) * cols + idx + k];
+          v4[k] = A[(i + 4) * cols + idx + k];
+          v5[k] = A[(i + 5) * cols + idx + k];
+          v6[k] = A[(i + 6) * cols + idx + k];
+          v7[k] = A[(i + 7) * cols + idx + k];
+        }
+        for (; k < 4; ++k) {
+          y0_3_0[k] = 0;
+          v0[k] = v1[k] = v2[k] = v3[k] = 0;
+          v4[k] = v5[k] = v6[k] = v7[k] = 0;
         }
 
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
-        y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_32, x2);
-        y0_3 = vfmaq_n_f32(y0_3, w3vec0_3_32, x3);
-        y0_3 = vfmaq_n_f32(y0_3, w4vec0_3_32, x4);
+        float32x4_t y0_3 = vld1q_f32(y0_3_0);
 
-        vst1q_f32(&Y32[idx], y0_3);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v0), x);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v1), x2);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v2), x3);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v3), x4);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v4), x5);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v5), x6);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v6), x7);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v7), x8);
+
+        for (unsigned int k = 0; k < cols - idx; ++k) {
+          Y32[idx + k] = y0_3[k];
+        }
       }
     }
   } else if (rows % 4 == 0) {
@@ -793,46 +853,45 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
 
         float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
 
-        float32x4_t wvec0_3_32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
-        float32x4_t w2vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx]));
-        float32x4_t w3vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx]));
-        float32x4_t w4vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx]));
-
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
-        y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_32, x2);
-        y0_3 = vfmaq_n_f32(y0_3, w3vec0_3_32, x3);
-        y0_3 = vfmaq_n_f32(y0_3, w4vec0_3_32, x4);
+        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&A[i * cols + idx])), x);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx])), x2);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx])), x3);
+        y0_3 = vfmaq_n_f32(
+          y0_3, vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx])), x4);
 
         vst1q_f32(&Y32[idx], y0_3);
       }
 
-      if (cols != idx) {
-        float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-        float32x4_t wvec0_3_32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
-        float32x4_t w2vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 1) * cols + idx]));
-        float32x4_t w3vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 2) * cols + idx]));
-        float32x4_t w4vec0_3_32 =
-          vcvt_f32_f16(vld1_f16(&A[(i + 3) * cols + idx]));
+      if (cols - idx >= 1) {
+        float y0_3_0[4];
 
-        for (int j = cols - idx; j < 4; ++j) {
-          y0_3[j] = 0;
-          wvec0_3_32[j] = 0;
-          w2vec0_3_32[j] = 0;
-          w3vec0_3_32[j] = 0;
-          w4vec0_3_32[j] = 0;
+        float v0[4], v1[4], v2[4], v3[4];
+        unsigned int k = 0;
+        for (; k < cols - idx; ++k) {
+          y0_3_0[k] = Y32[idx + k];
+
+          v0[k] = A[i * cols + idx + k];
+          v1[k] = A[(i + 1) * cols + idx + k];
+          v2[k] = A[(i + 2) * cols + idx + k];
+          v3[k] = A[(i + 3) * cols + idx + k];
+        }
+        for (; k < 4; ++k) {
+          y0_3_0[k] = 0;
+          v0[k] = v1[k] = v2[k] = v3[k] = 0;
         }
 
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
-        y0_3 = vfmaq_n_f32(y0_3, w2vec0_3_32, x2);
-        y0_3 = vfmaq_n_f32(y0_3, w3vec0_3_32, x3);
-        y0_3 = vfmaq_n_f32(y0_3, w4vec0_3_32, x4);
+        float32x4_t y0_3 = vld1q_f32(y0_3_0);
 
-        vst1q_f32(&Y32[idx], y0_3);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v0), x);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v1), x2);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v2), x3);
+        y0_3 = vfmaq_n_f32(y0_3, vld1q_f32(v3), x4);
+
+        for (unsigned int k = 0; k < cols - idx; ++k) {
+          Y32[idx + k] = y0_3[k];
+        }
       }
     }
   } else {
@@ -854,29 +913,29 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
       for (; cols - idx >= 4; idx += 4) {
 
         float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-
-        float32x4_t wvec0_3_32 = vcvt_f32_f16(vld1_f16(&A[i * cols + idx]));
-
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
+        y0_3 = vfmaq_n_f32(y0_3, vcvt_f32_f16(vld1_f16(&A[i * cols + idx])), x);
 
         vst1q_f32(&Y32[idx], y0_3);
       }
 
       if (cols != idx) {
-        float32x4_t y0_3 = vld1q_f32(&Y32[idx]);
-
-        float16x4_t wvec0_3 = vld1_f16(&A[i * cols + idx]);
-
+        float y0_3[4];
+        float wvec0_3[4];
+        for (int j = 0; j < cols - idx; ++j) {
+          y0_3[j] = Y32[idx + j];
+          wvec0_3[j] = A[i * cols + idx + j];
+        }
         for (int j = cols - idx; j < 4; ++j) {
           y0_3[j] = 0;
           wvec0_3[j] = 0;
         }
 
-        float32x4_t wvec0_3_32 = vcvt_f32_f16(wvec0_3);
+        float32x4_t y0_3_32 = vld1q_f32(y0_3);
+        y0_3_32 = vfmaq_n_f32(y0_3_32, vld1q_f32(wvec0_3), x);
 
-        y0_3 = vfmaq_n_f32(y0_3, wvec0_3_32, x);
-
-        vst1q_f32(&Y32[idx], y0_3);
+        for (int j = 0; j < cols - idx; ++j) {
+          Y32[idx + j] = y0_3_32[j];
+        }
       }
     }
   }


### PR DESCRIPTION
This PR includes:

- Optimize sgemv transpose with partial summation
 * 50% faster sgemv_transpose in case of large scale Tensors
 * Support every column length (bugFix)

- Optimize sgemv noTrans with more variables
 * 20% faster sgemv in case of large scale Tensors
