### PR TITLE
rotary_emb_kernel fix

### DIFF
--- a/nntrainer/cl_buffer_manager.cpp
+++ b/nntrainer/cl_buffer_manager.cpp
@@ -22,9 +22,9 @@ namespace nntrainer {
 void ClBufferManager::initBuffers() {
   inBufferA = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
   inBufferB = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
-  inBufferC = new opencl::Buffer(context_inst_, unused_buffer_bytes, true);
+  inBufferC = new opencl::Buffer(context_inst_, buffer_size_bytes, true);
   outBufferA = new opencl::Buffer(context_inst_, buffer_size_bytes, false);
-  outBufferB = new opencl::Buffer(context_inst_, unused_buffer_bytes, false);
+  outBufferB = new opencl::Buffer(context_inst_, buffer_size_bytes, false);
 
   data_input = context_inst_.createSVMRegion(buffer_size_bytes);
   for (unsigned int i = 0; i < max_qs; ++i) {

--- a/nntrainer/tensor/cl_operations/attention_kernels_templates.h
+++ b/nntrainer/tensor/cl_operations/attention_kernels_templates.h
@@ -86,14 +86,14 @@ inline static void rotary_emb_cl_internal(
       break;
     }
 
-    result = cl_buffer_manager.getInBufferC()->WriteDataRegion(
+    result = cl_buffer_manager.getOutBufferB()->WriteDataRegion(
       cl_context->command_queue_inst_, dim3_size, cos_.data());
     if (!result) {
       printf("Failed to write cos data\n");
       break;
     }
 
-    result = cl_buffer_manager.getInBufferC()->WriteDataRegion(
+    result = cl_buffer_manager.getOutBufferB()->WriteDataRegion(
       cl_context->command_queue_inst_, dim4_size, sin_.data(), 0, dim3_size);
     if (!result) {
       printf("Failed to write sin data\n");
@@ -128,14 +128,14 @@ inline static void rotary_emb_cl_internal(
       break;
     }
 
-    result = kernel->SetKernelArguments(4, cl_buffer_manager.getInBufferC(),
+    result = kernel->SetKernelArguments(4, cl_buffer_manager.getOutBufferB(),
                                         sizeof(cl_mem));
     if (!result) {
       printf("Failed to set cosBuf argument\n");
       break;
     }
 
-    result = kernel->SetKernelArguments(5, cl_buffer_manager.getInBufferC(),
+    result = kernel->SetKernelArguments(5, cl_buffer_manager.getOutBufferB(),
                                         sizeof(cl_mem));
     if (!result) {
       printf("Failed to set sinBuf argument\n");


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>rotary_emb_kernel fix</summary><br />

attention kernels attempted to write to a read-only buffer of size "unused_buffer_bytes" = sizeof(float).

Please note that the 2 tests affected by this bug (rotary_emb_kernel_FP32 and rotary_emb_kernel_FP32_case2) still randomly fail (from run to run), which means there's still more to debug. 


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Anna Szal <a.szal@samsung.com>

</details>


### Summary

- fixed a bug in CL Buffer Manager 

Signed-off-by: Anna Szal <a.szal@samsung.com>
