### PR TITLE
Work on OpenCL compiler options and rotary_emb_cl

### DIFF
--- a/nntrainer/cl_context.h
+++ b/nntrainer/cl_context.h
@@ -208,10 +208,13 @@ public:
    * @brief register or return already present OpenCl kernel pointer
    * @param kernel_string kernel implementation string
    * @param kernel_name kernel name
+   * @param compiler_options compiler options for OpenCL kernel compiler
    * @return std::shared_ptr<opencl::Kernel>
    */
-  const SharedPtrClKernel registerClKernel(std::string kernel_string,
-                                           std::string kernel_name);
+  const SharedPtrClKernel
+  registerClKernel(const std::string &kernel_string,
+                   const std::string &kernel_name,
+                   const std::string &compiler_options = "");
 
   /**
    * @brief Initialize and register all blas OpenCl kernels
@@ -300,11 +303,14 @@ private:
    * @brief create OpenCl kernel
    * @param kernel_string reference of implementation string
    * @param kernel_name reference of kernel_name
-   * @param kernel_ptr_ reference of shared_ptr of Kernel
+   * @param kernel_ptr reference of shared_ptr of Kernel
+   * @param compiler_options compiler options for OpenCL kernel compiler
    * @return true if successful, false otherwise
    */
-  bool clCreateKernel(std::string &kernel_string, std::string &kernel_name,
-                      const SharedPtrClKernel &kernel_ptr_);
+  bool clCreateKernel(const std::string &kernel_string,
+                      const std::string &kernel_name,
+                      const SharedPtrClKernel &kernel_ptr,
+                      const std::string &compiler_options);
 };
 
 /**

--- a/nntrainer/tensor/cl_operations/attention_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/attention_kernels.cpp
@@ -16,14 +16,15 @@
 
 namespace nntrainer {
 
-void rotary_emb_cl(float *in, float *out,
-                   std::vector<std::vector<float>> freqs_cos,
-                   std::vector<std::vector<float>> freqs_sin,
-                   std::vector<float> cos_, std::vector<float> sin_,
-                   unsigned int batch, unsigned int channel,
-                   unsigned int height, unsigned int width, unsigned int dim,
-                   unsigned int from, unsigned int max_timestep,
-                   unsigned int in_size, unsigned int out_size) {
+void rotary_emb_cl(const float *in, float *out,
+                   const std::vector<std::vector<float>> &freqs_cos,
+                   const std::vector<std::vector<float>> &freqs_sin,
+                   const std::vector<float> &cos_,
+                   const std::vector<float> &sin_, unsigned int batch,
+                   unsigned int channel, unsigned int height,
+                   unsigned int width, unsigned int dim, unsigned int from,
+                   unsigned int max_timestep, unsigned int in_size,
+                   unsigned int out_size) {
   bool result = false;
 
   auto *cl_context =

--- a/nntrainer/tensor/cl_operations/attention_kernels.h
+++ b/nntrainer/tensor/cl_operations/attention_kernels.h
@@ -41,14 +41,15 @@ namespace nntrainer {
  * @param[in] in_size size of input
  * @param[in] out_size size of output
  */
-void rotary_emb_cl(float *in, float *out,
-                   std::vector<std::vector<float>> freqs_cos,
-                   std::vector<std::vector<float>> freqs_sin,
-                   std::vector<float> cos_, std::vector<float> sin_,
-                   unsigned int batch, unsigned int channel,
-                   unsigned int height, unsigned int width, unsigned int dim,
-                   unsigned int from, unsigned int max_timestamp,
-                   unsigned int in_size, unsigned int out_size);
+void rotary_emb_cl(const float *in, float *out,
+                   const std::vector<std::vector<float>> &freqs_cos,
+                   const std::vector<std::vector<float>> &freqs_sin,
+                   const std::vector<float> &cos_,
+                   const std::vector<float> &sin_, unsigned int batch,
+                   unsigned int channel, unsigned int height,
+                   unsigned int width, unsigned int dim, unsigned int from,
+                   unsigned int max_timestamp, unsigned int in_size,
+                   unsigned int out_size);
 
 #ifdef ENABLE_FP16
 
@@ -70,14 +71,15 @@ void rotary_emb_cl(float *in, float *out,
  * @param[in] in_size size of input
  * @param[in] out_size size of output
  */
-void rotary_emb_cl(_FP16 *in, _FP16 *out,
-                   std::vector<std::vector<float>> freqs_cos,
-                   std::vector<std::vector<float>> freqs_sin,
-                   std::vector<float> cos_, std::vector<float> sin_,
-                   unsigned int batch, unsigned int channel,
-                   unsigned int height, unsigned int width, unsigned int dim,
-                   unsigned int from, unsigned int max_timestamp,
-                   unsigned int in_size, unsigned int out_size);
+void rotary_emb_cl(const _FP16 *in, _FP16 *out,
+                   const std::vector<std::vector<float>> &freqs_cos,
+                   const std::vector<std::vector<float>> &freqs_sin,
+                   const std::vector<float> &cos_,
+                   const std::vector<float> &sin_, unsigned int batch,
+                   unsigned int channel, unsigned int height,
+                   unsigned int width, unsigned int dim, unsigned int from,
+                   unsigned int max_timestamp, unsigned int in_size,
+                   unsigned int out_size);
 
 #endif
 

--- a/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
@@ -16,14 +16,15 @@
 
 namespace nntrainer {
 
-void rotary_emb_cl(_FP16 *in, _FP16 *out,
-                   std::vector<std::vector<float>> freqs_cos,
-                   std::vector<std::vector<float>> freqs_sin,
-                   std::vector<float> cos_, std::vector<float> sin_,
-                   unsigned int batch, unsigned int channel,
-                   unsigned int height, unsigned int width, unsigned int dim,
-                   unsigned int from, unsigned int max_timestep,
-                   unsigned int in_size, unsigned int out_size) {
+void rotary_emb_cl(const _FP16 *in, _FP16 *out,
+                   const std::vector<std::vector<float>> &freqs_cos,
+                   const std::vector<std::vector<float>> &freqs_sin,
+                   const std::vector<float> &cos_,
+                   const std::vector<float> &sin_, unsigned int batch,
+                   unsigned int channel, unsigned int height,
+                   unsigned int width, unsigned int dim, unsigned int from,
+                   unsigned int max_timestep, unsigned int in_size,
+                   unsigned int out_size) {
 
   bool result = false;
 


### PR DESCRIPTION
- Add possibility to pass OpenCL compiler options from registerKernel() (plan to use in future to configure kernels via #defines which is helpful in case of Qn_K kernels)
- Do not copy data in rotary_emb_cl - use reference

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: mwlasiuk <testmailsmtp12345@gmail.com>