### PR TITLE
[Fix] Fix nntrainer build with ggml enabled on windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -467,6 +467,8 @@ if get_option('enable-ggml')
   ggml_root = meson.source_root() / 'subprojects' / 'ggml'
   if cxx_compiler_id == 'msvc'
     ggml_options.add_cmake_defines(common_win_subproject_cmake_defines)
+  else
+    ggml_options.append_compile_args('c', ['-Wno-error=maybe-uninitialized', '-Wno-error=pointer-to-int-cast'])
   endif
   ggml_options.add_cmake_defines({'BUILD_SHARED_LIBS': host_machine.system() != 'windows'})
   ggml_options.add_cmake_defines({'GGML_BUILD_TESTS': false})
@@ -491,8 +493,6 @@ if get_option('enable-ggml')
       ggml_options.append_compile_args('cpp', '-march=' + cpu_type)
     endif
   endif
-
-  ggml_options.append_compile_args('c', ['-Wno-error=maybe-uninitialized', '-Wno-error=pointer-to-int-cast'])
 
   ggml_proj = cmake.subproject('ggml', options: ggml_options, required: true)
   ggml_dep = [

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -99,7 +99,8 @@ void __ggml_q4_0_8x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
     ::quantize_row_q8_0(A, QA.data(), K);
 
 #pragma omp parallel for num_threads(n_threads)
-    for (unsigned int thread_idx = 0; thread_idx < n_threads; ++thread_idx) {
+    for (int thread_idx = 0; thread_idx < static_cast<int>(n_threads);
+         ++thread_idx) {
       unsigned int M_step_start = (thread_idx * N) / n_threads;     // = 0
       unsigned int M_step_end = ((thread_idx + 1) * N) / n_threads; // ne01 = N
 
@@ -124,7 +125,7 @@ void __ggml_q4_0_8x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
     /// @note Heuristic inspection conducted that applying multithreading on
     /// run-time quantization hurts model latency
     // #pragma omp parallel for collapse(1) num_threads(16)
-    for (unsigned int i = 0; i < M4; i++) {
+    for (int i = 0; i < static_cast<int>(M4); i++) {
       ::ggml_quantize_mat_q8_0_4x8(A + 4 * i * K,
                                    QA.data() + i * qa_4_rows_size, K);
     }
@@ -169,7 +170,8 @@ void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
     ::quantize_row_q8_K(A, QA.data(), K);
 
 #pragma omp parallel for num_threads(n_threads)
-    for (unsigned int thread_idx = 0; thread_idx < n_threads; ++thread_idx) {
+    for (int thread_idx = 0; thread_idx < static_cast<int>(n_threads);
+         ++thread_idx) {
       unsigned int M_step_start = (thread_idx * N) / n_threads;     // = 0
       unsigned int M_step_end = ((thread_idx + 1) * N) / n_threads; // ne01 = N
 
@@ -196,13 +198,13 @@ void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
     /// @note Heuristic inspection conducted that applying multithreading on
     /// run-time quantization hurts model latency
     // #pragma omp parallel for collapse(1) num_threads(16)
-    for (unsigned int i = 0; i < M4; i++) {
+    for (int i = 0; i < static_cast<int>(M4); i++) {
       ::ggml_quantize_mat_q8_K_4x8(A + 4 * i * K,
                                    QA.data() + i * qa_4_rows_size, K);
     }
 
 #pragma omp parallel for collapse(1) num_threads(thread_num)
-    for (unsigned int i = 0; i < thread_num; i++) {
+    for (int i = 0; i < static_cast<int>(thread_num); i++) {
       unsigned int src0_start = (i * N) / thread_num;
       unsigned int src0_end = ((i + 1) * N) / thread_num;
 


### PR DESCRIPTION
Fix nntrainer build with enable-ggml=true on Windows

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

