### PR TITLE
[unittest] add negative unittests

### DIFF
--- a/test/unittest/layers/unittest_layer_node.cpp
+++ b/test/unittest/layers/unittest_layer_node.cpp
@@ -136,6 +136,58 @@ TEST(nntrainer_LayerNode, finalize_05_n) {
 }
 
 /**
+ * @brief finalize with invalid input_shape (1D)
+ */
+TEST(nntrainer_LayerNode, finalize_06_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+  EXPECT_NO_THROW(lnode->setProperty({"input_shape=1"}));
+
+  EXPECT_THROW(lnode->finalize(), std::invalid_argument);
+}
+
+/**
+ * @brief finalize with invalid input_shape (2D)
+ */
+TEST(nntrainer_LayerNode, finalize_07_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+  EXPECT_NO_THROW(lnode->setProperty({"input_shape=1:1"}));
+
+  EXPECT_THROW(lnode->finalize(), std::invalid_argument);
+}
+
+/**
+ * @brief finalize with missing input_shape
+ */
+TEST(nntrainer_LayerNode, finalize_08_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+  EXPECT_NO_THROW(lnode->setProperty({}));
+
+  EXPECT_THROW(lnode->finalize(), std::invalid_argument);
+}
+
+/**
+ * @brief finalize with invalid input_shape (negative value)
+ */
+TEST(nntrainer_LayerNode, finalize_09_n) {
+  std::unique_ptr<nntrainer::LayerNode> lnode;
+
+  EXPECT_NO_THROW(lnode =
+                    nntrainer::createLayerNode(nntrainer::IdentityLayer::type));
+  EXPECT_NO_THROW(lnode->setProperty({"input_shape=-1:1:1"}));
+
+  EXPECT_THROW(lnode->finalize(), std::invalid_argument);
+}
+
+/**
  * @brief getRunContext for empty run_context
  */
 TEST(nntrainer_LayerNode, getRunContext_01_n) {

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -120,6 +120,70 @@ TEST(nntrainer_TensorDim, setTensorDim_04_p) {
   EXPECT_EQ(d.width(), 7u);
 }
 
+TEST(nntrainer_TensorDim, setTensorDim_05_n) {
+  nntrainer::TensorDim d;
+
+  EXPECT_THROW(d.setTensorDim(0, 0), std::invalid_argument);
+}
+
+TEST(nntrainer_TensorDim, setTensorDim_06_n) {
+  nntrainer::TensorDim d;
+
+  EXPECT_THROW(d.setTensorDim(1, 0), std::invalid_argument);
+}
+
+TEST(nntrainer_TensorDim, setTensorDim_07_n) {
+  nntrainer::TensorDim d;
+
+  EXPECT_THROW(d.setTensorDim(2, 0), std::invalid_argument);
+}
+
+TEST(nntrainer_TensorDim, setTensorDim_08_n) {
+  nntrainer::TensorDim d;
+
+  EXPECT_THROW(d.setTensorDim(3, 0), std::invalid_argument);
+}
+
+TEST(nntrainer_TensorDim, setTensorDim_09_n) {
+  nntrainer::TensorDim d;
+
+  EXPECT_THROW(d.setTensorDim("0"), std::invalid_argument);
+}
+
+TEST(nntrainer_TensorDim, setTensorDim_10_n) {
+  nntrainer::TensorDim d;
+
+  EXPECT_THROW(d.setTensorDim("1:0"), std::invalid_argument);
+}
+
+TEST(nntrainer_TensorDim, setTensorDim_11_n) {
+  nntrainer::TensorDim d;
+
+  EXPECT_THROW(d.setTensorDim("0:1:1"), std::invalid_argument);
+}
+
+TEST(nntrainer_TensorDim, setTensorDim_12_n) {
+  nntrainer::TensorDim d;
+
+  EXPECT_THROW(d.setTensorDim("1:1:1:0"), std::invalid_argument);
+}
+
+TEST(nntrainer_TensorDim, setTensorDim_13_n) {
+  int status = ML_ERROR_NONE;
+
+  nntrainer::TensorDim tensor_dim;
+  status = tensor_dim.setTensorDim("1:2:2:2:1");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_TensorDim, setTensorDim_14_n) {
+  int status = ML_ERROR_NONE;
+
+  nntrainer::TensorDim tensor_dim;
+  status = tensor_dim.setTensorDim("0:2:2:2:1");
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
 TEST(nntrainer_Tensor, Tensor_01_p) {
   int status = ML_ERROR_NONE;
   nntrainer::Tensor tensor = nntrainer::Tensor(1, 2, 3);
@@ -334,6 +398,70 @@ TEST(nntrainer_Tensor, multiply_i_03_n) {
 
   nntrainer::Tensor target2(batch, channel, height - 2, width - 1);
   status = input.multiply_i(target2);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, multiply_i_04_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor target(batch + 1, channel, height, width);
+  status = input.multiply_i(target);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, multiply_i_05_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor target(batch, channel + 1, height, width);
+  status = input.multiply_i(target);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, multiply_i_06_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor target(batch, channel, height + 1, width);
+  status = input.multiply_i(target);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, multiply_i_07_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor target(batch, channel, height, width + 1);
+  status = input.multiply_i(target);
 
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
@@ -679,6 +807,66 @@ TEST(nntrainer_Tensor, multiply_08_n) {
   EXPECT_THROW(input.multiply(test, output), std::invalid_argument);
 }
 
+TEST(nntrainer_Tensor, multiply_10_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch + 1, channel, height, width);
+  nntrainer::Tensor output(dim, false);
+
+  EXPECT_THROW(input.multiply(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, multiply_11_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch, channel + 1, height, width);
+  nntrainer::Tensor output(dim, false);
+
+  EXPECT_THROW(input.multiply(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, multiply_12_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch, channel, height + 1, width);
+  nntrainer::Tensor output(dim, false);
+
+  EXPECT_THROW(input.multiply(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, multiply_13_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch, channel, height, width + 1);
+  nntrainer::Tensor output(dim, false);
+
+  EXPECT_THROW(input.multiply(test, output), std::invalid_argument);
+}
+
 TEST(nntrainer_Tensor, multiply_float_01_p) {
   int batch = 3;
   int channel = 1;
@@ -769,6 +957,66 @@ TEST(nntrainer_Tensor, divide_i_02_n) {
   nntrainer::Tensor original(batch, channel, height - 2, width - 1);
 
   status = input.divide_i(original);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, divide_i_03_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor divisor(batch, channel, height, width - 1);
+  status = input.divide_i(divisor);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, divide_i_04_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor divisor(batch, channel, height - 1, width);
+  status = input.divide_i(divisor);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, divide_i_05_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor divisor(batch - 1, channel, height, width);
+  status = input.divide_i(divisor);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, divide_i_06_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor divisor(batch, channel + 1, height, width);
+  status = input.divide_i(divisor);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -879,6 +1127,88 @@ TEST(nntrainer_Tensor, divide_08_n) {
   GEN_TEST_INPUT(test, i * (batch * height) + j * (width) + k + 2);
   nntrainer::Tensor output(dim, false);
 
+  EXPECT_THROW(input.divide(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, divide_09_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch + 1, channel, height, width);
+  nntrainer::Tensor output(dim, false);
+  EXPECT_THROW(input.divide(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, divide_10_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch, channel + 1, height, width);
+  nntrainer::Tensor output(dim, false);
+  EXPECT_THROW(input.divide(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, divide_11_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch, channel, height + 1, width);
+  nntrainer::Tensor output(dim, false);
+  EXPECT_THROW(input.divide(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, divide_12_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch, channel, height, width + 1);
+  nntrainer::Tensor output(dim, false);
+  EXPECT_THROW(input.divide(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, divide_13_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k + 1);
+  nntrainer::Tensor test(batch, channel, height, width + 1);
+  GEN_TEST_INPUT(test, 0);
+  nntrainer::Tensor output(dim, false);
+  EXPECT_THROW(input.divide(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, divide_14_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+  nntrainer::Tensor test(batch, channel, height, width + 1);
+  GEN_TEST_INPUT(test, i * (batch * height) + j * (width) + k);
+  nntrainer::Tensor output(dim, false);
   EXPECT_THROW(input.divide(test, output), std::invalid_argument);
 }
 
@@ -1641,6 +1971,58 @@ TEST(nntrainer_Tensor, add_08_n) {
   EXPECT_THROW(input.add(test, output), std::invalid_argument);
 }
 
+TEST(nntrainer_Tensor, add_10_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch + 1, channel, height, width);
+  nntrainer::Tensor output(dim, false);
+  EXPECT_THROW(input.add(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, add_11_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch, channel + 1, height, width);
+  nntrainer::Tensor output(dim, false);
+  EXPECT_THROW(input.add(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, add_12_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch, channel, height + 1, width);
+  nntrainer::Tensor output(dim, false);
+  EXPECT_THROW(input.add(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, add_13_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch, channel, height, width + 1);
+  nntrainer::Tensor output(dim, false);
+  EXPECT_THROW(input.add(test, output), std::invalid_argument);
+}
+
 TEST(nntrainer_Tensor, pow_01_p) {
 
   nntrainer::Tensor input = constant(4.0, 3, 2, 4, 5);
@@ -1720,6 +2102,58 @@ TEST(nntrainer_Tensor, subtract_i_03_n) {
   nntrainer::Tensor target2(batch, channel, height - 1, width - 3);
 
   status = target.subtract_i(target2);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, subtract_i_04_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  nntrainer::Tensor target(batch + 1, channel, height, width);
+  status = input.subtract_i(target);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, subtract_i_05_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  nntrainer::Tensor target(batch, channel + 1, height, width);
+  status = input.subtract_i(target);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, subtract_i_06_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  nntrainer::Tensor target(batch, channel, height + 1, width);
+  status = input.subtract_i(target);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, subtract_i_07_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor input(batch, channel, height, width);
+  nntrainer::Tensor target(batch, channel, height, width + 1);
+  status = input.subtract_i(target);
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -1852,6 +2286,58 @@ TEST(nntrainer_Tensor, subtract_08_n) {
   GEN_TEST_INPUT(test, i * (batch * height) + j * (width) + k + 2);
   nntrainer::Tensor output(dim, false);
 
+  EXPECT_THROW(input.subtract(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, subtract_09_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch + 1, channel, height, width);
+  nntrainer::Tensor output(dim, false);
+  EXPECT_THROW(input.subtract(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, subtract_10_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch, channel + 1, height, width);
+  nntrainer::Tensor output(dim, false);
+  EXPECT_THROW(input.subtract(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, subtract_11_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch, channel, height + 1, width);
+  nntrainer::Tensor output(dim, false);
+  EXPECT_THROW(input.subtract(test, output), std::invalid_argument);
+}
+
+TEST(nntrainer_Tensor, subtract_12_n) {
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::TensorDim dim(batch, channel, height, width);
+  nntrainer::Tensor input(dim);
+  nntrainer::Tensor test(batch, channel, height, width + 1);
+  nntrainer::Tensor output(dim, false);
   EXPECT_THROW(input.subtract(test, output), std::invalid_argument);
 }
 
@@ -2437,6 +2923,36 @@ TEST(nntrainer_Tensor, dot_06_p) {
   }
 end_dot_01_p:
   EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+TEST(nntrainer_Tensor, dot_07_n) {
+  nntrainer::Tensor input(3, 4, 5);
+  nntrainer::Tensor m(2, 4, 5);
+  EXPECT_THROW(nntrainer::Tensor result = input.dot(m), std::runtime_error);
+}
+
+TEST(nntrainer_Tensor, dot_08_n) {
+  nntrainer::Tensor input(2, 3, 4);
+  nntrainer::Tensor m(2, 1, 4);
+  EXPECT_THROW(nntrainer::Tensor result = input.dot(m), std::runtime_error);
+}
+
+TEST(nntrainer_Tensor, dot_09_n) {
+  nntrainer::Tensor input(4, 5, 6);
+  nntrainer::Tensor m(4, 5, 1);
+  EXPECT_THROW(nntrainer::Tensor result = input.dot(m), std::runtime_error);
+}
+
+TEST(nntrainer_Tensor, dot_10_n) {
+  nntrainer::Tensor input(2, 3, 4);
+  nntrainer::Tensor m(2, 3, 5);
+  EXPECT_THROW(nntrainer::Tensor result = input.dot(m), std::runtime_error);
+}
+
+TEST(nntrainer_Tensor, dot_11_n) {
+  nntrainer::Tensor input(3, 4, 5);
+  nntrainer::Tensor m(3, 4, 6);
+  EXPECT_THROW(nntrainer::Tensor result = input.dot(m), std::runtime_error);
 }
 
 TEST(nntrainer_Tensor, dot_transpose_p) {
@@ -3996,6 +4512,61 @@ TEST(nntrainer_Tensor, cat_07_n) {
   EXPECT_THROW(nntrainer::Tensor::cat(inputs, 3), std::invalid_argument);
 }
 
+TEST(nntrainer_Tensor, cat_08_n) {
+  {
+    std::vector<nntrainer::Tensor> inputs;
+    inputs.reserve(2);
+    inputs.emplace_back(nntrainer::Tensor(1, 1, 1, 2));
+    inputs.emplace_back(nntrainer::Tensor(1, 2, 1, 2));
+    EXPECT_THROW(nntrainer::Tensor::cat(inputs, 0), std::invalid_argument);
+  }
+}
+
+TEST(nntrainer_Tensor, cat_09_n) {
+  {
+    std::vector<nntrainer::Tensor> inputs;
+    inputs.reserve(3);
+    inputs.emplace_back(nntrainer::Tensor(1, 1, 1, 2));
+    inputs.emplace_back(nntrainer::Tensor(1, 2, 1, 2));
+    inputs.emplace_back(nntrainer::Tensor(1, 2, 1, 2));
+    EXPECT_THROW(nntrainer::Tensor::cat(inputs, 0), std::invalid_argument);
+  }
+}
+
+TEST(nntrainer_Tensor, cat_10_n) {
+  {
+    std::vector<nntrainer::Tensor> inputs;
+    inputs.reserve(3);
+    inputs.emplace_back(nntrainer::Tensor(1, 1, 1, 2));
+    inputs.emplace_back(nntrainer::Tensor(1, 2, 1, 2));
+    inputs.emplace_back(nntrainer::Tensor(1, 2, 1, 2));
+    EXPECT_THROW(nntrainer::Tensor::cat(inputs, 2), std::invalid_argument);
+  }
+}
+
+TEST(nntrainer_Tensor, cat_11_n) {
+  {
+    std::vector<nntrainer::Tensor> inputs;
+    inputs.reserve(3);
+    inputs.emplace_back(nntrainer::Tensor(1, 1, 1, 2));
+    inputs.emplace_back(nntrainer::Tensor(1, 2, 1, 2));
+    inputs.emplace_back(nntrainer::Tensor(1, 2, 1, 2));
+    EXPECT_THROW(nntrainer::Tensor::cat(inputs, 3), std::invalid_argument);
+  }
+}
+
+TEST(nntrainer_Tensor, cat_12_n) {
+  {
+    std::vector<nntrainer::Tensor> inputs;
+    inputs.reserve(4);
+    inputs.emplace_back(nntrainer::Tensor(1, 1, 1, 2));
+    inputs.emplace_back(nntrainer::Tensor(1, 2, 1, 2));
+    inputs.emplace_back(nntrainer::Tensor(1, 2, 1, 2));
+    inputs.emplace_back(nntrainer::Tensor(1, 2, 1, 2));
+    EXPECT_THROW(nntrainer::Tensor::cat(inputs, 3), std::invalid_argument);
+  }
+}
+
 TEST(nntrainer_Tensor, zoneout_mask_01_n) {
   const float zoneout_rate = 0.3f;
   nntrainer::Tensor t(10, 10, 10, 10);
@@ -4413,6 +4984,61 @@ TEST(nntrainer_Tensor, multiply_strided_06_p) {
   }
 
   EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+TEST(nntrainer_Tensor, func_FloatTensor_01_p) {
+  int status = ML_ERROR_NONE;
+  std::vector<std::vector<std::vector<std::vector<float>>>> in = {
+    {{{0, 1}, {14, 15}}}};
+  nntrainer::FloatTensor tensor =
+    nntrainer::FloatTensor(in, nntrainer::Tformat::NCHW);
+  ASSERT_EQ(int(tensor.max_abs()), 15);
+
+  nntrainer::Tensor out = nntrainer::Tensor(tensor.getDim());
+  tensor.erf(out);
+  for (size_t b = 0; b < out.batch(); ++b) {
+    for (size_t c = 0; c < out.channel(); ++c) {
+      for (size_t h = 0; h < out.height(); ++h) {
+        for (size_t w = 0; w < out.width(); ++w) {
+          size_t idx = out.getIndex(b, c, h, w);
+          ASSERT_EQ(out.getValue(idx), out.getValue(b, c, h, w));
+        }
+      }
+    }
+  }
+}
+
+TEST(nntrainer_Tensor, func_ShortTensor_02_p) {
+  int status = ML_ERROR_NONE;
+  nntrainer::TensorDim dim(1, 1, 1, 2);
+  nntrainer::ShortTensor tensor = nntrainer::ShortTensor(dim);
+  for (size_t b = 0; b < tensor.batch(); ++b) {
+    for (size_t c = 0; c < tensor.channel(); ++c) {
+      for (size_t h = 0; h < tensor.height(); ++h) {
+        for (size_t w = 0; w < tensor.width(); ++w) {
+          size_t idx = tensor.getIndex(b, c, h, w);
+          ASSERT_EQ(tensor.getValue(idx), tensor.getValue(b, c, h, w));
+
+          void *address1 = tensor.getAddress(idx);
+          const void *address2 = tensor.getAddress(idx);
+          ASSERT_EQ(address1, address2);
+        }
+      }
+    }
+  }
+}
+
+TEST(nntrainer_Tensor, fcall_VGrad_Weight_03_p) {
+  int status = ML_ERROR_NONE;
+  nntrainer::TensorDim dim(1, 1, 1, 2);
+  dim.reverse();
+  ASSERT_EQ(false, dim.isEmpty());
+  nntrainer::Var_Grad grad = nntrainer::Var_Grad(dim);
+  ASSERT_EQ(grad.isDependent(), false);
+
+  nntrainer::Weight w1 = nntrainer::Weight(dim);
+  nntrainer::Weight w2 = w1.clone();
+  ASSERT_EQ(w1.getNumOptVariable(), w2.getNumOptVariable());
 }
 
 // /**

--- a/test/unittest/unittest_nntrainer_tensor_fp16.cpp
+++ b/test/unittest/unittest_nntrainer_tensor_fp16.cpp
@@ -191,6 +191,74 @@ TEST(nntrainer_Tensor, multiply_i_03_fp16_n) {
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
+TEST(nntrainer_Tensor, multiply_i_04_fp16_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width,
+                          nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
+  nntrainer::Tensor target(batch, channel, height - 1, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+  status = input.multiply_i(target);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, multiply_i_05_fp16_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width,
+                          nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
+  nntrainer::Tensor target(batch + 1, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+  status = input.multiply_i(target);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, multiply_i_06_fp16_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width,
+                          nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
+  nntrainer::Tensor target(batch, channel + 1, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+  status = input.multiply_i(target);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, multiply_i_07_fp16_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width,
+                          nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
+  nntrainer::Tensor target(batch, channel, height, width,
+                           nntrainer::Tformat::NHWC,
+                           nntrainer::Tdatatype::FP16);
+  status = input.multiply_i(target);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
 TEST(nntrainer_Tensor, multiply_i_broadcast_01_fp16_p) {
   {
     nntrainer::TensorDim ref_dim(3, 2, 4, 5, nntrainer::Tformat::NCHW,
@@ -1142,6 +1210,122 @@ TEST(nntrainer_Tensor, divide_i_02_n) {
                              nntrainer::Tdatatype::FP16);
 
   status = input.divide_i(original);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, divide_i_03_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width,
+                          nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor target(batch, channel, height - 1, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+  status = input.divide_i(target);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, divide_i_04_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width,
+                          nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor target(batch + 1, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+  status = input.divide_i(target);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, divide_i_05_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width,
+                          nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor target(batch, channel + 1, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+  status = input.divide_i(target);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, divide_i_06_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width,
+                          nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor target(batch, channel, height, width,
+                           nntrainer::Tformat::NHWC,
+                           nntrainer::Tdatatype::FP16);
+  status = input.divide_i(target);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, divide_i_07_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width,
+                          nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor target(batch, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP32);
+  status = input.divide_i(target);
+
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, divide_i_08_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int channel = 1;
+  int height = 3;
+  int width = 10;
+
+  nntrainer::Tensor input(batch, channel, height, width,
+                          nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16);
+  GEN_TEST_INPUT(input, i * (batch * height) + j * (width) + k);
+
+  nntrainer::Tensor target(batch, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+  target.fill(_FP16(0));
+
+  status = input.divide_i(target);
+
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
@@ -3165,6 +3349,106 @@ TEST(nntrainer_Tensor, subtract_i_03_n) {
   EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
 }
 
+TEST(nntrainer_Tensor, subtract_i_04_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor target(batch, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1 + channel);
+
+  nntrainer::Tensor target2(batch, channel, height - 2, width,
+                            nntrainer::Tformat::NCHW,
+                            nntrainer::Tdatatype::FP16);
+
+  status = target.subtract_i(target2);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, subtract_i_05_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor target(batch, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1 + channel);
+
+  nntrainer::Tensor target2(batch + 1, channel, height, width,
+                            nntrainer::Tformat::NCHW,
+                            nntrainer::Tdatatype::FP16);
+
+  status = target.subtract_i(target2);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, subtract_i_06_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor target(batch, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1 + channel);
+
+  nntrainer::Tensor target2(batch, channel + 1, height, width,
+                            nntrainer::Tformat::NCHW,
+                            nntrainer::Tdatatype::FP16);
+
+  status = target.subtract_i(target2);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, subtract_i_07_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor target(batch, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1 + channel);
+
+  nntrainer::Tensor target2(batch, channel, height, width,
+                            nntrainer::Tformat::NHWC,
+                            nntrainer::Tdatatype::FP16);
+
+  status = target.subtract_i(target2);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
+TEST(nntrainer_Tensor, subtract_i_08_n) {
+  int status = ML_ERROR_NONE;
+  int batch = 3;
+  int height = 3;
+  int width = 10;
+  int channel = 1;
+
+  nntrainer::Tensor target(batch, channel, height, width,
+                           nntrainer::Tformat::NCHW,
+                           nntrainer::Tdatatype::FP16);
+  GEN_TEST_INPUT(target, i * (batch * height) + j * (width) + k + 1 + channel);
+
+  nntrainer::Tensor target2(batch, channel, height, width,
+                            nntrainer::Tformat::NCHW,
+                            nntrainer::Tdatatype::FP32);
+
+  status = target.subtract_i(target2);
+  EXPECT_EQ(status, ML_ERROR_INVALID_PARAMETER);
+}
+
 TEST(nntrainer_Tensor, subtract_01_p) {
   int status = ML_ERROR_NONE;
   int batch = 3;
@@ -3907,6 +4191,46 @@ TEST(nntrainer_Tensor, dot_06_p) {
   }
 end_dot_01_p:
   EXPECT_EQ(status, ML_ERROR_NONE);
+}
+
+TEST(nntrainer_Tensor, dot_07_n) {
+  nntrainer::TensorDim::TensorType t_type;
+  t_type.format = nntrainer::Tformat::NCHW;
+  t_type.data_type = nntrainer::Tdatatype::FP16;
+
+  nntrainer::Tensor input(2, 3, 4, 5, t_type);
+  nntrainer::Tensor m(2, 1, 4, 5, t_type);
+  EXPECT_THROW(nntrainer::Tensor result = input.dot(m), std::runtime_error);
+}
+
+TEST(nntrainer_Tensor, dot_08_n) {
+  nntrainer::TensorDim::TensorType t_type;
+  t_type.format = nntrainer::Tformat::NCHW;
+  t_type.data_type = nntrainer::Tdatatype::FP16;
+
+  nntrainer::Tensor input(4, 5, 6, t_type);
+  nntrainer::Tensor m(4, 5, 1, t_type);
+  EXPECT_THROW(nntrainer::Tensor result = input.dot(m), std::runtime_error);
+}
+
+TEST(nntrainer_Tensor, dot_09_n) {
+  nntrainer::TensorDim::TensorType t_type;
+  t_type.format = nntrainer::Tformat::NCHW;
+  t_type.data_type = nntrainer::Tdatatype::FP16;
+
+  nntrainer::Tensor input(2, 3, 4, t_type);
+  nntrainer::Tensor m(2, 3, 5, t_type);
+  EXPECT_THROW(nntrainer::Tensor result = input.dot(m), std::runtime_error);
+}
+
+TEST(nntrainer_Tensor, dot_10_n) {
+  nntrainer::TensorDim::TensorType t_type;
+  t_type.format = nntrainer::Tformat::NCHW;
+  t_type.data_type = nntrainer::Tdatatype::FP16;
+
+  nntrainer::Tensor input(3, 4, 5, t_type);
+  nntrainer::Tensor m(3, 4, 6, t_type);
+  EXPECT_THROW(nntrainer::Tensor result = input.dot(m), std::runtime_error);
 }
 
 TEST(nntrainer_Tensor, dot_transpose_p) {


### PR DESCRIPTION
- added 81 number of negative unittests
- expanded function call coverage

before:
- Positive TCs: 503
- Negative TCs: 475

after:
- Positive TCs: 503
- Negative TCs: 556

Signed-off-by: Seungbaek Hong <sb92.hong@samsung.com>