### PR TITLE
Make FP16 code more reusable. @open sesame 03/07 10:42

### DIFF
--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -54,6 +54,9 @@ public:
   template <typename T = float> void setActiFunc(ActivationType acti_type) {
     activation_type = acti_type;
 
+    if (typeid(T) == typeid(_FP16))
+      THROW_UNLESS_FP16_ENABLED;
+
     switch (acti_type) {
     case ActivationType::ACT_TANH:
       this->setActivation<T>(tanhFloat<T>, tanhPrime<T>);

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -19,17 +19,21 @@
 namespace nntrainer {
 
 HalfTensor::HalfTensor(std::string name_, Tformat fm) :
-  TensorBase(name_, fm, Tdatatype::FP16) {}
+  TensorBase(name_, fm, Tdatatype::FP16) {
+  THROW_UNLESS_FP16_ENABLED;
+}
 
 HalfTensor::HalfTensor(const TensorDim &d, bool alloc_now, Initializer init,
                        std::string name) :
   TensorBase(d, alloc_now, init, name) {
+  THROW_UNLESS_FP16_ENABLED;
   if (alloc_now)
     allocate();
 }
 
 HalfTensor::HalfTensor(const TensorDim &d, const void *buf) :
   HalfTensor(d, true) {
+  THROW_UNLESS_FP16_ENABLED;
   if (d.getDataLen() != 0) {
     if (buf != nullptr)
       copy(buf);
@@ -40,6 +44,7 @@ HalfTensor::HalfTensor(
   std::vector<std::vector<std::vector<std::vector<_FP16>>>> const &d,
   Tformat fm) {
 
+  THROW_UNLESS_FP16_ENABLED;
   if (d.empty() || d[0].empty() || d[0][0].empty() || d[0][0][0].empty()) {
     throw std::out_of_range(
       "[Tensor] trying to initialize HalfTensor from empty vector");
@@ -89,6 +94,7 @@ HalfTensor::HalfTensor(
 }
 
 bool HalfTensor::operator==(const HalfTensor &rhs) const {
+  THROW_UNLESS_FP16_ENABLED;
   const _FP16 *_data = (_FP16 *)getData();
   const _FP16 *_rdata = (_FP16 *)rhs.getData();
   for (size_t i = 0; i < size(); ++i) {
@@ -102,6 +108,7 @@ bool HalfTensor::operator==(const HalfTensor &rhs) const {
 
 /// @todo support allocation by src_tensor
 void HalfTensor::allocate() {
+  THROW_UNLESS_FP16_ENABLED;
   if (empty() || data)
     /// already allocated
     return;

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -205,22 +205,21 @@ public:
   virtual void print(std::ostream &out) const = 0;
 
   /**
+   * @copydoc TensorV2::apply(std::function<_FP16(_FP16)> f, TensorV2 &output)
+   */
+  virtual TensorV2 &apply(std::function<_FP16(_FP16)> f,
+                          TensorV2 &output) const {
+    THROW_UNLESS_FP16_ENABLED;
+    return output;
+  }
+
+  /**
    * @copydoc TensorV2::apply(std::function<T(T)> f, TensorV2 &output)
    */
   virtual TensorV2 &apply(std::function<float(float)> f,
                           TensorV2 &output) const {
     return output;
   }
-
-#ifdef ENABLE_FP16
-  /**
-   * @copydoc TensorV2::apply(std::function<T(T)> f, TensorV2 &output)
-   */
-  virtual TensorV2 &apply(std::function<_FP16(_FP16)> f,
-                          TensorV2 &output) const {
-    return output;
-  }
-#endif
 
   /**
    * @brief     put data of Tensor

--- a/nntrainer/tensor/tensor_dim.cpp
+++ b/nntrainer/tensor/tensor_dim.cpp
@@ -150,11 +150,7 @@ TensorDim &TensorDim::operator=(TensorDim &&rhs) noexcept {
 uint TensorDim::getDataTypeSize() const {
   switch (t_type.data_type) {
   case TensorDim::DataType::FP16:
-#ifdef ENABLE_FP16
     return sizeof(_FP16);
-#else
-    return 2;
-#endif
   case TensorDim::DataType::FP32:
     return sizeof(float);
   case TensorDim::DataType::QINT8:

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -406,6 +406,20 @@ public:
   void initialize(Initializer init);
 
   /**
+   * @brief Apply instantly to the element for _FP16
+   * @param[in] *function function pointer applied
+   * @return int ML_ERROR_NONE if successful
+   * @throws runtime_error if _FP16 is not supported.
+   */
+  int apply_i(std::function<_FP16(_FP16)> f) {
+    THROW_UNLESS_FP16_ENABLED;
+    TensorV2 result = *this;
+    apply<_FP16>(f, result);
+
+    return ML_ERROR_NONE;
+  };
+
+  /**
    * @brief Apply instantly to the element
    * @param[in] *function function pointer applied
    * @return int ML_ERROR_NONE if successful


### PR DESCRIPTION
This allows writing FP16-independent code without
breaking the current code.

This is a non-invasive subset of #2403 to
address the concern of https://github.com/nnstreamer/nntrainer/pull/2403#issuecomment-1899450849

I believe nntrainer can use this during the refactoring so that we do not introduce additional code divergences.