### PR TITLE
[GPU/OpenCL] Moving Addition kernel to Tensor Directory @open sesame 07/04 09:01

### DIFF
--- a/nntrainer/layers/cl_layers/addition_layer_cl.h
+++ b/nntrainer/layers/cl_layers/addition_layer_cl.h
@@ -77,15 +77,6 @@ public:
   void calcDerivative(RunLayerContext &context) override;
 
   /**
-   * @brief Process data and dimensions for add operation used in addition layer
-   * @param[in] input Tensor
-   * @param[in] result Tensor
-   * @param[in] RunLayerContext reference
-   */
-  void AddProcess(Tensor const &input, Tensor &result,
-                  RunLayerContext &context);
-
-  /**
    * @copydoc bool supportBackwarding() const
    */
   bool supportBackwarding() const override { return true; };

--- a/nntrainer/tensor/cl_operations/blas_kernel_interface.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_interface.cpp
@@ -211,4 +211,39 @@ void multiplyCl(Tensor &input, float const &value, RunLayerContext &context) {
   }
 }
 
+void add_i_cl(Tensor const &input, Tensor &result, RunLayerContext &context) {
+
+  CREATE_IF_EMPTY_DIMS(result, result.getDim());
+
+  NNTR_THROW_IF(result.getData() == nullptr, std::invalid_argument)
+    << result.getName() << " is not allocated";
+  NNTR_THROW_IF(input.getData() == nullptr, std::invalid_argument)
+    << input.getName() << " is not allocated";
+
+  if (input.getDim() != result.getDim()) {
+    throw std::invalid_argument(
+      "Error: Dimensions does not match for addition");
+  }
+
+  if (input.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    unsigned int size = input.size();
+    const float *data = input.getData();
+    float *rdata = result.getData();
+
+    addition_cl(data, rdata, size, context);
+
+  } else if (input.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    unsigned int size = input.size();
+    const _FP16 *data = input.getData<_FP16>();
+    _FP16 *rdata = result.getData<_FP16>();
+
+    addition_cl(data, rdata, size, context);
+
+#else
+    throw std::invalid_argument("Error: enable-fp16 is not enabled");
+#endif
+  }
+}
+
 } // namespace nntrainer

--- a/nntrainer/tensor/cl_operations/blas_kernel_interface.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_interface.h
@@ -63,5 +63,13 @@ void dotBatchedCl(Tensor const &input, Tensor const &m, Tensor &result,
  */
 void multiplyCl(Tensor &input, float const &value, RunLayerContext &context);
 
+/**
+ * @brief Process data and dimensions for add operation
+ * @param[in] input Tensor
+ * @param[in] result Tensor
+ * @param[in] RunLayerContext reference
+ */
+void add_i_cl(Tensor const &input, Tensor &result, RunLayerContext &context);
+
 } // namespace nntrainer
 #endif /* __BLAS_KERNEL_INTERFACE_H__ */

--- a/test/unittest/layers/unittest_layers_addition_cl.cpp
+++ b/test/unittest/layers/unittest_layers_addition_cl.cpp
@@ -51,6 +51,6 @@ auto addition_w16a16_gpu = LayerGoldenTestParamType(
   "added_w16a16.nnlayergolden", LayerGoldenTestParamOptions::DEFAULT, "nchw",
   "fp16", "fp16");
 
-GTEST_PARAMETER_TEST(Addition16, LayerGoldenTest,
+GTEST_PARAMETER_TEST(AdditionGPU16, LayerGoldenTest,
                      ::testing::Values(addition_w16a16_gpu));
 #endif


### PR DESCRIPTION
Moved `addition_cl` kernel to Tensor directory and refactored it for generalization.
Naming convention changed for `fp16` in `addition_layer` unittests.