### PR TITLE
[CPU] Add AVX implementation of __fallback_transpose_matrix

### DIFF
--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
@@ -67,6 +67,20 @@ bool is_valid(const unsigned int N, const float *X);
 void custom_scopy(const unsigned int N, const float *X, const int incX,
                   float *Y, const int incY);
 
+/**
+ * @brief Matrix transpose / 2D Tensor transpose
+ *
+ * @param M row length of input matrix
+ * @param N col length of input matrix
+ * @param src src data of input matrix
+ * @param ld_src data offset of input matrix
+ * @param dst destination of output matrix
+ * @param ld_dst data offset of output matrix
+ */
+void transpose_matrix(const unsigned int M, const unsigned int N,
+                      const float *src, unsigned int ld_src, float *dst,
+                      unsigned int ld_dst);
+
 } // namespace nntrainer::avx2
 
 #endif /* __cplusplus */

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -156,7 +156,7 @@ unsigned int isamax(const unsigned int N, const float *X,
 void transpose_matrix(const unsigned int M, const unsigned int N,
                       const float *src, unsigned int ld_src, float *dst,
                       unsigned int ld_dst) {
-  __fallback_transpose_matrix(M, N, src, ld_src, dst, ld_dst);
+  nntrainer::avx2::transpose_matrix(M, N, src, ld_src, dst, ld_dst);
 }
 
 bool is_valid(const unsigned int N, const float *input) {


### PR DESCRIPTION
Added AVX implementation for transpose matrix operation.
It is the first implementation - not the best, but much faster than the current implementation.
In the future (if needed) we will further optimize this method.

**Latency measurement**
| dim        | prev    | AVX    | speedups |
|------------|---------|--------|------- |
| 768x768    | 3.1 ms  | 0.5 ms | x6.1   |
| 1440x1440  | 4.7 ms  | 1.7 ms | x2.7   |
| 1920x1560  | 10.9 ms |2.8 ms  | x3.9   |
| 1560x2048  | 15.8 ms | 3.9 ms | x4.0   |
| 512x2048   | 7.3 ms  | 1.4 ms | x5.2   |

Measurement was made on 12th Gen Intel(R) Core(TM) i7-12700
using the modified unit test `transpose_5122048`
We modified dimensions and we run 1000 iterations of transpose in both directions, the part of code:
```
  for (int i = 0; i < 1000; i++) {
    A_T = A_fp32.transpose("0:2:1");
    A_T_T = A_T.transpose("0:2:1");
  }
```


**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

