### PR TITLE
android: consistant ML_API_COMMON macro

### DIFF
--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -60,8 +60,8 @@ LOCAL_C_INCLUDES    := @MESON_NNTRAINER_INCS@ @MESON_ML_API_COMMON_ROOT@/include
 LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ -DML_API_COMMON=1
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1 @MESON_CXXFLAGS@
+LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ @ML_API_COMMON@
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions @ML_API_COMMON@ @MESON_CXXFLAGS@
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
@@ -82,8 +82,8 @@ LOCAL_C_INCLUDES    := @MESON_CCAPI_NNTRAINER_INCS@ @MESON_ML_API_COMMON_ROOT@/i
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
 
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ -DML_API_COMMON=1
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1 -DVERSION_MAJOR=@VERSION_MAJOR@ -DVERSION_MINOR=@VERSION_MINOR@ -DVERSION_MICRO=@VERSION_MICRO@ @MESON_CXXFLAGS@
+LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ @ML_API_COMMON@
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions @ML_API_COMMON@ -DVERSION_MAJOR=@VERSION_MAJOR@ -DVERSION_MINOR=@VERSION_MINOR@ -DVERSION_MICRO=@VERSION_MICRO@ @MESON_CXXFLAGS@
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
@@ -100,8 +100,8 @@ LOCAL_C_INCLUDES    := @MESON_CAPI_NNTRAINER_INCS@
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
 
 LOCAL_ARM_NEON      := true
-LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ -DML_API_COMMON=1
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DML_API_COMMON=1 @MESON_CXXFLAGS@
+LOCAL_CFLAGS        += -pthread -fexceptions -fopenmp -static-openmp @MESON_CFLAGS@ @ML_API_COMMON@
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions @ML_API_COMMON@ @MESON_CXXFLAGS@
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp

--- a/jni/meson.build
+++ b/jni/meson.build
@@ -44,6 +44,9 @@ else
   and_conf.set('MESON_HAS_TFLITE', 0)
 endif
 
+# -DML_API_COMMON=[01]
+and_conf.set('ML_API_COMMON', ml_api_common_flag)
+
 if blas_dep.found()
   and_conf.set('MESON_BLAS_ROOT', blas_root)
 else

--- a/meson.build
+++ b/meson.build
@@ -200,6 +200,7 @@ nntrainer_conf.set('MEMORY_SWAP_PATH', nntrainer_swapdir)
 
 dummy_dep = dependency('', required: false)
 found_dummy_dep = declare_dependency() # dummy dep to use if found
+ml_api_common_flag = '-DML_API_COMMON=0'
 
 # if ml-api-support is disabled, enable dummy common api interfaces and disable related dependencies.
 ml_api_common_dep = dependency(get_option('capi-ml-common-actual'), required : get_option('ml-api-support').enabled())
@@ -209,6 +210,7 @@ if (ml_api_common_dep.found())
   if (nnstreamer_capi_dep.found())
     nntrainer_conf.set('CAPI_ML_COMMON_DEP', get_option('capi-ml-common-actual'))
     extra_defines += '-DML_API_COMMON=1'
+    ml_api_common_flag = '-DML_API_COMMON=1'
     extra_defines += '-DNNSTREAMER_AVAILABLE=1'
     # accessing this variable when dep_.not_found() remains hard error on purpose
     supported_nnstreamer_capi = nnstreamer_capi_dep.version().version_compare('>=1.7.0')


### PR DESCRIPTION
ML_API_COMMON macro has been inconsistent for Android build, where it is force-defined 1 in Android.mk while it may become 0 or 1 depending on build system in meson.

Because android build uses meson and Android.mk simultaneously, this must become consistent.