### PR TITLE
[ Tizen7.0 ] Adding `neuralnet.h` into dev header.

### DIFF
--- a/Applications/LoRA/jni/main.cpp
+++ b/Applications/LoRA/jni/main.cpp
@@ -1,0 +1,92 @@
+#include <cifar_dataloader.h>
+#include <layer.h>
+#include <model.h>
+#include <optimizer.h>
+
+const int number_of_db = 10;
+const int batch_size = 10;
+const int epochs = 2;
+const float learning_rate = 0.001;
+
+const int input_dim = 5;
+const int unit_dim1 = 10;
+const int unit_dim2 = 5;
+const int rank = 3;
+const float scaling = 2.0 / rank;
+const int alpha = 2;
+
+/** create test model */
+std::unique_ptr<ml::train::Model> create_model() {
+  std::unique_ptr<ml::train::Model> model =
+    ml::train::createModel(ml::train::ModelType::NEURAL_NET, {"loss=mse"});
+
+  model->addLayer(ml::train::createLayer(
+    "input", {"name=input", "input_shape=1:1:" + std::to_string(input_dim)}));
+
+  model->addLayer(ml::train::createLayer(
+    "fully_connected",
+    {"input_layers=input",
+     "name=fc0",
+     "unit=" + std::to_string(unit_dim1), "lora_rank=" + std::to_string(rank),
+     "lora_alpha=" + std::to_string(alpha), "disable_bias=true"}));
+  model->addLayer(ml::train::createLayer(
+    "fully_connected",
+    {"input_layers=fc0",
+     "name=fc1",
+     "unit=" + std::to_string(unit_dim2), "lora_rank=" + std::to_string(rank),
+     "lora_alpha=" + std::to_string(alpha), "disable_bias=true"}));
+
+  return model;
+}
+
+/** test dataset input */
+std::unique_ptr<nntrainer::util::DataLoader> getRandomDataGenerator() {
+  std::unique_ptr<nntrainer::util::DataLoader> random_db(
+    new nntrainer::util::RandomDataLoader(
+      {{batch_size, 1, 1, input_dim}}, {{batch_size, 1, 1, 1}}, number_of_db));
+  return random_db;
+}
+
+/** test dataset generator */
+std::unique_ptr<nntrainer::util::DataLoader> getTestDataGenerator() {
+  std::unique_ptr<nntrainer::util::DataLoader> test_db(
+    new nntrainer::util::OnesTestDataLoader(
+      {{batch_size, 1, 1, input_dim}}, {{batch_size, 1, 1, 10}}, number_of_db));
+  return test_db;
+}
+
+/** dataset callback */
+int dataset_cb(float **input, float **label, bool *last, void *user_data) {
+  auto data = reinterpret_cast<nntrainer::util::DataLoader *>(user_data);
+
+  data->next(input, label, last);
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+
+  /** a single fc layer with LoRA */
+  auto model = create_model();
+
+  model->setProperty({"batch_size=" + std::to_string(batch_size),
+                      "epochs=" + std::to_string(epochs),
+                      "save_path=my_app.bin"});
+
+  auto optimizer = ml::train::createOptimizer(
+    "SGD", {"learning_rate=" + std::to_string(learning_rate)});
+  model->setOptimizer(std::move(optimizer));
+
+  int status = model->compile();
+  status = model->initialize();
+
+  // auto random_generator = getRandomDataGenerator();
+  auto testdata_generator = getTestDataGenerator();
+  auto train_dataset = ml::train::createDataset(
+    ml::train::DatasetType::GENERATOR, dataset_cb, testdata_generator.get());
+
+  model->setDataset(ml::train::DatasetModeType::MODE_TRAIN,
+                    std::move(train_dataset));
+  model->train();
+
+  return status;
+}

--- a/Applications/LoRA/jni/meson.build
+++ b/Applications/LoRA/jni/meson.build
@@ -1,0 +1,9 @@
+lora_sources = [ 'main.cpp', cifar_path / 'cifar_dataloader.cpp' ]
+
+  lora_dependencies = [ app_utils_dep, nntrainer_ccapi_dep ]
+
+  e = executable('nntrainer_lora', lora_sources, include_directories
+                 : [ include_directories('.'), cifar_include_dir ], dependencies
+                 : lora_dependencies, install
+                 : get_option('install-app'), install_dir
+                 : application_install_dir)

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -26,3 +26,4 @@ if get_option('enable-tflite-backbone')
   subdir('SimpleShot')
 endif
 subdir('PicoGPT/jni')
+subdir('LoRA/jni')

--- a/Applications/utils/datagen/cifar/cifar_dataloader.h
+++ b/Applications/utils/datagen/cifar/cifar_dataloader.h
@@ -121,4 +121,33 @@ private:
   std::vector<unsigned int> idxes; /**< index information for one epoch */
 };
 
+/**
+ * OnesTestDataLoader is a data loader for function testing, generating
+ * ones data for input and zeros for label.
+ */
+class OnesTestDataLoader : public DataLoader {
+
+public:
+  OnesTestDataLoader(const std::vector<TensorDim> &input_shapes,
+                     const std::vector<TensorDim> &output_shapes,
+                     int data_size_);
+
+  /**
+   * @brief Destroy the Random Data Loader object
+   */
+  ~OnesTestDataLoader() {}
+
+  /**
+   * @copydoc void DataLoader::next(float **input, float**label, bool *last)
+   */
+  void next(float **input, float **label, bool *last);
+
+private:
+  unsigned int iteration;
+  unsigned int data_size;
+
+  std::vector<TensorDim> input_shapes;
+  std::vector<TensorDim> output_shapes;
+};
+
 } // namespace nntrainer::util

--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -42,3 +42,5 @@
 /usr/include/nntrainer/util_func.h
 /usr/include/nntrainer/fp16.h
 /usr/include/nntrainer/util_simd.h
+# model
+/usr/include/nntrainer/neuralnet.h

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -91,11 +91,14 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
   /** set weight specifications */
   // @todo : This NCHW format setting is just temporal, it needs to be set by
   // global configuration
+
+  /** Bias Dimension : (1, 1, 1, unit) */
   TensorDim bias_dim(
     1, is_nchw ? 1 : unit, 1, is_nchw ? unit : 1,
     TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
     is_nchw ? 0b0001 : 0b0100);
 
+  /** Weight Dimension : (1, 1, in_dim.width(), unit)*/
   TensorDim weight_dim(
     1, is_nchw ? 1 : unit, is_nchw ? in_dim.width() : 1,
     is_nchw ? unit : in_dim.channel(),
@@ -115,25 +118,33 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
   /** create weights for LoRA */
   if (lora_rank) {
 
-    /** loraA : (in_dim.width, lora_rank) */
+    /** loraA Dimension : (1, 1, in_dim.width, lora_rank) */
     TensorDim loraA_dim(
       1, is_nchw ? 1 : lora_rank, is_nchw ? in_dim.width() : 1,
       is_nchw ? lora_rank : in_dim.channel(),
       TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
       is_nchw ? 0b0011 : 0b0101);
 
-    /** loraB: (lora_rank, out_dim) */
+    /** loraB Dimension : (1, 1, lora_rank, unit) */
     TensorDim loraB_dim(
       1, is_nchw ? 1 : unit, is_nchw ? lora_rank : 1,
       is_nchw ? unit : lora_rank,
       TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
       is_nchw ? 0b0011 : 0b0101);
 
-    /** loraTmp: (1, lora_rank) */
+    /** loraTmp Dimension : (B, 1, in_dim.height(), lora_rank) */
     TensorDim loraTmp_dim(
-      1, is_nchw ? 1 : lora_rank, 1, is_nchw ? lora_rank : 1,
+      in_dim.batch(), is_nchw ? 1 : lora_rank, is_nchw ? in_dim.height() : 1,
+      is_nchw ? lora_rank : in_dim.width(),
       TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
-      is_nchw ? 0b0001 : 0b0100);
+      is_nchw ? 0b1011 : 0b1101);
+
+    /** loraTmp Dimension : (B, 1, in_dim.height(), unit) */
+    TensorDim loraOut_dim(
+      in_dim.batch(), is_nchw ? 1 : unit, is_nchw ? in_dim.height() : 1,
+      is_nchw ? unit : in_dim.width(),
+      TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
+      is_nchw ? 0b1011 : 0b1101);
 
     lora_idx[LORAParams::loraA] = context.requestWeight(
       loraA_dim, Initializer::ZEROS, weight_regularizer,
@@ -148,7 +159,7 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
                             true, TensorLifespan::FORWARD_DERIV_LIFESPAN);
 
     lora_idx[LORAParams::loraOut] =
-      context.requestTensor(bias_dim, "hidden_lora", Initializer::NONE, true,
+      context.requestTensor(loraOut_dim, "hidden_lora", Initializer::NONE, true,
                             TensorLifespan::FORWARD_FUNC_LIFESPAN);
   }
 }
@@ -162,6 +173,15 @@ void FullyConnectedLayer::exportTo(
 void FullyConnectedLayer::setProperty(const std::vector<std::string> &values) {
   auto remain_props = loadProperties(values, fc_props);
   LayerImpl::setProperty(remain_props);
+}
+
+void FullyConnectedLayer::setBatch(nntrainer::RunLayerContext &context,
+                                   unsigned int batch) {
+  if (!std::get<props::LoraRank>(fc_props).empty()) {
+    // update Lora Tensor's batch info.
+    context.updateTensor(lora_idx[LORAParams::loraTmp], batch);
+    context.updateTensor(lora_idx[LORAParams::loraOut], batch);
+  }
 }
 
 void FullyConnectedLayer::forwarding(RunLayerContext &context, bool training) {

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -103,6 +103,12 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
+  /**
+   * @copydoc Layer::setBatch(RunLayerContext &context, unsigned int batch)
+   */
+  void setBatch(nntrainer::RunLayerContext &context,
+                unsigned int batch) override;
+
   inline static const std::string type = "fully_connected";
 
 private:

--- a/nntrainer/models/meson.build
+++ b/nntrainer/models/meson.build
@@ -5,7 +5,9 @@ model_sources = [
   'dynamic_training_optimization.cpp',
 ]
 
-model_headers = []
+model_headers = [
+  'neuralnet.h'
+]
 
 foreach s : model_sources
   nntrainer_sources += meson.current_source_dir() / s

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -576,6 +576,8 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %endif
 %endif
 %{_includedir}/nntrainer/acti_func.h
+# model headers
+%{_includedir}/nntrainer/neuralnet.h
 
 
 %files devel-static


### PR DESCRIPTION
Some applications, e.g. Reinforcement Learning example,  are directly using `forwarding` and `backwarding` in the main function. Thus, this PR includes the `neuralnet.h` in dev pacakge to support them.

- Update  `nntrainer-dev.install`
- Update `nntrainer.spec`
- Update `model/meson.build`

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped
