### PR TITLE
Enhance OpenCL Context: Memory Allocator and Kernel Registration Improvements

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -74,6 +74,8 @@ static void add_default_object(ClContext &cc) {
 
 static void registerer(ClContext &cc) noexcept {
   try {
+    cc.setMemAllocator(std::make_shared<MemAllocator>());
+
     cc.initBlasClKernels();
     cc.initAttentionClKernels();
     add_default_object(cc);

--- a/nntrainer/cl_context.h
+++ b/nntrainer/cl_context.h
@@ -29,6 +29,7 @@
 #include <context.h>
 #include <layer.h>
 #include <layer_devel.h>
+#include <mem_allocator.h>
 
 #include <cl_buffer_manager.h>
 #include <opencl_command_queue_manager.h>
@@ -46,7 +47,6 @@ extern std::mutex cl_factory_mutex;
  */
 
 class ClContext : public Context {
-
 public:
   using SharedPtrClKernel = std::shared_ptr<opencl::Kernel>;
 
@@ -232,6 +232,15 @@ public:
    * @brief Get the name of the context
    */
   std::string getName() override { return "gpu"; }
+
+  /**
+   * @brief Set the Mem Allocator object
+   *
+   * @param mem Memory allocator object
+   */
+  void setMemAllocator(std::shared_ptr<MemAllocator> mem) {
+    getContextData()->setMemAllocator(mem);
+  }
 
 private:
   // flag to check opencl commandqueue and context inititalization

--- a/nntrainer/layers/cl_layers/concat_cl.cpp
+++ b/nntrainer/layers/cl_layers/concat_cl.cpp
@@ -33,6 +33,7 @@ static constexpr size_t INPUT_IDX_1 = 0;
 static constexpr size_t INPUT_IDX_2 = 1;
 
 bool ConcatLayerCl::registerClKernels() {
+  auto &layer_kernel_ptrs = getLayerKernelPtrs();
 
   // check if already registered
   if (!layer_kernel_ptrs.empty()) {
@@ -231,7 +232,8 @@ void ConcatLayerCl::concat_cl_axis3(const float *matAdata,
 
   do {
 
-    const auto &kernel_concat_ptr = layer_kernel_ptrs[Kernels::CONCAT_CL_AXIS3];
+    const auto &kernel_concat_ptr =
+      getLayerKernelPtrs()[Kernels::CONCAT_CL_AXIS3];
 
     int dim = int(input1_batch_size * input1_channels * input1_height *
                   (input1_width + input2_width));
@@ -344,7 +346,8 @@ void ConcatLayerCl::concat_cl_axis2(const float *matAdata,
 
   do {
 
-    const auto &kernel_concat_ptr = layer_kernel_ptrs[Kernels::CONCAT_CL_AXIS2];
+    const auto &kernel_concat_ptr =
+      getLayerKernelPtrs()[Kernels::CONCAT_CL_AXIS2];
 
     int dim = int(input1_batch_size * input1_channels * input1_width *
                   (input1_height + input2_height));
@@ -455,7 +458,8 @@ void ConcatLayerCl::concat_cl_axis1(const float *matAdata,
   bool result = false;
 
   do {
-    const auto &kernel_concat_ptr = layer_kernel_ptrs[Kernels::CONCAT_CL_AXIS1];
+    const auto &kernel_concat_ptr =
+      getLayerKernelPtrs()[Kernels::CONCAT_CL_AXIS1];
 
     int dim = int(input1_batch_size * input1_width * input1_height *
                   (input1_channels + input2_channels));
@@ -570,7 +574,7 @@ void ConcatLayerCl::concat_cl_axis3_fp16(const _FP16 *matAdata,
   do {
 
     const auto &kernel_concat_ptr =
-      layer_kernel_ptrs[Kernels::CONCAT_CL_AXIS3_FP16];
+      getLayerKernelPtrs()[Kernels::CONCAT_CL_AXIS3_FP16];
 
     int dim = int(input1_batch_size * input1_channels * input1_height *
                   (input1_width + input2_width));
@@ -683,7 +687,7 @@ void ConcatLayerCl::concat_cl_axis2_fp16(const _FP16 *matAdata,
 
   do {
     const auto &kernel_concat_ptr =
-      layer_kernel_ptrs[Kernels::CONCAT_CL_AXIS2_FP16];
+      getLayerKernelPtrs()[Kernels::CONCAT_CL_AXIS2_FP16];
 
     int dim = int(input1_batch_size * input1_channels * input1_width *
                   (input1_height + input2_height));
@@ -796,7 +800,7 @@ void ConcatLayerCl::concat_cl_axis1_fp16(const _FP16 *matAdata,
   do {
 
     const auto &kernel_concat_ptr =
-      layer_kernel_ptrs[Kernels::CONCAT_CL_AXIS1_FP16];
+      getLayerKernelPtrs()[Kernels::CONCAT_CL_AXIS1_FP16];
 
     int dim = int(input1_batch_size * input1_width * input1_height *
                   (input1_channels + input2_channels));
@@ -915,6 +919,12 @@ void ConcatLayerCl::exportTo(Exporter &exporter,
                              const ml::train::ExportMethods &method) const {
   Layer::exportTo(exporter, method);
   exporter.saveResult(concat_props, method, this);
+}
+
+std::vector<ClContext::SharedPtrClKernel> &ConcatLayerCl::getLayerKernelPtrs() {
+  /**< kernel list relevant with this layer */
+  static std::vector<ClContext::SharedPtrClKernel> layer_kernel_ptrs;
+  return layer_kernel_ptrs;
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/cl_layers/concat_cl.h
+++ b/nntrainer/layers/cl_layers/concat_cl.h
@@ -230,8 +230,7 @@ public:
 private:
   std::tuple<props::ConcatDimension> concat_props;
 
-  inline static std::vector<ClContext::SharedPtrClKernel>
-    layer_kernel_ptrs; /** kernel list relevant with this layer */
+  static std::vector<ClContext::SharedPtrClKernel> &getLayerKernelPtrs();
 
   enum Kernels {
     CONCAT_CL_AXIS1,

--- a/nntrainer/layers/cl_layers/reshape_cl.h
+++ b/nntrainer/layers/cl_layers/reshape_cl.h
@@ -33,7 +33,7 @@ public:
   /**
    * @brief     Constructor of Reshape Layer
    */
-  ReshapeLayerCl() : Layer() {}
+  ReshapeLayerCl() : LayerImplCl() {}
 
   /**
    * @brief     Destructor of Reshape Layer
@@ -153,7 +153,7 @@ private:
   std::tuple<props::TargetShape>
     reshape_props; /**< reshape properties : target_shape after reshape */
 
-  inline static std::vector<ClContext::SharedPtrClKernel> layer_kernel_ptrs;
+  static std::vector<ClContext::SharedPtrClKernel> &getLayerKernelPtrs();
 
   enum Kernels { COPY_CL, COPY_CL_FP16 };
 };

--- a/nntrainer/layers/cl_layers/rmsnorm_layer_cl.cpp
+++ b/nntrainer/layers/cl_layers/rmsnorm_layer_cl.cpp
@@ -29,6 +29,46 @@ enum RMSParams { gamma };
 
 RMSNormLayerCl::RMSNormLayerCl() : LayerImplCl() { wt_idx.fill(0); }
 
+bool RMSNormLayerCl::registerClKernels() {
+  auto &layer_kernel_ptrs = getLayerKernelPtrs();
+
+  // check if already registered
+  if (!layer_kernel_ptrs.empty()) {
+    ml_loge("kernels for reshape layer are already registered");
+    return false;
+  }
+
+  do {
+
+    ClContext::SharedPtrClKernel kernel_rmsnorm_ptr =
+      global_cl_context->registerClKernel(getRMSNormClKernel(), "rmsnorm_cl");
+    if (!kernel_rmsnorm_ptr) {
+      ml_loge("OpenCL Error: Fail to register rmsnorm_cl kernel");
+      break;
+    }
+    layer_kernel_ptrs.emplace_back(kernel_rmsnorm_ptr);
+
+#ifdef ENABLE_FP16
+    ClContext::SharedPtrClKernel kernel_rmsnorm_fp16_ptr =
+      global_cl_context->registerClKernel(getRMSNormClKernelFP16(),
+                                          "rmsnorm_cl_fp16");
+    if (!kernel_rmsnorm_fp16_ptr) {
+      ml_loge("OpenCL Error: Fail to register rmsnorm_cl_fp16 kernel");
+      break;
+    }
+    layer_kernel_ptrs.emplace_back(kernel_rmsnorm_ptr);
+#endif
+
+    return true;
+
+  } while (false);
+
+  // clear all registered kernels if any error occurs during registration
+  // layer_kernel_ptrs.clear();
+
+  return false;
+}
+
 void RMSNormLayerCl::finalize(InitLayerContext &context) {
   std::vector<TensorDim> dim = context.getInputDimensions();
   context.setOutputDimensions(dim);
@@ -70,8 +110,7 @@ void RMSNormLayerCl::rmsnormProcess(Tensor const &input, Tensor &result,
   int w = input.width();
 
   do {
-
-    auto kernel_rmsnorm_ptr = layer_kernel_ptrs[Kernels::RMSNORM_CL];
+    const auto &kernel_rmsnorm_ptr = getLayerKernelPtrs()[Kernels::RMSNORM_CL];
 
     const float *data = input.getData();
     float *rdata = result.getData();
@@ -162,7 +201,7 @@ void RMSNormLayerCl::rmsnormProcess_fp16(Tensor const &input, Tensor &result,
   int h = input.height();
   int w = input.width();
   do {
-    auto kernel_rmsnorm_ptr = layer_kernel_ptrs[Kernels::RMSNORM_CL_FP16];
+    auto kernel_rmsnorm_ptr = getLayerKernelPtrs()[Kernels::RMSNORM_CL_FP16];
 
     const _FP16 *data = input.getData<_FP16>();
     _FP16 *rdata = result.getData<_FP16>();
@@ -297,44 +336,11 @@ void RMSNormLayerCl::setProperty(const std::vector<std::string> &values) {
   LayerImpl::setProperty(remain_props);
 }
 
-bool RMSNormLayerCl::registerClKernels() {
-
-  // check if already registered
-  if (!layer_kernel_ptrs.empty()) {
-    ml_loge("kernels for concat layer are already registered.");
-    return false;
-  }
-
-  do {
-
-    ClContext::SharedPtrClKernel kernel_rmsnorm_ptr = nullptr;
-
-    kernel_rmsnorm_ptr =
-      global_cl_context->registerClKernel(getRMSNormClKernel(), "rmsnorm_cl");
-    if (!kernel_rmsnorm_ptr) {
-      ml_loge("OpenCL Error: Fail to register rmsnorm_cl kernel");
-      break;
-    }
-    layer_kernel_ptrs.emplace_back(kernel_rmsnorm_ptr);
-
-#ifdef ENABLE_FP16
-    kernel_rmsnorm_ptr = global_cl_context->registerClKernel(
-      getRMSNormClKernelFP16(), "rmsnorm_cl_fp16");
-    if (!kernel_rmsnorm_ptr) {
-      ml_loge("OpenCL Error: Fail to register rmsnorm_cl_fp16 kernel");
-      break;
-    }
-    layer_kernel_ptrs.emplace_back(kernel_rmsnorm_ptr);
-#endif
-
-    return true;
-
-  } while (false);
-
-  // clear all registered kernels if any error occurs during registration
-  layer_kernel_ptrs.clear();
-
-  return false;
+std::vector<ClContext::SharedPtrClKernel> &
+RMSNormLayerCl::getLayerKernelPtrs() {
+  /**< kernel list relevant with this layer */
+  static std::vector<ClContext::SharedPtrClKernel> layer_kernel_ptrs;
+  return layer_kernel_ptrs;
 }
 
 } // namespace nntrainer

--- a/nntrainer/layers/cl_layers/rmsnorm_layer_cl.h
+++ b/nntrainer/layers/cl_layers/rmsnorm_layer_cl.h
@@ -138,8 +138,7 @@ private:
   std::tuple<props::GammaInitializer, props::Epsilon>
     rmsnorm_props; /**< rmsnorm layer properties */
 
-  inline static std::vector<ClContext::SharedPtrClKernel>
-    layer_kernel_ptrs; /**< kernel list relevant with this layer */
+  static std::vector<ClContext::SharedPtrClKernel> &getLayerKernelPtrs();
 
   enum Kernels {
     RMSNORM_CL,

--- a/nntrainer/layers/cl_layers/swiglu_cl.h
+++ b/nntrainer/layers/cl_layers/swiglu_cl.h
@@ -132,8 +132,7 @@ private:
   std::tuple<props::Print> swiglu_props; /**< swiglu layer properties : unit -
                                             number of output neurons */
 
-  inline static std::vector<ClContext::SharedPtrClKernel>
-    layer_kernel_ptrs; /** kernel list relevant with this layer */
+  static std::vector<ClContext::SharedPtrClKernel> &getLayerKernelPtrs();
 
   enum Kernels { SWIGLU_CL, SWIGLU_CL_FP16 }; /** kernels enum */
 };


### PR DESCRIPTION
This patch introduces a Memory Allocator for the OpenCL context, which was previously lacking, and ensures that the Context data captures information about GPU layers created by ClContext.
It fixes an error related to the initialization order of a static member variable, which affected the use of registered kernels in OpenCL Layers.
Additionally, the patch addresses issues in OpenCL kernel strings by modifying the concatenation logic and providing a temporary fix for SwiGLU and RMSNorm half-precision operations, ensuring the correct registration of half-precision kernels when FP16 is enabled.