### PR TITLE
[ q4K ] Add optimized q4K/q40 GEMM and GEMV functions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -471,7 +471,7 @@ if get_option('enable-ggml')
   ggml_options.add_cmake_defines({'BUILD_SHARED_LIBS': host_machine.system() != 'windows'})
   ggml_options.add_cmake_defines({'GGML_BUILD_TESTS': false})
   ggml_options.add_cmake_defines({'GGML_BUILD_EXAMPLES': false})
-  if get_option('platform') == 'android'
+  if arch == 'arm' or arch == 'aarch64' or get_option('platform') == 'android'
     ggml_options.add_cmake_defines({'CMAKE_INSTALL_LIBDIR': nntrainer_libdir / 'arm64-v8a'})
   endif
   ggml_options.append_compile_args('c', ['-Wno-error=maybe-uninitialized', '-Wno-error=pointer-to-int-cast'])

--- a/meson.build
+++ b/meson.build
@@ -476,20 +476,21 @@ if get_option('enable-ggml')
   endif
   ggml_options.append_compile_args('c', ['-Wno-error=maybe-uninitialized', '-Wno-error=pointer-to-int-cast'])
 
-  if arch == 'x86_64'
-    if cc.has_argument('-march=x86-64-v2')
-      cpu_type = 'x86-64-v2'
-    elif cc.has_argument('-march=haswell')
-      cpu_type = 'haswell'
-    else
-      cpu_type = 'x86-64'
-    endif
-  endif
+  # TODO : This commit is to enable ggml in ubuntu 20.04, but occured error. Since ubuntu 20.04 is not the main target anymore, temporarily disable it.
+  # if arch == 'x86_64'
+  #   if cc.has_argument('-march=x86-64-v2')
+  #     cpu_type = 'x86-64-v2'
+  #   elif cc.has_argument('-march=haswell')
+  #     cpu_type = 'haswell'
+  #   else
+  #     cpu_type = 'x86-64'
+  #   endif
+  # endif
 
-  message('Auto-detected safe CPU tuning: ' + cpu_type)
+  # message('Auto-detected safe CPU tuning: ' + cpu_type)
 
-  ggml_options.append_compile_args('c', '-march=' + cpu_type)
-  ggml_options.append_compile_args('cpp', '-march=' + cpu_type)
+  # ggml_options.append_compile_args('c', '-march=' + cpu_type)
+  # ggml_options.append_compile_args('cpp', '-march=' + cpu_type)
 
   ggml_proj = cmake.subproject('ggml', options: ggml_options, required: true)
   ggml_dep = [

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -26,13 +26,22 @@
 #include <vector>
 
 namespace nntrainer {
-
+/**
+ * @brief Continuously packed 4 q8_K
+ *
+ */
 struct block_q8_Kx4 {
   float d[4];              // delta
   int8_t qs[QK_K * 4];     // quants
   int16_t bsums[QK_K / 4]; // sum of quants in groups of 16
 };
 
+/**
+ * @brief struct template for q4_0 and q8_0
+ *
+ * @tparam K 4 or 8
+ * @return constexpr int number of elements in the quantized block
+ */
 template <int K> constexpr int QK_0() {
   if constexpr (K == 4) {
     return QK4_0;
@@ -43,6 +52,12 @@ template <int K> constexpr int QK_0() {
   return -1;
 }
 
+/**
+ * @brief block of q4_0 or q8_0 block
+ *
+ * @tparam K 4 or 8
+ * @tparam N number of blocks to be packed
+ */
 template <int K, int N> struct block {
   ggml_half d[N];                     // deltas for N qK_0 blocks
   int8_t qs[(QK_0<K>() * N * K) / 8]; // quants for N qK_0 blocks

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2025 Michal Wlasiuk <testmailsmtp12345@gmail.com>
+ * Copyright (C) 2025 Sungsik Kong <ss.kong@samsung.com>
  *
  * @file   ggml_interface.h
  * @date   15 April 2025
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Michal Wlasiuk <testmailsmtp12345@gmail.com>
+ * @author Sungsik Kong <ss.kong@samsung.com>
  * @bug    No known bugs except for NYI items
  * @brief  Function interface to use ggml lib from cpu_backend
  */
@@ -27,9 +29,9 @@ void __ggml_init();
 /**
  * @brief Quantize float to q4_0 Quantization format
  *
- * @param src
- * @param dst
- * @param nrow
+ * @param src input src to be quantized
+ * @param dst output destination for quantized data
+ * @param nrow 
  * @param n_per_row
  * @param quant_weights
  * @return size_t

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -31,10 +31,11 @@ void __ggml_init();
  *
  * @param src input src to be quantized
  * @param dst output destination for quantized data
- * @param nrow 
- * @param n_per_row
- * @param quant_weights
- * @return size_t
+ * @param nrow number of row
+ * @param n_per_row number of elements per row
+ * @param quant_weights additional information for quantization. Currently in no
+ * use.
+ * @return size_t total size of quantized data
  */
 size_t __ggml_quantize_q4_0(const float *src, void *dst, int64_t nrow,
                             int64_t n_per_row, const float *quant_weights);
@@ -42,28 +43,29 @@ size_t __ggml_quantize_q4_0(const float *src, void *dst, int64_t nrow,
 /**
  * @brief Quantize float to q4_K Quantization format
  *
- * @param src
- * @param dst
- * @param nrow
- * @param n_per_row
- * @param quant_weights
- * @return size_t
+ * @param src input src to be quantized
+ * @param dst output destination for quantized data
+ * @param nrow number of row
+ * @param n_per_row number of elements per row
+ * @param quant_weights additional information for quantization. Currently in no
+ * use.
+ * @return size_t total size of quantized data
  */
 size_t __ggml_quantize_q4_K(const float *src, void *dst, int64_t nrow,
                             int64_t n_per_row, const float *quant_weights);
 
 /**
- * @brief
+ * @brief A(M, K) * W.T(N, K) = (M, N)
  *
- * @param M
- * @param N
- * @param K
- * @param A
- * @param lda
- * @param B
- * @param ldb
- * @param C
- * @param ldc
+ * @param M as descripted above
+ * @param N as descripted above
+ * @param K as descripted above
+ * @param A Activation
+ * @param lda leading dimension of A
+ * @param B offline quantized and packed q4_0x8 Weight
+ * @param ldb leading dimension of B
+ * @param C dst matrix
+ * @param ldc leading dimension of C
  */
 void __ggml_q4_0_8x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
                                const unsigned int K, const float *A,
@@ -72,17 +74,17 @@ void __ggml_q4_0_8x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
                                const unsigned int ldc);
 
 /**
- * @brief
+ * @brief A(M, K) * W.T(N, K) = (M, N)
  *
- * @param M
- * @param N
- * @param K
- * @param A
- * @param lda
- * @param B
- * @param ldb
- * @param C
- * @param ldc
+ * @param M as descripted above
+ * @param N as descripted above
+ * @param K as descripted above
+ * @param A Activation
+ * @param lda leading dimension of A
+ * @param B offline quantized and packed q4_kx8 Weight
+ * @param ldb leading dimension of B
+ * @param C dst matrix
+ * @param ldc leading dimension of C
  */
 void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
                                const unsigned int K, const float *A,
@@ -91,43 +93,43 @@ void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
                                const unsigned int ldc);
 
 /**
- * @brief
+ * @brief q4K to float dequantize
  *
- * @param x_raw
- * @param y
- * @param k
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
  */
 void __ggml_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
 
 /**
- * @brief
+ * @brief q8K to float dequantize
  *
- * @param x
- * @param y
- * @param k
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
  */
 void __ggml_dequantize_row_q8_K(const void *x, float *y, int64_t k);
 
 /**
- * @brief
+ * @brief repack q40 to q40x8
  *
- * @param W
- * @param repacked_W
- * @param data_size
- * @param M
- * @param N
+ * @param W input q40
+ * @param repacked_W output q40x8
+ * @param data_size total weight size
+ * @param M number of rows
+ * @param N number of columns
  */
 void __ggml_repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
                                   const unsigned int M, const unsigned int N);
 
 /**
- * @brief
+ * @brief repack q4K to q4Kx8
  *
- * @param W
- * @param repacked_W
- * @param data_size
- * @param M
- * @param N
+ * @param W input q4K
+ * @param repacked_W output q4Kx8
+ * @param data_size total weight size
+ * @param M number of rows
+ * @param N number of columns
  */
 void __ggml_repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
                                   const unsigned int M, const unsigned int N);

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -558,6 +558,8 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/fallback_internal.h
 %{_includedir}/nntrainer/cblas_interface.h
 %{_includedir}/nntrainer/ggml_interface.h
+%{_includedir}/nntrainer/bs_thread_pool.h
+%{_includedir}/nntrainer/bs_thread_pool_manager.hpp
 %ifarch %{ix86} x86_64
 %{_includedir}/nntrainer/x86_compute_backend.h
 %{_includedir}/nntrainer/avx2_impl.h
@@ -618,8 +620,6 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 # update this to enable external applications
 # @todo filter out headers that should be hidden, and classifiy in the appropriate place if not
 %{_includedir}/nntrainer/util_func.h
-%{_includedir}/nntrainer/bs_thread_pool.h
-%{_includedir}/nntrainer/bs_thread_pool_manager.hpp
 %{_includedir}/nntrainer/fp16.h
 %{_includedir}/nntrainer/util_simd.h
 %{_includedir}/nntrainer/dynamic_library_loader.h


### PR DESCRIPTION
- Add openMP-optimized q4K GEMM and GEMV multithreaded functions
- Add openMP-optimized q40 GEMM and GEMV multithreaded functions  
- Remove redundant codes and print statements
- BS threadpool-optimized functions will be introduced later on
- non-256-divisible-M computation of q4K GEMM will be introduced later on