### PR TITLE
memory leak fix (valgrind error): Application/KNN

### DIFF
--- a/Applications/KNN/jni/main.cpp
+++ b/Applications/KNN/jni/main.cpp
@@ -199,6 +199,8 @@ int main(int argc, char *argv[]) {
       output = interpreter->typed_output_tensor<float>(0);
 
       std::copy(output, output + 128, out[i][j]);
+
+      delete[] in;
     }
   }
 
@@ -264,6 +266,8 @@ int main(int argc, char *argv[]) {
      */
     ret = KNN(out, testout[i]);
     printf("class %d\n", ret);
+
+    delete[] in;
   }
 
   return 0;


### PR DESCRIPTION
Before turning on github-action valgrind testing,
I'm clearing all known Valgrind errors in meson test.

This fixes:
```
==1574890==
==1574890== 540,000 bytes in 2 blocks are possibly lost in loss record 12 of 14
==1574890==    at 0x48485C3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1574890==    by 0x111F73: tflite::label_image::read_bmp(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int*, int*, int*) (bitmap_helpers.cpp:109)
==1574890==    by 0x10DA64: main (main.cpp:181)
==1574890==
==1574890== 2,160,000 bytes in 8 blocks are definitely lost in loss record 13 of 14
==1574890==    at 0x48485C3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1574890==    by 0x111F73: tflite::label_image::read_bmp(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int*, int*, int*) (bitmap_helpers.cpp:109)
==1574890==    by 0x10E5A5: main (main.cpp:239)
==1574890==
==1574890== 3,510,000 bytes in 13 blocks are definitely lost in loss record 14 of 14
==1574890==    at 0x48485C3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1574890==    by 0x111F73: tflite::label_image::read_bmp(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int*, int*, int*) (bitmap_helpers.cpp:109)
==1574890==    by 0x10DA64: main (main.cpp:181)

```
