### PR TITLE
[Network] fix canExecuteInPlace logic

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -695,7 +695,7 @@ NetworkGraph::canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode) {
       return InPlace::NONE;
   }
 
-  return InPlace::NONE;
+  return InPlace::NON_RESTRICTING;
 }
 
 void NetworkGraph::inPlaceOptimize() {


### PR DESCRIPTION
currenly, there is an issue where in-place might not be applied even if you set supportInplace to true in the layer-node. Regarding this, I think that there is a issue with the "canExecuteInPlace" function which determines the type of in-place.

The logic of this function is as follows:
- step 1. If the supportInPlace property of the layer node is set to false, in-place is disabled.
- step 2. If the supportInPlace property of the layer node is set to true, decide whether to execute restricting_inplace or non_restricting_inplace through various conditional statements.
- step 3. If they do not meet "#2"'s conditions, in-place is disabled.

However, even though supportInPlace is set to true in layerNode, there could be situations where it doesn't satisfy the requirements mentioned in "step 2".

For example, in the condition "if there is no operation in the layer or it does not support backwarding," it decides whether to execute restricting_inplace or non_restricting_inplace depending on the connection relationship between the layers.

However, if an "add layer" is added, since the layer has operations and supports backwarding, it does not correspond to the above conditions at all, so even if supportInPlace is set to true, in-place may not set to restricting_inplace or non_restricting_inplace.

So I suggest modifying "step 3" as follows: "If they do not meet "step 2"'s conditions, non-restricting-inplace is enabled."
Wouldn't it be better to add "step 2" only when exception handling is required?

In summary, at the last step of this function, since the in-place option is turned on and it does not meet the conditions where inplace needs to be forcibly turned off or a restricting-inplace operation should be performed, I suggest to execute non-restricting-inplace in this case.

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped