### PR TITLE
[tensor] modify dotBatch for gqa

### DIFF
--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1361,7 +1361,9 @@ public:
   /**
    * @copydoc Tensor::dot(Tensor const &input, Tensor &output, bool trans,
               bool trans_in, float beta) const
-   * @details performs dot operation over a batch of inputs
+   * @details performs dot operation over a batch of inputs. If the batch sizes
+   of the given two tensors are different, the bigger one should be a multiple
+   of the smaller one.
    */
   Tensor &dotBatched(Tensor const &input, Tensor &result, bool trans = false,
                      bool trans_in = false, float beta = 0.0f) const;

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -13,6 +13,7 @@
 
 #include "nntrainer_test_util.h"
 #include "util_func.h"
+#include <cmath>
 #include <float_tensor.h>
 #include <fstream>
 #include <nntrainer_error.h>
@@ -3770,6 +3771,64 @@ TEST(nntrainer_Tensor, dot_shortcuts_p) {
     nntrainer::Tensor ret = a.dot(b, true, true);
     EXPECT_EQ(ret, answer);
   }
+}
+
+TEST(nntrainer_Tensor, dotbatch_01_n) {
+  nntrainer::Tensor a = ranged(2, 1, 2, 2);
+  nntrainer::Tensor b = ranged(3, 1, 2, 2);
+  nntrainer::Tensor c = ranged(6, 1, 2, 2);
+  EXPECT_THROW(a.dotBatched(b, c), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, dotbatch_02_n) {
+  nntrainer::Tensor a = ranged(6, 1, 2, 2);
+  nntrainer::Tensor b = ranged(4, 1, 2, 2);
+  nntrainer::Tensor c = ranged(12, 1, 2, 2);
+  EXPECT_THROW(a.dotBatched(b, c), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, dotbatch_01_p) {
+  nntrainer::Tensor a = ranged(2, 1, 2, 2);
+  nntrainer::Tensor b = ranged(2, 1, 2, 2);
+  float answer_data[] = {2, 3, 6, 11, 46, 55, 66, 79};
+  float dummy_data[] = {std::nan(""), std::nan(""), std::nan(""), std::nan(""),
+                        std::nan(""), std::nan(""), std::nan(""), std::nan(""),
+                        std::nan(""), std::nan(""), std::nan(""), std::nan(""),
+                        std::nan(""), std::nan(""), std::nan(""), std::nan("")};
+  nntrainer::Tensor answer({2, 1, 2, 2}, answer_data);
+  nntrainer::Tensor out({2, 1, 2, 2}, dummy_data);
+  a.dotBatched(b, out);
+  EXPECT_EQ(answer, out);
+}
+
+TEST(nntrainer_Tensor, dotbatch_02_p) {
+  nntrainer::Tensor a = ranged(4, 1, 2, 2);
+  nntrainer::Tensor b = ranged(2, 1, 2, 2);
+  float answer_data[] = {2,  3,   6,   11,  10,  19,  14,  27,
+                         86, 103, 106, 127, 126, 151, 146, 175};
+  float dummy_data[] = {std::nan(""), std::nan(""), std::nan(""), std::nan(""),
+                        std::nan(""), std::nan(""), std::nan(""), std::nan(""),
+                        std::nan(""), std::nan(""), std::nan(""), std::nan(""),
+                        std::nan(""), std::nan(""), std::nan(""), std::nan("")};
+  nntrainer::Tensor answer({4, 1, 2, 2}, answer_data);
+  nntrainer::Tensor out({4, 1, 2, 2}, dummy_data);
+  a.dotBatched(b, out);
+  EXPECT_EQ(answer, out);
+}
+
+TEST(nntrainer_Tensor, dotbatch_03_p) {
+  nntrainer::Tensor a = ranged(2, 1, 2, 2);
+  nntrainer::Tensor b = ranged(4, 1, 2, 2);
+  float answer_data[] = {2,  3,  6,   11,  6,   7,   26,  31,
+                         82, 91, 118, 131, 118, 127, 170, 183};
+  float dummy_data[] = {std::nan(""), std::nan(""), std::nan(""), std::nan(""),
+                        std::nan(""), std::nan(""), std::nan(""), std::nan(""),
+                        std::nan(""), std::nan(""), std::nan(""), std::nan(""),
+                        std::nan(""), std::nan(""), std::nan(""), std::nan("")};
+  nntrainer::Tensor answer({4, 1, 2, 2}, answer_data);
+  nntrainer::Tensor out({4, 1, 2, 2}, dummy_data);
+  a.dotBatched(b, out);
+  EXPECT_EQ(answer, out);
 }
 
 TEST(nntrainer_Tensor, transpose_p) {


### PR DESCRIPTION
     [tensor] Enhance dotBatch to enable GQA(Grouped Query Attention)
    
     - In GQA(Grouped Query Attention) given two tensors have a different batch sizes.
       So we need to figured out which samples are corresponding to each other.
       LCM(least common multiple) is used as a key point to figure this out.
       Each sample performs a dot operation one by one with corresponding group samples.
    
       In case of the batch size of the given tensor does not equal, the bigger on should be a multiple of the smaller one.

    [test] Add dot batch unittest
    
     - Added dot batch unittest for following cases
      (1) If the batch sizes of the given two tensors does not have common multiple.
      (2) If the batch sizes of the bigger one is not a multiple of the smaller one.
      (3) If the batch sizes of the bigger one is a multiple of the smaller one.