### PR TITLE
[do not merge] fix input/output order issue

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -1326,7 +1326,7 @@ int NetworkGraph::initialize(ExecutionMode mode,
                                           auto &&pred, auto &&identify) {
     if (conns.empty()) {
       for (unsigned int i = 0; i < graph.size(); ++i) {
-        auto lnode = getSortedLayerNode(i).get();
+        auto lnode = LNODE(graph.getNode(i)).get();
         if (!pred(lnode)) {
           continue;
         }
@@ -1538,7 +1538,7 @@ int NetworkGraph::reinitialize(
                                           auto &&pred, auto &&identify) {
     if (conns.empty()) {
       for (unsigned int i = 0; i < graph.size(); ++i) {
-        auto lnode = getSortedLayerNode(i).get();
+        auto lnode = LNODE(graph.getNode(i)).get();
         if (!pred(lnode)) {
           continue;
         }


### PR DESCRIPTION
It resolved the issue where the input and output order got mixed up
after compilation (a single line of code within `network_graph`).

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>