### PR TITLE
Meson: Fix Meson's b_vscrt handling for Clang by switching to clang-cl

### DIFF
--- a/windows-native-clang.ini
+++ b/windows-native-clang.ini
@@ -6,17 +6,18 @@ install-app=false
 enable-opencl=false
 
 [built-in options]
-werror=false
-c_std='c17'
-cpp_std='c++20'
-platform='windows'
+werror = false
+c_std = 'c17'
+cpp_std = 'c++20'
+platform = 'windows'
 vsenv = true
 default_library = 'static'
+b_vscrt = 'static_from_buildtype'
 
 [binaries]
-c = 'clang'
-cpp = 'clang++'
-ar = 'llvm-ar'
-c_ld = 'lld'
-cpp_ld = 'lld'
+c = 'clang-cl'
+cpp = 'clang-cl'
+ar = 'llvm-lib'
+c_ld = 'link'
+cpp_ld = 'link'
 strip = 'llvm-strip'


### PR DESCRIPTION
This pull request addresses the known limitations in Meson related to applying the b_vscrt settings for clang++ in builds.
The patch replaces clang and clang++ with clang-cl, which correctly pulls the necessary MSVC debug CRT and STL.
This change allows Clang to behave like MSVC's cl.exe, enabling b_vscrt to select the appropriate MSVC runtime (e.g., `/MTd` for debug builds).

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped