### PR TITLE
[CI] Add cpp file format checker

### DIFF
--- a/.github/workflows/cpp_linter.yml
+++ b/.github/workflows/cpp_linter.yml
@@ -1,0 +1,25 @@
+name: C++ Format Checker
+
+on: pull_request
+
+jobs:
+  cpp-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cpp-linter/cpp-linter-action@v2
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: file
+          extensions: 'cc'
+          version: 16
+          lines-changed-only: true
+
+
+      - name: failing fast
+        if: steps.linter.outputs.clang-format-checks-failed > 0
+        run: |
+          echo "This PR failed to pass the C++ source file format checks."
+          exit 1


### PR DESCRIPTION
This patch adds a Github Action workflow to check cpp file format
- this file imported from deviceMLOps.MLAgent
- this file use cpp_linter marketplace actions

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped