### PR TITLE
[Coverity] Fix Coverity issue at neuralnet destructor

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -1008,9 +1008,14 @@ int NeuralNetwork::allocate(ExecutionMode mode) {
 }
 
 int NeuralNetwork::deallocate() {
-  model_graph.deallocateTensors(true);
-
-  return ML_ERROR_NONE;
+  try {
+    model_graph.deallocateTensors(true);
+    return ML_ERROR_NONE;
+  } catch (const std::exception &e) {
+    std::cerr << "Error occurred during deallocation of NeuralNetwork: "
+              << e.what() << std::endl;
+    return ML_ERROR_UNKNOWN;
+  }
 }
 
 int NeuralNetwork::train(const std::vector<std::string> &values,


### PR DESCRIPTION
Uncaught exception (UNCAUGHT_EXCEPT)

exn_spec_violation: An exception of type std::length_error is thrown but the exception specification /*implicit*/noexcept doesn't allow it to be thrown. This will result in a call to terminate().
- in general, throw exception at destrctor is not allowed
- so, add exception at deallocate Tensor

Resolves:

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Donghak PARK <donghak.park@samsung.com>
