### PR TITLE
[bugfix] Resolve fp16 enabled build error

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -138,7 +138,7 @@ static void sgemv_FP16(const unsigned int TStorageOrder, bool TransA,
   scopy(lenX, X, 1, X_, 1);
   scopy(lenY, Y, 1, Y_, 1);
 
-  sgemv(order, TransA, M, N, alpha, A_, lda, X_, incX, beta, Y_, incY);
+  sgemv(TStorageOrder, TransA, M, N, alpha, A_, lda, X_, incX, beta, Y_, incY);
 
   scopy(lenY, Y_, 1, Y, 1);
 


### PR DESCRIPTION
This PR resolves the build error after #2704 when enable_fp16 is true.

This fixes:
blas_interface.cpp:141:9: error: ‘order’ was not declared in this scope
  141 |   sgemv(order, TransA, M, N, alpha, A_, lda, X_, incX, beta, Y_, incY);
      |         ^~~~~

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [ ]Passed [X]Failed [ ]Skipped