### PR TITLE
[Tensor] Support source tensor allocation

### DIFF
--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -26,17 +26,23 @@ void FloatTensor::allocate() {
   if (empty() || data)
     return;
 
-  /// allocate new memory for the tensor data
-  MemoryData *mem_data;
+  if (src_tensor) {
+    /// allocate data based on the source tensor
+    allocateSrcTensor();
+    /** as this memory is shared, do NOT initialize */
+  } else {
+    /// allocate new memory for the tensor data
+    MemoryData *mem_data;
 
-  mem_data = new MemoryData((void *)(new float[dim.getDataLen()]{}));
-  data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-    delete[] mem_data->template getAddr<float>();
-    delete mem_data;
-  });
+    mem_data = new MemoryData((void *)(new float[dim.getDataLen()]{}));
+    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
+      delete[] mem_data->template getAddr<float>();
+      delete mem_data;
+    });
 
-  offset = 0;
-  initialize();
+    offset = 0;
+    initialize();
+  }
 }
 
 void FloatTensor::deallocate() {

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -27,17 +27,23 @@ void HalfTensor::allocate() {
     /// already allocated
     return;
 
-  /// allocate new memory for the tensor data
-  MemoryData *mem_data;
+  if (src_tensor) {
+    /// allocate data based on the source tensor
+    allocateSrcTensor();
+    /** as this memory is shared, do NOT initialize */
+  } else {
+    /// allocate new memory for the tensor data
+    MemoryData *mem_data;
 
-  mem_data = new MemoryData((void *)(new _FP16[dim.getDataLen()]{}));
-  data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-    delete[] mem_data->template getAddr<_FP16>();
-    delete mem_data;
-  });
+    mem_data = new MemoryData((void *)(new _FP16[dim.getDataLen()]{}));
+    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
+      delete[] mem_data->template getAddr<_FP16>();
+      delete mem_data;
+    });
 
-  offset = 0;
-  initialize();
+    offset = 0;
+    initialize();
+  }
 }
 
 void HalfTensor::deallocate() {


### PR DESCRIPTION
In this PR, the float/half tensor can be allocated based on the source tensor.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped