### PR TITLE
[Unittest] Add network_graph & lr_cosine unit test case

### DIFF
--- a/api/ccapi/include/optimizer.h
+++ b/api/ccapi/include/optimizer.h
@@ -143,8 +143,9 @@ SGD(const std::vector<std::string> &properties = {}) {
 enum LearningRateSchedulerType {
   CONSTANT = ML_TRAIN_LR_SCHEDULER_TYPE_CONSTANT, /**< constant */
   EXPONENTIAL =
-    ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL, /**< exponentially decay */
-  STEP = ML_TRAIN_LR_SCHEDULER_TYPE_STEP    /**< step wise decay */
+    ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL,  /**< exponentially decay */
+  STEP = ML_TRAIN_LR_SCHEDULER_TYPE_STEP,    /**< step wise decay */
+  COSINE = ML_TRAIN_LR_SCHEDULER_TYPE_COSINE /**< cosine annealing */
 };
 
 /**
@@ -248,6 +249,15 @@ Exponential(const std::vector<std::string> &properties = {}) {
 inline std::unique_ptr<LearningRateScheduler>
 Step(const std::vector<std::string> &properties = {}) {
   return createLearningRateScheduler(LearningRateSchedulerType::STEP,
+                                     properties);
+}
+
+/**
+ * @brief Helper function to create cosine learning rate scheduler
+ */
+inline std::unique_ptr<LearningRateScheduler>
+Cosine(const std::vector<std::string> &properties = {}) {
+  return createLearningRateScheduler(LearningRateSchedulerType::COSINE,
                                      properties);
 }
 

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -99,6 +99,7 @@ typedef enum {
   ML_TRAIN_LR_SCHEDULER_TYPE_CONSTANT = 0,    /**< Constant lr scheduler */
   ML_TRAIN_LR_SCHEDULER_TYPE_EXPONENTIAL = 1, /**< Exponentially lr scheduler */
   ML_TRAIN_LR_SCHEDULER_TYPE_STEP = 2,        /**< Step lr scheduler */
+  ML_TRAIN_LR_SCHEDULER_TYPE_COSINE = 3,      /**< Cosine lr scheduler */
   ML_TRAIN_LR_SCHEDULER_TYPE_UNKNOWN = 999    /**< Unknown lr scheduler */
 } ml_train_lr_scheduler_type_e;
 

--- a/test/unittest/unittest_nntrainer_lr_scheduler.cpp
+++ b/test/unittest/unittest_nntrainer_lr_scheduler.cpp
@@ -16,6 +16,7 @@
 
 #include <lr_scheduler.h>
 #include <lr_scheduler_constant.h>
+#include <lr_scheduler_cosine.h>
 #include <lr_scheduler_exponential.h>
 #include <nntrainer_error.h>
 
@@ -52,6 +53,14 @@ TEST(lr_constant, ctor_initializer_02_p) {
  */
 TEST(lr_constant, ctor_initializer_03_n) {
   EXPECT_ANY_THROW(createLRS("random"));
+}
+
+/**
+ * @brief test constructing lr scheduler
+ *
+ */
+TEST(lr_constant, ctor_initializer_cosine_n) {
+  EXPECT_NO_THROW(createLRS("cosine"));
 }
 
 /**
@@ -418,6 +427,57 @@ TEST(lr_step, get_learning_rate_02_p) {
   EXPECT_FLOAT_EQ(lr->getLearningRate(1000), 0.001f);
 }
 
+TEST(lr_cosine, prop_01_n) {
+  auto lr = createLRS("cosine");
+  EXPECT_THROW(lr->setProperty({"unknown=unknown"}), std::invalid_argument);
+}
+
+TEST(lr_cosine, prop_02_n) {
+  auto lr = createLRS("cosine");
+  EXPECT_THROW(lr->setProperty({"learning_rate:0.1"}), std::invalid_argument);
+}
+
+TEST(lr_cosine, prop_03_n) {
+  auto lr = createLRS("cosine");
+  EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
+}
+
+TEST(lr_cosine, prop_04_n) {
+  auto lr = createLRS("cosine");
+  EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
+}
+
+TEST(lr_cosine, prop_05_n) {
+  auto lr = createLRS("cosine");
+  EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
+  EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
+}
+
+TEST(lr_cosine, prop_06_n) {
+  auto lr = createLRS("cosine");
+  EXPECT_NO_THROW(lr->setProperty({"decay_steps=1"}));
+}
+
+TEST(lr_cosine, finalize_01_n) {
+  auto lr = createLRS("cosine");
+  EXPECT_THROW(lr->finalize(), std::invalid_argument);
+}
+
+TEST(lr_cosine, finalize_02_n) {
+  auto lr = createLRS("cosine");
+  EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
+  EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
+  EXPECT_NO_THROW(lr->setProperty({"decay_steps=1"}));
+  EXPECT_NO_THROW(lr->finalize());
+}
+TEST(lr_cosine, getlearningrate_01_n) {
+  auto lr = createLRS("cosine");
+  EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
+  EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
+  EXPECT_NO_THROW(lr->setProperty({"decay_steps=1"}));
+  EXPECT_NO_THROW(lr->finalize());
+  EXPECT_FLOAT_EQ(lr->getLearningRate(0), 1);
+}
 int main(int argc, char **argv) {
   int result = -1;
 


### PR DESCRIPTION
1. [[Unittest] Add network_graph unit test](https://github.com/nnstreamer/nntrainer/pull/2762/commits/72ecd76f69911a4b7dcb64900188f15069031edb)
- add reinitialize / catch exceptions
- These tests are not limited to specific layers but rather serve as test cases for checking activities performed on actual network graphs.

2. [[Unittest] Add lr_scheduler_cosine unit test](https://github.com/nnstreamer/nntrainer/pull/2762/commits/5423dabe7d9d9cb50b8532f6e262c0d0257adb37)
- property setting test / finalize test / getLearningRate test
- add to api and make helper function 

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped