### PR TITLE
util_simd: make typename consistent (__fp16 --> _FP16)

### DIFF
--- a/nntrainer/utils/util_simd.h
+++ b/nntrainer/utils/util_simd.h
@@ -60,11 +60,11 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
  * @brief swish function : X = (Y / (1 + exp( -Y ))) * Z
  *
  * @param N number of elements in X
- * @param X __fp16 * for Vector X
- * @param Y __fp16 * for Vector Y
- * @param Z __fp16 * for Vector Z
+ * @param X _FP16 * for Vector X
+ * @param Y _FP16 * for Vector Y
+ * @param Z _FP16 * for Vector Z
  */
-void swish(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z);
+void swish(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z);
 #endif
 
 } /* namespace nntrainer */


### PR DESCRIPTION
_FP16 is the macro to unify different fp16 typenames across different architectures or libraries.

Note that util_simd.cpp has the correct name (_FP16) while the header has the incorrect naming (__fp16).

Although this does not break the build or execution, this is not good for readability and dependency clean-ups.

CC: @skykongkong8