### PR TITLE
[Tensor] Support additional weight initialization @open sesame 1/5 11:58

### DIFF
--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -168,10 +168,44 @@ void FloatTensor::setZero() {
   }
 }
 
-/// @todo support additional initializer
+void FloatTensor::setRandNormal(float mean, float stddev) {
+  setDist<std::normal_distribution<float>>(
+    std::normal_distribution<float>(mean, stddev));
+}
+
+void FloatTensor::setRandUniform(float min, float max) {
+  setDist<std::uniform_real_distribution<float>>(
+    std::uniform_real_distribution<float>(min, max));
+}
+
+void FloatTensor::setRandBernoulli(float probability) {
+  setDist<std::bernoulli_distribution>(
+    std::bernoulli_distribution(probability));
+}
+
 void FloatTensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  unsigned int fan_in, fan_out;
+
+  /// @fixme: when unit is equal to one, this does not work, we need to rely on
+  /// effective dimension then actual numbers here. For now, some heuristics
+  /// added to infer what would be fan_in/fan_out
+  if (dim.batch() * dim.channel() * dim.height() == 1) {
+    fan_out = fan_in = dim.width();
+  } else if (dim.batch() * dim.channel() == 1) { /// fc layer - 2-D tensor
+    fan_in = dim.height();
+    fan_out = dim.width();
+  } else { /// conv2d filters - 4d tensor, @todo extend this to > 4
+    auto field_size = dim.height() * dim.width();
+
+    // this also handles below cases.
+    // 1. fan_in = fan_out = 1 as well.
+    // 2. batch == 1, channel == 1 and height == 1, theoretical rank of 1
+    fan_in = dim.channel() * field_size;
+    fan_out = dim.batch() * field_size;
+  }
 
   switch (initializer) {
   case Initializer::ZEROS:
@@ -180,6 +214,25 @@ void FloatTensor::initialize() {
   case Initializer::ONES:
     setValue(1.0f);
     break;
+  case Initializer::LECUN_NORMAL:
+    setRandNormal(0.0f, sqrtFloat(1.0f / fan_in));
+    break;
+  case Initializer::XAVIER_NORMAL:
+    setRandNormal(0.0f, sqrtFloat(2.0f / (fan_in + fan_out)));
+    break;
+  case Initializer::HE_NORMAL:
+    setRandNormal(0.0f, sqrtFloat(2.0f / (fan_in)));
+    break;
+  case Initializer::LECUN_UNIFORM:
+    setRandUniform(-1.0f * sqrtFloat(1.0f / fan_in), sqrtFloat(1.0f / fan_in));
+    break;
+  case Initializer::XAVIER_UNIFORM:
+    setRandUniform(-1.0f * sqrtFloat(6.0f / (fan_in + fan_out)),
+                   sqrtFloat(6.0 / (fan_in + fan_out)));
+    break;
+  case Initializer::HE_UNIFORM:
+    setRandUniform(-1.0f * sqrtFloat(6.0f / (fan_in)),
+                   sqrtFloat(6.0 / (fan_in)));
   default:
     break;
   }

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -118,6 +118,37 @@ public:
   void setZero() override;
 
   /**
+   * @brief Set the Dist object
+   * @param dist distribution engine
+   */
+  template <typename Engine> void setDist(Engine dist) {
+    NNTR_THROW_IF(!contiguous, std::invalid_argument)
+      // << getName() << " Tensor is not contiguous, cannot set distribution";
+      << " Tensor is not contiguous, cannot set distribution";
+
+    float *data_ = (float *)getData();
+    unsigned int len = size();
+    for (unsigned int i = 0; i < len; ++i) {
+      data_[i] = (float)dist(rng);
+    }
+  };
+
+  /**
+   * @copydoc TensorV2::setRandNormal()
+   */
+  void setRandNormal(float mean = 0.0f, float stddev = 0.05f);
+
+  /**
+   * @copydoc TensorV2::setRandUniform()
+   */
+  void setRandUniform(float min = -0.05f, float max = 0.05f);
+
+  /**
+   * @copydoc TensorV2::setRandBernoulli()
+   */
+  void setRandBernoulli(float probability = 0.5f);
+
+  /**
    * @copydoc TensorV2::initialize()
    */
   void initialize() override;

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -170,10 +170,44 @@ void HalfTensor::setZero() {
   }
 }
 
-/// @todo support additional initializer
+void HalfTensor::setRandNormal(float mean, float stddev) {
+  setDist<std::normal_distribution<float>>(
+    std::normal_distribution<float>(mean, stddev));
+}
+
+void HalfTensor::setRandUniform(float min, float max) {
+  setDist<std::uniform_real_distribution<float>>(
+    std::uniform_real_distribution<float>(min, max));
+}
+
+void HalfTensor::setRandBernoulli(float probability) {
+  setDist<std::bernoulli_distribution>(
+    std::bernoulli_distribution(probability));
+}
+
 void HalfTensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  unsigned int fan_in, fan_out;
