### PR TITLE
[Quantizer] Unsigned Integer Tensor Support

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -69,6 +69,10 @@ void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y) {
   nntrainer::neon::copy_s16_fp32(N, X, Y);
 }
 
+void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y) {
+  nntrainer::neon::copy_u16_fp32(N, X, Y);
+}
+
 void copy_s16(const unsigned int N, const int16_t *X, int16_t *Y) {
   nntrainer::neon::copy_s16(N, X, Y);
 }

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -421,6 +421,14 @@ void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y);
 /**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
+ * @param[in] X uint16_t * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
+void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
  * @param[in] X int16_t * for Vector X
  * @param[in] Y int16_t * for Vector Y
  */

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl.cpp
@@ -693,6 +693,14 @@ void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y) {
   }
 }
 
+void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y) {
+  /// @todo implement int16_t to fp32
+  unsigned int idx = 0;
+  for (; (N - idx) >= 1; ++idx) {
+    Y[idx] = X[idx];
+  }
+}
+
 void copy_s16(const unsigned int N, const int16_t *X, int16_t *Y) {
   /// @todo implement int16_t to int16_t
   unsigned int idx = 0;

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl.h
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl.h
@@ -406,6 +406,14 @@ void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y);
 /**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
+ * @param[in] X uint16_t * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
+void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
  * @param[in] X int16_t * for Vector X
  * @param[in] Y int16_t * for Vector Y
  */

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -414,6 +414,14 @@ extern void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y);
 /**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
+ * @param[in] X uint16_t * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
+extern void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
  * @param[in] X int16_t * for Vector X
  * @param[in] Y int16_t * for Vector Y
  */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -141,6 +141,10 @@ void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y) {
   __fallback_copy_s16_fp32(N, X, Y);
 }
 
+void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y) {
+  __fallback_copy_u16_fp32(N, X, Y);
+}
+
 void copy_s16(const unsigned int N, const int16_t *X, int16_t *Y) {
   __fallback_copy_s16(N, X, Y);
 }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -400,6 +400,14 @@ void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y);
 /**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
+ * @param[in] X uint16_t * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
+void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
  * @param[in] X int16_t * for Vector X
  * @param[in] Y int16_t * for Vector Y
  */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -60,6 +60,13 @@ void __fallback_copy_s16_fp32(const unsigned int N, const int16_t *X,
   }
 }
 
+void __fallback_copy_u16_fp32(const unsigned int N, const uint16_t *X,
+                              float *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    Y[i] = X[i];
+  }
+}
+
 void __fallback_copy_s16(const unsigned int N, const int16_t *X, int16_t *Y) {
   for (unsigned int i = 0; i < N; ++i) {
     Y[i] = X[i];

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -398,6 +398,15 @@ void __fallback_copy_u16(const unsigned int N, const uint16_t *X, uint16_t *Y);
  * @param[in] Y float * for Vector Y
  */
 void __fallback_copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X uint16_t * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
+void __fallback_copy_u16_fp32(const unsigned int N, const uint16_t *X,
+                              float *Y);
 /**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -42,6 +42,10 @@ void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y) {
   __fallback_copy_s16_fp32(N, X, Y);
 }
 
+void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y) {
+  __fallback_copy_u16_fp32(N, X, Y);
+}
+
 void scopy_int8_to_float32(const unsigned int N, const uint8_t *X,
                            const unsigned int incX, float *Y,
                            const unsigned int incY) {

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -400,6 +400,14 @@ void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y);
 /**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
+ * @param[in] X uint16_t * for Vector X
+ * @param[in] Y float * for Vector Y
+ */
+void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
  * @param[in] X int16_t * for Vector X
  * @param[in] Y int16_t * for Vector Y
  */

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -756,8 +756,16 @@ void FloatTensor::copyData(const Tensor &from) {
     scopy_int8_to_float32(from.size(), from.getData<int8_t>(), 1,
                           (float *)getData(), 1);
     break;
+  case ml::train::TensorDim::DataType::UINT16:
+    copy_u16_fp32(from.size(), from.getData<uint16_t>(), (float *)getData());
+    break;
+  case ml::train::TensorDim::DataType::UINT8:
+    scopy_int8_to_float32(from.size(), from.getData<uint8_t>(), 1,
+                          (float *)getData(), 1);
+    break;
   default:
-    throw std::invalid_argument("Error: Unsupported data type");
+    throw std::invalid_argument(
+      "[FloatTensor::copyData] Error: Unsupported data type");
     break;
   }
 }

--- a/nntrainer/tensor/quantizer.h
+++ b/nntrainer/tensor/quantizer.h
@@ -135,10 +135,11 @@ public:
    * @param[in] input Floating point tensor to quantize
    * @param[out] output Quantized tensor
    * @param[in] scales float scale factors
+   * @param[in] zero_points unsigned int zero points
    * @return Tensor quantized tensor
    */
-  virtual Tensor &quantize(const Tensor &input, Tensor &output,
-                           float *scales) = 0;
+  virtual Tensor &quantize(const Tensor &input, Tensor &output, float *scales,
+                           unsigned int *zero_points = nullptr) = 0;
 
   /**
    * @brief Dequantize a quantized tensor into a tensor.
@@ -204,9 +205,10 @@ public:
 
   /**
    * @copydoc Quantizer::quantize(const Tensor &input, Tensor &output, float
-   * *scales)
+   * *scales, unsigned int *zero_points)
    */
-  Tensor &quantize(const Tensor &input, Tensor &output, float *scales) override;
+  Tensor &quantize(const Tensor &input, Tensor &output, float *scales,
+                   unsigned int *zero_points = nullptr) override;
 
   /**
    * @copydoc Quantizer::dequantize(const Tensor &input)
@@ -221,6 +223,7 @@ public:
 
 private:
   float scale;
+  unsigned int zero_point = 0;
 
   /**
    * @copydoc Quantizer::calculateQParams(const Tensor &input,
@@ -264,9 +267,10 @@ public:
 
   /**
    * @copydoc Quantizer::quantize(const Tensor &input, Tensor &output, float
-   * *scales)
+   * *scales, unsigned int *zero_points)
    */
-  Tensor &quantize(const Tensor &input, Tensor &output, float *scales) override;
+  Tensor &quantize(const Tensor &input, Tensor &output, float *scales,
+                   unsigned int *zero_points = nullptr) override;
 
   /**
    * @copydoc Quantizer::dequantize(const Tensor &input)
@@ -319,9 +323,10 @@ public:
 
   /**
    * @copydoc Quantizer::quantize(const Tensor &input, Tensor &output, float
-   * *scales)
+   * *scales, unsigned int *zero_points)
    */
-  Tensor &quantize(const Tensor &input, Tensor &output, float *scales) override;
+  Tensor &quantize(const Tensor &input, Tensor &output, float *scales,
+                   unsigned int *zero_points = nullptr) override;
 
   /**
    * @copydoc Quantizer::dequantize(const Tensor &input)


### PR DESCRIPTION
This pull request enhances the quantizer class by allowing it to perform quantization on tensors with an unsigned integer data type. It includes consideration of the zero-point during the quantization process.

**Changes proposed in this PR:**
- The quantizer can now quantize and dequantize unsigned integer data types.
- Test cases have been added to verify quantization on unsigned integers.
- Functions for copying unsigned integer data to floating-point format have also been included.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped