### PR TITLE
[Tensor] FloatTensor class for 32-bit floating point

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -9,6 +9,7 @@
 # tensor headers
 /usr/include/nntrainer/memory_data.h
 /usr/include/nntrainer/tensor.h
+/usr/include/nntrainer/float_tensor.h
 /usr/include/nntrainer/tensor_wrap_specs.h
 /usr/include/nntrainer/blas_interface.h
 /usr/include/nntrainer/var_grad.h

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -1,0 +1,2279 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file	float_tensor.cpp
+ * @date	09 November 2023
+ * @brief	This is FloatTensor class for 32-bit floating point calculation
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Donghyeon Jeong <dhyeon.jeong@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#include <algorithm>
+#include <assert.h>
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <stdio.h>
+
+#include <float_tensor.h>
+#include <util_func.h>
+
+#define transposeloop(cl, ci, cj, ck, sl, si, sj, sk)                 \
+  do {                                                                \
+    unsigned int i, j, k, l;                                          \
+    int inidx = 0, outidx = 0;                                        \
+    for (cl = 0; cl < sl; cl++)                                       \
+      for (ci = 0; ci < si; ci++)                                     \
+        for (cj = 0; cj < sj; cj++)                                   \
+          for (ck = 0; ck < sk; ck++) {                               \
+            outidx = si * sj * sk * cl + sj * sk * ci + sk * cj + ck; \
+            inidx = l * SI * SJ * SK + i * SJ * SK + j * SK + k;      \
+            outptr[outidx] = inptr[inidx];                            \
+          }                                                           \
+  } while (0);
+
+#define transposeloop_nhwc(cl, ci, cj, ck, sl, si, sj, sk)            \
+  do {                                                                \
+    unsigned int i, j, k, l;                                          \
+    int inidx = 0, outidx = 0;                                        \
+    for (cl = 0; cl < sl; cl++)                                       \
+      for (ci = 0; ci < si; ci++)                                     \
+        for (cj = 0; cj < sj; cj++)                                   \
+          for (ck = 0; ck < sk; ck++) {                               \
+            outidx = si * sj * sk * cl + sj * sk * ci + sk * cj + ck; \
+            inidx = l * SJ * SK * SI + j * SK * SI + k * SI + i;      \
+            outptr[outidx] = inptr[inidx];                            \
+          }                                                           \
+  } while (0);
+
+namespace nntrainer {
+
+/**
+ * @struct External Loop Info for broadcasted info
+ * @brief External Loop Info for broadcasted iteration. Please refer to
+ * DISABLED_private_external_loop_n in unittest_nntrainer_tensor.
+ * @note This should better be implemented in iterator fashion before used
+ * extensively.
+ */
+struct FloatTensor::BroadcastInfo {
+
+  /**
+   * @brief Construct a new External Loop Info object
+   *
+   */
+  BroadcastInfo() :
+    buffer_size(0),
+    buffer_axis(-1),
+    strides{0, 0, 0, 0},
+    tensor_type(nntrainer::TensorDim::TensorType()) {}
+
+  unsigned int buffer_size; /**< virtual size of the buffer */
+  int buffer_axis;          /**< the smallest axis that should be looped.
+                                 -1 means no loop needed*/
+  std::array<unsigned int, TensorDim::MAXDIM>
+    strides; /**< modified strides for the loop */
+  nntrainer::TensorDim::TensorType tensor_type;
+};
+
+FloatTensor::FloatTensor(const TensorDim &d, bool alloc_now,
+                         FloatTensor::Initializer init, std::string name_) :
+  FloatTensor(name_, d.getFormat()) {
+  if (d.getDataLen() != 0) {
+    dim = d;
+    strides = d.computeStrides();
+    initializer = init;
+    if (alloc_now)
+      allocate();
+  }
+}
+
+FloatTensor::FloatTensor(const TensorDim &d, const void *buf) :
+  FloatTensor(d, true) {
+  if (d.getDataLen() != 0) {
+    if (buf != nullptr)
+      copy(buf);
+  }
+}
+
+/**
+ * @class SrcSharedFloatTensor
+ * @brief Source of the shared tensor
+ * @note Remove this class
+ */
+class SrcSharedFloatTensor {
+public:
+  /**
+   * @brief   Constructor for the class
+   */
+  SrcSharedFloatTensor() : src(nullptr), off(0) {}
+
+  SrcSharedFloatTensor(const FloatTensor *tensor, size_t offset) :
+    src(tensor),
+    off(offset) {}
+
+  /**
+   * @brief   Get the allocated src tensor
+   */
+  const FloatTensor *tensor() const {
+    if (!src)
+      throw std::runtime_error("Accessing empty src tensor");
+
+    return src;
+  }
+
+  /**
+   * @brief   Get the offset from the source tensor
+   */
+  size_t offset() const { return off; }
+
+private:
+  const FloatTensor *src; /**< FloatTensor of the source */
+  size_t off;             /**< offset from the source data ptr */
+};
+
+void FloatTensor::allocate() {
+  if (empty() || data)
+    /// already allocated
+    return;
+
+  if (src_tensor) {
+    /// allocate data based on the source tensor
+    data = src_tensor->tensor()->data;
+    offset = src_tensor->tensor()->offset + src_tensor->offset();
+    /** as this memory is shared, do NOT initialize */
+  } else {
+    /// allocate new memory for the tensor data
+
+    MemoryData *mem_data;
+
+    mem_data = new MemoryData((void *)(new float[dim.getDataLen()]{}));
+    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
+      delete[] mem_data->template getAddr<float>();
+      delete mem_data;
+    });
+
+    offset = 0;
+    initialize();
+  }
+}
+
+bool FloatTensor::operator==(const FloatTensor &rhs) const {
+  if (this->dim != rhs.dim)
+    return false;
+
+  size_t len = size();
+
+  if (len != rhs.size())
+    return false;
+
+  if (contiguous != rhs.contiguous)
+    return false;
+
+  if (strides != rhs.strides)
+    return false;
+
+  const float *_data = getData();
+  const float *_rdata = rhs.getData();
+  for (size_t i = 0; i < len; ++i) {
+    /** not checking sign change is intentional to avoid float calculation
+     * errors around 0 */
+    if ((std::isnan(_data[i]) && !std::isnan(_rdata[i])) ||
+        (!std::isnan(_data[i]) && std::isnan(_rdata[i])) ||
+        std::fabs(_data[i] - _rdata[i]) > epsilon)
+      return false;
+  }
+
+  return true;
+}
+
+void FloatTensor::setRandNormal(float mean, float std) {
+  setDist<std::normal_distribution<float>>(
+    std::normal_distribution<float>(mean, std));
+}
+
+void FloatTensor::setRandUniform(float min, float max) {
+  setDist<std::uniform_real_distribution<float>>(
+    std::uniform_real_distribution<float>(min, max));
+}
+
+void FloatTensor::setRandBernoulli(float probability) {
+  setDist<std::bernoulli_distribution>(
+    std::bernoulli_distribution(probability));
+}
+
+void FloatTensor::initialize() {
+  if (empty() || !isAllocated())
+    return;
+
+  unsigned int fan_in, fan_out;
+
+  /// @fixme: when unit is equal to one, this does not work, we need to rely on
+  /// effective dimension then actual numbers here. For now, some heuristics
+  /// added to infer what would be fan_in/fan_out
+  if (dim.batch() * dim.channel() * dim.height() == 1) {
+    fan_out = fan_in = dim.width();
+  } else if (dim.batch() * dim.channel() == 1) { /// fc layer - 2-D tensor
+    fan_in = dim.height();
+    fan_out = dim.width();
+  } else { /// conv2d filters - 4d tensor, @todo extend this to > 4
+    auto field_size = dim.height() * dim.width();
+
+    // this also handles below cases.
+    // 1. fan_in = fan_out = 1 as well.
+    // 2. batch == 1, channel == 1 and height == 1, theoretical rank of 1
+    fan_in = dim.channel() * field_size;
+    fan_out = dim.batch() * field_size;
+  }
+
+  switch (initializer) {
+  case FloatTensor::Initializer::ZEROS:
+    setZero();
+    break;
+  case FloatTensor::Initializer::ONES:
+    setValue(1.0f);
+    break;
+  case FloatTensor::Initializer::LECUN_NORMAL:
+    setRandNormal(0.0f, sqrtFloat(1.0f / fan_in));
+    break;
+  case FloatTensor::Initializer::XAVIER_NORMAL:
+    setRandNormal(0.0f, sqrtFloat(2.0f / (fan_in + fan_out)));
+    break;
+  case FloatTensor::Initializer::HE_NORMAL:
+    setRandNormal(0.0f, sqrtFloat(2.0f / (fan_in)));
+    break;
+  case FloatTensor::Initializer::LECUN_UNIFORM:
+    setRandUniform(-1.0f * sqrtFloat(1.0f / fan_in), sqrtFloat(1.0f / fan_in));
+    break;
+  case FloatTensor::Initializer::XAVIER_UNIFORM:
+    setRandUniform(-1.0f * sqrtFloat(6.0f / (fan_in + fan_out)),
+                   sqrtFloat(6.0 / (fan_in + fan_out)));
+    break;
+  case FloatTensor::Initializer::HE_UNIFORM:
+    setRandUniform(-1.0f * sqrtFloat(6.0f / (fan_in)),
+                   sqrtFloat(6.0 / (fan_in)));
+    break;
+  default:
+    break;
+  }
+
+  putData();
+}
+
+int FloatTensor::multiply_i_strided(FloatTensor const &m, const float beta) {
+  try {
+    this->multiply_strided(m, *this, beta);
+  } catch (std::exception &err) {
+    ml_loge("%s %s", typeid(err).name(), err.what());
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
+  return ML_ERROR_NONE;
+}
+
+FloatTensor FloatTensor::multiply_strided(FloatTensor const &m,
+                                          const float beta) const {
+  FloatTensor t;
+  return this->multiply_strided(m, t, beta);
+}
+
+FloatTensor &FloatTensor::multiply_strided(FloatTensor const &m,
+                                           FloatTensor &output,
+                                           const float beta) const {
+  /** TODO: throw than create new dimenions */
+  CREATE_IF_EMPTY_DIMS_FLOAT(output, dim, nullptr);
+
+  if (size() != m.size() || size() != output.size())
+    throw std::invalid_argument(
+      "Strided multiplication does not support broadcasting");
+
+  NNTR_THROW_IF(getData() == nullptr, std::invalid_argument)
+    << getName() << " is not allocated";
+  NNTR_THROW_IF(m.getData() == nullptr, std::invalid_argument)
+    << m.getName() << " is not allocated";
+  NNTR_THROW_IF(output.getData() == nullptr, std::invalid_argument)
+    << output.getName() << " is not allocated";
+
+  // Format NCHW Case
+  if (this->getFormat() == Tformat::NCHW) {
+    if (strides[3] != 1 || m.strides[3] != 1 || output.strides[3] != 1 ||
+        beta != 0.0) {
+      for (unsigned int b = 0; b < batch(); ++b) {
+        for (unsigned int c = 0; c < channel(); ++c) {
+          for (unsigned int h = 0; h < height(); ++h) {
+            for (unsigned int w = 0; w < width(); ++w) {
+              output.addValue(b, c, h, w,
+                              getValue(b, c, h, w) * m.getValue(b, c, h, w),
+                              beta);
+            }
+          }
+        }
+      }
+    } else {
+      /** @todo optimize this with combining these loops where stride is 1
+       */
+      for (unsigned int b = 0; b < batch(); ++b) {
+        for (unsigned int c = 0; c < channel(); ++c) {
+          for (unsigned int h = 0; h < height(); ++h) {
+            float *out_data = output.getAddress(b, c, h, 0);
+            const float *m_data = m.getAddress(b, c, h, 0);
+            const float *in_data = getAddress(b, c, h, 0);
+            std::transform(in_data, in_data + width(), m_data, out_data,
+                           std::multiplies<float>());
+          }
+        }
+      }
+    }
+  } else { // Format NHWC Case
+    if (strides[3] != 1 || m.strides[3] != 1 || output.strides[3] != 1 ||
+        beta != 0.0) {
+      for (unsigned int b = 0; b < batch(); ++b) {
+        for (unsigned int h = 0; h < height(); ++h) {
+          for (unsigned int w = 0; w < width(); ++w) {
+            for (unsigned int c = 0; c < channel(); ++c) {
+              output.addValue(b, c, h, w,
+                              getValue(b, c, h, w) * m.getValue(b, c, h, w),
+                              beta);
+            }
+          }
+        }
+      }
+    } else {
+      /** @todo optimize this with combining these loops where
+       * stride is 1 */
+      for (unsigned int b = 0; b < batch(); ++b) {
+        for (unsigned int h = 0; h < height(); ++h) {
+          for (unsigned int w = 0; w < width(); ++w) {
+            float *out_data = output.getAddress(b, 0, h, w);
+            const float *m_data = m.getAddress(b, 0, h, w);
+            const float *in_data = getAddress(b, 0, h, w);
+            std::transform(in_data, in_data + channel(), m_data, out_data,
+                           std::multiplies<float>());
+          }
+        }
+      }
+    }
+  }
+
+  return output;
+}
+
+int FloatTensor::add_i_strided(FloatTensor const &m, const float beta) {
+  try {
+    this->add_strided(m, *this, beta);
+  } catch (std::exception &err) {
+    ml_loge("%s %s", typeid(err).name(), err.what());
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
+  return ML_ERROR_NONE;
+}
+
+FloatTensor FloatTensor::add_strided(FloatTensor const &m,
+                                     const float beta) const {
+  FloatTensor t;
+  return this->add_strided(m, t, beta);
+}
+
+FloatTensor &FloatTensor::add_strided(FloatTensor const &m, FloatTensor &output,
+                                      const float beta) const {
+  /** TODO: throw than create new dimenions */
+  CREATE_IF_EMPTY_DIMS_FLOAT(output, dim, nullptr);
+
+  if (size() != m.size() || size() != output.size())
+    throw std::invalid_argument(
+      "Strided addition does not support broadcasting");
+
+  NNTR_THROW_IF(getData() == nullptr, std::invalid_argument)
+    << getName() << " is not allocated";
+  NNTR_THROW_IF(m.getData() == nullptr, std::invalid_argument)
+    << m.getName() << " is not allocated";
+  NNTR_THROW_IF(output.getData() == nullptr, std::invalid_argument)
+    << output.getName() << " is not allocated";
+
+  // Format NCHW Case
+  if (this->getFormat() == Tformat::NCHW) {
+    if (strides[3] != 1 || m.strides[3] != 1 || output.strides[3] != 1 ||
+        beta != 0.0) {
+      for (unsigned int b = 0; b < batch(); ++b) {
+        for (unsigned int c = 0; c < channel(); ++c) {
+          for (unsigned int h = 0; h < height(); ++h) {
+            for (unsigned int w = 0; w < width(); ++w) {
+              output.setValue(b, c, h, w,
+                              getValue(b, c, h, w) +
+                                m.getValue(b, c, h, w) * beta);
+            }
+          }
+        }
+      }
+    } else {
+      /** @todo optimize this with combining these loops where stride is 1 */
+      for (unsigned int b = 0; b < batch(); ++b) {
+        for (unsigned int c = 0; c < channel(); ++c) {
+          for (unsigned int h = 0; h < height(); ++h) {
+            float *out_data = output.getAddress(b, c, h, 0);
+            const float *m_data = m.getAddress(b, c, h, 0);
+            const float *in_data = getAddress(b, c, h, 0);
+            std::transform(in_data, in_data + width(), m_data, out_data,
+                           std::plus<float>());
+          }
+        }
+      }
+    }
+
+  } else { // Format NHWC Case
+    if (strides[3] != 1 || m.strides[3] != 1 || output.strides[3] != 1 ||
+        beta != 0.0) {
+      for (unsigned int b = 0; b < batch(); ++b) {
+        for (unsigned int h = 0; h < height(); ++h) {
+          for (unsigned int w = 0; w < width(); ++w) {
+            for (unsigned int c = 0; c < channel(); ++c) {
+              output.setValue(b, c, h, w,
+                              getValue(b, c, h, w) +
+                                m.getValue(b, c, h, w) * beta);
+            }
+          }
+        }
+      }
+    } else {
+      /** @todo optimize this with combining these loops where
+       * stride is 1 */
+      for (unsigned int b = 0; b < batch(); ++b) {
+        for (unsigned int h = 0; h < height(); ++h) {
+          for (unsigned int w = 0; w < width(); ++w) {
+            float *out_data = output.getAddress(b, 0, h, w);
+            const float *m_data = m.getAddress(b, 0, h, w);
+            const float *in_data = getAddress(b, 0, h, w);
+            std::transform(in_data, in_data + channel(), m_data, out_data,
+                           std::plus<float>());
+          }
+        }
+      }
+    }
+  }
+  return output;
+}
+
+int FloatTensor::multiply_i(float const &value) {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot multiply";
+
+  /// @note this is not depending on multiply_i as there is an optimized
+  /// version for multiply_i
+  float *data = getData();
+  unsigned int len = size();
+
+  sscal(len, value, data, 1);
+
+  return ML_ERROR_NONE;
+}
+
+FloatTensor FloatTensor::multiply(float const &value) const {
+  FloatTensor t;
+  return multiply(value, t);
+}
+
+FloatTensor &FloatTensor::multiply(float const &value, FloatTensor &out) const {
+  /// @todo add unittest
+  auto f = std::bind(std::multiplies<float>(), std::placeholders::_1, value);
+  apply(f, out);
+  return out;
+
+  return out;
+}
+
+int FloatTensor::multiply_i(FloatTensor const &m, const float beta) {
+  try {
+    this->multiply(m, *this, beta);
+  } catch (std::exception &err) {
+    ml_loge("%s %s", typeid(err).name(), err.what());
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
+  return ML_ERROR_NONE;
+}
+
+FloatTensor FloatTensor::multiply(FloatTensor const &m,
+                                  const float beta) const {
+  FloatTensor t("", this->getFormat());
+  return this->multiply(m, t, beta);
+}
+
+FloatTensor &FloatTensor::multiply(FloatTensor const &m, FloatTensor &output,
+                                   const float beta) const {
+  /**
+   * @note this does not work correctly with differently strided inputs.
+   * Use multiply_strided alternatively
+   */
+  auto f = [&](const BroadcastInfo &e, const float *buf, const float *m_buf,
+               float *out_buf) {
+    if (e.strides[3] == 1 && output.strides[3] == 1 && strides[3] == 1 &&
+        beta == 0.0) {
+      std::transform(buf, buf + e.buffer_size, m_buf, out_buf,
+                     std::multiplies<float>());
+    } else {
+      for (unsigned int i = 0; i < e.buffer_size; ++i) {
+        *out_buf = *buf * *m_buf + beta * *out_buf;
+        buf += strides[3];
+        m_buf += e.strides[3];
+        out_buf += output.strides[3];
+      }
+    }
+  };
+
+  NNTR_THROW_IF(m.getFormat() != this->getFormat(), std::invalid_argument)
+    << "FloatTensor Format of " << getName() << ":"
+    << ((bool)(this->getFormat()) ? "NHWC" : "NCHW") << " is not match. ("
+    << ((bool)(m.getFormat()) ? "NHWC" : "NCHW") << ")";
+
+  NNTR_THROW_IF(!contiguous || !m.contiguous || !output.contiguous,
+                std::invalid_argument)
+    << getName() << " is not contiguous, cannot multiply";
+
+  NNTR_THROW_IF(!contiguous || !m.contiguous || !output.contiguous,
+                std::invalid_argument)
+    << getName() << " is not contiguous, cannot multiply";
+
+  apply_broadcast(m, f, output);
+
+  return output;
+}
+
+int FloatTensor::divide_i(float const &value) {
+  if (value == 0.0f) {
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+  this->divide(value, *this);
+  return ML_ERROR_NONE;
+}
+
+FloatTensor FloatTensor::divide(float const &value) const {
+  FloatTensor t;
+  return divide(value, t);
+}
+
+FloatTensor &FloatTensor::divide(float const &value, FloatTensor &out) const {
+  /// @todo add unittest
+  if (value == 0.0f) {
+    std::stringstream ss;
+    ss << "[FloatTensor] divide by value failed, value: " << value;
+    throw std::invalid_argument(ss.str().c_str());
+  }
+
+  auto f = std::bind(std::divides<float>(), std::placeholders::_1, value);
+  apply(f, out);
+  return out;
+}
+
+int FloatTensor::divide_i(FloatTensor const &m) {
+  try {
+    this->divide(m, *this);
+  } catch (std::exception &err) {
+    ml_loge("%s %s", typeid(err).name(), err.what());
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
+  return ML_ERROR_NONE;
+}
+
+FloatTensor FloatTensor::divide(FloatTensor const &m) const {
+  FloatTensor t;
+  return this->divide(m, t);
+}
+
+FloatTensor &FloatTensor::divide(FloatTensor const &m,
+                                 FloatTensor &output) const {
+  auto f = [&](const BroadcastInfo &e, const float *buf, const float *m_buf,
+               float *out_buf) {
+    if (e.strides[3] == 1 && output.strides[3] == 1 && strides[3] == 1) {
+      std::transform(buf, buf + e.buffer_size, m_buf, out_buf,
+                     std::divides<float>());
+    } else {
+      for (unsigned int i = 0; i < e.buffer_size; ++i) {
+        *out_buf = *buf / *m_buf;
+        buf += strides[3];
+        m_buf += e.strides[3];
+        out_buf += output.strides[3];
+      }
+    }
+  };
+
+  NNTR_THROW_IF(!contiguous || !m.contiguous || !output.contiguous,
+                std::invalid_argument)
+    << getName() << " is not contiguous, cannot divide";
+
+  apply_broadcast(m, f, output);
+
+  return output;
+}
+
+int FloatTensor::add_i(float const &value) {
+  this->add(value, *this);
+  return ML_ERROR_NONE;
+}
+
+FloatTensor FloatTensor::add(float const &value) const {
+  FloatTensor t;
+  return add(value, t);
+}
+
+FloatTensor &FloatTensor::add(float const &value, FloatTensor &out) const {
+  /// @todo add unittest
+  auto f = std::bind(std::plus<float>(), std::placeholders::_1, value);
+  apply(f, out);
+  return out;
+}
+
+int FloatTensor::add_i(FloatTensor const &m, float const alpha) {
+  /// @todo: add axis rather doing add over the last two dimensions always
+  /// operator i has optimized version
+  auto f = [&](const BroadcastInfo &e, const float *buf, const float *m_buf,
+               float *out_buf) {
+    saxpy(e.buffer_size, alpha, m_buf, e.strides[3], out_buf, strides[3]);
+  };
+
+  /// @todo: enable this after add_strided supports broadcast
+  // NNTR_THROW_IF(!contiguous || !m.contiguous, std::invalid_argument)
+  //   << getName() << " is not contiguous, cannot add";
+
+  try {
+    apply_broadcast(m, f, *this);
+  } catch (std::exception &err) {
+    ml_loge("%s %s", typeid(err).name(), err.what());
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
+  return ML_ERROR_NONE;
+}
+
+FloatTensor FloatTensor::add(FloatTensor const &m, float const alpha) const {
+  FloatTensor t;
+  return this->add(m, t, alpha);
+}
+
+FloatTensor &FloatTensor::add(FloatTensor const &m, FloatTensor &output,
+                              float const alpha) const {
+  NNTR_THROW_IF(!contiguous || !m.contiguous || !output.contiguous,
+                std::invalid_argument)
+    << getName() << " is not contiguous, cannot add";
+
+  auto f = [&](const BroadcastInfo &e, const float *buf, const float *m_buf,
+               float *out_buf) {
+    if (e.strides[3] == 1 && strides[3] == 1 && strides[3] == 1 && alpha == 0) {
+      std::transform(buf, buf + e.buffer_size, m_buf, out_buf,
+                     std::plus<float>());
+    } else {
+      for (unsigned int i = 0; i < e.buffer_size; ++i) {
+        *out_buf = *buf + *m_buf * alpha;
+        buf += strides[3];
+        m_buf += e.strides[3];
+        out_buf += strides[3];
+      }
+    }
+  };
+
+  apply_broadcast(m, f, output);
+
+  return output;
+}
+
+int FloatTensor::subtract_i(float const &value) {
+  this->subtract(value, *this);
+  return ML_ERROR_NONE;
+}
+
+FloatTensor FloatTensor::subtract(float const &value) const {
+  FloatTensor t;
+  return subtract(value, t);
+}
+
+FloatTensor &FloatTensor::subtract(float const &value, FloatTensor &out) const {
+  /// @todo add unittest
+  auto f = std::bind(std::minus<float>(), std::placeholders::_1, value);
+  apply(f, out);
+  return out;
+}
+
+int FloatTensor::subtract_i(FloatTensor const &m) { return add_i(m, -1); }
+
+FloatTensor FloatTensor::subtract(FloatTensor const &m) const {
+  return add(m, -1);
+}
+
+FloatTensor &FloatTensor::subtract(FloatTensor const &m,
+                                   FloatTensor &out) const {
+  return add(m, out, -1);
+}
+
+int FloatTensor::pow_i(float exponent) {
+  pow(exponent, *this);
+  return ML_ERROR_NONE;
+}
+
+FloatTensor FloatTensor::pow(float exponent) const {
+  FloatTensor t;
+  return pow(exponent, t);
+}
+
+FloatTensor &FloatTensor::pow(float exponent, FloatTensor &out) const {
+  auto f = [exponent](float in) { return powf(in, exponent); };
+  apply(f, out);
+  return out;
+}
+
+FloatTensor FloatTensor::getBatchSlice(size_t offset, unsigned int size) const {
+  TensorDim dim_ = dim;
+  dim_.batch(size);
+
+  return getSharedDataTensor(dim_, offset * this->dim.getFeatureLen());
+}
+
+void FloatTensor::createSharedDataTensor(const FloatTensor &src,
+                                         FloatTensor &dest, size_t offset) {
+  /**
+   * - If src already has data allocaed, then directly make dest tensor based on
+   * the src tensor.
+   * - If src.data does not exist (meaning tensor does not memory allocated),
+   * and src.src_tensor does not exist (meaning the src tensor does not depened
+   * on another tensor), then create a SrcSharedFloatTensor around the src.
+   * - If src.src_tensor exists, then use the src.src_tensor to create the
+   *  required SrcSharedFloatTensor to avoid recursive dependency.
+   *
+   * @note src.data and src.src_tensor CAN co-exist. src.src_tensor is stored
+   * if the batch size of src is updated and needs reallocation.
+   */
+  dest.data = nullptr;
+  if (src.data) {
+    dest.src_tensor = std::make_shared<SrcSharedFloatTensor>(&src, offset);
+    dest.allocate();
+  } else if (!src.src_tensor)
+    dest.src_tensor = std::make_shared<SrcSharedFloatTensor>(&src, offset);
+  else
+    dest.src_tensor = std::make_shared<SrcSharedFloatTensor>(
+      src.src_tensor->tensor(), offset + src.src_tensor->offset());
+}
+
+FloatTensor FloatTensor::getSharedDataTensor(const TensorDim dim_,
+                                             size_t offset, bool reset_stride,
+                                             const std::string &name_) const {
+  FloatTensor ret = *this;
+  if (dim_.getFormat() != ret.dim.getFormat())
+    throw std::invalid_argument("FloatTensor format does not match");
+
+  ret.dim = dim_;
+  if (!name_.empty())
+    ret.name = name_;
+
+  if (dim_.getDataLen() + offset > dim.getDataLen())
+    throw std::invalid_argument(
+      "Creating shared tensor of size bigger than tensor memory.");
+
+  if (reset_stride)
+    ret.strides = ret.dim.computeStrides();
+
+  TensorDim new_match_dim = dim_;
+  new_match_dim.batch(dim.batch());
+  if (new_match_dim != dim && !reset_stride)
+    ret.contiguous = false;
+
+  /**
+   * In this case, its the caller's responsibility to ensure that allocate() is
+   * called for the output tensor before operating on the output tensor.
+   */
+  createSharedDataTensor(*this, ret, offset);
+
+  return ret;
+}
+
+std::vector<FloatTensor> FloatTensor::split(unsigned num_size, int axis) {
+  NNTR_THROW_IF(num_size == 0, std::invalid_argument)
+    << "num size cannot be zero";
+
+  if (axis == -1) {
+    axis = 3;
+  }
+
+  NNTR_THROW_IF(!(0 <= axis && axis < 4), std::invalid_argument)
+    << "cannot split axis of axis: " << axis;
+
+  NNTR_THROW_IF(dim.getTensorDim(axis) % num_size != 0, std::invalid_argument)
+    << "axis is not divisible by num_size, axis: " << axis
+    << " num size: " << num_size;
+
+  std::vector<size_t> sizes;
+  sizes.resize(num_size);
+
+  unsigned int sz = dim.getTensorDim(axis) / num_size;
+  std::fill(sizes.begin(), sizes.end(), sz);
+
+  return split(sizes, axis);
+}
+
+std::vector<FloatTensor> FloatTensor::split(std::vector<size_t> sizes,
+                                            int axis) {
+  size_t num_size = sizes.size();
+
+  NNTR_THROW_IF(num_size == 0, std::invalid_argument)
+    << "num size cannot be zero";
+
+  if (axis == -1) {
+    axis = 3;
+  }
+
+  NNTR_THROW_IF(!(0 <= axis && axis < 4), std::invalid_argument)
+    << "cannot split axis of axis: " << axis;
+
+  NNTR_THROW_IF(
+    std::any_of(sizes.begin(), sizes.end(), [](size_t sz) { return !sz; }),
+    std::invalid_argument)
+    << "among given sizes at least one of size is 0";
+
+  size_t total_size = std::accumulate(sizes.begin(), sizes.end(), 0);
+  NNTR_THROW_IF(dim.getTensorDim(axis) != total_size, std::invalid_argument)
+    << "given sum of sizes did not match with origin tensor dim, tensor dim: "
+    << dim.getTensorDim(axis) << " total size: " << total_size;
+
+  std::vector<TensorDim> ret_dims;
+  ret_dims.reserve(num_size);
+  for (unsigned int i = 0; i < num_size; ++i) {
+    ret_dims[i] = dim;
+    ret_dims[i].setTensorDim(axis, sizes[i]);
+  }
+
+  bool is_format_nchw = (dim.getFormat() == Tformat::NCHW) ? true : false;
+  std::vector<FloatTensor> ret;
+
+  auto iter_value = [this, is_format_nchw](
+                      std::array<size_t, 4> &loc,
+                      const std::array<size_t, 4> &end_loc,
+                      const std::array<size_t, 4> &reset_dim_arr) -> float & {
+    auto &value = (is_format_nchw) ? getValue(loc[0], loc[1], loc[2], loc[3])
+                                   : getValue(loc[0], loc[3], loc[1], loc[2]);
+    for (int i = 3; i >= 0; --i) {
+      loc[i]++;
+      if (loc[i] == end_loc[i]) {
+        loc[i] -= reset_dim_arr[i];
+        continue;
+      }
+      break;
+    }
+    return value;
+  };
+
+  ret.reserve(num_size);
+
+  unsigned int accumulated_size = 0;
+  for (unsigned int i = 0; i < num_size; ++i) {
+    std::array<size_t, 4> loc = {0, 0, 0, 0};
+
+    if (is_format_nchw) {
+      loc[axis] += accumulated_size;
+    } else {
+      if (axis == 0) {
+        loc[0] += accumulated_size;
+      } else if (axis == 1) {
+        loc[3] += accumulated_size;
+      } else if (axis == 2 || axis == 3) {
+        loc[axis - 1] += accumulated_size;
+      }
+    }
+
+    ret.emplace_back(ret_dims[i]);
+    auto &ret_t = ret.back();
+
+    std::array<size_t, 4> end_loc;
+
+    if (is_format_nchw) {
+      end_loc = {ret_dims[i].batch(), ret_dims[i].channel(),
+                 ret_dims[i].height(), ret_dims[i].width()};
+    } else {
+      end_loc = {ret_dims[i].batch(), ret_dims[i].height(), ret_dims[i].width(),
+                 ret_dims[i].channel()};
+    }
+
+    accumulated_size += sizes[i];
+
+    if (is_format_nchw) {
+      end_loc[axis] = accumulated_size;
+    } else {
+      if (axis == 0) {
+        end_loc[0] = accumulated_size;
+      } else if (axis == 1) {
+        end_loc[3] = accumulated_size;
+      } else if (axis == 2 || axis == 3) {
+        end_loc[axis - 1] = accumulated_size;
+      }
+    }
+
+    std::array<size_t, 4> reset_dim_arr;
+    if (is_format_nchw) {
+      reset_dim_arr = {ret_dims[i].batch(), ret_dims[i].channel(),
+                       ret_dims[i].height(), ret_dims[i].width()};
+    } else {
+      reset_dim_arr = {ret_dims[i].batch(), ret_dims[i].height(),
+                       ret_dims[i].width(), ret_dims[i].channel()};
+    }
+
+    ret_t.apply_i([&iter_value, &loc, &end_loc, &reset_dim_arr](float _) {
+      return iter_value(loc, end_loc, reset_dim_arr);
+    });
+  }
+
+  return ret;
+}
+
+FloatTensor FloatTensor::cat(const std::vector<FloatTensor> &tensors,
+                             int axis) {
+
+  if (axis == -1) {
+    axis = 3;
+  }
+
+  NNTR_THROW_IF(!(0 <= axis && axis < 4), std::invalid_argument)
+    << "cannot split axis of axis: " << axis;
+
+  NNTR_THROW_IF(tensors.empty(), std::invalid_argument)
+    << "given tensor vector is empty";
+
+  FloatTensor ret;
+  auto ref_dim = tensors.front().getDim();
+  bool is_format_nchw = (ref_dim.getFormat() == Tformat::NCHW);
+  ref_dim.setTensorDim(axis, 1);
+  NNTR_THROW_IF(!std::all_of(tensors.begin(), tensors.end(),
+                             [&ref_dim, axis](const FloatTensor &t) {
+                               auto cur_dim = t.getDim();
+                               cur_dim.setTensorDim(axis, 1);
+                               return ref_dim == cur_dim;
+                             }),
+                std::invalid_argument)
+    << " all tensor must have the same dimension except for the axis, ref_dim: "
+    << ref_dim << " axis : " << axis;
+
+  auto axis_dim = std::accumulate(tensors.begin(), tensors.end(), 0u,
+                                  [axis](unsigned cur, const FloatTensor &t) {
+                                    return cur += t.getDim().getTensorDim(axis);
+                                  });
+  auto iter_value =
+    [is_format_nchw](std::array<unsigned, 4> &loc,
+                     const std::array<unsigned, 4> &start_loc, FloatTensor &t,
+                     const std::array<unsigned, 4> &ref_dim_arr) -> float & {
+    auto &value = is_format_nchw ? t.getValue(loc[0], loc[1], loc[2], loc[3])
+                                 : t.getValue(loc[0], loc[3], loc[1], loc[2]);
+
+    for (int i = 3; i >= 0; --i) {
+      loc[i]++;
+      if (loc[i] - start_loc[i] == ref_dim_arr[i]) {
+        loc[i] = start_loc[i];
+        continue;
+      }
+      break;
+    }
+    return value;
+  };
+
+  auto ret_dim = ref_dim;
+  ret_dim.setTensorDim(axis, axis_dim);
+
+  ret = FloatTensor(ret_dim);
+
+  std::array<unsigned, 4> loc = {0, 0, 0, 0};
+  for (auto &t : tensors) {
+    std::array<unsigned, 4> start_loc = loc;
+    std::array<unsigned, 4> tensor_dim_arr;
+    if (is_format_nchw) {
+      tensor_dim_arr[0] = t.getDim().getTensorDim(0);
+      tensor_dim_arr[1] = t.getDim().getTensorDim(1);
+      tensor_dim_arr[2] = t.getDim().getTensorDim(2);
+      tensor_dim_arr[3] = t.getDim().getTensorDim(3);
+    } else {
+      tensor_dim_arr[0] = t.getDim().getTensorDim(0);
+      tensor_dim_arr[1] = t.getDim().getTensorDim(2);
+      tensor_dim_arr[2] = t.getDim().getTensorDim(3);
+      tensor_dim_arr[3] = t.getDim().getTensorDim(1);
+    }
+
+    for (size_t i = 0u, sz = t.size(); i < sz; ++i) {
+      iter_value(loc, start_loc, ret, tensor_dim_arr) = t.getValue(i);
+    }
+
+    if (is_format_nchw) {
+      loc[axis] += t.getDim().getTensorDim(axis);
+    } else {
+      if (axis == 0) {
+        loc[0] += t.getDim().getTensorDim(axis);
+      } else if (axis == 1) {
+        loc[3] += t.getDim().getTensorDim(axis);
+      } else if (axis == 2 || axis == 3) {
+        loc[axis - 1] += t.getDim().getTensorDim(axis);
+      }
+    }
+  }
+
+  return ret;
+}
+
+void FloatTensor::makeSharedDataTensor(const FloatTensor &src, size_t offset) {
+  if (strides != src.strides)
+    throw std::invalid_argument(
+      "Creating shared tensor of different stride than source tensor.");
+
+  if (getDim().getDataLen() + offset > src.getDim().getDataLen())
+    throw std::invalid_argument(
+      "Creating shared tensor of different size or stride than source tensor.");
+
+  /**
+   * In this case, its the caller's responsibility to ensure that allocate() is
+   * called for the output tensor before operating on the output tensor.
+   */
+  createSharedDataTensor(src, *this, offset);
+}
+
+void FloatTensor::apply_broadcast(
+  FloatTensor const &m,
+  std::function<void(const BroadcastInfo &e, const float *, const float *,
+                     float *)>
+    v_func,
+  FloatTensor &output) const {
+  CREATE_IF_EMPTY_DIMS_FLOAT(output, dim);
+
+  NNTR_THROW_IF(getData() == nullptr, std::invalid_argument)
+    << getName() << " is not allocated";
+  NNTR_THROW_IF(m.getData() == nullptr, std::invalid_argument)
+    << m.getName() << " is not allocated";
+  NNTR_THROW_IF(output.getData() == nullptr, std::invalid_argument)
+    << output.getName() << " is not allocated";
+
+  /// shortcut to cover when dimension matches
+  /// note that buffer_size, the last stride is only used in v_func but it
+  /// might be changed
+  if (dim == m.dim) {
+    BroadcastInfo e;
+    e.buffer_size = size();
+    e.strides[3] = 1;
+    e.tensor_type = getTensorType();
+    v_func(e, getData(), m.getData(), output.getData());
+    return;
+  }
+
+  return apply_broadcast_util(m, v_func, output, this->computeBroadcastInfo(m));
+}
+
+void FloatTensor::apply_broadcast_util(
+  FloatTensor const &m,
+  std::function<void(const BroadcastInfo &e, const float *, const float *,
+                     float *)>
+    v_func,
+  FloatTensor &output, const BroadcastInfo &e, int cur_axis, size_t offset,
+  size_t m_offset) const {
+
+  const float *buf = this->getData();
+  const float *m_buf = m.getData();
+  float *out_buf = output.getData();
+
+  if (e.buffer_axis == cur_axis) {
+    v_func(e, buf + offset, m_buf + m_offset, out_buf + offset);
+    return;
+  }
+
+  cur_axis++;
+  uint continuity[4] = {0, 1, 2, 3};
+  if (getFormat() == Tformat::NHWC) {
+    continuity[1] = 2;
+    continuity[2] = 3;
+    continuity[3] = 1;
+  }
+  for (unsigned int i = 0; i < dim.getTensorDim(continuity[cur_axis]); ++i) {
+    size_t next_offset = offset + i * strides[cur_axis];
+    size_t next_m_offset = m_offset + i * e.strides[cur_axis];
+    apply_broadcast_util(m, v_func, output, e, cur_axis, next_offset,
+                         next_m_offset);
+  }
+}
+
+/**
+ * This is to sum the FloatTensor data according to the dim.batch().
+ * Therefore the result has M(dim.batch(), 1, 1, 1) dimension.
+ */
+FloatTensor FloatTensor::sum_by_batch() const {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot sum";
+
+  FloatTensor ret(dim.batch(), 1, 1, 1, this->getFormat(), getDataType());
+  size_t feat_len = dim.getFeatureLen();
+  size_t batch = dim.batch();
+
+  const float *data = getData();
+  float *rdata = ret.getData();
+
+  FloatTensor ones(1, 1, 1, feat_len, this->getFormat());
+  ones.setValue(1.0);
+  sgemv(CblasRowMajor, CblasNoTrans, batch, feat_len, 1, data, feat_len,
+        ones.getData(), 1, 0.0, rdata, 1);
+
+  return ret;
+}
+
+/**
+ * @brief Calculate sum according to the axis.
+ */
+FloatTensor FloatTensor::sum(unsigned int axis, float alpha) const {
+  FloatTensor ret("", this->getFormat(), this->getDataType());
+  return sum(axis, ret, alpha, 0);
+}
+
+FloatTensor &FloatTensor::sum(unsigned int axis, FloatTensor &ret, float alpha,
+                              float beta) const {
+
+  const float *data = getData();
+
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot sum";
+
+  if (axis >= 4)
+    throw std::out_of_range("Error: axis is invalid");
+
+  if (dim.getDim()[axis] == 1 and alpha == 1.0 and !beta) {
+    CREATE_IF_EMPTY_DIMS_FLOAT(ret, dim);
+    ret.copy(this->getData());
+    return ret;
+  }
+
+  switch (axis) {
+  case 0: {
+    CREATE_IF_EMPTY_DIMS_FLOAT(ret, 1, dim.channel(), dim.height(), dim.width(),
+                               this->getTensorType());
+    size_t feat_len = dim.getFeatureLen();
+    size_t batch = dim.batch();
+    FloatTensor ones(1, 1, 1, batch, this->getFormat());
+    ones.setValue(alpha);
+    sgemv(CblasRowMajor, CblasTrans, batch, feat_len, 1, data, feat_len,
+          ones.getData(), 1, beta, ret.getData(), 1);
+  } break;
+  case 1: {
+    CREATE_IF_EMPTY_DIMS_FLOAT(ret, dim[0], 1, dim[2], dim[3], getTensorType());
+    if (this->getFormat() == Tformat::NHWC) {
+      unsigned int m = ret.dim.getDataLen();
+      unsigned int n = dim[1];
+      FloatTensor ones(1, 1, 1, n, this->getTensorType());
+      ones.setValue(alpha);
+      sgemv(CblasRowMajor, CblasNoTrans, m, n, 1, data, n, ones.getData(), 1,
+            beta, ret.getData(), 1);
+    } else {
+      unsigned int feat_len = dim[2] * dim[3];
+      unsigned int t_axis = dim[1];
+      FloatTensor ones(1, 1, 1, t_axis, getTensorType());
+      ones.setValue(alpha);
+      float *rdata = ret.getData();
+      for (unsigned int k = 0; k < dim[0]; ++k) {
+        sgemv(CblasRowMajor, CblasTrans, t_axis, feat_len, 1,
+              &data[k * dim.getFeatureLen()], feat_len, ones.getData(), 1, beta,
+              &rdata[k * feat_len], 1);
+      }
+    }
+  } break;
+  case 2: {
+    CREATE_IF_EMPTY_DIMS_FLOAT(ret, dim[0], dim[1], 1, dim[3], getTensorType());
+
+    if (this->getFormat() == Tformat::NHWC) {
+      unsigned int feat_len = dim[1] * dim[3];
+      unsigned int t_axis = dim[2];
+      FloatTensor ones(1, 1, 1, t_axis, this->getTensorType());
+      ones.setValue(alpha);
+      float *rdata = ret.getData();
+      for (unsigned int k = 0; k < dim[0]; ++k) {
+        sgemv(CblasRowMajor, CblasTrans, t_axis, feat_len, 1,
+              &data[k * dim.getFeatureLen()], feat_len, ones.getData(), 1, beta,
+              &rdata[k * feat_len], 1);
+      }
+    } else {
+      unsigned int t_3 = dim[3];
+      unsigned int t_axis = dim[2];
+      FloatTensor ones(1, 1, 1, t_axis, this->getTensorType());
+      ones.setValue(alpha);
+      float *rdata = ret.getData();
+      for (unsigned int k = 0; k < dim[0]; ++k) {
+        for (unsigned int c = 0; c < dim[1]; ++c) {
+          unsigned int idx = k * dim.getFeatureLen() + c * dim[3] * dim[2];
+          unsigned int ridx = k * ret.dim.getFeatureLen() + c * dim[3];
+          sgemv(CblasRowMajor, CblasTrans, t_axis, t_3, 1, &data[idx], t_3,
+                ones.getData(), 1, beta, &rdata[ridx], 1);
+        }
+      }
+    }
+  } break;
+  case 3: {
+    CREATE_IF_EMPTY_DIMS_FLOAT(ret, dim[0], dim[1], dim[2], 1,
+                               this->getTensorType());
+    if (this->getFormat() == Tformat::NHWC) {
+      unsigned int t_3 = dim[1];
+      unsigned int t_axis = dim[3];
+      FloatTensor ones(1, 1, 1, t_axis, this->getTensorType());
+      ones.setValue(alpha);
+      float *rdata = ret.getData();
+      for (unsigned int k = 0; k < dim[0]; ++k) {
+        for (unsigned int c = 0; c < dim[2]; ++c) {
+          unsigned int idx = k * dim.getFeatureLen() + c * dim[3] * dim[1];
+          unsigned int ridx = k * ret.dim.getFeatureLen() + c * dim[1];
+          sgemv(CblasRowMajor, CblasTrans, t_axis, t_3, 1, &data[idx], t_3,
+                ones.getData(), 1, beta, &rdata[ridx], 1);
+        }
+      }
+    } else {
+      unsigned int m = ret.dim.getDataLen();
+      unsigned int n = dim[3];
+      FloatTensor ones(1, 1, 1, n);
+      ones.setValue(alpha);
+      sgemv(CblasRowMajor, CblasNoTrans, m, n, 1, data, n, ones.getData(), 1,
+            beta, ret.getData(), 1);
+    }
+  } break;
+  default:
+    throw std::out_of_range("Error: Dimension cannot exceed 3");
+  }
+  return ret;
+}
+
+FloatTensor FloatTensor::sum(const std::vector<unsigned int> &axes,
+                             float alpha) const {
+  FloatTensor ret("", this->getFormat());
+  return sum(axes, ret, alpha);
+}
+
+void FloatTensor::mergeAxis(unsigned int axis1, unsigned int axis2) {
+  std::vector<unsigned int> continuous_order = {0, 3, 1, 2};
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot merge axis";
+
+  if (axis2 != axis1 + 1)
+    if (!checkContinuous(axis1, axis2))
+      throw std::invalid_argument("axis2 must be axis1 + 1 for merging.");
+
+  dim.setTensorDim(axis2, dim.getTensorDim(axis1) * dim.getTensorDim(axis2));
+  dim.setTensorDim(axis1, 1);
+}
+
+FloatTensor &FloatTensor::sum(const std::vector<unsigned int> &axes,
+                              FloatTensor &output, float alpha) const {
+  if (axes.empty())
+    throw std::invalid_argument("empty axes given");
+
+  if (axes.size() == 1) {
+    this->sum(axes[0], output, alpha);
+  } else {
+    /** club axes together */
+    FloatTensor new_reshaped = *this;
+    std::vector<unsigned int> continuous_order = {0, 3, 1, 2};
+    std::vector<unsigned int> new_axes = {axes[0]};
+
+    for (unsigned int i = 1; i < axes.size(); ++i) {
+      if (checkContinuous(axes[i - 1], axes[i])) {
+        new_reshaped.mergeAxis(axes[i - 1], axes[i]);
+        new_axes.back() = axes[i];
+      } else {
+        new_axes.push_back(axes[i]);
+      }
+    }
+
+    FloatTensor ret = new_reshaped.sum(new_axes[0]);
+    for (unsigned int i = 1; i < new_axes.size() - 1; ++i)
+      ret = ret.sum(axes[i]);
+    ret.sum(new_axes.back(), output, alpha);
+  }
+
+  return output;
+}
+
+FloatTensor &FloatTensor::dotBatched(FloatTensor const &m, FloatTensor &result,
+                                     bool trans, bool trans_m,
+                                     float beta) const {
+  if (!result.isAllocated())
+    throw std::invalid_argument(
+      "Output tensor must be preallocated for dotBatched operation");
+  for (unsigned int b = 0; b < batch(); b++) {
+    /** @todo try using transpose to speedup the operation */
+    const FloatTensor this_b = this->getBatchSlice(b, 1);
+    FloatTensor m_b = m.getBatchSlice(b, 1);
+    FloatTensor result_b = result.getBatchSlice(b, 1);
+
+    this_b.dot(m_b, result_b, trans, trans_m, beta);
+  }
+
+  return result;
+}
+
+FloatTensor FloatTensor::dot(FloatTensor const &m, bool trans,
+                             bool trans_m) const {
+  FloatTensor output("", this->getFormat(), this->getDataType());
+  dot(m, output, trans, trans_m);
+
+  return output;
+}
+/**
+ * @brief compute the derivative of this in the current tensor
+ * @todo will have to see if beta effects this computation
+ */
+FloatTensor &FloatTensor::dot_deriv_wrt_1(FloatTensor const &m,
+                                          FloatTensor const &output_deriv,
+                                          bool trans, bool trans_m,
+                                          float beta) {
+  bool deriv_trans_m = true;
+  bool deriv_trans = false;
+  /** @todo handle all cases of trans and trans_m */
+  if (!trans && trans_m) {
+    deriv_trans_m = false;
+  }
+
+  return output_deriv.dot(m, *this, deriv_trans, deriv_trans_m, beta);
+}
+
+/**
+ * @brief compute the derivative wrt m in the m tensor
+ * @note The caller tensor must be the same tensor as the one which called the
+ * dot() product.
+ */
+FloatTensor &FloatTensor::dot_deriv_wrt_2(FloatTensor &m_deriv,
+                                          FloatTensor const &output_deriv,
+                                          bool trans, bool trans_m,
+                                          float beta) const {
+  bool deriv_trans_m = false;
+  bool deriv_trans = true;
+  /** @todo handle all cases of trans and trans_m */
+
+  if (!trans && trans_m) {
+    output_deriv.dot(*this, m_deriv, deriv_trans, deriv_trans_m, beta);
+    return m_deriv;
+  } else {
+    return dot(output_deriv, m_deriv, deriv_trans, deriv_trans_m, beta);
+  }
+}
+
+FloatTensor &
+FloatTensor::dot_batched_deriv_wrt_1(FloatTensor const &m,
+                                     FloatTensor const &output_deriv,
+                                     bool trans, bool trans_m, float beta) {
+  bool deriv_trans_m = true;
+  bool deriv_trans = false;
+  /** @todo handle all cases of trans and trans_m */
+  if (!trans && trans_m) {
+    deriv_trans_m = false;
+  }
+
+  return output_deriv.dotBatched(m, *this, deriv_trans, deriv_trans_m, beta);
+}
+
+FloatTensor &FloatTensor::dot_batched_deriv_wrt_2(
+  FloatTensor &m_deriv, FloatTensor const &output_deriv, bool trans,
+  bool trans_m, float beta) const {
+  bool deriv_trans_m = false;
+  bool deriv_trans = true;
+  /** @todo handle all cases of trans and trans_m */
+
+  if (!trans && trans_m) {
+    output_deriv.dotBatched(*this, m_deriv, deriv_trans, deriv_trans_m, beta);
+    return m_deriv;
+  } else {
+    return dotBatched(output_deriv, m_deriv, deriv_trans, deriv_trans_m, beta);
+  }
+}
+
+/**
+ * @note: This dot product flattens the fist 3 axis for the purpose of
+ * computation. So, while performing, these matrices are behaving as 2-D
+ * matrices. The dimensions are restored while returning back the tensor
+ * in case of trans is false.
+ */
+FloatTensor &FloatTensor::dot(FloatTensor const &m, FloatTensor &result,
+                              bool trans, bool trans_m, float beta) const {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous. Cannot dot product.";
+
+  // Comment out with intension to support the calculation wrt. batch and
+  // height direction. It supposes to have this->dim as [ BxCxH,W ] and m.dim
+  // is [BxCxH,W] as well if (m.dim.rank() > 2) {
+  //   throw exception::not_supported("Error: support only for rank of dot "
+  //                                  "matrix <= 2");
+  // }
+
+  // Comment out with intension to support the calculation wrt. batch and
+  // height direction of this tensor. It is OK as long as m is 2D
+  //
+  if (trans && dim.rank() > 2) {
+    ml_logw("Warning: support only for rank of dot matrix <= 2 with trans");
+  }
+  unsigned int dim1, dim2, mdim1, mdim2;
+  if (getFormat() == Tformat::NHWC) {
+    dim1 = batch() * height() * width();
+    dim2 = channel();
+    mdim1 = m.batch() * m.height() * m.width();
+    mdim2 = m.channel();
+  } else {
+    dim1 = batch() * channel() * height();
+    dim2 = width();
+    mdim1 = m.batch() * m.channel() * m.height();
+    mdim2 = m.width();
+  }
+
+  unsigned int M, N, K, lda, ldb, ldc;
+
+  if (!trans && !trans_m) {
+    if (dim2 != mdim1)
+      throw std::runtime_error(
+        "Error: incompatible dimensions for dot product");
+    K = mdim1; /** == dim2 */
+    N = mdim2;
+    M = dim1;
+    if (getFormat() == Tformat::NHWC) {
+      CREATE_IF_EMPTY_DIMS_FLOAT(result, batch(), N, height(), width(),
+                                 getTensorType()); //  NHWC Result FloatTensor
+    } else {
+      CREATE_IF_EMPTY_DIMS_FLOAT(result, batch(), channel(), height(), N,
+                                 getTensorType());
+    }
+
+    // We are not set zero the result because of performance reason.
+    // However, result is not initialized properly. There might include
+    // garbage like nan. When we have to use this value as in C = alpha*A*B +
+    // beta*C, then have to check garbage data of C is not effect or not.
+
+  } else if (!trans && trans_m) {
+    if (dim2 != mdim2)
+      throw std::runtime_error(
+        "Error: incompatible dimensions for dot product");
+    K = mdim2; /** == dim2 */
+    N = mdim1;
+    M = dim1;
+    if (getFormat() == Tformat::NHWC) {
+      CREATE_IF_EMPTY_DIMS_FLOAT(result, batch(), N, height(), width(),
+                                 getTensorType());
+    } else {
+      CREATE_IF_EMPTY_DIMS_FLOAT(result, batch(), channel(), height(), N,
+                                 getTensorType());
+    }
+  } else if (trans && !trans_m) {
+    if (dim1 != mdim1)
+      throw std::runtime_error(
+        "Error: incompatible dimensions for dot product");
+    K = mdim1; /** == dim1 */
+    N = mdim2;
+    M = dim2;
+    if (getFormat() == Tformat::NHWC) {
+      CREATE_IF_EMPTY_DIMS_FLOAT(result, 1, N, M, 1, getTensorType());
+    } else {
+      CREATE_IF_EMPTY_DIMS_FLOAT(result, 1, 1, M, N, getTensorType());
+    }
+  } else {
+    if (dim1 != mdim2)
+      throw std::runtime_error(
+        "Error: incompatible dimensions for dot product");
+    K = mdim2; /** == dim1 */
+    N = mdim1;
+    M = dim2;
+    if (getFormat() == Tformat::NHWC) {
+      CREATE_IF_EMPTY_DIMS_FLOAT(result, 1, N, M, 1, getTensorType());
+    } else {
+      CREATE_IF_EMPTY_DIMS_FLOAT(result, 1, 1, M, N, getTensorType());
+    }
+  }
+  lda = dim2;
+  ldb = mdim2;
+  ldc = (getFormat() == Tformat::NHWC) ? result.channel() : result.width();
+
+  const float *data = getData();
+  const float *mdata = m.getData();
+  float *rdata = result.getData();
+  const float alpha = 1.0f;
+  enum CBLAS_TRANSPOSE transA = trans ? CblasTrans : CblasNoTrans;
+  enum CBLAS_TRANSPOSE transB = trans_m ? CblasTrans : CblasNoTrans;
+
+  /// shortcut handling in case of vector
+  /// for vector, (1 * K) == (K * 1) in current memory layout...
+  /// and plaese note that N, K, M is a fixed place holder after considering
+  /// transpose.
+  /// For example, there is no case like (1 * K) X (1 * K) while
+  /// (1 * K) X (1 * M) can be a case
+  /// case1: (1 * K) X (K * 1)
+  if (M == 1 && N == 1) {
+    *rdata = sdot(K, data, 1, mdata, 1) + beta * (*rdata);
+  }
+  /// case2: (M * K) X (K * 1)
+  else if (N == 1) {
+    sgemv(CblasRowMajor, transA, dim1, dim2, alpha, data, lda, mdata, 1, beta,
+          rdata, 1);
+  }
+  /// case3: (1 * K) X (K * N) = 1 * N = R
+  /// = R^T = (K * N) ^T * (1 * K) ^T = (N * K) * (K * 1) = (N * K) * (1 *
+  /// K) Effectively a translation of sgemv
+  else if (M == 1) {
+    transB = transB == CblasTrans ? CblasNoTrans : CblasTrans;
+    sgemv(CblasRowMajor, transB, mdim1, mdim2, alpha, mdata, ldb, data, 1, beta,
+          rdata, 1);
+  }
+  /// case others: use gemm
+  else {
+    sgemm(CblasRowMajor, transA, transB, M, N, K, alpha, data, lda, mdata, ldb,
+          beta, rdata, ldc);
+  }
+
+  return result;
+}
+
+FloatTensor &FloatTensor::transpose(const std::string &direction,
+                                    FloatTensor &out) const {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous. Cannot transpose.";
+
+  if (out.getData() == getData()) {
+    FloatTensor tmp = clone();
+    return tmp.transpose(direction, out);
+  }
+
+  unsigned int SL, SI, SJ, SK;
+
+  out.reshape(dim.transpose(direction));
+
+  int indexI = direction[0] - '0';
+  int indexJ = direction[2] - '0';
+
+  SL = dim.batch(), SI = dim.channel(), SJ = dim.height(), SK = dim.width();
+
+  bool is_format_nchw = (getFormat() == Tformat::NCHW);
+
+  const float *inptr = getData();
+  float *outptr = out.getData();
+  switch (indexI) {
+  case 0:
+    if (indexJ == 1) {
+      if (is_format_nchw) {
+        transposeloop(l, i, j, k, SL, SI, SJ, SK);
+      } else {
+        transposeloop_nhwc(l, j, k, i, SL, SJ, SK, SI);
+      }
+    } else {
+      if (is_format_nchw) {
+        transposeloop(l, i, k, j, SL, SI, SK, SJ);
+      } else {
+        transposeloop_nhwc(l, k, j, i, SL, SK, SJ, SI);
+      }
+    }
+    break;
+  case 1:
+    if (indexJ == 0) {
+      if (is_format_nchw) {
+        transposeloop(l, j, i, k, SL, SJ, SI, SK);
+      } else {
+        transposeloop_nhwc(l, i, k, j, SL, SI, SK, SJ);
+      }
+    } else {
+      if (is_format_nchw) {
+        transposeloop(l, j, k, i, SL, SJ, SK, SI);
+      } else {
+        transposeloop_nhwc(l, k, i, j, SL, SK, SI, SJ);
+      }
+    }
+    break;
+  case 2:
+    if (indexJ == 0) {
+      if (is_format_nchw) {
+        transposeloop(l, k, i, j, SL, SK, SI, SJ);
+      } else {
+        transposeloop_nhwc(l, i, j, k, SL, SI, SJ, SK);
+      }
+    } else {
+      if (is_format_nchw) {
+        transposeloop(l, k, j, i, SL, SK, SJ, SI);
+      } else {
+        transposeloop_nhwc(l, j, i, k, SL, SJ, SI, SK);
+      }
+    }
+    break;
+  }
+
+  return out;
+}
+
+FloatTensor FloatTensor::transpose(const std::string &direction) const {
+  FloatTensor result(dim);
+  transpose(direction, result);
+  return result;
+}
+
+FloatTensor FloatTensor::dropout_mask(float dropout) const {
+  FloatTensor result(dim);
+  result.dropout_mask(dropout);
+  return result;
+}
+
+void FloatTensor::dropout_mask(float dropout) {
+  setRandUniform(0.0, 1.0);
+  float scale = 1.0 / (1 - dropout);
+  float *data_ = getData();
+  for (unsigned int i = 0; i < size(); ++i) {
+    if (data_[i] >= dropout)
+      data_[i] = scale;
+    else
+      data_[i] = 0.0;
+  }
+}
+
+void FloatTensor::filter_mask(const FloatTensor &mask_len, bool reverse) {
+  float fill_mask_val = 0.0;
+  float en_mask_val = 1.0 - fill_mask_val;
+
+  if (reverse) {
+    fill_mask_val = 1.0;
+    en_mask_val = 1.0 - fill_mask_val;
+  }
+
+  setValue(fill_mask_val);
+  if (mask_len.batch() != batch())
+    throw std::invalid_argument("Number of filter masks mismatched");
+  for (unsigned int b = 0; b < batch(); b++) {
+    float *addr = getAddress(b, 0, 0, 0);
+    const uint *mask_len_val = (uint *)mask_len.getAddress(b, 0, 0, 0);
+    std::fill(addr, addr + (*mask_len_val), en_mask_val);
+  }
+}
+
+FloatTensor FloatTensor::zoneout_mask(float zoneout) {
+  FloatTensor ret(getDim());
+  zoneout_mask(ret, zoneout);
+  return ret;
+}
+
+void FloatTensor::zoneout_mask(FloatTensor &opposite, float zoneout) {
+  if (dim != opposite.dim) {
+    throw std::invalid_argument(
+      "[FloatTensor::zoneout_mask] opposite dimension does not match");
+  }
+
+  opposite.setRandBernoulli(zoneout);
+
+  float *data = getData();
+  float *opposite_data = opposite.getData();
+
+  for (unsigned int i = 0; i < size(); ++i) {
+    if (opposite_data[i] > epsilon) {
+      data[i] = 0.0f;
+    } else {
+      data[i] = 1.0f;
+    }
+  }
+}
+
+FloatTensor
+FloatTensor::apply(std::function<FloatTensor(FloatTensor)> f) const {
+  return f(*this);
+}
+
+FloatTensor &
+FloatTensor::apply(std::function<FloatTensor &(FloatTensor, FloatTensor &)> f,
+                   FloatTensor &output) const {
+  return f(*this, output);
+}
+
+void FloatTensor::print(std::ostream &out) const {
+  printInstance(out, this);
+  const float *data = getData();
+  unsigned int len = size();
+  out << "data addr: " << data << '\n';
+  out << dim;
+
+  if (len > 100) {
+    out << '[' << data[0] << ' ' << data[1] << ' ' << data[2] << " ... "
+        << data[len - 3] << ' ' << data[len - 2] << ' ' << data[len - 1] << ']'
+        << std::endl;
+    return;
+  }
+
+  std::ios init(NULL);
+  init.copyfmt(out);
+  float max_ = 0.0;
+  float min_ = 10000000;
+  if (getFormat() == Tformat::NCHW) {
+    for (unsigned int k = 0; k < batch(); k++) {
+      for (unsigned int l = 0; l < channel(); l++) {
+        for (unsigned int i = 0; i < height(); i++) {
+          for (unsigned int j = 0; j < width(); j++) {
+            out << std::setw(10) << std::setprecision(10)
+                << this->getValue(k, l, i, j) << " ";
+          }
+          out << std::endl;
+        }
+        out << std::endl;
+      }
+      out << "-------" << std::endl;
+    }
+  } else {
+    for (unsigned int k = 0; k < batch(); k++) {
+      for (unsigned int i = 0; i < height(); i++) {
+        for (unsigned int j = 0; j < width(); j++) {
+          for (unsigned int l = 0; l < channel(); l++) {
+            out << std::setw(10) << std::setprecision(10)
+                << this->getValue(k, l, i, j) << " ";
+          }
+          out << std::endl;
+        }
+        out << std::endl;
+      }
+      out << "-------" << std::endl;
+    }
+  }
+  out.copyfmt(init);
+}
+
+void FloatTensor::print_(std::ostream &out, uint opt) const {
+  printInstance(out, this);
+
+  unsigned int len = size();
+
+  std::ios init(NULL);
+  init.copyfmt(out);
+  if (opt == 0) {
+    if (getFormat() == Tformat::NCHW) {
+      out << "{";
+      for (unsigned int k = 0; k < batch(); k++) {
+        out << "{";
+        for (unsigned int i = 0; i < channel(); i++) {
+          out << "{";
+          for (unsigned int j = 0; j < height(); j++) {
+            out << "{";
+            for (unsigned int l = 0; l < width(); l++) {
+              if (l < width() - 1)
+                out << std::setw(10) << std::setprecision(10)
+                    << this->getValue(k, l, i, j) << ", ";
+              else
+                out << std::setw(10) << std::setprecision(10)
+                    << this->getValue(k, l, i, j);
+            }
+            if (j < height() - 1)
+              out << "},";
+            else
+              out << "}";
+            out << std::endl;
+          }
+          if (i < channel() - 1)
+            out << "},";
+          else
+            out << "}";
+          out << std::endl;
+        }
+        if (k < batch() - 1)
+          out << "},";
+        else
+          out << "}";
+        out << std::endl;
+      }
+      out << "}";
+    } else {
+      out << "{";
+      for (unsigned int k = 0; k < batch(); k++) {
+        out << "{";
+        for (unsigned int i = 0; i < height(); i++) {
+          out << "{";
+          for (unsigned int j = 0; j < width(); j++) {
+            out << "{";
+            for (unsigned int l = 0; l < channel(); l++) {
+              if (l < channel() - 1)
+                out << std::setw(10) << std::setprecision(10)
+                    << this->getValue(k, l, i, j) << ", ";
+              else
+                out << std::setw(10) << std::setprecision(10)
+                    << this->getValue(k, l, i, j);
+            }
+            if (j < width() - 1)
+              out << "},";
+            else
+              out << "}";
+            out << std::endl;
+          }
+          if (i < height() - 1)
+            out << "},";
+          else
+            out << "}";
+          out << std::endl;
+        }
+        if (k < batch() - 1)
+          out << "},";
+        else
+          out << "}";
+        out << std::endl;
+      }
+      out << "}";
+    }
+  } else {
+    for (uint i = 0; i < len; ++i) {
+      out << getData()[i] << ", ";
+    }
+  }
+  out.copyfmt(init);
+}
+
+std::ostream &operator<<(std::ostream &out, FloatTensor const &m) {
+  m.print(out);
+  return out;
+}
+
+void FloatTensor::copy(const void *buf) {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << "FloatTensor is not contiguous, cannot copy.";
+
+  if (buf == getData()) {
+    return;
+  }
+
+  scopy(size(), (float *)buf, 1, getData(), 1);
+}
+
+void FloatTensor::copy_with_stride(const FloatTensor &from) {
+  if (dim == from.getDim()) {
+    for (unsigned int b = 0; b < batch(); ++b) {
+      for (unsigned int c = 0; c < channel(); ++c) {
+        for (unsigned int h = 0; h < height(); ++h) {
+          for (unsigned int w = 0; w < width(); ++w) {
+            setValue(b, c, h, w, from.getValue(b, c, h, w));
+          }
+        }
+      }
+    }
+  } else {
+    FloatTensor t = FloatTensor(from.getDim(), true);
+    for (unsigned int b = 0; b < t.batch(); ++b) {
+      for (unsigned int c = 0; c < t.channel(); ++c) {
+        for (unsigned int h = 0; h < t.height(); ++h) {
+          for (unsigned int w = 0; w < t.width(); ++w) {
+            t.setValue(b, c, h, w, from.getValue(b, c, h, w));
+          }
+        }
+      }
+    }
+
+    swap(t, *this);
+  }
+}
+
+void FloatTensor::copy(const FloatTensor &from) {
+  // todo: enable copy to non-contiguous tensor
+  if (!contiguous) {
+    throw std::runtime_error("Cannot copy non-contiguous tensor");
+  }
+
+  if (from.size() != 0 && size() == from.size() &&
+      getDataType() == from.getDataType()) {
+    reshape(from.getDim());
+    copy(from.getData());
+  } else {
+    FloatTensor t = FloatTensor(from.getDim(), from.getData());
+    swap(t, *this);
+  }
+}
+
+void FloatTensor::copyData(const FloatTensor &from) {
+  // todo: enable copy to non-contiguous tensor
+  if (!contiguous) {
+    throw std::runtime_error("Cannot copy non-contiguous tensor");
+  }
+
+  if (size() != from.size())
+    throw std::invalid_argument("Size of tensor to copy must match");
+
+  copy(from.getData());
+}
+
+FloatTensor FloatTensor::clone() const {
+  FloatTensor t;
+  t.copy(*this);
+  t.name = name;
+  return t;
+}
+
+void FloatTensor::reshape(const TensorDim &d) {
+
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot reshape.";
+
+  NNTR_THROW_IF(d.getDataLen() != dim.getDataLen(), std::invalid_argument)
+    << "[FloatTensor]: reshape cannot change the buffer size, trying "
+       "reshaping "
+       "\nfrom "
+    << getDim() << " to " << d;
+
+  // dim = d;
+  dim.batch(d.batch());
+  dim.channel(d.channel());
+  dim.height(d.height());
+  dim.width(d.width());
+
+  strides = d.computeStrides();
+}
+
+void FloatTensor::fill(const FloatTensor &from, bool alloc) {
+  if (alloc && this->empty()) {
+    this->copy(from);
+    return;
+  }
+
+  if (!from.contiguous || !contiguous) {
+    /// @todo enable this if needed
+    throw nntrainer::exception::not_supported(
+      "[FloatTensor::fill] non-contiguous tensors are not supported");
+  }
+
+  if (dim != from.getDim()) {
+    throw std::invalid_argument(
+      "[FloatTensor::fill] dimension must be the same");
+  }
+
+  if (strides != from.getStrides()) {
+    /// @todo length does not represent buffer size, there should be way to
+    /// get the buffer size
+    throw std::invalid_argument(
+      "[FloatTensor::fill] buffer size must be the same");
+  }
+
+  this->copy(from.getData());
+}
+
+void FloatTensor::save(std::ostream &file) {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot save.";
+
+  std::streamsize sz = static_cast<std::streamsize>(bytes());
+  NNTR_THROW_IF(sz < 0, std::invalid_argument)
+    << "save size: " << bytes()
+    << " is too big. It cannot be represented by std::streamsize";
+
+  checkedWrite(file, (char *)getData(), sz,
+               "[FloatTensor::save] operation failed");
+
+  putData();
+}
+
+void FloatTensor::read(std::ifstream &file, Tdatatype s_type) {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot read.";
+
+  std::streamsize sz = static_cast<std::streamsize>(bytes());
+
+  NNTR_THROW_IF(sz < 0, std::invalid_argument)
+    << "read size: " << bytes()
+    << " is too big. It cannot be represented by std::streamsize";
+
+  checkedRead(file, (char *)getData(), sz,
+              "[FloatTensor::read] operation failed");
+  putData();
+}
+
+/**
+ * @brief Calculate average value according to the axis.
+ */
+FloatTensor FloatTensor::average(unsigned int axis) const {
+  FloatTensor t("", this->getFormat(), this->getDataType());
+  return average(axis, t);
+}
+
+/**
+ * @brief Calculate average value according to the axis.
+ */
+FloatTensor &FloatTensor::average(unsigned int axis,
+                                  FloatTensor &output) const {
+  if (axis >= TensorDim::MAXDIM)
+    throw std::out_of_range(
+      "negative axis or axis more then MAXDIM is invalid");
+
+  unsigned int axis_size = dim.getDim()[axis];
+  if (axis_size == 1)
+    output.copy(*this);
+  else
+    this->sum(axis, output, 1.0 / ((float)axis_size));
+
+  return output;
+}
+
+FloatTensor FloatTensor::average(const std::vector<unsigned int> &axes) const {
+  FloatTensor t("", this->getFormat(), this->getDataType());
+  return average(axes, t);
+}
+
+FloatTensor &FloatTensor::average(const std::vector<unsigned int> &axes,
+                                  FloatTensor &output) const {
+  if (axes.empty())
+    return this->average(output);
+
+  TensorDim ret_shape(getTensorType());
+
+  for (const auto &idx : axes) {
+    if (idx >= TensorDim::MAXDIM) {
+      throw std::out_of_range("axis more then MAXDIM is invalid");
+    }
+    ret_shape.setTensorDim(idx, dim.getTensorDim(idx));
+  }
+
+  return this->sum(axes, output, 1.0 / (float)ret_shape.getDataLen());
+}
+
+/**
+ * @brief Calculate average value according to the axis.
+ */
+FloatTensor FloatTensor::average() const {
+  FloatTensor result = *this;
+  unsigned int axis = 0;
+  if (this->getFormat() == Tformat::NHWC) {
+    result.reshape({1, dim.getDataLen(), 1, 1, this->getTensorType()});
+    axis = 1;
+  } else {
+    result.reshape({1, 1, 1, dim.getDataLen(), this->getTensorType()});
+    axis = 3;
+  }
+  return result.average(axis);
+}
+
+/**
+ * @brief Calculate average value according to the axis.
+ */
+FloatTensor &FloatTensor::average(FloatTensor &output) const {
+  FloatTensor result = *this;
+  result.reshape({1, 1, 1, dim.getDataLen()});
+  return result.average(3, output);
+}
+
+void FloatTensor::setValue(float val) {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot set value.";
+  float *data = getData();
+  std::fill(data, data + size(), val);
+}
+
+void FloatTensor::setZero() {
+  if (contiguous)
+    sscal(size(), 0, getData(), 1);
+  else
+    apply([](float val) -> float { return 0; });
+}
+
+std::vector<unsigned int> FloatTensor::argmax() const {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot get argmax.";
+  std::vector<unsigned int> result;
+
+  const float *data = getData();
+  size_t batch_size = batch();
+  size_t feature_len = dim.getFeatureLen();
+
+  result.resize(batch_size);
+
+  for (unsigned int b = 0; b < batch_size; b++) {
+    auto max_iter =
+      std::max_element(data + b * feature_len, data + (b + 1) * feature_len);
+    result[b] = std::distance(data, max_iter) - (b * feature_len);
+  }
+
+  return result;
+}
+
+int FloatTensor::erf_i() {
+  erf(*this);
+  return ML_ERROR_NONE;
+}
+
+FloatTensor FloatTensor::erf() const {
+  FloatTensor t;
+  return erf(t);
+}
+
+FloatTensor &FloatTensor::erf(FloatTensor &out) const {
+  auto f = [](float in) { return std::erf(in); };
+  apply(f, out);
+  return out;
+}
+
+float FloatTensor::l2norm() const {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot get l2norm.";
+  float ret = 0;
+  unsigned int len = size();
+  const float *data = getData();
+  ret = snrm2(len, data, 1);
+  return ret;
+}
+
+float FloatTensor::max_abs() const {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot get max_abs.";
+
+  unsigned int len = size();
+  float ret = 0;
+  const float *data = getData();
+
+  unsigned int idx = isamax(len, data, 1);
+  ret = *(data + idx);
+
+  return ret;
+}
+
+FloatTensor &FloatTensor::normalization(FloatTensor &output) const {
+  if (output.empty())
+    output = FloatTensor(dim);
+
+  output.copy(*this);
+  output.normalization_i();
+
+  return output;
+}
+
+void FloatTensor::normalization_i() {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot do normalization.";
+
+  const float *data = getData();
+
+  auto bounds = std::minmax_element(data, data + size());
+  const float min = *bounds.first;
+  const float max = *bounds.second;
+
+  if (max == min) {
+    FloatTensor tmp = *this;
+    this->subtract_i(tmp);
+  } else {
+    this->subtract_i(min);
+    this->divide_i(max - min);
+  }
+}
+
+// @todo: uncomment when type erasure is enabled
+// LazyTensor FloatTensor::chain() const { return LazyTensor(*this); }
+
+FloatTensor &FloatTensor::standardization(FloatTensor &output) const {
+  if (output.empty())
+    output = FloatTensor(dim);
+
+  output.copy(*this);
+  output.standardization_i();
+
+  return output;
+}
+
+void FloatTensor::standardization_i() {
+  FloatTensor mean_by_batch = this->sum_by_batch();
+  mean_by_batch.divide_i(dim.getFeatureLen());
+
+  this->subtract_i(mean_by_batch);
+
+  FloatTensor std_dev_by_batch(dim.batch(), 1, 1, 1, dim.getFormat(),
+                               dim.getDataType());
+  std_dev_by_batch.setZero();
+  float *std_dev = std_dev_by_batch.getData();
+
+  for (unsigned int k = 0; k < dim.batch(); ++k) {
+    FloatTensor sub_this = this->getBatchSlice(k, 1);
+    std_dev[k] = sub_this.l2norm();
+  }
+
+  std_dev_by_batch.divide_i(dim.getFeatureLen());
+  this->divide_i(std_dev_by_batch);
+}
+
+FloatTensor::BroadcastInfo
+FloatTensor::computeBroadcastInfo(const FloatTensor &m) const {
+  if (m.size() > this->size())
+    throw exception::not_supported("broadcasting *this is not supported");
+
+  const TensorDim m_dim = m.getDim();
+
+  BroadcastInfo e;
+  e.tensor_type = getTensorType();
+
+  uint continuity[4] = {0, 1, 2, 3};
+  if (getFormat() == Tformat::NHWC) {
+    continuity[1] = 2;
+    continuity[2] = 3;
+    continuity[3] = 1;
+  }
+
+  /// checking if given FloatTensor's can be broadcasted
+  for (unsigned int i = 0; i < TensorDim::MAXDIM; ++i) {
+    if (dim.getTensorDim(continuity[i]) == m_dim.getTensorDim(continuity[i])) {
+      e.strides[i] = m.strides[i];
+      continue;
+    }
+
+    /// If given dimension is 1, it could be reused, the stride remaining 0
+    /// Need to check if dim[i] == 1 && m_dim[i] == 1 first though
+    /// If so, strides should not change
+    if (m_dim.getTensorDim(continuity[i]) == 1) {
+      continue;
+    }
+
+    std::stringstream ss;
+    ss << "[computeBroadcastInfo] broadcasting only allowed for "
+          "dimension value of 1 \n"
+       << "this: " << dim << "target: " << m_dim;
+    throw std::invalid_argument(ss.str().c_str());
+  }
+
+  /// calculate inner loop size
+  e.buffer_size = 1;
+  e.buffer_axis = -1;
+  e.strides[3] = m.strides[3];
+
+  /// initiate buffer info with matching dimension strategy
+  for (int axis = 3; axis >= 0; --axis) {
+    if (dim.getTensorDim(continuity[axis]) !=
+        m_dim.getTensorDim(continuity[axis])) {
+      e.buffer_axis = axis;
+      break;
+    }
+
+    e.buffer_size *= dim.getTensorDim(continuity[axis]);
+  }
+
+  /// check strategy that uses consecutive ones
+  if (m_dim.getTensorDim(continuity[3]) == 1) {
+    unsigned int inner_loop_size = 1;
+    int axis;
+    for (axis = 3; axis >= 0; --axis) {
+      if (m_dim.getTensorDim(continuity[axis]) != 1) {
+        break;
+      }
+
+      inner_loop_size *= dim.getTensorDim(continuity[axis]);
+    }
+
+    /// if consecutive-one strategy has bigger chunk size, replace the
+    /// information
+    if (inner_loop_size > e.buffer_size) {
+      e.buffer_axis = axis;
+      e.buffer_size = inner_loop_size;
+      e.strides[3] = 0;
+    }
+  }
+
+  return e;
+}
+
+FloatTensor FloatTensor::rotate_180(FloatTensor in) {
+  FloatTensor output(in.getDim());
+
+  output.setZero();
+  for (unsigned int i = 0; i < in.batch(); ++i) {
+    for (unsigned int j = 0; j < in.channel(); ++j) {
+      for (unsigned int k = 0; k < in.height(); ++k) {
+        for (unsigned int l = 0; l < in.width(); ++l) {
+          output.setValue(
+            i, j, k, l,
+            in.getValue(i, j, (in.height() - k - 1), (in.width() - l - 1)));
+        }
+      }
+    }
+  }
+
+  return output;
+}
+
+} /* namespace nntrainer */

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -1,0 +1,1820 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2023 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file	float_tensor.h
+ * @date	09 November 2023
+ * @brief	This is FloatTensor class for 32-bit floating point calculation
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Donghyeon Jeong <dhyeon.jeong@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#ifndef __FLOAT_TENSOR_H__
+#define __FLOAT_TENSOR_H__
+#ifdef __cplusplus
+
+#include <array>
+#include <functional>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <vector>
+
+#include <blas_interface.h>
+#include <memory_data.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <tensor_dim.h>
+#include <util_func.h>
+
+#ifdef DEBUG
+#define EXCEPT_WHEN_DEBUG
+#else
+#define EXCEPT_WHEN_DEBUG noexcept
+#endif
+
+#define MAKE_SHARED_FLOAT_TENSOR(...) \
+  std::make_shared<nntrainer::FloatTensor>(__VA_ARGS__)
+
+#define CREATE_IF_EMPTY_DIMS_FLOAT(tensor, ...) \
+  do {                                          \
+    if (tensor.empty())                         \
+      tensor = FloatTensor(__VA_ARGS__);        \
+  } while (0);
+
+namespace nntrainer {
+
+using TensorDim = ml::train::TensorDim;
+using Tformat = ml::train::TensorDim::Format;
+using Tdatatype = ml::train::TensorDim::DataType;
+
+class LazyTensor;
+class SrcSharedFloatTensor;
+
+/**
+ * @class   FloatTensor Class for Calculation
+ * @brief   FloatTensor Class for Calculation
+ */
+class FloatTensor {
+public:
+  /**
+   * @brief     Enumeration of Weight Initialization Type
+   * @todo      support intialization from file
+   * @note      Remove this enum class
+   */
+  enum class Initializer {
+    ZEROS,          /** Zero initialization */
+    ONES,           /** One initialization */
+    LECUN_NORMAL,   /** LeCun normal initialization */
+    LECUN_UNIFORM,  /** uniform initialization */
+    XAVIER_NORMAL,  /** Xavier normal initialization */
+    XAVIER_UNIFORM, /** Xavier uniform initialization */
+    HE_NORMAL,      /** He normal initialization */
+    HE_UNIFORM,     /** He uniform initialization */
+    NONE            /** No initialization */
+  };
+
+  /**
+   * @brief     Basic Constructor of FloatTensor
+   */
+  FloatTensor(std::string name_ = "", Tformat fm = Tformat::NCHW,
+              Tdatatype d_type = Tdatatype::FP32) :
+    dim(TensorDim(fm, d_type)),
+    strides(dim.computeStrides()),
+    contiguous(true),
+    initializer(Initializer::NONE),
+    name(name_),
+    data(nullptr),
+    offset(0),
+    src_tensor() {}
+
+  /**
+   * @brief     Constructor of FloatTensor with dimension, possibly lazily
+   * @param d FloatTensor dim for this tensor
+   * @param alloc_now If the memory of the tensor must be allocated
+   * @param init Initializer for the tensor
+   * @param name Name of the tensor
+   */
+  FloatTensor(const TensorDim &d, bool alloc_now,
+              Initializer init = Initializer::NONE, std::string name = "");
+
+  /**
+   * @brief     Constructor of FloatTensor with dimension/buf
+   * @param d FloatTensor dim for this tensor
+   * @param buf buffer
+   * @note Memory for this tensor is instantaneously allocated
+   */
+  FloatTensor(const TensorDim &d, const void *buf = nullptr);
+
+  /**
+   * @brief     Constructor of FloatTensor
+   * @param[in] d0 Batch of FloatTensor
+   * @param[in] d1 Channel
+   * @param[in] d2 Height
+   * @param[in] d3 Width
+   */
+  FloatTensor(size_t d0, size_t d1, size_t d2, size_t d3,
+              Tformat fm = Tformat::NCHW, Tdatatype d_type = Tdatatype::FP32) :
+    FloatTensor(TensorDim(d0, d1, d2, d3, fm, d_type), nullptr){};
+
+  /**
+   * @brief     Constructor of FloatTensor
+   * @param[in] d1 Channel
+   * @param[in] d2 Height
+   * @param[in] d3 Width
+   */
+  FloatTensor(size_t d1, size_t d2, size_t d3, Tformat fm = Tformat::NCHW,
+              Tdatatype d_type = Tdatatype::FP32) :
+    FloatTensor(1, d1, d2, d3, fm, d_type){};
+
+  /**
+   * @brief     Constructor of FloatTensor with batch size one and d1 size one
+   * @param[in] d2 Height (NCHW) or Width (NHWC)
+   * @param[in] d3 Width (NCHW) or Channel (NHWC)
+   */
+  FloatTensor(size_t d2, size_t d3, Tformat fm = Tformat::NCHW,
+              Tdatatype d_type = Tdatatype::FP32) :
+    FloatTensor(1, 1, d2, d3, fm, d_type){};
+
+  /**
+   * @brief     Constructor of FloatTensor with just Width or Channel
+   * @param[in] d3 Width (NCHW) or Channel (NHWC)
+   */
+  explicit FloatTensor(size_t d3, Tformat fm = Tformat::NCHW,
+                       Tdatatype d_type = Tdatatype::FP32) :
+    FloatTensor(1, 1, 1, d3, fm, d_type){};
+
+  /**
+   * @brief     Constructor of FloatTensor
+   * @param[in] d0 Batch of FloatTensor
+   * @param[in] d1 Channel (NCHW) or Height (NHWC)
+   * @param[in] d2 Height (NCHW) or Width (NHWC)
+   * @param[in] d3 Width (NCHW) or Channel (NHWC)
+   */
+  FloatTensor(size_t d0, size_t d1, size_t d2, size_t d3,
+              ml::train::TensorDim::TensorType t_type) :
+    FloatTensor(TensorDim(d0, d1, d2, d3, t_type), nullptr){};
+
+  /**
+   * @brief     Constructor of FloatTensor
+   * @param[in] d1 Channel
+   * @param[in] d2 Height
+   * @param[in] d3 Width
+   */
+  FloatTensor(size_t d1, size_t d2, size_t d3,
+              ml::train::TensorDim::TensorType t_type) :
+    FloatTensor(1, d1, d2, d3, t_type){};
+
+  /**
+   * @brief     Constructor of FloatTensor with batch size one and d1 size one
+   * @param[in] d2 Height (NCHW) or Width (NHWC)
+   * @param[in] d3 Width (NCHW) or Channel (NHWC)
+   */
+  FloatTensor(size_t d2, size_t d3, ml::train::TensorDim::TensorType t_type) :
+    FloatTensor(1, (t_type.format == Tformat::NCHW) ? 1 : d3,
+                (t_type.format == Tformat::NCHW) ? d2 : 1,
+                (t_type.format == Tformat::NCHW) ? d3 : d2, t_type){};
+  /**
+   * @brief     Constructor of FloatTensor with just Width or Channel
+   * @param[in] d3 Width (NCHW) or Channel (NHWC)
+   */
+  explicit FloatTensor(size_t d3, ml::train::TensorDim::TensorType t_type) :
+    FloatTensor(1, (t_type.format == Tformat::NCHW) ? 1 : d3, 1,
+                (t_type.format == Tformat::NCHW) ? d3 : 1, t_type){};
+
+  /**
+   * @brief     Constructor of FloatTensor
+   * @param[in] d data for the FloatTensor. It needs to set format properly.
+   */
+
+  FloatTensor(
+    std::vector<std::vector<std::vector<std::vector<float>>>> const &d,
+    ml::train::TensorDim::TensorType t_type) {
+    if (d.empty() || d[0].empty() || d[0][0].empty() || d[0][0][0].empty()) {
+      throw std::out_of_range(
+        "[FloatTensor] trying to initialize FloatTensor from empty vector");
+    }
+    // if fm == Tformat::NCHW, then dim[0] == batch , dim[1] == channel, dim[2]
+    // == height, dim[3] == width. and if fm == Tformat::NHWC, dim[0] == batch,
+    // dim[1] == height, dim[2] == width, dim[3] == channel
+    dim.setTensorDim(0, d.size());
+    if (t_type.format == Tformat::NCHW) {
+      dim.setTensorDim(1, d[0].size());
+      dim.setTensorDim(2, d[0][0].size());
+      dim.setTensorDim(3, d[0][0][0].size());
+    } else {
+      dim.setTensorDim(2, d[0].size());
+      dim.setTensorDim(3, d[0][0].size());
+      dim.setTensorDim(1, d[0][0][0].size());
+    }
+
+    setTensorType(t_type);
+
+    strides = dim.computeStrides();
+
+    MemoryData *mem_data =
+      new MemoryData((void *)(new float[dim.getDataLen()]()));
+    data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
+      delete[] mem_data->getAddr<float>();
+    });
+    offset = 0;
+    contiguous = true;
+    initializer = Initializer::NONE;
+    // if fm == Tformat::NCHW, then dim[0] == batch , dim[1] == channel, dim[2]
+    // == height, dim[3] == width. and if fm == Tformat::NHWC, dim[0] == batch,
+    // dim[1] == height, dim[2] == width, dim[3] == channel
+    if (t_type.format == Tformat::NCHW) {
+      for (unsigned int i = 0; i < batch(); ++i)
+        for (unsigned int j = 0; j < channel(); ++j)
+          for (unsigned int k = 0; k < height(); ++k)
+            for (unsigned int l = 0; l < width(); ++l)
+              this->setValue(i, j, k, l, d[i][j][k][l]);
+    } else {
+      for (unsigned int i = 0; i < batch(); ++i)
+        for (unsigned int j = 0; j < height(); ++j)
+          for (unsigned int k = 0; k < width(); ++k)
+            for (unsigned int l = 0; l < channel(); ++l)
+              this->setValue(i, l, j, k, d[i][j][k][l]);
+    }
+  };
+
+  /**
+   * @brief     Constructor of FloatTensor
+   * @note      This constructor copies vector again. needs refactoring
+   * @param[in] d data for the FloatTensor. It needs to set format properly.
+   */
+  FloatTensor(std::vector<std::vector<std::vector<float>>> const &d,
+              ml::train::TensorDim::TensorType t_type) :
+    FloatTensor(std::vector<std::decay<decltype(d)>::type>{d}, t_type){};
+
+  /**
+   * @brief     Constructor of FloatTensor
+   * @note      This constructor copies vector again. needs refactoring
+   * @param[in] d data for the FloatTensor with batch size one
+   */
+  FloatTensor(std::vector<std::vector<float>> const &d,
+              ml::train::TensorDim::TensorType t_type) :
+    FloatTensor(std::vector<std::decay<decltype(d)>::type>{d}, t_type){};
+
+  /**
+   *  @brief  Copy constructor of FloatTensor.
+   *  @param[in] FloatTensor &
+   */
+  FloatTensor(const FloatTensor &rhs) = default;
+
+  /**
+   *  @brief  Move constructor of FloatTensor.
+   *  @param[in] FloatTensor &&
+   */
+  FloatTensor(FloatTensor &&rhs) noexcept = default;
+
+  /**
+   * @brief  Copy assignment operator.
+   * @param[in] rhs FloatTensor to be copied.
+   */
+  FloatTensor &operator=(const FloatTensor &rhs) = default;
+
+  /**
+   * @brief  Move assignment operator.
+   * @parma[in] rhs FloatTensor to be moved.
+   */
+  FloatTensor &operator=(FloatTensor &&rhs) noexcept = default;
+
+  /**
+   * @brief Construct a new FloatTensor object from a buffer
+   * This will not copy buffer to a new tensor but directly uses it
+   *
+   * @param buf buffer
+   * @param bytes buffer size in bytes
+   * @param d tensor dim
+   * @param offset offset to be used from current
+   * @return FloatTensor object
+   * @throws std::invalid_argument if buf is null
+   */
+  static FloatTensor Map(float *buf, unsigned int bytes, const TensorDim &d,
+                         size_t offset = 0) {
+    if (d.getDataLen() == 0 || buf == nullptr) {
+      throw std::invalid_argument(
+        "[FloatTensor::Map] empty tensor dim is not allowed");
+    }
+
+    if (d.getDataLen() * sizeof(float) + offset > bytes) {
+      throw std::invalid_argument(
+        "Creating shared tensor of size bigger than tensor memory.");
+    }
+
+    FloatTensor tmp;
+    tmp.dim = d;
+    tmp.strides = d.computeStrides();
+    /// FloatTensor does not own the memory
+    tmp.data = std::shared_ptr<MemoryData>(new MemoryData((void *)buf),
+                                           std::default_delete<MemoryData>());
+    tmp.offset = offset;
+
+    return tmp;
+  };
+
+  friend void swap(FloatTensor &lhs, FloatTensor &rhs) noexcept {
+    std::swap(lhs.dim, rhs.dim);
+    std::swap(lhs.strides, rhs.strides);
+    std::swap(lhs.contiguous, rhs.contiguous);
+    std::swap(lhs.initializer, rhs.initializer);
+    std::swap(lhs.data, rhs.data);
+    std::swap(lhs.name, rhs.name);
+  }
+
+  /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs FloatTensor to be compared with
+   */
+  bool operator==(const FloatTensor &rhs) const;
+
+  /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs FloatTensor to be compared with
+   */
+  bool operator!=(const FloatTensor &rhs) const { return !(*this == rhs); }
+
+  /**
+   * @brief    Allocate memory for this tensor
+   */
+  void allocate();
+
+  /**
+   * @brief    Deallocate memory for this tensor
+   * @note     This will not necessary free the memory as tensors share memory
+   */
+  void deallocate() {
+    data = nullptr;
+    offset = 0;
+  }
+
+  /**
+   * @brief    Check if the tensor has memory allocated/assigned/associated
+   */
+  bool isAllocated() const { return data != nullptr; }
+
+  /**
+   * @brief     return value at specific location
+   * @param[in] batch batch location
+   * @param[in] c channel location
+   * @param[in] h height location
+   * @param[in] w width location
+   */
+  const float &getValue(unsigned int batch, unsigned int c, unsigned int h,
+                        unsigned int w) const noexcept {
+    return getValue(getIndex(batch, c, h, w));
+  }
+
+  float &getValue(unsigned int batch, unsigned int c, unsigned int h,
+                  unsigned int w) noexcept {
+    return getValue(getIndex(batch, c, h, w));
+  }
+
+  /**
+   * @brief     return value at specific location
+   * @param[in] idx location
+   */
+  const float &getValue(unsigned int idx) const noexcept {
+    if (getDataType() == Tdatatype::QINT4) {
+      return getData()[idx / 2];
+    }
+    return getData()[idx];
+  }
+
+  /**
+   * @brief     return value at specific location
+   * @param[in] idx location
+   */
+  float &getValue(unsigned int idx) noexcept {
+    if (getDataType() == Tdatatype::QINT4) {
+      return getData()[idx / 2];
+    }
+    return getData()[idx];
+  }
+
+  /**
+   * @brief Get the Value thinking that it is padded
+   * for example, for the tensor (virtually padded) below,
+   * getValue(0, 0, 2, 2, 1, 1, .0f) will return 5
+   * padding available for height and width axis for now
+   * 0 0 0 0 0
+   * 0 1 2 3 0
+   * 0 4 5 6 0
+   * 0 7 8 9 0
+   * 0 0 0 0 0
+   * @param b batch index
+   * @param c channel index
+   * @param h height index
+   * @param w width index
+   * @param ph padding height
+   * @param pw padding width
+   * @return float value
+   */
+  const float
+  getValuePaddedVirtual(unsigned int b, unsigned int c, unsigned int h,
+                        unsigned int w, unsigned int ph, unsigned int pw,
+                        float pad_value = 0) const EXCEPT_WHEN_DEBUG {
+#if DEBUG
+    unsigned int padded_h = 2 * ph + h;
+    unsigned int padded_w = 2 * pw + w;
+    if (h > padded_h && w > padded_w) {
+      throw std::out_of_range(
+        "[FloatTensor::getValuePadded] trying to access out of range");
+    }
+#endif
+
+    if (ph <= h && h < ph + height() && pw <= w && w < pw + width()) {
+      return getValue(b, c, h - ph, w - pw);
+    }
+
+    return pad_value;
+  }
+
+  /**
+   * @brief     Multiply value element by element immediately
+   * @param[in] value multiplier
+   * @retval    #ML_ERROR_INVALID_PARAMETER FloatTensor dimension is not right
+   * @retval    #ML_ERROR_NONE Successful
+   */
+  int multiply_i(float const &value);
+
+  /**
+   * @brief     Multiply value element by element
+   * @param[in] value multiplier
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor multiply(float const &value) const;
+
+  /**
+   * @brief     multiply value element by element
+   * @param[in] value multiplier
+   * @param[out] out out tensor to store the result
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &multiply(float const &value, FloatTensor &out) const;
+
+  /**
+   * @brief     Multiply FloatTensor Elementwise
+   * @param[in] m FloatTensor to be multiplied
+   * @param[in] beta scalar to multiply output with and add
+   * @retval    #ML_ERROR_NONE successful
+   */
+  int multiply_i(FloatTensor const &m, const float beta = 0.0);
+
+  /**
+   * @brief     Multiply FloatTensor Element by Element ( Not the MxM )
+   * @param[in] m FloatTensor to be multiplied
+   * @param[in] beta scalar to multiply output with and add
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor multiply(FloatTensor const &m, const float beta = 0.0) const;
+
+  /**
+   * @brief     Multiply FloatTensor Element by Element ( Not the MxM )
+   * @param[in] m FloatTensor to be multiplied
+   * @param[out] output FloatTensor to store the result
+   * @param[in] beta scalar to multiply output with and add
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &multiply(FloatTensor const &m, FloatTensor &output,
+                        const float beta = 0.0) const;
+
+  /**
+   * @brief     Multiply FloatTensor Elementwise
+   * @param[in] m FloatTensor to be multiplied
+   * @param[in] beta scalar to multiply output with and add
+   * @retval    #ML_ERROR_NONE successful
+   *
+   * @note support different strided inputs and output
+   * @note does not support broadcasting
+   *
+   * @todo merge this to multiply_i
+   */
+  int multiply_i_strided(FloatTensor const &m, const float beta = 0.0);
+
+  /**
+   * @brief     Multiply FloatTensor Element by Element ( Not the MxM )
+   * @param[in] m FloatTensor to be multiplied
+   * @param[in] beta scalar to multiply output with and add
+   * @retval    Calculated FloatTensor
+   *
+   * @note support different strided inputs and output
+   * @note does not support broadcasting
+   *
+   * @todo merge this to multiply
+   */
+  FloatTensor multiply_strided(FloatTensor const &m,
+                               const float beta = 0.0) const;
+
+  /**
+   * @brief     Multiply FloatTensor Element by Element ( Not the MxM )
+   * @param[in] m FloatTensor to be multiplied
+   * @param[out] output FloatTensor to store the result
+   * @param[in] beta scalar to multiply output with and add
+   * @retval    Calculated FloatTensor
+   *
+   * @note support different strided inputs and output
+   * @note does not support broadcasting
+   *
+   * @todo merge this to multiply
+   */
+  FloatTensor &multiply_strided(FloatTensor const &m, FloatTensor &output,
+                                const float beta = 0.0) const;
+
+  /**
+   * @brief     Add FloatTensor Elementwise
+   * @param[in] m FloatTensor to be added
+   * @param[in] beta scalar to add output with and add
+   * @retval    #ML_ERROR_NONE successful
+   *
+   * @note support different strided inputs and output
+   * @note does not support broadcasting
+   *
+   * @todo merge this to add_i
+   */
+  int add_i_strided(FloatTensor const &m, const float beta = 0.0);
+
+  /**
+   * @brief     Add FloatTensor Element by Element
+   * @param[in] m FloatTensor to be added
+   * @param[in] beta Value to be scale the added tensor
+   * @retval    Calculated FloatTensor
+   *
+   * @note support different strided inputs and output
+   * @note does not support broadcasting
+   *
+   * @todo merge this to add
+   */
+  FloatTensor add_strided(FloatTensor const &m, const float beta = 0.0) const;
+
+  /**
+   * @brief     Add FloatTensor Element by Element
+   * @param[in] m FloatTensor to be added
+   * @param[out] output FloatTensor to store the result
+   * @param[in] beta Value to be scale the added tensor
+   * @retval    Calculated FloatTensor
+   *
+   * @note support different strided inputs and output
+   * @note does not support broadcasting
+   *
+   * @todo merge this to add
+   */
+  FloatTensor &add_strided(FloatTensor const &m, FloatTensor &output,
+                           const float beta = 0.0) const;
+
+  /**
+   * @brief     Divide value element by element immediately
+   * @param[in] value divisor
+   * @retval    #ML_ERROR_INVALID_PARAMETER FloatTensor dimension is not right
+   * @retval    #ML_ERROR_NONE Successful
+   */
+  int divide_i(float const &value);
+
+  /**
+   * @brief     Divide value element by element
+   * @param[in] value Divisor
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor divide(float const &value) const;
+
+  /**
+   * @brief     Divide value element by element
+   * @param[in] value Divisor
+   * @param[out] out out parameter to store the result
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &divide(float const &value, FloatTensor &out) const;
+
+  /**
+   * @brief     divide FloatTensor Elementwise
+   * @param[in] m FloatTensor to be multiplied
+   * @retval    #ML_ERROR_NONE successful
+   */
+  int divide_i(FloatTensor const &m);
+
+  /**
+   * @brief     Divide FloatTensor Element by Element
+   * @param[in] m Divisor FloatTensor
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor divide(FloatTensor const &m) const;
+
+  /**
+   * @brief     divide FloatTensor Elementwise
+   * @param[in] m FloatTensor to be multiplied
+   * @param[out] output FloatTensor to store the result
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &divide(FloatTensor const &m, FloatTensor &output) const;
+
+  /**
+   * @brief Add FloatTensor Element immediately to target tensor without mem
+   * copy
+   * @param[in] value value to be added
+   * @retval #ML_ERROR_NONE  Successful
+   * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter
+   */
+  int add_i(float const &value);
+
+  /**
+   * @brief     Add value Element by Element
+   * @param[in] value value to be added
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor add(float const &value) const;
+
+  /**
+   * @brief     Add FloatTensor Element by Element
+   * @param[in] value value to be added
+   * @param[out] out FloatTensor to save output without allocating new memory
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &add(float const &value, FloatTensor &out) const;
+
+  /**
+   * @brief Add FloatTensor Element by Element without mem copy
+   * @param[in] m FloatTensor to be added
+   * @param[out] alpha Values to be scaled
+   * @retval #ML_ERROR_NONE  Successful
+   * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter
+   */
+  int add_i(FloatTensor const &m, float const alpha = 1);
+
+  /**
+   * @brief     Add FloatTensor Element by Element
+   * @param[in] m FloatTensor to be added
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor add(FloatTensor const &m, float const alpha = 1) const;
+
+  /**
+   * @brief     Add FloatTensor Element by Element
+   * @param[in] m FloatTensor to be added
+   * @param[out] m FloatTensor to be out
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &add(FloatTensor const &m, FloatTensor &out,
+                   float const alpha = 1) const;
+
+  /**
+   * @brief     memcpyless version of subtract
+   * @param[in] value value to subtract
+   * @retval #ML_ERROR_NONE  Successful
+   * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter
+   */
+  int subtract_i(float const &value);
+
+  /**
+   * @brief     subtract value Element by Element
+   * @param[in] value value to be subtracted
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor subtract(float const &value) const;
+
+  /**
+   * @brief     Subtract FloatTensor Element by Element
+   * @param[in] value value to be added
+   * @param[out] out FloatTensor to save output without allocating new memory
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &subtract(float const &value, FloatTensor &out) const;
+
+  /**
+   * @brief     memcpyless version of subtract
+   * @param[in] m FloatTensor to be subtracted
+   * @retval #ML_ERROR_NONE  Successful
+   * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter
+   */
+  int subtract_i(FloatTensor const &m);
+
+  /**
+   * @brief     Substract FloatTensor Element by Element
+   * @param[in] m FloatTensor to be subtracted
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor subtract(FloatTensor const &m) const;
+
+  /**
+   * @brief     Subtract FloatTensor Element by Element
+   * @param[in] m FloatTensor to be added
+   * @param[out] m FloatTensor to be out
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &subtract(FloatTensor const &m, FloatTensor &out) const;
+
+  /**
+   * @brief FloatTensor power elementwise
+   *
+   * @param exponent exponent
+   * @return int ML_ERROR_NONE if successful
+   */
+  int pow_i(float exponent);
+
+  /**
+   * @brief    FloatTensor power Element by Element
+   * @param[in] exponent exponent
+   * @retval Calculated FloatTensor
+   */
+  FloatTensor pow(float exponent) const;
+
+  /**
+   * @brief    FloatTensor power Element by Element
+   * @param[in] exponent exponent
+   * @param[out] out out to store the result
+   * @retval Calculated FloatTensor
+   */
+  FloatTensor &pow(float exponent, FloatTensor &out) const;
+
+  /**
+   * @brief  gaussian error function
+   * @return int ML_ERROR_NONE if successful
+   */
+  int erf_i();
+
+  /**
+   * @brief    gaussian error function
+   * @retval Calculated FloatTensor
+   */
+  FloatTensor erf() const;
+
+  /**
+   * @brief    gaussian error function
+   * @param[out] out out to store the result
+   * @retval Calculated FloatTensor
+   */
+  FloatTensor &erf(FloatTensor &out) const;
+
+  /**
+   * @brief  getter of size of data
+   * @retval size of data
+   */
+  unsigned int sizeofData() { return dim.getDataTypeSize(); }
+
+  /**
+   * @brief     Dot Product of FloatTensor ( equal MxM )
+   * @details   This applies dot of the last dimension of this and second-last
+   * dimension of passed tensor m.
+   * @param[in] m FloatTensor
+   * @param[in] trans Transpose
+   * @param[in] trans_m Transpose m
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor dot(FloatTensor const &m, bool trans = false,
+                  bool trans_m = false) const;
+
+  /**
+   * @brief     Dot Product of FloatTensor ( equal MxM )
+   * @details   This applies dot of the last dimension of this and second-last
+   * dimension of passed tensor m.
+   * @param[in] m FloatTensor
+   * @param[in] output output FloatTensor
+   * @param[in] trans Transpose
+   * @param[in] trans_m Transpose m
+   * @param[in] beta beta
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &dot(FloatTensor const &m, FloatTensor &output,
+                   bool trans = false, bool trans_m = false,
+                   float beta = 0.0f) const;
+
+  /**
+   * @brief compute the derivative of this in the current tensor
+   * @param m same as given to the dot()
+   * @param output_deriv the derivative of the output
+   * @param[in] trans same as given to the dot()
+   * @param[in] trans_m same as given to the dot()
+   * @param[in] beta same as given to the dot()
+   * @note This will compute the derivative in-place and will overwrite existing
+   * data in the tensor
+   */
+  FloatTensor &dot_deriv_wrt_1(FloatTensor const &m,
+                               FloatTensor const &output_deriv,
+                               bool trans = false, bool trans_m = false,
+                               float beta = 0.0f);
+
+  /**
+   * @brief compute the derivative wrt m in the m tensor
+   * @param m_deriv tensor where derivative wrt m will be stored
+   * @param output_deriv the derivative of the output
+   * @param[in] trans same as given to the dot()
+   * @param[in] trans_m same as given to the dot()
+   * @param[in] beta same as given to the dot()
+   * @note The caller tensor must be the same tensor as the one which called the
+   * dot() product.
+   */
+  FloatTensor &dot_deriv_wrt_2(FloatTensor &m_deriv,
+                               FloatTensor const &output_deriv,
+                               bool trans = false, bool trans_m = false,
+                               float beta = 0.0f) const;
+
+  /**
+   * @copydoc FloatTensor::dot(FloatTensor const &m, FloatTensor &output, bool
+   trans, bool trans_m, float beta) const
+   * @details performs dot operation over a batch of inputs
+   */
+  FloatTensor &dotBatched(FloatTensor const &m, FloatTensor &result,
+                          bool trans = false, bool trans_m = false,
+                          float beta = 0.0f) const;
+
+  /**
+   * @copydoc FloatTensor::dot_deriv_wrt_1(FloatTensor const &m, FloatTensor
+   const &output_deriv, bool trans, bool trans_m, float beta)
+   */
+  FloatTensor &dot_batched_deriv_wrt_1(FloatTensor const &m,
+                                       FloatTensor const &output_deriv,
+                                       bool trans = false, bool trans_m = false,
+                                       float beta = 0.0f);
+
+  /**
+   * @brief FloatTensor::dot_deriv_wrt_2(FloatTensor const &m_deriv, FloatTensor
+   const &output_deriv, bool trans, bool trans_m, float beta) const
+   */
+  FloatTensor &dot_batched_deriv_wrt_2(FloatTensor &m_deriv,
+                                       FloatTensor const &output_deriv,
+                                       bool trans = false, bool trans_m = false,
+                                       float beta = 0.0f) const;
+
+  /**
+   * @brief Transpose FloatTensor
+   *
+   * @param direction to transpose ex) 0:2:1
+   * @return FloatTensor
+   */
+  FloatTensor transpose(const std::string &direction) const;
+
+  /**
+   * @brief Transpose FloatTensor
+   * @param direction to transpose ex) 0:2:1
+   * @param[out] FloatTensor to save to, dimension is always reshaped.
+   * @retval FloatTensor& reference to the out
+   */
+  FloatTensor &transpose(const std::string &direction, FloatTensor &out) const;
+
+  /**
+   * @brief Calculate Drop Out Mask : x * 1.0/(1.0-rate)
+   * @param dropout drop out rate
+   * @retval FloatTensor& reference of drop out mask
+   */
+  FloatTensor dropout_mask(float dropout) const;
+
+  /**
+   * @brief Calculate Drop Out Mask : x * 1.0/(1.0-rate) inplace
+   * @param dropout drop out rate
+   */
+  void dropout_mask(float dropout);
+
+  /**
+   * @brief Calculate filter mask
+   * @param mask_len length of each mask along the last axis
+   * @param invert invert the mask
+   */
+  void filter_mask(const FloatTensor &mask_len, bool reverse = false);
+
+  /**
+   * @brief Calculate 2 Zone Out Mask
+   * @details Calculate zone out mask according to the bernoulli distribution.
+   * Zone out mask with rate @a zoneout for inplace and the other zone out mask
+   * with rate @a (1-zoneout).
+   * @param zoneout zone out rate
+   * @retval FloatTensor zone out mask for opposite tensor
+   */
+  FloatTensor zoneout_mask(float zoneout);
+
+  /**
+   * @brief Calculate 2 Zone Out Mask
+   * @details Calculate zone out mask according to the bernoulli distribution.
+   * Zone out mask with rate @a zoneout for inplace and the other zone out mask
+   * with rate @a (1-zoneout).
+   * @param opposite opposite zone out mask
+   * @param zoneout zone out rate
+   */
+  void zoneout_mask(FloatTensor &opposite, float zoneout);
+
+  /**
+   * @brief     sum all the FloatTensor elements according to the batch
+   * @retval    Calculated FloatTensor(batch, 1, 1, 1)
+   */
+  FloatTensor sum_by_batch() const;
+
+  /**
+   * @brief     sum all the FloatTensor elements according to the axis
+   *            0 : batch direction
+   *            1 : channel direction
+   *            2 : height direction
+   *            3 : width direction
+   * @param[in] axis Axis to calculate sum along
+   * @param[in] alpha Scale the sum by this value
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor sum(unsigned int axis, float alpha = 1.0) const;
+
+  /**
+   * @brief     sum all the FloatTensor elements according to the axis
+   *            0 : batch direction
+   *            1 : channel direction
+   *            2 : height direction
+   *            3 : width direction
+   * @param[in] axis Axis to calculate sum along
+   * @param[out] output output tensor
+   * @param[in] alpha Scale the sum by this value
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &sum(unsigned int axis, FloatTensor &output, float alpha = 1.0,
+                   float beta = 0.0) const;
+
+  /**
+   * @brief sum all the FloatTensor by multiple axes
+   *
+   * @param axes axes to sum along
+   * @param alpha Scale the sum by this value
+   * @return FloatTensor
+   */
+  FloatTensor sum(const std::vector<unsigned int> &axes,
+                  float alpha = 1.0) const;
+
+  /**
+   * @brief sum all the FloatTensor by multiple axes
+   *
+   * @param axes axes to sum along
+   * @param[out] output output tensor
+   * @param alpha Scale the sum by this value
+   * @return FloatTensor
+   */
+  FloatTensor &sum(const std::vector<unsigned int> &axes, FloatTensor &output,
+                   float alpha = 1.0) const;
+
+  /**
+   * @brief     Averaging the FloatTensor elements according to the axis
+   *            0 : batch direction
+   *            1 : channel direction
+   *            2 : height direction
+   *            3 : width direction
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor average(unsigned int axis) const;
+  /**
+   * @brief     Averaging the FloatTensor elements according to the axis
+   *
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &average(unsigned int axis, FloatTensor &output) const;
+
+  /**
+   * @brief average all the FloatTensor by multiple axes
+   *
+   * @param axes axes to sum along
+   * @return FloatTensor
+   */
+  FloatTensor average(const std::vector<unsigned int> &axes) const;
+
+  /**
+   * @brief average all the FloatTensor by multiple axes
+   *
+   * @param axes axes to sum along
+   * @param output output tensor
+   * @return FloatTensor
+   */
+  FloatTensor &average(const std::vector<unsigned int> &axes,
+                       FloatTensor &output) const;
+
+  /**
+   * @brief     Averaging the FloatTensor elements by all axis
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor average() const;
+
+  /**
+   * @brief     Averaging the FloatTensor elements by all axis
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &average(FloatTensor &output) const;
+
+  /**
+   * @brief     Anchor a starting point to defer following evaluation
+   * @retval    LazyTensor class that can be used with run();
+   */
+  LazyTensor chain() const;
+
+  /**
+   * @brief     Softmax the FloatTensor elements
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor softmax() const;
+
+  /**
+   * @brief     l2norm the FloatTensor elements
+   * @retval    Calculated l2norm
+   */
+  float l2norm() const;
+
+  /**
+   * @brief     Normalize the FloatTensor elements
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &normalization(FloatTensor &output) const;
+
+  /**
+   * @brief     Standardize the FloatTensor elements
+   * @retval    Calculated FloatTensor
+   */
+  FloatTensor &standardization(FloatTensor &output) const;
+
+  /**
+   * @brief     Normalize the FloatTensor elements in-place
+   * @retval    Calculated FloatTensor
+   */
+  void normalization_i();
+
+  /**
+   * @brief     Standardize the FloatTensor elements in-place
+   * @retval    Calculated FloatTensor
+   */
+  void standardization_i();
+
+  /**
+   * @brief     i data index
+   * @retval    address of ith data
+   */
+  float *getAddress(unsigned int i) {
+    size_t index = getIndex(batch(), channel(), height(), width());
+    if (i > index) {
+      return nullptr;
+    }
+    return &getData()[i];
+  }
+
+  /**
+   * @brief     i data index
+   * @retval    address of ith data
+   */
+  const float *getAddress(unsigned int i) const {
+    size_t index = getIndex(batch(), channel(), height(), width());
+    if (i > index) {
+      return nullptr;
+    }
+
+    return &getData()[i];
+  }
+
+  /**
+   * @brief    get address of n-d data
+   */
+  float *getAddress(unsigned int b, unsigned int c, unsigned int h,
+                    unsigned int w) {
+    return getAddress(getIndex(b, c, h, w));
+  }
+
+  /**
+   * @brief    get address of n-d data
+   */
+  const float *getAddress(unsigned int b, unsigned int c, unsigned int h,
+                          unsigned int w) const {
+    return getAddress(getIndex(b, c, h, w));
+  }
+
+  /**
+   * @brief Apply instantly to the element
+   *
+   * @param f function to apply
+   * @return int ML_ERROR_NONE if successful
+   */
+  int apply_i(std::function<float(float)> f) {
+    FloatTensor result = *this;
+    apply(f, result);
+
+    return ML_ERROR_NONE;
+  };
+
+  /**
+   * @brief     Apply function element by element
+   * @param[in] *function function pointer applied
+   * @param[out] output output tensor
+   * @retval    FloatTensor
+   */
+  FloatTensor &apply(std::function<float(float)> f, FloatTensor &output) const {
+    CREATE_IF_EMPTY_DIMS_FLOAT(output, dim, nullptr);
+
+    if (dim != output.dim) {
+      /// @todo add unittest
+      throw std::invalid_argument(
+        "[FloatTensor::apply] output dimension does not match");
+    }
+
+    if (contiguous && output.contiguous) {
+      const float *data = getData();
+      float *rdata = output.getData();
+
+      std::transform(data, data + size(), rdata, f);
+    } else if (strides[3] == 1 && output.strides[3] == 1) {
+      /** @todo optimize this with combining these loops where stride is 1 */
+      for (unsigned int b = 0; b < batch(); ++b) {
+        for (unsigned int c = 0; c < channel(); ++c) {
+          for (unsigned int h = 0; h < height(); ++h) {
+            float *out_data = output.getAddress(b, c, h, 0);
+            const float *in_data = getAddress(b, c, h, 0);
+            std::transform(in_data, in_data + width(), out_data, f);
+          }
+        }
+      }
+    } else {
+      for (unsigned int b = 0; b < batch(); ++b) {
+        for (unsigned int c = 0; c < channel(); ++c) {
+          for (unsigned int h = 0; h < height(); ++h) {
+            for (unsigned int w = 0; w < width(); ++w) {
+              output.setValue(b, c, h, w, f(getValue(b, c, h, w)));
+            }
+          }
+        }
+      }
+    }
+
+    return output;
+  };
+
+  /**
+   * @brief     Apply function element by element
+   * @param[in] *function function pointer applied
+   * @retval    FloatTensor
+   */
+  FloatTensor apply(std::function<float(float)> f) const {
+    FloatTensor result;
+    apply(f, result);
+
+    return result;
+  };
+
+  /**
+   * @brief     Apply function to FloatTensor
+   * @param[in] *function function pointer applied
+   * @retval    FloatTensor
+   */
+  FloatTensor apply(std::function<FloatTensor(FloatTensor)> f) const;
+
+  /**
+   * @brief     Apply function to FloatTensor
+   * @param[in] *function function pointer applied
+   * @param[out] output output tensor
+   * @retval    FloatTensor
+   */
+  FloatTensor &apply(std::function<FloatTensor &(FloatTensor, FloatTensor &)> f,
+                     FloatTensor &output) const;
+
+  /**
+   * @brief     Print element
+   * @param[in] out out stream
+   * @retval    FloatTensor
+   */
+  void print(std::ostream &out) const;
+
+  /**
+   * @brief     Print element
+   * @param[in] out out stream
+   * @param[in] opt print formatting option. opt=0 would pretty print the data,
+   * else it would print the raw data.
+   * @retval    FloatTensor
+   */
+  void print_(std::ostream &out, uint opt = 0) const;
+
+  /**
+   * @brief     Get size of current tensor
+   * @retval    unsigned int size of the current tensor
+   */
+  size_t size() const { return dim.getDataLen(); }
+
+  /**
+   * @brief     Get if the tensor is empty
+   * @retval    true if the tensor is empty
+   */
+  bool empty() const { return size() == 0; }
+
+  /**
+   * @brief     Get size of the data in bytes
+   * @retval    size_t Size in bytes
+   */
+  size_t bytes() const {
+    if (getDataType() == Tdatatype::QINT4) {
+      return (size() * dim.getDataTypeSize() + 1) / 2;
+    }
+    return size() * dim.getDataTypeSize();
+  }
+
+  /**
+   * @brief     Set the element value
+   * @param[in] batch batch location
+   * @param[in] c channel location
+   * @param[in] h height location
+   * @param[in] w width location
+   * @param[in] value value to be stored
+   */
+  void setValue(unsigned int batch, unsigned int c, unsigned int h,
+                unsigned int w, float value) noexcept {
+    getData()[getIndex(batch, c, h, w)] = value;
+  }
+
+  /**
+   * @brief     add the element value to the location
+   * @param[in] batch batch location
+   * @param[in] c channel location
+   * @param[in] h height location
+   * @param[in] w width location
+   * @param[in] value value to be stored
+   * @param[in] beta scalar to multiply output with and add
+   */
+  void addValue(unsigned int batch, unsigned int c, unsigned int h,
+                unsigned int w, float value, float beta) noexcept {
+    auto const &idx = getIndex(batch, c, h, w);
+    getData()[idx] *= beta;
+    getData()[idx] += value;
+  }
+
+  /**
+   * @brief     Fill the FloatTensor elements with value
+   * @param[in] value value to be stored
+   */
+  void setValue(float value);
+
+  /**
+   * @brief     Fill the FloatTensor elements with zero
+   */
+  void setZero();
+
+  /**
+   * @brief Set the Dist object
+   *
+   * @tparam T distrubution engine
+   * @param dist distribution engine
+   */
+  template <typename Engine> void setDist(Engine dist) {
+    NNTR_THROW_IF(!contiguous, std::invalid_argument)
+      << getName() << " FloatTensor is not contiguous, cannot set distribution";
+
+    float *data_ = getData();
+    unsigned int len = size();
+    for (unsigned int i = 0; i < len; ++i) {
+      data_[i] = (float)dist(rng);
+    }
+  };
+
+  /**
+   * @brief     Set the tensor with random normal distribution
+   * @param[in] mean mean of the distribution
+   * @param[in] std standard deviation of the distribution
+   */
+  void setRandNormal(float mean = 0.0f, float std = 0.05f);
+
+  /**
+   * @brief     Set the tensor with random uniform distribution
+   * @param[in] min minimum value for the distribution
+   * @param[in] max maximum value for the distribution
+   */
+  void setRandUniform(float min = -0.05f, float max = 0.05f);
+
+  /**
+   * @brief     Set the tensor with random bernoulli distribution
+   * @param[in] probability probability value for the distribution
+   */
+  void setRandBernoulli(float probability = 0.5f);
+
+  /**
+   * @brief     Initialize the memory of the given tensor
+   */
+  void initialize();
+
+  /**
+   * @brief     Initialize the memory of the given tensor
+   * @param     init Initiailizer to use for the initialization
+   */
+  void initialize(Initializer init) {
+    initializer = init;
+    initialize();
+  }
+
+  /**
+   * @brief     set the memory format
+   * @param     fm format of FloatTensor
+   */
+  void convertFormat(TensorDim::Format fm) {
+    if (getFormat() != fm) {
+      transpose("2:1:0");
+    }
+
+    dim.setFormat(fm);
+  }
+
+  /**
+   * @brief     Copy the FloatTensor
+   * @param[in] from FloatTensor to be copied
+   *
+   * @note copy can reshape the tensor to match the shape
+   */
+  void copy(const FloatTensor &from);
+
+  /**
+   * @brief     Copy the FloatTensor
+   * @param[in] from FloatTensor to be copied
+   */
+  void copyData(const FloatTensor &from);
+
+  /**
+   * @brief     Copy the FloatTensor
+   * @param[in] from FloatTensor to be copied
+   */
+  void copy_with_stride(const FloatTensor &from);
+
+  /**
+   * @brief Get slice of the tensor, sliced by batch
+   * @param[in] offset offset in batch to start the slice
+   * @param[in] size size of the slice
+   * @retval slice of this tensor
+   * @note This function provides a slice of this tensor, and does not create a
+   * copy
+   */
+  FloatTensor getBatchSlice(size_t offset, unsigned int size) const;
+
+  /**
+   * @brief Get new tensor which shares memory with current tensor but different
+   * shape
+   *
+   * @param dim new dimension to be set for this tensor
+   * @param offset offset to be used from the start of the data in elements
+   * @note The new tensor will share the same data as the current tensor but
+   * can have different size.
+   * @note New size added with offset must be less than the size of the original
+   * tensor.
+   */
+  FloatTensor getSharedDataTensor(const TensorDim dim, size_t offset,
+                                  bool reset_stride = true,
+                                  const std::string &name_ = "") const;
+  /**
+   * @brief split tensor along axis.
+   *
+   * @param num_size num_size
+   * @param axis axis
+   * @return FloatTensor splitted tensor
+   */
+  std::vector<FloatTensor> split(unsigned num_size, int axis = 0);
+
+  /**
+   * @brief split tensor along axis.
+   *
+   * @param sizes sizes
+   * @param axis axis
+   * @return FloatTensor splitted tensor
+   * @note if the given array sizes is just a 1 unsigned int value, assumes that
+   * it divide tensor by given size evenly
+   */
+  std::vector<FloatTensor> split(std::vector<size_t> sizes, int axis = 0);
+
+  /**
+   * @brief concatenate tensors along axis
+   *
+   * @param tensors tensors to be concatenated to the first tensor
+   * @param axis axis
+   * @return FloatTensor concatenated tensor
+   */
+  static FloatTensor cat(const std::vector<FloatTensor> &tensors, int axis = 0);
+
+  /**
+   * @brief make this tensor share memory with given tensor
+   *
+   * @param src Source tensor whose memory is to be shared
+   * @param offset offset to be used from the start of the data in bytes
+   * @note This tensor will share the same data as the current tensor but
+   * can have different size.
+   * @note This tensor's size added with offset must be less than the size of
+   * the source tensor.
+   * @note The stride of the source tensor and this tensor must be same.
+   */
+  void makeSharedDataTensor(const FloatTensor &src, size_t offset = 0);
+
+  /**
+   * @brief     Convient wrapper for inplace copy of @a this.
+   * @retval    Copied version of this
+   */
+  FloatTensor clone() const;
+
+  /**
+   * @brief     Save the FloatTensor into file
+   * @param[in] file output file stream
+   */
+  void save(std::ostream &file);
+
+  /**
+   * @brief     Read the FloatTensor from file
+   * @param[in] file input file stream
+   * @param[in] s_type scale factor data type
+   */
+  void read(std::ifstream &file, Tdatatype s_type = Tdatatype::FP32);
+
+  /**
+   * @brief     return argument index which value is max by batch
+   * @retval    unsigned int argument index
+   */
+  std::vector<unsigned int> argmax() const;
+
+  /**
+   * @brief     return max of the absolute values of the tensor
+   * @retval    maximum absolute value
+   */
+  float max_abs() const;
+
+  /**
+   * @brief     return a copy of the FloatTensor Dim
+   * @retval    TensorDim
+   */
+  TensorDim getDim() const { return TensorDim(dim); }
+
+  /**
+   * @brief     return FloatTensor Dim for a given axis
+   * @retval    dimension
+   */
+  size_t getTensorDim(unsigned int axis);
+
+  /**
+   * @brief     return FloatTensor Type
+   */
+  TensorDim::TensorType getTensorType() const { return dim.getTensorType(); };
+
+  /**
+   * @brief     return FloatTensor batch size
+   * @retval    batch size
+   */
+  size_t batch() const { return dim.batch(); }
+
+  /**
+   * @brief     return FloatTensor batch size
+   * @retval    batch size
+   */
+  size_t channel() const { return dim.channel(); }
+
+  /**
+   * @brief     return FloatTensor height size
+   * @retval    height size
+   */
+  size_t height() const { return dim.height(); }
+
+  /**
+   * @brief     return FloatTensor batch size
+   * @retval    width size
+   */
+  size_t width() const { return dim.width(); }
+
+  /**
+   * @brief     return FloatTensor Data Type Size
+   * @retval    data type size
+   */
+  uint getDataTypeSize() const { return dim.getDataTypeSize(); }
+
+  /**
+   * @brief     update batch size for this tensor
+   * @param     batch size
+   * @note      The batchsize of src_tensor need not be related with this
+   * tensor's batch size
+   *
+   * @note      The memory for this tensor will re-allocated/re-assigned if the
+   * updated batch size is different than the current batch size.
+   *
+   * @note      If this tensor is/was the src_tensor for some other, then
+   * reduction in batch size can make the dependent tensors allocate fail due to
+   * memory smaller. Caller must handle this in their own end.
+   *
+   * @note      If this tensor is re-allocated, then the memory might not be
+   * immediately freed as the tensor already depending on this tensor also
+   * share the same memory. So, the peak memory consumption in worst case can
+   * reach the total memory requirements of a model with old batchsize and the
+   * new batch size. It is recommended to first deallocate all the tensors,
+   * updateBatch and then allocate again to avoid such issues.
+   */
+  void updateBatch(unsigned int batch) {
+    if (dim.batch() == batch) {
+      return;
+    }
+
+    if (isAllocated())
+      throw std::invalid_argument(
+        "Cannot update batch for an allocated tensor");
+    dim.batch(batch);
+  }
+
+  /**
+   * @brief     return Data pointer of FloatTensor
+   * @retval    template T pointer (float pointer as default)
+   */
+  float *getData() {
+    if (!data)
+      return nullptr;
+
+    data->validate();
+    return data->getAddr<float>() + offset;
+  }
+
+  /**
+   * @brief     return Data pointer of FloatTensor
+   * @retval    template T pointer (float pointer as default)
+   */
+  const float *getData() const {
+    if (!data)
+      return nullptr;
+
+    data->validate();
+    return data->getAddr<float>() + offset;
+  }
+
+  /**
+   * @brief     return Data pointer of FloatTensor
+   * @retval    template T pointer (float pointer as default)
+   */
+  float *getData(size_t idx) const {
+    if (!data)
+      return nullptr;
+
+    size_t index = idx;
+
+    data->validate();
+    return data->getAddr<float>() + offset + index;
+  }
+
+  /**
+   * @brief     setter data type
+   * @param[in] Data Type
+   */
+  void setDataType(Tdatatype d_type) { dim.setDataType(d_type); }
+
+  /**
+   * @brief     setter tensor type
+   * @param[in] tensor Type
+   */
+  void setTensorType(ml::train::TensorDim::TensorType t_type) {
+    dim.setTensorType(t_type);
+  }
+
+  /**
+   * @brief     put data of FloatTensor
+   *
+   * @note      It is only effective when memory_swap is used
+   */
+  void putData() const {
+    if (!data)
+      return;
+
+    data->invalidate();
+  }
+
+  /**
+   * @brief     return Data pointer of FloatTensor
+   * @retval    template T pointer (float pointer as default)
+   */
+  const std::shared_ptr<MemoryData> getMemoryData() const { return data; }
+
+  /**
+   * @brief     return offset
+   */
+  size_t getOffset() const { return offset; }
+
+  /**
+   * @brief     i data index
+   * @retval    address of ith data
+   */
+  /**
+   * @brief     set FloatTensor Dim
+   * @param[in] d TensorDim
+   * @note      Throws std::invalid_argument if size mismatch
+   */
+  void reshape(const TensorDim &d);
+
+  /**
+   * @brief fill tensor data with current value,
+   * if dimension is not exactly same, it is a hard error in this function
+   * so, only stride is overriden to @a this
+   *
+   * @param from FloatTensor to fill the data from
+   * @param allocate if unallocated, allocate with from.getDim()
+   * @throws std::invalid_argument if dimension and stride does not match
+   */
+  void fill(const FloatTensor &from, bool allocate = false);
+
+  /**
+   * @brief     return current stride of tensor.
+   * @retval    int[MAXDIM] strides
+   */
+  const std::array<size_t, TensorDim::MAXDIM> getStrides() const noexcept {
+    return strides;
+  }
+  /**
+   * @brief Get linear index given the n-d index
+   */
+  inline size_t getIndex(unsigned int b, unsigned int c, unsigned int h,
+                         unsigned int w) const noexcept {
+    if (getFormat() == Tformat::NCHW) {
+      return (b * strides[0] + c * strides[1] + h * strides[2] +
+              w * strides[3]);
+    } else {
+      return (b * strides[0] + h * strides[1] + w * strides[2] +
+              c * strides[3]);
+    }
+  }
+
+  /**
+   * @brief Check if two given axes are contiguous
+   */
+  bool checkContinuous(unsigned int n, unsigned int np1) const {
+    std::vector<unsigned int> continuous_order_nhwc = {0, 3, 1, 2};
+    bool continuous = false;
+    if (getFormat() == Tformat::NHWC) {
+      if (continuous_order_nhwc[np1] == continuous_order_nhwc[n] + 1)
+        continuous = true;
+    } else {
+      if (n + 1 == np1)
+        continuous = true;
+    }
+    return continuous;
+  }
+
+  /**
+   * @brief   Get name of the tensor
+   *
+   * @return name of the tensor
+   */
+  void setName(const std::string &name_) { name = name_; }
+
+  /**
+   * @brief   Get name of the tensor
+   *
+   * @return name of the tensor
+   */
+  const std::string &getName() const { return name; }
+
+  /**
+   * @brief Set the memory buffer for the tensor
+   *
+   * @param buf the memory buffer
+   * @param init intialize the buffer
+   */
+  void setData(const std::shared_ptr<MemoryData> buf, size_t off = 0,
+               bool init = false) {
+    if (buf) {
+      data = buf;
+      offset = off;
+      if (init)
+        initialize();
+    } else {
+      data = nullptr;
+      offset = 0;
+    }
+  }
+
+  /**
+   * @brief Get initializer for the tensor
+   *
+   * @return initializer of the tensor
+   */
+  FloatTensor::Initializer getInitializer() const { return initializer; }
+
+  /**
+   * @brief Get format for the tensor
+   *
+   * @return format of the tensor
+   */
+  TensorDim::Format getFormat() const { return dim.getFormat(); }
+
+  /**
+   * @brief Get data type for the tensor
+   *
+   * @return data type of the tensor
+   */
+  Tdatatype getDataType() const { return dim.getDataType(); }
+
+  static constexpr float epsilon = 1e-5;
+
+protected:
+  /**< handle the data as a std::shared_ptr<float> type */
+  TensorDim dim;
+  std::array<size_t, TensorDim::MAXDIM> strides;
+  bool contiguous;
+  FloatTensor::Initializer initializer;
+  std::string name; /**< name of the tensor */
+  std::shared_ptr<MemoryData> data;
+  size_t offset;
+
+  /**<
+   * When using shared_data with tensor, this stores the ptr of the source
+   * tensor which handles the full memory. If tensor data is already allocated,
+   * this does not affect the tensor. If the tensor data is not allocated, and
+   * src_ptr is valid, this tensor will use the memory allocated by the src_ptr
+   */
+  std::shared_ptr<SrcSharedFloatTensor> src_tensor;
+
+  struct BroadcastInfo;
+
+  /**
+   * @brief Applies the given operator to the tensor with the passed argument
+   * @param[in] m FloatTensor
+   * @param[in] v_func vectorized function to apply
+   * @param e broadcast info.
+   * @param cur_axis current axis. pass default when calling outside.
+   * @param offset offset for this.  pass default when calling outside.
+   * @param m_offset offset for m.  pass default when calling outside.
+   * @retval #ML_ERROR_NONE Successful
+   * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter
+   */
+  void
+  apply_broadcast_util(FloatTensor const &m,
+                       std::function<void(const BroadcastInfo &e, const float *,
+                                          const float *, float *)>
+                         v_func,
+                       FloatTensor &output, const BroadcastInfo &e,
+                       int cur_axis = -1, size_t offset = 0,
+                       size_t m_offset = 0) const;
+
+  /**
+   * @brief Applies the given operator to the tensor with the passed argument
+   *
+   * @param[in] m FloatTensor
+   * @param[in] v_func vectorized function to apply
+   * @retval #ML_ERROR_NONE Successful
+   * @retval #ML_ERROR_INVALID_PARAMETER Invalid Parameter
+   */
+  void apply_broadcast(FloatTensor const &m,
+                       std::function<void(const BroadcastInfo &e, const float *,
+                                          const float *, float *)>
+                         v_func,
+                       FloatTensor &output) const;
+
+  /**
+   * @brief compute Loop info for broadcasting and vectorization
+   *
+   * @param m target tensor to be calculated against.
+   * @return BroadcastInfo Loopinfo needed to run external loop
+   */
+  BroadcastInfo computeBroadcastInfo(const FloatTensor &m) const;
+
+  /**
+   * @brief copy a buffer to @a this, the caller has to ensure that @a this is
+   * initialized otherwise undefined behavior
+   *
+   * @param buf buffer to copy from
+   */
+  void copy(const void *buf);
+
+  /**
+   * @brief Update destination tensor to share memory with source tensor
+   *
+   * @param src src tensor containing the memory
+   * @param dest destination tensor which will share the memory
+   * @param offset offset to be used from the start of the data in bytes
+   * @note The new tensor will share the same data as the current tensor but
+   * can have different size.
+   * @note New size added with offset must be less than the size of the original
+   * tensor.
+   */
+  static void createSharedDataTensor(const FloatTensor &src, FloatTensor &dest,
+                                     size_t offset);
+
+  /**
+   * @brief    Reallocate memory for this tensor
+   * @note     This will not necessary free the memory as tensors share memory
+   * @note     This can increase the peak memory consumption when callled on all
+   * the tensors of a model sequentially. It is advised to first deallocate all
+   * the tensors and then allocate, than reallocate tensors one by one.
+   */
+  void reallocate() {
+    deallocate();
+    allocate();
+  }
+
+  /**
+   * @brief Merge the given two axis for tensor at second axis inplace
+   *
+   * @param axis1 first axis to merge
+   * @param axis2 second axis to merge
+   */
+  void mergeAxis(unsigned int axis1, unsigned int axis2);
+
+  /**
+   * @brief     rotate 180 dgree
+   * @param[in] in input FloatTensor
+   * @retVal FloatTensor rotated tensor (180 degree)
+   */
+  FloatTensor rotate_180(FloatTensor in);
+
+}; // namespace nntrainer
+
+/**
+ * @brief   Overriding output stream
+ */
+std::ostream &operator<<(std::ostream &out, FloatTensor const &m);
+
+typedef std::shared_ptr<FloatTensor> sharedFloatTensor;
+
+typedef std::shared_ptr<const FloatTensor> sharedConstFloatTensor;
+
+typedef std::vector<sharedConstFloatTensor> sharedConstFloatTensors;
+
+typedef std::vector<sharedFloatTensor> sharedFloatTensors;
+
+} /* namespace nntrainer */
+
+#endif /* __cplusplus */
+#endif /* __FLOAT_TENSOR_H__ */

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -6,6 +6,7 @@ tensor_sources = [
   'lazy_tensor.cpp',
   'manager.cpp',
   'tensor.cpp',
+  'float_tensor.cpp',
   'tensor_dim.cpp',
   'var_grad.cpp',
   'weight.cpp',
@@ -22,6 +23,7 @@ tensor_sources = [
 tensor_headers = [
   'memory_data.h',
   'tensor.h',
+  'float_tensor.h',
   'weight.h',
   'var_grad.h',    
   'tensor_wrap_specs.h',

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -531,6 +531,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 # tensor headers
 %{_includedir}/nntrainer/memory_data.h
 %{_includedir}/nntrainer/tensor.h
+%{_includedir}/nntrainer/float_tensor.h
 %{_includedir}/nntrainer/tensor_wrap_specs.h
 %{_includedir}/nntrainer/blas_interface.h
 %{_includedir}/nntrainer/var_grad.h


### PR DESCRIPTION
This PR includes creating the FloatTensor class which separates 32-bit floating point calculation from `nntrainer::Tensor`.

**Changes proposed in this PR:**
- Create a FloatTensor class that only handles 32-bit floating point calculation.
- Remove operations for Quantized Tensor.

Note that FloatTensor class is one of the steps in tensor refactoring, and the implementation of internal operation functions can vary depending on the situation. In addition, all operations have been verified with modification of `unittest_nntrainer_tensor`.