+
+  /// @fixme: when unit is equal to one, this does not work, we need to rely on
+  /// effective dimension then actual numbers here. For now, some heuristics
+  /// added to infer what would be fan_in/fan_out
+  if (dim.batch() * dim.channel() * dim.height() == 1) {
+    fan_out = fan_in = dim.width();
+  } else if (dim.batch() * dim.channel() == 1) { /// fc layer - 2-D tensor
+    fan_in = dim.height();
+    fan_out = dim.width();
+  } else { /// conv2d filters - 4d tensor, @todo extend this to > 4
+    auto field_size = dim.height() * dim.width();
+
+    // this also handles below cases.
+    // 1. fan_in = fan_out = 1 as well.
+    // 2. batch == 1, channel == 1 and height == 1, theoretical rank of 1
+    fan_in = dim.channel() * field_size;
+    fan_out = dim.batch() * field_size;
+  }
 
   switch (initializer) {
   case Initializer::ZEROS:
@@ -182,6 +216,25 @@ void HalfTensor::initialize() {
   case Initializer::ONES:
     setValue(1.0f);
     break;
+  case Initializer::LECUN_NORMAL:
+    setRandNormal(0.0f, sqrtFloat(1.0f / fan_in));
+    break;
+  case Initializer::XAVIER_NORMAL:
+    setRandNormal(0.0f, sqrtFloat(2.0f / (fan_in + fan_out)));
+    break;
+  case Initializer::HE_NORMAL:
+    setRandNormal(0.0f, sqrtFloat(2.0f / (fan_in)));
+    break;
+  case Initializer::LECUN_UNIFORM:
+    setRandUniform(-1.0f * sqrtFloat(1.0f / fan_in), sqrtFloat(1.0f / fan_in));
+    break;
+  case Initializer::XAVIER_UNIFORM:
+    setRandUniform(-1.0f * sqrtFloat(6.0f / (fan_in + fan_out)),
+                   sqrtFloat(6.0 / (fan_in + fan_out)));
+    break;
+  case Initializer::HE_UNIFORM:
+    setRandUniform(-1.0f * sqrtFloat(6.0f / (fan_in)),
+                   sqrtFloat(6.0 / (fan_in)));
   default:
     break;
   }

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -117,6 +117,37 @@ public:
   void setZero() override;
 
   /**
+   * @brief Set the Dist object
+   * @param dist distribution engine
+   */
+  template <typename Engine> void setDist(Engine dist) {
+    NNTR_THROW_IF(!contiguous, std::invalid_argument)
+      // << getName() << " Tensor is not contiguous, cannot set distribution";
+      << " Tensor is not contiguous, cannot set distribution";
+
+    _FP16 *data_ = (_FP16 *)getData();
+    unsigned int len = size();
+    for (unsigned int i = 0; i < len; ++i) {
+      data_[i] = (_FP16)dist(rng);
+    }
+  };
+
+  /**
+   * @copydoc TensorV2::setRandNormal()
+   */
+  void setRandNormal(float mean = 0.0f, float stddev = 0.05f);
+
+  /**
+   * @copydoc TensorV2::setRandUniform()
+   */
+  void setRandUniform(float min = -0.05f, float max = 0.05f);
+
+  /**
+   * @copydoc TensorV2::setRandBernoulli()
+   */
+  void setRandBernoulli(float probability = 0.5f);
+
+  /**
    * @copydoc TensorV2::initialize()
    */
   void initialize() override;

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -17,7 +17,9 @@
 #include <stdexcept>
 
 #include <memory_data.h>
+#include <nntrainer_error.h>
 #include <tensor_dim.h>
+#include <util_func.h>
 
 namespace nntrainer {
 
@@ -139,6 +141,21 @@ public:
    * @copydoc TensorV2::setZero()
    */
   virtual void setZero() = 0;
+
+  /**
+   * @copydoc TensorV2::setRandNormal()
+   */
+  virtual void setRandNormal(float mean, float stddev) = 0;
+
+  /**
+   * @copydoc TensorV2::setRandBernoulli()
+   */
+  virtual void setRandUniform(float min, float max) = 0;
+
+  /**
+   * @copydoc TensorV2::setRandBernoulli()
+   */
+  virtual void setRandBernoulli(float probability) = 0;
 
   /**
    * @copydoc TensorV2::initialize()

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -105,6 +105,18 @@ void TensorV2::setValue(unsigned int b, unsigned int c, unsigned int h,
 
 void TensorV2::setZero() { itensor->setZero(); }
 
+void TensorV2::setRandNormal(float mean, float stddev) {
+  itensor->setRandNormal(mean, stddev);
+}
+
+void TensorV2::setRandUniform(float min, float max) {
+  itensor->setRandUniform(min, max);
+}
+
+void TensorV2::setRandBernoulli(float probability) {
+  itensor->setRandBernoulli(probability);
+}
+
 void TensorV2::initialize() { itensor->initialize(); }
 
 void TensorV2::initialize(Initializer init) { itensor->initialize(init); }

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -314,6 +314,26 @@ public:
   void setZero();
 
   /**
+   * @brief     Set the tensor with random normal distribution
+   * @param[in] mean mean of the distribution
+   * @param[in] std standard deviation of the distribution
+   */
+  void setRandNormal(float mean = 0.0f, float stddev = 0.05f);
+
+  /**
+   * @brief     Set the tensor with random uniform distribution
+   * @param[in] min minimum value for the distribution
+   * @param[in] max maximum value for the distribution
+   */
+  void setRandUniform(float min = -0.05f, float max = 0.05f);
+
+  /**
+   * @brief     Set the tensor with random bernoulli distribution
+   * @param[in] probability probability value for the distribution
+   */
+  void setRandBernoulli(float probability = 0.5f);
+
+  /**
    * @brief     Initialize the memory of the given tensor
    */
   void initialize();


### PR DESCRIPTION
This PR enables additional weight initializers with a probability distribution.

**Changes proposed in this PR:**
- Functions to set tensor with random distribution are implemented.
- Tensor now supports various initializers besides zero and one.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped