### PR TITLE
l2norm test fix

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -296,6 +296,14 @@ float snrm2(const unsigned int N, const float *X, const unsigned int incX) {
 #endif
 }
 
+double dnrm2(const unsigned int N, const double *X, const unsigned int incX) {
+#ifdef USE_BLAS
+  return __cblas_dnrm2(N, X, incX);
+#else
+  return __fallback_dnrm2(N, X, incX);
+#endif
+}
+
 void sgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
            const unsigned int M, const unsigned int N, const unsigned int K,
            const float alpha, const float *A, const unsigned int lda,

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -809,6 +809,12 @@ void sscal(const unsigned int N, const float alpha, float *X,
  * @param[in] X float * for Vector X
  */
 float snrm2(const unsigned int N, const float *X, const unsigned int incX);
+/**
+ * @brief     dnrm2 computation : Euclidean norm
+ * @param[in] N number of elements in X
+ * @param[in] X double * for Vector X
+ */
+double dnrm2(const unsigned int N, const double *X, const unsigned int incX);
 
 /**
  * @brief     copy function : Y = X

--- a/nntrainer/tensor/cpu_backend/cblas_interface/cblas_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/cblas_interface/cblas_interface.cpp
@@ -73,6 +73,11 @@ float __cblas_snrm2(const unsigned int N, const float *X,
   return cblas_snrm2(N, X, incX);
 }
 
+double __cblas_dnrm2(const unsigned int N, const double *X,
+                    const unsigned int incX) {
+  return cblas_dnrm2(N, X, incX);
+}
+
 void __cblas_sgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
                    const unsigned int M, const unsigned int N,
                    const unsigned int K, const float alpha, const float *A,

--- a/nntrainer/tensor/cpu_backend/cblas_interface/cblas_interface.h
+++ b/nntrainer/tensor/cpu_backend/cblas_interface/cblas_interface.h
@@ -82,6 +82,13 @@ void __cblas_sscal(const unsigned int N, const float alpha, float *X,
 float __cblas_snrm2(const unsigned int N, const float *X,
                     const unsigned int incX);
 /**
+ * @brief     dnrm2 computation : Euclidean norm
+ * @param[in] N number of elements in X
+ * @param[in] X double * for Vector X
+ */
+double __cblas_dnrm2(const unsigned int N, const double *X,
+                    const unsigned int incX);
+/**
  * @brief     sgemm computation  : Y = alpha*op(A)*op(B) + beta*C,
  * where op(X) is one of X or X**T
  * @param[in] TStorageOrder Row major / Col major

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -109,6 +109,10 @@ float snrm2(const unsigned int N, const float *X, const unsigned int incX) {
   return __fallback_snrm2(N, X, incX);
 }
 
+double dnrm2(const unsigned int N, const double *X, const unsigned int incX) {
+  return __fallback_dnrm2(N, X, incX);
+}
+
 void sgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
            const unsigned int M, const unsigned int N, const unsigned int K,
            const float alpha, const float *A, const unsigned int lda,

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -668,6 +668,13 @@ void sscal(const unsigned int N, const float alpha, float *X,
  */
 float snrm2(const unsigned int N, const float *X, const unsigned int incX);
 /**
+ * @brief     dnrm2 computation : Euclidean norm
+ * @param[in] N number of elements in X
+ * @param[in] X double * for Vector X
+ */
+double dnrm2(const unsigned int N, const double *X, const unsigned int incX);
+
+/**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
  * @param[in] X float * for Vector X

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -67,6 +67,19 @@ float __fallback_snrm2(const unsigned int N, const float *X,
   return sqrt(sum);
 }
 
+double __fallback_dnrm2(const unsigned int N, const double *X,
+                       const unsigned int incX) {
+  assert(incX > 0);
+  double sum = 0.0;
+  double tmp;
+
+  for (unsigned int i = 0; i < N; i++) {
+    tmp = X[i * incX];
+    sum += tmp * tmp;
+  }
+  return sqrt(sum);
+}
+
 void __fallback_copy_s16_fp32(const unsigned int N, const int16_t *X,
                               float *Y) {
   for (unsigned int i = 0; i < N; ++i) {

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -614,6 +614,13 @@ void __fallback_sscal(const unsigned int N, const float alpha, float *X,
 float __fallback_snrm2(const unsigned int N, const float *X,
                        const unsigned int incX);
 /**
+ * @brief     dnrm2 computation : Euclidean norm
+ * @param[in] N number of elements in X
+ * @param[in] X double * for Vector X
+ */
+double __fallback_dnrm2(const unsigned int N, const double *X,
+                       const unsigned int incX);
+/**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X
  * @param[in] X int16_t * for Vector X

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -241,6 +241,14 @@ float snrm2(const unsigned int N, const float *X, const unsigned int incX) {
 #endif
 }
 
+double dnrm2(const unsigned int N, const double *X, const unsigned int incX) {
+#ifdef USE_BLAS
+  return __cblas_dnrm2(N, X, incX);
+#else
+  return __fallback_dnrm2(N, X, incX);
+#endif
+}
+
 void sgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
            const unsigned int M, const unsigned int N, const unsigned int K,
            const float alpha, const float *A, const unsigned int lda,

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -570,7 +570,12 @@ void sscal(const unsigned int N, const float alpha, float *X,
  * @param[in] X float * for Vector X
  */
 float snrm2(const unsigned int N, const float *X, const unsigned int incX);
-
+/**
+ * @brief     snrm2 computation : Euclidean norm
+ * @param[in] N number of elements in X
+ * @param[in] X double * for Vector X
+ */
+double dnrm2(const unsigned int N, const double *X, const unsigned int incX);
 /**
  * @brief     copy function : Y = X
  * @param[in] N number of elements in X

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -103,92 +103,107 @@ private:
   nntrainer::IniWrapper ini;
 };
 
-#define GEN_TEST_INPUT_NHWC(input, eqation_i_j_k_l) \
-  do {                                              \
-    for (int i = 0; i < batch; ++i) {               \
-      for (int j = 0; j < height; ++j) {            \
-        for (int k = 0; k < width; ++k) {           \
-          for (int l = 0; l < channel; ++l) {       \
-            float val = (eqation_i_j_k_l);          \
-            input.setValue(i, l, j, k, val);        \
-          }                                         \
-        }                                           \
-      }                                             \
-    }                                               \
+#define GEN_TEST_INPUT_NHWC(input, eqation_i_j_k_l)                            \
+  do {                                                                         \
+    for (int i = 0; i < batch; ++i) {                                          \
+      for (int j = 0; j < height; ++j) {                                       \
+        for (int k = 0; k < width; ++k) {                                      \
+          for (int l = 0; l < channel; ++l) {                                  \
+            float val = (eqation_i_j_k_l);                                     \
+            input.setValue(i, l, j, k, val);                                   \
+          }                                                                    \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
   } while (0)
 
-#define GEN_TEST_INPUT(input, eqation_i_j_k_l) \
-  do {                                         \
-    for (int i = 0; i < batch; ++i) {          \
-      for (int j = 0; j < channel; ++j) {      \
-        for (int k = 0; k < height; ++k) {     \
-          for (int l = 0; l < width; ++l) {    \
-            float val = (eqation_i_j_k_l);     \
-            input.setValue(i, j, k, l, val);   \
-          }                                    \
-        }                                      \
-      }                                        \
-    }                                          \
+#define GEN_TEST_INPUT(input, eqation_i_j_k_l)                                 \
+  do {                                                                         \
+    for (int i = 0; i < batch; ++i) {                                          \
+      for (int j = 0; j < channel; ++j) {                                      \
+        for (int k = 0; k < height; ++k) {                                     \
+          for (int l = 0; l < width; ++l) {                                    \
+            float val = (eqation_i_j_k_l);                                     \
+            input.setValue(i, j, k, l, val);                                   \
+          }                                                                    \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
   } while (0)
 
-#define GEN_TEST_INPUT_RAND(input, min, max)                       \
-  do {                                                             \
-    for (int i = 0; i < batch; ++i) {                              \
-      for (int j = 0; j < channel; ++j) {                          \
-        for (int k = 0; k < height; ++k) {                         \
-          for (int l = 0; l < width; ++l) {                        \
-            std::uniform_real_distribution<double> dist(min, max); \
-            std::default_random_engine gen((k + 1) * (l + 42));    \
-            float val = dist(gen);                                 \
-            input.setValue(i, j, k, l, val);                       \
-          }                                                        \
-        }                                                          \
-      }                                                            \
-    }                                                              \
+#define GEN_TEST_INPUT_RAND(input, min, max)                                   \
+  do {                                                                         \
+    for (int i = 0; i < batch; ++i) {                                          \
+      for (int j = 0; j < channel; ++j) {                                      \
+        for (int k = 0; k < height; ++k) {                                     \
+          for (int l = 0; l < width; ++l) {                                    \
+            std::uniform_real_distribution<double> dist(min, max);             \
+            std::default_random_engine gen((k + 1) * (l + 42));                \
+            float val = dist(gen);                                             \
+            input.setValue(i, j, k, l, val);                                   \
+          }                                                                    \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
   } while (0)
 
-#define GEN_TEST_INPUT_RAND_B(input, min, max)                     \
-  do {                                                             \
-    for (int i = 0; i < batch; ++i) {                              \
-      for (int j = 0; j < channel; ++j) {                          \
-        for (int k = 0; k < height_b; ++k) {                       \
-          for (int l = 0; l < width_b; ++l) {                      \
-            std::uniform_real_distribution<double> dist(min, max); \
-            std::default_random_engine gen((k + 42) * (l + 1));    \
-            float val = dist(gen);                                 \
-            input.setValue(i, j, k, l, val);                       \
-          }                                                        \
-        }                                                          \
-      }                                                            \
-    }                                                              \
+#define GEN_TEST_INPUT_RAND_B(input, min, max)                                 \
+  do {                                                                         \
+    for (int i = 0; i < batch; ++i) {                                          \
+      for (int j = 0; j < channel; ++j) {                                      \
+        for (int k = 0; k < height_b; ++k) {                                   \
+          for (int l = 0; l < width_b; ++l) {                                  \
+            std::uniform_real_distribution<double> dist(min, max);             \
+            std::default_random_engine gen((k + 42) * (l + 1));                \
+            float val = dist(gen);                                             \
+            input.setValue(i, j, k, l, val);                                   \
+          }                                                                    \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
   } while (0)
 
-#define GEN_TEST_INPUT_B(input, equation_i_j_k_l) \
-  do {                                            \
-    for (int i = 0; i < batch; ++i) {             \
-      for (int j = 0; j < channel; ++j) {         \
-        for (int k = 0; k < height_b; ++k) {      \
-          for (int l = 0; l < width_b; ++l) {     \
-            float val = (equation_i_j_k_l);       \
-            input.setValue(i, j, k, l, val);      \
-          }                                       \
-        }                                         \
-      }                                           \
-    }                                             \
+#define GEN_TEST_INPUT_B(input, equation_i_j_k_l)                              \
+  do {                                                                         \
+    for (int i = 0; i < batch; ++i) {                                          \
+      for (int j = 0; j < channel; ++j) {                                      \
+        for (int k = 0; k < height_b; ++k) {                                   \
+          for (int l = 0; l < width_b; ++l) {                                  \
+            float val = (equation_i_j_k_l);                                    \
+            input.setValue(i, j, k, l, val);                                   \
+          }                                                                    \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
   } while (0)
 
-#define GEN_TEST_INPUT_C(input, equation_i_j_k_l) \
-  do {                                            \
-    for (int i = 0; i < batch_b; ++i) {           \
-      for (int j = 0; j < channel; ++j) {         \
-        for (int k = 0; k < height; ++k) {        \
-          for (int l = 0; l < width; ++l) {       \
-            float val = (equation_i_j_k_l);       \
-            input.setValue(i, j, k, l, val);      \
-          }                                       \
-        }                                         \
-      }                                           \
-    }                                             \
+#define GEN_TEST_INPUT_C(input, equation_i_j_k_l)                              \
+  do {                                                                         \
+    for (int i = 0; i < batch_b; ++i) {                                        \
+      for (int j = 0; j < channel; ++j) {                                      \
+        for (int k = 0; k < height; ++k) {                                     \
+          for (int l = 0; l < width; ++l) {                                    \
+            float val = (equation_i_j_k_l);                                    \
+            input.setValue(i, j, k, l, val);                                   \
+          }                                                                    \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
+  } while (0)
+
+#define GEN_TEST_INPUT_DOUBLE(input, batch, channel, height, width,            \
+                              equation_i_j_k_l)                                \
+  do {                                                                         \
+    for (int i = 0; i < batch; ++i) {                                          \
+      for (int j = 0; j < channel; ++j) {                                      \
+        for (int k = 0; k < height; ++k) {                                     \
+          for (int l = 0; l < width; ++l) {                                    \
+            double val = (equation_i_j_k_l);                                   \
+            input[((i * channel + j) * height + k) * width + l] = val;         \
+          }                                                                    \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
   } while (0)
 
 /**

--- a/test/unittest/unittest_blas_kernels_cl.cpp
+++ b/test/unittest/unittest_blas_kernels_cl.cpp
@@ -1704,6 +1704,7 @@ TEST(blas_kernels, l2norm) {
   const int channel = 1;
   const int height = 768;
   const int width = 768;
+  const int size = batch * channel * height * width;
 
   const float alpha = 1e-1;
   const int MOD = 10;
@@ -1712,20 +1713,21 @@ TEST(blas_kernels, l2norm) {
     nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
 
   nntrainer::Tensor A_fp32(batch, channel, height, width, t_type_nchw_fp32);
-  nntrainer::Tensor B_fp32(batch, channel, height, width, t_type_nchw_fp32);
-
   GEN_TEST_INPUT(A_fp32, ((i * (batch * height * channel) +
                            j * (batch * height) + k * (width) + l + 1) %
                           MOD) *
                            alpha);
 
-  GEN_TEST_INPUT(B_fp32, ((i * (batch * height * channel) +
-                           j * (batch * height) + k * (width) + l + 1) %
-                          MOD) *
-                           alpha);
+  double *B_fp32 = new double[size];
+  GEN_TEST_INPUT_DOUBLE(B_fp32, batch, channel, height, width,
+                        ((i * (batch * height * channel) +
+                          j * (batch * height) + k * (width) + l + 1) %
+                         MOD) *
+                          alpha);
 
   float gpu_result = nrm2Cl(A_fp32);
-  float cpu_result = B_fp32.l2norm();
+  float cpu_result = dnrm2(size, B_fp32, 1);
+  delete[] B_fp32;
 
   EXPECT_FLOAT_EQ(gpu_result, cpu_result);
 }


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>l2norm test fix</summary><br />

**test**: blas_kernels --> l2norm

**problem**: the output was compared against CPU version of the algorithm which turned out to be less precise

**solution**: using fp64 version of the CPU algorithm as ground truth.  To avoid including headers related to CBLAS directly, double-float versions of backend functions were implemented.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Anna Szal <a.szal@samsung.com>

</details>


### Summary

- fix for failing blas_kernels.l2norm test

Signed-off-by: Anna Szal <a.szal@samsung.com>
