### PR TITLE
Fix GCC 13.3 build on Ubuntu 22.04 when OpenCL bakecnd is enabled .

### DIFF
--- a/nntrainer/layers/cl_layers/concat_cl.cpp
+++ b/nntrainer/layers/cl_layers/concat_cl.cpp
@@ -374,26 +374,23 @@ void ConcatLayerCl::incremental_forwarding(RunLayerContext &context,
   ConcatProcess(in1, in2, out);
 }
 
-void ConcatLayerCl::ConcatProcess(Tensor const &in1, Tensor const &in2,
+void ConcatLayerCl::ConcatProcess(Tensor const &input1, Tensor const &input2,
                                   Tensor &result) {
+  auto dim1 = input1.getDim();
+  auto dim2 = input2.getDim();
 
-  unsigned int input1_batch_size, input1_height, input1_width, input1_channels,
-    input2_batch_size, input2_height, input2_width, input2_channels;
+  unsigned int input1_batch_size = dim1.batch();
+  unsigned int input1_height = dim1.height();
+  unsigned int input1_channels = dim1.channel();
+  unsigned int input1_width = dim1.width();
+  unsigned int input2_batch_size = dim2.batch();
+  unsigned int input2_height = dim2.height();
+  unsigned int input2_channels = dim2.channel();
+  unsigned int input2_width = dim2.width();
 
-  auto dim1 = in1.getDim();
-  auto dim2 = in2.getDim();
-  input1_batch_size = dim1.batch();
-  input1_height = dim1.height();
-  input1_channels = dim1.channel();
-  input1_width = dim1.width();
-  input2_batch_size = dim2.batch();
-  input2_height = dim2.height();
-  input2_channels = dim2.channel();
-  input2_width = dim2.width();
-
-  if (in1.getDataType() == ml::train::TensorDim::DataType::FP32) {
-    const float *data1 = in1.getData();
-    const float *data2 = in2.getData();
+  if (input1.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    const float *data1 = input1.getData();
+    const float *data2 = input2.getData();
     float *rdata = result.getData();
     if (input1_width != input2_width) {
       concat_cl_axis3(data1, data2, rdata, input1_batch_size, input1_channels,
@@ -405,10 +402,10 @@ void ConcatLayerCl::ConcatProcess(Tensor const &in1, Tensor const &in2,
       concat_cl_axis1(data1, data2, rdata, input1_batch_size, input1_height,
                       input1_width, input1_channels, input2_channels);
     }
-  } else if (in1.getDataType() == ml::train::TensorDim::DataType::FP16) {
+  } else if (input1.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-    const _FP16 *data1 = in1.getData<_FP16>();
-    const _FP16 *data2 = in2.getData<_FP16>();
+    const _FP16 *data1 = input1.getData<_FP16>();
+    const _FP16 *data2 = input2.getData<_FP16>();
     _FP16 *rdata = result.getData<_FP16>();
     if (input1_width != input2_width) {
       concat_cl_axis3_fp16(data1, data2, rdata, input1_batch_size,

--- a/nntrainer/layers/cl_layers/concat_cl.h
+++ b/nntrainer/layers/cl_layers/concat_cl.h
@@ -114,7 +114,8 @@ public:
    * @param[in] input2 Tensor
    * @param[in] result Tensor
    */
-  void ConcatProcess(Tensor const &in1, Tensor const &in2, Tensor &result);
+  void ConcatProcess(Tensor const &input1, Tensor const &input2,
+                     Tensor &result);
 
   /**
    * @brief     concat computation for axis 3


### PR DESCRIPTION
This PR fixes build using GCC version 13.3 on Ubuntu 22.04 when OpenCL backend is enabled.

``` bash
/home/michal/code/nntrainer/nntrainer/layers/cl_layers/concat_cl.cpp:381:5: error: variable ‘input2_batch_size’ set but not used [-Werror=unused-but-set-variable]
  381 |     input2_batch_size, input2_height, input2_width, input2_channels;
      |     ^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```

Unused __input2_batch_size__ could be removed but I would imagine it might be nice to inspect it using debugger.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
Checkout on this PR branch on Ubuntu 22.04 machine and try building project using gcc version 13.3 compiler. Now build should succeed. 