### PR TITLE
[Tensor] Support multiple data types in `copyData`

### DIFF
--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -2004,12 +2004,6 @@ public:
    */
   void dequantize(Tensor &output, unsigned int axis) const;
 
-  /**
-   * @brief      copy QINT Tensor and save to output tensor
-   * @param[out] output Tensor to store the result
-   */
-  void flate(Tensor &output) const;
-
   static constexpr float epsilon = 1e-5;
 
 private:


### PR DESCRIPTION
Previously, `copyData` only supported copying data of the same data type.
Copying data of different data types is needed with the increased demand for flexibility of mixed-precision.

**Changes proposed in this PR:**
- `copyData` supports copying data of different types with the use of NEON
- Remove the flate function
- utilize `copyData` in dequantize

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped