### PR TITLE
[onnx] fix issue of weight layer

### DIFF
--- a/nntrainer/compiler/onnx_interpreter.cpp
+++ b/nntrainer/compiler/onnx_interpreter.cpp
@@ -251,8 +251,8 @@ void ONNXInterpreter::loadInputsAndWeights(
     // weight layer should be modified not to use input_shape as a parameter
     representation.push_back(createLayerNode(
       "weight",
-      {withKey("name", cleanName(initializer.name())), withKey("dim", dim),
-       withKey("input_shape", dim),
+      {withKey("name", cleanName(initializer.name())),
+       withKey("weight_dim", dim),
        withKey("tensor_dtype", getDataTypeFromONNX(initializer.data_type())),
        withKey("weight_name", cleanName(initializer.name()))}));
   }

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -1191,7 +1191,7 @@ int NetworkGraph::initialize(ExecutionMode mode,
 
   /** check if the given config of node is of input node */
   auto is_input_node = [](const LayerNode *node) -> bool {
-    return node->getInputConnections().empty();
+    return node->getInputConnections().empty() && !node->isWeightNode();
   };
 
   for (unsigned int idx = 0; idx < graph.size(); ++idx) {
@@ -1403,7 +1403,7 @@ int NetworkGraph::reinitialize(
 
   /** check if the given config of node is of input node */
   auto is_input_node = [](const LayerNode *node) -> bool {
-    return node->getInputConnections().empty();
+    return node->getInputConnections().empty() && !node->isWeightNode();
   };
 
   for (unsigned int idx = 0; idx < graph.size(); ++idx) {

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -114,6 +114,17 @@ public:
 };
 
 /**
+ * @brief Weight Dimension property which saves a single tensor dim
+ *
+ */
+class WeightDim : public GenericShape {
+
+public:
+  static constexpr const char *key = "weight_dim"; /**< unique key to access */
+  using prop_tag = dimension_prop_tag;             /**< property type */
+};
+
+/**
  * @brief properties for shared from
  *
  */
@@ -201,8 +212,9 @@ LayerNode::LayerNode(std::unique_ptr<nntrainer::Layer> &&l) :
   run_context(nullptr),
   layer_node_props(new PropsType(
     props::Name(), props::Distribute(), props::Trainable(), {}, {},
-    props::SharedFrom(), props::ClipGradByGlobalNorm(), props::Packed(),
-    props::WeightDtype(), props::LossScaleForMixed(), props::ComputeEngine())),
+    props::WeightDim(), props::SharedFrom(), props::ClipGradByGlobalNorm(),
+    props::Packed(), props::WeightDtype(), props::LossScaleForMixed(),
+    props::ComputeEngine())),
   layer_node_props_realization(
     new RealizationPropsType(props::Flatten(), props::Activation())),
   loss(new props::Loss()),
@@ -462,6 +474,10 @@ bool LayerNode::hasInputShapeProperty() const {
                      [](const auto &input) { return !input.empty(); });
 }
 
+bool LayerNode::isWeightNode() const {
+  return layer->getType() == "weight" ? true : false;
+}
+
 const std::vector<TensorDim> LayerNode::getInputDimensions() const {
   NNTR_THROW_IF(!run_context, std::runtime_error)
     << __func__ << " layer needs to be finalized first!";
@@ -554,14 +570,14 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
       "Trying to finalizing a layer which is already finalized in layer: " +
       getName());
 
-  std::vector<TensorDim> actual_input_dims;
+  std::vector<TensorDim> init_dims;
   auto &prop_dims = std::get<std::vector<props::InputShape>>(*layer_node_props);
   auto &prop_in_layers =
     std::get<std::vector<props::InputConnection>>(*layer_node_props);
 
   /** prepare input dimensions */
   if (!input_dims.empty()) {
-    actual_input_dims = input_dims;
+    init_dims = input_dims;
     if (hasInputShapeProperty()) {
       std::vector<TensorDim> actual_prop_dims(prop_dims.begin(),
                                               prop_dims.end());
@@ -578,6 +594,9 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
             from_string(tensor_type[0]));
       }
     }
+  } else if (isWeightNode()) {
+    init_dims =
+      std::vector<TensorDim>({std::get<props::WeightDim>(*layer_node_props)});
   } else {
     NNTR_THROW_IF(!hasInputShapeProperty(), std::invalid_argument)
       << "if input dims not given, input shapes must be given by the user as "
@@ -589,9 +608,8 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
       << "input shapes must be one if connection is not given but given "
          "dimesions size of: "
       << prop_dims.size();
-    actual_input_dims =
-      std::vector<TensorDim>(prop_dims.begin(), prop_dims.end());
-    for (auto &d : actual_input_dims) {
+    init_dims = std::vector<TensorDim>(prop_dims.begin(), prop_dims.end());
+    for (auto &d : init_dims) {
       /// Input Tensor type of input layer needs to be float.
       d.setDataType(
         str_converter<enum_class_prop_tag,
@@ -602,7 +620,7 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
     }
   }
 
-  NNTR_THROW_IF(actual_input_dims.size() < getNumInputConnections(),
+  NNTR_THROW_IF(init_dims.size() < getNumInputConnections(),
                 std::invalid_argument)
     << "number of input dimensions must be equal or larger "
     << "than number of input connections, node name: " << getName()
@@ -656,8 +674,8 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
   }
 
   auto context = InitLayerContext(
-    actual_input_dims, out_info, getInPlaceType() != InPlaceType::NONE,
-    getName(), scope, max_norm, tensor_type, loss_scale, mode, compute_engine);
+    init_dims, out_info, getInPlaceType() != InPlaceType::NONE, getName(),
+    scope, max_norm, tensor_type, loss_scale, mode, compute_engine);
 
   layer->finalize(context);
 
@@ -685,14 +703,14 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
  */
 InitLayerContext
 LayerNode::refinalize(const std::vector<TensorDim> &input_dims) {
-  std::vector<TensorDim> actual_input_dims;
+  std::vector<TensorDim> init_dims;
   auto &prop_dims = std::get<std::vector<props::InputShape>>(*layer_node_props);
   auto &prop_in_layers =
     std::get<std::vector<props::InputConnection>>(*layer_node_props);
 
   /** prepare input dimensions */
   if (!input_dims.empty()) {
-    actual_input_dims = input_dims;
+    init_dims = input_dims;
     if (hasInputShapeProperty()) {
       std::vector<TensorDim> actual_prop_dims(prop_dims.begin(),
                                               prop_dims.end());
@@ -701,6 +719,9 @@ LayerNode::refinalize(const std::vector<TensorDim> &input_dims) {
         << "calculated input dimension is different from given input_shape "
            "property";
     }
+  } else if (isWeightNode()) {
+    init_dims =
+      std::vector<TensorDim>({std::get<props::WeightDim>(*layer_node_props)});
   } else {
     NNTR_THROW_IF(!hasInputShapeProperty(), std::invalid_argument)
       << "if input dims not given, input shapes must be given by the user as "
@@ -712,11 +733,10 @@ LayerNode::refinalize(const std::vector<TensorDim> &input_dims) {
       << "input shapes must be one if connection is not given but given "
          "dimesions size of: "
       << prop_dims.size();
-    actual_input_dims =
-      std::vector<TensorDim>(prop_dims.begin(), prop_dims.end());
+    init_dims = std::vector<TensorDim>(prop_dims.begin(), prop_dims.end());
   }
 
-  NNTR_THROW_IF(actual_input_dims.size() < getNumInputConnections(),
+  NNTR_THROW_IF(init_dims.size() < getNumInputConnections(),
                 std::invalid_argument)
     << "number of input dimensions must be equal or larger "
     << "than number of input connections, node name: " << getName()
@@ -748,9 +768,9 @@ LayerNode::refinalize(const std::vector<TensorDim> &input_dims) {
     out_info.push_back(true);
   }
 
-  auto context = InitLayerContext(actual_input_dims, out_info,
-                                  getInPlaceType() != InPlaceType::NONE,
-                                  getName(), scope, max_norm);
+  auto context =
+    InitLayerContext(init_dims, out_info, getInPlaceType() != InPlaceType::NONE,
+                     getName(), scope, max_norm);
 
   layer->finalize(context);
 

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -48,6 +48,7 @@ class Distribute;
 class Flatten;
 class Loss;
 class InputShape;
+class WeightDim;
 class Activation;
 class SharedFrom;
 class InputConnection;
@@ -519,6 +520,13 @@ public:
    * @return bool true if input shape property has set
    */
   bool hasInputShapeProperty() const;
+
+  /**
+   * @brief check whether the layer is weight layer
+   *
+   * @return bool true if weight layer, else false
+   */
+  bool isWeightNode() const;
 
   /**
    * @brief Get the input dimension
@@ -1043,12 +1051,12 @@ will also contain the properties of the layer. The properties will be copied
 upon final creation. Editing properties of the layer after init will not the
 properties in the context/graph unless intended. */
 
-  using PropsType =
-    std::tuple<props::Name, props::Distribute, props::Trainable,
-               std::vector<props::InputConnection>,
-               std::vector<props::InputShape>, props::SharedFrom,
-               props::ClipGradByGlobalNorm, props::Packed, props::WeightDtype,
-               props::LossScaleForMixed, props::ComputeEngine>;
+  using PropsType = std::tuple<props::Name, props::Distribute, props::Trainable,
+                               std::vector<props::InputConnection>,
+                               std::vector<props::InputShape>, props::WeightDim,
+                               props::SharedFrom, props::ClipGradByGlobalNorm,
+                               props::Packed, props::WeightDtype,
+                               props::LossScaleForMixed, props::ComputeEngine>;
 
   using RealizationPropsType = std::tuple<props::Flatten, props::Activation>;
   /** these realization properties results in addition of new layers, hence

--- a/test/unittest/layers/layers_dependent_common_tests.cpp
+++ b/test/unittest/layers/layers_dependent_common_tests.cpp
@@ -57,10 +57,15 @@ TEST_P(LayerSemantics, finalizeValidateLayerNode_p) {
   auto lnode = nntrainer::createLayerNode(expected_type);
   std::vector<std::string> props = {"name=test"};
   std::string input_shape = "input_shape=1:1:1";
+  if (expected_type == "weight") {
+    input_shape = "weight_dim=1:1:1";
+  }
   std::string input_layers = "input_layers=a";
   for (auto idx = 1u; idx < num_inputs; idx++) {
-    input_shape += ",1:1:1";
-    input_layers += ",a";
+    if (expected_type != "weight") {
+      input_shape += ",1:1:1";
+      input_layers += ",a";
+    }
   }
   props.push_back(input_shape);
   props.push_back(input_layers);
@@ -103,10 +108,15 @@ TEST_P(LayerSemantics, setBatchValidateLayerNode_p) {
   auto lnode = nntrainer::createLayerNode(expected_type);
   std::vector<std::string> props = {"name=test"};
   std::string input_shape = "input_shape=1:1:1";
+  if (expected_type == "weight") {
+    input_shape = "weight_dim=1:1:1";
+  }
   std::string input_layers = "input_layers=a";
   for (auto idx = 1u; idx < num_inputs; idx++) {
-    input_shape += ",1:1:1";
-    input_layers += ",a";
+    if (expected_type != "weight") {
+      input_shape += ",1:1:1";
+      input_layers += ",a";
+    }
   }
   props.push_back(input_shape);
   props.push_back(input_layers);
@@ -155,10 +165,15 @@ TEST_P(LayerSemanticsGpu, finalizeValidateLayerNode_p) {
   auto lnode = nntrainer::createLayerNode(expected_type, {"engine=gpu"});
   std::vector<std::string> props = {"name=test"};
   std::string input_shape = "input_shape=1:1:1";
+  if (expected_type == "weight") {
+    input_shape = "weight_dim=1:1:1";
+  }
   std::string input_layers = "input_layers=a";
   for (auto idx = 1u; idx < num_inputs; idx++) {
-    input_shape += ",1:1:1";
-    input_layers += ",a";
+    if (expected_type != "weight") {
+      input_shape += ",1:1:1";
+      input_layers += ",a";
+    }
   }
   props.push_back(input_shape);
   props.push_back(input_layers);
@@ -201,10 +216,15 @@ TEST_P(LayerSemanticsGpu, setBatchValidateLayerNode_p) {
   auto lnode = nntrainer::createLayerNode(expected_type, {"engine=gpu"});
   std::vector<std::string> props = {"name=test"};
   std::string input_shape = "input_shape=1:1:1";
+  if (expected_type == "weight") {
+    input_shape = "weight_dim=1:1:1";
+  }
   std::string input_layers = "input_layers=a";
   for (auto idx = 1u; idx < num_inputs; idx++) {
-    input_shape += ",1:1:1";
-    input_layers += ",a";
+    if (expected_type != "weight") {
+      input_shape += ",1:1:1";
+      input_layers += ",a";
+    }
   }
   props.push_back(input_shape);
   props.push_back(input_layers);


### PR DESCRIPTION
It's rebased version PR of #3413 and fixed some unittest issues.

The input layer was identified during compilation based on the number of
input connections(or property). Howerver, weight layer also has no input
connection, so it causes some issues. this commit resolved these issues.

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>