### PR TITLE
Split platform / device creation function and add device type selection for future use

### DIFF
--- a/nntrainer/opencl/opencl_context_manager.cpp
+++ b/nntrainer/opencl/opencl_context_manager.cpp
@@ -61,7 +61,7 @@ const cl_context &ContextManager::GetContext() {
       break;
     }
 
-    result = CreateDefaultGPUDevice();
+    result = CreateDefaultDevice();
     if (!result) {
       break;
     }
@@ -147,19 +147,18 @@ bool ContextManager::CreateDefaultPlatform() {
 }
 
 /**
- * @brief Create a Default GPU Device object
+ * @brief Create a default device object
  *
  * @return true if successful or false otherwise
  */
-bool ContextManager::CreateDefaultGPUDevice() {
+bool ContextManager::CreateDefaultDevice(cl_device_type type) {
   cl_int status = 0;
 
   cl_uint num_devices = 0;
   cl_uint preferred_device_index = 0;
 
-  // getting available GPU devices
-  status =
-    clGetDeviceIDs(platform_id_, CL_DEVICE_TYPE_GPU, 0, nullptr, &num_devices);
+  // getting number of available devices of selected type
+  status = clGetDeviceIDs(platform_id_, type, 0, nullptr, &num_devices);
   if (status != CL_SUCCESS) {
     ml_loge("clGetDeviceIDs returned %d", status);
     return false;
@@ -169,17 +168,16 @@ bool ContextManager::CreateDefaultGPUDevice() {
     return false;
   }
 
-  // getting the GPU device IDs
+  // getting the device IDs
   std::vector<cl_device_id> devices(num_devices);
-  status = clGetDeviceIDs(platform_id_, CL_DEVICE_TYPE_GPU, num_devices,
-                          devices.data(), nullptr);
+  status =
+    clGetDeviceIDs(platform_id_, type, num_devices, devices.data(), nullptr);
   if (status != CL_SUCCESS) {
     ml_loge("clGetDeviceIDs returned %d", status);
     return false;
   }
 
-  // setting the first GPU ID that is available on platform selected in
-  // ContextManager::CreateDefazultPlatform function
+  // setting the first device ID that is available on platform
   device_id_ = devices[preferred_device_index];
 
 #ifdef ENABLE_FP16

--- a/nntrainer/opencl/opencl_context_manager.cpp
+++ b/nntrainer/opencl/opencl_context_manager.cpp
@@ -56,6 +56,11 @@ const cl_context &ContextManager::GetContext() {
   bool result = true;
 
   do {
+    result = CreateDefaultPlatform();
+    if (!result) {
+      break;
+    }
+
     result = CreateDefaultGPUDevice();
     if (!result) {
       break;
@@ -106,15 +111,18 @@ ContextManager::~ContextManager() {
 }
 
 /**
- * @brief Create a Default GPU Device object
+ * @brief Create a default platform object
  *
  * @return true if successful or false otherwise
  */
-bool ContextManager::CreateDefaultGPUDevice() {
-  cl_uint num_platforms;
+bool ContextManager::CreateDefaultPlatform() {
+  cl_int status = 0;
+
+  cl_uint num_platforms = 0;
+  cl_uint preferred_platform_index = 0;
 
   // returns number of OpenCL supported platforms
-  cl_int status = clGetPlatformIDs(0, nullptr, &num_platforms);
+  status = clGetPlatformIDs(0, nullptr, &num_platforms);
   if (status != CL_SUCCESS) {
     ml_loge("clGetPlatformIDs returned %d", status);
     return false;
@@ -133,9 +141,21 @@ bool ContextManager::CreateDefaultGPUDevice() {
   }
 
   // platform is a specific OpenCL implementation, for instance ARM
-  cl_platform_id platform_id_ = platforms[0];
+  platform_id_ = platforms[preferred_platform_index];
 
-  cl_uint num_devices;
+  return true;
+}
+
+/**
+ * @brief Create a Default GPU Device object
+ *
+ * @return true if successful or false otherwise
+ */
+bool ContextManager::CreateDefaultGPUDevice() {
+  cl_int status = 0;
+
+  cl_uint num_devices = 0;
+  cl_uint preferred_device_index = 0;
 
   // getting available GPU devices
   status =
@@ -158,9 +178,9 @@ bool ContextManager::CreateDefaultGPUDevice() {
     return false;
   }
 
-  // setting the first GPU ID and platform (ARM)
-  device_id_ = devices[0];
-  this->platform_id_ = platform_id_;
+  // setting the first GPU ID that is available on platform selected in
+  // ContextManager::CreateDefazultPlatform function
+  device_id_ = devices[preferred_device_index];
 
 #ifdef ENABLE_FP16
   /// @note This is working incorrectly. For CUDA devices, cl_khr_fp16 is not

--- a/nntrainer/opencl/opencl_context_manager.h
+++ b/nntrainer/opencl/opencl_context_manager.h
@@ -31,6 +31,13 @@ class ContextManager {
   cl_context context_{nullptr};
 
   /**
+   * @brief Create a default platform object
+   *
+   * @return true if successful or false otherwise
+   */
+  bool CreateDefaultPlatform();
+
+  /**
    * @brief Create a Default GPU Device object
    *
    * @return true if successful or false otherwise
@@ -48,7 +55,7 @@ class ContextManager {
    * @brief Private constructor to prevent object creation
    *
    */
-  ContextManager(){};
+  ContextManager() {};
 
 public:
   /**

--- a/nntrainer/opencl/opencl_context_manager.h
+++ b/nntrainer/opencl/opencl_context_manager.h
@@ -38,11 +38,11 @@ class ContextManager {
   bool CreateDefaultPlatform();
 
   /**
-   * @brief Create a Default GPU Device object
+   * @brief Create a default device object
    *
    * @return true if successful or false otherwise
    */
-  bool CreateDefaultGPUDevice();
+  bool CreateDefaultDevice(cl_device_type type = CL_DEVICE_TYPE_GPU);
 
   /**
    * @brief Create OpenCL context
@@ -55,7 +55,7 @@ class ContextManager {
    * @brief Private constructor to prevent object creation
    *
    */
-  ContextManager() {};
+  ContextManager(){};
 
 public:
   /**


### PR DESCRIPTION
Introduced:

- split OpenCL platform / device creation function to 2 separate functions
- pass device type to device create function  

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: mwlasiuk <testmailsmtp12345@gmail.com>
