### PR TITLE
float_tensor: fix dangerous lamba def

### DIFF
--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -86,9 +86,9 @@ public:
 
     MemoryData *mem_data =
       new MemoryData((void *)(new float[dim.getDataLen()]()));
-    data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
-      delete[] mem_data->getAddr<float>();
-      delete mem_data;
+    data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *ptr) {
+      delete[] ptr->getAddr<float>();
+      delete ptr;
     });
 
     offset = 0;


### PR DESCRIPTION
Please do not play with scoping.
Do NOT shadow variables, especially when the name is concrete or the two names are located pretty close.

PTAL @djeong20

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the parameter in the `std::shared_ptr<MemoryData>` custom deleter within `nntrainer/tensor/float_tensor.h` to avoid shadowing, with no functional change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de388aa91365fc874021676830b1be637af805b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->