### PR TITLE
[FSU][Bugfix] Bugfix on FSU Inference

### DIFF
--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -381,9 +381,9 @@ std::vector<Weight *> Manager::requestWeights(
     var_ls = TensorLifespan::MAX_LIFESPAN;
   } else {
     if (enable_swap) {
-      var_ls = TensorLifespan::FORWARD_INFER_LIFESPAN;
-    } else {
       var_ls = TensorLifespan::FORWARD_FUNC_LIFESPAN;
+    } else {
+      var_ls = TensorLifespan::FORWARD_INFER_LIFESPAN;
     }
   }
 


### PR DESCRIPTION
at case of inference there are some bug
- when set lifespan to tensor swap & non-swap value is exchanged
- set swap case - forward_func_lifespan
- set non-swap case - forward_infer_lifespan

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped
