### PR TITLE
[Bug] fix multithreading issue in lstm layer

### DIFF
--- a/nntrainer/layers/lstm.cpp
+++ b/nntrainer/layers/lstm.cpp
@@ -314,9 +314,15 @@ void LSTMLayer::calcGradientBatchFirstLSTM(
 
       d_weight_ih.add_i(p_d_weight_ih);
       d_weight_hh.add_i(p_d_weight_hh);
-      d_bias_ih.add_i(p_d_bias_ih);
-      d_bias_hh.add_i(p_d_bias_hh);
-      d_bias_h.add_i(p_d_bias_h);
+
+      if (!disable_bias) {
+        if (integrate_bias) {
+          d_bias_h.add_i(p_d_bias_h);
+        } else {
+          d_bias_ih.add_i(p_d_bias_ih);
+          d_bias_hh.add_i(p_d_bias_hh);
+        }
+      }
     }
 
   } else {


### PR DESCRIPTION
In LSTM, when the multi-thread option is enabled, either only the d_bias_h (hidden) value is calculated or both d_bias_ih (input-hidden) and d_bias_hh (hidden-hidden) values are calculated, depending on whether the integrate_bias option is set. However, there was an error because all three values were being attempted to be calculated at the same time. Therefore, this patch adds a conditional statement to fix this bug.

**Self evaluation:**

Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>