### PR TITLE
meson: avx condition fix.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -72,15 +72,20 @@ arch = host_machine.cpu_family()
 
 target = target_machine.cpu_family()
 
+avx_enabled = false
 if get_option('enable-avx')
-   if get_option('platform') != 'android'
-      if target == 'x86_64' or target == 'x86'
-         extra_defines += '-DUSE_AVX=1'
-	 add_project_arguments(['-march=native'], language: ['c','cpp'])
-	 add_project_arguments(['-mavx2'], language: ['c','cpp'])
-         message('-march=native added for AVX hardware acceleration.')
-      endif
-      message('This arch does not support avx2')
+  if get_option('platform') != 'android'
+    if target == 'x86_64' or target == 'x86'
+      extra_defines += '-DUSE_AVX=1'
+      add_project_arguments(['-march=native'], language: ['c','cpp'])
+      add_project_arguments(['-mavx2'], language: ['c','cpp'])
+      message('-march=native added for AVX hardware acceleration.')
+      avx_enabled = true
+    else
+      warning('The target arch, ' + target + ', does not support AVX. enable-avx=true is ignored.')
+    endif
+  else
+    warning('Android build does not support AVX. enable-avx=true is ignored.')
   endif
 endif
 

--- a/nntrainer/tensor/meson.build
+++ b/nntrainer/tensor/meson.build
@@ -52,9 +52,10 @@ tensor_headers = [
 
 arch = host_machine.cpu_family()
 
-if get_option('enable-avx') and get_option('platform') != 'android'
-    tensor_sources += 'blas_avx.cpp'
-    tensor_headers += 'blas_avx.h'
+
+if avx_enabled == true
+  tensor_sources += 'blas_avx.cpp'
+  tensor_headers += 'blas_avx.h'
 endif
 
 if get_option('enable-fp16') 


### PR DESCRIPTION
enable-avx=true is the default option, which breaks the build in other archs in general.

1. Ignore AVX if arch is not x64/x86.
2. Reading get_option should be done only once. Fixed for enable-avx.
2. Corrected the buggy AVX condition.

This fix is required by RISC-V: #2638