### PR TITLE
[Tensor] copy_fp32 implementation and its application in tensor copyData()

### DIFF
--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -384,6 +384,9 @@ void CharTensor::copyData(const Tensor &from) {
   case ml::train::TensorDim::DataType::QINT8:
     copy(from.getData());
     break;
+  case ml::train::TensorDim::DataType::FP32:
+    copy_fp32(from.size(), from.getData<float>(), (int8_t *)getData());
+    break;
   default:
     throw std::invalid_argument("Error: Unsupported data type");
     break;

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -24,6 +24,7 @@
 #endif
 
 #include <cstdint>
+#include <stdexcept>
 #include <tensor_dim.h>
 
 #ifdef ENABLE_FP16
@@ -418,6 +419,26 @@ extern void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y);
  * @param[in] Y float * for Vector Y
  */
 extern void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y T * for Vector Y
+ */
+template <typename T>
+void copy_fp32(const unsigned int N, const float *X, T *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y T * for Vector Y
+ */
+template <typename T>
+void copy_fp32(const unsigned int N, const float *X, T *Y) {
+  throw std::invalid_argument("copy_fp32 for the type is not supported");
+}
 
 /**
  * @brief     copy function : Y = X

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -145,6 +145,26 @@ void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y) {
   __fallback_copy_u16_fp32(N, X, Y);
 }
 
+void copy_fp32_u32(const unsigned int N, const float *X, uint32_t *Y) {
+  __fallback_copy_fp32_u32(N, X, Y);
+}
+
+void copy_fp32_u16(const unsigned int N, const float *X, uint16_t *Y) {
+  __fallback_copy_fp32_u16(N, X, Y);
+}
+
+void copy_fp32_u8(const unsigned int N, const float *X, uint8_t *Y) {
+  __fallback_copy_fp32_u8(N, X, Y);
+}
+
+void copy_fp32_s16(const unsigned int N, const float *X, int16_t *Y) {
+  __fallback_copy_fp32_s16(N, X, Y);
+}
+
+void copy_fp32_s8(const unsigned int N, const float *X, int8_t *Y) {
+  __fallback_copy_fp32_s8(N, X, Y);
+}
+
 void copy_s16(const unsigned int N, const int16_t *X, int16_t *Y) {
   __fallback_copy_s16(N, X, Y);
 }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -408,6 +408,100 @@ void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y);
 /**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint32_t * for Vector Y
+ */
+void copy_fp32_u32(const unsigned int N, const float *X, uint32_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+void copy_fp32_u16(const unsigned int N, const float *X, uint16_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint8_t * for Vector Y
+ */
+void copy_fp32_u8(const unsigned int N, const float *X, uint8_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int16_t * for Vector Y
+ */
+void copy_fp32_s16(const unsigned int N, const float *X, int16_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int8_t * for Vector Y
+ */
+void copy_fp32_s8(const unsigned int N, const float *X, int8_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint32_t * for Vector Y
+ */
+template <>
+void copy_fp32<uint32_t>(const unsigned int N, const float *X, uint32_t *Y) {
+  copy_fp32_u32(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+template <>
+void copy_fp32<uint16_t>(const unsigned int N, const float *X, uint16_t *Y) {
+  copy_fp32_u16(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+template <>
+void copy_fp32<uint8_t>(const unsigned int N, const float *X, uint8_t *Y) {
+  copy_fp32_u8(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int16_t * for Vector Y
+ */
+template <>
+void copy_fp32<int16_t>(const unsigned int N, const float *X, int16_t *Y) {
+  copy_fp32_s16(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int8_t * for Vector Y
+ */
+template <>
+void copy_fp32<int8_t>(const unsigned int N, const float *X,
+                       int8_t *Y){copy_fp32_s8(N, X, Y)};
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
  * @param[in] X int16_t * for Vector X
  * @param[in] Y int16_t * for Vector Y
  */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -67,6 +67,39 @@ void __fallback_copy_u16_fp32(const unsigned int N, const uint16_t *X,
   }
 }
 
+void __fallback_copy_fp32_u32(const unsigned int N, const float *X,
+                              uint32_t *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    Y[i] = X[i];
+  }
+}
+
+void __fallback_copy_fp32_u16(const unsigned int N, const float *X,
+                              uint16_t *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    Y[i] = X[i];
+  }
+}
+
+void __fallback_copy_fp32_u8(const unsigned int N, const float *X, uint8_t *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    Y[i] = X[i];
+  }
+}
+
+void __fallback_copy_fp32_s16(const unsigned int N, const float *X,
+                              int16_t *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    Y[i] = X[i];
+  }
+}
+
+void __fallback_copy_fp32_s8(const unsigned int N, const float *X, int8_t *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    Y[i] = X[i];
+  }
+}
+
 void __fallback_copy_s16(const unsigned int N, const int16_t *X, int16_t *Y) {
   for (unsigned int i = 0; i < N; ++i) {
     Y[i] = X[i];

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -411,6 +411,43 @@ void __fallback_copy_u16_fp32(const unsigned int N, const uint16_t *X,
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
  * @param[in] X float * for Vector X
+ * @param[in] Y uint32_t * for Vector Y
+ */
+void __fallback_copy_fp32_u32(const unsigned int N, const float *X,
+                              uint32_t *Y);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+void __fallback_copy_fp32_u16(const unsigned int N, const float *X,
+                              uint16_t *Y);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint8_t * for Vector Y
+ */
+void __fallback_copy_fp32_u8(const unsigned int N, const float *X, uint8_t *Y);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int16_t * for Vector Y
+ */
+void __fallback_copy_fp32_s16(const unsigned int N, const float *X, int16_t *Y);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int8_t * for Vector Y
+ */
+void __fallback_copy_fp32_s8(const unsigned int N, const float *X, int8_t *Y);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
  * @param[in] Y float * for Vector Y
  */
 void __fallback_scopy(const unsigned int N, const float *X,

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -285,6 +285,9 @@ void ShortTensor::copyData(const Tensor &from) {
   case ml::train::TensorDim::DataType::QINT16:
     copy(from.getData());
     break;
+  case ml::train::TensorDim::DataType::FP32:
+    copy_fp32(from.size(), from.getData<float>(), (int16_t *)getData());
+    break;
   default:
     throw std::invalid_argument("Error: Unsupported data type");
     break;

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -331,11 +331,18 @@ template <typename T> void UIntTensor<T>::copyData(const Tensor &from) {
   NNTR_THROW_IF(size() != from.size(), std::invalid_argument)
     << "Size of tensor to copy must match";
 
+  // copy data with the same data type T
+  if (from.getDataType() == getDataType()) {
+    copy(from.getData<T>());
+    return;
+  }
+
   /// @todo support copy from other data types
   switch (from.getDataType()) {
-  case ml::train::TensorDim::DataType::UINT16:
-    copy(from.getData());
+  case ml::train::TensorDim::DataType::FP32: {
+    copy_fp32(from.size(), from.getData<float>(), (T *)getData());
     break;
+  }
   default:
     throw std::invalid_argument("Error: Unsupported data type");
     break;


### PR DESCRIPTION
- This commit implements template function copy_fp32 in cpu_backend
- This commit implements several copy_fp32 support in fallback
- This commit updates tensrs' copyData() in uint/short/char tensor
- see also #3065

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped