### PR TITLE
[ coverity ] Fix coverity issue : Double unlocking @open sesame 02/08 11:00

### DIFF
--- a/nntrainer/tensor/task_executor.cpp
+++ b/nntrainer/tensor/task_executor.cpp
@@ -38,7 +38,6 @@ TaskExecutor::TaskExecutor(const std::string &n) :
       task_cv.wait(lk, [&] { return !task_queue.empty() || stop_all; });
       if (stop_all && task_queue.empty())
         return;
-
       auto &task_info = task_queue.front();
 
       const auto &id = std::get<int>(task_info);
@@ -48,7 +47,6 @@ TaskExecutor::TaskExecutor(const std::string &n) :
       callback(id, status);
 
       task_queue.pop_front();
-      lk.unlock();
     }
     ml_logd("Task Thread(%s): finish thread", name.c_str());
   });


### PR DESCRIPTION
Resolves:
- double_unlock: ~unique_lock unlocks lk while it is unlocked.   

By applying:
- Removing unnecessary `unlock()`, since it will be unlocked through loop anyway.
- In this case, #2913 (using std::lock_guard) is not valid since wait() function from std::condition_variable is being called.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped
