### PR TITLE
Fix opencl/context member property init.

### DIFF
--- a/nntrainer/opencl/opencl_context_manager.cpp
+++ b/nntrainer/opencl/opencl_context_manager.cpp
@@ -153,7 +153,7 @@ bool ContextManager::CreateDefaultGPUDevice() {
 
   // setting the first GPU ID and platform (ARM)
   device_id_ = devices[0];
-  platform_id_ = platform_id_;
+  this->platform_id_ = platform_id_;
 
 #ifdef ENABLE_FP16
   // check for fp16 (half) support available on device


### PR DESCRIPTION
If you have a local variable having the same with the member property, you need ```this``` to address the member property.

Fixes #2763

CC: @DonghakPark 