### PR TITLE
[Coverity] Fix Coverity issue

### DIFF
--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -284,6 +284,7 @@ void ShortTensor::copyData(const Tensor &from) {
   switch (from.getDataType()) {
   case ml::train::TensorDim::DataType::QINT16:
     copy(from.getData());
+    break;
   default:
     throw std::invalid_argument("Error: Unsupported data type");
     break;


### PR DESCRIPTION
1. Resolve FALL_THROUGH : Missing break at the end of case ```ml::train:TensorDim::DataType::QINT16``` at line 285
--> Add break to exit the case
2. Resolve LOCAL_VAR : Uninitialized data is read from local variable max_element_idx at int4_tensor.cpp:351
--> Add initialize

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

