### PR TITLE
[LoRA] add alpha parameter to LoRA (fc_layer) @open sesame 04/23 09:33

### DIFF
--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -1340,7 +1340,17 @@ class LoraRank : public PositiveIntegerProperty {
 public:
   static constexpr const char *key = "lora_rank"; /**< unique key to access */
   using prop_tag = uint_prop_tag;                 /**< property type */
-  ;
+};
+
+/**
+ * @brief LoRA alpha parameter
+ * @details It is used to set the scaling factor of LoRA, which is calculated as
+ * `scaling = alpha / rank` in the original paper.
+ */
+class LoraAlpha : public PositiveIntegerProperty {
+public:
+  static constexpr const char *key = "lora_alpha"; /**< unique key to access */
+  using prop_tag = uint_prop_tag;                  /**< property type */
 };
 
 /**

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -106,9 +106,13 @@ public:
   inline static const std::string type = "fully_connected";
 
 private:
-  std::tuple<props::Unit, props::LoraRank>
-    fc_props; /**< fc layer properties : unit - number of output neurons,
-                 lora_rank : rank of lora (optional) */
+  float lora_scaling;
+  std::tuple<props::Unit, props::LoraRank, props::LoraAlpha>
+    fc_props;                             /**< fc layer properties :
+                                                unit - number of output neurons,
+                                                lora_rank - rank of lora (optional)
+                                                lora_scaling - scaling factor of LoRA apply, i.e.,
+                                             lora_scaling = alpha / lora_rank */
   std::array<unsigned int, 2> weight_idx; /**< indices of the weights */
   std::array<unsigned int, 2> lora_idx;   /**< indices of the lora weights */
 };

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -108,7 +108,7 @@ void Exporter::saveTflResult(
 
 template <>
 void Exporter::saveTflResult(
-  const std::tuple<props::Unit, props::LoraRank> &props,
+  const std::tuple<props::Unit, props::LoraRank, props::LoraAlpha> &props,
   const FullyConnectedLayer *self) {
   createIfNull(tf_node);
   tf_node->setOpType(tflite::BuiltinOperator_FULLY_CONNECTED);

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -284,7 +284,7 @@ class FullyConnectedLayer;
  */
 template <>
 void Exporter::saveTflResult(
-  const std::tuple<props::Unit, props::LoraRank> &props,
+  const std::tuple<props::Unit, props::LoraRank, props::LoraAlpha> &props,
   const FullyConnectedLayer *self);
 
 class ActivationLayer;


### PR DESCRIPTION
This PR is reopened. It is updated from [#2539](https://github.com/nnstreamer/nntrainer/pull/2539), in the way of taking `lora_alpha` as a hyper-parameter instead of getting `lora_scaling` parameter directly.


- This commit adds `lora_alpha` parameter to LoRA (fc layer)
- In the original paper,they adopted `lora_alpha (uint)` as a parameter to derive the scaling factor internally, i.e., scaling = alpha / rank
- This commit takes `lora_alpha` as a hyper-parameter and apply the scaling factor to the LoRA layer.
- This commit's updates are summarized as follows:
	- `common_properties.h` : add LoraAlpha as a parameter.
	- `fc_layer.cpp`: update forwarding / calcGradient / calcDerivative func to apply scaling factor in LoRA computation
	- `fc_layer.h`: update to take LoraAlpha as fc_props, add `lora_scaling` as a member variable **(diff with  [#2539](https://github.com/nnstreamer/nntrainer/pull/2539))**
	- `node_exporter.cpp/h`: add LoraAlpha as a parameter in tf.export format of fc layer (to pass the test code)
- fix the code lines which may cause coverity issue.
- LoRA initialization is updated: **(diff with  [#2539](https://github.com/nnstreamer/nntrainer/pull/2539))**
	- LoRA A : ZEROS
	- LoRA B : Normal
- [TODO] update tf exporter of fc layer

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped