### PR TITLE
[Wait for #2989][bug fix] key duplication in llama application

### DIFF
--- a/Applications/LLaMA/jni/custom_multi_head_attention_layer.cpp
+++ b/Applications/LLaMA/jni/custom_multi_head_attention_layer.cpp
@@ -22,7 +22,7 @@
 #include <thread>
 #include <vector>
 
-namespace nntrainer {
+namespace custom {
 
 MultiHeadAttentionLayer::MultiHeadAttentionLayer() :
   multi_head_attention_props(
@@ -355,7 +355,7 @@ void MultiHeadAttentionLayer::finalize(InitLayerContext &context) {
     precompute_freqs(projected_key_dim_prop, max_timestep);
 }
 
-#define _MASK_NUM(datatype) \
+#define _MASK_NUM(datatype)                                                    \
   (((datatype) == ml::train::TensorDim::DataType::FP16) ? (-1e4) : (-1e10))
 
 void MultiHeadAttentionLayer::forwarding(RunLayerContext &context,
@@ -1534,4 +1534,4 @@ void MultiHeadAttentionLayer::exportTo(
   exporter.saveResult(multi_head_attention_props, method, this);
 }
 
-} /* namespace nntrainer */
+} // namespace custom

--- a/Applications/LLaMA/jni/custom_multi_head_attention_layer.cpp
+++ b/Applications/LLaMA/jni/custom_multi_head_attention_layer.cpp
@@ -1507,7 +1507,9 @@ void MultiHeadAttentionLayer::calcGradient(RunLayerContext &context) {
 
 void MultiHeadAttentionLayer::setProperty(
   const std::vector<std::string> &values) {
+
   auto remain_props = loadProperties(values, multi_head_attention_props);
+
   LayerImpl::setProperty(remain_props);
 }
 

--- a/Applications/LLaMA/jni/custom_multi_head_attention_layer.h
+++ b/Applications/LLaMA/jni/custom_multi_head_attention_layer.h
@@ -12,8 +12,8 @@
  *
  */
 
-#ifndef __MULTI_HEAD_ATTENTION_LAYER_H__
-#define __MULTI_HEAD_ATTENTION_LAYER_H__
+#ifndef __CUSTOM_MULTI_HEAD_ATTENTION_LAYER_H__
+#define __CUSTOM_MULTI_HEAD_ATTENTION_LAYER_H__
 #ifdef __cplusplus
 
 #include <acti_func.h>
@@ -22,7 +22,8 @@
 #include <util_simd.h>
 #include <utility>
 
-namespace nntrainer {
+namespace custom {
+using namespace nntrainer;
 
 /**
  * @class   Multi Head Attention Layer
@@ -303,7 +304,7 @@ private:
   void calcCommonDerivative(RunLayerContext &context);
 };
 
-} // namespace nntrainer
+} // namespace custom
 
 #endif /* __cplusplus */
-#endif /* __MULTI_HEAD_ATTENTION_LAYER_H__ */
+#endif /* __CUSTOM_MULTI_HEAD_ATTENTION_LAYER_H__ */

--- a/Applications/LLaMA/jni/custom_multi_head_attention_layer.h
+++ b/Applications/LLaMA/jni/custom_multi_head_attention_layer.h
@@ -118,7 +118,7 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
-  static constexpr const char *type = "multi_head_attention";
+  static constexpr const char *type = "custom_multi_head_attention";
 
 private:
   std::tuple<props::NumHeads, props::ProjectedKeyDim, props::ProjectedValueDim,


### PR DESCRIPTION
In PR #2617 , the `internal multi_head_attention` and `custom_multi_head_attention for llama application` were seperated, but
there was duplication in the key values of `multi_head_attention` and `custom_multi_head_attention`, causing unintended issues.

So, the llama application has been modified to always use the `custom_multi_head_attention` layer.

It seems that the errors occuring in the llama application have now been revoled, but I'll carry out the refactoring the example to improve usability and add unit tests for this application.

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>