### PR TITLE
[TensorV2] `multiply_strided()` skeleton

### DIFF
--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -179,6 +179,17 @@ public:
                   TensorV2 &output) const override;
 
   /**
+   * @copydoc TensorV2::multiply_strided(TensorV2 const &m, TensorV2 &output,
+   * const float beta)
+   * @todo    Need implementation and unit tests
+   */
+  TensorV2 multiply_strided(TensorV2 const &m, TensorV2 &output,
+                            const float beta) const override {
+    throw std::logic_error("multiply_strided is not implemented yet");
+    return output;
+  }
+
+  /**
    * @copydoc TensorV2::multiply_i(float const &value)
    * @todo    Need implementation and unit tests
    */

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -178,6 +178,17 @@ public:
                   TensorV2 &output) const override;
 
   /**
+   * @copydoc TensorV2::multiply_strided(TensorV2 const &m, TensorV2 &output,
+   * const float beta)
+   * @todo    Need implementation and unit tests
+   */
+  TensorV2 multiply_strided(TensorV2 const &m, TensorV2 &output,
+                            const float beta) const override {
+    throw std::logic_error("multiply_strided is not implemented yet");
+    return output;
+  }
+
+  /**
    * @copydoc TensorV2::multiply_i(float const &value)
    * @todo    Need implementation and unit tests
    */

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -183,6 +183,13 @@ public:
   virtual void initialize(Initializer init) = 0;
 
   /**
+   * @copydoc TensorV2::multiply_strided(TensorV2 const &m, TensorV2 &output,
+   * const float beta)
+   */
+  virtual TensorV2 multiply_strided(TensorV2 const &m, TensorV2 &output,
+                                    const float beta) const = 0;
+
+  /**
    * @copydoc TensorV2::multiply_i(float const &value)
    */
   virtual int multiply_i(float const &value) = 0;

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -151,6 +151,28 @@ TensorV2 &TensorV2::apply(std::function<TensorV2 &(TensorV2, TensorV2 &)> f,
   return f(*this, output);
 }
 
+int TensorV2::multiply_i_strided(TensorV2 const &m, const float beta) {
+  try {
+    this->multiply_strided(m, *this, beta);
+  } catch (std::exception &err) {
+    ml_loge("%s %s", typeid(err).name(), err.what());
+    return ML_ERROR_INVALID_PARAMETER;
+  }
+
+  return ML_ERROR_NONE;
+}
+
+TensorV2 TensorV2::multiply_strided(TensorV2 const &m, const float beta) const {
+  TensorV2 t;
+  return this->multiply_strided(m, t, beta);
+}
+
+TensorV2 &TensorV2::multiply_strided(TensorV2 const &m, TensorV2 &output,
+                                     const float beta) const {
+  throw std::logic_error("multiply_strided is not implemented yet");
+  return output;
+}
+
 int TensorV2::multiply_i(float const &value) { return ML_ERROR_NONE; }
 
 TensorV2 TensorV2::multiply(float const &value) const {

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -469,6 +469,47 @@ public:
                   TensorV2 &output) const;
 
   /**
+   * @brief     Multiply Tensor Elementwise
+   * @param[in] m Tensor to be multiplied
+   * @param[in] beta scalar to multiply output with and add
+   * @retval    #ML_ERROR_NONE successful
+   *
+   * @note support different strided inputs and output
+   * @note does not support broadcasting
+   *
+   * @todo merge this to multiply_i
+   */
+  int multiply_i_strided(TensorV2 const &m, const float beta = 0.0);
+
+  /**
+   * @brief     Multiply Tensor Element by Element ( Not the MxM )
+   * @param[in] m Tensor to be multiplied
+   * @param[in] beta scalar to multiply output with and add
+   * @retval    Calculated Tensor
+   *
+   * @note support different strided inputs and output
+   * @note does not support broadcasting
+   *
+   * @todo merge this to multiply
+   */
+  TensorV2 multiply_strided(TensorV2 const &m, const float beta = 0.0) const;
+
+  /**
+   * @brief     Multiply Tensor Element by Element ( Not the MxM )
+   * @param[in] m Tensor to be multiplied
+   * @param[out] output Tensor to store the result
+   * @param[in] beta scalar to multiply output with and add
+   * @retval    Calculated Tensor
+   *
+   * @note support different strided inputs and output
+   * @note does not support broadcasting
+   *
+   * @todo merge this to multiply
+   */
+  TensorV2 &multiply_strided(TensorV2 const &m, TensorV2 &output,
+                             const float beta = 0.0) const;
+
+  /**
    * @brief     Multiply value element by element immediately
    * @param[in] value multiplier
    * @retval    #ML_ERROR_INVALID_PARAMETER Tensor dimension is not right


### PR DESCRIPTION
This pull request introduces a basic structure of tensor multiplication operations that support different strided inputs and outputs.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped