### PR TITLE
[ coverity ] Fix coverity issue : leaked_storage

### DIFF
--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -529,7 +529,7 @@ int AppContext::registerLayer(const std::string &library_path,
       return layer;
     };
 
-  return registerFactory<nntrainer::Layer>(factory_func, type);
+  return registerFactory<nntrainer::Layer>(std::move(factory_func), type);
 }
 
 int AppContext::registerOptimizer(const std::string &library_path,
@@ -569,7 +569,7 @@ int AppContext::registerOptimizer(const std::string &library_path,
       return optimizer;
     };
 
-  return registerFactory<nntrainer::Optimizer>(factory_func, type);
+  return registerFactory<nntrainer::Optimizer>(std::move(factory_func), type);
 }
 
 std::vector<int>


### PR DESCRIPTION
- Fixes: leaked_storage: Variable handle going out of scope leaks the storage it points to.
- Apply: Use std::move(factory_func) instead of factory_func.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped
