### PR TITLE
Bug Fix: OpenCL Context Registration in Engine Class for NNTrainer GPU Support

### DIFF
--- a/nntrainer/engine.cpp
+++ b/nntrainer/engine.cpp
@@ -46,9 +46,9 @@ void Engine::add_default_object(Engine &eg) {
 
   eg.registerContext("cpu", app_context);
 
-#ifdef ENALBE_OPENCL
-  eg.registererContext("gpu",
-                       nntrainer::ClContext(nntrainer::ClContext::Global()));
+#ifdef ENABLE_OPENCL
+  eg.registerContext("gpu",
+                     nntrainer::ClContext(nntrainer::ClContext::Global()));
 #endif
 }
 

--- a/nntrainer/engine.cpp
+++ b/nntrainer/engine.cpp
@@ -23,10 +23,6 @@
 #include <dynamic_library_loader.h>
 #include <engine.h>
 
-#ifdef ENABLE_OPENCL
-#include <cl_context.h>
-#endif
-
 static std::string solib_suffix = ".so";
 static std::string contextlib_suffix = "context.so";
 static const std::string func_tag = "[Engine] ";
@@ -47,8 +43,10 @@ void Engine::add_default_object(Engine &eg) {
   eg.registerContext("cpu", app_context);
 
 #ifdef ENABLE_OPENCL
-  eg.registerContext("gpu",
-                     nntrainer::ClContext(nntrainer::ClContext::Global()));
+  nntrainer::ClContext *cl_context = new nntrainer::ClContext();
+  cl_context->Global();
+
+  eg.registerContext("gpu", cl_context);
 #endif
 }
 

--- a/nntrainer/engine.h
+++ b/nntrainer/engine.h
@@ -28,8 +28,11 @@
 
 #include <context.h>
 #include <mem_allocator.h>
-
 #include <nntrainer_error.h>
+
+#ifdef ENABLE_OPENCL
+#include <cl_context.h>
+#endif
 
 namespace nntrainer {
 

--- a/test/unittest/layers/layers_dependent_common_tests.cpp
+++ b/test/unittest/layers/layers_dependent_common_tests.cpp
@@ -124,12 +124,13 @@ TEST_P(LayerSemantics, setBatchValidateLayerNode_p) {
 
 #ifdef ENABLE_OPENCL
 TEST_P(LayerSemanticsGpu, createFromClContext_pn) {
-  auto &ac = nntrainer::ClContext::Global();
+  auto &eg = nntrainer::Engine::Global();
+  auto cc = static_cast<nntrainer::ClContext *>(eg.getRegisteredContext("gpu"));
   if (!(options & LayerCreateSetPropertyOptions::AVAILABLE_FROM_APP_CONTEXT)) {
-    ac.registerFactory<nntrainer::Layer>(std::get<0>(GetParam()));
+    cc->registerFactory<nntrainer::Layer>(std::get<0>(GetParam()));
   }
 
-  EXPECT_EQ(ac.createObject<nntrainer::Layer>(expected_type)->getType(),
+  EXPECT_EQ(cc->createObject<nntrainer::Layer>(expected_type)->getType(),
             expected_type);
 }
 

--- a/test/unittest/unittest_attention_kernels_cl.cpp
+++ b/test/unittest/unittest_attention_kernels_cl.cpp
@@ -29,14 +29,7 @@
 
 using namespace nntrainer;
 
-static void setUpGpuContext() {
-  auto &ac = nntrainer::ClContext::Global();
-  ac.initAttentionClKernels();
-}
-
 TEST(attention_kernels, rotary_emb_kernel_FP32) {
-  setUpGpuContext();
-
   int batch = 1;
   int channel = 1;
   int height = 4;
@@ -78,8 +71,6 @@ TEST(attention_kernels, rotary_emb_kernel_FP32) {
 }
 
 TEST(attention_kernels, rotary_emb_kernel_FP32_case2) {
-  setUpGpuContext();
-
   int batch = 4;
   int channel = 4;
   int height = 8;
@@ -121,8 +112,6 @@ TEST(attention_kernels, rotary_emb_kernel_FP32_case2) {
 }
 
 TEST(attention_kernels, rotary_emb_kernel_FP16) {
-  setUpGpuContext();
-
   int batch = 1;
   int channel = 1;
   int height = 4;
@@ -163,8 +152,6 @@ TEST(attention_kernels, rotary_emb_kernel_FP16) {
 }
 
 TEST(attention_kernels, rotary_emb_kernel_FP16_case2) {
-  setUpGpuContext();
-
   int batch = 4;
   int channel = 4;
   int height = 8;

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -27,10 +27,7 @@
 
 using namespace nntrainer;
 
-static void setUpGpuContext() { auto &ac = nntrainer::ClContext::Global(); }
-
 TEST(blas_kernels, dotCL_sgemv_M_1_1) {
-  setUpGpuContext();
   int batch = 1;
   int channel = 1;
   int height = 1;
@@ -76,7 +73,6 @@ TEST(blas_kernels, dotCL_sgemv_M_1_1) {
 }
 
 TEST(blas_kernels, dotCL_sgemv_M_1_1_fp16) {
-  setUpGpuContext();
   int batch = 1;
   int channel = 1;
   int height = 1;
@@ -460,7 +456,6 @@ TEST(blas_kernels, dotCL_sgemv_n_fp16) {
 }
 
 TEST(blas_kernels, dotCL_sgemv_N_1_M_1_1) {
-  setUpGpuContext();
   int batch = 1;
   int channel = 1;
   int height = 1;
@@ -505,7 +500,6 @@ TEST(blas_kernels, dotCL_sgemv_N_1_M_1_1) {
 }
 
 TEST(blas_kernels, dotCL_sgemv_N_1_M_1_2) {
-  setUpGpuContext();
   int batch = 1;
   int channel = 1;
   int height = 1;


### PR DESCRIPTION
This pull request addresses a bug in the Engine class related to the registration of the OpenCL context. The newly introduced Engine class lacked the functionality to register the OpenCL context, which prevented NNTrainer from utilizing the GPU engine. Additionally, I corrected a typo that caused the registerContext function to fail in checking the GPU context, preventing it from registering properly with the engine. I have also updated the functions for context registration.