### PR TITLE
[trivial] remove unused function (initialize func of layer)

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -136,11 +136,6 @@ public:
   virtual const std::string getType() const = 0;
 
   /**
-   * @brief Initialize layer
-   */
-  virtual void initialize() = 0;
-
-  /**
    * @brief     Default allowed properties
    * - input shape : string
    * - bias zero : bool

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -161,11 +161,6 @@ public:
   virtual void finalize(InitLayerContext &context) = 0;
 
   /**
-   * @brief    Initialize the layer
-   */
-  virtual void initialize(RunLayerContext &context){};
-
-  /**
    * @brief     Forward Propagation of a layer
    * @param     context Context of the layer
    * @param     training true if training, false if inference

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -300,8 +300,6 @@ public:
    */
   InitLayerContext refinalize(const std::vector<TensorDim> &input_dims = {});
 
-  void initialize() override { layer->initialize(*run_context); }
-
   /**
    * @brief     Forward Propagation of a layer
    * @param     training true if training, false if inference


### PR DESCRIPTION
remove initialize functions of layer, layer_node and layer_devel.
because it have been replaced to finalize functions (renamed)

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped