### PR TITLE
[FSU] Modify the condition of LoadTensors

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -393,20 +393,10 @@ sharedConstTensors NeuralNetwork::forwarding(
         unsigned int lookahead =
           std::get<props::MemorySwapLookahead>(model_flex_props);
 
-        if (lookahead != 0) {
-          if ((f) % (lookahead + 1) == lookahead - 1) {
-            std::cout << "request load tensor : " << f + lookahead + 1
-                      << std::endl;
-            ml_logd("request load tensor for %d", f + 1);
-            model_graph.LoadTensors((f / (lookahead + 1) + 1) *
-                                    (lookahead + 1));
-          }
-        } else {
+        if (f != 0) {
           model_graph.LoadTensors(f);
-        }
-
-        if (f != 0)
           model_graph.UnloadTensors(f);
+        }
       }
     }
   };

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -813,9 +813,11 @@ void Manager::LoadTensors(unsigned int order) {
     async_load_tensor[o] = std::make_tuple(load_weight, load_tensor);
   };
 
-  for (unsigned int i = order; i < order + swap_lookahead + 1; ++i) {
-    if (i <= max_exec_order)
+  for (unsigned int i = order>last_order?order:last_order; i < order + swap_lookahead + 1; ++i) {
+    if (!async_load_tensor.count(i) && i <= max_exec_order) {
       enqueTasks(i);
+      last_order = i;
+    }
   }
 }
 

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -137,7 +137,8 @@ public:
     swap_lookahead(0),
     tensor_format("NCHW"),
     tensor_dtype(split("FP32-FP32", getRegex("\\-"))),
-    exec_mode(ExecutionMode::TRAIN) {}
+    exec_mode(ExecutionMode::TRAIN),
+    last_order(0) {}
 
   /**
    * @brief     Constructor of Manager
@@ -154,7 +155,8 @@ public:
     swap_lookahead(lookahead),
     tensor_format(tensor_format_),
     tensor_dtype(split(tensor_dtype_, getRegex("\\-"))),
-    exec_mode(exec_mode_) {}
+    exec_mode(exec_mode_),
+    last_order(0) {}
 
   /**
    * @brief Construct a new Manager object (deleted)
@@ -600,6 +602,8 @@ private:
   ExecutionMode exec_mode;
 
   unsigned int max_exec_order;
+
+  unsigned int last_order;
 
   /**
    * @brief Finalize the given tensor pool


### PR DESCRIPTION
Previously, more layers were loaded into memory than the value of lookahead. 
I modified the code so that the correct number of layers are loaded.

In addition, I removed the conditional statement so that the same code is executed 
when the value of lookahead is 0 and when it is not.

Signed-off-by: SeoHyungjun <hyungjun.seo@samsung.com>