### PR TITLE
[GPU/OpenCL] Remove duplicate macro definition.

### DIFF
--- a/nntrainer/layers/cl_layers/addition_layer_cl.h
+++ b/nntrainer/layers/cl_layers/addition_layer_cl.h
@@ -18,12 +18,6 @@
 #include <common_properties.h>
 #include <layer_devel.h>
 
-#define CREATE_IF_EMPTY_DIMS(tensor, ...) \
-  do {                                    \
-    if (tensor.empty())                   \
-      tensor = Tensor(__VA_ARGS__);       \
-  } while (0);
-
 namespace nntrainer {
 
 /**


### PR DESCRIPTION
This PR removes a macro with the same name and functionality defined in multiple locations.
This ensures only one source has the definition of the macro, preventing compilation errors or unexpected behavior.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped