### PR TITLE
[ Ahub ] Fix svace issue

### DIFF
--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -24,7 +24,11 @@ TensorV2::TensorV2(std::string name_, Tformat fm, Tdatatype d_type) {
 #else
     throw std::invalid_argument("Error: enable-fp16 is not enabled");
 #endif
-  }
+  } else
+    throw std::invalid_argument(
+      "Error: TensorV2 cannot be constructed because the given d_type is not "
+      "compatible with itensor. The supported d_types are: FP32, FP16 "
+      "(if built with ENABLE_FP16)).");
 }
 
 void TensorV2::allocate() { itensor->allocate(); }

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -32,6 +32,11 @@ public:
            Tdatatype d_type = Tdatatype::FP32);
 
   /**
+   * @brief Basic Destructor
+   */
+  ~TensorV2() { free(itensor); }
+
+  /**
    * @brief    Allocate memory for this tensor
    */
   void allocate();


### PR DESCRIPTION
- Fixes : TensorV2 may not initialize itensor
- Fixes : After dynamic memory allocation of itensor, there is no destructor

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped