### PR TITLE
[build] Added third party to include directories

### DIFF
--- a/nntrainer/opencl/meson.build
+++ b/nntrainer/opencl/meson.build
@@ -24,3 +24,5 @@ endforeach
 foreach h : opencl_headers
   nntrainer_headers += meson.current_source_dir() / h
 endforeach
+
+install_subdir('third_party', install_dir : nntrainer_prefix / 'include' / 'nntrainer')


### PR DESCRIPTION
Changes in this PR:
- Added opencl/third_party folder to include directory.
- Will prevent file not found errors if GPU related APIs used inside Applications.

Signed-off-by: Debadri Samaddar <s.debadri@samsung.com>