### PR TITLE
[Trivial] Disable cpp-linter action's clang-format

### DIFF
--- a/.github/workflows/cpp_linter.yml
+++ b/.github/workflows/cpp_linter.yml
@@ -12,8 +12,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          style: file
-          version: 14
+          style: ''
+          version: 16
           lines-changed-only: true
           file-annotations: false
           step-summary: true


### PR DESCRIPTION
We currently perform a Clang format check during our static checks.

The CPP-Linter we are using is from the Action Market and occasionally produces different results even when the same version is specified. This reduces efficiency for developers, so only the static check with more detailed logs will be left and the CPP-Linter function will be disabled.

However, the existing Linter function will remain.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped