### PR TITLE
[ layer ] SIMD function for Rotary embedding incremental forwarding

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -39,3 +39,4 @@
 # @todo filter out headers that should be hidden
 /usr/include/nntrainer/util_func.h
 /usr/include/nntrainer/fp16.h
+/usr/include/nntrainer/util_simd.h

--- a/nntrainer/utils/meson.build
+++ b/nntrainer/utils/meson.build
@@ -5,7 +5,8 @@ util_sources = [
   'node_exporter.cpp',
   'base_properties.cpp',
   'nntr_threads.cpp',
-  'fp16.cpp'
+  'fp16.cpp',
+  'util_simd.cpp',
 ]
 
 util_headers = [
@@ -14,12 +15,18 @@ util_headers = [
   'util_func.h',
   'profiler.h',
   'nntr_threads.h',
-  'fp16.h'
+  'fp16.h',
+  'util_simd.h',
 ]
 
 if get_option('enable-trace')
   util_sources += 'tracer.cpp'
   util_headers += 'tracer.h'
+endif
+
+if get_option('platform') == 'android'
+  util_sources += 'util_simd_neon.cpp'
+  util_headers += 'util_simd_neon.h'
 endif
 
 foreach s : util_sources

--- a/nntrainer/utils/util_simd.cpp
+++ b/nntrainer/utils/util_simd.cpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file	util_simd.cpp
+ * @date	09 Jan 2024
+ * @brief	This is a collection of simd util functions
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Sungsik Kong <ss.kong@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#include <util_simd.h>
+#ifdef USE_NEON
+#include <util_simd_neon.h>
+#endif
+
+namespace nntrainer {
+
+void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
+                                 float *sin_, unsigned int alpha) {
+#ifdef USE_NEON
+  nntrainer::neon::calc_trigonometric_vals_dup_neon(N_half, angle, cos_, sin_,
+                                                    alpha);
+#else
+  throw std::invalid_argument(
+    "Error: No implementation of rotary embedding layer incremental_forwarding "
+    "with SIMD acceleration except for NEON!");
+#endif
+}
+
+#ifdef ENABLE_FP16
+
+void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
+                                    unsigned int w, _FP16 *in, _FP16 *out,
+                                    float *cos_, float *sin_) {
+#ifdef USE_NEON
+  nntrainer::neon::compute_rotary_embedding_value_neon(dim, half_, w, in, out,
+                                                       cos_, sin_);
+#else
+  throw std::invalid_argument(
+    "Error: No implementation of rotary embedding layer incremental_forwarding "
+    "with SIMD acceleration except for NEON!");
+#endif
+}
+#endif
+
+} // namespace nntrainer

--- a/nntrainer/utils/util_simd.h
+++ b/nntrainer/utils/util_simd.h
@@ -15,7 +15,6 @@
 
 #include <nntrainer_error.h>
 #include <tensor_dim.h>
-#include <util_simd_neon.h>
 
 namespace nntrainer {
 

--- a/nntrainer/utils/util_simd.h
+++ b/nntrainer/utils/util_simd.h
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file	util_simd.h
+ * @date	09 Jan 2024
+ * @brief	This is a collection of simd util functions
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Sungsik Kong <ss.kong@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#ifndef __UTIL_SIMD_H__
+#define __UTIL_SIMD_H__
+
+#ifdef __cplusplus
+
+#include <nntrainer_error.h>
+#include <tensor_dim.h>
+#include <util_simd_neon.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Get half-sized angles, transform them into each cos, sin, and scopy in
+ * the same vector : cos_ = cos(freq).extend(cos(freq)), sin_ =
+ * sin(freq).extend(sin_(req))
+ *
+ * @param N_half : size of angle
+ * @param freqs float* for Vector angle
+ * @param cos_ float* for cos_
+ * @param sin_ float* for sin_
+ * @param alpha scaling factor
+ */
+void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
+                                 float *sin_, unsigned int alpha = 1.0);
+
+#ifdef ENABLE_FP16
+/**
+ * @brief Accelerating function for rotary embedding layer forwarding
+ *
+ * @param dim unit length of simd computation
+ * @param half_ criterion for rotational direction of embedding
+ * @param w current w value from b, c, h, w
+ * @param in _FP16* input
+ * @param out _FP16* output
+ * @param cos_ precomputed cos_ for corresponding rotational indices
+ * @param sin_ precomputed sin_ for corresponding rotational indices
+ */
+void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
+                                    unsigned int w, _FP16 *in, _FP16 *out,
+                                    float *cos_, float *sin_);
+#endif
+
+} /* namespace nntrainer */
+
+#endif /* __cplusplus */
+#endif /* __UTIL_SIMD_H__ */

--- a/nntrainer/utils/util_simd_neon.cpp
+++ b/nntrainer/utils/util_simd_neon.cpp
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file	util_simd_neon.cpp
+ * @date	09 Jan 2024
+ * @brief	This is a collection of simd util neon functions
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Sungsik Kong <ss.kong@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#include <blas_neon.h>
+#include <util_simd_neon.h>
+
+namespace nntrainer::neon {
+
+void calc_trigonometric_vals_dup_neon(unsigned int N_half, float *angle,
+                                             float *cos_, float *sin_,
+                                             unsigned int from) {
+  cosine_transformation_neon(N_half, angle, cos_, from);
+  sine_transformation_neon(N_half, angle, sin_, from);
+
+  unsigned int N = 2 * N_half;
+  unsigned int i = N_half;
+  unsigned int i_half = 0;
+
+  for (; (N - i >= 4) && (N_half - i_half >= 4);
+       i += 4, i_half += 4) {
+    vst1q_f32(&cos_[i], vld1q_f32(&cos_[i_half]));
+    vst1q_f32(&sin_[i], vld1q_f32(&sin_[i_half]));
+  }
+  while (i < N || i_half < N_half) {
+    cos_[i] = cos_[i_half];
+    sin_[i] = sin_[i_half];
+    ++i;
+    ++i_half;
+  }
+}
+
+#ifdef ENABLE_FP16
+void compute_rotary_embedding_value_neon(unsigned int dim, unsigned int half_,
+                                         unsigned int w, __fp16 *in,
+                                         __fp16 *out, float *cos_,
+                                         float *sin_) {
+  unsigned int k = 0;
+  while (k < dim) {
+    unsigned int span = w + k;
+
+    if (k < half_) { // upper half
+      if (half_ - k >= 8) {
+        float16x8_t values0_7 = vld1q_f16(&in[span]);
+        float16x8_t transformed_values0_7 =
+          vmulq_n_f16(vld1q_f16(&in[span + half_]), -1);
+        float32x4_t cos0_3 = vld1q_f32(&cos_[k]);
+        float32x4_t cos4_7 = vld1q_f32(&cos_[k + 4]);
+        float32x4_t sin0_3 = vld1q_f32(&sin_[k]);
+        float32x4_t sin4_7 = vld1q_f32(&sin_[k + 4]);
+
+        float32x4_t values0_3 = vaddq_f32(
+          vmulq_f32(vcvt_f32_f16(vget_low_f16(values0_7)), cos0_3),
+          vmulq_f32(vcvt_f32_f16(vget_low_f16(transformed_values0_7)), sin0_3));
+        float32x4_t values4_7 = vaddq_f32(
+          vmulq_f32(vcvt_f32_f16(vget_high_f16(values0_7)), cos4_7),
+          vmulq_f32(vcvt_f32_f16(vget_high_f16(transformed_values0_7)),
+                    sin4_7));
+
+        vst1q_f16(&out[span], vcombine_f16(vcvt_f16_f32(values0_3),
+                                           vcvt_f16_f32(values4_7)));
+
+        k += 8;
+      } else {
+        float value = in[span];
+        float transformed_value = -1 * in[span + half_];
+
+        value = (value * cos_[k]) + (transformed_value * sin_[k]);
+
+        out[span] = value;
+
+        ++k;
+      }
+    } else { // lower half : k >= half_
+      if (dim - k >= 8) {
+        float16x8_t values0_7 = vld1q_f16(&in[span]);
+        float16x8_t transformed_values0_7 = vld1q_f16(&in[span - half_]);
+        float32x4_t cos0_3 = vld1q_f32(&cos_[k]);
+        float32x4_t cos4_7 = vld1q_f32(&cos_[k + 4]);
+        float32x4_t sin0_3 = vld1q_f32(&sin_[k]);
+        float32x4_t sin4_7 = vld1q_f32(&sin_[k + 4]);
+
+        float32x4_t values0_3 = vaddq_f32(
+          vmulq_f32(vcvt_f32_f16(vget_low_f16(values0_7)), cos0_3),
+          vmulq_f32(vcvt_f32_f16(vget_low_f16(transformed_values0_7)), sin0_3));
+        float32x4_t values4_7 = vaddq_f32(
+          vmulq_f32(vcvt_f32_f16(vget_high_f16(values0_7)), cos4_7),
+          vmulq_f32(vcvt_f32_f16(vget_high_f16(transformed_values0_7)),
+                    sin4_7));
+
+        vst1q_f16(&out[span], vcombine_f16(vcvt_f16_f32(values0_3),
+                                           vcvt_f16_f32(values4_7)));
+
+        k += 8;
+      } else {
+        float value = in[span];
+        float transformed_value = in[span - half_];
+
+        value = (value * cos_[k]) + (transformed_value * sin_[k]);
+
+        out[span] = value;
+
+        ++k;
+      }
+    }
+  }
+}
+#endif
+
+} // namespace nntrainer::neon

--- a/nntrainer/utils/util_simd_neon.h
+++ b/nntrainer/utils/util_simd_neon.h
@@ -15,6 +15,9 @@
 #ifdef USE_NEON
 #include <arm_neon.h>
 #endif
+
+#define VL_FP32 4
+#define VL_FP16 8
 namespace nntrainer::neon {
 
 /**

--- a/nntrainer/utils/util_simd_neon.h
+++ b/nntrainer/utils/util_simd_neon.h
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file	util_simd_neon.h
+ * @date	09 Jan 2024
+ * @brief	This is a collection of simd util neon functions
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Sungsik Kong <ss.kong@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#ifndef __UTIL_SIMD_NEON_H__
+#define __UTIL_SIMD_NEON_H__
+
+#ifdef __cplusplus
+#ifdef USE_NEON
+#include <arm_neon.h>
+#endif
+namespace nntrainer::neon {
+
+/**
+ * @brief Get half-sized angles, transform them into each cos, sin, and scopy in
+ * the same vector : cos_ = cos(freq).extend(cos(freq)), sin_ =
+ * sin(freq).extend(sin_(req))
+ *
+ * @param N_half : size of angle
+ * @param angle float* for Vector (radian) angle
+ * @param cos_ float* for cos_
+ * @param sin_ float* for sin_
+ * @param alpha scaling factor
+ */
+void calc_trigonometric_vals_dup_neon(unsigned int N_half, float *angle,
+                                      float *cos_, float *sin_,
+                                      unsigned int alpha = 1.0);
+
+#ifdef ENABLE_FP16
+/**
+ * @brief Accelerating function for rotary embedding layer forwarding
+ *
+ * @param dim unit length of simd computation
+ * @param half_ criterion for rotational direction of embedding
+ * @param w current w value from b, c, h, w
+ * @param in __fp16* input
+ * @param out __fp16* output
+ * @param cos_ precomputed cos_ for corresponding rotational indices
+ * @param sin_ precomputed sin_ for corresponding rotational indices
+ */
+void compute_rotary_embedding_value_neon(unsigned int dim, unsigned int half_,
+                                         unsigned int w, __fp16 *in,
+                                         __fp16 *out, float *cos_, float *sin_);
+
+#endif
+
+} // namespace nntrainer::neon
+
+#endif /* __cplusplus */
+#endif /* __UTIL_SIMD_NEON_H__ */

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -562,6 +562,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 # @todo filter out headers that should be hidden, and classifiy in the appropriate place if not
 %{_includedir}/nntrainer/util_func.h
 %{_includedir}/nntrainer/fp16.h
+%{_includedir}/nntrainer/util_simd.h
 
 %files devel-static
 %{_libdir}/libnntrainer*.a


### PR DESCRIPTION
[ util ] Add util_simd file
    
- Here I would like to introduce util_simd. I had no choice but to differentiate this file with blas for following reasons:
      1. This is actually not 'Basic Linear Algebra Subprogram' indeed
      2. This code is only used in very specific occasion.

[ layer ] Apply neon simd acceleration in rotary embedding computation
    
- Previous rotary embedding computation code was naively implemented with for-loop
- Using simd code, I expect this code to behave efficiently in time cost perspective, without precision loss
- Current implementation only supports Neon simd (ARMv8)

    **Self evaluation:**
    1. Build test:   [X]Passed [ ]Failed [ ]Skipped
    2. Run test:     [X]Passed [ ]Failed [ ]Skipped
    
    Signed-off-by: skykongkong8 <ss.kong@samsung.com>