### PR TITLE
[ coverity ] Fix Coverity issue

### DIFF
--- a/test/unittest/layers/layers_golden_tests.cpp
+++ b/test/unittest/layers/layers_golden_tests.cpp
@@ -370,7 +370,7 @@ bool LayerGoldenTest::shouldSkipCosineSimilarity() {
 }
 
 TEST_P(LayerGoldenTest, run) {
-  auto f = std::get<0>(GetParam());
+  const auto &f = std::get<0>(GetParam());
   auto layer = f(std::get<1>(GetParam()));
   std::string format = std::get<5>(GetParam());
   std::string type_w = std::get<6>(GetParam());


### PR DESCRIPTION
Fix Coverity issue on
- /test/unittest/layers/layers_golden_tests.cpp
- /test/unittest/models/unittest_models_recurrent.cpp
- /test/unittest/unittest_nntrainer_models.cpp

Resolves:
```
Use of auto that causes a copy (AUTO_CAUSES_COPY)
auto_causes_copy: This lambda has an unspecified return type
copy: This return statement creates a copy.
```
**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped