### PR TITLE
[TensorV2] Average Tensor element by axes @open sesame 03/07 10:42

### DIFF
--- a/nntrainer/tensor/tensor_v2.h
+++ b/nntrainer/tensor/tensor_v2.h
@@ -804,6 +804,50 @@ public:
                 float alpha = 1.0) const;
 
   /**
+   * @brief     Averaging the Tensor elements according to the axis
+   *            0 : batch direction
+   *            1 : channel direction
+   *            2 : height direction
+   *            3 : width direction
+   * @retval    Calculated Tensor
+   */
+  TensorV2 average(unsigned int axis) const;
+
+  /**
+   * @brief     Averaging the Tensor elements according to the axis
+   * @retval    Calculated Tensor
+   */
+  TensorV2 &average(unsigned int axis, TensorV2 &output) const;
+
+  /**
+   * @brief     Average all the Tensor by multiple axes
+   * @param[in] axes axes to sum along
+   * @retval    Calculated Tensor
+   */
+  TensorV2 average(const std::vector<unsigned int> &axes) const;
+
+  /**
+   * @brief      Average all the Tensor by multiple axes
+   * @param[in]  axes axes to sum along
+   * @param[out] output output tensor
+   * @retval     Calculated Tensor
+   */
+  TensorV2 &average(const std::vector<unsigned int> &axes,
+                    TensorV2 &output) const;
+
+  /**
+   * @brief     Average the Tensor elements by all axis
+   * @retval    Calculated Tensor
+   */
+  TensorV2 average() const;
+
+  /**
+   * @brief     Averaging the Tensor elements by all axis
+   * @retval    Calculated Tensor
+   */
+  TensorV2 &average(TensorV2 &output) const;
+
+  /**
    * @brief     Tensor power element without mem copy
    * @param[in] exponent exponent
    * @retval    #ML_ERROR_NONE  Successful


### PR DESCRIPTION
This pull request adds new functions to the TensorV2 that allow users to average tensor elements along specified axes. 
The functions take in an axis or list of axes as input and return a new tensor with elements replaced by their corresponding means. If no axis is provided, it returns a tensor value by averaging the elements by all axes.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped