### PR TITLE
[bugfix] memory overwrite error fix in `unittest_tizen_capi`

### DIFF
--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -929,9 +929,9 @@ TEST(nntrainer_capi_nnmodel, getWeight_01) {
   ml_tensors_info_h weight_info;
   ml_tensors_data_h weights;
   unsigned int num_weights;
-  unsigned int dim[2][MAXDIM];
   unsigned int weight_dim_expected[2][MAXDIM] = {{1, 1, 62720, 10},
                                                  {1, 1, 1, 10}};
+  unsigned int dim[2][MAXDIM];
 
   ScopedIni s("capi_test_get_weight_01",
               {model_base, optimizer, dataset, inputlayer, outputlayer});


### PR DESCRIPTION

This PR resolves the failing getWeight_01 test case in the unittest_tizen_capi.
In the [ML API](https://github.com/nnstreamer/api/blob/main/c/include/ml-api-common.h#L100) common data structure, the maximum rank in Tizen APIs has changed from 4 to 16 since Tizen 8.0.
However, the NNTrainer getWeight test uses a dimension with a MAXDIM of 4.
This causes an issue of `ml_tensors_info_get_tensor_dimension` overwriting irrelevant memory since it expects an array length of 16 while passing an array length of 4.

**Changes proposed in this PR:**
- Switch the order of defining variables to avoid memory overwrites.

This fixes:
```
[ RUN      ] nntrainer_capi_nnmodel.getWeight_01
../test/tizen_capi/unittest_tizen_capi.cpp:960: Failure
Expected equality of these values:
  dim[idx][i]
    Which is: 1
  weight_dim_expected[idx][i]
    Which is: 0
../test/tizen_capi/unittest_tizen_capi.cpp:960: Failure
Expected equality of these values:
  dim[idx][i]
    Which is: 1
  weight_dim_expected[idx][i]
    Which is: 0
../test/tizen_capi/unittest_tizen_capi.cpp:960: Failure
Expected equality of these values:
  dim[idx][i]
    Which is: 62720
  weight_dim_expected[idx][i]
    Which is: 0
../test/tizen_capi/unittest_tizen_capi.cpp:960: Failure
Expected equality of these values:
  dim[idx][i]
    Which is: 10
  weight_dim_expected[idx][i]
    Which is: 0
../test/tizen_capi/unittest_tizen_capi.cpp:960: Failure
Expected equality of these values:
  dim[idx][i]
    Which is: 1
  weight_dim_expected[idx][i]
    Which is: 0
../test/tizen_capi/unittest_tizen_capi.cpp:960: Failure
Expected equality of these values:
  dim[idx][i]
    Which is: 1
  weight_dim_expected[idx][i]
    Which is: 0
../test/tizen_capi/unittest_tizen_capi.cpp:960: Failure
Expected equality of these values:
  dim[idx][i]
    Which is: 1
  weight_dim_expected[idx][i]
    Which is: 0
../test/tizen_capi/unittest_tizen_capi.cpp:960: Failure
Expected equality of these values:
  dim[idx][i]
    Which is: 10
  weight_dim_expected[idx][i]
    Which is: 0
[  FAILED  ] nntrainer_capi_nnmodel.getWeight_01 (10 ms)
```

Note that this is a temporal fix to avoid memory overwrite.

**Self-evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped