### PR TITLE
ci / remove cpp-linter's false positive reports.

### DIFF
--- a/.github/workflows/cpp_linter.yml
+++ b/.github/workflows/cpp_linter.yml
@@ -7,6 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: install dev packages
+        run: |
+          echo "Install mandatory dev packages to avoid false-positive reports from cpp-linter"
+          sudo apt-get update
+          sudo apt-get install libstdc++-*-dev
       - uses: cpp-linter/cpp-linter-action@v2.8.0
         id: linter
         env:


### PR DESCRIPTION
It gives an error of "iostream" not found.

Install libstdc++-dev for possible compilers.