### PR TITLE
[Emergency Fix] Revert "memory leak fix (valgrind error): Application/KNN"

### DIFF
--- a/Applications/KNN/jni/main.cpp
+++ b/Applications/KNN/jni/main.cpp
@@ -199,8 +199,6 @@ int main(int argc, char *argv[]) {
       output = interpreter->typed_output_tensor<float>(0);
 
       std::copy(output, output + 128, out[i][j]);
-
-      delete[] in;
     }
   }
 
@@ -266,8 +264,6 @@ int main(int argc, char *argv[]) {
      */
     ret = KNN(out, testout[i]);
     printf("class %d\n", ret);
-
-    delete[] in;
   }
 
   return 0;


### PR DESCRIPTION
5731541cb254b2e579ba1a9edc0cc4b8e9ab1d2c has already fixed the issue in a different way, which creates a build error with this commit.

This reverts commit bc19f1af859acde591509d826708bd0b64ddf1ea.
