### PR TITLE
Address a few small memory leaks

### DIFF
--- a/Applications/KNN/jni/main.cpp
+++ b/Applications/KNN/jni/main.cpp
@@ -176,7 +176,7 @@ int main(int argc, char *argv[]) {
       img += total_label[i] + std::to_string(j + 1) + ".bmp";
       printf("%s\n", img.c_str());
 
-      uint8_t *in;
+      std::vector<uint8_t> in;
       float *output;
       in = tflite::label_image::read_bmp(img, &wanted_width, &wanted_height,
                                          &wanted_channels);
@@ -234,7 +234,7 @@ int main(int argc, char *argv[]) {
     img += "test" + std::to_string(i + 1) + ".bmp";
     printf("%s\n", img.c_str());
 
-    uint8_t *in;
+    std::vector<uint8_t> in;
     float *output;
     in = tflite::label_image::read_bmp(img, &wanted_width, &wanted_height,
                                        &wanted_channels);

--- a/Applications/TransferLearning/CIFAR_Classification/jni/main.cpp
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/main.cpp
@@ -161,7 +161,7 @@ void getFeature(const string filename, vector<float> &feature_input) {
   int _input = interpreter->inputs()[0];
 
   float *output;
-  uint8_t *in = tflite::label_image::read_bmp(filename, &wanted_width,
+  std::vector<uint8_t> in = tflite::label_image::read_bmp(filename, &wanted_width,
                                               &wanted_height, &wanted_channels);
 
   if (interpreter->AllocateTensors() != kTfLiteOk) {
@@ -188,8 +188,6 @@ void getFeature(const string filename, vector<float> &feature_input) {
   for (unsigned int l = 0; l < feature_size; l++) {
     feature_input[l] = output[l];
   }
-
-  delete[] in;
 }
 
 /**

--- a/Applications/TransferLearning/CIFAR_Classification/jni/main_func.cpp
+++ b/Applications/TransferLearning/CIFAR_Classification/jni/main_func.cpp
@@ -113,7 +113,7 @@ static int rangeRandom(int min, int max) {
  */
 void getImage(const string filename, float *image) {
   int width, height, channels;
-  uint8_t *in =
+  std::vector<uint8_t> in =
     tflite::label_image::read_bmp(filename, &width, &height, &channels);
 
   if (width * height * channels != image_size)
@@ -122,8 +122,6 @@ void getImage(const string filename, float *image) {
   for (size_t i = 0; i < image_size; i++) {
     image[i] = ((float)in[i]) / 255.0;
   }
-
-  delete[] in;
 }
 
 /**

--- a/Applications/utils/jni/bitmap_helpers.cpp
+++ b/Applications/utils/jni/bitmap_helpers.cpp
@@ -72,7 +72,7 @@ uint8_t *decode_bmp(const uint8_t *input, int row_size, uint8_t *const output,
   return output;
 }
 
-uint8_t *read_bmp(const std::string &input_bmp_name, int *width, int *height,
+std::vector<uint8_t> read_bmp(const std::string &input_bmp_name, int *width, int *height,
                   int *channels) {
   int begin, end;
 
@@ -106,11 +106,11 @@ uint8_t *read_bmp(const std::string &input_bmp_name, int *width, int *height,
   bool top_down = (*height < 0);
 
   // Decode image, allocating tensor once the image size is known
-  uint8_t *output = new uint8_t[abs(*height) * *width * *channels];
+  std::vector<uint8_t> output(abs(*height) * (*width) * (*channels));
 
   const uint8_t *bmp_pixels = &img_bytes[header_size];
 
-  decode_bmp(bmp_pixels, row_size, output, *width, abs(*height), *channels,
+  decode_bmp(bmp_pixels, row_size, output.data(), *width, abs(*height), *channels,
              top_down);
 
   delete[] img_bytes;

--- a/Applications/utils/jni/includes/bitmap_helpers.h
+++ b/Applications/utils/jni/includes/bitmap_helpers.h
@@ -20,9 +20,10 @@ limitations under the License.
 #define TENSORFLOW_CONTRIB_LITE_EXAMPLES_LABEL_IMAGE_BITMAP_HELPERS_H_
 #include <cstdint>
 #include <string>
+#include <vector>
 namespace tflite {
 namespace label_image {
-uint8_t *read_bmp(const std::string &input_bmp_name, int *width, int *height,
+std::vector<uint8_t> read_bmp(const std::string &input_bmp_name, int *width, int *height,
                   int *channels);
 } // namespace label_image
 } // namespace tflite

--- a/test/unittest/layers/unittest_layer_node.cpp
+++ b/test/unittest/layers/unittest_layer_node.cpp
@@ -296,14 +296,12 @@ TEST(nntrainer_LayerNode, getWeights_01_n) {
  */
 TEST(nntrainer_LayerNode, setWeights_01_n) {
   std::unique_ptr<nntrainer::LayerNode> lnode;
-  const std::vector<float *> weights({new float});
+  float f;
+  const std::vector<float *> weights({&f});
 
   EXPECT_NO_THROW(lnode =
                     nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
   EXPECT_THROW(lnode->setWeights(weights), std::runtime_error);
-
-  for (auto &i : weights)
-    delete i;
 }
 
 /**


### PR DESCRIPTION
`tflite::label_image::read_bmp` allocated memory for the image, which requires manual freeing. In some cases the resultant buffer was not freed. I changed this to return `std::vector<uint8_t>` so no manual memory management is needed.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
3. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: p-pokorski-samsung p.pokorski@samsung.com