### PR TITLE
Fix `Applications/LLaMA`'s Windows build error

### DIFF
--- a/Applications/LLaMA/jni/main.cpp
+++ b/Applications/LLaMA/jni/main.cpp
@@ -8,6 +8,7 @@
  * @author Seungbaek Hong <sb92.hong@samsung.com>
  * @bug    No known bugs except for NYI items
  */
+#include <string.h>
 
 #include <algorithm>
 #include <array>
@@ -740,8 +741,11 @@ int main(int argc, char *argv[]) {
   try {
     const std::vector<std::string> args(argv + 1, argv + argc);
 
+#ifdef _WIN32
+    bool apply_temp = _stricmp("true", args[1].c_str()) == 0;
+#else
     bool apply_temp = (strcasecmp("true", args[1].c_str()) == 0);
-
+#endif
     createAndRun(epoch, batch_size);
 
     run(text, apply_temp);

--- a/Applications/LLaMA/jni/meson.build
+++ b/Applications/LLaMA/jni/meson.build
@@ -1,5 +1,5 @@
 transpose_src = files('transpose_layer.cpp')
-transpose_layer = shared_library('transpose',
+transpose_layer = static_library('transpose',
   transpose_src,
   dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
   include_directories: include_directories('./'),
@@ -12,12 +12,16 @@ transpose_dep = declare_dependency(
   include_directories: include_directories('./')
 )
 
-if get_option('platform') != 'tizen'
-   run_command(meson.source_root() / 'jni' / 'prepare_encoder.sh', meson.build_root(), '0.2' ,check: true)
+message('platform is: ' + get_option('platform'))
+
+if get_option('platform') == 'windows'
+  run_command('powershell', '-ExecutionPolicy', 'Bypass', '-File', join_paths(meson.source_root(), 'jni', 'prepare_encoder.ps1'), meson.build_root(), '0.2', check: true)
+elif get_option('platform') != 'tizen'
+  run_command(meson.source_root() / 'jni' / 'prepare_encoder.sh', meson.build_root(), '0.2', check: true)
 endif
 
 rms_norm_src = files('rms_norm.cpp')
-rms_norm_layer = shared_library('rms_norm',
+rms_norm_layer = static_library('rms_norm',
   rms_norm_src,
   dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
   include_directories: include_directories('./'),
@@ -31,7 +35,7 @@ rms_norm_dep = declare_dependency(
 )
 
 swiglu_src = files('swiglu.cpp')
-swiglu_layer = shared_library('swiglu',
+swiglu_layer = static_library('swiglu',
   swiglu_src,
   dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
   include_directories: include_directories('./'),
@@ -45,7 +49,7 @@ swiglu_dep = declare_dependency(
 )
 
 rotary_emb_src = files('rotary_embedding.cpp')
-rotary_emb_layer = shared_library('rotary_embedding',
+rotary_emb_layer = static_library('rotary_embedding',
   rotary_emb_src,
   dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
   include_directories: include_directories('./'),
@@ -59,7 +63,7 @@ rotary_emb_dep = declare_dependency(
 )
 
 mha_src = files('custom_multi_head_attention_layer.cpp')
-mha_layer = shared_library('custom_multi_head_attention_layer',
+mha_layer = static_library('custom_multi_head_attention_layer',
   mha_src,
   dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
   include_directories: include_directories('./'),


### PR DESCRIPTION
**Changes proposed in this PR:**

1. `strcasecmp` => `_stricmp` for Windows
   - `strcasecmp` is a Posix function, not available for Windows

2. Applications/LLaMA/meson.build
   - Use `static_library` instead of `shared_library`
     - `shared_library` doesn't generate `.lib` file
     - Windows build fails to link shared libraries for executable
     - To avoid the error, `static_library` for sub-libraries

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [*]Failed [ ]Skipped

**How to evaluate:**
1. Run `builddir/Applications/LLaMA/nntrainer/jni/nntrainer_llama.exe

