### PR TITLE
[CI] Add clang build to continues integration

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build_clang.yml
+++ b/.github/workflows/ubuntu_clean_meson_build_clang.yml
@@ -1,0 +1,37 @@
+name: "Build Test - Ubuntu Meson (clang)"
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  meson_test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: install additional package from PPA for testing
+      run: sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
+    - name: install minimal requirements
+      run: sudo apt-get update && sudo apt-get install -y libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
+    - name: install additional packages for features
+      run: sudo apt-get install -y python3-dev python3-numpy python3
+    - name: Install llvm
+      run: sudo apt install -y llvm libomp-dev
+    - name: Install submodules
+      run: git submodule sync && git submodule update --init --recursive
+    - name: Install build systems
+      run: sudo apt install meson ninja-build
+    - name: Prepare Build
+      run: meson setup --native-file linux-native-clang.ini builddir
+    - name: Run Build
+      run: meson compile -C builddir
+    - name: Run Test Suite
+      run: meson test -C builddir

--- a/linux-native-clang.ini
+++ b/linux-native-clang.ini
@@ -1,0 +1,10 @@
+[built-in options]
+werror=false
+
+[binaries]
+c = 'clang'
+cpp = 'clang++'
+ar = 'llvm-ar'
+c_ld = 'lld'
+cpp_ld = 'lld'
+strip = 'llvm-strip'

--- a/nntrainer/engine.h
+++ b/nntrainer/engine.h
@@ -49,7 +49,7 @@ protected:
 
   static void add_default_object(Engine &eg);
 
-  static void registerContext(std::string name, nntrainer::Context *context) {
+  void registerContext(std::string name, nntrainer::Context *context) {
     const std::lock_guard<std::mutex> lock(engine_mutex);
 
     std::transform(name.begin(), name.end(), name.begin(),
@@ -99,7 +99,7 @@ public:
    * @return Context Pointer : for register Object factory, casting might be
    * needed.
    */
-  static nntrainer::Context *getRegisteredContext(std::string name) {
+  nntrainer::Context *getRegisteredContext(std::string name) const {
 
     std::transform(name.begin(), name.end(), name.begin(),
                    [](unsigned char c) { return std::tolower(c); });
@@ -111,8 +111,7 @@ public:
     return engines.at(name);
   }
 
-  static std::unordered_map<std::string,
-                            std::shared_ptr<nntrainer::MemAllocator>>
+  std::unordered_map<std::string, std::shared_ptr<nntrainer::MemAllocator>>
   getAllocators() {
     return allocator;
   }
@@ -257,10 +256,9 @@ private:
    * @brief map for Context and Context name
    *
    */
-  static inline std::unordered_map<std::string, nntrainer::Context *> engines;
+  std::unordered_map<std::string, nntrainer::Context *> engines;
 
-  static inline std::unordered_map<std::string,
-                                   std::shared_ptr<nntrainer::MemAllocator>>
+  std::unordered_map<std::string, std::shared_ptr<nntrainer::MemAllocator>>
     allocator;
 
   std::string working_path_base;

--- a/test/tizen_capi/unittest_tizen_capi.cpp
+++ b/test/tizen_capi/unittest_tizen_capi.cpp
@@ -929,9 +929,9 @@ TEST(nntrainer_capi_nnmodel, getWeight_01) {
   ml_tensors_info_h weight_info;
   ml_tensors_data_h weights;
   unsigned int num_weights;
-  unsigned int weight_dim_expected[2][MAXDIM] = {{1, 1, 62720, 10},
-                                                 {1, 1, 1, 10}};
-  unsigned int dim[2][MAXDIM];
+  const unsigned int weight_dim_expected[2][MAXDIM] = {{1, 1, 62720, 10},
+                                                       {1, 1, 1, 10}};
+  ml_tensor_dimension dim;
 
   ScopedIni s("capi_test_get_weight_01",
               {model_base, optimizer, dataset, inputlayer, outputlayer});
@@ -955,9 +955,9 @@ TEST(nntrainer_capi_nnmodel, getWeight_01) {
   EXPECT_EQ(num_weights, 2ul);
 
   for (unsigned int idx = 0; idx < num_weights; ++idx) {
-    ml_tensors_info_get_tensor_dimension(weight_info, idx, dim[idx]);
+    ml_tensors_info_get_tensor_dimension(weight_info, idx, dim);
     for (unsigned int i = 0; i < MAXDIM; ++i) {
-      EXPECT_EQ(dim[idx][i], weight_dim_expected[idx][i]);
+      EXPECT_EQ(dim[i], weight_dim_expected[idx][i]);
     }
   }
 
@@ -1406,9 +1406,9 @@ TEST(nntrainer_capi_nnmodel, get_input_output_dimension_01_p) {
 
   unsigned int input_count, output_count;
   const unsigned int MAXDIM = 4;
-  unsigned int input_dim_expected[MAXDIM] = {32, 1, 1, 62720};
-  unsigned int output_dim_expected[MAXDIM] = {32, 1, 1, 10};
-  unsigned int dim[MAXDIM];
+  const unsigned int input_dim_expected[MAXDIM] = {32, 1, 1, 62720};
+  const unsigned int output_dim_expected[MAXDIM] = {32, 1, 1, 10};
+  ml_tensor_dimension dim;
 
   int status = ML_ERROR_NONE;
 
@@ -1460,9 +1460,9 @@ TEST(nntrainer_capi_nnmodel, get_input_output_dimension_02_p) {
 
   unsigned int input_count, output_count;
   const unsigned int MAXDIM = 4;
-  unsigned int input_dim_expected[MAXDIM] = {32, 1, 1, 62720};
-  unsigned int output_dim_expected[MAXDIM] = {32, 1, 1, 10};
-  unsigned int dim[MAXDIM];
+  const unsigned int input_dim_expected[MAXDIM] = {32, 1, 1, 62720};
+  const unsigned int output_dim_expected[MAXDIM] = {32, 1, 1, 10};
+  ml_tensor_dimension dim;
 
   int status = ML_ERROR_NONE;
 
@@ -1567,9 +1567,9 @@ TEST(nntrainer_capi_nnmodel, get_input_output_dimension_06_n) {
 
   unsigned int input_count, output_count;
   const unsigned int MAXDIM = 4;
-  unsigned int input_dim_expected[MAXDIM] = {32, 1, 1, 62720};
-  unsigned int output_dim_expected[MAXDIM] = {32, 1, 1, 10};
-  unsigned int dim[MAXDIM];
+  const unsigned int input_dim_expected[MAXDIM] = {32, 1, 1, 62720};
+  const unsigned int output_dim_expected[MAXDIM] = {32, 1, 1, 10};
+  ml_tensor_dimension dim;
 
   int status = ML_ERROR_NONE;
 


### PR DESCRIPTION
We're now supporting 3 major compilers: gcc, clang, msvc
This PR add running clang build to continues integration in order to not lose clang compilation ability.
It will also give us chance to monitor and fix multiple compiler warnigs


