### PR TITLE
[Windows] Fix OpenMP linking problem of ggml on windows clang build

### DIFF
--- a/jni/prepare_ggml.sh
+++ b/jni/prepare_ggml.sh
@@ -4,7 +4,7 @@ set -e
 GGML_SRC=$1
 
 REVISION=489716ba99ecd51164f79e8c6fec0b5bf634eac9
-PATCH_PATH="${GGML_SRC}"/../packagefiles/ggml/0001-Export-some-internal-methods.patch
+PATCH_PATH="${GGML_SRC}"/../packagefiles/ggml/0001-nntrainer-ggml-patch.patch
 
 echo "[GGML] PREPARING GGML..."
 

--- a/meson.build
+++ b/meson.build
@@ -517,7 +517,8 @@ if get_option('enable-ggml')
     ggml_options.add_cmake_defines({'CMAKE_INSTALL_LIBDIR': nntrainer_libdir / 'arm64-v8a'})
   endif
 
-  if host_machine.system() == 'windows'
+  # we do not want it for clang on windows
+  if cxx_compiler_id == 'msvc'
     if arch == 'x86_64'
       if cc.has_argument('-march=x86-64-v2')
         cpu_type = 'x86-64-v2'

--- a/subprojects/ggml.wrap
+++ b/subprojects/ggml.wrap
@@ -3,5 +3,5 @@ url = https://github.com/ggml-org/ggml.git
 directory = ggml
 revision = 489716ba99ecd51164f79e8c6fec0b5bf634eac9
 patch_directory = ggml
-diff_files = ggml/0001-Export-some-internal-methods.patch
+diff_files = ggml/0001-nntrainer-ggml-patch.patch
 method = cmake

--- a/subprojects/packagefiles/ggml/0001-nntrainer-ggml-patch.patch
+++ b/subprojects/packagefiles/ggml/0001-nntrainer-ggml-patch.patch
@@ -1,14 +1,15 @@
-From 7affdf7eb6044da3aea7f52d3c6fc8f05b7c3403 Mon Sep 17 00:00:00 2001
-From: Maciej Nalewaj <m.nalewaj@samsung.com>
-Date: Fri, 9 May 2025 11:40:20 +0200
-Subject: [PATCH] Export some internal methods
+From 057409c8c6688fc466112fde14d305be26fda429 Mon Sep 17 00:00:00 2001
+From: Grzegorz Kisala <g.kisala@samsung.com>
+Date: Thu, 22 May 2025 15:51:08 +0200
+Subject: [PATCH] nntrainer ggml patch
 
-Signed-off-by: Maciej Nalewaj <m.nalewaj@samsung.com>
+Signed-off-by: Grzegorz Kisala <g.kisala@samsung.com>
 ---
  CMakeLists.txt                    |  2 +-
  include/ggml.h                    | 13 ++++++
+ src/ggml-cpu/CMakeLists.txt       | 10 ++++-
  src/ggml-cpu/ggml-cpu-aarch64.cpp | 74 ++++++++++++++++++++++++++++---
- 3 files changed, 81 insertions(+), 8 deletions(-)
+ 4 files changed, 90 insertions(+), 9 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 61fe15a..cf7aec3 100644
@@ -44,6 +45,27 @@ index 51aa5b3..02f4126 100644
  #ifdef  __cplusplus
  }
  #endif
+diff --git a/src/ggml-cpu/CMakeLists.txt b/src/ggml-cpu/CMakeLists.txt
+index 6a65273..fc178b9 100644
+--- a/src/ggml-cpu/CMakeLists.txt
++++ b/src/ggml-cpu/CMakeLists.txt
+@@ -60,7 +60,15 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
+ 
+             target_link_libraries(${GGML_CPU_NAME} PRIVATE OpenMP::OpenMP_C OpenMP::OpenMP_CXX)
+         else()
+-            message(WARNING "OpenMP not found")
++            if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_C_COMPILER_ID STREQUAL "Clang")
++                message("Apply workaround for OpenMP problem for clang build on windows")
++                target_compile_definitions(${GGML_CPU_NAME} PRIVATE GGML_USE_OPENMP)
++                set(OpenMP_C_FLAGS "-Xclang -fopenmp")
++                set(OpenMP_CXX_FLAGS "-Xclang -fopenmp")
++                target_link_libraries(${GGML_CPU_NAME} PRIVATE ${OpenMP_C_FLAGS} ${OpenMP_CXX_FLAGS})
++            else()
++                message(WARNING "OpenMP not found")
++            endif()
+         endif()
+     endif()
+ 
 diff --git a/src/ggml-cpu/ggml-cpu-aarch64.cpp b/src/ggml-cpu/ggml-cpu-aarch64.cpp
 index 175cba3..c06ec51 100644
 --- a/src/ggml-cpu/ggml-cpu-aarch64.cpp
@@ -186,5 +208,5 @@ index 175cba3..c06ec51 100644
      GGML_ASSERT(t->type == GGML_TYPE_Q4_0);
      GGML_ASSERT(interleave_block == 8);
 -- 
-2.34.1
+2.39.0.windows.2
 


### PR DESCRIPTION
CMake is not able to find OpenMP package when compiling with clang on windows platform. It cause that ggml is running on single thread. This PR apply patch in ggml to workaround this problem

With this change clang build is ~20% faster than msvc build on LLM inference

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

