### PR TITLE
[Tensor] Proposal for unifying tensor addition: remove add_i implementation

### DIFF
--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -440,21 +440,6 @@ Tensor &FloatTensor::add_strided(Tensor const &input, Tensor &output,
   return output;
 }
 
-int FloatTensor::add_i(Tensor const &m, Tensor &output, float const alpha) {
-  auto f = [&](const BroadcastInfo &e, const float *buf, const float *m_buf,
-               float *out_buf) {
-    saxpy(e.buffer_size, alpha, m_buf, e.strides[3], out_buf, strides[3]);
-  };
-
-  try {
-    apply_broadcast(m, f, output);
-  } catch (std::exception &err) {
-    ml_loge("%s %s", typeid(err).name(), err.what());
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-  return ML_ERROR_NONE;
-}
-
 int FloatTensor::add_i_partial(unsigned int len, unsigned int addr_idx,
                                Tensor &m, unsigned int incX, unsigned int incY,
                                const Tensor alphas, unsigned int alpha_idx) {

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -309,11 +309,6 @@ public:
                       const float beta) const override;
 
   /**
-   * @copydoc Tensor::add_i(Tensor const &m, float const alpha)
-   */
-  int add_i(Tensor const &m, Tensor &output, float const alpha) override;
-
-  /**
    * @copydoc Tensor::add_i_partial()
    */
   int add_i_partial(unsigned int len, unsigned int addr_idx, Tensor &m,

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -422,22 +422,6 @@ Tensor &HalfTensor::add_strided(Tensor const &input, Tensor &output,
   return output;
 }
 
-int HalfTensor::add_i(Tensor const &m, Tensor &output, float const alpha) {
-  auto f = [&](const BroadcastInfo &e, const _FP16 *buf, const _FP16 *m_buf,
-               _FP16 *out_buf) {
-    saxpy(e.buffer_size, alpha, m_buf, e.strides[3], out_buf, strides[3]);
-    /// @todo: saxpy is not valid for _FP16
-  };
-
-  try {
-    apply_broadcast(m, f, output);
-  } catch (std::exception &err) {
-    ml_loge("%s %s", typeid(err).name(), err.what());
-    return ML_ERROR_INVALID_PARAMETER;
-  }
-  return ML_ERROR_NONE;
-}
-
 int HalfTensor::add_i_partial(unsigned int len, unsigned int addr_idx,
                               Tensor &m, unsigned int incX, unsigned int incY,
                               const Tensor alphas, unsigned int alpha_idx) {

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -309,11 +309,6 @@ public:
                       const float beta) const override;
 
   /**
-   * @copydoc Tensor::add_i(Tensor const &m, float const alpha)
-   */
-  int add_i(Tensor const &m, Tensor &output, float const alpha) override;
-
-  /**
    * @copydoc Tensor::add_i_partial()
    */
   int add_i_partial(unsigned int len, unsigned int addr_idx, Tensor &m,

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -410,12 +410,6 @@ Tensor &TensorBase::add_strided(Tensor const &input, Tensor &output,
     getStringDataType());
 }
 
-int TensorBase::add_i(Tensor const &m, Tensor &output, float const alpha) {
-  throw std::invalid_argument(
-    "Tensor::add_i() is currently not supported in tensor data type " +
-    getStringDataType());
-}
-
 int TensorBase::add_i_partial(unsigned int len, unsigned int addr_idx,
                               Tensor &m, unsigned int incX, unsigned int incY,
                               const Tensor alphas, unsigned int alpha_idx) {

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -307,11 +307,6 @@ public:
                               const float beta) const;
 
   /**
-   * @copydoc Tensor::add_i(Tensor const &m, float const alpha)
-   */
-  virtual int add_i(Tensor const &m, Tensor &output, float const alpha);
-
-  /**
    * @copydoc Tensor::add_i_partial()
    */
   virtual int add_i_partial(unsigned int len, unsigned int addr_idx, Tensor &m,


### PR DESCRIPTION
This pull request proposes the removal of the add_i implementation and its unification with the add function.
Currently, the use of two distinct kernels for tensor addition can result in performance inefficiencies.
To enhance overall performance, it is crucial to address this issue.
Additionally, we must undertake follow-up work to integrate ele_add and sxapy successfully.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

