### PR TITLE
[neon] Support scopy for multiple dataTypes in neon

### DIFF
--- a/nntrainer/tensor/blas_interface.h
+++ b/nntrainer/tensor/blas_interface.h
@@ -70,8 +70,17 @@ void scopy(const unsigned int N, const _FP16 *X, const int incX, _FP16 *Y,
  * @param[in] X uint8_t * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  */
-void scopy(const unsigned int N, const uint8_t *X, const int incX, _FP16 *Y,
-           const int incY);
+void scopy_int4_to_float16(const unsigned int N, const uint8_t *X,
+                           const int incX, _FP16 *Y, const int incY);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X uint8_t * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ */
+void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
+                           const int incX, _FP16 *Y, const int incY);
 
 /**
  * @brief     sdot computation : sum of all X * Y
@@ -185,6 +194,32 @@ void scopy(const unsigned int N, const void *X, const int incX, void *Y,
  */
 void scopy(const unsigned int N, const float *X, const int incX, float *Y,
            const int intY);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X uint8_t * for Vector X
+ * @param[in] Y uint8_t * for Vector Y
+ */
+void scopy(const unsigned int N, const uint8_t *X, const int incX, uint8_t *Y,
+           const int intY);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X uint8_t * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
+void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
+                           const int incX, float *Y, const int intY);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X uint8_t * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
+void scopy_int8_to_float32(const unsigned int N, const uint8_t *X,
+                           const int incX, float *Y, const int intY);
+
 /**
  * @brief     sdot computation : sum of all X * Y
  * @param[in] N number of elements in Y

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -48,6 +48,31 @@ void sgemv_transpose_neon(const float *A, const float *X, float *Y,
                           uint32_t rows, uint32_t cols, float alpha,
                           float beta);
 
+/**
+ * @brief     copy function with neon: Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint8_t * for Vector Y
+ */
+void scopy_neon_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
+
+/**
+ * @brief     copy function with neon: Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint8_t * for Vector Y
+ */
+void scopy_neon_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
+
+/**
+ * @brief     copy function with neon: Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X uint8_t * for Vector X
+ * @param[in] Y uint8_t * for Vector Y
+ */
+void scopy_neon_int8_or_int4(const unsigned int N, const uint8_t *X,
+                             uint8_t *Y);
+
 #ifdef ENABLE_FP16
 /**
  * @brief     sgemv computation with neon : Y = alpha*A*X + beta*Y
@@ -132,6 +157,13 @@ __fp16 snrm2_neon_fp16(const unsigned int N, const __fp16 *X);
 void sscal_neon_fp16(const unsigned int N, __fp16 *X, const float alpha);
 
 /**
+ * @brief     convert uint32x4_t to float32x4_t with neon with bitwise
+ * optimization
+ * @param[in] u32 element to convert
+ */
+float32x4_t vcvtq_f32_u32_bitwise(uint32x4_t u32);
+
+/**
  * @brief     copy function with neon: Y = X
  * @param[in] N number of elements in X
  * @param[in] X __fp16 * for Vector X
@@ -146,6 +178,14 @@ void scopy_neon_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y);
  * @param[in] Y uint8_t * for Vector Y
  */
 void scopy_neon_int4_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
+
+/**
+ * @brief     copy function with neon: Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint8_t * for Vector Y
+ */
+void scopy_neon_int8_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
 
 /**
  * @brief     copy function with neon: Y = X

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -3758,8 +3758,8 @@ void Tensor::dequantize(Tensor &output, unsigned int axis) const {
   if (output.getDataType() == Tdatatype::FP16) {
 #ifdef ENABLE_FP16
     if (getDataType() == Tdatatype::QINT4) {
-      scopy((size() + 1) / 2, getData<uint8_t>(), 1, output.getData<_FP16>(),
-            1);
+      scopy_int4_to_float16((size() + 1) / 2, getData<uint8_t>(), 1,
+                            output.getData<_FP16>(), 1);
     } else if (getDataType() == Tdatatype::QINT8) {
       // @todo scopy for qint8
       flate(output);


### PR DESCRIPTION
- scopy_int4_to_fp32
- scopy_int8_to_fp32
- scopy_int8_to_fp16
- scopy_int8_or_int4 : Since we use uint8_t for int4 Tensors, codes can be shared here
- vcvt_fp32_u32_bitwise : Faster optimization can be done with bitwise operation rather than elementwise operation

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped