### PR TITLE
[Build] support opencl disablement in Android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,6 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     name: Android NDK build on Ubuntu for arm64-v8a
+    strategy:
+      matrix:
+        cl_options: [ "-Denable-opencl=false", "-Denable-opencl=true" ]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -36,7 +39,7 @@ jobs:
       if: env.rebuild == '1'
       run: |
         echo "::group::Run package_android.sh"
-        ./tools/package_android.sh
+        ./tools/package_android.sh ${{ matrix.cl_options }}
         echo "::endgroup::"
     - name: Install built binaries for application build
       if: env.rebuild == '1'

--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -81,12 +81,14 @@ LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 
 include $(BUILD_STATIC_LIBRARY)
 
+ifeq (@MESON_ENABLE_OPENCL@,1)
 include $(CLEAR_VARS)
 LOCAL_MODULE            := OpenCL
 LOCAL_SRC_FILES         := @MESON_CL_ROOT@/lib/arm64-v8a/libOpenCL.so
 LOCAL_EXPORT_C_INCLUDES := @MESON_CL_ROOT@/include
 
 include $(PREBUILT_SHARED_LIBRARY)
+endif
 
 include $(CLEAR_VARS)
 
@@ -128,6 +130,7 @@ include $(BUILD_SHARED_LIBRARY)
 
 endif # MESON_HAS_GGML
 
+ifeq (@MESON_ENABLE_OPENCL@,1)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE        := clblast
@@ -239,6 +242,7 @@ LOCAL_CXXFLAGS      += -std=c++17 -O3 -fexceptions -DOPENCL_API
 LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 
 include $(BUILD_STATIC_LIBRARY)
+endif
 
 include $(CLEAR_VARS)
 
@@ -256,8 +260,8 @@ LOCAL_MODULE_TAGS   := optional
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
 LOCAL_LDFLAGS 	    += "-Wl,-z,max-page-size=16384"
 
-LOCAL_SHARED_LIBRARIES := OpenCL
-LOCAL_STATIC_LIBRARIES += iniparser openblas ruy clblast
+@MESON_OPENCL_SHARED_LIBS@
+LOCAL_STATIC_LIBRARIES += iniparser openblas ruy @MESON_OPENCL_STATIC_LIBS@
 
 ifeq ($(MESON_HAS_TFLITE), 1)
   LOCAL_STATIC_LIBRARIES += tensorflow-lite

--- a/jni/meson.build
+++ b/jni/meson.build
@@ -41,9 +41,25 @@ if ruy_dep.found()
   and_conf.set('MESON_RUY_ROOT', ruy_root)
 endif
 
-if clblast_dep.found()
-  and_conf.set('MESON_CLBLAST_ROOT', clblast_root)
-  and_conf.set('MESON_CL_ROOT', opencl_root)
+if get_option('enable-opencl')
+  # Set OpenCL block markers to include the OpenCL sections
+  and_conf.set('MESON_ENABLE_OPENCL', 1) 
+  if clblast_dep.found()
+    and_conf.set('MESON_CLBLAST_ROOT', clblast_root)
+    and_conf.set('MESON_CL_ROOT', opencl_root)
+  endif
+  # Set library dependencies
+  and_conf.set('MESON_OPENCL_SHARED_LIBS', 'LOCAL_SHARED_LIBRARIES := OpenCL')
+  and_conf.set('MESON_OPENCL_STATIC_LIBS', 'clblast')
+else
+  # Disable OpenCL
+  and_conf.set('MESON_ENABLE_OPENCL', 0)
+  # No OpenCL libraries needed
+  and_conf.set('MESON_OPENCL_SHARED_LIBS', '')
+  and_conf.set('MESON_OPENCL_STATIC_LIBS', '')
+  # Set dummy paths to avoid undefined variables
+  and_conf.set('MESON_CLBLAST_ROOT', '')
+  and_conf.set('MESON_CL_ROOT', '')
 endif
 
 if tflite_dep.found()

--- a/jni/prepare_ggml.sh
+++ b/jni/prepare_ggml.sh
@@ -4,16 +4,34 @@ set -e
 GGML_SRC=$1
 
 REVISION=489716ba99ecd51164f79e8c6fec0b5bf634eac9
-PATCH_PATH="${GGML_SRC}"/../packagefiles/ggml/0001-nntrainer-ggml-patch.patch
+PATCH_FILE="${GGML_SRC}"/../packagefiles/ggml/0001-nntrainer-ggml-patch.patch
+
+is_patch_applied() {  
+    # save patch file to tmp path
+    temp_file=$(mktemp)  
+    cat "$PATCH_FILE" | grep -v '^$' > "$temp_file"  
+
+    diff_output=$(diff "$temp_file" <(git diff HEAD))  
+    rm "$temp_file"  
+
+    if [ -z "$diff_output" ]; then  
+        return 1
+    else  
+        return 0
+    fi  
+
+}  
 
 echo "[GGML] PREPARING GGML..."
 
 pushd "${GGML_SRC}"
-git checkout "${REVISION}"
-git restore CMakeLists.txt
-git restore include
-git restore src
-git apply "${PATCH_PATH}"
+if !is_patch_applied; then
+    git checkout "${REVISION}"
+    git restore CMakeLists.txt
+    git restore include
+    git restore src
+    git apply "${PATCH_FILE}"
+fi
 cp ./src/ggml-cpu/ggml-cpu.c ./src/ggml-cpu/ggml-cpu_c.c
 popd
 

--- a/jni/prepare_ggml.sh
+++ b/jni/prepare_ggml.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 set -e
 GGML_SRC=$1
@@ -6,33 +6,46 @@ GGML_SRC=$1
 REVISION=489716ba99ecd51164f79e8c6fec0b5bf634eac9
 PATCH_FILE="${GGML_SRC}"/../packagefiles/ggml/0001-nntrainer-ggml-patch.patch
 
-is_patch_applied() {  
-    # save patch file to tmp path
-    temp_file=$(mktemp)  
-    cat "$PATCH_FILE" | grep -v '^$' > "$temp_file"  
-
-    diff_output=$(diff "$temp_file" <(git diff HEAD))  
-    rm "$temp_file"  
-
-    if [ -z "$diff_output" ]; then  
-        return 1
-    else  
-        return 0
-    fi  
-
-}  
+is_patch_applied() {
+    # check if the patch is already applied
+    if git apply --reverse --check "$PATCH_FILE" >/dev/null 2>&1; then
+        return 0  
+    else
+        return 1  
+    fi
+}
 
 echo "[GGML] PREPARING GGML..."
 
 pushd "${GGML_SRC}"
-if !is_patch_applied; then
+
+if is_patch_applied; then
+    echo "[GGML] Patch is already applied. Only performing file copy."
+else
+    echo "[GGML] Patch not applied. Performing full setup..."
+    
+    # checkout to deisgnated version
     git checkout "${REVISION}"
+    
+    # restore files
     git restore CMakeLists.txt
     git restore include
     git restore src
+    
+    # apply patch
+    echo "[GGML] Applying patch..."
     git apply "${PATCH_FILE}"
+    echo "[GGML] Patch applied successfully."
 fi
-cp ./src/ggml-cpu/ggml-cpu.c ./src/ggml-cpu/ggml-cpu_c.c
+
+# copy ggml files
+if [ -f "./src/ggml-cpu/ggml-cpu.c" ]; then
+    cp ./src/ggml-cpu/ggml-cpu.c ./src/ggml-cpu/ggml-cpu_c.c
+    echo "[GGML] Copied ggml-cpu.c to ggml-cpu_c.c"
+else
+    echo "[GGML] WARNING: ./src/ggml-cpu/ggml-cpu.c not found. Skipping file copy."
+fi
+
 popd
 
 echo "[GGML] PREPARING GGML FINISHED"

--- a/meson.build
+++ b/meson.build
@@ -206,13 +206,6 @@ if get_option('enable-opencl')
     clblast_proj = cmake.subproject('clblast', options: clblast_options, required: true)
     clblast_dep = clblast_proj.dependency('clblast')
   endif
-else 
-  # When OpenCL is disabled, set clblast_dep to dummy_dep for Android
-  if get_option('platform') == 'android'
-    clblast_dep = dummy_dep
-    clblast_root = ''
-    opencl_root = ''
-  endif
 endif
 
 if get_option('opencl-kernel-path') != ''

--- a/meson.build
+++ b/meson.build
@@ -176,6 +176,8 @@ if get_option('enable-mmap')
   extra_defines += '-DUSE_MMAP=1'
 endif
 
+dummy_dep = dependency('', required: false)
+
 if get_option('enable-opencl')
   if get_option('platform') == 'android'
   endif
@@ -203,6 +205,13 @@ if get_option('enable-opencl')
     clblast_options.add_cmake_defines({'CMAKE_POLICY_VERSION_MINIMUM': '3.10'})
     clblast_proj = cmake.subproject('clblast', options: clblast_options, required: true)
     clblast_dep = clblast_proj.dependency('clblast')
+  endif
+else 
+  # When OpenCL is disabled, set clblast_dep to dummy_dep for Android
+  if get_option('platform') == 'android'
+    clblast_dep = dummy_dep
+    clblast_root = ''
+    opencl_root = ''
   endif
 endif
 
@@ -313,7 +322,6 @@ nntrainer_conf.set('INCLUDE_INSTALL_DIR', nntrainer_includedir / '..')
 nntrainer_conf.set('FLASH_STORAGE_UTILIZATION', nntrainer_enable_fsu)
 nntrainer_conf.set('FLASH_STORAGE_UTILIZATION_PATH', nntrainer_fsudir)
 
-dummy_dep = dependency('', required: false)
 ml_api_common_flag = '-DML_API_COMMON=0'
 
 # if ml-api-support is disabled, enable dummy common api interfaces and disable related dependencies.

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -16,20 +16,24 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 	$(NNTRAINER_ROOT)/nntrainer/dataset \
 	$(NNTRAINER_ROOT)/nntrainer/models \
 	$(NNTRAINER_ROOT)/nntrainer/layers \
-	$(NNTRAINER_ROOT)/nntrainer/layers/cl_layers \
 	$(NNTRAINER_ROOT)/nntrainer/compiler \
 	$(NNTRAINER_ROOT)/nntrainer/graph \
-	$(NNTRAINER_ROOT)/nntrainer/opencl \
 	$(NNTRAINER_ROOT)/nntrainer/optimizers \
 	$(NNTRAINER_ROOT)/nntrainer/tensor \
 	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend \
 	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend/fallback \
 	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend/arm \
-	$(NNTRAINER_ROOT)/nntrainer/tensor/cl_operations \
 	$(NNTRAINER_ROOT)/nntrainer/utils \
 	$(NNTRAINER_ROOT)/api \
 	$(NNTRAINER_ROOT)/api/ccapi/include \
 	${ML_API_COMMON_INCLUDES}
+
+ifeq ( $(MESON_ENABLE_OPENCL), 1)
+NNTRAINER_INCLUDES += $(NNTRAINER_ROOT)/nntrainer/opencl \
+	$(NNTRAINER_ROOT)/nntrainer/tensor/cl_operations \
+	$(NNTRAINER_ROOT)/nntrainer/layers/cl_layers 
+endif
+
 
 LOCAL_MODULE := nntrainer
 LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/builddir/jni/$(TARGET_ARCH_ABI)/libnntrainer.so
@@ -57,6 +61,7 @@ LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/builddir/jni/$(TARGET_ARCH_ABI)//libggml.so
 
 include $(PREBUILT_SHARED_LIBRARY)
 
+ifeq ( $(MESON_ENABLE_OPENCL), 1)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := opencl
@@ -70,6 +75,7 @@ LOCAL_MODULE := clblast
 LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/builddir/obj/local/$(TARGET_ARCH_ABI)/libclblast.a
 
 include $(PREBUILT_STATIC_LIBRARY)
+endif
 
 include $(CLEAR_VARS)
 GTEST_PATH := googletest
@@ -109,8 +115,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -126,8 +132,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -143,8 +149,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -160,8 +166,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -177,8 +183,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -194,8 +200,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -211,8 +217,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -228,8 +234,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -245,8 +251,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -262,8 +268,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -279,8 +285,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -295,8 +301,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -311,8 +317,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_SHARED_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -327,8 +333,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -343,8 +349,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -359,8 +365,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -375,8 +381,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -393,8 +399,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -411,8 +417,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -431,8 +437,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -455,16 +461,19 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := unittest_layers
-LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 -march=armv8.2-a+fp16+dotprod -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DENABLE_OPENCL=1 
+LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 -march=armv8.2-a+fp16+dotprod -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1
 LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
+ifeq ( $(MESON_ENABLE_OPENCL), 1)
+LOCAL_CFLAGS += -DEANBLE_OPENCL=1
+endif
 
 LOCAL_SRC_FILES := \
 	 ../unittest/layers/layers_dependent_common_tests.cpp \
@@ -473,15 +482,9 @@ LOCAL_SRC_FILES := \
 	 ../unittest/layers/unittest_layer_node.cpp \
 	 ../unittest/layers/unittest_layers.cpp \
 	 ../unittest/layers/unittest_layers_impl.cpp \
-	 ../unittest/layers/unittest_layers_transpose_cl.cpp \
-	 ../unittest/layers/unittest_layers_concat_cl.cpp \
-	 ../unittest/layers/unittest_layers_swiglu_cl.cpp \
-	 ../unittest/layers/unittest_layers_fully_connected_cl.cpp \
 	 ../unittest/layers/unittest_layers_input.cpp \
 	 ../unittest/layers/unittest_layers_loss.cpp \
-	 ../unittest/layers/unittest_layers_reshape_cl.cpp \
 	 ../unittest/layers/unittest_layers_fully_connected.cpp \
-	 ../unittest/layers/unittest_layers_rmsnorm_cl.cpp \
 	 ../unittest/layers/unittest_layers_batch_normalization.cpp \
 	 ../unittest/layers/unittest_layers_layer_normalization.cpp \
 	 ../unittest/layers/unittest_layers_convolution2d.cpp \
@@ -507,14 +510,25 @@ LOCAL_SRC_FILES := \
 	 ../unittest/layers/unittest_layers_reshape.cpp \
 	 ../unittest/layers/unittest_layers_multi_head_attention.cpp \
 	 ../unittest/layers/unittest_layers_positional_encoding.cpp \
+
+ifeq ( $(MESON_ENABLE_OPENCL), 1)
+LOCAL_SRC_FILES += \
+	 ../unittest/layers/unittest_layers_transpose_cl.cpp \
+	 ../unittest/layers/unittest_layers_concat_cl.cpp \
+	 ../unittest/layers/unittest_layers_swiglu_cl.cpp \
+	 ../unittest/layers/unittest_layers_fully_connected_cl.cpp \
 	 ../unittest/layers/unittest_layers_addition_cl.cpp \
+	 ../unittest/layers/unittest_layers_rmsnorm_cl.cpp \
+	 ../unittest/layers/unittest_layers_reshape_cl.cpp 
+endif
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
+ifeq ( $(MESON_ENABLE_OPENCL), 1)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := unittest_blas_kernels_cl
@@ -527,8 +541,8 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -543,40 +557,47 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
 LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
 include $(BUILD_EXECUTABLE)
+endif
 
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := unittest_nntrainer_cpu_backend
-LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 -march=armv8.2-a+fp16+dotprod -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DENABLE_OPENCL=1 -DUSE__FP16=1
+LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 -march=armv8.2-a+fp16+dotprod -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DUSE__FP16=1
 LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DENABLE_GGML
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
+ifeq ( $(MESON_ENABLE_OPENCL), 1)
+LOCAL_CFLAGS += -DEANBLE_OPENCL=1
+endif
 
 LOCAL_SRC_FILES := \
 	 ../unittest/unittest_nntrainer_cpu_backend.cpp
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := unittest_nntrainer_cpu_backend_fp16
-LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 -march=armv8.2-a+fp16+dotprod -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DENABLE_OPENCL=1 -DUSE__FP16=1
+LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 -march=armv8.2-a+fp16+dotprod -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DUSE__FP16=1
 LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DENABLE_GGML
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
+ifeq ( $(MESON_ENABLE_OPENCL), 1)
+LOCAL_CFLAGS += -DEANBLE_OPENCL=1
+endif
 
 LOCAL_SRC_FILES := \
 	 ../unittest/unittest_nntrainer_cpu_backend_fp16.cpp
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 # unittest_ccapi
@@ -592,6 +613,6 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
-LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml opencl
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer clblast
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer ggml $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -568,9 +568,6 @@ LOCAL_MODULE := unittest_nntrainer_cpu_backend
 LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 -march=armv8.2-a+fp16+dotprod -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DUSE__FP16=1
 LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DENABLE_GGML
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
-ifeq ( $(MESON_ENABLE_OPENCL), 1)
-LOCAL_CFLAGS += -DEANBLE_OPENCL=1
-endif
 
 LOCAL_SRC_FILES := \
 	 ../unittest/unittest_nntrainer_cpu_backend.cpp
@@ -587,9 +584,6 @@ LOCAL_MODULE := unittest_nntrainer_cpu_backend_fp16
 LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 -march=armv8.2-a+fp16+dotprod -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DUSE__FP16=1
 LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DENABLE_GGML
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
-ifeq ( $(MESON_ENABLE_OPENCL), 1)
-LOCAL_CFLAGS += -DEANBLE_OPENCL=1
-endif
 
 LOCAL_SRC_FILES := \
 	 ../unittest/unittest_nntrainer_cpu_backend_fp16.cpp

--- a/test/jni/meson.build
+++ b/test/jni/meson.build
@@ -45,6 +45,14 @@ endif
 #   error('blas is needed for the android build')
 # endif
 
+if get_option('enable-opencl')
+  and_conf.set('MESON_OPENCL_SHARED_LIBS', 'opencl')
+  and_conf.set('MESON_OPENCL_STATIC_LIBS', 'clblast')
+else
+  and_conf.set('MESON_OPENCL_SHARED_LIBS', '')
+  and_conf.set('MESON_OPENCL_STATIC_LIBS', '')
+endif
+
 if ml_api_common_dep.found()
   and_conf.set('MESON_ML_API_COMMON_ROOT', ml_api_common_root)
 else

--- a/tools/package_android.sh
+++ b/tools/package_android.sh
@@ -31,14 +31,14 @@ if [ ! -d builddir ]; then
     #default value of openblas num threads is 1 for android
     #enable-tflite-interpreter=false is just temporally until ci system is stabel
     #enable-opencl=true will compile OpenCL related changes or remove this option to exclude OpenCL compilations.
-  meson builddir -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Domp-num-threads=1 -Denable-opencl=true -Dhgemm-experimental-kernel=false -Denable-ggml=true ${filtered_args[@]}
+  meson builddir -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Domp-num-threads=1 -Dhgemm-experimental-kernel=false -Denable-ggml=true ${filtered_args[@]}
 else
   echo "warning: $TARGET/builddir has already been taken, this script tries to reconfigure and try building"
   pushd builddir
     #default value of openblas num threads is 1 for android
     #enable-tflite-interpreter=false is just temporally until ci system is stabel  
     #enable-opencl=true will compile OpenCL related changes or remove this option to exclude OpenCL compilations.
-    meson configure -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Domp-num-threads=1 -Denable-opencl=true -Dhgemm-experimental-kernel=false -Denable-ggml=true ${filtered_args[@]}
+    meson configure -Dplatform=android -Dopenblas-num-threads=1 -Denable-tflite-interpreter=false -Denable-tflite-backbone=false -Denable-fp16=true -Domp-num-threads=1 -Dhgemm-experimental-kernel=false -Denable-ggml=true ${filtered_args[@]}
     meson --wipe
   popd
 fi


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[Build] fix android build to support opencl disablement</summary><br />

- Fix #3416
- This patch updates build script for Android (ggml-related script)
- This patch updates meson build and Android mk files to support enable-opencl=false option

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
</details>



### Summary

- Fix #3416
- This patch updates build script for Android (ggml-related script)
- This patch updates meson build and Android mk files to support enable-opencl=false option
- One can do the android build with `./tools/package_android.sh -Denable-opencl=true / false`

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
