### PR TITLE
[CharTensor] QINT8 addition feature

### DIFF
--- a/nntrainer/tensor/char_tensor.h
+++ b/nntrainer/tensor/char_tensor.h
@@ -214,6 +214,12 @@ public:
    */
   Tensor &multiply(Tensor const &m, Tensor &output,
                    const float scale = 0.0) const override;
+  /**
+   * @copydoc Tensor::add(Tensor const &m, Tensor &output, float const
+   * alpha)
+   */
+  Tensor &add(Tensor const &m, Tensor &output,
+              float const scale) const override;
 
   /**
    * @copydoc Tensor::copy(const Tensor &from)


### PR DESCRIPTION
This pull request addresses activating the QINT8 element-wise addition feature in CharTensor.
It allows the addition of two tensors of the same dimensions, returning a matrix that contains the sums of the corresponding elements.
Please note that the functionality for automatically determining the new scale factor will be implemented in a future update.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped