### PR TITLE
Meson option build fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -583,7 +583,7 @@ if get_option('enable-app')
   endif
 endif
 
-if get_option('platform') != 'android' and host_machine.system() != 'windows'
+if get_option('platform') != 'android' and host_machine.system() != 'windows' and get_option('enable-nnstreamer-backbone')
   nnstreamer_dep = dependency('nnstreamer')
   message('building nnstreamer')
   subdir('nnstreamer')

--- a/test/unittest/compiler/meson.build
+++ b/test/unittest/compiler/meson.build
@@ -24,6 +24,7 @@ exe = executable(
   install_dir: application_install_dir
 )
 
+
 test(test_name, exe,
   args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), test_name),
   timeout: test_timeout

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -104,4 +104,6 @@ subdir('compiler')
 subdir('layers')
 subdir('datasets')
 subdir('models')
-subdir('integration_tests')
+if get_option('enable-tflite-interpreter')
+  subdir('integration_tests')
+endif


### PR DESCRIPTION
Misc fixes for some of the options disabled by configuration options.
This is step in direction of fixing builds with various configuration options configurations.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

meson setup <builddir> --native-file=disables.ini

`disables.ini` with contents:
```
[project options]

enable-blas=false 
enable-tflite-backbone=false 
enable-memory-swap=false 
enable-nnstreamer-backbone=false 
enable-tflite-interpreter=false 
enable-app=false 
ml-api-support='disabled'
enable-test=true
werror=false
```