### PR TITLE
[CI] Update cpp-linter's option - extensions

### DIFF
--- a/.github/workflows/cpp_linter.yml
+++ b/.github/workflows/cpp_linter.yml
@@ -13,7 +13,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           style: file
-          extensions: 'cc'
           version: 16
           lines-changed-only: true
 


### PR DESCRIPTION
update cpp-linter action's option
- extensions : cc only -> defualt option

below is cpp-linter's defualt Option & Description

```
extensions
Description: The file extensions to run the action against. This is a comma-separated string.
Default: 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
```

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped