### PR TITLE
[ GPU/OpenCL ] Split kernel registration from forwarding method @open sesame 12/02 09:39

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -33,30 +33,37 @@ std::once_flag global_cl_context_init_flag;
 
 static void add_default_object(ClContext &cc) {
 
-  FullyConnectedLayerCl::registerClKernels();
-  cc.registerFactory(nntrainer::createLayer<FullyConnectedLayerCl>,
-                     FullyConnectedLayerCl::type,
-                     ml::train::LayerType::LAYER_FC);
+  if (FullyConnectedLayerCl::registerClKernels()) {
+    cc.registerFactory(nntrainer::createLayer<FullyConnectedLayerCl>,
+                       FullyConnectedLayerCl::type,
+                       ml::train::LayerType::LAYER_FC);
+  }
 
   // cc.registerFactory(nntrainer::createLayer<AdditionLayerCL>,
   //                    AdditionLayerCL::type,
   //                    ml::train::LayerType::LAYER_ADDITION);
 
-  // cc.registerFactory(nntrainer::createLayer<SwiGLULayerCl>,
-  // SwiGLULayerCl::type,
-  //  ml::train::LayerType::LAYER_SWIGLU);
+  // @todo swiglulayercl also needs to be updated.
+  cc.registerFactory(nntrainer::createLayer<SwiGLULayerCl>,
+  SwiGLULayerCl::type,
+   ml::train::LayerType::LAYER_SWIGLU);
 
-  ReshapeLayerCl::registerClKernels();
-  cc.registerFactory(nntrainer::createLayer<ReshapeLayerCl>,
-                     ReshapeLayerCl::type, ml::train::LayerType::LAYER_RESHAPE);
+  if (ReshapeLayerCl::registerClKernels()) {
+    cc.registerFactory(nntrainer::createLayer<ReshapeLayerCl>,
+                       ReshapeLayerCl::type,
+                       ml::train::LayerType::LAYER_RESHAPE);
+  }
 
-  // cc.registerFactory(nntrainer::createLayer<RMSNormLayerCl>,
-  //  RMSNormLayerCl::type, ml::train::LayerType::LAYER_RMSNORM);
+  // @todo rmsnormlayercl also needs to be updated.
+  cc.registerFactory(nntrainer::createLayer<RMSNormLayerCl>,
+   RMSNormLayerCl::type, ml::train::LayerType::LAYER_RMSNORM);
 
-  ConcatLayerCl::registerClKernels();
-  cc.registerFactory(nntrainer::createLayer<ConcatLayerCl>, ConcatLayerCl::type,
-                     ml::train::LayerType::LAYER_CONCAT);
+  if (ConcatLayerCl::registerClKernels()) {
+    cc.registerFactory(nntrainer::createLayer<ConcatLayerCl>,
+                       ConcatLayerCl::type, ml::train::LayerType::LAYER_CONCAT);
+  }
 
+  // @todo transposlayercl also needs to be updated.
   cc.registerFactory(nntrainer::createLayer<TransposeLayerCl>,
                      TransposeLayerCl::type,
                      ml::train::LayerType::LAYER_TRANSPOSE);

--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -33,6 +33,7 @@ std::once_flag global_cl_context_init_flag;
 
 static void add_default_object(ClContext &cc) {
 
+  FullyConnectedLayerCl::registerClKernels();
   cc.registerFactory(nntrainer::createLayer<FullyConnectedLayerCl>,
                      FullyConnectedLayerCl::type,
                      ml::train::LayerType::LAYER_FC);
@@ -41,15 +42,18 @@ static void add_default_object(ClContext &cc) {
   //                    AdditionLayerCL::type,
   //                    ml::train::LayerType::LAYER_ADDITION);
 
-  cc.registerFactory(nntrainer::createLayer<SwiGLULayerCl>, SwiGLULayerCl::type,
-                     ml::train::LayerType::LAYER_SWIGLU);
+  // cc.registerFactory(nntrainer::createLayer<SwiGLULayerCl>,
+  // SwiGLULayerCl::type,
+  //  ml::train::LayerType::LAYER_SWIGLU);
 
+  ReshapeLayerCl::registerClKernels();
   cc.registerFactory(nntrainer::createLayer<ReshapeLayerCl>,
                      ReshapeLayerCl::type, ml::train::LayerType::LAYER_RESHAPE);
 
-  cc.registerFactory(nntrainer::createLayer<RMSNormLayerCl>,
-                     RMSNormLayerCl::type, ml::train::LayerType::LAYER_RMSNORM);
+  // cc.registerFactory(nntrainer::createLayer<RMSNormLayerCl>,
+  //  RMSNormLayerCl::type, ml::train::LayerType::LAYER_RMSNORM);
 
+  ConcatLayerCl::registerClKernels();
   cc.registerFactory(nntrainer::createLayer<ConcatLayerCl>, ConcatLayerCl::type,
                      ml::train::LayerType::LAYER_CONCAT);
 

--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -44,9 +44,8 @@ static void add_default_object(ClContext &cc) {
   //                    ml::train::LayerType::LAYER_ADDITION);
 
   // @todo swiglulayercl also needs to be updated.
-  cc.registerFactory(nntrainer::createLayer<SwiGLULayerCl>,
-  SwiGLULayerCl::type,
-   ml::train::LayerType::LAYER_SWIGLU);
+  cc.registerFactory(nntrainer::createLayer<SwiGLULayerCl>, SwiGLULayerCl::type,
+                     ml::train::LayerType::LAYER_SWIGLU);
 
   if (ReshapeLayerCl::registerClKernels()) {
     cc.registerFactory(nntrainer::createLayer<ReshapeLayerCl>,
@@ -56,7 +55,7 @@ static void add_default_object(ClContext &cc) {
 
   // @todo rmsnormlayercl also needs to be updated.
   cc.registerFactory(nntrainer::createLayer<RMSNormLayerCl>,
-   RMSNormLayerCl::type, ml::train::LayerType::LAYER_RMSNORM);
+                     RMSNormLayerCl::type, ml::train::LayerType::LAYER_RMSNORM);
 
   if (ConcatLayerCl::registerClKernels()) {
     cc.registerFactory(nntrainer::createLayer<ConcatLayerCl>,

--- a/nntrainer/layers/cl_layers/concat_cl.cpp
+++ b/nntrainer/layers/cl_layers/concat_cl.cpp
@@ -242,8 +242,10 @@ static constexpr size_t INPUT_IDX_2 = 1;
 bool ConcatLayerCl::registerClKernels() {
 
   // check if already registered
-  if (!layer_kernel_ptrs.empty())
-    return true;
+  if (!layer_kernel_ptrs.empty()) {
+    ml_loge("kernels for concat layer are already registered");
+    return false;
+  }
 
   do {
 

--- a/nntrainer/layers/cl_layers/concat_cl.cpp
+++ b/nntrainer/layers/cl_layers/concat_cl.cpp
@@ -536,114 +536,6 @@ void ConcatLayerCl::concat_cl_axis3(const float *matAdata,
   } while (false);
 }
 
-void ConcatLayerCl::concat_cl_axis3_fp16(
-  const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
-  unsigned int input1_batch_size, unsigned int input1_channels,
-  unsigned int input1_height, unsigned int input1_width,
-  unsigned int input2_width) {
-
-  bool result = false;
-
-  do {
-
-    const auto &kernel_concat_ptr =
-      layer_kernel_ptrs[Kernels::CONCAT_CL_AXIS3_FP16];
-
-    int dim = int(input1_batch_size * input1_channels * input1_height *
-                  (input1_width + input2_width));
-
-    opencl::Buffer inputA(cl_context_ref.context_inst_,
-                          sizeof(__fp16) * input1_batch_size * input1_channels *
-                            input1_height * input1_width,
-                          true, nullptr);
-
-    opencl::Buffer inputX(cl_context_ref.context_inst_,
-                          sizeof(__fp16) * input1_batch_size * input1_channels *
-                            input1_height * input2_width,
-                          true, nullptr);
-
-    opencl::Buffer inOutY(cl_context_ref.context_inst_,
-                          sizeof(__fp16) * input1_batch_size * input1_channels *
-                            input1_height * (input1_width + input2_width),
-                          true, nullptr);
-
-    result = inputA.WriteData(cl_context_ref.command_queue_inst_, matAdata);
-    if (!result) {
-      break;
-    }
-
-    result = inputX.WriteData(cl_context_ref.command_queue_inst_, vecXdata);
-    if (!result) {
-      break;
-    }
-
-    result = inOutY.WriteData(cl_context_ref.command_queue_inst_, vecYdata);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_concat_ptr->SetKernelArguments(0, &inputA, sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_concat_ptr->SetKernelArguments(1, &inputX, sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_concat_ptr->SetKernelArguments(2, &inOutY, sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_concat_ptr->SetKernelArguments(3, &input1_batch_size, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_concat_ptr->SetKernelArguments(4, &input1_channels, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_concat_ptr->SetKernelArguments(5, &input1_height, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_concat_ptr->SetKernelArguments(6, &input1_width, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_concat_ptr->SetKernelArguments(7, &input2_width, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    const int work_groups_count[3] = {dim, 1, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
-
-    result = cl_context_ref.command_queue_inst_.DispatchCommand(
-      kernel_concat_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = inOutY.ReadData(cl_context_ref.command_queue_inst_, vecYdata);
-    if (!result) {
-      break;
-    }
-
-  } while (false);
-}
-
 void ConcatLayerCl::concat_cl_axis2(const float *matAdata,
                                     const float *vecXdata, float *vecYdata,
                                     unsigned int input1_batch_size,
@@ -673,113 +565,6 @@ void ConcatLayerCl::concat_cl_axis2(const float *matAdata,
 
     opencl::Buffer inOutY(cl_context_ref.context_inst_,
                           sizeof(float) * input1_batch_size * input1_channels *
-                            (input1_height + input2_height) * input1_width,
-                          true, nullptr);
-
-    result = inputA.WriteData(cl_context_ref.command_queue_inst_, matAdata);
-    if (!result) {
-      break;
-    }
-
-    result = inputX.WriteData(cl_context_ref.command_queue_inst_, vecXdata);
-    if (!result) {
-      break;
-    }
-
-    result = inOutY.WriteData(cl_context_ref.command_queue_inst_, vecYdata);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_concat_ptr->SetKernelArguments(0, &inputA, sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_concat_ptr->SetKernelArguments(1, &inputX, sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_concat_ptr->SetKernelArguments(2, &inOutY, sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_concat_ptr->SetKernelArguments(3, &input1_batch_size, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_concat_ptr->SetKernelArguments(4, &input1_channels, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_concat_ptr->SetKernelArguments(5, &input1_height, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_concat_ptr->SetKernelArguments(6, &input2_height, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_concat_ptr->SetKernelArguments(7, &input1_width, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    const int work_groups_count[3] = {dim, 1, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
-
-    result = cl_context_ref.command_queue_inst_.DispatchCommand(
-      kernel_concat_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = inOutY.ReadData(cl_context_ref.command_queue_inst_, vecYdata);
-    if (!result) {
-      break;
-    }
-
-  } while (false);
-}
-
-void ConcatLayerCl::concat_cl_axis2_fp16(
-  const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
-  unsigned int input1_batch_size, unsigned int input1_channels,
-  unsigned int input1_width, unsigned int input1_height,
-  unsigned int input2_height) {
-
-  bool result = false;
-
-  do {
-    const auto &kernel_concat_ptr =
-      layer_kernel_ptrs[Kernels::CONCAT_CL_AXIS2_FP16];
-
-    int dim = int(input1_batch_size * input1_channels * input1_width *
-                  (input1_height + input2_height));
-
-    opencl::Buffer inputA(cl_context_ref.context_inst_,
-                          sizeof(__fp16) * input1_batch_size * input1_channels *
-                            input1_height * input1_width,
-                          true, nullptr);
-
-    opencl::Buffer inputX(cl_context_ref.context_inst_,
-                          sizeof(__fp16) * input1_batch_size * input1_channels *
-                            input2_height * input1_width,
-                          true, nullptr);
-
-    opencl::Buffer inOutY(cl_context_ref.context_inst_,
-                          sizeof(__fp16) * input1_batch_size * input1_channels *
                             (input1_height + input2_height) * input1_width,
                           true, nullptr);
 
@@ -968,11 +753,233 @@ void ConcatLayerCl::concat_cl_axis1(const float *matAdata,
   } while (false);
 }
 
-void ConcatLayerCl::concat_cl_axis1_fp16(
-  const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
-  unsigned int input1_batch_size, unsigned int input1_height,
-  unsigned int input1_width, unsigned int input1_channels,
-  unsigned int input2_channels) {
+#ifdef ENABLE_FP16
+void ConcatLayerCl::concat_cl_axis3_fp16(const _FP16 *matAdata,
+                                         const _FP16 *vecXdata, _FP16 *vecYdata,
+                                         unsigned int input1_batch_size,
+                                         unsigned int input1_channels,
+                                         unsigned int input1_height,
+                                         unsigned int input1_width,
+                                         unsigned int input2_width) {
+
+  bool result = false;
+
+  do {
+
+    const auto &kernel_concat_ptr =
+      layer_kernel_ptrs[Kernels::CONCAT_CL_AXIS3_FP16];
+
+    int dim = int(input1_batch_size * input1_channels * input1_height *
+                  (input1_width + input2_width));
+
+    opencl::Buffer inputA(cl_context_ref.context_inst_,
+                          sizeof(_FP16) * input1_batch_size * input1_channels *
+                            input1_height * input1_width,
+                          true, nullptr);
+
+    opencl::Buffer inputX(cl_context_ref.context_inst_,
+                          sizeof(_FP16) * input1_batch_size * input1_channels *
+                            input1_height * input2_width,
+                          true, nullptr);
+
+    opencl::Buffer inOutY(cl_context_ref.context_inst_,
+                          sizeof(_FP16) * input1_batch_size * input1_channels *
+                            input1_height * (input1_width + input2_width),
+                          true, nullptr);
+
+    result = inputA.WriteData(cl_context_ref.command_queue_inst_, matAdata);
+    if (!result) {
+      break;
+    }
+
+    result = inputX.WriteData(cl_context_ref.command_queue_inst_, vecXdata);
+    if (!result) {
+      break;
+    }
+
+    result = inOutY.WriteData(cl_context_ref.command_queue_inst_, vecYdata);
+    if (!result) {
+      break;
+    }
+
+    result = kernel_concat_ptr->SetKernelArguments(0, &inputA, sizeof(cl_mem));
+    if (!result) {
+      break;
+    }
+
+    result = kernel_concat_ptr->SetKernelArguments(1, &inputX, sizeof(cl_mem));
+    if (!result) {
+      break;
+    }
+
+    result = kernel_concat_ptr->SetKernelArguments(2, &inOutY, sizeof(cl_mem));
+    if (!result) {
+      break;
+    }
+
+    result =
+      kernel_concat_ptr->SetKernelArguments(3, &input1_batch_size, sizeof(int));
+    if (!result) {
+      break;
+    }
+
+    result =
+      kernel_concat_ptr->SetKernelArguments(4, &input1_channels, sizeof(int));
+    if (!result) {
+      break;
+    }
+
+    result =
+      kernel_concat_ptr->SetKernelArguments(5, &input1_height, sizeof(int));
+    if (!result) {
+      break;
+    }
+
+    result =
+      kernel_concat_ptr->SetKernelArguments(6, &input1_width, sizeof(int));
+    if (!result) {
+      break;
+    }
+
+    result =
+      kernel_concat_ptr->SetKernelArguments(7, &input2_width, sizeof(int));
+    if (!result) {
+      break;
+    }
+
+    const int work_groups_count[3] = {dim, 1, 1};
+    const int work_group_size[3] = {32, 32, 1}; // test-value
+
+    result = cl_context_ref.command_queue_inst_.DispatchCommand(
+      kernel_concat_ptr, work_groups_count, work_group_size);
+    if (!result) {
+      break;
+    }
+
+    result = inOutY.ReadData(cl_context_ref.command_queue_inst_, vecYdata);
+    if (!result) {
+      break;
+    }
+
+  } while (false);
+}
+
+void ConcatLayerCl::concat_cl_axis2_fp16(const _FP16 *matAdata,
+                                         const _FP16 *vecXdata, _FP16 *vecYdata,
+                                         unsigned int input1_batch_size,
+                                         unsigned int input1_channels,
+                                         unsigned int input1_width,
+                                         unsigned int input1_height,
+                                         unsigned int input2_height) {
+
+  bool result = false;
+
+  do {
+    const auto &kernel_concat_ptr =
+      layer_kernel_ptrs[Kernels::CONCAT_CL_AXIS2_FP16];
+
+    int dim = int(input1_batch_size * input1_channels * input1_width *
+                  (input1_height + input2_height));
+
+    opencl::Buffer inputA(cl_context_ref.context_inst_,
+                          sizeof(_FP16) * input1_batch_size * input1_channels *
+                            input1_height * input1_width,
+                          true, nullptr);
+
+    opencl::Buffer inputX(cl_context_ref.context_inst_,
+                          sizeof(_FP16) * input1_batch_size * input1_channels *
+                            input2_height * input1_width,
+                          true, nullptr);
+
+    opencl::Buffer inOutY(cl_context_ref.context_inst_,
+                          sizeof(_FP16) * input1_batch_size * input1_channels *
+                            (input1_height + input2_height) * input1_width,
+                          true, nullptr);
+
+    result = inputA.WriteData(cl_context_ref.command_queue_inst_, matAdata);
+    if (!result) {
+      break;
+    }
+
+    result = inputX.WriteData(cl_context_ref.command_queue_inst_, vecXdata);
+    if (!result) {
+      break;
+    }
+
+    result = inOutY.WriteData(cl_context_ref.command_queue_inst_, vecYdata);
+    if (!result) {
+      break;
+    }
+
+    result = kernel_concat_ptr->SetKernelArguments(0, &inputA, sizeof(cl_mem));
+    if (!result) {
+      break;
+    }
+
+    result = kernel_concat_ptr->SetKernelArguments(1, &inputX, sizeof(cl_mem));
+    if (!result) {
+      break;
+    }
+
+    result = kernel_concat_ptr->SetKernelArguments(2, &inOutY, sizeof(cl_mem));
+    if (!result) {
+      break;
+    }
+
+    result =
+      kernel_concat_ptr->SetKernelArguments(3, &input1_batch_size, sizeof(int));
+    if (!result) {
+      break;
+    }
+
+    result =
+      kernel_concat_ptr->SetKernelArguments(4, &input1_channels, sizeof(int));
+    if (!result) {
+      break;
+    }
+
+    result =
+      kernel_concat_ptr->SetKernelArguments(5, &input1_height, sizeof(int));
+    if (!result) {
+      break;
+    }
+
+    result =
+      kernel_concat_ptr->SetKernelArguments(6, &input2_height, sizeof(int));
+    if (!result) {
+      break;
+    }
+
+    result =
+      kernel_concat_ptr->SetKernelArguments(7, &input1_width, sizeof(int));
+    if (!result) {
+      break;
+    }
+
+    const int work_groups_count[3] = {dim, 1, 1};
+    const int work_group_size[3] = {32, 32, 1}; // test-value
+
+    result = cl_context_ref.command_queue_inst_.DispatchCommand(
+      kernel_concat_ptr, work_groups_count, work_group_size);
+    if (!result) {
+      break;
+    }
+
+    result = inOutY.ReadData(cl_context_ref.command_queue_inst_, vecYdata);
+    if (!result) {
+      break;
+    }
+
+  } while (false);
+}
+
+void ConcatLayerCl::concat_cl_axis1_fp16(const _FP16 *matAdata,
+                                         const _FP16 *vecXdata, _FP16 *vecYdata,
+                                         unsigned int input1_batch_size,
+                                         unsigned int input1_height,
+                                         unsigned int input1_width,
+                                         unsigned int input1_channels,
+                                         unsigned int input2_channels) {
 
   bool result = false;
 
@@ -985,17 +992,17 @@ void ConcatLayerCl::concat_cl_axis1_fp16(
                   (input1_channels + input2_channels));
 
     opencl::Buffer inputA(cl_context_ref.context_inst_,
-                          sizeof(__fp16) * input1_batch_size * input1_channels *
+                          sizeof(_FP16) * input1_batch_size * input1_channels *
                             input1_height * input1_width,
                           true, nullptr);
 
     opencl::Buffer inputX(cl_context_ref.context_inst_,
-                          sizeof(__fp16) * input1_batch_size * input2_channels *
+                          sizeof(_FP16) * input1_batch_size * input2_channels *
                             input1_height * input1_width,
                           true, nullptr);
 
     opencl::Buffer inOutY(cl_context_ref.context_inst_,
-                          sizeof(__fp16) * input1_batch_size * input1_width *
+                          sizeof(_FP16) * input1_batch_size * input1_width *
                             input1_height * (input1_channels + input2_channels),
                           true, nullptr);
 
@@ -1075,6 +1082,7 @@ void ConcatLayerCl::concat_cl_axis1_fp16(
 
   } while (false);
 }
+#endif
 
 void ConcatLayerCl::calcDerivative(RunLayerContext &context) {
   //   /**

--- a/nntrainer/layers/cl_layers/concat_cl.cpp
+++ b/nntrainer/layers/cl_layers/concat_cl.cpp
@@ -240,45 +240,73 @@ static constexpr size_t INPUT_IDX_1 = 0;
 static constexpr size_t INPUT_IDX_2 = 1;
 
 bool ConcatLayerCl::registerClKernels() {
-  ClContext::SharedPtrClKernel kernel_concat_ptr = nullptr;
 
-  kernel_concat_ptr =
-    cl_context_ref.registerClKernel(concat_cl_axis1_kernel_, "concat_cl_axis1");
-  NNTR_THROW_IF(!kernel_concat_ptr, std::runtime_error)
-    << "OpenCL Error: Fail to register concat_cl_axis1 kernel";
-  layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
+  // check if already registered
+  if (!layer_kernel_ptrs.empty())
+    return true;
 
-  kernel_concat_ptr =
-    cl_context_ref.registerClKernel(concat_cl_axis2_kernel_, "concat_cl_axis2");
-  NNTR_THROW_IF(!kernel_concat_ptr, std::runtime_error)
-    << "OpenCL Error: Fail to register concat_cl_axis2 kernel";
-  layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
+  do {
 
-  kernel_concat_ptr =
-    cl_context_ref.registerClKernel(concat_cl_axis3_kernel_, "concat_cl_axis3");
-  NNTR_THROW_IF(!kernel_concat_ptr, std::runtime_error)
-    << "OpenCL Error: Fail to register concat_cl_axis3 kernel";
-  layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
+    ClContext::SharedPtrClKernel kernel_concat_ptr = nullptr;
 
-  kernel_concat_ptr = cl_context_ref.registerClKernel(
-    concat_cl_axis1_kernel_fp16_, "concat_cl_axis1_fp16");
-  NNTR_THROW_IF(!kernel_concat_ptr, std::runtime_error)
-    << "OpenCL Error: Fail to register concat_cl_axis1_fp16 kernel";
-  layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
+    kernel_concat_ptr = cl_context_ref.registerClKernel(concat_cl_axis1_kernel_,
+                                                        "concat_cl_axis1");
+    if (!kernel_concat_ptr) {
+      ml_loge("OpenCL Error: Fail to register concat_cl_axis1 kernel");
+      break;
+    }
+    layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
 
-  kernel_concat_ptr = cl_context_ref.registerClKernel(
-    concat_cl_axis2_kernel_fp16_, "concat_cl_axis2_fp16");
-  NNTR_THROW_IF(!kernel_concat_ptr, std::runtime_error)
-    << "OpenCL Error: Fail to register concat_cl_axis2_fp16 kernel";
-  layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
+    kernel_concat_ptr = cl_context_ref.registerClKernel(concat_cl_axis2_kernel_,
+                                                        "concat_cl_axis2");
+    if (!kernel_concat_ptr) {
+      ml_loge("OpenCL Error: Fail to register concat_cl_axis2 kernel");
+      break;
+    }
+    layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
 
-  kernel_concat_ptr = cl_context_ref.registerClKernel(
-    concat_cl_axis3_kernel_fp16_, "concat_cl_axis3_fp16");
-  NNTR_THROW_IF(!kernel_concat_ptr, std::runtime_error)
-    << "OpenCL Error: Fail to register concat_cl_axis3_fp16 kernel";
-  layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
+    kernel_concat_ptr = cl_context_ref.registerClKernel(concat_cl_axis3_kernel_,
+                                                        "concat_cl_axis3");
+    if (!kernel_concat_ptr) {
+      ml_loge("OpenCL Error: Fail to register concat_cl_axis3 kernel");
+      break;
+    }
+    layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
 
-  return true;
+#ifdef ENABLE_FP16
+    kernel_concat_ptr = cl_context_ref.registerClKernel(
+      concat_cl_axis1_kernel_fp16_, "concat_cl_axis1_fp16");
+    if (!kernel_concat_ptr) {
+      ml_loge("OpenCL Error: Fail to register concat_cl_axis1_fp16 kernel");
+      break;
+    }
+    layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
+
+    kernel_concat_ptr = cl_context_ref.registerClKernel(
+      concat_cl_axis2_kernel_fp16_, "concat_cl_axis2_fp16");
+    if (!kernel_concat_ptr) {
+      ml_loge("OpenCL Error: Fail to register concat_cl_axis2_fp16 kernel");
+      break;
+    }
+    layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
+
+    kernel_concat_ptr = cl_context_ref.registerClKernel(
+      concat_cl_axis3_kernel_fp16_, "concat_cl_axis3_fp16");
+    if (!kernel_concat_ptr) {
+      ml_loge("OpenCL Error: Fail to register concat_cl_axis3_fp16 kernel");
+      break;
+    }
+    layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
+#endif
+
+    return true;
+
+  } while (false);
+
+  // clear all registered kernels if any error occurs during registration
+  layer_kernel_ptrs.clear();
+
+  return false;
 }
 
 void ConcatLayerCl::finalize(InitLayerContext &context) {

--- a/nntrainer/layers/cl_layers/concat_cl.h
+++ b/nntrainer/layers/cl_layers/concat_cl.h
@@ -19,7 +19,7 @@
 #include <common_properties.h>
 #include <layer_context.h>
 #include <layer_devel.h>
-#include <layer_impl.h>
+#include <layer_impl_cl.h>
 #include <opencl_buffer.h>
 #include <opencl_kernel.h>
 #include <tensor_dim.h>
@@ -31,10 +31,7 @@ namespace nntrainer {
  * @class   Concat Layer
  * @brief   Concat Layer
  */
-class ConcatLayerCl : public Layer {
-
-private:
-  inline static ClContext cl_context_ref;
+class ConcatLayerCl : public LayerImplCl {
 
 public:
   /**
@@ -104,14 +101,12 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "concat";
+  /**
+   * @brief registerClKernels
+   */
+  static bool registerClKernels();
 
-  static opencl::Kernel kernel_concat_axis3;
-  static opencl::Kernel kernel_concat_axis3_fp16;
-  static opencl::Kernel kernel_concat_axis2;
-  static opencl::Kernel kernel_concat_axis2_fp16;
-  static opencl::Kernel kernel_concat_axis1;
-  static opencl::Kernel kernel_concat_axis1_fp16;
+  inline static const std::string type = "concat";
 
   /**
    * @brief Process data and dimensions for concat
@@ -233,6 +228,18 @@ public:
 #endif
 private:
   std::tuple<props::ConcatDimension> concat_props;
+
+  inline static std::vector<ClContext::SharedPtrClKernel>
+    layer_kernel_ptrs; /** kernel list relevant with this layer */
+
+  enum Kernels {
+    CONCAT_CL_AXIS1,
+    CONCAT_CL_AXIS2,
+    CONCAT_CL_AXIS3,
+    CONCAT_CL_AXIS1_FP16,
+    CONCAT_CL_AXIS2_FP16,
+    CONCAT_CL_AXIS3_FP16,
+  };
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/cl_layers/fc_layer_cl.cpp
+++ b/nntrainer/layers/cl_layers/fc_layer_cl.cpp
@@ -29,7 +29,7 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 enum FCParams { weight, bias };
 
 FullyConnectedLayerCl::FullyConnectedLayerCl() :
-  LayerImpl(), fc_props(props::Unit()) {
+  LayerImplCl(), fc_props(props::Unit()) {
   weight_idx.fill(std::numeric_limits<unsigned>::max());
 }
 

--- a/nntrainer/layers/cl_layers/fc_layer_cl.h
+++ b/nntrainer/layers/cl_layers/fc_layer_cl.h
@@ -17,7 +17,7 @@
 #ifdef __cplusplus
 
 #include <common_properties.h>
-#include <layer_impl.h>
+#include <layer_impl_cl.h>
 
 namespace nntrainer {
 
@@ -25,7 +25,7 @@ namespace nntrainer {
  * @class   FullyConnecedLayer
  * @brief   fully connected layer
  */
-class FullyConnectedLayerCl : public LayerImpl {
+class FullyConnectedLayerCl : public LayerImplCl {
 public:
   /**
    * @brief     Constructor of Fully Connected Layer
@@ -101,12 +101,19 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
+  static bool registerClKernels() { return true; };
+
   inline static const std::string type = "fully_connected";
 
 private:
   std::tuple<props::Unit>
     fc_props; /**< fc layer properties : unit - number of output neurons */
   std::array<unsigned int, 2> weight_idx; /**< indices of the weights */
+
+  const static int num_layer_kernels = 0; /** < number of layer kernels */
+
+  static std::vector<ClContext::SharedPtrClKernel>
+    layer_kernel_ptrs; /**< kernel list relevant with this layer */
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/cl_layers/fc_layer_cl.h
+++ b/nntrainer/layers/cl_layers/fc_layer_cl.h
@@ -110,8 +110,6 @@ private:
     fc_props; /**< fc layer properties : unit - number of output neurons */
   std::array<unsigned int, 2> weight_idx; /**< indices of the weights */
 
-  const static int num_layer_kernels = 0; /** < number of layer kernels */
-
   static std::vector<ClContext::SharedPtrClKernel>
     layer_kernel_ptrs; /**< kernel list relevant with this layer */
 };

--- a/nntrainer/layers/cl_layers/layer_impl_cl.h
+++ b/nntrainer/layers/cl_layers/layer_impl_cl.h
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Eunju Yang <ej.yang@samsung.com>
+ *
+ * @file   layer_impl_cl.h
+ * @date   04 Nov 2024
+ * @brief  This is base Layer implementation class for OpenCL
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Eunju Yang <ej.yang@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * @details LayerImplCl forms the base class for all the opencl_layer with
+ * weights and bias parameters. LayerImpl provides parsing of properties like
+ * Weight/bias initializer and regularizers. LayerImpl also provides checks for
+ * double calls to finalize function. This is wrpper class of layer_impl for
+ * OpenCL.
+ */
+#ifndef __LAYER_IMPL_CL_H__
+#define __LAYER_IMPL_CL_H__
+#ifdef __cplusplus
+
+#include <cl_context.h>
+#include <layer_impl.h>
+
+namespace nntrainer {
+
+/**
+ * @class LayerImplCl
+ * @brief LayerImplCl
+ */
+class LayerImplCl : public LayerImpl {
+
+public:
+  /**
+   * @brief     Constructor of Layer Class
+   */
+  LayerImplCl() : LayerImpl(){};
+
+  /**
+   * @brief     Destructor of Layer Class
+   */
+  virtual ~LayerImplCl() = default;
+
+  /**
+   *  @brief  Move constructor of LayerImpl Layer.
+   *  @param[in] LayerImplCl &&
+   */
+  LayerImplCl(LayerImplCl &&rhs) noexcept = default;
+
+  /**
+   * @brief  Move assignment operator.
+   * @parma[in] rhs LayerImplCl to be moved.
+   */
+  LayerImplCl &operator=(LayerImplCl &&rhs) = default;
+
+  /**
+   * @brief     register ClKernels for this layer
+   * registerClKernels() is called in global ClContext.
+   */
+  static bool registerClKernels();
+
+protected:
+  inline static ClContext cl_context_ref;
+};
+
+} // namespace nntrainer
+
+#endif /** __cplusplus */
+#endif /** LAYER_IMPL_CL */

--- a/nntrainer/layers/cl_layers/reshape_cl.cpp
+++ b/nntrainer/layers/cl_layers/reshape_cl.cpp
@@ -52,8 +52,10 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 bool ReshapeLayerCl::registerClKernels() {
 
   // check if already registered
-  if (!layer_kernel_ptrs.empty())
-    return true;
+  if (!layer_kernel_ptrs.empty()) {
+    ml_loge("kernels for reshape layer are already registered");
+    return false;
+  }
 
   do {
     ClContext::SharedPtrClKernel kernel_copy_ptr = nullptr;

--- a/nntrainer/layers/cl_layers/reshape_cl.h
+++ b/nntrainer/layers/cl_layers/reshape_cl.h
@@ -18,6 +18,7 @@
 #include <cl_context.h>
 #include <common_properties.h>
 #include <layer_devel.h>
+#include <layer_impl_cl.h>
 #include <opencl_buffer.h>
 #include <opencl_kernel.h>
 
@@ -26,10 +27,7 @@ namespace nntrainer {
  * @class   Reshape Layer
  * @brief   Reshape Layer
  */
-class ReshapeLayerCl : public Layer {
-
-private:
-  inline static ClContext cl_context_ref;
+class ReshapeLayerCl : public LayerImplCl {
 
 public:
   /**
@@ -105,15 +103,17 @@ public:
 
   inline static const std::string type = "reshape";
 
-  static opencl::Kernel kernel_copy;
-  static opencl::Kernel kernel_copy_fp16;
-
   /**
    * @brief Process data and dimensions for reshape operation
    * @param[in] input Tensor
    * @param[in] result Tensor
    */
   void ReshapeProcess(Tensor const &input, Tensor &result);
+
+  /**
+   * @brief registerClKernels
+   */
+  static bool registerClKernels();
 
   /**
    * @brief     copy computation
@@ -145,9 +145,13 @@ public:
                     unsigned int input_height, unsigned int input_width);
 #endif
 
-protected:
+private:
   std::tuple<props::TargetShape>
     reshape_props; /**< reshape properties : target_shape after reshape */
+
+  inline static std::vector<ClContext::SharedPtrClKernel> layer_kernel_ptrs;
+
+  enum Kernels { COPY_CL, COPY_CL_FP16 };
 };
 
 } // namespace nntrainer

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -444,13 +444,11 @@ LOCAL_SRC_FILES := \
 	 ../unittest/layers/unittest_layers_impl.cpp \
 	 ../unittest/layers/unittest_layers_transpose_cl.cpp \
 	 ../unittest/layers/unittest_layers_concat_cl.cpp \
-	 ../unittest/layers/unittest_layers_swiglu_cl.cpp \
 	 ../unittest/layers/unittest_layers_fully_connected_cl.cpp \
 	 ../unittest/layers/unittest_layers_input.cpp \
 	 ../unittest/layers/unittest_layers_loss.cpp \
 	 ../unittest/layers/unittest_layers_reshape_cl.cpp \
 	 ../unittest/layers/unittest_layers_fully_connected.cpp \
-     ../unittest/layers/unittest_layers_rmsnorm_cl.cpp \
 	 ../unittest/layers/unittest_layers_batch_normalization.cpp \
 	 ../unittest/layers/unittest_layers_layer_normalization.cpp \
 	 ../unittest/layers/unittest_layers_convolution2d.cpp \

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -444,11 +444,13 @@ LOCAL_SRC_FILES := \
 	 ../unittest/layers/unittest_layers_impl.cpp \
 	 ../unittest/layers/unittest_layers_transpose_cl.cpp \
 	 ../unittest/layers/unittest_layers_concat_cl.cpp \
+	 ../unittest/layers/unittest_layers_swiglu_cl.cpp \
 	 ../unittest/layers/unittest_layers_fully_connected_cl.cpp \
 	 ../unittest/layers/unittest_layers_input.cpp \
 	 ../unittest/layers/unittest_layers_loss.cpp \
 	 ../unittest/layers/unittest_layers_reshape_cl.cpp \
 	 ../unittest/layers/unittest_layers_fully_connected.cpp \
+	 ../unittest/layers/unittest_layers_rmsnorm_cl.cpp \
 	 ../unittest/layers/unittest_layers_batch_normalization.cpp \
 	 ../unittest/layers/unittest_layers_layer_normalization.cpp \
 	 ../unittest/layers/unittest_layers_convolution2d.cpp \


### PR DESCRIPTION
- This draft is a suggestion for #2723
- This draft splits kernel registration from forwarding function.
- This draft make kernelPtr as static member of layer to avoid redundant kernel registration.
- This draft contains example update for `concat_cl` , `reshape_cl`, and `fc_layer_cl` only.

Self evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped