### PR TITLE
Update: NNstreamer-lite-Native URL with const name

### DIFF
--- a/jni/prepare_ml-api.sh
+++ b/jni/prepare_ml-api.sh
@@ -13,7 +13,7 @@
 set -e
 TARGET=$1
 # Note: zip name can be nnstreamer-native-*.zip but this file is heavier to download
-FILE_PREFIX=nnstreamer-lite-native-$(date +"%Y-%m-%d")
+FILE_PREFIX=nnstreamer-lite-native
 ZIP_NAME=${FILE_PREFIX}.zip
 URL="https://nnstreamer-release.s3-ap-northeast-2.amazonaws.com/nnstreamer/latest/android/"
 
@@ -26,7 +26,7 @@ pushd ${TARGET}
 function _download_ml_api {
   [ -f $ZIP_NAME ] && echo "${ZIP_NAME} exists, skip downloading" && return 0
   echo "[ml_api] downloading ${ZIP_NAME}\n"
-  if ! wget -r -l1 -nH --cut-dirs=6 ${URL}${ZIP_NAME} -O ${ZIP_NAME} ; then
+  if ! wget -r -l1 -nH --cut-dirs=3 ${URL}${ZIP_NAME} -O ${ZIP_NAME} ; then
     echo "[ml_api] Download failed, please check url\n"
     exit $?
   fi


### PR DESCRIPTION
**Update nnstreamer-lite-native url to const name from date base name**
1. if the cron job of NNStreamer runs and builds at a certain time while the day has changed, the file may not exist due to the interval between those times.
2. For whatever reason, if NNStreamer fails to perform daily build, the file may not exist.

**change --cut-dirs : 6 -> 3**
- "nH" option will remove "https://nnstreamer-release.s3-ap-northeast-2.amazonaws.com"
- then dir would be /nnstreamer/latest/android/
- cut 3 dir will make "main" dir on builddir/ml-api-inference directly

@djeong20 Thank you for working on the URL-related task. 
Although it works normally now, using the ZIP file named updated by @gichan-jang  would increase stability to prevent failures as much as possible.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped