### PR TITLE
[Tensor] Parameterized constructor with TensorBase 

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -187,6 +187,13 @@ Tensor::Tensor(const Tensor &rhs) {
   }
 }
 
+Tensor::Tensor(std::shared_ptr<TensorBase> rhs) {
+  NNTR_THROW_IF(rhs == nullptr, std::invalid_argument)
+    << "Error: received a nullptr. Tensor cannot be constructed";
+
+  itensor = rhs;
+}
+
 Tensor &Tensor::operator=(const Tensor &rhs) {
   if (rhs.getDataType() == Tdatatype::FP32) {
     itensor = std::shared_ptr<FloatTensor>(new FloatTensor(*rhs.itensor),

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -340,6 +340,15 @@ public:
     Tensor(std::vector<std::decay<decltype(d)>::type>{d}, t_type){};
 
   /**
+   *  @brief  Constructor of Tensor by directly assigning TensorBase.
+   *  @param[in] rhs shared_ptr of a TensorBase
+   *  @note TensorBase is an abstract class so we can't directly instantiate it.
+   *  Make sure to use a shared_ptr with a derived class when utilizing this
+   *  constructor.
+   */
+  Tensor(std::shared_ptr<TensorBase> rhs);
+
+  /**
    * @brief Basic Destructor
    */
   ~Tensor() = default;


### PR DESCRIPTION
This PR updates a parameterized constructor accepting a shared pointer of the TensorBase class.
Users now have greater flexibility when creating Tensors, enabling them to adapt new types of user-defined tensors by initializing the itensor object.
Please note that TensorBase remains an abstract class and cannot be instantiated directly.
Remember to utilize a shared_ptr with a derived class when employing this constructor.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped