### PR TITLE
[UINT] Support UINT4-UINT8 / UINT4-UINT16 / UINT8-UINT8 / UINT8-UINT16 (@open sesame 2025-03-31)

### DIFF
--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -55,7 +55,7 @@ void InputLayer::forwarding(RunLayerContext &context, bool training) {
     case Tdatatype::UINT8:
     case Tdatatype::UINT16: {
       //@todo it would be better to be replaced with
-      // hidden_.copy_with_stride(input_);
+      // hidden_.copyData(input_);
       for (size_t b = 0; b < input_.batch(); ++b)
         for (size_t c = 0; c < input_.channel(); ++c)
           for (size_t h = 0; h < input_.height(); ++h)

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -195,17 +195,20 @@ struct ModelTensorDataTypeInfo {
     W32A32,
     WQ16AQ16,
     WU16AU16,
-    W8AU16
+    W8AU16,
+    WU8AU8,
+    WU8AU16,
   };
   static constexpr std::initializer_list<Enum> EnumList = {
-    Enum::W3A32,  Enum::W4A16,    Enum::W4A32,    Enum::W8A16,
-    Enum::W8A32,  Enum::W16A16,   Enum::W16A32,   Enum::W32A16,
-    Enum::W32A32, Enum::WQ16AQ16, Enum::WU16AU16, Enum::W8AU16};
+    Enum::W3A32,    Enum::W4A16,  Enum::W4A32,  Enum::W8A16,  Enum::W8A32,
+    Enum::W16A16,   Enum::W16A32, Enum::W32A16, Enum::W32A32, Enum::WQ16AQ16,
+    Enum::WU16AU16, Enum::W8AU16, Enum::WU8AU8, Enum::WU8AU16};
 
   static constexpr const char *EnumStr[] = {
-    "BCQ-FP32",   "QINT4-FP16",    "QINT4-FP32",    "QINT8-FP16",
-    "QINT8-FP32", "FP16-FP16",     "FP16-FP32",     "FP32-FP16",
-    "FP32-FP32",  "QINT16-QINT16", "UINT16-UINT16", "QINT8-UINT16"};
+    "BCQ-FP32",    "QINT4-FP16",    "QINT4-FP32",    "QINT8-FP16",
+    "QINT8-FP32",  "FP16-FP16",     "FP16-FP32",     "FP32-FP16",
+    "FP32-FP32",   "QINT16-QINT16", "UINT16-UINT16", "QINT8-UINT16",
+    "UINT8-UINT8", "UINT8-UINT16"};
 };
 
 /**

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -196,19 +196,22 @@ struct ModelTensorDataTypeInfo {
     WQ16AQ16,
     WU16AU16,
     W8AU16,
+    WU4AU8,
+    WU4AU16,
     WU8AU8,
-    WU8AU16,
+    WU8AU16
   };
   static constexpr std::initializer_list<Enum> EnumList = {
-    Enum::W3A32,    Enum::W4A16,  Enum::W4A32,  Enum::W8A16,  Enum::W8A32,
-    Enum::W16A16,   Enum::W16A32, Enum::W32A16, Enum::W32A32, Enum::WQ16AQ16,
-    Enum::WU16AU16, Enum::W8AU16, Enum::WU8AU8, Enum::WU8AU16};
+    Enum::W3A32,  Enum::W4A16,    Enum::W4A32,    Enum::W8A16,
+    Enum::W8A32,  Enum::W16A16,   Enum::W16A32,   Enum::W32A16,
+    Enum::W32A32, Enum::WQ16AQ16, Enum::WU16AU16, Enum::W8AU16,
+    Enum::WU4AU8, Enum::WU4AU16,  Enum::WU8AU8,   Enum::WU8AU16};
 
   static constexpr const char *EnumStr[] = {
     "BCQ-FP32",    "QINT4-FP16",    "QINT4-FP32",    "QINT8-FP16",
     "QINT8-FP32",  "FP16-FP16",     "FP16-FP32",     "FP32-FP16",
     "FP32-FP32",   "QINT16-QINT16", "UINT16-UINT16", "QINT8-UINT16",
-    "UINT8-UINT8", "UINT8-UINT16"};
+    "UINT4-UINT8", "UINT4-UINT16",  "UINT8-UINT8",   "UINT8-UINT16"};
 };
 
 /**

--- a/test/unittest/integration_tests/integration_test_mixed_precision.cpp
+++ b/test/unittest/integration_tests/integration_test_mixed_precision.cpp
@@ -118,11 +118,12 @@ TEST(mixed_precision, model_tensor_type_test) {
   std::unique_ptr<ml::train::Model> nn =
     ml::train::createModel(ml::train::ModelType::NEURAL_NET, {"loss=mse"});
 
-  std::string positive_type_list[] = {"QINT4-FP16", "QINT4-FP32", "QINT8-FP16",
-                                      "QINT8-FP32", "FP16-FP16",  "FP16-FP32",
-                                      "FP32-FP16",  "FP32-FP32"};
-  std::string negative_type_list[] = {"FP16-XXX", "XXX-XXX", "", "ttkt",
-                                      "UINT8-UINT8"};
+  std::string positive_type_list[] = {
+    "QINT4-FP16",    "QINT4-FP32",    "QINT8-FP16",   "QINT8-FP32",
+    "FP16-FP16",     "FP16-FP32",     "FP32-FP16",    "FP32-FP32",
+    "QINT16-QINT16", "UINT16-UINT16", "QINT8-UINT16", "UINT4-UINT8",
+    "UINT4-UINT16",  "UINT8-UINT8",   "UINT8-UINT16"};
+  std::string negative_type_list[] = {"FP16-XXX", "XXX-XXX", "", "ttkt"};
 
   for (auto type_item : positive_type_list) {
     EXPECT_NO_THROW(nn->setProperty(


### PR DESCRIPTION
- This patch supports UINT4-UINT8 / UINT4-UINT16 / UINT8-UINT8 / UINT8-UINT16
- Please note that the input_layer is updated to `copyData` 
- Quantizer is removed in this layer. 
- Input layer should be updated in the way to take `quantize` parameter making a branch of its action.

**Self evaluation:**

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped