### PR TITLE
Bump actions/checkout in Ubuntu Meson build & test

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ ubuntu-20.04, ubuntu-22.04 ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v1
       with:
         python-version: '3.x'


### PR DESCRIPTION
Node 16 has reached end of life. So, github recommend transition to actions which use node 20+. [Ref](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: heka1024 <heka1024@gmail.com>