### PR TITLE
Compile nntrainer on windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -134,6 +134,11 @@ if get_option('enable-fp16')
    endif  
 endif
 
+if get_option('enable-mmap')
+  message ('MMAP enabled')
+  extra_defines += '-DUSE_MMAP=1'
+endif
+
 if get_option('enable-opencl')
   message ('OpenCL build is enabled. Will work only if OpenCL supported GPU is available.')
   extra_defines += '-DENABLE_OPENCL=1'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,6 +17,7 @@ option('enable-memory-swap', type: 'boolean', value: false)
 option('memory-swap-path', type: 'string', value: '')
 option('test-timeout', type: 'integer', value: 60)
 option('opencl-kernel-path', type: 'string', value: 'nntrainer_opencl_kernels')
+option('enable-mmap', type: 'boolean', value: true)
 
 # dependency conflict resolution
 option('capi-ml-inference-actual', type: 'string', value: 'capi-ml-inference',

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -222,14 +222,6 @@ const std::string getFullPath(const std::string &path,
 
 std::mutex factory_mutex;
 
-/**
- * @brief finalize global context
- *
- */
-static void fini_global_context_nntrainer(void) __attribute__((destructor));
-
-static void fini_global_context_nntrainer(void) {}
-
 std::once_flag global_app_context_init_flag;
 
 static void add_default_object(AppContext &ac) {

--- a/nntrainer/compiler/remap_realizer.h
+++ b/nntrainer/compiler/remap_realizer.h
@@ -14,6 +14,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <realizer.h>

--- a/nntrainer/dataset/databuffer.cpp
+++ b/nntrainer/dataset/databuffer.cpp
@@ -33,6 +33,7 @@
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>
+#include <numeric>
 #include <sstream>
 #include <stdexcept>
 #include <stdio.h>
@@ -61,9 +62,7 @@ public:
 constexpr char USER_DATA[] = "user_data";
 
 DataBuffer::DataBuffer(std::unique_ptr<DataProducer> &&producer_) :
-  producer(std::move(producer_)),
-  db_props(new Props()),
-  user_data(nullptr) {
+  producer(std::move(producer_)), db_props(new Props()), user_data(nullptr) {
   rng.seed(0);
 }
 

--- a/nntrainer/dataset/dir_data_producers.cpp
+++ b/nntrainer/dataset/dir_data_producers.cpp
@@ -104,7 +104,7 @@ DirDataProducer::finalize(const std::vector<TensorDim> &input_dims,
   const auto &dir_path = std::get<props::DirPath>(*dir_data_props).get();
 
   for (const auto &entry : std::filesystem::directory_iterator(dir_path))
-    class_names.push_back(entry.path());
+    class_names.push_back(entry.path().string());
 
   num_class = class_names.size();
 

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -19,6 +19,11 @@
 #include <blas_interface.h>
 #include <common_properties.h>
 
+#if defined(_WIN32)
+#define _USE_MATH_DEFINES
+#include <math.h>
+#endif
+
 namespace nntrainer {
 
 class Tensor;

--- a/nntrainer/layers/dropout.h
+++ b/nntrainer/layers/dropout.h
@@ -29,8 +29,8 @@ public:
   /**
    * @brief     Constructor of DropOut Layer
    */
-  DropOutLayer(float dropout = 0.0) :
-    Layer(), dropout_rate(props::DropOutRate(dropout)), epsilon(1e-3) {}
+  DropOutLayer(float dropout = 0.0f) :
+    Layer(), dropout_rate(props::DropOutRate(dropout)), epsilon(1e-3f) {}
 
   /**
    * @brief     Destructor of DropOut Layer

--- a/nntrainer/layers/rnn.cpp
+++ b/nntrainer/layers/rnn.cpp
@@ -44,7 +44,7 @@ RNNLayer::RNNLayer() :
     props::Unit(), props::HiddenStateActivation() = ActivationType::ACT_TANH,
     props::ReturnSequences(), props::DropOutRate(), props::IntegrateBias()),
   acti_func(ActivationType::ACT_NONE, true),
-  epsilon(1e-3) {
+  epsilon(1e-3f) {
   wt_idx.fill(std::numeric_limits<unsigned>::max());
 }
 

--- a/nntrainer/layers/rnncell.cpp
+++ b/nntrainer/layers/rnncell.cpp
@@ -45,7 +45,7 @@ RNNCellLayer::RNNCellLayer() :
                 props::HiddenStateActivation() = ActivationType::ACT_TANH,
                 props::DropOutRate()),
   acti_func(ActivationType::ACT_NONE, true),
-  epsilon(1e-3) {
+  epsilon(1e-3f) {
   wt_idx.fill(std::numeric_limits<unsigned>::max());
 }
 

--- a/nntrainer/models/dynamic_training_optimization.cpp
+++ b/nntrainer/models/dynamic_training_optimization.cpp
@@ -11,6 +11,7 @@
  *
  */
 
+#include <numeric>
 #include <random>
 #include <vector>
 

--- a/nntrainer/nntrainer_log.h
+++ b/nntrainer/nntrainer_log.h
@@ -56,27 +56,27 @@
 #include <nntrainer_logger.h>
 
 #if !defined(ml_logi)
-#define ml_logi(format, args...)                                            \
+#define ml_logi(format, ...)                                                \
   __nntrainer_log_print(NNTRAINER_LOG_INFO, "(%s:%s:%d) " format, __FILE__, \
-                        __func__, __LINE__, ##args)
+                        __func__, __LINE__, ##__VA_ARGS__)
 #endif
 
 #if !defined(ml_logw)
-#define ml_logw(format, args...)                                            \
+#define ml_logw(format, ...)                                                \
   __nntrainer_log_print(NNTRAINER_LOG_WARN, "(%s:%s:%d) " format, __FILE__, \
-                        __func__, __LINE__, ##args)
+                        __func__, __LINE__, ##__VA_ARGS__)
 #endif
 
 #if !defined(ml_loge)
-#define ml_loge(format, args...)                                             \
+#define ml_loge(format, ...)                                                 \
   __nntrainer_log_print(NNTRAINER_LOG_ERROR, "(%s:%s:%d) " format, __FILE__, \
-                        __func__, __LINE__, ##args)
+                        __func__, __LINE__, ##__VA_ARGS__)
 #endif
 
 #if !defined(ml_logd)
-#define ml_logd(format, args...)                                             \
+#define ml_logd(format, ...)                                                 \
   __nntrainer_log_print(NNTRAINER_LOG_DEBUG, "(%s:%s:%d) " format, __FILE__, \
-                        __func__, __LINE__, ##args)
+                        __func__, __LINE__, ##__VA_ARGS__)
 #endif
 
 #endif

--- a/nntrainer/nntrainer_logger.cpp
+++ b/nntrainer/nntrainer_logger.cpp
@@ -30,7 +30,6 @@
 #include <sstream>
 #include <stdarg.h>
 #include <stdexcept>
-#include <unistd.h>
 #include <util_func.h>
 
 namespace nntrainer {
@@ -78,7 +77,9 @@ Logger::Logger() : ts_type(NNTRAINER_LOG_TIMESTAMP_SEC) {
      << std::setw(2) << now.tm_sec << ".out";
   outputstream.open(ss.str(), std::ios_base::app);
   if (!outputstream.good()) {
-    char buf[256] = {0,};
+    char buf[256] = {
+      0,
+    };
     std::string cur_path = std::string(buf);
     std::string err_msg =
       "Unable to initialize the Logger on path(" + cur_path + ")";

--- a/nntrainer/optimizers/lr_scheduler_cosine.cpp
+++ b/nntrainer/optimizers/lr_scheduler_cosine.cpp
@@ -11,7 +11,12 @@
  *
  */
 
+#if defined(_WIN32)
+#define _USE_MATH_DEFINES
+#include <math.h>
+#else
 #include <cmath>
+#endif
 
 #include <common_properties.h>
 #include <lr_scheduler_cosine.h>

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -11,6 +11,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <numeric>
 
 #include <blas_interface.h>
 #include <float_tensor.h>

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -24,10 +24,13 @@
 #include <functional>
 #include <limits>
 #include <stdexcept>
-#include <sys/mman.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <vector>
+
+#if !defined(_WIN32)
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
 
 #include <activation_layer.h>
 #include <basic_planner.h>
@@ -51,6 +54,8 @@
 #include <var_grad.h>
 
 namespace nntrainer {
+
+#if !defined(_WIN32)
 MMapedMemory::MMapedMemory(size_t size, bool allocate_fd_) :
   fd(-1), buf(nullptr), buf_size(0), allocate_fd(allocate_fd_) {
 
@@ -136,6 +141,7 @@ MMapedMemory::~MMapedMemory() noexcept {
   buf_size = 0;
   ml_logd("[MMapedMemory] buf released");
 }
+#endif
 
 void Manager::reinitialize() {
   inputs_v2.clear();

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -38,6 +38,8 @@
 
 namespace nntrainer {
 using ExecutionMode = ml::train::ExecutionMode;
+
+#if !defined(_WIN32)
 /**
  * @class MMappedMemory
  * @brief Memory Handler, that has mmaped memory with a file descriptor
@@ -104,6 +106,7 @@ private:
   size_t buf_size;  /**< buffer size */
   bool allocate_fd; /**< option to choose to allocate an fd */
 };
+#endif
 
 /**
  * @class   Manager

--- a/nntrainer/tensor/swap_device.cpp
+++ b/nntrainer/tensor/swap_device.cpp
@@ -16,9 +16,7 @@
 #include <malloc.h>
 #include <profiler.h>
 #include <stdlib.h>
-#include <sys/mman.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
@@ -30,8 +28,7 @@ void SwapDevice::start(size_t size) {
   if (fd > 0)
     return;
 
-  fd =
-    open(dev_path.c_str(), O_RDWR | O_CREAT | O_TRUNC | O_SYNC, (mode_t)0666);
+  fd = open(dev_path.c_str(), O_RDWR | O_CREAT | O_TRUNC | O_SYNC, 0666UL);
   NNTR_THROW_IF(fd < 0, std::runtime_error)
     << "SwapDevice: open file: " << dev_path;
 
@@ -153,7 +150,7 @@ void SwapDevice::putBuffer(void *ptr, bool dealloc_only) {
   free(ptr);
   allocated.erase(ptr);
 
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && !defined(_WIN32)
   malloc_trim(0);
 #endif
 

--- a/nntrainer/tensor/swap_device.h
+++ b/nntrainer/tensor/swap_device.h
@@ -18,15 +18,22 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <system_error>
-#include <unistd.h>
 #include <utility>
 
-/* Uncomment this to use mmap for swap data */
-#define USE_MMAP
+#if defined(_WIN32)
+#include <io.h>
+#define O_SYNC 0UL
+#else
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+#if defined(_WIN32)
+using ssize_t = std::make_signed_t<size_t>;
+#endif
 
 namespace nntrainer {
 
@@ -47,16 +54,14 @@ public:
    *
    */
   explicit SwapDevice(const std::string &name) :
-    dev_path(swap_device_default_path + name),
-    fd(-1) {}
+    dev_path(swap_device_default_path + name), fd(-1) {}
 
   /**
    * @brief SwapDevice default constructor
    *
    */
   explicit SwapDevice(const std::string &path, const std::string &name) :
-    dev_path(path + "/" + name),
-    fd(-1) {}
+    dev_path(path + "/" + name), fd(-1) {}
 
   /**
    * @brief SwapDevice destructor

--- a/nntrainer/tensor/task_executor.h
+++ b/nntrainer/tensor/task_executor.h
@@ -22,7 +22,6 @@
 #include <memory>
 #include <mutex>
 #include <thread>
-#include <unistd.h>
 
 #include <task.h>
 

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -9,6 +9,8 @@
  * @bug		No known bugs except for NYI items
  */
 
+#include <numeric>
+
 #include <char_tensor.h>
 #include <float_tensor.h>
 #include <lazy_tensor.h>

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1745,7 +1745,7 @@ public:
    */
   bool isValid() const { return itensor->isValid(); };
 
-  static constexpr float epsilon = 1e-5;
+  static constexpr float epsilon = 1e-5f;
 
 private:
   std::shared_ptr<TensorBase> itensor;

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -704,7 +704,7 @@ public:
    */
   virtual bool isValid() const = 0;
 
-  static constexpr float epsilon = 1e-5;
+  static constexpr float epsilon = 1e-5f;
 
 protected:
   TensorDim dim;

--- a/nntrainer/tensor/weight.h
+++ b/nntrainer/tensor/weight.h
@@ -364,9 +364,9 @@ public:
   const float getLossScale() { return loss_scale; };
 
 private:
-  static constexpr float epsilon = 1e-6; /**< epsilon for zero comparison */
+  static constexpr float epsilon = 1e-6f; /**< epsilon for zero comparison */
   static constexpr float epsilon_decay =
-    1e-8; /**< epsilon for zero comparison */
+    1e-8f; /**< epsilon for zero comparison */
 
   WeightRegularizer regularizer; /**< regularizer for this variable */
   float regularizer_constant;    /**< constant factor for regularization */


### PR DESCRIPTION
[Windows] Compile nntrainer on windows

After this PR all nntrainer library files are possible to compile with MSVC compiler on Windows and most of MSVC warnigs are fixed.
It can be tested by using meson.build from #2868 

Following options should be disabled during build:

[project options]

enable-blas=false 
enable-tflite-backbone=false 
enable-memory-swap=false 
enable-nnstreamer-backbone=false 
enable-tflite-interpreter=false 
enable-app=false 
ml-api-support='disabled'
enable-test=false
install-app=false
enable-avx=false
enable-mmap=false

[built-in options]
werror=false


As a next step I'll modify build system in order to make both windows / linux / android / tizen build possible using the same meson scripts

Self-evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped