### PR TITLE
Remove dependencies on FP16 support status.

### DIFF
--- a/Applications/YOLO/jni/yolo_v2_loss.cpp
+++ b/Applications/YOLO/jni/yolo_v2_loss.cpp
@@ -178,11 +178,7 @@ calc_iou(nntrainer::Tensor &bbox1_x1, nntrainer::Tensor &bbox1_y1,
   if (type_intersection_width == ml::train::TensorDim::DataType::FP32) {
     intersection_width.apply_i<float>(nntrainer::ActiFunc::relu<float>);
   } else if (type_intersection_width == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     intersection_width.apply_i<_FP16>(nntrainer::ActiFunc::relu<_FP16>);
-#else
-    throw std::runtime_error("Not supported data type");
-#endif
   }
 
   intersection_y2.subtract(intersection_y1, intersection_height);
@@ -191,11 +187,7 @@ calc_iou(nntrainer::Tensor &bbox1_x1, nntrainer::Tensor &bbox1_y1,
   if (type_intersection_height == ml::train::TensorDim::DataType::FP32) {
     intersection_height.apply_i<float>(nntrainer::ActiFunc::relu<float>);
   } else if (type_intersection_height == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     intersection_height.apply_i<_FP16>(nntrainer::ActiFunc::relu<_FP16>);
-#else
-    throw std::runtime_error("Not supported data type");
-#endif
   }
 
   nntrainer::Tensor intersection =
@@ -238,12 +230,8 @@ std::vector<nntrainer::Tensor> calc_iou_grad(
     intersection_width_relu_prime =
       intersection_width.apply<float>(nntrainer::ActiFunc::reluPrime<float>);
   } else if (type_intersection_width == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     intersection_height_relu_prime =
       intersection_height.apply<_FP16>(nntrainer::ActiFunc::reluPrime<_FP16>);
-#else
-    throw std::runtime_error("Not supported data type");
-#endif
   }
 
   nntrainer::Tensor intersection_x2_local_grad =
@@ -539,22 +527,14 @@ void YoloV2LossLayer::forwarding(nntrainer::RunLayerContext &context,
   if (type_bbox_w_pred == ml::train::TensorDim::DataType::FP32) {
     bbox_w_pred.apply_i<float>(nntrainer::exp_util<float>);
   } else if (type_bbox_w_pred == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     bbox_w_pred.apply_i<_FP16>(nntrainer::exp_util<_FP16>);
-#else
-    throw std::runtime_error("Not supported data type");
-#endif
   }
 
   auto type_bbox_h_pred = bbox_h_pred.getDataType();
   if (type_bbox_h_pred == ml::train::TensorDim::DataType::FP32) {
     bbox_h_pred.apply_i<float>(nntrainer::exp_util<float>);
   } else if (type_bbox_h_pred == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     bbox_h_pred.apply_i<_FP16>(nntrainer::exp_util<_FP16>);
-#else
-    throw std::runtime_error("Not supported data type");
-#endif
   }
 
   sigmoid.run_fn(confidence_pred, confidence_pred);
@@ -569,11 +549,7 @@ void YoloV2LossLayer::forwarding(nntrainer::RunLayerContext &context,
   if (type_bbox_w_pred_anchor == ml::train::TensorDim::DataType::FP32) {
     bbox_w_pred_anchor.apply_i<float>(nntrainer::sqrtFloat<float>);
   } else if (type_bbox_w_pred_anchor == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     bbox_w_pred_anchor.apply_i<_FP16>(nntrainer::sqrtFloat<_FP16>);
-#else
-    throw std::runtime_error("Not supported data type");
-#endif
   }
 
   bbox_h_pred_anchor.multiply_i(anchors_h);
@@ -581,11 +557,7 @@ void YoloV2LossLayer::forwarding(nntrainer::RunLayerContext &context,
   if (type_bbox_h_pred_anchor == ml::train::TensorDim::DataType::FP32) {
     bbox_h_pred_anchor.apply_i<float>(nntrainer::sqrtFloat<float>);
   } else if (type_bbox_h_pred_anchor == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     bbox_h_pred_anchor.apply_i<_FP16>(nntrainer::sqrtFloat<_FP16>);
-#else
-    throw std::runtime_error("Not supported data type");
-#endif
   }
 
   generate_ground_truth(context);
@@ -810,11 +782,7 @@ unsigned int YoloV2LossLayer::find_responsible_anchors(float bbox_ratio) {
   if (data_type == ml::train::TensorDim::DataType::FP32) {
     similarity.apply_i<float>(nntrainer::absFloat<float>);
   } else if (data_type == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     similarity.apply_i<_FP16>(nntrainer::absFloat<_FP16>);
-#else
-    throw std::runtime_error("Not supported data type");
-#endif
   }
   auto data = similarity.getData();
 

--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -204,7 +204,6 @@ public:
   virtual void getWeights(std::vector<float *> &weights,
                           std::vector<ml::train::TensorDim> &weights_dim) = 0;
 
-#ifdef ENABLE_FP16
   /**
    * @brief     Get weight data of the layer
    * @retval    weight data of the layer
@@ -225,7 +224,7 @@ public:
   virtual void
   getFP16Weights(std::vector<_FP16 *> &weights,
                  std::vector<ml::train::TensorDim> &weights_dim) = 0;
-#endif
+
   /**
    * @brief     Set weight data of the layer
    * @note      Size of vector must be the same with number of weights.

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -54,6 +54,9 @@ public:
   template <typename T = float> void setActiFunc(ActivationType acti_type) {
     activation_type = acti_type;
 
+    if (typeid(T) == typeid(_FP16))
+      THROW_UNLESS_FP16_ENABLED;
+
     switch (acti_type) {
     case ActivationType::ACT_TANH:
       this->setActivation<T>(tanhFloat<T>, tanhPrime<T>);

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -44,11 +44,7 @@ void ActivationLayer::finalize(InitLayerContext &context) {
   NNTR_THROW_IF(act.empty(), std::invalid_argument)
     << "activation has not been set!";
   if (context.getActivationDataType() == TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     acti_func.setActiFunc<_FP16>(act.get());
-#else
-    NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
-#endif
   } else if (context.getActivationDataType() == TensorDim::DataType::FP32) {
     acti_func.setActiFunc<float>(act.get());
   }

--- a/nntrainer/layers/attention_layer.cpp
+++ b/nntrainer/layers/attention_layer.cpp
@@ -74,11 +74,7 @@ void AttentionLayer::finalize(InitLayerContext &context) {
   if (data_type == ml::train::TensorDim::DataType::FP32) {
     sm.setActiFunc<float>(ActivationType::ACT_SOFTMAX);
   } else if (data_type == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     sm.setActiFunc<_FP16>(ActivationType::ACT_SOFTMAX);
-#else
-    throw std::runtime_error("enable-fp16 is not enabled");
-#endif
   }
 }
 

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -143,7 +143,7 @@ void ConcatLayer::forwarding(RunLayerContext &context, bool training) {
         }
       }
     } else if (in_dim.getDataType() == TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+      THROW_UNLESS_FP16_ENABLED;
       /** loop over the dimensions before the concat dimension */
       for (unsigned int batch = 0; batch < output.batch(); batch++) {
         /** loop over the concat dimension itself */
@@ -159,9 +159,6 @@ void ConcatLayer::forwarding(RunLayerContext &context, bool training) {
           dest_tensor.copy(source_tensor);
         }
       }
-#else
-      throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
     }
 
     input.reshape(in_dim);
@@ -229,7 +226,7 @@ void ConcatLayer::calcDerivative(RunLayerContext &context) {
   unsigned int data_copy_size = output_reshape_helper.width();
   TensorDim::TensorType tensor_type = output.getTensorType();
 
- for (unsigned int idx = 0; idx < context.getNumInputs(); idx++) {
+  for (unsigned int idx = 0; idx < context.getNumInputs(); idx++) {
     Tensor &input = context.getOutgoingDerivative(idx);
     const TensorDim in_dim = input.getDim();
     auto const &irh = input_reshape_helper[idx];
@@ -252,7 +249,7 @@ void ConcatLayer::calcDerivative(RunLayerContext &context) {
         }
       }
     } else if (in_dim.getDataType() == TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+      THROW_UNLESS_FP16_ENABLED;
       /** loop over the dimensions before the concat dimension */
       for (unsigned int batch = 0; batch < output.batch(); batch++) {
         /** loop over the concat dimension itself */
@@ -268,9 +265,6 @@ void ConcatLayer::calcDerivative(RunLayerContext &context) {
           dest_tensor.copy(source_tensor);
         }
       }
-#else
-      throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
     }
 
     input.reshape(in_dim);

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -174,7 +174,7 @@ void EmbeddingLayer::calcGradient(RunLayerContext &context) {
   // This is to calculate gradient with current implementation of optimizer.
   // In order to accelerate, we need to better way like using index to weight.
 
- /// @todo
+  /// @todo
   // Current nntrainer gradient Tensor shape is identical to its
   // weight shape. However, this creates a sparse Tensor since we are only using
   // certain indices of the Tensor that we are interested in. Since we have such
@@ -201,7 +201,7 @@ void EmbeddingLayer::calcGradient(RunLayerContext &context) {
                        std::plus<float>());
       }
     } else if (djdw.getDataType() == TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+      THROW_UNLESS_FP16_ENABLED;
       for (unsigned int i = 0; i < input_.width(); ++i) {
         uint embed_idx = ((float *)(in_data))[i];
         // Assume padding is 0 and index always start from 1.
@@ -216,9 +216,6 @@ void EmbeddingLayer::calcGradient(RunLayerContext &context) {
         std::transform(djdw_data, djdw_data + out_dim, grad_data, djdw_data,
                        std::plus<_FP16>());
       }
-#else
-      throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
     }
   }
 }

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -507,13 +507,10 @@ bool RunLayerContext::validate(bool skip_input, bool skip_label) {
           tensor_map[val->getGradientName()] = val->getGradientRef().getData();
         } else if (val->getVariableRef().getTensorType().data_type ==
                    TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+          THROW_UNLESS_FP16_ENABLED;
           tensor_map[val->getName()] = val->getVariableRef().getData<_FP16>();
           tensor_map[val->getGradientName()] =
             val->getGradientRef().getData<_FP16>();
-#else
-          throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
         }
       }
     };

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -559,16 +559,13 @@ public:
 
       if (getWeight(idx).getDataType() ==
           ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+        THROW_UNLESS_FP16_ENABLED;
         _FP16 *data = getWeight(idx).getData<_FP16>();
         float *d = new float[getWeight(idx).size()]();
         weights.emplace_back(d);
         for (unsigned int i = 0; i < getWeight(idx).size(); ++i) {
           weights[idx][i] = static_cast<float>(data[i]);
         }
-#else
-        throw std::runtime_error("enable-fp16 is not set");
-#endif
       } else {
         weights.emplace_back(getWeight(idx).getData());
       }
@@ -597,7 +594,6 @@ public:
     }
     return;
   }
-#ifdef ENABLE_FP16
   /**
    * @brief     Get weight data of the layer
    * @retval    weight data of the layer
@@ -606,6 +602,8 @@ public:
    * @note      layer needs to be finalized before called.
    */
   const std::vector<_FP16 *> getFP16Weights() override {
+    THROW_UNLESS_FP16_ENABLED;
+
     NNTR_THROW_IF(!run_context, std::runtime_error)
       << __func__ << " layer needs to be finalized first!";
 
@@ -626,6 +624,8 @@ public:
    */
   void getFP16Weights(std::vector<_FP16 *> &weights,
                       std::vector<TensorDim> &weight_dim) override {
+    THROW_UNLESS_FP16_ENABLED;
+
     NNTR_THROW_IF(!run_context, std::runtime_error)
       << __func__ << " layer needs to be finalized first!";
 
@@ -637,7 +637,6 @@ public:
     }
     return;
   }
-#endif
 
   /**
    * @brief     Set weight data of the layer

--- a/nntrainer/layers/loss/cross_entropy_softmax_loss_layer.cpp
+++ b/nntrainer/layers/loss/cross_entropy_softmax_loss_layer.cpp
@@ -44,7 +44,6 @@ void CrossEntropySoftmaxLossLayer::forwarding(RunLayerContext &context,
       LossLayer::updateLoss(context, l);
     }
   } else if (dataType == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     hidden_ = y.apply(ActiFunc::softmax<_FP16>, hidden_);
 
     if (context.isLabelAvailable(SINGLE_INOUT_IDX)) {
@@ -56,9 +55,6 @@ void CrossEntropySoftmaxLossLayer::forwarding(RunLayerContext &context,
       // update the loss value
       LossLayer::updateLoss(context, l);
     }
-#else
-    throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
   }
 }
 
@@ -74,11 +70,7 @@ void CrossEntropySoftmaxLossLayer::calcDerivative(RunLayerContext &context) {
   if (dataType == ml::train::TensorDim::DataType::FP32) {
     y.apply(ActiFunc::softmax<float>, ret);
   } else if (dataType == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     y.apply(ActiFunc::softmax<_FP16>, ret);
-#else
-    throw std::runtime_error("enable-fp16 is not enabled");
-#endif
   }
 
   /// @note y and ret_derivative can be same here, so this has to be out-place

--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -151,14 +151,10 @@ void LSTMLayer::calcGradientBatchFirstLSTM(
                   incoming_derivative.size(),
                 d_hidden_state_.getData<float>());
     } else if (incoming_derivative.getDataType() == TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
-      std::copy(incoming_derivative.getData<_FP16>(),
-                incoming_derivative.getData<_FP16>() +
-                  incoming_derivative.size(),
-                d_hidden_state_.getData<_FP16>());
-#else
-      throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
+      FP16_REQUIRED(std::copy(incoming_derivative.getData<_FP16>(),
+                              incoming_derivative.getData<_FP16>() +
+                                incoming_derivative.size(),
+                              d_hidden_state_.getData<_FP16>()));
     }
   } else {
     unsigned int end_timestep = return_sequences ? max_timestep : 1;
@@ -604,12 +600,8 @@ void LSTMLayer::finalize(InitLayerContext &context) {
     acti_func.setActiFunc<float>(hidden_state_activation_type);
     recurrent_acti_func.setActiFunc<float>(recurrent_activation_type);
   } else if (context.getActivationDataType() == TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     acti_func.setActiFunc<_FP16>(hidden_state_activation_type);
     recurrent_acti_func.setActiFunc<_FP16>(recurrent_activation_type);
-#else
-    throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
   }
 }
 
@@ -718,13 +710,10 @@ void LSTMLayer::forwarding(RunLayerContext &context, bool training) {
                 hidden_state.getData<float>() + hidden_state.size(),
                 output.getData<float>());
     } else if (hidden_state.getDataType() == TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
-      std::copy(hidden_state.getData<_FP16>(),
-                hidden_state.getData<_FP16>() + hidden_state.size(),
-                output.getData<_FP16>());
-#else
-      throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
+      FP16_REQUIRED(
+        std::copy(hidden_state.getData<_FP16>(),
+                  hidden_state.getData<_FP16>() + hidden_state.size(),
+                  output.getData<_FP16>()));
     }
   } else {
     unsigned int end_timestep = return_sequences ? max_timestep : 1;
@@ -755,7 +744,7 @@ void LSTMLayer::forwarding(RunLayerContext &context, bool training) {
         }
       }
     } else if (hidden_state.getDataType() == TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+      THROW_UNLESS_FP16_ENABLED;
       for (unsigned int batch = 0; batch < batch_size; ++batch) {
         for (unsigned int timestep = 0; timestep < end_timestep; ++timestep) {
           _FP16 *hidden_state_data = hidden_state.getAddress<_FP16>(
@@ -781,9 +770,6 @@ void LSTMLayer::forwarding(RunLayerContext &context, bool training) {
           }
         }
       }
-#else
-      throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
     }
   }
 }

--- a/nntrainer/layers/lstmcell.cpp
+++ b/nntrainer/layers/lstmcell.cpp
@@ -167,12 +167,8 @@ void LSTMCellLayer::finalize(InitLayerContext &context) {
     acti_func.setActiFunc<float>(hidden_state_activation_type);
     recurrent_acti_func.setActiFunc<float>(recurrent_activation_type);
   } else if (context.getActivationDataType() == TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
     acti_func.setActiFunc<_FP16>(hidden_state_activation_type);
     recurrent_acti_func.setActiFunc<_FP16>(recurrent_activation_type);
-#else
-    throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
   }
 }
 

--- a/nntrainer/layers/lstmcell_core.cpp
+++ b/nntrainer/layers/lstmcell_core.cpp
@@ -164,7 +164,7 @@ void LSTMCore::calcGradientLSTM(
 #endif
       }
     } else if (input.getDataType() == TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+      THROW_UNLESS_FP16_ENABLED;
       for (unsigned int i = 0; i < d_weight_ih.height(); ++i) {
         unsigned int out_width = d_weight_ih.width();
         _FP16 in_ih = input.getValue<_FP16>(i);
@@ -175,9 +175,6 @@ void LSTMCore::calcGradientLSTM(
           d_weight_ih_address[j] += d_ifgo_address[j] * in_ih;
         }
       }
-#else
-      throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
     }
   }
 
@@ -202,7 +199,7 @@ void LSTMCore::calcGradientLSTM(
 #endif
       }
     } else if (prev_hidden_state.getDataType() == TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+      THROW_UNLESS_FP16_ENABLED;
       for (unsigned int i = 0; i < d_weight_hh.height(); ++i) {
         unsigned int out_width = d_weight_hh.width();
         _FP16 in_hh = prev_hidden_state.getValue<_FP16>(i);
@@ -213,9 +210,6 @@ void LSTMCore::calcGradientLSTM(
           d_weight_hh_address[j] += d_ifgo_address[j] * in_hh;
         }
       }
-#else
-      throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
     }
   }
   d_ifgo.dot(weight_hh, d_prev_hidden_state, false, true);

--- a/nntrainer/layers/multi_head_attention_layer.h
+++ b/nntrainer/layers/multi_head_attention_layer.h
@@ -247,7 +247,7 @@ private:
         }
       }
     } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+      THROW_UNLESS_FP16_ENABLED;
       for (unsigned int b = 0; b < in.batch(); b++) {
         for (unsigned int c = 0; c < in.channel(); c++) {
           for (unsigned int h = 0; h < in.height(); h++) {
@@ -284,9 +284,6 @@ private:
           }
         }
       }
-#else
-      throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
     }
 
     if (from >= max_timestep) {

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -847,16 +847,13 @@ std::vector<float *> NeuralNetwork::incremental_inference(
   }
   for (auto &out : output_tensors) {
     if (out->getDataType() == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+      THROW_UNLESS_FP16_ENABLED;
       auto out_t = *out.get();
       float *vec_fp32 = new float[out_t.width()];
       for (unsigned int i = 0; i < out_t.width(); ++i) {
         (vec_fp32)[i] = static_cast<float>(out_t.getValue<_FP16>(0, 0, idx, i));
       }
       output.emplace_back(vec_fp32);
-#else
-      throw std::invalid_argument("Errro: enable-fp16 is not set");
-#endif
     } else {
       auto out_t = *out.get();
       TensorDim last_out_dim = out_t.getDim();

--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -73,7 +73,6 @@
 
 namespace nntrainer {
 
-#ifdef ENABLE_FP16
 static void saxpy_FP16(const unsigned int N, const float alpha, const _FP16 *X,
                        const int incX, _FP16 *Y, const int incY) {
   if (incX < 0 or incY < 0)
@@ -98,6 +97,7 @@ static void sgemv_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
                        const unsigned int lda, const _FP16 *X, const int incX,
                        const float beta, _FP16 *Y, const int incY) {
 
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
@@ -119,7 +119,7 @@ static void sgemv_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
 static _FP16 sdot_FP16(const unsigned int N, const _FP16 *X,
                        const unsigned int incX, const _FP16 *Y,
                        const unsigned int incY) {
-
+  THROW_UNLESS_FP16_ENABLED;
   if (incX < 0 or incY < 0)
     throw std::invalid_argument("Error: negative inc not supported");
 
@@ -143,6 +143,7 @@ static _FP16 sdot_FP16(const unsigned int N, const _FP16 *X,
 
 static void scopy_FP16(const unsigned int N, const _FP16 *X, const int incX,
                        _FP16 *Y, const int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
@@ -161,6 +162,7 @@ static void scopy_FP16(const unsigned int N, const _FP16 *X, const int incX,
 
 static void scopy_float32_to_float16(const unsigned int N, const float *X,
                                      const int incX, _FP16 *Y, const int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
@@ -179,6 +181,7 @@ static void scopy_float32_to_float16(const unsigned int N, const float *X,
 
 static void scopy_float16_to_float32(const unsigned int N, const _FP16 *X,
                                      const int incX, float *Y, const int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
@@ -197,6 +200,7 @@ static void scopy_float16_to_float32(const unsigned int N, const _FP16 *X,
 
 static void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X,
                                const int incX, _FP16 *Y, const int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
@@ -217,6 +221,7 @@ static void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X,
 
 static void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X,
                                const int incX, _FP16 *Y, const int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
@@ -236,6 +241,7 @@ static void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X,
 
 static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                       _FP16 *Z) {
+  THROW_UNLESS_FP16_ENABLED;
 #if (defined USE__FP16 && USE_NEON)
   nntrainer::neon::elementwise_vector_multiplication_neon_fp16(N, X, Y, Z);
 #else
@@ -246,6 +252,7 @@ static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
 
 static void ewva_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                       _FP16 *Z) {
+  THROW_UNLESS_FP16_ENABLED;
 #if (defined USE__FP16 && USE_NEON)
   nntrainer::neon::elementwise_vector_addition_neon_fp16(N, X, Y, Z);
 #else
@@ -254,6 +261,7 @@ static void ewva_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
 #endif
 }
 void sscal(const unsigned int N, const float alpha, _FP16 *X, const int incX) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int incx = abs(incX);
 
 #if (defined USE__FP16 && USE_NEON)
@@ -270,6 +278,7 @@ void sscal(const unsigned int N, const float alpha, _FP16 *X, const int incX) {
 }
 
 static _FP16 snrm2_FP16(const unsigned int N, const _FP16 *X, const int incX) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int incx = abs(incX);
   _FP16 sum = 0;
   _FP16 tmp;
@@ -299,6 +308,7 @@ static void sgemm_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
                        const unsigned int ldb, const float beta, _FP16 *C,
                        const unsigned int ldc) {
 
+  THROW_UNLESS_FP16_ENABLED;
 #if (defined USE__FP16 && USE_NEON)
   nntrainer::neon::sgemm_neon_fp16(A, B, C, M, N, K, alpha, beta,
                                    TransA == CblasTrans, TransB == CblasTrans);
@@ -309,6 +319,7 @@ static void sgemm_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
 
 static unsigned int isamax_FP16(const unsigned int N, const _FP16 *X,
                                 const int incX) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int max_idx = 0;
 
 #if (defined USE__FP16 && USE_NEON)
@@ -340,6 +351,7 @@ static unsigned int isamax_FP16(const unsigned int N, const _FP16 *X,
 
 void saxpy(const unsigned int N, const float alpha, const _FP16 *X,
            const int incX, _FP16 *Y, const int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   saxpy_FP16(N, alpha, X, incX, Y, incY);
 }
 
@@ -348,49 +360,59 @@ void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
            const float alpha, const _FP16 *A, const unsigned int lda,
            const _FP16 *B, const unsigned int ldb, const float beta, _FP16 *C,
            const unsigned int ldc) {
+  THROW_UNLESS_FP16_ENABLED;
   sgemm_FP16(order, TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C,
              ldc);
 }
 
 void scopy(const unsigned int N, const _FP16 *X, const int incX, _FP16 *Y,
            const int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   scopy_FP16(N, X, incX, Y, incY);
 }
 
 void scopy(const unsigned int N, const float *X, const int incX, _FP16 *Y,
            const int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   scopy_float32_to_float16(N, X, incX, Y, incY);
 }
 
 void scopy(const unsigned int N, const _FP16 *X, const int incX, float *Y,
            const int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   scopy_float16_to_float32(N, X, incX, Y, incY);
 }
 
 void scopy_int4_to_float16(const unsigned int N, const uint8_t *X,
                            const int incX, _FP16 *Y, const int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   scopy_int4_to_fp16(N, X, incX, Y, incY);
 }
 
 void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
                            const int incX, _FP16 *Y, const int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   scopy_int8_to_fp16(N, X, incX, Y, incY);
 }
 
 void ewvm(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z) {
+  THROW_UNLESS_FP16_ENABLED;
   ewvm_FP16(N, X, Y, Z);
 }
 
 void ewva(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z) {
+  THROW_UNLESS_FP16_ENABLED;
   ewva_FP16(N, X, Y, Z);
 }
 
 _FP16 snrm2(const int N, const _FP16 *X, const int incX) {
+  THROW_UNLESS_FP16_ENABLED;
   return snrm2_FP16(N, X, incX);
 }
 
 _FP16 sdot(const unsigned int N, const _FP16 *X, const unsigned int incX,
            const _FP16 *Y, const unsigned int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   return sdot_FP16(N, X, incX, Y, incY);
 }
 
@@ -398,15 +420,18 @@ void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
            const unsigned int N, const float alpha, const _FP16 *A,
            const unsigned int lda, const _FP16 *X, const int incX,
            const float beta, _FP16 *Y, const int incY) {
+  THROW_UNLESS_FP16_ENABLED;
   sgemv_FP16(order, TransA, M, N, alpha, A, lda, X, incX, beta, Y, incY);
 }
 
 unsigned int isamax(const unsigned int N, const _FP16 *X, const int incX) {
   /// @todo isamax_FP16 for BLAS_NUM_THREADS
+  THROW_UNLESS_FP16_ENABLED;
   return isamax_FP16(N, X, incX);
 }
 
 void inv_sqrt_inplace(const unsigned int N, _FP16 *X) {
+  THROW_UNLESS_FP16_ENABLED;
 #ifdef USE_NEON
   nntrainer::neon::inv_sqrt_inplace_neon(N, X);
 #else
@@ -415,7 +440,6 @@ void inv_sqrt_inplace(const unsigned int N, _FP16 *X) {
   }
 #endif
 }
-#endif
 
 #ifndef USE_BLAS
 static void saxpy_raw(const unsigned int N, const float alpha, const float *X,
@@ -538,11 +562,8 @@ void sscal(const unsigned int N, const float alpha, void *X, const int incX,
     sscal_raw(N, alpha, (float *)X, incX);
 #endif //  USE_BLAS
   } else if (d_type == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+    THROW_UNLESS_FP16_ENABLED;
     sscal(N, alpha, (_FP16 *)X, incX);
-#else
-    throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
   }
 }
 
@@ -572,12 +593,9 @@ void saxpy(const unsigned int N, const float alpha, const void *X,
               static_cast<float *>(Y), incY);
 #endif
   } else if (d_type == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+    THROW_UNLESS_FP16_ENABLED;
     saxpy_FP16(N, alpha, static_cast<const _FP16 *>(X), incX,
                static_cast<_FP16 *>(Y), incY);
-#else
-    throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
   }
 }
 
@@ -645,13 +663,10 @@ void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
 #endif
 
   } else if (d_type == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+    THROW_UNLESS_FP16_ENABLED;
     sgemm_FP16(
       order, TransA, TransB, M, N, K, alpha, static_cast<const _FP16 *>(A), lda,
       static_cast<const _FP16 *>(B), ldb, beta, static_cast<_FP16 *>(C), ldc);
-#else
-    throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
   }
 } // namespace nntrainer
 
@@ -714,11 +729,8 @@ void scopy(const unsigned int N, const void *X, const int incX, void *Y,
 #endif
 
   } else if (d_type == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+    THROW_UNLESS_FP16_ENABLED;
     scopy_FP16(N, (_FP16 *)X, incX, (_FP16 *)Y, incY);
-#else
-    throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
   }
 }
 
@@ -811,13 +823,10 @@ void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
                      static_cast<float *>(Y), incY);
 #endif
   } else if (d_type == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
+    THROW_UNLESS_FP16_ENABLED;
     return sgemv_FP16(order, TransA, M, N, alpha, static_cast<const _FP16 *>(A),
                       lda, static_cast<const _FP16 *>(X), incX, beta,
                       static_cast<_FP16 *>(Y), incY);
-#else
-    throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
   }
 }
 

--- a/nntrainer/tensor/blas_interface.h
+++ b/nntrainer/tensor/blas_interface.h
@@ -40,7 +40,6 @@ enum CBLAS_TRANSPOSE {
 #include <tensor_dim.h>
 namespace nntrainer {
 
-#ifdef ENABLE_FP16
 /**
  * @brief     sscal computation : X = alpha * X
  * @param[in] N number of elements in X
@@ -183,7 +182,7 @@ unsigned int isamax(const unsigned int N, const _FP16 *X, const int incX);
  * @param X __fp16 * for Vector X
  */
 void inv_sqrt_inplace(const unsigned int N, _FP16 *X);
-#endif
+
 /**
  * @brief     sscal computation : X = alpha * X
  * @param[in] N number of elements in X

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -438,10 +438,9 @@ void inv_sqrt_inplace_neon(const unsigned int N, float *X) {
   }
 }
 
-#ifdef ENABLE_FP16
-
 void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
                      uint32_t cols, float alpha, float beta) {
+  THROW_UNLESS_FP16_ENABLED;
   const int batch = 0;
   const __fp16 *__restrict x;
   float Y32[rows];
@@ -701,6 +700,7 @@ void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
 void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
                                uint32_t rows, uint32_t cols, float alpha,
                                float beta) {
+  THROW_UNLESS_FP16_ENABLED;
   float Y32[cols];
   const int batch = 20;
   unsigned int idx = 0;
@@ -1117,6 +1117,7 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
 void saxpy_neon_fp16(const unsigned int N, const float alpha, const __fp16 *X,
                      __fp16 *Y) {
 
+  THROW_UNLESS_FP16_ENABLED;
   const float16x8_t v_alphaX8 = vmovq_n_f16(alpha);
   const float16x4_t v_alphaX4 = vmov_n_f16(alpha);
 
@@ -1149,6 +1150,7 @@ void saxpy_neon_fp16(const unsigned int N, const float alpha, const __fp16 *X,
 
 __fp16 sdot_neon_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y) {
 
+  THROW_UNLESS_FP16_ENABLED;
   float16x8_t accX8 = vmovq_n_f16(0);
   float16x4_t accX4 = vmov_n_f16(0);
 
@@ -1197,6 +1199,7 @@ __fp16 sdot_neon_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y) {
 
 __fp16 snrm2_neon_fp16(const unsigned int N, const __fp16 *X) {
 
+  THROW_UNLESS_FP16_ENABLED;
   float16x8_t accX8 = vmovq_n_f16(0);
   float16x4_t accX4 = vmov_n_f16(0);
 
@@ -1242,6 +1245,7 @@ __fp16 snrm2_neon_fp16(const unsigned int N, const __fp16 *X) {
 }
 
 void sscal_neon_fp16(const unsigned int N, __fp16 *X, const float alpha) {
+  THROW_UNLESS_FP16_ENABLED;
   const float16x8_t v_alphaX8 = vmovq_n_f16(alpha);
   const float16x4_t v_alphaX4 = vmov_n_f16(alpha);
 
@@ -1271,6 +1275,7 @@ void sscal_neon_fp16(const unsigned int N, __fp16 *X, const float alpha) {
 }
 
 float32x4_t vcvtq_f32_u32_bitwise(uint32x4_t u32) {
+  THROW_UNLESS_FP16_ENABLED;
   constexpr uint32_t offsetValue = 0x4b000000;
   const uint32x4_t offsetInt = vdupq_n_u32(offsetValue);
   return vsubq_f32(vreinterpretq_f32_u32(vorrq_u32(u32, offsetInt)),
@@ -1279,6 +1284,7 @@ float32x4_t vcvtq_f32_u32_bitwise(uint32x4_t u32) {
 
 void scopy_neon_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y) {
 
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int idx = 0;
 
   // processing batch of 8
@@ -1301,6 +1307,7 @@ void scopy_neon_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y) {
 void scopy_neon_int4_to_fp16(const unsigned int N, const uint8_t *X,
                              __fp16 *Y) {
 
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int idx = 0;
 
   // keep in mind that : len(X) = N, and len(Y) = 2*N
@@ -1378,6 +1385,7 @@ void scopy_neon_int4_to_fp16(const unsigned int N, const uint8_t *X,
 
 void scopy_neon_int8_to_fp16(const unsigned int N, const uint8_t *X,
                              __fp16 *Y) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int idx = 0;
   for (; (N - idx) >= 16; idx += 16) {
     uint8x16_t batch = vld1q_u8(&X[idx]);
@@ -1406,6 +1414,7 @@ void scopy_neon_int8_to_fp16(const unsigned int N, const uint8_t *X,
 }
 
 void scopy_neon_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int idx = 0;
   for (; (N - idx) >= 16; idx += 16) {
     uint8x16_t batch = vld1q_u8(&X[idx]);
@@ -1448,6 +1457,7 @@ void scopy_neon_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
 }
 
 void scopy_neon_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y) {
+  THROW_UNLESS_FP16_ENABLED;
   int idx = 0;
 
   for (; N - idx >= 8; idx += 8) {
@@ -1470,6 +1480,7 @@ void scopy_neon_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y) {
 }
 
 void scopy_neon_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y) {
+  THROW_UNLESS_FP16_ENABLED;
   int idx = 0;
 
   for (; N - idx >= 8; idx += 8) {
@@ -1496,6 +1507,7 @@ void scopy_neon_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y) {
 
 unsigned int isamax_neon_fp16(const unsigned int N, const __fp16 *X) {
 
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int retIdx;
   __fp16 maxNum;
 
@@ -1550,6 +1562,7 @@ void sgemm_neon_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
                      uint32_t N, uint32_t K, float alpha, float beta,
                      bool TransA, bool TransB) {
 
+  THROW_UNLESS_FP16_ENABLED;
   // dynamic creation to avoid reaching stack limit(causes segmentation fault)
   float *C32 = (float *)malloc(M * N * sizeof(float));
 
@@ -1592,6 +1605,7 @@ void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
                              uint32_t M, uint32_t N, uint32_t K, float alpha,
                              float beta) {
 
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int k = 0, n = 0;
   __fp16 a[16];
   for (; (K - k) >= 16; k += 16) {
@@ -1765,6 +1779,7 @@ void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
 void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
                             uint32_t M, uint32_t N, uint32_t K, float alpha,
                             float beta) {
+  THROW_UNLESS_FP16_ENABLED;
   __fp16 valsB[8];
   float valsC[8];
   for (unsigned int k = 0; k < K; k++) {
@@ -1815,6 +1830,7 @@ void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
 void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
                             uint32_t M, uint32_t N, uint32_t K, float alpha,
                             float beta) {
+  THROW_UNLESS_FP16_ENABLED;
   __fp16 valsB[8];
   __fp16 valsA[8];
   int m = 0;
@@ -1984,6 +2000,7 @@ void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
 void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
                              uint32_t M, uint32_t N, uint32_t K, float alpha,
                              float beta, uint32_t idx) {
+  THROW_UNLESS_FP16_ENABLED;
   float vals[8];
   __fp16 vals_fp16[8];
   for (unsigned int n = 0; n < N; n++) {
@@ -2025,6 +2042,7 @@ void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
 void elementwise_vector_multiplication_neon_fp16(const unsigned int N,
                                                  const __fp16 *X,
                                                  const __fp16 *Y, __fp16 *Z) {
+  THROW_UNLESS_FP16_ENABLED;
   int i = 0;
   for (; N - i >= 8; i += 8) {
     float16x8_t x0_7 = vld1q_f16(&X[i]);
@@ -2042,6 +2060,7 @@ void elementwise_vector_multiplication_neon_fp16(const unsigned int N,
 void elementwise_vector_addition_neon_fp16(const unsigned int N,
                                            const __fp16 *X, const __fp16 *Y,
                                            __fp16 *Z) {
+  THROW_UNLESS_FP16_ENABLED;
   int i = 0;
   for (; N - i >= 8; i += 8) {
     float16x8_t x0_7 = vld1q_f16(&X[i]);
@@ -2057,6 +2076,7 @@ void elementwise_vector_addition_neon_fp16(const unsigned int N,
 }
 
 void inv_sqrt_inplace_neon(const unsigned int N, __fp16 *X) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int i = 0;
   for (; N - i >= 8; i += 8) {
     float16x8_t x0_7 = vld1q_f16(&X[i]);
@@ -2071,5 +2091,4 @@ void inv_sqrt_inplace_neon(const unsigned int N, __fp16 *X) {
   }
 }
 
-#endif
 } // namespace nntrainer::neon

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -102,7 +102,6 @@ void cosine_transformation_neon(const unsigned int N, float *X, float *Y,
  */
 void inv_sqrt_inplace_neon(const unsigned int N, float *X);
 
-#ifdef ENABLE_FP16
 /**
  * @brief     sgemv computation with neon : Y = alpha*A*X + beta*Y
  * @param[in] A __fp16 * for Matrix A
@@ -321,7 +320,6 @@ void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
  * @param X __fp16 * for Vector X
  */
 void inv_sqrt_inplace_neon(const unsigned int N, __fp16 *X);
-#endif
 
 } // namespace nntrainer::neon
 

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -19,17 +19,21 @@
 namespace nntrainer {
 
 HalfTensor::HalfTensor(std::string name_, Tformat fm) :
-  TensorBase(name_, fm, Tdatatype::FP16) {}
+  TensorBase(name_, fm, Tdatatype::FP16) {
+  THROW_UNLESS_FP16_ENABLED;
+}
 
 HalfTensor::HalfTensor(const TensorDim &d, bool alloc_now, Initializer init,
                        std::string name) :
   TensorBase(d, alloc_now, init, name) {
+  THROW_UNLESS_FP16_ENABLED;
   if (alloc_now)
     allocate();
 }
 
 HalfTensor::HalfTensor(const TensorDim &d, const void *buf) :
   HalfTensor(d, true) {
+  THROW_UNLESS_FP16_ENABLED;
   if (d.getDataLen() != 0) {
     if (buf != nullptr)
       copy(buf);
@@ -40,6 +44,7 @@ HalfTensor::HalfTensor(
   std::vector<std::vector<std::vector<std::vector<_FP16>>>> const &d,
   Tformat fm) {
 
+  THROW_UNLESS_FP16_ENABLED;
   if (d.empty() || d[0].empty() || d[0][0].empty() || d[0][0][0].empty()) {
     throw std::out_of_range(
       "[Tensor] trying to initialize HalfTensor from empty vector");
@@ -89,6 +94,7 @@ HalfTensor::HalfTensor(
 }
 
 bool HalfTensor::operator==(const HalfTensor &rhs) const {
+  THROW_UNLESS_FP16_ENABLED;
   const _FP16 *_data = (_FP16 *)getData();
   const _FP16 *_rdata = (_FP16 *)rhs.getData();
   for (size_t i = 0; i < size(); ++i) {
@@ -102,6 +108,7 @@ bool HalfTensor::operator==(const HalfTensor &rhs) const {
 
 /// @todo support allocation by src_tensor
 void HalfTensor::allocate() {
+  THROW_UNLESS_FP16_ENABLED;
   if (empty() || data)
     /// already allocated
     return;

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -20,6 +20,7 @@ tensor_sources = [
   'optimized_v2_planner.cpp',
   'optimized_v3_planner.cpp',
   'task_executor.cpp',
+  'half_tensor.cpp'
 ]
 
 tensor_headers = [
@@ -31,18 +32,14 @@ tensor_headers = [
   'weight.h',
   'var_grad.h',    
   'tensor_wrap_specs.h',
-  'blas_interface.h'
+  'blas_interface.h',
+  'half_tensor.h'
 ]
 
 arch = target_machine.cpu_family()
 
 if get_option('platform') == 'android' or arch == 'aarch64'
   tensor_sources += 'blas_neon.cpp'
-endif
-
-if get_option('enable-fp16')
-  tensor_headers += 'half_tensor.h'
-  tensor_sources += 'half_tensor.cpp'
 endif
 
 foreach s : tensor_sources

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -188,22 +188,21 @@ public:
   virtual void print(std::ostream &out) const = 0;
 
   /**
+   * @copydoc TensorV2::apply(std::function<_FP16(_FP16)> f, TensorV2 &output)
+   */
+  virtual TensorV2 &apply(std::function<_FP16(_FP16)> f,
+                          TensorV2 &output) const {
+    THROW_UNLESS_FP16_ENABLED;
+    return output;
+  }
+
+  /**
    * @copydoc TensorV2::apply(std::function<T(T)> f, TensorV2 &output)
    */
   virtual TensorV2 &apply(std::function<float(float)> f,
                           TensorV2 &output) const {
     return output;
   }
-
-#ifdef ENABLE_FP16
-  /**
-   * @copydoc TensorV2::apply(std::function<T(T)> f, TensorV2 &output)
-   */
-  virtual TensorV2 &apply(std::function<_FP16(_FP16)> f,
-                          TensorV2 &output) const {
-    return output;
-  }
-#endif
 
   /**
    * @brief     put data of Tensor

--- a/nntrainer/tensor/tensor_dim.cpp
+++ b/nntrainer/tensor/tensor_dim.cpp
@@ -150,11 +150,7 @@ TensorDim &TensorDim::operator=(TensorDim &&rhs) noexcept {
 uint TensorDim::getDataTypeSize() const {
   switch (t_type.data_type) {
   case TensorDim::DataType::FP16:
-#ifdef ENABLE_FP16
     return sizeof(_FP16);
-#else
-    return 2;
-#endif
   case TensorDim::DataType::FP32:
     return sizeof(float);
   case TensorDim::DataType::QINT8:

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -10,11 +10,8 @@
  */
 
 #include <float_tensor.h>
-#include <tensor_v2.h>
-
-#ifdef ENABLE_FP16
 #include <half_tensor.h>
-#endif
+#include <tensor_v2.h>
 
 namespace nntrainer {
 
@@ -24,11 +21,7 @@ TensorV2::TensorV2(std::string name_, Tformat fm, Tdatatype d_type) {
   if (d_type == Tdatatype::FP32) {
     itensor = new FloatTensor(name_, fm);
   } else if (d_type == Tdatatype::FP16) {
-#ifdef ENABLE_FP16
     itensor = new HalfTensor(name_, fm);
-#else
-    throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
   } else {
     throw std::invalid_argument(
       "Error: TensorV2 cannot be constructed because the given d_type is not "
@@ -44,11 +37,7 @@ TensorV2::TensorV2(const TensorDim &d, bool alloc_now, Initializer init,
   if (d.getDataType() == Tdatatype::FP32) {
     itensor = new FloatTensor(d, alloc_now, init, name);
   } else if (d.getDataType() == Tdatatype::FP16) {
-#ifdef ENABLE_FP16
     itensor = new HalfTensor(d, alloc_now, init, name);
-#else
-    throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
   } else {
     throw std::invalid_argument(
       "Error: TensorV2 cannot be constructed because the given d_type is not "
@@ -63,11 +52,7 @@ TensorV2::TensorV2(const TensorDim &d, const void *buf) {
   if (d.getDataType() == Tdatatype::FP32) {
     itensor = new FloatTensor(d, buf);
   } else if (d.getDataType() == Tdatatype::FP16) {
-#ifdef ENABLE_FP16
     itensor = new HalfTensor(d, buf);
-#else
-    throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
   } else {
     throw std::invalid_argument(
       "Error: TensorV2 cannot be constructed because the given d_type is not "
@@ -82,13 +67,11 @@ TensorV2::TensorV2(
   itensor = new FloatTensor(d, t_type.format);
 }
 
-#ifdef ENABLE_FP16
 TensorV2::TensorV2(
   std::vector<std::vector<std::vector<std::vector<_FP16>>>> const &d,
   ml::train::TensorDim::TensorType t_type) {
   itensor = new HalfTensor(d, t_type.format);
 }
-#endif
 
 bool TensorV2::operator==(const TensorV2 &rhs) const {
   /// compares tensor information
@@ -98,14 +81,8 @@ bool TensorV2::operator==(const TensorV2 &rhs) const {
       return *dynamic_cast<FloatTensor *>(itensor) ==
              *dynamic_cast<FloatTensor *>(rhs.itensor);
     } else if (getDataType() == Tdatatype::FP16) {
-#ifdef ENABLE_FP16
       return *dynamic_cast<HalfTensor *>(itensor) ==
              *dynamic_cast<HalfTensor *>(rhs.itensor);
-#else
-      throw std::invalid_argument(
-        "Error: HalfTensor cannot be created or used when FP16 is not enabled. "
-        "Please check if the tensor data type is set properly.");
-#endif
     }
   }
   return false;

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -171,7 +171,6 @@ public:
            ml::train::TensorDim::TensorType t_type) :
     TensorV2(std::vector<std::decay<decltype(d)>::type>{d}, t_type){};
 
-#ifdef ENABLE_FP16
   /**
    * @brief     Constructor of Tensor
    * @note      This constructor copies vector again. needs refactoring
@@ -200,8 +199,6 @@ public:
   TensorV2(std::vector<std::vector<_FP16>> const &d,
            ml::train::TensorDim::TensorType t_type) :
     TensorV2(std::vector<std::decay<decltype(d)>::type>{d}, t_type){};
-
-#endif
 
   /**
    * @brief Basic Destructor
@@ -403,6 +400,20 @@ public:
    * @param     init Initiailizer to use for the initialization
    */
   void initialize(Initializer init);
+
+  /**
+   * @brief Apply instantly to the element for _FP16
+   * @param[in] *function function pointer applied
+   * @return int ML_ERROR_NONE if successful
+   * @throws runtime_error if _FP16 is not supported.
+   */
+  int apply_i(std::function<_FP16(_FP16)> f) {
+    THROW_UNLESS_FP16_ENABLED;
+    TensorV2 result = *this;
+    apply<_FP16>(f, result);
+
+    return ML_ERROR_NONE;
+  };
 
   /**
    * @brief Apply instantly to the element

--- a/nntrainer/utils/util_simd.cpp
+++ b/nntrainer/utils/util_simd.cpp
@@ -40,11 +40,10 @@ void swish(const unsigned int N, float *X, float *Y, float *Z) {
 #endif
 }
 
-#ifdef ENABLE_FP16
-
 void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
                                     unsigned int w, _FP16 *in, _FP16 *out,
                                     float *cos_, float *sin_) {
+  THROW_UNLESS_FP16_ENABLED;
 #ifdef USE_NEON
   nntrainer::neon::compute_rotary_embedding_value_neon(dim, half_, w, in, out,
                                                        cos_, sin_);
@@ -56,6 +55,7 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
 }
 
 void swish(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z) {
+  THROW_UNLESS_FP16_ENABLED;
 #ifdef USE_NEON
   nntrainer::neon::swish_neon(N, X, Y, Z);
 #else
@@ -68,6 +68,5 @@ void swish(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z) {
   }
 #endif
 }
-#endif
 
 } // namespace nntrainer

--- a/nntrainer/utils/util_simd.h
+++ b/nntrainer/utils/util_simd.h
@@ -41,7 +41,6 @@ void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
  */
 void swish(const unsigned int N, float *X, float *Y, float *Z);
 
-#ifdef ENABLE_FP16
 /**
  * @brief Accelerating function for rotary embedding layer forwarding
  *
@@ -52,6 +51,7 @@ void swish(const unsigned int N, float *X, float *Y, float *Z);
  * @param out _FP16* output
  * @param cos_ precomputed cos_ for corresponding rotational indices
  * @param sin_ precomputed sin_ for corresponding rotational indices
+ * @throws runtime_error if FP16 is not supported
  */
 void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
                                     unsigned int w, _FP16 *in, _FP16 *out,
@@ -63,9 +63,9 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
  * @param X _FP16 * for Vector X
  * @param Y _FP16 * for Vector Y
  * @param Z _FP16 * for Vector Z
+ * @throws runtime_error if FP16 is not supported
  */
 void swish(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z);
-#endif
 
 } /* namespace nntrainer */
 

--- a/nntrainer/utils/util_simd.h
+++ b/nntrainer/utils/util_simd.h
@@ -60,11 +60,11 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
  * @brief swish function : X = (Y / (1 + exp( -Y ))) * Z
  *
  * @param N number of elements in X
- * @param X __fp16 * for Vector X
- * @param Y __fp16 * for Vector Y
- * @param Z __fp16 * for Vector Z
+ * @param X _FP16 * for Vector X
+ * @param Y _FP16 * for Vector Y
+ * @param Z _FP16 * for Vector Z
  */
-void swish(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z);
+void swish(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z);
 #endif
 
 } /* namespace nntrainer */

--- a/nntrainer/utils/util_simd_neon.cpp
+++ b/nntrainer/utils/util_simd_neon.cpp
@@ -56,11 +56,11 @@ void swish_neon(const unsigned int N, float *X, float *Y, float *Z) {
   }
 }
 
-#ifdef ENABLE_FP16
 void compute_rotary_embedding_value_neon(unsigned int dim, unsigned int half_,
                                          unsigned int w, __fp16 *in,
                                          __fp16 *out, float *cos_,
                                          float *sin_) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int k = 0;
   while (k < dim) {
     unsigned int span = w + k;
@@ -133,6 +133,7 @@ void compute_rotary_embedding_value_neon(unsigned int dim, unsigned int half_,
 }
 
 void swish_neon(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z) {
+  THROW_UNLESS_FP16_ENABLED;
   unsigned int i = 0;
   for (; N - i >= VL_FP16; i += VL_FP16) {
     float16x8_t y0_7 = vld1q_f16(&Y[i]);
@@ -155,6 +156,5 @@ void swish_neon(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z) {
     ++i;
   }
 }
-#endif
 
 } // namespace nntrainer::neon

--- a/nntrainer/utils/util_simd_neon.h
+++ b/nntrainer/utils/util_simd_neon.h
@@ -41,7 +41,6 @@ void calc_trigonometric_vals_dup_neon(unsigned int N_half, float *angle,
  * @param Z float * for Vector Z
  */
 void swish_neon(const unsigned int N, float *X, float *Y, float *Z);
-#ifdef ENABLE_FP16
 /**
  * @brief Accelerating function for rotary embedding layer forwarding
  *
@@ -52,6 +51,7 @@ void swish_neon(const unsigned int N, float *X, float *Y, float *Z);
  * @param out __fp16* output
  * @param cos_ precomputed cos_ for corresponding rotational indices
  * @param sin_ precomputed sin_ for corresponding rotational indices
+ * @throws runtime_error when FP16 is not supported.
  */
 void compute_rotary_embedding_value_neon(unsigned int dim, unsigned int half_,
                                          unsigned int w, __fp16 *in,
@@ -63,9 +63,9 @@ void compute_rotary_embedding_value_neon(unsigned int dim, unsigned int half_,
  * @param X __fp16 * for Vector X
  * @param Y __fp16 * for Vector Y
  * @param Z __fp16 * for Vector Z
+ * @throws runtime_error when FP16 is not supported.
  */
 void swish_neon(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z);
-#endif
 
 } // namespace nntrainer::neon
 

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -534,9 +534,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/tensor_v2.h
 %{_includedir}/nntrainer/tensor_base.h
 %{_includedir}/nntrainer/float_tensor.h
-%if 0%{?enable_fp16}
 %{_includedir}/nntrainer/half_tensor.h
-%endif
 %{_includedir}/nntrainer/tensor_wrap_specs.h
 %{_includedir}/nntrainer/blas_interface.h
 %{_includedir}/nntrainer/var_grad.h


### PR DESCRIPTION
Most modules should NOT depend on the existnace of FP16 support. Let a single (or minimal) entity (a single class?) know and handle it.

This is a suggestion commit that shows an example how to refactor it. Most modules are not yet touched with this commit.

CC: @skykongkong8 (I've seen some #if/#endif in your commits.)