### PR TITLE
Release of 0.6.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nntrainer (0.6.0) unstable; urgency=medium
+
+  * 0.6.0 released
+
+ -- MyungJoo Ham <myungjoo.ham@samsung.com>  Thu, 23 Jan 2025 14:08:00 +0900
+
 nntrainer (0.5.0) unstable; urgency=medium
 
   * 0.5.0 released

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('nntrainer', 'c', 'cpp',
-  version: '0.5.0',
+  version: '0.6.0',
   license: ['apache-2.0'],
   meson_version: '>=0.50.0',
   default_options: [

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -75,7 +75,7 @@
 
 Name:		nntrainer
 Summary:	Software framework for training neural networks
-Version:	0.5.0
+Version:	0.6.0
 Release:	0
 Packager:	Jijoong Moon <jijoong.moon@samsung.com>
 License:	Apache-2.0
@@ -704,6 +704,8 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %endif
 
 %changelog
+* Thu Jan 23 2025 MyungJoo Ham <myungjoo.ham@samsung.com>
+- Release of 0.6.0
 * Tue Apr 04 2023 Jijoong Moon <jijoong.moon@samsung.com>
 - Release of 0.5.0
 * Mon Sep 26 2022 Jijoong Moon <jijoong.moon@samsung.com>


### PR DESCRIPTION
It has been too long since the last version update, and we had too huge changes since 0.5.0 release.

Besides, PPA Launchpad has issue of having 0.5.1 release, which blocks updating latest 0.5.0 updates.

PPA status:
```
[Built] by recipe [nntrainer-daily] for [nnstreamer]
Published on 2023-09-18
Changelog
nntrainer (0.5.1-0~202309180717~ubuntu22.04.1) jammy; urgency=low

  * Auto build.

 -- Launchpad Package Builder <[noreply@launchpad.net]>  Mon, 18 Sep 2023 12:47:09 +0000
```