### PR TITLE
memory leak fix (valgrind error): int4_tensor leak

### DIFF
--- a/nntrainer/tensor/int4_tensor.cpp
+++ b/nntrainer/tensor/int4_tensor.cpp
@@ -73,6 +73,7 @@ Int4QTensor::Int4QTensor(
                                        sizeof(float) * scale_size()]()));
   data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
     delete[] mem_data->getAddr<int8_t>();
+    delete mem_data;
   });
 
   offset = 0;


### PR DESCRIPTION
This fixes the following Valgrind error (didn't delete an object)

CC: @djeong20 (this leak comes from 5120f50af653ebe94e0adcfda18d53fb2351a8b8 )

```
==1519278==
==1519278== HEAP SUMMARY:
==1519278==     in use at exit: 440 bytes in 5 blocks
==1519278==   total heap usage: 123,581 allocs, 123,576 frees, 82,037,108 bytes allocated
==1519278==
==1519278== 88 bytes in 1 blocks are definitely lost in loss record 1 of 5
==1519278==    at 0x4846FA3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1519278==    by 0x4C6D824: nntrainer::Int4QTensor::Int4QTensor(std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::Format, nntrainer::QScheme) (int4_tensor.cpp:73)
==1519278==    by 0x4C3B670: make_unique<nntrainer::Int4QTensor, const std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > >&, const std::vector<float, std::allocator<float> >&, ml::train::TensorDim::Format&, nntrainer::QScheme&> (unique_ptr.h:1070)
==1519278==    by 0x4C3B670: nntrainer::Tensor::Tensor(std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::TensorType, nntrainer::QScheme) (tensor.cpp:56)
==1519278==    by 0x1F9953: nntrainer::Tensor::Tensor(std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::TensorType, nntrainer::QScheme) (tensor.h:380)
==1519278==    by 0x18BA02: nntrainer_Tensor_QTensor_03_p_Test::TestBody() (unittest_nntrainer_tensor.cpp:394)
==1519278==    by 0x26B62E: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252775: testing::Test::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252934: testing::TestInfo::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252B1E: testing::TestSuite::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x26098B: testing::internal::UnitTestImpl::RunAllTests() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x26BD06: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252D17: testing::UnitTest::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==
==1519278== 88 bytes in 1 blocks are definitely lost in loss record 2 of 5
==1519278==    at 0x4846FA3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1519278==    by 0x4C6D824: nntrainer::Int4QTensor::Int4QTensor(std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::Format, nntrainer::QScheme) (int4_tensor.cpp:73)
==1519278==    by 0x4C3B670: make_unique<nntrainer::Int4QTensor, const std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > >&, const std::vector<float, std::allocator<float> >&, ml::train::TensorDim::Format&, nntrainer::QScheme&> (unique_ptr.h:1070)
==1519278==    by 0x4C3B670: nntrainer::Tensor::Tensor(std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::TensorType, nntrainer::QScheme) (tensor.cpp:56)
==1519278==    by 0x1F9953: nntrainer::Tensor::Tensor(std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::TensorType, nntrainer::QScheme) (tensor.h:380)
==1519278==    by 0x1920E3: Tensor (tensor.h:394)
==1519278==    by 0x1920E3: nntrainer_Tensor_copy_13_p_Test::TestBody() (unittest_nntrainer_tensor.cpp:1265)
==1519278==    by 0x26B62E: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252775: testing::Test::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252934: testing::TestInfo::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252B1E: testing::TestSuite::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x26098B: testing::internal::UnitTestImpl::RunAllTests() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x26BD06: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252D17: testing::UnitTest::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==
==1519278== 88 bytes in 1 blocks are definitely lost in loss record 3 of 5
==1519278==    at 0x4846FA3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1519278==    by 0x4C6D824: nntrainer::Int4QTensor::Int4QTensor(std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::Format, nntrainer::QScheme) (int4_tensor.cpp:73)
==1519278==    by 0x4C3B670: make_unique<nntrainer::Int4QTensor, const std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > >&, const std::vector<float, std::allocator<float> >&, ml::train::TensorDim::Format&, nntrainer::QScheme&> (unique_ptr.h:1070)
==1519278==    by 0x4C3B670: nntrainer::Tensor::Tensor(std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::TensorType, nntrainer::QScheme) (tensor.cpp:56)
==1519278==    by 0x1E4B98: nntrainer_Tensor_argmax_03_p_Test::TestBody() (unittest_nntrainer_tensor.cpp:4591)
==1519278==    by 0x26B62E: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252775: testing::Test::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252934: testing::TestInfo::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252B1E: testing::TestSuite::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x26098B: testing::internal::UnitTestImpl::RunAllTests() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x26BD06: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252D17: testing::UnitTest::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x166DC3: RUN_ALL_TESTS (gtest.h:2317)
==1519278==    by 0x166DC3: main (unittest_nntrainer_tensor.cpp:6549)
==1519278==
==1519278== 88 bytes in 1 blocks are definitely lost in loss record 4 of 5
==1519278==    at 0x4846FA3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1519278==    by 0x4C6D824: nntrainer::Int4QTensor::Int4QTensor(std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::Format, nntrainer::QScheme) (int4_tensor.cpp:73)
==1519278==    by 0x4C3B670: make_unique<nntrainer::Int4QTensor, const std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > >&, const std::vector<float, std::allocator<float> >&, ml::train::TensorDim::Format&, nntrainer::QScheme&> (unique_ptr.h:1070)
==1519278==    by 0x4C3B670: nntrainer::Tensor::Tensor(std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::TensorType, nntrainer::QScheme) (tensor.cpp:56)
==1519278==    by 0x1F9953: nntrainer::Tensor::Tensor(std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::TensorType, nntrainer::QScheme) (tensor.h:380)
==1519278==    by 0x1E12BD: nntrainer_Tensor_max_element_03_p_Test::TestBody() (unittest_nntrainer_tensor.cpp:4641)
==1519278==    by 0x26B62E: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252775: testing::Test::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252934: testing::TestInfo::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252B1E: testing::TestSuite::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x26098B: testing::internal::UnitTestImpl::RunAllTests() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x26BD06: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252D17: testing::UnitTest::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==
==1519278== 88 bytes in 1 blocks are definitely lost in loss record 5 of 5
==1519278==    at 0x4846FA3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1519278==    by 0x4C6D824: nntrainer::Int4QTensor::Int4QTensor(std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::Format, nntrainer::QScheme) (int4_tensor.cpp:73)
==1519278==    by 0x4C3B670: make_unique<nntrainer::Int4QTensor, const std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > >&, const std::vector<float, std::allocator<float> >&, ml::train::TensorDim::Format&, nntrainer::QScheme&> (unique_ptr.h:1070)
==1519278==    by 0x4C3B670: nntrainer::Tensor::Tensor(std::vector<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > >, std::allocator<std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::TensorType, nntrainer::QScheme) (tensor.cpp:56)
==1519278==    by 0x1F9953: nntrainer::Tensor::Tensor(std::vector<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > >, std::allocator<std::vector<std::vector<signed char, std::allocator<signed char> >, std::allocator<std::vector<signed char, std::allocator<signed char> > > > > > const&, std::vector<float, std::allocator<float> > const&, ml::train::TensorDim::TensorType, nntrainer::QScheme) (tensor.h:380)
==1519278==    by 0x1E1C8C: Tensor (tensor.h:394)
==1519278==    by 0x1E1C8C: nntrainer_Tensor_min_element_03_p_Test::TestBody() (unittest_nntrainer_tensor.cpp:4696)
==1519278==    by 0x26B62E: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252775: testing::Test::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252934: testing::TestInfo::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252B1E: testing::TestSuite::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x26098B: testing::internal::UnitTestImpl::RunAllTests() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x26BD06: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==    by 0x252D17: testing::UnitTest::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/unittest_nntrainer_tensor)
==1519278==
```