### PR TITLE
[CI] Add daily Ubuntu build

### DIFF
--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -1,0 +1,65 @@
+name: Daily Ubuntu Build
+
+on:
+  schedule:
+    # 04:30 AM (KST) Mon-Fri
+    - cron: "30 19 * * 0-4"
+
+jobs:
+  meson_test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        meson_options: [ "-Denable-fp16=false", "-Denable-fp16=true" ]
+        meson_swap_options: ["-Denable-memory-swap=true", "-Denable-memory-swap=false"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: install additional package from PPA for testing
+        run: sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
+      - name: install minimal requirements
+        run: sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
+      - name: install additional packages for features
+        run: sudo apt-get install -y python3-dev python3-numpy python3
+      - name: gcc version change
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get install build-essential
+          sudo apt update
+          sudo apt install -y gcc-13
+          sudo apt install -y g++-13
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1000 
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 1000
+          sudo update-alternatives --set gcc /usr/bin/gcc-13
+      - name: install build systems
+        run: sudo apt install meson ninja-build
+      - run: |
+          meson \
+            --buildtype=plain \
+            --prefix=/usr \
+            --sysconfdir=/etc \
+            --libdir=lib/x86_64-linux-gnu \
+            --bindir=lib/nntrainer/bin \
+            --includedir=include \
+            -Dinstall-app=true \
+            -Dreduce-tolerance=false \
+            -Denable-debug=true \
+            -Dml-api-support=enabled \
+            -Denable-nnstreamer-tensor-filter=enabled \
+            -Denable-nnstreamer-tensor-trainer=enabled \
+            -Denable-nnstreamer-backbone=true \
+            -Dcapi-ml-common-actual=capi-ml-common \
+            -Dcapi-ml-inference-actual=capi-ml-inference \
+            -Denable-capi=enabled \
+            ${{ matrix.meson_options }} \
+            ${{ matrix.meson_swap_options }} \
+            build
+      - run: ninja -C build
+      - name: run ninja test
+        run: cd ./build && ninja test


### PR DESCRIPTION
Add Dailt Ubuntu build for our projects build test
- for now we use AWS S3 for daily build from now we use gitaction
- use matrix on ubuntu 20.04, ubuntu 22.04
- use matrix on fp16 enable / disable
- use matrix on swap enable / disable

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped