### PR TITLE
[Nnstreamer-subplugin] Add save_path to setProperty

### DIFF
--- a/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.cc
+++ b/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.cc
@@ -555,7 +555,8 @@ void NNTrainer::NNTrainerImpl::trainModel() {
   ml_logd("pid[%d], tid[%d]", pid, tid);
 
   try {
-    model->setProperty({"epochs=" + std::to_string(num_epochs)});
+    model->setProperty(
+      {"epochs=" + std::to_string(num_epochs), "save_path=" + model_save_path});
   } catch (const std::exception &e) {
     ml_loge("Error %s, %s", typeid(e).name(), e.what());
     return;
@@ -574,14 +575,6 @@ void NNTrainer::NNTrainerImpl::trainModel() {
     return;
   }
 
-  try {
-    ml_logd("Save_model: %s", model_save_path.c_str());
-    model->save(model_save_path, ml::train::ModelFormat::MODEL_FORMAT_BIN);
-
-  } catch (const std::exception &e) {
-    ml_loge("Error %s, %s", typeid(e).name(), e.what());
-    return;
-  }
   /* send event */
   nnstreamer_trainer_notify_event(this->notifier,
                                   TRAINER_EVENT_TRAINING_COMPLETION, NULL);


### PR DESCRIPTION
- Add save_path to setProperty to save the model for each epoch.
- Remove model->save() call to avoid saving the current epoch result to the model when current epoch is interrupted

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped