### PR TITLE
[Save] Update save action (from layer_node -> to layer-wise)

### DIFF
--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -124,6 +124,18 @@ public:
 
   static constexpr const char *type = "batch_normalization";
 
+  /**
+  * @copydoc Layer::save(std::ofstream &file,
+        RunLayerContext &run_context,
+        bool opt_var,
+        ml::train::ExecutionMode mode,
+        bool trainable,
+        TensorDim::DataType definedWeightDataType)
+   */
+  void save(std::ofstream &file, RunLayerContext &run_context, bool opt_var,
+            ml::train::ExecutionMode mode, bool trainable,
+            TensorDim::DataType definedWeightDataType) const override;
+
 private:
   float divider; /**< size of the axes of the reduced */
 


### PR DESCRIPTION
- This patch move action of save from layer_node to every layer
- Instead of branchiing the action of save in the common layer_node wrapper, it is more desirable to define every save action in layer
- This update refers to #2984, which enabled similar features in `read()`

**Self evaluation:**

Build test: [*]Passed [ ]Failed [ ]Skipped
Run test: [*]Passed [ ]Failed [ ]Skipped


