### PR TITLE
[ bugfix ] Fix fp16 is_valid algorithm bug

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/neon_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl_fp16.cpp
@@ -51,7 +51,8 @@ bool is_valid(const unsigned int N, const __fp16 *input) {
     if (val != val) {
       return false;
     }
-    uint16_t val_bits = reinterpret_cast<uint16_t &>(val);
+    uint16_t val_bits;
+    std::memcpy((char *)&val_bits, (const char *)&val, sizeof(__fp16));
     if (val_bits == 0x7C00 || val_bits == 0xFC00) {
       return false;
     }

--- a/nntrainer/tensor/swap_device.h
+++ b/nntrainer/tensor/swap_device.h
@@ -24,6 +24,7 @@
 #include <sys/types.h>
 #include <system_error>
 #include <utility>
+#include <vector>
 #if defined(_WIN32)
 #include <io.h>
 #define O_SYNC 0UL


### PR DESCRIPTION
- Followed by discussion made from #3001, naive reinterpret cast is an undefined behavior. (Thanks @piotrrak !)
- Instead, using std::memcpy will do.
- Meanwhile, SIMD instruction for reinterpret cast will work as the way it is expected.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped


