### PR TITLE
[Android] Ruy as a prebuilt static library

### DIFF
--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -22,8 +22,6 @@
 #include <tensor_dim.h>
 #include <util_func.h>
 
-#include "ruy/ruy.h"
-
 #define transposeloop(cl, ci, cj, ck, sl, si, sj, sk)                          \
   do {                                                                         \
     unsigned int i, j, k, l;                                                   \

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -29,7 +29,6 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 	$(NNTRAINER_ROOT)/nntrainer/utils \
 	$(NNTRAINER_ROOT)/api \
 	$(NNTRAINER_ROOT)/api/ccapi/include \
-	$(NNTRAINER_ROOT)/subprojects/ruy \
 	${ML_API_COMMON_INCLUDES}
 
 LOCAL_MODULE := nntrainer
@@ -43,6 +42,13 @@ LOCAL_MODULE := ccapi-nntrainer
 LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/builddir/jni/$(TARGET_ARCH_ABI)/libccapi-nntrainer.so
 
 include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := ruy-nntrainer
+LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/builddir/obj/local/$(TARGET_ARCH_ABI)/libruy.a
+
+include $(PREBUILT_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
 GTEST_PATH := googletest
@@ -83,7 +89,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 
@@ -100,7 +106,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 
@@ -117,7 +123,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 
@@ -134,7 +140,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 
@@ -151,7 +157,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 
@@ -168,7 +174,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 
@@ -185,7 +191,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 
@@ -202,7 +208,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 
@@ -219,7 +225,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 
@@ -236,7 +242,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 
@@ -253,7 +259,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -269,7 +275,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -285,7 +291,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -301,7 +307,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -317,7 +323,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -333,7 +339,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -349,7 +355,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -367,7 +373,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -385,7 +391,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -405,7 +411,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -429,7 +435,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -485,7 +491,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -501,7 +507,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -517,7 +523,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
 # unittest_ccapi
@@ -534,5 +540,5 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
-LOCAL_STATIC_LIBRARIES := googletest_main test_util
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
This PR enables using Ruy as a prebuilt static library in Android tests.
When the proper Ruy interface is introduced, the Ruy header will be included in the cpu_backend directory.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

