### PR TITLE
[ q6K ] Vanilla implementation of q6K GEMM

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -312,6 +312,14 @@ void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
 #endif
 }
 
+void dequantize_row_q6_K(const void *x, float *y, int64_t k) {
+#ifdef ENABLE_GGML
+  __ggml_dequantize_row_q6_K(x, y, k);
+#else
+  __fallback_dequantize_row_q6_K(x, y, k);
+#endif
+}
+
 void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
 #ifdef ENABLE_GGML
   __ggml_dequantize_row_q8_K(x, y, k);

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -261,6 +261,15 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
 #endif
 }
 
+float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
+                    const void *v_q8_K) {
+#ifdef ENABLE_GGML
+  return __ggml_vec_dot_q6_K_q8_K(K, v_q6_K, v_q8_K);
+#else
+  return __fallback_dot_q6_K_q8_K(K, v_q6_K, v_q8_K);
+#endif
+}
+
 size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights) {
 #ifdef ENABLE_GGML
@@ -276,6 +285,22 @@ size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
   return __ggml_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
 #else
   return __fallback_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
+#endif
+}
+
+void quantize_row_q6_K(const float *src, void *dst, int64_t k) {
+#ifdef ENABLE_GGML
+  __ggml_quantize_row_q6_K(src, dst, k);
+#else
+  __fallback_quantize_row_q6_K(src, dst, k);
+#endif
+}
+
+void quantize_row_q8_K(const float *src, void *dst, int64_t k) {
+#ifdef ENABLE_GGML
+  __ggml_quantize_row_q8_K(src, dst, k);
+#else
+  __fallback_quantize_row_q8_K(src, dst, k);
 #endif
 }
 

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -261,6 +261,17 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
 #endif
 }
 
+void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc) {
+#ifdef ENABLE_GGML
+  return __ggml_gemm_q6_K(M, N, K, A, lda, B, ldb, C, ldc);
+#else
+  // return __fallback_gemm_q6_K(M, N, K, A, lda, B, ldb, C, ldc);
+  return;
+#endif
+}
+
 float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                     const void *v_q8_K) {
 #ifdef ENABLE_GGML
@@ -286,6 +297,15 @@ size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
 #else
   return __fallback_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
 #endif
+}
+
+size_t quantize_q6_K(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights) {
+#ifdef ENABLE_GGML
+  return __ggml_quantize_q6_K(src, dst, nrow, n_per_row, quant_weights);
+#endif
+  // return __fallback_quantize_q6_K(src, dst, nrow, n_per_row, quant_weights);
+  return 0;
 }
 
 void quantize_row_q6_K(const float *src, void *dst, int64_t k) {

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -758,6 +758,17 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
 /**
  * @brief
  *
+ * @param K
+ * @param v_q6_K
+ * @param v_q8_K
+ * @return float
+ */
+float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
+                    const void *v_q8_K);
+
+/**
+ * @brief
+ *
  * @param src
  * @param dst
  * @param nrow
@@ -780,6 +791,24 @@ size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
  */
 size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param k
+ */
+void quantize_row_q6_K(const float *src, void *dst, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param k
+ */
+void quantize_row_q8_K(const float *src, void *dst, int64_t k);
 
 /**
  * @brief

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -795,9 +795,9 @@ size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
 /**
  * @brief
  *
- * @param src
- * @param dst
- * @param k
+ * @param src input to be quantized from float to q6_K
+ * @param dst quantized data output
+ * @param k number of elements in src
  */
 void quantize_row_q6_K(const float *src, void *dst, int64_t k);
 
@@ -811,20 +811,29 @@ void quantize_row_q6_K(const float *src, void *dst, int64_t k);
 void quantize_row_q8_K(const float *src, void *dst, int64_t k);
 
 /**
- * @brief
+ * @brief dequantize row of q4_K data to float
  *
- * @param x_raw
- * @param y
- * @param k
+ * @param x input to be dequantized from q4_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
  */
-void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
+void dequantize_row_q4_K(const void *x, float *y, int64_t k);
 
 /**
- * @brief
+ * @brief dequantize row of q6_K data to float
  *
- * @param x
- * @param y
- * @param k
+ * @param x input to be dequantized from q6_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+void dequantize_row_q6_K(const void *x, float *y, int64_t k);
+
+/**
+ * @brief dequantize row of q8_K data to float
+ *
+ * @param x input to be dequantized from q8_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
  */
 void dequantize_row_q8_K(const void *x, float *y, int64_t k);
 

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -754,7 +754,22 @@ void gemm_q4_0(const unsigned int M, const unsigned int N, const unsigned int K,
 void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);
-
+/**
+ * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
+ *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
 /**
  * @brief
  *
@@ -791,7 +806,18 @@ size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
  */
 size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
-
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+size_t quantize_q6_K(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights);
 /**
  * @brief
  *
@@ -860,7 +886,6 @@ void repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
  */
 void repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
                            const unsigned int M, const unsigned int N);
-
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __ARM_COMPUTE_BACKEND_H__ */

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -758,10 +758,10 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
 /**
  * @brief
  *
- * @param K
- * @param v_q6_K
- * @param v_q8_K
- * @return float
+ * @param K Length of vectors
+ * @param v_q6_K lhs vector - data stored in Q6_K format
+ * @param v_q8_K rhs vector - data stored in Q8_K format
+ * @return float Result of performing dot operation on v_q6_K and v_q8_K
  */
 float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                     const void *v_q8_K);

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -647,5 +647,32 @@ extern void gemm_q4_K(const unsigned int M, const unsigned int N,
  */
 extern float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                            const void *v_q8_K);
+
+/**
+ * @brief dequantize row of q4_K data to float
+ *
+ * @param x input to be dequantized from q4_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+extern void dequantize_row_q4_K(const void *x, float *y, int64_t k);
+
+/**
+ * @brief dequantize row of q6_K data to float
+ *
+ * @param x input to be dequantized from q6_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+extern void dequantize_row_q6_K(const void *x, float *y, int64_t k);
+
+/**
+ * @brief dequantize row of q8_K data to float
+ *
+ * @param x input to be dequantized from q8_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+extern void dequantize_row_q8_K(const void *x, float *y, int64_t k);
 #endif
 #endif

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -636,5 +636,16 @@ extern void gemm_q4_K(const unsigned int M, const unsigned int N,
                       const unsigned int K, const float *A,
                       const unsigned int lda, const void *B,
                       const unsigned int ldb, float *C, const unsigned int ldc);
+
+/**
+ * @brief
+ *
+ * @param K
+ * @param v_q6_K
+ * @param v_q8_K
+ * @return float
+ */
+extern float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
+                           const void *v_q8_K);
 #endif
 #endif

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -640,10 +640,10 @@ extern void gemm_q4_K(const unsigned int M, const unsigned int N,
 /**
  * @brief
  *
- * @param K
- * @param v_q6_K
- * @param v_q8_K
- * @return float
+ * @param K Length of vectors
+ * @param v_q6_K lhs vector - data stored in Q6_K format
+ * @param v_q8_K rhs vector - data stored in Q8_K format
+ * @return float Result of performing dot operation on v_q6_K and v_q8_K
  */
 extern float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                            const void *v_q8_K);

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -636,7 +636,35 @@ extern void gemm_q4_K(const unsigned int M, const unsigned int N,
                       const unsigned int K, const float *A,
                       const unsigned int lda, const void *B,
                       const unsigned int ldb, float *C, const unsigned int ldc);
-
+/**
+ * @brief
+ *
+ * @param M
+ * @param N
+ * @param K
+ * @param A
+ * @param lda
+ * @param B
+ * @param ldb
+ * @param C
+ * @param ldc
+ */
+extern void gemm_q6_K(const unsigned int M, const unsigned int N,
+                      const unsigned int K, const float *A,
+                      const unsigned int lda, const void *B,
+                      const unsigned int ldb, float *C, const unsigned int ldc);
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+extern size_t quantize_q6_K(const float *src, void *dst, int64_t nrow,
+                            int64_t n_per_row, const float *quant_weights);
 /**
  * @brief
  *

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -219,6 +219,10 @@ void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
   return __fallback_dequantize_row_q4_K(x_raw, y, k);
 }
 
+void dequantize_row_q6_K(const void *x, float *y, int64_t k) {
+  return __fallback_dequantize_row_q6_K(x, y, k);
+}
+
 void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
   return __fallback_dequantize_row_q8_K(x, y, k);
 }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -200,6 +200,11 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
   return __fallback_gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
 }
 
+float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
+                    const void *v_q8_K) {
+  return __fallback_dot_q6_K_q8_K(K, v_q6_K, v_q8_K);
+}
+
 size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights) {
   return __fallback_quantize_q4_0(src, dst, nrow, n_per_row, quant_weights);

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -767,20 +767,29 @@ size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
 
 /**
- * @brief
+ * @brief dequantize row of q4_K data to float
  *
- * @param x_raw
- * @param y
- * @param k
+ * @param x input to be dequantized from q4_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
  */
-void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
+void dequantize_row_q4_K(const void *x, float *y, int64_t k);
 
 /**
- * @brief
+ * @brief dequantize row of q6_K data to float
  *
- * @param x
- * @param y
- * @param k
+ * @param x input to be dequantized from q6_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+void dequantize_row_q6_K(const void *x, float *y, int64_t k);
+
+/**
+ * @brief dequantize row of q8_K data to float
+ *
+ * @param x input to be dequantized from q8_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
  */
 void dequantize_row_q8_K(const void *x, float *y, int64_t k);
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -16,7 +16,7 @@
 #ifdef __cplusplus
 
 #include <cstdint>
-#include <stdexcept>
+#include <stdexcept>p
 #include <tensor_dim.h>
 
 namespace nntrainer {
@@ -728,6 +728,18 @@ bool is_valid(const unsigned int N, const float *X);
 void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);
+
+/**
+ * @brief
+ *
+ * @param K
+ * @param v_q6_K
+ * @param v_q8_K
+ * @return float
+ */
+float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
+                    const void *v_q8_K);
+
 /**
  * @brief
  *

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -711,7 +711,22 @@ void ele_div(const unsigned N, const float *X, const float *Y, float *Z,
  * @param[out] bool false if not valid else true
  */
 bool is_valid(const unsigned int N, const float *X);
-
+/**
+ * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
+ *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void gemm_q4_0(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
 /**
  * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
  *
@@ -728,7 +743,22 @@ bool is_valid(const unsigned int N, const float *X);
 void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);
-
+/**
+ * @brief q4_K GEMM : A (M,K) * W.T (N,K) = O (M,N)
+ *
+ * @param M Original row size of output
+ * @param N Original col size of output
+ * @param K Hidden size
+ * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param lda Leading dimension of A
+ * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param ldb Leading dimenstion of B
+ * @param C float* output
+ * @param ldc Leading dimension of C
+ */
+void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
 /**
  * @brief
  *
@@ -752,7 +782,6 @@ float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
  */
 size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
-
 /**
  * @brief
  *
@@ -765,7 +794,18 @@ size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
  */
 size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
-
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
+ */
+size_t quantize_q6_K(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights);
 /**
  * @brief dequantize row of q4_K data to float
  *

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -732,10 +732,10 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
 /**
  * @brief
  *
- * @param K
- * @param v_q6_K
- * @param v_q8_K
- * @return float
+ * @param K Length of vectors
+ * @param v_q6_K lhs vector - data stored in Q6_K format
+ * @param v_q8_K rhs vector - data stored in Q8_K format
+ * @return float Result of performing dot operation on v_q6_K and v_q8_K
  */
 float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                     const void *v_q8_K);

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -16,7 +16,7 @@
 #ifdef __cplusplus
 
 #include <cstdint>
-#include <stdexcept>p
+#include <stdexcept>
 #include <tensor_dim.h>
 
 namespace nntrainer {

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -391,6 +391,10 @@ void __fallback_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
   throw std::runtime_error("NYI : __fallback_dequantize_row_q4_K");
 }
 
+void __fallback_dequantize_row_q6_K(const void *x, float *y, int64_t k) {
+  throw std::runtime_error("NYI : __fallback_dequantize_row_q6_K");
+}
+
 void __fallback_quantize_row_q6_K(const float *src, void *dst, int64_t k) {
   throw std::runtime_error("NYI : __fallback_quantize_row_q6_K");
 }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -369,6 +369,12 @@ void __fallback_gemm_q4_K(const unsigned int M, const unsigned int N,
   throw std::runtime_error("NYI : __fallback_gemm_q4_K");
 }
 
+float __fallback_dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
+                               const void *v_q8_K) {
+  throw std::runtime_error("NYI : __fallback_dot_q6_K_q8_K");
+  return 0;
+}
+
 size_t __fallback_quantize_q4_0(const float *src, void *dst, int64_t nrow,
                                 int64_t n_per_row, const float *quant_weights) {
   throw std::runtime_error("NYI : __fallback_quantize_q4_0");
@@ -383,6 +389,14 @@ size_t __fallback_quantize_q4_K(const float *src, void *dst, int64_t nrow,
 
 void __fallback_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
   throw std::runtime_error("NYI : __fallback_dequantize_row_q4_K");
+}
+
+void __fallback_quantize_row_q6_K(const float *src, void *dst, int64_t k) {
+  throw std::runtime_error("NYI : __fallback_quantize_row_q6_K");
+}
+
+void __fallback_quantize_row_q8_K(const float *src, void *dst, int64_t k) {
+  throw std::runtime_error("NYI : __fallback_quantize_row_q8_K");
 }
 
 void __fallback_dequantize_row_q8_K(const void *x, float *y, int64_t k) {

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -693,6 +693,17 @@ void __fallback_gemm_q4_K(const unsigned int M, const unsigned int N,
 /**
  * @brief
  *
+ * @param K
+ * @param v_q6_K
+ * @param v_q8_K
+ * @return float
+ */
+float __fallback_dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
+                               const void *v_q8_K);
+
+/**
+ * @brief
+ *
  * @param src
  * @param dst
  * @param nrow
@@ -715,6 +726,24 @@ size_t __fallback_quantize_q4_0(const float *src, void *dst, int64_t nrow,
  */
 size_t __fallback_quantize_q4_K(const float *src, void *dst, int64_t nrow,
                                 int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param k
+ */
+void __fallback_quantize_row_q6_K(const float *src, void *dst, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param k
+ */
+void __fallback_quantize_row_q8_K(const float *src, void *dst, int64_t k);
 
 /**
  * @brief

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -746,20 +746,29 @@ void __fallback_quantize_row_q6_K(const float *src, void *dst, int64_t k);
 void __fallback_quantize_row_q8_K(const float *src, void *dst, int64_t k);
 
 /**
- * @brief
+ * @brief dequantize row of q4_K data to float
  *
- * @param x_raw
- * @param y
- * @param k
+ * @param x input to be dequantized from q4_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
  */
 void __fallback_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
 
 /**
- * @brief
+ * @brief dequantize row of q6_K data to float
  *
- * @param x
- * @param y
- * @param k
+ * @param x input to be dequantized from q6_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+void __fallback_dequantize_row_q6_K(const void *x, float *y, int64_t k);
+
+/**
+ * @brief dequantize row of q8_K data to float
+ *
+ * @param x input to be dequantized from q8_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
  */
 void __fallback_dequantize_row_q8_K(const void *x, float *y, int64_t k);
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -693,10 +693,10 @@ void __fallback_gemm_q4_K(const unsigned int M, const unsigned int N,
 /**
  * @brief
  *
- * @param K
- * @param v_q6_K
- * @param v_q8_K
- * @return float
+ * @param K Length of vectors
+ * @param v_q6_K lhs vector - data stored in Q6_K format
+ * @param v_q8_K rhs vector - data stored in Q8_K format
+ * @return float Result of performing dot operation on v_q6_K and v_q8_K
  */
 float __fallback_dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                                const void *v_q8_K);

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -300,6 +300,10 @@ void __ggml_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
   ::dequantize_row_q4_K((const block_q4_K *)x_raw, y, k);
 }
 
+void __ggml_dequantize_row_q6_K(const void *x, float *y, int64_t k) {
+  ::dequantize_row_q6_K((const block_q6_K *)x, y, k);
+}
+
 void __ggml_dequantize_row_q8_K(const void *x, float *y, int64_t k) {
   ::dequantize_row_q8_K((const block_q8_K *)x, y, k);
 }

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -318,6 +318,7 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
                       const unsigned int ldb, float *C,
                       const unsigned int ldc) {
   int num_blocks_per_row = (K + QK_K - 1) / QK_K;
+#pragma omp parallel for collapse(2)
   for (unsigned int i = 0; i < M; i++) {
     for (unsigned int j = 0; j < N; j++) {
       C[i * ldc + j] = __ggml_vec_dot_q6_K(

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -249,8 +249,7 @@ void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
           M_step_end - M_step_start);
       }
     }
-  }
-  else { // GEMM
+  } else { // GEMM
     unsigned int blocks_per_4_rows = (K + QK_K - 1) / QK_K;
     unsigned int qa_4_rows_size = sizeof(block_q8_Kx4) * blocks_per_4_rows;
     unsigned int M4 = ((M + 3) / 4);
@@ -297,8 +296,8 @@ float __ggml_vec_dot_q6_K_q8_K(const unsigned int K,
 }
 
 float __ggml_vec_dot_q6_K(const unsigned int K,
-                               const void *GGML_RESTRICT v_q6_K,
-                               const float *GGML_RESTRICT activation) {
+                          const void *GGML_RESTRICT v_q6_K,
+                          const float *GGML_RESTRICT activation) {
   float result;
   int bs = 1, bx = 1, by = 1,
       nrc = 1; // unused variables in ::ggml_vec_dot_q6_K_q8_K
@@ -314,10 +313,10 @@ float __ggml_vec_dot_q6_K(const unsigned int K,
 }
 
 void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
-                           const unsigned int K, const float *A,
-                           const unsigned int lda, const void *B,
-                           const unsigned int ldb, float *C,
-                           const unsigned int ldc) {
+                      const unsigned int K, const float *A,
+                      const unsigned int lda, const void *B,
+                      const unsigned int ldb, float *C,
+                      const unsigned int ldc) {
   int num_blocks_per_row = (K + QK_K - 1) / QK_K;
   for (unsigned int i = 0; i < M; i++) {
     for (unsigned int j = 0; j < N; j++) {

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -83,6 +83,14 @@ size_t __ggml_quantize_q4_K(const float *src, void *dst, int64_t nrow,
   return ::quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
 }
 
+void __ggml_quantize_row_q6_K(const float *src, void *dst, int64_t k) {
+  ::quantize_q6_K(src, dst, 1, k, nullptr);
+}
+
+void __ggml_quantize_row_q8_K(const float *src, void *dst, int64_t k) {
+  ::quantize_row_q8_K(src, dst, k);
+}
+
 void __ggml_q4_0_8x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
                                const unsigned int K, const float *A,
                                const unsigned int lda, const void *B,
@@ -276,6 +284,16 @@ void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
                                 QA.data(), M, src0_end - src0_start);
     }
   }
+}
+
+float __ggml_vec_dot_q6_K_q8_K(const unsigned int K,
+                               const void *GGML_RESTRICT v_q6_K,
+                               const void *GGML_RESTRICT v_q8_K) {
+  float result;
+  int bs = 1, bx = 1, by = 1,
+      nrc = 1; // unused variables in ::ggml_vec_dot_q6_K_q8_K
+  ::ggml_vec_dot_q6_K_q8_K(K, &result, bs, v_q6_K, bx, v_q8_K, by, nrc);
+  return result;
 }
 
 void __ggml_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -55,6 +55,24 @@ size_t __ggml_quantize_q4_K(const float *src, void *dst, int64_t nrow,
                             int64_t n_per_row, const float *quant_weights);
 
 /**
+ * @brief Quantize float to q6_K Quantization format
+ *
+ * @param src
+ * @param dst
+ * @param k
+ */
+void __ggml_quantize_row_q6_K(const float *src, void *dst, int64_t k);
+
+/**
+ * @brief Quantize float to q6_K Quantization format
+ *
+ * @param src
+ * @param dst
+ * @param k
+ */
+void __ggml_quantize_row_q8_K(const float *src, void *dst, int64_t k);
+
+/**
  * @brief A(M, K) * W.T(N, K) = (M, N)
  *
  * @param M as descripted above
@@ -91,6 +109,17 @@ void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
                                const unsigned int lda, const void *B,
                                const unsigned int ldb, float *C,
                                const unsigned int ldc);
+
+/**
+ * @brief
+ *
+ * @param K
+ * @param v_q6_K
+ * @param v_q8_K
+ * @return float
+ */
+float __ggml_vec_dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
+                               const void *v_q8_K);
 
 /**
  * @brief q4K to float dequantize

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -131,6 +131,15 @@ float __ggml_vec_dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
 void __ggml_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
 
 /**
+ * @brief dequantize row of q6_K data to float
+ *
+ * @param x input to be dequantized from q6_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+void __ggml_dequantize_row_q6_K(const void *x, float *y, int64_t k);
+
+/**
  * @brief q8K to float dequantize
  *
  * @param x_raw input src to be dequantized

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -54,14 +54,14 @@ size_t __ggml_quantize_q4_0(const float *src, void *dst, int64_t nrow,
 size_t __ggml_quantize_q4_K(const float *src, void *dst, int64_t nrow,
                             int64_t n_per_row, const float *quant_weights);
 /**
- * @brief 
- * 
- * @param src 
- * @param dst 
- * @param nrow 
- * @param n_per_row 
- * @param quant_weights 
- * @return size_t 
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
  */
 size_t __ggml_quantize_q6_K(const float *src, void *dst, int64_t nrow,
                             int64_t n_per_row, const float *quant_weights);

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -54,6 +54,9 @@ size_t __ggml_quantize_q4_0(const float *src, void *dst, int64_t nrow,
 size_t __ggml_quantize_q4_K(const float *src, void *dst, int64_t nrow,
                             int64_t n_per_row, const float *quant_weights);
 
+size_t __ggml_quantize_q6_K(const float *src, void *dst, int64_t nrow,
+                            int64_t n_per_row, const float *quant_weights);
+
 /**
  * @brief Quantize float to q6_K Quantization format
  *
@@ -110,6 +113,11 @@ void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
                                const unsigned int ldb, float *C,
                                const unsigned int ldc);
 
+void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
+                           const unsigned int K, const float *A,
+                           const unsigned int lda, const void *B,
+                           const unsigned int ldb, float *C,
+                           const unsigned int ldc);
 /**
  * @brief
  *

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -53,7 +53,16 @@ size_t __ggml_quantize_q4_0(const float *src, void *dst, int64_t nrow,
  */
 size_t __ggml_quantize_q4_K(const float *src, void *dst, int64_t nrow,
                             int64_t n_per_row, const float *quant_weights);
-
+/**
+ * @brief 
+ * 
+ * @param src 
+ * @param dst 
+ * @param nrow 
+ * @param n_per_row 
+ * @param quant_weights 
+ * @return size_t 
+ */
 size_t __ggml_quantize_q6_K(const float *src, void *dst, int64_t nrow,
                             int64_t n_per_row, const float *quant_weights);
 

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -112,12 +112,23 @@ void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
                                const unsigned int lda, const void *B,
                                const unsigned int ldb, float *C,
                                const unsigned int ldc);
-
+/**
+ * @brief
+ *
+ * @param M
+ * @param N
+ * @param K
+ * @param A
+ * @param lda
+ * @param B
+ * @param ldb
+ * @param C
+ * @param ldc
+ */
 void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
-                           const unsigned int K, const float *A,
-                           const unsigned int lda, const void *B,
-                           const unsigned int ldb, float *C,
-                           const unsigned int ldc);
+                      const unsigned int K, const float *A,
+                      const unsigned int lda, const void *B,
+                      const unsigned int ldb, float *C, const unsigned int ldc);
 /**
  * @brief
  *

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -113,10 +113,10 @@ void __ggml_q4_K_8x8_q8_K_GEMM(const unsigned int M, const unsigned int N,
 /**
  * @brief
  *
- * @param K
- * @param v_q6_K
- * @param v_q8_K
- * @return float
+ * @param K Length of vectors
+ * @param v_q6_K lhs vector - data stored in Q6_K format
+ * @param v_q8_K rhs vector - data stored in Q8_K format
+ * @return float Result of performing dot operation on v_q6_K and v_q8_K
  */
 float __ggml_vec_dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                                const void *v_q8_K);

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -229,6 +229,15 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
 #endif
 }
 
+float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
+                    const void *v_q8_K) {
+#ifdef ENABLE_GGML
+  return __ggml_vec_dot_q6_K_q8_K(K, v_q6_K, v_q8_K);
+#else
+  return __fallback_dot_q6_K_q8_K(K, v_q6_K, v_q8_K);
+#endif
+}
+
 size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights) {
 #ifdef ENABLE_GGML
@@ -244,6 +253,22 @@ size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
   return __ggml_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
 #else
   return __fallback_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
+#endif
+}
+
+void quantize_row_q6_K(const float *src, void *dst, int64_t k) {
+#ifdef ENABLE_GGML
+  __ggml_quantize_row_q6_K(src, dst, k);
+#else
+  __fallback_quantize_row_q6_K(src, dst, k);
+#endif
+}
+
+void quantize_row_q8_K(const float *src, void *dst, int64_t k) {
+#ifdef ENABLE_GGML
+  __ggml_quantize_row_q8_K(src, dst, k);
+#else
+  __fallback_quantize_row_q8_K(src, dst, k);
 #endif
 }
 

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -280,6 +280,14 @@ void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
 #endif
 }
 
+void dequantize_row_q6_K(const void *x, float *y, int64_t k) {
+#ifdef ENABLE_GGML
+  __ggml_dequantize_row_q6_K(x, y, k);
+#else
+  __fallback_dequantize_row_q6_K(x, y, k);
+#endif
+}
+
 void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
 #ifdef ENABLE_GGML
   __ggml_dequantize_row_q8_K(x, y, k);

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -269,6 +269,7 @@ size_t quantize_q6_K(const float *src, void *dst, int64_t nrow,
 #ifdef ENABLE_GGML
   return __ggml_quantize_q6_K(src, dst, nrow, n_per_row, quant_weights);
 #endif
+  // return __fallback_quantize_q6_K(src, dst, nrow, n_per_row, quant_weights);
   return 0;
 }
 

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -238,6 +238,14 @@ float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
 #endif
 }
 
+void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc) {
+#ifdef ENABLE_GGML
+  return __ggml_gemm_q6_K(M, N, K, A, lda, B, ldb, C, ldc);
+#endif
+}
+
 size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights) {
 #ifdef ENABLE_GGML
@@ -253,6 +261,13 @@ size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
   return __ggml_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
 #else
   return __fallback_quantize_q4_K(src, dst, nrow, n_per_row, quant_weights);
+#endif
+}
+
+size_t quantize_q6_K(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights) {
+#ifdef ENABLE_GGML
+  return __ggml_quantize_q6_K(src, dst, nrow, n_per_row, quant_weights);
 #endif
 }
 

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -269,6 +269,7 @@ size_t quantize_q6_K(const float *src, void *dst, int64_t nrow,
 #ifdef ENABLE_GGML
   return __ggml_quantize_q6_K(src, dst, nrow, n_per_row, quant_weights);
 #endif
+  return 0;
 }
 
 void quantize_row_q6_K(const float *src, void *dst, int64_t k) {

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -754,6 +754,17 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
 /**
  * @brief
  *
+ * @param K
+ * @param v_q6_K
+ * @param v_q8_K
+ * @return float
+ */
+float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
+                    const void *v_q8_K);
+
+/**
+ * @brief
+ *
  * @param src
  * @param dst
  * @param nrow
@@ -776,6 +787,24 @@ size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
  */
 size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param k
+ */
+void quantize_row_q6_K(const float *src, void *dst, int64_t k);
+
+/**
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param k
+ */
+void quantize_row_q8_K(const float *src, void *dst, int64_t k);
 
 /**
  * @brief

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -807,20 +807,29 @@ void quantize_row_q6_K(const float *src, void *dst, int64_t k);
 void quantize_row_q8_K(const float *src, void *dst, int64_t k);
 
 /**
- * @brief
+ * @brief dequantize row of q4_K data to float
  *
- * @param x_raw
- * @param y
- * @param k
+ * @param x input to be dequantized from q4_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
  */
-void dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
+void dequantize_row_q4_K(const void *x, float *y, int64_t k);
 
 /**
- * @brief
+ * @brief dequantize row of q6_K data to float
  *
- * @param x
- * @param y
- * @param k
+ * @param x input to be dequantized from q6_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+void dequantize_row_q6_K(const void *x, float *y, int64_t k);
+
+/**
+ * @brief dequantize row of q8_K data to float
+ *
+ * @param x input to be dequantized from q8_K to float
+ * @param y dequantized data output
+ * @param k number of elements in x
  */
 void dequantize_row_q8_K(const void *x, float *y, int64_t k);
 

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -803,6 +803,16 @@ size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
  */
 size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
+/**
+ * @brief 
+ * 
+ * @param src 
+ * @param dst 
+ * @param nrow 
+ * @param n_per_row 
+ * @param quant_weights 
+ * @return size_t 
+ */
 size_t quantize_q6_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
 

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -751,6 +751,9 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);
 
+void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
+               const float *A, const unsigned int lda, const void *B,
+               const unsigned int ldb, float *C, const unsigned int ldc);
 /**
  * @brief
  *
@@ -786,6 +789,8 @@ size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
  * @return size_t
  */
 size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
+                     int64_t n_per_row, const float *quant_weights);
+size_t quantize_q6_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
 
 /**

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -751,6 +751,19 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);
 
+/**
+ * @brief
+ *
+ * @param M
+ * @param N
+ * @param K
+ * @param A
+ * @param lda
+ * @param B
+ * @param ldb
+ * @param C
+ * @param ldc
+ */
 void gemm_q6_K(const unsigned int M, const unsigned int N, const unsigned int K,
                const float *A, const unsigned int lda, const void *B,
                const unsigned int ldb, float *C, const unsigned int ldc);

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -754,10 +754,10 @@ void gemm_q4_K(const unsigned int M, const unsigned int N, const unsigned int K,
 /**
  * @brief
  *
- * @param K
- * @param v_q6_K
- * @param v_q8_K
- * @return float
+ * @param K Length of vectors
+ * @param v_q6_K lhs vector - data stored in Q6_K format
+ * @param v_q8_K rhs vector - data stored in Q8_K format
+ * @return float Result of performing dot operation on v_q6_K and v_q8_K
  */
 float dot_q6_K_q8_K(const unsigned int K, const void *v_q6_K,
                     const void *v_q8_K);

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -804,14 +804,14 @@ size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
 size_t quantize_q4_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);
 /**
- * @brief 
- * 
- * @param src 
- * @param dst 
- * @param nrow 
- * @param n_per_row 
- * @param quant_weights 
- * @return size_t 
+ * @brief
+ *
+ * @param src
+ * @param dst
+ * @param nrow
+ * @param n_per_row
+ * @param quant_weights
+ * @return size_t
  */
 size_t quantize_q6_K(const float *src, void *dst, int64_t nrow,
                      int64_t n_per_row, const float *quant_weights);

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -114,8 +114,8 @@ endforeach
 
 unittest_inc = include_directories('.')
 
-# subdir('memory')
-# subdir('compiler')
+subdir('memory')
+subdir('compiler')
 subdir('layers')
 subdir('datasets')
 subdir('models')

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -114,8 +114,8 @@ endforeach
 
 unittest_inc = include_directories('.')
 
-subdir('memory')
-subdir('compiler')
+# subdir('memory')
+# subdir('compiler')
 subdir('layers')
 subdir('datasets')
 subdir('models')

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -270,7 +270,7 @@ static float test_gemm_q4_0(const uint32_t M, const uint32_t K,
   }
 
   // Step4. Compute quantization error
-  auto mean_squared_error = compute_mse(M, N, ref_dst, dst);
+  auto mean_squared_error = compute_mse(M, N, ref_dst, dst, print);
   return mean_squared_error;
 }
 
@@ -312,7 +312,7 @@ static float test_gemm_q4_K(const uint32_t M, const uint32_t K,
   }
 
   // Step4. Compare quantization error
-  auto mean_squared_error = compute_mse(M, N, ref_dst, dst);
+  auto mean_squared_error = compute_mse(M, N, ref_dst, dst, print);
   return mean_squared_error;
 }
 
@@ -348,7 +348,7 @@ static float test_gemm_q6_K(const uint32_t M, const uint32_t K,
   }
 
   // Step4. Compare quantization error
-  auto mean_squared_error = compute_mse(M, N, ref_dst, dst);
+  auto mean_squared_error = compute_mse(M, N, ref_dst, dst, print);
   return mean_squared_error;
 }
 

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -464,18 +464,6 @@ static void run_vec_dot_test(const uint32_t K) {
     std::vector<char> q6_K_weight = std::vector<char>(q6_k_data_size);
     nntrainer::quantize_row_q6_K(weight.data(), q6_K_weight.data(), K);
 
-    std::vector<float> weight_dequant(K, 0.0f);
-    nntrainer::dequantize_row_q6_K(q6_K_weight.data(), weight_dequant.data(),
-                                   K);
-
-    const auto weights_quant_dequant_cos_sim =
-      cosine_similarity(weight.data(), weight_dequant.data(), K);
-    const auto weights_quant_dequant_max_diff =
-      find_max_diff(weight.data(), weight_dequant.data(), 1, K);
-
-    EXPECT_NEAR(weights_quant_dequant_cos_sim, 1.0f, 0.001f);
-    EXPECT_NEAR(weights_quant_dequant_max_diff, 0.0f, 0.025f);
-
     // Quantization of activations
     int blocks_per_row = (K + QK_K - 1) / QK_K;
     int q8_K_activation_size = sizeof(block_q8_K_testonly) * blocks_per_row;

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -278,8 +278,44 @@ static float test_gemm_q4_K(const uint32_t M, const uint32_t K,
   return mean_squared_error;
 }
 
+static float test_gemm_q6_K(const uint32_t M, const uint32_t K,
+                            const uint32_t N, const float *weights,
+                            const float *activations,
+                            std::vector<float> &ref_dst, bool print = false) {
+  // Step0. Allocate a temporary buffer for quantized weight
+  int64_t q6_k_block_size = 256;
+  int64_t q6_k_type_size = sizeof(block_q6_K_testonly);
+  int64_t num_blocks = (K * N) / q6_k_block_size;
+  size_t data_size = q6_k_type_size * N / q6_k_block_size;
+  data_size *= K;
+  std::vector<char> offline_qWeight = std::vector<char>(data_size);
+  char *offline_qWeight_ptr = (char *)offline_qWeight.data();
+
+  // Step1. Supposed to be an offline Weight quantization from float to q4_K
+  // (Zero latency overhead for the model runtime)
+  nntrainer::quantize_q6_K(weights, (void *)offline_qWeight_ptr, N, K, nullptr);
+
+  // Step2. Run GEMM! (Online activation quantization + kernel routine + return
+  // float)
+  std::vector<float> dst(M * N);
+  auto t1 = high_resolution_clock::now();
+  // #### MAIN TESTED METHOD ####
+  nntrainer::gemm_q6_K(M, N, K, activations, K, (void *)offline_qWeight_ptr, N,
+                       dst.data(), N);
+  // #### MAIN TESTED METHOD ####
+  auto t2 = high_resolution_clock::now();
+  auto dt = duration_cast<nanoseconds>(t2 - t1);
+  if (print) {
+    std::cout << "[INFO] gemm_q6_K: " << dt.count() << " ns " << std::endl;
+  }
+
+  // Step4. Compare quantization error
+  auto mean_squared_error = compute_mse(M, N, ref_dst, dst);
+  return mean_squared_error;
+}
+
 static void run_quant_test(const uint32_t M, const uint32_t K, const uint32_t N,
-                           float &q0_k_mse, float &q4_k_mse,
+                           float &q4_0_mse, float &q4_k_mse, float &q6_k_mse,
                            bool print = false) {
   if (print) {
     std::cout << "[INFO] Quantization Test (M:" << M << ", K:" << K
@@ -302,138 +338,155 @@ static void run_quant_test(const uint32_t M, const uint32_t K, const uint32_t N,
   if (print) {
     std::cout << "[INFO] sgemm :    " << dt.count() << " ns " << std::endl;
   }
-  q0_k_mse = test_gemm_q4_0(M, K, N, weight.data(), activation.data(), ref_dst);
-  q4_k_mse = test_gemm_q4_K(M, K, N, weight.data(), activation.data(), ref_dst);
+  q4_0_mse =
+    test_gemm_q4_0(M, K, N, weight.data(), activation.data(), ref_dst, print);
+  q4_k_mse =
+    test_gemm_q4_K(M, K, N, weight.data(), activation.data(), ref_dst, print);
+  q6_k_mse =
+    test_gemm_q6_K(M, K, N, weight.data(), activation.data(), ref_dst, print);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMM_256x1024x512) {
   const unsigned int M = 256;
   const unsigned int K = 1024;
   const unsigned int N = 512;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  ASSERT_LE(q0_k_mse, 2.0f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
+  ASSERT_LE(q6_k_mse, 2.0f);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMM_512x768x1024) {
   const unsigned int M = 512;
   const unsigned int K = 768;
   const unsigned int N = 1024;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  ASSERT_LE(q0_k_mse, 2.0f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
+  ASSERT_LE(q6_k_mse, 2.0f);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x1536x1536) {
   const unsigned int M = 1024;
   const unsigned int K = 1536;
   const unsigned int N = 1536;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  ASSERT_LE(q0_k_mse, 2.0f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
+  ASSERT_LE(q6_k_mse, 2.0f);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x1536x5760) {
   const unsigned int M = 1024;
   const unsigned int K = 1536;
   const unsigned int N = 5760;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  ASSERT_LE(q0_k_mse, 2.0f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
+  ASSERT_LE(q6_k_mse, 2.0f);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x3072x3072) {
   const unsigned int M = 457;
   const unsigned int K = 3072;
   const unsigned int N = 3072;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  // ASSERT_LE(q0_k_mse, 1.5f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  // ASSERT_LE(q4_0_mse, 1.5f);
   ASSERT_LE(q4_k_mse, 1.5f);
+  ASSERT_LE(q6_k_mse, 1.5f);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x3072x3072) {
   const unsigned int M = 458;
   const unsigned int K = 3072;
   const unsigned int N = 3072;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  // ASSERT_LE(q0_k_mse, 1.5f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  // ASSERT_LE(q4_0_mse, 1.5f);
   ASSERT_LE(q4_k_mse, 1.5f);
+  ASSERT_LE(q6_k_mse, 1.5f);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x3072x3072) {
   const unsigned int M = 459;
   const unsigned int K = 3072;
   const unsigned int N = 3072;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  // ASSERT_LE(q0_k_mse, 1.5f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  // ASSERT_LE(q4_0_mse, 1.5f);
   ASSERT_LE(q4_k_mse, 1.5f);
+  ASSERT_LE(q6_k_mse, 1.5f);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x3072x3072) {
   const unsigned int M = 1024;
   const unsigned int K = 3072;
   const unsigned int N = 3072;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  ASSERT_LE(q0_k_mse, 2.0f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
+  ASSERT_LE(q6_k_mse, 2.0f);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x512x768) {
   const unsigned int M = 1;
   const unsigned int K = 512;
   const unsigned int N = 768;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  ASSERT_LE(q0_k_mse, 1.0f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
+  ASSERT_LE(q6_k_mse, 1.0f);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x768x512) {
   const unsigned int M = 1;
   const unsigned int K = 768;
   const unsigned int N = 512;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  ASSERT_LE(q0_k_mse, 1.0f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
+  ASSERT_LE(q6_k_mse, 1.0f);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x768x1024) {
   const unsigned int M = 1;
   const unsigned int K = 768;
   const unsigned int N = 1024;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  ASSERT_LE(q0_k_mse, 1.0f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
+  ASSERT_LE(q6_k_mse, 1.0f);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1536x1536) {
   const unsigned int M = 1;
   const unsigned int K = 1536;
   const unsigned int N = 1536;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  ASSERT_LE(q0_k_mse, 1.0f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
+  ASSERT_LE(q6_k_mse, 1.0f);
 }
 
 TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1536x5760) {
   const unsigned int M = 1;
   const unsigned int K = 1536;
   const unsigned int N = 5760;
-  float q0_k_mse, q4_k_mse;
-  run_quant_test(M, K, N, q0_k_mse, q4_k_mse);
-  ASSERT_LE(q0_k_mse, 1.0f);
+  float q4_0_mse, q4_k_mse, q6_k_mse;
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
+  ASSERT_LE(q6_k_mse, 1.0f);
 }
 
 static void run_vec_dot_test(const uint32_t K) {

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -134,8 +134,9 @@ TEST(nntrainer_cpu_backend_standalone, ele_add) {
 }
 
 #ifdef ENABLE_GGML
-
 TEST(nntrainer_cpu_backend_standalone, q4_K_quantization) {
+  nntrainer::init_backend();
+
   const unsigned int K = 768;
   const unsigned int N = 512;
 
@@ -172,6 +173,8 @@ TEST(nntrainer_cpu_backend_standalone, q4_K_quantization) {
 }
 
 TEST(nntrainer_cpu_backend_standalone, q6_K_quantization) {
+  nntrainer::init_backend();
+
   const unsigned int K = 768;
   const unsigned int N = 512;
 
@@ -230,7 +233,6 @@ static float test_gemm_q4_0(const uint32_t M, const uint32_t K,
                             const float *activations,
                             std::vector<float> &ref_dst, bool print = false) {
   // needed to initialize f16 tables
-  nntrainer::init_backend();
 
   // Step0. Allocate a temporary buffer for quantized weight
   int64_t q4_0_type_size = sizeof(block_q4_0_testonly);
@@ -353,6 +355,8 @@ static float test_gemm_q6_K(const uint32_t M, const uint32_t K,
 static void run_quant_test(const uint32_t M, const uint32_t K, const uint32_t N,
                            float &q4_0_mse, float &q4_k_mse, float &q6_k_mse,
                            bool print = false) {
+  nntrainer::init_backend();
+
   if (print) {
     std::cout << "[INFO] Quantization Test (M:" << M << ", K:" << K
               << ", N:" << N << ")" << std::endl;
@@ -387,7 +391,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_256x1024x512) {
   const unsigned int K = 1024;
   const unsigned int N = 512;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
   ASSERT_LE(q6_k_mse, 2.0f);
@@ -398,7 +402,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_512x768x1024) {
   const unsigned int K = 768;
   const unsigned int N = 1024;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
   ASSERT_LE(q6_k_mse, 2.0f);
@@ -409,7 +413,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x1536x1536) {
   const unsigned int K = 1536;
   const unsigned int N = 1536;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
   ASSERT_LE(q6_k_mse, 2.0f);
@@ -420,7 +424,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x1536x5760) {
   const unsigned int K = 1536;
   const unsigned int N = 5760;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
   ASSERT_LE(q6_k_mse, 2.0f);
@@ -431,7 +435,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x3072x3072) {
   const unsigned int K = 3072;
   const unsigned int N = 3072;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   // ASSERT_LE(q4_0_mse, 1.5f);
   ASSERT_LE(q4_k_mse, 1.5f);
   ASSERT_LE(q6_k_mse, 1.5f);
@@ -442,7 +446,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x3072x3072) {
   const unsigned int K = 3072;
   const unsigned int N = 3072;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   // ASSERT_LE(q4_0_mse, 1.5f);
   ASSERT_LE(q4_k_mse, 1.5f);
   ASSERT_LE(q6_k_mse, 1.5f);
@@ -453,7 +457,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x3072x3072) {
   const unsigned int K = 3072;
   const unsigned int N = 3072;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   // ASSERT_LE(q4_0_mse, 1.5f);
   ASSERT_LE(q4_k_mse, 1.5f);
   ASSERT_LE(q6_k_mse, 1.5f);
@@ -464,7 +468,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x3072x3072) {
   const unsigned int K = 3072;
   const unsigned int N = 3072;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   ASSERT_LE(q4_0_mse, 2.0f);
   ASSERT_LE(q4_k_mse, 2.0f);
   ASSERT_LE(q6_k_mse, 2.0f);
@@ -475,7 +479,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x512x768) {
   const unsigned int K = 512;
   const unsigned int N = 768;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
   ASSERT_LE(q6_k_mse, 1.0f);
@@ -486,7 +490,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x768x512) {
   const unsigned int K = 768;
   const unsigned int N = 512;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
   ASSERT_LE(q6_k_mse, 1.0f);
@@ -497,7 +501,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x768x1024) {
   const unsigned int K = 768;
   const unsigned int N = 1024;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
   ASSERT_LE(q6_k_mse, 1.0f);
@@ -508,7 +512,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1536x1536) {
   const unsigned int K = 1536;
   const unsigned int N = 1536;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
   ASSERT_LE(q6_k_mse, 1.0f);
@@ -519,7 +523,7 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x1536x5760) {
   const unsigned int K = 1536;
   const unsigned int N = 5760;
   float q4_0_mse, q4_k_mse, q6_k_mse;
-  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, true);
+  run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse);
   ASSERT_LE(q4_0_mse, 1.0f);
   ASSERT_LE(q4_k_mse, 1.0f);
   ASSERT_LE(q6_k_mse, 1.0f);


### PR DESCRIPTION
Implement q6_K gemm with simple logic:

- fill all the output scalar from q6_K dot kernel for all output matrix
- Need to apply multithreading for optimal performance.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: skykongkong8 <ss.kong@samsung.com>

## Update: 2025.05.27
- With this simple openMP parallelization,
```bash
for TC : GEMV_1x3072x105900
BEFORE:
[INFO] gemm_q6_K: 251178704 ns
AFTER:
[INFO] gemm_q6_K: 28968825 ns

while, 
[INFO] sgemm :   50981615 ns 
```