### PR TITLE
[Wait for #2375][Unit Test] Fix unittest_interpreter

### DIFF
--- a/test/unittest/compiler/meson.build
+++ b/test/unittest/compiler/meson.build
@@ -3,7 +3,7 @@ test_name = 'unittest_compiler'
 test_target = [
   'compiler_test_util.cpp',
   'unittest_compiler.cpp',
-# 'unittest_interpreter.cpp',
+  'unittest_interpreter.cpp',
   'unittest_tflite_export.cpp',
   'unittest_realizer.cpp',
 ]

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -16,15 +16,11 @@
 #include <memory>
 
 #include <app_context.h>
-#include <execution_mode.h>
-#include <flatten_realizer.h>
 #include <ini_interpreter.h>
 #include <interpreter.h>
 #include <layer.h>
 #include <layer_node.h>
 #include <network_graph.h>
-#include <node_exporter.h>
-#include <realizer.h>
 
 #include <app_context.h>
 #include <compiler_test_util.h>


### PR DESCRIPTION
**Fix unittest_interpreter**

The unit test interpreter had been previously disabled due to build errors.
However, the TensorFlow Lite (TFLite) related unit tests were separated and dependencies were removed, reflecting changes made in the neural network trainer.

**Changes proposed in this PR:**
- modified:   ../test/unittest/compiler/meson.build
- modified:   ../test/unittest/compiler/unittest_interpreter.cpp

**Resolves:** 
- #2375 

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Donghak PARK <donghak.park@samsung.com>