### PR TITLE
[ Tizen7.0 ] Include `neuralnet.h` in -dev header

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -42,3 +42,5 @@
 /usr/include/nntrainer/util_func.h
 /usr/include/nntrainer/fp16.h
 /usr/include/nntrainer/util_simd.h
+# model
+/usr/include/nntrainer/neuralnet.h

--- a/nntrainer/models/meson.build
+++ b/nntrainer/models/meson.build
@@ -5,7 +5,9 @@ model_sources = [
   'dynamic_training_optimization.cpp',
 ]
 
-model_headers = []
+model_headers = [
+  'neuralnet.h'
+]
 
 foreach s : model_sources
   nntrainer_sources += meson.current_source_dir() / s

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -576,6 +576,8 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %endif
 %endif
 %{_includedir}/nntrainer/acti_func.h
+# model headers
+%{_includedir}/nntrainer/neuralnet.h
 
 
 %files devel-static


### PR DESCRIPTION
- Update the code to include `neuralnet.h` in -dev header.
- Some applications, e.g., ReinforcementLearning uses `forwarding` and `backwarding` directly. To support it, this commit adds the header into dev package.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped