### PR TITLE
[API] Add getVersion function

### DIFF
--- a/api/ccapi/include/common.h
+++ b/api/ccapi/include/common.h
@@ -18,6 +18,7 @@
 #if __cplusplus >= MIN_CPP_VERSION
 
 #include <nntrainer-api-common.h>
+#include <string>
 
 namespace ml {
 namespace train {
@@ -41,6 +42,11 @@ enum class ExecutionMode {
   INFERENCE, /** Inference mode, label is optional */
   VALIDATE   /** Validate mode, label is necessary */
 };
+
+/**
+ * @brief Get the version of NNTrainer
+ */
+extern std::string getVersion();
 
 } // namespace train
 } // namespace ml

--- a/api/ccapi/src/factory.cpp
+++ b/api/ccapi/src/factory.cpp
@@ -24,6 +24,8 @@
 #include <optimizer.h>
 #include <optimizer_wrapped.h>
 
+#include <cstdlib>
+
 namespace ml {
 namespace train {
 
@@ -136,6 +138,16 @@ createLearningRateScheduler(const std::string &type,
                             const std::vector<std::string> &properties) {
   auto &ac = nntrainer::AppContext::Global();
   return ac.createObject<ml::train::LearningRateScheduler>(type, properties);
+}
+
+std::string getVersion() {
+  std::string version = std::to_string(VERSION_MAJOR);
+  version += ".";
+  version += std::to_string(VERSION_MINOR);
+  version += ".";
+  version += std::to_string(VERSION_MICRO);
+
+  return version;
 }
 
 } // namespace train

--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -83,7 +83,7 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
 
 LOCAL_ARM_NEON      := true
 LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ -DML_API_COMMON=1
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1 -DVERSION_MAJOR=@VERSION_MAJOR@ -DVERSION_MINOR=@VERSION_MINOR@ -DVERSION_MICRO=@VERSION_MICRO@
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp

--- a/jni/meson.build
+++ b/jni/meson.build
@@ -20,6 +20,10 @@ and_conf.set('MESON_NNTRAINER_INCS', ' '.join(nntrainer_inc_abs))
 and_conf.set('MESON_CCAPI_NNTRAINER_SRCS', ' '.join(ccapi_src))
 and_conf.set('MESON_CCAPI_NNTRAINER_INCS', ' '.join(ccapi_inc_abs))
 
+and_conf.set('VERSION_MAJOR', ' '.join(nntrainer_version_split[0]))
+and_conf.set('VERSION_MINOR', ' '.join(nntrainer_version_split[1]))
+and_conf.set('VERSION_MICRO', ' '.join(nntrainer_version_split[2]))
+
 if get_option('enable-capi').enabled()
    and_conf.set('MESON_CAPI_NNTRAINER_SRCS', ' '.join(capi_src))
    and_conf.set('MESON_CAPI_NNTRAINER_INCS', ' '.join(capi_inc_abs))

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,16 @@ project('nntrainer', 'c', 'cpp',
     'buildtype=release'
   ]
 )
+
+# Set version info
+nntrainer_version = meson.project_version()
+nntrainer_version_split = nntrainer_version.split('.')
+
+add_project_arguments('-DVERSION="' + nntrainer_version + '"', language: ['c', 'cpp'])
+add_project_arguments('-DVERSION_MAJOR=' + nntrainer_version_split[0], language: ['c', 'cpp'])
+add_project_arguments('-DVERSION_MINOR=' + nntrainer_version_split[1], language: ['c', 'cpp'])
+add_project_arguments('-DVERSION_MICRO=' + nntrainer_version_split[2], language: ['c', 'cpp'])
+
 extra_defines = ['-DMIN_CPP_VERSION=201703L']
 
 cc = meson.get_compiler('c')


### PR DESCRIPTION
An API has been added to check the version of nntrainer through the project version of meson build.

Available via ml::train::getVersion.

issue : #2435
Signed-off-by: SeoHyungjun <hyungjun.seo@samsung.com>