### PR TITLE
[GPU/OpenCL] Added fp16 support for FC layer on GPU

### DIFF
--- a/nntrainer/layers/cl_layers/blas_kernels.h
+++ b/nntrainer/layers/cl_layers/blas_kernels.h
@@ -25,8 +25,11 @@ namespace nntrainer {
  * @brief declaring global kernel objects
  */
 extern opencl::Kernel kernel_sgemv;
+extern opencl::Kernel kernel_sgemv_fp16;
 extern opencl::Kernel kernel_sgemm;
+extern opencl::Kernel kernel_sgemm_fp16;
 extern opencl::Kernel kernel_dot;
+extern opencl::Kernel kernel_dot_fp16;
 
 /**
  * @brief     sgemv computation : Y = A*X + Y
@@ -43,14 +46,40 @@ void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
               RunLayerContext &context);
 
 /**
+ * @brief     fp16 sgemv computation : Y = A*X + Y
+ * @param[in] matAdata fp16 * for Matrix A
+ * @param[in] vecXdata fp16 * for Vector X
+ * @param[in] vecYdata fp16 * for Vector Y
+ * @param[in] dim1 number of A's columns
+ * @param[in] dim2 number of A's rows
+ * @param[in] lda number of X's columns
+ * @param[in] context RunLayerContext reference
+ */
+void sgemv_cl(const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
+              unsigned int dim1, unsigned int dim2, unsigned int lda,
+              RunLayerContext &context);
+
+/**
  * @brief     dot computation : sum of all X * Y
  * @param[in] vecAdata float * for Vector A
  * @param[in] vecXdata float * for Vector X
  * @param[in] dim1 number of elements in both input vectors
  * @param[in] context RunLayerContext reference
+ * @return    float dot product result
  */
 float dot_cl(const float *vecAdata, const float *vecXdata, unsigned int dim1,
              RunLayerContext &context);
+
+/**
+ * @brief     fp16 dot computation : sum of all X * Y
+ * @param[in] vecAdata fp16 * for Vector A
+ * @param[in] vecXdata fp16 * for Vector X
+ * @param[in] dim1 number of elements in both input vectors
+ * @param[in] context RunLayerContext reference
+ * @return    fp16 dot product result
+ */
+__fp16 dot_cl(const __fp16 *vecAdata, const __fp16 *vecXdata, unsigned int dim1,
+              RunLayerContext &context);
 
 /**
  * @brief     sgemm computation : Y = op(A)*op(B) + C,
@@ -67,6 +96,24 @@ float dot_cl(const float *vecAdata, const float *vecXdata, unsigned int dim1,
  * @param[in] context RunLayerContext reference
  */
 void sgemm_cl(const float *A, const float *B, float *C, unsigned int M,
+              unsigned int N, unsigned int K, unsigned int lda,
+              unsigned int ldb, unsigned int ldc, RunLayerContext &context);
+
+/**
+ * @brief     fp16 sgemm computation : Y = op(A)*op(B) + C,
+ * where op(X) is one of X or X**T
+ * @param[in] A fp16 * for Matrix A
+ * @param[in] B fp16 * for Matrix B
+ * @param[in] C fp16 * for Matrix C
+ * @param[in] M number of op(A)'s and C's row
+ * @param[in] N number of op(B)'s and C's columns
+ * @param[in] K number of op(A)'s and columns and op(B)'s rows
+ * @param[in] lda number of A's columns
+ * @param[in] ldb number of B's columns
+ * @param[in] ldc number of C's columns
+ * @param[in] context RunLayerContext reference
+ */
+void sgemm_cl(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
               unsigned int N, unsigned int K, unsigned int lda,
               unsigned int ldb, unsigned int ldc, RunLayerContext &context);
 

--- a/nntrainer/layers/cl_layers/meson.build
+++ b/nntrainer/layers/cl_layers/meson.build
@@ -1,7 +1,11 @@
 cl_layer_sources = [
   'fc_layer_cl.cpp',
-  'blas_kernels.cpp'
+  'blas_kernels.cpp',
 ]
+
+if get_option('enable-fp16')
+  cl_layer_sources += 'blas_kernels_fp16.cpp'
+endif
 
 foreach s : cl_layer_sources
   nntrainer_sources += meson.current_source_dir() / s

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -656,6 +656,12 @@ std::string RunLayerContext::getKernelName(LayerKernel layerKernel) {
     return "dot_cl";
   case LayerKernel::SGEMM:
     return "sgemm_cl";
+  case LayerKernel::SGEMV_FP16:
+    return "sgemv_cl_fp16";
+  case LayerKernel::DOT_FP16:
+    return "dot_cl_fp16";
+  case LayerKernel::SGEMM_FP16:
+    return "sgemm_cl_fp16";
   default:
     return "";
   }

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -830,9 +830,12 @@ public:
    * getKernelName function.
    */
   enum LayerKernel {
-    SGEMV = 1, /**< placeholder for kernel name */
-    DOT = 2,   /**< placeholder for kernel name */
-    SGEMM = 4  /**< placeholder for kernel name */
+    SGEMV = 1 << 0,      /**< placeholder for kernel name */
+    DOT = 1 << 1,        /**< placeholder for kernel name */
+    SGEMM = 1 << 2,      /**< placeholder for kernel name */
+    SGEMV_FP16 = 1 << 3, /**< placeholder for kernel name */
+    DOT_FP16 = 1 << 4,   /**< placeholder for kernel name */
+    SGEMM_FP16 = 1 << 5, /**< placeholder for kernel name */
   };
 
   /**

--- a/test/unittest/layers/unittest_layers_fully_connected_cl.cpp
+++ b/test/unittest/layers/unittest_layers_fully_connected_cl.cpp
@@ -66,3 +66,29 @@ GTEST_PARAMETER_TEST(FullyConnectedGPU, LayerGoldenTest,
                                        fc_gpu_no_decay, fc_gpu_plain_nhwc,
                                        fc_gpu_single_batch_nhwc,
                                        fc_gpu_no_decay_nhwc));
+
+#ifdef ENABLE_FP16
+auto fc_gpu_basic_plain_w16a16 = LayerGoldenTestParamType(
+  nntrainer::createLayer<nntrainer::FullyConnectedLayerCl>, {"unit=5"},
+  "3:1:1:10", "fc_plain_w16a16.nnlayergolden",
+  LayerGoldenTestParamOptions::DEFAULT, "nchw", "fp16", "fp16");
+
+auto fc_gpu_basic_single_batch_w16a16 = LayerGoldenTestParamType(
+  nntrainer::createLayer<nntrainer::FullyConnectedLayerCl>, {"unit=4"},
+  "1:1:1:10", "fc_single_batch_w16a16.nnlayergolden",
+  LayerGoldenTestParamOptions::DEFAULT, "nchw", "fp16", "fp16");
+
+auto fc_gpu_basic_no_decay_w16a16 = LayerGoldenTestParamType(
+  nntrainer::createLayer<nntrainer::FullyConnectedLayerCl>,
+  {"unit=5", "weight_decay=0.0", "bias_decay=0.0"}, "3:1:1:10",
+  "fc_plain_w16a16.nnlayergolden",
+  LayerGoldenTestParamOptions::SKIP_CALC_DERIV |
+    LayerGoldenTestParamOptions::SKIP_CALC_GRAD |
+    LayerGoldenTestParamOptions::USE_INC_FORWARD,
+  "nchw", "fp16", "fp16");
+
+GTEST_PARAMETER_TEST(FullyConnected16, LayerGoldenTest,
+                     ::testing::Values(fc_gpu_basic_plain_w16a16,
+                                       fc_gpu_basic_single_batch_w16a16,
+                                       fc_gpu_basic_no_decay_w16a16));
+#endif


### PR DESCRIPTION
FC Layer GPU kernels added for `fp16` operation:
- Added `blas_kernels_fp16.cpp` for BLAS `fp16` OpenCL kernels.
- Used `lda` for SGEMV computation for generalization.
- Unit tests added for FC Layer `fp16` support on GPU.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Debadri Samaddar <s.debadri@samsung.com>
