### PR TITLE
[Docs] Fix readme in Applications dir

### DIFF
--- a/Applications/Custom/README.md
+++ b/Applications/Custom/README.md
@@ -22,4 +22,4 @@ There are two ways to apply custom object to the code.
 
 
 1. **Pow Layer**: A custom layer object which get x -> returns x^(exponent), exponent can be set by `layer.setProperty({"exponent={n}"});`.
-2. **Mean Absoulute Error(MAE) Loss Layer**: A loss layer object which calculates MAE.
+2. **Mean Absolute Error(MAE) Loss Layer**: A loss layer object which calculates MAE.

--- a/Applications/Custom/mae_loss.h
+++ b/Applications/Custom/mae_loss.h
@@ -4,7 +4,7 @@
  *
  * @file   mae_loss.h
  * @date   10 June 2021
- * @brief  This file contains the mean absoulte error loss as a sample layer
+ * @brief  This file contains the mean absolute error loss as a sample layer
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug    No known bugs except for NYI items

--- a/Applications/README.md
+++ b/Applications/README.md
@@ -28,10 +28,6 @@ An example to train resnet18 network.
 
 An example to train vgg16 network.
 
-#### [LSTM Example](https://github.com/nnstreamer/nntrainer/tree/main/Applications/LSTM)
-
-An example to train LSTM network.
-
 #### [ProductRating Example](https://github.com/nnstreamer/nntrainer/tree/main/Applications/ProductRatings)
 
 This application contains a simple embedding-based model that predicts ratings given a user and a product.

--- a/Applications/YOLO/jni/reorg_layer.cpp
+++ b/Applications/YOLO/jni/reorg_layer.cpp
@@ -7,7 +7,7 @@
  * @todo support in-place operation. we can get channel, height, width
  * coordinate from index of buffer memory. then we can use reorganizePos and
  * restorePos func
- * @brief  This file contains the mean absoulte error loss as a sample layer
+ * @brief  This file contains the mean absolute error loss as a sample layer
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>
  * @bug    No known bugs except for NYI items

--- a/Applications/YOLO/jni/reorg_layer.h
+++ b/Applications/YOLO/jni/reorg_layer.h
@@ -4,7 +4,7 @@
  *
  * @file   reorganization.h
  * @date   4 April 2023
- * @brief  This file contains the mean absoulte error loss as a sample layer
+ * @brief  This file contains the mean absolute error loss as a sample layer
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>
  * @bug    No known bugs except for NYI items


### PR DESCRIPTION
Remove LSTM example in Applications/README.md

- existing link to LSTM example does not work
- user can find LSTM example in Layers dir
  + LSTM dir merged to Layers dir (in #2107)
- delete LSTM example in order to reduce confusion

**Self evaluation:**
1. Build test:  [X]Passed [ ]Failed [ ]Skipped
2. Run test:    [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Boseong Seo <suzy13549@snu.ac.kr>