### PR TITLE
[Bug] fix memory leakage issue in inference mode @open sesame 02/10 19:43

### DIFF
--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -130,6 +130,10 @@ std::shared_ptr<MemoryData> MemoryPool::getMemory(unsigned int idx) {
 void MemoryPool::deallocate() {
   if (mem_pool != nullptr) {
     free(mem_pool);
+    memory_size.clear();
+    memory_validity.clear();
+    memory_exec_order.clear();
+    memory_is_wgrad.clear();
     PROFILE_MEM_DEALLOC(mem_pool);
   }
 


### PR DESCRIPTION
this patch fix a memory leakage issue in inference mode.

The problem occurred because even though deallocation was performed,
vectors inside the memory pool were still remained.

**Self evaluation:**

Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>