### PR TITLE
Fix meson.build for Applications on Windows

### DIFF
--- a/Applications/AlexNet/jni/meson.build
+++ b/Applications/AlexNet/jni/meson.build
@@ -8,7 +8,7 @@ if build_machine.system() == 'windows'
   if not fs.exists (build_app_res_dir_win)
     run_command([prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win], check: true)
   endif
-  run_command([prog_win_cmd, '/C', 'xcopy', app_res_dir_win, build_app_res_dir_win], check: true)
+  run_command(['xcopy', '/C', '/Y', app_res_dir_win, build_app_res_dir_win], check: true)
 else
   run_command(['cp', '-lr', app_res_dir, build_app_res_dir], check: true)
 endif

--- a/Applications/Custom/LayerClient/jni/meson.build
+++ b/Applications/Custom/LayerClient/jni/meson.build
@@ -8,7 +8,7 @@ if build_machine.system() == 'windows'
   if not fs.exists (build_app_res_dir_win)
     run_command([prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win], check: true)
   endif
-  run_command([prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win], check: true)
+  run_command(['xcopy', '/C', '/Y', app_res_dir_win, build_app_res_dir_win], check: true)
 else
   run_command(['cp', '-lr', app_res_dir, build_app_res_dir], check: true)
 endif

--- a/Applications/Layers/jni/meson.build
+++ b/Applications/Layers/jni/meson.build
@@ -8,7 +8,7 @@ if build_machine.system() == 'windows'
   if not fs.exists (build_app_res_dir_win)
     run_command([prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win], check: true)
   endif
-  run_command([prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win], check: true)
+  run_command(['xcopy', '/C', '/Y', app_res_dir_win, build_app_res_dir_win], check: true)
 else
   run_command(['cp', '-lr', app_res_dir, build_app_res_dir], check: true)
 endif

--- a/Applications/LogisticRegression/jni/meson.build
+++ b/Applications/LogisticRegression/jni/meson.build
@@ -8,7 +8,7 @@ if build_machine.system() == 'windows'
   if not fs.exists (build_app_res_dir_win)
     run_command([prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win], check: true)
   endif
-  run_command([prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win], check: true)
+  run_command(['xcopy', '/C', '/Y', app_res_dir_win, build_app_res_dir_win], check: true)
 else
   run_command(['cp', '-lr', app_res_dir, build_app_res_dir], check: true)
 endif

--- a/Applications/MNIST/jni/meson.build
+++ b/Applications/MNIST/jni/meson.build
@@ -8,7 +8,7 @@ if build_machine.system() == 'windows'
   if not fs.exists (build_app_res_dir_win)
     run_command([prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win], check: true)
   endif
-  run_command([prog_win_cmd, '/C', 'xcopy', app_res_dir_win, build_app_res_dir_win], check: true)
+  run_command(['xcopy', '/C', '/Y', app_res_dir_win, build_app_res_dir_win], check: true)
 else
   run_command(['cp', '-lr', app_res_dir, build_app_res_dir], check: true)
 endif

--- a/Applications/ProductRatings/jni/meson.build
+++ b/Applications/ProductRatings/jni/meson.build
@@ -8,7 +8,7 @@ if build_machine.system() == 'windows'
   if not fs.exists (build_app_res_dir_win)
     run_command([prog_win_cmd, '/C', 'mkdir', build_app_res_dir_win], check: true)
   endif
-  run_command([prog_win_cmd, '/C', 'xcopy',app_res_dir_win, build_app_res_dir_win], check: true)
+  run_command(['xcopy', '/C', '/Y', app_res_dir_win, build_app_res_dir_win], check: true)
 else
   run_command(['cp', '-lr', app_res_dir, build_app_res_dir], check: true)
 endif


### PR DESCRIPTION
While meson-setting is being run on Windows, `xcopy` fails when it overwrites

with the build dir already containing resource files (mostly by previous build). 

This commit fixes it by adding `/Y` option.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped


