### PR TITLE
[ q4K ] Enable non-4-divisible-M q4K GEMM case

### DIFF
--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -182,7 +182,37 @@ void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
                                 (void *)((char *)B + M_step_start * B_step),
                                 QA.data(), M, M_step_end - M_step_start);
     }
-  } else { // GEMM
+  } else if (M % 4 != 0) {
+    int n_threads = 4;
+    if (K < 1592 && N < 1592)
+      n_threads = 1;
+    int blocks_per_row = (K + QK_K - 1) / QK_K;
+    int qa_size = sizeof(block_q8_K) * blocks_per_row;
+    int B_step = sizeof(block_q4_K) * (K / QK_K);
+
+    for (unsigned int pb = 0; pb < M; ++pb) {
+      std::vector<char> QA = std::vector<char>(qa_size);
+      ::quantize_row_q8_K(A + pb * K, QA.data(), K);
+
+#pragma omp parallel for num_threads(n_threads)
+      for (int thread_idx = 0; thread_idx < n_threads; ++thread_idx) {
+        int M_step_start = (thread_idx * N) / n_threads;     // = 0
+        int M_step_end = ((thread_idx + 1) * N) / n_threads; // ne01 = N
+
+        M_step_start = (M_step_start % 8)
+                         ? M_step_start + 8 - (M_step_start % 8)
+                         : M_step_start;
+        M_step_end =
+          (M_step_end % 8) ? M_step_end + 8 - (M_step_end % 8) : M_step_end;
+
+        ::ggml_gemv_q4_K_8x8_q8_K(K, (float *)((C + pb * N) + M_step_start), N,
+                                  (void *)((char *)B + M_step_start * B_step),
+                                  QA.data(), 1, M_step_end - M_step_start);
+      }
+    }
+  }
+
+  else { // GEMM
     unsigned int blocks_per_4_rows = (K + QK_K - 1) / QK_K;
     unsigned int qa_4_rows_size = sizeof(block_q8_Kx4) * blocks_per_4_rows;
     unsigned int M4 = ((M + 3) / 4);

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -337,6 +337,36 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x1536x5760) {
   ASSERT_LE(q4_k_mse, 2.0f);
 }
 
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x3072x3072) {
+  const unsigned int M = 457;
+  const unsigned int K = 3072;
+  const unsigned int N = 3072;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  // ASSERT_LE(q0_k_mse, 1.5f);
+  ASSERT_LE(q4_k_mse, 1.5f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x3072x3072) {
+  const unsigned int M = 458;
+  const unsigned int K = 3072;
+  const unsigned int N = 3072;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  // ASSERT_LE(q0_k_mse, 1.5f);
+  ASSERT_LE(q4_k_mse, 1.5f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x3072x3072) {
+  const unsigned int M = 459;
+  const unsigned int K = 3072;
+  const unsigned int N = 3072;
+  float q0_k_mse, q4_k_mse;
+  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
+  // ASSERT_LE(q0_k_mse, 1.5f);
+  ASSERT_LE(q4_k_mse, 1.5f);
+}
+
 TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x3072x3072) {
   const unsigned int M = 1024;
   const unsigned int K = 3072;


### PR DESCRIPTION
- DONE : Compute all q4K GEMM rows with q4K GEMV to avoid divisibility
- TODO : Compute with q4K GEMM kernel first, and compute remaining rows with q4K GEMV + apply multithreading on the total sequence
- Add unittest for that (M = 457, 458, 459) accordingly
- With recent upstream main, leftover rows for 4 after GEMM kernel, left zero-filled rows


**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped
