### PR TITLE
[ Application/bugfix ] Remove unnecessary link @open sesame 08/19 4:43

### DIFF
--- a/Applications/Android/NNDetector/app/src/main/jni/Android.mk
+++ b/Applications/Android/NNDetector/app/src/main/jni/Android.mk
@@ -1,5 +1,7 @@
 LOCAL_PATH := $(call my-dir)
 
+$(shell ($(LOCAL_PATH))/prepare_android_deps.sh)
+
 include $(CLEAR_VARS)
 
 # ndk path

--- a/Applications/Android/NNDetector/app/src/main/jni/nntrainer
+++ b/Applications/Android/NNDetector/app/src/main/jni/nntrainer
@@ -1,1 +1,0 @@
-../../../../../../../builddir/android_build_result


### PR DESCRIPTION
- Previous commit left this unnecessary link and this makes newly-implemented features to fail CI test. Remove accordingly.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped