### PR TITLE
[ cpu_backend ] Add skeleton for gemm_q4_K

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -210,4 +210,9 @@ bool is_valid(const unsigned int N, const float *input) {
   return nntrainer::neon::is_valid(N, input);
 }
 
+void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc) {
+  return __gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
+}
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -595,6 +595,23 @@ void ele_div(const unsigned N, const float *X, const float *Y, float *Z,
  * @param[out] bool false if not valid else true
  */
 bool is_valid(const unsigned int N, const float *X);
+
+/**
+ * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
+ *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __ARM_COMPUTE_BACKEND_H__ */

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -599,5 +599,23 @@ extern void ele_div(const unsigned N, const float *X, const float *Y, float *Z,
  * @param[out] bool false if not valid else true
  */
 extern bool is_valid(const unsigned int N, const float *X);
+
+/**
+ * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
+ *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+extern void gemm_q4_K(const unsigned int M, const unsigned int N,
+                      const unsigned int K, const float *A,
+                      const unsigned int lda, const void *B,
+                      const unsigned int ldb, float *C, const unsigned int ldc);
 #endif
 #endif

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -167,4 +167,10 @@ float max_val(const unsigned int N, float *X) { return __fallback_max(N, X); }
 void softmax(const unsigned int N, float *X, float *Y) {
   __fallback_softmax(N, X, Y);
 }
+
+void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc) {
+  return __gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
+}
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -591,6 +591,23 @@ void ele_div(const unsigned N, const float *X, const float *Y, float *Z,
  * @param[out] bool false if not valid else true
  */
 bool is_valid(const unsigned int N, const float *X);
+
+/**
+ * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
+ *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __FALLBACK_H__ */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -319,4 +319,11 @@ void __fallback_softmax(const unsigned int N, float *X, float *Y) {
     ++i;
   }
 }
+
+void __gemm_q4_K(const unsigned int M, const unsigned int N,
+                 const unsigned int K, const float *A, const unsigned int lda,
+                 const void *B, const unsigned int ldb, float *C,
+                 const unsigned int ldc) {
+  throw std::runtime_error("NYI : __gemm_q4_K");
+}
 } // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -613,6 +613,23 @@ void __fallback_ele_sub(const unsigned N, const float *X, const float *Y,
 void __fallback_ele_div(const unsigned N, const float *X, const float *Y,
                         float *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride);
+/**
+ * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
+ *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void __gemm_q4_K(const unsigned int M, const unsigned int N,
+                 const unsigned int K, const float *A, const unsigned int lda,
+                 const void *B, const unsigned int ldb, float *C,
+                 const unsigned int ldc);
 } // namespace nntrainer
 #endif
 #endif

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -178,4 +178,9 @@ void softmax(const unsigned int N, float *X, float *Y) {
   __fallback_softmax(N, X, Y);
 }
 
+void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc) {
+  return __gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
+}
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -591,6 +591,23 @@ void ele_div(const unsigned N, const float *X, const float *Y, float *Z,
  * @param[out] bool false if not valid else true
  */
 bool is_valid(const unsigned int N, const float *X);
+
+/**
+ * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
+ *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __x86_COMPUTE_BACKEND_H__ */


### PR DESCRIPTION
To reviewers, this PR might be helpful for those who want to add a new function interface on `cpu_backend.h`.
Those who want to involve in adding more features here can come back to this PR, and implement from the beginning.

Proposes:
- Add a skeleton implementation for q4_K quantized GEMM.
- Internal representation will be proposed later on.
- Function parameters introduced here might change.


**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped


