### PR TITLE
Update QScheme data type and add total memory size retrieval

### DIFF
--- a/nntrainer/tensor/bcq_tensor.cpp
+++ b/nntrainer/tensor/bcq_tensor.cpp
@@ -257,12 +257,10 @@ void BCQTensor::save(std::ostream &file) {
   /// @note Save quantization information
   save_quantization_info(file);
 
-  size_t tensor_bytes = bytes() + scale_size() * sizeof(float);
-
-  std::streamsize sz = static_cast<std::streamsize>(tensor_bytes);
+  std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
-    << "save size: " << bytes()
+    << "save size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedWrite(file, (char *)getData(), sz,
@@ -274,12 +272,10 @@ void BCQTensor::read(std::ifstream &file) {
   /// @note Read quantization information
   read_quantization_info(file);
 
-  size_t tensor_bytes = bytes() + scale_size() * sizeof(float);
-
-  std::streamsize sz = static_cast<std::streamsize>(tensor_bytes);
+  std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
-    << "read size: " << tensor_bytes
+    << "read size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedRead(file, (char *)getData(), sz,
@@ -361,6 +357,10 @@ void BCQTensor::print(std::ostream &out) const {
     out << "-------" << std::endl;
   }
   printScales(out);
+}
+
+size_t BCQTensor::getMemoryBytes() const {
+  return bytes() + scale_size() * sizeof(float);
 }
 
 size_t BCQTensor::scale_size() const { return height() * quantized_bit_size; }

--- a/nntrainer/tensor/bcq_tensor.h
+++ b/nntrainer/tensor/bcq_tensor.h
@@ -230,6 +230,7 @@ public:
    * @copydoc TensorBase::size()
    */
   size_t size() const override;
+
   /**
    * @copydoc Tensor::max_abs()
    */
@@ -249,6 +250,11 @@ public:
    * @copydoc Tensor::print(std::ostream &out)
    */
   void print(std::ostream &out) const override;
+
+  /**
+   * @copydoc Tensor::getMemoryBytes()
+   */
+  size_t getMemoryBytes() const override;
 
   /**
    * @copydoc Tensor::scale_size()

--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -406,12 +406,10 @@ void CharTensor::save(std::ostream &file) {
   /// @note Save quantization information
   save_quantization_info(file);
 
-  size_t tensor_bytes = bytes() + scale_size() * sizeof(float);
-
-  std::streamsize sz = static_cast<std::streamsize>(tensor_bytes);
+  std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
-    << "save size: " << bytes()
+    << "save size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedWrite(file, (char *)getData(), sz,
@@ -423,12 +421,10 @@ void CharTensor::read(std::ifstream &file) {
   /// @note Read quantization information
   read_quantization_info(file);
 
-  size_t tensor_bytes = bytes() + scale_size() * sizeof(float);
-
-  std::streamsize sz = static_cast<std::streamsize>(tensor_bytes);
+  std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
-    << "read size: " << tensor_bytes
+    << "read size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedRead(file, (char *)getData(), sz,
@@ -536,6 +532,10 @@ void CharTensor::print(std::ostream &out) const {
     out << q_scales[i] << " ";
   }
   out << std::endl;
+}
+
+size_t CharTensor::getMemoryBytes() const {
+  return bytes() + scale_size() * sizeof(float);
 }
 
 size_t CharTensor::scale_size() const {

--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -569,12 +569,12 @@ void CharTensor::copy(const void *buf) {
 }
 
 void CharTensor::save_quantization_info(std::ostream &file) {
-  checkedWrite(file, (char *)&qscheme, sizeof(uint8_t),
+  checkedWrite(file, (char *)&qscheme, sizeof(uint16_t),
                "[CharTensor::save] failed to write quantization information");
 }
 
 void CharTensor::read_quantization_info(std::ifstream &file) {
-  checkedRead(file, (char *)&qscheme, sizeof(uint8_t),
+  checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
               "[CharTensor::read] failed to read quantization information");
 }
 

--- a/nntrainer/tensor/char_tensor.h
+++ b/nntrainer/tensor/char_tensor.h
@@ -272,6 +272,11 @@ public:
   void print(std::ostream &out) const override;
 
   /**
+   * @copydoc Tensor::getMemoryBytes()
+   */
+  size_t getMemoryBytes() const override;
+
+  /**
    * @copydoc TensorBase::save_quantization_info()
    */
   void save_quantization_info(std::ostream &file) override;

--- a/nntrainer/tensor/int4_tensor.cpp
+++ b/nntrainer/tensor/int4_tensor.cpp
@@ -334,12 +334,10 @@ void Int4QTensor::save(std::ostream &file) {
   /// @note Save quantization information
   save_quantization_info(file);
 
-  size_t tensor_bytes = bytes() + scale_size() * sizeof(float);
-
-  std::streamsize sz = static_cast<std::streamsize>(tensor_bytes);
+  std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
-    << "save size: " << bytes()
+    << "save size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedWrite(file, (char *)getData(), sz,
@@ -351,12 +349,10 @@ void Int4QTensor::read(std::ifstream &file) {
   /// @note Read quantization information
   read_quantization_info(file);
 
-  size_t tensor_bytes = bytes() + scale_size() * sizeof(float);
-
-  std::streamsize sz = static_cast<std::streamsize>(tensor_bytes);
+  std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
-    << "read size: " << tensor_bytes
+    << "read size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedRead(file, (char *)getData(), sz,
@@ -492,6 +488,11 @@ void Int4QTensor::print(std::ostream &out) const {
     out << q_scales[i] << " ";
   }
   out << std::endl;
+}
+
+size_t Int4QTensor::getMemoryBytes() const {
+  return ((size() + 1) / 2) * dim.getDataTypeSize() +
+         scale_size() * sizeof(float);
 }
 
 size_t Int4QTensor::scale_size() const {

--- a/nntrainer/tensor/int4_tensor.cpp
+++ b/nntrainer/tensor/int4_tensor.cpp
@@ -527,12 +527,12 @@ void Int4QTensor::copy(const void *buf) {
 }
 
 void Int4QTensor::save_quantization_info(std::ostream &file) {
-  checkedWrite(file, (char *)&qscheme, sizeof(uint8_t),
+  checkedWrite(file, (char *)&qscheme, sizeof(uint16_t),
                "[Int4QTensor::save] failed to write quantization information");
 }
 
 void Int4QTensor::read_quantization_info(std::ifstream &file) {
-  checkedRead(file, (char *)&qscheme, sizeof(uint8_t),
+  checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
               "[Int4QTensor::read] failed to read quantization information");
 }
 

--- a/nntrainer/tensor/int4_tensor.h
+++ b/nntrainer/tensor/int4_tensor.h
@@ -261,6 +261,11 @@ public:
   void read_quantization_info(std::ifstream &file) override;
 
   /**
+   * @copydoc Tensor::getMemoryBytes()
+   */
+  size_t getMemoryBytes() const override;
+
+  /**
    * @copydoc Tensor::scale_size()
    */
   size_t scale_size() const override;

--- a/nntrainer/tensor/quantizer.h
+++ b/nntrainer/tensor/quantizer.h
@@ -29,7 +29,7 @@ class Tensor;
  * updated. If you would like to use a different quantization technique, please
  * select a custom quantizer scheme.
  */
-enum class QScheme : uint8_t {
+enum class QScheme : uint16_t {
   /** predefined quantizer */
   PER_TENSOR_AFFINE = 0x00,
   PER_CHANNEL_AFFINE = 0x01,

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -307,12 +307,10 @@ void ShortTensor::save(std::ostream &file) {
   /// @note Save quantization information
   save_quantization_info(file);
 
-  size_t tensor_bytes = bytes() + scale_size() * sizeof(float);
-
-  std::streamsize sz = static_cast<std::streamsize>(tensor_bytes);
+  std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
-    << "save size: " << bytes()
+    << "save size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedWrite(file, (char *)getData(), sz,
@@ -324,12 +322,10 @@ void ShortTensor::read(std::ifstream &file) {
   /// @note Read quantization information
   read_quantization_info(file);
 
-  size_t tensor_bytes = bytes() + scale_size() * sizeof(float);
-
-  std::streamsize sz = static_cast<std::streamsize>(tensor_bytes);
+  std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
-    << "read size: " << tensor_bytes
+    << "read size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedRead(file, (char *)getData(), sz,
@@ -437,6 +433,10 @@ void ShortTensor::print(std::ostream &out) const {
     out << q_scales[i] << " ";
   }
   out << std::endl;
+}
+
+size_t ShortTensor::getMemoryBytes() const {
+  return bytes() + scale_size() * sizeof(float);
 }
 
 size_t ShortTensor::scale_size() const {

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -470,11 +470,11 @@ void ShortTensor::copy(const void *buf) {
 }
 
 void ShortTensor::save_quantization_info(std::ostream &file) {
-  checkedWrite(file, (char *)&qscheme, sizeof(uint8_t),
+  checkedWrite(file, (char *)&qscheme, sizeof(uint16_t),
                "[ShortTensor::save] failed to write quantization information");
 }
 void ShortTensor::read_quantization_info(std::ifstream &file) {
-  checkedRead(file, (char *)&qscheme, sizeof(uint8_t),
+  checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
               "[ShortTensor::read] failed to read quantization information");
 }
 

--- a/nntrainer/tensor/short_tensor.h
+++ b/nntrainer/tensor/short_tensor.h
@@ -235,6 +235,11 @@ public:
   float minValue() const override;
 
   /**
+   * @copydoc Tensor::getMemoryBytes()
+   */
+  size_t getMemoryBytes() const override;
+
+  /**
    * @copydoc Tensor::print(std::ostream &out)
    */
   void print(std::ostream &out) const override;

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1308,6 +1308,8 @@ bool Tensor::empty() const { return itensor->empty(); }
 
 size_t Tensor::bytes() const { return itensor->bytes(); }
 
+size_t Tensor::getMemoryBytes() const { return itensor->getMemoryBytes(); }
+
 size_t Tensor::batch() const { return itensor->batch(); }
 
 size_t Tensor::channel() const { return itensor->channel(); }

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1695,6 +1695,15 @@ public:
   size_t bytes() const;
 
   /**
+   * @brief     Get a total size of the memory data in bytes
+   * @retval    size_t Size in bytes
+   * @note      This is the total size of the memory data, including the scale
+   * factors and the zero points. For float type, this will return the same as
+   * bytes()
+   */
+  size_t getMemoryBytes() const;
+
+  /**
    * @brief     return Tensor batch size
    * @retval    batch size
    */

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -639,6 +639,14 @@ public:
   size_t bytes() const { return size() * dim.getDataTypeSize(); }
 
   /**
+   * @brief     Get a total size of the memory data in bytes
+   * @retval    size_t Size in bytes
+   */
+  virtual size_t getMemoryBytes() const {
+    return size() * dim.getDataTypeSize();
+  }
+
+  /**
    * @brief     return Tensor batch size
    * @retval    batch size
    */

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -359,13 +359,10 @@ template <typename T> void UIntTensor<T>::save(std::ostream &file) {
   /// @note Save quantization information
   save_quantization_info(file);
 
-  size_t tensor_bytes = bytes() + scale_size() * sizeof(float) +
-                        scale_size() * sizeof(unsigned int);
-
-  std::streamsize sz = static_cast<std::streamsize>(tensor_bytes);
+  std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
-    << "save size: " << bytes()
+    << "save size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedWrite(file, (char *)getData(), sz,
@@ -377,13 +374,10 @@ template <typename T> void UIntTensor<T>::read(std::ifstream &file) {
   /// @note Read quantization information
   read_quantization_info(file);
 
-  size_t tensor_bytes = bytes() + scale_size() * sizeof(float) +
-                        scale_size() * sizeof(unsigned int);
-
-  std::streamsize sz = static_cast<std::streamsize>(tensor_bytes);
+  std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
-    << "read size: " << tensor_bytes
+    << "read size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedRead(file, (char *)getData(), sz,
@@ -492,6 +486,11 @@ template <typename T> void UIntTensor<T>::print(std::ostream &out) const {
     out << q_zero_points[i] << " ";
   }
   out << std::endl;
+}
+
+template <typename T> size_t UIntTensor<T>::getMemoryBytes() const {
+  return bytes() + scale_size() * sizeof(float) +
+         scale_size() * sizeof(unsigned int);
 }
 
 template <typename T>

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -495,13 +495,13 @@ template <typename T> size_t UIntTensor<T>::getMemoryBytes() const {
 
 template <typename T>
 void UIntTensor<T>::save_quantization_info(std::ostream &file) {
-  checkedWrite(file, (char *)&qscheme, sizeof(uint8_t),
+  checkedWrite(file, (char *)&qscheme, sizeof(uint16_t),
                "[CharTensor::save] failed to write quantization information");
 }
 
 template <typename T>
 void UIntTensor<T>::read_quantization_info(std::ifstream &file) {
-  checkedRead(file, (char *)&qscheme, sizeof(uint8_t),
+  checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
               "[CharTensor::read] failed to read quantization information");
 }
 

--- a/nntrainer/tensor/uint_tensor.h
+++ b/nntrainer/tensor/uint_tensor.h
@@ -261,6 +261,11 @@ public:
   void print(std::ostream &out) const override;
 
   /**
+   * @copydoc Tensor::getMemoryBytes()
+   */
+  size_t getMemoryBytes() const override;
+
+  /**
    * @copydoc TensorBase::save_quantization_info()
    */
   void save_quantization_info(std::ostream &file) override;


### PR DESCRIPTION
This PR includes two commits that enhance the functionality of the tensor class:

1. Update QScheme data type to 16-bit unsigned integer

This commit changes the QScheme data type to a 16-bit unsigned integer. This modification ensures consistency with the BCQTensor in reading and saving quantization information, which simplifies calculating the offset.

2. [Tensor] Total Memory Size Retrieval

This commit introduces a new method, getMemoryBytes(), to the tensor class, which retrieves the total size of the allocated memory in bytes. The key difference between the existing bytes() function and the new method is that bytes() only returns the storage size for quantized data in quantized tensors, without accounting for the memory used for scaling factors and zero points. However, for float-type tensors, both bytes() and getMemoryBytes() will return the same value.

These changes improve the accuracy and consistency of memory size calculations, making it easier to manage and optimize memory usage in tensor operations.