### PR TITLE
Fix Ubuntu build with OpenBLAS as subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -320,11 +320,11 @@ if get_option('enable-blas')
       endif
       blas_options.add_cmake_defines({'BUILD_TESTING': false})
       blas_options.add_cmake_defines({'BUILD_BENCHMARKS': false})
-      blas_options.add_cmake_defines({'BUILD_SHARED_LIBS': false})
+      blas_options.add_cmake_defines({'BUILD_SHARED_LIBS': host_machine.system() != 'windows'})
       blas_options.add_cmake_defines({'BUILD_WITHOUT_LAPACK': true})
       blas_options.add_cmake_defines({'NOFORTRAN': true})
       blas_subproject = cmake.subproject('openblas', options: blas_options, required: true)
-      blas_dep = blas_subproject.dependency('openblas_static')    
+      blas_dep = host_machine.system() == 'windows'? blas_subproject.dependency('openblas_static') : blas_subproject.dependency('openblas_shared')
     endif
   endif
 


### PR DESCRIPTION
Quick fix for Ubuntu when OpenBLAS is build as subproject

Resolves: #2996

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
Not applicable
