### PR TITLE
Edited build instructions for Resnet18 test

### DIFF
--- a/Applications/Resnet/README.md
+++ b/Applications/Resnet/README.md
@@ -14,7 +14,7 @@ Please file an issue if you have a problem running the example.
 
 ```bash
 $ meson ${build_dir} -Denable-test=true -Denable-long-test=true
-$ meson test app_resnet18 -v -c ${build_dir}
+$ meson test app_resnet18 -v -C ${build_dir}
 ```
 
 ### To run with a real data.


### PR DESCRIPTION
Edited build instructions for Resnet18 test
**Fixing the meson build option**

Resolves: Error on building the test example where it says  `-c is an un-recognized option` and in the meson documentation -C is used, so it seems to be a typo. 

**Self evaluation:**
1. Build test:     []Passed [ ]Failed [ X]Skipped
2. Run test:     []Passed [ ]Failed [ X]Skipped