### PR TITLE
[gpu/blas] sgemv_noTrans kernel and unit tests @open sesame 10/29 21:54

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -129,6 +129,7 @@ void ClContext::initBlasClKernels() {
   }
 
   registerClKernel(sgemv_cl_kernel_, "sgemv_cl");
+  registerClKernel(sgemv_cl_noTrans_kernel_, "sgemv_cl_noTrans");
   registerClKernel(dot_cl_kernel_, "dot_cl");
   registerClKernel(sgemm_cl_noTrans_kernel_, "sgemm_cl_noTrans");
   registerClKernel(sgemm_cl_transA_kernel_, "sgemm_cl_transA");
@@ -139,6 +140,7 @@ void ClContext::initBlasClKernels() {
 
 #ifdef ENABLE_FP16
   registerClKernel(sgemv_cl_kernel_fp16_, "sgemv_cl_fp16");
+  registerClKernel(sgemv_cl_noTrans_kernel_fp16_, "sgemv_cl_noTrans_fp16");
   registerClKernel(dot_cl_kernel_fp16_, "dot_cl_fp16");
   registerClKernel(sgemm_cl_noTrans_kernel_fp16_, "sgemm_cl_noTrans_fp16");
   registerClKernel(sgemm_cl_transA_kernel_fp16_, "sgemm_cl_transA_fp16");

--- a/nntrainer/tensor/cl_operations/blas_kernel_interface.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_interface.cpp
@@ -131,15 +131,15 @@ void dotCl(Tensor const &input, Tensor const &m, Tensor &result, bool trans,
     }
     /// case2: (M * K) X (K * 1)
     else if (N == 1) {
-      trans ? sgemv_cl(data, mdata, rdata, dim2, dim1, lda)
-            : sgemv_cl(data, mdata, rdata, dim1, dim2, lda);
+      trans ? sgemv_cl(data, mdata, rdata, trans, dim2, dim1, lda)
+            : sgemv_cl(data, mdata, rdata, trans, dim1, dim2, lda);
     }
     /// case3: (1 * K) X (K * N) = 1 * N = R
     /// = R^T = (K * N) ^T * (1 * K) ^T = (N * K) * (K * 1) = (N * K) * (1 * K)
     /// Effectively a translation of sgemv
     else if (M == 1) {
-      trans_m ? sgemv_cl(mdata, data, rdata, mdim1, mdim2, ldb)
-              : sgemv_cl(mdata, data, rdata, mdim2, mdim1, ldb);
+      trans_m ? sgemv_cl(mdata, data, rdata, !trans_m, mdim1, mdim2, ldb)
+              : sgemv_cl(mdata, data, rdata, !trans_m, mdim2, mdim1, ldb);
     }
     /// case others: use gemm
     else {
@@ -163,15 +163,15 @@ void dotCl(Tensor const &input, Tensor const &m, Tensor &result, bool trans,
     }
     /// case2: (M * K) X (K * 1)
     else if (N == 1) {
-      trans ? sgemv_cl(data, mdata, rdata, dim2, dim1, lda)
-            : sgemv_cl(data, mdata, rdata, dim1, dim2, lda);
+      trans ? sgemv_cl(data, mdata, rdata, trans, dim2, dim1, lda)
+            : sgemv_cl(data, mdata, rdata, trans, dim1, dim2, lda);
     }
     /// case3: (1 * K) X (K * N) = 1 * N = R
     /// = R^T = (K * N) ^T * (1 * K) ^T = (N * K) * (K * 1) = (N * K) * (1 * K)
     /// Effectively a translation of sgemv
     else if (M == 1) {
-      trans_m ? sgemv_cl(mdata, data, rdata, mdim1, mdim2, ldb)
-              : sgemv_cl(mdata, data, rdata, mdim2, mdim1, ldb);
+      trans_m ? sgemv_cl(mdata, data, rdata, !trans_m, mdim1, mdim2, ldb)
+              : sgemv_cl(mdata, data, rdata, !trans_m, mdim2, mdim1, ldb);
     }
     /// case others: use sgemm
     else {

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.h
@@ -29,6 +29,18 @@ static const std::string sgemv_cl_kernel_ =
           
     })";
 
+static const std::string sgemv_cl_noTrans_kernel_ =
+  R"(__kernel void sgemv_cl_noTrans(const __global float* A, const __global float* X,
+                      __global float* Y, unsigned int N, unsigned int lda) {                                            
+        unsigned int i;
+        i = get_global_id(0);                         
+        float y0 = 0.0f;
+        for (unsigned int j = 0; j < N; j++)                         
+            y0 += A[j + i * lda] * X[j]; 
+        Y[i] = y0;                            
+          
+    })";
+
 static const std::string dot_cl_kernel_ =
   R"(__kernel void dot_cl(const __global float* A, const __global float* X, unsigned int K, __global float* res) {
         *res = 0;
@@ -133,6 +145,21 @@ static const std::string sgemv_cl_kernel_fp16_ =
         half y0 = 0.0f;
         for (unsigned int j = 0; j < N; j++)                         
             y0 += A[i + j * lda] * X[j]; 
+        Y[i] = y0;                            
+          
+    })";
+
+static const std::string sgemv_cl_noTrans_kernel_fp16_ =
+  R"(
+    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+    __kernel void sgemv_cl_noTrans_fp16(const __global half* A, const __global half* X,
+                      __global half* Y, unsigned int N, unsigned int lda) {                                            
+        unsigned int i;
+        i = get_global_id(0);                         
+        half y0 = 0.0f;
+        for (unsigned int j = 0; j < N; j++)                         
+            y0 += A[j + i * lda] * X[j]; 
         Y[i] = y0;                            
           
     })";

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -17,13 +17,22 @@
 namespace nntrainer {
 
 void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
-              unsigned int dim1, unsigned int dim2, unsigned int lda) {
+              bool TransA, unsigned int dim1, unsigned int dim2,
+              unsigned int lda) {
 
   bool result = false;
 
   do {
-    ClContext::SharedPtrClKernel kernel_sgemv_ptr =
-      cl_context_ref.registerClKernel(sgemv_cl_kernel_, "sgemv_cl");
+    ClContext::SharedPtrClKernel kernel_sgemv_ptr;
+
+    if (TransA) {
+      kernel_sgemv_ptr =
+        cl_context_ref.registerClKernel(sgemv_cl_kernel_, "sgemv_cl");
+    } else {
+      kernel_sgemv_ptr = cl_context_ref.registerClKernel(
+        sgemv_cl_noTrans_kernel_, "sgemv_cl_noTrans");
+    }
+
     if (!kernel_sgemv_ptr) {
       break;
     }

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -29,13 +29,15 @@ static ClContext cl_context_ref;
  * @param[in] matAdata float * for Matrix A
  * @param[in] vecXdata float * for Vector X
  * @param[in] vecYdata float * for Vector Y
+ * @param[in] transA bool transpose
  * @param[in] dim1 number of A's columns
  * @param[in] dim2 number of A's rows
  * @param[in] lda number of X's columns
  * @param[in] context RunLayerContext reference
  */
 void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
-              unsigned int dim1, unsigned int dim2, unsigned int lda);
+              bool TransA, unsigned int dim1, unsigned int dim2,
+              unsigned int lda);
 
 /**
  * @brief     dot computation : sum of all X * Y
@@ -92,13 +94,15 @@ void sscal_cl(float *X, const unsigned int N, const float alpha);
  * @param[in] matAdata fp16 * for Matrix A
  * @param[in] vecXdata fp16 * for Vector X
  * @param[in] vecYdata fp16 * for Vector Y
+ * @param[in] transA bool transpose
  * @param[in] dim1 number of A's columns
  * @param[in] dim2 number of A's rows
  * @param[in] lda number of X's columns
  * @param[in] context RunLayerContext reference
  */
 void sgemv_cl(const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
-              unsigned int dim1, unsigned int dim2, unsigned int lda);
+              bool TransA, unsigned int dim1, unsigned int dim2,
+              unsigned int lda);
 
 /**
  * @brief     fp16 dot computation : sum of all X * Y

--- a/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
@@ -17,13 +17,22 @@
 namespace nntrainer {
 
 void sgemv_cl(const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
-              unsigned int dim1, unsigned int dim2, unsigned int lda) {
+              bool TransA, unsigned int dim1, unsigned int dim2,
+              unsigned int lda) {
 
   bool result = false;
 
   do {
-    ClContext::SharedPtrClKernel kernel_sgemv_fp16_ptr =
-      cl_context_ref.registerClKernel(sgemv_cl_kernel_fp16_, "sgemv_cl_fp16");
+    ClContext::SharedPtrClKernel kernel_sgemv_fp16_ptr;
+
+    if (TransA) {
+      kernel_sgemv_fp16_ptr =
+        cl_context_ref.registerClKernel(sgemv_cl_kernel_fp16_, "sgemv_cl_fp16");
+    } else {
+      kernel_sgemv_fp16_ptr = cl_context_ref.registerClKernel(
+        sgemv_cl_noTrans_kernel_fp16_, "sgemv_cl_noTrans_fp16");
+    }
+
     if (!kernel_sgemv_fp16_ptr) {
       break;
     }

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -32,8 +32,53 @@ static void setUpGpuContext() {
   ac.initBlasClKernels();
 }
 
-TEST(blas_kernels, dotCL_sgemv) {
+TEST(blas_kernels, dotCL_sgemv_M_1_1) {
   setUpGpuContext();
+  int batch = 1;
+  int channel = 1;
+  int height = 1;
+  int width = 768;
+
+  int height_b = 2048;
+  int width_b = 768;
+
+  bool transA = false;
+  bool transB = true;
+
+  const float alpha = 1e-1;
+  const int MOD = 10;
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  nntrainer::Tensor A_fp32(batch, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor B_fp32(batch, channel, height_b, width_b, t_type_nchw_fp32);
+
+  GEN_TEST_INPUT(A_fp32, ((i * (batch * height * channel) +
+                           j * (batch * height) + k * (width) + l + 1) %
+                          MOD) *
+                           alpha);
+  GEN_TEST_INPUT_B(B_fp32, ((i * (batch * height_b * channel) +
+                             j * (batch * height_b) + k * (width_b) + l + 1) %
+                            MOD) *
+                             alpha);
+
+  nntrainer::Tensor C = dotCl(A_fp32, B_fp32, transA, transB);
+  nntrainer::Tensor C_fp32 = A_fp32.dot(B_fp32, transA, transB);
+
+  float mseErrorNeon =
+    mse<float>(C.getData<float>(), C_fp32.getData<float>(), C.size());
+
+  double cosSimNeon = cosine_similarity<float>(
+    C.getData<float>(), C_fp32.getData<float>(), C.size());
+
+  const float epsilon = 1e-3 * width;
+
+  EXPECT_IN_RANGE(mseErrorNeon, 0, epsilon);
+  EXPECT_IN_RANGE((float)cosSimNeon, 0.99, 1);
+}
+
+TEST(blas_kernels, dotCL_sgemv_M_1_2) {
   int batch = 1;
   int channel = 1;
   int height = 1;
@@ -48,8 +93,95 @@ TEST(blas_kernels, dotCL_sgemv) {
   const float alpha = 1e-1;
   const int MOD = 10;
 
-  nntrainer::TensorDim::TensorType t_type_nchw_fp16 = {
-    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16};
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  nntrainer::Tensor A_fp32(batch, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor B_fp32(batch, channel, height_b, width_b, t_type_nchw_fp32);
+
+  GEN_TEST_INPUT(A_fp32, ((i * (batch * height * channel) +
+                           j * (batch * height) + k * (width) + l + 1) %
+                          MOD) *
+                           alpha);
+  GEN_TEST_INPUT_B(B_fp32, ((i * (batch * height_b * channel) +
+                             j * (batch * height_b) + k * (width_b) + l + 1) %
+                            MOD) *
+                             alpha);
+
+  nntrainer::Tensor C = dotCl(A_fp32, B_fp32, transA, transB);
+  nntrainer::Tensor C_fp32 = A_fp32.dot(B_fp32, transA, transB);
+
+  float mseErrorNeon =
+    mse<float>(C.getData<float>(), C_fp32.getData<float>(), C.size());
+
+  double cosSimNeon = cosine_similarity<float>(
+    C.getData<float>(), C_fp32.getData<float>(), C.size());
+
+  const float epsilon = 1e-3 * width;
+
+  EXPECT_IN_RANGE(mseErrorNeon, 0, epsilon);
+  EXPECT_IN_RANGE((float)cosSimNeon, 0.99, 1);
+}
+
+TEST(blas_kernels, dotCL_sgemv_N_1_1) {
+  int batch = 1;
+  int channel = 1;
+  int height = 768;
+  int width = 2048;
+
+  int height_b = 768;
+  int width_b = 1;
+
+  bool transA = true;
+  bool transB = false;
+
+  const float alpha = 1e-1;
+  const int MOD = 10;
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  nntrainer::Tensor A_fp32(batch, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor B_fp32(batch, channel, height_b, width_b, t_type_nchw_fp32);
+
+  GEN_TEST_INPUT(A_fp32, ((i * (batch * height * channel) +
+                           j * (batch * height) + k * (width) + l + 1) %
+                          MOD) *
+                           alpha);
+  GEN_TEST_INPUT_B(B_fp32, ((i * (batch * height_b * channel) +
+                             j * (batch * height_b) + k * (width_b) + l + 1) %
+                            MOD) *
+                             alpha);
+
+  nntrainer::Tensor C = dotCl(A_fp32, B_fp32, transA, transB);
+  nntrainer::Tensor C_fp32 = A_fp32.dot(B_fp32, transA, transB);
+
+  float mseErrorNeon =
+    mse<float>(C.getData<float>(), C_fp32.getData<float>(), C.size());
+
+  double cosSimNeon = cosine_similarity<float>(
+    C.getData<float>(), C_fp32.getData<float>(), C.size());
+
+  const float epsilon = 1e-3 * width;
+
+  EXPECT_IN_RANGE(mseErrorNeon, 0, epsilon);
+  EXPECT_IN_RANGE((float)cosSimNeon, 0.99, 1);
+}
+
+TEST(blas_kernels, dotCL_sgemv_N_1_2) {
+  int batch = 1;
+  int channel = 1;
+  int height = 768;
+  int width = 2048;
+
+  int height_b = 2048;
+  int width_b = 1;
+
+  bool transA = false;
+  bool transB = false;
+
+  const float alpha = 1e-1;
+  const int MOD = 10;
 
   nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
     nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
@@ -96,9 +228,6 @@ TEST(blas_kernels, dotCL_sgemv_n) {
 
   const float alpha = 1e-1;
   const int MOD = 10;
-
-  nntrainer::TensorDim::TensorType t_type_nchw_fp16 = {
-    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16};
 
   nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
     nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};


### PR DESCRIPTION
Changes in this PR:

- Added `sgemv_noTrans` kernel.
- `trans` information was added to the required functions.
- Added all possible unit tests for `sgemv` and `sgemv_noTrans`.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Debadri Samaddar <s.debadri@samsung.com>