### PR TITLE
[Tensor] Scaling functions for `Tensor`

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -20,7 +20,10 @@
 #endif
 
 #include <cmath>
+<<<<<<< HEAD
 #include <iostream>
+=======
+>>>>>>> 011e1c23... [Tensor] Consider scale factor in math ops
 
 #define sgemv_loop(ci, cj, cM, cN)           \
   do {                                       \

--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -15,7 +15,7 @@
 #include <blas_interface.h>
 #include <nntrainer_error.h>
 
-#if (defined USE__FP16 && defined USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
 #include <blas_neon.h>
 #endif
 
@@ -73,14 +73,14 @@
 
 namespace nntrainer {
 
-#ifdef ENABLE_FP16
+#if defined(ENABLE_FP16)
 static void saxpy_FP16(const unsigned int N, const float alpha, const _FP16 *X,
                        const int incX, _FP16 *Y, const int incY) {
   if (incX < 0 or incY < 0)
     throw std::invalid_argument(
       "Error: negative inc not supported without cblas");
 
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   // USE__FP16 is defined when platform is android
   if (incX == 1 && incY == 1) {
     nntrainer::neon::saxpy_neon_fp16(N, alpha, X, Y);
@@ -102,13 +102,13 @@ static void sgemv_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
   unsigned int incx = abs(incX);
 
   if (TransA == CblasTrans) {
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
     nntrainer::neon::sgemv_transpose_neon_fp16(A, X, Y, M, N, alpha, beta);
 #else
     sgemv_loop_fp16(i, j, N, M);
 #endif
   } else {
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
     nntrainer::neon::sgemv_neon_fp16(A, X, Y, M, N, alpha, beta);
 #else
     sgemv_loop_fp16(j, i, M, N);
@@ -125,7 +125,7 @@ static _FP16 sdot_FP16(const unsigned int N, const _FP16 *X,
 
   _FP16 ret = 0;
 
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   if (incX == 1 && incY == 1) {
     ret = nntrainer::neon::sdot_neon_fp16(N, X, Y);
   } else {
@@ -146,7 +146,7 @@ static void scopy_FP16(const unsigned int N, const _FP16 *X, const int incX,
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   if (incX == 1 && incY == 1) {
     nntrainer::neon::scopy_neon_fp16(N, X, Y);
   } else {
@@ -164,7 +164,7 @@ static void scopy_float32_to_float16(const unsigned int N, const float *X,
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   if (incX == 1 && incY == 1) {
     nntrainer::neon::scopy_neon_fp32_to_fp16(N, X, Y);
   } else {
@@ -182,7 +182,7 @@ static void scopy_float16_to_float32(const unsigned int N, const _FP16 *X,
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   if (incX == 1 && incY == 1) {
     nntrainer::neon::scopy_neon_fp16_to_fp32(N, X, Y);
   } else {
@@ -200,7 +200,7 @@ static void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X,
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   if (incX == 1 && incY == 1) {
     nntrainer::neon::scopy_neon_int4_to_fp16(N, X, Y);
   } else {
@@ -220,7 +220,7 @@ static void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X,
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   if (incX == 1 && incY == 1) {
     nntrainer::neon::scopy_neon_int8_to_fp16(N, X, Y);
   } else {
@@ -236,7 +236,7 @@ static void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X,
 
 static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                       _FP16 *Z, const float alpha) {
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   nntrainer::neon::elementwise_vector_multiplication_neon_fp16(N, X, Y, Z,
                                                                alpha);
 #else
@@ -247,7 +247,7 @@ static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
 }
 static void ewva_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                       _FP16 *Z, const float alpha) {
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   nntrainer::neon::elementwise_vector_addition_neon_fp16(N, X, Y, Z, alpha);
 #else
   for (unsigned int i = 0; i < N; ++i) {
@@ -258,7 +258,7 @@ static void ewva_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
 void sscal(const unsigned int N, const float alpha, _FP16 *X, const int incX) {
   unsigned int incx = abs(incX);
 
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   if (incX == 1) {
     nntrainer::neon::sscal_neon_fp16(N, X, alpha);
   } else {
@@ -275,7 +275,7 @@ static _FP16 snrm2_FP16(const unsigned int N, const _FP16 *X, const int incX) {
   unsigned int incx = abs(incX);
   _FP16 sum = 0;
   _FP16 tmp;
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   if (incX == 1) {
     sum = nntrainer::neon::snrm2_neon_fp16(N, X);
   } else {
@@ -301,7 +301,7 @@ static void sgemm_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
                        const unsigned int ldb, const float beta, _FP16 *C,
                        const unsigned int ldc) {
 
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   nntrainer::neon::sgemm_neon_fp16(A, B, C, M, N, K, alpha, beta,
                                    TransA == CblasTrans, TransB == CblasTrans);
 #else
@@ -313,7 +313,7 @@ static unsigned int isamax_FP16(const unsigned int N, const _FP16 *X,
                                 const int incX) {
   unsigned int max_idx = 0;
 
-#if (defined USE__FP16 && USE_NEON)
+#if (defined(USE__FP16) && defined(USE_NEON))
   if (incX == 1 && N >= 8) {
     max_idx = nntrainer::neon::isamax_neon_fp16(N, X);
   } else {
@@ -524,8 +524,8 @@ void sscal(const unsigned int N, const float alpha, void *X, const int incX,
 
   if (d_type == ml::train::TensorDim::DataType::FP32) {
 
-#ifdef USE_BLAS
-#ifdef BLAS_NUM_THREADS
+#if defined(USE_BLAS)
+#if defined(BLAS_NUM_THREADS)
     openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif // BLAS_NUM_THREADS
     cblas_sscal(N, alpha, (float *)X, incX);
@@ -533,7 +533,7 @@ void sscal(const unsigned int N, const float alpha, void *X, const int incX,
     sscal_raw(N, alpha, (float *)X, incX);
 #endif //  USE_BLAS
   } else if (d_type == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+#if defined(ENABLE_FP16)
     sscal(N, alpha, (_FP16 *)X, incX);
 #else
     throw std::invalid_argument("Error: enable-fp16 is not enabled");
@@ -542,8 +542,8 @@ void sscal(const unsigned int N, const float alpha, void *X, const int incX,
 }
 
 void sscal(const unsigned int N, const float alpha, float *X, const int incX) {
-#ifdef USE_BLAS
-#ifdef BLAS_NUM_THREADS
+#if defined(USE_BLAS)
+#if defined(BLAS_NUM_THREADS)
   openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
   cblas_sscal(N, alpha, X, incX);
@@ -556,8 +556,8 @@ void saxpy(const unsigned int N, const float alpha, const void *X,
            const int incX, void *Y, const int incY,
            ml::train::TensorDim::DataType d_type) {
   if (d_type == ml::train::TensorDim::DataType::FP32) {
-#ifdef USE_BLAS
-#ifdef BLAS_NUM_THREADS
+#if defined(USE_BLAS)
+#if defined(BLAS_NUM_THREADS)
     openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
     cblas_saxpy(N, alpha, static_cast<const float *>(X), incX,
@@ -567,7 +567,7 @@ void saxpy(const unsigned int N, const float alpha, const void *X,
               static_cast<float *>(Y), incY);
 #endif
   } else if (d_type == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+#if defined(ENABLE_FP16)
     saxpy_FP16(N, alpha, static_cast<const _FP16 *>(X), incX,
                static_cast<_FP16 *>(Y), incY);
 #else
@@ -578,8 +578,8 @@ void saxpy(const unsigned int N, const float alpha, const void *X,
 
 void saxpy(const unsigned int N, const float alpha, const float *X,
            const int incX, float *Y, const int incY) {
-#ifdef USE_BLAS
-#ifdef BLAS_NUM_THREADS
+#if defined(USE_BLAS)
+#if defined(BLAS_NUM_THREADS)
   openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
   cblas_saxpy(N, alpha, X, incX, Y, incY);
@@ -595,7 +595,7 @@ void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
            const unsigned int ldc, ml::train::TensorDim::DataType d_type) {
 
   if (d_type == ml::train::TensorDim::DataType::FP32) {
-#ifdef USE_CUBLAS
+#if defined(USE_CUBLAS)
     int devID = 0;
     cudaDeviceProp deviceProp;
     cudaGetDeviceProperties(&deviceProp, devID);
@@ -624,9 +624,9 @@ void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
     cudaMemcpy(C, d_C, size_C, cudaMemcpyDeviceToHost);
     cublasDestroy(handle);
 
-#elif defined USE_BLAS
+#elif defined(USE_BLAS)
 
-#ifdef BLAS_NUM_THREADS
+#if defined(BLAS_NUM_THREADS)
     openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
 
@@ -640,7 +640,7 @@ void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
 #endif
 
   } else if (d_type == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+#if defined(ENABLE_FP16)
     sgemm_FP16(
       order, TransA, TransB, M, N, K, alpha, static_cast<const _FP16 *>(A), lda,
       static_cast<const _FP16 *>(B), ldb, beta, static_cast<_FP16 *>(C), ldc);
@@ -648,7 +648,7 @@ void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
     throw std::invalid_argument("Error: enable-fp16 is not enabled");
 #endif
   }
-} // namespace nntrainer
+}
 
 void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
            const unsigned int M, const unsigned int N, const unsigned int K,
@@ -656,7 +656,7 @@ void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
            const float *B, const unsigned int ldb, const float beta, float *C,
            const unsigned int ldc) {
 
-#ifdef USE_CUBLAS
+#if defined(USE_CUBLAS)
   int devID = 0;
   cudaDeviceProp deviceProp;
   cudaGetDeviceProperties(&deviceProp, devID);
@@ -682,8 +682,8 @@ void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
 
   cudaMemcpy(C, d_C, size_C, cudaMemcpyDeviceToHost);
   cublasDestroy(handle);
-#elif defined USE_BLAS
-#ifdef BLAS_NUM_THREADS
+#elif defined(USE_BLAS)
+#if defined(BLAS_NUM_THREADS)
   openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
   cblas_sgemm(order, TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C,
@@ -699,8 +699,8 @@ void scopy(const unsigned int N, const void *X, const int incX, void *Y,
 
   if (d_type == ml::train::TensorDim::DataType::FP32) {
 
-#ifdef USE_BLAS
-#ifdef BLAS_NUM_THREADS
+#if defined(USE_BLAS)
+#if defined(BLAS_NUM_THREADS)
     openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
     cblas_scopy(N, (float *)X, incX, (float *)Y, incY);
@@ -709,7 +709,7 @@ void scopy(const unsigned int N, const void *X, const int incX, void *Y,
 #endif
 
   } else if (d_type == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+#if defined(ENABLE_FP16)
     scopy_FP16(N, (_FP16 *)X, incX, (_FP16 *)Y, incY);
 #else
     throw std::invalid_argument("Error: enable-fp16 is not enabled");
@@ -719,8 +719,8 @@ void scopy(const unsigned int N, const void *X, const int incX, void *Y,
 
 void scopy(const unsigned int N, const float *X, const int incX, float *Y,
            const int incY) {
-#ifdef USE_BLAS
-#ifdef BLAS_NUM_THREADS
+#if defined(USE_BLAS)
+#if defined(BLAS_NUM_THREADS)
   openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
   cblas_scopy(N, X, incX, Y, incY);
@@ -731,7 +731,7 @@ void scopy(const unsigned int N, const float *X, const int incX, float *Y,
 
 void scopy(const unsigned int N, const uint8_t *X, const int incX, uint8_t *Y,
            const int intY) {
-#ifdef USE_NEON
+#if defined(USE_NEON)
   nntrainer::neon::scopy_neon_int8_or_int4(N, X, Y);
 #else
   for (unsigned int idx = 0; idx < N; idx++) {
@@ -742,7 +742,7 @@ void scopy(const unsigned int N, const uint8_t *X, const int incX, uint8_t *Y,
 
 void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
                            const int incX, float *Y, const int incY) {
-#ifdef USE_NEON
+#if defined(USE_NEON)
   nntrainer::neon::scopy_neon_int4_to_fp32(N, X, Y);
 #else
   for (unsigned int idx = 0; idx < N; idx++) {
@@ -754,7 +754,7 @@ void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
 
 void scopy_int8_to_float32(const unsigned int N, const uint8_t *X,
                            const int incX, float *Y, const int incY) {
-#ifdef USE_NEON
+#if defined(USE_NEON)
   nntrainer::neon::scopy_neon_int8_to_fp32(N, X, Y);
 #else
   for (unsigned int idx = 0; idx < N; idx++) {
@@ -764,8 +764,8 @@ void scopy_int8_to_float32(const unsigned int N, const uint8_t *X,
 }
 
 float snrm2(const int N, const float *X, const int incX) {
-#ifdef USE_BLAS
-#ifdef BLAS_NUM_THREADS
+#if defined(USE_BLAS)
+#if defined(BLAS_NUM_THREADS)
   openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
   return cblas_snrm2(N, X, incX);
@@ -776,8 +776,8 @@ float snrm2(const int N, const float *X, const int incX) {
 
 float sdot(const unsigned int N, const float *X, const unsigned int incX,
            const float *Y, const unsigned int incY) {
-#ifdef USE_BLAS
-#ifdef BLAS_NUM_THREADS
+#if defined(USE_BLAS)
+#if defined(BLAS_NUM_THREADS)
   openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
   return cblas_sdot(N, X, incX, Y, incY);
@@ -792,8 +792,8 @@ void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
            const float beta, void *Y, const int incY,
            ml::train::TensorDim::DataType d_type) {
   if (d_type == ml::train::TensorDim::DataType::FP32) {
-#ifdef USE_BLAS
-#ifdef BLAS_NUM_THREADS
+#if defined(USE_BLAS)
+#if defined(BLAS_NUM_THREADS)
     openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
     return cblas_sgemv(
@@ -806,7 +806,7 @@ void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
                      static_cast<float *>(Y), incY);
 #endif
   } else if (d_type == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+#if defined(ENABLE_FP16)
     return sgemv_FP16(order, TransA, M, N, alpha, static_cast<const _FP16 *>(A),
                       lda, static_cast<const _FP16 *>(X), incX, beta,
                       static_cast<_FP16 *>(Y), incY);
@@ -820,8 +820,8 @@ void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
            const unsigned int N, const float alpha, const float *A,
            const unsigned int lda, const float *X, const int incX,
            const float beta, float *Y, const int incY) {
-#ifdef USE_BLAS
-#ifdef BLAS_NUM_THREADS
+#if defined(USE_BLAS)
+#if defined(BLAS_NUM_THREADS)
   openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
   return cblas_sgemv(order, TransA, M, N, alpha, A, lda, X, incX, beta, Y,
@@ -832,8 +832,8 @@ void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
 }
 
 unsigned int isamax(const unsigned int N, const float *X, const int incX) {
-#ifdef USE_BLAS
-#ifdef BLAS_NUM_THREADS
+#if defined(USE_BLAS)
+#if defined(BLAS_NUM_THREADS)
   openblas_set_num_threads(BLAS_NUM_THREADS);
 #endif
   return cblas_isamax(N, X, incX);

--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -20,10 +20,6 @@
 #endif
 
 #include <cmath>
-<<<<<<< HEAD
-#include <iostream>
-=======
->>>>>>> 011e1c23... [Tensor] Consider scale factor in math ops
 
 #define sgemv_loop(ci, cj, cM, cN)           \
   do {                                       \

--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #include <cmath>
+#include <iostream>
 
 #define sgemv_loop(ci, cj, cM, cN)           \
   do {                                       \
@@ -235,22 +236,24 @@ static void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X,
 }
 
 static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
-                      _FP16 *Z) {
+                      _FP16 *Z, const float alpha) {
 #if (defined USE__FP16 && USE_NEON)
-  nntrainer::neon::elementwise_vector_multiplication_neon_fp16(N, X, Y, Z);
+  nntrainer::neon::elementwise_vector_multiplication_neon_fp16(N, X, Y, Z,
+                                                               alpha);
 #else
-  for (unsigned int i = 0; i < N; ++i)
-    Z[i] = X[i] * Y[i];
+  for (unsigned int i = 0; i < N; ++i) {
+    Z[i] = static_cast<_FP16>(alpha) * X[i] * Y[i];
+  }
 #endif
 }
-
 static void ewva_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
-                      _FP16 *Z) {
+                      _FP16 *Z, const float alpha) {
 #if (defined USE__FP16 && USE_NEON)
-  nntrainer::neon::elementwise_vector_addition_neon_fp16(N, X, Y, Z);
+  nntrainer::neon::elementwise_vector_addition_neon_fp16(N, X, Y, Z, alpha);
 #else
-  for (unsigned int i = 0; i < N; ++i)
-    Z[i] = X[i] + Y[i];
+  for (unsigned int i = 0; i < N; ++i) {
+    Z[i] = X[i] + static_cast<_FP16>(alpha) * Y[i];
+  }
 #endif
 }
 void sscal(const unsigned int N, const float alpha, _FP16 *X, const int incX) {
@@ -377,12 +380,14 @@ void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
   scopy_int8_to_fp16(N, X, incX, Y, incY);
 }
 
-void ewvm(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z) {
-  ewvm_FP16(N, X, Y, Z);
+void ewvm(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
+          const float alpha) {
+  ewvm_FP16(N, X, Y, Z, alpha);
 }
 
-void ewva(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z) {
-  ewva_FP16(N, X, Y, Z);
+void ewva(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
+          const float alpha) {
+  ewva_FP16(N, X, Y, Z, alpha);
 }
 
 _FP16 snrm2(const int N, const _FP16 *X, const int incX) {

--- a/nntrainer/tensor/blas_interface.h
+++ b/nntrainer/tensor/blas_interface.h
@@ -152,22 +152,24 @@ void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
            const unsigned int lda, const _FP16 *X, const int incX,
            const float beta, _FP16 *Y, const int incY);
 /**
- * @brief     elementwise vector multiplication : Z = X ⊙ Y
+ * @brief     elementwise vector multiplication : Z = (alpha) * (X ⊙ Y)
  * @param[in] N  length of the vector
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  * @param[in] Z __fp16 * for Vector Z
+ * @param[in] alpha scaling factor
  */
-void ewvm(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z);
+void ewvm(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z, const float alpha = 1);
 
 /**
- * @brief     elementwise vector addition : Z = X + Y
+ * @brief     elementwise vector addition : Z = X + (alpha) * Y
  * @param[in] N  length of the vector
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  * @param[in] Z __fp16 * for Vector Z
+ * @param[in] alpha scaling factor
  */
-void ewva(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z);
+void ewva(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z, const float alpha = 1);
 
 /**
  * @brief     isamax function : index of first maxima

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -1977,34 +1977,38 @@ void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
 
 void elementwise_vector_multiplication_neon_fp16(const unsigned int N,
                                                  const __fp16 *X,
-                                                 const __fp16 *Y, __fp16 *Z) {
+                                                 const __fp16 *Y, __fp16 *Z,
+                                                 const float alpha) {
   int i = 0;
   for (; N - i >= 8; i += 8) {
     float16x8_t x0_7 = vld1q_f16(&X[i]);
     float16x8_t y0_7 = vld1q_f16(&Y[i]);
     float16x8_t z0_7 = vmulq_f16(x0_7, y0_7);
+    z0_7 = vmulq_n_f16(z0_7, alpha);
 
     vst1q_f16(&Z[i], z0_7);
   }
   while (i < N) {
     Z[i] = X[i] * Y[i];
+    Z[i] *= alpha;
     ++i;
   }
 }
 
 void elementwise_vector_addition_neon_fp16(const unsigned int N,
                                            const __fp16 *X, const __fp16 *Y,
-                                           __fp16 *Z) {
+                                           __fp16 *Z, const float alpha) {
   int i = 0;
   for (; N - i >= 8; i += 8) {
     float16x8_t x0_7 = vld1q_f16(&X[i]);
     float16x8_t y0_7 = vld1q_f16(&Y[i]);
+    y0_7 = vmulq_n_f16(y0_7, alpha);
     float16x8_t z0_7 = vaddq_f16(x0_7, y0_7);
 
     vst1q_f16(&Z[i], z0_7);
   }
   while (i < N) {
-    Z[i] = X[i] * Y[i];
+    Z[i] = X[i] + alpha * Y[i];
     ++i;
   }
 }

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -88,24 +88,28 @@ void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
                      uint32_t cols, float alpha, float beta);
 
 /**
- * @brief     elementwise vector multiplication with neon : Z = X ⊙ Y
+ * @brief     elementwise vector multiplication with neon : Z = alpha * (X ⊙ Y)
  * @param[in] N  length of the vector
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  * @param[in] Z __fp16 * for Vector Z
+ * @param[in] alpha scaling factor
  */
 void elementwise_vector_multiplication_neon_fp16(const unsigned N,
                                                  const __fp16 *X,
-                                                 const __fp16 *Y, __fp16 *Z);
+                                                 const __fp16 *Y, __fp16 *Z,
+                                                 const float alpha);
 /**
- * @brief     elementwise vector addition with neon : Z = X + Y
+ * @brief     elementwise vector addition with neon : Z = X + alpha * Y
  * @param[in] N  length of the vector
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  * @param[in] Z __fp16 * for Vector Z
+ * @param[in] alpha scaling factor
  */
 void elementwise_vector_addition_neon_fp16(const unsigned N, const __fp16 *X,
-                                           const __fp16 *Y, __fp16 *Z);
+                                           const __fp16 *Y, __fp16 *Z,
+                                           const float alpha);
 
 /**
  * @brief     transposed sgemv computation with neon

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1093,7 +1093,7 @@ Tensor &Tensor::add(Tensor const &m, Tensor &output, float const alpha) const {
   } else if (dim.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
     auto f = [&](const BroadcastInfo &e, const _FP16 *buf, const _FP16 *m_buf,
-                 _FP16 *out_buf) {
+                _FP16 *out_buf) {
       if (e.strides[3] == 1 && strides[3] == 1 && strides[3] == 1 &&
           alpha == 0) {
         ewva(e.buffer_size, buf, m_buf, out_buf);
@@ -3691,6 +3691,19 @@ uint8_t Tensor::decode_qint(uint8_t val, bool isHigh) const {
 
 std::vector<float> Tensor::getScaleFactors() const {
   return scale_factors_fp32;
+}
+
+void Tensor::setScaleFactor(float val) {
+  scale_factors_fp32.clear();
+  scale_factors_fp32.push_back(val);
+}
+
+void Tensor::applyScaleFactor_i() {
+  if (scale_factors_fp32.empty()){
+      throw std::invalid_argument("Error: scaling Tensor needs scale factor");
+  }
+  this->multiply_i(*scale_factors_fp32.begin());
+  scale_factors_fp32.clear();
 }
 
 void Tensor::setZeroPoints(std::vector<uint8_t> zp) {

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -3124,6 +3124,7 @@ Tensor Tensor::clone() const {
   Tensor t;
   t.copy(*this);
   t.name = name;
+  t.setScaleFactors(getScaleFactors());
   return t;
 }
 

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1972,6 +1972,17 @@ public:
   std::vector<float> getScaleFactors() const;
 
   /**
+   * @brief Set new scale factor of the tensor
+   * @param[in] val zero points
+   */
+  void setScaleFactor(float val);
+
+    /**
+   * @brief Apply scale factor of the tensor
+   */
+  void applyScaleFactor_i();
+
+  /**
    * @brief     Set output axis of the tensor
    * @param[in] zp zero points
    */

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1972,15 +1972,16 @@ public:
   std::vector<float> getScaleFactors() const;
 
   /**
-   * @brief Set new scale factor of the tensor
-   * @param[in] val zero points
+   * @brief Scale Tensor with single scalar value
+   * @param[in] val scale factor value
    */
-  void setScaleFactor(float val);
+  void scale(float val);
 
-    /**
-   * @brief Apply scale factor of the tensor
+  /**
+   * @brief Restore the Tensor with its values and scale factors with value
+   * of 1.
    */
-  void applyScaleFactor_i();
+  void descale();
 
   /**
    * @brief     Set output axis of the tensor

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -2108,6 +2108,7 @@ private:
                                           const _FP16 *, _FP16 *)>
                          v_func,
                        Tensor &output) const;
+
 #endif
   /**
    * @brief compute Loop info for broadcasting and vectorization


### PR DESCRIPTION
- For mixed precision training, we must support loss scaling to preserve round-off accuracy from half-precision.
- Scale factor for such training is generally a model hyperparameter, but here we gave it as a Tensor parameter for more subtle handling in lower level. Refer to each commit for propsed changes.
- Loss Scaler, which will govern all scaling situations for Tensor, Weight, Optimizer will be propsed in the near future.
- Add unittest accordingly.

For easier review, followings are the functions I revised to convey/consider `scale_factors_fp32` :
* `sum_by_batch`
* `sum`
* `multiply`
* `divide`
* `add`
* `dot`
* `transpose`
* `clone`
* `rotate_180`
* `scale`
* `descale`