### PR TITLE
[Q6K] Add Q6K as weight & dot operation & related unittest

### DIFF
--- a/nntrainer/engine.cpp
+++ b/nntrainer/engine.cpp
@@ -40,6 +40,7 @@ void Engine::add_default_object(Engine &eg) {
   nntrainer::AppContext *app_context = new nntrainer::AppContext();
   app_context->Global();
 
+  init_backend(); // initialize cpu backend
   eg.registerContext("cpu", app_context);
 
 #ifdef ENABLE_OPENCL

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -681,8 +681,15 @@ void NeuralNetwork::load(const std::string &file_path,
       size_t size = weight->getVariable().getMemoryBytes();
       auto tensor_data_type = weight->getDim().getDataType();
 
+      ///@todo instead of checking the data type,
+      /// we may need to create a common parent class for
+      /// quantized tensors, requiring qparam to be saved
+      /// and creating a common interface to check if qparam is needed
+      /// this kind of type checking should be avoided
       if (tensor_data_type != TensorDim::DataType::FP32 &&
-          tensor_data_type != TensorDim::DataType::FP16) {
+          tensor_data_type != TensorDim::DataType::FP16 &&
+          tensor_data_type != TensorDim::DataType::Q6_K) {
+        // for tensor with qparam
         size += sizeof(uint16_t);
       }
       file_offset.emplace_back(std::make_pair(start_from, size));

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -537,11 +537,11 @@ private:
                    bool trans_in, float beta) const;
 
   /**
-   * @brief Float.dot(Q4K)
+   * @brief Float.dot(Q4K/Q6K)
    * @return Tensor& reference to the output tensor
    */
-  Tensor &dotQ4K(Tensor const &input, Tensor &output, bool trans, bool trans_in,
-                 float beta) const;
+  Tensor &dotQnK(Tensor const &input, Tensor &output, bool trans, bool trans_in,
+                 float beta, Tdatatype dtype) const;
 };
 
 } // namespace nntrainer

--- a/nntrainer/utils/base_properties.h
+++ b/nntrainer/utils/base_properties.h
@@ -662,11 +662,12 @@ void from_string(const std::string &value, std::vector<T> &property) {
 struct TensorDataTypeInfo {
   using Enum = nntrainer::TensorDim::DataType;
   static constexpr std::initializer_list<Enum> EnumList = {
-    Enum::BCQ,  Enum::QINT4, Enum::QINT8, Enum::QINT16, Enum::FP16,
-    Enum::FP32, Enum::UINT4, Enum::UINT8, Enum::UINT16, Enum::Q4_K};
+    Enum::BCQ,    Enum::QINT4, Enum::QINT8, Enum::QINT16,
+    Enum::FP16,   Enum::FP32,  Enum::UINT4, Enum::UINT8,
+    Enum::UINT16, Enum::Q4_K,  Enum::Q6_K};
   static constexpr const char *EnumStr[] = {
-    "BCQ",  "QINT4", "QINT8", "QINT16", "FP16",
-    "FP32", "UINT4", "UINT8", "UINT16", "Q4_K"};
+    "BCQ",   "QINT4", "QINT8",  "QINT16", "FP16", "FP32",
+    "UINT4", "UINT8", "UINT16", "Q4_K",   "Q6_K"};
 };
 
 /**


### PR DESCRIPTION
- This patch adds Q6K weight type
- This ptach implements dot operation of Q6K with FP32 tensor
- This patch adds init_backend to support cpu_backend initialization
- This patch adds Q6_K as the type to be read without givine an offset
  for qparam when loading the tensor
- This patch adds Q6_K tensor unittests: dot with FP32, quant/dequant

Self evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped

