### PR TITLE
Update OpenCL Kernels for INT4 Computation with Runtime Macro Calculation

### DIFF
--- a/nntrainer/tensor/cl_operations/cl_kernels/int4_quantize_input.cl
+++ b/nntrainer/tensor/cl_operations/cl_kernels/int4_quantize_input.cl
@@ -9,23 +9,29 @@
 
 kernel void quantize_input_int4(const __global half *restrict input,
                                 __global char *restrict quantized_input,
-                                __global half *restrict quan_var) {
+                                __global half *restrict quan_var,
+                                const int size_n,
+                                const int size_k,
+                                const int quantization_group_size) {
   const uint offset = get_global_id(0);
-  const uint input_offset = offset * SIZE_QUANTIZATION_GROUP;
-  const uint quantize_block = SIZE_QUANTIZATION_GROUP / 4;
+  const uint input_offset = offset * quantization_group_size;
+  const uint quantize_block = quantization_group_size / 4;
   half4 input_0;
   char4 quantized_value;
-  half max[quantize_block];
+  half max_vals[32] = {0}; // MAX_QUANTIZATION_GROUP_SIZE / 4 = 128 / 4 = 32
 
-  unroll_for(uint i = 0; i < quantize_block; ++i) {
+  for(uint i = 0; i < quantize_block; ++i) {
     input_0 = vload4(0, &input[input_offset + (i * 4)]);
-    max[i] = fmax(fmax(fabs(input_0[0]), fabs(input_0[1])),
+    max_vals[i] = fmax(fmax(fabs(input_0[0]), fabs(input_0[1])),
                   fmax(fabs(input_0[2]), fabs(input_0[3])));
   }
 
-  half max_value = fmax(fmax(fmax(max[0], max[1]), fmax(max[2], max[3])),
-                        fmax(fmax(max[4], max[5]), fmax(max[6], max[7])));
-  max_value = fmax(max_value, 0.001h);
+  half max_value = 0.001h;
+  for (uint i = 0; i < quantize_block; i += 8) {
+    half temp = fmax(fmax(fmax(max_vals[i], max_vals[i + 1]), fmax(max_vals[i + 2], max_vals[i + 3])),
+                     fmax(fmax(max_vals[i + 4], max_vals[i + 5]), fmax(max_vals[i + 6], max_vals[i + 7])));
+    max_value = fmax(max_value, temp);
+  }
 
   float quan_scale = convert_float(max_value) / 127.0f;
 
@@ -42,36 +48,42 @@ kernel void quantize_input_int4(const __global half *restrict input,
 
 kernel void quantize_input_int4_pad(const __global half *restrict input,
                                     __global char *restrict quantized_input,
-                                    __global half *restrict quan_var) {
+                                    __global half *restrict quan_var,
+                                    const int size_n,
+                                    const int size_k,
+                                    const int quantization_group_size) {
   const uint group_id = get_global_id(0);
-  const uint groups_in_row = ALIGN_SIZE_K / SIZE_QUANTIZATION_GROUP;
+  const uint groups_in_row = ALIGN(size_k, quantization_group_size) / quantization_group_size;
   const uint row_id = group_id / groups_in_row;
   const uint group_id_in_row = group_id % groups_in_row;
   const uint input_offset =
-    (row_id * SIZE_K) + (group_id_in_row * SIZE_QUANTIZATION_GROUP);
-  const uint output_offset = group_id * SIZE_QUANTIZATION_GROUP;
-  const uint max_quantize_block = SIZE_QUANTIZATION_GROUP / 4;
+    (row_id * size_k) + (group_id_in_row * quantization_group_size);
+  const uint output_offset = group_id * quantization_group_size;
+  const uint max_quantize_block = quantization_group_size / 4;
   uint quantize_block;
 
   if (group_id_in_row == groups_in_row - 1) {
-    quantize_block = (SIZE_QUANTIZATION_GROUP - (ALIGN_SIZE_K - SIZE_K)) / 4;
+    quantize_block = (quantization_group_size - (ALIGN(size_k, quantization_group_size) - size_k)) / 4;
   } else {
-    quantize_block = SIZE_QUANTIZATION_GROUP / 4;
+    quantize_block = quantization_group_size / 4;
   }
 
   half4 input_0;
   char4 quantized_value;
-  half max[max_quantize_block] = {0};
+  half max_vals[32] = {0}; // MAX_QUANTIZATION_GROUP_SIZE / 4 = 128 / 4 = 32
 
-  unroll_for(uint i = 0; i < quantize_block; ++i) {
+  for(uint i = 0; i < quantize_block; ++i) {
     input_0 = vload4(0, &input[input_offset + (i * 4)]);
-    max[i] = fmax(fmax(fabs(input_0[0]), fabs(input_0[1])),
+    max_vals[i] = fmax(fmax(fabs(input_0[0]), fabs(input_0[1])),
                   fmax(fabs(input_0[2]), fabs(input_0[3])));
   }
 
-  half max_value = fmax(fmax(fmax(max[0], max[1]), fmax(max[2], max[3])),
-                        fmax(fmax(max[4], max[5]), fmax(max[6], max[7])));
-  max_value = fmax(max_value, 0.001h);
+  half max_value = 0.001h;
+  for (uint i = 0; i < quantize_block; i += 8) {
+     half temp = fmax(fmax(fmax(max_vals[i], max_vals[i + 1]), fmax(max_vals[i + 2], max_vals[i + 3])),
+                      fmax(fmax(max_vals[i + 4], max_vals[i + 5]), fmax(max_vals[i + 6], max_vals[i + 7])));
+     max_value = fmax(max_value, temp);
+  }
 
   float quan_scale = convert_float(max_value) / 127.0f;
 


### PR DESCRIPTION
This PR updates the OpenCL kernels for INT4 computation by eliminating compile options.
This patch now computes macros as runtime variables within the kernel functions.
This change reduces engine initialization time by initializing and building the kernel only once.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped
