### PR TITLE
[OpenCL] Add Q6_K GEMV kernel

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -153,6 +153,7 @@ void ClContext::initBlasClKernels() {
   registerClKernel(getSgemmClTransABKernel(), "sgemm_cl_transAB");
   registerClKernel(getAdditionClKernel(), "addition_cl");
   registerClKernel(getSscalClKernel(), "sscal_cl");
+  registerClKernel(getQ6KSgemvClKernel(), "kernel_mul_mv_q6_K_f32");
 
 #ifdef ENABLE_FP16
   registerClKernel(getHgemvClKernel(), "sgemv_cl_fp16");

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
@@ -16,6 +16,132 @@
 
 namespace nntrainer {
 
+const std::string &getQ6KSgemvClKernel() {
+  static const std::string q6_k_sgemv_cl_kernel_ =
+    R"(
+    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+    #define QK_K 256
+    #define N_SIMDWIDTH 16
+    #define N_SIMDGROUP 2
+    #define N_DST 1
+    #define BLOCK_STRIDE (N_SIMDWIDTH / 16)
+
+    typedef char int8_t;
+    typedef uchar uint8_t;
+    typedef short int16_t;
+    typedef ushort uint16_t;
+    typedef int int32_t;
+    typedef uint uint32_t;
+
+    typedef struct {
+        uint8_t ql[QK_K / 2];
+        uint8_t qh[QK_K / 4];
+        int8_t  scales[QK_K / 16];
+        half d;
+    } block_q6_K;
+
+    kernel void kernel_mul_mv_q6_K_f32(
+        global void * src0,
+        ulong offset0,
+        global float * src1,
+        ulong offset1,
+        global float * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        int ne10,
+        int ne12,
+        int ne0,
+        int ne1,
+        int r2,
+        int r3
+    ) {
+        __local float reduction_buf[N_SIMDGROUP][N_SIMDWIDTH];
+
+        src0 = (global void*)((global char*)src0 + offset0);
+        src1 = (global float*)((global char*)src1 + offset1);
+        dst = (global float*)((global char*)dst + offsetd);
+
+        int nb = ne00 / QK_K;
+
+        int r0 = get_group_id(0);
+        int r1 = get_group_id(1);
+        int im = get_group_id(2);
+        int lid = get_local_id(0);
+        int lsize = get_local_size(0);
+
+        int row_group = lid / N_SIMDWIDTH;
+        int lane = lid % N_SIMDWIDTH;
+        int row = r0 * N_SIMDGROUP + row_group;
+
+        int i12 = im % ne12;
+        int i13 = im / ne12;
+
+        ulong offset_src0 = (i12 / r2) * (nb * ne01) + (i13 / r3) * (nb * ne01 * ne02);
+
+        global block_q6_K * x = (global block_q6_K *) src0 + row * nb + offset_src0;
+        global float      * yy = (global float     *) src1 + r1 * ne10 + im * ne00 * ne1;
+
+        uchar kmask1 = 0x03, kmask2 = 0x0C, kmask3 = 0x30, kmask4 = 0xC0;
+
+        int tid  = lane / BLOCK_STRIDE;
+        int ix   = lane % BLOCK_STRIDE;
+        int ip   = tid / 8;
+        int il   = tid % 8;
+        int n    = 4;
+        int l0   = n * il;
+        int is   = 8 * ip + l0 / 16;
+
+        int y_offset = 128 * ip + l0;
+        int q_offset_l = 64 * ip + l0;
+        int q_offset_h = 32 * ip + l0;
+
+        float sumf = 0.0f;
+
+        for (int i = ix; i < nb; i += BLOCK_STRIDE) {
+            global uint8_t * q1 = x[i].ql + q_offset_l;
+            global uint8_t * q2 = q1 + QK_K / 8;
+            global uint8_t * qh = x[i].qh + q_offset_h;
+            global int8_t  * sc = x[i].scales + is;
+            global float   * y = yy + i * QK_K + y_offset;
+
+            float dall = x[i].d;
+            float4 sums = {0.f, 0.f, 0.f, 0.f};
+
+            for (int j = 0; j < 4; j++) {
+                sums.s0 += y[j + 0]   * ((float)((q1[j] & 0xF) | ((qh[j] & kmask1) << 4)) - 32.f);
+                sums.s1 += y[j + 32]  * ((float)((q2[j] & 0xF) | ((qh[j] & kmask2) << 2)) - 32.f);
+                sums.s2 += y[j + 64]  * ((float)((q1[j] >> 4) | ((qh[j] & kmask3) >> 0)) - 32.f);
+                sums.s3 += y[j + 96]  * ((float)((q2[j] >> 4) | ((qh[j] & kmask4) >> 2)) - 32.f);
+            }
+
+            sumf += dall * (sums.s0 * sc[0] + sums.s1 * sc[2] + sums.s2 * sc[4] + sums.s3 * sc[6]);
+        }
+
+        reduction_buf[row_group][lane] = sumf;
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int offset = N_SIMDWIDTH / 2; offset > 0; offset >>= 1) {
+            if (lane < offset) {
+                reduction_buf[row_group][lane] += reduction_buf[row_group][lane + offset];
+            }
+            barrier(CLK_LOCAL_MEM_FENCE);
+        }
+
+        if (lane == 0) {
+            int global_row = r0 * N_SIMDGROUP + row_group;
+            dst[r1 * ne0 + im * ne0 * ne1 + global_row] = reduction_buf[row_group][0];
+
+            // dst[r1 * ne0 + im * ne0 * ne1 + row] = reduction_buf[row_group][0];
+        }
+    }
+    )";
+
+  return q6_k_sgemv_cl_kernel_;
+}
+
 const std::string &getSgemvClKernel() {
   static const std::string sgemv_cl_kernel_ =
     R"(__kernel void sgemv_cl(const __global float* A, const __global float* X,

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.h
@@ -18,6 +18,8 @@
 
 namespace nntrainer {
 
+const std::string &getQ6KSgemvClKernel();
+
 const std::string &getSgemvClKernel();
 
 const std::string &getSgemvClNoTransKernel();

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -30,6 +30,17 @@ static ClContext *blas_cc =
 static ClBufferManager &clbuffInstance = ClBufferManager::getInstance();
 
 /**
+ * @brief     Q6_K sgemv computation : Y = A*X
+ * @param[in] matAdata void * for Matrix A
+ * @param[in] vecXdata float * for Vector X
+ * @param[in] vecYdata float * for Vector Y
+ * @param[in] M number of rows in matrix A
+ * @param[in] N number of columns in matrix A
+ */
+void sgemv_q6_k_cl(const void *matAdata, const float *vecXdata, float *vecYdata,
+                   unsigned int M, unsigned int N);
+
+/**
  * @brief     sgemv computation : Y = A*X + Y
  * @param[in] matAdata float * for Matrix A
  * @param[in] vecXdata float * for Vector X


### PR DESCRIPTION
This PR implements the Q6_K GEMV OpenCL kernel.
Note that the current implementation loads input data into global memory every time.
A preloading version is a work in progress.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

## Benchmark Result

#### 1. Linux-x86 (NVIDIA GeForce GTX 1650)
|Engine|avg time|
|------|---|
|GPU (preload) | 0.02982 ms|
|GPU| 2.21088 ms|
|CPU| 6.31663 ms|

#### 2. Android (Qualcomm Adreno 740)
|Engine|avg time|
|------|---|
|GPU (preload) | 0.18577 ms|
|GPU| 2.981 ms|
|CPU| 16.050 ms|

## Note

The following matrix sizes are used for the benchmark and profile.
- M: 1
- K: 3072
- N: 105900