### PR TITLE
[Feat] Add kvcache save and load func

### DIFF
--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -93,7 +93,8 @@ for inference and training without any configurations*/
     ML_TRAIN_MODEL_FORMAT_FLATBUFFER,             /**< flatbuffer file */
   MODEL_FORMAT_ONNX = ML_TRAIN_MODEL_FORMAT_ONNX, /**< ONNX file */
 
-  MODEL_FORMAT_QNN = ML_TRAIN_MODEL_FORMAT_QNN /**< qnn binary file */
+  MODEL_FORMAT_QNN = ML_TRAIN_MODEL_FORMAT_QNN, /**< qnn binary file */
+  MODEL_FORMAT_KVCACHE = ML_TRAIN_MODEL_FORMAT_KVCACHE
 };
 
 /**

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -275,7 +275,9 @@ typedef enum {
   ML_TRAIN_MODEL_FORMAT_ONNX =
     4, /**< QNNX binary format file saves model configurations and weights. */
   ML_TRAIN_MODEL_FORMAT_QNN =
-    5 /**< QNN binary format file saves model configurations and weights. */
+    5, /**< QNN binary format file saves model configurations and weights. */
+  ML_TRAIN_MODEL_FORMAT_KVCACHE = 
+    6,
 } ml_train_model_format_e;
 
 /**

--- a/nntrainer/graph/graph_core.cpp
+++ b/nntrainer/graph/graph_core.cpp
@@ -13,6 +13,7 @@
  */
 
 #include <algorithm>
+#include <filesystem>
 #include <sstream>
 
 #include <graph_core.h>
@@ -194,6 +195,30 @@ void GraphCore::realizeInputOutputNode() {
 
 unsigned int GraphCore::getNodeIdx(const std::string &name) {
   return node_map.at(name);
+}
+
+void GraphCore::save_kvcache(const std::string &file_path) {
+  if (!std::filesystem::exists(file_path)) {
+    if (!std::filesystem::create_directories(file_path)) {
+      ml_loge("Error: create kvcache directory failed");
+      return;
+    }
+  }
+
+  for (auto node : node_list) {
+    node->save_kvcache(file_path);
+  }
+}
+
+void GraphCore::load_kvcache(const std::string &file_path) {
+  if (!std::filesystem::exists(file_path)) {
+    ml_loge("Error: create kvcache directory failed");
+    return;
+  }
+
+  for (auto node : node_list) {
+    node->load_kvcache(file_path);
+  }
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/graph/graph_core.h
+++ b/nntrainer/graph/graph_core.h
@@ -253,6 +253,10 @@ public:
     return true;
   }
 
+  void save_kvcache(const std::string &file_path);
+
+  void load_kvcache(const std::string &file_path);
+
 private:
   std::vector<std::shared_ptr<GraphNode>> input_list;
   std::vector<std::shared_ptr<GraphNode>> output_list;

--- a/nntrainer/graph/graph_node.h
+++ b/nntrainer/graph/graph_node.h
@@ -109,6 +109,10 @@ public:
    * respectively
    */
   virtual void setExecutionOrder(ExecutionOrder exec_order_) = 0;
+
+  virtual void save_kvcache(const std::string &file_path){};
+
+  virtual void load_kvcache(const std::string &file_path){};
 };
 
 /**

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -1636,6 +1636,10 @@ void NetworkGraph::UnloadTensors(unsigned int order) {
   tensor_manager->UnloadTensors(order);
 }
 
+void NetworkGraph::save_kvcache(const std::string &file_path) { graph.save_kvcache(file_path); }
+
+void NetworkGraph::load_kvcache(const std::string &file_path) { graph.load_kvcache(file_path); }
+
 void NetworkGraph::requestOptimizerVariable(
   std::function<std::vector<TensorDim>(const TensorDim &)> cb,
   bool request_only_trainable) {

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -487,6 +487,10 @@ public:
    */
   void UnloadTensors(const unsigned int order);
 
+  void save_kvcache(const std::string &file_path);
+
+  void load_kvcache(const std::string &file_path);
+
 #ifdef ENABLE_TEST
   /**
    * @brief Get layer node's tenexecution orders

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -410,6 +410,10 @@ public:
     }
   }
 
+  virtual void save_kvcache(RunLayerContext &context, std::string layerName, const std::string &file_path){};
+
+  virtual void load_kvcache(RunLayerContext &context, std::string layerName, const std::string &file_path){};
+
 protected:
   bool is_inplace = false; /**< whether this layer is in-place or not */
 };

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -1089,4 +1089,13 @@ void LayerNode::print(std::ostream &out, unsigned int flags) {
     printMetric(out);
   }
 };
+
+void LayerNode::save_kvcache(const std::string &file_path) {
+  getLayer()->save_kvcache(*run_context, getName(), file_path);
+}
+
+void LayerNode::load_kvcache(const std::string &file_path) {
+  getLayer()->load_kvcache(*run_context, getName(), file_path);
+}
+
 }; // namespace nntrainer

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -974,6 +974,10 @@ public:
     return "cpu";
   }
 
+  void save_kvcache(const std::string &file_path) override;
+
+  void load_kvcache(const std::string &file_path) override;
+
 private:
   /**
    * @brief     Get the Input Layers object

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -654,6 +654,10 @@ void NeuralNetwork::save(const std::string &file_path,
       "saving with ONNX format is not supported yet.");
     break;
   }
+  case ml::train::ModelFormat::MODEL_FORMAT_KVCACHE: {
+    model_graph.save_kvcache(file_path); 
+    break;
+  }
   default:
     throw nntrainer::exception::not_supported(
       "saving with given format is not supported yet");
@@ -812,6 +816,10 @@ void NeuralNetwork::load(const std::string &file_path,
     }
 
     qnn_load.join();
+    break;
+  }
+  case ml::train::ModelFormat::MODEL_FORMAT_KVCACHE: {
+    model_graph.load_kvcache(file_path);
     break;
   }
   default:


### PR DESCRIPTION
I've added enum values for KV cache and LoRA in nntrainer API's model.h and nntrainer-api-common.h. 
The existing model save function now supports save/load operations using the newly added model format.

For KV cache save/load functionality, the actual implementation code needs to be added in the layer implementation.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped