### PR TITLE
[ hgemm ] Consider K=1 changes

### DIFF
--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -1588,7 +1588,11 @@ unsigned int isamax(const unsigned int N, const __fp16 *X) {
 
 void hgemm(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M, uint32_t N,
            uint32_t K, float alpha, float beta, bool TransA, bool TransB) {
-
+  if (K == 1) {
+    unsigned int lda = (TransA) ? M : K;
+    unsigned int ldb = (TransB) ? K : N;
+    return hgemm_K1(M, N, K, A, lda, B, ldb, C, N, alpha, beta);
+  }
   // dynamic creation to avoid reaching stack limit(causes segmentation fault)
   float *C32 = (float *)malloc(M * N * sizeof(float));
 

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -331,6 +331,22 @@ void hgemm(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M, uint32_t N,
            uint32_t K, float alpha, float beta, bool TransA, bool TransB);
 
 /**
+ * @brief     hgemm computation with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * where op(X) is one of X or X**T
+ * @param[in] A __fp16 * for Matrix A
+ * @param[in] B __fp16 * for Matrix B
+ * @param[in] C __fp16 * for Matrix C
+ * @param[in] M number of op(A)'s and C's row
+ * @param[in] N number of op(B)'s and C's columns
+ * @param[in] K number of op(A)'s and columns and op(B)'s rows
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void hgemm_K1(const __fp16 *A, const __fp16 *B, __fp16 *C, uint32_t M,
+              uint32_t N, uint32_t K, float alpha, float beta, bool TransA,
+              bool TransB);
+
+/**
  * @brief squared root transformation with neon : X = sqrt(X)
  *
  * @param N number of elements in X

--- a/nntrainer/tensor/hgemm/hgemm.cpp
+++ b/nntrainer/tensor/hgemm/hgemm.cpp
@@ -144,20 +144,72 @@ void hgemm_noTrans_padding_wrt_K(const __fp16 *A, const __fp16 *B, float *C,
   free(B8);
 }
 
-void hgemm_K1(unsigned int M, unsigned int N, unsigned int K, const __fp16 *A,
-              unsigned int lda, const __fp16 *B, unsigned int ldb, __fp16 *C,
-              unsigned int ldc, float alpha, float beta) {
+void hgemm_K1_noTrans(unsigned int M, unsigned int N, unsigned int K,
+                      const __fp16 *A, unsigned int lda, const __fp16 *B,
+                      unsigned int ldb, __fp16 *C, unsigned int ldc,
+                      float alpha, float beta) {
+  const float eps = std::numeric_limits<float>::epsilon();
   float16x8_t a_vec;
   unsigned int N8 = (N >> 3) << 3;
   for (unsigned int m = 0; m < M; ++m) {
-    a_vec = vmovq_n_f16(A[m]);
-    for (unsigned int n = 0; n < N8; n += 8) {
-      vst1q_f16(&C[m * ldc + n], vmulq_f16(a_vec, vld1q_f16(&B[n])));
+    a_vec = vmovq_n_f16(alpha * A[m]);
+    if (std::fpclassify(beta) != FP_ZERO) {
+      for (unsigned int n = 0; n < N8; n += 8) {
+        vst1q_f16(&C[m * ldc + n],
+                  vaddq_f16(vmulq_f16(a_vec, vld1q_f16(&B[n])),
+                            vmulq_n_f16(vld1q_f16(&C[m * ldc + n]), beta)));
+      }
+    } else {
+      for (unsigned int n = 0; n < N8; n += 8) {
+        vst1q_f16(&C[m * ldc + n], vmulq_f16(a_vec, vld1q_f16(&B[n])));
+      }
     }
     for (unsigned int n = N8; n < N; ++n) {
-      C[m * ldc + n] = A[m] * B[n];
+      C[m * ldc + n] = alpha * A[m] * B[n] + beta * C[m * ldc + n];
     }
   }
+}
+
+void hgemm_K1_transA(unsigned int M, unsigned int N, unsigned int K,
+                     const __fp16 *A, unsigned int lda, const __fp16 *B,
+                     unsigned int ldb, __fp16 *C, unsigned int ldc, float alpha,
+                     float beta) {
+  __fp16 *A_T = new __fp16[M * K];
+
+  transpose_neon<__fp16>(K, M, A, M, A_T, K);
+
+  hgemm_K1_noTrans(M, N, K, A_T, lda, B, ldb, C, ldc, alpha, beta);
+
+  free(A_T);
+}
+
+void hgemm_K1_transB(unsigned int M, unsigned int N, unsigned int K,
+                     const __fp16 *A, unsigned int lda, const __fp16 *B,
+                     unsigned int ldb, __fp16 *C, unsigned int ldc, float alpha,
+                     float beta) {
+  __fp16 *B_T = new __fp16[K * N];
+
+  transpose_neon<__fp16>(N, K, B, K, B_T, N);
+
+  hgemm_K1_noTrans(M, N, K, A, lda, B_T, ldb, C, ldc, alpha, beta);
+
+  free(B_T);
+}
+
+void hgemm_K1_transAB(unsigned int M, unsigned int N, unsigned int K,
+                      const __fp16 *A, unsigned int lda, const __fp16 *B,
+                      unsigned int ldb, __fp16 *C, unsigned int ldc,
+                      float alpha, float beta) {
+  __fp16 *A_T = new __fp16[M * K];
+  __fp16 *B_T = new __fp16[K * N];
+
+  transpose_neon<__fp16>(K, M, A, M, A_T, K);
+  transpose_neon<__fp16>(N, K, B, K, B_T, N);
+
+  hgemm_K1_noTrans(M, N, K, A_T, lda, B_T, ldb, C, ldc, alpha, beta);
+
+  free(A_T);
+  free(B_T);
 }
 
 void hgemm_noTrans_1x4(unsigned int M, unsigned int N, unsigned int K,

--- a/nntrainer/tensor/hgemm/hgemm.cpp
+++ b/nntrainer/tensor/hgemm/hgemm.cpp
@@ -174,7 +174,7 @@ void hgemm_K1_transA(unsigned int M, unsigned int N, unsigned int K,
                      const __fp16 *A, unsigned int lda, const __fp16 *B,
                      unsigned int ldb, __fp16 *C, unsigned int ldc, float alpha,
                      float beta) {
-  __fp16 *A_T = new __fp16[M * K];
+  __fp16 *A_T = alignedMalloc(M * K);
 
   transpose_neon<__fp16>(K, M, A, M, A_T, K);
 
@@ -187,7 +187,7 @@ void hgemm_K1_transB(unsigned int M, unsigned int N, unsigned int K,
                      const __fp16 *A, unsigned int lda, const __fp16 *B,
                      unsigned int ldb, __fp16 *C, unsigned int ldc, float alpha,
                      float beta) {
-  __fp16 *B_T = new __fp16[K * N];
+  __fp16 *B_T = alignedMalloc(K * N);
 
   transpose_neon<__fp16>(N, K, B, K, B_T, N);
 
@@ -200,8 +200,8 @@ void hgemm_K1_transAB(unsigned int M, unsigned int N, unsigned int K,
                       const __fp16 *A, unsigned int lda, const __fp16 *B,
                       unsigned int ldb, __fp16 *C, unsigned int ldc,
                       float alpha, float beta) {
-  __fp16 *A_T = new __fp16[M * K];
-  __fp16 *B_T = new __fp16[K * N];
+  __fp16 *A_T = alignedMalloc(M * K);
+  __fp16 *B_T = alignedMalloc(K * N);
 
   transpose_neon<__fp16>(K, M, A, M, A_T, K);
   transpose_neon<__fp16>(N, K, B, K, B_T, N);

--- a/nntrainer/tensor/hgemm/hgemm.cpp
+++ b/nntrainer/tensor/hgemm/hgemm.cpp
@@ -144,6 +144,22 @@ void hgemm_noTrans_padding_wrt_K(const __fp16 *A, const __fp16 *B, float *C,
   free(B8);
 }
 
+void hgemm_K1(unsigned int M, unsigned int N, unsigned int K, const __fp16 *A,
+              unsigned int lda, const __fp16 *B, unsigned int ldb, __fp16 *C,
+              unsigned int ldc, float alpha, float beta) {
+  float16x8_t a_vec;
+  unsigned int N8 = (N >> 3) << 3;
+  for (unsigned int m = 0; m < M; ++m) {
+    a_vec = vmovq_n_f16(A[m]);
+    for (unsigned int n = 0; n < N8; n += 8) {
+      vst1q_f16(&C[m * ldc + n], vmulq_f16(a_vec, vld1q_f16(&B[n])));
+    }
+    for (unsigned int n = N8; n < N; ++n) {
+      C[m * ldc + n] = A[m] * B[n];
+    }
+  }
+}
+
 void hgemm_noTrans_1x4(unsigned int M, unsigned int N, unsigned int K,
                        const __fp16 *A, unsigned int lda, const __fp16 *B,
                        unsigned int ldb, __fp16 *C, unsigned int ldc,

--- a/nntrainer/tensor/hgemm/hgemm.h
+++ b/nntrainer/tensor/hgemm/hgemm.h
@@ -120,7 +120,61 @@ void hgemm_noTrans_fallback(unsigned int M, unsigned int N, unsigned int K,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void hgemm_K1(unsigned int M, unsigned int N, unsigned int K,
+void hgemm_K1_noTrans(unsigned int M, unsigned int N, unsigned int K,
+                      const __fp16 *A, unsigned int lda, const __fp16 *B,
+                      unsigned int ldb, __fp16 *C, unsigned int ldc,
+                      float alpha = 1.F, float beta = 0.F);
+/**
+ * @brief     hgemm fallback with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * @param M length of the row of matrix A
+ * @param N length of the col of matrix B
+ * @param K length of the col of matrix A
+ * @param A input matrix A
+ * @param lda length of the col of matrix A
+ * @param B input matrix B
+ * @param ldb length of the col of matrix B
+ * @param C output matrix C
+ * @param ldc length of the col of matrix C
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void hgemm_K1_transA(unsigned int M, unsigned int N, unsigned int K,
+                     const __fp16 *A, unsigned int lda, const __fp16 *B,
+                     unsigned int ldb, __fp16 *C, unsigned int ldc,
+                     float alpha = 1.F, float beta = 0.F);
+/**
+ * @brief     hgemm fallback with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * @param M length of the row of matrix A
+ * @param N length of the col of matrix B
+ * @param K length of the col of matrix A
+ * @param A input matrix A
+ * @param lda length of the col of matrix A
+ * @param B input matrix B
+ * @param ldb length of the col of matrix B
+ * @param C output matrix C
+ * @param ldc length of the col of matrix C
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void hgemm_K1_transB(unsigned int M, unsigned int N, unsigned int K,
+                     const __fp16 *A, unsigned int lda, const __fp16 *B,
+                     unsigned int ldb, __fp16 *C, unsigned int ldc,
+                     float alpha = 1.F, float beta = 0.F);
+/**
+ * @brief     hgemm fallback with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * @param M length of the row of matrix A
+ * @param N length of the col of matrix B
+ * @param K length of the col of matrix A
+ * @param A input matrix A
+ * @param lda length of the col of matrix A
+ * @param B input matrix B
+ * @param ldb length of the col of matrix B
+ * @param C output matrix C
+ * @param ldc length of the col of matrix C
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void hgemm_K1_transAB(unsigned int M, unsigned int N, unsigned int K,
                       const __fp16 *A, unsigned int lda, const __fp16 *B,
                       unsigned int ldb, __fp16 *C, unsigned int ldc,
                       float alpha = 1.F, float beta = 0.F);

--- a/nntrainer/tensor/hgemm/hgemm.h
+++ b/nntrainer/tensor/hgemm/hgemm.h
@@ -107,6 +107,25 @@ void hgemm_noTrans_fallback(unsigned int M, unsigned int N, unsigned int K,
                             float alpha = 1.F, float beta = 0.F);
 
 /**
+ * @brief     hgemm fallback with neon : Y = alpha*op(A)*op(B) + beta*C,
+ * @param M length of the row of matrix A
+ * @param N length of the col of matrix B
+ * @param K length of the col of matrix A
+ * @param A input matrix A
+ * @param lda length of the col of matrix A
+ * @param B input matrix B
+ * @param ldb length of the col of matrix B
+ * @param C output matrix C
+ * @param ldc length of the col of matrix C
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void hgemm_K1(unsigned int M, unsigned int N, unsigned int K,
+                      const __fp16 *A, unsigned int lda, const __fp16 *B,
+                      unsigned int ldb, __fp16 *C, unsigned int ldc,
+                      float alpha = 1.F, float beta = 0.F);
+
+/**
  * @brief hgemm noTrans computation with 1x4 kernel : C = A*B,
  *
  * @param M length of the row of matrix A


### PR DESCRIPTION
- Current implementation is rooted on general cases, thus optimize only w.r.t. K accumulation.
- However, when it comes to M,1 x 1,N computation, all optimizations like packing, transposing is no use.
- Implementing a explicit kernel function for such case resolved the latency issue.

| dim = (576, 1) x (1, 1024) | fp16 | fp32 |
| --- | --- | --- |
| noTrans | **190834 ns** |  380525 ns |
| transA |  **173896 ns** | 387860 ns |
| transB | **180369 ns** | 382123 ns |
| transAB | **179263 ns** | 379238 ns |

Since this is K=1 case, we do not need to partial-accumulate w.r.t. K-direction with fp32, thereby accelerated approximately 200%


**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped