### PR TITLE
[ blas/bugfix ] Fix irrelevant function call

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -343,7 +343,8 @@ static void sgemm_FP16(const unsigned int TStorageOrder, bool TransA,
   scopy(M * K, A, 1, A_, 1);
   scopy(N * K, B, 1, B_, 1);
   scopy(M * N, C, 1, C_, 1);
-  sgemm(order, transA, transB, M, N, K, alpha, A_, lda, B_, ldb, beta, C_, ldc);
+  cblas_sgemm(order, transA, transB, M, N, K, alpha, A_, lda, B_, ldb, beta, C_,
+              ldc);
   scopy(M * N, C_, 1, C, 1);
 
   delete[] A_;


### PR DESCRIPTION
- Since current function implementations are not using CBLAS params, should directly call function from cblas.h

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped