### PR TITLE
[TensorV2] Refactoring TensorBase pointer to shared_ptr

### DIFF
--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -708,7 +708,7 @@ public:
   }
 
 private:
-  TensorBase *itensor;
+  std::shared_ptr<TensorBase> itensor;
 };
 
 } // namespace nntrainer


### PR DESCRIPTION
This PR proposes refactoring the TensorV2 class to use a shared_ptr instead of a raw pointer for managing its TensorBase object. By adopting this change, we can improve the safety and reliability of our code and reduce the likelihood of memory leaks and other issues related to manual memory management.

**Changes proposed in this PR:**
- Replace the TensorBase pointer in the Tensor class with a shared_ptr.
- Update any relevant code to use the shared_ptr instead of the raw pointer.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped