### PR TITLE
Update Neural Network Load Regex for Windows Compatibility

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -683,7 +683,7 @@ void NeuralNetwork::load(const std::string &file_path,
 
   bool fsu_mode = std::get<props::Fsu>(model_flex_props);
 
-  const std::regex reg_("\\s*\\:\\s*");
+  const std::regex reg_("\\s*\\;\\s*");
   auto v = split(file_path, reg_);
 
   size_t start_from = 0;

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -779,7 +779,9 @@ void FloatTensor::dot(std::vector<Tensor *> input, std::vector<Tensor *> output,
     }
 #endif
   } else {
-    throw std::runtime_error("unsupported data type");
+    for (unsigned int i = 0; i < input.size(); ++i) {
+      dot(*input[i], *output[i], trans, trans_in, beta);
+    }
   }
 }
 


### PR DESCRIPTION
This pull request updates the neuralnet load regex to use a semicolon (;) instead of a colon (:).
This is to have compatibility with the Windows environment.
Additionally, this patch adds a fallback in the FloatTensor dot method for handling multiple inputs.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped
