### PR TITLE
Update Windows Native Clang Configuration

### DIFF
--- a/windows-native-clang.ini
+++ b/windows-native-clang.ini
@@ -3,13 +3,15 @@ enable-tflite-backbone=false
 enable-nnstreamer-backbone=false
 enable-tflite-interpreter=false
 install-app=false
-openblas-num-threads = 6
+enable-opencl=false
 
 [built-in options]
 werror=false
 c_std='c17'
 cpp_std='c++20'
 platform='windows'
+vsenv = true
+default_library = 'static'
 
 [binaries]
 c = 'clang'


### PR DESCRIPTION
This pull request updates the Windows native Clang configuration file.
This patch removes the BLAS number of threads option and sets a static build as the default.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped