### PR TITLE
[ unittest ] Fix modelfile TCs @open sesame 11/07 16:09

### DIFF
--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -118,7 +118,6 @@ TEST_P(nntrainerIniTest, loadConfigTwice_n) {
 
 /**
  * @brief check given ini is failing/succeeding at init
- * @todo Fix : basic3_p, basic4_p, basic_act_p
  */
 TEST_P(nntrainerIniTest, init) {
   std::cout << std::get<0>(GetParam()) << std::endl;
@@ -157,7 +156,6 @@ TEST_P(nntrainerIniTest, init) {
 /**
  * @brief check given ini is failing/succeeding when init happens twice.
  * this should fail at all time.
- * @todo Fix basic3_p, basic4_p, basic_act_p
  */
 TEST_P(nntrainerIniTest, initTwice_n) {
   std::cout << std::get<0>(GetParam()) << std::endl;
@@ -357,12 +355,9 @@ GTEST_PARAMETER_TEST(
      mkIniTc("basic_act_p", {nw_base_cross, sgd, input + "-Activation", act_relu+"input_layers=inputlayer", out+"input_layers=activation_relu" }, SUCCESS),
      mkIniTc("basic_bn_p", {nw_base_cross, sgd, input + "-Activation", batch_normal+"input_layers=inputlayer", act_relu+"input_layers=bn", out+"input_layers=activation_relu" }, SUCCESS),
      mkIniTc("basic_bn2_p", {nw_base_cross, sgd, input + "-Activation", batch_normal + "Activation = relu"+"input_layers=inputlayer", out+"input_layers=bn" }, SUCCESS),
-    /**
-    * @todo Fail on Android loadConfig Test
-    */
-    //  mkIniTc("basic_dataset_p", {nw_base_cross, adam, dataset, input, out+"input_layers=inputlayer"}, SUCCESS),
-    //  mkIniTc("basic_dataset2_p", {nw_base_cross, sgd, input, out+"input_layers=inputlayer", dataset}, SUCCESS),
-    //  mkIniTc("basic_dataset3_p", {dataset, nw_base_cross, sgd, input, out+"input_layers=inputlayer"}, SUCCESS),
+     mkIniTc("basic_dataset_p", {nw_base_cross, adam, dataset, input, out+"input_layers=inputlayer"}, SUCCESS),
+     mkIniTc("basic_dataset2_p", {nw_base_cross, sgd, input, out+"input_layers=inputlayer", dataset}, SUCCESS),
+     mkIniTc("basic_dataset3_p", {dataset, nw_base_cross, sgd, input, out+"input_layers=inputlayer"}, SUCCESS),
      /**
       * @todo Fail on both PC and Android
       */
@@ -375,11 +370,8 @@ GTEST_PARAMETER_TEST(
     mkIniTc("no_testSet_p", {nw_base_cross, adam, dataset + "-TestData", input, out+"input_layers=inputlayer"}, SUCCESS),
     mkIniTc("no_validSet_p", {nw_base_cross, adam, dataset + "-ValidData", input, out+"input_layers=inputlayer"}, SUCCESS),
     mkIniTc("no_bufferSize_p", {nw_base_cross, adam, dataset + "-BufferSize", input, out+"input_layers=inputlayer"}, SUCCESS),
-    /**
-    * @todo Fail at Android loadConfig Test
-    */
-    //  mkIniTc("buffer_size_smaller_than_batch_size_p", {nw_base_cross, adam, dataset + "BufferSize=26", input, out+"input_layers=inputlayer"}, SUCCESS),
-    //  mkIniTc("buffer_size_smaller_than_batch_size2_p", {nw_base_cross, adam, input, out+"input_layers=inputlayer", dataset + "BufferSize=26"}, SUCCESS),
+     mkIniTc("buffer_size_smaller_than_batch_size_p", {nw_base_cross, adam, dataset + "BufferSize=26", input, out+"input_layers=inputlayer"}, SUCCESS),
+     mkIniTc("buffer_size_smaller_than_batch_size2_p", {nw_base_cross, adam, input, out+"input_layers=inputlayer", dataset + "BufferSize=26"}, SUCCESS),
      mkIniTc("loss_layer1_p", {nw_base, adam, input + "-Activation", out + "-Activation", loss_mse}, SUCCESS),
      mkIniTc("loss_layer2_p", {nw_base, adam, input + "-Activation", out, loss_mse}, SUCCESS),
      mkIniTc("loss_layer3_n", {nw_base, adam, input + "-Activation", out + "-Activation", loss_cross}, ALLFAIL),
@@ -587,40 +579,37 @@ TEST(nntrainerIniTest, backbone_07_p) {
 
 /**
  * @brief Ini file unittest with backbone with normal backbone
- * @todo Fail at NN.loadFromConfig(s.getIniName())
  */
-// TEST(nntrainerIniTest, backbone_08_n) {
-//   ScopedIni s("backbone_08_n", {nw_base_mse, adam,
-//   backbone_random_external});
+TEST(nntrainerIniTest, backbone_08_n) {
+  ScopedIni s("backbone_08_n", {nw_base_mse, adam, backbone_random_external});
 
-//   nntrainer::NeuralNetwork NN;
+  nntrainer::NeuralNetwork NN;
 
-// #if defined(ENABLE_NNSTREAMER_BACKBONE) || defined(ENABLE_TFLITE_BACKBONE)
-//   EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_NONE);
-//   EXPECT_EQ(NN.compile(), ML_ERROR_INVALID_PARAMETER);
-//   EXPECT_EQ(NN.initialize(), ML_ERROR_NOT_SUPPORTED);
-// #else
-//   EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_NOT_SUPPORTED);
-// #endif
-// }
+#if defined(ENABLE_NNSTREAMER_BACKBONE) || defined(ENABLE_TFLITE_BACKBONE)
+  EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_INVALID_PARAMETER);
+  EXPECT_EQ(NN.compile(), ML_ERROR_INVALID_PARAMETER);
+  EXPECT_EQ(NN.initialize(), ML_ERROR_NOT_SUPPORTED);
+#else
+  EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_INVALID_PARAMETER);
+#endif
+}
 
 /**
  * @brief Ini file unittest with backbone with normal backbone
- * @todo Fail on AndroidTest
  */
-// TEST(nntrainerIniTest, backbone_09_p) {
-//   ScopedIni s("backbone_09_p",
-//               {nw_base_mse + "-batch_size", adam, backbone_valid_external});
-//   nntrainer::NeuralNetwork NN;
+TEST(nntrainerIniTest, backbone_09_p) {
+  ScopedIni s("backbone_09_p",
+              {nw_base_mse + "-batch_size", adam, backbone_valid_external});
+  nntrainer::NeuralNetwork NN;
 
-// #if defined(ENABLE_NNSTREAMER_BACKBONE) || defined(ENABLE_TFLITE_BACKBONE)
-//   EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_NONE);
-//   EXPECT_EQ(NN.compile(), ML_ERROR_NONE);
-//   EXPECT_EQ(NN.initialize(), ML_ERROR_NONE);
-// #else
-//   EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_NOT_SUPPORTED);
-// #endif
-// }
+#if defined(ENABLE_NNSTREAMER_BACKBONE) || defined(ENABLE_TFLITE_BACKBONE)
+  EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_NONE);
+  EXPECT_EQ(NN.compile(), ML_ERROR_NONE);
+  EXPECT_EQ(NN.initialize(), ML_ERROR_NONE);
+#else
+  EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_INVALID_PARAMETER);
+#endif
+}
 
 /**
  * @brief Ini file unittest with backbone
@@ -727,20 +716,19 @@ TEST(nntrainerIniTest, backbone_20_p) {
 /**
  * @brief backbone is relative to original ini, if working directory is not set,
  * it should be referred relative to the .ini
- * @todo Fix TC to check invalid working directory and relative ini source
  */
-// TEST(nntrainerIniTest, backbone_relative_to_ini_p) {
-//   ScopedIni b{getResPath("base"), {nw_base_cross, batch_normal}};
-//   ScopedIni s{getResPath("original"),
-//               {nw_base_cross + "loss=mse", adam, input,
-//                backbone_valid + "input_layers=inputlayer"}};
+TEST(nntrainerIniTest, backbone_relative_to_ini_p) {
+  ScopedIni b{getResPath("base"), {nw_base_cross, batch_normal}};
+  ScopedIni s{getResPath("original"),
+              {nw_base_cross + "loss=mse", adam, input,
+               backbone_valid + "input_layers=inputlayer"}};
 
-//   nntrainer::NeuralNetwork NN;
+  nntrainer::NeuralNetwork NN;
 
-//   EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_NONE);
-//   EXPECT_EQ(NN.compile(), ML_ERROR_NONE);
-//   EXPECT_EQ(NN.initialize(), ML_ERROR_NONE);
-// }
+  EXPECT_EQ(NN.loadFromConfig(s.getIniName()), ML_ERROR_NONE);
+  EXPECT_EQ(NN.compile(), ML_ERROR_NONE);
+  EXPECT_EQ(NN.initialize(), ML_ERROR_NONE);
+}
 
 /**
  * @brief backbone is at different directory, if working directory is not set,

--- a/test/unittest/unittest_nntrainer_modelfile.cpp
+++ b/test/unittest/unittest_nntrainer_modelfile.cpp
@@ -371,10 +371,7 @@ GTEST_PARAMETER_TEST(
     //  mkIniTc("basic_train_valid_p", {dataset, nw_base_cross, sgd, input, out+"input_layers=inputlayer", train_set, valid_set}, SUCCESS),
     //  mkIniTc("basic_all_p", {dataset, nw_base_cross, test_set, sgd, input, out+"input_layers=inputlayer", train_set, valid_set}, SUCCESS),
     //  mkIniTc("basic_test_train_valid_p", {dataset, nw_base_cross, test_set, sgd, input, out+"input_layers=inputlayer", train_set, valid_set}, SUCCESS),
-     mkIniTc("basic_conv2d_p", {nw_base_cross, adam, conv2d + "input_shape = 1:10:10"}, SUCCESS),
-     /**
-      * @todo Fail on Android loadConfig Test
-      */
+    mkIniTc("basic_conv2d_p", {nw_base_cross, adam, conv2d + "input_shape = 1:10:10"}, SUCCESS),
     mkIniTc("no_testSet_p", {nw_base_cross, adam, dataset + "-TestData", input, out+"input_layers=inputlayer"}, SUCCESS),
     mkIniTc("no_validSet_p", {nw_base_cross, adam, dataset + "-ValidData", input, out+"input_layers=inputlayer"}, SUCCESS),
     mkIniTc("no_bufferSize_p", {nw_base_cross, adam, dataset + "-BufferSize", input, out+"input_layers=inputlayer"}, SUCCESS),
@@ -466,7 +463,6 @@ TEST(nntrainerIniTest, backbone_02_n) {
 
 /**
  * @brief Ini file unittest with backbone with normal backbone
- * @todo Fail at NN.loadFromConfig(s.getIniName())
  */
 TEST(nntrainerIniTest, backbone_03_p) {
   ScopedIni b{"base", {nw_base_cross, batch_normal}};
@@ -489,7 +485,6 @@ TEST(nntrainerIniTest, backbone_04_p) {
 
 /**
  * @brief Ini file unittest matching model with and without backbone
- * @todo Fail at different layer names : "conv2d" vs "block1conv2d"
  */
 TEST(nntrainerIniTest, backbone_05_p) {
 
@@ -695,7 +690,6 @@ TEST(nntrainerIniTest, backbone_17_p) {
 /**
  * @brief Ini file unittest with backbone
  * @note Input layer name not found, empty backbone
- * @todo fix this testcase to check unknown input layer name
  */
 TEST(nntrainerIniTest, backbone_19_n) {
   nntrainer::NeuralNetwork NN;
@@ -712,8 +706,6 @@ TEST(nntrainerIniTest, backbone_19_n) {
 /**
  * @brief Ini file unittest with backbone
  * @note input and output layer specified are found
- * @todo C++ exception with description "Failed to initialize: in size + padding
- * is smaller than effective kernel" thrown in the test body.
  */
 TEST(nntrainerIniTest, backbone_20_p) {
   nntrainer::NeuralNetwork NN;
@@ -753,7 +745,6 @@ TEST(nntrainerIniTest, backbone_20_p) {
 /**
  * @brief backbone is at different directory, if working directory is not set,
  * it should be referred relative to the .ini
- * @todo Fail on Android
  */
 TEST(nntrainerIniTest, backbone_from_different_directory_n) {
   ScopedIni b{"base", {nw_base_cross, batch_normal}};


### PR DESCRIPTION
- `backbone_relative_to_ini_p` : fix invalid bn layer param
- `backbone_08_n` : insufficient init parameters should fail, thus wrong test status
- `backbone_09_n` : current loadFromConfig does not return `ML_ERROR_NOT_SUPPORTED`. Think this is deprecated. Instead, `ML_INVALID_PARAM` is thrown in current version
- `buffer_size_smaller_than_batch_size_p`, `buffer_size_smaller_than_batch_size_2p` : missing res directory
- `basic_dataset_p`, `basic_dataset2_p`, `basic_dataset3_p`: missing res directory

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: skykongkong8 <ss.kong@samsung.com>