### PR TITLE
Fix setting kernel args

### DIFF
--- a/nntrainer/layers/cl_layers/concat_cl.cpp
+++ b/nntrainer/layers/cl_layers/concat_cl.cpp
@@ -270,19 +270,19 @@ void ConcatLayerCl::concat_cl_axis3(const float *matAdata,
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -388,19 +388,19 @@ void ConcatLayerCl::concat_cl_axis2(const float *matAdata,
       break;
     }
     result = kernel_concat_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -506,19 +506,19 @@ void ConcatLayerCl::concat_cl_axis1(const float *matAdata,
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -626,19 +626,19 @@ void ConcatLayerCl::concat_cl_axis3_fp16(const _FP16 *matAdata,
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -743,19 +743,19 @@ void ConcatLayerCl::concat_cl_axis2_fp16(const _FP16 *matAdata,
       break;
     }
     result = kernel_concat_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -862,19 +862,19 @@ void ConcatLayerCl::concat_cl_axis1_fp16(const _FP16 *matAdata,
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_concat_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }

--- a/nntrainer/layers/cl_layers/reshape_cl.cpp
+++ b/nntrainer/layers/cl_layers/reshape_cl.cpp
@@ -169,13 +169,13 @@ void ReshapeLayerCl::copy_cl_fp16(const _FP16 *input, _FP16 *res,
     }
 
     result = kernel_copy_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_copy_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      1, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -255,13 +255,13 @@ void ReshapeLayerCl::scopy_cl(const float *input, float *res,
     }
 
     result = kernel_copy_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_copy_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      1, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }

--- a/nntrainer/layers/cl_layers/rmsnorm_layer_cl.cpp
+++ b/nntrainer/layers/cl_layers/rmsnorm_layer_cl.cpp
@@ -132,19 +132,19 @@ void RMSNormLayerCl::rmsnormProcess(Tensor const &input, Tensor &result,
     }
 
     ret = kernel_rmsnorm_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!ret) {
       break;
     }
 
     ret = kernel_rmsnorm_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      1, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!ret) {
       break;
     }
 
     ret = kernel_rmsnorm_ptr->SetKernelArguments(
-      2, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      2, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!ret) {
       break;
     }
@@ -230,19 +230,19 @@ void RMSNormLayerCl::rmsnormProcess_fp16(Tensor const &input, Tensor &result,
     }
 
     ret = kernel_rmsnorm_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!ret) {
       break;
     }
 
     ret = kernel_rmsnorm_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      1, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!ret) {
       break;
     }
 
     ret = kernel_rmsnorm_ptr->SetKernelArguments(
-      2, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      2, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!ret) {
       break;
     }

--- a/nntrainer/layers/cl_layers/swiglu_cl.cpp
+++ b/nntrainer/layers/cl_layers/swiglu_cl.cpp
@@ -147,19 +147,19 @@ void SwiGLULayerCl::swiglu_cl(const float *matAdata, const float *vecXdata,
     }
 
     result = kernel_swiglu_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_swiglu_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_swiglu_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -219,19 +219,19 @@ void SwiGLULayerCl::swiglu_cl_fp16(const _FP16 *matAdata, const _FP16 *vecXdata,
     }
 
     result = kernel_swiglu_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_swiglu_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_swiglu_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }

--- a/nntrainer/tensor/cl_operations/attention_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/attention_kernels.cpp
@@ -103,42 +103,42 @@ void rotary_emb_cl(float *in, float *out,
     }
 
     result = kernel_rotaryEmb_ptr->SetKernelArguments(
-      0, cl_buffer_manager.getInBufferA(), sizeof(cl_mem));
+      0, cl_buffer_manager.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set inputA argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_ptr->SetKernelArguments(
-      1, cl_buffer_manager.getOutBufferA(), sizeof(cl_mem));
+      1, cl_buffer_manager.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set inOutRes argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_ptr->SetKernelArguments(
-      2, cl_buffer_manager.getInBufferB(), sizeof(cl_mem));
+      2, cl_buffer_manager.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set freqs_cosBuf argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_ptr->SetKernelArguments(
-      3, cl_buffer_manager.getInBufferB(), sizeof(cl_mem));
+      3, cl_buffer_manager.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set freqs_sinBuf argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_ptr->SetKernelArguments(
-      4, cl_buffer_manager.getInBufferC(), sizeof(cl_mem));
+      4, cl_buffer_manager.getInBufferC()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set cosBuf argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_ptr->SetKernelArguments(
-      5, cl_buffer_manager.getInBufferC(), sizeof(cl_mem));
+      5, cl_buffer_manager.getInBufferC()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set sinBuf argument\n");
       break;

--- a/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
@@ -104,42 +104,42 @@ void rotary_emb_cl(_FP16 *in, _FP16 *out,
     }
 
     result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
-      0, cl_buffer_manager.getInBufferA(), sizeof(cl_mem));
+      0, cl_buffer_manager.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set inputA argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
-      1, cl_buffer_manager.getOutBufferA(), sizeof(cl_mem));
+      1, cl_buffer_manager.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set inOutRes argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
-      2, cl_buffer_manager.getInBufferB(), sizeof(cl_mem));
+      2, cl_buffer_manager.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set freqs_cosBuf argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
-      3, cl_buffer_manager.getInBufferB(), sizeof(cl_mem));
+      3, cl_buffer_manager.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set freqs_sinBuf argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
-      4, cl_buffer_manager.getInBufferC(), sizeof(cl_mem));
+      4, cl_buffer_manager.getInBufferC()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set cosBuf argument\n");
       break;
     }
 
     result = kernel_rotaryEmb_fp16_ptr->SetKernelArguments(
-      5, cl_buffer_manager.getInBufferC(), sizeof(cl_mem));
+      5, cl_buffer_manager.getInBufferC()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       printf("Failed to set sinBuf argument\n");
       break;

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -251,19 +251,19 @@ void sgemv_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
     }
 
     result = kernel_sgemv_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_sgemv_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_sgemv_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -329,13 +329,13 @@ float dot_cl(const float *vecAdata, const float *vecXdata, unsigned int dim1) {
     }
 
     result = kernel_dot_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_dot_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -346,7 +346,7 @@ float dot_cl(const float *vecAdata, const float *vecXdata, unsigned int dim1) {
     }
 
     result = kernel_dot_ptr->SetKernelArguments(
-      3, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      3, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -430,19 +430,19 @@ void sgemm_cl(bool TransA, bool TransB, const float *A, const float *B,
     }
 
     result = kernel_sgemm_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_sgemm_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_sgemm_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -515,12 +515,12 @@ void addition_cl(const float *input, float *res, unsigned int size_input,
     }
 
     result = kernel_addition_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
     result = kernel_addition_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      1, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -578,8 +578,8 @@ void sscal_cl(float *X, const unsigned int N, const float alpha) {
       break;
     }
 
-    result = kernel_ptr->SetKernelArguments(0, clbuffInstance.getOutBufferA(),
-                                            sizeof(cl_mem));
+    result = kernel_ptr->SetKernelArguments(
+      0, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -658,13 +658,13 @@ void transpose_cl_axis(const float *in, float *res,
     }
 
     result = kernel_transpose_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_transpose_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      1, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }

--- a/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
@@ -63,19 +63,19 @@ void sgemv_cl(const _FP16 *matAdata, const _FP16 *vecXdata, _FP16 *vecYdata,
     }
 
     result = kernel_sgemv_fp16_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_sgemv_fp16_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_sgemv_fp16_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -142,13 +142,13 @@ _FP16 dot_cl(const _FP16 *vecAdata, const _FP16 *vecXdata, unsigned int dim1) {
     }
 
     result = kernel_dot_fp16_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_dot_fp16_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -159,7 +159,7 @@ _FP16 dot_cl(const _FP16 *vecAdata, const _FP16 *vecXdata, unsigned int dim1) {
     }
 
     result = kernel_dot_fp16_ptr->SetKernelArguments(
-      3, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      3, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -243,19 +243,19 @@ void sgemm_cl(bool TransA, bool TransB, const _FP16 *A, const _FP16 *B,
     }
 
     result = kernel_sgemm_fp16_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_sgemm_fp16_ptr->SetKernelArguments(
-      1, clbuffInstance.getInBufferB(), sizeof(cl_mem));
+      1, clbuffInstance.getInBufferB()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_sgemm_fp16_ptr->SetKernelArguments(
-      2, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      2, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -329,13 +329,13 @@ void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
     }
 
     result = kernel_addition_fp16_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_addition_fp16_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      1, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -395,7 +395,7 @@ void sscal_cl(_FP16 *X, const unsigned int N, const float alpha) {
     }
 
     result = kernel_sscal_fp16_ptr->SetKernelArguments(
-      0, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
@@ -475,13 +475,13 @@ void transpose_cl_axis(const _FP16 *in, _FP16 *res,
     }
 
     result = kernel_transpose_fp_16_ptr->SetKernelArguments(
-      0, clbuffInstance.getInBufferA(), sizeof(cl_mem));
+      0, clbuffInstance.getInBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }
 
     result = kernel_transpose_fp_16_ptr->SetKernelArguments(
-      1, clbuffInstance.getOutBufferA(), sizeof(cl_mem));
+      1, clbuffInstance.getOutBufferA()->GetBuffer(), sizeof(cl_mem));
     if (!result) {
       break;
     }


### PR DESCRIPTION
We should use cl_mem instead of opencl::Buffer*
when setting kernel arguments with clSetKernelArg

