### PR TITLE
bugfix: windows build

### DIFF
--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface_omp.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface_omp.cpp
@@ -21,6 +21,8 @@
 
 #include <ggml_interface.h>
 #include <nntr_ggml_impl.h>
+
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 #include <thread>


### PR DESCRIPTION
This PR fixes an issue where the std::all_of() function cannot be recognized.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped