### PR TITLE
[ hnrm2 ] Use precision-enhanced hnrm2

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -281,24 +281,28 @@ void sscal(const unsigned int N, const float alpha, _FP16 *X, const int incX) {
 
 static _FP16 snrm2_FP16(const unsigned int N, const _FP16 *X, const int incX) {
   unsigned int incx = abs(incX);
-  _FP16 sum = 0;
+  _FP16 sum;
   _FP16 tmp;
 #if (defined USE__FP16 && USE_NEON)
   if (incX == 1) {
     sum = nntrainer::neon::hnrm2(N, X);
   } else {
+    float sum32 = 0;
     for (unsigned int i = 0; i < N; i++) {
       tmp = X[i * incx];
-      sum += tmp * tmp;
+      sum32 += tmp * tmp;
     }
+    sum = static_cast<_FP16>(sqrt(sum32));
   }
 #else
+  float sum32 = 0;
   for (unsigned int i = 0; i < N; i++) {
     tmp = X[i * incx];
-    sum += tmp * tmp;
+    sum32 += tmp * tmp;
   }
+  sum = static_cast<_FP16>(sqrt(sum32));
 #endif
-  return static_cast<_FP16>(sqrt(sum));
+  return sum;
 }
 
 static void sgemm_FP16(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA,

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -1240,49 +1240,29 @@ __fp16 hdot(const unsigned int N, const __fp16 *X, const __fp16 *Y) {
 }
 
 __fp16 hnrm2(const unsigned int N, const __fp16 *X) {
-
-  float16x8_t accX8 = vmovq_n_f16(0);
-  float16x4_t accX4 = vmov_n_f16(0);
+  float32x4_t accX0_3 = vmovq_n_f32(0.F);
+  float32x4_t accX4_7 = vmovq_n_f32(0.F);
 
   unsigned int idx = 0;
-  __fp16 ret = 0;
+  unsigned int N8 = (N >> 3) << 3;
+  float ret = 0;
 
-  // processing batch of 8
-  for (; (N - idx) >= 8; idx += 8) {
-    float16x8_t x = vld1q_f16(&X[idx]);
+  // Adaptive loop for batch size of 8
+  for (; idx < N8; idx += 8) {
+    float16x8_t x0_7 = vld1q_f16(&X[idx]);
 
-    // x*x + accX8 -> accX8
-    accX8 = vfmaq_f16(accX8, x, x);
+    x0_7 = vmulq_f16(x0_7, x0_7);
+    accX0_3 = vaddq_f32(accX0_3, vcvt_f32_f16(vget_low_f16(x0_7)));
+    accX4_7 = vaddq_f32(accX4_7, vcvt_f32_f16(vget_high_f16(x0_7)));
   }
+  ret += vaddvq_f32(accX0_3) + vaddvq_f32(accX4_7);
 
-  // check at least one batch of 8 is processed
-  if (N - 8 >= 0) {
-    __fp16 result[8];
-    vst1q_f16(result, accX8);
-    for (unsigned int i = 0; i < 8; i++)
-      ret += result[i];
-  }
-
-  // processing remaining batch of 4
-  for (; (N - idx) >= 4; idx += 4) {
-    float16x4_t x = vld1_f16(&X[idx]);
-
-    // x*x + accX4 -> accX4
-    accX4 = vfma_f16(accX4, x, x);
-  }
-
-  // check at least one batch of 4 is processed
-  if (N % 8 >= 4) {
-    __fp16 result[4];
-    vst1_f16(result, accX4);
-    ret += result[0] + result[1] + result[2] + result[3];
-  }
-
-  // pocessing remaining values
-  for (; idx < N; idx++)
+  // Loop for remaining indices
+  for (; idx < N; idx++) {
     ret += X[idx] * X[idx];
+  }
 
-  return ret;
+  return static_cast<__fp16>(sqrt(ret));
 }
 
 void hscal(const unsigned int N, __fp16 *X, const float alpha) {


### PR DESCRIPTION
Along with #2555 I inspected through every custom-made half-precision calculation function, and `hnrm2` is the only one left that needs f16-f32 precision supplement.


**Proposed Changes**
- Previous hnrm2 was using full-fp16.
- Since this is also one of dimension-shrinking computation, should use inter-fp32 values to enhance precision.
- This has not been detected due to small dimension Tensor usage in unittest. Add higher dimension test case accordingly.
- Note that this function is responsible for `Tensor::l2norm()`, frequently used for mse loss computation.

### Differnece w.r.t. fp32-cblas
| dim | f16 (prev) | f16f32 (now) |
| --- | --- | --- |
| 768 | 282.233 | 0.232574 |

### Latency
> mean value ( TC = 100)
> Since this is nanosec-unit result, almost trivial

| dim | f16 | f16f32 | fp32-cblas | 
| --- | --- | --- | --- |
| 768 | 508 ns | 579 ns | 4242 ns |

Better accuracy with almost no latency deterioration

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped