### PR TITLE
[bugfix] Fix Tensor save function when float16

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -3140,7 +3140,7 @@ void Tensor::save(std::ostream &file) {
 #ifdef ENABLE_FP16
     std::vector<_FP16> temp(size());
     for (unsigned int i = 0; i < size(); ++i) {
-      temp[i] = static_cast<_FP16>(getData()[i]);
+      temp[i] = static_cast<_FP16>(getData<_FP16>()[i]);
     }
 
     checkedWrite(file, (char *)temp.data(),


### PR DESCRIPTION
- Previously, wrong getData function was called when saving fp16 Tensor
- Apply proper template parameter: _FP16

Resolves:
```
...
23/41 unittest_nntrainer_tensor_fp16          FAIL     2.26 s (exit status 1)
...
[  FAILED  ] nntrainer_Tensor.save_read_01_p
...
```

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped