### PR TITLE
[CausalLM] Sync gpt-oss with kv-cache-update

### DIFF
--- a/Applications/CausalLM/layers/gpt_oss_moe_layer.cpp
+++ b/Applications/CausalLM/layers/gpt_oss_moe_layer.cpp
@@ -457,12 +457,6 @@ inline void GptOssMoELayer::compute_expert_forward_no_critical(
 void GptOssMoELayer::incremental_forwarding(nntrainer::RunLayerContext &context,
                                             unsigned int from, unsigned int to,
                                             bool training) {
-  if (from) {
-    NNTR_THROW_IF(to - from != 1, std::invalid_argument)
-      << "incremental step size is not 1";
-    from = 0;
-    to = 1;
-  }
 
   nntrainer::Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
   nntrainer::Tensor &output_ = context.getOutput(SINGLE_INOUT_IDX);

--- a/Applications/CausalLM/layers/gpt_oss_moe_layer_cached.cpp
+++ b/Applications/CausalLM/layers/gpt_oss_moe_layer_cached.cpp
@@ -199,12 +199,6 @@ void CachedSlimGptOssMoELayer::forwarding(nntrainer::RunLayerContext &context,
 void CachedSlimGptOssMoELayer::incremental_forwarding(
   nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
   bool training) {
-  if (from) {
-    NNTR_THROW_IF(to - from != 1, std::invalid_argument)
-      << "incremental step size is not 1";
-    from = 0;
-    to = 1;
-  }
 #ifdef DEBUG
   auto t1 = high_resolution_clock::now();
 #endif
@@ -384,7 +378,7 @@ void CachedSlimGptOssMoELayer::incremental_forwarding(
 
 // Evict experts
 #pragma omp parallel
-    while (loaded_expert_deque.size() > 8) {
+    while (loaded_expert_deque.size() > 16) {
       int target_idx;
       {
         std::lock_guard<std::mutex> lock(cache_mutex);

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -603,9 +603,9 @@ void MHACoreLayer::one_batch_incremental_forwarding(
 
   softmax_triangle(out_, to - from, num_heads_Q, from, pool, sink_step);
 
-  compute_fp16vcache_transposed(out_, b_cached_value, attention_output_step, to,
-                                num_heads_KV, gqa_size, head_dim,
-                                (from) ? false : true, pool);
+  compute_fp16vcache_transposed(out_, b_cached_value, attention_output_step,
+                                from, num_heads_KV, gqa_size, head_dim, to,
+                                pool);
 }
 
 /************************************************************** */


### PR DESCRIPTION

## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] Sync gpt-oss with kv-cache-update</summary><br />
- This patch updates gpt-oss-related operations.
- This patch synchronizes the operation of kv-cache save/loading in `2cd6b`.
- remove if(from) branch in incremental_forwarding (layer)
- Update mha_core layer (function prototype is updated!)

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

### Summary

- This patch updates gpt-oss-related operations.
- This patch synchronizes the operation of kv-cache save/loading in `2cd6b`.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
