### PR TITLE
[Q6_K] Update Q6_K dot opration.

### DIFF
--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -789,27 +789,28 @@ Tensor &FloatTensor::dotFloat(Tensor const &input, Tensor &output, bool trans,
 }
 Tensor &FloatTensor::dotQnK(Tensor const &input, Tensor &output, bool trans,
                             bool trans_in, float beta, Tdatatype dtype) const {
-  ///@note trans / trans_in is not yet applied
-  NNTR_THROW_IF(trans || trans_in, std::invalid_argument)
-    << "dotQnK does not support trans / trans_in";
+  ///@note Be cautious.
+  /// Qn_K does not support transpose in principle.
+  /// This trans option only aims to support Tensor Dimension only,
+  /// not data.
+  ///@note trans is not yet applied
+  NNTR_THROW_IF(trans, std::invalid_argument)
+    << "dotQnK does not support trans";
 
   float *data = (float *)getData();
   uint8_t *mdata = input.getData<uint8_t>();
   float *rdata = output.getData<float>();
 
   unsigned int M, N, K;
+  M = getDim().height();
+  K = getDim().width();
+  N = trans_in ? input.getDim().height() : input.getDim().width();
 
   switch (dtype) {
   case Tdatatype::Q4_K:
-    M = getDim().height();
-    K = getDim().width();
-    N = input.getDim().width();
     gemm_q4_K(M, N, K, data, K, (void *)mdata, N, rdata, N);
     break;
   case Tdatatype::Q6_K:
-    M = getDim().height();
-    K = getDim().width();
-    N = input.getDim().height();
 #ifdef ENABLE_OPENCL
     /// @note For Q6K, use OpenCL kernel by default when GPU is enabled
     sgemv_q6_k_cl((void *)mdata, data, rdata, K, N);


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[Q6_K] Update Q6_K dot opration</summary><br />

- This patch updatese Q6_K's dot operation to support transpose.
- In pricinple, Q6_K doesn't support transpose, but here, we aim to support trans option for dimension change in tensor for dot operation.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
</details>


### Summary
- This PR updates FP32.dot(Q6_K).
- In the previous implementation, it assumes 'transposed' in dimension by default.
- This PR fixes the operation, while supporting in_transpose.
- Please note that this in_transpose support does not transpose of the matrix data but only change the dimension of height and weight.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
