### PR TITLE
[Bugfix] Revert mixed precision case inplace set false

### DIFF
--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -75,6 +75,9 @@ void InputLayer::finalize(InitLayerContext &context) {
   }
 
   context.setOutputDimensions(output_dims);
+  is_inplace = true;
+  if (context.getActivationDataType() != ml::train::TensorDim::DataType::FP32)
+    is_inplace = false;
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -105,7 +105,7 @@ public:
 
 private:
   std::tuple<props::Normalization, props::Standardization> input_props;
-  bool is_inplace = true;
+  bool is_inplace;
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/loss/loss_layer.cpp
+++ b/nntrainer/layers/loss/loss_layer.cpp
@@ -25,6 +25,10 @@ void LossLayer::finalize(InitLayerContext &context) {
                     nntrainer::TensorDataTypeInfo>::from_string("FP32"));
 
   context.setOutputDimensions(output_dim);
+
+  is_inplace = true;
+  if (context.getActivationDataType() != ml::train::TensorDim::DataType::FP32)
+    is_inplace = false;
 }
 
 void LossLayer::updateLoss(RunLayerContext &context, const Tensor &l) {

--- a/nntrainer/layers/loss/loss_layer.h
+++ b/nntrainer/layers/loss/loss_layer.h
@@ -72,7 +72,7 @@ protected:
   Tensor
     l; /**< loss tensor to store intermediate value to calculate loss value */
 
-  bool is_inplace = true;
+  bool is_inplace;
 };
 
 } // namespace nntrainer


### PR DESCRIPTION
Currently, when using mixed precision mode with in-place set to true, the ninja test fails.

I think this failure is due to setting the in-place default value as true for all cases where it shouldn't have been.

Since loss layers and input layers haven't yet implemented non-FP32 operations, I've modified them so that they now specify in-place computations as false.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped