### PR TITLE
[Unittest] Add constant DerivativeLossLayer unittest

### DIFF
--- a/test/unittest/layers/unittest_layers_loss.cpp
+++ b/test/unittest/layers/unittest_layers_loss.cpp
@@ -13,6 +13,7 @@
 
 #include <gtest/gtest.h>
 
+#include <constant_derivative_loss_layer.h>
 #include <cross_entropy_loss_layer.h>
 #include <cross_entropy_sigmoid_loss_layer.h>
 #include <cross_entropy_softmax_loss_layer.h>
@@ -34,6 +35,11 @@ auto semantic_loss_mse = LayerSemanticsParamType(
   nntrainer::MSELossLayer::type, {},
   LayerCreateSetPropertyOptions::AVAILABLE_FROM_APP_CONTEXT, false, 1);
 
+auto semantic_loss_constant_derivative = LayerSemanticsParamType(
+  nntrainer::createLayer<nntrainer::ConstantDerivativeLossLayer>,
+  nntrainer::ConstantDerivativeLossLayer::type, {},
+  LayerCreateSetPropertyOptions::AVAILABLE_FROM_APP_CONTEXT, false, 1);
+
 auto semantic_loss_cross = LayerSemanticsParamType(
   nntrainer::createLayer<nntrainer::CrossEntropyLossLayer>,
   nntrainer::CrossEntropyLossLayer::type, {}, 0, true, 1);
@@ -41,4 +47,5 @@ auto semantic_loss_cross = LayerSemanticsParamType(
 GTEST_PARAMETER_TEST(LossCross, LayerSemantics,
                      ::testing::Values(semantic_loss_cross, semantic_loss_mse,
                                        semantic_loss_cross_softmax,
-                                       semantic_loss_cross_sigmoid));
+                                       semantic_loss_cross_sigmoid,
+                                       semantic_loss_constant_derivative));


### PR DESCRIPTION
Currently, there is a layersemantics in the NNTrainer Unittest that verifies the behavior of the losslayer but it does not include the case for the constant DerivativeLossLayer.

By simply filling in the parameters and passing them over, we can perform unit tests on basic operations so I added this feature.

commit : [[Unittest] Add constant DerivativeLossLayer unittest](https://github.com/nnstreamer/nntrainer/commit/5044f9885bde1fe75f424ea94cfa8c51ea0a68ef)

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped