### PR TITLE
[coverity] fix coverity issue

### DIFF
--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -40,8 +40,11 @@ enum FCParams { weight, bias };
 enum LORAParams { loraA, loraB, loraTmp, loraOut };
 
 FullyConnectedLayer::FullyConnectedLayer() :
-  LayerImpl(), fc_props(props::Unit(), props::LoraRank(), props::LoraAlpha()) {
+  LayerImpl(),
+  lora_scaling(1.0f),
+  fc_props(props::Unit(), props::LoraRank(), props::LoraAlpha()) {
   weight_idx.fill(std::numeric_limits<unsigned>::max());
+  lora_idx.fill(std::numeric_limits<unsigned>::max());
 }
 
 void FullyConnectedLayer::finalize(InitLayerContext &context) {


### PR DESCRIPTION
This PR resolves the coverity issue of the constructor may not initialize class members.

**Changes proposed in this PR:**
- initialize lora_idx and lora_scaling in class constructor.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped