### PR TITLE
[Coverity] Fix Coverity issue on test/tizen_capi

### DIFF
--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -164,7 +164,7 @@ TEST(nntrainer_capi_nnmodel, compile_02_n) {
 TEST(nntrainer_capi_nnmodel, compile_03_p) {
   int status = ML_ERROR_NONE;
 
-  ml_train_model_h model;
+  ml_train_model_h model = nullptr;
   ml_train_layer_h layers[2];
   ml_train_layer_h get_layer;
   ml_train_optimizer_h optimizer;


### PR DESCRIPTION
Resolve UNINIT.LOCAL_VAR Alarm

Coverity issue : Uninitialized data is read from local variable 'model' at unittest_tizen_capi.cpp:183.
Fix : Add Null Check

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped
