### PR TITLE
[realizer] fix previous_input_realizer for weight layer

### DIFF
--- a/nntrainer/compiler/previous_input_realizer.cpp
+++ b/nntrainer/compiler/previous_input_realizer.cpp
@@ -54,6 +54,13 @@ PreviousInputRealizer::realize(const GraphRepresentation &reference) {
       continue;
     }
 
+    /**
+     * @brief Weight layer can't have a previous input
+     *
+     */
+    if (node->getType() == "weight")
+      continue;
+
     NNTR_THROW_IF(iter == processed.begin(), std::invalid_argument)
       << "First node must be identified as an input if it is qualified to be "
          "input, name: "


### PR DESCRIPTION
The weight layer does not have an input, so it was modified not to check input layers in the previous input realizer.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>