### PR TITLE
[FSU] Inference FSU with Shared memory

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -382,7 +382,8 @@ sharedConstTensors NetworkGraph::forwarding(
   for (unsigned int i = 0; i < graph.getNumOutputNodes(); ++i) {
     auto const &output_layer_node = LNODE(graph.getOutputNode(i));
     for (unsigned int j = 0; j < output_layer_node->getNumOutputs(); ++j) {
-      out.push_back(MAKE_SHARED_TENSOR(output_layer_node->getOutput(j)));
+      // @todo we should determine what type to return
+      out.push_back(MAKE_SHARED_TENSOR(output_layer_node->getOutput(j).clone(TensorDim::DataType::FP32)));
     }
   }
 

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -12,12 +12,6 @@
  * @todo    Support multi-input graph.
  */
 
-#include "graph_node.h"
-#include "tensor.h"
-#include <cmath>
-#include <stdexcept>
-#include <string>
-
 #include <activation_layer.h>
 #include <addition_layer.h>
 #include <bn_layer.h>
@@ -30,7 +24,6 @@
 #include <grucell.h>
 #include <identity_layer.h>
 #include <input_layer.h>
-#include <iostream>
 #include <layer_node.h>
 #include <layer_normalization_layer.h>
 #include <lstmcell.h>
@@ -46,10 +39,17 @@
 #include <tracer.h>
 #include <util_func.h>
 
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "graph_node.h"
+#include "tensor.h"
+
 #define LNODE(x) std::static_pointer_cast<LayerNode>(x)
 
 namespace nntrainer {
-
 int NetworkGraph::compile(const std::string &loss_type) {
   int status = ML_ERROR_NONE;
 
@@ -77,8 +77,8 @@ int NetworkGraph::compile(const std::string &loss_type) {
     }
   } else {
     if (!loss_type.empty()) {
-      ml_loge(
-        "Warning : Loss type is given in inference mode. Ignoring loss type.");
+      ml_loge("Warning : Loss type is given in inference mode. Ignoring loss "
+              "type.");
     }
   }
 
@@ -253,7 +253,7 @@ void NetworkGraph::markNodesForBackwarding() {
     auto lnode = (*iter);
     if (lnode->getTrainable() ||
         must_support_backwarding.find(lnode->getName()) !=
-        must_support_backwarding.end()) {
+          must_support_backwarding.end()) {
       if (lnode->getTrainable()) {
         lnode->needsCalcGradient(true);
       }
@@ -330,7 +330,6 @@ void NetworkGraph::setBatchSize(unsigned int batch_size) {
 
 void NetworkGraph::applyGradients(
   LayerNode *node, const std::function<void(Weight &)> &apply_func) {
-
   if (!node->getTrainable())
     return;
 
@@ -570,11 +569,11 @@ LayerNode *NetworkGraph::computeBackwardEnd() {
 void NetworkGraph::allocateTensors(ExecutionMode exec_mode_) {
   exec_mode = exec_mode_;
   if (exec_mode == ExecutionMode::INFERENCE)
-  /**
-   * get the order of execution/usage order for the forwarding of the last
-   * layer and pass that as the max_exec_order ensuring that all tensors
-   * with usage less than the max_exec_order are allocated.
-   */
+    /**
+     * get the order of execution/usage order for the forwarding of the last
+     * layer and pass that as the max_exec_order ensuring that all tensors
+     * with usage less than the max_exec_order are allocated.
+     */
     tensor_manager->allocateTensors(
       std::get<0>((*(cend() - 1))->getExecutionOrder()));
   else {
@@ -607,7 +606,7 @@ std::vector<TensorDim> NetworkGraph::getOutputDimension() const {
   return label_dims;
 }
 
-std::vector<std::shared_ptr<LayerNode> >
+std::vector<std::shared_ptr<LayerNode>>
 NetworkGraph::getUnsortedLayers(const std::string &input_layer,
                                 const std::string &output_layer) const {
   /// @fixme: this won't work if input, output layers are not in order
@@ -641,7 +640,7 @@ NetworkGraph::getUnsortedLayers(const std::string &input_layer,
   }
 
   /** copy the graph and return */
-  std::vector<std::shared_ptr<LayerNode> > ret;
+  std::vector<std::shared_ptr<LayerNode>> ret;
   std::transform(graph.cbegin() + num_layers_remove_start,
                  graph.cend() - num_layers_remove_end, std::back_inserter(ret),
                  [](auto const &elem) { return LNODE(elem); });
@@ -649,8 +648,8 @@ NetworkGraph::getUnsortedLayers(const std::string &input_layer,
   return ret;
 }
 
-std::vector<std::shared_ptr<LayerNode> > NetworkGraph::getLayerNodes() const {
-  return std::vector<std::shared_ptr<LayerNode> >(cbegin(), cend());
+std::vector<std::shared_ptr<LayerNode>> NetworkGraph::getLayerNodes() const {
+  return std::vector<std::shared_ptr<LayerNode>>(cbegin(), cend());
 }
 
 void NetworkGraph::addLayer(std::shared_ptr<LayerNode> layer) {
@@ -759,9 +758,9 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
    */
   std::vector<std::string> input_names;
   input_names.reserve(prev_inputs.size());
-  std::transform(prev_inputs.begin(), prev_inputs.end(),
-                 std::back_inserter(input_names),
-                 [](auto const &vg) -> const auto &{ return vg->getName(); });
+  std::transform(
+    prev_inputs.begin(), prev_inputs.end(), std::back_inserter(input_names),
+    [](auto const &vg) -> const auto & { return vg->getName(); });
   const std::vector<Var_Grad *> &inputs = tensor_manager->requestInputs(
     gnode, init_context.getInputDimensions(), input_names);
 
@@ -926,9 +925,9 @@ NetworkGraph::refinalizeContext(const std::shared_ptr<LayerNode> &lnode,
    */
   std::vector<std::string> input_names;
   input_names.reserve(prev_inputs.size());
-  std::transform(prev_inputs.begin(), prev_inputs.end(),
-                 std::back_inserter(input_names),
-                 [](auto const &vg) -> const auto &{ return vg->getName(); });
+  std::transform(
+    prev_inputs.begin(), prev_inputs.end(), std::back_inserter(input_names),
+    [](auto const &vg) -> const auto & { return vg->getName(); });
   const std::vector<Var_Grad *> &inputs = tensor_manager->requestInputs(
     gnode, init_context.getInputDimensions(), input_names);
 
@@ -1066,14 +1065,14 @@ NetworkGraph::refinalizeContext(const std::shared_ptr<LayerNode> &lnode,
 
 #ifdef ENABLE_TEST
 
-std::map<std::string, std::vector<unsigned int> >
+std::map<std::string, std::vector<unsigned int>>
 NetworkGraph::getLayerExecutionOrders(const std::shared_ptr<LayerNode> &lnode) {
   const auto &init_context = lnode->getInitContext();
   auto out_specs = init_context.getOutSpecs();
   auto weight_specs = init_context.getWeightsSpec();
   auto tensor_specs = init_context.getTensorsSpec();
 
-  std::map<std::string, std::vector<unsigned int> > exec_orders;
+  std::map<std::string, std::vector<unsigned int>> exec_orders;
 
   for (auto &spec : out_specs) {
     const auto &name = lnode->getName() + ":" + spec.variable_spec.name;
@@ -1125,14 +1124,13 @@ NetworkGraph::getLayerExecutionOrders(const std::shared_ptr<LayerNode> &lnode) {
 int NetworkGraph::initialize(ExecutionMode mode,
                              const std::vector<Connection> &model_input_names,
                              const std::vector<Connection> &model_label_names) {
-
   exec_mode = mode;
   tensor_manager->setExecutionMode(mode);
   /**
    * this contains the map from node name to its input tensor names
    * @note: these input tensors have already been allocated
    */
-  std::unordered_map<std::string, std::vector<Var_Grad *> > input_map;
+  std::unordered_map<std::string, std::vector<Var_Grad *>> input_map;
 
   /** check if the given config of node is of input node */
   auto is_input_node = [](const LayerNode *node) -> bool {
@@ -1182,7 +1180,7 @@ int NetworkGraph::initialize(ExecutionMode mode,
         input_map.try_emplace({sink_node->getName(), {}});
 
       NNTR_THROW_IF(sink_node->getInputConnectionName(conn->getIndex()) !=
-                    lnode->getName(),
+                      lnode->getName(),
                     std::invalid_argument)
         << "node pair does not match between " << lnode->getName() << ' '
         << sink_node->getName();
@@ -1203,8 +1201,8 @@ int NetworkGraph::initialize(ExecutionMode mode,
         /// @todo this is duck taping that MUST BE REMOVED. We will need to
         /// have, is weight first access kind of concept.
         if (tensor_manager->isFirstAccess(
-          rc.getWeight(i).getName(),
-          std::get<0>(lnode->getExecutionOrder()), true)) {
+              rc.getWeight(i).getName(),
+              std::get<0>(lnode->getExecutionOrder()), true)) {
           rc.getWeightObject(i).setAsGradientFirstAccess();
         }
         if (tensor_manager->isLastAccess(rc.getWeight(i).getName(),
@@ -1344,7 +1342,7 @@ int NetworkGraph::reinitialize(
    * this contains the map from node name to its input tensor names
    * @note: these input tensors have already been allocated
    */
-  std::unordered_map<std::string, std::vector<Var_Grad *> > input_map;
+  std::unordered_map<std::string, std::vector<Var_Grad *>> input_map;
 
   /** check if the given config of node is of input node */
   auto is_input_node = [](const LayerNode *node) -> bool {
@@ -1395,7 +1393,7 @@ int NetworkGraph::reinitialize(
         input_map.try_emplace({sink_node->getName(), {}});
 
       NNTR_THROW_IF(sink_node->getInputConnectionName(conn->getIndex()) !=
-                    lnode->getName(),
+                      lnode->getName(),
                     std::invalid_argument)
         << "node pair does not match between " << lnode->getName() << ' '
         << sink_node->getName();
@@ -1416,8 +1414,8 @@ int NetworkGraph::reinitialize(
         /// @todo this is duck taping that MUST BE REMOVED. We will need to
         /// have, is weight first access kind of concept.
         if (tensor_manager->isFirstAccess(
-          rc.getWeight(i).getName(),
-          std::get<0>(lnode->getExecutionOrder()), true)) {
+              rc.getWeight(i).getName(),
+              std::get<0>(lnode->getExecutionOrder()), true)) {
           rc.getWeightObject(i).setAsGradientFirstAccess();
         }
         if (tensor_manager->isLastAccess(rc.getWeight(i).getName(),
@@ -1523,7 +1521,6 @@ int NetworkGraph::reinitialize(
 
 void NetworkGraph::setExternalTensors(const std::vector<Tensor> &data,
                                       const std::vector<std::string> names) {
-
   /// feed or clear label
   for (unsigned int idx = 0; idx < names.size(); idx++) {
     if (data.empty())
@@ -1537,7 +1534,6 @@ void NetworkGraph::setExternalTensors(const std::vector<Tensor> &data,
 
 void NetworkGraph::setInputsLabels(const std::vector<Tensor> &inputs,
                                    const std::vector<Tensor> &labels) {
-
   NNTR_THROW_IF(labels.size() > 1 && labels.size() != label_list.size(),
                 std::invalid_argument)
     << "label size does not match with the network requirements"
@@ -1556,14 +1552,15 @@ void NetworkGraph::setInputsLabels(const std::vector<Tensor> &inputs,
 
 void NetworkGraph::setInputsLabels(sharedConstTensors &inputs,
                                    sharedConstTensors &labels) {
-
   std::vector<Tensor> ins;
-  std::transform(inputs.begin(), inputs.end(), std::back_inserter(ins),
-                 [](auto const &val) -> const auto &{ return *val.get(); });
+  std::transform(
+    inputs.begin(), inputs.end(), std::back_inserter(ins),
+    [](auto const &val) -> const auto & { return *val.get(); });
 
   std::vector<Tensor> labs;
-  std::transform(labels.begin(), labels.end(), std::back_inserter(labs),
-                 [](auto const &val) -> const auto &{ return *val.get(); });
+  std::transform(
+    labels.begin(), labels.end(), std::back_inserter(labs),
+    [](auto const &val) -> const auto & { return *val.get(); });
 
   setInputsLabels(ins, labs);
 }

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -253,7 +253,7 @@ void NetworkGraph::markNodesForBackwarding() {
     auto lnode = (*iter);
     if (lnode->getTrainable() ||
         must_support_backwarding.find(lnode->getName()) !=
-          must_support_backwarding.end()) {
+        must_support_backwarding.end()) {
       if (lnode->getTrainable()) {
         lnode->needsCalcGradient(true);
       }
@@ -570,11 +570,11 @@ LayerNode *NetworkGraph::computeBackwardEnd() {
 void NetworkGraph::allocateTensors(ExecutionMode exec_mode_) {
   exec_mode = exec_mode_;
   if (exec_mode == ExecutionMode::INFERENCE)
-    /**
-     * get the order of execution/usage order for the forwarding of the last
-     * layer and pass that as the max_exec_order ensuring that all tensors
-     * with usage less than the max_exec_order are allocated.
-     */
+  /**
+   * get the order of execution/usage order for the forwarding of the last
+   * layer and pass that as the max_exec_order ensuring that all tensors
+   * with usage less than the max_exec_order are allocated.
+   */
     tensor_manager->allocateTensors(
       std::get<0>((*(cend() - 1))->getExecutionOrder()));
   else {
@@ -607,7 +607,7 @@ std::vector<TensorDim> NetworkGraph::getOutputDimension() const {
   return label_dims;
 }
 
-std::vector<std::shared_ptr<LayerNode>>
+std::vector<std::shared_ptr<LayerNode> >
 NetworkGraph::getUnsortedLayers(const std::string &input_layer,
                                 const std::string &output_layer) const {
   /// @fixme: this won't work if input, output layers are not in order
@@ -641,7 +641,7 @@ NetworkGraph::getUnsortedLayers(const std::string &input_layer,
   }
 
   /** copy the graph and return */
-  std::vector<std::shared_ptr<LayerNode>> ret;
+  std::vector<std::shared_ptr<LayerNode> > ret;
   std::transform(graph.cbegin() + num_layers_remove_start,
                  graph.cend() - num_layers_remove_end, std::back_inserter(ret),
                  [](auto const &elem) { return LNODE(elem); });
@@ -649,8 +649,8 @@ NetworkGraph::getUnsortedLayers(const std::string &input_layer,
   return ret;
 }
 
-std::vector<std::shared_ptr<LayerNode>> NetworkGraph::getLayerNodes() const {
-  return std::vector<std::shared_ptr<LayerNode>>(cbegin(), cend());
+std::vector<std::shared_ptr<LayerNode> > NetworkGraph::getLayerNodes() const {
+  return std::vector<std::shared_ptr<LayerNode> >(cbegin(), cend());
 }
 
 void NetworkGraph::addLayer(std::shared_ptr<LayerNode> layer) {
@@ -692,7 +692,8 @@ NetworkGraph::canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode) {
   }
   /** A case where it cannot operate in-place if there is a multi-out type
    * input connection. */
-  else { /** condition: NON_RESTRICTING */
+  else {
+    /** condition: NON_RESTRICTING */
     for (size_t i = 0, num_node = lnode->getNumInputConnections(); i < num_node;
          ++i) {
       const std::string &input_name = lnode->getInputConnectionName(i);
@@ -758,9 +759,9 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
    */
   std::vector<std::string> input_names;
   input_names.reserve(prev_inputs.size());
-  std::transform(
-    prev_inputs.begin(), prev_inputs.end(), std::back_inserter(input_names),
-    [](auto const &vg) -> const auto & { return vg->getName(); });
+  std::transform(prev_inputs.begin(), prev_inputs.end(),
+                 std::back_inserter(input_names),
+                 [](auto const &vg) -> const auto &{ return vg->getName(); });
   const std::vector<Var_Grad *> &inputs = tensor_manager->requestInputs(
     gnode, init_context.getInputDimensions(), input_names);
 
@@ -925,9 +926,9 @@ NetworkGraph::refinalizeContext(const std::shared_ptr<LayerNode> &lnode,
    */
   std::vector<std::string> input_names;
   input_names.reserve(prev_inputs.size());
-  std::transform(
-    prev_inputs.begin(), prev_inputs.end(), std::back_inserter(input_names),
-    [](auto const &vg) -> const auto & { return vg->getName(); });
+  std::transform(prev_inputs.begin(), prev_inputs.end(),
+                 std::back_inserter(input_names),
+                 [](auto const &vg) -> const auto &{ return vg->getName(); });
   const std::vector<Var_Grad *> &inputs = tensor_manager->requestInputs(
     gnode, init_context.getInputDimensions(), input_names);
 
@@ -1065,14 +1066,14 @@ NetworkGraph::refinalizeContext(const std::shared_ptr<LayerNode> &lnode,
 
 #ifdef ENABLE_TEST
 
-std::map<std::string, std::vector<unsigned int>>
+std::map<std::string, std::vector<unsigned int> >
 NetworkGraph::getLayerExecutionOrders(const std::shared_ptr<LayerNode> &lnode) {
   const auto &init_context = lnode->getInitContext();
   auto out_specs = init_context.getOutSpecs();
   auto weight_specs = init_context.getWeightsSpec();
   auto tensor_specs = init_context.getTensorsSpec();
 
-  std::map<std::string, std::vector<unsigned int>> exec_orders;
+  std::map<std::string, std::vector<unsigned int> > exec_orders;
 
   for (auto &spec : out_specs) {
     const auto &name = lnode->getName() + ":" + spec.variable_spec.name;
@@ -1131,7 +1132,7 @@ int NetworkGraph::initialize(ExecutionMode mode,
    * this contains the map from node name to its input tensor names
    * @note: these input tensors have already been allocated
    */
-  std::unordered_map<std::string, std::vector<Var_Grad *>> input_map;
+  std::unordered_map<std::string, std::vector<Var_Grad *> > input_map;
 
   /** check if the given config of node is of input node */
   auto is_input_node = [](const LayerNode *node) -> bool {
@@ -1181,7 +1182,7 @@ int NetworkGraph::initialize(ExecutionMode mode,
         input_map.try_emplace({sink_node->getName(), {}});
 
       NNTR_THROW_IF(sink_node->getInputConnectionName(conn->getIndex()) !=
-                      lnode->getName(),
+                    lnode->getName(),
                     std::invalid_argument)
         << "node pair does not match between " << lnode->getName() << ' '
         << sink_node->getName();
@@ -1202,8 +1203,8 @@ int NetworkGraph::initialize(ExecutionMode mode,
         /// @todo this is duck taping that MUST BE REMOVED. We will need to
         /// have, is weight first access kind of concept.
         if (tensor_manager->isFirstAccess(
-              rc.getWeight(i).getName(),
-              std::get<0>(lnode->getExecutionOrder()), true)) {
+          rc.getWeight(i).getName(),
+          std::get<0>(lnode->getExecutionOrder()), true)) {
           rc.getWeightObject(i).setAsGradientFirstAccess();
         }
         if (tensor_manager->isLastAccess(rc.getWeight(i).getName(),
@@ -1343,7 +1344,7 @@ int NetworkGraph::reinitialize(
    * this contains the map from node name to its input tensor names
    * @note: these input tensors have already been allocated
    */
-  std::unordered_map<std::string, std::vector<Var_Grad *>> input_map;
+  std::unordered_map<std::string, std::vector<Var_Grad *> > input_map;
 
   /** check if the given config of node is of input node */
   auto is_input_node = [](const LayerNode *node) -> bool {
@@ -1394,7 +1395,7 @@ int NetworkGraph::reinitialize(
         input_map.try_emplace({sink_node->getName(), {}});
 
       NNTR_THROW_IF(sink_node->getInputConnectionName(conn->getIndex()) !=
-                      lnode->getName(),
+                    lnode->getName(),
                     std::invalid_argument)
         << "node pair does not match between " << lnode->getName() << ' '
         << sink_node->getName();
@@ -1415,8 +1416,8 @@ int NetworkGraph::reinitialize(
         /// @todo this is duck taping that MUST BE REMOVED. We will need to
         /// have, is weight first access kind of concept.
         if (tensor_manager->isFirstAccess(
-              rc.getWeight(i).getName(),
-              std::get<0>(lnode->getExecutionOrder()), true)) {
+          rc.getWeight(i).getName(),
+          std::get<0>(lnode->getExecutionOrder()), true)) {
           rc.getWeightObject(i).setAsGradientFirstAccess();
         }
         if (tensor_manager->isLastAccess(rc.getWeight(i).getName(),
@@ -1557,14 +1558,12 @@ void NetworkGraph::setInputsLabels(sharedConstTensors &inputs,
                                    sharedConstTensors &labels) {
 
   std::vector<Tensor> ins;
-  std::transform(
-    inputs.begin(), inputs.end(), std::back_inserter(ins),
-    [](auto const &val) -> const auto & { return *val.get(); });
+  std::transform(inputs.begin(), inputs.end(), std::back_inserter(ins),
+                 [](auto const &val) -> const auto &{ return *val.get(); });
 
   std::vector<Tensor> labs;
-  std::transform(
-    labels.begin(), labels.end(), std::back_inserter(labs),
-    [](auto const &val) -> const auto & { return *val.get(); });
+  std::transform(labels.begin(), labels.end(), std::back_inserter(labs),
+                 [](auto const &val) -> const auto &{ return *val.get(); });
 
   setInputsLabels(ins, labs);
 }

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -383,7 +383,8 @@ sharedConstTensors NetworkGraph::forwarding(
     auto const &output_layer_node = LNODE(graph.getOutputNode(i));
     for (unsigned int j = 0; j < output_layer_node->getNumOutputs(); ++j) {
       // @todo we should determine what type to return
-      out.push_back(MAKE_SHARED_TENSOR(output_layer_node->getOutput(j).clone(TensorDim::DataType::FP32)));
+      // out.push_back(MAKE_SHARED_TENSOR(output_layer_node->getOutput(j).clone(TensorDim::DataType::FP32)));
+      out.push_back(MAKE_SHARED_TENSOR(output_layer_node->getOutput(j)));
     }
   }
 

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -534,7 +534,7 @@ public:
    *
    * @param offsets weight file offset
    */
-  void setWeightOffset(std::vector<std::pair<size_t,size_t>> offsets) {
+  void setWeightOffset(std::vector<std::pair<size_t, size_t>> offsets) {
     tensor_manager->setWeightOffset(offsets);
   }
 

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -520,6 +520,24 @@ public:
    */
   unsigned int getNumLoadedTensorPoolTensors();
 
+  /**
+   * @brief set FSU weight path
+   *
+   * @param path FSU weight file path
+   */
+  void setFsuWeightPath(std::string path) {
+    tensor_manager->setFsuWeightPath(path);
+  }
+
+  /**
+   * @brief set weight file offset for FSU loading
+   *
+   * @param offsets weight file offset
+   */
+  void setWeightOffset(std::vector<std::pair<size_t,size_t>> offsets) {
+    tensor_manager->setWeightOffset(offsets);
+  }
+
 private:
   std::map<std::string, std::string> sub_in_out; /** This is map to identify
                    input and output layer name of subgraph */

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -679,10 +679,12 @@ void NeuralNetwork::load(const std::string &file_path,
         }
       }
 
-      checkedRead(model_file, (char *)&epoch_idx, sizeof(epoch_idx),
-                  "[NeuralNetwork::readModel] failed to read epoch_idx");
-      checkedRead(model_file, (char *)&iter, sizeof(iter),
-                  "[NeuralNetwork::readModel] failed to read iteration");
+      if (!swap_mode) {
+        checkedRead(model_file, (char *)&epoch_idx, sizeof(epoch_idx),
+                    "[NeuralNetwork::readModel] failed to read epoch_idx");
+        checkedRead(model_file, (char *)&iter, sizeof(iter),
+                    "[NeuralNetwork::readModel] failed to read iteration");
+      }
     } catch (...) {
       std::cerr << "failed to read additional data like optimizer variable, "
                    "iteration, proceeding with default\n";

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -638,13 +638,14 @@ void NeuralNetwork::load(const std::string &file_path,
   if (exec_mode == ExecutionMode::INFERENCE && swap_mode) {
     model_graph.setFsuWeightPath(file_path);
 
-    std::vector<std::pair<size_t,size_t>> file_offset;
+    std::vector<std::pair<size_t, size_t>> file_offset;
     size_t start_from = 0;
     for (auto node : model_graph.getLayerNodes()) {
       auto weights = node->getRunContext().getWeights();
       for (auto weight : weights) {
         auto dim = weight->getDim();
-        size_t size = dim.getDataTypeSize() * dim.getDataLen(); // + scale_size * float
+        size_t size =
+          dim.getDataTypeSize() * dim.getDataLen(); // + scale_size * float
         file_offset.emplace_back(std::make_pair(start_from, size));
         start_from += size;
       }

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -592,7 +592,7 @@ void NeuralNetwork::save(const std::string &file_path,
     auto model_file = checkedOpenStream<std::ofstream>(
       file_path, std::ios::out | std::ios::binary | std::ios::trunc);
     for (auto iter = model_graph.cbegin(); iter != model_graph.cend(); iter++) {
-      (*iter)->save(model_file);
+      (*iter)->save(model_file, false, exec_mode);
     }
     if (opt && istrequal(opt->getType(), "adam")) {
       std::string adam = "adam";
@@ -635,6 +635,23 @@ void NeuralNetwork::load(const std::string &file_path,
   /// @todo this switch case should be delegating the function call only. It's
   /// not delegating for now as required logics are manageable for now.
   bool swap_mode = std::get<props::MemorySwap>(model_flex_props);
+  if (exec_mode == ExecutionMode::INFERENCE && swap_mode) {
+    model_graph.setFsuWeightPath(file_path);
+
+    std::vector<std::pair<size_t,size_t>> file_offset;
+    size_t start_from = 0;
+    for (auto node : model_graph.getLayerNodes()) {
+      auto weights = node->getRunContext().getWeights();
+      for (auto weight : weights) {
+        auto dim = weight->getDim();
+        size_t size = dim.getDataTypeSize() * dim.getDataLen(); // + scale_size * float
+        file_offset.emplace_back(std::make_pair(start_from, size));
+        start_from += size;
+      }
+    }
+    model_graph.setWeightOffset(file_offset);
+  }
+
   switch (format) {
   case ml::train::ModelFormat::MODEL_FORMAT_BIN: {
     NNTR_THROW_IF(!initialized, std::runtime_error)

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -388,19 +388,9 @@ sharedConstTensors NeuralNetwork::forwarding(
                the forwarding, ask load tensors for next n layers.
       **/
 
-      unsigned int lookahead =
-        std::get<props::MemorySwapLookahead>(model_flex_props);
-
-      if (!((model_graph.getNumLoadedWeightPoolTensors() + 1) / 2 <
-            lookahead + 1)) {
-        model_graph.checkUnloadComplete(f - 1);
-      }
-      model_graph.LoadTensors(
-        f, lookahead - (model_graph.getNumLoadedWeightPoolTensors() + 1) / 2);
-
+      model_graph.LoadTensors(f);
       model_graph.checkLoadComplete(f);
       node->forwarding(training);
-      model_graph.UnloadTensors(f);
     }
   };
 

--- a/nntrainer/tensor/cache_elem.cpp
+++ b/nntrainer/tensor/cache_elem.cpp
@@ -54,7 +54,7 @@ void CacheElem::swapIn(Options opt) {
 
   opt = static_cast<Options>(opt | initial_opt);
   bool alloc_only = checkAllocOnly(policy, opt);
-  void *buf = device->getBuffer(offset, length, alloc_only);
+  void *buf = device->getBuffer(offset, length, memory_ptr, alloc_only);
 
   initial_opt = static_cast<Options>(initial_opt & ~Options::FIRST_ACCESS);
   mem_data->setAddr((void *)buf);

--- a/nntrainer/tensor/cache_elem.cpp
+++ b/nntrainer/tensor/cache_elem.cpp
@@ -75,7 +75,10 @@ void CacheElem::swapOut(Options opt) {
   void *buf = (void *)mem_data->getAddr();
 
   initial_opt = static_cast<Options>(initial_opt & ~Options::FIRST_WRITE);
-  device->putBuffer(buf, dealloc_only);
+  if (!device->address_unmapped(buf)) {
+    device->putBuffer(buf, dealloc_only);
+    device->set_unmapped(buf);
+  }
   mem_data->setAddr(nullptr);
   mem_data->setValid(false);
   active = false;

--- a/nntrainer/tensor/cache_elem.cpp
+++ b/nntrainer/tensor/cache_elem.cpp
@@ -75,7 +75,8 @@ void CacheElem::swapOut(Options opt) {
   void *buf = (void *)mem_data->getAddr();
 
   initial_opt = static_cast<Options>(initial_opt & ~Options::FIRST_WRITE);
-  if (!device->address_unmapped(buf)) {
+  auto is_unmapped = device->address_unmapped(buf);
+  if (is_unmapped == false) {
     device->putBuffer(buf, dealloc_only);
     device->set_unmapped(buf);
   }

--- a/nntrainer/tensor/cache_elem.cpp
+++ b/nntrainer/tensor/cache_elem.cpp
@@ -75,11 +75,12 @@ void CacheElem::swapOut(Options opt) {
   void *buf = (void *)mem_data->getAddr();
 
   initial_opt = static_cast<Options>(initial_opt & ~Options::FIRST_WRITE);
-  auto is_unmapped = device->address_unmapped(buf);
-  if (is_unmapped == false) {
-    device->putBuffer(buf, dealloc_only);
-    device->set_unmapped(buf);
-  }
+  // auto is_unmapped = device->address_unmapped(buf);
+  // if (is_unmapped == false) {
+  //   device->putBuffer(buf, dealloc_only);
+  //   device->set_unmapped(buf);
+  // }
+  device->putBuffer(buf, dealloc_only);
   mem_data->setAddr(nullptr);
   mem_data->setValid(false);
   active = false;

--- a/nntrainer/tensor/cache_elem.h
+++ b/nntrainer/tensor/cache_elem.h
@@ -62,7 +62,8 @@ public:
    */
   explicit CacheElem(std::shared_ptr<SwapDevice> dev, unsigned int mem_id,
                      size_t off, size_t len, std::shared_ptr<MemoryData> data,
-                     CachePolicy pol = CachePolicy::ALWAYS_SYNCED) :
+                     CachePolicy pol = CachePolicy::ALWAYS_SYNCED,
+                     void *ptr = nullptr) :
     initial_opt(Options::FIRST_ACCESS_WRITE),
     device(dev),
     active(false),
@@ -70,7 +71,8 @@ public:
     offset(off),
     length(len),
     policy(pol),
-    mem_data(data) {}
+    mem_data(data),
+    memory_ptr(ptr) {}
 
   /**
    * @brief CacheElem destructor
@@ -132,6 +134,7 @@ private:
   size_t length;                        /**< element size */
   CachePolicy policy;                   /**< cache policy */
   std::shared_ptr<MemoryData> mem_data; /**< allocated memory data */
+  void *memory_ptr;                     /** memory ptr to store read data*/
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -125,7 +125,7 @@ void CachePool::allocate() {
 
   NNTR_THROW_IF(pool_size == 0, std::runtime_error)
     << "Allocating memory pool with size 0";
-
+  MemoryPool::allocate();
   swap_device->start(pool_size);
 }
 
@@ -182,8 +182,10 @@ std::shared_ptr<MemoryData> CachePool::getMemory(unsigned int id) {
   auto mem_data = std::make_shared<MemoryData>(
     id, std::bind(&CachePool::validate, this, std::placeholders::_1),
     std::bind(&CachePool::invalidate, this, std::placeholders::_1));
-  auto elem =
-    std::make_shared<CacheElem>(swap_device, id, offset, len, mem_data, policy);
+  auto mem_pool_address = getMemoryPoolAddress();
+  void *memory_ptr = static_cast<char *>(mem_pool_address) + offset;
+  auto elem = std::make_shared<CacheElem>(swap_device, id, offset, len,
+                                          mem_data, policy, memory_ptr);
   elems[id] = elem;
 
   std::string ords;

--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -96,10 +96,12 @@ std::atomic_int pool_id = 0;
 
 CachePool::CachePool(const std::string &n) :
   name(n),
+  execution_mode_(ml::train::ExecutionMode::TRAIN),
   swap_device(std::make_shared<SwapDevice>(n + "_" + std::to_string(getpid()) +
                                            "_" + std::to_string(pool_id++))) {}
 
-CachePool::CachePool(const std::string &path, const std::string &n) : name(n) {
+CachePool::CachePool(const std::string &path, const std::string &n) :
+  name(n), execution_mode_(ml::train::ExecutionMode::TRAIN) {
   if (path.empty())
     swap_device = std::make_shared<SwapDevice>(
       n + "_" + std::to_string(getpid()) + "_" + std::to_string(pool_id++));
@@ -137,8 +139,8 @@ void CachePool::allocate() {
 
   NNTR_THROW_IF(pool_size == 0, std::runtime_error)
     << "Allocating memory pool with size 0";
-  MemoryPool::allocate();
   if (execution_mode_ == ml::train::ExecutionMode::INFERENCE) {
+    MemoryPool::allocate();
     swap_device->start(size(), false);
   } else {
     swap_device->start(size(), true);

--- a/nntrainer/tensor/cache_pool.h
+++ b/nntrainer/tensor/cache_pool.h
@@ -253,9 +253,9 @@ protected:
 
 private:
   std::string name;                         /**< pool name */
+  ml::train::ExecutionMode execution_mode_; /**< execution mode */
   std::shared_ptr<SwapDevice> swap_device;  /**< swap device */
   CacheElems elems;                         /**< cache elements */
-  ml::train::ExecutionMode execution_mode_; /**< execution mode */
   std::list<std::shared_ptr<CacheElem>> actives;
   std::vector<CachePolicy> policies;
   std::map<unsigned int, ExecIds> exec_ids;

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -916,8 +916,7 @@ void Manager::finalizeTensorPool(TensorPool &pool, unsigned int start,
     } else {
       pool.finalize(OptimizedV1Planner(), start, end);
     }
-  }
-  else {
+  } else {
     pool.finalize(BasicPlanner(), start, end);
   }
 }

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -463,6 +463,18 @@ std::vector<Weight *> Manager::requestWeights(
       }
     } else {
       /** case requesting fresh weights */
+
+      if (exec_mode == ExecutionMode::INFERENCE && enable_swap) {
+        for (unsigned int i = 0; i < swap_lookahead; ++i) {
+          int lah_order = (forwarding_order - (swap_lookahead - i));
+          if (lah_order < 0) {
+            var_exec_order.push_back(0);
+          } else {
+            var_exec_order.push_back(lah_order);
+          }
+        }
+      }
+
       var =
         weight_pool.request(name, dim_v, var_exec_order, var_ls, t_initializer);
 
@@ -898,8 +910,12 @@ void Manager::flushCacheExcept(unsigned int order) {
 
 void Manager::finalizeTensorPool(TensorPool &pool, unsigned int start,
                                  unsigned int end) {
-  if (enable_optimizations)
+  if (enable_optimizations) {
     pool.finalize(OptimizedV1Planner(), start, end);
+    if (exec_mode == ExecutionMode::INFERENCE && enable_swap) {
+      pool.finalize(OptimizedV3Planner(), start, end);
+    }
+  }
   else
     pool.finalize(BasicPlanner(), start, end);
 }

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -911,13 +911,15 @@ void Manager::flushCacheExcept(unsigned int order) {
 void Manager::finalizeTensorPool(TensorPool &pool, unsigned int start,
                                  unsigned int end) {
   if (enable_optimizations) {
-    pool.finalize(OptimizedV1Planner(), start, end);
     if (exec_mode == ExecutionMode::INFERENCE && enable_swap) {
       pool.finalize(OptimizedV3Planner(), start, end);
+    } else {
+      pool.finalize(OptimizedV1Planner(), start, end);
     }
   }
-  else
+  else {
     pool.finalize(BasicPlanner(), start, end);
+  }
 }
 
 unsigned int Manager::getNumLoadedWeightPoolTensors() {

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -149,9 +149,9 @@ public:
           unsigned int lookahead = 0, const std::string tensor_format_ = "NCHW",
           const std::string tensor_dtype_ = "FP32-FP32",
           ExecutionMode exec_mode_ = ExecutionMode::TRAIN) :
-    weight_pool(enable_swap_, swap_path, "weight_pool"),
+    weight_pool(enable_swap_, swap_path, "weight_pool", exec_mode_),
     tensor_pool(enable_swap_ && (exec_mode_ == ExecutionMode::TRAIN), swap_path,
-                "tensor_pool"),
+                "tensor_pool", exec_mode_),
     enable_swap(enable_swap_),
     enable_optimizations(true),
     swap_lookahead(lookahead),
@@ -553,6 +553,24 @@ public:
    * @return Number of Loaded TensorPool Tensor
    */
   unsigned int getNumLoadedTensorPoolTensors();
+
+  /**
+   * @brief set FSU weight path
+   *
+   * @param path FSU weight file path
+   */
+  void setFsuWeightPath(std::string path) {
+    weight_pool.setFsuWeightPath(path);
+  }
+
+  /**
+   * @brief set weight file offset for FSU loading
+   *
+   * @param offsets weight file offset
+   */
+  void setWeightOffset(std::vector<std::pair<size_t, size_t>> offsets) {
+    weight_pool.setWeightOffset(offsets);
+  }
 
 private:
   /** @todo: merge this list to one */

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -119,7 +119,7 @@ std::shared_ptr<MemoryData> MemoryPool::getMemory(unsigned int idx) {
 
   char *ptr = static_cast<char *>(mem_pool) + memory_offset.at(idx - 1);
   auto mem_data = std::make_shared<MemoryData>((void *)ptr);
-
+  memory_ptrs.emplace_back(ptr);
   return mem_data;
 }
 
@@ -135,6 +135,7 @@ void MemoryPool::deallocate() {
     memory_exec_order.clear();
     memory_is_wgrad.clear();
     PROFILE_MEM_DEALLOC(mem_pool);
+    memory_ptrs.clear();
   }
 
   mem_pool = nullptr;

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -326,6 +326,7 @@ void MemoryPool::clear() {
   memory_size.clear();
   memory_validity.clear();
   memory_offset.clear();
+  file_offset.clear();
   memory_is_wgrad.clear();
 
   pool_size = 0;

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -19,237 +19,236 @@
 #ifndef __MEMORY_POOL_H__
 #define __MEMORY_POOL_H__
 
-#include <functional>
-#include <memory>
-#include <vector>
-
 #include <memory_data.h>
 #include <memory_planner.h>
 #include <tensor_wrap_specs.h>
 
+#include <functional>
+#include <memory>
+#include <vector>
+
 namespace nntrainer {
+/**
+ * @class   MemoryPool
+ * @brief   Memory Pool provides a common pool for all the tensor memory
+ */
+class MemoryPool {
+public:
   /**
-   * @class   MemoryPool
-   * @brief   Memory Pool provides a common pool for all the tensor memory
+   * @brief MemoryPool default constructor
+   *
    */
-  class MemoryPool {
-  public:
-    /**
-     * @brief MemoryPool default constructor
-     *
-     */
-    explicit MemoryPool() : mem_pool(nullptr), pool_size(0), min_pool_size(0), n_wgrad(0) {
-    }
+  explicit MemoryPool() :
+    mem_pool(nullptr), pool_size(0), min_pool_size(0), n_wgrad(0) {}
 
-    /**
-     * @brief MemoryPool destructor
-     *
-     */
-    virtual ~MemoryPool() { deallocate(); }
+  /**
+   * @brief MemoryPool destructor
+   *
+   */
+  virtual ~MemoryPool() { deallocate(); }
 
-    /**
-     * @brief Request Memory from memory pool
-     *
-     * @param bytes The size of the memory requested in bytes
-     * @param start_time The start of the validity interval of this memory
-     * @param end_time The end of the validity interval of this memory
-     * @param exec_order execution orders of this memory
-     * @param lifespan lifespan of memory
-     * @param is_wgrad check if the tensor is weight gradient
-     *
-     * @return The token to get the pointer for this memory after allocation
-     * @note start_time is inclusive, but end_time is exclusive
-     * @note The value of the return token starts from 1.
-     */
-    virtual unsigned int requestMemory(
-      size_t bytes, unsigned int start_time, unsigned int end_time,
-      std::vector<unsigned int> exec_order = std::vector<unsigned int>(),
-      TensorLifespan lifespan = TensorLifespan::MAX_LIFESPAN,
-      bool is_wgrad = false);
+  /**
+   * @brief Request Memory from memory pool
+   *
+   * @param bytes The size of the memory requested in bytes
+   * @param start_time The start of the validity interval of this memory
+   * @param end_time The end of the validity interval of this memory
+   * @param exec_order execution orders of this memory
+   * @param lifespan lifespan of memory
+   * @param is_wgrad check if the tensor is weight gradient
+   *
+   * @return The token to get the pointer for this memory after allocation
+   * @note start_time is inclusive, but end_time is exclusive
+   * @note The value of the return token starts from 1.
+   */
+  virtual unsigned int requestMemory(
+    size_t bytes, unsigned int start_time, unsigned int end_time,
+    std::vector<unsigned int> exec_order = std::vector<unsigned int>(),
+    TensorLifespan lifespan = TensorLifespan::MAX_LIFESPAN,
+    bool is_wgrad = false);
 
-    /**
-     * @brief Plan the layout with memory planner
-     *
-     * @param planner The memory planner to be used for finalizing the layout
-     *
-     * @return The efficiency of the memory layer with the given memory planner
-     *
-     * @details The efficiency of the planner is calculated as the ratio of the
-     * theoretical minimum memory requirement divided by the memory requirement
-     * given by the memory planner.
-     *
-     * @details planLayout can be called multiple times as this does not perform
-     * any allocation but rather just plans the layout and stores the layout.
-     * Subsequent call to this function will overwrite any existing layout.
-     */
-    double planLayout(const MemoryPlanner &planner);
+  /**
+   * @brief Plan the layout with memory planner
+   *
+   * @param planner The memory planner to be used for finalizing the layout
+   *
+   * @return The efficiency of the memory layer with the given memory planner
+   *
+   * @details The efficiency of the planner is calculated as the ratio of the
+   * theoretical minimum memory requirement divided by the memory requirement
+   * given by the memory planner.
+   *
+   * @details planLayout can be called multiple times as this does not perform
+   * any allocation but rather just plans the layout and stores the layout.
+   * Subsequent call to this function will overwrite any existing layout.
+   */
+  double planLayout(const MemoryPlanner &planner);
 
-    /**
-     * @brief Do the allocation of memory
-     *
-     */
-    virtual void allocate();
+  /**
+   * @brief Do the allocation of memory
+   *
+   */
+  virtual void allocate();
 
-    /**
-     * @brief Get the allocated memory
-     *
-     * @param token The token received from the requestMemory
-     *
-     * @return The pointer of the memory
-     *
-     * @details This function will throw if called before allocation.
-     */
-    virtual std::shared_ptr<MemoryData> getMemory(unsigned int idx);
+  /**
+   * @brief Get the allocated memory
+   *
+   * @param token The token received from the requestMemory
+   *
+   * @return The pointer of the memory
+   *
+   * @details This function will throw if called before allocation.
+   */
+  virtual std::shared_ptr<MemoryData> getMemory(unsigned int idx);
 
-    /**
-     * @brief Free all the allocated memory
-     *
-     */
-    virtual void deallocate();
+  /**
+   * @brief Free all the allocated memory
+   *
+   */
+  virtual void deallocate();
 
-    /**
-     * @brief Get the maximum real memory requirement
-     *
-     * @return The real memory requirement with this strategy in bytes
-     */
-    size_t size();
+  /**
+   * @brief Get the maximum real memory requirement
+   *
+   * @return The real memory requirement with this strategy in bytes
+   */
+  size_t size();
 
-    /**
-     * @brief Get the minimum theoretical memory requirement
-     *
-     * @return The theoretical memory requirement with this strategy in bytes
-     */
-    size_t minMemoryRequirement();
+  /**
+   * @brief Get the minimum theoretical memory requirement
+   *
+   * @return The theoretical memory requirement with this strategy in bytes
+   */
+  size_t minMemoryRequirement();
 
-    /**
-     * @brief Clear the memory pool
-     *
-     */
-    virtual void clear();
+  /**
+   * @brief Clear the memory pool
+   *
+   */
+  virtual void clear();
 
-    /**
-     * @brief Is the memory pool allocated
-     *
-     * @return true if the memory is allocated, else false
-     */
-    virtual bool isAllocated() const;
+  /**
+   * @brief Is the memory pool allocated
+   *
+   * @return true if the memory is allocated, else false
+   */
+  virtual bool isAllocated() const;
 
-    /**
-     *  @brief Get memory ptrs vector from memory pool class.
-     *
-     * @return memory ptrs vector
-     */
-    std::vector<void *> getMemoryPtrs() { return memory_ptrs; }
+  /**
+   *  @brief Get memory ptrs vector from memory pool class.
+   *
+   * @return memory ptrs vector
+   */
+  std::vector<void *> getMemoryPtrs() { return memory_ptrs; }
 
-    /**
-     * @brief Get the memory pool address.
-     *
-     * @return MemoryPool address.
-     */
-    void *getMemoryPoolAddress() { return mem_pool; }
+  /**
+   * @brief Get the memory pool address.
+   *
+   * @return MemoryPool address.
+   */
+  void *getMemoryPoolAddress() { return mem_pool; }
 
-    /**
-     * @brief set FSU weight path
-     *
-     * @param path FSU weight file path
-     */
-    virtual void setFsuWeightPath(std::string path) {
-    };
+  /**
+   * @brief set FSU weight path
+   *
+   * @param path FSU weight file path
+   */
+  virtual void setFsuWeightPath(std::string path){};
 
-    /**
-     * @brief set weight file offset for FSU loading
-     *
-     * @param offsets weight file offset
-     */
-    virtual void setWeightOffset(std::vector<std::pair<size_t, size_t> > offsets) {
-    };
+  /**
+   * @brief set weight file offset for FSU loading
+   *
+   * @param offsets weight file offset
+   */
+  virtual void
+  setWeightOffset(std::vector<std::pair<size_t, size_t>> offsets){};
 
-  protected:
-    /**
-     * @brief  Get memory offset
-     */
-    std::vector<size_t> &getMemoryOffset() { return memory_offset; }
+protected:
+  /**
+   * @brief  Get memory offset
+   */
+  std::vector<size_t> &getMemoryOffset() { return memory_offset; }
 
-    /**
-     * @brief  Get file offset
-     */
-    std::vector<size_t> &getFileOffset() { return file_offset; }
+  /**
+   * @brief  Get file offset
+   */
+  std::vector<size_t> &getFileOffset() { return file_offset; }
 
-    /**
-     * @brief  Get memory size
-     */
-    std::vector<size_t> &getMemorySize() { return memory_size; }
+  /**
+   * @brief  Get memory size
+   */
+  std::vector<size_t> &getMemorySize() { return memory_size; }
 
-    /**
-     * @brief  Get memory execution order
-     */
-    std::vector<std::vector<unsigned int> > &getMemoryExecOrder() {
-      return memory_exec_order;
-    }
+  /**
+   * @brief  Get memory execution order
+   */
+  std::vector<std::vector<unsigned int>> &getMemoryExecOrder() {
+    return memory_exec_order;
+  }
 
-  private:
-    /**
-     * @brief Validate the provided layout
-     */
-    bool validateLayout();
+private:
+  /**
+   * @brief Validate the provided layout
+   */
+  bool validateLayout();
 
-    /**
-     * @brief Validate the provided layout does not overflow outside the given
-     * size of the memory pool
-     */
-    bool validateOverflow();
+  /**
+   * @brief Validate the provided layout does not overflow outside the given
+   * size of the memory pool
+   */
+  bool validateOverflow();
 
-    /**
-     * @brief Validate the provided layout so that no two memories to be used at
-     * overlap interval has overlapping memories
-     */
-    bool validateOverlap();
+  /**
+   * @brief Validate the provided layout so that no two memories to be used at
+   * overlap interval has overlapping memories
+   */
+  bool validateOverlap();
 
-    /**
-     * @brief Calculate the minimum memory requirement for the given memory
-     * requests
-     *
-     * @return the minimum memory requirement in bytes
-     *
-     * @note This will be theoretical minimum memory requirement ensuring that the
-     * memory usages at the same time do not overlap with their validity. This
-     * does not consider about the fragmentation which comes from the actual
-     * memory layout.
-     */
-    size_t calcMinMemoryRequirement();
+  /**
+   * @brief Calculate the minimum memory requirement for the given memory
+   * requests
+   *
+   * @return the minimum memory requirement in bytes
+   *
+   * @note This will be theoretical minimum memory requirement ensuring that the
+   * memory usages at the same time do not overlap with their validity. This
+   * does not consider about the fragmentation which comes from the actual
+   * memory layout.
+   */
+  size_t calcMinMemoryRequirement();
 
-    /**
-     * @brief Get sorted permuation for the memory requests
-     *
-     * @return sorted permutation
-     *
-     * @details Performs sorting based on the memory overlap using memory offset
-     * as the start and the memory offset + memory size as the end of the
-     * interval.
-     */
-    std::vector<unsigned int> getSortedPermutation();
+  /**
+   * @brief Get sorted permuation for the memory requests
+   *
+   * @return sorted permutation
+   *
+   * @details Performs sorting based on the memory overlap using memory offset
+   * as the start and the memory offset + memory size as the end of the
+   * interval.
+   */
+  std::vector<unsigned int> getSortedPermutation();
 
-    std::vector<size_t> memory_size; /**< various sizes memory requested */
-    std::vector<std::pair<unsigned int, unsigned int> >
+  std::vector<size_t> memory_size; /**< various sizes memory requested */
+  std::vector<std::pair<unsigned int, unsigned int>>
     memory_validity; /**< validity intervals for each requested memory */
-    std::vector<size_t> memory_offset; /**< offsets for the memory requested */
-    std::vector<size_t> file_offset; /**< offsets for the bin file */
-    std::vector<std::vector<unsigned int> >
+  std::vector<size_t> memory_offset; /**< offsets for the memory requested */
+  std::vector<size_t> file_offset;   /**< offsets for the bin file */
+  std::vector<std::vector<unsigned int>>
     memory_exec_order; /**< execution order for the requested memory */
 
-    std::vector<bool>
+  std::vector<bool>
     memory_is_wgrad; /**< index for identification of weight gradient */
 
-    void *mem_pool; /**< memory pool allocated at once */
+  void *mem_pool; /**< memory pool allocated at once */
 
-    size_t pool_size; /**< memory requirement for this pool */
+  size_t pool_size; /**< memory requirement for this pool */
 
-    size_t min_pool_size; /**< minimum theoretical memory requirement */
+  size_t min_pool_size; /**< minimum theoretical memory requirement */
 
-    size_t n_wgrad;
+  size_t n_wgrad;
 
-    std::vector<void *> memory_ptrs; /**< memory ptr vector */
-  };
+  std::vector<void *> memory_ptrs; /**< memory ptr vector */
+};
 } // namespace nntrainer
 
 #endif /** __MEMORY_POOL_H__ */

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -28,228 +28,228 @@
 #include <tensor_wrap_specs.h>
 
 namespace nntrainer {
-
-/**
- * @class   MemoryPool
- * @brief   Memory Pool provides a common pool for all the tensor memory
- */
-class MemoryPool {
-public:
   /**
-   * @brief MemoryPool default constructor
-   *
+   * @class   MemoryPool
+   * @brief   Memory Pool provides a common pool for all the tensor memory
    */
-  explicit MemoryPool() :
-    mem_pool(nullptr), pool_size(0), min_pool_size(0), n_wgrad(0) {}
+  class MemoryPool {
+  public:
+    /**
+     * @brief MemoryPool default constructor
+     *
+     */
+    explicit MemoryPool() : mem_pool(nullptr), pool_size(0), min_pool_size(0), n_wgrad(0) {
+    }
 
-  /**
-   * @brief MemoryPool destructor
-   *
-   */
-  virtual ~MemoryPool() { deallocate(); }
+    /**
+     * @brief MemoryPool destructor
+     *
+     */
+    virtual ~MemoryPool() { deallocate(); }
 
-  /**
-   * @brief Request Memory from memory pool
-   *
-   * @param bytes The size of the memory requested in bytes
-   * @param start_time The start of the validity interval of this memory
-   * @param end_time The end of the validity interval of this memory
-   * @param exec_order execution orders of this memory
-   * @param lifespan lifespan of memory
-   * @param is_wgrad check if the tensor is weight gradient
-   *
-   * @return The token to get the pointer for this memory after allocation
-   * @note start_time is inclusive, but end_time is exclusive
-   * @note The value of the return token starts from 1.
-   */
-  virtual unsigned int requestMemory(
-    size_t bytes, unsigned int start_time, unsigned int end_time,
-    std::vector<unsigned int> exec_order = std::vector<unsigned int>(),
-    TensorLifespan lifespan = TensorLifespan::MAX_LIFESPAN,
-    bool is_wgrad = false);
+    /**
+     * @brief Request Memory from memory pool
+     *
+     * @param bytes The size of the memory requested in bytes
+     * @param start_time The start of the validity interval of this memory
+     * @param end_time The end of the validity interval of this memory
+     * @param exec_order execution orders of this memory
+     * @param lifespan lifespan of memory
+     * @param is_wgrad check if the tensor is weight gradient
+     *
+     * @return The token to get the pointer for this memory after allocation
+     * @note start_time is inclusive, but end_time is exclusive
+     * @note The value of the return token starts from 1.
+     */
+    virtual unsigned int requestMemory(
+      size_t bytes, unsigned int start_time, unsigned int end_time,
+      std::vector<unsigned int> exec_order = std::vector<unsigned int>(),
+      TensorLifespan lifespan = TensorLifespan::MAX_LIFESPAN,
+      bool is_wgrad = false);
 
-  /**
-   * @brief Plan the layout with memory planner
-   *
-   * @param planner The memory planner to be used for finalizing the layout
-   *
-   * @return The efficiency of the memory layer with the given memory planner
-   *
-   * @details The efficiency of the planner is calculated as the ratio of the
-   * theoretical minimum memory requirement divided by the memory requirement
-   * given by the memory planner.
-   *
-   * @details planLayout can be called multiple times as this does not perform
-   * any allocation but rather just plans the layout and stores the layout.
-   * Subsequent call to this function will overwrite any existing layout.
-   */
-  double planLayout(const MemoryPlanner &planner);
+    /**
+     * @brief Plan the layout with memory planner
+     *
+     * @param planner The memory planner to be used for finalizing the layout
+     *
+     * @return The efficiency of the memory layer with the given memory planner
+     *
+     * @details The efficiency of the planner is calculated as the ratio of the
+     * theoretical minimum memory requirement divided by the memory requirement
+     * given by the memory planner.
+     *
+     * @details planLayout can be called multiple times as this does not perform
+     * any allocation but rather just plans the layout and stores the layout.
+     * Subsequent call to this function will overwrite any existing layout.
+     */
+    double planLayout(const MemoryPlanner &planner);
 
-  /**
-   * @brief Do the allocation of memory
-   *
-   */
-  virtual void allocate();
+    /**
+     * @brief Do the allocation of memory
+     *
+     */
+    virtual void allocate();
 
-  /**
-   * @brief Get the allocated memory
-   *
-   * @param token The token received from the requestMemory
-   *
-   * @return The pointer of the memory
-   *
-   * @details This function will throw if called before allocation.
-   */
-  virtual std::shared_ptr<MemoryData> getMemory(unsigned int idx);
+    /**
+     * @brief Get the allocated memory
+     *
+     * @param token The token received from the requestMemory
+     *
+     * @return The pointer of the memory
+     *
+     * @details This function will throw if called before allocation.
+     */
+    virtual std::shared_ptr<MemoryData> getMemory(unsigned int idx);
 
-  /**
-   * @brief Free all the allocated memory
-   *
-   */
-  virtual void deallocate();
+    /**
+     * @brief Free all the allocated memory
+     *
+     */
+    virtual void deallocate();
 
-  /**
-   * @brief Get the maximum real memory requirement
-   *
-   * @return The real memory requirement with this strategy in bytes
-   */
-  size_t size();
+    /**
+     * @brief Get the maximum real memory requirement
+     *
+     * @return The real memory requirement with this strategy in bytes
+     */
+    size_t size();
 
-  /**
-   * @brief Get the minimum theoretical memory requirement
-   *
-   * @return The theoretical memory requirement with this strategy in bytes
-   */
-  size_t minMemoryRequirement();
+    /**
+     * @brief Get the minimum theoretical memory requirement
+     *
+     * @return The theoretical memory requirement with this strategy in bytes
+     */
+    size_t minMemoryRequirement();
 
-  /**
-   * @brief Clear the memory pool
-   *
-   */
-  virtual void clear();
+    /**
+     * @brief Clear the memory pool
+     *
+     */
+    virtual void clear();
 
-  /**
-   * @brief Is the memory pool allocated
-   *
-   * @return true if the memory is allocated, else false
-   */
-  virtual bool isAllocated() const;
+    /**
+     * @brief Is the memory pool allocated
+     *
+     * @return true if the memory is allocated, else false
+     */
+    virtual bool isAllocated() const;
 
-  /**
-   *  @brief Get memory ptrs vector from memory pool class.
-   *
-   * @return memory ptrs vector
-   */
-  std::vector<void *> getMemoryPtrs() { return memory_ptrs; }
+    /**
+     *  @brief Get memory ptrs vector from memory pool class.
+     *
+     * @return memory ptrs vector
+     */
+    std::vector<void *> getMemoryPtrs() { return memory_ptrs; }
 
-  /**
-   * @brief Get the memory pool address.
-   *
-   * @return MemoryPool address.
-   */
-  void *getMemoryPoolAddress() { return mem_pool; }
+    /**
+     * @brief Get the memory pool address.
+     *
+     * @return MemoryPool address.
+     */
+    void *getMemoryPoolAddress() { return mem_pool; }
 
-  /**
-   * @brief set FSU weight path
-   *
-   * @param path FSU weight file path
-   */
-  virtual void setFsuWeightPath(std::string path) {};
+    /**
+     * @brief set FSU weight path
+     *
+     * @param path FSU weight file path
+     */
+    virtual void setFsuWeightPath(std::string path) {
+    };
 
-  /**
-   * @brief set weight file offset for FSU loading
-   *
-   * @param offsets weight file offset
-   */
-  virtual void setWeightOffset(std::vector<std::pair<size_t,size_t>> offsets) {};
+    /**
+     * @brief set weight file offset for FSU loading
+     *
+     * @param offsets weight file offset
+     */
+    virtual void setWeightOffset(std::vector<std::pair<size_t, size_t> > offsets) {
+    };
 
-protected:
-  /**
-   * @brief  Get memory offset
-   */
-  std::vector<size_t> &getMemoryOffset() { return memory_offset; }
+  protected:
+    /**
+     * @brief  Get memory offset
+     */
+    std::vector<size_t> &getMemoryOffset() { return memory_offset; }
 
-  /**
-   * @brief  Get file offset
-   */
-  std::vector<size_t> &getFileOffset() { return file_offset; }
+    /**
+     * @brief  Get file offset
+     */
+    std::vector<size_t> &getFileOffset() { return file_offset; }
 
-  /**
-   * @brief  Get memory size
-   */
-  std::vector<size_t> &getMemorySize() { return memory_size; }
+    /**
+     * @brief  Get memory size
+     */
+    std::vector<size_t> &getMemorySize() { return memory_size; }
 
-  /**
-   * @brief  Get memory execution order
-   */
-  std::vector<std::vector<unsigned int>> &getMemoryExecOrder() {
-    return memory_exec_order;
-  }
+    /**
+     * @brief  Get memory execution order
+     */
+    std::vector<std::vector<unsigned int> > &getMemoryExecOrder() {
+      return memory_exec_order;
+    }
 
-private:
-  /**
-   * @brief Validate the provided layout
-   */
-  bool validateLayout();
+  private:
+    /**
+     * @brief Validate the provided layout
+     */
+    bool validateLayout();
 
-  /**
-   * @brief Validate the provided layout does not overflow outside the given
-   * size of the memory pool
-   */
-  bool validateOverflow();
+    /**
+     * @brief Validate the provided layout does not overflow outside the given
+     * size of the memory pool
+     */
+    bool validateOverflow();
 
-  /**
-   * @brief Validate the provided layout so that no two memories to be used at
-   * overlap interval has overlapping memories
-   */
-  bool validateOverlap();
+    /**
+     * @brief Validate the provided layout so that no two memories to be used at
+     * overlap interval has overlapping memories
+     */
+    bool validateOverlap();
 
-  /**
-   * @brief Calculate the minimum memory requirement for the given memory
-   * requests
-   *
-   * @return the minimum memory requirement in bytes
-   *
-   * @note This will be theoretical minimum memory requirement ensuring that the
-   * memory usages at the same time do not overlap with their validity. This
-   * does not consider about the fragmentation which comes from the actual
-   * memory layout.
-   */
-  size_t calcMinMemoryRequirement();
+    /**
+     * @brief Calculate the minimum memory requirement for the given memory
+     * requests
+     *
+     * @return the minimum memory requirement in bytes
+     *
+     * @note This will be theoretical minimum memory requirement ensuring that the
+     * memory usages at the same time do not overlap with their validity. This
+     * does not consider about the fragmentation which comes from the actual
+     * memory layout.
+     */
+    size_t calcMinMemoryRequirement();
 
-  /**
-   * @brief Get sorted permuation for the memory requests
-   *
-   * @return sorted permutation
-   *
-   * @details Performs sorting based on the memory overlap using memory offset
-   * as the start and the memory offset + memory size as the end of the
-   * interval.
-   */
-  std::vector<unsigned int> getSortedPermutation();
+    /**
+     * @brief Get sorted permuation for the memory requests
+     *
+     * @return sorted permutation
+     *
+     * @details Performs sorting based on the memory overlap using memory offset
+     * as the start and the memory offset + memory size as the end of the
+     * interval.
+     */
+    std::vector<unsigned int> getSortedPermutation();
 
-  std::vector<size_t> memory_size; /**< various sizes memory requested */
-  std::vector<std::pair<unsigned int, unsigned int>>
+    std::vector<size_t> memory_size; /**< various sizes memory requested */
+    std::vector<std::pair<unsigned int, unsigned int> >
     memory_validity; /**< validity intervals for each requested memory */
-  std::vector<size_t> memory_offset; /**< offsets for the memory requested */
-  std::vector<size_t> file_offset; /**< offsets for the bin file */
-  std::vector<std::vector<unsigned int>>
+    std::vector<size_t> memory_offset; /**< offsets for the memory requested */
+    std::vector<size_t> file_offset; /**< offsets for the bin file */
+    std::vector<std::vector<unsigned int> >
     memory_exec_order; /**< execution order for the requested memory */
 
-  std::vector<bool>
+    std::vector<bool>
     memory_is_wgrad; /**< index for identification of weight gradient */
 
-  void *mem_pool; /**< memory pool allocated at once */
+    void *mem_pool; /**< memory pool allocated at once */
 
-  size_t pool_size; /**< memory requirement for this pool */
+    size_t pool_size; /**< memory requirement for this pool */
 
-  size_t min_pool_size; /**< minimum theoretical memory requirement */
+    size_t min_pool_size; /**< minimum theoretical memory requirement */
 
-  size_t n_wgrad;
+    size_t n_wgrad;
 
-  std::vector<void *> memory_ptrs; /**< memory ptr vector */
-};
-
+    std::vector<void *> memory_ptrs; /**< memory ptr vector */
+  };
 } // namespace nntrainer
 
 #endif /** __MEMORY_POOL_H__ */

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -161,7 +161,7 @@ public:
    *
    * @param offsets weight file offset
    */
-  virtual void setWeightOffset(std::vector<std::pair<size_t,size_t>>) {};
+  virtual void setWeightOffset(std::vector<std::pair<size_t,size_t>> offsets) {};
 
 protected:
   /**

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -40,10 +40,7 @@ public:
    *
    */
   explicit MemoryPool() :
-    mem_pool(nullptr),
-    pool_size(0),
-    min_pool_size(0),
-    n_wgrad(0) {}
+    mem_pool(nullptr), pool_size(0), min_pool_size(0), n_wgrad(0) {}
 
   /**
    * @brief MemoryPool destructor
@@ -138,6 +135,20 @@ public:
    */
   virtual bool isAllocated() const;
 
+  /**
+   *  @brief Get memory ptrs vector from memory pool class.
+   *
+   * @return memory ptrs vector
+   */
+  std::vector<void *> getMemoryPtrs() { return memory_ptrs; }
+
+  /**
+   * @brief Get the memory pool address.
+   *
+   * @return MemoryPool address.
+   */
+  void *getMemoryPoolAddress() { return mem_pool; }
+
 protected:
   /**
    * @brief  Get memory offset
@@ -215,6 +226,8 @@ private:
   size_t min_pool_size; /**< minimum theoretical memory requirement */
 
   size_t n_wgrad;
+
+  std::vector<void *> memory_ptrs; /**< memory ptr vector */
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -149,11 +149,30 @@ public:
    */
   void *getMemoryPoolAddress() { return mem_pool; }
 
+  /**
+   * @brief set FSU weight path
+   *
+   * @param path FSU weight file path
+   */
+  virtual void setFsuWeightPath(std::string path) {};
+
+  /**
+   * @brief set weight file offset for FSU loading
+   *
+   * @param offsets weight file offset
+   */
+  virtual void setWeightOffset(std::vector<std::pair<size_t,size_t>>) {};
+
 protected:
   /**
    * @brief  Get memory offset
    */
   std::vector<size_t> &getMemoryOffset() { return memory_offset; }
+
+  /**
+   * @brief  Get file offset
+   */
+  std::vector<size_t> &getFileOffset() { return file_offset; }
 
   /**
    * @brief  Get memory size
@@ -213,6 +232,7 @@ private:
   std::vector<std::pair<unsigned int, unsigned int>>
     memory_validity; /**< validity intervals for each requested memory */
   std::vector<size_t> memory_offset; /**< offsets for the memory requested */
+  std::vector<size_t> file_offset; /**< offsets for the bin file */
   std::vector<std::vector<unsigned int>>
     memory_exec_order; /**< execution order for the requested memory */
 

--- a/nntrainer/tensor/swap_device.cpp
+++ b/nntrainer/tensor/swap_device.cpp
@@ -33,6 +33,7 @@ void SwapDevice::start(size_t size, bool writeable) {
       open(dev_path.c_str(), O_RDWR | O_CREAT | O_TRUNC | O_SYNC, (mode_t)0666);
   } else {
     fd = open(dev_path.c_str(), O_RDWR | O_CREAT, (mode_t)0666);
+    execution_mode = ml::train::ExecutionMode::INFERENCE;
   }
   NNTR_THROW_IF(fd < 0, std::runtime_error)
     << "SwapDevice: open file: " << dev_path;
@@ -62,25 +63,54 @@ void *SwapDevice::getBuffer(off_t offset, size_t size, void *memory_ptr,
 
 #ifdef USE_MMAP
   // page aligned
-  size_t off = (offset / sysconf(_SC_PAGE_SIZE)) * sysconf(_SC_PAGE_SIZE);
-  size_t diff = offset - off;
-  size_t len = size + diff;
+  if (execution_mode == ml::train::ExecutionMode::INFERENCE) {
+    auto len_offset = weight_offset.at(offset_index);
 
-  char *ptr = static_cast<char *>(
-    mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, off));
+    if (len_offset.second % sysconf(_SC_PAGE_SIZE) != 0) {
+      std::cerr << "weight & bias is not page aligned!" << std::endl;
+    }
 
-  const size_t error_buflen = 100;
-  char error_buf[error_buflen];
-  NNTR_THROW_IF(ptr == (void *)-1, std::runtime_error)
-    << "SwapDevice: mmap: "
-    << std::string(strerror_r(errno, error_buf, error_buflen));
+    void *ptr =
+      mmap(NULL, len_offset.second, PROT_READ | PROT_WRITE | PROT_EXEC,
+           MAP_SHARED, fd, len_offset.first);
 
-  mapped[ptr] = std::make_tuple(ptr, len, offset, (ssize_t)size);
-  is_unmapped.insert(std::make_pair(ptr, false));
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
+    NNTR_THROW_IF(ptr == (void *)-1, std::runtime_error)
+      << "SwapDevice: mmap: "
+      << std::string(strerror_r(errno, error_buf, error_buflen));
 
-  ++num_loaded_tensors;
+    std::memcpy(memory_ptr, ptr, len_offset.second);
+    munmap(ptr, len_offset.second);
 
-  return ptr;
+    mapped[memory_ptr] =
+      std::make_tuple(memory_ptr, len_offset.second, len_offset.first,
+                      (ssize_t)len_offset.second);
+    is_unmapped.insert(std::make_pair(memory_ptr, true));
+
+    ++offset_index;
+    ++num_loaded_tensors;
+    return memory_ptr;
+  } else {
+    size_t off = (offset / sysconf(_SC_PAGE_SIZE)) * sysconf(_SC_PAGE_SIZE);
+    size_t diff = offset - off;
+    size_t len = size + diff;
+
+    char *ptr = static_cast<char *>(
+      mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, off));
+
+    const size_t error_buflen = 100;
+    char error_buf[error_buflen];
+    NNTR_THROW_IF(ptr == (void *)-1, std::runtime_error)
+      << "SwapDevice: mmap: "
+      << std::string(strerror_r(errno, error_buf, error_buflen));
+    void *buf = static_cast<void *>(ptr + diff);
+    mapped[buf] = std::make_tuple(ptr, len, offset, (ssize_t)size);
+    is_unmapped.insert(std::make_pair(ptr, false));
+
+    ++num_loaded_tensors;
+    return buf;
+  }
 #else
   off_t off;
   ssize_t len;
@@ -199,10 +229,11 @@ void SwapDevice::finish() {
 
   close(fd);
   fd = -1;
-  int status = std::remove(dev_path.c_str());
-
-  NNTR_THROW_IF(status, std::runtime_error)
-    << "SwapDevice: Couldn't remove " << dev_path.c_str();
+  if (execution_mode == ml::train::ExecutionMode::TRAIN) {
+    int status = std::remove(dev_path.c_str());
+    NNTR_THROW_IF(status, std::runtime_error)
+      << "SwapDevice: Couldn't remove " << dev_path.c_str();
+  }
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/swap_device.cpp
+++ b/nntrainer/tensor/swap_device.cpp
@@ -83,10 +83,10 @@ void *SwapDevice::getBuffer(off_t offset, size_t size, void *memory_ptr,
     std::memcpy(memory_ptr, ptr, len_offset.second);
     munmap(ptr, len_offset.second);
 
-    mapped[memory_ptr] =
-      std::make_tuple(memory_ptr, len_offset.second, len_offset.first,
-                      (ssize_t)len_offset.second);
-    is_unmapped.insert(std::make_pair(memory_ptr, true));
+    // mapped[memory_ptr] =
+    //   std::make_tuple(memory_ptr, len_offset.second, len_offset.first,
+    //                   (ssize_t)len_offset.second);
+    // is_unmapped.insert(std::make_pair(memory_ptr, true));
 
     ++offset_index;
     ++num_loaded_tensors;
@@ -142,6 +142,9 @@ void SwapDevice::putBuffer(void *ptr, bool dealloc_only) {
   NNTR_THROW_IF(fd <= 0, std::runtime_error)
     << "SwapDevice: Device is not started";
 #ifdef USE_MMAP
+  if (mapped.size() == 0) {
+    return;
+  }
   int ret;
 
   NNTR_THROW_IF(mapped.find(ptr) == mapped.end(), std::runtime_error)

--- a/nntrainer/tensor/swap_device.cpp
+++ b/nntrainer/tensor/swap_device.cpp
@@ -24,11 +24,16 @@
 
 namespace nntrainer {
 
-void SwapDevice::start(size_t size) {
+void SwapDevice::start(size_t size, bool writeable) {
   if (fd > 0)
     return;
 
-  fd = open(dev_path.c_str(), O_RDWR | O_CREAT | O_TRUNC | O_SYNC, 0666UL);
+  if (writeable) {
+    fd =
+      open(dev_path.c_str(), O_RDWR | O_CREAT | O_TRUNC | O_SYNC, (mode_t)0666);
+  } else {
+    fd = open(dev_path.c_str(), O_RDWR | O_CREAT, (mode_t)0666);
+  }
   NNTR_THROW_IF(fd < 0, std::runtime_error)
     << "SwapDevice: open file: " << dev_path;
 
@@ -39,11 +44,12 @@ void SwapDevice::start(size_t size) {
   NNTR_THROW_IF(off < 0, std::runtime_error)
     << "SwapDevice: seek file: " << dev_path;
 
-  ssize_t len;
-  len = write(fd, "", 1);
-  NNTR_THROW_IF(len != 1, std::runtime_error)
-    << "SwapDevice: write file: " << dev_path;
-
+  if (writeable) {
+    ssize_t len;
+    len = write(fd, "", 1);
+    NNTR_THROW_IF(len != 1, std::runtime_error)
+      << "SwapDevice: write file: " << dev_path;
+  }
   off = lseek(fd, 0, SEEK_SET);
   NNTR_THROW_IF(off < 0, std::runtime_error)
     << "SwapDevice: seek file: " << dev_path;
@@ -62,6 +68,7 @@ void *SwapDevice::getBuffer(off_t offset, size_t size, void *memory_ptr,
 
   char *ptr = static_cast<char *>(
     mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, off));
+
   const size_t error_buflen = 100;
   char error_buf[error_buflen];
   NNTR_THROW_IF(ptr == (void *)-1, std::runtime_error)

--- a/nntrainer/tensor/swap_device.h
+++ b/nntrainer/tensor/swap_device.h
@@ -17,6 +17,7 @@
 #include <fcntl.h>
 #include <map>
 #include <memory>
+#include <nntrainer_error.h>
 #include <string>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -87,7 +88,8 @@ public:
    * @return The pointer of the swap space
    *
    */
-  void *getBuffer(off_t offset, size_t size, bool alloc_only = false);
+  void *getBuffer(off_t offset, size_t size, void *memory_ptr,
+                  bool alloc_only = false);
 
   /**
    * @brief Deallocate and put data
@@ -126,6 +128,31 @@ public:
    */
   unsigned int getNumLoadedTensors();
 
+  /**
+   * @brief Check if address is unmapped or not.
+   *
+   * @param address
+   * @return bool true if address is unmapped, otherwise false.
+   */
+  bool address_unmapped(void *address) {
+    NNTR_THROW_IF(is_unmapped.find(address) == is_unmapped.end(),
+                  std::runtime_error)
+      << "Couldn't find address";
+    return is_unmapped[address];
+  }
+
+  /**
+   * @brief Set address as unmapped.
+   *
+   * @param address
+   */
+  void set_unmapped(void *address) {
+    NNTR_THROW_IF(is_unmapped.find(address) == is_unmapped.end(),
+                  std::runtime_error)
+      << "Couldn't find address";
+    is_unmapped[address] = true;
+  }
+
 private:
   const std::string dev_path; /**< device path */
   int fd;                     /**< device file description */
@@ -134,6 +161,7 @@ private:
 #ifdef USE_MMAP
   std::map<void *, std::tuple<void *, size_t, off_t, ssize_t>>
     mapped; /**< <pointer, <orig_pointer, size, offset, origianl size>> */
+  std::map<void *, bool> is_unmapped;
 #else
   std::map<void *, std::pair<off_t, ssize_t>>
     allocated; /**< <pointer, <offset, size>> */

--- a/nntrainer/tensor/swap_device.h
+++ b/nntrainer/tensor/swap_device.h
@@ -55,14 +55,20 @@ public:
    *
    */
   explicit SwapDevice(const std::string &name) :
-    dev_path(swap_device_default_path + name), fd(-1), num_loaded_tensors(0) {}
+    dev_path(swap_device_default_path + name),
+    fd(-1),
+    num_loaded_tensors(0),
+    offset_index(0) {}
 
   /**
    * @brief SwapDevice default constructor
    *
    */
   explicit SwapDevice(const std::string &path, const std::string &name) :
-    dev_path(path + "/" + name), fd(-1), num_loaded_tensors(0) {}
+    dev_path(path + "/" + name),
+    fd(-1),
+    num_loaded_tensors(0),
+    offset_index(0) {}
 
   /**
    * @brief SwapDevice destructor
@@ -74,9 +80,10 @@ public:
    * @brief Start device
    *
    * @param size The size of requested swap device space
+   * @param writeable Writeable flag
    *
    */
-  void start(size_t size);
+  void start(size_t size, bool writeable = true);
 
   /**
    * @brief Allocate and get data
@@ -153,11 +160,28 @@ public:
     is_unmapped[address] = true;
   }
 
-private:
-  const std::string dev_path; /**< device path */
-  int fd;                     /**< device file description */
+  /**
+   * @brief set FSU weight path
+   *
+   * @param path FSU weight file path
+   */
+  void setFsuWeightPath(std::string file_path) { dev_path = file_path; }
 
+  /**
+   * @brief set weight file offset for FSU loading
+   *
+   * @param offsets weight file offset
+   */
+  void setWeightOffset(std::vector<std::pair<size_t, size_t>> offsets) {
+    weight_offset = offsets;
+  }
+
+private:
+  std::string dev_path; /**< device path */
+  int fd;               /**< device file description */
+  std::vector<std::pair<size_t, size_t>> weight_offset;
   unsigned int num_loaded_tensors;
+  int offset_index;
 #ifdef USE_MMAP
   std::map<void *, std::tuple<void *, size_t, off_t, ssize_t>>
     mapped; /**< <pointer, <orig_pointer, size, offset, origianl size>> */

--- a/nntrainer/tensor/swap_device.h
+++ b/nntrainer/tensor/swap_device.h
@@ -17,13 +17,14 @@
 #include <fcntl.h>
 #include <map>
 #include <memory>
+#include <network_graph.h>
 #include <nntrainer_error.h>
 #include <string>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <system_error>
 #include <utility>
-
+#include <common.h>
 #if defined(_WIN32)
 #include <io.h>
 #define O_SYNC 0UL
@@ -58,7 +59,8 @@ public:
     dev_path(swap_device_default_path + name),
     fd(-1),
     num_loaded_tensors(0),
-    offset_index(0) {}
+    offset_index(0),
+    execution_mode(ml::train::ExecutionMode::TRAIN) {}
 
   /**
    * @brief SwapDevice default constructor
@@ -68,7 +70,8 @@ public:
     dev_path(path + "/" + name),
     fd(-1),
     num_loaded_tensors(0),
-    offset_index(0) {}
+    offset_index(0),
+    execution_mode(ml::train::ExecutionMode::TRAIN) {}
 
   /**
    * @brief SwapDevice destructor
@@ -182,6 +185,7 @@ private:
   std::vector<std::pair<size_t, size_t>> weight_offset;
   unsigned int num_loaded_tensors;
   int offset_index;
+  ml::train::ExecutionMode execution_mode;
 #ifdef USE_MMAP
   std::map<void *, std::tuple<void *, size_t, off_t, ssize_t>>
     mapped; /**< <pointer, <orig_pointer, size, offset, origianl size>> */

--- a/nntrainer/tensor/swap_device.h
+++ b/nntrainer/tensor/swap_device.h
@@ -17,7 +17,6 @@
 #include <fcntl.h>
 #include <map>
 #include <memory>
-#include <network_graph.h>
 #include <nntrainer_error.h>
 #include <string>
 #include <sys/stat.h>

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -55,7 +55,7 @@ public:
     ml::train::ExecutionMode execution_mode = ml::train::ExecutionMode::TRAIN) {
     if (enable_swap) {
       auto cache_pool =
-        std::make_shared<CachePool>(swap_path, swap_name, exec_mode_);
+        std::make_shared<CachePool>(swap_path, swap_name, execution_mode);
       cache_loader = std::make_unique<CacheLoader>(cache_pool);
       mem_pool = cache_pool;
     } else {

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -25,6 +25,7 @@
 
 #include <cache_loader.h>
 #include <cache_pool.h>
+#include <common.h>
 #include <tensor.h>
 #include <tensor_wrap_specs.h>
 
@@ -48,10 +49,13 @@ public:
   /**
    * @brief     Constructor of TensorPool
    */
-  TensorPool(bool enable_swap, const std::string &swap_path = "",
-             const std::string &swap_name = "") {
+  TensorPool(
+    bool enable_swap, const std::string &swap_path = "",
+    const std::string &swap_name = "",
+    ml::train::ExecutionMode execution_mode = ml::train::ExecutionMode::TRAIN) {
     if (enable_swap) {
-      auto cache_pool = std::make_shared<CachePool>(swap_path, swap_name);
+      auto cache_pool =
+        std::make_shared<CachePool>(swap_path, swap_name, exec_mode_);
       cache_loader = std::make_unique<CacheLoader>(cache_pool);
       mem_pool = cache_pool;
     } else {
@@ -310,6 +314,28 @@ public:
    * @return number of loaded tensors
    */
   unsigned int getNumLoadedTensors();
+
+  /**
+   * @brief set FSU weight path
+   *
+   * @param path FSU weight file path
+   */
+  void setFsuWeightPath(std::string path) {
+    if (mem_pool) {
+      mem_pool->setFsuWeightPath(path);
+    }
+  }
+
+  /**
+   * @brief set weight file offset for FSU loading
+   *
+   * @param offsets weight file offset
+   */
+  void setWeightOffset(std::vector<std::pair<size_t, size_t>> offsets) {
+    if (mem_pool) {
+      mem_pool->setWeightOffset(offsets);
+    }
+  }
 
 private:
   /**

--- a/test/unittest/integration_tests/integration_test_fsu.cpp
+++ b/test/unittest/integration_tests/integration_test_fsu.cpp
@@ -34,18 +34,18 @@ TEST(fsu, simple_fc) {
 
   model->addLayer(ml::train::createLayer(
     "input", {nntrainer::withKey("name", "input0"),
-              nntrainer::withKey("input_shape", "1:1:320")}));
+              nntrainer::withKey("input_shape", "1:1:2048")}));
   for (int i = 0; i < 6; i++) {
     model->addLayer(ml::train::createLayer(
       "fully_connected",
-      {nntrainer::withKey("unit", 1000),
+      {nntrainer::withKey("unit", 2048),
        nntrainer::withKey("weight_initializer", "xavier_uniform"),
        nntrainer::withKey("bias_initializer", "zeros")}));
   }
 
   model->addLayer(ml::train::createLayer(
     "fully_connected",
-    {nntrainer::withKey("unit", 100),
+    {nntrainer::withKey("unit", 2048),
      nntrainer::withKey("weight_initializer", "xavier_uniform"),
      nntrainer::withKey("bias_initializer", "zeros")}));
 
@@ -65,8 +65,8 @@ TEST(fsu, simple_fc) {
               ml::train::ModelFormat::MODEL_FORMAT_BIN);
   model->load("./simplefc_weight_fp16_fp16_100.bin");
 
-  unsigned int feature_size = 320;
-  float input[320];
+  unsigned int feature_size = 2048;
+  float input[2048];
 
   for (unsigned int j = 0; j < feature_size; ++j)
     input[j] = j;


### PR DESCRIPTION
[FSU] Inference FSU with Shared memory

To reduce memory usage during inference by utilizing FSU, and to minimize speed degradation by performing loading during forwarding, changed to use shared memory. and ensure the existing swap in training mode is also performed normally.

Commit 1 : [[FSU] Update FSU Forwarding (Load) Logis](https://github.com/nnstreamer/nntrainer/commit/cc6d48ac36e2d87e352a7c67d3e1ec98353fdd25) 
- Change FSU Forwarding Logic ( Load weight with look ahead)


Commit 2 : [[FSU] Update swap device & cache element](https://github.com/nnstreamer/nntrainer/commit/1f7f04fae2cddc3dac7ce2bb81ec8b307a568d57) 
- Update Swap Device's function to Support FSU (Inference)


Commit 3 : [[FSU] Update FSU mem allocate Logic](https://github.com/nnstreamer/nntrainer/commit/51fbd2397099f5866d2b5d8591939f8ba550b53c) 
- Update Memory Allocation to Shared Mem


Commit 4 : [[FSU] add FSU file offset info](https://github.com/nnstreamer/nntrainer/commit/ea20170850ba2e2252b6a5b7cc7fdf96b89c7979) 
- Add Weight bin file offset that can pass to swap device

Commit 5 : [[FSU] Apply Shared Mem & FSU](https://github.com/nnstreamer/nntrainer/commit/3b395aa7c1b0563b2ab8b74e5abf123ea0e9b7b3) 
- Update Logic to support both Inference Mode & Training Mode


This PR was include #2957 #2927 #2949, So i will close previous PRs