### PR TITLE
[ModelTest] Add Inference_only test mode

### DIFF
--- a/test/unittest/models/models_golden_test.cpp
+++ b/test/unittest/models/models_golden_test.cpp
@@ -24,7 +24,8 @@ void nntrainerModelTest::compare(
   auto net = creator ? creator() : createModel();
   GraphWatcher g(std::move(net), opt);
   if (options & (ModelTestOption::USE_V2)) {
-    g.compareFor_V2(getGoldenName_V2());
+    g.compareFor_V2(getGoldenName_V2(),
+                    options & (ModelTestOption::INFERENCE_ONLY));
   } else {
     g.compareFor(getGoldenName(), getLabelDim(), getIteration());
   }
@@ -37,7 +38,7 @@ void nntrainerModelTest::validate(
   auto net = creator ? creator() : createModel();
   GraphWatcher g(std::move(net), opt);
   if (options & (ModelTestOption::USE_V2)) {
-    g.validateFor_V2();
+    g.validateFor_V2(options & (ModelTestOption::INFERENCE_ONLY));
   } else {
     g.validateFor(getLabelDim());
   }

--- a/test/unittest/models/models_golden_test.h
+++ b/test/unittest/models/models_golden_test.h
@@ -38,6 +38,7 @@ typedef enum {
   SAVE_AND_LOAD_INI = 1 << 2, /**< Set this to check if saving and constructing
                                  a new model works okay (without weights) */
   USE_V2 = 1 << 3,            /**< use v2 model format */
+  INFERENCE_ONLY = 1 << 4,    /**< inference test only */
   COMPARE = COMPARE_RUN | NO_THROW_RUN, /**< Set this to comp are the numbers */
 
   COMPARE_RUN_V2 = COMPARE_RUN | USE_V2,         /**< compare run v2 */
@@ -46,7 +47,9 @@ typedef enum {
   SAVE_AND_LOAD_V2 = SAVE_AND_LOAD_INI | USE_V2, /**< save and load with v2 */
 
   ALL = COMPARE | SAVE_AND_LOAD_INI, /**< Set every option */
-  ALL_V2 = ALL | USE_V2              /**< Set every option with v2 */
+  ALL_V2 = ALL | USE_V2,             /**< Set every option with v2 */
+  ALL_V2_WITH_INFERENCE =
+    ALL | USE_V2 | INFERENCE_ONLY /**< Set every inference option with v2 */
 } ModelTestOption;
 
 using ModelGoldenTestParamType =

--- a/test/unittest/models/models_test_utils.h
+++ b/test/unittest/models/models_test_utils.h
@@ -188,12 +188,13 @@ public:
    *
    * @param reference reference file name
    */
-  void compareFor_V2(const std::string &reference);
+  void compareFor_V2(const std::string &reference,
+                     bool test_inference_only = false);
 
   /**
    * @brief   Validate the running of the graph without any errors
    */
-  void validateFor_V2();
+  void validateFor_V2(bool test_inference_only = false);
 
 private:
   /**


### PR DESCRIPTION
## Dependency of the PR
None

## Commits to be reviewed in this PR


<details><summary>[ModelTest] Add Inference_only test mode</summary><br />

- This patch adds model test option for inference-only
- One can add model unittest with inference-only test

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


### Summary
- Since we are actively supporting inference mode as well, we may create layers that only support inference mode. However, there is currently no support for unit tests in this case. This PR aims to address this issue.
- This PR introduces an inference-only mode for the nngoldenmodel test.
- I tested this PR with a MoE layer, which exclusively supports inference mode. (This will be submitted as a separate PR soon.)

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
