### PR TITLE
Add Softplus activation function @open sesame 04/15 10:41

### DIFF
--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -78,6 +78,9 @@ public:
       in_place = false;
       this->setActivation<Tensor>(gelu<T>, geluPrime<T>);
       break;
+    case ActivationType::ACT_SOFTPLUS:
+      this->setActivation<T>(softplus<T>, softplusPrime<T>);
+      break;
     case ActivationType::ACT_NONE:
       this->setActivation<T>(no_op<T>, no_op_prime<T>);
       break;
@@ -345,6 +348,27 @@ public:
   template <typename T = float> static T leakyReluPrime(T x) {
     return x >= static_cast<T>(0.0) ? static_cast<T>(1.0)
                                     : static_cast<T>(NEGATIVE_SLOPE);
+  }
+
+  /**
+   * @brief     Softplus activation function
+   * @tparam T type of an input/output
+   * @param x input
+   * @return T type output
+   */
+  template <typename T = float> static T softplus(T x) {
+    /** TODO: Change beta to be a property */
+    return static_cast<T>(log(1 + exp_util<T>(beta * x)) / beta);
+  }
+
+  /**
+   * @brief     derivative softplus function
+   * @tparam T type of an input/output
+   * @param x input
+   * @return T type output
+   */
+  template <typename T = float> static T softplusPrime(T x) {
+    return sigmoid<T>(beta * x);
   }
 
   /**
@@ -621,6 +645,7 @@ public:
 
 private:
   constexpr static inline float alpha = 1.0f; /**< alpha for elu */
+  constexpr static inline float beta = 1.0f;  /**< beta for Softplus */
 
   std::function<Tensor &(Tensor const &, Tensor &)> _act_fn;
   std::function<Tensor &(Tensor const &, Tensor &, Tensor &, Tensor const &)>

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -36,6 +36,7 @@ enum class ActivationType {
   ACT_SWISH,      /**< Swish */
   ACT_GELU,       /**< GELU */
   ACT_SOFTMAX,    /**< softmax */
+  ACT_SOFTPLUS,   /**< softplus */
   ACT_LEAKY_RELU, /**< Leaky ReLU */
   ACT_ELU,        /**< ELU */
   ACT_NONE,       /**< no op */

--- a/test/unittest/unittest_nntrainer_activations.cpp
+++ b/test/unittest/unittest_nntrainer_activations.cpp
@@ -122,6 +122,60 @@ TEST(nntrainer_activation, softmax_prime_02_n) {
                std::invalid_argument);
 }
 
+TEST(nntrainer_activation, softplus_01_p) {
+  int batch = 3;
+  int channel = 1;
+  int height = 1;
+  int width = 10;
+
+  float answer[30] = {
+    0.51301527, 0.55435520, 0.59813887, 0.64439666, 0.69314718, 0.74439669,
+    0.79813886, 0.85435522, 0.91301525, 0.97407699, 0.37110066, 0.43748793,
+    0.51301527, 0.59813887, 0.69314718, 0.79813886, 0.91301525, 1.03748798,
+    1.17110062, 1.31326163, 0.26328245, 0.34115386, 0.43748793, 0.55435526,
+    0.69314718, 0.85435528, 1.03748798, 1.24115384, 1.46328247, 1.70141327};
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
+
+  nntrainer::Tensor softplus_result =
+    input.apply<float>(nntrainer::ActiFunc::softplus<float>);
+
+  float *data = softplus_result.getData();
+  ASSERT_NE(nullptr, data);
+
+  for (int i = 0; i < batch * height * width; ++i) {
+    EXPECT_NEAR(data[i], answer[i], tolerance);
+  }
+}
+
+TEST(nntrainer_activation, softplusPrime_01_p) {
+  int batch = 3;
+  int channel = 1;
+  int height = 1;
+  int width = 10;
+
+  float answer[30] = {
+    0.40131232, 0.42555746, 0.45016599, 0.47502083, 0.50000000, 0.52497917,
+    0.54983401, 0.57444251, 0.59868765, 0.62245935, 0.31002554, 0.35434368,
+    0.40131232, 0.45016599, 0.50000000, 0.54983401, 0.59868771, 0.64565635,
+    0.68997449, 0.73105860, 0.23147520, 0.28905049, 0.35434368, 0.42555746,
+    0.50000000, 0.57444257, 0.64565635, 0.71094948, 0.76852477, 0.81757450};
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, (l - 4) * 0.1 * (i + 1));
+
+  nntrainer::Tensor softplus_prime_result =
+    input.apply<float>(nntrainer::ActiFunc::softplusPrime<float>);
+
+  float *data = softplus_prime_result.getData();
+  ASSERT_NE(nullptr, data);
+
+  for (int i = 0; i < batch * height * width; ++i) {
+    EXPECT_NEAR(data[i], answer[i], tolerance);
+  }
+}
+
 TEST(nntrainer_activation, sigmoid_01_p) {
   int batch = 3;
   int channel = 1;


### PR DESCRIPTION
- Now, user can use Softplus activation function like torch or tensor flow.
- Furthermore, we can use this function to build Mish or other activation functions

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: heka1024 <heka1024@gmail.com>