### PR TITLE
Remove Half-Precision Floating Point Support Check and Adjust Kernel Execution Work Sizes

### DIFF
--- a/nntrainer/cl_buffer_manager.cpp
+++ b/nntrainer/cl_buffer_manager.cpp
@@ -16,7 +16,6 @@ namespace nntrainer {
 
 ClBufferManager &ClBufferManager::getInstance() {
   static ClBufferManager instance;
-  instance.initBuffers();
   return instance;
 }
 

--- a/nntrainer/layers/cl_layers/concat_cl.cpp
+++ b/nntrainer/layers/cl_layers/concat_cl.cpp
@@ -314,7 +314,8 @@ void ConcatLayerCl::concat_cl_axis3(const float *matAdata,
     }
 
     const int work_groups_count[3] = {dim, 1, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    /// @todo: create a group size by device & input
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
       kernel_concat_ptr, work_groups_count, work_group_size);
@@ -427,7 +428,8 @@ void ConcatLayerCl::concat_cl_axis2(const float *matAdata,
     }
 
     const int work_groups_count[3] = {dim, 1, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    /// @todo: create a group size by device & input
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
       kernel_concat_ptr, work_groups_count, work_group_size);
@@ -540,7 +542,8 @@ void ConcatLayerCl::concat_cl_axis1(const float *matAdata,
     }
 
     const int work_groups_count[3] = {dim, 1, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    /// @todo: create a group size by device & input
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
       kernel_concat_ptr, work_groups_count, work_group_size);
@@ -655,7 +658,8 @@ void ConcatLayerCl::concat_cl_axis3_fp16(const _FP16 *matAdata,
     }
 
     const int work_groups_count[3] = {dim, 1, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    /// @todo: create a group size by device & input
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
       kernel_concat_ptr, work_groups_count, work_group_size);
@@ -767,7 +771,8 @@ void ConcatLayerCl::concat_cl_axis2_fp16(const _FP16 *matAdata,
     }
 
     const int work_groups_count[3] = {dim, 1, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    /// @todo: create a group size by device & input
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
       kernel_concat_ptr, work_groups_count, work_group_size);
@@ -881,7 +886,8 @@ void ConcatLayerCl::concat_cl_axis1_fp16(const _FP16 *matAdata,
     }
 
     const int work_groups_count[3] = {dim, 1, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    /// @todo: create a group size by device & input
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
       kernel_concat_ptr, work_groups_count, work_group_size);

--- a/nntrainer/layers/cl_layers/reshape_cl.cpp
+++ b/nntrainer/layers/cl_layers/reshape_cl.cpp
@@ -201,8 +201,11 @@ void ReshapeLayerCl::copy_cl_fp16(const _FP16 *input, _FP16 *res,
       break;
     }
 
-    const int work_groups_count[3] = {(int)dim_size, 1, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    const int work_groups_count[3] = {
+      (int)(input_batch_size * input_height * input_width * input_channels), 1,
+      1};
+    /// @todo: create a group size by device & input
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
       kernel_copy_ptr, work_groups_count, work_group_size);
@@ -281,7 +284,10 @@ void ReshapeLayerCl::copy_cl(const float *input, float *res,
       break;
     }
 
-    const int work_groups_count[3] = {(int)dim_size, 1, 1};
+    const int work_groups_count[3] = {
+      (int)(input_batch_size * input_height * input_width * input_channels), 1,
+      1};
+    /// @todo: create a group size by device & input
     const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(

--- a/nntrainer/layers/cl_layers/rmsnorm_layer_cl.cpp
+++ b/nntrainer/layers/cl_layers/rmsnorm_layer_cl.cpp
@@ -170,7 +170,8 @@ void RMSNormLayerCl::rmsnormProcess(Tensor const &input, Tensor &result,
       break;
     }
     const int work_groups_count[3] = {b * c, h, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    /// @todo: create a group size by device & input
+    const int work_group_size[3] = {w, 1, 1}; // test-value
 
     ret = global_cl_context->command_queue_inst_.DispatchCommand(
       kernel_rmsnorm_ptr, work_groups_count, work_group_size);
@@ -262,7 +263,8 @@ void RMSNormLayerCl::rmsnormProcess_fp16(Tensor const &input, Tensor &result,
       break;
     }
     const int work_groups_count[3] = {b * c, h, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    /// @todo: create a group size by device & input
+    const int work_group_size[3] = {w, 1, 1}; // test-value
 
     ret = global_cl_context->command_queue_inst_.DispatchCommand(
       kernel_rmsnorm_ptr, work_groups_count, work_group_size);

--- a/nntrainer/layers/cl_layers/swiglu_cl.cpp
+++ b/nntrainer/layers/cl_layers/swiglu_cl.cpp
@@ -164,7 +164,8 @@ void SwiGLULayerCl::swiglu_cl(const float *matAdata, const float *vecXdata,
     }
 
     const int work_groups_count[3] = {dim, 1, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    /// @todo: create a group size by device & input
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
       kernel_swiglu_ptr, work_groups_count, work_group_size);
@@ -232,7 +233,8 @@ void SwiGLULayerCl::swiglu_cl_fp16(const _FP16 *matAdata, const _FP16 *vecXdata,
     }
 
     const int work_groups_count[3] = {dim, 1, 1};
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    /// @todo: create a group size by device & input
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
       kernel_swiglu_ptr, work_groups_count, work_group_size);

--- a/nntrainer/opencl/opencl_context_manager.cpp
+++ b/nntrainer/opencl/opencl_context_manager.cpp
@@ -13,6 +13,7 @@
 
 #include "opencl_context_manager.h"
 
+#include <iostream>
 #include <vector>
 
 #include "opencl_loader.h"
@@ -162,29 +163,33 @@ bool ContextManager::CreateDefaultGPUDevice() {
   this->platform_id_ = platform_id_;
 
 #ifdef ENABLE_FP16
+  /// @note This is working incorrectly. For CUDA devices, cl_khr_fp16 is not
+  /// listed, but compilation with half-precision works.
+
   // check for fp16 (half) support available on device
   // getting extensions
-  size_t extension_size;
-  status =
-    clGetDeviceInfo(device_id_, CL_DEVICE_EXTENSIONS, 0, NULL, &extension_size);
-  if (status != CL_SUCCESS) {
-    ml_loge("clGetDeviceInfo returned %d", status);
-    return false;
-  }
+  // size_t extension_size;
+  // status =
+  //   clGetDeviceInfo(device_id_, CL_DEVICE_EXTENSIONS, 0, NULL,
+  //   &extension_size);
+  // if (status != CL_SUCCESS) {
+  //   ml_loge("clGetDeviceInfo returned %d", status);
+  //   return false;
+  // }
 
-  std::vector<char> extensions(extension_size);
-  status = clGetDeviceInfo(device_id_, CL_DEVICE_EXTENSIONS, extension_size,
-                           extensions.data(), NULL);
-  if (status != CL_SUCCESS) {
-    ml_loge("clGetDeviceInfo returned %d", status);
-    return false;
-  }
+  // std::vector<char> extensions(extension_size);
+  // status = clGetDeviceInfo(device_id_, CL_DEVICE_EXTENSIONS, extension_size,
+  //                          extensions.data(), NULL);
+  // if (status != CL_SUCCESS) {
+  //   ml_loge("clGetDeviceInfo returned %d", status);
+  //   return false;
+  // }
 
-  if (std::string(extensions.data()).find("cl_khr_fp16") == std::string::npos) {
-    throw std::runtime_error("fp16 (half) is not supported by device.");
-    ml_loge("fp16 (half) is not supported by device");
-    return false;
-  }
+  // if (std::string(extensions.data()).find("cl_khr_fp16") ==
+  // std::string::npos) {
+  //   ml_loge("fp16 (half) is not supported by device");
+  //   return false;
+  // }
 #endif
 
   return true;

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -88,7 +88,7 @@ void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
 
     const int work_groups_count[3] = {(int)dim1, 1, 1};
     /// @todo: create a group size by device & input
-    const int work_group_size[3] = {32, 1, 1};
+    const int work_group_size[3] = {1, 1, 1};
 
     result = opencl::CommandQueueManager::GetInstance().DispatchCommand(
       kernel_sgemv_ptr, work_groups_count, work_group_size);
@@ -157,7 +157,7 @@ float dot_cl(const float *vecAdata, const float *vecXdata, unsigned int dim1) {
 
     const int work_groups_count[3] = {(int)dim1, 1, 1};
     /// @todo: create a group size by device & input
-    const int work_group_size[3] = {32, 1, 1}; // test-value
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = blas_cc->command_queue_inst_.DispatchCommand(
       kernel_dot_ptr, work_groups_count, work_group_size);
@@ -269,7 +269,7 @@ void sgemm_cl(bool TransA, bool TransB, const float *A, const float *B,
 
     const int work_groups_count[3] = {(int)M, (int)N, 1};
     /// @todo: create a group size by device & input
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = blas_cc->command_queue_inst_.DispatchCommand(
       kernel_sgemm_ptr, work_groups_count, work_group_size);

--- a/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
@@ -88,7 +88,7 @@ void sgemv_cl(const _FP16 *matAdata, const _FP16 *vecXdata, _FP16 *vecYdata,
 
     const int work_groups_count[3] = {(int)dim1, 1, 1};
     /// @todo: create a group size by device & input
-    const int work_group_size[3] = {32, 1, 1}; // test-value
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = blas_cc->command_queue_inst_.DispatchCommand(
       kernel_sgemv_fp16_ptr, work_groups_count, work_group_size);
@@ -158,7 +158,7 @@ _FP16 dot_cl(const _FP16 *vecAdata, const _FP16 *vecXdata, unsigned int dim1) {
 
     const int work_groups_count[3] = {(int)dim1, 1, 1};
     /// @todo: create a group size by device & input
-    const int work_group_size[3] = {32, 1, 1};
+    const int work_group_size[3] = {1, 1, 1};
 
     result = blas_cc->command_queue_inst_.DispatchCommand(
       kernel_dot_fp16_ptr, work_groups_count, work_group_size);
@@ -270,7 +270,7 @@ void sgemm_cl(bool TransA, bool TransB, const _FP16 *A, const _FP16 *B,
 
     const int work_groups_count[3] = {(int)M, (int)N, 1};
     /// @todo: create a group size by device & input
-    const int work_group_size[3] = {32, 32, 1}; // test-value
+    const int work_group_size[3] = {1, 1, 1}; // test-value
 
     result = blas_cc->command_queue_inst_.DispatchCommand(
       kernel_sgemm_fp16_ptr, work_groups_count, work_group_size);


### PR DESCRIPTION
This PR combines two commits that address improvements in our OpenCL implementation:

1. Removal of Half-Precision Floating Point Support Check: The first commit removes the requirement to check for half-precision floating point support on devices. In CUDA, enabling the cl_khr_fp16 pragma/feature macro allows for basic operations using half data types, including addition, subtraction, multiplication, and division, with the newer compiler. 

2. Adjust Kernel Execution Global and Local Work Sizes: The second commit updates the global and local work sizes used when dispatching OpenCL kernels. Previously set to a fixed value of 32, this could lead to errors when the input size was less than 32. The work sizes have now been adjusted to align with the specific requirements of each kernel, ensuring more efficient and accurate execution.