### PR TITLE
[Wait for #3419][MHA] improve mha layer for Android

### DIFF
--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -16,20 +16,13 @@
 #include <thread>
 #include <vector>
 
-#ifdef _WIN32
-#include <chrono>
-#endif
-
 #include <fp16.h>
 #include <layer_context.h>
 #include <mha_core.h>
 #include <nntrainer_error.h>
 #include <node_exporter.h>
 
-#include <cassert>
-#include <chrono>
 #include <cstdint>
-#include <type_traits>
 
 inline float convert_scalar(uint16_t h) {
   return nntrainer::compute_fp16_to_fp32(h);
@@ -246,7 +239,6 @@ void MHACoreLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
     get_step_dim(cache_value_dim); // (B, 1, from-to, n_heads_KV * head_dim)
 
   unsigned int batch_size = (_from) ? 1 : query_dim.batch();
-  // auto start_time = std::chrono::high_resolution_clock::now();
   // do the incremental forwarding
   for (unsigned int batch = 0; batch < batch_size; ++batch) {
     one_batch_incremental_forwarding(
@@ -367,7 +359,7 @@ void MHACoreLayer::one_batch_incremental_forwarding(
 
   /** 1. Load Input Tensors of this batch : b_ denotes a Tensor for this batch
    * **/
-  auto &pool = nntrainer::ThreadPoolManager::getInstance();
+  auto &pool = nntrainer::ThreadPoolManager::Global().getThreadPool();
 
   nntrainer::Tensor b_projected_query_step = query.getSharedDataTensor(
     query_step_dim, batch * query_dim.getFeatureLen(), true);

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -1,0 +1,767 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   mha_core.cpp
+ * @date   11 July 2025
+ * @see    https://github.com/nnstreamer/nntrainer
+ *         https://arxiv.org/abs/1706.03762
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This code is based on custom_multi_head_attention_layer.cpp.
+ *         This code is a part of the break down version of the mha layer.
+ */
+#include <algorithm>
+#include <cmath>
+#include <thread>
+#include <vector>
+
+#ifdef _WIN32
+#include <chrono>
+#endif
+
+#include <fp16.h>
+#include <layer_context.h>
+#include <mha_core.h>
+#include <nntrainer_error.h>
+#include <node_exporter.h>
+
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <type_traits>
+
+inline float convert_scalar(uint16_t h) {
+  return nntrainer::compute_fp16_to_fp32(h);
+}
+
+namespace causallm {
+
+/************************************************************** */
+
+/**
+ * @brief constructor of MHACoreLayer
+ */
+MHACoreLayer::MHACoreLayer() :
+  mha_core_props(
+    nntrainer::props::NumHeads(), props::NumHeads_KV(),
+    nntrainer::props::ProjectedKeyDim(), nntrainer::props::ProjectedValueDim(),
+    nntrainer::props::OutputShape(), nntrainer::props::DropOutRate(),
+    nntrainer::props::ReturnAttentionWeight(),
+    nntrainer::props::AverageAttentionWeight(), nntrainer::props::MaxTimestep(),
+    props::SlidingWindow(), props::MaxNewTokens(), props::RopeTheta(),
+    props::MaxPositionEmbeddings()),
+  sm(nntrainer::ActivationType::ACT_SOFTMAX),
+  epsilon(1e-3),
+  cache_index(0),
+  num_heads_Q(0),
+  num_heads_KV(0),
+  head_dim(0),
+  cache_shift(false) {
+  weight_idx.fill(std::numeric_limits<unsigned>::max());
+}
+
+MHACoreLayer::~MHACoreLayer() {}
+
+/************************************************************** */
+
+void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
+
+  NNTR_THROW_IF(context.getNumInputs() < 3 || context.getNumInputs() > 4,
+                std::invalid_argument)
+    << "Multi head Attention layer needs 3 or 4 inputs. (query, key, value and "
+       "mask is optional)";
+  ml::train::TensorDim::TensorType activation_type = {
+    context.getFormat(), context.getActivationDataType()};
+  ml::train::TensorDim empty_dim(activation_type);
+
+  const std::vector<ml::train::TensorDim> &input_dims =
+    context.getInputDimensions();
+  const ml::train::TensorDim &query_dim = input_dims[INOUT_INDEX::QUERY];
+  const ml::train::TensorDim &key_dim = input_dims[INOUT_INDEX::KEY];
+
+  /** max time step of this model */
+  const unsigned int max_timestep =
+    std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
+
+  /** max position embeddings */
+  const unsigned int max_position_embeddings =
+    std::get<props::MaxPositionEmbeddings>(mha_core_props).get();
+
+  /** query_dim = (B, 1, seq_len, H_Q * Head_Dim ) */
+  const unsigned int batch_size = query_dim.batch();
+  const unsigned int query_width = query_dim.width();
+  /** key_dim = (B, 1, max_seq_len, H_KV * Head_Dim ) */
+  const unsigned int key_width = key_dim.width();
+
+  /**
+   *  @note If NumHeads_KV is set, then use the value. Otherwise,
+   *        we initialize num_heads_KV with num_heads_Q.
+   */
+  num_heads_Q = static_cast<size_t>(
+    std::get<nntrainer::props::NumHeads>(mha_core_props).get());
+  num_heads_KV =
+    std::get<props::NumHeads_KV>(mha_core_props).empty()
+      ? num_heads_Q
+      : static_cast<size_t>(std::get<props::NumHeads_KV>(mha_core_props).get());
+
+  // head_dim
+  head_dim = static_cast<size_t>(query_width) / num_heads_Q;
+  NNTR_THROW_IF(head_dim != key_width / num_heads_KV, std::invalid_argument)
+    << "num_heads_Q and num_heads_KV are not properly given. Please check the "
+       "num_heads_* are set correctly so that the `head_dim`s are all same for "
+       "query / key / value";
+
+  /** Tensor for KV-Cache */
+
+#ifdef ENABLE_FP16
+  ml::train::TensorDim cache_key_dim(
+    {batch_size, 1, max_timestep, num_heads_KV * head_dim},
+    {context.getFormat(), ml::train::TensorDim::DataType::FP16});
+  ml::train::TensorDim cache_value_dim(
+    {batch_size, 1, max_timestep, num_heads_KV * head_dim},
+    {context.getFormat(), ml::train::TensorDim::DataType::FP16});
+#else
+  ml::train::TensorDim cache_key_dim(
+    {batch_size, 1, max_timestep, num_heads_KV * head_dim},
+    {context.getFormat(), ml::train::TensorDim::DataType::UINT16});
+  ml::train::TensorDim cache_value_dim(
+    {batch_size, 1, max_timestep, num_heads_KV * head_dim},
+    {context.getFormat(), ml::train::TensorDim::DataType::UINT16});
+#endif
+
+  weight_idx[AttentionParams::cache_key] = context.requestTensor(
+    cache_key_dim, "cache_key", nntrainer::Initializer::NONE, false,
+    nntrainer::TensorLifespan::MAX_LIFESPAN);
+  weight_idx[AttentionParams::cache_value] = context.requestTensor(
+    cache_value_dim, "cache_value", nntrainer::Initializer::NONE, false,
+    nntrainer::TensorLifespan::MAX_LIFESPAN);
+
+  theta = (float)std::get<props::RopeTheta>(mha_core_props).get();
+
+  /** precompute_freqs will be invoked only once */
+  if (freqs_cos == nullptr)
+    precompute_freqs(head_dim, max_position_embeddings, theta);
+
+  /** set Output dimension! - one output */
+  std::vector<nntrainer::TensorDim> output_dims(1);
+  output_dims[0] = input_dims[0];
+  output_dims[0].width(head_dim * num_heads_Q);
+  output_dims[0].setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+  context.setOutputDimensions(output_dims);
+}
+
+/************************************************************** */
+
+/**
+ * @note This forwarding function is used for training mode.
+ *       This will be implemented ASAP.
+ * @date 2024-09-02
+ */
+void MHACoreLayer::forwarding(nntrainer::RunLayerContext &context,
+                              bool training) {}
+
+/**
+ * @note This incremental_forwarding method is invoked for inference mode.
+ *       Please note that Transformer Decoder's MHA takes only one sequence at a
+ * step. Incremental forwarding function is used for this.
+ */
+void MHACoreLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
+                                          unsigned int _from, unsigned int _to,
+                                          bool training) {
+
+  if (_from && (_to - _from != 1)) {
+    throw std::invalid_argument(
+      "if it is not initial forwarding, then step size(difference between to "
+      "and from) should be 1");
+  }
+
+  unsigned int max_timestep =
+    std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
+
+  unsigned int from = _from;
+  unsigned int to = _to;
+
+  if (to >= max_timestep) {
+    // initial forwarding
+    if (!_from) {
+      throw std::invalid_argument(
+        "to shouldn't greater than max_timestep for initial forwarding");
+    } else {
+      // exceeds the kv_cache size
+      // KV_cache is shifted!
+      cache_shift = true;
+      from = max_timestep - 1;
+      to = max_timestep;
+    }
+  }
+
+  // util fn to compute tensor dimension for one step.
+  auto get_step_dim = [to, from](const ml::train::TensorDim &dim) {
+    auto step_dim = dim;
+    step_dim.batch(1);
+    step_dim.height(to - from); // One is expected.
+    return step_dim;
+  };
+
+  /** incremental forwarding for each batch */
+  nntrainer::Tensor &query =
+    context.getInput(INOUT_INDEX::QUERY); // projected query
+  nntrainer::Tensor &key = context.getInput(INOUT_INDEX::KEY); // projected key
+  nntrainer::Tensor &value =
+    context.getInput(INOUT_INDEX::VALUE); // projected value
+  nntrainer::Tensor &output =
+    context.getOutput(INOUT_INDEX::OUTPUT); // output to be projected
+
+  nntrainer::Tensor &cache_key =
+    context.getTensor(weight_idx[AttentionParams::cache_key]);
+  nntrainer::Tensor &cache_value =
+    context.getTensor(weight_idx[AttentionParams::cache_value]);
+
+  const unsigned int num_heads_Q =
+    std::get<nntrainer::props::NumHeads>(mha_core_props).get();
+
+  ml::train::TensorDim query_dim =
+    query.getDim(); // (B, 1, seq_len, n_heads_Q * head_dim)
+  ml::train::TensorDim key_dim =
+    key.getDim(); // (B, 1, seq_len, n_heads_KV * head_dim)
+  ml::train::TensorDim value_dim =
+    value.getDim(); // (B, 1, seq_len, n_heads_KV * head_dim)
+  ml::train::TensorDim output_dim =
+    output.getDim(); // (B, 1, seq_len, n_heads_Q * head_dim)
+  ml::train::TensorDim cache_key_dim =
+    cache_key.getDim(); // (B, 1, max_seq_len, n_heads_KV * head_dim)
+  ml::train::TensorDim cache_value_dim =
+    cache_value.getDim(); // (B, 1, max_seq_len, n_heads_KV * head_dim)
+
+  ml::train::TensorDim query_step_dim =
+    get_step_dim(query_dim); // (B, 1, from-to, n_heads_Q * head_dim)
+  ml::train::TensorDim output_step_dim =
+    get_step_dim(output_dim); // (B, 1, from-to, n_heads_Q * head_dim)
+  ml::train::TensorDim cache_key_step_dim =
+    get_step_dim(cache_key_dim); // (B, 1, from-to, n_heads_KV * head_dim)
+
+  ml::train::TensorDim cache_value_step_dim =
+    get_step_dim(cache_value_dim); // (B, 1, from-to, n_heads_KV * head_dim)
+
+  unsigned int batch_size = (_from) ? 1 : query_dim.batch();
+  // auto start_time = std::chrono::high_resolution_clock::now();
+  // do the incremental forwarding
+  for (unsigned int batch = 0; batch < batch_size; ++batch) {
+    one_batch_incremental_forwarding(
+      batch, _from, from, to, query, key, value, output, cache_key, cache_value,
+      query_dim, query_step_dim, key_dim, value_dim, cache_key_dim,
+      cache_key_step_dim, cache_value_dim, cache_value_step_dim, output_dim,
+      output_step_dim);
+  }
+
+  if (!_from) {
+    batch_size = query_dim.batch();
+    nntrainer::Tensor cache_key_0_step =
+      cache_key.getSharedDataTensor(cache_key_step_dim, 0, true);
+    nntrainer::Tensor cache_value_0_step =
+      cache_value.getSharedDataTensor(cache_value_step_dim, 0, true);
+
+    for (unsigned int batch = 1; batch < batch_size; ++batch) {
+      nntrainer::Tensor cache_key_nth_step = cache_key.getSharedDataTensor(
+        cache_key_step_dim,
+        batch * cache_key_dim.getFeatureLen() + from * cache_key_dim.width(),
+        true);
+      nntrainer::Tensor cache_value_nth_step =
+        cache_key.getSharedDataTensor(cache_value_step_dim,
+                                      batch * cache_value_dim.getFeatureLen() +
+                                        from * cache_value_dim.width(),
+                                      true);
+
+      cache_key_nth_step.copyData(cache_key_0_step);
+      cache_key_nth_step.copyData(cache_value_0_step);
+    }
+  }
+}
+
+void MHACoreLayer::compute_kcaches(
+  nntrainer::Tensor &in, nntrainer::Tensor &cache, nntrainer::Tensor &out,
+  unsigned int from, size_t sequence_len, unsigned int num_head,
+  unsigned int group_size, unsigned int head_dim, BS::thread_pool<> &pool) {
+
+  if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    if (from) {
+      nntrainer::compute_kcaches<uint16_t>(
+        in.getData<float>(), cache.getData<uint16_t>(), out.getData<float>(),
+        from + 1, num_head / group_size, head_dim, group_size, 16);
+    } else {
+      std::vector<std::future<void>> futures;
+      for (unsigned int i = 0; i < sequence_len; ++i) {
+        float *input_addr = in.getData<float>() + num_head * head_dim * i;
+        uint16_t *cache_addr = cache.getData<uint16_t>();
+        int row_to_compute = i + 1;
+        size_t out_start_row = (i + 1) * i / 2;
+
+        float *output_addr = out.getData<float>() + out_start_row * num_head;
+
+        futures.emplace_back(pool.submit_task([=]() {
+          nntrainer::compute_kcaches<uint16_t>(
+            input_addr, cache_addr, output_addr, row_to_compute,
+            num_head / group_size, head_dim, group_size, 16);
+        }));
+      }
+      for (auto &fut : futures)
+        fut.get();
+    }
+  } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    if (from) {
+      nntrainer::compute_kcaches(
+        in.getData<_FP16>(), cache.getData<_FP16>(), out.getData<_FP16>(),
+        from + 1, num_head / group_size, head_dim, group_size, 16);
+    } else {
+      std::vector<std::future<void>> futures;
+      for (unsigned int i = 0; i < sequence_len; ++i) {
+        _FP16 *input_addr = in.getData<_FP16>() + num_head * head_dim * i;
+        _FP16 *cache_addr = cache.getData<_FP16>();
+        int row_to_compute = i + 1;
+        size_t out_start_row = (i + 1) * i / 2;
+
+        _FP16 *output_addr = out.getData<_FP16>() + out_start_row * num_head;
+
+        futures.emplace_back(pool.submit_task([=]() {
+          nntrainer::compute_kcaches(input_addr, cache_addr, output_addr,
+                                     row_to_compute, num_head / group_size,
+                                     head_dim, group_size, 16);
+        }));
+      }
+      for (auto &fut : futures)
+        fut.get();
+    }
+#else
+    NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
+#endif
+  }
+}
+
+void MHACoreLayer::one_batch_incremental_forwarding(
+  const unsigned int batch, const unsigned int _from, const unsigned int from,
+  const unsigned int to, nntrainer::Tensor &query, nntrainer::Tensor &key,
+  nntrainer::Tensor &value, nntrainer::Tensor &output,
+  nntrainer::Tensor &cache_key, nntrainer::Tensor &cache_value,
+  ml::train::TensorDim &query_dim, ml::train::TensorDim &query_step_dim,
+  ml::train::TensorDim &key_dim, ml::train::TensorDim &value_dim,
+
+  ml::train::TensorDim &cache_key_dim, ml::train::TensorDim &cache_key_step_dim,
+  ml::train::TensorDim &cache_value_dim,
+  ml::train::TensorDim &cache_value_step_dim, ml::train::TensorDim &output_dim,
+  ml::train::TensorDim &output_step_dim) {
+
+  /**
+   *  cache_key
+   *  +--------+                        ->
+   *  |        |                        ->
+   *  |        |                        ->
+   *  |........| from                   ->
+   *  |........| to -> b_cache_key_step -> b_cached_key
+   *  |        |
+   *  +--------+
+   *
+   */
+
+  /** 1. Load Input Tensors of this batch : b_ denotes a Tensor for this batch
+   * **/
+  auto &pool = nntrainer::ThreadPoolManager::getInstance();
+
+  nntrainer::Tensor b_projected_query_step = query.getSharedDataTensor(
+    query_step_dim, batch * query_dim.getFeatureLen(), true);
+
+  apply_rotary_emb_tensor_v2(b_projected_query_step, b_projected_query_step,
+                             head_dim, _from, false);
+
+  nntrainer::Tensor b_cache_key_step = cache_key.getSharedDataTensor(
+    cache_key_step_dim,
+    batch * cache_key_dim.getFeatureLen() + from * cache_key_dim.width(), true);
+
+  ml::train::TensorDim key_step_dim = key.getDim();
+  key_step_dim.height(to - from);
+
+  nntrainer::Tensor key_step = key.getSharedDataTensor(
+    key_step_dim, batch * key_dim.getFeatureLen(), true);
+
+  apply_rotary_emb_tensor_v2(key_step, b_cache_key_step, head_dim, _from,
+                             false);
+
+  nntrainer::Tensor b_cache_value_step = cache_value.getSharedDataTensor(
+    cache_value_step_dim,
+    batch * cache_value_dim.getFeatureLen() + from * cache_value_dim.width(),
+    true);
+
+  nntrainer::Tensor value_step = value.getSharedDataTensor(
+    key_step_dim, batch * value_dim.getFeatureLen(), true);
+
+  if (query.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    apply_rotary_emb_tensor_v2(value_step, b_cache_value_step, head_dim, _from,
+                               true);
+  } else if (query.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    // Copy tensor
+    int byteSize = value_dim.getDataLen() * sizeof(_FP16);
+    memcpy(b_cache_value_step.getData<_FP16>(), value_step.getData<_FP16>(),
+           byteSize);
+#else
+    NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
+#endif
+  }
+
+  ml::train::TensorDim cached_key_dim = cache_key_dim;
+  ml::train::TensorDim cached_value_dim = cache_value_dim;
+  cached_key_dim.height(to);
+  cached_value_dim.height(to);
+
+  nntrainer::Tensor b_cached_key = cache_key.getSharedDataTensor(
+    cached_key_dim, batch * cache_key_dim.getFeatureLen(), true);
+  nntrainer::Tensor b_cached_value = cache_value.getSharedDataTensor(
+    cached_value_dim, batch * cache_value_dim.getFeatureLen(), true);
+
+  nntrainer::Tensor attention_output_step = output.getSharedDataTensor(
+    output_step_dim, batch * output_dim.getFeatureLen(), true);
+
+  nntrainer::Tensor out_(1, 1,
+                         (from) ? to : ((to - from) * (to - from + 1) / 2),
+                         num_heads_Q, b_projected_query_step.getTensorType());
+
+  unsigned int gqa_size = num_heads_Q / num_heads_KV;
+
+  compute_kcaches(b_projected_query_step, b_cached_key, out_, _from, to - from,
+                  num_heads_Q, gqa_size, head_dim, pool);
+
+  softmax_triangle(out_, to - from, num_heads_Q, from, pool);
+
+  compute_fp16vcache_transposed(out_, b_cached_value, attention_output_step, to,
+                                num_heads_KV, gqa_size, head_dim,
+                                (from) ? false : true, pool);
+}
+
+/************************************************************** */
+
+/**
+ * @brief rotary embedding-related member function
+ * @note seq_len -> max_position_embeddings
+ */
+void MHACoreLayer::precompute_freqs(int head_dim, unsigned int seq_len,
+                                    float theta) {
+  // compute the freqs only when it is the first time to call this function
+  if (freqs_cos != nullptr && freqs_cos->size() == seq_len)
+    return;
+
+  // theta_i = 10000^(-2(i-1)/dim) for i = [1, 2, ... , dim/2]
+  // head_dim should be divisible by 2
+  unsigned int half_ = head_dim / 2;
+  for (unsigned int i = 0; i < half_; ++i) {
+    thetas.push_back(1.0 /
+                     (std::pow(theta, (2 * i) / static_cast<float>(head_dim))));
+  }
+
+  // cos / sin
+  auto cos = new std::vector<std::vector<float>>();
+  cos->assign(seq_len, std::vector<float>(head_dim, 0));
+  auto sin = new std::vector<std::vector<float>>();
+  sin->assign(seq_len, std::vector<float>(head_dim, 0));
+
+  // update cos / sin frequency
+  for (unsigned int i = 0; i < seq_len; ++i) {
+
+#ifdef USE_NEON
+    nntrainer::calc_trigonometric_vals_dup(
+      half_, thetas.data(), (*cos)[i].data(), (*sin)[i].data(), i);
+#else
+    for (unsigned int j = 0; j < half_; ++j) {
+      float angle = i * thetas[j];
+      (*cos)[i][j] = std::cos(angle);
+      (*cos)[i][j + half_] = std::cos(angle); // repeated 2 times
+
+      (*sin)[i][j] = std::sin(angle);
+      (*sin)[i][j + half_] = std::sin(angle); // repeated 2 times
+    }
+#endif
+  }
+  freqs_cos = cos;
+  freqs_sin = sin;
+
+#ifdef ENABLE_FP16
+  // cos / sin for FP16
+  auto cos_fp16 = new std::vector<std::vector<_FP16>>();
+  cos_fp16->assign(seq_len, std::vector<_FP16>(head_dim, 0));
+  auto sin_fp16 = new std::vector<std::vector<_FP16>>();
+  sin_fp16->assign(seq_len, std::vector<_FP16>(head_dim, 0));
+  for (unsigned int i = 0; i < seq_len; ++i) {
+    for (unsigned int j = 0; j < head_dim; ++j) {
+      (*cos_fp16)[i][j] = (_FP16)(*cos)[i][j];
+      (*sin_fp16)[i][j] = (_FP16)(*sin)[i][j];
+    }
+  }
+  freqs_cos_fp16 = cos_fp16;
+  freqs_sin_fp16 = sin_fp16;
+#endif
+};
+
+void MHACoreLayer::apply_rotary_emb_tensor_v2(nntrainer::Tensor &in,
+                                              nntrainer::Tensor &out,
+                                              unsigned int dim,
+                                              unsigned int from,
+                                              bool convert_only) {
+  unsigned int half_ = dim / 2;
+  unsigned int max_timestep =
+    std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
+
+  if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    std::vector<float> *cos_ = nullptr;
+    std::vector<float> *sin_ = nullptr;
+
+    for (unsigned int b = 0; b < in.batch(); b++) {
+      for (unsigned int c = 0; c < in.channel(); c++) {
+        for (unsigned int h = 0; h < in.height(); h++) {
+          if (from < max_timestep) {
+            cos_ = &(*freqs_cos)[from + h];
+            sin_ = &(*freqs_sin)[from + h];
+          }
+          float *in_ptr = in.getData<float>() +
+                          b * in.channel() * in.height() * in.width() +
+                          c * in.height() * in.width() + h * in.width();
+
+          if (out.getDataType() == ml::train::TensorDim::DataType::FP32) {
+
+            nntrainer::compute_rotary_emb_value(in.width(), dim, half_, in_ptr,
+                                                nullptr, cos_->data(),
+                                                sin_->data(), convert_only);
+          } else if (out.getDataType() ==
+                       ml::train::TensorDim::DataType::UINT16 ||
+                     out.getDataType() ==
+                       ml::train::TensorDim::DataType::FP16) {
+            uint16_t *out_ptr = out.getData<uint16_t>() +
+                                b * out.channel() * out.height() * out.width() +
+                                c * out.height() * out.width() +
+                                h * out.width();
+
+            nntrainer::compute_rotary_emb_value(in.width(), dim, half_, in_ptr,
+                                                out_ptr, cos_->data(),
+                                                sin_->data(), convert_only);
+          }
+        }
+      }
+    }
+  } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    std::vector<_FP16> *cos_ = nullptr;
+    std::vector<_FP16> *sin_ = nullptr;
+
+    for (unsigned int b = 0; b < in.batch(); b++) {
+      for (unsigned int c = 0; c < in.channel(); c++) {
+        for (unsigned int h = 0; h < in.height(); h++) {
+          if (from < max_timestep) {
+            cos_ = &(*freqs_cos_fp16)[from + h];
+            sin_ = &(*freqs_sin_fp16)[from + h];
+          }
+          _FP16 *in_ptr = in.getData<_FP16>() +
+                          b * in.channel() * in.height() * in.width() +
+                          c * in.height() * in.width() + h * in.width();
+          _FP16 *out_ptr = out.getData<_FP16>() +
+                           b * out.channel() * out.height() * out.width() +
+                           c * out.height() * out.width() + h * out.width();
+
+          nntrainer::compute_rotary_emb_value(in.width(), dim, half_, in_ptr,
+                                              out_ptr, cos_->data(),
+                                              sin_->data());
+        }
+      }
+    }
+#else
+    NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
+#endif
+  }
+}
+
+void MHACoreLayer::softmax_triangle(nntrainer::Tensor &qk_out, size_t row,
+                                    size_t num_head, unsigned int from,
+                                    BS::thread_pool<> &pool) {
+  if (qk_out.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    float *qk_out_ = qk_out.getData<float>();
+
+    if (from) {
+      size_t start_row = 0;
+      size_t end_row = from + 1;
+      nntrainer::softmax_row_inplace(qk_out_, start_row, end_row, num_head);
+    } else {
+      std::vector<std::future<void>> futures;
+      for (size_t i = 0; i < row; ++i) {
+        size_t start_row = (i * (i + 1)) / 2;
+        size_t end_row = ((i + 1) * (i + 2)) / 2;
+        futures.push_back(pool.submit_task([=]() {
+          nntrainer::softmax_row(qk_out_, start_row, end_row, num_head);
+        }));
+      }
+      for (auto &fut : futures) {
+        fut.get();
+      }
+    }
+  } else if (qk_out.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    _FP16 *qk_out_ = qk_out.getData<_FP16>();
+
+    if (from) {
+      size_t start_row = 0;
+      size_t end_row = from + 1;
+      nntrainer::softmax_row_inplace(qk_out_, start_row, end_row, num_head);
+    } else {
+      std::vector<std::future<void>> futures;
+      for (size_t i = 0; i < row; ++i) {
+        size_t start_row = (i * (i + 1)) / 2;
+        size_t end_row = ((i + 1) * (i + 2)) / 2;
+        futures.push_back(pool.submit_task([=]() {
+          nntrainer::softmax_row(qk_out_, start_row, end_row, num_head);
+        }));
+      }
+      for (auto &fut : futures) {
+        fut.get();
+      }
+    }
+#else
+    NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
+#endif
+  }
+}
+
+void MHACoreLayer::compute_fp16vcache_transposed(
+  nntrainer::Tensor &in, nntrainer::Tensor &vcache, nntrainer::Tensor &output,
+  int seq, int num_cache_head, int gqa_size, int head_dim, bool process_all,
+  BS::thread_pool<> &pool) {
+
+  if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    if (process_all) {
+      std::vector<std::future<void>> futures;
+      futures.reserve(seq);
+
+      for (int i = 0; i < seq; ++i) {
+        futures.push_back(pool.submit_task([=]() {
+          const float *input = in.getData<float>() +
+                               ((i * (i + 1)) / 2) * num_cache_head * gqa_size;
+          float *out = output.getData<float>() +
+                       i * (num_cache_head * gqa_size * head_dim);
+          nntrainer::compute_fp16vcache_fp32_transposed(
+            i, input, vcache.getData<uint16_t>(), out, num_cache_head, gqa_size,
+            head_dim);
+        }));
+      }
+      for (auto &fut : futures)
+        fut.get();
+    } else {
+      nntrainer::compute_fp16vcache_fp32_transposed(
+        seq - 1, in.getData<float>(), vcache.getData<uint16_t>(),
+        output.getData<float>(), num_cache_head, gqa_size, head_dim);
+    }
+  } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    if (process_all) {
+      std::vector<std::future<void>> futures;
+      futures.reserve(seq);
+
+      for (int i = 0; i < seq; ++i) {
+        futures.push_back(pool.submit_task([=]() {
+          const _FP16 *input = in.getData<_FP16>() +
+                               ((i * (i + 1)) / 2) * num_cache_head * gqa_size;
+          _FP16 *out = output.getData<_FP16>() +
+                       i * (num_cache_head * gqa_size * head_dim);
+          nntrainer::compute_fp16vcache_transposed(
+            i, input, vcache.getData<_FP16>(), out, num_cache_head, gqa_size,
+            head_dim);
+        }));
+      }
+      for (auto &fut : futures)
+        fut.get();
+    } else {
+      nntrainer::compute_fp16vcache_transposed(
+        seq - 1, in.getData<_FP16>(), vcache.getData<_FP16>(),
+        output.getData<_FP16>(), num_cache_head, gqa_size, head_dim);
+    }
+#else
+    NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
+#endif
+  }
+}
+
+void MHACoreLayer::setBatch(nntrainer::RunLayerContext &context,
+                            unsigned int batch) {
+
+  const float dropout_rate =
+    std::get<nntrainer::props::DropOutRate>(mha_core_props).get();
+  context.updateTensor(weight_idx[AttentionParams::cache_key], batch);
+  context.updateTensor(weight_idx[AttentionParams::cache_value], batch);
+  // context.updateTensor(weight_idx[AttentionParams::attention_weight], batch);
+  if (dropout_rate > epsilon) {
+    context.updateTensor(weight_idx[AttentionParams::dropout_mask], batch);
+  }
+}
+
+void MHACoreLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  unsigned int height = input_dimensions[0].height();
+  unsigned int &max_timestep =
+    std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
+  unsigned int &max_new_tokens =
+    std::get<props::MaxNewTokens>(mha_core_props).get();
+  unsigned int &max_position_embeddings =
+    std::get<props::MaxPositionEmbeddings>(mha_core_props).get();
+  max_timestep = height + max_new_tokens;
+
+  ml::train::TensorDim kv_dim = input_dimensions[0];
+  kv_dim.width(kv_dim.width() / (num_heads_Q / num_heads_KV));
+
+  ml::train::TensorDim kv_cache_dim = kv_dim;
+#ifdef ENABLE_FP16
+  kv_cache_dim.setDataType(ml::train::TensorDim::DataType::FP16);
+#else
+  kv_cache_dim.setDataType(ml::train::TensorDim::DataType::UINT16);
+#endif
+  kv_cache_dim.height(max_timestep);
+
+  precompute_freqs(head_dim, max_position_embeddings, theta);
+
+  context.updateInput(INOUT_INDEX::QUERY, input_dimensions[0]);
+  context.updateInput(INOUT_INDEX::KEY, kv_dim);
+  context.updateInput(INOUT_INDEX::VALUE, kv_dim);
+  context.updateOutput(0, input_dimensions[0]);
+
+  context.updateTensor(weight_idx[AttentionParams::cache_key], kv_cache_dim);
+  context.updateTensor(weight_idx[AttentionParams::cache_value], kv_cache_dim);
+}
+
+void MHACoreLayer::calcDerivative(nntrainer::RunLayerContext &context) {}
+
+void MHACoreLayer::calcGradient(nntrainer::RunLayerContext &context) {}
+
+void MHACoreLayer::exportTo(nntrainer::Exporter &exporter,
+                            const ml::train::ExportMethods &method) const {
+  LayerImpl::exportTo(exporter, method);
+  exporter.saveResult(mha_core_props, method, this);
+}
+
+void MHACoreLayer::setProperty(const std::vector<std::string> &values) {
+  auto remain_props = loadProperties(values, mha_core_props);
+  LayerImpl::setProperty(remain_props);
+}
+
+#ifdef PLUGGABLE
+
+nntrainer::Layer *create_mha_core_layer() {
+  auto layer = new MHACoreLayer();
+  return layer;
+}
+
+void destroy_mha_core_layer(nntrainer::Layer *layer) { delete layer; }
+
+extern "C" {
+nntrainer::LayerPluggable ml_train_layer_pluggable{create_mha_core_layer,
+                                                   destroy_mha_core_layer};
+}
+
+#endif
+
+} // namespace causallm

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   mha_core.h
+ * @date   02 September 2024
+ * @see    https://github.com/nnstreamer/nntrainer
+ *         https://arxiv.org/abs/1706.03762
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is custom_mha_core layer supports
+ *         the work of multi_head_attention.
+ * @note   Unlike custom_multi_head_attention_layer,
+ *         which works all of the attention operations
+ *         in a layer, this layer is attached after Q / K / V
+ *         fully connected layer to post-process them
+ *         including KV-Cache.
+ *         For inference, incremental_forwarding is called,
+ *         which takes inputs of seq_len = 1 via `from` / `to` param.
+ *         For training, forwarding is called,
+ *         which takes all input seqences at once.
+ */
+
+#ifndef __MHA_CORE_H__
+#define __MHA_CORE_H__
+
+#pragma once
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#else
+#define WIN_EXPORT
+#endif
+
+#include <complex>
+
+#include <acti_func.h>
+#include <bs_thread_pool_manager.hpp>
+#include <common_properties.h>
+#include <cpu_backend.h>
+#include <layer_impl.h>
+#include <limits.h>
+#include <util_simd.h>
+
+#include <utility>
+
+namespace causallm {
+
+namespace props {
+
+/**
+ * @brief NumHeads property, NumHeads is number of head in multi head attention
+ * of Q
+ */
+class NumHeads_KV : public nntrainer::PositiveIntegerProperty {
+public:
+  /**
+   * @brief Construct a new NumHeads object with default value 1
+   */
+  NumHeads_KV(unsigned int value = 1) { set(value); };
+  static constexpr const char *key =
+    "num_heads_KV";                          /**< unique key to access */
+  using prop_tag = nntrainer::uint_prop_tag; /**< property type */
+};
+
+/**
+ * @brief SlidingWindow
+ */
+class SlidingWindow : public nntrainer::Property<unsigned int> {
+public:
+  SlidingWindow(unsigned int value = UINT_MAX) { set(value); };
+  static constexpr const char *key =
+    "sliding_window";                        /**< unique key to access */
+  using prop_tag = nntrainer::uint_prop_tag; /**< property type */
+};
+
+/**
+ * @brief MaxNewTokens
+ */
+class MaxNewTokens : public nntrainer::Property<unsigned int> {
+public:
+  MaxNewTokens(unsigned int value = 1) { set(value); };
+  static constexpr const char *key =
+    "max_new_tokens";                        /**< unique key to access */
+  using prop_tag = nntrainer::uint_prop_tag; /**< property type */
+};
+
+/**
+ * @brief MaxNewTokens
+ */
+class MaxPositionEmbeddings : public nntrainer::Property<unsigned int> {
+public:
+  MaxPositionEmbeddings(unsigned int value = 40960) { set(value); };
+  static constexpr const char *key =
+    "max_position_embeddings";               /**< unique key to access */
+  using prop_tag = nntrainer::uint_prop_tag; /**< property type */
+};
+
+/**
+ * @brief RopeTheta
+ */
+class RopeTheta : public nntrainer::Property<unsigned int> {
+public:
+  RopeTheta(unsigned int value = 500000) { set(value); };
+  static constexpr const char *key = "rope_theta"; /**< unique key to access */
+  using prop_tag = nntrainer::uint_prop_tag;       /**< property type */
+};
+
+}; // namespace props
+
+/**
+ * @class MHA Core Layer
+ * @brief Part of Multi-Head-Attention Layer.
+ *        It should be attached after Q / K / V fc layers and before O fc layer.
+ *        custom_mha_core_layer computes attention, while updating KV-cache for
+ *        inference mode.
+ *
+ *    [ Q ]    [ K ]    [ V ]
+ *      |        |        |
+ *     [      mha_core      ]
+ *               |
+ *             [ O ]
+ *
+ */
+WIN_EXPORT class MHACoreLayer : public nntrainer::LayerImpl {
+public:
+  /**
+   * @brief Constructor of MhaCore Layer
+   */
+  WIN_EXPORT MHACoreLayer();
+
+  /**
+   * @brief Destructor of MhaPost Layer
+   */
+  WIN_EXPORT ~MHACoreLayer();
+
+  /**
+   *  @brief  Move constructor of CustomMultiHeadAttentionLayer.
+   *  @param[in] CustomMultiHeadAttentionLayer &&
+   */
+  WIN_EXPORT MHACoreLayer(MHACoreLayer &&rhs) noexcept = default;
+
+  /**
+   * @brief  Move assignment operator.
+   * @parma[in] rhs CustomMultiHeadAttentionLayer to be moved.
+   */
+  WIN_EXPORT MHACoreLayer &operator=(MHACoreLayer &&rhs) = default;
+
+  /**
+   * @brief Finalize funciton of MhaCore Layer
+   */
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @brief forwarding function of MhaCore Layer
+   *        Please note that forwarding function is used only for training.
+   */
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+
+  /**
+   * @copydoc Layer::incremental_forwarding
+   */
+  WIN_EXPORT void one_batch_incremental_forwarding(
+    const unsigned int batch, const unsigned int _from, const unsigned int from,
+    const unsigned int to, nntrainer::Tensor &query, nntrainer::Tensor &key,
+    nntrainer::Tensor &value, nntrainer::Tensor &output,
+    nntrainer::Tensor &cache_key, nntrainer::Tensor &cache_value,
+    ml::train::TensorDim &query_dim, ml::train::TensorDim &query_step_dim,
+    ml::train::TensorDim &key_dim, ml::train::TensorDim &value_dim,
+    ml::train::TensorDim &cache_key_dim,
+    ml::train::TensorDim &cache_key_step_dim,
+    ml::train::TensorDim &cache_value_dim,
+    ml::train::TensorDim &cache_value_step_dim,
+    ml::train::TensorDim &output_dim, ml::train::TensorDim &output_step_dim);
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::calcGradient(RunLayerContext &context)
+   */
+  WIN_EXPORT void calcGradient(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc bool supportBackwarding() const
+   * @note In current version, we do not support backwarding yet.
+   * It will be updated ASAP.
+   */
+  WIN_EXPORT bool supportBackwarding() const override { return true; };
+
+  /**
+   * @copydoc Layer::setBatch(RunLayerContext &context, unsigned int batch)
+   */
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override;
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  WIN_EXPORT const std::string getType() const override {
+    return MHACoreLayer::type;
+  };
+
+  /**
+   * @copydoc Layer::setBatch(RunLayerContext &context, unsigned int batch)
+   */
+  WIN_EXPORT void setBatch(nntrainer::RunLayerContext &context,
+                           unsigned int batch) override;
+
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  inline static const std::string type = "mha_core";
+
+private:
+  std::tuple<
+    nntrainer::props::NumHeads, props::NumHeads_KV,
+    nntrainer::props::ProjectedKeyDim, nntrainer::props::ProjectedValueDim,
+    nntrainer::props::OutputShape, nntrainer::props::DropOutRate,
+    nntrainer::props::ReturnAttentionWeight,
+    nntrainer::props::AverageAttentionWeight, nntrainer::props::MaxTimestep,
+    props::SlidingWindow, props::MaxNewTokens, props::RopeTheta,
+    props::MaxPositionEmbeddings>
+    mha_core_props; /**< mha_core layer properties */
+
+  /** softmax activation operation */
+  nntrainer::ActiFunc sm;
+
+  float epsilon;            /** to avoid overflow */
+  unsigned int cache_index; /** idx of kv cache */
+
+  /** intermal info */
+  size_t num_heads_Q;
+  size_t num_heads_KV;
+  size_t head_dim;
+  bool cache_shift;
+  float theta;
+
+  enum INOUT_INDEX {
+    /** input index */
+    QUERY = 0,
+    KEY = 1,
+    VALUE = 2,
+    MASK = 3,
+
+    /** output index */
+    OUTPUT = 0,
+    RETURN_ATTENTION_WEIGHT = 1,
+  };
+
+  /**< indices of the weights and tensors */
+  enum AttentionParams {
+    cache_key,
+    cache_value,
+    projected_key,
+    projected_value,
+    /** intended comment for later use of attention_mask */
+    // attention_mask,
+    attention_weight,
+    dropout_mask,
+    attention_output,
+  };
+  std::array<unsigned int, 7> weight_idx;
+
+  /****************** ROTARY EMBEDDING *****************/
+  /** static variable - they are all expected to be initialized once */
+  inline static std::vector<std::vector<float>> *freqs_cos = {};
+  inline static std::vector<std::vector<float>> *freqs_sin = {};
+  inline static std::vector<float> thetas;
+#ifdef ENABLE_FP16
+  inline static std::vector<std::vector<_FP16>> *freqs_cos_fp16 = {};
+  inline static std::vector<std::vector<_FP16>> *freqs_sin_fp16 = {};
+#endif
+
+  /**
+   * @brief pre_compute frequencies for Rotary Embedding.
+   * @note it is expected to be called only once at the finalize.
+   * @param[in] head_dim dimension of head
+   * @param[in] seq_len sequence length
+   * @param[in] theta base of theta (default = 10000)
+   */
+  void precompute_freqs(int head_dim, unsigned int seq_len,
+                        float theta = 10000.0);
+
+  /**
+   * @brief     apply rotary embedding
+   * @param[in] in input tensor
+   * @param[out] out output tensor
+   * @param[in] dim hidden dim size
+   * @param[in] from sequence order
+   * @param[in] convert_only - conversion only
+   */
+  void apply_rotary_emb_tensor_v2(nntrainer::Tensor &in, nntrainer::Tensor &out,
+                                  unsigned int dim, unsigned int from,
+                                  bool convert_only = false);
+
+  template <typename BType>
+  void compute(const float *A, const BType *B, float *output, int num_rows,
+               int N, int chunk_size, int group_size, int tile_size,
+               bool process_all);
+
+  void compute_kcaches(nntrainer::Tensor &in, nntrainer::Tensor &cache,
+                       nntrainer::Tensor &out, unsigned int from,
+                       size_t sequence_len, unsigned int num_heads,
+                       unsigned int group_size, unsigned int head_dim,
+                       BS::thread_pool<> &pool);
+
+  void softmax_triangle(nntrainer::Tensor &qk_out, size_t row, size_t num_heads,
+                        unsigned int from, BS::thread_pool<> &pool);
+
+  void compute_vcaches(nntrainer::Tensor &in, nntrainer::Tensor &vcache,
+                       nntrainer::Tensor &out, unsigned int from,
+                       size_t sequence_len, unsigned int num_heads,
+                       unsigned int group_size, unsigned int head_dim);
+
+  void compute_fp16vcache_transposed(nntrainer::Tensor &in,
+                                     nntrainer::Tensor &vcache,
+                                     nntrainer::Tensor &output, int seq,
+                                     int num_cache_head, int gqa_size,
+                                     int head_dim, bool process_all,
+                                     BS::thread_pool<> &pool);
+
+  /************** END OF  ROTARY EMBEDDING *************/
+
+  /**
+   * @brief calculate common derivative
+   * @param context Context of the layer
+   */
+  void calcCommonDerivative(nntrainer::RunLayerContext &context);
+
+}; // end of class MHACoreLayer
+} // end of namespace causallm
+
+#endif

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -3,10 +3,12 @@
  * Copyright (C) 2025 Jijoong Moon <jijoong.moon@samsung.com>
  *
  * @file   mha_core.h
- * @date   02 September 2024
+ * @date   11 July 2025
  * @see    https://github.com/nnstreamer/nntrainer
  *         https://arxiv.org/abs/1706.03762
  * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Maciej Nalewaj <m.nalewaj@samsung.com>
+ * @author Eunju Yang <ej.yang@samsung.com>
  * @bug    No known bugs except for NYI items
  * @brief  This is custom_mha_core layer supports
  *         the work of multi_head_attention.
@@ -137,7 +139,8 @@ public:
    *  @brief  Move constructor of CustomMultiHeadAttentionLayer.
    *  @param[in] CustomMultiHeadAttentionLayer &&
    */
-  WIN_EXPORT MHACoreLayer(MHACoreLayer &&rhs) noexcept = default;
+  WIN_EXPORT
+  MHACoreLayer(MHACoreLayer &&rhs) noexcept = default;
 
   /**
    * @brief  Move assignment operator.
@@ -158,20 +161,17 @@ public:
                              bool training) override;
 
   /**
-   * @copydoc Layer::incremental_forwarding
+   * @brief incremental forwarding for one batch
    */
-  WIN_EXPORT void one_batch_incremental_forwarding(
+  void one_batch_incremental_forwarding(
     const unsigned int batch, const unsigned int _from, const unsigned int from,
-    const unsigned int to, nntrainer::Tensor &query, nntrainer::Tensor &key,
-    nntrainer::Tensor &value, nntrainer::Tensor &output,
-    nntrainer::Tensor &cache_key, nntrainer::Tensor &cache_value,
-    ml::train::TensorDim &query_dim, ml::train::TensorDim &query_step_dim,
-    ml::train::TensorDim &key_dim, ml::train::TensorDim &value_dim,
-    ml::train::TensorDim &cache_key_dim,
+    const unsigned int to, nntrainer::Tensor &query_step,
+    nntrainer::Tensor &key_step, nntrainer::Tensor &value_step,
+    nntrainer::Tensor &attention_output_step, nntrainer::Tensor &cache_key,
+    nntrainer::Tensor &cache_value, ml::train::TensorDim &cache_key_dim,
     ml::train::TensorDim &cache_key_step_dim,
     ml::train::TensorDim &cache_value_dim,
-    ml::train::TensorDim &cache_value_step_dim,
-    ml::train::TensorDim &output_dim, ml::train::TensorDim &output_step_dim);
+    ml::train::TensorDim &cache_value_step_dim);
 
   /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
@@ -345,6 +345,6 @@ private:
   void calcCommonDerivative(nntrainer::RunLayerContext &context);
 
 }; // end of class MHACoreLayer
-} // end of namespace causallm
+} // namespace causallm
 
 #endif

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -435,11 +435,13 @@ void compute_kcaches(const _FP16 *A, const _FP16 *B, _FP16 *output,
  * @param[in] dim unit length of simd computation
  * @param[in] half_ criterion for rotational direction of embedding
  * @param[in/out] inout _FP16* used also as output
+ * @param[out] output _FP16* output, if it is equal nullptr then inout is used
+ * as output
  * @param[in] cos_ _FP16* input con values
  * @param[in] sin_ _FP16* input sin values
  */
 void compute_rotary_emb_value(unsigned int width, unsigned int dim,
-                              unsigned int half_, _FP16 *inout,
+                              unsigned int half_, _FP16 *inout, _FP16 *output,
                               const _FP16 *cos_, const _FP16 *sin_);
 #endif
 /**

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend_fp16.cpp
@@ -425,8 +425,8 @@ void compute_kcaches(const _FP16 *A, const _FP16 *B, _FP16 *output,
 }
 
 void compute_rotary_emb_value(unsigned int width, unsigned int dim,
-                              unsigned int half_, _FP16 *inout,
+                              unsigned int half_, _FP16 *inout, _FP16 *output,
                               const _FP16 *cos_, const _FP16 *sin_) {
-  neon::compute_rotary_emb_value(width, dim, half_, inout, cos_, sin_);
+  neon::compute_rotary_emb_value(width, dim, half_, inout, output, cos_, sin_);
 }
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl.h
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl.h
@@ -393,11 +393,13 @@ void compute_kcaches(const __fp16 *A, const __fp16 *B, __fp16 *output,
  * @param[in] dim unit length of simd computation
  * @param[in] half_ criterion for rotational direction of embedding
  * @param[in/out] inout __fp16* used also as output
+ * @param[out] output _FP16* output, if it is equal nullptr then inout is used
+ * as output
  * @param[in] cos_ __fp16* input con values
  * @param[in] sin_ __fp16* input sin values
  */
 void compute_rotary_emb_value(unsigned int width, unsigned int dim,
-                              unsigned int half_, __fp16 *inout,
+                              unsigned int half_, __fp16 *inout, __fp16 *output,
                               const __fp16 *cos_, const __fp16 *sin_);
 
 #endif

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -407,6 +407,54 @@ extern void inv_sqrt_inplace(const unsigned int N, _FP16 *X);
 extern void transpose_matrix(const unsigned int M, const unsigned int N,
                              const _FP16 *src, unsigned int ld_src, _FP16 *dst,
                              unsigned int ld_dst);
+
+/**
+ * @brief Compute vcache for one row transposed
+ * @param[in] row_num row number
+ * @param[in] in _FP16* input vector
+ * @param[in] vcache _FP16* input vector
+ * @param[out] output _FP16* output vector
+ * @param[in] num_cache_head number head of cache
+ * @param[in] gqa_size size of group
+ * @param[in] head_dim head dimension
+ */
+extern void compute_fp16vcache_transposed(int row_num, const _FP16 *in,
+                                          const _FP16 *vcache, _FP16 *output,
+                                          int num_cache_head, int gqa_size,
+                                          int head_dim);
+
+/**
+ * @brief Compute kcaches
+ * @tparam BType type of B vector element
+ * @param[in] A float* input vector A
+ * @param[in] B BType* input vector B
+ * @param[out] output float* output float vector
+ * @param[in] num_rows number of row
+ * @param[in] N number of chunk
+ * @param[in] chunk_size size of chunk
+ * @param[in] group_size size of group
+ * @param[in] tile_size size of tile
+ */
+extern void compute_kcaches(const _FP16 *A, const _FP16 *B, _FP16 *output,
+                            int num_rows, int N, int chunk_size, int group_size,
+                            int tile_size);
+
+/**
+ * @brief Compute rotary embedding value
+ * @param[in] width current w value from b, c, h, w
+ * @param[in] dim unit length of simd computation
+ * @param[in] half_ criterion for rotational direction of embedding
+ * @param[in/out] inout __fp16* used also as output
+ * @param[out] output _FP16* output, if it is equal nullptr then inout is used
+ * as output
+ * @param[in] cos_ __fp16* input con values
+ * @param[in] sin_ __fp16* input sin values
+ */
+extern void compute_rotary_emb_value(unsigned int width, unsigned int dim,
+                                     unsigned int half_, _FP16 *inout,
+                                     _FP16 *output, const _FP16 *cos_,
+                                     const _FP16 *sin_);
+
 #endif
 /**
  * @brief Initialization of ggml backend

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -1020,7 +1020,7 @@ TEST(nntrainer_cpu_backend_standalone, compute_kcaches_fp16) {
   }
 }
 
-TEST(nntrainer_cpu_backend_standalone, compute_rotary_emb_value_fp16) {
+TEST(nntrainer_cpu_backend_standalone, compute_rotary_emb_value_out_null_fp16) {
   unsigned int width = 40;
   unsigned int dim = 20;
   unsigned int half_ = 10;
@@ -1046,11 +1046,46 @@ TEST(nntrainer_cpu_backend_standalone, compute_rotary_emb_value_fp16) {
     0.205859,  0.266457,  -0.454117, 0.581280,  0.181472,  0.204634,  -0.646542,
     0.020328,  0.556058,  1.354487,  -0.087349, -0.396113};
 
-  nntrainer::compute_rotary_emb_value(width, dim, half_, inout.data(),
+  nntrainer::compute_rotary_emb_value(width, dim, half_, inout.data(), nullptr,
                                       cos_.data(), sin_.data());
 
   for (size_t i = 0; i < inout.size(); i++) {
     EXPECT_NEAR(ref_out[i], inout[i], 0.001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, compute_rotary_emb_value_fp16) {
+  unsigned int width = 40;
+  unsigned int dim = 20;
+  unsigned int half_ = 10;
+
+  std::vector<__fp16> inout = {
+    -0.250920, 0.593086,  0.901429,  -0.633130, 0.463988,  0.559382,  0.197317,
+    0.193700,  -0.687963, -0.108334, -0.688011, -0.800050, -0.883833, -0.081502,
+    0.732352,  -0.332583, 0.202230,  -0.714266, 0.416145,  0.301777,  -0.958831,
+    -0.887177, 0.939820,  0.443998,  0.664885,  0.877105,  -0.575322, -0.998442,
+    -0.636350, 0.984423,  -0.633191, 0.234963,  -0.391515, 0.223306,  0.049513,
+    -0.985867, -0.136110, -0.953875, -0.417542, 0.049549};
+  std::vector<__fp16> cos_ = {-0.508061, 0.998221,  -0.733869, 0.164825,
+                              0.297530,  -0.591437, -0.165907, -0.999895,
+                              -0.163179, 0.249787};
+  std::vector<__fp16> sin_ = {0.809128,  -0.390829, -0.112627, 0.377992,
+                              -0.994569, -0.641599, -0.927266, -0.401338,
+                              0.244335,  -0.414953};
+  std::vector<__fp16> ref_out = {
+    0.684172,  0.279348,  -0.761074, -0.073549, 0.866425,  -0.544224, 0.154785,
+    -0.480342, 0.010582,  0.098163,  0.146526,  -1.030422, 0.547092,  -0.252752,
+    -0.243571, -0.162197, -0.216517, 0.636452,  -0.236000, 0.120334,  0.999478,
+    -0.793769, -0.733800, -0.011226, 0.247067,  -1.151284, -0.030760, 0.615511,
+    0.205859,  0.266457,  -0.454117, 0.581280,  0.181472,  0.204634,  -0.646542,
+    0.020328,  0.556058,  1.354487,  -0.087349, -0.396113};
+  std::vector<__fp16> output(width);
+
+  nntrainer::compute_rotary_emb_value(width, dim, half_, inout.data(),
+                                      output.data(), cos_.data(), sin_.data());
+
+  for (size_t i = 0; i < output.size(); i++) {
+    EXPECT_NEAR(ref_out[i], output[i], 0.001f);
   }
 }
 


### PR DESCRIPTION
## Dependency of the PR
#3419 

## Commits to be reviewed in this PR


<details><summary>[MHAcore] Update mha layer (use FP16 for FP32-act)</summary><br />

- This patch update mha layer to use FP16 for FP32 activation
- This can much improve llm speed on Android
**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

### Summary

- This PR enables FP16 computation even with FP32 activation (for Android).
- This PR improves llm performance on Android:

|      | PF | TG |
|:---:|:---:|:---:|
| Before | 230 | 40 |
| After | 310 | 58 |

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
