### PR TITLE
[Graph] rename variable and remove non-working codes @open sesame 11/14 19:02

### DIFF
--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -37,8 +37,8 @@ public:
    */
   template <typename T = float>
   ActiFunc(ActivationType at = ActivationType::ACT_NONE,
-           bool in_place_ = true) :
-    in_place(in_place_) {
+           bool is_inplace_ = true) :
+    is_inplace(is_inplace_) {
     setActiFunc<T>(at);
   }
 
@@ -72,19 +72,19 @@ public:
       this->setActivation<T>(leakyRelu<T>, leakyReluPrime<T>);
       break;
     case ActivationType::ACT_SWISH:
-      in_place = false;
+      is_inplace = false;
       this->setActivation<Tensor>(swish<T>, swishPrime<T>);
       break;
     case ActivationType::ACT_GELU:
-      in_place = false;
+      is_inplace = false;
       this->setActivation<Tensor>(gelu<T>, geluPrime<T>);
       break;
     case ActivationType::ACT_TANH_GELU:
-      in_place = false;
+      is_inplace = false;
       this->setActivation<Tensor>(tanhGelu<T>, tanhGeluPrime<T>);
       break;
     case ActivationType::ACT_SIGMOID_GELU:
-      in_place = false;
+      is_inplace = false;
       this->setActivation<Tensor>(sigmoidGelu<T>, sigmoidGeluPrime<T>);
       break;
     case ActivationType::ACT_ELU:
@@ -149,7 +149,7 @@ public:
   /**
    * @copydoc Layer::supportInPlace()
    */
-  bool supportInPlace() const { return in_place; }
+  bool supportInPlace() const { return is_inplace; }
 
   /**
    * @brief       Calculate softmax for Tensor Type
@@ -649,7 +649,7 @@ public:
       &activation_fn,
     std::function<funcParam &(funcParam const &, funcParam const &, funcParam &,
                               funcParam const &)> const &activation_prime_fn) {
-    if (in_place)
+    if (is_inplace)
       return ML_ERROR_INVALID_PARAMETER;
 
     _act_fn = activation_fn;
@@ -672,7 +672,7 @@ public:
       &activation_fn,
     std::function<funcParam &(funcParam &, funcParam &)> const
       &activation_prime_fn) {
-    if (!in_place) {
+    if (!is_inplace) {
       _act_prime_fn = [activation_prime_fn](
                         funcParam const &t_in, funcParam &t_out,
                         funcParam &outgoing_derivative,
@@ -715,7 +715,7 @@ public:
     _act_fn = [activation_fn](Tensor const &x, Tensor &hidden) -> Tensor & {
       return x.apply(activation_fn, hidden);
     };
-    if (!in_place) {
+    if (!is_inplace) {
       _act_prime_fn =
         [activation_prime_fn](Tensor const &t_in, Tensor &t_out,
                               Tensor &outgoing_derivative,
@@ -765,7 +765,7 @@ public:
       throw std::runtime_error(
         "Error setting activation layer to work in-place");
 
-    in_place = val;
+    is_inplace = val;
   }
 
 private:
@@ -780,7 +780,7 @@ private:
 
   ActivationType
     activation_type; /**< type of the activation represented by this */
-  bool in_place;     /**< if this class should operate in_place */
+  bool is_inplace;   /**< if this class should operate is_inplace */
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -75,17 +75,6 @@ void InputLayer::finalize(InitLayerContext &context) {
   }
 
   context.setOutputDimensions(output_dims);
-
-  is_inplace = true;
-
-  /**
-   * @note Input Layer assuems that the FP32 IN Tensor always. Therefore, if the
-   * activation data type is not fp32, then it does not support in-place
-   * operation.
-   */
-  if (context.getActivationDataType() != ml::train::TensorDim::DataType::FP32) {
-    is_inplace = false;
-  }
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -105,7 +105,7 @@ public:
 
 private:
   std::tuple<props::Normalization, props::Standardization> input_props;
-  bool is_inplace;
+  bool is_inplace = true;
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -41,11 +41,11 @@ static void suffixSpec(VarGradSpecV2 &spec, unsigned int idx) {
 
 InitLayerContext::InitLayerContext(
   const std::vector<TensorDim> &dim, const std::vector<bool> &req_out_connected,
-  bool in_place_, const std::string &n, const std::string &prefix_,
+  bool is_inplace_, const std::string &n, const std::string &prefix_,
   const float max_norm, std::array<std::string, 3> tensor_type_,
   const float loss_scale_, ml::train::ExecutionMode mode_) :
   input_dim(dim),
-  in_place(in_place_),
+  is_inplace(is_inplace_),
   clip_by_global_norm(max_norm),
   output_specs(),
   req_out_is_connected(req_out_connected),
@@ -126,13 +126,13 @@ const std::vector<VarGradSpecV2> &InitLayerContext::getOutSpecs() const {
 }
 
 RunLayerContext::RunLayerContext(const std::string &name, bool trainable,
-                                 float l, bool in_place_, float loss_scale_,
+                                 float l, bool is_inplace_, float loss_scale_,
                                  bool restore_, const std::vector<Weight *> &w,
                                  const std::vector<Var_Grad *> &in,
                                  const std::vector<Var_Grad *> &out,
                                  const std::vector<Var_Grad *> &t) :
   loss(l),
-  in_place(in_place_),
+  is_inplace(is_inplace_),
   loss_scale(loss_scale_),
   restoreData(restore_),
   weights(w),

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -46,7 +46,7 @@ public:
    * @param dim Input dimensions for the layer
    * @param req_out_connected bool vector to tell if requested output is
    * trainable or not
-   * @param in_place_ true if the context is inplacable
+   * @param is_inplace_ true if the context is inplacable
    * @param name name
    * @param prefix_ prefix
    * @param max_norm max norm
@@ -57,7 +57,7 @@ public:
    */
   InitLayerContext(
     const std::vector<TensorDim> &dim,
-    const std::vector<bool> &req_out_connected, bool in_place_,
+    const std::vector<bool> &req_out_connected, bool is_inplace_,
     const std::string &n = "", const std::string &prefix_ = "",
     const float max_norm = 0.0,
     std::array<std::string, 3> tensor_type_ = {"NCHW", "FP32", "FP32"},
@@ -383,7 +383,7 @@ public:
    *
    * @return true if in-place, else false
    */
-  bool getInPlace() const { return in_place; }
+  bool getInPlace() const { return is_inplace; }
 
   /**
    * @brief   get Initial value of Loss_Scale. This is set to RunLayerContext
@@ -403,7 +403,7 @@ public:
 
 private:
   std::vector<TensorDim> input_dim; /**< Input dimensions for the layer */
-  bool in_place;             /**< if the layer is expected to run in-place */
+  bool is_inplace;           /**< if the layer is expected to run in-place */
   float clip_by_global_norm; /**< max norm value for clip by norm */
 
   std::vector<VarGradSpecV2> output_specs; /**< Specification for the output */
@@ -440,14 +440,15 @@ public:
    *
    */
   RunLayerContext() :
-    loss(0.0), in_place(false), loss_scale(1.0), restoreData(false) {}
+    loss(0.0), is_inplace(false), loss_scale(1.0), restoreData(false) {}
 
   /**
    * @brief Construct a new Run Layer Context object
    *
    */
-  RunLayerContext(const std::string &name, bool in_place_) : RunLayerContext() {
-    in_place = in_place_;
+  RunLayerContext(const std::string &name, bool is_inplace_) :
+    RunLayerContext() {
+    is_inplace = is_inplace_;
     std::get<props::Name>(props).set(name);
   }
 
@@ -455,9 +456,10 @@ public:
    * @brief Construct a new Run Layer Context object
    *
    */
-  RunLayerContext(const std::string &name, bool in_place_, float loss_scale_) :
+  RunLayerContext(const std::string &name, bool is_inplace_,
+                  float loss_scale_) :
     RunLayerContext() {
-    in_place = in_place_;
+    is_inplace = is_inplace_;
     std::get<props::Name>(props).set(name);
     loss_scale = loss_scale_;
   }
@@ -468,7 +470,7 @@ public:
    * @param name name of the layer
    * @param trainable if the layer is trainable
    * @param l loss of the layer
-   * @param in_place_ execution in-place of the layer
+   * @param is_inplace_ execution in-place of the layer
    * @param loss_scale loss_scale of the layer
    * @param w weights of the layer
    * @param in inputs of the layer
@@ -476,7 +478,7 @@ public:
    * @param t extra tensors of the layer
    */
   RunLayerContext(const std::string &name, bool trainable, float l,
-                  bool in_place_, float loss_scale_, bool restoreData_,
+                  bool is_inplace_, float loss_scale_, bool restoreData_,
                   const std::vector<Weight *> &w,
                   const std::vector<Var_Grad *> &in,
                   const std::vector<Var_Grad *> &out,
@@ -889,7 +891,7 @@ public:
    *
    * @return true if in-place, else false
    */
-  bool getInPlace() const { return in_place; }
+  bool getInPlace() const { return is_inplace; }
 
   /**
    * @brief   get layer weights
@@ -946,7 +948,7 @@ public:
 private:
   std::tuple<props::Name, props::Trainable> props; /**< props of the layer */
   float loss;                                      /**< loss of the layer */
-  bool in_place;    /**< if the layer is expected to run in-place */
+  bool is_inplace;  /**< if the layer is expected to run in-place */
   float loss_scale; /**< loss_scale of the layer */
   bool restoreData; /**< reset output for mixed precsion */
 

--- a/nntrainer/layers/loss/loss_layer.cpp
+++ b/nntrainer/layers/loss/loss_layer.cpp
@@ -25,10 +25,6 @@ void LossLayer::finalize(InitLayerContext &context) {
                     nntrainer::TensorDataTypeInfo>::from_string("FP32"));
 
   context.setOutputDimensions(output_dim);
-
-  is_inplace = true;
-  if (context.getActivationDataType() != ml::train::TensorDim::DataType::FP32)
-    is_inplace = false;
 }
 
 void LossLayer::updateLoss(RunLayerContext &context, const Tensor &l) {

--- a/nntrainer/layers/loss/loss_layer.h
+++ b/nntrainer/layers/loss/loss_layer.h
@@ -72,7 +72,7 @@ protected:
   Tensor
     l; /**< loss tensor to store intermediate value to calculate loss value */
 
-  bool is_inplace;
+  bool is_inplace = true;
 };
 
 } // namespace nntrainer


### PR DESCRIPTION
- The variables with the same meaning are written as `in_place` or `is_inplace` by the script, so I unified it to use the term "is_inplace".

- Some layer's finalize function includes code that determines whether or not to support in-place depending on the tensor type. However, this code does not work. The reason it seems like this code is working is because there is a same purpose of code at the top of the `canExecuteInPlace` function within the `network_graph.cpp` and that code works.

It is meaningless to determine whether or not to support in-place within the `finalize` function because the `canExecuteInPlace` function, which decides how InPlace will behave, is called before the `finalize` function.

The canExecuteInPlace function is called during `compile` while the finalize function is called during `initialize` after `compile`. Therefore, setting supportInplace inside the finalize function does not work.

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped