### PR TITLE
[Trivial/CI] sync cpp-linter version with clang-format

### DIFF
--- a/.github/workflows/cpp_linter.yml
+++ b/.github/workflows/cpp_linter.yml
@@ -13,7 +13,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           style: file
-          version: 16
+          version: 14
           lines-changed-only: true
           file-annotations: false
           step-summary: true


### PR DESCRIPTION
sync cpp-linter version with clang-format
- change cpp-linter version to 14

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped