### PR TITLE
Bugfix: GGML Build Error in NNTrainer on Ubuntu 20.04

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -473,6 +473,22 @@ if get_option('enable-ggml')
   ggml_options.add_cmake_defines({'GGML_BUILD_EXAMPLES': false})
   ggml_options.add_cmake_defines({'CMAKE_INSTALL_LIBDIR': nntrainer_libdir / 'arm64-v8a'})
   ggml_options.append_compile_args('c', ['-Wno-error=maybe-uninitialized', '-Wno-error=pointer-to-int-cast'])
+
+  if arch == 'x86_64'
+    if cc.has_argument('-march=x86-64-v2')
+      cpu_type = 'x86-64-v2'
+    elif cc.has_argument('-march=haswell')
+      cpu_type = 'haswell'
+    else
+      cpu_type = 'x86-64'
+    endif
+  endif
+
+  message('Auto-detected safe CPU tuning: ' + cpu_type)
+
+  ggml_options.append_compile_args('c', '-march=' + cpu_type)
+  ggml_options.append_compile_args('cpp', '-march=' + cpu_type)
+
   ggml_proj = cmake.subproject('ggml', options: ggml_options, required: true)
   ggml_dep = [
     ggml_proj.dependency('ggml-base'),

--- a/meson.build
+++ b/meson.build
@@ -471,7 +471,9 @@ if get_option('enable-ggml')
   ggml_options.add_cmake_defines({'BUILD_SHARED_LIBS': host_machine.system() != 'windows'})
   ggml_options.add_cmake_defines({'GGML_BUILD_TESTS': false})
   ggml_options.add_cmake_defines({'GGML_BUILD_EXAMPLES': false})
-  ggml_options.add_cmake_defines({'CMAKE_INSTALL_LIBDIR': nntrainer_libdir / 'arm64-v8a'})
+  if get_option('platform') == 'android'
+    ggml_options.add_cmake_defines({'CMAKE_INSTALL_LIBDIR': nntrainer_libdir / 'arm64-v8a'})
+  endif
   ggml_options.append_compile_args('c', ['-Wno-error=maybe-uninitialized', '-Wno-error=pointer-to-int-cast'])
 
   if arch == 'x86_64'


### PR DESCRIPTION
This pull request addresses an error that occurred during the GGML build in NNTrainer.
The error reported unsupported instructions from AVX512, which happens exclusively on Ubuntu 20.04 with assembler version 2.34.
This change restricts the use of any AVX-512 instructions, allowing only up to AVX2 level instructions.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped