### PR TITLE
Update: New URL for NNStreamer Latest Android Build

### DIFF
--- a/jni/prepare_ml-api.sh
+++ b/jni/prepare_ml-api.sh
@@ -13,10 +13,9 @@
 set -e
 TARGET=$1
 # Note: zip name can be nnstreamer-native-*.zip but this file is heavier to download
-FILE_PREFIX=nnstreamer-lite-native
-ZIP_NAME_REGEX=${FILE_PREFIX}-*.zip
+FILE_PREFIX=nnstreamer-lite-native-$(date +"%Y-%m-%d")
 ZIP_NAME=${FILE_PREFIX}.zip
-URL="http://ci.nnstreamer.ai/nnstreamer/ci/daily-build/build_result/latest/android"
+URL="https://nnstreamer-release.s3-ap-northeast-2.amazonaws.com/nnstreamer/latest/android/"
 
 echo "PREPARING ml_api at ${TARGET}"
 
@@ -27,7 +26,7 @@ pushd ${TARGET}
 function _download_ml_api {
   [ -f $ZIP_NAME ] && echo "${ZIP_NAME} exists, skip downloading" && return 0
   echo "[ml_api] downloading ${ZIP_NAME}\n"
-  if ! wget -r -l1 -nH --cut-dirs=6 ${URL} -A ${ZIP_NAME_REGEX} -O ${ZIP_NAME} ; then
+  if ! wget -r -l1 -nH --cut-dirs=6 ${URL}${ZIP_NAME} -O ${ZIP_NAME} ; then
     echo "[ml_api] Download failed, please check url\n"
     exit $?
   fi


### PR DESCRIPTION
This PR updates the URL of the NNStreamer's latest android build result.
The previous URL is deprecated and is no longer be updated.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped