### PR TITLE
[Windows] Fix nntrainer double to float init warnings

### DIFF
--- a/nntrainer/layers/gru.cpp
+++ b/nntrainer/layers/gru.cpp
@@ -59,7 +59,7 @@ GRULayer::GRULayer() :
             props::IntegrateBias(), props::ResetAfter()),
   acti_func(ActivationType::ACT_NONE, true),
   recurrent_acti_func(ActivationType::ACT_NONE, true),
-  epsilon(1e-3) {
+  epsilon(1e-3f) {
   wt_idx.fill(std::numeric_limits<unsigned>::max());
 }
 

--- a/nntrainer/layers/grucell.cpp
+++ b/nntrainer/layers/grucell.cpp
@@ -271,7 +271,7 @@ GRUCellLayer::GRUCellLayer() :
                 props::DropOutRate()),
   acti_func(ActivationType::ACT_NONE, true),
   recurrent_acti_func(ActivationType::ACT_NONE, true),
-  epsilon(1e-3) {
+  epsilon(1e-3f) {
   wt_idx.fill(std::numeric_limits<unsigned>::max());
 }
 

--- a/nntrainer/layers/lstmcell_core.cpp
+++ b/nntrainer/layers/lstmcell_core.cpp
@@ -24,7 +24,7 @@ LSTMCore::LSTMCore() :
                  props::RecurrentActivation() = ActivationType::ACT_SIGMOID),
   acti_func(ActivationType::ACT_NONE, true),
   recurrent_acti_func(ActivationType::ACT_NONE, true),
-  epsilon(1e-3) {}
+  epsilon(1e-3f) {}
 
 void LSTMCore::forwardLSTM(const unsigned int batch_size,
                            const unsigned int unit, const bool disable_bias,

--- a/nntrainer/layers/multi_head_attention_layer.cpp
+++ b/nntrainer/layers/multi_head_attention_layer.cpp
@@ -28,7 +28,7 @@ MultiHeadAttentionLayer::MultiHeadAttentionLayer() :
     props::OutputShape(), props::DropOutRate(), props::ReturnAttentionWeight(),
     props::AverageAttentionWeight()),
   sm(ActivationType::ACT_SOFTMAX),
-  epsilon(1e-3) {
+  epsilon(1e-3f) {
   weight_idx.fill(std::numeric_limits<unsigned>::max());
 }
 

--- a/nntrainer/layers/preprocess_translate_layer.cpp
+++ b/nntrainer/layers/preprocess_translate_layer.cpp
@@ -29,7 +29,7 @@
 namespace nntrainer {
 PreprocessTranslateLayer::PreprocessTranslateLayer() :
   Layer(),
-  epsilon(1e-5),
+  epsilon(1e-5f),
   preprocess_translate_props(props::RandomTranslate()) {}
 
 void PreprocessTranslateLayer::finalize(InitLayerContext &context) {

--- a/nntrainer/models/dynamic_training_optimization.cpp
+++ b/nntrainer/models/dynamic_training_optimization.cpp
@@ -22,11 +22,11 @@
 #include <weight.h>
 
 namespace nntrainer {
-DynamicTrainingOptimization::DynamicTrainingOptimization(int threshold_,
+DynamicTrainingOptimization::DynamicTrainingOptimization(float threshold_,
                                                          int skip_n_iter) :
   threshold(threshold_),
   enabled(false),
-  epsilon(1e-7),
+  epsilon(1e-7f),
   skip_n_iterations(skip_n_iter) {
   reduce_op = reduceByNorm;
   calc_ratio_op = ratioUsingDerivative;

--- a/nntrainer/models/dynamic_training_optimization.h
+++ b/nntrainer/models/dynamic_training_optimization.h
@@ -57,7 +57,7 @@ public:
   /**
    * @brief     Constructor of DynamicFineTuning Optimization
    */
-  DynamicTrainingOptimization(int threshold_ = 1, int skip_n_iter = 1);
+  DynamicTrainingOptimization(float threshold_ = 1.0f, int skip_n_iter = 1);
 
   /**
    * @brief     Set threshold for optimization


### PR DESCRIPTION
This PR fix some of compilation warnings related with initialization of float variable with double value on Windows build