### PR TITLE
[Performance] Configure Open BLAS threads.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -320,6 +320,7 @@ if get_option('enable-blas')
 
     if not blas_dep.found()
       blas_options = cmake.subproject_options()
+      blas_options.add_cmake_defines({'NUM_THREADS': get_option('openblas-num-threads').to_string()})
       blas_options.add_cmake_defines({'BUILD_TESTING': false})
       blas_options.add_cmake_defines({'BUILD_BENCHMARKS': false})
       blas_options.add_cmake_defines({'BUILD_SHARED_LIBS': host_machine.system() != 'windows'})

--- a/windows-native.ini
+++ b/windows-native.ini
@@ -4,6 +4,7 @@ enable-nnstreamer-backbone=false
 enable-tflite-interpreter=false
 install-app=false
 enable-mmap=false
+openblas-num-threads = 6
 
 [built-in options]
 werror=false


### PR DESCRIPTION
This PR make number of threads for Open BLAS configurable (when we build Open BLAS from source) Based on benchmarks on windows with LLM's it seems that 6 threads are optimal for Windows.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped