### PR TITLE
Fix GCC-13.3 Ubuntu 22.04 OpenCL build

### DIFF
--- a/nntrainer/layers/cl_layers/concat_cl.cpp
+++ b/nntrainer/layers/cl_layers/concat_cl.cpp
@@ -376,20 +376,17 @@ void ConcatLayerCl::incremental_forwarding(RunLayerContext &context,
 
 void ConcatLayerCl::ConcatProcess(Tensor const &in1, Tensor const &in2,
                                   Tensor &result) {
-
-  unsigned int input1_batch_size, input1_height, input1_width, input1_channels,
-    input2_batch_size, input2_height, input2_width, input2_channels;
-
   auto dim1 = in1.getDim();
   auto dim2 = in2.getDim();
-  input1_batch_size = dim1.batch();
-  input1_height = dim1.height();
-  input1_channels = dim1.channel();
-  input1_width = dim1.width();
-  input2_batch_size = dim2.batch();
-  input2_height = dim2.height();
-  input2_channels = dim2.channel();
-  input2_width = dim2.width();
+
+  unsigned int input1_batch_size = dim1.batch();
+  unsigned int input1_height = dim1.height();
+  unsigned int input1_channels = dim1.channel();
+  unsigned int input1_width = dim1.width();
+  unsigned int input2_batch_size = dim2.batch();
+  unsigned int input2_height = dim2.height();
+  unsigned int input2_channels = dim2.channel();
+  unsigned int input2_width = dim2.width();
 
   if (in1.getDataType() == ml::train::TensorDim::DataType::FP32) {
     const float *data1 = in1.getData();


### PR DESCRIPTION
This PR fixes build using GCC version 13.3 on Ubuntu 22.04 when OpenCL backend is enabled.

``` bash
/home/michal/code/nntrainer/nntrainer/layers/cl_layers/concat_cl.cpp:381:5: error: variable ‘input2_batch_size’ set but not used [-Werror=unused-but-set-variable]
  381 |     input2_batch_size, input2_height, input2_width, input2_channels;
      |     ^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```

Unused __input2_batch_size__ could be removed but I would imagine it might be nice to inspect it using debugger.