### PR TITLE
[ hgemm ] hgemm noTrans with kernel 8x16

### DIFF
--- a/nntrainer/tensor/hgemm/hgemm.cpp
+++ b/nntrainer/tensor/hgemm/hgemm.cpp
@@ -29,9 +29,7 @@ void hgemm_noTrans(const __fp16 *A, const __fp16 *B, float *C32, unsigned int M,
   if (alpha == 1.F && beta == 0.F) {
     if (M % 8 == 0 && N % 16 == 0 && K % 8 == 0) {
       hgemm_noTrans_8x16(M, N, K, A, K, B, N, C32, N, alpha, beta);
-    }
-    else
-    if (M % 8 == 0 && N % 8 == 0 && K % 8 == 0) {
+    } else if (M % 8 == 0 && N % 8 == 0 && K % 8 == 0) {
       hgemm_noTrans_8x8(M, N, K, A, K, B, N, C32, N, alpha, beta);
     } else if (M % 4 == 0 && N % 8 == 0 && K % 4 == 0) {
       hgemm_noTrans_4x8(M, N, K, A, K, B, N, C32, N, alpha, beta);
@@ -47,8 +45,7 @@ void hgemm_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
   if (alpha == 1.F && beta == 0.F) {
     if (M % 8 == 0 && N % 16 == 0 && K % 8 == 0) {
       hgemm_noTrans_8x16(M, N, K, A, K, B, N, C, N, alpha, beta);
-    } else 
-    if (M % 8 == 0 && N % 8 == 0 && K % 8 == 0) {
+    } else if (M % 8 == 0 && N % 8 == 0 && K % 8 == 0) {
       hgemm_noTrans_8x8(M, N, K, A, K, B, N, C, N, alpha, beta);
     } else if (M % 4 == 0 && N % 8 == 0 && K % 4 == 0) {
       hgemm_noTrans_4x8(M, N, K, A, K, B, N, C, N, alpha, beta);

--- a/nntrainer/tensor/hgemm/hgemm.h
+++ b/nntrainer/tensor/hgemm/hgemm.h
@@ -15,7 +15,7 @@
  * @brief     hgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
  * @param[in] A __fp16 * for Matrix A
  * @param[in] B __fp16 * for Matrix B
- * @param[in] C __fp16 * for Matrix C
+ * @param[in] C float * for Matrix C
  * @param[in] M number of op(A)'s and C's row
  * @param[in] N number of op(B)'s and C's columns
  * @param[in] K number of op(A)'s and columns and op(B)'s rows
@@ -23,6 +23,21 @@
  * @param[in] beta float number
  */
 void hgemm_noTrans(const __fp16 *A, const __fp16 *B, float *C, unsigned int M,
+                   unsigned int N, unsigned int K, float alpha = 1.F,
+                   float beta = 0.F);
+
+/**
+ * @brief     hgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * @param[in] A __fp16 * for Matrix A
+ * @param[in] B __fp16 * for Matrix B
+ * @param[in] C __fp16 * for Matrix C
+ * @param[in] M number of op(A)'s and C's row
+ * @param[in] N number of op(B)'s and C's columns
+ * @param[in] K number of op(A)'s and columns and op(B)'s rows
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void hgemm_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
                    unsigned int N, unsigned int K, float alpha = 1.F,
                    float beta = 0.F);
 
@@ -146,7 +161,7 @@ void hgemm_noTrans_4x8(unsigned int M, unsigned int N, unsigned int K,
                        float alpha = 1.F, float beta = 0.F);
 
 /**
- * @brief hgemm noTrans computation with 4x8 kernel : C = A*B,
+ * @brief hgemm noTrans computation with 8x16 kernel : C = A*B,
  *
  * @param M length of the row of matrix A
  * @param N length of the col of matrix B
@@ -161,6 +176,26 @@ void hgemm_noTrans_4x8(unsigned int M, unsigned int N, unsigned int K,
  * @param[in] beta float number
  */
 void hgemm_noTrans_8x16(unsigned int M, unsigned int N, unsigned int K,
-                       const __fp16 *A, unsigned int lda, const __fp16 *B,
-                       unsigned int ldb, __fp16 *C, unsigned int ldc,
-                       float alpha = 1.F, float beta = 0.F);
+                        const __fp16 *A, unsigned int lda, const __fp16 *B,
+                        unsigned int ldb, __fp16 *C, unsigned int ldc,
+                        float alpha = 1.F, float beta = 0.F);
+
+/**
+ * @brief hgemm noTrans computation with 8x16 kernel : C = A*B,
+ *
+ * @param M length of the row of matrix A
+ * @param N length of the col of matrix B
+ * @param K length of the col of matrix A
+ * @param A input matrix A
+ * @param lda length of the col of matrix C
+ * @param B input matrix B
+ * @param ldb length of the col of matrix C
+ * @param C output matrix C
+ * @param ldc length of the col of matrix C
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void hgemm_noTrans_8x16(unsigned int M, unsigned int N, unsigned int K,
+                        const __fp16 *A, unsigned int lda, const __fp16 *B,
+                        unsigned int ldb, float *C, unsigned int ldc,
+                        float alpha = 1.F, float beta = 0.F);

--- a/nntrainer/tensor/hgemm/hgemm_kernel_4x8.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_4x8.h
@@ -14,6 +14,9 @@
 #include <hgemm_common.h>
 #include <stdlib.h>
 
+/// @note Following KERNELs are the combinations of accuracy-latency
+/// tradeoff. User can select which kernel to use by replacing them.
+
 // 1. Partial sum 256 digits : worst accuracy, best latency
 #define KERNEL_4x8_ACC8()               \
   v0 = vdupq_n_f16(0.F);                \
@@ -69,6 +72,8 @@
   v6 = vfmaq_lane_f16(v6, v31, dv7, 2); \
   v9 = vfmaq_lane_f16(v9, v31, dv7, 3); \
   l += 8;                               \
+  __builtin_prefetch(b + 64, 0, 3);     \
+  __builtin_prefetch(a + 32, 0, 3);     \
   b += 8 * 8;                           \
   a += 4 * 8;
 
@@ -103,6 +108,8 @@
   v6 = vfmaq_lane_f16(v6, v27, dv3, 2); \
   v9 = vfmaq_lane_f16(v9, v27, dv3, 3); \
   l += 4;                               \
+  __builtin_prefetch(b + 32, 0, 3);     \
+  __builtin_prefetch(a + 16, 0, 3);     \
   b += 8 * 4;                           \
   a += 4 * 4;
 
@@ -119,6 +126,8 @@
   v6 = vfmaq_lane_f16(v6, v24, dv0, 2); \
   v9 = vfmaq_lane_f16(v9, v24, dv0, 3); \
   l += 1;                               \
+  __builtin_prefetch(b + 8, 0, 3);      \
+  __builtin_prefetch(a + 4, 0, 3);      \
   b += 8 * 1;                           \
   a += 4 * 1;
 

--- a/nntrainer/tensor/hgemm/hgemm_kernel_8x16.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_8x16.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2024 Sungsik Kong <ss.kong@samsung.com>
  *
  * @file   hgemm_kernel_8x16.h
- * @date   01 April 2024
+ * @date   04 April 2024
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Sungsik Kong <ss.kong@samsung.com>
  * @bug    No known bugs except for NYI items
@@ -14,168 +14,539 @@
 #include <hgemm_common.h>
 #include <stdlib.h>
 
-// NOPE! THIS is not the right way to implement 8x16 kernel
-// note that A is right, but B would be a little bit different
-// 1. Partial sum 256 digits : worst accuracy, best latency
-#define KERNEL_8x16_ACC8()                 \
-  v0 = vdupq_n_f16(0.F);                   \
-  v3 = vdupq_n_f16(0.F);                   \
-  v6 = vdupq_n_f16(0.F);                   \
-  v9 = vdupq_n_f16(0.F);                   \
-  v12 = vdupq_n_f16(0.F);                  \
-  v15 = vdupq_n_f16(0.F);                  \
-  v18 = vdupq_n_f16(0.F);                  \
-  v21 = vdupq_n_f16(0.F);                  \
-  va0 = vld1q_f16(a);                      \
-  v24 = vld1q_f16(b);                      \
-  v0 = vfmaq_laneq_f16(v0, v24, va0, 0);   \
-  v3 = vfmaq_laneq_f16(v3, v24, va0, 1);   \
-  v6 = vfmaq_laneq_f16(v6, v24, va0, 2);   \
-  v9 = vfmaq_laneq_f16(v9, v24, va0, 3);   \
-  v12 = vfmaq_laneq_f16(v12, v24, va0, 4); \
-  v15 = vfmaq_laneq_f16(v15, v24, va0, 5); \
-  v18 = vfmaq_laneq_f16(v18, v24, va0, 6); \
-  v21 = vfmaq_laneq_f16(v21, v24, va0, 7); \
-  va1 = vld1q_f16(a + 4);                  \
-  v25 = vld1q_f16(b + 8);                  \
-  v0 = vfmaq_laneq_f16(v0, v25, va1, 0);   \
-  v3 = vfmaq_laneq_f16(v3, v25, va1, 1);   \
-  v6 = vfmaq_laneq_f16(v6, v25, va1, 2);   \
-  v9 = vfmaq_laneq_f16(v9, v25, va1, 3);   \
-  v12 = vfmaq_laneq_f16(v12, v25, va1, 4); \
-  v15 = vfmaq_laneq_f16(v15, v25, va1, 5); \
-  v18 = vfmaq_laneq_f16(v18, v25, va1, 6); \
-  v21 = vfmaq_laneq_f16(v21, v25, va1, 7); \
-  va2 = vld1q_f16(a + 8);                  \
-  v26 = vld1q_f16(b + 16);                 \
-  v0 = vfmaq_laneq_f16(v0, v26, va2, 0);   \
-  v3 = vfmaq_laneq_f16(v3, v26, va2, 1);   \
-  v6 = vfmaq_laneq_f16(v6, v26, va2, 2);   \
-  v9 = vfmaq_laneq_f16(v9, v26, va2, 3);   \
-  v12 = vfmaq_laneq_f16(v12, v26, va2, 4); \
-  v15 = vfmaq_laneq_f16(v15, v26, va2, 5); \
-  v18 = vfmaq_laneq_f16(v18, v26, va2, 6); \
-  v21 = vfmaq_laneq_f16(v21, v26, va2, 7); \
-  va3 = vld1q_f16(a + 12);                 \
-  v27 = vld1q_f16(b + 24);                 \
-  v0 = vfmaq_laneq_f16(v0, v27, va3, 0);   \
-  v3 = vfmaq_laneq_f16(v3, v27, va3, 1);   \
-  v6 = vfmaq_laneq_f16(v6, v27, va3, 2);   \
-  v9 = vfmaq_laneq_f16(v9, v27, va3, 3);   \
-  v12 = vfmaq_laneq_f16(v12, v27, va3, 4); \
-  v15 = vfmaq_laneq_f16(v15, v27, va3, 5); \
-  v18 = vfmaq_laneq_f16(v18, v27, va3, 6); \
-  v21 = vfmaq_laneq_f16(v21, v27, va3, 7); \
-  va4 = vld1q_f16(a + 16);                 \
-  v28 = vld1q_f16(b + 32);                 \
-  v0 = vfmaq_laneq_f16(v0, v28, va4, 0);   \
-  v3 = vfmaq_laneq_f16(v3, v28, va4, 1);   \
-  v6 = vfmaq_laneq_f16(v6, v28, va4, 2);   \
-  v9 = vfmaq_laneq_f16(v9, v28, va4, 3);   \
-  v12 = vfmaq_laneq_f16(v12, v28, va4, 4); \
-  v15 = vfmaq_laneq_f16(v15, v28, va4, 5); \
-  v18 = vfmaq_laneq_f16(v18, v28, va4, 6); \
-  v21 = vfmaq_laneq_f16(v21, v28, va4, 7); \
-  va5 = vld1q_f16(a + 20);                 \
-  v29 = vld1q_f16(b + 40);                 \
-  v0 = vfmaq_laneq_f16(v0, v29, va5, 0);   \
-  v3 = vfmaq_laneq_f16(v3, v29, va5, 1);   \
-  v6 = vfmaq_laneq_f16(v6, v29, va5, 2);   \
-  v9 = vfmaq_laneq_f16(v9, v29, va5, 3);   \
-  v12 = vfmaq_laneq_f16(v12, v29, va5, 4); \
-  v15 = vfmaq_laneq_f16(v15, v29, va5, 5); \
-  v18 = vfmaq_laneq_f16(v18, v29, va5, 6); \
-  v21 = vfmaq_laneq_f16(v21, v29, va5, 7); \
-  va6 = vld1q_f16(a + 24);                 \
-  v30 = vld1q_f16(b + 48);                 \
-  v0 = vfmaq_laneq_f16(v0, v30, va6, 0);   \
-  v3 = vfmaq_laneq_f16(v3, v30, va6, 1);   \
-  v6 = vfmaq_laneq_f16(v6, v30, va6, 2);   \
-  v9 = vfmaq_laneq_f16(v9, v30, va6, 3);   \
-  v12 = vfmaq_laneq_f16(v12, v30, va6, 4); \
-  v15 = vfmaq_laneq_f16(v15, v30, va6, 5); \
-  v18 = vfmaq_laneq_f16(v18, v30, va6, 6); \
-  v21 = vfmaq_laneq_f16(v21, v30, va6, 7); \
-  va7 = vld1q_f16(a + 28);                 \
-  v31 = vld1q_f16(b + 56);                 \
-  v0 = vfmaq_laneq_f16(v0, v31, va7, 0);   \
-  v3 = vfmaq_laneq_f16(v3, v31, va7, 1);   \
-  v6 = vfmaq_laneq_f16(v6, v31, va7, 2);   \
-  v9 = vfmaq_laneq_f16(v9, v31, va7, 3);   \
-  v12 = vfmaq_laneq_f16(v12, v31, va7, 4); \
-  v15 = vfmaq_laneq_f16(v15, v31, va7, 5); \
-  v18 = vfmaq_laneq_f16(v18, v31, va7, 6); \
-  v21 = vfmaq_laneq_f16(v21, v31, va7, 7); \
-  l += 8;                                  \
-  b += 16 * 8;                             \
+/// @note Following KERNELs are the combinations of accuracy-latency
+/// tradeoff. User can select which kernel to use by replacing them.
+
+// 1. Partial sum 1024 digits : Worst accuracy, best latency
+#define KERNEL_8x16_ACC8()                           \
+  v0_7 = vdupq_n_f16(0.F);                           \
+  v8_15 = vdupq_n_f16(0.F);                          \
+  v16_23 = vdupq_n_f16(0.F);                         \
+  v24_31 = vdupq_n_f16(0.F);                         \
+  v32_39 = vdupq_n_f16(0.F);                         \
+  v40_47 = vdupq_n_f16(0.F);                         \
+  v48_55 = vdupq_n_f16(0.F);                         \
+  v56_63 = vdupq_n_f16(0.F);                         \
+  v64_71 = vdupq_n_f16(0.F);                         \
+  v72_79 = vdupq_n_f16(0.F);                         \
+  v80_87 = vdupq_n_f16(0.F);                         \
+  v88_95 = vdupq_n_f16(0.F);                         \
+  v96_103 = vdupq_n_f16(0.F);                        \
+  v104_111 = vdupq_n_f16(0.F);                       \
+  v112_119 = vdupq_n_f16(0.F);                       \
+  v120_127 = vdupq_n_f16(0.F);                       \
+  va0 = vld1q_f16(a);                                \
+  v24 = vld1q_f16(b);                                \
+  v25 = vld1q_f16(b + 8);                            \
+  v0_7 = vfmaq_laneq_f16(v0_7, v24, va0, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v24, va0, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v24, va0, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v24, va0, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v24, va0, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v24, va0, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v24, va0, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v24, va0, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v25, va0, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v25, va0, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v25, va0, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v25, va0, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v25, va0, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v25, va0, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v25, va0, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v25, va0, 7); \
+  va1 = vld1q_f16(a + 8);                            \
+  v26 = vld1q_f16(b + 16);                           \
+  v27 = vld1q_f16(b + 24);                           \
+  v0_7 = vfmaq_laneq_f16(v0_7, v26, va1, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v26, va1, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v26, va1, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v26, va1, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v26, va1, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v26, va1, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v26, va1, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v26, va1, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v27, va1, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v27, va1, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v27, va1, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v27, va1, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v27, va1, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v27, va1, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v27, va1, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v27, va1, 7); \
+  va2 = vld1q_f16(a + 16);                           \
+  v28 = vld1q_f16(b + 32);                           \
+  v29 = vld1q_f16(b + 40);                           \
+  v0_7 = vfmaq_laneq_f16(v0_7, v28, va2, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v28, va2, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v28, va2, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v28, va2, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v28, va2, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v28, va2, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v28, va2, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v28, va2, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v29, va2, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v29, va2, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v29, va2, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v29, va2, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v29, va2, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v29, va2, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v29, va2, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v29, va2, 7); \
+  va3 = vld1q_f16(a + 24);                           \
+  v30 = vld1q_f16(b + 48);                           \
+  v31 = vld1q_f16(b + 56);                           \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va3, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va3, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va3, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va3, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va3, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va3, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va3, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va3, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va3, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va3, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va3, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va3, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va3, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va3, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va3, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va3, 7); \
+  va4 = vld1q_f16(a + 32);                           \
+  v24 = vld1q_f16(b + 64);                           \
+  v25 = vld1q_f16(b + 72);                           \
+  v0_7 = vfmaq_laneq_f16(v0_7, v24, va4, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v24, va4, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v24, va4, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v24, va4, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v24, va4, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v24, va4, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v24, va4, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v24, va4, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v25, va4, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v25, va4, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v25, va4, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v25, va4, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v25, va4, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v25, va4, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v25, va4, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v25, va4, 7); \
+  va5 = vld1q_f16(a + 40);                           \
+  v26 = vld1q_f16(b + 80);                           \
+  v27 = vld1q_f16(b + 88);                           \
+  v0_7 = vfmaq_laneq_f16(v0_7, v26, va5, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v26, va5, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v26, va5, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v26, va5, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v26, va5, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v26, va5, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v26, va5, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v26, va5, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v27, va5, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v27, va5, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v27, va5, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v27, va5, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v27, va5, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v27, va5, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v27, va5, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v27, va5, 7); \
+  va6 = vld1q_f16(a + 48);                           \
+  v28 = vld1q_f16(b + 96);                           \
+  v29 = vld1q_f16(b + 104);                           \
+  v0_7 = vfmaq_laneq_f16(v0_7, v28, va6, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v28, va6, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v28, va6, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v28, va6, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v28, va6, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v28, va6, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v28, va6, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v28, va6, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v29, va6, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v29, va6, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v29, va6, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v29, va6, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v29, va6, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v29, va6, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v29, va6, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v29, va6, 7); \
+  va7 = vld1q_f16(a + 56);                           \
+  v30 = vld1q_f16(b + 112);                           \
+  v31 = vld1q_f16(b + 120);                           \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va7, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va7, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va7, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va7, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va7, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va7, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va7, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va7, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va7, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va7, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va7, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va7, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va7, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va7, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va7, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va7, 7); \
+  l += 8;                                            \
+  __builtin_prefetch(b + 128, 0, 3);                 \
+  __builtin_prefetch(a + 64, 0, 3);                  \
+  b += 16 * 8;                                       \
   a += 8 * 8;
+
+// 2. Partial sum 512 digits : Medium accuracy, medium latency
+#define KERNEL_8x16_ACC4()                           \
+  v0_7 = vdupq_n_f16(0.F);                           \
+  v8_15 = vdupq_n_f16(0.F);                          \
+  v16_23 = vdupq_n_f16(0.F);                         \
+  v24_31 = vdupq_n_f16(0.F);                         \
+  v32_39 = vdupq_n_f16(0.F);                         \
+  v40_47 = vdupq_n_f16(0.F);                         \
+  v48_55 = vdupq_n_f16(0.F);                         \
+  v56_63 = vdupq_n_f16(0.F);                         \
+  v64_71 = vdupq_n_f16(0.F);                         \
+  v72_79 = vdupq_n_f16(0.F);                         \
+  v80_87 = vdupq_n_f16(0.F);                         \
+  v88_95 = vdupq_n_f16(0.F);                         \
+  v96_103 = vdupq_n_f16(0.F);                        \
+  v104_111 = vdupq_n_f16(0.F);                       \
+  v112_119 = vdupq_n_f16(0.F);                       \
+  v120_127 = vdupq_n_f16(0.F);                       \
+  va0 = vld1q_f16(a);                                \
+  v24 = vld1q_f16(b);                                \
+  v25 = vld1q_f16(b + 8);                            \
+  v0_7 = vfmaq_laneq_f16(v0_7, v24, va0, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v24, va0, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v24, va0, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v24, va0, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v24, va0, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v24, va0, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v24, va0, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v24, va0, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v25, va0, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v25, va0, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v25, va0, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v25, va0, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v25, va0, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v25, va0, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v25, va0, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v25, va0, 7); \
+  va1 = vld1q_f16(a + 8);                            \
+  v26 = vld1q_f16(b + 16);                           \
+  v27 = vld1q_f16(b + 24);                           \
+  v0_7 = vfmaq_laneq_f16(v0_7, v26, va1, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v26, va1, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v26, va1, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v26, va1, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v26, va1, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v26, va1, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v26, va1, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v26, va1, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v27, va1, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v27, va1, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v27, va1, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v27, va1, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v27, va1, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v27, va1, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v27, va1, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v27, va1, 7); \
+  va2 = vld1q_f16(a + 16);                           \
+  v28 = vld1q_f16(b + 32);                           \
+  v29 = vld1q_f16(b + 40);                           \
+  v0_7 = vfmaq_laneq_f16(v0_7, v28, va2, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v28, va2, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v28, va2, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v28, va2, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v28, va2, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v28, va2, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v28, va2, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v28, va2, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v29, va2, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v29, va2, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v29, va2, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v29, va2, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v29, va2, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v29, va2, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v29, va2, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v29, va2, 7); \
+  va3 = vld1q_f16(a + 24);                           \
+  v30 = vld1q_f16(b + 48);                           \
+  v31 = vld1q_f16(b + 56);                           \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va3, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va3, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va3, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va3, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va3, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va3, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va3, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va3, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va3, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va3, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va3, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va3, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va3, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va3, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va3, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va3, 7); \
+  l += 4;                                            \
+  __builtin_prefetch(b + 64, 0, 3);                  \
+  __builtin_prefetch(a + 32, 0, 3);                  \
+  b += 16 * 4;                                       \
+  a += 8 * 4;
+
+// 3. Partial sum 128 digits : Best accuracy, worst latency
+#define KERNEL_8x16_ACC1()                           \
+  v0_7 = vdupq_n_f16(0.F);                           \
+  v8_15 = vdupq_n_f16(0.F);                          \
+  v16_23 = vdupq_n_f16(0.F);                         \
+  v24_31 = vdupq_n_f16(0.F);                         \
+  v32_39 = vdupq_n_f16(0.F);                         \
+  v40_47 = vdupq_n_f16(0.F);                         \
+  v48_55 = vdupq_n_f16(0.F);                         \
+  v56_63 = vdupq_n_f16(0.F);                         \
+  v64_71 = vdupq_n_f16(0.F);                         \
+  v72_79 = vdupq_n_f16(0.F);                         \
+  v80_87 = vdupq_n_f16(0.F);                         \
+  v88_95 = vdupq_n_f16(0.F);                         \
+  v96_103 = vdupq_n_f16(0.F);                        \
+  v104_111 = vdupq_n_f16(0.F);                       \
+  v112_119 = vdupq_n_f16(0.F);                       \
+  v120_127 = vdupq_n_f16(0.F);                       \
+  va0 = vld1q_f16(a);                                \
+  v24 = vld1q_f16(b);                                \
+  v25 = vld1q_f16(b + 8);                            \
+  v0_7 = vfmaq_laneq_f16(v0_7, v24, va0, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v24, va0, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v24, va0, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v24, va0, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v24, va0, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v24, va0, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v24, va0, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v24, va0, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v25, va0, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v25, va0, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v25, va0, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v25, va0, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v25, va0, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v25, va0, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v25, va0, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v25, va0, 7); \
+  l += 1;                                            \
+  __builtin_prefetch(b + 16, 0, 3);                  \
+  __builtin_prefetch(a + 8, 0, 3);                   \
+  b += 16 * 1;                                       \
+  a += 8 * 1;
 
 /**
  * @brief hgemm 8x16 kernel sc = sa * sb
  *
- * @param m length of the row of matrix A
- * @param n length of the col of matrix B
- * @param k length of the col of matrix A
+ * @param M length of the row of matrix A
+ * @param N length of the col of matrix B
+ * @param K length of the col of matrix A
  * @param sa sub-matrix of input matrix A
  * @param sb sub-matrix of input matrix B
  * @param sc sub-matrix of output matrix C
  * @param ldc leading-dimension of matrix C
  */
-void hgemm_kernel_8x16(unsigned int m, unsigned int n, unsigned int k,
+void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
                        __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc) {
-  assert(m > 0 && n > 0 && k > 0);
-  assert(m % 4 == 0 && n % 8 == 0);
+  assert(M > 0 && N > 0 && K > 0);
+  assert(M % 8 == 0 && N % 16 == 0);
 
   __fp16 *a = sa, *b = sb, *c = sc;
-  unsigned int k8 = (k >> 3) << 3;
   unsigned int i, j, l;
-  for (i = 0; i < m; i += 8) {
-    for (j = 0; j < n; j += 16) {
+  for (i = 0; i < M; i += 8) {
+    for (j = 0; j < N; j += 16) {
       __builtin_prefetch(b, 0, 3);
       __builtin_prefetch(a, 0, 3);
-      float16x8_t v0, v3, v6, v9;
-      float16x8_t v12, v15, v18, v21;
+      // 8x16
+      float16x8_t v0_7, v8_15;
+      float16x8_t v16_23, v24_31;
+      float16x8_t v32_39, v40_47;
+      float16x8_t v48_55, v56_63;
+      float16x8_t v64_71, v72_79;
+      float16x8_t v80_87, v88_95;
+      float16x8_t v96_103, v104_111;
+      float16x8_t v112_119, v120_127;
+
       float16x8_t v24, v25, v26, v27, v28, v29, v30, v31;
-      float16x8_t va0, va1, va2, va3, va4, va5, va6, va7;
+      float16x8_t va0, va1, va2, va3;
       l = 0;
-      for (; l < k8;) {
-        KERNEL_8x16_ACC8();
-
-        vst1q_f16(c, vaddq_f16(vld1q_f16(c), v0));
-        vst1q_f16(c + 8, vaddq_f16(vld1q_f16(c + 8), v3));
-
-        vst1q_f16(c + ldc, vaddq_f16(vld1q_f16(c + ldc), v6));
-        vst1q_f16(c + 8 + ldc, vaddq_f16(vld1q_f16(c + 8 + ldc), v9));
-
-        vst1q_f16(c + 2 * ldc, vaddq_f16(vld1q_f16(c + 2 * ldc), v12));
-        vst1q_f16(c + 8 + 2 * ldc, vaddq_f16(vld1q_f16(c + 8 + 2 * ldc), v15));
-
-        vst1q_f16(c + 3 * ldc, vaddq_f16(vld1q_f16(c + 3 * ldc), v18));
-        vst1q_f16(c + 8 + 3 * ldc, vaddq_f16(vld1q_f16(c + 8 + 3 * ldc), v21));
+      for (; l < K;) {
+        KERNEL_8x16_ACC4();
+        vst1q_f16(c, vaddq_f16(vld1q_f16(c), v0_7));
+        vst1q_f16(c + 8, vaddq_f16(vld1q_f16(c + 8), v64_71));
+        vst1q_f16(c + ldc, vaddq_f16(vld1q_f16(c + ldc), v8_15));
+        vst1q_f16(c + ldc + 8, vaddq_f16(vld1q_f16(c + ldc + 8), v72_79));
+        vst1q_f16(c + 2 * ldc, vaddq_f16(vld1q_f16(c + 2 * ldc), v16_23));
+        vst1q_f16(c + 2 * ldc + 8,
+                  vaddq_f16(vld1q_f16(c + 2 * ldc + 8), v80_87));
+        vst1q_f16(c + 3 * ldc, vaddq_f16(vld1q_f16(c + 3 * ldc), v24_31));
+        vst1q_f16(c + 3 * ldc + 8,
+                  vaddq_f16(vld1q_f16(c + 3 * ldc + 8), v88_95));
+        vst1q_f16(c + 4 * ldc, vaddq_f16(vld1q_f16(c + 4 * ldc), v32_39));
+        vst1q_f16(c + 4 * ldc + 8,
+                  vaddq_f16(vld1q_f16(c + 4 * ldc + 8), v96_103));
+        vst1q_f16(c + 5 * ldc, vaddq_f16(vld1q_f16(c + 5 * ldc), v40_47));
+        vst1q_f16(c + 5 * ldc + 8,
+                  vaddq_f16(vld1q_f16(c + 5 * ldc + 8), v104_111));
+        vst1q_f16(c + 6 * ldc, vaddq_f16(vld1q_f16(c + 6 * ldc), v48_55));
+        vst1q_f16(c + 6 * ldc + 8,
+                  vaddq_f16(vld1q_f16(c + 6 * ldc + 8), v112_119));
+        vst1q_f16(c + 7 * ldc, vaddq_f16(vld1q_f16(c + 7 * ldc), v56_63));
+        vst1q_f16(c + 7 * ldc + 8,
+                  vaddq_f16(vld1q_f16(c + 7 * ldc + 8), v120_127));
       }
-      //   for (; l < k;) {
-      //     KERNEL_8x16_ACC1();
-
-      //     vst1q_f16(c, vaddq_f16(vld1q_f16(c), v0));
-      //     vst1q_f16(c + 8, vaddq_f16(vld1q_f16(c + 8), v3));
-
-      //     vst1q_f16(c + ldc, vaddq_f16(vld1q_f16(c + ldc), v6));
-      //     vst1q_f16(c + 8 + ldc, vaddq_f16(vld1q_f16(c + 8 + ldc), v9));
-
-      //     vst1q_f16(c + 2 * ldc, vaddq_f16(vld1q_f16(c + 2 * ldc), v12));
-      //     vst1q_f16(c + 8 + 2 * ldc, vaddq_f16(vld1q_f16(c + 8 + 2 * ldc),
-      //     v15));
-
-      //     vst1q_f16(c + 3 * ldc, vaddq_f16(vld1q_f16(c + 3 * ldc), v18));
-      //     vst1q_f16(c + 8 + 3 * ldc, vaddq_f16(vld1q_f16(c + 8 + 3 * ldc),
-      //     v21));
-      //   }
       c += 16;
-      a -= 8 * k;
+      a -= 8 * K;
     }
     sc += ldc * 8;
     c = sc;
-    a += 8 * k;
+    a += 8 * K;
+    b = sb;
+  }
+}
+
+/**
+ * @brief hgemm 8x16 kernel sc = sa * sb
+ *
+ * @param M length of the row of matrix A
+ * @param N length of the col of matrix B
+ * @param K length of the col of matrix A
+ * @param sa sub-matrix of input matrix A
+ * @param sb sub-matrix of input matrix B
+ * @param sc sub-matrix of output matrix C
+ * @param ldc leading-dimension of matrix C
+ */
+void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
+                       __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc) {
+  assert(M > 0 && N > 0 && K > 0);
+  assert(M % 8 == 0 && N % 16 == 0);
+
+  __fp16 *a = sa, *b = sb;
+  float *c = sc;
+  unsigned int i, j, l;
+  for (i = 0; i < M; i += 8) {
+    for (j = 0; j < N; j += 16) {
+      __builtin_prefetch(b, 0, 3);
+      __builtin_prefetch(a, 0, 3);
+      float16x8_t v0_7, v8_15;
+      float16x8_t v16_23, v24_31;
+      float16x8_t v32_39, v40_47;
+      float16x8_t v48_55, v56_63;
+      float16x8_t v64_71, v72_79;
+      float16x8_t v80_87, v88_95;
+      float16x8_t v96_103, v104_111;
+      float16x8_t v112_119, v120_127;
+      float16x8_t v24, v25, v26, v27, v28, v29, v30, v31;
+      float16x8_t va0, va1, va2, va3, va4, va5, va6, va7;
+      l = 0;
+      for (; l < K;) {
+        KERNEL_8x16_ACC8();
+
+        vst1q_f32(c, vaddq_f32(vld1q_f32(c), vcvt_f32_f16(vget_low_f16(v0_7))));
+        vst1q_f32(c + 4, vaddq_f32(vld1q_f32(c + 4),
+                                   vcvt_f32_f16(vget_high_f16(v0_7))));
+
+        vst1q_f32(c + 8, vaddq_f32(vld1q_f32(c + 8),
+                                   vcvt_f32_f16(vget_low_f16(v64_71))));
+        vst1q_f32(c + 8 + 4, vaddq_f32(vld1q_f32(c + 8 + 4),
+                                       vcvt_f32_f16(vget_high_f16(v64_71))));
+
+        vst1q_f32(c + ldc, vaddq_f32(vld1q_f32(c + ldc),
+                                     vcvt_f32_f16(vget_low_f16(v8_15))));
+        vst1q_f32(c + ldc + 4, vaddq_f32(vld1q_f32(c + ldc + 4),
+                                         vcvt_f32_f16(vget_high_f16(v8_15))));
+
+        vst1q_f32(c + ldc + 8, vaddq_f32(vld1q_f32(c + ldc + 8),
+                                         vcvt_f32_f16(vget_low_f16(v72_79))));
+        vst1q_f32(c + ldc + 8 + 4,
+                  vaddq_f32(vld1q_f32(c + ldc + 8 + 4),
+                            vcvt_f32_f16(vget_high_f16(v72_79))));
+
+        vst1q_f32(c + 2 * ldc, vaddq_f32(vld1q_f32(c + 2 * ldc),
+                                         vcvt_f32_f16(vget_low_f16(v16_23))));
+        vst1q_f32(c + 2 * ldc + 4,
+                  vaddq_f32(vld1q_f32(c + 2 * ldc + 4),
+                            vcvt_f32_f16(vget_high_f16(v16_23))));
+
+        vst1q_f32(c + 2 * ldc + 8,
+                  vaddq_f32(vld1q_f32(c + 2 * ldc + 8),
+                            vcvt_f32_f16(vget_low_f16(v80_87))));
+        vst1q_f32(c + 2 * ldc + 8 + 4,
+                  vaddq_f32(vld1q_f32(c + 2 * ldc + 8 + 4),
+                            vcvt_f32_f16(vget_high_f16(v80_87))));
+
+        vst1q_f32(c + 3 * ldc, vaddq_f32(vld1q_f32(c + 3 * ldc),
+                                         vcvt_f32_f16(vget_low_f16(v24_31))));
+        vst1q_f32(c + 3 * ldc + 4,
+                  vaddq_f32(vld1q_f32(c + 3 * ldc + 4),
+                            vcvt_f32_f16(vget_high_f16(v24_31))));
+
+        vst1q_f32(c + 3 * ldc + 8,
+                  vaddq_f32(vld1q_f32(c + 3 * ldc + 8),
+                            vcvt_f32_f16(vget_low_f16(v88_95))));
+        vst1q_f32(c + 3 * ldc + 8 + 4,
+                  vaddq_f32(vld1q_f32(c + 3 * ldc + 8 + 4),
+                            vcvt_f32_f16(vget_high_f16(v88_95))));
+
+        vst1q_f32(c + 4 * ldc, vaddq_f32(vld1q_f32(c + 4 * ldc),
+                                         vcvt_f32_f16(vget_low_f16(v32_39))));
+        vst1q_f32(c + 4 * ldc + 4,
+                  vaddq_f32(vld1q_f32(c + 4 * ldc + 4),
+                            vcvt_f32_f16(vget_high_f16(v32_39))));
+
+        vst1q_f32(c + 4 * ldc + 8,
+                  vaddq_f32(vld1q_f32(c + 4 * ldc + 8),
+                            vcvt_f32_f16(vget_low_f16(v96_103))));
+        vst1q_f32(c + 4 * ldc + 8 + 4,
+                  vaddq_f32(vld1q_f32(c + 4 * ldc + 8 + 4),
+                            vcvt_f32_f16(vget_high_f16(v96_103))));
+
+        vst1q_f32(c + 5 * ldc, vaddq_f32(vld1q_f32(c + 5 * ldc),
+                                         vcvt_f32_f16(vget_low_f16(v40_47))));
+        vst1q_f32(c + 5 * ldc + 4,
+                  vaddq_f32(vld1q_f32(c + 5 * ldc + 4),
+                            vcvt_f32_f16(vget_high_f16(v40_47))));
+
+        vst1q_f32(c + 5 * ldc + 8,
+                  vaddq_f32(vld1q_f32(c + 5 * ldc + 8),
+                            vcvt_f32_f16(vget_low_f16(v104_111))));
+        vst1q_f32(c + 5 * ldc + 8 + 4,
+                  vaddq_f32(vld1q_f32(c + 5 * ldc + 8 + 4),
+                            vcvt_f32_f16(vget_high_f16(v104_111))));
+
+        vst1q_f32(c + 6 * ldc, vaddq_f32(vld1q_f32(c + 6 * ldc),
+                                         vcvt_f32_f16(vget_low_f16(v48_55))));
+        vst1q_f32(c + 6 * ldc + 4,
+                  vaddq_f32(vld1q_f32(c + 6 * ldc + 4),
+                            vcvt_f32_f16(vget_high_f16(v48_55))));
+
+        vst1q_f32(c + 6 * ldc + 8,
+                  vaddq_f32(vld1q_f32(c + 6 * ldc + 8),
+                            vcvt_f32_f16(vget_low_f16(v112_119))));
+        vst1q_f32(c + 6 * ldc + 8 + 4,
+                  vaddq_f32(vld1q_f32(c + 6 * ldc + 8 + 4),
+                            vcvt_f32_f16(vget_high_f16(v112_119))));
+
+        vst1q_f32(c + 7 * ldc, vaddq_f32(vld1q_f32(c + 7 * ldc),
+                                         vcvt_f32_f16(vget_low_f16(v56_63))));
+        vst1q_f32(c + 7 * ldc + 4,
+                  vaddq_f32(vld1q_f32(c + 7 * ldc + 4),
+                            vcvt_f32_f16(vget_high_f16(v56_63))));
+
+        vst1q_f32(c + 7 * ldc + 8,
+                  vaddq_f32(vld1q_f32(c + 7 * ldc + 8),
+                            vcvt_f32_f16(vget_low_f16(v120_127))));
+        vst1q_f32(c + 7 * ldc + 8 + 4,
+                  vaddq_f32(vld1q_f32(c + 7 * ldc + 8 + 4),
+                            vcvt_f32_f16(vget_high_f16(v120_127))));
+      }
+      c += 16;
+      a -= 8 * K;
+    }
+    sc += ldc * 8;
+    c = sc;
+    a += 8 * K;
     b = sb;
   }
 }

--- a/nntrainer/tensor/hgemm/hgemm_kernel_8x16.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_8x16.h
@@ -151,7 +151,7 @@
   v120_127 = vfmaq_laneq_f16(v120_127, v27, va5, 7); \
   va6 = vld1q_f16(a + 48);                           \
   v28 = vld1q_f16(b + 96);                           \
-  v29 = vld1q_f16(b + 104);                           \
+  v29 = vld1q_f16(b + 104);                          \
   v0_7 = vfmaq_laneq_f16(v0_7, v28, va6, 0);         \
   v8_15 = vfmaq_laneq_f16(v8_15, v28, va6, 1);       \
   v16_23 = vfmaq_laneq_f16(v16_23, v28, va6, 2);     \
@@ -169,8 +169,8 @@
   v112_119 = vfmaq_laneq_f16(v112_119, v29, va6, 6); \
   v120_127 = vfmaq_laneq_f16(v120_127, v29, va6, 7); \
   va7 = vld1q_f16(a + 56);                           \
-  v30 = vld1q_f16(b + 112);                           \
-  v31 = vld1q_f16(b + 120);                           \
+  v30 = vld1q_f16(b + 112);                          \
+  v31 = vld1q_f16(b + 120);                          \
   v0_7 = vfmaq_laneq_f16(v0_7, v30, va7, 0);         \
   v8_15 = vfmaq_laneq_f16(v8_15, v30, va7, 1);       \
   v16_23 = vfmaq_laneq_f16(v16_23, v30, va7, 2);     \

--- a/nntrainer/tensor/hgemm/hgemm_kernel_8x8.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_8x8.h
@@ -14,6 +14,187 @@
 #include <hgemm_common.h>
 #include <stdlib.h>
 
+/// @note Following KERNELs are the combinations of accuracy-latency
+/// tradeoff. User can select which kernel to use by replacing them.
+
+// 1. Partial sum 512 digits : Worst accuracy, best latency
+#define KERNEL_8x8_ACC8()                  \
+  v24 = vdupq_n_f16(0.F);                  \
+  v25 = vdupq_n_f16(0.F);                  \
+  v26 = vdupq_n_f16(0.F);                  \
+  v27 = vdupq_n_f16(0.F);                  \
+  v28 = vdupq_n_f16(0.F);                  \
+  v29 = vdupq_n_f16(0.F);                  \
+  v30 = vdupq_n_f16(0.F);                  \
+  v31 = vdupq_n_f16(0.F);                  \
+  va0 = vld1q_f16(a);                      \
+  v16 = vld1q_f16(b);                      \
+  v24 = vfmaq_laneq_f16(v24, v16, va0, 0); \
+  v25 = vfmaq_laneq_f16(v25, v16, va0, 1); \
+  v26 = vfmaq_laneq_f16(v26, v16, va0, 2); \
+  v27 = vfmaq_laneq_f16(v27, v16, va0, 3); \
+  v28 = vfmaq_laneq_f16(v28, v16, va0, 4); \
+  v29 = vfmaq_laneq_f16(v29, v16, va0, 5); \
+  v30 = vfmaq_laneq_f16(v30, v16, va0, 6); \
+  v31 = vfmaq_laneq_f16(v31, v16, va0, 7); \
+  va1 = vld1q_f16(a + 8);                  \
+  v17 = vld1q_f16(b + 8);                  \
+  v24 = vfmaq_laneq_f16(v24, v17, va1, 0); \
+  v25 = vfmaq_laneq_f16(v25, v17, va1, 1); \
+  v26 = vfmaq_laneq_f16(v26, v17, va1, 2); \
+  v27 = vfmaq_laneq_f16(v27, v17, va1, 3); \
+  v28 = vfmaq_laneq_f16(v28, v17, va1, 4); \
+  v29 = vfmaq_laneq_f16(v29, v17, va1, 5); \
+  v30 = vfmaq_laneq_f16(v30, v17, va1, 6); \
+  v31 = vfmaq_laneq_f16(v31, v17, va1, 7); \
+  va2 = vld1q_f16(a + 16);                 \
+  v18 = vld1q_f16(b + 16);                 \
+  v24 = vfmaq_laneq_f16(v24, v18, va2, 0); \
+  v25 = vfmaq_laneq_f16(v25, v18, va2, 1); \
+  v26 = vfmaq_laneq_f16(v26, v18, va2, 2); \
+  v27 = vfmaq_laneq_f16(v27, v18, va2, 3); \
+  v28 = vfmaq_laneq_f16(v28, v18, va2, 4); \
+  v29 = vfmaq_laneq_f16(v29, v18, va2, 5); \
+  v30 = vfmaq_laneq_f16(v30, v18, va2, 6); \
+  v31 = vfmaq_laneq_f16(v31, v18, va2, 7); \
+  va3 = vld1q_f16(a + 24);                 \
+  v19 = vld1q_f16(b + 24);                 \
+  v24 = vfmaq_laneq_f16(v24, v19, va3, 0); \
+  v25 = vfmaq_laneq_f16(v25, v19, va3, 1); \
+  v26 = vfmaq_laneq_f16(v26, v19, va3, 2); \
+  v27 = vfmaq_laneq_f16(v27, v19, va3, 3); \
+  v28 = vfmaq_laneq_f16(v28, v19, va3, 4); \
+  v29 = vfmaq_laneq_f16(v29, v19, va3, 5); \
+  v30 = vfmaq_laneq_f16(v30, v19, va3, 6); \
+  v31 = vfmaq_laneq_f16(v31, v19, va3, 7); \
+  va4 = vld1q_f16(a + 32);                 \
+  v20 = vld1q_f16(b + 32);                 \
+  v24 = vfmaq_laneq_f16(v24, v20, va4, 0); \
+  v25 = vfmaq_laneq_f16(v25, v20, va4, 1); \
+  v26 = vfmaq_laneq_f16(v26, v20, va4, 2); \
+  v27 = vfmaq_laneq_f16(v27, v20, va4, 3); \
+  v28 = vfmaq_laneq_f16(v28, v20, va4, 4); \
+  v29 = vfmaq_laneq_f16(v29, v20, va4, 5); \
+  v30 = vfmaq_laneq_f16(v30, v20, va4, 6); \
+  v31 = vfmaq_laneq_f16(v31, v20, va4, 7); \
+  va5 = vld1q_f16(a + 40);                 \
+  v21 = vld1q_f16(b + 40);                 \
+  v24 = vfmaq_laneq_f16(v24, v21, va5, 0); \
+  v25 = vfmaq_laneq_f16(v25, v21, va5, 1); \
+  v26 = vfmaq_laneq_f16(v26, v21, va5, 2); \
+  v27 = vfmaq_laneq_f16(v27, v21, va5, 3); \
+  v28 = vfmaq_laneq_f16(v28, v21, va5, 4); \
+  v29 = vfmaq_laneq_f16(v29, v21, va5, 5); \
+  v30 = vfmaq_laneq_f16(v30, v21, va5, 6); \
+  v31 = vfmaq_laneq_f16(v31, v21, va5, 7); \
+  va6 = vld1q_f16(a + 48);                 \
+  v22 = vld1q_f16(b + 48);                 \
+  v24 = vfmaq_laneq_f16(v24, v22, va6, 0); \
+  v25 = vfmaq_laneq_f16(v25, v22, va6, 1); \
+  v26 = vfmaq_laneq_f16(v26, v22, va6, 2); \
+  v27 = vfmaq_laneq_f16(v27, v22, va6, 3); \
+  v28 = vfmaq_laneq_f16(v28, v22, va6, 4); \
+  v29 = vfmaq_laneq_f16(v29, v22, va6, 5); \
+  v30 = vfmaq_laneq_f16(v30, v22, va6, 6); \
+  v31 = vfmaq_laneq_f16(v31, v22, va6, 7); \
+  va7 = vld1q_f16(a + 56);                 \
+  v23 = vld1q_f16(b + 56);                 \
+  v24 = vfmaq_laneq_f16(v24, v23, va7, 0); \
+  v25 = vfmaq_laneq_f16(v25, v23, va7, 1); \
+  v26 = vfmaq_laneq_f16(v26, v23, va7, 2); \
+  v27 = vfmaq_laneq_f16(v27, v23, va7, 3); \
+  v28 = vfmaq_laneq_f16(v28, v23, va7, 4); \
+  v29 = vfmaq_laneq_f16(v29, v23, va7, 5); \
+  v30 = vfmaq_laneq_f16(v30, v23, va7, 6); \
+  v31 = vfmaq_laneq_f16(v31, v23, va7, 7); \
+  __builtin_prefetch(b + 64, 0, 3);        \
+  __builtin_prefetch(a + 64, 0, 3);        \
+  l += 8;                                  \
+  b += 8 * 8;                              \
+  a += 8 * 8;
+
+// 2. Partial sum 256 digits : Medium accuracy, medium latency
+#define KERNEL_8x8_ACC4()                  \
+  v24 = vdupq_n_f16(0.F);                  \
+  v25 = vdupq_n_f16(0.F);                  \
+  v26 = vdupq_n_f16(0.F);                  \
+  v27 = vdupq_n_f16(0.F);                  \
+  v28 = vdupq_n_f16(0.F);                  \
+  v29 = vdupq_n_f16(0.F);                  \
+  v30 = vdupq_n_f16(0.F);                  \
+  v31 = vdupq_n_f16(0.F);                  \
+  va0 = vld1q_f16(a);                      \
+  v16 = vld1q_f16(b);                      \
+  v24 = vfmaq_laneq_f16(v24, v16, va0, 0); \
+  v25 = vfmaq_laneq_f16(v25, v16, va0, 1); \
+  v26 = vfmaq_laneq_f16(v26, v16, va0, 2); \
+  v27 = vfmaq_laneq_f16(v27, v16, va0, 3); \
+  v28 = vfmaq_laneq_f16(v28, v16, va0, 4); \
+  v29 = vfmaq_laneq_f16(v29, v16, va0, 5); \
+  v30 = vfmaq_laneq_f16(v30, v16, va0, 6); \
+  v31 = vfmaq_laneq_f16(v31, v16, va0, 7); \
+  va1 = vld1q_f16(a + 8);                  \
+  v17 = vld1q_f16(b + 8);                  \
+  v24 = vfmaq_laneq_f16(v24, v17, va1, 0); \
+  v25 = vfmaq_laneq_f16(v25, v17, va1, 1); \
+  v26 = vfmaq_laneq_f16(v26, v17, va1, 2); \
+  v27 = vfmaq_laneq_f16(v27, v17, va1, 3); \
+  v28 = vfmaq_laneq_f16(v28, v17, va1, 4); \
+  v29 = vfmaq_laneq_f16(v29, v17, va1, 5); \
+  v30 = vfmaq_laneq_f16(v30, v17, va1, 6); \
+  v31 = vfmaq_laneq_f16(v31, v17, va1, 7); \
+  va2 = vld1q_f16(a + 16);                 \
+  v18 = vld1q_f16(b + 16);                 \
+  v24 = vfmaq_laneq_f16(v24, v18, va2, 0); \
+  v25 = vfmaq_laneq_f16(v25, v18, va2, 1); \
+  v26 = vfmaq_laneq_f16(v26, v18, va2, 2); \
+  v27 = vfmaq_laneq_f16(v27, v18, va2, 3); \
+  v28 = vfmaq_laneq_f16(v28, v18, va2, 4); \
+  v29 = vfmaq_laneq_f16(v29, v18, va2, 5); \
+  v30 = vfmaq_laneq_f16(v30, v18, va2, 6); \
+  v31 = vfmaq_laneq_f16(v31, v18, va2, 7); \
+  va3 = vld1q_f16(a + 24);                 \
+  v19 = vld1q_f16(b + 24);                 \
+  v24 = vfmaq_laneq_f16(v24, v19, va3, 0); \
+  v25 = vfmaq_laneq_f16(v25, v19, va3, 1); \
+  v26 = vfmaq_laneq_f16(v26, v19, va3, 2); \
+  v27 = vfmaq_laneq_f16(v27, v19, va3, 3); \
+  v28 = vfmaq_laneq_f16(v28, v19, va3, 4); \
+  v29 = vfmaq_laneq_f16(v29, v19, va3, 5); \
+  v30 = vfmaq_laneq_f16(v30, v19, va3, 6); \
+  v31 = vfmaq_laneq_f16(v31, v19, va3, 7); \
+  __builtin_prefetch(b + 32, 0, 3);        \
+  __builtin_prefetch(a + 32, 0, 3);        \
+  l += 4;                                  \
+  b += 8 * 4;                              \
+  a += 8 * 4;
+
+// 3. Partial sum 64 digits : Best accuracy, worst latency
+#define KERNEL_8x8_ACC1()                  \
+  v24 = vdupq_n_f16(0.F);                  \
+  v25 = vdupq_n_f16(0.F);                  \
+  v26 = vdupq_n_f16(0.F);                  \
+  v27 = vdupq_n_f16(0.F);                  \
+  v28 = vdupq_n_f16(0.F);                  \
+  v29 = vdupq_n_f16(0.F);                  \
+  v30 = vdupq_n_f16(0.F);                  \
+  v31 = vdupq_n_f16(0.F);                  \
+  va0 = vld1q_f16(a);                      \
+  v16 = vld1q_f16(b);                      \
+  v24 = vfmaq_laneq_f16(v24, v16, va0, 0); \
+  v25 = vfmaq_laneq_f16(v25, v16, va0, 1); \
+  v26 = vfmaq_laneq_f16(v26, v16, va0, 2); \
+  v27 = vfmaq_laneq_f16(v27, v16, va0, 3); \
+  v28 = vfmaq_laneq_f16(v28, v16, va0, 4); \
+  v29 = vfmaq_laneq_f16(v29, v16, va0, 5); \
+  v30 = vfmaq_laneq_f16(v30, v16, va0, 6); \
+  v31 = vfmaq_laneq_f16(v31, v16, va0, 7); \
+  __builtin_prefetch(b + 8, 0, 3);         \
+  __builtin_prefetch(a + 8, 0, 3);         \
+  l += 1;                                  \
+  b += 8 * 1;                              \
+  a += 8 * 1;
+
 /**
  * @brief hgemm 8x8 kernel sc = sa * sb
  *
@@ -37,138 +218,22 @@ void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
       __builtin_prefetch(b, 0, 3);
       __builtin_prefetch(a, 0, 3);
 
-      float16x8_t v24 = {0};
-      float16x8_t v25 = {0};
-      float16x8_t v26 = {0};
-      float16x8_t v27 = {0};
-      float16x8_t v28 = {0};
-      float16x8_t v29 = {0};
-      float16x8_t v30 = {0};
-      float16x8_t v31 = {0};
+      float16x8_t v16, v17, v18, v19, v20, v21, v22, v23;
+      float16x8_t v24, v25, v26, v27, v28, v29, v30, v31;
+      float16x8_t va0, va1, va2, va3, va4, va5, va6, va7;
+      l = 0;
+      for (; l < K;) {
+        KERNEL_8x8_ACC8();
 
-      for (l = 0; l < K; l += VL_FP16) {
-        float16x8_t v0 = vld1q_f16(b);
-        float16x8_t v16 = vld1q_f16(a);
-
-        v24 = vfmaq_laneq_f16(v24, v0, v16, 0);
-        v25 = vfmaq_laneq_f16(v25, v0, v16, 1);
-        v26 = vfmaq_laneq_f16(v26, v0, v16, 2);
-        v27 = vfmaq_laneq_f16(v27, v0, v16, 3);
-        v28 = vfmaq_laneq_f16(v28, v0, v16, 4);
-        v29 = vfmaq_laneq_f16(v29, v0, v16, 5);
-        v30 = vfmaq_laneq_f16(v30, v0, v16, 6);
-        v31 = vfmaq_laneq_f16(v31, v0, v16, 7);
-
-        float16x8_t v1 = vld1q_f16(b + 8);
-        float16x8_t v17 = vld1q_f16(a + 8);
-
-        v24 = vfmaq_laneq_f16(v24, v1, v17, 0);
-        v25 = vfmaq_laneq_f16(v25, v1, v17, 1);
-        v26 = vfmaq_laneq_f16(v26, v1, v17, 2);
-        v27 = vfmaq_laneq_f16(v27, v1, v17, 3);
-        v28 = vfmaq_laneq_f16(v28, v1, v17, 4);
-        v29 = vfmaq_laneq_f16(v29, v1, v17, 5);
-        v30 = vfmaq_laneq_f16(v30, v1, v17, 6);
-        v31 = vfmaq_laneq_f16(v31, v1, v17, 7);
-
-        float16x8_t v2 = vld1q_f16(b + 16);
-        float16x8_t v18 = vld1q_f16(a + 16);
-
-        v24 = vfmaq_laneq_f16(v24, v2, v18, 0);
-        v25 = vfmaq_laneq_f16(v25, v2, v18, 1);
-        v26 = vfmaq_laneq_f16(v26, v2, v18, 2);
-        v27 = vfmaq_laneq_f16(v27, v2, v18, 3);
-        v28 = vfmaq_laneq_f16(v28, v2, v18, 4);
-        v29 = vfmaq_laneq_f16(v29, v2, v18, 5);
-        v30 = vfmaq_laneq_f16(v30, v2, v18, 6);
-        v31 = vfmaq_laneq_f16(v31, v2, v18, 7);
-
-        float16x8_t v3 = vld1q_f16(b + 24);
-        float16x8_t v19 = vld1q_f16(a + 24);
-
-        v24 = vfmaq_laneq_f16(v24, v3, v19, 0);
-        v25 = vfmaq_laneq_f16(v25, v3, v19, 1);
-        v26 = vfmaq_laneq_f16(v26, v3, v19, 2);
-        v27 = vfmaq_laneq_f16(v27, v3, v19, 3);
-        v28 = vfmaq_laneq_f16(v28, v3, v19, 4);
-        v29 = vfmaq_laneq_f16(v29, v3, v19, 5);
-        v30 = vfmaq_laneq_f16(v30, v3, v19, 6);
-        v31 = vfmaq_laneq_f16(v31, v3, v19, 7);
-
-        float16x8_t v4 = vld1q_f16(b + 32);
-        float16x8_t v20 = vld1q_f16(a + 32);
-
-        v24 = vfmaq_laneq_f16(v24, v4, v20, 0);
-        v25 = vfmaq_laneq_f16(v25, v4, v20, 1);
-        v26 = vfmaq_laneq_f16(v26, v4, v20, 2);
-        v27 = vfmaq_laneq_f16(v27, v4, v20, 3);
-        v28 = vfmaq_laneq_f16(v28, v4, v20, 4);
-        v29 = vfmaq_laneq_f16(v29, v4, v20, 5);
-        v30 = vfmaq_laneq_f16(v30, v4, v20, 6);
-        v31 = vfmaq_laneq_f16(v31, v4, v20, 7);
-
-        float16x8_t v5 = vld1q_f16(b + 40);
-        float16x8_t v21 = vld1q_f16(a + 40);
-
-        v24 = vfmaq_laneq_f16(v24, v5, v21, 0);
-        v25 = vfmaq_laneq_f16(v25, v5, v21, 1);
-        v26 = vfmaq_laneq_f16(v26, v5, v21, 2);
-        v27 = vfmaq_laneq_f16(v27, v5, v21, 3);
-        v28 = vfmaq_laneq_f16(v28, v5, v21, 4);
-        v29 = vfmaq_laneq_f16(v29, v5, v21, 5);
-        v30 = vfmaq_laneq_f16(v30, v5, v21, 6);
-        v31 = vfmaq_laneq_f16(v31, v5, v21, 7);
-
-        float16x8_t v6 = vld1q_f16(b + 48);
-        float16x8_t v22 = vld1q_f16(a + 48);
-
-        v24 = vfmaq_laneq_f16(v24, v6, v22, 0);
-        v25 = vfmaq_laneq_f16(v25, v6, v22, 1);
-        v26 = vfmaq_laneq_f16(v26, v6, v22, 2);
-        v27 = vfmaq_laneq_f16(v27, v6, v22, 3);
-        v28 = vfmaq_laneq_f16(v28, v6, v22, 4);
-        v29 = vfmaq_laneq_f16(v29, v6, v22, 5);
-        v30 = vfmaq_laneq_f16(v30, v6, v22, 6);
-        v31 = vfmaq_laneq_f16(v31, v6, v22, 7);
-
-        float16x8_t v7 = vld1q_f16(b + 56);
-        float16x8_t v23 = vld1q_f16(a + 56);
-
-        v24 = vfmaq_laneq_f16(v24, v7, v23, 0);
-        v25 = vfmaq_laneq_f16(v25, v7, v23, 1);
-        v26 = vfmaq_laneq_f16(v26, v7, v23, 2);
-        v27 = vfmaq_laneq_f16(v27, v7, v23, 3);
-        v28 = vfmaq_laneq_f16(v28, v7, v23, 4);
-        v29 = vfmaq_laneq_f16(v29, v7, v23, 5);
-        v30 = vfmaq_laneq_f16(v30, v7, v23, 6);
-        v31 = vfmaq_laneq_f16(v31, v7, v23, 7);
-
-        __builtin_prefetch(b + 64, 0, 3);
-        __builtin_prefetch(a + 64, 0, 3);
-
-        b += 64;
-        a += 64;
+        vst1q_f16(c, vaddq_f16(vld1q_f16(c), v24));
+        vst1q_f16(c + ldc, vaddq_f16(vld1q_f16(c + ldc), v25));
+        vst1q_f16(c + 2 * ldc, vaddq_f16(vld1q_f16(c + 2 * ldc), v26));
+        vst1q_f16(c + 3 * ldc, vaddq_f16(vld1q_f16(c + 3 * ldc), v27));
+        vst1q_f16(c + 4 * ldc, vaddq_f16(vld1q_f16(c + 4 * ldc), v28));
+        vst1q_f16(c + 5 * ldc, vaddq_f16(vld1q_f16(c + 5 * ldc), v29));
+        vst1q_f16(c + 6 * ldc, vaddq_f16(vld1q_f16(c + 6 * ldc), v30));
+        vst1q_f16(c + 7 * ldc, vaddq_f16(vld1q_f16(c + 7 * ldc), v31));
       }
-
-      v24 = vaddq_f16(vld1q_f16(c), v24);
-      v25 = vaddq_f16(vld1q_f16(c + ldc), v25);
-      v26 = vaddq_f16(vld1q_f16(c + 2 * ldc), v26);
-      v27 = vaddq_f16(vld1q_f16(c + 3 * ldc), v27);
-      v28 = vaddq_f16(vld1q_f16(c + 4 * ldc), v28);
-      v29 = vaddq_f16(vld1q_f16(c + 5 * ldc), v29);
-      v30 = vaddq_f16(vld1q_f16(c + 6 * ldc), v30);
-      v31 = vaddq_f16(vld1q_f16(c + 7 * ldc), v31);
-
-      vst1q_f16(c, v24);
-      vst1q_f16(c + ldc, v25);
-      vst1q_f16(c + 2 * ldc, v26);
-      vst1q_f16(c + 3 * ldc, v27);
-      //
-      vst1q_f16(c + 4 * ldc, v28);
-      vst1q_f16(c + 5 * ldc, v29);
-      vst1q_f16(c + 6 * ldc, v30);
-      vst1q_f16(c + 7 * ldc, v31);
-
       c += 8;
       a -= 8 * K;
     }
@@ -203,111 +268,13 @@ void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
       __builtin_prefetch(b, 0, 3);
       __builtin_prefetch(a, 0, 3);
 
-      for (l = 0; l < K; l += VL_FP16) {
-        float16x8_t v24 = {0};
-        float16x8_t v25 = {0};
-        float16x8_t v26 = {0};
-        float16x8_t v27 = {0};
-        float16x8_t v28 = {0};
-        float16x8_t v29 = {0};
-        float16x8_t v30 = {0};
-        float16x8_t v31 = {0};
+      float16x8_t v16, v17, v18, v19, v20, v21, v22, v23;
+      float16x8_t v24, v25, v26, v27, v28, v29, v30, v31;
+      float16x8_t va0, va1, va2, va3, va4, va5, va6, va7;
+      l = 0;
 
-        float16x8_t v0 = vld1q_f16(b);
-        float16x8_t v16 = vld1q_f16(a);
-
-        v24 = vfmaq_laneq_f16(v24, v0, v16, 0);
-        v25 = vfmaq_laneq_f16(v25, v0, v16, 1);
-        v26 = vfmaq_laneq_f16(v26, v0, v16, 2);
-        v27 = vfmaq_laneq_f16(v27, v0, v16, 3);
-        v28 = vfmaq_laneq_f16(v28, v0, v16, 4);
-        v29 = vfmaq_laneq_f16(v29, v0, v16, 5);
-        v30 = vfmaq_laneq_f16(v30, v0, v16, 6);
-        v31 = vfmaq_laneq_f16(v31, v0, v16, 7);
-
-        float16x8_t v1 = vld1q_f16(b + 8);
-        float16x8_t v17 = vld1q_f16(a + 8);
-
-        v24 = vfmaq_laneq_f16(v24, v1, v17, 0);
-        v25 = vfmaq_laneq_f16(v25, v1, v17, 1);
-        v26 = vfmaq_laneq_f16(v26, v1, v17, 2);
-        v27 = vfmaq_laneq_f16(v27, v1, v17, 3);
-        v28 = vfmaq_laneq_f16(v28, v1, v17, 4);
-        v29 = vfmaq_laneq_f16(v29, v1, v17, 5);
-        v30 = vfmaq_laneq_f16(v30, v1, v17, 6);
-        v31 = vfmaq_laneq_f16(v31, v1, v17, 7);
-
-        float16x8_t v2 = vld1q_f16(b + 16);
-        float16x8_t v18 = vld1q_f16(a + 16);
-
-        v24 = vfmaq_laneq_f16(v24, v2, v18, 0);
-        v25 = vfmaq_laneq_f16(v25, v2, v18, 1);
-        v26 = vfmaq_laneq_f16(v26, v2, v18, 2);
-        v27 = vfmaq_laneq_f16(v27, v2, v18, 3);
-        v28 = vfmaq_laneq_f16(v28, v2, v18, 4);
-        v29 = vfmaq_laneq_f16(v29, v2, v18, 5);
-        v30 = vfmaq_laneq_f16(v30, v2, v18, 6);
-        v31 = vfmaq_laneq_f16(v31, v2, v18, 7);
-
-        float16x8_t v3 = vld1q_f16(b + 24);
-        float16x8_t v19 = vld1q_f16(a + 24);
-
-        v24 = vfmaq_laneq_f16(v24, v3, v19, 0);
-        v25 = vfmaq_laneq_f16(v25, v3, v19, 1);
-        v26 = vfmaq_laneq_f16(v26, v3, v19, 2);
-        v27 = vfmaq_laneq_f16(v27, v3, v19, 3);
-        v28 = vfmaq_laneq_f16(v28, v3, v19, 4);
-        v29 = vfmaq_laneq_f16(v29, v3, v19, 5);
-        v30 = vfmaq_laneq_f16(v30, v3, v19, 6);
-        v31 = vfmaq_laneq_f16(v31, v3, v19, 7);
-
-        float16x8_t v4 = vld1q_f16(b + 32);
-        float16x8_t v20 = vld1q_f16(a + 32);
-
-        v24 = vfmaq_laneq_f16(v24, v4, v20, 0);
-        v25 = vfmaq_laneq_f16(v25, v4, v20, 1);
-        v26 = vfmaq_laneq_f16(v26, v4, v20, 2);
-        v27 = vfmaq_laneq_f16(v27, v4, v20, 3);
-        v28 = vfmaq_laneq_f16(v28, v4, v20, 4);
-        v29 = vfmaq_laneq_f16(v29, v4, v20, 5);
-        v30 = vfmaq_laneq_f16(v30, v4, v20, 6);
-        v31 = vfmaq_laneq_f16(v31, v4, v20, 7);
-
-        float16x8_t v5 = vld1q_f16(b + 40);
-        float16x8_t v21 = vld1q_f16(a + 40);
-
-        v24 = vfmaq_laneq_f16(v24, v5, v21, 0);
-        v25 = vfmaq_laneq_f16(v25, v5, v21, 1);
-        v26 = vfmaq_laneq_f16(v26, v5, v21, 2);
-        v27 = vfmaq_laneq_f16(v27, v5, v21, 3);
-        v28 = vfmaq_laneq_f16(v28, v5, v21, 4);
-        v29 = vfmaq_laneq_f16(v29, v5, v21, 5);
-        v30 = vfmaq_laneq_f16(v30, v5, v21, 6);
-        v31 = vfmaq_laneq_f16(v31, v5, v21, 7);
-
-        float16x8_t v6 = vld1q_f16(b + 48);
-        float16x8_t v22 = vld1q_f16(a + 48);
-
-        v24 = vfmaq_laneq_f16(v24, v6, v22, 0);
-        v25 = vfmaq_laneq_f16(v25, v6, v22, 1);
-        v26 = vfmaq_laneq_f16(v26, v6, v22, 2);
-        v27 = vfmaq_laneq_f16(v27, v6, v22, 3);
-        v28 = vfmaq_laneq_f16(v28, v6, v22, 4);
-        v29 = vfmaq_laneq_f16(v29, v6, v22, 5);
-        v30 = vfmaq_laneq_f16(v30, v6, v22, 6);
-        v31 = vfmaq_laneq_f16(v31, v6, v22, 7);
-
-        float16x8_t v7 = vld1q_f16(b + 56);
-        float16x8_t v23 = vld1q_f16(a + 56);
-
-        v24 = vfmaq_laneq_f16(v24, v7, v23, 0);
-        v25 = vfmaq_laneq_f16(v25, v7, v23, 1);
-        v26 = vfmaq_laneq_f16(v26, v7, v23, 2);
-        v27 = vfmaq_laneq_f16(v27, v7, v23, 3);
-        v28 = vfmaq_laneq_f16(v28, v7, v23, 4);
-        v29 = vfmaq_laneq_f16(v29, v7, v23, 5);
-        v30 = vfmaq_laneq_f16(v30, v7, v23, 6);
-        v31 = vfmaq_laneq_f16(v31, v7, v23, 7);
+      for (; l < K;) {
+        KERNEL_8x8_ACC8();
 
         vst1q_f32(c, vaddq_f32(vld1q_f32(c), vcvt_f32_f16(vget_low_f16(v24))));
         vst1q_f32(
@@ -347,12 +314,6 @@ void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
                                          vcvt_f32_f16(vget_low_f16(v31))));
         vst1q_f32(c + 4 + 7 * ldc, vaddq_f32(vld1q_f32(c + 4 + 7 * ldc),
                                              vcvt_f32_f16(vget_high_f16(v31))));
-
-        __builtin_prefetch(b + 64, 0, 3);
-        __builtin_prefetch(a + 64, 0, 3);
-
-        b += 64;
-        a += 64;
       }
 
       c += 8;

--- a/nntrainer/tensor/hgemm/hgemm_kernel_pack.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_pack.h
@@ -361,7 +361,7 @@ void packing_B8(unsigned int K, unsigned int N, const __fp16 *src,
  * @param dst output of packed data of the matrix
  */
 void packing_B16(unsigned int K, unsigned int N, const __fp16 *src,
-                unsigned int ldb, const __fp16 *dst) {
+                 unsigned int ldb, const __fp16 *dst) {
   assert(K != 0 && N != 0 && N % 16 == 0);
 
   for (int i = 0; i < K; i++) {
@@ -378,4 +378,3 @@ void packing_B16(unsigned int K, unsigned int N, const __fp16 *src,
     }
   }
 }
-

--- a/test/unittest/unittest_nntrainer_tensor_neon_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_neon_fp16.cpp
@@ -360,17 +360,17 @@ TEST(nntrainer_Tensor, sum_gemv_2_10) {
   EXPECT_IN_RANGE((float)cosSimNeon, 0.99, 1);
 }
 
-TEST(nntrainer_Tensor, dot_gemm_16_8_16) {
+TEST(nntrainer_Tensor, dot_gemm_16_16_16) {
   /// @note GEMM : A X B = C
   int batch = 1;
   int channel = 1;
-  int height = 8;
+  int height = 16;
   int width = 16;
 
-  int height_b = 8;
+  int height_b = 16;
   int width_b = 16;
 
-  bool transA = true;
+  bool transA = false;
   bool transB = false;
 
   const float alpha = 1e-1;
@@ -479,15 +479,15 @@ TEST(nntrainer_Tensor, dot_gemm_1024_1024_1024) {
   EXPECT_IN_RANGE((float)cosSimNeon, 0.99, 1);
 }
 
-TEST(nntrainer_Tensor, dot_gemm_50_768_96000) {
+TEST(nntrainer_Tensor, dot_gemm_768) {
   /// @note GEMM : A X B = C
   int batch = 1;
   int channel = 1;
-  int height = 1;
+  int height = 768;
   int width = 768;
 
   int height_b = 768;
-  int width_b = 10000;
+  int width_b = 768;
 
   bool transA = false;
   bool transB = false;
@@ -662,7 +662,7 @@ TEST(nntrainer_Tensor, dot_gemv_768_96000) {
   /// @note GEMV : A X B = C
   int batch = 1;
   int channel = 1;
-  int height = 50;
+  int height = 1;
   int width = 768;
 
   int height_b = 768;


### PR DESCRIPTION
This commit proposes a 8x16 kernel for Half-precision GEMM
Note that this is not an '100%' optimized version of HGEMM, but still better than before.
Following is unittest output with f16-f32 partial accumulated HGEMM.
Fine accuracy with better latency.

> **mean latency ( TC = 20 )**

| GEMM dimension | fp32 (cblas) | prev | 8x8 | 8x16 |
| --- | --- | --- | --- | --- |
| 4096 square | 2087 ms  | 7172 ms | ... | **1964 ms** |
| 2048 square | 260 ms  | 413 ms | ... | **250 ms** |
| 1024 square | 34 ms  | 52 ms | ... | **30 ms** |
| 768 square | 13 ms | 18 ms | ... | **11 ms** |
| 256X1440X256 | 2869 mcrs | 3807 mcrs | ... | **2544 mcrs** |
| 256X256X1440 | 2929 mcrs | 3950 mcrs | ... | **2467 mcrs** |
| 8X1440X8 | 5 mcrs | **5 mcrs** | ... | 10 mcrs |
| 8X8X1440 | 5 mcrs | **4 mcrs** | ... | 8 mcrs |