### PR TITLE
[ hgemm/bugfix ] Consider small hgemm case @open sesame 05/13 21:35

### DIFF
--- a/nntrainer/tensor/hgemm/hgemm.cpp
+++ b/nntrainer/tensor/hgemm/hgemm.cpp
@@ -31,7 +31,7 @@
 
 void hgemm_noTrans(const __fp16 *A, const __fp16 *B, float *C32, unsigned int M,
                    unsigned int N, unsigned int K, float alpha, float beta) {
-  if (alpha == 1.F && beta == 0.F) {
+  if (alpha == 1.F && beta == 0.F && N > 4) {
     // used bitwise operator instead of modulo for performance
     // e.g (M % 8) is same as (M & 0x7) which will extract last 3 bits of M
     if ((M & 0x7) == 0 && (N & 0xF) == 0 && (K & 0x7) == 0) {


### PR DESCRIPTION
- Small means, for here, is smaller than: (4x4) * (4x4) 
- With hard-coded sized (4x4, 8x8, ...) kernel hgemm, matrix length that are smaller than unit vector length might fail.
- Toss such case to fallback. Such small sized gemm will take a few nanoseconds and therefore negligible.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: skykongkong8 <ss.kong@samsung.com>