### PR TITLE
memory leak fix (valgrind error): unit test tizen capi optimizer

### DIFF
--- a/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
+++ b/test/tizen_capi/unittest_tizen_capi_optimizer.cpp
@@ -138,6 +138,8 @@ TEST(nntrainer_capi_nnopt, setProperty_05_n) {
   EXPECT_EQ(status, ML_ERROR_NONE);
   status = ml_train_optimizer_set_property(handle, "unknown=unknown", NULL);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+  status = ml_train_optimizer_destroy(handle);
+  EXPECT_EQ(status, ML_ERROR_NONE);
 }
 
 /**


### PR DESCRIPTION
Fix the following Valgrind error:

==1356345==
==1356345== 285 (80 direct, 205 indirect) bytes in 1 blocks are definitely lost in loss record 395 of 404
==1356345==    at 0x4846FA3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1356345==    by 0x155042: ml_train_optimizer_create (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1356345==    by 0x12C7B7: nntrainer_capi_nnopt_setProperty_05_n_Test::TestBody() (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1356345==    by 0x19704E: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1356345==    by 0x17E375: testing::Test::Run() (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1356345==    by 0x17E534: testing::TestInfo::Run() (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1356345==    by 0x17E71E: testing::TestSuite::Run() (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1356345==    by 0x18C58B: testing::internal::UnitTestImpl::RunAllTests() (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1356345==    by 0x197726: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1356345==    by 0x17E917: testing::UnitTest::Run() (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1356345==    by 0x128E93: main (in /source/github/nnstreamer/nntrainer/build/test/tizen_capi/unittest_tizen_capi_optimizer)
==1356345==


Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
