### PR TITLE
[bugfix] Android ndk-build error fix

### DIFF
--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1953,10 +1953,16 @@ public:
   Tdatatype getDataType() const { return dim.getDataType(); }
 
   /**
-   * @brief     Set scale factors of the tensor
-   * @param[in] scales scale factors
+   * @brief     Set fp32 scale factors of the tensor
+   * @param[in] scales fp32 scale factors
    */
-  void setScaleFactors(std::vector<float> scales);
+  void setScaleFactors(std::vector<float> scales) {
+    if (scales.empty()) {
+      throw std::invalid_argument("Error: invalid parameter");
+    }
+
+    scale_factors_fp32 = scales;
+  }
 
   /**
    * @brief Get scale factors of the tensor
@@ -1976,7 +1982,13 @@ public:
    * @brief     Set fp16 scale factors of the tensor
    * @param[in] scales fp16 scale factors
    */
-  void setScaleFactors16(std::vector<_FP16> scales);
+  void setScaleFactorsFP16(std::vector<_FP16> scales) {
+    if (scales.empty()) {
+      throw std::invalid_argument("Error: invalid parameter");
+    }
+
+    scale_factors_fp16 = scales;
+  }
 #endif
 
   /**
@@ -2009,9 +2021,9 @@ private:
   std::string name; /**< name of the tensor */
   std::shared_ptr<MemoryData> data;
   size_t offset;
-  std::vector<float> scale_factors_32;
+  std::vector<float> scale_factors_fp32;
 #ifdef ENABLE_FP16
-  std::vector<_FP16> scale_factors_16;
+  std::vector<_FP16> scale_factors_fp16;
 #endif
   std::vector<uint8_t> zero_points;
 

--- a/test/unittest/unittest_nntrainer_tensor_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_fp16.cpp
@@ -5802,8 +5802,8 @@ TEST(nntrainer_Tensor, dequantize_01_n) {
                           nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
 
-  input.setScaleFactors16({static_cast<_FP16>(1.5), static_cast<_FP16>(1.0),
-                           static_cast<_FP16>(0.5)});
+  input.setScaleFactorsFP16({static_cast<_FP16>(1.5), static_cast<_FP16>(1.0),
+                             static_cast<_FP16>(0.5)});
   input.setZeroPoints({1, 4, 7});
 
   nntrainer::Tensor output(batch, channel, height, width,
@@ -5827,8 +5827,8 @@ TEST(nntrainer_Tensor, dequantize_02_n) {
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
 
-  input.setScaleFactors16({static_cast<_FP16>(1.5), static_cast<_FP16>(1.0),
-                           static_cast<_FP16>(0.5)});
+  input.setScaleFactorsFP16({static_cast<_FP16>(1.5), static_cast<_FP16>(1.0),
+                             static_cast<_FP16>(0.5)});
   input.setZeroPoints({1, 4, 7});
 
   nntrainer::Tensor output(batch, channel, height, width,
@@ -5873,8 +5873,8 @@ TEST(nntrainer_Tensor, dequantize_04_p) {
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
 
-  input.setScaleFactors16({static_cast<_FP16>(1.5), static_cast<_FP16>(1.0),
-                           static_cast<_FP16>(0.5)});
+  input.setScaleFactorsFP16({static_cast<_FP16>(1.5), static_cast<_FP16>(1.0),
+                             static_cast<_FP16>(0.5)});
   input.setZeroPoints({0, 0, 0});
 
   nntrainer::Tensor output(
@@ -5933,7 +5933,7 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
                            nntrainer::Tdatatype::FP16);
 
   // Dequantize by channel
-  EXPECT_NO_THROW(input.setScaleFactors16(
+  EXPECT_NO_THROW(input.setScaleFactorsFP16(
     {static_cast<_FP16>(2), static_cast<_FP16>(-2), static_cast<_FP16>(-4)}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1}));
   EXPECT_NO_THROW({ input.dequantize(output, 1); });
@@ -5953,7 +5953,7 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
 
   // Dequantize by height
 
-  EXPECT_NO_THROW(input.setScaleFactors16(
+  EXPECT_NO_THROW(input.setScaleFactorsFP16(
     {static_cast<_FP16>(4.2), static_cast<_FP16>(2), static_cast<_FP16>(-2),
      static_cast<_FP16>(-4.8)}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1}));
@@ -5997,7 +5997,7 @@ TEST(nntrainer_Tensor, dequantize_05_p) {
   EXPECT_EQ(output, answer2);
 
   // Dequantize by width
-  EXPECT_NO_THROW(input.setScaleFactors16(
+  EXPECT_NO_THROW(input.setScaleFactorsFP16(
     {static_cast<_FP16>(4.2), static_cast<_FP16>(2), static_cast<_FP16>(-2),
      static_cast<_FP16>(-4), static_cast<_FP16>(8)}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1, 1}));
@@ -6063,7 +6063,7 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
                            nntrainer::Tdatatype::FP16);
 
   // Dequantize by channel
-  EXPECT_NO_THROW(input.setScaleFactors16(
+  EXPECT_NO_THROW(input.setScaleFactorsFP16(
     {static_cast<_FP16>(2), static_cast<_FP16>(-2), static_cast<_FP16>(-4)}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1}));
   EXPECT_NO_THROW({ input.dequantize(output, 1); });
@@ -6082,9 +6082,9 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
   EXPECT_EQ(output, answer1);
 
   // Dequantize by height
-  EXPECT_NO_THROW(
-    input.setScaleFactors16({static_cast<_FP16>(4.2), static_cast<_FP16>(2),
-                             static_cast<_FP16>(-2), static_cast<_FP16>(-4)}));
+  EXPECT_NO_THROW(input.setScaleFactorsFP16(
+    {static_cast<_FP16>(4.2), static_cast<_FP16>(2), static_cast<_FP16>(-2),
+     static_cast<_FP16>(-4)}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1}));
   EXPECT_NO_THROW({ input.dequantize(output, 2); });
 
@@ -6126,7 +6126,7 @@ TEST(nntrainer_Tensor, dequantize_06_p) {
   EXPECT_EQ(output, answer2);
 
   // Dequantize by width
-  EXPECT_NO_THROW(input.setScaleFactors16(
+  EXPECT_NO_THROW(input.setScaleFactorsFP16(
     {static_cast<_FP16>(4.2), static_cast<_FP16>(2), static_cast<_FP16>(-2),
      static_cast<_FP16>(-4), static_cast<_FP16>(8)}));
   EXPECT_NO_THROW(input.setZeroPoints({1, 1, 1, 1, 1}));


### PR DESCRIPTION
This PR resolves ndk-build issue in the tensor fp16 unit test.

**Changes proposed in this PR:**
- Move implementation to header file to avoid linker error
- Change ambiguous variable and function names

This fixes:
```
[arm64-v8a] Executable     : unittest_nntrainer_tensor_fp16
ld: error: undefined symbol: nntrainer::Tensor::setScaleFactors16(std::__ndk1::vector<_Float16, std::__ndk1::allocator<_Float16>)
>>> referenced by unittest_nntrainer_tensor_fp16.cpp:5805 (../unittest/unittest_nntrainer_tensor_fp16.cpp:5805)
```

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped