### PR TITLE
[Tizen7.0] PR to support Tizen7.0

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -131,6 +131,8 @@ public:
    */
   virtual const std::string getType() const = 0;
 
+  virtual void initialize() = 0;
+
   /**
    * @brief     Default allowed properties
    * - input shape : string

--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -131,6 +131,9 @@ public:
    */
   virtual const std::string getType() const = 0;
 
+  /**
+   * @brief Initialize layer
+   */
   virtual void initialize() = 0;
 
   /**

--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -24,6 +24,7 @@
 /usr/include/nntrainer/layer_context.h
 /usr/include/nntrainer/layer_devel.h
 /usr/include/nntrainer/layer_impl.h
+/usr/include/nntrainer/acti_func.h
 # custom layer kits
 /usr/include/nntrainer/app_context.h
 # logger

--- a/meson.build
+++ b/meson.build
@@ -88,6 +88,7 @@ if get_option('enable-fp16')
      # comaptible with armv8.0 machines.
      if cxx.has_argument('-mfp16-format=ieee')
        add_project_arguments('-mfp16-format=ieee', language: ['c', 'cpp'])
+       add_project_arguments('-march=armv8.2-a+fp16', language: ['c', 'cpp'])
      else
        message ('The compiler does not support -mfp16-format=ieee. However, according to https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/Half-Precision.html, gcc may use IEEE fp16 anyway. Thus, we will proceed without the option for FP16 support.')
      endif

--- a/nnstreamer/meson.build
+++ b/nnstreamer/meson.build
@@ -3,5 +3,5 @@ if get_option('enable-nnstreamer-tensor-filter').enabled()
   subdir('tensor_filter')
 endif
 if get_option('enable-nnstreamer-tensor-trainer').enabled()
-#  subdir('tensor_trainer')
+ subdir('tensor_trainer')
 endif

--- a/nnstreamer/meson.build
+++ b/nnstreamer/meson.build
@@ -3,5 +3,5 @@ if get_option('enable-nnstreamer-tensor-filter').enabled()
   subdir('tensor_filter')
 endif
 if get_option('enable-nnstreamer-tensor-trainer').enabled()
-  subdir('tensor_trainer')
+#  subdir('tensor_trainer')
 endif

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -541,9 +541,10 @@ bool RunLayerContext::validate(bool skip_input, bool skip_label) {
         } else if (val->getVariableRef().getTensorType().data_type ==
                    TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-          tensor_map[val->getName()] = val->getVariableRef().getData<_FP16>();
+          tensor_map[val->getName()] =
+            val->getVariableRef().template getData<_FP16>();
           tensor_map[val->getGradientName()] =
-            val->getGradientRef().getData<_FP16>();
+            val->getGradientRef().template getData<_FP16>();
 #else
           throw std::invalid_argument("Error: enable-fp16 is not enabled");
 #endif

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -438,9 +438,6 @@ public:
       d.setDataType(o_t);
       w = Tensor(d, true);
     }
-    unsigned int o_ax = getWeightObject(idx).getOutputAxis();
-
-    // t_w.dequantize(w, o_ax);
 
     return;
   }

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -160,6 +160,8 @@ public:
    */
   virtual void finalize(InitLayerContext &context) = 0;
 
+  virtual void initialize(RunLayerContext &context){};
+
   /**
    * @brief     Forward Propagation of a layer
    * @param     context Context of the layer

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -160,6 +160,9 @@ public:
    */
   virtual void finalize(InitLayerContext &context) = 0;
 
+  /**
+   * @brief    Initialize the layer
+   */
   virtual void initialize(RunLayerContext &context){};
 
   /**

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -273,6 +273,8 @@ public:
    */
   InitLayerContext refinalize(const std::vector<TensorDim> &input_dims = {});
 
+  void initialize() override { layer->initialize(*run_context); }
+
   /**
    * @brief     Forward Propagation of a layer
    * @param     training true if training, false if inference

--- a/nntrainer/layers/meson.build
+++ b/nntrainer/layers/meson.build
@@ -51,6 +51,7 @@ layer_headers = [
   'layer_context.h',
   'layer_devel.h',
   'layer_impl.h',
+  'acti_func.h',
   'common_properties.h',
 ]
 

--- a/nntrainer/tensor/hgemm/hgemm_pack.cpp
+++ b/nntrainer/tensor/hgemm/hgemm_pack.cpp
@@ -367,10 +367,10 @@ void packing_B8(unsigned int K, unsigned int N, const __fp16 *src,
                 unsigned int ldb, const __fp16 *dst) {
   assert(K != 0 && N != 0 && N % 8 == 0);
 
-  for (int i = 0; i < K; i++) {
+  for (unsigned int i = 0; i < K; i++) {
     const __fp16 *a_off = src + i * ldb;
     __fp16 *b_off = (__fp16 *)dst + i * 8;
-    for (int j = 0; j < N; j += 8) {
+    for (unsigned int j = 0; j < N; j += 8) {
       float16x8_t v = vld1q_f16(a_off);
       a_off += 8;
 
@@ -384,10 +384,10 @@ void packing_B16(unsigned int K, unsigned int N, const __fp16 *src,
                  unsigned int ldb, const __fp16 *dst) {
   assert(K != 0 && N != 0 && N % 16 == 0);
 
-  for (int i = 0; i < K; i++) {
+  for (unsigned int i = 0; i < K; i++) {
     const __fp16 *a_off = src + i * ldb;
     __fp16 *b_off = (__fp16 *)dst + i * 16;
-    for (int j = 0; j < N; j += 16) {
+    for (unsigned int j = 0; j < N; j += 16) {
       float16x8_t v0_7 = vld1q_f16(a_off);
       float16x8_t v8_15 = vld1q_f16(a_off + 8);
       a_off += 16;

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -393,6 +393,11 @@ export CFLAGS+=" -fprofile-arcs -ftest-coverage"
 export CXXFLAGS+=" -fprofile-arcs -ftest-coverage"
 %endif
 
+%if 0%{?enable_fp16}
+export CFLAGS+=" -march=armv8.2-a+fp16"
+export CXXFLAGS+=" -march=armv8.2-a+fp16"
+%endif
+
 # Add backward competibility for tizen < 6
 %if 0%{tizen_version_major} < 6
 ln -sf %{_includedir}/nnstreamer/nnstreamer.h %{_includedir}/nnstreamer/ml-api-common.h

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -131,13 +131,13 @@ BuildRequires: tensorflow2-lite-devel
 BuildRequires: tensorflow2-lite-devel
 %endif # support_tflite_interpreter
 
-%define enable_nnstreamer_tensor_filter -Denable-nnstreamer-tensor-filter=false
-%define enable_nnstreamer_tensor_trainer -Denable-nnstreamer-tensor-trainer=false
+%define enable_nnstreamer_tensor_filter -Denable-nnstreamer-tensor-filter=disabled
+%define enable_nnstreamer_tensor_trainer -Denable-nnstreamer-tensor-trainer=disabled
 
 %if  0%{?nnstreamer_filter}
 Requires:	nnstreamer-nntrainer = %{version}-%{release}
 BuildRequires:	nnstreamer-devel
-%define enable_nnstreamer_tensor_filter -Denable-nnstreamer-tensor-filter=true
+%define enable_nnstreamer_tensor_filter -Denable-nnstreamer-tensor-filter=enabled
 
 %if 0%{?unit_test}
 %if 0%{tizen_version_major}%{tizen_version_minor} > 60
@@ -151,7 +151,7 @@ BuildRequires:	python
 %if  0%{?nnstreamer_trainer}
 Requires:	nnstreamer-nntrainer = %{version}-%{release}
 BuildRequires:	nnstreamer-devel
-%define enable_nnstreamer_tensor_trainer -Denable-nnstreamer-tensor-trainer=true
+%define enable_nnstreamer_tensor_trainer -Denable-nnstreamer-tensor-trainer=enabled
 %endif # nnstreamer_trainer
 %endif # tizen
 
@@ -413,8 +413,8 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} \
       %{enable_profile} %{enable_nnstreamer_backbone} %{enable_tflite_backbone} \
       %{enable_tflite_interpreter} %{capi_ml_pkg_dep_resolution} \
       %{enable_reduce_tolerance} %{configure_subplugin_install_path} %{enable_debug} \
-      -Dml-api-support=enabled -Denable-nnstreamer-tensor-filter=enabled \
-      -Denable-nnstreamer-tensor-trainer=enabled -Denable-capi=enabled \
+      -Dml-api-support=enabled \
+      -Denable-capi=enabled \
       %{fp16_support} %{neon_support} build
 
 ninja -C build %{?_smp_mflags}
@@ -565,9 +565,18 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/util_func.h
 %{_includedir}/nntrainer/fp16.h
 %{_includedir}/nntrainer/util_simd.h
+# In the current version, Neon SIMD is enabled only when FP16 is enabled with AArch64. 
+# This may be subject to change in future versions.
+%ifarch aarch64
 %if 0%{?enable_fp16}
 %{_includedir}/nntrainer/util_simd_neon.h
+%{_includedir}/nntrainer/blas_neon.h
+%{_includedir}/nntrainer/hgemm.h
+%{_includedir}/nntrainer/hgemm_util.h
 %endif
+%endif
+%{_includedir}/nntrainer/acti_func.h
+
 
 %files devel-static
 %{_libdir}/libnntrainer*.a

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -1,7 +1,7 @@
 # Execute gbs with --define "testcoverage 1" in case that you must get unittest coverage statistics
 %define         use_cblas 1
 %define         nnstreamer_filter 1
-%define         nnstreamer_trainer 1
+%define         nnstreamer_trainer 0
 %define         nnstreamer_subplugin_path /usr/lib/nnstreamer
 %define         use_gym 0
 %define         support_ccapi 1


### PR DESCRIPTION
This pull request includes the following commits to backport NNTrainer for Tizen 7.0:
- Commit related to fp16 enablement is included: 9328d1f898953d08d5e2f48c3c9f500b1ad3fdee
- Commit for layer initialization is included : 4d7a8c4b9bfc998a71df94aec2b2a856aba71478
- Commit to disable nnstreamer nntrainer is included : 450000572e8a7e993d36f06e0413c2ae4abc2e5a
- Commit to support Tizen7.0 is included : 96bb3df9726e3975710817a82c2889f1c26b4484

This PR is tested with AuXFT example on QRB4210 board (w/ Tizen 7.0).

----
**Self evaluation:**

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped