### PR TITLE
[mmap][MemoryLeak] Deactivate mapped_ptr at ~Tensor()

### DIFF
--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -447,7 +447,11 @@ public:
   /**
    * @brief Basic Destructor
    */
-  ~Tensor() = default;
+  ~Tensor() noexcept {
+    if (mapped_ptr != nullptr) {
+      deactivate();
+    }
+  };
 
   /**
    *  @brief  Copy constructor of Tensor.


### PR DESCRIPTION
## Dependency of the PR
- None

## Commits to be reviewed in this PR

<details><summary>Deactivate mmaped_ptr at ~Tensor()</summary><br />

Deactivate mmaped_ptr at ~Tensor()
- mmaped ptr will not free at ~Tensor()

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Donghak PARK <donghak.park@samsung.com>

</details>

### Summary

- deactivate mmaped_ptr at ~Tensor()
### Ref
```
 ┌───────────────────── 0xFFFFFFFF ──────────────────────────┐  (high addresses)  
 │  …                     (rest of the virtual address space)│  
 │  ──────────────────────────────────────────────────────── │  
 │  Stack (↑)               ← grows downward (↓)             │  
 │  ──────────────────────────────────────────────────────── │  
 │  … (stack‑guard page, unmapped guard region)              │  
 │  ──────────────────────────────────────────────────────── │  
 │  Heap (←)                ← grows upward (↑)               │  
 │      (traditional brk/sbrk‑expanded heap)                 │  
 │  ──────────────────────────────────────────────────────── │  
 │  mmap area (anonymous or file‑backed mappings)            │  
 │      → regions created explicitly with `mmap()`           │  
 │  ──────────────────────────────────────────────────────── │  
 │  .bss / .data / .rodata / Text segment (code)             │  
 │  ──────────────────────────────────────────────────────── │  
 │  … (program entry point, ELF headers, etc.)               │  
 └───────────────────── 0x00000000 ──────────────────────────┘  (low addresses)  
```
Signed-off-by: Donghak PARK <donghak.park@samsung.com>
