### PR TITLE
Add GGML subrepo, related wrap files and meson options

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -458,6 +458,14 @@ else
   endif
 endif
 
+if get_option('enable-ggml')
+  ggml_options = cmake.subproject_options()
+
+  ggml_proj = cmake.subproject('ggml', options: ggml_options, required: true)
+
+  message('Configuring with GGML interface enabled')
+endif
+
 # Configure the Ruy project (CMake)
 if get_option('platform') == 'android'
   ruy_root = meson.source_root() / 'subprojects' / 'ruy'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -46,6 +46,7 @@ option('enable-opencl', type: 'boolean', value: false)
 option('enable-biqgemm', type: 'boolean', value: false)
 option('biqgemm-path', type: 'string', value: '../BiQGEMM')
 option('enable-benchmarks', type: 'boolean', value : false)
+option('enable-ggml', type: 'boolean', value: false) 
 
 # ml-api dependency (to enable, install capi-inference from github.com/nnstreamer/api )
 # To inter-operate with nnstreamer and ML-API packages, you need to enable this.

--- a/subprojects/ggml.wrap
+++ b/subprojects/ggml.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/ggml-org/ggml.git
+directory=ggml
+revision = HEAD


### PR DESCRIPTION
Added [GGML](https://github.com/ggml-org/ggml) subrepository that contains tensor operations code being part of [llama.cpp](https://github.com/ggml-org/ggml).

Added build support:

```bash
meson setup build -Denable-ggml=true --wipe
```
This PR only includes build support but does not give possibility to use added features out of the box.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
