### PR TITLE
[CausalLM] enable Q4_0 in Embedding Layer

### DIFF
--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -135,6 +135,13 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
           (void *)((char *)weight.getData<uint8_t>() +
                    (210 * num_blocks_per_row) * embed_idx),
           out_tensor.getData(), out_dim);
+      } else if (weight.getDataType() == nntrainer::TensorDim::DataType::Q4_0) {
+        ///@note this should be replaced with quantizer operation
+        int num_blocks_per_row = (weight.width() + 32 - 1) / 32;
+        nntrainer::dequantize_row_q4_0(
+          (void *)((char *)weight.getData<uint8_t>() +
+                   (18 * num_blocks_per_row) * embed_idx),
+          out_tensor.getData(), out_dim);
       } else {
         out_tensor.copyData(cur_weight);
       }


### PR DESCRIPTION
## Dependency of the PR
- wait for #3452 
- see also #3466 

## Commits to be reviewed in this PR


<details><summary>[CausalLM] enable Q4_0 in Embedding Layer</summary><br />

- This patch enables Q4_0 embedding layer
- This patch reduces embedding layer size by supporting Q4_0 type

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

### Summary

- Enable Q4_0 type for embedding layer.
- This can reduces memory size by supporting Q4_0
- Performance comparison gpt-oss-20b with FP32 embedding layer vs. Q4_0 embedding layer
    - x86 / FP32 embedding layer
    ```
    =================[ LLM with NNTrainer ]===================
    prefill: 78 tokens, 5141 ms, 15.1721 TPS
    generation: 1024 tokens, 156711 ms, 6.53432 TPS
    ==========================================================
    Max Resident Set Size: 6714712 KB
    ```
    - x86 / Q4_0  embedding layer
    ```
  =================[ LLM with NNTrainer ]===================
  prefill: 78 tokens, 5030 ms, 15.507 TPS
  generation: 998 tokens, 140372 ms, 7.10968 TPS
  ==========================================================
  Max Resident Set Size: 4751136 KB
    ```



Signed-off-by: Eunju Yang <ej.yang@samsung.com>
