### PR TITLE
[gtest] Enable gtest built as subproject on linux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -394,12 +394,17 @@ if not gmock_dep.found() or not gtest_dep.found() or not gtest_main_dep.found()
   if host_machine.system() == 'windows'
     googletest_options.append_compile_args('c', windows_compile_args)
     googletest_options.append_compile_args('cpp', windows_compile_args)
+  else
+    googletest_options.add_cmake_defines({'CMAKE_POSITION_INDEPENDENT_CODE': true})
   endif
   googletest_options.add_cmake_defines({'BUILD_SHARED_LIBS': false})
   googletest_subproject = cmake.subproject('googletest', options: googletest_options, required: true)
   gmock_dep = googletest_subproject.dependency('gmock')
   gtest_dep = googletest_subproject.dependency('gtest')
-  gtest_main_dep = googletest_subproject.dependency('gtest_main')
+  gtest_main_dep = [googletest_subproject.dependency('gtest_main')]
+  # meson provided dependency gtest_main_dep is sum of [gtest_dep, gtest_main_dep]
+  # This difference between cmake and meson dependency is exposed on linux
+  gtest_main_dep += gtest_dep
 endif
 
 if get_option('enable-test') # and get_option('platform') != 'android'


### PR DESCRIPTION
googletest provided as CMake subproject requires both gtest_dep and gtest_main_dep Also it should be built with PIC (Position Independent Code) when built as static library


**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
Not applicable (if possible remove system googletest and build)
