### PR TITLE
[git] update ignore file to exclude res/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tensorflow-2.3.0
 Applications/**/data
 cifar-100-binary*
 Applications/**/*.bin
+Applications/**/res/*
 
 # CTag
 /tags


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[git] update ignore file to exclude res/*</summary><br />

- This patch aims to exclude files under Applications/**/res/*
- This may protect your unexpected resource addition

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


### Summary

- [git] update ignore file to exclude `Applications/**/res/*`


Signed-off-by: Eunju Yang <ej.yang@samsung.com>
