### PR TITLE
GPU Context Initialization and Layer Object Creation

### DIFF
--- a/nntrainer/cl_context.h
+++ b/nntrainer/cl_context.h
@@ -36,8 +36,6 @@
 #include <opencl_kernel.h>
 #include <opencl_program.h>
 
-#include <nntrainer_log.h>
-
 namespace nntrainer {
 
 extern std::mutex cl_factory_mutex;
@@ -183,6 +181,32 @@ public:
 
     // entry -> object of str_map -> unordered_map<std::string, FactoryType<T>>
     return entry->second(props);
+  }
+
+  /**
+   * @brief Create a Layer object from the string key
+   *
+   * @param type string key
+   * @param properties property
+   * @return std::unique_ptr<nntrainer::Layer> unique pointer to the object
+   */
+  std::unique_ptr<nntrainer::Layer>
+  createLayerObject(const std::string &type,
+                    const std::vector<std::string> &properties = {}) override {
+    return createObject<nntrainer::Layer>(type, properties);
+  }
+
+  /**
+   * @brief Create a Layer object from the integer key
+   *
+   * @param type integer key
+   * @param properties property
+   * @return std::unique_ptr<nntrainer::Layer> unique pointer to the object
+   */
+  std::unique_ptr<nntrainer::Layer>
+  createLayerObject(const int int_key,
+                    const std::vector<std::string> &properties = {}) override {
+    return createObject<nntrainer::Layer>(int_key, properties);
   }
 
   /**

--- a/nntrainer/context.h
+++ b/nntrainer/context.h
@@ -125,6 +125,9 @@ public:
   virtual PtrType<nntrainer::Layer>
   createLayerObject(const std::string &type,
                     const std::vector<std::string> &props = {}) {
+    ml_logw(
+      "[Warning] Implement createLayerObject for the concrete context class to "
+      "properly create the layer");
     return nullptr;
   };
 
@@ -138,11 +141,14 @@ public:
   virtual PtrType<nntrainer::Layer>
   createLayerObject(const int int_key,
                     const std::vector<std::string> &props = {}) {
+    ml_logw(
+      "[Warning] Implement createLayerObject for the concrete context class to "
+      "properly create the layer");
     return nullptr;
   };
 
   /**
-   * @brief Create an Optimizer Object from the type (stirng)
+   * @brief Create an Optimizer Object from the type (string)
    *
    * @param type type of optimizer
    * @param props property

--- a/nntrainer/engine.h
+++ b/nntrainer/engine.h
@@ -143,7 +143,6 @@ public:
   createLayerObject(const std::string &type,
                     const std::vector<std::string> &properties = {}) const {
     auto ct = getRegisteredContext(parseComputeEngine(properties));
-    ct->getName();
     return ct->createLayerObject(type);
   }
 


### PR DESCRIPTION
This pull request addresses issues related to the GPU context when creating the global instance and the GPU layer object.

**Changes proposed in this PR:**
- Modify ClContext::Global to return the newly created object rather than a static instance.
- Override the Context::createLayerObject function to correctly create a GPU layer object.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped