### PR TITLE
[Blas] copy functionality for signed int8 data type

### DIFF
--- a/nntrainer/tensor/blas_interface.h
+++ b/nntrainer/tensor/blas_interface.h
@@ -87,6 +87,15 @@ void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
                            const int incX, _FP16 *Y, const int incY);
 
 /**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X int8_t * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ */
+void scopy_int8_to_float16(const unsigned int N, const int8_t *X,
+                           const int incX, _FP16 *Y, const int incY);
+
+/**
  * @brief     sdot computation : sum of all X * Y
  * @param[in] N number of elements in Y
  * @param[in] X __fp16 * for Vector X
@@ -274,6 +283,16 @@ void scopy(const unsigned int N, const float *X, const int incX, float *Y,
  */
 void scopy(const unsigned int N, const uint8_t *X, const int incX, uint8_t *Y,
            const int incY);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X int8_t * for Vector X
+ * @param[in] Y int8_t * for Vector Y
+ */
+void scopy(const unsigned int N, const int8_t *X, const int incX, int8_t *Y,
+           const int intY);
+
 /**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
@@ -291,6 +310,15 @@ void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
  */
 void scopy_int8_to_float32(const unsigned int N, const uint8_t *X,
                            const int incX, float *Y, const int incY);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X uint8_t * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
+void scopy_int8_to_float32(const unsigned int N, const int8_t *X,
+                           const int incX, float *Y, const int intY);
 
 /**
  * @brief     sdot computation : sum of all X * Y

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -68,10 +68,26 @@ void copy_int8_to_fp32(const unsigned int N, const uint8_t *X, float *Y);
 /**
  * @brief     copy function with neon: Y = X
  * @param[in] N number of elements in X
+ * @param[in] X int8_t * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
+void copy_int8_to_fp32(const unsigned int N, const int8_t *X, float *Y);
+
+/**
+ * @brief     copy function with neon: Y = X
+ * @param[in] N number of elements in X
  * @param[in] X uint8_t * for Vector X
  * @param[in] Y uint8_t * for Vector Y
  */
 void copy_int8_or_int4(const unsigned int N, const uint8_t *X, uint8_t *Y);
+
+/**
+ * @brief     copy function with neon: Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X int8_t * for Vector X
+ * @param[in] Y int8_t * for Vector Y
+ */
+void copy_int8(const unsigned int N, const int8_t *X, int8_t *Y);
 /**
  * @brief     sine with neon: Y = sin(alpha * X)
  * @param[in] N number of elements in X
@@ -310,6 +326,14 @@ void copy_int4_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
  * @param[in] Y uint8_t * for Vector Y
  */
 void copy_int8_to_fp16(const unsigned int N, const uint8_t *X, __fp16 *Y);
+
+/**
+ * @brief     copy function with neon: Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X int8_t * for Vector X
+ * @param[in] Y __fp16 * for Vector Y
+ */
+void copy_int8_to_fp16(const unsigned int N, const int8_t *X, __fp16 *Y);
 
 /**
  * @brief     copy function with neon: Y = X

--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -361,9 +361,7 @@ void CharTensor::copy(const void *buf) {
   }
 
   /// @todo need to optimize
-  for (unsigned int i = 0; i < size(); ++i) {
-    ((int8_t *)getData())[i] = ((int8_t *)buf)[i];
-  }
+  scopy(size(), (int8_t *)buf, 1, (int8_t *)getData(), 1);
 }
 
 void CharTensor::save_quantization_info(std::ostream &file) {

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -764,7 +764,7 @@ void FloatTensor::copyData(const Tensor &from) {
 #endif
     break;
   case ml::train::TensorDim::DataType::QINT8:
-    scopy_int8_to_float32(from.size(), from.getData<uint8_t>(), 1,
+    scopy_int8_to_float32(from.size(), from.getData<int8_t>(), 1,
                           (float *)getData(), 1);
     break;
   default:

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -983,7 +983,7 @@ void HalfTensor::copyData(const Tensor &from) {
     copy(from.getData<_FP16>());
     break;
   case ml::train::TensorDim::DataType::QINT8:
-    scopy_int8_to_float16(from.size(), from.getData<uint8_t>(), 1,
+    scopy_int8_to_float16(from.size(), from.getData<int8_t>(), 1,
                           (_FP16 *)getData(), 1);
     break;
   default:


### PR DESCRIPTION
This pull request aims at adding the functionality to copy the int8 data type into other types such as int8, fp16, and fp32.
Please note that this implementation follows the intrinsic used for copying uint8 values.
By including this feature, we can expect more flexibility in handling different data types which will contribute to overall system performance improvement.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped
