### PR TITLE
[OpenCL] Load clWaitForEvents

### DIFF
--- a/nntrainer/opencl/opencl_loader.cpp
+++ b/nntrainer/opencl/opencl_loader.cpp
@@ -105,6 +105,7 @@ void LoadOpenCLFunctions(void *libopencl) {
   LoadFunction(clEnqueueSVMMap);
   LoadFunction(clEnqueueSVMUnmap);
   LoadFunction(clSetKernelArgSVMPointer);
+  LoadFunction(clWaitForEvents);
 }
 
 PFN_clGetPlatformIDs clGetPlatformIDs;
@@ -141,5 +142,5 @@ PFN_clSVMFree clSVMFree;
 PFN_clEnqueueSVMMap clEnqueueSVMMap;
 PFN_clEnqueueSVMUnmap clEnqueueSVMUnmap;
 PFN_clSetKernelArgSVMPointer clSetKernelArgSVMPointer;
-
+PFN_clWaitForEvents clWaitForEvents;
 } // namespace nntrainer::opencl

--- a/nntrainer/opencl/opencl_loader.h
+++ b/nntrainer/opencl/opencl_loader.h
@@ -16,10 +16,6 @@
 
 #include "CL/cl.h"
 
-#define CL_API_ENTRY
-#define CL_API_CALL
-#define CL_CALLBACK
-
 namespace nntrainer::opencl {
 
 /**
@@ -198,6 +194,9 @@ typedef cl_int(CL_API_CALL *PFN_clEnqueueSVMUnmap)(
   cl_uint /**< num_events_in_wait_list */,
   const cl_event * /**< event_wait_list */, cl_event * /**< event */);
 
+typedef cl_int (CL_API_CALL *PFN_clWaitForEvents)(cl_uint num_events,
+    const cl_event* event_list);
+
 extern PFN_clGetPlatformIDs clGetPlatformIDs;
 extern PFN_clGetDeviceIDs clGetDeviceIDs;
 extern PFN_clGetDeviceInfo clGetDeviceInfo;
@@ -232,7 +231,7 @@ extern PFN_clSVMFree clSVMFree;
 extern PFN_clEnqueueSVMMap clEnqueueSVMMap;
 extern PFN_clEnqueueSVMUnmap clEnqueueSVMUnmap;
 extern PFN_clSetKernelArgSVMPointer clSetKernelArgSVMPointer;
-
+extern PFN_clWaitForEvents clWaitForEvents;
 } // namespace nntrainer::opencl
 
 #endif // __OPENCL_LOADER_H__


### PR DESCRIPTION

## Dependency of the PR
None

## Commits to be reviewed in this PR
fe45afe1

<details><summary>[OpenCL] Load clWaitForEvents</summary><br />

- Enable clWaitForEvents
- Remove macros defined in cl.h (CL_API_ENTRY, CL_API_CALL, CL_CALLBACK)

Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>

</details>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

</details>

### Summary

- [OpenCL] Load clWaitForEvents

Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>
