### PR TITLE
[Utils] Conversion to/from half-precision floating point

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -35,3 +35,4 @@
 # update this to enable external applications
 # @todo filter out headers that should be hidden
 /usr/include/nntrainer/util_func.h
+/usr/include/nntrainer/fp16.h

--- a/nntrainer/utils/fp16.h
+++ b/nntrainer/utils/fp16.h
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: The MIT License (MIT)
+/**
+ * Copyright (c) 2017 Facebook Inc.
+ * Copyright (c) 2017 Georgia Institute of Technology
+ * Copyright 2019 Google LLC
+ */
+/**
+ * @file   fp16.h
+ * @date   03 Nov 2023
+ * @brief  This is collection of FP16 and FP32 conversion
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Marat Dukhan <maratek@gmail.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __FP16_H__
+#define __FP16_H__
+
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
+#include <cmath>
+#include <cstdint>
+#elif !defined(__OPENCL_VERSION__)
+#include <math.h>
+#include <stdint.h>
+#endif
+
+namespace nntrainer {
+
+/**
+ * @brief convert 32-bit float in bit representation to a value
+ *
+ * @param w 32-bit float as bits
+ * @return float 32-bit float as value
+ */
+static inline float fp32_from_bits(uint32_t w) {
+#if defined(__OPENCL_VERSION__)
+  return as_float(w);
+#elif defined(__CUDA_ARCH__)
+  return __uint_as_float((unsigned int)w);
+#elif defined(__INTEL_COMPILER)
+  return _castu32_f32(w);
+#elif defined(_MSC_VER) && (defined(_M_ARM) || defined(_M_ARM64))
+  return _CopyFloatFromInt32((__int32)w);
+#else
+  union {
+    uint32_t as_bits;
+    float as_value;
+  } fp32 = {w};
+  return fp32.as_value;
+#endif
+}
+
+/**
+ * @brief convert 32-bit float value as bits
+ *
+ * @param f 32-bit float as value
+ * @return float 32-bit float as bits
+ */
+static inline uint32_t fp32_to_bits(float f) {
+#if defined(__OPENCL_VERSION__)
+  return as_uint(f);
+#elif defined(__CUDA_ARCH__)
+  return (uint32_t)__float_as_uint(f);
+#elif defined(__INTEL_COMPILER)
+  return _castf32_u32(f);
+#elif defined(_MSC_VER) && (defined(_M_ARM) || defined(_M_ARM64))
+  return (uint32_t)_CopyInt32FromFloat(f);
+#else
+  union {
+    float as_value;
+    uint32_t as_bits;
+  } fp32 = {f};
+  return fp32.as_bits;
+#endif
+}
+
+/**
+ * @brief convert a 32-bit float to a 16-bit float in bit representation
+ *
+ * @param f 32-bit float as value
+ * @return uint16_t 16-bit float as bits
+ */
+uint16_t compute_fp32_to_fp16(float f) {
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) || \
+  defined(__GNUC__) && !defined(__STRICT_ANSI__)
+  const float scale_to_inf = 0x1.0p+112f;
+  const float scale_to_zero = 0x1.0p-110f;
+#else
+  const float scale_to_inf = fp32_from_bits(UINT32_C(0x77800000));
+  const float scale_to_zero = fp32_from_bits(UINT32_C(0x08800000));
+#endif
+  float base = (fabsf(f) * scale_to_inf) * scale_to_zero;
+
+  const uint32_t w = fp32_to_bits(f);
+  const uint32_t shl1_w = w + w;
+  const uint32_t sign = w & UINT32_C(0x80000000);
+  uint32_t bias = shl1_w & UINT32_C(0xFF000000);
+  if (bias < UINT32_C(0x71000000)) {
+    bias = UINT32_C(0x71000000);
+  }
+
+  base = fp32_from_bits((bias >> 1) + UINT32_C(0x07800000)) + base;
+  const uint32_t bits = fp32_to_bits(base);
+  const uint32_t exp_bits = (bits >> 13) & UINT32_C(0x00007C00);
+  const uint32_t mantissa_bits = bits & UINT32_C(0x00000FFF);
+  const uint32_t nonsign = exp_bits + mantissa_bits;
+  return (sign >> 16) |
+         (shl1_w > UINT32_C(0xFF000000) ? UINT16_C(0x7E00) : nonsign);
+}
+
+/**
+ * @brief convert a 16-bit float, in bit representation, to a 32-bit float
+ *
+ * @param h 16-bit float as bits
+ * @return float 32-bit float as value
+ */
+float compute_fp16_to_fp32(uint16_t h) {
+  const uint32_t w = (uint32_t)h << 16;
+  const uint32_t sign = w & UINT32_C(0x80000000);
+  const uint32_t two_w = w + w;
+  const uint32_t exp_offset = UINT32_C(0xE0) << 23;
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) || \
+  defined(__GNUC__) && !defined(__STRICT_ANSI__)
+  const float exp_scale = 0x1.0p-112f;
+#else
+  const float exp_scale = fp32_from_bits(UINT32_C(0x7800000));
+#endif
+  const float normalized_value =
+    fp32_from_bits((two_w >> 4) + exp_offset) * exp_scale;
+
+  const uint32_t magic_mask = UINT32_C(126) << 23;
+  const float magic_bias = 0.5f;
+  const float denormalized_value =
+    fp32_from_bits((two_w >> 17) | magic_mask) - magic_bias;
+
+  const uint32_t denormalized_cutoff = UINT32_C(1) << 27;
+  const uint32_t result =
+    sign | (two_w < denormalized_cutoff ? fp32_to_bits(denormalized_value)
+                                        : fp32_to_bits(normalized_value));
+  return fp32_from_bits(result);
+}
+
+} /* namespace nntrainer */
+
+#endif /* __FP16_H__ */

--- a/nntrainer/utils/meson.build
+++ b/nntrainer/utils/meson.build
@@ -12,7 +12,8 @@ util_headers = [
   'node_exporter.h',
   'util_func.h',
   'profiler.h',
-  'nntr_threads.h'
+  'nntr_threads.h',
+  'fp16.h'
 ]
 
 if get_option('enable-trace')

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -555,6 +555,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 # update this to enable external applications
 # @todo filter out headers that should be hidden, and classifiy in the appropriate place if not
 %{_includedir}/nntrainer/util_func.h
+%{_includedir}/nntrainer/fp16.h
 
 %files devel-static
 %{_libdir}/libnntrainer*.a


### PR DESCRIPTION
This PR includes utility functions for conversion to/from 16-bit floating point number, in bit representation, from/to 32-bit floating point number in IEEE format.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped