### PR TITLE
Integration of Basic BLAS Functions in CLBlast with Enhancements for NNTrainer

### DIFF
--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -82,6 +82,13 @@ LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE            := OpenCL
+LOCAL_SRC_FILES         := @MESON_CL_ROOT@/lib/arm64-v8a/libOpenCL.so
+LOCAL_EXPORT_C_INCLUDES := @MESON_CL_ROOT@/include
+
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
 
 MESON_HAS_GGML := @MESON_HAS_GGML@
 
@@ -124,19 +131,110 @@ endif # MESON_HAS_GGML
 include $(CLEAR_VARS)
 
 LOCAL_MODULE        := clblast
-LOCAL_SRC_FILES     := \
-    $(wildcard../subprojects/CLBlast/src/*.cpp) \
-    $(wildcard../subprojects/CLBlast/src/*/*.cpp) \
-    $(wildcard../subprojects/CLBlast/src/*/*/*.cpp)
+LOCAL_SRC_FILES     :=  @MESON_CLBLAST_ROOT@/src/cache.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/xger/xger.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/xgemv/xgemv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/xgemv_fast/xgemv_fast.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/xconvgemm/xconvgemm.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/copy/copy.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/gemm_routine/gemm_routine.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/xdot/xdot.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/invert/invert.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/xgemv_fast_rot/xgemv_fast_rot.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/padtranspose/padtranspose.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/xgemm/xgemm.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/trsv_routine/trsv_routine.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/transpose/transpose.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/xgemm_direct/xgemm_direct.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/pad/pad.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/kernels/xaxpy/xaxpy.cpp \
+                        @MESON_CLBLAST_ROOT@/src/database/database.cpp \
+                        @MESON_CLBLAST_ROOT@/src/api_common.cpp \
+                        @MESON_CLBLAST_ROOT@/src/utilities/clblast_exceptions.cpp \
+                        @MESON_CLBLAST_ROOT@/src/utilities/compile.cpp \
+                        @MESON_CLBLAST_ROOT@/src/utilities/utilities.cpp \
+                        @MESON_CLBLAST_ROOT@/src/utilities/timing.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routine.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/configurations.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/routines/xgemm.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/routines/xtrsv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/tuning_api.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/kernels/xgemm.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/kernels/xgemm_direct.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/kernels/copy_pad.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/kernels/copy_fast.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/kernels/invert.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/kernels/xaxpy.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/kernels/xgemv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/kernels/xdot.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/kernels/xconvgemm.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/kernels/transpose_pad.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/kernels/transpose_fast.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/kernels/xger.cpp \
+                        @MESON_CLBLAST_ROOT@/src/tuning/tuning.cpp \
+                        @MESON_CLBLAST_ROOT@/src/clblast_c.cpp \
+                        @MESON_CLBLAST_ROOT@/src/kernel_preprocessor.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level1/xdotc.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level1/xcopy.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level1/xswap.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level1/xaxpy.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level1/xamax.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level1/xdot.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level1/xnrm2.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level1/xdotu.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level1/xscal.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level1/xasum.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xhpr.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xhpmv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xtrmv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xgerc.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xtrsv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xsbmv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xhpr2.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xgemv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xher.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xher2.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xspmv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xtpmv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xtbmv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xsyr2.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xhemv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xgbmv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xgeru.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xsymv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xhbmv.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xspr.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xger.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xsyr.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level2/xspr2.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level3/xhemm.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level3/xgemm.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level3/xtrmm.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level3/xher2k.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level3/xtrsm.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level3/xherk.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level3/xsyr2k.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level3/xsymm.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/level3/xsyrk.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/levelx/xim2col.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/levelx/xcol2im.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/levelx/xaxpybatched.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/levelx/xinvert.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/levelx/xgemmstridedbatched.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/levelx/xomatcopy.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/levelx/xconvgemm.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/levelx/xhad.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/levelx/xgemmbatched.cpp \
+                        @MESON_CLBLAST_ROOT@/src/routines/common.cpp \
+                        @MESON_CLBLAST_ROOT@/test/test_utilities.cpp \
+                        @MESON_CLBLAST_ROOT@/src/clblast.cpp
 
-LOCAL_C_INCLUDES    := $(LOCAL_PATH)/../subprojects/CLBlast \
-                       $(LOCAL_PATH)/../subprojects/CLBlast/include \
-                       $(LOCAL_PATH)/../subprojects/CLBlast/src \
-                       $(LOCAL_PATH)
+LOCAL_C_INCLUDES    := @MESON_CLBLAST_ROOT@/include \
+                       @MESON_CLBLAST_ROOT@/src \
+                       @MESON_CLBLAST_ROOT@ \
+                       @MESON_CL_ROOT@/include
 
-
-LOCAL_CXXFLAGS      += -std=c++17 -O3
-LOCAL_LDLIBS        := -lOpenCL
+LOCAL_CXXFLAGS      += -std=c++17 -O3 -fexceptions -DOPENCL_API
 
 LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 
@@ -158,6 +256,7 @@ LOCAL_MODULE_TAGS   := optional
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
 LOCAL_LDFLAGS 	    += "-Wl,-z,max-page-size=16384"
 
+LOCAL_SHARED_LIBRARIES := OpenCL
 LOCAL_STATIC_LIBRARIES += iniparser openblas ruy clblast
 
 ifeq ($(MESON_HAS_TFLITE), 1)

--- a/jni/meson.build
+++ b/jni/meson.build
@@ -41,6 +41,11 @@ if ruy_dep.found()
   and_conf.set('MESON_RUY_ROOT', ruy_root)
 endif
 
+if clblast_dep.found()
+  and_conf.set('MESON_CLBLAST_ROOT', clblast_root)
+  and_conf.set('MESON_CL_ROOT', opencl_root)
+endif
+
 if tflite_dep.found()
   and_conf.set('MESON_HAS_TFLITE', 1)
   and_conf.set('MESON_TFLITE_ROOT', tflite_root)

--- a/jni/prepare_opencl.sh
+++ b/jni/prepare_opencl.sh
@@ -1,0 +1,44 @@
+#! /bin/bash
+# SPDX-License-Identifier: Apache-2.0
+##
+# Copyright (C) 2025 Donghyeon Jeong <dhyeon.jeong@samsung.com>
+#
+# @file prepare_opencl.sh
+# @date 15 May 2025
+# @brief This file is a helper tool to build android
+# @author Donghyeon Jeong <dhyeon.jeong@samsung.com>
+#
+# usage: ./prepare_opencl.sh target
+
+set -e
+TARGET=$1
+TAR_PREFIX=opencl
+
+TAR_NAME=${TAR_PREFIX}.tar.xz
+URL="https://raw.githubusercontent.com/nnstreamer/nnstreamer-android-resource/main/external/${TAR_NAME}"
+
+echo "Preparing OpenCL at ${TARGET}"
+
+[ ! -d ${TARGET} ] && mkdir -p ${TARGET}
+
+pushd ${TARGET}
+
+function _download_opencl {
+  [ -f $TAR_NAME ] && echo "${TAR_NAME} exists, skip downloading" && return 0
+  echo "[OpenCL] downloading ${TAR_NAME}\n"
+  if ! wget -q ${URL} ; then
+    echo "[OpenCL] Download failed, please check url\n"
+    exit $?
+  fi
+  echo "[OpenCL] Finish downloading OpenCL\n"
+}
+
+function _untar_opencl {
+  echo "[OpenCL] untar OpenCL\n"
+  tar xf ${TAR_NAME} -C ${TARGET}
+  rm -f ${TAR_NAME}
+}
+
+[ ! -d "${TAR_PREFIX}" ] && _download_opencl && _untar_opencl
+
+popd

--- a/meson.build
+++ b/meson.build
@@ -167,6 +167,10 @@ if get_option('enable-opencl')
   clblast_options = cmake.subproject_options()
 
   if get_option('platform') == 'android'
+    message('preparing opencl')
+    run_command([meson.source_root() / 'jni' / 'prepare_opencl.sh', meson.build_root()], check: true)
+    clblast_root = meson.source_root() / 'subprojects' / 'CLBlast'
+    opencl_root = meson.build_root() / 'opencl'
     clblast_dep = declare_dependency()
   else
     if host_machine.system() == 'windows'

--- a/nntrainer/layers/cl_layers/reshape_cl.h
+++ b/nntrainer/layers/cl_layers/reshape_cl.h
@@ -129,9 +129,9 @@ public:
    * @param[in] input_height   represents the height of the input tensor
    * @param[in] input_width   represents the width of the input tensor
    */
-  void copy_cl(const float *input, float *res, unsigned int input_batch_size,
-               unsigned int input_channels, unsigned int input_height,
-               unsigned int input_width);
+  void scopy_cl(const float *input, float *res, unsigned int input_batch_size,
+                unsigned int input_channels, unsigned int input_height,
+                unsigned int input_width);
 
 #ifdef ENABLE_FP16
   /**

--- a/nntrainer/tensor/cl_operations/blas_kernel_interface.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_interface.cpp
@@ -13,6 +13,7 @@
 
 #include <blas_kernel_interface.h>
 #include <blas_kernels.h>
+#include <clblast_interface.h>
 
 namespace nntrainer {
 void dotBatchedCl(Tensor const &input, Tensor const &m, Tensor &result,
@@ -127,7 +128,8 @@ void dotCl(Tensor const &input, Tensor const &m, Tensor &result, bool trans,
     /// (1 * K) X (1 * M) can be a case
     /// case1: (1 * K) X (K * 1)
     if (M == 1 && N == 1) {
-      *rdata = dot_cl(data, mdata, K) + (*rdata);
+      // *rdata = dot_cl(data, mdata, K) + (*rdata);
+      *rdata = dot_cl(K, data, mdata) + (*rdata);
     }
     /// case2: (M * K) X (K * 1)
     else if (N == 1) {
@@ -188,7 +190,7 @@ void multiplyCl(Tensor &input, float const &value) {
     float *data = input.getData<float>();
     unsigned int len = input.size();
 
-    sscal_cl(data, len, value);
+    scal_cl(len, value, data);
   } else if (input.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
     _FP16 *data = input.getData<_FP16>();
@@ -215,13 +217,13 @@ void add_i_cl(Tensor &result, Tensor const &input) {
        result.height() == input.height() && result.width() == input.width())) {
 
     if (result.getDataType() == ml::train::TensorDim::DataType::FP32) {
-      unsigned int size_res = result.size();
-      unsigned int size_input = input.size();
-      float *data_res = result.getData();
-      const float *data_input = input.getData();
+      float *Y = result.getData();
+      const float *X = input.getData();
 
-      addition_cl(data_input, data_res, size_input, size_res);
-
+      for (unsigned int i = 0; i < result.batch() / input.batch(); ++i) {
+        axpy_cl(input.size(), 1.0f, X, Y);
+        Y += input.size();
+      }
     } else if (result.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
       unsigned int size_res = result.size();
@@ -295,6 +297,85 @@ void transposeCl(const std::string &direction, Tensor const &in,
     throw std::invalid_argument("Error: enable-fp16 is not enabled");
 #endif
   }
+}
+
+void copyCl(const Tensor &input, Tensor &result) {
+  if (input.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    const float *data = input.getData();
+    float *rdata = result.getData();
+
+    unsigned int len = input.size();
+
+    copy_cl(len, data, rdata);
+  } else if (input.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    throw std::runtime_error("Error: Currently, copyCl not supported for FP16");
+#endif
+  }
+}
+
+float nrm2Cl(const Tensor &input) {
+  float result = 0.0f;
+  if (input.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    float *data = input.getData();
+    unsigned int len = input.size();
+
+    result = nrm2_cl(len, data);
+  } else if (input.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    throw std::runtime_error("Error: Currently, nrm2Cl not supported for FP16");
+#endif
+  }
+
+  return result;
+}
+
+float asumCl(const Tensor &input) {
+  float result = 0.0f;
+  if (input.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    float *data = input.getData();
+    unsigned int len = input.size();
+
+    result = asum_cl(len, data);
+  } else if (input.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    throw std::runtime_error("Error: Currently, asumCl not supported for FP16");
+#endif
+  }
+
+  return result;
+}
+
+int amaxCl(const Tensor &input) {
+  int result = 0;
+  if (input.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    float *data = input.getData();
+    unsigned int len = input.size();
+
+    result = amax_cl(len, data);
+  } else if (input.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    throw std::runtime_error("Error: Currently, amaxCl not supported for FP16");
+#endif
+  }
+
+  return result;
+}
+
+int aminCl(const Tensor &input) {
+  int result = 0;
+  if (input.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    float *data = input.getData();
+    unsigned int len = input.size();
+
+    result = amin_cl(len, data);
+  } else if (input.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    throw std::runtime_error("Error: Currently, amaxCl not supported for FP16");
+#endif
+  }
+
+  return result;
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/cl_operations/blas_kernel_interface.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_interface.h
@@ -78,5 +78,47 @@ void add_i_cl(Tensor &result, Tensor const &input);
 void transposeCl(const std::string &direction, Tensor const &in,
                  Tensor &result);
 
+/**
+ * @brief Copy data from one tensor to another
+ *
+ * @param input Tensor
+ * @param result Tensor
+ */
+void copyCl(const Tensor &input, Tensor &result);
+
+/**
+ * @brief nrm2 computation : Euclidean norm
+ * @param input Tensor
+ * @return Euclidean norm
+ * @note This function is used to compute the Euclidean norm of a vector.
+ */
+float nrm2Cl(const Tensor &input);
+
+/**
+ * @brief Absolute sum computation
+ *
+ * @param input Tensor
+ * @return float absolute sum of the elements
+ */
+float asumCl(const Tensor &input);
+
+/**
+ * @brief Absolute max computation
+ *
+ * @param input Tensor
+ * @return int index of the maximum absolute value
+ * @note Not necessarily the first if there are multiple maximums.
+ */
+int amaxCl(const Tensor &input);
+
+/**
+ * @brief Absolute min computation
+ *
+ * @param input Tensor
+ * @return int index of the minimum absolute value
+ * @note Not necessarily the first if there are multiple minimums.
+ */
+int aminCl(const Tensor &input);
+
 } // namespace nntrainer
 #endif /* __BLAS_KERNEL_INTERFACE_H__ */

--- a/nntrainer/tensor/cl_operations/clblast_interface.cpp
+++ b/nntrainer/tensor/cl_operations/clblast_interface.cpp
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Donghyeon Jeong <dhyeon.jeong@samsung.com>
+ *
+ * @file	clblast_interface.cpp
+ * @date	12 May 2025
+ * @brief	CLBlast library interface
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Donghyeon Jeong <dhyeon.jeong@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#include <stdexcept>
+
+#define CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED // to disable deprecation warnings
+#include "clblast.h"
+#include "clblast_interface.h"
+
+namespace nntrainer {
+
+void scal_cl(const unsigned int N, const float alpha, float *X,
+             unsigned int incX) {
+  clBuffManagerInst.getOutBufferA()->WriteDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+
+  clblast::Scal<float>(N, alpha, clBuffManagerInst.getOutBufferA()->GetBuffer(),
+                       0, incX, &command_queue);
+
+  clBuffManagerInst.getOutBufferA()->ReadDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+}
+
+void copy_cl(const unsigned int N, const float *X, float *Y, unsigned int incX,
+             unsigned int incY) {
+  clBuffManagerInst.getInBufferA()->WriteDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+
+  clblast::Copy<float>(N, clBuffManagerInst.getInBufferA()->GetBuffer(), 0,
+                       incX, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
+                       incY, &command_queue);
+
+  clBuffManagerInst.getOutBufferA()->ReadDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), Y);
+}
+
+void axpy_cl(const unsigned int N, const float alpha, const float *X, float *Y,
+             unsigned int incX, unsigned int incY) {
+  clBuffManagerInst.getInBufferA()->WriteDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+
+  clBuffManagerInst.getOutBufferA()->WriteDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), Y);
+
+  clblast::Axpy<float>(N, alpha, clBuffManagerInst.getInBufferA()->GetBuffer(),
+                       0, incX, clBuffManagerInst.getOutBufferA()->GetBuffer(),
+                       0, incY, &command_queue);
+
+  clBuffManagerInst.getOutBufferA()->ReadDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), Y);
+}
+
+float dot_cl(const unsigned int N, const float *X, const float *Y,
+             unsigned int incX, unsigned int incY) {
+  clBuffManagerInst.getInBufferA()->WriteDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+
+  clBuffManagerInst.getInBufferB()->WriteDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), Y);
+
+  clblast::Dot<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
+                      clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
+                      clBuffManagerInst.getInBufferB()->GetBuffer(), 0, incY,
+                      &command_queue);
+
+  float result;
+  clBuffManagerInst.getOutBufferA()->ReadDataRegion(
+    clblast_cc->command_queue_inst_, sizeof(float), &result);
+  return result;
+}
+
+float nrm2_cl(const unsigned int N, const float *X, unsigned int incX) {
+  clBuffManagerInst.getInBufferA()->WriteDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+
+  clblast::Nrm2<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
+                       clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
+                       &command_queue);
+
+  float result;
+  clBuffManagerInst.getOutBufferA()->ReadDataRegion(
+    clblast_cc->command_queue_inst_, sizeof(float), &result);
+
+  return result;
+}
+
+float asum_cl(const unsigned int N, const float *X, unsigned int incX) {
+  clBuffManagerInst.getInBufferA()->WriteDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+
+  clblast::Asum<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
+                       clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
+                       &command_queue);
+
+  float result;
+  clBuffManagerInst.getOutBufferA()->ReadDataRegion(
+    clblast_cc->command_queue_inst_, sizeof(float), &result);
+
+  return result;
+}
+
+int amax_cl(const unsigned int N, const float *X, unsigned int incX) {
+  clBuffManagerInst.getInBufferA()->WriteDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+
+  clblast::Amax<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
+                       clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
+                       &command_queue);
+
+  int result;
+  clBuffManagerInst.getOutBufferA()->ReadDataRegion(
+    clblast_cc->command_queue_inst_, sizeof(int), &result);
+
+  return result;
+}
+
+int amin_cl(const unsigned int N, const float *X, unsigned int incX) {
+  clBuffManagerInst.getInBufferA()->WriteDataRegion(
+    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+
+  clblast::Amin<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
+                       clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
+                       &command_queue);
+
+  int result;
+  clBuffManagerInst.getOutBufferA()->ReadDataRegion(
+    clblast_cc->command_queue_inst_, sizeof(int), &result);
+
+  return result;
+}
+
+void gemv_cl(const unsigned int layout, bool TransA, const unsigned int M,
+             const unsigned int N, const float alpha, const float *A,
+             const unsigned int lda, const float *X, const float beta, float *Y,
+             unsigned int incX, unsigned int incY) {
+  throw std::runtime_error("gemv_cl is not implemented");
+}
+
+void gemm_cl(const unsigned int layout, bool TransA, bool TransB,
+             const unsigned int M, const unsigned int N, const unsigned int K,
+             const float alpha, const float *A, const unsigned int lda,
+             const float *B, const unsigned int ldb, const float beta, float *C,
+             const unsigned int ldc) {
+  throw std::runtime_error("gemm_cl is not implemented");
+}
+
+void gemm_batched_cl(const unsigned int layout, bool TransA, bool TransB,
+                     const unsigned int M, const unsigned int N,
+                     const unsigned int K, const float *alpha, const float *A,
+                     const unsigned int lda, const float *B,
+                     const unsigned int ldb, const float *beta, float *C,
+                     const unsigned int ldc, const unsigned int batch_size) {
+  throw std::runtime_error("gemm_batched_cl is not implemented");
+}
+
+void im2col_cl(const unsigned int C, const unsigned int H, const unsigned int W,
+               const unsigned int kernel_h, const unsigned int kernel_w,
+               const unsigned int pad_h, const unsigned int pad_w,
+               const unsigned int stride_h, const unsigned int stride_w,
+               const unsigned int dilation_h, const unsigned int dilation_w,
+               const float *input, float *output) {
+  throw std::runtime_error("im2col_cl is not implemented");
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/cl_operations/clblast_interface.h
+++ b/nntrainer/tensor/cl_operations/clblast_interface.h
@@ -13,7 +13,16 @@
 #ifndef __CLBLAST_INTERFACE_H__
 #define __CLBLAST_INTERFACE_H__
 
+#include <engine.h>
+
 namespace nntrainer {
+
+static ClContext *clblast_cc =
+  static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+static ClBufferManager &clBuffManagerInst = ClBufferManager::getInstance();
+
+static cl_command_queue command_queue =
+  clblast_cc->command_queue_inst_.GetCommandQueue();
 
 /**
  * @brief Multiplies n elements of vector x by a scalar constant alpha.
@@ -22,10 +31,8 @@ namespace nntrainer {
  * @param X Vector X (input)
  * @param incX Increment for input
  */
-template <typename T>
-void scal_cl(const unsigned int N, const T alpha, T *X, unsigned int incX = 1) {
-  throw std::runtime_error("scal_cl is not implemented");
-}
+void scal_cl(const unsigned int N, const float alpha, float *X,
+             unsigned int incX = 1);
 
 /**
  * @brief Copies the contents of vector x into vector y.
@@ -37,11 +44,8 @@ void scal_cl(const unsigned int N, const T alpha, T *X, unsigned int incX = 1) {
  * @param incY Increment for output
  * @note incX and incY are used to skip elements in the input and output
  */
-template <typename T>
-void copy_cl(const unsigned int N, const T *X, T *Y, unsigned int incX = 1,
-             unsigned int incY = 1) {
-  throw std::runtime_error("copy_cl is not implemented");
-}
+void copy_cl(const unsigned int N, const float *X, float *Y,
+             unsigned int incX = 1, unsigned int incY = 1);
 
 /**
  * @brief Performs the operation y = alpha * x + y
@@ -50,11 +54,8 @@ void copy_cl(const unsigned int N, const T *X, T *Y, unsigned int incX = 1,
  * @param X Vector X (input)
  * @param Y Vector Y (output)
  */
-template <typename T>
-void axpy_cl(const unsigned int N, const T alpha, const T *X, T *Y,
-             unsigned int incX = 1, unsigned int incY = 1) {
-  throw std::runtime_error("axpy_cl is not implemented");
-}
+void axpy_cl(const unsigned int N, const float alpha, const float *X, float *Y,
+             unsigned int incX = 1, unsigned int incY = 1);
 
 /**
  * @brief Multiplies n elements of the vectors x and y element-wise
@@ -65,11 +66,8 @@ void axpy_cl(const unsigned int N, const T alpha, const T *X, T *Y,
  * @param incY Increment for input Y
  * @note incX and incY are used to skip elements in the X and Y
  */
-template <typename T>
-T dot_cl(const unsigned int N, const T *X, const T *Y, unsigned int incX = 1,
-         unsigned int incY = 1) {
-  throw std::runtime_error("dot_cl is not implemented");
-}
+float dot_cl(const unsigned int N, const float *X, const float *Y,
+             unsigned int incX = 1, unsigned int incY = 1);
 
 /**
  * @brief Accumulates the square of n elements in the x vector and takes the
@@ -78,43 +76,31 @@ T dot_cl(const unsigned int N, const T *X, const T *Y, unsigned int incX = 1,
  * @param X Vector X (input)
  * @param incX Increment for input
  */
-template <typename T>
-T nrm2_cl(const unsigned int N, const T *X, unsigned int incX = 1) {
-  throw std::runtime_error("nrm2_cl is not implemented");
-}
+float nrm2_cl(const unsigned int N, const float *X, unsigned int incX = 1);
 
 /**
- * @brief     Computes the absolute sum of value in the vector X
+ * @brief Computes the absolute sum of value in the vector X
  * @param N Number of elements
  * @param X Vector X (input)
  * @param incX Increment for input
  */
-template <typename T>
-T asum_cl(const unsigned int N, const T *X, unsigned int incX = 1) {
-  throw std::runtime_error("asum_cl is not implemented");
-}
+float asum_cl(const unsigned int N, const float *X, unsigned int incX = 1);
 
 /**
- * @brief     Index of absolute maximum value in a vector X
+ * @brief Index of absolute maximum value in a vector X
  * @param N Number of elements
  * @param X Vector X (input)
  * @param incX Increment for input
  */
-template <typename T>
-int amax_cl(const unsigned int N, const T *X, unsigned int incX = 1) {
-  throw std::runtime_error("amax_cl is not implemented");
-}
+int amax_cl(const unsigned int N, const float *X, unsigned int incX = 1);
 
 /**
- * @brief     Index of absolute minimum value in a vector X
+ * @brief Index of absolute minimum value in a vector X
  * @param N Number of elements
  * @param X Vector X (input)
  * @param incX Increment for input
  */
-template <typename T>
-int amin_cl(const unsigned int N, const T *X, unsigned int incX = 1) {
-  throw std::runtime_error("amin_cl is not implemented");
-}
+int amin_cl(const unsigned int N, const float *X, unsigned int incX = 1);
 
 /**
  * @brief General matrix-vector multiplication
@@ -133,13 +119,10 @@ int amin_cl(const unsigned int N, const T *X, unsigned int incX = 1) {
  * @param incX increment for input
  * @param incY increment for output
  */
-template <typename T>
 void gemv_cl(const unsigned int layout, bool TransA, const unsigned int M,
-             const unsigned int N, const T alpha, const T *A,
-             const unsigned int lda, const T *X, const T beta, T *Y,
-             unsigned int incX = 1, unsigned int incY = 1) {
-  throw std::runtime_error("gemv_cl is not implemented");
-}
+             const unsigned int N, const float alpha, const float *A,
+             const unsigned int lda, const float *X, const float beta, float *Y,
+             unsigned int incX = 1, unsigned int incY = 1);
 
 /**
  * @brief General matrix-matrix multiplication
@@ -161,14 +144,11 @@ void gemv_cl(const unsigned int layout, bool TransA, const unsigned int M,
  * @param ldc leading dimension of C
  * @note The result is stored in C, which is also the output matrix.
  */
-template <typename T>
 void gemm_cl(const unsigned int layout, bool TransA, bool TransB,
              const unsigned int M, const unsigned int N, const unsigned int K,
-             const T alpha, const T *A, const unsigned int lda, const T *B,
-             const unsigned int ldb, const T beta, T *C,
-             const unsigned int ldc) {
-  throw std::runtime_error("gemm_cl is not implemented");
-}
+             const float alpha, const float *A, const unsigned int lda,
+             const float *B, const unsigned int ldb, const float beta, float *C,
+             const unsigned int ldc);
 
 /**
  * @brief Batched version of GEMM
@@ -191,15 +171,12 @@ void gemm_cl(const unsigned int layout, bool TransA, bool TransB,
  * @param batch_size number of batches
  * @note The result is stored in C, which is also the output matrix.
  */
-template <typename T>
 void gemm_batched_cl(const unsigned int layout, bool TransA, bool TransB,
                      const unsigned int M, const unsigned int N,
-                     const unsigned int K, const T *alpha, const T *A,
-                     const unsigned int lda, const T *B, const unsigned int ldb,
-                     const T *beta, T *C, const unsigned int ldc,
-                     const unsigned int batch_size) {
-  throw std::runtime_error("gemm_batched_cl is not implemented");
-}
+                     const unsigned int K, const float *alpha, const float *A,
+                     const unsigned int lda, const float *B,
+                     const unsigned int ldb, const float *beta, float *C,
+                     const unsigned int ldc, const unsigned int batch_size);
 
 /**
  * @brief Performs the im2col algorithm
@@ -223,15 +200,12 @@ void gemm_batched_cl(const unsigned int layout, bool TransA, bool TransB,
  * The number of columns is equal to the number of patches that can be
  * extracted from the input tensor.
  */
-template <typename T>
 void im2col_cl(const unsigned int C, const unsigned int H, const unsigned int W,
                const unsigned int kernel_h, const unsigned int kernel_w,
                const unsigned int pad_h, const unsigned int pad_w,
                const unsigned int stride_h, const unsigned int stride_w,
                const unsigned int dilation_h, const unsigned int dilation_w,
-               const T *input, T *output) {
-  throw std::runtime_error("im2col_cl is not implemented");
-}
+               const float *input, float *output);
 
 } // namespace nntrainer
 

--- a/nntrainer/tensor/cl_operations/clblast_interface.h
+++ b/nntrainer/tensor/cl_operations/clblast_interface.h
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Donghyeon Jeong <dhyeon.jeong@samsung.com>
+ *
+ * @file	clblast_interface.h
+ * @date	12 May 2025
+ * @brief	CLBlast library interface
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Donghyeon Jeong <dhyeon.jeong@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#ifndef __CLBLAST_INTERFACE_H__
+#define __CLBLAST_INTERFACE_H__
+
+namespace nntrainer {
+
+/**
+ * @brief Multiplies n elements of vector x by a scalar constant alpha.
+ * @param N Number of elements
+ * @param alpha Scalar constant
+ * @param X Vector X (input)
+ * @param incX Increment for input
+ */
+template <typename T>
+void scal_cl(const unsigned int N, const T alpha, T *X, unsigned int incX = 1) {
+  throw std::runtime_error("scal_cl is not implemented");
+}
+
+/**
+ * @brief Copies the contents of vector x into vector y.
+ *
+ * @param N Number of elements
+ * @param X Vector X (input)
+ * @param Y Vector Y (output)
+ * @param incX Increment for input
+ * @param incY Increment for output
+ * @note incX and incY are used to skip elements in the input and output
+ */
+template <typename T>
+void copy_cl(const unsigned int N, const T *X, T *Y, unsigned int incX = 1,
+             unsigned int incY = 1) {
+  throw std::runtime_error("copy_cl is not implemented");
+}
+
+/**
+ * @brief Performs the operation y = alpha * x + y
+ * @param N Number of elements
+ * @param alpha Scalar constant
+ * @param X Vector X (input)
+ * @param Y Vector Y (output)
+ */
+template <typename T>
+void axpy_cl(const unsigned int N, const T alpha, const T *X, T *Y,
+             unsigned int incX = 1, unsigned int incY = 1) {
+  throw std::runtime_error("axpy_cl is not implemented");
+}
+
+/**
+ * @brief Multiplies n elements of the vectors x and y element-wise
+ * @param N Number of elements
+ * @param X Vector X (input)
+ * @param Y Vector Y (input)
+ * @param incX Increment for input X
+ * @param incY Increment for input Y
+ * @note incX and incY are used to skip elements in the X and Y
+ */
+template <typename T>
+T dot_cl(const unsigned int N, const T *X, const T *Y, unsigned int incX = 1,
+         unsigned int incY = 1) {
+  throw std::runtime_error("dot_cl is not implemented");
+}
+
+/**
+ * @brief Accumulates the square of n elements in the x vector and takes the
+ * square root.
+ * @param N Number of elements
+ * @param X Vector X (input)
+ * @param incX Increment for input
+ */
+template <typename T>
+T nrm2_cl(const unsigned int N, const T *X, unsigned int incX = 1) {
+  throw std::runtime_error("nrm2_cl is not implemented");
+}
+
+/**
+ * @brief     Computes the absolute sum of value in the vector X
+ * @param N Number of elements
+ * @param X Vector X (input)
+ * @param incX Increment for input
+ */
+template <typename T>
+T asum_cl(const unsigned int N, const T *X, unsigned int incX = 1) {
+  throw std::runtime_error("asum_cl is not implemented");
+}
+
+/**
+ * @brief     Index of absolute maximum value in a vector X
+ * @param N Number of elements
+ * @param X Vector X (input)
+ * @param incX Increment for input
+ */
+template <typename T>
+int amax_cl(const unsigned int N, const T *X, unsigned int incX = 1) {
+  throw std::runtime_error("amax_cl is not implemented");
+}
+
+/**
+ * @brief     Index of absolute minimum value in a vector X
+ * @param N Number of elements
+ * @param X Vector X (input)
+ * @param incX Increment for input
+ */
+template <typename T>
+int amin_cl(const unsigned int N, const T *X, unsigned int incX = 1) {
+  throw std::runtime_error("amin_cl is not implemented");
+}
+
+/**
+ * @brief General matrix-vector multiplication
+ * Performs the operation y = alpha * A * x + beta * y
+ *
+ * @param layout Data-layout of the matrix (Row-major or Column-major)
+ * @param TransA Transpose flag for matrix A
+ * @param M number of rows in A
+ * @param N number of columns in A
+ * @param alpha scalar multiplier for A
+ * @param A Matrix A (input)
+ * @param lda leading dimension of A
+ * @param X Vector X (input)
+ * @param beta scalar multiplier for Y
+ * @param Y Vector Y (output)
+ * @param incX increment for input
+ * @param incY increment for output
+ */
+template <typename T>
+void gemv_cl(const unsigned int layout, bool TransA, const unsigned int M,
+             const unsigned int N, const T alpha, const T *A,
+             const unsigned int lda, const T *X, const T beta, T *Y,
+             unsigned int incX = 1, unsigned int incY = 1) {
+  throw std::runtime_error("gemv_cl is not implemented");
+}
+
+/**
+ * @brief General matrix-matrix multiplication
+ * Performs the matrix product C = alpha * A * B + beta * C
+ *
+ * @param layout Data-layout of the matrix (Row-major or Column-major)
+ * @param TransA Transpose flag for matrix A
+ * @param TransB Transpose flag for matrix B
+ * @param M number of rows in A and C
+ * @param N number of columns in B and C
+ * @param K number of columns in A and rows in B
+ * @param alpha scalar multiplier for A and B
+ * @param A Matrix A (input)
+ * @param lda leading dimension of A
+ * @param B Matrix B (input)
+ * @param ldb leading dimension of B
+ * @param beta scalar multiplier for C
+ * @param C Matrix C (input/output)
+ * @param ldc leading dimension of C
+ * @note The result is stored in C, which is also the output matrix.
+ */
+template <typename T>
+void gemm_cl(const unsigned int layout, bool TransA, bool TransB,
+             const unsigned int M, const unsigned int N, const unsigned int K,
+             const T alpha, const T *A, const unsigned int lda, const T *B,
+             const unsigned int ldb, const T beta, T *C,
+             const unsigned int ldc) {
+  throw std::runtime_error("gemm_cl is not implemented");
+}
+
+/**
+ * @brief Batched version of GEMM
+ * As GEMM, but multiple operations are batched together for better performance.
+ *
+ * @param layout Data-layout of the matrix (Row-major or Column-major)
+ * @param TransA Transpose flag for matrix A
+ * @param TransB Transpose flag for matrix B
+ * @param M number of rows in A and C
+ * @param N number of columns in B and C
+ * @param K number of columns in A and rows in B
+ * @param alpha scalar multipliers for A and B
+ * @param A Matrix A (input)
+ * @param lda leading dimension of A
+ * @param B Matrix B (input)
+ * @param ldb leading dimension of B
+ * @param beta scalar multipliers for C
+ * @param C Matrix C (input/output)
+ * @param ldc leading dimension of C
+ * @param batch_size number of batches
+ * @note The result is stored in C, which is also the output matrix.
+ */
+template <typename T>
+void gemm_batched_cl(const unsigned int layout, bool TransA, bool TransB,
+                     const unsigned int M, const unsigned int N,
+                     const unsigned int K, const T *alpha, const T *A,
+                     const unsigned int lda, const T *B, const unsigned int ldb,
+                     const T *beta, T *C, const unsigned int ldc,
+                     const unsigned int batch_size) {
+  throw std::runtime_error("gemm_batched_cl is not implemented");
+}
+
+/**
+ * @brief Performs the im2col algorithm
+ *
+ * @param C channel size
+ * @param H height of the input
+ * @param W width of the input
+ * @param kernel_h height of the kernel
+ * @param kernel_w width of the kernel
+ * @param pad_h padding height
+ * @param pad_w padding width
+ * @param stride_h stride height
+ * @param stride_w stride width
+ * @param dilation_h dilation height
+ * @param dilation_w dilation width
+ * @param input input tensor
+ * @param output output tensor
+ * @note The output tensor is a 2D matrix where each column corresponds to a
+ * patch of the input tensor. The number of rows is equal to the number of
+ * channels multiplied by the kernel size (kernel_h * kernel_w).
+ * The number of columns is equal to the number of patches that can be
+ * extracted from the input tensor.
+ */
+template <typename T>
+void im2col_cl(const unsigned int C, const unsigned int H, const unsigned int W,
+               const unsigned int kernel_h, const unsigned int kernel_w,
+               const unsigned int pad_h, const unsigned int pad_w,
+               const unsigned int stride_h, const unsigned int stride_w,
+               const unsigned int dilation_h, const unsigned int dilation_w,
+               const T *input, T *output) {
+  throw std::runtime_error("im2col_cl is not implemented");
+}
+
+} // namespace nntrainer
+
+#endif /* __CLBLAST_INTERFACE_H__ */

--- a/nntrainer/tensor/cl_operations/meson.build
+++ b/nntrainer/tensor/cl_operations/meson.build
@@ -12,6 +12,7 @@ cl_op_headers = [
   'blas_kernel_strings.h',
   'attention_kernel_interface.h',
   'attention_kernel_strings.h',
+  'clblast_interface.h'
 ]
 
 if get_option('enable-fp16')

--- a/nntrainer/tensor/cl_operations/meson.build
+++ b/nntrainer/tensor/cl_operations/meson.build
@@ -5,6 +5,7 @@ cl_op_sources = [
   'attention_kernel_interface.cpp',
   'attention_kernel_strings.cpp',
   'attention_kernels.cpp',
+  'clblast_interface.cpp'
 ]
 
 cl_op_headers = [

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -57,6 +57,15 @@ LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/builddir/jni/$(TARGET_ARCH_ABI)//libggml.so
 
 include $(PREBUILT_SHARED_LIBRARY)
 
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := opencl
+LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/builddir/jni/$(TARGET_ARCH_ABI)/libOpenCL.so
+
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+
 LOCAL_MODULE := clblast
 LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/builddir/obj/local/$(TARGET_ARCH_ABI)/libclblast.a
 
@@ -100,7 +109,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -117,7 +126,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -134,7 +143,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -151,7 +160,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -168,7 +177,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -185,7 +194,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -202,7 +211,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -219,7 +228,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -236,7 +245,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -253,7 +262,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -270,7 +279,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -286,7 +295,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -302,7 +311,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -318,7 +327,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -334,7 +343,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -350,7 +359,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -366,7 +375,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -384,7 +393,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -402,7 +411,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -422,7 +431,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -446,7 +455,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -502,7 +511,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -518,7 +527,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -534,7 +543,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
 
@@ -550,7 +559,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)
 
@@ -567,6 +576,6 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
This PR introduces the implementation of basic BLAS functions in CLBlast, including scal, copy, axpy, dot, nrm2, asum, amax, and amin, while noting that GEMV, GEMM, and im2col will be included in a future pull request. Additionally, it enhances the NNTrainer BLAS kernel with newly added CLBlast kernels by incorporating new kernel interfaces and replacing existing ones, although half-precision support is not yet implemented and will be addressed later. Furthermore, unit tests were added for the new OpenCL BLAS kernels to verify their adaptation to NNTrainer and to compare the results with those generated by the CPU.