### PR TITLE
[ layer ] Bugfix for enabling unittest_models on Android

### DIFF
--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -413,6 +413,34 @@ const std::string &RunLayerContext::getTensorName(unsigned int idx) const {
 }
 
 /**
+ * @brief Get the number of Outputs tensor objects
+ *
+ * @return unsigned int number of output tensors
+ */
+unsigned int RunLayerContext::getNumOutputs() const { return outputs.size(); }
+
+/**
+ * @brief Get the number of inputs tensor objects
+ *
+ * @return unsigned int number of input tensors
+ */
+unsigned int RunLayerContext::getNumInputs() const { return inputs.size(); }
+
+/**
+ * @brief Get the number of weights tensor objects
+ *
+ * @return unsigned int number of weight tensors
+ */
+unsigned int RunLayerContext::getNumWeights() const { return weights.size(); }
+
+/**
+ * @brief Get the number of requested tensors objects
+ *
+ * @return unsigned int number of requested tensors
+ */
+unsigned int RunLayerContext::getNumTensors() const { return tensors.size(); }
+
+/**
  * @brief Set the batch for the run context
  *
  * @param batch Update batch size

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -672,21 +672,21 @@ public:
    *
    * @return unsigned int number of output tensors
    */
-  unsigned int getNumOutputs() const { return outputs.size(); }
+  unsigned int getNumOutputs() const;
 
   /**
    * @brief Get the number of inputs tensor objects
    *
    * @return unsigned int number of input tensors
    */
-  unsigned int getNumInputs() const { return inputs.size(); }
+  unsigned int getNumInputs() const;
 
   /**
    * @brief Get the number of weights tensor objects
    *
    * @return unsigned int number of weight tensors
    */
-  unsigned int getNumWeights() const { return weights.size(); }
+  unsigned int getNumWeights() const;
 
   /**
    * @brief Get the Number of Weight Optimizer Variable tensor object
@@ -701,8 +701,7 @@ public:
    *
    * @return unsigned int number of requested tensors
    */
-  unsigned int getNumTensors() const { return tensors.size(); }
-
+  unsigned int getNumTensors() const;
   /**
    * @brief Set the batch for the run context
    *


### PR DESCRIPTION
- This commit fixes unusual memory access on cross-compiled unittest executable on Android

Resolves:
> SIGSEGV : signal segmentation violation
- lldb | signal SIGSEGV: invalid address
- SIGILL : illegal instruction

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped