### PR TITLE
[ Tensor ] Remove CBLAS params from Tensor related files.

### DIFF
--- a/nntrainer/tensor/blas_interface.h
+++ b/nntrainer/tensor/blas_interface.h
@@ -16,21 +16,6 @@
 #define __BLAS_INTERFACE_H_
 #ifdef __cplusplus
 
-#ifdef USE_BLAS
-extern "C" {
-#include <cblas.h>
-}
-#else
-enum CBLAS_ORDER { CblasRowMajor = 101, CblasColMajor = 102 };
-
-enum CBLAS_TRANSPOSE {
-  CblasNoTrans = 111,
-  CblasTrans = 112,
-  CblasConjTrans = 113
-};
-
-#endif
-
 #ifdef USE_CUBLAS
 #include <helper_cuda.h>
 #include <helper_functions.h>
@@ -132,7 +117,7 @@ void saxpy(const unsigned int N, const float alpha, const _FP16 *X,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
+void sgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
            const unsigned int M, const unsigned int N, const unsigned int K,
            const float alpha, const _FP16 *A, const unsigned int lda,
            const _FP16 *B, const unsigned int ldb, const float beta, _FP16 *C,
@@ -147,7 +132,7 @@ void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
+void sgemv(const unsigned int TStorageOrder, bool TransA, const unsigned int M,
            const unsigned int N, const float alpha, const _FP16 *A,
            const unsigned int lda, const _FP16 *X, const int incX,
            const float beta, _FP16 *Y, const int incY);
@@ -346,7 +331,7 @@ void saxpy(const unsigned int N, const float alpha, const float *X,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
+void sgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
            const unsigned int M, const unsigned int N, const unsigned int K,
            const float alpha, const void *A, const unsigned int lda,
            const void *B, const unsigned int ldb, const float beta, void *C,
@@ -363,7 +348,7 @@ void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
+void sgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
            const unsigned int M, const unsigned int N, const unsigned int K,
            const float alpha, const float *A, const unsigned int lda,
            const float *B, const unsigned int ldb, const float beta, float *C,
@@ -378,7 +363,7 @@ void sgemm(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
+void sgemv(const unsigned int TStorageOrder, bool TransA, const unsigned int M,
            const unsigned int N, const float alpha, const void *A,
            const unsigned int lda, const void *X, const int incX,
            const float beta, void *Y, const int incY,
@@ -393,7 +378,7 @@ void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
  * @param[in] alpha float number
  * @param[in] beta float number
  */
-void sgemv(CBLAS_ORDER order, CBLAS_TRANSPOSE TransA, const unsigned int M,
+void sgemv(const unsigned int TStorageOrder, bool TransA, const unsigned int M,
            const unsigned int N, const float alpha, const float *A,
            const unsigned int lda, const float *X, const int incX,
            const float beta, float *Y, const int incY);

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -282,24 +282,24 @@ float dot_cl(const float *vecAdata, const float *vecXdata, unsigned int dim1,
   return cl_ret;
 }
 
-void sgemm_cl(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, const float *A,
-              const float *B, float *C, unsigned int M, unsigned int N,
-              unsigned int K, unsigned int lda, unsigned int ldb,
-              unsigned int ldc, RunLayerContext &context) {
+void sgemm_cl(bool TransA, bool TransB, const float *A, const float *B,
+              float *C, unsigned int M, unsigned int N, unsigned int K,
+              unsigned int lda, unsigned int ldb, unsigned int ldc,
+              RunLayerContext &context) {
 
   opencl::Kernel *kernel_sgemm = nullptr;
   RunLayerContext::LayerKernel layerKernel;
   std::string sgemm_cl_kernel_;
 
-  if (TransA != CblasTrans && TransB != CblasTrans) {
+  if (!TransA && !TransB) {
     kernel_sgemm = &kernel_sgemm_noTrans;
     layerKernel = context.LayerKernel::SGEMM_NOTRANS;
     sgemm_cl_kernel_ = sgemm_cl_noTrans_kernel_;
-  } else if (TransA == CblasTrans && TransB != CblasTrans) {
+  } else if (TransA && !TransB) {
     kernel_sgemm = &kernel_sgemm_transA;
     layerKernel = context.LayerKernel::SGEMM_TRANSA;
     sgemm_cl_kernel_ = sgemm_cl_transA_kernel_;
-  } else if (TransA != CblasTrans && TransB == CblasTrans) {
+  } else if (!TransA && TransB) {
     kernel_sgemm = &kernel_sgemm_transB;
     layerKernel = context.LayerKernel::SGEMM_TRANSB;
     sgemm_cl_kernel_ = sgemm_cl_transB_kernel_;

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -61,8 +61,8 @@ float dot_cl(const float *vecAdata, const float *vecXdata, unsigned int dim1,
 /**
  * @brief     sgemm computation : Y = op(A)*op(B) + C,
  * where op(X) is one of X or X**T
- * @param[in] transA CBLAS_TRANSPOSE
- * @param[in] transB CBLAS_TRANSPOSE
+ * @param[in] transA bool transpose
+ * @param[in] transB bool transpose
  * @param[in] A float * for Matrix A
  * @param[in] B float * for Matrix B
  * @param[in] C float * for Matrix C
@@ -74,10 +74,10 @@ float dot_cl(const float *vecAdata, const float *vecXdata, unsigned int dim1,
  * @param[in] ldc number of C's columns
  * @param[in] context RunLayerContext reference
  */
-void sgemm_cl(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, const float *A,
-              const float *B, float *C, unsigned int M, unsigned int N,
-              unsigned int K, unsigned int lda, unsigned int ldb,
-              unsigned int ldc, RunLayerContext &context);
+void sgemm_cl(bool TransA, bool TransB, const float *A, const float *B,
+              float *C, unsigned int M, unsigned int N, unsigned int K,
+              unsigned int lda, unsigned int ldb, unsigned int ldc,
+              RunLayerContext &context);
 
 /**
  * @brief     addition : sum of all input vectors
@@ -140,8 +140,8 @@ __fp16 dot_cl(const __fp16 *vecAdata, const __fp16 *vecXdata, unsigned int dim1,
 /**
  * @brief     fp16 sgemm computation : Y = op(A)*op(B) + C,
  * where op(X) is one of X or X**T
- * @param[in] transA CBLAS_TRANSPOSE
- * @param[in] transB CBLAS_TRANSPOSE
+ * @param[in] transA bool transpose
+ * @param[in] transB bool transpose
  * @param[in] A fp16 * for Matrix A
  * @param[in] B fp16 * for Matrix B
  * @param[in] C fp16 * for Matrix C
@@ -153,10 +153,10 @@ __fp16 dot_cl(const __fp16 *vecAdata, const __fp16 *vecXdata, unsigned int dim1,
  * @param[in] ldc number of C's columns
  * @param[in] context RunLayerContext reference
  */
-void sgemm_cl(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, const __fp16 *A,
-              const __fp16 *B, __fp16 *C, unsigned int M, unsigned int N,
-              unsigned int K, unsigned int lda, unsigned int ldb,
-              unsigned int ldc, RunLayerContext &context);
+void sgemm_cl(bool TransA, bool TransB, const __fp16 *A, const __fp16 *B,
+              __fp16 *C, unsigned int M, unsigned int N, unsigned int K,
+              unsigned int lda, unsigned int ldb, unsigned int ldc,
+              RunLayerContext &context);
 
 /**
  * @brief     fp16 addition : sum of all input vectors

--- a/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
@@ -302,24 +302,24 @@ __fp16 dot_cl(const __fp16 *vecAdata, const __fp16 *vecXdata, unsigned int dim1,
   return cl_ret;
 }
 
-void sgemm_cl(CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, const __fp16 *A,
-              const __fp16 *B, __fp16 *C, unsigned int M, unsigned int N,
-              unsigned int K, unsigned int lda, unsigned int ldb,
-              unsigned int ldc, RunLayerContext &context) {
+void sgemm_cl(bool TransA, bool TransB, const __fp16 *A, const __fp16 *B,
+              __fp16 *C, unsigned int M, unsigned int N, unsigned int K,
+              unsigned int lda, unsigned int ldb, unsigned int ldc,
+              RunLayerContext &context) {
 
   opencl::Kernel *kernel_sgemm_fp16 = nullptr;
   RunLayerContext::LayerKernel layerKernel;
   std::string sgemm_cl_kernel_fp16_;
 
-  if (TransA != CblasTrans && TransB != CblasTrans) {
+  if (!TransA && !TransB) {
     kernel_sgemm_fp16 = &kernel_sgemm_noTrans_fp16;
     layerKernel = context.LayerKernel::SGEMM_NOTRANS_FP16;
     sgemm_cl_kernel_fp16_ = sgemm_cl_noTrans_kernel_fp16_;
-  } else if (TransA == CblasTrans && TransB != CblasTrans) {
+  } else if (TransA && !TransB) {
     kernel_sgemm_fp16 = &kernel_sgemm_transA_fp16;
     layerKernel = context.LayerKernel::SGEMM_TRANSA_FP16;
     sgemm_cl_kernel_fp16_ = sgemm_cl_transA_kernel_fp16_;
-  } else if (TransA != CblasTrans && TransB == CblasTrans) {
+  } else if (!TransA && TransB) {
     kernel_sgemm_fp16 = &kernel_sgemm_transB_fp16;
     layerKernel = context.LayerKernel::SGEMM_TRANSB_FP16;
     sgemm_cl_kernel_fp16_ = sgemm_cl_transB_kernel_fp16_;


### PR DESCRIPTION
- Remove cblas params from tensor related files since nntrainer is not fully-dependent on cblas anymore.
- Letting tensors to be aware of Cblas related parameters is a nonsense at the first place.
- CBLAS params will be declared only when functions from cblas is called.
- fyi) `TStorageOrder` : Tensor Storage Order

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped