### PR TITLE
[LoRA] bugfix in LoRA

### DIFF
--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -137,14 +137,16 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
     TensorDim loraTmp_dim(
       in_dim.batch(), is_nchw ? 1 : lora_rank, is_nchw ? in_dim.height() : 1,
       is_nchw ? lora_rank : in_dim.width(),
-      TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
+      TensorDim::TensorType(context.getFormat(),
+                            context.getActivationDataType()),
       is_nchw ? 0b1011 : 0b1101);
 
     /** loraTmp Dimension : (B, 1, in_dim.height(), unit) */
     TensorDim loraOut_dim(
       in_dim.batch(), is_nchw ? 1 : unit, is_nchw ? in_dim.height() : 1,
       is_nchw ? unit : in_dim.width(),
-      TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
+      TensorDim::TensorType(context.getFormat(),
+                            context.getActivationDataType()),
       is_nchw ? 0b1011 : 0b1101);
 
     lora_idx[LORAParams::loraA] = context.requestWeight(


### PR DESCRIPTION
## Dependency of the PR

(None)

## Commits to be reviewed in this PR


<details><summary>[LoRA] bugfix in LoRA</summary><br />

- Fix the data type of tensor allocated when the LoRA is enabled.
- loratmp and loraout tensors should be `activation_type`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

### Summary

- Fix the data type of tensor allocated when the LoRA is enabled.
- loratmp and loraout tensors should be `activation_type`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
