### PR TITLE
[trivial/bugfix] Add `inference_only_option` in multi_head_attention

### DIFF
--- a/test/unittest/layers/unittest_layers_multi_head_attention.cpp
+++ b/test/unittest/layers/unittest_layers_multi_head_attention.cpp
@@ -34,6 +34,10 @@ GTEST_PARAMETER_TEST(
                     semantic_multi_head_attention_with_mask));
 
 auto no_cos_sim_option = LayerGoldenTestParamOptions::SKIP_COSINE_SIMILARITY;
+auto inference_only_option =
+  LayerGoldenTestParamOptions::SKIP_COSINE_SIMILARITY |
+  LayerGoldenTestParamOptions::SKIP_CALC_DERIV |
+  LayerGoldenTestParamOptions::SKIP_CALC_GRAD;
 
 auto multi_head_attention_single_batch = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::MultiHeadAttentionLayer>,


### PR DESCRIPTION
- We were using `inference_only_option` for multi_head_attention fp16 unittest since we do not have loss scaling implementation yet.
- However, I discovered that there was a missing declaration of such option which might make malfunction when build, and added accordingly.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped