### PR TITLE
[CI] Drop i586 GBS build test

### DIFF
--- a/.github/workflows/gbs_build.yml
+++ b/.github/workflows/gbs_build.yml
@@ -15,8 +15,6 @@ jobs:
         include:
           - gbs_build_arch: "x86_64"
             gbs_build_option: "--define \"unit_test 1\""
-          - gbs_build_arch: "i586"
-            gbs_build_option: "--define \"unit_test 1\""
           - gbs_build_arch: "armv7l"
             gbs_build_option: "--define \"unit_test 0\""
           - gbs_build_arch: "aarch64"


### PR DESCRIPTION
according to Tizen official supported arch list, drop i586 no longer need to test

below list is official supported arch
- armv7l
- armv7hl
- aarch64
- x86_64
- riscv64

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped