### PR TITLE
uint4_tensor: missing delete

### DIFF
--- a/nntrainer/tensor/uint4_tensor.cpp
+++ b/nntrainer/tensor/uint4_tensor.cpp
@@ -74,8 +74,9 @@ Uint4QTensor::Uint4QTensor(
     void
       *)(new uint8_t[(dim.getDataLen() + 1) / 2 + sizeof(float) * scale_size() +
                      sizeof(unsigned int) * scale_size()]()));
-  data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *mem_data) {
-    delete[] mem_data->getAddr<uint8_t>();
+  data = std::shared_ptr<MemoryData>(mem_data, [](MemoryData *ptr) {
+    delete[] ptr->getAddr<uint8_t>();
+    delete ptr;
   });
 
   offset = 0;


### PR DESCRIPTION
It appears that the lamba is missing delete.

PTAL: @djeong20


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `MemoryData` is deleted in `Uint4QTensor` constructor’s `shared_ptr` deleter to properly free allocated memory.
> 
> - **Memory management**: Update `shared_ptr` custom deleter in `nntrainer/tensor/uint4_tensor.cpp` to delete both the underlying `uint8_t` buffer and the `MemoryData` object in the `Uint4QTensor` constructor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab4c25d2c8cccc523db699c0592a01c40780e70f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->