### PR TITLE
[Windows] Check if directory exist prior running mkdir

### DIFF
--- a/Applications/AlexNet/jni/meson.build
+++ b/Applications/AlexNet/jni/meson.build
@@ -5,7 +5,9 @@ build_app_res_dir = nntr_app_resdir / 'AlexNet'
 if host_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
-  run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+  if not fs.exists (build_app_res_dir_win)
+    run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+  endif
   run_command('cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
 else
   run_command('cp', '-lr', app_res_dir, build_app_res_dir)

--- a/Applications/Custom/LayerClient/jni/meson.build
+++ b/Applications/Custom/LayerClient/jni/meson.build
@@ -5,7 +5,9 @@ build_app_res_dir = nntr_app_resdir / 'LayerClient'
 if host_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
-  run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+  if not fs.exists (build_app_res_dir_win)
+    run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+  endif
   run_command('cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
 else
   run_command('cp', '-lr', app_res_dir, build_app_res_dir)

--- a/Applications/Layers/jni/meson.build
+++ b/Applications/Layers/jni/meson.build
@@ -5,7 +5,9 @@ build_app_res_dir = nntr_app_resdir / 'Layers'
 if host_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
-  run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+  if not fs.exists (build_app_res_dir_win)
+    run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+  endif
   run_command('cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
 else
   run_command('cp', '-lr', app_res_dir, build_app_res_dir)

--- a/Applications/LogisticRegression/jni/meson.build
+++ b/Applications/LogisticRegression/jni/meson.build
@@ -5,7 +5,9 @@ build_app_res_dir = nntr_app_resdir / 'LogisticRegression'
 if host_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
-  run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+  if not fs.exists (build_app_res_dir_win)
+    run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+  endif
   run_command('cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
 else
   run_command('cp', '-lr', app_res_dir, build_app_res_dir)

--- a/Applications/MNIST/jni/meson.build
+++ b/Applications/MNIST/jni/meson.build
@@ -5,7 +5,9 @@ build_app_res_dir = nntr_app_resdir / 'MNIST'
 if host_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
-  run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+  if not fs.exists (build_app_res_dir_win)
+    run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+  endif
   run_command('cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
 else
   run_command('cp', '-lr', app_res_dir, build_app_res_dir)

--- a/Applications/ProductRatings/jni/meson.build
+++ b/Applications/ProductRatings/jni/meson.build
@@ -5,7 +5,9 @@ build_app_res_dir = nntr_app_resdir / 'ProductRatings'
 if host_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
-  run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+  if not fs.exists (build_app_res_dir_win)
+    run_command('cmd.exe', '/C', 'mkdir', build_app_res_dir_win)
+  endif
   run_command('cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win)
 else
   run_command('cp', '-lr', app_res_dir, build_app_res_dir)

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -1,8 +1,12 @@
+fs = import('fs')
+
 nntr_app_resdir = nntrainer_resdir / 'app'
 
 if host_machine.system() == 'windows'
   nntr_app_resdir_win = nntr_app_resdir.replace('/', '\\')
-  run_command('cmd.exe', '/C', 'mkdir', nntr_app_resdir_win)
+  if not fs.exists (nntr_app_resdir_win)
+    run_command('cmd.exe', '/C', 'mkdir', nntr_app_resdir_win)
+  endif
 else
   run_command('mkdir', '-p', nntr_app_resdir)
 endif

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ nntrainer_version_split = nntrainer_version.split('.')
 
 # CMake module
 cmake = import('cmake')
+fs = import('fs')
 
 if host_machine.system() == 'windows'
   windows_compile_args = ['/MT']
@@ -179,7 +180,6 @@ if get_option('enable-biqgemm')
       # relative path from biqgemm is assumed
       biqgemm_path = get_option('biqgemm-path')
       message('[lib:biqgemm] fallback: finding biqgemm from user-path :' + biqgemm_path)
-      fs = import('fs')
       if fs.is_dir(biqgemm_path) 
         message('[lib:biqgemm] biqgemm header is found successfully')
         extra_defines += '-DENABLE_BIQGEMM=1'
@@ -243,7 +243,9 @@ nntrainer_resdir = meson.build_root() / 'res'
 
 if host_machine.system() == 'windows'
   nntrainer_resdir_win = nntrainer_resdir.replace('/', '\\')
-  run_command('cmd.exe', '/C', 'mkdir', nntrainer_resdir_win)
+  if not fs.exists (nntrainer_resdir_win)
+    run_command('cmd.exe', '/C', 'mkdir', nntrainer_resdir_win)
+  endif
 else
   run_command('mkdir', '-p', nntrainer_resdir)
 endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,11 +1,16 @@
+fs = import('fs')
 nntrainer_test_resdir = nntrainer_resdir / 'test'
 
 if host_machine.system() == 'windows'
   nntrainer_test_resdir_win = nntrainer_test_resdir.replace('/', '\\')
   nntrainer_test_resdir_models_win = (nntrainer_test_resdir / 'test_models/').replace('/', '\\')
   test_models_dir_win = (meson.current_source_dir() / 'test_models/').replace('/', '\\')
-  run_command('cmd.exe', '/C', 'mkdir', nntrainer_test_resdir_win)
-  run_command('cmd.exe', '/C', 'mkdir', nntrainer_test_resdir_models_win)
+  if not fs.exists (nntrainer_test_resdir_win)
+    run_command('cmd.exe', '/C', 'mkdir', nntrainer_test_resdir_win)
+  endif
+  if not fs.exists (nntrainer_test_resdir_models_win)
+    run_command('cmd.exe', '/C', 'mkdir', nntrainer_test_resdir_models_win)
+  endif
   run_command('cmd.exe', '/C', 'xcopy',test_models_dir_win, nntrainer_test_resdir_models_win, '/i', '/s', '/y')
 else
   run_command('mkdir', '-p', nntrainer_test_resdir)

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -1,3 +1,5 @@
+fs = import('fs')
+
 unittest_nntrainer_deps = [
   nntrainer_test_deps,
   nntrainer_ccapi_dep
@@ -32,7 +34,9 @@ foreach target: unzip_target
   if host_machine.system() == 'windows'
     _src_path_win = _src_path.replace('/', '\\')
     _dest_path_win = _dest_path.replace('/', '\\')
-    run_command('cmd.exe', '/C', 'mkdir', _dest_path_win)
+    if not fs.exists (_dest_path_win)
+      run_command('cmd.exe', '/C', 'mkdir', _dest_path_win)
+    endif
     run_command('cmd.exe', '/C', 'tar', 'xzf', _src_path_win, '-C', _dest_path_win)
   else
     run_command('mkdir', '-p', _dest_path)


### PR DESCRIPTION
On windows mkdir command does not have flag allowing to skip making dir if it already exists This PR add check if directory exist on windows before calling mkdir

It should fix build on #2964

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped
