### PR TITLE
[WIP][tensor] update batchedDot

### DIFF
--- a/nntrainer/layers/matmul_layer.cpp
+++ b/nntrainer/layers/matmul_layer.cpp
@@ -24,7 +24,6 @@ namespace nntrainer {
 void MatMulLayer::finalize(InitLayerContext &context) {
   TensorDim inputDim0 = context.getInputDimensions()[0];
   TensorDim inputDim1 = context.getInputDimensions()[1];
-
   if (inputDim0[1] != inputDim1[1]) {
     throw std::invalid_argument("MatMulLayer requires matching channel size. ");
   } else if (inputDim0[3] != inputDim1[2]) {
@@ -40,7 +39,7 @@ void MatMulLayer::finalize(InitLayerContext &context) {
 
 void MatMulLayer::forwarding_operation(const Tensor &input0,
                                        const Tensor &input1, Tensor &output) {
-  input0.dot(input1, output);
+  input0.dotBatched(input1, output, false, false);
 }
 
 void MatMulLayer::calcDerivative(RunLayerContext &context) {

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -337,7 +337,7 @@ void TensorBase::calculateFlattenDot(
   }
 
   if (!trans && !trans_in) {
-    if (last_axis != input_first_three_flat)
+    if (last_axis != input.batch() * input.height())
       throw std::runtime_error(
         "Error: incompatible dimensions for dot product");
     K = input_first_three_flat; /** == last_axis */


### PR DESCRIPTION
`Dot` operation was implemented with a focus on width and height,
so it only worked when the channel size was 1.

To support case where the chennal size is greater than 1,
I modified batchedDot function to perform the dot operation repeatedly
not only along the batch dimension but also along the channel dimension.

(the number of `dot` function calls becomes batch * channel,
so it isn't ideal solution, but the current `dot` function cannot handle
the channel, height, and width simultaneously)

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [X]Failed [ ]Skipped

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>