### PR TITLE
[ blas ] Custom-defined scopy functions : aarch64, armv7, x86, incremental indices

### DIFF
--- a/nntrainer/tensor/blas_avx.cpp
+++ b/nntrainer/tensor/blas_avx.cpp
@@ -274,4 +274,19 @@ bool isValid(const size_t N, const float *input) {
   return true;
 }
 
+void custom_scopy(const unsigned int N, const float *X, const int incX,
+                  float *Y, const int incY) {
+  unsigned int N8 = (N >> 3) << 3;
+  for (unsigned int i = 0; i < N8; i += 8) {
+    __asm__ __volatile__("vmovups (%1), %%ymm0\n\t"
+                         "vmovups %%ymm0, (%0)\n\t"
+                         :
+                         : "r"(&Y[i]), "r"(&X[i])
+                         : "ymm0", "memory");
+  }
+  for (unsigned int i = N8; i < N; ++i) {
+    Y[i] = X[i];
+  }
+}
+
 } // namespace nntrainer::avx

--- a/nntrainer/tensor/blas_avx.h
+++ b/nntrainer/tensor/blas_avx.h
@@ -60,6 +60,16 @@ bool isValid(const size_t N, const _Float16 *X);
  */
 bool isValid(const size_t N, const float *X);
 
+/**
+ * @brief cblas_scopy occasionally emits SIGSEGV, so implement a custom version.
+ *
+ * @param N length of the vector
+ * @param X float * for Vector X (input)
+ * @param Y float * for Vector Y (output)
+ */
+void custom_scopy(const unsigned int N, const float *X, const int incX,
+                  float *Y, const int incY);
+
 } // namespace nntrainer::avx
 
 #endif /* __cplusplus */

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -15,7 +15,6 @@
 #include <blas_neon.h>
 #include <blas_neon_setting.h>
 #include <hgemm.h>
-#include <iostream>
 #include <memory>
 #include <nntrainer_error.h>
 
@@ -600,9 +599,9 @@ void custom_scopy(const unsigned int N, const float *X, const int incX,
     __asm__ __volatile__("ld1 {v0.4s}, [%1]\n\t"
                          "st1 {v0.4s}, [%0]\n\t"
                          :
-                         : "+r"(&Y[i]), "+r"(&X[i])
+                         : "r"(&Y[i]), "r"(&X[i])
                          : "v0", "memory");
-#elif
+#else
     __scopy_kernel(N, X + i, Y + i);
 #endif
   }

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -157,6 +157,16 @@ void ele_div(const unsigned N, const float *X, const float *Y, float *Z,
  */
 bool isValid(const size_t N, const float *input);
 
+/**
+ * @brief cblas_scopy occasionally emits SIGSEGV, so implement a custom version.
+ *
+ * @param N length of the vector
+ * @param X float * for Vector X (input)
+ * @param Y float * for Vector Y (output)
+ */
+void custom_scopy(const unsigned int N, const float *X, const int incX,
+                  float *Y, const int incY);
+
 #ifdef ENABLE_FP16
 /**
  * @brief     hgemv computation with neon : Y = alpha*A*X + beta*Y


### PR DESCRIPTION
- Using traditional cblas_scopy is causing some segfault in some cases.
- Implement custom scopy function to avoid this issue.

### X86 (AVX2 asm)

> TC = 20, unit : microseconds 

| dim | intrinsic | cblas | asm | loop |
| --- | --- | --- | --- | --- |
| 3x1x768x768 | 567.384 | 238.796 | 346.572 | 1438.179 |


### aarch64 (NEON asm), armv7l (NEON intrinsic)

> TC = 20, unit : microseconds

| dim | intrinsic | cblas | asm | loop |
| --- | --- | --- | --- | --- |
| 3x1x768x768 | 224.382 | 210.520 | 213.494 | 655.476 |

This is my first time coding in inline asm style, so there might be a little bit of awkwardness. Please review carefully.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped