### PR TITLE
[Wait for #3323] Fix M Non-Multiples of 4 in Q4_K GEMM and Adds Dynamic Quantization

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -153,6 +153,7 @@ void ClContext::initBlasClKernels() {
   registerClKernel(getSgemmClTransABKernel(), "sgemm_cl_transAB");
   registerClKernel(getAdditionClKernel(), "addition_cl");
   registerClKernel(getSscalClKernel(), "sscal_cl");
+  registerClKernel(getQ6KSgemvClKernel(), "kernel_mul_mv_q6_K_f32");
 
 #ifdef ENABLE_FP16
   registerClKernel(getHgemvClKernel(), "sgemv_cl_fp16");

--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -154,6 +154,7 @@ void ClContext::initBlasClKernels() {
   registerClKernel(getAdditionClKernel(), "addition_cl");
   registerClKernel(getSscalClKernel(), "sscal_cl");
   registerClKernel(getQ6KSgemvClKernel(), "kernel_mul_mv_q6_K_f32");
+  registerClKernel(getQ4KGemmClKernel(), "mat_mul_q4_K_8x8_q8_K");
 
 #ifdef ENABLE_FP16
   registerClKernel(getHgemvClKernel(), "sgemv_cl_fp16");

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
@@ -133,8 +133,6 @@ const std::string &getQ6KSgemvClKernel() {
         if (lane == 0) {
             int global_row = r0 * N_SIMDGROUP + row_group;
             dst[r1 * ne0 + im * ne0 * ne1 + global_row] = reduction_buf[row_group][0];
-
-            // dst[r1 * ne0 + im * ne0 * ne1 + row] = reduction_buf[row_group][0];
         }
     }
     )";

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
@@ -16,6 +16,132 @@
 
 namespace nntrainer {
 
+const std::string &getQ6KSgemvClKernel() {
+  static const std::string q6_k_sgemv_cl_kernel_ =
+    R"(
+    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+    #define QK_K 256
+    #define N_SIMDWIDTH 16
+    #define N_SIMDGROUP 2
+    #define N_DST 1
+    #define BLOCK_STRIDE (N_SIMDWIDTH / 16)
+
+    typedef char int8_t;
+    typedef uchar uint8_t;
+    typedef short int16_t;
+    typedef ushort uint16_t;
+    typedef int int32_t;
+    typedef uint uint32_t;
+
+    typedef struct {
+        uint8_t ql[QK_K / 2];
+        uint8_t qh[QK_K / 4];
+        int8_t  scales[QK_K / 16];
+        half d;
+    } block_q6_K;
+
+    kernel void kernel_mul_mv_q6_K_f32(
+        global void * src0,
+        ulong offset0,
+        global float * src1,
+        ulong offset1,
+        global float * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        int ne10,
+        int ne12,
+        int ne0,
+        int ne1,
+        int r2,
+        int r3
+    ) {
+        __local float reduction_buf[N_SIMDGROUP][N_SIMDWIDTH];
+
+        src0 = (global void*)((global char*)src0 + offset0);
+        src1 = (global float*)((global char*)src1 + offset1);
+        dst = (global float*)((global char*)dst + offsetd);
+
+        int nb = ne00 / QK_K;
+
+        int r0 = get_group_id(0);
+        int r1 = get_group_id(1);
+        int im = get_group_id(2);
+        int lid = get_local_id(0);
+        int lsize = get_local_size(0);
+
+        int row_group = lid / N_SIMDWIDTH;
+        int lane = lid % N_SIMDWIDTH;
+        int row = r0 * N_SIMDGROUP + row_group;
+
+        int i12 = im % ne12;
+        int i13 = im / ne12;
+
+        ulong offset_src0 = (i12 / r2) * (nb * ne01) + (i13 / r3) * (nb * ne01 * ne02);
+
+        global block_q6_K * x = (global block_q6_K *) src0 + row * nb + offset_src0;
+        global float      * yy = (global float     *) src1 + r1 * ne10 + im * ne00 * ne1;
+
+        uchar kmask1 = 0x03, kmask2 = 0x0C, kmask3 = 0x30, kmask4 = 0xC0;
+
+        int tid  = lane / BLOCK_STRIDE;
+        int ix   = lane % BLOCK_STRIDE;
+        int ip   = tid / 8;
+        int il   = tid % 8;
+        int n    = 4;
+        int l0   = n * il;
+        int is   = 8 * ip + l0 / 16;
+
+        int y_offset = 128 * ip + l0;
+        int q_offset_l = 64 * ip + l0;
+        int q_offset_h = 32 * ip + l0;
+
+        float sumf = 0.0f;
+
+        for (int i = ix; i < nb; i += BLOCK_STRIDE) {
+            global uint8_t * q1 = x[i].ql + q_offset_l;
+            global uint8_t * q2 = q1 + QK_K / 8;
+            global uint8_t * qh = x[i].qh + q_offset_h;
+            global int8_t  * sc = x[i].scales + is;
+            global float   * y = yy + i * QK_K + y_offset;
+
+            float dall = x[i].d;
+            float4 sums = {0.f, 0.f, 0.f, 0.f};
+
+            for (int j = 0; j < 4; j++) {
+                sums.s0 += y[j + 0]   * ((float)((q1[j] & 0xF) | ((qh[j] & kmask1) << 4)) - 32.f);
+                sums.s1 += y[j + 32]  * ((float)((q2[j] & 0xF) | ((qh[j] & kmask2) << 2)) - 32.f);
+                sums.s2 += y[j + 64]  * ((float)((q1[j] >> 4) | ((qh[j] & kmask3) >> 0)) - 32.f);
+                sums.s3 += y[j + 96]  * ((float)((q2[j] >> 4) | ((qh[j] & kmask4) >> 2)) - 32.f);
+            }
+
+            sumf += dall * (sums.s0 * sc[0] + sums.s1 * sc[2] + sums.s2 * sc[4] + sums.s3 * sc[6]);
+        }
+
+        reduction_buf[row_group][lane] = sumf;
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int offset = N_SIMDWIDTH / 2; offset > 0; offset >>= 1) {
+            if (lane < offset) {
+                reduction_buf[row_group][lane] += reduction_buf[row_group][lane + offset];
+            }
+            barrier(CLK_LOCAL_MEM_FENCE);
+        }
+
+        if (lane == 0) {
+            int global_row = r0 * N_SIMDGROUP + row_group;
+            dst[r1 * ne0 + im * ne0 * ne1 + global_row] = reduction_buf[row_group][0];
+
+            // dst[r1 * ne0 + im * ne0 * ne1 + row] = reduction_buf[row_group][0];
+        }
+    }
+    )";
+
+  return q6_k_sgemv_cl_kernel_;
+}
+
 const std::string &getSgemvClKernel() {
   static const std::string sgemv_cl_kernel_ =
     R"(__kernel void sgemv_cl(const __global float* A, const __global float* X,

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.h
@@ -18,6 +18,8 @@
 
 namespace nntrainer {
 
+const std::string &getQ4KGemmClKernel();
+
 const std::string &getQ6KSgemvClKernel();
 
 const std::string &getSgemvClKernel();

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.h
@@ -18,6 +18,8 @@
 
 namespace nntrainer {
 
+const std::string &getQ6KSgemvClKernel();
+
 const std::string &getSgemvClKernel();
 
 const std::string &getSgemvClNoTransKernel();

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -247,8 +247,8 @@ void sgemm_q4_k_cl(const unsigned int M, const unsigned int N,
     return;
   }
 
-  const int tile_size = 32;
-  const int work_groups_count[3] = {(int)(M / 4) * tile_size, (int)N / 8, 1};
+  const int tile_size = 64;
+  const int work_groups_count[3] = {(int)(M / 4) * tile_size, (int)N / 16, 1};
   const int work_group_size[3] = {tile_size, 1, 1};
 
   if (!opencl::CommandQueueManager::GetInstance().DispatchCommand(

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -18,6 +18,191 @@
 
 namespace nntrainer {
 
+void sgemv_q6_k_cl(const void *matAdata, const float *vecXdata, float *vecYdata,
+                   unsigned int M, unsigned int N) {
+  bool result = false;
+
+  ClContext::SharedPtrClKernel kernel_q6_k_sgemv_ptr;
+
+  kernel_q6_k_sgemv_ptr =
+    blas_cc->registerClKernel(getQ6KSgemvClKernel(), "kernel_mul_mv_q6_K_f32");
+
+  if (!kernel_q6_k_sgemv_ptr) {
+    ml_loge("Failed to register kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  int q6k_size = 210 * M * N / 256;
+
+  result = clbuffInstance.getInBufferA()->WriteDataRegion(
+    blas_cc->command_queue_inst_, q6k_size, matAdata);
+  if (!result) {
+    ml_loge("Failed to write data to input buffer A for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result = clbuffInstance.getInBufferB()->WriteDataRegion(
+    blas_cc->command_queue_inst_, M * sizeof(float), vecXdata);
+  if (!result) {
+    ml_loge("Failed to write data to input buffer B for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  int ne00 = M; // number of rows in matrix X
+  int ne01 = N; // number of columns in matrix X
+  int ne02 = 1; // number of channels in matrix X
+  int ne10 = M; // number of rows in vector A
+  int ne11 = 1; // number of columns in vector A
+  int ne12 = 1; // number of channels in vector A
+  int ne13 = 1; // number of channels in vector A (Need to check)
+  int ne0 = N;  // number of rows in output vector Y
+  int ne1 = 1;  // number of columns in output vector Y
+
+  int r2 = 1; // number of batches in vector A
+  int r3 = 1; // number of batches in matrix X
+
+  int nth0 = 2;
+  int nth1 = 16;
+
+  cl_ulong offset0 = 0;
+  cl_ulong offset1 = 0;
+  cl_ulong offsetd = 0;
+
+  result = kernel_q6_k_sgemv_ptr->SetKernelArguments(
+    0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 0 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result =
+    kernel_q6_k_sgemv_ptr->SetKernelArguments(1, &offset0, sizeof(cl_ulong));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 1 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result = kernel_q6_k_sgemv_ptr->SetKernelArguments(
+    2, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 2 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result =
+    kernel_q6_k_sgemv_ptr->SetKernelArguments(3, &offset1, sizeof(cl_ulong));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 3 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result = kernel_q6_k_sgemv_ptr->SetKernelArguments(
+    4, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 4 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result =
+    kernel_q6_k_sgemv_ptr->SetKernelArguments(5, &offsetd, sizeof(cl_ulong));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 5 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result = kernel_q6_k_sgemv_ptr->SetKernelArguments(6, &ne00, sizeof(int));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 6 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result = kernel_q6_k_sgemv_ptr->SetKernelArguments(7, &ne01, sizeof(int));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 7 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result = kernel_q6_k_sgemv_ptr->SetKernelArguments(8, &ne02, sizeof(int));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 8 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result = kernel_q6_k_sgemv_ptr->SetKernelArguments(9, &ne10, sizeof(int));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 9 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result = kernel_q6_k_sgemv_ptr->SetKernelArguments(10, &ne12, sizeof(int));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 10 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result = kernel_q6_k_sgemv_ptr->SetKernelArguments(11, &ne0, sizeof(int));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 11 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result = kernel_q6_k_sgemv_ptr->SetKernelArguments(12, &ne1, sizeof(int));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 12 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result = kernel_q6_k_sgemv_ptr->SetKernelArguments(13, &r2, sizeof(int));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 13 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+  result = kernel_q6_k_sgemv_ptr->SetKernelArguments(14, &r3, sizeof(int));
+
+  if (!result) {
+    ml_loge("Failed to set kernel argument 14 for kernel_q6_k_sgemv_ptr");
+    return;
+  }
+
+#define N_SIMDWIDTH 16
+#define N_SIMDGROUP 2
+
+  const int work_groups_count[3] = {ne00, 1, 1};
+  /// @todo: create a group size by device & input
+  const int work_group_size[3] = {N_SIMDWIDTH * N_SIMDGROUP, 1, 1};
+
+  result = opencl::CommandQueueManager::GetInstance().DispatchCommand(
+    kernel_q6_k_sgemv_ptr, work_groups_count, work_group_size);
+  if (!result) {
+    ml_loge("Failed to dispatch kernel q6_k_sgemv");
+    return;
+  }
+
+  result = clbuffInstance.getOutBufferA()->ReadDataRegion(
+    blas_cc->command_queue_inst_, N * sizeof(float), vecYdata);
+  if (!result) {
+    ml_loge(
+      "Failed to read data from the output buffer for kernel_q6_k_sgemv_ptr");
+
+    return;
+  }
+}
+
 void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
               bool TransA, unsigned int dim1, unsigned int dim2,
               unsigned int lda) {

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -41,6 +41,19 @@ void sgemv_q6_k_cl(void *matAdata, float *vecXdata, float *vecYdata,
                    unsigned int M, unsigned int N);
 
 /**
+ * @brief     Q6_K GEMM computation
+ * @param[in] M as descripted above
+ * @param[in] N as descripted above
+ * @param K as descripted above
+ * @param[in] matAdata void * for Matrix A; offline quantized and q4_kx8 packed
+ * @param[in] matBdata float * for Matrix B
+ * @param[in] matCdata float * for Matrix C
+ */
+void sgemm_q4_k_cl(const unsigned int M, const unsigned int N,
+                   const unsigned int K, void *matAdata, void *matBdata,
+                   float *matCdata);
+
+/**
  * @brief     sgemv computation : Y = A*X + Y
  * @param[in] matAdata float * for Matrix A
  * @param[in] vecXdata float * for Vector X

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -37,7 +37,7 @@ static ClBufferManager &clbuffInstance = ClBufferManager::getInstance();
  * @param[in] M number of rows in matrix A
  * @param[in] N number of columns in matrix A
  */
-void sgemv_q6_k_cl(const void *matAdata, const float *vecXdata, float *vecYdata,
+void sgemv_q6_k_cl(void *matAdata, float *vecXdata, float *vecYdata,
                    unsigned int M, unsigned int N);
 
 /**

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -30,6 +30,17 @@ static ClContext *blas_cc =
 static ClBufferManager &clbuffInstance = ClBufferManager::getInstance();
 
 /**
+ * @brief     Q6_K sgemv computation : Y = A*X
+ * @param[in] matAdata void * for Matrix A
+ * @param[in] vecXdata float * for Vector X
+ * @param[in] vecYdata float * for Vector Y
+ * @param[in] M number of rows in matrix A
+ * @param[in] N number of columns in matrix A
+ */
+void sgemv_q6_k_cl(const void *matAdata, const float *vecXdata, float *vecYdata,
+                   unsigned int M, unsigned int N);
+
+/**
  * @brief     sgemv computation : Y = A*X + Y
  * @param[in] matAdata float * for Matrix A
  * @param[in] vecXdata float * for Vector X

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -803,7 +803,11 @@ Tensor &FloatTensor::dotQnK(Tensor const &input, Tensor &output, bool trans,
     M = getDim().height();
     K = getDim().width();
     N = input.getDim().width();
+#ifdef ENABLE_OPENCL
+    sgemm_q4_k_cl(M, N, K, (void *)mdata, data, rdata);
+#else
     gemm_q4_K(M, N, K, data, K, (void *)mdata, N, rdata, N);
+#endif
     break;
   case Tdatatype::Q6_K:
     M = getDim().height();

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -18,6 +18,10 @@
 #include <tensor.h>
 #include <util_func.h>
 
+#ifdef ENABLE_OPENCL
+#include "blas_kernels.h"
+#endif
+
 namespace nntrainer {
 
 FloatTensor::FloatTensor(std::string name_, Tformat fm) :
@@ -65,11 +69,33 @@ void FloatTensor::allocate() {
     /// allocate new memory for the tensor data
     MemoryData *mem_data;
 
+#ifdef ENABLE_OPENCL
+    if (blas_cc != nullptr) {
+      mem_data = new MemoryData(blas_cc->context_inst_.createSVMRegion(
+        dim.getDataLen() * sizeof(float)));
+
+      data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
+        blas_cc->context_inst_.releaseSVMRegion(
+          mem_data->template getAddr<float>());
+      });
+
+      blas_cc->command_queue_inst_.enqueueSVMMap(
+        mem_data->template getAddr<float>(), dim.getDataLen() * sizeof(float),
+        false);
+    } else {
+      mem_data = new MemoryData((void *)(new float[dim.getDataLen()]{}));
+      data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
+        delete[] mem_data->template getAddr<float>();
+        delete mem_data;
+      });
+    }
+#else
     mem_data = new MemoryData((void *)(new float[dim.getDataLen()]{}));
     data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
       delete[] mem_data->template getAddr<float>();
       delete mem_data;
     });
+#endif
 
     offset = 0;
     initialize();
@@ -766,8 +792,8 @@ Tensor &FloatTensor::dotQnK(Tensor const &input, Tensor &output, bool trans,
   NNTR_THROW_IF(trans || trans_in, std::invalid_argument)
     << "dotQnK does not support trans / trans_in";
 
-  const float *data = (float *)getData();
-  const uint8_t *mdata = input.getData<uint8_t>();
+  float *data = (float *)getData();
+  uint8_t *mdata = input.getData<uint8_t>();
   float *rdata = output.getData<float>();
 
   unsigned int M, N, K;
@@ -783,7 +809,12 @@ Tensor &FloatTensor::dotQnK(Tensor const &input, Tensor &output, bool trans,
     M = getDim().height();
     K = getDim().width();
     N = input.getDim().height();
+#ifdef ENABLE_OPENCL
+    /// @note For Q6K, use OpenCL kernel by default when GPU is enabled
+    sgemv_q6_k_cl((void *)mdata, data, rdata, K, N);
+#else
     gemm_q6_K(M, N, K, data, K, (void *)mdata, N, rdata, N);
+#endif
     break;
   default:
     throw std::invalid_argument("Error: unsupported datatype");

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -1409,25 +1409,6 @@ static void run_q_4_K_test(const uint32_t M, const uint32_t K,
   auto t2 = std::chrono::high_resolution_clock::now();
   auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);
 
-  static constexpr size_t qk_k = 256;
-  static constexpr size_t sizeof_block_q8_K = 292;
-
-  unsigned int blocks_per_4_rows = (K + qk_k - 1) / qk_k;
-  unsigned int qa_4_rows_size = sizeof_block_q8_K * 4 * blocks_per_4_rows;
-  unsigned int M4 = ((M + 3) / 4);
-
-  std::memset(activations_f32_ptr, 0x00, M * K * sizeof(float));
-
-  if (M == 1) {
-    ::quantize_row_q8_K((float *)activation.data(), activations_f32_ptr, K);
-  } else {
-    for (int i = 0; i < static_cast<int>(M4); i++) {
-      ::ggml_quantize_mat_q8_K_4x8(
-        activation.data() + 4 * i * K,
-        reinterpret_cast<char *>(activations_f32_ptr) + i * qa_4_rows_size, K);
-    }
-  }
-
   // GPU Q4_K GEMM
   auto t3 = std::chrono::high_resolution_clock::now();
   for (unsigned int i = 0; i < run_count; ++i) {
@@ -1498,10 +1479,24 @@ static void run_q_4_K_test(const uint32_t M, const uint32_t K,
 // DECLARE_q_4_K_test_M_K_N(1, 768, 1024);
 
 DECLARE_q_4_K_test_M_K_N(256, 1024, 256);
-DECLARE_q_4_K_test_M_K_N(3072, 8192, 3072);
 DECLARE_q_4_K_test_M_K_N(256, 3072, 8192);
 DECLARE_q_4_K_test_M_K_N(256, 8192, 3072);
 DECLARE_q_4_K_test_M_K_N(256, 3072, 3072);
+
+DECLARE_q_4_K_test_M_K_N(255, 1024, 256);
+DECLARE_q_4_K_test_M_K_N(255, 3072, 8192);
+DECLARE_q_4_K_test_M_K_N(255, 8192, 3072);
+DECLARE_q_4_K_test_M_K_N(255, 3072, 3072);
+
+DECLARE_q_4_K_test_M_K_N(33, 1024, 256);
+DECLARE_q_4_K_test_M_K_N(33, 3072, 8192);
+DECLARE_q_4_K_test_M_K_N(33, 8192, 3072);
+DECLARE_q_4_K_test_M_K_N(33, 3072, 3072);
+
+DECLARE_q_4_K_test_M_K_N(32, 1024, 256);
+DECLARE_q_4_K_test_M_K_N(32, 3072, 8192);
+DECLARE_q_4_K_test_M_K_N(32, 8192, 3072);
+DECLARE_q_4_K_test_M_K_N(32, 3072, 3072);
 
 // DECLARE_q_4_K_test_M_K_N(256, 256, 3072);
 // DECLARE_q_4_K_test_M_K_N(3072, 256, 256);

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -12,8 +12,12 @@
 
 #include <fstream>
 #include <gtest/gtest.h>
+#include <iostream>
+#include <numeric>
 #include <random>
 #include <type_traits>
+
+#include "ggml.h"
 
 #include "nntrainer_test_util.h"
 #include "util_func.h"
@@ -24,11 +28,72 @@
 #include <layer_context.h>
 #include <tensor.h>
 
+typedef struct {
+  union {
+    struct {
+      int16_t d;    // super-block scale for quantized scales
+      int16_t dmin; // super-block scale for quantized mins
+    };
+    uint32_t dm;
+  };
+  uint8_t scales[12];  // scales and mins, quantized with 6 bits
+  uint8_t qs[256 / 2]; // 4--bit quants
+} block_q4_K_testonly;
+
 #define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
   EXPECT_GE((VAL), (MIN));                                                     \
   EXPECT_LE((VAL), (MAX))
 
 using namespace nntrainer;
+
+template <typename T>
+static inline double find_max_diff(T *src, T *src2, int M, int N) {
+  float max_diff = 0;
+  double err_sum = 0;
+  for (int i = 0; i < M; ++i) {
+    for (int j = 0; j < N; ++j) {
+      max_diff = std::max(max_diff, std::abs(src[i * N + j] - src2[i * N + j]));
+      err_sum += std::abs(src[i * N + j] - src2[i * N + j]);
+    }
+  }
+  // std::cout << "err_sum : " << err_sum << std::endl;
+  return max_diff;
+}
+
+float compute_mse(const uint32_t M, const uint32_t N, float *ref_dst,
+                  const size_t ref_dst_sz, float *dst, const size_t dst_sz,
+                  bool print = false) {
+  auto mean_squared_error = mse<float, float>(ref_dst, dst, M * N);
+  auto cos_sim = cosine_similarity(ref_dst, dst, M * N);
+  auto max_differ = find_max_diff(ref_dst, dst, M, N);
+
+  auto sum = std::accumulate(dst, dst + dst_sz, 0.0);
+  auto sum_gt = std::accumulate(ref_dst, ref_dst + ref_dst_sz, 0.0);
+  if (print) {
+    std::cout << "[INFO]            MSE: " << mean_squared_error
+              << ", COS_SIM: " << cos_sim << ", MAX_DIFFER: " << max_differ
+              << ", SUM: " << sum << ", SUM_GT: " << sum_gt << std::endl;
+  }
+  return mean_squared_error;
+}
+
+float compute_mse(const uint32_t M, const uint32_t N,
+                  std::vector<float> &ref_dst, std::vector<float> &dst,
+                  bool print = false) {
+  auto mean_squared_error =
+    mse<float, float>(ref_dst.data(), dst.data(), M * N);
+  auto cos_sim = cosine_similarity(ref_dst.data(), dst.data(), M * N);
+  auto max_differ = find_max_diff(ref_dst.data(), dst.data(), M, N);
+
+  auto sum = std::accumulate(dst.begin(), dst.end(), 0.0);
+  auto sum_gt = std::accumulate(ref_dst.begin(), ref_dst.end(), 0.0);
+  if (print) {
+    std::cout << "[INFO]            MSE: " << mean_squared_error
+              << ", COS_SIM: " << cos_sim << ", MAX_DIFFER: " << max_differ
+              << ", SUM: " << sum << ", SUM_GT: " << sum_gt << std::endl;
+  }
+  return mean_squared_error;
+}
 
 TEST(blas_kernels, dotCL_sgemv_M_1_1) {
   int batch = 1;
@@ -1135,6 +1200,7 @@ generate_random_vector(size_t size, float min_val = -1.F, float max_val = 1.F) {
   return vec;
 }
 
+#if 0 
 static void run_q_6_K_test(const uint32_t M, const uint32_t K,
                            const uint32_t N) {
   nntrainer::init_backend();
@@ -1155,7 +1221,7 @@ static void run_q_6_K_test(const uint32_t M, const uint32_t K,
     std::cout << "]";
   };
 
-  static constexpr uint32_t run_count = 100;
+  static constexpr uint32_t run_count = 1;
 
   std::vector<float> activation = generate_random_vector<float, false>(M * K);
   std::vector<float> weight = generate_random_vector<float, false>(N * K);
@@ -1266,7 +1332,181 @@ static void run_q_6_K_test(const uint32_t M, const uint32_t K,
   }
 
 DECLARE_q_6_K_test_M_K_N(1, 3072, 105900);
+#endif
 
+#if 1
+static void run_q_4_K_test(const uint32_t M, const uint32_t K,
+                           const uint32_t N) {
+  nntrainer::init_backend();
+
+  auto *blas_cc = static_cast<nntrainer::ClContext *>(
+    nntrainer::Engine::Global().getRegisteredContext("gpu"));
+
+  auto debug_print_beg_end = [M, K, N](const float *const data,
+                                       const uint32_t count = 12) {
+    std::cout << "[";
+    for (unsigned int i = 0; i < count; ++i) {
+      std::cout << data[i] << " ";
+    }
+    std::cout << "][";
+    for (unsigned int i = M * N - count; i < M * N; ++i) {
+      std::cout << data[i] << " ";
+    }
+    std::cout << "]";
+  };
+
+  static constexpr uint32_t run_count = 16;
+
+  std::vector<float> activation = generate_random_vector<float, false>(M * K);
+  std::vector<float> weight = generate_random_vector<float, false>(N * K);
+
+  std::vector<float> ref_dst(M * N, 0.0f);
+  std::vector<float> cpu_q4_dst(M * N, 0.0f);
+
+  int64_t q4_k_block_size = 256;
+  int64_t q4_k_type_size = sizeof(block_q4_K_testonly);
+  int64_t num_blocks = (K * N) / q4_k_block_size;
+  size_t data_size = q4_k_type_size * N / q4_k_block_size;
+  data_size *= K;
+
+  // Generate result from SGEMM
+  nntrainer::sgemm(0, false, true, M, N, K, 1.F, activation.data(), K,
+                   weight.data(), K, 0.F, ref_dst.data(), N);
+
+  // Initialize data
+  void *gpu_q4_dst =
+    blas_cc->context_inst_.createSVMRegion(M * N * sizeof(float));
+
+  void *q4_weight_ptr = blas_cc->context_inst_.createSVMRegion(data_size);
+  void *q4_weight_repack_ptr =
+    blas_cc->context_inst_.createSVMRegion(data_size);
+
+  blas_cc->command_queue_inst_.enqueueSVMMap(q4_weight_ptr, data_size, false);
+
+  float *weights_f32_ptr = weight.data();
+
+  float *activations_f32_ptr =
+    (float *)blas_cc->context_inst_.createSVMRegion(M * K * sizeof(float));
+
+  blas_cc->command_queue_inst_.enqueueSVMMap(activations_f32_ptr,
+                                             M * K * sizeof(float), false);
+
+  for (unsigned int i = 0; i < M * K; ++i) {
+    activations_f32_ptr[i] = activation[i];
+  }
+
+  /// Quantize weight data
+  nntrainer::quantize_q4_K(weights_f32_ptr, q4_weight_ptr, N, K, nullptr);
+  nntrainer::repack_q4_K_to_q4_K_8(q4_weight_repack_ptr, q4_weight_ptr,
+                                   data_size, N, K);
+
+  // CPU Q4_K GEMM
+  auto t1 = std::chrono::high_resolution_clock::now();
+  for (unsigned int i = 0; i < run_count; ++i) {
+    nntrainer::gemm_q4_K(M, N, K, activations_f32_ptr, K, q4_weight_repack_ptr,
+                         N, cpu_q4_dst.data(), N);
+  }
+  auto t2 = std::chrono::high_resolution_clock::now();
+  auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);
+
+  static constexpr size_t qk_k = 256;
+  static constexpr size_t sizeof_block_q8_K = 292;
+
+  unsigned int blocks_per_4_rows = (K + qk_k - 1) / qk_k;
+  unsigned int qa_4_rows_size = sizeof_block_q8_K * 4 * blocks_per_4_rows;
+  unsigned int M4 = ((M + 3) / 4);
+
+  std::memset(activations_f32_ptr, 0x00, M * K * sizeof(float));
+
+  if (M == 1) {
+    ::quantize_row_q8_K((float *)activation.data(), activations_f32_ptr, K);
+  } else {
+    for (int i = 0; i < static_cast<int>(M4); i++) {
+      ::ggml_quantize_mat_q8_K_4x8(
+        activation.data() + 4 * i * K,
+        reinterpret_cast<char *>(activations_f32_ptr) + i * qa_4_rows_size, K);
+    }
+  }
+
+  // GPU Q4_K GEMM
+  auto t3 = std::chrono::high_resolution_clock::now();
+  for (unsigned int i = 0; i < run_count; ++i) {
+
+    nntrainer::sgemm_q4_k_cl(M, N, K, q4_weight_repack_ptr, activations_f32_ptr,
+                             (float *)gpu_q4_dst);
+  }
+  auto t4 = std::chrono::high_resolution_clock::now();
+  auto gpu_dt = std::chrono::duration_cast<std::chrono::milliseconds>(t4 - t3);
+
+  // Compute raports
+  {
+    uint32_t first_zero_index = UINT32_MAX;
+    int zeros = 0;
+    int nans = 0;
+
+    for (uint32_t i = 0; i < M * N; ++i) {
+      if (((float *)gpu_q4_dst)[i] == 0) {
+        zeros++;
+        if (first_zero_index == UINT32_MAX) {
+          first_zero_index = i;
+        }
+      }
+
+      if (std::isnan(((float *)gpu_q4_dst)[i])) {
+        nans++;
+      }
+    }
+
+    const auto mean_squared_error_dst_gpu = compute_mse(
+      M, N, (float *)ref_dst.data(), M * N, (float *)gpu_q4_dst, M * N, false);
+    const auto mean_squared_error_dst =
+      compute_mse(M, N, (float *)ref_dst.data(), M * N,
+                  (float *)cpu_q4_dst.data(), M * N, false);
+
+    const auto data_size_mb = data_size / (1024 * 1024.0f);
+
+    std::cout << "Q4_K GEMM : " << M << " x " << K << " x " << N << std::endl;
+    std::cout << " - q4_K data size : " << data_size_mb << " [MB]" << std::endl;
+    std::cout << " - time : CPU = " << dt.count() / (run_count * 1.0f) << " ms"
+              << std::endl;
+    std::cout << " - time : GPU = " << gpu_dt.count() / (run_count * 1.0f)
+              << " ms" << std::endl;
+    std::cout << " - sample : REF = ";
+    debug_print_beg_end(ref_dst.data());
+    std::cout << std::endl;
+    std::cout << " - sample : CPU = ";
+    debug_print_beg_end(cpu_q4_dst.data());
+    std::cout << std::endl;
+    std::cout << " - sample : GPU = ";
+    debug_print_beg_end((float *)gpu_q4_dst);
+    std::cout << std::endl;
+    std::cout << " - zeros : " << zeros << " / " << M * N << " [ "
+              << zeros * 100.0f / float(M * N) << " %] - first at [ "
+              << first_zero_index << " ]" << std::endl;
+    std::cout << " - nans : " << nans << " / " << M * N << " [ "
+              << nans * 100.0f / float(M * N) << " %]" << std::endl;
+    std::cout << " - MSE : CPU = " << mean_squared_error_dst << std::endl;
+    std::cout << " - MSE : GPU = " << mean_squared_error_dst_gpu << std::endl;
+  }
+}
+
+#define DECLARE_q_4_K_test_M_K_N(M, K, N)                                      \
+  TEST(nntrainer_cpu_backend_standalone, q_4_K_test_##M##_##K##_##N) {         \
+    run_q_4_K_test(M, K, N);                                                   \
+  }
+
+// DECLARE_q_4_K_test_M_K_N(1, 768, 1024);
+
+DECLARE_q_4_K_test_M_K_N(256, 1024, 256);
+DECLARE_q_4_K_test_M_K_N(3072, 8192, 3072);
+DECLARE_q_4_K_test_M_K_N(256, 3072, 8192);
+DECLARE_q_4_K_test_M_K_N(256, 8192, 3072);
+DECLARE_q_4_K_test_M_K_N(256, 3072, 3072);
+
+// DECLARE_q_4_K_test_M_K_N(256, 256, 3072);
+// DECLARE_q_4_K_test_M_K_N(3072, 256, 256);
+// DECLARE_q_4_K_test_M_K_N(1, 3072, 128000);
+#endif
 #endif // ENABLE_GGML
 
 GTEST_API_ int main(int argc, char **argv) {


### PR DESCRIPTION
This pull request (PR) addresses an issue where the variable M is not a multiple of 4. Since the q4_K_8x8_q8_K GEMM operation requires M to be a multiple of 4, we need to use GEMV for the remainder when it is not. The current patch implements the CPU version of GEMV until the GPU kernel becomes available. Additionally, this patch introduces dynamic quantization for float input.