### PR TITLE
[Android] Fix for cxxflags

### DIFF
--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -61,7 +61,7 @@ LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 
 LOCAL_ARM_NEON      := true
 LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ -DML_API_COMMON=1
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1 @MESON_CXXFLAGS@
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
@@ -83,7 +83,7 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
 
 LOCAL_ARM_NEON      := true
 LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ -DML_API_COMMON=1
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1 -DVERSION_MAJOR=@VERSION_MAJOR@ -DVERSION_MINOR=@VERSION_MINOR@ -DVERSION_MICRO=@VERSION_MICRO@
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1 -DVERSION_MAJOR=@VERSION_MAJOR@ -DVERSION_MINOR=@VERSION_MINOR@ -DVERSION_MICRO=@VERSION_MICRO@ @MESON_CXXFLAGS@
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
@@ -101,7 +101,7 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
 
 LOCAL_ARM_NEON      := true
 LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ -DML_API_COMMON=1
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1 @MESON_CXXFLAGS@
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp

--- a/jni/meson.build
+++ b/jni/meson.build
@@ -15,6 +15,7 @@ message('compile flags are:' + ' '.join(flags))
 flags = extra_defines + flags
 
 and_conf.set('MESON_CFLAGS', ' '.join(flags))
+and_conf.set('MESON_CXXFLAGS', ' '.join(flags))
 and_conf.set('MESON_NNTRAINER_SRCS', ' '.join(nntrainer_sources))
 and_conf.set('MESON_NNTRAINER_INCS', ' '.join(nntrainer_inc_abs))
 and_conf.set('MESON_CCAPI_NNTRAINER_SRCS', ' '.join(ccapi_src))


### PR DESCRIPTION
It fixes Android conf for CXX flags.
It uses the same flags as c initially.

Signed-off-by: Jiho Chu <jiho.chu@samsung.com> 