### PR TITLE
[Windows] Fix Application/LLaMA for Windows @open sesame (03/19 21:00)

### DIFF
--- a/Applications/LLaMA/jni/main.cpp
+++ b/Applications/LLaMA/jni/main.cpp
@@ -8,6 +8,7 @@
  * @author Seungbaek Hong <sb92.hong@samsung.com>
  * @bug    No known bugs except for NYI items
  */
+#include <string.h>
 
 #include <algorithm>
 #include <array>
@@ -750,8 +751,11 @@ int main(int argc, char *argv[]) {
   try {
     const std::vector<std::string> args(argv + 1, argv + argc);
 
+#ifdef _WIN32
+    bool apply_temp = _stricmp("true", args[1].c_str()) == 0;
+#else
     bool apply_temp = (strcasecmp("true", args[1].c_str()) == 0);
-
+#endif
     createAndRun(epoch, batch_size);
 
     run(text, apply_temp);

--- a/Applications/LLaMA/jni/meson.build
+++ b/Applications/LLaMA/jni/meson.build
@@ -1,5 +1,5 @@
 transpose_src = files('transpose_layer.cpp')
-transpose_layer = shared_library('transpose',
+transpose_layer = static_library('transpose',
   transpose_src,
   dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
   include_directories: include_directories('./'),
@@ -12,12 +12,14 @@ transpose_dep = declare_dependency(
   include_directories: include_directories('./')
 )
 
-if get_option('platform') != 'tizen'
-   run_command([meson.source_root() / 'jni' / 'prepare_encoder.sh', meson.build_root(), '0.2'], check: true)
+if get_option('platform') == 'windows'
+  run_command('powershell', '-ExecutionPolicy', 'Bypass', '-File', join_paths(meson.source_root(), 'jni', 'prepare_encoder.ps1'), meson.build_root(), '0.2', check: true)
+elif get_option('platform') != 'tizen'
+  run_command([meson.source_root() / 'jni' / 'prepare_encoder.sh', meson.build_root(), '0.2'], check: true)
 endif
 
 rms_norm_src = files('rms_norm.cpp')
-rms_norm_layer = shared_library('rms_norm',
+rms_norm_layer = static_library('rms_norm',
   rms_norm_src,
   dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
   include_directories: include_directories('./'),
@@ -31,7 +33,7 @@ rms_norm_dep = declare_dependency(
 )
 
 swiglu_src = files('swiglu.cpp')
-swiglu_layer = shared_library('swiglu',
+swiglu_layer = static_library('swiglu',
   swiglu_src,
   dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
   include_directories: include_directories('./'),
@@ -45,7 +47,7 @@ swiglu_dep = declare_dependency(
 )
 
 rotary_emb_src = files('rotary_embedding.cpp')
-rotary_emb_layer = shared_library('rotary_embedding',
+rotary_emb_layer = static_library('rotary_embedding',
   rotary_emb_src,
   dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
   include_directories: include_directories('./'),
@@ -59,7 +61,7 @@ rotary_emb_dep = declare_dependency(
 )
 
 mha_src = files('custom_multi_head_attention_layer.cpp')
-mha_layer = shared_library('custom_multi_head_attention_layer',
+mha_layer = static_library('custom_multi_head_attention_layer',
   mha_src,
   dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
   include_directories: include_directories('./'),

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -36,11 +36,11 @@ endif
 subdir('ONNX/jni')
 subdir('SimpleFC/jni')
 
+subdir('LLaMA/jni')
 if host_machine.system() != 'windows'
   subdir('KNN/jni')
   subdir('YOLOv2/jni')
   subdir('YOLOv3/jni')
-  subdir('LLaMA/jni')
   subdir('ReinforcementLearning/DeepQ/jni')
   subdir('TransferLearning/CIFAR_Classification/jni')
   subdir('Custom')

--- a/jni/prepare_encoder.ps1
+++ b/jni/prepare_encoder.ps1
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+##
+# Copyright (C) 2024 Daekyoung Jung <dk.zz79ya@gmail.com>
+#
+# @file prepare_encoder.ps1
+# @date 13 MAR 2025
+# @brief This file is a helper tool to build encoder at LLM
+# @author Daekyoung Jung <dk.zz79ya@gmail.com>
+#
+# usage: ./prepare_encoder.ps1 target version(either 0.1, 0.2)
+
+param (
+    [string]$Target,
+    [string]$TargetVersion
+)
+
+$TarPrefix = "encoder"
+$TarName = "$TarPrefix-$TargetVersion.tar.gz"
+$Url = "https://github.com/nnstreamer/nnstreamer-android-resource/raw/main/external/$TarName"
+
+Write-Output "PREPARING Encoder at $Target"
+
+if (-Not (Test-Path $Target)) {
+    New-Item -ItemType Directory -Path $Target
+}
+
+Push-Location $Target
+
+function _download_encoder {
+    if (Test-Path $TarName) {
+        Write-Output "$TarName exists, skip downloading"
+        return
+    }
+
+    Write-Output "[Encoder] downloading $TarName"
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $TarName
+        Write-Output "[Encoder] Finish downloading encoder"
+    } catch {
+        Write-Output "[Encoder] Download failed, please check url"
+        exit $_
+    }
+}
+
+function _untar_encoder {
+    Write-Output "[Encoder] untar encoder"
+    Write-Output $TarName
+    Write-Output $Target
+    tar -zxvf $TarName
+    Remove-Item $TarName
+
+    if ($TargetVersion -eq "0.1") {
+        Move-Item -Path "ctre-unicode.hpp", "json.hpp", "encoder.hpp" -Destination "..\PicoGPT\jni\"
+        Write-Output "[Encoder] Finish moving encoder to PicoGPT"
+    }
+
+    if ($TargetVersion -eq "0.2") {
+        Move-Item -Path "ctre-unicode.hpp", "json.hpp", "encoder.hpp" -Destination "..\LLaMA\jni\"
+        Write-Output "[Encoder] Finish moving encoder to LLaMA"
+    }
+}
+
+if (-Not (Test-Path "$TarPrefix")) {
+    _download_encoder
+    _untar_encoder
+}
+
+Pop-Location

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-option('platform', type: 'combo', choices: ['none', 'tizen', 'yocto', 'android'], value: 'none')
+option('platform', type: 'combo', choices: ['none', 'tizen', 'yocto', 'android', 'windows'], value: 'none')
 option('enable-app', type: 'boolean', value: true)
 option('install-app', type: 'boolean', value: true)
 option('use_gym', type: 'boolean', value: false)

--- a/windows-native.ini
+++ b/windows-native.ini
@@ -9,3 +9,4 @@ enable-mmap=false
 werror=false
 c_std='c17'
 cpp_std='c++20'
+platform='windows'


### PR DESCRIPTION
0. `Applications/LLaMA` requires the encoder's download. The following Powershell scirpt
   - jni/prepare_encoder.ps1

   is meant to be doing the same as jni/prepare_encoder.sh.

1. The following file
   - /Applications/LLaMA/jni/meson.build

   is edited to invoke the script for Windows build.

2. `strcasecmp` => `_stricmp` for Windows
   - `strcasecmp` is a Posix function, not available for Windows

3. Applications/LLaMA/meson.build
   - Use `static_library` instead of `shared_library`
     - `shared_library` doesn't generate `.lib` file
     - Windows build fails to link shared libraries for executable
     - To avoid the error, `static_library` for sub-libraries

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
