### PR TITLE
docs: fix typo

### DIFF
--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -179,7 +179,7 @@ typedef enum {
  * }
  *
  * // Fill label data
- * for (int idx = 0; idx < num_inputs; ++ idx) {
+ * for (int idx = 0; idx < num_labels; ++ idx) {
  *   for (int len = 0; len < label_length[idx]; ++ len) {
  *     label[idx][len] = rand();
  *   }


### PR DESCRIPTION
---
# Fix typo in header file

It's about fixing typo to example code `ml_train_datagen_cb` of  `nntrainer-api-common.h`