### PR TITLE
[Fix] Fix x86 backend on Windows

### DIFF
--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -17,7 +17,8 @@
 #if defined(__aarch64__) || defined(__ARM_ARCH_7A__) ||                        \
   defined(__ANDROID__) || defined(__arm__)
 #include <arm_compute_backend.h>
-#elif defined(__x86_64__) || defined(__i586__)
+#elif defined(__x86_64__) || defined(__i586__) || defined(_M_X64) ||           \
+  defined(_M_IX86)
 #include <x86_compute_backend.h>
 #else
 #include <fallback.h>


### PR DESCRIPTION
This PR fix selection of proper CPU backend on Windows

__x86_64__ macro is not recognized by MSVC which cause that instead of selecting 

<x86_compute_backend.h> we chose <fallback.h> in backend selection

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

