### PR TITLE
Enable OpenCL Support on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -166,16 +166,14 @@ if get_option('enable-opencl')
   extra_defines += '-DENABLE_OPENCL=1'
   clblast_options = cmake.subproject_options()
 
-  if get_option('platform') == 'android'
-    clblast_dep = declare_dependency()
-  else
-    if host_machine.system() == 'windows'
-      clblast_options.add_cmake_defines(common_win_subproject_cmake_defines)
+  if host_machine.system() != 'windows'
+    if get_option('platform') == 'android'
+      clblast_dep = declare_dependency()
+    else
+      clblast_options.add_cmake_defines({'CMAKE_POLICY_VERSION_MINIMUM': '3.10'})
+      clblast_proj = cmake.subproject('clblast', options: clblast_options, required: true)
+      clblast_dep = clblast_proj.dependency('clblast')
     endif
-
-    clblast_options.add_cmake_defines({'CMAKE_POLICY_VERSION_MINIMUM': '3.10'})
-    clblast_proj = cmake.subproject('clblast', options: clblast_options, required: true)
-    clblast_dep = clblast_proj.dependency('clblast')
   endif
 endif
 

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -35,7 +35,9 @@ nntrainer_base_deps=[
 ]
 
 if get_option('enable-opencl')
-  nntrainer_base_deps += clblast_dep
+  if host_machine.system() != 'windows'
+    nntrainer_base_deps += clblast_dep
+  endif
 endif
 
 if get_option('platform') == 'tizen'

--- a/nntrainer/opencl/opencl_loader.cpp
+++ b/nntrainer/opencl/opencl_loader.cpp
@@ -44,7 +44,12 @@ bool LoadOpenCL() {
   }
 
   void *libopencl = nullptr;
+
+#if defined(_WIN32)
+  static const char *kClLibName = "OpenCL.dll";
+#else
   static const char *kClLibName = "libOpenCL.so";
+#endif
 
   libopencl =
     DynamicLibraryLoader::loadLibrary(kClLibName, RTLD_NOW | RTLD_LOCAL);

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -14,8 +14,10 @@
 #include <blas_kernel_strings.h>
 #include <blas_kernels.h>
 
+#if !defined(_WIN32)
 #define CL_EXT_SUFFIX__VERSION_2_0_DEPRECATED // to disable deprecation warnings
 #include "clblast.h"
+#endif
 
 namespace nntrainer {
 


### PR DESCRIPTION
This PR enables the use of OpenCL on Windows.
Please note that **OpenCL must be installed** in order to use OpenCL.

