### PR TITLE
[ Layer ] Fix Input layer to get the Low precision tensor

### DIFF
--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -43,10 +43,26 @@ void InputLayer::setProperty(const std::vector<std::string> &values) {
 }
 
 void InputLayer::forwarding(RunLayerContext &context, bool training) {
+
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
+  std::unique_ptr<nntrainer::Quantizer> quantizer;
   if (!context.getInPlace()) {
     Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
-    hidden_.copyData(input_);
+    quantizer = nullptr;
+
+    switch (hidden_.getDataType()) {
+      // This will be supported in Tensor itself. Until then, we use this.
+    case Tdatatype::QINT16:
+    case Tdatatype::UINT16: {
+      quantizer =
+        Quantization::createQuantizer(nntrainer::QScheme::PER_TENSOR_AFFINE);
+      Tensor dq_i = quantizer->quantize(input_, hidden_.getDataType());
+      hidden_.copyData(dq_i);
+    } break;
+    default:
+      hidden_.copyData(input_);
+      break;
+    }
   }
 
   if (std::get<props::Normalization>(input_props))


### PR DESCRIPTION
Input Layer only takes the FP32 type. So we do need to quantize it if the output of input layer is low-bit. Until the
quantization/dequantization support Tensor Class inside, we do use calling quantize explicitly on layer to support.

Resolves:

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped


Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
