### PR TITLE
[Load]Optimize load with Async

### DIFF
--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -423,7 +423,7 @@ void BatchNormalizationLayer::read(std::ifstream &file,
                                    ml::train::ExecutionMode mode,
                                    bool trainable,
                                    TensorDim::DataType definedWeightDataType,
-                                   bool fsu) {
+                                   bool fsu, size_t start_offset) {
   if (opt_var) {
     for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
       if (run_context.isGradientLastAccess(i) && trainable) {
@@ -452,7 +452,7 @@ void BatchNormalizationLayer::read(std::ifstream &file,
           T_read.read(file);
           run_context.getWeight(i).copyData(T_read);
         } else {
-          run_context.getWeight(i).read(file);
+          run_context.getWeight(i).read(file, start_offset);
         }
 
         if (run_context.isMixedPrecision(i) && trainable &&

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -423,7 +423,8 @@ void BatchNormalizationLayer::read(std::ifstream &file,
                                    ml::train::ExecutionMode mode,
                                    bool trainable,
                                    TensorDim::DataType definedWeightDataType,
-                                   bool fsu, size_t start_offset) {
+                                   bool fsu, size_t start_offset,
+                                   bool read_from_offset) {
   if (opt_var) {
     for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
       if (run_context.isGradientLastAccess(i) && trainable) {

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -144,7 +144,7 @@ public:
   void read(std::ifstream &file, RunLayerContext &context, bool opt_var,
             ml::train::ExecutionMode mode, bool trainable,
             TensorDim::DataType definedWeightDataType, bool fsu = false,
-            size_t start_offset = -1) override;
+            size_t start_offset = -1, bool read_from_offset = false) override;
 
 private:
   float divider; /**< size of the axes of the reduced */

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -144,7 +144,7 @@ public:
   void read(std::ifstream &file, RunLayerContext &context, bool opt_var,
             ml::train::ExecutionMode mode, bool trainable,
             TensorDim::DataType definedWeightDataType,
-            bool fsu = false) override;
+            bool fsu = false, size_t start_offset = -1) override;
 
 private:
   float divider; /**< size of the axes of the reduced */

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -144,7 +144,7 @@ public:
   void read(std::ifstream &file, RunLayerContext &context, bool opt_var,
             ml::train::ExecutionMode mode, bool trainable,
             TensorDim::DataType definedWeightDataType, bool fsu = false,
-            size_t start_offset = -1, bool read_from_offset = false) override;
+            size_t start_offset = 0, bool read_from_offset = false) override;
 
 private:
   float divider; /**< size of the axes of the reduced */

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -143,8 +143,8 @@ public:
    */
   void read(std::ifstream &file, RunLayerContext &context, bool opt_var,
             ml::train::ExecutionMode mode, bool trainable,
-            TensorDim::DataType definedWeightDataType,
-            bool fsu = false, size_t start_offset = -1) override;
+            TensorDim::DataType definedWeightDataType, bool fsu = false,
+            size_t start_offset = -1) override;
 
 private:
   float divider; /**< size of the axes of the reduced */

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -368,7 +368,7 @@ public:
    */
   virtual void read(std::ifstream &file, RunLayerContext &run_context,
                     bool opt_var, ml::train::ExecutionMode mode, bool trainable,
-                    TensorDim::DataType defineWeightDataType, bool fsu) {
+                    TensorDim::DataType defineWeightDataType, bool fsu, size_t start_offset = -1) {
     if (fsu) {
       for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
         if (run_context.getWeight(i).getDataType() ==
@@ -383,7 +383,7 @@ public:
             /// @note read optimizer variables
             for (unsigned int j = 0; j < run_context.getNumWeightOptVar(i);
                  ++j) {
-              run_context.getWeightOptVar(i, j).read(file);
+              run_context.getWeightOptVar(i, j).read(file, start_offset);
             }
           }
         }
@@ -391,7 +391,7 @@ public:
         for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
           /// @note shared weights are only be read at the first acecss
           if (run_context.isGradientFirstAccess(i)) {
-            run_context.getWeight(i).read(file);
+            run_context.getWeight(i).read(file, start_offset);
 
             if (run_context.isMixedPrecision(i) && trainable &&
                 !run_context.getWeightFP32(i).empty()) {

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -369,7 +369,7 @@ public:
   virtual void read(std::ifstream &file, RunLayerContext &run_context,
                     bool opt_var, ml::train::ExecutionMode mode, bool trainable,
                     TensorDim::DataType defineWeightDataType, bool fsu,
-                    size_t start_offset = -1) {
+                    size_t start_offset = -1, bool read_from_offset = false) {
     if (fsu) {
       for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
         if (run_context.getWeight(i).getDataType() ==
@@ -392,7 +392,7 @@ public:
         for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
           /// @note shared weights are only be read at the first acecss
           if (run_context.isGradientFirstAccess(i)) {
-            run_context.getWeight(i).read(file, start_offset);
+            run_context.getWeight(i).read(file, start_offset, read_from_offset);
 
             if (run_context.isMixedPrecision(i) && trainable &&
                 !run_context.getWeightFP32(i).empty()) {

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -368,7 +368,8 @@ public:
    */
   virtual void read(std::ifstream &file, RunLayerContext &run_context,
                     bool opt_var, ml::train::ExecutionMode mode, bool trainable,
-                    TensorDim::DataType defineWeightDataType, bool fsu, size_t start_offset = -1) {
+                    TensorDim::DataType defineWeightDataType, bool fsu,
+                    size_t start_offset = -1) {
     if (fsu) {
       for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
         if (run_context.getWeight(i).getDataType() ==

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -369,7 +369,7 @@ public:
   virtual void read(std::ifstream &file, RunLayerContext &run_context,
                     bool opt_var, ml::train::ExecutionMode mode, bool trainable,
                     TensorDim::DataType defineWeightDataType, bool fsu,
-                    size_t start_offset = -1, bool read_from_offset = false) {
+                    size_t start_offset = 0, bool read_from_offset = false) {
     if (fsu) {
       for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
         if (run_context.getWeight(i).getDataType() ==
@@ -393,7 +393,6 @@ public:
           /// @note shared weights are only be read at the first acecss
           if (run_context.isGradientFirstAccess(i)) {
             run_context.getWeight(i).read(file, start_offset, read_from_offset);
-
             if (run_context.isMixedPrecision(i) && trainable &&
                 !run_context.getWeightFP32(i).empty()) {
               run_context.getWeightFP32(i).copyData(run_context.getWeight(i));

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -481,12 +481,12 @@ void LayerNode::exportTo(Exporter &exporter,
 
 void LayerNode::read(std::ifstream &file, bool opt_var,
                      ml::train::ExecutionMode mode, bool fsu,
-                     size_t start_offset) {
+                     size_t start_offset, bool read_from_offset) {
   NNTR_THROW_IF(!run_context, std::runtime_error)
     << __func__ << " layer needs to be finalized first!";
   getLayer()->read(file, *run_context, opt_var, mode,
                    (getTrainable() && mode == ml::train::ExecutionMode::TRAIN),
-                   getWeightDataType(), fsu, start_offset);
+                   getWeightDataType(), fsu, start_offset, read_from_offset);
 }
 
 void LayerNode::save(std::ofstream &file, bool opt_var,

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -480,12 +480,12 @@ void LayerNode::exportTo(Exporter &exporter,
 }
 
 void LayerNode::read(std::ifstream &file, bool opt_var,
-                     ml::train::ExecutionMode mode, bool fsu) {
+                     ml::train::ExecutionMode mode, bool fsu, size_t start_offset) {
   NNTR_THROW_IF(!run_context, std::runtime_error)
     << __func__ << " layer needs to be finalized first!";
   getLayer()->read(file, *run_context, opt_var, mode,
                    (getTrainable() && mode == ml::train::ExecutionMode::TRAIN),
-                   getWeightDataType(), fsu);
+                   getWeightDataType(), fsu, start_offset);
 }
 
 void LayerNode::save(std::ofstream &file, bool opt_var,

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -480,7 +480,8 @@ void LayerNode::exportTo(Exporter &exporter,
 }
 
 void LayerNode::read(std::ifstream &file, bool opt_var,
-                     ml::train::ExecutionMode mode, bool fsu, size_t start_offset) {
+                     ml::train::ExecutionMode mode, bool fsu,
+                     size_t start_offset) {
   NNTR_THROW_IF(!run_context, std::runtime_error)
     << __func__ << " layer needs to be finalized first!";
   getLayer()->read(file, *run_context, opt_var, mode,

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -759,7 +759,7 @@ public:
    */
   void read(std::ifstream &file, bool opt_var = false,
             ml::train::ExecutionMode mode = ml::train::ExecutionMode::TRAIN,
-            bool fsu = false, size_t start_offset = -1,
+            bool fsu = false, size_t start_offset = 0,
             bool read_from_offset = false);
 
   /**

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -760,7 +760,7 @@ public:
    */
   void read(std::ifstream &file, bool opt_var = false,
             ml::train::ExecutionMode mode = ml::train::ExecutionMode::TRAIN,
-            bool fsu = false);
+            bool fsu = false, size_t start_offset = -1);
 
   /**
    * @brief     save layer Weight & Bias data from file

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -290,7 +290,6 @@ public:
    */
   InitLayerContext refinalize(const std::vector<TensorDim> &input_dims = {});
 
-
   void initialize() override { layer->initialize(*run_context); }
 
   /**
@@ -760,7 +759,8 @@ public:
    */
   void read(std::ifstream &file, bool opt_var = false,
             ml::train::ExecutionMode mode = ml::train::ExecutionMode::TRAIN,
-            bool fsu = false, size_t start_offset = -1);
+            bool fsu = false, size_t start_offset = -1,
+            bool read_from_offset = false);
 
   /**
    * @brief     save layer Weight & Bias data from file

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -678,7 +678,10 @@ void NeuralNetwork::load(const std::string &file_path,
     auto local_offset = start_offsets.back();
     for (auto weight : weights) {
       size_t size = weight->getVariable().getMemoryBytes();
-      if (weight->getDim().getDataType() == TensorDim::DataType::Q4_K) {
+      auto tensor_data_type = weight->getDim().getDataType();
+
+      if (tensor_data_type != TensorDim::DataType::FP32 ||
+          tensor_data_type != TensorDim::DataType::FP16) {
         size += sizeof(uint16_t);
       }
       file_offset.emplace_back(std::make_pair(start_from, size));

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -707,7 +707,7 @@ void NeuralNetwork::load(const std::string &file_path,
           auto local_model_file = checkedOpenStream<std::ifstream>(
             (v.size() == 2) ? v[1] : v[0], std::ios::in | std::ios::binary);
           (*iter)->read(local_model_file, false, exec_mode, fsu_mode,
-                        start_offsets[exec_order]);
+                        start_offsets[exec_order], true);
         }));
       }
       // 모든 작업이 끝날 때까지 대기

--- a/nntrainer/tensor/bcq_tensor.cpp
+++ b/nntrainer/tensor/bcq_tensor.cpp
@@ -266,7 +266,7 @@ void BCQTensor::readFSU() { createBCQW(); }
 
 void BCQTensor::read(std::ifstream &file) {
   /// @note Read quantization information
-  read_quantization_info(file);
+  read_quantization_info(file, start_offset, read_from_offset);
 
   std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
@@ -274,8 +274,12 @@ void BCQTensor::read(std::ifstream &file) {
     << "read size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
-  checkedRead(file, (char *)getData(), sz,
-              "[BCQTensor::read] operation failed");
+  if (read_from_offset) {
+    start_offset += sizeof(uint16_t);
+  }
+
+  checkedRead(file, (char *)getData(), sz, "[BCQTensor::read] operation failed",
+              start_offset, read_from_offset);
   putData();
 
   createBCQW();
@@ -302,9 +306,11 @@ void BCQTensor::save_quantization_info(std::ostream &file) {
                "[BCQTensor::save] failed to write quantization information");
 }
 
-void BCQTensor::read_quantization_info(std::ifstream &file) {
+void BCQTensor::read_quantization_info(std::ifstream &file, start_offset,
+                                       read_from_offset) {
   checkedRead(file, (char *)&quantized_bit_size_, sizeof(uint16_t),
-              "[BCQTensor::read] failed to read quantization information");
+              "[BCQTensor::read] failed to read quantization information",
+              start_offset, read_from_offset);
 }
 
 size_t BCQTensor::size() const {

--- a/nntrainer/tensor/bcq_tensor.h
+++ b/nntrainer/tensor/bcq_tensor.h
@@ -216,7 +216,8 @@ public:
   /**
    * @copydoc Tensor::read(std::ifstream &file)
    */
-  void read(std::ifstream &file) override;
+  void read(std::ifstream &file, size_t start_offset,
+            bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::argmax()
@@ -231,7 +232,8 @@ public:
   /**
    * @copydoc TensorBase::read_quantization_info(std::ifstream &file)
    */
-  void read_quantization_info(std::ifstream &file) override;
+  void read_quantization_info(std::ifstream &file, size_t start_offset,
+                              bool read_from_offset) override;
 
   /**
    * @copydoc TensorBase::size()

--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -420,7 +420,7 @@ void CharTensor::save(std::ostream &file) {
   putData();
 }
 
-void CharTensor::read(std::ifstream &file) {
+void CharTensor::read(std::ifstream &file, size_t start_offset) {
   /// @note Read quantization information
   read_quantization_info(file);
 

--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -593,7 +593,9 @@ void CharTensor::save_quantization_info(std::ostream &file) {
                "[CharTensor::save] failed to write quantization information");
 }
 
-void CharTensor::read_quantization_info(std::ifstream &file, size_t start_offset, bool read_from_offset) {
+void CharTensor::read_quantization_info(std::ifstream &file,
+                                        size_t start_offset,
+                                        bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
               "[CharTensor::read] failed to read quantization information");
 }

--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -420,7 +420,8 @@ void CharTensor::save(std::ostream &file) {
   putData();
 }
 
-void CharTensor::read(std::ifstream &file, size_t start_offset) {
+void CharTensor::read(std::ifstream &file, size_t start_offset,
+                      bool read_from_offset) {
   /// @note Read quantization information
   read_quantization_info(file);
 

--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -431,8 +431,13 @@ void CharTensor::read(std::ifstream &file, size_t start_offset,
     << "read size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
+  if (read_from_offset) {
+    start_offset += sizeof(uint16_t);
+  }
+
   checkedRead(file, (char *)getData(), sz,
-              "[CharTensor::read] operation failed");
+              "[CharTensor::read] operation failed", start_offset,
+              read_from_offset);
   putData();
 }
 
@@ -597,7 +602,8 @@ void CharTensor::read_quantization_info(std::ifstream &file,
                                         size_t start_offset,
                                         bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
-              "[CharTensor::read] failed to read quantization information");
+              "[CharTensor::read] failed to read quantization information",
+              start_offset, read_from_offset);
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -423,7 +423,7 @@ void CharTensor::save(std::ostream &file) {
 void CharTensor::read(std::ifstream &file, size_t start_offset,
                       bool read_from_offset) {
   /// @note Read quantization information
-  read_quantization_info(file);
+  read_quantization_info(file, start_offset, read_from_offset);
 
   std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
@@ -593,7 +593,7 @@ void CharTensor::save_quantization_info(std::ostream &file) {
                "[CharTensor::save] failed to write quantization information");
 }
 
-void CharTensor::read_quantization_info(std::ifstream &file) {
+void CharTensor::read_quantization_info(std::ifstream &file, size_t start_offset, bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
               "[CharTensor::read] failed to read quantization information");
 }

--- a/nntrainer/tensor/char_tensor.h
+++ b/nntrainer/tensor/char_tensor.h
@@ -291,7 +291,7 @@ public:
    * @copydoc TensorBase::read_quantization_info()
    */
   void read_quantization_info(std::ifstream &file, size_t start_offset,
-                        bool read_from_offset ) override;
+                              bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::scale_size()

--- a/nntrainer/tensor/char_tensor.h
+++ b/nntrainer/tensor/char_tensor.h
@@ -290,7 +290,8 @@ public:
   /**
    * @copydoc TensorBase::read_quantization_info()
    */
-  void read_quantization_info(std::ifstream &file) override;
+  void read_quantization_info(std::ifstream &file, size_t start_offset,
+                        bool read_from_offset ) override;
 
   /**
    * @copydoc Tensor::scale_size()

--- a/nntrainer/tensor/char_tensor.h
+++ b/nntrainer/tensor/char_tensor.h
@@ -244,7 +244,8 @@ public:
   /**
    * @copydoc Tensor::read(std::ifstream &file)
    */
-  void read(std::ifstream &file, size_t start_offset) override;
+  void read(std::ifstream &file, size_t start_offset,
+            bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::argmax()

--- a/nntrainer/tensor/char_tensor.h
+++ b/nntrainer/tensor/char_tensor.h
@@ -244,7 +244,7 @@ public:
   /**
    * @copydoc Tensor::read(std::ifstream &file)
    */
-  void read(std::ifstream &file) override;
+  void read(std::ifstream &file, size_t start_offset) override;
 
   /**
    * @copydoc Tensor::argmax()

--- a/nntrainer/tensor/int4_tensor.cpp
+++ b/nntrainer/tensor/int4_tensor.cpp
@@ -345,7 +345,8 @@ void Int4QTensor::save(std::ostream &file) {
   putData();
 }
 
-void Int4QTensor::read(std::ifstream &file, size_t start_offset) {
+void Int4QTensor::read(std::ifstream &file, size_t start_offset,
+                       bool read_from_offset) {
   /// @note Read quantization information
   read_quantization_info(file);
 

--- a/nntrainer/tensor/int4_tensor.cpp
+++ b/nntrainer/tensor/int4_tensor.cpp
@@ -356,8 +356,13 @@ void Int4QTensor::read(std::ifstream &file, size_t start_offset,
     << "read size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
+  if (read_from_offset) {
+    start_offset += sizeof(uint16_t);
+  }
+
   checkedRead(file, (char *)getData(), sz,
-              "[Int4QTensor::read] operation failed");
+              "[Int4QTensor::read] operation failed", start_offset,
+              read_from_offset);
   putData();
 }
 
@@ -559,7 +564,8 @@ void Int4QTensor::read_quantization_info(std::ifstream &file,
                                          size_t start_offset,
                                          bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
-              "[Int4QTensor::read] failed to read quantization information");
+              "[Int4QTensor::read] failed to read quantization information",
+              start_offset, read_from_offset);
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/int4_tensor.cpp
+++ b/nntrainer/tensor/int4_tensor.cpp
@@ -345,7 +345,7 @@ void Int4QTensor::save(std::ostream &file) {
   putData();
 }
 
-void Int4QTensor::read(std::ifstream &file) {
+void Int4QTensor::read(std::ifstream &file, size_t start_offset) {
   /// @note Read quantization information
   read_quantization_info(file);
 

--- a/nntrainer/tensor/int4_tensor.cpp
+++ b/nntrainer/tensor/int4_tensor.cpp
@@ -348,7 +348,7 @@ void Int4QTensor::save(std::ostream &file) {
 void Int4QTensor::read(std::ifstream &file, size_t start_offset,
                        bool read_from_offset) {
   /// @note Read quantization information
-  read_quantization_info(file);
+  read_quantization_info(file, start_offset, read_from_offset);
 
   std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
@@ -555,7 +555,8 @@ void Int4QTensor::save_quantization_info(std::ostream &file) {
                "[Int4QTensor::save] failed to write quantization information");
 }
 
-void Int4QTensor::read_quantization_info(std::ifstream &file) {
+void Int4QTensor::read_quantization_info(std::ifstream &file, size_t start_offset,
+                        bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
               "[Int4QTensor::read] failed to read quantization information");
 }

--- a/nntrainer/tensor/int4_tensor.cpp
+++ b/nntrainer/tensor/int4_tensor.cpp
@@ -555,8 +555,9 @@ void Int4QTensor::save_quantization_info(std::ostream &file) {
                "[Int4QTensor::save] failed to write quantization information");
 }
 
-void Int4QTensor::read_quantization_info(std::ifstream &file, size_t start_offset,
-                        bool read_from_offset) {
+void Int4QTensor::read_quantization_info(std::ifstream &file,
+                                         size_t start_offset,
+                                         bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
               "[Int4QTensor::read] failed to read quantization information");
 }

--- a/nntrainer/tensor/int4_tensor.h
+++ b/nntrainer/tensor/int4_tensor.h
@@ -264,7 +264,8 @@ public:
   /**
    * @copydoc TensorBase::read_quantization_info()
    */
-  void read_quantization_info(std::ifstream &file) override;
+  void read_quantization_info(std::ifstream &file, size_t start_offset,
+                        bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::getMemoryBytes()

--- a/nntrainer/tensor/int4_tensor.h
+++ b/nntrainer/tensor/int4_tensor.h
@@ -265,7 +265,7 @@ public:
    * @copydoc TensorBase::read_quantization_info()
    */
   void read_quantization_info(std::ifstream &file, size_t start_offset,
-                        bool read_from_offset) override;
+                              bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::getMemoryBytes()

--- a/nntrainer/tensor/int4_tensor.h
+++ b/nntrainer/tensor/int4_tensor.h
@@ -223,7 +223,7 @@ public:
   /**
    * @copydoc Tensor::read(std::ifstream &file)
    */
-  void read(std::ifstream &file) override;
+  void read(std::ifstream &file, size_t start_offset) override;
 
   /**
    * @copydoc Tensor::argmax()

--- a/nntrainer/tensor/int4_tensor.h
+++ b/nntrainer/tensor/int4_tensor.h
@@ -223,7 +223,8 @@ public:
   /**
    * @copydoc Tensor::read(std::ifstream &file)
    */
-  void read(std::ifstream &file, size_t start_offset) override;
+  void read(std::ifstream &file, size_t start_offset,
+            bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::argmax()

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -332,8 +332,13 @@ void ShortTensor::read(std::ifstream &file, size_t start_offset,
     << "read size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
+  if (read_from_offset) {
+    start_offset += sizeof(uint16_t);
+  }
+
   checkedRead(file, (char *)getData(), sz,
-              "[ShortTensor::read] operation failed");
+              "[ShortTensor::read] operation failed", start_offset,
+              read_from_offset);
   putData();
 }
 
@@ -497,7 +502,8 @@ void ShortTensor::read_quantization_info(std::ifstream &file,
                                          size_t start_offset,
                                          bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
-              "[ShortTensor::read] failed to read quantization information");
+              "[ShortTensor::read] failed to read quantization information",
+              start_offset, read_from_offset);
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -493,8 +493,9 @@ void ShortTensor::save_quantization_info(std::ostream &file) {
   checkedWrite(file, (char *)&qscheme, sizeof(uint16_t),
                "[ShortTensor::save] failed to write quantization information");
 }
-void ShortTensor::read_quantization_info(std::ifstream &file, size_t start_offset,
-                        bool read_from_offset) {
+void ShortTensor::read_quantization_info(std::ifstream &file,
+                                         size_t start_offset,
+                                         bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
               "[ShortTensor::read] failed to read quantization information");
 }

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -321,7 +321,8 @@ void ShortTensor::save(std::ostream &file) {
   putData();
 }
 
-void ShortTensor::read(std::ifstream &file, size_t start_offset) {
+void ShortTensor::read(std::ifstream &file, size_t start_offset,
+                       bool read_from_offset) {
   /// @note Read quantization information
   read_quantization_info(file);
 

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -324,7 +324,7 @@ void ShortTensor::save(std::ostream &file) {
 void ShortTensor::read(std::ifstream &file, size_t start_offset,
                        bool read_from_offset) {
   /// @note Read quantization information
-  read_quantization_info(file);
+  read_quantization_info(file, start_offset, read_from_offset);
 
   std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
@@ -493,7 +493,8 @@ void ShortTensor::save_quantization_info(std::ostream &file) {
   checkedWrite(file, (char *)&qscheme, sizeof(uint16_t),
                "[ShortTensor::save] failed to write quantization information");
 }
-void ShortTensor::read_quantization_info(std::ifstream &file) {
+void ShortTensor::read_quantization_info(std::ifstream &file, size_t start_offset,
+                        bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
               "[ShortTensor::read] failed to read quantization information");
 }

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -321,7 +321,7 @@ void ShortTensor::save(std::ostream &file) {
   putData();
 }
 
-void ShortTensor::read(std::ifstream &file) {
+void ShortTensor::read(std::ifstream &file, size_t start_offset) {
   /// @note Read quantization information
   read_quantization_info(file);
 

--- a/nntrainer/tensor/short_tensor.h
+++ b/nntrainer/tensor/short_tensor.h
@@ -212,7 +212,7 @@ public:
   /**
    * @copydoc Tensor::read(std::ifstream &file)
    */
-  void read(std::ifstream &file) override;
+  void read(std::ifstream &file, size_t start_offset) override;
 
   /**
    * @copydoc Tensor::argmax()

--- a/nntrainer/tensor/short_tensor.h
+++ b/nntrainer/tensor/short_tensor.h
@@ -259,7 +259,7 @@ public:
    * @copydoc TensorBase::read_quantization_info()
    */
   void read_quantization_info(std::ifstream &file, size_t start_offset,
-                        bool read_from_offset) override;
+                              bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::scale_size()

--- a/nntrainer/tensor/short_tensor.h
+++ b/nntrainer/tensor/short_tensor.h
@@ -258,7 +258,8 @@ public:
   /**
    * @copydoc TensorBase::read_quantization_info()
    */
-  void read_quantization_info(std::ifstream &file) override;
+  void read_quantization_info(std::ifstream &file, size_t start_offset,
+                        bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::scale_size()

--- a/nntrainer/tensor/short_tensor.h
+++ b/nntrainer/tensor/short_tensor.h
@@ -212,7 +212,8 @@ public:
   /**
    * @copydoc Tensor::read(std::ifstream &file)
    */
-  void read(std::ifstream &file, size_t start_offset) override;
+  void read(std::ifstream &file, size_t start_offset,
+            bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::argmax()

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1239,11 +1239,12 @@ void Tensor::save(std::ostream &file) {
   itensor_->save(file);
 }
 
-void Tensor::read(std::ifstream &file, size_t start_offset) {
+void Tensor::read(std::ifstream &file, size_t start_offset,
+                  bool read_from_offset) {
   NNTR_THROW_IF(!getContiguous(), std::invalid_argument)
     << getName() << " is not contiguous, cannot read.";
 
-  itensor_->read(file, start_offset);
+  itensor_->read(file, start_offset, read_from_offset);
 }
 
 std::vector<unsigned int> Tensor::argmax() const {

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1239,11 +1239,11 @@ void Tensor::save(std::ostream &file) {
   itensor_->save(file);
 }
 
-void Tensor::read(std::ifstream &file) {
+void Tensor::read(std::ifstream &file, size_t start_offset) {
   NNTR_THROW_IF(!getContiguous(), std::invalid_argument)
     << getName() << " is not contiguous, cannot read.";
 
-  itensor_->read(file);
+  itensor_->read(file, start_offset);
 }
 
 std::vector<unsigned int> Tensor::argmax() const {

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1589,7 +1589,8 @@ public:
    * @brief     Read the Tensor from file
    * @param[in] file input file stream
    */
-  void read(std::ifstream &file, size_t start_offset = -1);
+  void read(std::ifstream &file, size_t start_offset = 0,
+            bool read_from_offset = false);
 
   /**
    * @brief     return argument index which value is max by batch

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1589,7 +1589,7 @@ public:
    * @brief     Read the Tensor from file
    * @param[in] file input file stream
    */
-  void read(std::ifstream &file);
+  void read(std::ifstream &file, size_t start_offset = -1);
 
   /**
    * @brief     return argument index which value is max by batch

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -65,7 +65,8 @@ void TensorBase::read(std::ifstream &file, size_t start_offset) {
     << "read size: " << bytes()
     << " is too big. It cannot be represented by std::streamsize";
 
-  checkedRead(file, (char *)getData(), sz, "[Tensor::read] operation failed", start_offset);
+  checkedRead(file, (char *)getData(), sz, "[Tensor::read] operation failed",
+              start_offset);
   putData();
 }
 

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -58,14 +58,14 @@ void TensorBase::save(std::ostream &file) {
   putData();
 }
 
-void TensorBase::read(std::ifstream &file) {
+void TensorBase::read(std::ifstream &file, size_t start_offset) {
   std::streamsize sz = static_cast<std::streamsize>(bytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
     << "read size: " << bytes()
     << " is too big. It cannot be represented by std::streamsize";
 
-  checkedRead(file, (char *)getData(), sz, "[Tensor::read] operation failed");
+  checkedRead(file, (char *)getData(), sz, "[Tensor::read] operation failed", start_offset);
   putData();
 }
 

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -58,7 +58,8 @@ void TensorBase::save(std::ostream &file) {
   putData();
 }
 
-void TensorBase::read(std::ifstream &file, size_t start_offset) {
+void TensorBase::read(std::ifstream &file, size_t start_offset,
+                      bool read_from_offset) {
   std::streamsize sz = static_cast<std::streamsize>(bytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
@@ -66,7 +67,7 @@ void TensorBase::read(std::ifstream &file, size_t start_offset) {
     << " is too big. It cannot be represented by std::streamsize";
 
   checkedRead(file, (char *)getData(), sz, "[Tensor::read] operation failed",
-              start_offset);
+              start_offset, read_from_offset);
   putData();
 }
 

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -643,7 +643,8 @@ public:
   /**
    * @brief     Read quantization information
    */
-  virtual void read_quantization_info(std::ifstream &file) {}
+  virtual void read_quantization_info(std::ifstream &file, size_t start_offset = 0,
+                        bool read_from_offset = false) {}
 
   /**
    * @brief     Get size of current tensor

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -500,7 +500,7 @@ public:
    * @brief     Read the Tensor from file
    * @param[in] file input file stream
    */
-  virtual void read(std::ifstream &file);
+  virtual void read(std::ifstream &file, size_t start_offset);
 
   /**
    * @copydoc Tensor::readFSU()

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -643,8 +643,9 @@ public:
   /**
    * @brief     Read quantization information
    */
-  virtual void read_quantization_info(std::ifstream &file, size_t start_offset = 0,
-                        bool read_from_offset = false) {}
+  virtual void read_quantization_info(std::ifstream &file,
+                                      size_t start_offset = 0,
+                                      bool read_from_offset = false) {}
 
   /**
    * @brief     Get size of current tensor

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -500,7 +500,8 @@ public:
    * @brief     Read the Tensor from file
    * @param[in] file input file stream
    */
-  virtual void read(std::ifstream &file, size_t start_offset);
+  virtual void read(std::ifstream &file, size_t start_offset = 0,
+                    bool read_from_offset = false);
 
   /**
    * @copydoc Tensor::readFSU()

--- a/nntrainer/tensor/uint4_tensor.cpp
+++ b/nntrainer/tensor/uint4_tensor.cpp
@@ -380,7 +380,8 @@ void Uint4QTensor::save(std::ostream &file) {
   putData();
 }
 
-void Uint4QTensor::read(std::ifstream &file, size_t start_offset) {
+void Uint4QTensor::read(std::ifstream &file, size_t start_offset,
+                        bool read_from_offset) {
   /// @note Read quantization information
   read_quantization_info(file);
 

--- a/nntrainer/tensor/uint4_tensor.cpp
+++ b/nntrainer/tensor/uint4_tensor.cpp
@@ -394,7 +394,8 @@ void Uint4QTensor::read(std::ifstream &file, size_t start_offset,
     start_offset += sizeof(uint16_t);
   }
   checkedRead(file, (char *)getData(), sz,
-              "[Uint4QTensor::read] operation failed", start_offset, read_from_offset);
+              "[Uint4QTensor::read] operation failed", start_offset,
+              read_from_offset);
   putData();
 }
 
@@ -610,10 +611,12 @@ void Uint4QTensor::save_quantization_info(std::ostream &file) {
                "[Uint4QTensor::save] failed to write quantization information");
 }
 
-void Uint4QTensor::read_quantization_info(std::ifstream &file, size_t start_offset,
-                        bool read_from_offset) {
+void Uint4QTensor::read_quantization_info(std::ifstream &file,
+                                          size_t start_offset,
+                                          bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
-              "[Uint4QTensor::read] failed to read quantization information", start_offset, read_from_offset);
+              "[Uint4QTensor::read] failed to read quantization information",
+              start_offset, read_from_offset);
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/uint4_tensor.cpp
+++ b/nntrainer/tensor/uint4_tensor.cpp
@@ -383,16 +383,18 @@ void Uint4QTensor::save(std::ostream &file) {
 void Uint4QTensor::read(std::ifstream &file, size_t start_offset,
                         bool read_from_offset) {
   /// @note Read quantization information
-  read_quantization_info(file);
+  read_quantization_info(file, start_offset, read_from_offset);
 
   std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
     << "read size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
-
+  if (read_from_offset) {
+    start_offset += sizeof(uint16_t);
+  }
   checkedRead(file, (char *)getData(), sz,
-              "[Uint4QTensor::read] operation failed");
+              "[Uint4QTensor::read] operation failed", start_offset, read_from_offset);
   putData();
 }
 
@@ -608,9 +610,10 @@ void Uint4QTensor::save_quantization_info(std::ostream &file) {
                "[Uint4QTensor::save] failed to write quantization information");
 }
 
-void Uint4QTensor::read_quantization_info(std::ifstream &file) {
+void Uint4QTensor::read_quantization_info(std::ifstream &file, size_t start_offset,
+                        bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
-              "[Uint4QTensor::read] failed to read quantization information");
+              "[Uint4QTensor::read] failed to read quantization information", start_offset, read_from_offset);
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/uint4_tensor.cpp
+++ b/nntrainer/tensor/uint4_tensor.cpp
@@ -380,7 +380,7 @@ void Uint4QTensor::save(std::ostream &file) {
   putData();
 }
 
-void Uint4QTensor::read(std::ifstream &file) {
+void Uint4QTensor::read(std::ifstream &file, size_t start_offset) {
   /// @note Read quantization information
   read_quantization_info(file);
 

--- a/nntrainer/tensor/uint4_tensor.cpp
+++ b/nntrainer/tensor/uint4_tensor.cpp
@@ -390,9 +390,11 @@ void Uint4QTensor::read(std::ifstream &file, size_t start_offset,
   NNTR_THROW_IF(sz < 0, std::invalid_argument)
     << "read size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
+
   if (read_from_offset) {
     start_offset += sizeof(uint16_t);
   }
+
   checkedRead(file, (char *)getData(), sz,
               "[Uint4QTensor::read] operation failed", start_offset,
               read_from_offset);

--- a/nntrainer/tensor/uint4_tensor.h
+++ b/nntrainer/tensor/uint4_tensor.h
@@ -243,7 +243,7 @@ public:
   /**
    * @copydoc Tensor::read(std::ifstream &file)
    */
-  void read(std::ifstream &file) override;
+  void read(std::ifstream &file, size_t start_offset) override;
 
   /**
    * @copydoc Tensor::argmax()

--- a/nntrainer/tensor/uint4_tensor.h
+++ b/nntrainer/tensor/uint4_tensor.h
@@ -284,7 +284,8 @@ public:
   /**
    * @copydoc TensorBase::read_quantization_info()
    */
-  void read_quantization_info(std::ifstream &file) override;
+  void read_quantization_info(std::ifstream &file, size_t start_offset,
+                        bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::getMemoryBytes()

--- a/nntrainer/tensor/uint4_tensor.h
+++ b/nntrainer/tensor/uint4_tensor.h
@@ -243,7 +243,8 @@ public:
   /**
    * @copydoc Tensor::read(std::ifstream &file)
    */
-  void read(std::ifstream &file, size_t start_offset) override;
+  void read(std::ifstream &file, size_t start_offset,
+            bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::argmax()

--- a/nntrainer/tensor/uint4_tensor.h
+++ b/nntrainer/tensor/uint4_tensor.h
@@ -285,7 +285,7 @@ public:
    * @copydoc TensorBase::read_quantization_info()
    */
   void read_quantization_info(std::ifstream &file, size_t start_offset,
-                        bool read_from_offset) override;
+                              bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::getMemoryBytes()

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -377,7 +377,7 @@ template <typename T> void UIntTensor<T>::save(std::ostream &file) {
   putData();
 }
 
-template <typename T> void UIntTensor<T>::read(std::ifstream &file) {
+template <typename T> void UIntTensor<T>::read(std::ifstream &file, size_t start_offset) {
   /// @note Read quantization information
   read_quantization_info(file);
 

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -378,7 +378,8 @@ template <typename T> void UIntTensor<T>::save(std::ostream &file) {
 }
 
 template <typename T>
-void UIntTensor<T>::read(std::ifstream &file, size_t start_offset) {
+void UIntTensor<T>::read(std::ifstream &file, size_t start_offset,
+                         bool read_from_offset) {
   /// @note Read quantization information
   read_quantization_info(file);
 

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -525,8 +525,9 @@ void UIntTensor<T>::save_quantization_info(std::ostream &file) {
 }
 
 template <typename T>
-void UIntTensor<T>::read_quantization_info(std::ifstream &file, size_t start_offset,
-                        bool read_from_offset) {
+void UIntTensor<T>::read_quantization_info(std::ifstream &file,
+                                           size_t start_offset,
+                                           bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
               "[CharTensor::read] failed to read quantization information");
 }

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -377,7 +377,8 @@ template <typename T> void UIntTensor<T>::save(std::ostream &file) {
   putData();
 }
 
-template <typename T> void UIntTensor<T>::read(std::ifstream &file, size_t start_offset) {
+template <typename T>
+void UIntTensor<T>::read(std::ifstream &file, size_t start_offset) {
   /// @note Read quantization information
   read_quantization_info(file);
 

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -389,8 +389,13 @@ void UIntTensor<T>::read(std::ifstream &file, size_t start_offset,
     << "read size: " << getMemoryBytes()
     << " is too big. It cannot be represented by std::streamsize";
 
+  if (read_from_offset) {
+    start_offset += sizeof(uint16_t);
+  }
+
   checkedRead(file, (char *)getData(), sz,
-              "[UIntTensor::read] operation failed");
+              "[UIntTensor::read] operation failed", start_offset,
+              read_from_offset);
   putData();
 }
 
@@ -529,7 +534,8 @@ void UIntTensor<T>::read_quantization_info(std::ifstream &file,
                                            size_t start_offset,
                                            bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
-              "[CharTensor::read] failed to read quantization information");
+              "[CharTensor::read] failed to read quantization information",
+              start_offset, read_from_offset);
 }
 
 template <typename T> size_t UIntTensor<T>::scale_size() const {

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -381,7 +381,7 @@ template <typename T>
 void UIntTensor<T>::read(std::ifstream &file, size_t start_offset,
                          bool read_from_offset) {
   /// @note Read quantization information
-  read_quantization_info(file);
+  read_quantization_info(file, start_offset, read_from_offset);
 
   std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());
 
@@ -525,7 +525,8 @@ void UIntTensor<T>::save_quantization_info(std::ostream &file) {
 }
 
 template <typename T>
-void UIntTensor<T>::read_quantization_info(std::ifstream &file) {
+void UIntTensor<T>::read_quantization_info(std::ifstream &file, size_t start_offset,
+                        bool read_from_offset) {
   checkedRead(file, (char *)&qscheme, sizeof(uint16_t),
               "[CharTensor::read] failed to read quantization information");
 }

--- a/nntrainer/tensor/uint_tensor.h
+++ b/nntrainer/tensor/uint_tensor.h
@@ -279,7 +279,8 @@ public:
   /**
    * @copydoc TensorBase::read_quantization_info()
    */
-  void read_quantization_info(std::ifstream &file) override;
+  void read_quantization_info(std::ifstream &file, size_t start_offset,
+                        bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::scale_size()

--- a/nntrainer/tensor/uint_tensor.h
+++ b/nntrainer/tensor/uint_tensor.h
@@ -280,7 +280,7 @@ public:
    * @copydoc TensorBase::read_quantization_info()
    */
   void read_quantization_info(std::ifstream &file, size_t start_offset,
-                        bool read_from_offset) override;
+                              bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::scale_size()

--- a/nntrainer/tensor/uint_tensor.h
+++ b/nntrainer/tensor/uint_tensor.h
@@ -233,7 +233,7 @@ public:
   /**
    * @copydoc Tensor::read(std::ifstream &file)
    */
-  void read(std::ifstream &file) override;
+  void read(std::ifstream &file, size_t start_offset) override;
 
   /**
    * @copydoc Tensor::argmax()

--- a/nntrainer/tensor/uint_tensor.h
+++ b/nntrainer/tensor/uint_tensor.h
@@ -233,7 +233,8 @@ public:
   /**
    * @copydoc Tensor::read(std::ifstream &file)
    */
-  void read(std::ifstream &file, size_t start_offset) override;
+  void read(std::ifstream &file, size_t start_offset,
+            bool read_from_offset) override;
 
   /**
    * @copydoc Tensor::argmax()

--- a/nntrainer/utils/util_func.cpp
+++ b/nntrainer/utils/util_func.cpp
@@ -72,13 +72,13 @@ static void checkFile(const T &file, const char *error_msg) {
 }
 
 void checkedRead(std::ifstream &file, char *array, std::streamsize size,
-                 const char *error_msg, size_t start_offset) {
-  if (start_offset >= 0) {
+                 const char *error_msg, size_t start_offset,
+                 bool read_from_offset) {
+  if (read_from_offset) {
     file.seekg(start_offset, std::ios::beg);
     checkFile(file, "failed to move offset");
   }
   file.read(array, size);
-
   checkFile(file, error_msg);
 }
 

--- a/nntrainer/utils/util_func.cpp
+++ b/nntrainer/utils/util_func.cpp
@@ -72,7 +72,11 @@ static void checkFile(const T &file, const char *error_msg) {
 }
 
 void checkedRead(std::ifstream &file, char *array, std::streamsize size,
-                 const char *error_msg) {
+                 const char *error_msg, size_t start_offset) {
+  if (start_offset >= 0) {
+    file.seekg(start_offset, std::ios::beg);
+    checkFile(file, "failed to move offset");
+  }
   file.read(array, size);
 
   checkFile(file, error_msg);

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -136,7 +136,7 @@ constexpr const char *default_error_msg =
  */
 void checkedRead(std::ifstream &file, char *array, std::streamsize size,
                  const char *error_msg = default_error_msg,
-                 size_t start_offset = -1);
+                 size_t start_offset = 0, bool read_from_offset = false);
 
 /**
  * @brief same as file.write except it checks if fail to write the file

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -40,11 +40,11 @@
 
 namespace nntrainer {
 
-#define NN_RETURN_STATUS()         \
-  do {                             \
-    if (status != ML_ERROR_NONE) { \
-      return status;               \
-    }                              \
+#define NN_RETURN_STATUS()                                                     \
+  do {                                                                         \
+    if (status != ML_ERROR_NONE) {                                             \
+      return status;                                                           \
+    }                                                                          \
   } while (0)
 
 /**
@@ -135,7 +135,8 @@ constexpr const char *default_error_msg =
  * @throw std::runtime_error if file.fail() is true after read.
  */
 void checkedRead(std::ifstream &file, char *array, std::streamsize size,
-                 const char *error_msg = default_error_msg, size_t start_offset = -1);
+                 const char *error_msg = default_error_msg,
+                 size_t start_offset = -1);
 
 /**
  * @brief same as file.write except it checks if fail to write the file

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -135,7 +135,7 @@ constexpr const char *default_error_msg =
  * @throw std::runtime_error if file.fail() is true after read.
  */
 void checkedRead(std::ifstream &file, char *array, std::streamsize size,
-                 const char *error_msg = default_error_msg);
+                 const char *error_msg = default_error_msg, size_t start_offset = -1);
 
 /**
  * @brief same as file.write except it checks if fail to write the file


### PR DESCRIPTION
In This PR 
----
This PR improves the loading logic so that model weight files are read asynchronously and in parallel.
By calculating each weight’s file offset, multiple threads can simultaneously read weights, and to enable this, a start_offset parameter was added to read function interfaces, ensuring that file reading uses the right offset.

Loading performance improved (for 16GB, about 4500ms → 1600ms).

``` 
Linux
CPU info : 11th i7-11700
memory Performance 28693.32 MB/s

Disk Random 16.0 Read 240.06 MB/s 8.0
Disk Sequential 64.0 Read 835.56 MB/s 8.3
Disk Sequential 64.0 Write 287.56 MB/s 7.7

load : 16GB bin file, 4543 ms --> 1446 ms,
```

 The implementation uses futures and async so that multiple layers or weights are loaded at the same time, and read function signatures across tensor and layer classes were modified to support this. Also, utility functions were updated to handle file offsets according to these changes.

Resolves
- #3159 

close #3159 

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Donghak PARK <donghak.park@samsung.com>