### PR TITLE
[ Tizen7.0 ] Include some headers in -dev header for neuralnet.h

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -44,3 +44,24 @@
 /usr/include/nntrainer/util_simd.h
 # model
 /usr/include/nntrainer/neuralnet.h
+## neuralnet.h : forwarding() / backwarding() support
+/usr/include/nntrainer/compiler_fwd.h 
+/usr/include/nntrainer/dynamic_training_optimization.h
+/usr/include/nntrainer/layer_node.h
+/usr/include/nntrainer/graph_node.h
+/usr/include/nntrainer/model_common_properties.h
+/usr/include/nntrainer/network_graph.h
+/usr/include/nntrainer/graph_core.h
+/usr/include/nntrainer/graph_node.h
+/usr/include/nntrainer/manager.h
+/usr/include/nntrainer/basic_planner.h
+/usr/include/nntrainer/memory_planner.h
+/usr/include/nntrainer/tensor_pool.h
+/usr/include/nntrainer/cache_loader.h
+/usr/include/nntrainer/task.h
+/usr/include/nntrainer/task_executor.h
+/usr/include/nntrainer/cache_pool.h
+/usr/include/nntrainer/cache_elem.h
+/usr/include/nntrainer/memory_pool.h
+/usr/include/nntrainer/swap_device.h
+/usr/include/nntrainer/optimizer_wrapped.h

--- a/nntrainer/compiler/meson.build
+++ b/nntrainer/compiler/meson.build
@@ -12,7 +12,9 @@ compiler_sources = [
   'loss_realizer.cpp',
 ]
 
-compiler_headers = []
+compiler_headers = [
+  'compiler_fwd.h'
+]
 
 if get_option('enable-tflite-interpreter')
   if not tflite_dep.found()

--- a/nntrainer/graph/meson.build
+++ b/nntrainer/graph/meson.build
@@ -4,7 +4,13 @@ graph_sources = [
   'connection.cpp'
 ]
 
-graph_headers = ['connection.h']
+graph_headers = [
+  'connection.h',
+  'graph_node.h',
+  'network_graph.h',
+  'graph_core.h',
+  'graph_node.h',
+]
 
 foreach s : graph_sources
   nntrainer_sources += meson.current_source_dir() / s

--- a/nntrainer/layers/meson.build
+++ b/nntrainer/layers/meson.build
@@ -53,6 +53,7 @@ layer_headers = [
   'layer_impl.h',
   'acti_func.h',
   'common_properties.h',
+  'layer_node.h',
 ]
 
 layer_deps = []

--- a/nntrainer/models/meson.build
+++ b/nntrainer/models/meson.build
@@ -6,7 +6,9 @@ model_sources = [
 ]
 
 model_headers = [
-  'neuralnet.h'
+  'neuralnet.h',
+  'dynamic_training_optimization.h',
+  'model_common_properties.h',
 ]
 
 foreach s : model_sources

--- a/nntrainer/optimizers/meson.build
+++ b/nntrainer/optimizers/meson.build
@@ -12,7 +12,8 @@ optimizer_sources = [
 optimizer_headers = [
   'optimizer_devel.h',
   'optimizer_context.h',
-  'lr_scheduler.h'
+  'lr_scheduler.h',
+  'optimizer_wrapped.h'
 ]
 
 foreach s : optimizer_sources

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -33,7 +33,18 @@ tensor_headers = [
   'weight.h',
   'var_grad.h',    
   'tensor_wrap_specs.h',
-  'blas_interface.h'
+  'blas_interface.h',
+  'manager.h',
+  'basic_planner.h',
+  'memory_planner.h',
+  'tensor_pool.h',
+  'cache_loader.h',
+  'task_executor.h',
+  'cache_pool.h',
+  'cache_elem.h',
+  'memory_pool.h',
+  'swap_device.h',
+  'task.h'
 ]
 
 arch = host_machine.cpu_family()

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -578,9 +578,27 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/acti_func.h
 # model headers
 %{_includedir}/nntrainer/neuralnet.h
-
-
-%{_includedir}/nntrainer/acti_func.h
+## neuralnet.h
+%{_includedir}/nntrainer/compiler_fwd.h 
+%{_includedir}/nntrainer/dynamic_training_optimization.h
+%{_includedir}/nntrainer/layer_node.h
+%{_includedir}/nntrainer/graph_node.h
+%{_includedir}/nntrainer/model_common_properties.h
+%{_includedir}/nntrainer/network_graph.h
+%{_includedir}/nntrainer/graph_core.h
+%{_includedir}/nntrainer/graph_node.h
+%{_includedir}/nntrainer/manager.h
+%{_includedir}/nntrainer/basic_planner.h
+%{_includedir}/nntrainer/memory_planner.h
+%{_includedir}/nntrainer/tensor_pool.h
+%{_includedir}/nntrainer/cache_loader.h
+%{_includedir}/nntrainer/task.h
+%{_includedir}/nntrainer/task_executor.h
+%{_includedir}/nntrainer/cache_pool.h
+%{_includedir}/nntrainer/cache_elem.h
+%{_includedir}/nntrainer/memory_pool.h
+%{_includedir}/nntrainer/swap_device.h
+%{_includedir}/nntrainer/optimizer_wrapped.h
 
 
 %files devel-static


### PR DESCRIPTION
- In the previous PR (77e56f1), `neuralnet.h` was included in dev package.
- However, some headers were missing used in `nueralnet.h`
- This PR adds headers which have dependencies with `neuralnet.h`
- This version is tested; It supports ReinforcementLearning example app on Tizen7.0

Here is the list of headers, included in `neuralnet.h`

- compiler_fwd.h
- dynamic_training_optimization.h
- layer_node.h
    - graph_node.h
- model_common_properties.h
- network_graph.h
    - graph_core.h
        - graph_node.h
    - manager.h
        - basic_planner.h
            - memory_planner.h
        - tensor_pool.h
            - cache_loader.h
                - task_executor.h
            - cache_pool.h
                - cache_elem.h
                - memory_pool.h
                - swap_device.h
    - optimizer_wrapped.h


Self evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped