### PR TITLE
[LoRA] add scaling parameter to LoRA

### DIFF
--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -1340,7 +1340,19 @@ class LoraRank : public PositiveIntegerProperty {
 public:
   static constexpr const char *key = "lora_rank"; /**< unique key to access */
   using prop_tag = uint_prop_tag;                 /**< property type */
-  ;
+};
+
+/**
+ * @brief LoRA scaling parameter
+ * @details It is used to set the scaling factor of LoRA, which is calculated as
+ * `scaling = alpha / rank` in the original paper. Defulat = 1.
+ */
+class LoraScaling : public Property<float> {
+public:
+  LoraScaling(float value = 1.0) : nntrainer::Property<float>(value) {}
+  static constexpr const char *key =
+    "lora_scaling";                /**< unique key to access */
+  using prop_tag = float_prop_tag; /**< property type */
 };
 
 /**

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -106,9 +106,12 @@ public:
   inline static const std::string type = "fully_connected";
 
 private:
-  std::tuple<props::Unit, props::LoraRank>
-    fc_props; /**< fc layer properties : unit - number of output neurons,
-                 lora_rank : rank of lora (optional) */
+  std::tuple<props::Unit, props::LoraRank, props::LoraScaling>
+    fc_props;                             /**< fc layer properties :
+                                                unit - number of output neurons,
+                                                lora_rank - rank of lora (optional)
+                                                lora_scaling - scaling factor of LoRA apply, i.e.,
+                                             lora_scaling = alpha / lora_rank */
   std::array<unsigned int, 2> weight_idx; /**< indices of the weights */
   std::array<unsigned int, 2> lora_idx;   /**< indices of the lora weights */
 };

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -108,7 +108,7 @@ void Exporter::saveTflResult(
 
 template <>
 void Exporter::saveTflResult(
-  const std::tuple<props::Unit, props::LoraRank> &props,
+  const std::tuple<props::Unit, props::LoraRank, props::LoraScaling> &props,
   const FullyConnectedLayer *self) {
   createIfNull(tf_node);
   tf_node->setOpType(tflite::BuiltinOperator_FULLY_CONNECTED);

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -284,7 +284,7 @@ class FullyConnectedLayer;
  */
 template <>
 void Exporter::saveTflResult(
-  const std::tuple<props::Unit, props::LoraRank> &props,
+  const std::tuple<props::Unit, props::LoraRank, props::LoraScaling> &props,
   const FullyConnectedLayer *self);
 
 class ActivationLayer;


### PR DESCRIPTION
- This commit adds `scaling` parameter to LoRA (fc)
- In the original paper, they adopted `alpha (int)` as a parameter to derive the scaling factor internally, i.e., scaling = alpha / rank.
- However, in this commit it directly takes `scaling` as a hyper-parameter.
- The updates are summarized as follows:
	- `common_properties.h` : add LoraScaling as a parameter.
	- `fc_layer.cpp`: update forwarding / calcGradient / calcDerivative func to apply scaling factor in LoRA computation
	- `fc_layer.h`: update to take LoraScaling as fc_props
	- `node_exporter.cpp/h`: add LoRA Scaling as a parameter in tf.export format of fc layer
- [TODO] update tflite format to support the updated fc_layer params.

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped