### PR TITLE
[ util ] Implement softmax calculation function in util

### DIFF
--- a/nntrainer/utils/util_simd.cpp
+++ b/nntrainer/utils/util_simd.cpp
@@ -44,13 +44,8 @@ float max(const unsigned int N, float *X) {
 #ifdef USE_NEON
   return nntrainer::neon::max(N, X);
 #else
-  float ret = X[0];
-  unsigned int i = 1;
-  while (i < N) {
-    ret = std::fmax(ret, X[i]);
-    ++i;
-  }
-  return ret;
+  std::vector<float> v(X, X + N);
+  return *std::max_element(v.begin(), v.end());
 #endif
 }
 
@@ -106,13 +101,8 @@ _FP16 max(const unsigned int N, _FP16 *X) {
 #ifdef USE_NEON
   return nntrainer::neon::max(N, X);
 #else
-  _FP16 ret = X[0];
-  unsigned int i = 1;
-  while (i < N) {
-    ret = (ret > X[i]) ? ret : X[i];
-    ++i;
-  }
-  return ret;
+  std::vector<_FP16> v(X, X + N);
+  return *std::max_element(v.begin(), v.end());
 #endif
 }
 

--- a/nntrainer/utils/util_simd.cpp
+++ b/nntrainer/utils/util_simd.cpp
@@ -40,6 +40,24 @@ void swish(const unsigned int N, float *X, float *Y, float *Z) {
 #endif
 }
 
+void softmax(const unsigned int N, float *X, float *Y) {
+#ifdef USE_NEON
+  nntrainer::neon::softmax(N, X, Y);
+#else
+  unsigned int i = 0;
+  float sum = 0.f;
+  while (i < N) {
+    sum += std::exp(X[i]);
+    ++i;
+  }
+  i = 0;
+  while (i < N) {
+    Y[i] = std::exp(X[i]) / sum;
+    ++i;
+  }
+#endif
+}
+
 #ifdef ENABLE_FP16
 
 void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
@@ -64,6 +82,24 @@ void swish(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z) {
     X[i] =
       (Y[i] / static_cast<_FP16>(1.f + std::exp(static_cast<float>(-Y[i])))) *
       Z[i];
+    ++i;
+  }
+#endif
+}
+
+void softmax(const unsigned int N, _FP16 *X, _FP16 *Y) {
+#ifdef USE_NEON
+  nntrainer::neon::softmax(N, X, Y);
+#else
+  unsigned int i = 0;
+  float sum = 0.f;
+  while (i < N) {
+    sum += std::exp(static_cast<float>(X[i]));
+    ++i;
+  }
+  i = 0;
+  while (i < N) {
+    Y[i] = static_cast<_FP16>(std::exp(static_cast<float>(X[i])) / sum);
     ++i;
   }
 #endif

--- a/nntrainer/utils/util_simd.cpp
+++ b/nntrainer/utils/util_simd.cpp
@@ -40,6 +40,20 @@ void swish(const unsigned int N, float *X, float *Y, float *Z) {
 #endif
 }
 
+float max(const unsigned int N, float *X) {
+#ifdef USE_NEON
+  return nntrainer::neon::max(N, X);
+#else
+  float ret = X[0];
+  unsigned int i = 1;
+  while (i < N) {
+    ret = std::fmax(ret, X[i]);
+    ++i;
+  }
+  return ret;
+#endif
+}
+
 void softmax(const unsigned int N, float *X, float *Y) {
 #ifdef USE_NEON
   nntrainer::neon::softmax(N, X, Y);
@@ -84,6 +98,20 @@ void swish(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z) {
       Z[i];
     ++i;
   }
+#endif
+}
+
+__fp16 max(const unsigned int N, __fp16 *X) {
+#ifdef USE_NEON
+  return nntrainer::neon::max(N, X);
+#else
+  __fp16 ret = X[0];
+  unsigned int i = 1;
+  while (i < N) {
+    ret = (ret > X[i]) ? ret : X[i];
+    ++i;
+  }
+  return ret;
 #endif
 }
 

--- a/nntrainer/utils/util_simd.cpp
+++ b/nntrainer/utils/util_simd.cpp
@@ -60,13 +60,14 @@ void softmax(const unsigned int N, float *X, float *Y) {
 #else
   unsigned int i = 0;
   float sum = 0.f;
+  float max_x = max(N, X);
   while (i < N) {
-    sum += std::exp(X[i]);
+    sum += std::exp(X[i] - max_x);
     ++i;
   }
   i = 0;
   while (i < N) {
-    Y[i] = std::exp(X[i]) / sum;
+    Y[i] = std::exp(X[i] - max_x) / sum;
     ++i;
   }
 #endif
@@ -101,11 +102,11 @@ void swish(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z) {
 #endif
 }
 
-__fp16 max(const unsigned int N, __fp16 *X) {
+_FP16 max(const unsigned int N, _FP16 *X) {
 #ifdef USE_NEON
   return nntrainer::neon::max(N, X);
 #else
-  __fp16 ret = X[0];
+  _FP16 ret = X[0];
   unsigned int i = 1;
   while (i < N) {
     ret = (ret > X[i]) ? ret : X[i];
@@ -119,15 +120,16 @@ void softmax(const unsigned int N, _FP16 *X, _FP16 *Y) {
 #ifdef USE_NEON
   nntrainer::neon::softmax(N, X, Y);
 #else
+  _FP16 max_x = max(N, X);
   unsigned int i = 0;
   float sum = 0.f;
   while (i < N) {
-    sum += std::exp(static_cast<float>(X[i]));
+    sum += std::exp(static_cast<float>(X[i] - max_x));
     ++i;
   }
   i = 0;
   while (i < N) {
-    Y[i] = static_cast<_FP16>(std::exp(static_cast<float>(X[i])) / sum);
+    Y[i] = static_cast<_FP16>(std::exp(static_cast<float>(X[i] - max_x)) / sum);
     ++i;
   }
 #endif

--- a/nntrainer/utils/util_simd.h
+++ b/nntrainer/utils/util_simd.h
@@ -41,6 +41,15 @@ void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
  */
 void swish(const unsigned int N, float *X, float *Y, float *Z);
 
+/**
+ * @brief softmax function y_i = exp(x_i) / sum( exp(x_i) )
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X
+ * @param Y  float * for Vector Y
+ */
+void softmax(const unsigned int N, float *X, float *Y);
+
 #ifdef ENABLE_FP16
 /**
  * @brief Accelerating function for rotary embedding layer forwarding
@@ -65,6 +74,17 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
  * @param Z _FP16 * for Vector Z
  */
 void swish(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z);
+
+/**
+ * @brief soft max function with neon y_i = exp(x_i) / sum( exp(x_i) )
+ * Note that half-precision softmax function needs to be computed with
+ * single-precision
+ *
+ * @param N number of elements in X
+ * @param X _FP16 * for Vector X
+ * @param Y  _FP16 * for Vector Y
+ */
+void softmax(const unsigned int N, _FP16 *X, _FP16 *Y);
 #endif
 
 } /* namespace nntrainer */

--- a/nntrainer/utils/util_simd.h
+++ b/nntrainer/utils/util_simd.h
@@ -43,12 +43,12 @@ void swish(const unsigned int N, float *X, float *Y, float *Z);
 
 /**
  * @brief returns maximum value of the vector X
- * 
+ *
  * @param N number of elements in X
  * @param X float * for Vector X
  * @return float maximum value of vector X
  */
-float max(const unsigned int N, float* X);
+float max(const unsigned int N, float *X);
 
 /**
  * @brief softmax function y_i = exp(x_i) / sum( exp(x_i) )
@@ -86,12 +86,12 @@ void swish(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z);
 
 /**
  * @brief returns maximum value of the vector X
- * 
+ *
  * @param N number of elements in X
  * @param X _FP16 * for Vector X
  * @return _FP16 maximum value of vector X
  */
-_FP16 max(const unsigned int N, _FP16* X);
+_FP16 max(const unsigned int N, _FP16 *X);
 
 /**
  * @brief soft max function with neon y_i = exp(x_i) / sum( exp(x_i) )

--- a/nntrainer/utils/util_simd.h
+++ b/nntrainer/utils/util_simd.h
@@ -42,6 +42,15 @@ void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
 void swish(const unsigned int N, float *X, float *Y, float *Z);
 
 /**
+ * @brief returns maximum value of the vector X
+ * 
+ * @param N number of elements in X
+ * @param X float * for Vector X
+ * @return float maximum value of vector X
+ */
+float max(const unsigned int N, float* X);
+
+/**
  * @brief softmax function y_i = exp(x_i) / sum( exp(x_i) )
  *
  * @param N number of elements in X
@@ -74,6 +83,15 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
  * @param Z _FP16 * for Vector Z
  */
 void swish(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z);
+
+/**
+ * @brief returns maximum value of the vector X
+ * 
+ * @param N number of elements in X
+ * @param X _FP16 * for Vector X
+ * @return _FP16 maximum value of vector X
+ */
+_FP16 max(const unsigned int N, _FP16* X);
 
 /**
  * @brief soft max function with neon y_i = exp(x_i) / sum( exp(x_i) )

--- a/nntrainer/utils/util_simd_neon.cpp
+++ b/nntrainer/utils/util_simd_neon.cpp
@@ -100,6 +100,17 @@ void softmax(const unsigned int N, float *X, float *Y) {
   }
 }
 
+void exp_i(const unsigned int N, float *X) {
+  unsigned int i = 0;
+  for (; N - i >= VL_FP32; i += VL_FP32) {
+    vst1q_f32(&X[i], exp_ps(vld1q_f32(&X[i])));
+  }
+  while (i < N) {
+    X[i] = std::exp(X[i]);
+    ++i;
+  }
+}
+
 #ifdef ENABLE_FP16
 void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
                                     unsigned int w, __fp16 *in, __fp16 *out,

--- a/nntrainer/utils/util_simd_neon.cpp
+++ b/nntrainer/utils/util_simd_neon.cpp
@@ -55,6 +55,20 @@ void swish(const unsigned int N, float *X, float *Y, float *Z) {
   }
 }
 
+float max(const unsigned int N, float *X) {
+  unsigned int i = 0;
+  float ret = X[i];
+  for (; N - i >= VL_FP32; i += VL_FP32) {
+    float32x4_t x0_3 = vld1q_f32(&X[i]);
+    ret = std::fmax(ret, vmaxvq_f32(x0_3));
+  }
+  while (i < N) {
+    ret = std::fmax(ret, X[i]);
+    ++i;
+  }
+  return ret;
+}
+
 void softmax(const unsigned int N, float *X, float *Y) {
   unsigned int i = 0;
   float sum = 0.f;
@@ -179,6 +193,21 @@ void swish(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z) {
     X[i] = (Y[i] / (1.f + std::exp(static_cast<float>(-Y[i])))) * Z[i];
     ++i;
   }
+}
+
+__fp16 max(const unsigned int N, __fp16 *X) {
+  unsigned int i = 0;
+  __fp16 ret = X[i];
+  for (; N - i >= VL_FP16; i += VL_FP16) {
+    float16x8_t x0_7 = vld1q_f16(&X[i]);
+    __fp16 x_max = vmaxvq_f16(x0_7);
+    ret = (ret > x_max) ? ret : x_max;
+  }
+  while (i < N) {
+    ret = (ret > X[i]) ? ret : X[i];
+    ++i;
+  }
+  return ret;
 }
 
 void softmax(const unsigned int N, __fp16 *X, __fp16 *Y) {

--- a/nntrainer/utils/util_simd_neon.h
+++ b/nntrainer/utils/util_simd_neon.h
@@ -39,19 +39,16 @@ void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
  * @param Y float * for Vector Y
  * @param Z float * for Vector Z
  */
-<<<<<<< HEAD
 void swish(const unsigned int N, float *X, float *Y, float *Z);
-=======
-void swish_neon(const unsigned int N, float *X, float *Y, float *Z);
 
 /**
  * @brief returns maximum value of the vector X
- * 
+ *
  * @param N number of elements in X
  * @param X float * for Vector X
  * @return float maximum value of vector X
  */
-float max(const unsigned int N, float* X);
+float max(const unsigned int N, float *X);
 
 /**
  * @brief soft max function with neon y_i = exp(x_i) / sum( exp(x_i) )
@@ -61,7 +58,14 @@ float max(const unsigned int N, float* X);
  * @param Y  float * for Vector Y
  */
 void softmax(const unsigned int N, float *X, float *Y);
->>>>>>> [ util ] Implement softmax function in util_simd
+
+/**
+ * @brief exponential inplace function
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X
+ */
+void exp_i(const unsigned int N, float *X);
 #ifdef ENABLE_FP16
 /**
  * @brief Accelerating function for rotary embedding layer forwarding
@@ -85,19 +89,16 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
  * @param Y __fp16 * for Vector Y
  * @param Z __fp16 * for Vector Z
  */
-<<<<<<< HEAD
 void swish(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z);
-=======
-void swish_neon(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z);
 
 /**
  * @brief returns maximum value of the vector X
- * 
+ *
  * @param N number of elements in X
  * @param X __fp16 * for Vector X
  * @return __fp16 maximum value of vector X
  */
-__fp16 max(const unsigned int N, __fp16* X);
+__fp16 max(const unsigned int N, __fp16 *X);
 
 /**
  * @brief soft max function with neon y_i = exp(x_i) / sum( exp(x_i) )
@@ -109,7 +110,6 @@ __fp16 max(const unsigned int N, __fp16* X);
  * @param Y  __fp16 * for Vector Y
  */
 void softmax(const unsigned int N, __fp16 *X, __fp16 *Y);
->>>>>>> [ util ] Implement softmax function in util_simd
 #endif
 
 } // namespace nntrainer::neon

--- a/nntrainer/utils/util_simd_neon.h
+++ b/nntrainer/utils/util_simd_neon.h
@@ -39,7 +39,20 @@ void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
  * @param Y float * for Vector Y
  * @param Z float * for Vector Z
  */
+<<<<<<< HEAD
 void swish(const unsigned int N, float *X, float *Y, float *Z);
+=======
+void swish_neon(const unsigned int N, float *X, float *Y, float *Z);
+
+/**
+ * @brief soft max function with neon y_i = exp(x_i) / sum( exp(x_i) )
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X
+ * @param Y  float * for Vector Y
+ */
+void softmax(const unsigned int N, float *X, float *Y);
+>>>>>>> [ util ] Implement softmax function in util_simd
 #ifdef ENABLE_FP16
 /**
  * @brief Accelerating function for rotary embedding layer forwarding
@@ -63,7 +76,22 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
  * @param Y __fp16 * for Vector Y
  * @param Z __fp16 * for Vector Z
  */
+<<<<<<< HEAD
 void swish(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z);
+=======
+void swish_neon(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z);
+
+/**
+ * @brief soft max function with neon y_i = exp(x_i) / sum( exp(x_i) )
+ * Note that half-precision softmax function needs to be computed with
+ * single-precision
+ *
+ * @param N number of elements in X
+ * @param X __fp16 * for Vector X
+ * @param Y  __fp16 * for Vector Y
+ */
+void softmax(const unsigned int N, __fp16 *X, __fp16 *Y);
+>>>>>>> [ util ] Implement softmax function in util_simd
 #endif
 
 } // namespace nntrainer::neon

--- a/nntrainer/utils/util_simd_neon.h
+++ b/nntrainer/utils/util_simd_neon.h
@@ -45,6 +45,15 @@ void swish(const unsigned int N, float *X, float *Y, float *Z);
 void swish_neon(const unsigned int N, float *X, float *Y, float *Z);
 
 /**
+ * @brief returns maximum value of the vector X
+ * 
+ * @param N number of elements in X
+ * @param X float * for Vector X
+ * @return float maximum value of vector X
+ */
+float max(const unsigned int N, float* X);
+
+/**
  * @brief soft max function with neon y_i = exp(x_i) / sum( exp(x_i) )
  *
  * @param N number of elements in X
@@ -80,6 +89,15 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
 void swish(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z);
 =======
 void swish_neon(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z);
+
+/**
+ * @brief returns maximum value of the vector X
+ * 
+ * @param N number of elements in X
+ * @param X __fp16 * for Vector X
+ * @return __fp16 maximum value of vector X
+ */
+__fp16 max(const unsigned int N, __fp16* X);
 
 /**
  * @brief soft max function with neon y_i = exp(x_i) / sum( exp(x_i) )


### PR DESCRIPTION
- Current activation functions are implemented as a function template, and fully computes with the function template parameter's precision unless using NEON intrinsics with inter-fp32-values explicitly.
- According to current papers, for safe convergence of mixed precision training, it is quite critical to calculate softmax with fp32 precision.
- This PR proposes a SIMD version of softmax calculation, and uses temporally higher precision when using half-precision
- For mathematical stability, applied linear translation (using minus values for the input of exponential function) to avoid precision overflow 