### PR TITLE
[CI] update Github-hosted runner & remove Ubuntu 20.04 @open sesame 02/12 13:01

### DIFF
--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-22.04 ]
         meson_options: [ "-Denable-fp16=false", "-Denable-fp16=true" ]
         meson_swap_options: ["-Denable-memory-swap=true", "-Denable-memory-swap=false"]
 

--- a/.github/workflows/pdebuild.yml
+++ b/.github/workflows/pdebuild.yml
@@ -37,8 +37,6 @@ jobs:
         include:
           - distroname: jammy
             os: ubuntu-22.04
-        #  - distroname: focal
-        #    os: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ubuntu_benchmarks.yml
+++ b/.github/workflows/ubuntu_benchmarks.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-22.04 ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-22.04 ]
         meson_options: [ "-Denable-fp16=false", "-Denable-fp16=true" ]
 
     steps:


### PR DESCRIPTION
1. Remove Ubuntu 20.04 : Github will soon end support

- For now 24.04 stability is low, so it has been excluded. --> will add later

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped
