### PR TITLE
[Tizen] fix tizen-build related to ruy and ggml

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -600,8 +600,10 @@ else
     ruy_flags += '-Wno-error=uninitialized'
   else
     ruy_flags += '-Wno-error=maybe-uninitialized'
-    ruy_flags += '-Wno-error=stringop-overread'
-    ruy_flags += '-Wno-error=array-parameter'
+    if cxx.has_argument('-Wno-error=stringop-overread') and cxx.has_argument('-Wno-error=array-parameter')
+      ruy_flags += '-Wno-error=stringop-overread'
+      ruy_flags += '-Wno-error=array-parameter'
+    endif
   endif
   
   ruy_options.append_compile_args('c', '-Wno-implicit-function-declaration')

--- a/meson.build
+++ b/meson.build
@@ -575,6 +575,8 @@ else
 endif
 
 # Configure the Ruy project (CMake)
+ruy_dep = dummy_dep
+if get_option('enable-ruy')
 if get_option('platform') == 'android'
   ruy_root = subprojects_dir_absolute / 'ruy'
   ruy_dep = declare_dependency()
@@ -609,6 +611,7 @@ else
   ruy_proj = cmake.subproject('ruy', options: ruy_options, required: true)
   ruy_dep = ruy_proj.dependency('ruy').partial_dependency(includes: true)
 endif
+endif # enable ruy
 
 if get_option('platform') == 'android'
   message('preparing ml api')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -48,6 +48,7 @@ option('enable-opencl', type: 'boolean', value: false)
 option('enable-biqgemm', type: 'boolean', value: false)
 option('biqgemm-path', type: 'string', value: '../BiQGEMM')
 option('enable-benchmarks', type: 'boolean', value : false)
+option('enable-ruy', type: 'boolean', value: true)
 option('ggml-thread-backend', type: 'string', value: 'mixed')
 
 # ml-api dependency (to enable, install capi-inference from github.com/nnstreamer/api )

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -4,7 +4,6 @@
 %define         nnstreamer_trainer 1
 %define         nnstreamer_subplugin_path lib/nnstreamer
 %define         use_gym 0
-%define         use_ggml 1
 %define         use_ruy 1
 %define         use_biqgemm 0
 %define         support_ccapi 1
@@ -380,11 +379,6 @@ Summary: CLBlast as an OpenCL backend for BLAS operations in NNTrainer
 %define enable_cblas -Denable-blas=true
 %endif
 
-%if 0%{?use_ggml}
-%define enable_ggml -Denable-ggml=true
-%else
-%define enable_ggml -Denable-ggml=false
-%endif
 
 %if 0%{?use_ruy}
 %define enable_ruy -Denable-ruy=true
@@ -584,11 +578,9 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/memory_data.h
 %{_includedir}/nntrainer/tensor.h
 %{_includedir}/nntrainer/tensor_base.h
-%if 0%{?use_ggml}
 %{_includedir}/nntrainer/q4_k_tensor.h
 %{_includedir}/nntrainer/q6_k_tensor.h
 %{_includedir}/nntrainer/q4_0_tensor.h
-%endif
 %{_includedir}/nntrainer/int4_tensor.h
 %{_includedir}/nntrainer/uint4_tensor.h
 %{_includedir}/nntrainer/char_tensor.h

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -1,4 +1,4 @@
- #Execute gbs with --define "testcoverage 1" in case that you must get unittest coverage statistics
+# Execute gbs with --define "testcoverage 1" in case that you must get unittest coverage statistics
 %define         use_cblas 1
 %define         nnstreamer_filter 1
 %define         nnstreamer_trainer 1
@@ -840,7 +840,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %defattr(-,root,root,-)
 %license LICENSE
 %{_libdir}/nntrainer/bin/applications/*
-%{_libdir}/nntrainer/layers/*layer.so 
+%{_libdir}/nntrainer/layers/*layer.so
 
 %if 0%{?gcov:1}
 %files gcov


### PR DESCRIPTION
## Dependency of the PR
#3410 

## Commits to be reviewed in this PR


<details><summary>[Tizen] fix tizen-build related to ruy and ggml </summary><br />

- This patch fixes some issues in tizen-7.0 build
- This patch updates ruy and ggml use as an option in tizen build
- tizen build error by warning is fixed (removing unused param)

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

<details><summary>[Tizen-7.0] edit build options for submodules</summary><br />

- This patch aims to resolve tizen-7.0 gbs build error.
- This patch resolves ruy-related issue

```
[   93s] c++ -Isubprojects/ruy/libruy_system_aligned_alloc.a.p -Isubprojects/ruy -I../subprojects/ruy -Isubprojects/ruy/__CMake_build -I../subprojects/ruy/__CMake_build -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -Werror -std=gnu++14 -O2 -g2 -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong -Wformat-security -fmessage-length=0 -frecord-gcc-switches -Wl,-z,relro,--as-needed -feliminate-unused-debug-types -Wformat -march=armv8-a+fp+simd+crc+crypto -mtune=cortex-a57.cortex-a53 -g -O2 -g2 -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong -Wformat-security -fmessage-length=0 -frecord-gcc-switches -Wl,-z,relro,--as-needed -feliminate-unused-debug-types -Wformat -march=armv8-a+fp+simd+crc+crypto -mtune=cortex-a57.cortex-a53 -g -Wundef -O3 -Wno-error=unused-result -Wno-error=comment -Wno-error=unknown-pragmas -Wno-error=unused-function -Wno-error=maybe-uninitialized -Wno-error=stringop-overread -Wno-error=array-parameter -MD -MQ subprojects/ruy/libruy_system_aligned_alloc.a.p/ruy_system_aligned_alloc.cc.o -MF subprojects/ruy/libruy_system_aligned_alloc.a.p/ruy_system_aligned_alloc.cc.o.d -o subprojects/ruy/libruy_system_aligned_alloc.a.p/ruy_system_aligned_alloc.cc.o -c ../subprojects/ruy/ruy/system_aligned_alloc.cc
[   93s] cc1plus: error: '-Werror=stringop-overread': no option -Wstringop-overread
[   93s] cc1plus: error: '-Werror=array-parameter': no option -Warray-parameter
```

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



### Summary

- This PR updates `packaging/nntrainer.spec` to enable the submodule build option for Tizen, ensuring alignment with the enable-ggml option in the Meson script.
- This PR modifies `meson.build` to add a submodule option for ruy and fixes a compilation error in Tizen 7.0.
- This PR partially resolves #3315. Please note that the ggml issue is not addressed in this PR.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
