### PR TITLE
Add arm-native build and test on Ubuntu (wait for #2910) @open sesame 02/05 17:05

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -42,9 +42,7 @@ jobs:
           --buildtype=plain \
           --prefix=/usr \
           --sysconfdir=/etc \
-          --libdir=lib/x86_64-linux-gnu \
           --bindir=lib/nntrainer/bin \
-          --includedir=include \
           -Dinstall-app=true \
           -Dreduce-tolerance=false \
           -Denable-debug=true \

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-22.04-arm ]
         meson_options: [ "-Denable-fp16=false", "-Denable-fp16=true" ]
 
     steps:


### PR DESCRIPTION
We can run arm natively with github-action.
Test fp16 natively on arm machines!

