### PR TITLE
[build] Updated Android build script for OpenCl inclusion

### DIFF
--- a/tools/package_android.sh
+++ b/tools/package_android.sh
@@ -16,13 +16,15 @@ pushd $TARGET
 if [ ! -d builddir ]; then
     #default value of openblas num threads is 1 for android
     #enable-tflite-interpreter=false is just temporally until ci system is stabel
-  meson builddir -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Denable-neon=true -Domp-num-threads=1
+    #enable-opencl=true will compile OpenCL related changes or remove this option to exclude OpenCL compilations.
+  meson builddir -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Denable-neon=true -Domp-num-threads=1 -Denable-opencl=true
 else
   echo "warning: $TARGET/builddir has already been taken, this script tries to reconfigure and try building"
   pushd builddir
     #default value of openblas num threads is 1 for android
     #enable-tflite-interpreter=false is just temporally until ci system is stabel  
-    meson configure -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Denable-neon=true -Domp-num-threads=1
+    #enable-opencl=true will compile OpenCL related changes or remove this option to exclude OpenCL compilations.
+    meson configure -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Denable-neon=true -Domp-num-threads=1 -Denable-opencl=true
     meson --wipe
   popd
 fi


### PR DESCRIPTION
Added `enable-opencl` flag to `/tools/package_android.sh`.
This will compile OpenCL related changes for `libnntrainer.so`.

Signed-off-by: Debadri Samaddar <s.debadri@samsung.com>