### PR TITLE
[ GPU ] move `initBlaseClKernels()` to registerer

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -55,6 +55,7 @@ static void add_default_object(ClContext &cc) {
 
 static void registerer(ClContext &cc) noexcept {
   try {
+    cc.initBlasClKernels();
     add_default_object(cc);
   } catch (std::exception &e) {
     ml_loge("cl_context: registering layers failed!!, reason: %s", e.what());

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -139,7 +139,6 @@ createLayerNode(const ml::train::LayerType &type,
 #ifdef ENABLE_OPENCL
   if (compute_engine == ml::train::LayerComputeEngine::GPU) {
     auto &cc = nntrainer::ClContext::Global();
-    cc.initBlasClKernels();
     return createLayerNode(cc.createObject<nntrainer::Layer>(type), properties,
                            compute_engine);
   }
@@ -158,7 +157,6 @@ createLayerNode(const std::string &type,
 #ifdef ENABLE_OPENCL
   if (compute_engine == ml::train::LayerComputeEngine::GPU) {
     auto &cc = nntrainer::ClContext::Global();
-    cc.initBlasClKernels();
     return createLayerNode(cc.createObject<nntrainer::Layer>(type), properties,
                            compute_engine);
   }

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -27,10 +27,7 @@
 
 using namespace nntrainer;
 
-static void setUpGpuContext() {
-  auto &ac = nntrainer::ClContext::Global();
-  ac.initBlasClKernels();
-}
+static void setUpGpuContext() { auto &ac = nntrainer::ClContext::Global(); }
 
 TEST(blas_kernels, dotCL_sgemv) {
   setUpGpuContext();


### PR DESCRIPTION
- With the current version code, a user should be care about the timing to call `initBlasClKernels()`. However, it is not desirable, causing some unexpected mistakes.
- Instead of that, this draft moves the `initBlasClKernels()` into registerer, which is called once in Global().`
- This PR is related to #2723 

Self evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped