### PR TITLE
Wrap nntrainer::ErrorNotification with warning suppressor

### DIFF
--- a/nntrainer/nntrainer_error.h
+++ b/nntrainer/nntrainer_error.h
@@ -104,6 +104,11 @@ public:
   explicit ErrorNotification(std::function<void()> cleanup_func_) :
     cleanup_func(cleanup_func_) {}
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4722) // MSVC: destructor never returns
+#endif
+
   /**
    * @brief Destroy the Error Notification object, Error is thrown when
    * destroying this
@@ -119,6 +124,10 @@ public:
     }
     throw Err(ss.str().c_str());
   }
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
   /**
    * @brief Error notification stream wrapper


### PR DESCRIPTION
- Added macros disabling warning (throwing exception in class destructor) to silence compiler warnings (as this throw is intended here)

Not proper way to fix it but if original code is written that way by intention lets at least suppress this warning

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: {your_name} <{your_email}>

