### PR TITLE
Lets make singletons great again.

### DIFF
--- a/Applications/Custom/LayerPlugin/layer_plugin_common_test.cpp
+++ b/Applications/Custom/LayerPlugin/layer_plugin_common_test.cpp
@@ -16,24 +16,24 @@
 #include <layer_node.h>
 
 TEST_P(LayerPluginCommonTest, DlRegisterOpen_p) {
-  ac.registerLayer(plugin_lib_name, NNTRAINER_PATH);
-  auto layer = ac.createObject<nntrainer::Layer>(layer_type_name);
+  ac->registerLayer(plugin_lib_name, NNTRAINER_PATH);
+  auto layer = ac->createObject<nntrainer::Layer>(layer_type_name);
 
   EXPECT_EQ(layer->getType(), layer_type_name);
 }
 
 TEST_P(LayerPluginCommonTest, DlRegisterWrongPath_n) {
-  EXPECT_THROW(ac.registerLayer("wrong_name.so"), std::invalid_argument);
+  EXPECT_THROW(ac->registerLayer("wrong_name.so"), std::invalid_argument);
 }
 
 TEST_P(LayerPluginCommonTest, DlRegisterDirectory_p) {
-  ac.registerPluggableFromDirectory(NNTRAINER_PATH);
-  auto layer = ac.createObject<nntrainer::Layer>(layer_type_name);
+  ac->registerPluggableFromDirectory(NNTRAINER_PATH);
+  auto layer = ac->createObject<nntrainer::Layer>(layer_type_name);
   EXPECT_EQ(layer->getType(), layer_type_name);
 }
 
 TEST_P(LayerPluginCommonTest, DlRegisterDirectory_n) {
-  EXPECT_THROW(ac.registerPluggableFromDirectory("wrong path"),
+  EXPECT_THROW(ac->registerPluggableFromDirectory("wrong path"),
                std::invalid_argument);
 }
 

--- a/Applications/Custom/LayerPlugin/layer_plugin_common_test.h
+++ b/Applications/Custom/LayerPlugin/layer_plugin_common_test.h
@@ -42,7 +42,7 @@ public:
     const auto &params = GetParam();
     plugin_lib_name = std::get<0>(params);
     layer_type_name = std::get<1>(params);
-    ac = nntrainer::AppContext();
+    ac = std::make_unique<nntrainer::AppContext>();
   };
 
   /**
@@ -52,8 +52,8 @@ public:
   virtual void TearDown(){};
 
 protected:
-  nntrainer::AppContext ac;    /**< AppContext          */
-  std::string plugin_lib_name; /**< plugin library name */
-  std::string layer_type_name; /**< layer type name */
+  std::unique_ptr<nntrainer::AppContext> ac; /**< AppContext          */
+  std::string plugin_lib_name;               /**< plugin library name */
+  std::string layer_type_name;               /**< layer type name */
 };
 #endif // __LAYER_PLUGIN_COMMON_TEST_H__

--- a/Applications/Custom/OptimizerPlugin/optimizer_plugin_common_test.cpp
+++ b/Applications/Custom/OptimizerPlugin/optimizer_plugin_common_test.cpp
@@ -17,24 +17,24 @@
 #include <optimizer.h>
 
 TEST_P(OptimizerPluginCommonTest, DlRegisterOpen_p) {
-  ac.registerOptimizer(plugin_lib_name, NNTRAINER_PATH);
-  auto optimizer = ac.createObject<nntrainer::Optimizer>(optimizer_type_name);
+  ac->registerOptimizer(plugin_lib_name, NNTRAINER_PATH);
+  auto optimizer = ac->createObject<nntrainer::Optimizer>(optimizer_type_name);
 
   EXPECT_EQ(optimizer->getType(), optimizer_type_name);
 }
 
 TEST_P(OptimizerPluginCommonTest, DlRegisterWrongPath_n) {
-  EXPECT_THROW(ac.registerOptimizer("wrong_name.so"), std::invalid_argument);
+  EXPECT_THROW(ac->registerOptimizer("wrong_name.so"), std::invalid_argument);
 }
 
 TEST_P(OptimizerPluginCommonTest, DlRegisterDirectory_p) {
-  ac.registerPluggableFromDirectory(NNTRAINER_PATH);
-  auto optimizer = ac.createObject<nntrainer::Optimizer>(optimizer_type_name);
+  ac->registerPluggableFromDirectory(NNTRAINER_PATH);
+  auto optimizer = ac->createObject<nntrainer::Optimizer>(optimizer_type_name);
   EXPECT_EQ(optimizer->getType(), optimizer_type_name);
 }
 
 TEST_P(OptimizerPluginCommonTest, DlRegisterDirectory_n) {
-  EXPECT_THROW(ac.registerPluggableFromDirectory("wrong path"),
+  EXPECT_THROW(ac->registerPluggableFromDirectory("wrong path"),
                std::invalid_argument);
 }
 

--- a/Applications/Custom/OptimizerPlugin/optimizer_plugin_common_test.h
+++ b/Applications/Custom/OptimizerPlugin/optimizer_plugin_common_test.h
@@ -95,7 +95,7 @@ public:
     const auto &params = GetParam();
     plugin_lib_name = std::get<0>(params);
     optimizer_type_name = std::get<1>(params);
-    ac = nntrainer::AppContext();
+    ac = std::make_unique<nntrainer::AppContext>();
   };
 
   /**
@@ -105,8 +105,8 @@ public:
   virtual void TearDown(){};
 
 protected:
-  nntrainer::AppContext ac;        /**< AppContext          */
-  std::string plugin_lib_name;     /**< plugin library name */
-  std::string optimizer_type_name; /**< optimizer type name */
+  std::unique_ptr<nntrainer::AppContext> ac; /**< AppContext          */
+  std::string plugin_lib_name;               /**< plugin library name */
+  std::string optimizer_type_name;           /**< optimizer type name */
 };
 #endif // __OPTIMIZER_PLUGIN_COMMON_TEST_H__

--- a/generate_def.py
+++ b/generate_def.py
@@ -1,0 +1,118 @@
+"""
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+@file build_windows_resources.py
+@date 16 July 2025
+@brief Extract symbols from obj files to build def file
+@author Grzegorz Kisala <gkisala@gmail.com>
+"""
+import sys
+import os
+import re
+import subprocess
+import argparse
+from collections import defaultdict
+
+def extract_syms(symfile, defs):
+    print('Opening ', symfile)
+    with open(symfile, 'r') as f:
+        for line in f:
+            if not line.strip():
+                continue
+            line = re.sub(r'notype \(\)', 'func', line)
+            line = re.sub(r'notype', 'data', line)
+            pieces = line.split()
+            
+            if not pieces[0] or not re.match('^[A-F0-9]{3,}$', pieces[0]):
+                continue
+
+            try:
+                symbol_name = pieces[6]
+            except IndexError:
+                continue
+            
+            if pieces[2] == "UNDEF":
+                continue
+            
+            if pieces[4] != "External":
+                continue
+            
+            if re.match('^@', symbol_name) or re.match('^[(]', symbol_name):
+                continue
+            
+            if re.match('^__real', symbol_name) or re.match('^__xmm', symbol_name):
+                continue
+            
+            if re.match('^__imp', symbol_name):
+                continue
+            
+            if re.search('NULL_THUNK_DATA$', symbol_name) or re.match('^__IMPORT_DESCRIPTOR', symbol_name) or re.match('^__NULL_IMPORT', symbol_name):
+                continue
+            
+            if re.match('^\\?\\?_C', symbol_name):
+                continue
+            
+            defs[symbol_name] = pieces[3]
+
+def writedef(deffile, defs):
+    with open(deffile, 'w') as fh:
+        fh.write("EXPORTS\n")
+        for k in sorted(defs.keys()):
+            isdata = defs[k] == 'data'
+
+            if isdata:
+                fh.write("  {} DATA\n".format(k))
+            else:
+                fh.write("  {}\n".format(k))
+
+REPO_DIR = os.path.abspath(os.path.dirname(__file__))
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--objects_dir', type=str, required=True, help='Path to directory with obj files')
+    parser.add_argument('--working_dir', type=str, required=True, help='Path to working directory')
+    return parser.parse_args()
+
+def run_command(args, cwd, exit_on_failure=True):
+    cmd = ' '.join(args)
+
+    print('Running command: {}'.format(cmd))
+
+    returncode = subprocess.run(args, cwd=cwd, check=exit_on_failure).returncode
+
+    if exit_on_failure and returncode != 0:
+        print('Application {} failed with returncode {}. Exiting...'.format(
+            args[0], returncode))
+        sys.exit(returncode)
+
+    return returncode
+
+def list_files(path, extension):
+    file_list = []
+    for file in os.listdir(path):
+        file_path = os.path.join(path, file)
+        if os.path.isfile(file_path) and file_path.endswith(extension):
+            file_list.append(file_path)
+    
+    return file_list
+
+def main():
+    args = get_args()
+
+    print("args.objects_dir: {}".format(args.objects_dir))
+    sym_file = os.path.join(args.working_dir, 'nntrainer.sym')
+    def_file = os.path.join(args.working_dir, 'nntrainer.def')
+    files = list_files(args.objects_dir, '.obj')
+
+    dumpbin_command = ['dumpbin', '/symbols', '/out:{}'.format(sym_file)] + files
+
+    run_command(dumpbin_command, REPO_DIR)
+
+    defs = defaultdict()
+    extract_syms(sym_file, defs)
+
+    writedef(def_file, defs)
+
+if __name__ == '__main__':
+    main()

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -234,196 +234,12 @@ std::mutex factory_mutex;
 
 std::once_flag global_app_context_init_flag;
 
-static void add_default_object(AppContext &ac) {
-  /// @note all layers should be added to the app_context to guarantee that
-  /// createLayer/createOptimizer class is created
-  using OptType = ml::train::OptimizerType;
-  ac.registerFactory(nntrainer::createOptimizer<SGD>, SGD::type, OptType::SGD);
-  ac.registerFactory(nntrainer::createOptimizer<Adam>, Adam::type,
-                     OptType::ADAM);
-  ac.registerFactory(nntrainer::createOptimizer<AdamW>, AdamW::type,
-                     OptType::ADAMW);
-  ac.registerFactory(AppContext::unknownFactory<nntrainer::Optimizer>,
-                     "unknown", OptType::UNKNOWN);
-
-  using LRType = LearningRateSchedulerType;
-  ac.registerFactory(
-    ml::train::createLearningRateScheduler<ConstantLearningRateScheduler>,
-    ConstantLearningRateScheduler::type, LRType::CONSTANT);
-  ac.registerFactory(
-    ml::train::createLearningRateScheduler<ExponentialLearningRateScheduler>,
-    ExponentialLearningRateScheduler::type, LRType::EXPONENTIAL);
-  ac.registerFactory(
-    ml::train::createLearningRateScheduler<StepLearningRateScheduler>,
-    StepLearningRateScheduler::type, LRType::STEP);
-  ac.registerFactory(ml::train::createLearningRateScheduler<
-                       CosineAnnealingLearningRateScheduler>,
-                     CosineAnnealingLearningRateScheduler::type,
-                     LRType::COSINE);
-  ac.registerFactory(
-    ml::train::createLearningRateScheduler<LinearLearningRateScheduler>,
-    LinearLearningRateScheduler::type, LRType::LINEAR);
-
-  using LayerType = ml::train::LayerType;
-  ac.registerFactory(nntrainer::createLayer<InputLayer>, InputLayer::type,
-                     LayerType::LAYER_IN);
-  ac.registerFactory(nntrainer::createLayer<WeightLayer>, WeightLayer::type,
-                     LayerType::LAYER_WEIGHT);
-  ac.registerFactory(nntrainer::createLayer<AddLayer>, AddLayer::type,
-                     LayerType::LAYER_ADD);
-  ac.registerFactory(nntrainer::createLayer<SubtractLayer>, SubtractLayer::type,
-                     LayerType::LAYER_SUBTRACT);
-  ac.registerFactory(nntrainer::createLayer<MultiplyLayer>, MultiplyLayer::type,
-                     LayerType::LAYER_MULTIPLY);
-  ac.registerFactory(nntrainer::createLayer<DivideLayer>, DivideLayer::type,
-                     LayerType::LAYER_DIVIDE);
-  ac.registerFactory(nntrainer::createLayer<PowLayer>, PowLayer::type,
-                     LayerType::LAYER_POW);
-  ac.registerFactory(nntrainer::createLayer<SQRTLayer>, SQRTLayer::type,
-                     LayerType::LAYER_SQRT);
-  ac.registerFactory(nntrainer::createLayer<SineLayer>, SineLayer::type,
-                     LayerType::LAYER_SINE);
-  ac.registerFactory(nntrainer::createLayer<CosineLayer>, CosineLayer::type,
-                     LayerType::LAYER_COSINE);
-  ac.registerFactory(nntrainer::createLayer<TangentLayer>, TangentLayer::type,
-                     LayerType::LAYER_TANGENT);
-  ac.registerFactory(nntrainer::createLayer<MatMulLayer>, MatMulLayer::type,
-                     LayerType::LAYER_MATMUL);
-  ac.registerFactory(nntrainer::createLayer<NegLayer>, NegLayer::type,
-                     LayerType::LAYER_NEG);
-  ac.registerFactory(nntrainer::createLayer<FullyConnectedLayer>,
-                     FullyConnectedLayer::type, LayerType::LAYER_FC);
-  ac.registerFactory(nntrainer::createLayer<BatchNormalizationLayer>,
-                     BatchNormalizationLayer::type, LayerType::LAYER_BN);
-  ac.registerFactory(nntrainer::createLayer<LayerNormalizationLayer>,
-                     LayerNormalizationLayer::type,
-                     LayerType::LAYER_LAYER_NORMALIZATION);
-  ac.registerFactory(nntrainer::createLayer<Conv2DLayer>, Conv2DLayer::type,
-                     LayerType::LAYER_CONV2D);
-  ac.registerFactory(nntrainer::createLayer<Conv2DTransposeLayer>,
-                     Conv2DTransposeLayer::type,
-                     LayerType::LAYER_CONV2D_TRANSPOSE);
-  ac.registerFactory(nntrainer::createLayer<Conv1DLayer>, Conv1DLayer::type,
-                     LayerType::LAYER_CONV1D);
-  ac.registerFactory(nntrainer::createLayer<Pooling2DLayer>,
-                     Pooling2DLayer::type, LayerType::LAYER_POOLING2D);
-  ac.registerFactory(nntrainer::createLayer<FlattenLayer>, FlattenLayer::type,
-                     LayerType::LAYER_FLATTEN);
-  ac.registerFactory(nntrainer::createLayer<ReshapeLayer>, ReshapeLayer::type,
-                     LayerType::LAYER_RESHAPE);
-  ac.registerFactory(nntrainer::createLayer<ActivationLayer>,
-                     ActivationLayer::type, LayerType::LAYER_ACTIVATION);
-  ac.registerFactory(nntrainer::createLayer<AdditionLayer>, AdditionLayer::type,
-                     LayerType::LAYER_ADDITION);
-  ac.registerFactory(nntrainer::createLayer<ConcatLayer>, ConcatLayer::type,
-                     LayerType::LAYER_CONCAT);
-  ac.registerFactory(nntrainer::createLayer<MultiOutLayer>, MultiOutLayer::type,
-                     LayerType::LAYER_MULTIOUT);
-  ac.registerFactory(nntrainer::createLayer<EmbeddingLayer>,
-                     EmbeddingLayer::type, LayerType::LAYER_EMBEDDING);
-  ac.registerFactory(nntrainer::createLayer<RNNLayer>, RNNLayer::type,
-                     LayerType::LAYER_RNN);
-  ac.registerFactory(nntrainer::createLayer<RNNCellLayer>, RNNCellLayer::type,
-                     LayerType::LAYER_RNNCELL);
-  ac.registerFactory(nntrainer::createLayer<LSTMLayer>, LSTMLayer::type,
-                     LayerType::LAYER_LSTM);
-  ac.registerFactory(nntrainer::createLayer<LSTMCellLayer>, LSTMCellLayer::type,
-                     LayerType::LAYER_LSTMCELL);
-  ac.registerFactory(nntrainer::createLayer<ZoneoutLSTMCellLayer>,
-                     ZoneoutLSTMCellLayer::type,
-                     LayerType::LAYER_ZONEOUT_LSTMCELL);
-  ac.registerFactory(nntrainer::createLayer<SplitLayer>, SplitLayer::type,
-                     LayerType::LAYER_SPLIT);
-  ac.registerFactory(nntrainer::createLayer<GRULayer>, GRULayer::type,
-                     LayerType::LAYER_GRU);
-  ac.registerFactory(nntrainer::createLayer<GRUCellLayer>, GRUCellLayer::type,
-                     LayerType::LAYER_GRUCELL);
-  ac.registerFactory(nntrainer::createLayer<PermuteLayer>, PermuteLayer::type,
-                     LayerType::LAYER_PERMUTE);
-  ac.registerFactory(nntrainer::createLayer<DropOutLayer>, DropOutLayer::type,
-                     LayerType::LAYER_DROPOUT);
-  ac.registerFactory(nntrainer::createLayer<AttentionLayer>,
-                     AttentionLayer::type, LayerType::LAYER_ATTENTION);
-  ac.registerFactory(nntrainer::createLayer<MoLAttentionLayer>,
-                     MoLAttentionLayer::type, LayerType::LAYER_MOL_ATTENTION);
-  ac.registerFactory(nntrainer::createLayer<MultiHeadAttentionLayer>,
-                     MultiHeadAttentionLayer::type,
-                     LayerType::LAYER_MULTI_HEAD_ATTENTION);
-  ac.registerFactory(nntrainer::createLayer<ReduceMeanLayer>,
-                     ReduceMeanLayer::type, LayerType::LAYER_REDUCE_MEAN);
-  ac.registerFactory(nntrainer::createLayer<PositionalEncodingLayer>,
-                     PositionalEncodingLayer::type,
-                     LayerType::LAYER_POSITIONAL_ENCODING);
-  ac.registerFactory(nntrainer::createLayer<IdentityLayer>, IdentityLayer::type,
-                     LayerType::LAYER_IDENTITY);
-  ac.registerFactory(nntrainer::createLayer<Upsample2dLayer>,
-                     Upsample2dLayer::type, LayerType::LAYER_UPSAMPLE2D);
-
-  ac.registerFactory(nntrainer::createLayer<ChannelShuffle>,
-                     ChannelShuffle::type, LayerType::LAYER_CHANNEL_SHUFFLE);
-
-#ifdef ENABLE_NNSTREAMER_BACKBONE
-  ac.registerFactory(nntrainer::createLayer<NNStreamerLayer>,
-                     NNStreamerLayer::type,
-                     LayerType::LAYER_BACKBONE_NNSTREAMER);
-#endif
-#ifdef ENABLE_TFLITE_BACKBONE
-  ac.registerFactory(nntrainer::createLayer<TfLiteLayer>, TfLiteLayer::type,
-                     LayerType::LAYER_BACKBONE_TFLITE);
-#endif
-  ac.registerFactory(nntrainer::createLayer<CentroidKNN>, CentroidKNN::type,
-                     LayerType::LAYER_CENTROID_KNN);
-
-  /** preprocess layers */
-  ac.registerFactory(nntrainer::createLayer<PreprocessFlipLayer>,
-                     PreprocessFlipLayer::type,
-                     LayerType::LAYER_PREPROCESS_FLIP);
-  ac.registerFactory(nntrainer::createLayer<PreprocessTranslateLayer>,
-                     PreprocessTranslateLayer::type,
-                     LayerType::LAYER_PREPROCESS_TRANSLATE);
-  ac.registerFactory(nntrainer::createLayer<PreprocessL2NormLayer>,
-                     PreprocessL2NormLayer::type,
-                     LayerType::LAYER_PREPROCESS_L2NORM);
-
-  /** register losses */
-  ac.registerFactory(nntrainer::createLayer<MSELossLayer>, MSELossLayer::type,
-                     LayerType::LAYER_LOSS_MSE);
-  ac.registerFactory(nntrainer::createLayer<CrossEntropySigmoidLossLayer>,
-                     CrossEntropySigmoidLossLayer::type,
-                     LayerType::LAYER_LOSS_CROSS_ENTROPY_SIGMOID);
-  ac.registerFactory(nntrainer::createLayer<CrossEntropySoftmaxLossLayer>,
-                     CrossEntropySoftmaxLossLayer::type,
-                     LayerType::LAYER_LOSS_CROSS_ENTROPY_SOFTMAX);
-  ac.registerFactory(nntrainer::createLayer<ConstantDerivativeLossLayer>,
-                     ConstantDerivativeLossLayer::type,
-                     LayerType::LAYER_LOSS_CONSTANT_DERIVATIVE);
-
-  ac.registerFactory(nntrainer::createLayer<TimeDistLayer>, TimeDistLayer::type,
-                     LayerType::LAYER_TIME_DIST);
-
-  ac.registerFactory(AppContext::unknownFactory<nntrainer::Layer>, "unknown",
-                     LayerType::LAYER_UNKNOWN);
-}
-
-static void add_extension_object(AppContext &ac) {
-  auto dir_list = getPluginPaths();
-
-  for (auto &path : dir_list) {
-    try {
-      ac.registerPluggableFromDirectory(path);
-    } catch (std::exception &e) {
-      ml_logw("tried to register extension from %s but failed, reason: %s",
-              path.c_str(), e.what());
-    }
-  }
-}
-
-static void registerer(AppContext &ac) noexcept {
+void AppContext::initialize() noexcept {
   try {
-    ac.setMemAllocator(std::make_shared<MemAllocator>());
+    setMemAllocator(std::make_shared<MemAllocator>());
 
-    add_default_object(ac);
-    add_extension_object(ac);
+    add_default_object();
+    add_extension_object();
   } catch (std::exception &e) {
     ml_loge("registering layers failed!!, reason: %s", e.what());
   } catch (...) {
@@ -431,9 +247,184 @@ static void registerer(AppContext &ac) noexcept {
   }
 };
 
-AppContext &AppContext::Global() {
-  registerer(*this);
-  return *this;
+void AppContext::add_default_object() {
+  /// @note all layers should be added to the app_context to guarantee that
+  /// createLayer/createOptimizer class is created
+  using OptType = ml::train::OptimizerType;
+  registerFactory(nntrainer::createOptimizer<SGD>, SGD::type, OptType::SGD);
+  registerFactory(nntrainer::createOptimizer<Adam>, Adam::type, OptType::ADAM);
+  registerFactory(nntrainer::createOptimizer<AdamW>, AdamW::type,
+                  OptType::ADAMW);
+  registerFactory(AppContext::unknownFactory<nntrainer::Optimizer>, "unknown",
+                  OptType::UNKNOWN);
+
+  using LRType = LearningRateSchedulerType;
+  registerFactory(
+    ml::train::createLearningRateScheduler<ConstantLearningRateScheduler>,
+    ConstantLearningRateScheduler::type, LRType::CONSTANT);
+  registerFactory(
+    ml::train::createLearningRateScheduler<ExponentialLearningRateScheduler>,
+    ExponentialLearningRateScheduler::type, LRType::EXPONENTIAL);
+  registerFactory(
+    ml::train::createLearningRateScheduler<StepLearningRateScheduler>,
+    StepLearningRateScheduler::type, LRType::STEP);
+  registerFactory(ml::train::createLearningRateScheduler<
+                    CosineAnnealingLearningRateScheduler>,
+                  CosineAnnealingLearningRateScheduler::type, LRType::COSINE);
+  registerFactory(
+    ml::train::createLearningRateScheduler<LinearLearningRateScheduler>,
+    LinearLearningRateScheduler::type, LRType::LINEAR);
+
+  using LayerType = ml::train::LayerType;
+  registerFactory(nntrainer::createLayer<InputLayer>, InputLayer::type,
+                  LayerType::LAYER_IN);
+  registerFactory(nntrainer::createLayer<WeightLayer>, WeightLayer::type,
+                  LayerType::LAYER_WEIGHT);
+  registerFactory(nntrainer::createLayer<AddLayer>, AddLayer::type,
+                  LayerType::LAYER_ADD);
+  registerFactory(nntrainer::createLayer<SubtractLayer>, SubtractLayer::type,
+                  LayerType::LAYER_SUBTRACT);
+  registerFactory(nntrainer::createLayer<MultiplyLayer>, MultiplyLayer::type,
+                  LayerType::LAYER_MULTIPLY);
+  registerFactory(nntrainer::createLayer<DivideLayer>, DivideLayer::type,
+                  LayerType::LAYER_DIVIDE);
+  registerFactory(nntrainer::createLayer<PowLayer>, PowLayer::type,
+                  LayerType::LAYER_POW);
+  registerFactory(nntrainer::createLayer<SQRTLayer>, SQRTLayer::type,
+                  LayerType::LAYER_SQRT);
+  registerFactory(nntrainer::createLayer<SineLayer>, SineLayer::type,
+                  LayerType::LAYER_SINE);
+  registerFactory(nntrainer::createLayer<CosineLayer>, CosineLayer::type,
+                  LayerType::LAYER_COSINE);
+  registerFactory(nntrainer::createLayer<TangentLayer>, TangentLayer::type,
+                  LayerType::LAYER_TANGENT);
+  registerFactory(nntrainer::createLayer<MatMulLayer>, MatMulLayer::type,
+                  LayerType::LAYER_MATMUL);
+  registerFactory(nntrainer::createLayer<NegLayer>, NegLayer::type,
+                  LayerType::LAYER_NEG);
+  registerFactory(nntrainer::createLayer<FullyConnectedLayer>,
+                  FullyConnectedLayer::type, LayerType::LAYER_FC);
+  registerFactory(nntrainer::createLayer<BatchNormalizationLayer>,
+                  BatchNormalizationLayer::type, LayerType::LAYER_BN);
+  registerFactory(nntrainer::createLayer<LayerNormalizationLayer>,
+                  LayerNormalizationLayer::type,
+                  LayerType::LAYER_LAYER_NORMALIZATION);
+  registerFactory(nntrainer::createLayer<Conv2DLayer>, Conv2DLayer::type,
+                  LayerType::LAYER_CONV2D);
+  registerFactory(nntrainer::createLayer<Conv2DTransposeLayer>,
+                  Conv2DTransposeLayer::type,
+                  LayerType::LAYER_CONV2D_TRANSPOSE);
+  registerFactory(nntrainer::createLayer<Conv1DLayer>, Conv1DLayer::type,
+                  LayerType::LAYER_CONV1D);
+  registerFactory(nntrainer::createLayer<Pooling2DLayer>, Pooling2DLayer::type,
+                  LayerType::LAYER_POOLING2D);
+  registerFactory(nntrainer::createLayer<FlattenLayer>, FlattenLayer::type,
+                  LayerType::LAYER_FLATTEN);
+  registerFactory(nntrainer::createLayer<ReshapeLayer>, ReshapeLayer::type,
+                  LayerType::LAYER_RESHAPE);
+  registerFactory(nntrainer::createLayer<ActivationLayer>,
+                  ActivationLayer::type, LayerType::LAYER_ACTIVATION);
+  registerFactory(nntrainer::createLayer<AdditionLayer>, AdditionLayer::type,
+                  LayerType::LAYER_ADDITION);
+  registerFactory(nntrainer::createLayer<ConcatLayer>, ConcatLayer::type,
+                  LayerType::LAYER_CONCAT);
+  registerFactory(nntrainer::createLayer<MultiOutLayer>, MultiOutLayer::type,
+                  LayerType::LAYER_MULTIOUT);
+  registerFactory(nntrainer::createLayer<EmbeddingLayer>, EmbeddingLayer::type,
+                  LayerType::LAYER_EMBEDDING);
+  registerFactory(nntrainer::createLayer<RNNLayer>, RNNLayer::type,
+                  LayerType::LAYER_RNN);
+  registerFactory(nntrainer::createLayer<RNNCellLayer>, RNNCellLayer::type,
+                  LayerType::LAYER_RNNCELL);
+  registerFactory(nntrainer::createLayer<LSTMLayer>, LSTMLayer::type,
+                  LayerType::LAYER_LSTM);
+  registerFactory(nntrainer::createLayer<LSTMCellLayer>, LSTMCellLayer::type,
+                  LayerType::LAYER_LSTMCELL);
+  registerFactory(nntrainer::createLayer<ZoneoutLSTMCellLayer>,
+                  ZoneoutLSTMCellLayer::type,
+                  LayerType::LAYER_ZONEOUT_LSTMCELL);
+  registerFactory(nntrainer::createLayer<SplitLayer>, SplitLayer::type,
+                  LayerType::LAYER_SPLIT);
+  registerFactory(nntrainer::createLayer<GRULayer>, GRULayer::type,
+                  LayerType::LAYER_GRU);
+  registerFactory(nntrainer::createLayer<GRUCellLayer>, GRUCellLayer::type,
+                  LayerType::LAYER_GRUCELL);
+  registerFactory(nntrainer::createLayer<PermuteLayer>, PermuteLayer::type,
+                  LayerType::LAYER_PERMUTE);
+  registerFactory(nntrainer::createLayer<DropOutLayer>, DropOutLayer::type,
+                  LayerType::LAYER_DROPOUT);
+  registerFactory(nntrainer::createLayer<AttentionLayer>, AttentionLayer::type,
+                  LayerType::LAYER_ATTENTION);
+  registerFactory(nntrainer::createLayer<MoLAttentionLayer>,
+                  MoLAttentionLayer::type, LayerType::LAYER_MOL_ATTENTION);
+  registerFactory(nntrainer::createLayer<MultiHeadAttentionLayer>,
+                  MultiHeadAttentionLayer::type,
+                  LayerType::LAYER_MULTI_HEAD_ATTENTION);
+  registerFactory(nntrainer::createLayer<ReduceMeanLayer>,
+                  ReduceMeanLayer::type, LayerType::LAYER_REDUCE_MEAN);
+  registerFactory(nntrainer::createLayer<PositionalEncodingLayer>,
+                  PositionalEncodingLayer::type,
+                  LayerType::LAYER_POSITIONAL_ENCODING);
+  registerFactory(nntrainer::createLayer<IdentityLayer>, IdentityLayer::type,
+                  LayerType::LAYER_IDENTITY);
+  registerFactory(nntrainer::createLayer<Upsample2dLayer>,
+                  Upsample2dLayer::type, LayerType::LAYER_UPSAMPLE2D);
+
+  registerFactory(nntrainer::createLayer<ChannelShuffle>, ChannelShuffle::type,
+                  LayerType::LAYER_CHANNEL_SHUFFLE);
+
+#ifdef ENABLE_NNSTREAMER_BACKBONE
+  registerFactory(nntrainer::createLayer<NNStreamerLayer>,
+                  NNStreamerLayer::type, LayerType::LAYER_BACKBONE_NNSTREAMER);
+#endif
+#ifdef ENABLE_TFLITE_BACKBONE
+  registerFactory(nntrainer::createLayer<TfLiteLayer>, TfLiteLayer::type,
+                  LayerType::LAYER_BACKBONE_TFLITE);
+#endif
+  registerFactory(nntrainer::createLayer<CentroidKNN>, CentroidKNN::type,
+                  LayerType::LAYER_CENTROID_KNN);
+
+  /** preprocess layers */
+  registerFactory(nntrainer::createLayer<PreprocessFlipLayer>,
+                  PreprocessFlipLayer::type, LayerType::LAYER_PREPROCESS_FLIP);
+  registerFactory(nntrainer::createLayer<PreprocessTranslateLayer>,
+                  PreprocessTranslateLayer::type,
+                  LayerType::LAYER_PREPROCESS_TRANSLATE);
+  registerFactory(nntrainer::createLayer<PreprocessL2NormLayer>,
+                  PreprocessL2NormLayer::type,
+                  LayerType::LAYER_PREPROCESS_L2NORM);
+
+  /** register losses */
+  registerFactory(nntrainer::createLayer<MSELossLayer>, MSELossLayer::type,
+                  LayerType::LAYER_LOSS_MSE);
+  registerFactory(nntrainer::createLayer<CrossEntropySigmoidLossLayer>,
+                  CrossEntropySigmoidLossLayer::type,
+                  LayerType::LAYER_LOSS_CROSS_ENTROPY_SIGMOID);
+  registerFactory(nntrainer::createLayer<CrossEntropySoftmaxLossLayer>,
+                  CrossEntropySoftmaxLossLayer::type,
+                  LayerType::LAYER_LOSS_CROSS_ENTROPY_SOFTMAX);
+  registerFactory(nntrainer::createLayer<ConstantDerivativeLossLayer>,
+                  ConstantDerivativeLossLayer::type,
+                  LayerType::LAYER_LOSS_CONSTANT_DERIVATIVE);
+
+  registerFactory(nntrainer::createLayer<TimeDistLayer>, TimeDistLayer::type,
+                  LayerType::LAYER_TIME_DIST);
+
+  registerFactory(AppContext::unknownFactory<nntrainer::Layer>, "unknown",
+                  LayerType::LAYER_UNKNOWN);
+}
+
+void AppContext::add_extension_object() {
+  auto dir_list = getPluginPaths();
+
+  for (auto &path : dir_list) {
+    try {
+      registerPluggableFromDirectory(path);
+    } catch (std::exception &e) {
+      ml_logw("tried to register extension from %s but failed, reason: %s",
+              path.c_str(), e.what());
+    }
+  }
 }
 
 void AppContext::setWorkingDirectory(const std::string &base) {

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -35,6 +35,8 @@
 #include <mem_allocator.h>
 #include <nntrainer_error.h>
 
+#include "utils/singleton.h"
+
 namespace nntrainer {
 
 extern std::mutex factory_mutex;
@@ -44,7 +46,7 @@ namespace {} // namespace
  * @class AppContext contains user-dependent configuration
  * @brief App
  */
-class AppContext : public Context {
+class AppContext : public Context, public Singleton<AppContext> {
 public:
   /**
    * @brief   Default constructor
@@ -55,14 +57,6 @@ public:
    * @brief   Default destructor
    */
   ~AppContext() override = default;
-
-  /**
-   *
-   * @brief Get Global app context.
-   *
-   * @return AppContext&
-   */
-  AppContext &Global() override;
 
   /**
    * @brief Set Working Directory for a relative path. working directory is set
@@ -298,6 +292,15 @@ public:
   }
 
 private:
+  /**
+   * @brief   Overriden initialization function
+   */
+  void initialize() noexcept override;
+
+  void add_default_object();
+
+  void add_extension_object();
+
   FactoryMap<nntrainer::Optimizer, nntrainer::Layer,
              ml::train::LearningRateScheduler>
     factory_map;

--- a/nntrainer/cl_buffer_manager.cpp
+++ b/nntrainer/cl_buffer_manager.cpp
@@ -14,11 +14,6 @@
 
 namespace nntrainer {
 
-ClBufferManager &ClBufferManager::getInstance() {
-  static ClBufferManager instance;
-  return instance;
-}
-
 // to-do: Implementation to be updated with array of Buffer objects if required
 // fp16 Buffer objects to be added in future
 void ClBufferManager::initBuffers() {

--- a/nntrainer/cl_buffer_manager.h
+++ b/nntrainer/cl_buffer_manager.h
@@ -20,6 +20,8 @@
 
 #include <nntrainer_log.h>
 
+#include "utils/singleton.h"
+
 namespace nntrainer {
 
 /**
@@ -27,45 +29,27 @@ namespace nntrainer {
  * @brief Support for Buffer management
  */
 
-class ClBufferManager {
+class ClBufferManager : public Singleton<ClBufferManager> {
 
 private:
-  /**
-   * @brief Private constructor to prevent object creation
-   *
-   */
-  ClBufferManager() :
-    inBufferA(nullptr),
-    inBufferB(nullptr),
-    inBufferC(nullptr),
-    outBufferA(nullptr),
-    outBufferB(nullptr){};
-
   /**
    * @brief OpenCl context global instance
    *
    */
-  opencl::ContextManager &context_inst_ = opencl::ContextManager::GetInstance();
+  opencl::ContextManager &context_inst_ = opencl::ContextManager::Global();
 
   /**
    * @brief Buffer size in bytes preset (256 mebibytes)
    */
   const size_t buffer_size_bytes = 8192 * 8192 * sizeof(float);
 
-  opencl::Buffer *inBufferA;
-  opencl::Buffer *inBufferB;
-  opencl::Buffer *inBufferC;
-  opencl::Buffer *outBufferA;
-  opencl::Buffer *outBufferB;
+  opencl::Buffer *inBufferA = nullptr;
+  opencl::Buffer *inBufferB = nullptr;
+  opencl::Buffer *inBufferC = nullptr;
+  opencl::Buffer *outBufferA = nullptr;
+  opencl::Buffer *outBufferB = nullptr;
 
 public:
-  /**
-   * @brief Get Global ClBufferManager.
-   *
-   * @return ClBufferManager&
-   */
-  static ClBufferManager &getInstance();
-
   /**
    * @brief Initialize Buffer objects.
    */

--- a/nntrainer/cl_context.h
+++ b/nntrainer/cl_context.h
@@ -37,6 +37,8 @@
 #include <opencl_kernel.h>
 #include <opencl_program.h>
 
+#include "utils/singleton.h"
+
 namespace nntrainer {
 
 extern std::mutex cl_factory_mutex;
@@ -46,7 +48,7 @@ extern std::mutex cl_factory_mutex;
  * @brief OpenCL support for app context
  */
 
-class ClContext : public Context {
+class ClContext : public Context, public Singleton<ClContext> {
 public:
   using SharedPtrClKernel = std::shared_ptr<opencl::Kernel>;
 
@@ -55,11 +57,11 @@ public:
 
   // getting static instance of commandqueue, opencl context and buffermanager
   opencl::CommandQueueManager &command_queue_inst_ =
-    opencl::CommandQueueManager::GetInstance();
+    opencl::CommandQueueManager::Global();
 
-  opencl::ContextManager &context_inst_ = opencl::ContextManager::GetInstance();
+  opencl::ContextManager &context_inst_ = opencl::ContextManager::Global();
 
-  ClBufferManager &clbuffInstance = ClBufferManager::getInstance();
+  ClBufferManager &clbuffInstance = ClBufferManager::Global();
 
   /**
    * @brief   Default constructor
@@ -76,13 +78,6 @@ public:
       context_inst_.ReleaseContext();
     }
   };
-
-  /**
-   * @brief Get Global cl context.
-   *
-   * @return ClContext&
-   */
-  ClContext &Global() override;
 
   /**
    * @brief Factory register function, use this function to register custom
@@ -243,6 +238,13 @@ public:
   }
 
 private:
+  /**
+   * @brief   Overriden initialization function
+   */
+  void initialize() noexcept override;
+
+  void add_default_object();
+
   // flag to check opencl commandqueue and context inititalization
   bool cl_initialized = false;
 

--- a/nntrainer/context.h
+++ b/nntrainer/context.h
@@ -101,14 +101,6 @@ public:
 
   /**
    *
-   * @brief Get Global qnn context.
-   *
-   * @return Context&
-   */
-  virtual Context &Global() = 0;
-
-  /**
-   *
    * @brief Initialization of Context.
    *
    * @return status &

--- a/nntrainer/engine.h
+++ b/nntrainer/engine.h
@@ -34,6 +34,8 @@
 #include <cl_context.h>
 #endif
 
+#include "utils/singleton.h"
+
 namespace nntrainer {
 
 extern std::mutex engine_mutex;
@@ -43,10 +45,8 @@ namespace {} // namespace
  * @class Engine contains user-dependent configuration
  * @brief App
  */
-class Engine {
+class Engine : public Singleton<Engine> {
 protected:
-  static void registerer(Engine &eg) noexcept;
-
   static const int RegisterContextMax = 16;
   static nntrainer::Context *nntrainerRegisteredContext[RegisterContextMax];
   /// Valgrind complains memory leaks with context registered because
@@ -56,7 +56,9 @@ protected:
   /// let's not bother modify all the related functions, but waste
   /// a few words.
 
-  static void add_default_object(Engine &eg);
+  void initialize() noexcept override;
+
+  void add_default_object();
 
   void registerContext(std::string name, nntrainer::Context *context) {
     const std::lock_guard<std::mutex> lock(engine_mutex);
@@ -92,30 +94,6 @@ public:
    * @brief   Default Destructor
    */
   ~Engine() = default;
-
-  /**
-   * @brief Deleting copy constructor
-   *
-   */
-  Engine(const Engine &) = delete;
-
-  /**
-   * @brief Deleting assignment operator
-   *
-   */
-  Engine &operator=(const Engine &) = delete;
-
-  /**
-   * @brief Deleting move constructor
-   *
-   */
-  Engine(Engine &&) = delete;
-
-  /**
-   * @brief Deleting move assignment operator
-   *
-   */
-  Engine &operator=(Engine &&) = delete;
 
   /**
    * @brief register a Context from a shared library
@@ -154,14 +132,6 @@ public:
   getAllocators() {
     return allocator;
   }
-
-  /**
-   *
-   * @brief Get Global Engine which is Static.
-   *
-   * @return Engine&
-   */
-  static Engine &Global();
 
   /**
    *

--- a/nntrainer/layers/cl_layers/addition_layer_cl.h
+++ b/nntrainer/layers/cl_layers/addition_layer_cl.h
@@ -100,7 +100,9 @@ public:
    * function simply returns `true` because `AdditionLayerCl` does not rely on
    * the specific kernels for the layer.
    */
-  static bool registerClKernels() { return true; };
+  static bool registerClKernels([[maybe_unused]] ClContext &cl_context) {
+    return true;
+  };
 
   static constexpr const char *type = "addition";
 

--- a/nntrainer/layers/cl_layers/concat_cl.cpp
+++ b/nntrainer/layers/cl_layers/concat_cl.cpp
@@ -32,7 +32,7 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 static constexpr size_t INPUT_IDX_1 = 0;
 static constexpr size_t INPUT_IDX_2 = 1;
 
-bool ConcatLayerCl::registerClKernels() {
+bool ConcatLayerCl::registerClKernels(ClContext &cl_context) {
   auto &layer_kernel_ptrs = getLayerKernelPtrs();
 
   // check if already registered
@@ -45,24 +45,24 @@ bool ConcatLayerCl::registerClKernels() {
 
     ClContext::SharedPtrClKernel kernel_concat_ptr = nullptr;
 
-    kernel_concat_ptr = global_cl_context->registerClKernel(
-      getConcatClAxis1Kernel(), "concat_cl_axis1");
+    kernel_concat_ptr =
+      cl_context.registerClKernel(getConcatClAxis1Kernel(), "concat_cl_axis1");
     if (!kernel_concat_ptr) {
       ml_loge("OpenCL Error: Fail to register concat_cl_axis1 kernel");
       break;
     }
     layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
 
-    kernel_concat_ptr = global_cl_context->registerClKernel(
-      getConcatClAxis2Kernel(), "concat_cl_axis2");
+    kernel_concat_ptr =
+      cl_context.registerClKernel(getConcatClAxis2Kernel(), "concat_cl_axis2");
     if (!kernel_concat_ptr) {
       ml_loge("OpenCL Error: Fail to register concat_cl_axis2 kernel");
       break;
     }
     layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
 
-    kernel_concat_ptr = global_cl_context->registerClKernel(
-      getConcatClAxis3Kernel(), "concat_cl_axis3");
+    kernel_concat_ptr =
+      cl_context.registerClKernel(getConcatClAxis3Kernel(), "concat_cl_axis3");
     if (!kernel_concat_ptr) {
       ml_loge("OpenCL Error: Fail to register concat_cl_axis3 kernel");
       break;
@@ -70,7 +70,7 @@ bool ConcatLayerCl::registerClKernels() {
     layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
 
 #ifdef ENABLE_FP16
-    kernel_concat_ptr = global_cl_context->registerClKernel(
+    kernel_concat_ptr = cl_context.registerClKernel(
       getConcatClAxis1KernelFP16(), "concat_cl_axis1_fp16");
     if (!kernel_concat_ptr) {
       ml_loge("OpenCL Error: Fail to register concat_cl_axis1_fp16 kernel");
@@ -78,7 +78,7 @@ bool ConcatLayerCl::registerClKernels() {
     }
     layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
 
-    kernel_concat_ptr = global_cl_context->registerClKernel(
+    kernel_concat_ptr = cl_context.registerClKernel(
       getConcatClAxis2KernelFP16(), "concat_cl_axis2_fp16");
     if (!kernel_concat_ptr) {
       ml_loge("OpenCL Error: Fail to register concat_cl_axis2_fp16 kernel");
@@ -86,7 +86,7 @@ bool ConcatLayerCl::registerClKernels() {
     }
     layer_kernel_ptrs.emplace_back(kernel_concat_ptr);
 
-    kernel_concat_ptr = global_cl_context->registerClKernel(
+    kernel_concat_ptr = cl_context.registerClKernel(
       getConcatClAxis3KernelFP16(), "concat_cl_axis3_fp16");
     if (!kernel_concat_ptr) {
       ml_loge("OpenCL Error: Fail to register concat_cl_axis3_fp16 kernel");
@@ -230,6 +230,10 @@ void ConcatLayerCl::concat_cl_axis3(const float *matAdata,
 
   bool result = false;
 
+  auto *global_cl_context =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
   do {
 
     const auto &kernel_concat_ptr =
@@ -345,6 +349,10 @@ void ConcatLayerCl::concat_cl_axis2(const float *matAdata,
 
   bool result = false;
 
+  auto *global_cl_context =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
   do {
 
     const auto &kernel_concat_ptr =
@@ -458,6 +466,10 @@ void ConcatLayerCl::concat_cl_axis1(const float *matAdata,
                                     unsigned int input2_channels) {
 
   bool result = false;
+
+  auto *global_cl_context =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
 
   do {
     const auto &kernel_concat_ptr =
@@ -574,6 +586,10 @@ void ConcatLayerCl::concat_cl_axis3_fp16(const _FP16 *matAdata,
 
   bool result = false;
 
+  auto *global_cl_context =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
   do {
 
     const auto &kernel_concat_ptr =
@@ -689,6 +705,10 @@ void ConcatLayerCl::concat_cl_axis2_fp16(const _FP16 *matAdata,
 
   bool result = false;
 
+  auto *global_cl_context =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
   do {
     const auto &kernel_concat_ptr =
       getLayerKernelPtrs()[Kernels::CONCAT_CL_AXIS2_FP16];
@@ -801,6 +821,10 @@ void ConcatLayerCl::concat_cl_axis1_fp16(const _FP16 *matAdata,
                                          unsigned int input2_channels) {
 
   bool result = false;
+
+  auto *global_cl_context =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
 
   do {
 

--- a/nntrainer/layers/cl_layers/concat_cl.h
+++ b/nntrainer/layers/cl_layers/concat_cl.h
@@ -104,7 +104,7 @@ public:
   /**
    * @brief registerClKernels
    */
-  static bool registerClKernels();
+  static bool registerClKernels(ClContext &cl_context);
 
   static constexpr const char *type = "concat";
 

--- a/nntrainer/layers/cl_layers/fc_layer_cl.h
+++ b/nntrainer/layers/cl_layers/fc_layer_cl.h
@@ -101,7 +101,9 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
-  static bool registerClKernels() { return true; };
+  static bool registerClKernels([[maybe_unused]] ClContext &cl_context) {
+    return true;
+  };
 
   static constexpr const char *type = "fully_connected";
 

--- a/nntrainer/layers/cl_layers/layer_impl_cl.h
+++ b/nntrainer/layers/cl_layers/layer_impl_cl.h
@@ -53,18 +53,6 @@ public:
    * @parma[in] rhs LayerImplCl to be moved.
    */
   LayerImplCl &operator=(LayerImplCl &&rhs) = default;
-
-  /**
-   * @brief     register ClKernels for this layer
-   * registerClKernels() is called in global ClContext.
-   */
-  static bool registerClKernels();
-
-protected:
-  inline static ClContext *global_cl_context =
-    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  inline static ClBufferManager &clbuffInstance =
-    ClBufferManager::getInstance();
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/cl_layers/reshape_cl.h
+++ b/nntrainer/layers/cl_layers/reshape_cl.h
@@ -117,7 +117,7 @@ public:
   /**
    * @brief registerClKernels
    */
-  static bool registerClKernels();
+  static bool registerClKernels(ClContext &cl_context);
 
   /**
    * @brief     copy computation

--- a/nntrainer/layers/cl_layers/rmsnorm_layer_cl.h
+++ b/nntrainer/layers/cl_layers/rmsnorm_layer_cl.h
@@ -128,7 +128,7 @@ public:
   /**
    * @brief registerClKernels
    */
-  static bool registerClKernels();
+  static bool registerClKernels(ClContext &cl_context);
 
   static constexpr const char *type = "rmsnorm";
 

--- a/nntrainer/layers/cl_layers/swiglu_cl.h
+++ b/nntrainer/layers/cl_layers/swiglu_cl.h
@@ -126,7 +126,7 @@ public:
   /**
    * @brief     Register OpenCL kernels for SwiGLU layer. This should be called
    */
-  static bool registerClKernels();
+  static bool registerClKernels(ClContext &cl_context);
 
 private:
   std::tuple<props::Print> swiglu_props; /**< swiglu layer properties : unit -

--- a/nntrainer/layers/cl_layers/transpose_cl.h
+++ b/nntrainer/layers/cl_layers/transpose_cl.h
@@ -89,7 +89,9 @@ public:
    * function simply returns `true` because `TransposeLayerCl` does not rely on
    * the specific kernels for the layer.
    */
-  static bool registerClKernels() { return true; };
+  static bool registerClKernels([[maybe_unused]] ClContext &cl_context) {
+    return true;
+  };
 
   static constexpr const char *type = "transpose";
 

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -97,13 +97,6 @@ if get_option('platform') == 'android'
   nntrainer_dep = declare_dependency(include_directories: nntrainer_inc)
 else
   # Build libraries
-  nntrainer_shared = shared_library('nntrainer',
-    nntrainer_sources,
-    dependencies: nntrainer_base_deps,
-    include_directories: nntrainer_inc,
-    install: true,
-    install_dir: nntrainer_libdir
-  )
 
   nntrainer_static = static_library('nntrainer',
     nntrainer_sources,
@@ -113,13 +106,34 @@ else
     install_dir: nntrainer_libdir
   )
 
-  if host_machine.system() == 'windows'
-    nntrainer_lib = nntrainer_static
+  if get_option('platform') == 'windows'
+    nntrainer_def = custom_target('nntrainer_def',
+    command : ['python', meson.source_root() / 'generate_def.py', '--objects_dir', meson.build_root() / 'nntrainer' / 'libnntrainer.a.p', '--working_dir', meson.current_build_dir()],
+    output: 'nntrainer.def',
+    depends: nntrainer_static,
+    )
+
+    nntrainer_shared = shared_library('nntrainer',
+      nntrainer_sources,
+      dependencies: nntrainer_base_deps,
+      include_directories: nntrainer_inc,
+      install: true,
+      install_dir: nntrainer_libdir,
+      vs_module_defs : nntrainer_def
+    )
   else
-    nntrainer_lib = nntrainer_shared
-    if get_option('default_library') == 'static'
-      nntrainer_lib = nntrainer_static
-    endif
+    nntrainer_shared = shared_library('nntrainer',
+      nntrainer_sources,
+      dependencies: nntrainer_base_deps,
+      include_directories: nntrainer_inc,
+      install: true,
+      install_dir: nntrainer_libdir
+    )
+  endif
+
+  nntrainer_lib = nntrainer_shared
+  if get_option('default_library') == 'static'
+    nntrainer_lib = nntrainer_static
   endif
 
   nntrainer_dep = declare_dependency(link_with: nntrainer_lib,
@@ -132,4 +146,3 @@ endif
 install_headers(nntrainer_headers,
   install_dir: nntrainer_includedir,
 )
-

--- a/nntrainer/models/dynamic_training_optimization.cpp
+++ b/nntrainer/models/dynamic_training_optimization.cpp
@@ -135,13 +135,4 @@ float DynamicTrainingOptimization::reduceByNorm(Tensor const &ratio) {
   return l2norm / std::sqrt(ratio.size());
 }
 
-/**< Different types of reduce operations */
-const std::string DynamicTrainingOptimization::dft_opt_max = "max";
-const std::string DynamicTrainingOptimization::dft_opt_norm = "norm";
-
-const std::string DynamicTrainingOptimization::dft_opt_mode_gradient =
-  "gradient";
-const std::string DynamicTrainingOptimization::dft_opt_mode_derivative =
-  "derivative";
-
 } /* namespace nntrainer */

--- a/nntrainer/models/dynamic_training_optimization.h
+++ b/nntrainer/models/dynamic_training_optimization.h
@@ -165,12 +165,12 @@ public:
                     int iteration);
 
   /**< Different types of reduce operations */
-  static const std::string dft_opt_max;
-  static const std::string dft_opt_norm;
+  static constexpr const char *dft_opt_max = "max";
+  static constexpr const char *dft_opt_norm = "norm";
 
   /**< Different types of optimization modes */
-  static const std::string dft_opt_mode_gradient;
-  static const std::string dft_opt_mode_derivative;
+  static constexpr const char *dft_opt_mode_gradient = "gradient";
+  static constexpr const char *dft_opt_mode_derivative = "derivative";
 
 private:
   std::mt19937 rng; /**< random number generator */

--- a/nntrainer/nntrainer_logger.cpp
+++ b/nntrainer/nntrainer_logger.cpp
@@ -68,7 +68,7 @@ Logger::Cleanup::~Cleanup() {
 Logger::~Logger() {
   try {
     outputstream.close();
-  } catch(...) {
+  } catch (...) {
     std::cerr << "Error closing the log file\n";
   }
 }
@@ -141,6 +141,8 @@ void Logger::log(const std::string &message,
   outputstream << ss.str() << " " << message << std::endl;
 }
 
+} /* namespace nntrainer */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -164,7 +166,7 @@ void __nntrainer_log_print(nntrainer_loglevel loglevel,
   std::string ss = std::string(formatted.get());
 
 #if defined(__LOGGING__)
-  Logger::instance().log(ss, loglevel);
+  nntrainer::Logger::instance().log(ss, loglevel);
 #else
 
 #if defined(DEBUG)
@@ -186,4 +188,3 @@ void __nntrainer_log_print(nntrainer_loglevel loglevel,
 #ifdef __cplusplus
 }
 #endif
-} /* namespace nntrainer */

--- a/nntrainer/opencl/opencl_buffer.h
+++ b/nntrainer/opencl/opencl_buffer.h
@@ -17,6 +17,7 @@
 #include "CL/cl.h"
 #include "opencl_command_queue_manager.h"
 #include "opencl_context_manager.h"
+#include "utils/noncopyable.h"
 
 namespace nntrainer::opencl {
 
@@ -24,7 +25,7 @@ namespace nntrainer::opencl {
  * @class Buffer contains wrappers for managing OpenCL buffer
  * @brief OpenCL wrapper for buffer
  */
-class Buffer {
+class Buffer : public Noncopyable {
   /**
    * @brief cl_mem object to store the buffer
    *
@@ -71,18 +72,6 @@ public:
    * @return Buffer&
    */
   Buffer &operator=(Buffer &&buffer);
-
-  /**
-   * @brief Deleting copy constructor
-   *
-   */
-  Buffer(const Buffer &) = delete;
-
-  /**
-   * @brief Deleting operator overload
-   *
-   */
-  Buffer &operator=(const Buffer &) = delete;
 
   /**
    * @brief Destroy the Buffer object

--- a/nntrainer/opencl/opencl_command_queue_manager.cpp
+++ b/nntrainer/opencl/opencl_command_queue_manager.cpp
@@ -21,16 +21,6 @@
 namespace nntrainer::opencl {
 
 /**
- * @brief Get the global instance
- *
- * @return CommandQueueManager global instance
- */
-CommandQueueManager &CommandQueueManager::GetInstance() {
-  static CommandQueueManager instance;
-  return instance;
-}
-
-/**
  * @brief Create a Command Queue object
  *
  * @return true if creation is successful or false otherwise
@@ -44,7 +34,7 @@ bool CommandQueueManager::CreateCommandQueue() {
   }
 
   int error_code;
-  ContextManager &context_instance = ContextManager::GetInstance();
+  ContextManager &context_instance = ContextManager::Global();
 
   // OpenCL context is created
   cl_context context = context_instance.GetContext();
@@ -90,7 +80,7 @@ CommandQueueManager::~CommandQueueManager() {
 
     // releasing OpenCL context since it has been created by
     // CommandQueueManager::CreateCommandQueue
-    ContextManager::GetInstance().ReleaseContext();
+    ContextManager::Global().ReleaseContext();
   }
 }
 

--- a/nntrainer/opencl/opencl_command_queue_manager.h
+++ b/nntrainer/opencl/opencl_command_queue_manager.h
@@ -16,6 +16,7 @@
 
 #include "CL/cl.h"
 #include "opencl_kernel.h"
+#include "utils/singleton.h"
 #include <memory>
 
 namespace nntrainer::opencl {
@@ -26,7 +27,7 @@ namespace nntrainer::opencl {
  * @brief OpenCL command queue wrapper
  *
  */
-class CommandQueueManager {
+class CommandQueueManager : public Singleton<CommandQueueManager> {
 
   /**
    * @brief cl_command_queue instance
@@ -34,20 +35,7 @@ class CommandQueueManager {
    */
   cl_command_queue command_queue_{nullptr};
 
-  /**
-   * @brief Private constructor to prevent object creation
-   *
-   */
-  CommandQueueManager(){};
-
 public:
-  /**
-   * @brief Get the global instance
-   *
-   * @return CommandQueueManager global instance
-   */
-  static CommandQueueManager &GetInstance();
-
   /**
    * @brief Create a Command Queue object
    *
@@ -209,18 +197,6 @@ public:
    * @return const cl_command_queue
    */
   const cl_command_queue GetCommandQueue();
-
-  /**
-   * @brief Deleting operator overload
-   *
-   */
-  void operator=(CommandQueueManager const &) = delete;
-
-  /**
-   * @brief Deleting copy constructor
-   *
-   */
-  CommandQueueManager(CommandQueueManager const &) = delete;
 
   /**
    * @brief Destroy the Command Queue Manager object

--- a/nntrainer/opencl/opencl_context_manager.cpp
+++ b/nntrainer/opencl/opencl_context_manager.cpp
@@ -26,16 +26,6 @@
 namespace nntrainer::opencl {
 
 /**
- * @brief Get the global instance object
- *
- * @return ContextManager global instance
- */
-ContextManager &ContextManager::GetInstance() {
-  static ContextManager instance;
-  return instance;
-}
-
-/**
  * @brief Get the OpenCL context object
  *
  * @return const cl_context

--- a/nntrainer/opencl/opencl_context_manager.h
+++ b/nntrainer/opencl/opencl_context_manager.h
@@ -18,6 +18,8 @@
 
 #include "CL/cl.h"
 
+#include "utils/singleton.h"
+
 namespace nntrainer::opencl {
 
 /**
@@ -25,7 +27,7 @@ namespace nntrainer::opencl {
  * @brief OpenCL context wrapper
  *
  */
-class ContextManager {
+class ContextManager : public Singleton<ContextManager> {
   cl_platform_id platform_id_{nullptr};
   cl_device_id device_id_{nullptr};
   cl_context context_{nullptr};
@@ -44,20 +46,7 @@ class ContextManager {
    */
   bool CreateCLContext();
 
-  /**
-   * @brief Private constructor to prevent object creation
-   *
-   */
-  ContextManager(){};
-
 public:
-  /**
-   * @brief Get the global instance object
-   *
-   * @return ContextManager global instance
-   */
-  static ContextManager &GetInstance();
-
   /**
    * @brief Get the OpenCL context object
    *
@@ -92,18 +81,6 @@ public:
    * @param svm_ptr pointer to the SVM memory to be deallocated
    */
   void releaseSVMRegion(void *svm_ptr);
-
-  /**
-   * @brief Deleting operator overload
-   *
-   */
-  void operator=(ContextManager const &) = delete;
-
-  /**
-   * @brief Deleting copy constructor
-   *
-   */
-  ContextManager(ContextManager const &) = delete;
 
   /**
    * @brief Destroy the Context Manager object

--- a/nntrainer/opencl/opencl_op_interface.h
+++ b/nntrainer/opencl/opencl_op_interface.h
@@ -38,8 +38,8 @@ class GpuCLOpInterface {
 protected:
   bool initialized_;
   Kernel kernel_;
-  ContextManager &context_inst_ = ContextManager::GetInstance();
-  CommandQueueManager &command_queue_inst_ = CommandQueueManager::GetInstance();
+  ContextManager &context_inst_ = ContextManager::Global();
+  CommandQueueManager &command_queue_inst_ = CommandQueueManager::Global();
 
   /**
    * @brief Initialize OpenCL kernel

--- a/nntrainer/tensor/cl_operations/attention_kernels.h
+++ b/nntrainer/tensor/cl_operations/attention_kernels.h
@@ -23,11 +23,6 @@
 
 namespace nntrainer {
 
-// get global cl_context to use in kernels
-static ClContext *attention_cc =
-  static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-static ClBufferManager &clbuffInstance = ClBufferManager::getInstance();
-
 /**
  * @brief     Rotary Embedding process
  * @param[in] in _FP16 * input

--- a/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
@@ -26,10 +26,15 @@ void rotary_emb_cl(_FP16 *in, _FP16 *out,
                    unsigned int in_size, unsigned int out_size) {
 
   bool result = false;
+
+  auto *cl_context =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &cl_buffer_manager = ClBufferManager::Global();
+
   do {
     ClContext::SharedPtrClKernel kernel_rotaryEmb_fp16_ptr =
-      attention_cc->registerClKernel(getRotaryEmbClKernelFP16(),
-                                     "rotary_emb_cl_fp16");
+      cl_context->registerClKernel(getRotaryEmbClKernelFP16(),
+                                   "rotary_emb_cl_fp16");
     if (!kernel_rotaryEmb_fp16_ptr) {
       break;
     }
@@ -55,86 +60,86 @@ void rotary_emb_cl(_FP16 *in, _FP16 *out,
       freqs_sin_flat.insert(freqs_sin_flat.end(), row.begin(), row.end());
     }
 
-    result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      attention_cc->command_queue_inst_, dim1_size, in);
+    result = cl_buffer_manager.getInBufferA()->WriteDataRegion(
+      cl_context->command_queue_inst_, dim1_size, in);
     if (!result) {
       printf("Failed to write input data\n");
       break;
     }
 
-    result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      attention_cc->command_queue_inst_, dim2_size, out);
+    result = cl_buffer_manager.getOutBufferA()->WriteDataRegion(
+      cl_context->command_queue_inst_, dim2_size, out);
     if (!result) {
       printf("Failed to write output data\n");
       break;
     }
 
-    result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      attention_cc->command_queue_inst_, dim5_size, freqs_cos_flat.data());
+    result = cl_buffer_manager.getInBufferB()->WriteDataRegion(
+      cl_context->command_queue_inst_, dim5_size, freqs_cos_flat.data());
     if (!result) {
       printf("Failed to write freqs cos data\n");
       break;
     }
 
-    result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      attention_cc->command_queue_inst_, dim6_size, freqs_sin_flat.data(), 0,
+    result = cl_buffer_manager.getInBufferB()->WriteDataRegion(
+      cl_context->command_queue_inst_, dim6_size, freqs_sin_flat.data(), 0,
       dim5_size);
     if (!result) {
       printf("Failed to write freqs sin data\n");
       break;
     }
 
-    result = clbuffInstance.getInBufferC()->WriteDataRegion(
-      attention_cc->command_queue_inst_, dim3_size, cos_.data());
+    result = cl_buffer_manager.getInBufferC()->WriteDataRegion(
+      cl_context->command_queue_inst_, dim3_size, cos_.data());
     if (!result) {
       printf("Failed to write cos data\n");
       break;
     }
 
-    result = clbuffInstance.getInBufferC()->WriteDataRegion(
-      attention_cc->command_queue_inst_, dim4_size, sin_.data(), 0, dim3_size);
+    result = cl_buffer_manager.getInBufferC()->WriteDataRegion(
+      cl_context->command_queue_inst_, dim4_size, sin_.data(), 0, dim3_size);
     if (!result) {
       printf("Failed to write sin data\n");
       break;
     }
 
     result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, cl_buffer_manager.getInBufferA(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set inputA argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      1, cl_buffer_manager.getOutBufferA(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set inOutRes argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
-      2, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      2, cl_buffer_manager.getInBufferB(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set freqs_cosBuf argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
-      3, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      3, cl_buffer_manager.getInBufferB(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set freqs_sinBuf argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
-      4, clbuffInstance.getInBufferC(), sizeof(cl_mem));
+      4, cl_buffer_manager.getInBufferC(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set cosBuf argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
-      5, clbuffInstance.getInBufferC(), sizeof(cl_mem));
+      5, cl_buffer_manager.getInBufferC(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set sinBuf argument\n");
       break;
@@ -215,15 +220,15 @@ void rotary_emb_cl(_FP16 *in, _FP16 *out,
     const int work_groups_count[3] = {(int)batch, (int)channel, 1};
     /// @todo: create a group size by device & input
     const int work_group_size[3] = {1, 1, 1}; // test-value
-    result = attention_cc->command_queue_inst_.DispatchCommand(
+    result = cl_context->command_queue_inst_.DispatchCommand(
       kernel_rotaryEmb_fp16_ptr, work_groups_count, work_group_size);
     if (!result) {
       printf("Failed to dispatch command\n");
       break;
     }
 
-    result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      attention_cc->command_queue_inst_, dim2_size, out);
+    result = cl_buffer_manager.getOutBufferA()->ReadDataRegion(
+      cl_context->command_queue_inst_, dim2_size, out);
     if (!result) {
       printf("Failed to read data\n");
       break;

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -22,6 +22,9 @@ void sgemv_q6_k_cl(void *matAdata, float *vecXdata, float *vecYdata,
                    unsigned int M, unsigned int N) {
   bool result = false;
 
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+
   ClContext::SharedPtrClKernel kernel_q6_k_sgemv_ptr;
 
   kernel_q6_k_sgemv_ptr =
@@ -183,7 +186,7 @@ void sgemv_q6_k_cl(void *matAdata, float *vecXdata, float *vecYdata,
   /// @todo: create a group size by device & input
   const int work_group_size[3] = {32, 1, 1};
 
-  result = opencl::CommandQueueManager::GetInstance().DispatchCommand(
+  result = opencl::CommandQueueManager::Global().DispatchCommand(
     kernel_q6_k_sgemv_ptr, work_groups_count, work_group_size);
   if (!result) {
     ml_loge("Failed to dispatch kernel q6_k_sgemv");
@@ -206,6 +209,10 @@ void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
               unsigned int lda) {
 
   bool result = false;
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
 
   do {
     ClContext::SharedPtrClKernel kernel_sgemv_ptr;
@@ -275,7 +282,7 @@ void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
     /// @todo: create a group size by device & input
     const int work_group_size[3] = {1, 1, 1};
 
-    result = opencl::CommandQueueManager::GetInstance().DispatchCommand(
+    result = opencl::CommandQueueManager::Global().DispatchCommand(
       kernel_sgemv_ptr, work_groups_count, work_group_size);
     if (!result) {
       break;
@@ -293,6 +300,10 @@ void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
 float dot_cl(const float *vecAdata, const float *vecXdata, unsigned int dim1) {
 
   bool result = false;
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
 
   float cl_ret = 0;
 
@@ -384,6 +395,10 @@ void sgemm_cl(bool TransA, bool TransB, const float *A, const float *B,
 
   bool result = false;
 
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
   do {
     ClContext::SharedPtrClKernel kernel_sgemm_ptr =
       blas_cc->registerClKernel(sgemm_cl_kernel_, kernel_func_);
@@ -473,6 +488,10 @@ void addition_cl(const float *input, float *res, unsigned int size_input,
 
   bool result = false;
 
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
   do {
     ClContext::SharedPtrClKernel kernel_addition_ptr =
       blas_cc->registerClKernel(getAdditionClKernel(), "addition_cl");
@@ -539,6 +558,10 @@ void addition_cl(const float *input, float *res, unsigned int size_input,
 void sscal_cl(float *X, const unsigned int N, const float alpha) {
   bool result = false;
 
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
   do {
     ClContext::SharedPtrClKernel kernel_ptr =
       blas_cc->registerClKernel(getSscalClKernel(), "sscal_cl");
@@ -591,6 +614,10 @@ void transpose_cl_axis(const float *in, float *res,
                        unsigned int input_width, unsigned int axis) {
 
   bool result = false;
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
 
   do {
     ClContext::SharedPtrClKernel kernel_transpose_ptr;

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -24,11 +24,6 @@
 
 namespace nntrainer {
 
-// get global cl_context to use in kernels
-static ClContext *blas_cc =
-  static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-static ClBufferManager &clbuffInstance = ClBufferManager::getInstance();
-
 /**
  * @brief     Q6_K sgemv computation : Y = A*X
  * @param[in] matAdata void * for Matrix A

--- a/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
@@ -22,6 +22,10 @@ void sgemv_cl(const _FP16 *matAdata, const _FP16 *vecXdata, _FP16 *vecYdata,
 
   bool result = false;
 
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
   do {
     ClContext::SharedPtrClKernel kernel_sgemv_fp16_ptr;
 
@@ -108,6 +112,10 @@ void sgemv_cl(const _FP16 *matAdata, const _FP16 *vecXdata, _FP16 *vecYdata,
 _FP16 dot_cl(const _FP16 *vecAdata, const _FP16 *vecXdata, unsigned int dim1) {
 
   bool result = false;
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
 
   _FP16 cl_ret = 0;
 
@@ -200,6 +208,10 @@ void sgemm_cl(bool TransA, bool TransB, const _FP16 *A, const _FP16 *B,
 
   bool result = false;
 
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
   do {
     ClContext::SharedPtrClKernel kernel_sgemm_fp16_ptr =
       blas_cc->registerClKernel(sgemm_cl_kernel_fp16_, kernel_func_);
@@ -290,6 +302,10 @@ void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
 
   bool result = false;
 
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
   do {
     ClContext::SharedPtrClKernel kernel_addition_fp16_ptr =
       blas_cc->registerClKernel(getAdditionClKernelFP16(), "addition_cl_fp16");
@@ -358,6 +374,10 @@ void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
 void sscal_cl(_FP16 *X, const unsigned int N, const float alpha) {
   bool result = false;
 
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
+
   do {
     ClContext::SharedPtrClKernel kernel_sscal_fp16_ptr =
       blas_cc->registerClKernel(getHscalClKernel(), "sscal_cl_fp16");
@@ -411,6 +431,10 @@ void transpose_cl_axis(const _FP16 *in, _FP16 *res,
                        unsigned int input_width, unsigned int axis) {
 
   bool result = false;
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clbuffInstance = ClBufferManager::Global();
 
   do {
     ClContext::SharedPtrClKernel kernel_transpose_fp_16_ptr;

--- a/nntrainer/tensor/cl_operations/clblast_interface.cpp
+++ b/nntrainer/tensor/cl_operations/clblast_interface.cpp
@@ -20,6 +20,11 @@ namespace nntrainer {
 
 void scal_cl(const unsigned int N, const float alpha, float *X,
              unsigned int incX) {
+  auto *clblast_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clBuffManagerInst = ClBufferManager::Global();
+  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+
   clBuffManagerInst.getOutBufferA()->WriteDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), X);
 
@@ -32,6 +37,11 @@ void scal_cl(const unsigned int N, const float alpha, float *X,
 
 void copy_cl(const unsigned int N, const float *X, float *Y, unsigned int incX,
              unsigned int incY) {
+  auto *clblast_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clBuffManagerInst = ClBufferManager::Global();
+  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), X);
 
@@ -45,6 +55,11 @@ void copy_cl(const unsigned int N, const float *X, float *Y, unsigned int incX,
 
 void axpy_cl(const unsigned int N, const float alpha, const float *X, float *Y,
              unsigned int incX, unsigned int incY) {
+  auto *clblast_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clBuffManagerInst = ClBufferManager::Global();
+  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), X);
 
@@ -61,6 +76,11 @@ void axpy_cl(const unsigned int N, const float alpha, const float *X, float *Y,
 
 float dot_cl(const unsigned int N, const float *X, const float *Y,
              unsigned int incX, unsigned int incY) {
+  auto *clblast_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clBuffManagerInst = ClBufferManager::Global();
+  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), X);
 
@@ -79,6 +99,11 @@ float dot_cl(const unsigned int N, const float *X, const float *Y,
 }
 
 float nrm2_cl(const unsigned int N, const float *X, unsigned int incX) {
+  auto *clblast_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clBuffManagerInst = ClBufferManager::Global();
+  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), X);
 
@@ -94,6 +119,11 @@ float nrm2_cl(const unsigned int N, const float *X, unsigned int incX) {
 }
 
 float asum_cl(const unsigned int N, const float *X, unsigned int incX) {
+  auto *clblast_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clBuffManagerInst = ClBufferManager::Global();
+  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), X);
 
@@ -109,6 +139,11 @@ float asum_cl(const unsigned int N, const float *X, unsigned int incX) {
 }
 
 int amax_cl(const unsigned int N, const float *X, unsigned int incX) {
+  auto *clblast_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clBuffManagerInst = ClBufferManager::Global();
+  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), X);
 
@@ -124,6 +159,11 @@ int amax_cl(const unsigned int N, const float *X, unsigned int incX) {
 }
 
 int amin_cl(const unsigned int N, const float *X, unsigned int incX) {
+  auto *clblast_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clBuffManagerInst = ClBufferManager::Global();
+  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), X);
 
@@ -150,6 +190,11 @@ void gemm_cl(const unsigned int layout, bool TransA, bool TransB,
              const float alpha, const float *A, const unsigned int lda,
              const float *B, const unsigned int ldb, const float beta, float *C,
              const unsigned int ldc) {
+  auto *clblast_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  auto &clBuffManagerInst = ClBufferManager::Global();
+  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+
   clblast::Transpose transA =
     (TransA) ? clblast::Transpose::kYes : clblast::Transpose::kNo;
   clblast::Transpose transB =

--- a/nntrainer/tensor/cl_operations/clblast_interface.h
+++ b/nntrainer/tensor/cl_operations/clblast_interface.h
@@ -17,13 +17,6 @@
 
 namespace nntrainer {
 
-static ClContext *clblast_cc =
-  static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-static ClBufferManager &clBuffManagerInst = ClBufferManager::getInstance();
-
-static cl_command_queue command_queue =
-  clblast_cc->command_queue_inst_.GetCommandQueue();
-
 /**
  * @brief Multiplies n elements of vector x by a scalar constant alpha.
  * @param N Number of elements

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface_bs_threadpool.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface_bs_threadpool.cpp
@@ -133,13 +133,12 @@ static inline void __ggml_q4_0_8x8_q8_0_GEMM_GEMM(
   const unsigned int M, const unsigned int N, const unsigned int K,
   const float *A, const unsigned int lda, const void *B, const unsigned int ldb,
   float *C, const unsigned int ldc) {
-  auto &bs_thread_pool = ThreadPoolManager::getInstance();
+  auto &bs_thread_pool = ThreadPoolManager::Global().getThreadPool();
   unsigned int blocks_per_4_rows = (K + QK8_0 - 1) / QK8_0;
   unsigned int qa_4_rows_size = sizeof(block_q8_0x4) * blocks_per_4_rows;
   const size_t qa_row_size = (sizeof(block_q8_0) * K) / QK8_0;
   unsigned int M4 = ((M - M % 4) / 4);
   int B_step = sizeof(block_q4_0) * (K / QK4_0);
-
   unsigned int qa_size = qa_4_rows_size * (((M >> 2) << 2) / 4 + 1);
   std::vector<char> QA = std::vector<char>(qa_size);
 
@@ -241,13 +240,12 @@ static inline void __ggml_q4_K_8x8_q8_K_GEMM_GEMM(
   const unsigned int M, const unsigned int N, const unsigned int K,
   const float *A, const unsigned int lda, const void *B, const unsigned int ldb,
   float *C, const unsigned int ldc) {
-  auto &bs_thread_pool = ThreadPoolManager::getInstance();
+  auto &bs_thread_pool = ThreadPoolManager::Global().getThreadPool();
   unsigned int blocks_per_4_rows = (K + QK_K - 1) / QK_K;
   unsigned int qa_4_rows_size = sizeof(block_q8_Kx4) * blocks_per_4_rows;
   const size_t qa_row_size = (sizeof(block_q8_K) * K) / QK_K;
   unsigned int M4 = ((M - M % 4) / 4);
   int B_step = sizeof(block_q4_K) * (K / QK_K);
-
   unsigned int qa_size = qa_4_rows_size * (((M >> 2) << 2) / 4 + 1);
   std::vector<char> QA = std::vector<char>(qa_size);
 

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -70,11 +70,15 @@ void FloatTensor::allocate() {
     MemoryData *mem_data;
 
 #ifdef ENABLE_OPENCL
+    auto *blas_cc =
+      static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
     if (blas_cc != nullptr) {
       mem_data = new MemoryData(blas_cc->context_inst_.createSVMRegion(
         dim.getDataLen() * sizeof(float)));
 
       data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
+        auto *blas_cc = static_cast<ClContext *>(
+          Engine::Global().getRegisteredContext("gpu"));
         blas_cc->context_inst_.releaseSVMRegion(
           mem_data->template getAddr<float>());
       });

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -36,6 +36,9 @@
 #include <var_grad.h>
 #include <weight.h>
 
+#include "utils/noncopyable.h"
+#include "utils/nonmovable.h"
+
 namespace nntrainer {
 using ExecutionMode = ml::train::ExecutionMode;
 
@@ -43,7 +46,7 @@ using ExecutionMode = ml::train::ExecutionMode;
  * @class MMappedMemory
  * @brief Memory Handler, that has mmaped memory with a file descriptor
  */
-class MMapedMemory {
+class MMapedMemory : public Noncopyable, public Nonmovable {
 public:
   /**
    * @brief Construct a new MMapedMemory object
@@ -58,18 +61,6 @@ public:
    *
    */
   ~MMapedMemory() noexcept;
-
-  /**
-   * @brief Construct a new MMapedMemory object (deleted)
-   *
-   */
-  MMapedMemory(const MMapedMemory &) = delete;
-
-  /**
-   * @brief Copy assignment operator (deleted)
-   *
-   */
-  MMapedMemory &operator=(const MMapedMemory &) = delete;
 
   /**
    * @brief Get the File descriptor.
@@ -110,7 +101,7 @@ private:
  * @class   Manager
  * @brief   manager of nntrainer
  */
-class Manager {
+class Manager : public Noncopyable, public Nonmovable {
 
 public:
   /**
@@ -156,18 +147,6 @@ public:
     tensor_format(tensor_format_),
     tensor_dtype(split(tensor_dtype_, getRegex("\\-"))),
     exec_mode(exec_mode_) {}
-
-  /**
-   * @brief Construct a new Manager object (deleted)
-   *
-   */
-  Manager(const Manager &) = delete;
-
-  /**
-   * @brief Copy Assign a new Manager object (deleted)
-   *
-   */
-  Manager &operator=(const Manager &) = delete;
 
   /**
    * @brief Move Construct a new Manager object

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -168,7 +168,9 @@ void MemoryPool::allocate() {
 #else
 
 #ifdef ENABLE_OPENCL
-  mem_pool = cl_context_->context_inst_.createSVMRegion(pool_size);
+  auto *cl_context =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+  mem_pool = cl_context->context_inst_.createSVMRegion(pool_size);
 
   if (mem_pool == nullptr) {
     throw std::runtime_error("Failed to allocate SVM memory pool of size " +
@@ -268,7 +270,9 @@ std::shared_ptr<MemoryData> MemoryPool::getMemory(unsigned int idx) {
 void MemoryPool::deallocate() {
   if (mem_pool != nullptr) {
 #ifdef ENABLE_OPENCL
-    cl_context_->context_inst_.releaseSVMRegion(mem_pool);
+    auto *cl_context =
+      static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+    cl_context->context_inst_.releaseSVMRegion(mem_pool);
 #else
     free(mem_pool);
 #endif

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -70,11 +70,6 @@ enum {
 
 namespace nntrainer {
 
-#ifdef ENABLE_OPENCL
-static ClContext *cl_context_ =
-  static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-#endif
-
 /**
  * @class   MemoryPool
  * @brief   Memory Pool provides a common pool for all the tensor memory

--- a/nntrainer/utils/bs_thread_pool_manager.cpp
+++ b/nntrainer/utils/bs_thread_pool_manager.cpp
@@ -23,7 +23,6 @@ namespace nntrainer {
  *
  * @return BS::thread_pool<>
  */
-BS::thread_pool<> ThreadPoolManager::pool(std::thread::hardware_concurrency());
 
 std::size_t ThreadPoolManager::select_k_quant_thread_count(unsigned int M,
                                                            unsigned int N,

--- a/nntrainer/utils/bs_thread_pool_manager.hpp
+++ b/nntrainer/utils/bs_thread_pool_manager.hpp
@@ -15,30 +15,15 @@
 
 #pragma once
 #include "bs_thread_pool.h"
+#include "utils/singleton.h"
 
 namespace nntrainer {
 /**
  * @brief ThreadPoolManager is a singleton class that manages a thread pool
  *
  */
-class ThreadPoolManager {
-protected:
-  static BS::thread_pool<> pool;
-
+class ThreadPoolManager : public Singleton<ThreadPoolManager> {
 public:
-  // Delete copy and move constructors and assignment operators
-  /**
-   * @brief Construct a new Thread Pool Manager object
-   *
-   */
-  ThreadPoolManager(const ThreadPoolManager &) = delete;
-
-  /**
-   * @brief Construct a new Thread Pool Manager object
-   *
-   */
-  ThreadPoolManager(ThreadPoolManager &&) = delete;
-
   /**
    * @brief Select optimal number of thread to use in K-quantized GEMM and GEMV
    *
@@ -50,24 +35,21 @@ public:
   std::size_t select_k_quant_thread_count(unsigned int M, unsigned int N,
                                           unsigned int K);
 
-  /**
-   * @brief Static method to access the single instance
-   *
-   * @return BS::thread_pool<>&
-   */
-  static BS::thread_pool<> &getInstance() { return pool; }
+  BS::thread_pool<> &getThreadPool() { return pool_; }
 
-private:
   /**
    * @brief Construct a new Thread Pool Manager object
    *
    */
-  ThreadPoolManager() = default;
+  ThreadPoolManager() : pool_(std::thread::hardware_concurrency()) {}
   /**
    * @brief Destroy the Thread Pool Manager object
    *
    */
   ~ThreadPoolManager() = default;
+
+private:
+  BS::thread_pool<> pool_;
 };
 } // namespace nntrainer
 

--- a/nntrainer/utils/noncopyable.h
+++ b/nntrainer/utils/noncopyable.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   noncopyable.h
+ * @date   11 July 2025
+ * @brief  Base class preventing copying of derived classes
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Grzegorz Kisala <g.kisala@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __NNTRAINER_NONCOPYABLE_H__
+#define __NNTRAINER_NONCOPYABLE_H__
+
+namespace nntrainer {
+
+/**
+ * @class   Noncopyable
+ * @brief   Use it as base class to prevent copy operations
+ */
+class Noncopyable {
+public:
+  /**
+   * @brief   Default constructor
+   */
+  Noncopyable() = default;
+
+  /**
+   * @brief Deleting copy constructor
+   *
+   */
+  Noncopyable(const Noncopyable &) = delete;
+
+  /**
+   * @brief Deleting assignment operator
+   *
+   */
+  Noncopyable &operator=(const Noncopyable &) = delete;
+
+  /**
+   * @brief   Default destructor
+   */
+  virtual ~Noncopyable() = default;
+};
+
+} // namespace nntrainer
+
+#endif // __NNTRAINER_NONCOPYABLE_H__

--- a/nntrainer/utils/nonmovable.h
+++ b/nntrainer/utils/nonmovable.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   nonmovable.h
+ * @date   11 July 2025
+ * @brief  Base class preventing moving of derived classes
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Grzegorz Kisala <g.kisala@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __NNTRAINER_NONMOVABLE_H__
+#define __NNTRAINER_NONMOVABLE_H__
+
+namespace nntrainer {
+
+/**
+ * @class   Nonmovable
+ * @brief   Use it as base class to prevent move operations
+ */
+class Nonmovable {
+public:
+  /**
+   * @brief   Default constructor
+   */
+  Nonmovable() = default;
+
+  /**
+   * @brief Deleting move constructor
+   *
+   */
+  Nonmovable(Nonmovable &&) = delete;
+
+  /**
+   * @brief Deleting move assignment operator
+   *
+   */
+  Nonmovable &operator=(Nonmovable &&) = delete;
+
+  /**
+   * @brief   Default destructor
+   */
+  virtual ~Nonmovable() = default;
+};
+
+} // namespace nntrainer
+
+#endif // __NNTRAINER_NONMOVABLE_H__

--- a/nntrainer/utils/profiler.cpp
+++ b/nntrainer/utils/profiler.cpp
@@ -254,11 +254,6 @@ void GenericProfileListener::report(std::ostream &out) const {
   out << "Average Memory Size = " << mem_average << std::endl;
 }
 
-Profiler &Profiler::Global() {
-  static Profiler instance;
-  return instance;
-}
-
 void Profiler::start(const int item) {
 #ifdef DEBUG
   /// @todo: consider race condition
@@ -369,8 +364,7 @@ void Profiler::alloc(const void *ptr, size_t size, const std::string &str,
   total_size += size;
 
   auto data = std::make_shared<ProfileEventData>(
-    0, size, total_size.load(), str, std::chrono::microseconds(0), policy,
-    fsu);
+    0, size, total_size.load(), str, std::chrono::microseconds(0), policy, fsu);
   notifyListeners(EVENT_MEM_ALLOC, data);
 }
 

--- a/nntrainer/utils/profiler.h
+++ b/nntrainer/utils/profiler.h
@@ -24,6 +24,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include "utils/singleton.h"
+
 using timepoint = std::chrono::time_point<std::chrono::steady_clock>;
 
 #ifndef PROFILE
@@ -306,29 +308,8 @@ std::ostream &operator<<(std::ostream &out, T &l) {
  * @brief Profiler object
  *
  */
-class Profiler {
+class Profiler : public Singleton<Profiler> {
 public:
-  /**
-   * @brief Construct a new Profiler object
-   *
-   */
-  Profiler() : total_size(0) {}
-
-  /**
-   * @brief Deleted constructor
-   *
-   */
-  Profiler(const Profiler &) = delete;
-  Profiler &operator=(const Profiler &) = delete;
-
-  /**
-   *
-   * @brief Get Global Profiler
-   *
-   * @return Profiler&
-   */
-  static Profiler &Global();
-
   /**
    * @brief start time profile
    *
@@ -419,7 +400,7 @@ private:
   std::unordered_map<const void *, std::tuple<size_t, timepoint, std::string>>
     allocates; /**< allocated memory information (ptr, (size, time, info) */
 
-  std::atomic<std::size_t> total_size; /**< total allocated memory size */
+  std::atomic<std::size_t> total_size = 0; /**< total allocated memory size */
 
   std::mutex listeners_mutex; /**< protect listeners */
   std::mutex allocates_mutex; /**< protect allocates */

--- a/nntrainer/utils/singleton.h
+++ b/nntrainer/utils/singleton.h
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   singleton.h
+ * @date   11 July 2025
+ * @brief  Base class making derived class singleton
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Grzegorz Kisala <g.kisala@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __NNTRAINER_SINGLETON_H__
+#define __NNTRAINER_SINGLETON_H__
+
+#include <mutex>
+
+#include "utils/noncopyable.h"
+#include "utils/nonmovable.h"
+
+namespace nntrainer {
+
+/**
+ * @class   Singleton
+ * @brief   Use it as base class of singletons
+ */
+template <typename T> class Singleton : public Noncopyable, public Nonmovable {
+
+public:
+  /**
+   * @brief   Get reference to global instance object
+   * once
+   * @return Instance to singleton class reference
+   */
+  static T &Global() {
+    static T instance;
+    instance.initializeOnce();
+    return instance;
+  }
+
+  /**
+   * @brief   Initialize helper function ensuring that initialize is called only
+   * once
+   */
+  void initializeOnce() {
+    std::call_once(initialized_, [&]() { this->initialize(); });
+  }
+
+protected:
+  /**
+   * @brief   Default constructor
+   */
+  Singleton() = default;
+
+  /**
+   * @brief   Override this function to initialize derived class
+   */
+  virtual void initialize() noexcept {}
+
+  std::once_flag initialized_;
+};
+
+} // namespace nntrainer
+
+#endif // __NNTRAINER_SINGLETON_H__


### PR DESCRIPTION
1. Unify the way we create noncopyable and nonmovable objects
2. Unify the way we create singletons
3. Prevent copy of move of selected classes
4. Avoid using global static variables
5. Generate .def file for nntrainer symbols (windows only)
6. Build nntrainer as shared library on windows

