### PR TITLE
[ Layers ] Bug Fix for NHWC Support

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -779,8 +779,10 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
           TensorSpecV2::RequestType::READ_ONLY_VIEW;
         if (lnode->getType() == IdentityLayer::type) {
           s.variable_spec.reference_name = inputs[i]->getName();
+          s.variable_spec.dim.setFormat(inputs[i]->getDim().getFormat());
         } else {
           s.variable_spec.reference_name = inputs[0]->getName();
+          s.variable_spec.dim.setFormat(inputs[0]->getDim().getFormat());
         }
       }
       if (shared_grad && s.gradient_spec) {
@@ -788,8 +790,10 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
           TensorSpecV2::RequestType::READ_ONLY_VIEW;
         if (lnode->getType() == IdentityLayer::type) {
           s.gradient_spec->reference_name = inputs[i]->getGradientName();
+          s.gradient_spec->dim.setFormat(inputs[i]->getDim().getFormat());
         } else {
           s.gradient_spec->reference_name = inputs[0]->getGradientName();
+          s.gradient_spec->dim.setFormat(inputs[0]->getDim().getFormat());
         }
       }
     }


### PR DESCRIPTION
This PR fixes the bug about the inplace layers when the channel last is enabled.
Previously, the input var_grad tensor's format is not changed in inplace layers.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped