### PR TITLE
build/install: install path of nnstreamer subplugins

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -56,7 +56,7 @@ option('ml-api-support', type: 'feature', value: 'auto')
 # @todo : make them use 'feature' and depend on ml-api-support
 option('enable-nnstreamer-tensor-filter', type: 'feature', value: 'auto')
 option('enable-nnstreamer-tensor-trainer', type: 'feature', value: 'auto')
-option('nnstreamer-subplugin-install-path', type: 'string', value: '/usr/lib/nnstreamer') # where nnstreamer subplugin should be installed
+option('nnstreamer-subplugin-install-path', type: 'string', value: 'lib/nnstreamer') # where nnstreamer subplugin should be installed (after prefix)
 
 # application related options
 option('enable_encoder', type: 'boolean', value: false)

--- a/nnstreamer/tensor_filter/meson.build
+++ b/nnstreamer/tensor_filter/meson.build
@@ -18,7 +18,7 @@ nntrainer_prefix = get_option('prefix')
 nnstreamer_filter_nntrainer_deps = [glib_dep, gmodule_dep, gst_dep, nntrainer_ccapi_dep, nnstreamer_dep]
 
 nnstreamer_libdir = nntrainer_prefix / get_option('libdir')
-subplugin_install_prefix = get_option('nnstreamer-subplugin-install-path')
+subplugin_install_prefix = nntrainer_prefix / get_option('nnstreamer-subplugin-install-path')
 filter_subplugin_install_dir = subplugin_install_prefix / 'filters'
 
 shared_library('nnstreamer_filter_nntrainer',

--- a/nnstreamer/tensor_trainer/meson.build
+++ b/nnstreamer/tensor_trainer/meson.build
@@ -18,7 +18,7 @@ nntrainer_prefix = get_option('prefix')
 nnstreamer_trainer_nntrainer_deps = [glib_dep, gmodule_dep, gst_dep, nntrainer_ccapi_dep, nnstreamer_dep]
 
 nnstreamer_libdir = nntrainer_prefix / get_option('libdir')
-subplugin_install_prefix = get_option('nnstreamer-subplugin-install-path')
+subplugin_install_prefix = nntrainer_prefix / get_option('nnstreamer-subplugin-install-path')
 trainer_subplugin_install_dir = subplugin_install_prefix / 'trainers'
 
 shared_library('nnstreamer_trainer_nntrainer',

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -2,7 +2,7 @@
 %define         use_cblas 1
 %define         nnstreamer_filter 1
 %define         nnstreamer_trainer 1
-%define         nnstreamer_subplugin_path %{_prefix}/lib/nnstreamer
+%define         nnstreamer_subplugin_path lib/nnstreamer
 %define         use_gym 0
 %define         support_ccapi 1
 %define         support_nnstreamer_backbone 1
@@ -739,7 +739,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %manifest nntrainer.manifest
 %defattr(-,root,root,-)
 %license LICENSE
-%{nnstreamer_subplugin_path}/filters/libnnstreamer_filter_nntrainer.so
+%{_prefix}/%{nnstreamer_subplugin_path}/filters/libnnstreamer_filter_nntrainer.so
 
 %files -n nnstreamer-nntrainer-devel-static
 %manifest nntrainer.manifest
@@ -753,7 +753,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %manifest nntrainer.manifest
 %defattr(-,root,root,-)
 %license LICENSE
-%{nnstreamer_subplugin_path}/trainers/libnnstreamer_trainer_nntrainer.so
+%{_prefix}/%{nnstreamer_subplugin_path}/trainers/libnnstreamer_trainer_nntrainer.so
 
 %files -n nnstreamer-nntrainer-trainer-devel-static
 %manifest nntrainer.manifest


### PR DESCRIPTION
The default option should follow the prefix.
Don't make a hardcoded absolute path as the default.

This often make problems in Github workflow action script testing.