### PR TITLE
[ ruy ] Set ruy usage to false by default

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -91,10 +91,3 @@ Multi-Arch: same
 Depends: nnstreamer-nntrainer-trainer, ${shlibs:Depends}, ${misc:Depends}
 Description: Development package for nntrainer tensor trainer
  This is a developement package of nntrainer's tensor trainer.
-
-Package: ruy
-Architecture: any
-Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: Ruy package
- This is a ruy package for NNTrainer.

--- a/debian/rules
+++ b/debian/rules
@@ -31,7 +31,6 @@ override_dh_auto_clean:
 	rm -rf build
 
 override_dh_auto_configure:
-	tar -xf packaging/ruy.tar.gz -C subprojects
 	mkdir -p build
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc \
 		--libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nntrainer/bin \
@@ -55,14 +54,6 @@ override_dh_auto_test:
 
 override_dh_auto_install:
 	DESTDIR=$(CURDIR)/debian/tmp ninja -C build install
-
-override_dh_install:
-	dh_install --sourcedir=debian/tmp
-	if [ "$(DEB_HOST_ARCH)" = "amd64" ]; then \
-		dh_install /usr/bin/cpuid_dump; \
-	else \
-		echo "Skipping cpuid_dump on non-x86_64 architecture"; \
-	fi
 
 override_dh_missing:
 	dh_missing --fail-missing

--- a/debian/ruy.install
+++ b/debian/ruy.install
@@ -1,6 +1,0 @@
-/usr/lib/*/libruy*.a
-/usr/lib/*/libclog.a
-/usr/lib/*/libcpuinfo.a
-/usr/bin/cache_info
-/usr/bin/cpu_info
-/usr/bin/isa_info

--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -52,35 +52,6 @@ LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 
 include $(BUILD_STATIC_LIBRARY)
 
-include $(CLEAR_VARS)
-
-LOCAL_MODULE        := ruy
-LOCAL_SRC_FILES     := @MESON_RUY_ROOT@/ruy/ctx.cc \
-                       @MESON_RUY_ROOT@/ruy/context.cc \
-                       @MESON_RUY_ROOT@/ruy/denormal.cc \
-                       @MESON_RUY_ROOT@/ruy/kernel_arm32.cc \
-                       @MESON_RUY_ROOT@/ruy/trmul.cc \
-                       @MESON_RUY_ROOT@/ruy/tune.cc \
-                       @MESON_RUY_ROOT@/ruy/kernel_arm64.cc \
-                       @MESON_RUY_ROOT@/ruy/pack_arm.cc \
-                       @MESON_RUY_ROOT@/ruy/thread_pool.cc \
-                       @MESON_RUY_ROOT@/ruy/prepare_packed_matrices.cc \
-                       @MESON_RUY_ROOT@/ruy/frontend.cc \
-                       @MESON_RUY_ROOT@/ruy/prepacked_cache.cc \
-                       @MESON_RUY_ROOT@/ruy/apply_multiplier.cc \
-                       @MESON_RUY_ROOT@/ruy/blocking_counter.cc \
-                       @MESON_RUY_ROOT@/ruy/wait.cc \
-                       @MESON_RUY_ROOT@/ruy/pmu.cc \
-                       @MESON_RUY_ROOT@/ruy/allocator.cc \
-                       @MESON_RUY_ROOT@/ruy/block_map.cc \
-                       @MESON_RUY_ROOT@/ruy/context_get_ctx.cc \
-                       @MESON_RUY_ROOT@/ruy/cpuinfo.cc \
-                       @MESON_RUY_ROOT@/ruy/system_aligned_alloc.cc
-LOCAL_C_INCLUDES    := @MESON_RUY_ROOT@
-LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
-
-include $(BUILD_STATIC_LIBRARY)
-
 ifeq (@MESON_ENABLE_OPENCL@,1)
 include $(CLEAR_VARS)
 LOCAL_MODULE            := OpenCL
@@ -223,7 +194,7 @@ LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
 LOCAL_LDFLAGS 	    += "-Wl,-z,max-page-size=16384"
 
 @MESON_OPENCL_SHARED_LIBS@
-LOCAL_STATIC_LIBRARIES += iniparser openblas ruy @MESON_OPENCL_STATIC_LIBS@
+LOCAL_STATIC_LIBRARIES += iniparser openblas @MESON_OPENCL_STATIC_LIBS@
 
 ifeq ($(MESON_HAS_TFLITE), 1)
   LOCAL_STATIC_LIBRARIES += tensorflow-lite

--- a/jni/meson.build
+++ b/jni/meson.build
@@ -37,8 +37,10 @@ if iniparser_dep.found()
   and_conf.set('MESON_INIPARSER_ROOT', iniparser_root)
 endif
 
-if ruy_dep.found()
-  and_conf.set('MESON_RUY_ROOT', ruy_root)
+if get_option('enable-ruy')
+  if ruy_dep.found()
+    and_conf.set('MESON_RUY_ROOT', ruy_root)
+  endif
 endif
 
 if get_option('enable-opencl')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -48,7 +48,7 @@ option('enable-opencl', type: 'boolean', value: false)
 option('enable-biqgemm', type: 'boolean', value: false)
 option('biqgemm-path', type: 'string', value: '../BiQGEMM')
 option('enable-benchmarks', type: 'boolean', value : false)
-option('enable-ruy', type: 'boolean', value: true)
+option('enable-ruy', type: 'boolean', value: false)
 option('ggml-thread-backend', type: 'string', value: 'mixed')
 
 # ml-api dependency (to enable, install capi-inference from github.com/nnstreamer/api )

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -4,7 +4,7 @@
 %define         nnstreamer_trainer 1
 %define         nnstreamer_subplugin_path lib/nnstreamer
 %define         use_gym 0
-%define         use_ruy 1
+%define         use_ruy 0
 %define         use_biqgemm 0
 %define         support_ccapi 1
 %define         support_nnstreamer_backbone 1

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -47,12 +47,6 @@ LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/builddir/jni/$(TARGET_ARCH_ABI)/libccapi-nn
 
 include $(PREBUILT_SHARED_LIBRARY)
 
-include $(CLEAR_VARS)
-
-LOCAL_MODULE := ruy-nntrainer
-LOCAL_SRC_FILES := $(NNTRAINER_ROOT)/builddir/obj/local/$(TARGET_ARCH_ABI)/libruy.a
-
-include $(PREBUILT_STATIC_LIBRARY)
 
 ifeq ( $(MESON_ENABLE_OPENCL), 1)
 include $(CLEAR_VARS)
@@ -109,7 +103,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -126,7 +120,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -143,7 +137,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -160,7 +154,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -177,7 +171,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -194,7 +188,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -211,7 +205,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -228,7 +222,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -245,7 +239,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -262,7 +256,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 
@@ -279,7 +273,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -295,7 +289,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -311,7 +305,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_SHARED_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_SHARED_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -327,7 +321,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -343,7 +337,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -359,7 +353,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -375,7 +369,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -393,7 +387,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -411,7 +405,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -431,7 +425,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -455,7 +449,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -518,7 +512,7 @@ endif
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 ifeq ( $(MESON_ENABLE_OPENCL), 1)
@@ -535,7 +529,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -551,8 +545,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer
-include $(BUILD_EXECUTABLE)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util include $(BUILD_EXECUTABLE)
 endif
 
 include $(CLEAR_VARS)
@@ -568,7 +561,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
@@ -584,7 +577,7 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)
 
 # unittest_ccapi
@@ -601,5 +594,5 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer $(MESON_OPENCL_SHARED_LIBS)
-LOCAL_STATIC_LIBRARIES := googletest_main test_util ruy-nntrainer $(MESON_OPENCL_STATIC_LIBS)
+LOCAL_STATIC_LIBRARIES := googletest_main test_util $(MESON_OPENCL_STATIC_LIBS)
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
See also : #3512

- nntrainer never have been using ruy in any feature or module. Never used at all, even once.
- it is highly-unlikely to use ruy in the near, or even long-term future.
- Remove ruy from android build, and let all the default options for ruy to false.

**Self evaluation:**
1. Build test:     [X]Passed [ ]Failed [ ]Skipped
2. Run test:     [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: skykongkong8 <ss.kong@samsung.com>