### PR TITLE
[Tensor] Zero point support for unsigned int type 

### DIFF
--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -253,7 +253,8 @@ public:
    * @param[in] t_type Tensor Type
    */
   Tensor(std::vector<std::vector<std::vector<std::vector<uint8_t>>>> const &d,
-         std::vector<float> const &scales, unsigned int zero_point,
+         std::vector<float> const &scales,
+         std::vector<unsigned int> const &zero_points,
          ml::train::TensorDim::TensorType t_type, QScheme qscheme_);
 
   /**
@@ -263,9 +264,10 @@ public:
    * @param[in] t_type Tensor Type
    */
   Tensor(std::vector<std::vector<std::vector<uint8_t>>> const &d,
-         std::vector<float> const &scales, unsigned int zero_point,
+         std::vector<float> const &scales,
+         std::vector<unsigned int> const &zero_points,
          ml::train::TensorDim::TensorType t_type, QScheme qscheme_) :
-    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, zero_point,
+    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, zero_points,
            t_type, qscheme_){};
 
   /**
@@ -275,9 +277,10 @@ public:
    * @param[in] t_type Tensor Type
    */
   Tensor(std::vector<std::vector<uint8_t>> const &d,
-         std::vector<float> const &scales, unsigned int zero_point,
+         std::vector<float> const &scales,
+         std::vector<unsigned int> const &zero_points,
          ml::train::TensorDim::TensorType t_type, QScheme qscheme_) :
-    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, zero_point,
+    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, zero_points,
            t_type, qscheme_){};
 
   /**
@@ -286,7 +289,8 @@ public:
    * @param[in] t_type Tensor Type
    */
   Tensor(std::vector<std::vector<std::vector<std::vector<uint16_t>>>> const &d,
-         std::vector<float> const &scales, unsigned int zero_point,
+         std::vector<float> const &scales,
+         std::vector<unsigned int> const &zero_points,
          ml::train::TensorDim::TensorType t_type, QScheme qscheme_);
 
   /**
@@ -296,9 +300,10 @@ public:
    * @param[in] t_type Tensor Type
    */
   Tensor(std::vector<std::vector<std::vector<uint16_t>>> const &d,
-         std::vector<float> const &scales, unsigned int zero_point,
+         std::vector<float> const &scales,
+         std::vector<unsigned int> const &zero_points,
          ml::train::TensorDim::TensorType t_type, QScheme qscheme_) :
-    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, zero_point,
+    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, zero_points,
            t_type, qscheme_){};
 
   /**
@@ -308,9 +313,10 @@ public:
    * @param[in] t_type Tensor Type
    */
   Tensor(std::vector<std::vector<uint16_t>> const &d,
-         std::vector<float> const &scales, unsigned int zero_point,
+         std::vector<float> const &scales,
+         std::vector<unsigned int> const &zero_points,
          ml::train::TensorDim::TensorType t_type, QScheme qscheme_) :
-    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, zero_point,
+    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, zero_points,
            t_type, qscheme_){};
 
   /**
@@ -319,7 +325,8 @@ public:
    * @param[in] t_type Tensor Type
    */
   Tensor(std::vector<std::vector<std::vector<std::vector<uint32_t>>>> const &d,
-         std::vector<float> const &scales, unsigned int zero_point,
+         std::vector<float> const &scales,
+         std::vector<unsigned int> const &zero_points,
          ml::train::TensorDim::TensorType t_type, QScheme qscheme_);
 
   /**
@@ -329,9 +336,10 @@ public:
    * @param[in] t_type Tensor Type
    */
   Tensor(std::vector<std::vector<std::vector<uint32_t>>> const &d,
-         std::vector<float> const &scales, unsigned int zero_point,
+         std::vector<float> const &scales,
+         std::vector<unsigned int> const &zero_points,
          ml::train::TensorDim::TensorType t_type, QScheme qscheme_) :
-    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, zero_point,
+    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, zero_points,
            t_type, qscheme_){};
 
   /**
@@ -341,9 +349,10 @@ public:
    * @param[in] t_type Tensor Type
    */
   Tensor(std::vector<std::vector<uint32_t>> const &d,
-         std::vector<float> const &scales, unsigned int zero_point,
+         std::vector<float> const &scales,
+         std::vector<unsigned int> const &zero_points,
          ml::train::TensorDim::TensorType t_type, QScheme qscheme_) :
-    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, zero_point,
+    Tensor(std::vector<std::decay<decltype(d)>::type>{d}, scales, zero_points,
            t_type, qscheme_){};
 
   /**
@@ -549,6 +558,20 @@ public:
    */
   template <typename T = float> T *getScale(size_t idx) const {
     return (T *)itensor->getScale(idx);
+  }
+
+  /**
+   * @brief     return zero point pointer of Tensor
+   * @retval    unsigned int pointer
+   */
+  unsigned int *getZeroPoint() const { return itensor->getZeroPoint(); }
+
+  /**
+   * @brief     return zero point pointer of Tensor
+   * @retval    unsigned int pointer
+   */
+  unsigned int *getZeroPoint(size_t idx) const {
+    return itensor->getZeroPoint(idx);
   }
 
   /**

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -210,6 +210,24 @@ public:
   }
 
   /**
+   * @copydoc Tensor::getZeroPoint()
+   */
+  virtual unsigned int *getZeroPoint() const {
+    throw std::invalid_argument(
+      "Tensor::getZeroPoint() is not supported in tensor data type " +
+      getStringDataType());
+  }
+
+  /**
+   * @copydoc Tensor::getZeroPoint(size_t idx)
+   */
+  virtual unsigned int *getZeroPoint(size_t idx) const {
+    throw std::invalid_argument(
+      "Tensor::getZeroPoint() is not supported in tensor data type " +
+      getStringDataType());
+  }
+
+  /**
    * @brief     i data index
    * @retval    address of ith data
    */

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -186,17 +186,25 @@ void TensorPool::finalize(const MemoryPlanner &planner,
      * 3. requestMemory for all the tensors and set their tokens
      * @note +1 is to make the validity_end exlusive in the interval range
      */
+    size_t tensor_bytes =
+      spec.tensor->bytes() + spec.tensor->scale_size() * sizeof(float);
+
+    /// @note this is a temporal way to reserve memory space for zero point
+    if (spec.tensor->getDataType() == Tdatatype::UINT8 ||
+        spec.tensor->getDataType() == Tdatatype::UINT16 ||
+        spec.tensor->getDataType() == Tdatatype::UINT32) {
+      tensor_bytes += spec.tensor->scale_size() * sizeof(unsigned int);
+    }
+
     details->token = mem_pool->requestMemory(
-      spec.tensor->bytes() + spec.tensor->scale_size() * sizeof(float),
-      validity_start, validity_end + 1, details->exec_order, details->lifespan,
-      spec.is_weight_grad);
+      tensor_bytes, validity_start, validity_end + 1, details->exec_order,
+      details->lifespan, spec.is_weight_grad);
 #ifdef DEBUG
     if (details->token == 0)
       throw std::runtime_error("Received invalid token from memory pool");
 #endif
 
-    bytes_requested +=
-      spec.tensor->bytes() + spec.tensor->scale_size() * sizeof(float);
+    bytes_requested += tensor_bytes;
   }
 
   /** 4. finalizeLayout for the memory pool. */

--- a/nntrainer/tensor/uint_tensor.h
+++ b/nntrainer/tensor/uint_tensor.h
@@ -41,6 +41,7 @@ public:
    * @param alloc_now Allocate memory to this tensor or not
    * @param init Initializer for the tensor
    * @param name Name of the tensor
+   * @param qscheme_ quantization scheme
    */
   UIntTensor(const TensorDim &d, bool alloc_now,
              Initializer init = Initializer::NONE, std::string name = "",
@@ -51,6 +52,7 @@ public:
    *
    * @param d Tensor dim for this tensor
    * @param buf buffer
+   * @param qscheme_ quantization scheme
    */
   UIntTensor(const TensorDim &d, const void *buf = nullptr,
              QScheme qscheme_ = QScheme::PER_TENSOR_AFFINE);
@@ -59,11 +61,15 @@ public:
    * @brief Construct a new UIntTensor object
    *
    * @param d data for the Tensor
+   * @param scales scale factors for the Tensor
+   * @param zero_points zero_points for the Tensor
    * @param fm format for the Tensor
+   * @param qscheme_ quantization scheme
    */
   UIntTensor(std::vector<std::vector<std::vector<std::vector<T>>>> const &d,
-             std::vector<float> const &scales, unsigned int zero_point,
-             Tformat fm, QScheme qscheme_);
+             std::vector<float> const &scales,
+             std::vector<unsigned int> const &zero_points, Tformat fm,
+             QScheme qscheme_);
 
   /**
    * @brief Construct a new UIntTensor object
@@ -79,14 +85,12 @@ public:
   /**
    * @brief     Comparison operator overload
    * @param[in] rhs Tensor to be compared with
-   * @note      Only compares Tensor data
    */
   bool operator==(const UIntTensor &rhs) const;
 
   /**
    * @brief     Comparison operator overload
    * @param[in] rhs Tensor to be compared with
-   * @note      Only compares Tensor data
    */
   bool operator!=(const UIntTensor &rhs) const { return !(*this == rhs); }
 
@@ -119,6 +123,16 @@ public:
    * @copydoc Tensor::getScale(size_t idx)
    */
   void *getScale(size_t idx) const override;
+
+  /**
+   * @copydoc Tensor::getZeroPoint()
+   */
+  unsigned int *getZeroPoint() const override;
+
+  /**
+   * @copydoc Tensor::getZeroPoint(size_t idx)
+   */
+  unsigned int *getZeroPoint(size_t idx) const override;
 
   /**
    * @brief     i data index


### PR DESCRIPTION
This pull request updates the unsigned int type Tensor class to include zero points in its memory management.
It's important to note that the size of the scale factors matches the size of the zero points.
At present, the zero point uses a scale factor size, which will be modified soon.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped
