### PR TITLE
[Tensor][Read] Change Tensor read from file_offset

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -671,12 +671,10 @@ void NeuralNetwork::load(const std::string &file_path,
   const std::regex reg_("\\s*\\:\\s*");
   auto v = split(file_path, reg_);
 
-  std::vector<size_t> start_offsets = {0};
-  std::vector<std::pair<size_t, size_t>> file_offset;
   size_t start_from = 0;
+  std::vector<std::pair<size_t, size_t>> file_offset;
   for (auto iter = model_graph.cbegin(); iter != model_graph.cend(); iter++) {
     auto weights = (*iter)->getRunContext().getWeights();
-    auto local_offset = start_offsets.back();
     for (auto weight : weights) {
       size_t size = weight->getVariable().getMemoryBytes();
       auto tensor_data_type = weight->getDim().getDataType();
@@ -694,9 +692,7 @@ void NeuralNetwork::load(const std::string &file_path,
       }
       file_offset.emplace_back(std::make_pair(start_from, size));
       start_from += size;
-      local_offset += size;
     }
-    start_offsets.push_back(local_offset);
   }
 
   if (exec_mode == ExecutionMode::INFERENCE && fsu_mode) {
@@ -722,7 +718,7 @@ void NeuralNetwork::load(const std::string &file_path,
           auto local_model_file = checkedOpenStream<std::ifstream>(
             (v.size() == 2) ? v[1] : v[0], std::ios::in | std::ios::binary);
           (*iter)->read(local_model_file, false, exec_mode, fsu_mode,
-                        start_offsets[exec_order], true);
+                        std::numeric_limits<size_t>::max(), true);
         }));
       }
       for (auto &f : futures)

--- a/nntrainer/tensor/bcq_tensor.cpp
+++ b/nntrainer/tensor/bcq_tensor.cpp
@@ -266,7 +266,9 @@ void BCQTensor::readFSU() { createBCQW(); }
 
 void BCQTensor::read(std::ifstream &file, size_t start_offset,
                      bool read_from_offset) {
-  /// @note Read quantization information
+  if (start_offset == std::numeric_limits<size_t>::max()) {
+    start_offset = file_offset;
+  }
   read_quantization_info(file, start_offset, read_from_offset);
 
   std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());

--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -422,7 +422,9 @@ void CharTensor::save(std::ostream &file) {
 
 void CharTensor::read(std::ifstream &file, size_t start_offset,
                       bool read_from_offset) {
-  /// @note Read quantization information
+  if (start_offset == std::numeric_limits<size_t>::max()) {
+    start_offset = file_offset;
+  }
   read_quantization_info(file, start_offset, read_from_offset);
 
   std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());

--- a/nntrainer/tensor/int4_tensor.cpp
+++ b/nntrainer/tensor/int4_tensor.cpp
@@ -347,7 +347,9 @@ void Int4QTensor::save(std::ostream &file) {
 
 void Int4QTensor::read(std::ifstream &file, size_t start_offset,
                        bool read_from_offset) {
-  /// @note Read quantization information
+  if (start_offset == std::numeric_limits<size_t>::max()) {
+    start_offset = file_offset;
+  }
   read_quantization_info(file, start_offset, read_from_offset);
 
   std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -323,7 +323,9 @@ void ShortTensor::save(std::ostream &file) {
 
 void ShortTensor::read(std::ifstream &file, size_t start_offset,
                        bool read_from_offset) {
-  /// @note Read quantization information
+  if (start_offset == std::numeric_limits<size_t>::max()) {
+    start_offset = file_offset;
+  }
   read_quantization_info(file, start_offset, read_from_offset);
 
   std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -60,6 +60,9 @@ void TensorBase::save(std::ostream &file) {
 
 void TensorBase::read(std::ifstream &file, size_t start_offset,
                       bool read_from_offset) {
+  if (start_offset == std::numeric_limits<size_t>::max()) {
+    start_offset = file_offset;
+  }
   std::streamsize sz = static_cast<std::streamsize>(bytes());
 
   NNTR_THROW_IF(sz < 0, std::invalid_argument)

--- a/nntrainer/tensor/uint4_tensor.cpp
+++ b/nntrainer/tensor/uint4_tensor.cpp
@@ -382,7 +382,9 @@ void Uint4QTensor::save(std::ostream &file) {
 
 void Uint4QTensor::read(std::ifstream &file, size_t start_offset,
                         bool read_from_offset) {
-  /// @note Read quantization information
+  if (start_offset == std::numeric_limits<size_t>::max()) {
+    start_offset = file_offset;
+  }
   read_quantization_info(file, start_offset, read_from_offset);
 
   std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());

--- a/nntrainer/tensor/uint_tensor.cpp
+++ b/nntrainer/tensor/uint_tensor.cpp
@@ -380,7 +380,9 @@ template <typename T> void UIntTensor<T>::save(std::ostream &file) {
 template <typename T>
 void UIntTensor<T>::read(std::ifstream &file, size_t start_offset,
                          bool read_from_offset) {
-  /// @note Read quantization information
+  if (start_offset == std::numeric_limits<size_t>::max()) {
+    start_offset = file_offset;
+  }
   read_quantization_info(file, start_offset, read_from_offset);
 
   std::streamsize sz = static_cast<std::streamsize>(getMemoryBytes());


### PR DESCRIPTION
## Dependency of the PR
- None
## Commits to be reviewed in this PR


<details><summary>[Tensor][Read] Change Tensor read from file_offset</summary><br />

    [Tensor][Read] Change Tensor read from file_offset
    
    Previously, the tensor would receive parameters and, if the flag to read from the file offset was true, it would read from the passed start_offset.
    Now, since the tensor holds its own fileOffset, if the value is size_t::max, it will default to reading from the stored fileOffset.
    
    **Self evaluation:**
    1. Build test:   [X]Passed [ ]Failed [ ]Skipped
    2. Run test:     [X]Passed [ ]Failed [ ]Skipped
    
    Signed-off-by: Donghak PARK <donghak.park@samsung.com>


</details>



<details><summary>[Load] Refactoring Model Load Async</summary><br />

    [Load] Refactoring Model Load Async
    
    The existing method, which passed the offset through the execution order for each layer using a separate start_offset,
    has been modified to store and read the start_offset calculated by the FSU at the tensor level.
    
    **Self evaluation:**
    1. Build test:   [X]Passed [ ]Failed [ ]Skipped
    2. Run test:     [X]Passed [ ]Failed [ ]Skipped
    
    Signed-off-by: Donghak PARK <donghak.park@samsung.com>


</details>

### Summary

- The tensor now stores its own fileOffset and defaults to reading from this stored offset if the value is ```size_t::max.```
- After this pr, read will work as below 
```.cpp
read(std::ifstream &file, bool opt_var, ml::train::ExecutionMode mode, bool fsu, size_t start_offset = 0, bool read_from_offset = false)
```
**case 1. read(file, opt_var, exec_mode, fsu)** 
- will read from 0 to end

**case 2. read(file, opt_var, exec_mode, fsu,std::numeric_limits<size_t>::max(), true)**
- will read from tensor's fileOffset

**case 3. read(file, opt_var, exec_mode, fsu, 1050, true)**
- will read from 1050 to 1050 + Tensor's size

----

## Motivation & History of Change 

To help reviewers better understand, I will explain the motivation and background behind the changes.

**1. Sequential Loading Issue:**
- During inference, NNTrainer loaded weights by sequentially reading files based on their size. As modern AI models (especially LLMs) grew larger, this approach caused significant delays in loading large files. To address this, an **asynchronous loading** mechanism was introduced.

**2. Preloading Weight Sizes for Async Support:**
- To enable async loading, the starting point of each file segment needed to be determined beforehand. Thus, the system was modified to **pre-scan layer weights** and calculate their sizes before loading.

**3. Handling Quantization Info:**
- With support for diverse tensor types, certain cases (e.g., quantized tensors) required special handling due to embedded quantization metadata. This necessitated separate processing logic for such tensors.

**4. Offset Adjustment for Quantized Tensors:**
- For tensors with quantization info, the system first reads the metadata before creating/setting the tensor. The actual data is loaded afterward, requiring adjustments to the starting offset during the read operation.

**5. Dynamic LoRA Support:**
- While async loading improved speed, dynamic adaptations (e.g., LoRA) required tensors to **store their original offsets** instead of relying on runtime parameters. The default behavior was updated to read from these stored offsets.

**6. Flexible Offset Handling for LoRA:**
- To support LoRA, the read() function was modified to accept a **user-specified offset** when needed. Otherwise, it defaults to the tensor’s pre-stored offset for standard weight loading.

**Key Improvements:**
- **Faster loading** via async I/O and pre-scanning.
- **Enhanced flexibility** for quantized tensors and dynamic adaptations like LoRA.
- **Backward-compatible** offset management for both default and custom read operations.


Signed-off-by: Donghak PARK <donghak.park@samsung.com>
