### PR TITLE
[meson] fix typo error and add encoder option

### DIFF
--- a/Applications/LLaMA/jni/main.cpp
+++ b/Applications/LLaMA/jni/main.cpp
@@ -31,7 +31,7 @@
 #include <swiglu.h>
 #include <transpose_layer.h>
 
-#if defined(DENABLE_ENCODER)
+#if defined(ENABLE_ENCODER)
 #include "json.hpp"
 #include <codecvt>
 #include <encoder.hpp>
@@ -573,7 +573,7 @@ void run(std::string text, bool apply_temperature) {
 
   unsigned int init_len;
 
-#if defined(DENABLE_ENCODER)
+#if defined(ENABLE_ENCODER)
   std::string vocab_file_name = "../Applications/LLaMA/jni/vocab.json";
   std::string merge_file_name = "../Applications/LLaMA/jni/merges.txt";
 
@@ -620,7 +620,7 @@ void run(std::string text, bool apply_temperature) {
   std::cout << " Progress Reading: 100 % " << std::endl;
   std::cout << std::endl << "### Output : " << std::endl;
   if (init_len < INIT_SEQ_LEN) {
-#if defined(DENABLE_ENCODER)
+#if defined(ENABLE_ENCODER)
     auto decoded_str = tokenizer.decode({static_cast<int64_t>(ids)});
     std::cout << decoded_str << " ";
     std::cout.flush();
@@ -636,7 +636,7 @@ void run(std::string text, bool apply_temperature) {
       input_sample[0] = static_cast<float>(init_input[i]);
     } else {
       input_sample[0] = static_cast<float>(ids);
-#if defined(DENABLE_ENCODER)
+#if defined(ENABLE_ENCODER)
       auto decoded_str = tokenizer.decode({static_cast<int64_t>(ids)});
       std::cout << decoded_str << " ";
       std::cout.flush();
@@ -685,7 +685,7 @@ void createAndRun(unsigned int epochs, unsigned int batch_size) {
   g_model->load(weight_path);
 }
 
-#if defined(DENABLE_ENCODER)
+#if defined(ENABLE_ENCODER)
 std::wstring decodeUnicodeEscape(const std::wstring &input) {
   std::wstringstream result;
 
@@ -713,7 +713,7 @@ int main(int argc, char *argv[]) {
   // Setting locale
   std::locale::global(std::locale("ko_KR.UTF-8"));
 
-#if defined(DENABLE_ENCODER)
+#if defined(ENABLE_ENCODER)
   // Getting arguments From terminal
   std::wstring input;
   std::getline(std::wcin, input);

--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,9 @@ if get_option('platform') == 'tizen'
   if get_option('enable-tizen-feature-check')
     add_project_arguments('-D__FEATURE_CHECK_SUPPORT__', language: ['c', 'cpp'])
   endif
-elif get_option('platform') == 'android'
+endif
+
+if get_option('enable_encoder')
   add_project_arguments('-DENABLE_ENCODER=1', language: ['c', 'cpp'])
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -51,3 +51,6 @@ option('ml-api-support', type: 'feature', value: 'auto')
 option('enable-nnstreamer-tensor-filter', type: 'feature', value: 'auto')
 option('enable-nnstreamer-tensor-trainer', type: 'feature', value: 'auto')
 option('nnstreamer-subplugin-install-path', type: 'string', value: '/usr/lib/nnstreamer') # where nnstreamer subplugin should be installed
+
+# application related options
+option('enable_encoder', type: 'boolean', value: false)


### PR DESCRIPTION
- fix 'ENABLE_ENCODER' option typo errors in llama application
- add 'enable_encoder' to meson option

After reflecting this modifications, i've checked that the llama is running well. (If you build the enable_encoder option as true, it works.)

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped