### PR TITLE
[Windows] Add multi os wrapper for loading dynamic libraries

### DIFF
--- a/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_test.cpp
@@ -12,7 +12,6 @@
  */
 #include <gtest/gtest.h>
 
-#include <dlfcn.h>
 #include <fstream>
 #include <iostream>
 #include <string>

--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -47,6 +47,7 @@
 /usr/include/nntrainer/util_func.h
 /usr/include/nntrainer/fp16.h
 /usr/include/nntrainer/util_simd.h
+/usr/include/nntrainer/dynamic_library_loader.h
 # model
 /usr/include/nntrainer/neuralnet.h
 ## neuralnet.h : forwarding() / backwarding() support

--- a/nntrainer/utils/dynamic_library_loader.h
+++ b/nntrainer/utils/dynamic_library_loader.h
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   dynamic_library_loader.h
+ * @date   14 January 2025
+ * @brief  Wrapper for loading dynamic libraries on multiple operating systems
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Grzegorz Kisala <g.kisala@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __DYNAMIC_LIBRARY_LOADER__
+#define __DYNAMIC_LIBRARY_LOADER__
+
+#include <string>
+
+#ifdef _WIN32
+#include "windows.h"
+
+// This flags are not used on windows. Defining those symbols for windows make
+// possible using the same external interface for loadLibrary function
+#define RTLD_LAZY 0
+#define RTLD_NOW 0
+#define RTLD_BINDING_MASK 0
+#define RTLD_NOLOAD 0
+#define RTLD_DEEPBIND 0
+#define RTLD_GLOBAL 0
+#define RTLD_LOCAL 0
+#define RTLD_NODELETE 0
+
+#else
+#include <dlfcn.h>
+#endif
+
+namespace nntrainer {
+
+/**
+ * @brief DynamicLibraryLoader wrap process of loading dynamic libraries for
+ * multiple operating system
+ *
+ */
+class DynamicLibraryLoader {
+public:
+  static void *loadLibrary(const char *path, [[maybe_unused]] const int flag) {
+#if defined(_WIN32)
+    return LoadLibraryA(path);
+#else
+    return dlopen(path, flag);
+#endif
+  }
+
+  static int freeLibrary(void *handle) {
+#if defined(_WIN32)
+    return FreeLibrary((HMODULE)handle);
+#else
+    return dlclose(handle);
+#endif
+  }
+
+  static const char *getLastError() {
+#if defined(_WIN32)
+    return std::to_string(GetLastError()).c_str();
+#else
+    return dlerror();
+#endif
+  }
+
+  static void *loadSymbol(void *handle, const char *symbol_name) {
+#if defined(_WIN32)
+    return GetProcAddress((HMODULE)handle, symbol_name);
+#else
+    return dlsym(handle, symbol_name);
+#endif
+  }
+};
+
+} // namespace nntrainer
+
+#endif // __DYNAMIC_LIBRARY_LOADER__

--- a/nntrainer/utils/meson.build
+++ b/nntrainer/utils/meson.build
@@ -17,6 +17,7 @@ util_headers = [
   'nntr_threads.h',
   'fp16.h',
   'util_simd.h',
+  'dynamic_library_loader.h',
 ]
 
 if get_option('enable-trace')

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -576,6 +576,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/util_func.h
 %{_includedir}/nntrainer/fp16.h
 %{_includedir}/nntrainer/util_simd.h
+%{_includedir}/nntrainer/dynamic_library_loader.h
 %{_includedir}/nntrainer/loss_layer.h
 %ifarch aarch64
 %if 0%{?enable_fp16}


### PR DESCRIPTION
Create class which make possible to use the same interface for loading dynamic libraries and symbols for multiple operating systems

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped