### PR TITLE
[trivial] remove unnecessary code

### DIFF
--- a/test/unittest/models/models_test_utils.cpp
+++ b/test/unittest/models/models_test_utils.cpp
@@ -442,12 +442,10 @@ void GraphWatcher::compareFor_V2(const std::string &reference) {
 
   unsigned int num_iter;
   nntrainer::checkedRead(file, (char *)&num_iter, sizeof(unsigned));
-  std::cout << "num iter: " << num_iter << '\n';
 
   IterationForGolden ifg(nn.get());
 
   for (unsigned int i = 0; i < num_iter; ++i) {
-    std::cout << "iteration: " << i << std::endl;
     ifg.test(i, file, i != 0);
   }
 }


### PR DESCRIPTION
This PR removes the print statement that was previously added for debugging purposes.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped