### PR TITLE
[ONNX] add basic onnx interpreter @open sesame 02/17 20:00

### DIFF
--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -90,7 +90,8 @@ for inference and training without any configurations*/
     ML_TRAIN_MODEL_FORMAT_INI_WITH_BIN, /**< ini file with save_path defined
                                            where the binary will be saved */
   MODEL_FORMAT_FLATBUFFER =
-    ML_TRAIN_MODEL_FORMAT_FLATBUFFER, /**< flatbuffer file */
+    ML_TRAIN_MODEL_FORMAT_FLATBUFFER,             /**< flatbuffer file */
+  MODEL_FORMAT_ONNX = ML_TRAIN_MODEL_FORMAT_ONNX, /**< ONNX file */
 };
 
 /**

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -263,7 +263,8 @@ typedef enum {
     2, /**< Ini with bin format file saves configurations with parameters
          required for inference and training. */
   ML_TRAIN_MODEL_FORMAT_FLATBUFFER =
-    3 /**< Flatbuffer format file saves model configurations and weights. */
+    3, /**< Flatbuffer format file saves model configurations and weights. */
+  ML_TRAIN_MODEL_FORMAT_ONNX = 4, /**< ONNX format file. */
 } ml_train_model_format_e;
 
 /**

--- a/meson.build
+++ b/meson.build
@@ -516,6 +516,10 @@ if get_option('enable-tflite-interpreter')
   extra_defines += '-DENABLE_TFLITE_INTERPRETER=1'
 endif
 
+if get_option('enable-onnx-interpreter')
+  extra_defines += '-DENABLE_ONNX_INTERPRETER=1'
+endif
+
 opencv_dep = dummy_dep
 
 if get_option('platform') != 'android'

--- a/nntrainer/compiler/meson.build
+++ b/nntrainer/compiler/meson.build
@@ -16,6 +16,15 @@ compiler_headers = [
   'compiler_fwd.h'
 ]
 
+if get_option('enable-onnx-interpreter')
+  compiler_sources += [
+    'onnx_interpreter.cpp',
+  ]
+  compiler_headers += [
+    'onnx_interpreter.h',
+  ]
+endif
+
 if get_option('enable-tflite-interpreter')
   compiler_sources += [
     'tflite_interpreter.cpp',

--- a/nntrainer/compiler/onnx_interpreter.cpp
+++ b/nntrainer/compiler/onnx_interpreter.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 SeungBaek Hong <sb92.hong@samsung.com>
+ *
+ * @file   onnx_interpreter.cpp
+ * @date   12 February 2025
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author SeungBaek Hong <sb92.hong@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ * @brief  This is onnx converter interface for c++ API
+ */
+
+#include "layer_node.h"
+#include <onnx_interpreter.h>
+
+namespace nntrainer {
+
+void ONNXInterpreter::serialize(const GraphRepresentation &representation,
+                                const std::string &out){};
+
+GraphRepresentation ONNXInterpreter::deserialize(const std::string &in) {
+  // Load and parse onnx file with protobuf
+  std::ifstream file(in, std::ios::binary);
+  if (!file.is_open()) {
+    throw std::runtime_error("File does not exist: " + in);
+  }
+
+  onnx_model.ParseFromIstream(&file);
+
+  // Create nntrainer model instance
+  GraphRepresentation graph;
+  //   std::vector<std::shared_ptr<ml::train::Layer>> layers;
+
+  // Create initializer(weight) unordered map and create weight layer
+  for (auto &initializer : onnx_model.graph().initializer()) {
+    // initializers are used to identify weights in the model
+    initializers.insert({cleanName(initializer.name()), initializer});
+    std::string dim = transformDimString(initializer);
+
+    // weight layer should be modified not to use input_shape as a parameter
+    graph.push_back(createLayerNode(
+      "weight", {withKey("name", cleanName(initializer.name())),
+                 withKey("dim", dim), withKey("input_shape", dim)}));
+  }
+
+  // Create input & constant tensor layer
+  for (const auto &input : onnx_model.graph().input()) {
+    auto shape = input.type().tensor_type().shape();
+    if (shape.dim_size() >= 4 || shape.dim_size() == 0) {
+      throw std::runtime_error(
+        "Tensors with batch dimensions of 5 or more, or zero_dimensional "
+        "tensors are not supported.");
+    }
+
+    std::string dim = transformDimString(shape);
+    if (input.name().find("input") != std::string::npos) { // Create input layer
+      graph.push_back(
+        createLayerNode("input", {withKey("name", cleanName(input.name())),
+                                  withKey("input_shape", dim)}));
+    } else { // Create constant tensor layer
+      throw std::runtime_error("Constant tensors are not supported yet.");
+    }
+  }
+
+  // Create graph
+  for (const auto &node : onnx_model.graph().node()) {
+    /**
+     * @brief While NNTrainer represents graphs as connections between
+     * operations, ONNX represents graphs as connections between
+     operations
+     * and tensors, requiring remapping of the names of output tensors
+     from
+     * operations.
+     */
+    std::vector<std::string> inputNames;
+    auto outputRemap = [this](std::string &input_layer_name) {
+      if (layerOutputMap.find(input_layer_name) != layerOutputMap.end()) {
+        input_layer_name = layerOutputMap.find(input_layer_name)->second;
+      }
+    };
+    for (auto &input : node.input()) {
+      std::string inputName = cleanName(input);
+      outputRemap(inputName);
+      inputNames.push_back(inputName);
+    }
+
+    if (node.op_type() == "Add") {
+      layerOutputMap.insert(
+        {cleanName(node.output()[0]), cleanName(node.name())});
+
+      graph.push_back(createLayerNode(
+        "add", {"name=" + cleanName(node.name()),
+                withKey("input_layers", inputNames[0] + "," + inputNames[1])}));
+    } else {
+      throw std::runtime_error("Unsupported operation type: " + node.op_type());
+    }
+  }
+
+  return graph;
+};
+
+std::string ONNXInterpreter::cleanName(std::string name) {
+  if (!name.empty() && name[0] == '/') {
+    name.erase(0, 1);
+  }
+  std::replace(name.begin(), name.end(), '/', '_');
+  std::replace(name.begin(), name.end(), '.', '_');
+  std::transform(name.begin(), name.end(), name.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return name;
+}
+
+std::string ONNXInterpreter::transformDimString(onnx::TensorShapeProto shape) {
+  std::string dim = "";
+  for (int i = 0; i < shape.dim_size(); ++i) {
+    if (shape.dim()[i].has_dim_param()) {
+      throw std::runtime_error("Dynamic dimensions are not supported");
+    }
+    dim += std::to_string(shape.dim()[i].dim_value());
+    if (i < shape.dim_size() - 1) {
+      dim += ":";
+    }
+  }
+
+  if (shape.dim_size() == 1) {
+    dim = "1:1:" + dim;
+  } else if (shape.dim_size() == 2) {
+    dim = "1:" + dim;
+  }
+
+  return dim;
+}
+
+std::string ONNXInterpreter::transformDimString(onnx::TensorProto initializer) {
+  std::string dim = "";
+  for (int i = 0; i < initializer.dims_size(); ++i) {
+    dim += std::to_string(initializer.dims()[i]);
+    if (i < initializer.dims_size() - 1) {
+      dim += ":";
+    }
+  }
+
+  if (initializer.dims_size() == 1) {
+    dim = "1:1:" + dim;
+  } else if (initializer.dims_size() == 2) {
+    dim = "1:" + dim;
+  }
+
+  return dim;
+};
+
+}; // namespace nntrainer

--- a/nntrainer/compiler/onnx_interpreter.h
+++ b/nntrainer/compiler/onnx_interpreter.h
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 SeungBaek Hong <sb92.hong@samsung.com>
+ *
+ * @file   onnx_interpreter.h
+ * @date   12 February 2025
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author SeungBaek Hong <sb92.hong@samsung.com>
+ * @bug	   No known bugs except for NYI items
+ * @brief  This is onnx converter interface for c++ API
+ */
+
+#ifndef __ONNX_INTERPRETER_H__
+#define __ONNX_INTERPRETER_H__
+#ifdef ENABLE_ONNX_INTERPRETER
+
+#include <app_context.h>
+#include <interpreter.h>
+#include <layer.h>
+#include <layer_node.h>
+#include <model.h>
+#include <nntrainer-api-common.h>
+#include <onnx.pb.h>
+#include <string>
+#include <util_func.h>
+
+namespace nntrainer {
+/**
+ * @brief ONNX Interpreter class for converting onnx model to nntrainer model.
+ *
+ */
+class ONNXInterpreter : public GraphInterpreter {
+public:
+  /**
+   * @brief Construct a new ONNXInterpreter object
+   *
+   */
+  ONNXInterpreter(){};
+
+  /**
+   * @brief Destroy the ONNXInterpreter object
+   *
+   */
+  ~ONNXInterpreter(){};
+
+  /**
+   * @copydoc GraphInterpreter::serialize(const GraphRepresentation
+   * representation, const std::string &out)
+   */
+  void serialize(const GraphRepresentation &representation,
+                 const std::string &out) override;
+
+  /**
+   * @copydoc GraphInterpreter::deserialize(const std::string &in)
+   */
+  GraphRepresentation deserialize(const std::string &in) override;
+
+  /**
+   * @brief Clean the name of the layer to be used in nntrainer model
+   *
+   * @param name name of the layer
+   */
+  std::string cleanName(std::string name);
+
+  /**
+   * @brief Transform dimension string to nntrainer's format.
+   *
+   * @param shape ONNX TensorShapeProto
+   */
+  std::string transformDimString(onnx::TensorShapeProto shape);
+
+  // /**
+  //  * @brief Transform dimension string to nntrainer's format.
+  //  *
+  //  * @param initializer ONNX TensorProto
+  //  */
+  std::string transformDimString(onnx::TensorProto initializer);
+
+private:
+  onnx::ModelProto onnx_model; // parsed onnx model
+  std::unique_ptr<ml::train::Model>
+    nntrainer_model; // converted nntrainer model
+  std::unordered_map<std::string, std::string>
+    layerOutputMap; // key: name of output, value: name of layer
+  std::unordered_map<std::string, onnx::TensorProto>
+    initializers; // initializers are used to identify weights
+};
+
+} // namespace nntrainer
+
+#endif // ENABLE_ONNX_INTERPRETER
+#endif // __ONNX_INTERPRETER_H__

--- a/nntrainer/models/model_loader.h
+++ b/nntrainer/models/model_loader.h
@@ -35,8 +35,7 @@ public:
    * @brief     Constructor of the model loader
    */
   ModelLoader(const AppContext &app_context_ = AppContext::Global()) :
-    app_context(app_context_),
-    model_file_context(nullptr) {}
+    app_context(app_context_), model_file_context(nullptr) {}
 
   /**
    * @brief     Destructor of the model loader
@@ -72,6 +71,13 @@ private:
    * @param[in/out] model model to be loaded
    */
   int loadFromIni(std::string ini_file, NeuralNetwork &model, bool bare_layers);
+
+  /**
+   * @brief     load model from ONNX file
+   * @param[in] onnx_file onnx config file path
+   * @param[in/out] model model to be loaded
+   */
+  int loadFromONNX(std::string onnx_file, NeuralNetwork &model);
 
   /**
    * @brief     load dataset config from ini
@@ -115,14 +121,21 @@ private:
    * @param[in] filename full name of the file
    * @retval true if ini, else false
    */
-  static bool fileIni(const std::string &filename);
+  static bool isIniFile(const std::string &filename);
 
   /**
    * @brief     Check if the file extension is tflite
    * @param[in] filename full name of the file
    * @retval true if tflite, else false
    */
-  static bool fileTfLite(const std::string &filename);
+  static bool isTfLiteFile(const std::string &filename);
+
+  /**
+   * @brief Check if the file extension is ONNX
+   * @param[in] filename full name of the ONNX file
+   * @retval true if ONNX, else false
+   */
+  static bool isONNXFile(const std::string &filename);
 
   /**
    * @brief resolvePath to absolute path written in a model description

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "layer_context.h"
+#include "model.h"
 #include "model_common_properties.h"
 #include <cmath>
 #include <cstring>
@@ -622,7 +623,6 @@ void NeuralNetwork::save(const std::string &file_path,
   case ml::train::ModelFormat::MODEL_FORMAT_INI:
     saveModelIni(file_path);
     break;
-
   case ml::train::ModelFormat::MODEL_FORMAT_INI_WITH_BIN: {
     auto old_save_path = std::get<props::SavePath>(model_flex_props);
     auto bin_file_name =
@@ -632,6 +632,11 @@ void NeuralNetwork::save(const std::string &file_path,
     save(file_path, ml::train::ModelFormat::MODEL_FORMAT_INI);
     save(bin_file_name, ml::train::ModelFormat::MODEL_FORMAT_BIN);
     std::get<props::SavePath>(model_flex_props) = old_save_path;
+    break;
+  }
+  case ml::train::ModelFormat::MODEL_FORMAT_ONNX: {
+    throw nntrainer::exception::not_supported(
+      "saving with ONNX format is not supported yet.");
     break;
   }
   default:
@@ -700,6 +705,11 @@ void NeuralNetwork::load(const std::string &file_path,
     break;
   }
   case ml::train::ModelFormat::MODEL_FORMAT_FLATBUFFER: {
+    break;
+  }
+  case ml::train::ModelFormat::MODEL_FORMAT_ONNX: {
+    int ret = loadFromConfig(file_path);
+    throw_status(ret);
     break;
   }
   default:


### PR DESCRIPTION
A simplest basic structure of onnx_interpreter has been added.
In this implementation, only input layer, weight layer, add layer are supported.

Basically, it is implemented by reading and parsing the onnx file using protobuf, and then creating an NNTrainer graph by sequentially checking the nodes. Users can simply specify the path to the ONNX model file through the "loadONNX" NNTrainer API function.

The types of tensors handled during the process of creating a graph can be classified into input tensor, constant tensor, weight tensor.
Among these, the current implementation only supports input tensor and weight tensor.
In ONNX, weight tensors have initializers unlike other tensors, so it can be distinguished as weight tensors through initializers. In the current implementation, initializer list are managed separately as a vector, but this vector will be removed as the implementation is completed in the future.

This commit uploads a minimal working implementation, and the onnx interpreter needs to be continuously updated.
An example application of reading an onnx file to create an NNTrainer model using this interpreter, and a document setting up the execution environment by installing protobuf will be uploaded as separate commits.

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>