### PR TITLE
[bugfix] Fix the creation of SharedDataTensor

### DIFF
--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -105,10 +105,10 @@ void TensorBase::createSharedDataTensor(const TensorBase *src, TensorBase *dest,
       src->src_tensor->tensor(), offset + src->src_tensor->offset());
 }
 
-TensorBase *TensorBase::getSharedDataTensor(const TensorDim dim_, size_t offset,
-                                            bool reset_stride,
-                                            const std::string &name_) {
-  TensorBase *ret = this;
+void TensorBase::getSharedDataTensor(const TensorDim dim_, size_t offset,
+                                     bool reset_stride,
+                                     const std::string &name_,
+                                     TensorBase *ret) {
   if (dim_.getFormat() != ret->dim.getFormat())
     throw std::invalid_argument("Tensor format does not match");
 
@@ -133,8 +133,6 @@ TensorBase *TensorBase::getSharedDataTensor(const TensorDim dim_, size_t offset,
    * called for the output tensor before operating on the output tensor.
    */
   createSharedDataTensor(this, ret, offset);
-
-  return ret;
 }
 
 TensorBase::BroadcastInfoV2

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -382,15 +382,19 @@ public:
    * @brief Get new tensor which shares memory with current tensor but different
    * shape
    *
-   * @param dim new dimension to be set for this tensor
-   * @param offset offset to be used from the start of the data in elements
+   * @param[in] dim new dimension to be set for this tensor
+   * @param[in] offset offset to be used from the start of the data in elements
+   * @param[in] reset_stride reset stride
+   * @param[in] name_ name of the Tensor
+   * @param[out] ret output TensorBase pointer
    * @note The new tensor will share the same data as the current tensor but
    * can have different size.
    * @note New size added with offset must be less than the size of the original
    * tensor.
    */
-  TensorBase *getSharedDataTensor(const TensorDim dim_, size_t offset,
-                                  bool reset_stride, const std::string &name_);
+  void getSharedDataTensor(const TensorDim dim_, size_t offset,
+                           bool reset_stride, const std::string &name_,
+                           TensorBase *ret);
 
   static constexpr float epsilon = 1e-5;
 

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -359,8 +359,8 @@ TensorV2 TensorV2::getSharedDataTensor(const TensorDim dim_, size_t offset,
                                        bool reset_stride,
                                        const std::string &name_) const {
   TensorV2 ret = *this;
-  ret.itensor = std::shared_ptr<TensorBase>(
-    itensor->getSharedDataTensor(dim_, offset, reset_stride, name_));
+  itensor->getSharedDataTensor(dim_, offset, reset_stride, name_,
+                               ret.itensor.get());
   return ret;
 }
 


### PR DESCRIPTION
This PR resolves a bug that occurred after #2428 in the TensorV2 class when getting a shared data tensor, which shares memory.

** Self-evaluation**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped