### PR TITLE
[Windows] Use portable version of strerror

### DIFF
--- a/Applications/utils/datagen/cifar/cifar_dataloader.cpp
+++ b/Applications/utils/datagen/cifar/cifar_dataloader.cpp
@@ -137,11 +137,8 @@ void Cifar100DataLoader::next(float **input, float **label, bool *last) {
   /// @note below logic assumes a single input and the fine label is used
 
   auto fill_one_sample = [this](float *input_, float *label_, int index) {
-    const size_t error_buflen = 102;
-    char error_buf[error_buflen];
     NNTR_THROW_IF(!file.good(), std::invalid_argument)
-      << "file is not good, reason: "
-      << strerror_r(errno, error_buf, error_buflen);
+      << "file is not good, reason: " << std::strerror(errno);
     file.seekg(index * Cifar100DataLoader::SampleSize, std::ios_base::beg);
 
     uint8_t current_label;

--- a/benchmarks/fake_data_gen/fake_data_gen.cpp
+++ b/benchmarks/fake_data_gen/fake_data_gen.cpp
@@ -137,11 +137,8 @@ void Cifar100DataLoader::next(float **input, float **label, bool *last) {
   /// @note below logic assumes a single input and the fine label is used
 
   auto fill_one_sample = [this](float *input_, float *label_, int index) {
-    const size_t error_buflen = 102;
-    char error_buf[error_buflen];
     NNTR_THROW_IF(!file.good(), std::invalid_argument)
-      << "file is not good, reason: "
-      << strerror_r(errno, error_buf, error_buflen);
+      << "file is not good, reason: " << std::strerror(errno);
     file.seekg(index * Cifar100DataLoader::SampleSize, std::ios_base::beg);
 
     uint8_t current_label;

--- a/nntrainer/compiler/tflite_interpreter.cpp
+++ b/nntrainer/compiler/tflite_interpreter.cpp
@@ -57,11 +57,8 @@ void builder2file(const flatbuffers::FlatBufferBuilder &builder,
   NNTR_THROW_IF(!tflite::VerifyModelBuffer(v), std::invalid_argument)
     << FUNC_TAG << "Verifying serialized model failed";
   std::ofstream os(out, std::ios_base::binary);
-  const size_t error_buflen = 100;
-  char error_buf[error_buflen];
   NNTR_THROW_IF(!os.good(), std::invalid_argument)
-    << FUNC_TAG
-    << "failed to open, reason: " << strerror_r(errno, error_buf, error_buflen);
+    << FUNC_TAG << "failed to open, reason: " << std::strerror(errno);
 
   std::streamsize sz = static_cast<std::streamsize>(builder.GetSize());
   NNTR_THROW_IF(sz < 0, std::invalid_argument)

--- a/nntrainer/models/model_loader.cpp
+++ b/nntrainer/models/model_loader.cpp
@@ -472,10 +472,8 @@ int ModelLoader::loadFromConfig(std::string config, NeuralNetwork &model) {
 
   auto config_realpath_char = getRealpath(config.c_str(), nullptr);
   if (config_realpath_char == nullptr) {
-    const size_t error_buflen = 100;
-    char error_buf[error_buflen];
     ml_loge("failed to resolve config path to absolute path, reason: %s",
-            strerror_r(errno, error_buf, error_buflen));
+            std::strerror(errno));
     return ML_ERROR_INVALID_PARAMETER;
   }
   std::string config_realpath(config_realpath_char);

--- a/nntrainer/tensor/swap_device.cpp
+++ b/nntrainer/tensor/swap_device.cpp
@@ -11,11 +11,11 @@
  *
  */
 
+#include <cstring>
 #include <fcntl.h>
 #include <malloc.h>
 #include <profiler.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -64,11 +64,8 @@ void *SwapDevice::getBuffer(off_t offset, size_t size, bool alloc_only) {
 
   char *ptr = static_cast<char *>(
     mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, off));
-  const size_t error_buflen = 100;
-  char error_buf[error_buflen];
   NNTR_THROW_IF(ptr == (void *)-1, std::runtime_error)
-    << "SwapDevice: mmap: "
-    << std::string(strerror_r(errno, error_buf, error_buflen));
+    << "SwapDevice: mmap: " << std::string(std::strerror(errno));
 
   void *buf = static_cast<void *>(ptr + diff);
   mapped[buf] = std::make_tuple(ptr, len, offset, (ssize_t)size);
@@ -125,11 +122,8 @@ void SwapDevice::putBuffer(void *ptr, bool dealloc_only) {
   }
 
   ret = munmap(std::get<void *>(info), std::get<size_t>(info));
-  const size_t error_buflen = 100;
-  char error_buf[error_buflen];
   NNTR_THROW_IF(ret == -1, std::runtime_error)
-    << "SwapDevice: munmap: "
-    << std::string(strerror_r(errno, error_buf, error_buflen));
+    << "SwapDevice: munmap: " << std::string(std::strerror(errno));
 
   mapped.erase(ptr);
 

--- a/nntrainer/utils/ini_wrapper.cpp
+++ b/nntrainer/utils/ini_wrapper.cpp
@@ -128,10 +128,8 @@ void IniWrapper::save_ini(const std::string &ini_name) const {
 
 void IniWrapper::erase_ini() const noexcept {
   if (remove(getIniName().c_str())) {
-    const size_t error_buflen = 100;
-    char error_buf[error_buflen];
-    std::cerr << "remove ini " << getIniName() << "failed, reason: "
-              << strerror_r(errno, error_buf, error_buflen);
+    std::cerr << "remove ini " << getIniName()
+              << "failed, reason: " << std::strerror(errno);
   }
 }
 

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -200,11 +200,9 @@ template <typename T>
 T checkedOpenStream(const std::string &path, std::ios_base::openmode mode) {
   T model_file(path, mode);
   if (!model_file.good()) {
-    const size_t error_buflen = 100;
-    char error_buf[error_buflen];
     std::stringstream ss;
     ss << "[parseutil] requested file not opened, file path: " << path
-       << " reason: " << strerror_r(errno, error_buf, error_buflen);
+       << " reason: " << std::strerror(errno);
     if (errno == EPERM || errno == EACCES) {
       throw nntrainer::exception::permission_denied(ss.str().c_str());
     } else {

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -452,10 +452,8 @@ TEST(nntrainer_ccapi, save_ini_p) {
   EXPECT_EQ(model->initialize(), ML_ERROR_NONE);
   auto saved_ini_name = s.getIniName() + "_saved";
   if (remove(saved_ini_name.c_str())) {
-    const size_t error_buflen = 100;
-    char error_buf[error_buflen];
-    std::cerr << "remove ini " << saved_ini_name << "failed, reason: "
-              << strerror_r(errno, error_buf, error_buflen);
+    std::cerr << "remove ini " << saved_ini_name
+              << "failed, reason: " << std::strerror(errno);
   }
 
   model->save(saved_ini_name, ml::train::ModelFormat::MODEL_FORMAT_INI);

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -98,11 +98,7 @@ TEST_P(nntrainerInterpreterTest, graphSerializeAfterDeserialize) {
 
   graphEqual(g, new_g);
 
-  const size_t error_buflen = 100;
-  char error_buf[error_buflen];
-
-  EXPECT_EQ(remove(out_file_path.c_str()), 0)
-    << strerror_r(errno, error_buf, error_buflen);
+  EXPECT_EQ(remove(out_file_path.c_str()), 0) << std::strerror(errno);
 }
 
 TEST_P(nntrainerInterpreterTest, deserialize_01_n) {

--- a/test/unittest/compiler/unittest_tflite_export.cpp
+++ b/test/unittest/compiler/unittest_tflite_export.cpp
@@ -179,12 +179,9 @@ TEST(nntrainerInterpreterTflite, simple_fc) {
     EXPECT_NEAR(out[i], ans[i], 0.000001f);
 
   if (remove("simple_fc.tflite")) {
-    const size_t error_buflen = 100;
-    char error_buf[error_buflen];
     std::cerr << "remove tflite "
               << "simple_fc.tflite"
-              << "failed, reason: "
-              << strerror_r(errno, error_buf, error_buflen);
+              << "failed, reason: " << std::strerror(errno);
   }
 }
 
@@ -236,12 +233,9 @@ TEST(nntrainerInterpreterTflite, flatten_test) {
     EXPECT_NEAR(out[i], ans[i], 0.000001f);
 
   if (remove("flatten_test.tflite")) {
-    const size_t error_buflen = 100;
-    char error_buf[error_buflen];
     std::cerr << "remove tflite "
               << "flatten_test.tflite"
-              << "failed, reason: "
-              << strerror_r(errno, error_buf, error_buflen);
+              << "failed, reason: " << std::strerror(errno);
   }
 }
 
@@ -311,12 +305,9 @@ TEST(nntrainerInterpreterTflite, part_of_resnet_0) {
     EXPECT_NEAR(out[i], ans[i], 0.000001f);
 
   if (remove("part_of_resnet.tflite")) {
-    const size_t error_buflen = 100;
-    char error_buf[error_buflen];
     std::cerr << "remove ini "
               << "part_of_resnet.tflite"
-              << "failed, reason: "
-              << strerror_r(errno, error_buf, error_buflen);
+              << "failed, reason: " << std::strerror(errno);
   }
 }
 
@@ -395,11 +386,8 @@ TEST(nntrainerInterpreterTflite, MNIST_FULL_TEST) {
     std::cout << "out : " << out[i] << " ans : " << ans[i] << std::endl;
   }
   if (remove("MNIST_FULL_TEST.tflite")) {
-    const size_t error_buflen = 100;
-    char error_buf[error_buflen];
     std::cerr << "remove tflite "
               << "MNIST_FULL_TEST.tflite"
-              << "failed, reason: "
-              << strerror_r(errno, error_buf, error_buflen);
+              << "failed, reason: " << std::strerror(errno);
   }
 }

--- a/test/unittest/models/models_golden_test.cpp
+++ b/test/unittest/models/models_golden_test.cpp
@@ -65,10 +65,8 @@ TEST_P(nntrainerModelTest, model_test_save_load_compare) {
       new nntrainer::NeuralNetwork());
     nn->load(saved_ini_name, ml::train::ModelFormat::MODEL_FORMAT_INI);
     if (remove(saved_ini_name.c_str())) {
-      const size_t error_buflen = 100;
-      char error_buf[error_buflen];
-      std::cerr << "remove ini " << saved_ini_name << "failed, reason: "
-                << strerror_r(errno, error_buf, error_buflen);
+      std::cerr << "remove ini " << saved_ini_name
+                << "failed, reason: " << std::strerror(errno);
     }
     return nn;
   };
@@ -97,10 +95,8 @@ TEST_P(nntrainerModelTest, model_test_save_load_verify) {
       new nntrainer::NeuralNetwork());
     nn->load(saved_ini_name, ml::train::ModelFormat::MODEL_FORMAT_INI);
     if (remove(saved_ini_name.c_str())) {
-      const size_t error_buflen = 100;
-      char error_buf[error_buflen];
-      std::cerr << "remove ini " << saved_ini_name << "failed, reason: "
-                << strerror_r(errno, error_buf, error_buflen);
+      std::cerr << "remove ini " << saved_ini_name
+                << "failed, reason: " << std::strerror(errno);
     }
     return nn;
   };


### PR DESCRIPTION
This PR is part of porting nntrainer to windows.
This PR replace using GNU specific function strerror_r with portable version std::strerror

Replace this:
https://linux.die.net/man/3/strerror_r 
With:
https://en.cppreference.com/w/cpp/string/byte/strerror

Self-evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped








