### PR TITLE
[bugfix] Fix applying erf function

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -3388,10 +3388,9 @@ Tensor &Tensor::erf(Tensor &out) const {
     apply<float>(f, out);
   } else if (dim.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-    //    auto f = [](_FP16 in) {
-    // return static_cast<_FP16>(std::erf(static_cast<float>(in)));
-    //    };
-    auto f = [](_FP16 in) { return std::erf(in); };
+    auto f = [](_FP16 in) {
+      return static_cast<_FP16>(std::erf(static_cast<float>(in)));
+    };
     apply<_FP16>(f, out);
 #else
     throw std::invalid_argument("Error: enable-fp16 is not enabled");


### PR DESCRIPTION
- std::erf function does not support _Float16
- Fix by casting temporally

Resolves:
error: call of overloaded ‘erf(_Float16&)’ is ambiguous
 3394 |     auto f = [](_FP16 in) { return std::erf(in); };
      |                                    ~~~~~~~~^~~~

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped