### PR TITLE
Fix fp16 opencl build.

### DIFF
--- a/nntrainer/layers/cl_layers/concat_cl.cpp
+++ b/nntrainer/layers/cl_layers/concat_cl.cpp
@@ -764,11 +764,13 @@ void ConcatLayerCl::concat_cl_axis1(const float *matAdata,
 }
 
 #ifdef ENABLE_FP16
-void ConcatLayerCl::concat_cl_axis3_fp16(
-  const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
-  unsigned int input1_batch_size, unsigned int input1_channels,
-  unsigned int input1_height, unsigned int input1_width,
-  unsigned int input2_width) {
+void ConcatLayerCl::concat_cl_axis3_fp16(const _FP16 *matAdata,
+                                         const _FP16 *vecXdata, _FP16 *vecYdata,
+                                         unsigned int input1_batch_size,
+                                         unsigned int input1_channels,
+                                         unsigned int input1_height,
+                                         unsigned int input1_width,
+                                         unsigned int input2_width) {
 
   bool result = false;
 
@@ -782,7 +784,7 @@ void ConcatLayerCl::concat_cl_axis3_fp16(
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
       cl_context_ref.command_queue_inst_,
-      sizeof(__fp16) * input1_batch_size * input1_channels * input1_height *
+      sizeof(_FP16) * input1_batch_size * input1_channels * input1_height *
         input1_width,
       matAdata);
     if (!result) {
@@ -791,7 +793,7 @@ void ConcatLayerCl::concat_cl_axis3_fp16(
 
     result = clbuffInstance.getInBufferB()->WriteDataRegion(
       cl_context_ref.command_queue_inst_,
-      sizeof(__fp16) * input1_batch_size * input1_channels * input1_height *
+      sizeof(_FP16) * input1_batch_size * input1_channels * input1_height *
         input2_width,
       vecXdata);
     if (!result) {
@@ -800,7 +802,7 @@ void ConcatLayerCl::concat_cl_axis3_fp16(
 
     result = clbuffInstance.getOutBufferA()->WriteDataRegion(
       cl_context_ref.command_queue_inst_,
-      sizeof(__fp16) * input1_batch_size * input1_channels * input1_height *
+      sizeof(_FP16) * input1_batch_size * input1_channels * input1_height *
         (input1_width + input2_width),
       vecYdata);
     if (!result) {
@@ -866,7 +868,7 @@ void ConcatLayerCl::concat_cl_axis3_fp16(
 
     result = clbuffInstance.getOutBufferA()->ReadDataRegion(
       cl_context_ref.command_queue_inst_,
-      sizeof(__fp16) * input1_batch_size * input1_channels * input1_height *
+      sizeof(_FP16) * input1_batch_size * input1_channels * input1_height *
         (input1_width + input2_width),
       vecYdata);
     if (!result) {
@@ -876,11 +878,13 @@ void ConcatLayerCl::concat_cl_axis3_fp16(
   } while (false);
 }
 
-void ConcatLayerCl::concat_cl_axis2_fp16(
-  const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
-  unsigned int input1_batch_size, unsigned int input1_channels,
-  unsigned int input1_width, unsigned int input1_height,
-  unsigned int input2_height) {
+void ConcatLayerCl::concat_cl_axis2_fp16(const _FP16 *matAdata,
+                                         const _FP16 *vecXdata, _FP16 *vecYdata,
+                                         unsigned int input1_batch_size,
+                                         unsigned int input1_channels,
+                                         unsigned int input1_width,
+                                         unsigned int input1_height,
+                                         unsigned int input2_height) {
 
   bool result = false;
 
@@ -893,7 +897,7 @@ void ConcatLayerCl::concat_cl_axis2_fp16(
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
       cl_context_ref.command_queue_inst_,
-      sizeof(__fp16) * input1_batch_size * input1_channels * input1_height *
+      sizeof(_FP16) * input1_batch_size * input1_channels * input1_height *
         input1_width,
       matAdata);
     if (!result) {
@@ -902,7 +906,7 @@ void ConcatLayerCl::concat_cl_axis2_fp16(
 
     result = clbuffInstance.getInBufferB()->WriteDataRegion(
       cl_context_ref.command_queue_inst_,
-      sizeof(__fp16) * input1_batch_size * input1_channels * input2_height *
+      sizeof(_FP16) * input1_batch_size * input1_channels * input2_height *
         input1_width,
       vecXdata);
     if (!result) {
@@ -911,7 +915,7 @@ void ConcatLayerCl::concat_cl_axis2_fp16(
 
     result = clbuffInstance.getOutBufferA()->WriteDataRegion(
       cl_context_ref.command_queue_inst_,
-      sizeof(__fp16) * input1_batch_size * input1_channels *
+      sizeof(_FP16) * input1_batch_size * input1_channels *
         (input1_height + input2_height) * input1_width,
       vecYdata);
     if (!result) {
@@ -976,7 +980,7 @@ void ConcatLayerCl::concat_cl_axis2_fp16(
 
     result = clbuffInstance.getOutBufferA()->ReadDataRegion(
       cl_context_ref.command_queue_inst_,
-      sizeof(__fp16) * input1_batch_size * input1_channels *
+      sizeof(_FP16) * input1_batch_size * input1_channels *
         (input1_height + input2_height) * input1_width,
       vecYdata);
     if (!result) {
@@ -986,11 +990,13 @@ void ConcatLayerCl::concat_cl_axis2_fp16(
   } while (false);
 }
 
-void ConcatLayerCl::concat_cl_axis1_fp16(
-  const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
-  unsigned int input1_batch_size, unsigned int input1_height,
-  unsigned int input1_width, unsigned int input1_channels,
-  unsigned int input2_channels) {
+void ConcatLayerCl::concat_cl_axis1_fp16(const _FP16 *matAdata,
+                                         const _FP16 *vecXdata, _FP16 *vecYdata,
+                                         unsigned int input1_batch_size,
+                                         unsigned int input1_height,
+                                         unsigned int input1_width,
+                                         unsigned int input1_channels,
+                                         unsigned int input2_channels) {
 
   bool result = false;
 
@@ -1004,7 +1010,7 @@ void ConcatLayerCl::concat_cl_axis1_fp16(
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
       cl_context_ref.command_queue_inst_,
-      sizeof(__fp16) * input1_batch_size * input1_channels * input1_height *
+      sizeof(_FP16) * input1_batch_size * input1_channels * input1_height *
         input1_width,
       matAdata);
     if (!result) {
@@ -1013,7 +1019,7 @@ void ConcatLayerCl::concat_cl_axis1_fp16(
 
     result = clbuffInstance.getInBufferB()->WriteDataRegion(
       cl_context_ref.command_queue_inst_,
-      sizeof(__fp16) * input1_batch_size * input2_channels * input1_height *
+      sizeof(_FP16) * input1_batch_size * input2_channels * input1_height *
         input1_width,
       vecXdata);
     if (!result) {
@@ -1022,7 +1028,7 @@ void ConcatLayerCl::concat_cl_axis1_fp16(
 
     result = clbuffInstance.getOutBufferA()->WriteDataRegion(
       cl_context_ref.command_queue_inst_,
-      sizeof(__fp16) * input1_batch_size * input1_width * input1_height *
+      sizeof(_FP16) * input1_batch_size * input1_width * input1_height *
         (input1_channels + input2_channels),
       vecYdata);
     if (!result) {
@@ -1088,7 +1094,7 @@ void ConcatLayerCl::concat_cl_axis1_fp16(
 
     result = clbuffInstance.getOutBufferA()->ReadDataRegion(
       cl_context_ref.command_queue_inst_,
-      sizeof(__fp16) * input1_batch_size * input1_width * input1_height *
+      sizeof(_FP16) * input1_batch_size * input1_width * input1_height *
         (input1_channels + input2_channels),
       vecYdata);
     if (!result) {

--- a/nntrainer/layers/cl_layers/concat_cl.h
+++ b/nntrainer/layers/cl_layers/concat_cl.h
@@ -182,8 +182,8 @@ public:
    * @param[in] input1_width   represents the width of the input tensor A
    * @param[in] input2_width   represents the width of the input tensor X
    */
-  void concat_cl_axis3_fp16(const __fp16 *matAdata, const __fp16 *vecXdata,
-                            __fp16 *vecYdata, unsigned int input1_batch_size,
+  void concat_cl_axis3_fp16(const _FP16 *matAdata, const _FP16 *vecXdata,
+                            _FP16 *vecYdata, unsigned int input1_batch_size,
                             unsigned int input1_channels,
                             unsigned int input1_height,
                             unsigned int input1_width,
@@ -201,8 +201,8 @@ public:
    * @param[in] input1_height   represents the height of the input tensor A
    * @param[in] input2_height   represents the height of the input tensor X
    */
-  void concat_cl_axis2_fp16(const __fp16 *matAdata, const __fp16 *vecXdata,
-                            __fp16 *vecYdata, unsigned int input1_batch_size,
+  void concat_cl_axis2_fp16(const _FP16 *matAdata, const _FP16 *vecXdata,
+                            _FP16 *vecYdata, unsigned int input1_batch_size,
                             unsigned int input1_channels,
                             unsigned int input1_width,
                             unsigned int input1_height,
@@ -220,8 +220,8 @@ public:
    * @param[in] input1_channels   represents the channels of the input tensor A
    * @param[in] input2_channels   represents the channels of the input tensor X
    */
-  void concat_cl_axis1_fp16(const __fp16 *matAdata, const __fp16 *vecXdata,
-                            __fp16 *vecYdata, unsigned int input1_batch_size,
+  void concat_cl_axis1_fp16(const _FP16 *matAdata, const _FP16 *vecXdata,
+                            _FP16 *vecYdata, unsigned int input1_batch_size,
                             unsigned int input1_height,
                             unsigned int input1_width,
                             unsigned int input1_channels,

--- a/nntrainer/layers/cl_layers/reshape_cl.cpp
+++ b/nntrainer/layers/cl_layers/reshape_cl.cpp
@@ -164,7 +164,7 @@ void ReshapeLayerCl::ReshapeProcess(Tensor const &input, Tensor &output) {
 }
 
 #ifdef ENABLE_FP16
-void ReshapeLayerCl::copy_cl_fp16(const __fp16 *input, __fp16 *res,
+void ReshapeLayerCl::copy_cl_fp16(const _FP16 *input, _FP16 *res,
                                   unsigned int input_batch_size,
                                   unsigned int input_channels,
                                   unsigned int input_height,
@@ -175,7 +175,7 @@ void ReshapeLayerCl::copy_cl_fp16(const __fp16 *input, __fp16 *res,
   do {
     const auto &kernel_copy_ptr = layer_kernel_ptrs[Kernels::COPY_CL];
 
-    size_t dim_size = sizeof(__fp16) * input_batch_size * input_height *
+    size_t dim_size = sizeof(_FP16) * input_batch_size * input_height *
                       input_width * input_channels;
 
     opencl::Buffer inputA(cl_context_ref.context_inst_, dim_size, true,

--- a/nntrainer/layers/cl_layers/reshape_cl.h
+++ b/nntrainer/layers/cl_layers/reshape_cl.h
@@ -144,7 +144,7 @@ public:
    * @param[in] input_height   represents the height of the input tensor
    * @param[in] input_width   represents the width of the input tensor
    */
-  void copy_cl_fp16(const __fp16 *input, __fp16 *res,
+  void copy_cl_fp16(const _FP16 *input, _FP16 *res,
                     unsigned int input_batch_size, unsigned int input_channels,
                     unsigned int input_height, unsigned int input_width);
 #endif

--- a/nntrainer/layers/cl_layers/rmsnorm_layer_cl.cpp
+++ b/nntrainer/layers/cl_layers/rmsnorm_layer_cl.cpp
@@ -227,9 +227,9 @@ void RMSNormLayerCl::rmsnormProcess_fp16(Tensor const &input, Tensor &result,
   do {
     auto kernel_rmsnorm_ptr = layer_kernel_ptrs[Kernels::RMSNORM_CL_FP16];
 
-    const __fp16 *data = input.getData<__fp16>();
-    __fp16 *rdata = result.getData<__fp16>();
-    const __fp16 *gdata = gamma.getData<__fp16>();
+    const _FP16 *data = input.getData<_FP16>();
+    _FP16 *rdata = result.getData<_FP16>();
+    const _FP16 *gdata = gamma.getData<_FP16>();
 
     ret = clbuffInstance.getInBufferA()->WriteDataRegion(
       cl_context_ref.command_queue_inst_, dim1 * sizeof(cl_half), data);

--- a/nntrainer/layers/cl_layers/swiglu_cl.cpp
+++ b/nntrainer/layers/cl_layers/swiglu_cl.cpp
@@ -195,9 +195,9 @@ void SwiGLULayerCl::swiglu_cl(const float *matAdata, const float *vecXdata,
 }
 
 #ifdef ENABLE_FP16
-void SwiGLULayerCl::swiglu_cl_fp16(const __fp16 *matAdata,
-                                   const __fp16 *vecXdata, __fp16 *vecYdata,
-                                   unsigned int dim1, unsigned int dim2) {
+void SwiGLULayerCl::swiglu_cl_fp16(const _FP16 *matAdata, const _FP16 *vecXdata,
+                                   _FP16 *vecYdata, unsigned int dim1,
+                                   unsigned int dim2) {
 
   bool result = false;
 
@@ -207,13 +207,13 @@ void SwiGLULayerCl::swiglu_cl_fp16(const __fp16 *matAdata,
 
     int dim = int(dim1 * dim2);
     opencl::Buffer inputA(cl_context_ref.context_inst_,
-                          sizeof(__fp16) * dim1 * dim2, true, nullptr);
+                          sizeof(_FP16) * dim1 * dim2, true, nullptr);
 
     opencl::Buffer inputX(cl_context_ref.context_inst_,
-                          sizeof(__fp16) * dim1 * dim2, true, nullptr);
+                          sizeof(_FP16) * dim1 * dim2, true, nullptr);
 
     opencl::Buffer inOutY(cl_context_ref.context_inst_,
-                          sizeof(__fp16) * dim1 * dim2, true, nullptr);
+                          sizeof(_FP16) * dim1 * dim2, true, nullptr);
 
     result = inputA.WriteData(cl_context_ref.command_queue_inst_, matAdata);
     if (!result) {

--- a/nntrainer/layers/cl_layers/swiglu_cl.h
+++ b/nntrainer/layers/cl_layers/swiglu_cl.h
@@ -119,8 +119,8 @@ public:
    * @param[in] dim1 number of elements in input vector A
    * @param[in] dim1 number of elements in input vector X
    */
-  void swiglu_cl_fp16(const __fp16 *matAdata, const __fp16 *vecXdata,
-                      __fp16 *vecYdata, unsigned int dim1, unsigned int dim2);
+  void swiglu_cl_fp16(const _FP16 *matAdata, const _FP16 *vecXdata,
+                      _FP16 *vecYdata, unsigned int dim1, unsigned int dim2);
 #endif
 
   /**

--- a/nntrainer/opencl/opencl_context_manager.cpp
+++ b/nntrainer/opencl/opencl_context_manager.cpp
@@ -166,15 +166,15 @@ bool ContextManager::CreateDefaultGPUDevice() {
     return false;
   }
 
-  char extensions[extension_size];
+  std::vector<char> extensions(extension_size);
   status = clGetDeviceInfo(device_id_, CL_DEVICE_EXTENSIONS, extension_size,
-                           extensions, NULL);
+                           extensions.data(), NULL);
   if (status != CL_SUCCESS) {
     ml_loge("clGetDeviceInfo returned %d", status);
     return false;
   }
 
-  if (std::string(extensions).find("cl_khr_fp16") == std::string::npos) {
+  if (std::string(extensions.data()).find("cl_khr_fp16") == std::string::npos) {
     ml_loge("fp16 (half) is not supported by device");
     return false;
   }

--- a/nntrainer/tensor/cl_operations/attention_kernels.h
+++ b/nntrainer/tensor/cl_operations/attention_kernels.h
@@ -26,8 +26,8 @@ static ClContext cl_context_ref;
 
 /**
  * @brief     Rotary Embedding process
- * @param[in] in __fp16 * input
- * @param[in] out __fp16 * output
+ * @param[in] in _FP16 * input
+ * @param[in] out _FP16 * output
  * @param[out] freqs_cos cosine of the frequencies
  * @param[out] freqs_sin sine of the frequencies
  * @param[in] cos_ vector of cos values
@@ -55,8 +55,8 @@ void rotary_emb_cl(float *in, float *out,
 
 /**
  * @brief     Rotary Embedding process
- * @param[in] in __fp16 * input
- * @param[in] out __fp16 * output
+ * @param[in] in _FP16 * input
+ * @param[in] out _FP16 * output
  * @param[out] freqs_cos cosine of the frequencies
  * @param[out] freqs_sin sine of the frequencies
  * @param[in] cos_ vector of cos values
@@ -71,7 +71,7 @@ void rotary_emb_cl(float *in, float *out,
  * @param[in] in_size size of input
  * @param[in] out_size size of output
  */
-void rotary_emb_cl(__fp16 *in, __fp16 *out,
+void rotary_emb_cl(_FP16 *in, _FP16 *out,
                    std::vector<std::vector<float>> freqs_cos,
                    std::vector<std::vector<float>> freqs_sin,
                    std::vector<float> cos_, std::vector<float> sin_,

--- a/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
@@ -16,7 +16,7 @@
 
 namespace nntrainer {
 
-void rotary_emb_cl(__fp16 *in, __fp16 *out,
+void rotary_emb_cl(_FP16 *in, _FP16 *out,
                    std::vector<std::vector<float>> freqs_cos,
                    std::vector<std::vector<float>> freqs_sin,
                    std::vector<float> cos_, std::vector<float> sin_,

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -121,7 +121,7 @@ void transpose_cl_axis(const float *in, float *res,
  * @param[in] lda number of X's columns
  * @param[in] context RunLayerContext reference
  */
-void sgemv_cl(const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
+void sgemv_cl(const _FP16 *matAdata, const _FP16 *vecXdata, _FP16 *vecYdata,
               bool TransA, unsigned int dim1, unsigned int dim2,
               unsigned int lda);
 
@@ -133,8 +133,7 @@ void sgemv_cl(const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
  * @param[in] context RunLayerContext reference
  * @return    fp16 dot product result
  */
-__fp16 dot_cl(const __fp16 *vecAdata, const __fp16 *vecXdata,
-              unsigned int dim1);
+_FP16 dot_cl(const _FP16 *vecAdata, const _FP16 *vecXdata, unsigned int dim1);
 
 /**
  * @brief     fp16 sgemm computation : Y = op(A)*op(B) + C,
@@ -152,8 +151,8 @@ __fp16 dot_cl(const __fp16 *vecAdata, const __fp16 *vecXdata,
  * @param[in] ldc number of C's columns
  * @param[in] context RunLayerContext reference
  */
-void sgemm_cl(bool TransA, bool TransB, const __fp16 *A, const __fp16 *B,
-              __fp16 *C, unsigned int M, unsigned int N, unsigned int K,
+void sgemm_cl(bool TransA, bool TransB, const _FP16 *A, const _FP16 *B,
+              _FP16 *C, unsigned int M, unsigned int N, unsigned int K,
               unsigned int lda, unsigned int ldb, unsigned int ldc);
 
 /**
@@ -168,12 +167,12 @@ void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
 
 /**
  * @brief     fp16 sscal value element by element immediately
- * @param[in] X __fp16 * input
+ * @param[in] X _FP16 * input
  * @param[in] N unsigned int number of elements
  * @param[in] alpha float multiplier
  * @param[in] context RunLayerContext reference
  */
-void sscal_cl(__fp16 *X, const unsigned int N, const float alpha);
+void sscal_cl(_FP16 *X, const unsigned int N, const float alpha);
 
 /**
  * @brief     transpose computation
@@ -187,7 +186,7 @@ void sscal_cl(__fp16 *X, const unsigned int N, const float alpha);
  * @param[in] axis   transpose about axis, 0-> channels & height, 1-> height &
  * width, 2-> channels and width
  */
-void transpose_cl_axis(const __fp16 *in, __fp16 *res,
+void transpose_cl_axis(const _FP16 *in, _FP16 *res,
                        unsigned int input_batch_size,
                        unsigned int input_channels, unsigned int input_height,
                        unsigned int input_width, unsigned int axis);

--- a/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
@@ -16,7 +16,7 @@
 
 namespace nntrainer {
 
-void sgemv_cl(const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
+void sgemv_cl(const _FP16 *matAdata, const _FP16 *vecXdata, _FP16 *vecYdata,
               bool TransA, unsigned int dim1, unsigned int dim2,
               unsigned int lda) {
 
@@ -37,11 +37,11 @@ void sgemv_cl(const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
       break;
     }
 
-    size_t dim1_size = sizeof(__fp16) * dim1;
-    size_t dim2_size = sizeof(__fp16) * dim2;
+    size_t dim1_size = sizeof(_FP16) * dim1;
+    size_t dim2_size = sizeof(_FP16) * dim2;
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      cl_context_ref.command_queue_inst_, dim1 * dim2 * sizeof(__fp16),
+      cl_context_ref.command_queue_inst_, dim1 * dim2 * sizeof(_FP16),
       matAdata);
     if (!result) {
       break;
@@ -105,12 +105,11 @@ void sgemv_cl(const __fp16 *matAdata, const __fp16 *vecXdata, __fp16 *vecYdata,
   } while (false);
 }
 
-__fp16 dot_cl(const __fp16 *vecAdata, const __fp16 *vecXdata,
-              unsigned int dim1) {
+_FP16 dot_cl(const _FP16 *vecAdata, const _FP16 *vecXdata, unsigned int dim1) {
 
   bool result = false;
 
-  __fp16 cl_ret = 0;
+  _FP16 cl_ret = 0;
 
   do {
     ClContext::SharedPtrClKernel kernel_dot_fp16_ptr =
@@ -120,7 +119,7 @@ __fp16 dot_cl(const __fp16 *vecAdata, const __fp16 *vecXdata,
       break;
     }
 
-    size_t dim1_size = sizeof(__fp16) * dim1;
+    size_t dim1_size = sizeof(_FP16) * dim1;
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
       cl_context_ref.command_queue_inst_, dim1_size, vecAdata);
@@ -167,7 +166,7 @@ __fp16 dot_cl(const __fp16 *vecAdata, const __fp16 *vecXdata,
     }
 
     result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      cl_context_ref.command_queue_inst_, sizeof(__fp16), &cl_ret);
+      cl_context_ref.command_queue_inst_, sizeof(_FP16), &cl_ret);
     if (!result) {
       break;
     }
@@ -177,8 +176,8 @@ __fp16 dot_cl(const __fp16 *vecAdata, const __fp16 *vecXdata,
   return cl_ret;
 }
 
-void sgemm_cl(bool TransA, bool TransB, const __fp16 *A, const __fp16 *B,
-              __fp16 *C, unsigned int M, unsigned int N, unsigned int K,
+void sgemm_cl(bool TransA, bool TransB, const _FP16 *A, const _FP16 *B,
+              _FP16 *C, unsigned int M, unsigned int N, unsigned int K,
               unsigned int lda, unsigned int ldb, unsigned int ldc) {
 
   std::string kernel_func_;
@@ -208,9 +207,9 @@ void sgemm_cl(bool TransA, bool TransB, const __fp16 *A, const __fp16 *B,
     }
 
     // sizes will be same for transpose
-    size_t m_k_size = M * K * sizeof(__fp16);
-    size_t k_n_size = K * N * sizeof(__fp16);
-    size_t m_n_size = M * N * sizeof(__fp16);
+    size_t m_k_size = M * K * sizeof(_FP16);
+    size_t k_n_size = K * N * sizeof(_FP16);
+    size_t m_n_size = M * N * sizeof(_FP16);
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
       cl_context_ref.command_queue_inst_, m_k_size, A);
@@ -299,8 +298,8 @@ void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
       break;
     }
 
-    size_t dim1_size = sizeof(__fp16) * size_input;
-    size_t dim2_size = sizeof(__fp16) * size_res;
+    size_t dim1_size = sizeof(_FP16) * size_input;
+    size_t dim2_size = sizeof(_FP16) * size_res;
     opencl::Buffer inputA(cl_context_ref.context_inst_, dim1_size, true,
                           nullptr);
 
@@ -357,7 +356,7 @@ void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
   } while (false);
 }
 
-void sscal_cl(__fp16 *X, const unsigned int N, const float alpha) {
+void sscal_cl(_FP16 *X, const unsigned int N, const float alpha) {
   bool result = false;
 
   do {
@@ -368,7 +367,7 @@ void sscal_cl(__fp16 *X, const unsigned int N, const float alpha) {
       break;
     }
 
-    size_t x_size = N * sizeof(__fp16);
+    size_t x_size = N * sizeof(_FP16);
 
     result = clbuffInstance.getOutBufferA()->WriteDataRegion(
       cl_context_ref.command_queue_inst_, x_size, X);
@@ -406,7 +405,7 @@ void sscal_cl(__fp16 *X, const unsigned int N, const float alpha) {
   } while (false);
 }
 
-void transpose_cl_axis(const __fp16 *in, __fp16 *res,
+void transpose_cl_axis(const _FP16 *in, _FP16 *res,
                        unsigned int input_batch_size,
                        unsigned int input_channels, unsigned int input_height,
                        unsigned int input_width, unsigned int axis) {
@@ -436,7 +435,7 @@ void transpose_cl_axis(const __fp16 *in, __fp16 *res,
       break;
     }
 
-    size_t dim_size = sizeof(__fp16) * input_batch_size * input_height *
+    size_t dim_size = sizeof(_FP16) * input_batch_size * input_height *
                       input_width * input_channels;
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(


### PR DESCRIPTION
Fixed OpenCL with FP16 build - changed used FP16 type in files that used __fp16 instead of _FP16 which is defined based on platform capabilities. Fixed allocation of static array with dynamic size - used std::vector

Comparison of build outputs on main and this branch. Both done (after removing build directory) with:

```bash
meson setup build -Denable-opencl=true -Denable-fp16=true && meson compile -C build
```

On **main** branch:
[opencl_fp16_main.txt](https://github.com/user-attachments/files/19102305/opencl_fp16_main.txt)

On **fix-fp16-opencl-build** branch:
[oepncl_fp16_this_branch.txt](https://github.com/user-attachments/files/19102306/oepncl_fp16_this_branch.txt)

Note that this PR only changes files used on desktop build.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
Checkout on this PR branch on Ubuntu 22.04 machine and try building project using gcc version 13.3 compiler with FP16 and OpenCL enabled. Now build should succeed. 