### PR TITLE
Unify tensor memory allocation.

### DIFF
--- a/nntrainer/tensor/bcq_tensor.h
+++ b/nntrainer/tensor/bcq_tensor.h
@@ -84,24 +84,14 @@ public:
   void deallocate() override;
 
   /**
-   * @copydoc Tensor::getData()
-   */
-  void *getData() const override;
-
-  /**
    * @copydoc Tensor::getData(size_t idx)
    */
   void *getData(size_t idx) const override;
 
   /**
-   * @copydoc Tensor::getScale()
+   * @copydoc Tensor::hasScale()
    */
-  void *getScale() const override;
-
-  /**
-   * @copydoc Tensor::getScale(size_t idx)
-   */
-  void *getScale(size_t idx) const override;
+  bool hasScale() const override { return true; }
 
   /**
    * @brief     i data index
@@ -303,6 +293,10 @@ private:
    * @brief print quantization scale factors
    */
   void printScales(std::ostream &out) const;
+
+  std::size_t getDataTypeBitsSize() const override {
+    return sizeof(uint32_t) * CHAR_BIT;
+  }
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/char_tensor.h
+++ b/nntrainer/tensor/char_tensor.h
@@ -101,24 +101,9 @@ public:
   void deallocate() override;
 
   /**
-   * @copydoc Tensor::getData()
+   * @copydoc Tensor::hasScale()
    */
-  void *getData() const override;
-
-  /**
-   * @copydoc Tensor::getData(size_t idx)
-   */
-  void *getData(size_t idx) const override;
-
-  /**
-   * @copydoc Tensor::getScale()
-   */
-  void *getScale() const override;
-
-  /**
-   * @copydoc Tensor::getScale(size_t idx)
-   */
-  void *getScale(size_t idx) const override;
+  bool hasScale() const override { return true; }
 
   /**
    * @brief     i data index
@@ -327,6 +312,10 @@ private:
    * @copydoc Tensor::isValid()
    */
   bool isValid() const override { return true; }; // NYI
+
+  std::size_t getDataTypeBitsSize() const override {
+    return sizeof(int8_t) * CHAR_BIT;
+  }
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -68,13 +68,8 @@ void FloatTensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
 
-    mem_data = new MemoryData((void *)(new float[dim.getDataLen()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<float>();
-      delete mem_data;
-    });
+    allocateInternal();
 
     offset = 0;
     initialize();
@@ -84,22 +79,6 @@ void FloatTensor::allocate() {
 void FloatTensor::deallocate() {
   data = nullptr;
   offset = 0;
-}
-
-void *FloatTensor::getData() const {
-  if (!data)
-    return nullptr;
-
-  data->validate();
-  return data->getAddr<float>() + offset;
-}
-
-void *FloatTensor::getData(size_t idx) const {
-  if (!data)
-    return nullptr;
-
-  data->validate();
-  return data->getAddr<float>() + offset + idx;
 }
 
 void *FloatTensor::getAddress(unsigned int i) {
@@ -182,6 +161,8 @@ void FloatTensor::setRandBernoulli(float probability) {
 void FloatTensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  TensorBase::initialize();
 
   unsigned int fan_in, fan_out;
 

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -84,12 +84,7 @@ public:
     contiguous = true;
     initializer = Initializer::NONE;
 
-    MemoryData *mem_data =
-      new MemoryData((void *)(new float[dim.getDataLen()]()));
-    data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
-      delete[] mem_data->getAddr<float>();
-      delete mem_data;
-    });
+    allocateInternal();
 
     offset = 0;
 
@@ -145,16 +140,6 @@ public:
    * @copydoc Tensor::deallocate()
    */
   void deallocate() override;
-
-  /**
-   * @copydoc Tensor::getData()
-   */
-  void *getData() const override;
-
-  /**
-   * @copydoc Tensor::getData(size_t idx)
-   */
-  void *getData(size_t idx) const override;
 
   /**
    * @brief     i data index
@@ -564,6 +549,10 @@ private:
    */
   Tensor &dotQInteger(Tensor const &input, Tensor &output, bool trans,
                       bool trans_in, float beta, Tdatatype dtype) const;
+
+  std::size_t getDataTypeBitsSize() const override {
+    return sizeof(float) * CHAR_BIT;
+  }
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -61,13 +61,7 @@ void HalfTensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    mem_data = new MemoryData((void *)(new _FP16[dim.getDataLen()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<_FP16>();
-      delete mem_data;
-    });
+    allocateInternal();
 
     offset = 0;
     initialize();
@@ -77,22 +71,6 @@ void HalfTensor::allocate() {
 void HalfTensor::deallocate() {
   data = nullptr;
   offset = 0;
-}
-
-void *HalfTensor::getData() const {
-  if (!data)
-    return nullptr;
-
-  data->validate();
-  return data->getAddr<_FP16>() + offset;
-}
-
-void *HalfTensor::getData(size_t idx) const {
-  if (!data)
-    return nullptr;
-
-  data->validate();
-  return data->getAddr<_FP16>() + offset + idx;
 }
 
 void *HalfTensor::getAddress(unsigned int i) {
@@ -175,6 +153,8 @@ void HalfTensor::setRandBernoulli(float probability) {
 void HalfTensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  TensorBase::initialize();
 
   unsigned int fan_in, fan_out;
 

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -83,12 +83,7 @@ public:
     contiguous = true;
     initializer = Initializer::NONE;
 
-    MemoryData *mem_data =
-      new MemoryData((void *)(new _FP16[dim.getDataLen()]()));
-    data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
-      delete[] mem_data->getAddr<_FP16>();
-      delete mem_data;
-    });
+    allocateInternal();
 
     offset = 0;
 
@@ -145,16 +140,6 @@ public:
    * @copydoc Tensor::deallocate()
    */
   void deallocate() override;
-
-  /**
-   * @copydoc Tensor::getData()
-   */
-  void *getData() const override;
-
-  /**
-   * @copydoc Tensor::getData(size_t idx)
-   */
-  void *getData(size_t idx) const override;
 
   /**
    * @brief     i data index
@@ -531,6 +516,10 @@ private:
    * @copydoc Tensor::isValid()
    */
   bool isValid() const override;
+
+  std::size_t getDataTypeBitsSize() const override {
+    return sizeof(_FP16) * CHAR_BIT;
+  }
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/int4_tensor.cpp
+++ b/nntrainer/tensor/int4_tensor.cpp
@@ -70,15 +70,7 @@ Int4QTensor::Int4QTensor(
   initializer = Initializer::NONE;
   qscheme = qscheme_;
 
-  /// @note sizeof(float) * scale_size() assumes scale factors are in
-  /// full-precision fp.
-  MemoryData *mem_data =
-    new MemoryData((void *)(new int8_t[(dim.getDataLen() + 1) / 2 +
-                                       sizeof(float) * scale_size()]()));
-  data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
-    delete[] mem_data->getAddr<int8_t>();
-    delete mem_data;
-  });
+  allocateInternal();
 
   offset = 0;
 
@@ -133,16 +125,7 @@ void Int4QTensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    /// quantized 4-bit is stored as a 8-bit signed integer (int4x2)
-    mem_data =
-      new MemoryData((void *)(new int8_t[(dim.getDataLen() + 1) / 2 +
-                                         sizeof(float) * scale_size()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<int8_t>();
-      delete mem_data;
-    });
+    allocateInternal();
 
     offset = 0;
     initialize();
@@ -152,41 +135,6 @@ void Int4QTensor::allocate() {
 void Int4QTensor::deallocate() {
   data = nullptr;
   offset = 0;
-}
-
-void *Int4QTensor::getData() const {
-  if (!data)
-    return nullptr;
-
-  data->validate();
-  return data->getAddr<int8_t>() + offset;
-}
-
-void *Int4QTensor::getData(size_t idx) const {
-  if (!data)
-    return nullptr;
-
-  data->validate();
-  return data->getAddr<int8_t>() + offset + (idx / 2);
-}
-
-void *Int4QTensor::getScale() const {
-  if (!data)
-    return nullptr;
-
-  data->validate();
-  return ((int8_t *)getData()) + (size() + 1) / 2;
-}
-
-void *Int4QTensor::getScale(size_t idx) const {
-  NNTR_THROW_IF(idx > scale_size(), std::invalid_argument)
-    << "Tensor::getScale() index is not valid";
-
-  if (!data)
-    return nullptr;
-
-  data->validate();
-  return ((float *)getScale()) + idx;
 }
 
 void *Int4QTensor::getAddress(unsigned int i) {
@@ -274,6 +222,8 @@ void Int4QTensor::setZero() {
 void Int4QTensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  TensorBase::initialize();
 
   /// @note Sampling from the normal/uniform distribution is invalid
   switch (initializer) {

--- a/nntrainer/tensor/int4_tensor.h
+++ b/nntrainer/tensor/int4_tensor.h
@@ -111,24 +111,9 @@ public:
   void deallocate() override;
 
   /**
-   * @copydoc Tensor::getData()
+   * @copydoc Tensor::hasScale()
    */
-  void *getData() const override;
-
-  /**
-   * @copydoc Tensor::getData(size_t idx)
-   */
-  void *getData(size_t idx) const override;
-
-  /**
-   * @copydoc Tensor::getScale()
-   */
-  void *getScale() const override;
-
-  /**
-   * @copydoc Tensor::getScale(size_t idx)
-   */
-  void *getScale(size_t idx) const override;
+  bool hasScale() const override { return true; }
 
   /**
    * @brief     i data index
@@ -331,6 +316,10 @@ private:
    * @copydoc Tensor::isValid()
    */
   bool isValid() const override { return true; };
+
+  std::size_t getDataTypeBitsSize() const override {
+    return sizeof(int8_t) * CHAR_BIT / 2;
+  }
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/memory_data.h
+++ b/nntrainer/tensor/memory_data.h
@@ -14,6 +14,8 @@
 #ifndef __MEMORY_DATA_H__
 #define __MEMORY_DATA_H__
 
+#include <cstdint>
+#include <cstdlib>
 #include <functional>
 
 namespace nntrainer {
@@ -27,94 +29,109 @@ class MemoryData {
 public:
   /**
    * @brief  Constructor of Memory Data
-   * @param[in] addr Memory data
+   * @param[in] addres Memory data address
+   * @param[in] own_memory Memory ownership flag
    */
-  explicit MemoryData(void *addr) :
-    valid(true),
-    id(0),
-    address(addr),
-    validate_cb([](unsigned int) {}),
-    invalidate_cb([](unsigned int) {}) {}
+  explicit MemoryData(void *address, bool own_memory) :
+    valid_(true),
+    id_(0),
+    address_(address),
+    own_memory_(own_memory),
+    validate_cb_([](unsigned int) {}),
+    invalidate_cb_([](unsigned int) {}) {}
 
   /**
    * @brief  Constructor of Memory Data
-   * @param[in] mem_id validate callback.
-   * @param[in] v_cb validate callback.
-   * @param[in] i_cb invalidate callback.
+   * @param[in] id validate callback.
+   * @param[in] validate_cb validate callback.
+   * @param[in] invalidate_cb invalidate callback.
    */
-  explicit MemoryData(unsigned int mem_id, MemoryDataValidateCallback v_cb,
-                      MemoryDataValidateCallback i_cb,
-                      void *memory_ptr = nullptr) :
-    valid(false),
-    id(mem_id),
-    address(memory_ptr),
-    validate_cb(v_cb),
-    invalidate_cb(i_cb) {}
+  explicit MemoryData(unsigned int id, MemoryDataValidateCallback validate_cb,
+                      MemoryDataValidateCallback invalidate_cb,
+                      void *address = nullptr) :
+    valid_(false),
+    id_(id),
+    address_(address),
+    own_memory_(false),
+    validate_cb_(validate_cb),
+    invalidate_cb_(invalidate_cb) {}
 
   /**
    * @brief  Deleted constructor of Memory Data
    */
   explicit MemoryData() = delete;
 
-  /**
-   * @brief  Constructor of MemoryData
-   */
-  explicit MemoryData(MemoryDataValidateCallback v_cb,
-                      MemoryDataValidateCallback i_cb) = delete;
-  /**
-   * @brief  Constructor of MemoryData
-   */
-  explicit MemoryData(void *addr, MemoryDataValidateCallback v_cb,
-                      MemoryDataValidateCallback i_cb) = delete;
+  MemoryData(const MemoryData &) = delete;
+
+  MemoryData &operator=(const MemoryData &) = delete;
 
   /**
    * @brief  Destructor of Memory Data
    */
-  virtual ~MemoryData() = default;
+  ~MemoryData() {
+    if (own_memory_ && (address_ != nullptr)) {
+#if defined(_WIN32)
+      _aligned_free(address_);
+#else
+      std::free(address_);
+#endif
+    }
+  };
 
   /**
    * @brief  Set address
    */
-  void setAddr(void *addr) { address = addr; }
+  void setAddr(void *address) { address_ = address; }
 
   /**
    * @brief  Get address
    */
   template <typename T = float> T *getAddr() const {
-    return static_cast<T *>(address);
+    return static_cast<T *>(address_);
   }
 
   /**
    * @brief  Validate memory data
    */
   void validate() {
-    if (valid)
+    if (valid_) {
       return;
-    if (validate_cb != nullptr)
-      validate_cb(id);
+    }
+
+    if (validate_cb_ != nullptr) {
+      validate_cb_(id_);
+    }
   }
 
   /**
    * @brief  Invalidate memory data
    */
   void invalidate() {
-    if (!valid)
+    if (!valid_) {
       return;
-    if (invalidate_cb != nullptr)
-      invalidate_cb(id);
+    }
+
+    if (invalidate_cb_ != nullptr) {
+      invalidate_cb_(id_);
+    }
   }
 
   /**
    * @brief  Set valid
    */
-  void setValid(bool v) { valid = v; }
+  void setValid(bool valid) { valid_ = valid; }
+
+  bool is_aligned(const void *pointer, const std::size_t alignment) {
+    return ((reinterpret_cast<uintptr_t>(pointer) % alignment) == 0);
+  }
 
 private:
-  bool valid;
-  unsigned int id;
-  void *address;
-  MemoryDataValidateCallback validate_cb;
-  MemoryDataValidateCallback invalidate_cb;
+  bool valid_;
+  unsigned int id_;
+  void *address_;
+  bool own_memory_;
+  MemoryDataValidateCallback validate_cb_;
+  MemoryDataValidateCallback invalidate_cb_;
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -252,12 +252,14 @@ void MemoryPool::allocateFSU() {
  */
 std::shared_ptr<MemoryData> MemoryPool::getMemory(unsigned int idx) {
 #if defined(__ANDROID__)
-  auto mem_data = std::make_shared<MemoryData>((void *)memory_ptrs.at(idx - 1));
+  auto mem_data =
+    std::make_shared<MemoryData>((void *)memory_ptrs.at(idx - 1), false);
 #else
   if (mem_pool == nullptr)
     throw std::invalid_argument("Getting memory before allocation");
 
-  auto mem_data = std::make_shared<MemoryData>((void *)memory_ptrs.at(idx - 1));
+  auto mem_data =
+    std::make_shared<MemoryData>((void *)memory_ptrs.at(idx - 1), false);
 #endif
   return mem_data;
 }

--- a/nntrainer/tensor/q4_0_tensor.cpp
+++ b/nntrainer/tensor/q4_0_tensor.cpp
@@ -50,25 +50,11 @@ void Q4_0_Tensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    mem_data = new MemoryData((void *)(new uint8_t[size()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<uint8_t>();
-      delete mem_data;
-    });
+    allocateInternal();
 
     offset = 0;
     initialize();
   }
-}
-
-void *Q4_0_Tensor::getData() const {
-  if (!data)
-    return nullptr;
-
-  data->validate();
-  return data->getAddr<uint8_t>() + offset;
 }
 
 size_t Q4_0_Tensor::size() const {
@@ -97,6 +83,8 @@ void Q4_0_Tensor::setZero() {
 void Q4_0_Tensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  TensorBase::initialize();
 
   setZero();
   putData();

--- a/nntrainer/tensor/q4_0_tensor.h
+++ b/nntrainer/tensor/q4_0_tensor.h
@@ -81,19 +81,6 @@ public:
   }
 
   /**
-   * @copydoc Tensor::getData()
-   */
-  void *getData() const override;
-
-  /**
-   * @copydoc Tensor::getData()
-   */
-  void *getData(size_t idx) const override {
-    throw std::invalid_argument(
-      "Q4_0_Tensor::getData() is not supported. Use getData() instead.");
-  }
-
-  /**
    * @copydoc Tensor::getAddress()
    */
   void *getAddress(unsigned int i) override {
@@ -230,6 +217,10 @@ private:
    * @copydoc Tensor::isValid()
    */
   bool isValid() const override { return true; }
+
+  std::size_t getDataTypeBitsSize() const override {
+    return sizeof(uint8_t) * CHAR_BIT;
+  }
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/q4_k_tensor.cpp
+++ b/nntrainer/tensor/q4_k_tensor.cpp
@@ -45,6 +45,17 @@ Q4_K_Tensor::Q4_K_Tensor(const TensorDim &d, const void *buf,
   }
 }
 
+bool Q4_K_Tensor::operator==(const Q4_K_Tensor &rhs) const {
+  if (qscheme != rhs.qscheme)
+    return false;
+
+  // compare quantized data
+  const uint8_t *_data = (uint8_t *)getData();
+  const uint8_t *_rdata = (uint8_t *)rhs.getData();
+
+  return std::equal(_data, _data + size(), _rdata);
+}
+
 void Q4_K_Tensor::allocate() {
   if (empty() || data)
     return;
@@ -55,13 +66,7 @@ void Q4_K_Tensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    mem_data = new MemoryData((void *)(new uint8_t[size()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<uint8_t>();
-      delete mem_data;
-    });
+    allocateInternal();
 
     offset = 0;
     initialize();

--- a/nntrainer/tensor/q4_k_tensor.h
+++ b/nntrainer/tensor/q4_k_tensor.h
@@ -72,9 +72,25 @@ public:
   Q4_K_Tensor(TensorBase &rhs) : Uint4QTensor(rhs, QScheme::Q4_Kx8) {}
 
   /**
+   * @brief     Comparison operator overload
+   * @param[in] rhs Tensor to be compared with
+   */
+  bool operator==(const Q4_K_Tensor &rhs) const;
+
+  /**
    * @copydoc Tensor::allocate()
    */
   void allocate() override;
+
+  /**
+   * @copydoc Tensor::hasScale()
+   */
+  bool hasScale() const override { return false; }
+
+  /**
+   * @copydoc Tensor::hasZeroPoint()
+   */
+  bool hasZeroPoint() const override { return false; }
 
   /**
    * @copydoc TensorBase::size()
@@ -110,6 +126,10 @@ private:
    * @copydoc Tensor::isValid()
    */
   bool isValid() const override { return true; }
+
+  std::size_t getDataTypeBitsSize() const override {
+    return sizeof(uint8_t) * CHAR_BIT;
+  }
 
 }; // class Q4_K_Tensor
 

--- a/nntrainer/tensor/q6_k_tensor.cpp
+++ b/nntrainer/tensor/q6_k_tensor.cpp
@@ -47,25 +47,11 @@ void Q6_K_Tensor::allocate() {
     /** as this memory is shared, do NOT initialize */
   } else {
     /// allocate new memory for the tensor data
-    MemoryData *mem_data;
-
-    mem_data = new MemoryData((void *)(new uint8_t[size()]{}));
-    data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
-      delete[] mem_data->template getAddr<uint8_t>();
-      delete mem_data;
-    });
+    allocateInternal();
 
     offset = 0;
     initialize();
   }
-}
-
-void *Q6_K_Tensor::getData() const {
-  if (!data)
-    return nullptr;
-
-  data->validate();
-  return data->getAddr<uint8_t>() + offset;
 }
 
 size_t Q6_K_Tensor::size() const {
@@ -94,6 +80,8 @@ void Q6_K_Tensor::setZero() {
 void Q6_K_Tensor::initialize() {
   if (empty() || !isAllocated())
     return;
+
+  TensorBase::initialize();
 
   setZero();
   putData();

--- a/nntrainer/tensor/q6_k_tensor.h
+++ b/nntrainer/tensor/q6_k_tensor.h
@@ -81,19 +81,6 @@ public:
   }
 
   /**
-   * @copydoc Tensor::getData()
-   */
-  void *getData() const override;
-
-  /**
-   * @copydoc Tensor::getData()
-   */
-  void *getData(size_t idx) const override {
-    throw std::invalid_argument(
-      "Q6_K_Tensor::getData() is not supported. Use getData() instead.");
-  }
-
-  /**
    * @copydoc Tensor::getAddress()
    */
   void *getAddress(unsigned int i) override {
@@ -230,6 +217,10 @@ private:
    * @copydoc Tensor::isValid()
    */
   bool isValid() const override { return true; }
+
+  std::size_t getDataTypeBitsSize() const override {
+    return sizeof(uint8_t) * CHAR_BIT;
+  }
 
 }; // class Q6_K_Tensor
 

--- a/nntrainer/tensor/quantizer.cpp
+++ b/nntrainer/tensor/quantizer.cpp
@@ -143,7 +143,7 @@ Tensor &PerTensorAffineQuantizer::quantize(const Tensor &input, Tensor &output,
       }
     }
   }
-  *output.getScale<float>() = *scales;
+  *output.getScale() = *scales;
 
   if (output.getDataType() == Tdatatype::UINT4 ||
       output.getDataType() == Tdatatype::UINT8 ||
@@ -163,7 +163,7 @@ Tensor PerTensorAffineQuantizer::dequantize(const Tensor &input,
     output.subtract_i(*input.getZeroPoint());
   }
 
-  output.multiply_i(*input.getScale<float>());
+  output.multiply_i(*input.getScale());
 
   return output;
 }

--- a/nntrainer/tensor/short_tensor.h
+++ b/nntrainer/tensor/short_tensor.h
@@ -94,24 +94,9 @@ public:
   void deallocate() override;
 
   /**
-   * @copydoc Tensor::getData()
+   * @copydoc Tensor::hasScale()
    */
-  void *getData() const override;
-
-  /**
-   * @copydoc Tensor::getData(size_t idx)
-   */
-  void *getData(size_t idx) const override;
-
-  /**
-   * @copydoc Tensor::getScale()
-   */
-  void *getScale() const override;
-
-  /**
-   * @copydoc Tensor::getScale(size_t idx)
-   */
-  void *getScale(size_t idx) const override;
+  bool hasScale() const override { return true; }
 
   /**
    * @brief     i data index
@@ -295,6 +280,10 @@ private:
    * @copydoc Tensor::isValid()
    */
   bool isValid() const override { return true; };
+
+  std::size_t getDataTypeBitsSize() const override {
+    return sizeof(int16_t) * CHAR_BIT;
+  }
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -565,19 +565,27 @@ public:
 
   /**
    * @brief     return scale pointer of Tensor
-   * @retval    template T pointer
+   * @retval    float pointer
    */
-  template <typename T = float> T *getScale() const {
-    return (T *)itensor_->getScale();
-  }
+  float *getScale() const { return itensor_->getScale(); }
 
   /**
    * @brief     return scale pointer of Tensor
-   * @retval    template T pointer
+   * @retval    float pointer
    */
-  template <typename T = float> T *getScale(size_t idx) const {
-    return (T *)itensor_->getScale(idx);
-  }
+  float *getScale(size_t idx) const { return itensor_->getScale(idx); }
+
+  /**
+   * @brief     set scale of Tensor to given const value
+   * @param[in] value of scale to set
+   */
+  void setScale(const float value) { itensor_->setScale(value); }
+
+  /**
+   * @brief     check if tensor have scale
+   * @retval    tensor has scale flag
+   */
+  bool hasScale() const { return itensor_->hasScale(); }
 
   /**
    * @brief     return zero point pointer of Tensor
@@ -592,6 +600,18 @@ public:
   unsigned int *getZeroPoint(size_t idx) const {
     return itensor_->getZeroPoint(idx);
   }
+
+  /**
+   * @brief     set zero points of Tensor to given const value
+   * @param[in] value of zero point to set
+   */
+  void setZeroPoint(const unsigned int value) { itensor_->setZeroPoint(value); }
+
+  /**
+   * @brief     check if tensor have zero point
+   * @retval    tensor has zero point flag
+   */
+  bool hasZeroPoint() const { return itensor_->hasZeroPoint(); }
 
   /**
    * @brief     i data index

--- a/nntrainer/tensor/uint4_tensor.h
+++ b/nntrainer/tensor/uint4_tensor.h
@@ -115,34 +115,14 @@ public:
   void deallocate() override;
 
   /**
-   * @copydoc Tensor::getData()
+   * @copydoc Tensor::hasScale()
    */
-  void *getData() const override;
+  bool hasScale() const override { return true; }
 
   /**
-   * @copydoc Tensor::getData(size_t idx)
+   * @copydoc Tensor::hasZeroPoint()
    */
-  void *getData(size_t idx) const override;
-
-  /**
-   * @copydoc Tensor::getScale()
-   */
-  void *getScale() const override;
-
-  /**
-   * @copydoc Tensor::getScale(size_t idx)
-   */
-  void *getScale(size_t idx) const override;
-
-  /**
-   * @copydoc Tensor::getZeroPoint()
-   */
-  unsigned int *getZeroPoint() const override;
-
-  /**
-   * @copydoc Tensor::getZeroPoint(size_t idx)
-   */
-  unsigned int *getZeroPoint(size_t idx) const override;
+  bool hasZeroPoint() const override { return true; }
 
   /**
    * @brief     i data index
@@ -338,6 +318,10 @@ protected:
    * @copydoc Tensor::isValid()
    */
   bool isValid() const override { return true; };
+
+  std::size_t getDataTypeBitsSize() const override {
+    return sizeof(uint8_t) * CHAR_BIT / 2;
+  }
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/uint_tensor.h
+++ b/nntrainer/tensor/uint_tensor.h
@@ -106,34 +106,14 @@ public:
   void deallocate() override;
 
   /**
-   * @copydoc Tensor::getData()
+   * @copydoc Tensor::hasScale()
    */
-  void *getData() const override;
+  bool hasScale() const override { return true; }
 
   /**
-   * @copydoc Tensor::getData(size_t idx)
+   * @copydoc Tensor::hasZeroPoint()
    */
-  void *getData(size_t idx) const override;
-
-  /**
-   * @copydoc Tensor::getScale()
-   */
-  void *getScale() const override;
-
-  /**
-   * @copydoc Tensor::getScale(size_t idx)
-   */
-  void *getScale(size_t idx) const override;
-
-  /**
-   * @copydoc Tensor::getZeroPoint()
-   */
-  unsigned int *getZeroPoint() const override;
-
-  /**
-   * @copydoc Tensor::getZeroPoint(size_t idx)
-   */
-  unsigned int *getZeroPoint(size_t idx) const override;
+  bool hasZeroPoint() const override { return true; }
 
   /**
    * @brief     i data index
@@ -352,6 +332,10 @@ private:
    * @copydoc Tensor::isValid()
    */
   bool isValid() const override { return true; }; // NYI
+
+  std::size_t getDataTypeBitsSize() const override {
+    return sizeof(T) * CHAR_BIT;
+  }
 };
 
 /******  Alias for UIntTensors ******/

--- a/nntrainer/utils/util_func.cpp
+++ b/nntrainer/utils/util_func.cpp
@@ -277,4 +277,9 @@ float fixedPointAndExponentToFloat(int fixedpoint, int exponent) {
   return std::ldexp(mantissa, exponent);
 }
 
+size_t roundNumberTo(const size_t number, const size_t round_to) {
+  return ((number / round_to) + (((number % round_to) != 0) ? 1 : 0)) *
+         round_to;
+}
+
 } // namespace nntrainer

--- a/nntrainer/utils/util_func.h
+++ b/nntrainer/utils/util_func.h
@@ -446,6 +446,8 @@ void floatToFixedPointAndExponent(float input, int &fixedpoint, int &exponent);
  */
 float fixedPointAndExponentToFloat(int fixedpoint, int exponent);
 
+size_t roundNumberTo(const size_t number, const size_t round_to);
+
 } /* namespace nntrainer */
 
 #endif /* __cplusplus */

--- a/test/unittest/layers/layers_golden_tests.cpp
+++ b/test/unittest/layers/layers_golden_tests.cpp
@@ -26,8 +26,8 @@
 
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 
-#define EXPECT_IN_RANGE(VAL, MIN, MAX) \
-  EXPECT_GE((VAL), (MIN));             \
+#define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
+  EXPECT_GE((VAL), (MIN));                                                     \
   EXPECT_LE((VAL), (MAX))
 
 using namespace nntrainer;
@@ -145,7 +145,10 @@ static TensorPacks prepareTensors(const InitLayerContext &context,
         sizeCheckedReadTensor(weights.back().getVariableRef(), file,
                               weights.back().getName());
       }
-      weights.back().getGradientRef().setZero();
+
+      if (weights.back().getGradientRef().isAllocated()) {
+        weights.back().getGradientRef().setZero();
+      }
     }
     return weights;
   };

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -228,7 +228,7 @@ TEST(nntrainer_Tensor, Tensor_04_p) {
   if (tensor.getValue<int8_t>(0, 0, 0, 1) != 1)
     status = ML_ERROR_INVALID_PARAMETER;
 
-  float *scale_data = tensor.getScale<float>();
+  float *scale_data = tensor.getScale();
 
   for (unsigned int idx = 0; idx < scales.size(); ++idx) {
     ASSERT_FLOAT_EQ(scale_data[idx], scales[idx]);
@@ -339,7 +339,7 @@ TEST(nntrainer_Tensor, QTensor_01_p) {
     }
   }
 
-  float *tensor_scales = tensor.getScale<float>();
+  float *tensor_scales = tensor.getScale();
 
   // check scale factors
   for (unsigned int idx = 0; idx < scales.size(); ++idx) {
@@ -412,7 +412,7 @@ TEST(nntrainer_Tensor, QTensor_03_p) {
     }
   }
 
-  ASSERT_FLOAT_EQ(*tensor.getScale<float>(), 3.561f);
+  ASSERT_FLOAT_EQ(*tensor.getScale(), 3.561f);
 }
 
 /**
@@ -462,7 +462,7 @@ TEST(nntrainer_Tensor, QTensor_05_p) {
   }
 
   // compare scale factors
-  float *tensor_scales = tensor.getScale<float>();
+  float *tensor_scales = tensor.getScale();
 
   for (unsigned int idx = 0; idx < scales.size(); ++idx) {
     ASSERT_FLOAT_EQ(tensor_scales[idx], scales[idx]);
@@ -505,7 +505,7 @@ TEST(nntrainer_Tensor, QTensor_06_p) {
     }
   }
 
-  float *tensor_scales = tensor.getScale<float>();
+  float *tensor_scales = tensor.getScale();
   unsigned int *tensor_zero_points = tensor.getZeroPoint();
 
   for (unsigned int idx = 0; idx < scales.size(); ++idx) {
@@ -546,7 +546,7 @@ TEST(nntrainer_Tensor, QTensor_07_p) {
     }
   }
 
-  float *tensor_scales = tensor.getScale<float>();
+  float *tensor_scales = tensor.getScale();
   unsigned int *tensor_zero_points = tensor.getZeroPoint();
 
   for (unsigned int idx = 0; idx < scales.size(); ++idx) {
@@ -587,7 +587,7 @@ TEST(nntrainer_Tensor, QTensor_08_p) {
     }
   }
 
-  float *tensor_scales = tensor.getScale<float>();
+  float *tensor_scales = tensor.getScale();
   unsigned int *tensor_zero_points = tensor.getZeroPoint();
 
   for (unsigned int idx = 0; idx < scales.size(); ++idx) {
@@ -642,11 +642,11 @@ TEST(nntrainer_Tensor, QTensor_10_n) {
  */
 TEST(nntrainer_Tensor, QTensor_11_n) {
   EXPECT_ANY_THROW(nntrainer::Tensor q4_k_tensor(
-    {1, 1, 4, 256, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::UINT4}, true,
+    {1, 1, 4, 256, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::Q4_K}, true,
     nntrainer::Initializer::NONE, "q4_k_tensor", nntrainer::QScheme::Q4_Kx8));
 
   EXPECT_ANY_THROW(nntrainer::Tensor q4_k_tensor(
-    {1, 1, 8, 8, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::UINT4}, true,
+    {1, 1, 8, 8, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::Q4_K}, true,
     nntrainer::Initializer::NONE, "q4_k_tensor", nntrainer::QScheme::Q4_Kx8));
 }
 
@@ -656,9 +656,8 @@ TEST(nntrainer_Tensor, QTensor_11_n) {
 TEST(nntrainer_Tensor, QTensor_12_p) {
   // This will create a single q4_kx8 block
   nntrainer::Tensor q4_k_tensor(
-    {1, 1, 8, 256, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::UINT4},
-    false, nntrainer::Initializer::NONE, "q4_k_tensor",
-    nntrainer::QScheme::Q4_Kx8);
+    {1, 1, 8, 256, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::Q4_K}, false,
+    nntrainer::Initializer::NONE, "q4_k_tensor", nntrainer::QScheme::Q4_Kx8);
 
   EXPECT_EQ(q4_k_tensor.getData<uint8_t>(), nullptr);
   EXPECT_EQ(q4_k_tensor.q_scheme(), nntrainer::QScheme::Q4_Kx8);
@@ -1587,7 +1586,7 @@ TEST(nntrainer_Tensor, copy_14_p) {
     {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::UINT16});
   GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
 
-  *input.getScale<float>() = 1.536f;
+  *input.getScale() = 1.536f;
   *input.getZeroPoint() = 12;
 
   nntrainer::Tensor output(
@@ -4787,7 +4786,7 @@ TEST(nntrainer_Tensor, save_read_03_p) {
   GEN_TEST_INPUT(target, i * (channel * width * height) + j * (height * width) +
                            k * (width) + l + 1);
 
-  *target.getScale<float>() = 1.536f;
+  *target.getScale() = 1.536f;
   *target.getZeroPoint() = 12;
 
   std::ofstream save_file("save_quint16.bin", std::ios::out | std::ios::binary);
@@ -4807,12 +4806,12 @@ TEST(nntrainer_Tensor, save_read_03_p) {
 
 TEST(nntrainer_Tensor, save_read_04_p) {
   nntrainer::Tensor target(
-    {1, 1, 512, 768, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::UINT4},
+    {1, 1, 512, 768, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::Q4_K},
     true, nntrainer::Initializer::NONE, "q4_k_tensor",
     nntrainer::QScheme::Q4_Kx8);
 
   nntrainer::Tensor readed(
-    {1, 1, 512, 768, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::UINT4},
+    {1, 1, 512, 768, nntrainer::Tformat::NCHW, nntrainer::Tdatatype::Q4_K},
     true, nntrainer::Initializer::NONE, "q4_k_tensor",
     nntrainer::QScheme::Q4_Kx8);
 
@@ -5401,7 +5400,7 @@ TEST(nntrainer_Tensor, print_small_size_02) {
            << "         1          1 \n"
            << "         1          1 \n"
            << "\n"
-           << "-------\nScale factors: 0 \n";
+           << "-------\nScale factors: 1 \n";
 
   EXPECT_EQ(ss.str(), expected.str());
 }
@@ -5597,13 +5596,11 @@ TEST(nntrainer_Tensor, initialize_01_p) {
 
 TEST(nntrainer_Tensor, initialize_02_p) {
   nntrainer::Tensor t({1, 2, 3, 4}, true);
+  t.initialize(nntrainer::Initializer::ONES);
 
   nntrainer::Tensor golden(1, 2, 3, 4);
   golden.setValue(1);
 
-  EXPECT_NE(golden, t);
-
-  t.initialize(nntrainer::Initializer::ONES);
   EXPECT_EQ(golden, t);
 }
 

--- a/test/unittest/unittest_nntrainer_tensor_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_fp16.cpp
@@ -4968,13 +4968,11 @@ TEST(nntrainer_Tensor, initialize_02_p) {
   t_type.data_type = nntrainer::Tdatatype::FP16;
 
   nntrainer::Tensor t({1, 2, 3, 4, t_type}, true);
+  t.initialize(nntrainer::Initializer::ONES);
 
   nntrainer::Tensor golden(1, 2, 3, 4, t_type);
   golden.setValue(1);
 
-  EXPECT_NE(golden, t);
-
-  t.initialize(nntrainer::Initializer::ONES);
   EXPECT_EQ(golden, t);
 }
 


### PR DESCRIPTION
1. This PR unify the code for tensor data memory allocation.
Instead of repeating code for data allocation and data access 11 times (for every tensor type) we've got now single function in tensor base which is responsible for that.
2. This PR also fix problem with not allocated scale and zero point data