### PR TITLE
[Bug Fix] Fix static initialization order fiasco

### DIFF
--- a/Applications/Custom/mae_loss.h
+++ b/Applications/Custom/mae_loss.h
@@ -88,7 +88,7 @@ public:
    */
   bool requireLabel() const { return true; }
 
-  inline static const std::string type = "mae_loss";
+  static constexpr const char *type = "mae_loss";
 };
 
 } // namespace custom

--- a/Applications/Custom/momentum.h
+++ b/Applications/Custom/momentum.h
@@ -78,7 +78,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "momentum";
+  static constexpr const char *type = "momentum";
 
 private:
   std::tuple<PropsM> momentum_props; /** momentum for grad */

--- a/Applications/Custom/pow.h
+++ b/Applications/Custom/pow.h
@@ -77,7 +77,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "custom_pow";
+  static constexpr const char *type = "custom_pow";
 
 private:
   float exponent;

--- a/Applications/Custom/rnnt_loss.h
+++ b/Applications/Custom/rnnt_loss.h
@@ -79,7 +79,7 @@ public:
    */
   const std::string getType() const override { return RNNTLossLayer::type; }
 
-  inline static const std::string type = "rnnt_loss";
+  static constexpr const char *type = "rnnt_loss";
 };
 
 } // namespace custom

--- a/Applications/LLaMA/jni/custom_multi_head_attention_layer.h
+++ b/Applications/LLaMA/jni/custom_multi_head_attention_layer.h
@@ -117,7 +117,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "multi_head_attention";
+  static constexpr const char *type = "multi_head_attention";
 
 private:
   std::tuple<props::NumHeads, props::ProjectedKeyDim, props::ProjectedValueDim,

--- a/Applications/LLaMA/jni/rms_norm.h
+++ b/Applications/LLaMA/jni/rms_norm.h
@@ -118,7 +118,7 @@ public:
            std::to_string(values.size());
   };
 
-  inline static const std::string type = "rms_norm";
+  static constexpr const char *type = "rms_norm";
 
 private:
   std::array<unsigned int, 1> wt_idx;

--- a/Applications/LLaMA/jni/rotary_embedding.h
+++ b/Applications/LLaMA/jni/rotary_embedding.h
@@ -86,7 +86,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override{};
 
-  inline static const std::string type = "rotary_embedding";
+  static constexpr const char *type = "rotary_embedding";
 
 private:
   std::vector<std::vector<std::complex<float>>> *freqs_cis;

--- a/Applications/LLaMA/jni/swiglu.h
+++ b/Applications/LLaMA/jni/swiglu.h
@@ -83,7 +83,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override{};
 
-  inline static const std::string type = "swiglu";
+  static constexpr const char *type = "swiglu";
 };
 
 } // namespace custom

--- a/Applications/LLaMA/jni/transpose_layer.h
+++ b/Applications/LLaMA/jni/transpose_layer.h
@@ -76,7 +76,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override{};
 
-  inline static const std::string type = "transpose";
+  static constexpr const char *type = "transpose";
 };
 } // namespace custom
 

--- a/Applications/SimpleShot/layers/centering.h
+++ b/Applications/SimpleShot/layers/centering.h
@@ -96,7 +96,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "centering";
+  static constexpr const char *type = "centering";
 
 private:
   std::string feature_path;

--- a/Applications/YOLOv2/jni/reorg_layer.h
+++ b/Applications/YOLOv2/jni/reorg_layer.h
@@ -75,7 +75,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override{};
 
-  inline static const std::string type = "reorg_layer";
+  static constexpr const char *type = "reorg_layer";
 };
 
 } // namespace custom

--- a/Applications/YOLOv2/jni/yolo_v2_loss.h
+++ b/Applications/YOLOv2/jni/yolo_v2_loss.h
@@ -136,7 +136,7 @@ public:
    */
   const std::string getType() const override { return YoloV2LossLayer::type; };
 
-  inline static const std::string type = "yolo_v2_loss";
+  static constexpr const char *type = "yolo_v2_loss";
 
 private:
   static constexpr unsigned int NUM_ANCHOR = 5;

--- a/Applications/YOLOv3/jni/upsample_layer.h
+++ b/Applications/YOLOv3/jni/upsample_layer.h
@@ -75,7 +75,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override{};
 
-  inline static const std::string type = "upsample";
+  static constexpr const char *type = "upsample";
 };
 
 } // namespace custom

--- a/Applications/YOLOv3/jni/yolo_v3_loss.h
+++ b/Applications/YOLOv3/jni/yolo_v3_loss.h
@@ -149,7 +149,7 @@ public:
    */
   const std::string getType() const override { return YoloV3LossLayer::type; };
 
-  inline static const std::string type = "yolo_v3_loss";
+  static constexpr const char *type = "yolo_v3_loss";
 
 private:
   static constexpr unsigned int NUM_ANCHOR = 3;

--- a/nntrainer/dataset/dir_data_producers.h
+++ b/nntrainer/dataset/dir_data_producers.h
@@ -51,7 +51,7 @@ public:
    */
   ~DirDataProducer();
 
-  inline static const std::string type = "dir";
+  static constexpr const char *type = "dir";
 
   /**
    * @copydoc DataProducer::getType()

--- a/nntrainer/dataset/func_data_producer.h
+++ b/nntrainer/dataset/func_data_producer.h
@@ -47,7 +47,7 @@ public:
    */
   ~FuncDataProducer();
 
-  inline static const std::string type = "callback";
+  static constexpr const char *type = "callback";
 
   /**
    * @copydoc DataProducer::getType()

--- a/nntrainer/dataset/random_data_producers.h
+++ b/nntrainer/dataset/random_data_producers.h
@@ -44,7 +44,7 @@ public:
    */
   ~RandomDataOneHotProducer();
 
-  inline static const std::string type = "random_data_one_hot";
+  static constexpr const char *type = "random_data_one_hot";
 
   /**
    * @copydoc DataProducer::getType()

--- a/nntrainer/dataset/raw_file_data_producer.h
+++ b/nntrainer/dataset/raw_file_data_producer.h
@@ -57,7 +57,7 @@ public:
    */
   ~RawFileDataProducer();
 
-  inline static const std::string type = "file";
+  static constexpr const char *type = "file";
 
   /**
    * @copydoc DataProducer::getType()

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -81,7 +81,7 @@ public:
    */
   bool supportInPlace() const override { return acti_func.supportInPlace(); }
 
-  inline static const std::string type = "activation";
+  static constexpr const char *type = "activation";
 
 private:
   using PropTypes = std::tuple<props::Activation>;

--- a/nntrainer/layers/add_layer.h
+++ b/nntrainer/layers/add_layer.h
@@ -130,7 +130,7 @@ public:
   std::tuple<props::Print, props::InPlaceProp, props::InPlaceDirectionProp>
     add_props;
 
-  inline static const std::string type = "add";
+  static constexpr const char *type = "add";
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -95,7 +95,7 @@ public:
   std::tuple<props::Print>
     add_props; /**< fc layer properties : unit - number of output neurons */
 
-  inline static const std::string type = "addition";
+  static constexpr const char *type = "addition";
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/attention_layer.h
+++ b/nntrainer/layers/attention_layer.h
@@ -99,7 +99,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "attention";
+  static constexpr const char *type = "attention";
 
 protected:
   /**

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -122,7 +122,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "batch_normalization";
+  static constexpr const char *type = "batch_normalization";
 
 private:
   float divider; /**< size of the axes of the reduced */

--- a/nntrainer/layers/centroid_knn.h
+++ b/nntrainer/layers/centroid_knn.h
@@ -91,7 +91,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "centroid_knn";
+  static constexpr const char *type = "centroid_knn";
 
 private:
   std::tuple<props::NumClass> centroid_knn_props;

--- a/nntrainer/layers/cl_layers/addition_layer_cl.h
+++ b/nntrainer/layers/cl_layers/addition_layer_cl.h
@@ -102,7 +102,7 @@ public:
    */
   static bool registerClKernels() { return true; };
 
-  inline static const std::string type = "addition";
+  static constexpr const char *type = "addition";
 
 private:
   std::tuple<props::Print>

--- a/nntrainer/layers/cl_layers/concat_cl.h
+++ b/nntrainer/layers/cl_layers/concat_cl.h
@@ -106,7 +106,7 @@ public:
    */
   static bool registerClKernels();
 
-  inline static const std::string type = "concat";
+  static constexpr const char *type = "concat";
 
   /**
    * @brief Process data and dimensions for concat

--- a/nntrainer/layers/cl_layers/fc_layer_cl.h
+++ b/nntrainer/layers/cl_layers/fc_layer_cl.h
@@ -103,7 +103,7 @@ public:
 
   static bool registerClKernels() { return true; };
 
-  inline static const std::string type = "fully_connected";
+  static constexpr const char *type = "fully_connected";
 
 private:
   std::tuple<props::Unit>

--- a/nntrainer/layers/cl_layers/reshape_cl.h
+++ b/nntrainer/layers/cl_layers/reshape_cl.h
@@ -105,7 +105,7 @@ public:
    */
   const std::string getType() const override { return ReshapeLayerCl::type; };
 
-  inline static const std::string type = "reshape";
+  static constexpr const char *type = "reshape";
 
   /**
    * @brief Process data and dimensions for reshape operation

--- a/nntrainer/layers/cl_layers/rmsnorm_layer_cl.h
+++ b/nntrainer/layers/cl_layers/rmsnorm_layer_cl.h
@@ -130,7 +130,7 @@ public:
    */
   static bool registerClKernels();
 
-  inline static const std::string type = "rmsnorm";
+  static constexpr const char *type = "rmsnorm";
 
 private:
   std::array<unsigned int, 1> wt_idx;

--- a/nntrainer/layers/cl_layers/swiglu_cl.h
+++ b/nntrainer/layers/cl_layers/swiglu_cl.h
@@ -89,7 +89,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "swiglu";
+  static constexpr const char *type = "swiglu";
 
   /**
    * @brief Process data and dimensions for swiglu operation

--- a/nntrainer/layers/cl_layers/transpose_cl.h
+++ b/nntrainer/layers/cl_layers/transpose_cl.h
@@ -91,7 +91,7 @@ public:
    */
   static bool registerClKernels() { return true; };
 
-  inline static const std::string type = "transpose";
+  static constexpr const char *type = "transpose";
 
 private:
   std::tuple<props::Print> transpose_props; /**< transpose layer properties :

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -100,7 +100,7 @@ public:
     setBatch(batch);
   }
 
-  inline static const std::string type = "concat";
+  static constexpr const char *type = "concat";
 
 private:
   unsigned int leading_helper_dim; /**< batch dimension of helper dimension not

--- a/nntrainer/layers/conv1d_layer.h
+++ b/nntrainer/layers/conv1d_layer.h
@@ -96,7 +96,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "conv1d";
+  static constexpr const char *type = "conv1d";
 
 private:
   std::tuple<props::FilterSize, props::KernelSize, props::Stride,

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -106,7 +106,7 @@ public:
   /*   unknown = 3, */
   /* }; */
 
-  inline static const std::string type = "conv2d";
+  static constexpr const char *type = "conv2d";
 
 private:
   std::array<unsigned int, CONV2D_DIM * 2> padding;

--- a/nntrainer/layers/conv2d_transpose_layer.h
+++ b/nntrainer/layers/conv2d_transpose_layer.h
@@ -108,7 +108,7 @@ public:
   /*   unknown = 3, */
   /* }; */
 
-  inline static const std::string type = "conv2dtranspose";
+  static constexpr const char *type = "conv2dtranspose";
 
 private:
   std::array<unsigned int, CONV2D_TRANSPOSE_DIM * 2> padding;

--- a/nntrainer/layers/depthwise_conv2d_layer.h
+++ b/nntrainer/layers/depthwise_conv2d_layer.h
@@ -108,7 +108,7 @@ public:
   /*   unknown = 3, */
   /* }; */
 
