### PR TITLE
[code clean] remove std::cout in cache_pool

### DIFF
--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -294,7 +294,6 @@ void CachePool::clear() {
 bool CachePool::isAllocated() const { return swap_device->isOperating(); }
 
 void CachePool::loadExec(unsigned int order) {
-  std::cout << "loadExec " << order << std::endl;
   for (auto &id : exec_ids[order])
     validate(id);
 }


### PR DESCRIPTION
- This message is used only for debugging.
- This patch remove the code line


**Self evaluation:**

Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped