### PR TITLE
[OpenCL] Enable SVM for SGEMV Kernel

### DIFF
--- a/nntrainer/tensor/cl_operations/blas_kernel_interface.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_interface.cpp
@@ -116,8 +116,8 @@ void dotCl(Tensor const &input, Tensor const &m, Tensor &result, bool trans,
     (input.getFormat() == Tformat::NHWC) ? result.channel() : result.width();
 
   if (input.getDataType() == ml::train::TensorDim::DataType::FP32) {
-    const float *data = input.getData();
-    const float *mdata = m.getData();
+    float *data = input.getData();
+    float *mdata = m.getData();
     float *rdata = result.getData();
 
     /// shortcut handling in case of vector

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -46,9 +46,8 @@ void sgemv_q6_k_cl(void *matAdata, float *vecXdata, float *vecYdata,
  * @param[in] lda number of X's columns
  * @param[in] context RunLayerContext reference
  */
-void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
-              bool TransA, unsigned int dim1, unsigned int dim2,
-              unsigned int lda);
+void sgemv_cl(float *matAdata, float *vecXdata, float *vecYdata, bool TransA,
+              unsigned int dim1, unsigned int dim2, unsigned int lda);
 
 /**
  * @brief     dot computation : sum of all X * Y


### PR DESCRIPTION
This patch updates FloatTensor to allocate SVM (Shared Virtual Memory) for unmanaged memory.
This change enables the use of SVM in the SGEMV (Single Precision General Matrix-Vector Multiplication) kernel.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

## Benchmark Result

#### 1. Linux-x86 (NVIDIA GeForce RTX 1650)
| |Time|
|------|---|
|Before|47 ms|
|After|19.15 ms|


#### 2. Linux-x86 (Intel(R) UHD Graphics 770)
| |Time|
|------|---|
|Before|89.7 ms|
|After|45.25 ms|

#### 3. Android (Qualcomm Adreno 740)
| |Time|
|------|---|
|Before|145.8 ms|
|After|108.85ms|

## Note

The following matrix sizes are used for the benchmark and profile.
- M: 1
- K: 3072
- N: 21180