### PR TITLE
[Tensor] Enable additional constructors

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -12,7 +12,6 @@
 /usr/include/nntrainer/tensor_v2.h
 /usr/include/nntrainer/tensor_base.h
 /usr/include/nntrainer/float_tensor.h
-/usr/include/nntrainer/half_tensor.h
 /usr/include/nntrainer/tensor_wrap_specs.h
 /usr/include/nntrainer/blas_interface.h
 /usr/include/nntrainer/var_grad.h

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -36,6 +36,35 @@ public:
   FloatTensor(std::string name_ = "", Tformat fm = Tformat::NCHW);
 
   /**
+   * @brief Construct a new FloatTensor object
+   *
+   * @param d Tensor dim for this float tensor
+   * @param alloc_now Allocate memory to this tensor or not
+   * @param init Initializer for the tensor
+   * @param name Name of the tensor
+   */
+  FloatTensor(const TensorDim &d, bool alloc_now,
+              Initializer init = Initializer::NONE, std::string name = "");
+
+  /**
+   * @brief Construct a new FloatTensor object
+   *
+   * @param d Tensor dim for this tensor
+   * @param buf buffer
+   */
+  FloatTensor(const TensorDim &d, const void *buf = nullptr);
+
+  /**
+   * @brief Construct a new FloatTensor object
+   *
+   * @param d data for the Tensor
+   * @param fm format for the Tensor
+   */
+  FloatTensor(
+    std::vector<std::vector<std::vector<std::vector<float>>>> const &d,
+    Tformat fm);
+
+  /**
    * @brief Basic Destructor
    */
   ~FloatTensor() {}
@@ -102,6 +131,15 @@ public:
    * @copydoc TensorV2::print(std::ostream &out)
    */
   void print(std::ostream &out) const override;
+
+private:
+  /**
+   * @brief copy a buffer to @a this, the caller has to ensure that @a this is
+   * initialized otherwise undefined behavior
+   *
+   * @param buf buffer to copy from
+   */
+  void copy(const void *buf);
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -21,6 +21,73 @@ namespace nntrainer {
 HalfTensor::HalfTensor(std::string name_, Tformat fm) :
   TensorBase(name_, fm, Tdatatype::FP16) {}
 
+HalfTensor::HalfTensor(const TensorDim &d, bool alloc_now, Initializer init,
+                       std::string name) :
+  TensorBase(d, alloc_now, init, name) {
+  if (alloc_now)
+    allocate();
+}
+
+HalfTensor::HalfTensor(const TensorDim &d, const void *buf) :
+  HalfTensor(d, true) {
+  if (d.getDataLen() != 0) {
+    if (buf != nullptr)
+      copy(buf);
+  }
+}
+
+HalfTensor::HalfTensor(
+  std::vector<std::vector<std::vector<std::vector<_FP16>>>> const &d,
+  Tformat fm) {
+
+  if (d.empty() || d[0].empty() || d[0][0].empty() || d[0][0][0].empty()) {
+    throw std::out_of_range(
+      "[Tensor] trying to initialize HalfTensor from empty vector");
+  }
+
+  dim.setTensorDim(0, d.size());
+  if (fm == Tformat::NCHW) {
+    dim.setTensorDim(1, d[0].size());
+    dim.setTensorDim(2, d[0][0].size());
+    dim.setTensorDim(3, d[0][0][0].size());
+  } else {
+    dim.setTensorDim(2, d[0].size());
+    dim.setTensorDim(3, d[0][0].size());
+    dim.setTensorDim(1, d[0][0][0].size());
+  }
+
+  dim.setTensorType({fm, Tdatatype::FP16});
+
+  strides = dim.computeStrides();
+  contiguous = true;
+  initializer = Initializer::NONE;
+
+  MemoryData *mem_data =
+    new MemoryData((void *)(new _FP16[dim.getDataLen()]()));
+  data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
+    delete[] mem_data->getAddr<_FP16>();
+  });
+
+  offset = 0;
+
+  // if fm == Tformat::NCHW, then dim[0] == batch , dim[1] == channel, dim[2]
+  // == height, dim[3] == width. and if fm == Tformat::NHWC, dim[0] == batch,
+  // dim[1] == height, dim[2] == width, dim[3] == channel
+  if (fm == Tformat::NCHW) {
+    for (unsigned int i = 0; i < batch(); ++i)
+      for (unsigned int j = 0; j < channel(); ++j)
+        for (unsigned int k = 0; k < height(); ++k)
+          for (unsigned int l = 0; l < width(); ++l)
+            this->setValue(i, j, k, l, d[i][j][k][l]);
+  } else {
+    for (unsigned int i = 0; i < batch(); ++i)
+      for (unsigned int j = 0; j < height(); ++j)
+        for (unsigned int k = 0; k < width(); ++k)
+          for (unsigned int l = 0; l < channel(); ++l)
+            this->setValue(i, l, j, k, d[i][j][k][l]);
+  }
+}
+
 /// @todo support allocation by src_tensor
 void HalfTensor::allocate() {
   if (empty() || data)
@@ -175,6 +242,18 @@ void HalfTensor::print(std::ostream &out) const {
     }
   }
   out.copyfmt(init);
+}
+
+/// @todo include getName()
+void HalfTensor::copy(const void *buf) {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << "Tensor is not contiguous, cannot copy.";
+
+  if (buf == getData()) {
+    return;
+  }
+
+  scopy(size(), (_FP16 *)buf, 1, (_FP16 *)getData(), 1);
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -36,6 +36,34 @@ public:
   HalfTensor(std::string name_ = "", Tformat fm = Tformat::NCHW);
 
   /**
+   * @brief Construct a new HalfTensor object
+   *
+   * @param d Tensor dim for this float tensor
+   * @param alloc_now Allocate memory to this tensor or not
+   * @param init Initializer for the tensor
+   * @param name Name of the tensor
+   */
+  HalfTensor(const TensorDim &d, bool alloc_now,
+             Initializer init = Initializer::NONE, std::string name = "");
+
+  /**
+   * @brief Construct a new HalfTensor object
+   *
+   * @param d Tensor dim for this tensor
+   * @param buf buffer
+   */
+  HalfTensor(const TensorDim &d, const void *buf = nullptr);
+
+  /**
+   * @brief Construct a new HalfTensor object
+   *
+   * @param d data for the Tensor
+   * @param fm format for the Tensor
+   */
+  HalfTensor(std::vector<std::vector<std::vector<std::vector<_FP16>>>> const &d,
+             Tformat fm);
+
+  /**
    * @brief Basic Destructor
    */
   ~HalfTensor() {}
@@ -102,6 +130,15 @@ public:
    * @copydoc TensorV2::print(std::ostream &out)
    */
   void print(std::ostream &out) const override;
+
+private:
+  /**
+   * @brief copy a buffer to @a this, the caller has to ensure that @a this is
+   * initialized otherwise undefined behavior
+   *
+   * @param buf buffer to copy from
+   */
+  void copy(const void *buf);
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -28,7 +28,6 @@ tensor_headers = [
   'tensor_v2.h',
   'tensor_base.h',
   'float_tensor.h',
-  'half_tensor.h',
   'weight.h',
   'var_grad.h',    
   'tensor_wrap_specs.h',
@@ -42,6 +41,7 @@ if get_option('platform') == 'android' or arch == 'aarch64'
 endif
 
 if get_option('enable-fp16')
+  tensor_headers += 'half_tensor.h'
   tensor_sources += 'half_tensor.cpp'
 endif
 

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -13,6 +13,16 @@
 
 namespace nntrainer {
 
+TensorBase::TensorBase(const TensorDim &d, bool alloc_now, Initializer init,
+                       std::string name_) :
+  TensorBase(name_, d.getFormat()) {
+  if (d.getDataLen() != 0) {
+    dim = d;
+    strides = d.computeStrides();
+    initializer = init;
+  }
+}
+
 void TensorBase::putData() const {
   if (!data)
     return;

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -64,6 +64,25 @@ public:
     src_tensor() {}
 
   /**
+   * @brief     Constructor of Tensor with dimension, possibly lazily
+   * @param d Tensor dim for this tensor
+   * @param alloc_now If the memory of the tensor must be allocated
+   * @param init Initializer for the tensor
+   * @param name Name of the tensor
+   */
+  TensorBase(const TensorDim &d, bool alloc_now,
+             Initializer init = Initializer::NONE, std::string name = "");
+
+  /**
+   * @brief     Constructor of Tensor with dimension/buf
+   * @param d Tensor dim for this tensor
+   * @param buf buffer
+   * @note Memory for this tensor is instantaneously allocated
+   */
+  TensorBase(const TensorDim &d, const void *buf = nullptr) :
+    TensorBase(d, true) {}
+
+  /**
    * @brief Basic Destructor
    */
   virtual ~TensorBase() {}

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -10,8 +10,11 @@
  */
 
 #include <float_tensor.h>
-#include <half_tensor.h>
 #include <tensor_v2.h>
+
+#ifdef ENABLE_FP16
+#include <half_tensor.h>
+#endif
 
 namespace nntrainer {
 

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -16,6 +16,8 @@
 namespace nntrainer {
 
 TensorV2::TensorV2(std::string name_, Tformat fm, Tdatatype d_type) {
+  itensor = nullptr;
+
   if (d_type == Tdatatype::FP32) {
     itensor = new FloatTensor(name_, fm);
   } else if (d_type == Tdatatype::FP16) {
@@ -24,12 +26,66 @@ TensorV2::TensorV2(std::string name_, Tformat fm, Tdatatype d_type) {
 #else
     throw std::invalid_argument("Error: enable-fp16 is not enabled");
 #endif
-  } else
+  } else {
     throw std::invalid_argument(
       "Error: TensorV2 cannot be constructed because the given d_type is not "
       "compatible with itensor. The supported d_types are: FP32, FP16 "
-      "(if built with ENABLE_FP16)).");
+      "(if built with ENABLE_FP16).");
+  }
 }
+
+TensorV2::TensorV2(const TensorDim &d, bool alloc_now, Initializer init,
+                   std::string name) {
+  itensor = nullptr;
+
+  if (d.getDataType() == Tdatatype::FP32) {
+    itensor = new FloatTensor(d, alloc_now, init, name);
+  } else if (d.getDataType() == Tdatatype::FP16) {
+#ifdef ENABLE_FP16
+    itensor = new HalfTensor(d, alloc_now, init, name);
+#else
+    throw std::invalid_argument("Error: enable-fp16 is not enabled");
+#endif
+  } else {
+    throw std::invalid_argument(
+      "Error: TensorV2 cannot be constructed because the given d_type is not "
+      "compatible with itensor. The supported d_types are: FP32, FP16 "
+      "(if built with ENABLE_FP16).");
+  }
+}
+
+TensorV2::TensorV2(const TensorDim &d, const void *buf) {
+  itensor = nullptr;
+
+  if (d.getDataType() == Tdatatype::FP32) {
+    itensor = new FloatTensor(d, buf);
+  } else if (d.getDataType() == Tdatatype::FP16) {
+#ifdef ENABLE_FP16
+    itensor = new HalfTensor(d, buf);
+#else
+    throw std::invalid_argument("Error: enable-fp16 is not enabled");
+#endif
+  } else {
+    throw std::invalid_argument(
+      "Error: TensorV2 cannot be constructed because the given d_type is not "
+      "compatible with itensor. The supported d_types are: FP32, FP16 "
+      "(if built with ENABLE_FP16).");
+  }
+}
+
+TensorV2::TensorV2(
+  std::vector<std::vector<std::vector<std::vector<float>>>> const &d,
+  ml::train::TensorDim::TensorType t_type) {
+  itensor = new FloatTensor(d, t_type.format);
+}
+
+#ifdef ENABLE_FP16
+TensorV2::TensorV2(
+  std::vector<std::vector<std::vector<std::vector<_FP16>>>> const &d,
+  ml::train::TensorDim::TensorType t_type) {
+  itensor = new HalfTensor(d, t_type.format);
+}
+#endif
 
 void TensorV2::allocate() { itensor->allocate(); }
 

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -32,6 +32,172 @@ public:
            Tdatatype d_type = Tdatatype::FP32);
 
   /**
+   * @brief     Constructor of Tensor with dimension, possibly lazily
+   * @param d Tensor dim for this tensor
+   * @param alloc_now If the memory of the tensor must be allocated
+   * @param init Initializer for the tensor
+   * @param name Name of the tensor
+   */
+  TensorV2(const TensorDim &d, bool alloc_now,
+           Initializer init = Initializer::NONE, std::string name = "");
+
+  /**
+   * @brief     Constructor of Tensor with dimension/buf
+   * @param d Tensor dim for this tensor
+   * @param buf buffer
+   * @note Memory for this tensor is instantaneously allocated
+   */
+  TensorV2(const TensorDim &d, const void *buf = nullptr);
+
+  /**
+   * @brief     Constructor of Tensor
+   * @param[in] d0 Batch of Tensor
+   * @param[in] d1 Channel
+   * @param[in] d2 Height
+   * @param[in] d3 Width
+   * @param[in] fm Tensor Format
+   * @param[in] d_type Tensor Data Type
+   */
+  TensorV2(size_t d0, size_t d1, size_t d2, size_t d3,
+           Tformat fm = Tformat::NCHW, Tdatatype d_type = Tdatatype::FP32) :
+    TensorV2(TensorDim(d0, d1, d2, d3, fm, d_type), nullptr){};
+
+  /**
+   * @brief     Constructor of Tensor
+   * @param[in] d1 Channel
+   * @param[in] d2 Height
+   * @param[in] d3 Width
+   * @param[in] fm Tensor Format
+   * @param[in] d_type Tensor Data Type
+   */
+  TensorV2(size_t d1, size_t d2, size_t d3, Tformat fm = Tformat::NCHW,
+           Tdatatype d_type = Tdatatype::FP32) :
+    TensorV2(1, d1, d2, d3, fm, d_type){};
+
+  /**
+   * @brief     Constructor of Tensor with batch size one and d1 size one
+   * @param[in] d2 Height (NCHW) or Width (NHWC)
+   * @param[in] d3 Width (NCHW) or Channel (NHWC)
+   * @param[in] fm Tensor Format
+   * @param[in] d_type Tensor Data Type
+   */
+  TensorV2(size_t d2, size_t d3, Tformat fm = Tformat::NCHW,
+           Tdatatype d_type = Tdatatype::FP32) :
+    TensorV2(1, 1, d2, d3, fm, d_type){};
+
+  /**
+   * @brief     Constructor of Tensor with just Width or Channel
+   * @param[in] d3 Width (NCHW) or Channel (NHWC)
+   * @param[in] fm Tensor Format
+   * @param[in] d_type Tensor Data Type
+   */
+  explicit TensorV2(size_t d3, Tformat fm = Tformat::NCHW,
+                    Tdatatype d_type = Tdatatype::FP32) :
+    TensorV2(1, 1, 1, d3, fm, d_type){};
+
+  /**
+   * @brief     Constructor of Tensor
+   * @param[in] d0 Batch of Tensor
+   * @param[in] d1 Channel (NCHW) or Height (NHWC)
+   * @param[in] d2 Height (NCHW) or Width (NHWC)
+   * @param[in] d3 Width (NCHW) or Channel (NHWC)
+   * @param[in] t_type Tensor Type
+   */
+  TensorV2(size_t d0, size_t d1, size_t d2, size_t d3,
+           ml::train::TensorDim::TensorType t_type) :
+    TensorV2(TensorDim(d0, d1, d2, d3, t_type), nullptr){};
+
+  /**
+   * @brief     Constructor of Tensor
+   * @param[in] d1 Channel
+   * @param[in] d2 Height
+   * @param[in] d3 Width
+   * @param[in] t_type Tensor Type
+   */
+  TensorV2(size_t d1, size_t d2, size_t d3,
+           ml::train::TensorDim::TensorType t_type) :
+    TensorV2(1, d1, d2, d3, t_type){};
+
+  /**
+   * @brief     Constructor of Tensor with batch size one and d1 size one
+   * @param[in] d2 Height (NCHW) or Width (NHWC)
+   * @param[in] d3 Width (NCHW) or Channel (NHWC)
+   * @param[in] t_type Tensor Type
+   */
+  TensorV2(size_t d2, size_t d3, ml::train::TensorDim::TensorType t_type) :
+    TensorV2(1, (t_type.format == Tformat::NCHW) ? 1 : d3,
+             (t_type.format == Tformat::NCHW) ? d2 : 1,
+             (t_type.format == Tformat::NCHW) ? d3 : d2, t_type){};
+  /**
+   * @brief     Constructor of Tensor with just Width or Channel
+   * @param[in] d3 Width (NCHW) or Channel (NHWC)
+   * @param[in] t_type Tensor Type
+   */
+  explicit TensorV2(size_t d3, ml::train::TensorDim::TensorType t_type) :
+    TensorV2(1, (t_type.format == Tformat::NCHW) ? 1 : d3, 1,
+             (t_type.format == Tformat::NCHW) ? d3 : 1, t_type){};
+
+  /**
+   * @brief     Constructor of Tensor
+   * @param[in] d data for the Tensor. It needs to set format properly.
+   * @param[in] t_type Tensor Type
+   */
+  TensorV2(std::vector<std::vector<std::vector<std::vector<float>>>> const &d,
+           ml::train::TensorDim::TensorType t_type);
+
+  /**
+   * @brief     Constructor of Tensor
+   * @note      This constructor copies vector again. needs refactoring
+   * @param[in] d data for the Tensor. It needs to set format properly.
+   * @param[in] t_type Tensor Type
+   */
+  TensorV2(std::vector<std::vector<std::vector<float>>> const &d,
+           ml::train::TensorDim::TensorType t_type) :
+    TensorV2(std::vector<std::decay<decltype(d)>::type>{d}, t_type){};
+
+  /**
+   * @brief     Constructor of Tensor
+   * @note      This constructor copies vector again. needs refactoring
+   * @param[in] d data for the Tensor with batch size one
+   * @param[in] t_type Tensor Type
+   */
+  TensorV2(std::vector<std::vector<float>> const &d,
+           ml::train::TensorDim::TensorType t_type) :
+    TensorV2(std::vector<std::decay<decltype(d)>::type>{d}, t_type){};
+
+#ifdef ENABLE_FP16
+  /**
+   * @brief     Constructor of Tensor
+   * @note      This constructor copies vector again. needs refactoring
+   * @param[in] d data for the Tensor with batch size one
+   * @param[in] t_type Tensor Type
+   */
+  TensorV2(std::vector<std::vector<std::vector<std::vector<_FP16>>>> const &d,
+           ml::train::TensorDim::TensorType t_type);
+
+  /**
+   * @brief     Constructor of Tensor
+   * @note      This constructor copies vector again. needs refactoring
+   * @param[in] d data for the Tensor. It needs to set format properly.
+   * @param[in] t_type Tensor Type
+   */
+  TensorV2(std::vector<std::vector<std::vector<_FP16>>> const &d,
+           ml::train::TensorDim::TensorType t_type) :
+    TensorV2(std::vector<std::decay<decltype(d)>::type>{d}, t_type){};
+
+  /**
+   * @brief     Constructor of Tensor
+   * @note      This constructor copies vector again. needs refactoring
+   * @param[in] d data for the Tensor with batch size one
+   * @param[in] t_type Tensor Type
+   */
+  TensorV2(std::vector<std::vector<_FP16>> const &d,
+           ml::train::TensorDim::TensorType t_type) :
+    TensorV2(std::vector<std::decay<decltype(d)>::type>{d}, t_type){};
+
+#endif
+
+  /**
    * @brief Basic Destructor
    */
   ~TensorV2() { free(itensor); }

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -534,7 +534,9 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/tensor_v2.h
 %{_includedir}/nntrainer/tensor_base.h
 %{_includedir}/nntrainer/float_tensor.h
+%if 0%{?enable_fp16}
 %{_includedir}/nntrainer/half_tensor.h
+%endif
 %{_includedir}/nntrainer/tensor_wrap_specs.h
 %{_includedir}/nntrainer/blas_interface.h
 %{_includedir}/nntrainer/var_grad.h


### PR DESCRIPTION
In this PR, multiple constructors are supported in the original Tensor class.

- TensorV2 constructors decide which Tensor to create.
- TensorBase constructors handle initialization that is shared.
- Float/HalfTensor constructors manage their own unique initialization.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped