### PR TITLE
[Tensor] copy_fp32 implementation and its application in tensor copyData() @open sesame

### DIFF
--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -384,6 +384,9 @@ void CharTensor::copyData(const Tensor &from) {
   case ml::train::TensorDim::DataType::QINT8:
     copy(from.getData());
     break;
+  case ml::train::TensorDim::DataType::FP32:
+    copy_fp32(from.size(), from.getData<float>(), (int8_t *)getData());
+    break;
   default:
     throw std::invalid_argument("Error: Unsupported data type");
     break;

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -65,6 +65,26 @@ void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
   }
 }
 
+void copy_fp32_u32(const unsigned int N, const float *X, uint32_t *Y) {
+  __fallback_copy_fp32_u32(N, X, Y);
+}
+
+void copy_fp32_u16(const unsigned int N, const float *X, uint16_t *Y) {
+  __fallback_copy_fp32_u16(N, X, Y);
+}
+
+void copy_fp32_u8(const unsigned int N, const float *X, uint8_t *Y) {
+  __fallback_copy_fp32_u8(N, X, Y);
+}
+
+void copy_fp32_s16(const unsigned int N, const float *X, int16_t *Y) {
+  __fallback_copy_fp32_s16(N, X, Y);
+}
+
+void copy_fp32_s8(const unsigned int N, const float *X, int8_t *Y) {
+  __fallback_copy_fp32_s8(N, X, Y);
+}
+
 void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y) {
   nntrainer::neon::copy_s16_fp32(N, X, Y);
 }

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -15,6 +15,7 @@
 #ifdef __cplusplus
 
 #include <cstdint>
+#include <stdexcept>
 #include <tensor_dim.h>
 
 namespace nntrainer {
@@ -425,6 +426,125 @@ void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y);
  * @param[in] Y float * for Vector Y
  */
 void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint32_t * for Vector Y
+ */
+void copy_fp32_u32(const unsigned int N, const float *X, uint32_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+void copy_fp32_u16(const unsigned int N, const float *X, uint16_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint8_t * for Vector Y
+ */
+void copy_fp32_u8(const unsigned int N, const float *X, uint8_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int16_t * for Vector Y
+ */
+void copy_fp32_s16(const unsigned int N, const float *X, int16_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int8_t * for Vector Y
+ */
+void copy_fp32_s8(const unsigned int N, const float *X, int8_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y T * for Vector Y
+ */
+template <typename T>
+void copy_fp32(const unsigned int N, const float *X, T *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y T * for Vector Y
+ */
+template <typename T>
+inline void copy_fp32(const unsigned int N, const float *X, T *Y) {
+  throw std::invalid_argument("copy_fp32 for the type is not supported");
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint32_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<uint32_t>(const unsigned int N, const float *X,
+                                uint32_t *Y) {
+  copy_fp32_u32(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<uint16_t>(const unsigned int N, const float *X,
+                                uint16_t *Y) {
+  copy_fp32_u16(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<uint8_t>(const unsigned int N, const float *X,
+                               uint8_t *Y) {
+  copy_fp32_u8(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int16_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<int16_t>(const unsigned int N, const float *X,
+                               int16_t *Y) {
+  copy_fp32_s16(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int8_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<int8_t>(const unsigned int N, const float *X, int8_t *Y) {
+  copy_fp32_s8(N, X, Y);
+}
 
 /**
  * @brief     copy function : Y = X

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -145,6 +145,26 @@ void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y) {
   __fallback_copy_u16_fp32(N, X, Y);
 }
 
+void copy_fp32_u32(const unsigned int N, const float *X, uint32_t *Y) {
+  __fallback_copy_fp32_u32(N, X, Y);
+}
+
+void copy_fp32_u16(const unsigned int N, const float *X, uint16_t *Y) {
+  __fallback_copy_fp32_u16(N, X, Y);
+}
+
+void copy_fp32_u8(const unsigned int N, const float *X, uint8_t *Y) {
+  __fallback_copy_fp32_u8(N, X, Y);
+}
+
+void copy_fp32_s16(const unsigned int N, const float *X, int16_t *Y) {
+  __fallback_copy_fp32_s16(N, X, Y);
+}
+
+void copy_fp32_s8(const unsigned int N, const float *X, int8_t *Y) {
+  __fallback_copy_fp32_s8(N, X, Y);
+}
+
 void copy_s16(const unsigned int N, const int16_t *X, int16_t *Y) {
   __fallback_copy_s16(N, X, Y);
 }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -16,6 +16,7 @@
 #ifdef __cplusplus
 
 #include <cstdint>
+#include <stdexcept>
 #include <tensor_dim.h>
 
 namespace nntrainer {
@@ -404,6 +405,125 @@ void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y);
  * @param[in] Y float * for Vector Y
  */
 void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint32_t * for Vector Y
+ */
+void copy_fp32_u32(const unsigned int N, const float *X, uint32_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+void copy_fp32_u16(const unsigned int N, const float *X, uint16_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint8_t * for Vector Y
+ */
+void copy_fp32_u8(const unsigned int N, const float *X, uint8_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int16_t * for Vector Y
+ */
+void copy_fp32_s16(const unsigned int N, const float *X, int16_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int8_t * for Vector Y
+ */
+void copy_fp32_s8(const unsigned int N, const float *X, int8_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y T * for Vector Y
+ */
+template <typename T>
+void copy_fp32(const unsigned int N, const float *X, T *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y T * for Vector Y
+ */
+template <typename T>
+inline void copy_fp32(const unsigned int N, const float *X, T *Y) {
+  throw std::invalid_argument("copy_fp32 for the type is not supported");
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint32_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<uint32_t>(const unsigned int N, const float *X,
+                                uint32_t *Y) {
+  copy_fp32_u32(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<uint16_t>(const unsigned int N, const float *X,
+                                uint16_t *Y) {
+  copy_fp32_u16(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<uint8_t>(const unsigned int N, const float *X,
+                               uint8_t *Y) {
+  copy_fp32_u8(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int16_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<int16_t>(const unsigned int N, const float *X,
+                               int16_t *Y) {
+  copy_fp32_s16(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int8_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<int8_t>(const unsigned int N, const float *X, int8_t *Y) {
+  copy_fp32_s8(N, X, Y);
+}
 
 /**
  * @brief     copy function : Y = X

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -67,6 +67,39 @@ void __fallback_copy_u16_fp32(const unsigned int N, const uint16_t *X,
   }
 }
 
+void __fallback_copy_fp32_u32(const unsigned int N, const float *X,
+                              uint32_t *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    Y[i] = X[i];
+  }
+}
+
+void __fallback_copy_fp32_u16(const unsigned int N, const float *X,
+                              uint16_t *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    Y[i] = X[i];
+  }
+}
+
+void __fallback_copy_fp32_u8(const unsigned int N, const float *X, uint8_t *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    Y[i] = X[i];
+  }
+}
+
+void __fallback_copy_fp32_s16(const unsigned int N, const float *X,
+                              int16_t *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    Y[i] = X[i];
+  }
+}
+
+void __fallback_copy_fp32_s8(const unsigned int N, const float *X, int8_t *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    Y[i] = X[i];
+  }
+}
+
 void __fallback_copy_s16(const unsigned int N, const int16_t *X, int16_t *Y) {
   for (unsigned int i = 0; i < N; ++i) {
     Y[i] = X[i];

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -411,6 +411,44 @@ void __fallback_copy_u16_fp32(const unsigned int N, const uint16_t *X,
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
  * @param[in] X float * for Vector X
+ * @param[in] Y uint32_t * for Vector Y
+ */
+void __fallback_copy_fp32_u32(const unsigned int N, const float *X,
+                              uint32_t *Y);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+void __fallback_copy_fp32_u16(const unsigned int N, const float *X,
+                              uint16_t *Y);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint8_t * for Vector Y
+ */
+void __fallback_copy_fp32_u8(const unsigned int N, const float *X, uint8_t *Y);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int16_t * for Vector Y
+ */
+void __fallback_copy_fp32_s16(const unsigned int N, const float *X, int16_t *Y);
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int8_t * for Vector Y
+ */
+void __fallback_copy_fp32_s8(const unsigned int N, const float *X, int8_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
  * @param[in] Y float * for Vector Y
  */
 void __fallback_scopy(const unsigned int N, const float *X,

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -46,6 +46,26 @@ void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y) {
   __fallback_copy_u16_fp32(N, X, Y);
 }
 
+void copy_fp32_u32(const unsigned int N, const float *X, uint32_t *Y) {
+  __fallback_copy_fp32_u32(N, X, Y);
+}
+
+void copy_fp32_u16(const unsigned int N, const float *X, uint16_t *Y) {
+  __fallback_copy_fp32_u16(N, X, Y);
+}
+
+void copy_fp32_u8(const unsigned int N, const float *X, uint8_t *Y) {
+  __fallback_copy_fp32_u8(N, X, Y);
+}
+
+void copy_fp32_s16(const unsigned int N, const float *X, int16_t *Y) {
+  __fallback_copy_fp32_s16(N, X, Y);
+}
+
+void copy_fp32_s8(const unsigned int N, const float *X, int8_t *Y) {
+  __fallback_copy_fp32_s8(N, X, Y);
+}
+
 void scopy_int8_to_float32(const unsigned int N, const uint8_t *X,
                            const unsigned int incX, float *Y,
                            const unsigned int incY) {

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -16,6 +16,7 @@
 #ifdef __cplusplus
 
 #include <cstdint>
+#include <stdexcept>
 #include <tensor_dim.h>
 
 namespace nntrainer {
@@ -404,6 +405,125 @@ void copy_s16_fp32(const unsigned int N, const int16_t *X, float *Y);
  * @param[in] Y float * for Vector Y
  */
 void copy_u16_fp32(const unsigned int N, const uint16_t *X, float *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint32_t * for Vector Y
+ */
+void copy_fp32_u32(const unsigned int N, const float *X, uint32_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+void copy_fp32_u16(const unsigned int N, const float *X, uint16_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint8_t * for Vector Y
+ */
+void copy_fp32_u8(const unsigned int N, const float *X, uint8_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int16_t * for Vector Y
+ */
+void copy_fp32_s16(const unsigned int N, const float *X, int16_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int8_t * for Vector Y
+ */
+void copy_fp32_s8(const unsigned int N, const float *X, int8_t *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y T * for Vector Y
+ */
+template <typename T>
+void copy_fp32(const unsigned int N, const float *X, T *Y);
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y T * for Vector Y
+ */
+template <typename T>
+inline void copy_fp32(const unsigned int N, const float *X, T *Y) {
+  throw std::invalid_argument("copy_fp32 for the type is not supported");
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint32_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<uint32_t>(const unsigned int N, const float *X,
+                                uint32_t *Y) {
+  copy_fp32_u32(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<uint16_t>(const unsigned int N, const float *X,
+                                uint16_t *Y) {
+  copy_fp32_u16(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y uint16_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<uint8_t>(const unsigned int N, const float *X,
+                               uint8_t *Y) {
+  copy_fp32_u8(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int16_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<int16_t>(const unsigned int N, const float *X,
+                               int16_t *Y) {
+  copy_fp32_s16(N, X, Y);
+}
+
+/**
+ * @brief     copy function : Y = X
+ * @param[in] N number of elements in X
+ * @param[in] X float * for Vector X
+ * @param[in] Y int8_t * for Vector Y
+ */
+template <>
+inline void copy_fp32<int8_t>(const unsigned int N, const float *X, int8_t *Y) {
+  copy_fp32_s8(N, X, Y);
+}
 
 /**
  * @brief     copy function : Y = X

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -285,6 +285,9 @@ void ShortTensor::copyData(const Tensor &from) {
   case ml::train::TensorDim::DataType::QINT16:
     copy(from.getData());
     break;
+  case ml::train::TensorDim::DataType::FP32:
+    copy_fp32(from.size(), from.getData<float>(), (int16_t *)getData());
+    break;
   default:
     throw std::invalid_argument("Error: Unsupported data type");
     break;

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -331,11 +331,18 @@ template <typename T> void UIntTensor<T>::copyData(const Tensor &from) {
   NNTR_THROW_IF(size() != from.size(), std::invalid_argument)
     << "Size of tensor to copy must match";
 
+  // copy data with the same data type T
+  if (from.getDataType() == getDataType()) {
+    copy(from.getData<T>());
+    return;
+  }
+
   /// @todo support copy from other data types
   switch (from.getDataType()) {
-  case ml::train::TensorDim::DataType::UINT16:
-    copy(from.getData());
+  case ml::train::TensorDim::DataType::FP32: {
+    copy_fp32(from.size(), from.getData<float>(), (T *)getData());
     break;
+  }
   default:
     throw std::invalid_argument("Error: Unsupported data type");
     break;

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -759,7 +759,7 @@ TEST(nntrainer_Tensor, copy_07_p) {
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
-TEST(nntrainer_Tensor, copy_08_n) {
+TEST(nntrainer_Tensor, copy_08_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
   int channel = 1;
@@ -773,11 +773,17 @@ TEST(nntrainer_Tensor, copy_08_n) {
 
   nntrainer::Tensor output(batch, channel, height, width);
 
-  // Currently, CharTensor does not support copyData of a different data type
-  EXPECT_THROW(input.copyData(output), std::invalid_argument);
+  EXPECT_NO_THROW(input.copyData(output));
+
+  for (unsigned int b = 0; b < output.batch(); ++b)
+    for (unsigned int c = 0; c < output.channel(); ++c)
+      for (unsigned int h = 0; h < output.height(); ++h)
+        for (unsigned int w = 0; w < output.height(); ++w)
+          EXPECT_EQ(input.getValue<int8_t>(b, c, h, w),
+                    output.getValue<float>(b, c, h, w));
 }
 
-TEST(nntrainer_Tensor, copy_09_n) {
+TEST(nntrainer_Tensor, copy_09_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
   int channel = 1;
@@ -791,8 +797,14 @@ TEST(nntrainer_Tensor, copy_09_n) {
 
   nntrainer::Tensor output(batch, channel, height, width);
 
-  // Currently, UINT Tensor does not support copyData of a different data type
-  EXPECT_THROW(input.copyData(output), std::invalid_argument);
+  EXPECT_NO_THROW(input.copyData(output));
+
+  for (unsigned int b = 0; b < output.batch(); ++b)
+    for (unsigned int c = 0; c < output.channel(); ++c)
+      for (unsigned int h = 0; h < output.height(); ++h)
+        for (unsigned int w = 0; w < output.height(); ++w)
+          EXPECT_EQ(input.getValue<uint16_t>(b, c, h, w),
+                    output.getValue<float>(b, c, h, w));
 }
 
 TEST(nntrainer_Tensor, copy_10_p) {
@@ -928,6 +940,46 @@ TEST(nntrainer_Tensor, copy_14_p) {
   output.copy(input);
 
   ASSERT_EQ(input, output);
+}
+
+TEST(nntrainer_Tensor, copy_15_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(
+    batch, channel, height, width,
+    {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::UINT16});
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor output(
+    batch, channel, height, width,
+    {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::UINT8});
+
+  // Currently, UINT16 does not support copyData of UINT8 data type
+  EXPECT_THROW(input.copyData(output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, copy_16_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(
+    batch, channel, height, width,
+    {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::QINT8});
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor output(
+    batch, channel, height, width,
+    {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::UINT16});
+
+  // Currently, CharTensor does not support copyData of a UINT16 data type
+  EXPECT_THROW(input.copyData(output), std::invalid_argument);
 }
 
 TEST(nntrainer_Tensor, multiply_i_01_p) {


### PR DESCRIPTION
- This commit implements template function copy_fp32 in x86_backend / fallback / arm_backend with __fallback
- This commit updates tensors' copyData() in uint/short/char tensor
- The reason I used template for `copy_fp32` is to use same signature function (overriden) in UIntTensor, which is implemented with template. In order to avoid the case where the type is not yet implemented, I implemented copy_fp32 as template as well.
- Please leave comment if you have better and simpler way to update
- This patch updates unittest for tensor: 1) update two negative cases as positive 2) add two more negative cases
- see also https://github.com/nnstreamer/nntrainer/issues/3065


**Self-evaluation:**

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped
