### PR TITLE
[Coverity] Fix Coverity issue on ini_interpreter (path nullptr excetion)

### DIFF
--- a/nntrainer/compiler/ini_interpreter.cpp
+++ b/nntrainer/compiler/ini_interpreter.cpp
@@ -333,6 +333,9 @@ GraphRepresentation IniGraphInterpreter::deserialize(const std::string &in) {
       const char *backbone_path =
         iniparser_getstring(ini, (sec_name + ":Backbone").c_str(), UNKNOWN_STR);
 
+      NNTR_THROW_IF(backbone_path == nullptr, std::invalid_argument)
+        << FUNC_TAG << "backbone path is null";
+
       const std::string &backbone = pathResolver(backbone_path);
       if (graphSupported(backbone)) {
         /// @todo: this will be changed to a general way to add a graph


### PR DESCRIPTION
For Resolve below issue
- Return value of a function 'iniparser_getstring' is dereferenced at ini_interpreter.cpp:350 without checking for null, but it is usually checked for this function

add NNTR_THROW_IF() to check backbone_path is null when backbone_path is nullptr then it will print error msg

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Donghak PARK <donghak.park@samsung.com>