### PR TITLE
[OpenCL] Convert q4_0x8 into two arrays, scale and quant

### DIFF
--- a/nntrainer/tensor/cl_operations/blas_kernel_helper.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_helper.cpp
@@ -1,0 +1,31 @@
+#include "blas_kernel_helper.h"
+
+#include <omp.h>
+
+#include <cstring>
+
+namespace nntrainer {
+
+struct block_q4_0x8 {
+  unsigned short d[8];
+  unsigned char qs[128];
+};
+
+void convert_st(const void *src, unsigned short *d, unsigned char *qs, size_t N) {
+  block_q4_0x8 *x = (block_q4_0x8 *)src;
+  for (int i = 0; i < N; ++i) {
+    std::memcpy(&d[i * 8], x[i].d, sizeof(unsigned short) * 8);
+    std::memcpy(&qs[i * 128], x[i].qs, sizeof(unsigned char) * 128);
+  }
+}
+
+void convert_omp(const void *src, unsigned short *d, unsigned char *qs, size_t N) {
+  block_q4_0x8 *x = (block_q4_0x8 *)src;
+#pragma omp parallel for
+  for (int i = 0; i < N; ++i) {
+    std::memcpy(&d[i * 8], x[i].d, sizeof(unsigned short) * 8);
+    std::memcpy(&qs[i * 128], x[i].qs, sizeof(unsigned char) * 128);
+  }
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/cl_operations/blas_kernel_helper.h
+++ b/nntrainer/tensor/cl_operations/blas_kernel_helper.h
@@ -1,0 +1,26 @@
+#ifndef __BLAS_KERNELS_HELPER_H__
+#define __BLAS_KERNELS_HELPER_H__
+
+namespace nntrainer {
+
+/**
+ * @brief Convert array of block_q4_0x8 into two arrays for scale, qs (st)
+ * @param[in] x Array of struct block_q4_0x8
+ * @param[out] d Array of unsigned short
+ * @param[out] qs Array of unsigned char
+ * @param N size of @param x
+ */
+void convert_st(const void *x, unsigned short *d, unsigned char *qs, size_t N);
+
+/**
+ * @brief Convert array of block_q4_0x8 into two arrays for scale, qs (mt)
+ * @param[in] x Array of struct block_q4_0x8
+ * @param[out] d Array of unsigned short
+ * @param[out] qs Array of unsigned char
+ * @param N size of @param x
+ */
+void convert_omp(const void *x, unsigned short *d, unsigned char *qs, size_t N);
+
+} // namespace nntrainer
+
+#endif /* __BLAS_KERNELS_HELPER_H__ */

--- a/nntrainer/tensor/cl_operations/meson.build
+++ b/nntrainer/tensor/cl_operations/meson.build
@@ -1,5 +1,6 @@
 cl_op_sources = [
   'blas_kernels.cpp',
+  'blas_kernel_helper.cpp',
   'blas_kernel_interface.cpp',
   'blas_kernel_strings.cpp',
   'attention_kernel_interface.cpp',


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>Convert q4_0x8 into two arrays, scale and quant </summary><br />

As gemm for q4_0 formatted data has better performance with split arrays , this commit implements

- nntrainer::convert_st (single thread version), and
- nntrainer::convert_omp (multi thread version)

to convert q4_0x8 format data into two arrays, each has
- scales
- quantized values

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>

</details>


### Summary

- Convert q4_0x8 into two arrays, scale and quant

Signed-off-by: Daekyoung Jung dk11.jung@samsung.com
