### PR TITLE
[WIP] PathProperty prepartion for openvino backbone and layer

### DIFF
--- a/Applications/AlexNet/jni/meson.build
+++ b/Applications/AlexNet/jni/meson.build
@@ -2,13 +2,13 @@ fs = import('fs')
 app_res_dir = fs.parent(meson.current_source_dir()) / 'res'
 build_app_res_dir = nntr_app_resdir / 'AlexNet'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
   if not fs.exists (build_app_res_dir_win)
-    run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+    run_command(prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win)
   endif
-  run_command('cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
+  run_command(prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
 else
   run_command('cp', '-lr', app_res_dir, build_app_res_dir)
 endif

--- a/Applications/Custom/LayerClient/jni/meson.build
+++ b/Applications/Custom/LayerClient/jni/meson.build
@@ -2,13 +2,13 @@ fs = import('fs')
 app_res_dir = fs.parent(meson.current_source_dir()) / 'res'
 build_app_res_dir = nntr_app_resdir / 'LayerClient'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
   if not fs.exists (build_app_res_dir_win)
-    run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+    run_command(prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win)
   endif
-  run_command('cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
+  run_command(prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
 else
   run_command('cp', '-lr', app_res_dir, build_app_res_dir)
 endif

--- a/Applications/Layers/jni/meson.build
+++ b/Applications/Layers/jni/meson.build
@@ -2,13 +2,13 @@ fs = import('fs')
 app_res_dir = fs.parent(meson.current_source_dir()) / 'res'
 build_app_res_dir = nntr_app_resdir / 'Layers'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
   if not fs.exists (build_app_res_dir_win)
-    run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+    run_command(prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win)
   endif
-  run_command('cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
+  run_command(prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
 else
   run_command('cp', '-lr', app_res_dir, build_app_res_dir)
 endif

--- a/Applications/LogisticRegression/jni/meson.build
+++ b/Applications/LogisticRegression/jni/meson.build
@@ -2,13 +2,13 @@ fs = import('fs')
 app_res_dir = fs.parent(meson.current_source_dir()) / 'res'
 build_app_res_dir = nntr_app_resdir / 'LogisticRegression'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
   if not fs.exists (build_app_res_dir_win)
-    run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+    run_command(prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win)
   endif
-  run_command('cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
+  run_command(prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
 else
   run_command('cp', '-lr', app_res_dir, build_app_res_dir)
 endif

--- a/Applications/MNIST/jni/meson.build
+++ b/Applications/MNIST/jni/meson.build
@@ -2,13 +2,13 @@ fs = import('fs')
 app_res_dir = fs.parent(meson.current_source_dir()) / 'res'
 build_app_res_dir = nntr_app_resdir / 'MNIST'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
   if not fs.exists (build_app_res_dir_win)
-    run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+    run_command(prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win)
   endif
-  run_command('cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
+  run_command(prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
 else
   run_command('cp', '-lr', app_res_dir, build_app_res_dir)
 endif

--- a/Applications/ProductRatings/jni/meson.build
+++ b/Applications/ProductRatings/jni/meson.build
@@ -2,13 +2,13 @@ fs = import('fs')
 app_res_dir = fs.parent(meson.current_source_dir()) / 'res'
 build_app_res_dir = nntr_app_resdir / 'ProductRatings'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
   if not fs.exists (build_app_res_dir_win)
-    run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+    run_command(prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win)
   endif
-  run_command('cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
+  run_command(prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
 else
   run_command('cp', '-lr', app_res_dir, build_app_res_dir)
 endif

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -2,10 +2,10 @@ fs = import('fs')
 
 nntr_app_resdir = nntrainer_resdir / 'app'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   nntr_app_resdir_win = nntr_app_resdir.replace('/', '\\')
   if not fs.exists (nntr_app_resdir_win)
-    run_command('cmd.exe', '/C', 'mkdir', nntr_app_resdir_win)
+    run_command(prog_win_cmd, '/C', 'mkdir', nntr_app_resdir_win)
   endif
 else
   run_command('mkdir', '-p', nntr_app_resdir)

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -18,6 +18,7 @@
 
 #if __cplusplus >= MIN_CPP_VERSION
 
+#include <filesystem>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -164,6 +165,18 @@ public:
                     ModelFormat format = ModelFormat::MODEL_FORMAT_BIN) = 0;
 
   /**
+   * @copydoc Model::save(const std::string &file_path, ml::train::ModelFormat
+   * format);
+   */
+  template <typename PathType_,
+            typename = std::enable_if_t<
+              std::is_same_v<PathType_, std::filesystem::path>, void>>
+  inline void save(const PathType_ &file_path,
+                   ModelFormat format = ModelFormat::MODEL_FORMAT_BIN) {
+    this->save(file_path.string(), format);
+  }
+
+  /**
    * @brief  load model with regard to the format
    * @param file_path file_path to save the model, if full path is not
    * given, it should be saved inside working directory
@@ -172,6 +185,17 @@ public:
   virtual void load(const std::string &file_path,
                     ModelFormat format = ModelFormat::MODEL_FORMAT_BIN) = 0;
 
+  /**
+   * @copydoc Model::load(const std::string &file_path, ml::train::ModelFormat
+   * format);
+   */
+  template <typename PathType_,
+            typename = std::enable_if_t<
+              std::is_same_v<PathType_, std::filesystem::path>, void>>
+  inline void load(const PathType_ &file_path,
+                   ModelFormat format = ModelFormat::MODEL_FORMAT_BIN) {
+    this->load(file_path.string(), format);
+  }
   /**
    * @brief     Run Model training and validation
    * @param[in] values hyper parameters

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -170,10 +170,11 @@ public:
    */
   template <typename PathType_,
             typename = std::enable_if_t<
-              std::is_same_v<PathType_, std::filesystem::path>, void>>
+              std::is_convertible_v<PathType_, std::filesystem::path> and
+              !std::is_convertible_v<PathType_, std::string>, void>>
   inline void save(const PathType_ &file_path,
                    ModelFormat format = ModelFormat::MODEL_FORMAT_BIN) {
-    this->save(file_path.string(), format);
+    this->save(static_cast<std::filesystem::path>(file_path).string(), format);
   }
 
   /**
@@ -191,10 +192,11 @@ public:
    */
   template <typename PathType_,
             typename = std::enable_if_t<
-              std::is_same_v<PathType_, std::filesystem::path>, void>>
+              std::is_convertible_v<PathType_, std::filesystem::path> and
+              !std::is_convertible_v<PathType_, std::string>, void>>
   inline void load(const PathType_ &file_path,
                    ModelFormat format = ModelFormat::MODEL_FORMAT_BIN) {
-    this->load(file_path.string(), format);
+    this->load(static_cast<std::filesystem::path>(file_path).string(), format);
   }
   /**
    * @brief     Run Model training and validation

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,8 @@ nproc_prog = find_program('nproc',
 # Older libc++ has <filesystem> in seperate library
 opt_stdcpp_fs_dep = cxx.find_library('stdc++fs', required: false)
 
+prog_win_cmd = find_program('cmd.exe', required: build_machine.system() == 'windows')
+
 if get_option('platform') == 'tizen'
   # Pass __TIZEN__ to the compiler
   add_project_arguments('-D__TIZEN__=1', language:['c','cpp'])
@@ -192,7 +194,7 @@ if get_option('enable-biqgemm')
   endif
 endif # end of enable-biqgemm
 
-if host_machine.system() != 'windows'
+if cc.get_id() != 'msvc' and cxx.get_id() != 'msvc'
   foreach extra_arg : warning_flags
     if cc.has_argument (extra_arg)
       add_project_arguments([extra_arg], language: 'c')
@@ -243,10 +245,10 @@ endif
 # handle resources
 nntrainer_resdir = meson.build_root() / 'res'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   nntrainer_resdir_win = nntrainer_resdir.replace('/', '\\')
   if not fs.exists (nntrainer_resdir_win)
-    run_command('cmd.exe', '/C', 'mkdir', nntrainer_resdir_win)
+    run_command(prog_win_cmd, '/C', 'mkdir', nntrainer_resdir_win)
   endif
 else
   run_command('mkdir', '-p', nntrainer_resdir)
@@ -423,10 +425,8 @@ if get_option('reduce-tolerance')
   extra_defines += '-DREDUCE_TOLERANCE=1'
 endif
 
-if host_machine.system() != 'windows'
-  libm_dep = cxx.find_library('m') # cmath library
-  libdl_dep = cxx.find_library('dl') # DL library
-endif
+libm_dep = cxx.find_library('m', required: false) # cmath library
+libdl_dep = cxx.find_library('dl', required: false) # DL library
 
 thread_dep = dependency('threads') # pthread for tensorflow-lite
 

--- a/meson.build
+++ b/meson.build
@@ -329,6 +329,9 @@ if get_option('enable-blas')
       blas_options.add_cmake_defines({'BUILD_SHARED_LIBS': host_machine.system() != 'windows'})
       blas_options.add_cmake_defines({'BUILD_WITHOUT_LAPACK': true})
       blas_options.add_cmake_defines({'NOFORTRAN': true})
+      blas_options.add_cmake_defines({'CMAKE_CXX_COMPILER_WORKS' : true})
+      blas_options.add_cmake_defines({'CMAKE_C_COMPILER_WORKS' : true})
+      blas_options.add_cmake_defines({'CMAKE_MSVC_DEBUG_INFORMATION_FORMAT': 'Embedded'})
       blas_subproject = cmake.subproject('openblas', options: blas_options, required: true)
       blas_dep = host_machine.system() == 'windows'? blas_subproject.dependency('openblas_static') : blas_subproject.dependency('openblas_shared')
     endif
@@ -446,6 +449,9 @@ else
     iniparser_options.add_cmake_defines({'BUILD_EXAMPLES': false})
     iniparser_options.add_cmake_defines({'BUILD_TESTING': false})
     iniparser_options.add_cmake_defines({'BUILD_SHARED_LIBS': false})
+    iniparser_options.add_cmake_defines({'CMAKE_CXX_COMPILER_WORKS' : true})
+    iniparser_options.add_cmake_defines({'CMAKE_C_COMPILER_WORKS' : true})
+    iniparser_options.add_cmake_defines({'CMAKE_MSVC_DEBUG_INFORMATION_FORMAT': 'Embedded'})
     iniparser_subproject = cmake.subproject('iniparser', options: iniparser_options, required: true)
     iniparser_dep = iniparser_subproject.dependency('iniparser-static')
   endif
@@ -461,6 +467,9 @@ else
   if host_machine.system() == 'windows'
     ruy_options.append_compile_args('c', windows_compile_args)
     ruy_options.append_compile_args('cpp', windows_compile_args)
+    ruy_options.add_cmake_defines({'CMAKE_CXX_COMPILER_WORKS' : true})
+    ruy_options.add_cmake_defines({'CMAKE_C_COMPILER_WORKS' : true})
+    ruy_options.add_cmake_defines({'CMAKE_MSVC_DEBUG_INFORMATION_FORMAT': 'Embedded'})
   else
     ruy_flags = [
       '-Wno-error=unused-result',

--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,8 @@ cxx = meson.get_compiler('cpp')
 # Obtains number of cores
 nproc_prog = find_program('nproc',
                           required: (get_option('platform') == 'android') and (build_machine.system() != 'windows'))
+# Older libc++ has <filesystem> in seperate library
+opt_stdcpp_fs_dep = cxx.find_library('stdc++fs', required: false)
 
 if get_option('platform') == 'tizen'
   # Pass __TIZEN__ to the compiler

--- a/nntrainer/dataset/raw_file_data_producer.cpp
+++ b/nntrainer/dataset/raw_file_data_producer.cpp
@@ -109,8 +109,8 @@ RawFileDataProducer::size(const std::vector<TensorDim> &input_dims,
   //   << " Given file does not align with the given sample size, sample size: "
   //   << sample_size << " file_size: " << file_size;
 
-  return static_cast<unsigned int>(file_size) /
-         (sample_size * RawFileDataProducer::pixel_size);
+  return static_cast<unsigned int>(
+    file_size / (sample_size * RawFileDataProducer::pixel_size));
 }
 
 void RawFileDataProducer::exportTo(

--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -66,10 +66,9 @@ bool FilePath::isValid(const fs::path &v) const {
 
 void FilePath::set(const fs::path &v) {
   PathProperty::set(v);
-  cached_pos_size = fs::file_size(v);
 }
 
-std::uintmax_t FilePath::file_size() const { return cached_pos_size; }
+std::uintmax_t FilePath::file_size() const { return fs::file_size(*this); }
 
 bool LossScaleForMixed::isValid(const float &value) const {
   return (value != 0);

--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -24,6 +24,8 @@
 #include <utility>
 #include <vector>
 
+namespace fs = std::filesystem;
+
 namespace nntrainer {
 namespace props {
 
@@ -56,18 +58,18 @@ void RandomTranslate::set(const float &value) {
   Property<float>::set(std::abs(value));
 }
 
-bool FilePath::isValid(const std::string &v) const {
-  std::ifstream file(v, std::ios::binary | std::ios::ate);
-  return file.good();
+bool FilePath::isValid(const fs::path &v) const {
+  const bool regular = PathProperty::isRegularFile(v);
+  const bool is_readable = PathProperty::isReadAccessible(v);
+  return regular && is_readable;
 }
 
-void FilePath::set(const std::string &v) {
-  Property<std::string>::set(v);
-  std::ifstream file(v, std::ios::binary | std::ios::ate);
-  cached_pos_size = file.tellg();
+void FilePath::set(const fs::path &v) {
+  PathProperty::set(v);
+  cached_pos_size = fs::file_size(v);
 }
 
-std::ifstream::pos_type FilePath::file_size() { return cached_pos_size; }
+std::uintmax_t FilePath::file_size() const { return cached_pos_size; }
 
 bool LossScaleForMixed::isValid(const float &value) const {
   return (value != 0);

--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -20,7 +20,6 @@
 
 #include <regex>
 #include <sstream>
-#include <sys/stat.h>
 #include <utility>
 #include <vector>
 
@@ -64,22 +63,15 @@ bool FilePath::isValid(const fs::path &v) const {
   return regular && is_readable;
 }
 
-void FilePath::set(const fs::path &v) {
-  PathProperty::set(v);
-}
-
 std::uintmax_t FilePath::file_size() const { return fs::file_size(*this); }
 
 bool LossScaleForMixed::isValid(const float &value) const {
   return (value != 0);
 }
 
-bool DirPath::isValid(const std::string &v) const {
-  struct stat dir;
-  return (stat(v.c_str(), &dir) == 0);
+bool DirPath::isValid(const fs::path &v) const {
+  return PathProperty::isDirectory(v);
 }
-
-void DirPath::set(const std::string &v) { Property<std::string>::set(v); }
 
 ReturnSequences::ReturnSequences(bool value) { set(value); }
 

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -669,15 +669,21 @@ public:
   /**
    * @brief Construct a new File Path object
    */
-  FilePath() : PathProperty() {}
+  FilePath() = default;
 
   /**
    * @brief Construct a new File Path object
    *
    * @param path path to set
    */
-  explicit FilePath(const std::string &path) { set(path); }
-  FilePath(const std::filesystem::path &path) { set(path); }
+  explicit FilePath(const std::string &path) : PathProperty{} { set(path); }
+
+  /**
+   * @brief Construct a new File Path object
+   *
+   * @param path path to set
+   */
+  explicit FilePath(const std::filesystem::path &path) : PathProperty{} { set(path); }
   static constexpr const char *key = "path"; /**< unique key to access */
   using prop_tag = path_prop_tag;            /**< property type */
 
@@ -688,13 +694,6 @@ public:
    * @return bool true if valid
    */
   bool isValid(const std::filesystem::path &v) const override;
-
-  /**
-   * @brief setter
-   *
-   * @param v value to set
-   */
-  void set(const std::filesystem::path &v) override;
 
   /**
    * @brief return file size
@@ -708,21 +707,28 @@ public:
  * @brief Props containing directory path value
  *
  */
-class DirPath : public Property<std::string> {
+class DirPath : public PathProperty {
 public:
   /**
    * @brief Construct a new Dir Path object
    */
-  DirPath() : Property<std::string>() {}
+  DirPath() = default;
 
   /**
    * @brief Construct a new Dir Path object
    *
    * @param path path to set
    */
-  DirPath(const std::string &path) { set(path); }
+  explicit DirPath(const std::string &path) : PathProperty{} { set(path); }
+
+  /**
+   * @brief Construct a new Dir Path object
+   *
+   * @param path path to set
+   */
+  explicit DirPath(const std::filesystem::path &path) : PathProperty{} { set(path); }
   static constexpr const char *key = "dir_path"; /**< unique key to access */
-  using prop_tag = str_prop_tag;                 /**< property type */
+  using prop_tag = path_prop_tag;                /**< property type */
 
   /**
    * @brief check if given value is valid
@@ -730,14 +736,7 @@ public:
    * @param v value to check
    * @return bool true if valid
    */
-  bool isValid(const std::string &v) const override;
-
-  /**
-   * @brief setter
-   *
-   * @param v value to set
-   */
-  void set(const std::string &v) override;
+  bool isValid(const std::filesystem::path &v) const override;
 };
 
 /**

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -702,9 +702,6 @@ public:
    * @return std::uintmax_t size of the file
    */
   std::uintmax_t file_size() const;
-
-private:
-  std::uintmax_t cached_pos_size;
 };
 
 /**

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -664,21 +664,22 @@ public:
  * @brief Props containing file path value
  *
  */
-class FilePath : public Property<std::string> {
+class FilePath : public PathProperty {
 public:
   /**
    * @brief Construct a new File Path object
    */
-  FilePath() : Property<std::string>() {}
+  FilePath() : PathProperty() {}
 
   /**
    * @brief Construct a new File Path object
    *
    * @param path path to set
    */
-  FilePath(const std::string &path) { set(path); }
+  explicit FilePath(const std::string &path) { set(path); }
+  FilePath(const std::filesystem::path &path) { set(path); }
   static constexpr const char *key = "path"; /**< unique key to access */
-  using prop_tag = str_prop_tag;             /**< property type */
+  using prop_tag = path_prop_tag;            /**< property type */
 
   /**
    * @brief check if given value is valid
@@ -686,24 +687,24 @@ public:
    * @param v value to check
    * @return bool true if valid
    */
-  bool isValid(const std::string &v) const override;
+  bool isValid(const std::filesystem::path &v) const override;
 
   /**
    * @brief setter
    *
    * @param v value to set
    */
-  void set(const std::string &v) override;
+  void set(const std::filesystem::path &v) override;
 
   /**
    * @brief return file size
    *
-   * @return std::ifstream::pos_type size of the file
+   * @return std::uintmax_t size of the file
    */
-  std::ifstream::pos_type file_size();
+  std::uintmax_t file_size() const;
 
 private:
-  std::ifstream::pos_type cached_pos_size;
+  std::uintmax_t cached_pos_size;
 };
 
 /**

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -31,7 +31,8 @@ nntrainer_base_deps=[
 if host_machine.system() != 'windows'
   nntrainer_base_deps += [
     libm_dep,
-    libdl_dep
+    libdl_dep,
+    opt_stdcpp_fs_dep
   ]
 endif
 

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -22,19 +22,14 @@ nntrainer_headers = [
 nntrainer_base_deps=[
   blas_dep,
   iniparser_dep,
-  ruy_dep,
+  libdl_dep,
+  libm_dep,
   ml_api_common_dep,
+  openmp_dep,
+  opt_stdcpp_fs_dep,
+  ruy_dep,
   thread_dep,
-  openmp_dep
 ]
-
-if host_machine.system() != 'windows'
-  nntrainer_base_deps += [
-    libm_dep,
-    libdl_dep,
-    opt_stdcpp_fs_dep
-  ]
-endif
 
 if get_option('platform') == 'tizen'
   nntrainer_base_deps += dependency('dlog')

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -56,21 +56,19 @@ public:
  * @brief model save path property
  *
  */
-class SavePath : public Property<std::string> {
+class SavePath : public PathProperty {
 public:
   static constexpr const char *key = "save_path"; /**< unique key to access */
-  using prop_tag = str_prop_tag;                  /**< property type */
 };
 
 /**
  * @brief model save path property
  *
  */
-class SaveBestPath : public Property<std::string> {
+class SaveBestPath : public PathProperty {
 public:
   static constexpr const char *key =
-    "save_best_path";            /**< unique key to access */
-  using prop_tag = str_prop_tag; /**< property type */
+    "save_best_path"; /**< unique key to access */
 };
 
 /**

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -624,14 +624,13 @@ void NeuralNetwork::save(const std::string &file_path,
     saveModelIni(file_path);
     break;
   case ml::train::ModelFormat::MODEL_FORMAT_INI_WITH_BIN: {
-    auto old_save_path = std::get<props::SavePath>(model_flex_props);
-    auto bin_file_name =
-      file_path.substr(0, file_path.find_last_of('.')) + ".bin";
-
-    std::get<props::SavePath>(model_flex_props).set(bin_file_name);
+    auto old_save_path_prop = std::get<props::SavePath>(model_flex_props);
+    auto bin_file_path = old_save_path_prop.get();
+    bin_file_path.replace_extension("bin");
+    std::get<props::SavePath>(model_flex_props).set(bin_file_path);
     save(file_path, ml::train::ModelFormat::MODEL_FORMAT_INI);
-    save(bin_file_name, ml::train::ModelFormat::MODEL_FORMAT_BIN);
-    std::get<props::SavePath>(model_flex_props) = old_save_path;
+    save(bin_file_path, ml::train::ModelFormat::MODEL_FORMAT_BIN);
+    std::get<props::SavePath>(model_flex_props) = old_save_path_prop;
     break;
   }
   case ml::train::ModelFormat::MODEL_FORMAT_ONNX: {

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -692,9 +692,10 @@ void NeuralNetwork::load(const std::string &file_path,
     throw_status(ret);
     auto &save_path = std::get<props::SavePath>(model_flex_props);
     if (!save_path.empty()) {
-      checkedOpenStream<std::ifstream>(save_path,
+      std::filesystem::path p = save_path;
+      checkedOpenStream<std::ifstream>(p.string(),
                                        std::ios::in | std::ios::binary);
-      load_path = save_path;
+      load_path = p.string();
     }
     break;
   }

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -275,6 +275,8 @@ public:
             ml::train::ModelFormat format =
               ml::train::ModelFormat::MODEL_FORMAT_BIN) override;
 
+  using ml::train::Model::save;
+
   /**
    * @copydoc Model::load(const std::string &file_path, ml::train::ModelFormat
    * format);
@@ -283,6 +285,7 @@ public:
             ml::train::ModelFormat format =
               ml::train::ModelFormat::MODEL_FORMAT_BIN) override;
 
+  using ml::train::Model::load;
   /**
    * @brief     get Epochs
    * @retval    epochs

--- a/nntrainer/utils/base_properties.cpp
+++ b/nntrainer/utils/base_properties.cpp
@@ -13,6 +13,7 @@
 
 #include <cerrno>
 #include <regex>
+#include <fstream>
 #include <sstream>
 #include <string>
 #include <system_error>
@@ -48,7 +49,7 @@ bool isFileReadAccessisble(fs::path p, std::error_code &ec) {
 #else
   ec = std::error_code{};
   // Unless it is POSIX, best bet is to try it
-  std::ifstream file(p, std::ios::binary | std::ios::ate);
+  std::ifstream file(p.string(), std::ios::binary | std::ios::ate);
   return file.good();
 #endif
 }
@@ -107,7 +108,7 @@ std::string str_converter<str_prop_tag, std::string>::from_string(
 template <>
 std::string
 str_converter<path_prop_tag, fs::path>::to_string(const fs::path &value) {
-  return value;
+  return value.string();
 }
 
 template <>

--- a/nntrainer/utils/base_properties.h
+++ b/nntrainer/utils/base_properties.h
@@ -13,6 +13,7 @@
 #define __BASE_PROPERTIES_H__
 
 #include <array>
+#include <filesystem>
 #include <memory>
 #include <regex>
 #include <sstream>
@@ -115,6 +116,12 @@ struct double_prop_tag {};
  *
  */
 struct str_prop_tag {};
+
+/**
+ * @brief property is treated as a path
+ *
+ */
+struct path_prop_tag {};
 
 /**
  * @brief property is treated as boolean
@@ -264,6 +271,29 @@ public:
 
 private:
   std::unique_ptr<T> value; /**< underlying data */
+};
+
+/**
+ * @brief The filesystem path property
+ */
+struct PathProperty : Property<std::filesystem::path> {
+  using base = Property<std::filesystem::path>;
+
+  using base::base;
+
+  using prop_tag = path_prop_tag;
+
+  explicit PathProperty(const std::string &str) : base(str) {}
+
+  virtual bool isValid(const std::filesystem::path &value) const override {
+    return true;
+  };
+
+  virtual ~PathProperty() override;
+
+protected:
+  static bool isRegularFile(const std::filesystem::path &) noexcept;
+  static bool isReadAccessible(const std::filesystem::path &) noexcept;
 };
 
 /**
@@ -460,6 +490,21 @@ str_converter<str_prop_tag, std::string>::to_string(const std::string &value);
 template <>
 std::string
 str_converter<str_prop_tag, std::string>::from_string(const std::string &value);
+
+/**
+ * @copydoc template <typename Tag, typename DataType> struct str_converter
+ */
+template <>
+std::string str_converter<path_prop_tag, std::filesystem::path>::to_string(
+  const std::filesystem::path &value);
+
+/**
+ * @copydoc template <typename Tag, typename DataType> struct str_converter
+ */
+template <>
+std::filesystem::path
+str_converter<path_prop_tag, std::filesystem::path>::from_string(
+  const std::string &value);
 
 /**
  * @copydoc template <typename Tag, typename DataType> struct str_converter

--- a/nntrainer/utils/base_properties.h
+++ b/nntrainer/utils/base_properties.h
@@ -288,6 +288,11 @@ struct PathProperty : Property<std::filesystem::path> {
 
   explicit PathProperty(const std::string &str) : base(str) {}
 
+  /**
+   * @brief conversion operator to string
+   */
+  operator typename std::filesystem::path::string_type() const { return get(); }
+
   virtual bool isValid(const std::filesystem::path &value) const override {
     return true;
   };

--- a/nntrainer/utils/base_properties.h
+++ b/nntrainer/utils/base_properties.h
@@ -301,6 +301,7 @@ struct PathProperty : Property<std::filesystem::path> {
 
 protected:
   static bool isRegularFile(const std::filesystem::path &) noexcept;
+  static bool isDirectory(const std::filesystem::path &) noexcept;
   static bool isReadAccessible(const std::filesystem::path &) noexcept;
 };
 

--- a/nntrainer/utils/base_properties.h
+++ b/nntrainer/utils/base_properties.h
@@ -286,7 +286,16 @@ struct PathProperty : Property<std::filesystem::path> {
 
   using prop_tag = path_prop_tag;
 
-  explicit PathProperty(const std::string &str) : base(str) {}
+  /**
+   * @brief Construct a new PathProperty object
+   *
+   * @param str default value
+   */
+  explicit PathProperty(const std::string &str) : base() { set(str); }
+
+  template <typename PathType_,
+            typename = std::enable_if_t<std::is_same_v<PathType_, std::filesystem::path>>>
+  explicit PathProperty(const PathType_& v): base() { set(v); }
 
   /**
    * @brief conversion operator to string

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -28,6 +28,7 @@
 #include <cstring>
 #include <regex>
 #include <sstream>
+#include <system_error>
 
 #include <nntrainer_error.h>
 #include <random>

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,17 +1,17 @@
 fs = import('fs')
 nntrainer_test_resdir = nntrainer_resdir / 'test'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   nntrainer_test_resdir_win = nntrainer_test_resdir.replace('/', '\\')
   nntrainer_test_resdir_models_win = (nntrainer_test_resdir / 'test_models/').replace('/', '\\')
   test_models_dir_win = (meson.current_source_dir() / 'test_models/').replace('/', '\\')
   if not fs.exists (nntrainer_test_resdir_win)
-    run_command('cmd.exe', '/C', 'mkdir', nntrainer_test_resdir_win)
+    run_command(prog_win_cmd, '/C', 'mkdir', nntrainer_test_resdir_win)
   endif
   if not fs.exists (nntrainer_test_resdir_models_win)
-    run_command('cmd.exe', '/C', 'mkdir', nntrainer_test_resdir_models_win)
+    run_command(prog_win_cmd, '/C', 'mkdir', nntrainer_test_resdir_models_win)
   endif
-  run_command('cmd.exe', '/C', 'xcopy',test_models_dir_win, nntrainer_test_resdir_models_win, '/i', '/s', '/y')
+  run_command(prog_win_cmd, '/C', 'xcopy',test_models_dir_win, nntrainer_test_resdir_models_win, '/i', '/s', '/y')
 else
   run_command('mkdir', '-p', nntrainer_test_resdir)
 endif

--- a/test/unittest/memory/meson.build
+++ b/test/unittest/memory/meson.build
@@ -11,7 +11,7 @@ test_target = [
   'unittest_cache_pool.cpp'
 ]
 
-if host_machine.system() == 'windows'
+if cxx.get_id() == 'msvc'
   cpp_args_str = ''
 else
   cpp_args_str = '-Wno-maybe-uninitialized'

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -31,13 +31,13 @@ foreach target: unzip_target
   _src_path = src_path / target[0]
   _dest_path = dest_path / target[1]
 
-  if host_machine.system() == 'windows'
+  if build_machine.system() == 'windows'
     _src_path_win = _src_path.replace('/', '\\')
     _dest_path_win = _dest_path.replace('/', '\\')
     if not fs.exists (_dest_path_win)
-      run_command('cmd.exe', '/C', 'mkdir', _dest_path_win)
+      run_command(prog_win_cmd, '/C', 'mkdir', _dest_path_win)
     endif
-    run_command('cmd.exe', '/C', 'tar', 'xzf', _src_path_win, '-C', _dest_path_win)
+    run_command(prog_win_cmd, '/C', 'tar', 'xzf', _src_path_win, '-C', _dest_path_win)
   else
     run_command('mkdir', '-p', _dest_path)
     run_command(['tar', 'xzf', _src_path, '-C', _dest_path])
@@ -46,10 +46,10 @@ endforeach
 
 src_path_label = src_path / 'label.dat'
 dest_path_label = dest_path / 'label.dat'
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   src_path_label_win = src_path_label.replace('/', '\\')
   dest_path_label_win = dest_path_label.replace('/', '\\')
-  run_command('cmd.exe', '/C', 'copy', src_path_label_win, dest_path_label_win)
+  run_command(prog_win_cmd, '/C', 'copy', src_path_label_win, dest_path_label_win)
 else
   run_command(['cp', '-l', src_path_label, dest_path_label])
 endif

--- a/x64-msvc-wine-toolchain.ini
+++ b/x64-msvc-wine-toolchain.ini
@@ -1,0 +1,27 @@
+[binaries]
+c = [x64_msvc_wine_path+'/'+'cl']
+cpp = [x64_msvc_wine_path+'/'+'cl']
+ar = [x64_msvc_wine_path+'/'+'lib']
+c_ld = [x64_msvc_wine_path+'/'+'link']
+cpp_ld = [x64_msvc_wine_path+'/'+'link']
+windres = [x64_msvc_wine_path+'/'+'rc']
+exe_wrapper = ['wine']
+cmd.exe = ['wine', 'cmd.exe']
+
+[project options]
+enable-blas = false
+
+[properties]
+needs_exe_wrapper = true
+cmake_skip_compiler_test = 'always'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[cmake]
+CMAKE_MSVC_DEBUG_INFORMATION_FORMAT = 'Embedded'
+CMAKE_C_COMPILER_WORKS = '1'
+CMAKE_CXX_COMPILER_WORKS = '1'


### PR DESCRIPTION
# DR Description
This PR is preparation for OpenVINO backend.
- adds `PathProperty` that represents filesystem path
- adds `ModelPathProperty` that facilitates checking if path points to file with given set of the file extensions.

`The ModelPathProperty` generalizes `nntrainer::PropsTflModelPath` and will be used by OpenVINO model path property.
Since OpenVINO has multiple frontends there is need to filter paths with multiple possible extensions.
In addition this allows to switch `Property<std::string>` to `PathProperty` and use c++17 `std::filesystem` library facilities for properties that are paths.


OpenVINO frontends are:
- TensorflowLite
- PyTorch
- PaddlePaddle
- ONNX
- JAX


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s). `TODO`

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```

