### PR TITLE
[TensorV2] Enable copying data from Tensor

### DIFF
--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -203,6 +203,16 @@ public:
   }
 
   /**
+   * @copydoc TensorV2::copy(const TensorV2 &from)
+   */
+  void copy(const TensorV2 &from);
+
+  /**
+   * @copydoc TensorV2::copyData(const TensorV2 &from)
+   */
+  void copyData(const TensorV2 &from);
+
+  /**
    * @copydoc TensorV2::print(std::ostream &out)
    */
   void print(std::ostream &out) const override;

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -202,6 +202,16 @@ public:
   }
 
   /**
+   * @copydoc TensorV2::copy(const TensorV2 &from)
+   */
+  void copy(const TensorV2 &from);
+
+  /**
+   * @copydoc TensorV2::copyData(const TensorV2 &from)
+   */
+  void copyData(const TensorV2 &from);
+
+  /**
    * @copydoc TensorV2::print(std::ostream &out)
    */
   void print(std::ostream &out) const override;

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -74,6 +74,23 @@ void TensorBase::putData() const {
   data->invalidate();
 }
 
+void TensorBase::reshape(const TensorDim &d) {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot reshape.";
+
+  NNTR_THROW_IF(d.getDataLen() != dim.getDataLen(), std::invalid_argument)
+    << "[Tensor]: reshape cannot change the buffer size, trying reshaping "
+       "\nfrom "
+    << getDim() << " to " << d;
+
+  dim.batch(d.batch());
+  dim.channel(d.channel());
+  dim.height(d.height());
+  dim.width(d.width());
+
+  strides = d.computeStrides();
+}
+
 size_t TensorBase::getIndex(unsigned int b, unsigned int c, unsigned int h,
                             unsigned int w) const noexcept {
   if (getFormat() == Tformat::NCHW) {

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -223,6 +223,20 @@ public:
 #endif
 
   /**
+   * @brief     Copy the Tensor
+   * @param[in] from Tensor to be copied
+   *
+   * @note copy can reshape the tensor to match the shape
+   */
+  virtual void copy(const TensorV2 &from) = 0;
+
+  /**
+   * @brief     Copy the Tensor
+   * @param[in] from Tensor to be copied
+   */
+  virtual void copyData(const TensorV2 &from) = 0;
+
+  /**
    * @brief     put data of Tensor
    * @note      It is only effective when memory_swap is used
    */

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -229,6 +229,13 @@ public:
   void putData() const;
 
   /**
+   * @brief     set Tensor Dim
+   * @param[in] d TensorDim
+   * @note      Throws std::invalid_argument if size mismatch
+   */
+  void reshape(const TensorDim &d);
+
+  /**
    * @brief     return a copy of the Tensor Dim
    * @retval    TensorDim
    */

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -180,6 +180,8 @@ void TensorV2::print(std::ostream &out) const { itensor->print(out); }
 
 void TensorV2::putData() const { itensor->putData(); }
 
+void TensorV2::reshape(const TensorDim &d) { itensor->reshape(d); }
+
 TensorDim TensorV2::getDim() const { return itensor->getDim(); }
 
 TensorDim::TensorType TensorV2::getTensorType() const {

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -530,6 +530,29 @@ public:
   void putData() const;
 
   /**
+   * @brief     Copy the Tensor
+   * @param[in] from Tensor to be copied
+   *
+   * @note copy can reshape the tensor to match the shape
+   * @note support copying data from multiple data type
+   */
+  void copy(const TensorV2 &from);
+
+  /**
+   * @brief     Copy the Tensor
+   * @param[in] from Tensor to be copied
+   * @note      support copying data from multiple data type
+   */
+  void copyData(const TensorV2 &from);
+
+  /**
+   * @brief     Copy the Tensor
+   * @param[in] from Tensor to be copied
+   * @note      only support copying data from tensor with the same data type
+   */
+  void copy_with_stride(const TensorV2 &from);
+
+  /**
    * @brief     set Tensor Dim
    * @param[in] d TensorDim
    * @note      Throws std::invalid_argument if size mismatch

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -530,6 +530,13 @@ public:
   void putData() const;
 
   /**
+   * @brief     set Tensor Dim
+   * @param[in] d TensorDim
+   * @note      Throws std::invalid_argument if size mismatch
+   */
+  void reshape(const TensorDim &d);
+
+  /**
    * @brief     return a copy of the Tensor Dim
    * @retval    TensorDim
    */


### PR DESCRIPTION
This PR enables deep copy functionalities of a contiguous tensor with the following functions. `copy()`, `copyData()`, and `copy_with_strides()`.

The copy function completely copies the target tensor values regardless of the dimension of the input tensor. All elements and properties of the original tensor are copied to the new tensor. Therefore, if the copy function is used, a new tensor with the same size and shape as the original tensor is created.

On the other hand, the copyData function must match the size of the input and target tensors. This function only copies the data of the original tenor, so if the size or shape of the tensor is different, the copy may not be done properly.

Note that `copy` and `copyData` functions support copy data from multiple tensor data types while the `copy_with_strides` function only supports copying data from the same data type.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped
