### PR TITLE
Fallback to cpu context when OpenCL device is not available in runtime

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -90,6 +90,8 @@ ClContext &ClContext::Global() {
   // initializing commandqueue and context
   if (!clInit()) {
     ml_loge("cl_context: opencl command queue creation failed");
+    throw std::runtime_error(
+      "cl_context: opencl command queue creation failed");
   }
 
   registerer(*this);

--- a/nntrainer/engine.cpp
+++ b/nntrainer/engine.cpp
@@ -48,9 +48,13 @@ void Engine::add_default_object(Engine &eg) {
 
 #ifdef ENABLE_OPENCL
   nntrainer::ClContext *cl_context = new nntrainer::ClContext();
-  cl_context->Global();
+  try {
+    cl_context->Global();
 
-  eg.registerContext("gpu", cl_context);
+    eg.registerContext("gpu", cl_context);
+  } catch (std::runtime_error &e) {
+    ml_loge("Error initializing cl_context: %s", e.what());
+  }
 #endif
 }
 

--- a/nntrainer/engine.h
+++ b/nntrainer/engine.h
@@ -138,16 +138,33 @@ public:
    * @return Context Pointer : for register Object factory, casting might be
    * needed.
    */
-  nntrainer::Context *getRegisteredContext(std::string name) const {
+  nntrainer::Context *getRegisteredContext(const std::string &name) const {
+    auto context = maybeGetRegisteredContext(name);
+    if (context == nullptr) {
+      throw std::invalid_argument("[Engine] " + name +
+                                  " Context is not registered");
+    } else {
+      return context;
+    }
+  }
 
+  /**
+   * @brief get registered a Context
+   *
+   * @param name Registered Context Name
+   * @return Context Pointer : for register Object factory, casting might be
+   * needed. nullptr if no registered context with this name
+   */
+  nntrainer::Context *maybeGetRegisteredContext(std::string name) const {
     std::transform(name.begin(), name.end(), name.begin(),
                    [](unsigned char c) { return std::tolower(c); });
 
-    if (engines.find(name) == engines.end()) {
-      throw std::invalid_argument("[Engine] " + name +
-                                  " Context is not registered");
+    auto it = engines.find(name);
+    if (it == engines.end()) {
+      return nullptr;
+    } else {
+      return it->second;
     }
-    return engines.at(name);
   }
 
   std::unordered_map<std::string, std::shared_ptr<nntrainer::MemAllocator>>

--- a/nntrainer/layers/cl_layers/layer_impl_cl.h
+++ b/nntrainer/layers/cl_layers/layer_impl_cl.h
@@ -62,7 +62,7 @@ public:
 
 protected:
   inline static ClContext *global_cl_context =
-    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+    static_cast<ClContext *>(Engine::Global().maybeGetRegisteredContext("gpu"));
   inline static ClBufferManager &clbuffInstance =
     ClBufferManager::getInstance();
 };

--- a/nntrainer/opencl/opencl_command_queue_manager.cpp
+++ b/nntrainer/opencl/opencl_command_queue_manager.cpp
@@ -97,9 +97,9 @@ CommandQueueManager::~CommandQueueManager() {
 /**
  * @brief Get the OpenCL Command Queue object
  *
- * @return const cl_command_queue
+ * @return cl_command_queue
  */
-const cl_command_queue CommandQueueManager::GetCommandQueue() {
+cl_command_queue &CommandQueueManager::GetCommandQueue() {
   return command_queue_;
 }
 

--- a/nntrainer/opencl/opencl_command_queue_manager.h
+++ b/nntrainer/opencl/opencl_command_queue_manager.h
@@ -38,7 +38,7 @@ class CommandQueueManager {
    * @brief Private constructor to prevent object creation
    *
    */
-  CommandQueueManager(){};
+  CommandQueueManager() {};
 
 public:
   /**
@@ -206,9 +206,9 @@ public:
   /**
    * @brief Get the OpenCL Command Queue object
    *
-   * @return const cl_command_queue
+   * @return cl_command_queue
    */
-  const cl_command_queue GetCommandQueue();
+  cl_command_queue &GetCommandQueue();
 
   /**
    * @brief Deleting operator overload

--- a/nntrainer/tensor/cl_operations/attention_kernels.h
+++ b/nntrainer/tensor/cl_operations/attention_kernels.h
@@ -25,7 +25,7 @@ namespace nntrainer {
 
 // get global cl_context to use in kernels
 static ClContext *attention_cc =
-  static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  static_cast<ClContext *>(Engine::Global().maybeGetRegisteredContext("gpu"));
 static ClBufferManager &clbuffInstance = ClBufferManager::getInstance();
 
 /**

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -26,7 +26,7 @@ namespace nntrainer {
 
 // get global cl_context to use in kernels
 static ClContext *blas_cc =
-  static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  static_cast<ClContext *>(Engine::Global().maybeGetRegisteredContext("gpu"));
 static ClBufferManager &clbuffInstance = ClBufferManager::getInstance();
 
 /**

--- a/nntrainer/tensor/cl_operations/clblast_interface.cpp
+++ b/nntrainer/tensor/cl_operations/clblast_interface.cpp
@@ -24,7 +24,8 @@ void scal_cl(const unsigned int N, const float alpha, float *X,
     clblast_cc->command_queue_inst_, N * sizeof(float), X);
 
   clblast::Scal<float>(N, alpha, clBuffManagerInst.getOutBufferA()->GetBuffer(),
-                       0, incX, &command_queue);
+                       0, incX,
+                       &clblast_cc->command_queue_inst_.GetCommandQueue());
 
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), X);
@@ -37,7 +38,8 @@ void copy_cl(const unsigned int N, const float *X, float *Y, unsigned int incX,
 
   clblast::Copy<float>(N, clBuffManagerInst.getInBufferA()->GetBuffer(), 0,
                        incX, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
-                       incY, &command_queue);
+                       incY,
+                       &clblast_cc->command_queue_inst_.GetCommandQueue());
 
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), Y);
@@ -53,7 +55,8 @@ void axpy_cl(const unsigned int N, const float alpha, const float *X, float *Y,
 
   clblast::Axpy<float>(N, alpha, clBuffManagerInst.getInBufferA()->GetBuffer(),
                        0, incX, clBuffManagerInst.getOutBufferA()->GetBuffer(),
-                       0, incY, &command_queue);
+                       0, incY,
+                       &clblast_cc->command_queue_inst_.GetCommandQueue());
 
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), Y);
@@ -70,7 +73,7 @@ float dot_cl(const unsigned int N, const float *X, const float *Y,
   clblast::Dot<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
                       clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
                       clBuffManagerInst.getInBufferB()->GetBuffer(), 0, incY,
-                      &command_queue);
+                      &clblast_cc->command_queue_inst_.GetCommandQueue());
 
   float result;
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
@@ -84,7 +87,7 @@ float nrm2_cl(const unsigned int N, const float *X, unsigned int incX) {
 
   clblast::Nrm2<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
                        clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
-                       &command_queue);
+                       &clblast_cc->command_queue_inst_.GetCommandQueue());
 
   float result;
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
@@ -99,7 +102,7 @@ float asum_cl(const unsigned int N, const float *X, unsigned int incX) {
 
   clblast::Asum<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
                        clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
-                       &command_queue);
+                       &clblast_cc->command_queue_inst_.GetCommandQueue());
 
   float result;
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
@@ -114,7 +117,7 @@ int amax_cl(const unsigned int N, const float *X, unsigned int incX) {
 
   clblast::Amax<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
                        clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
-                       &command_queue);
+                       &clblast_cc->command_queue_inst_.GetCommandQueue());
 
   int result;
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
@@ -129,7 +132,7 @@ int amin_cl(const unsigned int N, const float *X, unsigned int incX) {
 
   clblast::Amin<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
                        clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
-                       &command_queue);
+                       &clblast_cc->command_queue_inst_.GetCommandQueue());
 
   int result;
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
@@ -165,11 +168,12 @@ void gemm_cl(const unsigned int layout, bool TransA, bool TransB,
     clblast_cc->command_queue_inst_, M * N * sizeof(float), C);
 
   // layout is currently fixed to RowMajor
-  clblast::Gemm<float>(
-    clblast::Layout::kRowMajor, transA, transB, M, N, K, alpha,
-    clBuffManagerInst.getInBufferA()->GetBuffer(), 0, lda,
-    clBuffManagerInst.getInBufferB()->GetBuffer(), 0, ldb, beta,
-    clBuffManagerInst.getOutBufferA()->GetBuffer(), 0, ldc, &command_queue);
+  clblast::Gemm<float>(clblast::Layout::kRowMajor, transA, transB, M, N, K,
+                       alpha, clBuffManagerInst.getInBufferA()->GetBuffer(), 0,
+                       lda, clBuffManagerInst.getInBufferB()->GetBuffer(), 0,
+                       ldb, beta,
+                       clBuffManagerInst.getOutBufferA()->GetBuffer(), 0, ldc,
+                       &clblast_cc->command_queue_inst_.GetCommandQueue());
 
   // Read the result back to C
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(

--- a/nntrainer/tensor/cl_operations/clblast_interface.h
+++ b/nntrainer/tensor/cl_operations/clblast_interface.h
@@ -18,11 +18,8 @@
 namespace nntrainer {
 
 static ClContext *clblast_cc =
-  static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  static_cast<ClContext *>(Engine::Global().maybeGetRegisteredContext("gpu"));
 static ClBufferManager &clBuffManagerInst = ClBufferManager::getInstance();
-
-static cl_command_queue command_queue =
-  clblast_cc->command_queue_inst_.GetCommandQueue();
 
 /**
  * @brief Multiplies n elements of vector x by a scalar constant alpha.

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -72,7 +72,7 @@ namespace nntrainer {
 
 #ifdef ENABLE_OPENCL
 static ClContext *cl_context_ =
-  static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  static_cast<ClContext *>(Engine::Global().maybeGetRegisteredContext("gpu"));
 #endif
 
 /**
@@ -228,15 +228,15 @@ public:
    *
    * @param path FSU weight file path
    */
-  virtual void setFsuWeightPath(std::string path){};
+  virtual void setFsuWeightPath(std::string path) {};
 
   /**
    * @brief set weight file offset for FSU loading
    *
    * @param offsets weight file offset
    */
-  virtual void
-  setWeightOffset(std::vector<std::pair<size_t, size_t>> offsets){};
+  virtual void setWeightOffset(std::vector<std::pair<size_t, size_t>> offsets) {
+  };
 
 protected:
   /**

--- a/test/unittest/layers/layers_common_tests.h
+++ b/test/unittest/layers/layers_common_tests.h
@@ -91,7 +91,15 @@ protected:
  * @brief LayerSemanticsGpu
  * @details Inherit LayerSemantics to test layers on GPU
  */
-class LayerSemanticsGpu : public LayerSemantics {};
+class LayerSemanticsGpu : public LayerSemantics {
+  void SetUp() override {
+    if (nntrainer::Engine::Global().maybeGetRegisteredContext("gpu") ==
+        nullptr) {
+      GTEST_SKIP() << "OpenCL not available";
+    }
+    LayerSemantics::SetUp();
+  }
+};
 
 /**
  * @brief LayerPropertySemantics

--- a/test/unittest/layers/layers_golden_tests.cpp
+++ b/test/unittest/layers/layers_golden_tests.cpp
@@ -26,8 +26,8 @@
 
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 
-#define EXPECT_IN_RANGE(VAL, MIN, MAX) \
-  EXPECT_GE((VAL), (MIN));             \
+#define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
+  EXPECT_GE((VAL), (MIN));                                                     \
   EXPECT_LE((VAL), (MAX))
 
 using namespace nntrainer;
@@ -379,7 +379,16 @@ static void compareRunContext(RunLayerContext &rc, std::ifstream &file,
 
 LayerGoldenTest::~LayerGoldenTest() {}
 
-void LayerGoldenTest::SetUp() {}
+void LayerGoldenTest::SetUp() {
+  bool is_gpu_test =
+    std::string(
+      ::testing::UnitTest::GetInstance()->current_test_suite()->name())
+      .find("GPU") != std::string::npos;
+  if (is_gpu_test &&
+      nntrainer::Engine::Global().maybeGetRegisteredContext("gpu") == nullptr) {
+    GTEST_SKIP() << "OpenCL not available";
+  }
+}
 
 void LayerGoldenTest::TearDown() {}
 

--- a/test/unittest/unittest_attention_kernels_cl.cpp
+++ b/test/unittest/unittest_attention_kernels_cl.cpp
@@ -29,7 +29,17 @@
 
 using namespace nntrainer;
 
-TEST(attention_kernels, rotary_emb_kernel_FP32) {
+class attention_kernels : public ::testing::Test {
+public:
+  void SetUp() override {
+    if (nntrainer::Engine::Global().maybeGetRegisteredContext("gpu") ==
+        nullptr) {
+      GTEST_SKIP() << "OpenCL not available";
+    }
+  }
+};
+
+TEST_F(attention_kernels, rotary_emb_kernel_FP32) {
   int batch = 1;
   int channel = 1;
   int height = 4;
@@ -70,7 +80,7 @@ TEST(attention_kernels, rotary_emb_kernel_FP32) {
   EXPECT_IN_RANGE((float)cosSimNeon_fp32, 0.99, 1);
 }
 
-TEST(attention_kernels, rotary_emb_kernel_FP32_case2) {
+TEST_F(attention_kernels, rotary_emb_kernel_FP32_case2) {
   int batch = 4;
   int channel = 4;
   int height = 8;
@@ -113,7 +123,7 @@ TEST(attention_kernels, rotary_emb_kernel_FP32_case2) {
 
 #ifdef ENABLE_FP16
 
-TEST(attention_kernels, rotary_emb_kernel_FP16) {
+TEST_F(attention_kernels, rotary_emb_kernel_FP16) {
   int batch = 1;
   int channel = 1;
   int height = 4;
@@ -153,7 +163,7 @@ TEST(attention_kernels, rotary_emb_kernel_FP16) {
   EXPECT_IN_RANGE((float)cosSimNeon_fp16, 0.99, 1);
 }
 
-TEST(attention_kernels, rotary_emb_kernel_FP16_case2) {
+TEST_F(attention_kernels, rotary_emb_kernel_FP16_case2) {
   int batch = 4;
   int channel = 4;
   int height = 8;

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -27,7 +27,17 @@
 
 using namespace nntrainer;
 
-TEST(blas_kernels, dotCL_sgemv_M_1_1) {
+class blas_kernels : public ::testing::Test {
+public:
+  void SetUp() override {
+    if (nntrainer::Engine::Global().maybeGetRegisteredContext("gpu") ==
+        nullptr) {
+      GTEST_SKIP() << "OpenCL not available";
+    }
+  }
+};
+
+TEST_F(blas_kernels, dotCL_sgemv_M_1_1) {
   int batch = 1;
   int channel = 1;
   int height = 1;
@@ -72,7 +82,7 @@ TEST(blas_kernels, dotCL_sgemv_M_1_1) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dotCL_sgemv_M_1_2) {
+TEST_F(blas_kernels, dotCL_sgemv_M_1_2) {
   int batch = 1;
   int channel = 1;
   int height = 1;
@@ -117,7 +127,7 @@ TEST(blas_kernels, dotCL_sgemv_M_1_2) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dotCL_sgemv_N_1_1) {
+TEST_F(blas_kernels, dotCL_sgemv_N_1_1) {
   int batch = 1;
   int channel = 1;
   int height = 768;
@@ -162,7 +172,7 @@ TEST(blas_kernels, dotCL_sgemv_N_1_1) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dotCL_sgemv_N_1_2) {
+TEST_F(blas_kernels, dotCL_sgemv_N_1_2) {
   int batch = 1;
   int channel = 1;
   int height = 768;
@@ -207,7 +217,7 @@ TEST(blas_kernels, dotCL_sgemv_N_1_2) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dotCL_sgemv_n) {
+TEST_F(blas_kernels, dotCL_sgemv_n) {
 
   int batch = 1;
   int channel = 1;
@@ -241,7 +251,7 @@ TEST(blas_kernels, dotCL_sgemv_n) {
   EXPECT_THROW(dotCl(A_fp32, B_fp32, transA, transB), std::runtime_error);
 }
 
-TEST(blas_kernels, dotCL_sgemv_N_1_M_1_1) {
+TEST_F(blas_kernels, dotCL_sgemv_N_1_M_1_1) {
   int batch = 1;
   int channel = 1;
   int height = 1;
@@ -285,7 +295,7 @@ TEST(blas_kernels, dotCL_sgemv_N_1_M_1_1) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dotCL_sgemv_N_1_M_1_2) {
+TEST_F(blas_kernels, dotCL_sgemv_N_1_M_1_2) {
   int batch = 1;
   int channel = 1;
   int height = 1;
@@ -330,7 +340,7 @@ TEST(blas_kernels, dotCL_sgemv_N_1_M_1_2) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dot_gemm_50_768_1024_noTrans) {
+TEST_F(blas_kernels, dot_gemm_50_768_1024_noTrans) {
   int batch = 1;
   int channel = 1;
   int height = 50;
@@ -375,7 +385,7 @@ TEST(blas_kernels, dot_gemm_50_768_1024_noTrans) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dot_gemm_50_768_2048_transB) {
+TEST_F(blas_kernels, dot_gemm_50_768_2048_transB) {
   int batch = 1;
   int channel = 1;
   int height = 50;
@@ -420,7 +430,7 @@ TEST(blas_kernels, dot_gemm_50_768_2048_transB) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dot_gemm_50_768_1024_transA) {
+TEST_F(blas_kernels, dot_gemm_50_768_1024_transA) {
   int batch = 1;
   int channel = 1;
   int height = 768;
@@ -465,7 +475,7 @@ TEST(blas_kernels, dot_gemm_50_768_1024_transA) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dot_gemm_50_768_2048_transAB) {
+TEST_F(blas_kernels, dot_gemm_50_768_2048_transAB) {
   int batch = 1;
   int channel = 1;
   int height = 768;
@@ -510,7 +520,7 @@ TEST(blas_kernels, dot_gemm_50_768_2048_transAB) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, addition_i) {
+TEST_F(blas_kernels, addition_i) {
 
   int batch = 12;
   int channel = 1;
@@ -562,7 +572,7 @@ TEST(blas_kernels, addition_i) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, l2norm) {
+TEST_F(blas_kernels, l2norm) {
   int batch = 1;
   int channel = 1;
   int height = 768;
@@ -593,7 +603,7 @@ TEST(blas_kernels, l2norm) {
   EXPECT_FLOAT_EQ(gpu_result, cpu_result);
 }
 
-TEST(blas_kernels, absolute_sum) {
+TEST_F(blas_kernels, absolute_sum) {
   int batch = 1;
   int channel = 1;
   int height = 32;
@@ -624,7 +634,7 @@ TEST(blas_kernels, absolute_sum) {
 
 #ifdef ENABLE_FP16
 
-TEST(blas_kernels, dotCL_sgemv_M_1_1_fp16) {
+TEST_F(blas_kernels, dotCL_sgemv_M_1_1_fp16) {
   int batch = 1;
   int channel = 1;
   int height = 1;
@@ -669,7 +679,7 @@ TEST(blas_kernels, dotCL_sgemv_M_1_1_fp16) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dotCL_sgemv_M_1_2_fp16) {
+TEST_F(blas_kernels, dotCL_sgemv_M_1_2_fp16) {
   int batch = 1;
   int channel = 1;
   int height = 1;
@@ -714,7 +724,7 @@ TEST(blas_kernels, dotCL_sgemv_M_1_2_fp16) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dotCL_sgemv_N_1_1_fp16) {
+TEST_F(blas_kernels, dotCL_sgemv_N_1_1_fp16) {
   int batch = 1;
   int channel = 1;
   int height = 768;
@@ -759,7 +769,7 @@ TEST(blas_kernels, dotCL_sgemv_N_1_1_fp16) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dotCL_sgemv_N_1_2_fp16) {
+TEST_F(blas_kernels, dotCL_sgemv_N_1_2_fp16) {
   int batch = 1;
   int channel = 1;
   int height = 768;
@@ -804,7 +814,7 @@ TEST(blas_kernels, dotCL_sgemv_N_1_2_fp16) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dotCL_sgemv_n_fp16) {
+TEST_F(blas_kernels, dotCL_sgemv_n_fp16) {
 
   int batch = 1;
   int channel = 1;
@@ -838,7 +848,7 @@ TEST(blas_kernels, dotCL_sgemv_n_fp16) {
   EXPECT_THROW(dotCl(A_fp16, B_fp16, transA, transB), std::runtime_error);
 }
 
-TEST(blas_kernels, multiply_i) {
+TEST_F(blas_kernels, multiply_i) {
   int batch = 1;
   int channel = 1;
   int height = 2;
@@ -879,7 +889,7 @@ TEST(blas_kernels, multiply_i) {
   EXPECT_IN_RANGE(cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dot_gemm_50_768_1024_noTrans_fp16) {
+TEST_F(blas_kernels, dot_gemm_50_768_1024_noTrans_fp16) {
   /// @note GEMM : A X B = C
 
   int batch = 1;
@@ -926,7 +936,7 @@ TEST(blas_kernels, dot_gemm_50_768_1024_noTrans_fp16) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dot_gemm_50_768_2048_transB_fp16) {
+TEST_F(blas_kernels, dot_gemm_50_768_2048_transB_fp16) {
   /// @note GEMM : A X B = C
 
   int batch = 1;
@@ -973,7 +983,7 @@ TEST(blas_kernels, dot_gemm_50_768_2048_transB_fp16) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dot_gemm_50_768_1024_transA_fp16) {
+TEST_F(blas_kernels, dot_gemm_50_768_1024_transA_fp16) {
   int batch = 1;
   int channel = 1;
   int height = 768;
@@ -1018,7 +1028,7 @@ TEST(blas_kernels, dot_gemm_50_768_1024_transA_fp16) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, dot_gemm_50_768_2048_transAB_fp16) {
+TEST_F(blas_kernels, dot_gemm_50_768_2048_transAB_fp16) {
   int batch = 1;
   int channel = 1;
   int height = 768;
@@ -1063,7 +1073,7 @@ TEST(blas_kernels, dot_gemm_50_768_2048_transAB_fp16) {
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 }
 
-TEST(blas_kernels, addition_i_fp16) {
+TEST_F(blas_kernels, addition_i_fp16) {
 
   int batch = 12;
   int channel = 1;


### PR DESCRIPTION
## Dependency of the PR
None

## Commits to be reviewed in this PR


<details><summary>Fallback to cpu context when OpenCL device is not available in runtime</summary><br />

1. Don't register OpenCL context in Engine when initialization fails
2. Change fetching GPU context to make it optional by maybeGetRegisteredContext
3. In MemoryPool use calloc when OpenCL context is unavailable
4. Skip tests using OpenCL if OpenCL is unavailable

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Piotr Pokorski <p.pokorski@samsung.com>
</details>

### Summary

- Enable CPU fallback when OpenCL is enabled at compile-time, but unavailable during runtime (For example - no detected device)
- Don't register OpenCL context when OpenCL initialization fails
- Modify MemoryPool to use calloc when OpenCL is not available
- Change some OpenCL context fetching (by `getRegisteredContext`) to make it optional (`maybeGetRegisteredContext`)
- Skip tests when OpenCL is not available

Signed-off-by: Piotr Pokorski p.pokorski@samsung.com
