### PR TITLE
[ GPU ] split kernel registration from forwarding function in `rmsnorm_layer_cl`

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -53,9 +53,11 @@ static void add_default_object(ClContext &cc) {
                        ml::train::LayerType::LAYER_RESHAPE);
   }
 
-  // @todo rmsnormlayercl also needs to be updated.
-  cc.registerFactory(nntrainer::createLayer<RMSNormLayerCl>,
-                     RMSNormLayerCl::type, ml::train::LayerType::LAYER_RMSNORM);
+  if (RMSNormLayerCl::registerClKernels()) {
+    cc.registerFactory(nntrainer::createLayer<RMSNormLayerCl>,
+                       RMSNormLayerCl::type,
+                       ml::train::LayerType::LAYER_RMSNORM);
+  }
 
   if (ConcatLayerCl::registerClKernels()) {
     cc.registerFactory(nntrainer::createLayer<ConcatLayerCl>,

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -50,10 +50,10 @@ enum BNParams {
 BatchNormalizationLayer::BatchNormalizationLayer() :
   Layer(),
   divider(0),
-  bn_props(props::Epsilon(), props::BNPARAMS_MU_INIT(),
-           props::BNPARAMS_VAR_INIT(), props::BNPARAMS_BETA_INIT(),
-           props::BNPARAMS_GAMMA_INIT(), props::Momentum(), props::Axis(),
-           props::WeightDecay(), props::BiasDecay()) {
+  bn_props(props::Epsilon(), props::MuInitializer(), props::VarInitializer(),
+           props::BetaInitializer(), props::GammaInitializer(),
+           props::Momentum(), props::Axis(), props::WeightDecay(),
+           props::BiasDecay()) {
   wt_idx.fill(std::numeric_limits<unsigned>::max());
 }
 
@@ -62,10 +62,10 @@ void BatchNormalizationLayer::finalize(InitLayerContext &context) {
   NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
     << "Only one input is allowed for batch normalization layer";
 
-  auto &bnparams_mu = std::get<props::BNPARAMS_MU_INIT>(bn_props);
-  auto &bnparams_var = std::get<props::BNPARAMS_VAR_INIT>(bn_props);
-  auto &bnparams_beta = std::get<props::BNPARAMS_BETA_INIT>(bn_props);
-  auto &bnparams_gamma = std::get<props::BNPARAMS_GAMMA_INIT>(bn_props);
+  auto &bnparams_mu = std::get<props::MuInitializer>(bn_props);
+  auto &bnparams_var = std::get<props::VarInitializer>(bn_props);
+  auto &bnparams_beta = std::get<props::BetaInitializer>(bn_props);
+  auto &bnparams_gamma = std::get<props::GammaInitializer>(bn_props);
   auto &weight_decay = std::get<props::WeightDecay>(bn_props);
   auto &bias_decay = std::get<props::BiasDecay>(bn_props);
 

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -126,9 +126,9 @@ private:
   std::vector<unsigned int> axes_to_reduce; /**< target axes to reduce */
   std::array<unsigned int, 11>
     wt_idx; /**< indices of the weights and tensors */
-  std::tuple<props::Epsilon, props::BNPARAMS_MU_INIT, props::BNPARAMS_VAR_INIT,
-             props::BNPARAMS_BETA_INIT, props::BNPARAMS_GAMMA_INIT,
-             props::Momentum, props::Axis, props::WeightDecay, props::BiasDecay>
+  std::tuple<props::Epsilon, props::MuInitializer, props::VarInitializer,
+             props::BetaInitializer, props::GammaInitializer, props::Momentum,
+             props::Axis, props::WeightDecay, props::BiasDecay>
     bn_props;
 };
 

--- a/nntrainer/layers/cl_layers/rmsnorm_layer_cl.cpp
+++ b/nntrainer/layers/cl_layers/rmsnorm_layer_cl.cpp
@@ -96,7 +96,7 @@ RMSNormLayerCl::RMSNormLayerCl() : LayerImplCl() { wt_idx.fill(0); }
 void RMSNormLayerCl::finalize(InitLayerContext &context) {
   std::vector<TensorDim> dim = context.getInputDimensions();
   context.setOutputDimensions(dim);
-  auto &rmsparams_gamma = std::get<props::RMS_NORM_GAMMA_INIT>(rmsnorm_props);
+  auto &rmsparams_gamma = std::get<props::GammaInitializer>(rmsnorm_props);
 
   TensorDim gamma_dim(
     1, 1, 1, dim[0].width(),

--- a/nntrainer/layers/cl_layers/rmsnorm_layer_cl.h
+++ b/nntrainer/layers/cl_layers/rmsnorm_layer_cl.h
@@ -16,7 +16,7 @@
 #ifdef __cplusplus
 
 #include <common_properties.h>
-#include <layer_impl.h>
+#include <layer_impl_cl.h>
 #include <nntrainer_log.h>
 
 #include <cl_context.h>
@@ -25,36 +25,11 @@
 
 namespace nntrainer {
 
-namespace props {
-
-/**
- * @brief RMS_NORM_GAMMA_INIT_GPU Initialization Enumeration Information
- *
- */
-class RMS_NORM_GAMMA_INIT_GPU final
-  : public ::nntrainer::EnumProperty<::nntrainer::props::InitializerInfo> {
-public:
-  /**
-   * @brief Construct a RMS_NORM_GAMMA_INIT object
-   */
-  RMS_NORM_GAMMA_INIT_GPU(
-    ::nntrainer::Initializer value = ::nntrainer::Initializer::ONES) {
-    set(value);
-  };
-  using prop_tag = enum_class_prop_tag;
-  static constexpr const char *key = "gamma_initializer";
-};
-}; // namespace props
-
 /**
  * @class   RMSNormLayer
  * @brief   RMS Norm layer
  */
-
-class RMSNormLayerCl : public LayerImpl {
-
-private:
-  inline static ClContext cl_context_ref;
+class RMSNormLayerCl : public LayerImplCl {
 
 public:
   /**
@@ -118,9 +93,6 @@ public:
    */
   const std::string getType() const override { return RMSNormLayerCl::type; };
 
-  static opencl::Kernel kernel_rmsnorm;
-  static opencl::Kernel kernel_rmsnorm_fp16;
-
   /**
    * @brief Process data and dimensions for rms norm operation
    * @param[in] input Tensor
@@ -153,12 +125,26 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
+  /**
+   * @brief registerClKernels
+   */
+  static bool registerClKernels();
+
   inline static const std::string type = "rmsnorm";
 
 private:
   std::array<unsigned int, 1> wt_idx;
-  std::tuple<props::RMS_NORM_GAMMA_INIT_GPU, props::Epsilon>
+
+  std::tuple<props::RMS_NORM_GAMMA_INIT, props::Epsilon>
     rmsnorm_props; /**< rmsnorm layer properties */
+
+  inline static std::vector<ClContext::SharedPtrClKernel>
+    layer_kernel_ptrs; /**< kernel list relevant with this layer */
+
+  enum Kernels {
+    RMSNORM_CL,
+    RMSNORM_CL_FP16,
+  };
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/cl_layers/rmsnorm_layer_cl.h
+++ b/nntrainer/layers/cl_layers/rmsnorm_layer_cl.h
@@ -135,7 +135,7 @@ public:
 private:
   std::array<unsigned int, 1> wt_idx;
 
-  std::tuple<props::RMS_NORM_GAMMA_INIT, props::Epsilon>
+  std::tuple<props::GammaInitializer, props::Epsilon>
     rmsnorm_props; /**< rmsnorm layer properties */
 
   inline static std::vector<ClContext::SharedPtrClKernel>

--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -314,13 +314,13 @@ WeightInitializer::WeightInitializer(Initializer value) { set(value); }
 
 BiasInitializer::BiasInitializer(Initializer value) { set(value); }
 
-BNPARAMS_MU_INIT::BNPARAMS_MU_INIT(Initializer value) { set(value); }
+MuInitializer::MuInitializer(Initializer value) { set(value); }
 
-BNPARAMS_VAR_INIT::BNPARAMS_VAR_INIT(Initializer value) { set(value); }
+VarInitializer::VarInitializer(Initializer value) { set(value); }
 
-BNPARAMS_GAMMA_INIT::BNPARAMS_GAMMA_INIT(Initializer value) { set(value); }
+GammaInitializer::GammaInitializer(Initializer value) { set(value); }
 
-BNPARAMS_BETA_INIT::BNPARAMS_BETA_INIT(Initializer value) { set(value); }
+BetaInitializer::BetaInitializer(Initializer value) { set(value); }
 
 BasicRegularizer::BasicRegularizer(nntrainer::WeightRegularizer value) {
   set(value);

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -1076,6 +1076,19 @@ public:
 };
 
 /**
+ * @brief RMS_NORM_GAMMA_INIT Initialization Enumeration Information
+ */
+class RMS_NORM_GAMMA_INIT final : public EnumProperty<InitializerInfo> {
+public:
+  /**
+   * @brief Construct a RMS_NORM_GAMMA_INIT object
+   */
+  RMS_NORM_GAMMA_INIT(Initializer value = Initializer::ONES) { set(value); };
+  using prop_tag = enum_class_prop_tag;
+  static constexpr const char *key = "gamma_initializer";
+};
+
+/**
  * @brief     Enumeration of tensor regularization type
  */
 struct RegularizerInfo {

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -1020,72 +1020,59 @@ public:
 };
 
 /**
- * @brief BNPARAMS_MU_INIT Initialization Enumeration Information
+ * @brief MuInitializer Initialization Enumeration Information
  *
  */
-class BNPARAMS_MU_INIT final : public EnumProperty<InitializerInfo> {
+class MuInitializer final : public EnumProperty<InitializerInfo> {
 public:
   /**
-   * @brief Construct a BNPARAMS_MU_INIT object
+   * @brief Construct a MuInitializer object
    */
-  BNPARAMS_MU_INIT(Initializer value = Initializer::ZEROS);
+  MuInitializer(Initializer value = Initializer::ZEROS);
   using prop_tag = enum_class_prop_tag;
   static constexpr const char *key = "moving_mean_initializer";
 };
 
 /**
- * @brief BNPARAMS_VAR_INIT Initialization Enumeration Information
+ * @brief VarInitializer Initialization Enumeration Information
  *
  */
-class BNPARAMS_VAR_INIT final : public EnumProperty<InitializerInfo> {
+class VarInitializer final : public EnumProperty<InitializerInfo> {
 public:
   /**
-   * @brief Construct a BNPARAMS_VAR_INIT object
+   * @brief Construct a VarInitializer object
    */
-  BNPARAMS_VAR_INIT(Initializer value = Initializer::ONES);
+  VarInitializer(Initializer value = Initializer::ONES);
   using prop_tag = enum_class_prop_tag;
   static constexpr const char *key = "moving_variance_initializer";
 };
 
 /**
- * @brief BNPARAMS_GAMMA_INIT Initialization Enumeration Information
+ * @brief GammaInitializer Initialization Enumeration Information
  *
  */
-class BNPARAMS_GAMMA_INIT final : public EnumProperty<InitializerInfo> {
+class GammaInitializer final : public EnumProperty<InitializerInfo> {
 public:
   /**
-   * @brief Construct a BNPARAMS_GAMMA_INIT object
+   * @brief Construct a GammaInitializer object
    */
-  BNPARAMS_GAMMA_INIT(Initializer value = Initializer::ONES);
+  GammaInitializer(Initializer value = Initializer::ONES);
   using prop_tag = enum_class_prop_tag;
   static constexpr const char *key = "gamma_initializer";
 };
 
 /**
- * @brief BNPARAMS_BETA_INIT Initialization Enumeration Information
+ * @brief BetaInitializer Initialization Enumeration Information
  *
  */
-class BNPARAMS_BETA_INIT final : public EnumProperty<InitializerInfo> {
+class BetaInitializer final : public EnumProperty<InitializerInfo> {
 public:
   /**
-   * @brief Construct a BNPARAMS_BETA_INIT object
+   * @brief Construct a BetaInitializer object
    */
-  BNPARAMS_BETA_INIT(Initializer value = Initializer::ZEROS);
+  BetaInitializer(Initializer value = Initializer::ZEROS);
   using prop_tag = enum_class_prop_tag;
   static constexpr const char *key = "beta_initializer";
-};
-
-/**
- * @brief RMS_NORM_GAMMA_INIT Initialization Enumeration Information
- */
-class RMS_NORM_GAMMA_INIT final : public EnumProperty<InitializerInfo> {
-public:
-  /**
-   * @brief Construct a RMS_NORM_GAMMA_INIT object
-   */
-  RMS_NORM_GAMMA_INIT(Initializer value = Initializer::ONES) { set(value); };
-  using prop_tag = enum_class_prop_tag;
-  static constexpr const char *key = "gamma_initializer";
 };
 
 /**

--- a/nntrainer/layers/layer_normalization_layer.cpp
+++ b/nntrainer/layers/layer_normalization_layer.cpp
@@ -38,9 +38,9 @@ enum LNParams {
 
 LayerNormalizationLayer::LayerNormalizationLayer() :
   Layer(),
-  layer_normalization_props(
-    std::vector<props::Axis>(), props::Epsilon(), props::BNPARAMS_GAMMA_INIT(),
-    props::BNPARAMS_BETA_INIT(), props::WeightDecay(), props::BiasDecay()) {
+  layer_normalization_props(std::vector<props::Axis>(), props::Epsilon(),
+                            props::GammaInitializer(), props::BetaInitializer(),
+                            props::WeightDecay(), props::BiasDecay()) {
   wt_idx.fill(std::numeric_limits<unsigned>::max());
 }
 
@@ -51,9 +51,9 @@ void LayerNormalizationLayer::finalize(InitLayerContext &context) {
   }
 
   auto gamma_initializer =
-    std::get<props::BNPARAMS_GAMMA_INIT>(layer_normalization_props).get();
+    std::get<props::GammaInitializer>(layer_normalization_props).get();
   auto beta_initializer =
-    std::get<props::BNPARAMS_BETA_INIT>(layer_normalization_props).get();
+    std::get<props::BetaInitializer>(layer_normalization_props).get();
   auto weight_decay = std::get<props::WeightDecay>(layer_normalization_props);
   auto bias_decay = std::get<props::BiasDecay>(layer_normalization_props);
 

--- a/nntrainer/layers/layer_normalization_layer.h
+++ b/nntrainer/layers/layer_normalization_layer.h
@@ -124,9 +124,8 @@ private:
     remain_axes; /**< remained axes (exclusive with normalize axes) */
 
   std::array<unsigned int, 7> wt_idx;
-  std::tuple<std::vector<props::Axis>, props::Epsilon,
-             props::BNPARAMS_GAMMA_INIT, props::BNPARAMS_BETA_INIT,
-             props::WeightDecay, props::BiasDecay>
+  std::tuple<std::vector<props::Axis>, props::Epsilon, props::GammaInitializer,
+             props::BetaInitializer, props::WeightDecay, props::BiasDecay>
     layer_normalization_props;
 };
 

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -144,10 +144,10 @@ void Exporter::saveTflResult(const std::tuple<props::Activation> &props,
 
 template <>
 void Exporter::saveTflResult(
-  const std::tuple<props::Epsilon, props::BNPARAMS_MU_INIT,
-                   props::BNPARAMS_VAR_INIT, props::BNPARAMS_BETA_INIT,
-                   props::BNPARAMS_GAMMA_INIT, props::Momentum, props::Axis,
-                   props::WeightDecay, props::BiasDecay> &props,
+  const std::tuple<props::Epsilon, props::MuInitializer, props::VarInitializer,
+                   props::BetaInitializer, props::GammaInitializer,
+                   props::Momentum, props::Axis, props::WeightDecay,
+                   props::BiasDecay> &props,
   const BatchNormalizationLayer *self) {
   createIfNull(tf_node);
 

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -258,10 +258,10 @@ class BatchNormalizationLayer;
  */
 template <>
 void Exporter::saveTflResult(
-  const std::tuple<props::Epsilon, props::BNPARAMS_MU_INIT,
-                   props::BNPARAMS_VAR_INIT, props::BNPARAMS_BETA_INIT,
-                   props::BNPARAMS_GAMMA_INIT, props::Momentum, props::Axis,
-                   props::WeightDecay, props::BiasDecay> &props,
+  const std::tuple<props::Epsilon, props::MuInitializer, props::VarInitializer,
+                   props::BetaInitializer, props::GammaInitializer,
+                   props::Momentum, props::Axis, props::WeightDecay,
+                   props::BiasDecay> &props,
   const BatchNormalizationLayer *self);
 
 class LayerImpl;

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -444,6 +444,7 @@ LOCAL_SRC_FILES := \
 	 ../unittest/layers/unittest_layers_impl.cpp \
 	 ../unittest/layers/unittest_layers_transpose_cl.cpp \
 	 ../unittest/layers/unittest_layers_concat_cl.cpp \
+	 ../unittest/layers/unittest_layers_swiglu_cl.cpp \
 	 ../unittest/layers/unittest_layers_fully_connected_cl.cpp \
 	 ../unittest/layers/unittest_layers_input.cpp \
 	 ../unittest/layers/unittest_layers_loss.cpp \

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -444,7 +444,6 @@ LOCAL_SRC_FILES := \
 	 ../unittest/layers/unittest_layers_impl.cpp \
 	 ../unittest/layers/unittest_layers_transpose_cl.cpp \
 	 ../unittest/layers/unittest_layers_concat_cl.cpp \
-	 ../unittest/layers/unittest_layers_swiglu_cl.cpp \
 	 ../unittest/layers/unittest_layers_fully_connected_cl.cpp \
 	 ../unittest/layers/unittest_layers_input.cpp \
 	 ../unittest/layers/unittest_layers_loss.cpp \


### PR DESCRIPTION
- This PR is continuation of #2785 .
- This PR applies the splitting kernel registration in forward function to RMSNorm layer.
- Please refer to #2723
- 0be5f29aedc3c8861f5cb735f85b7c1a0756e0b0 : new feature included in this PR

-----------------------------------
**2024-12-02** New commit is added :
78907d7b59f887f2751ad6419a00094cf72b15ce
 
- This commit updates some bn layer's properties to make them follow
  naming convention
  - BNPARAMS_GAMMA_INIT -> GammaInitializer
  - BNPARAMS_MU_INIT -> MuInitializer
  - BNPARAMS_VAR_INIT -> VarInitializer
  - BNPARAMS_BETA_INIT -> BetaInitializer
- This commit replaces parts of using RMS_NORM_GAMMA_INIT to GammaInitializer
---------------------------------


Self evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped