### PR TITLE
[Wait for #2846][FSU] Modify Load Logic at FSU @open sesame 01/07 09:50

### DIFF
--- a/Applications/SimpleFC/jni/main.cpp
+++ b/Applications/SimpleFC/jni/main.cpp
@@ -15,17 +15,13 @@
 #include <iostream>
 #include <memory>
 #include <sstream>
+#include <fstream>
 #include <vector>
-
-#if defined(ENABLE_TEST)
-#include <gtest/gtest.h>
-#endif
 
 #include <layer.h>
 #include <model.h>
 #include <optimizer.h>
-
-#include <cifar_dataloader.h>
+#include <unistd.h>
 
 #ifdef PROFILE
 #include <profiler.h>
@@ -34,11 +30,6 @@
 using LayerHandle = std::shared_ptr<ml::train::Layer>;
 using ModelHandle = std::unique_ptr<ml::train::Model>;
 
-using UserDataType = std::unique_ptr<nntrainer::util::DataLoader>;
-
-/** cache loss values post training for test */
-float training_loss = 0.0;
-float validation_loss = 0.0;
 
 /**
  * @brief make "key=value" from key and value
@@ -84,16 +75,18 @@ std::vector<LayerHandle> createGraph() {
 
   std::vector<LayerHandle> layers;
 
-  layers.push_back(createLayer(
-    "input", {withKey("name", "input0"), withKey("input_shape", "1:1:320")}));
+  layers.push_back(
+    createLayer("input", {withKey("name", "input0"),
+                          withKey("input_shape", "1:1024:1440")}));
 
+  for (int i = 0; i < 5; i++) {
+    layers.push_back(createLayer(
+      "fully_connected",
+      {withKey("unit", 1440), withKey("weight_initializer", "xavier_uniform"),
+       withKey("bias_initializer", "zeros")}));
+  }
   layers.push_back(createLayer("fully_connected",
-                               {withKey("unit", 100),
-                                withKey("weight_initializer", "xavier_uniform"),
-                                withKey("bias_initializer", "zeros")}));
-
-  layers.push_back(createLayer("fully_connected",
-                               {withKey("unit", 100),
+                               {withKey("unit", 1),
                                 withKey("weight_initializer", "xavier_uniform"),
                                 withKey("bias_initializer", "zeros")}));
 
@@ -111,33 +104,19 @@ ModelHandle create() {
   return model;
 }
 
-int trainData_cb(float **input, float **label, bool *last, void *user_data) {
-  auto data = reinterpret_cast<nntrainer::util::DataLoader *>(user_data);
-
-  data->next(input, label, last);
-  return 0;
-}
-
-int validData_cb(float **input, float **label, bool *last, void *user_data) {
-  auto data = reinterpret_cast<nntrainer::util::DataLoader *>(user_data);
-
-  data->next(input, label, last);
-  return 0;
-}
-
 void createAndRun(unsigned int epochs, unsigned int batch_size,
-                  UserDataType &train_user_data,
-                  UserDataType &valid_user_data) {
+                  std::string swap_on_off, std::string look_ahaed) {
 
   // setup model
   ModelHandle model = create();
-  model->setProperty(
-    {withKey("batch_size", batch_size), withKey("epochs", epochs),
-     // withKey("save_path", "model_full.bin")});
-     // withKey("save_path", "model_full.bin"), withKey("memory_swap",
-     // "true")});
-     withKey("memory_swap", "true"), withKey("memory_swap_lookahead", "1"),
-     withKey("model_tensor_type", "FP16-FP16")});
+  model->setProperty({withKey("batch_size", batch_size),
+                      withKey("epochs", epochs),
+                      withKey("model_tensor_type", "FP16-FP16")});
+
+  model->setProperty({withKey("memory_swap", swap_on_off)});
+  if (swap_on_off == "true") {
+    model->setProperty({withKey("memory_swap_lookahead", look_ahaed)});
+  }
 
   auto optimizer = ml::train::createOptimizer("sgd", {"learning_rate=0.001"});
   int status = model->setOptimizer(std::move(optimizer));
@@ -155,25 +134,13 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
     throw std::invalid_argument("model initialization failed!");
   }
 
-  auto dataset_train = ml::train::createDataset(
-    ml::train::DatasetType::GENERATOR, trainData_cb, train_user_data.get());
-  auto dataset_valid = ml::train::createDataset(
-    ml::train::DatasetType::GENERATOR, validData_cb, valid_user_data.get());
+  uint feature_size = 1 * 1024 * 1440;
 
-  // to test asynch fsu, we do need save the model weight data in file
-  model->save("simplefc_weight_fp16_fp16_100.bin",
-              ml::train::ModelFormat::MODEL_FORMAT_BIN);
-  model->load("./simplefc_weight_fp16_fp16_100.bin");
-
-  model->summarize(std::cout, ML_TRAIN_SUMMARY_MODEL);
-
-  unsigned int feature_size = 320;
-
-  float input[320];
+  float input[1 * 1024 * 1440];
   float label[1];
 
-  for (unsigned int j = 0; j < feature_size; ++j)
-    input[j] = j;
+  for (uint j = 0; j < feature_size; ++j)
+    input[j] = (j / feature_size);
 
   std::vector<float *> in;
   std::vector<float *> l;
@@ -182,80 +149,25 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
   in.push_back(input);
   l.push_back(label);
 
-  answer = model->inference(1, in, l);
-
-  in.clear();
-  l.clear();
-
-  std::cout << "done" << std::endl;
-}
-
-std::array<UserDataType, 2>
-createFakeDataGenerator(unsigned int batch_size,
-                        unsigned int simulated_data_size,
-                        unsigned int data_split) {
-  UserDataType train_data(new nntrainer::util::RandomDataLoader(
-    {{batch_size, 1, 1, 320}}, {{batch_size, 1, 1, 100}},
-    simulated_data_size / data_split));
-  UserDataType valid_data(new nntrainer::util::RandomDataLoader(
-    {{batch_size, 1, 1, 320}}, {{batch_size, 1, 1, 100}},
-    simulated_data_size / data_split));
-
-  return {std::move(train_data), std::move(valid_data)};
-}
-
-std::array<UserDataType, 2>
-createRealDataGenerator(const std::string &directory, unsigned int batch_size,
-                        unsigned int data_split) {
-
-  UserDataType train_data(new nntrainer::util::Cifar100DataLoader(
-    directory + "/train.bin", batch_size, data_split));
-  UserDataType valid_data(new nntrainer::util::Cifar100DataLoader(
-    directory + "/test.bin", batch_size, data_split));
-
-  return {std::move(train_data), std::move(valid_data)};
-}
-
-int main(int argc, char *argv[]) {
   auto start = std::chrono::system_clock::now();
   std::time_t start_time = std::chrono::system_clock::to_time_t(start);
   std::cout << "started computation at " << std::ctime(&start_time)
             << std::endl;
 
-#ifdef PROFILE
-  auto listener =
-    std::make_shared<nntrainer::profile::GenericProfileListener>();
-  nntrainer::profile::Profiler::Global().subscribe(listener);
-#endif
+  // to test asynch fsu, we do need save the model weight data in file
+  std::string filePath = "./simplefc_weight_fp16_fp16_100.bin";
+  if (access(filePath.c_str(), F_OK) == 0) {
+    model->load(filePath);
 
-  std::string data_dir = "fake";
-  unsigned int batch_size = 1;
-  unsigned int data_split = 1;
-  unsigned int epoch = 1;
-
-  std::array<UserDataType, 2> user_datas;
-
-  try {
-    if (data_dir == "fake") {
-      user_datas = createFakeDataGenerator(batch_size, 512, data_split);
-    } else {
-      user_datas = createRealDataGenerator(data_dir, batch_size, data_split);
-    }
-  } catch (const std::exception &e) {
-    std::cerr << "uncaught error while creating data generator! details: "
-              << e.what() << std::endl;
-    return EXIT_FAILURE;
+  } else {
+    model->save(filePath, ml::train::ModelFormat::MODEL_FORMAT_BIN);
+    model->load(filePath);
   }
 
-  auto &[train_user_data, valid_user_data] = user_datas;
+  // model->summarize(std::cout, ML_TRAIN_SUMMARY_MODEL);
 
-  try {
-    createAndRun(epoch, batch_size, train_user_data, valid_user_data);
-  } catch (const std::exception &e) {
-    std::cerr << "uncaught error while running! details: " << e.what()
-              << std::endl;
-    return EXIT_FAILURE;
-  }
+  answer = model->inference(1, in, l);
+  std::cout << answer[0][0] << std::endl;
   auto end = std::chrono::system_clock::now();
 
   std::chrono::duration<double> elapsed_seconds = end - start;
@@ -263,6 +175,42 @@ int main(int argc, char *argv[]) {
 
   std::cout << "finished computation at " << std::ctime(&end_time)
             << "elapsed time: " << elapsed_seconds.count() << "s\n";
+  in.clear();
+  l.clear();
+
+  std::cout << "done" << std::endl;
+}
+
+int main(int argc, char *argv[]) {
+
+#ifdef PROFILE
+  auto listener =
+    std::make_shared<nntrainer::profile::GenericProfileListener>();
+  nntrainer::profile::Profiler::Global().subscribe(listener);
+#endif
+
+  std::string swap_on = "true";
+  std::string look_ahead = "1";
+  if (argc < 3) {
+    std::cerr << "need more argc, executable swap_on look_ahead" << std::endl;
+  }
+
+  swap_on = argv[1];    // true or false
+  look_ahead = argv[2]; // int
+
+  std::cout << "swap_on : " << swap_on << std::endl;
+  std::cout << "look_ahead : " << look_ahead << std::endl;
+
+  uint batch_size = 1;
+  uint epoch = 1;
+
+  try {
+    createAndRun(epoch, batch_size, swap_on, look_ahead);
+  } catch (const std::exception &e) {
+    std::cerr << "uncaught error while running! details: " << e.what()
+              << std::endl;
+    return EXIT_FAILURE;
+  }
 
 #ifdef PROFILE
   std::cout << *listener;

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -500,7 +500,7 @@ void LayerNode::exportTo(Exporter &exporter,
 }
 
 void LayerNode::read(std::ifstream &file, bool opt_var,
-                     ml::train::ExecutionMode mode) {
+                     ml::train::ExecutionMode mode, bool swap) {
   NNTR_THROW_IF(!run_context, std::runtime_error)
     << __func__ << " layer needs to be finalized first!";
 
@@ -519,24 +519,21 @@ void LayerNode::read(std::ifstream &file, bool opt_var,
       /// @note shared weights are only be read at the first acecss
       //      if (run_context->isGradientLastAccess(i)) {
       if (run_context->isGradientFirstAccess(i)) {
-        if (layer->getType() == BatchNormalizationLayer::type) {
-          if ((mode == ml::train::ExecutionMode::TRAIN) &&
-              (this->getWeightDataType() != TensorDim::DataType::FP32)) {
+        if (layer->getType() == BatchNormalizationLayer::type &&
+            mode == ml::train::ExecutionMode::TRAIN &&
+            (this->getWeightDataType() != TensorDim::DataType::FP32)) {
+          /** @note for batch normalization layer, we do need full precision
+           * for training. but weight can be saved with other type. for
+           * training, bn weight type is fixed with full precsion */
 
-            /** @note for batch normalization layer, we do need full precision
-             * for training. but weight can be saved with other type. for
-             * training, bn weight type is fixed with full precsion */
-
-            TensorDim dim = run_context->getWeight(i).getDim();
-            dim.setDataType(this->getWeightDataType());
-            Tensor T_read(dim, true);
-            T_read.read(file);
-            run_context->getWeight(i).copyData(T_read);
-          } else {
-            run_context->getWeight(i).read(file);
-          }
+          TensorDim dim = run_context->getWeight(i).getDim();
+          dim.setDataType(this->getWeightDataType());
+          Tensor T_read(dim, true);
+          T_read.read(file);
+          run_context->getWeight(i).copyData(T_read);
         } else {
-          run_context->getWeight(i).read(file);
+          if (!swap)
+            run_context->getWeight(i).read(file);
         }
 
         if (run_context->isMixedPrecision(i) && getTrainable() &&

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -753,7 +753,8 @@ public:
    * @param bool read optimizer variables
    */
   void read(std::ifstream &file, bool opt_var = false,
-            ml::train::ExecutionMode mode = ml::train::ExecutionMode::TRAIN);
+            ml::train::ExecutionMode mode = ml::train::ExecutionMode::TRAIN,
+            bool swap = false);
 
   /**
    * @brief     save layer Weight & Bias data from file

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -656,6 +656,7 @@ void NeuralNetwork::load(const std::string &file_path,
                          ml::train::ModelFormat format) {
   /// @todo this switch case should be delegating the function call only. It's
   /// not delegating for now as required logics are manageable for now.
+  bool swap_mode = std::get<props::MemorySwap>(model_flex_props);
   switch (format) {
   case ml::train::ModelFormat::MODEL_FORMAT_BIN: {
     NNTR_THROW_IF(!initialized, std::runtime_error)
@@ -665,7 +666,7 @@ void NeuralNetwork::load(const std::string &file_path,
     auto model_file = checkedOpenStream<std::ifstream>(
       file_path, std::ios::in | std::ios::binary);
     for (auto iter = model_graph.cbegin(); iter != model_graph.cend(); iter++) {
-      (*iter)->read(model_file, false, exec_mode);
+      (*iter)->read(model_file, false, exec_mode, swap_mode);
     }
     try {
       /// this is assuming that the failure is allowed at the end of the file


### PR DESCRIPTION
The process of loading trained weights during inference in NNTrainer currently uses model->load(). (before call inference)

However, since FSU loads weights from flash memory according to the required layers up to the specified look-ahead value, we need to prevent weights from being loaded before inference.

To reflect this change, I modified the code in LayerNode and added a new parameter called swap_parm.

commit summary
commit 1 [[Application] Update FSU SimpleFC Application](https://github.com/nnstreamer/nntrainer/commit/c0569b52f0ceb4f54de85329fec028e279f1f4e2) : update SimpleFC Application for more easy test & actual environment
commit 2 [[FSU] update layer weight load logic at fsu](https://github.com/nnstreamer/nntrainer/commit/950c5d50efdb2a038d5bc228b11effb3e660d3c3) : update layernode not to load weight at load()


**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Donghak PARK <donghak.park@samsung.com>