### PR TITLE
[GGML] Add GEMM and GEMV for Q4_0 and Q4_K quantization using ggml.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 [submodule "subprojects/ruy"]
 	path = subprojects/ruy
 	url = https://github.com/google/ruy
+
+[submodule "subprojects/ggml"]
+	path = subprojects/ggml
+	url = https://github.com/ggml-org/ggml.git

--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -83,6 +83,46 @@ include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
 
+MESON_HAS_GGML := @MESON_HAS_GGML@
+
+ifeq ($(MESON_HAS_GGML),1)
+
+LOCAL_MODULE        := ggml
+LOCAL_SRC_FILES     := @MESON_GGML_ROOT@/src/ggml-backend.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/ggml-cpu-hbm.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/unary-ops.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/vec.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/ggml-cpu-traits.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/llamafile/sgemm.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/ops.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/amx/mmq.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/amx/amx.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/binary-ops.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/ggml-cpu-aarch64.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/cpu-feats-x86.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-backend-reg.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-opt.cpp \
+                       @MESON_GGML_ROOT@/src/gguf.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-threading.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-alloc.c \
+                       @MESON_GGML_ROOT@/src/ggml-quants.c \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/ggml-cpu.cpp \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/ggml-cpu_c.c \
+                       @MESON_GGML_ROOT@/src/ggml-cpu/ggml-cpu-quants.c \
+                       @MESON_GGML_ROOT@/src/ggml.c
+LOCAL_CXXFLAGS += -std=c++17 -O3 -fexceptions
+LOCAL_C_INCLUDES    := @MESON_GGML_ROOT@/include \
+                       @MESON_GGML_ROOT@/src \
+                       @MESON_GGML_ROOT@/src/ggml-cpu
+
+LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
+
+include $(BUILD_SHARED_LIBRARY)
+
+endif # MESON_HAS_GGML
+
+include $(CLEAR_VARS)
+
 LOCAL_MODULE        := nntrainer
 LOCAL_SRC_FILES     := @MESON_NNTRAINER_SRCS@
 # @todo ML_API_COMMON_ROOT should be included by exporting ml-api-common lib later
@@ -102,6 +142,10 @@ LOCAL_STATIC_LIBRARIES += iniparser openblas ruy
 ifeq ($(MESON_HAS_TFLITE), 1)
   LOCAL_STATIC_LIBRARIES += tensorflow-lite
 endif # MESON_HAS_TFLITE
+
+ifeq ($(MESON_HAS_GGML), 1)
+  LOCAL_STATIC_LIBRARIES += ggml
+endif # MESON_HAS_GGML
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/jni/meson.build
+++ b/jni/meson.build
@@ -63,6 +63,13 @@ else
   error('ml api common dep is needed for the android build')
 endif
 
+if get_option('enable-ggml')
+  and_conf.set('MESON_HAS_GGML', 1)
+  and_conf.set('MESON_GGML_ROOT', ggml_root)
+else
+  and_conf.set('MESON_HAS_GGML', 0)
+endif
+
 configure_file(input: 'Android.mk.in', output: 'Android.mk',
   configuration: and_conf
 )

--- a/jni/prepare_ggml.sh
+++ b/jni/prepare_ggml.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+set -e
+GGML_SRC=$1
+
+REVISION=489716ba99ecd51164f79e8c6fec0b5bf634eac9
+PATCH_PATH="${GGML_SRC}"/../packagefiles/ggml/0001-Export-some-internal-methods.patch
+
+echo "[GGML] PREPARING GGML..."
+
+pushd "${GGML_SRC}"
+git checkout "${REVISION}"
+git restore CMakeLists.txt
+git restore include
+git restore src
+git apply "${PATCH_PATH}"
+cp ./src/ggml-cpu/ggml-cpu.c ./src/ggml-cpu/ggml-cpu_c.c
+popd
+
+echo "[GGML] PREPARING GGML FINISHED"

--- a/meson.build
+++ b/meson.build
@@ -471,6 +471,14 @@ if get_option('enable-ggml')
   ggml_options.add_cmake_defines({'GGML_BUILD_EXAMPLES': false})
   ggml_proj = cmake.subproject('ggml', options: ggml_options, required: true)
   ggml_dep = ggml_proj.dependency('ggml-cpu')
+  ggml_options.add_cmake_defines({'BUILD_SHARED_LIBS': host_machine.system() != 'windows'})
+  ggml_options.add_cmake_defines({'GGML_BUILD_TESTS': false})
+  ggml_options.add_cmake_defines({'GGML_BUILD_EXAMPLES': false})
+  ggml_proj = cmake.subproject('ggml', options: ggml_options, required: true)
+  ggml_dep = [
+    ggml_proj.dependency('ggml-base'),
+    ggml_proj.dependency('ggml-cpu'),
+    ggml_proj.dependency('ggml')]
 endif
 
 # Configure the Ruy project (CMake)

--- a/meson.build
+++ b/meson.build
@@ -462,18 +462,26 @@ endif
 ggml_dep = dummy_dep
 
 if get_option('enable-ggml')
+  message('preparing ggml')
   ggml_options = cmake.subproject_options()
+  ggml_root = meson.source_root() / 'subprojects' / 'ggml'
   if cxx_compiler_id == 'msvc'
     ggml_options.add_cmake_defines(common_win_subproject_cmake_defines)
   endif
   ggml_options.add_cmake_defines({'BUILD_SHARED_LIBS': host_machine.system() != 'windows'})
   ggml_options.add_cmake_defines({'GGML_BUILD_TESTS': false})
   ggml_options.add_cmake_defines({'GGML_BUILD_EXAMPLES': false})
+  ggml_options.add_cmake_defines({'CMAKE_INSTALL_LIBDIR': nntrainer_libdir / 'arm64-v8a'})
   ggml_proj = cmake.subproject('ggml', options: ggml_options, required: true)
   ggml_dep = [
     ggml_proj.dependency('ggml-base'),
     ggml_proj.dependency('ggml-cpu'),
     ggml_proj.dependency('ggml')]
+
+  if get_option('platform') == 'android'
+    message('preparing ggml for Android')
+    run_command([meson.source_root() / 'jni' / 'prepare_ggml.sh', ggml_root ], check: true)
+  endif
 
   extra_defines += '-DENABLE_GGML=1'
 endif

--- a/meson.build
+++ b/meson.build
@@ -470,15 +470,12 @@ if get_option('enable-ggml')
   ggml_options.add_cmake_defines({'GGML_BUILD_TESTS': false})
   ggml_options.add_cmake_defines({'GGML_BUILD_EXAMPLES': false})
   ggml_proj = cmake.subproject('ggml', options: ggml_options, required: true)
-  ggml_dep = ggml_proj.dependency('ggml-cpu')
-  ggml_options.add_cmake_defines({'BUILD_SHARED_LIBS': host_machine.system() != 'windows'})
-  ggml_options.add_cmake_defines({'GGML_BUILD_TESTS': false})
-  ggml_options.add_cmake_defines({'GGML_BUILD_EXAMPLES': false})
-  ggml_proj = cmake.subproject('ggml', options: ggml_options, required: true)
   ggml_dep = [
     ggml_proj.dependency('ggml-base'),
     ggml_proj.dependency('ggml-cpu'),
     ggml_proj.dependency('ggml')]
+
+  extra_defines += '-DENABLE_GGML=1'
 endif
 
 # Configure the Ruy project (CMake)

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('nntrainer', 'c', 'cpp',
   license: ['apache-2.0'],
   meson_version: '>=0.55.0',
   default_options: [
-    'werror=true',
+    'werror=false',
     'warning_level=1',
     'c_std=gnu89',
     'cpp_std=c++17',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -46,7 +46,6 @@ option('enable-opencl', type: 'boolean', value: false)
 option('enable-biqgemm', type: 'boolean', value: false)
 option('biqgemm-path', type: 'string', value: '../BiQGEMM')
 option('enable-benchmarks', type: 'boolean', value : false)
-option('enable-ggml', type: 'boolean', value: false) 
 
 # ml-api dependency (to enable, install capi-inference from github.com/nnstreamer/api )
 # To inter-operate with nnstreamer and ML-API packages, you need to enable this.

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -46,6 +46,7 @@ option('enable-opencl', type: 'boolean', value: false)
 option('enable-biqgemm', type: 'boolean', value: false)
 option('biqgemm-path', type: 'string', value: '../BiQGEMM')
 option('enable-benchmarks', type: 'boolean', value : false)
+option('enable-ggml', type: 'boolean', value: false)
 
 # ml-api dependency (to enable, install capi-inference from github.com/nnstreamer/api )
 # To inter-operate with nnstreamer and ML-API packages, you need to enable this.

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -70,6 +70,12 @@ nntrainer_common_sources = [
 
 nntrainer_inc_abs += meson.source_root() / 'subprojects' / 'ruy'
 
+if get_option('enable-ggml')
+  nntrainer_inc_abs += meson.source_root() / 'subprojects' / 'ggml' / 'include'
+  nntrainer_inc_abs += meson.source_root() / 'subprojects' / 'ggml' / 'src'
+  nntrainer_inc_abs += meson.source_root() / 'subprojects' / 'ggml' / 'src' / 'ggml-cpu'
+endif
+
 if get_option('enable-opencl')
   nntrainer_headers += meson.current_source_dir() / 'cl_context.h'
   nntrainer_headers += meson.current_source_dir() / 'cl_buffer_manager.h'

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -16,8 +16,19 @@
 #include <fallback_internal.h>
 #include <neon_impl.h>
 #include <nntrainer_error.h>
+#ifdef ENABLE_GGML
+#include <ggml_interface.h>
+#endif
 
 namespace nntrainer {
+
+void init_backend() {
+#ifdef ENABLE_GGML
+  __ggml_init();
+#else
+  // TODO it needed.
+#endif
+}
 
 void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
                                  float *sin_, unsigned int alpha) {
@@ -230,9 +241,75 @@ bool is_valid(const unsigned int N, const float *input) {
   return nntrainer::neon::is_valid(N, input);
 }
 
+void gemm_q4_0(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc) {
+#ifdef ENABLE_GGML
+  return __ggml_q4_0_8x8_q8_0_GEMM(M, N, K, A, lda, B, ldb, C, ldc);
+#else
+  return __fallback_gemm_q4_0(M, N, K, A, lda, B, ldb, C, ldc);
+#endif
+}
+
 void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc) {
+#ifdef ENABLE_GGML
+  return __ggml_q4_K_8x8_q8_K_GEMM(M, N, K, A, lda, B, ldb, C, ldc);
+#else
   return __fallback_gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
+#endif
+}
+
+size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights) {
+#ifdef ENABLE_GGML
+  return __ggml_quantize_q4_0(src, dst, nrow, n_per_row, quant_weights);
+#else
+  return __fallback_quantize_q4_0(src, dst, nrow, n_per_row, quant_weights);
+#endif
+}
+
+size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights) {
+#ifdef ENABLE_GGML
+  return __ggml_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
+#else
+  return __fallback_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
+#endif
+}
+
+void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
+#ifdef ENABLE_GGML
+  __ggml_dequantize_row_q4_K(x_raw, y, k);
+#else
+  __fallback_dequantize_row_q4_K(x_raw, y, k);
+#endif
+}
+
+void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
+#ifdef ENABLE_GGML
+  __ggml_dequantize_row_q8_K(x, y, k);
+#else
+  __fallback_dequantize_row_q8_K(x, y, k);
+#endif
+}
+
+void repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
+                           const unsigned int M, const unsigned int N) {
+#ifdef ENABLE_GGML
+  __ggml_repack_q4_0_to_q4_0_8(W, repacked_W, data_size, M, N);
+#else
+  __fallback_repack_q4_0_to_q4_0_8(W, repacked_W, data_size, M, N);
+#endif
+}
+
+void repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
+                           const unsigned int M, const unsigned int N) {
+#ifdef ENABLE_GGML
+  __ggml_repack_q4_K_to_q4_K_8(W, repacked_W, data_size, M, N);
+#else
+  __fallback_repack_q4_K_to_q4_K_8(W, repacked_W, data_size, M, N);
+#endif
 }
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -233,6 +233,6 @@ bool is_valid(const unsigned int N, const float *input) {
 void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc) {
-  return __gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
+  return __fallback_gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
 }
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -20,6 +20,11 @@
 
 namespace nntrainer {
 
+/**
+ * @brief Initialization of ggml backend
+ */
+void init_backend();
+
 #ifdef ENABLE_FP16
 /**
  * @brief Accelerating function for rotary embedding layer forwarding
@@ -717,6 +722,23 @@ void ele_div(const unsigned N, const float *X, const float *Y, float *Z,
 bool is_valid(const unsigned int N, const float *X);
 
 /**
+ * @brief q4_0 GEMM : A (M,K) * W.T (N,K) = O (M,N)
+ *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void gemm_q4_0(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
+
+/**
  * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
  *
  * @param M Original row size of output
@@ -732,6 +754,75 @@ bool is_valid(const unsigned int N, const float *X);
 void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief
+ *
+ * @param x_raw
+ * @param y
+ * @param k
+ */
+void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param x
+ * @param y
+ * @param k
+ */
+void dequantize_row_q8_K(const void *x, float *y, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param W
+ * @param repacked_W
+ * @param data_size
+ * @param M
+ * @param N
+ */
+void repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
+                           const unsigned int M, const unsigned int N);
+
+/**
+ * @brief
+ *
+ * @param W
+ * @param repacked_W
+ * @param data_size
+ * @param M
+ * @param N
+ */
+void repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
+                           const unsigned int M, const unsigned int N);
+
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __ARM_COMPUTE_BACKEND_H__ */

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -614,6 +614,24 @@ extern bool is_valid(const unsigned int N, const float *X);
  * @param C float* output
  * @param ldc Leading dimension of C
  */
+extern void gemm_q4_0(const unsigned int M, const unsigned int N,
+                      const unsigned int K, const float *A,
+                      const unsigned int lda, const void *B,
+                      const unsigned int ldb, float *C, const unsigned int ldc);
+
+/**
+ * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
+ *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
 extern void gemm_q4_K(const unsigned int M, const unsigned int N,
                       const unsigned int K, const float *A,
                       const unsigned int lda, const void *B,

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -188,9 +188,44 @@ void softmax(const unsigned int N, float *X, float *Y) {
   __fallback_softmax(N, X, Y);
 }
 
+void gemm_q4_0(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc) {
+  return __fallback_gemm_q4_0(M, N, K, A, lda, B, ldb, C, ldc);
+}
+
 void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc) {
-  return __gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
+  return __fallback_gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
 }
+
+size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights) {
+  return __fallback_quantize_q4_0(src, dst, nrow, n_per_row, quant_weights);
+}
+
+size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights) {
+  return __fallback_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
+}
+
+void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
+  return __fallback_dequantize_row_q4_K(x_raw, y, k);
+}
+
+void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
+  return __fallback_dequantize_row_q8_K(x, y, k);
+}
+
+void repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
+                           const unsigned int M, const unsigned int N) {
+  return __fallback_repack_q4_0_to_q4_0_8(W, repacked_W, data_size, M, N);
+}
+
+void repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
+                           const unsigned int M, const unsigned int N) {
+  return __fallback_repack_q4_K_to_q4_K_8(W, repacked_W, data_size, M, N);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -738,7 +738,7 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
  * @param quant_weights
  * @return size_t
  */
-size_t quantize_q0_K(const float *src, void *dst, int64_t nrow,
+size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
 
 /**

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -728,6 +728,62 @@ bool is_valid(const unsigned int N, const float *X);
 void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+size_t quantize_q0_K(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief
+ *
+ * @param x_raw
+ * @param y
+ * @param k
+ */
+void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param x
+ * @param y
+ * @param k
+ */
+void dequantize_row_q8_K(const void *x, float *y, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param W
+ * @param repacked_W
+ * @param data_size
+ * @param M
+ * @param N
+ */
+void repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
+                           const unsigned int M, const unsigned int N);
+
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __FALLBACK_H__ */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -353,10 +353,52 @@ void __fallback_softmax(const unsigned int N, float *X, float *Y) {
   }
 }
 
-void __gemm_q4_K(const unsigned int M, const unsigned int N,
-                 const unsigned int K, const float *A, const unsigned int lda,
-                 const void *B, const unsigned int ldb, float *C,
-                 const unsigned int ldc) {
-  throw std::runtime_error("NYI : __gemm_q4_K");
+void __fallback_gemm_q4_0(const unsigned int M, const unsigned int N,
+                          const unsigned int K, const float *A,
+                          const unsigned int lda, const void *B,
+                          const unsigned int ldb, float *C,
+                          const unsigned int ldc) {
+  throw std::runtime_error("NYI : __fallback_gemm_q4_0");
 }
+
+void __fallback_gemm_q4_K(const unsigned int M, const unsigned int N,
+                          const unsigned int K, const float *A,
+                          const unsigned int lda, const void *B,
+                          const unsigned int ldb, float *C,
+                          const unsigned int ldc) {
+  throw std::runtime_error("NYI : __fallback_gemm_q4_K");
+}
+
+size_t __fallback_quantize_q4_0(const float *src, void *dst, int64_t nrow,
+                                int64_t n_per_row, const float *quant_weights) {
+  throw std::runtime_error("NYI : __fallback_quantize_q4_0");
+  return 1;
+}
+
+size_t __fallback_quantize_q4_K(const float *src, void *dst, int64_t nrow,
+                                int64_t n_per_row, const float *quant_weights) {
+  throw std::runtime_error("NYI : __fallback_quantize_q4_K");
+  return 1;
+}
+
+void __fallback_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
+  throw std::runtime_error("NYI : __fallback_dequantize_row_q4_K");
+}
+
+void __fallback_dequantize_row_q8_K(const void *x, float *y, int64_t k) {
+  throw std::runtime_error("NYI : __fallback_dequantize_row_q8_K");
+}
+
+void __fallback_repack_q4_0_to_q4_0_8(void *W, void *repacked_W,
+                                      size_t data_size, const unsigned int M,
+                                      const unsigned int N) {
+  throw std::runtime_error("NYI : __fallback_repack_q4_0_to_q4_0_8");
+}
+
+void __fallback_repack_q4_K_to_q4_K_8(void *W, void *repacked_W,
+                                      size_t data_size, const unsigned int M,
+                                      const unsigned int N) {
+  throw std::runtime_error("NYI : __fallback_repack_q4_K_to_q4_K_8");
+}
+
 } // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -651,6 +651,26 @@ void __fallback_ele_sub(const unsigned N, const float *X, const float *Y,
 void __fallback_ele_div(const unsigned N, const float *X, const float *Y,
                         float *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride);
+
+/**
+ * @brief q4_0 GEMM : A (M,K) * W.T (N,K) = O (M,N)
+ *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void __fallback_gemm_q4_0(const unsigned int M, const unsigned int N,
+                          const unsigned int K, const float *A,
+                          const unsigned int lda, const void *B,
+                          const unsigned int ldb, float *C,
+                          const unsigned int ldc);
+
 /**
  * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
  *
@@ -664,10 +684,82 @@ void __fallback_ele_div(const unsigned N, const float *X, const float *Y,
  * @param C float* output
  * @param ldc Leading dimension of C
  */
-void __gemm_q4_K(const unsigned int M, const unsigned int N,
-                 const unsigned int K, const float *A, const unsigned int lda,
-                 const void *B, const unsigned int ldb, float *C,
-                 const unsigned int ldc);
+void __fallback_gemm_q4_K(const unsigned int M, const unsigned int N,
+                          const unsigned int K, const float *A,
+                          const unsigned int lda, const void *B,
+                          const unsigned int ldb, float *C,
+                          const unsigned int ldc);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+size_t __fallback_quantize_q4_0(const float *src, void *dst, int64_t nrow,
+                                int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+size_t __fallback_quantize_q4_K(const float *src, void *dst, int64_t nrow,
+                                int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief
+ *
+ * @param x_raw
+ * @param y
+ * @param k
+ */
+void __fallback_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param x
+ * @param y
+ * @param k
+ */
+void __fallback_dequantize_row_q8_K(const void *x, float *y, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param W
+ * @param repacked_W
+ * @param data_size
+ * @param M
+ * @param N
+ */
+void __fallback_repack_q4_0_to_q4_0_8(void *W, void *repacked_W,
+                                      size_t data_size, const unsigned int M,
+                                      const unsigned int N);
+
+/**
+ * @brief
+ *
+ * @param W
+ * @param repacked_W
+ * @param data_size
+ * @param M
+ * @param N
+ */
+void __fallback_repack_q4_K_to_q4_K_8(void *W, void *repacked_W,
+                                      size_t data_size, const unsigned int M,
+                                      const unsigned int N);
+
 } // namespace nntrainer
 #endif
 #endif

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -10,7 +10,196 @@
  * @brief  Function interface to use ggml lib from cpu_backend
  */
 
+#include "ggml-cpu-quants.h"
+#include "ggml-quants.h"
 #include <ggml.h>
 #include <ggml_interface.h>
 
-namespace nntrainer {}
+#include "ggml-common.h"
+#include "ggml-cpu.h"
+#include "ggml.h"
+#include <iostream>
+#include <stdint.h>
+#include <stdio.h>
+#include <string>
+#include <vector>
+
+namespace nntrainer {
+
+template <typename T>
+static inline void
+print_matrix_partially_n(const std::string &name, const T *src, int M, int N,
+                         int partial_m = 5, int partial_n = 5) {
+  std::cout << name << ":" << std::endl;
+  std::cout << "--------------------------" << std::endl;
+  for (int i = 0; i < partial_m; ++i) {
+    for (int j = 0; j < partial_n; ++j) {
+      std::cout << src[i * N + j] << "  ";
+    }
+    std::cout << std::endl;
+  }
+  std::cout << "--------------------------" << std::endl;
+}
+
+/**
+ * @brief
+ */
+struct block_q8_Kx4 {
+  float d[4];              // delta
+  int8_t qs[QK_K * 4];     // quants
+  int16_t bsums[QK_K / 4]; // sum of quants in groups of 16
+};
+
+template <int K> constexpr int QK_0() {
+  if constexpr (K == 4) {
+    return QK4_0;
+  }
+  if constexpr (K == 8) {
+    return QK8_0;
+  }
+  return -1;
+}
+
+/**
+ * @brief
+ *
+ * @tparam K
+ * @tparam N
+ */
+template <int K, int N> struct block {
+  ggml_half d[N];                     // deltas for N qK_0 blocks
+  int8_t qs[(QK_0<K>() * N * K) / 8]; // quants for N qK_0 blocks
+};
+
+using block_q4_0x4 = block<4, 4>;
+using block_q8_0x4 = block<8, 4>;
+
+void __ggml_init() {
+  // needed to initialize f16 tables
+  struct ggml_init_params params = {0, NULL, false};
+  struct ggml_context *ctx = ggml_init(params);
+  ggml_free(ctx);
+}
+
+size_t __ggml_quantize_q4_0(const float *src, void *dst, int64_t nrow,
+                            int64_t n_per_row, const float *quant_weights) {
+  return ::quantize_q4_0(src, dst, nrow, n_per_row, quant_weights);
+}
+
+size_t __ggml_quantize_q4_K(const float *src, void *dst, int64_t nrow,
+                            int64_t n_per_row, const float *quant_weights) {
+  return ::quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
+}
+
+void __ggml_q4_0_8x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
+                               const unsigned int K, const float *A,
+                               const unsigned int lda, const void *B,
+                               const unsigned int ldb, float *C,
+                               const unsigned int ldc) {
+  if (M == 1) { // GEMV
+    int blocks_per_row = (K + QK8_0 - 1) / QK8_0;
+    int qa_size = sizeof(block_q8_0) * blocks_per_row;
+    std::vector<char> QA = std::vector<char>(qa_size);
+    ::quantize_row_q8_0(A, QA.data(), K);
+
+    ::ggml_gemv_q4_0_8x8_q8_0(K, C, ldc, B, QA.data(), M, N);
+  } else { // GEMM
+    int blocks_per_4_rows = (K + QK8_0 - 1) / QK8_0;
+    int qa_4_rows_size = sizeof(block_q8_0x4) * blocks_per_4_rows;
+    int M4 = ((M + 3) / 4);
+
+    int qa_size = qa_4_rows_size * M4;
+    std::vector<char> QA = std::vector<char>(qa_size);
+
+    // Quantization of activations
+#pragma omp parallel for collapse(1) num_threads(16)
+    for (int i = 0; i < M4; i++) {
+      ::ggml_quantize_mat_q8_0_4x8(A + 4 * i * K,
+                                   QA.data() + i * qa_4_rows_size, K);
+    }
+
+#if 0
+    // single thread
+    ::ggml_gemm_q4_0_8x8_q8_0(K, C, ldc, B, QA.data(), M, N);
+#else
+    // TODO check beter multithreading
+    int delta = 8;
+    // int delta = 384 / 4;
+    int step_N = N / delta;
+    int step_C = delta;
+    int step_B = blocks_per_4_rows * sizeof(block_q4_0) * delta;
+#pragma omp parallel for collapse(1) num_threads(16)
+    for (int i = 0; i < step_N; i++) {
+      ::ggml_gemm_q4_0_8x8_q8_0(K, C + i * step_C, ldc, (char *)B + i * step_B,
+                                QA.data(), M, delta);
+    }
+#endif
+  }
+}
+
+void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
+                               const unsigned int K, const float *A,
+                               const unsigned int lda, const void *B,
+                               const unsigned int ldb, float *C,
+                               const unsigned int ldc) {
+  if (M == 1) { // GEMV
+    int blocks_per_row = (K + QK_K - 1) / QK_K;
+    int qa_size = sizeof(block_q8_K) * blocks_per_row;
+    std::vector<char> QA = std::vector<char>(qa_size);
+
+    ::quantize_row_q8_K(A, QA.data(), K);
+
+    ::ggml_gemv_q4_K_8x8_q8_K(K, C, ldc, B, QA.data(), M, N);
+  } else { // GEMM
+    int blocks_per_4_rows = (K + QK_K - 1) / QK_K;
+    int qa_4_rows_size = sizeof(block_q8_Kx4) * blocks_per_4_rows;
+    int M4 = ((M + 3) / 4);
+
+    int qa_size = qa_4_rows_size * M4;
+    std::vector<char> QA = std::vector<char>(qa_size);
+
+    // Quantization of activations
+#pragma omp parallel for collapse(1) num_threads(16)
+    for (int i = 0; i < M4; i++) {
+      ::ggml_quantize_mat_q8_K_4x8(A + 4 * i * K,
+                                   QA.data() + i * qa_4_rows_size, K);
+    }
+
+#if 0
+    // single thread
+    ggml_gemm_q4_K_8x8_q8_K(K, C, ldc, B, QA.data(), M, N);
+#else
+    // TODO check beter multithreading
+    int delta = 8;
+    // int delta = 384 / 4;
+    int step_N = N / delta;
+    int step_C = delta;
+    int step_B = blocks_per_4_rows * sizeof(block_q4_K) * delta;
+#pragma omp parallel for collapse(1) num_threads(16)
+    for (int i = 0; i < step_N; i++) {
+      ::ggml_gemm_q4_K_8x8_q8_K(K, C + i * step_C, ldc, (char *)B + i * step_B,
+                                QA.data(), M, delta);
+    }
+#endif
+  }
+}
+
+void __ggml_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
+  ::dequantize_row_q4_K((const block_q4_K *)x_raw, y, k);
+}
+
+void __ggml_dequantize_row_q8_K(const void *x, float *y, int64_t k) {
+  ::dequantize_row_q8_K((const block_q8_K *)x, y, k);
+}
+
+void __ggml_repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
+                                  const unsigned int M, const unsigned int N) {
+  ::ggml_repack_q4_0_to_q4_0_8_bl(W, 8, repacked_W, data_size, M, N);
+}
+
+void __ggml_repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
+                                  const unsigned int M, const unsigned int N) {
+  ::ggml_repack_q4_K_to_q4_K_8_bl(W, 8, repacked_W, data_size, M, N);
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -14,7 +14,122 @@
 #define __GGML_INTERFACE_H__
 #ifdef __cplusplus
 
-namespace nntrainer {}
+#include <stdint.h>
+#include <stdlib.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Initialization of ggml backend
+ */
+void __ggml_init();
+
+/**
+ * @brief Quantize float to q4_0 Quantization format
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+size_t __ggml_quantize_q4_0(const float *src, void *dst, int64_t nrow,
+                            int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief Quantize float to q4_K Quantization format
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+size_t __ggml_quantize_q4_K(const float *src, void *dst, int64_t nrow,
+                            int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief
+ *
+ * @param M
+ * @param N
+ * @param K
+ * @param A
+ * @param lda
+ * @param B
+ * @param ldb
+ * @param C
+ * @param ldc
+ */
+void __ggml_q4_0_8x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
+                               const unsigned int K, const float *A,
+                               const unsigned int lda, const void *B,
+                               const unsigned int ldb, float *C,
+                               const unsigned int ldc);
+
+/**
+ * @brief
+ *
+ * @param M
+ * @param N
+ * @param K
+ * @param A
+ * @param lda
+ * @param B
+ * @param ldb
+ * @param C
+ * @param ldc
+ */
+void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
+                               const unsigned int K, const float *A,
+                               const unsigned int lda, const void *B,
+                               const unsigned int ldb, float *C,
+                               const unsigned int ldc);
+
+/**
+ * @brief
+ *
+ * @param x_raw
+ * @param y
+ * @param k
+ */
+void __ggml_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param x
+ * @param y
+ * @param k
+ */
+void __ggml_dequantize_row_q8_K(const void *x, float *y, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param W
+ * @param repacked_W
+ * @param data_size
+ * @param M
+ * @param N
+ */
+void __ggml_repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
+                                  const unsigned int M, const unsigned int N);
+
+/**
+ * @brief
+ *
+ * @param W
+ * @param repacked_W
+ * @param data_size
+ * @param M
+ * @param N
+ */
+void __ggml_repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
+                                  const unsigned int M, const unsigned int N);
+} // namespace nntrainer
 
 #endif
 #endif

--- a/nntrainer/tensor/cpu_backend/meson.build
+++ b/nntrainer/tensor/cpu_backend/meson.build
@@ -6,9 +6,11 @@ subdir('fallback')
 nntrainer_inc += include_directories('fallback')
 nntrainer_inc_abs += meson.current_source_dir() / 'fallback'
 
-subdir('ggml_interface')
-nntrainer_inc += include_directories('ggml_interface')
-nntrainer_inc_abs += meson.current_source_dir() / 'ggml_interface'
+if get_option('enable-ggml')
+  subdir('ggml_interface')
+  nntrainer_inc += include_directories('ggml_interface')
+  nntrainer_inc_abs += meson.current_source_dir() / 'ggml_interface'
+endif
 
 if get_option('enable-blas')
   subdir('cblas_interface')

--- a/nntrainer/tensor/cpu_backend/meson.build
+++ b/nntrainer/tensor/cpu_backend/meson.build
@@ -6,11 +6,9 @@ subdir('fallback')
 nntrainer_inc += include_directories('fallback')
 nntrainer_inc_abs += meson.current_source_dir() / 'fallback'
 
-if get_option('enable-ggml')
-  subdir('ggml_interface')
-  nntrainer_inc += include_directories('ggml_interface')
-  nntrainer_inc_abs += meson.current_source_dir() / 'ggml_interface'
-endif
+subdir('ggml_interface')
+nntrainer_inc += include_directories('ggml_interface')
+nntrainer_inc_abs += meson.current_source_dir() / 'ggml_interface'
 
 if get_option('enable-blas')
   subdir('cblas_interface')

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -16,6 +16,7 @@
 #include <avx2_impl.h>
 #include <cblas_interface.h>
 #include <fallback_internal.h>
+#include <ggml_interface.h>
 #include <nntrainer_error.h>
 #include <x86_compute_backend.h>
 
@@ -23,6 +24,8 @@
 #define COL_MAJOR 1
 
 namespace nntrainer {
+
+void init_backend() { __ggml_init(); }
 
 void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
                            const unsigned int incX, float *Y,
@@ -198,9 +201,44 @@ void softmax(const unsigned int N, float *X, float *Y) {
   __fallback_softmax(N, X, Y);
 }
 
+void gemm_q4_0(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc) {
+  return __fallback_gemm_q4_0(M, N, K, A, lda, B, ldb, C, ldc);
+}
+
 void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc) {
-  return __gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
+  return __fallback_gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
 }
+
+size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights) {
+  return __fallback_quantize_q4_0(src, dst, nrow, n_per_row, quant_weights);
+}
+
+size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights) {
+  return __fallback_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
+}
+
+void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
+  __fallback_dequantize_row_q4_K(x_raw, y, k);
+}
+
+void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
+  __fallback_dequantize_row_q8_K(x, y, k);
+}
+
+void repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
+                           const unsigned int M, const unsigned int N) {
+  __fallback_repack_q4_0_to_q4_0_8(W, repacked_W, data_size, M, N);
+}
+
+void repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
+                           const unsigned int M, const unsigned int N) {
+  __fallback_repack_q4_K_to_q4_K_8(W, repacked_W, data_size, M, N);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -16,16 +16,24 @@
 #include <avx2_impl.h>
 #include <cblas_interface.h>
 #include <fallback_internal.h>
-#include <ggml_interface.h>
 #include <nntrainer_error.h>
 #include <x86_compute_backend.h>
+#ifdef ENABLE_GGML
+#include <ggml_interface.h>
+#endif
 
 #define ROW_MAJOR 0
 #define COL_MAJOR 1
 
 namespace nntrainer {
 
-void init_backend() { __ggml_init(); }
+void init_backend() {
+#ifdef ENABLE_GGML
+  __ggml_init();
+#else
+  // TODO it needed.
+#endif
+}
 
 void scopy_int4_to_float32(const unsigned int N, const uint8_t *X,
                            const unsigned int incX, float *Y,
@@ -204,41 +212,73 @@ void softmax(const unsigned int N, float *X, float *Y) {
 void gemm_q4_0(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc) {
+#ifdef ENABLE_GGML
+  return __ggml_q4_0_8x8_q8_0_GEMM(M, N, K, A, lda, B, ldb, C, ldc);
+#else
   return __fallback_gemm_q4_0(M, N, K, A, lda, B, ldb, C, ldc);
+#endif
 }
 
 void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc) {
+#ifdef ENABLE_GGML
+  return __ggml_q4_K_8x8_q8_K_GEMM(M, N, K, A, lda, B, ldb, C, ldc);
+#else
   return __fallback_gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
+#endif
 }
 
 size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights) {
+#ifdef ENABLE_GGML
+  return __ggml_quantize_q4_0(src, dst, nrow, n_per_row, quant_weights);
+#else
   return __fallback_quantize_q4_0(src, dst, nrow, n_per_row, quant_weights);
+#endif
 }
 
 size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights) {
+#ifdef ENABLE_GGML
+  return __ggml_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
+#else
   return __fallback_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
+#endif
 }
 
 void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
+#ifdef ENABLE_GGML
+  __ggml_dequantize_row_q4_K(x_raw, y, k);
+#else
   __fallback_dequantize_row_q4_K(x_raw, y, k);
+#endif
 }
 
 void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
+#ifdef ENABLE_GGML
+  __ggml_dequantize_row_q8_K(x, y, k);
+#else
   __fallback_dequantize_row_q8_K(x, y, k);
+#endif
 }
 
 void repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
                            const unsigned int M, const unsigned int N) {
+#ifdef ENABLE_GGML
+  __ggml_repack_q4_0_to_q4_0_8(W, repacked_W, data_size, M, N);
+#else
   __fallback_repack_q4_0_to_q4_0_8(W, repacked_W, data_size, M, N);
+#endif
 }
 
 void repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
                            const unsigned int M, const unsigned int N) {
+#ifdef ENABLE_GGML
+  __ggml_repack_q4_K_to_q4_K_8(W, repacked_W, data_size, M, N);
+#else
   __fallback_repack_q4_K_to_q4_K_8(W, repacked_W, data_size, M, N);
+#endif
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -21,6 +21,11 @@
 
 namespace nntrainer {
 
+/**
+ * @brief Initialization of ggml backend
+ */
+void init_backend();
+
 #ifdef ENABLE_FP16
 /**
  * @brief Accelerating function for rotary embedding layer forwarding
@@ -713,6 +718,23 @@ void ele_div(const unsigned N, const float *X, const float *Y, float *Z,
 bool is_valid(const unsigned int N, const float *X);
 
 /**
+ * @brief q4_0 GEMM : A (M,K) * W.T (N,K) = O (M,N)
+ *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void gemm_q4_0(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
+
+/**
  * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
  *
  * @param M Original row size of output
@@ -728,6 +750,75 @@ bool is_valid(const unsigned int N, const float *X);
 void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief
+ *
+ * @param x_raw
+ * @param y
+ * @param k
+ */
+void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param x
+ * @param y
+ * @param k
+ */
+void dequantize_row_q8_K(const void *x, float *y, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param W
+ * @param repacked_W
+ * @param data_size
+ * @param M
+ * @param N
+ */
+void repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
+                           const unsigned int M, const unsigned int N);
+
+/**
+ * @brief
+ *
+ * @param W
+ * @param repacked_W
+ * @param data_size
+ * @param M
+ * @param N
+ */
+void repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
+                           const unsigned int M, const unsigned int N);
+
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __x86_COMPUTE_BACKEND_H__ */

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -316,6 +316,10 @@ NNSteamer tensor trainer static package for nntrainer to support inference.
 Summary: Ruy support in NNTrainer
 %description -n ruy
 
+%package -n ggml
+Summary: GGML support in NNTrainer
+%description -n ggml
+
 %endif #tizen
 
 ## Define build options
@@ -405,6 +409,9 @@ ln -sf %{_libdir}/pkgconfig/capi-nnstreamer.pc %{_libdir}/pkgconfig/capi-ml-comm
 # Setup Ruy
 tar -xf packaging/ruy.tar.gz -C subprojects
 
+# Setup GGML
+tar -xf packaging/ggml.tar.gz -C subprojects
+
 mkdir -p build
 meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} \
       --libdir=%{_lib} --bindir=%{nntrainerapplicationdir} \
@@ -416,6 +423,7 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} \
       %{enable_reduce_tolerance} %{configure_subplugin_install_path} %{enable_debug} \
       -Dml-api-support=enabled -Denable-nnstreamer-tensor-filter=enabled \
       -Denable-nnstreamer-tensor-trainer=enabled -Denable-capi=enabled \
+      -Denable-ggml=true \
       %{fp16_support} build --wrap-mode=nodownload
 
 ninja -C build %{?_smp_mflags}
@@ -548,6 +556,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/cpu_backend.h
 %{_includedir}/nntrainer/fallback_internal.h
 %{_includedir}/nntrainer/cblas_interface.h
+%{_includedir}/nntrainer/ggml_interface.h
 %ifarch %{ix86} x86_64
 %{_includedir}/nntrainer/x86_compute_backend.h
 %{_includedir}/nntrainer/avx2_impl.h
@@ -722,6 +731,15 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %ifarch x86_64
 %{_bindir}/cpuid_dump
 %endif #x86_64
+
+# GGML
+%files -n ggml
+%manifest nntrainer.manifest
+%defattr(-,root,root,-)
+%license LICENSE
+%{_libdir}/arm64-v8a/libggml.so
+%{_libdir}/arm64-v8a/libggml_base.so
+%{_libdir}/arm64-v8a/libggml_cpu.so
 
 %endif #tizen
 

--- a/subprojects/ggml.wrap
+++ b/subprojects/ggml.wrap
@@ -1,4 +1,7 @@
 [wrap-git]
 url = https://github.com/ggml-org/ggml.git
-directory=ggml
-revision = HEAD
+directory = ggml
+revision = 489716ba99ecd51164f79e8c6fec0b5bf634eac9
+patch_directory = ggml
+diff_files = ggml/0001-Export-some-internal-methods.patch
+method = cmake

--- a/subprojects/packagefiles/ggml/0001-Export-some-internal-methods.patch
+++ b/subprojects/packagefiles/ggml/0001-Export-some-internal-methods.patch
@@ -1,0 +1,179 @@
+From cd79bc216aa3b25e65caf1415911c5a16a0c4576 Mon Sep 17 00:00:00 2001
+From: Maciej Nalewaj <m.nalewaj@samsung.com>
+Date: Fri, 25 Apr 2025 10:39:18 +0200
+Subject: [PATCH] Export some internal methods
+
+Signed-off-by: Maciej Nalewaj <m.nalewaj@samsung.com>
+---
+ include/ggml.h                    | 13 ++++++
+ src/ggml-cpu/ggml-cpu-aarch64.cpp | 74 ++++++++++++++++++++++++++++---
+ 2 files changed, 80 insertions(+), 7 deletions(-)
+
+diff --git a/include/ggml.h b/include/ggml.h
+index 51aa5b3..02f4126 100644
+--- a/include/ggml.h
++++ b/include/ggml.h
+@@ -2183,6 +2183,19 @@ extern "C" {
+     GGML_API void                          ggml_threadpool_params_init   (struct ggml_threadpool_params * p, int n_threads);
+     GGML_API bool                          ggml_threadpool_params_match  (const struct ggml_threadpool_params * p0, const struct ggml_threadpool_params * p1);
+ 
++    // Internal methods exported to be used by nntrainer
++    GGML_API void ggml_gemm_q4_0_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
++    GGML_API void ggml_gemm_q4_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
++
++    GGML_API void ggml_gemv_q4_0_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
++    GGML_API void ggml_gemv_q4_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
++
++    GGML_API void ggml_quantize_mat_q8_0_4x8(const float *GGML_RESTRICT x, void *GGML_RESTRICT vy, int64_t k);
++    GGML_API void ggml_quantize_mat_q8_K_4x8(const float *GGML_RESTRICT x, void *GGML_RESTRICT vy, int64_t k);
++
++    GGML_API int  ggml_repack_q4_0_to_q4_0_8_bl(void * GGML_RESTRICT dst, int interleave_block, const void * GGML_RESTRICT data, size_t data_size, size_t nrow, size_t k);
++    GGML_API int  ggml_repack_q4_K_to_q4_K_8_bl(void * GGML_RESTRICT dst, int interleave_block, const void * GGML_RESTRICT data, size_t data_size, size_t nrow, size_t k);
++
+ #ifdef  __cplusplus
+ }
+ #endif
+diff --git a/src/ggml-cpu/ggml-cpu-aarch64.cpp b/src/ggml-cpu/ggml-cpu-aarch64.cpp
+index 175cba3..c06ec51 100644
+--- a/src/ggml-cpu/ggml-cpu-aarch64.cpp
++++ b/src/ggml-cpu/ggml-cpu-aarch64.cpp
+@@ -340,7 +340,7 @@ static void ggml_quantize_mat_q8_0_4x4(const float * GGML_RESTRICT x, void * GGM
+ #endif
+ }
+ 
+-static void ggml_quantize_mat_q8_0_4x8(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, int64_t k) {
++void ggml_quantize_mat_q8_0_4x8(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, int64_t k) {
+     assert(QK8_0 == 32);
+     assert(k % QK8_0 == 0);
+     const int nb = k / QK8_0;
+@@ -555,7 +555,7 @@ static void ggml_quantize_mat_q8_0_4x8(const float * GGML_RESTRICT x, void * GGM
+ #endif
+ }
+ 
+-static void ggml_quantize_mat_q8_K_4x8(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, int64_t k) {
++void ggml_quantize_mat_q8_K_4x8(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, int64_t k) {
+     assert(QK_K == 256);
+     assert(k % QK_K == 0);
+     const int nb = k / QK_K;
+@@ -1015,7 +1015,7 @@ static void ggml_gemv_q4_0_4x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, c
+     }
+ }
+ 
+-static void ggml_gemv_q4_0_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
++void ggml_gemv_q4_0_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+     const int qk = QK8_0;
+     const int nb = n / qk;
+     const int ncols_interleaved = 8;
+@@ -1264,7 +1264,6 @@ static void ggml_gemv_q4_0_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, c
+     {
+         float sumf[8];
+         int sumi;
+-
+         const block_q8_0 * a_ptr = (const block_q8_0 *) vy;
+         for (int x = 0; x < nc / ncols_interleaved; x++) {
+             const block_q4_0x8 * b_ptr = (const block_q4_0x8 *) vx + (x * nb);
+@@ -1288,7 +1287,7 @@ static void ggml_gemv_q4_0_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, c
+     }
+ }
+ 
+-static void ggml_gemv_q4_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
++void ggml_gemv_q4_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+     const int qk = QK_K;
+     const int nb = n / qk;
+     const int ncols_interleaved = 8;
+@@ -2629,7 +2628,7 @@ static void ggml_gemm_q4_0_4x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, c
+     }
+ }
+ 
+-static void ggml_gemm_q4_0_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
++void ggml_gemm_q4_0_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+     const int qk = QK8_0;
+     const int nb = n / qk;
+     const int ncols_interleaved = 8;
+@@ -4021,7 +4020,7 @@ static void ggml_gemm_q4_0_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, c
+     }
+ }
+ 
+-static void ggml_gemm_q4_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
++void ggml_gemm_q4_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+     const int qk = QK_K;
+     const int nb = n / qk;
+     const int ncols_interleaved = 8;
+@@ -5822,6 +5821,37 @@ static int repack_q4_0_to_q4_0_4_bl(struct ggml_tensor * t, int interleave_block
+ 
+     GGML_UNUSED(data_size);
+ }
++
++// The method was modified (from repack_q4_K_to_q4_K_8_bl) to be used by nntrainer
++int ggml_repack_q4_K_to_q4_K_8_bl(void * GGML_RESTRICT dst, int interleave_block, const void * GGML_RESTRICT data, size_t data_size, size_t nrow, size_t k) {
++    GGML_ASSERT(interleave_block == 8);
++    constexpr size_t nrows_interleaved = 8;
++
++    block_q4_Kx8 * dst_ = (block_q4_Kx8*)dst;
++    const block_q4_K * src = (const block_q4_K*) data;
++    block_q4_K dst_tmp[8];
++    int nblocks = k / QK_K;
++
++    GGML_ASSERT(data_size == nrow * nblocks * sizeof(block_q4_K));
++
++    if (nrow % nrows_interleaved != 0 || k % 8 != 0) {
++        return -1;
++    }
++
++    for (size_t b = 0; b < nrow; b += nrows_interleaved) {
++        for (int64_t x = 0; x < nblocks; x++) {
++            for (size_t i  = 0; i < nrows_interleaved; i++ ) {
++                dst_tmp[i] = src[x + i * nblocks];
++            }
++            *dst_++ = make_block_q4_Kx8(dst_tmp, interleave_block);
++        }
++        src += nrows_interleaved * nblocks;
++    }
++    return 0;
++
++    GGML_UNUSED(data_size);
++}
++
+ static int repack_q4_K_to_q4_K_8_bl(struct ggml_tensor * t, int interleave_block, const void * GGML_RESTRICT data, size_t data_size) {
+     GGML_ASSERT(t->type == GGML_TYPE_Q4_K);
+     GGML_ASSERT(interleave_block == 8);
+@@ -5853,6 +5883,36 @@ static int repack_q4_K_to_q4_K_8_bl(struct ggml_tensor * t, int interleave_block
+     GGML_UNUSED(data_size);
+ }
+ 
++// The method was modified (from repack_q4_0_to_q4_0_8_bl) to be used by nntrainer
++int ggml_repack_q4_0_to_q4_0_8_bl(void * GGML_RESTRICT dst, int interleave_block, const void * GGML_RESTRICT data, size_t data_size, size_t nrow, size_t k) {
++    GGML_ASSERT(interleave_block == 8);
++    constexpr size_t nrows_interleaved = 8;
++
++    block_q4_0x8 * dst_ = (block_q4_0x8*)dst;
++    const block_q4_0 * src = (const block_q4_0*) data;
++    block_q4_0 dst_tmp[8];
++    int nblocks = k / QK4_0;
++
++    GGML_ASSERT(data_size == nrow * nblocks * sizeof(block_q4_0));
++
++    if (nrow % nrows_interleaved != 0 || k % 8 != 0) {
++        return -1;
++    }
++
++    for (size_t b = 0; b < nrow; b += nrows_interleaved) {
++        for (int64_t x = 0; x < nblocks; x++) {
++            for (size_t i  = 0; i < nrows_interleaved; i++ ) {
++                dst_tmp[i] = src[x + i * nblocks];
++            }
++            *dst_++ = make_block_q4_0x8(dst_tmp, interleave_block);
++        }
++        src += nrows_interleaved * nblocks;
++    }
++    return 0;
++
++    GGML_UNUSED(data_size);
++}
++
+ static int repack_q4_0_to_q4_0_8_bl(struct ggml_tensor * t, int interleave_block, const void * GGML_RESTRICT data, size_t data_size) {
+     GGML_ASSERT(t->type == GGML_TYPE_Q4_0);
+     GGML_ASSERT(interleave_block == 8);
+-- 
+2.34.1
+

--- a/subprojects/packagefiles/ggml/0001-Export-some-internal-methods.patch
+++ b/subprojects/packagefiles/ggml/0001-Export-some-internal-methods.patch
@@ -1,14 +1,25 @@
-From cd79bc216aa3b25e65caf1415911c5a16a0c4576 Mon Sep 17 00:00:00 2001
+From 7affdf7eb6044da3aea7f52d3c6fc8f05b7c3403 Mon Sep 17 00:00:00 2001
 From: Maciej Nalewaj <m.nalewaj@samsung.com>
-Date: Fri, 25 Apr 2025 10:39:18 +0200
+Date: Fri, 9 May 2025 11:40:20 +0200
 Subject: [PATCH] Export some internal methods
 
 Signed-off-by: Maciej Nalewaj <m.nalewaj@samsung.com>
 ---
+ CMakeLists.txt                    |  2 +-
  include/ggml.h                    | 13 ++++++
  src/ggml-cpu/ggml-cpu-aarch64.cpp | 74 ++++++++++++++++++++++++++++---
- 2 files changed, 80 insertions(+), 7 deletions(-)
+ 3 files changed, 81 insertions(+), 8 deletions(-)
 
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 61fe15a..cf7aec3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.14) # for add_link_options and implicit target directories.
++cmake_minimum_required(VERSION 3.16) # for add_link_options and implicit target directories.
+ project("ggml" C CXX)
+ include(CheckIncludeFileCXX)
+ 
 diff --git a/include/ggml.h b/include/ggml.h
 index 51aa5b3..02f4126 100644
 --- a/include/ggml.h

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -51,6 +51,13 @@ LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/builddir/obj/local/$(TARGET_ARCH_ABI)/libru
 include $(PREBUILT_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
+
+LOCAL_MODULE := ggml
+LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/builddir/jni/$(TARGET_ARCH_ABI)//libggml.so
+
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
 GTEST_PATH := googletest
 
 LOCAL_MODULE := googletest_main
@@ -88,7 +95,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -105,7 +112,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -122,7 +129,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -139,7 +146,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -156,7 +163,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -173,7 +180,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -190,7 +197,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -207,7 +214,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -224,7 +231,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -241,7 +248,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -258,7 +265,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -274,7 +281,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -290,7 +297,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -306,7 +313,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -322,7 +329,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -338,7 +345,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -354,7 +361,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -372,7 +379,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -390,7 +397,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -410,7 +417,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -434,7 +441,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -490,7 +497,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -506,7 +513,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -522,7 +529,22 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
+include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := unittest_nntrainer_cpu_backend
+LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 -march=armv8.2-a+fp16 -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DENABLE_OPENCL=1 -DUSE__FP16=1
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DENABLE_GGML
+LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
+
+LOCAL_SRC_FILES := \
+	 ../unittest/unittest_nntrainer_cpu_backend.cpp
+
+LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -539,6 +561,6 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -56,6 +56,7 @@ endif
 
 test_target = [
   ['unittest_nntrainer_activations', []],
+  ['unittest_nntrainer_cpu_backend', []],
   ['unittest_nntrainer_exe_order', []],
   ['unittest_nntrainer_internal', []],
   ['unittest_nntrainer_lazy_tensor', []],

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -196,6 +196,8 @@ TEST(nntrainer_cpu_backend_standalone, ele_add) {
   }
 }
 
+#ifdef ENABLE_GGML
+
 TEST(nntrainer_cpu_backend_standalone, q4_K_quantization) {
   const unsigned int K = 768;
   const unsigned int N = 512;
@@ -460,6 +462,8 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1536x5760) {
   ASSERT_LE(q4_k_mse, 1.0f);
 }
 
+#endif
+
 /**
  * Room for optimization
  *
@@ -473,6 +477,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1536x5760) {
 
 int main(int argc, char **argv) {
   int result = -1;
+#ifdef ENABLE_GGML
   try {
     testing::InitGoogleTest(&argc, argv);
   } catch (...) {
@@ -485,5 +490,8 @@ int main(int argc, char **argv) {
   } catch (...) {
     std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
   }
+#else
+  result = 0;
+#endif
   return result;
 }

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -356,7 +356,7 @@ static void run_quant_test(const uint32_t M, const uint32_t K, const uint32_t N,
                    weight.data(), K, 0.F, ref_dst.data(), N);
   auto t2 = high_resolution_clock::now();
   auto dt = duration_cast<nanoseconds>(t2 - t1);
-  std::cout << "[INFO] sgemm : " << dt.count() << " ns " << std::endl;
+  std::cout << "[INFO] sgemm :    " << dt.count() << " ns " << std::endl;
 
   q0_k_mse = test_gemm_q4_0(M, K, N, weight.data(), activation.data(), ref_dst);
   q4_k_mse = test_gemm_q4_K(M, K, N, weight.data(), activation.data(), ref_dst);

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -1,0 +1,489 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file	unittest_nntrainer_cpu_backend.cpp
+ * @date	03 April 2025
+ * @brief	This is unittest for cpu_backend standalone
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Sungsik Kong <ss.kong@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#include "nntrainer_test_util.h"
+#include <cpu_backend.h>
+#include <gtest/gtest.h>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include <chrono>
+#include <iostream>
+using std::chrono::duration_cast;
+using std::chrono::high_resolution_clock;
+using std::chrono::microseconds;
+using std::chrono::milliseconds;
+using std::chrono::nanoseconds;
+using std::chrono::seconds;
+
+template <typename T>
+static inline std::vector<T>
+generate_random_vector(size_t size, float min_val = -1.F, float max_val = 1.F) {
+  std::random_device rd;
+  std::mt19937 gen(42);
+  // std::mt19937 gen(rd());
+  std::uniform_real_distribution<float> dist(min_val, max_val);
+  std::vector<T> vec(size);
+  for (auto &val : vec) {
+    val = static_cast<T>(dist(gen));
+  }
+  return vec;
+}
+
+template <typename T>
+inline std::vector<T> generate_random_positive_vector(size_t size,
+                                                      float min_val = 0.F,
+                                                      float max_val = 0.5F) {
+  std::random_device rd;
+  std::mt19937 gen(42);
+  // std::mt19937 gen(rd());
+  std::uniform_real_distribution<float> dist(min_val, max_val);
+  std::vector<T> vec(size);
+  for (auto &val : vec) {
+    val = static_cast<T>(dist(gen));
+  }
+  return vec;
+}
+
+template <typename T>
+static inline std::vector<T> generate_homogeneous_vector(size_t size, T value) {
+  std::vector<T> vec(size);
+  for (auto &val : vec) {
+    val = value;
+  }
+  return vec;
+}
+
+template <typename T> static inline void print_matrix(T *src, int M, int N) {
+  for (int i = 0; i < M; ++i) {
+    for (int j = 0; j < N; ++j) {
+      std::cout << src[i * N + j] << " ";
+    }
+    std::cout << std::endl;
+  }
+}
+
+template <typename T>
+inline void print_matrix_partially(T *src, int M, int N, int partial_m = 5,
+                                   int partial_n = 5, int partial_len = 5) {
+  for (int k = 0; k < partial_len; ++k) {
+    std::cout << src[partial_m * N + partial_n + k] << " ";
+  }
+  std::cout << std::endl;
+}
+
+template <typename T>
+inline void print_vector_partially(T *src, int init_idx = 5,
+                                   int partial_len = 5) {
+  for (int k = 0; k < partial_len; ++k) {
+    std::cout << src[init_idx + k] << " ";
+  }
+  std::cout << std::endl;
+}
+
+template <typename T>
+static inline void
+print_matrix_partially_n(const std::string &name, const T *src, int M, int N,
+                         int partial_m = 5, int partial_n = 5) {
+  std::cout << name << ":" << std::endl;
+  std::cout << "--------------------------" << std::endl;
+  for (int i = 0; i < partial_m; ++i) {
+    for (int j = 0; j < partial_n; ++j) {
+      std::cout << src[i * N + j] << "  ";
+    }
+    std::cout << std::endl;
+  }
+  std::cout << "--------------------------" << std::endl;
+}
+
+template <typename T>
+static inline double find_max_diff(T *src, T *src2, int M, int N) {
+  float max_diff = 0;
+  double err_sum = 0;
+  for (int i = 0; i < M; ++i) {
+    for (int j = 0; j < N; ++j) {
+      max_diff = std::max(max_diff, std::abs(src[i * N + j] - src2[i * N + j]));
+      err_sum += std::abs(src[i * N + j] - src2[i * N + j]);
+    }
+  }
+  // std::cout << "err_sum : " << err_sum << std::endl;
+  return max_diff;
+}
+
+#define QK4_0 32
+typedef struct {
+  uint16_t d;            // delta
+  uint8_t qs[QK4_0 / 2]; // nibbles / quants
+} block_q4_0_testonly;
+
+typedef struct {
+  union {
+    struct {
+      int16_t d;    // super-block scale for quantized scales
+      int16_t dmin; // super-block scale for quantized mins
+    };
+    uint32_t dm;
+  };
+  uint8_t scales[12];  // scales and mins, quantized with 6 bits
+  uint8_t qs[256 / 2]; // 4--bit quants
+} block_q4_K_testonly;
+
+typedef struct {
+  float d;                 // delta
+  int8_t qs[256];          // quants
+  int16_t bsums[256 / 16]; // sum of quants in groups of 16
+} block_q8_K_testonly;
+
+/**
+ * @brief
+ */
+struct block_q4_Kx8_testonly {
+  int16_t d[8];       // super-block scale for quantized scales
+  int16_t dmin[8];    // super-block scale for quantized mins
+  uint8_t scales[96]; // scales and mins, quantized with 6 bits
+  uint8_t qs[1024];   // 4--bit quants
+};
+
+static inline void print_q4_k_block_partially(void *block) {
+  block_q4_K_testonly *b = (block_q4_K_testonly *)block;
+  std::cout << "d : " << b->d << std::endl;
+  std::cout << "dmin : " << b->dmin << std::endl;
+  // std::cout << "qs : ";
+  // for (int i = 0; i < 256/2; ++i){
+  //     uint8_t packed_val = b->qs[i];
+  //     uint8_t val1 = packed_val & 0x0F;
+  //     uint8_t val2 = (packed_val >> 4) & 0x0F;
+  //     std::cout << (int)val1 << " " << (int)val2 << " ";
+  // }
+  std::cout << "qs 5~8 : ";
+  for (int i = 5; i < 8; ++i) {
+    uint8_t packed_val = b->qs[i];
+    uint8_t val1 = packed_val & 0x0F;
+    uint8_t val2 = (packed_val >> 4) & 0x0F;
+    std::cout << (int)val1 << " " << (int)val2 << " ";
+  }
+  std::cout << std::endl;
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_add) {
+  const unsigned int TEST_SIZE = 100;
+  float alpha = 1.F;
+  float beta = 0.F;
+  unsigned int i_stride = 1;
+  unsigned int o_stride = 1;
+
+  std::vector<float> lhs = generate_random_vector<float>(TEST_SIZE);
+  std::vector<float> rhs = generate_random_vector<float>(TEST_SIZE);
+  std::vector<float> dst(TEST_SIZE);
+
+  const float *lhs_ptr = (const float *)lhs.data();
+  const float *rhs_ptr = (const float *)rhs.data();
+  float *dst_ptr = (float *)dst.data();
+
+  nntrainer::ele_add(TEST_SIZE, lhs_ptr, rhs_ptr, dst_ptr, alpha, beta,
+                     i_stride, o_stride);
+
+  for (unsigned int i = 0; i < TEST_SIZE; ++i) {
+    EXPECT_EQ(dst[i], lhs[i] + rhs[i]);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, q4_K_quantization) {
+  const unsigned int K = 768;
+  const unsigned int N = 512;
+
+  std::vector<float> weight = generate_random_vector<float>(N * K);
+  std::vector<float> weight_tmp(N * K);
+
+  const float *rhs_ptr = (const float *)weight.data();
+  float *rhs_ptr_tmp = weight_tmp.data();
+
+  int64_t ne0 = N; // row length of the weight matrix
+  int64_t q4_k_block_size = 256;
+  int64_t q4_k_type_size = sizeof(block_q4_K_testonly);
+  int64_t num_blocks = (K * N) / q4_k_block_size;
+  size_t data_size = q4_k_type_size * ne0 / q4_k_block_size;
+  data_size *= K;
+
+  std::vector<char> offline_qWeight = std::vector<char>(data_size);
+  char *offline_qWeight_ptr = (char *)offline_qWeight.data();
+
+  nntrainer::quantize_q4_K(rhs_ptr, (void *)offline_qWeight_ptr, K, N, nullptr);
+
+  nntrainer::dequantize_row_q4_K(offline_qWeight_ptr, rhs_ptr_tmp, K * N);
+
+  auto mean_squared_error =
+    mse<float, float>(weight.data(), rhs_ptr_tmp, N * K);
+  auto cos_sim = cosine_similarity(weight.data(), rhs_ptr_tmp, N * K);
+  auto max_differ = find_max_diff(weight.data(), rhs_ptr_tmp, N, K);
+
+  const float eps = 1e-5;
+  ///@todo Find proper metric and standard to assess
+  EXPECT_NEAR(mean_squared_error, 0., eps * K * N);
+  EXPECT_NEAR(cos_sim, 0., eps * K * N);
+  EXPECT_NEAR(max_differ, 0., eps * K * N);
+}
+
+static float compute_mse(const uint32_t M, const uint32_t N,
+                         std::vector<float> &ref_dst, std::vector<float> &dst) {
+  auto mean_squared_error =
+    mse<float, float>(ref_dst.data(), dst.data(), M * N);
+  auto cos_sim = cosine_similarity(ref_dst.data(), dst.data(), M * N);
+  auto max_differ = find_max_diff(ref_dst.data(), dst.data(), M, N);
+
+  auto sum = std::accumulate(dst.begin(), dst.end(), 0.0);
+  auto sum_gt = std::accumulate(ref_dst.begin(), ref_dst.end(), 0.0);
+  std::cout << "[INFO]            MSE: " << mean_squared_error
+            << ", COS_SIM: " << cos_sim << ", MAX_DIFFER: " << max_differ
+            << ", SUM: " << sum << ", SUM_GT: " << sum_gt << std::endl;
+  return mean_squared_error;
+}
+
+static float test_gemm_q4_0(const uint32_t M, const uint32_t K,
+                            const uint32_t N, const float *weights,
+                            const float *activations,
+                            std::vector<float> &ref_dst) {
+  // needed to initialize f16 tables
+  nntrainer::init_backend();
+
+  // Step0. Allocate a temporary buffer for quantized weight
+  int64_t q4_0_type_size = sizeof(block_q4_0_testonly);
+  int64_t q4_0_block_size = 32;
+  int64_t q4_0_num_blocks = (K * N) / q4_0_block_size;
+  size_t q4_0_data_size = q4_0_type_size * N / q4_0_block_size;
+  q4_0_data_size *= K;
+  std::vector<char> q4_0_offline_qWeight = std::vector<char>(q4_0_data_size);
+
+  // Step1. Supposed to be an offline Weight quantization from float to q4_K
+  // (Zero latency overhead for the model runtime)
+  char *q4_0_offline_qWeight_ptr = (char *)q4_0_offline_qWeight.data();
+  nntrainer::quantize_q4_0(weights, (void *)q4_0_offline_qWeight_ptr, N, K,
+                           nullptr);
+
+  // Step2. Repack Weight to q4_K_8x8 layout (This happens when you load the
+  // model weights. It's a one-time operation)
+  std::vector<char> q4_0_repacked_qWeight = std::vector<char>(q4_0_data_size);
+  nntrainer::repack_q4_0_to_q4_0_8(q4_0_repacked_qWeight.data(),
+                                   q4_0_offline_qWeight_ptr, q4_0_data_size, N,
+                                   K);
+
+  // Step3. Run GEMM! (Online activation quantization + kernel routine + return
+  // float)
+  std::vector<float> dst(M * N);
+  auto t1 = high_resolution_clock::now();
+  // #### MAIN TESTED METHOD ####
+  nntrainer::gemm_q4_0(M, N, K, activations, K,
+                       (void *)q4_0_repacked_qWeight.data(), N, dst.data(), N);
+  // #### MAIN TESTED METHOD ####
+  auto t2 = high_resolution_clock::now();
+  auto dt = duration_cast<nanoseconds>(t2 - t1);
+  std::cout << "[INFO] gemm_q4_0: " << dt.count() << " ns " << std::endl;
+
+  // Step4. Compute quantization error
+  auto mean_squared_error = compute_mse(M, N, ref_dst, dst);
+  return mean_squared_error;
+}
+
+static float test_gemm_q4_K(const uint32_t M, const uint32_t K,
+                            const uint32_t N, const float *weights,
+                            const float *activations,
+                            std::vector<float> &ref_dst) {
+  // Step0. Allocate a temporary buffer for quantized weight
+  int64_t q4_k_block_size = 256;
+  int64_t q4_k_type_size = sizeof(block_q4_K_testonly);
+  int64_t num_blocks = (K * N) / q4_k_block_size;
+  size_t data_size = q4_k_type_size * N / q4_k_block_size;
+  data_size *= K;
+  std::vector<char> offline_qWeight = std::vector<char>(data_size);
+  char *offline_qWeight_ptr = (char *)offline_qWeight.data();
+
+  // Step1. Supposed to be an offline Weight quantization from float to q4_K
+  // (Zero latency overhead for the model runtime)
+  nntrainer::quantize_q4_K(weights, (void *)offline_qWeight_ptr, N, K, nullptr);
+
+  // Step2. Repack Weight to q4_K_8x8 layout (This happens when you load the
+  // model weights. It's a one-time operation)
+  std::vector<char> repacked_qWeight = std::vector<char>(data_size);
+  nntrainer::repack_q4_K_to_q4_K_8(repacked_qWeight.data(), offline_qWeight_ptr,
+                                   data_size, N, K);
+
+  // Step3. Run GEMM! (Online activation quantization + kernel routine + return
+  // float)
+  std::vector<float> dst(M * N);
+  auto t1 = high_resolution_clock::now();
+  // #### MAIN TESTED METHOD ####
+  nntrainer::gemm_q4_K(M, N, K, activations, K, (void *)repacked_qWeight.data(),
+                       N, dst.data(), N);
+  // #### MAIN TESTED METHOD ####
+  auto t2 = high_resolution_clock::now();
+  auto dt = duration_cast<nanoseconds>(t2 - t1);
+  std::cout << "[INFO] gemm_q4_K: " << dt.count() << " ns " << std::endl;
+  ///@note Needs validation!
+
+  // Step4. Compare quantization error
+  auto mean_squared_error = compute_mse(M, N, ref_dst, dst);
+  return mean_squared_error;
+}
+
+static void run_quant_test(const uint32_t M, const uint32_t K, const uint32_t N,
+                           float &q0_k_mse, float &q4_k_mse) {
+  std::cout << "[INFO] Quantization Test (M:" << M << ", K:" << K << ", N:" << N
+            << ")" << std::endl;
+  ///@note A(M, K) * W.T(N, K) = (M, N)
+  ///@note A(sizez, sizex) * W.T(sizey, sizex) = (sizez, sizey)
+
+  ///@note q4_K GEMM is a Row-Major, transB GEMM
+  // std::vector<float> activation = generate_homogeneous_vector<float>(M *
+  // K, 2.0f); std::vector<float> weight = generate_homogeneous_vector<float>(N
+  // * K, 1.0F);
+  std::vector<float> activation = generate_random_vector<float>(M * K);
+  std::vector<float> weight = generate_random_vector<float>(N * K);
+  std::vector<float> ref_dst(M * N);
+
+  // GROUND TRUTH TRANSB SGEMM for reference
+  auto t1 = high_resolution_clock::now();
+  nntrainer::sgemm(0, false, true, M, N, K, 1.F, activation.data(), K,
+                   weight.data(), K, 0.F, ref_dst.data(), N);
+  auto t2 = high_resolution_clock::now();
+  auto dt = duration_cast<nanoseconds>(t2 - t1);
+  std::cout << "[INFO] sgemm : " << dt.count() << " ns " << std::endl;
+
+  q0_k_mse = test_gemm_q4_0(M, K, N, weight.data(), activation.data(), ref_dst);
+  q4_k_mse = test_gemm_q4_K(M, K, N, weight.data(), activation.data(), ref_dst);
+}
+
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_256x1024x512) {
+  const unsigned int M = 256;
+  const unsigned int K = 1024;
+  const unsigned int N = 512;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  ASSERT_LE(q0_k_mse, 2.0f);
+  ASSERT_LE(q4_k_mse, 2.0f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_512x768x1024) {
+  const unsigned int M = 512;
+  const unsigned int K = 768;
+  const unsigned int N = 1024;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  ASSERT_LE(q0_k_mse, 2.0f);
+  ASSERT_LE(q4_k_mse, 2.0f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x1536x1536) {
+  const unsigned int M = 1024;
+  const unsigned int K = 1536;
+  const unsigned int N = 1536;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  ASSERT_LE(q0_k_mse, 2.0f);
+  ASSERT_LE(q4_k_mse, 2.0f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x1536x5760) {
+  const unsigned int M = 1024;
+  const unsigned int K = 1536;
+  const unsigned int N = 5760;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  ASSERT_LE(q0_k_mse, 2.0f);
+  ASSERT_LE(q4_k_mse, 2.0f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x3072x3072) {
+  const unsigned int M = 1024;
+  const unsigned int K = 3072;
+  const unsigned int N = 3072;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  ASSERT_LE(q0_k_mse, 2.0f);
+  ASSERT_LE(q4_k_mse, 2.0f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x512x768) {
+  const unsigned int M = 1;
+  const unsigned int K = 512;
+  const unsigned int N = 768;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  ASSERT_LE(q0_k_mse, 1.0f);
+  ASSERT_LE(q4_k_mse, 1.0f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x768x512) {
+  const unsigned int M = 1;
+  const unsigned int K = 768;
+  const unsigned int N = 512;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  ASSERT_LE(q0_k_mse, 1.0f);
+  ASSERT_LE(q4_k_mse, 1.0f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x768x1024) {
+  const unsigned int M = 1;
+  const unsigned int K = 768;
+  const unsigned int N = 1024;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  ASSERT_LE(q0_k_mse, 1.0f);
+  ASSERT_LE(q4_k_mse, 1.0f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1536x1536) {
+  const unsigned int M = 1;
+  const unsigned int K = 1536;
+  const unsigned int N = 1536;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  ASSERT_LE(q0_k_mse, 1.0f);
+  ASSERT_LE(q4_k_mse, 1.0f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1536x5760) {
+  const unsigned int M = 1;
+  const unsigned int K = 1536;
+  const unsigned int N = 5760;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  ASSERT_LE(q0_k_mse, 1.0f);
+  ASSERT_LE(q4_k_mse, 1.0f);
+}
+
+/**
+ * Room for optimization
+ *
+ *   1. Why don't we save weights for GEMM in q4_K_8x8 format offline?
+ *        - PRO : We can save the time for repacking the weight
+ *        - CON : We need to save the weight in two different formats (q4_K and
+ *   q4_K_8x8), and such kernel works for specific HWs.
+ *    2. Pre-allocation of runtime quantized activation buffer
+ *   3. ???
+ */
+
+int main(int argc, char **argv) {
+  int result = -1;
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during InitGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+  return result;
+}

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -3792,10 +3792,12 @@ TEST(nntrainer_Tensor, dotbatch_01_p) {
   nntrainer::Tensor b = ranged(2, 1, 2, 2);
   float answer_data[] = {2, 3, 6, 11, 46, 55, 66, 79};
   float dummy_data[] = {
-    std::nanf(""), std::nanf(""), std::nanf(""), std::nanf(""),
-    std::nanf(""), std::nanf(""), std::nanf(""), std::nanf(""),
-    std::nanf(""), std::nanf(""), std::nanf(""), std::nanf(""),
-    std::nanf(""), std::nanf(""), std::nanf(""), std::nanf("")};
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan("")};
   nntrainer::Tensor answer({2, 1, 2, 2}, answer_data);
   nntrainer::Tensor out({2, 1, 2, 2}, dummy_data);
   a.dotBatched(b, out);
@@ -3808,10 +3810,12 @@ TEST(nntrainer_Tensor, dotbatch_02_p) {
   float answer_data[] = {2,  3,   6,   11,  10,  19,  14,  27,
                          86, 103, 106, 127, 126, 151, 146, 175};
   float dummy_data[] = {
-    std::nanf(""), std::nanf(""), std::nanf(""), std::nanf(""),
-    std::nanf(""), std::nanf(""), std::nanf(""), std::nanf(""),
-    std::nanf(""), std::nanf(""), std::nanf(""), std::nanf(""),
-    std::nanf(""), std::nanf(""), std::nanf(""), std::nanf("")};
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan("")};
   nntrainer::Tensor answer({4, 1, 2, 2}, answer_data);
   nntrainer::Tensor out({4, 1, 2, 2}, dummy_data);
   a.dotBatched(b, out);
@@ -3824,10 +3828,12 @@ TEST(nntrainer_Tensor, dotbatch_03_p) {
   float answer_data[] = {2,  3,  6,   11,  6,   7,   26,  31,
                          82, 91, 118, 131, 118, 127, 170, 183};
   float dummy_data[] = {
-    std::nanf(""), std::nanf(""), std::nanf(""), std::nanf(""),
-    std::nanf(""), std::nanf(""), std::nanf(""), std::nanf(""),
-    std::nanf(""), std::nanf(""), std::nanf(""), std::nanf(""),
-    std::nanf(""), std::nanf(""), std::nanf(""), std::nanf("")};
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan(""), (float)std::nan(""), (float)std::nan(""),
+    (float)std::nan("")};
   nntrainer::Tensor answer({4, 1, 2, 2}, answer_data);
   nntrainer::Tensor out({4, 1, 2, 2}, dummy_data);
   a.dotBatched(b, out);

--- a/tools/android_test.sh
+++ b/tools/android_test.sh
@@ -23,17 +23,25 @@ fi
 popd
 pushd test/libs/arm64-v8a
 
-adb root
+if [ -v ADB_IP ]; then
+  echo "Variable is set"
+  ADB_CMD="adb -H ${ADB_IP}"
+else
+  echo "Variable is not set"
+  ADB_CMD="adb"
+fi
+
+$ADB_CMD root
 
 if [ $? != 0 ]; then
   echo "$0: adb root failed"
   exit 1
 fi
 
-adb shell mkdir -p /data/local/tmp/nntr_android_test/res
-adb shell mkdir -p /data/local/tmp/nntr_android_test/nntrainer_opencl_kernels
+$ADB_CMD shell mkdir -p /data/local/tmp/nntr_android_test/res
+$ADB_CMD shell mkdir -p /data/local/tmp/nntr_android_test/nntrainer_opencl_kernels
 
-adb push . /data/local/tmp/nntr_android_test
+$ADB_CMD push . /data/local/tmp/nntr_android_test
 
 if [ $? != 0 ]; then
   echo "$0: adb push failed to write to /data/local/tmp/nntr_android_test"
@@ -47,13 +55,13 @@ fi
 # meson build will unzip golden data for the unit tests
 popd
 if [ ! -d build ]; then
-  meson build -Dopenblas-num-threads=1  -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Domp-num-threads=1 -Denable-opencl=true -Dhgemm-experimental-kernel=false
+  meson build -Dopenblas-num-threads=1  -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Domp-num-threads=1 -Denable-opencl=true -Denable-ggml=true -Dhgemm-experimental-kernel=false
 else
   echo "warning: build has already been taken, this script tries to reconfigure and try building"
   pushd build
-  meson configure -Dopenblas-num-threads=1  -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Domp-num-threads=1 -Denable-opencl=true -Dhgemm-experimental-kernel=false
+  meson configure -Dopenblas-num-threads=1  -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Domp-num-threads=1 -Denable-opencl=true -Denable-ggml=true -Dhgemm-experimental-kernel=false
   popd
 fi
 
 cd build
-adb push res/ /data/local/tmp/nntr_android_test
+$ADB_CMD push res/ /data/local/tmp/nntr_android_test

--- a/tools/package_android.sh
+++ b/tools/package_android.sh
@@ -31,14 +31,14 @@ if [ ! -d builddir ]; then
     #default value of openblas num threads is 1 for android
     #enable-tflite-interpreter=false is just temporally until ci system is stabel
     #enable-opencl=true will compile OpenCL related changes or remove this option to exclude OpenCL compilations.
-  meson builddir -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Domp-num-threads=1 -Denable-opencl=true -Dhgemm-experimental-kernel=false ${filtered_args[@]}
+  meson builddir -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Domp-num-threads=1 -Denable-opencl=true -Dhgemm-experimental-kernel=false -Denable-ggml=true ${filtered_args[@]}
 else
   echo "warning: $TARGET/builddir has already been taken, this script tries to reconfigure and try building"
   pushd builddir
     #default value of openblas num threads is 1 for android
     #enable-tflite-interpreter=false is just temporally until ci system is stabel  
     #enable-opencl=true will compile OpenCL related changes or remove this option to exclude OpenCL compilations.
-    meson configure -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Domp-num-threads=1 -Denable-opencl=true -Dhgemm-experimental-kernel=false ${filtered_args[@]}
+    meson configure -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Domp-num-threads=1 -Denable-opencl=true -Dhgemm-experimental-kernel=false -Denable-ggml=true ${filtered_args[@]}
     meson --wipe
   popd
 fi

--- a/windows-native.ini
+++ b/windows-native.ini
@@ -29,3 +29,21 @@ buildtype = 'release'
 default_library = 'static'
 prefer_static = true
 b_vscrt = 'mt'
+
+[ggml:project built-in options]
+buildtype = 'release'
+default_library = 'static'
+prefer_static = true
+b_vscrt = 'mt'
+
+[ggml-cpu:project built-in options]
+buildtype = 'release'
+default_library = 'static'
+prefer_static = true
+b_vscrt = 'mt'
+
+[ggml-base:project built-in options]
+buildtype = 'release'
+default_library = 'static'
+prefer_static = true
+b_vscrt = 'mt'


### PR DESCRIPTION
This PR adds GEMM and GEMV for Q4_0 and Q4_K quantization using ggml:
- adds ggml repo to subprojects
- adds standalone unit tests for cpu_backend
- adds Q4_0 quantization
- adds Q4_K quantization
- adds GEMM and GEMM using Q4_0 Q4_K
- adds flag ENABLE_GGML

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped


