### PR TITLE
[Bugfix] neuralnet load is fixed.

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -764,7 +764,7 @@ void NeuralNetwork::load(const std::string &file_path,
           if (!MMAP_READ) {
             auto local_model_file = checkedOpenStream<std::ifstream>(
               (v.size() == 2) ? v[1] : v[0], std::ios::in | std::ios::binary);
-            node->read(&local_model_file, false, exec_mode, fsu_mode,
+            node->read(local_model_file, false, exec_mode, fsu_mode,
                        std::numeric_limits<size_t>::max(), true);
           } else {
             node->read(mmaped, false, exec_mode, fsu_mode,


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[Bugfix] neuralnet load is fixed.</summary><br />

- read with filedescriptor should be used
- variant doesn't work in ubuntu.
- In current, mmap is set 0. This mmap read option should be fixed later.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

### Summary

- Bug fix in neuralnet.cpp
- read(ReadSource ...) doesn't work in Linux. Thus, this patch fixes the read from read(ReadSource) to read(std::ifstream)

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
