### PR TITLE
[Tensor] Add SQRT & arg_min tensor operation

### DIFF
--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -418,6 +418,22 @@ std::vector<unsigned int> CharTensor::argmax() const {
   return result;
 }
 
+std::vector<unsigned int> CharTensor::argmin() const {
+  std::vector<unsigned int> result;
+  const int8_t *data = (int8_t *)getData();
+  size_t batch_size = batch();
+  size_t feature_len = dim.getFeatureLen();
+
+  result.resize(batch_size);
+
+  for (unsigned int b = 0; b < batch_size; b++) {
+    auto min_iter =
+      std::min_element(data + b * feature_len, data + (b + 1) * feature_len);
+    result[b] = std::distance(data, min_iter) - (b * feature_len);
+  }
+  return result;
+}
+
 float CharTensor::max_abs() const {
   const int8_t *data = (int8_t *)getData();
   unsigned int idx;

--- a/nntrainer/tensor/char_tensor.h
+++ b/nntrainer/tensor/char_tensor.h
@@ -242,6 +242,11 @@ public:
   std::vector<unsigned int> argmax() const override;
 
   /**
+   * @copydoc Tensor::argmin()
+   */
+  std::vector<unsigned int> argmin() const override;
+
+  /**
    * @copydoc Tensor::max_abs()
    */
   float max_abs() const override;

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -635,6 +635,12 @@ Tensor &FloatTensor::pow(float exponent, Tensor &output) const {
   return output;
 }
 
+Tensor &FloatTensor::sqrt(Tensor &output) const {
+  auto f = [](float in) { return std::sqrt(in); };
+  apply(f, output);
+  return output;
+}
+
 Tensor &FloatTensor::erf(Tensor &output) const {
   auto f = [](float in) { return std::erf(in); };
   apply(f, output);

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -804,6 +804,22 @@ std::vector<unsigned int> FloatTensor::argmax() const {
   return result;
 }
 
+std::vector<unsigned int> FloatTensor::argmin() const {
+  std::vector<unsigned int> result;
+  const float *data = (float *)getData();
+  size_t batch_size = batch();
+  size_t feature_len = dim.getFeatureLen();
+
+  result.resize(batch_size);
+
+  for (unsigned int b = 0; b < batch_size; b++) {
+    auto min_iter =
+      std::min_element(data + b * feature_len, data + (b + 1) * feature_len);
+    result[b] = std::distance(data, min_iter) - (b * feature_len);
+  }
+  return result;
+}
+
 float FloatTensor::max_abs() const {
   const float *data = (float *)getData();
   unsigned int idx = isamax(size(), data, 1);

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -436,6 +436,11 @@ public:
   std::vector<unsigned int> argmax() const override;
 
   /**
+   * @copydoc Tensor::argmin()
+   */
+  std::vector<unsigned int> argmin() const override;
+
+  /**
    * @copydoc Tensor::max_abs()
    */
   float max_abs() const override;

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -356,6 +356,11 @@ public:
   Tensor &pow(float exponent, Tensor &output) const override;
 
   /**
+   * @copydoc Tensor::sqrt(&output)
+   */
+  Tensor &sqrt(Tensor &output) const override;
+
+  /**
    * @copydoc Tensor::erf(Tensor &output)
    */
   Tensor &erf(Tensor &output) const override;

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -596,6 +596,14 @@ Tensor &HalfTensor::pow(float exponent, Tensor &output) const {
   return output;
 }
 
+Tensor &HalfTensor::sqrt(Tensor &output) const {
+  auto f = [](_FP16 in) {
+    return static_cast<_FP16>(std::sqrt(static_cast<float>(in)));
+  };
+  apply(f, output);
+  return output;
+}
+
 Tensor &HalfTensor::erf(Tensor &output) const {
   auto f = [](_FP16 in) {
     return static_cast<_FP16>(std::erf(static_cast<float>(in)));

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -1010,6 +1010,22 @@ std::vector<unsigned int> HalfTensor::argmax() const {
   return result;
 }
 
+std::vector<unsigned int> HalfTensor::argmin() const {
+  std::vector<unsigned int> result;
+  const _FP16 *data = (_FP16 *)getData();
+  size_t batch_size = batch();
+  size_t feature_len = dim.getFeatureLen();
+
+  result.resize(batch_size);
+
+  for (unsigned int b = 0; b < batch_size; b++) {
+    auto min_iter =
+      std::min_element(data + b * feature_len, data + (b + 1) * feature_len);
+    result[b] = std::distance(data, min_iter) - (b * feature_len);
+  }
+  return result;
+}
+
 float HalfTensor::max_abs() const {
   const _FP16 *data = (_FP16 *)getData();
   unsigned int idx = isamax(size(), data, 1);

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -356,6 +356,11 @@ public:
   Tensor &pow(float exponent, Tensor &output) const override;
 
   /**
+   * @copydoc Tensor::sqrt(Tensor &output)
+   */
+  Tensor &sqrt(Tensor &output) const override;
+
+  /**
    * @copydoc Tensor::erf(Tensor &output)
    */
   Tensor &erf(Tensor &output) const override;

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -426,6 +426,11 @@ public:
   std::vector<unsigned int> argmax() const override;
 
   /**
+   * @copydoc Tensor::argmin()
+   */
+  std::vector<unsigned int> argmin() const override;
+
+  /**
    * @copydoc Tensor::max_abs()
    */
   float max_abs() const override;

--- a/nntrainer/tensor/int4_tensor.cpp
+++ b/nntrainer/tensor/int4_tensor.cpp
@@ -353,6 +353,29 @@ std::vector<unsigned int> Int4QTensor::argmax() const {
   return result;
 }
 
+std::vector<unsigned int> Int4QTensor::argmin() const {
+  std::vector<unsigned int> result;
+  const int8_t *data = (int8_t *)getData();
+  size_t batch_size = batch();
+  size_t feature_len = dim.getFeatureLen();
+  result.resize(batch_size);
+
+  for (unsigned int b = 0; b < batch_size; ++b) {
+    int8_t curr_val, min_val = 7;
+    unsigned int min_element_idx = 0;
+    for (unsigned int idx = 0; idx < feature_len; ++idx) {
+      curr_val = getValue(idx + b * feature_len);
+
+      if (curr_val < min_val) {
+        min_val = curr_val;
+        min_element_idx = idx;
+      }
+    }
+    result[b] = min_element_idx;
+  }
+  return result;
+}
+
 float Int4QTensor::max_abs() const {
   int8_t abs_max_val = 0;
   int8_t curr_val;

--- a/nntrainer/tensor/int4_tensor.h
+++ b/nntrainer/tensor/int4_tensor.h
@@ -221,6 +221,11 @@ public:
   std::vector<unsigned int> argmax() const override;
 
   /**
+   * @copydoc Tensor::argmin()
+   */
+  std::vector<unsigned int> argmin() const override;
+
+  /**
    * @copydoc Tensor::max_abs()
    */
   float max_abs() const override;

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -319,6 +319,22 @@ std::vector<unsigned int> ShortTensor::argmax() const {
   return result;
 }
 
+std::vector<unsigned int> ShortTensor::argmin() const {
+  std::vector<unsigned int> result;
+  const int16_t *data = (int16_t *)getData();
+  size_t batch_size = batch();
+  size_t feature_len = dim.getFeatureLen();
+
+  result.resize(batch_size);
+
+  for (unsigned int b = 0; b < batch_size; b++) {
+    auto min_iter =
+      std::min_element(data + b * feature_len, data + (b + 1) * feature_len);
+    result[b] = std::distance(data, min_iter) - (b * feature_len);
+  }
+  return result;
+}
+
 float ShortTensor::max_abs() const {
   const int16_t *data = (int16_t *)getData();
   unsigned int idx;

--- a/nntrainer/tensor/short_tensor.h
+++ b/nntrainer/tensor/short_tensor.h
@@ -210,6 +210,11 @@ public:
   std::vector<unsigned int> argmax() const override;
 
   /**
+   * @copydoc Tensor::argmin()
+   */
+  std::vector<unsigned int> argmin() const override;
+
+  /**
    * @copydoc Tensor::max_abs()
    */
   float max_abs() const override;

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -797,6 +797,21 @@ Tensor &Tensor::pow(float exponent, Tensor &output) const {
   return output;
 }
 
+int Tensor::sqrt_i() {
+  sqrt(*this);
+  return ML_ERROR_NONE;
+}
+
+Tensor Tensor::sqrt() const {
+  Tensor output("", getFormat(), getDataType());
+  return sqrt(output);
+};
+
+Tensor &Tensor::sqrt(Tensor &output) const {
+  itensor->sqrt(output);
+  return output;
+};
+
 int Tensor::erf_i() {
   erf(*this);
   return ML_ERROR_NONE;

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -798,7 +798,7 @@ Tensor &Tensor::pow(float exponent, Tensor &output) const {
 }
 
 int Tensor::sqrt_i() {
-  sqrt(*this);
+  this->sqrt(*this);
   return ML_ERROR_NONE;
 }
 
@@ -808,6 +808,12 @@ Tensor Tensor::sqrt() const {
 };
 
 Tensor &Tensor::sqrt(Tensor &output) const {
+  if (size() != output.size() || getDataType() != output.getDataType() ||
+      getFormat() != output.getFormat())
+    throw std::invalid_argument(
+      "Error: Tensor::sqrt requires output tensor to be same size, data type "
+      "and format as input tensor.");
+
   itensor->sqrt(output);
   return output;
 };
@@ -1243,6 +1249,12 @@ std::vector<unsigned int> Tensor::argmax() const {
   NNTR_THROW_IF(!getContiguous(), std::invalid_argument)
     << getName() << " is not contiguous, cannot get argmax.";
   return itensor->argmax();
+}
+
+std::vector<unsigned int> Tensor::argmin() const {
+  NNTR_THROW_IF(!getContiguous(), std::invalid_argument)
+    << getName() << " is not contiguous, cannot get argmin.";
+  return itensor->argmin();
 }
 
 float Tensor::max_abs() const {

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1556,6 +1556,12 @@ public:
   std::vector<unsigned int> argmax() const;
 
   /**
+   * @brief     return argument index which value is min by batch
+   * @retval    unsigned int argument indices
+   */
+  std::vector<unsigned int> argmin() const;
+
+  /**
    * @brief     return max of the absolute values of the tensor
    * @retval    maximum absolute value
    */

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -15,10 +15,10 @@
 
 #define MAKE_SHARED_TENSOR(...) std::make_shared<nntrainer::Tensor>(__VA_ARGS__)
 
-#define CREATE_IF_EMPTY_DIMS(tensor, ...) \
-  do {                                    \
-    if (tensor.empty())                   \
-      tensor = Tensor(__VA_ARGS__);       \
+#define CREATE_IF_EMPTY_DIMS(tensor, ...)                                      \
+  do {                                                                         \
+    if (tensor.empty())                                                        \
+      tensor = Tensor(__VA_ARGS__);                                            \
   } while (0);
 
 #include <cstddef>

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1196,6 +1196,25 @@ public:
   Tensor &pow(float exponent, Tensor &output) const;
 
   /**
+   * @brief     Compute square-root element by element
+   * @retval    #ML_ERROR_NONE  Successful
+   */
+  int sqrt_i();
+
+  /**
+   * @brief     Compute square-root by element
+   * @retval    Calculated Tensor
+   */
+  Tensor sqrt() const;
+
+  /**
+   * @brief      Compute square-root by element
+   * @param[out] output out to store the result
+   * @retval     Calculated Tensor
+   */
+  Tensor &sqrt(Tensor &output) const;
+
+  /**
    * @brief     Gauss error function
    * @retval    #ML_ERROR_NONE  Successful
    */

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -462,6 +462,12 @@ Tensor &TensorBase::pow(float exponent, Tensor &output) const {
     getStringDataType());
 }
 
+Tensor &TensorBase::sqrt(Tensor &output) const {
+  throw std::invalid_argument(
+    "Tensor::sqrt() is currently not supported in tensor data type " +
+    getStringDataType());
+}
+
 Tensor &TensorBase::erf(Tensor &output) const {
   throw std::invalid_argument(
     "Tensor::erf() is currently not supported in tensor data type " +

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -374,6 +374,11 @@ public:
   virtual Tensor &pow(float exponent, Tensor &output) const;
 
   /**
+   * @copydoc Tensor::sqrt(Tensor &output)
+   */
+  virtual Tensor &sqrt(Tensor &output) const;
+
+  /**
    * @copydoc Tensor::erf(Tensor &output)
    */
   virtual Tensor &erf(Tensor &output) const;

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -24,32 +24,32 @@
 
 #include "ruy/ruy.h"
 
-#define transposeloop(cl, ci, cj, ck, sl, si, sj, sk)                 \
-  do {                                                                \
-    unsigned int i, j, k, l;                                          \
-    int inidx = 0, outidx = 0;                                        \
-    for (cl = 0; cl < sl; cl++)                                       \
-      for (ci = 0; ci < si; ci++)                                     \
-        for (cj = 0; cj < sj; cj++)                                   \
-          for (ck = 0; ck < sk; ck++) {                               \
-            outidx = si * sj * sk * cl + sj * sk * ci + sk * cj + ck; \
-            inidx = l * SI * SJ * SK + i * SJ * SK + j * SK + k;      \
-            outptr[outidx] = inptr[inidx];                            \
-          }                                                           \
+#define transposeloop(cl, ci, cj, ck, sl, si, sj, sk)                          \
+  do {                                                                         \
+    unsigned int i, j, k, l;                                                   \
+    int inidx = 0, outidx = 0;                                                 \
+    for (cl = 0; cl < sl; cl++)                                                \
+      for (ci = 0; ci < si; ci++)                                              \
+        for (cj = 0; cj < sj; cj++)                                            \
+          for (ck = 0; ck < sk; ck++) {                                        \
+            outidx = si * sj * sk * cl + sj * sk * ci + sk * cj + ck;          \
+            inidx = l * SI * SJ * SK + i * SJ * SK + j * SK + k;               \
+            outptr[outidx] = inptr[inidx];                                     \
+          }                                                                    \
   } while (0);
 
-#define transposeloop_nhwc(cl, ci, cj, ck, sl, si, sj, sk)            \
-  do {                                                                \
-    unsigned int i, j, k, l;                                          \
-    int inidx = 0, outidx = 0;                                        \
-    for (cl = 0; cl < sl; cl++)                                       \
-      for (ci = 0; ci < si; ci++)                                     \
-        for (cj = 0; cj < sj; cj++)                                   \
-          for (ck = 0; ck < sk; ck++) {                               \
-            outidx = si * sj * sk * cl + sj * sk * ci + sk * cj + ck; \
-            inidx = l * SJ * SK * SI + j * SK * SI + k * SI + i;      \
-            outptr[outidx] = inptr[inidx];                            \
-          }                                                           \
+#define transposeloop_nhwc(cl, ci, cj, ck, sl, si, sj, sk)                     \
+  do {                                                                         \
+    unsigned int i, j, k, l;                                                   \
+    int inidx = 0, outidx = 0;                                                 \
+    for (cl = 0; cl < sl; cl++)                                                \
+      for (ci = 0; ci < si; ci++)                                              \
+        for (cj = 0; cj < sj; cj++)                                            \
+          for (ck = 0; ck < sk; ck++) {                                        \
+            outidx = si * sj * sk * cl + sj * sk * ci + sk * cj + ck;          \
+            inidx = l * SJ * SK * SI + j * SK * SI + k * SI + i;               \
+            outptr[outidx] = inptr[inidx];                                     \
+          }                                                                    \
   } while (0);
 
 namespace nntrainer {

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -487,6 +487,11 @@ public:
   virtual std::vector<unsigned int> argmax() const = 0;
 
   /**
+   * @copydoc Tensor::argmin()
+   */
+  virtual std::vector<unsigned int> argmin() const = 0;
+
+  /**
    * @copydoc Tensor::max_abs()
    */
   virtual float max_abs() const = 0;

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -371,6 +371,22 @@ template <typename T> std::vector<unsigned int> UIntTensor<T>::argmax() const {
   return result;
 }
 
+template <typename T> std::vector<unsigned int> UIntTensor<T>::argmin() const {
+  std::vector<unsigned int> result;
+  const T *data = (T *)getData();
+  size_t batch_size = batch();
+  size_t feature_len = dim.getFeatureLen();
+
+  result.resize(batch_size);
+
+  for (unsigned int b = 0; b < batch_size; b++) {
+    auto min_iter =
+      std::min_element(data + b * feature_len, data + (b + 1) * feature_len);
+    result[b] = std::distance(data, min_iter) - (b * feature_len);
+  }
+  return result;
+}
+
 template <typename T> float UIntTensor<T>::max_abs() const {
   return maxValue();
 }

--- a/nntrainer/tensor/uint_tensor.h
+++ b/nntrainer/tensor/uint_tensor.h
@@ -231,6 +231,11 @@ public:
   std::vector<unsigned int> argmax() const override;
 
   /**
+   * @copydoc Tensor::argmin()
+   */
+  std::vector<unsigned int> argmin() const override;
+
+  /**
    * @copydoc Tensor::max_abs()
    */
   float max_abs() const override;


### PR DESCRIPTION
- Added SQRT tensor operation for fp32 and fp16.
- Added arg_min tensor operation for fp32, fp16, int8, int4 and unsigned int.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>