### PR TITLE
[Wait for #2803][Mixed Precision] Fix gradient clipping logic @open sesame 12/02 09:37

### DIFF
--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -508,7 +508,7 @@ private:
     lazy_weights; /**< weights with delayed grad update, e.g., gradient
                      clipping, loss scaling */
   bool is_clip_grad;
-
+  float loss_scale;
   unsigned int nan_count;
 
   /**


### PR DESCRIPTION
 [Mixed Precision] Fix gradient clipping logic
    
update mixed precision - gradient clipping logic
- when gradient clipping, gradient should unscale before calc l2norm

Resolves:
- #2746 

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Donghak PARK <donghak.park@samsung.com>
