### PR TITLE
[CI] Rename laber & upgrade node version & add workflow fail process

### DIFF
--- a/.github/workflows/check_count.yml
+++ b/.github/workflows/check_count.yml
@@ -1,4 +1,4 @@
-name: Upload Data
+name: Check Review
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
     types: [edited, dismissed, submitted]
 
 jobs:
-  label:
+  check_review:
     runs-on: ubuntu-latest
     steps:
       - name: review_count
@@ -27,7 +27,7 @@ jobs:
           echo $review > ./pr/review_num
           echo $IS_CONTAIN > ./pr/contain_bool
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr_number
           path: pr/

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,15 +1,23 @@
-name: Labeler
+name: Review_label
 on:
   workflow_run:
-    workflows: ["Upload Data"]
+    workflows: ["Check Review"]
     types:
       - completed
 jobs:
+
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'The triggering workflow failed'
+
   label:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: "Download artifact"
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -36,7 +44,7 @@ jobs:
         run: unzip pr_number.zip
 
       - name: Remove label if approved review >= 3
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -55,7 +63,7 @@ jobs:
             }
 
       - name: Make label if approved review < 3
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
In order to improve the convenience and robustness of GitAction, make the following modifications:

1. In accordance with the guidelines to upgrade from Node 16 to Node 20, change gitaction-script version to v7
- ref : https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
2. If the check_count fails, alter it so that no additional actions are executed and the process terminates immediately.
3. adopt more descriptive and clear names for better understanding.

**Changes proposed in this PR:**
    renamed:    .github/workflows/Upload.yml -> .github/workflows/check_count.yml
    modified:   .github/workflows/labeler.yml

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped