### PR TITLE
Fix SwiGLU layer + utilize local group.

### DIFF
--- a/nntrainer/layers/cl_layers/swiglu_cl.h
+++ b/nntrainer/layers/cl_layers/swiglu_cl.h
@@ -77,7 +77,7 @@ public:
    * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
    */
   void exportTo(Exporter &exporter,
-                const ml::train::ExportMethods &method) const override{};
+                const ml::train::ExportMethods &method) const override {};
 
   /**
    * @copydoc Layer::getType()
@@ -107,8 +107,8 @@ public:
    * @param[in] dim1 number of elements in input vector A
    * @param[in] dim1 number of elements in input vector X
    */
-  void swiglu_cl(const float *matAdata, const float *vecXdata, float *vecYdata,
-                 unsigned int dim1, unsigned int dim2);
+  void swiglu_cl(float *matAdata, float *vecXdata, float *vecYdata,
+                 unsigned int dim1, unsigned int dim2, bool svm = false);
 
 #ifdef ENABLE_FP16
   /**
@@ -119,8 +119,8 @@ public:
    * @param[in] dim1 number of elements in input vector A
    * @param[in] dim1 number of elements in input vector X
    */
-  void swiglu_cl_fp16(const _FP16 *matAdata, const _FP16 *vecXdata,
-                      _FP16 *vecYdata, unsigned int dim1, unsigned int dim2);
+  void swiglu_cl_fp16(_FP16 *matAdata, _FP16 *vecXdata, _FP16 *vecYdata,
+                      unsigned int dim1, unsigned int dim2, bool svm = false);
 #endif
 
   /**

--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
@@ -656,11 +656,23 @@ const std::string &getTransposeClKernelAxis2() {
 
 const std::string &getSwiGluClKernel() {
   static const std::string swiglu_cl_kernel_ =
-    R"(__kernel void swiglu_cl(__global const float *in1, __global const float *in2, __global float *out) {
-int i = get_global_id(0);
-float swish = in1[i] * exp(in1[i]) / (1 + exp(in1[i]));
-out[i] = swish * in2[i];
-})";
+    R"(
+    __kernel void swiglu_cl(
+      __global const float * restrict in1,
+      __global const float * restrict in2,
+      __global       float * restrict out)
+    {
+      const int i = get_global_id(0);
+
+      const float in1_val = in1[i];
+      const float in2_val = in2[i];
+
+      const float in1_exp = exp(in1_val);
+      
+      const float swish = in1_val * in1_exp / (1.0f + in1_exp);
+
+      out[i] = swish * in2_val;
+    })";
   return swiglu_cl_kernel_;
 }
 
@@ -1493,9 +1505,17 @@ const std::string &getSwiGluClKernelFP16() {
     R"(
     #pragma OPENCL EXTENSION cl_khr_fp16 : enable
     __kernel void swiglu_cl_fp16(__global const half *in1, __global const half *in2, __global half *out) {
-    int i = get_global_id(0);
-    half swish = in1[i] * exp((float)in1[i]) / (1 + exp((float)in1[i]));
-    out[i] = swish * in2[i];
+      const int i = get_global_id(0);
+
+      const half in1_val = in1[i];
+      const half in2_val = in2[i];
+
+      const half in1_exp = exp(in1_val);
+      
+      const half half_one = (half)(1.0f);
+      const half swish = in1_val * in1_exp / (half_one + in1_exp);
+
+      out[i] = swish * in2_val;    
 })";
   return swiglu_cl_kernel_fp16_;
 }

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -10,6 +10,7 @@
  * @bug		No known bugs except for NYI items
  */
 
+#include <cstring>
 #include <fstream>
 #include <gtest/gtest.h>
 #include <random>
@@ -1258,8 +1259,8 @@ DECLARE_q4_0_test_M_K_N(28, 3072, 3072);
 TEST(blas_kernels, swiglu_layer_fp16) {
   const int batch = 1;
   const int channel = 1;
-  const int height = 4 * 1024;
-  const int width = 8 * 1024;
+  const int height = 16;
+  const int width = 8;
 
   const int batch_b = 1;
 
@@ -1326,7 +1327,7 @@ TEST(blas_kernels, swiglu_layer_fp16) {
   EXPECT_IN_RANGE(mseError, 0, epsilon);
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 
-  uint32_t print_count = 4;
+  uint32_t print_count = 64;
 
   for (uint32_t i = 0; i < print_count; i++) {
     auto from_ref = (float)out_ref_fp16.getData<_FP16>()[i];
@@ -1335,7 +1336,9 @@ TEST(blas_kernels, swiglu_layer_fp16) {
     std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
   }
 
-  for (uint32_t i = 0; i < 32; i++) {
+  std::cout << "BRK" << std::endl;
+
+  for (uint32_t i = 0; i < print_count; i++) {
     auto from_ref =
       (float)out_ref_fp16.getData<_FP16>()[height * width - 1 - i];
     auto from_cl = (float)out_cl_fp16.getData<_FP16>()[height * width - 1 - i];
@@ -1348,8 +1351,8 @@ TEST(blas_kernels, swiglu_layer_fp16) {
 TEST(blas_kernels, swiglu_layer_fp32) {
   const int batch = 1;
   const int channel = 1;
-  const int height = 4 * 1024;
-  const int width = 8 * 1024;
+  const int height = 16;
+  const int width = 8;
 
   const int batch_b = 1;
 
@@ -1416,7 +1419,7 @@ TEST(blas_kernels, swiglu_layer_fp32) {
   EXPECT_IN_RANGE(mseError, 0, epsilon);
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
 
-  uint32_t print_count = 4;
+  uint32_t print_count = 64;
 
   for (uint32_t i = 0; i < print_count; i++) {
     auto from_ref = out_ref_fp32.getData()[i];
@@ -1425,9 +1428,117 @@ TEST(blas_kernels, swiglu_layer_fp32) {
     std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
   }
 
+  std::cout << "BRK" << std::endl;
+
   for (uint32_t i = 0; i < print_count; i++) {
     auto from_ref = (float)out_ref_fp32.getData()[height * width - 1 - i];
     auto from_cl = (float)out_cl_fp32.getData()[height * width - 1 - i];
+
+    std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
+  }
+}
+
+TEST(blas_kernels, swiglu_layer_fp32_svm) {
+  const int batch = 1;
+  const int channel = 1;
+  const int height = 16;
+  const int width = 8;
+
+  const int dim = width * height;
+
+  const int batch_b = 1;
+
+  const float alpha = 1e-1;
+  const int MOD = 10;
+
+  nntrainer::init_backend();
+
+  auto *blas_cc = static_cast<nntrainer::ClContext *>(
+    nntrainer::Engine::Global().getRegisteredContext("gpu"));
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  nntrainer::Tensor A_fp32(batch, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor B_fp32(batch_b, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor out_ref_fp32(batch, channel, height, width,
+                                 t_type_nchw_fp32);
+
+  GEN_TEST_INPUT(A_fp32, ((i * (batch * height * channel) +
+                           j * (batch * height) + k * (width) + l + 1) %
+                          MOD) *
+                           alpha);
+  GEN_TEST_INPUT_C(B_fp32, ((i * (batch_b * height * channel) +
+                             j * (batch_b * height) + k * (width) + l + 1) %
+                            MOD) *
+                             alpha);
+
+  void *gpu_in1 = blas_cc->context_inst_.createSVMRegion(dim * sizeof(float));
+  void *gpu_in2 = blas_cc->context_inst_.createSVMRegion(dim * sizeof(float));
+  void *gpu_dst = blas_cc->context_inst_.createSVMRegion(dim * sizeof(float));
+
+  blas_cc->command_queue_inst_.enqueueSVMMap(gpu_in1, dim * sizeof(float),
+                                             false);
+  blas_cc->command_queue_inst_.enqueueSVMMap(gpu_in2, dim * sizeof(float),
+                                             false);
+
+  std::memcpy(gpu_in1, A_fp32.getData(), dim * sizeof(float));
+  std::memcpy(gpu_in2, B_fp32.getData(), dim * sizeof(float));
+
+  static constexpr uint32_t run_count = 8;
+
+  SwiGLULayerCl layer;
+
+  auto t1_cl = std::chrono::high_resolution_clock::now();
+  for (unsigned int i = 0; i < run_count; ++i) {
+    layer.swiglu_cl((float *)gpu_in1, (float *)gpu_in2, (float *)gpu_dst, width,
+                    height, true);
+  }
+  auto t2_cl = std::chrono::high_resolution_clock::now();
+
+  auto t1_ref = std::chrono::high_resolution_clock::now();
+  for (unsigned int i = 0; i < run_count; ++i) {
+    nntrainer::swiglu(height * width, out_ref_fp32.getData(), A_fp32.getData(),
+                      B_fp32.getData());
+  }
+  auto t2_ref = std::chrono::high_resolution_clock::now();
+
+  auto dt_cl =
+    std::chrono::duration_cast<std::chrono::milliseconds>(t2_cl - t1_cl);
+  auto dt_ref =
+    std::chrono::duration_cast<std::chrono::milliseconds>(t2_ref - t1_ref);
+
+  std::cout << "Swiglu time : GPU = " << dt_cl.count() / (run_count * 1.0f)
+            << " ms" << std::endl;
+
+  std::cout << "Swiglu time : CPU = " << dt_ref.count() / (run_count * 1.0f)
+            << " ms" << std::endl;
+
+  float mseError =
+    mse<float>((float *)gpu_dst, out_ref_fp32.getData<float>(), height * width);
+
+  double cosSim = cosine_similarity<float>(
+    (float *)gpu_dst, out_ref_fp32.getData<float>(), height * width);
+
+  const float epsilon = 1e-3 * width;
+
+  EXPECT_IN_RANGE(mseError, 0, epsilon);
+  EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
+
+  uint32_t print_count = 64;
+
+  for (uint32_t i = 0; i < print_count; i++) {
+    auto from_ref = out_ref_fp32.getData()[i];
+    auto from_cl = ((float *)gpu_dst)[i];
+
+    std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
+  }
+
+  std::cout << "BRK" << std::endl;
+
+  for (uint32_t i = 0; i < print_count; i++) {
+    auto from_ref = (float)out_ref_fp32.getData()[height * width - 1 - i];
+    auto from_cl = (float)((float *)gpu_dst)[height * width - 1 - i];
 
     std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
   }

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -11,17 +11,13 @@
  */
 
 #include <cstring>
-#include <fstream>
 #include <gtest/gtest.h>
-#include <random>
-#include <type_traits>
 #include <utility>
 
-#include "avx2_impl.h"
+#include "fallback_internal.h"
 #include "nntrainer_test_util.h"
 #include "swiglu_cl.h"
 #include "tensor_dim.h"
-#include "util_func.h"
 #include "x86_compute_backend.h"
 #include <blas_kernel_interface.h>
 #include <blas_kernels.h>
@@ -1259,8 +1255,8 @@ DECLARE_q4_0_test_M_K_N(28, 3072, 3072);
 TEST(blas_kernels, swiglu_layer_fp16) {
   const int batch = 1;
   const int channel = 1;
-  const int height = 16;
-  const int width = 8;
+  const int height = 3072;
+  const int width = 3072;
 
   const int batch_b = 1;
 
@@ -1299,7 +1295,7 @@ TEST(blas_kernels, swiglu_layer_fp16) {
 
   auto t1_ref = std::chrono::high_resolution_clock::now();
   for (unsigned int i = 0; i < run_count; ++i) {
-    nntrainer::swiglu(height * width, out_ref_fp16.getData<_FP16>(),
+    __fallback_swiglu(height * width, out_ref_fp16.getData<_FP16>(),
                       A_fp16.getData<_FP16>(), B_fp16.getData<_FP16>());
   }
   auto t2_ref = std::chrono::high_resolution_clock::now();
@@ -1326,33 +1322,14 @@ TEST(blas_kernels, swiglu_layer_fp16) {
 
   EXPECT_IN_RANGE(mseError, 0, epsilon);
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
-
-  uint32_t print_count = 64;
-
-  for (uint32_t i = 0; i < print_count; i++) {
-    auto from_ref = (float)out_ref_fp16.getData<_FP16>()[i];
-    auto from_cl = (float)out_cl_fp16.getData<_FP16>()[i];
-
-    std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
-  }
-
-  std::cout << "BRK" << std::endl;
-
-  for (uint32_t i = 0; i < print_count; i++) {
-    auto from_ref =
-      (float)out_ref_fp16.getData<_FP16>()[height * width - 1 - i];
-    auto from_cl = (float)out_cl_fp16.getData<_FP16>()[height * width - 1 - i];
-
-    std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
-  }
 }
 #endif
 
 TEST(blas_kernels, swiglu_layer_fp32) {
   const int batch = 1;
   const int channel = 1;
-  const int height = 16;
-  const int width = 8;
+  const int height = 3072;
+  const int width = 3072;
 
   const int batch_b = 1;
 
@@ -1391,7 +1368,7 @@ TEST(blas_kernels, swiglu_layer_fp32) {
 
   auto t1_ref = std::chrono::high_resolution_clock::now();
   for (unsigned int i = 0; i < run_count; ++i) {
-    nntrainer::swiglu(height * width, out_ref_fp32.getData(), A_fp32.getData(),
+    __fallback_swiglu(height * width, out_ref_fp32.getData(), A_fp32.getData(),
                       B_fp32.getData());
   }
   auto t2_ref = std::chrono::high_resolution_clock::now();
@@ -1418,31 +1395,13 @@ TEST(blas_kernels, swiglu_layer_fp32) {
 
   EXPECT_IN_RANGE(mseError, 0, epsilon);
   EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
-
-  uint32_t print_count = 64;
-
-  for (uint32_t i = 0; i < print_count; i++) {
-    auto from_ref = out_ref_fp32.getData()[i];
-    auto from_cl = out_cl_fp32.getData()[i];
-
-    std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
-  }
-
-  std::cout << "BRK" << std::endl;
-
-  for (uint32_t i = 0; i < print_count; i++) {
-    auto from_ref = (float)out_ref_fp32.getData()[height * width - 1 - i];
-    auto from_cl = (float)out_cl_fp32.getData()[height * width - 1 - i];
-
-    std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
-  }
 }
 
 TEST(blas_kernels, swiglu_layer_fp32_svm) {
   const int batch = 1;
   const int channel = 1;
-  const int height = 16;
-  const int width = 8;
+  const int height = 3072;
+  const int width = 3072;
 
   const int dim = width * height;
 
@@ -1498,7 +1457,7 @@ TEST(blas_kernels, swiglu_layer_fp32_svm) {
 
   auto t1_ref = std::chrono::high_resolution_clock::now();
   for (unsigned int i = 0; i < run_count; ++i) {
-    nntrainer::swiglu(height * width, out_ref_fp32.getData(), A_fp32.getData(),
+    __fallback_swiglu(height * width, out_ref_fp32.getData(), A_fp32.getData(),
                       B_fp32.getData());
   }
   auto t2_ref = std::chrono::high_resolution_clock::now();

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -16,8 +16,12 @@
 #include <type_traits>
 #include <utility>
 
+#include "avx2_impl.h"
 #include "nntrainer_test_util.h"
+#include "swiglu_cl.h"
+#include "tensor_dim.h"
 #include "util_func.h"
+#include "x86_compute_backend.h"
 #include <blas_kernel_interface.h>
 #include <blas_kernels.h>
 #include <cl_context.h>
@@ -1249,6 +1253,185 @@ DECLARE_q4_0_test_M_K_N(28, 3072, 3072);
 #endif
 
 #endif // ENABLE_GGML
+
+#ifdef ENABLE_FP16
+TEST(blas_kernels, swiglu_layer_fp16) {
+  const int batch = 1;
+  const int channel = 1;
+  const int height = 4 * 1024;
+  const int width = 8 * 1024;
+
+  const int batch_b = 1;
+
+  const float alpha = 1e-1;
+  const int MOD = 10;
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp16 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP16};
+
+  nntrainer::Tensor A_fp16(batch, channel, height, width, t_type_nchw_fp16);
+  nntrainer::Tensor B_fp16(batch_b, channel, height, width, t_type_nchw_fp16);
+  nntrainer::Tensor out_cl_fp16(batch_b, channel, height, width,
+                                t_type_nchw_fp16);
+  nntrainer::Tensor out_ref_fp16(batch, channel, height, width,
+                                 t_type_nchw_fp16);
+
+  GEN_TEST_INPUT(A_fp16, ((i * (batch * height * channel) +
+                           j * (batch * height) + k * (width) + l + 1) %
+                          MOD) *
+                           alpha);
+  GEN_TEST_INPUT_C(B_fp16, ((i * (batch_b * height * channel) +
+                             j * (batch_b * height) + k * (width) + l + 1) %
+                            MOD) *
+                             alpha);
+
+  static constexpr uint32_t run_count = 8;
+
+  SwiGLULayerCl layer;
+
+  auto t1_cl = std::chrono::high_resolution_clock::now();
+  for (unsigned int i = 0; i < run_count; ++i) {
+    layer.swiglu_cl_fp16(A_fp16.getData<_FP16>(), B_fp16.getData<_FP16>(),
+                         out_cl_fp16.getData<_FP16>(), width, height);
+  }
+  auto t2_cl = std::chrono::high_resolution_clock::now();
+
+  auto t1_ref = std::chrono::high_resolution_clock::now();
+  for (unsigned int i = 0; i < run_count; ++i) {
+    nntrainer::swiglu(height * width, out_ref_fp16.getData<_FP16>(),
+                      A_fp16.getData<_FP16>(), B_fp16.getData<_FP16>());
+  }
+  auto t2_ref = std::chrono::high_resolution_clock::now();
+
+  auto dt_cl =
+    std::chrono::duration_cast<std::chrono::milliseconds>(t2_cl - t1_cl);
+  auto dt_ref =
+    std::chrono::duration_cast<std::chrono::milliseconds>(t2_ref - t1_ref);
+
+  std::cout << "Swiglu time : GPU = " << dt_cl.count() / (run_count * 1.0f)
+            << " ms" << std::endl;
+
+  std::cout << "Swiglu time : CPU = " << dt_ref.count() / (run_count * 1.0f)
+            << " ms" << std::endl;
+
+  float mseError = mse<_FP16>(out_cl_fp16.getData<_FP16>(),
+                              out_ref_fp16.getData<_FP16>(), height * width);
+
+  double cosSim =
+    cosine_similarity<_FP16>(out_cl_fp16.getData<_FP16>(),
+                             out_ref_fp16.getData<_FP16>(), height * width);
+
+  const float epsilon = 1e-3 * width;
+
+  EXPECT_IN_RANGE(mseError, 0, epsilon);
+  EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
+
+  uint32_t print_count = 4;
+
+  for (uint32_t i = 0; i < print_count; i++) {
+    auto from_ref = (float)out_ref_fp16.getData<_FP16>()[i];
+    auto from_cl = (float)out_cl_fp16.getData<_FP16>()[i];
+
+    std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
+  }
+
+  for (uint32_t i = 0; i < 32; i++) {
+    auto from_ref =
+      (float)out_ref_fp16.getData<_FP16>()[height * width - 1 - i];
+    auto from_cl = (float)out_cl_fp16.getData<_FP16>()[height * width - 1 - i];
+
+    std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
+  }
+}
+#endif
+
+TEST(blas_kernels, swiglu_layer_fp32) {
+  const int batch = 1;
+  const int channel = 1;
+  const int height = 4 * 1024;
+  const int width = 8 * 1024;
+
+  const int batch_b = 1;
+
+  const float alpha = 1e-1;
+  const int MOD = 10;
+
+  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
+    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
+
+  nntrainer::Tensor A_fp32(batch, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor B_fp32(batch_b, channel, height, width, t_type_nchw_fp32);
+  nntrainer::Tensor out_cl_fp32(batch_b, channel, height, width,
+                                t_type_nchw_fp32);
+  nntrainer::Tensor out_ref_fp32(batch, channel, height, width,
+                                 t_type_nchw_fp32);
+
+  GEN_TEST_INPUT(A_fp32, ((i * (batch * height * channel) +
+                           j * (batch * height) + k * (width) + l + 1) %
+                          MOD) *
+                           alpha);
+  GEN_TEST_INPUT_C(B_fp32, ((i * (batch_b * height * channel) +
+                             j * (batch_b * height) + k * (width) + l + 1) %
+                            MOD) *
+                             alpha);
+
+  static constexpr uint32_t run_count = 8;
+
+  SwiGLULayerCl layer;
+
+  auto t1_cl = std::chrono::high_resolution_clock::now();
+  for (unsigned int i = 0; i < run_count; ++i) {
+    layer.swiglu_cl(A_fp32.getData(), B_fp32.getData(), out_cl_fp32.getData(),
+                    width, height);
+  }
+  auto t2_cl = std::chrono::high_resolution_clock::now();
+
+  auto t1_ref = std::chrono::high_resolution_clock::now();
+  for (unsigned int i = 0; i < run_count; ++i) {
+    nntrainer::swiglu(height * width, out_ref_fp32.getData(), A_fp32.getData(),
+                      B_fp32.getData());
+  }
+  auto t2_ref = std::chrono::high_resolution_clock::now();
+
+  auto dt_cl =
+    std::chrono::duration_cast<std::chrono::milliseconds>(t2_cl - t1_cl);
+  auto dt_ref =
+    std::chrono::duration_cast<std::chrono::milliseconds>(t2_ref - t1_ref);
+
+  std::cout << "Swiglu time : GPU = " << dt_cl.count() / (run_count * 1.0f)
+            << " ms" << std::endl;
+
+  std::cout << "Swiglu time : CPU = " << dt_ref.count() / (run_count * 1.0f)
+            << " ms" << std::endl;
+
+  float mseError = mse<float>(out_cl_fp32.getData<float>(),
+                              out_ref_fp32.getData<float>(), height * width);
+
+  double cosSim =
+    cosine_similarity<float>(out_cl_fp32.getData<float>(),
+                             out_ref_fp32.getData<float>(), height * width);
+
+  const float epsilon = 1e-3 * width;
+
+  EXPECT_IN_RANGE(mseError, 0, epsilon);
+  EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
+
+  uint32_t print_count = 4;
+
+  for (uint32_t i = 0; i < print_count; i++) {
+    auto from_ref = out_ref_fp32.getData()[i];
+    auto from_cl = out_cl_fp32.getData()[i];
+
+    std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
+  }
+
+  for (uint32_t i = 0; i < print_count; i++) {
+    auto from_ref = (float)out_ref_fp32.getData()[height * width - 1 - i];
+    auto from_cl = (float)out_cl_fp32.getData()[height * width - 1 - i];
+
+    std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
+  }
+}
 
 GTEST_API_ int main(int argc, char **argv) {
   int result = -1;


### PR DESCRIPTION
- swiglu layer was setting cl_mem object instead pointer to cl_mem object as input / outpt arg causing error '-38'
- this PR fixes failing SwiGLU layer tests

``` bash
Running main() from ./googletest/src/gtest_main.cc
Note: Google Test filter = *Swiglu*
[==========] Running 12 tests from 3 test suites.
[----------] Global test environment set-up.
[----------] 10 tests from SwigluGPU/LayerSemanticsGpu
[ RUN      ] SwigluGPU/LayerSemanticsGpu.createFromClContext_pn/0
[       OK ] SwigluGPU/LayerSemanticsGpu.createFromClContext_pn/0 (472 ms)
[ RUN      ] SwigluGPU/LayerSemanticsGpu.setPropertiesInvalid_n/0
[       OK ] SwigluGPU/LayerSemanticsGpu.setPropertiesInvalid_n/0 (0 ms)
[ RUN      ] SwigluGPU/LayerSemanticsGpu.finalizeValidateLayerNode_p/0
[       OK ] SwigluGPU/LayerSemanticsGpu.finalizeValidateLayerNode_p/0 (0 ms)
[ RUN      ] SwigluGPU/LayerSemanticsGpu.getTypeValidateLayerNode_p/0
[       OK ] SwigluGPU/LayerSemanticsGpu.getTypeValidateLayerNode_p/0 (0 ms)
[ RUN      ] SwigluGPU/LayerSemanticsGpu.gettersValidateLayerNode_p/0
[       OK ] SwigluGPU/LayerSemanticsGpu.gettersValidateLayerNode_p/0 (0 ms)
[ RUN      ] SwigluGPU/LayerSemanticsGpu.setBatchValidateLayerNode_p/0
[       OK ] SwigluGPU/LayerSemanticsGpu.setBatchValidateLayerNode_p/0 (0 ms)
[ RUN      ] SwigluGPU/LayerSemanticsGpu.setProperties_n/0
[       OK ] SwigluGPU/LayerSemanticsGpu.setProperties_n/0 (0 ms)
[ RUN      ] SwigluGPU/LayerSemanticsGpu.gettersValidate_p/0
[       OK ] SwigluGPU/LayerSemanticsGpu.gettersValidate_p/0 (0 ms)
[ RUN      ] SwigluGPU/LayerSemanticsGpu.finalizeValidate_p/0
[       OK ] SwigluGPU/LayerSemanticsGpu.finalizeValidate_p/0 (0 ms)
[ RUN      ] SwigluGPU/LayerSemanticsGpu.setBatchValidate_p/0
[       OK ] SwigluGPU/LayerSemanticsGpu.setBatchValidate_p/0 (0 ms)
[----------] 10 tests from SwigluGPU/LayerSemanticsGpu (472 ms total)

[----------] 1 test from SwigluGPU/LayerGoldenTest
[ RUN      ] SwigluGPU/LayerGoldenTest.run/0
[       OK ] SwigluGPU/LayerGoldenTest.run/0 (4 ms)
[----------] 1 test from SwigluGPU/LayerGoldenTest (4 ms total)

[----------] 1 test from SwigluGPU16/LayerGoldenTest
[ RUN      ] SwigluGPU16/LayerGoldenTest.run/0
[       OK ] SwigluGPU16/LayerGoldenTest.run/0 (2 ms)
[----------] 1 test from SwigluGPU16/LayerGoldenTest (2 ms total)

[----------] Global test environment tear-down
[==========] 12 tests from 3 test suites ran. (481 ms total)
[  PASSED  ] 12 tests.
```

In tests i used fallback swiglu as CPU implementation as AVX one produces zeros in output after some point - to be fixed in future...

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: {your_name} <{your_email}>
