### PR TITLE
[Wait for #2342] [ Weight ] Add packed property and output axis in weight spec 

### DIFF
--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -109,6 +109,24 @@ public:
 };
 
 /**
+ * @brief trainable property, use this to set and check how if certain layer is
+ * trainable
+ *
+ */
+class Packed : public nntrainer::Property<bool> {
+public:
+  /**
+   * @brief Construct a new Trainable object
+   * if it is true, then weight type always follows tensor_type[1]( Global
+   * Weight Type ). if it is false, the weight type follows tensor_type[2]
+   * (Global Activation Type)
+   */
+  Packed(bool val = true) : nntrainer::Property<bool>(val) {}
+  static constexpr const char *key = "packed";
+  using prop_tag = bool_prop_tag;
+};
+
+/**
  * @brief DisableBias to disable the bias
  *
  */
@@ -1158,7 +1176,6 @@ public:
   using prop_tag = dimension_prop_tag; /**< property type */
 };
 
-
 /**
  * @brief scaled dot product property, used to check
  * whether attention layer is a kind of scaled dot product attention
@@ -1190,7 +1207,10 @@ public:
   using prop_tag = bool_prop_tag;
 };
 
-
+/**
+ * @brief Print object
+ *
+ */
 class Print : public nntrainer::Property<bool> {
 public:
   /**

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -289,12 +289,12 @@ void Conv2DLayer::finalize(InitLayerContext &context) {
 
   wt_idx[ConvParams::weight] = context.requestWeight(
     kernel_dim, weight_initializer, weight_regularizer,
-    weight_regularizer_constant, weight_decay, "filter", true);
+    weight_regularizer_constant, weight_decay, "filter", true, 0);
 
   if (disable_bias.empty() || disable_bias.get() == false) {
     wt_idx[ConvParams::bias] =
       context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                            1.0f, bias_decay, "bias", true);
+                            1.0f, bias_decay, "bias", true, 0);
   }
 
   // this output_dim must be the same with dimension of hidden

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -69,20 +69,6 @@ void InitLayerContext::setOutputDimensions(
   for (unsigned i = 0u, sz = out_dim.size(); i < sz; ++i) {
     auto spec = outSpec(out_dim.at(i));
 
-/*     spec.variable_spec.dim.setFormat(
-      str_converter<enum_class_prop_tag,
-                    nntrainer::TensorFormatInfo>::from_string(tensor_type[0]));
-    spec.variable_spec.dim.setDataType(
-      str_converter<enum_class_prop_tag, nntrainer::TensorDataTypeInfo>::
-        from_string(tensor_type[2]));
-
-    spec.gradient_spec->dim.setFormat(
-      str_converter<enum_class_prop_tag,
-                    nntrainer::TensorFormatInfo>::from_string(tensor_type[0]));
-    spec.gradient_spec->dim.setDataType(
-      str_converter<enum_class_prop_tag, nntrainer::TensorDataTypeInfo>::
-        from_string(tensor_type[2]));
- */
     specs.push_back(std::move(spec));
   }
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -163,9 +163,9 @@ LayerNode::LayerNode(std::unique_ptr<nntrainer::Layer> &&l) :
   needs_calc_gradient(false),
   output_connections(),
   run_context(nullptr),
-  layer_node_props(
-    new PropsType(props::Name(), props::Distribute(), props::Trainable(), {},
-                  {}, props::SharedFrom(), props::ClipGradByGlobalNorm())),
+  layer_node_props(new PropsType(
+    props::Name(), props::Distribute(), props::Trainable(), {}, {},
+    props::SharedFrom(), props::ClipGradByGlobalNorm(), props::Packed())),
   layer_node_props_realization(
     new RealizationPropsType(props::Flatten(), props::Activation())),
   loss(new props::Loss()),
@@ -575,6 +575,14 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
   float max_norm = 0.0;
   if (!std::get<props::ClipGradByGlobalNorm>(*layer_node_props).empty())
     max_norm = std::get<props::ClipGradByGlobalNorm>(*layer_node_props).get();
+
+  if (!std::get<props::Packed>(*layer_node_props).empty()) {
+    bool isPacked = std::get<props::Packed>(*layer_node_props);
+    if (!isPacked) {
+      // set weight type = activation type
+      tensor_type[1] = tensor_type[2];
+    }
+  }
 
   std::vector<bool> out_info;
   out_info.reserve(output_connections.size());

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -50,6 +50,7 @@ class Activation;
 class SharedFrom;
 class InputConnection;
 class ClipGradByGlobalNorm;
+class Packed;
 } // namespace props
 
 /**
@@ -930,10 +931,11 @@ will also contain the properties of the layer. The properties will be copied
 upon final creation. Editing properties of the layer after init will not the
 properties in the context/graph unless intended. */
 
-  using PropsType = std::tuple<props::Name, props::Distribute, props::Trainable,
-                               std::vector<props::InputConnection>,
-                               std::vector<props::InputShape>,
-                               props::SharedFrom, props::ClipGradByGlobalNorm>;
+  using PropsType =
+    std::tuple<props::Name, props::Distribute, props::Trainable,
+               std::vector<props::InputConnection>,
+               std::vector<props::InputShape>, props::SharedFrom,
+               props::ClipGradByGlobalNorm, props::Packed>;
 
   using RealizationPropsType = std::tuple<props::Flatten, props::Activation>;
   /** these realization properties results in addition of new layers, hence

--- a/nntrainer/tensor/tensor_wrap_specs.h
+++ b/nntrainer/tensor/tensor_wrap_specs.h
@@ -62,8 +62,10 @@ enum class TensorLifespan {
                         layer finishes its execution in the current
                         iteration, eg. hidden memory/cells of RNN */
   EPOCH_LIFESPAN = 0b11111, /**< tensor must be valid before the epoch ends */
-  MAX_LIFESPAN = 0b111111,  /**< tensor must not be reset until the end of the
-                   model  execution, eg. layer weights */
+  FORWARD_INFER_LIFESPAN =
+    0b100000,               /**< tensor is only used for only inference */
+  MAX_LIFESPAN = 0b1111111, /**< tensor must not be reset until the end of the
+                  model  execution, eg. layer weights */
 };
 
 /**


### PR DESCRIPTION
In This PR includes,

. enable packed (bool) property for layer node. It is only for the
weight. If it is false, it follows the global activation datatype; if it is true, 
it will follow the global weight datatype.

. add output axis in Weight Spec and set the private variable in weight.
  it is to find the right direction for multiplying scales and zero-point

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>