### PR TITLE
[ Tensor ] copyData to fp16 from fp32

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -3092,7 +3092,9 @@ void Tensor::copyData(const Tensor &from) {
       }
     } else if (getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-      if (from.getDataType() == ml::train::TensorDim::DataType::QINT8) {
+      if (from.getDataType() == ml::train::TensorDim::DataType::FP32) {
+        scopy(size(), from.getData<float>(), 1, getData<_FP16>(), 1);
+      } else if (from.getDataType() == ml::train::TensorDim::DataType::QINT8) {
         scopy_int8_to_float16(from.size(), from.getData<uint8_t>(), 1,
                               getData<_FP16>(), 1);
       } else if (from.getDataType() == ml::train::TensorDim::DataType::QINT4) {


### PR DESCRIPTION
- copyData function now supports fp16_fp32 conversion
- This is crucial for BatchNormalization layer in mixed precision training

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped