### PR TITLE
[TensorV2] Add Transpose Support for Tensor

### DIFF
--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -370,36 +370,6 @@ TensorV2 FloatTensor::multiply_strided(TensorV2 const &m, TensorV2 &output,
   return output;
 }
 
-void FloatTensor::copy(const TensorV2 &from) {
-  reshape(from.getDim());
-  copy(from.getData<float>());
-}
-
-void FloatTensor::copyData(const TensorV2 &from) {
-  NNTR_THROW_IF(!contiguous, std::invalid_argument)
-    << getName() << " is not contiguous, cannot copy.";
-
-  NNTR_THROW_IF(size() != from.size(), std::invalid_argument)
-    << "Size of tensor to copy must match";
-
-  switch (from.getDataType()) {
-  case ml::train::TensorDim::DataType::FP32:
-    copy(from.getData<float>());
-    break;
-  case ml::train::TensorDim::DataType::FP16:
-/// @todo remove #ifdef ENABLE_FP16
-#ifdef ENABLE_FP16
-    scopy(size(), from.getData<_FP16>(), 1, (float *)getData(), 1);
-#else
-    throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
-    break;
-  default:
-    throw std::invalid_argument("Error: Unsupported data type");
-    break;
-  }
-}
-
 int FloatTensor::multiply_i(float const &value) {
   float *data = (float *)getData();
   unsigned int len = size();
@@ -629,6 +599,102 @@ TensorV2 &FloatTensor::dot(TensorV2 const &input, TensorV2 &output, bool trans,
   else {
     sgemm(CblasRowMajor, transA, transB, M, N, K, alpha, data, lda, mdata, ldb,
           beta, rdata, ldc);
+  }
+
+  return output;
+}
+
+void FloatTensor::copy(const TensorV2 &from) {
+  reshape(from.getDim());
+  copy(from.getData<float>());
+}
+
+void FloatTensor::copyData(const TensorV2 &from) {
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot copy.";
+
+  NNTR_THROW_IF(size() != from.size(), std::invalid_argument)
+    << "Size of tensor to copy must match";
+
+  switch (from.getDataType()) {
+  case ml::train::TensorDim::DataType::FP32:
+    copy(from.getData<float>());
+    break;
+  case ml::train::TensorDim::DataType::FP16:
+/// @todo remove #ifdef ENABLE_FP16
+#ifdef ENABLE_FP16
+    scopy(size(), from.getData<_FP16>(), 1, (float *)getData(), 1);
+#else
+    throw std::invalid_argument("Error: enable-fp16 is not enabled");
+#endif
+    break;
+  default:
+    throw std::invalid_argument("Error: Unsupported data type");
+    break;
+  }
+}
+
+TensorV2 &FloatTensor::transpose(const std::string &direction,
+                                 TensorV2 &output) const {
+  unsigned int SL, SI, SJ, SK;
+
+  output.reshape(dim.transpose(direction));
+
+  int indexI = direction[0] - '0';
+  int indexJ = direction[2] - '0';
+
+  SL = dim.batch(), SI = dim.channel(), SJ = dim.height(), SK = dim.width();
+
+  bool is_format_nchw = (getFormat() == Tformat::NCHW);
+
+  const float *inptr = (float *)getData();
+  float *outptr = output.getData<float>();
+  switch (indexI) {
+  case 0:
+    if (indexJ == 1) {
+      if (is_format_nchw) {
+        transposeloop(l, i, j, k, SL, SI, SJ, SK);
+      } else {
+        transposeloop_nhwc(l, j, k, i, SL, SJ, SK, SI);
+      }
+    } else {
+      if (is_format_nchw) {
+        transposeloop(l, i, k, j, SL, SI, SK, SJ);
+      } else {
+        transposeloop_nhwc(l, k, j, i, SL, SK, SJ, SI);
+      }
+    }
+    break;
+  case 1:
+    if (indexJ == 0) {
+      if (is_format_nchw) {
+        transposeloop(l, j, i, k, SL, SJ, SI, SK);
+      } else {
+        transposeloop_nhwc(l, i, k, j, SL, SI, SK, SJ);
+      }
+    } else {
+      if (is_format_nchw) {
+        transposeloop(l, j, k, i, SL, SJ, SK, SI);
+      } else {
+        transposeloop_nhwc(l, k, i, j, SL, SK, SI, SJ);
+      }
+    }
+    break;
+  case 2:
+    if (indexJ == 0) {
+      if (is_format_nchw) {
+        transposeloop(l, k, i, j, SL, SK, SI, SJ);
+      } else {
+        transposeloop_nhwc(l, i, j, k, SL, SI, SJ, SK);
+      }
+    } else {
+      if (is_format_nchw) {
+        transposeloop(l, k, j, i, SL, SK, SJ, SI);
+      } else {
+        transposeloop_nhwc(l, j, i, k, SL, SJ, SI, SK);
+      }
+    }
+    break;
   }
 
   return output;

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -286,6 +286,12 @@ public:
   void copyData(const TensorV2 &from);
 
   /**
+   * @copydoc TensorV2::transpose(const std::string &direction, TensorV2 &out)
+   */
+  TensorV2 &transpose(const std::string &direction,
+                      TensorV2 &output) const override;
+
+  /**
    * @copydoc TensorV2::print(std::ostream &out)
    */
   void print(std::ostream &out) const override;

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -285,6 +285,12 @@ public:
   void copyData(const TensorV2 &from);
 
   /**
+   * @copydoc TensorV2::transpose(const std::string &direction, TensorV2 &out)
+   */
+  TensorV2 &transpose(const std::string &direction,
+                      TensorV2 &output) const override;
+
+  /**
    * @copydoc TensorV2::print(std::ostream &out)
    */
   void print(std::ostream &out) const override;

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -21,6 +21,34 @@
 #include <tensor_dim.h>
 #include <util_func.h>
 
+#define transposeloop(cl, ci, cj, ck, sl, si, sj, sk)                 \
+  do {                                                                \
+    unsigned int i, j, k, l;                                          \
+    int inidx = 0, outidx = 0;                                        \
+    for (cl = 0; cl < sl; cl++)                                       \
+      for (ci = 0; ci < si; ci++)                                     \
+        for (cj = 0; cj < sj; cj++)                                   \
+          for (ck = 0; ck < sk; ck++) {                               \
+            outidx = si * sj * sk * cl + sj * sk * ci + sk * cj + ck; \
+            inidx = l * SI * SJ * SK + i * SJ * SK + j * SK + k;      \
+            outptr[outidx] = inptr[inidx];                            \
+          }                                                           \
+  } while (0);
+
+#define transposeloop_nhwc(cl, ci, cj, ck, sl, si, sj, sk)            \
+  do {                                                                \
+    unsigned int i, j, k, l;                                          \
+    int inidx = 0, outidx = 0;                                        \
+    for (cl = 0; cl < sl; cl++)                                       \
+      for (ci = 0; ci < si; ci++)                                     \
+        for (cj = 0; cj < sj; cj++)                                   \
+          for (ck = 0; ck < sk; ck++) {                               \
+            outidx = si * sj * sk * cl + sj * sk * ci + sk * cj + ck; \
+            inidx = l * SJ * SK * SI + j * SK * SI + k * SI + i;      \
+            outptr[outidx] = inptr[inidx];                            \
+          }                                                           \
+  } while (0);
+
 namespace nntrainer {
 
 using TensorDim = ml::train::TensorDim;
@@ -306,6 +334,12 @@ public:
    * @param[in] from Tensor to be copied
    */
   virtual void copyData(const TensorV2 &from) = 0;
+
+  /**
+   * @copydoc TensorV2::transpose(const std::string &direction, TensorV2 &out)
+   */
+  virtual TensorV2 &transpose(const std::string &direction,
+                              TensorV2 &out) const = 0;
 
   /**
    * @brief     put data of Tensor

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -576,6 +576,33 @@ TensorV2 TensorV2::getBatchSlice(size_t offset, unsigned int size) const {
                              true, "");
 }
 
+TensorV2 TensorV2::clone() const {
+  TensorV2 output(getName(), getFormat(), getDataType());
+  output.copy(*this);
+  return output;
+}
+
+TensorV2 TensorV2::transpose(const std::string &direction) const {
+  TensorV2 output(getDim());
+  transpose(direction, output);
+  return output;
+}
+
+TensorV2 &TensorV2::transpose(const std::string &direction,
+                              TensorV2 &output) const {
+  NNTR_THROW_IF(!getContiguous(), std::invalid_argument)
+    << getName() << " is not contiguous. Cannot transpose.";
+
+  if (output.getData<char>() == getData<char>()) {
+    TensorV2 result = clone();
+    return result.transpose(direction, output);
+  }
+
+  itensor->transpose(direction, output);
+
+  return output;
+}
+
 void TensorV2::reshape(const TensorDim &d) { itensor->reshape(d); }
 
 TensorDim TensorV2::getDim() const { return itensor->getDim(); }

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -920,6 +920,27 @@ public:
   TensorV2 getBatchSlice(size_t offset, unsigned int size) const;
 
   /**
+   * @brief     Convient wrapper for inplace copy of @a this.
+   * @retval    Copied version of this
+   */
+  TensorV2 clone() const;
+
+  /**
+   * @brief  Transpose Tensor
+   * @param  direction to transpose ex) 0:2:1
+   * @return Tensor
+   */
+  TensorV2 transpose(const std::string &direction) const;
+
+  /**
+   * @brief      Transpose Tensor
+   * @param      direction to transpose ex) 0:2:1
+   * @param[out] Tensor to save to, dimension is always reshaped.
+   * @retval     Tensor& reference to the out
+   */
+  TensorV2 &transpose(const std::string &direction, TensorV2 &out) const;
+
+  /**
    * @brief     set Tensor Dim
    * @param[in] d TensorDim
    * @note      Throws std::invalid_argument if size mismatch


### PR DESCRIPTION
This pull request adds the ability to transpose tensors, which allows users to flip or rotate their data along its axes.

**Changes proposed in this PR:**
- Added a new method called transpose() to the TensorV2 class, which takes direction argument: the axes to be swapped.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped