### PR TITLE
[TensorV2] Multiplication support

### DIFF
--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -191,27 +191,20 @@ public:
 
   /**
    * @copydoc TensorV2::multiply_i(float const &value)
-   * @todo    Need implementation and unit tests
    */
-  int multiply_i(float const &value) override { return 0; }
+  int multiply_i(float const &value) override;
 
   /**
    * @copydoc TensorV2::multiply(float const &value, TensorV2 &out)
-   * @todo    Need implementation and unit tests
    */
-  TensorV2 &multiply(float const &value, TensorV2 &out) const override {
-    return out;
-  }
+  TensorV2 &multiply(float const &value, TensorV2 &out) const override;
 
   /**
    * @copydoc TensorV2::multiply(TensorV2 const &m, TensorV2 &output, const
    * float beta = 0.0)
-   * @todo    Need implementation and unit tests
    */
   TensorV2 &multiply(TensorV2 const &m, TensorV2 &output,
-                     const float beta = 0.0) const override {
-    return output;
-  }
+                     const float beta = 0.0) const override;
 
   /**
    * @copydoc TensorV2::copy(const TensorV2 &from)

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -190,27 +190,20 @@ public:
 
   /**
    * @copydoc TensorV2::multiply_i(float const &value)
-   * @todo    Need implementation and unit tests
    */
-  int multiply_i(float const &value) override { return 0; }
+  int multiply_i(float const &value) override;
 
   /**
    * @copydoc TensorV2::multiply(float const &value, TensorV2 &out)
-   * @todo    Need implementation and unit tests
    */
-  TensorV2 &multiply(float const &value, TensorV2 &out) const override {
-    return out;
-  }
+  TensorV2 &multiply(float const &value, TensorV2 &out) const override;
 
   /**
    * @copydoc TensorV2::multiply(TensorV2 const &m, TensorV2 &output, const
    * float beta = 0.0)
-   * @todo    Need implementation and unit tests
    */
   TensorV2 &multiply(TensorV2 const &m, TensorV2 &output,
-                     const float beta = 0.0) const override {
-    return output;
-  }
+                     const float beta = 0.0) const override;
 
   /**
    * @copydoc TensorV2::copy(const TensorV2 &from)

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -173,7 +173,12 @@ TensorV2 &TensorV2::multiply_strided(TensorV2 const &m, TensorV2 &output,
   return output;
 }
 
-int TensorV2::multiply_i(float const &value) { return ML_ERROR_NONE; }
+int TensorV2::multiply_i(float const &value) {
+  NNTR_THROW_IF(!getContiguous(), std::invalid_argument)
+    << getName() << " is not contiguous, cannot multiply";
+
+  return itensor->multiply_i(value);
+}
 
 TensorV2 TensorV2::multiply(float const &value) const {
   TensorV2 t;
@@ -181,10 +186,18 @@ TensorV2 TensorV2::multiply(float const &value) const {
 }
 
 TensorV2 &TensorV2::multiply(float const &value, TensorV2 &out) const {
+  itensor->multiply(value, out);
   return out;
 }
 
 int TensorV2::multiply_i(TensorV2 const &m, const float beta) {
+  try {
+    this->multiply(m, *this, beta);
+  } catch (std::exception &err) {
+    ml_loge("%s %s", typeid(err).name(), err.what());
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
   return ML_ERROR_NONE;
 }
 
@@ -195,6 +208,7 @@ TensorV2 TensorV2::multiply(TensorV2 const &m, const float beta) const {
 
 TensorV2 &TensorV2::multiply(TensorV2 const &m, TensorV2 &output,
                              const float beta) const {
+  itensor->multiply(m, output, beta);
   return output;
 }
 


### PR DESCRIPTION
This PR adds support for performing the multiplication operation on two tensors.

**Changes proposed in this PR:**
- TensorV2 includes member functions to perform tensor multiplication.
- FloatTensor and HalfTensor take TensorV2 as input/output to perform multiplication.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped