### PR TITLE
[FSU] Optimize FSU Feature

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -1626,9 +1626,7 @@ bool NetworkGraph::checkLoadComplete(unsigned int order) {
   return tensor_manager->checkLoadComplete(order);
 }
 
-bool NetworkGraph::inActive(unsigned int order) {
-  return tensor_manager->inActive(order);
-}
+bool NetworkGraph::inActiveAll() { return tensor_manager->inActiveAll(); }
 
 bool NetworkGraph::checkUnloadComplete(unsigned int order) {
   return tensor_manager->checkUnloadComplete(order);

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -468,10 +468,10 @@ public:
   bool checkLoadComplete(const unsigned int order);
 
   /**
-   * @brief inactive the elem
+   * @brief inactive all element
    *
    */
-  bool inActive(unsigned int order);
+  bool inActiveAll();
 
   /**
    * @brief check data of order is Unloaded

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -425,7 +425,7 @@ sharedConstTensors NeuralNetwork::forwarding(sharedConstTensors input,
   model_graph.setInputsLabels(input, label);
   auto fsu_enable = std::get<props::Fsu>(model_flex_props);
   if (fsu_enable) {
-    model_graph.inActive(0);
+    model_graph.inActiveAll();
   }
   return forwarding(training);
 }
@@ -1021,7 +1021,7 @@ sharedConstTensors NeuralNetwork::incremental_inference(
   model_graph.setInputsLabels({}, {});
   auto fsu_enable = std::get<props::Fsu>(model_flex_props);
   if (fsu_enable) {
-    model_graph.inActive(0);
+    model_graph.inActiveAll();
   }
   return out;
 }

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -395,7 +395,7 @@ sharedConstTensors NeuralNetwork::forwarding(
       **/
       model_graph.checkLoadComplete(f);
       node->forwarding(training);
-      model_graph.inActive(f);
+      // model_graph.inActive(f);
       model_graph.LoadTensors(f + lookahead);
     }
   };
@@ -424,7 +424,10 @@ sharedConstTensors NeuralNetwork::forwarding(sharedConstTensors input,
     << " target_batch: " << current_batch;
 
   model_graph.setInputsLabels(input, label);
-
+  auto fsu_enable = std::get<props::Fsu>(model_flex_props);
+  if (fsu_enable) {
+    model_graph.inActive(0);
+  }
   return forwarding(training);
 }
 
@@ -454,7 +457,7 @@ sharedConstTensors NeuralNetwork::incremental_forwarding(
     } else {
       model_graph.checkLoadComplete(f);
       node->incremental_forwarding(from, to, training);
-      model_graph.inActive(f);
+      // model_graph.inActive(f);
       model_graph.LoadTensors(f + lookahead);
     }
   };
@@ -1018,7 +1021,10 @@ sharedConstTensors NeuralNetwork::incremental_inference(
   /** @todo: deallocate tensor after incremental inference **/
   /** Clear the set inputs and labels */
   model_graph.setInputsLabels({}, {});
-
+  auto fsu_enable = std::get<props::Fsu>(model_flex_props);
+  if (fsu_enable) {
+    model_graph.inActive(0);
+  }
   return out;
 }
 

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -395,7 +395,6 @@ sharedConstTensors NeuralNetwork::forwarding(
       **/
       model_graph.checkLoadComplete(f);
       node->forwarding(training);
-      // model_graph.inActive(f);
       model_graph.LoadTensors(f + lookahead);
     }
   };
@@ -457,7 +456,6 @@ sharedConstTensors NeuralNetwork::incremental_forwarding(
     } else {
       model_graph.checkLoadComplete(f);
       node->incremental_forwarding(from, to, training);
-      // model_graph.inActive(f);
       model_graph.LoadTensors(f + lookahead);
     }
   };

--- a/nntrainer/tensor/cache_loader.cpp
+++ b/nntrainer/tensor/cache_loader.cpp
@@ -194,7 +194,7 @@ int CacheLoader::cancelAsync(int id) {
   return ML_ERROR_NONE;
 }
 
-unsigned int CacheLoader::inActive(unsigned int order) {
+unsigned int CacheLoader::inActiveAll() {
   auto order_to_execids = pool->getExecIDsAll();
   std::list<std::shared_ptr<CacheElem>> actives = pool->getActiveElems();
   actives.clear();

--- a/nntrainer/tensor/cache_loader.cpp
+++ b/nntrainer/tensor/cache_loader.cpp
@@ -195,19 +195,19 @@ int CacheLoader::cancelAsync(int id) {
 }
 
 unsigned int CacheLoader::inActive(unsigned int order) {
-  auto ids = pool->getExecIDsAll();
+  auto order_to_execids = pool->getExecIDsAll();
   std::list<std::shared_ptr<CacheElem>> actives = pool->getActiveElems();
   actives.clear();
 
-  for (auto id : ids) {
-    auto exec_id = id.second;
-    for (auto &id : exec_id) {
-      std::shared_ptr<CacheElem> elem = pool->getCacheElem(id);
+  for (auto element : order_to_execids) {
+    auto exec_ids = element.second;
+    for (auto &element_id : exec_ids) {
+      std::shared_ptr<CacheElem> elem = pool->getCacheElem(element_id);
       int load_task_id = elem->getLoadTaskID();
       if (load_task_id >= 0) {
         load_task_executor->releaseTask(load_task_id);
         elem->setLoadTaskID(-1);
-        states[id] = LoadState::Unloading;
+        states[element_id] = LoadState::Unloading;
       }
       elem->inActive();
     }

--- a/nntrainer/tensor/cache_loader.h
+++ b/nntrainer/tensor/cache_loader.h
@@ -130,11 +130,10 @@ public:
   virtual int cancelAsync(int id);
 
   /**
-   * @brief set Inactive elems in order
+   * @brief set Inactive All elems
    *
    */
-
-  unsigned int inActive(unsigned int order);
+  unsigned int inActiveAll();
 
   /**
    * @brief wait for the load tasks in order are complete

--- a/nntrainer/tensor/cache_pool.cpp
+++ b/nntrainer/tensor/cache_pool.cpp
@@ -131,15 +131,6 @@ CachePool::~CachePool() {
   }
 }
 
-void CachePool::inActive(unsigned int order) {
-
-  auto exec_id = exec_ids[order];
-  for (auto &id : exec_id) {
-    actives.remove(elems[id]);
-    elems[id]->inActive();
-  }
-}
-
 void CachePool::allocate() {
   NNTR_THROW_IF(swap_device->isOperating(), std::runtime_error)
     << "Cache pool is already allocated";

--- a/nntrainer/tensor/cache_pool.h
+++ b/nntrainer/tensor/cache_pool.h
@@ -22,6 +22,7 @@
 #include <common.h>
 #include <memory_pool.h>
 #include <swap_device.h>
+#include <unordered_set>
 
 namespace nntrainer {
 
@@ -35,7 +36,7 @@ public:
     std::unordered_map<unsigned int,
                        std::shared_ptr<CacheElem>>; /**< cache id, cache elem */
   using CacheElemsIter = CacheElems::iterator;
-  using ExecIds = std::set<unsigned int>;
+  using ExecIds = std::unordered_set<unsigned int>;
   using ExecIdsIter = ExecIds::iterator;
 
   /**
@@ -220,9 +221,16 @@ public:
    * @param order Execution order
    * @return Tensor id set
    */
-  std::set<unsigned int> getExecIDs(unsigned int order) {
+  std::unordered_set<unsigned int> getExecIDs(unsigned int order) {
     return exec_ids[order];
   }
+
+  /**
+   * @brief get Active Cache Elem lists All
+   *
+   * @return Active Cache Elem list All
+   */
+  std::unordered_map<unsigned int, ExecIds> getExecIDsAll() { return exec_ids; }
 
   /**
    * @brief get Active Cache Elem lists

--- a/nntrainer/tensor/cache_pool.h
+++ b/nntrainer/tensor/cache_pool.h
@@ -67,13 +67,6 @@ public:
   virtual ~CachePool();
 
   /**
-   * @brief inactive elements
-   *
-   * @param order order to inactive
-   */
-  void inActive(unsigned int order);
-
-  /**
    * @brief Do the allocation of cache
    *
    */

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -915,8 +915,6 @@ void Manager::finalizeTensorPool(TensorPool &pool, unsigned int start,
   }
 }
 
-unsigned int Manager::inActive(unsigned int order) {
-  return weight_pool.inActive(order);
-}
+unsigned int Manager::inActiveAll() { return weight_pool.inActiveAll(); }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -550,10 +550,10 @@ public:
   bool isMixedPrecision() { return !istrequal(tensor_dtype[0], "FP32"); }
 
   /**
-   * @brief set Inactive elems in order
+   * @brief set Inactive All elems
    *
    */
-  unsigned int inActive(unsigned int order);
+  unsigned int inActiveAll();
 
   /**
    * @brief set FSU weight path

--- a/nntrainer/tensor/task_executor.cpp
+++ b/nntrainer/tensor/task_executor.cpp
@@ -112,12 +112,13 @@ void TaskExecutor::submitTasks(const std::vector<TaskDesc> &tasks) {
 
 bool TaskExecutor::cancel(int id) {
   std::lock_guard<std::mutex> lock(queue_mutex);
+
   auto it = cancel_map.find(id);
-  if (it != cancel_map.end()) {
-    *(it->second) = true;
-    return true;
+  if (it == cancel_map.end() || it == nullptr) {
+    return false;
   }
-  return false;
+  *(it->second) = true;
+  return true;
 }
 
 void TaskExecutor::wait(int id) {

--- a/nntrainer/tensor/task_executor.cpp
+++ b/nntrainer/tensor/task_executor.cpp
@@ -114,7 +114,7 @@ bool TaskExecutor::cancel(int id) {
   std::lock_guard<std::mutex> lock(queue_mutex);
 
   auto it = cancel_map.find(id);
-  if (it == cancel_map.end() || it == nullptr) {
+  if (it == cancel_map.end()) {
     return false;
   }
   *(it->second) = true;

--- a/nntrainer/tensor/task_executor.h
+++ b/nntrainer/tensor/task_executor.h
@@ -173,9 +173,9 @@ private:
   std::string name;
   std::vector<std::thread> workers;
   std::queue<Task> task_queue;
-  std::map<int, std::shared_ptr<std::atomic_bool>> cancel_map;
-  std::map<int, std::shared_future<void>> future_map;
-  std::map<int, bool> task_started;
+  std::unordered_map<int, std::shared_ptr<std::atomic_bool>> cancel_map;
+  std::unordered_map<int, std::shared_future<void>> future_map;
+  std::unordered_map<int, bool> task_started;
   std::mutex queue_mutex;
   std::condition_variable cond_var;
   std::condition_variable task_started_cv;

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -507,8 +507,6 @@ void TensorPool::loadCacheCancel(int id) {
   cache_loader->cancelAsync(id);
 }
 
-unsigned int TensorPool::inActive(unsigned int order) {
-  return cache_loader->inActive(order);
-}
+unsigned int TensorPool::inActiveAll() { return cache_loader->inActiveAll(); }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -317,10 +317,10 @@ public:
   void loadCacheCancel(int id);
 
   /**
-   * @brief This function will reset Actives at the given order.
+   * @brief This function will reset Actives
    *
    */
-  unsigned int inActive(unsigned int order);
+  unsigned int inActiveAll();
 
   /**
    * @brief set FSU weight path


### PR DESCRIPTION
In this PR
---

There are several Point for improvement in the current FSU Logic. the following improvements have been made:

1. Change the InActivate timing - now, inActivate is being performed within forwarding after each layer execution, but this does not make sense within a single inference. Therefore, we have changed it to inActivate after one complete inference is finished.
2. early exit in Task Cancle
3. Change map to unordered_map - we don't need sorted list for task executor

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
5. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Donghak PARK <donghak.park@samsung.com>