### PR TITLE
[Tensor] Resolve SrcSharedTensorV2 cyclic dependency

### DIFF
--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -29,4 +29,68 @@ size_t TensorBase::getIndex(unsigned int b, unsigned int c, unsigned int h,
   }
 }
 
+void TensorBase::allocateSrcTensor() {
+  if (src_tensor) {
+    data = src_tensor->tensor()->data;
+    offset = src_tensor->tensor()->offset + src_tensor->offset();
+  }
+}
+
+void TensorBase::createSharedDataTensor(const TensorBase *src, TensorBase *dest,
+                                        size_t offset) const {
+  /**
+   * - If src already has data allocated, then directly make dest tensor based
+   * on the src tensor.
+   * - If src->data does not exist (meaning tensor does not memory allocated),
+   * and src->src_tensor does not exist (meaning the src tensor does not depened
+   * on another tensor), then create a SrcSharedTensor around the src.
+   * - If src->src_tensor exists, then use the src->src_tensor to create the
+   *  required SrcSharedTensor to avoid recursive dependency.
+   *
+   * @note src->data and src->src_tensor CAN co-exist. src->src_tensor is stored
+   * if the batch size of src is updated and needs reallocation.
+   */
+  dest->data = nullptr;
+  if (src->data) {
+    dest->src_tensor = std::make_shared<SrcSharedTensorBase>(src, offset);
+    dest->allocate();
+  } else if (!src->src_tensor)
+    dest->src_tensor = std::make_shared<SrcSharedTensorBase>(src, offset);
+  else
+    dest->src_tensor = std::make_shared<SrcSharedTensorBase>(
+      src->src_tensor->tensor(), offset + src->src_tensor->offset());
+}
+
+TensorBase *TensorBase::getSharedDataTensor(const TensorDim dim_, size_t offset,
+                                            bool reset_stride,
+                                            const std::string &name_) {
+  TensorBase *ret = this;
+  if (dim_.getFormat() != ret->dim.getFormat())
+    throw std::invalid_argument("Tensor format does not match");
+
+  ret->dim = dim_;
+  if (!name_.empty())
+    ret->name = name_;
+
+  if (dim_.getDataLen() + offset > dim.getDataLen())
+    throw std::invalid_argument(
+      "Creating shared tensor of size bigger than tensor memory.");
+
+  if (reset_stride)
+    ret->strides = ret->dim.computeStrides();
+
+  TensorDim new_match_dim = dim_;
+  new_match_dim.batch(dim.batch());
+  if (new_match_dim != dim && !reset_stride)
+    ret->contiguous = false;
+
+  /**
+   * In this case, its the caller's responsibility to ensure that allocate() is
+   * called for the output tensor before operating on the output tensor.
+   */
+  createSharedDataTensor(this, ret, offset);
+
+  return ret;
+}
+
 } // namespace nntrainer

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -77,4 +77,17 @@ size_t TensorV2::height() const { return itensor->height(); }
 
 size_t TensorV2::width() const { return itensor->width(); }
 
+void TensorV2::createSharedDataTensor(const TensorV2 &src, TensorV2 &dest,
+                                      size_t offset) const {
+  itensor->createSharedDataTensor(src.itensor, dest.itensor, offset);
+}
+
+TensorV2 TensorV2::getSharedDataTensor(const TensorDim dim_, size_t offset,
+                                       bool reset_stride,
+                                       const std::string &name_) const {
+  TensorV2 ret = *this;
+  ret.itensor = itensor->getSharedDataTensor(dim_, offset, reset_stride, name_);
+  return ret;
+}
+
 } // namespace nntrainer

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -232,6 +232,35 @@ public:
    */
   size_t width() const;
 
+  /**
+   * @brief Update destination tensor to share memory with source tensor
+   *
+   * @param src src tensor containing the memory
+   * @param dest destination tensor which will share the memory
+   * @param offset offset to be used from the start of the data in bytes
+   * @note The new tensor will share the same data as the current tensor but
+   * can have different size.
+   * @note New size added with offset must be less than the size of the original
+   * tensor.
+   */
+  void createSharedDataTensor(const TensorV2 &src, TensorV2 &dest,
+                              size_t offset) const;
+
+  /**
+   * @brief Get new tensor which shares memory with current tensor but different
+   * shape
+   *
+   * @param dim new dimension to be set for this tensor
+   * @param offset offset to be used from the start of the data in elements
+   * @note The new tensor will share the same data as the current tensor but
+   * can have different size.
+   * @note New size added with offset must be less than the size of the original
+   * tensor.
+   */
+  TensorV2 getSharedDataTensor(const TensorDim dim_, size_t offset,
+                               bool reset_stride,
+                               const std::string &name_) const;
+
 private:
   TensorBase *itensor;
 };


### PR DESCRIPTION
This PR fixes the issue of SrcSharedTensorV2 containing TensorV2 which creates cyclic dependency.
(SrcSharedTensorV2 -> TensorV2 -> TensorBase -> SrcSharedTensorV2)

**Changes proposed in this PR:**
- SrcSharedTensorV2 owns TensorBase instead of TensorV2.
- Rename SrcSharedTensorV2 as SrcSharedTensorBase accordingly.
- Add functions to create and get shared data tensor.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped