### PR TITLE
fix: multi-head-attention incorrect macro usage. @open sesame 1/16 17:11

### DIFF
--- a/nntrainer/layers/multi_head_attention_layer.cpp
+++ b/nntrainer/layers/multi_head_attention_layer.cpp
@@ -355,6 +355,9 @@ void MultiHeadAttentionLayer::finalize(InitLayerContext &context) {
     precompute_freqs(projected_key_dim_prop, max_timestep);
 }
 
+#define _MASK_NUM(datatype) \
+  (((datatype) == ml::train::TensorDim::DataType::FP16) ? (-1e4) : (-1e10))
+
 void MultiHeadAttentionLayer::forwarding(RunLayerContext &context,
                                          bool training) {
 
@@ -495,15 +498,10 @@ void MultiHeadAttentionLayer::forwarding(RunLayerContext &context,
 
   causal_mask.setZero();
 
-#ifdef ENABLE_FP16
-#define _MASK_NUM -1e4
-#else
-#define _MASK_NUM -1e10
-#endif
-
   for (unsigned int i = 0; i < mask_dim_height; ++i) {
     for (unsigned int j = i + 1; j < mask_dim_width; ++j) {
-      causal_mask.setValue(0, 0, i, j, _MASK_NUM);
+      causal_mask.setValue(
+        0, 0, i, j, _MASK_NUM(attention_weight.getTensorType().data_type));
     }
   }
 
@@ -828,15 +826,10 @@ void MultiHeadAttentionLayer::initial_incremental_forwarding(
 
     causal_mask.setZero();
 
-#ifdef ENABLE_FP16
-#define _MASK_NUM -1e4
-#else
-#define _MASK_NUM -1e10
-#endif
-
     for (unsigned int i = 0; i < mask_dim_height; ++i) {
       for (unsigned int j = i + 1; j < mask_dim_width; ++j) {
-        causal_mask.setValue(0, 0, i, j, _MASK_NUM);
+        causal_mask.setValue(
+          0, 0, i, j, _MASK_NUM(attention_weight.getTensorType().data_type));
       }
     }
 
@@ -1140,15 +1133,10 @@ void MultiHeadAttentionLayer::incremental_forwarding(RunLayerContext &context,
 
     causal_mask.setZero();
 
-#ifdef ENABLE_FP16
-#define _MASK_NUM -1e4
-#else
-#define _MASK_NUM -1e10
-#endif
-
     for (unsigned int i = 0; i < mask_dim_height; ++i) {
       for (unsigned int j = i + 1; j < mask_dim_width; ++j) {
-        causal_mask.setValue(0, 0, i, j, _MASK_NUM);
+        causal_mask.setValue(
+          0, 0, i, j, _MASK_NUM(attention_weight.getTensorType().data_type));
       }
     }
 

--- a/nntrainer/layers/multi_head_attention_layer.cpp
+++ b/nntrainer/layers/multi_head_attention_layer.cpp
@@ -501,7 +501,7 @@ void MultiHeadAttentionLayer::forwarding(RunLayerContext &context,
   for (unsigned int i = 0; i < mask_dim_height; ++i) {
     for (unsigned int j = i + 1; j < mask_dim_width; ++j) {
       causal_mask.setValue(
-        0, 0, i, j, _MASK_NUM(attention_weight.getTensorType().data_type));
+        0, 0, i, j, _MASK_NUM(attention_weight.getDataType()));
     }
   }
 


### PR DESCRIPTION
1. Fix re-definitions of macros
2. Determine mask num in runtime, not in compile-time. You do not know whether users want fp16 or not at compile-time.

Fixes #2407


CC: @lhs8928 