### PR TITLE
[Meson] Add minimum cmake policy version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -467,6 +467,7 @@ else
   if host_machine.system() == 'windows'
     ruy_options.add_cmake_defines(common_win_subproject_cmake_defines)
   else
+    ruy_options.add_cmake_defines({'CMAKE_POLICY_VERSION_MINIMUM': '3.5'})
     ruy_flags = [
       '-Wno-error=unused-result',
       '-Wno-error=comment',


### PR DESCRIPTION
This PR adds the minimum CMake policy version since compatibility with CMake < 3.5 has been removed.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped