### PR TITLE
[windows] replace strerror with thread_safe func

### DIFF
--- a/Applications/utils/datagen/cifar/cifar_dataloader.cpp
+++ b/Applications/utils/datagen/cifar/cifar_dataloader.cpp
@@ -137,8 +137,11 @@ void Cifar100DataLoader::next(float **input, float **label, bool *last) {
   /// @note below logic assumes a single input and the fine label is used
 
   auto fill_one_sample = [this](float *input_, float *label_, int index) {
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
     NNTR_THROW_IF(!file.good(), std::invalid_argument)
-      << "file is not good, reason: " << std::strerror(errno);
+      << "file is not good, reason: "
+      << SAFE_STRERROR(errno, error_buf, error_buflen);
     file.seekg(index * Cifar100DataLoader::SampleSize, std::ios_base::beg);
 
     uint8_t current_label;

--- a/benchmarks/fake_data_gen/fake_data_gen.cpp
+++ b/benchmarks/fake_data_gen/fake_data_gen.cpp
@@ -137,8 +137,11 @@ void Cifar100DataLoader::next(float **input, float **label, bool *last) {
   /// @note below logic assumes a single input and the fine label is used
 
   auto fill_one_sample = [this](float *input_, float *label_, int index) {
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
     NNTR_THROW_IF(!file.good(), std::invalid_argument)
-      << "file is not good, reason: " << std::strerror(errno);
+      << "file is not good, reason: "
+      << SAFE_STRERROR(errno, error_buf, error_buflen);
     file.seekg(index * Cifar100DataLoader::SampleSize, std::ios_base::beg);
 
     uint8_t current_label;

--- a/nntrainer/compiler/tflite_interpreter.cpp
+++ b/nntrainer/compiler/tflite_interpreter.cpp
@@ -57,8 +57,12 @@ void builder2file(const flatbuffers::FlatBufferBuilder &builder,
   NNTR_THROW_IF(!tflite::VerifyModelBuffer(v), std::invalid_argument)
     << FUNC_TAG << "Verifying serialized model failed";
   std::ofstream os(out, std::ios_base::binary);
+
+  const size_t error_buflen = 100;
+  char error_buf[error_buflen];
   NNTR_THROW_IF(!os.good(), std::invalid_argument)
-    << FUNC_TAG << "failed to open, reason: " << std::strerror(errno);
+    << FUNC_TAG << "failed to open, reason: "
+    << SAFE_STRERROR(errno, error_buf, error_buflen);
 
   std::streamsize sz = static_cast<std::streamsize>(builder.GetSize());
   NNTR_THROW_IF(sz < 0, std::invalid_argument)

--- a/nntrainer/models/model_loader.cpp
+++ b/nntrainer/models/model_loader.cpp
@@ -472,8 +472,10 @@ int ModelLoader::loadFromConfig(std::string config, NeuralNetwork &model) {
 
   auto config_realpath_char = getRealpath(config.c_str(), nullptr);
   if (config_realpath_char == nullptr) {
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
     ml_loge("failed to resolve config path to absolute path, reason: %s",
-            std::strerror(errno));
+            SAFE_STRERROR(errno, error_buf, error_buflen));
     return ML_ERROR_INVALID_PARAMETER;
   }
   std::string config_realpath(config_realpath_char);

--- a/nntrainer/nntrainer_error.h
+++ b/nntrainer/nntrainer_error.h
@@ -23,6 +23,7 @@
 #define ML_ERROR_RESULT_OUT_OF_RANGE (-ERANGE)
 #endif
 
+#include <cstring>
 #include <functional>
 #include <sstream>
 #include <stdexcept>
@@ -34,6 +35,12 @@
 #define NNTR_THROW_IF_CLEANUP(pred, err, cleanup_func) \
   if ((pred))                                          \
     nntrainer::exception::ErrorNotification<err> { cleanup_func }
+
+#ifdef _WIN32
+#define SAFE_STRERROR(errnum, buffer, size) strerror_s(buffer, size, errnum)
+#else
+#define SAFE_STRERROR(errnum, buffer, size) strerror_r(errnum, buffer, size)
+#endif
 
 #if ML_API_COMMON
 #include <ml-api-common.h>

--- a/nntrainer/tensor/swap_device.cpp
+++ b/nntrainer/tensor/swap_device.cpp
@@ -61,8 +61,11 @@ void *SwapDevice::getBuffer(off_t offset, size_t size, bool alloc_only) {
 
   char *ptr = static_cast<char *>(
     mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, off));
+  const size_t error_buflen = 100;
+  char error_buf[error_buflen];
   NNTR_THROW_IF(ptr == (void *)-1, std::runtime_error)
-    << "SwapDevice: mmap: " << std::string(std::strerror(errno));
+    << "SwapDevice: mmap: "
+    << std::string(strerror_r(errno, error_buf, error_buflen));
 
   void *buf = static_cast<void *>(ptr + diff);
   mapped[buf] = std::make_tuple(ptr, len, offset, (ssize_t)size);
@@ -123,8 +126,11 @@ void SwapDevice::putBuffer(void *ptr, bool dealloc_only) {
   }
 
   ret = munmap(std::get<void *>(info), std::get<size_t>(info));
+  const size_t error_buflen = 100;
+  char error_buf[error_buflen];
   NNTR_THROW_IF(ret == -1, std::runtime_error)
-    << "SwapDevice: munmap: " << std::string(std::strerror(errno));
+    << "SwapDevice: munmap: "
+    << std::string(strerror_r(errno, error_buf, error_buflen));
 
   mapped.erase(ptr);
 

--- a/nntrainer/utils/ini_wrapper.cpp
+++ b/nntrainer/utils/ini_wrapper.cpp
@@ -128,8 +128,10 @@ void IniWrapper::save_ini(const std::string &ini_name) const {
 
 void IniWrapper::erase_ini() const noexcept {
   if (remove(getIniName().c_str())) {
-    std::cerr << "remove ini " << getIniName()
-              << "failed, reason: " << std::strerror(errno);
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
+    std::cerr << "remove ini " << getIniName() << "failed, reason: "
+              << SAFE_STRERROR(errno, error_buf, error_buflen);
   }
 }
 

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -200,9 +200,11 @@ template <typename T>
 T checkedOpenStream(const std::string &path, std::ios_base::openmode mode) {
   T model_file(path, mode);
   if (!model_file.good()) {
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
     std::stringstream ss;
     ss << "[parseutil] requested file not opened, file path: " << path
-       << " reason: " << std::strerror(errno);
+       << " reason: " << SAFE_STRERROR(errno, error_buf, error_buflen);
     if (errno == EPERM || errno == EACCES) {
       throw nntrainer::exception::permission_denied(ss.str().c_str());
     } else {

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -452,8 +452,10 @@ TEST(nntrainer_ccapi, save_ini_p) {
   EXPECT_EQ(model->initialize(), ML_ERROR_NONE);
   auto saved_ini_name = s.getIniName() + "_saved";
   if (remove(saved_ini_name.c_str())) {
-    std::cerr << "remove ini " << saved_ini_name
-              << "failed, reason: " << std::strerror(errno);
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
+    std::cerr << "remove ini " << saved_ini_name << "failed, reason: "
+              << SAFE_STRERROR(errno, error_buf, error_buflen);
   }
 
   model->save(saved_ini_name, ml::train::ModelFormat::MODEL_FORMAT_INI);

--- a/test/unittest/compiler/unittest_interpreter.cpp
+++ b/test/unittest/compiler/unittest_interpreter.cpp
@@ -21,6 +21,7 @@
 #include <layer.h>
 #include <layer_node.h>
 #include <network_graph.h>
+#include <nntrainer_error.h>
 
 #include <app_context.h>
 #include <compiler_test_util.h>
@@ -98,7 +99,10 @@ TEST_P(nntrainerInterpreterTest, graphSerializeAfterDeserialize) {
 
   graphEqual(g, new_g);
 
-  EXPECT_EQ(remove(out_file_path.c_str()), 0) << std::strerror(errno);
+  const size_t error_buflen = 100;
+  char error_buf[error_buflen];
+  EXPECT_EQ(remove(out_file_path.c_str()), 0)
+    << SAFE_STRERROR(errno, error_buf, error_buflen);
 }
 
 TEST_P(nntrainerInterpreterTest, deserialize_01_n) {

--- a/test/unittest/compiler/unittest_tflite_export.cpp
+++ b/test/unittest/compiler/unittest_tflite_export.cpp
@@ -178,10 +178,13 @@ TEST(nntrainerInterpreterTflite, simple_fc) {
   for (size_t i = 0; i < out.size(); i++)
     EXPECT_NEAR(out[i], ans[i], 0.000001f);
 
+  const size_t error_buflen = 100;
+  char error_buf[error_buflen];
   if (remove("simple_fc.tflite")) {
     std::cerr << "remove tflite "
               << "simple_fc.tflite"
-              << "failed, reason: " << std::strerror(errno);
+              << "failed, reason: "
+              << SAFE_STRERROR(errno, error_buf, error_buflen);
   }
 }
 
@@ -232,10 +235,13 @@ TEST(nntrainerInterpreterTflite, flatten_test) {
   for (size_t i = 0; i < out.size(); i++)
     EXPECT_NEAR(out[i], ans[i], 0.000001f);
 
+  const size_t error_buflen = 100;
+  char error_buf[error_buflen];
   if (remove("flatten_test.tflite")) {
     std::cerr << "remove tflite "
               << "flatten_test.tflite"
-              << "failed, reason: " << std::strerror(errno);
+              << "failed, reason: "
+              << SAFE_STRERROR(errno, error_buf, error_buflen);
   }
 }
 
@@ -305,9 +311,12 @@ TEST(nntrainerInterpreterTflite, part_of_resnet_0) {
     EXPECT_NEAR(out[i], ans[i], 0.000001f);
 
   if (remove("part_of_resnet.tflite")) {
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
     std::cerr << "remove ini "
               << "part_of_resnet.tflite"
-              << "failed, reason: " << std::strerror(errno);
+              << "failed, reason: "
+              << SAFE_STRERROR(errno, error_buf, error_buflen);
   }
 }
 
@@ -386,8 +395,11 @@ TEST(nntrainerInterpreterTflite, MNIST_FULL_TEST) {
     std::cout << "out : " << out[i] << " ans : " << ans[i] << std::endl;
   }
   if (remove("MNIST_FULL_TEST.tflite")) {
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
     std::cerr << "remove tflite "
               << "MNIST_FULL_TEST.tflite"
-              << "failed, reason: " << std::strerror(errno);
+              << "failed, reason: "
+              << SAFE_STRERROR(errno, error_buf, error_buflen);
   }
 }

--- a/test/unittest/models/models_golden_test.cpp
+++ b/test/unittest/models/models_golden_test.cpp
@@ -65,8 +65,10 @@ TEST_P(nntrainerModelTest, model_test_save_load_compare) {
       new nntrainer::NeuralNetwork());
     nn->load(saved_ini_name, ml::train::ModelFormat::MODEL_FORMAT_INI);
     if (remove(saved_ini_name.c_str())) {
-      std::cerr << "remove ini " << saved_ini_name
-                << "failed, reason: " << std::strerror(errno);
+      const size_t error_buflen = 100;
+      char error_buf[error_buflen];
+      std::cerr << "remove ini " << saved_ini_name << "failed, reason: "
+                << SAFE_STRERROR(errno, error_buf, error_buflen);
     }
     return nn;
   };
@@ -95,8 +97,10 @@ TEST_P(nntrainerModelTest, model_test_save_load_verify) {
       new nntrainer::NeuralNetwork());
     nn->load(saved_ini_name, ml::train::ModelFormat::MODEL_FORMAT_INI);
     if (remove(saved_ini_name.c_str())) {
-      std::cerr << "remove ini " << saved_ini_name
-                << "failed, reason: " << std::strerror(errno);
+      const size_t error_buflen = 100;
+      char error_buf[error_buflen];
+      std::cerr << "remove ini " << saved_ini_name << "failed, reason: "
+                << SAFE_STRERROR(errno, error_buf, error_buflen);
     }
     return nn;
   };


### PR DESCRIPTION
In #2870, the thread-safe function strerror_r was replaced with the non-thread-safe function strerror.

However, due to issues related to thread_safe, it was re-modified to use the thread-safe function.

For Windows support, a macro was defined to replace strerror_r with strerror_s only when the operating system is Windows.

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>