### PR TITLE
[Android] Verify Android NDK Installation and Configuration

### DIFF
--- a/tools/android_test.sh
+++ b/tools/android_test.sh
@@ -8,7 +8,11 @@
 # You can modify test/jni/Android.mk to choose module that you wish to build
 cd test/jni
 
-# Perequisite: Install and configure the NDK
+if [ ! -d $ANDROID_NDK ]; then
+  echo "Error: ANDROID_NDK not found."
+  exit 1
+fi
+
 ndk-build
 
 if [ $? != 0 ]; then


### PR DESCRIPTION
This patch checks if Android NDK is installed and configured before building using NDK in the Android test script.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped