### PR TITLE
[Coverity] Fix double_unlock issue in markFilled()

### DIFF
--- a/nntrainer/dataset/iteration_queue.cpp
+++ b/nntrainer/dataset/iteration_queue.cpp
@@ -153,10 +153,11 @@ void IterationQueue::notifyEndOfRequestEmpty() {
 }
 
 void IterationQueue::markFilled(MarkableIteration *iteration) {
-  std::unique_lock lg(empty_mutex);
-  num_being_filled--;
-  filled_q.push(iteration);
-  lg.unlock();
+  {
+    std::lock_guard lg(empty_mutex);
+    --num_being_filled;
+    filled_q.push(iteration);
+  }
   notify_emptied_cv.notify_all();
 }
 


### PR DESCRIPTION
- This PR resolves coverity issue (number : 1831328) in recent report. I verified this PR resolves the coverity issue.
- The `unique_lock` was manually unlocked before going out of scope, causing a double unlock issue.
- This has been fixed by removing the explicit `unlock()` call.
- Additionally, `notify_emptied_cv.notify_all()` is now called without holding the lock to avoid unnecessary cntention.

FYI) I initially thought it would be fine to simply remove the unlock code line (no issue with notify_all) , but I decided to update it to a scoped lock just in case.

**Self evaluation:**

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped

