### PR TITLE
Add getProperty function

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -195,6 +195,18 @@ public:
   virtual void setProperty(const std::vector<std::string> &values) = 0;
 
   /**
+   * @brief     Get property value of layer
+   * @param[in] key Property key to retrieve
+   * @retval    std::string Property value as string
+   * @retval    Empty string if property not found
+   * @details   For layers derived from layer_impl: Property lookup is handled
+   * automatically.
+   * @details For layers derived from layer_devel: The getProperty() function
+   * must be overridden to enable property retrieval.
+   */
+  virtual std::string getProperty(const std::string &key) = 0;
+
+  /**
    * @brief     Get name of the layer
    * @retval    name of the layer
    * @note      This name is unique to this layer in a model

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -252,6 +252,13 @@ public:
   virtual void setProperty(const std::vector<std::string> &values) = 0;
 
   /**
+   * @brief     Get property value of layer
+   * @param     key Property key to retrieve
+   * @return    Property value as string (empty string if not found)
+   */
+  virtual std::string getProperty(const std::string &key) { return ""; }
+
+  /**
    * @brief this function helps exporting the layer in a predefined format,
    * while workarounding issue caused by templated function type eraser
    *

--- a/nntrainer/layers/layer_impl.cpp
+++ b/nntrainer/layers/layer_impl.cpp
@@ -37,6 +37,14 @@ void LayerImpl::setProperty(const std::vector<std::string> &values) {
          std::to_string(values.size());
 }
 
+std::string LayerImpl::getProperty(const std::string &key) {
+  if (!layer_impl_props)
+    return "";
+
+  std::string result = find_in_tuple(*layer_impl_props, key);
+  return !result.empty() ? result : "";
+}
+
 void LayerImpl::exportTo(Exporter &exporter,
                          const ml::train::ExportMethods &method) const {
   exporter.saveResult(*layer_impl_props, method, this);

--- a/nntrainer/layers/layer_impl.h
+++ b/nntrainer/layers/layer_impl.h
@@ -78,6 +78,11 @@ public:
   virtual void setProperty(const std::vector<std::string> &values) override;
 
   /**
+   * @copydoc Layer::getProperty(const std::string &key)
+   */
+  virtual std::string getProperty(const std::string &key) override;
+
+  /**
    * @copydoc Layer::exportTo(Exporter &exporter, const ml::train::ExportMethods
    * &methods)
    */

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -228,6 +228,24 @@ void LayerNode::setProperty(const std::vector<std::string> &properties) {
   }
 }
 
+std::string LayerNode::getProperty(const std::string &key) {
+  if (layer_node_props) {
+    std::string result = find_in_tuple(*layer_node_props, key);
+    if (!result.empty()) {
+      return result;
+    }
+  }
+
+  if (layer_node_props_realization) {
+    std::string result = find_in_tuple(*layer_node_props_realization, key);
+    if (!result.empty()) {
+      return result;
+    }
+  }
+
+  return layer->getProperty(key);
+}
+
 void LayerNode::setWeights(const std::vector<float *> weights) {
   NNTR_THROW_IF(!run_context, std::runtime_error)
     << __func__ << " layer needs to be finalized first!";

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -98,6 +98,8 @@ public:
    */
   void setProperty(const std::vector<std::string> &properties) override;
 
+  std::string getProperty(const std::string &key) override;
+
   /**
    * @brief     Get name of the layer
    *

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -334,6 +334,46 @@ template <typename T, typename C = int> T enum_class_or(T e1, T e2) {
 }
 
 /**
+ * @brief Find value in tuple by key (internal impl)
+ *
+ * @tparam Tuple Tuple type to search
+ * @tparam ls... Tuple index sequence
+ * @param t Tuple to search
+ * @param key Key to find
+ *
+ * @return Found value or empty string
+ */
+template <typename Tuple, std::size_t... ls>
+std::string find_in_tuple(const Tuple &t, std::index_sequence<ls...>,
+                          const std::string &key) {
+  std::string result = "";
+
+  (..., ([&] {
+     auto &&elem = std::get<ls>(t);
+     if (strcmp(getPropKey(elem), key.c_str()) == 0) {
+       result = elem.empty() ? "empty" : to_string(elem);
+     }
+   }()));
+
+  return result;
+}
+
+/**
+ * @brief Find value in tuple by key (user-friendly wrapper)
+ *
+ * @tparam Args Tuple element types
+ * @param t Tuple to search
+ * @param key Key to find
+ *
+ * @return Found value or empty string
+ */
+template <typename... Args>
+std::string find_in_tuple(const std::tuple<Args...> &t,
+                          const std::string &key) {
+  return find_in_tuple(t, std::index_sequence_for<Args...>{}, key);
+}
+
+/**
  * @brief Convert a relative path into an absolute path.
  *
  * @param name relative path


### PR DESCRIPTION
Implemented a getProperty function that allows checking the value using the key of a set property.
The actual implementation must be added in the layer. 
If not implemented, it returns an empty string ("").

To use getProperty, inherit from layer_impl and insert the property tuple existing in the layer into LayerImpl::for_each function.

If the key exists in the tuple, it returns the value. If the property is not set and there is no default value, it returns "empty".