### PR TITLE
Fix Build Errors on Android

### DIFF
--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -23,6 +23,8 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend \
 	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend/fallback \
 	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend/arm \
+	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend/ggml_interface \
+	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl \
 	$(NNTRAINER_ROOT)/nntrainer/utils \
 	$(NNTRAINER_ROOT)/api \
 	$(NNTRAINER_ROOT)/api/ccapi/include \

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -2160,7 +2160,6 @@ static void run_q_6_K_test(const uint32_t M, const uint32_t K,
 
 DECLARE_q_6_K_test_M_K_N(1, 3072, 105900);
 
-#if 1
 static void run_q4_0_test(const uint32_t M, const uint32_t K,
                           const uint32_t N) {
   nntrainer::init_backend();


### PR DESCRIPTION
This pull request resolves the following build errors on Android:
1. The file 'nntr_ggml_impl_common.h' was not found.
2. There is a non-terminating '#if 1' statement.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped