### PR TITLE
fix: incorrect C/C++ preprocessor macro

### DIFF
--- a/Applications/PicoGPT/jni/main.cpp
+++ b/Applications/PicoGPT/jni/main.cpp
@@ -17,7 +17,7 @@
 #include <string.h>
 #include <tensor.h>
 
-#if defined(DENABLE_ENCODER)
+#if defined(ENABLE_ENCODER)
 #include "encoder.hpp"
 #endif
 
@@ -43,7 +43,7 @@ bool optimize = false;
 // bool optimize = true;
 bool optimize_attention = false;
 
-#if defined(DENABLE_ENCODER)
+#if defined(ENABLE_ENCODER)
 template <typename T>
 T unwrap(std::optional<T> &&value, const std::string &error_msg) {
   if (value.has_value()) {
@@ -318,7 +318,7 @@ int main(int argc, char *argv[]) {
 
     std::vector<int64_t> init_input;
 
-#if defined(DENABLE_ENCODER)
+#if defined(ENABLE_ENCODER)
 
     std::string vocab_file_name = "../Applications/PicoGPT/jni/vocab.json";
     std::string merge_file_name = "../Applications/PicoGPT/jni/merges.txt";
@@ -372,7 +372,7 @@ int main(int argc, char *argv[]) {
 
       ((uint *)(wpe_input))[0] = i;
 
-#if defined(DENABLE_ENCODER)
+#if defined(ENABLE_ENCODER)
       std::vector<int64_t> token_ids;
       for (auto element : ids) {
         token_ids.push_back(static_cast<int64_t>(element));


### PR DESCRIPTION
When -DENABLE_ENCODER is given, you do
 #ifdef ENABLE_ENCODER
not
 #ifdef DENABLE_ENCODER

CC: @baek2sm