### PR TITLE
Tensor/get batch slice with indices

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1259,7 +1259,7 @@ Tensor Tensor::getBatchSlice(const std::vector<unsigned int> &indices) const {
 
 // Parallel copy using OpenMP
 #pragma omp parallel for schedule(static)
-  for (size_t i = 0; i < indices.size(); ++i) {
+  for (int i = 0; i < static_cast<int>(indices.size()); ++i) {
     const unsigned batch_idx = indices[i];
 
     // Calculate memory offsets

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1232,6 +1232,10 @@ Tensor Tensor::getBatchSlice(const std::vector<unsigned int> &indices) const {
   NNTR_THROW_IF(!this->getContiguous(), std::runtime_error)
     << "getBatchSlice requires contiguous tensor layer";
 
+  // Validate indices vector is not empty
+  NNTR_THROW_IF(indices.empty(), std::invalid_argument)
+    << "Indices vector cannot be empty";
+
   // Validate indices
   const unsigned batch_size = getDim().batch();
   for (auto idx : indices) {
@@ -1251,6 +1255,10 @@ Tensor Tensor::getBatchSlice(const std::vector<unsigned int> &indices) const {
   new_dim.batch(indices.size());
   Tensor output(new_dim);
 
+  // Validate output tensor size
+  const size_t output_bytes = output.bytes();
+  const size_t single_batch_bytes = single_batch_size * element_size;
+
   // Get raw data pointers
   const unsigned char *src_data =
     static_cast<const unsigned char *>(this->getData<unsigned char>());
@@ -1263,12 +1271,18 @@ Tensor Tensor::getBatchSlice(const std::vector<unsigned int> &indices) const {
     const unsigned batch_idx = indices[i];
 
     // Calculate memory offsets
-    const size_t src_offset = batch_idx * single_batch_size * element_size;
-    const size_t dst_offset = i * single_batch_size * element_size;
+    const size_t src_offset =
+      static_cast<size_t>(batch_idx) * single_batch_bytes;
+    const size_t dst_offset = static_cast<size_t>(i) * single_batch_bytes;
+
+    // Bounds check for destination buffer
+    NNTR_THROW_IF(dst_offset + single_batch_bytes > output_bytes,
+                  std::runtime_error)
+      << "Destination buffer overflow detected";
 
     // Perform memory copy
     std::memcpy(dst_data + dst_offset, src_data + src_offset,
-                single_batch_size * element_size);
+                single_batch_bytes);
   }
 
   return output;

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1226,6 +1226,54 @@ Tensor Tensor::getBatchSlice(size_t offset, unsigned int size) const {
                              true, "");
 }
 
+Tensor Tensor::getBatchSlice(const std::vector<unsigned int> &indices) const {
+
+  // Validate tensor contiguity
+  NNTR_THROW_IF(!this->getContiguous(), std::runtime_error)
+    << "getBatchSlice requires contiguous tensor layer";
+
+  // Validate indices
+  const unsigned batch_size = getDim().batch();
+  for (auto idx : indices) {
+    NNTR_THROW_IF(idx >= batch_size, std::out_of_range)
+      << "Batch index " << idx << " out of range [0," << batch_size << ")";
+  }
+
+  // Get original tensor dimensions
+  const TensorDim &orig_dim = this->getDim();
+  const size_t element_size = orig_dim.getDataTypeSize();
+
+  // Calculate single batch size in elements
+  const size_t single_batch_size = orig_dim.getFeatureLen();
+
+  // Create output tensor with selected batches
+  TensorDim new_dim = orig_dim;
+  new_dim.batch(indices.size());
+  Tensor output(new_dim);
+
+  // Get raw data pointers
+  const unsigned char *src_data =
+    static_cast<const unsigned char *>(this->getData<unsigned char>());
+  unsigned char *dst_data =
+    static_cast<unsigned char *>(output.getData<void>());
+
+// Parallel copy using OpenMP
+#pragma omp parallel for schedule(static)
+  for (size_t i = 0; i < indices.size(); ++i) {
+    const unsigned batch_idx = indices[i];
+
+    // Calculate memory offsets
+    const size_t src_offset = batch_idx * single_batch_size * element_size;
+    const size_t dst_offset = i * single_batch_size * element_size;
+
+    // Perform memory copy
+    std::memcpy(dst_data + dst_offset, src_data + src_offset,
+                single_batch_size * element_size);
+  }
+
+  return output;
+}
+
 Tensor Tensor::clone() const {
   Tensor output(getName(), getFormat(), getDataType());
   output.copy(*this);

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1561,6 +1561,32 @@ public:
   Tensor getBatchSlice(size_t offset, unsigned int size) const;
 
   /**
+   * @brief Extract sub-tensor containing specified batch indices
+   *
+   * @param indices List of batch indices to extract (0-based)
+   * @return Tensor New tensor containing only specified batches  (copied
+   * tensor!)
+   *
+   * @details
+   * This function creates a new tensor containing copies of data from
+   * specified batch indices of the original tensor. The operation:
+   * - Requires the original tensor to be contiguous in memory
+   * - Preserves channel/height/width dimensions
+   * - Maintains data ordering within each batch
+   * - Uses memcpy for efficient memory operations
+   *
+   * @note
+   * - Time complexity: O(k*C*H*W) where k = num_indices
+   * - Memory complexity: O(k*C*H*W)
+   * - Thread-safe when using different indices in parallel
+   *
+   * @throw std::runtime_error If:
+   * - Tensor is not contiguous
+   * - Any index is out of bounds
+   */
+  Tensor getBatchSlice(const std::vector<unsigned int> &indices) const;
+
+  /**
    * @brief     Convient wrapper for inplace copy of @a this.
    * @retval    Copied version of this
    */

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1563,7 +1563,8 @@ public:
   /**
    * @brief Extract sub-tensor containing specified batch indices
    *
-   * @param indices List of batch indices to extract (0-based)
+   * @param indices List of batch indices to extract (0-based) Duplicates are
+   * allowed and will result in the same batch data being copied multiple times.
    * @return Tensor New tensor containing only specified batches  (copied
    * tensor!)
    *
@@ -1574,6 +1575,11 @@ public:
    * - Preserves channel/height/width dimensions
    * - Maintains data ordering within each batch
    * - Uses memcpy for efficient memory operations
+   *
+   * @note Duplicate indices: If the same index appears multiple times, the
+   * corresponding batch data will be copied to each position in the output
+   * tensor. Example: indices {0, 1, 1} creates output with 3 batches where
+   * positions 1 and 2 contain identical copies  of input batch 1.
    *
    * @note
    * - Time complexity: O(k*C*H*W) where k = num_indices

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -1006,10 +1006,13 @@ TEST(nntrainer_Tensor, getBatchSlice_float_p) {
 
   // Test invalid index
   EXPECT_THROW(input.getBatchSlice({3}), std::out_of_range);
+
+  // Test empty indices vector
+  EXPECT_THROW(input.getBatchSlice({}), std::invalid_argument);
 }
 
 TEST(nntrainer_Tensor, getBatchSlice_uint16_p) {
-  // UINT16 텐서 생성: [batch=3][channel=2][height=4][width=2]
+  // Create UINT16 tensor: [batch=3, channel=2, height=4, width=2]
   std::vector<std::vector<std::vector<std::vector<float>>>> data = {
     {// Batch 0
      {{1000, 2000}, {3000, 4000}, {5000, 6000}, {7000, 8000}},
@@ -1074,6 +1077,47 @@ TEST(nntrainer_Tensor, getBatchSlice_parallel_p) {
       EXPECT_FLOAT_EQ(ref_slice.getValue(idx), par_slice.getValue(idx));
     }
   }
+}
+
+TEST(nntrainer_Tensor, getBatchSlice_duplicate_indices_p) {
+  // Create input tensor: batch=4, channel=1, height=1, width=2
+  std::vector<std::vector<std::vector<std::vector<float>>>> data = {
+    {{{10.0f, 11.0f}}},
+    {{{20.0f, 21.0f}}},
+    {{{30.0f, 31.0f}}},
+    {{{40.0f, 41.0f}}}};
+
+  nntrainer::Tensor input(
+    data, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
+
+  // Test with duplicate indices: {0, 1, 3, 1, 1}
+  std::vector<unsigned int> indices = {0, 1, 3, 1, 1};
+
+  nntrainer::Tensor sliced = input.getBatchSlice(indices);
+
+  // Verify  output tensor dimensions
+  EXPECT_EQ(sliced.getDim(), nntrainer::TensorDim(5, 1, 1, 2));
+
+  // Verify each batch in the output
+  // Position 0: should contain batch 0 data
+  EXPECT_FLOAT_EQ(sliced.getValue(0, 0, 0, 0), 10.0f);
+  EXPECT_FLOAT_EQ(sliced.getValue(0, 0, 0, 1), 11.0f);
+
+  // Position 1: should contain batch 1 data
+  EXPECT_FLOAT_EQ(sliced.getValue(1, 0, 0, 0), 20.0f);
+  EXPECT_FLOAT_EQ(sliced.getValue(1, 0, 0, 1), 21.0f);
+
+  // Position 2: should contain batch 3 data
+  EXPECT_FLOAT_EQ(sliced.getValue(2, 0, 0, 0), 40.0f);
+  EXPECT_FLOAT_EQ(sliced.getValue(2, 0, 0, 1), 41.0f);
+
+  // Position 3: should contain batch 1 data again
+  EXPECT_FLOAT_EQ(sliced.getValue(3, 0, 0, 0), 20.0f);
+  EXPECT_FLOAT_EQ(sliced.getValue(3, 0, 0, 1), 21.0f);
+
+  // Position 4: should contain batch 1 data again
+  EXPECT_FLOAT_EQ(sliced.getValue(4, 0, 0, 0), 20.0f);
+  EXPECT_FLOAT_EQ(sliced.getValue(4, 0, 0, 1), 21.0f);
 }
 
 TEST(nntrainer_Tensor, copy_01_n) {


### PR DESCRIPTION
## Dependency of the PR
None

## Commits to be reviewed in this PR


<details><summary>[Tensor] Add batch slicing for a given indices vector</summary><br />

- Implement `Tensor::getBatchSlice(std::vector<unsigned int>) for MoE
  layer token routing (MoE token routing is irrelevant with this patch
though)
- Validate tensor contiguity before slicing operations
- Add dimension checks for out-of-range indices
- Please note that this operation does not use sharedFrom but do the
  copy.
- This operation would be used in scatter

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



<details><summary>[Tensor] Add unittest for getBatchSlice</summary><br />

- Verify FP32/UINT16 data type handling
- Add positive test cases:
   - Single/Multi-batch selection
   - Large tensor stress test
- Add negative test cases
   - out of range index validation
- Include parallel execution stability test
   - 100x concurrent access check


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

### Summary

- This PR aims to implement `getBatchSlice(std::vector<unsigned int> indices)` and create its unit test cases
- This PR's operation is implemented to support scatter operation in MoE layer
- Please also see #3252 

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
