### PR TITLE
Possible memleak fix: delete[] for arrays

### DIFF
--- a/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.cc
+++ b/nnstreamer/tensor_trainer/tensor_trainer_nntrainer.cc
@@ -407,11 +407,11 @@ NNTrainer::TensorsQueue::~TensorsQueue() {
   for (auto &data : queue) {
     for (auto inputs : data.inputs) {
       ml_logd("free: ##I addr:%p", inputs);
-      delete inputs;
+      delete[] inputs;
     }
     for (auto labels : data.labels) {
       ml_logd("free: ##L addr:%p", labels);
-      delete labels;
+      delete[] labels;
     }
   }
 }


### PR DESCRIPTION
The inputs and labels are arrays (new char[...]), not single objects (new char). Apply delete[] for arrays:
https://stackoverflow.com/questions/2425728/what-is-the-difference-between-delete-and-delete
