### PR TITLE
[ Tensor ] Integrate saxpy and ele_add

### DIFF
--- a/nntrainer/tensor/blas_interface.h
+++ b/nntrainer/tensor/blas_interface.h
@@ -162,20 +162,36 @@ void ele_mul(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
              unsigned int o_stride = 1);
 
 /**
- * @brief     elementwise vector addition : Z = X + alpha * Y + beta *
+ * @brief     elementwise vector addition : Z = X + beta * Y + gamma *
  * Z
  * @param[in] N  length of the vector
  * @param[in] X _FP16 * for Vector X
  * @param[in] Y _FP16 * for Vector Y
  * @param[in] Z _FP16 * for Vector Z
- * @param[in] alpha scalar multiplier for input
- * @param[in] beta scalar multiplier for output
+ * @param[in] beta scalar multiplier for input
+ * @param[in] gamma scalar multiplier for output
+ * @param[in] i_stride input stride
+ * @param[in] o_stride output stride
+ */
+void xpbypcz(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
+             float beta = 1.f, float gamma = 0.f, unsigned int i_stride = 1,
+             unsigned int o_stride = 1);
+
+/**
+ * @brief     elementwise vector addition : Z = alpha * X + beta * Y + gamma *
+ * Z. This function classify whether the given context is saxpy or xpbypcz.
+ * @param[in] N  length of the vector
+ * @param[in] X float * for Vector X
+ * @param[in] Y float * for Vector Y
+ * @param[in] Z float * for Vector Z
+ * @param[in] beta scalar multiplier for input
+ * @param[in] gamma scalar multiplier for output
  * @param[in] i_stride input stride
  * @param[in] o_stride output stride
  */
 void ele_add(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
-             float alpha = 1.f, float beta = 0.f, unsigned int i_stride = 1,
-             unsigned int o_stride = 1);
+             float alpha = 1.f, float beta = 0.f, float gamma = 0.f,
+             unsigned int i_stride = 1, unsigned int o_stride = 1);
 /**
  * @brief     elementwise vector subtraction with neon : Z = X - alpha * Y +
  * beta * Z
@@ -496,8 +512,24 @@ void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
              unsigned int o_stride = 1);
 
 /**
- * @brief     elementwise vector addition : Z = X + alpha * Y + beta *
+ * @brief     elementwise vector addition : Z = X + beta * Y + gamma *
  * Z
+ * @param[in] N  length of the vector
+ * @param[in] X float * for Vector X
+ * @param[in] Y float * for Vector Y
+ * @param[in] Z float * for Vector Z
+ * @param[in] beta scalar multiplier for input
+ * @param[in] gamma scalar multiplier for output
+ * @param[in] i_stride input stride
+ * @param[in] o_stride output stride
+ */
+void xpbypcz(const unsigned int N, const float *X, const float *Y, float *Z,
+             float beta = 1.f, float gamma = 0.f, unsigned int i_stride = 1,
+             unsigned int o_stride = 1);
+
+/**
+ * @brief     elementwise vector addition : Z = alpha * X + beta * Y + gamma *
+ * Z. This function classify whether the given context is saxpy or xpbypcz.
  * @param[in] N  length of the vector
  * @param[in] X float * for Vector X
  * @param[in] Y float * for Vector Y
@@ -508,8 +540,8 @@ void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
  * @param[in] o_stride output stride
  */
 void ele_add(const unsigned int N, const float *X, const float *Y, float *Z,
-             float alpha = 1.f, float beta = 0.f, unsigned int i_stride = 1,
-             unsigned int o_stride = 1);
+             float alpha = 1.f, float beta = 0.f, float gamma = 0.f,
+             unsigned int i_stride = 1, unsigned int o_stride = 1);
 /**
  * @brief     elementwise vector subtraction with neon : Z = X - alpha * Y +
  * beta * Z

--- a/nntrainer/tensor/blas_neon.cpp
+++ b/nntrainer/tensor/blas_neon.cpp
@@ -492,29 +492,29 @@ void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
   }
 }
 
-void ele_add(const unsigned int N, const float *X, const float *Y, float *Z,
-             float alpha, float beta) {
+void xpbypcz(const unsigned int N, const float *X, const float *Y, float *Z,
+             float beta, float gamma) {
   unsigned int i = 0;
-  float32x4_t alpha_vec = vdupq_n_f32(alpha);
   float32x4_t beta_vec = vdupq_n_f32(beta);
+  float32x4_t gamma_vec = vdupq_n_f32(gamma);
   for (; N - i >= 4; i += 4) {
     float32x4_t x0_3 = vld1q_f32(&X[i]);
     float32x4_t y0_3 = vld1q_f32(&Y[i]);
-    if (alpha != 1.f) {
-      y0_3 = vmulq_f32(y0_3, alpha_vec);
+    if (beta != 1.f) {
+      y0_3 = vmulq_f32(y0_3, beta_vec);
     }
     float32x4_t xy0_3 = vaddq_f32(x0_3, y0_3);
-    if (std::abs(beta) > __FLT_MIN__) {
-      float32x4_t z0_3 = vmulq_f32(vld1q_f32(&Z[i]), beta_vec);
+    if (std::abs(gamma) > __FLT_MIN__) {
+      float32x4_t z0_3 = vmulq_f32(vld1q_f32(&Z[i]), gamma_vec);
       vst1q_f32(&Z[i], vaddq_f32(z0_3, xy0_3));
     } else
       vst1q_f32(&Z[i], xy0_3);
   }
   while (i < N) {
-    if (std::abs(beta) > __FLT_MIN__)
-      Z[i] = X[i] + alpha * Y[i] + beta * Z[i];
+    if (std::abs(gamma) > __FLT_MIN__)
+      Z[i] = X[i] + beta * Y[i] + gamma * Z[i];
     else
-      Z[i] = X[i] + alpha * Y[i];
+      Z[i] = X[i] + beta * Y[i];
     ++i;
   }
 }
@@ -1836,30 +1836,30 @@ void ele_mul(const unsigned int N, const __fp16 *X, const __fp16 *Y, __fp16 *Z,
   }
 }
 
-void ele_add(const unsigned int N, const __fp16 *X, const __fp16 *Y, __fp16 *Z,
-             float alpha, float beta) {
+void xpbypcz(const unsigned int N, const __fp16 *X, const __fp16 *Y, __fp16 *Z,
+             float beta, float gamma) {
   unsigned int i = 0;
-  float16x8_t alpha_vec = vdupq_n_f16(alpha);
   float16x8_t beta_vec = vdupq_n_f16(beta);
+  float16x8_t gamma_vec = vdupq_n_f16(gamma);
   for (; N - i >= 8; i += 8) {
     float16x8_t x0_7 = vld1q_f16(&X[i]);
     float16x8_t y0_7 = vld1q_f16(&Y[i]);
-    if (alpha != 1.f) {
-      y0_7 = vmulq_f16(y0_7, alpha_vec);
+    if (beta != 1.f) {
+      y0_7 = vmulq_f16(y0_7, beta_vec);
     }
     float16x8_t xy0_7 = vaddq_f16(x0_7, y0_7);
-    if (std::abs(beta) > __FLT_MIN__) {
-      float16x8_t z0_7 = vmulq_f16(vld1q_f16(&Z[i]), beta_vec);
+    if (std::abs(gamma) > __FLT_MIN__) {
+      float16x8_t z0_7 = vmulq_f16(vld1q_f16(&Z[i]), gamma_vec);
       vst1q_f16(&Z[i], vaddq_f16(z0_7, xy0_7));
     } else {
       vst1q_f16(&Z[i], xy0_7);
     }
   }
   while (i < N) {
-    if (std::abs(beta) > __FLT_MIN__)
-      Z[i] = X[i] + alpha * Y[i] + beta * Z[i];
+    if (std::abs(gamma) > __FLT_MIN__)
+      Z[i] = X[i] + beta * Y[i] + gamma * Z[i];
     else
-      Z[i] = X[i] + alpha * Y[i];
+      Z[i] = X[i] + beta * Y[i];
     ++i;
   }
 }

--- a/nntrainer/tensor/blas_neon.h
+++ b/nntrainer/tensor/blas_neon.h
@@ -160,16 +160,16 @@ void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
              float alpha = 1.f, float beta = 0.f);
 
 /**
- * @brief     elementwise vector addition : Z = X + alpha * Y + beta * Z
+ * @brief     elementwise vector addition : Z = X + beta * Y + gamma * Z
  * @param[in] N  length of the vector
  * @param[in] X float * for Vector X
  * @param[in] Y float * for Vector Y
  * @param[in] Z float * for Vector Z
- * @param[in] alpha scalar multiplier for input
- * @param[in] beta scalar multiplier for output
+ * @param[in] beta scalar multiplier for input
+ * @param[in] gamma scalar multiplier for output
  */
-void ele_add(const unsigned int N, const float *X, const float *Y, float *Z,
-             float alpha = 1.f, float beta = 0.f);
+void xpbypcz(const unsigned int N, const float *X, const float *Y, float *Z,
+             float beta = 1.f, float gamma = 0.f);
 /**
  * @brief     elementwise vector subtraction with neon : Z = X - alpha * Y +
  * beta * Z
@@ -243,17 +243,17 @@ void hgemv(const __fp16 *A, const __fp16 *X, __fp16 *Y, uint32_t M, uint32_t N,
 void ele_mul(const unsigned N, const __fp16 *X, const __fp16 *Y, __fp16 *Z,
              float alpha = 1.f, float beta = 0.f);
 /**
- * @brief     elementwise vector addition with neon : Z = X + alpha * Y + beta *
+ * @brief     elementwise vector addition with neon : Z = X + beta * Y + gamma *
  * Z
  * @param[in] N  length of the vector
  * @param[in] X __fp16 * for Vector X
  * @param[in] Y __fp16 * for Vector Y
  * @param[in] Z __fp16 * for Vector Z
- * @param[in] alpha scalar multiplier for input
- * @param[in] beta scalar multiplier for output
+ * @param[in] beta scalar multiplier for input
+ * @param[in] gamma scalar multiplier for output
  */
-void ele_add(const unsigned N, const __fp16 *X, const __fp16 *Y, __fp16 *Z,
-             float alpha = 1.f, float beta = 0.f);
+void xpbypcz(const unsigned N, const __fp16 *X, const __fp16 *Y, __fp16 *Z,
+             float beta = 1.f, float gamma = 0.f);
 
 /**
  * @brief     elementwise vector subtraction with neon : Z = X - alpha * Y +

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -443,8 +443,8 @@ Tensor &FloatTensor::add_strided(Tensor const &input, Tensor &output,
 int FloatTensor::add_i_partial(unsigned int len, unsigned int addr_idx,
                                Tensor &m, unsigned int incX, unsigned int incY,
                                const Tensor alphas, unsigned int alpha_idx) {
-  saxpy(len, alphas.getValue<float>(alpha_idx), m.getData<float>(), incX,
-        (float *)getAddress(addr_idx), incY);
+  ele_add(len, nullptr, m.getData<float>(), (float *)getAddress(addr_idx), 0.F,
+          alphas.getValue<float>(alpha_idx), 1.F, incX, incY);
 
   return ML_ERROR_NONE;
 }
@@ -455,12 +455,12 @@ Tensor &FloatTensor::add(float const &value, Tensor &output) const {
   return output;
 }
 
-Tensor &FloatTensor::add(Tensor const &m, Tensor &output,
-                         float const alpha) const {
+Tensor &FloatTensor::add(Tensor const &m, Tensor &output, float const alpha,
+                         float const beta, float const gamma) const {
   auto f = [&](const BroadcastInfo &e, const float *buf, const float *m_buf,
                float *out_buf) {
-    ele_add(e.buffer_size, buf, m_buf, out_buf, alpha, 0, e.strides[3],
-            strides[3]);
+    ele_add(e.buffer_size, buf, m_buf, out_buf, alpha, beta, gamma,
+            e.strides[3], strides[3]);
   };
   apply_broadcast(m, f, output);
   return output;

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -324,8 +324,8 @@ public:
    * @copydoc Tensor::add(Tensor const &m, Tensor &output, float const
    * alpha)
    */
-  Tensor &add(Tensor const &m, Tensor &output,
-              float const alpha) const override;
+  Tensor &add(Tensor const &m, Tensor &output, float const alpha = 1,
+              float const beta = 1, float const gamma = 0) const override;
 
   /**
    *  @copydoc Tensor::subtract(float const &value, Tensor &output)

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -425,9 +425,8 @@ Tensor &HalfTensor::add_strided(Tensor const &input, Tensor &output,
 int HalfTensor::add_i_partial(unsigned int len, unsigned int addr_idx,
                               Tensor &m, unsigned int incX, unsigned int incY,
                               const Tensor alphas, unsigned int alpha_idx) {
-  saxpy(len, alphas.getValue<_FP16>(alpha_idx), m.getData<_FP16>(), incX,
-        (_FP16 *)getAddress(addr_idx), incY);
-
+  ele_add(len, nullptr, m.getData<_FP16>(), (_FP16 *)getAddress(addr_idx), 0.F,
+          alphas.getValue<_FP16>(alpha_idx), 1.F, incX, incY);
   return ML_ERROR_NONE;
 }
 
@@ -438,12 +437,12 @@ Tensor &HalfTensor::add(float const &value, Tensor &output) const {
   return output;
 }
 
-Tensor &HalfTensor::add(Tensor const &m, Tensor &output,
-                        float const alpha) const {
+Tensor &HalfTensor::add(Tensor const &m, Tensor &output, float const alpha,
+                        float const beta, float const gamma) const {
   auto f = [&](const BroadcastInfo &e, const _FP16 *buf, const _FP16 *m_buf,
                _FP16 *out_buf) {
-    ele_add(e.buffer_size, buf, m_buf, out_buf, alpha, 0, e.strides[3],
-            strides[3]);
+    ele_add(e.buffer_size, buf, m_buf, out_buf, alpha, beta, gamma,
+            e.strides[3], strides[3]);
   };
   apply_broadcast(m, f, output);
   return output;

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -324,8 +324,8 @@ public:
    * @copydoc Tensor::add(Tensor const &m, Tensor &output, float const
    * alpha)
    */
-  Tensor &add(Tensor const &m, Tensor &output,
-              float const alpha) const override;
+  Tensor &add(Tensor const &m, Tensor &output, float const alpha = 1,
+              float const beta = 1, float const gamma = 0) const override;
 
   /**
    * @copydoc Tensor::subtract(float const &value, Tensor &output)

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -559,7 +559,7 @@ Tensor &Tensor::add(float const &value, Tensor &output) const {
 
 int Tensor::add_i(Tensor const &m, float const alpha) {
   try {
-    itensor->add(m, *this, alpha);
+    itensor->add(m, *this, 0.F, alpha, 1.F);
   } catch (std::exception &err) {
     ml_loge("%s %s", typeid(err).name(), err.what());
     return ML_ERROR_INVALID_PARAMETER;
@@ -576,10 +576,11 @@ int Tensor::add_i_partial(unsigned int len, unsigned int addr_idx, Tensor &m,
 
 Tensor Tensor::add(Tensor const &m, float const alpha) const {
   Tensor t("", getFormat(), getDataType());
-  return this->add(m, t, alpha);
+  return this->add(m, t, 1.F, alpha, 0.F);
 }
 
-Tensor &Tensor::add(Tensor const &m, Tensor &output, float const alpha) const {
+Tensor &Tensor::add(Tensor const &m, Tensor &output, float const alpha,
+                    float const beta, float const gamma) const {
   NNTR_THROW_IF(m.getFormat() != this->getFormat(), std::invalid_argument)
     << "Tensor Format of " << getName() << ":"
     << ((bool)(this->getFormat()) ? "NHWC" : "NCHW") << " is not match. ("
@@ -589,7 +590,7 @@ Tensor &Tensor::add(Tensor const &m, Tensor &output, float const alpha) const {
                   !output.getContiguous(),
                 std::invalid_argument)
     << getName() << " is not contiguous, cannot add";
-  itensor->add(m, output, alpha);
+  itensor->add(m, output, alpha, beta, gamma);
   return output;
 }
 
@@ -616,7 +617,7 @@ Tensor Tensor::subtract(Tensor const &m) const {
 }
 
 Tensor &Tensor::subtract(Tensor const &m, Tensor &output) const {
-  return add(m, output, -1);
+  return add(m, output, 1.F, -1, 0.F);
 }
 
 /**

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -993,7 +993,8 @@ public:
    * @param[in]  alpha Values to be scaled
    * @retval     Calculated Tensor
    */
-  Tensor &add(Tensor const &m, Tensor &output, float const alpha = 1) const;
+  Tensor &add(Tensor const &m, Tensor &output, float const alpha = 1,
+              float const beta = 1, float const gamma = 0) const;
 
   /**
    * @brief     memcpyless version of subtract

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -424,8 +424,8 @@ Tensor &TensorBase::add(float const &value, Tensor &output) const {
     getStringDataType());
 }
 
-Tensor &TensorBase::add(Tensor const &m, Tensor &output,
-                        float const alpha) const {
+Tensor &TensorBase::add(Tensor const &m, Tensor &output, float const alpha,
+                        float const beta, float const gamma) const {
   throw std::invalid_argument(
     "Tensor::add() is currently not supported in tensor data type " +
     getStringDataType());

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -323,7 +323,8 @@ public:
    * @copydoc Tensor::add(Tensor const &m, Tensor &output, float const
    * alpha)
    */
-  virtual Tensor &add(Tensor const &m, Tensor &output, float const alpha) const;
+  virtual Tensor &add(Tensor const &m, Tensor &output, float const alpha = 1,
+                      float const beta = 1, float const gamma = 0) const;
 
   /**
    * @copydoc Tensor::subtract(float const &value, Tensor &output)


### PR DESCRIPTION
- This PR resolves the issue proposed from #2858
- Integrate for better maintenance and functionality from the Tensor level
- Add alpha, beta, gamma constant to differentiate the operation
- note :
    - axpy : a * x plus y
    - xpaypbz : x plus a * y plus b * z

- AS-IS
    1. ele_add : z = x + a * y + b * z
    2. axpy : y = a * x + y
- TO-BE
    1. ele_add : z = a * x + b * y + c * z
    2. axpy : y = a * x + y ( z = b * y + z from current fix )
    3. xpaypbz : z = x + a * y + b * z

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: skykongkong8 <ss.kong@samsung.com>