### PR TITLE
[OpenCL] Tiling GEMM Computation for Large Inputs in GPU Memory

### DIFF
--- a/nntrainer/tensor/cl_operations/blas_kernel_interface.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_interface.cpp
@@ -148,8 +148,9 @@ void dotCl(Tensor const &input, Tensor const &m, Tensor &result, bool trans,
       if (input.getFormat() == Tformat::NHWC) {
         sgemm_cl(trans, trans_m, data, mdata, rdata, M, N, K, lda, ldb, ldc);
       } else {
-        gemm_cl(0, trans, trans_m, M, N, K, 1.0f, data, (trans) ? M : K, mdata,
-                (trans_m) ? K : N, 1.0f, rdata, N);
+        ldc = (trans_m) ? mdim1 : mdim2;
+        gemm_cl(0, trans, trans_m, M, N, K, 1.0f, data, dim2, mdata, mdim2,
+                0.0f, rdata, ldc);
       }
     }
   } else if (input.getDataType() == ml::train::TensorDim::DataType::FP16) {

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -1117,6 +1117,186 @@ TEST(blas_kernels, addition_i_fp16) {
 
 #endif
 
+TEST(blas_kernels, sgemm_1024_3072_105900_noTrans) {
+  int batch = 1;
+  int channel = 1;
+  int height = 1024;
+  int width = 3072;
+
+  int height_b = 3072;
+  int width_b = 105900;
+
+  bool transA = false;
+  bool transB = false;
+
+  const float alpha = 1e-1;
+  const int MOD = 10;
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  nntrainer::Tensor A_fp32(batch, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor B_fp32(batch, channel, height_b, width_b, t_type_nchw_fp32);
+
+  GEN_TEST_INPUT(A_fp32, ((i * (batch * height * channel) +
+                           j * (batch * height) + k * (width) + l + 1) %
+                          MOD) *
+                           alpha);
+  GEN_TEST_INPUT_B(B_fp32, ((i * (batch * height_b * channel) +
+                             j * (batch * height_b) + k * (width_b) + l + 1) %
+                            MOD) *
+                             alpha);
+
+  nntrainer::Tensor C = dotCl(A_fp32, B_fp32, transA, transB);
+  nntrainer::Tensor C_fp32 = A_fp32.dot(B_fp32, transA, transB);
+
+  float mseError =
+    mse<float>(C.getData<float>(), C_fp32.getData<float>(), C.size());
+
+  double cosSim = cosine_similarity<float>(C.getData<float>(),
+                                           C_fp32.getData<float>(), C.size());
+
+  const float epsilon = 1e-3 * width;
+
+  EXPECT_IN_RANGE(mseError, 0, epsilon);
+  EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
+}
+
+TEST(blas_kernels, sgemm_1024_3072_105900_transB) {
+  int batch = 1;
+  int channel = 1;
+  int height = 1024;
+  int width = 3072;
+
+  int height_b = 105900;
+  int width_b = 3072;
+
+  bool transA = false;
+  bool transB = true;
+
+  const float alpha = 1e-1;
+  const int MOD = 10;
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  nntrainer::Tensor A_fp32(batch, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor B_fp32(batch, channel, height_b, width_b, t_type_nchw_fp32);
+
+  GEN_TEST_INPUT(A_fp32, ((i * (batch * height * channel) +
+                           j * (batch * height) + k * (width) + l + 1) %
+                          MOD) *
+                           alpha);
+  GEN_TEST_INPUT_B(B_fp32, ((i * (batch * height_b * channel) +
+                             j * (batch * height_b) + k * (width_b) + l + 1) %
+                            MOD) *
+                             alpha);
+
+  nntrainer::Tensor C = dotCl(A_fp32, B_fp32, transA, transB);
+  nntrainer::Tensor C_fp32 = A_fp32.dot(B_fp32, transA, transB);
+
+  float mseError =
+    mse<float>(C.getData<float>(), C_fp32.getData<float>(), C.size());
+
+  double cosSim = cosine_similarity<float>(C.getData<float>(),
+                                           C_fp32.getData<float>(), C.size());
+
+  const float epsilon = 1e-3 * width;
+
+  EXPECT_IN_RANGE(mseError, 0, epsilon);
+  EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
+}
+
+TEST(blas_kernels, sgemm_1024_3072_105900_transA) {
+  int batch = 1;
+  int channel = 1;
+  int height = 3072;
+  int width = 1024;
+
+  int height_b = 3072;
+  int width_b = 105900;
+
+  bool transA = true;
+  bool transB = false;
+
+  const float alpha = 1e-1;
+  const int MOD = 10;
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  nntrainer::Tensor A_fp32(batch, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor B_fp32(batch, channel, height_b, width_b, t_type_nchw_fp32);
+
+  GEN_TEST_INPUT(A_fp32, ((i * (batch * height * channel) +
+                           j * (batch * height) + k * (width) + l + 1) %
+                          MOD) *
+                           alpha);
+  GEN_TEST_INPUT_B(B_fp32, ((i * (batch * height_b * channel) +
+                             j * (batch * height_b) + k * (width_b) + l + 1) %
+                            MOD) *
+                             alpha);
+
+  nntrainer::Tensor C = dotCl(A_fp32, B_fp32, transA, transB);
+  nntrainer::Tensor C_fp32 = A_fp32.dot(B_fp32, transA, transB);
+
+  float mseError =
+    mse<float>(C.getData<float>(), C_fp32.getData<float>(), C.size());
+
+  double cosSim = cosine_similarity<float>(C.getData<float>(),
+                                           C_fp32.getData<float>(), C.size());
+
+  const float epsilon = 1e-3 * width;
+
+  EXPECT_IN_RANGE(mseError, 0, epsilon);
+  EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
+}
+
+TEST(blas_kernels, sgemm_1024_3072_105900_transAB) {
+  int batch = 1;
+  int channel = 1;
+  int height = 3072;
+  int width = 1024;
+
+  int height_b = 105900;
+  int width_b = 3072;
+
+  bool transA = true;
+  bool transB = true;
+
+  const float alpha = 1e-1;
+  const int MOD = 10;
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  nntrainer::Tensor A_fp32(batch, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor B_fp32(batch, channel, height_b, width_b, t_type_nchw_fp32);
+
+  GEN_TEST_INPUT(A_fp32, ((i * (batch * height * channel) +
+                           j * (batch * height) + k * (width) + l + 1) %
+                          MOD) *
+                           alpha);
+  GEN_TEST_INPUT_B(B_fp32, ((i * (batch * height_b * channel) +
+                             j * (batch * height_b) + k * (width_b) + l + 1) %
+                            MOD) *
+                             alpha);
+
+  nntrainer::Tensor C = dotCl(A_fp32, B_fp32, transA, transB);
+  nntrainer::Tensor C_fp32 = A_fp32.dot(B_fp32, transA, transB);
+
+  float mseError =
+    mse<float>(C.getData<float>(), C_fp32.getData<float>(), C.size());
+
+  double cosSim = cosine_similarity<float>(C.getData<float>(),
+                                           C_fp32.getData<float>(), C.size());
+
+  const float epsilon = 1e-3 * width;
+
+  EXPECT_IN_RANGE(mseError, 0, epsilon);
+  EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
+}
+
 GTEST_API_ int main(int argc, char **argv) {
   int result = -1;
 


### PR DESCRIPTION
This pull request implements Tiling GEMM computation for large inputs by breaking matrices B and C into smaller tiles along the N dimension, allowing them to fit into GPU memory.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

## Benchmark Result

#### 1. Linux-x86 (NVIDIA GeForce RTX 2080 Ti)
|Engine|noTrans|transA|transB|transAB|
|------|---|---|---|---|
|GPU|421.629 ms|431.252 ms|424.622 ms|432.207 ms|
|CPU|1414 ms|1350.7 ms|1381.21 ms|1380.13 ms|

#### 2. Android-aarch64 (Qualcomm Adreno 830 GPU)
|Engine|noTrans|transA|transB|transAB|
|------|---|---|---|---|
|GPU|2571.44 ms|2833.03 ms|2696.37 ms|3005.35 ms|
|CPU|6284.88 ms|6285.92 ms|6287.1 ms|6489.28 ms|

## Profile Result

#### 1. Linux-x86 (NVIDIA GeForce RTX 2080 Ti)
- Read/Write Buffer: average 25-30%
- Kernel Execution: average 70-75%

#### 2. Android-aarch64 (Qualcomm Adreno 830 GPU)
- Read/Write Buffer: average 5-10%
- Kernel Execution: average 85-90%


## Note

The following matrix sizes are used for the benchmark and profile.
- M: 1024
- K: 3072
- N: 105900