### PR TITLE
[trivial] bug fix on recorder_v2.py script

### DIFF
--- a/test/input_gen/genModelTests_v2.py
+++ b/test/input_gen/genModelTests_v2.py
@@ -801,6 +801,7 @@ if __name__ == "__main__":
         label_dims=[(1, 10)],
         name="fc_mixed_training",
         optimizer=fc_mixed_training.getOptimizer(),
+        type="mixed",
     )
 
     inspect_file("fc_mixed_training.nnmodelgolden")
@@ -846,6 +847,7 @@ if __name__ == "__main__":
         label_dims=[(1, 1)],
         name="fc_mixed_training_nan_sgd",
         optimizer=fc_mixed_training_nan_sgd.getOptimizer(),
+        type="mixed",
     )
 
     #    Function to check the created golden test file


### PR DESCRIPTION
Currently, errors occur in creating golden data for most of `genModelTests_v2.py` unittests except for mixed-precision unittests. Therefore, I've restored the previous function as a 'default' type for non-mixed-precision unittests, while newly added mixed-precision unittests are classified as 'mixed' type.

Additionally, python formatter has been applied and some bugs(cpu<->cuda mismatch, etc.) have been fixed.

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>