### PR TITLE
[Windows] Fix meson version on Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install submodules
         run: git submodule sync && git submodule update --init --recursive
       - name: Install Python Dependencies
-        run: pip install meson ninja
+        run: pip install meson==1.7.2 ninja
       - name: Prepare MSVC
         uses: bus1/cabuild/action/msdevshell@v1
         with:


### PR DESCRIPTION
Windows build on CI on Windows fail due to regression in meson 1.8.0. (add /WX option to subprojects).
Use latest stable version of meson till it will be fixed.
