### PR TITLE
[ Trivial ] Refactor trigonometric functions & inv_sqrt_i

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -847,10 +847,10 @@ unsigned int isamax(const unsigned int N, const float *X, const int incX) {
 #endif
 }
 
-void sine_transformation(const unsigned int N, float *X, float *Y,
+void sine(const unsigned int N, float *X, float *Y,
                          float alpha) {
 #ifdef USE_NEON
-  nntrainer::neon::sine_transformation_neon(N, X, Y, alpha);
+  nntrainer::neon::sine_neon(N, X, Y, alpha);
 #else
   unsigned int i = 0;
   while (i < N) {
@@ -860,10 +860,10 @@ void sine_transformation(const unsigned int N, float *X, float *Y,
 #endif
 }
 
-void cosine_transformation(const unsigned int N, float *X, float *Y,
+void cosine(const unsigned int N, float *X, float *Y,
                            float alpha) {
 #ifdef USE_NEON
-  nntrainer::neon::cosine_transformation_neon(N, X, Y, alpha);
+  nntrainer::neon::cosine_neon(N, X, Y, alpha);
 #else
   unsigned int i = 0;
   while (i < N) {

--- a/nntrainer/tensor/blas_interface.h
+++ b/nntrainer/tensor/blas_interface.h
@@ -345,23 +345,23 @@ void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
 unsigned int isamax(const unsigned int N, const float *X, const int incX);
 
 /**
- * @brief     sine transformation with neon: Y = sin(alpha * X)
+ * @brief     sine with neon: Y = sin(alpha * X)
  * @param[in] N number of elements in X
  * @param[in] X float * for Vector X
  * @param[in] Y float * for Vector Y
  * @param[in] alpha float * for scaling angle (radian)
  */
-void sine_transformation(const unsigned int N, float *X, float *Y,
+void sine(const unsigned int N, float *X, float *Y,
                          float alpha = 1.0);
 
 /**
- * @brief     cosine transformation with neon: Y = cos(alpha * X)
+ * @brief     cosine with neon: Y = cos(alpha * X)
  * @param[in] N number of elements in X
  * @param[in] X float * for Vector X
  * @param[in] Y float * for Vector Y
  * @param[in] alpha float * for scaling angle (radian)
  */
-void cosine_transformation(const unsigned int N, float *X, float *Y,
+void cosine(const unsigned int N, float *X, float *Y,
                            float alpha = 1.0);
 
 /**

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -392,7 +392,7 @@ void scopy_neon_int8_or_int4(const unsigned int N, const uint8_t *X,
   }
 }
 
-void sine_transformation_neon(const unsigned int N, float *X, float *Y,
+void sine_neon(const unsigned int N, float *X, float *Y,
                               float alpha) {
   unsigned int i = 0;
   for (; N - i >= 4; i += 4) {
@@ -408,7 +408,7 @@ void sine_transformation_neon(const unsigned int N, float *X, float *Y,
   }
 }
 
-void cosine_transformation_neon(const unsigned int N, float *X, float *Y,
+void cosine_neon(const unsigned int N, float *X, float *Y,
                                 float alpha) {
   unsigned int i = 0;
   for (; N - i >= 4; i += 4) {

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -74,23 +74,23 @@ void scopy_neon_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
 void scopy_neon_int8_or_int4(const unsigned int N, const uint8_t *X,
                              uint8_t *Y);
 /**
- * @brief     sine transformation with neon: Y = sin(alpha * X)
+ * @brief     sine with neon: Y = sin(alpha * X)
  * @param[in] N number of elements in X
  * @param[in] X float * for Vector X
  * @param[in] Y float * for Vector Y
  * @param[in] alpha float * for scaling angle (radian)
  */
-void sine_transformation_neon(const unsigned int N, float *X, float *Y,
+void sine_neon(const unsigned int N, float *X, float *Y,
                               float alpha = 1.0);
 
 /**
- * @brief     cosine transformation with neon: Y = cos(alpha * X)
+ * @brief     cosine with neon: Y = cos(alpha * X)
  * @param[in] N number of elements in X
  * @param[in] X float * for Vector X
  * @param[in] Y float * for Vector Y
  * @param[in] alpha float * for scaling angle (radian)
  */
-void cosine_transformation_neon(const unsigned int N, float *X, float *Y,
+void cosine_neon(const unsigned int N, float *X, float *Y,
                                 float alpha = 1.0);
 
 /**

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -127,8 +127,7 @@ public:
   SrcSharedTensor() : src(nullptr), off(0) {}
 
   SrcSharedTensor(const Tensor *tensor, size_t offset) :
-    src(tensor),
-    off(offset) {}
+    src(tensor), off(offset) {}
 
   /**
    * @brief   Get the allocated src tensor
@@ -3440,18 +3439,20 @@ Tensor &Tensor::erf(Tensor &out) const {
   return out;
 }
 
-void Tensor::sin_transform(Tensor &out, float alpha) {
+void Tensor::sin(Tensor &out, float alpha) {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot calculate sin.";
   if (getDataType() == ml::train::TensorDim::DataType::FP32) {
-    sine_transformation(this->size(), getData<float>(), out.getData<float>(),
-                        alpha);
+    sine(size(), getData<float>(), out.getData<float>(), alpha);
   } else
     throw std::invalid_argument("Error: sin_transform supports fp32 case only");
 }
 
-void Tensor::cos_transform(Tensor &out, float alpha) {
+void Tensor::cos(Tensor &out, float alpha) {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot calculate cos.";
   if (getDataType() == ml::train::TensorDim::DataType::FP32) {
-    cosine_transformation(this->size(), getData<float>(), out.getData<float>(),
-                          alpha);
+    cosine(size(), getData<float>(), out.getData<float>(), alpha);
   } else
     throw std::invalid_argument("Error: cos_transform supports fp32 case only");
 }

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -127,7 +127,8 @@ public:
   SrcSharedTensor() : src(nullptr), off(0) {}
 
   SrcSharedTensor(const Tensor *tensor, size_t offset) :
-    src(tensor), off(offset) {}
+    src(tensor),
+    off(offset) {}
 
   /**
    * @brief   Get the allocated src tensor
@@ -3442,22 +3443,28 @@ Tensor &Tensor::erf(Tensor &out) const {
 void Tensor::sin(Tensor &out, float alpha) {
   NNTR_THROW_IF(!contiguous, std::invalid_argument)
     << getName() << " is not contiguous, cannot calculate sin.";
+  if (size() != out.size())
+    throw std::invalid_argument("Error: Size of out of Tensor::sin must match");
   if (getDataType() == ml::train::TensorDim::DataType::FP32) {
     sine(size(), getData<float>(), out.getData<float>(), alpha);
   } else
-    throw std::invalid_argument("Error: sin_transform supports fp32 case only");
+    throw std::invalid_argument("Error: Tensor::sin supports fp32 case only.");
 }
 
 void Tensor::cos(Tensor &out, float alpha) {
   NNTR_THROW_IF(!contiguous, std::invalid_argument)
     << getName() << " is not contiguous, cannot calculate cos.";
+  if (size() != out.size())
+    throw std::invalid_argument("Error: Size of out of Tensor::sin must match");
   if (getDataType() == ml::train::TensorDim::DataType::FP32) {
     cosine(size(), getData<float>(), out.getData<float>(), alpha);
   } else
-    throw std::invalid_argument("Error: cos_transform supports fp32 case only");
+    throw std::invalid_argument("Error: Tensor::cos supports fp32 case only.");
 }
 
 void Tensor::inv_sqrt_i() {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot calculate inv_sqrt_i.";
   if (getDataType() == ml::train::TensorDim::DataType::FP32) {
     inv_sqrt_inplace(this->size(), getData<float>());
   } else if (getDataType() == ml::train::TensorDim::DataType::FP16) {

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -974,13 +974,13 @@ public:
    * @brief    sin transform function
    * @param[out] out out to store the result
    */
-  void sin_transform(Tensor &out, float alpha = 1.0);
+  void sin(Tensor &out, float alpha = 1.0);
 
   /**
    * @brief    cos transform function
    * @param[out] out out to store the result
    */
-  void cos_transform(Tensor &out, float alpha = 1.0);
+  void cos(Tensor &out, float alpha = 1.0);
 
   /**
    * @brief inverse squared root function

--- a/nntrainer/utils/util_simd_neon.cpp
+++ b/nntrainer/utils/util_simd_neon.cpp
@@ -16,8 +16,8 @@ namespace nntrainer::neon {
 void calc_trigonometric_vals_dup_neon(unsigned int N_half, float *angle,
                                       float *cos_, float *sin_,
                                       unsigned int from) {
-  cosine_transformation_neon(N_half, angle, cos_, from);
-  sine_transformation_neon(N_half, angle, sin_, from);
+  cosine_neon(N_half, angle, cos_, from);
+  sine_neon(N_half, angle, sin_, from);
 
   unsigned int N = 2 * N_half;
   unsigned int i = N_half;

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -4460,7 +4460,7 @@ TEST(nntrainer_Tensor, dequantize_05_n) {
   EXPECT_THROW({ input.dequantize(output, 1); }, std::invalid_argument);
 }
 
-TEST(nntrainer_neon_experimental, trigonometric_simd_sin) {
+TEST(nntrainer_Tensor, sin_contiguous_p) {
   int batch = 1;
   int channel = 1;
   int height = 1440;
@@ -4492,40 +4492,29 @@ TEST(nntrainer_neon_experimental, trigonometric_simd_sin) {
 
   input.sin(sin_output);
 
-  bool flag = true;
-
   for (int b = 0; b < batch; b++) {
     for (int c = 0; c < channel; c++) {
       for (int h = 0; h < height; h++) {
         for (int w = 0; w < width; w++) {
-          double sin_err = std::abs(sin_output.getValue(b, c, h, w) -
-                                    result_sine.getValue(b, c, h, w));
-
-          if (sin_err > eps) {
-            flag = false;
-            std::cout << sin_output.getValue(b, c, h, w) << " VS "
-                      << result_sine.getValue(b, c, h, w) << std::endl;
-          }
+          EXPECT_NEAR(sin_output.getValue(b, c, h, w),
+                      result_sine.getValue(b, c, h, w), eps);
         }
       }
     }
   }
-
-  EXPECT_EQ(flag, true);
 }
 
-TEST(nntrainer_neon_experimental, trigonometric_simd_cos) {
+TEST(nntrainer_Tensor, cos_contiguous_p) {
   int batch = 1;
   int channel = 1;
   int height = 1440;
   int width = 1440;
 
-  const int MOD = 10;
-
-  const float eps = 1e-6;
-
   nntrainer::Tensor input(batch, channel, height, width);
   nntrainer::Tensor cos_output(batch, channel, height, width);
+
+  const int MOD = 10;
+  const float eps = 1e-6;
 
   GEN_TEST_INPUT(input, (i * (channel * width * height) + j * (height * width) +
                          k * (width) + l + 1) %
@@ -4546,26 +4535,173 @@ TEST(nntrainer_neon_experimental, trigonometric_simd_cos) {
 
   input.cos(cos_output);
 
-  bool flag = true;
+  for (int b = 0; b < batch; b++) {
+    for (int c = 0; c < channel; c++) {
+      for (int h = 0; h < height; h++) {
+        for (int w = 0; w < width; w++) {
+          EXPECT_NEAR(cos_output.getValue(b, c, h, w),
+                      result_cosine.getValue(b, c, h, w), eps);
+        }
+      }
+    }
+  }
+}
+
+TEST(nntrainer_Tensor, cos_uncontiguous_p) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(batch, channel, height, 2 * width);
+  nntrainer::Tensor shared_output(batch, channel, height, width);
+  nntrainer::Tensor ground_truth(batch, channel, height, width);
+
+  const int MOD = 10;
+  const float eps = 1e-5;
+
+  GEN_TEST_INPUT(input, (i * (channel * width * height) + j * (height * width) +
+                         k * (width) + l + 1) %
+                          MOD);
+
+  nntrainer::Tensor shared_input = input.getSharedDataTensor(dim, 0, false);
+  ground_truth.copy_with_stride(shared_input);
 
   for (int b = 0; b < batch; b++) {
     for (int c = 0; c < channel; c++) {
       for (int h = 0; h < height; h++) {
         for (int w = 0; w < width; w++) {
-          double cos_err = std::abs(cos_output.getValue(b, c, h, w) -
-                                    result_cosine.getValue(b, c, h, w));
-
-          if (cos_err > eps) {
-            flag = false;
-            std::cout << cos_output.getValue(b, c, h, w) << " VS "
-                      << result_cosine.getValue(b, c, h, w) << std::endl;
-          }
+          ground_truth.setValue(b, c, h, w,
+                                std::cos(ground_truth.getValue(b, c, h, w)));
         }
       }
     }
   }
 
-  EXPECT_EQ(flag, true);
+  shared_input.cos(shared_output);
+
+  for (int b = 0; b < batch; b++) {
+    for (int c = 0; c < channel; c++) {
+      for (int h = 0; h < height; h++) {
+        for (int w = 0; w < width; w++) {
+          EXPECT_NEAR(shared_output.getValue(b, c, h, w),
+                      ground_truth.getValue(b, c, h, w), eps);
+        }
+      }
+    }
+  }
+}
+
+TEST(nntrainer_Tensor, sin_uncontiguous_p) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(batch, channel, height, 2 * width);
+  nntrainer::Tensor shared_output(batch, channel, height, width);
+  nntrainer::Tensor ground_truth(batch, channel, height, width);
+
+  const int MOD = 10;
+  const float eps = 1e-5;
+
+  GEN_TEST_INPUT(input, (i * (channel * width * height) + j * (height * width) +
+                         k * (width) + l + 1) %
+                          MOD);
+
+  nntrainer::Tensor shared_input = input.getSharedDataTensor(dim, 0, false);
+  ground_truth.copy_with_stride(shared_input);
+
+  for (int b = 0; b < batch; b++) {
+    for (int c = 0; c < channel; c++) {
+      for (int h = 0; h < height; h++) {
+        for (int w = 0; w < width; w++) {
+          ground_truth.setValue(b, c, h, w,
+                                std::sin(ground_truth.getValue(b, c, h, w)));
+        }
+      }
+    }
+  }
+
+  shared_input.sin(shared_output);
+
+  for (int b = 0; b < batch; b++) {
+    for (int c = 0; c < channel; c++) {
+      for (int h = 0; h < height; h++) {
+        for (int w = 0; w < width; w++) {
+          EXPECT_NEAR(shared_output.getValue(b, c, h, w),
+                      ground_truth.getValue(b, c, h, w), eps);
+        }
+      }
+    }
+  }
+}
+
+TEST(nntrainer_Tensor, sin_unmatched_dim_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, 2 * width);
+  nntrainer::Tensor output(batch, channel, height, width);
+
+  const int MOD = 10;
+
+  GEN_TEST_INPUT(input, (i * (channel * width * height) + j * (height * width) +
+                         k * (width) + l + 1) %
+                          MOD);
+
+  EXPECT_THROW({ input.sin(output); }, std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, inv_sqrt_i_uncontiguous_p) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(batch, channel, height, 2 * width);
+  nntrainer::Tensor ground_truth(batch, channel, height, width);
+
+  const int MOD = 10;
+
+  GEN_TEST_INPUT(input, (i * (channel * width * height) + j * (height * width) +
+                         k * (width) + l + 1) %
+                            MOD +
+                          1);
+
+  nntrainer::Tensor shared_input = input.getSharedDataTensor(dim, 0, false);
+  ground_truth.copy_with_stride(shared_input);
+
+  for (int b = 0; b < batch; b++) {
+    for (int c = 0; c < channel; c++) {
+      for (int h = 0; h < height; h++) {
+        for (int w = 0; w < width; w++) {
+          ground_truth.setValue(
+            b, c, h, w, 1 / std::sqrt(ground_truth.getValue(b, c, h, w)));
+        }
+      }
+    }
+  }
+
+  shared_input.inv_sqrt_i();
+
+  const float eps = 1e-5;
+
+  for (int b = 0; b < batch; b++) {
+    for (int c = 0; c < channel; c++) {
+      for (int h = 0; h < height; h++) {
+        for (int w = 0; w < width; w++) {
+          EXPECT_NEAR(shared_input.getValue(b, c, h, w),
+                      ground_truth.getValue(b, c, h, w), eps);
+        }
+      }
+    }
+  }
 }
 
 int main(int argc, char **argv) {

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -4490,7 +4490,7 @@ TEST(nntrainer_neon_experimental, trigonometric_simd_sin) {
     }
   }
 
-  input.sin_transform(sin_output);
+  input.sin(sin_output);
 
   bool flag = true;
 
@@ -4544,7 +4544,7 @@ TEST(nntrainer_neon_experimental, trigonometric_simd_cos) {
     }
   }
 
-  input.cos_transform(cos_output);
+  input.cos(cos_output);
 
   bool flag = true;
 


### PR DESCRIPTION
[ Trivial ] Refactor trigonometric functions

- In case of non-contiguous Tensor, it is impossible to apply SIMD instructions. Add expection accordingly.
- Rename the function name for intuitiveness :
  -  sin_transform-> sin
  - cos_transform -> cos

[ Trivial ] Add exception in inv_sqrt_i function
    
- In case of non-contiguous Tensor, it is impossible to apply SIMD instructions. Add expection accordingly.

 [ Tensor ] Support non-contiguous case in sin, cos, inv_sqrt_i
    
- If it is not for BLAS, we can also support sin, cos, inv_sqrt_i functions for non-contiguous case as well.
- Fix related functions and add unittest accordingly.

Resolves: non-contiguous Tensor case of function usage raised from #2402 and #2410 

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: skykongkong8 <ss.kong@samsung.com>