### PR TITLE
[Wait for #2720][CI] Fix meson ubuntu ci build

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -25,11 +25,23 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
     - name: install additional packages for features
       run: sudo apt-get install -y python3-dev python3-numpy python3
+#    - name: add repo
+#      if: ${{matrix.os}} == 'ubuntu-22.04'
+#      run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+    - name: gcc version change
+      run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        sudo apt-get install build-essential
+        sudo apt update
+        sudo apt install -y gcc-13
+        sudo apt install -y g++-13
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1000 
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 1000
+        sudo update-alternatives --set gcc /usr/bin/gcc-13
+    - name: check gcc version
+      run: gcc --version
     - name: install build systems
       run: sudo apt install meson ninja-build
-    - run: meson setup build/
-      env:
-        CC: gcc
     - run: |
         meson \
           --buildtype=plain \

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -25,9 +25,6 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
     - name: install additional packages for features
       run: sudo apt-get install -y python3-dev python3-numpy python3
-#    - name: add repo
-#      if: ${{matrix.os}} == 'ubuntu-22.04'
-#      run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     - name: gcc version change
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
@@ -38,8 +35,6 @@ jobs:
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1000 
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 1000
         sudo update-alternatives --set gcc /usr/bin/gcc-13
-    - name: check gcc version
-      run: gcc --version
     - name: install build systems
       run: sudo apt install meson ninja-build
     - run: |

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -578,6 +578,9 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/acti_func.h
 
 
+%{_includedir}/nntrainer/acti_func.h
+
+
 %files devel-static
 %{_libdir}/libnntrainer*.a
 %exclude %{_libdir}/libcapi*.a


### PR DESCRIPTION
Fix build bug
- Currently, there is a bug in the matrix used in CI where the first Meson build runs successfully but subsequent builds fail due to the presence of a 'build' folder. I would like to fix this issue.
- Before running the Meson build, ensure that any existing folders named 'build' are deleted.

Resolves:
- https://github.com/nnstreamer/nntrainer/issues/2715

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Donghak PARK <donghak.park@samsung.com>
Co-authored-by: hyeonseok <hs89.lee@samsung.com>
Co-authored-by: Donghyeon Jeong <dhyeon.jeong@samsung.com>