### PR TITLE
Remove duplicated std::endl while printing device info

### DIFF
--- a/nntrainer/opencl/opencl_context_manager.cpp
+++ b/nntrainer/opencl/opencl_context_manager.cpp
@@ -235,7 +235,7 @@ bool ContextManager::CreateDefaultGPUDevice() {
   }
 
   // Raport device name
-  ml_logi("Using device\n%s", device_info_->getDeviceName().data());
+  ml_logi("Using device %s", device_info_->getDeviceName().data());
   device_info_->print();
 
   return true;

--- a/nntrainer/opencl/opencl_device_info.cpp
+++ b/nntrainer/opencl/opencl_device_info.cpp
@@ -185,28 +185,26 @@ void DeviceInfo::print() const {
       oss << "UNKNOWN";
       break;
     }
-    oss << std::endl;
     ml_logi("%s", oss.str().data());
   }
 
   {
     std::ostringstream oss;
     oss << "    CL_DEVICE_VENDOR_ID: " << std::hex << "0x"
-        << getDeviceVendorId() << std::endl;
+        << getDeviceVendorId();
     ml_logi("%s", oss.str().data());
   }
 
   {
     std::ostringstream oss;
-    oss << "    CL_DEVICE_MAX_COMPUTE_UNITS: " << getDeviceMaxComputeUnits()
-        << std::endl;
+    oss << "    CL_DEVICE_MAX_COMPUTE_UNITS: " << getDeviceMaxComputeUnits();
     ml_logi("%s", oss.str().data());
   }
 
   {
     std::ostringstream oss;
     oss << "    CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS: "
-        << getDeviceMaxWorkItemDimensions() << std::endl;
+        << getDeviceMaxWorkItemDimensions();
     ml_logi("%s", oss.str().data());
   }
 
@@ -216,45 +214,42 @@ void DeviceInfo::print() const {
     for (auto size : getDeviceMaxWorkItemSizes()) {
       oss << " " << size;
     }
-    oss << std::endl;
     ml_logi("%s", oss.str().data());
   }
 
   {
     std::ostringstream oss;
-    oss << "    CL_DEVICE_MAX_WORK_GROUP_SIZE: " << getDeviceMaxWorkGroupSize()
-        << std::endl;
+    oss << "    CL_DEVICE_MAX_WORK_GROUP_SIZE: " << getDeviceMaxWorkGroupSize();
     ml_logi("%s", oss.str().data());
   }
 
   {
     std::ostringstream oss;
-    oss << "    CL_DEVICE_MAX_MEM_ALLOC_SIZE: " << getDeviceMaxMemAllocSize()
-        << std::endl;
+    oss << "    CL_DEVICE_MAX_MEM_ALLOC_SIZE: " << getDeviceMaxMemAllocSize();
     ml_logi("%s", oss.str().data());
   }
 
   {
     std::ostringstream oss;
-    oss << "    CL_DEVICE_NAME: " << getDeviceName() << std::endl;
+    oss << "    CL_DEVICE_NAME: " << getDeviceName();
     ml_logi("%s", oss.str().data());
   }
 
   {
     std::ostringstream oss;
-    oss << "    CL_DEVICE_VENDOR: " << getDeviceVendor() << std::endl;
+    oss << "    CL_DEVICE_VENDOR: " << getDeviceVendor();
     ml_logi("%s", oss.str().data());
   }
 
   {
     std::ostringstream oss;
-    oss << "    CL_DRIVER_VERSION: " << getDriverVersion() << std::endl;
+    oss << "    CL_DRIVER_VERSION: " << getDriverVersion();
     ml_logi("%s", oss.str().data());
   }
 
   {
     std::ostringstream oss;
-    oss << "    CL_DEVICE_EXTENSIONS: " << getDeviceExtensions() << std::endl;
+    oss << "    CL_DEVICE_EXTENSIONS: " << getDeviceExtensions();
     ml_logi("%s", oss.str().data());
   }
 
@@ -273,7 +268,6 @@ void DeviceInfo::print() const {
     if (getDeviceSVMCapabilities() & CL_DEVICE_SVM_ATOMICS) {
       oss << "CL_DEVICE_SVM_ATOMICS ";
     }
-    oss << std::endl;
     ml_logi("%s", oss.str().data());
   }
 }


### PR DESCRIPTION
ml_log... inserts newline at the end of each message - no need to pass string with enline / \n as it causes dplicated newlines and unreadable logs

Old log:
``` bash
[NNTRAINER WARN  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/app_context.cpp:add_extension_object:424) tried to register extension from /usr/local/lib/x86_64-linux-gnu/nntrainer/layers but failed, reason: Tensor::divide() is currently not supported in tensor data type UINT4
[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_context_manager.cpp:CreateDefaultGPUDevice:128) Collecting OpenCL platforms ...
[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_context_manager.cpp:CreateDefaultGPUDevice:151) Collecting OpenCL devices for platform 0 / 1 ...
[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_context_manager.cpp:CreateDefaultGPUDevice:182) Looking for suitable OpenCL platform and device ...
[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_context_manager.cpp:CreateDefaultGPUDevice:238) Using device
Intel(R) Graphics [0x46a6]
[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:163) Device info:
[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:189)     CL_DEVICE_TYPE: CL_DEVICE_TYPE_GPU

[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:196)     CL_DEVICE_VENDOR_ID: 0x8086

[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:203)     CL_DEVICE_MAX_COMPUTE_UNITS: 96

[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:210)     CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS: 3

[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:220)     CL_DEVICE_MAX_WORK_ITEM_SIZES: 512 512 512

[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:227)     CL_DEVICE_MAX_WORK_GROUP_SIZE: 512

[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:234)     CL_DEVICE_MAX_MEM_ALLOC_SIZE: 1073741824

[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:240)     CL_DEVICE_NAME: Intel(R) Graphics [0x46a6]
[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:246)     CL_DEVICE_VENDOR: Intel(R) Corporation
[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:252)     CL_DRIVER_VERSION: 25.18.33578
[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:258)     CL_DEVICE_EXTENSIONS: cl_khr_byte_addressable_store cl_khr_device_uuid cl_khr_fp16 cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_icd cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_intel_command_queue_families cl_intel_subgroups cl_intel_required_subgroup_size cl_intel_subgroups_short cl_khr_spir cl_intel_accelerator cl_intel_driver_diagnostics cl_khr_priority_hints cl_khr_throttle_hints cl_khr_create_command_queue cl_intel_subgroups_char cl_intel_subgroups_long cl_khr_il_program cl_intel_mem_force_host_memory cl_khr_subgroup_extended_types cl_khr_subgroup_non_uniform_vote cl_khr_subgroup_ballot cl_khr_subgroup_non_uniform_arithmetic cl_khr_subgroup_shuffle cl_khr_subgroup_shuffle_relative cl_khr_subgroup_clustered_reduce cl_intel_device_attribute_query cl_khr_expect_assume cl_khr_extended_bit_ops cl_khr_suggested_local_work_size cl_intel_split_work_group_barrier cl_intel_spirv_media_block_io cl_intel_spirv_subgroups cl_khr_spirv_linkonce_odr cl_khr_spirv_no_integer_wrap_decoration cl_intel_unified_shared_memory cl_khr_mipmap_image cl_khr_mipmap_image_writes cl_ext_float_atomics cl_khr_external_memory cl_intel_planar_yuv cl_intel_packed_yuv cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_image2d_from_buffer cl_khr_depth_images cl_khr_3d_image_writes cl_intel_media_block_io cl_intel_subgroup_local_block_io cl_khr_integer_dot_product cl_khr_gl_sharing cl_khr_gl_depth_images cl_khr_gl_event cl_khr_gl_msaa_sharing cl_intel_va_api_media_sharing cl_intel_sharing_format_query cl_khr_pci_bus_info 
[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:277)     CL_DEVICE_SVM_CAPABILITIES: CL_DEVICE_SVM_COARSE_GRAIN_BUFFER 

[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_command_queue_manager.cpp:CreateCommandQueue:53) opencl_command_queue_manager: Created command queue
[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_command_queue_manager.cpp:CreateCommandQueue:56) opencl_command_queue_manager: Retained command queue
[NNTRAINER INFO  2025-09-09 10:28:08] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/cl_buffer_manager.cpp:initBuffers:35) ClBufferManager: Buffers & images initialized
```

New log:
``` bash
[NNTRAINER DEBUG 2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/app_context.cpp:getPluginPaths:195) DEFAULT CONF PATH, path: /usr/local/lib/x86_64-linux-gnu/nntrainer/layers
[NNTRAINER WARN  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/app_context.cpp:add_extension_object:424) tried to register extension from /usr/local/lib/x86_64-linux-gnu/nntrainer/layers but failed, reason: Tensor::divide() is currently not supported in tensor data type UINT4
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_context_manager.cpp:CreateDefaultGPUDevice:128) Collecting OpenCL platforms ...
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_context_manager.cpp:CreateDefaultGPUDevice:151) Collecting OpenCL devices for platform 0 / 1 ...
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_context_manager.cpp:CreateDefaultGPUDevice:182) Looking for suitable OpenCL platform and device ...
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_context_manager.cpp:CreateDefaultGPUDevice:238) Using device Intel(R) Graphics [0x46a6]
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:163) Device info:
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:188)     CL_DEVICE_TYPE: CL_DEVICE_TYPE_GPU
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:195)     CL_DEVICE_VENDOR_ID: 0x8086
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:201)     CL_DEVICE_MAX_COMPUTE_UNITS: 96
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:208)     CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS: 3
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:217)     CL_DEVICE_MAX_WORK_ITEM_SIZES: 512 512 512
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:223)     CL_DEVICE_MAX_WORK_GROUP_SIZE: 512
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:229)     CL_DEVICE_MAX_MEM_ALLOC_SIZE: 1073741824
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:235)     CL_DEVICE_NAME: Intel(R) Graphics [0x46a6]
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:241)     CL_DEVICE_VENDOR: Intel(R) Corporation
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:247)     CL_DRIVER_VERSION: 25.18.33578
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:253)     CL_DEVICE_EXTENSIONS: cl_khr_byte_addressable_store cl_khr_device_uuid cl_khr_fp16 cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_icd cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_intel_command_queue_families cl_intel_subgroups cl_intel_required_subgroup_size cl_intel_subgroups_short cl_khr_spir cl_intel_accelerator cl_intel_driver_diagnostics cl_khr_priority_hints cl_khr_throttle_hints cl_khr_create_command_queue cl_intel_subgroups_char cl_intel_subgroups_long cl_khr_il_program cl_intel_mem_force_host_memory cl_khr_subgroup_extended_types cl_khr_subgroup_non_uniform_vote cl_khr_subgroup_ballot cl_khr_subgroup_non_uniform_arithmetic cl_khr_subgroup_shuffle cl_khr_subgroup_shuffle_relative cl_khr_subgroup_clustered_reduce cl_intel_device_attribute_query cl_khr_expect_assume cl_khr_extended_bit_ops cl_khr_suggested_local_work_size cl_intel_split_work_group_barrier cl_intel_spirv_media_block_io cl_intel_spirv_subgroups cl_khr_spirv_linkonce_odr cl_khr_spirv_no_integer_wrap_decoration cl_intel_unified_shared_memory cl_khr_mipmap_image cl_khr_mipmap_image_writes cl_ext_float_atomics cl_khr_external_memory cl_intel_planar_yuv cl_intel_packed_yuv cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_image2d_from_buffer cl_khr_depth_images cl_khr_3d_image_writes cl_intel_media_block_io cl_intel_subgroup_local_block_io cl_khr_integer_dot_product cl_khr_gl_sharing cl_khr_gl_depth_images cl_khr_gl_event cl_khr_gl_msaa_sharing cl_intel_va_api_media_sharing cl_intel_sharing_format_query cl_khr_pci_bus_info 
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_device_info.cpp:print:271)     CL_DEVICE_SVM_CAPABILITIES: CL_DEVICE_SVM_COARSE_GRAIN_BUFFER 
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_command_queue_manager.cpp:CreateCommandQueue:53) opencl_command_queue_manager: Created command queue
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/opencl/opencl_command_queue_manager.cpp:CreateCommandQueue:56) opencl_command_queue_manager: Retained command queue
[NNTRAINER INFO  2025-09-09 10:32:51] (/home/mwlasiuk/code/nntrainer-mw/nntrainer/cl_buffer_manager.cpp:initBuffers:35) ClBufferManager: Buffers & images **initialized**
```


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: mwlasiuk <testmailsmtp12345@gmail.com>
