### PR TITLE
Restricting OpenCL Context Usage When Unavailable

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -36,19 +36,15 @@ std::mutex cl_factory_mutex;
 void ClContext::initialize() noexcept {
   try {
     if (!clInit()) {
-      ml_loge("cl_context: opencl command queue creation failed");
+      ml_loge("Error: ClContext::initialize() failed");
+      return;
     }
 
-    setMemAllocator(std::make_shared<MemAllocator>());
-
     initBlasClKernels();
     initAttentionClKernels();
     add_default_object();
     setMemAllocator(std::make_shared<MemAllocator>());
 
-    initBlasClKernels();
-    initAttentionClKernels();
-    add_default_object();
   } catch (std::exception &e) {
     ml_loge("cl_context: registering layers failed!!, reason: %s", e.what());
   } catch (...) {

--- a/nntrainer/cl_context.h
+++ b/nntrainer/cl_context.h
@@ -289,6 +289,11 @@ private:
 
     // getContext() called inside createCommandQueue which creates clContext
     bool result = command_queue_inst_.CreateCommandQueue();
+
+    // Return false when creating command queue fails
+    if (!result)
+      return result;
+
     // initialize device buffers
     clbuffInstance.initBuffers();
     cl_initialized = result;

--- a/nntrainer/opencl/opencl_buffer.cpp
+++ b/nntrainer/opencl/opencl_buffer.cpp
@@ -30,6 +30,11 @@ namespace nntrainer::opencl {
 Buffer::Buffer(ContextManager &context_manager, size_t size_in_bytes,
                bool read_only, void *data) {
   cl_context context = context_manager.GetContext();
+
+  // If context is invalid, return
+  if (context == nullptr)
+    return;
+
   cl_mem_flags flags = read_only ? CL_MEM_READ_ONLY : CL_MEM_READ_WRITE;
   if (data) {
     flags |= CL_MEM_USE_HOST_PTR;

--- a/nntrainer/opencl/opencl_command_queue_manager.cpp
+++ b/nntrainer/opencl/opencl_command_queue_manager.cpp
@@ -39,6 +39,11 @@ bool CommandQueueManager::CreateCommandQueue() {
   // OpenCL context is created
   cl_context context = context_instance.GetContext();
 
+  // If context is invalid, return false
+  if (context == nullptr) {
+    return false;
+  }
+
   // getting GPU device ID
   cl_device_id device_id = context_instance.GetDeviceId();
 

--- a/nntrainer/opencl/opencl_context_manager.cpp
+++ b/nntrainer/opencl/opencl_context_manager.cpp
@@ -32,7 +32,12 @@ namespace nntrainer::opencl {
  */
 const cl_context &ContextManager::GetContext() {
   // loading the OpenCL library and required functions
-  LoadOpenCL();
+  bool result = LoadOpenCL();
+
+  if (!result) {
+    context_ = nullptr;
+    return context_;
+  }
 
   if (context_) {
     // increments the context reference count
@@ -45,8 +50,6 @@ const cl_context &ContextManager::GetContext() {
 
     return context_;
   }
-
-  bool result = true;
 
   do {
     result = CreateDefaultGPUDevice();
@@ -87,7 +90,10 @@ void ContextManager::ReleaseContext() {
 const cl_device_id ContextManager::GetDeviceId() { return device_id_; }
 
 void *ContextManager::createSVMRegion(size_t size) {
-  return clSVMAlloc(context_, CL_MEM_READ_WRITE, size, 0);
+  if (context_)
+    return clSVMAlloc(context_, CL_MEM_READ_WRITE, size, 0);
+  else
+    return nullptr;
 }
 
 void ContextManager::releaseSVMRegion(void *svm_ptr) {

--- a/nntrainer/opencl/opencl_loader.cpp
+++ b/nntrainer/opencl/opencl_loader.cpp
@@ -32,6 +32,8 @@ void LoadOpenCLFunctions(void *libopencl);
 
 static bool open_cl_initialized = false;
 
+static bool opencl_init_failed = false;
+
 /**
  * @brief Loading OpenCL libraries and required function
  *
@@ -41,6 +43,10 @@ bool LoadOpenCL() {
   // check if already loaded
   if (open_cl_initialized) {
     return true;
+  }
+  // if OpenCL is not available
+  if (opencl_init_failed) {
+    return false;
   }
 
   void *libopencl = nullptr;
@@ -61,7 +67,8 @@ bool LoadOpenCL() {
 
   // record error
   std::string error(DynamicLibraryLoader::getLastError());
-  ml_loge("Can not open OpenCL library on this device - %s", error.c_str());
+  ml_loge("Cannot open OpenCL library on this device - %s", error.c_str());
+  opencl_init_failed = true;
   return false;
 }
 


### PR DESCRIPTION
This PR addresses issues where the OpenCL context only considered scenarios in which OpenCL was available.
As a result, there was no proper handling of cases where OpenCL was not available.
This patch now restricts the use of the OpenCL context accordingly.
Please note that additional work may still be required.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped