### PR TITLE
[CI] Replace TAOS -> gitaction & Add more CI

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+---
+name: Issue report
+about: Create a report to help us improve
+
+---
+
+Having problems with a source code of a github repository?
+
+Having problems with the CI bot that controls the build process?
+
+Good to go? Then please remove these lines above, including this one, and help us understand your issue by answering the following:
+
+# Issue Description
+A clear and concise description of what the bug is.
+
+Expected Result
+============
+A clear and concise description of what you expected to happen.
+
+How to Reproduce
+===============
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+
+Further Information
+===============
+* A link to an output result showing the issue
+* Exact OS version

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+Having problems with a source code of a github repository?
+
+Having problems with the CI bot that controls the build process?
+
+Good to go? Then please remove these lines above, including this one, and help us understand your issue by answering the following:
+
+# Issue Description
+A clear and concise description of what the bug is.
+
+Expected Result
+============
+A clear and concise description of what you expected to happen.
+
+How to Reproduce
+===============
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+
+Further Information
+===============
+* A link to an output result showing the issue
+* Exact OS version

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. For example, I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/Support_request.md
+++ b/.github/ISSUE_TEMPLATE/Support_request.md
@@ -1,0 +1,13 @@
+---
+name: Support Request
+about: Report a problem with our project source code
+
+---
+
+![WARNING](https://media.giphy.com/media/Zsx8ZwmX3ajny/giphy.gif)
+
+Please only create issues/feature requests for the project here.
+
+For support contact our project maintainer(s), they meet online in a 'Issues' list.
+There you can ask questions if you have trouble understanding something, seek advice and mingle with other project members.
+For further information see 'Wiki' page.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+
+---
+# [Template] PR Description
+
+In general, github system automatically copies your commit message for your convenience.
+Please remove unused part of the template after writing your own PR description with this template.
+```bash
+$ git commit -s filename1 filename2 ... [enter]
+
+Summarize changes in around 50 characters or less
+
+More detailed explanatory text, if necessary. Wrap it to about 72
+characters or so. In some contexts, the first line is treated as the
+subject of the commit and the rest of the text as the body. The
+blank line separating the summary from the body is critical;
+various tools like `log`, `shortlog` and `rebase` can get confused 
+if you run the two together.
+
+Further paragraphs come after blank lines.
+
+**Changes proposed in this PR:**
+- Bullet points are okay, too
+- Typically a hyphen or asterisk is used for the bullet, preceded
+  by a single space, with blank lines in between, but conventions vary here.
+
+Resolves: #123
+See also: #456, #789
+
+**Self evaluation:**
+1. Build test: [ ]Passed [ ]Failed [*]Skipped
+2. Run test: [ ]Passed [ ]Failed [*]Skipped
+
+**How to evaluate:**
+1. Describe how to evaluate in order to be reproduced by reviewer(s).
+
+Add signed-off message automatically by running **$git commit -s ...** command.
+
+$ git push origin <your_branch_name>
+```
+

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+# Security policy
+
+1. [Vulnerability Reports Table](#1-vulnerability-reports-table)  
+2. [Vulnerability Report](#2-vulnerability-report)  
+3. [Security Disclosure](#3-security-disclosure)  
+
+---
+
+## 1. Vulnerability Reports Table
+
+Table reports on vulnerabilities found and patches/descriptions to mitigating them.
+| Version     | Vulnerability | Patch/description |
+| ----------- | --------------|-------------------|
+| 1.x.x       | N/A           |                   |
+| 2.x.x       | N/A           |                   |
+
+---
+
+## 2. Vulnerability Report
+
+Search and fix of vulnerability issue is the highest priority for the NNStreamer project team.
+
+Please report security bugs by contact to [jaeyun-jung](https://github.com/jaeyun-jung) marked "SECURITY".
+NNstreamer team will confirm your request and within 2 week will try to prepare recommendations for elimination. Our team will keep you updated on the progress towards the fix until the full announcement of the patch release. During this process, the NNStreamer team may request additional information or guidance.
+
+---
+
+## 3. Security Disclosure
+
+When a person responsible for security receives a vulnerability report as previously mentioned, it is assigned the highest priority and the person in charge. This person will coordinate the patch and release process.
+
+Actions that must be made by the NNStreamer team.
+  * Confirm the problem and identify the affected versions.
+  * Check the code to find any similar problems.
+  * Prepare fixes for all releases still in maintenance. These fixes will
+    released as quickly as possible.
+
+We suggest the following format when disclosing vulnerabilities:
+
+  * Your name and email.
+  * Include scope of vulnerability. Let us know who could use this exploit.
+  * Document steps to identify the vulnerability. It is important that we can reproduce your findings. 
+  * How to exploit vulnerability, give us an attack scenario.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,110 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '34 18 * * 5'
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ 'ubuntu-22.04' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: c-cpp
+          build-mode: manual
+        - language: python
+          build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
+        sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
+        sudo apt-get install -y python3-dev python3-numpy python3
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        sudo apt-get install build-essential
+        sudo apt update
+        sudo apt install -y gcc-13
+        sudo apt install -y g++-13
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1000 
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 1000
+        sudo update-alternatives --set gcc /usr/bin/gcc-13
+        pip install meson ninja
+        meson setup \
+          --buildtype=plain \
+          --prefix=/usr \
+          --sysconfdir=/etc \
+          --libdir=lib/x86_64-linux-gnu \
+          --bindir=lib/nntrainer/bin \
+          --includedir=include \
+          -Dinstall-app=true \
+          -Dreduce-tolerance=false \
+          -Denable-debug=true \
+          -Dml-api-support=enabled \
+          -Denable-nnstreamer-tensor-filter=enabled \
+          -Denable-nnstreamer-tensor-trainer=enabled \
+          -Denable-nnstreamer-backbone=true \
+          -Dcapi-ml-common-actual=capi-ml-common \
+          -Dcapi-ml-inference-actual=capi-ml-inference \
+          -Denable-capi=enabled \
+          build/
+        meson compile -C build/
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
This is a pull request to add and modify necessary actions as we completely disable TAOS CI in NNTrainer.
- Add CodeQL to nntrainer (This .yml file, simply copy from nnstreamer's ci file )
- i will add more action for variout test

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
3. Run test:	 [X]Passed [ ]Failed [ ]Skipped