### PR TITLE
Enable Using Pre-Built CLBlast Packages

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,7 +74,7 @@ jobs:
       shell: bash
       run: |
         sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
-        sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
+        sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libclblast-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
         sudo apt-get install -y python3-dev python3-numpy python3
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get install build-essential

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: install additional package from PPA for testing
         run: sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
       - name: install minimal requirements
-        run: sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
+        run: sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libclblast-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
       - name: install additional packages for features
         run: sudo apt-get install -y python3-dev python3-numpy python3
       - name: gcc version change

--- a/.github/workflows/ubuntu_benchmarks.yml
+++ b/.github/workflows/ubuntu_benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
     - name: install additional package from PPA for testing
       run: sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
     - name: install minimal requirements
-      run: sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev libbenchmark-dev
+      run: sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libclblast-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev libbenchmark-dev
     - name: install additional packages for features
       run: sudo apt-get install -y python3-dev python3-numpy python3
     - name: Install submodules

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: install additional package from PPA for testing
       run: sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
     - name: install minimal requirements
-      run: sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
+      run: sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libclblast-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
     - name: install additional packages for features
       run: sudo apt-get install -y python3-dev python3-numpy python3
     - name: gcc version change

--- a/.github/workflows/ubuntu_clean_meson_build_clang.yml
+++ b/.github/workflows/ubuntu_clean_meson_build_clang.yml
@@ -20,7 +20,7 @@ jobs:
     - name: install additional package from PPA for testing
       run: sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
     - name: install minimal requirements
-      run: sudo apt-get update && sudo apt-get install -y libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
+      run: sudo apt-get update && sudo apt-get install -y libopenblas-dev libiniparser-dev libclblast-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
     - name: install additional packages for features
       run: sudo apt-get install -y python3-dev python3-numpy python3
     - name: Install llvm

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -132,7 +132,7 @@ Install the required packages.
 
 ```bash
 sudo apt install meson ninja-build
-sudo apt install gcc g++ pkg-config libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev
+sudo apt install gcc g++ pkg-config libopenblas-dev libiniparser-dev libclblast-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev
 ```
 
 Install submodules.

--- a/meson.build
+++ b/meson.build
@@ -169,13 +169,17 @@ if get_option('enable-opencl')
   if get_option('platform') == 'android'
     clblast_dep = declare_dependency()
   else
-    if host_machine.system() == 'windows'
-      clblast_options.add_cmake_defines(common_win_subproject_cmake_defines)
-    endif
+    clblast_dep = dependency('clblast', required : false)
 
-    clblast_options.add_cmake_defines({'CMAKE_POLICY_VERSION_MINIMUM': '3.10'})
-    clblast_proj = cmake.subproject('clblast', options: clblast_options, required: true)
-    clblast_dep = clblast_proj.dependency('clblast')
+    if not clblast_dep.found()
+      if host_machine.system() == 'windows'
+        clblast_options.add_cmake_defines(common_win_subproject_cmake_defines)
+      endif
+
+      clblast_options.add_cmake_defines({'CMAKE_POLICY_VERSION_MINIMUM': '3.10'})
+      clblast_proj = cmake.subproject('clblast', options: clblast_options, required: true)
+      clblast_dep = clblast_proj.dependency('clblast')
+    endif
   endif
 endif
 


### PR DESCRIPTION
This PR allows the use of pre-built CLBlast packages.
It uses the installed CLBlast and compiles it from source if it does not exist, potentially reducing compilation time.

Note that CLBlast can be installed with:
```
sudo apt install libclblast-dev
```

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped
