### PR TITLE
[neon/bugfix] Fix ewva function

### DIFF
--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -2004,7 +2004,7 @@ void elementwise_vector_addition_neon_fp16(const unsigned int N,
     vst1q_f16(&Z[i], z0_7);
   }
   while (i < N) {
-    Z[i] = X[i] * Y[i];
+    Z[i] = X[i] + Y[i];
     ++i;
   }
 }


### PR DESCRIPTION
- There was a wrong implementation of `ewva` function. It should be added, not multiplied.
- I was implementing more options for SIMD BLAS operations, but it is being postponed for merging due to current Tensor refactorization. However as far as I am concerned, for this particular bug, it might be fatal in imbalanced-Tensor or exceptional cases, so made an immediate PR before a whole new PR for refactorization of BLAS library in NNTrainer.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped