### PR TITLE
[ minor ] bugfix in printing error log (model_commo_properties / LossScale)

### DIFF
--- a/nntrainer/models/model_common_properties.cpp
+++ b/nntrainer/models/model_common_properties.cpp
@@ -43,8 +43,10 @@ ModelTensorDataType::ModelTensorDataType(ModelTensorDataTypeInfo::Enum value) {
 LossScale::LossScale(float value) { set(value); }
 
 bool LossScale::isValid(const float &value) const {
-  ml_loge("Loss scale cannot be 0");
-  return value != 0;
+  bool is_valid = (std::fpclassify(value) != FP_ZERO);
+  if (!is_valid)
+    ml_loge("Loss scale cannot be 0");
+  return is_valid;
 }
 
 } // namespace nntrainer::props


### PR DESCRIPTION
- This commit fixes a minor error to print error log.
- This commit adds a condition to print the error log.

Relevant issue: #2826 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped


