### PR TITLE
[Windows] Modify meson.build for windows build(msvc)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -474,23 +474,25 @@ if get_option('enable-ggml')
   if arch == 'arm' or arch == 'aarch64' or get_option('platform') == 'android'
     ggml_options.add_cmake_defines({'CMAKE_INSTALL_LIBDIR': nntrainer_libdir / 'arm64-v8a'})
   endif
+
+  if host_machine.system() == 'windows'
+    if arch == 'x86_64'
+      if cc.has_argument('-march=x86-64-v2')
+        cpu_type = 'x86-64-v2'
+      elif cc.has_argument('-march=haswell')
+        cpu_type = 'haswell'
+      else
+        cpu_type = 'x86-64'
+      endif
+      
+      message('Auto-detected safe CPU tuning: ' + cpu_type)
+
+      ggml_options.append_compile_args('c', '-march=' + cpu_type)
+      ggml_options.append_compile_args('cpp', '-march=' + cpu_type)
+    endif
+  endif
+
   ggml_options.append_compile_args('c', ['-Wno-error=maybe-uninitialized', '-Wno-error=pointer-to-int-cast'])
-
-  # TODO : This commit is to enable ggml in ubuntu 20.04, but occured error. Since ubuntu 20.04 is not the main target anymore, temporarily disable it.
-  # if arch == 'x86_64'
-  #   if cc.has_argument('-march=x86-64-v2')
-  #     cpu_type = 'x86-64-v2'
-  #   elif cc.has_argument('-march=haswell')
-  #     cpu_type = 'haswell'
-  #   else
-  #     cpu_type = 'x86-64'
-  #   endif
-  # endif
-
-  # message('Auto-detected safe CPU tuning: ' + cpu_type)
-
-  # ggml_options.append_compile_args('c', '-march=' + cpu_type)
-  # ggml_options.append_compile_args('cpp', '-march=' + cpu_type)
 
   ggml_proj = cmake.subproject('ggml', options: ggml_options, required: true)
   ggml_dep = [

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -115,6 +115,14 @@ template <typename T = float> T logFloat(T x) {
  */
 template <typename T = float> T exp_util(T x) { return static_cast<T>(exp(x)); }
 
+#ifdef _WIN32
+#ifdef _Float16
+template <> _Float16 exp_util<_Float16>(_Float16 x) {
+  return static_cast<_Float16>(std::exp(static_cast<float>(x)));
+}
+#endif
+#endif
+
 /**
  * @brief     Check Existance of File
  * @param[in] file path of the file to be checked


### PR DESCRIPTION
The meson.build has been modified to build nntrainer on Windows. 
Additionally, exp_util with _Float16 type has been added for Windows.

The current modifications have only been tested with msvc. 
Testing and additional support for Clang builds will be implemented later.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped