### PR TITLE
[Log] Change the log files to be saved under the logs folder

### DIFF
--- a/nntrainer/nntrainer_logger.cpp
+++ b/nntrainer/nntrainer_logger.cpp
@@ -23,6 +23,7 @@
 
 #include <cstring>
 #include <ctime>
+#include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <mutex>
@@ -39,7 +40,7 @@ namespace nntrainer {
  * @brief     logfile name
  */
 const char *const Logger::logfile_name = "log_nntrainer_";
-
+const char *const Logger::logfile_dir = "./logs/";
 /**
  * @brief     instance for single logger
  */
@@ -76,9 +77,14 @@ Logger::Logger() : ts_type(NNTRAINER_LOG_TIMESTAMP_SEC) {
      << now.tm_mday << std::setfill('0') << std::setw(2) << now.tm_hour
      << std::setfill('0') << std::setw(2) << now.tm_min << std::setfill('0')
      << std::setw(2) << now.tm_sec << ".out";
-  outputstream.open(ss.str(), std::ios_base::app);
+  if (!std::filesystem::exists(logfile_dir)) {
+    std::filesystem::create_directories(logfile_dir);
+  }
+  outputstream.open(logfile_dir + ss.str(), std::ios_base::app);
   if (!outputstream.good()) {
-    char buf[256] = {0,};
+    char buf[256] = {
+      0,
+    };
     std::string cur_path = std::string(buf);
     std::string err_msg =
       "Unable to initialize the Logger on path(" + cur_path + ")";

--- a/nntrainer/nntrainer_logger.h
+++ b/nntrainer/nntrainer_logger.h
@@ -86,7 +86,10 @@ protected:
    * @brief     Log file name
    */
   static const char *const logfile_name;
-
+  /**
+   * @brief     Log file directory path.
+   */
+  static const char *const logfile_dir;
   /**
    * @brief     output stream
    */


### PR DESCRIPTION
Now, the nntrainer log file have timestamps as their names are saved directly under the execution folder every time. Since Unnecessary files keep pilling up with multiple executions. I changed it this stored under "logs" folder

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Donghak PARK <donghak.park@samsung.com>
