### PR TITLE
[meson] Use nproc for number of cores

### DIFF
--- a/jni/meson.build
+++ b/jni/meson.build
@@ -81,7 +81,7 @@ ndk_build = find_program('ndk-build', required : true)
 ndk_args = {
   'NDK_LIBS_OUT': meson.current_build_dir(),
 }
-num_threads = run_command('grep', '-c', '^processor', '/proc/cpuinfo').stdout().strip()
+num_threads = run_command(nproc_prog).stdout().strip()
 message('num processor are: ' + num_threads)
 
 thread_opt_flag = '-j' + num_threads

--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,10 @@ extra_defines = ['-DMIN_CPP_VERSION=201703L']
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')
 
+# Obtains number of cores
+nproc_prog = find_program('nproc',
+                          required: (get_option('platform') == 'android') and (build_machine.system() != 'windows'))
+
 if get_option('platform') == 'tizen'
   # Pass __TIZEN__ to the compiler
   add_project_arguments('-D__TIZEN__=1', language:['c','cpp'])

--- a/test/jni/meson.build
+++ b/test/jni/meson.build
@@ -73,7 +73,7 @@ ndk_build = find_program('ndk-build', required : true)
 ndk_args = {
   'NDK_LIBS_OUT': meson.current_build_dir(),
 }
-num_threads = run_command('grep', '-c', '^processor', '/proc/cpuinfo').stdout().strip()
+num_threads = run_command(nproc_prog).stdout().strip()
 message('num processor are: ' + num_threads)
 
 thread_opt_flag = '-j' + num_threads


### PR DESCRIPTION
Both grep and nproc are part of coreutils.
One can obtain number of cores/threads directly using this command.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
Not applicable, it is sufficient it builds.

