### PR TITLE
[ BCQ ] Add a feature to enable BCQ tensor as a weight type (cont.)

### DIFF
--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -495,7 +495,8 @@ public:
     Tensor &t_w = weights[idx]->getVariableRef();
 
     if (t_w.getDataType() == Tdatatype::FP32 ||
-        t_w.getDataType() == Tdatatype::FP16) {
+        t_w.getDataType() == Tdatatype::FP16 ||
+        t_w.getDataType() == Tdatatype::BCQ) {
       w = t_w;
       return;
     }


### PR DESCRIPTION
- This patch adds a missing part of #2820.
- In order to use BCQ as a weight, this patch should be included.

**Self-evaluation:**

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped



