### PR TITLE
[ GPU ] Removing PLUGGABLE flag and its action from official cl layers.

### DIFF
--- a/nntrainer/layers/cl_layers/swiglu_cl.cpp
+++ b/nntrainer/layers/cl_layers/swiglu_cl.cpp
@@ -243,19 +243,4 @@ void SwiGLULayerCl::setProperty(const std::vector<std::string> &values) {
   }
 }
 
-#ifdef PLUGGABLE
-
-Layer *create_swiglu_layer_cl() {
-  auto layer = new SwiGLULayerCl();
-  return layer;
-}
-
-void destroy_swiglu_layer_cl(Layer *layer) { delete layer; }
-
-extern "C" {
-LayerPluggable ml_train_layer_pluggable{create_swiglu_layer_cl,
-                                        destroy_swiglu_layer_cl};
-}
-
-#endif
 } // namespace nntrainer

--- a/nntrainer/layers/cl_layers/transpose_cl.cpp
+++ b/nntrainer/layers/cl_layers/transpose_cl.cpp
@@ -70,20 +70,4 @@ void TransposeLayerCl::setProperty(const std::vector<std::string> &values) {
   }
 }
 
-#ifdef PLUGGABLE
-
-Layer *create_transpose_layer_cl() {
-  auto layer = new TransposeLayerCl();
-  return layer;
-}
-
-void destroy_transpose_layer_cl(Layer *layer) { delete layer; }
-
-extern "C" {
-LayerPluggable ml_train_layer_pluggable{create_transpose_layer_cl,
-                                        destroy_transpose_layer_cl};
-}
-
-#endif
-
 } // namespace nntrainer


### PR DESCRIPTION
- As far as I know, `PLUGGABLE` flag is valid only for custom layers.
- However, there are pluggable-related codes in  `transpose_cl` and `swiglu_cl` layers.
- This commit removes the code blocks.

**Self evaluation:**

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped