### PR TITLE
[FSU] Apply Static Memory allocation at FSU(Swap)

### DIFF
--- a/Applications/SimpleFC/jni/main.cpp
+++ b/Applications/SimpleFC/jni/main.cpp
@@ -111,13 +111,7 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
     model->setProperty({withKey("memory_swap_lookahead", look_ahaed)});
   }
 
-  auto optimizer = ml::train::createOptimizer("sgd", {"learning_rate=0.001"});
-  int status = model->setOptimizer(std::move(optimizer));
-  if (status) {
-    throw std::invalid_argument("failed to set optimizer!");
-  }
-
-  status = model->compile(ml::train::ExecutionMode::INFERENCE);
+  int status = model->compile(ml::train::ExecutionMode::INFERENCE);
   if (status) {
     throw std::invalid_argument("model compilation failed!");
   }
@@ -152,6 +146,7 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
     model->save(filePath, ml::train::ModelFormat::MODEL_FORMAT_BIN);
     model->load(filePath);
   }
+  model->summarize(std::cout, ML_TRAIN_SUMMARY_MODEL);
 
   answer = model->inference(1, in);
 

--- a/nntrainer/tensor/cache_elem.cpp
+++ b/nntrainer/tensor/cache_elem.cpp
@@ -54,8 +54,7 @@ void CacheElem::swapIn(Options opt) {
 
   opt = static_cast<Options>(opt | initial_opt);
   bool alloc_only = checkAllocOnly(policy, opt);
-  void *buf = device->getBuffer(offset, length, alloc_only);
-
+  void *buf = device->getBuffer(offset, length, memory_ptr, alloc_only);
   initial_opt = static_cast<Options>(initial_opt & ~Options::FIRST_ACCESS);
   mem_data->setAddr((void *)buf);
   mem_data->setValid(true);
@@ -75,7 +74,10 @@ void CacheElem::swapOut(Options opt) {
   void *buf = (void *)mem_data->getAddr();
 
   initial_opt = static_cast<Options>(initial_opt & ~Options::FIRST_WRITE);
-  device->putBuffer(buf, dealloc_only);
+  if (!device->address_unmapped(buf)) {
+    device->putBuffer(buf, dealloc_only);
+    device->set_unmapped(buf);
+  }
   mem_data->setAddr(nullptr);
   mem_data->setValid(false);
   active = false;

--- a/nntrainer/tensor/cache_elem.h
+++ b/nntrainer/tensor/cache_elem.h
@@ -62,7 +62,8 @@ public:
    */
   explicit CacheElem(std::shared_ptr<SwapDevice> dev, unsigned int mem_id,
                      size_t off, size_t len, std::shared_ptr<MemoryData> data,
-                     CachePolicy pol = CachePolicy::ALWAYS_SYNCED) :
+                     CachePolicy pol = CachePolicy::ALWAYS_SYNCED,
+                     void *ptr = nullptr) :
     initial_opt(Options::FIRST_ACCESS_WRITE),
     device(dev),
     active(false),
@@ -70,7 +71,8 @@ public:
     offset(off),
     length(len),
     policy(pol),
-    mem_data(data) {}
+    mem_data(data),
+    memory_ptr(ptr) {}
 
   /**
    * @brief CacheElem destructor
@@ -132,6 +134,7 @@ private:
   size_t length;                        /**< element size */
   CachePolicy policy;                   /**< cache policy */
   std::shared_ptr<MemoryData> mem_data; /**< allocated memory data */
+  void *memory_ptr;
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -125,6 +125,7 @@ void CachePool::allocate() {
 
   NNTR_THROW_IF(pool_size == 0, std::runtime_error)
     << "Allocating memory pool with size 0";
+  MemoryPool::allocate();
 
   swap_device->start(pool_size);
 }
@@ -132,10 +133,9 @@ void CachePool::allocate() {
 void CachePool::deallocate() {
   if (!swap_device->isOperating())
     return;
-
-  for (auto &[id, elem] : elems)
+  for (auto &[id, elem] : elems) {
     invalidate(id);
-
+  }
   actives.clear();
   swap_device->finish();
 }
@@ -182,8 +182,11 @@ std::shared_ptr<MemoryData> CachePool::getMemory(unsigned int id) {
   auto mem_data = std::make_shared<MemoryData>(
     id, std::bind(&CachePool::validate, this, std::placeholders::_1),
     std::bind(&CachePool::invalidate, this, std::placeholders::_1));
-  auto elem =
-    std::make_shared<CacheElem>(swap_device, id, offset, len, mem_data, policy);
+
+  auto mem_pool_address = getMemoryPoolAddress();
+  void *memory_ptr = static_cast<char *>(mem_pool_address) + offset;
+  auto elem = std::make_shared<CacheElem>(swap_device, id, offset, len,
+                                          mem_data, policy, memory_ptr);
   elems[id] = elem;
 
   std::string ords;

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -95,6 +95,7 @@ void MemoryPool::allocate() {
   if (mem_pool != nullptr)
     throw std::runtime_error("Memory pool is already allocated");
 
+
   mem_pool = calloc(pool_size, 1);
   if (mem_pool == nullptr)
     throw std::runtime_error(
@@ -119,7 +120,7 @@ std::shared_ptr<MemoryData> MemoryPool::getMemory(unsigned int idx) {
 
   char *ptr = static_cast<char *>(mem_pool) + memory_offset.at(idx - 1);
   auto mem_data = std::make_shared<MemoryData>((void *)ptr);
-
+  memory_ptrs.emplace_back(ptr);
   return mem_data;
 }
 
@@ -135,6 +136,7 @@ void MemoryPool::deallocate() {
     memory_exec_order.clear();
     memory_is_wgrad.clear();
     PROFILE_MEM_DEALLOC(mem_pool);
+    memory_ptrs.clear();
   }
 
   mem_pool = nullptr;

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -40,10 +40,7 @@ public:
    *
    */
   explicit MemoryPool() :
-    mem_pool(nullptr),
-    pool_size(0),
-    min_pool_size(0),
-    n_wgrad(0) {}
+    mem_pool(nullptr), pool_size(0), min_pool_size(0), n_wgrad(0) {}
 
   /**
    * @brief MemoryPool destructor
@@ -138,12 +135,14 @@ public:
    */
   virtual bool isAllocated() const;
 
-protected:
+  std::vector<void *> getMemoryPtrs() { return memory_ptrs; }
+  void *getMemoryPoolAddress() { return mem_pool; }
   /**
    * @brief  Get memory offset
    */
   std::vector<size_t> &getMemoryOffset() { return memory_offset; }
 
+protected:
   /**
    * @brief  Get memory size
    */
@@ -215,6 +214,8 @@ private:
   size_t min_pool_size; /**< minimum theoretical memory requirement */
 
   size_t n_wgrad;
+
+  std::vector<void *> memory_ptrs;
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/swap_device.cpp
+++ b/nntrainer/tensor/swap_device.cpp
@@ -49,7 +49,8 @@ void SwapDevice::start(size_t size) {
     << "SwapDevice: seek file: " << dev_path;
 }
 
-void *SwapDevice::getBuffer(off_t offset, size_t size, bool alloc_only) {
+void *SwapDevice::getBuffer(off_t offset, size_t size, void *memory_ptr,
+                            bool alloc_only) {
   NNTR_THROW_IF(fd <= 0, std::runtime_error)
     << "SwapDevice: Device is not started";
 
@@ -67,12 +68,12 @@ void *SwapDevice::getBuffer(off_t offset, size_t size, bool alloc_only) {
     << "SwapDevice: mmap: "
     << std::string(strerror_r(errno, error_buf, error_buflen));
 
-  void *buf = static_cast<void *>(ptr + diff);
-  mapped[buf] = std::make_tuple(ptr, len, offset, (ssize_t)size);
+  mapped[ptr] = std::make_tuple(ptr, len, offset, (ssize_t)size);
+  is_unmapped.insert(std::make_pair(ptr, false));
 
   ++num_loaded_tensors;
+  return ptr;
 
-  return buf;
 #else
   off_t off;
   ssize_t len;
@@ -182,6 +183,7 @@ void SwapDevice::finish() {
   for (auto &[ptr, info] : mapped)
     free(ptr);
   mapped.clear();
+  is_unmapped.clear();
 #else
   for (auto &alloc : allocated)
     free(alloc.first);

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -231,20 +231,22 @@ void TensorPool::allocate(bool init) {
   if (minMemoryRequirement() == 0)
     return;
   mem_pool->allocate();
-
-  // std::cout << "syncDependents start" << std::endl;
+  unsigned int i = 0;
   /** set the pointers using the token for all the tensors */
   for (auto &spec : pool) {
     auto details = std::get_if<SourceDetails>(&spec.details);
     if (!details || details->token == 0) {
       continue;
     }
+
     spec.tensor->setData(mem_pool->getMemory(details->token), 0, init);
     syncDependents(spec);
+    i++;
   }
 
-  if (cache_loader)
+  if (cache_loader) {
     cache_loader->init();
+  }
 }
 
 /**


### PR DESCRIPTION
Replaced the FSU Logic from dynamically allocating memory --> overwriting and sharing statica allocated memory.

1. In order to prevent multiple frees, I added a map to check whether the mem_address has already been processed. Previously, memory was allocated through buf, but now it is being allocated directly.

2. Update FSU forwarding logic
--> FSU will handle look ahead tensor inside of pool
--> so we don't need to call Loadtensor for f + i

3. inference we don't need optimizer at application : remove optimizer at application

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Co-authored-by: jijoong.moon <jijoong.moon@samsung.com>
Signed-off-by: Donghak PARK <donghak.park@samsung.com>
