### PR TITLE
[gtest] Remove duplicated main() in integration unit test

### DIFF
--- a/test/unittest/integration_tests/meson.build
+++ b/test/unittest/integration_tests/meson.build
@@ -26,7 +26,7 @@ exe = executable(
     test_target,
     include_directories: [include_directories('.'), model_util_include_dir],
     dependencies: [
-        nntrainer_test_main_deps,
+        nntrainer_test_deps,
         nntrainer_dep,
         nntrainer_ccapi_dep,
     ],


### PR DESCRIPTION
the test/unittest/integration_tests/integration_tests.cpp already contains main, causing linking to fail on some Ubuntu 22.04
The suspicion is that are those with multilib installed, due to libc difference.
The root cause of this issue exposing on some systems is not confirmed.
But both gtest and this compilation unit contain symbol 'main' thus change of dependency is correct fix.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
