### PR TITLE
[ bug ] Use fp16 when applying sqrt_i

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -3479,7 +3479,7 @@ void Tensor::inv_sqrt_i() {
 #ifdef ENABLE_FP16
     if (!contiguous) {
       apply_i<_FP16>([](_FP16 val) -> _FP16 {
-        return 1 / std::sqrt(static_cast<float>(val));
+        return static_cast<_FP16>(1 / std::sqrt(static_cast<float>(val)));
       });
     } else {
       inv_sqrt_inplace(this->size(), getData<_FP16>());


### PR DESCRIPTION
- std::sqrt does not support fp16, so need to be casted
- Have to re-cast to fp16 when using apply function with _Float16 ( not __fp16 )

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped