### PR TITLE
Fix minor error in github action

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Report list of changed files
       run: |
         echo Changed files: ${{ steps.get_file_changes.outputs.files }}
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -14,9 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v1
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: "3.10"
     - name: install additional package from PPA for testing
       run: sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
     - name: install minimal requirements


### PR DESCRIPTION
- `actions/setup-python@v1` is deprecated. So, bump version to v5.
- Step name says it uses python3.9, but it actually installs 3.10. Match name and what it actually doing.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: heka1024 <heka1024@gmail.com>