### PR TITLE
[bugfix] Resolves Android build warnings

### DIFF
--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -384,7 +384,7 @@ public:
    *
    * @return boolean true if trainable, else false
    */
-  bool getTrainable() const;
+  bool getTrainable() const override;
 
   /**
    * @brief     get if the output of this layer must be flatten

--- a/nntrainer/layers/lstm.h
+++ b/nntrainer/layers/lstm.h
@@ -41,13 +41,13 @@ public:
    *  @brief  Move constructor.
    *  @param[in] LSTMLayer &&
    */
-  LSTMLayer(LSTMLayer &&rhs) noexcept = default;
+  LSTMLayer(LSTMLayer &&rhs) noexcept;
 
   /**
    * @brief  Move assignment operator.
    * @parma[in] rhs LSTMLayer to be moved.
    */
-  LSTMLayer &operator=(LSTMLayer &&rhs) = default;
+  LSTMLayer &operator=(LSTMLayer &&rhs);
 
   /**
    * @copydoc Layer::finalize(InitLayerContext &context)

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -194,7 +194,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int allocate(ExecutionMode mode = ExecutionMode::TRAIN);
+  int allocate(ExecutionMode mode = ExecutionMode::TRAIN) override;
 
   /**
    * @brief     Deallocate memory for the model.

--- a/nntrainer/tensor/cache_pool.h
+++ b/nntrainer/tensor/cache_pool.h
@@ -76,7 +76,7 @@ public:
     size_t bytes, unsigned int start_time, unsigned int end_time,
     std::vector<unsigned int> exec_order = std::vector<unsigned int>(),
     TensorLifespan lifespan = TensorLifespan::MAX_LIFESPAN,
-    bool is_wgrad = false);
+    bool is_wgrad = false) override;
   /**
    * @brief Get the allocated cache
    *
@@ -86,7 +86,7 @@ public:
    *
    * @details This function will throw if called before allocation.
    */
-  virtual std::shared_ptr<MemoryData> getMemory(unsigned int id);
+  virtual std::shared_ptr<MemoryData> getMemory(unsigned int id) override;
 
   /**
    * @brief Is the cache pool allocated

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -168,14 +168,14 @@ public:
    * @brief Move Construct a new Manager object
    *
    */
-  Manager(Manager &&) noexcept = default;
+  Manager(Manager &&) noexcept;
 
   /**
    * @brief Move assign a new Manager object
    *
    * @return Manager& reference to newly assign
    */
-  Manager &operator=(Manager &&) noexcept = default;
+  Manager &operator=(Manager &&) noexcept;
 
   /**
    * @brief     Destructor of Manager

--- a/test/unittest/unittest_nntrainer_appcontext.cpp
+++ b/test/unittest/unittest_nntrainer_appcontext.cpp
@@ -176,9 +176,12 @@ TEST_P(AppContextTest, RegisterCreateCustomOptimizer_p) {
   EXPECT_EQ(num_id, ((int_key == -1) ? (-1) * int_key : int_key));
   auto opt = ac.createObject<nntrainer::Optimizer>(
     ((key == "") ? "identity_optimizer" : key), {});
-  EXPECT_EQ(typeid(*opt).hash_code(), typeid(CustomOptimizer).hash_code());
+  auto &optimizer = *opt.get();
+  EXPECT_EQ(typeid(optimizer).hash_code(), typeid(CustomOptimizer).hash_code());
   opt = ac.createObject<nntrainer::Optimizer>(num_id, {});
-  EXPECT_EQ(typeid(*opt).hash_code(), typeid(CustomOptimizer).hash_code());
+  auto &new_optimizer = *opt.get();
+  EXPECT_EQ(typeid(new_optimizer).hash_code(),
+            typeid(CustomOptimizer).hash_code());
 }
 
 GTEST_PARAMETER_TEST(RegisterCreateCustomOptimizerTests, AppContextTest,

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -2225,7 +2225,7 @@ TEST(nntrainer_Tensor, multiple_sum_invalid_args_01_n) {
 
 TEST(nntrainer_Tensor, multiple_sum_out_of_range_n) {
   nntrainer::Tensor t = constant(1.0, 1, 1, 1, 1);
-  EXPECT_THROW(t.sum({7}), std::out_of_range);
+  EXPECT_THROW(t.sum(7), std::out_of_range);
 }
 
 TEST(nntrainer_Tensor, multiple_sum_p) {

--- a/test/unittest/unittest_nntrainer_tensor_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_fp16.cpp
@@ -3686,7 +3686,7 @@ TEST(nntrainer_Tensor, multiple_sum_invalid_args_01_n) {
 TEST(nntrainer_Tensor, multiple_sum_out_of_range_n) {
   nntrainer::Tensor t = constant(1.0, 1, 1, 1, 1, nntrainer::Tformat::NCHW,
                                  nntrainer::Tdatatype::FP16);
-  EXPECT_THROW(t.sum({7}), std::out_of_range);
+  EXPECT_THROW(t.sum(7), std::out_of_range);
 }
 
 TEST(nntrainer_Tensor, multiple_sum_p) {

--- a/test/unittest/unittest_nntrainer_tensor_nhwc.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_nhwc.cpp
@@ -2527,7 +2527,7 @@ TEST(nntrainer_Tensor, multiple_sum_invalid_args_01_hnwc_n) {
 
 TEST(nntrainer_Tensor, multiple_sum_out_of_range_nhwc_n) {
   nntrainer::Tensor t = constant(1.0, 1, 1, 1, 1, NHWC_, FP32_);
-  EXPECT_THROW(t.sum({7}), std::out_of_range);
+  EXPECT_THROW(t.sum(7), std::out_of_range);
 }
 
 TEST(nntrainer_Tensor, multiple_sum_nhwc_p) {


### PR DESCRIPTION
This PR resolves warnings that occur during the Android build. The list is as follows.

**Changes proposed in this PR:**
- Resolves explicitly defaulted function is implicitly deleted.
- Fix function that overrides virtual functions but is not marked override.
- Resolves clang warning on expression side effects.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped