### PR TITLE
App/Yolo5: compiler error fix!

### DIFF
--- a/Applications/YOLOv3/jni/yolo_v3_loss.cpp
+++ b/Applications/YOLOv3/jni/yolo_v3_loss.cpp
@@ -794,10 +794,10 @@ unsigned int YoloV3LossLayer::find_responsible_anchors(float bbox_ratio) {
   nntrainer::Tensor similarity = anchors_ratio.subtract(bbox_ratio);
   auto data_type = similarity.getDataType();
   if (data_type == ml::train::TensorDim::DataType::FP32) {
-    similarity.apply_i<float>(nntrainer::absFloat);
+    similarity.apply_i<float>(nntrainer::absFloat<float>);
   } else if (data_type == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-    similarity.apply_i<_FP16>(nntrainer::absFloat);
+    similarity.apply_i<_FP16>(nntrainer::absFloat<_FP16>);
 #else
     throw std::runtime_error("Not supported data type");
 #endif


### PR DESCRIPTION
You cannot use a template function for std::function without specifying the template type name.

The usage should be updated from
```
similarity.apply_i<float>(nntrainer::absFloat)
```
to
```
similarity.apply_i<float>(nntrainer::absFloat<float>)
```

CC: @baek2sm This is caused by #2229. I'm not sure how it passed the CI system.

This fixes:
```
[  462s] [358/446] Compiling C++ object Applications/YOLOv3/jni/nntrainer_yolov3.p/yolo_v3_loss.cpp.o
[  462s] FAILED: Applications/YOLOv3/jni/nntrainer_yolov3.p/yolo_v3_loss.cpp.o
[  462s] c++ -IApplications/YOLOv3/jni/nntrainer_yolov3.p -IApplications/YOLOv3/jni -I../Applications/YOLOv3/jni -I../Applications/utils/jni/includes -Inntrainer -I../nntrainer -Iapi -I../api -I../api/ccapi/include -Inntrainer/compiler -I../nntrainer/compiler -Inntrainer/dataset -I../nntrainer/dataset -Inntrainer/layers/loss -I../nntrainer/layers/loss -Inntrainer/layers -I../nntrainer/layers -Inntrainer/models -I../nntrainer/models -Inntrainer/optimizers -I../nntrainer/optimizers -Inntrainer/tensor -I../nntrainer/tensor -Inntrainer/utils -I../nntrainer/utils -Inntrainer/graph -I../nntrainer/graph -I/usr/include/openblas -I/usr/include/nnstreamer -I/usr/include/dlog -I/usr/include/tensorflow2/ -I/usr/include/opencv4 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Werror -std=c++17 -D__TIZEN__=1 -DTIZENVERSION=8 -DTIZENVERSIONMINOR=0 -D__FEATURE_CHECK_SUPPORT__ -Wredundant-decls -Wwrite-strings -Wformat -Wformat-nonliteral -Wformat-security -Winit-self -Waddress -Wvla -Wpointer-arith -Wno-error=varargs -ftree-vectorize -Wno-maybe-uninitialized -Wno-unused-variable -DMIN_CPP_VERSION=201703L -DML_API_COMMON=1 -DNNSTREAMER_AVAILABLE=1 -DUSE_BLAS=1 -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 -DENABLE_NNSTREAMER_BACKBONE=1 -DENABLE_TFLITE_BACKBONE=1 -DENABLE_TFLITE_INTERPRETER=1 -DENABLE_DATA_AUGMENTATION_OPENCV=1 '-DNNTRAINER_CONF_PATH="/etc/nntrainer.ini"' -O2 -g2 -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong -Wformat-security -fmessage-length=0 -frecord-gcc-switches -Wl,-z,relro,--as-needed -feliminate-unused-debug-types --param=ssp-buffer-size=4 -fdiagnostics-color=never -m64 -march=nehalem -msse4.2 -mfpmath=sse -fasynchronous-unwind-tables -fno-omit-frame-pointer -g -fopenmp -pthread -MD -MQ Applications/YOLOv3/jni/nntrainer_yolov3.p/yolo_v3_loss.cpp.o -MF Applications/YOLOv3/jni/nntrainer_yolov3.p/yolo_v3_loss.cpp.o.d -o Applications/YOLOv3/jni/nntrainer_yolov3.p/yolo_v3_loss.cpp.o -c ../Applications/YOLOv3/jni/yolo_v3_loss.cpp
[  462s] ../Applications/YOLOv3/jni/yolo_v3_loss.cpp: In member function 'unsigned int custom::YoloV3LossLayer::find_responsible_anchors(float)':
[  462s] ../Applications/YOLOv3/jni/yolo_v3_loss.cpp:797:50: error: cannot convert '<unresolved overloaded function type>' to 'std::function<float(float)>'
[  462s]   797 |     similarity.apply_i<float>(nntrainer::absFloat);
[  462s]       |                                                  ^
[  462s] In file included from ../nntrainer/layers/common_properties.h:22,
[  462s]                  from ../nntrainer/layers/acti_func.h:19,
[  462s]                  from ../Applications/YOLOv3/jni/yolo_v3_loss.h:19,
[  462s]                  from ../Applications/YOLOv3/jni/yolo_v3_loss.cpp:15:
[  462s] ../nntrainer/tensor/tensor.h:1303:65: note:   initializing argument 1 of 'int nntrainer::Tensor::apply_i(std::function<T(T)>) [with T = float]'
[  462s]  1303 |   template <typename T = float> int apply_i(std::function<T(T)> f) {
[  462s]       |
~~~~~~~~~~~~~~~~~~~~^
```