### PR TITLE
Apply RAII for ClContext internals

### DIFF
--- a/nntrainer/cl_buffer_manager.cpp
+++ b/nntrainer/cl_buffer_manager.cpp
@@ -20,17 +20,17 @@ namespace nntrainer {
 // to-do: Implementation to be updated with array of Buffer objects if required
 // fp16 Buffer objects to be added in future
 void ClBufferManager::initBuffers() {
-  inBufferA = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
-  inBufferB = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
-  inBufferC = new opencl::Buffer(context_inst_, unused_buffer_bytes, true);
-  outBufferA = new opencl::Buffer(context_inst_, buffer_size_bytes, false);
-  outBufferB = new opencl::Buffer(context_inst_, unused_buffer_bytes, false);
+  inBufferA = new opencl::Buffer(context_manager_, buffer_size_bytes, true);
+  inBufferB = new opencl::Buffer(context_manager_, buffer_size_bytes, true);
+  inBufferC = new opencl::Buffer(context_manager_, unused_buffer_bytes, true);
+  outBufferA = new opencl::Buffer(context_manager_, buffer_size_bytes, false);
+  outBufferB = new opencl::Buffer(context_manager_, unused_buffer_bytes, false);
 
-  data_input = context_inst_.createSVMRegion(buffer_size_bytes);
+  data_input = context_manager_.createSVMRegion(buffer_size_bytes);
   for (unsigned int i = 0; i < max_qs; ++i) {
-    scale_vec.push_back(context_inst_.createSVMRegion(scale_q4_0_size));
-    quant_vec.push_back(context_inst_.createSVMRegion(quant_q4_0_size));
-    output_vec.push_back(context_inst_.createSVMRegion(buffer_size_bytes));
+    scale_vec.push_back(context_manager_.createSVMRegion(scale_q4_0_size));
+    quant_vec.push_back(context_manager_.createSVMRegion(quant_q4_0_size));
+    output_vec.push_back(context_manager_.createSVMRegion(buffer_size_bytes));
   }
 
   ml_logi("ClBufferManager: Buffers & images initialized");
@@ -43,11 +43,11 @@ ClBufferManager::~ClBufferManager() {
   delete outBufferA;
   delete outBufferB;
 
-  context_inst_.releaseSVMRegion(data_input);
+  context_manager_.releaseSVMRegion(data_input);
   for (unsigned int i = 0; i < max_qs; ++i) {
-    context_inst_.releaseSVMRegion(scale_vec[i]);
-    context_inst_.releaseSVMRegion(quant_vec[i]);
-    context_inst_.releaseSVMRegion(output_vec[i]);
+    context_manager_.releaseSVMRegion(scale_vec[i]);
+    context_manager_.releaseSVMRegion(quant_vec[i]);
+    context_manager_.releaseSVMRegion(output_vec[i]);
   }
 
   ml_logi("ClBufferManager: Buffers destroyed");

--- a/nntrainer/cl_buffer_manager.h
+++ b/nntrainer/cl_buffer_manager.h
@@ -29,14 +29,10 @@ namespace nntrainer {
  * @brief Support for Buffer management
  */
 
-class ClBufferManager : public Singleton<ClBufferManager> {
+class ClBufferManager : public Noncopyable, public Nonmovable {
 
 private:
-  /**
-   * @brief OpenCl context global instance
-   *
-   */
-  opencl::ContextManager &context_inst_ = opencl::ContextManager::Global();
+  opencl::ContextManager &context_manager_;
 
   /**
    * @brief Buffer size in bytes preset (256 mebibytes)
@@ -62,6 +58,10 @@ private:
   std::vector<void *> output_vec;
 
 public:
+  ClBufferManager() = delete;
+
+  ClBufferManager(opencl::ContextManager &context_manager) :
+    context_manager_(context_manager) {}
   /**
    * @brief Initialize Buffer objects.
    */

--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -272,20 +272,17 @@ bool ClContext::clCreateKernel(std::string &kernel_string,
     ml_logi("Using cached version of kernel: %s at path %s",
             kernel_name.c_str(), binary_file_path.c_str());
     result = program.CreateCLProgramWithBinary(
-      opencl::ContextManager::Global().GetContext(),
-      opencl::ContextManager::Global().GetDeviceId(), binary_data,
-      binary_file_path, "");
+      context_manager_.GetContext(), context_manager_.GetDeviceId(),
+      binary_data, binary_file_path, "");
   } else {
     ml_logi("Binary for kernel %s not found, compiling from source...",
             kernel_name.c_str());
-    result =
-      program.CreateCLProgram(opencl::ContextManager::Global().GetContext(),
-                              opencl::ContextManager::Global().GetDeviceId(),
-                              kernel_string, compile_options);
+    result = program.CreateCLProgram(context_manager_.GetContext(),
+                                     context_manager_.GetDeviceId(),
+                                     kernel_string, compile_options);
 
     if (KERNEL_CACHE_ENABLED && result) {
-      auto binary = program.GetProgramBinary(
-        opencl::ContextManager::Global().GetDeviceId());
+      auto binary = program.GetProgramBinary(context_manager_.GetDeviceId());
 
       if (binary.empty()) {
         ml_loge("Failed retrieving binary for kernel %s", kernel_name.c_str());

--- a/nntrainer/layers/cl_layers/concat_cl.cpp
+++ b/nntrainer/layers/cl_layers/concat_cl.cpp
@@ -239,7 +239,7 @@ void ConcatLayerCl::concat_cl_axis3(const float *matAdata,
 
   auto *global_cl_context =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
+  auto &clbuffInstance = global_cl_context->getBufferManager();
 
   do {
 
@@ -250,7 +250,7 @@ void ConcatLayerCl::concat_cl_axis3(const float *matAdata,
                   (input1_width + input2_width));
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(float) * input1_batch_size * input1_channels * input1_height *
         input1_width,
       matAdata);
@@ -259,7 +259,7 @@ void ConcatLayerCl::concat_cl_axis3(const float *matAdata,
     }
 
     result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(float) * input1_batch_size * input1_channels * input1_height *
         input2_width,
       vecXdata);
@@ -268,7 +268,7 @@ void ConcatLayerCl::concat_cl_axis3(const float *matAdata,
     }
 
     result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(float) * input1_batch_size * input1_channels * input1_height *
         (input1_width + input2_width),
       vecYdata);
@@ -328,14 +328,14 @@ void ConcatLayerCl::concat_cl_axis3(const float *matAdata,
     /// @todo: create a group size by device & input
     const int work_group_size[3] = {1, 1, 1}; // test-value
 
-    result = global_cl_context->command_queue_inst_.DispatchCommand(
+    result = global_cl_context->getCommandQueueManager().DispatchCommand(
       kernel_concat_ptr, work_groups_count, work_group_size);
     if (!result) {
       break;
     }
 
     result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(float) * input1_batch_size * input1_channels * input1_height *
         (input1_width + input2_width),
       vecYdata);
@@ -358,7 +358,7 @@ void ConcatLayerCl::concat_cl_axis2(const float *matAdata,
 
   auto *global_cl_context =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
+  auto &clbuffInstance = global_cl_context->getBufferManager();
 
   do {
 
@@ -369,7 +369,7 @@ void ConcatLayerCl::concat_cl_axis2(const float *matAdata,
                   (input1_height + input2_height));
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(float) * input1_batch_size * input1_channels * input1_height *
         input1_width,
       matAdata);
@@ -378,7 +378,7 @@ void ConcatLayerCl::concat_cl_axis2(const float *matAdata,
     }
 
     result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(float) * input1_batch_size * input1_channels * input2_height *
         input1_width,
       vecXdata);
@@ -387,7 +387,7 @@ void ConcatLayerCl::concat_cl_axis2(const float *matAdata,
     }
 
     result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(float) * input1_batch_size * input1_channels *
         (input1_height + input2_height) * input1_width,
       vecYdata);
@@ -446,14 +446,14 @@ void ConcatLayerCl::concat_cl_axis2(const float *matAdata,
     /// @todo: create a group size by device & input
     const int work_group_size[3] = {1, 1, 1}; // test-value
 
-    result = global_cl_context->command_queue_inst_.DispatchCommand(
+    result = global_cl_context->getCommandQueueManager().DispatchCommand(
       kernel_concat_ptr, work_groups_count, work_group_size);
     if (!result) {
       break;
     }
 
     result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(float) * input1_batch_size * input1_channels *
         (input1_height + input2_height) * input1_width,
       vecYdata);
@@ -476,7 +476,7 @@ void ConcatLayerCl::concat_cl_axis1(const float *matAdata,
 
   auto *global_cl_context =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
+  auto &clbuffInstance = global_cl_context->getBufferManager();
 
   do {
     const auto &kernel_concat_ptr =
@@ -486,7 +486,7 @@ void ConcatLayerCl::concat_cl_axis1(const float *matAdata,
                   (input1_channels + input2_channels));
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(float) * input1_batch_size * input1_channels * input1_height *
         input1_width,
       matAdata);
@@ -495,7 +495,7 @@ void ConcatLayerCl::concat_cl_axis1(const float *matAdata,
     }
 
     result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(float) * input1_batch_size * input2_channels * input1_height *
         input1_width,
       vecXdata);
@@ -504,7 +504,7 @@ void ConcatLayerCl::concat_cl_axis1(const float *matAdata,
     }
 
     result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(float) * input1_batch_size * input1_width * input1_height *
         (input1_channels + input2_channels),
       vecYdata);
@@ -564,14 +564,14 @@ void ConcatLayerCl::concat_cl_axis1(const float *matAdata,
     /// @todo: create a group size by device & input
     const int work_group_size[3] = {1, 1, 1}; // test-value
 
-    result = global_cl_context->command_queue_inst_.DispatchCommand(
+    result = global_cl_context->getCommandQueueManager().DispatchCommand(
       kernel_concat_ptr, work_groups_count, work_group_size);
     if (!result) {
       break;
     }
 
     result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(float) * input1_batch_size * input1_width * input1_height *
         (input1_channels + input2_channels),
       vecYdata);
@@ -595,7 +595,7 @@ void ConcatLayerCl::concat_cl_axis3_fp16(const _FP16 *matAdata,
 
   auto *global_cl_context =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
+  auto &clbuffInstance = global_cl_context->getBufferManager();
 
   do {
 
@@ -606,7 +606,7 @@ void ConcatLayerCl::concat_cl_axis3_fp16(const _FP16 *matAdata,
                   (input1_width + input2_width));
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(_FP16) * input1_batch_size * input1_channels * input1_height *
         input1_width,
       matAdata);
@@ -615,7 +615,7 @@ void ConcatLayerCl::concat_cl_axis3_fp16(const _FP16 *matAdata,
     }
 
     result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(_FP16) * input1_batch_size * input1_channels * input1_height *
         input2_width,
       vecXdata);
@@ -624,7 +624,7 @@ void ConcatLayerCl::concat_cl_axis3_fp16(const _FP16 *matAdata,
     }
 
     result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(_FP16) * input1_batch_size * input1_channels * input1_height *
         (input1_width + input2_width),
       vecYdata);
@@ -684,14 +684,14 @@ void ConcatLayerCl::concat_cl_axis3_fp16(const _FP16 *matAdata,
     /// @todo: create a group size by device & input
     const int work_group_size[3] = {1, 1, 1}; // test-value
 
-    result = global_cl_context->command_queue_inst_.DispatchCommand(
+    result = global_cl_context->getCommandQueueManager().DispatchCommand(
       kernel_concat_ptr, work_groups_count, work_group_size);
     if (!result) {
       break;
     }
 
     result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(_FP16) * input1_batch_size * input1_channels * input1_height *
         (input1_width + input2_width),
       vecYdata);
@@ -714,7 +714,7 @@ void ConcatLayerCl::concat_cl_axis2_fp16(const _FP16 *matAdata,
 
   auto *global_cl_context =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
+  auto &clbuffInstance = global_cl_context->getBufferManager();
 
   do {
     const auto &kernel_concat_ptr =
@@ -724,7 +724,7 @@ void ConcatLayerCl::concat_cl_axis2_fp16(const _FP16 *matAdata,
                   (input1_height + input2_height));
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(_FP16) * input1_batch_size * input1_channels * input1_height *
         input1_width,
       matAdata);
@@ -733,7 +733,7 @@ void ConcatLayerCl::concat_cl_axis2_fp16(const _FP16 *matAdata,
     }
 
     result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(_FP16) * input1_batch_size * input1_channels * input2_height *
         input1_width,
       vecXdata);
@@ -742,7 +742,7 @@ void ConcatLayerCl::concat_cl_axis2_fp16(const _FP16 *matAdata,
     }
 
     result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(_FP16) * input1_batch_size * input1_channels *
         (input1_height + input2_height) * input1_width,
       vecYdata);
@@ -801,14 +801,14 @@ void ConcatLayerCl::concat_cl_axis2_fp16(const _FP16 *matAdata,
     /// @todo: create a group size by device & input
     const int work_group_size[3] = {1, 1, 1}; // test-value
 
-    result = global_cl_context->command_queue_inst_.DispatchCommand(
+    result = global_cl_context->getCommandQueueManager().DispatchCommand(
       kernel_concat_ptr, work_groups_count, work_group_size);
     if (!result) {
       break;
     }
 
     result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(_FP16) * input1_batch_size * input1_channels *
         (input1_height + input2_height) * input1_width,
       vecYdata);
@@ -831,7 +831,7 @@ void ConcatLayerCl::concat_cl_axis1_fp16(const _FP16 *matAdata,
 
   auto *global_cl_context =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
+  auto &clbuffInstance = global_cl_context->getBufferManager();
 
   do {
 
@@ -842,7 +842,7 @@ void ConcatLayerCl::concat_cl_axis1_fp16(const _FP16 *matAdata,
                   (input1_channels + input2_channels));
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(_FP16) * input1_batch_size * input1_channels * input1_height *
         input1_width,
       matAdata);
@@ -851,7 +851,7 @@ void ConcatLayerCl::concat_cl_axis1_fp16(const _FP16 *matAdata,
     }
 
     result = clbuffInstance.getInBufferB()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(_FP16) * input1_batch_size * input2_channels * input1_height *
         input1_width,
       vecXdata);
@@ -860,7 +860,7 @@ void ConcatLayerCl::concat_cl_axis1_fp16(const _FP16 *matAdata,
     }
 
     result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(_FP16) * input1_batch_size * input1_width * input1_height *
         (input1_channels + input2_channels),
       vecYdata);
@@ -920,14 +920,14 @@ void ConcatLayerCl::concat_cl_axis1_fp16(const _FP16 *matAdata,
     /// @todo: create a group size by device & input
     const int work_group_size[3] = {1, 1, 1}; // test-value
 
-    result = global_cl_context->command_queue_inst_.DispatchCommand(
+    result = global_cl_context->getCommandQueueManager().DispatchCommand(
       kernel_concat_ptr, work_groups_count, work_group_size);
     if (!result) {
       break;
     }
 
     result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      global_cl_context->command_queue_inst_,
+      global_cl_context->getCommandQueueManager(),
       sizeof(_FP16) * input1_batch_size * input1_width * input1_height *
         (input1_channels + input2_channels),
       vecYdata);

--- a/nntrainer/layers/cl_layers/reshape_cl.cpp
+++ b/nntrainer/layers/cl_layers/reshape_cl.cpp
@@ -150,7 +150,7 @@ void ReshapeLayerCl::copy_cl_fp16(const _FP16 *input, _FP16 *res,
 
   auto *global_cl_context =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
+  auto &clbuffInstance = global_cl_context->getBufferManager();
 
   do {
     const auto &kernel_copy_ptr = getLayerKernelPtrs()[Kernels::COPY_CL];
@@ -159,13 +159,13 @@ void ReshapeLayerCl::copy_cl_fp16(const _FP16 *input, _FP16 *res,
                       input_width * input_channels;
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_, dim_size, input);
+      global_cl_context->getCommandQueueManager(), dim_size, input);
     if (!result) {
       break;
     }
 
     result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_, dim_size, res);
+      global_cl_context->getCommandQueueManager(), dim_size, res);
 
     if (!result) {
       break;
@@ -211,14 +211,14 @@ void ReshapeLayerCl::copy_cl_fp16(const _FP16 *input, _FP16 *res,
     /// @todo: create a group size by device & input
     const int work_group_size[3] = {1, 1, 1}; // test-value
 
-    result = global_cl_context->command_queue_inst_.DispatchCommand(
+    result = global_cl_context->getCommandQueueManager().DispatchCommand(
       kernel_copy_ptr, work_groups_count, work_group_size);
     if (!result) {
       break;
     }
 
     result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      global_cl_context->command_queue_inst_, dim_size, res);
+      global_cl_context->getCommandQueueManager(), dim_size, res);
     if (!result) {
       break;
     }
@@ -237,7 +237,7 @@ void ReshapeLayerCl::scopy_cl(const float *input, float *res,
 
   auto *global_cl_context =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
+  auto &clbuffInstance = global_cl_context->getBufferManager();
 
   do {
     const auto &kernel_copy_ptr = getLayerKernelPtrs()[Kernels::COPY_CL];
@@ -246,13 +246,13 @@ void ReshapeLayerCl::scopy_cl(const float *input, float *res,
                       input_width * input_channels;
 
     result = clbuffInstance.getInBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_, dim_size, input);
+      global_cl_context->getCommandQueueManager(), dim_size, input);
     if (!result) {
       break;
     }
 
     result = clbuffInstance.getOutBufferA()->WriteDataRegion(
-      global_cl_context->command_queue_inst_, dim_size, res);
+      global_cl_context->getCommandQueueManager(), dim_size, res);
     if (!result) {
       break;
     }
@@ -297,14 +297,14 @@ void ReshapeLayerCl::scopy_cl(const float *input, float *res,
     /// @todo: create a group size by device & input
     const int work_group_size[3] = {1, 1, 1}; // test-value
 
-    result = global_cl_context->command_queue_inst_.DispatchCommand(
+    result = global_cl_context->getCommandQueueManager().DispatchCommand(
       kernel_copy_ptr, work_groups_count, work_group_size);
     if (!result) {
       break;
     }
 
     result = clbuffInstance.getOutBufferA()->ReadDataRegion(
-      global_cl_context->command_queue_inst_, dim_size, res);
+      global_cl_context->getCommandQueueManager(), dim_size, res);
     if (!result) {
       break;
     }

--- a/nntrainer/opencl/opencl_command_queue_manager.cpp
+++ b/nntrainer/opencl/opencl_command_queue_manager.cpp
@@ -35,10 +35,9 @@ bool CommandQueueManager::CreateCommandQueue() {
   }
 
   int error_code;
-  ContextManager &context_instance = ContextManager::Global();
 
   // OpenCL context is created
-  cl_context context = context_instance.GetContext();
+  cl_context context = context_manager_.GetContext();
 
   // If context is invalid, return false
   if (context == nullptr) {
@@ -46,7 +45,7 @@ bool CommandQueueManager::CreateCommandQueue() {
   }
 
   // getting GPU device ID
-  cl_device_id device_id = context_instance.GetDeviceId();
+  cl_device_id device_id = context_manager_.GetDeviceId();
 
   // returns NULL with error code if fails
   command_queue_ = clCreateCommandQueue(
@@ -84,10 +83,6 @@ CommandQueueManager::~CommandQueueManager() {
     // decrements the command_queue reference count
     clReleaseCommandQueue(command_queue_);
     command_queue_ = nullptr;
-
-    // releasing OpenCL context since it has been created by
-    // CommandQueueManager::CreateCommandQueue
-    ContextManager::Global().ReleaseContext();
   }
 }
 

--- a/nntrainer/opencl/opencl_command_queue_manager.h
+++ b/nntrainer/opencl/opencl_command_queue_manager.h
@@ -15,6 +15,7 @@
 #define __OPENCL_COMMAND_QUEUE_MANAGER_H__
 
 #include "CL/cl.h"
+#include "opencl_context_manager.h"
 #include "opencl_kernel.h"
 #include "singleton.h"
 #include <memory>
@@ -27,8 +28,9 @@ namespace nntrainer::opencl {
  * @brief OpenCL command queue wrapper
  *
  */
-class CommandQueueManager : public Singleton<CommandQueueManager> {
+class CommandQueueManager : public Noncopyable, public Nonmovable {
 
+  ContextManager &context_manager_;
   /**
    * @brief cl_command_queue instance
    *
@@ -36,6 +38,11 @@ class CommandQueueManager : public Singleton<CommandQueueManager> {
   cl_command_queue command_queue_{nullptr};
 
 public:
+  CommandQueueManager() = delete;
+
+  CommandQueueManager(ContextManager &context_manager) :
+    context_manager_(context_manager) {}
+
   /**
    * @brief Create a Command Queue object
    *

--- a/nntrainer/opencl/opencl_context_manager.h
+++ b/nntrainer/opencl/opencl_context_manager.h
@@ -28,7 +28,7 @@ namespace nntrainer::opencl {
  * @brief OpenCL context wrapper
  *
  */
-class ContextManager : public Singleton<ContextManager> {
+class ContextManager : public Noncopyable, public Nonmovable {
 
   /**
    * @brief Create a Default GPU Device object
@@ -51,12 +51,6 @@ public:
    * @return const cl_context
    */
   const cl_context &GetContext();
-
-  /**
-   * @brief Release OpenCL context
-   *
-   */
-  void ReleaseContext();
 
   /**
    * @brief Get the Device Id object

--- a/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/attention_kernels_fp16.cpp
@@ -29,7 +29,7 @@ void rotary_emb_cl(_FP16 *in, _FP16 *out,
 
   auto *cl_context =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &cl_buffer_manager = ClBufferManager::Global();
+  auto &cl_buffer_manager = cl_context->getBufferManager();
 
   ClContext::SharedPtrClKernel kernel_rotaryEmb_fp16_ptr =
     cl_context->registerClKernel(rotary_emb_fp16_kernel, "rotary_emb_cl_fp16");

--- a/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernels_fp16.cpp
@@ -103,7 +103,7 @@ void addition_cl(const _FP16 *input, _FP16 *res, unsigned int size_input,
 void sscal_cl(_FP16 *X, const unsigned int N, const float alpha) {
   auto *blas_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clbuffInstance = ClBufferManager::Global();
+  auto &clbuffInstance = blas_cc->getBufferManager();
 
   ClContext::SharedPtrClKernel kernel_sscal_fp16_ptr =
     blas_cc->registerClKernel(hscal_kernel, "sscal_cl_fp16");

--- a/nntrainer/tensor/cl_operations/clblast_interface.cpp
+++ b/nntrainer/tensor/cl_operations/clblast_interface.cpp
@@ -24,70 +24,70 @@ void scal_cl(const unsigned int N, const float alpha, float *X,
              unsigned int incX) {
   auto *clblast_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clBuffManagerInst = ClBufferManager::Global();
-  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+  auto &clBuffManagerInst = clblast_cc->getBufferManager();
+  auto command_queue = clblast_cc->getCommandQueueManager().GetCommandQueue();
 
   clBuffManagerInst.getOutBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), X);
 
   clblast::Scal<float>(N, alpha, clBuffManagerInst.getOutBufferA()->GetBuffer(),
                        0, incX, &command_queue);
 
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), X);
 }
 
 void copy_cl(const unsigned int N, const float *X, float *Y, unsigned int incX,
              unsigned int incY) {
   auto *clblast_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clBuffManagerInst = ClBufferManager::Global();
-  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+  auto &clBuffManagerInst = clblast_cc->getBufferManager();
+  auto command_queue = clblast_cc->getCommandQueueManager().GetCommandQueue();
 
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), X);
 
   clblast::Copy<float>(N, clBuffManagerInst.getInBufferA()->GetBuffer(), 0,
                        incX, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
                        incY, &command_queue);
 
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), Y);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), Y);
 }
 
 void axpy_cl(const unsigned int N, const float alpha, const float *X, float *Y,
              unsigned int incX, unsigned int incY) {
   auto *clblast_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clBuffManagerInst = ClBufferManager::Global();
-  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+  auto &clBuffManagerInst = clblast_cc->getBufferManager();
+  auto command_queue = clblast_cc->getCommandQueueManager().GetCommandQueue();
 
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), X);
 
   clBuffManagerInst.getOutBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), Y);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), Y);
 
   clblast::Axpy<float>(N, alpha, clBuffManagerInst.getInBufferA()->GetBuffer(),
                        0, incX, clBuffManagerInst.getOutBufferA()->GetBuffer(),
                        0, incY, &command_queue);
 
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), Y);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), Y);
 }
 
 float dot_cl(const unsigned int N, const float *X, const float *Y,
              unsigned int incX, unsigned int incY) {
   auto *clblast_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clBuffManagerInst = ClBufferManager::Global();
-  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+  auto &clBuffManagerInst = clblast_cc->getBufferManager();
+  auto command_queue = clblast_cc->getCommandQueueManager().GetCommandQueue();
 
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), X);
 
   clBuffManagerInst.getInBufferB()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), Y);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), Y);
 
   clblast::Dot<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
                       clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
@@ -96,18 +96,18 @@ float dot_cl(const unsigned int N, const float *X, const float *Y,
 
   float result;
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
-    clblast_cc->command_queue_inst_, sizeof(float), &result);
+    clblast_cc->getCommandQueueManager(), sizeof(float), &result);
   return result;
 }
 
 float nrm2_cl(const unsigned int N, const float *X, unsigned int incX) {
   auto *clblast_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clBuffManagerInst = ClBufferManager::Global();
-  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+  auto &clBuffManagerInst = clblast_cc->getBufferManager();
+  auto command_queue = clblast_cc->getCommandQueueManager().GetCommandQueue();
 
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), X);
 
   clblast::Nrm2<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
                        clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
@@ -115,7 +115,7 @@ float nrm2_cl(const unsigned int N, const float *X, unsigned int incX) {
 
   float result;
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
-    clblast_cc->command_queue_inst_, sizeof(float), &result);
+    clblast_cc->getCommandQueueManager(), sizeof(float), &result);
 
   return result;
 }
@@ -123,11 +123,11 @@ float nrm2_cl(const unsigned int N, const float *X, unsigned int incX) {
 float asum_cl(const unsigned int N, const float *X, unsigned int incX) {
   auto *clblast_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clBuffManagerInst = ClBufferManager::Global();
-  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+  auto &clBuffManagerInst = clblast_cc->getBufferManager();
+  auto command_queue = clblast_cc->getCommandQueueManager().GetCommandQueue();
 
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), X);
 
   clblast::Asum<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
                        clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
@@ -135,7 +135,7 @@ float asum_cl(const unsigned int N, const float *X, unsigned int incX) {
 
   float result;
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
-    clblast_cc->command_queue_inst_, sizeof(float), &result);
+    clblast_cc->getCommandQueueManager(), sizeof(float), &result);
 
   return result;
 }
@@ -143,11 +143,11 @@ float asum_cl(const unsigned int N, const float *X, unsigned int incX) {
 int amax_cl(const unsigned int N, const float *X, unsigned int incX) {
   auto *clblast_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clBuffManagerInst = ClBufferManager::Global();
-  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+  auto &clBuffManagerInst = clblast_cc->getBufferManager();
+  auto command_queue = clblast_cc->getCommandQueueManager().GetCommandQueue();
 
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), X);
 
   clblast::Amax<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
                        clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
@@ -155,7 +155,7 @@ int amax_cl(const unsigned int N, const float *X, unsigned int incX) {
 
   int result;
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
-    clblast_cc->command_queue_inst_, sizeof(int), &result);
+    clblast_cc->getCommandQueueManager(), sizeof(int), &result);
 
   return result;
 }
@@ -163,11 +163,11 @@ int amax_cl(const unsigned int N, const float *X, unsigned int incX) {
 int amin_cl(const unsigned int N, const float *X, unsigned int incX) {
   auto *clblast_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clBuffManagerInst = ClBufferManager::Global();
-  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+  auto &clBuffManagerInst = clblast_cc->getBufferManager();
+  auto command_queue = clblast_cc->getCommandQueueManager().GetCommandQueue();
 
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, N * sizeof(float), X);
+    clblast_cc->getCommandQueueManager(), N * sizeof(float), X);
 
   clblast::Amin<float>(N, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
                        clBuffManagerInst.getInBufferA()->GetBuffer(), 0, incX,
@@ -175,7 +175,7 @@ int amin_cl(const unsigned int N, const float *X, unsigned int incX) {
 
   int result;
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
-    clblast_cc->command_queue_inst_, sizeof(int), &result);
+    clblast_cc->getCommandQueueManager(), sizeof(int), &result);
 
   return result;
 }
@@ -186,8 +186,8 @@ void gemv_cl(const unsigned int layout, bool TransA, const unsigned int M,
              unsigned int incX, unsigned int incY) {
   auto *clblast_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clBuffManagerInst = ClBufferManager::Global();
-  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+  auto &clBuffManagerInst = clblast_cc->getBufferManager();
+  auto command_queue = clblast_cc->getCommandQueueManager().GetCommandQueue();
 
   clblast::Transpose transA =
     (TransA) ? clblast::Transpose::kYes : clblast::Transpose::kNo;
@@ -197,13 +197,13 @@ void gemv_cl(const unsigned int layout, bool TransA, const unsigned int M,
   const size_t y_size = (TransA ? N : M) * incY;
 
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, a_size * sizeof(float), A);
+    clblast_cc->getCommandQueueManager(), a_size * sizeof(float), A);
 
   clBuffManagerInst.getOutBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, y_size * sizeof(float), Y);
+    clblast_cc->getCommandQueueManager(), y_size * sizeof(float), Y);
 
   clBuffManagerInst.getInBufferB()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, x_size * sizeof(float), X);
+    clblast_cc->getCommandQueueManager(), x_size * sizeof(float), X);
 
   auto s = clblast::Gemv<float>(
     clblast::Layout::kRowMajor, transA, M, N, alpha,
@@ -211,12 +211,12 @@ void gemv_cl(const unsigned int layout, bool TransA, const unsigned int M,
     clBuffManagerInst.getInBufferB()->GetBuffer(), 0, incX, beta,
     clBuffManagerInst.getOutBufferA()->GetBuffer(), 0, incY, &command_queue);
 
-  opencl::clFinish(clblast_cc->command_queue_inst_.GetCommandQueue());
+  opencl::clFinish(clblast_cc->getCommandQueueManager().GetCommandQueue());
 
-  opencl::clEnqueueReadBuffer(clblast_cc->command_queue_inst_.GetCommandQueue(),
-                              clBuffManagerInst.getOutBufferA()->GetBuffer(),
-                              CL_TRUE, 0, y_size * sizeof(float), Y, 0, nullptr,
-                              nullptr);
+  opencl::clEnqueueReadBuffer(
+    clblast_cc->getCommandQueueManager().GetCommandQueue(),
+    clBuffManagerInst.getOutBufferA()->GetBuffer(), CL_TRUE, 0,
+    y_size * sizeof(float), Y, 0, nullptr, nullptr);
 }
 
 void gemm_cl(const unsigned int layout, bool TransA, bool TransB,
@@ -226,8 +226,8 @@ void gemm_cl(const unsigned int layout, bool TransA, bool TransB,
              const unsigned int ldc) {
   auto *clblast_cc =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  auto &clBuffManagerInst = ClBufferManager::Global();
-  auto command_queue = clblast_cc->command_queue_inst_.GetCommandQueue();
+  auto &clBuffManagerInst = clblast_cc->getBufferManager();
+  auto command_queue = clblast_cc->getCommandQueueManager().GetCommandQueue();
 
   clblast::Transpose transA =
     (TransA) ? clblast::Transpose::kYes : clblast::Transpose::kNo;
@@ -235,13 +235,13 @@ void gemm_cl(const unsigned int layout, bool TransA, bool TransB,
     (TransB) ? clblast::Transpose::kYes : clblast::Transpose::kNo;
 
   clBuffManagerInst.getInBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, M * K * sizeof(float), A);
+    clblast_cc->getCommandQueueManager(), M * K * sizeof(float), A);
 
   clBuffManagerInst.getInBufferB()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, K * N * sizeof(float), B);
+    clblast_cc->getCommandQueueManager(), K * N * sizeof(float), B);
 
   clBuffManagerInst.getOutBufferA()->WriteDataRegion(
-    clblast_cc->command_queue_inst_, M * N * sizeof(float), C);
+    clblast_cc->getCommandQueueManager(), M * N * sizeof(float), C);
 
   // layout is currently fixed to RowMajor
   clblast::Gemm<float>(
@@ -252,7 +252,7 @@ void gemm_cl(const unsigned int layout, bool TransA, bool TransB,
 
   // Read the result back to C
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
-    clblast_cc->command_queue_inst_, M * N * sizeof(float), C);
+    clblast_cc->getCommandQueueManager(), M * N * sizeof(float), C);
 }
 
 void gemm_batched_cl(const unsigned int layout, bool TransA, bool TransB,

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -170,7 +170,7 @@ void MemoryPool::allocate() {
 #ifdef ENABLE_OPENCL
   auto *cl_context =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-  mem_pool = cl_context->context_inst_.createSVMRegion(pool_size);
+  mem_pool = cl_context->getContextManager().createSVMRegion(pool_size);
 
   if (mem_pool == nullptr) {
     throw std::runtime_error("Failed to allocate SVM memory pool of size " +
@@ -271,7 +271,7 @@ void MemoryPool::deallocate() {
 #ifdef ENABLE_OPENCL
     auto *cl_context =
       static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
-    cl_context->context_inst_.releaseSVMRegion(mem_pool);
+    cl_context->getContextManager().releaseSVMRegion(mem_pool);
 #else
     free(mem_pool);
 #endif


### PR DESCRIPTION
Make ContextManager, CommandQueueManager and BufferManager owned by ClContext instead of global singleton objects It gives us better control over lifetime of this objects

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped
