### PR TITLE
Add GraphNodeIterator::operator<= required by std::reverse_iterator

### DIFF
--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -194,6 +194,19 @@ public:
   }
 
   /**
+   * @brief <= comparison operator override
+   *
+   * @param lhs iterator lhs
+   * @param rhs iterator rhs
+   * @retval true if left is less than or equal to the right value
+   * @retval false if left is greater than the right value
+   */
+  friend bool operator<=(GraphNodeIterator const &lhs,
+                         GraphNodeIterator const &rhs) {
+    return lhs.p <= rhs.p;
+  }
+
+  /**
    * @brief override for ++ operator
    *
    * @return GraphNodeIterator&


### PR DESCRIPTION
While it is not technically used by normal build its presence is verified during debug standard library build.

More info about debug mode of standard library: https://gcc.gnu.org/onlinedocs/libstdc++/manual/debug_mode.html