### PR TITLE
[blas] Optimize gemv and gemm for float16 data type

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -870,8 +870,7 @@ unsigned int isamax(const unsigned int N, const float *X, const int incX) {
 #endif
 }
 
-void sine(const unsigned int N, float *X, float *Y,
-                         float alpha) {
+void sine(const unsigned int N, float *X, float *Y, float alpha) {
 #ifdef USE_NEON
   nntrainer::neon::sine_neon(N, X, Y, alpha);
 #else
@@ -883,8 +882,7 @@ void sine(const unsigned int N, float *X, float *Y,
 #endif
 }
 
-void cosine(const unsigned int N, float *X, float *Y,
-                           float alpha) {
+void cosine(const unsigned int N, float *X, float *Y, float alpha) {
 #ifdef USE_NEON
   nntrainer::neon::cosine_neon(N, X, Y, alpha);
 #else


### PR DESCRIPTION
## Description

This pull request aims to optimize the performance of `GEMV` and `GEMM` operations when the data type is float16. 
This is achieved by converting the half-precision data to single-precision and utilizing the cblas functions instead of manually computing them using for loops. 
This change should improve the overall efficiency of these operations without requiring ARM NEON support. 

## Result

### 1. `GEMV`

#### Before
 | TensorDim | Time | CPU | Iterations |
| --- | --- | --- | --- |
| (1, 1, 1, 512) $\times$ (1, 1, 512, 512) | 1.32ms | 1.32 ms | 452 |
| (1, 1, 1, 1024) $\times$ (1, 1, 1024, 1024) | 5.37ms | 5.37ms | 130|
| (1, 1, 1, 2048) $\times$ (1, 1, 2048, 2048) | 22.4ms | 22.4ms | 31|
| (1, 1, 1, 768) $\times$ (1, 1, 768, 96000) |  407ms | 407ms | 2 |

#### After
 | TensorDim | Time | CPU | Iterations |
| --- | --- | --- | --- |
| (1, 1, 1, 512) $\times$ (1, 1, 512, 512) | 0.953ms | 0.933ms | 754 |
| (1, 1, 1, 1024) $\times$ (1, 1, 1024, 1024) | 3.67ms | 3.64ms | 188 |
| (1, 1, 1, 2048) $\times$ (1, 1, 2048, 2048) | 15.6ms | 15.0ms | 45 |
| (1, 1, 1, 768) $\times$ (1, 1, 768, 96000) |  278ms | 278ms | 3 |

### 2. `GEMM`

#### Before

 | TensorDim | Time | CPU | Iterations |
| --- | --- | --- | --- |
| (1, 1, 512, 512) $\times$ (1, 1, 512, 512) | 696ms | 696 ms | 1 |
| (1, 1, 1024, 1024) $\times$ (1, 1, 1024, 1024) | 5.58s | 5.58s | 1|
| (1, 1, 2048, 2048) $\times$ (1, 1, 2048, 2048) | 46.1s | 46.1s | 1|
| (1, 1, 50, 768) $\times$ (1, 1, 768, 96000) |  20.7s | 20.7s | 1 |

#### After
 | TensorDim | Time | CPU | Iterations |
| --- | --- | --- | --- |
| (1, 1, 512, 512) $\times$ (1, 1, 512, 512) | 5.87ms | 4.84 ms | 152 |
| (1, 1, 1024, 1024) $\times$ (1, 1, 1024, 1024) | 24.3ms | 24.3ms | 29 |
| (1, 1, 2048, 2048) $\times$ (1, 1, 2048, 2048) | 149ms | 149ms | 5 |
| (1, 1, 50, 768) $\times$ (1, 1, 768, 96000) |  332ms | 332ms | 2 |

Tested with [Google Benchmark](https://github.com/google/benchmark/) 

## Note

Time: The average wall time per iteration
CPU: The average CPU time per iteration
Iterations: The number of iterations the benchmark ran

#### Hardware spec
Run on (20 X 4398.75 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x10)
  L1 Instruction 32 KiB (x10)
  L2 Unified 1280 KiB (x10)
  L3 Unified 25600 KiB (x1)





