### PR TITLE
Update FloatTensor Class for Q4_0 GEMM Support and Optimize GEMV Performance

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -30,7 +30,7 @@ option('tizen-version-minor', type: 'integer', min : 0, max : 9999, value: 0)
 option('openblas-num-threads', type: 'integer', min : 0, max : 9999, value: 0)
 #This is for the multi-threading in nntrainer
 option('nntr-num-threads', type: 'integer', min : 0, max : 9999, value: 1)
-option('omp-num-threads', type: 'integer', min : 0, max : 9999, value: 1)
+option('omp-num-threads', type: 'integer', min : 0, max : 9999, value: 6)
 option('hgemm-experimental-kernel', type: 'boolean', value: false)
 
 # test related option


### PR DESCRIPTION
This pull request updates the FloatTensor class to enable Q4_0 GEMM computation.
Note that the Q4_0 CPU kernel is utilized for GEMV operations.
Additionally, this patch restores the number of OpenMP threads to 6, as a decrease in performance was observed

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped