### PR TITLE
[Wait for #2819] [BCQ] Add a feature to enable BCQ tensor as a weight type

### DIFF
--- a/api/ccapi/include/tensor_dim.h
+++ b/api/ccapi/include/tensor_dim.h
@@ -49,7 +49,7 @@ public:
 
   /**
    * @brief Tensor Data Type.
-   * Currently support QINT4, QINT8, UINT8, UINT16, UINT32, FP16 & FP32
+   * Currently support QINT4, QINT8, BCQ, UINT8, UINT16, UINT32, FP16 & FP32
    */
   enum class DataType {
     QINT4,  /** quantized int 4*/
@@ -115,8 +115,8 @@ public:
    * @brief     Creator of TensorDim with Format & DataType
    *
    * @param fm format NCHW | HNWC
-   * @param d_type DataType QINT4 | QINT8 | UINT8 | UINT16 | UINT32 | FP16 |
-   * FP32
+   * @param d_type DataType QINT4 | QINT8 | BCQ | UINT8 | UINT16 | UINT32 | FP16
+   * | FP32
    * @param eff_dim_flag_ effective dimension flag (1 means it's effective)
    * @param dyn_dim_flag_ dynamic dimension flag (1 means it's unspecified)
    */
@@ -219,8 +219,8 @@ public:
    * @param h height
    * @param w width
    * @param fm format NCHW | HNWC
-   * @param d_type DataType QINT4 | QINT8 | UINT8 | UINT16 | UINT32 | FP16 |
-   * FP32
+   * @param d_type DataType QINT4 | QINT8 | BCQ | UINT8 | UINT16 | UINT32 | FP16
+   * | FP32
    * @param eff_dim_flag_ dimension bit flag to calculate the dynamic
    * dimension, rightmost is width
    */
@@ -249,8 +249,8 @@ public:
    *
    * @param shape shape of format
    * @param fm format NCHW | HNWC
-   * @param d_type DataType QINT4 | QINT8 | UINT8 | UINT16 | UINT32 | FP16 |
-   * FP32
+   * @param d_type DataType QINT4 | QINT8 | BCQ | UINT8 | UINT16 | UINT32 | FP16
+   * | FP32
    * @param order data storage order ROW_MAJOR | COL_MAJOR
    */
   TensorDim(const std::string &shape, TensorDim::Format fm,

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -201,14 +201,24 @@ public:
  * @brief     Enumeration of Data Type for model & layer
  */
 struct ModelTensorDataTypeInfo {
-  enum Enum { W4A16, W4A32, W8A16, W8A32, W16A16, W16A32, W32A16, W32A32 };
+  enum Enum {
+    W3A32,
+    W4A16,
+    W4A32,
+    W8A16,
+    W8A32,
+    W16A16,
+    W16A32,
+    W32A16,
+    W32A32
+  };
   static constexpr std::initializer_list<Enum> EnumList = {
-    Enum::W4A16,  Enum::W4A32,  Enum::W8A16,  Enum::W8A32,
+    Enum::W3A32,  Enum::W4A16,  Enum::W4A32,  Enum::W8A16, Enum::W8A32,
     Enum::W16A16, Enum::W16A32, Enum::W32A16, Enum::W32A32};
 
   static constexpr const char *EnumStr[] = {
-    "QINT4-FP16", "QINT4-FP32", "QINT8-FP16", "QINT8-FP32",
-    "FP16-FP16",  "FP16-FP32",  "FP32-FP16",  "FP32-FP32"};
+    "BCQ-FP32",  "QINT4-FP16", "QINT4-FP32", "QINT8-FP16", "QINT8-FP32",
+    "FP16-FP16", "FP16-FP32",  "FP32-FP16",  "FP32-FP32"};
 };
 
 /**

--- a/nntrainer/tensor/bcq_tensor.cpp
+++ b/nntrainer/tensor/bcq_tensor.cpp
@@ -269,11 +269,15 @@ std::vector<unsigned int> BCQTensor::argmax() const {
   return result;
 }
 
-// void BCQTensor::save_quant_bit(std::ostream &file) { return; }
+void BCQTensor::save_quantization_info(std::ostream &file) {
+  checkedWrite(file, (char *)&quantized_bit_size, sizeof(uint16_t),
+               "[BCQTensor::save] failed to write quantization information");
+}
 
-// void BCQTensor::read_quant_bit(std::ifstream &file) {
-//   file.read((char *)&quantized_bit_size, sizeof(uint16_t));
-// }
+void BCQTensor::read_quantization_info(std::ifstream &file) {
+  checkedRead(file, (char *)&quantized_bit_size, sizeof(uint16_t),
+              "[BCQTensor::read] failed to read quantization information");
+}
 
 size_t BCQTensor::size() const {
   return quantized_bit_size * dim.height() * ((dim.width() + 31) / 32);

--- a/nntrainer/tensor/bcq_tensor.h
+++ b/nntrainer/tensor/bcq_tensor.h
@@ -207,14 +207,14 @@ public:
   std::vector<unsigned int> argmax() const override;
 
   /**
-   * @copydoc TensorBase::save_quant_bit(std::ostream &file)
+   * @copydoc TensorBase::save_quantization_info(std::ostream &file)
    */
-  // void save_quant_bit(std::ostream &file) override;
+  void save_quantization_info(std::ostream &file) override;
 
   /**
-   * @copydoc TensorBase::read_quant_bit(std::ifstream &file)
+   * @copydoc TensorBase::read_quantization_info(std::ifstream &file)
    */
-  // void read_quant_bit(std::ifstream &file) override;
+  void read_quantization_info(std::ifstream &file) override;
 
   /**
    * @copydoc TensorBase::size()

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1094,9 +1094,11 @@ void Tensor::save(std::ostream &file) {
   /// @note Save quantization information which only works on Quantized Tensor
   itensor->save_quantization_info(file);
 
-  std::streamsize sz = static_cast<std::streamsize>(bytes() + scale_size());
+  /// @note Scale factors are temporary fixed to float for now
+  std::streamsize sz =
+    static_cast<std::streamsize>(bytes() + scale_size() * sizeof(float));
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
-    << "save size: " << bytes() + scale_size()
+    << "save size: " << bytes() + scale_size() * sizeof(float)
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedWrite(file, getData<char>(), sz, "[Tensor::save] operation failed");
@@ -1110,10 +1112,12 @@ void Tensor::read(std::ifstream &file) {
   /// @note Read quantization information which only works on Quantized Tensor
   itensor->read_quantization_info(file);
 
-  std::streamsize sz = static_cast<std::streamsize>(bytes() + scale_size());
+  /// @note Scale factors are temporary fixed to float for now
+  std::streamsize sz =
+    static_cast<std::streamsize>(bytes() + scale_size() * sizeof(float));
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
-    << "read size: " << bytes() + scale_size()
+    << "read size: " << bytes() + scale_size() * sizeof(float)
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedRead(file, getData<char>(), sz, "[Tensor::read] operation failed");

--- a/nntrainer/utils/base_properties.h
+++ b/nntrainer/utils/base_properties.h
@@ -661,9 +661,10 @@ void from_string(const std::string &value, std::vector<T> &property) {
 struct TensorDataTypeInfo {
   using Enum = nntrainer::TensorDim::DataType;
   static constexpr std::initializer_list<Enum> EnumList = {
-    Enum::QINT4, Enum::QINT8, Enum::FP16, Enum::FP32};
+    Enum::BCQ, Enum::QINT4, Enum::QINT8, Enum::FP16, Enum::FP32};
 
-  static constexpr const char *EnumStr[] = {"QINT4", "QINT8", "FP16", "FP32"};
+  static constexpr const char *EnumStr[] = {"BCQ", "QINT4", "QINT8", "FP16",
+                                            "FP32"};
 };
 
 /**


### PR DESCRIPTION
[ BCQ ] Support BCQ type as model Weight
    
- Previous PR enabled BCQTensor.
- This PR enables BCQTensor as a weight.
- This PR add BCQ-FP32 as a weight-activation type.
    
**Self-evaluation:**
    
Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped
    
Signed-off-by: Eunju Yang <ej.yang@samsung.com>