### PR TITLE
[ API ] Add Tensor CPP API for Auto Grad

### DIFF
--- a/api/ccapi/include/tensor_api.h
+++ b/api/ccapi/include/tensor_api.h
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2023 Jijoong Moon <jijoong.moon@@samsung.com>
+ *
+ * @file   tensor_api.h
+ * @date   11 December 2023
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ * @brief  This is Tensor interface for c++ API
+ *
+ * @note This is experimental API and not stable.
+ */
+
+#ifndef __ML_TRAIN_TENSOR_H__
+#define __ML_TRAIN_TENSOR_H__
+
+#if __cplusplus < MIN_CPP_VERSION
+#error "CPP versions c++17 or over are only supported"
+#endif // __cpluscplus
+
+#include <layer.h>
+#include <tensor.h>
+#include <tuple>
+#include <var_grad.h>
+
+using iTensor = nntrainer::Tensor;
+
+namespace ml {
+namespace train {
+
+/**
+ * @class   Tensor
+ * @brief   Tensor extends over Var_Grad for the API
+ */
+class Tensor : public nntrainer::Var_Grad {
+public:
+  /**
+   * @brief Weight default constructor
+   */
+  Tensor() : nntrainer::Var_Grad() {}
+
+  /**
+   * @brief Construct a new Tensor object
+   *
+   * @param dim Variable and gradient tensor dimension
+   * @param init Initializer for the Tensor
+   * @param needg If the tensor needs gradient
+   * @param name Name for this tensor
+   */
+  explicit Tensor(const TensorDim &dim,
+                  const iTensor::Initializer init = iTensor::Initializer::ZEROS,
+                  bool ng = false, std::string name = ""){};
+
+  /**
+   * @brief Swap for weight
+   *
+   * @param lhs Swap to
+   * @param rhs Swap from
+   * @note Only swap gradient if need gradient
+   */
+  friend void swap(Tensor &lhs, Tensor &rhs) noexcept {
+    using std::swap;
+    swap(static_cast<Var_Grad &>(lhs), static_cast<Var_Grad &>(rhs));
+  }
+
+  /**
+   * @brief Copy constructor for weight
+   *
+   * @param rhs weight to construct from
+   */
+  Tensor(const Tensor &rhs) = default;
+
+  /**
+   * @brief Move constructor for weight
+   *
+   * @param rhs weight to construct from
+   */
+  Tensor(Tensor &&rhs) = default;
+
+  /**
+   * @brief copy assigment
+   *
+   * @param rhs copy from
+   * @return Tensor& Updated weight
+   */
+  Tensor &operator=(const Tensor &rhs) = default;
+
+  /**
+   * @brief move assignment
+   *
+   * @param rhs move from
+   * @return Tensor& Updated weight
+   */
+  Tensor &operator=(Tensor &&rhs) = default;
+
+  /**
+   * @brief Clone the currnet object
+   *
+   * @return Cloned copy
+   */
+  Tensor clone() const {
+    Tensor t(*this);
+    if (!this->var->empty())
+      t.var = std::make_shared<iTensor>(this->var->clone());
+    if (!this->grad->empty())
+      t.grad = std::make_shared<iTensor>(this->grad->clone());
+
+    return t;
+  }
+
+  /**
+   * @brief source layer setter
+   *
+   */
+  void setSrcLayer(std::shared_ptr<Layer> l) { src_layer = l; }
+
+  /**
+   * @brief source layer getter
+   *
+   * @return Layer
+   */
+  std::shared_ptr<Layer> getSrcLayer() { return src_layer; }
+
+private:
+  std::shared_ptr<Layer>
+    src_layer; /**< source layer which create this Tensor */
+};
+
+} // namespace train
+} // namespace ml
+#endif // __ML_TRAIN_TENSOR_H__

--- a/api/ccapi/meson.build
+++ b/api/ccapi/meson.build
@@ -16,6 +16,7 @@ ccapi_headers += meson.current_source_dir() / 'include' / 'layer.h'
 ccapi_headers += meson.current_source_dir() / 'include' / 'model.h'
 ccapi_headers += meson.current_source_dir() / 'include' / 'optimizer.h'
 ccapi_headers += meson.current_source_dir() / 'include' / 'tensor_dim.h'
+ccapi_headers += meson.current_source_dir() / 'include' / 'tensor_api.h'
 ccapi_headers += meson.current_source_dir() / '..' / 'nntrainer-api-common.h'
 
 ccapi_deps = [

--- a/api/ccapi/src/tensor_api.cpp
+++ b/api/ccapi/src/tensor_api.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2023 Jijoong Moon <jijoong.moon@@samsung.com>
+ *
+ * @file   tensor_api.cpp
+ * @date   11 December 2023
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ * @brief  This is Tensor interface for c++ API
+ *
+ * @note This is experimental API and not stable.
+ */
+
+#include <layer.h>
+#include <tensor.h>
+#include <tuple>
+#include <var_grad.h>
+
+namespace ml {
+namespace train {
+
+Tensor::Tensor(const TensorDim &dim, const iTensor::Initializer init, bool ng,
+               std::string name) :
+  Var_Grad(dim, init, ng, false, name),
+  src_layer(nullptr) {}
+
+} // namespace train
+} // namespace ml

--- a/debian/ccapi-ml-training-dev.install
+++ b/debian/ccapi-ml-training-dev.install
@@ -4,5 +4,6 @@
 /usr/include/nntrainer/optimizer.h
 /usr/include/nntrainer/dataset.h
 /usr/include/nntrainer/tensor_dim.h
+/usr/include/nntrainer/tensor_api.h
 /usr/lib/*/pkgconfig/ccapi-ml-training.pc
 /usr/lib/*/libccapi-*.a

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -592,6 +592,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/common.h
 %{_includedir}/nntrainer/model.h
 %{_includedir}/nntrainer/layer.h
+%{_includedir}/nntrainer/tensor_api.h
 %{_includedir}/nntrainer/optimizer.h
 %{_includedir}/nntrainer/dataset.h
 %{_includedir}/nntrainer/tensor_dim.h

--- a/test/ccapi/meson.build
+++ b/test/ccapi/meson.build
@@ -3,9 +3,14 @@ unittest_ccapi_deps = [
   nntrainer_test_deps,
 ]
 
+ccapi_targets = [
+  'unittest_ccapi.cpp',
+  'unittest_ccapi_tensor.cpp',
+]
+
 exec = executable(
   'unittest_ccapi',
-  'unittest_ccapi.cpp',
+  ccapi_targets,
   dependencies: unittest_ccapi_deps,
   install: get_option('enable-test'),
   install_dir: application_install_dir

--- a/test/ccapi/unittest_ccapi_tensor.cpp
+++ b/test/ccapi/unittest_ccapi_tensor.cpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2023 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file        unittest_ccapi_tensor.cpp
+ * @date        11 December 2023
+ * @brief       cc API Tensor Unit tests.
+ * @see         https://github.com/nnstreamer/nntrainer
+ * @author      Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug         No known bugs
+ */
+
+#include <gtest/gtest.h>
+#include <iostream>
+
+#include <layer.h>
+#include <nntrainer_error.h>
+#include <nntrainer_test_util.h>
+#include <tensor_api.h>
+
+/**
+ * @brief Tensor Construct Test
+ */
+
+TEST(nntrainer_ccapi, tensor_01_p) {
+
+  std::shared_ptr<ml::train::Layer> layer;
+
+  ml::train::Tensor a;
+
+  EXPECT_NO_THROW(layer =
+                    ml::train::layer::Input({"name=input0", "input_shape=1:1:2",
+                                             "normalization=true"}));
+
+  EXPECT_NO_THROW(a.setSrcLayer(layer));
+
+  std::shared_ptr<ml::train::Layer> layer_b = a.getSrcLayer();
+  EXPECT_EQ(layer_b->getName(), "input0");
+}


### PR DESCRIPTION
In this PR,
 . Add skeleton Tensor Class in cpp api which inherite the
 nntrainer::var_grad.
 . include setter and getter of source layer which create this
 tensor.
 . Add unittest case

Resolves:

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped