### PR TITLE
Bug Fix: OpenCL Kernel Registration Error through Lazy Initialization

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -74,9 +74,6 @@ static void add_default_object(ClContext &cc) {
 
 static void registerer(ClContext &cc) noexcept {
   try {
-    /// @todo: initialize kernels from the kernel strings in this function
-    /// currently does not work. registering from each kernel interface works.
-    /// Need to fix it.
     cc.initBlasClKernels();
     cc.initAttentionClKernels();
     add_default_object(cc);
@@ -145,26 +142,26 @@ void ClContext::initBlasClKernels() {
     return;
   }
 
-  registerClKernel(sgemv_cl_kernel_, "sgemv_cl");
-  registerClKernel(sgemv_cl_noTrans_kernel_, "sgemv_cl_noTrans");
-  registerClKernel(dot_cl_kernel_, "dot_cl");
-  registerClKernel(sgemm_cl_noTrans_kernel_, "sgemm_cl_noTrans");
-  registerClKernel(sgemm_cl_transA_kernel_, "sgemm_cl_transA");
-  registerClKernel(sgemm_cl_transB_kernel_, "sgemm_cl_transB");
-  registerClKernel(sgemm_cl_transAB_kernel_, "sgemm_cl_transAB");
-  registerClKernel(addition_cl_kernel_, "addition_cl");
-  registerClKernel(sscal_cl_kernel_, "sscal_cl");
+  registerClKernel(getSgemvClKernel(), "sgemv_cl");
+  registerClKernel(getSgemvClNoTransKernel(), "sgemv_cl_noTrans");
+  registerClKernel(getDotClKernel(), "dot_cl");
+  registerClKernel(getSgemmClNoTransKernel(), "sgemm_cl_noTrans");
+  registerClKernel(getSgemmClTransAKernel(), "sgemm_cl_transA");
+  registerClKernel(getSgemmClTransBKernel(), "sgemm_cl_transB");
+  registerClKernel(getSgemmClTransABKernel(), "sgemm_cl_transAB");
+  registerClKernel(getAdditionClKernel(), "addition_cl");
+  registerClKernel(getSscalClKernel(), "sscal_cl");
 
 #ifdef ENABLE_FP16
-  registerClKernel(sgemv_cl_kernel_fp16_, "sgemv_cl_fp16");
-  registerClKernel(sgemv_cl_noTrans_kernel_fp16_, "sgemv_cl_noTrans_fp16");
-  registerClKernel(dot_cl_kernel_fp16_, "dot_cl_fp16");
-  registerClKernel(sgemm_cl_noTrans_kernel_fp16_, "sgemm_cl_noTrans_fp16");
-  registerClKernel(sgemm_cl_transA_kernel_fp16_, "sgemm_cl_transA_fp16");
-  registerClKernel(sgemm_cl_transB_kernel_fp16_, "sgemm_cl_transB_fp16");
-  registerClKernel(sgemm_cl_transAB_kernel_fp16_, "sgemm_cl_transAB_fp16");
-  registerClKernel(addition_cl_kernel_fp16_, "addition_cl_fp16");
-  registerClKernel(sscal_cl_kernel_fp16_, "sscal_cl_fp16");
+  registerClKernel(getHgemvClKernel(), "sgemv_cl_fp16");
+  registerClKernel(getHgemvClNoTransKernel(), "sgemv_cl_noTrans_fp16");
+  registerClKernel(getDotClKernelFP16(), "dot_cl_fp16");
+  registerClKernel(getHgemmClNoTransKernel(), "sgemm_cl_noTrans_fp16");
+  registerClKernel(getHgemmClTransAKernel(), "sgemm_cl_transA_fp16");
+  registerClKernel(getHgemmClTransBKernel(), "sgemm_cl_transB_fp16");
+  registerClKernel(getHgemmClTransABKernel(), "sgemm_cl_transAB_fp16");
+  registerClKernel(getAdditionClKernelFP16(), "addition_cl_fp16");
+  registerClKernel(getHscalClKernel(), "sscal_cl_fp16");
 #endif
   blas_kernels_initialized = true;
 }
@@ -176,10 +173,10 @@ void ClContext::initAttentionClKernels() {
     return;
   }
 
-  registerClKernel(rotary_emb_cl_kernel_, "rotary_emb_cl");
+  registerClKernel(getRotaryEmbClKernel(), "rotary_emb_cl");
 
 #ifdef ENABLE_FP16
-  registerClKernel(rotary_emb_cl_kernel_fp16_, "rotary_emb_cl_fp16");
+  registerClKernel(getRotaryEmbClKernelFP16(), "rotary_emb_cl_fp16");
 #endif
   attention_kernels_initialized = true;
 }

--- a/nntrainer/engine.h
+++ b/nntrainer/engine.h
@@ -105,7 +105,8 @@ public:
                    [](unsigned char c) { return std::tolower(c); });
 
     if (engines.find(name) == engines.end()) {
-      throw std::invalid_argument("not registered");
+      throw std::invalid_argument("[Engine] " + name +
+                                  " Context is not registered");
     }
     return engines.at(name);
   }

--- a/nntrainer/tensor/cl_operations/attention_kernel_strings.cpp
+++ b/nntrainer/tensor/cl_operations/attention_kernel_strings.cpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Yash Singh <yash.singh@samsung.com>
+ *
+ * @file	attention_kernel_strings.cpp
+ * @date	2 April 2025
+ * @brief	All attention OpenCL kernel strings
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Yash Singh <yash.singh@samsung.com>
+ * @author	Donghyeon Jeong <dhyeon.jeong@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#include "attention_kernel_strings.h"
+
+namespace nntrainer {
+
+const std::string &getRotaryEmbClKernel() {
+  static const std::string rotary_emb_cl_kernel_ = R"(
+  __kernel void rotary_emb_cl(__global float *input,
+                                        __global float *output,
+                                        __global float *freqs_cos,
+                                        __global float *freqs_sin,
+                                        __global float *cos_,
+                                        __global float *sin_,
+                                        unsigned int batch,
+                                        unsigned int channel,
+                                        unsigned int height,
+                                        unsigned int width,
+                                        unsigned int dim,
+                                        unsigned int half_,
+                                        unsigned int max_timestep,
+                                        unsigned int from) {
+      __global float *cos_ptr = cos_;
+      __global float *sin_ptr = sin_;
+  
+      float value = 0.0f;
+      float transformed_value = 0.0f;
+  
+      unsigned int b = get_global_id(0);
+      unsigned int c = get_global_id(1);
+      
+      if(b < batch && c < channel){
+        for (unsigned int h = 0; h < height; h++) {
+          if (from + h < max_timestep) {
+            unsigned idx = (from + h)*dim;
+            for(unsigned int i = idx; i < idx + dim; i++){
+              cos_ptr[i - idx] = freqs_cos[i];
+              sin_ptr[i - idx] = freqs_sin[i];
+            }
+          }
+  
+          for (unsigned int w = 0; w < width; w = w + dim) {
+            for (unsigned int k = 0; k < dim; k++) {
+              unsigned int span = w + k;
+              value = input[b * channel * height * width + c * height * width + h * width + span];
+              if (k < half_) {
+                transformed_value = -1.0f * input[b * channel * height * width + c * height * width + h * width + span + half_];
+              } else {
+                transformed_value = input[b * channel * height * width + c * height * width + h * width + span - half_];
+              }
+              value = value * cos_ptr[k] + transformed_value * sin_ptr[k];
+              output[b * channel * height * width + c * height * width + h * width + span] = value;
+            }
+          }
+        }
+      }
+  }
+  )";
+  return rotary_emb_cl_kernel_;
+}
+
+#ifdef ENABLE_FP16
+
+const std::string &getRotaryEmbClKernelFP16() {
+  static const std::string rotary_emb_cl_kernel_fp16_ = R"(
+  
+    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    
+  __kernel void rotary_emb_cl_fp16(__global half *input,
+                                        __global half *output,
+                                        __global float *freqs_cos,
+                                        __global float *freqs_sin,
+                                        __global float *cos_,
+                                        __global float *sin_,
+                                        unsigned int batch,
+                                        unsigned int channel,
+                                        unsigned int height,
+                                        unsigned int width,
+                                        unsigned int dim,
+                                        unsigned int half_,
+                                        unsigned int max_timestep,
+                                        unsigned int from) {
+      __global float *cos_ptr = cos_;
+      __global float *sin_ptr = sin_;
+  
+      float value = 0.0f;
+      float transformed_value = 0.0f;
+  
+      unsigned int b = get_global_id(0);
+      unsigned int c = get_global_id(1);
+      
+      if(b < batch && c < channel){
+        for (unsigned int h = 0; h < height; h++) {
+          if (from + h < max_timestep) {
+            unsigned idx = (from + h)*dim;
+            for(int i = idx; i < idx + dim; i++ ){
+              cos_ptr[i - idx] = freqs_cos[i];
+              sin_ptr[i - idx] = freqs_sin[i];
+            }
+          }
+  
+          for (unsigned int w = 0; w < width; w = w + dim) {
+            for (unsigned int k = 0; k < dim; k++) {
+              unsigned int span = w + k;
+              value = (float)input[b * channel * height * width + c * height * width + h * width + span];
+              if (k < half_) {
+                transformed_value = -1.0f * (float)input[b * channel * height * width + c * height * width + h * width + span + half_];
+              } else {
+                transformed_value = (float)input[b * channel * height * width + c * height * width + h * width + span - half_];
+              }
+              value = value * cos_ptr[k] + transformed_value * sin_ptr[k];
+              output[b * channel * height * width + c * height * width + h * width + span] = (half)value;
+            }
+          }
+        }
+      }
+  }
+  )";
+  return rotary_emb_cl_kernel_fp16_;
+}
+#endif
+
+} // namespace nntrainer

--- a/nntrainer/tensor/cl_operations/attention_kernel_strings.h
+++ b/nntrainer/tensor/cl_operations/attention_kernel_strings.h
@@ -17,117 +17,14 @@
 #include <string>
 
 namespace nntrainer {
-static const std::string rotary_emb_cl_kernel_ = R"(
 
-  #pragma OPENCL EXTENSION cl_khr_fp16 : enable
-
-__kernel void rotary_emb_cl(__global float *input,
-                                      __global float *output,
-                                      __global float *freqs_cos,
-                                      __global float *freqs_sin,
-                                      __global float *cos_,
-                                      __global float *sin_,
-                                      unsigned int batch,
-                                      unsigned int channel,
-                                      unsigned int height,
-                                      unsigned int width,
-                                      unsigned int dim,
-                                      unsigned int half_,
-                                      unsigned int max_timestep,
-                                      unsigned int from) {
-    __global float *cos_ptr = cos_;
-    __global float *sin_ptr = sin_;
-
-    float value = 0.0f;
-    float transformed_value = 0.0f;
-
-    unsigned int b = get_global_id(0);
-    unsigned int c = get_global_id(1);
-    
-    if(b < batch && c < channel){
-      for (unsigned int h = 0; h < height; h++) {
-        if (from + h < max_timestep) {
-          unsigned idx = (from + h)*dim;
-          for(unsigned int i = idx; i < idx + dim; i++){
-            cos_ptr[i - idx] = freqs_cos[i];
-            sin_ptr[i - idx] = freqs_sin[i];
-          }
-        }
-
-        for (unsigned int w = 0; w < width; w = w + dim) {
-          for (unsigned int k = 0; k < dim; k++) {
-            unsigned int span = w + k;
-            value = input[b * channel * height * width + c * height * width + h * width + span];
-            if (k < half_) {
-              transformed_value = -1.0f * input[b * channel * height * width + c * height * width + h * width + span + half_];
-            } else {
-              transformed_value = input[b * channel * height * width + c * height * width + h * width + span - half_];
-            }
-            value = value * cos_ptr[k] + transformed_value * sin_ptr[k];
-            output[b * channel * height * width + c * height * width + h * width + span] = value;
-          }
-        }
-      }
-    }
-}
-)";
+const std::string &getRotaryEmbClKernel();
 
 #ifdef ENABLE_FP16
-static const std::string rotary_emb_cl_kernel_fp16_ = R"(
 
-  #pragma OPENCL EXTENSION cl_khr_fp16 : enable
-  
-__kernel void rotary_emb_cl_fp16(__global half *input,
-                                      __global half *output,
-                                      __global float *freqs_cos,
-                                      __global float *freqs_sin,
-                                      __global float *cos_,
-                                      __global float *sin_,
-                                      unsigned int batch,
-                                      unsigned int channel,
-                                      unsigned int height,
-                                      unsigned int width,
-                                      unsigned int dim,
-                                      unsigned int half_,
-                                      unsigned int max_timestep,
-                                      unsigned int from) {
-    __global float *cos_ptr = cos_;
-    __global float *sin_ptr = sin_;
-
-    float value = 0.0f;
-    float transformed_value = 0.0f;
-
-    unsigned int b = get_global_id(0);
-    unsigned int c = get_global_id(1);
-    
-    if(b < batch && c < channel){
-      for (unsigned int h = 0; h < height; h++) {
-        if (from + h < max_timestep) {
-          unsigned idx = (from + h)*dim;
-          for(int i = idx; i < idx + dim; i++ ){
-            cos_ptr[i - idx] = freqs_cos[i];
-            sin_ptr[i - idx] = freqs_sin[i];
-          }
-        }
-
-        for (unsigned int w = 0; w < width; w = w + dim) {
-          for (unsigned int k = 0; k < dim; k++) {
-            unsigned int span = w + k;
-            value = (float)input[b * channel * height * width + c * height * width + h * width + span];
-            if (k < half_) {
-              transformed_value = -1.0f * (float)input[b * channel * height * width + c * height * width + h * width + span + half_];
-            } else {
-              transformed_value = (float)input[b * channel * height * width + c * height * width + h * width + span - half_];
-            }
-            value = value * cos_ptr[k] + transformed_value * sin_ptr[k];
-            output[b * channel * height * width + c * height * width + h * width + span] = (half)value;
-          }
-        }
-      }
-    }
-}
-)";
+const std::string &getRotaryEmbClKernelFP16();
 
 #endif
+
 } // namespace nntrainer
 #endif /* __ATTENTION_KERNEL_INTERFACE_H__ */

--- a/nntrainer/tensor/cl_operations/attention_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/attention_kernels.cpp
@@ -28,7 +28,7 @@ void rotary_emb_cl(float *in, float *out,
 
   do {
     ClContext::SharedPtrClKernel kernel_rotaryEmb_ptr =
-      attention_cc->registerClKernel(rotary_emb_cl_kernel_, "rotary_emb_cl");
+      attention_cc->registerClKernel(getRotaryEmbClKernel(), "rotary_emb_cl");
     if (!kernel_rotaryEmb_ptr) {
       break;
     }

--- a/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
@@ -28,7 +28,7 @@ void rotary_emb_cl(_FP16 *in, _FP16 *out,
   bool result = false;
   do {
     ClContext::SharedPtrClKernel kernel_rotaryEmb_fp16_ptr =
-      attention_cc->registerClKernel(rotary_emb_cl_kernel_fp16_,
+      attention_cc->registerClKernel(getRotaryEmbClKernelFP16(),
                                      "rotary_emb_cl_fp16");
     if (!kernel_rotaryEmb_fp16_ptr) {
       break;

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
@@ -1,0 +1,844 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Debadri Samaddar <s.debadri@samsung.com>
+ *
+ * @file	blas_kernel_strings.cpp
+ * @date	April 01 2025
+ * @brief	All blas OpenCL kernel strings
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Debadri Samaddar <s.debadri@samsung.com>
+ * @author	Donghyeon Jeong <dhyeon.jeong@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#include "blas_kernel_strings.h"
+
+namespace nntrainer {
+
+const std::string &getSgemvClKernel() {
+  static const std::string sgemv_cl_kernel_ =
+    R"(__kernel void sgemv_cl(const __global float* A, const __global float* X,
+                          __global float* Y, unsigned int N, unsigned int lda) {                                            
+            unsigned int i;
+            i = get_global_id(0);                         
+            float y0 = 0.0f;
+            for (unsigned int j = 0; j < N; j++)                         
+                y0 += A[i + j * lda] * X[j]; 
+            Y[i] = y0;                            
+              
+        })";
+  return sgemv_cl_kernel_;
+}
+
+const std::string &getSgemvClNoTransKernel() {
+  static const std::string sgemv_cl_noTrans_kernel_ =
+    R"(__kernel void sgemv_cl_noTrans(const __global float* A, const __global float* X,
+                          __global float* Y, unsigned int N, unsigned int lda) {                                            
+            unsigned int i;
+            i = get_global_id(0);                         
+            float y0 = 0.0f;
+            for (unsigned int j = 0; j < N; j++)                         
+                y0 += A[j + i * lda] * X[j]; 
+            Y[i] = y0;                            
+              
+        })";
+  return sgemv_cl_noTrans_kernel_;
+}
+
+const std::string &getDotClKernel() {
+  static const std::string dot_cl_kernel_ =
+    R"(__kernel void dot_cl(const __global float* A, const __global float* X, unsigned int K, __global float* res) {
+            *res = 0;
+            for (unsigned int i = 0; i < K; i++){
+                *res += A[i] * X[i];
+            }
+        })";
+  return dot_cl_kernel_;
+}
+
+const std::string &getSgemmClNoTransKernel() {
+  static const std::string sgemm_cl_noTrans_kernel_ =
+    R"(__kernel void sgemm_cl_noTrans(const __global float* A, const __global float* B,
+                        __global float* C, unsigned int K, unsigned int lda, unsigned int ldb, unsigned int ldc) {
+          
+          unsigned int m = get_global_id(0);
+          unsigned int n = get_global_id(1);
+          float c = 0.0f;
+          for (unsigned int k = 0; k < K; ++k) {
+            float a, b;
+            a = A[m * lda + k];
+            b = B[k * ldb + n];
+            c += a * b;
+          }
+          C[m * ldc + n] = c;
+      })";
+  return sgemm_cl_noTrans_kernel_;
+}
+
+const std::string &getSgemmClTransAKernel() {
+  static const std::string sgemm_cl_transA_kernel_ =
+    R"(__kernel void sgemm_cl_transA(const __global float* A, const __global float* B,
+                          __global float* C, unsigned int K, unsigned int lda, unsigned int ldb, unsigned int ldc) {
+            
+            unsigned int m = get_global_id(0);
+            unsigned int n = get_global_id(1);
+            float c = 0.0f;
+            for (unsigned int k = 0; k < K; ++k) {
+              float a, b;
+              a = A[k * lda + m];
+              b = B[k * ldb + n];
+              c += a * b;
+            }
+            C[m * ldc + n] = c;
+        })";
+  return sgemm_cl_transA_kernel_;
+}
+
+const std::string &getSgemmClTransBKernel() {
+  static const std::string sgemm_cl_transB_kernel_ =
+    R"(__kernel void sgemm_cl_transB(const __global float *A, const __global float *B,
+                                  __global float *C, unsigned int K,
+                                  unsigned int lda, unsigned int ldb,
+                                  unsigned int ldc) {
+    
+            unsigned int m = get_global_id(0);
+            unsigned int n = get_global_id(1);
+            float c = 0.0f;
+            for (unsigned int k = 0; k < K; ++k) {
+              float a, b;
+              a = A[m * lda + k];
+              b = B[n * ldb + k];
+              c += a * b;
+            }
+            C[m * ldc + n] = c;
+        })";
+  return sgemm_cl_transB_kernel_;
+}
+
+const std::string &getSgemmClTransABKernel() {
+  static const std::string sgemm_cl_transAB_kernel_ =
+    R"(__kernel void sgemm_cl_transAB(const __global float *A, const __global float *B,
+                                   __global float *C, unsigned int K,
+                                   unsigned int lda, unsigned int ldb,
+                                   unsigned int ldc) {
+    
+            unsigned int m = get_global_id(0);
+            unsigned int n = get_global_id(1);
+            float c = 0.0f;
+            for (unsigned int k = 0; k < K; ++k) {
+              float a, b;
+              a = A[k * lda + m];
+              b = B[n * ldb + k];
+              c += a * b;
+            }
+            C[m * ldc + n] = c;
+        })";
+  return sgemm_cl_transAB_kernel_;
+}
+
+const std::string &getAdditionClKernel() {
+  static const std::string addition_cl_kernel_ =
+    R"(__kernel void addition_cl(const __global float* input, __global float* output, unsigned int size_input, unsigned int size_res) {
+        #pragma printf_support
+        size_t idx = get_global_id(0);
+        if (idx < size_res) {
+            output[idx] = output[idx] + input[idx % size_input];
+        }
+      })";
+  return addition_cl_kernel_;
+}
+
+const std::string &getSscalClKernel() {
+  static const std::string sscal_cl_kernel_ =
+    R"(__kernel void sscal_cl(__global float* X, const float alpha) {
+            
+            unsigned int i = get_global_id(0);
+            X[i] *= alpha;
+        })";
+  return sscal_cl_kernel_;
+}
+
+const std::string &getTransposeClKernelAxis0() {
+  static const std::string transpose_cl_kernel_axis0 =
+    R"(__kernel void transpose_cl_axis0(__global const float* in, 
+                                   __global float* output,
+                                   const int batch_size, 
+                                   const int channels, 
+                                   const int height, 
+                                   const int width) {
+        // Calculate h and w from the global IDs
+        int h = get_global_id(0);
+        int w = get_global_id(1);
+        if (h < height && w < width) {
+            for (int c = 0; c < channels; ++c) {
+                for (int n = 0; n < batch_size; ++n) {
+                    // Calculate the input and output indices
+                    int input_index = n * (channels * height * width) + c * (height * width) + h * width + w;
+                    int output_index = n * (channels * height * width) + h * (channels * width) + c * width + w;
+                    // Transpose channel and height, copying data from input to output
+                    output[output_index] = in[input_index];
+                }
+            }
+        }
+    })";
+  return transpose_cl_kernel_axis0;
+}
+
+const std::string &getTransposeClKernelAxis1() {
+  static const std::string transpose_cl_kernel_axis1 =
+    R"(__kernel void transpose_cl_axis1(__global const float* in, 
+                                   __global float* output,
+                                   const int batch_size, 
+                                   const int channels, 
+                                   const int height, 
+                                   const int width) {
+        // Calculate h and w from the global IDs
+        int h = get_global_id(0);
+        int w = get_global_id(1);
+        if (h < height && w < width) {
+            for (int c = 0; c < channels; ++c) {
+                for (int n = 0; n < batch_size; ++n) {
+                    // Calculate the input and output indices
+                    int input_index = n * (channels * height * width) + c * (height * width) + h * width + w;
+                    int output_index = n * (channels * height * width) + c * (height * width) + w * height + h;
+                    // Transpose height and width, copying data from input to output
+                    output[output_index] = in[input_index];
+                }
+            }
+        }
+    })";
+
+  return transpose_cl_kernel_axis1;
+}
+
+const std::string &getTransposeClKernelAxis2() {
+  static const std::string transpose_cl_kernel_axis2 =
+    R"(__kernel void transpose_cl_axis2(__global const float* in, 
+                                   __global float* output,
+                                   const int batch_size, 
+                                   const int channels, 
+                                   const int height, 
+                                   const int width) {
+        // Calculate c and w from the global IDs
+        int c = get_global_id(0);
+        int w = get_global_id(1);
+        if (c < channels && w < width) {
+            for (int h = 0; h < height; ++h) {
+                for (int n = 0; n < batch_size; ++n) {
+                    // Calculate the input and output indices
+                    int input_index = n * (channels * height * width) + c * (height * width) + h * width + w;
+                    int output_index = n * (channels * height * width) + w * (height * channels) + h * channels + c;
+                    // Transpose channel and width, copying data from input to output
+                    output[output_index] = in[input_index];
+                }
+            }
+        }
+    })";
+  return transpose_cl_kernel_axis2;
+}
+
+const std::string &getSwiGluClKernel() {
+  static const std::string swiglu_cl_kernel_ =
+    R"(__kernel void swiglu_cl(__global const float *in1, __global const float *in2, __global float *out) {
+int i = get_global_id(0);
+float swish = in1[i] * exp(in1[i]) / (1 + exp(in1[i]));
+out[i] = swish * in2[i];
+})";
+  return swiglu_cl_kernel_;
+}
+
+const std::string &getCopyClKernel() {
+  static const std::string copy_cl_kernel_ =
+    R"(__kernel void copy_cl(__global const float* input, 
+                           __global float* output,
+                           const int batchsize, 
+                           const int channels, 
+                           const int height, 
+                           const int width) {
+int i= get_global_id(0);
+output[i] = input[i];
+})";
+  return copy_cl_kernel_;
+}
+
+const std::string &getConcatClAxis3Kernel() {
+  static const std::string concat_cl_axis3_kernel_ =
+    R"(__kernel void concat_cl_axis3(__global const float* in1, 
+                                           __global const float* in2, 
+                                           __global float* out,
+                                           const int batch_size, 
+                                           const int channels, 
+                                           const int height, 
+                                           const int width1, 
+                                           const int width2) {
+    int global_id = get_global_id(0);
+    
+    int total_width = width1 + width2;
+    
+    int width = total_width;
+
+    // 4D space coordinates
+    int w = global_id % total_width;
+    int h = (global_id / total_width) % height;
+    int c = (global_id / (total_width * height)) % channels;
+    int b = global_id / (total_width * height * channels);
+
+    int output_index = ((b * channels + c) * height + h) * total_width + w;
+    
+    // Determining if the index is in in1 or in2
+    if (w < width1) {
+        // in1 index calculation
+        int input1_index = ((b * channels + c) * height + h) * width1 + w;
+        out[output_index] = in1[input1_index];
+  
+    } else {
+        // in2 index calculation
+        int input2_index = ((b * channels + c) * height + h) * width2 + (w - width1);
+        out[output_index] = in2[input2_index];
+    }
+})";
+  return concat_cl_axis3_kernel_;
+}
+
+const std::string &getConcatClAxis2Kernel() {
+  static const std::string concat_cl_axis2_kernel_ =
+    R"(__kernel void concat_cl_axis2(__global const float* in1,
+                             __global const float* in2,
+                             __global float* out,
+                             const int batch_size,
+                             const int channels,
+                             const int height1,
+                             const int height2,
+                             const int width) {
+    
+    int total_height = height1 + height2;
+    int global_id = get_global_id(0);
+    
+    // Calculate the coordinates in the 4D space
+    int w = global_id % width;
+    int h = (global_id / width) % total_height;
+    int c = (global_id / (width * total_height)) % channels;
+    int b = global_id / (width * total_height * channels);
+
+    // Calculate the offset for the current batch, channel, and width in the output tensor
+    int output_index = ((b * channels + c) * total_height + h) * width + w;
+
+    if (h < height1) {
+        // Index within input1
+        int input1_index = ((b * channels + c) * height1 + h) * width + w;
+        out[output_index] = in1[input1_index];
+    } else {
+        // Index within input2
+        int input2_index = ((b * channels + c) * height2 + (h - height1)) * width + w;
+        out[output_index] = in2[input2_index];
+    }
+
+})";
+  return concat_cl_axis2_kernel_;
+}
+
+const std::string &getConcatClAxis1Kernel() {
+  static const std::string concat_cl_axis1_kernel_ =
+    R"(__kernel void concat_cl_axis1(__global const float* in1, 
+                                           __global const float* in2, 
+                                           __global float* out,
+                                           const int batch_size, 
+                                           const int channels1, 
+                                           const int channels2, 
+                                           const int height, 
+                                           const int width) {
+    int global_id = get_global_id(0);
+    
+    int total_channels = channels1 + channels2;
+
+    // Calculate the coordinates in the 4D space
+    int w = global_id % width;
+    int h = (global_id / width) % height;
+    int c = (global_id / (width * height)) % total_channels;
+    int b = global_id / (width * height * total_channels);
+
+    // Calculate the offset for the current batch, height, and width in the output tensor
+    int output_index = ((b * total_channels + c) * height + h) * width + w;
+
+    if (c < channels1) {
+        // Index within input1
+        int input1_index = ((b * channels1 + c) * height + h) * width + w;
+        out[output_index] = in1[input1_index];
+    } else {
+        // Index within input2
+        int input2_index = ((b * channels2 + (c - channels1)) * height + h) * width + w;
+        out[output_index] = in2[input2_index];
+    }
+})";
+  return concat_cl_axis1_kernel_;
+}
+
+const std::string &getRMSNormClKernel() {
+  static const std::string rmsnorm_cl_kernel_ =
+    R"(__kernel void rmsnorm_cl(
+    __global const float *input,  // Input tensor
+    __global float *output,    // Output tensor
+    __global const float *alpha,  // Alpha values (one for each width)
+    float epsilon,
+    int B,                  // Number of batches
+    int C,                  // Number of channels
+    int H,                  // Height of feature map
+    int W                   // Width of feature map
+) {
+    // Compute the corresponding batch, height, and channel indices
+    int n = get_global_id(0) / C;
+    int c = get_global_id(0) % C;
+    int h = get_global_id(1);
+    int index = ((n * C + c) * H + h) * W;
+    // Calculate RMS norm for the current channel, height, and batch
+    float sum_squares = 0.0f;
+    for (int j = 0; j < W; ++j) {
+        sum_squares += input[index+j] * input[index+j];
+    }
+    sum_squares /= W;
+    float rms_norm = sqrt(sum_squares + epsilon);
+    // Each work item processes all width elements for its specific n, h, c
+    for (int w = 0; w < W; ++w) {
+        output[index+w] = (input[index+w] / rms_norm) * alpha[w];
+    }
+}
+)";
+
+  return rmsnorm_cl_kernel_;
+}
+
+#ifdef ENABLE_FP16
+const std::string &getHgemvClKernel() {
+  static const std::string hgemv_cl_kernel_ =
+    R"(
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+        
+        __kernel void sgemv_cl_fp16(const __global half* A, const __global half* X,
+                          __global half* Y, unsigned int N, unsigned int lda) {                                            
+            unsigned int i;
+            i = get_global_id(0);                         
+            half y0 = 0.0f;
+            for (unsigned int j = 0; j < N; j++)                         
+                y0 += A[i + j * lda] * X[j]; 
+            Y[i] = y0;                            
+              
+        })";
+  return hgemv_cl_kernel_;
+}
+
+const std::string &getHgemvClNoTransKernel() {
+  static const std::string hgemv_cl_noTrans_kernel_ =
+    R"(
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    
+        __kernel void sgemv_cl_noTrans_fp16(const __global half* A, const __global half* X,
+                          __global half* Y, unsigned int N, unsigned int lda) {                                            
+            unsigned int i;
+            i = get_global_id(0);                         
+            half y0 = 0.0f;
+            for (unsigned int j = 0; j < N; j++)                         
+                y0 += A[j + i * lda] * X[j]; 
+            Y[i] = y0;                            
+              
+        })";
+  return hgemv_cl_noTrans_kernel_;
+}
+
+const std::string &getDotClKernelFP16() {
+  static const std::string dot_cl_kernel_fp16_ =
+    R"(
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    
+        __kernel void dot_cl_fp16(const __global half* A, const __global half* X, unsigned int K, __global half* res) {
+            *res = 0;
+            for (unsigned int i = 0; i < K; i++){
+                *res += A[i] * X[i];
+            }
+        })";
+  return dot_cl_kernel_fp16_;
+}
+
+const std::string &getHgemmClNoTransKernel() {
+  static const std::string hgemm_cl_noTrans_kernel_ =
+    R"(
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    
+        __kernel void sgemm_cl_noTrans_fp16(const __global half* A, const __global half* B,
+                          __global half* C, unsigned int K, unsigned int lda, unsigned int ldb, unsigned int ldc) {
+            
+            unsigned int m = get_global_id(0);
+            unsigned int n = get_global_id(1);
+            half c = 0.0f;
+            for (unsigned int k = 0; k < K; ++k) {
+              half a, b;
+              a = A[m * lda + k];
+              b = B[k * ldb + n];
+              c += a * b;
+            }
+            C[m * ldc + n] = c;
+        })";
+  return hgemm_cl_noTrans_kernel_;
+}
+
+const std::string &getHgemmClTransAKernel() {
+  static const std::string hgemm_cl_transA_kernel_ =
+    R"(
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    
+        __kernel void sgemm_cl_transA_fp16(const __global half* A, const __global half* B,
+                          __global half* C, unsigned int K, unsigned int lda, unsigned int ldb, unsigned int ldc) {
+            
+            unsigned int m = get_global_id(0);
+            unsigned int n = get_global_id(1);
+            half c = 0.0f;
+            for (unsigned int k = 0; k < K; ++k) {
+              half a, b;
+              a = A[k * lda + m];
+              b = B[k * ldb + n];
+              c += a * b;
+            }
+            C[m * ldc + n] = c;
+        })";
+  return hgemm_cl_transA_kernel_;
+}
+
+const std::string &getHgemmClTransBKernel() {
+  static const std::string hgemm_cl_transB_kernel_ =
+    R"(
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    
+        __kernel void sgemm_cl_transB_fp16(const __global half* A, const __global half* B,
+                          __global half* C, unsigned int K, unsigned int lda, unsigned int ldb, unsigned int ldc) {
+            
+            unsigned int m = get_global_id(0);
+            unsigned int n = get_global_id(1);
+            half c = 0.0f;
+            for (unsigned int k = 0; k < K; ++k) {
+              half a, b;
+              a = A[m * lda + k];
+              b = B[n * ldb + k];
+              c += a * b;
+            }
+            C[m * ldc + n] = c;
+        })";
+  return hgemm_cl_transB_kernel_;
+}
+
+const std::string &getHgemmClTransABKernel() {
+  static const std::string hgemm_cl_transAB_kernel_ =
+    R"(
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    
+        __kernel void sgemm_cl_transAB_fp16(const __global half* A, const __global half* B,
+                          __global half* C, unsigned int K, unsigned int lda, unsigned int ldb, unsigned int ldc) {
+            
+            unsigned int m = get_global_id(0);
+            unsigned int n = get_global_id(1);
+            half c = 0.0f;
+            for (unsigned int k = 0; k < K; ++k) {
+              half a, b;
+              a = A[k * lda + m];
+              b = B[n * ldb + k];
+              c += a * b;
+            }
+            C[m * ldc + n] = c;
+        })";
+  return hgemm_cl_transAB_kernel_;
+}
+
+const std::string &getAdditionClKernelFP16() {
+  static const std::string addition_cl_kernel_fp16_ =
+    R"(
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    
+        __kernel void addition_cl_fp16(const __global half* input, __global half* output, unsigned int size_input, unsigned int size_res) {
+        size_t idx = get_global_id(0);
+        if (idx < size_res) {
+            output[idx] = output[idx] + input[idx % size_input];
+        }
+      })";
+  return addition_cl_kernel_fp16_;
+}
+
+const std::string &getHscalClKernel() {
+  static const std::string hscal_cl_kernel_ =
+    R"(
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    
+        __kernel void sscal_cl_fp16(__global half* X, const float alpha) {
+            
+            unsigned int i = get_global_id(0);
+            X[i] *= alpha;
+        })";
+  return hscal_cl_kernel_;
+}
+
+const std::string &getTransposeClAxis0KernelFP16() {
+  static const std::string transpose_cl_kernel_fp16_axis0 =
+    R"(
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+        __kernel void transpose_cl_fp16_axis0(__global const half* in, 
+                                   __global half* output,
+                                   const int batch_size, 
+                                   const int channels, 
+                                   const int height, 
+                                   const int width) {
+        // Calculate h and w from the global IDs
+        int h = get_global_id(0);
+        int w = get_global_id(1);
+        if (h < height && w < width) {
+            for (int c = 0; c < channels; ++c) {
+                for (int n = 0; n < batch_size; ++n) {
+                    // Calculate the input and output indices
+                    int input_index = n * (channels * height * width) + c * (height * width) + h * width + w;
+                    int output_index = n * (channels * height * width) + h * (channels * width) + c * width + w;
+                    // Transpose channel and height, copying data from input to output
+                    output[output_index] = in[input_index];
+                }
+            }
+        }
+    })";
+  return transpose_cl_kernel_fp16_axis0;
+}
+
+const std::string &getTransposeClAxis1KernelFP16() {
+  static const std::string transpose_cl_kernel_fp16_axis1 =
+    R"(
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+        __kernel void transpose_cl_fp16_axis1(__global const half* in, 
+                                   __global half* output,
+                                   const int batch_size, 
+                                   const int channels, 
+                                   const int height, 
+                                   const int width) {
+        // Calculate h and w from the global IDs
+        int h = get_global_id(0);
+        int w = get_global_id(1);
+        if (h < height && w < width) {
+            for (int c = 0; c < channels; ++c) {
+                for (int n = 0; n < batch_size; ++n) {
+                    // Calculate the input and output indices
+                    int input_index = n * (channels * height * width) + c * (height * width) + h * width + w;
+                    int output_index = n * (channels * height * width) + c * (height * width) + w * height + h;
+                    // Transpose height and width, copying data from input to output
+                    output[output_index] = in[input_index];
+                }
+            }
+        }
+    })";
+  return transpose_cl_kernel_fp16_axis1;
+}
+
+const std::string &getTransposeClAxis2KernelFP16() {
+  static const std::string transpose_cl_kernel_fp16_axis2 =
+    R"(
+        #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+        __kernel void transpose_cl_fp16_axis2(__global const half* in, 
+                                   __global half* output,
+                                   const int batch_size, 
+                                   const int channels, 
+                                   const int height, 
+                                   const int width) {
+        // Calculate c and w from the global IDs
+        int c = get_global_id(0);
+        int w = get_global_id(1);
+        if (c < channels && w < width) {
+            for (int h = 0; h < height; ++h) {
+                for (int n = 0; n < batch_size; ++n) {
+                    // Calculate the input and output indices
+                    int input_index = n * (channels * height * width) + c * (height * width) + h * width + w;
+                    int output_index = n * (channels * height * width) + w * (height * channels) + h * channels + c;
+                    // Transpose channel and width, copying data from input to output
+                    output[output_index] = in[input_index];
+                }
+            }
+        }
+    })";
+  return transpose_cl_kernel_fp16_axis2;
+}
+
+const std::string &getSwiGluClKernelFP16() {
+  static const std::string swiglu_cl_kernel_fp16_ =
+    R"(
+    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    __kernel void swiglu_cl_fp16(__global const half *in1, __global const half *in2, __global half *out) {
+    int i = get_global_id(0);
+    half swish = in1[i] * exp(in1[i]) / (1 + exp(in1[i]));
+    out[i] = swish * in2[i];
+})";
+  return swiglu_cl_kernel_fp16_;
+}
+
+const std::string &getCopyClKernelFP16() {
+  static const std::string copy_cl_kernel_fp16_ =
+    R"(
+    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    __kernel void copy_cl_fp16(__global const half* input, 
+                               __global half* output,
+                               const int batchsize, 
+                               const int channels, 
+                               const int height, 
+                               const int width) {
+
+    int i= get_global_id(0);
+    output[i] = input[i];
+    
+})";
+  return copy_cl_kernel_fp16_;
+}
+
+const std::string &getConcatClAxis3KernelFP16() {
+  static const std::string concat_cl_axis3_kernel_fp16_ =
+    R"(
+    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    __kernel void concat_cl_axis3_fp16(__global const half* in1, 
+                                           __global const half* in2, 
+                                           __global half* out,
+                                           const int batch_size, 
+                                           const int channels, 
+                                           const int height, 
+                                           const int width1, 
+                                           const int width2) {
+    int global_id = get_global_id(0);
+    
+    int total_width = width1 + width2;
+    
+    int width = total_width;
+
+    // 4D space coordinates
+    int w = global_id % total_width;
+    int h = (global_id / total_width) % height;
+    int c = (global_id / (total_width * height)) % channels;
+    int b = global_id / (total_width * height * channels);
+
+    int output_index = ((b * channels + c) * height + h) * total_width + w;
+    
+    // Determining if the index is in in1 or in2
+    if (w < width1) {
+        // in1 index calculation
+        int input1_index = ((b * channels + c) * height + h) * width1 + w;
+        out[output_index] = in1[input1_index];
+  
+    } else {
+        // in2 index calculation
+        int input2_index = ((b * channels + c) * height + h) * width2 + (w - width1);
+        out[output_index] = in2[input2_index];
+    }
+})";
+  return concat_cl_axis3_kernel_fp16_;
+}
+
+const std::string &getConcatClAxis2KernelFP16() {
+  static const std::string concat_cl_axis2_kernel_fp16_ =
+    R"(__kernel void concat_cl_axis2_fp16(__global const half* in1,
+                           __global const half* in2,
+                           __global half* out,
+                           const int batch_size,
+                           const int channels,
+                           const int height1,
+                           const int height2,
+                           const int width) {
+  
+  int total_height = height1 + height2;
+  int global_id = get_global_id(0);
+  
+  // Calculate the coordinates in the 4D space
+  int w = global_id % width;
+  int h = (global_id / width) % total_height;
+  int c = (global_id / (width * total_height)) % channels;
+  int b = global_id / (width * total_height * channels);
+
+  // Calculate the offset for the current batch, channel, and width in the output tensor
+  int output_index = ((b * channels + c) * total_height + h) * width + w;
+
+  if (h < height1) {
+      // Index within input1
+      int input1_index = ((b * channels + c) * height1 + h) * width + w;
+      out[output_index] = in1[input1_index];
+  } else {
+      // Index within input2
+      int input2_index = ((b * channels + c) * height2 + (h - height1)) * width + w;
+      out[output_index] = in2[input2_index];
+  }
+
+})";
+  return concat_cl_axis2_kernel_fp16_;
+}
+
+const std::string &getConcatClAxis1KernelFP16() {
+  static const std::string concat_cl_axis1_kernel_fp16_ =
+    R"(__kernel void concat_cl_axis1_fp16(__global const half* in1, 
+                                           __global const half* in2, 
+                                           __global half* out,
+                                           const int batch_size, 
+                                           const int channels1, 
+                                           const int channels2, 
+                                           const int height, 
+                                           const int width) {
+    int global_id = get_global_id(0);
+    
+    int total_channels = channels1 + channels2;
+
+    // Calculate the coordinates in the 4D space
+    int w = global_id % width;
+    int h = (global_id / width) % height;
+    int c = (global_id / (width * height)) % total_channels;
+    int b = global_id / (width * height * total_channels);
+
+    // Calculate the offset for the current batch, height, and width in the output tensor
+    int output_index = ((b * total_channels + c) * height + h) * width + w;
+
+    if (c < channels1) {
+        // Index within input1
+        int input1_index = ((b * channels1 + c) * height + h) * width + w;
+        out[output_index] = in1[input1_index];
+    } else {
+        // Index within input2
+        int input2_index = ((b * channels2 + (c - channels1)) * height + h) * width + w;
+        out[output_index] = in2[input2_index];
+    }
+})";
+  return concat_cl_axis1_kernel_fp16_;
+}
+
+const std::string &getRMSNormClKernelFP16() {
+  static const std::string rmsnorm_cl_kernel_fp16_ =
+    R"(
+    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+    __kernel void rmsnorm_cl_fp16(
+    __global const half *input,  // Input tensor
+    __global half *output,    // Output tensor
+    __global const half *alpha,  // Alpha values (one for each width)
+    half epsilon,
+    int B,                  // Number of batches
+    int C,                  // Number of channels
+    int H,                  // Height of feature map
+    int W                   // Width of feature map
+) {
+    int global_id = get_global_id(0);  // Get the global work item index
+
+    // Compute the corresponding batch, height, and channel indices
+    int n = global_id / C;       // Batch index
+    int c = global_id % C;                    // Height index
+    int h = get_global_id(1);                    // Channel index
+    int index = ((n * C + c) * H + h) * W;
+
+    // Calculate RMS norm for the current channel, height, and batch
+    half sum_squares = 0.0f;
+    for (int j = 0; j < W; ++j) {
+        sum_squares += input[index+j] * input[index+j];
+    }
+    sum_squares /= W;
+    half rms_norm = sqrt(sum_squares + epsilon);
+    // Each work item processes all width elements for its specific n, h, c
+    for (int w = 0; w < W; ++w) {
+        output[index+w] = (input[index+w] / rms_norm) * alpha[w];
+    } 
+}
+)";
+  return rmsnorm_cl_kernel_fp16_;
+}
+
+#endif
+} // namespace nntrainer

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.h
@@ -17,404 +17,81 @@
 #include <string>
 
 namespace nntrainer {
-static const std::string sgemv_cl_kernel_ =
-  R"(__kernel void sgemv_cl(const __global float* A, const __global float* X,
-                      __global float* Y, unsigned int N, unsigned int lda) {                                            
-        unsigned int i;
-        i = get_global_id(0);                         
-        float y0 = 0.0f;
-        for (unsigned int j = 0; j < N; j++)                         
-            y0 += A[i + j * lda] * X[j]; 
-        Y[i] = y0;                            
-          
-    })";
 
-static const std::string sgemv_cl_noTrans_kernel_ =
-  R"(__kernel void sgemv_cl_noTrans(const __global float* A, const __global float* X,
-                      __global float* Y, unsigned int N, unsigned int lda) {                                            
-        unsigned int i;
-        i = get_global_id(0);                         
-        float y0 = 0.0f;
-        for (unsigned int j = 0; j < N; j++)                         
-            y0 += A[j + i * lda] * X[j]; 
-        Y[i] = y0;                            
-          
-    })";
+const std::string &getSgemvClKernel();
 
-static const std::string dot_cl_kernel_ =
-  R"(__kernel void dot_cl(const __global float* A, const __global float* X, unsigned int K, __global float* res) {
-        *res = 0;
-        for (unsigned int i = 0; i < K; i++){
-            *res += A[i] * X[i];
-        }
-    })";
+const std::string &getSgemvClNoTransKernel();
 
-static const std::string sgemm_cl_noTrans_kernel_ =
-  R"(__kernel void sgemm_cl_noTrans(const __global float* A, const __global float* B,
-                      __global float* C, unsigned int K, unsigned int lda, unsigned int ldb, unsigned int ldc) {
-        
-        unsigned int m = get_global_id(0);
-        unsigned int n = get_global_id(1);
-        float c = 0.0f;
-        for (unsigned int k = 0; k < K; ++k) {
-          float a, b;
-          a = A[m * lda + k];
-          b = B[k * ldb + n];
-          c += a * b;
-        }
-        C[m * ldc + n] = c;
-    })";
+const std::string &getDotClKernel();
 
-static const std::string sgemm_cl_transA_kernel_ =
-  R"(__kernel void sgemm_cl_transA(const __global float* A, const __global float* B,
-                      __global float* C, unsigned int K, unsigned int lda, unsigned int ldb, unsigned int ldc) {
-        
-        unsigned int m = get_global_id(0);
-        unsigned int n = get_global_id(1);
-        float c = 0.0f;
-        for (unsigned int k = 0; k < K; ++k) {
-          float a, b;
-          a = A[k * lda + m];
-          b = B[k * ldb + n];
-          c += a * b;
-        }
-        C[m * ldc + n] = c;
-    })";
+const std::string &getSgemmClNoTransKernel();
 
-static const std::string sgemm_cl_transB_kernel_ =
-  R"(__kernel void sgemm_cl_transB(const __global float *A, const __global float *B,
-                              __global float *C, unsigned int K,
-                              unsigned int lda, unsigned int ldb,
-                              unsigned int ldc) {
+const std::string &getSgemmClTransAKernel();
 
-        unsigned int m = get_global_id(0);
-        unsigned int n = get_global_id(1);
-        float c = 0.0f;
-        for (unsigned int k = 0; k < K; ++k) {
-          float a, b;
-          a = A[m * lda + k];
-          b = B[n * ldb + k];
-          c += a * b;
-        }
-        C[m * ldc + n] = c;
-    })";
+const std::string &getSgemmClTransBKernel();
 
-static const std::string sgemm_cl_transAB_kernel_ =
-  R"(__kernel void sgemm_cl_transAB(const __global float *A, const __global float *B,
-                               __global float *C, unsigned int K,
-                               unsigned int lda, unsigned int ldb,
-                               unsigned int ldc) {
+const std::string &getSgemmClTransABKernel();
 
-        unsigned int m = get_global_id(0);
-        unsigned int n = get_global_id(1);
-        float c = 0.0f;
-        for (unsigned int k = 0; k < K; ++k) {
-          float a, b;
-          a = A[k * lda + m];
-          b = B[n * ldb + k];
-          c += a * b;
-        }
-        C[m * ldc + n] = c;
-    })";
+const std::string &getAdditionClKernel();
 
-static const std::string addition_cl_kernel_ =
-  R"(__kernel void addition_cl(const __global float* input, __global float* output, unsigned int size_input, unsigned int size_res) {
-    #pragma printf_support
-    size_t idx = get_global_id(0);
-    if (idx < size_res) {
-        output[idx] = output[idx] + input[idx % size_input];
-    }
-  })";
+const std::string &getSscalClKernel();
 
-static const std::string sscal_cl_kernel_ =
-  R"(__kernel void sscal_cl(__global float* X, const float alpha) {
-        
-        unsigned int i = get_global_id(0);
-        X[i] *= alpha;
-    })";
+const std::string &getTransposeClKernelAxis0();
 
-static const std::string transpose_cl_kernel_axis0 =
-  R"(__kernel void transpose_cl_axis0(__global const float* in, 
-                               __global float* output,
-                               const int batch_size, 
-                               const int channels, 
-                               const int height, 
-                               const int width) {
-    // Calculate h and w from the global IDs
-    int h = get_global_id(0);
-    int w = get_global_id(1);
-    if (h < height && w < width) {
-        for (int c = 0; c < channels; ++c) {
-            for (int n = 0; n < batch_size; ++n) {
-                // Calculate the input and output indices
-                int input_index = n * (channels * height * width) + c * (height * width) + h * width + w;
-                int output_index = n * (channels * height * width) + h * (channels * width) + c * width + w;
-                // Transpose channel and height, copying data from input to output
-                output[output_index] = in[input_index];
-            }
-        }
-    }
-})";
+const std::string &getTransposeClKernelAxis1();
 
-static const std::string transpose_cl_kernel_axis1 =
-  R"(__kernel void transpose_cl_axis1(__global const float* in, 
-                               __global float* output,
-                               const int batch_size, 
-                               const int channels, 
-                               const int height, 
-                               const int width) {
-    // Calculate h and w from the global IDs
-    int h = get_global_id(0);
-    int w = get_global_id(1);
-    if (h < height && w < width) {
-        for (int c = 0; c < channels; ++c) {
-            for (int n = 0; n < batch_size; ++n) {
-                // Calculate the input and output indices
-                int input_index = n * (channels * height * width) + c * (height * width) + h * width + w;
-                int output_index = n * (channels * height * width) + c * (height * width) + w * height + h;
-                // Transpose height and width, copying data from input to output
-                output[output_index] = in[input_index];
-            }
-        }
-    }
-})";
+const std::string &getTransposeClKernelAxis2();
 
-static const std::string transpose_cl_kernel_axis2 =
-  R"(__kernel void transpose_cl_axis2(__global const float* in, 
-                               __global float* output,
-                               const int batch_size, 
-                               const int channels, 
-                               const int height, 
-                               const int width) {
-    // Calculate c and w from the global IDs
-    int c = get_global_id(0);
-    int w = get_global_id(1);
-    if (c < channels && w < width) {
-        for (int h = 0; h < height; ++h) {
-            for (int n = 0; n < batch_size; ++n) {
-                // Calculate the input and output indices
-                int input_index = n * (channels * height * width) + c * (height * width) + h * width + w;
-                int output_index = n * (channels * height * width) + w * (height * channels) + h * channels + c;
-                // Transpose channel and width, copying data from input to output
-                output[output_index] = in[input_index];
-            }
-        }
-    }
-})";
+const std::string &getSwiGluClKernel();
+
+const std::string &getCopyClKernel();
+
+const std::string &getConcatClAxis3Kernel();
+
+const std::string &getConcatClAxis2Kernel();
+
+const std::string &getConcatClAxis1Kernel();
+
+const std::string &getRMSNormClKernel();
 
 #ifdef ENABLE_FP16
-static const std::string sgemv_cl_kernel_fp16_ =
-  R"(
-    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
-    
-    __kernel void sgemv_cl_fp16(const __global half* A, const __global half* X,
-                      __global half* Y, unsigned int N, unsigned int lda) {                                            
-        unsigned int i;
-        i = get_global_id(0);                         
-        half y0 = 0.0f;
-        for (unsigned int j = 0; j < N; j++)                         
-            y0 += A[i + j * lda] * X[j]; 
-        Y[i] = y0;                            
-          
-    })";
 
-static const std::string sgemv_cl_noTrans_kernel_fp16_ =
-  R"(
-    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+const std::string &getHgemvClKernel();
 
-    __kernel void sgemv_cl_noTrans_fp16(const __global half* A, const __global half* X,
-                      __global half* Y, unsigned int N, unsigned int lda) {                                            
-        unsigned int i;
-        i = get_global_id(0);                         
-        half y0 = 0.0f;
-        for (unsigned int j = 0; j < N; j++)                         
-            y0 += A[j + i * lda] * X[j]; 
-        Y[i] = y0;                            
-          
-    })";
+const std::string &getHgemvClNoTransKernel();
 
-static const std::string dot_cl_kernel_fp16_ =
-  R"(
-    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+const std::string &getDotClKernelFP16();
 
-    __kernel void dot_cl_fp16(const __global half* A, const __global half* X, unsigned int K, __global half* res) {
-        *res = 0;
-        for (unsigned int i = 0; i < K; i++){
-            *res += A[i] * X[i];
-        }
-    })";
+const std::string &getHgemmClNoTransKernel();
 
-static const std::string sgemm_cl_noTrans_kernel_fp16_ =
-  R"(
-    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+const std::string &getHgemmClTransAKernel();
 
-    __kernel void sgemm_cl_noTrans_fp16(const __global half* A, const __global half* B,
-                      __global half* C, unsigned int K, unsigned int lda, unsigned int ldb, unsigned int ldc) {
-        
-        unsigned int m = get_global_id(0);
-        unsigned int n = get_global_id(1);
-        half c = 0.0f;
-        for (unsigned int k = 0; k < K; ++k) {
-          half a, b;
-          a = A[m * lda + k];
-          b = B[k * ldb + n];
-          c += a * b;
-        }
-        C[m * ldc + n] = c;
-    })";
+const std::string &getHgemmClTransBKernel();
 
-static const std::string sgemm_cl_transA_kernel_fp16_ =
-  R"(
-    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+const std::string &getHgemmClTransABKernel();
 
-    __kernel void sgemm_cl_transA_fp16(const __global half* A, const __global half* B,
-                      __global half* C, unsigned int K, unsigned int lda, unsigned int ldb, unsigned int ldc) {
-        
-        unsigned int m = get_global_id(0);
-        unsigned int n = get_global_id(1);
-        half c = 0.0f;
-        for (unsigned int k = 0; k < K; ++k) {
-          half a, b;
-          a = A[k * lda + m];
-          b = B[k * ldb + n];
-          c += a * b;
-        }
-        C[m * ldc + n] = c;
-    })";
+const std::string &getAdditionClKernelFP16();
 
-static const std::string sgemm_cl_transB_kernel_fp16_ =
-  R"(
-    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+const std::string &getHscalClKernel();
 
-    __kernel void sgemm_cl_transB_fp16(const __global half* A, const __global half* B,
-                      __global half* C, unsigned int K, unsigned int lda, unsigned int ldb, unsigned int ldc) {
-        
-        unsigned int m = get_global_id(0);
-        unsigned int n = get_global_id(1);
-        half c = 0.0f;
-        for (unsigned int k = 0; k < K; ++k) {
-          half a, b;
-          a = A[m * lda + k];
-          b = B[n * ldb + k];
-          c += a * b;
-        }
-        C[m * ldc + n] = c;
-    })";
+const std::string &getTransposeClAxis0KernelFP16();
 
-static const std::string sgemm_cl_transAB_kernel_fp16_ =
-  R"(
-    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+const std::string &getTransposeClAxis1KernelFP16();
 
-    __kernel void sgemm_cl_transAB_fp16(const __global half* A, const __global half* B,
-                      __global half* C, unsigned int K, unsigned int lda, unsigned int ldb, unsigned int ldc) {
-        
-        unsigned int m = get_global_id(0);
-        unsigned int n = get_global_id(1);
-        half c = 0.0f;
-        for (unsigned int k = 0; k < K; ++k) {
-          half a, b;
-          a = A[k * lda + m];
-          b = B[n * ldb + k];
-          c += a * b;
-        }
-        C[m * ldc + n] = c;
-    })";
+const std::string &getTransposeClAxis2KernelFP16();
 
-static const std::string addition_cl_kernel_fp16_ =
-  R"(
-    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+const std::string &getSwiGluClKernelFP16();
 
-    __kernel void addition_cl_fp16(const __global half* input, __global half* output, unsigned int size_input, unsigned int size_res) {
-    size_t idx = get_global_id(0);
-    if (idx < size_res) {
-        output[idx] = output[idx] + input[idx % size_input];
-    }
-  })";
+const std::string &getCopyClKernelFP16();
 
-static const std::string sscal_cl_kernel_fp16_ =
-  R"(
-    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+const std::string &getConcatClAxis3KernelFP16();
 
-    __kernel void sscal_cl_fp16(__global half* X, const float alpha) {
-        
-        unsigned int i = get_global_id(0);
-        X[i] *= alpha;
-    })";
+const std::string &getConcatClAxis2KernelFP16();
 
-static const std::string transpose_cl_kernel_fp16_axis0 =
-  R"(
-    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
-    __kernel void transpose_cl_fp16_axis0(__global const half* in, 
-                               __global half* output,
-                               const int batch_size, 
-                               const int channels, 
-                               const int height, 
-                               const int width) {
-    // Calculate h and w from the global IDs
-    int h = get_global_id(0);
-    int w = get_global_id(1);
-    if (h < height && w < width) {
-        for (int c = 0; c < channels; ++c) {
-            for (int n = 0; n < batch_size; ++n) {
-                // Calculate the input and output indices
-                int input_index = n * (channels * height * width) + c * (height * width) + h * width + w;
-                int output_index = n * (channels * height * width) + h * (channels * width) + c * width + w;
-                // Transpose channel and height, copying data from input to output
-                output[output_index] = in[input_index];
-            }
-        }
-    }
-})";
+const std::string &getConcatClAxis1KernelFP16();
 
-static const std::string transpose_cl_kernel_fp16_axis1 =
-  R"(
-    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
-    __kernel void transpose_cl_fp16_axis1(__global const half* in, 
-                               __global half* output,
-                               const int batch_size, 
-                               const int channels, 
-                               const int height, 
-                               const int width) {
-    // Calculate h and w from the global IDs
-    int h = get_global_id(0);
-    int w = get_global_id(1);
-    if (h < height && w < width) {
-        for (int c = 0; c < channels; ++c) {
-            for (int n = 0; n < batch_size; ++n) {
-                // Calculate the input and output indices
-                int input_index = n * (channels * height * width) + c * (height * width) + h * width + w;
-                int output_index = n * (channels * height * width) + c * (height * width) + w * height + h;
-                // Transpose height and width, copying data from input to output
-                output[output_index] = in[input_index];
-            }
-        }
-    }
-})";
+const std::string &getRMSNormClKernelFP16();
 
-static const std::string transpose_cl_kernel_fp16_axis2 =
-  R"(
-    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
-    __kernel void transpose_cl_fp16_axis2(__global const half* in, 
-                               __global half* output,
-                               const int batch_size, 
-                               const int channels, 
-                               const int height, 
-                               const int width) {
-    // Calculate c and w from the global IDs
-    int c = get_global_id(0);
-    int w = get_global_id(1);
-    if (c < channels && w < width) {
-        for (int h = 0; h < height; ++h) {
-            for (int n = 0; n < batch_size; ++n) {
-                // Calculate the input and output indices
-                int input_index = n * (channels * height * width) + c * (height * width) + h * width + w;
-                int output_index = n * (channels * height * width) + w * (height * channels) + h * channels + c;
-                // Transpose channel and width, copying data from input to output
-                output[output_index] = in[input_index];
-            }
-        }
-    }
-})";
 #endif
 } // namespace nntrainer
 #endif /* __BLAS_KERNEL_INTERFACE_H__ */

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -27,10 +27,10 @@ void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
 
     if (TransA) {
       kernel_sgemv_ptr =
-        blas_cc->registerClKernel(sgemv_cl_kernel_, "sgemv_cl");
+        blas_cc->registerClKernel(getSgemvClKernel(), "sgemv_cl");
     } else {
-      kernel_sgemv_ptr =
-        blas_cc->registerClKernel(sgemv_cl_noTrans_kernel_, "sgemv_cl_noTrans");
+      kernel_sgemv_ptr = blas_cc->registerClKernel(getSgemvClNoTransKernel(),
+                                                   "sgemv_cl_noTrans");
     }
 
     if (!kernel_sgemv_ptr) {
@@ -113,7 +113,7 @@ float dot_cl(const float *vecAdata, const float *vecXdata, unsigned int dim1) {
 
   do {
     ClContext::SharedPtrClKernel kernel_dot_ptr =
-      blas_cc->registerClKernel(dot_cl_kernel_, "dot_cl");
+      blas_cc->registerClKernel(getDotClKernel(), "dot_cl");
     if (!kernel_dot_ptr) {
       break;
     }
@@ -185,16 +185,16 @@ void sgemm_cl(bool TransA, bool TransB, const float *A, const float *B,
 
   if (!TransA && !TransB) {
     kernel_func_ = "sgemm_cl_noTrans";
-    sgemm_cl_kernel_ = sgemm_cl_noTrans_kernel_;
+    sgemm_cl_kernel_ = getSgemmClNoTransKernel();
   } else if (TransA && !TransB) {
     kernel_func_ = "sgemm_cl_transA";
-    sgemm_cl_kernel_ = sgemm_cl_transA_kernel_;
+    sgemm_cl_kernel_ = getSgemmClTransAKernel();
   } else if (!TransA && TransB) {
     kernel_func_ = "sgemm_cl_transB";
-    sgemm_cl_kernel_ = sgemm_cl_transB_kernel_;
+    sgemm_cl_kernel_ = getSgemmClTransBKernel();
   } else {
     kernel_func_ = "sgemm_cl_transAB";
-    sgemm_cl_kernel_ = sgemm_cl_transAB_kernel_;
+    sgemm_cl_kernel_ = getSgemmClTransABKernel();
   }
 
   bool result = false;
@@ -293,7 +293,7 @@ void addition_cl(const float *input, float *res, unsigned int size_input,
 
   do {
     ClContext::SharedPtrClKernel kernel_addition_ptr =
-      blas_cc->registerClKernel(addition_cl_kernel_, "addition_cl");
+      blas_cc->registerClKernel(getAdditionClKernel(), "addition_cl");
     if (!kernel_addition_ptr) {
       break;
     }
@@ -360,7 +360,7 @@ void sscal_cl(float *X, const unsigned int N, const float alpha) {
 
   do {
     ClContext::SharedPtrClKernel kernel_ptr =
-      blas_cc->registerClKernel(sscal_cl_kernel_, "sscal_cl");
+      blas_cc->registerClKernel(getSscalClKernel(), "sscal_cl");
 
     if (!kernel_ptr) {
       break;
@@ -416,15 +416,15 @@ void transpose_cl_axis(const float *in, float *res,
     switch (axis) {
     case 0:
       kernel_transpose_ptr = blas_cc->registerClKernel(
-        transpose_cl_kernel_axis0, "transpose_cl_axis0");
+        getTransposeClKernelAxis0(), "transpose_cl_axis0");
       break;
     case 1:
       kernel_transpose_ptr = blas_cc->registerClKernel(
-        transpose_cl_kernel_axis1, "transpose_cl_axis1");
+        getTransposeClKernelAxis1(), "transpose_cl_axis1");
       break;
     case 2:
       kernel_transpose_ptr = blas_cc->registerClKernel(
-        transpose_cl_kernel_axis2, "transpose_cl_axis2");
+        getTransposeClKernelAxis2(), "transpose_cl_axis2");
       break;
     default:
       throw std::invalid_argument("failed to register CL kernel");

--- a/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
@@ -27,10 +27,10 @@ void sgemv_cl(const _FP16 *matAdata, const _FP16 *vecXdata, _FP16 *vecYdata,
 
     if (TransA) {
       kernel_sgemv_fp16_ptr =
-        blas_cc->registerClKernel(sgemv_cl_kernel_fp16_, "sgemv_cl_fp16");
+        blas_cc->registerClKernel(getHgemvClKernel(), "sgemv_cl_fp16");
     } else {
       kernel_sgemv_fp16_ptr = blas_cc->registerClKernel(
-        sgemv_cl_noTrans_kernel_fp16_, "sgemv_cl_noTrans_fp16");
+        getHgemvClNoTransKernel(), "sgemv_cl_noTrans_fp16");
     }
 
     if (!kernel_sgemv_fp16_ptr) {
@@ -113,7 +113,7 @@ _FP16 dot_cl(const _FP16 *vecAdata, const _FP16 *vecXdata, unsigned int dim1) {
 
   do {
     ClContext::SharedPtrClKernel kernel_dot_fp16_ptr =
-      blas_cc->registerClKernel(dot_cl_kernel_fp16_, "dot_cl_fp16");
+      blas_cc->registerClKernel(getDotClKernelFP16(), "dot_cl_fp16");
 
     if (!kernel_dot_fp16_ptr) {
       break;
@@ -186,16 +186,16 @@ void sgemm_cl(bool TransA, bool TransB, const _FP16 *A, const _FP16 *B,
 
   if (!TransA && !TransB) {
     kernel_func_ = "sgemm_cl_noTrans_fp16";
-    sgemm_cl_kernel_fp16_ = sgemm_cl_noTrans_kernel_fp16_;
+    sgemm_cl_kernel_fp16_ = getHgemmClNoTransKernel();
   } else if (TransA && !TransB) {
     kernel_func_ = "sgemm_cl_transA_fp16";
-    sgemm_cl_kernel_fp16_ = sgemm_cl_transA_kernel_fp16_;
+    sgemm_cl_kernel_fp16_ = getHgemmClTransAKernel();
   } else if (!TransA && TransB) {
     kernel_func_ = "sgemm_cl_transB_fp16";
-    sgemm_cl_kernel_fp16_ = sgemm_cl_transB_kernel_fp16_;
+    sgemm_cl_kernel_fp16_ = getHgemmClTransBKernel();
   } else {
     kernel_func_ = "sgemm_cl_transAB_fp16";
-    sgemm_cl_kernel_fp16_ = sgemm_cl_transAB_kernel_fp16_;
+    sgemm_cl_kernel_fp16_ = getHgemmClTransABKernel();
   }
 
   bool result = false;
@@ -294,7 +294,7 @@ void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
 
   do {
     ClContext::SharedPtrClKernel kernel_addition_fp16_ptr =
-      blas_cc->registerClKernel(addition_cl_kernel_fp16_, "addition_cl_fp16");
+      blas_cc->registerClKernel(getAdditionClKernelFP16(), "addition_cl_fp16");
     if (!kernel_addition_fp16_ptr) {
       break;
     }
@@ -361,7 +361,7 @@ void sscal_cl(_FP16 *X, const unsigned int N, const float alpha) {
 
   do {
     ClContext::SharedPtrClKernel kernel_sscal_fp16_ptr =
-      blas_cc->registerClKernel(sscal_cl_kernel_fp16_, "sscal_cl_fp16");
+      blas_cc->registerClKernel(getHscalClKernel(), "sscal_cl_fp16");
 
     if (!kernel_sscal_fp16_ptr) {
       break;
@@ -418,15 +418,15 @@ void transpose_cl_axis(const _FP16 *in, _FP16 *res,
     switch (axis) {
     case 0:
       kernel_transpose_fp_16_ptr = blas_cc->registerClKernel(
-        transpose_cl_kernel_fp16_axis0, "transpose_cl_fp16_axis0");
+        getTransposeClAxis0KernelFP16(), "transpose_cl_fp16_axis0");
       break;
     case 1:
       kernel_transpose_fp_16_ptr = blas_cc->registerClKernel(
-        transpose_cl_kernel_fp16_axis1, "transpose_cl_fp16_axis1");
+        getTransposeClAxis1KernelFP16(), "transpose_cl_fp16_axis1");
       break;
     case 2:
       kernel_transpose_fp_16_ptr = blas_cc->registerClKernel(
-        transpose_cl_kernel_fp16_axis2, "transpose_cl_fp16_axis2");
+        getTransposeClAxis2KernelFP16(), "transpose_cl_fp16_axis2");
       break;
     default:
       throw std::invalid_argument("failed to register CL kernel");

--- a/nntrainer/tensor/cl_operations/meson.build
+++ b/nntrainer/tensor/cl_operations/meson.build
@@ -1,7 +1,9 @@
 cl_op_sources = [
   'blas_kernels.cpp',
   'blas_kernel_interface.cpp',
+  'blas_kernel_strings.cpp',
   'attention_kernel_interface.cpp',
+  'attention_kernel_strings.cpp',
   'attention_kernels.cpp',
 ]
 


### PR DESCRIPTION
This commit fixes an error that occurred during the registration of OpenCL kernels. The issue was caused by the static initialization order, with `std::call_once` in the Engine class being invoked before the kernel strings had been initialized. This patch introduces functions to lazily initialize the kernel strings, ensuring that they are fully initialized before they are used.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped