### PR TITLE
[ hgemm ] Support beta case @open sesame 06/04 13:13

### DIFF
--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -1555,8 +1555,10 @@ void hgemm(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M, uint32_t N,
   // performing beta*C
   unsigned int idx = 0;
   unsigned int size = M * N;
+  unsigned int size8 = (size >> 3) << 3;
+  unsigned int size4 = (size >> 2) << 2;
   if (beta != 0.F) {
-    for (; idx < (size - idx) && (size - idx) >= 8; idx += 8) {
+    for (; idx < size8; idx += 8) {
       float16x8_t c =
         vmulq_n_f16(vld1q_f16(&C[idx]), static_cast<__fp16>(beta));
 
@@ -1564,7 +1566,7 @@ void hgemm(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M, uint32_t N,
       vst1q_f32(&C32[idx + 4], vcvt_f32_f16(vget_high_f16(c)));
     }
     // remaining 4
-    for (; idx < (size - idx) && (size - idx) >= 4; idx += 4) {
+    for (; idx < size4; idx += 4) {
       float16x4_t c = vmul_n_f16(vld1_f16(&C[idx]), static_cast<__fp16>(beta));
 
       vst1q_f32(&C32[idx], vcvt_f32_f16(c));
@@ -1576,7 +1578,7 @@ void hgemm(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M, uint32_t N,
     }
   } else {
     float32x4_t zeros = vmovq_n_f32(0.F);
-    for (; idx < (size - idx) && (size - idx) >= 4; idx += 4) {
+    for (; idx < size4; idx += 4) {
       vst1q_f32(&C32[idx], zeros);
     }
     for (; idx < size; idx++) {

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -1555,22 +1555,33 @@ void hgemm(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M, uint32_t N,
   // performing beta*C
   unsigned int idx = 0;
   unsigned int size = M * N;
-  for (; idx < (size - idx) && (size - idx) >= 8; idx += 8) {
-    float16x8_t c = vmulq_n_f16(vld1q_f16(&C[idx]), static_cast<__fp16>(beta));
+  if (beta != 0.F) {
+    for (; idx < (size - idx) && (size - idx) >= 8; idx += 8) {
+      float16x8_t c =
+        vmulq_n_f16(vld1q_f16(&C[idx]), static_cast<__fp16>(beta));
 
-    vst1q_f32(&C32[idx], vcvt_f32_f16(vget_low_f16(c)));
-    vst1q_f32(&C32[idx + 4], vcvt_f32_f16(vget_high_f16(c)));
-  }
-  // remaining 4
-  for (; idx < (size - idx) && (size - idx) >= 4; idx += 4) {
-    float16x4_t c = vmul_n_f16(vld1_f16(&C[idx]), static_cast<__fp16>(beta));
+      vst1q_f32(&C32[idx], vcvt_f32_f16(vget_low_f16(c)));
+      vst1q_f32(&C32[idx + 4], vcvt_f32_f16(vget_high_f16(c)));
+    }
+    // remaining 4
+    for (; idx < (size - idx) && (size - idx) >= 4; idx += 4) {
+      float16x4_t c = vmul_n_f16(vld1_f16(&C[idx]), static_cast<__fp16>(beta));
 
-    vst1q_f32(&C32[idx], vcvt_f32_f16(c));
-  }
+      vst1q_f32(&C32[idx], vcvt_f32_f16(c));
+    }
 
-  // remaining values if dimensions not a multiple of 8
-  for (; idx < size; idx++) {
-    C32[idx] = C[idx] * beta;
+    // remaining values if dimensions not a multiple of 8
+    for (; idx < size; idx++) {
+      C32[idx] = C[idx] * beta;
+    }
+  } else {
+    float32x4_t zeros = vmovq_n_f32(0.F);
+    for (; idx < (size - idx) && (size - idx) >= 4; idx += 4) {
+      vst1q_f32(&C32[idx], zeros);
+    }
+    for (; idx < size; idx++) {
+      C32[idx] = 0.F;
+    }
   }
 
   if (!TransA && TransB) {

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -1557,7 +1557,7 @@ void hgemm(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M, uint32_t N,
   unsigned int size = M * N;
   unsigned int size8 = (size >> 3) << 3;
   unsigned int size4 = (size >> 2) << 2;
-  if (beta != 0.F) {
+  if (std::fpclassify(beta) != FP_ZERO) {
     for (; idx < size8; idx += 8) {
       float16x8_t c =
         vmulq_n_f16(vld1q_f16(&C[idx]), static_cast<__fp16>(beta));

--- a/nntrainer/tensor/hgemm/hgemm.cpp
+++ b/nntrainer/tensor/hgemm/hgemm.cpp
@@ -31,7 +31,7 @@
 
 void hgemm_noTrans(const __fp16 *A, const __fp16 *B, float *C32, unsigned int M,
                    unsigned int N, unsigned int K, float alpha, float beta) {
-  if (alpha == 1.F && beta == 0.F) {
+  if (alpha == 1.F && beta == 0.F && N > 4) {
     // used bitwise operator instead of modulo for performance
     // e.g (M % 8) is same as (M & 0x7) which will extract last 3 bits of M
     if ((M & 0x7) == 0 && (N & 0xF) == 0 && (K & 0x7) == 0) {

--- a/nntrainer/tensor/hgemm/hgemm.cpp
+++ b/nntrainer/tensor/hgemm/hgemm.cpp
@@ -31,7 +31,7 @@
 
 void hgemm_noTrans(const __fp16 *A, const __fp16 *B, float *C32, unsigned int M,
                    unsigned int N, unsigned int K, float alpha, float beta) {
-  if (alpha == 1.F && beta == 0.F && N > 4) {
+  if (alpha == 1.F) {
     // used bitwise operator instead of modulo for performance
     // e.g (M % 8) is same as (M & 0x7) which will extract last 3 bits of M
     if ((M & 0x7) == 0 && (N & 0xF) == 0 && (K & 0x7) == 0) {
@@ -53,7 +53,7 @@ void hgemm_noTrans(const __fp16 *A, const __fp16 *B, float *C32, unsigned int M,
 
 void hgemm_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
                    unsigned int N, unsigned int K, float alpha, float beta) {
-  if (alpha == 1.F && beta == 0.F) {
+  if (alpha == 1.F) {
     // used bitwise operator instead of modulo for performance
     // e.g (M % 8) is same as (M & 0x7) which will extract last 3 bits of M
     if ((M & 0x7) == 0 && (N & 0xF) == 0 && (K & 0x7) == 0) {

--- a/nntrainer/tensor/hgemm/hgemm.cpp
+++ b/nntrainer/tensor/hgemm/hgemm.cpp
@@ -12,6 +12,7 @@
  *
  */
 
+#include <cmath>
 #include <hgemm.h>
 #include <hgemm_kernel_1x4.h>
 #include <hgemm_kernel_1x8.h>
@@ -21,6 +22,7 @@
 #include <hgemm_kernel_8x8.h>
 #include <hgemm_kernel_pack.h>
 #include <hgemm_util.h>
+#include <limits>
 
 #define HGEMM_KERNEL_1x4 hgemm_kernel_1x4
 #define HGEMM_KERNEL_4x4 hgemm_kernel_4x4
@@ -31,7 +33,8 @@
 
 void hgemm_noTrans(const __fp16 *A, const __fp16 *B, float *C32, unsigned int M,
                    unsigned int N, unsigned int K, float alpha, float beta) {
-  if (alpha == 1.F) {
+  const float eps = std::numeric_limits<float>::epsilon();
+  if (std::abs(alpha - 1.F) < eps) {
     // used bitwise operator instead of modulo for performance
     // e.g (M % 8) is same as (M & 0x7) which will extract last 3 bits of M
     if ((M & 0x7) == 0 && (N & 0xF) == 0 && (K & 0x7) == 0) {

--- a/nntrainer/tensor/hgemm/hgemm.h
+++ b/nntrainer/tensor/hgemm/hgemm.h
@@ -48,9 +48,9 @@ void hgemm_noTrans(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number
@@ -68,9 +68,9 @@ void hgemm_noTrans_fallback(unsigned int M, unsigned int N, unsigned int K,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number
@@ -88,9 +88,9 @@ void hgemm_noTrans_1x4(unsigned int M, unsigned int N, unsigned int K,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number
@@ -108,9 +108,9 @@ void hgemm_noTrans_1x4(unsigned int M, unsigned int N, unsigned int K,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number
@@ -128,9 +128,9 @@ void hgemm_noTrans_4x4(unsigned int M, unsigned int N, unsigned int K,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number
@@ -148,9 +148,9 @@ void hgemm_noTrans_1x8(unsigned int M, unsigned int N, unsigned int K,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number
@@ -168,9 +168,9 @@ void hgemm_noTrans_1x8(unsigned int M, unsigned int N, unsigned int K,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number
@@ -188,9 +188,9 @@ void hgemm_noTrans_8x8(unsigned int M, unsigned int N, unsigned int K,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number
@@ -208,9 +208,9 @@ void hgemm_noTrans_4x4(unsigned int M, unsigned int N, unsigned int K,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number
@@ -228,9 +228,9 @@ void hgemm_noTrans_8x8(unsigned int M, unsigned int N, unsigned int K,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number
@@ -248,9 +248,9 @@ void hgemm_noTrans_4x8(unsigned int M, unsigned int N, unsigned int K,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number
@@ -268,9 +268,9 @@ void hgemm_noTrans_4x8(unsigned int M, unsigned int N, unsigned int K,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number
@@ -288,9 +288,9 @@ void hgemm_noTrans_8x16(unsigned int M, unsigned int N, unsigned int K,
  * @param N length of the col of matrix B
  * @param K length of the col of matrix A
  * @param A input matrix A
- * @param lda length of the col of matrix C
+ * @param lda length of the col of matrix A
  * @param B input matrix B
- * @param ldb length of the col of matrix C
+ * @param ldb length of the col of matrix B
  * @param C output matrix C
  * @param ldc length of the col of matrix C
  * @param[in] alpha float number


### PR DESCRIPTION
- This commit allows hgemm to get beta condition as well.
- Note that beta for here is as follows:
```math
C = alpha * A * B + beta * C
```
- In many cases, beta is 0.F. However, we can fuse calculation process if we have to do something like:
```C++
Tensor A, B, C;
Tensor tmp;
bool transA = false;
bool transB = false;
float scalar = 1.1F // anything you want

// redundant case 1
tmp = A.dot(B);
C.multiply_i(scalar);
C = tmp.add(C);

// use beta
C = A.dot(B, C, transA , transB, scalar);

// redundant case 2
C = A.dot(B);
C.add_i(scalar);

// use beta
C = C.ones();
C = A.dot(B, C, transA , transB, scalar);

```
- In addition add zero-init code for beta = 0.F case. According to recent model profiling result, even for initialization, minimizing instruction is quite helpful for overall model latency reduction.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: skykongkong8 <ss.kong@samsung.com>