### PR TITLE
[Coverity] Fix the coverity issue

### DIFF
--- a/test/unittest/unittest_nntrainer_tensor_v2.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_v2.cpp
@@ -861,6 +861,9 @@ TEST(nntrainer_Tensor, multiply_strided_06_p) {
   float *indata = input.getData<float>();
   ASSERT_NE(nullptr, indata);
 
+  float *data = output.getData<float>();
+  ASSERT_NE(nullptr, data);
+
   float *outdata_beta = new float[(input.size())];
   float *indata_mul = new float[(input.size())];
   float *outdata = new float[(input.size())];
@@ -875,9 +878,6 @@ TEST(nntrainer_Tensor, multiply_strided_06_p) {
                  outdata_beta, outdata, std::plus<float>());
 
   input.multiply_strided(input, output, 10.0);
-
-  float *data = output.getData<float>();
-  ASSERT_NE(nullptr, data);
 
   for (int i = 0; i < batch * height * width; ++i) {
     if (data[i] != outdata[i]) {


### PR DESCRIPTION
This PR resolves the coverity issue of resource leak.

**Changes proposed in this PR:**
- Switch the order of assert to check if the output is a nullptr to ensure releasing acquired resources (e.g., outdata_beta)

**This fixes:**
- leaked_storage: Variables going out of scope leak the storage it points to

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped