### PR TITLE
Fix the url to download the encoder from

### DIFF
--- a/jni/prepare_encoder.sh
+++ b/jni/prepare_encoder.sh
@@ -17,7 +17,7 @@ TAR_PREFIX=encoder
 
 TAR_NAME=${TAR_PREFIX}-${TARGET_VERSION}.tar.gz
 
-URL="https://github.com/nnstreamer/nnstreamer-android-resource/raw/master/external/${TAR_NAME}"
+URL="https://github.com/nnstreamer/nnstreamer-android-resource/raw/main/external/${TAR_NAME}"
 
 echo "PREPARING Encoder at ${TARGET}"
 


### PR DESCRIPTION
# Fix the url to download the encoder from

The url to download an encoder for Application/Llama was outdated. 

This is going to update the url.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

