### PR TITLE
[meson] Remove bogus resource copy command

### DIFF
--- a/Applications/MixedPrecision/jni/meson.build
+++ b/Applications/MixedPrecision/jni/meson.build
@@ -1,9 +1,3 @@
-build_root = meson.build_root()
-res_path = meson.current_source_dir() / '..' / 'res'
-
-nntr_mixed_resdir = nntr_app_resdir / 'MixedPrecision'
-run_command('cp', '-lr', res_path, nntr_mixed_resdir)
-
 mixed_sources = [
   'main.cpp',
   cifar_path / 'cifar_dataloader.cpp'


### PR DESCRIPTION
This change removes copy run_command that was always failing without us noticing. This was part of change 931c586ac23
"[Application] Add Mixed Precision Application"
Path Application/MixedPrecision/res has never existed.


This change partly addresses build failure in #2964 on Ubuntu

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

