### PR TITLE
Disable log on Windows

### DIFF
--- a/nntrainer/nntrainer_log.h
+++ b/nntrainer/nntrainer_log.h
@@ -40,42 +40,49 @@
 #elif defined(__ANDROID__)
 #include <android/log.h>
 
-#define ml_logi(...) \
+#define ml_logi(...)                                                           \
   __android_log_print(ANDROID_LOG_INFO, TAG_NAME, __VA_ARGS__)
 
-#define ml_logw(...) \
+#define ml_logw(...)                                                           \
   __android_log_print(ANDROID_LOG_WARN, TAG_NAME, __VA_ARGS__)
 
-#define ml_loge(...) \
+#define ml_loge(...)                                                           \
   __android_log_print(ANDROID_LOG_ERROR, TAG_NAME, __VA_ARGS__)
 
-#define ml_logd(...) \
+#define ml_logd(...)                                                           \
   __android_log_print(ANDROID_LOG_DEBUG, TAG_NAME, __VA_ARGS__)
+
+#elif defined(_WIN32)
+
+#define ml_logi(format, ...)
+#define ml_logw(format, ...)
+#define ml_loge(format, ...)
+#define ml_logd(format, ...)
 
 #else /* Linux distro */
 #include <nntrainer_logger.h>
 
 #if !defined(ml_logi)
-#define ml_logi(format, ...)                                                \
-  __nntrainer_log_print(NNTRAINER_LOG_INFO, "(%s:%s:%d) " format, __FILE__, \
+#define ml_logi(format, ...)                                                   \
+  __nntrainer_log_print(NNTRAINER_LOG_INFO, "(%s:%s:%d) " format, __FILE__,    \
                         __func__, __LINE__, ##__VA_ARGS__)
 #endif
 
 #if !defined(ml_logw)
-#define ml_logw(format, ...)                                                \
-  __nntrainer_log_print(NNTRAINER_LOG_WARN, "(%s:%s:%d) " format, __FILE__, \
+#define ml_logw(format, ...)                                                   \
+  __nntrainer_log_print(NNTRAINER_LOG_WARN, "(%s:%s:%d) " format, __FILE__,    \
                         __func__, __LINE__, ##__VA_ARGS__)
 #endif
 
 #if !defined(ml_loge)
-#define ml_loge(format, ...)                                                 \
-  __nntrainer_log_print(NNTRAINER_LOG_ERROR, "(%s:%s:%d) " format, __FILE__, \
+#define ml_loge(format, ...)                                                   \
+  __nntrainer_log_print(NNTRAINER_LOG_ERROR, "(%s:%s:%d) " format, __FILE__,   \
                         __func__, __LINE__, ##__VA_ARGS__)
 #endif
 
 #if !defined(ml_logd)
-#define ml_logd(format, ...)                                                 \
-  __nntrainer_log_print(NNTRAINER_LOG_DEBUG, "(%s:%s:%d) " format, __FILE__, \
+#define ml_logd(format, ...)                                                   \
+  __nntrainer_log_print(NNTRAINER_LOG_DEBUG, "(%s:%s:%d) " format, __FILE__,   \
                         __func__, __LINE__, ##__VA_ARGS__)
 #endif
 


### PR DESCRIPTION
This pull request disables the logging functionality for Windows.
There's an issue with the Windows application in creating and accessing the log file directory using nntrainer_logger.
As a result, I have decided to turn off the logging feature on Windows.

**If anyone has a better solution for logging that does not involve nntrainer_logger, please let me know.**
