### PR TITLE
[Tensor] Add non-operation member functions of TensorV2

### DIFF
--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -4,6 +4,7 @@
  * @date	09 November 2023
  * @brief	This is FloatTensor class for 32-bit floating point calculation
  * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @author	Donghyeon Jeong <dhyeon.jeong@samsung.com>
  * @bug		No known bugs except for NYI items
  *

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -1069,7 +1069,7 @@ FloatTensor FloatTensor::sum_by_batch() const {
   NNTR_THROW_IF(!contiguous, std::invalid_argument)
     << getName() << " is not contiguous, cannot sum";
 
-  FloatTensor ret(dim.batch(), 1, 1, 1, this->getFormat(), getDataType());
+  FloatTensor ret(dim.batch(), 1, 1, 1, this->getFormat());
   size_t feat_len = dim.getFeatureLen();
   size_t batch = dim.batch();
 
@@ -1088,7 +1088,7 @@ FloatTensor FloatTensor::sum_by_batch() const {
  * @brief Calculate sum according to the axis.
  */
 FloatTensor FloatTensor::sum(unsigned int axis, float alpha) const {
-  FloatTensor ret("", this->getFormat(), this->getDataType());
+  FloatTensor ret("", this->getFormat());
   return sum(axis, ret, alpha, 0);
 }
 
@@ -1274,7 +1274,7 @@ FloatTensor &FloatTensor::dotBatched(FloatTensor const &m, FloatTensor &result,
 
 FloatTensor FloatTensor::dot(FloatTensor const &m, bool trans,
                              bool trans_m) const {
-  FloatTensor output("", this->getFormat(), this->getDataType());
+  FloatTensor output("", this->getFormat());
   dot(m, output, trans, trans_m);
 
   return output;
@@ -1828,8 +1828,7 @@ void FloatTensor::copy(const FloatTensor &from) {
     throw std::runtime_error("Cannot copy non-contiguous tensor");
   }
 
-  if (from.size() != 0 && size() == from.size() &&
-      getDataType() == from.getDataType()) {
+  if (from.size() != 0 && size() == from.size()) {
     reshape(from.getDim());
     copy(from.getData());
   } else {
@@ -1919,7 +1918,7 @@ void FloatTensor::save(std::ostream &file) {
   putData();
 }
 
-void FloatTensor::read(std::ifstream &file, Tdatatype s_type) {
+void FloatTensor::read(std::ifstream &file) {
   NNTR_THROW_IF(!contiguous, std::invalid_argument)
     << getName() << " is not contiguous, cannot read.";
 
@@ -1938,7 +1937,7 @@ void FloatTensor::read(std::ifstream &file, Tdatatype s_type) {
  * @brief Calculate average value according to the axis.
  */
 FloatTensor FloatTensor::average(unsigned int axis) const {
-  FloatTensor t("", this->getFormat(), this->getDataType());
+  FloatTensor t("", this->getFormat());
   return average(axis, t);
 }
 
@@ -1961,7 +1960,7 @@ FloatTensor &FloatTensor::average(unsigned int axis,
 }
 
 FloatTensor FloatTensor::average(const std::vector<unsigned int> &axes) const {
-  FloatTensor t("", this->getFormat(), this->getDataType());
+  FloatTensor t("", this->getFormat());
   return average(axes, t);
 }
 
@@ -2129,8 +2128,7 @@ void FloatTensor::standardization_i() {
 
   this->subtract_i(mean_by_batch);
 
-  FloatTensor std_dev_by_batch(dim.batch(), 1, 1, 1, dim.getFormat(),
-                               dim.getDataType());
+  FloatTensor std_dev_by_batch(dim.batch(), 1, 1, 1, dim.getFormat());
   std_dev_by_batch.setZero();
   float *std_dev = std_dev_by_batch.getData();
 

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -6,6 +6,7 @@
  * @date	09 November 2023
  * @brief	This is FloatTensor class for 32-bit floating point calculation
  * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @author	Donghyeon Jeong <dhyeon.jeong@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -61,9 +61,8 @@ public:
   /**
    * @brief     Basic Constructor of FloatTensor
    */
-  FloatTensor(std::string name_ = "", Tformat fm = Tformat::NCHW,
-              Tdatatype d_type = Tdatatype::FP32) :
-    dim(TensorDim(fm, d_type)),
+  FloatTensor(std::string name_ = "", Tformat fm = Tformat::NCHW) :
+    dim(TensorDim(fm, Tdatatype::FP32)),
     strides(dim.computeStrides()),
     contiguous(true),
     initializer(Initializer::NONE),
@@ -98,8 +97,8 @@ public:
    * @param[in] d3 Width
    */
   FloatTensor(size_t d0, size_t d1, size_t d2, size_t d3,
-              Tformat fm = Tformat::NCHW, Tdatatype d_type = Tdatatype::FP32) :
-    FloatTensor(TensorDim(d0, d1, d2, d3, fm, d_type), nullptr){};
+              Tformat fm = Tformat::NCHW) :
+    FloatTensor(TensorDim(d0, d1, d2, d3, fm, Tdatatype::FP32), nullptr){};
 
   /**
    * @brief     Constructor of FloatTensor
@@ -107,26 +106,23 @@ public:
    * @param[in] d2 Height
    * @param[in] d3 Width
    */
-  FloatTensor(size_t d1, size_t d2, size_t d3, Tformat fm = Tformat::NCHW,
-              Tdatatype d_type = Tdatatype::FP32) :
-    FloatTensor(1, d1, d2, d3, fm, d_type){};
+  FloatTensor(size_t d1, size_t d2, size_t d3, Tformat fm = Tformat::NCHW) :
+    FloatTensor(1, d1, d2, d3, fm){};
 
   /**
    * @brief     Constructor of FloatTensor with batch size one and d1 size one
    * @param[in] d2 Height (NCHW) or Width (NHWC)
    * @param[in] d3 Width (NCHW) or Channel (NHWC)
    */
-  FloatTensor(size_t d2, size_t d3, Tformat fm = Tformat::NCHW,
-              Tdatatype d_type = Tdatatype::FP32) :
-    FloatTensor(1, 1, d2, d3, fm, d_type){};
+  FloatTensor(size_t d2, size_t d3, Tformat fm = Tformat::NCHW) :
+    FloatTensor(1, 1, d2, d3, fm){};
 
   /**
    * @brief     Constructor of FloatTensor with just Width or Channel
    * @param[in] d3 Width (NCHW) or Channel (NHWC)
    */
-  explicit FloatTensor(size_t d3, Tformat fm = Tformat::NCHW,
-                       Tdatatype d_type = Tdatatype::FP32) :
-    FloatTensor(1, 1, 1, d3, fm, d_type){};
+  explicit FloatTensor(size_t d3, Tformat fm = Tformat::NCHW) :
+    FloatTensor(1, 1, 1, d3, fm){};
 
   /**
    * @brief     Constructor of FloatTensor
@@ -360,9 +356,6 @@ public:
    * @param[in] idx location
    */
   const float &getValue(unsigned int idx) const noexcept {
-    if (getDataType() == Tdatatype::QINT4) {
-      return getData()[idx / 2];
-    }
     return getData()[idx];
   }
 
@@ -370,12 +363,7 @@ public:
    * @brief     return value at specific location
    * @param[in] idx location
    */
-  float &getValue(unsigned int idx) noexcept {
-    if (getDataType() == Tdatatype::QINT4) {
-      return getData()[idx / 2];
-    }
-    return getData()[idx];
-  }
+  float &getValue(unsigned int idx) noexcept { return getData()[idx]; }
 
   /**
    * @brief Get the Value thinking that it is padded
@@ -733,7 +721,7 @@ public:
    * @brief  getter of size of data
    * @retval size of data
    */
-  unsigned int sizeofData() { return dim.getDataTypeSize(); }
+  unsigned int sizeofData() const { return dim.getDataTypeSize(); }
 
   /**
    * @brief     Dot Product of FloatTensor ( equal MxM )
@@ -1176,12 +1164,7 @@ public:
    * @brief     Get size of the data in bytes
    * @retval    size_t Size in bytes
    */
-  size_t bytes() const {
-    if (getDataType() == Tdatatype::QINT4) {
-      return (size() * dim.getDataTypeSize() + 1) / 2;
-    }
-    return size() * dim.getDataTypeSize();
-  }
+  size_t bytes() const { return size() * dim.getDataTypeSize(); }
 
   /**
    * @brief     Set the element value
@@ -1387,9 +1370,8 @@ public:
   /**
    * @brief     Read the FloatTensor from file
    * @param[in] file input file stream
-   * @param[in] s_type scale factor data type
    */
-  void read(std::ifstream &file, Tdatatype s_type = Tdatatype::FP32);
+  void read(std::ifstream &file);
 
   /**
    * @brief     return argument index which value is max by batch
@@ -1520,12 +1502,6 @@ public:
   }
 
   /**
-   * @brief     setter data type
-   * @param[in] Data Type
-   */
-  void setDataType(Tdatatype d_type) { dim.setDataType(d_type); }
-
-  /**
    * @brief     setter tensor type
    * @param[in] tensor Type
    */
@@ -1585,6 +1561,13 @@ public:
   const std::array<size_t, TensorDim::MAXDIM> getStrides() const noexcept {
     return strides;
   }
+
+  /**
+   * @brief     return contiguous state of tensor.
+   * @retval    bool contiguous
+   */
+  bool getContiguous() const { return contiguous; }
+
   /**
    * @brief Get linear index given the n-d index
    */

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -446,8 +446,6 @@ HalfTensor &HalfTensor::multiply(float const &value, HalfTensor &out) const {
                      static_cast<_FP16>(value));
   apply(f, out);
   return out;
-
-  return out;
 }
 
 int HalfTensor::multiply_i(HalfTensor const &m, const float beta) {
@@ -1061,7 +1059,7 @@ HalfTensor HalfTensor::sum_by_batch() const {
   NNTR_THROW_IF(!contiguous, std::invalid_argument)
     << getName() << " is not contiguous, cannot sum";
 
-  HalfTensor ret(dim.batch(), 1, 1, 1, this->getFormat(), getDataType());
+  HalfTensor ret(dim.batch(), 1, 1, 1, this->getFormat());
   size_t feat_len = dim.getFeatureLen();
   size_t batch = dim.batch();
 
@@ -1080,7 +1078,7 @@ HalfTensor HalfTensor::sum_by_batch() const {
  * @brief Calculate sum according to the axis.
  */
 HalfTensor HalfTensor::sum(unsigned int axis, float alpha) const {
-  HalfTensor ret("", this->getFormat(), this->getDataType());
+  HalfTensor ret("", this->getFormat());
   return sum(axis, ret, alpha, 0);
 }
 
@@ -1264,7 +1262,7 @@ HalfTensor &HalfTensor::dotBatched(HalfTensor const &m, HalfTensor &result,
 
 HalfTensor HalfTensor::dot(HalfTensor const &m, bool trans,
                            bool trans_m) const {
-  HalfTensor output("", this->getFormat(), this->getDataType());
+  HalfTensor output("", this->getFormat());
   dot(m, output, trans, trans_m);
 
   return output;
@@ -1832,8 +1830,7 @@ void HalfTensor::copy(const HalfTensor &from) {
     throw std::runtime_error("Cannot copy non-contiguous tensor");
   }
 
-  if (from.size() != 0 && size() == from.size() &&
-      getDataType() == from.getDataType()) {
+  if (from.size() != 0 && size() == from.size()) {
     reshape(from.getDim());
 
     copy(from.getData());
@@ -1931,7 +1928,7 @@ void HalfTensor::save(std::ostream &file) {
   putData();
 }
 
-void HalfTensor::read(std::ifstream &file, Tdatatype s_type) {
+void HalfTensor::read(std::ifstream &file) {
   NNTR_THROW_IF(!contiguous, std::invalid_argument)
     << getName() << " is not contiguous, cannot read.";
 
@@ -1950,7 +1947,7 @@ void HalfTensor::read(std::ifstream &file, Tdatatype s_type) {
  * @brief Calculate average value according to the axis.
  */
 HalfTensor HalfTensor::average(unsigned int axis) const {
-  HalfTensor t("", this->getFormat(), this->getDataType());
+  HalfTensor t("", this->getFormat());
   return average(axis, t);
 }
 
@@ -1972,7 +1969,7 @@ HalfTensor &HalfTensor::average(unsigned int axis, HalfTensor &output) const {
 }
 
 HalfTensor HalfTensor::average(const std::vector<unsigned int> &axes) const {
-  HalfTensor t("", this->getFormat(), this->getDataType());
+  HalfTensor t("", this->getFormat());
   return average(axes, t);
 }
 
@@ -2146,8 +2143,7 @@ void HalfTensor::standardization_i() {
 
   this->subtract_i(mean_by_batch);
 
-  HalfTensor std_dev_by_batch(dim.batch(), 1, 1, 1, dim.getFormat(),
-                              dim.getDataType());
+  HalfTensor std_dev_by_batch(dim.batch(), 1, 1, 1, dim.getFormat());
   std_dev_by_batch.setZero();
   _FP16 *std_dev = std_dev_by_batch.getData();
 

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -6,6 +6,7 @@
  * @date	 09 November 2023
  * @brief	 This is HalfTensor class for calculation
  * @see		 https://github.com/nnstreamer/nntrainer
+ * @author	 Jijoong Moon <jijoong.moon@samsung.com>
  * @author	 Donghyeon Jeong <dhyeon.jeong@samsung.com>
  * @bug		 No known bugs except for NYI items
  */

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -63,9 +63,8 @@ public:
   /**
    * @brief     Basic Constructor of HalfTensor
    */
-  HalfTensor(std::string name_ = "", Tformat fm = Tformat::NCHW,
-             Tdatatype d_type = Tdatatype::FP16) :
-    dim(TensorDim(fm, d_type)),
+  HalfTensor(std::string name_ = "", Tformat fm = Tformat::NCHW) :
+    dim(TensorDim(fm, Tdatatype::FP16)),
     strides(dim.computeStrides()),
     contiguous(true),
     initializer(Initializer::NONE),
@@ -100,8 +99,8 @@ public:
    * @param[in] d3 Width
    */
   HalfTensor(size_t d0, size_t d1, size_t d2, size_t d3,
-             Tformat fm = Tformat::NCHW, Tdatatype d_type = Tdatatype::FP16) :
-    HalfTensor(TensorDim(d0, d1, d2, d3, fm, d_type), nullptr){};
+             Tformat fm = Tformat::NCHW) :
+    HalfTensor(TensorDim(d0, d1, d2, d3, fm, Tdatatype::FP16), nullptr){};
 
   /**
    * @brief     Constructor of HalfTensor
@@ -109,26 +108,23 @@ public:
    * @param[in] d2 Height
    * @param[in] d3 Width
    */
-  HalfTensor(size_t d1, size_t d2, size_t d3, Tformat fm = Tformat::NCHW,
-             Tdatatype d_type = Tdatatype::FP16) :
-    HalfTensor(1, d1, d2, d3, fm, d_type){};
+  HalfTensor(size_t d1, size_t d2, size_t d3, Tformat fm = Tformat::NCHW) :
+    HalfTensor(1, d1, d2, d3, fm){};
 
   /**
    * @brief     Constructor of HalfTensor with batch size one and d1 size one
    * @param[in] d2 Height (NCHW) or Width (NHWC)
    * @param[in] d3 Width (NCHW) or Channel (NHWC)
    */
-  HalfTensor(size_t d2, size_t d3, Tformat fm = Tformat::NCHW,
-             Tdatatype d_type = Tdatatype::FP16) :
-    HalfTensor(1, 1, d2, d3, fm, d_type){};
+  HalfTensor(size_t d2, size_t d3, Tformat fm = Tformat::NCHW) :
+    HalfTensor(1, 1, d2, d3, fm){};
 
   /**
    * @brief     Constructor of HalfTensor with just Width or Channel
    * @param[in] d3 Width (NCHW) or Channel (NHWC)
    */
-  explicit HalfTensor(size_t d3, Tformat fm = Tformat::NCHW,
-                      Tdatatype d_type = Tdatatype::FP16) :
-    HalfTensor(1, 1, 1, d3, fm, d_type){};
+  explicit HalfTensor(size_t d3, Tformat fm = Tformat::NCHW) :
+    HalfTensor(1, 1, 1, d3, fm){};
 
   /**
    * @brief     Constructor of HalfTensor
@@ -204,8 +200,6 @@ public:
     offset = 0;
     contiguous = true;
     initializer = Initializer::NONE;
-
-    setDataType(Tdatatype::FP16);
 
     // if fm == Tformat::NCHW, then dim[0] == batch , dim[1] == channel, dim[2]
     // == height, dim[3] == width. and if fm == Tformat::NHWC, dim[0] == batch,
@@ -363,9 +357,6 @@ public:
    * @param[in] idx location
    */
   const _FP16 &getValue(unsigned int idx) const noexcept {
-    if (getDataType() == Tdatatype::QINT4) {
-      return getData()[idx / 2];
-    }
     return getData()[idx];
   }
 
@@ -373,12 +364,7 @@ public:
    * @brief     return value at specific location
    * @param[in] idx location
    */
-  _FP16 &getValue(unsigned int idx) noexcept {
-    if (getDataType() == Tdatatype::QINT4) {
-      return getData()[idx / 2];
-    }
-    return getData()[idx];
-  }
+  _FP16 &getValue(unsigned int idx) noexcept { return getData()[idx]; }
 
   /**
    * @brief Get the Value thinking that it is padded
@@ -735,7 +721,7 @@ public:
    * @brief  getter of size of data
    * @retval size of data
    */
-  unsigned int sizeofData() { return dim.getDataTypeSize(); }
+  unsigned int sizeofData() const { return dim.getDataTypeSize(); }
 
   /**
    * @brief     Dot Product of HalfTensor ( equal MxM )
@@ -1178,12 +1164,7 @@ public:
    * @brief     Get size of the data in bytes
    * @retval    size_t Size in bytes
    */
-  size_t bytes() const {
-    if (getDataType() == Tdatatype::QINT4) {
-      return (size() * dim.getDataTypeSize() + 1) / 2;
-    }
-    return size() * dim.getDataTypeSize();
-  }
+  size_t bytes() const { return size() * dim.getDataTypeSize(); }
 
   /**
    * @brief     Set the element value
@@ -1403,9 +1384,8 @@ public:
   /**
    * @brief     Read the HalfTensor from file
    * @param[in] file input file stream
-   * @param[in] s_type scale factor data type
    */
-  void read(std::ifstream &file, Tdatatype s_type = Tdatatype::FP32);
+  void read(std::ifstream &file);
 
   /**
    * @brief     return argument index which value is max by batch
@@ -1536,12 +1516,6 @@ public:
   }
 
   /**
-   * @brief     setter data type
-   * @param[in] Data Type
-   */
-  void setDataType(Tdatatype d_type) { dim.setDataType(d_type); }
-
-  /**
    * @brief     setter tensor type
    * @param[in] tensor Type
    */
@@ -1601,6 +1575,13 @@ public:
   const std::array<size_t, TensorDim::MAXDIM> getStrides() const noexcept {
     return strides;
   }
+
+  /**
+   * @brief     return contiguous state of tensor.
+   * @retval    bool contiguous
+   */
+  bool getContiguous() const { return contiguous; }
+
   /**
    * @brief Get linear index given the n-d index
    */

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -6,6 +6,7 @@
  * @date	 09 November 2023
  * @brief	 This is HalfTensor class for calculation
  * @see		 https://github.com/nnstreamer/nntrainer
+ * @author	 Jijoong Moon <jijoong.moon@samsung.com>
  * @author	 Donghyeon Jeong <dhyeon.jeong@samsung.com>
  * @bug		 No known bugs except for NYI items
  */

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -97,6 +97,40 @@ TensorV2::TensorV2(
 }
 #endif
 
+bool TensorV2::operator==(const TensorV2 &rhs) const {
+  if (object->getDim() != rhs.object->getDim())
+    return false;
+
+  size_t len = object->size();
+
+  if (len != rhs.object->size())
+    return false;
+
+  if (object->getContiguous() != rhs.object->getContiguous())
+    return false;
+
+  if (object->getStrides() != rhs.object->getStrides())
+    return false;
+
+  for (size_t i = 0; i < len; ++i) {
+    /** not checking sign change is intentional to avoid float calculation
+     * errors around 0 */
+    const float *_data = (float *)getData(i);
+    const float *_rdata = (float *)rhs.getData(i);
+
+    if ((std::isnan(*_data) && !std::isnan(*_rdata)) ||
+        (!std::isnan(*_data) && std::isnan(*_rdata)) ||
+        std::fabs(*_data - *_rdata) > 1e-5)
+      return false;
+  }
+
+  return true;
+}
+
+bool TensorV2::operator!=(const TensorV2 &rhs) const {
+  return !(this->object == rhs.object);
+}
+
 void TensorV2::allocate() { object->allocate(); }
 
 void TensorV2::deallocate() { object->deallocate(); }

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -6,6 +6,7 @@
  * @date	16 November 2023
  * @brief	This is Tensor class in Type erasure design
  * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @author	Donghyeon Jeong <dhyeon.jeong@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -255,6 +255,15 @@ TensorDim::Format TensorV2::getFormat() const { return object->getFormat(); }
 
 Tdatatype TensorV2::getDataType() const { return object->getDataType(); }
 
+TensorV2 TensorV2::apply(std::function<TensorV2(TensorV2)> f) const {
+  return f(*this);
+}
+
+TensorV2 &TensorV2::apply(std::function<TensorV2 &(TensorV2, TensorV2 &)> f,
+                          TensorV2 &output) const {
+  return f(*this, output);
+}
+
 std::ostream &operator<<(std::ostream &out, TensorV2 const &m) {
   m.print(out);
   return out;

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -103,9 +103,16 @@ void TensorV2::deallocate() { object->deallocate(); }
 
 bool TensorV2::isAllocated() const { return object->isAllocated(); }
 
+void TensorV2::setData(const std::shared_ptr<MemoryData> buf, size_t off,
+                       bool init) {
+  object->setData(buf, off, init);
+}
+
 const void *TensorV2::getData() const { return object->getData(); }
 
 void *TensorV2::getData(size_t idx) const { return object->getData(idx); }
+
+unsigned int TensorV2::sizeofData() const { return object->sizeofData(); }
 
 void *TensorV2::getAddress(unsigned int i) { return object->getAddress(i); }
 
@@ -124,6 +131,16 @@ const void *TensorV2::getAddress(unsigned int b, unsigned int c, unsigned int h,
 }
 
 void TensorV2::setValue(float value) { object->setValue(value); }
+
+void TensorV2::setValue(unsigned int b, unsigned int c, unsigned int h,
+                        unsigned int w, float value) noexcept {
+  object->setValue(b, c, h, w, value);
+}
+
+void TensorV2::addValue(unsigned int b, unsigned int c, unsigned int h,
+                        unsigned int w, float value, float beta) noexcept {
+  object->addValue(b, c, h, w, value, beta);
+}
 
 void TensorV2::setZero() { object->setZero(); }
 
@@ -145,24 +162,60 @@ void TensorV2::initialize(Initializer init) { object->initialize(init); }
 
 void TensorV2::print(std::ostream &out) const { object->print(out); }
 
-template <typename TensorClass>
-TensorClass &TensorV2::operator=(const TensorClass &rhs) {
-  object = rhs;
-}
+size_t TensorV2::size() const { return object->size(); }
 
-template <typename TensorClass>
-TensorClass &TensorV2::operator=(TensorClass &&rhs) noexcept {
-  object = rhs;
-}
+bool TensorV2::empty() const { return size() == 0; }
+
+size_t TensorV2::bytes() const { return size() * sizeofData(); }
 
 size_t TensorV2::getIndex(unsigned int b, unsigned int c, unsigned int h,
                           unsigned int w) const noexcept {
   return object->getIndex(b, c, h, w);
 }
 
+bool TensorV2::checkContinuous(unsigned int n, unsigned int np1) const {
+  std::vector<unsigned int> continuous_order_nhwc = {0, 3, 1, 2};
+  bool continuous = false;
+  if (getFormat() == Tformat::NHWC) {
+    if (continuous_order_nhwc[np1] == continuous_order_nhwc[n] + 1)
+      continuous = true;
+  } else {
+    if (n + 1 == np1)
+      continuous = true;
+  }
+  return continuous;
+}
+
+void TensorV2::setName(const std::string &name_) { object->setName(name_); }
+
+const std::string &TensorV2::getName() const { return object->getName(); }
+
 Initializer TensorV2::getInitializer() const {
   return object->getInitializer();
 }
+
+TensorDim TensorV2::getDim() const { return object->getDim(); }
+
+const std::array<size_t, TensorDim::MAXDIM> TensorV2::getStrides() const
+  noexcept {
+  return object->getStrides();
+}
+
+bool TensorV2::getContiguous() const { return object->getContiguous(); }
+
+TensorDim::TensorType TensorV2::getTensorType() const {
+  return object->getTensorType();
+}
+
+size_t TensorV2::batch() const { return object->batch(); }
+
+size_t TensorV2::channel() const { return object->channel(); }
+
+size_t TensorV2::height() const { return object->height(); }
+
+size_t TensorV2::width() const { return object->width(); }
+
+uint TensorV2::getDataTypeSize() const { return object->getDataTypeSize(); }
 
 TensorDim::Format TensorV2::getFormat() const { return object->getFormat(); }
 

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -33,12 +33,12 @@ namespace nntrainer {
 TensorV2::TensorV2(std::string name_, Tformat fm, Tdatatype d_type) {
   if (d_type == Tdatatype::FP32) {
     object = std::shared_ptr<TensorBase<FloatTensor>>(
-      new TensorBase<FloatTensor>(FloatTensor(name_, fm, d_type)),
+      new TensorBase<FloatTensor>(FloatTensor(name_, fm)),
       std::default_delete<TensorBase<FloatTensor>>());
   } else if (d_type == Tdatatype::FP16) {
 #ifdef ENABLE_FP16
     object = std::shared_ptr<TensorBase<HalfTensor>>(
-      new TensorBase<HalfTensor>(HalfTensor(name_, fm, d_type)),
+      new TensorBase<HalfTensor>(HalfTensor(name_, fm)),
       std::default_delete<TensorBase<HalfTensor>>());
 #else
     throw std::invalid_argument("Error: enable-fp16 is not enabled");

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -78,6 +78,12 @@ private:
     virtual bool isAllocated() = 0;
 
     /**
+     * @copydoc TensorV2::setData()
+     */
+    virtual void setData(const std::shared_ptr<MemoryData> buf, size_t off = 0,
+                         bool init = false) = 0;
+
+    /**
      * @copydoc TensorV2::getData()
      */
     virtual const void *getData() const = 0;
@@ -86,6 +92,11 @@ private:
      * @copydoc TensorV2::getData(size_t idx)
      */
     virtual void *getData(size_t idx) const = 0;
+
+    /**
+     * @copydoc TensorV2::sizeofData()
+     */
+    virtual unsigned int sizeofData() const = 0;
 
     /**
      * @brief     i data index
@@ -103,6 +114,18 @@ private:
      * @copydoc TensorV2::setValue(float value)
      */
     virtual void setValue(float value) = 0;
+
+    /**
+     * @copydoc TensorV2::setValue(b, c, h, w, value)
+     */
+    virtual void setValue(unsigned int b, unsigned int c, unsigned int h,
+                          unsigned int w, float value) noexcept = 0;
+
+    /**
+     * @copydoc TensorV2::addValue(b, c, h, w, value, beta)
+     */
+    virtual void addValue(unsigned int b, unsigned int c, unsigned int h,
+                          unsigned int w, float value, float beta) noexcept = 0;
 
     /**
      * @copydoc TensorV2::setZero()
@@ -140,15 +163,76 @@ private:
     virtual void print(std::ostream &out) const = 0;
 
     /**
+     * @copydoc TensorV2::size()
+     */
+    virtual size_t size() const = 0;
+
+    /**
      * @copydoc TensorV2::getIndex()
      */
     virtual size_t getIndex(unsigned int b, unsigned int c, unsigned int h,
                             unsigned int w) const noexcept = 0;
 
     /**
+     * @copydoc TensorV2::setName(const std::string &name_)
+     */
+    virtual void setName(const std::string &name_) = 0;
+
+    /**
+     * @copydoc TensorV2::getName()
+     */
+    virtual const std::string &getName() const = 0;
+
+    /**
      * @copydoc TensorV2::getInitializer()
      */
     virtual Initializer getInitializer() const = 0;
+
+    /**
+     * @copydoc TensorV2::getDim()
+     */
+    virtual TensorDim getDim() const = 0;
+
+    /**
+     * @copydoc TensorV2::getStrides()
+     */
+    virtual const std::array<size_t, TensorDim::MAXDIM> getStrides() const
+      noexcept = 0;
+
+    /**
+     * @copydoc TensorV2::getContiguous()
+     */
+    virtual bool getContiguous() const = 0;
+
+    /**
+     * @copydoc TensorV2::getTensorType()
+     */
+    virtual TensorDim::TensorType getTensorType() const = 0;
+
+    /**
+     * @copydoc TensorV2::batch()
+     */
+    virtual size_t batch() const = 0;
+
+    /**
+     * @copydoc TensorV2::channel()
+     */
+    virtual size_t channel() const = 0;
+
+    /**
+     * @copydoc TensorV2::height()
+     */
+    virtual size_t height() const = 0;
+
+    /**
+     * @copydoc TensorV2::width()
+     */
+    virtual size_t width() const = 0;
+
+    /**
+     * @copydoc TensorV2::getDataTypeSize()
+     */
+    virtual uint getDataTypeSize() const = 0;
 
     /**
      * @copydoc TensorV2::getFormat()
@@ -193,6 +277,14 @@ private:
     virtual bool isAllocated() { return object.isAllocated(); }
 
     /**
+     * @copydoc TensorV2::setData()
+     */
+    virtual void setData(const std::shared_ptr<MemoryData> buf, size_t off = 0,
+                         bool init = false) {
+      object.setData(buf, off, init);
+    }
+
+    /**
      * @copydoc TensorV2::getData()
      */
     virtual const void *getData() const { return object.getData(); }
@@ -201,6 +293,11 @@ private:
      * @copydoc TensorV2::getData(size_t idx)
      */
     virtual void *getData(size_t idx) const { return object.getData(idx); }
+
+    /**
+     * @copydoc TensorV2::sizeofData()
+     */
+    virtual unsigned int sizeofData() const { return object.sizeofData(); }
 
     /**
      * @brief     i data index
@@ -220,6 +317,22 @@ private:
      * @copydoc TensorV2::setValue(float value)
      */
     virtual void setValue(float value) { object.setValue(value); }
+
+    /**
+     * @copydoc TensorV2::setValue(b, c, h, w, value)
+     */
+    virtual void setValue(unsigned int b, unsigned int c, unsigned int h,
+                          unsigned int w, float value) noexcept {
+      object.setValue(b, c, h, w, value);
+    }
+
+    /**
+     * @copydoc TensorV2::addValue(b, c, h, w, value, beta)
+     */
+    virtual void addValue(unsigned int b, unsigned int c, unsigned int h,
+                          unsigned int w, float value, float beta) noexcept {
+      object.addValue(b, c, h, w, value, beta);
+    }
 
     /**
      * @copydoc TensorV2::setZero()
@@ -263,6 +376,11 @@ private:
     virtual void print(std::ostream &out) const { object.print(out); }
 
     /**
+     * @copydoc TensorV2::size()
+     */
+    virtual size_t size() const { return object.size(); }
+
+    /**
      * @copydoc TensorV2::getIndex()
      */
     virtual size_t getIndex(unsigned int b, unsigned int c, unsigned int h,
@@ -271,11 +389,71 @@ private:
     }
 
     /**
+     * @copydoc TensorV2::setName(const std::string &name_)
+     */
+    virtual void setName(const std::string &name_) { object.setName(name_); }
+
+    /**
+     * @copydoc TensorV2::getName()
+     */
+    virtual const std::string &getName() const { return object.getName(); }
+
+    /**
      * @copydoc TensorV2::getInitializer()
      */
     virtual Initializer getInitializer() const {
       return object.getInitializer();
     }
+
+    /**
+     * @copydoc TensorV2::getDim()
+     */
+    virtual TensorDim getDim() const { return object.getDim(); }
+
+    /**
+     * @copydoc TensorV2::getStrides()
+     */
+    virtual const std::array<size_t, TensorDim::MAXDIM> getStrides() const
+      noexcept {
+      return object.getStrides();
+    }
+
+    /**
+     * @copydoc TensorV2::getContiguous()
+     */
+    virtual bool getContiguous() const { return object.getContiguous(); }
+
+    /**
+     * @copydoc TensorV2::getTensorType()
+     */
+    virtual TensorDim::TensorType getTensorType() const {
+      return object.getTensorType();
+    }
+
+    /**
+     * @copydoc TensorV2::batch()
+     */
+    virtual size_t batch() const { return object.batch(); }
+
+    /**
+     * @copydoc TensorV2::channel()
+     */
+    virtual size_t channel() const { return object.channel(); }
+
+    /**
+     * @copydoc TensorV2::height()
+     */
+    virtual size_t height() const { return object.height(); }
+
+    /**
+     * @copydoc TensorV2::width()
+     */
+    virtual size_t width() const { return object.width(); }
+
+    /**
+     * @copydoc TensorV2::getDataTypeSize()
+     */
+    virtual uint getDataTypeSize() const { return object.getDataTypeSize(); }
 
     /**
      * @copydoc TensorV2::getFormat()
@@ -505,16 +683,72 @@ public:
   }
 
   /**
+   * @brief Get the Value thinking that it is padded
+   * for example, for the tensor (virtually padded) below,
+   * getValue(0, 0, 2, 2, 1, 1, .0f) will return 5
+   * padding available for height and width axis for now
+   * 0 0 0 0 0
+   * 0 1 2 3 0
+   * 0 4 5 6 0
+   * 0 7 8 9 0
+   * 0 0 0 0 0
+   * @param b batch index
+   * @param c channel index
+   * @param h height index
+   * @param w width index
+   * @param ph padding height
+   * @param pw padding width
+   * @return float value
+   */
+  template <typename T = float>
+  const T getValuePaddedVirtual(unsigned int b, unsigned int c, unsigned int h,
+                                unsigned int w, unsigned int ph,
+                                unsigned int pw,
+                                T pad_value = 0) const EXCEPT_WHEN_DEBUG {
+#if DEBUG
+    unsigned int padded_h = 2 * ph + h;
+    unsigned int padded_w = 2 * pw + w;
+    if (h > padded_h && w > padded_w) {
+      throw std::out_of_range(
+        "[Tensor::getValuePadded] trying to access out of range");
+    }
+#endif
+
+    if (ph <= h && h < ph + height() && pw <= w && w < pw + width()) {
+      return getValue<T>(b, c, h - ph, w - pw);
+    }
+
+    return pad_value;
+  }
+
+  /**
+   * @brief Set the memory buffer for the tensor
+   *
+   * @param buf the memory buffer
+   * @param init intialize the buffer
+   */
+  void setData(const std::shared_ptr<MemoryData> buf, size_t off = 0,
+               bool init = false);
+
+  /**
    * @brief     return Data pointer of Tensor
-   * @retval    template T pointer (float pointer as default)
+   * @retval    void pointer
+   * @note      this function will be removed
    */
   const void *getData() const;
 
   /**
    * @brief     return Data pointer of Tensor
-   * @retval    template T pointer (float pointer as default)
+   * @retval    void pointer
+   * @note      this function will be removed
    */
   void *getData(size_t idx) const;
+
+  /**
+   * @brief  getter of size of data
+   * @retval size of data
+   */
+  unsigned int sizeofData() const;
 
   /**
    * @brief     i data index
@@ -545,6 +779,29 @@ public:
    * @param[in] value value to be stored
    */
   void setValue(float value);
+
+  /**
+   * @brief     Set the element value
+   * @param[in] batch batch location
+   * @param[in] c channel location
+   * @param[in] h height location
+   * @param[in] w width location
+   * @param[in] value value to be stored
+   */
+  void setValue(unsigned int batch, unsigned int c, unsigned int h,
+                unsigned int w, float value) noexcept;
+
+  /**
+   * @brief     add the element value to the location
+   * @param[in] b batch location
+   * @param[in] c channel location
+   * @param[in] h height location
+   * @param[in] w width location
+   * @param[in] value value to be stored
+   * @param[in] beta scalar to multiply output with and add
+   */
+  void addValue(unsigned int b, unsigned int c, unsigned int h, unsigned int w,
+                float value, float beta) noexcept;
 
   /**
    * @brief     Fill the Tensor elements with zero
@@ -590,16 +847,106 @@ public:
   void print(std::ostream &out) const;
 
   /**
+   * @brief     Get size of current tensor
+   * @retval    unsigned int size of the current tensor
+   */
+  size_t size() const;
+
+  /**
+   * @brief     Get if the tensor is empty
+   * @retval    true if the tensor is empty
+   */
+  bool empty() const;
+
+  /**
+   * @brief     Get size of the data in bytes
+   * @retval    size_t Size in bytes
+   */
+  size_t bytes() const;
+
+  /**
    * @brief Get linear index given the n-d index
    */
   size_t getIndex(unsigned int b, unsigned int c, unsigned int h,
                   unsigned int w) const noexcept;
 
   /**
+   * @brief Check if two given axes are contiguous
+   */
+  bool checkContinuous(unsigned int n, unsigned int np1) const;
+
+  /**
+   * @brief   Get name of the tensor
+   *
+   * @return name of the tensor
+   */
+  void setName(const std::string &name_);
+
+  /**
+   * @brief   Get name of the tensor
+   *
+   * @return name of the tensor
+   */
+  const std::string &getName() const;
+
+  /**
    * @brief Get initializer for the tensor
    * @retval initializer of the tensor
    */
   Initializer getInitializer() const;
+
+  /**
+   * @brief     return a copy of the Tensor Dim
+   * @retval    TensorDim
+   */
+  TensorDim getDim() const;
+
+  /**
+   * @brief     return current stride of tensor.
+   * @retval    int[MAXDIM] strides
+   */
+  const std::array<size_t, TensorDim::MAXDIM> getStrides() const noexcept;
+
+  /**
+   * @brief     return contiguous state of tensor.
+   * @retval    bool contiguous
+   */
+  bool getContiguous() const;
+
+  /**
+   * @brief     return Tensor Type
+   */
+  TensorDim::TensorType getTensorType() const;
+
+  /**
+   * @brief     return Tensor batch size
+   * @retval    batch size
+   */
+  size_t batch() const;
+
+  /**
+   * @brief     return Tensor batch size
+   * @retval    batch size
+   */
+  size_t channel() const;
+
+  /**
+   * @brief     return Tensor height size
+   * @retval    height size
+   */
+  size_t height() const;
+
+  /**
+   * @brief     return Tensor batch size
+   * @retval    width size
+   */
+  size_t width() const;
+
+  /**
+   * @brief     return Tensor Data Type Size
+   * @retval    data type size
+   */
+  uint getDataTypeSize() const;
 
   /**
    * @brief Get format for the tensor

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -613,15 +613,33 @@ public:
    * @brief  Copy assignment operator.
    * @param[in] rhs Tensor to be copied.
    */
-  template <typename TensorClass>
-  TensorClass &operator=(const TensorClass &rhs);
+  TensorV2 &operator=(const TensorV2 &rhs) = default;
 
   /**
    * @brief  Move assignment operator.
-   * @parma[in] rhs Tensor to be moved.
+   * @param[in] rhs Tensor to be moved.
    */
-  template <typename TensorClass>
-  TensorClass &operator=(TensorClass &&rhs) noexcept;
+  TensorV2 &operator=(TensorV2 &&rhs) noexcept = default;
+
+  /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs Tensor to be compared with
+   */
+  bool operator==(const TensorV2 &rhs) const;
+  /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs Tensor to be compared with
+   */
+  bool operator!=(const TensorV2 &rhs) const;
+
+  /**
+   * @brief     Swap tensor
+   * @param[in] lhs Tensor to be swapped
+   * @param[in] rhs Tensor to be swapped
+   */
+  friend void swap(TensorV2 &lhs, TensorV2 &rhs) noexcept {
+    swap(lhs.object, rhs.object);
+  }
 
   /**
    * @brief    Allocate memory for this tensor

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -6,6 +6,7 @@
  * @date	16 November 2023
  * @brief	This is Tensor class with Type erause
  * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Jijoong Moon <jijoong.moon@samsung.com>
  * @author	Donghyeon Jeong <dhyeon.jeong@samsung.com>
  * @bug		No known bugs except for NYI items
  */

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -38,6 +38,7 @@
 #include <nntrainer_log.h>
 #include <realizer.h>
 #include <tensor.h>
+#include <tensor_v2.h>
 
 /** tolerance is reduced for packaging, but CI runs at full tolerance */
 #ifdef REDUCE_TOLERANCE
@@ -156,6 +157,31 @@ randUniform(unsigned int batch, unsigned channel, unsigned height,
             nntrainer::Tdatatype d_type = nntrainer::Tdatatype::FP32);
 
 /**
+ * @brief return a tensorV2 filled with contant value with dimension
+ */
+nntrainer::TensorV2
+constantV2(float value, unsigned int d0, unsigned d1, unsigned d2, unsigned d3,
+           nntrainer::Tformat fm = nntrainer::Tformat::NCHW,
+           nntrainer::Tdatatype d_type = nntrainer::Tdatatype::FP32);
+
+/**
+ * @brief return a tensorV2 filled with ranged value with given dimension
+ */
+nntrainer::TensorV2
+rangedV2(unsigned int batch, unsigned channel, unsigned height, unsigned width,
+         nntrainer::Tformat fm = nntrainer::Tformat::NCHW,
+         nntrainer::Tdatatype d_type = nntrainer::Tdatatype::FP32);
+
+/**
+ * @brief return a tensorV2 filled with random value with given dimension
+ */
+nntrainer::TensorV2
+randUniformV2(unsigned int batch, unsigned channel, unsigned height,
+              unsigned width, float min = -1, float max = 1,
+              nntrainer::Tformat fm = nntrainer::Tformat::NCHW,
+              nntrainer::Tdatatype d_type = nntrainer::Tdatatype::FP32);
+
+/**
  * @brief replace string and save in file
  * @param[in] from string to be replaced
  * @param[in] to string to repalce with
@@ -258,9 +284,16 @@ nntrainer::GraphRepresentation makeCompiledGraph(
 void sizeCheckedReadTensor(nntrainer::Tensor &t, std::ifstream &file,
                            const std::string &error_msg = "");
 
+/**
+ * @brief calculate cosine similarity
+ *
+ * @param A prediction data
+ * @param B reference data
+ * @param size data size
+ * @return cosine similarity value
+ */
 template <typename Ta = float, typename Tb = float>
-double cosine_similarity(Ta *A /*Predict*/, Tb *B /*Reference */,
-                         uint32_t size) {
+double cosine_similarity(Ta *A, Tb *B, uint32_t size) {
   double dot = 0.0, denom_a = 0.0, denom_b = 0.0;
   for (uint32_t i = 0u; i < size; ++i) {
     double pred = A[i];
@@ -277,8 +310,16 @@ double cosine_similarity(Ta *A /*Predict*/, Tb *B /*Reference */,
   return cosine_sim;
 }
 
+/**
+ * @brief calculate mean squared errer
+ *
+ * @param A prediction data
+ * @param B reference data
+ * @param size data size
+ * @return mean squared errer value
+ */
 template <typename Ta = float, typename Tb = float>
-float mse(Ta *A /* Predicted */, Tb *B /* Reference */, uint32_t size) {
+float mse(Ta *A, Tb *B, uint32_t size) {
   float pred;
   float ref;
   float mse_error = 0;

--- a/test/nntrainer_test_util.cpp
+++ b/test/nntrainer_test_util.cpp
@@ -213,6 +213,48 @@ nntrainer::Tensor randUniform(unsigned int batch, unsigned int channel,
   return t;
 }
 
+nntrainer::TensorV2 constantV2(float value, unsigned int d0, unsigned int d1,
+                               unsigned int d2, unsigned int d3,
+                               nntrainer::Tformat fm,
+                               nntrainer::Tdatatype d_type) {
+  nntrainer::TensorV2 t(d0, d1, d2, d3, {fm, d_type});
+  t.setValue(value);
+
+  return t;
+}
+
+nntrainer::TensorV2 rangedV2(unsigned int batch, unsigned int channel,
+                             unsigned int height, unsigned int width,
+                             nntrainer::Tformat fm,
+                             nntrainer::Tdatatype d_type) {
+  nntrainer::TensorV2 t(batch, channel, height, width, {fm, d_type});
+  if (d_type == nntrainer::Tdatatype::FP32) {
+    float i = 0;
+    t = t.apply<float>(
+      (std::function<float(float)>)[&](float in) { return i++; });
+  } else if (d_type == nntrainer::Tdatatype::FP16) {
+#ifdef ENABLE_FP16
+    _FP16 i = 0;
+    t = t.apply<_FP16>(
+      (std::function<_FP16(_FP16)>)[&](_FP16 in) { return i++; });
+#else
+    throw std::invalid_argument("Error: enable-fp16 is not enabled");
+#endif
+  }
+
+  return t;
+}
+
+nntrainer::TensorV2 randUniformV2(unsigned int batch, unsigned int channel,
+                                  unsigned int height, unsigned int width,
+                                  float min, float max, nntrainer::Tformat fm,
+                                  nntrainer::Tdatatype d_type) {
+  nntrainer::TensorDim::TensorType t_type(fm, d_type);
+  nntrainer::TensorV2 t(batch, channel, height, width, t_type);
+  t.setRandUniform(min, max);
+  return t;
+}
+
 const std::string
 getResPath(const std::string &filename,
            const std::initializer_list<const char *> fallback_base) {

--- a/test/unittest/unittest_nntrainer_tensor_v2.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_v2.cpp
@@ -100,6 +100,242 @@ TEST(nntrainer_Tensor, Tensor_03_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
+TEST(nntrainer_Tensor, Tensor_04_p) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  std::vector<std::vector<std::vector<float>>> in;
+
+  for (int k = 0; k < batch; ++k) {
+    std::vector<std::vector<float>> ttv;
+    for (int i = 0; i < height; ++i) {
+      std::vector<float> tv;
+      for (int j = 0; j < width; ++j) {
+        tv.push_back(k * height * width + i * width + j);
+      }
+      ttv.push_back(tv);
+    }
+    in.push_back(ttv);
+  }
+
+  nntrainer::TensorV2 t0 = nntrainer::TensorV2(
+    in, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
+
+  // copy assignment operator
+  nntrainer::TensorV2 t1 = t0;
+
+  if (t1.getValue<float>(0, 0, 0, 1) != 1.0)
+    status = ML_ERROR_INVALID_PARAMETER;
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  // comparison operator
+  EXPECT_EQ(t0, t1);
+}
+
+TEST(nntrainer_Tensor, Tensor_05_p) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  std::vector<std::vector<std::vector<float>>> in;
+
+  for (int k = 0; k < batch; ++k) {
+    std::vector<std::vector<float>> ttv;
+    for (int i = 0; i < height; ++i) {
+      std::vector<float> tv;
+      for (int j = 0; j < width; ++j) {
+        tv.push_back(k * height * width + i * width + j);
+      }
+      ttv.push_back(tv);
+    }
+    in.push_back(ttv);
+  }
+
+  nntrainer::TensorV2 t0 = nntrainer::TensorV2(
+    in, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
+
+  // copy assignment operator
+  nntrainer::TensorV2 t1 = nntrainer::TensorV2(batch, height, width);
+  t1.setRandNormal(2.3, 0.5);
+
+  float val_t0 = t0.getValue<float>(0, 0, 0, 1);
+  float val_t1 = t1.getValue<float>(0, 0, 0, 1);
+
+  swap(t0, t1);
+
+  if (t0.getValue<float>(0, 0, 0, 1) != val_t1)
+    status = ML_ERROR_INVALID_PARAMETER;
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  if (t1.getValue<float>(0, 0, 0, 1) != val_t0)
+    status = ML_ERROR_INVALID_PARAMETER;
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+TEST(nntrainer_Tensor, TensorPaddedValue_p) {
+  nntrainer::TensorV2 a = rangedV2(1, 1, 3, 3);
+  float default_padded = -1;
+
+  for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < 5; ++j) {
+      float expected = default_padded;
+      if (1 <= i && i <= 3 && 1 <= j && j <= 3) {
+        expected = (i - 1) * 3 + (j - 1);
+      }
+      float actual = a.getValuePaddedVirtual(0, 0, i, j, 1, 1, default_padded);
+      EXPECT_FLOAT_EQ(actual, expected);
+    }
+  }
+}
+
+TEST(nntrainer_Tensor, empty_01) {
+  nntrainer::TensorV2 t;
+
+  EXPECT_TRUE(t.empty());
+}
+
+TEST(nntrainer_Tensor, empty_02) {
+  nntrainer::TensorV2 t({1, 2, 3, 4}, false);
+
+  EXPECT_FALSE(t.empty());
+}
+
+TEST(nntrainer_Tensor, empty_03) {
+  nntrainer::TensorV2 t({1, 2, 3, 4}, true);
+
+  EXPECT_FALSE(t.empty());
+}
+
+TEST(nntrainer_Tensor, allocate_01_n) {
+  nntrainer::TensorV2 t;
+  EXPECT_FALSE(t.isAllocated());
+
+  t.allocate();
+  EXPECT_FALSE(t.isAllocated());
+}
+
+TEST(nntrainer_Tensor, allocate_02_p) {
+  nntrainer::TensorV2 t({1, 2, 3, 4}, false);
+  EXPECT_FALSE(t.isAllocated());
+
+  t.allocate();
+  EXPECT_TRUE(t.isAllocated());
+}
+
+TEST(nntrainer_Tensor, allocate_03_p) {
+  nntrainer::TensorV2 t({1, 2, 3, 4}, true);
+  EXPECT_TRUE(t.isAllocated());
+
+  t.allocate();
+  EXPECT_TRUE(t.isAllocated());
+}
+
+TEST(nntrainer_Tensor, initialize_01_p) {
+  nntrainer::TensorV2 t({1, 2, 3, 4}, true, nntrainer::Initializer::ONES);
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4);
+  golden.setValue(1);
+
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_02_p) {
+  nntrainer::TensorV2 t({1, 2, 3, 4}, true);
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4);
+  golden.setValue(1);
+
+  EXPECT_NE(golden, t);
+
+  t.initialize(nntrainer::Initializer::ONES);
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_03_p) {
+  nntrainer::TensorV2 t({1, 2, 3, 4}, false, nntrainer::Initializer::ONES);
+  t.allocate();
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4);
+  golden.setValue(1);
+
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_04_p) {
+  nntrainer::TensorV2 t({1, 2, 3, 4}, false);
+  t.initialize(nntrainer::Initializer::ONES);
+  t.allocate();
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4);
+  golden.setValue(1);
+
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_05_p) {
+  nntrainer::TensorV2 t({1, 2, 3, 4}, false);
+  t.allocate();
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4);
+  golden.setValue(1.f);
+
+  /**
+   * Ideally, it should be NE, but it can be equal due to no initialization
+   * EXPECT_NE(golden, t);
+   */
+
+  t.initialize(nntrainer::Initializer::ONES);
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_06_n) {
+  nntrainer::TensorV2 t({1, 2, 3, 4}, true, nntrainer::Initializer::ONES);
+  nntrainer::TensorV2 golden({1, 2, 3, 4}, true, nntrainer::Initializer::ZEROS);
+
+  EXPECT_NE(golden, t);
+
+  golden.initialize(nntrainer::Initializer::ONES);
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_07_p) {
+  nntrainer::TensorV2 t({1, 2, 3, 4}, true, nntrainer::Initializer::ONES);
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4);
+  golden.setValue(1);
+
+  EXPECT_EQ(golden, t);
+
+  t.setValue(0, 0, 0, 0, 0);
+  t.setValue(0, 0, 0, t.size() - 1, 0);
+  EXPECT_NE(golden, t);
+
+  t.initialize();
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_08_p) {
+  nntrainer::TensorV2 t({1, 2, 3, 4}, true, nntrainer::Initializer::ONES);
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4);
+  golden.setValue(1);
+
+  EXPECT_EQ(golden, t);
+
+  t.initialize(nntrainer::Initializer::HE_NORMAL);
+  EXPECT_NE(golden, t);
+
+  t.initialize();
+  EXPECT_NE(golden, t);
+
+  t.initialize(nntrainer::Initializer::ONES);
+  EXPECT_EQ(golden, t);
+
+  t.initialize();
+  EXPECT_EQ(golden, t);
+}
+
 int main(int argc, char **argv) {
   int result = -1;
 

--- a/test/unittest/unittest_nntrainer_tensor_v2_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_v2_fp16.cpp
@@ -101,6 +101,299 @@ TEST(nntrainer_Tensor, Tensor_03_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
+TEST(nntrainer_Tensor, Tensor_04_p) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  std::vector<std::vector<std::vector<_FP16>>> in;
+
+  for (int k = 0; k < batch; ++k) {
+    std::vector<std::vector<_FP16>> ttv;
+    for (int i = 0; i < height; ++i) {
+      std::vector<_FP16> tv;
+      for (int j = 0; j < width; ++j) {
+        tv.push_back(k * height * width + i * width + j);
+      }
+      ttv.push_back(tv);
+    }
+    in.push_back(ttv);
+  }
+
+  nntrainer::TensorV2 t0 = nntrainer::TensorV2(
+    in, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16});
+
+  // copy assignment operator
+  nntrainer::TensorV2 t1 = t0;
+
+  if (t1.getValue<_FP16>(0, 0, 0, 1) != 1.0)
+    status = ML_ERROR_INVALID_PARAMETER;
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  // comparison operator
+  EXPECT_EQ(t0, t1);
+}
+
+TEST(nntrainer_Tensor, Tensor_05_p) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  std::vector<std::vector<std::vector<_FP16>>> in;
+
+  for (int k = 0; k < batch; ++k) {
+    std::vector<std::vector<_FP16>> ttv;
+    for (int i = 0; i < height; ++i) {
+      std::vector<_FP16> tv;
+      for (int j = 0; j < width; ++j) {
+        tv.push_back(k * height * width + i * width + j);
+      }
+      ttv.push_back(tv);
+    }
+    in.push_back(ttv);
+  }
+
+  nntrainer::TensorV2 t0 = nntrainer::TensorV2(
+    in, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16});
+
+  // copy assignment operator
+  nntrainer::TensorV2 t1 = nntrainer::TensorV2(
+    batch, height, width, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
+  t1.setRandNormal(2.3, 0.5);
+
+  _FP16 val_t0 = t0.getValue<_FP16>(0, 0, 0, 1);
+  _FP16 val_t1 = t1.getValue<_FP16>(0, 0, 0, 1);
+
+  swap(t0, t1);
+
+  if (t0.getValue<_FP16>(0, 0, 0, 1) != val_t1)
+    status = ML_ERROR_INVALID_PARAMETER;
+  EXPECT_EQ(status, ML_ERROR_NONE);
+
+  if (t1.getValue<_FP16>(0, 0, 0, 1) != val_t0)
+    status = ML_ERROR_INVALID_PARAMETER;
+  EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+TEST(nntrainer_Tensor, Tensor_06_p) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  std::vector<std::vector<std::vector<float>>> in;
+  std::vector<std::vector<std::vector<_FP16>>> in2;
+
+  for (int k = 0; k < batch; ++k) {
+    std::vector<std::vector<float>> ttv;
+    std::vector<std::vector<_FP16>> ttv2;
+    for (int i = 0; i < height; ++i) {
+      std::vector<float> tv;
+      std::vector<_FP16> tv2;
+      for (int j = 0; j < width; ++j) {
+        tv.push_back(k * height * width + i * width + j);
+        tv2.push_back(k * height * width + i * width + j);
+      }
+      ttv.push_back(tv);
+      ttv2.push_back(tv2);
+    }
+    in.push_back(ttv);
+    in2.push_back(ttv2);
+  }
+
+  nntrainer::TensorV2 t0 = nntrainer::TensorV2(
+    in, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
+  nntrainer::TensorV2 t1 = nntrainer::TensorV2(
+    in2, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16});
+
+  EXPECT_NE(t0, t1);
+}
+
+TEST(nntrainer_Tensor, empty_01) {
+  nntrainer::TensorV2 t("", nntrainer::Tformat::NCHW,
+                        nntrainer::Tdatatype::FP16);
+
+  EXPECT_TRUE(t.empty());
+}
+
+TEST(nntrainer_Tensor, empty_02) {
+  nntrainer::TensorV2 t(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    false);
+
+  EXPECT_FALSE(t.empty());
+}
+
+TEST(nntrainer_Tensor, empty_03) {
+  nntrainer::TensorV2 t(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    true);
+
+  EXPECT_FALSE(t.empty());
+}
+
+TEST(nntrainer_Tensor, allocate_01_n) {
+  nntrainer::TensorV2 t;
+  EXPECT_FALSE(t.isAllocated());
+
+  t.allocate();
+  EXPECT_FALSE(t.isAllocated());
+}
+
+TEST(nntrainer_Tensor, allocate_02_p) {
+  nntrainer::TensorV2 t(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    false);
+  EXPECT_FALSE(t.isAllocated());
+
+  t.allocate();
+  EXPECT_TRUE(t.isAllocated());
+}
+
+TEST(nntrainer_Tensor, allocate_03_p) {
+  nntrainer::TensorV2 t(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    true);
+  EXPECT_TRUE(t.isAllocated());
+
+  t.allocate();
+  EXPECT_TRUE(t.isAllocated());
+}
+
+TEST(nntrainer_Tensor, initialize_01_p) {
+  nntrainer::TensorV2 t(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    true, nntrainer::Initializer::ONES);
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4, nntrainer::Tformat::NCHW,
+                             nntrainer::Tdatatype::FP16);
+  golden.setValue(1);
+
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_02_p) {
+  nntrainer::TensorV2 t(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    true);
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4, nntrainer::Tformat::NCHW,
+                             nntrainer::Tdatatype::FP16);
+  golden.setValue(1);
+
+  EXPECT_NE(golden, t);
+
+  t.initialize(nntrainer::Initializer::ONES);
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_03_p) {
+  nntrainer::TensorV2 t(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    false, nntrainer::Initializer::ONES);
+  t.allocate();
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4, nntrainer::Tformat::NCHW,
+                             nntrainer::Tdatatype::FP16);
+
+  golden.setValue(1);
+
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_04_p) {
+  nntrainer::TensorV2 t(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    false);
+  t.initialize(nntrainer::Initializer::ONES);
+  t.allocate();
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4, nntrainer::Tformat::NCHW,
+                             nntrainer::Tdatatype::FP16);
+  ;
+  golden.setValue(1);
+
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_05_p) {
+  nntrainer::TensorV2 t(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    false);
+  t.allocate();
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4, nntrainer::Tformat::NCHW,
+                             nntrainer::Tdatatype::FP16);
+
+  golden.setValue(1.f);
+
+  /**
+   * Ideally, it should be NE, but it can be equal due to no initialization
+   * EXPECT_NE(golden, t);
+   */
+
+  t.initialize(nntrainer::Initializer::ONES);
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_06_n) {
+  nntrainer::TensorV2 t(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    true, nntrainer::Initializer::ONES);
+  nntrainer::TensorV2 golden(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    true, nntrainer::Initializer::ZEROS);
+
+  EXPECT_NE(golden, t);
+
+  golden.initialize(nntrainer::Initializer::ONES);
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_07_p) {
+  nntrainer::TensorV2 t(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    true, nntrainer::Initializer::ONES);
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4, nntrainer::Tformat::NCHW,
+                             nntrainer::Tdatatype::FP16);
+
+  golden.setValue(1);
+
+  EXPECT_EQ(golden, t);
+
+  t.setValue(0, 0, 0, 0, 0);
+  t.setValue(0, 0, 0, t.size() - 1, 0);
+  EXPECT_NE(golden, t);
+
+  t.initialize();
+  EXPECT_EQ(golden, t);
+}
+
+TEST(nntrainer_Tensor, initialize_08_p) {
+  nntrainer::TensorV2 t(
+    {{1, 2, 3, 4}, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16}},
+    true, nntrainer::Initializer::ONES);
+
+  nntrainer::TensorV2 golden(1, 2, 3, 4, nntrainer::Tformat::NCHW,
+                             nntrainer::Tdatatype::FP16);
+
+  golden.setValue(1);
+
+  EXPECT_EQ(golden, t);
+
+  t.initialize(nntrainer::Initializer::HE_NORMAL);
+  EXPECT_NE(golden, t);
+
+  t.initialize();
+  EXPECT_NE(golden, t);
+
+  t.initialize(nntrainer::Initializer::ONES);
+  EXPECT_EQ(golden, t);
+
+  t.initialize();
+  EXPECT_EQ(golden, t);
+}
+
 int main(int argc, char **argv) {
   int result = -1;
 


### PR DESCRIPTION
This PR enables additional functionality for TensorV2, such as setting/getting various data, operator overloading, etc.

**Changes proposed in this PR:**
- Extends current TensorV2 member functions.
- Implement TensorV2 class operator overloading.
- Add unit test for newly added features.

**Self-evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped