### PR TITLE
[ cpu_backend ] Add q6_K dequantize function

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -287,6 +287,14 @@ void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
 #endif
 }
 
+void dequantize_row_q6_K(const void *x_raw, float *y, int64_t k) {
+#ifdef ENABLE_GGML
+  __ggml_dequantize_row_q6_K(x_raw, y, k);
+#else
+  __fallback_dequantize_row_q6_K(x_raw, y, k);
+#endif
+}
+
 void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
 #ifdef ENABLE_GGML
   __ggml_dequantize_row_q8_K(x, y, k);

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -782,20 +782,29 @@ size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
 
 /**
- * @brief
+ * @brief q4K to float dequantize
  *
- * @param x_raw
- * @param y
- * @param k
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
  */
 void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
 
 /**
- * @brief
+ * @brief q6K to float dequantize
  *
- * @param x
- * @param y
- * @param k
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
+ */
+void dequantize_row_q6_K(const void *x_raw, float *y, int64_t k);
+
+/**
+ * @brief q8K to float dequantize
+ *
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
  */
 void dequantize_row_q8_K(const void *x, float *y, int64_t k);
 

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -636,5 +636,32 @@ extern void gemm_q4_K(const unsigned int M, const unsigned int N,
                       const unsigned int K, const float *A,
                       const unsigned int lda, const void *B,
                       const unsigned int ldb, float *C, const unsigned int ldc);
+
+/**
+ * @brief q4K to float dequantize
+ *
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
+ */
+extern void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
+
+/**
+ * @brief q6K to float dequantize
+ *
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
+ */
+extern void dequantize_row_q6_K(const void *x_raw, float *y, int64_t k);
+
+/**
+ * @brief q8K to float dequantize
+ *
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
+ */
+extern void dequantize_row_q8_K(const void *x, float *y, int64_t k);
 #endif
 #endif

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -214,6 +214,10 @@ void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
   return __fallback_dequantize_row_q4_K(x_raw, y, k);
 }
 
+void dequantize_row_q6_K(const void *x, float *y, int64_t k) {
+  return __fallback_dequantize_row_q6_K(x, y, k);
+}
+
 void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
   return __fallback_dequantize_row_q8_K(x, y, k);
 }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -755,20 +755,29 @@ size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
 
 /**
- * @brief
+ * @brief q4K to float dequantize
  *
- * @param x_raw
- * @param y
- * @param k
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
  */
 void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
 
 /**
- * @brief
+ * @brief q6K to float dequantize
  *
- * @param x
- * @param y
- * @param k
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
+ */
+void dequantize_row_q6_K(const void *x_raw, float *y, int64_t k);
+
+/**
+ * @brief q8K to float dequantize
+ *
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
  */
 void dequantize_row_q8_K(const void *x, float *y, int64_t k);
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -385,6 +385,10 @@ void __fallback_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
   throw std::runtime_error("NYI : __fallback_dequantize_row_q4_K");
 }
 
+void __fallback_dequantize_row_q6_K(const void *x_raw, float *y, int64_t k) {
+  throw std::runtime_error("NYI : __fallback_dequantize_row_q6_K");
+}
+
 void __fallback_dequantize_row_q8_K(const void *x, float *y, int64_t k) {
   throw std::runtime_error("NYI : __fallback_dequantize_row_q8_K");
 }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -717,20 +717,29 @@ size_t __fallback_quantize_q4_K(const float *src, void *dst, int64_t nrow,
                                 int64_t n_per_row, const float *quant_weights);
 
 /**
- * @brief
+ * @brief q4K to float dequantize
  *
- * @param x_raw
- * @param y
- * @param k
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
  */
 void __fallback_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
 
 /**
- * @brief
+ * @brief q6K to float dequantize
  *
- * @param x
- * @param y
- * @param k
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
+ */
+void __fallback_dequantize_row_q6_K(const void *x_raw, float *y, int64_t k);
+
+/**
+ * @brief q8K to float dequantize
+ *
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
  */
 void __fallback_dequantize_row_q8_K(const void *x, float *y, int64_t k);
 

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -222,6 +222,10 @@ void __ggml_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
   ::dequantize_row_q4_K((const block_q4_K *)x_raw, y, k);
 }
 
+void __ggml_dequantize_row_q6_K(const void *x_raw, float *y, int64_t k) {
+  ::dequantize_row_q6_K((const block_q6_K *)x_raw, y, k);
+}
+
 void __ggml_dequantize_row_q8_K(const void *x, float *y, int64_t k) {
   ::dequantize_row_q8_K((const block_q8_K *)x, y, k);
 }

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -102,6 +102,15 @@ void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
 void __ggml_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
 
 /**
+ * @brief q6K to float dequantize
+ *
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
+ */
+void __ggml_dequantize_row_q6_K(const void *x_raw, float *y, int64_t k);
+
+/**
  * @brief q8K to float dequantize
  *
  * @param x_raw input src to be dequantized

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -255,6 +255,14 @@ void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
 #endif
 }
 
+void dequantize_row_q6_K(const void *x, float *y, int64_t k) {
+#ifdef ENABLE_GGML
+  __ggml_dequantize_row_q6_K(x, y, k);
+#else
+  __fallback_dequantize_row_q6_K(x, y, k);
+#endif
+}
+
 void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
 #ifdef ENABLE_GGML
   __ggml_dequantize_row_q8_K(x, y, k);

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -778,20 +778,29 @@ size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
 
 /**
- * @brief
+ * @brief q4K to float dequantize
  *
- * @param x_raw
- * @param y
- * @param k
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
  */
 void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
 
 /**
- * @brief
+ * @brief q6K to float dequantize
  *
- * @param x
- * @param y
- * @param k
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
+ */
+void dequantize_row_q6_K(const void *x_raw, float *y, int64_t k);
+
+/**
+ * @brief q8K to float dequantize
+ *
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
  */
 void dequantize_row_q8_K(const void *x, float *y, int64_t k);
 


### PR DESCRIPTION
- arm compute backend, x86 compute backend now supports q6K dequantize function
- fallback backend will emit error, but since ggml has naive implementations as well, it should work at the the final form of this commit

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: skykongkong8 <ss.kong@samsung.com>