### PR TITLE
[OpenCL] Enable Q4_0 Block Processing

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -155,6 +155,10 @@ void ClContext::initBlasClKernels() {
   registerClKernel(getSscalClKernel(), "sscal_cl");
   registerClKernel(getQ6KSgemvClKernel(), "kernel_mul_mv_q6_K_f32");
 
+  // register Q4_0 kernels
+  registerClKernel(getConvertBlockQ4_0Kernel(), "kernel_convert_block_q4_0");
+  registerClKernel(getRestoreBlockQ4_0Kernel(), "kernel_restore_block_q4_0");
+
 #ifdef ENABLE_FP16
   registerClKernel(getHgemvClKernel(), "sgemv_cl_fp16");
   registerClKernel(getHgemvClNoTransKernel(), "sgemv_cl_noTrans_fp16");

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
@@ -749,6 +749,99 @@ const std::string &getRMSNormClKernel() {
   return rmsnorm_cl_kernel_;
 }
 
+const std::string &getConvertBlockQ4_0Kernel() {
+  static const std::string convert_q4_0_block_kernel_ =
+    R"(
+    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+    #ifdef cl_intel_required_subgroup_size
+    #pragma OPENCL EXTENSION cl_intel_required_subgroup_size : enable
+    #define INTEL_GPU 1
+    #define REQD_SUBGROUP_SIZE_16 __attribute__((intel_reqd_sub_group_size(16)))
+    #define REQD_SUBGROUP_SIZE_32 __attribute__((intel_reqd_sub_group_size(32)))
+    #elif defined(cl_qcom_reqd_sub_group_size)
+    #pragma OPENCL EXTENSION cl_qcom_reqd_sub_group_size : enable
+    #define ADRENO_GPU 1
+    #define REQD_SUBGROUP_SIZE_64 __attribute__((qcom_reqd_sub_group_size("half")))
+    #define REQD_SUBGROUP_SIZE_128 __attribute__((qcom_reqd_sub_group_size("full")))
+    #endif
+
+    #define QK4_0 32
+
+    typedef uchar uint8_t;
+
+    struct block_q4_0 {
+      half d;
+      uint8_t qs[QK4_0 / 2];
+    };
+
+    //------------------------------------------------------------------------------
+    // kernel_convert_block_q4_0
+    // Convert the block_q4_0 format to 2 separate arrays (AOS -> SOA).
+    // This kernel does not deshuffle the bits.
+    // @todo: This kernel is not optimized for performance.
+    //------------------------------------------------------------------------------
+    kernel void kernel_convert_block_q4_0(global struct block_q4_0 *src0,
+                                          global uchar *dst_q, global half *dst_d) {
+      global struct block_q4_0 *b =
+        (global struct block_q4_0 *)src0 + get_global_id(0);
+      global uchar *q = (global uchar *)dst_q + QK4_0 / 2 * get_global_id(0);
+      global half *d = (global half *)dst_d + get_global_id(0);
+
+      *d = b->d;
+
+      for (int i = 0; i < QK4_0 / 2; ++i) {
+        q[i] = b->qs[i];
+      }
+    }
+    )";
+  return convert_q4_0_block_kernel_;
+}
+
+const std::string &getRestoreBlockQ4_0Kernel() {
+  static const std::string restore_q4_0_block_kernel_ =
+    R"(
+    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+    #ifdef cl_intel_required_subgroup_size
+    #pragma OPENCL EXTENSION cl_intel_required_subgroup_size : enable
+    #define INTEL_GPU 1
+    #define REQD_SUBGROUP_SIZE_16 __attribute__((intel_reqd_sub_group_size(16)))
+    #define REQD_SUBGROUP_SIZE_32 __attribute__((intel_reqd_sub_group_size(32)))
+    #elif defined(cl_qcom_reqd_sub_group_size)
+    #pragma OPENCL EXTENSION cl_qcom_reqd_sub_group_size : enable
+    #define ADRENO_GPU 1
+    #define REQD_SUBGROUP_SIZE_64 __attribute__((qcom_reqd_sub_group_size("half")))
+    #define REQD_SUBGROUP_SIZE_128 __attribute__((qcom_reqd_sub_group_size("full")))
+    #endif
+
+    #define QK4_0 32
+    
+    typedef uchar uint8_t;
+
+    struct block_q4_0 {
+      half d;
+      uint8_t qs[QK4_0 / 2];
+    };
+
+    // @todo: This kernel is not optimized for performance.
+    kernel void kernel_restore_block_q4_0(global uchar *src_q, global half *src_d,
+                                          global struct block_q4_0 *dst) {
+      global struct block_q4_0 *b =
+        (global struct block_q4_0 *)dst + get_global_id(0);
+      global uchar *q = (global uchar *)src_q + QK4_0 / 2 * get_global_id(0);
+      global half *d = (global half *)src_d + get_global_id(0);
+
+      b->d = *d;
+      for (int i = 0; i < QK4_0 / 2; ++i) {
+        b->qs[i] = q[i];
+      }
+    }
+    )";
+
+  return restore_q4_0_block_kernel_;
+}
+
 #ifdef ENABLE_FP16
 const std::string &getHgemvClKernel() {
   static const std::string hgemv_cl_kernel_ =

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.h
@@ -56,6 +56,10 @@ const std::string &getConcatClAxis1Kernel();
 
 const std::string &getRMSNormClKernel();
 
+const std::string &getConvertBlockQ4_0Kernel();
+
+const std::string &getRestoreBlockQ4_0Kernel();
+
 #ifdef ENABLE_FP16
 
 const std::string &getHgemvClKernel();

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -687,4 +687,89 @@ void transpose_cl_axis(const float *in, float *res,
 
   } while (false);
 }
+
+void flatten_block_q4_0_cl(const void *src, void *dst_q, void *dst_d,
+                           unsigned int num_blocks) {
+  bool result = false;
+
+  ClContext::SharedPtrClKernel kernel_ptr = blas_cc->registerClKernel(
+    getConvertBlockQ4_0Kernel(), "kernel_convert_block_q4_0");
+  if (!kernel_ptr) {
+    ml_loge("Failed to register kernel_ptr for flatten_block_q4_0_cl");
+    return;
+  }
+
+  int argIdx = 0;
+
+  result = kernel_ptr->SetKernelSVMArguments(argIdx++, src);
+  if (!result) {
+    ml_loge("Failed to set kernel argument 0 for flatten_block_q4_0_cl");
+    return;
+  }
+
+  result = kernel_ptr->SetKernelSVMArguments(argIdx++, dst_q);
+  if (!result) {
+    ml_loge("Failed to set kernel argument 1 for flatten_block_q4_0_cl");
+    return;
+  }
+
+  result = kernel_ptr->SetKernelSVMArguments(argIdx++, dst_d);
+  if (!result) {
+    ml_loge("Failed to set kernel argument 2 for flatten_block_q4_0_cl");
+    return;
+  }
+
+  const int work_groups_count[3] = {(int)num_blocks, 1, 1};
+  const int work_group_size[3] = {64, 1, 1};
+
+  result = opencl::CommandQueueManager::GetInstance().DispatchCommand(
+    kernel_ptr, work_groups_count, work_group_size);
+  if (!result) {
+    ml_loge("Failed to dispatch kernel for flatten_block_q4_0_cl");
+    return;
+  }
+}
+
+void restore_block_q4_0_cl(const void *src_q, const void *src_d, void *dst,
+                           unsigned int num_blocks) {
+  bool result = false;
+
+  ClContext::SharedPtrClKernel kernel_ptr = blas_cc->registerClKernel(
+    getConvertBlockQ4_0Kernel(), "kernel_restore_block_q4_0");
+  if (!kernel_ptr) {
+    ml_loge("Failed to register kernel_ptr for restore_block_q4_0_cl");
+    return;
+  }
+
+  int argIdx = 0;
+
+  result = kernel_ptr->SetKernelSVMArguments(argIdx++, src_q);
+  if (!result) {
+    ml_loge("Failed to set kernel argument 0 for restore_block_q4_0_cl");
+    return;
+  }
+
+  result = kernel_ptr->SetKernelSVMArguments(argIdx++, src_d);
+  if (!result) {
+    ml_loge("Failed to set kernel argument 1 for restore_block_q4_0_cl");
+    return;
+  }
+
+  result = kernel_ptr->SetKernelSVMArguments(argIdx++, dst);
+  if (!result) {
+    ml_loge("Failed to set kernel argument 2 for restore_block_q4_0_cl");
+    return;
+  }
+
+  const int work_groups_count[3] = {(int)num_blocks, 1, 1};
+  const int work_group_size[3] = {1, 1, 1};
+
+  result = opencl::CommandQueueManager::GetInstance().DispatchCommand(
+    kernel_ptr, work_groups_count, work_group_size);
+  if (!result) {
+    ml_loge("Failed to dispatch kernel for restore_block_q4_0_cl");
+    return;
+  }
+}
+
 } // namespace nntrainer

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -120,6 +120,27 @@ void transpose_cl_axis(const float *in, float *res,
                        unsigned int input_batch_size,
                        unsigned int input_channels, unsigned int input_height,
                        unsigned int input_width, unsigned int axis);
+/**
+ * @brief  Separate the quantized bits and scale from block_q4_0
+ *
+ * @param src source pointer to the block_q4_0 data
+ * @param dst_q destination pointer for the quantized bits
+ * @param dst_d destination pointer for the scale
+ * @param num_blocks number of blocks to process
+ */
+void flatten_block_q4_0_cl(const void *src, void *dst_q, void *dst_d,
+                           unsigned int num_blocks);
+
+/**
+ * @brief Restore the original block_q4_0 from the quantized bits and scale
+ *
+ * @param src_q source pointer to the quantized bits
+ * @param src_d source pointer to the scale
+ * @param dst destination pointer for the restored block_q4_0
+ * @param num_blocks number of blocks to process
+ */
+void restore_block_q4_0_cl(const void *src_q, const void *src_d, void *dst,
+                           unsigned int num_blocks);
 
 #ifdef ENABLE_FP16
 


### PR DESCRIPTION
This commit introduces OpenCL kernels for flattening and restoring the q4_0 block.
These kernels will convert an array of q4_0 blocks into a block of arrays, enabling the utilization of the GPU's memory read throughput.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped