### PR TITLE
Memory Leak Fixes in NNTrainer

### DIFF
--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -69,6 +69,7 @@ CharTensor::CharTensor(
     (void *)(new int8_t[dim.getDataLen() + sizeof(float) * scale_size()]()));
   data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
     delete[] mem_data->getAddr<int8_t>();
+    delete mem_data;
   });
 
   offset = 0;

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -88,6 +88,7 @@ public:
       new MemoryData((void *)(new float[dim.getDataLen()]()));
     data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
       delete[] mem_data->getAddr<float>();
+      delete mem_data;
     });
 
     offset = 0;

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -87,6 +87,7 @@ public:
       new MemoryData((void *)(new _FP16[dim.getDataLen()]()));
     data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
       delete[] mem_data->getAddr<_FP16>();
+      delete mem_data;
     });
 
     offset = 0;

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -67,6 +67,7 @@ ShortTensor::ShortTensor(
                          sizeof(float) / sizeof(int16_t) * scale_size()]()));
   data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
     delete[] mem_data->getAddr<int16_t>();
+    delete mem_data;
   });
 
   offset = 0;

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -61,8 +61,10 @@ UIntTensor<T>::UIntTensor(
   initializer = Initializer::NONE;
 
   MemoryData *mem_data = new MemoryData((void *)(new T[dim.getDataLen()]()));
-  data = std::shared_ptr<MemoryData>(
-    mem_data, [](MemoryData *mem_data) { delete[] mem_data->getAddr<T>(); });
+  data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
+    delete[] mem_data->getAddr<T>();
+    delete mem_data;
+  });
 
   offset = 0;
 


### PR DESCRIPTION
This PR addresses memory leak issues in the NNTrainer.

**Changes proposed in this PR:**
- Release the MemoryData pointer in the Tensor constructor using the vector.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped