### PR TITLE
[CI] Reduce unittest matrix size

### DIFF
--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -459,10 +459,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_256x1024x512) {
   ASSERT_LE(q6_k_mse, q4_k_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x3072x3072) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x512x512) {
   const unsigned int M = 457;
-  const unsigned int K = 3072;
-  const unsigned int N = 3072;
+  const unsigned int K = 512;
+  const unsigned int N = 512;
   float q4_0_mse, q4_k_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
@@ -471,10 +471,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_457x3072x3072) {
   ASSERT_LE(q6_k_mse, q4_k_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x3072x3072) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x512x512) {
   const unsigned int M = 458;
-  const unsigned int K = 3072;
-  const unsigned int N = 3072;
+  const unsigned int K = 512;
+  const unsigned int N = 512;
   float q4_0_mse, q4_k_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
@@ -483,10 +483,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_458x3072x3072) {
   ASSERT_LE(q6_k_mse, q4_k_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x3072x3072) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x512x512) {
   const unsigned int M = 459;
-  const unsigned int K = 3072;
-  const unsigned int N = 3072;
+  const unsigned int K = 512;
+  const unsigned int N = 512;
   float q4_0_mse, q4_k_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
@@ -495,10 +495,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMM_459x3072x3072) {
   ASSERT_LE(q6_k_mse, q4_k_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x3072x3072) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMM_1024x512x512) {
   const unsigned int M = 1024;
-  const unsigned int K = 3072;
-  const unsigned int N = 3072;
+  const unsigned int K = 512;
+  const unsigned int N = 512;
   float q4_0_mse, q4_k_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);
@@ -519,10 +519,10 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x768x1024) {
   ASSERT_LE(q6_k_mse, q4_k_mse);
 }
 
-TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x3072x3072) {
+TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x512x512) {
   const unsigned int M = 1;
-  const unsigned int K = 3072;
-  const unsigned int N = 3072;
+  const unsigned int K = 512;
+  const unsigned int N = 512;
   float q4_0_mse, q4_k_mse, q6_k_mse;
   constexpr float eps = 1e-5;
   run_quant_test(M, K, N, q4_0_mse, q4_k_mse, q6_k_mse, false);


### PR DESCRIPTION

## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CI] Reduce unittest matrix size</summary><br />

- This patch aims to fix #3492.
- In the previous version, the unittest was disabled in the CI (due to its enable-ggml option was false by default)
- In the current main, all of the unittest for cpu_backend runs automatically, cuasing timeout with large MM size.
- This patch aims to reduce the size of matrix causing the timeout issue.


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


### Summary

- This patch aims to fix #3492.
- In the previous version, the unittest was disabled in the CI (due to its enable-ggml option was false by default)
- In the current main, all of the unittest for cpu_backend runs automatically, cuasing timeout with large MM size.



Before
```
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMM_457x3072x3072
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMM_457x3072x3072 (9767 ms)
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMM_458x3072x3072
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMM_458x3072x3072 (7601 ms)
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMM_459x3072x3072
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMM_459x3072x3072 (6508 ms)
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMM_1024x3072x3072
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMM_1024x3072x3072 (6604 ms)
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMV_1x768x1024
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMV_1x768x1024 (423 ms)
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMV_1x3072x3072
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMV_1x3072x3072 (4654 ms)
```

After
```
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMM_256x1024x512
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMM_256x1024x512 (797 ms)
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMM_457x512x512
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMM_457x512x512 (551 ms)
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMM_458x512x512
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMM_458x512x512 (467 ms)
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMM_459x512x512
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMM_459x512x512 (406 ms)
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMM_1024x512x512
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMM_1024x512x512 (604 ms)
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMV_1x768x1024
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMV_1x768x1024 (826 ms)
[ RUN      ] nntrainer_cpu_backend_standalone.quant_GEMV_1x512x512
[       OK ] nntrainer_cpu_backend_standalone.quant_GEMV_1x512x512 (287 ms)
```

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
