### PR TITLE
[Format] Remove AlwaysBreakTemplateDeclarations (deprecated) options

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,7 +15,6 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-BreakTemplateDeclarations: Leave
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:


### PR DESCRIPTION
AlwaysBreakTemplateDeclarations (deprecated) will renamed as BreakTemplateDeclarations.
But BreakTemplateDeclarations from clang-format version 19 ( we use clang-format version 14 )

Sorry for confuse !

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped