### PR TITLE
[GPU] Global Buffer manager and optimization

### DIFF
--- a/nntrainer/cl_buffer_manager.cpp
+++ b/nntrainer/cl_buffer_manager.cpp
@@ -22,20 +22,20 @@ ClBufferManager &ClBufferManager::getInstance() {
 // to-do: Implementation to be updated with array of Buffer objects if required
 // fp16 Buffer objects to be added in future
 void ClBufferManager::initBuffers() {
-  readBufferA = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
-  readBufferB = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
-  readBufferC = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
-  writeBufferA = new opencl::Buffer(context_inst_, buffer_size_bytes, false);
-  writeBufferB = new opencl::Buffer(context_inst_, buffer_size_bytes, false);
+  inBufferA = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
+  inBufferB = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
+  inBufferC = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
+  outBufferA = new opencl::Buffer(context_inst_, buffer_size_bytes, false);
+  outBufferB = new opencl::Buffer(context_inst_, buffer_size_bytes, false);
   ml_logi("ClBufferManager: Buffers initialized");
 }
 
 ClBufferManager::~ClBufferManager() {
-  delete readBufferA;
-  delete readBufferB;
-  delete readBufferC;
-  delete writeBufferA;
-  delete writeBufferB;
+  delete inBufferA;
+  delete inBufferB;
+  delete inBufferC;
+  delete outBufferA;
+  delete outBufferB;
   ml_logi("ClBufferManager: Buffers destroyed");
 }
 

--- a/nntrainer/cl_buffer_manager.cpp
+++ b/nntrainer/cl_buffer_manager.cpp
@@ -21,7 +21,7 @@ ClBufferManager &ClBufferManager::getInstance() {
 
 // to-do: Implementation to be updated with array of Buffer objects if required
 // fp16 Buffer objects to be added in future
-ClBufferManager::ClBufferManager() {
+void ClBufferManager::initBuffers() {
   readBufferA = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
   readBufferB = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
   readBufferC = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
@@ -36,6 +36,7 @@ ClBufferManager::~ClBufferManager() {
   delete readBufferC;
   delete writeBufferA;
   delete writeBufferB;
+  ml_logi("ClBufferManager: Buffers destroyed");
 }
 
 } // namespace nntrainer

--- a/nntrainer/cl_buffer_manager.cpp
+++ b/nntrainer/cl_buffer_manager.cpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Debadri Samaddar <s.debadri@samsung.com>
+ *
+ * @file    cl_buffer_manager.cpp
+ * @date    01 Dec 2024
+ * @see     https://github.com/nnstreamer/nntrainer
+ * @author  Debadri Samaddar <s.debadri@samsung.com>
+ * @bug     No known bugs except for NYI items
+ * @brief   This file contains global Buffer objects and manages them
+ */
+
+#include <cl_buffer_manager.h>
+
+namespace nntrainer {
+
+ClBufferManager &ClBufferManager::getInstance() {
+  static ClBufferManager instance;
+  return instance;
+}
+
+// to-do: Implementation to be updated with array of Buffer objects if required
+// fp16 Buffer objects to be added in future
+ClBufferManager::ClBufferManager() {
+  readBufferA = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
+  readBufferB = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
+  readBufferC = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
+  writeBufferA = new opencl::Buffer(context_inst_, buffer_size_bytes, false);
+  writeBufferB = new opencl::Buffer(context_inst_, buffer_size_bytes, false);
+  ml_logi("ClBufferManager: Buffers initialized");
+}
+
+ClBufferManager::~ClBufferManager() {
+  delete readBufferA;
+  delete readBufferB;
+  delete readBufferC;
+  delete writeBufferA;
+  delete writeBufferB;
+}
+
+} // namespace nntrainer

--- a/nntrainer/cl_buffer_manager.h
+++ b/nntrainer/cl_buffer_manager.h
@@ -34,7 +34,7 @@ private:
    * @brief Private constructor to prevent object creation
    *
    */
-  ClBufferManager();
+  ClBufferManager(){};
 
   /**
    * @brief OpenCl context global instance
@@ -60,6 +60,11 @@ public:
   opencl::Buffer *readBufferC;
   opencl::Buffer *writeBufferA;
   opencl::Buffer *writeBufferB;
+
+  /**
+   * @brief Initialize Buffer objects.
+   */
+  void initBuffers();
 
   /**
    * @brief Destroy Buffer pointers.

--- a/nntrainer/cl_buffer_manager.h
+++ b/nntrainer/cl_buffer_manager.h
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Debadri Samaddar <s.debadri@samsung.com>
+ *
+ * @file    cl_buffer_manager.h
+ * @date    01 Dec 2024
+ * @see     https://github.com/nnstreamer/nntrainer
+ * @author  Debadri Samaddar <s.debadri@samsung.com>
+ * @bug     No known bugs except for NYI items
+ * @brief   This file contains global Buffer objects and manages them
+ */
+
+#ifndef __CL_BUFFER_MANAGER_H__
+#define __CL_BUFFER_MANAGER_H__
+
+#include <string>
+
+#include <opencl_buffer.h>
+#include <opencl_context_manager.h>
+
+#include <nntrainer_log.h>
+
+namespace nntrainer {
+
+/**
+ * @class ClBufferManager contains Buffer object management
+ * @brief Support for Buffer management
+ */
+
+class ClBufferManager {
+
+private:
+  /**
+   * @brief Private constructor to prevent object creation
+   *
+   */
+  ClBufferManager();
+
+  /**
+   * @brief OpenCl context global instance
+   *
+   */
+  opencl::ContextManager &context_inst_ = opencl::ContextManager::GetInstance();
+
+  /**
+   * @brief Buffer size in bytes preset (256 mebibytes)
+   */
+  size_t buffer_size_bytes = 8192 * 8192 * sizeof(float);
+
+public:
+  /**
+   * @brief Get Global ClBufferManager.
+   *
+   * @return ClBufferManager&
+   */
+  static ClBufferManager &getInstance();
+
+  opencl::Buffer *readBufferA;
+  opencl::Buffer *readBufferB;
+  opencl::Buffer *readBufferC;
+  opencl::Buffer *writeBufferA;
+  opencl::Buffer *writeBufferB;
+
+  /**
+   * @brief Destroy Buffer pointers.
+   *
+   */
+  ~ClBufferManager();
+};
+} // namespace nntrainer
+
+#endif /* __CL_BUFFER_MANAGER_H__ */

--- a/nntrainer/cl_buffer_manager.h
+++ b/nntrainer/cl_buffer_manager.h
@@ -34,7 +34,12 @@ private:
    * @brief Private constructor to prevent object creation
    *
    */
-  ClBufferManager(){};
+  ClBufferManager() :
+    inBufferA(nullptr),
+    inBufferB(nullptr),
+    inBufferC(nullptr),
+    outBufferA(nullptr),
+    outBufferB(nullptr){};
 
   /**
    * @brief OpenCl context global instance
@@ -45,7 +50,13 @@ private:
   /**
    * @brief Buffer size in bytes preset (256 mebibytes)
    */
-  size_t buffer_size_bytes = 8192 * 8192 * sizeof(float);
+  const size_t buffer_size_bytes = 8192 * 8192 * sizeof(float);
+
+  opencl::Buffer *inBufferA;
+  opencl::Buffer *inBufferB;
+  opencl::Buffer *inBufferC;
+  opencl::Buffer *outBufferA;
+  opencl::Buffer *outBufferB;
 
 public:
   /**
@@ -55,16 +66,40 @@ public:
    */
   static ClBufferManager &getInstance();
 
-  opencl::Buffer *readBufferA;
-  opencl::Buffer *readBufferB;
-  opencl::Buffer *readBufferC;
-  opencl::Buffer *writeBufferA;
-  opencl::Buffer *writeBufferB;
-
   /**
    * @brief Initialize Buffer objects.
    */
   void initBuffers();
+
+  /**
+   * @brief Get read only inBufferA.
+   * @return opencl::Buffer* or nullptr if initBuffers() is not called
+   */
+  opencl::Buffer *getInBufferA() { return inBufferA; }
+
+  /**
+   * @brief Get read only inBufferB.
+   * @return opencl::Buffer* or nullptr if initBuffers() is not called
+   */
+  opencl::Buffer *getInBufferB() { return inBufferB; }
+
+  /**
+   * @brief Get read only inBufferC.
+   * @return opencl::Buffer* or nullptr if initBuffers() is not called
+   */
+  opencl::Buffer *getInBufferC() { return inBufferC; }
+
+  /**
+   * @brief Get read-write outBufferA.
+   * @return opencl::Buffer* or nullptr if initBuffers() is not called
+   */
+  opencl::Buffer *getOutBufferA() { return outBufferA; }
+
+  /**
+   * @brief Get read-write outBufferB.
+   * @return opencl::Buffer* or nullptr if initBuffers() is not called
+   */
+  opencl::Buffer *getOutBufferB() { return outBufferB; }
 
   /**
    * @brief Destroy Buffer pointers.

--- a/nntrainer/cl_context.h
+++ b/nntrainer/cl_context.h
@@ -29,6 +29,7 @@
 #include <layer.h>
 #include <layer_devel.h>
 
+#include <cl_buffer_manager.h>
 #include <opencl_command_queue_manager.h>
 #include <opencl_context_manager.h>
 #include <opencl_kernel.h>
@@ -79,11 +80,13 @@ public:
 
   template <typename... Ts> using FactoryMap = std::tuple<IndexType<Ts>...>;
 
-  // getting static instance of commandqueue and opencl context
+  // getting static instance of commandqueue, opencl context and buffermanager
   opencl::CommandQueueManager &command_queue_inst_ =
     opencl::CommandQueueManager::GetInstance();
 
   opencl::ContextManager &context_inst_ = opencl::ContextManager::GetInstance();
+
+  ClBufferManager &clbuffInstance = ClBufferManager::getInstance();
 
   /**
    * @brief   Default constructor
@@ -272,6 +275,9 @@ private:
 
     // getContext() called inside createCommandQueue which creates clContext
     bool result = command_queue_inst_.CreateCommandQueue();
+    // initialize device buffers
+    clbuffInstance.initBuffers();
+
     cl_initialized = result;
     return cl_initialized;
   };

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -64,7 +64,9 @@ nntrainer_common_sources = [
 
 if get_option('enable-opencl')
   nntrainer_headers += meson.current_source_dir() / 'cl_context.h'
+  nntrainer_headers += meson.current_source_dir() / 'cl_buffer_manager.h'
   nntrainer_common_sources += 'cl_context.cpp'
+  nntrainer_common_sources += 'cl_buffer_manager.cpp'
 endif
 
 foreach s : nntrainer_common_sources

--- a/nntrainer/opencl/opencl_buffer.cpp
+++ b/nntrainer/opencl/opencl_buffer.cpp
@@ -27,7 +27,7 @@ namespace nntrainer::opencl {
  * @param read_only flag
  * @param data data for the buffer
  */
-Buffer::Buffer(ContextManager &context_manager, int size_in_bytes,
+Buffer::Buffer(ContextManager &context_manager, size_t size_in_bytes,
                bool read_only, void *data) {
   cl_context context = context_manager.GetContext();
   cl_mem_flags flags = read_only ? CL_MEM_READ_ONLY : CL_MEM_READ_WRITE;
@@ -94,6 +94,20 @@ bool Buffer::WriteData(CommandQueueManager &command_queue_inst,
   return command_queue_inst.EnqueueWriteBuffer(mem_buf_, size_, data);
 }
 
+bool Buffer::WriteDataRegion(CommandQueueManager &command_queue_inst,
+                             size_t size_in_bytes, const void *data,
+                             size_t host_origin_offset,
+                             size_t buffer_origin_offset) {
+  if (size_in_bytes > size_) {
+    ml_loge("Failed to write buffer region. Region size(%lu bytes) greater "
+            "than buffer size(%lu bytes).",
+            size_in_bytes, size_);
+    return false;
+  }
+  return command_queue_inst.EnqueueWriteBufferRegion(
+    mem_buf_, size_in_bytes, data, host_origin_offset, buffer_origin_offset);
+}
+
 /**
  * @brief reading data from the buffer
  *
@@ -103,6 +117,20 @@ bool Buffer::WriteData(CommandQueueManager &command_queue_inst,
  */
 bool Buffer::ReadData(CommandQueueManager &command_queue_inst, void *data) {
   return command_queue_inst.EnqueueReadBuffer(mem_buf_, size_, data);
+}
+
+bool Buffer::ReadDataRegion(CommandQueueManager &command_queue_inst,
+                            size_t size_in_bytes, void *data,
+                            size_t host_origin_offset,
+                            size_t buffer_origin_offset) {
+  if (size_in_bytes > size_) {
+    ml_loge("Failed to read from buffer region. Region size(%lu bytes) greater "
+            "than buffer size(%lu bytes).",
+            size_in_bytes, size_);
+    return false;
+  }
+  return command_queue_inst.EnqueueReadBufferRegion(
+    mem_buf_, size_in_bytes, data, host_origin_offset, buffer_origin_offset);
 }
 
 void *Buffer::MapBuffer(CommandQueueManager &command_queue_inst,

--- a/nntrainer/opencl/opencl_buffer.h
+++ b/nntrainer/opencl/opencl_buffer.h
@@ -54,8 +54,8 @@ public:
    * @param read_only flag
    * @param data data for the buffer
    */
-  Buffer(ContextManager &context_manager, int size_in_bytes, bool read_only,
-         void *data);
+  Buffer(ContextManager &context_manager, size_t size_in_bytes, bool read_only,
+         void *data = nullptr);
 
   /**
    * @brief Move constructor for buffer by deleting the previous buffer
@@ -107,6 +107,21 @@ public:
   bool WriteData(CommandQueueManager &command_queue_inst, const void *data);
 
   /**
+   * @brief writing data to a buffer region
+   *
+   * @param command_queue_inst reference of command queue instance
+   * @param size_in_bytes size of region
+   * @param data pointer of region
+   * @param host_origin_offset offset in the host memory region
+   * @param buffer_origin_offset offset in the buffer memory region
+   * @return true if successful write or false otherwise
+   */
+  bool WriteDataRegion(CommandQueueManager &command_queue_inst,
+                       size_t size_in_bytes, const void *data,
+                       size_t host_origin_offset = 0,
+                       size_t buffer_origin_offset = 0);
+
+  /**
    * @brief reading data from the buffer
    *
    * @param command_queue_inst reference of command queue instance
@@ -114,6 +129,21 @@ public:
    * @return true if successful read or false otherwise
    */
   bool ReadData(CommandQueueManager &command_queue_inst, void *data);
+
+  /**
+   * @brief Reading data from a buffer region
+   *
+   * @param command_queue_inst reference of command queue instance
+   * @param size_in_bytes size of region
+   * @param data pointer of region
+   * @param host_origin_offset offset in the host memory region
+   * @param buffer_origin_offset offset in the buffer memory region
+   * @return true if successful write or false otherwise
+   */
+  bool ReadDataRegion(CommandQueueManager &command_queue_inst,
+                      size_t size_in_bytes, void *data,
+                      size_t host_origin_offset = 0,
+                      size_t buffer_origin_offset = 0);
 
   /**
    * @brief Mapping buffer to host memory

--- a/nntrainer/opencl/opencl_command_queue_manager.h
+++ b/nntrainer/opencl/opencl_command_queue_manager.h
@@ -74,6 +74,22 @@ public:
                          bool async = false);
 
   /**
+   * @brief Reading 1D region from a buffer object. Used from Buffer class
+   *
+   * @param buffer cl_mem buffer object
+   * @param size_in_bytes size of data region
+   * @param data pointer for the region
+   * @param host_origin_offset offset in the host memory region
+   * @param buffer_origin_offset offset in the buffer memory region
+   * @param async flag for asynchronous operation
+   * @return true if reading is successful or false otherwise
+   */
+  bool EnqueueReadBufferRegion(cl_mem buffer, size_t size_in_bytes, void *data,
+                               size_t host_origin_offset = 0,
+                               size_t buffer_origin_offset = 0,
+                               bool async = false);
+
+  /**
    * @brief Writing buffer object. Used from Buffer class
    *
    * @param buffer cl_mem buffer object
@@ -85,6 +101,20 @@ public:
   bool EnqueueWriteBuffer(cl_mem buffer, size_t size_in_bytes, const void *data,
                           bool async = false);
 
+  /**
+   * @brief Writing 1D region of a buffer object. Used from Buffer class
+   *
+   * @param buffer cl_mem buffer object
+   * @param size_in_bytes size of data region
+   * @param data pointer for the region
+   * @param origin_offset offset in the memory region
+   * @param async flag for asynchronous operation
+   * @return true if writing is successful or false otherwise
+   */
+  bool EnqueueWriteBufferRegion(cl_mem buffer, size_t size_in_bytes,
+                                const void *data, size_t host_origin_offset = 0,
+                                size_t buffer_origin_offset = 0,
+                                bool async = false);
   /**
    * @brief Mapping a region of a buffer object into the host address space
    *

--- a/nntrainer/opencl/opencl_loader.cpp
+++ b/nntrainer/opencl/opencl_loader.cpp
@@ -75,6 +75,8 @@ void LoadOpenCLFunctions(void *libopencl) {
   LoadFunction(clEnqueueReadBuffer);
   LoadFunction(clEnqueueMapBuffer);
   LoadFunction(clEnqueueUnmapMemObject);
+  LoadFunction(clEnqueueWriteBufferRect);
+  LoadFunction(clEnqueueReadBufferRect);
   LoadFunction(clCreateProgramWithSource);
   LoadFunction(clCreateProgramWithBinary);
   LoadFunction(clBuildProgram);
@@ -102,6 +104,8 @@ PFN_clEnqueueWriteBuffer clEnqueueWriteBuffer;
 PFN_clEnqueueReadBuffer clEnqueueReadBuffer;
 PFN_clEnqueueMapBuffer clEnqueueMapBuffer;
 PFN_clEnqueueUnmapMemObject clEnqueueUnmapMemObject;
+PFN_clEnqueueWriteBufferRect clEnqueueWriteBufferRect;
+PFN_clEnqueueReadBufferRect clEnqueueReadBufferRect;
 PFN_clCreateProgramWithSource clCreateProgramWithSource;
 PFN_clCreateProgramWithBinary clCreateProgramWithBinary;
 PFN_clBuildProgram clBuildProgram;

--- a/nntrainer/opencl/opencl_loader.h
+++ b/nntrainer/opencl/opencl_loader.h
@@ -87,6 +87,24 @@ typedef cl_int(CL_API_CALL *PFN_clEnqueueUnmapMemObject)(
   const cl_event * /**< event_wait_list */, cl_event * /**< event */
 );
 
+typedef cl_int(CL_API_CALL *PFN_clEnqueueWriteBufferRect)(
+  cl_command_queue /**< command_queue */, cl_mem /**< buffer */,
+  cl_bool /**< blocking_write */, const size_t * /**< buffer_offset */,
+  const size_t * /**< host_offset */, const size_t * /**< region */,
+  size_t /**< buffer_row_pitch */, size_t /**< buffer_slice_pitch */,
+  size_t /**< host_row_pitch */, size_t /**< host_slice_pitch */,
+  const void * /**< ptr */, cl_uint /**< num_events_in_wait_list */,
+  const cl_event * /**< event_wait_list */, cl_event * /**< event */);
+
+typedef cl_int(CL_API_CALL *PFN_clEnqueueReadBufferRect)(
+  cl_command_queue /**< command_queue */, cl_mem /**< buffer */,
+  cl_bool /**< blocking_read */, const size_t * /**< buffer_offset */,
+  const size_t * /**< host_offset */, const size_t * /**< region */,
+  size_t /**< buffer_row_pitch */, size_t /**< buffer_slice_pitch */,
+  size_t /**< host_row_pitch */, size_t /**< host_slice_pitch */,
+  void * /**< ptr */, cl_uint /**< num_events_in_wait_list */,
+  const cl_event * /**< event_wait_list */, cl_event * /**< event */);
+
 typedef cl_program(CL_API_CALL *PFN_clCreateProgramWithSource)(
   cl_context /**< context */, cl_uint /**< count */,
   const char ** /**< strings */, const size_t * /**< lengths */,
@@ -161,6 +179,8 @@ extern PFN_clEnqueueWriteBuffer clEnqueueWriteBuffer;
 extern PFN_clEnqueueReadBuffer clEnqueueReadBuffer;
 extern PFN_clEnqueueMapBuffer clEnqueueMapBuffer;
 extern PFN_clEnqueueUnmapMemObject clEnqueueUnmapMemObject;
+extern PFN_clEnqueueWriteBufferRect clEnqueueWriteBufferRect;
+extern PFN_clEnqueueReadBufferRect clEnqueueReadBufferRect;
 extern PFN_clCreateProgramWithSource clCreateProgramWithSource;
 extern PFN_clCreateProgramWithBinary clCreateProgramWithBinary;
 extern PFN_clBuildProgram clBuildProgram;

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -39,41 +39,40 @@ void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
 
     size_t dim1_size = sizeof(float) * dim1;
     size_t dim2_size = sizeof(float) * dim2;
-    opencl::Buffer inputA(cl_context_ref.context_inst_,
-                          dim1 * dim2 * sizeof(float), true, nullptr);
 
-    opencl::Buffer inputX(cl_context_ref.context_inst_, dim2_size, true,
-                          nullptr);
-
-    opencl::Buffer inOutY(cl_context_ref.context_inst_, dim1_size, true,
-                          nullptr);
-
-    result = inputA.WriteData(cl_context_ref.command_queue_inst_, matAdata);
+    result = clbuffInstance.readBufferA->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim1 * dim2 * sizeof(float),
+      matAdata);
     if (!result) {
       break;
     }
 
-    result = inputX.WriteData(cl_context_ref.command_queue_inst_, vecXdata);
+    result = clbuffInstance.readBufferB->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim2_size, vecXdata);
     if (!result) {
       break;
     }
 
-    result = inOutY.WriteData(cl_context_ref.command_queue_inst_, vecYdata);
+    result = clbuffInstance.writeBufferA->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim1_size, vecYdata);
     if (!result) {
       break;
     }
 
-    result = kernel_sgemv_ptr->SetKernelArguments(0, &inputA, sizeof(cl_mem));
+    result = kernel_sgemv_ptr->SetKernelArguments(0, clbuffInstance.readBufferA,
+                                                  sizeof(cl_mem));
     if (!result) {
       break;
     }
 
-    result = kernel_sgemv_ptr->SetKernelArguments(1, &inputX, sizeof(cl_mem));
+    result = kernel_sgemv_ptr->SetKernelArguments(1, clbuffInstance.readBufferB,
+                                                  sizeof(cl_mem));
     if (!result) {
       break;
     }
 
-    result = kernel_sgemv_ptr->SetKernelArguments(2, &inOutY, sizeof(cl_mem));
+    result = kernel_sgemv_ptr->SetKernelArguments(
+      2, clbuffInstance.writeBufferA, sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -97,7 +96,8 @@ void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
       break;
     }
 
-    result = inOutY.ReadData(cl_context_ref.command_queue_inst_, vecYdata);
+    result = clbuffInstance.writeBufferA->ReadDataRegion(
+      cl_context_ref.command_queue_inst_, dim1_size, vecYdata);
     if (!result) {
       break;
     }

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -40,39 +40,39 @@ void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
     size_t dim1_size = sizeof(float) * dim1;
     size_t dim2_size = sizeof(float) * dim2;
 
-    result = clbuffInstance.readBufferA->WriteDataRegion(
+    result = clbuffInstance.getInBufferA()->WriteDataRegion(
       cl_context_ref.command_queue_inst_, dim1 * dim2 * sizeof(float),
       matAdata);
     if (!result) {
       break;
     }
 
-    result = clbuffInstance.readBufferB->WriteDataRegion(
+    result = clbuffInstance.getInBufferB()->WriteDataRegion(
       cl_context_ref.command_queue_inst_, dim2_size, vecXdata);
     if (!result) {
       break;
     }
 
-    result = clbuffInstance.writeBufferA->WriteDataRegion(
+    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
       cl_context_ref.command_queue_inst_, dim1_size, vecYdata);
     if (!result) {
       break;
     }
 
-    result = kernel_sgemv_ptr->SetKernelArguments(0, clbuffInstance.readBufferA,
-                                                  sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemv_ptr->SetKernelArguments(1, clbuffInstance.readBufferB,
-                                                  sizeof(cl_mem));
+    result = kernel_sgemv_ptr->SetKernelArguments(
+      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_sgemv_ptr->SetKernelArguments(
-      2, clbuffInstance.writeBufferA, sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+    if (!result) {
+      break;
+    }
+
+    result = kernel_sgemv_ptr->SetKernelArguments(
+      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -96,7 +96,7 @@ void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
       break;
     }
 
-    result = clbuffInstance.writeBufferA->ReadDataRegion(
+    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
       cl_context_ref.command_queue_inst_, dim1_size, vecYdata);
     if (!result) {
       break;

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -14,15 +14,18 @@
 #ifndef __BLAS_KERNELS_H__
 #define __BLAS_KERNELS_H__
 
+#include <cl_buffer_manager.h>
 #include <cl_context.h>
 #include <opencl_buffer.h>
 #include <opencl_kernel.h>
+
 #include <string>
 
 namespace nntrainer {
 
 // get global cl_context to use in kernels
 static ClContext cl_context_ref;
+static ClBufferManager &clbuffInstance = ClBufferManager::getInstance();
 
 /**
  * @brief     sgemv computation : Y = A*X + Y


### PR DESCRIPTION
Optimized GPU pipeline by managing `Buffer` creations globally:

- Added singleton class `ClBufferManager` for global `Buffer` objects.
- Created 5 buffers of 256 mebibytes globally which can be used by all the kernels multiple times.
- Added wrappers for OpenCL APIs `clEnqueueReadBufferRect` and `clEnqueueWriteBufferRect`.
- Implemented `WriteDataRegion` and `ReadDataRegion` members of `Buffer` class to read and write to a particular region of device  buffer.
- Lazy initialization of buffers at `cl_context`.
- Tested with BLAS kernels.

These changes optimizes the current GPU pipeline by managing device buffers optimally.

> Note: Device buffer preset size can be modified later if required.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Debadri Samaddar <s.debadri@samsung.com>