### PR TITLE
[Coverage] Make Coverage Result & Deploy to nntrainer.github.io

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,82 @@
+name: "Code Coverage"
+
+on:
+  schedule:
+    # 05:00 AM (KST) daily = 20:00 UTC previous day
+    - cron: "0 20 * * *"
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-24.04
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    
+    - name: Install dependencies
+      run: |
+        sudo add-apt-repository -y ppa:nnstreamer/ppa
+        sudo apt-get update
+        sudo apt-get install -y gcc-13 g++-13 pkg-config libopenblas-dev \
+          libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev \
+          nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev \
+          ml-api-common-dev flatbuffers-compiler ml-inference-api-dev \
+          libunwind-dev meson ninja-build lcov
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
+    
+    - name: Configure with coverage
+      run: |
+        meson setup build_coverage \
+          -Db_coverage=true \
+          -Denable-test=true \
+          -Denable-fp16=false
+    
+    - name: Build
+      run: ninja -C build_coverage
+    
+    - name: Run tests
+      run: ninja -C build_coverage test
+    
+    - name: Generate coverage report
+      run: |
+        cd build_coverage
+        lcov --directory . --capture --output-file coverage.info \
+          --ignore-errors mismatch,empty,unused
+        lcov --remove coverage.info \
+          '/usr/*' \
+          '*/subprojects/*' \
+          '*/test/*' \
+          '*/Applications/*' \
+          --output-file coverage_filtered.info \
+          --ignore-errors unused
+        genhtml coverage_filtered.info \
+          --output-directory coverage_html \
+          --ignore-errors unmapped
+    
+    - name: Create coverage badge
+      run: |
+        COVERAGE=$(lcov --summary build_coverage/coverage_filtered.info 2>&1 | grep "lines" | awk '{print $2}' | sed 's/%//')
+        echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"brightgreen\"}" > build_coverage/coverage_html/coverage.json
+        echo "Coverage: $COVERAGE%"
+    
+    - name: Clone nntrainer.github.io
+      run: |
+        git clone https://x-access-token:${{ secrets.COVERAGE_DEPLOY_TOKEN }}@github.com/nntrainer/nntrainer.github.io.git deploy_repo
+    
+    - name: Copy coverage report
+      run: |
+        rm -rf deploy_repo/coverage_result
+        cp -r build_coverage/coverage_html deploy_repo/coverage_result
+    
+    - name: Push to nntrainer.github.io
+      run: |
+        cd deploy_repo
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add coverage_result/
+        git commit -m "Update coverage report - $(date +'%Y-%m-%d %H:%M:%S')" || echo "No changes to commit"
+        git push
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NNtrainer
 
-[![Code Coverage](http://ci.nnstreamer.ai/nntrainer/ci/badge/codecoverage.svg)](http://ci.nnstreamer.ai/nntrainer/ci/gcov_html/index.html)
+[![Code Coverage](https://img.shields.io/endpoint?url=https://nntrainer.github.io/coverage_result/coverage.json)](https://nntrainer.github.io/coverage_result/)
 ![GitHub repo size](https://img.shields.io/github/repo-size/nnstreamer/nntrainer)
 ![GitHub issues](https://img.shields.io/github/issues/nnstreamer/nntrainer)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/nnstreamer/nntrainer)


### PR DESCRIPTION
## Dependency of the PR
- None

[Coverage] Make Coverage Result & Deploy to nntrainer.github.io/coverage_result

make coverage result with gitaction(linux) & deploy changed to github.io

then we can check coverage status at https://nntrainer.github.io/coverage_result

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

 Signed-off-by: Donghak PARK <donghak.park@samsung.com>
