### PR TITLE
Manual rebase of Q6 work (#3170) + add Q6 dequantization.

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -267,8 +267,7 @@ void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
 #ifdef ENABLE_GGML
   return __ggml_gemm_q6_K(M, N, K, A, lda, B, ldb, C, ldc);
 #else
-  // return __fallback_gemm_q6_K(M, N, K, A, lda, B, ldb, C, ldc);
-  return;
+  return __fallback_gemm_q6_K(M, N, K, A, lda, B, ldb, C, ldc);
 #endif
 }
 

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -280,6 +280,14 @@ float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
 #endif
 }
 
+float dot_q6_K_f32(const unsigned int K, const void *v_q6_K, const float *f) {
+#ifdef ENABLE_GGML
+  return __ggml_vec_dot_q6_K_f32(K, v_q6_K, f);
+#else
+  return __fallback_dot_q6_K_f32(K, v_q6_K, f);
+#endif
+}
+
 size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights) {
 #ifdef ENABLE_GGML

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -770,22 +770,6 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
 void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);
-/**
- * @brief
- *
- * @param M Original row size of output
- * @param N Original col size of output
- * @param K Hidden size
- * @param A Input activation to be online-runtime quantized to q6_K_MxN format
- * @param lda Leading dimension of A
- * @param B (void*) (block_q6_K*) for Offline-quantized transposed weight
- * @param ldb Leading dimenstion of B
- * @param C float* output
- * @param ldc Leading dimension of C
- */
-void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
-               const float *A, const unsigned int lda, const void *B,
-               const unsigned int ldb, float *C, const unsigned int ldc);
 
 /**
  * @brief

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -798,6 +798,8 @@ void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
 float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                     const void *v_q8_K);
 
+float dot_q6_K_f32(const unsigned int K, const void *v_q6_K, const float *f);
+
 /**
  * @brief
  *

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -773,6 +773,23 @@ void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
 /**
  * @brief
  *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q6_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q6_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
+
+/**
+ * @brief
+ *
  * @param K Length of vectors
  * @param v_q6_K lhs vector - data stored in Q6_K format
  * @param v_q8_K rhs vector - data stored in Q8_K format

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -668,6 +668,23 @@ extern size_t quantize_q6_K(const float *src, void *dst, int64_t nrow,
 /**
  * @brief
  *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q6_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q6_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
+
+/**
+ * @brief
+ *
  * @param K Length of vectors
  * @param v_q6_K lhs vector - data stored in Q6_K format
  * @param v_q8_K rhs vector - data stored in Q8_K format

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -702,7 +702,7 @@ extern float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
  * @return float Result of performing dot operation on v_q6_K and v_q8_K
  */
 extern float dot_q6_K_f32(const unsigned int K, const void *v_q6_K,
-                           const float *f);
+                          const float *f);
 
 /**
  * @brief dequantize row of q4_K data to float

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -694,6 +694,17 @@ extern float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                            const void *v_q8_K);
 
 /**
+ * @brief
+ *
+ * @param K Length of vectors
+ * @param v_q6_K lhs vector - data stored in Q6_K format
+ * @param f rhs vector - data stored in float format
+ * @return float Result of performing dot operation on v_q6_K and v_q8_K
+ */
+extern float dot_q6_K_f32(const unsigned int K, const void *v_q6_K,
+                           const float *f);
+
+/**
  * @brief dequantize row of q4_K data to float
  *
  * @param x input to be dequantized from q4_K to float

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -636,23 +636,7 @@ extern void gemm_q4_K(const unsigned int M, const unsigned int N,
                       const unsigned int K, const float *A,
                       const unsigned int lda, const void *B,
                       const unsigned int ldb, float *C, const unsigned int ldc);
-/**
- * @brief
- *
- * @param M
- * @param N
- * @param K
- * @param A
- * @param lda
- * @param B
- * @param ldb
- * @param C
- * @param ldc
- */
-extern void gemm_q6_K(const unsigned int M, const unsigned int N,
-                      const unsigned int K, const float *A,
-                      const unsigned int lda, const void *B,
-                      const unsigned int ldb, float *C, const unsigned int ldc);
+
 /**
  * @brief
  *

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -215,7 +215,7 @@ float dot_q6_K_f32(const unsigned int K, const void *v_q6_K, const float *f) {
   float __fallback_dot_q6_K_f32(K, v_q6_K, f);
 }
 
-float dot_q6_K_f32(const unsigned int K, const void *v_q6_K, const float *f) {
+float dot_q6_K_f32(const unsigned int K, const void *v_q6_K, const float *f){
 #error 2
 }
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -200,6 +200,12 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
   return __fallback_gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
 }
 
+void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc) {
+  return __fallback_gemm_q6_K(M, N, K, A, lda, B, ldb, C, ldc);
+}
+
 float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                     const void *v_q8_K) {
   return __fallback_dot_q6_K_q8_K(K, v_q6_K, v_q8_K);

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -211,6 +211,14 @@ float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
   return __fallback_dot_q6_K_q8_K(K, v_q6_K, v_q8_K);
 }
 
+float dot_q6_K_f32(const unsigned int K, const void *v_q6_K, const float *f) {
+  float __fallback_dot_q6_K_f32(K, v_q6_K, f);
+}
+
+float dot_q6_K_f32(const unsigned int K, const void *v_q6_K, const float *f) {
+#error 2
+}
+
 size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights) {
   return __fallback_quantize_q4_0(src, dst, nrow, n_per_row, quant_weights);

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -762,6 +762,23 @@ void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
 /**
  * @brief
  *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q6_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q6_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
+
+/**
+ * @brief
+ *
  * @param K Length of vectors
  * @param v_q6_K lhs vector - data stored in Q6_K format
  * @param v_q8_K rhs vector - data stored in Q8_K format

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -787,6 +787,8 @@ void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
 float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                     const void *v_q8_K);
 
+float dot_q6_K_f32(const unsigned int K, const void *v_q6_K, const float *f);
+
 /**
  * @brief
  *

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -375,6 +375,15 @@ float __fallback_dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
   return 0;
 }
 
+float __fallback_gemm_q6_K(const unsigned int M, const unsigned int N,
+                                const unsigned int K, const float *A,
+                                const unsigned int lda, const void *B,
+                                const unsigned int ldb, float *C,
+                                const unsigned int ldc) {
+  throw std::runtime_error("NYI : __fallback_gemm_q6_K");
+  return 0;
+}
+
 size_t __fallback_quantize_q4_0(const float *src, void *dst, int64_t nrow,
                                 int64_t n_per_row, const float *quant_weights) {
   throw std::runtime_error("NYI : __fallback_quantize_q4_0");

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -381,13 +381,12 @@ float __fallback_dot_q6_K_f32(const unsigned int K, const void *v_q6_K,
   return 0;
 }
 
-float __fallback_gemm_q6_K(const unsigned int M, const unsigned int N,
-                           const unsigned int K, const float *A,
-                           const unsigned int lda, const void *B,
-                           const unsigned int ldb, float *C,
-                           const unsigned int ldc) {
+void __fallback_gemm_q6_K(const unsigned int M, const unsigned int N,
+                          const unsigned int K, const float *A,
+                          const unsigned int lda, const void *B,
+                          const unsigned int ldb, float *C,
+                          const unsigned int ldc) {
   throw std::runtime_error("NYI : __fallback_gemm_q6_K");
-  return 0;
 }
 
 size_t __fallback_quantize_q4_0(const float *src, void *dst, int64_t nrow,

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -375,11 +375,17 @@ float __fallback_dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
   return 0;
 }
 
+float __fallback_dot_q6_K_f32(const unsigned int K, const void *v_q6_K,
+                              const float *f) {
+  throw std::runtime_error("NYI : __fallback_dot_q6_K_f32");
+  return 0;
+}
+
 float __fallback_gemm_q6_K(const unsigned int M, const unsigned int N,
-                                const unsigned int K, const float *A,
-                                const unsigned int lda, const void *B,
-                                const unsigned int ldb, float *C,
-                                const unsigned int ldc) {
+                           const unsigned int K, const float *A,
+                           const unsigned int lda, const void *B,
+                           const unsigned int ldb, float *C,
+                           const unsigned int ldc) {
   throw std::runtime_error("NYI : __fallback_gemm_q6_K");
   return 0;
 }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -701,6 +701,12 @@ void __fallback_gemm_q4_K(const unsigned int M, const unsigned int N,
 float __fallback_dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                                const void *v_q8_K);
 
+float __fallback_gemm_q6_K(const unsigned int M, const unsigned int N,
+                                const unsigned int K, const float *A,
+                                const unsigned int lda, const void *B,
+                                const unsigned int ldb, float *C,
+                                const unsigned int ldc);
+
 /**
  * @brief
  *

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -704,11 +704,11 @@ float __fallback_dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
 float __fallback_dot_q6_K_f32(const unsigned int K, const void *v_q6_K,
                               const float *f);
 
-float __fallback_gemm_q6_K(const unsigned int M, const unsigned int N,
-                           const unsigned int K, const float *A,
-                           const unsigned int lda, const void *B,
-                           const unsigned int ldb, float *C,
-                           const unsigned int ldc);
+void __fallback_gemm_q6_K(const unsigned int M, const unsigned int N,
+                          const unsigned int K, const float *A,
+                          const unsigned int lda, const void *B,
+                          const unsigned int ldb, float *C,
+                          const unsigned int ldc);
 
 /**
  * @brief

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -701,11 +701,14 @@ void __fallback_gemm_q4_K(const unsigned int M, const unsigned int N,
 float __fallback_dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                                const void *v_q8_K);
 
+float __fallback_dot_q6_K_f32(const unsigned int K, const void *v_q6_K,
+                              const float *f);
+
 float __fallback_gemm_q6_K(const unsigned int M, const unsigned int N,
-                                const unsigned int K, const float *A,
-                                const unsigned int lda, const void *B,
-                                const unsigned int ldb, float *C,
-                                const unsigned int ldc);
+                           const unsigned int K, const float *A,
+                           const unsigned int lda, const void *B,
+                           const unsigned int ldb, float *C,
+                           const unsigned int ldc);
 
 /**
  * @brief

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -346,7 +346,8 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
     const void *const quantized_A_data = quantized_A.data();
 
 #pragma omp parallel for collapse(1) num_threads(thread_count)
-    for (int32_t thread_job = 0; thread_job < N; thread_job++) {
+    for (int32_t thread_job = 0; thread_job < static_cast<int>(N);
+         thread_job++) {
       const int32_t B_row_data_offset = B_row_size * thread_job;
 
       const void *const B_data = (void *)((char *)B + B_row_data_offset);
@@ -359,13 +360,15 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
     std::vector<char> quantized_A(A_total_size);
 
 #pragma omp parallel for collapse(1) num_threads(thread_count)
-    for (int32_t thread_job = 0; thread_job < M; thread_job++) {
+    for (int32_t thread_job = 0; thread_job < static_cast<int>(M);
+         thread_job++) {
       const int32_t A_row_data_offset = A_row_size * thread_job;
       void *A_data = (void *)((char *)quantized_A.data() + A_row_data_offset);
       ::quantize_row_q8_K(A + thread_job * K, A_data, K);
     }
 #pragma omp parallel for collapse(1) num_threads(thread_count)
-    for (int32_t thread_job = 0; thread_job < M; thread_job++) {
+    for (int32_t thread_job = 0; thread_job < static_cast<int>(M);
+         thread_job++) {
       const int32_t A_row_data_offset = A_row_size * thread_job;
       void *A_data = (void *)((char *)quantized_A.data() + A_row_data_offset);
 

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -359,25 +359,6 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
       ::ggml_vec_dot_q6_K_q8_K(K, &C[thread_job], bs, B_data, bx,
                                quantized_A_data, by, nrc);
     }
-
-    // NOTE(m.wlasiuk) : to be used with pool
-    // #pragma omp parallel for collapse(1) num_threads(thread_count)
-    //     for (int32_t thread_idx = 0; thread_idx < thread_count; thread_idx++)
-    //     {
-    //       const uint32_t n_start = thread_idx * per_thread_N;
-    //       const uint32_t n_end = (thread_idx + 1) * per_thread_N;
-
-    //       for (int32_t thread_job = n_start; thread_job < n_end;
-    //       thread_job++) {
-    //         const int32_t B_row_data_offset = B_row_size * thread_job;
-
-    //         const void *const B_data = (void *)((char *)B +
-    //         B_row_data_offset);
-
-    //         ::ggml_vec_dot_q6_K_q8_K(K, &C[thread_job], bs, B_data, bx,
-    //                                  quantized_A_data, by, nrc);
-    //       }
-    //     }
   } else { // GEMM
     const int32_t per_thread_M = M / thread_count;
 
@@ -390,23 +371,6 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
       void *A_data = (void *)((char *)quantized_A.data() + A_row_data_offset);
       ::quantize_row_q8_K(A + thread_job * K, A_data, K);
     }
-
-    // NOTE(m.wlasiuk) : to be used with pool
-    // #pragma omp parallel for collapse(1) num_threads(thread_count)
-    //     for (int32_t thread_idx = 0; thread_idx < thread_count; thread_idx++)
-    //     {
-    //       const uint32_t m_start = thread_idx * per_thread_M;
-    //       const uint32_t m_end = (thread_idx + 1) * per_thread_M;
-    //
-    //       for (int32_t thread_job = m_start; thread_job < m_end;
-    //       thread_job++) {
-    //         const int32_t A_row_data_offset = A_row_size * thread_job;
-    //         void *A_data = (void *)((char *)quantized_A.data() +
-    //         A_row_data_offset);
-    //         ::quantize_row_q8_K(A + thread_job * K, A_data, K);
-    //       }
-    //     }
-
 #pragma omp parallel for collapse(1) num_threads(thread_count)
     for (int32_t thread_job = 0; thread_job < M; thread_job++) {
       const int32_t A_row_data_offset = A_row_size * thread_job;
@@ -420,31 +384,6 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
                                  A_data, by, nrc);
       }
     }
-
-    // NOTE(m.wlasiuk) : to be used with pool
-    // #pragma omp parallel for collapse(1) num_threads(thread_count)
-    //     for (int32_t thread_idx = 0; thread_idx < thread_count; thread_idx++)
-    //     {
-    //       const uint32_t m_start = thread_idx * per_thread_M;
-    //       const uint32_t m_end = (thread_idx + 1) * per_thread_M;
-
-    //       for (int32_t thread_job = m_start; thread_job < m_end;
-    //       thread_job++) {
-    //         const int32_t A_row_data_offset = A_row_size * thread_job;
-    //         void *A_data = (void *)((char *)quantized_A.data() +
-    //         A_row_data_offset);
-
-    //         for (uint32_t j = 0; j < N; j++) {
-    //           const int32_t B_row_data_offset = B_row_size * j;
-    //           const void *const B_data = (void *)((char *)B +
-    //           B_row_data_offset);
-
-    //           ::ggml_vec_dot_q6_K_q8_K(K, &C[thread_job * ldc + j], bs,
-    //           B_data, bx,
-    //                                    A_data, by, nrc);
-    //         }
-    //       }
-    //     }
   }
 }
 

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -327,7 +327,7 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
                       const unsigned int lda, const void *B,
                       const unsigned int ldb, float *C,
                       const unsigned int ldc) {
-  static constexpr const int32_t thread_count = 8;
+  static constexpr const int32_t thread_count = 16;
 
   static constexpr const int32_t bs = 1;  // unused in ::ggml_vec_dot_q6_K_q8_K
   static constexpr const int32_t bx = 1;  // unused in ::ggml_vec_dot_q6_K_q8_K
@@ -361,21 +361,41 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
       }
     }
   } /*MATRIX - MATRIX*/ else {
-    const int32_t A_total_size = A_row_size * M;
+    const int32_t per_thread_M = M / thread_count;
 
+    const int32_t A_total_size = A_row_size * M;
     std::vector<char> quantized_A(A_total_size);
 
-    for (unsigned int i = 0; i < M; i++) {
-      const int32_t A_row_data_offset = A_row_size * i;
-      void *A_data = (void *)((char *)quantized_A.data() + A_row_data_offset);
-      ::quantize_row_q8_K(A + i * K, A_data, K);
+#pragma omp parallel for collapse(1) num_threads(thread_count)
+    for (int32_t thread_idx = 0; thread_idx < thread_count; thread_idx++) {
+      const int32_t m_start = thread_idx * per_thread_M;
+      const int32_t m_end = (thread_idx + 1) * per_thread_M;
 
-      for (unsigned int j = 0; j < N; j++) {
-        const int32_t B_row_data_offset = B_row_size * j;
-        const void *const B_data = (void *)((char *)B + B_row_data_offset);
+      for (unsigned int thread_job = m_start; thread_job < m_end;
+           thread_job++) {
+        const int32_t A_row_data_offset = A_row_size * thread_job;
+        void *A_data = (void *)((char *)quantized_A.data() + A_row_data_offset);
+        ::quantize_row_q8_K(A + thread_job * K, A_data, K);
+      }
+    }
 
-        ::ggml_vec_dot_q6_K_q8_K(K, &C[i * ldc + j], bs, B_data, bx, A_data, by,
-                                 nrc);
+#pragma omp parallel for collapse(1) num_threads(thread_count)
+    for (int32_t thread_idx = 0; thread_idx < thread_count; thread_idx++) {
+      const int32_t m_start = thread_idx * per_thread_M;
+      const int32_t m_end = (thread_idx + 1) * per_thread_M;
+
+      for (unsigned int thread_job = m_start; thread_job < m_end;
+           thread_job++) {
+        const int32_t A_row_data_offset = A_row_size * thread_job;
+        void *A_data = (void *)((char *)quantized_A.data() + A_row_data_offset);
+
+        for (unsigned int j = 0; j < N; j++) {
+          const int32_t B_row_data_offset = B_row_size * j;
+          const void *const B_data = (void *)((char *)B + B_row_data_offset);
+
+          ::ggml_vec_dot_q6_K_q8_K(K, &C[thread_job * ldc + j], bs, B_data, bx,
+                                   A_data, by, nrc);
+        }
       }
     }
   }

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -327,9 +327,6 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
                       const unsigned int lda, const void *B,
                       const unsigned int ldb, float *C,
                       const unsigned int ldc) {
-
-#define USE_SPLIT 1
-
   static constexpr const int32_t thread_count = 16;
 
   static constexpr const int32_t bs = 1;  // unused in ::ggml_vec_dot_q6_K_q8_K
@@ -343,8 +340,6 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
 
   // GEMV
   if (M == 1) {
-    const int32_t per_thread_N = N / thread_count;
-
     std::vector<char> quantized_A(A_row_size);
     ::quantize_row_q8_K(A, quantized_A.data(), K);
 
@@ -360,8 +355,6 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
                                quantized_A_data, by, nrc);
     }
   } else { // GEMM
-    const int32_t per_thread_M = M / thread_count;
-
     const int32_t A_total_size = A_row_size * M;
     std::vector<char> quantized_A(A_total_size);
 

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -66,6 +66,9 @@ size_t __ggml_quantize_q4_K(const float *src, void *dst, int64_t nrow,
 size_t __ggml_quantize_q6_K(const float *src, void *dst, int64_t nrow,
                             int64_t n_per_row, const float *quant_weights);
 
+size_t __ggml_quantize_q6_K(const float *src, void *dst, int64_t nrow,
+                            int64_t n_per_row, const float *quant_weights);
+
 /**
  * @brief Quantize float to q6_K Quantization format
  *

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -66,9 +66,6 @@ size_t __ggml_quantize_q4_K(const float *src, void *dst, int64_t nrow,
 size_t __ggml_quantize_q6_K(const float *src, void *dst, int64_t nrow,
                             int64_t n_per_row, const float *quant_weights);
 
-size_t __ggml_quantize_q6_K(const float *src, void *dst, int64_t nrow,
-                            int64_t n_per_row, const float *quant_weights);
-
 /**
  * @brief Quantize float to q6_K Quantization format
  *

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -152,6 +152,9 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
 float __ggml_vec_dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                                const void *v_q8_K);
 
+float __ggml_vec_dot_q6_K_f32(const unsigned int K, const void *v_q6_K,
+                              const float *f);
+
 /**
  * @brief q4K to float dequantize
  *

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -238,6 +238,14 @@ float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
 #endif
 }
 
+float dot_q6_K_f32(const unsigned int K, const void *v_q6_K, const float *f) {
+#ifdef ENABLE_GGML
+  return __ggml_vec_dot_q6_K_f32(K, v_q6_K, f);
+#else
+  return __fallback_dot_q6_K_f32(K, v_q6_K, f);
+#endif
+}
+
 void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc) {

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -243,6 +243,8 @@ void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const unsigned int ldb, float *C, const unsigned int ldc) {
 #ifdef ENABLE_GGML
   return __ggml_gemm_q6_K(M, N, K, A, lda, B, ldb, C, ldc);
+#else
+  return __fallback_gemm_q6_K(M, N, K, A, lda, B, ldb, C, ldc);
 #endif
 }
 

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -767,22 +767,7 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
 void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);
-/**
- * @brief
- *
- * @param M
- * @param N
- * @param K
- * @param A
- * @param lda
- * @param B
- * @param ldb
- * @param C
- * @param ldc
- */
-void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
-               const float *A, const unsigned int lda, const void *B,
-               const unsigned int ldb, float *C, const unsigned int ldc);
+
 /**
  * @brief
  *

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -794,6 +794,8 @@ void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
 float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                     const void *v_q8_K);
 
+float dot_q6_K_f32(const unsigned int K, const void *v_q6_K, const float *f);
+
 /**
  * @brief
  *

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -751,6 +751,9 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);
 
+void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
 /**
  * @brief
  *

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -751,6 +751,19 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);
 
+/**
+ * @brief
+ *
+ * @param M
+ * @param N
+ * @param K
+ * @param A
+ * @param lda
+ * @param B
+ * @param ldb
+ * @param C
+ * @param ldc
+ */
 void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -754,15 +754,15 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
 /**
  * @brief
  *
- * @param M
- * @param N
- * @param K
- * @param A
- * @param lda
- * @param B
- * @param ldb
- * @param C
- * @param ldc
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q6_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q6_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
  */
 void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -114,8 +114,8 @@ endforeach
 
 unittest_inc = include_directories('.')
 
-# subdir('memory')
-# subdir('compiler')
+subdir('memory')
+subdir('compiler')
 subdir('layers')
 subdir('datasets')
 subdir('models')

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -114,8 +114,8 @@ endforeach
 
 unittest_inc = include_directories('.')
 
-subdir('memory')
-subdir('compiler')
+# subdir('memory')
+# subdir('compiler')
 subdir('layers')
 subdir('datasets')
 subdir('models')

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -266,7 +266,9 @@ static float test_gemm_q4_0(const uint32_t M, const uint32_t K,
   auto t2 = high_resolution_clock::now();
   auto dt = duration_cast<nanoseconds>(t2 - t1);
   if (print) {
-    std::cout << "[INFO] gemm_q4_0: " << dt.count() << " ns " << std::endl;
+    std::cout << "[INFO] gemm_q4_0: " << dt.count() << " ns "
+              << dt.count() / 1'000 << " us " << dt.count() / 1'000'000
+              << " ms " << std::endl;
   }
 
   // Step4. Compute quantization error
@@ -308,7 +310,9 @@ static float test_gemm_q4_K(const uint32_t M, const uint32_t K,
   auto t2 = high_resolution_clock::now();
   auto dt = duration_cast<nanoseconds>(t2 - t1);
   if (print) {
-    std::cout << "[INFO] gemm_q4_K: " << dt.count() << " ns " << std::endl;
+    std::cout << "[INFO] gemm_q4_K: " << dt.count() << " ns "
+              << dt.count() / 1'000 << " us " << dt.count() / 1'000'000
+              << " ms " << std::endl;
   }
 
   // Step4. Compare quantization error
@@ -344,7 +348,9 @@ static float test_gemm_q6_K(const uint32_t M, const uint32_t K,
   auto t2 = high_resolution_clock::now();
   auto dt = duration_cast<nanoseconds>(t2 - t1);
   if (print) {
-    std::cout << "[INFO] gemm_q6_K: " << dt.count() << " ns " << std::endl;
+    std::cout << "[INFO] gemm_q6_K: " << dt.count() << " ns "
+              << dt.count() / 1'000 << " us " << dt.count() / 1'000'000
+              << " ms " << std::endl;
   }
 
   // Step4. Compare quantization error
@@ -376,7 +382,9 @@ static void run_quant_test(const uint32_t M, const uint32_t K, const uint32_t N,
   auto t2 = high_resolution_clock::now();
   auto dt = duration_cast<nanoseconds>(t2 - t1);
   if (print) {
-    std::cout << "[INFO] sgemm :    " << dt.count() << " ns " << std::endl;
+    std::cout << "[INFO] sgemm :    " << dt.count() << " ns "
+              << dt.count() / 1'000 << " us " << dt.count() / 1'000'000
+              << " ms " << std::endl;
   }
   q4_0_mse =
     test_gemm_q4_0(M, K, N, weight.data(), activation.data(), ref_dst, print);

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -399,7 +399,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_256x1024x512) {
   const unsigned int K = 1024;
   const unsigned int N = 512;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
   ASSERT_LE(q6_k_mse, 2.0f);
@@ -410,7 +410,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_512x768x1024) {
   const unsigned int K = 768;
   const unsigned int N = 1024;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
   ASSERT_LE(q6_k_mse, 2.0f);
@@ -421,7 +421,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x1536x1536) {
   const unsigned int K = 1536;
   const unsigned int N = 1536;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
   ASSERT_LE(q6_k_mse, 2.0f);
@@ -432,7 +432,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x1536x5760) {
   const unsigned int K = 1536;
   const unsigned int N = 5760;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
   ASSERT_LE(q6_k_mse, 2.0f);
@@ -443,7 +443,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x3072x3072) {
   const unsigned int K = 3072;
   const unsigned int N = 3072;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   // ASSERT_LE(q4_0_mse, 1.5f);
   ASSERT_LE(q4_k_mse, 1.5f);
   ASSERT_LE(q6_k_mse, 1.5f);
@@ -454,7 +454,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x3072x3072) {
   const unsigned int K = 3072;
   const unsigned int N = 3072;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   // ASSERT_LE(q4_0_mse, 1.5f);
   ASSERT_LE(q4_k_mse, 1.5f);
   ASSERT_LE(q6_k_mse, 1.5f);
@@ -465,7 +465,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x3072x3072) {
   const unsigned int K = 3072;
   const unsigned int N = 3072;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   // ASSERT_LE(q4_0_mse, 1.5f);
   ASSERT_LE(q4_k_mse, 1.5f);
   ASSERT_LE(q6_k_mse, 1.5f);
@@ -476,7 +476,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x3072x3072) {
   const unsigned int K = 3072;
   const unsigned int N = 3072;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
   ASSERT_LE(q6_k_mse, 2.0f);
@@ -487,7 +487,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x512x768) {
   const unsigned int K = 512;
   const unsigned int N = 768;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
   ASSERT_LE(q6_k_mse, 1.0f);
@@ -498,7 +498,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x768x512) {
   const unsigned int K = 768;
   const unsigned int N = 512;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
   ASSERT_LE(q6_k_mse, 1.0f);
@@ -509,7 +509,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x768x1024) {
   const unsigned int K = 768;
   const unsigned int N = 1024;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
   ASSERT_LE(q6_k_mse, 1.0f);
@@ -520,7 +520,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1536x1536) {
   const unsigned int K = 1536;
   const unsigned int N = 1536;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
   ASSERT_LE(q6_k_mse, 1.0f);
@@ -531,7 +531,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1536x5760) {
   const unsigned int K = 1536;
   const unsigned int N = 5760;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
   ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
   ASSERT_LE(q6_k_mse, 1.0f);


### PR DESCRIPTION
This PR is manual rebase of #3170 with addition of dequantization methods for Q6_K. Additionally during the tests involving Q6_K computation I've added dequantization add cos_sim / max_diff check between input weights (before quantization) and dequantized weights/

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

**How to evaluate:**
Build project with tests and validated that checks of quantization vs dequantization do not fail - current threshold most likely to be adjusted in future.