### PR TITLE
Cache built kernel binaries and load them on subsequent runs

### DIFF
--- a/nntrainer/opencl/opencl_program.cpp
+++ b/nntrainer/opencl/opencl_program.cpp
@@ -14,7 +14,6 @@
 #include "opencl_program.h"
 
 #include <cstring>
-#include <fstream>
 #include <string>
 #include <vector>
 
@@ -52,120 +51,44 @@ bool Program::BuildProgram(cl_device_id device_id,
     return false;
   }
 
-  // saving kernel binary
-  /// @note: Temporary disabled due to failing
-  // if (!binaryCreated)
-  //   return GetProgramInfo(device_id);
-
   return true;
 }
 
 /**
- * @brief Utility to get program info and save kernel binaries
+ * @brief Utility to get program binary
  *
  * @param device_id OpenCL device id
- * @return true if successful or false otherwise
+ * @return vector of bytes if successful, empty if there was an error
  */
-bool Program::GetProgramInfo(cl_device_id device_id) {
-  // since only one GPU is being used
-  unsigned int num_devices = 1;
-
+std::vector<std::byte> Program::GetProgramBinary(cl_device_id device_id) {
   cl_int error_code = CL_SUCCESS;
 
-  // Read the binary size
-  std::vector<size_t> binaries_size(num_devices);
+  size_t binary_size;
   error_code = clGetProgramInfo(program_, CL_PROGRAM_BINARY_SIZES,
-                                sizeof(size_t) * num_devices,
-                                binaries_size.data(), nullptr);
+                                sizeof(size_t), &binary_size, nullptr);
 
   if (error_code != CL_SUCCESS) {
     ml_loge("Failed to get program binary size. OpenCL error code: %d : %s. %s",
             error_code, OpenCLErrorCodeToString(error_code),
             (GetProgramBuildInfo(device_id, CL_PROGRAM_BUILD_LOG)).c_str());
-    return false;
-  }
-
-  // Read the kernel name size
-  size_t kernel_names_size;
-  error_code = clGetProgramInfo(program_, CL_PROGRAM_KERNEL_NAMES, 0, nullptr,
-                                &kernel_names_size);
-
-  if (error_code != CL_SUCCESS) {
-    ml_loge(
-      "Failed to get program kernel name size. OpenCL error code: %d : %s. %s",
-      error_code, OpenCLErrorCodeToString(error_code),
-      (GetProgramBuildInfo(device_id, CL_PROGRAM_BUILD_LOG)).c_str());
-    return false;
-  }
-
-  // getting the kernel names
-  std::vector<char> kernel_names(kernel_names_size);
-  error_code =
-    clGetProgramInfo(program_, CL_PROGRAM_KERNEL_NAMES, kernel_names_size,
-                     kernel_names.data(), nullptr);
-
-  if (error_code != CL_SUCCESS) {
-    ml_loge(
-      "Failed to get program kernel names. OpenCL error code: %d : %s. %s",
-      error_code, OpenCLErrorCodeToString(error_code),
-      (GetProgramBuildInfo(device_id, CL_PROGRAM_BUILD_LOG)).c_str());
-    return false;
-  } else {
-    ml_logi("Saving kernel binary for: %s",
-            std::string(kernel_names.data()).c_str());
+    return {};
   }
 
   // Read the binary
-  size_t binaries_ptr_alloc_size = sizeof(unsigned char *) * num_devices;
-  std::vector<unsigned char *> binaries_ptr(num_devices);
-
-  for (unsigned int i = 0; i < num_devices; ++i) {
-    binaries_ptr[i] = new unsigned char[binaries_size[i]];
-  }
-
-  error_code =
-    clGetProgramInfo(program_, CL_PROGRAM_BINARIES, binaries_ptr_alloc_size,
-                     binaries_ptr.data(), nullptr);
+  std::vector<std::byte> binary(binary_size);
+  std::byte *binary_data = binary.data();
+  error_code = clGetProgramInfo(program_, CL_PROGRAM_BINARIES,
+                                sizeof(&binary_data), &binary_data, nullptr);
 
   if (error_code != CL_SUCCESS) {
     ml_loge("Failed to get program binary data. OpenCL error code: %d : %s. %s",
             error_code, OpenCLErrorCodeToString(error_code),
             (GetProgramBuildInfo(device_id, CL_PROGRAM_BUILD_LOG)).c_str());
 
-    // cleanup
-    for (unsigned int i = 0; i < num_devices; ++i) {
-      delete[] binaries_ptr[i];
-    }
-    return false;
+    return {};
   }
 
-  // Write the binary to file
-  // All kernels in the program will be saved in the binary file
-  for (unsigned int i = 0; i < num_devices; ++i) {
-    std::ofstream fs(Program::DEFAULT_KERNEL_PATH + "/" +
-                       std::string(kernel_names.data()) + "_kernel.bin",
-                     std::ios::out | std::ios::binary | std::ios::app);
-    if (!fs) {
-      ml_loge(
-        "opencl_program: could not find directory to save kernel binary - %s",
-        Program::DEFAULT_KERNEL_PATH.c_str());
-
-      // cleanup
-      for (unsigned int i = 0; i < num_devices; ++i) {
-        delete[] binaries_ptr[i];
-      }
-      return false;
-    }
-    fs.write((char *)binaries_ptr[i], binaries_size[i]);
-    fs.close();
-  }
-
-  // cleanup
-  for (unsigned int i = 0; i < num_devices; ++i) {
-    delete[] binaries_ptr[i];
-  }
-
-  return true;
+  return binary;
 }
 
 /**
@@ -200,6 +123,11 @@ std::string Program::GetProgramBuildInfo(cl_device_id device_id,
   return result;
 }
 
+std::string Program::GetDefaultCompilerOptions() const {
+  return "-cl-std=CL3.0 -cl-mad-enable -cl-unsafe-math-optimizations "
+         "-cl-finite-math-only -cl-fast-relaxed-math ";
+}
+
 /**
  * @brief Create OpenCL program from source
  *
@@ -226,10 +154,8 @@ bool Program::CreateCLProgram(const cl_context &context,
   }
 
   // building the created program
-  return BuildProgram(
-    device_id, compiler_options +
-                 "-cl-std=CL3.0 -cl-mad-enable -cl-unsafe-math-optimizations "
-                 "-cl-finite-math-only -cl-fast-relaxed-math");
+  return BuildProgram(device_id,
+                      GetDefaultCompilerOptions() + compiler_options);
 }
 
 /**
@@ -245,26 +171,35 @@ bool Program::CreateCLProgram(const cl_context &context,
  */
 bool Program::CreateCLProgramWithBinary(const cl_context &context,
                                         const cl_device_id &device_id,
-                                        size_t size, unsigned char *binary,
+                                        const std::vector<std::byte> &binary,
                                         std::string binary_name,
                                         const std::string &compiler_options) {
 
   int error_code;
-  const cl_device_id device_list[] = {device_id};
-  const size_t lengths[] = {size};
-  const unsigned char *binaries[] = {binary};
+  int binary_status;
+  const size_t size = binary.size();
+  const unsigned char *binary_data =
+    reinterpret_cast<const unsigned char *>(binary.data());
 
-  program_ = clCreateProgramWithBinary(context, 1, device_list, lengths,
-                                       binaries, NULL, &error_code);
+  program_ = clCreateProgramWithBinary(
+    context, 1, &device_id, &size, &binary_data, &binary_status, &error_code);
   if (!program_ || error_code != CL_SUCCESS) {
-    ml_loge("Failed to create compute program. OpenCL error code: %d : %s",
-            error_code, OpenCLErrorCodeToString(error_code));
+    ml_loge("Failed to create compute program. OpenCL error code: %d : %s, "
+            "binary status: %d : %s",
+            error_code, OpenCLErrorCodeToString(error_code), binary_status,
+            OpenCLErrorCodeToString(binary_status));
     return false;
   }
 
   ml_logi("Loaded program from binary for: %s", binary_name.c_str());
 
   return BuildProgram(device_id, compiler_options, true);
+}
+
+std::size_t Program::GetKernelHash(const std::string &code,
+                                   const std::string &compiler_options) {
+  return std::hash<std::string>{}(GetDefaultCompilerOptions() +
+                                  compiler_options + code);
 }
 
 /**

--- a/nntrainer/opencl/opencl_program.h
+++ b/nntrainer/opencl/opencl_program.h
@@ -15,6 +15,7 @@
 #define __OPENCL_PROGRAM_H__
 
 #include <string>
+#include <vector>
 
 #include "CL/cl.h"
 
@@ -40,14 +41,6 @@ class Program {
                     bool binaryCreated = false);
 
   /**
-   * @brief Utility to get program info and save kernel binaries
-   *
-   * @param device_id OpenCL device id
-   * @return true if successful or false otherwise
-   */
-  bool GetProgramInfo(cl_device_id device_id);
-
-  /**
    * @brief Get the information on the program build
    *
    * @param device_id OpenCL device id
@@ -56,6 +49,14 @@ class Program {
    */
   std::string GetProgramBuildInfo(cl_device_id device_id,
                                   cl_program_build_info info);
+
+  /**
+   * @brief Get default compiler options for the kernel - setting CL version and
+   * optimizations
+   *
+   * @return Default compiler options, blank space at the end
+   */
+  std::string GetDefaultCompilerOptions() const;
 
 public:
   static const std::string DEFAULT_KERNEL_PATH;
@@ -85,9 +86,28 @@ public:
    * @return true if successful or false otherwise
    */
   bool CreateCLProgramWithBinary(const cl_context &context,
-                                 const cl_device_id &device_id, size_t size,
-                                 unsigned char *binary, std::string binary_name,
+                                 const cl_device_id &device_id,
+                                 const std::vector<std::byte> &binary,
+                                 std::string binary_name,
                                  const std::string &compiler_options);
+
+  /**
+   * @brief Utility to get program binary
+   *
+   * @param device_id OpenCL device id
+   * @return vector of bytes if successful, empty if there was an error
+   */
+  std::vector<std::byte> GetProgramBinary(cl_device_id device_id);
+
+  /**
+   * @brief Calculate te hash of given kernel source given compiler options
+   *
+   * @param code kernel source code string
+   * @param compiler_options string compiler options
+   * @return hash of the code
+   */
+  std::size_t GetKernelHash(const std::string &code,
+                            const std::string &compiler_options);
 
   /**
    * @brief Get the Program object


### PR DESCRIPTION
Closes #3427 

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped

## Dependency of the PR
None
### Summary

- When building a kernel, a hash will be taken of the kernel code and build options. Hash will be the binary's filename
- Upon context initialization, the program will look for a binary. If it is found, binary will be used to create program.
- This change should be immune to changes in code and command line options. Not to driver and device version for now.

A quick tests I did showed the time to complete `nntrainer:unittests / unittest_blas_kernels_cl` reduced from 6.5 seconds without cache to 0.17 seconds with cache (for me this test fails after first test case but context initializes correctly).

Signed-off-by: Piotr Pokorski p.pokorski@samsung.com
