### PR TITLE
Replace repeating FP16/FP32 code with template

### DIFF
--- a/nntrainer/opencl/opencl_kernel.cpp
+++ b/nntrainer/opencl/opencl_kernel.cpp
@@ -60,7 +60,8 @@ bool Kernel::SetKernelArguments(cl_uint arg_index, const void *arg_value,
   // returns NULL with error code if fails
   error_code = clSetKernelArg(kernel_, arg_index, size, arg_value);
   if (error_code != CL_SUCCESS) {
-    ml_loge("Failed to set argument. OpenCL error code: %d", error_code);
+    ml_loge("Failed to set argument: %u = %p. OpenCL error code: %d", arg_index,
+            arg_value, error_code);
     return false;
   }
 

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -11,10 +11,7 @@
  *
  */
 
-#include <blas_kernel_strings.h>
-#include <blas_kernels.h>
-
-#include "clblast.h"
+#include "blas_kernels_templates.h"
 
 namespace nntrainer {
 
@@ -207,175 +204,43 @@ void sgemv_q6_k_cl(void *matAdata, float *vecXdata, float *vecYdata,
 void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
               bool TransA, unsigned int dim1, unsigned int dim2,
               unsigned int lda) {
-
-  bool result = false;
-
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
 
-  do {
-    ClContext::SharedPtrClKernel kernel_sgemv_ptr;
+  ClContext::SharedPtrClKernel kernel_sgemv_ptr;
 
-    if (TransA) {
-      kernel_sgemv_ptr =
-        blas_cc->registerClKernel(getSgemvClKernel(), "sgemv_cl");
-    } else {
-      kernel_sgemv_ptr = blas_cc->registerClKernel(getSgemvClNoTransKernel(),
-                                                   "sgemv_cl_noTrans");
-    }
+  if (TransA) {
+    kernel_sgemv_ptr =
+      blas_cc->registerClKernel(getSgemvClKernel(), "sgemv_cl");
+  } else {
+    kernel_sgemv_ptr =
+      blas_cc->registerClKernel(getSgemvClNoTransKernel(), "sgemv_cl_noTrans");
+  }
 
-    if (!kernel_sgemv_ptr) {
-      break;
-    }
+  if (!kernel_sgemv_ptr) {
+    return;
+  }
 
-    size_t dim1_size = sizeof(float) * dim1;
-    size_t dim2_size = sizeof(float) * dim2;
-
-    result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim1 * dim2 * sizeof(float), matAdata);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim2_size, vecXdata);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim1_size, vecYdata);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemv_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemv_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemv_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemv_ptr->SetKernelArguments(3, &dim2, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemv_ptr->SetKernelArguments(4, &lda, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    const int work_groups_count[3] = {(int)dim1, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1};
-
-    result = opencl::CommandQueueManager::Global().DispatchCommand(
-      kernel_sgemv_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      blas_cc->command_queue_inst_, dim1_size, vecYdata);
-    if (!result) {
-      break;
-    }
-
-  } while (false);
+  sgemv_cl_internal<float>(kernel_sgemv_ptr, matAdata, vecXdata, vecYdata, dim1,
+                           dim2, lda);
 }
 
 float dot_cl(const float *vecAdata, const float *vecXdata, unsigned int dim1) {
-
-  bool result = false;
-
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
 
-  float cl_ret = 0;
+  ClContext::SharedPtrClKernel kernel_dot_ptr =
+    blas_cc->registerClKernel(getDotClKernel(), "dot_cl");
+  if (!kernel_dot_ptr) {
+    return {};
+  }
 
-  do {
-    ClContext::SharedPtrClKernel kernel_dot_ptr =
-      blas_cc->registerClKernel(getDotClKernel(), "dot_cl");
-    if (!kernel_dot_ptr) {
-      break;
-    }
-
-    size_t dim1_size = sizeof(float) * dim1;
-
-    result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim1_size, vecAdata);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim1_size, vecXdata);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_dot_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_dot_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_dot_ptr->SetKernelArguments(2, &dim1, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_dot_ptr->SetKernelArguments(
-      3, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    const int work_groups_count[3] = {(int)dim1, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
-
-    result = blas_cc->command_queue_inst_.DispatchCommand(
-      kernel_dot_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      blas_cc->command_queue_inst_, sizeof(float), &cl_ret);
-    if (!result) {
-      break;
-    }
-
-  } while (false);
-
-  return cl_ret;
+  return dot_cl_internal<float>(kernel_dot_ptr, vecAdata, vecXdata, dim1);
 }
 
 void sgemm_cl(bool TransA, bool TransB, const float *A, const float *B,
               float *C, unsigned int M, unsigned int N, unsigned int K,
               unsigned int lda, unsigned int ldb, unsigned int ldc) {
-
   std::string kernel_func_;
   std::string sgemm_cl_kernel_;
 
@@ -393,325 +258,80 @@ void sgemm_cl(bool TransA, bool TransB, const float *A, const float *B,
     sgemm_cl_kernel_ = getSgemmClTransABKernel();
   }
 
-  bool result = false;
-
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
 
-  do {
-    ClContext::SharedPtrClKernel kernel_sgemm_ptr =
-      blas_cc->registerClKernel(sgemm_cl_kernel_, kernel_func_);
-    if (!kernel_sgemm_ptr) {
-      break;
-    }
+  ClContext::SharedPtrClKernel kernel_sgemm_ptr =
+    blas_cc->registerClKernel(sgemm_cl_kernel_, kernel_func_);
+  if (!kernel_sgemm_ptr) {
+    return;
+  }
 
-    // sizes will be same for transpose
-    size_t m_k_size = M * K * sizeof(float);
-    size_t k_n_size = K * N * sizeof(float);
-    size_t m_n_size = M * N * sizeof(float);
-
-    result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, m_k_size, A);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      blas_cc->command_queue_inst_, k_n_size, B);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, m_n_size, C);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemm_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemm_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemm_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemm_ptr->SetKernelArguments(3, &M, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemm_ptr->SetKernelArguments(4, &N, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemm_ptr->SetKernelArguments(5, &K, sizeof(int));
-    if (!result) {
-      break;
-    }
-    const int tiled_size = 16;
-    const int work_groups_count[3] = {
-      (int)((N + tiled_size - 1) / tiled_size) * tiled_size,
-      (int)((M + tiled_size - 1) / tiled_size) * tiled_size, 1}; // test-value
-
-    const int work_group_size[3] = {tiled_size, tiled_size, 1}; // test-value
-
-    result = blas_cc->command_queue_inst_.DispatchCommand(
-      kernel_sgemm_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      blas_cc->command_queue_inst_, m_n_size, C);
-    if (!result) {
-      break;
-    }
-
-  } while (false);
+  sgemm_cl_internal<float>(kernel_sgemm_ptr, TransA, TransB, A, B, C, M, N, K,
+                           lda, ldb, ldc);
 }
 
 void addition_cl(const float *input, float *res, unsigned int size_input,
                  unsigned int size_res) {
-
   bool result = false;
-
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
 
-  do {
-    ClContext::SharedPtrClKernel kernel_addition_ptr =
-      blas_cc->registerClKernel(getAdditionClKernel(), "addition_cl");
-    if (!kernel_addition_ptr) {
-      break;
-    }
+  ClContext::SharedPtrClKernel kernel_addition_ptr =
+    blas_cc->registerClKernel(getAdditionClKernel(), "addition_cl");
+  if (!kernel_addition_ptr) {
+    return;
+  }
 
-    size_t dim1_size = sizeof(float) * size_input;
-    size_t dim2_size = sizeof(float) * size_res;
-
-    result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim1_size, input);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim2_size, res);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_addition_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-    result = kernel_addition_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_addition_ptr->SetKernelArguments(2, &size_input, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_addition_ptr->SetKernelArguments(3, &size_res, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    const int work_groups_count[3] = {(int)size_res, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
-    result = blas_cc->command_queue_inst_.DispatchCommand(
-      kernel_addition_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      blas_cc->command_queue_inst_, dim2_size, res);
-
-    if (!result) {
-      break;
-    }
-
-  } while (false);
+  addition_cl_internal<float>(kernel_addition_ptr, input, res, size_input,
+                              size_res);
 }
 
 void sscal_cl(float *X, const unsigned int N, const float alpha) {
-  bool result = false;
-
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
 
-  do {
-    ClContext::SharedPtrClKernel kernel_ptr =
-      blas_cc->registerClKernel(getSscalClKernel(), "sscal_cl");
+  ClContext::SharedPtrClKernel kernel_ptr =
+    blas_cc->registerClKernel(getSscalClKernel(), "sscal_cl");
 
-    if (!kernel_ptr) {
-      break;
-    }
+  if (!kernel_ptr) {
+    return;
+  }
 
-    size_t x_size = N * sizeof(float);
-
-    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, x_size, X);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_ptr->SetKernelArguments(
-      0, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_ptr->SetKernelArguments(1, &alpha, sizeof(float));
-    if (!result) {
-      break;
-    }
-
-    const int work_groups_count[3] = {(int)N, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
-
-    result = blas_cc->command_queue_inst_.DispatchCommand(
-      kernel_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      blas_cc->command_queue_inst_, x_size, X);
-    if (!result) {
-      break;
-    }
-
-  } while (false);
+  sscal_cl_internal<float>(kernel_ptr, X, N, alpha);
 }
 
 void transpose_cl_axis(const float *in, float *res,
                        unsigned int input_batch_size,
                        unsigned int input_channels, unsigned int input_height,
                        unsigned int input_width, unsigned int axis) {
-
-  bool result = false;
-
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
 
-  do {
-    ClContext::SharedPtrClKernel kernel_transpose_ptr;
-    switch (axis) {
-    case 0:
-      kernel_transpose_ptr = blas_cc->registerClKernel(
-        getTransposeClKernelAxis0(), "transpose_cl_axis0");
-      break;
-    case 1:
-      kernel_transpose_ptr = blas_cc->registerClKernel(
-        getTransposeClKernelAxis1(), "transpose_cl_axis1");
-      break;
-    case 2:
-      kernel_transpose_ptr = blas_cc->registerClKernel(
-        getTransposeClKernelAxis2(), "transpose_cl_axis2");
-      break;
-    default:
-      throw std::invalid_argument("failed to register CL kernel");
-      break;
-    }
-    if (!kernel_transpose_ptr) {
-      break;
-    }
+  ClContext::SharedPtrClKernel kernel_transpose_ptr;
+  switch (axis) {
+  case 0:
+    kernel_transpose_ptr = blas_cc->registerClKernel(
+      getTransposeClKernelAxis0(), "transpose_cl_axis0");
+    break;
+  case 1:
+    kernel_transpose_ptr = blas_cc->registerClKernel(
+      getTransposeClKernelAxis1(), "transpose_cl_axis1");
+    break;
+  case 2:
+    kernel_transpose_ptr = blas_cc->registerClKernel(
+      getTransposeClKernelAxis2(), "transpose_cl_axis2");
+    break;
+  default:
+    throw std::invalid_argument("failed to register CL kernel");
+    break;
+  }
+  if (!kernel_transpose_ptr) {
+    return;
+  }
 
-    size_t dim_size = sizeof(float) * input_batch_size * input_height *
-                      input_width * input_channels;
-
-    result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim_size, in);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim_size, res);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_transpose_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_transpose_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_transpose_ptr->SetKernelArguments(2, &input_batch_size,
-                                                      sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_transpose_ptr->SetKernelArguments(3, &input_channels, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_transpose_ptr->SetKernelArguments(4, &input_height, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_transpose_ptr->SetKernelArguments(5, &input_width, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    int work_groups_count[3] = {(int)input_height, (int)input_width, 1};
-    if (axis == 2)
-      work_groups_count[0] = (int)input_channels;
-
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
-
-    result = blas_cc->command_queue_inst_.DispatchCommand(
-      kernel_transpose_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      blas_cc->command_queue_inst_, dim_size, res);
-    if (!result) {
-      break;
-    }
-
-  } while (false);
+  transpose_cl_axis_internal<float>(kernel_transpose_ptr, in, res,
+                                    input_batch_size, input_channels,
+                                    input_height, input_width, axis);
 }
 } // namespace nntrainer

--- a/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
@@ -11,187 +11,52 @@
  *
  */
 
-#include <blas_kernel_strings.h>
-#include <blas_kernels.h>
+#include "blas_kernels_templates.h"
 
 namespace nntrainer {
 
 void sgemv_cl(const _FP16 *matAdata, const _FP16 *vecXdata, _FP16 *vecYdata,
               bool TransA, unsigned int dim1, unsigned int dim2,
               unsigned int lda) {
-
-  bool result = false;
-
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
 
-  do {
-    ClContext::SharedPtrClKernel kernel_sgemv_fp16_ptr;
+  ClContext::SharedPtrClKernel kernel_sgemv_fp16_ptr;
+  if (TransA) {
+    kernel_sgemv_fp16_ptr =
+      blas_cc->registerClKernel(getHgemvClKernel(), "sgemv_cl_fp16");
+  } else {
+    kernel_sgemv_fp16_ptr = blas_cc->registerClKernel(getHgemvClNoTransKernel(),
+                                                      "sgemv_cl_noTrans_fp16");
+  }
 
-    if (TransA) {
-      kernel_sgemv_fp16_ptr =
-        blas_cc->registerClKernel(getHgemvClKernel(), "sgemv_cl_fp16");
-    } else {
-      kernel_sgemv_fp16_ptr = blas_cc->registerClKernel(
-        getHgemvClNoTransKernel(), "sgemv_cl_noTrans_fp16");
-    }
+  if (!kernel_sgemv_fp16_ptr) {
+    return;
+  }
 
-    if (!kernel_sgemv_fp16_ptr) {
-      break;
-    }
-
-    size_t dim1_size = sizeof(_FP16) * dim1;
-    size_t dim2_size = sizeof(_FP16) * dim2;
-
-    result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim1 * dim2 * sizeof(_FP16), matAdata);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim2_size, vecXdata);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim1_size, vecYdata);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemv_fp16_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemv_fp16_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemv_fp16_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemv_fp16_ptr->SetKernelArguments(3, &dim2, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemv_fp16_ptr->SetKernelArguments(4, &lda, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    const int work_groups_count[3] = {(int)dim1, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
-
-    result = blas_cc->command_queue_inst_.DispatchCommand(
-      kernel_sgemv_fp16_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      blas_cc->command_queue_inst_, dim1_size, vecYdata);
-    if (!result) {
-      break;
-    }
-
-  } while (false);
+  sgemv_cl_internal<_FP16>(kernel_sgemv_fp16_ptr, matAdata, vecXdata, vecYdata,
+                           dim1, dim2, lda);
 }
 
 _FP16 dot_cl(const _FP16 *vecAdata, const _FP16 *vecXdata, unsigned int dim1) {
-
-  bool result = false;
-
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
 
-  _FP16 cl_ret = 0;
+  ClContext::SharedPtrClKernel kernel_dot_fp16_ptr =
+    blas_cc->registerClKernel(getDotClKernelFP16(), "dot_cl_fp16");
 
-  do {
-    ClContext::SharedPtrClKernel kernel_dot_fp16_ptr =
-      blas_cc->registerClKernel(getDotClKernelFP16(), "dot_cl_fp16");
+  if (!kernel_dot_fp16_ptr) {
+    return {};
+  }
 
-    if (!kernel_dot_fp16_ptr) {
-      break;
-    }
-
-    size_t dim1_size = sizeof(_FP16) * dim1;
-
-    result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim1_size, vecAdata);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim1_size, vecXdata);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_dot_fp16_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_dot_fp16_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_dot_fp16_ptr->SetKernelArguments(2, &dim1, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_dot_fp16_ptr->SetKernelArguments(
-      3, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    const int work_groups_count[3] = {(int)dim1, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1};
-
-    result = blas_cc->command_queue_inst_.DispatchCommand(
-      kernel_dot_fp16_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      blas_cc->command_queue_inst_, sizeof(_FP16), &cl_ret);
-    if (!result) {
-      break;
-    }
-
-  } while (false);
-
-  return cl_ret;
+  return dot_cl_internal<_FP16>(kernel_dot_fp16_ptr, vecAdata, vecXdata, dim1);
 }
 
 void sgemm_cl(bool TransA, bool TransB, const _FP16 *A, const _FP16 *B,
               _FP16 *C, unsigned int M, unsigned int N, unsigned int K,
               unsigned int lda, unsigned int ldb, unsigned int ldc) {
-
   std::string kernel_func_;
   std::string sgemm_cl_kernel_fp16_;
-
   if (!TransA && !TransB) {
     kernel_func_ = "sgemm_cl_noTrans_fp16";
     sgemm_cl_kernel_fp16_ = getHgemmClNoTransKernel();
@@ -206,329 +71,81 @@ void sgemm_cl(bool TransA, bool TransB, const _FP16 *A, const _FP16 *B,
     sgemm_cl_kernel_fp16_ = getHgemmClTransABKernel();
   }
 
-  bool result = false;
-
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
 
-  do {
-    ClContext::SharedPtrClKernel kernel_sgemm_fp16_ptr =
-      blas_cc->registerClKernel(sgemm_cl_kernel_fp16_, kernel_func_);
-    if (!kernel_sgemm_fp16_ptr) {
-      break;
-    }
+  ClContext::SharedPtrClKernel kernel_sgemm_fp16_ptr =
+    blas_cc->registerClKernel(sgemm_cl_kernel_fp16_, kernel_func_);
+  if (!kernel_sgemm_fp16_ptr) {
+    return;
+  }
 
-    // sizes will be same for transpose
-    size_t m_k_size = M * K * sizeof(_FP16);
-    size_t k_n_size = K * N * sizeof(_FP16);
-    size_t m_n_size = M * N * sizeof(_FP16);
-
-    result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, m_k_size, A);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      blas_cc->command_queue_inst_, k_n_size, B);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, m_n_size, C);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemm_fp16_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemm_fp16_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemm_fp16_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemm_fp16_ptr->SetKernelArguments(3, &M, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemm_fp16_ptr->SetKernelArguments(4, &N, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sgemm_fp16_ptr->SetKernelArguments(5, &K, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    const int tiled_size = 16;
-    const int work_groups_count[3] = {
-      (int)((N + tiled_size - 1) / tiled_size) * tiled_size,
-      (int)((M + tiled_size - 1) / tiled_size) * tiled_size, 1}; // test-value
-
-    const int work_group_size[3] = {tiled_size, tiled_size, 1}; // test-value
-
-    result = blas_cc->command_queue_inst_.DispatchCommand(
-      kernel_sgemm_fp16_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      blas_cc->command_queue_inst_, m_n_size, C);
-    if (!result) {
-      break;
-    }
-
-  } while (false);
+  sgemm_cl_internal<_FP16>(kernel_sgemm_fp16_ptr, TransA, TransB, A, B, C, M, N,
+                           K, lda, ldb, ldc);
 }
 
 void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
                  unsigned int size_res) {
-
-  bool result = false;
-
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
 
-  do {
-    ClContext::SharedPtrClKernel kernel_addition_fp16_ptr =
-      blas_cc->registerClKernel(getAdditionClKernelFP16(), "addition_cl_fp16");
-    if (!kernel_addition_fp16_ptr) {
-      break;
-    }
+  ClContext::SharedPtrClKernel kernel_addition_fp16_ptr =
+    blas_cc->registerClKernel(getAdditionClKernelFP16(), "addition_cl_fp16");
+  if (!kernel_addition_fp16_ptr) {
+    return;
+  }
 
-    size_t dim1_size = sizeof(_FP16) * size_input;
-    size_t dim2_size = sizeof(_FP16) * size_res;
-
-    result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim1_size, input);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim2_size, res);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_addition_fp16_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_addition_fp16_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_addition_fp16_ptr->SetKernelArguments(2, &size_input, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_addition_fp16_ptr->SetKernelArguments(3, &size_res, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    const int work_groups_count[3] = {(int)size_res, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
-    result = blas_cc->command_queue_inst_.DispatchCommand(
-      kernel_addition_fp16_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      blas_cc->command_queue_inst_, dim2_size, res);
-
-    if (!result) {
-      break;
-    }
-
-  } while (false);
+  addition_cl_internal<_FP16>(kernel_addition_fp16_ptr, input, res, size_input,
+                              size_res);
 }
 
 void sscal_cl(_FP16 *X, const unsigned int N, const float alpha) {
-  bool result = false;
-
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
   auto &clbuffInstance = ClBufferManager::Global();
 
-  do {
-    ClContext::SharedPtrClKernel kernel_sscal_fp16_ptr =
-      blas_cc->registerClKernel(getHscalClKernel(), "sscal_cl_fp16");
+  ClContext::SharedPtrClKernel kernel_sscal_fp16_ptr =
+    blas_cc->registerClKernel(getHscalClKernel(), "sscal_cl_fp16");
 
-    if (!kernel_sscal_fp16_ptr) {
-      break;
-    }
+  if (!kernel_sscal_fp16_ptr) {
+    return;
+  }
 
-    size_t x_size = N * sizeof(_FP16);
-
-    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, x_size, X);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_sscal_fp16_ptr->SetKernelArguments(
-      0, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result =
-      kernel_sscal_fp16_ptr->SetKernelArguments(1, &alpha, sizeof(float));
-    if (!result) {
-      break;
-    }
-
-    const int work_groups_count[3] = {(int)N, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
-
-    result = blas_cc->command_queue_inst_.DispatchCommand(
-      kernel_sscal_fp16_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      blas_cc->command_queue_inst_, x_size, X);
-    if (!result) {
-      break;
-    }
-
-  } while (false);
+  sscal_cl_internal<_FP16>(kernel_sscal_fp16_ptr, X, N, alpha);
 }
 
 void transpose_cl_axis(const _FP16 *in, _FP16 *res,
                        unsigned int input_batch_size,
                        unsigned int input_channels, unsigned int input_height,
                        unsigned int input_width, unsigned int axis) {
-
-  bool result = false;
-
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
 
-  do {
-    ClContext::SharedPtrClKernel kernel_transpose_fp_16_ptr;
-    switch (axis) {
-    case 0:
-      kernel_transpose_fp_16_ptr = blas_cc->registerClKernel(
-        getTransposeClAxis0KernelFP16(), "transpose_cl_fp16_axis0");
-      break;
-    case 1:
-      kernel_transpose_fp_16_ptr = blas_cc->registerClKernel(
-        getTransposeClAxis1KernelFP16(), "transpose_cl_fp16_axis1");
-      break;
-    case 2:
-      kernel_transpose_fp_16_ptr = blas_cc->registerClKernel(
-        getTransposeClAxis2KernelFP16(), "transpose_cl_fp16_axis2");
-      break;
-    default:
-      throw std::invalid_argument("failed to register CL kernel");
-      break;
-    }
-    if (!kernel_transpose_fp_16_ptr) {
-      break;
-    }
+  ClContext::SharedPtrClKernel kernel_transpose_fp_16_ptr;
+  switch (axis) {
+  case 0:
+    kernel_transpose_fp_16_ptr = blas_cc->registerClKernel(
+      getTransposeClAxis0KernelFP16(), "transpose_cl_fp16_axis0");
+    break;
+  case 1:
+    kernel_transpose_fp_16_ptr = blas_cc->registerClKernel(
+      getTransposeClAxis1KernelFP16(), "transpose_cl_fp16_axis1");
+    break;
+  case 2:
+    kernel_transpose_fp_16_ptr = blas_cc->registerClKernel(
+      getTransposeClAxis2KernelFP16(), "transpose_cl_fp16_axis2");
+    break;
+  default:
+    throw std::invalid_argument("failed to register CL kernel");
+    break;
+  }
 
-    size_t dim_size = sizeof(_FP16) * input_batch_size * input_height *
-                      input_width * input_channels;
+  if (!kernel_transpose_fp_16_ptr) {
+    return;
+  }
 
-    result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim_size, in);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      blas_cc->command_queue_inst_, dim_size, res);
-    if (!result) {
-      break;
-    }
-
-    result = kernel_transpose_fp_16_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_transpose_fp_16_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_transpose_fp_16_ptr->SetKernelArguments(
-      2, &input_batch_size, sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_transpose_fp_16_ptr->SetKernelArguments(3, &input_channels,
-                                                            sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_transpose_fp_16_ptr->SetKernelArguments(4, &input_height,
-                                                            sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    result = kernel_transpose_fp_16_ptr->SetKernelArguments(5, &input_width,
-                                                            sizeof(int));
-    if (!result) {
-      break;
-    }
-
-    int work_groups_count[3] = {(int)input_height, (int)input_width, 1};
-    if (axis == 2)
-      work_groups_count[0] = (int)input_channels;
-
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
-
-    result = blas_cc->command_queue_inst_.DispatchCommand(
-      kernel_transpose_fp_16_ptr, work_groups_count, work_group_size);
-    if (!result) {
-      break;
-    }
-
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      blas_cc->command_queue_inst_, dim_size, res);
-    if (!result) {
-      break;
-    }
-
-  } while (false);
+  transpose_cl_axis_internal<_FP16>(kernel_transpose_fp_16_ptr, in, res,
+                                    input_batch_size, input_channels,
+                                    input_height, input_width, axis);
 }
 } // namespace nntrainer

--- a/nntrainer/tensor/cl_operations/blas_kernels_templates.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels_templates.h
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Debadri Samaddar <s.debadri@samsung.com>
+ * Copyright (C) 2025 Michal Wlasiuk <testmailsmtp12345@gmail.com>
+ *
+ * @file	blas_kernels_templates.hpp
+ * @date	07 July 2025
+ * @brief	Common blas OpenCL kernels (common templates used by
+ * blas_kernels_fp16.cpp and blas_kernels.cpp)
+ * @see		https://github.com/nnstreamer/nntrainer
+ * @author	Debadri Samaddar <s.debadri@samsung.com>
+ * @author	Michal Wlasiuk <testmailsmtp12345@gmail.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#ifndef __BLAS_KERNELS_TEMPLATES_H__
+#define __BLAS_KERNELS_TEMPLATES_H__
+
+#include <blas_kernel_strings.h>
+#include <blas_kernels.h>
+
+namespace nntrainer {
+template <typename T>
+inline static void sgemv_cl_internal(ClContext::SharedPtrClKernel kernel,
+                                     const T *matAdata, const T *vecXdata,
+                                     T *vecYdata, unsigned int dim1,
+                                     unsigned int dim2, unsigned int lda) {
+  bool result = false;
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
+  size_t dim1_size = sizeof(T) * dim1;
+  size_t dim2_size = sizeof(T) * dim2;
+  size_t dim1_dim2_size = sizeof(T) * dim1 * dim2;
+
+  result = clbuffInstance.getInBufferA()->WriteDataRegion(
+    blas_cc->command_queue_inst_, dim1_dim2_size, matAdata);
+  if (!result) {
+    return;
+  }
+
+  result = clbuffInstance.getInBufferB()->WriteDataRegion(
+    blas_cc->command_queue_inst_, dim2_size, vecXdata);
+  if (!result) {
+    return;
+  }
+
+  result = clbuffInstance.getOutBufferA()->WriteDataRegion(
+    blas_cc->command_queue_inst_, dim1_size, vecYdata);
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(0, clbuffInstance.getInBufferA(),
+                                      sizeof(cl_mem));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(1, clbuffInstance.getInBufferB(),
+                                      sizeof(cl_mem));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(2, clbuffInstance.getOutBufferA(),
+                                      sizeof(cl_mem));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(3, &dim2, sizeof(int));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(4, &lda, sizeof(int));
+  if (!result) {
+    return;
+  }
+
+  const int work_groups_count[3] = {(int)dim1, 1, 1};
+  const int work_group_size[3] = {1, 1, 1};
+
+  result = opencl::CommandQueueManager::Global().DispatchCommand(
+    kernel, work_groups_count, work_group_size);
+  if (!result) {
+    return;
+  }
+
+  result = clbuffInstance.getOutBufferA()->ReadDataRegion(
+    blas_cc->command_queue_inst_, dim1_size, vecYdata);
+  if (!result) {
+    return;
+  }
+}
+
+template <typename T>
+T dot_cl_internal(ClContext::SharedPtrClKernel kernel, const T *vecAdata,
+                  const T *vecXdata, unsigned int dim1) {
+  bool result = false;
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
+  T cl_ret = 0;
+
+  do {
+    size_t dim1_size = sizeof(T) * dim1;
+
+    result = clbuffInstance.getInBufferA()->WriteDataRegion(
+      blas_cc->command_queue_inst_, dim1_size, vecAdata);
+    if (!result) {
+      break;
+    }
+
+    result = clbuffInstance.getInBufferB()->WriteDataRegion(
+      blas_cc->command_queue_inst_, dim1_size, vecXdata);
+    if (!result) {
+      break;
+    }
+
+    result = kernel->SetKernelArguments(0, clbuffInstance.getInBufferA(),
+                                        sizeof(cl_mem));
+    if (!result) {
+      break;
+    }
+
+    result = kernel->SetKernelArguments(1, clbuffInstance.getInBufferB(),
+                                        sizeof(cl_mem));
+    if (!result) {
+      break;
+    }
+
+    result = kernel->SetKernelArguments(2, &dim1, sizeof(int));
+    if (!result) {
+      break;
+    }
+
+    result = kernel->SetKernelArguments(3, clbuffInstance.getOutBufferA(),
+                                        sizeof(cl_mem));
+    if (!result) {
+      break;
+    }
+
+    const int work_groups_count[3] = {(int)dim1, 1, 1};
+    const int work_group_size[3] = {1, 1, 1};
+
+    result = blas_cc->command_queue_inst_.DispatchCommand(
+      kernel, work_groups_count, work_group_size);
+    if (!result) {
+      break;
+    }
+
+    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
+      blas_cc->command_queue_inst_, sizeof(T), &cl_ret);
+    if (!result) {
+      break;
+    }
+
+  } while (false);
+
+  return cl_ret;
+}
+
+template <typename T>
+inline static void
+sgemm_cl_internal(ClContext::SharedPtrClKernel kernel, bool TransA, bool TransB,
+                  const T *A, const T *B, T *C, unsigned int M, unsigned int N,
+                  unsigned int K, unsigned int lda, unsigned int ldb,
+                  unsigned int ldc) {
+  bool result = false;
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
+  // sizes will be same for transpose
+  size_t m_k_size = M * K * sizeof(T);
+  size_t k_n_size = K * N * sizeof(T);
+  size_t m_n_size = M * N * sizeof(T);
+
+  result = clbuffInstance.getInBufferA()->WriteDataRegion(
+    blas_cc->command_queue_inst_, m_k_size, A);
+  if (!result) {
+    return;
+  }
+
+  result = clbuffInstance.getInBufferB()->WriteDataRegion(
+    blas_cc->command_queue_inst_, k_n_size, B);
+  if (!result) {
+    return;
+  }
+
+  result = clbuffInstance.getOutBufferA()->WriteDataRegion(
+    blas_cc->command_queue_inst_, m_n_size, C);
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(0, clbuffInstance.getInBufferA(),
+                                      sizeof(cl_mem));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(1, clbuffInstance.getInBufferB(),
+                                      sizeof(cl_mem));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(2, clbuffInstance.getOutBufferA(),
+                                      sizeof(cl_mem));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(3, &M, sizeof(int));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(4, &N, sizeof(int));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(5, &K, sizeof(int));
+  if (!result) {
+    return;
+  }
+
+  const int tiled_size = 16;
+  const int work_groups_count[3] = {
+    (int)((N + tiled_size - 1) / tiled_size) * tiled_size,
+    (int)((M + tiled_size - 1) / tiled_size) * tiled_size, 1}; // test-value
+
+  const int work_group_size[3] = {tiled_size, tiled_size, 1}; // test-value
+
+  result = blas_cc->command_queue_inst_.DispatchCommand(
+    kernel, work_groups_count, work_group_size);
+  if (!result) {
+    return;
+  }
+
+  result = clbuffInstance.getOutBufferA()->ReadDataRegion(
+    blas_cc->command_queue_inst_, m_n_size, C);
+  if (!result) {
+    return;
+  }
+}
+
+template <typename T>
+inline static void
+addition_cl_internal(ClContext::SharedPtrClKernel kernel, const T *input,
+                     T *res, unsigned int size_input, unsigned int size_res) {
+  bool result = false;
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
+  size_t dim1_size = sizeof(T) * size_input;
+  size_t dim2_size = sizeof(T) * size_res;
+
+  result = clbuffInstance.getInBufferA()->WriteDataRegion(
+    blas_cc->command_queue_inst_, dim1_size, input);
+  if (!result) {
+    return;
+  }
+
+  result = clbuffInstance.getOutBufferA()->WriteDataRegion(
+    blas_cc->command_queue_inst_, dim2_size, res);
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(0, clbuffInstance.getInBufferA(),
+                                      sizeof(cl_mem));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(1, clbuffInstance.getOutBufferA(),
+                                      sizeof(cl_mem));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(2, &size_input, sizeof(int));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(3, &size_res, sizeof(int));
+  if (!result) {
+    return;
+  }
+
+  const int work_groups_count[3] = {(int)size_res, 1, 1};
+  /// @todo: create a group size by device & input
+  const int work_group_size[3] = {1, 1, 1}; // test-value
+  result = blas_cc->command_queue_inst_.DispatchCommand(
+    kernel, work_groups_count, work_group_size);
+  if (!result) {
+    return;
+  }
+
+  result = clbuffInstance.getOutBufferA()->ReadDataRegion(
+    blas_cc->command_queue_inst_, dim2_size, res);
+
+  if (!result) {
+    return;
+  }
+}
+
+template <typename T>
+inline static void sscal_cl_internal(ClContext::SharedPtrClKernel kernel, T *X,
+                                     const unsigned int N, const float alpha) {
+  bool result = false;
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
+  size_t x_size = N * sizeof(T);
+
+  result = clbuffInstance.getOutBufferA()->WriteDataRegion(
+    blas_cc->command_queue_inst_, x_size, X);
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(0, clbuffInstance.getOutBufferA(),
+                                      sizeof(cl_mem));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(1, &alpha, sizeof(float));
+  if (!result) {
+    return;
+  }
+
+  const int work_groups_count[3] = {(int)N, 1, 1};
+  const int work_group_size[3] = {1, 1, 1};
+
+  result = blas_cc->command_queue_inst_.DispatchCommand(
+    kernel, work_groups_count, work_group_size);
+  if (!result) {
+    return;
+  }
+
+  result = clbuffInstance.getOutBufferA()->ReadDataRegion(
+    blas_cc->command_queue_inst_, x_size, X);
+  if (!result) {
+    return;
+  }
+}
+
+template <typename T>
+inline static void transpose_cl_axis_internal(
+  ClContext::SharedPtrClKernel kernel, const T *in, T *res,
+  unsigned int input_batch_size, unsigned int input_channels,
+  unsigned int input_height, unsigned int input_width, unsigned int axis) {
+
+  bool result = false;
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
+  size_t dim_size =
+    sizeof(T) * input_batch_size * input_height * input_width * input_channels;
+
+  result = clbuffInstance.getInBufferA()->WriteDataRegion(
+    blas_cc->command_queue_inst_, dim_size, in);
+  if (!result) {
+    return;
+  }
+
+  result = clbuffInstance.getOutBufferA()->WriteDataRegion(
+    blas_cc->command_queue_inst_, dim_size, res);
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(0, clbuffInstance.getInBufferA(),
+                                      sizeof(cl_mem));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(1, clbuffInstance.getOutBufferA(),
+                                      sizeof(cl_mem));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(2, &input_batch_size, sizeof(int));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(3, &input_channels, sizeof(int));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(4, &input_height, sizeof(int));
+  if (!result) {
+    return;
+  }
+
+  result = kernel->SetKernelArguments(5, &input_width, sizeof(int));
+  if (!result) {
+    return;
+  }
+
+  int work_groups_count[3] = {(int)input_height, (int)input_width, 1};
+  if (axis == 2)
+    work_groups_count[0] = (int)input_channels;
+
+  const int work_group_size[3] = {1, 1, 1};
+
+  result = blas_cc->command_queue_inst_.DispatchCommand(
+    kernel, work_groups_count, work_group_size);
+  if (!result) {
+    return;
+  }
+
+  result = clbuffInstance.getOutBufferA()->ReadDataRegion(
+    blas_cc->command_queue_inst_, dim_size, res);
+  if (!result) {
+    return;
+  }
+}
+
+} // namespace nntrainer
+
+#endif


### PR DESCRIPTION
Replace repeating FP16/FP32 code with template

- These kernels have exactly the same structure with only thing that differs is used kernel (its registered name) and type dependent sizeof()-s

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: {your_name} <{your_email}>