-  inline static const std::string type = "depthwiseconv2d";
+  static constexpr const char *type = "depthwiseconv2d";
 
 private:
   std::array<unsigned int, DEPTHWISE_CONV2D_DIM * 2> padding;

--- a/nntrainer/layers/divide_layer.h
+++ b/nntrainer/layers/divide_layer.h
@@ -135,7 +135,7 @@ public:
     divide_props;
   bool support_backwarding; /**< support backwarding */
 
-  inline static const std::string type = "divide";
+  static constexpr const char *type = "divide";
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/dropout.h
+++ b/nntrainer/layers/dropout.h
@@ -87,7 +87,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "dropout";
+  static constexpr const char *type = "dropout";
 
 private:
   std::tuple<props::DropOutRate> dropout_rate;

--- a/nntrainer/layers/embedding.h
+++ b/nntrainer/layers/embedding.h
@@ -101,7 +101,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "embedding";
+  static constexpr const char *type = "embedding";
 
 private:
   std::tuple<props::InDim, props::OutDim> embedding_props;

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -109,7 +109,7 @@ public:
   void setBatch(nntrainer::RunLayerContext &context,
                 unsigned int batch) override;
 
-  inline static const std::string type = "fully_connected";
+  static constexpr const char *type = "fully_connected";
 
 private:
   float lora_scaling;

--- a/nntrainer/layers/flatten_layer.h
+++ b/nntrainer/layers/flatten_layer.h
@@ -71,7 +71,7 @@ public:
    */
   const std::string getType() const override { return FlattenLayer::type; };
 
-  inline static const std::string type = "flatten";
+  static constexpr const char *type = "flatten";
 
   std::tuple<props::StartDimension, props::EndDimension> flatten_props;
 };

--- a/nntrainer/layers/gru.h
+++ b/nntrainer/layers/gru.h
@@ -97,7 +97,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "gru";
+  static constexpr const char *type = "gru";
 
 private:
   static constexpr unsigned int NUM_GATE = 3;

--- a/nntrainer/layers/grucell.h
+++ b/nntrainer/layers/grucell.h
@@ -97,7 +97,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "grucell";
+  static constexpr const char *type = "grucell";
 
 private:
   static constexpr unsigned int NUM_GATE = 3;

--- a/nntrainer/layers/identity_layer.h
+++ b/nntrainer/layers/identity_layer.h
@@ -88,7 +88,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "identity";
+  static constexpr const char *type = "identity";
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -105,7 +105,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "input";
+  static constexpr const char *type = "input";
 
 private:
   std::tuple<props::Normalization, props::Standardization> input_props;

--- a/nntrainer/layers/layer_normalization_layer.h
+++ b/nntrainer/layers/layer_normalization_layer.h
@@ -120,7 +120,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "layer_normalization";
+  static constexpr const char *type = "layer_normalization";
 
 private:
   std::vector<unsigned int> normalize_axes; /**< normalize axes */

--- a/nntrainer/layers/loss/constant_derivative_loss_layer.h
+++ b/nntrainer/layers/loss/constant_derivative_loss_layer.h
@@ -57,7 +57,7 @@ public:
     return ConstantDerivativeLossLayer::type;
   };
 
-  inline static const std::string type = "constant_derivative";
+  static constexpr const char *type = "constant_derivative";
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/loss/cross_entropy_loss_layer.h
+++ b/nntrainer/layers/loss/cross_entropy_loss_layer.h
@@ -67,7 +67,7 @@ public:
     return CrossEntropyLossLayer::type;
   };
 
-  inline static const std::string type = "cross";
+  static constexpr const char *type = "cross";
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/loss/cross_entropy_sigmoid_loss_layer.h
+++ b/nntrainer/layers/loss/cross_entropy_sigmoid_loss_layer.h
@@ -53,7 +53,7 @@ public:
     return CrossEntropySigmoidLossLayer::type;
   };
 
-  inline static const std::string type = "cross_sigmoid";
+  static constexpr const char *type = "cross_sigmoid";
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/loss/cross_entropy_softmax_loss_layer.h
+++ b/nntrainer/layers/loss/cross_entropy_softmax_loss_layer.h
@@ -53,7 +53,7 @@ public:
     return CrossEntropySoftmaxLossLayer::type;
   };
 
-  inline static const std::string type = "cross_softmax";
+  static constexpr const char *type = "cross_softmax";
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/loss/kld_loss_layer.h
+++ b/nntrainer/layers/loss/kld_loss_layer.h
@@ -52,7 +52,7 @@ public:
    */
   const std::string getType() const override { return KLDLossLayer::type; }
 
-  inline static const std::string type = "kld";
+  static constexpr const char *type = "kld";
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/loss/mse_loss_layer.h
+++ b/nntrainer/layers/loss/mse_loss_layer.h
@@ -50,7 +50,7 @@ public:
    */
   const std::string getType() const override { return MSELossLayer::type; };
 
-  inline static const std::string type = "mse";
+  static constexpr const char *type = "mse";
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/lstm.h
+++ b/nntrainer/layers/lstm.h
@@ -97,7 +97,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "lstm";
+  static constexpr const char *type = "lstm";
 
 private:
   static constexpr unsigned int NUM_GATE = 4;

--- a/nntrainer/layers/lstmcell.h
+++ b/nntrainer/layers/lstmcell.h
@@ -85,7 +85,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "lstmcell";
+  static constexpr const char *type = "lstmcell";
 
 private:
   static constexpr unsigned int NUM_GATE = 4;

--- a/nntrainer/layers/mol_attention_layer.h
+++ b/nntrainer/layers/mol_attention_layer.h
@@ -97,7 +97,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "mol_attention";
+  static constexpr const char *type = "mol_attention";
 
 private:
   std::tuple<props::Unit, props::MoL_K>

--- a/nntrainer/layers/multi_head_attention_layer.h
+++ b/nntrainer/layers/multi_head_attention_layer.h
@@ -106,7 +106,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "multi_head_attention";
+  static constexpr const char *type = "multi_head_attention";
 
 private:
   std::tuple<props::NumHeads, props::ProjectedKeyDim, props::ProjectedValueDim,

--- a/nntrainer/layers/multiout_layer.h
+++ b/nntrainer/layers/multiout_layer.h
@@ -99,7 +99,7 @@ public:
    */
   const std::string getType() const override { return MultiOutLayer::type; };
 
-  inline static const std::string type = "multiout";
+  static constexpr const char *type = "multiout";
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/multiply_layer.h
+++ b/nntrainer/layers/multiply_layer.h
@@ -136,7 +136,7 @@ public:
     multiply_props;
   bool support_backwarding; /**< support backwarding */
 
-  inline static const std::string type = "multiply";
+  static constexpr const char *type = "multiply";
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/nnstreamer_layer.h
+++ b/nntrainer/layers/nnstreamer_layer.h
@@ -79,7 +79,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "backbone_nnstreamer";
+  static constexpr const char *type = "backbone_nnstreamer";
 
 private:
   using PropsType = std::tuple<PropsNNSModelPath>;

--- a/nntrainer/layers/permute_layer.h
+++ b/nntrainer/layers/permute_layer.h
@@ -109,7 +109,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "permute";
+  static constexpr const char *type = "permute";
 
 private:
   std::string

--- a/nntrainer/layers/pooling2d_layer.h
+++ b/nntrainer/layers/pooling2d_layer.h
@@ -103,7 +103,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "pooling2d";
+  static constexpr const char *type = "pooling2d";
 
   /**
    * @copydoc Layer::setBatch(RunLayerContext &context, unsigned int batch)

--- a/nntrainer/layers/positional_encoding_layer.h
+++ b/nntrainer/layers/positional_encoding_layer.h
@@ -91,7 +91,7 @@ public:
     return PositionalEncodingLayer::type;
   };
 
-  inline static const std::string type = "positional_encoding";
+  static constexpr const char *type = "positional_encoding";
 
 private:
   bool isPEcalculated; // bool value to check positional encoding is already

--- a/nntrainer/layers/pow_layer.h
+++ b/nntrainer/layers/pow_layer.h
@@ -115,7 +115,7 @@ public:
   std::tuple<props::Print, props::InPlaceProp, props::Exponent> pow_props;
   bool support_backwarding; /**< support backwarding */
 
-  inline static const std::string type = "pow";
+  static constexpr const char *type = "pow";
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/preprocess_flip_layer.h
+++ b/nntrainer/layers/preprocess_flip_layer.h
@@ -89,7 +89,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "preprocess_flip";
+  static constexpr const char *type = "preprocess_flip";
 
 private:
   std::mt19937 rng; /**< random number generator */

--- a/nntrainer/layers/preprocess_l2norm_layer.h
+++ b/nntrainer/layers/preprocess_l2norm_layer.h
@@ -90,7 +90,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "preprocess_l2norm";
+  static constexpr const char *type = "preprocess_l2norm";
 
 private:
   std::tuple<props::Epsilon> l2norm_props;

--- a/nntrainer/layers/preprocess_translate_layer.h
+++ b/nntrainer/layers/preprocess_translate_layer.h
@@ -93,7 +93,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "preprocess_translate";
+  static constexpr const char *type = "preprocess_translate";
 
 private:
   float epsilon;

--- a/nntrainer/layers/reduce_mean_layer.h
+++ b/nntrainer/layers/reduce_mean_layer.h
@@ -88,7 +88,7 @@ public:
    */
   const std::string getType() const override { return ReduceMeanLayer::type; };
 
-  inline static const std::string type = "reduce_mean";
+  static constexpr const char *type = "reduce_mean";
 
 private:
   /** TODO: support scalar multiplier to simulate reduce_sum */

--- a/nntrainer/layers/reshape_layer.h
+++ b/nntrainer/layers/reshape_layer.h
@@ -94,7 +94,7 @@ public:
    */
   const std::string getType() const override { return ReshapeLayer::type; };
 
-  inline static const std::string type = "reshape";
+  static constexpr const char *type = "reshape";
 
 protected:
   std::tuple<props::TargetShape>

--- a/nntrainer/layers/rnn.h
+++ b/nntrainer/layers/rnn.h
@@ -97,7 +97,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "rnn";
+  static constexpr const char *type = "rnn";
 
 private:
   /**

--- a/nntrainer/layers/rnncell.h
+++ b/nntrainer/layers/rnncell.h
@@ -97,7 +97,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "rnncell";
+  static constexpr const char *type = "rnncell";
 
 private:
   enum INOUT_INDEX {

--- a/nntrainer/layers/split_layer.h
+++ b/nntrainer/layers/split_layer.h
@@ -88,7 +88,7 @@ public:
    */
   const std::string getType() const override { return SplitLayer::type; };
 
-  inline static const std::string type = "split";
+  static constexpr const char *type = "split";
 
   /**
    * @copydoc Layer::setBatch(RunLayerContext &context, unsigned int batch)

--- a/nntrainer/layers/subtract_layer.h
+++ b/nntrainer/layers/subtract_layer.h
@@ -131,7 +131,7 @@ public:
   std::tuple<props::Print, props::InPlaceProp, props::InPlaceDirectionProp>
     subtract_props;
 
-  inline static const std::string type = "subtract";
+  static constexpr const char *type = "subtract";
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/tflite_layer.h
+++ b/nntrainer/layers/tflite_layer.h
@@ -77,7 +77,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "backbone_tflite";
+  static constexpr const char *type = "backbone_tflite";
 
 private:
   using PropsType = std::tuple<PropsTflModelPath>;

--- a/nntrainer/layers/time_dist.h
+++ b/nntrainer/layers/time_dist.h
@@ -136,7 +136,7 @@ public:
    */
   const Layer *getDistLayer() const { return dist_layer.get(); };
 
-  inline static const std::string type = "time_dist";
+  static constexpr const char *type = "time_dist";
 
 private:
   /**

--- a/nntrainer/layers/upsample2d_layer.h
+++ b/nntrainer/layers/upsample2d_layer.h
@@ -78,7 +78,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "upsample2d";
+  static constexpr const char *type = "upsample2d";
 
 private:
   std::tuple<props::UpsampleMode, std::array<props::KernelSize, UPSAMPLE2D_DIM>>

--- a/nntrainer/layers/weight_layer.h
+++ b/nntrainer/layers/weight_layer.h
@@ -92,7 +92,7 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  inline static const std::string type = "weight";
+  static constexpr const char *type = "weight";
 
 private:
   std::tuple<props::TensorDimension> weight_props;

--- a/nntrainer/layers/zoneout_lstmcell.h
+++ b/nntrainer/layers/zoneout_lstmcell.h
@@ -165,7 +165,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  inline static const std::string type = "zoneout_lstmcell";
+  static constexpr const char *type = "zoneout_lstmcell";
 
 private:
   static constexpr unsigned int NUM_GATE = 4;

--- a/nntrainer/optimizers/adam.h
+++ b/nntrainer/optimizers/adam.h
@@ -108,7 +108,7 @@ public:
   void exportTo(Exporter &exporter,
                 const ml::train::ExportMethods &method) const override;
 
-  inline static const std::string type = "adam";
+  static constexpr const char *type = "adam";
 
   /**
    * @copydoc Optimizer::setProperty(const std::vector<std::string> &values)

--- a/nntrainer/optimizers/adamw.h
+++ b/nntrainer/optimizers/adamw.h
@@ -70,7 +70,7 @@ public:
   void exportTo(Exporter &exporter,
                 const ml::train::ExportMethods &method) const override;
 
-  inline static const std::string type = "adamw";
+  static constexpr const char *type = "adamw";
 
   /**
    * @copydoc Optimizer::setProperty(const std::vector<std::string> &values)

--- a/nntrainer/optimizers/lr_scheduler_constant.h
+++ b/nntrainer/optimizers/lr_scheduler_constant.h
@@ -69,7 +69,7 @@ public:
     return ConstantLearningRateScheduler::type;
   }
 
-  inline static const std::string type = "constant";
+  static constexpr const char *type = "constant";
 
 private:
   std::tuple<props::LearningRate> lr_props;

--- a/nntrainer/optimizers/lr_scheduler_cosine.h
+++ b/nntrainer/optimizers/lr_scheduler_cosine.h
@@ -67,7 +67,7 @@ public:
     return CosineAnnealingLearningRateScheduler::type;
   }
 
-  inline static const std::string type = "cosine";
+  static constexpr const char *type = "cosine";
 
 private:
   std::tuple<props::MaxLearningRate, props::MinLearningRate, props::DecaySteps>

--- a/nntrainer/optimizers/lr_scheduler_exponential.h
+++ b/nntrainer/optimizers/lr_scheduler_exponential.h
@@ -69,7 +69,7 @@ public:
     return ExponentialLearningRateScheduler::type;
   }
 
-  inline static const std::string type = "exponential";
+  static constexpr const char *type = "exponential";
 
 private:
   std::tuple<props::DecayRate, props::DecaySteps> lr_props;

--- a/nntrainer/optimizers/lr_scheduler_linear.h
+++ b/nntrainer/optimizers/lr_scheduler_linear.h
@@ -64,7 +64,7 @@ public:
     return LinearLearningRateScheduler::type;
   }
 
-  inline static const std::string type = "linear";
+  static constexpr const char *type = "linear";
 
 private:
   std::tuple<props::MaxLearningRate, props::MinLearningRate, props::DecaySteps>

--- a/nntrainer/optimizers/lr_scheduler_step.h
+++ b/nntrainer/optimizers/lr_scheduler_step.h
@@ -74,7 +74,7 @@ public:
     return StepLearningRateScheduler::type;
   }
 
-  inline static const std::string type = "step";
+  static constexpr const char *type = "step";
 
 private:
   std::tuple<std::vector<props::LearningRate>, std::vector<props::Iteration>>

--- a/nntrainer/optimizers/sgd.h
+++ b/nntrainer/optimizers/sgd.h
@@ -54,7 +54,7 @@ public:
     return {};
   }
 
-  inline static const std::string type = "sgd";
+  static constexpr const char *type = "sgd";
 };
 } /* namespace nntrainer */
 

--- a/nntrainer/tensor/basic_planner.h
+++ b/nntrainer/tensor/basic_planner.h
@@ -52,9 +52,9 @@ public:
    * @copydoc MemoryPlanner::getType() const
    *
    */
-  const std::string &getType() const { return type; }
+  const std::string getType() const { return type; }
 
-  inline static const std::string type = "basic_planner";
+  static constexpr const char *type = "basic_planner";
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/memory_planner.h
+++ b/nntrainer/tensor/memory_planner.h
@@ -55,7 +55,7 @@ public:
    *
    * @return The type of the planner
    */
-  virtual const std::string &getType() const = 0;
+  virtual const std::string getType() const = 0;
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/optimized_v1_planner.h
+++ b/nntrainer/tensor/optimized_v1_planner.h
@@ -67,9 +67,9 @@ public:
    * @copydoc MemoryPlanner::getType() const
    *
    */
-  const std::string &getType() const { return type; }
+  const std::string getType() const { return type; }
 
-  inline static const std::string type = "optimized_v1_planner";
+  static constexpr const char *type = "optimized_v1_planner";
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/optimized_v2_planner.h
+++ b/nntrainer/tensor/optimized_v2_planner.h
@@ -68,9 +68,9 @@ public:
    * @copydoc MemoryPlanner::getType() const
    *
    */
-  const std::string &getType() const { return type; }
+  const std::string getType() const { return type; }
 
-  inline static const std::string type = "optimized_v2_planner";
+  static constexpr const char *type = "optimized_v2_planner";
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/optimized_v3_planner.h
+++ b/nntrainer/tensor/optimized_v3_planner.h
@@ -54,9 +54,9 @@ public:
    * @copydoc MemoryPlanner::getType() const
    *
    */
-  const std::string &getType() const { return type; }
+  const std::string getType() const { return type; }
 
-  inline static const std::string type = "optimized_v3_planner";
+  static constexpr const char *type = "optimized_v3_planner";
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/var_grad.h
+++ b/nntrainer/tensor/var_grad.h
@@ -310,7 +310,7 @@ public:
    */
   float getGradientNorm() const { return grad->l2norm(); }
 
-  inline static const std::string grad_suffix = ":grad";
+  static constexpr const char *grad_suffix = ":grad";
 
 protected:
   bool is_dependent; /**< check if the weight tensor is burrowed from somewhere

--- a/test/unittest/layers/unittest_layers_impl.cpp
+++ b/test/unittest/layers/unittest_layers_impl.cpp
@@ -29,7 +29,7 @@ class MockLayer final : public LayerImpl {
 public:
   ~MockLayer() = default;
 
-  inline static const std::string type = "mock_";
+  static constexpr const char *type = "mock_";
   const std::string getType() const override { return type; }
   void finalize(InitLayerContext &context) override {
     context.setOutputDimensions(context.getInputDimensions());

--- a/test/unittest/unittest_nntrainer_appcontext.cpp
+++ b/test/unittest/unittest_nntrainer_appcontext.cpp
@@ -141,7 +141,7 @@ public:
  */
 class CustomLayer : public nntrainer::Layer {
 public:
-  inline static const std::string type = "identity_layer";
+  static constexpr const char *type = "identity_layer";
 
   void setProperty(const std::vector<std::string> &values) override {}
 


### PR DESCRIPTION
Execution of static object constructors are undefined across multiple compilation units which result in random failing of unit tests (especially visible on windows). This PR replace using of:
inline static const std::string
with
static constexpr const char *
which fix std::string constructor order randomness

see https://en.cppreference.com/w/cpp/language/siof

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped