### PR TITLE
[ hgemm ] Add experimental kernel

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -255,6 +255,7 @@ if get_option('enable-blas')
       message('set openblas num threads=@0@'.format(get_option('openblas-num-threads')))
     endif
   endif
+  extra_defines += '-DHGEMM_EXPERIMENTAL_KERNEL=@0@'.format(get_option('hgemm-experimental-kernel'))
 endif
 
 extra_defines += '-DNNTR_NUM_THREADS=@0@'.format(get_option('nntr-num-threads'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -29,6 +29,7 @@ option('openblas-num-threads', type: 'integer', min : 0, max : 9999, value: 0)
 #This is for the multi-threading in nntrainer
 option('nntr-num-threads', type: 'integer', min : 0, max : 9999, value: 1)
 option('omp-num-threads', type: 'integer', min : 0, max : 9999, value: 1)
+option('hgemm-experimental-kernel', type: 'boolean', value: false)
 
 # test related option
 option('reduce-tolerance', type: 'boolean', value: true)

--- a/nntrainer/tensor/hgemm/hgemm.h
+++ b/nntrainer/tensor/hgemm/hgemm.h
@@ -29,6 +29,22 @@ void hgemm(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
            bool TransB);
 
 /**
+ * @brief     hgemm computation with neon but with small dim without padding : Y
+ * = alpha*op(A)*op(B) + beta*C, where op(X) is one of X or X**T
+ * @param[in] A __fp16 * for Matrix A
+ * @param[in] B __fp16 * for Matrix B
+ * @param[in] C __fp16 * for Matrix C
+ * @param[in] M number of op(A)'s and C's row
+ * @param[in] N number of op(B)'s and C's columns
+ * @param[in] K number of op(A)'s and columns and op(B)'s rows
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void hgemm_small(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
+                 unsigned int N, unsigned int K, float alpha, float beta,
+                 bool TransA, bool TransB);
+
+/**
  * @brief     Checking function for whether matrix A or B needs padding for
  * optimal performance of fixed blocking-kernel sequence
  * @param[in] A __fp16 * for Matrix A

--- a/nntrainer/tensor/hgemm/hgemm.h
+++ b/nntrainer/tensor/hgemm/hgemm.h
@@ -23,6 +23,8 @@
  * @param[in] K number of op(A)'s and columns and op(B)'s rows
  * @param[in] alpha float number
  * @param[in] beta float number
+ * @param[in] TransA bool transpose info of lhs matrix
+ * @param[in] TransB bool transpose info of rhs matrix
  */
 void hgemm(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
            unsigned int N, unsigned int K, float alpha, float beta, bool TransA,
@@ -39,6 +41,8 @@ void hgemm(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
  * @param[in] K number of op(A)'s and columns and op(B)'s rows
  * @param[in] alpha float number
  * @param[in] beta float number
+ * @param[in] TransA bool transpose info of lhs matrix
+ * @param[in] TransB bool transpose info of rhs matrix
  */
 void hgemm_small(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
                  unsigned int N, unsigned int K, float alpha, float beta,
@@ -55,6 +59,8 @@ void hgemm_small(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
  * @param[in] K number of op(A)'s and columns and op(B)'s rows
  * @param[in] alpha float number
  * @param[in] beta float number
+ * @param[in] TransA bool transpose info of lhs matrix
+ * @param[in] TransB bool transpose info of rhs matrix
  */
 void hgemm_ensure_divisibility(const __fp16 *A, const __fp16 *B, float *C32,
                                unsigned int M, unsigned int N, unsigned int K,
@@ -72,6 +78,8 @@ void hgemm_ensure_divisibility(const __fp16 *A, const __fp16 *B, float *C32,
  * @param[in] K number of op(A)'s and columns and op(B)'s rows
  * @param[in] alpha float number
  * @param[in] beta float number
+ * @param[in] TransA bool transpose info of lhs matrix
+ * @param[in] TransB bool transpose info of rhs matrix
  */
 void hgemm_classify(const __fp16 *A, const __fp16 *B, float *C32,
                     unsigned int M, unsigned int N, unsigned int K,
@@ -88,6 +96,8 @@ void hgemm_classify(const __fp16 *A, const __fp16 *B, float *C32,
  * @param[in] K number of op(A)'s and columns and op(B)'s rows
  * @param[in] alpha float number
  * @param[in] beta float number
+ * @param[in] TransA bool transpose info of lhs matrix
+ * @param[in] TransB bool transpose info of rhs matrix
  */
 void hgemm_K1(const __fp16 *A, const __fp16 *B, __fp16 *C, unsigned int M,
               unsigned int N, unsigned int K, float alpha, float beta,

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel.h
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel.h
@@ -22,21 +22,10 @@
  * @param sc Starting address of blocked C
  * @param ldc Leading dimension of original matrix C
  */
+template <typename T>
 void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
-                       __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc);
-/**
- * @brief hgemm_kernel_8x16 KERNEL function
- *
- * @param M Length of blocked M
- * @param N Length of blocked N
- * @param K Length of blocked K
- * @param sa Starting address of blocked A
- * @param sb Starting address of blocked B
- * @param sc Starting address of blocked C
- * @param ldc Leading dimension of original matrix C
- */
-void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
-                       __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc);
+                       __fp16 *sa, __fp16 *sb, T *sc, unsigned int ldc);
+
 /**
  * @brief hgemm_kernel_8x8 KERNEL function
  *
@@ -48,21 +37,10 @@ void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
  * @param sc Starting address of blocked C
  * @param ldc Leading dimension of original matrix C
  */
+template <typename T>
 void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
-                      __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc);
-/**
- * @brief hgemm_kernel_8x8 KERNEL function
- *
- * @param M Length of blocked M
- * @param N Length of blocked N
- * @param K Length of blocked K
- * @param sa Starting address of blocked A
- * @param sb Starting address of blocked B
- * @param sc Starting address of blocked C
- * @param ldc Leading dimension of original matrix C
- */
-void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
-                      __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc);
+                      __fp16 *sa, __fp16 *sb, T *sc, unsigned int ldc);
+
 /**
  * @brief hgemm_kernel_4x8 KERNEL function
  *
@@ -74,21 +52,10 @@ void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
  * @param sc Starting address of blocked C
  * @param ldc Leading dimension of original matrix C
  */
+template <typename T>
 void hgemm_kernel_4x8(unsigned int M, unsigned int N, unsigned int K,
-                      __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc);
-/**
- * @brief hgemm_kernel_4x8 KERNEL function
- *
- * @param M Length of blocked M
- * @param N Length of blocked N
- * @param K Length of blocked K
- * @param sa Starting address of blocked A
- * @param sb Starting address of blocked B
- * @param sc Starting address of blocked C
- * @param ldc Leading dimension of original matrix C
- */
-void hgemm_kernel_4x8(unsigned int M, unsigned int N, unsigned int K,
-                      __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc);
+                      __fp16 *sa, __fp16 *sb, T *sc, unsigned int ldc);
+
 /**
  * @brief hgemm_kernel_4x4 KERNEL function
  *
@@ -100,21 +67,10 @@ void hgemm_kernel_4x8(unsigned int M, unsigned int N, unsigned int K,
  * @param sc Starting address of blocked C
  * @param ldc Leading dimension of original matrix C
  */
+template <typename T>
 void hgemm_kernel_4x4(unsigned int M, unsigned int N, unsigned int K,
-                      __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc);
-/**
- * @brief hgemm_kernel_4x4 KERNEL function
- *
- * @param M Length of blocked M
- * @param N Length of blocked N
- * @param K Length of blocked K
- * @param sa Starting address of blocked A
- * @param sb Starting address of blocked B
- * @param sc Starting address of blocked C
- * @param ldc Leading dimension of original matrix C
- */
-void hgemm_kernel_4x4(unsigned int M, unsigned int N, unsigned int K,
-                      __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc);
+                      __fp16 *sa, __fp16 *sb, T *sc, unsigned int ldc);
+
 /**
  * @brief hgemm_kernel_1x8 KERNEL function
  *
@@ -126,21 +82,10 @@ void hgemm_kernel_4x4(unsigned int M, unsigned int N, unsigned int K,
  * @param sc Starting address of blocked C
  * @param ldc Leading dimension of original matrix C
  */
+template <typename T>
 void hgemm_kernel_1x8(unsigned int M, unsigned int N, unsigned int K,
-                      __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc);
-/**
- * @brief hgemm_kernel_1x8 KERNEL function
- *
- * @param M Length of blocked M
- * @param N Length of blocked N
- * @param K Length of blocked K
- * @param sa Starting address of blocked A
- * @param sb Starting address of blocked B
- * @param sc Starting address of blocked C
- * @param ldc Leading dimension of original matrix C
- */
-void hgemm_kernel_1x8(unsigned int M, unsigned int N, unsigned int K,
-                      __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc);
+                      __fp16 *sa, __fp16 *sb, T *sc, unsigned int ldc);
+
 /**
  * @brief hgemm_kernel_1x4 KERNEL function
  *
@@ -152,18 +97,6 @@ void hgemm_kernel_1x8(unsigned int M, unsigned int N, unsigned int K,
  * @param sc Starting address of blocked C
  * @param ldc Leading dimension of original matrix C
  */
+template <typename T>
 void hgemm_kernel_1x4(unsigned int M, unsigned int N, unsigned int K,
-                      __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc);
-/**
- * @brief hgemm_kernel_1x4 KERNEL function
- *
- * @param M Length of blocked M
- * @param N Length of blocked N
- * @param K Length of blocked K
- * @param sa Starting address of blocked A
- * @param sb Starting address of blocked B
- * @param sc Starting address of blocked C
- * @param ldc Leading dimension of original matrix C
- */
-void hgemm_kernel_1x4(unsigned int M, unsigned int N, unsigned int K,
-                      __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc);
+                      __fp16 *sa, __fp16 *sb, T *sc, unsigned int ldc);

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_1x4.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_1x4.cpp
@@ -16,6 +16,7 @@
 #include <hgemm_kernel.h>
 #include <stdlib.h>
 
+template <>
 void hgemm_kernel_1x4(unsigned int M, unsigned int N, unsigned int K,
                       __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc) {
   assert(M > 0 && N > 0 && K > 0);
@@ -70,6 +71,7 @@ void hgemm_kernel_1x4(unsigned int M, unsigned int N, unsigned int K,
   }
 }
 
+template <>
 void hgemm_kernel_1x4(unsigned int M, unsigned int N, unsigned int K,
                       __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc) {
   assert(M > 0 && N > 0 && K > 0);

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_1x8.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_1x8.cpp
@@ -15,6 +15,7 @@
 #include <arm_neon.h>
 #include <assert.h>
 #include <hgemm_kernel.h>
+#include <hgemm_util.h>
 #include <stdlib.h>
 
 // 1. Partial sum 64 digits : worst accuracy, best latency
@@ -128,7 +129,7 @@ void hgemm_kernel_1x8(unsigned int M, unsigned int N, unsigned int K,
 
   __fp16 *a = sa, *b = sb;
   float *c = sc;
-  unsigned int k8 = (K >> 3) << 3;
+  unsigned int K8 = get_prev_mltpl_of_2p_n(K, 3);
   unsigned int i, j, l;
   for (i = 0; i < M; i++) {
     for (j = 0; j < N; j += 8) {
@@ -138,7 +139,7 @@ void hgemm_kernel_1x8(unsigned int M, unsigned int N, unsigned int K,
       float16x8_t v24, v25, v26, v27, v28, v29, v30, v31;
       float16_t dv0, dv1, dv2, dv3, dv4, dv5, dv6, dv7;
       l = 0;
-      for (; l < k8;) {
+      for (; l < K8;) {
         KERNEL_1x8_ACC8();
 
         vst1q_f32(c, vaddq_f32(vld1q_f32(c), vcvt_f32_f16(vget_low_f16(v0))));

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_1x8.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_1x8.cpp
@@ -83,6 +83,7 @@
     a++;                            \
   } while (0)
 
+template <>
 void hgemm_kernel_1x8(unsigned int M, unsigned int N, unsigned int K,
                       __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc) {
   assert(M > 0 && N > 0 && K > 0);
@@ -119,6 +120,7 @@ void hgemm_kernel_1x8(unsigned int M, unsigned int N, unsigned int K,
   }
 }
 
+template <>
 void hgemm_kernel_1x8(unsigned int M, unsigned int N, unsigned int K,
                       __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc) {
   assert(M > 0 && N > 0 && K > 0);

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_4x4.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_4x4.cpp
@@ -14,6 +14,7 @@
 #include <arm_neon.h>
 #include <assert.h>
 #include <hgemm_kernel.h>
+#include <hgemm_util.h>
 #include <stdlib.h>
 
 #define INIT_KERNEL_4x4()  \
@@ -302,8 +303,8 @@ void hgemm_kernel_4x4(unsigned int M, unsigned int N, unsigned int K,
   __fp16 *a = sa, *b = sb;
   float *c = sc;
   unsigned int i, j, l;
-  unsigned int K16 = (K >> 4) << 4;
-  unsigned int K8 = (K >> 3) << 3;
+  unsigned int K8 = get_prev_mltpl_of_2p_n(K, 3);
+  unsigned int K16 = get_prev_mltpl_of_2p_n(K, 4);
   for (i = 0; i < M; i += 4) {
     for (j = 0; j < N; j += 4) {
       __builtin_prefetch(b, 0, 3);

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_4x4.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_4x4.cpp
@@ -214,6 +214,7 @@
               vaddq_f32(vld1q_f32(c + 3 * ldc), vcvt_f32_f16(v27)));      \
   } while (0)
 
+template <>
 void hgemm_kernel_4x4(unsigned int M, unsigned int N, unsigned int K,
                       __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc) {
   assert(M > 0 && N > 0 && K > 0);
@@ -292,6 +293,7 @@ void hgemm_kernel_4x4(unsigned int M, unsigned int N, unsigned int K,
   }
 }
 
+template <>
 void hgemm_kernel_4x4(unsigned int M, unsigned int N, unsigned int K,
                       __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc) {
   assert(M > 0 && N > 0 && K > 0);

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_4x8.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_4x8.cpp
@@ -14,6 +14,7 @@
 #include <arm_neon.h>
 #include <assert.h>
 #include <hgemm_kernel.h>
+#include <hgemm_util.h>
 #include <stdlib.h>
 
 #define INIT_KERNEL_4X8()  \
@@ -304,9 +305,9 @@ void hgemm_kernel_4x8(unsigned int M, unsigned int N, unsigned int K,
 
   __fp16 *a = sa, *b = sb;
   float *c = sc;
-  unsigned int K16 = (K >> 4) << 4;
-  unsigned int K8 = (K >> 3) << 3;
-  unsigned int K4 = (K >> 2) << 2;
+  unsigned int K4 = get_prev_mltpl_of_2p_n(K, 2);
+  unsigned int K8 = get_prev_mltpl_of_2p_n(K, 3);
+  unsigned int K16 = get_prev_mltpl_of_2p_n(K, 4);
   unsigned int i, j, l;
   for (i = 0; i < M; i += 4) {
     for (j = 0; j < N; j += 8) {

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_4x8.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_4x8.cpp
@@ -258,6 +258,7 @@
                                          vcvt_f32_f16(vget_high_f16(v9))));   \
   } while (0)
 
+template <>
 void hgemm_kernel_4x8(unsigned int M, unsigned int N, unsigned int K,
                       __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc) {
   assert(M > 0 && N > 0 && K > 0);
@@ -295,6 +296,7 @@ void hgemm_kernel_4x8(unsigned int M, unsigned int N, unsigned int K,
   }
 }
 
+template <>
 void hgemm_kernel_4x8(unsigned int M, unsigned int N, unsigned int K,
                       __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc) {
   assert(M > 0 && N > 0 && K > 0);

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_8x16.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_8x16.cpp
@@ -14,6 +14,7 @@
 #include <arm_neon.h>
 #include <assert.h>
 #include <hgemm_kernel.h>
+#include <hgemm_util.h>
 #include <stdlib.h>
 
 #define INIT_KERNEL_8X16()       \
@@ -793,9 +794,9 @@ void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
   __fp16 *a = sa, *b = sb;
   float *c = sc;
   unsigned int i, j, l;
-  unsigned int K4 = (K >> 2) << 2;
-  unsigned int K8 = (K >> 3) << 3;
-  unsigned int K16 = (K >> 4) << 4;
+  unsigned int K4 = get_prev_mltpl_of_2p_n(K, 2);
+  unsigned int K8 = get_prev_mltpl_of_2p_n(K, 3);
+  unsigned int K16 = get_prev_mltpl_of_2p_n(K, 4);
   for (i = 0; i < M; i += 8) {
     for (j = 0; j < N; j += 16) {
       __builtin_prefetch(b, 0, 3);

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_8x16_experimental.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_8x16_experimental.cpp
@@ -14,6 +14,7 @@
 #include <arm_neon.h>
 #include <assert.h>
 #include <hgemm_kernel.h>
+#include <hgemm_util.h>
 #include <stdexcept>
 #include <stdlib.h>
 
@@ -742,11 +743,12 @@ void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
   __fp16 *a = sa, *b = sb;
   float *c = sc;
   unsigned int i, j, l;
-  unsigned int K4 = (K >> 2) << 2;
-  unsigned int K8 = (K >> 3) << 3;
-  unsigned int K16 = (K >> 4) << 4;
-  unsigned int K32 = (K >> 5) << 5;
-  unsigned int K64 = (K >> 6) << 6;
+  unsigned int K4 = get_prev_mltpl_of_2p_n(K, 2);
+  unsigned int K8 = get_prev_mltpl_of_2p_n(K, 3);
+  unsigned int K16 = get_prev_mltpl_of_2p_n(K, 4);
+  unsigned int K32 = get_prev_mltpl_of_2p_n(K, 5);
+  unsigned int K64 = get_prev_mltpl_of_2p_n(K, 6);
+
   for (i = 0; i < M; i += 8) {
     for (j = 0; j < N; j += 16) {
       __builtin_prefetch(b, 0, 3);

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_8x16_experimental.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_8x16_experimental.cpp
@@ -14,6 +14,7 @@
 #include <arm_neon.h>
 #include <assert.h>
 #include <hgemm_kernel.h>
+#include <stdexcept>
 #include <stdlib.h>
 
 #define INIT_KERNEL_8X16()       \
@@ -725,13 +726,14 @@
                         vcvt_f32_f16(vget_high_f16(v120_127))));               \
   } while (0)
 
-template<>
+template <>
 void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
                        __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc) {
-//  std::invalid_argument("Error : should not reach experimental kernel + full fp16 usage in hgemm");
+  throw std::runtime_error(
+    "Error : should not reach for full-fp16 usage in experimental kernel");
 }
 
-template<>
+template <>
 void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
                        __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc) {
   assert(M > 0 && N > 0 && K > 0);
@@ -803,4 +805,3 @@ void hgemm_kernel_8x16(unsigned int M, unsigned int N, unsigned int K,
     b = sb;
   }
 }
-

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_8x8.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_8x8.cpp
@@ -400,6 +400,7 @@
                                          vcvt_f32_f16(vget_high_f16(v31))));   \
   } while (0)
 
+template <>
 void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
                       __fp16 *sa, __fp16 *sb, __fp16 *sc, unsigned int ldc) {
   assert(M > 0 && N > 0 && K > 0);
@@ -438,6 +439,7 @@ void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
   }
 }
 
+template <>
 void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
                       __fp16 *sa, __fp16 *sb, float *sc, unsigned int ldc) {
   assert(M > 0 && N > 0 && K > 0);

--- a/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_8x8.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/hgemm_kernel_8x8.cpp
@@ -14,6 +14,7 @@
 #include <arm_neon.h>
 #include <assert.h>
 #include <hgemm_kernel.h>
+#include <hgemm_util.h>
 #include <stdlib.h>
 
 #define INIT_KERNEL_8x8()   \
@@ -448,9 +449,9 @@ void hgemm_kernel_8x8(unsigned int M, unsigned int N, unsigned int K,
   __fp16 *a = sa, *b = sb;
   float *c = sc;
   unsigned int i, j, l;
-  unsigned int K4 = (K >> 2) << 2;
-  unsigned int K8 = (K >> 3) << 3;
-  unsigned int K16 = (K >> 4) << 4;
+  unsigned int K4 = get_prev_mltpl_of_2p_n(K, 2);
+  unsigned int K8 = get_prev_mltpl_of_2p_n(K, 3);
+  unsigned int K16 = get_prev_mltpl_of_2p_n(K, 4);
   for (i = 0; i < M; i += 8) {
     for (j = 0; j < N; j += 8) {
       __builtin_prefetch(b, 0, 3);

--- a/nntrainer/tensor/hgemm/hgemm_kernel/meson.build
+++ b/nntrainer/tensor/hgemm/hgemm_kernel/meson.build
@@ -9,8 +9,13 @@ hgemm_kernel_sources = [
     'hgemm_kernel_4x4.cpp',
     'hgemm_kernel_4x8.cpp',
     'hgemm_kernel_8x8.cpp',
-    'hgemm_kernel_8x16.cpp',
 ]
+
+if get_option('hgemm-experimental-kernel')
+  hgemm_kernel_sources += 'hgemm_kernel_8x16_experimental.cpp'
+else
+  hgemm_kernel_sources += 'hgemm_kernel_8x16.cpp'
+endif
 
 foreach s : hgemm_kernel_sources
   nntrainer_sources += meson.current_source_dir() / s

--- a/nntrainer/tensor/hgemm/hgemm_noTrans.h
+++ b/nntrainer/tensor/hgemm/hgemm_noTrans.h
@@ -252,6 +252,28 @@ void hgemm_noTrans_8x16(unsigned int M, unsigned int N, unsigned int K,
                         float alpha = 1.F, float beta = 0.F);
 
 /**
+ * @brief hgemm noTrans computation with 8x16 kernel : C = A*B,
+ *
+ * @param M length of the row of matrix A
+ * @param N length of the col of matrix B
+ * @param K length of the col of matrix A
+ * @param A input matrix A
+ * @param lda length of the col of matrix A
+ * @param B input matrix B
+ * @param ldb length of the col of matrix B
+ * @param C output matrix C
+ * @param ldc length of the col of matrix C
+ * @param[in] alpha float number
+ * @param[in] beta float number
+ */
+void hgemm_noTrans_8x16_experimental(unsigned int M, unsigned int N,
+                                     unsigned int K, const __fp16 *A,
+                                     unsigned int lda, const __fp16 *B,
+                                     unsigned int ldb, float *C,
+                                     unsigned int ldc, float alpha = 1.F,
+                                     float beta = 0.F);
+
+/**
  * @brief     hgemm fallback with NEON : Y = alpha*op(A)*op(B) + beta*C,
  * @param M length of the row of matrix A
  * @param N length of the col of matrix B

--- a/nntrainer/tensor/hgemm/hgemm_noTrans.h
+++ b/nntrainer/tensor/hgemm/hgemm_noTrans.h
@@ -252,28 +252,6 @@ void hgemm_noTrans_8x16(unsigned int M, unsigned int N, unsigned int K,
                         float alpha = 1.F, float beta = 0.F);
 
 /**
- * @brief hgemm noTrans computation with 8x16 kernel : C = A*B,
- *
- * @param M length of the row of matrix A
- * @param N length of the col of matrix B
- * @param K length of the col of matrix A
- * @param A input matrix A
- * @param lda length of the col of matrix A
- * @param B input matrix B
- * @param ldb length of the col of matrix B
- * @param C output matrix C
- * @param ldc length of the col of matrix C
- * @param[in] alpha float number
- * @param[in] beta float number
- */
-void hgemm_noTrans_8x16_experimental(unsigned int M, unsigned int N,
-                                     unsigned int K, const __fp16 *A,
-                                     unsigned int lda, const __fp16 *B,
-                                     unsigned int ldb, float *C,
-                                     unsigned int ldc, float alpha = 1.F,
-                                     float beta = 0.F);
-
-/**
  * @brief     hgemm fallback with NEON : Y = alpha*op(A)*op(B) + beta*C,
  * @param M length of the row of matrix A
  * @param N length of the col of matrix B

--- a/nntrainer/tensor/hgemm/hgemm_util.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_util.cpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Sungsik Kong <ss.kong@samsung.com>
+ *
+ * @file   hgemm_util.cpp
+ * @date   01 August 2024
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Sungsik Kong <ss.kong@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is for util functions for half-precision GEMM
+ */
+
+#include <cmath>
+#include <hgemm_util.h>
+
+/**
+ * @brief aligned dynamic allocation function
+ *
+ * @param sz amount of data to allocate
+ * @return __fp16* addr of allocated memory
+ */
+__fp16 *alignedMalloc(unsigned int sz) {
+  void *addr = 0;
+  int iRet = posix_memalign(&addr, 64, sz * sizeof(__fp16));
+  assert(0 == iRet);
+  return (__fp16 *)addr;
+}
+
+unsigned int get_next_mltpl_of_n(unsigned int x, unsigned int n) {
+  assert(x > 0);
+  return ((x - 1) / n + 1) * n;
+}
+
+unsigned int get_prev_mltpl_of_2p_n(unsigned int x, unsigned int n) {
+  assert(x > 0);
+  assert(n % 2 == 0);
+  return (x >> n) << n;
+}
+
+void copy_C_to_C32(__fp16 *C, float *C32, unsigned int M, unsigned int N,
+                   float beta) {
+  float32x4_t ZEROS = vmovq_n_f32(0.F);
+  unsigned int size = M * N;
+  unsigned int size4 = (size >> 2) << 2;
+  const unsigned int N8_low = get_prev_mltpl_of_2p_n(N, 3);
+
+  if (std::fpclassify(beta) != FP_ZERO) {
+    for (unsigned int m = 0; m < M; ++m) {
+      for (unsigned int n = 0; n < N8_low; n += 8) {
+        float16x8_t c = vmulq_n_f16(vld1q_f16(&C[m * N + n]), beta);
+        vst1q_f32(&C32[m * N + n], vcvt_f32_f16(vget_low_f16(c)));
+        vst1q_f32(&C32[m * N + n + 4], vcvt_f32_f16(vget_high_f16(c)));
+      }
+      for (unsigned int n = N8_low; n < N; ++n) {
+        C32[m * N + n] = beta * C[m * N + n];
+      }
+    }
+  } else {
+    for (unsigned int idx = 0; idx < size4; idx += 4) {
+      vst1q_f32(&C32[idx], ZEROS);
+    }
+    for (unsigned int idx = size4; idx < size; idx++) {
+      C32[idx] = 0.F;
+    }
+  }
+}
+
+void copy_C32_to_C(float *C32, __fp16 *C, unsigned int M, unsigned int N,
+                   float beta) {
+  const unsigned int N8_low = get_prev_mltpl_of_2p_n(N, 3);
+  for (unsigned int m = 0; m < M; ++m) {
+    for (unsigned int n = 0; n < N8_low; n += 8) {
+      float32x4_t x1 = vld1q_f32(&C32[m * N + n]);
+      float32x4_t x2 = vld1q_f32(&C32[m * N + n + 4]);
+      vst1q_f16(&C[m * N + n],
+                vcombine_f16(vcvt_f16_f32(x1), vcvt_f16_f32(x2)));
+    }
+    for (unsigned int n = N8_low; n < N; ++n) {
+      C[m * N + n] = C32[m * N + n];
+    }
+  }
+}

--- a/nntrainer/tensor/hgemm/hgemm_util.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_util.cpp
@@ -10,6 +10,7 @@
  * @brief  This is for util functions for half-precision GEMM
  */
 
+#include <arm_neon.h>
 #include <cmath>
 #include <hgemm_util.h>
 

--- a/nntrainer/tensor/hgemm/hgemm_util.h
+++ b/nntrainer/tensor/hgemm/hgemm_util.h
@@ -10,6 +10,7 @@
  * @brief  This is for util functions for half-precision GEMM
  */
 
+#include <arm_neon.h>
 #include <assert.h>
 #include <stdlib.h>
 
@@ -19,9 +20,14 @@
  * @param sz amount of data to allocate
  * @return __fp16* addr of allocated memory
  */
-static inline __fp16 *alignedMalloc(int sz) {
-  void *addr = 0;
-  int iRet = posix_memalign(&addr, 64, sz * sizeof(__fp16));
-  assert(0 == iRet);
-  return (__fp16 *)addr;
-}
+__fp16 *alignedMalloc(unsigned int sz);
+
+unsigned int get_next_mltpl_of_n(unsigned int x, unsigned int n);
+
+unsigned int get_prev_mltpl_of_2p_n(unsigned int x, unsigned int n);
+
+void copy_C_to_C32(__fp16 *C, float *C32, unsigned int M, unsigned int N,
+                   float beta = 0.F);
+
+void copy_C32_to_C(float *C32, __fp16 *C, unsigned int M, unsigned int N,
+                   float beta = 0.F);

--- a/nntrainer/tensor/hgemm/hgemm_util.h
+++ b/nntrainer/tensor/hgemm/hgemm_util.h
@@ -10,7 +10,6 @@
  * @brief  This is for util functions for half-precision GEMM
  */
 
-#include <arm_neon.h>
 #include <assert.h>
 #include <stdlib.h>
 
@@ -22,12 +21,45 @@
  */
 __fp16 *alignedMalloc(unsigned int sz);
 
+/**
+ * @brief Get the mltpl of n that is bigger than or equal to x
+ *
+ * @param x unsigned int x
+ * @param n unsigned int n
+ * @return unsigned int
+ */
 unsigned int get_next_mltpl_of_n(unsigned int x, unsigned int n);
 
+/**
+ * @brief Get the mltpl of 2 power of n that is smaller than or equal to x
+ *
+ * @param x unsigned int x
+ * @param n unsigned int n
+ * @return unsigned int
+ */
 unsigned int get_prev_mltpl_of_2p_n(unsigned int x, unsigned int n);
 
+/**
+ * @brief from given output matrix address C, formulate fp32 version of it with
+ * scale factor beta
+ *
+ * @param C __fp16* matrix to be converted
+ * @param C32 float* converted and scaled matrix
+ * @param M row size of matrix
+ * @param N col size of matrix
+ * @param beta scale factor beta
+ */
 void copy_C_to_C32(__fp16 *C, float *C32, unsigned int M, unsigned int N,
                    float beta = 0.F);
 
+/**
+ * @brief from matrix C32, copy to matrix C
+ *
+ * @param C32 float* matrix to be converted
+ * @param C __fp16* converted matrix
+ * @param M row size of matrix
+ * @param N col size of matrix
+ * @param beta scale factor beta
+ */
 void copy_C32_to_C(float *C32, __fp16 *C, unsigned int M, unsigned int N,
                    float beta = 0.F);

--- a/nntrainer/tensor/hgemm/meson.build
+++ b/nntrainer/tensor/hgemm/meson.build
@@ -15,6 +15,7 @@ nntrainer_inc_abs += meson.current_source_dir() / 'hgemm_padding'
 
 hgemm_sources = [
     'hgemm.cpp',
+    'hgemm_util.cpp',
     'hgemm_pack.cpp',
     'hgemm_noTrans.cpp',
     'hgemm_transA.cpp',

--- a/tools/package_android.sh
+++ b/tools/package_android.sh
@@ -17,14 +17,14 @@ if [ ! -d builddir ]; then
     #default value of openblas num threads is 1 for android
     #enable-tflite-interpreter=false is just temporally until ci system is stabel
     #enable-opencl=true will compile OpenCL related changes or remove this option to exclude OpenCL compilations.
-  meson builddir -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Denable-neon=true -Domp-num-threads=1 -Denable-opencl=true
+  meson builddir -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Denable-neon=true -Domp-num-threads=1 -Denable-opencl=true -Dhgemm-experimental-kernel=false
 else
   echo "warning: $TARGET/builddir has already been taken, this script tries to reconfigure and try building"
   pushd builddir
     #default value of openblas num threads is 1 for android
     #enable-tflite-interpreter=false is just temporally until ci system is stabel  
     #enable-opencl=true will compile OpenCL related changes or remove this option to exclude OpenCL compilations.
-    meson configure -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Denable-neon=true -Domp-num-threads=1 -Denable-opencl=true
+    meson configure -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Denable-neon=true -Domp-num-threads=1 -Denable-opencl=true -Dhgemm-experimental-kernel=false
     meson --wipe
   popd
 fi


### PR DESCRIPTION
- According to current paper, accumulating up to 64 ~ 128 w.r.t. K-direction is fine.
- Since conventional error metric, and newly introduced metric (max component relative error) is fine as well, introduce experiemntal kernel that is faster, but less accurate.
- using build option `-Dhgemm-experimental-kernel=true` can enable such kernel when *android build*.
- Performance of this kernel is shown at  #2655 
- Include experimental kernel and exclude the previous one when experimental kernel build -> no newly added `#ifdef`s in file