### PR TITLE
[CI] Update labeler : Add READY2MERGE label

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -43,7 +43,7 @@ jobs:
       - name: "Unzip artifact"
         run: unzip pr_number.zip
 
-      - name: Remove label if approved review >= 3
+      - name: Remove & Make label if approved review >= 3
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,6 +61,15 @@ jobs:
               name : "Need Review"
             })
             }
+
+            if ((review >= 3) && (is_contain==String("true"))) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+                labels: ["PR/READY2MERGE"]
+              })
+              }
 
       - name: Make label if approved review < 3
         uses: actions/github-script@v7


### PR DESCRIPTION
Currently, we have a git action that automatically labels as "Need Review" when the number of reviews is insufficient, and removes it when necessary. This automation allows developers to know which pull requests need review.

In addition, we want to automate the process of labeling pull requests that require merging, to make it more convenient for developers.

Resolves:
- #2463 

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped