### PR TITLE
[Action] Update Ubuntu 20.04 to 22.04 on Yocto Build Test

### DIFF
--- a/.github/workflows/yocto.yml
+++ b/.github/workflows/yocto.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build with Yocto devtool on Ubuntu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -23,7 +23,7 @@ jobs:
       run: |
         echo "::group::apt-get install"
         sudo apt-get update
-        sudo apt-get install sudo curl diffstat python2.7 locales bash-completion qemu gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint3 xterm python3-subunit mesa-common-dev gzip libglib2.0-dev libjson-glib-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev googletest liborc-0.4-dev flex bison libopencv-dev pkg-config python3-dev python3-numpy git
+        sudo apt-get install sudo curl diffstat python2.7 locales bash-completion qemu gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint xterm python3-subunit mesa-common-dev gzip libglib2.0-dev libjson-glib-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev googletest liborc-0.4-dev flex bison libopencv-dev pkg-config python3-dev python3-numpy git
         sudo ln -sf python2.7 /usr/bin/python
         echo "::endgroup::"
         echo "::group::Locale Setup"


### PR DESCRIPTION
This PR changes Ubuntu version from 20.04 to 22.04.
Note that Ubuntu 20.04 LTS runner is removed from the Git Action.

**Self-evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test:   [ ]Passed [ ]Failed [X]Skipped
