### PR TITLE
[OpenCL] Asynchronous Execution and Out-of-Order Queue Support

### DIFF
--- a/nntrainer/cl_buffer_manager.cpp
+++ b/nntrainer/cl_buffer_manager.cpp
@@ -27,8 +27,10 @@ void ClBufferManager::initBuffers() {
   outBufferB = new opencl::Buffer(context_inst_, unused_buffer_bytes, false);
 
   data_input = context_inst_.createSVMRegion(buffer_size_bytes);
-  data_scale = context_inst_.createSVMRegion(scale_q4_0_size);
-  data_quant = context_inst_.createSVMRegion(quant_q4_0_size);
+  for (unsigned int i = 0; i < max_qs; ++i) {
+    scale_vec.push_back(context_inst_.createSVMRegion(scale_q4_0_size));
+    quant_vec.push_back(context_inst_.createSVMRegion(quant_q4_0_size));
+  }
 
   ml_logi("ClBufferManager: Buffers & images initialized");
 }
@@ -41,8 +43,10 @@ ClBufferManager::~ClBufferManager() {
   delete outBufferB;
 
   context_inst_.releaseSVMRegion(data_input);
-  context_inst_.releaseSVMRegion(data_scale);
-  context_inst_.releaseSVMRegion(data_quant);
+  for (unsigned int i = 0; i < max_qs; ++i) {
+    context_inst_.releaseSVMRegion(scale_vec[i]);
+    context_inst_.releaseSVMRegion(quant_vec[i]);
+  }
 
   ml_logi("ClBufferManager: Buffers destroyed");
 }

--- a/nntrainer/cl_buffer_manager.h
+++ b/nntrainer/cl_buffer_manager.h
@@ -43,6 +43,7 @@ private:
    */
   const size_t buffer_size_bytes = 1024 * 8192 * sizeof(float);
   const size_t unused_buffer_bytes = sizeof(float);
+  const unsigned int max_qs = 3;
 
   /// @note this size might be changed
   const size_t scale_q4_0_size =
@@ -57,8 +58,8 @@ private:
   opencl::Buffer *outBufferB = nullptr;
 
   void *data_input = nullptr;
-  void *data_scale = nullptr;
-  void *data_quant = nullptr;
+  std::vector<void *> scale_vec;
+  std::vector<void *> quant_vec;
 
 public:
   /**
@@ -104,12 +105,22 @@ public:
   /**
    * @brief Get the SVM pointer to data_input
    */
-  void *getSVMScale() { return data_scale; }
+  void *getSVMScale(unsigned int idx = 0) {
+    if (idx >= scale_vec.size())
+      return nullptr;
+
+    return scale_vec[idx];
+  }
 
   /**
    * @brief Get the SVM pointer to data_input
    */
-  void *getSVMQuant() { return data_quant; }
+  void *getSVMQuant(unsigned int idx = 0) {
+    if (idx >= quant_vec.size())
+      return nullptr;
+
+    return quant_vec[idx];
+  }
 
   /**
    * @brief Destroy Buffer pointers.

--- a/nntrainer/opencl/opencl_command_queue_manager.cpp
+++ b/nntrainer/opencl/opencl_command_queue_manager.cpp
@@ -43,7 +43,8 @@ bool CommandQueueManager::CreateCommandQueue() {
   cl_device_id device_id = context_instance.GetDeviceId();
 
   // returns NULL with error code if fails
-  command_queue_ = clCreateCommandQueue(context, device_id, 0, &error_code);
+  command_queue_ = clCreateCommandQueue(
+    context, device_id, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, &error_code);
   if (!command_queue_) {
     ml_loge("Failed to create a command queue. OpenCL error code: %d : ",
             error_code, OpenCLErrorCodeToString(error_code));

--- a/nntrainer/tensor/cl_operations/blas_kernels.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels.h
@@ -24,6 +24,10 @@
 
 namespace nntrainer {
 
+void gemm_q4_0_async_cl(std::vector<void *> matAdata, float *matBdata,
+                        std::vector<float *> matCdata, unsigned int M,
+                        std::vector<unsigned int> N, unsigned int K);
+
 /**
  * @brief     Q4_0 gemm computation : C = A*B
  * @param[in] matAdata void * for Matrix A

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -730,13 +730,21 @@ void FloatTensor::dot(std::vector<Tensor *> input, std::vector<Tensor *> output,
     if (M == 1) {
       gemm_q4_0(M, N, K, data, K, (void *)mdata, N, rdata, N);
     } else {
-      gemm_q4_0_cl((void *)mdata, data, rdata, M, N, K);
+      Ns.push_back(N);
+      mdatas.push_back(mdata);
+      rdatas.push_back(rdata);
     }
 #else
     /// @todo Support multi-weight q4_0 for x64
     gemm_q4_0(M, N, K, data, K, (void *)mdata, N, rdata, N);
 #endif
   }
+
+#ifdef ENABLE_OPENCL
+  if (M != 1) {
+    gemm_q4_0_async_cl(mdatas, data, rdatas, M, Ns, K);
+  }
+#endif
 }
 
 Tensor &FloatTensor::dotFloat(Tensor const &input, Tensor &output, bool trans,


### PR DESCRIPTION
This pull request introduces support for asynchronous execution of the Q4_0 GEMM kernel.
The main change involves configuring the OpenCL command queue to operate in an out-of-order mode.
Additionally, the CL buffer manager class has been updated to include a vector for scales and quantization parameters, which are reserved for asynchronous kernel launches.
