### PR TITLE
[refactoring] add withKey function to utility functions @open sesame 02/21 08:59

### DIFF
--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -188,6 +188,45 @@ void printInstance(std::ostream &out, const T &t) {
 }
 
 /**
+ * @brief make "key=value" from key and value
+ *
+ * @tparam T type of a value
+ * @param key key
+ * @param value value
+ * @return std::string with "key=value"
+ */
+template <typename T>
+static std::string withKey(const std::string &key, const T &value) {
+  std::stringstream ss;
+  ss << key << "=" << value;
+  return ss.str();
+}
+
+/**
+ * @brief make "key=value1,value2,...valueN" from key and multiple values
+ *
+ * @tparam T type of a value
+ * @param key key
+ * @param value list of values
+ * @return std::string with "key=value1,value2,...valueN"
+ */
+template <typename T>
+static std::string withKey(const std::string &key,
+                           std::initializer_list<T> value) {
+  if (std::empty(value)) {
+    throw std::invalid_argument("empty data cannot be converted");
+  }
+  std::stringstream ss;
+  ss << key << "=";
+  auto iter = value.begin();
+  for (; iter != value.end() - 1; ++iter) {
+    ss << *iter << ',';
+  }
+  ss << *iter;
+  return ss.str();
+}
+
+/**
  * @brief creat a stream, and if !stream.good() throw appropriate error code
  * depending on @c errno
  *

--- a/test/unittest/integration_tests/integration_test_fsu.cpp
+++ b/test/unittest/integration_tests/integration_test_fsu.cpp
@@ -21,61 +21,39 @@
 #include <model.h>
 #include <optimizer.h>
 #include <sstream>
+#include <util_func.h>
 #include <vector>
 
 using LayerHandle = std::shared_ptr<ml::train::Layer>;
 using ModelHandle = std::unique_ptr<ml::train::Model>;
 
-template <typename T>
-static std::string withKey(const std::string &key, const T &value) {
-  std::stringstream ss;
-  ss << key << "=" << value;
-  return ss.str();
-}
-
-template <typename T>
-static std::string withKey(const std::string &key,
-                           std::initializer_list<T> value) {
-  if (std::empty(value)) {
-    throw std::invalid_argument("empty data cannot be converted");
-  }
-
-  std::stringstream ss;
-  ss << key << "=";
-
-  auto iter = value.begin();
-  for (; iter != value.end() - 1; ++iter) {
-    ss << *iter << ',';
-  }
-  ss << *iter;
-
-  return ss.str();
-}
-
 TEST(fsu, simple_fc) {
 
   std::unique_ptr<ml::train::Model> model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {withKey("loss", "mse")});
+    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "mse")});
 
   model->addLayer(ml::train::createLayer(
-    "input", {withKey("name", "input0"), withKey("input_shape", "1:1:320")}));
-
+    "input", {nntrainer::withKey("name", "input0"),
+              nntrainer::withKey("input_shape", "1:1:320")}));
   for (int i = 0; i < 6; i++) {
     model->addLayer(ml::train::createLayer(
       "fully_connected",
-      {withKey("unit", 1000), withKey("weight_initializer", "xavier_uniform"),
-       withKey("bias_initializer", "zeros")}));
+      {nntrainer::withKey("unit", 1000),
+       nntrainer::withKey("weight_initializer", "xavier_uniform"),
+       nntrainer::withKey("bias_initializer", "zeros")}));
   }
 
   model->addLayer(ml::train::createLayer(
     "fully_connected",
-    {withKey("unit", 100), withKey("weight_initializer", "xavier_uniform"),
-     withKey("bias_initializer", "zeros")}));
+    {nntrainer::withKey("unit", 100),
+     nntrainer::withKey("weight_initializer", "xavier_uniform"),
+     nntrainer::withKey("bias_initializer", "zeros")}));
 
-  model->setProperty({withKey("batch_size", 1), withKey("epochs", 1),
-                      withKey("memory_swap", "true"),
-                      withKey("memory_swap_lookahead", "1"),
-                      withKey("model_tensor_type", "FP16-FP16")});
+  model->setProperty({nntrainer::withKey("batch_size", 1),
+                      nntrainer::withKey("epochs", 1),
+                      nntrainer::withKey("memory_swap", "true"),
+                      nntrainer::withKey("memory_swap_lookahead", "1"),
+                      nntrainer::withKey("model_tensor_type", "FP16-FP16")});
 
   int status = model->compile(ml::train::ExecutionMode::INFERENCE);
   EXPECT_EQ(status, ML_ERROR_NONE);

--- a/test/unittest/integration_tests/integration_test_loss.cpp
+++ b/test/unittest/integration_tests/integration_test_loss.cpp
@@ -18,49 +18,26 @@
 #include <layer.h>
 #include <model.h>
 #include <optimizer.h>
-
-template <typename T>
-static std::string withKey(const std::string &key, const T &value) {
-  std::stringstream ss;
-  ss << key << "=" << value;
-  return ss.str();
-}
-
-template <typename T>
-static std::string withKey(const std::string &key,
-                           std::initializer_list<T> value) {
-  if (std::empty(value)) {
-    throw std::invalid_argument("empty data cannot be converted");
-  }
-
-  std::stringstream ss;
-  ss << key << "=";
-
-  auto iter = value.begin();
-  for (; iter != value.end() - 1; ++iter) {
-    ss << *iter << ',';
-  }
-  ss << *iter;
-
-  return ss.str();
-}
+#include <util_func.h>
 
 TEST(crossentropy_loss, model_pass_test) {
 
   std::unique_ptr<ml::train::Model> model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {withKey("loss", "cross")});
+    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "cross")});
 
   std::shared_ptr<ml::train::Layer> input_layer = ml::train::createLayer(
-    "input", {withKey("name", "input0"), withKey("input_shape", "3:32:32")});
+    "input", {nntrainer::withKey("name", "input0"),
+              nntrainer::withKey("input_shape", "3:32:32")});
 
   std::shared_ptr<ml::train::Layer> fc_layer = ml::train::createLayer(
-    "fully_connected",
-    {withKey("unit", 100), withKey("activation", "softmax")});
+    "fully_connected", {nntrainer::withKey("unit", 100),
+                        nntrainer::withKey("activation", "softmax")});
 
   model->addLayer(input_layer);
   model->addLayer(fc_layer);
 
-  model->setProperty({withKey("batch_size", 16), withKey("epochs", 10)});
+  model->setProperty(
+    {nntrainer::withKey("batch_size", 16), nntrainer::withKey("epochs", 10)});
 
   auto optimizer = ml::train::createOptimizer("adam", {"learning_rate=0.001"});
   model->setOptimizer(std::move(optimizer));
@@ -73,17 +50,20 @@ TEST(crossentropy_loss, model_pass_test) {
 TEST(crossentropy_loss, model_fail_test) {
 
   std::unique_ptr<ml::train::Model> model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {withKey("loss", "cross")});
+    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "cross")});
 
   std::shared_ptr<ml::train::Layer> input_layer = ml::train::createLayer(
-    "input", {withKey("name", "input0"), withKey("input_shape", "3:32:32")});
+    "input", {nntrainer::withKey("name", "input0"),
+              nntrainer::withKey("input_shape", "3:32:32")});
   std::shared_ptr<ml::train::Layer> fc_layer = ml::train::createLayer(
-    "fully_connected", {withKey("unit", 100), withKey("activation", "relu")});
+    "fully_connected", {nntrainer::withKey("unit", 100),
+                        nntrainer::withKey("activation", "relu")});
 
   model->addLayer(input_layer);
   model->addLayer(fc_layer);
 
-  model->setProperty({withKey("batch_size", 16), withKey("epochs", 10)});
+  model->setProperty(
+    {nntrainer::withKey("batch_size", 16), nntrainer::withKey("epochs", 10)});
 
   auto optimizer = ml::train::createOptimizer("adam", {"learning_rate=0.001"});
   model->setOptimizer(std::move(optimizer));
@@ -94,18 +74,20 @@ TEST(crossentropy_loss, model_fail_test) {
 TEST(kld_loss, compile_test) {
 
   std::unique_ptr<ml::train::Model> model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {withKey("loss", "kld")});
+    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "kld")});
 
   std::shared_ptr<ml::train::Layer> input_layer = ml::train::createLayer(
-    "input", {withKey("name", "input0"), withKey("input_shape", "3:32:32")});
+    "input", {nntrainer::withKey("name", "input0"),
+              nntrainer::withKey("input_shape", "3:32:32")});
   std::shared_ptr<ml::train::Layer> fc_layer = ml::train::createLayer(
-    "fully_connected",
-    {withKey("unit", 100), withKey("activation", "softmax")});
+    "fully_connected", {nntrainer::withKey("unit", 100),
+                        nntrainer::withKey("activation", "softmax")});
 
   model->addLayer(input_layer);
   model->addLayer(fc_layer);
 
-  model->setProperty({withKey("batch_size", 16), withKey("epochs", 1)});
+  model->setProperty(
+    {nntrainer::withKey("batch_size", 16), nntrainer::withKey("epochs", 1)});
 
   auto optimizer = ml::train::createOptimizer("adam", {"learning_rate=0.001"});
   model->setOptimizer(std::move(optimizer));

--- a/test/unittest/unittest_nntrainer_graph.cpp
+++ b/test/unittest/unittest_nntrainer_graph.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 #include <ini_wrapper.h>
 #include <neuralnet.h>
+#include <util_func.h>
 
 #include "nntrainer_test_util.h"
 
@@ -20,40 +21,6 @@ using LayerRepresentation = std::pair<std::string, std::vector<std::string>>;
 using LayerHandle = std::shared_ptr<ml::train::Layer>;
 using ModelHandle = std::unique_ptr<ml::train::Model>;
 using ml::train::createLayer;
-
-/**
- * @brief make "key=value" from key and value
- *
- * @tparam T type of a value
- * @param key key
- * @param value value
- * @return std::string with "key=value"
- */
-template <typename T>
-static std::string withKey(const std::string &key, const T &value) {
-  std::stringstream ss;
-  ss << key << "=" << value;
-  return ss.str();
-}
-
-template <typename T>
-static std::string withKey(const std::string &key,
-                           std::initializer_list<T> value) {
-  if (std::empty(value)) {
-    throw std::invalid_argument("empty data cannot be converted");
-  }
-
-  std::stringstream ss;
-  ss << key << "=";
-
-  auto iter = value.begin();
-  for (; iter != value.end() - 1; ++iter) {
-    ss << *iter << ',';
-  }
-  ss << *iter;
-
-  return ss.str();
-}
 
 namespace initest {
 typedef enum {
@@ -305,7 +272,7 @@ TEST(nntrainerGraphUnitTest, cross_with_relu) {
   nntrainer::NetworkGraph ng;
 
   ModelHandle nn_model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {withKey("loss", "cross")});
+    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "cross")});
 
   for (auto &node : g) {
     EXPECT_NO_THROW(nn_model->addLayer(node));
@@ -325,7 +292,7 @@ TEST(nntrainerGraphUnitTest, compile_twice) {
   nntrainer::NetworkGraph ng;
 
   ModelHandle nn_model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {withKey("loss", "cross")});
+    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "cross")});
 
   for (auto &node : g) {
     EXPECT_NO_THROW(nn_model->addLayer(node));
@@ -352,7 +319,7 @@ TEST(nntrainerGraphUnitTest, call_functions) {
   nntrainer::NetworkGraph ng;
 
   ModelHandle nn_model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {withKey("loss", "cross")});
+    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "cross")});
 
   for (auto &node : g) {
     EXPECT_NO_THROW(nn_model->addLayer(node));
@@ -373,22 +340,26 @@ TEST(nntrainerGraphUnitTest, NoLossLayerWhenInferenceMode) {
     ml::train::createModel(ml::train::ModelType::NEURAL_NET);
 
   model->addLayer(ml::train::createLayer(
-    "input", {withKey("name", "input0"), withKey("input_shape", "1:1:256")}));
+    "input", {nntrainer::withKey("name", "input0"),
+              nntrainer::withKey("input_shape", "1:1:256")}));
 
   for (int i = 0; i < 3; ++i) {
     model->addLayer(ml::train::createLayer(
       "fully_connected",
-      {withKey("unit", 1024), withKey("weight_initializer", "xavier_uniform"),
-       withKey("bias_initializer", "zeros")}));
+      {nntrainer::withKey("unit", 1024),
+       nntrainer::withKey("weight_initializer", "xavier_uniform"),
+       nntrainer::withKey("bias_initializer", "zeros")}));
   }
   model->addLayer(ml::train::createLayer(
     "fully_connected",
-    {withKey("unit", 100), withKey("weight_initializer", "xavier_uniform"),
-     withKey("bias_initializer", "zeros")}));
+    {nntrainer::withKey("unit", 100),
+     nntrainer::withKey("weight_initializer", "xavier_uniform"),
+     nntrainer::withKey("bias_initializer", "zeros")}));
 
-  model->setProperty({withKey("batch_size", 1), withKey("epochs", 1),
-                      withKey("memory_swap", "false"),
-                      withKey("model_tensor_type", "FP32-FP32")});
+  model->setProperty({nntrainer::withKey("batch_size", 1),
+                      nntrainer::withKey("epochs", 1),
+                      nntrainer::withKey("memory_swap", "false"),
+                      nntrainer::withKey("model_tensor_type", "FP32-FP32")});
 
   int status = model->compile(ml::train::ExecutionMode::INFERENCE);
   EXPECT_EQ(status, ML_ERROR_NONE);


### PR DESCRIPTION
The `withKey` function is frequently used to pass keys and values when
using nntrainer. however, this function is re-defined in every
application example and unit test, resulting in significant code
duplication within the project(moreover, it is inconvenient because
users of nntrainer have to define this function every time)

So I removed the duplicated `withKey` functions from each script and
added `withKey` function to utility functions.

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>