### PR TITLE
[ cpu_backend ] Enable channelwise 4bit quantized GEMM ( A : F32 -> U8 * W : S4 = O : F32)

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -21,6 +21,7 @@
 /usr/include/nntrainer/float_tensor.h
 /usr/include/nntrainer/tensor_wrap_specs.h
 /usr/include/nntrainer/fallback_internal.h 
+/usr/include/nntrainer/fallback_kleidiai.h 
 /usr/include/nntrainer/cblas_interface.h
 /usr/include/nntrainer/x86_compute_backend.h
 /usr/include/nntrainer/cpu_backend.h

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -534,4 +534,22 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
            float upper_bound) {
   neon::clamp(input, output, length, lower_bound, upper_bound);
 }
+
+void nntr_quant_qs4cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                          void *rhs_native_mtx_qs4cx, void *rhs_scales_f32,
+                          bool transB) {
+  __fallback_nntr_quant_qs4cx_f32(n, k, rhs_native_mtx_f32,
+                                  rhs_native_mtx_qs4cx, rhs_scales_f32, transB);
+}
+
+template <>
+void nntr_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
+                               void *lhs_native_mtx_f32,
+                               void *rhs_native_mtx_qs4cx, void *rhs_scales_f32,
+                               float *dst_mtx_f32, bool transB,
+                               float lower_bound, float upper_bound) {
+  __fallback_nntr_gemm_qai8dxp_qsi4cxp(
+    m, n, k, lhs_native_mtx_f32, rhs_native_mtx_qs4cx, rhs_scales_f32,
+    dst_mtx_f32, transB, lower_bound, upper_bound);
+}
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1185,6 +1185,46 @@ template <typename T = float>
 void clamp(const T *input, T *output, size_t length,
            T lower_bound = std::numeric_limits<T>::lowest(),
            T upper_bound = std::numeric_limits<T>::max());
+
+/**
+ * @brief qs4cx quantization of (n*k) matrix. Typically a weight quantization,
+ * and generally regard the weight is already transposed, and quantize it as it
+ * is. qs4cx refers to quantized symmetric 4-bit quantization of channelwise x
+ * groups.
+ *
+ * @param n N length of the matrix
+ * @param k K length of the matrix
+ * @param rhs_native_mtx_f32 matrix data before quantization to load
+ * @param rhs_native_mtx_qs4cx matrix data after quantization to stroe
+ * @param rhs_scales_f32 matrix quant scale after quantization to stroe
+ * @param transB
+ */
+void nntr_quant_qs4cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                          void *rhs_native_mtx_qs4cx, void *rhs_scales_f32,
+                          bool transB = true);
+/**
+ * @brief GEMM of qai8dxp runtime-quantized activation and offline qs4cx
+ * quantized weight
+ *
+ * @tparam T dataType of input activation and output matrices
+ * @param m M length of the matrix
+ * @param n N length of the matrix
+ * @param k K length of the matrix
+ * @param lhs_native_mtx activation (not quantized)
+ * @param rhs_native_mtx_qs4cx offline quantized weight
+ * @param rhs_scales scale factor vector of quantized weight
+ * @param dst_mtx dst matrix
+ * @param lower_bound lower bound to clamp
+ * @param upper_bound upper bound to clamp
+ * @param transB Choose weight data to be transposed or not. Default value
+ * regards the weight to be transpoed.
+ */
+template <typename T = float>
+void nntr_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
+                               void *lhs_native_mtx, void *rhs_native_mtx_qs4cx,
+                               void *rhs_scales, T *dst_mtx, bool transB = true,
+                               T lower_bound = std::numeric_limits<T>::lowest(),
+                               T upper_bound = std::numeric_limits<T>::max());
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __ARM_COMPUTE_BACKEND_H__ */

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -1205,5 +1205,46 @@ template <typename T = float>
 extern void clamp(const T *input, T *output, size_t length,
                   T lower_bound = std::numeric_limits<T>::lowest(),
                   T upper_bound = std::numeric_limits<T>::max());
+
+/**
+ * @brief qs4cx quantization of (n*k) matrix. Typically a weight quantization,
+ * and generally regard the weight is already transposed, and quantize it as it
+ * is. qs4cx refers to quantized symmetric 4-bit quantization of channelwise x
+ * groups.
+ *
+ * @param n N length of the matrix
+ * @param k K length of the matrix
+ * @param rhs_native_mtx_f32 matrix data before quantization to load
+ * @param rhs_native_mtx_qs4cx matrix data after quantization to stroe
+ * @param rhs_scales_f32 matrix quant scale after quantization to stroe
+ * @param transB
+ */
+extern void nntr_quant_qs4cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                                 void *rhs_native_mtx_qs4cx,
+                                 void *rhs_scales_f32, bool transB = true);
+/**
+ * @brief GEMM of qai8dxp runtime-quantized activation and offline qs4cx
+ * quantized weight
+ *
+ * @tparam T dataType of input activation and output matrices
+ * @param m M length of the matrix
+ * @param n N length of the matrix
+ * @param k K length of the matrix
+ * @param lhs_native_mtx activation (not quantized)
+ * @param rhs_native_mtx_qs4cx offline quantized weight
+ * @param rhs_scales scale factor vector of quantized weight
+ * @param dst_mtx dst matrix
+ * @param lower_bound lower bound to clamp
+ * @param upper_bound upper bound to clamp
+ * @param transB Choose weight data to be transposed or not. Default value
+ * regards the weight to be transpoed.
+ */
+template <typename T = float>
+extern void
+nntr_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k, void *lhs_native_mtx,
+                          void *rhs_native_mtx_qs4cx, void *rhs_scales,
+                          T *dst_mtx, bool transB = true,
+                          T lower_bound = std::numeric_limits<T>::lowest(),
+                          T upper_bound = std::numeric_limits<T>::max());
 #endif
 #endif

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -339,4 +339,22 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
   __fallback_clamp(input, output, length, lower_bound, upper_bound);
 }
 
+void nntr_quant_qs4cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                          void *rhs_native_mtx_qs4cx, void *rhs_scales_f32,
+                          bool transB) {
+  __fallback_nntr_quant_qs4cx_f32(n, k, rhs_native_mtx_f32,
+                                  rhs_native_mtx_qs4cx, rhs_scales_f32, transB);
+}
+
+template <>
+void nntr_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
+                               void *lhs_native_mtx_f32,
+                               void *rhs_native_mtx_qs4cx, void *rhs_scales_f32,
+                               float *dst_mtx_f32, bool transB,
+                               float lower_bound, float upper_bound) {
+  __fallback_nntr_gemm_qai8dxp_qsi4cxp(
+    m, n, k, lhs_native_mtx_f32, rhs_native_mtx_qs4cx, rhs_scales_f32,
+    dst_mtx_f32, transB, lower_bound, upper_bound);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1156,6 +1156,47 @@ template <typename T = float>
 void clamp(const T *input, T *output, size_t length,
            T lower_bound = std::numeric_limits<T>::lowest(),
            T upper_bound = std::numeric_limits<T>::max());
+
+/**
+ * @brief qs4cx quantization of (n*k) matrix. Typically a weight quantization,
+ * and generally regard the weight is already transposed, and quantize it as it
+ * is. qs4cx refers to quantized symmetric 4-bit quantization of channelwise x
+ * groups.
+ *
+ * @param n N length of the matrix
+ * @param k K length of the matrix
+ * @param rhs_native_mtx_f32 matrix data before quantization to load
+ * @param rhs_native_mtx_qs4cx matrix data after quantization to store
+ * @param rhs_scales_f32 matrix quant scale after quantization to store
+ * @param transB Choose weight data to be transposed or not. Default value
+ * regards the weight to be transposed.
+ */
+void nntr_quant_qs4cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                          void *rhs_native_mtx_qs4cx, void *rhs_scales_f32,
+                          bool transB = true);
+/**
+ * @brief GEMM of qai8dxp runtime-quantized activation and offline qs4cx
+ * quantized weight
+ *
+ * @tparam T dataType of input activation and output matrices
+ * @param m M length of the matrix
+ * @param n N length of the matrix
+ * @param k K length of the matrix
+ * @param lhs_native_mtx activation (not quantized)
+ * @param rhs_native_mtx_qs4cx offline quantized weight
+ * @param rhs_scales scale factor vector of quantized weight
+ * @param dst_mtx dst matrix
+ * @param lower_bound lower bound to clamp
+ * @param upper_bound upper bound to clamp
+ * @param transB Choose weight data to be transposed or not. Default value
+ * regards the weight to be transposed.
+ */
+template <typename T = float>
+void nntr_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
+                               void *lhs_native_mtx, void *rhs_native_mtx_qs4cx,
+                               void *rhs_scales, T *dst_mtx, bool transB = true,
+                               T lower_bound = std::numeric_limits<T>::lowest(),
+                               T upper_bound = std::numeric_limits<T>::max());
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __FALLBACK_H__ */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -17,6 +17,8 @@
 #include <cmath>
 #include <cstdint>
 #include <fallback_internal.h>
+#include <fallback_kleidiai.h>
+#include <limits>
 #include <stdexcept>
 #include <tensor_dim.h>
 #include <util_func.h>
@@ -603,6 +605,47 @@ void __fallback_clamp(const float *input, float *output, size_t length,
   for (int i = 0; i < length; ++i) {
     output[i] = std::clamp(input[i], lower_bound, upper_bound);
   }
+}
+
+void __fallback_nntr_quant_qs4cx_f32(size_t n, size_t k,
+                                     void *rhs_native_mtx_f32,
+                                     void *rhs_native_mtx_qs4cx,
+                                     void *rhs_scales_f32, bool transB) {
+  rhs_format format = rhs_format::nxk;
+  if (!transB) {
+    format = rhs_format::kxn;
+  }
+
+  quant_qs4cx_f32(n, k, format, (const float *)rhs_native_mtx_f32,
+                  (uint8_t *)rhs_native_mtx_qs4cx, (float *)rhs_scales_f32);
+}
+
+template <>
+void __fallback_nntr_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
+                                          void *lhs_native_mtx_f32,
+                                          void *rhs_native_mtx_qs4cx,
+                                          void *rhs_scales_f32,
+                                          float *dst_mtx_f32, bool transB, float lower_bound,
+                                          float upper_bound) {
+
+  rhs_format format = rhs_format::nxk;
+  if (!transB) {
+    format = rhs_format::kxn;
+  }
+
+  const size_t lhs_ref_size_qa8dx = m * (k + sizeof(int32_t) + sizeof(float));
+
+  uint8_t *lhs_ref_mtx_qa8dx = new uint8_t[lhs_ref_size_qa8dx];
+
+  ref_quant_qa8dx_f32(m, k, (const float *)lhs_native_mtx_f32,
+                      (int8_t *)lhs_ref_mtx_qa8dx);
+
+  ref_matmul_f32_qa8dx_qs4cx(m, n, k, format, (const int8_t *)lhs_ref_mtx_qa8dx,
+                             (const uint8_t *)rhs_native_mtx_qs4cx,
+                             (const float *)rhs_scales_f32,
+                             (float *)dst_mtx_f32, lower_bound, upper_bound);
+
+  delete[] lhs_ref_mtx_qa8dx;
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -621,12 +621,10 @@ void __fallback_nntr_quant_qs4cx_f32(size_t n, size_t k,
 }
 
 template <>
-void __fallback_nntr_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
-                                          void *lhs_native_mtx_f32,
-                                          void *rhs_native_mtx_qs4cx,
-                                          void *rhs_scales_f32,
-                                          float *dst_mtx_f32, bool transB, float lower_bound,
-                                          float upper_bound) {
+void __fallback_nntr_gemm_qai8dxp_qsi4cxp(
+  size_t m, size_t n, size_t k, void *lhs_native_mtx_f32,
+  void *rhs_native_mtx_qs4cx, void *rhs_scales_f32, float *dst_mtx_f32,
+  bool transB, float lower_bound, float upper_bound) {
 
   rhs_format format = rhs_format::nxk;
   if (!transB) {

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -1141,8 +1141,8 @@ void __fallback_clamp(const T *input, T *output, size_t length,
  * @param n N length of the matrix
  * @param k K length of the matrix
  * @param rhs_native_mtx_f32 matrix data before quantization to load
- * @param rhs_native_mtx_qs4cx matrix data after quantization to stroe
- * @param rhs_scales_f32 matrix quant scale after quantization to stroe
+ * @param rhs_native_mtx_qs4cx matrix data after quantization to store
+ * @param rhs_scales_f32 matrix quant scale after quantization to store
  * @param transB
  */
 void __fallback_nntr_quant_qs4cx_f32(size_t n, size_t k,

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -16,6 +16,7 @@
 #ifdef __cplusplus
 
 #include <cstdint>
+#include <limits.h>
 #include <limits>
 #include <tensor_dim.h>
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -16,7 +16,6 @@
 #ifdef __cplusplus
 
 #include <cstdint>
-#include <limits.h>
 #include <limits>
 #include <tensor_dim.h>
 
@@ -136,8 +135,8 @@ void __fallback_quantize_row_q8_0(const _FP16 *__restrict src,
  * @param dst output destination for quantized data
  * @param nrow number of row
  * @param n_per_row number of elements per row
- * @param quant_weights additional information for quantization. Currently in no
- * use.
+ * @param quant_weights additional information for quantization. Currently in
+ * no use.
  * @return size_t total size of quantized data
  */
 size_t __fallback_quantize_q8_0(const _FP16 *src, void *dst, int64_t nrow,
@@ -327,7 +326,8 @@ void __fallback_ele_sub(const unsigned N, const _FP16 *X, const _FP16 *Y,
                         unsigned int i_stride, unsigned int o_stride);
 
 /**
- * @brief     elementwise vector division with neon : Z = X / (alpha * Y) + beta
+ * @brief     elementwise vector division with neon : Z = X / (alpha * Y) +
+ * beta
  * * Z
  * @note ZeroDivisionError is not guaranteed in this function
  * @param[in] N  length of the vector
@@ -436,8 +436,8 @@ void __fallback_unpack_q4_0x8_transpose16(const void *src,
                                           int K, int CT = 1);
 
 /**
- * @brief Get half-sized angles, transform them into each cos, sin, and scopy in
- * the same vector : cos_ = cos(freq).extend(cos(freq)), sin_ =
+ * @brief Get half-sized angles, transform them into each cos, sin, and scopy
+ * in the same vector : cos_ = cos(freq).extend(cos(freq)), sin_ =
  * sin(freq).extend(sin_(req))
  *
  * @param N_half : size of angle
@@ -792,7 +792,8 @@ void __fallback_ele_sub(const unsigned N, const float *X, const float *Y,
                         unsigned int i_stride, unsigned int o_stride);
 
 /**
- * @brief     elementwise vector division with neon : Z = X / (alpha * Y) + beta
+ * @brief     elementwise vector division with neon : Z = X / (alpha * Y) +
+ * beta
  * * Z
  * @note ZeroDivisionError is not guaranteed in this function
  * @param[in] N  length of the vector
@@ -1078,8 +1079,8 @@ void __fallback_compute_kcaches(const float *in, const BType *kcache,
  * @param[in] width current w value from b, c, h, w
  * @param[in] dim unit length of simd computation
  * @param[in] half_ criterion for rotational direction of embedding
- * @param[in/out] inout float* uesed also as output when expected output float*
- * values
+ * @param[in/out] inout float* uesed also as output when expected output
+ * float* values
  * @param[out] output void* output values, used when expected output __fp16*
  * values
  * @param[in] cos_ float* input con values
@@ -1131,6 +1132,46 @@ template <typename T = float>
 void __fallback_clamp(const T *input, T *output, size_t length,
                       T lower_bound = std::numeric_limits<T>::lowest(),
                       T upper_bound = std::numeric_limits<T>::max());
+/**
+ * @brief qs4cx quantization of (n*k) matrix. Typically a weight quantization,
+ * and generally regard the weight is already transposed, and quantize it as it
+ * is. qs4cx refers to quantized symmetric 4-bit quantization of channelwise x
+ * groups.
+ *
+ * @param n N length of the matrix
+ * @param k K length of the matrix
+ * @param rhs_native_mtx_f32 matrix data before quantization to load
+ * @param rhs_native_mtx_qs4cx matrix data after quantization to stroe
+ * @param rhs_scales_f32 matrix quant scale after quantization to stroe
+ * @param transB
+ */
+void __fallback_nntr_quant_qs4cx_f32(size_t n, size_t k,
+                                     void *rhs_native_mtx_f32,
+                                     void *rhs_native_mtx_qs4cx,
+                                     void *rhs_scales_f32, bool transB = true);
+/**
+ * @brief GEMM of qai8dxp runtime-quantized activation and offline qs4cx
+ * quantized weight
+ *
+ * @tparam T dataType of input activation and output matrices
+ * @param m M length of the matrix
+ * @param n N length of the matrix
+ * @param k K length of the matrix
+ * @param lhs_native_mtx activation (not quantized)
+ * @param rhs_native_mtx_qs4cx offline quantized weight
+ * @param rhs_scales scale factor vector of quantized weight
+ * @param dst_mtx dst matrix
+ * @param lower_bound lower bound to clamp
+ * @param upper_bound upper bound to clamp
+ * @param transB Choose weight data to be transposed or not. Default value
+ * regards the weight to be transpoed.
+ */
+template <typename T = float>
+void __fallback_nntr_gemm_qai8dxp_qsi4cxp(
+  size_t m, size_t n, size_t k, void *lhs_native_mtx,
+  void *rhs_native_mtx_qs4cx, void *rhs_scales, T *dst_mtx, bool transB = true,
+  T lower_bound = std::numeric_limits<T>::lowest(),
+  T upper_bound = std::numeric_limits<T>::max());
 } // namespace nntrainer
 #endif
 #endif

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.cpp
@@ -5,11 +5,11 @@
  * @file   fallback_kleidiai.cpp
  * @date   15 September 2025
  * @see    https://github.com/nnstreamer/nntrainer
- * @author Sungsik Kong
- * @brief  Modified computational backend components of
- * matmul_clamp_f32_qai8dxp_qsi4cxp. Portions of this file are derived from Arm
- * Limited code licensed under the Apache License, Version 2.0, with
- * modifications
+ * @author Sungsik Kong <ss.kong@samsung.com>
+ * @brief  Modified computational backend components of kleidiai. Portions of
+ * this file are derived from Arm Limited code licensed under the Apache
+ * License, Version 2.0, with modifications
+ * @bug    No known bugs except for NYI items
  * @note   Licensed under the Apache License, Version 2.0 (the "License");
  *         you may not use this file except in compliance with the License.
  *         You may obtain a copy of the License at
@@ -19,7 +19,6 @@
  *   - [2025-09-15] Integrated and adapted Arm-provided code into
  *     nntrainer CPU backend
  *
- * @bug    No known bugs except for NYI items
  */
 
 #include <cassert>

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.cpp
@@ -6,12 +6,10 @@
  * @date   15 September 2025
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Sungsik Kong
- *
  * @brief  Modified computational backend components of
- * matmul_clamp_f32_qai8dxp_qsi4cxp.cpp Portions of this file are derived from
- * Arm Limited code licensed under the Apache License, Version 2.0, with
+ * matmul_clamp_f32_qai8dxp_qsi4cxp. Portions of this file are derived from Arm
+ * Limited code licensed under the Apache License, Version 2.0, with
  * modifications
- *
  * @note   Licensed under the Apache License, Version 2.0 (the "License");
  *         you may not use this file except in compliance with the License.
  *         You may obtain a copy of the License at
@@ -105,8 +103,8 @@ void ref_quant_qa8dx_f32(size_t m, size_t k, const float *lhs_f32,
       int32_t v0_s32 = (int32_t)(round(src0_0 * scale0));
 
       v0_s32 = v0_s32 + nudged_zero_point0;
-      v0_s32 = std::max(v0_s32, INT8_MIN);
-      v0_s32 = std::min(v0_s32, INT8_MAX);
+      v0_s32 = std::max(v0_s32, static_cast<int32_t>(INT8_MIN));
+      v0_s32 = std::min(v0_s32, static_cast<int32_t>(INT8_MAX));
       dst_ptr[0] = (int8_t)v0_s32;
       dst_ptr += sizeof(int8_t);
     }
@@ -154,8 +152,8 @@ static void quant_nxk_qs4cx_f32(size_t n, size_t k, const float *rhs_f32,
       int32_t v0_s32 = (int32_t)(round(src0_0 * scale0));
 
       // Maximum/minimum int4 values
-      v0_s32 = std::max(v0_s32, INT4_MIN);
-      v0_s32 = std::min(v0_s32, INT4_MAX);
+      v0_s32 = std::max(v0_s32, static_cast<int32_t>(INT4_MIN));
+      v0_s32 = std::min(v0_s32, static_cast<int32_t>(INT4_MAX));
 
       const uint8_t v0_u8 = (uint8_t)(v0_s32 + 8);
 
@@ -215,8 +213,8 @@ static void quant_kxn_qs4cx_f32(size_t n, size_t k, const float *rhs_f32,
       int32_t v0_s32 = (int32_t)(round(src0_0 * scale0));
 
       // Maximum/minimum int4 values
-      v0_s32 = std::max(v0_s32, INT4_MIN);
-      v0_s32 = std::min(v0_s32, INT4_MAX);
+      v0_s32 = std::max(v0_s32, static_cast<int32_t>(INT4_MIN));
+      v0_s32 = std::min(v0_s32, static_cast<int32_t>(INT4_MAX));
 
       const uint8_t v0_u8 = (uint8_t)(v0_s32 + 8);
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.cpp
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Arm Limited and/or its affiliates
+ *
+ * @file   fallback_kleidiai.cpp
+ * @date   15 September 2025
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Sungsik Kong
+ *
+ * @brief  Modified computational backend components of matmul_clamp_f32_qai8dxp_qsi4cxp.
+ *         Portions of this file are derived from Arm Limited code licensed
+ *         under the Apache License, Version 2.0, with modifications
+ *
+ * @note   Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *             http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @modifications
+ *   - [2025-09-15] Integrated and adapted Arm-provided code into
+ *     nntrainer CPU backend
+ *
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <cassert>
+#include <cfloat>
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <string>
+
+#include <fallback_kleidiai.h>
+
+#define INT4_MIN (-8)
+#define INT4_MAX (7)
+
+
+
+static size_t roundup(size_t a, size_t b) { return ((a + b - 1) / b) * b; }
+
+void ref_quant_qa8dx_f32(size_t m, size_t k, const float *lhs_f32,
+                                int8_t *lhs_qa8dx) {
+  const size_t dst_stride =
+    (k * sizeof(int8_t) + sizeof(float) + sizeof(int32_t));
+
+  const size_t lhs_qa8dx_stride = k;
+
+  for (size_t m_idx = 0; m_idx < m; ++m_idx) {
+    const float *src_ptr = lhs_f32 + m_idx * lhs_qa8dx_stride;
+
+    float max0 = -FLT_MAX;
+    float min0 = FLT_MAX;
+
+    // Find min/max for each channel
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+      const float src0_0 = src_ptr[k_idx];
+
+      max0 = std::max(src0_0, max0);
+      min0 = std::min(src0_0, min0);
+    }
+
+    // Maximum/minimum int8 values
+    const float qmin = (float)INT8_MIN;
+    const float qmax = (float)INT8_MAX;
+
+    const float rmin0 = std::min(0.0f, min0);
+    const float rmax0 = std::max(0.0f, max0);
+
+    const float scale0 = rmin0 == rmax0 ? 1.f : (qmax - qmin) / (rmax0 - rmin0);
+
+    // Reciprocal to quantize
+    const float recip_scale0 = scale0 ? 1.0f / scale0 : 0.0f;
+
+    const float descaled_min0 = rmin0 * scale0;
+    const float descaled_max0 = rmax0 * scale0;
+
+    const float zero_point_from_min_error0 = qmin + descaled_min0;
+    const float zero_point_from_max_error0 = qmax + descaled_max0;
+
+    float zero_point0 =
+      zero_point_from_min_error0 + zero_point_from_max_error0 > 0
+        ? qmin - descaled_min0
+        : qmax - descaled_max0;
+
+    zero_point0 = std::max(zero_point0, qmin);
+    zero_point0 = std::min(zero_point0, qmax);
+
+    // Round to nearest integer
+    const int32_t nudged_zero_point0 = lrintf(zero_point0);
+
+    int8_t *dst_ptr = (int8_t *)lhs_qa8dx + m_idx * dst_stride;
+
+    // LHS offset at the beginning of the row
+    *((float *)(dst_ptr)) = recip_scale0;
+    dst_ptr += sizeof(float);
+    *((int32_t *)(dst_ptr)) = -nudged_zero_point0;
+    dst_ptr += sizeof(int32_t);
+
+    // Quantize the channels
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+      const float src0_0 = src_ptr[k_idx];
+
+      // Scale the values
+      int32_t v0_s32 = (int32_t)(round(src0_0 * scale0));
+
+      v0_s32 = v0_s32 + nudged_zero_point0;
+      v0_s32 = std::max(v0_s32, INT8_MIN);
+      v0_s32 = std::min(v0_s32, INT8_MAX);
+      dst_ptr[0] = (int8_t)v0_s32;
+      dst_ptr += sizeof(int8_t);
+    }
+  }
+};
+
+static void quant_nxk_qs4cx_f32(size_t n, size_t k, const float *rhs_f32,
+                                uint8_t *rhs_qs4cx, float *rhs_scales_f32) {
+  const size_t rhs_qs4cx_stride = (roundup(k, 2) / 2);
+
+  // Make sure the output is filled with zeros
+  std::memset(rhs_qs4cx, 0, n * rhs_qs4cx_stride);
+
+  for (size_t n_idx = 0; n_idx < n; ++n_idx) {
+    const float *src_ptr = rhs_f32 + n_idx * k;
+
+    float max0 = -FLT_MAX;
+    float min0 = FLT_MAX;
+
+    // Find min/max for each channel
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+      const float src0_0 = src_ptr[k_idx];
+
+      max0 = std::max(src0_0, max0);
+      min0 = std::min(src0_0, min0);
+    }
+
+    // Maximum/minimum int8 values
+    const float qmin = (float)INT4_MIN;
+    const float qmax = (float)INT4_MAX;
+
+    const float rmin0 = std::min(0.0f, min0);
+    const float rmax0 = std::max(0.0f, max0);
+
+    const float scale0 = rmin0 == rmax0 ? 1.f : (qmax - qmin) / (rmax0 - rmin0);
+
+    // Reciprocal to quantize
+    const float recip_scale0 = scale0 ? 1.0f / scale0 : 0.0f;
+
+    // Quantize the channels
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+      const float src0_0 = src_ptr[k_idx];
+
+      // Scale the values
+      int32_t v0_s32 = (int32_t)(round(src0_0 * scale0));
+
+      // Maximum/minimum int4 values
+      v0_s32 = std::max(v0_s32, INT4_MIN);
+      v0_s32 = std::min(v0_s32, INT4_MAX);
+
+      const uint8_t v0_u8 = (uint8_t)(v0_s32 + 8);
+
+      const size_t dst_addr = (k_idx / 2) + n_idx * rhs_qs4cx_stride;
+      uint8_t rhs_v0 = rhs_qs4cx[dst_addr];
+
+      if ((k_idx % 2) == 0) {
+        rhs_v0 |= v0_u8;
+      } else {
+        rhs_v0 |= (v0_u8 << 4);
+      }
+      rhs_qs4cx[dst_addr] = rhs_v0;
+    }
+
+    rhs_scales_f32[n_idx] = recip_scale0;
+  }
+};
+
+static void quant_kxn_qs4cx_f32(size_t n, size_t k, const float *rhs_f32,
+                                uint8_t *rhs_qs4cx, float *rhs_scales_f32) {
+  const size_t rhs_qs4cx_stride = (roundup(n, 2) / 2);
+
+  // Make sure the output is filled with zeros
+  std::memset(rhs_qs4cx, 0, k * rhs_qs4cx_stride);
+
+  for (size_t n_idx = 0; n_idx < n; ++n_idx) {
+    const float *src_ptr = rhs_f32 + n_idx * k;
+
+    float max0 = -FLT_MAX;
+    float min0 = FLT_MAX;
+
+    // Find min/max for each channel
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+      const float src0_0 = src_ptr[k_idx];
+
+      max0 = std::max(src0_0, max0);
+      min0 = std::min(src0_0, min0);
+    }
+
+    // Maximum/minimum int8 values
+    const float qmin = (float)INT4_MIN;
+    const float qmax = (float)INT4_MAX;
+
+    const float rmin0 = std::min(0.0f, min0);
+    const float rmax0 = std::max(0.0f, max0);
+
+    const float scale0 = rmin0 == rmax0 ? 1.f : (qmax - qmin) / (rmax0 - rmin0);
+
+    // Reciprocal to quantize
+    const float recip_scale0 = scale0 ? 1.0f / scale0 : 0.0f;
+
+    // Quantize the channels
+    for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+      const float src0_0 = src_ptr[k_idx];
+
+      // Scale the values
+      int32_t v0_s32 = (int32_t)(round(src0_0 * scale0));
+
+      // Maximum/minimum int4 values
+      v0_s32 = std::max(v0_s32, INT4_MIN);
+      v0_s32 = std::min(v0_s32, INT4_MAX);
+
+      const uint8_t v0_u8 = (uint8_t)(v0_s32 + 8);
+
+      const size_t dst_addr = (n_idx / 2) + k_idx * rhs_qs4cx_stride;
+      uint8_t rhs_v0 = rhs_qs4cx[dst_addr];
+
+      if ((n_idx % 2) == 0) {
+        rhs_v0 |= v0_u8;
+      } else {
+        rhs_v0 |= (v0_u8 << 4);
+      }
+      rhs_qs4cx[dst_addr] = rhs_v0;
+    }
+
+    rhs_scales_f32[n_idx] = recip_scale0;
+  }
+};
+
+void quant_qs4cx_f32(size_t n, size_t k, rhs_format format,
+                            const float *rhs_f32, uint8_t *rhs_qs4cx,
+                            float *rhs_scales_f32) {
+  if (rhs_format::nxk == format) {
+    quant_nxk_qs4cx_f32(n, k, rhs_f32, rhs_qs4cx, rhs_scales_f32);
+  } else {
+    quant_kxn_qs4cx_f32(n, k, rhs_f32, rhs_qs4cx, rhs_scales_f32);
+  }
+};
+
+static void ref_matmul_mxn_mxk_nxk_f32_qa8dx_qs4cx( // transB
+  size_t m, size_t n, size_t k, const int8_t *lhs_qa8dx,
+  const uint8_t *rhs_qs4cx, const float *rhs_scales_f32, float *dst_f32,
+  float scalar_min, float scalar_max) {
+  const size_t lhs_stride =
+    k * sizeof(int8_t) + sizeof(float) + sizeof(int32_t);
+
+  const size_t rhs_qs4cx_stride = (roundup(k, 2) / 2);
+
+  for (size_t m_idx = 0; m_idx < m; ++m_idx) {
+    const int8_t *lhs_ptr_start = lhs_qa8dx + m_idx * lhs_stride;
+
+    for (size_t n_idx = 0; n_idx < n; ++n_idx) {
+      // Main f32 accumulator
+      int32_t iacc = 0;
+
+      const int8_t *lhs_ptr = lhs_ptr_start;
+      const uint8_t *rhs_ptr = rhs_qs4cx + n_idx * rhs_qs4cx_stride;
+
+      // Get the LHS quantization parameters stored at the
+      // beginning of each row
+      const float lhs_scale = *(const float *)lhs_ptr;
+      lhs_ptr += sizeof(float);
+
+      const int32_t lhs_offset = *(const int32_t *)lhs_ptr;
+      lhs_ptr += sizeof(int32_t);
+
+      for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+        // Get the LHS values
+        const int32_t lhs_v0 = (int32_t)lhs_ptr[0];
+
+        // Get the RHS values
+        const uint8_t rhs_byte = rhs_ptr[0];
+
+        // Unpack the RHS values
+        int32_t rhs_v0 = 0;
+        if ((k_idx % 2) == 0) {
+          rhs_v0 = (((int32_t)(rhs_byte & 0x0F)) - 8);
+        } else {
+          rhs_v0 = (((int32_t)(rhs_byte >> 4)) - 8);
+        }
+
+        iacc += lhs_v0 * rhs_v0;
+        iacc += lhs_offset * rhs_v0;
+
+        lhs_ptr += 1;
+
+        // Increment only when k_idx is not a multiple of 2
+        rhs_ptr += k_idx % 2;
+      }
+
+      // Get the RHS scale
+      const float rhs_scale = rhs_scales_f32[n_idx];
+
+      float main_acc = iacc * rhs_scale;
+
+      main_acc = main_acc * lhs_scale;
+
+      // Clamp (min-max) operation
+      main_acc = std::max(main_acc, scalar_min);
+      main_acc = std::min(main_acc, scalar_max);
+
+      dst_f32[0] = main_acc;
+      dst_f32 += 1;
+    }
+  }
+};
+
+static void ref_matmul_mxn_mxk_kxn_f32_qa8dx_qs4cx( // noTrans
+  size_t m, size_t n, size_t k, const int8_t *lhs_qa8dx,
+  const uint8_t *rhs_qs4cx, const float *rhs_scales_f32, float *dst_f32,
+  float scalar_min, float scalar_max) {
+  const size_t lhs_stride =
+    k * sizeof(int8_t) + sizeof(float) + sizeof(int32_t);
+
+  const size_t rhs_qs4cx_stride = (roundup(n, 2) / 2);
+
+  for (size_t m_idx = 0; m_idx < m; ++m_idx) {
+    const int8_t *lhs_ptr_start = lhs_qa8dx + m_idx * lhs_stride;
+
+    for (size_t n_idx = 0; n_idx < n; ++n_idx) {
+      // Main f32 accumulator
+      int32_t iacc = 0;
+
+      const int8_t *lhs_ptr = lhs_ptr_start;
+      const uint8_t *rhs_ptr = rhs_qs4cx + (n_idx / 2);
+
+      // Get the LHS quantization parameters stored at the
+      // beginning of each row
+      const float lhs_scale = *(const float *)lhs_ptr;
+      lhs_ptr += sizeof(float);
+
+      const int32_t lhs_offset = *(const int32_t *)lhs_ptr;
+      lhs_ptr += sizeof(int32_t);
+
+      for (size_t k_idx = 0; k_idx < k; ++k_idx) {
+        // Get the LHS values
+        const int32_t lhs_v0 = (int32_t)lhs_ptr[0];
+
+        // Get the RHS values
+        const uint8_t rhs_byte = rhs_ptr[0];
+
+        // Unpack the RHS values
+        int32_t rhs_v0 = 0;
+        if ((n_idx % 2) == 0) {
+          rhs_v0 = (((int32_t)(rhs_byte & 0x0F)) - 8);
+        } else {
+          rhs_v0 = (((int32_t)(rhs_byte >> 4)) - 8);
+        }
+
+        iacc += lhs_v0 * rhs_v0;
+        iacc += lhs_offset * rhs_v0;
+
+        lhs_ptr += 1;
+
+        // Increment only when k_idx is not a multiple of 2
+        rhs_ptr += rhs_qs4cx_stride;
+      }
+
+      // Get the RHS scale
+      const float rhs_scale = rhs_scales_f32[n_idx];
+
+      float main_acc = iacc * rhs_scale;
+
+      main_acc = main_acc * lhs_scale;
+
+      // Clamp (min-max) operation
+      main_acc = std::max(main_acc, scalar_min);
+      main_acc = std::min(main_acc, scalar_max);
+
+      dst_f32[0] = main_acc;
+      dst_f32 += 1;
+    }
+  }
+};
+
+void
+ref_matmul_f32_qa8dx_qs4cx(size_t m, size_t n, size_t k, rhs_format format,
+                           const int8_t *lhs_qa8dx, const uint8_t *rhs_qs4cx,
+                           const float *rhs_scales_f32, float *dst_f32,
+                           float scalar_min, float scalar_max) {
+  const size_t lhs_stride =
+    k * sizeof(int8_t) + sizeof(float) + sizeof(int32_t);
+
+  if (rhs_format::nxk == format) {
+    ref_matmul_mxn_mxk_nxk_f32_qa8dx_qs4cx(m, n, k, lhs_qa8dx, rhs_qs4cx,
+                                           rhs_scales_f32, dst_f32, scalar_min,
+                                           scalar_max);
+  } else {
+    ref_matmul_mxn_mxk_kxn_f32_qa8dx_qs4cx(m, n, k, lhs_qa8dx, rhs_qs4cx,
+                                           rhs_scales_f32, dst_f32, scalar_min,
+                                           scalar_max);
+  }
+};

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.cpp
@@ -99,7 +99,7 @@ void ref_quant_qa8dx_f32(size_t m, size_t k, const float *lhs_f32,
       const float src0_0 = src_ptr[k_idx];
 
       // Scale the values
-      int32_t v0_s32 = (int32_t)(round(src0_0 * scale0));
+      int32_t v0_s32 = (int32_t)(std::round(src0_0 * scale0));
 
       v0_s32 = v0_s32 + nudged_zero_point0;
       v0_s32 = std::max(v0_s32, static_cast<int32_t>(INT8_MIN));
@@ -148,7 +148,7 @@ static void quant_nxk_qs4cx_f32(size_t n, size_t k, const float *rhs_f32,
       const float src0_0 = src_ptr[k_idx];
 
       // Scale the values
-      int32_t v0_s32 = (int32_t)(round(src0_0 * scale0));
+      int32_t v0_s32 = (int32_t)(std::round(src0_0 * scale0));
 
       // Maximum/minimum int4 values
       v0_s32 = std::max(v0_s32, static_cast<int32_t>(INT4_MIN));
@@ -209,7 +209,7 @@ static void quant_kxn_qs4cx_f32(size_t n, size_t k, const float *rhs_f32,
       const float src0_0 = src_ptr[k_idx];
 
       // Scale the values
-      int32_t v0_s32 = (int32_t)(round(src0_0 * scale0));
+      int32_t v0_s32 = (int32_t)(std::round(src0_0 * scale0));
 
       // Maximum/minimum int4 values
       v0_s32 = std::max(v0_s32, static_cast<int32_t>(INT4_MIN));

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.cpp
@@ -7,9 +7,10 @@
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Sungsik Kong
  *
- * @brief  Modified computational backend components of matmul_clamp_f32_qai8dxp_qsi4cxp.
- *         Portions of this file are derived from Arm Limited code licensed
- *         under the Apache License, Version 2.0, with modifications
+ * @brief  Modified computational backend components of
+ * matmul_clamp_f32_qai8dxp_qsi4cxp.cpp Portions of this file are derived from
+ * Arm Limited code licensed under the Apache License, Version 2.0, with
+ * modifications
  *
  * @note   Licensed under the Apache License, Version 2.0 (the "License");
  *         you may not use this file except in compliance with the License.
@@ -36,12 +37,10 @@
 #define INT4_MIN (-8)
 #define INT4_MAX (7)
 
-
-
 static size_t roundup(size_t a, size_t b) { return ((a + b - 1) / b) * b; }
 
 void ref_quant_qa8dx_f32(size_t m, size_t k, const float *lhs_f32,
-                                int8_t *lhs_qa8dx) {
+                         int8_t *lhs_qa8dx) {
   const size_t dst_stride =
     (k * sizeof(int8_t) + sizeof(float) + sizeof(int32_t));
 
@@ -237,8 +236,8 @@ static void quant_kxn_qs4cx_f32(size_t n, size_t k, const float *rhs_f32,
 };
 
 void quant_qs4cx_f32(size_t n, size_t k, rhs_format format,
-                            const float *rhs_f32, uint8_t *rhs_qs4cx,
-                            float *rhs_scales_f32) {
+                     const float *rhs_f32, uint8_t *rhs_qs4cx,
+                     float *rhs_scales_f32) {
   if (rhs_format::nxk == format) {
     quant_nxk_qs4cx_f32(n, k, rhs_f32, rhs_qs4cx, rhs_scales_f32);
   } else {
@@ -382,11 +381,11 @@ static void ref_matmul_mxn_mxk_kxn_f32_qa8dx_qs4cx( // noTrans
   }
 };
 
-void
-ref_matmul_f32_qa8dx_qs4cx(size_t m, size_t n, size_t k, rhs_format format,
-                           const int8_t *lhs_qa8dx, const uint8_t *rhs_qs4cx,
-                           const float *rhs_scales_f32, float *dst_f32,
-                           float scalar_min, float scalar_max) {
+void ref_matmul_f32_qa8dx_qs4cx(size_t m, size_t n, size_t k, rhs_format format,
+                                const int8_t *lhs_qa8dx,
+                                const uint8_t *rhs_qs4cx,
+                                const float *rhs_scales_f32, float *dst_f32,
+                                float scalar_min, float scalar_max) {
   const size_t lhs_stride =
     k * sizeof(int8_t) + sizeof(float) + sizeof(int32_t);
 

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.h
@@ -33,13 +33,50 @@ enum class rhs_format {
   kxn,
 };
 
+/**
+ * @brief qs4cx quantization of (n*k) matrix. Typically a weight quantization,
+ * and generally regard the weight is already transposed, and quantize it as it
+ * is. qs4cx refers to quantized symmetric 4-bit quantization of channelwise x
+ * groups.
+ *
+ * @param n N length of the matrix
+ * @param k K length of the matrix
+ * @param format whether rhs matrix is transpoed or not
+ * @param rhs_f32 matrix data before quantization to load
+ * @param rhs_qs4cx matrix data after quantization to store
+ * @param rhs_scales_f32  matrix quant scale after quantization to store
+ */
 void quant_qs4cx_f32(size_t n, size_t k, rhs_format format,
                      const float *rhs_f32, uint8_t *rhs_qs4cx,
                      float *rhs_scales_f32);
-
+/**
+ * @brief qa8dx quantization of (m*k) matrix. Typically a runtime activation
+ * quantization. qa8dx refer to quantized asymmetric 8bit per-dimension
+ * quantization
+ *
+ * @param m M length of the matrix
+ * @param k K length of the matrix
+ * @param lhs_f32 matrix data before quantization to load
+ * @param lhs_qa8dx matrix data after quantization to store
+ */
 void ref_quant_qa8dx_f32(size_t m, size_t k, const float *lhs_f32,
                          int8_t *lhs_qa8dx);
 
+/**
+ * @brief GEMM of qai8dxp runtime-quantized activation and offline qs4cx
+ * quantized weight
+ *
+ * @param m M length of the matrix
+ * @param n N length of the matrix
+ * @param k K length of the matrix
+ * @param format whether rhs matrix is transpoed or not
+ * @param lhs_qa8dx activation
+ * @param rhs_qs4cx weight
+ * @param rhs_scales_f32 weight scale factor
+ * @param dst_f32 dst matrix
+ * @param scalar_min lower bound to clamp
+ * @param scalar_max upper bound to clamp
+ */
 void ref_matmul_f32_qa8dx_qs4cx(size_t m, size_t n, size_t k, rhs_format format,
                                 const int8_t *lhs_qa8dx,
                                 const uint8_t *rhs_qs4cx,

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.h
@@ -1,18 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
  * Copyright (C) 2024 Arm Limited and/or its affiliates
- * Copyright (C) 2024 Sungsik Kong <ss.kong@samsung.com>
  *
  * @file   fallback_kleidiai.h
  * @date   15 September 2025
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Sungsik Kong
- *
  * @brief  Modified computational backend components of
  * matmul_clamp_f32_qai8dxp_qsi4cxp. Portions of this file are derived from Arm
  * Limited code licensed under the Apache License, Version 2.0, with
  * modifications
- *
  * @note   Licensed under the Apache License, Version 2.0 (the "License");
  *         you may not use this file except in compliance with the License.
  *         You may obtain a copy of the License at

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.h
@@ -8,9 +8,10 @@
  * @see    https://github.com/nnstreamer/nntrainer
  * @author Sungsik Kong
  *
- * @brief  Modified computational backend components of matmul_clamp_f32_qai8dxp_qsi4cxp.
- *         Portions of this file are derived from Arm Limited code licensed
- *         under the Apache License, Version 2.0, with modifications
+ * @brief  Modified computational backend components of
+ * matmul_clamp_f32_qai8dxp_qsi4cxp. Portions of this file are derived from Arm
+ * Limited code licensed under the Apache License, Version 2.0, with
+ * modifications
  *
  * @note   Licensed under the Apache License, Version 2.0 (the "License");
  *         you may not use this file except in compliance with the License.

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.h
@@ -5,11 +5,11 @@
  * @file   fallback_kleidiai.h
  * @date   15 September 2025
  * @see    https://github.com/nnstreamer/nntrainer
- * @author Sungsik Kong
- * @brief  Modified computational backend components of
- * matmul_clamp_f32_qai8dxp_qsi4cxp. Portions of this file are derived from Arm
- * Limited code licensed under the Apache License, Version 2.0, with
- * modifications
+ * @author Sungsik Kong <ss.kong@samsung.com>
+ * @brief  Modified computational backend components of kleidiai. Portions of
+ * this file are derived from Arm Limited code licensed under the Apache
+ * License, Version 2.0, with modifications
+ * @bug    No known bugs except for NYI items
  * @note   Licensed under the Apache License, Version 2.0 (the "License");
  *         you may not use this file except in compliance with the License.
  *         You may obtain a copy of the License at
@@ -19,12 +19,15 @@
  *   - [2025-09-15] Integrated and adapted Arm-provided code into
  *     nntrainer CPU backend
  *
- * @bug    No known bugs except for NYI items
  */
 
 #include <cstdint>
 #include <stddef.h>
 
+/**
+ * @brief rhs transpose indicator
+ *
+ */
 enum class rhs_format {
   nxk,
   kxn,

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_kleidiai.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Arm Limited and/or its affiliates
+ * Copyright (C) 2024 Sungsik Kong <ss.kong@samsung.com>
+ *
+ * @file   fallback_kleidiai.h
+ * @date   15 September 2025
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Sungsik Kong
+ *
+ * @brief  Modified computational backend components of matmul_clamp_f32_qai8dxp_qsi4cxp.
+ *         Portions of this file are derived from Arm Limited code licensed
+ *         under the Apache License, Version 2.0, with modifications
+ *
+ * @note   Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *             http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @modifications
+ *   - [2025-09-15] Integrated and adapted Arm-provided code into
+ *     nntrainer CPU backend
+ *
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <cstdint>
+#include <stddef.h>
+
+enum class rhs_format {
+  nxk,
+  kxn,
+};
+
+void quant_qs4cx_f32(size_t n, size_t k, rhs_format format,
+                     const float *rhs_f32, uint8_t *rhs_qs4cx,
+                     float *rhs_scales_f32);
+
+void ref_quant_qa8dx_f32(size_t m, size_t k, const float *lhs_f32,
+                         int8_t *lhs_qa8dx);
+
+void ref_matmul_f32_qa8dx_qs4cx(size_t m, size_t n, size_t k, rhs_format format,
+                                const int8_t *lhs_qa8dx,
+                                const uint8_t *rhs_qs4cx,
+                                const float *rhs_scales_f32, float *dst_f32,
+                                float scalar_min, float scalar_max);

--- a/nntrainer/tensor/cpu_backend/fallback/meson.build
+++ b/nntrainer/tensor/cpu_backend/fallback/meson.build
@@ -1,5 +1,5 @@
-fallback_headers = ['fallback_internal.h']
-fallback_sources = ['fallback_internal.cpp']
+fallback_headers = ['fallback_internal.h', 'fallback_kleidiai.h']
+fallback_sources = ['fallback_internal.cpp', 'fallback_kleidiai.cpp']
 
 arch = host_machine.cpu_family()
 

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -532,4 +532,22 @@ void clamp(const float *input, float *output, size_t length, float lower_bound,
            float upper_bound) {
   nntrainer::avx2::clamp(input, output, length, lower_bound, upper_bound);
 }
+
+void nntr_quant_qs4cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                          void *rhs_native_mtx_qs4cx, void *rhs_scales_f32,
+                          bool transB) {
+  __fallback_nntr_quant_qs4cx_f32(n, k, rhs_native_mtx_f32,
+                                  rhs_native_mtx_qs4cx, rhs_scales_f32, transB);
+}
+
+template <>
+void nntr_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
+                               void *lhs_native_mtx_f32,
+                               void *rhs_native_mtx_qs4cx, void *rhs_scales_f32,
+                               float *dst_mtx_f32, bool transB,
+                               float lower_bound, float upper_bound) {
+  __fallback_nntr_gemm_qai8dxp_qsi4cxp(
+    m, n, k, lhs_native_mtx_f32, rhs_native_mtx_qs4cx, rhs_scales_f32,
+    dst_mtx_f32, transB, lower_bound, upper_bound);
+}
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1122,6 +1122,46 @@ template <typename T = float>
 void clamp(const T *input, T *output, size_t length,
            T lower_bound = std::numeric_limits<T>::lowest(),
            T upper_bound = std::numeric_limits<T>::max());
+
+/**
+ * @brief qs4cx quantization of (n*k) matrix. Typically a weight quantization,
+ * and generally regard the weight is already transposed, and quantize it as it
+ * is. qs4cx refers to quantized symmetric 4-bit quantization of channelwise x
+ * groups.
+ *
+ * @param n N length of the matrix
+ * @param k K length of the matrix
+ * @param rhs_native_mtx_f32 matrix data before quantization to load
+ * @param rhs_native_mtx_qs4cx matrix data after quantization to stroe
+ * @param rhs_scales_f32 matrix quant scale after quantization to stroe
+ * @param transB
+ */
+void nntr_quant_qs4cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,
+                          void *rhs_native_mtx_qs4cx, void *rhs_scales_f32,
+                          bool transB = true);
+/**
+ * @brief GEMM of qai8dxp runtime-quantized activation and offline qs4cx
+ * quantized weight
+ *
+ * @tparam T dataType of input activation and output matrices
+ * @param m M length of the matrix
+ * @param n N length of the matrix
+ * @param k K length of the matrix
+ * @param lhs_native_mtx activation (not quantized)
+ * @param rhs_native_mtx_qs4cx offline quantized weight
+ * @param rhs_scales scale factor vector of quantized weight
+ * @param dst_mtx dst matrix
+ * @param lower_bound lower bound to clamp
+ * @param upper_bound upper bound to clamp
+ * @param transB Choose weight data to be transposed or not. Default value
+ * regards the weight to be transpoed.
+ */
+template <typename T = float>
+void nntr_gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
+                               void *lhs_native_mtx, void *rhs_native_mtx_qs4cx,
+                               void *rhs_scales, T *dst_mtx, bool transB = true,
+                               T lower_bound = std::numeric_limits<T>::lowest(),
+                               T upper_bound = std::numeric_limits<T>::max());
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __x86_COMPUTE_BACKEND_H__ */

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -595,6 +595,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/tensor_wrap_specs.h
 %{_includedir}/nntrainer/cpu_backend.h
 %{_includedir}/nntrainer/fallback_internal.h
+%{_includedir}/nntrainer/fallback_kleidiai.h
 %if 0%{?use_cblas}
 %{_includedir}/nntrainer/cblas_interface.h
 %endif

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -1209,10 +1209,12 @@ float test_gemm_qai8dxp_qsi4cxp(const uint32_t M, const uint32_t K,
                                 std::vector<float> &ref_dst, bool transB = true,
                                 bool print = false) {
   // Step1. Set qai8dxp_qsi4cxp quant test components
-  const size_t lhs_ref_size_qa8dx = M * (K + sizeof(int32_t) + sizeof(float));
+  const size_t lhs_ref_size_qa8dx =
+    static_cast<size_t>(M) * (K + sizeof(int32_t) + sizeof(float));
   const size_t rhs_native_size_qs4cx =
-    transB ? N * (((K + 2 - 1) / 2) * 2 / 2) * sizeof(uint8_t)
-           : K * (((N + 2 - 1) / 2) * 2 / 2) * sizeof(uint8_t);
+    transB
+      ? static_cast<size_t>(N) * (((K + 2 - 1) / 2) * 2 / 2) * sizeof(uint8_t)
+      : static_cast<size_t>(K) * (((N + 2 - 1) / 2) * 2 / 2) * sizeof(uint8_t);
   const size_t rhs_scales_size_f32 = N * sizeof(float);
 
   uint8_t *rhs_native_mtx_qs4cx = new uint8_t[rhs_native_size_qs4cx];
@@ -1226,7 +1228,7 @@ float test_gemm_qai8dxp_qsi4cxp(const uint32_t M, const uint32_t K,
 
   // Step3. Run GEMM! (Online activation quantization + kernel routine + return
   // float)
-  std::vector<float> dst(M * N);
+  std::vector<float> dst(static_cast<size_t>(M) * N);
   auto t1 = high_resolution_clock::now();
   // #### MAIN TESTED METHOD ####
   nntrainer::nntr_gemm_qai8dxp_qsi4cxp(
@@ -1262,9 +1264,11 @@ static void run_qai8dxp_qsi4cxp_test(const uint32_t M, const uint32_t K,
   ///@note A(sizez, sizex) * W.T(sizey, sizex) = (sizez, sizey)
 
   ///@note q4_K GEMM is a Row-Major, transB GEMM
-  std::vector<float> activation = generate_random_vector<float>(M * K);
-  std::vector<float> weight = generate_random_vector<float>(N * K);
-  std::vector<float> ref_dst(M * N);
+  std::vector<float> activation =
+    generate_random_vector<float>(static_cast<std::size_t>(M) * K);
+  std::vector<float> weight =
+    generate_random_vector<float>(static_cast<std::size_t>(N) * K);
+  std::vector<float> ref_dst(static_cast<std::size_t>(M) * N);
 
   // GROUND TRUTH TRANSB SGEMM for reference
   auto t1 = high_resolution_clock::now();
@@ -1287,7 +1291,7 @@ TEST(nntrainer_cpu_backend_standalone, qai8dxp_qsi4cxp_3072x768x1024) {
   const unsigned int N = 1024;
   float qai8dxp_qsi4cxp_q4_0_mse;
   constexpr float eps = 1e-5;
-  run_qai8dxp_qsi4cxp_test(M, K, N, qai8dxp_qsi4cxp_q4_0_mse, true, true);
+  run_qai8dxp_qsi4cxp_test(M, K, N, qai8dxp_qsi4cxp_q4_0_mse, true, false);
   ASSERT_LE(qai8dxp_qsi4cxp_q4_0_mse, eps * M * K * N);
 }
 


### PR DESCRIPTION
## Dependency of the PR
- None

## Commits to be reviewed in this PR

1. 0efcd42573b2393a4aafccefcfdb663df425ab3a
- Introduce reference functions from kleidiai (Apache 2.0) from ARM. I went through internal discussions with internal Open Source License Team, but let me know if there is anything illegal or harm the project LICENSE.
- Adapt with nntrainer's format, and verify with unittest.

2. b1746376d7fe71aa834319e43963d4e6eec3e30a
- Expand 1 to other backend's candidate.

## Note to understand this GEMM function
- `qai8dxp` : quantized asymmetric integer 8bit per-dimenstion packed
- `qsi4cxp` : quantized symmetric integer 4bit per-channel packed
- `qs4cx_f32` : `qs4cx` quantization from `f32` 
- This commit introduces a function that do GEMM of `qai8dxp` activation and `qsi4cxp` weight, for BOTH rhs weight transposed and non-transposed.
- activation will be runtime-quantized on the fly, and the kernel expects the weights to be offline quantized.
- SIMD-optimized functions will be introduced later on.

## Accuracy Test Result
With  `[ RUN      ] nntrainer_cpu_backend_standalone.qai8dxp_qsi4cxp_3072x8192x8192`,

```bash
[INFO] gemm_qai8dxp_qsi4cxp
[INFO]            MSE: 3.83836, COS_SIM: 0.998882, MAX_DIFFER: 20.0891, SUM: 8.54693e+06, SUM_GT: 8.59079e+06
```
Meanwhile, for ggml-based  4bit GEMMs:
```bash
[INFO] gemm_q4_0
[INFO]            MSE: 3.69726, COS_SIM: 0.998941, MAX_DIFFER: 31.5132, SUM: 8.5004e+06, SUM_GT: 8.59079e+06
[INFO] gemm_q4_K
[INFO]            MSE: 2.59339, COS_SIM: 0.999251, MAX_DIFFER: 9.64274, SUM: 8.57131e+06, SUM_GT: 8.59079e+06
```

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: skykongkong8 <ss.kong@samsung.com>