### PR TITLE
[ unittest/modelfile ] Fix backbone_n_15 @open sesame 10/17 17:36

### DIFF
--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -638,27 +638,24 @@ TEST(nntrainerIniTest, backbone_07_p) {
 /**
  * @brief Ini file unittest with backbone
  * @note Input shape is provided in model file
- * @todo C++ exception with description "First node must be identified as an
- * input if it is qualified to be input, name: conv2d" thrown in the test body.
  */
-// TEST(nntrainerIniTest, backbone_15_n) {
-//   ScopedIni base("base", {conv2d, conv2d});
+TEST(nntrainerIniTest, backbone_15_n) {
+  ScopedIni base("base", {conv2d, conv2d});
 
-//   ScopedIni full("backbone_15_n_scaled", {nw_base_mse, adam,
-//   backbone_valid});
+  ScopedIni full("backbone_15_n_scaled", {nw_base_mse, adam, backbone_valid});
 
-//   nntrainer::NeuralNetwork NN_scaled, NN_full;
-//   EXPECT_EQ(NN_full.loadFromConfig(full.getIniName()), ML_ERROR_NONE);
-//   EXPECT_EQ(NN_full.compile(), ML_ERROR_NONE);
-//   EXPECT_THROW(NN_full.initialize(), std::invalid_argument);
+  nntrainer::NeuralNetwork NN_scaled, NN_full;
+  EXPECT_EQ(NN_full.loadFromConfig(full.getIniName()), ML_ERROR_NONE);
+  EXPECT_THROW(NN_full.compile(), std::invalid_argument);
+  EXPECT_EQ(NN_full.initialize(), ML_ERROR_NOT_SUPPORTED);
 
-//   ScopedIni scaled("backbone_15_n_scaled",
-//                    {nw_base_mse, adam, backbone_scaled});
+  ScopedIni scaled("backbone_15_n_scaled",
+                   {nw_base_mse, adam, backbone_scaled});
 
-//   EXPECT_EQ(NN_scaled.loadFromConfig(scaled.getIniName()), ML_ERROR_NONE);
-//   EXPECT_EQ(NN_scaled.compile(), ML_ERROR_NONE);
-//   EXPECT_THROW(NN_scaled.initialize(), std::invalid_argument);
-// }
+  EXPECT_EQ(NN_scaled.loadFromConfig(scaled.getIniName()), ML_ERROR_NONE);
+  EXPECT_THROW(NN_scaled.compile(), std::invalid_argument);
+  EXPECT_EQ(NN_scaled.initialize(), ML_ERROR_NOT_SUPPORTED);
+}
 /**
  * @brief Ini file unittest with backbone
  * @note Input shape is striped from backbone and not provided in model file


### PR DESCRIPTION
- The original purpose of this TC is to make sure the model is not compiled when input layer is not clarified.
- As far as I am concerned, without any information about input layer, the model should fail to compile, and since it is not compiled, should not support initialization.
- Related commit hashes:
original purpose : 68e7dab5ed2f99e8b380ec8a5f599d76952b7fc3
wrong fix : e1c5915fba7d64db66062d8b62a722d6c1b653ad

