### PR TITLE
[Test] Enabled unit testing for TensorV2 class

### DIFF
--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -39,6 +39,7 @@ test_target = [
   ['unittest_nntrainer_internal', []],
   ['unittest_nntrainer_lazy_tensor', []],
   ['unittest_nntrainer_tensor', []],
+  ['unittest_nntrainer_tensor_v2', []],
   ['unittest_nntrainer_tensor_nhwc', []],
   ['unittest_util_func', []],
   ['unittest_nntrainer_modelfile', []],
@@ -57,6 +58,7 @@ test_target = [
 if get_option('enable-fp16')
   test_target += [['unittest_nntrainer_tensor_fp16', []]]
   test_target += [['unittest_nntrainer_tensor_pool_fp16', []]]
+  test_target += [['unittest_nntrainer_tensor_v2_fp16', []]]
 endif
 
 if get_option('enable-profile')

--- a/test/unittest/unittest_nntrainer_tensor_v2.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_v2.cpp
@@ -22,7 +22,8 @@ TEST(nntrainer_Tensor, Tensor_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::TensorV2 tensor = nntrainer::TensorV2(1, 2, 3);
   tensor.setZero();
-  ASSERT_NE(nullptr, tensor.getData());
+  ASSERT_NE(nullptr, tensor.getData<float>());
+
   if (tensor.getValue<float>(0, 0, 0, 0) != 0.0)
     status = ML_ERROR_INVALID_PARAMETER;
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -43,7 +44,7 @@ TEST(nntrainer_Tensor, Tensor_02_p) {
 
   nntrainer::TensorV2 tensor = nntrainer::TensorV2(
     in, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
-  ASSERT_NE(nullptr, tensor.getData());
+  ASSERT_NE(nullptr, tensor.getData<float>());
 
   if (tensor.getValue<float>(0, 0, 0, 1) != 1.0)
     status = ML_ERROR_INVALID_PARAMETER;
@@ -65,7 +66,7 @@ TEST(nntrainer_Tensor, Tensor_02_nhwc_p) {
 
   nntrainer::TensorV2 tensor = nntrainer::TensorV2(
     in, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
-  ASSERT_NE(nullptr, tensor.getData());
+  ASSERT_NE(nullptr, tensor.getData<float>());
 
   if (tensor.getValue<float>(0, 0, 0, 1) != 1.0)
     status = ML_ERROR_INVALID_PARAMETER;
@@ -93,7 +94,7 @@ TEST(nntrainer_Tensor, Tensor_03_p) {
 
   nntrainer::TensorV2 tensor = nntrainer::TensorV2(
     in, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
-  ASSERT_NE(nullptr, tensor.getData());
+  ASSERT_NE(nullptr, tensor.getData<float>());
 
   if (tensor.getValue<float>(0, 0, 0, 1) != 1.0)
     status = ML_ERROR_INVALID_PARAMETER;
@@ -171,22 +172,6 @@ TEST(nntrainer_Tensor, Tensor_05_p) {
   if (t1.getValue<float>(0, 0, 0, 1) != val_t0)
     status = ML_ERROR_INVALID_PARAMETER;
   EXPECT_EQ(status, ML_ERROR_NONE);
-}
-
-TEST(nntrainer_Tensor, TensorPaddedValue_p) {
-  nntrainer::TensorV2 a = rangedV2(1, 1, 3, 3);
-  float default_padded = -1;
-
-  for (int i = 0; i < 5; ++i) {
-    for (int j = 0; j < 5; ++j) {
-      float expected = default_padded;
-      if (1 <= i && i <= 3 && 1 <= j && j <= 3) {
-        expected = (i - 1) * 3 + (j - 1);
-      }
-      float actual = a.getValuePaddedVirtual(0, 0, i, j, 1, 1, default_padded);
-      EXPECT_FLOAT_EQ(actual, expected);
-    }
-  }
 }
 
 TEST(nntrainer_Tensor, empty_01) {

--- a/test/unittest/unittest_nntrainer_tensor_v2_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_v2_fp16.cpp
@@ -23,7 +23,7 @@ TEST(nntrainer_Tensor, Tensor_01_p) {
   nntrainer::TensorV2 tensor = nntrainer::TensorV2(
     1, 2, 3, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
   tensor.setZero();
-  ASSERT_NE(nullptr, tensor.getData());
+  ASSERT_NE(nullptr, tensor.getData<_FP16>());
   if (tensor.getValue<_FP16>(0, 0, 0, 0) != 0.0)
     status = ML_ERROR_INVALID_PARAMETER;
   EXPECT_EQ(status, ML_ERROR_NONE);
@@ -44,7 +44,7 @@ TEST(nntrainer_Tensor, Tensor_02_p) {
 
   nntrainer::TensorV2 tensor = nntrainer::TensorV2(
     in, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16});
-  ASSERT_NE(nullptr, tensor.getData());
+  ASSERT_NE(nullptr, tensor.getData<_FP16>());
 
   if (tensor.getValue<_FP16>(0, 0, 0, 1) != 1.0)
     status = ML_ERROR_INVALID_PARAMETER;
@@ -66,7 +66,7 @@ TEST(nntrainer_Tensor, Tensor_02_nhwc_p) {
 
   nntrainer::TensorV2 tensor = nntrainer::TensorV2(
     in, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16});
-  ASSERT_NE(nullptr, tensor.getData());
+  ASSERT_NE(nullptr, tensor.getData<_FP16>());
 
   if (tensor.getValue<_FP16>(0, 0, 0, 1) != 1.0)
     status = ML_ERROR_INVALID_PARAMETER;
@@ -94,7 +94,7 @@ TEST(nntrainer_Tensor, Tensor_03_p) {
 
   nntrainer::TensorV2 tensor = nntrainer::TensorV2(
     in, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16});
-  ASSERT_NE(nullptr, tensor.getData());
+  ASSERT_NE(nullptr, tensor.getData<_FP16>());
 
   if (tensor.getValue<_FP16>(0, 0, 0, 1) != 1.0)
     status = ML_ERROR_INVALID_PARAMETER;


### PR DESCRIPTION
This PR enables unit testing for the TensorV2 class by adding a suite of tests that cover public methods.
More tests will be added in a future PR to further validate the TensorV2 class.
    
**Changes proposed in this PR:**
- Edit meson build file to include tensor v2 unit tests
- Fix public methods usage due to changed function use.
    
**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped