### PR TITLE
[Wait for #2951][application] add onnx example

### DIFF
--- a/Applications/ONNX/jni/Android.mk
+++ b/Applications/ONNX/jni/Android.mk
@@ -1,0 +1,60 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+# ndk path
+ifndef ANDROID_NDK
+$(error ANDROID_NDK is not defined!)
+endif
+
+ifndef NNTRAINER_ROOT
+NNTRAINER_ROOT := $(LOCAL_PATH)/../../..
+endif
+
+ML_API_COMMON_INCLUDES := ${NNTRAINER_ROOT}/ml_api_common/include
+NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
+	$(NNTRAINER_ROOT)/nntrainer/dataset \
+	$(NNTRAINER_ROOT)/nntrainer/models \
+	$(NNTRAINER_ROOT)/nntrainer/layers \
+	$(NNTRAINER_ROOT)/nntrainer/compiler \
+	$(NNTRAINER_ROOT)/nntrainer/graph \
+	$(NNTRAINER_ROOT)/nntrainer/optimizers \
+	$(NNTRAINER_ROOT)/nntrainer/tensor \
+	$(NNTRAINER_ROOT)/nntrainer/utils \
+	$(NNTRAINER_ROOT)/nntrainer/converter \
+	$(NNTRAINER_ROOT)/api \
+	$(NNTRAINER_ROOT)/api/ccapi/include \
+	${ML_API_COMMON_INCLUDES}
+
+LOCAL_MODULE := nntrainer
+LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/libs/$(TARGET_ARCH_ABI)/libnntrainer.so
+
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := ccapi-nntrainer
+LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/libs/$(TARGET_ARCH_ABI)/libccapi-nntrainer.so
+
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+
+LOCAL_ARM_NEON := true
+LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib
+LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/$(TARGET_ARCH_ABI)/
+LOCAL_CXXFLAGS += -std=c++17 -frtti
+LOCAL_CFLAGS += -pthread -fexceptions -fopenmp
+LOCAL_LDFLAGS += -fexceptions
+LOCAL_MODULE_TAGS := optional
+LOCAL_ARM_MODE := arm
+LOCAL_MODULE := nntrainer_onnx_example
+LOCAL_LDLIBS := -llog -landroid -fopenmp
+
+LOCAL_SRC_FILES := main.cpp
+
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+
+LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
+
+include $(BUILD_EXECUTABLE)

--- a/Applications/ONNX/jni/Application.mk
+++ b/Applications/ONNX/jni/Application.mk
@@ -1,0 +1,4 @@
+APP_ABI := arm64-v8a
+APP_STL := c++_shared
+APP_PLATFORM := android-29
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true

--- a/Applications/ONNX/jni/add_example.onnx
+++ b/Applications/ONNX/jni/add_example.onnx
@@ -1,0 +1,14 @@
+pytorch2.3.1:{
+ 
+input
+biasoutput/Add"Add
+main_graph*BbiasJBÖ?É‰.¾Z
+input
+
+
+b
+output
+
+
+
+B

--- a/Applications/ONNX/jni/main.cpp
+++ b/Applications/ONNX/jni/main.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Seungbaek Hong <sb92.hong@samsung.com>
+ *
+ * @file   main.cpp
+ * @date   26 Feb 2025
+ * @brief  onnx example using nntrainer-onnx-api
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Seungbaek Hong <sb92.honge@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <iostream>
+#include <layer.h>
+#include <model.h>
+#include <nntrainer-api-common.h>
+#include <optimizer.h>
+#include <util_func.h>
+
+int main() {
+  auto model = ml::train::createModel();
+
+  try {
+    std::string path = "../../../../Applications/ONNX/jni/add_example.onnx";
+    model->load(path, ml::train::ModelFormat::MODEL_FORMAT_ONNX);
+  } catch (const std::exception &e) {
+    std::cerr << "Error during load: " << e.what() << "\n";
+    return 1;
+  }
+
+  try {
+    model->compile();
+  } catch (const std::exception &e) {
+    std::cerr << "Error during compile: " << e.what() << "\n";
+    return 1;
+  }
+
+  try {
+    model->initialize();
+  } catch (const std::exception &e) {
+    std::cerr << "Error during initialize: " << e.what() << "\n";
+    return 1;
+  }
+
+  model->summarize(std::cout, ML_TRAIN_SUMMARY_MODEL);
+
+  return 0;
+}

--- a/Applications/ONNX/jni/meson.build
+++ b/Applications/ONNX/jni/meson.build
@@ -1,0 +1,21 @@
+onnx_example_sources = [
+  'main.cpp',
+]
+
+onnx_example_dependencies = [app_utils_dep,
+  iniparser_dep,
+  nntrainer_dep,
+  nntrainer_ccapi_dep
+]
+
+if get_option('enable-test')
+  onnx_example_dependencies += [gtest_dep]
+endif
+
+e = executable('nntrainer_onnx_example',
+  onnx_example_sources,
+  include_directories: [include_directories('.')],
+  dependencies: onnx_example_dependencies,
+  install: get_option('install-app'),
+  install_dir: application_install_dir
+)

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -33,7 +33,7 @@ subdir('Layers/jni')
 if get_option('enable-tflite-backbone')
   subdir('SimpleShot')
 endif
-
+subdir('ONNX/jni')
 subdir('SimpleFC/jni')
 
 if host_machine.system() != 'windows'

--- a/nntrainer/compiler/onnx_interpreter.h
+++ b/nntrainer/compiler/onnx_interpreter.h
@@ -16,6 +16,7 @@
 
 #include <app_context.h>
 #include <interpreter.h>
+#include <iostream>
 #include <layer.h>
 #include <layer_node.h>
 #include <model.h>


### PR DESCRIPTION
added basic onnx application example.

It loads `add_example.onnx` file and create nntrainer network graph.
(network structure is "input + bias = output")


Output of this example is as below:
```
================================================================================
          Layer name          Layer type    Output dimension         Input layer
================================================================================
               input               input             1:1:1:2
--------------------------------------------------------------------------------
                bias              weight             1:1:1:2
--------------------------------------------------------------------------------
                 add                 add             1:1:1:2               input
                                                                            bias
================================================================================
```
**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>