### PR TITLE
[GPU/OpenCL] Broadcasting support added for GPU Addition kernel.

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -37,9 +37,9 @@ static void add_default_object(ClContext &cc) {
                      FullyConnectedLayerCl::type,
                      ml::train::LayerType::LAYER_FC);
 
-  // cc.registerFactory(nntrainer::createLayer<AdditionLayerCL>,
-  //                    AdditionLayerCL::type,
-  //                    ml::train::LayerType::LAYER_ADDITION);
+  cc.registerFactory(nntrainer::createLayer<AdditionLayerCL>,
+                     AdditionLayerCL::type,
+                     ml::train::LayerType::LAYER_ADDITION);
 
   cc.registerFactory(nntrainer::createLayer<SwiGLULayerCl>, SwiGLULayerCl::type,
                      ml::train::LayerType::LAYER_SWIGLU);

--- a/nntrainer/layers/cl_layers/addition_layer_cl.cpp
+++ b/nntrainer/layers/cl_layers/addition_layer_cl.cpp
@@ -37,7 +37,7 @@ void AdditionLayerCL::forwarding(RunLayerContext &context, bool training) {
     if (!idx) {
       hidden_.copy(input_);
     } else {
-      add_i_cl(input_, hidden_, context);
+      add_i_cl(hidden_, input_);
     }
   }
 }
@@ -77,7 +77,7 @@ void AdditionLayerCL::incremental_forwarding(RunLayerContext &context,
       if (!idx) {
         hidden_step.copy(input_step);
       } else {
-        add_i_cl(input_step, hidden_step, context);
+        add_i_cl(hidden_step, input_step);
       }
     }
   }

--- a/nntrainer/layers/cl_layers/addition_layer_cl.h
+++ b/nntrainer/layers/cl_layers/addition_layer_cl.h
@@ -15,6 +15,7 @@
 #define __ADDITION_LAYER_CL_H__
 #ifdef __cplusplus
 
+#include <cl_context.h>
 #include <common_properties.h>
 #include <layer_devel.h>
 

--- a/nntrainer/layers/cl_layers/meson.build
+++ b/nntrainer/layers/cl_layers/meson.build
@@ -1,6 +1,6 @@
 cl_layer_sources = [
-    'fc_layer_cl.cpp',
-  # 'addition_layer_cl.cpp',
+   'fc_layer_cl.cpp',
+   'addition_layer_cl.cpp',
    'swiglu_cl.cpp',
    'reshape_cl.cpp',
    'rmsnorm_layer_cl.cpp',

--- a/nntrainer/tensor/cl_operations/blas_kernel_interface.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_interface.h
@@ -64,11 +64,10 @@ void multiplyCl(Tensor &input, float const &value);
 
 /**
  * @brief Process data and dimensions for add operation
- * @param[in] input Tensor
  * @param[in] result Tensor
- * @param[in] RunLayerContext reference
+ * @param[in] input Tensor
  */
-void add_i_cl(Tensor const &input, Tensor &result);
+void add_i_cl(Tensor &result, Tensor const &input);
 
 /**
  * @brief Process data and dimensions for transpose operation

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.h
@@ -118,11 +118,11 @@ static const std::string sgemm_cl_transAB_kernel_ =
     })";
 
 static const std::string addition_cl_kernel_ =
-  R"(__kernel void addition_cl(__global const float* input, __global float* output, const unsigned int size) {
+  R"(__kernel void addition_cl(const __global float* input, __global float* output, unsigned int size_input, unsigned int size_res) {
     #pragma printf_support
     size_t idx = get_global_id(0);
-    if (idx < size) {
-        output[idx] = output[idx] + input[idx];
+    if (idx < size_res) {
+        output[idx] = output[idx] + input[idx % size_input];
     }
   })";
 
@@ -324,10 +324,10 @@ static const std::string addition_cl_kernel_fp16_ =
   R"(
     #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-    __kernel void addition_cl_fp16(__global const half* input, __global half* output, const unsigned int size) {
+    __kernel void addition_cl_fp16(const __global half* input, __global half* output, unsigned int size_input, unsigned int size_res) {
     size_t idx = get_global_id(0);
-    if (idx < size) {
-        output[idx] = output[idx] + input[idx];
+    if (idx < size_res) {
+        output[idx] = output[idx] + input[idx % size_input];
     }
   })";
 

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -73,10 +73,11 @@ void sgemm_cl(bool TransA, bool TransB, const float *A, const float *B,
  * @brief     addition : sum of all input vectors
  * @param[in] input float * for input
  * @param[in] res float * for result/output
- * @param[in] size number of elements in input vector
- * @param[in] context RunLayerContext reference
+ * @param[in] size_input number of elements in input vector
+ * @param[in] size_res number of elements in result vector
  */
-void addition_cl(const float *input, float *res, unsigned int size);
+void addition_cl(const float *input, float *res, unsigned int size_input,
+                 unsigned int size_res);
 
 /**
  * @brief     sscal value element by element immediately
@@ -156,10 +157,11 @@ void sgemm_cl(bool TransA, bool TransB, const __fp16 *A, const __fp16 *B,
  * @brief     fp16 addition : sum of all input vectors
  * @param[in] input fp16 * for input
  * @param[in] res fp16 * for result/output
- * @param[in] size number of elements in input vector
- * @param[in] context RunLayerContext reference
+ * @param[in] size_input number of elements in input vector
+ * @param[in] size_res number of elements in result vector
  */
-void addition_cl(const __fp16 *input, __fp16 *res, unsigned int size);
+void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
+                 unsigned int size_res);
 
 /**
  * @brief     fp16 sscal value element by element immediately

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -177,6 +177,20 @@ private:
     }                                             \
   } while (0)
 
+#define GEN_TEST_INPUT_C(input, equation_i_j_k_l) \
+  do {                                            \
+    for (int i = 0; i < batch_b; ++i) {           \
+      for (int j = 0; j < channel; ++j) {         \
+        for (int k = 0; k < height; ++k) {        \
+          for (int l = 0; l < width; ++l) {       \
+            float val = (equation_i_j_k_l);       \
+            input.setValue(i, j, k, l, val);      \
+          }                                       \
+        }                                         \
+      }                                           \
+    }                                             \
+  } while (0)
+
 /**
  * @brief return a tensor filled with contant value with dimension
  */

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -476,7 +476,7 @@ LOCAL_SRC_FILES := \
 	 ../unittest/layers/unittest_layers_reshape.cpp \
 	 ../unittest/layers/unittest_layers_multi_head_attention.cpp \
 	 ../unittest/layers/unittest_layers_positional_encoding.cpp \
-	#  ../unittest/layers/unittest_layers_addition_cl.cpp \
+	 ../unittest/layers/unittest_layers_addition_cl.cpp \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 


### PR DESCRIPTION
Performing addition where dimensions of InputA and InputB vary.
Added broadcasting support only where number of batches vary and other dimensions are same for both inputs.
Number of batch of InputB must be 1.
Output of add_i_cl(A,B) is stored in A inplace.

Self evaluation:

    Build test: [X]Passed [ ]Failed [ ]Skipped
    Run test: [X]Passed [ ]Failed [ ]Skipped