### PR TITLE
[CI] Update cpp-linter ci (false file-annotations)

### DIFF
--- a/.github/workflows/cpp_linter.yml
+++ b/.github/workflows/cpp_linter.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cpp-linter/cpp-linter-action@v2
+      - uses: cpp-linter/cpp-linter-action@v2.8.0
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -15,7 +15,8 @@ jobs:
           style: file
           version: 16
           lines-changed-only: true
-
+          file-annotations: false
+          step-summary: true
 
       - name: failing fast
         if: steps.linter.outputs.clang-format-checks-failed > 0

--- a/nntrainer/dataset/func_data_producer.h
+++ b/nntrainer/dataset/func_data_producer.h
@@ -55,7 +55,7 @@ public:
   const std::string getType() const override;
 
   /**
-   * @copydoc DataProducer::setProeprty(const std::vector<std::string>
+   * @copydoc DataProducer::setProperty(const std::vector<std::string>
    * &properties)
    */
   void setProperty(const std::vector<std::string> &properties) override;


### PR DESCRIPTION
For now we use cpp-linter as option 'file-annotations' but there is too many annotations and that make hard to read code

So make false file-annotations & replace that to **step-summary**

- fix typo for check cpp-linter exec

ref : https://github.com/marketplace/actions/c-c-linter

**Changes proposed in this PR:**
- modified:   .github/workflows/cpp_linter.yml
- modified:   nntrainer/dataset/func_data_producer.h

Resolves:
- #2463


### --> I will add nntrainer-review-bot that make comment in PR page.
### --> for now you can check error/warning in action's summary page.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped