### PR TITLE
[Softmax] change to online softmax

### DIFF
--- a/test/unittest/unittest_nntrainer_activations.cpp
+++ b/test/unittest/unittest_nntrainer_activations.cpp
@@ -97,6 +97,54 @@ TEST(nntrainer_activation, softmax_prime_01_p) {
   }
 }
 
+TEST(nntrainer_activation, softmax_big_test_1) {
+  int batch = 3;
+  int channel = 1;
+  int height = 2048;
+  int width = 2048;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  nntrainer::Tensor softmax_result;
+  GEN_TEST_INPUT(input, (i * (width) + k + l));
+
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_NO_THROW(
+      input.apply(nntrainer::ActiFunc::softmax<float>, softmax_result));
+  }
+}
+
+TEST(nntrainer_activation, softmax_big_test_2) {
+  int batch = 1;
+  int channel = 1;
+  int height = 4096;
+  int width = 1024;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  nntrainer::Tensor softmax_result;
+  GEN_TEST_INPUT(input, (i * (width) + k + l));
+
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_NO_THROW(
+      input.apply(nntrainer::ActiFunc::softmax<float>, softmax_result));
+  }
+}
+
+TEST(nntrainer_activation, softmax_big_test_3) {
+  int batch = 1;
+  int channel = 1;
+  int height = 1024;
+  int width = 4096;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  nntrainer::Tensor softmax_result;
+  GEN_TEST_INPUT(input, (i * (width) + k + l));
+
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_NO_THROW(
+      input.apply(nntrainer::ActiFunc::softmax<float>, softmax_result));
+  }
+}
+
 TEST(nntrainer_activation, softmax_prime_02_n) {
   int batch = 3;
   int channel = 1;


### PR DESCRIPTION
- This PR updates the softmax into online softmax
- This optimization fuses two loops into one
- I tested the performance improvement for several cases: 
    - b,c,h,w = 3, 1, 2048, 2048 -> 14.25 % speed-up 
    - b,c,h,w = 1, 1, 4096, 1024->  16.73 % speed-up 
    - b,c,h,w = 1, 1, 1024, 4096 ->  27.25% speed-up 


**Table**. average execution time (ms)
|b,c,h,w | BEFORE | AFTER|
|-- | -- | --|
|(3,1,2048,2048) | 149.5 | 128.2|
|(1,1,4096,1024) | 55.6 | 46.3|
|(1,1,1024,4096) | 52.1 | 37.9|
