### PR TITLE
[TensorV2] Subtraction support @open sesame 02/20 11:30

### DIFF
--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -503,7 +503,8 @@ TensorV2 &FloatTensor::add(TensorV2 const &m, TensorV2 &output,
 }
 
 TensorV2 &FloatTensor::subtract(float const &value, TensorV2 &output) const {
-  throw std::logic_error("FloatTensor::subtract is not implemented yet");
+  auto f = std::bind(std::minus<float>(), std::placeholders::_1, value);
+  apply(f, output);
   return output;
 }
 

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -468,7 +468,9 @@ TensorV2 &HalfTensor::add(TensorV2 const &m, TensorV2 &output,
 }
 
 TensorV2 &HalfTensor::subtract(float const &value, TensorV2 &output) const {
-  throw std::logic_error("HalfTensor::subtract is not implemented yet");
+  auto f = std::bind(std::minus<_FP16>(), std::placeholders::_1,
+                     static_cast<_FP16>(value));
+  apply(f, output);
   return output;
 }
 

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -317,33 +317,26 @@ TensorV2 &TensorV2::add(TensorV2 const &m, TensorV2 &output,
 }
 
 int TensorV2::subtract_i(float const &value) {
-  throw std::logic_error("TensorV2::subtract_i is not implemented yet");
-  return -1;
+  this->subtract(value, *this);
+  return ML_ERROR_NONE;
 }
 
 TensorV2 TensorV2::subtract(float const &value) const {
-  throw std::logic_error("TensorV2::subtract is not implemented yet");
-  return *this;
+  TensorV2 output("", getFormat(), getDataType());
+  return subtract(value, output);
 }
 
 TensorV2 &TensorV2::subtract(float const &value, TensorV2 &output) const {
-  throw std::logic_error("TensorV2::subtract is not implemented yet");
+  itensor->subtract(value, output);
   return output;
 }
 
-int TensorV2::subtract_i(TensorV2 const &m) {
-  throw std::logic_error("TensorV2::subtract_i is not implemented yet");
-  return -1;
-}
+int TensorV2::subtract_i(TensorV2 const &m) { return add_i(m, -1); }
 
-TensorV2 TensorV2::subtract(TensorV2 const &m) const {
-  throw std::logic_error("TensorV2::subtract is not implemented yet");
-  return *this;
-}
+TensorV2 TensorV2::subtract(TensorV2 const &m) const { return add(m, -1); }
 
 TensorV2 &TensorV2::subtract(TensorV2 const &m, TensorV2 &output) const {
-  throw std::logic_error("TensorV2::subtract is not implemented yet");
-  return output;
+  return add(m, output, -1);
 }
 
 void TensorV2::print(std::ostream &out) const { itensor->print(out); }


### PR DESCRIPTION
This PR adds support for performing the subtraction operation on two tensors.

**Changes proposed**
- TensorV2 includes member functions to perform tensor subtraction.
- FloatTensor and HalfTensor take TensorV2 as input/output to perform subtraction.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped