### PR TITLE
[Refactor] Simplify tensor memory data allocation @open sesame 05/23 09:17

### DIFF
--- a/nntrainer/tensor/bcq_tensor.cpp
+++ b/nntrainer/tensor/bcq_tensor.cpp
@@ -59,13 +59,9 @@ void BCQTensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    mem_data = new MemoryData((void *)(new uint32_t[size() + scale_size()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<uint32_t>();
-      delete mem_data;
-    });
+    auto data_t = std::make_shared<MemoryDataT<uint32_t>>(
+      new uint32_t[size() + scale_size()]);
+    data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
     offset = 0;
     initialize();
@@ -173,6 +169,8 @@ void BCQTensor::setZero() {
 void BCQTensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  TensorBase::initialize();
 
   /// @note Sampling from the normal/uniform distribution is invalid
   switch (initializer) {

--- a/nntrainer/tensor/bcq_tensor.h
+++ b/nntrainer/tensor/bcq_tensor.h
@@ -104,6 +104,11 @@ public:
   void *getScale(size_t idx) const override;
 
   /**
+   * @copydoc Tensor::hasScale()
+   */
+  bool hasScale() const override { return true; }
+
+  /**
    * @brief     i data index
    * @retval    address of ith data
    */

--- a/nntrainer/tensor/char_tensor.cpp
+++ b/nntrainer/tensor/char_tensor.cpp
@@ -64,12 +64,9 @@ CharTensor::CharTensor(
   NNTR_THROW_IF(scales.size() != scale_size(), std::invalid_argument)
     << "invalid scale factor size " << scales.size();
 
-  MemoryData *mem_data = new MemoryData(
-    (void *)(new int8_t[dim.getDataLen() + sizeof(float) * scale_size()]()));
-  data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
-    delete[] mem_data->getAddr<int8_t>();
-    delete mem_data;
-  });
+  auto data_t = std::make_shared<MemoryDataT<int8_t>>(
+    new int8_t[dim.getDataLen() + sizeof(float) * scale_size()]);
+  data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
   offset = 0;
 
@@ -127,14 +124,9 @@ void CharTensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    mem_data = new MemoryData(
-      (void *)(new int8_t[dim.getDataLen() + 4 * scale_size()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<int8_t>();
-      delete mem_data;
-    });
+    auto data_t = std::make_shared<MemoryDataT<int8_t>>(
+      new int8_t[dim.getDataLen() + 4 * scale_size()]);
+    data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
     offset = 0;
     initialize();
@@ -243,6 +235,8 @@ void CharTensor::setZero() {
 void CharTensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  TensorBase::initialize();
 
   /// @note Sampling from the normal/uniform distribution is invalid
   switch (initializer) {

--- a/nntrainer/tensor/char_tensor.h
+++ b/nntrainer/tensor/char_tensor.h
@@ -121,6 +121,11 @@ public:
   void *getScale(size_t idx) const override;
 
   /**
+   * @copydoc Tensor::hasScale()
+   */
+  bool hasScale() const override { return true; }
+
+  /**
    * @brief     i data index
    * @retval    address of ith data
    */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -26,7 +26,10 @@
     float y0;                                                                  \
     unsigned int i, j;                                                         \
     for (ci = 0; ci != cM; ci++) {                                             \
-      y0 = Y[ci * incY] * beta;                                                \
+      y0 = 0.0f;                                                               \
+      if (beta != 0.0f) {                                                      \
+        y0 = Y[ci * incY] * beta;                                              \
+      }                                                                        \
       for (cj = 0; cj != cN; cj++)                                             \
         y0 += A[i + j * lda] * X[cj * incX];                                   \
       Y[ci * incY] = y0;                                                       \
@@ -198,8 +201,9 @@ void __fallback_sgemm(const unsigned int TStorageOrder, bool TransA,
         c += a * b;
       }
       C[m * ldc + n] = alpha * c;
-      if (beta != 0.0)
+      if (beta != 0.0f) {
         C[m * ldc + n] += beta * c_old;
+      }
     }
   }
 }
@@ -258,7 +262,8 @@ void __fallback_ele_mul(const unsigned int N, const float *X, const float *Y,
                         float *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X * alpha * *Y + beta * *Z;
+    *Z = *X * alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+    ;
     X += o_stride;
     Y += i_stride;
     Z += o_stride;
@@ -269,7 +274,8 @@ void __fallback_ele_add(const unsigned int N, const float *X, const float *Y,
                         float *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X + alpha * *Y + beta * *Z;
+    *Z = *X + alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+    ;
     X += o_stride;
     Y += i_stride;
     Z += o_stride;
@@ -280,7 +286,8 @@ void __fallback_ele_sub(const unsigned N, const float *X, const float *Y,
                         float *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X - alpha * *Y + beta * *Z;
+    *Z = *X - alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+    ;
     X += o_stride;
     Y += i_stride;
     Z += o_stride;
@@ -291,7 +298,8 @@ void __fallback_ele_div(const unsigned N, const float *X, const float *Y,
                         float *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X / (alpha * *Y) + beta * *Z;
+    *Z = *X / (alpha * *Y) + ((0.0f == beta) ? 0.0f : beta * *Z);
+    ;
     X += o_stride;
     Y += i_stride;
     Z += o_stride;

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal_fp16.cpp
@@ -26,7 +26,10 @@
     float y0;                                                                  \
     unsigned int i, j;                                                         \
     for (ci = 0; ci != cM; ci++) {                                             \
-      y0 = static_cast<float>(Y[ci * incY] * static_cast<_FP16>(beta));        \
+      y0 = 0.0f;                                                               \
+      if (beta != 0.0f) {                                                      \
+        y0 = static_cast<float>(Y[ci * incY] * static_cast<_FP16>(beta));      \
+      }                                                                        \
       for (cj = 0; cj != cN; cj++)                                             \
         y0 += static_cast<float>(A[i + j * lda] * X[cj * incX]);               \
       Y[ci * incY] = static_cast<_FP16>(y0);                                   \
@@ -46,8 +49,9 @@
           c += static_cast<float>(a * b);                                      \
         }                                                                      \
         C[m * ldc + n] = static_cast<_FP16>(alpha * c);                        \
-        if (beta != 0.0)                                                       \
+        if (beta != 0.0f) {                                                    \
           C[m * ldc + n] += static_cast<_FP16>(beta) * c_old;                  \
+        }                                                                      \
       }                                                                        \
     }                                                                          \
   } while (0);
@@ -216,7 +220,9 @@ void __fallback_ele_mul(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                         _FP16 *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X * static_cast<_FP16>(alpha) * *Y + static_cast<_FP16>(beta) * *Z;
+    *Z = *X * static_cast<_FP16>(alpha) * *Y +
+         ((0.0f == beta) ? static_cast<_FP16>(0.0f)
+                         : static_cast<_FP16>(beta) * *Z);
     X += o_stride;
     Y += i_stride;
     Z += o_stride;
@@ -227,7 +233,10 @@ void __fallback_ele_add(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                         _FP16 *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X + static_cast<_FP16>(alpha) * *Y + static_cast<_FP16>(beta) * *Z;
+    *Z = *X + static_cast<_FP16>(alpha) * *Y +
+         ((0.0f == beta) ? static_cast<_FP16>(0.0f)
+                         : static_cast<_FP16>(beta) * *Z);
+    ;
     X += o_stride;
     Y += i_stride;
     Z += o_stride;
@@ -238,7 +247,10 @@ void __fallback_ele_sub(const unsigned N, const _FP16 *X, const _FP16 *Y,
                         _FP16 *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X - static_cast<_FP16>(alpha) * *Y + static_cast<_FP16>(beta) * *Z;
+    *Z = *X - static_cast<_FP16>(alpha) * *Y +
+         ((0.0f == beta) ? static_cast<_FP16>(0.0f)
+                         : static_cast<_FP16>(beta) * *Z);
+    ;
     X += o_stride;
     Y += i_stride;
     Z += o_stride;
@@ -249,7 +261,10 @@ void __fallback_ele_div(const unsigned N, const _FP16 *X, const _FP16 *Y,
                         _FP16 *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X / (static_cast<_FP16>(alpha) * *Y) + static_cast<_FP16>(beta) * *Z;
+    *Z = *X / (static_cast<_FP16>(alpha) * *Y) +
+         ((0.0f == beta) ? static_cast<_FP16>(0.0f)
+                         : static_cast<_FP16>(beta) * *Z);
+    ;
     X += o_stride;
     Y += i_stride;
     Z += o_stride;

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -526,7 +526,7 @@ void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
   } else {
     // TODO: AVX2 implementation if used
     for (unsigned int i = 0; i < N; ++i) {
-      *Z = *X * alpha * *Y + beta * *Z;
+      *Z = *X * alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
       X += o_stride;
       Y += i_stride;
       Z += o_stride;
@@ -570,7 +570,7 @@ void ele_add(const unsigned int N, const float *X, const float *Y, float *Z,
   } else {
     // TODO: AVX2 implementation if used
     for (unsigned int i = 0; i < N; ++i) {
-      *Z = *X + alpha * *Y + beta * *Z;
+      *Z = *X + alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
       X += o_stride;
       Y += i_stride;
       Z += o_stride;

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -11,6 +11,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <numeric>
 
 #include <cpu_backend.h>
@@ -63,13 +64,9 @@ void FloatTensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    mem_data = new MemoryData((void *)(new float[dim.getDataLen()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<float>();
-      delete mem_data;
-    });
+    auto data_t =
+      std::make_shared<MemoryDataT<float>>(new float[dim.getDataLen()]);
+    data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
     offset = 0;
     initialize();
@@ -177,6 +174,8 @@ void FloatTensor::setRandBernoulli(float probability) {
 void FloatTensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  TensorBase::initialize();
 
   unsigned int fan_in, fan_out;
 
@@ -737,7 +736,8 @@ Tensor &FloatTensor::dotFloat(Tensor const &input, Tensor &output, bool trans,
   /// (1 * K) X (1 * M) can be a case
   /// case1: (1 * K) X (K * 1)
   if (M == 1 && N == 1) {
-    *rdata = sdot(K, data, 1, mdata, 1) + beta * (*rdata);
+    *rdata =
+      sdot(K, data, 1, mdata, 1) + ((0.0f == beta) ? 0.0f : beta * *rdata);
   }
   /// case2: (M * K) X (K * 1)
   else if (N == 1) {

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -84,12 +84,9 @@ public:
     contiguous = true;
     initializer = Initializer::NONE;
 
-    MemoryData *mem_data =
-      new MemoryData((void *)(new float[dim.getDataLen()]()));
-    data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
-      delete[] mem_data->getAddr<float>();
-      delete mem_data;
-    });
+    auto data_t =
+      std::make_shared<MemoryDataT<float>>(new float[dim.getDataLen()]);
+    data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
     offset = 0;
 

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -83,12 +83,9 @@ public:
     contiguous = true;
     initializer = Initializer::NONE;
 
-    MemoryData *mem_data =
-      new MemoryData((void *)(new _FP16[dim.getDataLen()]()));
-    data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
-      delete[] mem_data->getAddr<_FP16>();
-      delete mem_data;
-    });
+    auto data_t =
+      std::make_shared<MemoryDataT<_FP16>>(new _FP16[dim.getDataLen()]);
+    data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
     offset = 0;
 

--- a/nntrainer/tensor/int4_tensor.cpp
+++ b/nntrainer/tensor/int4_tensor.cpp
@@ -68,13 +68,9 @@ Int4QTensor::Int4QTensor(
 
   /// @note sizeof(float) * scale_size() assumes scale factors are in
   /// full-precision fp.
-  MemoryData *mem_data =
-    new MemoryData((void *)(new int8_t[(dim.getDataLen() + 1) / 2 +
-                                       sizeof(float) * scale_size()]()));
-  data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
-    delete[] mem_data->getAddr<int8_t>();
-    delete mem_data;
-  });
+  auto data_t = std::make_shared<MemoryDataT<int8_t>>(
+    new int8_t[(dim.getDataLen() + 1) / 2 + sizeof(float) * scale_size()]);
+  data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
   offset = 0;
 
@@ -129,16 +125,9 @@ void Int4QTensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    /// quantized 4-bit is stored as a 8-bit signed integer (int4x2)
-    mem_data =
-      new MemoryData((void *)(new int8_t[(dim.getDataLen() + 1) / 2 +
-                                         sizeof(float) * scale_size()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<int8_t>();
-      delete mem_data;
-    });
+    auto data_t = std::make_shared<MemoryDataT<int8_t>>(
+      new int8_t[(dim.getDataLen() + 1) / 2 + sizeof(float) * scale_size()]);
+    data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
     offset = 0;
     initialize();
@@ -270,6 +259,8 @@ void Int4QTensor::setZero() {
 void Int4QTensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  TensorBase::initialize();
 
   /// @note Sampling from the normal/uniform distribution is invalid
   switch (initializer) {

--- a/nntrainer/tensor/int4_tensor.h
+++ b/nntrainer/tensor/int4_tensor.h
@@ -125,6 +125,11 @@ public:
   void *getScale(size_t idx) const override;
 
   /**
+   * @copydoc Tensor::hasScale()
+   */
+  bool hasScale() const override { return true; }
+
+  /**
    * @brief     i data index
    * @retval    address of ith data
    */

--- a/nntrainer/tensor/memory_data.h
+++ b/nntrainer/tensor/memory_data.h
@@ -109,12 +109,31 @@ public:
    */
   void setValid(bool v) { valid = v; }
 
-private:
+protected:
   bool valid;
   unsigned int id;
   void *address;
   MemoryDataValidateCallback validate_cb;
   MemoryDataValidateCallback invalidate_cb;
+};
+
+/**
+ * @class   MemoryDataT
+ * @brief   MemoryDataT make possible to create classes derived from MemoryData
+ * with proper memory release depends on data type
+ */
+template <typename T> class MemoryDataT : public MemoryData {
+public:
+  /**
+   * @brief  Constructor of MemoryDataT
+   * @param[in] addr Memory data
+   */
+  explicit MemoryDataT(void *addr) : MemoryData(addr) {}
+
+  /**
+   * @brief  Destructor of MemoryDataT
+   */
+  ~MemoryDataT() override { delete[] static_cast<T *>(address); };
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/q4_k_tensor.cpp
+++ b/nntrainer/tensor/q4_k_tensor.cpp
@@ -55,13 +55,8 @@ void Q4_K_Tensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    mem_data = new MemoryData((void *)(new uint8_t[size()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<uint8_t>();
-      delete mem_data;
-    });
+    auto data_t = std::make_shared<MemoryDataT<uint8_t>>(new uint8_t[size()]);
+    data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
     offset = 0;
     initialize();

--- a/nntrainer/tensor/q4_k_tensor.h
+++ b/nntrainer/tensor/q4_k_tensor.h
@@ -77,6 +77,16 @@ public:
   void allocate() override;
 
   /**
+   * @copydoc Tensor::hasScale()
+   */
+  bool hasScale() const override { return false; }
+
+  /**
+   * @copydoc Tensor::hasZeroPoint()
+   */
+  bool hasZeroPoint() const override { return false; }
+
+  /**
    * @copydoc TensorBase::size()
    */
   size_t size() const override;

--- a/nntrainer/tensor/q6_k_tensor.cpp
+++ b/nntrainer/tensor/q6_k_tensor.cpp
@@ -47,13 +47,8 @@ void Q6_K_Tensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    mem_data = new MemoryData((void *)(new uint8_t[size()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<uint8_t>();
-      delete mem_data;
-    });
+    auto data_t = std::make_shared<MemoryDataT<uint8_t>>(new uint8_t[size()]);
+    data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
     offset = 0;
     initialize();
@@ -94,6 +89,8 @@ void Q6_K_Tensor::setZero() {
 void Q6_K_Tensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  TensorBase::initialize();
 
   setZero();
   putData();

--- a/nntrainer/tensor/short_tensor.cpp
+++ b/nntrainer/tensor/short_tensor.cpp
@@ -62,13 +62,10 @@ ShortTensor::ShortTensor(
   contiguous = true;
   initializer = Initializer::NONE;
 
-  MemoryData *mem_data = new MemoryData(
-    (void *)(new int16_t[dim.getDataLen() +
-                         sizeof(float) / sizeof(int16_t) * scale_size()]()));
-  data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
-    delete[] mem_data->getAddr<int16_t>();
-    delete mem_data;
-  });
+  auto data_t = std::make_shared<MemoryDataT<int16_t>>(
+    new int16_t[dim.getDataLen() +
+                sizeof(float) / sizeof(int16_t) * scale_size()]);
+  data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
   offset = 0;
 
@@ -126,15 +123,10 @@ void ShortTensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    mem_data = new MemoryData(
-      (void *)(new int16_t[dim.getDataLen() +
-                           sizeof(float) / sizeof(int16_t) * scale_size()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<int16_t>();
-      delete mem_data;
-    });
+    auto data_t = std::make_shared<MemoryDataT<int16_t>>(
+      new int16_t[dim.getDataLen() +
+                  sizeof(float) / sizeof(int16_t) * scale_size()]);
+    data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
     offset = 0;
     initialize();
@@ -243,6 +235,8 @@ void ShortTensor::setZero() {
 void ShortTensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  TensorBase::initialize();
 
   /// @note Sampling from the normal/uniform distribution is invalid
   switch (initializer) {

--- a/nntrainer/tensor/short_tensor.h
+++ b/nntrainer/tensor/short_tensor.h
@@ -114,6 +114,11 @@ public:
   void *getScale(size_t idx) const override;
 
   /**
+   * @copydoc Tensor::hasScale()
+   */
+  bool hasScale() const override { return true; }
+
+  /**
    * @brief     i data index
    * @retval    address of ith data
    */

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -497,7 +497,7 @@ int Tensor::multiply_i(Tensor const &m, const float beta) {
 }
 
 Tensor Tensor::multiply(Tensor const &m, const float beta) const {
-  Tensor t("", this->getFormat());
+  Tensor t("", getFormat(), getDataType());
   return multiply(m, t, beta);
 }
 
@@ -664,7 +664,7 @@ Tensor &Tensor::subtract(float const &value, Tensor &output) const {
 int Tensor::subtract_i(Tensor const &m) { return add_i(m, -1); }
 
 Tensor Tensor::subtract(Tensor const &m) const {
-  Tensor t;
+  Tensor t("", getFormat(), getDataType());
   return this->subtract(m, t);
 }
 
@@ -941,7 +941,7 @@ void Tensor::standardization_i() {
 }
 
 Tensor Tensor::dot(Tensor const &input, bool trans, bool trans_in) const {
-  Tensor output("", this->getFormat(), this->getDataType());
+  Tensor output("", getFormat(), getDataType());
   dot(input, output, trans, trans_in);
 
   return output;

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -578,6 +578,18 @@ public:
   }
 
   /**
+   * @brief     set scale of Tensor to given const value
+   * @param[in] value of scale to set
+   */
+  void setScale(const float value) { itensor_->setScale(value); }
+
+  /**
+   * @brief     check if tensor have scale
+   * @retval    tensor has scale flag
+   */
+  bool hasScale() const { return itensor_->hasScale(); }
+
+  /**
    * @brief     return zero point pointer of Tensor
    * @retval    unsigned int pointer
    */
@@ -590,6 +602,18 @@ public:
   unsigned int *getZeroPoint(size_t idx) const {
     return itensor_->getZeroPoint(idx);
   }
+
+  /**
+   * @brief     set zero points of Tensor to given const value
+   * @param[in] value of zero point to set
+   */
+  void setZeroPoint(const unsigned int value) { itensor_->setZeroPoint(value); }
+
+  /**
+   * @brief     check if tensor have zero point
+   * @retval    tensor has zero point flag
+   */
+  bool hasZeroPoint() const { return itensor_->hasZeroPoint(); }
 
   /**
    * @brief     i data index

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -58,6 +58,25 @@ void TensorBase::save(std::ostream &file) {
   putData();
 }
 
+void TensorBase::setScale(const float value) {
+  NNTR_THROW_IF(!hasScale(), std::logic_error)
+    << "Tensor does not support scale";
+  NNTR_THROW_IF(scale_size() == 0, std::logic_error) << "Incorrect scale size";
+
+  auto *scale = (float *)getScale();
+  std::fill(scale, scale + scale_size(), value);
+}
+
+void TensorBase::setZeroPoint(const unsigned int value) {
+  NNTR_THROW_IF(!hasZeroPoint(), std::logic_error)
+    << "Tensor does not support zero point";
+  NNTR_THROW_IF(scale_size() == 0, std::logic_error)
+    << "Incorrect zero point size";
+
+  auto *zero_point = (unsigned int *)getZeroPoint();
+  std::fill(zero_point, zero_point + scale_size(), value);
+}
+
 void TensorBase::read(std::ifstream &file, size_t start_offset,
                       bool read_from_offset) {
   if (start_offset == std::numeric_limits<size_t>::max()) {
@@ -406,6 +425,16 @@ void TensorBase::setRandBernoulli(float probability) {
   throw std::invalid_argument("Tensor::setRandBernoulli() is currently not "
                               "supported in tensor data type " +
                               getStringDataType());
+}
+
+void TensorBase::initialize() {
+  if (hasScale()) {
+    setScale(DEFAULT_TENSOR_SCALE);
+  }
+
+  if (hasZeroPoint()) {
+    setZeroPoint(DEFAULT_TENSOR_ZERO_POINT);
+  }
 }
 
 Tensor TensorBase::multiply_strided(Tensor const &m, Tensor &output,

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -92,6 +92,8 @@ class SrcSharedTensorBase;
  */
 class TensorBase {
 public:
+  static constexpr float DEFAULT_TENSOR_SCALE = 1.0f;
+  static constexpr unsigned int DEFAULT_TENSOR_ZERO_POINT = 0u;
   /**
    * @brief     Basic Constructor of Tensor
    */
@@ -138,6 +140,7 @@ public:
     name = rhs.name;
     data = rhs.data;
     offset = rhs.offset;
+    file_offset = rhs.file_offset;
     src_tensor = rhs.src_tensor;
   }
 
@@ -209,6 +212,16 @@ public:
   }
 
   /**
+   * @copydoc Tensor::setScale(const float value)
+   */
+  void setScale(const float value);
+
+  /**
+   * @copydoc Tensor::hasScale()
+   */
+  virtual bool hasScale() const { return false; }
+
+  /**
    * @copydoc Tensor::getZeroPoint()
    */
   virtual unsigned int *getZeroPoint() const {
@@ -225,6 +238,16 @@ public:
       "Tensor::getZeroPoint() is not supported in tensor data type " +
       getStringDataType());
   }
+
+  /**
+   * @copydoc Tensor::setZeroPoint(const unsigned int value)
+   */
+  void setZeroPoint(const unsigned int value);
+
+  /**
+   * @copydoc Tensor::hasZeroPoint()
+   */
+  virtual bool hasZeroPoint() const { return false; }
 
   /**
    * @brief     i data index
@@ -278,7 +301,7 @@ public:
   /**
    * @copydoc Tensor::initialize()
    */
-  virtual void initialize() = 0;
+  virtual void initialize();
 
   /**
    * @copydoc Tensor::initialize(Initializer init)

--- a/nntrainer/tensor/uint4_tensor.cpp
+++ b/nntrainer/tensor/uint4_tensor.cpp
@@ -70,13 +70,10 @@ Uint4QTensor::Uint4QTensor(
 
   /// @note sizeof(float) * scale_size() assumes scale factors are in
   /// full-precision fp.
-  MemoryData *mem_data = new MemoryData((
-    void
-      *)(new uint8_t[(dim.getDataLen() + 1) / 2 + sizeof(float) * scale_size() +
-                     sizeof(unsigned int) * scale_size()]()));
-  data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
-    delete[] mem_data->getAddr<uint8_t>();
-  });
+  auto data_t = std::make_shared<MemoryDataT<uint8_t>>(
+    new uint8_t[(dim.getDataLen() + 1) / 2 + sizeof(float) * scale_size() +
+                sizeof(unsigned int) * scale_size()]);
+  data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
   offset = 0;
 
@@ -138,17 +135,10 @@ void Uint4QTensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    /// quantized 4-bit is stored as a 8-bit signed integer (uint4x2)
-    mem_data = new MemoryData(
-      (void *)(new uint8_t[(dim.getDataLen() + 1) / 2 +
-                           sizeof(float) * scale_size() +
-                           sizeof(unsigned int) * scale_size()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<uint8_t>();
-      delete mem_data;
-    });
+    auto data_t = std::make_shared<MemoryDataT<uint8_t>>(
+      new uint8_t[(dim.getDataLen() + 1) / 2 + sizeof(float) * scale_size() +
+                  sizeof(unsigned int) * scale_size()]);
+    data = std::static_pointer_cast<MemoryData>(std::move(data_t));
 
     offset = 0;
     initialize();
@@ -304,6 +294,8 @@ void Uint4QTensor::setZero() {
 void Uint4QTensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  TensorBase::initialize();
 
   /// @note Sampling from the normal/uniform distribution is invalid
   switch (initializer) {

--- a/nntrainer/tensor/uint4_tensor.h
+++ b/nntrainer/tensor/uint4_tensor.h
@@ -135,6 +135,11 @@ public:
   void *getScale(size_t idx) const override;
 
   /**
+   * @copydoc Tensor::hasScale()
+   */
+  bool hasScale() const override { return true; }
+
+  /**
    * @copydoc Tensor::getZeroPoint()
    */
   unsigned int *getZeroPoint() const override;
@@ -143,6 +148,11 @@ public:
    * @copydoc Tensor::getZeroPoint(size_t idx)
    */
   unsigned int *getZeroPoint(size_t idx) const override;
+
+  /**
+   * @copydoc Tensor::hasZeroPoint()
+   */
+  bool hasZeroPoint() const override { return true; }
 
   /**
    * @brief     i data index

--- a/nntrainer/tensor/uint_tensor.h
+++ b/nntrainer/tensor/uint_tensor.h
@@ -126,6 +126,11 @@ public:
   void *getScale(size_t idx) const override;
 
   /**
+   * @copydoc Tensor::hasScale()
+   */
+  bool hasScale() const override { return true; }
+
+  /**
    * @copydoc Tensor::getZeroPoint()
    */
   unsigned int *getZeroPoint() const override;
@@ -134,6 +139,11 @@ public:
    * @copydoc Tensor::getZeroPoint(size_t idx)
    */
   unsigned int *getZeroPoint(size_t idx) const override;
+
+  /**
+   * @copydoc Tensor::hasZeroPoint()
+   */
+  bool hasZeroPoint() const override { return true; }
 
   /**
    * @brief     i data index

--- a/test/unittest/layers/layers_golden_tests.cpp
+++ b/test/unittest/layers/layers_golden_tests.cpp
@@ -26,8 +26,8 @@
 
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 
-#define EXPECT_IN_RANGE(VAL, MIN, MAX) \
-  EXPECT_GE((VAL), (MIN));             \
+#define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
+  EXPECT_GE((VAL), (MIN));                                                     \
   EXPECT_LE((VAL), (MAX))
 
 using namespace nntrainer;
@@ -145,7 +145,10 @@ static TensorPacks prepareTensors(const InitLayerContext &context,
         sizeCheckedReadTensor(weights.back().getVariableRef(), file,
                               weights.back().getName());
       }
-      weights.back().getGradientRef().setZero();
+
+      if (weights.back().getGradientRef().isAllocated()) {
+        weights.back().getGradientRef().setZero();
+      }
     }
     return weights;
   };

--- a/test/unittest/models/models_test_utils.cpp
+++ b/test/unittest/models/models_test_utils.cpp
@@ -494,8 +494,16 @@ void GraphWatcher::validateFor_V2() {
   auto in_dims = nn->getInputDimension();
   auto out_dims = nn->getOutputDimension();
 
-  std::vector<Tensor> inputs(in_dims.begin(), in_dims.end());
-  std::vector<Tensor> labels(out_dims.begin(), out_dims.end());
+  std::vector<Tensor> inputs;
+  std::vector<Tensor> labels;
+
+  for (const auto &dim : in_dims) {
+    inputs.emplace_back(dim, true, Initializer::ZEROS);
+  }
+
+  for (const auto &dim : out_dims) {
+    labels.emplace_back(dim, true, Initializer::ZEROS);
+  }
 
   auto shared_inputs = toSharedTensors(inputs);
   auto shared_labels = toSharedTensors(labels);

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -655,9 +655,8 @@ TEST(nntrainer_Tensor, QTensor_11_n) {
 TEST(nntrainer_Tensor, QTensor_12_p) {
   // This will create a single q4_kx8 block
   nntrainer::Tensor q4_k_tensor(
-    {1, 1, 8, 256, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::UINT4},
-    false, nntrainer::Initializer::NONE, "q4_k_tensor",
-    nntrainer::QScheme::Q4_Kx8);
+    {1, 1, 8, 256, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::Q4_K}, false,
+    nntrainer::Initializer::NONE, "q4_k_tensor", nntrainer::QScheme::Q4_Kx8);
 
   EXPECT_EQ(q4_k_tensor.getData<uint8_t>(), nullptr);
   EXPECT_EQ(q4_k_tensor.q_scheme(), nntrainer::QScheme::Q4_Kx8);
@@ -4933,7 +4932,7 @@ TEST(nntrainer_Tensor, print_small_size_02) {
            << "         1          1 \n"
            << "         1          1 \n"
            << "\n"
-           << "-------\nScale factors: 0 \n";
+           << "-------\nScale factors: 1 \n";
 
   EXPECT_EQ(ss.str(), expected.str());
 }


### PR DESCRIPTION
This PR include following changes:
1. Simplify tensor memory data allocation and release
2. Fix problem of not initialized scale and zero point tensor data if tensor type has such data
3. Small fixes in unit tests

This refactor would be useful when we start adding possibility for tensor to allocate memory through SVM
