### PR TITLE
[FSU] Add readFSU to createFSU Tensor (BCQ)

### DIFF
--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -422,7 +422,8 @@ void BatchNormalizationLayer::read(std::ifstream &file,
                                    RunLayerContext &run_context, bool opt_var,
                                    ml::train::ExecutionMode mode,
                                    bool trainable,
-                                   TensorDim::DataType definedWeightDataType) {
+                                   TensorDim::DataType definedWeightDataType,
+                                   bool fsu) {
   if (opt_var) {
     for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
       if (run_context.isGradientLastAccess(i) && trainable) {

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -139,11 +139,12 @@ public:
   /**
    * @copydoc Layer::read(std::ifstream &file, RunLayerContext &context, bool
    * opt_var, ml::train::ExecutionMode mode, bool trainable, TensorDim::DataType
-   * definedWeightDataType)
+   * definedWeightDataType, bool fsu)
    */
   void read(std::ifstream &file, RunLayerContext &context, bool opt_var,
             ml::train::ExecutionMode mode, bool trainable,
-            TensorDim::DataType definedWeightDataType) override;
+            TensorDim::DataType definedWeightDataType,
+            bool fsu = false) override;
 
 private:
   float divider; /**< size of the axes of the reduced */

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -483,13 +483,9 @@ void LayerNode::read(std::ifstream &file, bool opt_var,
                      ml::train::ExecutionMode mode, bool fsu) {
   NNTR_THROW_IF(!run_context, std::runtime_error)
     << __func__ << " layer needs to be finalized first!";
-
-  if (!fsu) {
-    getLayer()->read(
-      file, *run_context, opt_var, mode,
-      (getTrainable() && mode == ml::train::ExecutionMode::TRAIN),
-      getWeightDataType());
-  }
+  getLayer()->read(file, *run_context, opt_var, mode,
+                   (getTrainable() && mode == ml::train::ExecutionMode::TRAIN),
+                   getWeightDataType(), fsu);
 }
 
 void LayerNode::save(std::ofstream &file, bool opt_var,

--- a/nntrainer/tensor/bcq_tensor.cpp
+++ b/nntrainer/tensor/bcq_tensor.cpp
@@ -401,15 +401,11 @@ void BCQTensor::createBCQW() {
   /// found with various values according to the usage environment.
   size_t hidden_tile_size = 32;
 
-  // bcq_weight = std::make_shared<BiQGEMM::BCQW>(
-  //   (uint32_t *)getData(), (float *)getScale(), width(), height(),
-  //   number_of_cluster, qbit_of_clusters, size_of_clusters, hidden_tile_size);
-
   bcq_weight = std::make_shared<BiQGEMM::BCQW>(
     (uint32_t *)(data->getAddr<uint32_t>()),
     (float *)((uint32_t *)(data->getAddr<uint32_t>()) + size()), width(),
     height(), number_of_cluster, qbit_of_clusters, size_of_clusters,
-    hidden_tile_size, true);
+    hidden_tile_size);
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/bcq_tensor.cpp
+++ b/nntrainer/tensor/bcq_tensor.cpp
@@ -255,6 +255,8 @@ void BCQTensor::save(std::ostream &file) {
   putData();
 }
 
+void BCQTensor::readFSU() { createBCQW(); }
+
 void BCQTensor::read(std::ifstream &file) {
   /// @note Read quantization information
   read_quantization_info(file);
@@ -399,9 +401,15 @@ void BCQTensor::createBCQW() {
   /// found with various values according to the usage environment.
   size_t hidden_tile_size = 32;
 
+  // bcq_weight = std::make_shared<BiQGEMM::BCQW>(
+  //   (uint32_t *)getData(), (float *)getScale(), width(), height(),
+  //   number_of_cluster, qbit_of_clusters, size_of_clusters, hidden_tile_size);
+
   bcq_weight = std::make_shared<BiQGEMM::BCQW>(
-    (uint32_t *)getData(), (float *)getScale(), width(), height(),
-    number_of_cluster, qbit_of_clusters, size_of_clusters, hidden_tile_size);
+    (uint32_t *)(data->getAddr<uint32_t>()),
+    (float *)((uint32_t *)(data->getAddr<uint32_t>()) + size()), width(),
+    height(), number_of_cluster, qbit_of_clusters, size_of_clusters,
+    hidden_tile_size, true);
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/bcq_tensor.h
+++ b/nntrainer/tensor/bcq_tensor.h
@@ -209,6 +209,11 @@ public:
   void save(std::ostream &file) override;
 
   /**
+   * @copydoc Tensor::readFSU()
+   */
+  void readFSU();
+
+  /**
    * @copydoc Tensor::read(std::ifstream &file)
    */
   void read(std::ifstream &file) override;

--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -198,14 +198,15 @@ std::shared_ptr<MemoryData> CachePool::getMemory(unsigned int id) {
   size_t len = getMemorySize().at(id - 1);
   auto exe_order = getMemoryExecOrder().at(id - 1);
   auto policy = getCachePolicy().at(id - 1);
-  auto mem_data = std::make_shared<MemoryData>(
-    id, std::bind(&CachePool::validate, this, std::placeholders::_1),
-    std::bind(&CachePool::invalidate, this, std::placeholders::_1));
 
   void *memory_ptr = nullptr;
   if (execution_mode_ == ml::train::ExecutionMode::INFERENCE) {
     memory_ptr = getMemoryPtrs().at(id - 1);
   }
+
+  auto mem_data = std::make_shared<MemoryData>(
+  id, std::bind(&CachePool::validate, this, std::placeholders::_1),
+  std::bind(&CachePool::invalidate, this, std::placeholders::_1), memory_ptr);
 
   auto elem = std::make_shared<CacheElem>(swap_device, id, offset, len,
                                           mem_data, policy, memory_ptr);

--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -205,8 +205,8 @@ std::shared_ptr<MemoryData> CachePool::getMemory(unsigned int id) {
   }
 
   auto mem_data = std::make_shared<MemoryData>(
-  id, std::bind(&CachePool::validate, this, std::placeholders::_1),
-  std::bind(&CachePool::invalidate, this, std::placeholders::_1), memory_ptr);
+    id, std::bind(&CachePool::validate, this, std::placeholders::_1),
+    std::bind(&CachePool::invalidate, this, std::placeholders::_1), memory_ptr);
 
   auto elem = std::make_shared<CacheElem>(swap_device, id, offset, len,
                                           mem_data, policy, memory_ptr);

--- a/nntrainer/tensor/memory_data.h
+++ b/nntrainer/tensor/memory_data.h
@@ -43,10 +43,10 @@ public:
    * @param[in] i_cb invalidate callback.
    */
   explicit MemoryData(unsigned int mem_id, MemoryDataValidateCallback v_cb,
-                      MemoryDataValidateCallback i_cb) :
+                      MemoryDataValidateCallback i_cb, void* memory_ptr = nullptr) :
     valid(false),
     id(mem_id),
-    address(nullptr),
+    address(memory_ptr),
     validate_cb(v_cb),
     invalidate_cb(i_cb) {}
 

--- a/nntrainer/tensor/memory_data.h
+++ b/nntrainer/tensor/memory_data.h
@@ -43,7 +43,8 @@ public:
    * @param[in] i_cb invalidate callback.
    */
   explicit MemoryData(unsigned int mem_id, MemoryDataValidateCallback v_cb,
-                      MemoryDataValidateCallback i_cb, void* memory_ptr = nullptr) :
+                      MemoryDataValidateCallback i_cb,
+                      void *memory_ptr = nullptr) :
     valid(false),
     id(mem_id),
     address(memory_ptr),

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1250,6 +1250,8 @@ Tensor Tensor::clone(ml::train::TensorDim::DataType type) const {
   return output;
 }
 
+void Tensor::readFSU() { itensor->readFSU(); }
+
 void Tensor::save(std::ostream &file) {
   NNTR_THROW_IF(!getContiguous(), std::invalid_argument)
     << getName() << " is not contiguous, cannot save.";

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1555,6 +1555,12 @@ public:
   Tensor clone(ml::train::TensorDim::DataType type) const;
 
   /**
+   * @brief     Read the Tensor For FSU
+   *
+   */
+  void readFSU();
+
+  /**
    * @brief     Save the Tensor into file
    * @param[in] file output file stream
    */

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -70,6 +70,8 @@ void TensorBase::read(std::ifstream &file) {
   putData();
 }
 
+void TensorBase::readFSU() {}
+
 void TensorBase::putData() const {
   if (!data)
     return;

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -503,6 +503,11 @@ public:
   virtual void read(std::ifstream &file);
 
   /**
+   * @copydoc Tensor::readFSU()
+   */
+  virtual void readFSU();
+
+  /**
    * @copydoc Tensor::argmax()
    */
   virtual std::vector<unsigned int> argmax() const;


### PR DESCRIPTION
In This PR
----
The current method of reading FSU weights is as follows (Simple Description):
1. In read, if FSU, it does not read during the initial load process.
2. During inference, depending on the execution order and look-ahead, the weight file is read through the FSU function at the moment it is needed and loaded.

There is a problem with this method. For logic like BCQ that reads information during loading and uses it to create tensors, the information needs to be known before memory allocation, so there is need to pass only that information. so I created a new readFSU function for cases in the future where settings for FSU are needed for various tensors.

Add readFSU function & Change BCQ Create Signature
- prepare Tensor that has other information (except Weight)
- Change bcq tensor create signature

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
4. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Donghak PARK <donghak.park@samsung.com>
