### PR TITLE
[CI] Add fp-16 build in github action

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -29,7 +29,74 @@ jobs:
     - run: meson setup build/
       env:
         CC: gcc
-    - run: meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/x86_64-linux-gnu --bindir=lib/nntrainer/bin --includedir=include -Dinstall-app=true -Dreduce-tolerance=false -Denable-debug=true -Dml-api-support=enabled -Denable-nnstreamer-tensor-filter=enabled -Denable-nnstreamer-tensor-trainer=enabled -Denable-nnstreamer-backbone=true -Dcapi-ml-common-actual=capi-ml-common -Dcapi-ml-inference-actual=capi-ml-inference -Denable-capi=enabled build
+    - run: |
+        meson \
+          --buildtype=plain \
+          --prefix=/usr \
+          --sysconfdir=/etc \
+          --libdir=lib/x86_64-linux-gnu \
+          --bindir=lib/nntrainer/bin \
+          --includedir=include \
+          -Dinstall-app=true \
+          -Dreduce-tolerance=false \
+          -Denable-debug=true \
+          -Dml-api-support=enabled \
+          -Denable-nnstreamer-tensor-filter=enabled \
+          -Denable-nnstreamer-tensor-trainer=enabled \
+          -Denable-nnstreamer-backbone=true \
+          -Dcapi-ml-common-actual=capi-ml-common \
+          -Dcapi-ml-inference-actual=capi-ml-inference \
+          -Denable-capi=enabled \
+          build
     - run: ninja -C build
     - name: run ninja test
       run: cd ./build && ninja test
+
+  meson_test_fp16:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: install additional package from PPA for testing
+        run: sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
+      - name: install minimal requirements
+        run: sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
+      - name: install additional packages for features
+        run: sudo apt-get install -y python3-dev python3-numpy python3
+      - name: install build systems
+        run: sudo apt install meson ninja-build
+      - run: meson setup build/
+        env:
+          CC: gcc
+      - run: |
+          meson \
+            --buildtype=plain \
+            --prefix=/usr \
+            --sysconfdir=/etc \
+            --libdir=lib/x86_64-linux-gnu \
+            --bindir=lib/nntrainer/bin \
+            --includedir=include \
+            -Dinstall-app=true \
+            -Dreduce-tolerance=false \
+            -Denable-debug=true \
+            -Dml-api-support=enabled \
+            -Denable-nnstreamer-tensor-filter=enabled \
+            -Denable-nnstreamer-tensor-trainer=enabled \
+            -Denable-nnstreamer-backbone=true \
+            -Dcapi-ml-common-actual=capi-ml-common \
+            -Dcapi-ml-inference-actual=capi-ml-inference \
+            -Denable-capi=enabled \
+            -Denable-fp16=true \
+            build
+      - run: ninja -C build
+      - name: run ninja test
+        run: cd ./build && ninja test
+        continue-on-error: true


### PR DESCRIPTION
Closes #2560. You can now see the build results from Fp16 in a Github action.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: heka1024 <heka1024@gmail.com>