### PR TITLE
[unittest] remove empty test case

### DIFF
--- a/test/unittest/memory/unittest_cache_pool.cpp
+++ b/test/unittest/memory/unittest_cache_pool.cpp
@@ -68,11 +68,6 @@ public:
 };
 
 /**
- * @brief creation and destruction
- */
-TEST_F(CachePoolTest, create_destroy) {}
-
-/**
  * @brief get cache memory
  */
 TEST_F(CachePoolTest, get_memory_01_p) {


### PR DESCRIPTION
 - create & destroy test case for cache pool does not do anything so removed it.