### PR TITLE
[GPU/OpenCL] Adding map/unmap feature for buffer @open sesame 10/29 21:51 

### DIFF
--- a/nntrainer/opencl/opencl_buffer.cpp
+++ b/nntrainer/opencl/opencl_buffer.cpp
@@ -32,7 +32,7 @@ Buffer::Buffer(ContextManager &context_manager, int size_in_bytes,
   cl_context context = context_manager.GetContext();
   cl_mem_flags flags = read_only ? CL_MEM_READ_ONLY : CL_MEM_READ_WRITE;
   if (data) {
-    flags |= CL_MEM_COPY_HOST_PTR;
+    flags |= CL_MEM_USE_HOST_PTR;
   }
   cl_int error_code;
 
@@ -103,6 +103,18 @@ bool Buffer::WriteData(CommandQueueManager &command_queue_inst,
  */
 bool Buffer::ReadData(CommandQueueManager &command_queue_inst, void *data) {
   return command_queue_inst.EnqueueReadBuffer(mem_buf_, size_, data);
+}
+
+void *Buffer::MapBuffer(CommandQueueManager &command_queue_inst,
+                        size_t offset_in_bytes, size_t size_in_bytes,
+                        bool read_only, bool async) {
+  return command_queue_inst.EnqueueMapBuffer(mem_buf_, offset_in_bytes,
+                                             size_in_bytes, read_only, async);
+}
+
+bool Buffer::UnMapBuffer(CommandQueueManager &command_queue_inst,
+                         void *mapped_ptr) {
+  return command_queue_inst.EnqueueUnmapMemObject(mem_buf_, mapped_ptr);
 }
 
 /**

--- a/nntrainer/opencl/opencl_buffer.h
+++ b/nntrainer/opencl/opencl_buffer.h
@@ -114,6 +114,30 @@ public:
    * @return true if successful read or false otherwise
    */
   bool ReadData(CommandQueueManager &command_queue_inst, void *data);
+
+  /**
+   * @brief Mapping buffer to host memory
+   *
+   * @param command_queue_inst reference of command queue instance
+   * @param offset_in_bytes offset of the region in the buffer object that is
+   * being mapped
+   * @param size_in_bytes size of the buffer object that is being mapped
+   * @param read_only flag for read only mapping
+   * @param async flag for asynchronous operation
+   * @return void* pointer to the mapped region
+   */
+  void *MapBuffer(CommandQueueManager &command_queue_inst,
+                  size_t offset_in_bytes, size_t size_in_bytes, bool read_only,
+                  bool async = false);
+
+  /**
+   * @brief Un-mapping buffer from host memeory
+   *
+   * @param command_queue_inst reference of command queue instance
+   * @param mapped_ptr pointer to the mapped region
+   * @return true if unmap is successful
+   */
+  bool UnMapBuffer(CommandQueueManager &command_queue_inst, void *mapped_ptr);
 };
 } // namespace nntrainer::opencl
 #endif // __OPENCL_BUFFER_H__

--- a/nntrainer/opencl/opencl_command_queue_manager.h
+++ b/nntrainer/opencl/opencl_command_queue_manager.h
@@ -85,6 +85,35 @@ public:
                           bool async = false);
 
   /**
+   * @brief Mapping a region of a buffer object into the host address space
+   *
+   * @param buffer cl_mem buffer object
+   * @param offset_in_bytes offset of the region in the buffer object that is
+   * being mapped
+   * @param size_in_bytes size of the buffer object that is being mapped
+   * @param read_only flag for read only mapping
+   * @param async flag for asynchronous operation
+   * @param event Object that identifies this command and can be used to query
+   * or wait for this command to complete
+   * @return void* pointer to the mapped region
+   */
+  void *EnqueueMapBuffer(cl_mem buffer, size_t offset_in_bytes,
+                         size_t size_in_bytes, bool read_only,
+                         bool async = false, cl_event *event = nullptr);
+
+  /**
+   * @brief Un-mapping a buffer object from the host address space
+   *
+   * @param buffer cl_mem buffer object
+   * @param mapped_ptr pointer to the mapped region
+   * @param event Object that identifies this command and can be used to query
+   * or wait for this command to complete
+   * @return true if unmap is successful
+   */
+  bool EnqueueUnmapMemObject(cl_mem buffer, void *mapped_ptr,
+                             cl_event *event = nullptr);
+
+  /**
    * @brief Function to initiate execution of the command queue.
    *
    * @param kernel OpenCL kernel

--- a/nntrainer/opencl/opencl_loader.cpp
+++ b/nntrainer/opencl/opencl_loader.cpp
@@ -73,6 +73,8 @@ void LoadOpenCLFunctions(void *libopencl) {
   LoadFunction(clCreateBuffer);
   LoadFunction(clEnqueueWriteBuffer);
   LoadFunction(clEnqueueReadBuffer);
+  LoadFunction(clEnqueueMapBuffer);
+  LoadFunction(clEnqueueUnmapMemObject);
   LoadFunction(clCreateProgramWithSource);
   LoadFunction(clCreateProgramWithBinary);
   LoadFunction(clBuildProgram);
@@ -98,6 +100,8 @@ PFN_clCreateCommandQueue clCreateCommandQueue;
 PFN_clCreateBuffer clCreateBuffer;
 PFN_clEnqueueWriteBuffer clEnqueueWriteBuffer;
 PFN_clEnqueueReadBuffer clEnqueueReadBuffer;
+PFN_clEnqueueMapBuffer clEnqueueMapBuffer;
+PFN_clEnqueueUnmapMemObject clEnqueueUnmapMemObject;
 PFN_clCreateProgramWithSource clCreateProgramWithSource;
 PFN_clCreateProgramWithBinary clCreateProgramWithBinary;
 PFN_clBuildProgram clBuildProgram;

--- a/nntrainer/opencl/opencl_loader.h
+++ b/nntrainer/opencl/opencl_loader.h
@@ -72,6 +72,21 @@ typedef cl_int(CL_API_CALL *PFN_clEnqueueReadBuffer)(
   void * /**< ptr */, cl_uint /**< num_events_in_wait_list */,
   const cl_event * /**< event_wait_list */, cl_event * /**< event */);
 
+typedef void *(CL_API_CALL *PFN_clEnqueueMapBuffer)(
+  cl_command_queue /**< command_queue */, cl_mem /**< buffer */,
+  cl_bool /**< blocking_map */, cl_map_flags /**< map_flags */,
+  size_t /**< offset */, size_t /**< size */,
+  cl_uint /**< num_events_in_wait_list */,
+  const cl_event * /**< event_wait_list */, cl_event * /**< event */,
+  cl_int * /**< errcode_ret */
+);
+
+typedef cl_int(CL_API_CALL *PFN_clEnqueueUnmapMemObject)(
+  cl_command_queue /**< command_queue */, cl_mem /**< memobj */,
+  void * /**< mapped_ptr */, cl_uint /**< num_events_in_wait_list */,
+  const cl_event * /**< event_wait_list */, cl_event * /**< event */
+);
+
 typedef cl_program(CL_API_CALL *PFN_clCreateProgramWithSource)(
   cl_context /**< context */, cl_uint /**< count */,
   const char ** /**< strings */, const size_t * /**< lengths */,
@@ -144,6 +159,8 @@ extern PFN_clCreateCommandQueue clCreateCommandQueue;
 extern PFN_clCreateBuffer clCreateBuffer;
 extern PFN_clEnqueueWriteBuffer clEnqueueWriteBuffer;
 extern PFN_clEnqueueReadBuffer clEnqueueReadBuffer;
+extern PFN_clEnqueueMapBuffer clEnqueueMapBuffer;
+extern PFN_clEnqueueUnmapMemObject clEnqueueUnmapMemObject;
 extern PFN_clCreateProgramWithSource clCreateProgramWithSource;
 extern PFN_clCreateProgramWithBinary clCreateProgramWithBinary;
 extern PFN_clBuildProgram clBuildProgram;


### PR DESCRIPTION
Changes in this PR:

- Modified `opencl::Buffer` constructor to use `CL_MEM_USE_HOST_PTR` to use host memory from GPU.
- Loaded APIs for `clEnqueueMapBuffer` and `clEnqueueUnmapMemObject` OpenCL functions to map/unmap `opencl::Buffer` to host address space.
- Added required functions in `opencl::Buffer` and `opencl::CommandQueueManager` classes to manage mapping and unmapping from host address.

> Purpose of these changes is to make use of host memory to reduce the copying of data to and from GPU.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Debadri Samaddar <s.debadri@samsung.com>