### PR TITLE
[TensorV2] Create a mask of dropout, filter, and zoneout @open sesame 02/26 12:23

### DIFF
--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -276,6 +276,21 @@ public:
                 bool trans_in, float beta) const override;
 
   /**
+   * @copydoc TensorV2::dropout_mask(float dropout)
+   */
+  void dropout_mask(float dropout) override;
+
+  /**
+   * @copydoc TensorV2::filter_mask(const TensorV2 &mask_len, bool reverse)
+   */
+  void filter_mask(const TensorV2 &mask_len, bool reverse) override;
+
+  /**
+   * @copydoc TensorV2::zoneout_mask(TensorV2 &opposite, float zoneout)
+   */
+  void zoneout_mask(TensorV2 &opposite, float zoneout) override;
+
+  /**
    * @copydoc TensorV2::copy(const TensorV2 &from)
    */
   void copy(const TensorV2 &from);

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -275,6 +275,21 @@ public:
                 bool trans_in, float beta) const override;
 
   /**
+   * @copydoc TensorV2::dropout_mask(float dropout)
+   */
+  void dropout_mask(float dropout) override;
+
+  /**
+   * @copydoc TensorV2::filter_mask(const TensorV2 &mask_len, bool reverse)
+   */
+  void filter_mask(const TensorV2 &mask_len, bool reverse) override;
+
+  /**
+   * @copydoc TensorV2::zoneout_mask(TensorV2 &opposite, float zoneout)
+   */
+  void zoneout_mask(TensorV2 &opposite, float zoneout) override;
+
+  /**
    * @copydoc TensorV2::copy(const TensorV2 &from)
    */
   void copy(const TensorV2 &from);

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -299,6 +299,21 @@ public:
                         bool trans_in, float beta) const = 0;
 
   /**
+   * @copydoc TensorV2::dropout_mask(float dropout)
+   */
+  virtual void dropout_mask(float dropout) = 0;
+
+  /**
+   * @copydoc TensorV2::filter_mask(const TensorV2 &mask_len, bool reverse)
+   */
+  virtual void filter_mask(const TensorV2 &mask_len, bool reverse) = 0;
+
+  /**
+   * @copydoc TensorV2::zoneout_mask(TensorV2 &opposite, float zoneout)
+   */
+  virtual void zoneout_mask(TensorV2 &opposite, float zoneout) = 0;
+
+  /**
    * @copydoc TensorV2::print(std::ostream &out)
    */
   virtual void print(std::ostream &out) const = 0;
@@ -591,8 +606,7 @@ public:
    * @brief   Constructor for the class
    */
   SrcSharedTensorBase(const TensorBase *tensor, size_t offset) :
-    src(tensor),
-    off(offset) {}
+    src(tensor), off(offset) {}
 
   /**
    * @brief   Get the allocated src tensor

--- a/nntrainer/tensor/tensor_v2.cpp
+++ b/nntrainer/tensor/tensor_v2.cpp
@@ -500,6 +500,50 @@ TensorV2 &TensorV2::dot_batched_deriv_wrt_2(TensorV2 &m_deriv,
   }
 }
 
+TensorV2 TensorV2::dropout_mask(float dropout) const {
+  TensorV2 output(getDim());
+  output.dropout_mask(dropout);
+  return output;
+}
+
+void TensorV2::dropout_mask(float dropout) {
+  /// @todo add unittest
+  NNTR_THROW_IF(dropout < 0 || dropout > 1, std::invalid_argument)
+    << "[Tensor::dropout_mask] Dropout rate should be between 0 and 1";
+
+  // if the rate is zero, no change is needed
+  if (std::fpclassify(dropout) == FP_ZERO)
+    return;
+
+  setRandUniform(0.0, 1.0);
+  itensor->dropout_mask(dropout);
+}
+
+void TensorV2::filter_mask(const TensorV2 &mask_len, bool reverse) {
+  /// @todo add unittest
+  itensor->filter_mask(mask_len, reverse);
+}
+
+TensorV2 TensorV2::zoneout_mask(float zoneout) {
+  TensorV2 output(getDim());
+  zoneout_mask(output, zoneout);
+  return output;
+}
+
+void TensorV2::zoneout_mask(TensorV2 &opposite, float zoneout) {
+  NNTR_THROW_IF(getDim() != opposite.getDim(), std::invalid_argument)
+    << "[Tensor::zoneout_mask] opposite dimension does not match";
+
+  NNTR_THROW_IF(zoneout < 0 || zoneout > 1, std::invalid_argument)
+    << "[Tensor::zoneout_mask] Zoneout rate should be between 0 and 1";
+
+  // if the rate is zero, no change is needed
+  if (std::fpclassify(zoneout) == FP_ZERO)
+    return;
+
+  itensor->zoneout_mask(opposite, zoneout);
+}
+
 void TensorV2::print(std::ostream &out) const { itensor->print(out); }
 
 void TensorV2::putData() const { itensor->putData(); }
@@ -616,8 +660,8 @@ const bool TensorV2::getContiguous() const noexcept {
   return itensor->getContiguous();
 }
 
-const std::array<size_t, TensorDim::MAXDIM> TensorV2::getStrides() const
-  noexcept {
+const std::array<size_t, TensorDim::MAXDIM>
+TensorV2::getStrides() const noexcept {
   return itensor->getStrides();
 }
 

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -875,6 +875,46 @@ public:
                                     float beta = 0.0f) const;
 
   /**
+   * @brief Calculate Drop Out Mask : x * 1.0/(1.0-rate)
+   * @param dropout drop out rate
+   * @retval Tensor& reference of drop out mask
+   */
+  TensorV2 dropout_mask(float dropout) const;
+
+  /**
+   * @brief Calculate Drop Out Mask : x * 1.0/(1.0-rate) inplace
+   * @param dropout drop out rate
+   */
+  void dropout_mask(float dropout);
+
+  /**
+   * @brief Calculate filter mask
+   * @param mask_len length of each mask along the last axis
+   * @param invert invert the mask
+   */
+  void filter_mask(const TensorV2 &mask_len, bool reverse = false);
+
+  /**
+   * @brief Calculate 2 Zone Out Mask
+   * @details Calculate zone out mask according to the bernoulli distribution.
+   * Zone out mask with rate @a zoneout for inplace and the other zone out mask
+   * with rate @a (1-zoneout).
+   * @param zoneout zone out rate
+   * @retval Tensor zone out mask for opposite tensor
+   */
+  TensorV2 zoneout_mask(float zoneout);
+
+  /**
+   * @brief Calculate 2 Zone Out Mask
+   * @details Calculate zone out mask according to the bernoulli distribution.
+   * Zone out mask with rate @a zoneout for inplace and the other zone out mask
+   * with rate @a (1-zoneout).
+   * @param opposite opposite zone out mask
+   * @param zoneout zone out rate
+   */
+  void zoneout_mask(TensorV2 &opposite, float zoneout);
+
+  /**
    * @brief     Print element
    * @param[in] out out stream
    */


### PR DESCRIPTION
This PR adds new functionalities for getting masks of the following techniques: dropout, filter, and zoneout. These functions enable working with masks, making it easier to perform such techniques in regularization.

**Changes proposed in this PR:**
- Added `dropout_mask()`, which calculates the dropout mask by multiplying tensor elements by 1.0 / (1.0 - dropout rate), in place.
- Added `filter_mask()`, which takes an input tensor and applies a filter mask based on the given mask length and invert option.
- Added `zoneout_mask()`, which generates two zoneout masks, one for in-place operation and another for opposite operation, based on the specified zoneout rate.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped