### PR TITLE
[layer] fix duplicate indices issues for layer enum

### DIFF
--- a/api/ccapi/include/layer.h
+++ b/api/ccapi/include/layer.h
@@ -111,20 +111,27 @@ enum LayerType {
     ML_TRAIN_LAYER_TYPE_LOSS_CROSS_ENTROPY_SOFTMAX, /**< Cross Entropy with
                                                        Softmax Loss Layer type
                                                      */
-  LAYER_TIME_DIST,       /**< Time Distributed Layer type */
-  LAYER_BACKBONE_TFLITE, /**< Backbone using TFLite */
-  LAYER_RESHAPE,         /**< Reshape Layer type */
-  LAYER_REDUCE_MEAN,     /**< Reduce mean Layer type */
+  LAYER_RMSNORM = ML_TRAIN_LAYER_TYPE_RMSNORM,      /**<RMS NORM Layer */
+  LAYER_TRANSPOSE = ML_TRAIN_LAYER_TYPE_TRANSPOSE,  /**< Transpose Layer type */
+  LAYER_CHANNEL_SHUFFLE =
+    ML_TRAIN_LAYER_TYPE_CHANNEL_SHUFFLE, /**< Channel Shuffle Layer type */
   LAYER_REDUCE_SUM =
     ML_TRAIN_LAYER_TYPE_REDUCE_SUM, /**< Reduce sum Layer type */
-  LAYER_LOSS_CONSTANT_DERIVATIVE,   /**< Synthetic loss layer to feed constant
-                                       derivative */
-  LAYER_UPSAMPLE2D,                 /**< Upsample 2D Layer type */
-  LAYER_RMSNORM = ML_TRAIN_LAYER_TYPE_RMSNORM,     /**<RMS NORM Layer */
-  LAYER_TRANSPOSE = ML_TRAIN_LAYER_TYPE_TRANSPOSE, /**< Transpose Layer type */
-  LAYER_CHANNEL_SHUFFLE =
-    ML_TRAIN_LAYER_TYPE_CHANNEL_SHUFFLE,      /**< Channel Shuffle Layer type */
-  LAYER_UNKNOWN = ML_TRAIN_LAYER_TYPE_UNKNOWN /**< Unknown */
+  LAYER_REDUCE_MEAN =
+    ML_TRAIN_LAYER_TYPE_REDUCE_MEAN,           /**< Reduce mean Layer type */
+  LAYER_RESHAPE = ML_TRAIN_LAYER_TYPE_RESHAPE, /**< Reshape Layer type */
+  LAYER_UPSAMPLE2D =
+    ML_TRAIN_LAYER_TYPE_UPSAMPLE2D, /**< Upsample 2D Layer type */
+
+  LAYER_UNKNOWN = ML_TRAIN_LAYER_TYPE_UNKNOWN, /**< Unknown */
+
+  LAYER_TIME_DIST =
+    ML_TRAIN_LAYER_EXPERIMENTAL, /**< Time Distributed Layer type */
+  LAYER_BACKBONE_TFLITE =
+    ML_TRAIN_LAYER_EXPERIMENTAL + 1, /**< Backbone using TFLite */
+  LAYER_LOSS_CONSTANT_DERIVATIVE =
+    ML_TRAIN_LAYER_EXPERIMENTAL + 2, /**< Synthetic loss layer to feed
+        constant derivative */
 };
 
 /**

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -13,6 +13,8 @@
 #ifndef __TIZEN_MACHINELEARNING_NNTRAINER_API_COMMON_H__
 #define __TIZEN_MACHINELEARNING_NNTRAINER_API_COMMON_H__
 
+#define ML_TRAIN_LAYER_EXPERIMENTAL (10000)
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -83,6 +85,11 @@ typedef enum {
     45,                         /**< Channel Shuffle Layer type (Since 9.0)*/
   ML_TRAIN_LAYER_TYPE_NEG = 46, /**< Neg Layer type (Since 9.0)*/
   ML_TRAIN_LAYER_TYPE_REDUCE_SUM = 48, /**< ReduceSum Layer type (Since 9.0) */
+  ML_TRAIN_LAYER_TYPE_REDUCE_MEAN =
+    51,                             /**< ReduceMean Layer type (Since 10.0) */
+  ML_TRAIN_LAYER_TYPE_RESHAPE = 52, /**< Reshape Layer type (Since 10.0) */
+  ML_TRAIN_LAYER_TYPE_UPSAMPLE2D =
+    53, /**< Upsample2D Layer type (Since 10.0) */
   ML_TRAIN_LAYER_TYPE_PREPROCESS_FLIP =
     300, /**< Preprocess flip Layer (Since 6.5) */
   ML_TRAIN_LAYER_TYPE_PREPROCESS_TRANSLATE =


### PR DESCRIPTION
The current layer enum indices are managed separately in
`layer.h` and `nntrainer-api-common.h`.

For layers that are distributed through the ml-api,
`layer.h` maps to the enums defined in `nntrainer-api-common.h`.

But as the number of layers grew, I discovered that some unmapped layers
were receiving duplicate index values, leading to unintended behavior.

** Fix **
- Assign indices starting from 1000 to any layer that does not have a
  mapping, ensuring that unmapped layers never clash with existing
indices.

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>