### PR TITLE
[ Doc ] add a note about the gcc/g++ version (enable_fp16)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,6 +9,7 @@ title: Getting Started
 The following dependencies are needed to compile/build/run.
 
 * gcc/g++ >= 7 ( std=c++17 is used )
+   - (note)  >= 13 is recommended to enable fp16 support
 * meson >= 0.55.0
 * libopenblas-dev and base
 * tensorflow-lite >= 2.3.0

--- a/docs/how-to-run-examples.md
+++ b/docs/how-to-run-examples.md
@@ -25,6 +25,7 @@ Refer <https://github.com/nnstreamer/nntrainer/blob/master/docs/getting-started.
 Install related packages before building nntrainer and examples.
 
 1. gcc/g++ >= 7 ( std=c++17 is used )
+    - (note) >= 13 is recommended to enable fp16 support
 2. meson >= 0.55.0
 3. libopenblas-dev and base
 4. tensorflow-lite >=1.14.0


### PR DESCRIPTION
- In order to build nntrainer with -Denable-fp16=true option on Ubuntu, it is required to use gcc/g++ >= 13.
- This commit adds the comment to the related `.md` files.

Self-evaluation:

Build test: [ ]Passed [ ]Failed [X]Skipped
Run test: [ ]Passed [ ]Failed [X]Skipped