### PR TITLE
[ hgemm ] Partial sum up to 2048 digits for more acceleration & trivial refactor @open sesame 05/10 10:47

### DIFF
--- a/nntrainer/tensor/hgemm/hgemm.cpp
+++ b/nntrainer/tensor/hgemm/hgemm.cpp
@@ -478,7 +478,6 @@ void hgemm_noTrans_4x4(unsigned int M, unsigned int N, unsigned int K,
   free(sb);
 }
 
-
 void hgemm_noTrans_4x8(unsigned int M, unsigned int N, unsigned int K,
                        const __fp16 *A, unsigned int lda, const __fp16 *B,
                        unsigned int ldb, __fp16 *C, unsigned int ldc,

--- a/nntrainer/tensor/hgemm/hgemm.cpp
+++ b/nntrainer/tensor/hgemm/hgemm.cpp
@@ -64,9 +64,9 @@ void hgemm_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
       hgemm_noTrans_4x8(M, N, K, A, K, B, N, C, N, alpha, beta);
     } else if ((M & 0x3) == 0 && (N & 0x3) == 0 && (K & 0x3) == 0) {
       hgemm_noTrans_4x4(M, N, K, A, K, B, N, C, N, alpha, beta);
-    } else if ((K & 0x7) == 0 && (N & 0x7) == 0) {
+    } else if ((N & 0x7) == 0 && (K & 0x7) == 0) {
       hgemm_noTrans_1x8(M, N, K, A, K, B, N, C, N, alpha, beta);
-    } else if ((K & 0x7) == 0 && (N & 0x3) == 0) {
+    } else if ((N & 0x3) == 0 && (K & 0x7) == 0) {
       hgemm_noTrans_1x4(M, N, K, A, K, B, N, C, N, alpha, beta);
     }
   }

--- a/nntrainer/tensor/hgemm/hgemm.h
+++ b/nntrainer/tensor/hgemm/hgemm.h
@@ -182,6 +182,26 @@ void hgemm_noTrans_8x8(unsigned int M, unsigned int N, unsigned int K,
                        float alpha = 1.F, float beta = 0.F);
 
 /**
+ * @brief hgemm noTrans computation with 4x4 kernel : C = A*B,
+ *
+ * @param M length of the row of matrix A
+ * @param N length of the col of matrix B
+ * @param K length of the col of matrix A
+ * @param A input matrix A
+ * @param lda length of the col of matrix C
+ * @param B input matrix B
+ * @param ldb length of the col of matrix C
+ * @param C output matrix C
+ * @param ldc length of the col of matrix C
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void hgemm_noTrans_4x4(unsigned int M, unsigned int N, unsigned int K,
+                       const __fp16 *A, unsigned int lda, const __fp16 *B,
+                       unsigned int ldb, float *C, unsigned int ldc,
+                       float alpha = 1.F, float beta = 0.F);
+
+/**
  * @brief hgemm noTrans computation with 8x8 kernel : C = A*B,
  *
  * @param M length of the row of matrix A

--- a/nntrainer/tensor/hgemm/hgemm_kernel_4x4.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_4x4.h
@@ -101,3 +101,88 @@ void hgemm_kernel_4x4(unsigned int M, unsigned int N, unsigned int K,
     b = sb;
   }
 }
+
+/**
+ * @brief hgemm 4x4 kernel sc = sa * sb
+ *
+ * @param m length of the row of matrix A
+ * @param n length of the col of matrix B
+ * @param k length of the col of matrix A
+ * @param sa sub-matrix of input matrix A
+ * @param sb sub-matrix of input matrix B
+ * @param sc sub-matrix of output matrix C
+ * @param ldc leading dimension of matrix C
+ */
+void hgemm_kernel_4x4(unsigned int M, unsigned int N, unsigned int K,
+                      __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc) {
+  assert(M > 0 && N > 0 && K > 0);
+  assert(M % 4 == 0 && N % 4 == 0 && K % 4 == 0);
+
+  __fp16 *a = sa, *b = sb;
+  float *c = sc;
+  unsigned int i, j, l;
+  for (i = 0; i < M; i += VL_FP16_HALF) {
+    for (j = 0; j < N; j += VL_FP16_HALF) {
+      __builtin_prefetch(b, 0, 3);
+      __builtin_prefetch(a, 0, 3);
+
+      float16x4_t v24 = {0};
+      float16x4_t v25 = {0};
+      float16x4_t v26 = {0};
+      float16x4_t v27 = {0};
+
+      for (l = 0; l < K; l += VL_FP16_HALF) {
+        float16x4_t v0 = vld1_f16(b);
+        float16x4_t v16 = vld1_f16(a);
+
+        v24 = vfma_lane_f16(v24, v0, v16, 0);
+        v25 = vfma_lane_f16(v25, v0, v16, 1);
+        v26 = vfma_lane_f16(v26, v0, v16, 2);
+        v27 = vfma_lane_f16(v27, v0, v16, 3);
+
+        float16x4_t v1 = vld1_f16(b + 4);
+        float16x4_t v17 = vld1_f16(a + 4);
+
+        v24 = vfma_lane_f16(v24, v1, v17, 0);
+        v25 = vfma_lane_f16(v25, v1, v17, 1);
+        v26 = vfma_lane_f16(v26, v1, v17, 2);
+        v27 = vfma_lane_f16(v27, v1, v17, 3);
+
+        float16x4_t v2 = vld1_f16(b + 8);
+        float16x4_t v18 = vld1_f16(a + 8);
+
+        v24 = vfma_lane_f16(v24, v2, v18, 0);
+        v25 = vfma_lane_f16(v25, v2, v18, 1);
+        v26 = vfma_lane_f16(v26, v2, v18, 2);
+        v27 = vfma_lane_f16(v27, v2, v18, 3);
+
+        float16x4_t v3 = vld1_f16(b + 12);
+        float16x4_t v19 = vld1_f16(a + 12);
+
+        v24 = vfma_lane_f16(v24, v3, v19, 0);
+        v25 = vfma_lane_f16(v25, v3, v19, 1);
+        v26 = vfma_lane_f16(v26, v3, v19, 2);
+        v27 = vfma_lane_f16(v27, v3, v19, 3);
+
+        __builtin_prefetch(b + 16, 0, 3);
+        __builtin_prefetch(a + 16, 0, 3);
+
+        b += 16;
+        a += 16;
+
+        vst1_f32(c, vadd_f32(vld1_f32(c), vcvt_f32_f16(v24)));
+        vst1_f32(c + ldc, vadd_f32(vld1_f32(c + ldc), vcvt_f32_f16(v25)));
+        vst1_f32(c + 2 * ldc, vadd_f32(vld1_f32(c + 2 * ldc), vcvt_f32_f16(v26)));
+        vst1_f32(c + 3 * ldc,  vadd_f32(vld1_f32(c + 3 * ldc), vcvt_f32_f16(v27)));
+      }
+
+      c += 4;
+      a -= 4 * K;
+    }
+    sc += ldc * 4;
+    c = sc;
+    a += 4 * K;
+    b = sb;
+  }
+}
+

--- a/nntrainer/tensor/hgemm/hgemm_kernel_4x4.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_4x4.h
@@ -14,7 +14,115 @@
 #include <hgemm_common.h>
 #include <stdlib.h>
 
-// 1. Partial sum 128 digits : worst accuracy, best latency
+// 1. Partial sum 256 digits : Medium accuracy, medium latency
+#define KERNEL_4x4_ACC16()               \
+  v24 = vdup_n_f16(0.F);                 \
+  v25 = vdup_n_f16(0.F);                 \
+  v26 = vdup_n_f16(0.F);                 \
+  v27 = vdup_n_f16(0.F);                 \
+  dv0 = vld1_f16(a);                     \
+  vb0 = vld1_f16(b);                     \
+  v24 = vfma_lane_f16(v24, vb0, dv0, 0); \
+  v25 = vfma_lane_f16(v25, vb0, dv0, 1); \
+  v26 = vfma_lane_f16(v26, vb0, dv0, 2); \
+  v27 = vfma_lane_f16(v27, vb0, dv0, 3); \
+  dv1 = vld1_f16(a + 4);                 \
+  vb1 = vld1_f16(b + 4);                 \
+  v24 = vfma_lane_f16(v24, vb1, dv1, 0); \
+  v25 = vfma_lane_f16(v25, vb1, dv1, 1); \
+  v26 = vfma_lane_f16(v26, vb1, dv1, 2); \
+  v27 = vfma_lane_f16(v27, vb1, dv1, 3); \
+  dv2 = vld1_f16(a + 4 * 2);             \
+  vb2 = vld1_f16(b + 4 * 2);             \
+  v24 = vfma_lane_f16(v24, vb2, dv2, 0); \
+  v25 = vfma_lane_f16(v25, vb2, dv2, 1); \
+  v26 = vfma_lane_f16(v26, vb2, dv2, 2); \
+  v27 = vfma_lane_f16(v27, vb2, dv2, 3); \
+  dv3 = vld1_f16(a + 4 * 3);             \
+  vb3 = vld1_f16(b + 4 * 3);             \
+  v24 = vfma_lane_f16(v24, vb3, dv3, 0); \
+  v25 = vfma_lane_f16(v25, vb3, dv3, 1); \
+  v26 = vfma_lane_f16(v26, vb3, dv3, 2); \
+  v27 = vfma_lane_f16(v27, vb3, dv3, 3); \
+  dv4 = vld1_f16(a + 4 * 4);             \
+  vb4 = vld1_f16(b + 4 * 4);             \
+  v24 = vfma_lane_f16(v24, vb4, dv4, 0); \
+  v25 = vfma_lane_f16(v25, vb4, dv4, 1); \
+  v26 = vfma_lane_f16(v26, vb4, dv4, 2); \
+  v27 = vfma_lane_f16(v27, vb4, dv4, 3); \
+  dv5 = vld1_f16(a + 4 * 5);             \
+  vb5 = vld1_f16(b + 4 * 5);             \
+  v24 = vfma_lane_f16(v24, vb5, dv5, 0); \
+  v25 = vfma_lane_f16(v25, vb5, dv5, 1); \
+  v26 = vfma_lane_f16(v26, vb5, dv5, 2); \
+  v27 = vfma_lane_f16(v27, vb5, dv5, 3); \
+  dv6 = vld1_f16(a + 4 * 6);             \
+  vb6 = vld1_f16(b + 4 * 6);             \
+  v24 = vfma_lane_f16(v24, vb6, dv6, 0); \
+  v25 = vfma_lane_f16(v25, vb6, dv6, 1); \
+  v26 = vfma_lane_f16(v26, vb6, dv6, 2); \
+  v27 = vfma_lane_f16(v27, vb6, dv6, 3); \
+  dv7 = vld1_f16(a + 4 * 7);             \
+  vb7 = vld1_f16(b + 4 * 7);             \
+  v24 = vfma_lane_f16(v24, vb7, dv7, 0); \
+  v25 = vfma_lane_f16(v25, vb7, dv7, 1); \
+  v26 = vfma_lane_f16(v26, vb7, dv7, 2); \
+  v27 = vfma_lane_f16(v27, vb7, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 8);             \
+  vb7 = vld1_f16(b + 4 * 8);             \
+  v24 = vfma_lane_f16(v24, vb7, dv7, 0); \
+  v25 = vfma_lane_f16(v25, vb7, dv7, 1); \
+  v26 = vfma_lane_f16(v26, vb7, dv7, 2); \
+  v27 = vfma_lane_f16(v27, vb7, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 9);             \
+  vb7 = vld1_f16(b + 4 * 9);             \
+  v24 = vfma_lane_f16(v24, vb7, dv7, 0); \
+  v25 = vfma_lane_f16(v25, vb7, dv7, 1); \
+  v26 = vfma_lane_f16(v26, vb7, dv7, 2); \
+  v27 = vfma_lane_f16(v27, vb7, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 10);            \
+  vb7 = vld1_f16(b + 4 * 10);            \
+  v24 = vfma_lane_f16(v24, vb7, dv7, 0); \
+  v25 = vfma_lane_f16(v25, vb7, dv7, 1); \
+  v26 = vfma_lane_f16(v26, vb7, dv7, 2); \
+  v27 = vfma_lane_f16(v27, vb7, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 11);            \
+  vb7 = vld1_f16(b + 4 * 11);            \
+  v24 = vfma_lane_f16(v24, vb7, dv7, 0); \
+  v25 = vfma_lane_f16(v25, vb7, dv7, 1); \
+  v26 = vfma_lane_f16(v26, vb7, dv7, 2); \
+  v27 = vfma_lane_f16(v27, vb7, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 12);            \
+  vb7 = vld1_f16(b + 4 * 12);            \
+  v24 = vfma_lane_f16(v24, vb7, dv7, 0); \
+  v25 = vfma_lane_f16(v25, vb7, dv7, 1); \
+  v26 = vfma_lane_f16(v26, vb7, dv7, 2); \
+  v27 = vfma_lane_f16(v27, vb7, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 13);            \
+  vb7 = vld1_f16(b + 4 * 13);            \
+  v24 = vfma_lane_f16(v24, vb7, dv7, 0); \
+  v25 = vfma_lane_f16(v25, vb7, dv7, 1); \
+  v26 = vfma_lane_f16(v26, vb7, dv7, 2); \
+  v27 = vfma_lane_f16(v27, vb7, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 14);            \
+  vb7 = vld1_f16(b + 4 * 14);            \
+  v24 = vfma_lane_f16(v24, vb7, dv7, 0); \
+  v25 = vfma_lane_f16(v25, vb7, dv7, 1); \
+  v26 = vfma_lane_f16(v26, vb7, dv7, 2); \
+  v27 = vfma_lane_f16(v27, vb7, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 15);            \
+  vb7 = vld1_f16(b + 4 * 15);            \
+  v24 = vfma_lane_f16(v24, vb7, dv7, 0); \
+  v25 = vfma_lane_f16(v25, vb7, dv7, 1); \
+  v26 = vfma_lane_f16(v26, vb7, dv7, 2); \
+  v27 = vfma_lane_f16(v27, vb7, dv7, 3); \
+  l += 16;                                \
+  __builtin_prefetch(b + 64, 0, 3);      \
+  __builtin_prefetch(a + 64, 0, 3);      \
+  b += 4 * 16;                            \
+  a += 4 * 16;
+
+// 2. Partial sum 128 digits : Medium accuracy, medium latency
 #define KERNEL_4x4_ACC8()                \
   v24 = vdup_n_f16(0.F);                 \
   v25 = vdup_n_f16(0.F);                 \
@@ -91,6 +199,13 @@
   __builtin_prefetch(a + 4, 0, 3);       \
   b += 4 * 1;                            \
   a += 4 * 1;
+
+#define SAVE_KERNEL_4X4_F16_F32()                                       \
+  vst1q_f32(c, vaddq_f32(vld1q_f32(c), vcvt_f32_f16(v24)));             \
+  vst1q_f32(c + ldc, vaddq_f32(vld1q_f32(c + ldc), vcvt_f32_f16(v25))); \
+  vst1q_f32(c + 2 * ldc,                                                \
+            vaddq_f32(vld1q_f32(c + 2 * ldc), vcvt_f32_f16(v26)));      \
+  vst1q_f32(c + 3 * ldc, vaddq_f32(vld1q_f32(c + 3 * ldc), vcvt_f32_f16(v27)));
 
 /**
  * @brief hgemm 4x4 kernel sc = sa * sb
@@ -199,6 +314,8 @@ void hgemm_kernel_4x4(unsigned int M, unsigned int N, unsigned int K,
   __fp16 *a = sa, *b = sb;
   float *c = sc;
   unsigned int i, j, l;
+  unsigned int K16 = (K >> 4) << 4;
+  unsigned int K8 = (K >> 3) << 3;
   for (i = 0; i < M; i += VL_FP16_HALF) {
     for (j = 0; j < N; j += VL_FP16_HALF) {
       __builtin_prefetch(b, 0, 3);
@@ -207,16 +324,18 @@ void hgemm_kernel_4x4(unsigned int M, unsigned int N, unsigned int K,
       float16x4_t v24, v25, v26, v27;
       float16x4_t dv0, dv1, dv2, dv3, dv4, dv5, dv6, dv7;
       float16x4_t vb0, vb1, vb2, vb3, vb4, vb5, vb6, vb7;
-
-      for (l = 0; l < K;) {
+      l = 0;
+      for (; l < K16;) {
+        KERNEL_4x4_ACC16();
+        SAVE_KERNEL_4X4_F16_F32();
+      }
+      for (; l < K8;) {
         KERNEL_4x4_ACC8();
-
-        vst1q_f32(c, vaddq_f32(vld1q_f32(c), vcvt_f32_f16(v24)));
-        vst1q_f32(c + ldc, vaddq_f32(vld1q_f32(c + ldc), vcvt_f32_f16(v25)));
-        vst1q_f32(c + 2 * ldc,
-                  vaddq_f32(vld1q_f32(c + 2 * ldc), vcvt_f32_f16(v26)));
-        vst1q_f32(c + 3 * ldc,
-                  vaddq_f32(vld1q_f32(c + 3 * ldc), vcvt_f32_f16(v27)));
+        SAVE_KERNEL_4X4_F16_F32();
+      }
+      for (; l < K;) {
+        KERNEL_4x4_ACC1();
+        SAVE_KERNEL_4X4_F16_F32();
       }
 
       c += 4;

--- a/nntrainer/tensor/hgemm/hgemm_kernel_4x4.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_4x4.h
@@ -20,7 +20,7 @@
   v26 = vdup_n_f16(0.F);  \
   v27 = vdup_n_f16(0.F);
 
-// 1. Partial sum 256 digits : Medium accuracy, medium latency
+// 1. Partial sum 256 digits
 #define KERNEL_4x4_ACC16()               \
   dv0 = vld1_f16(a);                     \
   vb0 = vld1_f16(b);                     \
@@ -124,7 +124,7 @@
   b += 4 * 16;                           \
   a += 4 * 16;
 
-// 2. Partial sum 128 digits : Medium accuracy, medium latency
+// 2. Partial sum 128 digits
 #define KERNEL_4x4_ACC8()                \
   dv0 = vld1_f16(a);                     \
   vb0 = vld1_f16(b);                     \
@@ -180,7 +180,7 @@
   b += 4 * 8;                            \
   a += 4 * 8;
 
-// 2. Partial sum 16 digits : Best accuracy, worst latency
+// 2. Partial sum 16 digits
 #define KERNEL_4x4_ACC1()                \
   dv0 = vld1_f16(a);                     \
   vb0 = vld1_f16(b);                     \

--- a/nntrainer/tensor/hgemm/hgemm_kernel_4x8.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_4x8.h
@@ -20,7 +20,7 @@
   v6 = vdupq_n_f16(0.F);  \
   v9 = vdupq_n_f16(0.F);
 
-// 1. Partial sum 256 digits : worst accuracy, best latency
+// 1. Partial sum 256 digits
 #define KERNEL_4x8_ACC16()              \
   dv0 = vld1_f16(a);                    \
   v24 = vld1q_f16(b);                   \
@@ -124,7 +124,7 @@
   b += 8 * 16;                          \
   a += 4 * 16;
 
-// 1. Partial sum 256 digits : worst accuracy, best latency
+// 1. Partial sum 256 digits
 #define KERNEL_4x8_ACC8()               \
   dv0 = vld1_f16(a);                    \
   v24 = vld1q_f16(b);                   \
@@ -180,7 +180,7 @@
   b += 8 * 8;                           \
   a += 4 * 8;
 
-// 2. Partial sum 128 digits : medium accuracy, medium latency
+// 2. Partial sum 128 digits
 #define KERNEL_4x8_ACC4()               \
   dv0 = vld1_f16(a);                    \
   v24 = vld1q_f16(b);                   \
@@ -212,7 +212,7 @@
   b += 8 * 4;                           \
   a += 4 * 4;
 
-// 3. Partial sum 32 digits : Best accuracy, worst latency
+// 3. Partial sum 32 digits
 #define KERNEL_4x8_ACC1()               \
   dv0 = vld1_f16(a);                    \
   v24 = vld1q_f16(b);                   \

--- a/nntrainer/tensor/hgemm/hgemm_kernel_4x8.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_4x8.h
@@ -18,6 +18,114 @@
 /// tradeoff. User can select which kernel to use by replacing them.
 
 // 1. Partial sum 256 digits : worst accuracy, best latency
+#define KERNEL_4x8_ACC16()              \
+  v0 = vdupq_n_f16(0.F);                \
+  v3 = vdupq_n_f16(0.F);                \
+  v6 = vdupq_n_f16(0.F);                \
+  v9 = vdupq_n_f16(0.F);                \
+  dv0 = vld1_f16(a);                    \
+  v24 = vld1q_f16(b);                   \
+  v0 = vfmaq_lane_f16(v0, v24, dv0, 0); \
+  v3 = vfmaq_lane_f16(v3, v24, dv0, 1); \
+  v6 = vfmaq_lane_f16(v6, v24, dv0, 2); \
+  v9 = vfmaq_lane_f16(v9, v24, dv0, 3); \
+  dv1 = vld1_f16(a + 4);                \
+  v25 = vld1q_f16(b + 8);               \
+  v0 = vfmaq_lane_f16(v0, v25, dv1, 0); \
+  v3 = vfmaq_lane_f16(v3, v25, dv1, 1); \
+  v6 = vfmaq_lane_f16(v6, v25, dv1, 2); \
+  v9 = vfmaq_lane_f16(v9, v25, dv1, 3); \
+  dv2 = vld1_f16(a + 4 * 2);            \
+  v26 = vld1q_f16(b + 8 * 2);           \
+  v0 = vfmaq_lane_f16(v0, v26, dv2, 0); \
+  v3 = vfmaq_lane_f16(v3, v26, dv2, 1); \
+  v6 = vfmaq_lane_f16(v6, v26, dv2, 2); \
+  v9 = vfmaq_lane_f16(v9, v26, dv2, 3); \
+  dv3 = vld1_f16(a + 4 * 3);            \
+  v27 = vld1q_f16(b + 8 * 3);           \
+  v0 = vfmaq_lane_f16(v0, v27, dv3, 0); \
+  v3 = vfmaq_lane_f16(v3, v27, dv3, 1); \
+  v6 = vfmaq_lane_f16(v6, v27, dv3, 2); \
+  v9 = vfmaq_lane_f16(v9, v27, dv3, 3); \
+  dv4 = vld1_f16(a + 4 * 4);            \
+  v28 = vld1q_f16(b + 8 * 4);           \
+  v0 = vfmaq_lane_f16(v0, v28, dv4, 0); \
+  v3 = vfmaq_lane_f16(v3, v28, dv4, 1); \
+  v6 = vfmaq_lane_f16(v6, v28, dv4, 2); \
+  v9 = vfmaq_lane_f16(v9, v28, dv4, 3); \
+  dv5 = vld1_f16(a + 4 * 5);            \
+  v29 = vld1q_f16(b + 8 * 5);           \
+  v0 = vfmaq_lane_f16(v0, v29, dv5, 0); \
+  v3 = vfmaq_lane_f16(v3, v29, dv5, 1); \
+  v6 = vfmaq_lane_f16(v6, v29, dv5, 2); \
+  v9 = vfmaq_lane_f16(v9, v29, dv5, 3); \
+  dv6 = vld1_f16(a + 4 * 6);            \
+  v30 = vld1q_f16(b + 8 * 6);           \
+  v0 = vfmaq_lane_f16(v0, v30, dv6, 0); \
+  v3 = vfmaq_lane_f16(v3, v30, dv6, 1); \
+  v6 = vfmaq_lane_f16(v6, v30, dv6, 2); \
+  v9 = vfmaq_lane_f16(v9, v30, dv6, 3); \
+  dv7 = vld1_f16(a + 4 * 7);            \
+  v31 = vld1q_f16(b + 8 * 7);           \
+  v0 = vfmaq_lane_f16(v0, v31, dv7, 0); \
+  v3 = vfmaq_lane_f16(v3, v31, dv7, 1); \
+  v6 = vfmaq_lane_f16(v6, v31, dv7, 2); \
+  v9 = vfmaq_lane_f16(v9, v31, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 8);            \
+  v31 = vld1q_f16(b + 8 * 8);           \
+  v0 = vfmaq_lane_f16(v0, v31, dv7, 0); \
+  v3 = vfmaq_lane_f16(v3, v31, dv7, 1); \
+  v6 = vfmaq_lane_f16(v6, v31, dv7, 2); \
+  v9 = vfmaq_lane_f16(v9, v31, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 9);            \
+  v31 = vld1q_f16(b + 8 * 9);           \
+  v0 = vfmaq_lane_f16(v0, v31, dv7, 0); \
+  v3 = vfmaq_lane_f16(v3, v31, dv7, 1); \
+  v6 = vfmaq_lane_f16(v6, v31, dv7, 2); \
+  v9 = vfmaq_lane_f16(v9, v31, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 10);           \
+  v31 = vld1q_f16(b + 8 * 10);          \
+  v0 = vfmaq_lane_f16(v0, v31, dv7, 0); \
+  v3 = vfmaq_lane_f16(v3, v31, dv7, 1); \
+  v6 = vfmaq_lane_f16(v6, v31, dv7, 2); \
+  v9 = vfmaq_lane_f16(v9, v31, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 11);           \
+  v31 = vld1q_f16(b + 8 * 11);          \
+  v0 = vfmaq_lane_f16(v0, v31, dv7, 0); \
+  v3 = vfmaq_lane_f16(v3, v31, dv7, 1); \
+  v6 = vfmaq_lane_f16(v6, v31, dv7, 2); \
+  v9 = vfmaq_lane_f16(v9, v31, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 12);           \
+  v31 = vld1q_f16(b + 8 * 12);          \
+  v0 = vfmaq_lane_f16(v0, v31, dv7, 0); \
+  v3 = vfmaq_lane_f16(v3, v31, dv7, 1); \
+  v6 = vfmaq_lane_f16(v6, v31, dv7, 2); \
+  v9 = vfmaq_lane_f16(v9, v31, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 13);           \
+  v31 = vld1q_f16(b + 8 * 13);          \
+  v0 = vfmaq_lane_f16(v0, v31, dv7, 0); \
+  v3 = vfmaq_lane_f16(v3, v31, dv7, 1); \
+  v6 = vfmaq_lane_f16(v6, v31, dv7, 2); \
+  v9 = vfmaq_lane_f16(v9, v31, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 14);           \
+  v31 = vld1q_f16(b + 8 * 14);          \
+  v0 = vfmaq_lane_f16(v0, v31, dv7, 0); \
+  v3 = vfmaq_lane_f16(v3, v31, dv7, 1); \
+  v6 = vfmaq_lane_f16(v6, v31, dv7, 2); \
+  v9 = vfmaq_lane_f16(v9, v31, dv7, 3); \
+  dv7 = vld1_f16(a + 4 * 15);           \
+  v31 = vld1q_f16(b + 8 * 15);          \
+  v0 = vfmaq_lane_f16(v0, v31, dv7, 0); \
+  v3 = vfmaq_lane_f16(v3, v31, dv7, 1); \
+  v6 = vfmaq_lane_f16(v6, v31, dv7, 2); \
+  v9 = vfmaq_lane_f16(v9, v31, dv7, 3); \
+  l += 16;                              \
+  __builtin_prefetch(b + 128, 0, 3);    \
+  __builtin_prefetch(a + 64, 0, 3);     \
+  b += 8 * 16;                          \
+  a += 4 * 16;
+
+// 1. Partial sum 256 digits : worst accuracy, best latency
 #define KERNEL_4x8_ACC8()               \
   v0 = vdupq_n_f16(0.F);                \
   v3 = vdupq_n_f16(0.F);                \
@@ -131,6 +239,24 @@
   b += 8 * 1;                           \
   a += 4 * 1;
 
+#define SAVE_KERNEL_4X8_F16_F32()                                           \
+  vst1q_f32(c, vaddq_f32(vld1q_f32(c), vcvt_f32_f16(vget_low_f16(v0))));    \
+  vst1q_f32(c + ldc,                                                        \
+            vaddq_f32(vld1q_f32(c + ldc), vcvt_f32_f16(vget_low_f16(v3)))); \
+  vst1q_f32(c + 2 * ldc, vaddq_f32(vld1q_f32(c + 2 * ldc),                  \
+                                   vcvt_f32_f16(vget_low_f16(v6))));        \
+  vst1q_f32(c + 3 * ldc, vaddq_f32(vld1q_f32(c + 3 * ldc),                  \
+                                   vcvt_f32_f16(vget_low_f16(v9))));        \
+                                                                            \
+  vst1q_f32(c + 4,                                                          \
+            vaddq_f32(vld1q_f32(c + 4), vcvt_f32_f16(vget_high_f16(v0))));  \
+  vst1q_f32(c + 4 + ldc, vaddq_f32(vld1q_f32(c + 4 + ldc),                  \
+                                   vcvt_f32_f16(vget_high_f16(v3))));       \
+  vst1q_f32(c + 4 + 2 * ldc, vaddq_f32(vld1q_f32(c + 4 + 2 * ldc),          \
+                                       vcvt_f32_f16(vget_high_f16(v6))));   \
+  vst1q_f32(c + 4 + 3 * ldc, vaddq_f32(vld1q_f32(c + 4 + 3 * ldc),          \
+                                       vcvt_f32_f16(vget_high_f16(v9))));
+
 /**
  * @brief hgemm 4x8 kernel sc = sa * sb
  *
@@ -202,7 +328,9 @@ void hgemm_kernel_4x8(unsigned int M, unsigned int N, unsigned int K,
 
   __fp16 *a = sa, *b = sb;
   float *c = sc;
-  unsigned int k8 = (K >> 3) << 3;
+  unsigned int K16 = (K >> 4) << 4;
+  unsigned int K8 = (K >> 3) << 3;
+  unsigned int K4 = (K >> 2) << 2;
   unsigned int i, j, l;
   for (i = 0; i < M; i += 4) {
     for (j = 0; j < N; j += 8) {
@@ -212,45 +340,21 @@ void hgemm_kernel_4x8(unsigned int M, unsigned int N, unsigned int K,
       float16x8_t v24, v25, v26, v27, v28, v29, v30, v31;
       float16x4_t dv0, dv1, dv2, dv3, dv4, dv5, dv6, dv7;
       l = 0;
-      for (; l < k8;) {
+      for (; l < K16;) {
+        KERNEL_4x8_ACC16();
+        SAVE_KERNEL_4X8_F16_F32();
+      }
+      for (; l < K8;) {
         KERNEL_4x8_ACC8();
-
-        vst1q_f32(c, vaddq_f32(vld1q_f32(c), vcvt_f32_f16(vget_low_f16(v0))));
-        vst1q_f32(c + ldc, vaddq_f32(vld1q_f32(c + ldc),
-                                     vcvt_f32_f16(vget_low_f16(v3))));
-        vst1q_f32(c + 2 * ldc, vaddq_f32(vld1q_f32(c + 2 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v6))));
-        vst1q_f32(c + 3 * ldc, vaddq_f32(vld1q_f32(c + 3 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v9))));
-
-        vst1q_f32(c + 4,
-                  vaddq_f32(vld1q_f32(c + 4), vcvt_f32_f16(vget_high_f16(v0))));
-        vst1q_f32(c + 4 + ldc, vaddq_f32(vld1q_f32(c + 4 + ldc),
-                                         vcvt_f32_f16(vget_high_f16(v3))));
-        vst1q_f32(c + 4 + 2 * ldc, vaddq_f32(vld1q_f32(c + 4 + 2 * ldc),
-                                             vcvt_f32_f16(vget_high_f16(v6))));
-        vst1q_f32(c + 4 + 3 * ldc, vaddq_f32(vld1q_f32(c + 4 + 3 * ldc),
-                                             vcvt_f32_f16(vget_high_f16(v9))));
+        SAVE_KERNEL_4X8_F16_F32();
+      }
+      for (; l < K4;) {
+        KERNEL_4x8_ACC4();
+        SAVE_KERNEL_4X8_F16_F32();
       }
       for (; l < K;) {
         KERNEL_4x8_ACC1();
-
-        vst1q_f32(c, vaddq_f32(vld1q_f32(c), vcvt_f32_f16(vget_low_f16(v0))));
-        vst1q_f32(c + ldc, vaddq_f32(vld1q_f32(c + ldc),
-                                     vcvt_f32_f16(vget_low_f16(v3))));
-        vst1q_f32(c + 2 * ldc, vaddq_f32(vld1q_f32(c + 2 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v6))));
-        vst1q_f32(c + 3 * ldc, vaddq_f32(vld1q_f32(c + 3 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v9))));
-
-        vst1q_f32(c + 4,
-                  vaddq_f32(vld1q_f32(c + 4), vcvt_f32_f16(vget_high_f16(v0))));
-        vst1q_f32(c + 4 + ldc, vaddq_f32(vld1q_f32(c + 4 + ldc),
-                                         vcvt_f32_f16(vget_high_f16(v3))));
-        vst1q_f32(c + 4 + 2 * ldc, vaddq_f32(vld1q_f32(c + 4 + 2 * ldc),
-                                             vcvt_f32_f16(vget_high_f16(v6))));
-        vst1q_f32(c + 4 + 3 * ldc, vaddq_f32(vld1q_f32(c + 4 + 3 * ldc),
-                                             vcvt_f32_f16(vget_high_f16(v9))));
+        SAVE_KERNEL_4X8_F16_F32();
       }
       c += 8;
       a -= 4 * K;

--- a/nntrainer/tensor/hgemm/hgemm_kernel_8x16.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_8x16.h
@@ -14,27 +14,26 @@
 #include <hgemm_common.h>
 #include <stdlib.h>
 
-/// @note Following KERNELs are the combinations of accuracy-latency
-/// tradeoff. User can select which kernel to use by replacing them.
+#define INIT_KERNEL_8X16()     \
+  v0_7 = vdupq_n_f16(0.F);     \
+  v8_15 = vdupq_n_f16(0.F);    \
+  v16_23 = vdupq_n_f16(0.F);   \
+  v24_31 = vdupq_n_f16(0.F);   \
+  v32_39 = vdupq_n_f16(0.F);   \
+  v40_47 = vdupq_n_f16(0.F);   \
+  v48_55 = vdupq_n_f16(0.F);   \
+  v56_63 = vdupq_n_f16(0.F);   \
+  v64_71 = vdupq_n_f16(0.F);   \
+  v72_79 = vdupq_n_f16(0.F);   \
+  v80_87 = vdupq_n_f16(0.F);   \
+  v88_95 = vdupq_n_f16(0.F);   \
+  v96_103 = vdupq_n_f16(0.F);  \
+  v104_111 = vdupq_n_f16(0.F); \
+  v112_119 = vdupq_n_f16(0.F); \
+  v120_127 = vdupq_n_f16(0.F);
 
 // 0. Partial sum 2048 digits : Best latency, worst accuracy.
 #define KERNEL_8x16_ACC16()                          \
-  v0_7 = vdupq_n_f16(0.F);                           \
-  v8_15 = vdupq_n_f16(0.F);                          \
-  v16_23 = vdupq_n_f16(0.F);                         \
-  v24_31 = vdupq_n_f16(0.F);                         \
-  v32_39 = vdupq_n_f16(0.F);                         \
-  v40_47 = vdupq_n_f16(0.F);                         \
-  v48_55 = vdupq_n_f16(0.F);                         \
-  v56_63 = vdupq_n_f16(0.F);                         \
-  v64_71 = vdupq_n_f16(0.F);                         \
-  v72_79 = vdupq_n_f16(0.F);                         \
-  v80_87 = vdupq_n_f16(0.F);                         \
-  v88_95 = vdupq_n_f16(0.F);                         \
-  v96_103 = vdupq_n_f16(0.F);                        \
-  v104_111 = vdupq_n_f16(0.F);                       \
-  v112_119 = vdupq_n_f16(0.F);                       \
-  v120_127 = vdupq_n_f16(0.F);                       \
   va0 = vld1q_f16(a);                                \
   v24 = vld1q_f16(b);                                \
   v25 = vld1q_f16(b + 8);                            \
@@ -347,22 +346,6 @@
 
 // 1. Partial sum 1024 digits : Medium-high accuracy, medium latency
 #define KERNEL_8x16_ACC8()                           \
-  v0_7 = vdupq_n_f16(0.F);                           \
-  v8_15 = vdupq_n_f16(0.F);                          \
-  v16_23 = vdupq_n_f16(0.F);                         \
-  v24_31 = vdupq_n_f16(0.F);                         \
-  v32_39 = vdupq_n_f16(0.F);                         \
-  v40_47 = vdupq_n_f16(0.F);                         \
-  v48_55 = vdupq_n_f16(0.F);                         \
-  v56_63 = vdupq_n_f16(0.F);                         \
-  v64_71 = vdupq_n_f16(0.F);                         \
-  v72_79 = vdupq_n_f16(0.F);                         \
-  v80_87 = vdupq_n_f16(0.F);                         \
-  v88_95 = vdupq_n_f16(0.F);                         \
-  v96_103 = vdupq_n_f16(0.F);                        \
-  v104_111 = vdupq_n_f16(0.F);                       \
-  v112_119 = vdupq_n_f16(0.F);                       \
-  v120_127 = vdupq_n_f16(0.F);                       \
   va0 = vld1q_f16(a);                                \
   v24 = vld1q_f16(b);                                \
   v25 = vld1q_f16(b + 8);                            \
@@ -523,22 +506,6 @@
 
 // 2. Partial sum 512 digits : Medium accuracy, medium latency
 #define KERNEL_8x16_ACC4()                           \
-  v0_7 = vdupq_n_f16(0.F);                           \
-  v8_15 = vdupq_n_f16(0.F);                          \
-  v16_23 = vdupq_n_f16(0.F);                         \
-  v24_31 = vdupq_n_f16(0.F);                         \
-  v32_39 = vdupq_n_f16(0.F);                         \
-  v40_47 = vdupq_n_f16(0.F);                         \
-  v48_55 = vdupq_n_f16(0.F);                         \
-  v56_63 = vdupq_n_f16(0.F);                         \
-  v64_71 = vdupq_n_f16(0.F);                         \
-  v72_79 = vdupq_n_f16(0.F);                         \
-  v80_87 = vdupq_n_f16(0.F);                         \
-  v88_95 = vdupq_n_f16(0.F);                         \
-  v96_103 = vdupq_n_f16(0.F);                        \
-  v104_111 = vdupq_n_f16(0.F);                       \
-  v112_119 = vdupq_n_f16(0.F);                       \
-  v120_127 = vdupq_n_f16(0.F);                       \
   va0 = vld1q_f16(a);                                \
   v24 = vld1q_f16(b);                                \
   v25 = vld1q_f16(b + 8);                            \
@@ -623,22 +590,6 @@
 
 // 3. Partial sum 128 digits : Best accuracy, worst latency
 #define KERNEL_8x16_ACC1()                           \
-  v0_7 = vdupq_n_f16(0.F);                           \
-  v8_15 = vdupq_n_f16(0.F);                          \
-  v16_23 = vdupq_n_f16(0.F);                         \
-  v24_31 = vdupq_n_f16(0.F);                         \
-  v32_39 = vdupq_n_f16(0.F);                         \
-  v40_47 = vdupq_n_f16(0.F);                         \
-  v48_55 = vdupq_n_f16(0.F);                         \
-  v56_63 = vdupq_n_f16(0.F);                         \
-  v64_71 = vdupq_n_f16(0.F);                         \
-  v72_79 = vdupq_n_f16(0.F);                         \
-  v80_87 = vdupq_n_f16(0.F);                         \
-  v88_95 = vdupq_n_f16(0.F);                         \
-  v96_103 = vdupq_n_f16(0.F);                        \
-  v104_111 = vdupq_n_f16(0.F);                       \
-  v112_119 = vdupq_n_f16(0.F);                       \
-  v120_127 = vdupq_n_f16(0.F);                       \
   va0 = vld1q_f16(a);                                \
   v24 = vld1q_f16(b);                                \
   v25 = vld1q_f16(b + 8);                            \
@@ -783,10 +734,13 @@ void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
 
       float16x8_t v24, v25, v26, v27, v28, v29, v30, v31;
       float16x8_t va0, va1, va2, va3;
+
+      INIT_KERNEL_8X16();
       l = 0;
       for (; l < K;) {
-        KERNEL_8x16_ACC4();
-        vst1q_f16(c, vaddq_f16(vld1q_f16(c), v0_7));
+        KERNEL_8x16_ACC1();
+      }
+       vst1q_f16(c, vaddq_f16(vld1q_f16(c), v0_7));
         vst1q_f16(c + 8, vaddq_f16(vld1q_f16(c + 8), v64_71));
         vst1q_f16(c + ldc, vaddq_f16(vld1q_f16(c + ldc), v8_15));
         vst1q_f16(c + ldc + 8, vaddq_f16(vld1q_f16(c + ldc + 8), v72_79));
@@ -808,7 +762,6 @@ void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
         vst1q_f16(c + 7 * ldc, vaddq_f16(vld1q_f16(c + 7 * ldc), v56_63));
         vst1q_f16(c + 7 * ldc + 8,
                   vaddq_f16(vld1q_f16(c + 7 * ldc + 8), v120_127));
-      }
       c += 16;
       a -= 8 * K;
     }
@@ -857,18 +810,22 @@ void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
       float16x8_t va0, va1, va2, va3, va4, va5, va6, va7;
       l = 0;
       for (; l < K16;) {
+        INIT_KERNEL_8X16();
         KERNEL_8x16_ACC16();
         SAVE_KERNEL_8X16_F16_F32();
       }
       for (; l < K8;) {
+        INIT_KERNEL_8X16();
         KERNEL_8x16_ACC8();
         SAVE_KERNEL_8X16_F16_F32();
       }
       for (; l < K4;) {
+        INIT_KERNEL_8X16();
         KERNEL_8x16_ACC4();
         SAVE_KERNEL_8X16_F16_F32();
       }
       for (; l < K;) {
+        INIT_KERNEL_8X16();
         KERNEL_8x16_ACC1();
         SAVE_KERNEL_8X16_F16_F32();
       }

--- a/nntrainer/tensor/hgemm/hgemm_kernel_8x16.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_8x16.h
@@ -32,7 +32,7 @@
   v112_119 = vdupq_n_f16(0.F); \
   v120_127 = vdupq_n_f16(0.F);
 
-// 0. Partial sum 2048 digits : Best latency, worst accuracy.
+// 1. Partial sum 2048 digits
 #define KERNEL_8x16_ACC16()                          \
   va0 = vld1q_f16(a);                                \
   v24 = vld1q_f16(b);                                \
@@ -344,7 +344,7 @@
   b += 16 * 16;                                      \
   a += 8 * 16;
 
-// 1. Partial sum 1024 digits : Medium-high accuracy, medium latency
+// 2. Partial sum 1024 digits
 #define KERNEL_8x16_ACC8()                           \
   va0 = vld1q_f16(a);                                \
   v24 = vld1q_f16(b);                                \
@@ -504,7 +504,7 @@
   b += 16 * 8;                                       \
   a += 8 * 8;
 
-// 2. Partial sum 512 digits : Medium accuracy, medium latency
+// 3. Partial sum 512 digits
 #define KERNEL_8x16_ACC4()                           \
   va0 = vld1q_f16(a);                                \
   v24 = vld1q_f16(b);                                \
@@ -588,7 +588,7 @@
   b += 16 * 4;                                       \
   a += 8 * 4;
 
-// 3. Partial sum 128 digits : Best accuracy, worst latency
+// 3. Partial sum 128 digits
 #define KERNEL_8x16_ACC1()                           \
   va0 = vld1q_f16(a);                                \
   v24 = vld1q_f16(b);                                \
@@ -740,28 +740,26 @@ void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
       for (; l < K;) {
         KERNEL_8x16_ACC1();
       }
-       vst1q_f16(c, vaddq_f16(vld1q_f16(c), v0_7));
-        vst1q_f16(c + 8, vaddq_f16(vld1q_f16(c + 8), v64_71));
-        vst1q_f16(c + ldc, vaddq_f16(vld1q_f16(c + ldc), v8_15));
-        vst1q_f16(c + ldc + 8, vaddq_f16(vld1q_f16(c + ldc + 8), v72_79));
-        vst1q_f16(c + 2 * ldc, vaddq_f16(vld1q_f16(c + 2 * ldc), v16_23));
-        vst1q_f16(c + 2 * ldc + 8,
-                  vaddq_f16(vld1q_f16(c + 2 * ldc + 8), v80_87));
-        vst1q_f16(c + 3 * ldc, vaddq_f16(vld1q_f16(c + 3 * ldc), v24_31));
-        vst1q_f16(c + 3 * ldc + 8,
-                  vaddq_f16(vld1q_f16(c + 3 * ldc + 8), v88_95));
-        vst1q_f16(c + 4 * ldc, vaddq_f16(vld1q_f16(c + 4 * ldc), v32_39));
-        vst1q_f16(c + 4 * ldc + 8,
-                  vaddq_f16(vld1q_f16(c + 4 * ldc + 8), v96_103));
-        vst1q_f16(c + 5 * ldc, vaddq_f16(vld1q_f16(c + 5 * ldc), v40_47));
-        vst1q_f16(c + 5 * ldc + 8,
-                  vaddq_f16(vld1q_f16(c + 5 * ldc + 8), v104_111));
-        vst1q_f16(c + 6 * ldc, vaddq_f16(vld1q_f16(c + 6 * ldc), v48_55));
-        vst1q_f16(c + 6 * ldc + 8,
-                  vaddq_f16(vld1q_f16(c + 6 * ldc + 8), v112_119));
-        vst1q_f16(c + 7 * ldc, vaddq_f16(vld1q_f16(c + 7 * ldc), v56_63));
-        vst1q_f16(c + 7 * ldc + 8,
-                  vaddq_f16(vld1q_f16(c + 7 * ldc + 8), v120_127));
+      vst1q_f16(c, vaddq_f16(vld1q_f16(c), v0_7));
+      vst1q_f16(c + 8, vaddq_f16(vld1q_f16(c + 8), v64_71));
+      vst1q_f16(c + ldc, vaddq_f16(vld1q_f16(c + ldc), v8_15));
+      vst1q_f16(c + ldc + 8, vaddq_f16(vld1q_f16(c + ldc + 8), v72_79));
+      vst1q_f16(c + 2 * ldc, vaddq_f16(vld1q_f16(c + 2 * ldc), v16_23));
+      vst1q_f16(c + 2 * ldc + 8, vaddq_f16(vld1q_f16(c + 2 * ldc + 8), v80_87));
+      vst1q_f16(c + 3 * ldc, vaddq_f16(vld1q_f16(c + 3 * ldc), v24_31));
+      vst1q_f16(c + 3 * ldc + 8, vaddq_f16(vld1q_f16(c + 3 * ldc + 8), v88_95));
+      vst1q_f16(c + 4 * ldc, vaddq_f16(vld1q_f16(c + 4 * ldc), v32_39));
+      vst1q_f16(c + 4 * ldc + 8,
+                vaddq_f16(vld1q_f16(c + 4 * ldc + 8), v96_103));
+      vst1q_f16(c + 5 * ldc, vaddq_f16(vld1q_f16(c + 5 * ldc), v40_47));
+      vst1q_f16(c + 5 * ldc + 8,
+                vaddq_f16(vld1q_f16(c + 5 * ldc + 8), v104_111));
+      vst1q_f16(c + 6 * ldc, vaddq_f16(vld1q_f16(c + 6 * ldc), v48_55));
+      vst1q_f16(c + 6 * ldc + 8,
+                vaddq_f16(vld1q_f16(c + 6 * ldc + 8), v112_119));
+      vst1q_f16(c + 7 * ldc, vaddq_f16(vld1q_f16(c + 7 * ldc), v56_63));
+      vst1q_f16(c + 7 * ldc + 8,
+                vaddq_f16(vld1q_f16(c + 7 * ldc + 8), v120_127));
       c += 16;
       a -= 8 * K;
     }

--- a/nntrainer/tensor/hgemm/hgemm_kernel_8x16.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_8x16.h
@@ -17,7 +17,335 @@
 /// @note Following KERNELs are the combinations of accuracy-latency
 /// tradeoff. User can select which kernel to use by replacing them.
 
-// 1. Partial sum 1024 digits : Worst accuracy, best latency
+// 0. Partial sum 2048 digits : Best latency, worst accuracy.
+#define KERNEL_8x16_ACC16()                          \
+  v0_7 = vdupq_n_f16(0.F);                           \
+  v8_15 = vdupq_n_f16(0.F);                          \
+  v16_23 = vdupq_n_f16(0.F);                         \
+  v24_31 = vdupq_n_f16(0.F);                         \
+  v32_39 = vdupq_n_f16(0.F);                         \
+  v40_47 = vdupq_n_f16(0.F);                         \
+  v48_55 = vdupq_n_f16(0.F);                         \
+  v56_63 = vdupq_n_f16(0.F);                         \
+  v64_71 = vdupq_n_f16(0.F);                         \
+  v72_79 = vdupq_n_f16(0.F);                         \
+  v80_87 = vdupq_n_f16(0.F);                         \
+  v88_95 = vdupq_n_f16(0.F);                         \
+  v96_103 = vdupq_n_f16(0.F);                        \
+  v104_111 = vdupq_n_f16(0.F);                       \
+  v112_119 = vdupq_n_f16(0.F);                       \
+  v120_127 = vdupq_n_f16(0.F);                       \
+  va0 = vld1q_f16(a);                                \
+  v24 = vld1q_f16(b);                                \
+  v25 = vld1q_f16(b + 8);                            \
+  v0_7 = vfmaq_laneq_f16(v0_7, v24, va0, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v24, va0, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v24, va0, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v24, va0, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v24, va0, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v24, va0, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v24, va0, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v24, va0, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v25, va0, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v25, va0, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v25, va0, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v25, va0, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v25, va0, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v25, va0, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v25, va0, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v25, va0, 7); \
+  va1 = vld1q_f16(a + 8);                            \
+  v26 = vld1q_f16(b + 8 * 2);                        \
+  v27 = vld1q_f16(b + 8 * 3);                        \
+  v0_7 = vfmaq_laneq_f16(v0_7, v26, va1, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v26, va1, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v26, va1, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v26, va1, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v26, va1, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v26, va1, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v26, va1, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v26, va1, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v27, va1, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v27, va1, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v27, va1, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v27, va1, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v27, va1, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v27, va1, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v27, va1, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v27, va1, 7); \
+  va2 = vld1q_f16(a + 8 * 2);                        \
+  v28 = vld1q_f16(b + 8 * 4);                        \
+  v29 = vld1q_f16(b + 8 * 5);                        \
+  v0_7 = vfmaq_laneq_f16(v0_7, v28, va2, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v28, va2, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v28, va2, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v28, va2, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v28, va2, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v28, va2, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v28, va2, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v28, va2, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v29, va2, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v29, va2, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v29, va2, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v29, va2, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v29, va2, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v29, va2, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v29, va2, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v29, va2, 7); \
+  va3 = vld1q_f16(a + 8 * 3);                        \
+  v30 = vld1q_f16(b + 8 * 6);                        \
+  v31 = vld1q_f16(b + 8 * 7);                        \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va3, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va3, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va3, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va3, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va3, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va3, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va3, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va3, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va3, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va3, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va3, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va3, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va3, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va3, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va3, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va3, 7); \
+  va4 = vld1q_f16(a + 8 * 4);                        \
+  v24 = vld1q_f16(b + 8 * 8);                        \
+  v25 = vld1q_f16(b + 8 * 9);                        \
+  v0_7 = vfmaq_laneq_f16(v0_7, v24, va4, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v24, va4, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v24, va4, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v24, va4, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v24, va4, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v24, va4, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v24, va4, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v24, va4, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v25, va4, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v25, va4, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v25, va4, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v25, va4, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v25, va4, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v25, va4, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v25, va4, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v25, va4, 7); \
+  va5 = vld1q_f16(a + 8 * 5);                        \
+  v26 = vld1q_f16(b + 8 * 10);                       \
+  v27 = vld1q_f16(b + 8 * 11);                       \
+  v0_7 = vfmaq_laneq_f16(v0_7, v26, va5, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v26, va5, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v26, va5, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v26, va5, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v26, va5, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v26, va5, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v26, va5, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v26, va5, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v27, va5, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v27, va5, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v27, va5, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v27, va5, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v27, va5, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v27, va5, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v27, va5, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v27, va5, 7); \
+  va6 = vld1q_f16(a + 8 * 6);                        \
+  v28 = vld1q_f16(b + 8 * 12);                       \
+  v29 = vld1q_f16(b + 8 * 13);                       \
+  v0_7 = vfmaq_laneq_f16(v0_7, v28, va6, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v28, va6, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v28, va6, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v28, va6, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v28, va6, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v28, va6, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v28, va6, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v28, va6, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v29, va6, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v29, va6, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v29, va6, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v29, va6, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v29, va6, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v29, va6, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v29, va6, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v29, va6, 7); \
+  va7 = vld1q_f16(a + 8 * 7);                        \
+  v30 = vld1q_f16(b + 8 * 14);                       \
+  v31 = vld1q_f16(b + 8 * 15);                       \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va7, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va7, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va7, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va7, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va7, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va7, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va7, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va7, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va7, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va7, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va7, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va7, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va7, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va7, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va7, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 8);                        \
+  v30 = vld1q_f16(b + 8 * 16);                       \
+  v31 = vld1q_f16(b + 8 * 17);                       \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va7, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va7, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va7, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va7, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va7, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va7, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va7, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va7, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va7, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va7, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va7, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va7, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va7, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va7, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va7, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 9);                        \
+  v30 = vld1q_f16(b + 8 * 18);                       \
+  v31 = vld1q_f16(b + 8 * 19);                       \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va7, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va7, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va7, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va7, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va7, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va7, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va7, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va7, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va7, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va7, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va7, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va7, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va7, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va7, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va7, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 10);                       \
+  v30 = vld1q_f16(b + 8 * 20);                       \
+  v31 = vld1q_f16(b + 8 * 21);                       \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va7, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va7, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va7, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va7, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va7, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va7, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va7, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va7, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va7, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va7, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va7, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va7, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va7, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va7, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va7, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 11);                       \
+  v30 = vld1q_f16(b + 8 * 22);                       \
+  v31 = vld1q_f16(b + 8 * 23);                       \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va7, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va7, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va7, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va7, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va7, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va7, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va7, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va7, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va7, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va7, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va7, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va7, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va7, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va7, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va7, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 12);                       \
+  v30 = vld1q_f16(b + 8 * 24);                       \
+  v31 = vld1q_f16(b + 8 * 25);                       \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va7, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va7, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va7, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va7, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va7, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va7, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va7, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va7, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va7, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va7, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va7, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va7, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va7, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va7, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va7, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 13);                       \
+  v30 = vld1q_f16(b + 8 * 26);                       \
+  v31 = vld1q_f16(b + 8 * 27);                       \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va7, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va7, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va7, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va7, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va7, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va7, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va7, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va7, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va7, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va7, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va7, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va7, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va7, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va7, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va7, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 14);                       \
+  v30 = vld1q_f16(b + 8 * 28);                       \
+  v31 = vld1q_f16(b + 8 * 29);                       \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va7, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va7, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va7, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va7, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va7, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va7, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va7, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va7, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va7, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va7, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va7, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va7, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va7, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va7, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va7, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 15);                       \
+  v30 = vld1q_f16(b + 8 * 30);                       \
+  v31 = vld1q_f16(b + 8 * 31);                       \
+  v0_7 = vfmaq_laneq_f16(v0_7, v30, va7, 0);         \
+  v8_15 = vfmaq_laneq_f16(v8_15, v30, va7, 1);       \
+  v16_23 = vfmaq_laneq_f16(v16_23, v30, va7, 2);     \
+  v24_31 = vfmaq_laneq_f16(v24_31, v30, va7, 3);     \
+  v32_39 = vfmaq_laneq_f16(v32_39, v30, va7, 4);     \
+  v40_47 = vfmaq_laneq_f16(v40_47, v30, va7, 5);     \
+  v48_55 = vfmaq_laneq_f16(v48_55, v30, va7, 6);     \
+  v56_63 = vfmaq_laneq_f16(v56_63, v30, va7, 7);     \
+  v64_71 = vfmaq_laneq_f16(v64_71, v31, va7, 0);     \
+  v72_79 = vfmaq_laneq_f16(v72_79, v31, va7, 1);     \
+  v80_87 = vfmaq_laneq_f16(v80_87, v31, va7, 2);     \
+  v88_95 = vfmaq_laneq_f16(v88_95, v31, va7, 3);     \
+  v96_103 = vfmaq_laneq_f16(v96_103, v31, va7, 4);   \
+  v104_111 = vfmaq_laneq_f16(v104_111, v31, va7, 5); \
+  v112_119 = vfmaq_laneq_f16(v112_119, v31, va7, 6); \
+  v120_127 = vfmaq_laneq_f16(v120_127, v31, va7, 7); \
+  l += 16;                                           \
+  __builtin_prefetch(b + 256, 0, 3);                 \
+  __builtin_prefetch(a + 128, 0, 3);                 \
+  b += 16 * 16;                                      \
+  a += 8 * 16;
+
+// 1. Partial sum 1024 digits : Medium-high accuracy, medium latency
 #define KERNEL_8x16_ACC8()                           \
   v0_7 = vdupq_n_f16(0.F);                           \
   v8_15 = vdupq_n_f16(0.F);                          \
@@ -336,6 +664,91 @@
   b += 16 * 1;                                       \
   a += 8 * 1;
 
+#define SAVE_KERNEL_8X16_F16_F32()                                             \
+  vst1q_f32(c, vaddq_f32(vld1q_f32(c), vcvt_f32_f16(vget_low_f16(v0_7))));     \
+  vst1q_f32(c + 4,                                                             \
+            vaddq_f32(vld1q_f32(c + 4), vcvt_f32_f16(vget_high_f16(v0_7))));   \
+                                                                               \
+  vst1q_f32(c + 8,                                                             \
+            vaddq_f32(vld1q_f32(c + 8), vcvt_f32_f16(vget_low_f16(v64_71))));  \
+  vst1q_f32(c + 8 + 4, vaddq_f32(vld1q_f32(c + 8 + 4),                         \
+                                 vcvt_f32_f16(vget_high_f16(v64_71))));        \
+                                                                               \
+  vst1q_f32(c + ldc,                                                           \
+            vaddq_f32(vld1q_f32(c + ldc), vcvt_f32_f16(vget_low_f16(v8_15)))); \
+  vst1q_f32(c + ldc + 4, vaddq_f32(vld1q_f32(c + ldc + 4),                     \
+                                   vcvt_f32_f16(vget_high_f16(v8_15))));       \
+                                                                               \
+  vst1q_f32(c + ldc + 8, vaddq_f32(vld1q_f32(c + ldc + 8),                     \
+                                   vcvt_f32_f16(vget_low_f16(v72_79))));       \
+  vst1q_f32(c + ldc + 8 + 4, vaddq_f32(vld1q_f32(c + ldc + 8 + 4),             \
+                                       vcvt_f32_f16(vget_high_f16(v72_79))));  \
+                                                                               \
+  vst1q_f32(c + 2 * ldc, vaddq_f32(vld1q_f32(c + 2 * ldc),                     \
+                                   vcvt_f32_f16(vget_low_f16(v16_23))));       \
+  vst1q_f32(c + 2 * ldc + 4, vaddq_f32(vld1q_f32(c + 2 * ldc + 4),             \
+                                       vcvt_f32_f16(vget_high_f16(v16_23))));  \
+                                                                               \
+  vst1q_f32(c + 2 * ldc + 8, vaddq_f32(vld1q_f32(c + 2 * ldc + 8),             \
+                                       vcvt_f32_f16(vget_low_f16(v80_87))));   \
+  vst1q_f32(c + 2 * ldc + 8 + 4,                                               \
+            vaddq_f32(vld1q_f32(c + 2 * ldc + 8 + 4),                          \
+                      vcvt_f32_f16(vget_high_f16(v80_87))));                   \
+                                                                               \
+  vst1q_f32(c + 3 * ldc, vaddq_f32(vld1q_f32(c + 3 * ldc),                     \
+                                   vcvt_f32_f16(vget_low_f16(v24_31))));       \
+  vst1q_f32(c + 3 * ldc + 4, vaddq_f32(vld1q_f32(c + 3 * ldc + 4),             \
+                                       vcvt_f32_f16(vget_high_f16(v24_31))));  \
+                                                                               \
+  vst1q_f32(c + 3 * ldc + 8, vaddq_f32(vld1q_f32(c + 3 * ldc + 8),             \
+                                       vcvt_f32_f16(vget_low_f16(v88_95))));   \
+  vst1q_f32(c + 3 * ldc + 8 + 4,                                               \
+            vaddq_f32(vld1q_f32(c + 3 * ldc + 8 + 4),                          \
+                      vcvt_f32_f16(vget_high_f16(v88_95))));                   \
+                                                                               \
+  vst1q_f32(c + 4 * ldc, vaddq_f32(vld1q_f32(c + 4 * ldc),                     \
+                                   vcvt_f32_f16(vget_low_f16(v32_39))));       \
+  vst1q_f32(c + 4 * ldc + 4, vaddq_f32(vld1q_f32(c + 4 * ldc + 4),             \
+                                       vcvt_f32_f16(vget_high_f16(v32_39))));  \
+                                                                               \
+  vst1q_f32(c + 4 * ldc + 8, vaddq_f32(vld1q_f32(c + 4 * ldc + 8),             \
+                                       vcvt_f32_f16(vget_low_f16(v96_103))));  \
+  vst1q_f32(c + 4 * ldc + 8 + 4,                                               \
+            vaddq_f32(vld1q_f32(c + 4 * ldc + 8 + 4),                          \
+                      vcvt_f32_f16(vget_high_f16(v96_103))));                  \
+                                                                               \
+  vst1q_f32(c + 5 * ldc, vaddq_f32(vld1q_f32(c + 5 * ldc),                     \
+                                   vcvt_f32_f16(vget_low_f16(v40_47))));       \
+  vst1q_f32(c + 5 * ldc + 4, vaddq_f32(vld1q_f32(c + 5 * ldc + 4),             \
+                                       vcvt_f32_f16(vget_high_f16(v40_47))));  \
+  vst1q_f32(c + 5 * ldc + 8, vaddq_f32(vld1q_f32(c + 5 * ldc + 8),             \
+                                       vcvt_f32_f16(vget_low_f16(v104_111)))); \
+  vst1q_f32(c + 5 * ldc + 8 + 4,                                               \
+            vaddq_f32(vld1q_f32(c + 5 * ldc + 8 + 4),                          \
+                      vcvt_f32_f16(vget_high_f16(v104_111))));                 \
+                                                                               \
+  vst1q_f32(c + 6 * ldc, vaddq_f32(vld1q_f32(c + 6 * ldc),                     \
+                                   vcvt_f32_f16(vget_low_f16(v48_55))));       \
+  vst1q_f32(c + 6 * ldc + 4, vaddq_f32(vld1q_f32(c + 6 * ldc + 4),             \
+                                       vcvt_f32_f16(vget_high_f16(v48_55))));  \
+                                                                               \
+  vst1q_f32(c + 6 * ldc + 8, vaddq_f32(vld1q_f32(c + 6 * ldc + 8),             \
+                                       vcvt_f32_f16(vget_low_f16(v112_119)))); \
+  vst1q_f32(c + 6 * ldc + 8 + 4,                                               \
+            vaddq_f32(vld1q_f32(c + 6 * ldc + 8 + 4),                          \
+                      vcvt_f32_f16(vget_high_f16(v112_119))));                 \
+                                                                               \
+  vst1q_f32(c + 7 * ldc, vaddq_f32(vld1q_f32(c + 7 * ldc),                     \
+                                   vcvt_f32_f16(vget_low_f16(v56_63))));       \
+  vst1q_f32(c + 7 * ldc + 4, vaddq_f32(vld1q_f32(c + 7 * ldc + 4),             \
+                                       vcvt_f32_f16(vget_high_f16(v56_63))));  \
+                                                                               \
+  vst1q_f32(c + 7 * ldc + 8, vaddq_f32(vld1q_f32(c + 7 * ldc + 8),             \
+                                       vcvt_f32_f16(vget_low_f16(v120_127)))); \
+  vst1q_f32(c + 7 * ldc + 8 + 4,                                               \
+            vaddq_f32(vld1q_f32(c + 7 * ldc + 8 + 4),                          \
+                      vcvt_f32_f16(vget_high_f16(v120_127))));
+
 /**
  * @brief hgemm 8x16 kernel sc = sa * sb
  *
@@ -425,6 +838,9 @@ void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
   __fp16 *a = sa, *b = sb;
   float *c = sc;
   unsigned int i, j, l;
+  unsigned int K4 = (K >> 2) << 2;
+  unsigned int K8 = (K >> 3) << 3;
+  unsigned int K16 = (K >> 4) << 4;
   for (i = 0; i < M; i += 8) {
     for (j = 0; j < N; j += 16) {
       __builtin_prefetch(b, 0, 3);
@@ -440,106 +856,21 @@ void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
       float16x8_t v24, v25, v26, v27, v28, v29, v30, v31;
       float16x8_t va0, va1, va2, va3, va4, va5, va6, va7;
       l = 0;
-      for (; l < K;) {
+      for (; l < K16;) {
+        KERNEL_8x16_ACC16();
+        SAVE_KERNEL_8X16_F16_F32();
+      }
+      for (; l < K8;) {
         KERNEL_8x16_ACC8();
-
-        vst1q_f32(c, vaddq_f32(vld1q_f32(c), vcvt_f32_f16(vget_low_f16(v0_7))));
-        vst1q_f32(c + 4, vaddq_f32(vld1q_f32(c + 4),
-                                   vcvt_f32_f16(vget_high_f16(v0_7))));
-
-        vst1q_f32(c + 8, vaddq_f32(vld1q_f32(c + 8),
-                                   vcvt_f32_f16(vget_low_f16(v64_71))));
-        vst1q_f32(c + 8 + 4, vaddq_f32(vld1q_f32(c + 8 + 4),
-                                       vcvt_f32_f16(vget_high_f16(v64_71))));
-
-        vst1q_f32(c + ldc, vaddq_f32(vld1q_f32(c + ldc),
-                                     vcvt_f32_f16(vget_low_f16(v8_15))));
-        vst1q_f32(c + ldc + 4, vaddq_f32(vld1q_f32(c + ldc + 4),
-                                         vcvt_f32_f16(vget_high_f16(v8_15))));
-
-        vst1q_f32(c + ldc + 8, vaddq_f32(vld1q_f32(c + ldc + 8),
-                                         vcvt_f32_f16(vget_low_f16(v72_79))));
-        vst1q_f32(c + ldc + 8 + 4,
-                  vaddq_f32(vld1q_f32(c + ldc + 8 + 4),
-                            vcvt_f32_f16(vget_high_f16(v72_79))));
-
-        vst1q_f32(c + 2 * ldc, vaddq_f32(vld1q_f32(c + 2 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v16_23))));
-        vst1q_f32(c + 2 * ldc + 4,
-                  vaddq_f32(vld1q_f32(c + 2 * ldc + 4),
-                            vcvt_f32_f16(vget_high_f16(v16_23))));
-
-        vst1q_f32(c + 2 * ldc + 8,
-                  vaddq_f32(vld1q_f32(c + 2 * ldc + 8),
-                            vcvt_f32_f16(vget_low_f16(v80_87))));
-        vst1q_f32(c + 2 * ldc + 8 + 4,
-                  vaddq_f32(vld1q_f32(c + 2 * ldc + 8 + 4),
-                            vcvt_f32_f16(vget_high_f16(v80_87))));
-
-        vst1q_f32(c + 3 * ldc, vaddq_f32(vld1q_f32(c + 3 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v24_31))));
-        vst1q_f32(c + 3 * ldc + 4,
-                  vaddq_f32(vld1q_f32(c + 3 * ldc + 4),
-                            vcvt_f32_f16(vget_high_f16(v24_31))));
-
-        vst1q_f32(c + 3 * ldc + 8,
-                  vaddq_f32(vld1q_f32(c + 3 * ldc + 8),
-                            vcvt_f32_f16(vget_low_f16(v88_95))));
-        vst1q_f32(c + 3 * ldc + 8 + 4,
-                  vaddq_f32(vld1q_f32(c + 3 * ldc + 8 + 4),
-                            vcvt_f32_f16(vget_high_f16(v88_95))));
-
-        vst1q_f32(c + 4 * ldc, vaddq_f32(vld1q_f32(c + 4 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v32_39))));
-        vst1q_f32(c + 4 * ldc + 4,
-                  vaddq_f32(vld1q_f32(c + 4 * ldc + 4),
-                            vcvt_f32_f16(vget_high_f16(v32_39))));
-
-        vst1q_f32(c + 4 * ldc + 8,
-                  vaddq_f32(vld1q_f32(c + 4 * ldc + 8),
-                            vcvt_f32_f16(vget_low_f16(v96_103))));
-        vst1q_f32(c + 4 * ldc + 8 + 4,
-                  vaddq_f32(vld1q_f32(c + 4 * ldc + 8 + 4),
-                            vcvt_f32_f16(vget_high_f16(v96_103))));
-
-        vst1q_f32(c + 5 * ldc, vaddq_f32(vld1q_f32(c + 5 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v40_47))));
-        vst1q_f32(c + 5 * ldc + 4,
-                  vaddq_f32(vld1q_f32(c + 5 * ldc + 4),
-                            vcvt_f32_f16(vget_high_f16(v40_47))));
-
-        vst1q_f32(c + 5 * ldc + 8,
-                  vaddq_f32(vld1q_f32(c + 5 * ldc + 8),
-                            vcvt_f32_f16(vget_low_f16(v104_111))));
-        vst1q_f32(c + 5 * ldc + 8 + 4,
-                  vaddq_f32(vld1q_f32(c + 5 * ldc + 8 + 4),
-                            vcvt_f32_f16(vget_high_f16(v104_111))));
-
-        vst1q_f32(c + 6 * ldc, vaddq_f32(vld1q_f32(c + 6 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v48_55))));
-        vst1q_f32(c + 6 * ldc + 4,
-                  vaddq_f32(vld1q_f32(c + 6 * ldc + 4),
-                            vcvt_f32_f16(vget_high_f16(v48_55))));
-
-        vst1q_f32(c + 6 * ldc + 8,
-                  vaddq_f32(vld1q_f32(c + 6 * ldc + 8),
-                            vcvt_f32_f16(vget_low_f16(v112_119))));
-        vst1q_f32(c + 6 * ldc + 8 + 4,
-                  vaddq_f32(vld1q_f32(c + 6 * ldc + 8 + 4),
-                            vcvt_f32_f16(vget_high_f16(v112_119))));
-
-        vst1q_f32(c + 7 * ldc, vaddq_f32(vld1q_f32(c + 7 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v56_63))));
-        vst1q_f32(c + 7 * ldc + 4,
-                  vaddq_f32(vld1q_f32(c + 7 * ldc + 4),
-                            vcvt_f32_f16(vget_high_f16(v56_63))));
-
-        vst1q_f32(c + 7 * ldc + 8,
-                  vaddq_f32(vld1q_f32(c + 7 * ldc + 8),
-                            vcvt_f32_f16(vget_low_f16(v120_127))));
-        vst1q_f32(c + 7 * ldc + 8 + 4,
-                  vaddq_f32(vld1q_f32(c + 7 * ldc + 8 + 4),
-                            vcvt_f32_f16(vget_high_f16(v120_127))));
+        SAVE_KERNEL_8X16_F16_F32();
+      }
+      for (; l < K4;) {
+        KERNEL_8x16_ACC4();
+        SAVE_KERNEL_8X16_F16_F32();
+      }
+      for (; l < K;) {
+        KERNEL_8x16_ACC1();
+        SAVE_KERNEL_8X16_F16_F32();
       }
       c += 16;
       a -= 8 * K;

--- a/nntrainer/tensor/hgemm/hgemm_kernel_8x8.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_8x8.h
@@ -17,7 +17,183 @@
 /// @note Following KERNELs are the combinations of accuracy-latency
 /// tradeoff. User can select which kernel to use by replacing them.
 
-// 1. Partial sum 512 digits : Worst accuracy, best latency
+// 1. Partial sum 1024 digits : Worst accuracy, best latency
+#define KERNEL_8x8_ACC16()                 \
+  v24 = vdupq_n_f16(0.F);                  \
+  v25 = vdupq_n_f16(0.F);                  \
+  v26 = vdupq_n_f16(0.F);                  \
+  v27 = vdupq_n_f16(0.F);                  \
+  v28 = vdupq_n_f16(0.F);                  \
+  v29 = vdupq_n_f16(0.F);                  \
+  v30 = vdupq_n_f16(0.F);                  \
+  v31 = vdupq_n_f16(0.F);                  \
+  va0 = vld1q_f16(a);                      \
+  v16 = vld1q_f16(b);                      \
+  v24 = vfmaq_laneq_f16(v24, v16, va0, 0); \
+  v25 = vfmaq_laneq_f16(v25, v16, va0, 1); \
+  v26 = vfmaq_laneq_f16(v26, v16, va0, 2); \
+  v27 = vfmaq_laneq_f16(v27, v16, va0, 3); \
+  v28 = vfmaq_laneq_f16(v28, v16, va0, 4); \
+  v29 = vfmaq_laneq_f16(v29, v16, va0, 5); \
+  v30 = vfmaq_laneq_f16(v30, v16, va0, 6); \
+  v31 = vfmaq_laneq_f16(v31, v16, va0, 7); \
+  va1 = vld1q_f16(a + 8);                  \
+  v17 = vld1q_f16(b + 8);                  \
+  v24 = vfmaq_laneq_f16(v24, v17, va1, 0); \
+  v25 = vfmaq_laneq_f16(v25, v17, va1, 1); \
+  v26 = vfmaq_laneq_f16(v26, v17, va1, 2); \
+  v27 = vfmaq_laneq_f16(v27, v17, va1, 3); \
+  v28 = vfmaq_laneq_f16(v28, v17, va1, 4); \
+  v29 = vfmaq_laneq_f16(v29, v17, va1, 5); \
+  v30 = vfmaq_laneq_f16(v30, v17, va1, 6); \
+  v31 = vfmaq_laneq_f16(v31, v17, va1, 7); \
+  va2 = vld1q_f16(a + 8 * 2);              \
+  v18 = vld1q_f16(b + 8 * 2);              \
+  v24 = vfmaq_laneq_f16(v24, v18, va2, 0); \
+  v25 = vfmaq_laneq_f16(v25, v18, va2, 1); \
+  v26 = vfmaq_laneq_f16(v26, v18, va2, 2); \
+  v27 = vfmaq_laneq_f16(v27, v18, va2, 3); \
+  v28 = vfmaq_laneq_f16(v28, v18, va2, 4); \
+  v29 = vfmaq_laneq_f16(v29, v18, va2, 5); \
+  v30 = vfmaq_laneq_f16(v30, v18, va2, 6); \
+  v31 = vfmaq_laneq_f16(v31, v18, va2, 7); \
+  va3 = vld1q_f16(a + 8 * 3);              \
+  v19 = vld1q_f16(b + 8 * 3);              \
+  v24 = vfmaq_laneq_f16(v24, v19, va3, 0); \
+  v25 = vfmaq_laneq_f16(v25, v19, va3, 1); \
+  v26 = vfmaq_laneq_f16(v26, v19, va3, 2); \
+  v27 = vfmaq_laneq_f16(v27, v19, va3, 3); \
+  v28 = vfmaq_laneq_f16(v28, v19, va3, 4); \
+  v29 = vfmaq_laneq_f16(v29, v19, va3, 5); \
+  v30 = vfmaq_laneq_f16(v30, v19, va3, 6); \
+  v31 = vfmaq_laneq_f16(v31, v19, va3, 7); \
+  va4 = vld1q_f16(a + 8 * 4);              \
+  v20 = vld1q_f16(b + 8 * 4);              \
+  v24 = vfmaq_laneq_f16(v24, v20, va4, 0); \
+  v25 = vfmaq_laneq_f16(v25, v20, va4, 1); \
+  v26 = vfmaq_laneq_f16(v26, v20, va4, 2); \
+  v27 = vfmaq_laneq_f16(v27, v20, va4, 3); \
+  v28 = vfmaq_laneq_f16(v28, v20, va4, 4); \
+  v29 = vfmaq_laneq_f16(v29, v20, va4, 5); \
+  v30 = vfmaq_laneq_f16(v30, v20, va4, 6); \
+  v31 = vfmaq_laneq_f16(v31, v20, va4, 7); \
+  va5 = vld1q_f16(a + 8 * 5);              \
+  v21 = vld1q_f16(b + 8 * 5);              \
+  v24 = vfmaq_laneq_f16(v24, v21, va5, 0); \
+  v25 = vfmaq_laneq_f16(v25, v21, va5, 1); \
+  v26 = vfmaq_laneq_f16(v26, v21, va5, 2); \
+  v27 = vfmaq_laneq_f16(v27, v21, va5, 3); \
+  v28 = vfmaq_laneq_f16(v28, v21, va5, 4); \
+  v29 = vfmaq_laneq_f16(v29, v21, va5, 5); \
+  v30 = vfmaq_laneq_f16(v30, v21, va5, 6); \
+  v31 = vfmaq_laneq_f16(v31, v21, va5, 7); \
+  va6 = vld1q_f16(a + 8 * 6);              \
+  v22 = vld1q_f16(b + 8 * 6);              \
+  v24 = vfmaq_laneq_f16(v24, v22, va6, 0); \
+  v25 = vfmaq_laneq_f16(v25, v22, va6, 1); \
+  v26 = vfmaq_laneq_f16(v26, v22, va6, 2); \
+  v27 = vfmaq_laneq_f16(v27, v22, va6, 3); \
+  v28 = vfmaq_laneq_f16(v28, v22, va6, 4); \
+  v29 = vfmaq_laneq_f16(v29, v22, va6, 5); \
+  v30 = vfmaq_laneq_f16(v30, v22, va6, 6); \
+  v31 = vfmaq_laneq_f16(v31, v22, va6, 7); \
+  va7 = vld1q_f16(a + 8 * 7);              \
+  v23 = vld1q_f16(b + 8 * 7);              \
+  v24 = vfmaq_laneq_f16(v24, v23, va7, 0); \
+  v25 = vfmaq_laneq_f16(v25, v23, va7, 1); \
+  v26 = vfmaq_laneq_f16(v26, v23, va7, 2); \
+  v27 = vfmaq_laneq_f16(v27, v23, va7, 3); \
+  v28 = vfmaq_laneq_f16(v28, v23, va7, 4); \
+  v29 = vfmaq_laneq_f16(v29, v23, va7, 5); \
+  v30 = vfmaq_laneq_f16(v30, v23, va7, 6); \
+  v31 = vfmaq_laneq_f16(v31, v23, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 8);              \
+  v23 = vld1q_f16(b + 8 * 8);              \
+  v24 = vfmaq_laneq_f16(v24, v23, va7, 0); \
+  v25 = vfmaq_laneq_f16(v25, v23, va7, 1); \
+  v26 = vfmaq_laneq_f16(v26, v23, va7, 2); \
+  v27 = vfmaq_laneq_f16(v27, v23, va7, 3); \
+  v28 = vfmaq_laneq_f16(v28, v23, va7, 4); \
+  v29 = vfmaq_laneq_f16(v29, v23, va7, 5); \
+  v30 = vfmaq_laneq_f16(v30, v23, va7, 6); \
+  v31 = vfmaq_laneq_f16(v31, v23, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 9);              \
+  v23 = vld1q_f16(b + 8 * 9);              \
+  v24 = vfmaq_laneq_f16(v24, v23, va7, 0); \
+  v25 = vfmaq_laneq_f16(v25, v23, va7, 1); \
+  v26 = vfmaq_laneq_f16(v26, v23, va7, 2); \
+  v27 = vfmaq_laneq_f16(v27, v23, va7, 3); \
+  v28 = vfmaq_laneq_f16(v28, v23, va7, 4); \
+  v29 = vfmaq_laneq_f16(v29, v23, va7, 5); \
+  v30 = vfmaq_laneq_f16(v30, v23, va7, 6); \
+  v31 = vfmaq_laneq_f16(v31, v23, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 10);             \
+  v23 = vld1q_f16(b + 8 * 10);             \
+  v24 = vfmaq_laneq_f16(v24, v23, va7, 0); \
+  v25 = vfmaq_laneq_f16(v25, v23, va7, 1); \
+  v26 = vfmaq_laneq_f16(v26, v23, va7, 2); \
+  v27 = vfmaq_laneq_f16(v27, v23, va7, 3); \
+  v28 = vfmaq_laneq_f16(v28, v23, va7, 4); \
+  v29 = vfmaq_laneq_f16(v29, v23, va7, 5); \
+  v30 = vfmaq_laneq_f16(v30, v23, va7, 6); \
+  v31 = vfmaq_laneq_f16(v31, v23, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 11);             \
+  v23 = vld1q_f16(b + 8 * 11);             \
+  v24 = vfmaq_laneq_f16(v24, v23, va7, 0); \
+  v25 = vfmaq_laneq_f16(v25, v23, va7, 1); \
+  v26 = vfmaq_laneq_f16(v26, v23, va7, 2); \
+  v27 = vfmaq_laneq_f16(v27, v23, va7, 3); \
+  v28 = vfmaq_laneq_f16(v28, v23, va7, 4); \
+  v29 = vfmaq_laneq_f16(v29, v23, va7, 5); \
+  v30 = vfmaq_laneq_f16(v30, v23, va7, 6); \
+  v31 = vfmaq_laneq_f16(v31, v23, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 12);             \
+  v23 = vld1q_f16(b + 8 * 12);             \
+  v24 = vfmaq_laneq_f16(v24, v23, va7, 0); \
+  v25 = vfmaq_laneq_f16(v25, v23, va7, 1); \
+  v26 = vfmaq_laneq_f16(v26, v23, va7, 2); \
+  v27 = vfmaq_laneq_f16(v27, v23, va7, 3); \
+  v28 = vfmaq_laneq_f16(v28, v23, va7, 4); \
+  v29 = vfmaq_laneq_f16(v29, v23, va7, 5); \
+  v30 = vfmaq_laneq_f16(v30, v23, va7, 6); \
+  v31 = vfmaq_laneq_f16(v31, v23, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 13);             \
+  v23 = vld1q_f16(b + 8 * 13);             \
+  v24 = vfmaq_laneq_f16(v24, v23, va7, 0); \
+  v25 = vfmaq_laneq_f16(v25, v23, va7, 1); \
+  v26 = vfmaq_laneq_f16(v26, v23, va7, 2); \
+  v27 = vfmaq_laneq_f16(v27, v23, va7, 3); \
+  v28 = vfmaq_laneq_f16(v28, v23, va7, 4); \
+  v29 = vfmaq_laneq_f16(v29, v23, va7, 5); \
+  v30 = vfmaq_laneq_f16(v30, v23, va7, 6); \
+  v31 = vfmaq_laneq_f16(v31, v23, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 14);             \
+  v23 = vld1q_f16(b + 8 * 14);             \
+  v24 = vfmaq_laneq_f16(v24, v23, va7, 0); \
+  v25 = vfmaq_laneq_f16(v25, v23, va7, 1); \
+  v26 = vfmaq_laneq_f16(v26, v23, va7, 2); \
+  v27 = vfmaq_laneq_f16(v27, v23, va7, 3); \
+  v28 = vfmaq_laneq_f16(v28, v23, va7, 4); \
+  v29 = vfmaq_laneq_f16(v29, v23, va7, 5); \
+  v30 = vfmaq_laneq_f16(v30, v23, va7, 6); \
+  v31 = vfmaq_laneq_f16(v31, v23, va7, 7); \
+  va7 = vld1q_f16(a + 8 * 15);             \
+  v23 = vld1q_f16(b + 8 * 15);             \
+  v24 = vfmaq_laneq_f16(v24, v23, va7, 0); \
+  v25 = vfmaq_laneq_f16(v25, v23, va7, 1); \
+  v26 = vfmaq_laneq_f16(v26, v23, va7, 2); \
+  v27 = vfmaq_laneq_f16(v27, v23, va7, 3); \
+  v28 = vfmaq_laneq_f16(v28, v23, va7, 4); \
+  v29 = vfmaq_laneq_f16(v29, v23, va7, 5); \
+  v30 = vfmaq_laneq_f16(v30, v23, va7, 6); \
+  v31 = vfmaq_laneq_f16(v31, v23, va7, 7); \
+  __builtin_prefetch(b + 128, 0, 3);       \
+  __builtin_prefetch(a + 128, 0, 3);       \
+  l += 16;                                 \
+  b += 8 * 16;                             \
+  a += 8 * 16;
+
+// 2. Partial sum 512 digits : Medium accuracy, medium latency
 #define KERNEL_8x8_ACC8()                  \
   v24 = vdupq_n_f16(0.F);                  \
   v25 = vdupq_n_f16(0.F);                  \
@@ -113,7 +289,7 @@
   b += 8 * 8;                              \
   a += 8 * 8;
 
-// 2. Partial sum 256 digits : Medium accuracy, medium latency
+// 3. Partial sum 256 digits : Medium accuracy, medium latency
 #define KERNEL_8x8_ACC4()                  \
   v24 = vdupq_n_f16(0.F);                  \
   v25 = vdupq_n_f16(0.F);                  \
@@ -169,7 +345,7 @@
   b += 8 * 4;                              \
   a += 8 * 4;
 
-// 3. Partial sum 64 digits : Best accuracy, worst latency
+// 4. Partial sum 64 digits : Best accuracy, worst latency
 #define KERNEL_8x8_ACC1()                  \
   v24 = vdupq_n_f16(0.F);                  \
   v25 = vdupq_n_f16(0.F);                  \
@@ -194,6 +370,46 @@
   l += 1;                                  \
   b += 8 * 1;                              \
   a += 8 * 1;
+
+#define SAVE_KERNEL_8X8_F16_f32()                                            \
+  vst1q_f32(c, vaddq_f32(vld1q_f32(c), vcvt_f32_f16(vget_low_f16(v24))));    \
+  vst1q_f32(c + 4,                                                           \
+            vaddq_f32(vld1q_f32(c + 4), vcvt_f32_f16(vget_high_f16(v24))));  \
+                                                                             \
+  vst1q_f32(c + ldc,                                                         \
+            vaddq_f32(vld1q_f32(c + ldc), vcvt_f32_f16(vget_low_f16(v25)))); \
+  vst1q_f32(c + 4 + ldc, vaddq_f32(vld1q_f32(c + 4 + ldc),                   \
+                                   vcvt_f32_f16(vget_high_f16(v25))));       \
+                                                                             \
+  vst1q_f32(c + 2 * ldc, vaddq_f32(vld1q_f32(c + 2 * ldc),                   \
+                                   vcvt_f32_f16(vget_low_f16(v26))));        \
+  vst1q_f32(c + 4 + 2 * ldc, vaddq_f32(vld1q_f32(c + 4 + 2 * ldc),           \
+                                       vcvt_f32_f16(vget_high_f16(v26))));   \
+                                                                             \
+  vst1q_f32(c + 3 * ldc, vaddq_f32(vld1q_f32(c + 3 * ldc),                   \
+                                   vcvt_f32_f16(vget_low_f16(v27))));        \
+  vst1q_f32(c + 4 + 3 * ldc, vaddq_f32(vld1q_f32(c + 4 + 3 * ldc),           \
+                                       vcvt_f32_f16(vget_high_f16(v27))));   \
+                                                                             \
+  vst1q_f32(c + 4 * ldc, vaddq_f32(vld1q_f32(c + 4 * ldc),                   \
+                                   vcvt_f32_f16(vget_low_f16(v28))));        \
+  vst1q_f32(c + 4 + 4 * ldc, vaddq_f32(vld1q_f32(c + 4 + 4 * ldc),           \
+                                       vcvt_f32_f16(vget_high_f16(v28))));   \
+                                                                             \
+  vst1q_f32(c + 5 * ldc, vaddq_f32(vld1q_f32(c + 5 * ldc),                   \
+                                   vcvt_f32_f16(vget_low_f16(v29))));        \
+  vst1q_f32(c + 4 + 5 * ldc, vaddq_f32(vld1q_f32(c + 4 + 5 * ldc),           \
+                                       vcvt_f32_f16(vget_high_f16(v29))));   \
+                                                                             \
+  vst1q_f32(c + 6 * ldc, vaddq_f32(vld1q_f32(c + 6 * ldc),                   \
+                                   vcvt_f32_f16(vget_low_f16(v30))));        \
+  vst1q_f32(c + 4 + 6 * ldc, vaddq_f32(vld1q_f32(c + 4 + 6 * ldc),           \
+                                       vcvt_f32_f16(vget_high_f16(v30))));   \
+                                                                             \
+  vst1q_f32(c + 7 * ldc, vaddq_f32(vld1q_f32(c + 7 * ldc),                   \
+                                   vcvt_f32_f16(vget_low_f16(v31))));        \
+  vst1q_f32(c + 4 + 7 * ldc, vaddq_f32(vld1q_f32(c + 4 + 7 * ldc),           \
+                                       vcvt_f32_f16(vget_high_f16(v31))));
 
 /**
  * @brief hgemm 8x8 kernel sc = sa * sb
@@ -263,6 +479,9 @@ void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
   __fp16 *a = sa, *b = sb;
   float *c = sc;
   unsigned int i, j, l;
+  unsigned int K4 = (K >> 2) << 2;
+  unsigned int K8 = (K >> 3) << 3;
+  unsigned int K16 = (K >> 4) << 4;
   for (i = 0; i < M; i += VL_FP16) {
     for (j = 0; j < N; j += VL_FP16) {
       __builtin_prefetch(b, 0, 3);
@@ -272,48 +491,21 @@ void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
       float16x8_t v24, v25, v26, v27, v28, v29, v30, v31;
       float16x8_t va0, va1, va2, va3, va4, va5, va6, va7;
       l = 0;
-
-      for (; l < K;) {
+      for (; l < K16;) {
+        KERNEL_8x8_ACC16();
+        SAVE_KERNEL_8X8_F16_f32();
+      }
+      for (; l < K8;) {
         KERNEL_8x8_ACC8();
-
-        vst1q_f32(c, vaddq_f32(vld1q_f32(c), vcvt_f32_f16(vget_low_f16(v24))));
-        vst1q_f32(
-          c + 4, vaddq_f32(vld1q_f32(c + 4), vcvt_f32_f16(vget_high_f16(v24))));
-
-        vst1q_f32(c + ldc, vaddq_f32(vld1q_f32(c + ldc),
-                                     vcvt_f32_f16(vget_low_f16(v25))));
-        vst1q_f32(c + 4 + ldc, vaddq_f32(vld1q_f32(c + 4 + ldc),
-                                         vcvt_f32_f16(vget_high_f16(v25))));
-
-        vst1q_f32(c + 2 * ldc, vaddq_f32(vld1q_f32(c + 2 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v26))));
-        vst1q_f32(c + 4 + 2 * ldc, vaddq_f32(vld1q_f32(c + 4 + 2 * ldc),
-                                             vcvt_f32_f16(vget_high_f16(v26))));
-
-        vst1q_f32(c + 3 * ldc, vaddq_f32(vld1q_f32(c + 3 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v27))));
-        vst1q_f32(c + 4 + 3 * ldc, vaddq_f32(vld1q_f32(c + 4 + 3 * ldc),
-                                             vcvt_f32_f16(vget_high_f16(v27))));
-
-        vst1q_f32(c + 4 * ldc, vaddq_f32(vld1q_f32(c + 4 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v28))));
-        vst1q_f32(c + 4 + 4 * ldc, vaddq_f32(vld1q_f32(c + 4 + 4 * ldc),
-                                             vcvt_f32_f16(vget_high_f16(v28))));
-
-        vst1q_f32(c + 5 * ldc, vaddq_f32(vld1q_f32(c + 5 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v29))));
-        vst1q_f32(c + 4 + 5 * ldc, vaddq_f32(vld1q_f32(c + 4 + 5 * ldc),
-                                             vcvt_f32_f16(vget_high_f16(v29))));
-
-        vst1q_f32(c + 6 * ldc, vaddq_f32(vld1q_f32(c + 6 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v30))));
-        vst1q_f32(c + 4 + 6 * ldc, vaddq_f32(vld1q_f32(c + 4 + 6 * ldc),
-                                             vcvt_f32_f16(vget_high_f16(v30))));
-
-        vst1q_f32(c + 7 * ldc, vaddq_f32(vld1q_f32(c + 7 * ldc),
-                                         vcvt_f32_f16(vget_low_f16(v31))));
-        vst1q_f32(c + 4 + 7 * ldc, vaddq_f32(vld1q_f32(c + 4 + 7 * ldc),
-                                             vcvt_f32_f16(vget_high_f16(v31))));
+        SAVE_KERNEL_8X8_F16_f32();
+      }
+      for (; l < K4;) {
+        KERNEL_8x8_ACC4();
+        SAVE_KERNEL_8X8_F16_f32();
+      }
+      for (; l < K;) {
+        KERNEL_8x8_ACC1();
+        SAVE_KERNEL_8X8_F16_f32();
       }
 
       c += 8;

--- a/nntrainer/tensor/hgemm/hgemm_kernel_8x8.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_8x8.h
@@ -24,7 +24,7 @@
   v30 = vdupq_n_f16(0.F); \
   v31 = vdupq_n_f16(0.F);
 
-// 1. Partial sum 1024 digits : Worst accuracy, best latency
+// 1. Partial sum 1024 digits
 #define KERNEL_8x8_ACC16()                 \
   va0 = vld1q_f16(a);                      \
   v16 = vld1q_f16(b);                      \
@@ -192,7 +192,7 @@
   b += 8 * 16;                             \
   a += 8 * 16;
 
-// 2. Partial sum 512 digits : Medium accuracy, medium latency
+// 2. Partial sum 512 digits
 #define KERNEL_8x8_ACC8()                  \
   va0 = vld1q_f16(a);                      \
   v16 = vld1q_f16(b);                      \
@@ -280,7 +280,7 @@
   b += 8 * 8;                              \
   a += 8 * 8;
 
-// 3. Partial sum 256 digits : Medium accuracy, medium latency
+// 3. Partial sum 256 digits
 #define KERNEL_8x8_ACC4()                  \
   va0 = vld1q_f16(a);                      \
   v16 = vld1q_f16(b);                      \
@@ -328,7 +328,7 @@
   b += 8 * 4;                              \
   a += 8 * 4;
 
-// 4. Partial sum 64 digits : Best accuracy, worst latency
+// 4. Partial sum 64 digits
 #define KERNEL_8x8_ACC1()                  \
   va0 = vld1q_f16(a);                      \
   v16 = vld1q_f16(b);                      \

--- a/nntrainer/tensor/hgemm/hgemm_kernel_8x8.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel_8x8.h
@@ -14,19 +14,18 @@
 #include <hgemm_common.h>
 #include <stdlib.h>
 
-/// @note Following KERNELs are the combinations of accuracy-latency
-/// tradeoff. User can select which kernel to use by replacing them.
+#define INIT_KERNEL_8x8() \
+  v24 = vdupq_n_f16(0.F); \
+  v25 = vdupq_n_f16(0.F); \
+  v26 = vdupq_n_f16(0.F); \
+  v27 = vdupq_n_f16(0.F); \
+  v28 = vdupq_n_f16(0.F); \
+  v29 = vdupq_n_f16(0.F); \
+  v30 = vdupq_n_f16(0.F); \
+  v31 = vdupq_n_f16(0.F);
 
 // 1. Partial sum 1024 digits : Worst accuracy, best latency
 #define KERNEL_8x8_ACC16()                 \
-  v24 = vdupq_n_f16(0.F);                  \
-  v25 = vdupq_n_f16(0.F);                  \
-  v26 = vdupq_n_f16(0.F);                  \
-  v27 = vdupq_n_f16(0.F);                  \
-  v28 = vdupq_n_f16(0.F);                  \
-  v29 = vdupq_n_f16(0.F);                  \
-  v30 = vdupq_n_f16(0.F);                  \
-  v31 = vdupq_n_f16(0.F);                  \
   va0 = vld1q_f16(a);                      \
   v16 = vld1q_f16(b);                      \
   v24 = vfmaq_laneq_f16(v24, v16, va0, 0); \
@@ -195,14 +194,6 @@
 
 // 2. Partial sum 512 digits : Medium accuracy, medium latency
 #define KERNEL_8x8_ACC8()                  \
-  v24 = vdupq_n_f16(0.F);                  \
-  v25 = vdupq_n_f16(0.F);                  \
-  v26 = vdupq_n_f16(0.F);                  \
-  v27 = vdupq_n_f16(0.F);                  \
-  v28 = vdupq_n_f16(0.F);                  \
-  v29 = vdupq_n_f16(0.F);                  \
-  v30 = vdupq_n_f16(0.F);                  \
-  v31 = vdupq_n_f16(0.F);                  \
   va0 = vld1q_f16(a);                      \
   v16 = vld1q_f16(b);                      \
   v24 = vfmaq_laneq_f16(v24, v16, va0, 0); \
@@ -291,14 +282,6 @@
 
 // 3. Partial sum 256 digits : Medium accuracy, medium latency
 #define KERNEL_8x8_ACC4()                  \
-  v24 = vdupq_n_f16(0.F);                  \
-  v25 = vdupq_n_f16(0.F);                  \
-  v26 = vdupq_n_f16(0.F);                  \
-  v27 = vdupq_n_f16(0.F);                  \
-  v28 = vdupq_n_f16(0.F);                  \
-  v29 = vdupq_n_f16(0.F);                  \
-  v30 = vdupq_n_f16(0.F);                  \
-  v31 = vdupq_n_f16(0.F);                  \
   va0 = vld1q_f16(a);                      \
   v16 = vld1q_f16(b);                      \
   v24 = vfmaq_laneq_f16(v24, v16, va0, 0); \
@@ -347,14 +330,6 @@
 
 // 4. Partial sum 64 digits : Best accuracy, worst latency
 #define KERNEL_8x8_ACC1()                  \
-  v24 = vdupq_n_f16(0.F);                  \
-  v25 = vdupq_n_f16(0.F);                  \
-  v26 = vdupq_n_f16(0.F);                  \
-  v27 = vdupq_n_f16(0.F);                  \
-  v28 = vdupq_n_f16(0.F);                  \
-  v29 = vdupq_n_f16(0.F);                  \
-  v30 = vdupq_n_f16(0.F);                  \
-  v31 = vdupq_n_f16(0.F);                  \
   va0 = vld1q_f16(a);                      \
   v16 = vld1q_f16(b);                      \
   v24 = vfmaq_laneq_f16(v24, v16, va0, 0); \
@@ -437,19 +412,19 @@ void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
       float16x8_t v16, v17, v18, v19, v20, v21, v22, v23;
       float16x8_t v24, v25, v26, v27, v28, v29, v30, v31;
       float16x8_t va0, va1, va2, va3, va4, va5, va6, va7;
+      INIT_KERNEL_8x8();
       l = 0;
       for (; l < K;) {
-        KERNEL_8x8_ACC8();
-
-        vst1q_f16(c, vaddq_f16(vld1q_f16(c), v24));
-        vst1q_f16(c + ldc, vaddq_f16(vld1q_f16(c + ldc), v25));
-        vst1q_f16(c + 2 * ldc, vaddq_f16(vld1q_f16(c + 2 * ldc), v26));
-        vst1q_f16(c + 3 * ldc, vaddq_f16(vld1q_f16(c + 3 * ldc), v27));
-        vst1q_f16(c + 4 * ldc, vaddq_f16(vld1q_f16(c + 4 * ldc), v28));
-        vst1q_f16(c + 5 * ldc, vaddq_f16(vld1q_f16(c + 5 * ldc), v29));
-        vst1q_f16(c + 6 * ldc, vaddq_f16(vld1q_f16(c + 6 * ldc), v30));
-        vst1q_f16(c + 7 * ldc, vaddq_f16(vld1q_f16(c + 7 * ldc), v31));
+        KERNEL_8x8_ACC1();
       }
+      vst1q_f16(c, vaddq_f16(vld1q_f16(c), v24));
+      vst1q_f16(c + ldc, vaddq_f16(vld1q_f16(c + ldc), v25));
+      vst1q_f16(c + 2 * ldc, vaddq_f16(vld1q_f16(c + 2 * ldc), v26));
+      vst1q_f16(c + 3 * ldc, vaddq_f16(vld1q_f16(c + 3 * ldc), v27));
+      vst1q_f16(c + 4 * ldc, vaddq_f16(vld1q_f16(c + 4 * ldc), v28));
+      vst1q_f16(c + 5 * ldc, vaddq_f16(vld1q_f16(c + 5 * ldc), v29));
+      vst1q_f16(c + 6 * ldc, vaddq_f16(vld1q_f16(c + 6 * ldc), v30));
+      vst1q_f16(c + 7 * ldc, vaddq_f16(vld1q_f16(c + 7 * ldc), v31));
       c += 8;
       a -= 8 * K;
     }
@@ -492,18 +467,22 @@ void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
       float16x8_t va0, va1, va2, va3, va4, va5, va6, va7;
       l = 0;
       for (; l < K16;) {
+        INIT_KERNEL_8x8();
         KERNEL_8x8_ACC16();
         SAVE_KERNEL_8X8_F16_f32();
       }
       for (; l < K8;) {
+        INIT_KERNEL_8x8();
         KERNEL_8x8_ACC8();
         SAVE_KERNEL_8X8_F16_f32();
       }
       for (; l < K4;) {
+        INIT_KERNEL_8x8();
         KERNEL_8x8_ACC4();
         SAVE_KERNEL_8X8_F16_f32();
       }
       for (; l < K;) {
+        INIT_KERNEL_8x8();
         KERNEL_8x8_ACC1();
         SAVE_KERNEL_8X8_F16_f32();
       }


### PR DESCRIPTION
> Unittest output using Galaxy S23 with local commit

### Latency
> mean latency with TC = 100

| dim | KERNEL_8x16_ACC16 | KERNEL_8x16_ACC8 | cblas fp32 |
| --- | --- | --- | --- |
| 1024 | **23 ms** | 30 ms | 32 ms |
| 768 | **9 ms** | 12.8 ms | 13.6 ms |
| 256x1440x256 | **2054 mcrs** | 2664 mcrs  | 2701 mcrs |
| 256x256x1440 | **2359 mcrs** | 2965 mcrs  | 3104 mcrs |

### mse w.r.t. sgemm

| dim | KERNEL_8x16_ACC16 | KERNEL_8x16_ACC8 |
| --- | --- | --- |
| 1024 |  0.00608169 | 0.00226737 |
| 768 | 0.00310214 | 0.0017091 |
| 256x1440x256  | 0.0149112 | 0.00518965 |
| 256x256x1440 | 0.00119428 | 0.000306849 |

- Overall, this shows **150% boost-up** with f16-f32 w.r.t. cblas fp32
- Considering enlarged vector length from f32 to f16, and partial-accumulation, result above sounds reasonable.
- However, this code takes a little bit of accuracy loss for its cost. Should be checked once more with model output.

### + Trivial refactor:
- unified macro-style GEMM kernels.
- adaptive K-direction loops