### PR TITLE
[ bugfix ] Fix is_valid algorithm

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend_fp16.cpp
@@ -209,7 +209,7 @@ void transpose_matrix(const unsigned int M, const unsigned int N,
 }
 
 bool is_valid(const unsigned int N, const __fp16 *input) {
-  nntrainer::neon::is_valid(N, input);
+  return nntrainer::neon::is_valid(N, input);
 }
 
 void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,


### PR DESCRIPTION
- Previous is_valid() for half-precision inspected with f32 inf values.
- Fix this to check with f16 inf and -inf values (reinterpreted from u16)
- Fix missing return bug

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped
