### PR TITLE
[ trivial ] Fix typo & misspelled function param

### DIFF
--- a/nntrainer/tensor/blas_interface.cpp
+++ b/nntrainer/tensor/blas_interface.cpp
@@ -891,7 +891,7 @@ void scopy(const unsigned int N, const float *X, const int incX, float *Y,
 }
 
 void scopy(const unsigned int N, const uint8_t *X, const int incX, uint8_t *Y,
-           const int intY) {
+           const int incY) {
 #ifdef USE_NEON
   nntrainer::neon::copy_int8_or_int4(N, X, Y);
 #else

--- a/nntrainer/tensor/blas_interface.h
+++ b/nntrainer/tensor/blas_interface.h
@@ -265,7 +265,7 @@ void scopy(const unsigned int N, const void *X, const int incX, void *Y,
  * @param[in] Y float * for Vector Y
  */
 void scopy(const unsigned int N, const float *X, const int incX, float *Y,
-           const int intY);
+           const int incY);
 /**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
@@ -273,7 +273,7 @@ void scopy(const unsigned int N, const float *X, const int incX, float *Y,
  * @param[in] Y uint8_t * for Vector Y
  */
 void scopy(const unsigned int N, const uint8_t *X, const int incX, uint8_t *Y,
-           const int intY);
+           const int incY);
 /**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
@@ -281,7 +281,7 @@ void scopy(const unsigned int N, const uint8_t *X, const int incX, uint8_t *Y,
  * @param[in] Y float * for Vector Y
  */
 void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
-                           const int incX, float *Y, const int intY);
+                           const int incX, float *Y, const int incY);
 
 /**
  * @brief     copy function : Y = X
@@ -290,7 +290,7 @@ void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
  * @param[in] Y float * for Vector Y
  */
 void scopy_int8_to_float32(const unsigned int N, const uint8_t *X,
-                           const int incX, float *Y, const int intY);
+                           const int incX, float *Y, const int incY);
 
 /**
  * @brief     sdot computation : sum of all X * Y

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -602,7 +602,7 @@ void custom_scopy(const unsigned int N, const float *X, const int incX,
                          : "r"(&Y[i]), "r"(&X[i])
                          : "v0", "memory");
 #else
-    __scopy_kernel(N, X + i, Y + i);
+    __scopy_kernel(X + i, Y + i);
 #endif
   }
   for (unsigned int i = N4; i < N; ++i) {

--- a/nntrainer/tensor/quantizer.h
+++ b/nntrainer/tensor/quantizer.h
@@ -13,6 +13,7 @@
 #ifdef __cplusplus
 
 #include <tensor.h>
+#include <unordered_map>
 
 namespace nntrainer {
 


### PR DESCRIPTION
- intY -> incY (incremental index of Y)
- __scopy_kernel() only works for interested SIMD register width

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped
