### PR TITLE
[ layer ] Enable mha gtest and match version @open sesame 06/04 13:01

### DIFF
--- a/Applications/LLaMA/jni/Android.mk
+++ b/Applications/LLaMA/jni/Android.mk
@@ -79,6 +79,26 @@ LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 include $(BUILD_SHARED_LIBRARY)
 
+include $(CLEAR_VARS)
+
+LOCAL_ARM_NEON := true
+LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib -DENABLE_FP16=1 -DUSE__FP16=1
+LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/$(TARGET_ARCH_ABI)/
+LOCAL_CXXFLAGS += -std=c++17 -frtti -DENABLE_FP16=1 -DUSE__FP16=1
+LOCAL_CFLAGS += -pthread -fexceptions -fopenmp -static-openmp -DENABLE_FP16=1 -DUSE__FP16=1
+LOCAL_LDFLAGS += -fexceptions -fopenmp -static-openmp -DENABLE_FP16=1 -DUSE__FP16=1
+LOCAL_MODULE_TAGS := optional
+LOCAL_ARM_MODE := arm
+LOCAL_MODULE := custom_multi_head_attention_layer
+LOCAL_LDLIBS := -llog -landroid -fopenmp -static-openmp -DENABLE_FP16=1 -DUSE__FP16=1
+
+LOCAL_SRC_FILES := custom_multi_head_attention_layer.cpp
+
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+
+LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
+
+include $(BUILD_SHARED_LIBRARY)
 
 
 include $(CLEAR_VARS)
@@ -96,7 +116,7 @@ LOCAL_LDLIBS := -llog -landroid -fopenmp -static-openmp -DENABLE_FP16=1 -DUSE__F
 
 LOCAL_SRC_FILES := main.cpp 
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer rms_norm_layer swiglu_layer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer rms_norm_layer swiglu_layer custom_multi_head_attention_layer
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 

--- a/Applications/LLaMA/jni/custom_multi_head_attention_layer.h
+++ b/Applications/LLaMA/jni/custom_multi_head_attention_layer.h
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2022 hyeonseok Lee <hs89.lee@samsung.com>
+ *
+ * @file   multi_head_attention_layer.h
+ * @date   08 July 2022
+ * @see    https://github.com/nnstreamer/nntrainer
+ *         https://arxiv.org/abs/1706.03762
+ * @author hyeonseok Lee <hs89.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is MultiHeadAttention Layer Class for Neural Network
+ *
+ */
+
+#ifndef __MULTI_HEAD_ATTENTION_LAYER_H__
+#define __MULTI_HEAD_ATTENTION_LAYER_H__
+#ifdef __cplusplus
+
+#include <acti_func.h>
+#include <complex>
+#include <layer_impl.h>
+#include <util_simd.h>
+#include <utility>
+
+namespace nntrainer {
+
+/**
+ * @class   Multi Head Attention Layer
+ * @brief   Implementation of multi head attention which is described in paper
+ * "Attention is all you need"
+ */
+class MultiHeadAttentionLayer : public LayerImpl {
+public:
+  /**
+   * @brief     Constructor of MultiHeadAttention Layer
+   */
+  MultiHeadAttentionLayer();
+
+  /**
+   * @brief     Destructor of MultiHeadAttention Layer
+   */
+  ~MultiHeadAttentionLayer();
+
+  /**
+   *  @brief  Move constructor of MultiHeadAttentionLayer.
+   *  @param[in] MultiHeadAttentionLayer &&
+   */
+  MultiHeadAttentionLayer(MultiHeadAttentionLayer &&rhs) noexcept = default;
+
+  /**
+   * @brief  Move assignment operator.
+   * @parma[in] rhs MultiHeadAttentionLayer to be moved.
+   */
+  MultiHeadAttentionLayer &operator=(MultiHeadAttentionLayer &&rhs) = default;
+
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  void finalize(InitLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
+   */
+  void forwarding(RunLayerContext &context, bool training) override;
+
+  /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void initial_incremental_forwarding(RunLayerContext &context,
+                                      unsigned int from, unsigned int to,
+                                      bool training);
+
+  /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(RunLayerContext &context, unsigned int from,
+                              unsigned int to, bool training) override;
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  void calcDerivative(RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::calcGradient(RunLayerContext &context)
+   */
+  void calcGradient(RunLayerContext &context) override;
+
+  /**
+   * @copydoc bool supportBackwarding() const
+   */
+  bool supportBackwarding() const override { return true; };
+
+  /**
+   * @copydoc Layer::exportTo(Exporter &exporter, ml::train::ExportMethods
+   * method)
+   */
+  void exportTo(Exporter &exporter,
+                const ml::train::ExportMethods &method) const override;
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  const std::string getType() const override {
+    return MultiHeadAttentionLayer::type;
+  };
+
+  /**
+   * @copydoc Layer::setBatch(RunLayerContext &context, unsigned int batch)
+   */
+  void setBatch(RunLayerContext &context, unsigned int batch) override;
+
+  inline static const std::string type = "multi_head_attention";
+
+private:
+  std::tuple<props::NumHeads, props::ProjectedKeyDim, props::ProjectedValueDim,
+             props::OutputShape, props::DropOutRate,
+             props::ReturnAttentionWeight, props::AverageAttentionWeight,
+             props::MaxTimestep>
+    multi_head_attention_props; /**< multi_head_attention layer properties */
+
+  ActiFunc sm; /** softmax activation operation */
+  std::array<unsigned int, 16>
+    weight_idx; /**< indices of the weights and tensors */
+
+  /**
+   * @brief     to protect overflow
+   */
+  float epsilon;
+
+  unsigned int cache_index;
+
+  inline static unsigned int layer_progress;
+
+  inline static std::vector<std::vector<float>> *freqs_cos = {};
+  inline static std::vector<std::vector<float>> *freqs_sin = {};
+  inline static std::vector<float> freqs;
+
+  /**
+   * @brief     compute frequency for rotary embedding
+   * @param[in] dim hidden dim size
+   * @param[in] seq_len sequency length
+   * @param[in] theta rotary angle
+   */
+  void precompute_freqs(int dim, unsigned int seq_len, float theta = 10000.0) {
+    if (freqs_cos == nullptr) {
+      unsigned int half_ = dim / 2;
+      for (unsigned int i = 0; i < half_; ++i) {
+        freqs.push_back(1.0 /
+                        (std::pow(theta, (2 * i) / static_cast<float>(dim))));
+      }
+
+      auto cos = new std::vector<std::vector<float>>();
+      cos->assign(seq_len, std::vector<float>(dim, 0));
+
+      auto sin = new std::vector<std::vector<float>>();
+      sin->assign(seq_len, std::vector<float>(dim, 0));
+
+      for (unsigned int i = 0; i < seq_len; ++i) {
+#ifdef USE_NEON
+        calc_trigonometric_vals_dup(half_, freqs.data(), (*cos)[i].data(),
+                                    (*sin)[i].data(), i);
+#else
+        for (unsigned int j = 0; j < half_; ++j) {
+          float angle = i * freqs[j];
+          (*cos)[i][j] = std::cos(angle);
+          (*cos)[i][j + half_] = std::cos(angle); // repeated 2 times
+
+          (*sin)[i][j] = std::sin(angle);
+          (*sin)[i][j + half_] = std::sin(angle); // repeated 2 times
+        }
+#endif
+      }
+      freqs_cos = cos;
+      freqs_sin = sin;
+    }
+  }
+
+  /**
+   * @brief     apply rotary embedding
+   * @param[in] in input tensor
+   * @param[in] dim hidden dim size
+   * @param[in] from sequence order
+   */
+  void apply_rotary_emb_tensor(Tensor &in, unsigned int dim,
+                               unsigned int from) {
+    Tensor out(in.getDim());
+    float value = 0;
+    float transformed_value = 0.0;
+    unsigned int half_ = dim / 2;
+    unsigned int max_timestep =
+      std::get<props::MaxTimestep>(multi_head_attention_props).get();
+
+    std::vector<float> *cos_;
+    std::vector<float> *sin_;
+
+    if (from >= max_timestep) {
+      cos_ = new std::vector<float>(dim);
+      sin_ = new std::vector<float>(dim);
+#ifdef USE_NEON
+      calc_trigonometric_vals_dup(half_, freqs.data(), cos_->data(),
+                                  sin_->data(), from);
+#else
+      for (unsigned int i = 0; i < half_; ++i) {
+        float angle = from * freqs[i];
+        (*cos_)[i] = std::cos(angle);
+        (*cos_)[i + half_] = std::cos(angle); // repeated 2 times
+
+        (*sin_)[i] = std::sin(angle);
+        (*sin_)[i + half_] = std::sin(angle); // repeated 2 times
+      }
+#endif
+    }
+
+    if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
+      for (unsigned int b = 0; b < in.batch(); b++) {
+        for (unsigned int c = 0; c < in.channel(); c++) {
+          for (unsigned int h = 0; h < in.height(); h++) {
+            if (from < max_timestep) {
+              cos_ = &(*freqs_cos)[from + h];
+              sin_ = &(*freqs_sin)[from + h];
+            }
+
+            for (unsigned int w = 0; w < in.width(); w = w + dim) {
+              for (unsigned int k = 0; k < dim; k++) {
+                unsigned int span = w + k;
+                value = in.getValue<float>(b, c, h, span);
+
+                if (k < half_) {
+                  transformed_value =
+                    -1.0 * in.getValue<float>(b, c, h, span + half_);
+                } else {
+                  transformed_value = in.getValue<float>(b, c, h, span - half_);
+                }
+                value = value * (*cos_)[k] + transformed_value * (*sin_)[k];
+                out.setValue(b, c, h, span, value);
+              }
+            }
+          }
+        }
+      }
+    } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+      for (unsigned int b = 0; b < in.batch(); b++) {
+        for (unsigned int c = 0; c < in.channel(); c++) {
+          for (unsigned int h = 0; h < in.height(); h++) {
+            if (from < max_timestep) {
+              cos_ = &(*freqs_cos)[from + h];
+              sin_ = &(*freqs_sin)[from + h];
+            }
+            for (unsigned int w = 0; w < in.width(); w = w + dim) {
+#ifdef USE_NEON
+              compute_rotary_embedding_value(
+                dim, half_, w, in.getData<_FP16>() + in.getIndex(b, c, h, 0),
+                out.getData<_FP16>() + out.getIndex(b, c, h, 0), cos_->data(),
+                sin_->data());
+#else
+              for (unsigned int k = 0; k < dim; k++) {
+                unsigned int span = w + k;
+                value = static_cast<float>(in.getValue<_FP16>(b, c, h, span));
+
+                if (k < half_) {
+                  transformed_value =
+                    -1.0 * static_cast<float>(
+                             in.getValue<_FP16>(b, c, h, half_ + span));
+                } else {
+                  transformed_value = static_cast<float>(
+                    in.getValue<_FP16>(b, c, h, span - half_));
+                }
+                out.setValue(
+                  b, c, h, span,
+                  static_cast<_FP16>(value * (*cos_)[k] +
+                                     transformed_value * (*sin_)[k]));
+              }
+#endif
+            }
+          }
+        }
+      }
+#else
+      throw std::invalid_argument("Error: enable-fp16 is not enabled");
+#endif
+    }
+
+    if (from >= max_timestep) {
+      delete cos_;
+      delete sin_;
+    }
+    in.copy(out);
+  }
+
+  /**
+   * @brief calculate common derivative
+   * @param context Context of the layer
+   */
+  void calcCommonDerivative(RunLayerContext &context);
+};
+
+} // namespace nntrainer
+
+#endif /* __cplusplus */
+#endif /* __MULTI_HEAD_ATTENTION_LAYER_H__ */

--- a/Applications/LLaMA/jni/main.cpp
+++ b/Applications/LLaMA/jni/main.cpp
@@ -25,6 +25,7 @@
 #include <optimizer.h>
 
 #include <app_context.h>
+#include <custom_multi_head_attention_layer.h>
 #include <rms_norm.h>
 #include <rotary_embedding.h>
 #include <swiglu.h>

--- a/Applications/LLaMA/jni/meson.build
+++ b/Applications/LLaMA/jni/meson.build
@@ -59,12 +59,27 @@ rotary_emb_dep = declare_dependency(
   include_directories: include_directories('./')
 )
 
+mha_src = files('custom_multi_head_attention_layer.cpp')
+mha_layer = shared_library('custom_multi_head_attention_layer',
+  mha_src,
+  dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+  include_directories: include_directories('./'),
+  install: true,
+  install_dir: application_install_dir,
+  cpp_args: '-DPLUGGABLE'
+)
+mha_dep = declare_dependency(
+  link_with: mha_layer,
+  include_directories: include_directories('./')
+)
+
 llama_sources = [
   'main.cpp',
   cifar_path / 'cifar_dataloader.cpp',
   rms_norm_src,
   swiglu_src,
-  rotary_emb_src
+  rotary_emb_src,
+  mha_src
 ]
 
 llama_dependencies = [app_utils_dep,
@@ -73,7 +88,8 @@ llama_dependencies = [app_utils_dep,
   transpose_dep,
   rms_norm_dep,
   swiglu_dep,
-  rotary_emb_dep
+  rotary_emb_dep,
+  mha_dep
 ]
 
 e = executable('nntrainer_llama',

--- a/nntrainer/layers/multi_head_attention_layer.h
+++ b/nntrainer/layers/multi_head_attention_layer.h
@@ -17,10 +17,7 @@
 #ifdef __cplusplus
 
 #include <acti_func.h>
-#include <complex>
 #include <layer_impl.h>
-#include <util_simd.h>
-#include <utility>
 
 namespace nntrainer {
 
@@ -62,14 +59,6 @@ public:
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   void forwarding(RunLayerContext &context, bool training) override;
-
-  /**
-   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
-   * int from, unsigned int to, bool training)
-   */
-  void initial_incremental_forwarding(RunLayerContext &context,
-                                      unsigned int from, unsigned int to,
-                                      bool training);
 
   /**
    * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
@@ -122,8 +111,7 @@ public:
 private:
   std::tuple<props::NumHeads, props::ProjectedKeyDim, props::ProjectedValueDim,
              props::OutputShape, props::DropOutRate,
-             props::ReturnAttentionWeight, props::AverageAttentionWeight,
-             props::MaxTimestep>
+             props::ReturnAttentionWeight, props::AverageAttentionWeight>
     multi_head_attention_props; /**< multi_head_attention layer properties */
 
   ActiFunc sm; /** softmax activation operation */
@@ -134,167 +122,6 @@ private:
    * @brief     to protect overflow
    */
   float epsilon;
-
-  unsigned int cache_index;
-
-  inline static unsigned int layer_progress;
-
-  inline static std::vector<std::vector<float>> *freqs_cos = {};
-  inline static std::vector<std::vector<float>> *freqs_sin = {};
-  inline static std::vector<float> freqs;
-
-  /**
-   * @brief     compute frequency for rotary embedding
-   * @param[in] dim hidden dim size
-   * @param[in] seq_len sequency length
-   * @param[in] theta rotary angle
-   */
-  void precompute_freqs(int dim, unsigned int seq_len, float theta = 10000.0) {
-    if (freqs_cos == nullptr) {
-      unsigned int half_ = dim / 2;
-      for (unsigned int i = 0; i < half_; ++i) {
-        freqs.push_back(1.0 /
-                        (std::pow(theta, (2 * i) / static_cast<float>(dim))));
-      }
-
-      auto cos = new std::vector<std::vector<float>>();
-      cos->assign(seq_len, std::vector<float>(dim, 0));
-
-      auto sin = new std::vector<std::vector<float>>();
-      sin->assign(seq_len, std::vector<float>(dim, 0));
-
-      for (unsigned int i = 0; i < seq_len; ++i) {
-#ifdef USE_NEON
-        calc_trigonometric_vals_dup(half_, freqs.data(), (*cos)[i].data(),
-                                    (*sin)[i].data(), i);
-#else
-        for (unsigned int j = 0; j < half_; ++j) {
-          float angle = i * freqs[j];
-          (*cos)[i][j] = std::cos(angle);
-          (*cos)[i][j + half_] = std::cos(angle); // repeated 2 times
-
-          (*sin)[i][j] = std::sin(angle);
-          (*sin)[i][j + half_] = std::sin(angle); // repeated 2 times
-        }
-#endif
-      }
-      freqs_cos = cos;
-      freqs_sin = sin;
-    }
-  }
-
-  /**
-   * @brief     apply rotary embedding
-   * @param[in] in input tensor
-   * @param[in] dim hidden dim size
-   * @param[in] from sequence order
-   */
-  void apply_rotary_emb_tensor(Tensor &in, unsigned int dim,
-                               unsigned int from) {
-    Tensor out(in.getDim());
-    float value = 0;
-    float transformed_value = 0.0;
-    unsigned int half_ = dim / 2;
-    unsigned int max_timestep =
-      std::get<props::MaxTimestep>(multi_head_attention_props).get();
-
-    std::vector<float> *cos_;
-    std::vector<float> *sin_;
-
-    if (from >= max_timestep) {
-      cos_ = new std::vector<float>(dim);
-      sin_ = new std::vector<float>(dim);
-#ifdef USE_NEON
-      calc_trigonometric_vals_dup(half_, freqs.data(), cos_->data(),
-                                  sin_->data(), from);
-#else
-      for (unsigned int i = 0; i < half_; ++i) {
-        float angle = from * freqs[i];
-        (*cos_)[i] = std::cos(angle);
-        (*cos_)[i + half_] = std::cos(angle); // repeated 2 times
-
-        (*sin_)[i] = std::sin(angle);
-        (*sin_)[i + half_] = std::sin(angle); // repeated 2 times
-      }
-#endif
-    }
-
-    if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
-      for (unsigned int b = 0; b < in.batch(); b++) {
-        for (unsigned int c = 0; c < in.channel(); c++) {
-          for (unsigned int h = 0; h < in.height(); h++) {
-            if (from < max_timestep) {
-              cos_ = &(*freqs_cos)[from + h];
-              sin_ = &(*freqs_sin)[from + h];
-            }
-
-            for (unsigned int w = 0; w < in.width(); w = w + dim) {
-              for (unsigned int k = 0; k < dim; k++) {
-                unsigned int span = w + k;
-                value = in.getValue<float>(b, c, h, span);
-
-                if (k < half_) {
-                  transformed_value =
-                    -1.0 * in.getValue<float>(b, c, h, span + half_);
-                } else {
-                  transformed_value = in.getValue<float>(b, c, h, span - half_);
-                }
-                value = value * (*cos_)[k] + transformed_value * (*sin_)[k];
-                out.setValue(b, c, h, span, value);
-              }
-            }
-          }
-        }
-      }
-    } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
-#ifdef ENABLE_FP16
-      for (unsigned int b = 0; b < in.batch(); b++) {
-        for (unsigned int c = 0; c < in.channel(); c++) {
-          for (unsigned int h = 0; h < in.height(); h++) {
-            if (from < max_timestep) {
-              cos_ = &(*freqs_cos)[from + h];
-              sin_ = &(*freqs_sin)[from + h];
-            }
-            for (unsigned int w = 0; w < in.width(); w = w + dim) {
-#ifdef USE_NEON
-              compute_rotary_embedding_value(
-                dim, half_, w, in.getData<_FP16>() + in.getIndex(b, c, h, 0),
-                out.getData<_FP16>() + out.getIndex(b, c, h, 0), cos_->data(),
-                sin_->data());
-#else
-              for (unsigned int k = 0; k < dim; k++) {
-                unsigned int span = w + k;
-                value = static_cast<float>(in.getValue<_FP16>(b, c, h, span));
-
-                if (k < half_) {
-                  transformed_value =
-                    -1.0 * static_cast<float>(
-                             in.getValue<_FP16>(b, c, h, half_ + span));
-                } else {
-                  transformed_value = static_cast<float>(
-                    in.getValue<_FP16>(b, c, h, span - half_));
-                }
-                out.setValue(
-                  b, c, h, span,
-                  static_cast<_FP16>(value * (*cos_)[k] +
-                                     transformed_value * (*sin_)[k]));
-              }
-#endif
-            }
-          }
-        }
-      }
-#else
-      throw std::invalid_argument("Error: enable-fp16 is not enabled");
-#endif
-    }
-
-    if (from >= max_timestep) {
-      delete cos_;
-      delete sin_;
-    }
-    in.copy(out);
-  }
 
   /**
    * @brief calculate common derivative

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -62,7 +62,7 @@ test_target = [
   'unittest_layers_dropout.cpp',
   'unittest_layers_reshape.cpp',
   # 'unittest_layers_mol_attention.cpp',
-  # 'unittest_layers_multi_head_attention.cpp',
+  'unittest_layers_multi_head_attention.cpp',
   'unittest_layers_positional_encoding.cpp',
 ]
 


### PR DESCRIPTION
- Current mha layer at nntrainer/layer is not for general use, but implemented solely for LLaMA support.
- In order to run unittest for mha layer:
1. rollback current mha layer to previous one
2. move current implemenation to Application/LLaMA
3. enable unittest

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped