### PR TITLE
[ blas/OpenCL ] Added multiply OpenCL kernel and unit test

### DIFF
--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -699,6 +699,10 @@ std::string RunLayerContext::getKernelName(LayerKernel layerKernel) {
     return "swiglu_cl";
   case LayerKernel::SWIGLU_FP16:
     return "swiglu_cl_fp16";
+  case LayerKernel::SSCAL:
+    return "sscal_cl";
+  case LayerKernel::SSCAL_FP16:
+    return "sscal_cl_fp16";
   default:
     return "";
   }

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -830,16 +830,18 @@ public:
    * getKernelName function.
    */
   enum LayerKernel {
-    SGEMV = 1 << 0,      /**< placeholder for kernel name */
-    DOT = 1 << 1,        /**< placeholder for kernel name */
-    SGEMM = 1 << 2,      /**< placeholder for kernel name */
-    SGEMV_FP16 = 1 << 3, /**< placeholder for kernel name */
-    DOT_FP16 = 1 << 4,   /**< placeholder for kernel name */
-    SGEMM_FP16 = 1 << 5, /**< placeholder for kernel name */
-    ADD = 1 << 6,        /**< placeholder for kernel name */
-    ADD_FP16 = 1 << 7,   /**< placeholder for kernel name */
-    SWIGLU = 1 << 8,     /**< placeholder for kernel name */
-    SWIGLU_FP16 = 1 << 9 /**< placeholder for kernel name */
+    SGEMV = 1 << 0,       /**< placeholder for kernel name */
+    DOT = 1 << 1,         /**< placeholder for kernel name */
+    SGEMM = 1 << 2,       /**< placeholder for kernel name */
+    SGEMV_FP16 = 1 << 3,  /**< placeholder for kernel name */
+    DOT_FP16 = 1 << 4,    /**< placeholder for kernel name */
+    SGEMM_FP16 = 1 << 5,  /**< placeholder for kernel name */
+    ADD = 1 << 6,         /**< placeholder for kernel name */
+    ADD_FP16 = 1 << 7,    /**< placeholder for kernel name */
+    SWIGLU = 1 << 8,      /**< placeholder for kernel name */
+    SWIGLU_FP16 = 1 << 9, /**< placeholder for kernel name */
+    SSCAL = 1 << 10,      /**< placeholder for kernel name */
+    SSCAL_FP16 = 1 << 11, /**< placeholder for kernel name */
   };
 
   /**

--- a/nntrainer/tensor/cl_operations/blas_kernel_interface.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_interface.h
@@ -28,6 +28,18 @@ namespace nntrainer {
  * @param[in] trans bool
  * @param[in] trans_m bool
  */
+Tensor dotCl(Tensor const &input, Tensor const &m, RunLayerContext &context,
+             bool trans = false, bool trans_m = false);
+
+/**
+ * @brief Process data and dimensions for OpenCL dot operation
+ * @param[in] input Tensor
+ * @param[in] m Tensor
+ * @param[in] result Tensor
+ * @param[in] RunLayerContext reference
+ * @param[in] trans bool
+ * @param[in] trans_m bool
+ */
 void dotCl(Tensor const &input, Tensor const &m, Tensor &result,
            RunLayerContext &context, bool trans = false, bool trans_m = false);
 
@@ -43,6 +55,14 @@ void dotCl(Tensor const &input, Tensor const &m, Tensor &result,
 void dotBatchedCl(Tensor const &input, Tensor const &m, Tensor &result,
                   RunLayerContext &context, bool trans = false,
                   bool trans_m = false);
+
+/**
+ * @brief Multiply value element by element immediately
+ * @param[in] input Tensor
+ * @param[in] value multiplier
+ * @param[in] RunLayerContext reference
+ */
+void multiplyCl(Tensor &input, float const &value, RunLayerContext &context);
 
 } // namespace nntrainer
 #endif /* __BLAS_KERNEL_INTERFACE_H__ */

--- a/nntrainer/tensor/cl_operations/blas_kernel_interface.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_interface.h
@@ -23,7 +23,6 @@ namespace nntrainer {
  * @brief Process data and dimensions for OpenCL dot operation
  * @param[in] input Tensor
  * @param[in] m Tensor
- * @param[in] result Tensor
  * @param[in] RunLayerContext reference
  * @param[in] trans bool
  * @param[in] trans_m bool

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -158,7 +158,7 @@ void addition_cl(const __fp16 *input, __fp16 *res, unsigned int size,
 
 /**
  * @brief     fp16 sscal value element by element immediately
- * @param[in] X float * input
+ * @param[in] X __fp16 * input
  * @param[in] N unsigned int number of elements
  * @param[in] alpha float multiplier
  * @param[in] context RunLayerContext reference

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -27,9 +27,8 @@ namespace nntrainer {
 extern opencl::Kernel kernel_sgemv;
 extern opencl::Kernel kernel_sgemm;
 extern opencl::Kernel kernel_dot;
-extern opencl::Kernel kernel_dot_fp16;
 extern opencl::Kernel kernel_addition;
-extern opencl::Kernel kernel_addition_fp16;
+extern opencl::Kernel kernel_sscal;
 
 /**
  * @brief     sgemv computation : Y = A*X + Y
@@ -74,6 +73,26 @@ void sgemm_cl(const float *A, const float *B, float *C, unsigned int M,
               unsigned int N, unsigned int K, unsigned int lda,
               unsigned int ldb, unsigned int ldc, RunLayerContext &context);
 
+/**
+ * @brief     addition : sum of all input vectors
+ * @param[in] input float * for input
+ * @param[in] res float * for result/output
+ * @param[in] size number of elements in input vector
+ * @param[in] context RunLayerContext reference
+ */
+void addition_cl(const float *input, float *res, unsigned int size,
+                 RunLayerContext &context);
+
+/**
+ * @brief     sscal value element by element immediately
+ * @param[in] X float * input
+ * @param[in] N unsigned int number of elements
+ * @param[in] alpha float multiplier
+ * @param[in] context RunLayerContext reference
+ */
+void sscal_cl(float *X, const unsigned int N, const float alpha,
+              RunLayerContext &context);
+
 #ifdef ENABLE_FP16
 /**
  * @brief declaring global fp16 kernel objects
@@ -81,6 +100,8 @@ void sgemm_cl(const float *A, const float *B, float *C, unsigned int M,
 extern opencl::Kernel kernel_sgemv_fp16;
 extern opencl::Kernel kernel_sgemm_fp16;
 extern opencl::Kernel kernel_dot_fp16;
+extern opencl::Kernel kernel_addition_fp16;
+extern opencl::Kernel kernel_sscal_fp16;
 
 /**
  * @brief     fp16 sgemv computation : Y = A*X + Y
@@ -124,17 +145,6 @@ __fp16 dot_cl(const __fp16 *vecAdata, const __fp16 *vecXdata, unsigned int dim1,
 void sgemm_cl(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
               unsigned int N, unsigned int K, unsigned int lda,
               unsigned int ldb, unsigned int ldc, RunLayerContext &context);
-#endif
-
-/**
- * @brief     addition : sum of all input vectors
- * @param[in] input float * for input
- * @param[in] res float * for result/output
- * @param[in] size number of elements in input vector
- * @param[in] context RunLayerContext reference
- */
-void addition_cl(const float *input, float *res, unsigned int size,
-                RunLayerContext &context);
 
 /**
  * @brief     fp16 addition : sum of all input vectors
@@ -144,7 +154,18 @@ void addition_cl(const float *input, float *res, unsigned int size,
  * @param[in] context RunLayerContext reference
  */
 void addition_cl(const __fp16 *input, __fp16 *res, unsigned int size,
-                RunLayerContext &context);
+                 RunLayerContext &context);
+
+/**
+ * @brief     fp16 sscal value element by element immediately
+ * @param[in] X float * input
+ * @param[in] N unsigned int number of elements
+ * @param[in] alpha float multiplier
+ * @param[in] context RunLayerContext reference
+ */
+void sscal_cl(__fp16 *X, const unsigned int N, const float alpha,
+              RunLayerContext &context);
+#endif
 
 } // namespace nntrainer
 #endif /* __BLAS_KERNELS_H__ */

--- a/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
@@ -71,6 +71,16 @@ std::string addition_cl_kernel_fp16_ =
     }
   })";
 
+std::string sscal_cl_kernel_fp16_ =
+  R"(
+    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+    __kernel void sscal_cl_fp16(__global half* X, const float alpha) {
+        
+        unsigned int i = get_global_id(0);
+        X[i] *= alpha;
+    })";
+
 /**
  * @brief defining global kernel objects
  */
@@ -78,6 +88,7 @@ opencl::Kernel kernel_sgemv_fp16;
 opencl::Kernel kernel_sgemm_fp16;
 opencl::Kernel kernel_dot_fp16;
 opencl::Kernel kernel_addition_fp16;
+opencl::Kernel kernel_sscal_fp16;
 
 void sgemv_cl(const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
               unsigned int dim1, unsigned int dim2, unsigned int lda,
@@ -376,6 +387,54 @@ void addition_cl(const __fp16 *input, __fp16 *res, unsigned int size,
     }
 
     result = inOutRes.ReadData(context.command_queue_inst_, res);
+    if (!result) {
+      break;
+    }
+
+  } while (false);
+}
+
+void sscal_cl(__fp16 *X, const unsigned int N, const float alpha,
+              RunLayerContext &context) {
+  bool result = false;
+
+  do {
+    result = context.clCreateKernel(sscal_cl_kernel_fp16_,
+                                    context.LayerKernel::SSCAL_FP16,
+                                    kernel_sscal_fp16);
+    if (!result) {
+      break;
+    }
+
+    size_t x_size = N * sizeof(cl_half);
+
+    opencl::Buffer inputX(context.context_inst_, x_size, false, nullptr);
+
+    result = inputX.WriteData(context.command_queue_inst_, X);
+    if (!result) {
+      break;
+    }
+
+    result = kernel_sscal_fp16.SetKernelArguments(0, &inputX, sizeof(cl_mem));
+    if (!result) {
+      break;
+    }
+
+    result = kernel_sscal_fp16.SetKernelArguments(1, &alpha, sizeof(float));
+    if (!result) {
+      break;
+    }
+
+    const int work_groups_count[3] = {(int)N, 1, 1};
+    const int work_group_size[3] = {32, 32, 1}; // test-value
+
+    result = context.command_queue_inst_.DispatchCommand(
+      kernel_sscal_fp16, work_groups_count, work_group_size);
+    if (!result) {
+      break;
+    }
+
+    result = inputX.ReadData(context.command_queue_inst_, X);
     if (!result) {
       break;
     }

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -22,6 +22,7 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 	$(NNTRAINER_ROOT)/nntrainer/opencl \
 	$(NNTRAINER_ROOT)/nntrainer/optimizers \
 	$(NNTRAINER_ROOT)/nntrainer/tensor \
+	$(NNTRAINER_ROOT)/nntrainer/tensor/cl_operations \
 	$(NNTRAINER_ROOT)/nntrainer/utils \
 	$(NNTRAINER_ROOT)/api \
 	$(NNTRAINER_ROOT)/api/ccapi/include \
@@ -472,6 +473,22 @@ LOCAL_SRC_FILES := \
 	 ../unittest/layers/unittest_layers_reshape.cpp \
 	 ../unittest/layers/unittest_layers_multi_head_attention.cpp \
 	 ../unittest/layers/unittest_layers_positional_encoding.cpp \
+
+LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
+
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_STATIC_LIBRARIES := googletest_main test_util
+include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := unittest_blas_kernels_cl
+LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 -march=armv8.2-a+fp16 -mfpu=neon-fp16 -mfloat-abi=softfp -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DENABLE_OPENCL=1 
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions
+LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
+
+LOCAL_SRC_FILES := \
+	 ../unittest/unittest_blas_kernels_cl.cpp 
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Debadri Samaddar <s.debadri@samsung.com>
+ *
+ * @file	unittest_blas_kernels_cl.cpp
+ * @date	6 June 2024
+ * @brief	Test setup for blas OpenCL kernels
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Debadri Samaddar <s.debadri@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#include <fstream>
+#include <gtest/gtest.h>
+#include <type_traits>
+
+#include "nntrainer_test_util.h"
+#include "util_func.h"
+#include <blas_kernel_interface.h>
+#include <cl_context.h>
+#include <layer_context.h>
+#include <tensor.h>
+
+#define EXPECT_IN_RANGE(VAL, MIN, MAX) \
+  EXPECT_GE((VAL), (MIN));             \
+  EXPECT_LE((VAL), (MAX))
+
+using namespace nntrainer;
+
+static RunLayerContext setUpGpuContext() {
+
+  auto &ac = nntrainer::ClContext::Global();
+  auto rc = RunLayerContext();
+
+  return rc;
+}
+
+TEST(blas_kernels, dotCL_sgemv) {
+  RunLayerContext rc = setUpGpuContext();
+
+  int batch = 1;
+  int channel = 1;
+  int height = 1;
+  int width = 768;
+
+  int height_b = 768;
+  int width_b = 96000;
+
+  bool transA = false;
+  bool transB = false;
+
+  const float alpha = 1e-1;
+  const int MOD = 10;
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp16 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16};
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  nntrainer::Tensor A_fp32(batch, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor B_fp32(batch, channel, height_b, width_b, t_type_nchw_fp32);
+
+  GEN_TEST_INPUT(A_fp32, ((i * (batch * height * channel) +
+                           j * (batch * height) + k * (width) + l + 1) %
+                          MOD) *
+                           alpha);
+  GEN_TEST_INPUT_B(B_fp32, ((i * (batch * height_b * channel) +
+                             j * (batch * height_b) + k * (width_b) + l + 1) %
+                            MOD) *
+                             alpha);
+
+  nntrainer::Tensor C = dotCl(A_fp32, B_fp32, rc, transA, transB);
+  nntrainer::Tensor C_fp32 = A_fp32.dot(B_fp32, transA, transB);
+
+  float mseErrorNeon =
+    mse<float>(C.getData<float>(), C_fp32.getData<float>(), C.size());
+
+  double cosSimNeon = cosine_similarity<float>(
+    C.getData<float>(), C_fp32.getData<float>(), C.size());
+
+  const float epsilon = 1e-3 * width;
+
+  EXPECT_IN_RANGE(mseErrorNeon, 0, epsilon);
+  EXPECT_IN_RANGE((float)cosSimNeon, 0.99, 1);
+}
+
+TEST(blas_kernels, dotCL_sgemv_n) {
+  RunLayerContext rc = setUpGpuContext();
+
+  int batch = 1;
+  int channel = 1;
+  int height = 1;
+  int width = 768;
+
+  int height_b = 768;
+  int width_b = 96000;
+
+  bool transA = true;
+  bool transB = false;
+
+  const float alpha = 1e-1;
+  const int MOD = 10;
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp16 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16};
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  nntrainer::Tensor A_fp32(batch, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor B_fp32(batch, channel, height_b, width_b, t_type_nchw_fp32);
+
+  GEN_TEST_INPUT(A_fp32, ((i * (batch * height * channel) +
+                           j * (batch * height) + k * (width) + l + 1) %
+                          MOD) *
+                           alpha);
+  GEN_TEST_INPUT_B(B_fp32, ((i * (batch * height_b * channel) +
+                             j * (batch * height_b) + k * (width_b) + l + 1) %
+                            MOD) *
+                             alpha);
+
+  EXPECT_THROW(dotCl(A_fp32, B_fp32, rc, transA, transB), std::runtime_error);
+}
+
+TEST(nntrainer_Tensor, multiply_i) {
+  RunLayerContext rc = setUpGpuContext();
+
+  int batch = 1;
+  int channel = 1;
+  int height = 2;
+  int width = 11;
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp16 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16};
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  nntrainer::Tensor input(batch, channel, height, width, t_type_nchw_fp16);
+  nntrainer::Tensor input_fp32(batch, channel, height, width, t_type_nchw_fp32);
+
+  const float alpha = 1e-5;
+  const float epsilon = 1e-4;
+
+  GEN_TEST_INPUT(input, i * (batch * height * channel) * alpha +
+                          j * (batch * height) * alpha + k * (width)*alpha + l +
+                          1);
+  GEN_TEST_INPUT(input_fp32, i * (batch * height * channel) * alpha +
+                               j * (batch * height) * alpha +
+                               k * (width)*alpha + l + 1);
+
+  // fp16
+  multiplyCl(input, 0.1, rc);
+
+  // fp32
+  multiplyCl(input_fp32, 0.1, rc);
+
+  float mseErrorNeon = mse<__fp16>(input.getData<__fp16>(),
+                                   input_fp32.getData<float>(), input.size());
+
+  double cosSimNeon = cosine_similarity<__fp16>(
+    input.getData<__fp16>(), input_fp32.getData<float>(), input.size());
+
+  EXPECT_IN_RANGE(mseErrorNeon, 0, epsilon);
+  EXPECT_IN_RANGE(cosSimNeon, 0.99, 1);
+}
+
+GTEST_API_ int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during InitGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}


### PR DESCRIPTION
- `sscal` equivalent kernel added for multiply.
- Added standalone unit test `unittest_blas_kernels_cl.cpp` for easily testing OpenCL kernels.
- Added an overload of `dotCl`.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Debadri Samaddar <s.debadri@samsung.com>