### PR TITLE
[Tensor] Remove NaN check for integer

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -249,11 +249,7 @@ bool Tensor::operator==(const Tensor &rhs) const {
     const uint8_t *_data = getData<uint8_t>();
     const uint8_t *_rdata = rhs.getData<uint8_t>();
     for (size_t i = 0; i < len; ++i) {
-      /** not checking sign change is intentional to avoid float calculation
-       * errors around 0 */
-      if ((std::isnan(_data[i]) && !std::isnan(_rdata[i])) ||
-          (!std::isnan(_data[i]) && std::isnan(_rdata[i])) ||
-          _data[i] != _rdata[i])
+      if (_data[i] != _rdata[i])
         return false;
     }
   } else if (dim.getDataType() == ml::train::TensorDim::DataType::QINT4) {
@@ -266,8 +262,7 @@ bool Tensor::operator==(const Tensor &rhs) const {
       data = decode_qint(_data[i / 2], (i % 2 == 0));
       rdata = decode_qint(_rdata[i / 2], (i % 2 == 0));
 
-      if ((std::isnan(data) && !std::isnan(rdata)) ||
-          (!std::isnan(data) && std::isnan(rdata)) || data != rdata)
+      if (data != rdata)
         return false;
     }
   }


### PR DESCRIPTION
Fixed-sized integer formats do not have a way of explicitly indicating invalid data.
Every possible value of an int is a number. Therefore, removing NaN check for int values.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped