### PR TITLE
[ GPU ] split kernel registration from forwarding function in `addition_layer_cl` and `transpose_cl`

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -39,9 +39,11 @@ static void add_default_object(ClContext &cc) {
                        ml::train::LayerType::LAYER_FC);
   }
 
-  cc.registerFactory(nntrainer::createLayer<AdditionLayerCL>,
-                     AdditionLayerCL::type,
-                     ml::train::LayerType::LAYER_ADDITION);
+  if (AdditionLayerCL::registerClKernels()) {
+    cc.registerFactory(nntrainer::createLayer<AdditionLayerCL>,
+                       AdditionLayerCL::type,
+                       ml::train::LayerType::LAYER_ADDITION);
+  }
 
   // @todo swiglulayercl also needs to be updated.
   cc.registerFactory(nntrainer::createLayer<SwiGLULayerCl>, SwiGLULayerCl::type,

--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -64,10 +64,11 @@ static void add_default_object(ClContext &cc) {
                        ConcatLayerCl::type, ml::train::LayerType::LAYER_CONCAT);
   }
 
-  // @todo transposlayercl also needs to be updated.
-  cc.registerFactory(nntrainer::createLayer<TransposeLayerCl>,
-                     TransposeLayerCl::type,
-                     ml::train::LayerType::LAYER_TRANSPOSE);
+  if (TransposeLayerCl::registerClKernels()) {
+    cc.registerFactory(nntrainer::createLayer<TransposeLayerCl>,
+                       TransposeLayerCl::type,
+                       ml::train::LayerType::LAYER_TRANSPOSE);
+  }
 }
 
 static void registerer(ClContext &cc) noexcept {

--- a/nntrainer/layers/cl_layers/addition_layer_cl.h
+++ b/nntrainer/layers/cl_layers/addition_layer_cl.h
@@ -18,6 +18,7 @@
 #include <cl_context.h>
 #include <common_properties.h>
 #include <layer_devel.h>
+#include <layer_impl_cl.h>
 
 namespace nntrainer {
 
@@ -25,12 +26,12 @@ namespace nntrainer {
  * @class   AdditionLayerCL
  * @brief   Addition Layer
  */
-class AdditionLayerCL : public Layer {
+class AdditionLayerCL : public LayerImplCl {
 public:
   /**
    * @brief     Constructor of Addition Layer
    */
-  AdditionLayerCL() : Layer(), add_props(props::Print()) {}
+  AdditionLayerCL() : LayerImplCl(), add_props(props::Print()) {}
 
   /**
    * @brief     Destructor of Addition Layer
@@ -93,10 +94,20 @@ public:
    */
   const std::string getType() const override { return AdditionLayerCL::type; };
 
-  std::tuple<props::Print>
-    add_props; /**< fc layer properties : unit - number of output neurons */
+  /**
+   * @brief     registerClKernels for addition_layer_cl
+   * @details   registerClKernels for addition_layer_cl always returns true
+   * without any specific action for kernel registeration. It only uses
+   * cl_blas_kernels and there is no specific kernels for this. If there are
+   * specific kernels for this, it should be updated to register the kernels .
+   */
+  static bool registerClKernels() { return true; };
 
   inline static const std::string type = "addition";
+
+private:
+  std::tuple<props::Print>
+    add_props; /**< fc layer properties : unit - number of output neurons */
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/cl_layers/addition_layer_cl.h
+++ b/nntrainer/layers/cl_layers/addition_layer_cl.h
@@ -95,11 +95,10 @@ public:
   const std::string getType() const override { return AdditionLayerCL::type; };
 
   /**
-   * @brief     registerClKernels for addition_layer_cl
-   * @details   registerClKernels for addition_layer_cl always returns true
-   * without any specific action for kernel registeration. It only uses
-   * cl_blas_kernels and there is no specific kernels for this. If there are
-   * specific kernels for this, it should be updated to register the kernels .
+   * @brief     Register Cl Kernels for `AdditionLayerCl`, bypassing the
+   * registration process since it does not require any specific kernels. This
+   * function simply returns `true` because `AdditionLayerCl` does not rely on
+   * the specific kernels for the layer.
    */
   static bool registerClKernels() { return true; };
 

--- a/nntrainer/layers/cl_layers/transpose_cl.h
+++ b/nntrainer/layers/cl_layers/transpose_cl.h
@@ -16,6 +16,7 @@
 
 #include <common_properties.h>
 #include <layer_devel.h>
+#include <layer_impl_cl.h>
 #include <opencl_buffer.h>
 #include <opencl_kernel.h>
 
@@ -25,13 +26,13 @@ namespace nntrainer {
  * @brief A tranpose layer.
  *
  */
-class TransposeLayerCl final : public Layer {
+class TransposeLayerCl final : public LayerImplCl {
 public:
   /**
    * @brief Construct a new transpose layer object
    *
    */
-  TransposeLayerCl() : Layer(), transpose_props(props::Print()) {}
+  TransposeLayerCl() : LayerImplCl(), transpose_props(props::Print()) {}
 
   /**
    * @brief Destroy the transpose layer object
@@ -82,15 +83,17 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
+  /**
+   * @brief     Register Cl Kernels for `TransposeLayerCl`, bypassing the
+   * registration process since it does not require any specific kernels. This
+   * function simply returns `true` because `TransposeLayerCl` does not rely on
+   * the specific kernels for the layer.
+   */
+  static bool registerClKernels() { return true; };
+
   inline static const std::string type = "transpose";
 
-  static opencl::Kernel kernel_transpose_axis0;
-  static opencl::Kernel kernel_transpose_fp16_axis0;
-  static opencl::Kernel kernel_transpose_axis1;
-  static opencl::Kernel kernel_transpose_fp16_axis1;
-  static opencl::Kernel kernel_transpose_axis2;
-  static opencl::Kernel kernel_transpose_fp16_axis2;
-
+private:
   std::tuple<props::Print> transpose_props; /**< transpose layer properties :
                                             unit - number of output neurons */
 };


### PR DESCRIPTION
[ GPU/OpenCL ] change  `addition_layer_cl` and `transpose_cl` to inherit LayerImplCl

- This commit updates  `addition_layer_cl` and `transpose_cl`.cpp/h to inherit LayerImplCl.
- This commit implements registerClKernels() of  `addition_layer_cl` and `transpose_cl` layer.
- This commit update cl_context.cpp (applying  `addition_layer_cl` and `transpose_cl`'s update)
- This PR is continuation of https://github.com/nnstreamer/nntrainer/pull/2785
- This PR can close #2723 

**Self evaluation:**

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped