### PR TITLE
[Graph] change of inplace-type setting method

### DIFF
--- a/nntrainer/layers/flatten_layer.h
+++ b/nntrainer/layers/flatten_layer.h
@@ -28,8 +28,9 @@ public:
   /**
    * @brief     Constructor of Flatten Layer
    */
-  FlattenLayer() : ReshapeLayer(), flatten_props(
-    props::StartDimension(), props::EndDimension()) {}
+  FlattenLayer() :
+    ReshapeLayer(),
+    flatten_props(props::StartDimension(), props::EndDimension()) {}
 
   /**
    * @brief     Destructor of Flatten Layer

--- a/nntrainer/layers/identity_layer.h
+++ b/nntrainer/layers/identity_layer.h
@@ -21,6 +21,7 @@ namespace nntrainer {
 
 /**
  * @class   Identity Layer
+ * @brief   Identity Layer
  * @note    Identity layers takes multiple tensors as input, redirects to output
  * without doing nothing (or if unavoidable, copying)
  */
@@ -72,6 +73,17 @@ public:
    * @copydoc Layer::supportInPlace()
    */
   bool supportInPlace() const override { return true; }
+
+  /**
+   * @brief Initialize the in-place type of the layer
+   * @return InPlaceType
+   */
+  InPlaceType initializeInPlaceType() final {
+    if (!supportInPlace())
+      return InPlaceType::NONE;
+    else
+      return InPlaceType::RESTRICTING;
+  }
 
   /**
    * @copydoc Layer::getType()

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -42,6 +42,18 @@ class RunLayerContext;
 class Exporter;
 
 /**
+ * @brief Enum class for the various types of inplace modes supported by layer
+ *
+ */
+enum class InPlaceType {
+  NONE,           /**< layer is not inplace */
+  RESTRICTING,    /**< layer is in-place and does place restriction on layers
+                    ahead of it to be in-place */
+  NON_RESTRICTING /**< layer is in-place and does NOT place restriction on the
+                    layers ahead of it to be in-place */
+};
+
+/**
  * @class   Layer Base class for layers
  * @brief   Base class for all layers
  *
@@ -247,6 +259,22 @@ public:
    * @note all layers default to out of place execution
    */
   virtual bool supportInPlace() const { return false; }
+
+  /**
+   * @brief Initialize the in-place type of the layer
+   * @details If it is a layer that supports in-place, the default in-place type
+   * is NONE_RESTRICTING, but if there is a RESTRICTING type among the input
+   * layers, it is set to NONE in the network_graph.cpp.
+   * Layers with exceptional behavior such as No-Operation layers should
+   * override this function.
+   * @return InPlaceType
+   */
+  virtual InPlaceType initializeInPlaceType() {
+    if (!supportInPlace())
+      return InPlaceType::NONE;
+    else
+      return InPlaceType::NON_RESTRICTING;
+  }
 
   /**
    * @brief  check if this layer requires label to be passed

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -931,6 +931,15 @@ bool LayerNode::supportInPlace() const {
 }
 
 /**
+ * @brief Initialize the in-place type of the layer
+ * @return InPlaceType
+ */
+InPlaceType LayerNode::initializeInPlaceType() {
+  inplace_type = layer->initializeInPlaceType();
+  return inplace_type;
+}
+
+/**
  * @brief  check if this layer requires label to be passed
  */
 bool LayerNode::requireLabel() const { return getLayer()->requireLabel(); }

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -56,18 +56,6 @@ class LossScaleForMixed;
 } // namespace props
 
 /**
- * @brief Enum class for the various types of inplace modes supported by layer
- *
- */
-enum class InPlaceType {
-  NONE,           /**< layer is not inplace */
-  RESTRICTING,    /**< layer is in-place and does place restriction on layers
-                    ahead of it to be in-place */
-  NON_RESTRICTING /**< layer is in-place and does NOT place restriction on the
-                    layers ahead of it to be in-place */
-};
-
-/**
  * @class   LayerNode class
  * @brief   layer node class for the graph
  */
@@ -365,6 +353,16 @@ public:
    */
   bool supportInPlace() const;
 
+  /**
+   * @brief Initialize the in-place type of the layer
+   * @details If it is a layer that supports in-place, the default in-place type
+   * is NONE_RESTRICTING, but if there is a RESTRICTING type among the input
+   * layers, it is set to NONE in the network_graph.cpp.
+   * Layers with exceptional behavior such as No-Operation layers should
+   * override this function.
+   * @return InPlaceType
+   */
+  InPlaceType initializeInPlaceType();
   /**
    * @brief   Notify that this layer will execute in-place
    *

--- a/nntrainer/layers/multiout_layer.h
+++ b/nntrainer/layers/multiout_layer.h
@@ -74,6 +74,17 @@ public:
   bool supportBackwarding() const override { return true; };
 
   /**
+   * @brief Initialize the in-place type of the layer
+   * @return InPlaceType
+   */
+  InPlaceType initializeInPlaceType() final {
+    if (!supportInPlace())
+      return InPlaceType::NONE;
+    else
+      return InPlaceType::RESTRICTING;
+  }
+
+  /**
    * @copydoc Layer::supportInPlace()
    */
   bool supportInPlace() const override { return true; }

--- a/nntrainer/layers/reshape_layer.h
+++ b/nntrainer/layers/reshape_layer.h
@@ -79,6 +79,17 @@ public:
   bool supportInPlace() const override { return true; }
 
   /**
+   * @brief Initialize the in-place type of the layer
+   * @return InPlaceType
+   */
+  InPlaceType initializeInPlaceType() final {
+    if (!supportInPlace())
+      return InPlaceType::NONE;
+    else
+      return InPlaceType::RESTRICTING;
+  }
+
+  /**
    * @copydoc Layer::exportTo(Exporter &exporter, ml::train::ExportMethods
    * method)
    */


### PR DESCRIPTION
The method of setting the inplace-type has been redefined.

The reason why inplace processing becomes complicated is that since a `multi-out layer` shares output variables, so it needs to be considered whether or not inplace can be performed.

Actually, the layers that can perform inplace even after the `multi-out layer` are only `no-operation layers(no-op layers)`. These `no-op layers` include `identity`, `reshape`, and `flatten layers`.

For other layers, even if they support inplace, they cannot perform inplace when there is a `multi-out layer` in front of them.

Note that because `no-op layers` connected with `multi-out layer` share memory with the `multi-out layer`, so they have the same properties as the `multi-out layer`. This property is expressed as `RESTRICTING` in our script.

Based on these definitions, I've redesigned the method of setting inplace type.

1. By default, initialize the inplace type for each layer. If supportInPlace is true, it will be initialized as `NON_RESTRICTING`; otherwise, it will be initialized as `NONE`.
2. However, not all layers are initialized like this. For `multi-out layers` or `no-op layers`, if supportInPlace is true, they will be initialized as `RESTRICTING` types(However, the `no-op layer` will be changed to a `NON_RESTRICTING` type if that is not connected with the `multi-out layer` within the `network_graph.cpp`).
3. After initialization, confirm the input connections from the `network_graph.cpp` to determine the final inplace type. It's clearer to see the source code for this part.

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>