### PR TITLE
[blas/neon] Add copy function for fp32 and fp16

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -159,6 +159,42 @@ static void scopy_FP16(const unsigned int N, const _FP16 *X, const int incX,
 #endif
 }
 
+static void scopy_float32_to_float16(const unsigned int N, const float *X,
+                                     const int incX, _FP16 *Y, const int incY) {
+  unsigned int incy = abs(incY);
+  unsigned int incx = abs(incX);
+
+#if (defined USE__FP16 && USE_NEON)
+  if (incX == 1 && incY == 1) {
+    nntrainer::neon::scopy_neon_fp32_to_fp16(N, X, Y);
+  } else {
+    for (unsigned int i = 0; i < N; ++i)
+      Y[i * incy] = X[i * incx];
+  }
+#else
+  for (unsigned int i = 0; i < N; ++i)
+    Y[i * incy] = static_cast<_FP16>(X[i * incx]);
+#endif
+}
+
+static void scopy_float16_to_float32(const unsigned int N, const _FP16 *X,
+                                     const int incX, float *Y, const int incY) {
+  unsigned int incy = abs(incY);
+  unsigned int incx = abs(incX);
+
+#if (defined USE__FP16 && USE_NEON)
+  if (incX == 1 && incY == 1) {
+    nntrainer::neon::scopy_neon_fp16_to_fp32(N, X, Y);
+  } else {
+    for (unsigned int i = 0; i < N; ++i)
+      Y[i * incy] = X[i * incx];
+  }
+#else
+  for (unsigned int i = 0; i < N; ++i)
+    Y[i * incy] = static_cast<float>(X[i * incx]);
+#endif
+}
+
 static void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X,
                                const int incX, _FP16 *Y, const int incY) {
   unsigned int incy = abs(incY);
@@ -319,6 +355,16 @@ void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
 void scopy(const unsigned int N, const _FP16 *X, const int incX, _FP16 *Y,
            const int incY) {
   scopy_FP16(N, X, incX, Y, incY);
+}
+
+void scopy(const unsigned int N, const float *X, const int incX, _FP16 *Y,
+           const int incY) {
+  scopy_float32_to_float16(N, X, incX, Y, incY);
+}
+
+void scopy(const unsigned int N, const _FP16 *X, const int incX, float *Y,
+           const int incY) {
+  scopy_float16_to_float32(N, X, incX, Y, incY);
 }
 
 void scopy_int4_to_float16(const unsigned int N, const uint8_t *X,

--- a/nntrainer/tensor/blas_interface.h
+++ b/nntrainer/tensor/blas_interface.h
@@ -64,6 +64,25 @@ _FP16 snrm2(const int N, const _FP16 *X, const int incX);
  */
 void scopy(const unsigned int N, const _FP16 *X, const int incX, _FP16 *Y,
            const int incY);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ */
+void scopy(const unsigned int N, const float *X, const int incX, _FP16 *Y,
+           const int incY);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X __fp16 * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
+void scopy(const unsigned int N, const _FP16 *X, const int incX, float *Y,
+           const int incY);
+
 /**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X


### PR DESCRIPTION
- There was a missing implementation of user interface of fp32<->fp16 copy neon function.
- Add blas interface to use such neon funcions

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped