### PR TITLE
[Windows] Fix D9024 warnings

### DIFF
--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -3,7 +3,7 @@ layer_common_test_standalone_files = files('layers_standalone_common_tests.cpp')
 layer_common_test_dependent_files = files('layers_dependent_common_tests.cpp')
 
 if host_machine.system() == 'windows'
-  cpp_args_str = ''
+  cpp_args_str = []
 else
   cpp_args_str = '-Wno-maybe-uninitialized'
 endif

--- a/test/unittest/memory/meson.build
+++ b/test/unittest/memory/meson.build
@@ -13,7 +13,7 @@ test_target = [
 ]
 
 if cxx.get_id() == 'msvc'
-  cpp_args_str = ''
+  cpp_args_str = []
 else
   cpp_args_str = '-Wno-maybe-uninitialized'
 endif


### PR DESCRIPTION
This PR fix following warnings during Windows compilation: cl : Command line warning D9024 : unrecognized source file type '', object file assumed

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

