### PR TITLE
 Experimental win32 cross fixes

### DIFF
--- a/Applications/AlexNet/jni/meson.build
+++ b/Applications/AlexNet/jni/meson.build
@@ -2,13 +2,13 @@ fs = import('fs')
 app_res_dir = fs.parent(meson.current_source_dir()) / 'res'
 build_app_res_dir = nntr_app_resdir / 'AlexNet'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
   if not fs.exists (build_app_res_dir_win)
-    run_command(['cmd.exe', '/C', 'mkdir', build_app_res_dir_win], check: true)
+    run_command([prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win], check: true)
   endif
-  run_command(['cmd.exe', '/C', 'xcopy', app_res_dir_win, build_app_res_dir_win], check: true)
+  run_command([prog_win_cmd, '/C', 'xcopy', app_res_dir_win, build_app_res_dir_win], check: true)
 else
   run_command(['cp', '-lr', app_res_dir, build_app_res_dir], check: true)
 endif

--- a/Applications/Custom/LayerClient/jni/meson.build
+++ b/Applications/Custom/LayerClient/jni/meson.build
@@ -2,13 +2,13 @@ fs = import('fs')
 app_res_dir = fs.parent(meson.current_source_dir()) / 'res'
 build_app_res_dir = nntr_app_resdir / 'LayerClient'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
   if not fs.exists (build_app_res_dir_win)
-    run_command(['cmd.exe', '/C', 'mkdir', build_app_res_dir_win], check: true)
+    run_command([prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win], check: true)
   endif
-  run_command(['cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win], check: true)
+  run_command([prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win], check: true)
 else
   run_command(['cp', '-lr', app_res_dir, build_app_res_dir], check: true)
 endif

--- a/Applications/Layers/jni/meson.build
+++ b/Applications/Layers/jni/meson.build
@@ -2,13 +2,13 @@ fs = import('fs')
 app_res_dir = fs.parent(meson.current_source_dir()) / 'res'
 build_app_res_dir = nntr_app_resdir / 'Layers'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
   if not fs.exists (build_app_res_dir_win)
-    run_command(['cmd.exe', '/C', 'mkdir', build_app_res_dir_win], check: true)
+    run_command([prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win], check: true)
   endif
-  run_command(['cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win], check: true)
+  run_command([prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win], check: true)
 else
   run_command(['cp', '-lr', app_res_dir, build_app_res_dir], check: true)
 endif

--- a/Applications/LogisticRegression/jni/meson.build
+++ b/Applications/LogisticRegression/jni/meson.build
@@ -2,13 +2,13 @@ fs = import('fs')
 app_res_dir = fs.parent(meson.current_source_dir()) / 'res'
 build_app_res_dir = nntr_app_resdir / 'LogisticRegression'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
   if not fs.exists (build_app_res_dir_win)
-    run_command(['cmd.exe', '/C', 'mkdir', build_app_res_dir_win], check: true)
+    run_command([prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win], check: true)
   endif
-  run_command(['cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win], check: true)
+  run_command([prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win], check: true)
 else
   run_command(['cp', '-lr', app_res_dir, build_app_res_dir], check: true)
 endif

--- a/Applications/MNIST/jni/meson.build
+++ b/Applications/MNIST/jni/meson.build
@@ -2,13 +2,13 @@ fs = import('fs')
 app_res_dir = fs.parent(meson.current_source_dir()) / 'res'
 build_app_res_dir = nntr_app_resdir / 'MNIST'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
   if not fs.exists (build_app_res_dir_win)
-    run_command(['cmd.exe', '/C', 'mkdir', build_app_res_dir_win], check: true)
+    run_command([prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win], check: true)
   endif
-  run_command(['cmd.exe', '/C', 'xcopy', app_res_dir_win, build_app_res_dir_win], check: true)
+  run_command([prog_win_cmd, '/C', 'xcopy', app_res_dir_win, build_app_res_dir_win], check: true)
 else
   run_command(['cp', '-lr', app_res_dir, build_app_res_dir], check: true)
 endif

--- a/Applications/ProductRatings/jni/meson.build
+++ b/Applications/ProductRatings/jni/meson.build
@@ -2,13 +2,13 @@ fs = import('fs')
 app_res_dir = fs.parent(meson.current_source_dir()) / 'res'
 build_app_res_dir = nntr_app_resdir / 'ProductRatings'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   app_res_dir_win = app_res_dir.replace('/', '\\')
   build_app_res_dir_win = build_app_res_dir.replace('/', '\\')
   if not fs.exists (build_app_res_dir_win)
-    run_command(['cmd.exe', '/C', 'mkdir', build_app_res_dir_win], check: true)
+    run_command([prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win], check: true)
   endif
-  run_command(['cmd.exe', '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win], check: true)
+  run_command([prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win], check: true)
 else
   run_command(['cp', '-lr', app_res_dir, build_app_res_dir], check: true)
 endif

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -2,10 +2,10 @@ fs = import('fs')
 
 nntr_app_resdir = nntrainer_resdir / 'app'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   nntr_app_resdir_win = nntr_app_resdir.replace('/', '\\')
   if not fs.exists (nntr_app_resdir_win)
-    run_command(['cmd.exe', '/C', 'mkdir', nntr_app_resdir_win], check: true)
+    run_command([prog_win_cmd, '/C', 'mkdir', nntr_app_resdir_win], check: true)
   endif
 else
   run_command(['mkdir', '-p', nntr_app_resdir], check: true)

--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,8 @@ cxx = meson.get_compiler('cpp')
 nproc_prog = find_program('nproc',
                           required: (get_option('platform') == 'android') and (build_machine.system() != 'windows'))
 
+prog_win_cmd = find_program('cmd.exe', required: build_machine.system() == 'windows')
+
 if get_option('platform') == 'tizen'
   # Pass __TIZEN__ to the compiler
   add_project_arguments('-D__TIZEN__=1', language:['c','cpp'])
@@ -190,7 +192,7 @@ if get_option('enable-biqgemm')
   endif
 endif # end of enable-biqgemm
 
-if host_machine.system() != 'windows'
+if cc.get_id() != 'msvc' and cxx.get_id() != 'msvc'
   foreach extra_arg : warning_flags
     if cc.has_argument (extra_arg)
       add_project_arguments([extra_arg], language: 'c')
@@ -241,10 +243,10 @@ endif
 # handle resources
 nntrainer_resdir = meson.build_root() / 'res'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   nntrainer_resdir_win = nntrainer_resdir.replace('/', '\\')
   if not fs.exists (nntrainer_resdir_win)
-    run_command(['cmd.exe', '/C', 'mkdir', nntrainer_resdir_win], check: true)
+    run_command([prog_win_cmd, '/C', 'mkdir', nntrainer_resdir_win], check: true)
   endif
 else
   run_command(['mkdir', '-p', nntrainer_resdir], check: true)
@@ -421,10 +423,8 @@ if get_option('reduce-tolerance')
   extra_defines += '-DREDUCE_TOLERANCE=1'
 endif
 
-if host_machine.system() != 'windows'
-  libm_dep = cxx.find_library('m') # cmath library
-  libdl_dep = cxx.find_library('dl') # DL library
-endif
+libm_dep = cxx.find_library('m', required: false) # cmath library
+libdl_dep = cxx.find_library('dl', required: false) # DL library
 
 thread_dep = dependency('threads') # pthread for tensorflow-lite
 

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -22,18 +22,13 @@ nntrainer_headers = [
 nntrainer_base_deps=[
   blas_dep,
   iniparser_dep,
-  ruy_dep,
+  libdl_dep,
+  libm_dep,
   ml_api_common_dep,
+  openmp_dep,
+  ruy_dep,
   thread_dep,
-  openmp_dep
 ]
-
-if host_machine.system() != 'windows'
-  nntrainer_base_deps += [
-    libm_dep,
-    libdl_dep
-  ]
-endif
 
 if get_option('platform') == 'tizen'
   nntrainer_base_deps += dependency('dlog')

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,17 +1,17 @@
 fs = import('fs')
 nntrainer_test_resdir = nntrainer_resdir / 'test'
 
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   nntrainer_test_resdir_win = nntrainer_test_resdir.replace('/', '\\')
   nntrainer_test_resdir_models_win = (nntrainer_test_resdir / 'test_models/').replace('/', '\\')
   test_models_dir_win = (meson.current_source_dir() / 'test_models/').replace('/', '\\')
   if not fs.exists (nntrainer_test_resdir_win)
-    run_command(['cmd.exe', '/C', 'mkdir', nntrainer_test_resdir_win], check: true)
+    run_command([prog_win_cmd, '/C', 'mkdir', nntrainer_test_resdir_win], check: true)
   endif
   if not fs.exists (nntrainer_test_resdir_models_win)
-    run_command(['cmd.exe', '/C', 'mkdir', nntrainer_test_resdir_models_win], check: true)
+    run_command([prog_win_cmd, '/C', 'mkdir', nntrainer_test_resdir_models_win], check: true)
   endif
-  run_command(['cmd.exe', '/C', 'xcopy',test_models_dir_win, nntrainer_test_resdir_models_win, '/i', '/s', '/y'], check: true)
+  run_command([prog_win_cmd, '/C', 'xcopy',test_models_dir_win, nntrainer_test_resdir_models_win, '/i', '/s', '/y'], check: true)
 else
   run_command(['mkdir', '-p', nntrainer_test_resdir], check: true)
 endif

--- a/test/unittest/memory/meson.build
+++ b/test/unittest/memory/meson.build
@@ -11,7 +11,7 @@ test_target = [
   'unittest_cache_pool.cpp'
 ]
 
-if host_machine.system() == 'windows'
+if cxx.get_id() == 'msvc'
   cpp_args_str = ''
 else
   cpp_args_str = '-Wno-maybe-uninitialized'

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -31,13 +31,13 @@ foreach target: unzip_target
   _src_path = src_path / target[0]
   _dest_path = dest_path / target[1]
 
-  if host_machine.system() == 'windows'
+  if build_machine.system() == 'windows'
     _src_path_win = _src_path.replace('/', '\\')
     _dest_path_win = _dest_path.replace('/', '\\')
     if not fs.exists (_dest_path_win)
-      run_command(['cmd.exe', '/C', 'mkdir', _dest_path_win], check: true)
+      run_command([prog_win_cmd, '/C', 'mkdir', _dest_path_win], check: true)
     endif
-    run_command(['cmd.exe', '/C', 'tar', 'xzf', _src_path_win, '-C', _dest_path_win], check: true)
+    run_command([prog_win_cmd, '/C', 'tar', 'xzf', _src_path_win, '-C', _dest_path_win], check: true)
   else
     run_command(['mkdir', '-p', _dest_path], check: true)
     run_command(['tar', 'xzf', _src_path, '-C', _dest_path], check: true)
@@ -46,10 +46,10 @@ endforeach
 
 src_path_label = src_path / 'label.dat'
 dest_path_label = dest_path / 'label.dat'
-if host_machine.system() == 'windows'
+if build_machine.system() == 'windows'
   src_path_label_win = src_path_label.replace('/', '\\')
   dest_path_label_win = dest_path_label.replace('/', '\\')
-  run_command(['cmd.exe', '/C', 'copy', src_path_label_win, dest_path_label_win], check: true)
+  run_command([prog_win_cmd, '/C', 'copy', src_path_label_win, dest_path_label_win], check: true)
 else
   run_command(['cp', '-l', src_path_label, dest_path_label], check: true)
 endif


### PR DESCRIPTION
Those are meson fixes to enable cross-compilation to windows on linux using MSVC
Those are not sufficient to get proper build, due to OpenBLAS cross-compilation problems, but are sufficient to check for compilation errors and warnings.
Using MSVC installed under wine it is possible to start cross-compilation (won't build properly functioning binary yet).

Configuring the tree:
```meson setup --wipe --cross-file=x64-msvc-wine-path.ini --cross-file=x64-msvc-wine-toolchain.ini --cross-file=windows-native.ini build=wine-msvc --buildtype=release```

Where:

`x64-msvc-wine-path.ini`:

```ini
[constants]
x64_msvc_wine_path = '<REPLACE_WITH_PATH_WHERE_INSTALLED>/MSVC/bin/x64/'
```

`x64-msvc-wine-toolchain.ini`:
```ini
[binaries]
c = [x64_msvc_wine_path+'/'+'cl']
cpp = [x64_msvc_wine_path+'/'+'cl']
ar = [x64_msvc_wine_path+'/'+'lib']
c_ld = [x64_msvc_wine_path+'/'+'link']
cpp_ld = [x64_msvc_wine_path+'/'+'link']
windres = [x64_msvc_wine_path+'/'+'rc']
exe_wrapper = ['wine']
cmd.exe = ['wine', 'cmd.exe']

[project options]
enable-blas = false

[properties]
needs_exe_wrapper = true
cmake_skip_compiler_test = 'always'

[host_machine]
system = 'windows'
cpu_family = 'x86_64'
cpu = 'x86_64'
endian = 'little'

[cmake]
CMAKE_MSVC_DEBUG_INFORMATION_FORMAT = 'Embedded'
CMAKE_C_COMPILER_WORKS = '1'
CMAKE_CXX_COMPILER_WORKS = '1'
```

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped