### PR TITLE
[CI] Add PR review from clang-format

### DIFF
--- a/.github/workflows/cpp_linter.yml
+++ b/.github/workflows/cpp_linter.yml
@@ -12,16 +12,17 @@ jobs:
           echo "Install mandatory dev packages to avoid false-positive reports from cpp-linter"
           sudo apt-get update
           sudo apt-get install libstdc++-*-dev
-      - uses: cpp-linter/cpp-linter-action@v2.8.0
+      - uses: cpp-linter/cpp-linter-action@v2.9.0
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          style: ''
-          version: 16
+          style: file
+          version: 14
           lines-changed-only: true
           file-annotations: false
           step-summary: true
+          format-review: true
 
       - name: failing fast
         if: steps.linter.outputs.clang-format-checks-failed > 0


### PR DESCRIPTION
This PR enables the GitHub actions bot to suggest changes based on the clang-format directly.

**Changes proposed in this PR:**
- Add format-review options to enable Pull Request reviews from clang-format.
- Upgrade the cpp-linter version to 2.9.0 to meet minimum version requirements.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped