### PR TITLE
[SPEC] support neon enable option

### DIFF
--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -38,9 +38,11 @@ arch = host_machine.cpu_family()
 if get_option('enable-fp16') 
   if arch == 'arm'
     error ('FP16/ARM code (blas_neon.cpp) uses armv8.2 instructions. armv7 is not supported.')
-  elif arch == 'aarch64' or get_option('enable-neon')
-    tensor_sources += 'blas_neon.cpp'
-    tensor_headers += 'blas_neon.h'
+  elif arch == 'aarch64' or get_option('platform') == 'android'
+    if get_option('enable-neon')
+      tensor_sources += 'blas_neon.cpp'
+      tensor_headers += 'blas_neon.h'
+    endif
   endif
 endif
 

--- a/nntrainer/utils/meson.build
+++ b/nntrainer/utils/meson.build
@@ -28,9 +28,11 @@ arch = host_machine.cpu_family()
 if get_option('enable-fp16') 
   if arch == 'arm'
     error ('FP16/ARM code (blas_neon.cpp) uses armv8.2 instructions. armv7 is not supported.')
-  elif arch == 'aarch64' or get_option('enable-neon')
-    util_sources += 'util_simd_neon.cpp'
-    util_headers += 'util_simd_neon.h'
+  elif arch == 'aarch64' or get_option('platform') == 'android'
+    if get_option('enable-neon')
+      util_sources += 'util_simd_neon.cpp'
+      util_headers += 'util_simd_neon.h'
+    endif
   endif
 endif
 

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -57,7 +57,13 @@
 %define fp16_support -Denable-fp16=true
 %else
 %define fp16_support -Denable-fp16=false
-%endif
+%endif # enalbe_fp16
+
+%ifarch aarch64
+%define neon_support -Denable-neon=true
+%else
+%define neon_support -Denable-neon=false
+%endif # arch aarch64
 
 
 Name:		nntrainer
@@ -414,7 +420,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} \
       %{enable_reduce_tolerance} %{configure_subplugin_install_path} %{enable_debug} \
       -Dml-api-support=enabled -Denable-nnstreamer-tensor-filter=enabled \
       -Denable-nnstreamer-tensor-trainer=enabled -Denable-capi=enabled \
-      %{fp16_support} build
+      %{fp16_support} %{neon_support} build
 
 ninja -C build %{?_smp_mflags}
 


### PR DESCRIPTION
It supports enable_neon only when aarch64 architecture.
And, neon option can be selectable for aarch64.

Signed-off-by: Jiho Chu <jiho.chu@samsung.com>