### PR TITLE
memory leak fix (valgrind error): engine and context

### DIFF
--- a/nntrainer/engine.cpp
+++ b/nntrainer/engine.cpp
@@ -33,6 +33,9 @@ std::mutex engine_mutex;
 
 std::once_flag global_engine_init_flag;
 
+nntrainer::Context
+  *Engine::nntrainerRegisteredContext[Engine::RegisterContextMax];
+
 void Engine::add_default_object(Engine &eg) {
   /// @note all layers should be added to the app_context to guarantee that
   /// createLayer/createOptimizer class is created


### PR DESCRIPTION
Fix the following valgrind error:

==1332058== 10,413 (392 direct, 10,021 indirect) bytes in 1 blocks are definitely lost in loss record 394 of 395
==1332058==    at 0x4846FA3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1332058==    by 0x4CE3C43: nntrainer::Engine::add_default_object(nntrainer::Engine&) (in /source/github/nnstreamer/nntrainer/build/nntrainer/libnntrainer.so)
==1332058==    by 0x4CE3F1E: nntrainer::Engine::registerer(nntrainer::Engine&) (in /source/github/nnstreamer/nntrainer/build/nntrainer/libnntrainer.so)
==1332058==    by 0x5787ED2: __pthread_once_slow (pthread_once.c:116)
==1332058==    by 0x4CE2C6F: nntrainer::Engine::Global() (in /source/github/nnstreamer/nntrainer/build/nntrainer/libnntrainer.so)
==1332058==    by 0x4C19E80: nntrainer::createOptimizerWrapped(ml::train::OptimizerType const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (in /source/github/nnstreamer/nntrainer/build/nntrainer/libnntrainer.so)
==1332058==    by 0x15F973: ml::train::createOptimizer(ml::train::OptimizerType const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1332058==    by 0x155C14: std::_Function_handler<int (), ml_train_optimizer_create::{lambda()#1}>::_M_invoke(std::_Any_data const&) (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1332058==    by 0x1500A5: int nntrainer_exception_boundary<std::function<int ()>&>(std::function<int ()>&) (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1332058==    by 0x1554D1: ml_train_optimizer_create (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1332058==    by 0x12C5B1: nntrainer_capi_nnopt_create_delete_01_p_Test::TestBody() (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1332058==    by 0x19746E: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1332058==

This "context" is sort of singleton object kept alive for the whole user process lifecycle. However, without properly deleting it by using unique_ptr or exit function or destructor, Valgrind will keep complaining it.

To enable automated Valgrind checks with workflow, let's add a workaround. Having context pointer kept in a static variable will let Valgrind ensure that this is intended to be kept alive for the whole time.


## Dependency of the PR

## Commits to be reviewed in this PR


Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
