### PR TITLE
[ LOGGING ] enable logging with cout & cerr only with DEBUG

### DIFF
--- a/nntrainer/nntrainer_logger.cpp
+++ b/nntrainer/nntrainer_logger.cpp
@@ -167,6 +167,7 @@ void __nntrainer_log_print(nntrainer_loglevel loglevel,
   Logger::instance().log(ss, loglevel);
 #else
 
+#if defined(DEBUG)
   switch (loglevel) {
   case NNTRAINER_LOG_ERROR:
     std::cerr << ss << std::endl;
@@ -178,7 +179,7 @@ void __nntrainer_log_print(nntrainer_loglevel loglevel,
   default:
     break;
   }
-
+#endif
 #endif
 }
 


### PR DESCRIPTION
This PR activates the Logging with cout & cerr only with DEBUG

Resolves:

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>