### PR TITLE
[FSU] update offset calc & Window page_size

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -117,7 +117,7 @@ void NetworkGraph::setExecutionOrder() {
 
     node->setExecutionOrder({forward_order, calc_gradient_order,
                              calc_derivative_order, apply_gradient_order});
-       }
+  }
 
   /**
    * This sets max execution order temporarily till model is initialized.
@@ -203,7 +203,7 @@ void NetworkGraph::setOutputConnections() {
 
       auto node_setting_output = getLayerNode(name);
       node_setting_output->setOutputConnection(idx, node->getName(), i);
-         }
+    }
   }
 }
 
@@ -274,8 +274,8 @@ void NetworkGraph::markNodesForBackwarding() {
         }
 
         must_support_backwarding.insert(conn->getName());
-           }
-          }
+      }
+    }
   }
 
   /** mark all the required nodes support backwarding */
@@ -562,7 +562,7 @@ LayerNode *NetworkGraph::computeBackwardEnd() {
       max_exec_order = cur_order;
       node = ln.get();
     }
-       }
+  }
 
   return node;
 }
@@ -578,8 +578,8 @@ void NetworkGraph::allocateTensors(ExecutionMode exec_mode_) {
      * layer and pass that as the max_exec_order ensuring that all tensors
      * with usage less than the max_exec_order are allocated.
      */
-      tensor_manager->allocateTensors(
-        std::get<0>((*(cend() - 1))->getExecutionOrder()));
+    tensor_manager->allocateTensors(
+      std::get<0>((*(cend() - 1))->getExecutionOrder()));
   else {
     /**
      * get the order of execution/usage order for the backwarding of the first
@@ -640,7 +640,7 @@ NetworkGraph::getUnsortedLayers(const std::string &input_layer,
         num_layers_remove_start++;
       else
         break;
-         }
+    }
   }
 
   /** copy the graph and return */
@@ -675,7 +675,7 @@ NetworkGraph::canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode) {
   if (lnode->getType() == InputLayer::type &&
       !istrequal(getTensorType()[2], "FP32")) {
     return InPlaceType::NONE;
-      }
+  }
 
   if (lnode->getType() == MultiOutLayer::type) {
     return InPlaceType::RESTRICTING;
@@ -690,7 +690,7 @@ NetworkGraph::canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode) {
       if (getLayerNode(input_name)->getInPlaceType() ==
           InPlaceType::RESTRICTING)
         return inplace_type;
-         }
+    }
     return InPlaceType::NON_RESTRICTING;
   }
   /** A case where it cannot operate in-place if there is a multi-out type
@@ -703,7 +703,7 @@ NetworkGraph::canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode) {
       if (getLayerNode(input_name)->getInPlaceType() ==
           InPlaceType::RESTRICTING)
         return InPlaceType::NONE;
-         }
+    }
     return inplace_type;
   }
 }
@@ -864,7 +864,7 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
       out_specs.begin(), out_specs.end(), [this](VarGradSpecV2 &spec) {
         spec.variable_spec.ls = TensorLifespan::FORWARD_GRAD_LIFESPAN;
       });
-      }
+  }
 
   const std::vector<Var_Grad *> &outputs = tensor_manager->requestTensors(
     out_specs, Manager::TensorGroupType::OUTPUT, lnode->getExecutionOrder(),
@@ -1033,7 +1033,7 @@ NetworkGraph::refinalizeContext(const std::shared_ptr<LayerNode> &lnode,
       out_specs.begin(), out_specs.end(), [this](VarGradSpecV2 &spec) {
         spec.variable_spec.ls = TensorLifespan::FORWARD_GRAD_LIFESPAN;
       });
-      }
+  }
 
   const std::vector<Var_Grad *> &outputs = tensor_manager->requestTensors(
     out_specs, Manager::TensorGroupType::OUTPUT, lnode->getExecutionOrder(),
@@ -1225,7 +1225,7 @@ int NetworkGraph::initialize(ExecutionMode mode,
       auto &sink_tensors = it->second;
       sink_tensors.resize(sink_node->getNumInputConnections());
       sink_tensors[conn->getIndex()] = outputs[i];
-         }
+    }
   }
 
   for (unsigned int idx = 0; idx < graph.size(); ++idx) {
@@ -1241,16 +1241,16 @@ int NetworkGraph::initialize(ExecutionMode mode,
               rc.getWeight(i).getName(),
               std::get<0>(lnode->getExecutionOrder()), true)) {
           rc.getWeightObject(i).setAsGradientFirstAccess();
-              }
+        }
         if (tensor_manager->isLastAccess(rc.getWeight(i).getName(),
                                          last_grad_access, true)) {
           rc.getWeightObject(i).setAsGradientLastAccess();
-                                         }
+        }
       } else {
         if (tensor_manager->isFirstAccess(rc.getWeightGrad(i).getName(),
                                           first_grad_access)) {
           rc.getWeightObject(i).setAsGradientFirstAccess();
-                                          }
+        }
         /**
          * if the gradient is to be clipped by global norm, then the last
          * access is by clipping itself. However, as clipping is not a layer
@@ -1267,7 +1267,7 @@ int NetworkGraph::initialize(ExecutionMode mode,
              tensor_manager->isSecondLastAccess(rc.getWeightGrad(i).getName(),
                                                 last_grad_access))) {
           rc.getWeightObject(i).setAsGradientLastAccess();
-                                                }
+        }
       }
     }
   }
@@ -1438,7 +1438,7 @@ int NetworkGraph::reinitialize(
       auto &sink_tensors = it->second;
       sink_tensors.resize(sink_node->getNumInputConnections());
       sink_tensors[conn->getIndex()] = outputs[i];
-         }
+    }
   }
 
   for (unsigned int idx = 0; idx < graph.size(); ++idx) {
@@ -1454,16 +1454,16 @@ int NetworkGraph::reinitialize(
               rc.getWeight(i).getName(),
               std::get<0>(lnode->getExecutionOrder()), true)) {
           rc.getWeightObject(i).setAsGradientFirstAccess();
-              }
+        }
         if (tensor_manager->isLastAccess(rc.getWeight(i).getName(),
                                          last_grad_access, true)) {
           rc.getWeightObject(i).setAsGradientLastAccess();
-                                         }
+        }
       } else {
         if (tensor_manager->isFirstAccess(rc.getWeightGrad(i).getName(),
                                           first_grad_access)) {
           rc.getWeightObject(i).setAsGradientFirstAccess();
-                                          }
+        }
         /**
          * if the gradient is to be clipped by global norm, then the last
          * access is by clipping itself. However, as clipping is not a layer
@@ -1480,7 +1480,7 @@ int NetworkGraph::reinitialize(
              tensor_manager->isSecondLastAccess(rc.getWeightGrad(i).getName(),
                                                 last_grad_access))) {
           rc.getWeightObject(i).setAsGradientLastAccess();
-                                                }
+        }
       }
     }
   }
@@ -1618,13 +1618,11 @@ void NetworkGraph::flushCacheExcept(unsigned int order) {
   tensor_manager->flushCacheExcept(order);
 }
 
-void NetworkGraph::LoadTensors(unsigned int order,
-                               unsigned int lookahead) {
+void NetworkGraph::LoadTensors(unsigned int order, unsigned int lookahead) {
   tensor_manager->LoadTensors(order, lookahead);
 }
 
-void NetworkGraph::LoadFsuTensors(unsigned int order,
-                               unsigned int lookahead) {
+void NetworkGraph::LoadFsuTensors(unsigned int order, unsigned int lookahead) {
   tensor_manager->LoadFsuTensors(order, lookahead);
 }
 
@@ -1632,9 +1630,7 @@ bool NetworkGraph::checkFsuLoadComplete(unsigned int order) {
   return tensor_manager->checkFsuLoadComplete(order);
 }
 
-void NetworkGraph::setupFSU() {
-  return tensor_manager->setupFsu();
-}
+void NetworkGraph::setupFSU() { return tensor_manager->setupFsu(); }
 
 bool NetworkGraph::checkLoadComplete(unsigned int order) {
   return tensor_manager->checkLoadComplete(order);

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -117,7 +117,7 @@ void NetworkGraph::setExecutionOrder() {
 
     node->setExecutionOrder({forward_order, calc_gradient_order,
                              calc_derivative_order, apply_gradient_order});
-  }
+       }
 
   /**
    * This sets max execution order temporarily till model is initialized.
@@ -203,7 +203,7 @@ void NetworkGraph::setOutputConnections() {
 
       auto node_setting_output = getLayerNode(name);
       node_setting_output->setOutputConnection(idx, node->getName(), i);
-    }
+         }
   }
 }
 
@@ -274,8 +274,8 @@ void NetworkGraph::markNodesForBackwarding() {
         }
 
         must_support_backwarding.insert(conn->getName());
-      }
-    }
+           }
+          }
   }
 
   /** mark all the required nodes support backwarding */
@@ -562,7 +562,7 @@ LayerNode *NetworkGraph::computeBackwardEnd() {
       max_exec_order = cur_order;
       node = ln.get();
     }
-  }
+       }
 
   return node;
 }
@@ -578,8 +578,8 @@ void NetworkGraph::allocateTensors(ExecutionMode exec_mode_) {
      * layer and pass that as the max_exec_order ensuring that all tensors
      * with usage less than the max_exec_order are allocated.
      */
-    tensor_manager->allocateTensors(
-      std::get<0>((*(cend() - 1))->getExecutionOrder()));
+      tensor_manager->allocateTensors(
+        std::get<0>((*(cend() - 1))->getExecutionOrder()));
   else {
     /**
      * get the order of execution/usage order for the backwarding of the first
@@ -640,7 +640,7 @@ NetworkGraph::getUnsortedLayers(const std::string &input_layer,
         num_layers_remove_start++;
       else
         break;
-    }
+         }
   }
 
   /** copy the graph and return */
@@ -675,7 +675,7 @@ NetworkGraph::canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode) {
   if (lnode->getType() == InputLayer::type &&
       !istrequal(getTensorType()[2], "FP32")) {
     return InPlaceType::NONE;
-  }
+      }
 
   if (lnode->getType() == MultiOutLayer::type) {
     return InPlaceType::RESTRICTING;
@@ -690,7 +690,7 @@ NetworkGraph::canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode) {
       if (getLayerNode(input_name)->getInPlaceType() ==
           InPlaceType::RESTRICTING)
         return inplace_type;
-    }
+         }
     return InPlaceType::NON_RESTRICTING;
   }
   /** A case where it cannot operate in-place if there is a multi-out type
@@ -703,7 +703,7 @@ NetworkGraph::canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode) {
       if (getLayerNode(input_name)->getInPlaceType() ==
           InPlaceType::RESTRICTING)
         return InPlaceType::NONE;
-    }
+         }
     return inplace_type;
   }
 }
@@ -864,7 +864,7 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
       out_specs.begin(), out_specs.end(), [this](VarGradSpecV2 &spec) {
         spec.variable_spec.ls = TensorLifespan::FORWARD_GRAD_LIFESPAN;
       });
-  }
+      }
 
   const std::vector<Var_Grad *> &outputs = tensor_manager->requestTensors(
     out_specs, Manager::TensorGroupType::OUTPUT, lnode->getExecutionOrder(),
@@ -1033,7 +1033,7 @@ NetworkGraph::refinalizeContext(const std::shared_ptr<LayerNode> &lnode,
       out_specs.begin(), out_specs.end(), [this](VarGradSpecV2 &spec) {
         spec.variable_spec.ls = TensorLifespan::FORWARD_GRAD_LIFESPAN;
       });
-  }
+      }
 
   const std::vector<Var_Grad *> &outputs = tensor_manager->requestTensors(
     out_specs, Manager::TensorGroupType::OUTPUT, lnode->getExecutionOrder(),
@@ -1225,7 +1225,7 @@ int NetworkGraph::initialize(ExecutionMode mode,
       auto &sink_tensors = it->second;
       sink_tensors.resize(sink_node->getNumInputConnections());
       sink_tensors[conn->getIndex()] = outputs[i];
-    }
+         }
   }
 
   for (unsigned int idx = 0; idx < graph.size(); ++idx) {
@@ -1241,16 +1241,16 @@ int NetworkGraph::initialize(ExecutionMode mode,
               rc.getWeight(i).getName(),
               std::get<0>(lnode->getExecutionOrder()), true)) {
           rc.getWeightObject(i).setAsGradientFirstAccess();
-        }
+              }
         if (tensor_manager->isLastAccess(rc.getWeight(i).getName(),
                                          last_grad_access, true)) {
           rc.getWeightObject(i).setAsGradientLastAccess();
-        }
+                                         }
       } else {
         if (tensor_manager->isFirstAccess(rc.getWeightGrad(i).getName(),
                                           first_grad_access)) {
           rc.getWeightObject(i).setAsGradientFirstAccess();
-        }
+                                          }
         /**
          * if the gradient is to be clipped by global norm, then the last
          * access is by clipping itself. However, as clipping is not a layer
@@ -1267,7 +1267,7 @@ int NetworkGraph::initialize(ExecutionMode mode,
              tensor_manager->isSecondLastAccess(rc.getWeightGrad(i).getName(),
                                                 last_grad_access))) {
           rc.getWeightObject(i).setAsGradientLastAccess();
-        }
+                                                }
       }
     }
   }
@@ -1438,7 +1438,7 @@ int NetworkGraph::reinitialize(
       auto &sink_tensors = it->second;
       sink_tensors.resize(sink_node->getNumInputConnections());
       sink_tensors[conn->getIndex()] = outputs[i];
-    }
+         }
   }
 
   for (unsigned int idx = 0; idx < graph.size(); ++idx) {
@@ -1454,16 +1454,16 @@ int NetworkGraph::reinitialize(
               rc.getWeight(i).getName(),
               std::get<0>(lnode->getExecutionOrder()), true)) {
           rc.getWeightObject(i).setAsGradientFirstAccess();
-        }
+              }
         if (tensor_manager->isLastAccess(rc.getWeight(i).getName(),
                                          last_grad_access, true)) {
           rc.getWeightObject(i).setAsGradientLastAccess();
-        }
+                                         }
       } else {
         if (tensor_manager->isFirstAccess(rc.getWeightGrad(i).getName(),
                                           first_grad_access)) {
           rc.getWeightObject(i).setAsGradientFirstAccess();
-        }
+                                          }
         /**
          * if the gradient is to be clipped by global norm, then the last
          * access is by clipping itself. However, as clipping is not a layer
@@ -1480,7 +1480,7 @@ int NetworkGraph::reinitialize(
              tensor_manager->isSecondLastAccess(rc.getWeightGrad(i).getName(),
                                                 last_grad_access))) {
           rc.getWeightObject(i).setAsGradientLastAccess();
-        }
+                                                }
       }
     }
   }
@@ -1619,8 +1619,21 @@ void NetworkGraph::flushCacheExcept(unsigned int order) {
 }
 
 void NetworkGraph::LoadTensors(unsigned int order,
-                               unsigned int remainder_lookahead) {
-  tensor_manager->LoadTensors(order, remainder_lookahead);
+                               unsigned int lookahead) {
+  tensor_manager->LoadTensors(order, lookahead);
+}
+
+void NetworkGraph::LoadFsuTensors(unsigned int order,
+                               unsigned int lookahead) {
+  tensor_manager->LoadFsuTensors(order, lookahead);
+}
+
+bool NetworkGraph::checkFsuLoadComplete(unsigned int order) {
+  return tensor_manager->checkFsuLoadComplete(order);
+}
+
+void NetworkGraph::setupFSU() {
+  return tensor_manager->setupFsu();
 }
 
 bool NetworkGraph::checkLoadComplete(unsigned int order) {

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -459,6 +459,10 @@ public:
    */
   void LoadTensors(const unsigned int order,
                    unsigned int remainder_lookahead = 0);
+  /**
+  * @brief Setup FSU, InActive FSU Element
+  */
+  bool setupFSU();
 
   /**
    * @brief check data of order is loaded

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -460,10 +460,10 @@ public:
   void LoadTensors(const unsigned int order,
                    unsigned int remainder_lookahead = 0);
   /**
- * @brief Load data of order to the device
- *
- * @param order execution order
- */
+   * @brief Load data of order to the device
+   *
+   * @param order execution order
+   */
   void LoadFsuTensors(unsigned int order, unsigned int lookahead);
 
   /**

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -460,9 +460,23 @@ public:
   void LoadTensors(const unsigned int order,
                    unsigned int remainder_lookahead = 0);
   /**
-  * @brief Setup FSU, InActive FSU Element
-  */
-  bool setupFSU();
+ * @brief Load data of order to the device
+ *
+ * @param order execution order
+ */
+  void LoadFsuTensors(unsigned int order, unsigned int lookahead);
+
+  /**
+   * @brief check data of order is loaded
+   *
+   * @param order execution order
+   */
+  bool checkFsuLoadComplete(unsigned int order);
+
+  /**
+   * @brief Setup FSU, InActive FSU Element
+   */
+  void setupFSU();
 
   /**
    * @brief check data of order is loaded

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -340,7 +340,11 @@ NeuralNetwork::~NeuralNetwork() {
   }
 }
 
-void NeuralNetwork::setupFSU() { model_graph.setupFSU(); }
+void NeuralNetwork::setupFSU() {
+  auto fsu_enable = std::get<props::Fsu>(model_flex_props);
+  if (fsu_enable)
+    model_graph.setupFSU();
+}
 
 /**
  * @brief     forward propagation using layers object which has layer

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -648,19 +648,15 @@ void NeuralNetwork::load(const std::string &file_path,
     std::vector<std::pair<size_t, size_t>> file_offset;
     // size_t start_from = sizeof(unsigned short);
     size_t start_from = 0;
-    for (auto node : model_graph.getLayerNodes()) {
-      auto weights = node->getRunContext().getWeights();
+    for (auto iter = model_graph.cbegin(); iter != model_graph.cend(); iter++) {
+      auto weights = (*iter)->getRunContext().getWeights();
       for (auto weight : weights) {
-        auto dim = weight->getDim();
+        auto dim = weight->getVariable();
+
         size_t size =
-          dim.getDataTypeSize() * dim.getDataLen(); // + scale_size * float
+          dim.getMemoryBytes(); // dim.getDataTypeSize() * dim.getDataLen();
 
-        // auto var_t = weight->getVariable();
-        // size_t size = var_t.getMemoryBytes();
-
-        // there is uint16 to save quantization bit for each tensor
         file_offset.emplace_back(std::make_pair(start_from, size));
-        // start_from += size + sizeof(unsigned short);
         start_from += size;
       }
     }

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -749,6 +749,11 @@ private:
    * @retval true if matches, false is error
    */
   bool validateInput(sharedConstTensors X);
+
+  /**
+   * @brief Setup FSU, InActive FSU Element
+   */
+  void setupFSU();
 };
 
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cache_elem.h
+++ b/nntrainer/tensor/cache_elem.h
@@ -105,6 +105,14 @@ public:
   }
 
   /**
+   * @brief set active status as false
+   */
+  void resetActive() {
+    std::scoped_lock lg(device_mutex);
+    active = false;
+  };
+
+  /**
    * @brief get length of cache element
    *
    * @return length of cache element in byte

--- a/nntrainer/tensor/cache_loader.cpp
+++ b/nntrainer/tensor/cache_loader.cpp
@@ -156,8 +156,8 @@ int CacheLoader::loadFsuAsync(unsigned int order, unsigned int look_ahead) {
   return 0;
 }
 
-void CacheLoader::setupFSU(unsigned int order) {
-  pool->setupFSU(order);
+void CacheLoader::setupFSU() {
+  pool->setupFSU();
   order_to_future.clear();
   order_to_future.clear();
 }

--- a/nntrainer/tensor/cache_loader.cpp
+++ b/nntrainer/tensor/cache_loader.cpp
@@ -128,4 +128,8 @@ unsigned int CacheLoader::getNumLoadedTensors() {
   return pool->getNumLoadedTensors();
 }
 
+void CacheLoader::setupFSU(unsigned int order) {
+  pool->setupFSU(order);
+}
+
 } // namespace nntrainer

--- a/nntrainer/tensor/cache_loader.cpp
+++ b/nntrainer/tensor/cache_loader.cpp
@@ -29,7 +29,7 @@ CacheLoader::CacheLoader(std::shared_ptr<CachePool> cache_pool) :
   pool(cache_pool),
   load_task_executor(nullptr),
   unload_task_executor(nullptr),
-  thread_pool_(nullptr){}
+  thread_pool_(nullptr) {}
 
 CacheLoader::~CacheLoader() {
   if (load_task_executor)

--- a/nntrainer/tensor/cache_loader.h
+++ b/nntrainer/tensor/cache_loader.h
@@ -122,6 +122,14 @@ public:
    */
   virtual unsigned int getNumLoadedTensors();
 
+  /**
+   * @brief setup FSU for the given execution order.
+   * This function will reset Actives at the given order.
+   *
+   * @param order execution order
+   */
+  virtual void setupFSU(unsigned int order);
+
 private:
   std::shared_ptr<CachePool> pool; /**< cache pool */
   TaskExecutor *load_task_executor;   /**< task executor */

--- a/nntrainer/tensor/cache_loader.h
+++ b/nntrainer/tensor/cache_loader.h
@@ -26,11 +26,32 @@
 
 namespace nntrainer {
 
+/**
+ * @class ThreadPool
+ * @brief ThreadPool class to manage multiple threads
+ */
 class ThreadPool {
 public:
+  /**
+   * @brief constructor of ThreadPool
+   *
+   * @param num_threads number of threads
+   */
   ThreadPool(size_t num_threads);
+
+  /**
+   * @brief destructor of ThreadPool
+   */
   ~ThreadPool();
 
+  /**
+   *
+   * @tparam F Function that work
+   * @tparam Args args for the function
+   * @param f functions
+   * @param args arguments for the function
+   * @return
+   */
   template <class F, class... Args>
   std::future<typename std::invoke_result<F, Args...>::type>
   EnqueueJob(F &&f, Args &&...args);
@@ -44,6 +65,9 @@ private:
 
   bool stop_all;
 
+  /**
+   * Thread Worker
+   */
   void WorkerThread();
 };
 

--- a/nntrainer/tensor/cache_loader.h
+++ b/nntrainer/tensor/cache_loader.h
@@ -151,9 +151,19 @@ public:
    */
   virtual void setupFSU();
 
-  bool checkFsuLoadComplete(unsigned int order);
+  /**
+   * @brief check data of order is loaded
+   *
+   * @param order execution order
+   */
+  virtual bool checkFsuLoadComplete(unsigned int order);
 
-  int loadFsuAsync(unsigned int order, unsigned int look_ahead);
+  /**
+   * @brief Load cache data with execution order for FSU
+   *
+   * @param order execution order
+   */
+  virtual int loadFsuAsync(unsigned int order, unsigned int look_ahead);
 
 private:
   std::shared_ptr<CachePool> pool;    /**< cache pool */

--- a/nntrainer/tensor/cache_loader.h
+++ b/nntrainer/tensor/cache_loader.h
@@ -148,9 +148,8 @@ public:
    * @brief setup FSU for the given execution order.
    * This function will reset Actives at the given order.
    *
-   * @param order execution order
    */
-  virtual void setupFSU(unsigned int order);
+  virtual void setupFSU();
 
   bool checkFsuLoadComplete(unsigned int order);
 

--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -213,15 +213,19 @@ std::shared_ptr<MemoryData> CachePool::getMemory(unsigned int id) {
   elems[id] = elem;
 
   std::string ords;
-  // for (auto &o : exe_order) {
-  //   exec_ids[o].push_back(id);
-  //   ords.append(std::to_string(o));
-  //   ords.append(" ");
-  // }
-  exec_ids[exe_order[0]].push_back(id);
-  ords.append(std::to_string(exe_order[0]));
-  ords.append(" ");
 
+  if (execution_mode_ == ml::train::ExecutionMode::INFERENCE) {
+    exec_ids[exe_order[0]].push_back(id);
+    std::cout << exec_ids.size() << std::endl;
+    ords.append(std::to_string(exe_order[0]));
+    ords.append(" ");
+  } else {
+    for (auto &o : exe_order) {
+      exec_ids[o].push_back(id);
+      ords.append(std::to_string(o));
+      ords.append(" ");
+    }
+  }
   ml_logd("[%d] exe_order(%s), offset: %llu, len: %zu", id, ords.c_str(),
           (long long unsigned int)offset, len);
 

--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -342,7 +342,7 @@ unsigned int CachePool::getNumLoadedTensors() {
 
 void CachePool::setupFSU() {
   for (auto active : actives) {
-      active->resetActive();
+    active->resetActive();
   }
 }
 

--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -213,11 +213,15 @@ std::shared_ptr<MemoryData> CachePool::getMemory(unsigned int id) {
   elems[id] = elem;
 
   std::string ords;
-  for (auto &o : exe_order) {
-    exec_ids[o].push_back(id);
-    ords.append(std::to_string(o));
-    ords.append(" ");
-  }
+  // for (auto &o : exe_order) {
+  //   exec_ids[o].push_back(id);
+  //   ords.append(std::to_string(o));
+  //   ords.append(" ");
+  // }
+  exec_ids[exe_order[0]].push_back(id);
+  ords.append(std::to_string(exe_order[0]));
+  ords.append(" ");
+
   ml_logd("[%d] exe_order(%s), offset: %llu, len: %zu", id, ords.c_str(),
           (long long unsigned int)offset, len);
 
@@ -336,7 +340,7 @@ unsigned int CachePool::getNumLoadedTensors() {
   return swap_device->getNumLoadedTensors();
 }
 
-void CachePool::setupFSU(unsigned int order) {
+void CachePool::setupFSU() {
   for (auto active : actives) {
       active->resetActive();
   }

--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -336,6 +336,12 @@ unsigned int CachePool::getNumLoadedTensors() {
   return swap_device->getNumLoadedTensors();
 }
 
+void CachePool::setupFSU(unsigned int order) {
+  for (auto active : actives) {
+      active->resetActive();
+  }
+}
+
 void CachePool::setFsuWeightPath(std::string path) {
   auto start_with = [](const std::string &str, const std::string &prefix) {
     return str.size() >= prefix.size() &&

--- a/nntrainer/tensor/cache_pool.h
+++ b/nntrainer/tensor/cache_pool.h
@@ -184,6 +184,14 @@ public:
   virtual unsigned int getNumLoadedTensors();
 
   /**
+   * @brief setup FSU for the given execution order.
+   * This function will reset Actives at the given order.
+   *
+   * @param order execution order
+   */
+  void setupFSU(unsigned int order);
+
+  /**
    * @brief set FSU weight path
    *
    * @param path FSU weight file path

--- a/nntrainer/tensor/cache_pool.h
+++ b/nntrainer/tensor/cache_pool.h
@@ -187,9 +187,8 @@ public:
    * @brief setup FSU for the given execution order.
    * This function will reset Actives at the given order.
    *
-   * @param order execution order
    */
-  void setupFSU(unsigned int order);
+  void setupFSU();
 
   /**
    * @brief set FSU weight path

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -815,7 +815,8 @@ bool Manager::checkUnloadComplete(unsigned int order) {
 
 void Manager::LoadFsuTensors(unsigned int order, unsigned int lookahead) {
 
-  auto enqueFsuTasks = [&](unsigned int execution_order, unsigned int look_ahead) {
+  auto enqueFsuTasks = [&](unsigned int execution_order,
+                           unsigned int look_ahead) {
     weight_pool.loadFsuWeight(order, look_ahead);
   };
   if (order <= max_exec_order) {
@@ -952,8 +953,6 @@ bool Manager::checkFsuLoadComplete(unsigned int order) {
   return weight_pool->checkFsuLoadComplete(order);
 }
 
-void Manager::setupFsu() {
-  return weight_pool.setupFSU();
-}
+void Manager::setupFsu() { return weight_pool.setupFSU(); }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -816,11 +816,12 @@ bool Manager::checkUnloadComplete(unsigned int order) {
 void Manager::LoadFsuTensors(unsigned int order, unsigned int lookahead) {
 
   auto enqueFsuTasks = [&](unsigned int execution_order,
-                           unsigned int look_ahead) {
-    weight_pool.loadFsuWeight(order, look_ahead);
+                           unsigned int lookahead) {
+    weight_pool.loadFsuWeight(execution_order, lookahead);
   };
+
   if (order <= max_exec_order) {
-    enqueFsuTasks(order, look_ahead);
+    enqueFsuTasks(order, lookahead);
   }
 }
 
@@ -950,7 +951,7 @@ unsigned int Manager::getNumLoadedTensorPoolTensors() {
 }
 
 bool Manager::checkFsuLoadComplete(unsigned int order) {
-  return weight_pool->checkFsuLoadComplete(order);
+  return weight_pool.checkFsuLoadComplete(order);
 }
 
 void Manager::setupFsu() { return weight_pool.setupFSU(); }

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -515,13 +515,13 @@ public:
   bool checkUnloadComplete(unsigned int order);
 
   /**
- * @brief load cache data for the execution order
- *
- * @param order execution order
- * @param lookahead look ahead value to load from execution order
- * @note preloading loads execution order data asynchronously,
- *       for lookahead size.
- */
+   * @brief load cache data for the execution order
+   *
+   * @param order execution order
+   * @param lookahead look ahead value to load from execution order
+   * @note preloading loads execution order data asynchronously,
+   *       for lookahead size.
+   */
   void LoadFsuTensors(unsigned int order, unsigned int lookahead);
 
   /**

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -492,6 +492,7 @@ public:
    * @brief load cache data for the execution order
    *
    * @param order execution order
+   * @param remainder_lookahead remain look_ahead
    * @note preloading loads execution order data asynchronously,
    *       for lookahead size.
    */
@@ -512,6 +513,16 @@ public:
    * @note preloading tensors for execution order.
    */
   bool checkUnloadComplete(unsigned int order);
+
+  /**
+ * @brief load cache data for the execution order
+ *
+ * @param order execution order
+ * @param lookahead look ahead value to load from execution order
+ * @note preloading loads execution order data asynchronously,
+ *       for lookahead size.
+ */
+  void LoadFsuTensors(unsigned int order, unsigned int lookahead);
 
   /**
    * @brief flush load data for the execution order
@@ -551,6 +562,19 @@ public:
    * @return Number of Loaded TensorPool Tensor
    */
   unsigned int getNumLoadedTensorPoolTensors();
+
+  /**
+   * @brief check completion of load data for the execution order
+   *
+   * @param order execution order
+   * @note preloading tensors for execution order.
+   */
+  bool checkFsuLoadComplete(unsigned int order);
+
+  /**
+   * @brief Setup FSU, InActive FSU Element
+   */
+  void setupFsu();
 
   /**
    * @brief set FSU weight path
@@ -602,8 +626,6 @@ private:
    * completed id>>
    */
   std::map<unsigned int, std::tuple<int, int>> async_load_tensor;
-
-  std::map<unsigned int, bool> complete_load_tensor;
 
   std::map<unsigned int, std::tuple<int, int>> async_unload_tensor;
 

--- a/nntrainer/tensor/swap_device.cpp
+++ b/nntrainer/tensor/swap_device.cpp
@@ -70,7 +70,7 @@ void *SwapDevice::getBuffer(off_t offset, size_t size, void *memory_ptr,
 #if defined(_WIN32)
   SYSTEM_INFO sysInfo;
   GetSystemInfo(&sysInfo);
-  auto page_size = sysInfo.dwPageSize;
+  auto page_size = sysInfo.dwAllocationGranularity;
 #else
   auto page_size = sysconf(_SC_PAGE_SIZE);
 #endif

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -475,6 +475,17 @@ void TensorPool::loadCacheExec(unsigned int order) {
     cache_loader->load(order);
 }
 
+int TensorPool::loadFsuWeight(unsigned int order, unsigned int look_ahead) {
+  if (dynamic_cast<CachePool *>(mem_pool.get()))
+    return cache_loader->loadFsuAsync(order, look_ahead);
+  else
+    return 0;
+}
+
+bool TensorPool::checkFsuLoadComplete(unsigned int order) {
+  return cache_loader->checkFsuLoadComplete(order);
+}
+
 int TensorPool::loadCacheExecAsync(
   unsigned int order, TaskExecutor::CompleteCallback complete_callback) {
   if (dynamic_cast<CachePool *>(mem_pool.get()))
@@ -502,8 +513,8 @@ unsigned int TensorPool::getNumLoadedTensors() {
   return cache_loader->getNumLoadedTensors();
 }
 
-void TensorPool::setupFSU(unsigned int order) {
-  return cache_loader->setupFSU(order);
+void TensorPool::setupFSU() {
+  return cache_loader->setupFSU();
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -502,4 +502,8 @@ unsigned int TensorPool::getNumLoadedTensors() {
   return cache_loader->getNumLoadedTensors();
 }
 
+void TensorPool::setupFSU(unsigned int order) {
+  return cache_loader->setupFSU(order);
+}
+
 } // namespace nntrainer

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -513,8 +513,6 @@ unsigned int TensorPool::getNumLoadedTensors() {
   return cache_loader->getNumLoadedTensors();
 }
 
-void TensorPool::setupFSU() {
-  return cache_loader->setupFSU();
-}
+void TensorPool::setupFSU() { return cache_loader->setupFSU(); }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -284,6 +284,21 @@ public:
   void loadCacheExec(unsigned int order);
 
   /**
+ * @brief load cache data by execution order
+ *
+ * @param order execution order
+ */
+  int loadFsuWeight(unsigned int order, unsigned int look_ahead);
+
+  /**
+   * @brief check if tensors are loaded for the given execution order.
+   *
+   * @param order target execution order
+   * @return bool true if tensors are loaded, false otherwise.
+   */
+  bool checkFsuLoadComplete(unsigned int order);
+
+  /**
    * @brief load cache data by execution order
    *
    * @param order execution order
@@ -319,9 +334,8 @@ public:
    * @brief setup FSU for the given execution order.
    * This function will reset Actives at the given order.
    *
-   * @param order execution order
    */
-  void setupFSU(unsigned int order);
+  void setupFSU();
 
   /**
    * @brief set FSU weight path

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -284,10 +284,10 @@ public:
   void loadCacheExec(unsigned int order);
 
   /**
- * @brief load cache data by execution order
- *
- * @param order execution order
- */
+   * @brief load cache data by execution order
+   *
+   * @param order execution order
+   */
   int loadFsuWeight(unsigned int order, unsigned int look_ahead);
 
   /**

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -316,6 +316,14 @@ public:
   unsigned int getNumLoadedTensors();
 
   /**
+   * @brief setup FSU for the given execution order.
+   * This function will reset Actives at the given order.
+   *
+   * @param order execution order
+   */
+  void setupFSU(unsigned int order);
+
+  /**
    * @brief set FSU weight path
    *
    * @param path FSU weight file path


### PR DESCRIPTION
[FSU] update offset calc & Window page_size

- Update offset calc with getmemoryBytes()
- Update Window page_size to  sysInfo.dwAllocationGranularity;

ref : https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffile

[in] dwFileOffsetLow

A low-order DWORD of the file offset where the view is to begin. The combination of the high and low offsets must specify an offset within the file mapping. They must also match the virtual memory allocation granularity of the system. That is, the offset must be a multiple of the VirtualAlloc allocation granularity. To obtain the VirtualAlloc memory allocation granularity of the system, use the [GetSystemInfo](https://learn.microsoft.com/en-us/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getsysteminfo) function, which fills in the members of a [SYSTEM_INFO](https://learn.microsoft.com/en-us/windows/desktop/api/sysinfoapi/ns-sysinfoapi-system_info) structure.

[in] dwNumberOfBytesToMap

The number of bytes of a file mapping to map to the view. All bytes must be within the maximum size specified by [CreateFileMapping](https://learn.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-createfilemappinga). If this parameter is 0 (zero), the mapping extends from the specified offset to the end of the file mapping.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Donghak PARK <donghak.park@samsung.com>