### PR TITLE
[Graph] rename variable & function names for clarity @open sesame 11/07 21:30

### DIFF
--- a/Applications/Custom/mae_loss.cpp
+++ b/Applications/Custom/mae_loss.cpp
@@ -27,7 +27,7 @@ void MaeLossLayer::forwarding(nntrainer::RunLayerContext &context,
   nntrainer::Tensor &predicted = context.getInput(SINGLE_INOUT_IDX);
   nntrainer::Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
 
-  if (!context.executeInPlace())
+  if (!context.getInPlace())
     output.fill(predicted);
 }
 

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -609,7 +609,7 @@ private:
    *
    * @return the mode of inplace for the layer
    */
-  InPlace canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode);
+  InPlaceType canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode);
 
   /**
    * @brief compute optimized backward end. This function calculated the valid

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -760,7 +760,7 @@ public:
    *
    * @param val True if execute in-place, else false
    */
-  void executeInPlace(bool val) {
+  void setInPlace(bool val) {
     if (val && !supportInPlace())
       throw std::runtime_error(
         "Error setting activation layer to work in-place");

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -32,8 +32,7 @@
 
 namespace nntrainer {
 ActivationLayer::ActivationLayer() :
-  Layer(),
-  activation_props(new PropTypes(props::Activation())) {
+  Layer(), activation_props(new PropTypes(props::Activation())) {
   acti_func.setActiFunc(ActivationType::ACT_NONE);
 }
 
@@ -65,7 +64,7 @@ void ActivationLayer::finalize(InitLayerContext &context) {
     InitLayerContext::outSpec(context.getInputDimensions()[0], "out",
                               TensorLifespan::FORWARD_DERIV_LIFESPAN));
   context.requestOutputs(std::move(out_specs));
-  acti_func.executeInPlace(context.executeInPlace());
+  acti_func.setInPlace(context.getInPlace());
 }
 
 void ActivationLayer::forwarding(RunLayerContext &context, bool training) {

--- a/nntrainer/layers/cl_layers/reshape_cl.cpp
+++ b/nntrainer/layers/cl_layers/reshape_cl.cpp
@@ -75,7 +75,7 @@ void ReshapeLayerCl::finalize(InitLayerContext &context) {
 }
 
 void ReshapeLayerCl::forwarding(RunLayerContext &context, bool training) {
-  if (!context.executeInPlace()) {
+  if (!context.getInPlace()) {
     Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
     const Tensor &input = context.getInput(SINGLE_INOUT_IDX);
     ReshapeProcess(input, output);
@@ -85,7 +85,7 @@ void ReshapeLayerCl::forwarding(RunLayerContext &context, bool training) {
 void ReshapeLayerCl::incremental_forwarding(RunLayerContext &context,
                                             unsigned int from, unsigned int to,
                                             bool training) {
-  if (!context.executeInPlace()) {
+  if (!context.getInPlace()) {
     Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
     const Tensor &input = context.getInput(SINGLE_INOUT_IDX);
     if (from) {
@@ -294,7 +294,7 @@ void ReshapeLayerCl::copy_cl(const float *input, float *res,
 }
 
 void ReshapeLayerCl::calcDerivative(RunLayerContext &context) {
-  if (!context.executeInPlace()) {
+  if (!context.getInPlace()) {
     context.getOutgoingDerivative(SINGLE_INOUT_IDX)
       .copyData(context.getIncomingDerivative(SINGLE_INOUT_IDX));
   }

--- a/nntrainer/layers/identity_layer.cpp
+++ b/nntrainer/layers/identity_layer.cpp
@@ -26,7 +26,7 @@ void IdentityLayer::finalize(InitLayerContext &context) {
 }
 
 void IdentityLayer::forwarding(RunLayerContext &context, bool training) {
-  if (!context.executeInPlace()) {
+  if (!context.getInPlace()) {
     for (unsigned int i = 0, sz = context.getNumInputs(); i < sz; ++i) {
       Tensor &input_ = context.getInput(i);
       Tensor &hidden_ = context.getOutput(i);
@@ -36,7 +36,7 @@ void IdentityLayer::forwarding(RunLayerContext &context, bool training) {
 }
 
 void IdentityLayer::calcDerivative(RunLayerContext &context) {
-  if (!context.executeInPlace()) {
+  if (!context.getInPlace()) {
     for (unsigned int i = 0, sz = context.getNumInputs(); i < sz; ++i) {
       const Tensor &d_hidden = context.getIncomingDerivative(i);
       Tensor &d_input = context.getOutgoingDerivative(i);

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -46,7 +46,7 @@ void InputLayer::setProperty(const std::vector<std::string> &values) {
 
 void InputLayer::forwarding(RunLayerContext &context, bool training) {
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
-  if (!context.executeInPlace()) {
+  if (!context.getInPlace()) {
     Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
     hidden_.copyData(input_);
   }

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -383,7 +383,7 @@ public:
    *
    * @return true if in-place, else false
    */
-  bool executeInPlace() const { return in_place; }
+  bool getInPlace() const { return in_place; }
 
   /**
    * @brief   get Initial value of Loss_Scale. This is set to RunLayerContext
@@ -889,7 +889,7 @@ public:
    *
    * @return true if in-place, else false
    */
-  bool executeInPlace() const { return in_place; }
+  bool getInPlace() const { return in_place; }
 
   /**
    * @brief   get layer weights

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -186,7 +186,7 @@ createLayerNode(std::unique_ptr<nntrainer::Layer> &&layer,
 
 LayerNode::LayerNode(std::unique_ptr<nntrainer::Layer> &&l) :
   layer(std::move(l)),
-  inplace(InPlace::NONE),
+  inplace_type(InPlaceType::NONE),
   needs_calc_derivative(false),
   needs_calc_gradient(false),
 
@@ -689,8 +689,8 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
   }
 
   auto context = InitLayerContext(
-    actual_input_dims, out_info, executeInPlace() != InPlace::NONE, getName(),
-    scope, max_norm, tensor_type, loss_scale, mode);
+    actual_input_dims, out_info, getInPlaceType() != InPlaceType::NONE,
+    getName(), scope, max_norm, tensor_type, loss_scale, mode);
 
   layer->finalize(context);
 
@@ -782,8 +782,8 @@ LayerNode::refinalize(const std::vector<TensorDim> &input_dims) {
   }
 
   auto context = InitLayerContext(actual_input_dims, out_info,
-                                  executeInPlace() != InPlace::NONE, getName(),
-                                  scope, max_norm);
+                                  getInPlaceType() != InPlaceType::NONE,
+                                  getName(), scope, max_norm);
 
   layer->finalize(context);
 
@@ -814,7 +814,7 @@ void LayerNode::forwarding(bool training) {
 
   PROFILE_TIME_START(forward_event_key);
   if (reStoreData()) {
-    if (executeInPlace() == InPlace::NONE) {
+    if (getInPlaceType() == InPlaceType::NONE) {
       for (unsigned int i = 0; i < run_context->getNumOutputs(); ++i) {
         run_context->getOutput(i).setValue(0);
         if (!run_context->getOutputGradUnsafe(i).isValid())
@@ -947,7 +947,7 @@ void LayerNode::configureRunContext(const std::vector<Weight *> &weights,
                                     const std::vector<Var_Grad *> &tensors,
                                     float loss_scale) {
   run_context = std::make_unique<RunLayerContext>(
-    getName(), getTrainable(), 0.0f, executeInPlace() != InPlace::NONE,
+    getName(), getTrainable(), 0.0f, getInPlaceType() != InPlaceType::NONE,
     loss_scale, false, weights, inputs, outputs, tensors);
 }
 

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -59,7 +59,7 @@ class LossScaleForMixed;
  * @brief Enum class for the various types of inplace modes supported by layer
  *
  */
-enum class InPlace {
+enum class InPlaceType {
   NONE,           /**< layer is not inplace */
   RESTRICTING,    /**< layer is in-place and does place restriction on layers
                     ahead of it to be in-place */
@@ -370,19 +370,19 @@ public:
    *
    * @param val in place state for the layer
    */
-  void executeInPlace(InPlace val) {
-    if (val != InPlace::NONE && !supportInPlace())
+  void setInPlaceType(InPlaceType val) {
+    if (val != InPlaceType::NONE && !supportInPlace())
       throw std::runtime_error("Error setting layer to work in-place");
 
-    inplace = val;
+    inplace_type = val;
   }
 
   /**
    * @brief   Get if the layer is going to execute in-place
    *
-   * @return InPlace type for the layer
+   * @return Inplace type for the layer
    */
-  InPlace executeInPlace() const { return inplace; }
+  InPlaceType getInPlaceType() const { return inplace_type; }
 
   /**
    * @brief  check if this layer requires label to be passed
@@ -967,8 +967,8 @@ private:
   std::unique_ptr<nntrainer::Layer>
     layer; /**< The actual object in the graph node */
 
-  InPlace
-    inplace; /**< store if the current layer is going to operate in-place */
+  InPlaceType inplace_type; /**< store if the current layer is going to operate
+                               in-place */
   bool needs_calc_derivative; /**< cache if this layer needs to do
                                  calcDerivative */
   bool needs_calc_gradient; /**< cache if this layer needs to do calcGradient */

--- a/nntrainer/layers/multiout_layer.cpp
+++ b/nntrainer/layers/multiout_layer.cpp
@@ -31,7 +31,7 @@ void MultiOutLayer::finalize(InitLayerContext &context) {
 }
 
 void MultiOutLayer::forwarding(RunLayerContext &context, bool training) {
-  if (!context.executeInPlace()) {
+  if (!context.getInPlace()) {
     const Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
     for (unsigned int idx = 0; idx < context.getNumOutputs(); ++idx) {
       context.getOutput(idx).fill(input_);
@@ -42,7 +42,7 @@ void MultiOutLayer::forwarding(RunLayerContext &context, bool training) {
 void MultiOutLayer::incremental_forwarding(RunLayerContext &context,
                                            unsigned int from, unsigned int to,
                                            bool training) {
-  if (!context.executeInPlace()) {
+  if (!context.getInPlace()) {
     if (from) {
       NNTR_THROW_IF(to - from != 1, std::invalid_argument)
         << "incremental step size is not 1";

--- a/nntrainer/layers/reshape_layer.cpp
+++ b/nntrainer/layers/reshape_layer.cpp
@@ -47,14 +47,14 @@ void ReshapeLayer::finalize(InitLayerContext &context) {
 }
 
 void ReshapeLayer::forwarding(RunLayerContext &context, bool training) {
-  if (!context.executeInPlace()) {
+  if (!context.getInPlace()) {
     context.getOutput(SINGLE_INOUT_IDX)
       .copyData(context.getInput(SINGLE_INOUT_IDX));
   }
 }
 
 void ReshapeLayer::calcDerivative(RunLayerContext &context) {
-  if (!context.executeInPlace()) {
+  if (!context.getInPlace()) {
     context.getOutgoingDerivative(SINGLE_INOUT_IDX)
       .copyData(context.getIncomingDerivative(SINGLE_INOUT_IDX));
   }

--- a/nntrainer/layers/time_dist.cpp
+++ b/nntrainer/layers/time_dist.cpp
@@ -123,7 +123,7 @@ void TimeDistLayer::finalize(InitLayerContext &context) {
    */
   TensorDim dist_dim = input_dim;
   dist_dim.height(1);
-  InitLayerContext dist_context({dist_dim}, {}, context.executeInPlace(),
+  InitLayerContext dist_context({dist_dim}, {}, context.getInPlace(),
                                 context.getName());
 
   // During forwarding and backwarding, it set the input and output buffer of
@@ -255,7 +255,7 @@ void TimeDistLayer::forwarding(RunLayerContext &context, bool training) {
 
     RunLayerContext dist_context(
       context.getName(), context.getTrainable(), context.getLoss(),
-      context.executeInPlace(), context.getLossScale(), false,
+      context.getInPlace(), context.getLossScale(), false,
       getWeightsForContext(), {&in_var}, {&out_var}, getTensorsForContext());
 
     dist_layer->forwarding(dist_context, training);
@@ -302,7 +302,7 @@ void TimeDistLayer::calcDerivative(RunLayerContext &context) {
 
     RunLayerContext dist_context(
       context.getName(), context.getTrainable(), context.getLoss(),
-      context.executeInPlace(), context.getLossScale(), false,
+      context.getInPlace(), context.getLossScale(), false,
       getWeightsForContext(), {&in_var}, {&out_var}, getTensorsForContext());
 
     dist_layer->calcDerivative(dist_context);
@@ -353,7 +353,7 @@ void TimeDistLayer::calcGradient(RunLayerContext &context) {
 
     RunLayerContext dist_context(
       context.getName(), context.getTrainable(), context.getLoss(),
-      context.executeInPlace(), context.getLossScale(), false,
+      context.getInPlace(), context.getLossScale(), false,
       getWeightsForContext(), {&in_var}, {&out_var}, getTensorsForContext());
 
     dist_layer->calcGradient(dist_context);
@@ -395,7 +395,7 @@ void TimeDistLayer::setBatch(RunLayerContext &context, unsigned int batch) {
 
     RunLayerContext dist_context(
       context.getName(), context.getTrainable(), context.getLoss(),
-      context.executeInPlace(), context.getLossScale(), false,
+      context.getInPlace(), context.getLossScale(), false,
       getWeightsForContext(), {&in_var}, {&out_var}, getTensorsForContext());
 
     dist_layer->setBatch(dist_context, batch);


### PR DESCRIPTION
currently, same term 'InPlace' is used with different meanings by script.

it could refer to a boolean type value indicating whether in-place operation is supported, or it could refer an enum type value representing the in-place type(type: None, Restriction, Non-Restriction).

To clarify this distinction, variables and functions related to the in-place type have been renamed from 'InPlace' to 'InPlaceType'.

Similarly, both functions for getting/setting whether it supports inplace (boolean) and those for getting/setting the type of inplace (enum) use the same name, "executeInPlace".

To clarify this, I've changed the names as follows..
- set the in-place flag (boolean) : 'executeInPlace' -> 'setInPlace'.
- get the in-place flag (boolean) : 'executeInPlace' -> 'getInplace'.
- set the type of in-place (enum) : 'executeInPlace' -> 'setInPlaceType'
- get the type of in-place (enum) : 'executeInPlace' -> 'getInPlaceType.'

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped