### PR TITLE
meson_version: >=0.55.0 -> 0.61.2

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ The following dependencies are needed to compile/build/run.
 
 * gcc/g++ >= 7 ( std=c++17 is used )
    - (note)  >= 13 is recommended to enable fp16 support
-* meson >= 0.55.0
+* meson >= 0.61.2
 * libopenblas-dev and base
 * tensorflow-lite >= 2.3.0
 * libiniparser

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('nntrainer', 'c', 'cpp',
   version: '0.6.0',
   license: ['apache-2.0'],
-  meson_version: '>=0.55.0',
+  meson_version: '>=0.61.2',
   default_options: [
     'werror=true',
     'warning_level=1',


### PR DESCRIPTION
- To fix the warning: ```WARNING: Project targets '>=0.55.0' but uses ...```

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

