### PR TITLE
[Property][Unittest] Mixed Precision Unittest & Adding verification code @open sesame 12/02 09:00

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -37,7 +37,7 @@ option('enable-long-test', type: 'boolean', value: false)
 
 # backend options
 option('enable-blas', type: 'boolean', value: true)
-option('enable-fp16', type: 'boolean', value: false)
+option('enable-fp16', type: 'boolean', value: true)
 option('enable-cublas', type: 'boolean', value: false)
 option('enable-openmp', type: 'boolean', value: true)
 option('enable-neon', type: 'boolean', value: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -37,7 +37,7 @@ option('enable-long-test', type: 'boolean', value: false)
 
 # backend options
 option('enable-blas', type: 'boolean', value: true)
-option('enable-fp16', type: 'boolean', value: true)
+option('enable-fp16', type: 'boolean', value: false)
 option('enable-cublas', type: 'boolean', value: false)
 option('enable-openmp', type: 'boolean', value: true)
 option('enable-neon', type: 'boolean', value: false)

--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -69,6 +69,10 @@ void FilePath::set(const std::string &v) {
 
 std::ifstream::pos_type FilePath::file_size() { return cached_pos_size; }
 
+bool LossScaleForMixed::isValid(const float &value) const {
+  return (value != 0);
+}
+
 bool DirPath::isValid(const std::string &v) const {
   struct stat dir;
   return (stat(v.c_str(), &dir) == 0);

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -1466,7 +1466,7 @@ public:
   /**
    * @brief check if given value is valid
    *
-   * @param v value to check
+   * @param value value to check
    * @retval true if it is Not 0
    * @retval false if it is 0
    */

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -1462,6 +1462,15 @@ class LossScaleForMixed : public Property<float> {
 public:
   static constexpr const char *key = "loss_scale"; /**< unique key to access */
   using prop_tag = float_prop_tag;                 /**< property type */
+
+  /**
+   * @brief check if given value is valid
+   *
+   * @param v value to check
+   * @retval true if it is Not 0
+   * @retval false if it is 0
+   */
+  bool isValid(const float &value) const override;
 };
 
 /**

--- a/nntrainer/models/model_common_properties.cpp
+++ b/nntrainer/models/model_common_properties.cpp
@@ -44,4 +44,9 @@ ModelTensorDataType::ModelTensorDataType(ModelTensorDataTypeInfo::Enum value) {
 }
 LossScale::LossScale(float value) { set(value); }
 
+bool LossScale::isValid(const float &value) const {
+  ml_loge("Loss scale cannot be 0");
+  return value != 0;
+}
+
 } // namespace nntrainer::props

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -238,6 +238,14 @@ public:
   LossScale(float value = 1.0f);
   static constexpr const char *key = "loss_scale"; /**< unique key to access */
   using prop_tag = float_prop_tag;                 /**< property type */
+
+  /**
+   * @brief check if valid
+   *
+   * @param value value to check
+   * @return bool true if valid
+   */
+  bool isValid(const float &value) const override;
 };
 
 } // namespace nntrainer::props

--- a/test/unittest/integration_tests/integration_test_mixed_precision.cpp
+++ b/test/unittest/integration_tests/integration_test_mixed_precision.cpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Donghak Park <donghak.park@samsung.com>
+ *
+ * @file integration_test_mixed_precision.cpp
+ * @date 26 Nov 2024
+ * @brief Mixed Precision integration test
+ * @see	https://github.com/nnstreamer/nntrainer
+ * @author Donghak Park <donghak.park@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include <app_context.h>
+#include <layer.h>
+#include <lite/core/c/common.h>
+#include <model.h>
+#include <neuralnet.h>
+#include <nntrainer_test_util.h>
+#include <optimizer.h>
+using namespace nntrainer;
+
+int add_3(int &a) {
+  a += 3;
+  return 0;
+}
+
+TEST(mixed_precision, input_only_model_test) {
+
+  std::unique_ptr<ml::train::Model> nn =
+    ml::train::createModel(ml::train::ModelType::NEURAL_NET, {"loss=mse"});
+  nn->setProperty(
+    {"batch_size=1", "model_tensor_type=FP16-FP16", "loss_scale=65536"});
+
+  auto graph = makeGraph({
+    {"input", {"name=in", "input_shape=1:1:3"}},
+  });
+  for (auto &node : graph) {
+    nn->addLayer(node);
+  }
+
+  nn->setOptimizer(ml::train::createOptimizer("adam", {"learning_rate = 0.1"}));
+
+  EXPECT_EQ(nn->compile(), ML_ERROR_NONE);
+  EXPECT_EQ(nn->initialize(), ML_ERROR_NONE);
+  EXPECT_EQ(nn->reinitialize(), ML_ERROR_NONE);
+}
+
+TEST(mixed_precision, loss_scale_test) {
+  std::unique_ptr<ml::train::Model> nn =
+    ml::train::createModel(ml::train::ModelType::NEURAL_NET, {"loss=mse"});
+  nn->setProperty(
+    {"batch_size=1", "model_tensor_type=FP16-FP16", "loss_scale=0"});
+
+  auto graph = makeGraph({
+    {"input", {"name=in", "input_shape=1:1:3"}},
+  });
+
+  for (auto &node : graph) {
+    nn->addLayer(node);
+  }
+
+  nn->setOptimizer(ml::train::createOptimizer("adam", {"learning_rate = 0.1"}));
+
+  EXPECT_THROW(nn->compile(), std::invalid_argument);
+}

--- a/test/unittest/integration_tests/meson.build
+++ b/test/unittest/integration_tests/meson.build
@@ -1,13 +1,24 @@
 test_name = 'integration_tests'
+mixed_precision_test_name = 'integration_test_mixed_precision'
 
 test_target = [
     'integration_tests.cpp',
     'integration_test_loss.cpp',
 ]
 
+mixed_precision_targets = [
+    model_util_path / 'models_test_utils.cpp',
+    'integration_test_mixed_precision.cpp',
+]
+
+if get_option('enable-fp16')
+    test_target += mixed_precision_targets
+endif
+
 exe = executable(
     test_name,
     test_target,
+    include_directories: [include_directories('.'), model_util_include_dir],
     dependencies: [
         nntrainer_test_main_deps,
         nntrainer_dep,

--- a/test/unittest/models/meson.build
+++ b/test/unittest/models/meson.build
@@ -1,3 +1,6 @@
+model_util_path = meson.current_source_dir()
+model_util_include_dir = include_directories('.')
+
 test_name = 'unittest_models'
 mixed_test_name = 'unittest_mixed_models'
 


### PR DESCRIPTION
## In this Pull Request

I would like to add missing verification code related to mixed precision operation and also include associated unittest 
- test each layers compile, initialize, train 
- add some property's validation check code

**Self evaluation:**
1. Build test:   [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Donghak PARK <donghak.park@samsung.com>
