### PR TITLE
[application] namespace duplication in llama application @open sesame 03/07 15:57

### DIFF
--- a/Applications/LLaMA/jni/custom_multi_head_attention_layer.cpp
+++ b/Applications/LLaMA/jni/custom_multi_head_attention_layer.cpp
@@ -22,7 +22,7 @@
 #include <thread>
 #include <vector>
 
-namespace nntrainer {
+namespace custom {
 
 MultiHeadAttentionLayer::MultiHeadAttentionLayer() :
   multi_head_attention_props(
@@ -355,7 +355,7 @@ void MultiHeadAttentionLayer::finalize(InitLayerContext &context) {
     precompute_freqs(projected_key_dim_prop, max_timestep);
 }
 
-#define _MASK_NUM(datatype) \
+#define _MASK_NUM(datatype)                                                    \
   (((datatype) == ml::train::TensorDim::DataType::FP16) ? (-1e4) : (-1e10))
 
 void MultiHeadAttentionLayer::forwarding(RunLayerContext &context,
@@ -1534,4 +1534,4 @@ void MultiHeadAttentionLayer::exportTo(
   exporter.saveResult(multi_head_attention_props, method, this);
 }
 
-} /* namespace nntrainer */
+} // namespace custom

--- a/Applications/LLaMA/jni/custom_multi_head_attention_layer.h
+++ b/Applications/LLaMA/jni/custom_multi_head_attention_layer.h
@@ -12,8 +12,8 @@
  *
  */
 
-#ifndef __MULTI_HEAD_ATTENTION_LAYER_H__
-#define __MULTI_HEAD_ATTENTION_LAYER_H__
+#ifndef __CUSTOM_MULTI_HEAD_ATTENTION_LAYER_H__
+#define __CUSTOM_MULTI_HEAD_ATTENTION_LAYER_H__
 #ifdef __cplusplus
 
 #include <acti_func.h>
@@ -22,7 +22,8 @@
 #include <util_simd.h>
 #include <utility>
 
-namespace nntrainer {
+namespace custom {
+using namespace nntrainer;
 
 /**
  * @class   Multi Head Attention Layer
@@ -303,7 +304,7 @@ private:
   void calcCommonDerivative(RunLayerContext &context);
 };
 
-} // namespace nntrainer
+} // namespace custom
 
 #endif /* __cplusplus */
-#endif /* __MULTI_HEAD_ATTENTION_LAYER_H__ */
+#endif /* __CUSTOM_MULTI_HEAD_ATTENTION_LAYER_H__ */


### PR DESCRIPTION
Previously, the `multi_head_attention_layer` is seperated into a custom layer called `custom_multi_head_attention_layer` for refactoring purposes. At that time, the namespace of custom layer should be changed, but they were copied over as-is, causing duplication. I've renamed namespace.

This issue was discovered and reported by @gkisalapl . I always appreciate your efforts. thanks a lot!

Even after resolving this problem, the llama application still does not work properly now.
I'll try to resolve this issue as soon as possible.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [ ]Passed [ ]Failed [X]Skipped