### PR TITLE
Add ComputeEngine Property for choosing Engine

### DIFF
--- a/api/ccapi/include/common.h
+++ b/api/ccapi/include/common.h
@@ -44,6 +44,15 @@ enum class ExecutionMode {
 };
 
 /**
+ * @brief     Enumeration of layer compute engine
+ */
+enum LayerComputeEngine {
+  CPU, /**< CPU as the compute engine */
+  GPU, /**< GPU as the compute engine */
+  QNN, /**< QNN as the compute engine */
+};
+
+/**
  * @brief Get the version of NNTrainer
  */
 extern std::string getVersion();

--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -115,14 +115,6 @@ enum LayerType {
 };
 
 /**
- * @brief     Enumeration of layer compute engine
- */
-enum LayerComputeEngine {
-  CPU, /**< CPU as the compute engine */
-  GPU, /**< GPU as the compute engine */
-};
-
-/**
  * @class   Layer Base class for layers
  * @brief   Base class for all layers
  */
@@ -261,16 +253,14 @@ public:
  */
 std::unique_ptr<Layer>
 createLayer(const LayerType &type,
-            const std::vector<std::string> &properties = {},
-            const LayerComputeEngine &compute_engine = LayerComputeEngine::CPU);
+            const std::vector<std::string> &properties = {});
 
 /**
  * @brief Factory creator with constructor for layer
  */
 std::unique_ptr<Layer>
 createLayer(const std::string &type,
-            const std::vector<std::string> &properties = {},
-            const LayerComputeEngine &compute_engine = LayerComputeEngine::CPU);
+            const std::vector<std::string> &properties = {});
 
 /**
  * @brief General Layer Factory function to register Layer
@@ -343,37 +333,33 @@ DivideLayer(const std::vector<std::string> &properties = {}) {
 /**
  * @brief Helper function to create fully connected layer
  */
-inline std::unique_ptr<Layer> FullyConnected(
-  const std::vector<std::string> &properties = {},
-  const LayerComputeEngine &compute_engine = LayerComputeEngine::CPU) {
-  return createLayer(LayerType::LAYER_FC, properties, compute_engine);
+inline std::unique_ptr<Layer>
+FullyConnected(const std::vector<std::string> &properties = {}) {
+  return createLayer(LayerType::LAYER_FC, properties);
 }
 
 /**
  * @brief Helper function to create Swiglu layer
  */
 inline std::unique_ptr<Layer>
-Swiglu(const std::vector<std::string> &properties = {},
-       const LayerComputeEngine &compute_engine = LayerComputeEngine::CPU) {
-  return createLayer(LayerType::LAYER_SWIGLU, properties, compute_engine);
+Swiglu(const std::vector<std::string> &properties = {}) {
+  return createLayer(LayerType::LAYER_SWIGLU, properties);
 }
 
 /**
  * @brief Helper function to create RMS normalization layer for GPU
  */
 inline std::unique_ptr<Layer>
-RMSNormCl(const std::vector<std::string> &properties = {},
-          const LayerComputeEngine &compute_engine = LayerComputeEngine::GPU) {
-  return createLayer(LayerType::LAYER_RMSNORM, properties, compute_engine);
+RMSNormCl(const std::vector<std::string> &properties = {}) {
+  return createLayer(LayerType::LAYER_RMSNORM, properties);
 }
 
 /**
  * @brief Helper function to create Transpose layer
  */
 inline std::unique_ptr<Layer>
-Transpose(const std::vector<std::string> &properties = {},
-          const LayerComputeEngine &compute_engine = LayerComputeEngine::CPU) {
-  return createLayer(LayerType::LAYER_TRANSPOSE, properties, compute_engine);
+Transpose(const std::vector<std::string> &properties = {}) {
+  return createLayer(LayerType::LAYER_TRANSPOSE, properties);
 }
 
 /**
@@ -428,27 +414,24 @@ Flatten(const std::vector<std::string> &properties = {}) {
  * @brief Helper function to create reshape layer
  */
 inline std::unique_ptr<Layer>
-Reshape(const std::vector<std::string> &properties = {},
-        const LayerComputeEngine &compute_engine = LayerComputeEngine::CPU) {
-  return createLayer(LayerType::LAYER_RESHAPE, properties, compute_engine);
+Reshape(const std::vector<std::string> &properties = {}) {
+  return createLayer(LayerType::LAYER_RESHAPE, properties);
 }
 
 /**
  * @brief Helper function to create addition layer
  */
 inline std::unique_ptr<Layer>
-Addition(const std::vector<std::string> &properties = {},
-         const LayerComputeEngine &compute_engine = LayerComputeEngine::CPU) {
-  return createLayer(LayerType::LAYER_ADDITION, properties, compute_engine);
+Addition(const std::vector<std::string> &properties = {}) {
+  return createLayer(LayerType::LAYER_ADDITION, properties);
 }
 
 /**
  * @brief Helper function to create concat layer
  */
 inline std::unique_ptr<Layer>
-Concat(const std::vector<std::string> &properties = {},
-       const LayerComputeEngine &compute_engine = LayerComputeEngine::CPU) {
-  return createLayer(LayerType::LAYER_CONCAT, properties, compute_engine);
+Concat(const std::vector<std::string> &properties = {}) {
+  return createLayer(LayerType::LAYER_CONCAT, properties);
 }
 
 /**

--- a/api/ccapi/src/factory.cpp
+++ b/api/ccapi/src/factory.cpp
@@ -31,18 +31,16 @@ namespace ml {
 namespace train {
 
 std::unique_ptr<Layer> createLayer(const LayerType &type,
-                                   const std::vector<std::string> &properties,
-                                   const LayerComputeEngine &compute_engine) {
-  return nntrainer::createLayerNode(type, properties, compute_engine);
+                                   const std::vector<std::string> &properties) {
+  return nntrainer::createLayerNode(type, properties);
 }
 
 /**
  * @brief Factory creator with constructor for layer
  */
 std::unique_ptr<Layer> createLayer(const std::string &type,
-                                   const std::vector<std::string> &properties,
-                                   const LayerComputeEngine &compute_engine) {
-  return nntrainer::createLayerNode(type, properties, compute_engine);
+                                   const std::vector<std::string> &properties) {
+  return nntrainer::createLayerNode(type, properties);
 }
 
 std::unique_ptr<Optimizer>

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -18,6 +18,7 @@
 #include <string>
 
 #include <base_properties.h>
+#include <common.h>
 #include <connection.h>
 #include <tensor.h>
 #include <tensor_wrap_specs.h>
@@ -945,10 +946,31 @@ struct ActivationTypeInfo {
  * @brief Activation Enumeration Information
  *
  */
-class Activation final : public EnumProperty<ActivationTypeInfo> {
+class Activation final
+  : public EnumProperty<nntrainer::props::ActivationTypeInfo> {
 public:
   using prop_tag = enum_class_prop_tag;
   static constexpr const char *key = "activation";
+};
+
+/**
+ * @brief     Enumeration of Run Engine type
+ */
+struct ComputeEngineTypeInfo {
+  using Enum = ml::train::LayerComputeEngine;
+  static constexpr std::initializer_list<Enum> EnumList = {Enum::CPU, Enum::GPU,
+                                                           Enum::QNN};
+  static constexpr const char *EnumStr[] = {"cpu", "gpu", "qnn"};
+};
+
+/**
+ * @brief ComputeEngine Enumeration Information
+ *
+ */
+class ComputeEngine final : public EnumProperty<ComputeEngineTypeInfo> {
+public:
+  using prop_tag = enum_class_prop_tag;
+  static constexpr const char *key = "engine";
 };
 
 /**

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -53,6 +53,7 @@ class InputConnection;
 class ClipGradByGlobalNorm;
 class Packed;
 class LossScaleForMixed;
+class ComputeEngine;
 } // namespace props
 
 /**
@@ -994,11 +995,12 @@ will also contain the properties of the layer. The properties will be copied
 upon final creation. Editing properties of the layer after init will not the
 properties in the context/graph unless intended. */
 
-  using PropsType = std::tuple<props::Name, props::Distribute, props::Trainable,
-                               std::vector<props::InputConnection>,
-                               std::vector<props::InputShape>,
-                               props::SharedFrom, props::ClipGradByGlobalNorm,
-                               props::Packed, props::LossScaleForMixed>;
+  using PropsType =
+    std::tuple<props::Name, props::Distribute, props::Trainable,
+               std::vector<props::InputConnection>,
+               std::vector<props::InputShape>, props::SharedFrom,
+               props::ClipGradByGlobalNorm, props::Packed,
+               props::LossScaleForMixed, props::ComputeEngine>;
 
   using RealizationPropsType = std::tuple<props::Flatten, props::Activation>;
   /** these realization properties results in addition of new layers, hence
@@ -1070,9 +1072,7 @@ properties in the context/graph unless intended. */
  */
 std::unique_ptr<LayerNode>
 createLayerNode(const ml::train::LayerType &type,
-                const std::vector<std::string> &properties = {},
-                const ml::train::LayerComputeEngine &compute_engine =
-                  ml::train::LayerComputeEngine::CPU);
+                const std::vector<std::string> &properties = {});
 
 /**
  * @brief LayerNode creator with constructor
@@ -1082,9 +1082,7 @@ createLayerNode(const ml::train::LayerType &type,
  */
 std::unique_ptr<LayerNode>
 createLayerNode(const std::string &type,
-                const std::vector<std::string> &properties = {},
-                const ml::train::LayerComputeEngine &compute_engine =
-                  ml::train::LayerComputeEngine::CPU);
+                const std::vector<std::string> &properties = {});
 
 /**
  * @brief LayerNode creator with constructor
@@ -1095,9 +1093,7 @@ createLayerNode(const std::string &type,
  */
 std::unique_ptr<LayerNode>
 createLayerNode(std::unique_ptr<nntrainer::Layer> &&layer,
-                const std::vector<std::string> &properties,
-                const ml::train::LayerComputeEngine &compute_engine =
-                  ml::train::LayerComputeEngine::CPU);
+                const std::vector<std::string> &properties);
 
 } // namespace nntrainer
 #endif // __LAYER_NODE_H__

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -92,7 +92,7 @@ void Exporter::saveTflResult(
                    std::vector<props::InputConnection>,
                    std::vector<props::InputShape>, props::SharedFrom,
                    props::ClipGradByGlobalNorm, props::Packed,
-                   props::LossScaleForMixed> &props,
+                   props::LossScaleForMixed, props::ComputeEngine> &props,
   const LayerNode *self) {
   createIfNull(tf_node);
   tf_node->setLayerNode(*self);

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -249,7 +249,7 @@ void Exporter::saveTflResult(
                    std::vector<props::InputConnection>,
                    std::vector<props::InputShape>, props::SharedFrom,
                    props::ClipGradByGlobalNorm, props::Packed,
-                   props::LossScaleForMixed> &props,
+                   props::LossScaleForMixed, props::ComputeEngine> &props,
   const LayerNode *self);
 
 class BatchNormalizationLayer;

--- a/test/unittest/layers/layers_dependent_common_tests.cpp
+++ b/test/unittest/layers/layers_dependent_common_tests.cpp
@@ -143,15 +143,13 @@ TEST_P(LayerSemanticsGpu, createFromClContext_pn) {
 // }
 
 TEST_P(LayerSemanticsGpu, setPropertiesInvalid_n) {
-  auto lnode =
-    nntrainer::createLayerNode(expected_type, {}, ComputeEngine::GPU);
+  auto lnode = nntrainer::createLayerNode(expected_type, {"engine=gpu"});
   /** must not crash */
   EXPECT_THROW(layer->setProperty({"unknown_props=2"}), std::invalid_argument);
 }
 
 TEST_P(LayerSemanticsGpu, finalizeValidateLayerNode_p) {
-  auto lnode =
-    nntrainer::createLayerNode(expected_type, {}, ComputeEngine::GPU);
+  auto lnode = nntrainer::createLayerNode(expected_type, {"engine=gpu"});
   std::vector<std::string> props = {"name=test"};
   std::string input_shape = "input_shape=1:1:1";
   std::string input_layers = "input_layers=a";
@@ -181,8 +179,7 @@ TEST_P(LayerSemanticsGpu, finalizeValidateLayerNode_p) {
 }
 
 TEST_P(LayerSemanticsGpu, getTypeValidateLayerNode_p) {
-  auto lnode =
-    nntrainer::createLayerNode(expected_type, {}, ComputeEngine::GPU);
+  auto lnode = nntrainer::createLayerNode(expected_type, {"engine=gpu"});
   std::string type;
 
   EXPECT_NO_THROW(type = lnode->getType());
@@ -190,8 +187,7 @@ TEST_P(LayerSemanticsGpu, getTypeValidateLayerNode_p) {
 }
 
 TEST_P(LayerSemanticsGpu, gettersValidateLayerNode_p) {
-  auto lnode =
-    nntrainer::createLayerNode(expected_type, {}, ComputeEngine::GPU);
+  auto lnode = nntrainer::createLayerNode(expected_type, {"engine=gpu"});
 
   EXPECT_NO_THROW(lnode->supportInPlace());
   EXPECT_NO_THROW(lnode->requireLabel());
@@ -199,8 +195,7 @@ TEST_P(LayerSemanticsGpu, gettersValidateLayerNode_p) {
 }
 
 TEST_P(LayerSemanticsGpu, setBatchValidateLayerNode_p) {
-  auto lnode =
-    nntrainer::createLayerNode(expected_type, {}, ComputeEngine::GPU);
+  auto lnode = nntrainer::createLayerNode(expected_type, {"engine=gpu"});
   std::vector<std::string> props = {"name=test"};
   std::string input_shape = "input_shape=1:1:1";
   std::string input_layers = "input_layers=a";


### PR DESCRIPTION
This PR add ComputeEngine Enum Property.
Enum elements are "cpu", "gpu", "qnn" for now.
The property format is "engine=qnn".

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>

