### PR TITLE
[hgemm] Removal of assert in get_prev_mltpl_of_2p_n

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/hgemm/hgemm_util.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/hgemm/hgemm_util.cpp
@@ -34,7 +34,6 @@ unsigned int get_next_mltpl_of_n(unsigned int x, unsigned int n) {
 
 unsigned int get_prev_mltpl_of_2p_n(unsigned int x, unsigned int n) {
   assert(x > 0);
-  assert(n % 2 == 0);
   return (x >> n) << n;
 }
 


### PR DESCRIPTION
This patch removes the assert statement in the function get_prev_mltpl_of_2p_n, which previously required that the input value N be a multiple of two. After review, I have identified several instances where N is not necessarily a multiple of two.

For instance, 
https://github.com/nnstreamer/nntrainer/blob/9c0c43e9f47ef7a0a94a316d570245ae44b0d79c/nntrainer/tensor/cpu_backend/arm/hgemm/hgemm_util.cpp#L46

Therefore, I've decided to remove this assert statement.



**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped
