### PR TITLE
Fix and optimize rmsnorm OpenCL implementation, inspired by GGML opecl kernel.

### DIFF
--- a/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_strings.cpp
@@ -880,11 +880,22 @@ const std::string &getConcatClAxis1Kernel() {
 const std::string &getRMSNormClKernel() {
   static const std::string rmsnorm_cl_kernel_ =
     R"(
-  #pragma OPENCL EXTENSION cl_intel_subgroups : enable  
-  #pragma OPENCL EXTENSION cl_intel_required_subgroup_size : enable
-
- __attribute__((intel_reqd_sub_group_size(32)))
- // __attribute__((reqd_work_group_size(32, 1, 1))) // For some reason gives worse performance, although should be necessary
+    #ifdef cl_intel_required_subgroup_size
+    #pragma OPENCL EXTENSION cl_intel_subgroups : enable
+    #pragma OPENCL EXTENSION cl_intel_required_subgroup_size : enable
+    #define INTEL_GPU 1
+    #define REQD_SUBGROUP_SIZE_32 __attribute__((intel_reqd_sub_group_size(32)))
+    #elif defined(cl_qcom_reqd_sub_group_size)
+    #pragma OPENCL EXTENSION cl_qcom_reqd_sub_group_size : enable
+    #define ADRENO_GPU 1
+    #define REQD_SUBGROUP_SIZE_64 __attribute__((qcom_reqd_sub_group_size("half")))
+    #endif
+    
+    #ifdef INTEL_GPU
+    REQD_SUBGROUP_SIZE_32
+    #elif defined(ADRENO_GPU)
+    REQD_SUBGROUP_SIZE_64
+    #endif
   __kernel void rmsnorm_cl(
     __global const float *input,  // Input tensor
     __global float *output,    // Output tensor
@@ -915,58 +926,6 @@ const std::string &getRMSNormClKernel() {
         out[i] = in[i] * scale * a[i];
     }
 }
-
-// This is alternate version to test on NUC
-//   #pragma OPENCL EXTENSION cl_intel_subgroups : enable  
-//   #pragma OPENCL EXTENSION cl_intel_required_subgroup_size : enable
-
-//  __attribute__((intel_reqd_sub_group_size(32)))
-//  __attribute__((reqd_work_group_size(64, 1, 1)))
-//   __kernel void rmsnorm_cl(
-//     __global const float *input,  // Input tensor
-//     __global float *output,    // Output tensor
-//     __global const float *alpha,  // Alpha values (one for each width)
-//     float epsilon,
-//     int B,                  // Number of batches
-//     int C,                  // Number of channels
-//     int H,                  // Height of feature map
-//     int W                   // Width of feature map
-// ) {
-//     // Compute the corresponding batch, height, and channel indices
-//     int h = get_group_id(0);
-//     int c = get_group_id(1);
-//     int b = get_group_id(2);
-//     int index = ((b * C + c) * H + h) * W;
-//     // Calculate RMS norm for the current channel, height, and batch
-//     __global const float4 *in = (__global const float4*)(input + index);
-//     float4 sum_squares_4 = 0.0f;
-//     for (int i = get_local_id(0); i < W / 4; i += get_local_size(0)) {
-//         sum_squares_4 += in[i] * in[i];
-//     }
-
-//     float sum_squares = sum_squares_4.x + sum_squares_4.y + sum_squares_4.z + sum_squares_4.w;
-//     sum_squares = sub_group_reduce_add(sum_squares);
-
-//     __local float sum[2];
-//     if (sub_group_elect()) {
-//       sum[get_sub_group_id()] = sum_squares;
-//     }
-//     barrier(CLK_LOCAL_MEM_FENCE);
-
-//     if (get_local_id(0) == 0) {
-//       sum[0] = (sum[0] + sum[1]) / W;
-//     }
-//     barrier(CLK_LOCAL_MEM_FENCE);
-
-//     const float mean  = sum[0];
-//     const float scale = 1.0f / sqrt(mean + epsilon);
-
-//     __global float4 *out = (__global float4*)(output + index);
-//     __global const float4 *a = (__global const float4*)(alpha);
-//     for (int i = get_local_id(0); i < W / 4; i += get_local_size(0)) {
-//         out[i] = in[i] * scale * a[i];
-//     }
-// }
 )";
 
   return rmsnorm_cl_kernel_;

--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
@@ -399,6 +399,22 @@ void addition_cl(const float *input, float *res, unsigned int size_input,
                               size_res);
 }
 
+void rmsnorm_cl(const float *input, const float *gamma, float *result,
+                const float epsilon, unsigned int height, unsigned int width,
+                bool use_svm) {
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+
+  ClContext::SharedPtrClKernel kernel_rmsnorm_ptr =
+    blas_cc->registerClKernel(getRMSNormClKernel(), "rmsnorm_cl");
+  if (!kernel_rmsnorm_ptr) {
+    return;
+  }
+
+  rmsnorm_cl_internal<float>(kernel_rmsnorm_ptr, input, gamma, result, epsilon,
+                             height, width, use_svm);
+}
+
 void sscal_cl(float *X, const unsigned int N, const float alpha) {
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -103,6 +103,20 @@ void addition_cl(const float *input, float *res, unsigned int size_input,
                  unsigned int size_res);
 
 /**
+ * @brief rmsnorm each row of the tensor
+ * @param[in] input float * for input
+ * @param[in] gamma float * for gamma multiplier for each row
+ * @param[in] result float * for result
+ * @param[in] epsilon epsilon to add to each row sum to prevent division by zero
+ * @param[in] height height of the tensor
+ * @param[in] width width of the tensor
+ * @param[in] use_svm whether to treat pointers as SVM
+ */
+void rmsnorm_cl(const float *input, const float *gamma, float *result,
+                const float epsilon, unsigned int height, unsigned int width,
+                const bool use_svm = false);
+
+/**
  * @brief     sscal value element by element immediately
  * @param[in] X float * input
  * @param[in] N unsigned int number of elements

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -663,6 +663,9 @@ TEST(blas_kernels, rmsnorm_fp32) {
   std::cout << "RMSNorm time : CPU = " << dt_ref.count() / (run_count * 1.0f)
             << " ms" << std::endl;
 
+  cl_context->command_queue_inst_.enqueueSVMMap(
+    out_fp32_svm, out_cl_fp32.size() * sizeof(float), false);
+
   float mseError = mse<float>((float *)out_fp32_svm,
                               out_ref_fp32.getData<float>(), height * width);
 
@@ -688,6 +691,8 @@ TEST(blas_kernels, rmsnorm_fp32) {
 
     std::cout << "CL : " << from_cl << " REF : " << from_ref << std::endl;
   }
+
+  cl_context->command_queue_inst_.enqueueSVMUnmap(out_fp32_svm);
 
   cl_context->context_inst_.releaseSVMRegion(in_fp32_svm);
   cl_context->context_inst_.releaseSVMRegion(gamma_fp32_svm);


### PR DESCRIPTION
This commit fixes and optimizes RMSNorm implementation of OpenCL kernel. Details:

1. `rmsnorm_cl` function is added to `blas_kernels.h`
2. RMSNormLayerCL now only calls `rmsnorm_cl` instead of setting up the kernel
3. `rmsnorm_cl` optionally uses SVM
4. The implementation is change inspired by GGML implementation - there's one subgroup per workgroup and each workgroup cooperatively calculates sum of elements in each row and then normalizes the row. Performance was tested for `3072x3072` tensor.
5. Currently there's an additional, commented implementation of kernel which uses 64 size workgroup (2 subgroups). On my machine (Intel UHD Graphics) there's no difference in performance between them, but on something other there can be.

| CPU      | GPU Before | GPU After         |
|----------|------------|-------------------|
| 25-40 ms | ~200 ms    | 3-5 ms (with SVM) | 

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
6. Run test:   [X]Passed [ ]Failed [ ]Skipped
