### PR TITLE
[Tensor] Fix comparison operator

### DIFF
--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -92,7 +92,7 @@ bool HalfTensor::operator==(const HalfTensor &rhs) const {
   const _FP16 *_data = (_FP16 *)getData();
   const _FP16 *_rdata = (_FP16 *)rhs.getData();
   for (size_t i = 0; i < size(); ++i) {
-    if (std::isnan(_data[i]) || std::isnan(_rdata[i]) ||
+    if (std::isnan((float)_data[i]) || std::isnan((float)_rdata[i]) ||
         std::fabs((float)(_data[i] - _rdata[i])) > epsilon)
       return false;
   }

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -228,8 +228,7 @@ bool Tensor::operator==(const Tensor &rhs) const {
     for (size_t i = 0; i < len; ++i) {
       /** not checking sign change is intentional to avoid float calculation
        * errors around 0 */
-      if ((std::isnan(_data[i]) && !std::isnan(_rdata[i])) ||
-          (!std::isnan(_data[i]) && std::isnan(_rdata[i])) ||
+      if (std::isnan(_data[i]) || std::isnan(_rdata[i]) ||
           std::fabs(_data[i] - _rdata[i]) > epsilon)
         return false;
     }


### PR DESCRIPTION
A tensor containing a NaN value cannot be equal to any other tensors since NaNs are never equal. Therefore, comparison operator logic changed in handling NaN values.

**Changes proposed in this PR:**
- Comparison operator returns false if tensor has a NaN value.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped