### PR TITLE
[OpenCL] Enable Support for Shared Virtual Memory (SVM)

### DIFF
--- a/nntrainer/opencl/opencl_command_queue_manager.cpp
+++ b/nntrainer/opencl/opencl_command_queue_manager.cpp
@@ -293,6 +293,36 @@ bool CommandQueueManager::EnqueueUnmapMemObject(cl_mem buffer, void *mapped_ptr,
   return true;
 }
 
+bool CommandQueueManager::enqueueSVMMap(void *svm_ptr, size_t size,
+                                        bool read_only, cl_event *event) {
+  // managing read/write flags
+  const cl_map_flags map_flag = read_only ? CL_MAP_READ : CL_MAP_WRITE;
+
+  cl_int error_code = clEnqueueSVMMap(command_queue_, CL_TRUE, map_flag,
+                                      svm_ptr, size, 0, nullptr, nullptr);
+
+  if (error_code != CL_SUCCESS) {
+    ml_loge("Failed to map SVM memory (clEnqueueSVMMap). OpenCL error code: %d",
+            error_code);
+    return false;
+  }
+  return true;
+}
+
+bool CommandQueueManager::enqueueSVMUnmap(void *svm_ptr, cl_event *event) {
+  cl_int error_code =
+    clEnqueueSVMUnmap(command_queue_, svm_ptr, 0, nullptr, event);
+
+  if (error_code != CL_SUCCESS) {
+    ml_loge(
+      "Failed to unmap SVM memory (clEnqueueSVMUnmap). OpenCL error code: "
+      "%d",
+      error_code);
+    return false;
+  }
+  return true;
+}
+
 /**
  * @brief Function to initiate execution of the command queue.
  *

--- a/nntrainer/opencl/opencl_command_queue_manager.h
+++ b/nntrainer/opencl/opencl_command_queue_manager.h
@@ -145,6 +145,34 @@ public:
                              cl_event *event = nullptr);
 
   /**
+   * @brief Enqueue SVM memory map operation.
+   *
+   * @param svm_ptr Pointer to the SVM memory region to be mapped
+   * @param size Size of the SVM memory region to be mapped
+   * @param read_only Flag indicating whether the SVM memory should be mapped
+   * for read-only access (true) or read-write access (false).
+   * @param event Optional event object that can be used to query or wait for
+   * the mapping operation to complete. If not provided, the mapping will be
+   * blocking.
+   * @return true if mapping is successful, false otherwise.
+   */
+  bool enqueueSVMMap(void *svm_ptr, size_t size, bool read_only,
+                     cl_event *event = nullptr);
+
+  /**
+   * @brief Enqueue SVM memory unmap operation.
+   *
+   * This function unmaps a previously mapped SVM memory region.
+   *
+   * @param svm_ptr Pointer to the SVM memory region to be unmapped
+   * @param event  Optional event object that can be used to query or wait for
+   * the mapping operation to complete. If not provided, the mapping will be
+   * blocking.
+   * @return true if unmapping is successful, false otherwise.
+   */
+  bool enqueueSVMUnmap(void *svm_ptr, cl_event *event = nullptr);
+
+  /**
    * @brief Function to initiate execution of the command queue.
    *
    * @param kernel OpenCL kernel

--- a/nntrainer/opencl/opencl_context_manager.cpp
+++ b/nntrainer/opencl/opencl_context_manager.cpp
@@ -93,6 +93,20 @@ void ContextManager::ReleaseContext() {
  */
 const cl_device_id ContextManager::GetDeviceId() { return device_id_; }
 
+void *ContextManager::createSVMRegion(size_t size) {
+  return clSVMAlloc(context_, CL_MEM_READ_WRITE, size, 0);
+}
+
+void ContextManager::releaseSVMRegion(void *svm_ptr) {
+  if (svm_ptr) {
+    // deallocates the SVM memory
+    clSVMFree(context_, svm_ptr);
+  } else {
+    ml_logw("Attempted to deallocate a null pointer");
+  }
+  svm_ptr = nullptr;
+}
+
 /**
  * @brief Destroy the Context Manager object
  *

--- a/nntrainer/opencl/opencl_context_manager.h
+++ b/nntrainer/opencl/opencl_context_manager.h
@@ -79,6 +79,21 @@ public:
   const cl_device_id GetDeviceId();
 
   /**
+   * @brief allocate SVM memory
+   *
+   * @param size size of the memory to be allocated
+   * @return void* pointer to the allocated SVM memory
+   */
+  void *createSVMRegion(size_t size);
+
+  /**
+   * @brief deallocate SVM memory
+   *
+   * @param svm_ptr pointer to the SVM memory to be deallocated
+   */
+  void releaseSVMRegion(void *svm_ptr);
+
+  /**
    * @brief Deleting operator overload
    *
    */

--- a/nntrainer/opencl/opencl_kernel.cpp
+++ b/nntrainer/opencl/opencl_kernel.cpp
@@ -68,6 +68,26 @@ bool Kernel::SetKernelArguments(cl_uint arg_index, const void *arg_value,
 }
 
 /**
+ * @brief Set the Kernel Arguments
+ *
+ * @param arg_index index of the argument
+ * @param arg_value value of the argument
+ * @param size size of the argument
+ * @return true if successful or false otherwise
+ */
+bool Kernel::SetKernelSVMArguments(cl_uint arg_index, const void *arg_value) {
+  int error_code;
+  // returns NULL with error code if fails
+  error_code = clSetKernelArgSVMPointer(kernel_, arg_index, arg_value);
+  if (error_code != CL_SUCCESS) {
+    ml_loge("Failed to set argument. OpenCL error code: %d", error_code);
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * @brief Get the Kernel object
  *
  * @return const cl_kernel

--- a/nntrainer/opencl/opencl_kernel.h
+++ b/nntrainer/opencl/opencl_kernel.h
@@ -52,6 +52,15 @@ public:
                           size_t size);
 
   /**
+   * @brief Set the Kernel Arguments
+   *
+   * @param arg_index index of the argument
+   * @param arg_value value of the argument
+   * @return true if successful or false otherwise
+   */
+  bool SetKernelSVMArguments(cl_uint arg_index, const void *arg_value);
+
+  /**
    * @brief Get the Kernel object
    *
    * @return const cl_kernel

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -168,8 +168,8 @@ void MemoryPool::allocate() {
 #else
 
 #ifdef ENABLE_OPENCL
-  mem_pool = opencl::clSVMAlloc(cl_context_->context_inst_.GetContext(),
-                                CL_MEM_READ_WRITE, pool_size, 0);
+  mem_pool = cl_context_->context_inst_.createSVMRegion(pool_size);
+
   if (mem_pool == nullptr) {
     throw std::runtime_error("Failed to allocate SVM memory pool of size " +
                              std::to_string(pool_size) + " bytes");
@@ -268,7 +268,7 @@ std::shared_ptr<MemoryData> MemoryPool::getMemory(unsigned int idx) {
 void MemoryPool::deallocate() {
   if (mem_pool != nullptr) {
 #ifdef ENABLE_OPENCL
-    opencl::clSVMFree(cl_context_->context_inst_.GetContext(), mem_pool);
+    cl_context_->context_inst_.releaseSVMRegion(mem_pool);
 #else
     free(mem_pool);
 #endif

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -30,7 +30,6 @@
 
 #ifdef ENABLE_OPENCL
 #include <cl_context.h>
-#include <opencl_loader.h>
 #endif
 
 #include <cstdlib>

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -23,9 +23,15 @@
 #include <memory>
 #include <vector>
 
+#include <engine.h>
 #include <memory_data.h>
 #include <memory_planner.h>
 #include <tensor_wrap_specs.h>
+
+#ifdef ENABLE_OPENCL
+#include <cl_context.h>
+#include <opencl_loader.h>
+#endif
 
 #include <cstdlib>
 #include <dynamic_library_loader.h>
@@ -64,6 +70,12 @@ enum {
 };
 
 namespace nntrainer {
+
+#ifdef ENABLE_OPENCL
+static ClContext *cl_context_ =
+  static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+#endif
+
 /**
  * @class   MemoryPool
  * @brief   Memory Pool provides a common pool for all the tensor memory


### PR DESCRIPTION
## Commits to be reviewed in this PR

<details><summary> Update OpenCL Kernel Wrappers</summary><br />

This commit updates the OpenCL kernel wrappers to utilize clSetKernelArgSVMPointer.
This enables the use of Shared Virtual Memory (SVM) to manage memory more efficiently.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

</details>

<details><summary>Update Memory Pool to Allocate SVM Buffer</summary><br />

This commit updates the memory pool to allocate a shared virtual memory buffer when it is available.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
