### PR TITLE
 [CharTensor] Enable memory data to store scale factors based on quantization schemes

### DIFF
--- a/nntrainer/tensor/char_tensor.h
+++ b/nntrainer/tensor/char_tensor.h
@@ -12,6 +12,7 @@
 #define __CHAR_TENSOR_H__
 #ifdef __cplusplus
 
+#include <quantizer.h>
 #include <tensor_base.h>
 
 namespace nntrainer {
@@ -25,7 +26,8 @@ public:
   /**
    * @brief     Basic Constructor of Tensor
    */
-  CharTensor(std::string name_ = "", Tformat fm = Tformat::NCHW);
+  CharTensor(std::string name_ = "", Tformat fm = Tformat::NCHW,
+             QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE);
 
   /**
    * @brief Construct a new CharTensor object
@@ -34,27 +36,33 @@ public:
    * @param alloc_now Allocate memory to this tensor or not
    * @param init Initializer for the tensor
    * @param name Name of the tensor
+   * @param qscheme_ Quantization scheme of the tensor
    */
   CharTensor(const TensorDim &d, bool alloc_now,
-             Initializer init = Initializer::NONE, std::string name = "");
+             Initializer init = Initializer::NONE, std::string name = "",
+             QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE);
 
   /**
    * @brief Construct a new CharTensor object
    *
    * @param d Tensor dim for this tensor
    * @param buf buffer
+   * @param qscheme_ quantization scheme of the tensor
    */
-  CharTensor(const TensorDim &d, const void *buf = nullptr);
+  CharTensor(const TensorDim &d, const void *buf = nullptr,
+             QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE);
 
   /**
    * @brief Construct a new CharTensor object
    *
    * @param d data for the Tensor
+   * @param scales scale factors for the Tensor
    * @param fm format for the Tensor
+   * @param qscheme_ quantization scheme of the tensor
    */
   CharTensor(
     std::vector<std::vector<std::vector<std::vector<int8_t>>>> const &d,
-    Tformat fm);
+    std::vector<float> const &scales, Tformat fm, QScheme qscheme_);
 
   /**
    * @brief Construct a new CharTensor object
@@ -100,6 +108,16 @@ public:
    * @copydoc Tensor::getData(size_t idx)
    */
   void *getData(size_t idx) const override;
+
+  /**
+   * @copydoc Tensor::getScale()
+   */
+  void *getScale() const override;
+
+  /**
+   * @copydoc Tensor::getScale(size_t idx)
+   */
+  void *getScale(size_t idx) const override;
 
   /**
    * @brief     i data index
@@ -227,11 +245,21 @@ public:
    */
   void read_quantization_info(std::ifstream &file) override;
 
+  /**
+   * @copydoc Tensor::scale_size()
+   */
+  size_t scale_size() const override;
+
+  /**
+   * @copydoc Tensor::scale_size()
+   */
+  QScheme q_scheme() const;
+
 private:
   /**
-   * @brief quantization axis
+   * @brief quantization scheme
    */
-  uint8_t axis;
+  QScheme qscheme;
 
   /**
    * @brief copy a buffer to @a this, the caller has to ensure that @a this is

--- a/nntrainer/tensor/quantizer.cpp
+++ b/nntrainer/tensor/quantizer.cpp
@@ -10,6 +10,7 @@
 
 #include <math.h>
 #include <quantizer.h>
+#include <tensor.h>
 
 namespace nntrainer {
 
@@ -63,6 +64,8 @@ Tensor PerTensorAffineQuantizer::quantize(const Tensor &input,
       }
     }
   }
+
+  *output.getScale<float>() = scale;
 
   return output;
 }

--- a/nntrainer/tensor/quantizer.h
+++ b/nntrainer/tensor/quantizer.h
@@ -12,10 +12,15 @@
 #define __QUANTIZER_H__
 #ifdef __cplusplus
 
-#include <tensor.h>
+#include <memory>
+#include <stdexcept>
 #include <unordered_map>
 
+#include <tensor_dim.h>
+
 namespace nntrainer {
+
+class Tensor;
 
 /**
  * @brief defines the quantization scheme
@@ -73,7 +78,8 @@ protected:
    * @param input Input tensor
    * @param qtype quantized data type
    */
-  virtual void calculateQParams(const Tensor &input, Tdatatype qtype) = 0;
+  virtual void calculateQParams(const Tensor &input,
+                                ml::train::TensorDim::DataType qtype) = 0;
 
 public:
   /**
@@ -112,14 +118,16 @@ public:
    * @param[in] input Floating point tensor to quantize
    * @return Tensor quantized tensor
    */
-  virtual Tensor quantize(const Tensor &input, Tdatatype qtype) = 0;
+  virtual Tensor quantize(const Tensor &input,
+                          ml::train::TensorDim::DataType qtype) = 0;
 
   /**
    * @brief Dequantize a quantized tensor into a tensor.
    * @param[in] input Quantized tensor to dequantize
    * @return Tensor dequantized tensor
    */
-  virtual Tensor dequantize(const Tensor &input, Tdatatype qtype) = 0;
+  virtual Tensor dequantize(const Tensor &input,
+                            ml::train::TensorDim::DataType qtype) = 0;
 
   /**
    * @brief Get quantization Scheme type.
@@ -172,12 +180,14 @@ public:
   /**
    * @copydoc Quantizer::quantize(const Tensor &input)
    */
-  Tensor quantize(const Tensor &input, Tdatatype qtype) override;
+  Tensor quantize(const Tensor &input,
+                  ml::train::TensorDim::DataType qtype) override;
 
   /**
    * @copydoc Quantizer::dequantize(const Tensor &input)
    */
-  Tensor dequantize(const Tensor &input, Tdatatype dtype) override;
+  Tensor dequantize(const Tensor &input,
+                    ml::train::TensorDim::DataType dtype) override;
 
   /**
    * @copydoc Quantizer::qscheme()
@@ -191,9 +201,11 @@ private:
   long int quant_max;
 
   /**
-   * @copydoc Quantizer::calculateQParams(const Tensor &input, Tdatatype qtype)
+   * @copydoc Quantizer::calculateQParams(const Tensor &input,
+   * ml::train::TensorDim::DataType qtype)
    */
-  void calculateQParams(const Tensor &input, Tdatatype qtype) override;
+  void calculateQParams(const Tensor &input,
+                        ml::train::TensorDim::DataType qtype) override;
 };
 
 /**
@@ -220,12 +232,14 @@ public:
   /**
    * @copydoc Quantizer::quantize(const Tensor &input)
    */
-  Tensor quantize(const Tensor &input, Tdatatype qtype) override;
+  Tensor quantize(const Tensor &input,
+                  ml::train::TensorDim::DataType qtype) override;
 
   /**
    * @copydoc Quantizer::dequantize(const Tensor &input)
    */
-  Tensor dequantize(const Tensor &input, Tdatatype dtype) override;
+  Tensor dequantize(const Tensor &input,
+                    ml::train::TensorDim::DataType dtype) override;
 
   /**
    * @copydoc Quantizer::qscheme()
@@ -239,9 +253,11 @@ private:
   long int quant_max;
 
   /**
-   * @copydoc Quantizer::calculateQParams(const Tensor &input, Tdatatype qtype)
+   * @copydoc Quantizer::calculateQParams(const Tensor &input,
+   * ml::train::TensorDim::DataType qtype)
    */
-  void calculateQParams(const Tensor &input, Tdatatype qtype) override {}
+  void calculateQParams(const Tensor &input,
+                        ml::train::TensorDim::DataType qtype) override {}
 };
 
 /**
@@ -265,12 +281,14 @@ public:
   /**
    * @copydoc Quantizer::quantize(const Tensor &input)
    */
-  Tensor quantize(const Tensor &input, Tdatatype qtype) override;
+  Tensor quantize(const Tensor &input,
+                  ml::train::TensorDim::DataType qtype) override;
 
   /**
    * @copydoc Quantizer::dequantize(const Tensor &input)
    */
-  Tensor dequantize(const Tensor &input, Tdatatype dtype) override;
+  Tensor dequantize(const Tensor &input,
+                    ml::train::TensorDim::DataType dtype) override;
 
   /**
    * @copydoc Quantizer::qscheme()
@@ -279,9 +297,11 @@ public:
 
 private:
   /**
-   * @copydoc Quantizer::calculateQParams(const Tensor &input, Tdatatype qtype)
+   * @copydoc Quantizer::calculateQParams(const Tensor &input,
+   * ml::train::TensorDim::DataType qtype)
    */
-  void calculateQParams(const Tensor &input, Tdatatype qtype) override {}
+  void calculateQParams(const Tensor &input,
+                        ml::train::TensorDim::DataType qtype) override {}
 };
 
 /**

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -63,17 +63,21 @@ public:
    * @param alloc_now If the memory of the tensor must be allocated
    * @param init Initializer for the tensor
    * @param name Name of the tensor
+   * @param qscheme_ Quantization scheme (only applies to Quantized Tensor)
    */
   Tensor(const TensorDim &d, bool alloc_now,
-         Initializer init = Initializer::NONE, std::string name = "");
+         Initializer init = Initializer::NONE, std::string name = "",
+         QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE);
 
   /**
    * @brief     Constructor of Tensor with dimension/buf
    * @param d Tensor dim for this tensor
    * @param buf buffer
+   * @param qscheme_ Quantization scheme (only applies to Quantized Tensor)
    * @note Memory for this tensor is instantaneously allocated
    */
-  Tensor(const TensorDim &d, const void *buf = nullptr);
+  Tensor(const TensorDim &d, const void *buf = nullptr,
+         QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE);
 
   /**
    * @brief     Constructor of Tensor
@@ -83,10 +87,12 @@ public:
    * @param[in] d3 Width
    * @param[in] fm Tensor Format
    * @param[in] d_type Tensor Data Type
+   * @param[in] qscheme_ Quantization scheme (only applies to Quantized Tensor)
    */
   Tensor(size_t d0, size_t d1, size_t d2, size_t d3, Tformat fm = Tformat::NCHW,
-         Tdatatype d_type = Tdatatype::FP32) :
-    Tensor(TensorDim(d0, d1, d2, d3, fm, d_type), nullptr){};
+         Tdatatype d_type = Tdatatype::FP32,
+         QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE) :
+    Tensor(TensorDim(d0, d1, d2, d3, fm, d_type), nullptr, qscheme_){};
 
   /**
    * @brief     Constructor of Tensor
@@ -95,10 +101,12 @@ public:
    * @param[in] d3 Width
    * @param[in] fm Tensor Format
    * @param[in] d_type Tensor Data Type
+   * @param[in] qscheme_ Quantization scheme (only applies to Quantized Tensor)
    */
   Tensor(size_t d1, size_t d2, size_t d3, Tformat fm = Tformat::NCHW,
-         Tdatatype d_type = Tdatatype::FP32) :
-    Tensor(1, d1, d2, d3, fm, d_type){};
+         Tdatatype d_type = Tdatatype::FP32,
+         QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE) :
+    Tensor(1, d1, d2, d3, fm, d_type, qscheme_){};
 
   /**
    * @brief     Constructor of Tensor with batch size one and d1 size one
@@ -106,20 +114,24 @@ public:
    * @param[in] d3 Width (NCHW) or Channel (NHWC)
    * @param[in] fm Tensor Format
    * @param[in] d_type Tensor Data Type
+   * @param[in] qscheme_ Quantization scheme (only applies to Quantized Tensor)
    */
   Tensor(size_t d2, size_t d3, Tformat fm = Tformat::NCHW,
-         Tdatatype d_type = Tdatatype::FP32) :
-    Tensor(1, 1, d2, d3, fm, d_type){};
+         Tdatatype d_type = Tdatatype::FP32,
+         QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE) :
+    Tensor(1, 1, d2, d3, fm, d_type, qscheme_){};
 
   /**
    * @brief     Constructor of Tensor with just Width or Channel
    * @param[in] d3 Width (NCHW) or Channel (NHWC)
    * @param[in] fm Tensor Format
    * @param[in] d_type Tensor Data Type
+   * @param[in] qscheme_ Quantization scheme (only applies to Quantized Tensor)
    */
   explicit Tensor(size_t d3, Tformat fm = Tformat::NCHW,
-                  Tdatatype d_type = Tdatatype::FP32) :
-    Tensor(1, 1, 1, d3, fm, d_type){};
+                  Tdatatype d_type = Tdatatype::FP32,
+                  QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE) :
+    Tensor(1, 1, 1, d3, fm, d_type, qscheme_){};
 
   /**
    * @brief     Constructor of Tensor
@@ -128,10 +140,12 @@ public:
    * @param[in] d2 Height (NCHW) or Width (NHWC)
    * @param[in] d3 Width (NCHW) or Channel (NHWC)
    * @param[in] t_type Tensor Type
+   * @param[in] qscheme_ Quantization scheme (only applies to Quantized Tensor)
    */
   Tensor(size_t d0, size_t d1, size_t d2, size_t d3,
-         ml::train::TensorDim::TensorType t_type) :
-    Tensor(TensorDim(d0, d1, d2, d3, t_type), nullptr){};
+         ml::train::TensorDim::TensorType t_type,
+         QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE) :
+    Tensor(TensorDim(d0, d1, d2, d3, t_type), nullptr, qscheme_){};
 
   /**
    * @brief     Constructor of Tensor
@@ -139,9 +153,11 @@ public:
    * @param[in] d2 Height
    * @param[in] d3 Width
    * @param[in] t_type Tensor Type
+   * @param[in] qscheme_ Quantization scheme (only applies to Quantized Tensor)
    */
   Tensor(size_t d1, size_t d2, size_t d3,
-         ml::train::TensorDim::TensorType t_type) :
+         ml::train::TensorDim::TensorType t_type,
+         QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE) :
     Tensor(1, d1, d2, d3, t_type){};
 
   /**
@@ -149,19 +165,23 @@ public:
    * @param[in] d2 Height (NCHW) or Width (NHWC)
    * @param[in] d3 Width (NCHW) or Channel (NHWC)
    * @param[in] t_type Tensor Type
+   * @param[in] qscheme_ Quantization scheme (only applies to Quantized Tensor)
    */
-  Tensor(size_t d2, size_t d3, ml::train::TensorDim::TensorType t_type) :
+  Tensor(size_t d2, size_t d3, ml::train::TensorDim::TensorType t_type,
+         QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE) :
     Tensor(1, (t_type.format == Tformat::NCHW) ? 1 : d3,
            (t_type.format == Tformat::NCHW) ? d2 : 1,
-           (t_type.format == Tformat::NCHW) ? d3 : d2, t_type){};
+           (t_type.format == Tformat::NCHW) ? d3 : d2, t_type, qscheme_){};
   /**
    * @brief     Constructor of Tensor with just Width or Channel
    * @param[in] d3 Width (NCHW) or Channel (NHWC)
    * @param[in] t_type Tensor Type
+   * @param[in] qscheme_ Quantization scheme (only applies to Quantized Tensor)
    */
-  explicit Tensor(size_t d3, ml::train::TensorDim::TensorType t_type) :
+  explicit Tensor(size_t d3, ml::train::TensorDim::TensorType t_type,
+                  QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE) :
     Tensor(1, (t_type.format == Tformat::NCHW) ? 1 : d3, 1,
-           (t_type.format == Tformat::NCHW) ? d3 : 1, t_type){};
+           (t_type.format == Tformat::NCHW) ? d3 : 1, t_type, qscheme_){};
 
   /**
    * @brief     Constructor of Tensor
@@ -312,32 +332,43 @@ public:
     Tensor(std::vector<std::decay<decltype(d)>::type>{d}, t_type){};
 
   /**
-   * @brief     Constructor of Tensor
+   * @brief     Constructor of CharTensor (QINT8)
    * @param[in] d data for the Tensor. It needs to set format properly.
+   * @param[in] scales scale factors for the Tensor.
    * @param[in] t_type Tensor Type
+   * @param[in] qscheme_ Quantization scheme (only applies to Quantized Tensor)
    */
   Tensor(std::vector<std::vector<std::vector<std::vector<int8_t>>>> const &d,
-         ml::train::TensorDim::TensorType t_type);
+         std::vector<float> const &scales,
+         ml::train::TensorDim::TensorType t_type, QScheme qscheme_);
 
   /**
-   * @brief     Constructor of Tensor
+   * @brief     Constructor of CharTensor (QINT8)
    * @note      This constructor copies vector again. needs refactoring
    * @param[in] d data for the Tensor. It needs to set format properly.
+   * @param[in] scales scale factors for the Tensor.
    * @param[in] t_type Tensor Type
+   * @param[in] qscheme_ Quantization scheme (only applies to Quantized Tensor)
    */
   Tensor(std::vector<std::vector<std::vector<int8_t>>> const &d,
-         ml::train::TensorDim::TensorType t_type) :
-    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, t_type){};
+         std::vector<float> const &scales,
+         ml::train::TensorDim::TensorType t_type, QScheme qscheme_) :
+    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, t_type,
+           qscheme_){};
 
   /**
-   * @brief     Constructor of Tensor
+   * @brief     Constructor of CharTensor (QINT8)
    * @note      This constructor copies vector again. needs refactoring
    * @param[in] d data for the Tensor with batch size one
+   * @param[in] scales scale factors for the Tensor.
    * @param[in] t_type Tensor Type
+   * @param[in] qscheme_ Quantization scheme (only applies to Quantized Tensor)
    */
   Tensor(std::vector<std::vector<int8_t>> const &d,
-         ml::train::TensorDim::TensorType t_type) :
-    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, t_type){};
+         std::vector<float> const &scales,
+         ml::train::TensorDim::TensorType t_type, QScheme qscheme_) :
+    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, t_type,
+           qscheme_){};
 
   /**
    *  @brief  Constructor of Tensor by directly assigning TensorBase.
@@ -1616,6 +1647,12 @@ public:
    * @retval    scale factor size
    */
   size_t scale_size() const;
+
+  /**
+   * @brief     return Tensor quantization scheme
+   * @retval    Qscheme qscheme
+   */
+  QScheme q_scheme() const;
 
   /**
    * @brief Merge the given two axis for tensor at second axis inplace

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -18,6 +18,7 @@
 
 #include <memory_data.h>
 #include <nntrainer_error.h>
+#include <quantizer.h>
 #include <tensor_dim.h>
 #include <util_func.h>
 
@@ -640,6 +641,17 @@ public:
    * @note      Override for quantize tensor
    */
   virtual size_t scale_size() const { return 0; }
+
+  /**
+   * @brief     return Tensor quantization scheme
+   * @retval    Qscheme qscheme
+   * @note      Override for quantize tensor
+   */
+  virtual QScheme q_scheme() const {
+    throw std::invalid_argument(
+      "Tensor::q_scheme() is not supported in tensor data type " +
+      getStringDataType());
+  }
 
   /**
    * @brief Merge the given two axis for tensor at second axis inplace

--- a/test/unittest/unittest_nntrainer_quantizer.cpp
+++ b/test/unittest/unittest_nntrainer_quantizer.cpp
@@ -52,10 +52,16 @@ TEST(nntrainer_Quantizer, per_tensor_affine_03_p) {
                         -0.07760239, -0.28348053, -0.37242615, 0.30941701};
   nntrainer::Tensor input({1, 1, 4, 4}, input_data);
 
-  int8_t qdata[] = {-47, -28, 87,  -1,  123, -42, 39,   -22,
-                    -59, -97, 127, -96, -21, -78, -102, 85};
+  std::vector<int8_t> qdata = {-47, -28, 87,  -1,  123, -42, 39,   -22,
+                               -59, -97, 127, -96, -21, -78, -102, 85};
+  float qscale = 0.00363567f;
+  int8_t *scale_array = reinterpret_cast<int8_t *>(&qscale);
+  for (unsigned int i = 0; i < 4; ++i) {
+    qdata.push_back(scale_array[i]);
+  }
   nntrainer::Tensor quant_answer(
-    {1, 1, 4, 4, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8}, qdata);
+    {1, 1, 4, 4, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8},
+    qdata.data());
 
   float output_data[] = {-0.17087643, -0.10179872, 0.31630316,  -0.00363567,
                          0.44718724,  -0.15269808, 0.14179108,  -0.07998471,
@@ -96,14 +102,20 @@ TEST(nntrainer_Quantizer, per_tensor_affine_04_p) {
     -0.20489319, 0.33036807,  0.27226517,  -0.25207010};
   nntrainer::Tensor input({1, 1, 8, 8}, input_data);
 
-  int8_t qdata[] = {-109, 9,    16,  14,  66,   16,   56,  -58, -29, 127, 61,
-                    -35,  -104, 121, -92, -122, 51,   68,  -97, 114, 31,  -33,
-                    33,   -110, -98, -60, -69,  -118, 25,  -18, 62,  8,   39,
-                    -107, 60,   -33, 91,  -99,  61,   85,  -58, -86, 98,  -41,
-                    -76,  110,  89,  -33, 82,   120,  -38, 12,  91,  102, 12,
-                    -1,   103,  -90, -71, -96,  -76,  122, 101, -93};
+  std::vector<int8_t> qdata = {
+    -109, 9,    16,   14,  66,  16,  56,  -58,  -29, 127, 61,   -35, -104,
+    121,  -92,  -122, 51,  68,  -97, 114, 31,   -33, 33,  -110, -98, -60,
+    -69,  -118, 25,   -18, 62,  8,   39,  -107, 60,  -33, 91,   -99, 61,
+    85,   -58,  -86,  98,  -41, -76, 110, 89,   -33, 82,  120,  -38, 12,
+    91,   102,  12,   -1,  103, -90, -71, -96,  -76, 122, 101,  -93};
+  float qscale = 0.00270727f;
+  int8_t *scale_array = reinterpret_cast<int8_t *>(&qscale);
+  for (unsigned int i = 0; i < 4; ++i) {
+    qdata.push_back(scale_array[i]);
+  }
   nntrainer::Tensor quant_answer(
-    {1, 1, 8, 8, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8}, qdata);
+    {1, 1, 8, 8, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8},
+    qdata.data());
 
   float output_data[] = {
     -0.29509223, 0.02436541,  0.04331629,  0.03790175,  0.17867969,


### PR DESCRIPTION
This pull request aims to modify the existing codebase such that the memory data of CharTensor can now store scale factors based on different quantization schemes.
Additionally, this change allows the Tensor class to specify the desired quantization scheme while creating a new CharTensor instance.
The scale factors are determined either during the quantization process using a specific quantizer or they can be manually initialized if both the quantized data and the corresponding scale factors are provided as inputs.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped