### PR TITLE
[OpenCL/GPU] Optimized Blas and Attention kernels with the latest GPU Pipeline.

### DIFF
--- a/nntrainer/tensor/cl_operations/attention_kernels.h
+++ b/nntrainer/tensor/cl_operations/attention_kernels.h
@@ -14,15 +14,18 @@
 #ifndef __ATTENTION_KERNELS_H__
 #define __ATTENTION_KERNELS_H__
 
+#include <cl_buffer_manager.h>
 #include <cl_context.h>
 #include <opencl_buffer.h>
 #include <opencl_kernel.h>
+
 #include <string>
 
 namespace nntrainer {
 
 // get global cl_context to use in kernels
 static ClContext cl_context_ref;
+static ClBufferManager &clbuffInstance = ClBufferManager::getInstance();
 
 /**
  * @brief     Rotary Embedding process

--- a/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
@@ -46,24 +46,6 @@ void rotary_emb_cl(__fp16 *in, __fp16 *out,
     size_t dim5_size = sizeof(float) * freqs_cos_dim * dim;
     size_t dim6_size = sizeof(float) * freqs_sin_dim * dim;
 
-    opencl::Buffer inputA(cl_context_ref.context_inst_, dim1_size, true,
-                          nullptr);
-
-    opencl::Buffer inOutRes(cl_context_ref.context_inst_, dim2_size, true,
-                            nullptr);
-
-    opencl::Buffer cosBuf(cl_context_ref.context_inst_, dim3_size, true,
-                          nullptr);
-
-    opencl::Buffer sinBuf(cl_context_ref.context_inst_, dim4_size, true,
-                          nullptr);
-
-    opencl::Buffer freqs_cosBuf(cl_context_ref.context_inst_, dim5_size, true,
-                                nullptr);
-
-    opencl::Buffer freqs_sinBuf(cl_context_ref.context_inst_, dim6_size, true,
-                                nullptr);
-
     std::vector<float> freqs_cos_flat;
     std::vector<float> freqs_sin_flat;
     for (const auto &row : freqs_cos) {
@@ -73,81 +55,86 @@ void rotary_emb_cl(__fp16 *in, __fp16 *out,
       freqs_sin_flat.insert(freqs_sin_flat.end(), row.begin(), row.end());
     }
 
-    result = inputA.WriteData(cl_context_ref.command_queue_inst_, in);
+    result = clbuffInstance.getInBufferA()->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim1_size, in);
     if (!result) {
       printf("Failed to write input data\n");
       break;
     }
 
-    result = inOutRes.WriteData(cl_context_ref.command_queue_inst_, out);
+    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim2_size, out);
     if (!result) {
       printf("Failed to write output data\n");
       break;
     }
 
-    result = freqs_cosBuf.WriteData(cl_context_ref.command_queue_inst_,
-                                    freqs_cos_flat.data());
+    result = clbuffInstance.getInBufferB()->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim5_size, freqs_cos_flat.data());
     if (!result) {
       printf("Failed to write freqs cos data\n");
       break;
     }
 
-    result = freqs_sinBuf.WriteData(cl_context_ref.command_queue_inst_,
-                                    freqs_sin_flat.data());
+    result = clbuffInstance.getInBufferB()->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim6_size, freqs_sin_flat.data(), 0,
+      dim5_size);
     if (!result) {
       printf("Failed to write freqs sin data\n");
       break;
     }
 
-    result = cosBuf.WriteData(cl_context_ref.command_queue_inst_, cos_.data());
+    result = clbuffInstance.getInBufferC()->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim3_size, cos_.data());
     if (!result) {
       printf("Failed to write cos data\n");
       break;
     }
 
-    result = sinBuf.WriteData(cl_context_ref.command_queue_inst_, sin_.data());
+    result = clbuffInstance.getInBufferC()->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim4_size, sin_.data(), 0, dim3_size);
     if (!result) {
       printf("Failed to write sin data\n");
       break;
     }
 
-    result =
-      kernel_rotaryEmb_fp16_ptr->SetKernelArguments(0, &inputA, sizeof(cl_mem));
+    result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
+      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set inputA argument\n");
       break;
     }
 
-    result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(1, &inOutRes,
-                                                           sizeof(cl_mem));
+    result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
+      1, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set inOutRes argument\n");
       break;
     }
 
-    result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(2, &freqs_cosBuf,
-                                                           sizeof(cl_mem));
+    result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
+      2, clbuffInstance.getInBufferB(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set freqs_cosBuf argument\n");
       break;
     }
 
-    result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(3, &freqs_sinBuf,
-                                                           sizeof(cl_mem));
+    result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
+      3, clbuffInstance.getInBufferB(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set freqs_sinBuf argument\n");
       break;
     }
 
-    result =
-      kernel_rotaryEmb_fp16_ptr->SetKernelArguments(4, &cosBuf, sizeof(cl_mem));
+    result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
+      4, clbuffInstance.getInBufferC(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set cosBuf argument\n");
       break;
     }
 
-    result =
-      kernel_rotaryEmb_fp16_ptr->SetKernelArguments(5, &sinBuf, sizeof(cl_mem));
+    result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
+      5, clbuffInstance.getInBufferC(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set sinBuf argument\n");
       break;
@@ -209,6 +196,22 @@ void rotary_emb_cl(__fp16 *in, __fp16 *out,
       break;
     }
 
+    unsigned int offsetFreqsSin = freqs_cos_dim * dim;
+    result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(14, &offsetFreqsSin,
+                                                           sizeof(int));
+    if (!result) {
+      printf("Failed to set offsetFreqsSin argument\n");
+      break;
+    }
+
+    unsigned int offsetSin = cos_dim;
+    result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(15, &offsetSin,
+                                                           sizeof(int));
+    if (!result) {
+      printf("Failed to set offsetSin argument\n");
+      break;
+    }
+
     const int work_groups_count[3] = {(int)batch, (int)channel, 1};
     const int work_group_size[3] = {32, 32, 1}; // test-value
     result = cl_context_ref.command_queue_inst_.DispatchCommand(
@@ -218,7 +221,8 @@ void rotary_emb_cl(__fp16 *in, __fp16 *out,
       break;
     }
 
-    result = inOutRes.ReadData(cl_context_ref.command_queue_inst_, out);
+    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
+      cl_context_ref.command_queue_inst_, dim2_size, out);
     if (!result) {
       printf("Failed to read data\n");
       break;

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -304,30 +304,27 @@ void addition_cl(const float *input, float *res, unsigned int size_input,
     size_t dim1_size = sizeof(float) * size_input;
     size_t dim2_size = sizeof(float) * size_res;
 
-    opencl::Buffer inputA(cl_context_ref.context_inst_, dim1_size, true,
-                          nullptr);
+    result = clbuffInstance.getInBufferA()->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim1_size, input);
 
-    opencl::Buffer inOutRes(cl_context_ref.context_inst_, dim2_size, true,
-                            nullptr);
-
-    result = inputA.WriteData(cl_context_ref.command_queue_inst_, input);
     if (!result) {
       break;
     }
 
-    result = inOutRes.WriteData(cl_context_ref.command_queue_inst_, res);
+    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim2_size, res);
     if (!result) {
       break;
     }
 
-    result =
-      kernel_addition_ptr->SetKernelArguments(0, &inputA, sizeof(cl_mem));
+    result = kernel_addition_ptr->SetKernelArguments(
+      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
-    result =
-      kernel_addition_ptr->SetKernelArguments(1, &inOutRes, sizeof(cl_mem));
+    result = kernel_addition_ptr->SetKernelArguments(
+      1, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -351,7 +348,8 @@ void addition_cl(const float *input, float *res, unsigned int size_input,
       break;
     }
 
-    result = inOutRes.ReadData(cl_context_ref.command_queue_inst_, res);
+    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
+      cl_context_ref.command_queue_inst_, dim2_size, res);
     if (!result) {
       break;
     }

--- a/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
@@ -315,30 +315,28 @@ void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
 
     size_t dim1_size = sizeof(cl_half) * size_input;
     size_t dim2_size = sizeof(cl_half) * size_res;
-    opencl::Buffer inputA(cl_context_ref.context_inst_, dim1_size, true,
-                          nullptr);
 
-    opencl::Buffer inOutRes(cl_context_ref.context_inst_, dim2_size, true,
-                            nullptr);
+    result = clbuffInstance.getInBufferA()->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim1_size, input);
 
-    result = inputA.WriteData(cl_context_ref.command_queue_inst_, input);
     if (!result) {
       break;
     }
 
-    result = inOutRes.WriteData(cl_context_ref.command_queue_inst_, res);
+    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
+      cl_context_ref.command_queue_inst_, dim2_size, res);
     if (!result) {
       break;
     }
 
-    result =
-      kernel_addition_fp16_ptr->SetKernelArguments(0, &inputA, sizeof(cl_mem));
+    result = kernel_addition_fp16_ptr->SetKernelArguments(
+      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
-    result = kernel_addition_fp16_ptr->SetKernelArguments(1, &inOutRes,
-                                                          sizeof(cl_mem));
+    result = kernel_addition_fp16_ptr->SetKernelArguments(
+      1, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -363,7 +361,8 @@ void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
       break;
     }
 
-    result = inOutRes.ReadData(cl_context_ref.command_queue_inst_, res);
+    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
+      cl_context_ref.command_queue_inst_, dim2_size, res);
     if (!result) {
       break;
     }


### PR DESCRIPTION
- Upated the kernels as per the latest buffer generalized changes for both `FP32 `and `FP16`.
- Added unittest for Addition Kernel FP16 in `unittest_blas_kernels_cl.cpp`.
- `add_i `and `rotary_emb` ops are updated.

Signed-off-by: Yash Singh [yash.singh@samsung.com](mailto:yash.singh@samsung.com)
