### PR TITLE
[OpenCL] Load clFinish to make synchronization point

### DIFF
--- a/nntrainer/opencl/opencl_command_queue_manager.cpp
+++ b/nntrainer/opencl/opencl_command_queue_manager.cpp
@@ -362,6 +362,8 @@ bool CommandQueueManager::DispatchCommand(
     return false;
   }
 
+  clFinish(command_queue_);
+
   return true;
 }
 

--- a/nntrainer/opencl/opencl_loader.cpp
+++ b/nntrainer/opencl/opencl_loader.cpp
@@ -19,8 +19,8 @@
 
 namespace nntrainer::opencl {
 
-#define LoadFunction(function)                 \
-  function = reinterpret_cast<PFN_##function>( \
+#define LoadFunction(function)                                                 \
+  function = reinterpret_cast<PFN_##function>(                                 \
     DynamicLibraryLoader::loadSymbol(libopencl, #function));
 
 /**
@@ -93,6 +93,7 @@ void LoadOpenCLFunctions(void *libopencl) {
   LoadFunction(clRetainCommandQueue);
   LoadFunction(clReleaseCommandQueue);
   LoadFunction(clReleaseMemObject);
+  LoadFunction(clFinish);
 }
 
 PFN_clGetPlatformIDs clGetPlatformIDs;
@@ -122,5 +123,6 @@ PFN_clReleaseContext clReleaseContext;
 PFN_clRetainCommandQueue clRetainCommandQueue;
 PFN_clReleaseCommandQueue clReleaseCommandQueue;
 PFN_clReleaseMemObject clReleaseMemObject;
+PFN_clFinish clFinish;
 
 } // namespace nntrainer::opencl

--- a/nntrainer/opencl/opencl_loader.h
+++ b/nntrainer/opencl/opencl_loader.h
@@ -169,6 +169,9 @@ typedef cl_int(CL_API_CALL *PFN_clReleaseCommandQueue)(
 
 typedef cl_int(CL_API_CALL *PFN_clReleaseMemObject)(cl_mem /**< memobj */);
 
+typedef cl_int(CL_API_CALL *PFN_clFinish)(
+  cl_command_queue /**< command_queue */);
+
 extern PFN_clGetPlatformIDs clGetPlatformIDs;
 extern PFN_clGetDeviceIDs clGetDeviceIDs;
 extern PFN_clGetDeviceInfo clGetDeviceInfo;
@@ -196,6 +199,7 @@ extern PFN_clReleaseContext clReleaseContext;
 extern PFN_clRetainCommandQueue clRetainCommandQueue;
 extern PFN_clReleaseCommandQueue clReleaseCommandQueue;
 extern PFN_clReleaseMemObject clReleaseMemObject;
+extern PFN_clFinish clFinish;
 
 } // namespace nntrainer::opencl
 


### PR DESCRIPTION
This PR adds loading clFinish to block until all previous queued OpenCL commands have been completed.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped