### PR TITLE
Make dispatching readable

### DIFF
--- a/nntrainer/layers/cl_layers/concat_cl.cpp
+++ b/nntrainer/layers/cl_layers/concat_cl.cpp
@@ -324,12 +324,16 @@ void ConcatLayerCl::concat_cl_axis3(const float *matAdata,
       break;
     }
 
-    const int work_groups_count[3] = {dim, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
+    opencl::DispatchSize sizes{};
+    sizes.local_x = 1;
+    sizes.local_y = 1;
+    sizes.local_z = 1;
+    sizes.global_x = dim;
+    sizes.global_y = 1;
+    sizes.global_z = 1;
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
-      kernel_concat_ptr, work_groups_count, work_group_size);
+      kernel_concat_ptr, sizes);
     if (!result) {
       break;
     }
@@ -442,12 +446,16 @@ void ConcatLayerCl::concat_cl_axis2(const float *matAdata,
       break;
     }
 
-    const int work_groups_count[3] = {dim, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
+    opencl::DispatchSize sizes{};
+    sizes.local_x = 1;
+    sizes.local_y = 1;
+    sizes.local_z = 1;
+    sizes.global_x = dim;
+    sizes.global_y = 1;
+    sizes.global_z = 1;
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
-      kernel_concat_ptr, work_groups_count, work_group_size);
+      kernel_concat_ptr, sizes);
     if (!result) {
       break;
     }
@@ -560,12 +568,16 @@ void ConcatLayerCl::concat_cl_axis1(const float *matAdata,
       break;
     }
 
-    const int work_groups_count[3] = {dim, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
+    opencl::DispatchSize sizes{};
+    sizes.local_x = 1;
+    sizes.local_y = 1;
+    sizes.local_z = 1;
+    sizes.global_x = dim;
+    sizes.global_y = 1;
+    sizes.global_z = 1;
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
-      kernel_concat_ptr, work_groups_count, work_group_size);
+      kernel_concat_ptr, sizes);
     if (!result) {
       break;
     }
@@ -680,12 +692,16 @@ void ConcatLayerCl::concat_cl_axis3_fp16(const _FP16 *matAdata,
       break;
     }
 
-    const int work_groups_count[3] = {dim, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
+    opencl::DispatchSize sizes{};
+    sizes.local_x = 1;
+    sizes.local_y = 1;
+    sizes.local_z = 1;
+    sizes.global_x = dim;
+    sizes.global_y = 1;
+    sizes.global_z = 1;
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
-      kernel_concat_ptr, work_groups_count, work_group_size);
+      kernel_concat_ptr, sizes);
     if (!result) {
       break;
     }
@@ -797,12 +813,16 @@ void ConcatLayerCl::concat_cl_axis2_fp16(const _FP16 *matAdata,
       break;
     }
 
-    const int work_groups_count[3] = {dim, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
+    opencl::DispatchSize sizes{};
+    sizes.local_x = 1;
+    sizes.local_y = 1;
+    sizes.local_z = 1;
+    sizes.global_x = dim;
+    sizes.global_y = 1;
+    sizes.global_z = 1;
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
-      kernel_concat_ptr, work_groups_count, work_group_size);
+      kernel_concat_ptr, sizes);
     if (!result) {
       break;
     }
@@ -916,12 +936,16 @@ void ConcatLayerCl::concat_cl_axis1_fp16(const _FP16 *matAdata,
       break;
     }
 
-    const int work_groups_count[3] = {dim, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
+    opencl::DispatchSize sizes{};
+    sizes.local_x = 1;
+    sizes.local_y = 1;
+    sizes.local_z = 1;
+    sizes.global_x = dim;
+    sizes.global_y = 1;
+    sizes.global_z = 1;
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
-      kernel_concat_ptr, work_groups_count, work_group_size);
+      kernel_concat_ptr, sizes);
     if (!result) {
       break;
     }

--- a/nntrainer/layers/cl_layers/reshape_cl.cpp
+++ b/nntrainer/layers/cl_layers/reshape_cl.cpp
@@ -205,14 +205,18 @@ void ReshapeLayerCl::copy_cl_fp16(const _FP16 *input, _FP16 *res,
       break;
     }
 
-    const int work_groups_count[3] = {
-      (int)(input_batch_size * input_height * input_width * input_channels), 1,
-      1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
+    auto dim = input_batch_size * input_height * input_width * input_channels;
+
+    opencl::DispatchSize sizes{};
+    sizes.local_x = 1;
+    sizes.local_y = 1;
+    sizes.local_z = 1;
+    sizes.global_x = dim;
+    sizes.global_y = 1;
+    sizes.global_z = 1;
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
-      kernel_copy_ptr, work_groups_count, work_group_size);
+      kernel_copy_ptr, sizes);
     if (!result) {
       break;
     }
@@ -291,14 +295,18 @@ void ReshapeLayerCl::scopy_cl(const float *input, float *res,
       break;
     }
 
-    const int work_groups_count[3] = {
-      (int)(input_batch_size * input_height * input_width * input_channels), 1,
-      1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {1, 1, 1}; // test-value
+    auto dim = input_batch_size * input_height * input_width * input_channels;
+
+    opencl::DispatchSize sizes{};
+    sizes.local_x = 1;
+    sizes.local_y = 1;
+    sizes.local_z = 1;
+    sizes.global_x = dim;
+    sizes.global_y = 1;
+    sizes.global_z = 1;
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
-      kernel_copy_ptr, work_groups_count, work_group_size);
+      kernel_copy_ptr, sizes);
     if (!result) {
       break;
     }

--- a/nntrainer/layers/cl_layers/rmsnorm_layer_cl.cpp
+++ b/nntrainer/layers/cl_layers/rmsnorm_layer_cl.cpp
@@ -187,12 +187,17 @@ void RMSNormLayerCl::rmsnormProcess_fp16(Tensor const &input, Tensor &result,
     if (!ret) {
       break;
     }
-    const int work_groups_count[3] = {b * c, h, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {w, 1, 1}; // test-value
+
+    opencl::DispatchSize sizes{};
+    sizes.local_x = w;
+    sizes.local_y = 1;
+    sizes.local_z = 1;
+    sizes.global_x = b * c;
+    sizes.global_y = h;
+    sizes.global_z = 1;
 
     ret = global_cl_context->command_queue_inst_.DispatchCommand(
-      kernel_rmsnorm_ptr, work_groups_count, work_group_size);
+      kernel_rmsnorm_ptr, sizes);
     if (!ret) {
       break;
     }

--- a/nntrainer/layers/cl_layers/swiglu_cl.cpp
+++ b/nntrainer/layers/cl_layers/swiglu_cl.cpp
@@ -178,12 +178,16 @@ void SwiGLULayerCl::swiglu_cl(float *matAdata, float *vecXdata, float *vecYdata,
     const bool can_use_desired = dim >= desired_local;
     const int32_t chosen_local = can_use_desired ? desired_local : dim;
 
-    const int work_groups_count[3] = {dim, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {chosen_local, 1, 1}; // test-value
+    opencl::DispatchSize sizes{};
+    sizes.local_x = chosen_local;
+    sizes.local_y = 1;
+    sizes.local_z = 1;
+    sizes.global_x = dim;
+    sizes.global_y = 1;
+    sizes.global_z = 1;
 
     if (!global_cl_context->command_queue_inst_.DispatchCommand(
-          kernel_swiglu_ptr, work_groups_count, work_group_size)) {
+          kernel_swiglu_ptr, sizes)) {
       ml_loge("Failed to run");
       break;
     }
@@ -254,12 +258,16 @@ void SwiGLULayerCl::swiglu_cl_fp16(_FP16 *matAdata, _FP16 *vecXdata,
     const bool can_use_desired = dim >= desired_local;
     const int32_t chosen_local = can_use_desired ? desired_local : dim;
 
-    const int work_groups_count[3] = {dim, 1, 1};
-    /// @todo: create a group size by device & input
-    const int work_group_size[3] = {chosen_local, 1, 1}; // test-value
+    opencl::DispatchSize sizes{};
+    sizes.local_x = chosen_local;
+    sizes.local_y = 1;
+    sizes.local_z = 1;
+    sizes.global_x = dim;
+    sizes.global_y = 1;
+    sizes.global_z = 1;
 
     result = global_cl_context->command_queue_inst_.DispatchCommand(
-      kernel_swiglu_ptr, work_groups_count, work_group_size);
+      kernel_swiglu_ptr, sizes);
     if (!result) {
       break;
     }

--- a/nntrainer/opencl/opencl_command_queue_manager.cpp
+++ b/nntrainer/opencl/opencl_command_queue_manager.cpp
@@ -324,31 +324,17 @@ bool CommandQueueManager::enqueueSVMUnmap(void *svm_ptr, cl_event *event) {
  * @brief Function to initiate execution of the command queue.
  *
  * @param kernel OpenCL kernel
- * @param work_groups_count Total number of work items that will execute the
- * kernel function
- * @param work_group_size Number of work items that make up a work group
+ * @param sizes Sizes for the dispatch
  * @param event Object that identifies this command and can be used to query
  * or wait for this command to complete
  * @return true if command queue execution is successful or false otherwise
  */
 bool CommandQueueManager::DispatchCommand(
-  Kernel kernel, const int (&work_groups_count)[3],
-  const int (&work_group_size)[3], cl_event *event,
-  std::vector<cl_event> events_to_wait) {
+  Kernel kernel, const DispatchSize &sizes, cl_event *event,
+  const std::vector<cl_event> &events_to_wait) {
 
-  // work_dim of 2 has been hardcoded, might be modified later based on
-  // requirements
-
-  // setting the local_work_size referred to as the size of the
-  // work-group
-  const size_t local[3] = {static_cast<size_t>(work_group_size[0]),
-                           static_cast<size_t>(work_group_size[1]),
-                           static_cast<size_t>(work_group_size[2])};
-
-  // setting the global_work_size that describe the number of global work-items
-  const size_t global[3] = {static_cast<size_t>(work_groups_count[0]),
-                            static_cast<size_t>(work_groups_count[1]),
-                            static_cast<size_t>(work_groups_count[2])};
+  const size_t local[3] = {sizes.local_x, sizes.local_y, sizes.local_z};
+  const size_t global[3] = {sizes.global_x, sizes.global_y, sizes.global_z};
 
   cl_kernel kernel_ = kernel.GetKernel();
 
@@ -365,24 +351,21 @@ bool CommandQueueManager::DispatchCommand(
   return true;
 }
 
+/**
+ * @brief Overloaded function to initiate execution of the command queue.
+ *
+ * @param kernel_ptr reference of OpenCL kernel shared_ptr
+ * @param sizes Sizes for the dispatch
+ * @param event Object that identifies this command and can be used to query
+ * or wait for this command to complete
+ * @return true if command queue execution is successful or false otherwise
+ */
 bool CommandQueueManager::DispatchCommand(
-  const std::shared_ptr<Kernel> &kernel_ptr, const int (&work_groups_count)[3],
-  const int (&work_group_size)[3], cl_event *event,
-  std::vector<cl_event> events_to_wait) {
+  const std::shared_ptr<Kernel> &kernel_ptr, const DispatchSize &sizes,
+  cl_event *event, const std::vector<cl_event> &events_to_wait) {
 
-  // work_dim of 2 has been hardcoded, might be modified later based on
-  // requirements
-
-  // setting the local_work_size referred to as the size of the
-  // work-group
-  const size_t local[3] = {static_cast<size_t>(work_group_size[0]),
-                           static_cast<size_t>(work_group_size[1]),
-                           static_cast<size_t>(work_group_size[2])};
-
-  // setting the global_work_size that describe the number of global work-items
-  const size_t global[3] = {static_cast<size_t>(work_groups_count[0]),
-                            static_cast<size_t>(work_groups_count[1]),
-                            static_cast<size_t>(work_groups_count[2])};
+  const size_t local[3] = {sizes.local_x, sizes.local_y, sizes.local_z};
+  const size_t global[3] = {sizes.global_x, sizes.global_y, sizes.global_z};
 
   cl_kernel kernel_ = kernel_ptr->GetKernel();
 

--- a/nntrainer/opencl/opencl_command_queue_manager.h
+++ b/nntrainer/opencl/opencl_command_queue_manager.h
@@ -22,6 +22,21 @@
 namespace nntrainer::opencl {
 
 /**
+ * @struct DispatchSize contains wrappers for managing OpenCL command
+ * queue
+ * @brief Sizes for OpenCL kernel enqueue function
+ *
+ */
+struct DispatchSize {
+  size_t local_x = 0;
+  size_t local_y = 0;
+  size_t local_z = 0;
+  size_t global_x = 0;
+  size_t global_y = 0;
+  size_t global_z = 0;
+};
+
+/**
  * @class CommandQueueManager contains wrappers for managing OpenCL command
  * queue
  * @brief OpenCL command queue wrapper
@@ -164,34 +179,27 @@ public:
    * @brief Function to initiate execution of the command queue.
    *
    * @param kernel OpenCL kernel
-   * @param work_groups_count Total number of work items that will execute the
-   * kernel function
-   * @param work_group_size Number of work items that make up a work group
+   * @param sizes Sizes for the dispatch
    * @param event Object that identifies this command and can be used to query
    * or wait for this command to complete
    * @return true if command queue execution is successful or false otherwise
    */
-  bool DispatchCommand(Kernel kernel, const int (&work_groups_count)[3],
-                       const int (&work_group_size)[3],
+  bool DispatchCommand(Kernel kernel, const DispatchSize &sizes,
                        cl_event *event = nullptr,
-                       std::vector<cl_event> events_to_wait = {});
+                       const std::vector<cl_event> &events_to_wait = {});
 
   /**
    * @brief Overloaded function to initiate execution of the command queue.
    *
    * @param kernel_ptr reference of OpenCL kernel shared_ptr
-   * @param work_groups_count Total number of work items that will execute the
-   * kernel function
-   * @param work_group_size Number of work items that make up a work group
+   * @param sizes Sizes for the dispatch
    * @param event Object that identifies this command and can be used to query
    * or wait for this command to complete
    * @return true if command queue execution is successful or false otherwise
    */
   bool DispatchCommand(const std::shared_ptr<Kernel> &kernel_ptr,
-                       const int (&work_groups_count)[3],
-                       const int (&work_group_size)[3],
-                       cl_event *event = nullptr,
-                       std::vector<cl_event> events_to_wait = {});
+                       const DispatchSize &sizes, cl_event *event = nullptr,
+                       const std::vector<cl_event> &events_to_wait = {});
 
   /**
    * @brief Get the OpenCL Command Queue object

--- a/nntrainer/tensor/cl_operations/attention_kernels_templates.h
+++ b/nntrainer/tensor/cl_operations/attention_kernels_templates.h
@@ -204,10 +204,15 @@ inline static void rotary_emb_cl_internal(
       break;
     }
 
-    const int work_groups_count[3] = {(int)batch, (int)channel, 1};
-    const int work_group_size[3] = {1, 1, 1};
-    result = cl_context->command_queue_inst_.DispatchCommand(
-      kernel, work_groups_count, work_group_size);
+    opencl::DispatchSize sizes{};
+    sizes.local_x = 1;
+    sizes.local_y = 1;
+    sizes.local_z = 1;
+    sizes.global_x = batch;
+    sizes.global_y = channel;
+    sizes.global_z = 1;
+
+    result = cl_context->command_queue_inst_.DispatchCommand(kernel, sizes);
     if (!result) {
       printf("Failed to dispatch command\n");
       break;


### PR DESCRIPTION
- Use struct with named fields instead of 2 arrays of 3 int
- This way dispatching kernels is more readable and less error prone

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: mwlasiuk <testmailsmtp12345@gmail.com>