### PR TITLE
[ Bug ] Fix coverity issues

### DIFF
--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -672,7 +672,6 @@ std::vector<Tensor *> Manager::requestWeightOptimizerVariables(
   const std::vector<TensorDim> &dims, const std::string &name,
   const TensorLifespan &lifespan, bool is_grad_clip,
   Tensor::Initializer initializer) {
-  auto const exec_order = weight_pool.getExecutionOrder(name);
 
   std::vector<Tensor *> ret;
   ret.reserve(dims.size());

--- a/nntrainer/tensor/optimized_v2_planner.cpp
+++ b/nntrainer/tensor/optimized_v2_planner.cpp
@@ -241,7 +241,7 @@ size_t OptimizedV2Planner::planLayout(
 #endif
     for (auto &req : wgrad_requests) {
       for (unsigned int idx = 0; idx < wgrad_sorted_req.size(); idx++) {
-        auto const sr = wgrad_sorted_req[idx];
+        const auto &sr = wgrad_sorted_req[idx];
         bool merge = true;
         if (sr.mem_req->size >= req.size) {
           for (auto &interval : sr.start_end) {

--- a/nntrainer/tensor/task_executor.cpp
+++ b/nntrainer/tensor/task_executor.cpp
@@ -43,7 +43,7 @@ TaskExecutor::TaskExecutor(const std::string &n) :
       auto &task_info = task_queue.front();
       lk.unlock();
 
-      auto id = std::get<int>(task_info);
+      const auto &id = std::get<int>(task_info);
       auto callback = std::get<CompleteCallback>(task_info);
 
       auto status = worker(task_info);


### PR DESCRIPTION
- Fix non-const variables to const variables since their value is never changed in actual practice
- Use reference to avoid object copy
- Delete redundant variable

Resolves:
```
non-const type variable, but its value is never changed.
auto_causes_copy
```

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped