### PR TITLE
[Fix] Fix nntrainer with BiQGEMM enabled compilation

### DIFF
--- a/nntrainer/tensor/bcq_tensor.cpp
+++ b/nntrainer/tensor/bcq_tensor.cpp
@@ -200,7 +200,7 @@ void BCQTensor::initialize(Initializer init) {
 
 Tensor &BCQTensor::dot(Tensor const &input, Tensor &output, bool trans,
                        bool trans_in, float beta) const {
-  BiQGEMM::matrixDotMatrix(output.getData(), bcq_weight, input.getData(),
+  BiQGEMM::matrixDotMatrix(output.getData(), *bcq_weight.get(), input.getData(),
                            input.width());
   return output;
 }
@@ -288,6 +288,22 @@ std::vector<unsigned int> BCQTensor::argmax() const {
     auto max_iter =
       std::max_element(data + b * feature_len, data + (b + 1) * feature_len);
     result[b] = std::distance(data, max_iter) - (b * feature_len);
+  }
+  return result;
+}
+
+std::vector<unsigned int> BCQTensor::argmin() const {
+  std::vector<unsigned int> result;
+  const uint32_t *data = (uint32_t *)getData();
+  size_t batch_size = batch();
+  size_t feature_len = dim.getFeatureLen();
+
+  result.resize(batch_size);
+
+  for (unsigned int b = 0; b < batch_size; b++) {
+    auto min_iter =
+      std::min_element(data + b * feature_len, data + (b + 1) * feature_len);
+    result[b] = std::distance(data, min_iter) - (b * feature_len);
   }
   return result;
 }

--- a/nntrainer/tensor/bcq_tensor.h
+++ b/nntrainer/tensor/bcq_tensor.h
@@ -218,6 +218,8 @@ public:
    */
   std::vector<unsigned int> argmax() const override;
 
+  std::vector<unsigned int> argmin() const override;
+
   /**
    * @copydoc TensorBase::save_quantization_info(std::ostream &file)
    */


### PR DESCRIPTION
BCQTensor class does not implement pure virtual argmin method from base class. So it's not possible to create instance of this class. It cause that nntrainer cannot be compiled with BIQGEMM enabled

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped
