### PR TITLE
[ Bug ] restore the initailize function in layer

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -133,6 +133,11 @@ public:
   virtual const std::string getType() const = 0;
 
   /**
+   * @brief Get the layer type
+   */
+  virtual void initialize() = 0;
+
+  /**
    * @brief     Default allowed properties
    * - input shape : string
    * - bias zero : bool

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -191,6 +191,11 @@ public:
   virtual void finalize(InitLayerContext &context) = 0;
 
   /**
+   * @brief    Initialize the layer
+   */
+  virtual void initialize(RunLayerContext &context){};
+
+  /**
    * @brief     Forward Propagation of a layer
    * @param     context Context of the layer
    * @param     training true if training, false if inference

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -289,6 +289,9 @@ public:
    */
   InitLayerContext refinalize(const std::vector<TensorDim> &input_dims = {});
 
+
+  void initialize() override { layer->initialize(*run_context); }
+
   /**
    * @brief     Forward Propagation of a layer
    * @param     training true if training, false if inference


### PR DESCRIPTION
This initialize function is used for running the llm model. It is removed accidently.

Resolves:

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped


Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>