### PR TITLE
[Tensor] Comparison operator overloading

### DIFF
--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -87,6 +87,20 @@ FloatTensor::FloatTensor(
   }
 }
 
+bool FloatTensor::operator==(const FloatTensor &rhs) const {
+  const float *_data = (float *)getData();
+  const float *_rdata = (float *)rhs.getData();
+  for (size_t i = 0; i < size(); ++i) {
+    /** not checking sign change is intentional to avoid float calculation
+     * errors around 0 */
+    if (std::isnan(_data[i]) || std::isnan(_rdata[i]) ||
+        std::fabs(_data[i] - _rdata[i]) > epsilon)
+      return false;
+  }
+
+  return true;
+}
+
 /// @todo support allocation by src_tensor
 void FloatTensor::allocate() {
   if (empty() || data)

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -70,6 +70,20 @@ public:
   ~FloatTensor() {}
 
   /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs Tensor to be compared with
+   * @note      Only compares Tensor data
+   */
+  bool operator==(const FloatTensor &rhs) const;
+
+  /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs Tensor to be compared with
+   * @note      Only compares Tensor data
+   */
+  bool operator!=(const FloatTensor &rhs) const { return !(*this == rhs); }
+
+  /**
    * @copydoc TensorV2::allocate()
    */
   void allocate() override;

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -88,6 +88,18 @@ HalfTensor::HalfTensor(
   }
 }
 
+bool HalfTensor::operator==(const HalfTensor &rhs) const {
+  const _FP16 *_data = (_FP16 *)getData();
+  const _FP16 *_rdata = (_FP16 *)rhs.getData();
+  for (size_t i = 0; i < size(); ++i) {
+    if (std::isnan(_data[i]) || std::isnan(_rdata[i]) ||
+        std::fabs((float)(_data[i] - _rdata[i])) > epsilon)
+      return false;
+  }
+
+  return true;
+}
+
 /// @todo support allocation by src_tensor
 void HalfTensor::allocate() {
   if (empty() || data)

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -69,6 +69,20 @@ public:
   ~HalfTensor() {}
 
   /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs Tensor to be compared with
+   * @note      Only compares Tensor data
+   */
+  bool operator==(const HalfTensor &rhs) const;
+
+  /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs Tensor to be compared with
+   * @note      Only compares Tensor data
+   */
+  bool operator!=(const HalfTensor &rhs) const { return !(*this == rhs); }
+
+  /**
    * @copydoc TensorV2::allocate()
    */
   void allocate() override;

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -23,6 +23,22 @@ TensorBase::TensorBase(const TensorDim &d, bool alloc_now, Initializer init,
   }
 }
 
+bool TensorBase::operator==(const TensorBase &rhs) const {
+  if (this->dim != rhs.dim)
+    return false;
+
+  if (size() != rhs.size())
+    return false;
+
+  if (contiguous != rhs.contiguous)
+    return false;
+
+  if (strides != rhs.strides)
+    return false;
+
+  return true;
+}
+
 void TensorBase::putData() const {
   if (!data)
     return;

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -83,6 +83,20 @@ public:
     TensorBase(d, true) {}
 
   /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs Tensor to be compared with
+   * @note      Only compares Tensor information
+   */
+  bool operator==(const TensorBase &rhs) const;
+
+  /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs Tensor to be compared with
+   * @note      Only compares Tensor information
+   */
+  bool operator!=(const TensorBase &rhs) const { return !(*this == rhs); }
+
+  /**
    * @brief Basic Destructor
    */
   virtual ~TensorBase() {}
@@ -260,6 +274,8 @@ public:
    */
   TensorBase *getSharedDataTensor(const TensorDim dim_, size_t offset,
                                   bool reset_stride, const std::string &name_);
+
+  static constexpr float epsilon = 1e-5;
 
 protected:
   TensorDim dim;

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -90,6 +90,27 @@ TensorV2::TensorV2(
 }
 #endif
 
+bool TensorV2::operator==(const TensorV2 &rhs) const {
+  /// compares tensor information
+  if (*itensor == *rhs.itensor) {
+    /// compares tensor data
+    if (getDataType() == Tdatatype::FP32) {
+      return *dynamic_cast<FloatTensor *>(itensor) ==
+             *dynamic_cast<FloatTensor *>(rhs.itensor);
+    } else if (getDataType() == Tdatatype::FP16) {
+#ifdef ENABLE_FP16
+      return *dynamic_cast<HalfTensor *>(itensor) ==
+             *dynamic_cast<HalfTensor *>(rhs.itensor);
+#else
+      throw std::invalid_argument(
+        "Error: HalfTensor cannot be created or used when FP16 is not enabled. "
+        "Please check if the tensor data type is set properly.");
+#endif
+    }
+  }
+  return false;
+}
+
 void TensorV2::allocate() { itensor->allocate(); }
 
 void TensorV2::deallocate() { itensor->deallocate(); }

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -200,7 +200,43 @@ public:
   /**
    * @brief Basic Destructor
    */
-  ~TensorV2() { free(itensor); }
+  ~TensorV2() = default;
+
+  /**
+   *  @brief  Copy constructor of Tensor.
+   *  @param[in] Tensor &
+   */
+  TensorV2(const TensorV2 &rhs) = default;
+
+  /**
+   *  @brief  Move constructor of Tensor.
+   *  @param[in] Tensor &&
+   */
+  TensorV2(TensorV2 &&rhs) noexcept = default;
+
+  /**
+   * @brief  Copy assignment operator.
+   * @param[in] rhs Tensor to be copied.
+   */
+  TensorV2 &operator=(const TensorV2 &rhs) = default;
+
+  /**
+   * @brief  Move assignment operator.
+   * @parma[in] rhs Tensor to be moved.
+   */
+  TensorV2 &operator=(TensorV2 &&rhs) noexcept = default;
+
+  /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs Tensor to be compared with
+   */
+  bool operator==(const TensorV2 &rhs) const;
+
+  /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs Tensor to be compared with
+   */
+  bool operator!=(const TensorV2 &rhs) const { return !(*this == rhs); }
 
   /**
    * @brief    Allocate memory for this tensor


### PR DESCRIPTION
This PR includes the implementation of comparison operators for TensorV2-related classes.

**Changes proposed in this PR:**
- TensorBase comparison operator compares Tensor information such as TensorDim.
- Float/HalfTensor comparison operator checks Tensor data.
- Destructor implementation is removed and set to default due to the rule of five.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped