### PR TITLE
[TensorV2] Tensor element summation by axes feature

### DIFF
--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -533,6 +533,154 @@ TensorV2 &FloatTensor::subtract(float const &value, TensorV2 &output) const {
   return output;
 }
 
+void FloatTensor::sum_by_batch(TensorV2 &output) const {
+  size_t feat_len = dim.getFeatureLen();
+  size_t batch = dim.batch();
+
+  const float *data = (float *)getData();
+  float *out_data = output.getData<float>();
+
+  TensorV2 ones(1, 1, 1, feat_len, this->getFormat());
+  ones.setValue(1.0);
+  sgemv(CblasRowMajor, CblasNoTrans, batch, feat_len, 1, data, feat_len,
+        ones.getData<float>(), 1, 0.0, out_data, 1);
+}
+
+TensorV2 &FloatTensor::sum(unsigned int axis, TensorV2 &output, float alpha,
+                           float beta) const {
+  const float *data = (float *)getData();
+
+  NNTR_THROW_IF(!contiguous, std::invalid_argument)
+    << getName() << " is not contiguous, cannot sum";
+
+  if (axis >= 4)
+    throw std::out_of_range("Error: axis is invalid");
+
+  if (dim.getDim()[axis] == 1 and alpha == 1.0 and !beta) {
+    CREATE_V2_IF_EMPTY_DIMS(output, dim);
+    scopy(size(), (float *)getData(), 1, output.getData<float>(), 1);
+    return output;
+  }
+
+  switch (axis) {
+  case 0: {
+    CREATE_V2_IF_EMPTY_DIMS(output, 1, dim.channel(), dim.height(), dim.width(),
+                            getTensorType());
+    size_t feat_len = dim.getFeatureLen();
+    size_t batch = dim.batch();
+    TensorV2 ones(1, 1, 1, batch, getTensorType());
+    ones.setValue(alpha);
+    sgemv(CblasRowMajor, CblasTrans, batch, feat_len, 1, data, feat_len,
+          ones.getData<float>(), 1, beta, output.getData<float>(), 1);
+  } break;
+  case 1: {
+    CREATE_V2_IF_EMPTY_DIMS(output, dim[0], 1, dim[2], dim[3], getTensorType());
+    if (this->getFormat() == Tformat::NHWC) {
+      unsigned int feat_len = output.getDim().getDataLen();
+      unsigned int t_axis = dim[1];
+      TensorV2 ones(1, 1, 1, t_axis, getTensorType());
+      ones.setValue(alpha);
+      sgemv(CblasRowMajor, CblasNoTrans, feat_len, t_axis, 1, data, t_axis,
+            ones.getData<float>(), 1, beta, output.getData<float>(), 1);
+    } else {
+      unsigned int feat_len = dim[2] * dim[3];
+      unsigned int t_axis = dim[1];
+      TensorV2 ones(1, 1, 1, t_axis, getTensorType());
+      ones.setValue(alpha);
+      float *rdata = output.getData<float>();
+      for (unsigned int k = 0; k < dim[0]; ++k) {
+        sgemv(CblasRowMajor, CblasTrans, t_axis, feat_len, 1,
+              &data[k * dim.getFeatureLen()], feat_len, ones.getData<float>(),
+              1, beta, &rdata[k * feat_len], 1);
+      }
+    }
+  } break;
+  case 2: {
+    CREATE_V2_IF_EMPTY_DIMS(output, dim[0], dim[1], 1, dim[3], getTensorType());
+    if (this->getFormat() == Tformat::NHWC) {
+      unsigned int feat_len = dim[1] * dim[3];
+      unsigned int t_axis = dim[2];
+      TensorV2 ones(1, 1, 1, t_axis, getTensorType());
+      ones.setValue(alpha);
+      float *rdata = output.getData<float>();
+      for (unsigned int k = 0; k < dim[0]; ++k) {
+        sgemv(CblasRowMajor, CblasTrans, t_axis, feat_len, 1,
+              &data[k * dim.getFeatureLen()], feat_len, ones.getData<float>(),
+              1, beta, &rdata[k * feat_len], 1);
+      }
+    } else {
+      unsigned int t_3 = dim[3];
+      unsigned int t_axis = dim[2];
+      TensorV2 ones(1, 1, 1, t_axis, getTensorType());
+      ones.setValue(alpha);
+
+      if (dim.getStorageOrder() == TStorageOrder::ROW_MAJOR) {
+        float *rdata = output.getData<float>();
+        for (unsigned int k = 0; k < dim[0]; ++k) {
+          for (unsigned int c = 0; c < dim[1]; ++c) {
+            unsigned int idx = k * dim.getFeatureLen() + c * dim[3] * dim[2];
+            unsigned int ridx =
+              k * output.getDim().getFeatureLen() + c * dim[3];
+
+            sgemv(CblasRowMajor, CblasTrans, t_axis, t_3, 1, &data[idx], t_3,
+                  ones.getData<float>(), 1, beta, &rdata[ridx], 1);
+          }
+        }
+      } else {
+        sgemv(CblasColMajor, CblasTrans, t_axis, output.getDim().getDataLen(),
+              1, data, t_axis, ones.getData<float>(), 1, beta,
+              output.getData<float>(), 1);
+      }
+    }
+  } break;
+  case 3: {
+    CREATE_V2_IF_EMPTY_DIMS(output, dim[0], dim[1], dim[2], 1,
+                            this->getTensorType());
+    if (this->getFormat() == Tformat::NHWC) {
+      unsigned int t_3 = dim[1];
+      unsigned int t_axis = dim[3];
+      TensorV2 ones(1, 1, 1, t_axis, getTensorType());
+      ones.setValue(alpha);
+      float *rdata = output.getData<float>();
+      for (unsigned int k = 0; k < dim[0]; ++k) {
+        for (unsigned int c = 0; c < dim[2]; ++c) {
+          unsigned int idx = k * dim.getFeatureLen() + c * dim[3] * dim[1];
+          unsigned int ridx = k * output.getDim().getFeatureLen() + c * dim[1];
+          sgemv(CblasRowMajor, CblasTrans, t_axis, t_3, 1, &data[idx], t_3,
+                ones.getData<float>(), 1, beta, &rdata[ridx], 1);
+        }
+      }
+    } else {
+      unsigned int m = output.getDim().getDataLen();
+      unsigned int n = dim[3];
+      TensorV2 ones(1, 1, 1, n, getTensorType());
+      ones.setValue(alpha);
+
+      if (dim.getStorageOrder() == TStorageOrder::ROW_MAJOR) {
+        sgemv(CblasRowMajor, CblasNoTrans, m, n, 1, data, n,
+              ones.getData<float>(), 1, beta, output.getData<float>(), 1);
+      } else {
+        float *rdata = output.getData<float>();
+
+        for (unsigned int k = 0; k < dim[0]; ++k) {
+          for (unsigned int c = 0; c < dim[1]; ++c) {
+            unsigned int idx = k * dim.getFeatureLen() + c * dim[3] * dim[2];
+            unsigned int ridx = k * dim[1] * dim[2] + c * dim[2];
+
+            sgemv(CblasColMajor, CblasNoTrans, dim[2], n, 1, &data[idx], dim[2],
+                  ones.getData<float>(), 1, beta, &rdata[ridx], 1);
+          }
+        }
+      }
+    }
+  } break;
+  default:
+    throw std::out_of_range("Error: Dimension cannot exceed 3");
+  }
+
+  return output;
+}
+
 TensorV2 &FloatTensor::pow(float exponent, TensorV2 &output) const {
   auto f = [exponent](float in) { return powf(in, exponent); };
   apply(f, output);

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -259,6 +259,18 @@ public:
   TensorV2 &subtract(float const &value, TensorV2 &output) const override;
 
   /**
+   *  @copydoc TensorBase::sum_by_batch(TensorV2 &output)
+   */
+  void sum_by_batch(TensorV2 &output) const override;
+
+  /**
+   * @copydoc TensorV2::sum(unsigned int axis, TensorV2 &output, float alpha,
+   * float beta) const
+   */
+  TensorV2 &sum(unsigned int axis, TensorV2 &output, float alpha,
+                float beta) const override;
+
+  /**
    * @copydoc TensorV2::pow(float exponent, TensorV2 &output)
    */
   TensorV2 &pow(float exponent, TensorV2 &output) const override;

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -258,6 +258,18 @@ public:
   TensorV2 &subtract(float const &value, TensorV2 &output) const override;
 
   /**
+   *  @copydoc TensorBase::sum_by_batch(TensorV2 &output)
+   */
+  void sum_by_batch(TensorV2 &output) const override;
+
+  /**
+   * @copydoc TensorV2::sum(unsigned int axis, TensorV2 &output, float alpha,
+   * float beta) const
+   */
+  TensorV2 &sum(unsigned int axis, TensorV2 &output, float alpha,
+                float beta) const override;
+
+  /**
    * @copydoc TensorV2::pow(float exponent, TensorV2 &output)
    */
   TensorV2 &pow(float exponent, TensorV2 &output) const override;

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -73,6 +73,11 @@ size_t TensorBase::getIndex(unsigned int b, unsigned int c, unsigned int h,
   }
 }
 
+void TensorBase::mergeAxis(unsigned int axis1, unsigned int axis2) {
+  dim.setTensorDim(axis2, dim.getTensorDim(axis1) * dim.getTensorDim(axis2));
+  dim.setTensorDim(axis1, 1);
+}
+
 void TensorBase::allocateSrcTensor() {
   if (src_tensor) {
     data = src_tensor->tensor()->data;

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -54,6 +54,7 @@ namespace nntrainer {
 using TensorDim = ml::train::TensorDim;
 using Tformat = ml::train::TensorDim::Format;
 using Tdatatype = ml::train::TensorDim::DataType;
+using TStorageOrder = ml::train::TensorDim::StorageOrder;
 
 /**
  * @brief     Enumeration of Weight Initialization Type
@@ -275,6 +276,19 @@ public:
   virtual TensorV2 &subtract(float const &value, TensorV2 &output) const = 0;
 
   /**
+   * @brief      Sum all the Tensor elements according to the batch
+   * @param[out] output Tensor(batch, 1, 1, 1)
+   */
+  virtual void sum_by_batch(TensorV2 &output) const = 0;
+
+  /**
+   * @copydoc TensorV2::sum(unsigned int axis, TensorV2 &output, float alpha,
+   * float beta) const
+   */
+  virtual TensorV2 &sum(unsigned int axis, TensorV2 &output, float alpha,
+                        float beta) const = 0;
+
+  /**
    * @copydoc TensorV2::pow(float exponent, TensorV2 &output)
    */
   virtual TensorV2 &pow(float exponent, TensorV2 &output) const = 0;
@@ -470,6 +484,14 @@ public:
    * @retval    width size
    */
   size_t width() const { return dim.width(); }
+
+  /**
+   * @brief Merge the given two axis for tensor at second axis inplace
+   *
+   * @param axis1 first axis to merge
+   * @param axis2 second axis to merge
+   */
+  void mergeAxis(unsigned int axis1, unsigned int axis2);
 
   /**
    * @brief Allocate data based on the source tensor

--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -752,6 +752,58 @@ public:
   TensorV2 &subtract(TensorV2 const &m, TensorV2 &output) const;
 
   /**
+   * @brief     sum all the Tensor elements according to the batch
+   * @retval    Calculated Tensor(batch, 1, 1, 1)
+   */
+  TensorV2 sum_by_batch() const;
+
+  /**
+   * @brief     sum all the Tensor elements according to the axis
+   *            0 : batch direction
+   *            1 : channel direction
+   *            2 : height direction
+   *            3 : width direction
+   * @param[in] axis Axis to calculate sum along
+   * @param[in] alpha Scale the sum by this value
+   * @retval    Calculated Tensor
+   */
+  TensorV2 sum(unsigned int axis, float alpha = 1.0) const;
+
+  /**
+   * @brief     sum all the Tensor elements according to the axis
+   *            0 : batch direction
+   *            1 : channel direction
+   *            2 : height direction
+   *            3 : width direction
+   * @param[in] axis Axis to calculate sum along
+   * @param[out] output output tensor
+   * @param[in] alpha Scale the sum by this value
+   * @retval    Calculated Tensor
+   */
+  TensorV2 &sum(unsigned int axis, TensorV2 &output, float alpha = 1.0,
+                float beta = 0.0) const;
+
+  /**
+   * @brief sum all the Tensor by multiple axes
+   *
+   * @param axes axes to sum along
+   * @param alpha Scale the sum by this value
+   * @return Tensor
+   */
+  TensorV2 sum(const std::vector<unsigned int> &axes, float alpha = 1.0) const;
+
+  /**
+   * @brief sum all the Tensor by multiple axes
+   *
+   * @param axes axes to sum along
+   * @param[out] output output tensor
+   * @param alpha Scale the sum by this value
+   * @return Tensor
+   */
+  TensorV2 &sum(const std::vector<unsigned int> &axes, TensorV2 &output,
+                float alpha = 1.0) const;
+
+  /**
    * @brief     Tensor power element without mem copy
    * @param[in] exponent exponent
    * @retval    #ML_ERROR_NONE  Successful
@@ -1096,6 +1148,14 @@ public:
    * @retval    width size
    */
   size_t width() const;
+
+  /**
+   * @brief Merge the given two axis for tensor at second axis inplace
+   *
+   * @param axis1 first axis to merge
+   * @param axis2 second axis to merge
+   */
+  void mergeAxis(unsigned int axis1, unsigned int axis2);
 
   /**
    * @brief Update destination tensor to share memory with source tensor


### PR DESCRIPTION
This pull request introduces a new feature that enables the summation of tensor elements by axes.
This feature allows users to sum up tensor values along specified axes, making it easier to perform complex mathematical operations involving tensors.

**Changes proposed in this PR:**
- Added new function sum() that takes a tensor and an axis as input and returns the sum of all elements along that axis.
- Added mergeAxis feature which merges the two axes for tensor into one.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped