### PR TITLE
[ GPU ] fix return by reference to return by value

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -153,7 +153,7 @@ void ClContext::initBlasClKernels() {
   blas_kernels_initialized = true;
 }
 
-const ClContext::SharedPtrClKernel &
+const ClContext::SharedPtrClKernel
 ClContext::registerClKernel(std::string kernel_string,
                             std::string kernel_name) {
   // check if created before

--- a/nntrainer/cl_context.h
+++ b/nntrainer/cl_context.h
@@ -201,10 +201,10 @@ public:
    * @brief register or return already present OpenCl kernel pointer
    * @param kernel_string kernel implementation string
    * @param kernel_name kernel name
-   * @return reference of std::shared_ptr<opencl::Kernel>
+   * @return std::shared_ptr<opencl::Kernel>
    */
-  const SharedPtrClKernel &registerClKernel(std::string kernel_string,
-                                            std::string kernel_name);
+  const SharedPtrClKernel registerClKernel(std::string kernel_string,
+                                           std::string kernel_name);
 
   /**
    * @brief Initialize and register all blas OpenCl kernels


### PR DESCRIPTION
- In the previous code, `registerClKernel` function returned reference of `SharedPtrClKernel`, causing the possible two problems: 
	- returning by reference cannot return nullptr, leading an error in line 170 of `cl_context.cpp`
	- returning by reference of `shared_ptr` may not increase the reference counter, leading to early free problem.