### PR TITLE
[ fp16 ] Fix to avoid build error / compiler warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -66,7 +66,7 @@ warning_c_flags = [
 
 
 if get_option('enable-fp16')
-   arch = target_machine.cpu_family()
+   arch = host_machine.cpu_family()
    if get_option('platform') == 'android'
      add_project_arguments('-mfp16-format=ieee', language: ['c', 'cpp'])
      extra_defines += '-DENABLE_FP16=1'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -37,6 +37,7 @@ option('enable-blas', type: 'boolean', value: true)
 option('enable-fp16', type: 'boolean', value: false)
 option('enable-cublas', type: 'boolean', value: false)
 option('enable-openmp', type: 'boolean', value: true)
+option('enable-neon', type: 'boolean', value: false)
 
 # ml-api dependency (to enable, install capi-inference from github.com/nnstreamer/api )
 # To inter-operate with nnstreamer and ML-API packages, you need to enable this.

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -34,10 +34,14 @@ tensor_headers = [
   'blas_interface.h'
 ]
 
-arch = target_machine.cpu_family()
-
-if get_option('platform') == 'android' or arch == 'aarch64'
-  tensor_sources += 'blas_neon.cpp'
+arch = host_machine.cpu_family()
+if get_option('enable-fp16') 
+  if arch == 'arm'
+    error ('FP16/ARM code (blas_neon.cpp) uses armv8.2 instructions. armv7 is not supported.')
+  elif arch == 'aarch64' or get_option('enable-neon')
+    tensor_sources += 'blas_neon.cpp'
+    tensor_headers += 'blas_neon.h'
+  endif
 endif
 
 if get_option('enable-fp16')

--- a/nntrainer/utils/meson.build
+++ b/nntrainer/utils/meson.build
@@ -24,9 +24,14 @@ if get_option('enable-trace')
   util_headers += 'tracer.h'
 endif
 
-if get_option('enable-fp16')
-  util_sources += 'util_simd_neon.cpp'
-  util_headers += 'util_simd_neon.h'
+arch = host_machine.cpu_family()
+if get_option('enable-fp16') 
+  if arch == 'arm'
+    error ('FP16/ARM code (blas_neon.cpp) uses armv8.2 instructions. armv7 is not supported.')
+  elif arch == 'aarch64' or get_option('enable-neon')
+    util_sources += 'util_simd_neon.cpp'
+    util_headers += 'util_simd_neon.h'
+  endif
 endif
 
 foreach s : util_sources

--- a/tools/package_android.sh
+++ b/tools/package_android.sh
@@ -16,13 +16,13 @@ pushd $TARGET
 if [ ! -d builddir ]; then
     #default value of openblas num threads is 1 for android
     #enable-tflite-interpreter=false is just temporally until ci system is stabel
-  meson builddir -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true
+  meson builddir -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Denable-neon=true
 else
   echo "warning: $TARGET/builddir has already been taken, this script tries to reconfigure and try building"
   pushd builddir
     #default value of openblas num threads is 1 for android
     #enable-tflite-interpreter=false is just temporally until ci system is stabel  
-    meson configure -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true
+    meson configure -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Denable-neon=true
     meson --wipe
   popd
 fi


### PR DESCRIPTION
- Use unsigend int iterator to avoid compiler warnings
- Keeping in mind that NEON is properly supported on later version than ARMv8.2, modify sources to include.