### PR TITLE
[ hdot ] Use precision-enhanced hdot

### DIFF
--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -1192,51 +1192,29 @@ void haxpy(const unsigned int N, const float alpha, const __fp16 *X,
 }
 
 __fp16 hdot(const unsigned int N, const __fp16 *X, const __fp16 *Y) {
-
-  float16x8_t accX8 = vmovq_n_f16(0);
-  float16x4_t accX4 = vmov_n_f16(0);
+  float32x4_t accX0_3 = vmovq_n_f32(0.F);
+  float32x4_t accX4_7 = vmovq_n_f32(0.F);
 
   unsigned int idx = 0;
-  __fp16 ret = 0;
+  unsigned int N8 = (N >> 3) << 3;
+  float ret = 0;
 
-  // processing batch of 8
-  for (; (N - idx) >= 8; idx += 8) {
+  // Adaptive loop for batch size of 8
+  for (; idx < N8; idx += 8) {
     float16x8_t x = vld1q_f16(&X[idx]);
     float16x8_t y = vld1q_f16(&Y[idx]);
 
-    // x*y + accX8 -> accX8
-    accX8 = vfmaq_f16(accX8, x, y);
+    x = vmulq_f16(x, y);
+    accX0_3 = vaddq_f32(accX0_3, vcvt_f32_f16(vget_low_f16(x)));
+    accX4_7 = vaddq_f32(accX4_7, vcvt_f32_f16(vget_high_f16(x)));
   }
+  ret += vaddvq_f32(accX0_3) + vaddvq_f32(accX4_7);
 
-  // check at least one batch of 8 is processed
-  if (N - 8 >= 0) {
-    __fp16 result[8];
-    vst1q_f16(result, accX8);
-    for (unsigned int i = 0; i < 8; i++)
-      ret += result[i];
-  }
-
-  // processing remaining batch of 4
-  for (; (N - idx) >= 4; idx += 4) {
-    float16x4_t x = vld1_f16(&X[idx]);
-    float16x4_t y = vld1_f16(&Y[idx]);
-
-    // x*y + accX4 -> accX4
-    accX4 = vfma_f16(accX4, x, y);
-  }
-
-  // check at least one batch of 4 is processed
-  if (N % 8 >= 4) {
-    __fp16 result[4];
-    vst1_f16(result, accX4);
-    ret += result[0] + result[1] + result[2] + result[3];
-  }
-
-  // pocessing remaining values
+  // Loop for remaining indices
   for (; idx < N; idx++)
     ret += X[idx] * Y[idx];
 
-  return ret;
+  return static_cast<__fp16>(ret);
 }
 
 __fp16 hnrm2(const unsigned int N, const __fp16 *X) {


### PR DESCRIPTION
**hdot : vec(1 x K ) x vec(K X 1 ) -> 1 (scalar)**

- Previous hdot was using full-fp16.
- Since this is also one of dimension-shrinking computations, should use inter-fp32 values to enhance precision.
- This has not been detected due to small dimension Tensor usage in unittest. Add bigger-sized test case accordingly.

### A. Accuracy w.r.t cblas-f32 (mse)
| dim | hdot-f16 (previous) | hdot-f16f32 (now) |
| --- | --- | --- |
| 1024 | 0.250061 | 3.72529e-09 |
| 2048 | 2.07308 | 0.00362171 |
| 4096 | 11.8475 | 0.195379 |

### B. Latency
> Since this is nanosec-unit result, almost trivial

| dim | hdot-f16 | hdot-f16f32 | cblas-f32 |
| --- | --- | --- | --- |
| 1024 | 261 ns | 280 ns | 347 ns |
| 2048 | 328 ns | 359 ns | 1473 ns |
| 4096 | 508 ns | 562 ns | 909 ns |

Conclusion : Better accuracy with almost no latency deterioration

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped