### PR TITLE
[ meson ] remove hard code path in meson script @open sesame 12/23 15:55

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -145,16 +145,30 @@ if get_option('opencl-kernel-path') != ''
 endif
 
 if get_option('enable-biqgemm')
-  # check if BiQGEMM directory exist. otherwise, throw an error
-  fs = import('fs')
-  if fs.is_dir('../BiQGEMM')
-    extra_defines += '-DENABLE_BIQGEMM=1'
-    biqgemm_inc = include_directories('../BiQGEMM')
+  # In order to enable biqgemm, BiQGEMM lib, which is header-only library, is required.
+  # This meson tries to find its installation.
+  #   1. Checking 'prefix'/'includedir'/BiQGEMM
+  #   2. Checking path meson-option specifies
+  biqgemm_path = join_paths(get_option('prefix'), get_option('includedir'), 'BiQGEMM')
+  if cxx.has_header('BiQGEMM.h', args: '-I'+biqgemm_path)
+      message('[lib:biqgemm] biqgemm header is found successfully')
+      extra_defines += '-DENABLE_BIQGEMM=1'
+      biqgemm_inc = include_directories(biqgemm_path)
   else
-    error ('BiQGEMM cannot be enabled without BiQGEMM library.')
+      # relative path from biqgemm is assumed
+      biqgemm_path = get_option('biqgemm-path')
+      message('[lib:biqgemm] fallback: finding biqgemm from user-path :' + biqgemm_path)
+      fs = import('fs')
+      if fs.is_dir(biqgemm_path) 
+        message('[lib:biqgemm] biqgemm header is found successfully')
+        extra_defines += '-DENABLE_BIQGEMM=1'
+        biqgemm_inc = include_directories(biqgemm_path)
+      else
+        error ('BiQGEMM cannot be enabled without BiQGEMM library.')
+      endif
   endif
-endif
-    
+endif # end of enable-biqgemm
+
 foreach extra_arg : warning_flags
   if cc.has_argument (extra_arg)
     add_project_arguments([extra_arg], language: 'c')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -44,6 +44,7 @@ option('enable-neon', type: 'boolean', value: false)
 option('enable-avx', type: 'boolean', value: true)
 option('enable-opencl', type: 'boolean', value: false)
 option('enable-biqgemm', type: 'boolean', value: false)
+option('biqgemm-path', type: 'string', value: '../BiQGEMM')
 option('enable-benchmarks', type: 'boolean', value : false)
 
 # ml-api dependency (to enable, install capi-inference from github.com/nnstreamer/api )

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -82,7 +82,12 @@ if get_option('enable-biqgemm')
   tensor_headers += 'bcq_tensor.h'
   tensor_sources += 'bcq_tensor.cpp'
   nntrainer_inc += biqgemm_inc
-  nntrainer_inc_abs += meson.source_root() / '..' / 'BiQGEMM'
+  fs = import('fs')
+  if fs.is_absolute(biqgemm_path)
+    nntrainer_inc_abs += biqgemm_path
+  else
+    nntrainer_inc_abs += meson.source_root() / biqgemm_path
+  endif
 endif
 
 if get_option('enable-opencl')


### PR DESCRIPTION
- This PR reflects the previous comment by @myungjoo [[link](https://github.com/nnstreamer/nntrainer/pull/2823#issuecomment-2533883640)]
    - removing hard code external path in meson script
    - Since BiQGEMM is header-only lib, I skipped the step to search from pkgconfig 
- In the previous version, meson.build contains hard coded path for the BiQGEMM enablement, which is undesirable.
- This commit updates the meson build script including the top meson and tensor meson by adding meson_option and the step to search the default path.

**Self-evaluation:**

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped

