### PR TITLE
[ rename/neon ] Fix neon-related functions name

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -83,7 +83,7 @@ static void saxpy_FP16(const unsigned int N, const float alpha, const _FP16 *X,
 #if (defined USE__FP16 && USE_NEON)
   // USE__FP16 is defined when platform is android
   if (incX == 1 && incY == 1) {
-    nntrainer::neon::saxpy_neon_fp16(N, alpha, X, Y);
+    nntrainer::neon::saxpy_fp16(N, alpha, X, Y);
   } else {
     saxpy_loop_fp16();
   }
@@ -99,9 +99,9 @@ static void sgemv_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
                        const float beta, _FP16 *Y, const int incY) {
 #if (defined USE__FP16 && USE_NEON)
   if (TransA == CblasTrans) {
-    nntrainer::neon::sgemv_transpose_neon_fp16(A, X, Y, M, N, alpha, beta);
+    nntrainer::neon::sgemv_transpose_fp16(A, X, Y, M, N, alpha, beta);
   } else {
-    nntrainer::neon::sgemv_neon_fp16(A, X, Y, M, N, alpha, beta);
+    nntrainer::neon::sgemv_fp16(A, X, Y, M, N, alpha, beta);
   }
 #else
   unsigned int lenX =
@@ -138,7 +138,7 @@ static _FP16 sdot_FP16(const unsigned int N, const _FP16 *X,
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
-    ret = nntrainer::neon::sdot_neon_fp16(N, X, Y);
+    ret = nntrainer::neon::sdot_fp16(N, X, Y);
   } else {
     for (unsigned int i = 0; i < N; ++i) {
       ret += X[i * incX] * Y[i * incY];
@@ -159,7 +159,7 @@ static void scopy_FP16(const unsigned int N, const _FP16 *X, const int incX,
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
-    nntrainer::neon::scopy_neon_fp16(N, X, Y);
+    nntrainer::neon::scopy_fp16(N, X, Y);
   } else {
     for (unsigned int i = 0; i < N; ++i)
       Y[i * incy] = X[i * incx];
@@ -177,7 +177,7 @@ static void scopy_float32_to_float16(const unsigned int N, const float *X,
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
-    nntrainer::neon::scopy_neon_fp32_to_fp16(N, X, Y);
+    nntrainer::neon::scopy_fp32_to_fp16(N, X, Y);
   } else {
     for (unsigned int i = 0; i < N; ++i)
       Y[i * incy] = X[i * incx];
@@ -195,7 +195,7 @@ static void scopy_float16_to_float32(const unsigned int N, const _FP16 *X,
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
-    nntrainer::neon::scopy_neon_fp16_to_fp32(N, X, Y);
+    nntrainer::neon::scopy_fp16_to_fp32(N, X, Y);
   } else {
     for (unsigned int i = 0; i < N; ++i)
       Y[i * incy] = X[i * incx];
@@ -213,7 +213,7 @@ static void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X,
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
-    nntrainer::neon::scopy_neon_int4_to_fp16(N, X, Y);
+    nntrainer::neon::scopy_int4_to_fp16(N, X, Y);
   } else {
     throw std::invalid_argument(
       "Error: incX == 1 && incY == 1 is supported only");
@@ -233,7 +233,7 @@ static void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X,
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
-    nntrainer::neon::scopy_neon_int8_to_fp16(N, X, Y);
+    nntrainer::neon::scopy_int8_to_fp16(N, X, Y);
   } else {
     throw std::invalid_argument(
       "Error: incX == 1 && incY == 1 is supported only");
@@ -248,7 +248,7 @@ static void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X,
 static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                       _FP16 *Z) {
 #if (defined USE__FP16 && USE_NEON)
-  nntrainer::neon::elementwise_vector_multiplication_neon_fp16(N, X, Y, Z);
+  nntrainer::neon::elementwise_vector_multiplication_fp16(N, X, Y, Z);
 #else
   for (unsigned int i = 0; i < N; ++i)
     Z[i] = X[i] * Y[i];
@@ -258,7 +258,7 @@ static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
 static void ewva_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                       _FP16 *Z) {
 #if (defined USE__FP16 && USE_NEON)
-  nntrainer::neon::elementwise_vector_addition_neon_fp16(N, X, Y, Z);
+  nntrainer::neon::elementwise_vector_addition_fp16(N, X, Y, Z);
 #else
   for (unsigned int i = 0; i < N; ++i)
     Z[i] = X[i] + Y[i];
@@ -269,7 +269,7 @@ void sscal(const unsigned int N, const float alpha, _FP16 *X, const int incX) {
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1) {
-    nntrainer::neon::sscal_neon_fp16(N, X, alpha);
+    nntrainer::neon::sscal_fp16(N, X, alpha);
   } else {
     for (unsigned int i = 0; i < N; ++i)
       X[i * incx] = static_cast<_FP16>(alpha) * X[i * incx];
@@ -286,7 +286,7 @@ static _FP16 snrm2_FP16(const unsigned int N, const _FP16 *X, const int incX) {
   _FP16 tmp;
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1) {
-    sum = nntrainer::neon::snrm2_neon_fp16(N, X);
+    sum = nntrainer::neon::snrm2_fp16(N, X);
   } else {
     for (unsigned int i = 0; i < N; i++) {
       tmp = X[i * incx];
@@ -311,7 +311,7 @@ static void sgemm_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
                        const unsigned int ldc) {
 
 #if (defined USE__FP16 && USE_NEON)
-  nntrainer::neon::sgemm_neon_fp16(A, B, C, M, N, K, alpha, beta,
+  nntrainer::neon::sgemm_fp16(A, B, C, M, N, K, alpha, beta,
                                    TransA == CblasTrans, TransB == CblasTrans);
 #else
   float *A_ = new float[M * K];
@@ -336,7 +336,7 @@ static unsigned int isamax_FP16(const unsigned int N, const _FP16 *X,
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && N >= 8) {
-    max_idx = nntrainer::neon::isamax_neon_fp16(N, X);
+    max_idx = nntrainer::neon::isamax_fp16(N, X);
   } else {
     _FP16 max_val = X[0];
     for (unsigned int n = 1; n < N; n += incX) {
@@ -431,7 +431,7 @@ unsigned int isamax(const unsigned int N, const _FP16 *X, const int incX) {
 
 void inv_sqrt_inplace(const unsigned int N, _FP16 *X) {
 #ifdef USE_NEON
-  nntrainer::neon::inv_sqrt_inplace_neon(N, X);
+  nntrainer::neon::inv_sqrt_inplace(N, X);
 #else
   for (unsigned int i = 0; i < N; ++i) {
     X[i] = static_cast<_FP16>(1 / std::sqrt(static_cast<float>(X[i])));
@@ -760,7 +760,7 @@ void scopy(const unsigned int N, const float *X, const int incX, float *Y,
 void scopy(const unsigned int N, const uint8_t *X, const int incX, uint8_t *Y,
            const int intY) {
 #ifdef USE_NEON
-  nntrainer::neon::scopy_neon_int8_or_int4(N, X, Y);
+  nntrainer::neon::scopy_int8_or_int4(N, X, Y);
 #else
   for (unsigned int idx = 0; idx < N; idx++) {
     Y[idx] = X[idx];
@@ -771,7 +771,7 @@ void scopy(const unsigned int N, const uint8_t *X, const int incX, uint8_t *Y,
 void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
                            const int incX, float *Y, const int incY) {
 #ifdef USE_NEON
-  nntrainer::neon::scopy_neon_int4_to_fp32(N, X, Y);
+  nntrainer::neon::scopy_int4_to_fp32(N, X, Y);
 #else
   for (unsigned int idx = 0; idx < N; idx++) {
     Y[2 * idx] = X[idx] >> 4;
@@ -783,7 +783,7 @@ void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
 void scopy_int8_to_float32(const unsigned int N, const uint8_t *X,
                            const int incX, float *Y, const int incY) {
 #ifdef USE_NEON
-  nntrainer::neon::scopy_neon_int8_to_fp32(N, X, Y);
+  nntrainer::neon::scopy_int8_to_fp32(N, X, Y);
 #else
   for (unsigned int idx = 0; idx < N; idx++) {
     Y[idx] = X[idx];
@@ -872,7 +872,7 @@ unsigned int isamax(const unsigned int N, const float *X, const int incX) {
 
 void sine(const unsigned int N, float *X, float *Y, float alpha) {
 #ifdef USE_NEON
-  nntrainer::neon::sine_neon(N, X, Y, alpha);
+  nntrainer::neon::sine(N, X, Y, alpha);
 #else
   unsigned int i = 0;
   while (i < N) {
@@ -884,7 +884,7 @@ void sine(const unsigned int N, float *X, float *Y, float alpha) {
 
 void cosine(const unsigned int N, float *X, float *Y, float alpha) {
 #ifdef USE_NEON
-  nntrainer::neon::cosine_neon(N, X, Y, alpha);
+  nntrainer::neon::cosine(N, X, Y, alpha);
 #else
   unsigned int i = 0;
   while (i < N) {
@@ -896,7 +896,7 @@ void cosine(const unsigned int N, float *X, float *Y, float alpha) {
 
 void inv_sqrt_inplace(const unsigned int N, float *X) {
 #ifdef USE_NEON
-  nntrainer::neon::inv_sqrt_inplace_neon(N, X);
+  nntrainer::neon::inv_sqrt_inplace(N, X);
 #else
   for (unsigned int i = 0; i < N; ++i) {
     X[i] = 1 / std::sqrt(static_cast<float>(X[i]));

--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -33,7 +33,7 @@
     }                                        \
   } while (0);
 
-#define hgemv_loop(ci, cj, cM, cN)                                 \
+#define hgemv_loop(ci, cj, cM, cN)                                      \
   do {                                                                  \
     float y0;                                                           \
     unsigned int i, j;                                                  \
@@ -45,14 +45,14 @@
     }                                                                   \
   } while (0);
 
-#define haxpy_loop()                                                  \
+#define haxpy_loop()                                                       \
   do {                                                                     \
     unsigned int i;                                                        \
     for (i = 0; i < N; ++i)                                                \
       Y[i * incY] = Y[i * incY] + static_cast<_FP16>(alpha) * X[i * incX]; \
   } while (0);
 
-#define hgemm_loop()                                                 \
+#define hgemm_loop()                                                      \
   do {                                                                    \
     for (unsigned int m = 0; m < M; ++m) {                                \
       for (unsigned int n = 0; n < N; ++n) {                              \
@@ -171,7 +171,7 @@ static void scopy_FP16(const unsigned int N, const _FP16 *X, const int incX,
 }
 
 static void copy_float32_to_float16(const unsigned int N, const float *X,
-                                     const int incX, _FP16 *Y, const int incY) {
+                                    const int incX, _FP16 *Y, const int incY) {
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
@@ -189,7 +189,7 @@ static void copy_float32_to_float16(const unsigned int N, const float *X,
 }
 
 static void copy_float16_to_float32(const unsigned int N, const _FP16 *X,
-                                     const int incX, float *Y, const int incY) {
+                                    const int incX, float *Y, const int incY) {
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
@@ -207,7 +207,7 @@ static void copy_float16_to_float32(const unsigned int N, const _FP16 *X,
 }
 
 static void copy_int4_to_fp16(const unsigned int N, const uint8_t *X,
-                               const int incX, _FP16 *Y, const int incY) {
+                              const int incX, _FP16 *Y, const int incY) {
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
@@ -227,7 +227,7 @@ static void copy_int4_to_fp16(const unsigned int N, const uint8_t *X,
 }
 
 static void copy_int8_to_fp16(const unsigned int N, const uint8_t *X,
-                               const int incX, _FP16 *Y, const int incY) {
+                              const int incX, _FP16 *Y, const int incY) {
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
@@ -248,7 +248,7 @@ static void copy_int8_to_fp16(const unsigned int N, const uint8_t *X,
 static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                       _FP16 *Z) {
 #if (defined USE__FP16 && USE_NEON)
-  nntrainer::neon::elementwise_vector_multiplication(N, X, Y, Z);
+  nntrainer::neon::ewvm(N, X, Y, Z);
 #else
   for (unsigned int i = 0; i < N; ++i)
     Z[i] = X[i] * Y[i];
@@ -258,7 +258,7 @@ static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
 static void ewva_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                       _FP16 *Z) {
 #if (defined USE__FP16 && USE_NEON)
-  nntrainer::neon::elementwise_vector_addition(N, X, Y, Z);
+  nntrainer::neon::ewva(N, X, Y, Z);
 #else
   for (unsigned int i = 0; i < N; ++i)
     Z[i] = X[i] + Y[i];
@@ -311,8 +311,8 @@ static void sgemm_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
                        const unsigned int ldc) {
 
 #if (defined USE__FP16 && USE_NEON)
-  nntrainer::neon::hgemm(A, B, C, M, N, K, alpha, beta,
-                                   TransA == CblasTrans, TransB == CblasTrans);
+  nntrainer::neon::hgemm(A, B, C, M, N, K, alpha, beta, TransA == CblasTrans,
+                         TransB == CblasTrans);
 #else
   float *A_ = new float[M * K];
   float *B_ = new float[N * K];

--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -33,7 +33,7 @@
     }                                        \
   } while (0);
 
-#define sgemv_loop_fp16(ci, cj, cM, cN)                                 \
+#define hgemv_loop(ci, cj, cM, cN)                                 \
   do {                                                                  \
     float y0;                                                           \
     unsigned int i, j;                                                  \
@@ -45,14 +45,14 @@
     }                                                                   \
   } while (0);
 
-#define saxpy_loop_fp16()                                                  \
+#define haxpy_loop()                                                  \
   do {                                                                     \
     unsigned int i;                                                        \
     for (i = 0; i < N; ++i)                                                \
       Y[i * incY] = Y[i * incY] + static_cast<_FP16>(alpha) * X[i * incX]; \
   } while (0);
 
-#define sgemm_loop_fp16()                                                 \
+#define hgemm_loop()                                                 \
   do {                                                                    \
     for (unsigned int m = 0; m < M; ++m) {                                \
       for (unsigned int n = 0; n < N; ++n) {                              \
@@ -83,12 +83,12 @@ static void saxpy_FP16(const unsigned int N, const float alpha, const _FP16 *X,
 #if (defined USE__FP16 && USE_NEON)
   // USE__FP16 is defined when platform is android
   if (incX == 1 && incY == 1) {
-    nntrainer::neon::saxpy_fp16(N, alpha, X, Y);
+    nntrainer::neon::haxpy(N, alpha, X, Y);
   } else {
-    saxpy_loop_fp16();
+    haxpy_loop();
   }
 #else
-  saxpy_loop_fp16();
+  haxpy_loop();
 #endif
 }
 
@@ -99,9 +99,9 @@ static void sgemv_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
                        const float beta, _FP16 *Y, const int incY) {
 #if (defined USE__FP16 && USE_NEON)
   if (TransA == CblasTrans) {
-    nntrainer::neon::sgemv_transpose_fp16(A, X, Y, M, N, alpha, beta);
+    nntrainer::neon::hgemv_transpose(A, X, Y, M, N, alpha, beta);
   } else {
-    nntrainer::neon::sgemv_fp16(A, X, Y, M, N, alpha, beta);
+    nntrainer::neon::hgemv(A, X, Y, M, N, alpha, beta);
   }
 #else
   unsigned int lenX =
@@ -138,7 +138,7 @@ static _FP16 sdot_FP16(const unsigned int N, const _FP16 *X,
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
-    ret = nntrainer::neon::sdot_fp16(N, X, Y);
+    ret = nntrainer::neon::hdot(N, X, Y);
   } else {
     for (unsigned int i = 0; i < N; ++i) {
       ret += X[i * incX] * Y[i * incY];
@@ -159,7 +159,7 @@ static void scopy_FP16(const unsigned int N, const _FP16 *X, const int incX,
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
-    nntrainer::neon::scopy_fp16(N, X, Y);
+    nntrainer::neon::hcopy(N, X, Y);
   } else {
     for (unsigned int i = 0; i < N; ++i)
       Y[i * incy] = X[i * incx];
@@ -170,14 +170,14 @@ static void scopy_FP16(const unsigned int N, const _FP16 *X, const int incX,
 #endif
 }
 
-static void scopy_float32_to_float16(const unsigned int N, const float *X,
+static void copy_float32_to_float16(const unsigned int N, const float *X,
                                      const int incX, _FP16 *Y, const int incY) {
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
-    nntrainer::neon::scopy_fp32_to_fp16(N, X, Y);
+    nntrainer::neon::copy_fp32_to_fp16(N, X, Y);
   } else {
     for (unsigned int i = 0; i < N; ++i)
       Y[i * incy] = X[i * incx];
@@ -188,14 +188,14 @@ static void scopy_float32_to_float16(const unsigned int N, const float *X,
 #endif
 }
 
-static void scopy_float16_to_float32(const unsigned int N, const _FP16 *X,
+static void copy_float16_to_float32(const unsigned int N, const _FP16 *X,
                                      const int incX, float *Y, const int incY) {
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
-    nntrainer::neon::scopy_fp16_to_fp32(N, X, Y);
+    nntrainer::neon::copy_fp16_to_fp32(N, X, Y);
   } else {
     for (unsigned int i = 0; i < N; ++i)
       Y[i * incy] = X[i * incx];
@@ -206,14 +206,14 @@ static void scopy_float16_to_float32(const unsigned int N, const _FP16 *X,
 #endif
 }
 
-static void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X,
+static void copy_int4_to_fp16(const unsigned int N, const uint8_t *X,
                                const int incX, _FP16 *Y, const int incY) {
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
-    nntrainer::neon::scopy_int4_to_fp16(N, X, Y);
+    nntrainer::neon::copy_int4_to_fp16(N, X, Y);
   } else {
     throw std::invalid_argument(
       "Error: incX == 1 && incY == 1 is supported only");
@@ -226,14 +226,14 @@ static void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X,
 #endif
 }
 
-static void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X,
+static void copy_int8_to_fp16(const unsigned int N, const uint8_t *X,
                                const int incX, _FP16 *Y, const int incY) {
   unsigned int incy = abs(incY);
   unsigned int incx = abs(incX);
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && incY == 1) {
-    nntrainer::neon::scopy_int8_to_fp16(N, X, Y);
+    nntrainer::neon::copy_int8_to_fp16(N, X, Y);
   } else {
     throw std::invalid_argument(
       "Error: incX == 1 && incY == 1 is supported only");
@@ -248,7 +248,7 @@ static void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X,
 static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                       _FP16 *Z) {
 #if (defined USE__FP16 && USE_NEON)
-  nntrainer::neon::elementwise_vector_multiplication_fp16(N, X, Y, Z);
+  nntrainer::neon::elementwise_vector_multiplication(N, X, Y, Z);
 #else
   for (unsigned int i = 0; i < N; ++i)
     Z[i] = X[i] * Y[i];
@@ -258,7 +258,7 @@ static void ewvm_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
 static void ewva_FP16(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                       _FP16 *Z) {
 #if (defined USE__FP16 && USE_NEON)
-  nntrainer::neon::elementwise_vector_addition_fp16(N, X, Y, Z);
+  nntrainer::neon::elementwise_vector_addition(N, X, Y, Z);
 #else
   for (unsigned int i = 0; i < N; ++i)
     Z[i] = X[i] + Y[i];
@@ -269,7 +269,7 @@ void sscal(const unsigned int N, const float alpha, _FP16 *X, const int incX) {
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1) {
-    nntrainer::neon::sscal_fp16(N, X, alpha);
+    nntrainer::neon::hscal(N, X, alpha);
   } else {
     for (unsigned int i = 0; i < N; ++i)
       X[i * incx] = static_cast<_FP16>(alpha) * X[i * incx];
@@ -286,7 +286,7 @@ static _FP16 snrm2_FP16(const unsigned int N, const _FP16 *X, const int incX) {
   _FP16 tmp;
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1) {
-    sum = nntrainer::neon::snrm2_fp16(N, X);
+    sum = nntrainer::neon::hnrm2(N, X);
   } else {
     for (unsigned int i = 0; i < N; i++) {
       tmp = X[i * incx];
@@ -311,7 +311,7 @@ static void sgemm_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,
                        const unsigned int ldc) {
 
 #if (defined USE__FP16 && USE_NEON)
-  nntrainer::neon::sgemm_fp16(A, B, C, M, N, K, alpha, beta,
+  nntrainer::neon::hgemm(A, B, C, M, N, K, alpha, beta,
                                    TransA == CblasTrans, TransB == CblasTrans);
 #else
   float *A_ = new float[M * K];
@@ -336,7 +336,7 @@ static unsigned int isamax_FP16(const unsigned int N, const _FP16 *X,
 
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1 && N >= 8) {
-    max_idx = nntrainer::neon::isamax_fp16(N, X);
+    max_idx = nntrainer::neon::isamax(N, X);
   } else {
     _FP16 max_val = X[0];
     for (unsigned int n = 1; n < N; n += incX) {
@@ -382,22 +382,22 @@ void scopy(const unsigned int N, const _FP16 *X, const int incX, _FP16 *Y,
 
 void scopy(const unsigned int N, const float *X, const int incX, _FP16 *Y,
            const int incY) {
-  scopy_float32_to_float16(N, X, incX, Y, incY);
+  copy_float32_to_float16(N, X, incX, Y, incY);
 }
 
 void scopy(const unsigned int N, const _FP16 *X, const int incX, float *Y,
            const int incY) {
-  scopy_float16_to_float32(N, X, incX, Y, incY);
+  copy_float16_to_float32(N, X, incX, Y, incY);
 }
 
 void scopy_int4_to_float16(const unsigned int N, const uint8_t *X,
                            const int incX, _FP16 *Y, const int incY) {
-  scopy_int4_to_fp16(N, X, incX, Y, incY);
+  copy_int4_to_fp16(N, X, incX, Y, incY);
 }
 
 void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
                            const int incX, _FP16 *Y, const int incY) {
-  scopy_int8_to_fp16(N, X, incX, Y, incY);
+  copy_int8_to_fp16(N, X, incX, Y, incY);
 }
 
 void ewvm(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z) {
@@ -760,7 +760,7 @@ void scopy(const unsigned int N, const float *X, const int incX, float *Y,
 void scopy(const unsigned int N, const uint8_t *X, const int incX, uint8_t *Y,
            const int intY) {
 #ifdef USE_NEON
-  nntrainer::neon::scopy_int8_or_int4(N, X, Y);
+  nntrainer::neon::copy_int8_or_int4(N, X, Y);
 #else
   for (unsigned int idx = 0; idx < N; idx++) {
     Y[idx] = X[idx];
@@ -771,7 +771,7 @@ void scopy(const unsigned int N, const uint8_t *X, const int incX, uint8_t *Y,
 void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
                            const int incX, float *Y, const int incY) {
 #ifdef USE_NEON
-  nntrainer::neon::scopy_int4_to_fp32(N, X, Y);
+  nntrainer::neon::copy_int4_to_fp32(N, X, Y);
 #else
   for (unsigned int idx = 0; idx < N; idx++) {
     Y[2 * idx] = X[idx] >> 4;
@@ -783,7 +783,7 @@ void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
 void scopy_int8_to_float32(const unsigned int N, const uint8_t *X,
                            const int incX, float *Y, const int incY) {
 #ifdef USE_NEON
-  nntrainer::neon::scopy_int8_to_fp32(N, X, Y);
+  nntrainer::neon::copy_int8_to_fp32(N, X, Y);
 #else
   for (unsigned int idx = 0; idx < N; idx++) {
     Y[idx] = X[idx];

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -18,7 +18,7 @@
 namespace nntrainer::neon {
 
 void sgemv(const float *A, const float *X, float *Y, uint32_t rows,
-                uint32_t cols, float alpha, float beta) {
+           uint32_t cols, float alpha, float beta) {
   const float *__restrict x;
 
   for (unsigned int i = 0; i < rows; ++i) {
@@ -134,9 +134,8 @@ void sgemv(const float *A, const float *X, float *Y, uint32_t rows,
   }
 }
 
-void sgemv_transpose(const float *A, const float *X, float *Y,
-                          uint32_t rows, uint32_t cols, float alpha,
-                          float beta) {
+void sgemv_transpose(const float *A, const float *X, float *Y, uint32_t rows,
+                     uint32_t cols, float alpha, float beta) {
   const float *__restrict x;
 
   const float32x4_t v_beta = vdupq_n_f32(beta);
@@ -273,7 +272,7 @@ void sgemv_transpose(const float *A, const float *X, float *Y,
   return;
 }
 
-void scopy_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
+void copy_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
 
   unsigned int idx = 0;
 
@@ -375,8 +374,7 @@ void scopy_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
   }
 }
 
-void scopy_int8_or_int4(const unsigned int N, const uint8_t *X,
-                             uint8_t *Y) {
+void copy_int8_or_int4(const unsigned int N, const uint8_t *X, uint8_t *Y) {
   ///@note int8 Tensor and int4 Tensor share the same memory offset
   unsigned int idx = 0;
   for (; N - idx >= 16; idx += 16) {
@@ -392,8 +390,7 @@ void scopy_int8_or_int4(const unsigned int N, const uint8_t *X,
   }
 }
 
-void sine(const unsigned int N, float *X, float *Y,
-                              float alpha) {
+void sine(const unsigned int N, float *X, float *Y, float alpha) {
   unsigned int i = 0;
   for (; N - i >= 4; i += 4) {
     float32x4_t x0_3 = vld1q_f32(&X[i]);
@@ -408,8 +405,7 @@ void sine(const unsigned int N, float *X, float *Y,
   }
 }
 
-void cosine(const unsigned int N, float *X, float *Y,
-                                float alpha) {
+void cosine(const unsigned int N, float *X, float *Y, float alpha) {
   unsigned int i = 0;
   for (; N - i >= 4; i += 4) {
     float32x4_t x0_3 = vld1q_f32(&X[i]);
@@ -441,8 +437,8 @@ void inv_sqrt_inplace(const unsigned int N, float *X) {
 
 #ifdef ENABLE_FP16
 
-void sgemv_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
-                     uint32_t cols, float alpha, float beta) {
+void hgemv(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
+           uint32_t cols, float alpha, float beta) {
   const int batch = 0;
   const __fp16 *__restrict x;
   float *Y32 = new float[rows];
@@ -695,14 +691,13 @@ void sgemv_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
     }
   }
 
-  scopy_fp32_to_fp16(rows, Y32, Y);
+  copy_fp32_to_fp16(rows, Y32, Y);
   delete[] Y32;
   return;
 }
 
-void sgemv_transpose_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
-                               uint32_t rows, uint32_t cols, float alpha,
-                               float beta) {
+void hgemv_transpose(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
+                     uint32_t cols, float alpha, float beta) {
   float *Y32 = new float[cols];
   const int batch = 20;
   unsigned int idx = 0;
@@ -1112,13 +1107,13 @@ void sgemv_transpose_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
       }
     }
   }
-  scopy_fp32_to_fp16(cols, Y32, Y);
+  copy_fp32_to_fp16(cols, Y32, Y);
   delete[] Y32;
   return;
 }
 
-void saxpy_fp16(const unsigned int N, const float alpha, const __fp16 *X,
-                     __fp16 *Y) {
+void haxpy(const unsigned int N, const float alpha, const __fp16 *X,
+           __fp16 *Y) {
 
   const float16x8_t v_alphaX8 = vmovq_n_f16(alpha);
   const float16x4_t v_alphaX4 = vmov_n_f16(alpha);
@@ -1150,7 +1145,7 @@ void saxpy_fp16(const unsigned int N, const float alpha, const __fp16 *X,
     Y[idx] = Y[idx] + alpha * X[idx];
 }
 
-__fp16 sdot_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y) {
+__fp16 hdot(const unsigned int N, const __fp16 *X, const __fp16 *Y) {
 
   float16x8_t accX8 = vmovq_n_f16(0);
   float16x4_t accX4 = vmov_n_f16(0);
@@ -1198,7 +1193,7 @@ __fp16 sdot_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y) {
   return ret;
 }
 
-__fp16 snrm2_fp16(const unsigned int N, const __fp16 *X) {
+__fp16 hnrm2(const unsigned int N, const __fp16 *X) {
 
   float16x8_t accX8 = vmovq_n_f16(0);
   float16x4_t accX4 = vmov_n_f16(0);
@@ -1244,7 +1239,7 @@ __fp16 snrm2_fp16(const unsigned int N, const __fp16 *X) {
   return ret;
 }
 
-void sscal_fp16(const unsigned int N, __fp16 *X, const float alpha) {
+void hscal(const unsigned int N, __fp16 *X, const float alpha) {
   const float16x8_t v_alphaX8 = vmovq_n_f16(alpha);
   const float16x4_t v_alphaX4 = vmov_n_f16(alpha);
 
@@ -1280,7 +1275,7 @@ float32x4_t vcvtq_f32_u32_bitwise(uint32x4_t u32) {
                    vreinterpretq_f32_u32(offsetInt));
 }
 
-void scopy_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y) {
+void hcopy(const unsigned int N, const __fp16 *X, __fp16 *Y) {
 
   unsigned int idx = 0;
 
@@ -1301,8 +1296,7 @@ void scopy_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y) {
     Y[idx] = X[idx];
 }
 
-void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X,
-                             __fp16 *Y) {
+void copy_int4_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y) {
 
   unsigned int idx = 0;
 
@@ -1379,8 +1373,7 @@ void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X,
   }
 }
 
-void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X,
-                             __fp16 *Y) {
+void copy_int8_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y) {
   unsigned int idx = 0;
   for (; (N - idx) >= 16; idx += 16) {
     uint8x16_t batch = vld1q_u8(&X[idx]);
@@ -1408,7 +1401,7 @@ void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X,
   }
 }
 
-void scopy_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
+void copy_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
   unsigned int idx = 0;
   for (; (N - idx) >= 16; idx += 16) {
     uint8x16_t batch = vld1q_u8(&X[idx]);
@@ -1450,7 +1443,7 @@ void scopy_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
   }
 }
 
-void scopy_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y) {
+void copy_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y) {
   unsigned int idx = 0;
 
   for (; N - idx >= 8; idx += 8) {
@@ -1472,7 +1465,7 @@ void scopy_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y) {
   }
 }
 
-void scopy_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y) {
+void copy_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y) {
   unsigned int idx = 0;
 
   for (; N - idx >= 8; idx += 8) {
@@ -1497,7 +1490,7 @@ void scopy_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y) {
   }
 }
 
-unsigned int isamax_fp16(const unsigned int N, const __fp16 *X) {
+unsigned int isamax(const unsigned int N, const __fp16 *X) {
 
   unsigned int retIdx;
   __fp16 maxNum;
@@ -1549,9 +1542,8 @@ unsigned int isamax_fp16(const unsigned int N, const __fp16 *X) {
   return retIdx;
 }
 
-void sgemm_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
-                     uint32_t N, uint32_t K, float alpha, float beta,
-                     bool TransA, bool TransB) {
+void hgemm(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M, uint32_t N,
+           uint32_t K, float alpha, float beta, bool TransA, bool TransB) {
 
   // dynamic creation to avoid reaching stack limit(causes segmentation fault)
   float *C32 = (float *)malloc(M * N * sizeof(float));
@@ -1578,22 +1570,21 @@ void sgemm_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
   }
 
   if (!TransA && TransB) {
-    sgemm_fp16_transB(A, B, C32, M, N, K, alpha, beta);
+    hgemm_transB(A, B, C32, M, N, K, alpha, beta);
   } else if (TransA && !TransB) {
-    sgemm_fp16_transA(A, B, C32, M, N, K, alpha, beta);
+    hgemm_transA(A, B, C32, M, N, K, alpha, beta);
   } else if (!TransA && !TransB) {
-    sgemm_fp16_noTrans(A, B, C32, M, N, K, alpha, beta);
+    hgemm_noTrans(A, B, C32, M, N, K, alpha, beta);
   } else { // TransA && TransB
-    sgemm_fp16_transAB(A, B, C32, M, N, K, alpha, beta, idx);
+    hgemm_transAB(A, B, C32, M, N, K, alpha, beta, idx);
   }
 
-  scopy_fp32_to_fp16(M * N, C32, C);
+  copy_fp32_to_fp16(M * N, C32, C);
   free(C32);
 }
 
-void sgemm_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
-                             uint32_t M, uint32_t N, uint32_t K, float alpha,
-                             float beta) {
+void hgemm_noTrans(const __fp16 *A, const __fp16 *B, float *C, uint32_t M,
+                   uint32_t N, uint32_t K, float alpha, float beta) {
 
   unsigned int k = 0, n = 0;
   __fp16 a[16];
@@ -1765,9 +1756,8 @@ void sgemm_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
   }
 }
 
-void sgemm_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
-                            uint32_t M, uint32_t N, uint32_t K, float alpha,
-                            float beta) {
+void hgemm_transA(const __fp16 *A, const __fp16 *B, float *C, uint32_t M,
+                  uint32_t N, uint32_t K, float alpha, float beta) {
   __fp16 valsB[8];
   float valsC[8];
   for (unsigned int k = 0; k < K; k++) {
@@ -1815,9 +1805,8 @@ void sgemm_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
   }
 }
 
-void sgemm_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
-                            uint32_t M, uint32_t N, uint32_t K, float alpha,
-                            float beta) {
+void hgemm_transB(const __fp16 *A, const __fp16 *B, float *C, uint32_t M,
+                  uint32_t N, uint32_t K, float alpha, float beta) {
   __fp16 valsB[8];
   __fp16 valsA[8];
   int m = 0;
@@ -1984,9 +1973,9 @@ void sgemm_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
   }
 }
 
-void sgemm_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
-                             uint32_t M, uint32_t N, uint32_t K, float alpha,
-                             float beta, uint32_t idx) {
+void hgemm_transAB(const __fp16 *A, const __fp16 *B, float *C, uint32_t M,
+                   uint32_t N, uint32_t K, float alpha, float beta,
+                   uint32_t idx) {
   float vals[8];
   __fp16 vals_fp16[8];
   for (unsigned int n = 0; n < N; n++) {
@@ -2025,9 +2014,8 @@ void sgemm_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
   }
 }
 
-void elementwise_vector_multiplication_fp16(const unsigned int N,
-                                                 const __fp16 *X,
-                                                 const __fp16 *Y, __fp16 *Z) {
+void elementwise_vector_multiplication(const unsigned int N, const __fp16 *X,
+                                       const __fp16 *Y, __fp16 *Z) {
   unsigned int i = 0;
   for (; N - i >= 8; i += 8) {
     float16x8_t x0_7 = vld1q_f16(&X[i]);
@@ -2042,9 +2030,8 @@ void elementwise_vector_multiplication_fp16(const unsigned int N,
   }
 }
 
-void elementwise_vector_addition_fp16(const unsigned int N,
-                                           const __fp16 *X, const __fp16 *Y,
-                                           __fp16 *Z) {
+void elementwise_vector_addition(const unsigned int N, const __fp16 *X,
+                                 const __fp16 *Y, __fp16 *Z) {
   unsigned int i = 0;
   for (; N - i >= 8; i += 8) {
     float16x8_t x0_7 = vld1q_f16(&X[i]);

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -2014,8 +2014,7 @@ void hgemm_transAB(const __fp16 *A, const __fp16 *B, float *C, uint32_t M,
   }
 }
 
-void elementwise_vector_multiplication(const unsigned int N, const __fp16 *X,
-                                       const __fp16 *Y, __fp16 *Z) {
+void ewvm(const unsigned int N, const __fp16 *X, const __fp16 *Y, __fp16 *Z) {
   unsigned int i = 0;
   for (; N - i >= 8; i += 8) {
     float16x8_t x0_7 = vld1q_f16(&X[i]);
@@ -2030,8 +2029,7 @@ void elementwise_vector_multiplication(const unsigned int N, const __fp16 *X,
   }
 }
 
-void elementwise_vector_addition(const unsigned int N, const __fp16 *X,
-                                 const __fp16 *Y, __fp16 *Z) {
+void ewva(const unsigned int N, const __fp16 *X, const __fp16 *Y, __fp16 *Z) {
   unsigned int i = 0;
   for (; N - i >= 8; i += 8) {
     float16x8_t x0_7 = vld1q_f16(&X[i]);

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -17,7 +17,7 @@
 #include <nntrainer_error.h>
 namespace nntrainer::neon {
 
-void sgemv_neon(const float *A, const float *X, float *Y, uint32_t rows,
+void sgemv(const float *A, const float *X, float *Y, uint32_t rows,
                 uint32_t cols, float alpha, float beta) {
   const float *__restrict x;
 
@@ -134,7 +134,7 @@ void sgemv_neon(const float *A, const float *X, float *Y, uint32_t rows,
   }
 }
 
-void sgemv_transpose_neon(const float *A, const float *X, float *Y,
+void sgemv_transpose(const float *A, const float *X, float *Y,
                           uint32_t rows, uint32_t cols, float alpha,
                           float beta) {
   const float *__restrict x;
@@ -273,7 +273,7 @@ void sgemv_transpose_neon(const float *A, const float *X, float *Y,
   return;
 }
 
-void scopy_neon_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
+void scopy_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
 
   unsigned int idx = 0;
 
@@ -375,7 +375,7 @@ void scopy_neon_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
   }
 }
 
-void scopy_neon_int8_or_int4(const unsigned int N, const uint8_t *X,
+void scopy_int8_or_int4(const unsigned int N, const uint8_t *X,
                              uint8_t *Y) {
   ///@note int8 Tensor and int4 Tensor share the same memory offset
   unsigned int idx = 0;
@@ -392,7 +392,7 @@ void scopy_neon_int8_or_int4(const unsigned int N, const uint8_t *X,
   }
 }
 
-void sine_neon(const unsigned int N, float *X, float *Y,
+void sine(const unsigned int N, float *X, float *Y,
                               float alpha) {
   unsigned int i = 0;
   for (; N - i >= 4; i += 4) {
@@ -408,7 +408,7 @@ void sine_neon(const unsigned int N, float *X, float *Y,
   }
 }
 
-void cosine_neon(const unsigned int N, float *X, float *Y,
+void cosine(const unsigned int N, float *X, float *Y,
                                 float alpha) {
   unsigned int i = 0;
   for (; N - i >= 4; i += 4) {
@@ -424,7 +424,7 @@ void cosine_neon(const unsigned int N, float *X, float *Y,
   }
 }
 
-void inv_sqrt_inplace_neon(const unsigned int N, float *X) {
+void inv_sqrt_inplace(const unsigned int N, float *X) {
   unsigned int i = 0;
   for (; N - i >= 4; i += 4) {
     float32x4_t x0_7 = vld1q_f32(&X[i]);
@@ -441,7 +441,7 @@ void inv_sqrt_inplace_neon(const unsigned int N, float *X) {
 
 #ifdef ENABLE_FP16
 
-void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
+void sgemv_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
                      uint32_t cols, float alpha, float beta) {
   const int batch = 0;
   const __fp16 *__restrict x;
@@ -695,12 +695,12 @@ void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
     }
   }
 
-  scopy_neon_fp32_to_fp16(rows, Y32, Y);
+  scopy_fp32_to_fp16(rows, Y32, Y);
   delete[] Y32;
   return;
 }
 
-void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
+void sgemv_transpose_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
                                uint32_t rows, uint32_t cols, float alpha,
                                float beta) {
   float *Y32 = new float[cols];
@@ -1112,12 +1112,12 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
       }
     }
   }
-  scopy_neon_fp32_to_fp16(cols, Y32, Y);
+  scopy_fp32_to_fp16(cols, Y32, Y);
   delete[] Y32;
   return;
 }
 
-void saxpy_neon_fp16(const unsigned int N, const float alpha, const __fp16 *X,
+void saxpy_fp16(const unsigned int N, const float alpha, const __fp16 *X,
                      __fp16 *Y) {
 
   const float16x8_t v_alphaX8 = vmovq_n_f16(alpha);
@@ -1150,7 +1150,7 @@ void saxpy_neon_fp16(const unsigned int N, const float alpha, const __fp16 *X,
     Y[idx] = Y[idx] + alpha * X[idx];
 }
 
-__fp16 sdot_neon_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y) {
+__fp16 sdot_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y) {
 
   float16x8_t accX8 = vmovq_n_f16(0);
   float16x4_t accX4 = vmov_n_f16(0);
@@ -1198,7 +1198,7 @@ __fp16 sdot_neon_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y) {
   return ret;
 }
 
-__fp16 snrm2_neon_fp16(const unsigned int N, const __fp16 *X) {
+__fp16 snrm2_fp16(const unsigned int N, const __fp16 *X) {
 
   float16x8_t accX8 = vmovq_n_f16(0);
   float16x4_t accX4 = vmov_n_f16(0);
@@ -1244,7 +1244,7 @@ __fp16 snrm2_neon_fp16(const unsigned int N, const __fp16 *X) {
   return ret;
 }
 
-void sscal_neon_fp16(const unsigned int N, __fp16 *X, const float alpha) {
+void sscal_fp16(const unsigned int N, __fp16 *X, const float alpha) {
   const float16x8_t v_alphaX8 = vmovq_n_f16(alpha);
   const float16x4_t v_alphaX4 = vmov_n_f16(alpha);
 
@@ -1280,7 +1280,7 @@ float32x4_t vcvtq_f32_u32_bitwise(uint32x4_t u32) {
                    vreinterpretq_f32_u32(offsetInt));
 }
 
-void scopy_neon_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y) {
+void scopy_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y) {
 
   unsigned int idx = 0;
 
@@ -1301,7 +1301,7 @@ void scopy_neon_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y) {
     Y[idx] = X[idx];
 }
 
-void scopy_neon_int4_to_fp16(const unsigned int N, const uint8_t *X,
+void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X,
                              __fp16 *Y) {
 
   unsigned int idx = 0;
@@ -1379,7 +1379,7 @@ void scopy_neon_int4_to_fp16(const unsigned int N, const uint8_t *X,
   }
 }
 
-void scopy_neon_int8_to_fp16(const unsigned int N, const uint8_t *X,
+void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X,
                              __fp16 *Y) {
   unsigned int idx = 0;
   for (; (N - idx) >= 16; idx += 16) {
@@ -1408,7 +1408,7 @@ void scopy_neon_int8_to_fp16(const unsigned int N, const uint8_t *X,
   }
 }
 
-void scopy_neon_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
+void scopy_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
   unsigned int idx = 0;
   for (; (N - idx) >= 16; idx += 16) {
     uint8x16_t batch = vld1q_u8(&X[idx]);
@@ -1450,7 +1450,7 @@ void scopy_neon_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y) {
   }
 }
 
-void scopy_neon_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y) {
+void scopy_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y) {
   unsigned int idx = 0;
 
   for (; N - idx >= 8; idx += 8) {
@@ -1472,7 +1472,7 @@ void scopy_neon_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y) {
   }
 }
 
-void scopy_neon_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y) {
+void scopy_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y) {
   unsigned int idx = 0;
 
   for (; N - idx >= 8; idx += 8) {
@@ -1497,7 +1497,7 @@ void scopy_neon_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y) {
   }
 }
 
-unsigned int isamax_neon_fp16(const unsigned int N, const __fp16 *X) {
+unsigned int isamax_fp16(const unsigned int N, const __fp16 *X) {
 
   unsigned int retIdx;
   __fp16 maxNum;
@@ -1549,7 +1549,7 @@ unsigned int isamax_neon_fp16(const unsigned int N, const __fp16 *X) {
   return retIdx;
 }
 
-void sgemm_neon_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
+void sgemm_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
                      uint32_t N, uint32_t K, float alpha, float beta,
                      bool TransA, bool TransB) {
 
@@ -1578,20 +1578,20 @@ void sgemm_neon_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
   }
 
   if (!TransA && TransB) {
-    sgemm_neon_fp16_transB(A, B, C32, M, N, K, alpha, beta);
+    sgemm_fp16_transB(A, B, C32, M, N, K, alpha, beta);
   } else if (TransA && !TransB) {
-    sgemm_neon_fp16_transA(A, B, C32, M, N, K, alpha, beta);
+    sgemm_fp16_transA(A, B, C32, M, N, K, alpha, beta);
   } else if (!TransA && !TransB) {
-    sgemm_neon_fp16_noTrans(A, B, C32, M, N, K, alpha, beta);
+    sgemm_fp16_noTrans(A, B, C32, M, N, K, alpha, beta);
   } else { // TransA && TransB
-    sgemm_neon_fp16_transAB(A, B, C32, M, N, K, alpha, beta, idx);
+    sgemm_fp16_transAB(A, B, C32, M, N, K, alpha, beta, idx);
   }
 
-  scopy_neon_fp32_to_fp16(M * N, C32, C);
+  scopy_fp32_to_fp16(M * N, C32, C);
   free(C32);
 }
 
-void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
+void sgemm_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
                              uint32_t M, uint32_t N, uint32_t K, float alpha,
                              float beta) {
 
@@ -1765,7 +1765,7 @@ void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
   }
 }
 
-void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
+void sgemm_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
                             uint32_t M, uint32_t N, uint32_t K, float alpha,
                             float beta) {
   __fp16 valsB[8];
@@ -1815,7 +1815,7 @@ void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
   }
 }
 
-void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
+void sgemm_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
                             uint32_t M, uint32_t N, uint32_t K, float alpha,
                             float beta) {
   __fp16 valsB[8];
@@ -1984,7 +1984,7 @@ void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
   }
 }
 
-void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
+void sgemm_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
                              uint32_t M, uint32_t N, uint32_t K, float alpha,
                              float beta, uint32_t idx) {
   float vals[8];
@@ -2025,7 +2025,7 @@ void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
   }
 }
 
-void elementwise_vector_multiplication_neon_fp16(const unsigned int N,
+void elementwise_vector_multiplication_fp16(const unsigned int N,
                                                  const __fp16 *X,
                                                  const __fp16 *Y, __fp16 *Z) {
   unsigned int i = 0;
@@ -2042,7 +2042,7 @@ void elementwise_vector_multiplication_neon_fp16(const unsigned int N,
   }
 }
 
-void elementwise_vector_addition_neon_fp16(const unsigned int N,
+void elementwise_vector_addition_fp16(const unsigned int N,
                                            const __fp16 *X, const __fp16 *Y,
                                            __fp16 *Z) {
   unsigned int i = 0;
@@ -2059,7 +2059,7 @@ void elementwise_vector_addition_neon_fp16(const unsigned int N,
   }
 }
 
-void inv_sqrt_inplace_neon(const unsigned int N, __fp16 *X) {
+void inv_sqrt_inplace(const unsigned int N, __fp16 *X) {
   unsigned int i = 0;
   for (; N - i >= 8; i += 8) {
     float16x8_t x0_7 = vld1q_f16(&X[i]);

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -31,7 +31,7 @@ namespace nntrainer::neon {
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemv_neon(const float *A, const float *X, float *Y, uint32_t rows,
+void sgemv(const float *A, const float *X, float *Y, uint32_t rows,
                 uint32_t cols, const float alpha, const float beta);
 
 /**
@@ -46,7 +46,7 @@ void sgemv_neon(const float *A, const float *X, float *Y, uint32_t rows,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemv_transpose_neon(const float *A, const float *X, float *Y,
+void sgemv_transpose(const float *A, const float *X, float *Y,
                           uint32_t rows, uint32_t cols, float alpha,
                           float beta);
 
@@ -56,7 +56,7 @@ void sgemv_transpose_neon(const float *A, const float *X, float *Y,
  * @param[in] X float * for Vector X
  * @param[in] Y uint8_t * for Vector Y
  */
-void scopy_neon_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
+void scopy_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -64,7 +64,7 @@ void scopy_neon_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
  * @param[in] X float * for Vector X
  * @param[in] Y uint8_t * for Vector Y
  */
-void scopy_neon_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
+void scopy_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -72,7 +72,7 @@ void scopy_neon_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
  * @param[in] X uint8_t * for Vector X
  * @param[in] Y uint8_t * for Vector Y
  */
-void scopy_neon_int8_or_int4(const unsigned int N, const uint8_t *X,
+void scopy_int8_or_int4(const unsigned int N, const uint8_t *X,
                              uint8_t *Y);
 /**
  * @brief     sine with neon: Y = sin(alpha * X)
@@ -81,7 +81,7 @@ void scopy_neon_int8_or_int4(const unsigned int N, const uint8_t *X,
  * @param[in] Y float * for Vector Y
  * @param[in] alpha float * for scaling angle (radian)
  */
-void sine_neon(const unsigned int N, float *X, float *Y,
+void sine(const unsigned int N, float *X, float *Y,
                               float alpha = 1.0);
 
 /**
@@ -91,7 +91,7 @@ void sine_neon(const unsigned int N, float *X, float *Y,
  * @param[in] Y float * for Vector Y
  * @param[in] alpha float * for scaling angle (radian)
  */
-void cosine_neon(const unsigned int N, float *X, float *Y,
+void cosine(const unsigned int N, float *X, float *Y,
                                 float alpha = 1.0);
 
 /**
@@ -100,7 +100,7 @@ void cosine_neon(const unsigned int N, float *X, float *Y,
  * @param N number of elements in X
  * @param X float * for Vector X
  */
-void inv_sqrt_inplace_neon(const unsigned int N, float *X);
+void inv_sqrt_inplace(const unsigned int N, float *X);
 
 #ifdef ENABLE_FP16
 /**
@@ -113,7 +113,7 @@ void inv_sqrt_inplace_neon(const unsigned int N, float *X);
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
+void sgemv_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
                      uint32_t cols, float alpha, float beta);
 
 /**
@@ -123,7 +123,7 @@ void sgemv_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
  * @param[in] Y __fp16 * for Vector Y
  * @param[in] Z __fp16 * for Vector Z
  */
-void elementwise_vector_multiplication_neon_fp16(const unsigned N,
+void elementwise_vector_multiplication_fp16(const unsigned N,
                                                  const __fp16 *X,
                                                  const __fp16 *Y, __fp16 *Z);
 /**
@@ -133,7 +133,7 @@ void elementwise_vector_multiplication_neon_fp16(const unsigned N,
  * @param[in] Y __fp16 * for Vector Y
  * @param[in] Z __fp16 * for Vector Z
  */
-void elementwise_vector_addition_neon_fp16(const unsigned N, const __fp16 *X,
+void elementwise_vector_addition_fp16(const unsigned N, const __fp16 *X,
                                            const __fp16 *Y, __fp16 *Z);
 
 /**
@@ -148,7 +148,7 @@ void elementwise_vector_addition_neon_fp16(const unsigned N, const __fp16 *X,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
+void sgemv_transpose_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
                                uint32_t rows, uint32_t cols, float alpha,
                                float beta);
 
@@ -159,7 +159,7 @@ void sgemv_transpose_neon_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  */
-void saxpy_neon_fp16(const unsigned int N, const float alpha, const __fp16 *X,
+void saxpy_fp16(const unsigned int N, const float alpha, const __fp16 *X,
                      __fp16 *Y);
 
 /**
@@ -168,14 +168,14 @@ void saxpy_neon_fp16(const unsigned int N, const float alpha, const __fp16 *X,
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  */
-__fp16 sdot_neon_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y);
+__fp16 sdot_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y);
 
 /**
  * @brief     snrm2 computation with neon: Euclidean norm
  * @param[in] N number of elements in X
  * @param[in] X __fp16 * for Vector X
  */
-__fp16 snrm2_neon_fp16(const unsigned int N, const __fp16 *X);
+__fp16 snrm2_fp16(const unsigned int N, const __fp16 *X);
 
 /**
  * @brief     sscal computation with neon: X = alpha * X
@@ -183,7 +183,7 @@ __fp16 snrm2_neon_fp16(const unsigned int N, const __fp16 *X);
  * @param[in] X __fp16 * for Vector X
  * @param[in] alpha float number
  */
-void sscal_neon_fp16(const unsigned int N, __fp16 *X, const float alpha);
+void sscal_fp16(const unsigned int N, __fp16 *X, const float alpha);
 
 /**
  * @brief     convert uint32x4_t to float32x4_t with neon with bitwise
@@ -198,7 +198,7 @@ float32x4_t vcvtq_f32_u32_bitwise(uint32x4_t u32);
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  */
-void scopy_neon_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y);
+void scopy_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -206,7 +206,7 @@ void scopy_neon_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y);
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y uint8_t * for Vector Y
  */
-void scopy_neon_int4_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
+void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -214,7 +214,7 @@ void scopy_neon_int4_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
  * @param[in] X float * for Vector X
  * @param[in] Y uint8_t * for Vector Y
  */
-void scopy_neon_int8_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
+void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -222,7 +222,7 @@ void scopy_neon_int8_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
  * @param[in] X float * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  */
-void scopy_neon_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y);
+void scopy_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -230,14 +230,14 @@ void scopy_neon_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y);
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y float * for Vector Y
  */
-void scopy_neon_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y);
+void scopy_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y);
 
 /**
  * @brief     isamax function with neon: index of first maxima
  * @param[in] N number of elements in X
  * @param[in] X __fp16 * for Vector X
  */
-unsigned int isamax_neon_fp16(const unsigned int N, const __fp16 *X);
+unsigned int isamax_fp16(const unsigned int N, const __fp16 *X);
 
 /**
  * @brief     sgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
@@ -251,7 +251,7 @@ unsigned int isamax_neon_fp16(const unsigned int N, const __fp16 *X);
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
+void sgemm_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
                      uint32_t N, uint32_t K, float alpha, float beta,
                      bool TransA, bool TransB);
 /**
@@ -266,7 +266,7 @@ void sgemm_neon_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
+void sgemm_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
                              uint32_t M, uint32_t N, uint32_t K, float alpha,
                              float beta);
 /**
@@ -281,7 +281,7 @@ void sgemm_neon_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
+void sgemm_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
                             uint32_t M, uint32_t N, uint32_t K, float alpha,
                             float beta);
 /**
@@ -296,7 +296,7 @@ void sgemm_neon_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
+void sgemm_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
                             uint32_t M, uint32_t N, uint32_t K, float alpha,
                             float beta);
 /**
@@ -311,7 +311,7 @@ void sgemm_neon_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
+void sgemm_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
                              uint32_t M, uint32_t N, uint32_t K, float alpha,
                              float beta, uint32_t idx);
 /**
@@ -320,7 +320,7 @@ void sgemm_neon_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
  * @param N number of elements in X
  * @param X __fp16 * for Vector X
  */
-void inv_sqrt_inplace_neon(const unsigned int N, __fp16 *X);
+void inv_sqrt_inplace(const unsigned int N, __fp16 *X);
 #endif
 
 } // namespace nntrainer::neon

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -119,8 +119,7 @@ void hgemv(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
  * @param[in] Y __fp16 * for Vector Y
  * @param[in] Z __fp16 * for Vector Z
  */
-void elementwise_vector_multiplication(const unsigned N, const __fp16 *X,
-                                       const __fp16 *Y, __fp16 *Z);
+void ewvm(const unsigned N, const __fp16 *X, const __fp16 *Y, __fp16 *Z);
 /**
  * @brief     elementwise vector addition with neon : Z = X + Y
  * @param[in] N  length of the vector
@@ -128,8 +127,7 @@ void elementwise_vector_multiplication(const unsigned N, const __fp16 *X,
  * @param[in] Y __fp16 * for Vector Y
  * @param[in] Z __fp16 * for Vector Z
  */
-void elementwise_vector_addition(const unsigned N, const __fp16 *X,
-                                 const __fp16 *Y, __fp16 *Z);
+void ewva(const unsigned N, const __fp16 *X, const __fp16 *Y, __fp16 *Z);
 
 /**
  * @brief     transposed hgemv computation with neon

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -32,7 +32,7 @@ namespace nntrainer::neon {
  * @param[in] beta float number
  */
 void sgemv(const float *A, const float *X, float *Y, uint32_t rows,
-                uint32_t cols, const float alpha, const float beta);
+           uint32_t cols, const float alpha, const float beta);
 
 /**
  * @brief     transposed sgemv computation with neon
@@ -46,9 +46,8 @@ void sgemv(const float *A, const float *X, float *Y, uint32_t rows,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemv_transpose(const float *A, const float *X, float *Y,
-                          uint32_t rows, uint32_t cols, float alpha,
-                          float beta);
+void sgemv_transpose(const float *A, const float *X, float *Y, uint32_t rows,
+                     uint32_t cols, float alpha, float beta);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -56,7 +55,7 @@ void sgemv_transpose(const float *A, const float *X, float *Y,
  * @param[in] X float * for Vector X
  * @param[in] Y uint8_t * for Vector Y
  */
-void scopy_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
+void copy_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -64,7 +63,7 @@ void scopy_int4_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
  * @param[in] X float * for Vector X
  * @param[in] Y uint8_t * for Vector Y
  */
-void scopy_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
+void copy_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -72,8 +71,7 @@ void scopy_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
  * @param[in] X uint8_t * for Vector X
  * @param[in] Y uint8_t * for Vector Y
  */
-void scopy_int8_or_int4(const unsigned int N, const uint8_t *X,
-                             uint8_t *Y);
+void copy_int8_or_int4(const unsigned int N, const uint8_t *X, uint8_t *Y);
 /**
  * @brief     sine with neon: Y = sin(alpha * X)
  * @param[in] N number of elements in X
@@ -81,8 +79,7 @@ void scopy_int8_or_int4(const unsigned int N, const uint8_t *X,
  * @param[in] Y float * for Vector Y
  * @param[in] alpha float * for scaling angle (radian)
  */
-void sine(const unsigned int N, float *X, float *Y,
-                              float alpha = 1.0);
+void sine(const unsigned int N, float *X, float *Y, float alpha = 1.0);
 
 /**
  * @brief     cosine with neon: Y = cos(alpha * X)
@@ -91,8 +88,7 @@ void sine(const unsigned int N, float *X, float *Y,
  * @param[in] Y float * for Vector Y
  * @param[in] alpha float * for scaling angle (radian)
  */
-void cosine(const unsigned int N, float *X, float *Y,
-                                float alpha = 1.0);
+void cosine(const unsigned int N, float *X, float *Y, float alpha = 1.0);
 
 /**
  * @brief inversed squared root transformation with neon : X = 1 / sqrt(X)
@@ -104,7 +100,7 @@ void inv_sqrt_inplace(const unsigned int N, float *X);
 
 #ifdef ENABLE_FP16
 /**
- * @brief     sgemv computation with neon : Y = alpha*A*X + beta*Y
+ * @brief     hgemv computation with neon : Y = alpha*A*X + beta*Y
  * @param[in] A __fp16 * for Matrix A
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y __fp16 * for Vector Y
@@ -113,8 +109,8 @@ void inv_sqrt_inplace(const unsigned int N, float *X);
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemv_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
-                     uint32_t cols, float alpha, float beta);
+void hgemv(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
+           uint32_t cols, float alpha, float beta);
 
 /**
  * @brief     elementwise vector multiplication with neon : Z = X ⊙ Y
@@ -123,9 +119,8 @@ void sgemv_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
  * @param[in] Y __fp16 * for Vector Y
  * @param[in] Z __fp16 * for Vector Z
  */
-void elementwise_vector_multiplication_fp16(const unsigned N,
-                                                 const __fp16 *X,
-                                                 const __fp16 *Y, __fp16 *Z);
+void elementwise_vector_multiplication(const unsigned N, const __fp16 *X,
+                                       const __fp16 *Y, __fp16 *Z);
 /**
  * @brief     elementwise vector addition with neon : Z = X + Y
  * @param[in] N  length of the vector
@@ -133,11 +128,11 @@ void elementwise_vector_multiplication_fp16(const unsigned N,
  * @param[in] Y __fp16 * for Vector Y
  * @param[in] Z __fp16 * for Vector Z
  */
-void elementwise_vector_addition_fp16(const unsigned N, const __fp16 *X,
-                                           const __fp16 *Y, __fp16 *Z);
+void elementwise_vector_addition(const unsigned N, const __fp16 *X,
+                                 const __fp16 *Y, __fp16 *Z);
 
 /**
- * @brief     transposed sgemv computation with neon
+ * @brief     transposed hgemv computation with neon
  *            Y = alpha*transpose(A)*X
  * + beta*Y
  * @param[in] A __fp16 * for Matrix A
@@ -148,42 +143,40 @@ void elementwise_vector_addition_fp16(const unsigned N, const __fp16 *X,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemv_transpose_fp16(const __fp16 *A, const __fp16 *X, __fp16 *Y,
-                               uint32_t rows, uint32_t cols, float alpha,
-                               float beta);
+void hgemv_transpose(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t rows,
+                     uint32_t cols, float alpha, float beta);
 
 /**
- * @brief     saxpy computation with neon: Y = alpha*X + Y
+ * @brief     haxpy computation with neon: Y = alpha*X + Y
  * @param[in] N number of elements in Y
  * @param[in] alpha float number
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  */
-void saxpy_fp16(const unsigned int N, const float alpha, const __fp16 *X,
-                     __fp16 *Y);
+void haxpy(const unsigned int N, const float alpha, const __fp16 *X, __fp16 *Y);
 
 /**
- * @brief     sdot computation with neon: sum of all X * Y
+ * @brief     hdot computation with neon: sum of all X * Y
  * @param[in] N number of elements in Y
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  */
-__fp16 sdot_fp16(const unsigned int N, const __fp16 *X, const __fp16 *Y);
+__fp16 hdot(const unsigned int N, const __fp16 *X, const __fp16 *Y);
 
 /**
- * @brief     snrm2 computation with neon: Euclidean norm
+ * @brief     hnrm2 computation with neon: Euclidean norm
  * @param[in] N number of elements in X
  * @param[in] X __fp16 * for Vector X
  */
-__fp16 snrm2_fp16(const unsigned int N, const __fp16 *X);
+__fp16 hnrm2(const unsigned int N, const __fp16 *X);
 
 /**
- * @brief     sscal computation with neon: X = alpha * X
+ * @brief     hscal computation with neon: X = alpha * X
  * @param[in] N number of elements in X
  * @param[in] X __fp16 * for Vector X
  * @param[in] alpha float number
  */
-void sscal_fp16(const unsigned int N, __fp16 *X, const float alpha);
+void hscal(const unsigned int N, __fp16 *X, const float alpha);
 
 /**
  * @brief     convert uint32x4_t to float32x4_t with neon with bitwise
@@ -193,12 +186,12 @@ void sscal_fp16(const unsigned int N, __fp16 *X, const float alpha);
 float32x4_t vcvtq_f32_u32_bitwise(uint32x4_t u32);
 
 /**
- * @brief     copy function with neon: Y = X
+ * @brief     hcopy function with neon: Y = X
  * @param[in] N number of elements in X
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  */
-void scopy_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y);
+void hcopy(const unsigned int N, const __fp16 *X, __fp16 *Y);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -206,7 +199,7 @@ void scopy_fp16(const unsigned int N, const __fp16 *X, __fp16 *Y);
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y uint8_t * for Vector Y
  */
-void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
+void copy_int4_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -214,7 +207,7 @@ void scopy_int4_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
  * @param[in] X float * for Vector X
  * @param[in] Y uint8_t * for Vector Y
  */
-void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
+void copy_int8_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -222,7 +215,7 @@ void scopy_int8_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
  * @param[in] X float * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  */
-void scopy_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y);
+void copy_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y);
 
 /**
  * @brief     copy function with neon: Y = X
@@ -230,17 +223,17 @@ void scopy_fp32_to_fp16(const unsigned int N, const float *X, __fp16 *Y);
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y float * for Vector Y
  */
-void scopy_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y);
+void copy_fp16_to_fp32(const unsigned int N, const __fp16 *X, float *Y);
 
 /**
  * @brief     isamax function with neon: index of first maxima
  * @param[in] N number of elements in X
  * @param[in] X __fp16 * for Vector X
  */
-unsigned int isamax_fp16(const unsigned int N, const __fp16 *X);
+unsigned int isamax(const unsigned int N, const __fp16 *X);
 
 /**
- * @brief     sgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * @brief     hgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
  * where op(X) is one of X or X**T
  * @param[in] A __fp16 * for Matrix A
  * @param[in] B __fp16 * for Matrix B
@@ -251,11 +244,10 @@ unsigned int isamax_fp16(const unsigned int N, const __fp16 *X);
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
-                     uint32_t N, uint32_t K, float alpha, float beta,
-                     bool TransA, bool TransB);
+void hgemm(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M, uint32_t N,
+           uint32_t K, float alpha, float beta, bool TransA, bool TransB);
 /**
- * @brief     sgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * @brief     hgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
  * where op(X) is one of X or X**T
  * @param[in] A __fp16 * for Matrix A
  * @param[in] B __fp16 * for Matrix B
@@ -266,11 +258,10 @@ void sgemm_fp16(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
-                             uint32_t M, uint32_t N, uint32_t K, float alpha,
-                             float beta);
+void hgemm_noTrans(const __fp16 *A, const __fp16 *B, float *C, uint32_t M,
+                   uint32_t N, uint32_t K, float alpha, float beta);
 /**
- * @brief     sgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * @brief     hgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
  * where op(X) is one of X or X**T
  * @param[in] A __fp16 * for Matrix A
  * @param[in] B __fp16 * for Matrix B
@@ -281,11 +272,10 @@ void sgemm_fp16_noTrans(const __fp16 *A, const __fp16 *B, float *C,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
-                            uint32_t M, uint32_t N, uint32_t K, float alpha,
-                            float beta);
+void hgemm_transA(const __fp16 *A, const __fp16 *B, float *C, uint32_t M,
+                  uint32_t N, uint32_t K, float alpha, float beta);
 /**
- * @brief     sgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * @brief     hgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
  * where op(X) is one of X or X**T
  * @param[in] A __fp16 * for Matrix A
  * @param[in] B __fp16 * for Matrix B
@@ -296,11 +286,10 @@ void sgemm_fp16_transA(const __fp16 *A, const __fp16 *B, float *C,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
-                            uint32_t M, uint32_t N, uint32_t K, float alpha,
-                            float beta);
+void hgemm_transB(const __fp16 *A, const __fp16 *B, float *C, uint32_t M,
+                  uint32_t N, uint32_t K, float alpha, float beta);
 /**
- * @brief     sgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * @brief     hgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
  * where op(X) is one of X or X**T
  * @param[in] A __fp16 * for Matrix A
  * @param[in] B __fp16 * for Matrix B
@@ -311,9 +300,9 @@ void sgemm_fp16_transB(const __fp16 *A, const __fp16 *B, float *C,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm_fp16_transAB(const __fp16 *A, const __fp16 *B, float *C,
-                             uint32_t M, uint32_t N, uint32_t K, float alpha,
-                             float beta, uint32_t idx);
+void hgemm_transAB(const __fp16 *A, const __fp16 *B, float *C, uint32_t M,
+                   uint32_t N, uint32_t K, float alpha, float beta,
+                   uint32_t idx);
 /**
  * @brief squared root transformation with neon : X = sqrt(X)
  *

--- a/nntrainer/utils/util_simd.cpp
+++ b/nntrainer/utils/util_simd.cpp
@@ -19,7 +19,7 @@ namespace nntrainer {
 void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
                                  float *sin_, unsigned int alpha) {
 #ifdef USE_NEON
-  nntrainer::neon::calc_trigonometric_vals_dup_neon(N_half, angle, cos_, sin_,
+  nntrainer::neon::calc_trigonometric_vals_dup(N_half, angle, cos_, sin_,
                                                     alpha);
 #else
   throw std::invalid_argument(
@@ -30,7 +30,7 @@ void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
 
 void swish(const unsigned int N, float *X, float *Y, float *Z) {
 #ifdef USE_NEON
-  nntrainer::neon::swish_neon(N, X, Y, Z);
+  nntrainer::neon::swish(N, X, Y, Z);
 #else
   unsigned int i = 0;
   while (i < N) {
@@ -46,7 +46,7 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
                                     unsigned int w, _FP16 *in, _FP16 *out,
                                     float *cos_, float *sin_) {
 #ifdef USE_NEON
-  nntrainer::neon::compute_rotary_embedding_value_neon(dim, half_, w, in, out,
+  nntrainer::neon::compute_rotary_embedding_value(dim, half_, w, in, out,
                                                        cos_, sin_);
 #else
   throw std::invalid_argument(
@@ -57,7 +57,7 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
 
 void swish(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z) {
 #ifdef USE_NEON
-  nntrainer::neon::swish_neon(N, X, Y, Z);
+  nntrainer::neon::swish(N, X, Y, Z);
 #else
   unsigned int i = 0;
   while (i < N) {

--- a/nntrainer/utils/util_simd.cpp
+++ b/nntrainer/utils/util_simd.cpp
@@ -20,7 +20,7 @@ void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
                                  float *sin_, unsigned int alpha) {
 #ifdef USE_NEON
   nntrainer::neon::calc_trigonometric_vals_dup(N_half, angle, cos_, sin_,
-                                                    alpha);
+                                               alpha);
 #else
   throw std::invalid_argument(
     "Error: No implementation of rotary embedding layer incremental_forwarding "
@@ -46,8 +46,8 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
                                     unsigned int w, _FP16 *in, _FP16 *out,
                                     float *cos_, float *sin_) {
 #ifdef USE_NEON
-  nntrainer::neon::compute_rotary_embedding_value(dim, half_, w, in, out,
-                                                       cos_, sin_);
+  nntrainer::neon::compute_rotary_embedding_value(dim, half_, w, in, out, cos_,
+                                                  sin_);
 #else
   throw std::invalid_argument(
     "Error: No implementation of rotary embedding layer incremental_forwarding "

--- a/nntrainer/utils/util_simd_neon.cpp
+++ b/nntrainer/utils/util_simd_neon.cpp
@@ -13,9 +13,8 @@
 
 namespace nntrainer::neon {
 
-void calc_trigonometric_vals_dup(unsigned int N_half, float *angle,
-                                      float *cos_, float *sin_,
-                                      unsigned int from) {
+void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
+                                 float *sin_, unsigned int from) {
   cosine(N_half, angle, cos_, from);
   sine(N_half, angle, sin_, from);
 
@@ -58,9 +57,8 @@ void swish(const unsigned int N, float *X, float *Y, float *Z) {
 
 #ifdef ENABLE_FP16
 void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
-                                         unsigned int w, __fp16 *in,
-                                         __fp16 *out, float *cos_,
-                                         float *sin_) {
+                                    unsigned int w, __fp16 *in, __fp16 *out,
+                                    float *cos_, float *sin_) {
   unsigned int k = 0;
   while (k < dim) {
     unsigned int span = w + k;

--- a/nntrainer/utils/util_simd_neon.cpp
+++ b/nntrainer/utils/util_simd_neon.cpp
@@ -13,11 +13,11 @@
 
 namespace nntrainer::neon {
 
-void calc_trigonometric_vals_dup_neon(unsigned int N_half, float *angle,
+void calc_trigonometric_vals_dup(unsigned int N_half, float *angle,
                                       float *cos_, float *sin_,
                                       unsigned int from) {
-  cosine_neon(N_half, angle, cos_, from);
-  sine_neon(N_half, angle, sin_, from);
+  cosine(N_half, angle, cos_, from);
+  sine(N_half, angle, sin_, from);
 
   unsigned int N = 2 * N_half;
   unsigned int i = N_half;
@@ -36,7 +36,7 @@ void calc_trigonometric_vals_dup_neon(unsigned int N_half, float *angle,
   }
 }
 
-void swish_neon(const unsigned int N, float *X, float *Y, float *Z) {
+void swish(const unsigned int N, float *X, float *Y, float *Z) {
   unsigned int i = 0;
   for (; N - i >= VL_FP32; i += VL_FP32) {
     float32x4_t y0_3 = vld1q_f32(&Y[i]);
@@ -57,7 +57,7 @@ void swish_neon(const unsigned int N, float *X, float *Y, float *Z) {
 }
 
 #ifdef ENABLE_FP16
-void compute_rotary_embedding_value_neon(unsigned int dim, unsigned int half_,
+void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
                                          unsigned int w, __fp16 *in,
                                          __fp16 *out, float *cos_,
                                          float *sin_) {
@@ -132,7 +132,7 @@ void compute_rotary_embedding_value_neon(unsigned int dim, unsigned int half_,
   }
 }
 
-void swish_neon(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z) {
+void swish(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z) {
   unsigned int i = 0;
   for (; N - i >= VL_FP16; i += VL_FP16) {
     float16x8_t y0_7 = vld1q_f16(&Y[i]);

--- a/nntrainer/utils/util_simd_neon.h
+++ b/nntrainer/utils/util_simd_neon.h
@@ -28,7 +28,7 @@ namespace nntrainer::neon {
  * @param sin_ float* for sin_
  * @param alpha scaling factor
  */
-void calc_trigonometric_vals_dup_neon(unsigned int N_half, float *angle,
+void calc_trigonometric_vals_dup(unsigned int N_half, float *angle,
                                       float *cos_, float *sin_,
                                       unsigned int alpha = 1.0);
 
@@ -40,7 +40,7 @@ void calc_trigonometric_vals_dup_neon(unsigned int N_half, float *angle,
  * @param Y float * for Vector Y
  * @param Z float * for Vector Z
  */
-void swish_neon(const unsigned int N, float *X, float *Y, float *Z);
+void swish(const unsigned int N, float *X, float *Y, float *Z);
 #ifdef ENABLE_FP16
 /**
  * @brief Accelerating function for rotary embedding layer forwarding
@@ -53,7 +53,7 @@ void swish_neon(const unsigned int N, float *X, float *Y, float *Z);
  * @param cos_ precomputed cos_ for corresponding rotational indices
  * @param sin_ precomputed sin_ for corresponding rotational indices
  */
-void compute_rotary_embedding_value_neon(unsigned int dim, unsigned int half_,
+void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
                                          unsigned int w, __fp16 *in,
                                          __fp16 *out, float *cos_, float *sin_);
 /**
@@ -64,7 +64,7 @@ void compute_rotary_embedding_value_neon(unsigned int dim, unsigned int half_,
  * @param Y __fp16 * for Vector Y
  * @param Z __fp16 * for Vector Z
  */
-void swish_neon(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z);
+void swish(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z);
 #endif
 
 } // namespace nntrainer::neon

--- a/nntrainer/utils/util_simd_neon.h
+++ b/nntrainer/utils/util_simd_neon.h
@@ -28,9 +28,8 @@ namespace nntrainer::neon {
  * @param sin_ float* for sin_
  * @param alpha scaling factor
  */
-void calc_trigonometric_vals_dup(unsigned int N_half, float *angle,
-                                      float *cos_, float *sin_,
-                                      unsigned int alpha = 1.0);
+void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
+                                 float *sin_, unsigned int alpha = 1.0);
 
 /**
  * @brief swish function with neon : X = (Y / (1 + exp( -Y ))) * Z
@@ -54,8 +53,8 @@ void swish(const unsigned int N, float *X, float *Y, float *Z);
  * @param sin_ precomputed sin_ for corresponding rotational indices
  */
 void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
-                                         unsigned int w, __fp16 *in,
-                                         __fp16 *out, float *cos_, float *sin_);
+                                    unsigned int w, __fp16 *in, __fp16 *out,
+                                    float *cos_, float *sin_);
 /**
  * @brief swish function with neon : X = (Y / (1 + exp( -Y ))) * Z
  *


### PR DESCRIPTION
- Every neon function resides in nntrainer::neon namespace, no need to be differentiated
- 's' in BLAS functions indicates the function works with single-precision (fp32). Incase of half-precision functions we should use 'h' instead of 's'
- In case of previous functions like : 'scopy_fp32_to_fp16', the function name itself shows the dataType it gets, so no need to add neither 's' nor 'h'
- There are more rooms for this, but still WIP ( e.g. `blas_interface.h` )
