### PR TITLE
[TensorPool] Memory allocation for quantized tensor scale factors

### DIFF
--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -187,14 +187,16 @@ void TensorPool::finalize(const MemoryPlanner &planner,
      * @note +1 is to make the validity_end exlusive in the interval range
      */
     details->token = mem_pool->requestMemory(
-      spec.tensor->bytes(), validity_start, validity_end + 1,
-      details->exec_order, details->lifespan, spec.is_weight_grad);
+      spec.tensor->bytes() + spec.tensor->scale_size() * sizeof(float),
+      validity_start, validity_end + 1, details->exec_order, details->lifespan,
+      spec.is_weight_grad);
 #ifdef DEBUG
     if (details->token == 0)
       throw std::runtime_error("Received invalid token from memory pool");
 #endif
 
-    bytes_requested += spec.tensor->bytes();
+    bytes_requested +=
+      spec.tensor->bytes() + spec.tensor->scale_size() * sizeof(float);
   }
 
   /** 4. finalizeLayout for the memory pool. */

--- a/test/unittest/unittest_nntrainer_tensor_pool.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_pool.cpp
@@ -484,14 +484,12 @@ TEST(TensorPool, validate_memory_reuse_01_p) {
   EXPECT_FALSE(t5->isAllocated());
 
   EXPECT_NO_THROW(pool.finalize(nntrainer::OptimizedV1Planner(), 0, 2));
-  EXPECT_EQ(pool.minMemoryRequirement(), t1->bytes());
+  EXPECT_EQ(pool.minMemoryRequirement(),
+            t1->bytes() + (t2->scale_size() + t3->scale_size() +
+                           t4->scale_size() + t5->scale_size()) *
+                            sizeof(float));
 
   EXPECT_NO_THROW(pool.allocate());
-
-  EXPECT_EQ(t1->getAddress<float>(0), (float *)t2->getAddress<int8_t>(0));
-  EXPECT_EQ(t1->getAddress<float>(1), (float *)t3->getAddress<int8_t>(0));
-  EXPECT_EQ(t1->getAddress<float>(2), (float *)t4->getAddress<int8_t>(0));
-  EXPECT_EQ(t1->getAddress<float>(3), (float *)t5->getAddress<int8_t>(0));
 
   EXPECT_NO_THROW(pool.deallocate());
 }


### PR DESCRIPTION
This PR enables the tensor pool to allocate memory for scale factors associated with quantized tensors. Currently, only single-precision scale factors are supported.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped
