### PR TITLE
[ trivial ] Fix typo

### DIFF
--- a/test/unittest/layers/unittest_layers_addition_cl.cpp
+++ b/test/unittest/layers/unittest_layers_addition_cl.cpp
@@ -7,6 +7,7 @@
  * @brief Addition Layer Test
  * @see	https://github.com/nnstreamer/nntrainer
  * @author Yash Singh <yash.singh@samsung.com>
+ * @author Sungsik Kong <ss.kong@samsung.com>
  * @bug No known bugs except for NYI items
  */
 #include <tuple>
@@ -30,25 +31,26 @@ GTEST_PARAMETER_TEST(AdditionGPU, LayerSemanticsGpu,
                      ::testing::Values(semantic_addition_gpu,
                                        semantic_addition_multi_gpu));
 
-auto addition_w32a32 = LayerGoldenTestParamType(
+auto addition_w32a32_gpu = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::AdditionLayerCL>, {}, "2:3:3:3,2:3:3:3",
   "added_w32a32.nnlayergolden", LayerGoldenTestParamOptions::DEFAULT, "nchw",
   "fp32", "fp32");
 
-auto addition_w32a32_2 = LayerGoldenTestParamType(
+auto addition_w32a32_2_gpu = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::AdditionLayerCL>, {}, "3:4:3:4,3:4:3:4",
   "added_w32a32_2.nnlayergolden", LayerGoldenTestParamOptions::DEFAULT, "nchw",
   "fp32", "fp32");
 
 GTEST_PARAMETER_TEST(AdditionGPU, LayerGoldenTest,
-                     ::testing::Values(addition_w32a32, addition_w32a32_2));
+                     ::testing::Values(addition_w32a32_gpu,
+                                       addition_w32a32_2_gpu));
 
 #ifdef ENABLE_FP16
-auto addition_w16a16 = LayerGoldenTestParamType(
+auto addition_w16a16_gpu = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::AdditionLayerCL>, {}, "2:3:3:3,2:3:3:3",
   "added_w16a16.nnlayergolden", LayerGoldenTestParamOptions::DEFAULT, "nchw",
   "fp16", "fp16");
 
 GTEST_PARAMETER_TEST(Addition16, LayerGoldenTest,
-                     ::testing::Values(addition_w16a16));
+                     ::testing::Values(addition_w16a16_gpu));
 #endif


### PR DESCRIPTION
- Found duplicated TC name while creating GPU unittest cases, and this makes unittest build to fail
CC : @yashSingh0723 


Resolves:
```
[arm64-v8a] Executable     : unittest_layers
ld: error: duplicate symbol: addition_w16a16
...
defined at unittest_layers_addition.cpp:33 (../unittest/layers/unittest_layers_addition.cpp:33)
...
defined at unittest_layers_addition_cl.cpp:47 (../unittest/layers/unittest_layers_addition_cl.cpp:47)
...
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped