### PR TITLE
[Windows] Modify meson build to support windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -181,20 +181,22 @@ if get_option('enable-biqgemm')
   endif
 endif # end of enable-biqgemm
 
-foreach extra_arg : warning_flags
-  if cc.has_argument (extra_arg)
-    add_project_arguments([extra_arg], language: 'c')
-  endif
-  if cxx.has_argument (extra_arg)
-    add_project_arguments([extra_arg], language: 'cpp')
-  endif
-endforeach
+if host_machine.system() != 'windows'
+  foreach extra_arg : warning_flags
+    if cc.has_argument (extra_arg)
+      add_project_arguments([extra_arg], language: 'c')
+    endif
+    if cxx.has_argument (extra_arg)
+      add_project_arguments([extra_arg], language: 'cpp')
+    endif
+  endforeach
 
-foreach extra_arg : warning_c_flags
-  if cc.has_argument (extra_arg)
-    add_project_arguments([extra_arg], language: 'c')
-  endif
-endforeach
+  foreach extra_arg : warning_c_flags
+    if cc.has_argument (extra_arg)
+      add_project_arguments([extra_arg], language: 'c')
+    endif
+  endforeach
+endif
 
 # Set install path
 nntrainer_prefix = get_option('prefix')
@@ -229,7 +231,13 @@ endif
 
 # handle resources
 nntrainer_resdir = meson.build_root() / 'res'
-run_command('mkdir', '-p', nntrainer_resdir)
+
+if host_machine.system() == 'windows'
+  nntrainer_resdir_win = nntrainer_resdir.replace('/', '\\')
+  run_command('cmd.exe', '/C', 'mkdir', nntrainer_resdir_win)
+else
+  run_command('mkdir', '-p', nntrainer_resdir)
+endif
 
 if get_option('install-app')
 # add a script to install resources from installs to application_install_dir
@@ -354,8 +362,11 @@ if get_option('reduce-tolerance')
   extra_defines += '-DREDUCE_TOLERANCE=1'
 endif
 
-libm_dep = cxx.find_library('m') # cmath library
-libdl_dep = cxx.find_library('dl') # DL library
+if host_machine.system() != 'windows'
+  libm_dep = cxx.find_library('m') # cmath library
+  libdl_dep = cxx.find_library('dl') # DL library
+endif
+
 thread_dep = dependency('threads') # pthread for tensorflow-lite
 
 if get_option('platform') == 'android'
@@ -493,7 +504,7 @@ if get_option('enable-app')
   endif
 endif
 
-if get_option('platform') != 'android'
+if get_option('platform') != 'android' and host_machine.system() != 'windows'
   nnstreamer_dep = dependency('nnstreamer')
   message('building nnstreamer')
   subdir('nnstreamer')

--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -231,12 +231,12 @@ bool ClContext::clCreateKernel(std::string &kernel_string,
       size_t binary_size = fs.tellg();
       fs.seekg(0, std::ios::beg);
 
-      unsigned char chunk[binary_size];
-      fs.read((char *)chunk, binary_size);
+      std::vector<unsigned char> chunk(binary_size);
+      fs.read((char *)chunk.data(), binary_size);
 
       result = program.CreateCLProgramWithBinary(
         context_inst_.GetContext(), context_inst_.GetDeviceId(), binary_size,
-        chunk,
+        chunk.data(),
         opencl::Program::DEFAULT_KERNEL_PATH + "/" + kernel_name +
           "_kernel.bin",
         "");

--- a/nntrainer/layers/cl_layers/reshape_cl.cpp
+++ b/nntrainer/layers/cl_layers/reshape_cl.cpp
@@ -163,6 +163,7 @@ void ReshapeLayerCl::ReshapeProcess(Tensor const &input, Tensor &output) {
   }
 }
 
+#ifdef ENABLE_FP16
 void ReshapeLayerCl::copy_cl_fp16(const __fp16 *input, __fp16 *res,
                                   unsigned int input_batch_size,
                                   unsigned int input_channels,
@@ -241,6 +242,7 @@ void ReshapeLayerCl::copy_cl_fp16(const __fp16 *input, __fp16 *res,
 
   } while (false);
 }
+#endif
 
 void ReshapeLayerCl::copy_cl(const float *input, float *res,
                              unsigned int input_batch_size,

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -20,15 +20,23 @@ nntrainer_headers = [
 ]
 
 # Dependencies
-nntrainer_base_deps=[
-  blas_dep,
-  iniparser_dep,
-  ml_api_common_dep,
-  libm_dep,
-  libdl_dep,
-  thread_dep,
-  openmp_dep
-]
+if host_machine.system() == 'windows'
+  nntrainer_base_deps=[
+    iniparser_dep,
+    thread_dep,
+    openmp_dep
+  ]
+else
+  nntrainer_base_deps=[
+    blas_dep,
+    iniparser_dep,
+    ml_api_common_dep,
+    libm_dep,
+    libdl_dep,
+    thread_dep,
+    openmp_dep
+  ]
+endif
 
 if get_option('platform') == 'tizen'
   nntrainer_base_deps += dependency('dlog')
@@ -101,9 +109,13 @@ else
     install_dir: nntrainer_libdir
   )
 
-  nntrainer_lib = nntrainer_shared
-  if get_option('default_library') == 'static'
+  if host_machine.system() == 'windows'
     nntrainer_lib = nntrainer_static
+  else
+    nntrainer_lib = nntrainer_shared
+    if get_option('default_library') == 'static'
+      nntrainer_lib = nntrainer_static
+    endif
   endif
 
   nntrainer_dep = declare_dependency(link_with: nntrainer_lib,

--- a/windows-native.ini
+++ b/windows-native.ini
@@ -1,0 +1,17 @@
+[project options]
+
+enable-blas=false
+enable-tflite-backbone=false
+enable-memory-swap=false
+enable-nnstreamer-backbone=false
+enable-tflite-interpreter=false
+enable-app=false
+enable-test=false
+install-app=false
+enable-avx=false
+enable-mmap=false
+
+[built-in options]
+werror=false
+c_std='c17'
+cpp_std='c++20'


### PR DESCRIPTION
After this change nntrainer can be build on windows using meson.
This change depends on #2904

Requirements on Windows:
1. Install MSVC compiler
2. Install CMake
3. Install meson (using pip)

How to run:
meson setup --native-file windows-native.ini builddir
meson compile -C builddir

This PR also fix build with opencl enabled on windows

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
5. Run test:   [X]Passed [ ]Failed [ ]Skipped

