### PR TITLE
Clean up fp16 related build scripts and conditions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,8 @@ if get_option('enable-fp16')
      extra_defines += '-DENABLE_FP16=1'
      extra_defines += '-DUSE__FP16=1'
      extra_defines += '-DUSE_NEON=1'
+   elif arch == 'arm'
+     error ('FP16/ARM code (blas_neon.cpp) uses armv8.2 instructions. armv7 is not supported.')
    else
      has_avx512fp16 = cc.has_argument('-mavx512fp16')
      if (has_avx512fp16)

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -1106,7 +1106,7 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
         float32x4_t y0_3_32 = vld1q_f32(y0_3);
         y0_3_32 = vfmaq_n_f32(y0_3_32, vld1q_f32(wvec0_3), x);
 
-        for (int j = 0; j < cols - idx; ++j) {
+        for (unsigned int j = 0; j < cols - idx; ++j) {
           Y32[idx + j] = y0_3_32[j];
         }
       }

--- a/nntrainer/utils/meson.build
+++ b/nntrainer/utils/meson.build
@@ -24,7 +24,7 @@ if get_option('enable-trace')
   util_headers += 'tracer.h'
 endif
 
-if get_option('platform') == 'android'
+if get_option('enable-fp16')
   util_sources += 'util_simd_neon.cpp'
   util_headers += 'util_simd_neon.h'
 endif


### PR DESCRIPTION
1. unsigned / signed int type mismatch in blas_neon.cpp
2. build condition cleanup (meson.build)
3. explicitly disable fp16 in armv7l/Tizen. (not because of HW support, but because of the library usage of nntrainer)