### PR TITLE
[TensorV2] Add dot product support

### DIFF
--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -262,6 +262,13 @@ public:
   TensorV2 &erf(TensorV2 &output) const override;
 
   /**
+   *  @copydoc TensorV2::dot(TensorV2 const &input, TensorV2 &output, bool
+   * trans, bool trans_in, float beta)
+   */
+  TensorV2 &dot(TensorV2 const &input, TensorV2 &output, bool trans,
+                bool trans_in, float beta) const override;
+
+  /**
    * @copydoc TensorV2::copy(const TensorV2 &from)
    */
   void copy(const TensorV2 &from);

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -488,6 +488,66 @@ TensorV2 &HalfTensor::erf(TensorV2 &output) const {
   return output;
 }
 
+TensorV2 &HalfTensor::dot(TensorV2 const &input, TensorV2 &output, bool trans,
+                          bool trans_in, float beta) const {
+  // Comment out with intension to support the calculation wrt. batch and height
+  // direction. It supposes to have this->dim as [ BxCxH,W ] and input.dim is
+  // [BxCxH,W] as well if (input.dim.rank() > 2) {
+  //   throw exception::not_supported("Error: support only for rank of dot "
+  //                                  "matrix <= 2");
+  // }
+
+  // Comment out with intension to support the calculation wrt. batch and height
+  // direction of this tensor. It is OK as long as input is 2D
+  if (trans && dim.rank() > 2) {
+    ml_logw("Warning: support only for rank of dot matrix <= 2 with trans");
+  }
+  unsigned int first_three_flat, last_axis, input_first_three_flat,
+    input_last_axis, M, N, K, lda, ldb, ldc;
+
+  calculateFlattenDot(input, output, trans, trans_in, first_three_flat,
+                      last_axis, input_first_three_flat, input_last_axis, M, N,
+                      K, lda, ldb, ldc);
+
+  const _FP16 *data = (_FP16 *)getData();
+  const _FP16 *mdata = input.getData<_FP16>();
+  _FP16 *rdata = output.getData<_FP16>();
+  const float alpha = 1.0f;
+  enum CBLAS_TRANSPOSE transA = trans ? CblasTrans : CblasNoTrans;
+  enum CBLAS_TRANSPOSE transB = trans_in ? CblasTrans : CblasNoTrans;
+
+  /// shortcut handling in case of vector
+  /// for vector, (1 * K) == (K * 1) in current memory layout...
+  /// and plaese note that N, K, M is a fixed place holder after considering
+  /// transpose.
+  /// For example, there is no case like (1 * K) X (1 * K) while
+  /// (1 * K) X (1 * M) can be a case
+  /// case1: (1 * K) X (K * 1)
+  if (M == 1 && N == 1) {
+    *rdata = sdot(K, data, 1, mdata, 1) + static_cast<_FP16>(beta) * (*rdata);
+  }
+  /// case2: (M * K) X (K * 1)
+  else if (N == 1) {
+    sgemv(CblasRowMajor, transA, first_three_flat, last_axis, alpha, data, lda,
+          mdata, 1, beta, rdata, 1);
+  }
+  /// case3: (1 * K) X (K * N) = 1 * N = R
+  /// = R^T = (K * N) ^T * (1 * K) ^T = (N * K) * (K * 1) = (N * K) * (1 * K)
+  /// Effectively a translation of sgemv
+  else if (M == 1) {
+    transB = transB == CblasTrans ? CblasNoTrans : CblasTrans;
+    sgemv(CblasRowMajor, transB, input_first_three_flat, input_last_axis, alpha,
+          mdata, ldb, data, 1, beta, rdata, 1);
+  }
+  /// case others: use sgemm
+  else {
+    sgemm(CblasRowMajor, transA, transB, M, N, K, alpha, data, lda, mdata, ldb,
+          beta, rdata, ldc);
+  }
+
+  return output;
+}
+
 void HalfTensor::print(std::ostream &out) const {
   printInstance(out, this);
   const _FP16 *data = (_FP16 *)getData();

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -261,6 +261,13 @@ public:
   TensorV2 &erf(TensorV2 &output) const override;
 
   /**
+   *  @copydoc TensorV2::dot(TensorV2 const &input, TensorV2 &output, bool
+   * trans, bool trans_in, float beta)
+   */
+  TensorV2 &dot(TensorV2 const &input, TensorV2 &output, bool trans,
+                bool trans_in, float beta) const override;
+
+  /**
    * @copydoc TensorV2::copy(const TensorV2 &from)
    */
   void copy(const TensorV2 &from);

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -250,6 +250,20 @@ public:
   virtual TensorV2 &erf(TensorV2 &output) const = 0;
 
   /**
+   * @brief     Dot Product of Tensor ( equal MxM )
+   * @details   This applies dot of the last dimension of this and
+   * second-last dimension of passed tensor m.
+   * @param[in] input Tensor
+   * @param[in] output output Tensor
+   * @param[in] trans Transpose
+   * @param[in] trans_in Transpose input
+   * @param[in] beta beta
+   * @retval    Calculated Tensor
+   */
+  virtual TensorV2 &dot(TensorV2 const &input, TensorV2 &output, bool trans,
+                        bool trans_in, float beta) const = 0;
+
+  /**
    * @copydoc TensorV2::print(std::ostream &out)
    */
   virtual void print(std::ostream &out) const = 0;
@@ -491,6 +505,34 @@ protected:
    * @return BroadcastInfo Loopinfo needed to run external loop
    */
   BroadcastInfoV2 computeBroadcastInfo(const TensorV2 &m) const;
+
+  /**
+   * @brief Calcuates variables needed to perform tensor flatten dot product
+   *
+   * @param[in]  input Tensor
+   * @param[in]  output output Tensor
+   * @param[in]  trans Transpose
+   * @param[in]  trans_in Transpose input
+   * @param[out] first_three_flat flattened the fist 3 axis
+   * @param[out] last_axis last axis
+   * @param[out] input_first_three_flat input's flattened the fist 3 axis
+   * @param[out] input_last_axis input's last axis
+   * @param[out] M number of op(this)'s and output's row
+   * @param[out] N number of op(inputs)'s and output's columns
+   * @param[out] K number of op(this)'s column and op(input)'s row
+   * @param[out] lda leading dimension of this
+   * @param[out] ldb leading dimension of input
+   * @param[out] ldc leading dimension of output
+   *
+   * @note op(X) is one of X or X**T
+   */
+  void calculateFlattenDot(TensorV2 const &input, TensorV2 &output, bool trans,
+                           bool trans_in, unsigned int &first_three_flat,
+                           unsigned int &last_axis,
+                           unsigned int &input_first_three_flat,
+                           unsigned int &input_last_axis, unsigned int &M,
+                           unsigned int &N, unsigned int &K, unsigned int &lda,
+                           unsigned int &ldb, unsigned int &ldc) const;
 };
 
 /**

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -752,6 +752,88 @@ public:
   TensorV2 &erf(TensorV2 &output) const;
 
   /**
+   * @brief     Dot Product of Tensor ( equal MxM )
+   * @details   This applies dot of the last dimension of this and second-last
+   * dimension of passed input tensor.
+   * @param[in] input Tensor
+   * @param[in] trans Transpose
+   * @param[in] trans_in Transpose input
+   * @retval    Calculated Tensor
+   */
+  TensorV2 dot(TensorV2 const &input, bool trans = false,
+               bool trans_in = false) const;
+
+  /**
+   * @brief     Dot Product of Tensor ( equal MxM )
+   * @details   This applies dot of the last dimension of this and
+   * second-last dimension of passed input tensor.
+   * @param[in] input Tensor
+   * @param[in] output output Tensor
+   * @param[in] trans Transpose
+   * @param[in] trans_in Transpose input
+   * @param[in] beta beta
+   * @retval    Calculated Tensor
+   */
+  TensorV2 &dot(TensorV2 const &input, TensorV2 &output, bool trans = false,
+                bool trans_in = false, float beta = 0.0f) const;
+
+  /**
+   * @brief compute the derivative of this in the current tensor
+   * @param input same as given to the dot()
+   * @param output_deriv the derivative of the output
+   * @param[in] trans same as given to the dot()
+   * @param[in] trans_in same as given to the dot()
+   * @param[in] beta same as given to the dot()
+   * @note This will compute the derivative in-place and will overwrite
+   existing
+   * data in the tensor
+   */
+  TensorV2 &dot_deriv_wrt_1(TensorV2 const &input, TensorV2 const &output_deriv,
+                            bool trans = false, bool trans_in = false,
+                            float beta = 0.0f);
+
+  /**
+   * @brief compute the derivative wrt m in the input tensor
+   * @param input_deriv tensor where derivative wrt m will be stored
+   * @param output_deriv the derivative of the output
+   * @param[in] trans same as given to the dot()
+   * @param[in] trans_in same as given to the dot()
+   * @param[in] beta same as given to the dot()
+   * @note The caller tensor must be the same tensor as the one which called
+   the dot() product.
+   */
+  TensorV2 &dot_deriv_wrt_2(TensorV2 &input_deriv, TensorV2 const &output_deriv,
+                            bool trans = false, bool trans_in = false,
+                            float beta = 0.0f) const;
+
+  /**
+   * @copydoc Tensor::dot(Tensor const &input, Tensor &output, bool trans,
+              bool trans_in, float beta) const
+   * @details performs dot operation over a batch of inputs
+   */
+  TensorV2 &dotBatched(TensorV2 const &input, TensorV2 &result,
+                       bool trans = false, bool trans_in = false,
+                       float beta = 0.0f) const;
+
+  /**
+   * @copydoc Tensor::dot_deriv_wrt_1(Tensor const &input, Tensor const
+   &output_deriv, bool trans, bool trans_in, float beta)
+   */
+  TensorV2 &dot_batched_deriv_wrt_1(TensorV2 const &input,
+                                    TensorV2 const &output_deriv,
+                                    bool trans = false, bool trans_in = false,
+                                    float beta = 0.0f);
+
+  /**
+   * @brief Tensor::dot_deriv_wrt_2(Tensor const &input_deriv, Tensor const
+   &output_deriv, bool trans, bool trans_in, float beta) const
+   */
+  TensorV2 &dot_batched_deriv_wrt_2(TensorV2 &input_deriv,
+                                    TensorV2 const &output_deriv,
+                                    bool trans = false, bool trans_in = false,
+                                    float beta = 0.0f) const;
+
+  /**
    * @brief     Print element
    * @param[in] out out stream
    */
@@ -785,6 +867,16 @@ public:
    * @note      only support copying data from tensor with the same data type
    */
   void copy_with_stride(const TensorV2 &from);
+
+  /**
+   * @brief Get slice of the tensor, sliced by batch
+   * @param[in] offset offset in batch to start the slice
+   * @param[in] size size of the slice
+   * @retval slice of this tensor
+   * @note This function provides a slice of this tensor, and does not create a
+   * copy
+   */
+  TensorV2 getBatchSlice(size_t offset, unsigned int size) const;
 
   /**
    * @brief     set Tensor Dim


### PR DESCRIPTION
This PR adds the ability to compute the dot product between two tensors.

**Changes proposed in this PR:**
- Added a new method `dot()` to the `TensorV2` class that computes the dot product between two tensors.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped