### PR TITLE
Fix for compiling with testcoverage

### DIFF
--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -495,10 +495,11 @@ lcov -t 'NNTrainer Unit Test Coverage' -o unittest.info -c -d . -b %{_builddir}/
     --exclude "*/tensorflow*" \
     --exclude "*/Applications/*" \
     --exclude "*/test/*" \
-    --exclude "*/meson*/*" \
     --exclude "*/nntrainer_logger.cpp" \
     --exclude "*/tf_schema_generated.h" \
     --exclude "*/nnstreamer_layer.*"
+
+#    --exclude "*/meson*/*" \
 # nnstreamer layer is untestable here
 
 # Visualize the report


### PR DESCRIPTION
In order to generate test coverage rerport with gcov, option needs to be fixed.

- remove meson exclude option

Resolves:

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped