### PR TITLE
[Fix] Fix nan values problem while beta calculation.

### DIFF
--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -26,7 +26,10 @@
     float y0;                                                                  \
     unsigned int i, j;                                                         \
     for (ci = 0; ci != cM; ci++) {                                             \
-      y0 = Y[ci * incY] * beta;                                                \
+      y0 = 0.0f;                                                               \
+      if (beta != 0.0f) {                                                      \
+        y0 = Y[ci * incY] * beta;                                              \
+      }                                                                        \
       for (cj = 0; cj != cN; cj++)                                             \
         y0 += A[i + j * lda] * X[cj * incX];                                   \
       Y[ci * incY] = y0;                                                       \
@@ -198,8 +201,9 @@ void __fallback_sgemm(const unsigned int TStorageOrder, bool TransA,
         c += a * b;
       }
       C[m * ldc + n] = alpha * c;
-      if (beta != 0.0)
+      if (beta != 0.0f) {
         C[m * ldc + n] += beta * c_old;
+      }
     }
   }
 }
@@ -258,7 +262,7 @@ void __fallback_ele_mul(const unsigned int N, const float *X, const float *Y,
                         float *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X * alpha * *Y + beta * *Z;
+    *Z = *X * alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
     X += o_stride;
     Y += i_stride;
     Z += o_stride;
@@ -269,7 +273,7 @@ void __fallback_ele_add(const unsigned int N, const float *X, const float *Y,
                         float *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X + alpha * *Y + beta * *Z;
+    *Z = *X + alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
     X += o_stride;
     Y += i_stride;
     Z += o_stride;
@@ -280,7 +284,7 @@ void __fallback_ele_sub(const unsigned N, const float *X, const float *Y,
                         float *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X - alpha * *Y + beta * *Z;
+    *Z = *X - alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
     X += o_stride;
     Y += i_stride;
     Z += o_stride;
@@ -291,7 +295,7 @@ void __fallback_ele_div(const unsigned N, const float *X, const float *Y,
                         float *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X / (alpha * *Y) + beta * *Z;
+    *Z = *X / (alpha * *Y) + ((0.0f == beta) ? 0.0f : beta * *Z);
     X += o_stride;
     Y += i_stride;
     Z += o_stride;

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal_fp16.cpp
@@ -26,7 +26,10 @@
     float y0;                                                                  \
     unsigned int i, j;                                                         \
     for (ci = 0; ci != cM; ci++) {                                             \
-      y0 = static_cast<float>(Y[ci * incY] * static_cast<_FP16>(beta));        \
+      y0 = 0.0f;                                                               \
+      if (beta != 0.0f) {                                                      \
+        y0 = static_cast<float>(Y[ci * incY] * static_cast<_FP16>(beta));      \
+      }                                                                        \
       for (cj = 0; cj != cN; cj++)                                             \
         y0 += static_cast<float>(A[i + j * lda] * X[cj * incX]);               \
       Y[ci * incY] = static_cast<_FP16>(y0);                                   \
@@ -46,8 +49,9 @@
           c += static_cast<float>(a * b);                                      \
         }                                                                      \
         C[m * ldc + n] = static_cast<_FP16>(alpha * c);                        \
-        if (beta != 0.0)                                                       \
+        if (beta != 0.0f) {                                                    \
           C[m * ldc + n] += static_cast<_FP16>(beta) * c_old;                  \
+        }                                                                      \
       }                                                                        \
     }                                                                          \
   } while (0);
@@ -216,7 +220,9 @@ void __fallback_ele_mul(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                         _FP16 *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X * static_cast<_FP16>(alpha) * *Y + static_cast<_FP16>(beta) * *Z;
+    *Z = *X * static_cast<_FP16>(alpha) * *Y +
+         ((0.0f == beta) ? static_cast<_FP16>(0.0f)
+                         : static_cast<_FP16>(beta) * *Z);
     X += o_stride;
     Y += i_stride;
     Z += o_stride;
@@ -227,7 +233,9 @@ void __fallback_ele_add(const unsigned int N, const _FP16 *X, const _FP16 *Y,
                         _FP16 *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X + static_cast<_FP16>(alpha) * *Y + static_cast<_FP16>(beta) * *Z;
+    *Z = *X + static_cast<_FP16>(alpha) * *Y +
+         ((0.0f == beta) ? static_cast<_FP16>(0.0f)
+                         : static_cast<_FP16>(beta) * *Z);
     X += o_stride;
     Y += i_stride;
     Z += o_stride;
@@ -238,7 +246,9 @@ void __fallback_ele_sub(const unsigned N, const _FP16 *X, const _FP16 *Y,
                         _FP16 *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X - static_cast<_FP16>(alpha) * *Y + static_cast<_FP16>(beta) * *Z;
+    *Z = *X - static_cast<_FP16>(alpha) * *Y +
+         ((0.0f == beta) ? static_cast<_FP16>(0.0f)
+                         : static_cast<_FP16>(beta) * *Z);
     X += o_stride;
     Y += i_stride;
     Z += o_stride;
@@ -249,7 +259,9 @@ void __fallback_ele_div(const unsigned N, const _FP16 *X, const _FP16 *Y,
                         _FP16 *Z, float alpha, float beta,
                         unsigned int i_stride, unsigned int o_stride) {
   for (unsigned int i = 0; i < N; ++i) {
-    *Z = *X / (static_cast<_FP16>(alpha) * *Y) + static_cast<_FP16>(beta) * *Z;
+    *Z = *X / (static_cast<_FP16>(alpha) * *Y) +
+         ((0.0f == beta) ? static_cast<_FP16>(0.0f)
+                         : static_cast<_FP16>(beta) * *Z);
     X += o_stride;
     Y += i_stride;
     Z += o_stride;

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -526,7 +526,7 @@ void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
   } else {
     // TODO: AVX2 implementation if used
     for (unsigned int i = 0; i < N; ++i) {
-      *Z = *X * alpha * *Y + beta * *Z;
+      *Z = *X * alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
       X += o_stride;
       Y += i_stride;
       Z += o_stride;
@@ -570,7 +570,7 @@ void ele_add(const unsigned int N, const float *X, const float *Y, float *Z,
   } else {
     // TODO: AVX2 implementation if used
     for (unsigned int i = 0; i < N; ++i) {
-      *Z = *X + alpha * *Y + beta * *Z;
+      *Z = *X + alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
       X += o_stride;
       Y += i_stride;
       Z += o_stride;

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -737,7 +737,8 @@ Tensor &FloatTensor::dotFloat(Tensor const &input, Tensor &output, bool trans,
   /// (1 * K) X (1 * M) can be a case
   /// case1: (1 * K) X (K * 1)
   if (M == 1 && N == 1) {
-    *rdata = sdot(K, data, 1, mdata, 1) + beta * (*rdata);
+    *rdata =
+      sdot(K, data, 1, mdata, 1) + ((0.0f == beta) ? 0.0f : beta * *rdata);
   }
   /// case2: (M * K) X (K * 1)
   else if (N == 1) {

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -673,7 +673,9 @@ Tensor &HalfTensor::dot(Tensor const &input, Tensor &output, bool trans,
   /// (1 * K) X (1 * M) can be a case
   /// case1: (1 * K) X (K * 1)
   if (M == 1 && N == 1) {
-    *rdata = sdot(K, data, 1, mdata, 1) + static_cast<_FP16>(beta) * (*rdata);
+    *rdata = sdot(K, data, 1, mdata, 1) +
+             ((0.0f == beta) ? static_cast<_FP16>(0.0f)
+                             : static_cast<_FP16>(beta) * *rdata);
   }
   /// case2: (M * K) X (K * 1)
   else if (N == 1) {

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -497,7 +497,7 @@ int Tensor::multiply_i(Tensor const &m, const float beta) {
 }
 
 Tensor Tensor::multiply(Tensor const &m, const float beta) const {
-  Tensor t("", this->getFormat());
+  Tensor t("", getFormat(), getDataType());
   return multiply(m, t, beta);
 }
 
@@ -664,7 +664,7 @@ Tensor &Tensor::subtract(float const &value, Tensor &output) const {
 int Tensor::subtract_i(Tensor const &m) { return add_i(m, -1); }
 
 Tensor Tensor::subtract(Tensor const &m) const {
-  Tensor t;
+  Tensor t("", getFormat(), getDataType());
   return this->subtract(m, t);
 }
 
@@ -941,7 +941,7 @@ void Tensor::standardization_i() {
 }
 
 Tensor Tensor::dot(Tensor const &input, bool trans, bool trans_in) const {
-  Tensor output("", this->getFormat(), this->getDataType());
+  Tensor output("", getFormat(), getDataType());
   dot(input, output, trans, trans_in);
 
   return output;

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -138,6 +138,7 @@ public:
     name = rhs.name;
     data = rhs.data;
     offset = rhs.offset;
+    file_offset = rhs.file_offset;
     src_tensor = rhs.src_tensor;
   }
 

--- a/test/unittest/models/models_test_utils.cpp
+++ b/test/unittest/models/models_test_utils.cpp
@@ -494,8 +494,16 @@ void GraphWatcher::validateFor_V2() {
   auto in_dims = nn->getInputDimension();
   auto out_dims = nn->getOutputDimension();
 
-  std::vector<Tensor> inputs(in_dims.begin(), in_dims.end());
-  std::vector<Tensor> labels(out_dims.begin(), out_dims.end());
+  std::vector<Tensor> inputs;
+  std::vector<Tensor> labels;
+
+  for (const auto &dim : in_dims) {
+    inputs.emplace_back(dim, true, Initializer::ZEROS);
+  }
+
+  for (const auto &dim : out_dims) {
+    labels.emplace_back(dim, true, Initializer::ZEROS);
+  }
 
   auto shared_inputs = toSharedTensors(inputs);
   auto shared_labels = toSharedTensors(labels);


### PR DESCRIPTION
This PR address following issues:

1. Workaround for problem with nan when calculating beta * nan

In many functions we're calculating:

Z[i] = X[i] - alpha * Y[i] + beta * Z[i];

if beta is zero we're expecting to have 0 as results of beta * Z[i] but it's not always true because when Z is not initialized it can be nan. This PR add workaround for this and fix problem when beta is 0


2. Fix problem of not initialized tensors in tests (model_test_utils.cpp) - we were running tests with uninitialized memory in tensors and expect zeros (which was not always true). This PR initialize tensors memory

