### PR TITLE
memory leak fix (valgrind error): layer unittest

### DIFF
--- a/test/unittest/layers/unittest_layer_node.cpp
+++ b/test/unittest/layers/unittest_layer_node.cpp
@@ -301,6 +301,9 @@ TEST(nntrainer_LayerNode, setWeights_01_n) {
   EXPECT_NO_THROW(lnode =
                     nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
   EXPECT_THROW(lnode->setWeights(weights), std::runtime_error);
+
+  for (auto &i : weights)
+    delete i;
 }
 
 /**


### PR DESCRIPTION
Although this is merely a unit test code,
we need to clean up all Valgrind errors before we turn the Valgrind-test github workflow on.

After that, we can reject all commits causing
any Valgrind errors.

This fixes:
```
==1541951==
==1541951== 4 bytes in 1 blocks are definitely lost in loss record 1 of 167
==1541951==    at 0x4846FA3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1541951==    by 0x1AE611: nntrainer_LayerNode_setWeights_01_n_Test::TestBody() (unittest_layer_node.cpp:299)
==1541951==    by 0x243ADE: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/unittest/layers/unittest_layers)
==1541951==    by 0x22ADB5: testing::Test::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/layers/unittest_layers)
==1541951==    by 0x22AF74: testing::TestInfo::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/layers/unittest_layers)
==1541951==    by 0x22B15E: testing::TestSuite::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/layers/unittest_layers)
==1541951==    by 0x238FCB: testing::internal::UnitTestImpl::RunAllTests() (in /source/github/nnstreamer/nntrainer/build/test/unittest/layers/unittest_layers)
==1541951==    by 0x2441B6: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (in /source/github/nnstreamer/nntrainer/build/test/unittest/layers/unittest_layers)
==1541951==    by 0x22B357: testing::UnitTest::Run() (in /source/github/nnstreamer/nntrainer/build/test/unittest/layers/unittest_layers)
==1541951==    by 0x177D03: main (in /source/github/nnstreamer/nntrainer/build/test/unittest/layers/unittest_layers)
==1541951==
```