### PR TITLE
[BCQTensor] add argmin & bugfix in BCQTensor @open sesame 13:23

### DIFF
--- a/nntrainer/tensor/bcq_tensor.cpp
+++ b/nntrainer/tensor/bcq_tensor.cpp
@@ -276,38 +276,6 @@ void BCQTensor::read(std::ifstream &file) {
   createBCQW();
 }
 
-std::vector<unsigned int> BCQTensor::argmax() const {
-  std::vector<unsigned int> result;
-  const uint32_t *data = (uint32_t *)getData();
-  size_t batch_size = batch();
-  size_t feature_len = dim.getFeatureLen();
-
-  result.resize(batch_size);
-
-  for (unsigned int b = 0; b < batch_size; b++) {
-    auto max_iter =
-      std::max_element(data + b * feature_len, data + (b + 1) * feature_len);
-    result[b] = std::distance(data, max_iter) - (b * feature_len);
-  }
-  return result;
-}
-
-std::vector<unsigned int> BCQTensor::argmin() const {
-  std::vector<unsigned int> result;
-  const uint32_t *data = (uint32_t *)getData();
-  size_t batch_size = batch();
-  size_t feature_len = dim.getFeatureLen();
-
-  result.resize(batch_size);
-
-  for (unsigned int b = 0; b < batch_size; b++) {
-    auto min_iter =
-      std::min_element(data + b * feature_len, data + (b + 1) * feature_len);
-    result[b] = std::distance(data, min_iter) - (b * feature_len);
-  }
-  return result;
-}
-
 void BCQTensor::save_quantization_info(std::ostream &file) {
   checkedWrite(file, (char *)&quantized_bit_size, sizeof(uint16_t),
                "[BCQTensor::save] failed to write quantization information");
@@ -410,9 +378,9 @@ void BCQTensor::createBCQW() {
   size_t size_of_clusters[] = {width()};
   const size_t number_of_cluster = 1;
 
-  /// @note hidden_tile_size should be set as a multiple of 32. This variable is
-  /// related to the speed of matrixDotMatrix. The optimal value should be found
-  /// with various values according to the usage environment.
+  /// @note hidden_tile_size should be set as a multiple of 32. This variable
+  /// is related to the speed of matrixDotMatrix. The optimal value should be
+  /// found with various values according to the usage environment.
   size_t hidden_tile_size = 32;
 
   bcq_weight = std::make_shared<BiQGEMM::BCQW>(

--- a/nntrainer/tensor/bcq_tensor.cpp
+++ b/nntrainer/tensor/bcq_tensor.cpp
@@ -292,6 +292,22 @@ std::vector<unsigned int> BCQTensor::argmax() const {
   return result;
 }
 
+std::vector<unsigned int> BCQTensor::argmin() const {
+  std::vector<unsigned int> result;
+  const uint32_t *data = (uint32_t *)getData();
+  size_t batch_size = batch();
+  size_t feature_len = dim.getFeatureLen();
+
+  result.resize(batch_size);
+
+  for (unsigned int b = 0; b < batch_size; b++) {
+    auto min_iter =
+      std::min_element(data + b * feature_len, data + (b + 1) * feature_len);
+    result[b] = std::distance(data, min_iter) - (b * feature_len);
+  }
+  return result;
+}
+
 void BCQTensor::save_quantization_info(std::ostream &file) {
   checkedWrite(file, (char *)&quantized_bit_size, sizeof(uint16_t),
                "[BCQTensor::save] failed to write quantization information");

--- a/nntrainer/tensor/bcq_tensor.cpp
+++ b/nntrainer/tensor/bcq_tensor.cpp
@@ -200,7 +200,7 @@ void BCQTensor::initialize(Initializer init) {
 
 Tensor &BCQTensor::dot(Tensor const &input, Tensor &output, bool trans,
                        bool trans_in, float beta) const {
-  BiQGEMM::matrixDotMatrix(output.getData(), bcq_weight, input.getData(),
+  BiQGEMM::matrixDotMatrix(output.getData(), *bcq_weight, input.getData(),
                            input.width());
   return output;
 }

--- a/nntrainer/tensor/bcq_tensor.h
+++ b/nntrainer/tensor/bcq_tensor.h
@@ -219,6 +219,11 @@ public:
   std::vector<unsigned int> argmax() const override;
 
   /**
+   * @copydoc Tensor::argmax()
+   */
+  std::vector<unsigned int> argmin() const override;
+
+  /**
    * @copydoc TensorBase::save_quantization_info(std::ostream &file)
    */
   void save_quantization_info(std::ostream &file) override;

--- a/nntrainer/tensor/bcq_tensor.h
+++ b/nntrainer/tensor/bcq_tensor.h
@@ -214,16 +214,6 @@ public:
   void read(std::ifstream &file) override;
 
   /**
-   * @copydoc Tensor::argmax()
-   */
-  std::vector<unsigned int> argmax() const override;
-
-  /**
-   * @copydoc Tensor::argmax()
-   */
-  std::vector<unsigned int> argmin() const override;
-
-  /**
    * @copydoc TensorBase::save_quantization_info(std::ostream &file)
    */
   void save_quantization_info(std::ostream &file) override;

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -567,6 +567,18 @@ Tensor &TensorBase::apply(std::function<_FP16(_FP16)> f, Tensor &output) const {
 }
 #endif
 
+std::vector<unsigned int> TensorBase::argmax() const {
+  throw std::invalid_argument(
+    "Tensor::argmax() is currently not supported in tensor data type " +
+    getStringDataType());
+}
+
+std::vector<unsigned int> TensorBase::argmin() const {
+  throw std::invalid_argument(
+    "Tensor::argmin() is currently not supported in tensor data type " +
+    getStringDataType());
+}
+
 Tensor &TensorBase::transpose(const std::string &direction, Tensor &out) const {
   throw std::invalid_argument(
     "Tensor::transpose() is currently not supported in tensor data type " +

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -496,12 +496,12 @@ public:
   /**
    * @copydoc Tensor::argmax()
    */
-  virtual std::vector<unsigned int> argmax() const = 0;
+  virtual std::vector<unsigned int> argmax() const;
 
   /**
    * @copydoc Tensor::argmin()
    */
-  virtual std::vector<unsigned int> argmin() const = 0;
+  virtual std::vector<unsigned int> argmin() const;
 
   /**
    * @copydoc Tensor::max_abs()


### PR DESCRIPTION
- Implement argmin() function for BCQTensor, which should be implemented
  to cover the virtual function (Based on @djeong20 's opinion, this patch changed argmin and argmax as non-pure virtual instead of implementing the op for BCQTensor in this PR)
- matrixDotMatrix takes reference (not pointer)

**Self evaluation:**

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped