### PR TITLE
[lr] Add Linear Learning Rate Scheduler

### DIFF
--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -55,6 +55,7 @@
 #include <lr_scheduler_constant.h>
 #include <lr_scheduler_cosine.h>
 #include <lr_scheduler_exponential.h>
+#include <lr_scheduler_linear.h>
 #include <lr_scheduler_step.h>
 #include <lstm.h>
 #include <lstmcell.h>
@@ -251,6 +252,9 @@ static void add_default_object(AppContext &ac) {
                        CosineAnnealingLearningRateScheduler>,
                      CosineAnnealingLearningRateScheduler::type,
                      LRType::COSINE);
+  ac.registerFactory(
+    ml::train::createLearningRateScheduler<LinearLearningRateScheduler>,
+    LinearLearningRateScheduler::type, LRType::LINEAR);
 
   using LayerType = ml::train::LayerType;
   ac.registerFactory(nntrainer::createLayer<InputLayer>, InputLayer::type,

--- a/nntrainer/optimizers/lr_scheduler.h
+++ b/nntrainer/optimizers/lr_scheduler.h
@@ -96,7 +96,7 @@ public:
    * Linear Learning rate scheduler
    * - max_learning_rate : float
    * - min_learning_rate : float
-   * - decay_steps : float
+   * - decay_steps : positive integer
    *
    * more to be added
    */

--- a/nntrainer/optimizers/lr_scheduler.h
+++ b/nntrainer/optimizers/lr_scheduler.h
@@ -30,7 +30,8 @@ enum LearningRateSchedulerType {
   CONSTANT = 0, /**< constant */
   EXPONENTIAL,  /**< exponentially decay */
   STEP,         /**< step wise decay */
-  COSINE        /**< cosine annealing */
+  COSINE,       /**< cosine annealing */
+  LINEAR        /**< linear decay */
 };
 
 /**
@@ -88,6 +89,11 @@ public:
    * - decay_steps : float,
    *
    * Cosine Annealing Learning rate scheduler
+   * - max_learning_rate : float
+   * - min_learning_rate : float
+   * - decay_steps : float
+   *
+   * Linear Learning rate scheduler
    * - max_learning_rate : float
    * - min_learning_rate : float
    * - decay_steps : float

--- a/nntrainer/optimizers/lr_scheduler_linear.cpp
+++ b/nntrainer/optimizers/lr_scheduler_linear.cpp
@@ -35,6 +35,9 @@ void LinearLearningRateScheduler::finalize() {
   NNTR_THROW_IF(std::get<props::DecaySteps>(lr_props).empty(),
                 std::invalid_argument)
     << "[LinearLearningRateScheduler] Decay Steps is not set";
+  NNTR_THROW_IF(std::get<props::DecaySteps>(lr_props) <= 0,
+                std::invalid_argument)
+    << "[LinearLearningRateScheduler] Decay Steps must be a positive integer";
 }
 
 void LinearLearningRateScheduler::setProperty(

--- a/nntrainer/optimizers/lr_scheduler_linear.cpp
+++ b/nntrainer/optimizers/lr_scheduler_linear.cpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Hyunwoo LEE <dlgusdn0414@snu.ac.kr>
+ *
+ * @file   lr_scheduler_linear.cpp
+ * @date   11 November 2024
+ * @brief  This is Linear Learning Rate Scheduler class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Hyunwoo LEE <dlgusdn0414@snu.ac.kr>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#include <cmath>
+
+#include <common_properties.h>
+#include <lr_scheduler_linear.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <node_exporter.h>
+
+namespace nntrainer {
+
+LinearLearningRateScheduler::LinearLearningRateScheduler() :
+  lr_props(props::MaxLearningRate(), props::MinLearningRate(),
+           props::DecaySteps()) {}
+
+void LinearLearningRateScheduler::finalize() {
+  NNTR_THROW_IF(std::get<props::MaxLearningRate>(lr_props).empty(),
+                std::invalid_argument)
+    << "[LinearLearningRateScheduler] Max Learning Rate is not set";
+  NNTR_THROW_IF(std::get<props::MinLearningRate>(lr_props).empty(),
+                std::invalid_argument)
+    << "[LinearLearningRateScheduler] Min Learning Rate is not set";
+  NNTR_THROW_IF(std::get<props::DecaySteps>(lr_props).empty(),
+                std::invalid_argument)
+    << "[LinearLearningRateScheduler] Decay Steps is not set";
+}
+
+void LinearLearningRateScheduler::setProperty(
+  const std::vector<std::string> &values) {
+  auto left = loadProperties(values, lr_props);
+  NNTR_THROW_IF(left.size(), std::invalid_argument)
+    << "[LinearLearningRateScheduler] There are unparsed properties";
+}
+
+void LinearLearningRateScheduler::exportTo(
+  Exporter &exporter, const ml::train::ExportMethods &method) const {
+  exporter.saveResult(lr_props, method, this);
+}
+
+double LinearLearningRateScheduler::getLearningRate(size_t iteration) {
+  auto const &max_lr = std::get<props::MaxLearningRate>(lr_props);
+  auto const &min_lr = std::get<props::MinLearningRate>(lr_props);
+  auto const &decay_steps = std::get<props::DecaySteps>(lr_props);
+
+  // Linear formula
+  double lr = max_lr - (max_lr - min_lr) * (iteration / (double)decay_steps);
+
+  return std::max(lr, (double)min_lr);
+}
+
+} // namespace nntrainer

--- a/nntrainer/optimizers/lr_scheduler_linear.h
+++ b/nntrainer/optimizers/lr_scheduler_linear.h
@@ -37,12 +37,12 @@ public:
   /**
    * @copydoc LearningRateScheduler::getLearningRate(size_t iteration) const
    */
-  virtual double getLearningRate(size_t iteration) override;
+  double getLearningRate(size_t iteration) override;
 
   /**
    * @copydoc LearningRateScheduler::finalize()
    */
-  virtual void finalize() override;
+  void finalize() override;
 
   /**
    * @copydoc LearningRateScheduler::exportTo(Exporter &exporter, const

--- a/nntrainer/optimizers/lr_scheduler_linear.h
+++ b/nntrainer/optimizers/lr_scheduler_linear.h
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Hyunwoo LEE <dlgusdn0414@snu.ac.kr>
+ *
+ * @file   lr_scheduler_linear.h
+ * @date   11 November 2024
+ * @brief  This is Linear Learning Rate Scheduler class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Hyunwoo LEE <dlgusdn0414@snu.ac.kr>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __LEARNING_RATE_SCHEDULER_LINEAR__
+#define __LEARNING_RATE_SCHEDULER_LINEAR__
+#ifdef __cplusplus
+
+#include <string>
+
+#include <common_properties.h>
+#include <lr_scheduler.h>
+
+namespace nntrainer {
+
+/**
+ * @class   Linear Learning Rate Scheduler class
+ * @brief   class for Linear Learning Rate Schedulers
+ */
+class LinearLearningRateScheduler : public LearningRateScheduler {
+
+public:
+  /**
+   * @brief Construct a new Linear Learning Rate Scheduler object
+   */
+  LinearLearningRateScheduler();
+
+  /**
+   * @copydoc LearningRateScheduler::getLearningRate(size_t iteration) const
+   */
+  virtual double getLearningRate(size_t iteration) override;
+
+  /**
+   * @copydoc LearningRateScheduler::finalize()
+   */
+  virtual void finalize() override;
+
+  /**
+   * @copydoc LearningRateScheduler::exportTo(Exporter &exporter, const
+   * ml::train::ExportMethods& method)
+   */
+  void exportTo(Exporter &exporter,
+                const ml::train::ExportMethods &method) const override;
+
+  /**
+   * @copydoc LearningRateScheduler::setProperty(const std::vector<std::string>
+   * &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @copydoc LearningRateScheduler::getType() const
+   */
+  const std::string getType() const override {
+    return LinearLearningRateScheduler::type;
+  }
+
+  inline static const std::string type = "linear";
+
+private:
+  std::tuple<props::MaxLearningRate, props::MinLearningRate, props::DecaySteps>
+    lr_props;
+};
+
+} // namespace nntrainer
+
+#endif /* __cplusplus */
+#endif /* __LEARNING_RATE_SCHEDULER_LINEAR__ */

--- a/nntrainer/optimizers/meson.build
+++ b/nntrainer/optimizers/meson.build
@@ -6,6 +6,7 @@ optimizer_sources = [
   'lr_scheduler_constant.cpp',
   'lr_scheduler_cosine.cpp',
   'lr_scheduler_exponential.cpp',
+  'lr_scheduler_linear.cpp',
   'lr_scheduler_step.cpp',
   'optimizer_wrapped.cpp'
 ]

--- a/test/unittest/unittest_nntrainer_lr_scheduler.cpp
+++ b/test/unittest/unittest_nntrainer_lr_scheduler.cpp
@@ -490,23 +490,23 @@ TEST(lr_linear, prop_02_n) {
   EXPECT_THROW(lr->setProperty({"learning_rate:0.1"}), std::invalid_argument);
 }
 
-TEST(lr_linear, prop_03_n) {
+TEST(lr_linear, prop_03_p) {
   auto lr = createLRS("linear");
   EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
 }
 
-TEST(lr_linear, prop_04_n) {
+TEST(lr_linear, prop_04_p) {
   auto lr = createLRS("linear");
   EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
 }
 
-TEST(lr_linear, prop_05_n) {
+TEST(lr_linear, prop_05_p) {
   auto lr = createLRS("linear");
   EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
   EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
 }
 
-TEST(lr_linear, prop_06_n) {
+TEST(lr_linear, prop_06_p) {
   auto lr = createLRS("linear");
   EXPECT_NO_THROW(lr->setProperty({"decay_steps=5"}));
 }
@@ -516,7 +516,7 @@ TEST(lr_linear, finalize_01_n) {
   EXPECT_THROW(lr->finalize(), std::invalid_argument);
 }
 
-TEST(lr_linear, finalize_02_n) {
+TEST(lr_linear, finalize_02_p) {
   auto lr = createLRS("linear");
   EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
   EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
@@ -524,7 +524,7 @@ TEST(lr_linear, finalize_02_n) {
   EXPECT_NO_THROW(lr->finalize());
 }
 
-TEST(lr_linear, getlearningrate_01_n) {
+TEST(lr_linear, getlearningrate_01_p) {
   auto lr = createLRS("linear");
   EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
   EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
@@ -533,7 +533,7 @@ TEST(lr_linear, getlearningrate_01_n) {
   EXPECT_FLOAT_EQ(lr->getLearningRate(0), 1);
 }
 
-TEST(lr_linear, getlearningrate_02_n) {
+TEST(lr_linear, getlearningrate_02_p) {
   auto lr = createLRS("linear");
   EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
   EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));

--- a/test/unittest/unittest_nntrainer_lr_scheduler.cpp
+++ b/test/unittest/unittest_nntrainer_lr_scheduler.cpp
@@ -18,6 +18,7 @@
 #include <lr_scheduler_constant.h>
 #include <lr_scheduler_cosine.h>
 #include <lr_scheduler_exponential.h>
+#include <lr_scheduler_linear.h>
 #include <nntrainer_error.h>
 
 #include "nntrainer_test_util.h"
@@ -478,6 +479,72 @@ TEST(lr_cosine, getlearningrate_01_n) {
   EXPECT_NO_THROW(lr->finalize());
   EXPECT_FLOAT_EQ(lr->getLearningRate(0), 1);
 }
+
+TEST(lr_linear, prop_01_n) {
+  auto lr = createLRS("linear");
+  EXPECT_THROW(lr->setProperty({"unknown=unknown"}), std::invalid_argument);
+}
+
+TEST(lr_linear, prop_02_n) {
+  auto lr = createLRS("linear");
+  EXPECT_THROW(lr->setProperty({"learning_rate:0.1"}), std::invalid_argument);
+}
+
+TEST(lr_linear, prop_03_n) {
+  auto lr = createLRS("linear");
+  EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
+}
+
+TEST(lr_linear, prop_04_n) {
+  auto lr = createLRS("linear");
+  EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
+}
+
+TEST(lr_linear, prop_05_n) {
+  auto lr = createLRS("linear");
+  EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
+  EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
+}
+
+TEST(lr_linear, prop_06_n) {
+  auto lr = createLRS("linear");
+  EXPECT_NO_THROW(lr->setProperty({"decay_steps=5"}));
+}
+
+TEST(lr_linear, finalize_01_n) {
+  auto lr = createLRS("linear");
+  EXPECT_THROW(lr->finalize(), std::invalid_argument);
+}
+
+TEST(lr_linear, finalize_02_n) {
+  auto lr = createLRS("linear");
+  EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
+  EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
+  EXPECT_NO_THROW(lr->setProperty({"decay_steps=10"}));
+  EXPECT_NO_THROW(lr->finalize());
+}
+
+TEST(lr_linear, getlearningrate_01_n) {
+  auto lr = createLRS("linear");
+  EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
+  EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
+  EXPECT_NO_THROW(lr->setProperty({"decay_steps=10"}));
+  EXPECT_NO_THROW(lr->finalize());
+  EXPECT_FLOAT_EQ(lr->getLearningRate(0), 1);
+}
+
+TEST(lr_linear, getlearningrate_02_n) {
+  auto lr = createLRS("linear");
+  EXPECT_NO_THROW(lr->setProperty({"max_learning_rate=1.0"}));
+  EXPECT_NO_THROW(lr->setProperty({"min_learning_rate=0.1"}));
+  EXPECT_NO_THROW(lr->setProperty({"decay_steps=9"}));
+  EXPECT_NO_THROW(lr->finalize());
+  EXPECT_FLOAT_EQ(lr->getLearningRate(0), 1);
+  EXPECT_FLOAT_EQ(lr->getLearningRate(1), 0.9);
+  EXPECT_FLOAT_EQ(lr->getLearningRate(5), 0.5);
+  EXPECT_FLOAT_EQ(lr->getLearningRate(9), 0.1);
+}
+
 int main(int argc, char **argv) {
   int result = -1;
 


### PR DESCRIPTION
This PR adds the [LinearLearningRateScheduler](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.LinearLR.html) class, which adjusts the learning rate using a Linear formula.

The implementation includes setting the max/min learning rates, decay steps, and proper error handling for missing properties.

And add unittest cases(property setting test, finalize test, getLearningRate test).

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
