### PR TITLE
[Layer] Fix logic: SwiGLU Layer Training Incompatibility

### DIFF
--- a/nntrainer/layers/cl_layers/swiglu_cl.h
+++ b/nntrainer/layers/cl_layers/swiglu_cl.h
@@ -69,7 +69,7 @@ public:
   /**
    * @copydoc bool supportBackwarding() const
    */
-  bool supportBackwarding() const override { return true; };
+  bool supportBackwarding() const override { return false; };
 
   /**
    * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)


### PR DESCRIPTION
Currently, the SwiGLU layer using OpenCL operations does not support training/backpropagation.
Consequently, we are updating the logic to reflect that it is false.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped