### PR TITLE
Fix static windows build

### DIFF
--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -50,6 +50,12 @@ endif
 tokenizer_dependencies = []
 tokenizer_path = meson.current_source_dir() / 'lib' / 'libtokenizers_c.a'
 
+cpp_args = []
+
+if get_option('default_library') == 'shared'
+    cpp_args += [ '-DPLUGGABLE' ]
+endif
+
 causallm = shared_library('causallm',
     causallm_src,
     dependencies: [
@@ -63,7 +69,7 @@ causallm = shared_library('causallm',
     install: true,
     install_dir: application_install_dir,
     link_args: [tokenizer_path],
-    cpp_args: '-DPLUGGABLE'
+    cpp_args: cpp_args
 )
 
 causallm_dep = declare_dependency(

--- a/Applications/Custom/LayerPlugin/meson.build
+++ b/Applications/Custom/LayerPlugin/meson.build
@@ -1,11 +1,18 @@
 # build command for libpow_layer.so
+
+cpp_args = []
+
+if get_option('default_library') == 'shared'
+    cpp_args += [ '-DPLUGGABLE' ]
+endif
+
 pow_layer = shared_library('pow_layer',
   layer_example_pow_src,
   dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
   include_directories: layer_example_inc,
   install: true,
   install_dir: application_install_dir,
-  cpp_args: '-DPLUGGABLE'
+  cpp_args: cpp_args
 )
 
 # build command for libmae_loss_layer.so
@@ -15,7 +22,7 @@ mae_loss_layer  = shared_library('mae_loss_layer',
   include_directories: layer_example_inc,
   install: true,
   install_dir: application_install_dir,
-  cpp_args: '-DPLUGGABLE'
+  cpp_args: cpp_args
 )
 
 # build command for librnnt_loss_layer.so
@@ -25,7 +32,7 @@ rnnt_loss_layer  = shared_library('rnnt_loss_layer',
   include_directories: layer_example_inc,
   install: true,
   install_dir: application_install_dir,
-  cpp_args: '-DPLUGGABLE'
+  cpp_args: cpp_args
 )
 
 pow_layer_dep = declare_dependency(

--- a/Applications/Custom/OptimizerPlugin/meson.build
+++ b/Applications/Custom/OptimizerPlugin/meson.build
@@ -1,11 +1,18 @@
 # build command for libmomentum_optimizer.so
+
+cpp_args = []
+
+if get_option('default_library') == 'shared'
+    cpp_args += [ '-DPLUGGABLE' ]
+endif
+
 momentum_optimizer = shared_library('momentum_optimizer',
   optimizer_example_momentum_src,
   dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
   include_directories: layer_example_inc,
   install: true,
   install_dir: application_install_dir,
-  cpp_args: '-DPLUGGABLE'
+  cpp_args: cpp_args
 )
 
 momentum_optimizer_dep = declare_dependency(

--- a/Applications/LLaMA/jni/meson.build
+++ b/Applications/LLaMA/jni/meson.build
@@ -1,3 +1,9 @@
+cpp_args = []
+
+if get_option('default_library') == 'shared'
+    cpp_args += [ '-DPLUGGABLE' ]
+endif
+
 transpose_src = files('transpose_layer.cpp')
 transpose_layer = static_library('transpose',
   transpose_src,
@@ -5,7 +11,7 @@ transpose_layer = static_library('transpose',
   include_directories: include_directories('./'),
   install: true,
   install_dir: application_install_dir,
-  cpp_args: '-DPLUGGABLE'
+  cpp_args: cpp_args
 )
 transpose_dep = declare_dependency(
   link_with: transpose_layer,
@@ -25,7 +31,7 @@ rms_norm_layer = static_library('rms_norm',
   include_directories: include_directories('./'),
   install: true,
   install_dir: application_install_dir,
-  cpp_args: '-DPLUGGABLE'
+  cpp_args: cpp_args
 )
 rms_norm_dep = declare_dependency(
   link_with: rms_norm_layer,
@@ -39,7 +45,7 @@ swiglu_layer = static_library('swiglu',
   include_directories: include_directories('./'),
   install: true,
   install_dir: application_install_dir,
-  cpp_args: '-DPLUGGABLE'
+  cpp_args: cpp_args
 )
 swiglu_dep = declare_dependency(
   link_with: swiglu_layer,
@@ -53,7 +59,7 @@ rotary_emb_layer = static_library('rotary_embedding',
   include_directories: include_directories('./'),
   install: true,
   install_dir: application_install_dir,
-  cpp_args: '-DPLUGGABLE'
+  cpp_args: cpp_args
 )
 rotary_emb_dep = declare_dependency(
   link_with: rotary_emb_layer,
@@ -67,7 +73,7 @@ mha_layer = static_library('custom_multi_head_attention_layer',
   include_directories: include_directories('./'),
   install: true,
   install_dir: application_install_dir,
-  cpp_args: '-DPLUGGABLE'
+  cpp_args: cpp_args
 )
 mha_dep = declare_dependency(
   link_with: mha_layer,

--- a/Applications/YOLOv2/jni/meson.build
+++ b/Applications/YOLOv2/jni/meson.build
@@ -1,28 +1,62 @@
 # build command for lib_yolov2_loss_layer.so
+
+cpp_args = []
+
+if get_option('default_library') == 'shared'
+    cpp_args += [ '-DPLUGGABLE' ]
+endif
+
 yolov2_loss_src = files('yolo_v2_loss.cpp')
-yolov2_loss_layer = shared_library('yolov2_loss_layer',
-  yolov2_loss_src,
-  dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
-  include_directories: include_directories('./'),
-  install: true,
-  install_dir: nntrainer_libdir/'nntrainer'/'layers',
-  cpp_args: '-DPLUGGABLE'
-)
+
+if get_option('default_library') == 'static'
+  yolov2_loss_layer = static_library('yolov2_loss_layer',
+    yolov2_loss_src,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    include_directories: include_directories('./'),
+    install: true,
+    install_dir: nntrainer_libdir/'nntrainer'/'layers',
+    cpp_args: cpp_args
+  )
+else
+  yolov2_loss_layer = shared_library('yolov2_loss_layer',
+    yolov2_loss_src,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    include_directories: include_directories('./'),
+    install: true,
+    install_dir: nntrainer_libdir/'nntrainer'/'layers',
+    cpp_args: cpp_args
+  )
+endif
+
 yolov2_loss_layer_dep = declare_dependency(
   link_with: yolov2_loss_layer,
   include_directories: include_directories('./')
 )
 
 # build command for lib_reorg_layer.so
+
 layer_reorg_src = files('reorg_layer.cpp')
-reorg_layer = shared_library('reorg_layer',
-  layer_reorg_src,
-  dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
-  include_directories: include_directories('./'),
-  install: true,
-  install_dir: nntrainer_libdir/'nntrainer'/'layers',
-  cpp_args: '-DPLUGGABLE'
-)
+
+if get_option('default_library') == 'static'
+  reorg_layer = static_library('reorg_layer',
+    layer_reorg_src,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    include_directories: include_directories('./'),
+    install: true,
+    install_dir: nntrainer_libdir/'nntrainer'/'layers',
+    cpp_args: cpp_args
+  )
+else
+  reorg_layer = shared_library('reorg_layer',
+    layer_reorg_src,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    include_directories: include_directories('./'),
+    install: true,
+    install_dir: nntrainer_libdir/'nntrainer'/'layers',
+    cpp_args: cpp_args
+  )
+endif
+
 reorg_layer_dep = declare_dependency(
   link_with: reorg_layer,
   include_directories: include_directories('./')

--- a/Applications/YOLOv3/jni/meson.build
+++ b/Applications/YOLOv3/jni/meson.build
@@ -1,13 +1,30 @@
+cpp_args = []
+
+if get_option('default_library') == 'shared'
+    cpp_args += [ '-DPLUGGABLE' ]
+endif
+
 upsample_layer_src = files('upsample_layer.cpp')
 
-upsample_layer = shared_library('upsample_layer',
-  upsample_layer_src,
-  dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
-  include_directories: include_directories('./'),
-  install: true,
-  install_dir: application_install_dir,
-  cpp_args: '-DPLUGGABLE'
-)
+if get_option('default_library') == 'static'
+  upsample_layer = static_library('upsample_layer',
+    upsample_layer_src,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    include_directories: include_directories('./'),
+    install: true,
+    install_dir: application_install_dir,
+    cpp_args: cpp_args
+  )
+else
+  upsample_layer = shared_library('upsample_layer',
+    upsample_layer_src,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    include_directories: include_directories('./'),
+    install: true,
+    install_dir: application_install_dir,
+    cpp_args: cpp_args
+  )
+endif
 
 upsample_layer_dep = declare_dependency(
   link_with: upsample_layer,

--- a/meson.build
+++ b/meson.build
@@ -210,16 +210,15 @@ if get_option('enable-opencl')
     clblast_root = subprojects_dir_absolute / 'CLBlast'
     opencl_root = meson.build_root() / 'opencl'
     clblast_dep = declare_dependency()
-  elif get_option('platform') == 'windows'
-    clblast_lib_dir_absolute = windows_resource_dir_absolute / 'CLBlast'
-    clblast_lib_dir_absolute_win = clblast_lib_dir_absolute.replace('/', '\\')
-    run_command(['xcopy', '/C', '/Y', clblast_lib_dir_absolute_win, meson.current_build_dir()], check: true)
-    clblast_dir_relative = subprojects_dir_relative / 'CLBlast'
-    clblast_include = include_directories(clblast_dir_relative / 'include')
-    clblast_dep = declare_dependency(include_directories: clblast_include, link_args:['clblast.lib'])
   else 
     clblast_options = cmake.subproject_options()
     clblast_options.add_cmake_defines({'CMAKE_POLICY_VERSION_MINIMUM': '3.10'})
+    clblast_options.add_cmake_defines({'CMAKE_CXX_STANDARD': '17'})
+    clblast_options.add_cmake_defines({'TUNERS': false})
+    if get_option('default_library') == 'static'
+      clblast_options.add_cmake_defines({'OVERRIDE_MSVC_FLAGS_TO_MT': false})
+      clblast_options.add_cmake_defines({'BUILD_SHARED_LIBS': false})
+    endif
     clblast_proj = cmake.subproject('clblast', options: clblast_options, required: true)
     clblast_dep = clblast_proj.dependency('clblast')
   endif
@@ -553,13 +552,6 @@ thread_dep = dependency('threads') # pthread for tensorflow-lite
 if get_option('platform') == 'android'
   iniparser_root = subprojects_dir_absolute / 'iniparser'
   iniparser_dep = declare_dependency()
-elif get_option('platform') == 'windows'
-  iniparser_lib_dir_absolute = windows_resource_dir_absolute / 'iniparser'
-  iniparser_lib_dir_absolute_win = iniparser_lib_dir_absolute.replace('/', '\\')
-  run_command(['xcopy', '/C', '/Y', iniparser_lib_dir_absolute_win, meson.current_build_dir()], check: true)
-  iniparser_dir_relative = subprojects_dir_relative / 'iniparser'
-  iniparser_include = include_directories(iniparser_dir_relative / 'src')
-  iniparser_dep = declare_dependency(include_directories: iniparser_include, link_args:['iniparser.lib'])
 else
   iniparser_dep = dependency('iniparser', required : false, version : '>=3.2') # iniparser
 

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -12,26 +12,48 @@ if cxx.get_id() != 'msvc'
   endif
 endif
 
-nntrainer_layer_common_standalone_tests_lib = shared_library(
-  'nntrainer_layer_common_standalone_tests',
-  'layers_standalone_common_tests.cpp',
-  cpp_args : cpp_args_str,
-  dependencies: [nntrainer_dep, gtest_dep], # nntrainer_devel_dep
-  include_directories: layer_common_test_inc
-)
+
+if get_option('default_library') == 'static'
+  nntrainer_layer_common_standalone_tests_lib = static_library(
+    'nntrainer_layer_common_standalone_tests',
+    'layers_standalone_common_tests.cpp',
+    cpp_args : cpp_args_str,
+    dependencies: [nntrainer_dep, gtest_dep], # nntrainer_devel_dep
+    include_directories: layer_common_test_inc
+  )
+else
+  nntrainer_layer_common_standalone_tests_lib = shared_library(
+    'nntrainer_layer_common_standalone_tests',
+    'layers_standalone_common_tests.cpp',
+    cpp_args : cpp_args_str,
+    dependencies: [nntrainer_dep, gtest_dep], # nntrainer_devel_dep
+    include_directories: layer_common_test_inc
+  )
+endif
 
 nntrainer_layer_common_standalone_tests_dep = declare_dependency(
   link_with: nntrainer_layer_common_standalone_tests_lib,
   include_directories: layer_common_test_inc
   )
 
-nntrainer_layer_common_dependent_tests_lib = shared_library(
-  'nntrainer_layer_common_dependent_tests',
-  'layers_dependent_common_tests.cpp',
-  cpp_args : cpp_args_str,
-  dependencies: [nntrainer_dep, gtest_dep], # nntrainer_devel_dep
-  include_directories: layer_common_test_inc
-)
+
+if get_option('default_library') == 'static'
+  nntrainer_layer_common_dependent_tests_lib = static_library(
+    'nntrainer_layer_common_dependent_tests',
+    'layers_dependent_common_tests.cpp',
+    cpp_args : cpp_args_str,
+    dependencies: [nntrainer_dep, gtest_dep], # nntrainer_devel_dep
+    include_directories: layer_common_test_inc
+  )
+else
+  nntrainer_layer_common_dependent_tests_lib = shared_library(
+    'nntrainer_layer_common_dependent_tests',
+    'layers_dependent_common_tests.cpp',
+    cpp_args : cpp_args_str,
+    dependencies: [nntrainer_dep, gtest_dep], # nntrainer_devel_dep
+    include_directories: layer_common_test_inc
+  )
+endif
 
 nntrainer_layer_common_dependent_tests_dep = declare_dependency(
   link_with: nntrainer_layer_common_dependent_tests_lib,

--- a/windows-native.ini
+++ b/windows-native.ini
@@ -11,3 +11,4 @@ c_std='c17'
 cpp_std='c++20'
 platform='windows'
 vsenv = true
+default_library = 'static'


### PR DESCRIPTION
Make possible to build nntrainer in static or shared version on
Windows platform

Use following commandt for static build:

meson setup --wipe --native-file windows-native.ini builddir -Ddefault_library=static -Denable-pluggable=false -Denable-opencl=true
meson compile -C builddir
