### PR TITLE
Pull request code review

### DIFF
--- a/pr-3630.patch
+++ b/pr-3630.patch
@@ -1,0 +1,7531 @@
+From fd48dca6700c6848783521257e7258b98d171a38 Mon Sep 17 00:00:00 2001
+From: Daekyoung Jung <dk11.jung@samsung.com>
+Date: Thu, 13 Nov 2025 17:12:03 +0900
+Subject: [PATCH 1/9] Add CUDA context support with build configuration
+
+Adds CUDA context management files (cuda_context.h
+and cuda_context.cpp) that provide similar
+functionality to the existing OpenCL context.
+
+The changes include:
+
+- CudaContext class inheriting from Context and Singleton
+- CUDA kernel management and execution interfaces
+- Build system updates to support CUDA with enable-cuda option
+- Conditional linking of CUDA runtime library for both Windows and Linux
+- Addition of enable-cuda option in meson_options.txt
+
+Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>
+---
+ meson_options.txt          |   1 +
+ nntrainer/cuda_context.cpp | 129 ++++++++++++++++++
+ nntrainer/cuda_context.h   | 260 +++++++++++++++++++++++++++++++++++++
+ nntrainer/meson.build      |  34 +++++
+ 4 files changed, 424 insertions(+)
+ create mode 100644 nntrainer/cuda_context.cpp
+ create mode 100644 nntrainer/cuda_context.h
+
+diff --git a/meson_options.txt b/meson_options.txt
+index ff144ff536..56a2ec035a 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -46,6 +46,7 @@ option('enable-fp16', type: 'boolean', value: false)
+ option('enable-cublas', type: 'boolean', value: false)
+ option('enable-openmp', type: 'boolean', value: true)
+ option('enable-opencl', type: 'boolean', value: false)
++option('enable-cuda', type: 'boolean', value: false)
+ option('enable-biqgemm', type: 'boolean', value: false)
+ option('biqgemm-path', type: 'string', value: '../BiQGEMM')
+ option('enable-benchmarks', type: 'boolean', value : false)
+diff --git a/nntrainer/cuda_context.cpp b/nntrainer/cuda_context.cpp
+new file mode 100644
+index 0000000000..daf09641e6
+--- /dev/null
++++ b/nntrainer/cuda_context.cpp
+@@ -0,0 +1,129 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file    cuda_context.cpp
++ * @date    13 Nov 2025
++ * @see     https://github.com/nnstreamer/nntrainer
++ * @author  Samsung Electronics Co., Ltd.
++ * @bug     No known bugs except for NYI items
++ * @brief   This file contains app context related functions and classes that
++ * manages the global configuration of the current CUDA environment. It also
++ * creates the CUDA stream and context.
++ */
++
++#include "cuda_context.h"
++
++#include <addition_layer.h>
++#include <fc_layer.h>
++#include <nntrainer_log.h>
++#include <reshape_layer.h>
++
++#include <cuda.h>
++#include <cuda_runtime.h>
++
++namespace nntrainer {
++std::mutex cuda_factory_mutex;
++
++void CudaContext::initialize() noexcept {
++  try {
++    if (!cudaInit()) {
++      ml_loge("Error: CudaContext::initialize() failed");
++      return;
++    }
++
++    add_default_object();
++    setMemAllocator(std::make_shared<MemAllocator>());
++
++  } catch (std::exception &e) {
++    ml_loge("cuda_context: registering layers failed!!, reason: %s", e.what());
++  } catch (...) {
++    ml_loge("cuda_context: registering layer failed due to unknown reason");
++  }
++};
++
++void CudaContext::add_default_object() {
++  // Register default layers that support CUDA
++  registerFactory(nntrainer::createLayer<FullyConnectedLayer>,
++                  FullyConnectedLayer::type, ml::train::LayerType::LAYER_FC);
++
++  registerFactory(nntrainer::createLayer<AdditionLayer>, AdditionLayer::type,
++                  ml::train::LayerType::LAYER_ADDITION);
++
++  registerFactory(nntrainer::createLayer<ReshapeLayer>, ReshapeLayer::type,
++                  ml::train::LayerType::LAYER_RESHAPE);
++}
++
++template <typename T>
++const int CudaContext::registerFactory(const FactoryType<T> factory,
++                                       const std::string &key,
++                                       const int int_key) {
++  static_assert(
++    isSupported<T>::value,
++    "cuda_context: given type is not supported for current context");
++
++  auto &index = std::get<IndexType<T>>(factory_map);
++  auto &str_map = std::get<StrIndexType<T>>(index);
++  auto &int_map = std::get<IntIndexType>(index);
++
++  std::string assigned_key = key == "" ? factory({})->getType() : key;
++
++  std::transform(assigned_key.begin(), assigned_key.end(), assigned_key.begin(),
++                 [](unsigned char c) { return std::tolower(c); });
++
++  const std::lock_guard<std::mutex> lock(cuda_factory_mutex);
++  if (str_map.find(assigned_key) != str_map.end()) {
++    ml_loge("cuda_context: cannot register factory with already taken key: %s",
++            key.c_str());
++    throw std::invalid_argument(key);
++  }
++
++  if (int_key != -1 && int_map.find(int_key) != int_map.end()) {
++    ml_loge(
++      "cuda_context: cannot register factory with already taken int key: %d",
++      int_key);
++    throw std::invalid_argument(std::to_string(int_key));
++  }
++
++  int assigned_int_key = int_key == -1 ? str_map.size() + 1 : int_key;
++
++  str_map[assigned_key] = factory;
++  int_map[assigned_int_key] = assigned_key;
++
++  ml_logd("cuda_context: factory has registered with key: %s, int_key: %d",
++          assigned_key.c_str(), assigned_int_key);
++
++  return assigned_int_key;
++}
++
++bool CudaContext::cudaInit() {
++  // if already initialized
++  if (cuda_initialized)
++    return true;
++
++  // Initialize CUDA context
++  cudaError_t err = cudaSetDevice(0);
++  if (err != cudaSuccess) {
++    ml_loge("Failed to set CUDA device: %s", cudaGetErrorString(err));
++    return false;
++  }
++
++  // Create CUDA stream for asynchronous operations
++  err = cudaStreamCreate(&stream_);
++  if (err != cudaSuccess) {
++    ml_loge("Failed to create CUDA stream: %s", cudaGetErrorString(err));
++    return false;
++  }
++
++  cuda_initialized = true;
++  return cuda_initialized;
++}
++
++/**
++ * @copydoc const int CudaContext::registerFactory
++ */
++template const int CudaContext::registerFactory<nntrainer::Layer>(
++  const FactoryType<nntrainer::Layer> factory, const std::string &key,
++  const int int_key);
++
++} // namespace nntrainer
+diff --git a/nntrainer/cuda_context.h b/nntrainer/cuda_context.h
+new file mode 100644
+index 0000000000..3cf1ce8dde
+--- /dev/null
++++ b/nntrainer/cuda_context.h
+@@ -0,0 +1,260 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file    cuda_context.h
++ * @date    13 Nov 2025
++ * @see     https://github.com/nnstreamer/nntrainer
++ * @author  Samsung Electronics Co., Ltd.
++ * @bug     No known bugs except for NYI items
++ * @brief   This file contains app context related functions and classes that
++ * manages the global configuration of the current CUDA environment. It also
++ * creates the CUDA stream and context.
++ */
++
++#ifndef __CUDA_CONTEXT_H__
++#define __CUDA_CONTEXT_H__
++
++#include <algorithm>
++#include <functional>
++#include <memory>
++#include <mutex>
++#include <stdexcept>
++#include <string>
++#include <type_traits>
++#include <unordered_map>
++#include <vector>
++
++#include <cuda.h>
++#include <cuda_runtime.h>
++
++#include <context.h>
++#include <layer.h>
++#include <layer_devel.h>
++#include <mem_allocator.h>
++
++#include "singleton.h"
++
++namespace nntrainer {
++
++extern std::mutex cuda_factory_mutex;
++
++/**
++ * @class CudaContext contains user-dependent configuration for CUDA support
++ * @brief CUDA support for app context
++ */
++class CudaContext : public Context, public Singleton<CudaContext> {
++public:
++  /**
++   * @brief   Default constructor
++   */
++  CudaContext() : Context(std::make_shared<ContextData>()) {}
++
++  /**
++   * @brief destructor to release cuda context
++   */
++  ~CudaContext() override {
++    if (cuda_initialized) {
++      // Release CUDA resources
++      if (stream_) {
++        cudaStreamDestroy(stream_);
++      }
++    }
++  };
++
++  /**
++   * @brief Factory register function, use this function to register custom
++   * object
++   *
++   * @tparam T object to create. Currently Layer is supported
++   * @param factory factory function that creates std::unique_ptr<T>
++   * @param key key to access the factory, if key is empty, try to find key by
++   * calling factory({})->getType();
++   * @param int_key key to access the factory by integer, if it is -1(default),
++   * the function automatically unsigned the key and return
++   * @return const int unique integer value to access the current factory
++   * @throw invalid argument when key and/or int_key is already taken
++   */
++  template <typename T>
++  const int registerFactory(const PtrFactoryType<T> factory,
++                            const std::string &key = "",
++                            const int int_key = -1) {
++    FactoryType<T> f = factory;
++    return registerFactory(f, key, int_key);
++  }
++
++  /**
++   * @brief Factory register function, use this function to register custom
++   * object
++   *
++   * @tparam T object to create. Currently Layer is supported
++   * @param factory factory function that creates std::unique_ptr<T>
++   * @param key key to access the factory, if key is empty, try to find key by
++   * calling factory({})->getType();
++   * @param int_key key to access the factory by integer, if it is -1(default),
++   * the function automatically unsigned the key and return
++   * @return const int unique integer value to access the current factory
++   * @throw invalid argument when key and/or int_key is already taken
++   */
++  template <typename T>
++  const int registerFactory(const FactoryType<T> factory,
++                            const std::string &key = "",
++                            const int int_key = -1);
++
++  /**
++   * @brief Create an Object from the integer key
++   *
++   * @tparam T Type of Object, currently, Only Layer is supported
++   * @param int_key integer key
++   * @param props property
++   * @return PtrType<T> unique pointer to the object
++   */
++  template <typename T>
++  PtrType<T> createObject(const int int_key,
++                          const PropsType &props = {}) const {
++    static_assert(isSupported<T>::value,
++                  "given type is not supported for current app context");
++    auto &index = std::get<IndexType<T>>(factory_map);
++    auto &int_map = std::get<IntIndexType>(index);
++
++    const auto &entry = int_map.find(int_key);
++
++    if (entry == int_map.end()) {
++      ml_loge("Int Key is not found for the object. Key: %d", int_key);
++      throw exception::not_supported(std::to_string(int_key));
++    }
++
++    // entry is an object of int_map which is an unordered_map<int, std::string>
++    return createObject<T>(entry->second, props);
++  }
++
++  /**
++   * @brief Create an Object from the string key
++   *
++   * @tparam T Type of object, currently, only Layer is supported
++   * @param key integer key
++   * @param props property
++   * @return PtrType<T> unique pointer to the object
++   */
++  template <typename T>
++  PtrType<T> createObject(const std::string &key,
++                          const PropsType &props = {}) const {
++    auto &index = std::get<IndexType<T>>(factory_map);
++    auto &str_map = std::get<StrIndexType<T>>(index);
++
++    std::string lower_key;
++    lower_key.resize(key.size());
++
++    std::transform(key.begin(), key.end(), lower_key.begin(),
++                   [](unsigned char c) { return std::tolower(c); });
++
++    const auto &entry = str_map.find(lower_key);
++
++    if (entry == str_map.end()) {
++      ml_loge("Key is not found for the object. Key: %s", lower_key.c_str());
++      throw exception::not_supported(lower_key);
++    }
++
++    // entry -> object of str_map -> unordered_map<std::string, FactoryType<T>>
++    return entry->second(props);
++  }
++
++  /**
++   * @brief Create a Layer object from the string key
++   *
++   * @param type string key
++   * @param properties property
++   * @return std::unique_ptr<nntrainer::Layer> unique pointer to the object
++   */
++  std::unique_ptr<nntrainer::Layer>
++  createLayerObject(const std::string &type,
++                    const std::vector<std::string> &properties = {}) override {
++    return createObject<nntrainer::Layer>(type, properties);
++  }
++
++  /**
++   * @brief Create a Layer object from the integer key
++   *
++   * @param type integer key
++   * @param properties property
++   * @return std::unique_ptr<nntrainer::Layer> unique pointer to the object
++   */
++  std::unique_ptr<nntrainer::Layer>
++  createLayerObject(const int int_key,
++                    const std::vector<std::string> &properties = {}) override {
++    return createObject<nntrainer::Layer>(int_key, properties);
++  }
++
++  /**
++   * @brief Get the name of the context
++   */
++  std::string getName() override { return "cuda"; }
++
++  /**
++   * @brief Set the Mem Allocator object
++   *
++   * @param mem Memory allocator object
++   */
++  void setMemAllocator(std::shared_ptr<MemAllocator> mem) {
++    getContextData()->setMemAllocator(mem);
++  }
++
++  /**
++   * @brief Get CUDA stream
++   * @return cudaStream_t
++   */
++  cudaStream_t getStream() const { return stream_; }
++
++private:
++  /**
++   * @brief   Overriden init function
++   */
++  void initialize() noexcept override;
++
++  void add_default_object();
++
++  // flag to check cuda initialization
++  bool cuda_initialized = false;
++
++  // CUDA stream for asynchronous operations
++  cudaStream_t stream_ = nullptr;
++
++  FactoryMap<nntrainer::Layer> factory_map;
++
++  template <typename Args, typename T> struct isSupportedHelper;
++
++  /**
++   * @brief supportHelper to check if given type is supported within cuda
++   * context
++   */
++  template <typename T, typename... Args>
++  struct isSupportedHelper<T, CudaContext::FactoryMap<Args...>> {
++    static constexpr bool value =
++      (std::is_same_v<std::decay_t<T>, std::decay_t<Args>> || ...);
++  };
++
++  /**
++   * @brief supportHelper to check if given type is supported within cuda
++   * context
++   */
++  template <typename T>
++  struct isSupported : isSupportedHelper<T, decltype(factory_map)> {};
++
++  /**
++   * @brief Initialize cuda context and stream
++   * @return true if CUDA context and stream creation is successful,
++   * false otherwise
++   */
++  bool cudaInit();
++};
++
++/**
++ * @copydoc const int CudaContext::registerFactory
++ */
++extern template const int CudaContext::registerFactory<nntrainer::Layer>(
++  const FactoryType<nntrainer::Layer> factory, const std::string &key,
++  const int int_key);
++
++} // namespace nntrainer
++
++#endif /* __CUDA_CONTEXT_H__ */
+diff --git a/nntrainer/meson.build b/nntrainer/meson.build
+index 9daa9a04d6..024250e60b 100644
+--- a/nntrainer/meson.build
++++ b/nntrainer/meson.build
+@@ -37,6 +37,35 @@ if get_option('enable-opencl')
+   nntrainer_base_deps += clblast_dep
+ endif
+ 
++if get_option('enable-cuda')
++  # Add CUDA runtime library dependency
++  if get_option('platform') == 'windows'
++    # Windows: Use CUDA runtime library
++    cuda_dep = dependency('cuda', method: 'cmake', required: false)
++    if not cuda_dep.found()
++      # Fallback to manual library specification for Windows
++      cuda_lib = cc.find_library('cudart', required: false)
++      if cuda_lib.found()
++        nntrainer_base_deps += cuda_lib
++      endif
++    else
++      nntrainer_base_deps += cuda_dep
++    endif
++  else
++    # Linux and others: Use pkg-config or manual library specification
++    cuda_dep = dependency('cuda', method: 'pkg-config', required: false)
++    if not cuda_dep.found()
++      # Fallback to manual library specification for Linux
++      cuda_lib = cc.find_library('cudart', required: false)
++      if cuda_lib.found()
++        nntrainer_base_deps += cuda_lib
++      endif
++    else
++      nntrainer_base_deps += cuda_dep
++    endif
++  endif
++endif
++
+ if get_option('platform') == 'tizen'
+   nntrainer_base_deps += dependency('dlog')
+ endif
+@@ -82,6 +111,11 @@ if get_option('enable-opencl')
+   nntrainer_common_sources += 'cl_buffer_manager.cpp'
+ endif
+ 
++if get_option('enable-cuda')
++  nntrainer_headers += meson.current_source_dir() / 'cuda_context.h'
++  nntrainer_common_sources += 'cuda_context.cpp'
++endif
++
+ foreach s : nntrainer_common_sources
+   nntrainer_sources += meson.current_source_dir() / s
+ endforeach
+
+From 42922deae71bb4992cf75e49324dca2b336b60c9 Mon Sep 17 00:00:00 2001
+From: Daekyoung Jung <dk11.jung@samsung.com>
+Date: Tue, 18 Nov 2025 10:09:40 +0900
+Subject: [PATCH 2/9] Add CUDA context support and build configuration
+
+This commit adds CUDA context management files (cuda_context.h and cuda_context.cpp)
+that provide similar functionality to the existing OpenCL context.
+
+The changes include:
+
+- Implementation of CudaContext class inheriting from Context and Singleton
+- CUDA kernel management and execution interface
+- Build system updates to support CUDA with enable-cuda meson_options
+- Conditional linking of CUDA runtime library for both Windows and Linux
+- Addition of enable-cuda option in meson_options.txt
+- Implementation of RMSNorm CUDA kernel and build configuration
+
+Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>
+---
+ nntrainer/engine.cpp                          |  6 ++
+ nntrainer/meson.build                         |  6 ++
+ nntrainer/tensor/cuda_operations/meson.build  | 34 +++++++
+ .../tensor/cuda_operations/rmsnorm_cuda.cu    | 95 +++++++++++++++++++
+ .../tensor/cuda_operations/rmsnorm_cuda.h     | 39 ++++++++
+ 5 files changed, 180 insertions(+)
+ create mode 100644 nntrainer/tensor/cuda_operations/meson.build
+ create mode 100644 nntrainer/tensor/cuda_operations/rmsnorm_cuda.cu
+ create mode 100644 nntrainer/tensor/cuda_operations/rmsnorm_cuda.h
+
+diff --git a/nntrainer/engine.cpp b/nntrainer/engine.cpp
+index 86f9e8b320..a5ed99055c 100644
+--- a/nntrainer/engine.cpp
++++ b/nntrainer/engine.cpp
+@@ -50,6 +50,12 @@ void Engine::add_default_object() {
+ 
+   registerContext("gpu", &cl_context);
+ #endif
++
++#ifdef ENABLE_CUDA
++  auto &cuda_context = nntrainer::CudaContext::Global();
++
++  registerContext("cuda", &cuda_context);
++#endif
+ }
+ 
+ void Engine::initialize() noexcept {
+diff --git a/nntrainer/meson.build b/nntrainer/meson.build
+index 024250e60b..6d0f3dd549 100644
+--- a/nntrainer/meson.build
++++ b/nntrainer/meson.build
+@@ -95,6 +95,11 @@ foreach elem : nntrainer_elements
+   nntrainer_inc_abs += meson.current_source_dir() / elem
+ endforeach
+ 
++# Add CUDA operations subdir if CUDA is enabled
++if get_option('enable-cuda')
++  subdir('tensor/cuda_operations')
++endif
++
+ nntrainer_common_sources = [
+   'nntrainer_logger.cpp',
+   'app_context.cpp',
+@@ -114,6 +119,7 @@ endif
+ if get_option('enable-cuda')
+   nntrainer_headers += meson.current_source_dir() / 'cuda_context.h'
+   nntrainer_common_sources += 'cuda_context.cpp'
++  extra_defines += '-DENABLE_CUDA=1'
+ endif
+ 
+ foreach s : nntrainer_common_sources
+diff --git a/nntrainer/tensor/cuda_operations/meson.build b/nntrainer/tensor/cuda_operations/meson.build
+new file mode 100644
+index 0000000000..61cafc73c6
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/meson.build
+@@ -0,0 +1,34 @@
++# Find CUDA compiler
++dep = dependency('cuda', version : '>=13', modules : ['cublas'])
++
++nvcc = find_program('nvcc', required: true)
++
++if nvcc.found()
++  cuda_sources = [
++    'rmsnorm_cuda.cu'
++  ]
++
++  cuda_headers = [
++    'rmsnorm_cuda.h'
++  ]
++
++  kernel_objects = []
++  foreach kernel : cuda_sources
++    obj_name = kernel.replace('.cu', '.o')
++    obj = custom_target(obj_name,
++      command: [nvcc, '-c', '-Xcompiler', '/MD', '@INPUT@', '-o', '@OUTPUT@'],
++      input: kernel,
++      output: obj_name
++    )
++    kernel_objects += obj
++  endforeach
++
++  nntrainer_sources += kernel_objects
++
++  foreach h : cuda_headers
++    nntrainer_headers += meson.current_source_dir() / h
++  endforeach
++
++else
++  message('CUDA compiler (nvcc) not found. CUDA kernels will not be compiled.')
++endif
+diff --git a/nntrainer/tensor/cuda_operations/rmsnorm_cuda.cu b/nntrainer/tensor/cuda_operations/rmsnorm_cuda.cu
+new file mode 100644
+index 0000000000..cb885871f6
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/rmsnorm_cuda.cu
+@@ -0,0 +1,95 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file	rmsnorm_cuda.cpp
++ * @date	14 Nov 2025
++ * @brief	Common blas CUDA kernels
++ * @see		https://github.com/nnstreamer/nntrainer
++ * @author	Samsung Electronics Co., Ltd.
++ * @bug		No known bugs except for NYI items
++ *
++ */
++
++#include "rmsnorm_cuda.h"
++#include <cuda_runtime.h>
++
++ __global__ void rmsnorm_cuda_kernel(const float *input, float *output,
++                                    const float *alpha, float epsilon,
++                                    int H, int W) {
++  // Each block processes one row (height index)
++  int h = blockIdx.x;
++  int index = h * W;
++  
++  // Shared memory for reduction
++  extern __shared__ float sdata[];
++  
++  // Thread index within block
++  int tid = threadIdx.x;
++  const int blockSize = blockDim.x;
++  
++  // Load input data and compute sum of squares
++  const float *in = input + index;
++  float sum_squares = 0.0f;
++  
++  // Each thread processes multiple elements if W > blockSize
++  for (int i = tid; i < W; i += blockSize) {
++    float val = in[i];
++    sum_squares += val * val;
++  }
++  
++  // Store partial sum in shared memory
++  sdata[tid] = sum_squares;
++  __syncthreads();
++  
++  // Reduction in shared memory
++  for (int s = blockSize / 2; s > 0; s >>= 1) {
++    if (tid < s) {
++      sdata[tid] += sdata[tid + s];
++    }
++    __syncthreads();
++  }
++  
++  // First thread in block computes the final result
++  if (tid == 0) {
++    float mean = sdata[0] / W;
++    float scale = 1.0f / sqrtf(mean + epsilon);
++    
++    // Store the scale value in shared memory for reuse
++    sdata[0] = scale;
++  }
++  __syncthreads();
++  
++  // Load the computed scale
++  float scale = sdata[0];
++  
++  // Compute output values
++  float *out = output + index;
++  for (int i = tid; i < W; i += blockSize) {
++    out[i] = in[i] * scale * alpha[i];
++  }
++}
++
++namespace nntrainer {
++
++void rmsnorm_cuda(const float *input, const float *gamma, float *result,
++                  const float epsilon, unsigned int height, unsigned int width) {
++  // Define block size
++  const int blockSize = 256;
++  
++  // Calculate grid size (one block per row)
++  const int gridSize = height;
++  
++  // Shared memory size for reduction
++  const int sharedMemSize = blockSize * sizeof(float);
++  
++  // Launch the CUDA kernel
++  rmsnorm_cuda_kernel<<<gridSize, blockSize, sharedMemSize>>>(
++    input, result, gamma, epsilon, height, width);
++}
++
++void sscal_cuda(float *X, const unsigned int N, const float alpha) {
++  // TODO: Implement CUDA kernel for sscal
++}
++
++} // namespace nntrainer
+diff --git a/nntrainer/tensor/cuda_operations/rmsnorm_cuda.h b/nntrainer/tensor/cuda_operations/rmsnorm_cuda.h
+new file mode 100644
+index 0000000000..77ad2fc811
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/rmsnorm_cuda.h
+@@ -0,0 +1,39 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file	rmsnorm_cuda.h
++ * @date	14 Nov 2025
++ * @brief	Common blas CUDA kernels
++ * @see		https://github.com/nnstreamer/nntrainer
++ * @author	Samsung Electronics Co., Ltd.
++ * @bug		No known bugs except for NYI items
++ *
++ */
++
++#pragma once
++
++namespace nntrainer {
++
++/**
++ * @brief rmsnorm each row of the tensor
++ * @param[in] input float * for input
++ * @param[in] gamma float * for gamma multiplier for each row
++ * @param[in] result float * for result
++ * @param[in] epsilon epsilon to add to each row sum to prevent division by zero
++ * @param[in] height height of the tensor
++ * @param[in] width width of the tensor
++ */
++void rmsnorm_cuda(const float *input, const float *gamma, float *result,
++                  const float epsilon, unsigned int height, unsigned int width);
++
++/**
++ * @brief     sscal value element by element immediately
++ * @param[in] X float * input
++ * @param[in] N unsigned int number of elements
++ * @param[in] alpha float multiplier
++ * @param[in] context RunLayerContext reference
++ */
++void sscal_cuda(float *X, const unsigned int N, const float alpha);
++
++} // namespace nntrainer
+
+From 078308c94c0cb38d49e5f831b0e3064c8c25f55e Mon Sep 17 00:00:00 2001
+From: Daekyoung Jung <dk11.jung@samsung.com>
+Date: Tue, 18 Nov 2025 14:47:36 +0900
+Subject: [PATCH 3/9] Add CUDA unit test and fix CUDA build configuration
+
+This commit includes the following changes:
+1. Add new CUDA unit test file (unittest_cuda.cpp) with RMSNorm CUDA kernel
+   tests
+2. Reorganize CUDA operations directory structure by moving subdir inclusion
+   from nntrainer/meson.build to nntrainer/tensor/meson.build
+3. Add CUDA test target in test/unittest/meson.build
+4. Fix CUDA linking issues by adding proper link arguments (-NOIMPLIB, -NOEXP)
+   to prevent generation of unnecessary .lib and .exp files
+5. Add CUDA dependencies handling in unit test build configuration
+
+The changes ensure proper CUDA support in the build system and add
+comprehensive unit tests for CUDA operations.
+
+Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>
+---
+ nntrainer/meson.build           |   5 -
+ nntrainer/tensor/meson.build    |   6 +
+ test/unittest/meson.build       |  14 +-
+ test/unittest/unittest_cuda.cpp | 371 ++++++++++++++++++++++++++++++++
+ 4 files changed, 390 insertions(+), 6 deletions(-)
+ create mode 100644 test/unittest/unittest_cuda.cpp
+
+diff --git a/nntrainer/meson.build b/nntrainer/meson.build
+index 6d0f3dd549..e4ee263cb0 100644
+--- a/nntrainer/meson.build
++++ b/nntrainer/meson.build
+@@ -95,11 +95,6 @@ foreach elem : nntrainer_elements
+   nntrainer_inc_abs += meson.current_source_dir() / elem
+ endforeach
+ 
+-# Add CUDA operations subdir if CUDA is enabled
+-if get_option('enable-cuda')
+-  subdir('tensor/cuda_operations')
+-endif
+-
+ nntrainer_common_sources = [
+   'nntrainer_logger.cpp',
+   'app_context.cpp',
+diff --git a/nntrainer/tensor/meson.build b/nntrainer/tensor/meson.build
+index ea6a74f8a3..8e1e88a415 100644
+--- a/nntrainer/tensor/meson.build
++++ b/nntrainer/tensor/meson.build
+@@ -90,6 +90,12 @@ if get_option('enable-opencl')
+   nntrainer_inc_abs += meson.current_source_dir() / 'cl_operations'
+ endif
+ 
++if get_option('enable-cuda')
++  subdir('cuda_operations')
++  nntrainer_inc += include_directories('cuda_operations')
++  nntrainer_inc_abs += meson.current_source_dir() / 'cuda_operations'
++endif
++
+ foreach s : tensor_sources
+   nntrainer_sources += meson.current_source_dir() / s
+ endforeach
+diff --git a/test/unittest/meson.build b/test/unittest/meson.build
+index b3100667bb..e714a07f0b 100644
+--- a/test/unittest/meson.build
++++ b/test/unittest/meson.build
+@@ -84,6 +84,10 @@ if get_option('enable-opencl')
+   test_target += [['unittest_attention_kernels_cl', []]]
+ endif
+ 
++if get_option('enable-cuda')
++  test_target += [['unittest_cuda', []]]
++endif
++
+ if get_option('enable-fp16')
+   test_target += [['unittest_nntrainer_tensor_fp16', []]]
+   test_target += [['unittest_nntrainer_tensor_pool_fp16', []]]
+@@ -96,12 +100,20 @@ if get_option('enable-profile')
+ endif
+ 
+ foreach target: test_target
++  cuda_deps = []
++  cuda_link_args = []
++  if target[0] == 'unittest_cuda' and get_option('enable-cuda')
++    cuda_deps = [cuda_dep]
++    cuda_link_args = ['-NODEFAULTLIB:LIBCMT', '-NOIMPLIB', '-NOEXP']
++  endif
++  
+   exe = executable(
+     target[0],
+     [target[0] + '.cpp'] + [target[1]],
+     # below is temporary measure, we will eventually remove unittest_nntrainer_models
+     include_directories: include_directories('models'),
+-    dependencies: unittest_nntrainer_deps,
++    dependencies: unittest_nntrainer_deps + cuda_deps,
++    link_args: cuda_link_args,
+     install: get_option('enable-test'),
+     install_dir: application_install_dir
+   )
+diff --git a/test/unittest/unittest_cuda.cpp b/test/unittest/unittest_cuda.cpp
+new file mode 100644
+index 0000000000..5f445e6bab
+--- /dev/null
++++ b/test/unittest/unittest_cuda.cpp
+@@ -0,0 +1,371 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file   unittest_cuda.cpp
++ * @date   18 Nov 2025
++ * @brief  Unit test for CUDA operations
++ * @see    https://github.com/nnstreamer/nntrainer
++ * @author Samsung Electronics Co., Ltd.
++ * @bug    No known bugs except for NYI items
++ */
++
++#include <cuda_runtime.h>
++#include <gtest/gtest.h>
++#include <nntrainer_test_util.h>
++#include <rmsnorm_cuda.h>
++#include <tensor.h>
++#include <tensor_dim.h>
++
++using namespace nntrainer;
++
++/**
++ * @brief Helper function to generate test data
++ *
++ * @tparam T data type
++ * @param size data length
++ * @param min_val minimum value
++ * @param max_val maximum value
++ * @return std::vector<T> random vector
++ */
++template <typename T>
++static inline std::vector<T> generate_test_data(size_t size, T min_val,
++                                                T max_val) {
++  std::random_device rd;
++  std::mt19937 gen(rd());
++  std::uniform_real_distribution<T> dist(min_val, max_val);
++  std::vector<T> vec(size);
++  for (auto &val : vec) {
++    val = static_cast<T>(dist(gen));
++  }
++  return vec;
++}
++
++/**
++ * @brief Test for rmsnorm_cuda function
++ */
++TEST(nntrainer_CUDA, rmsnorm_cuda_1) {
++  const int batch = 1;
++  const int channel = 1;
++  const int height = 67;
++  const int width = 3072;
++
++  const float epsilon = 1e-6;
++
++  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
++    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
++
++  /// Initialize CPU input data
++  nntrainer::Tensor input(batch, channel, height, width, t_type_nchw_fp32);
++  nntrainer::Tensor gamma(1, 1, 1, width, t_type_nchw_fp32);
++  nntrainer::Tensor output_cuda(batch, channel, height, width,
++                                t_type_nchw_fp32);
++  nntrainer::Tensor output_ref(batch, channel, height, width, t_type_nchw_fp32);
++
++  /// Generate test data
++  auto input_data = generate_test_data<float>(input.size(), -1.0f, 1.0f);
++  auto gamma_data = generate_test_data<float>(gamma.size(), 0.5f, 2.0f);
++
++  std::copy(input_data.begin(), input_data.end(), input.getData<float>());
++  std::copy(gamma_data.begin(), gamma_data.end(), gamma.getData<float>());
++
++  /// Allocate CUDA memory
++  float *d_input = nullptr, *d_gamma = nullptr, *d_output = nullptr;
++  size_t input_size = input.size() * sizeof(float);
++  size_t gamma_size = gamma.size() * sizeof(float);
++  size_t output_size = output_cuda.size() * sizeof(float);
++
++  cudaMalloc((void **)&d_input, input_size);
++  cudaMalloc((void **)&d_gamma, gamma_size);
++  cudaMalloc((void **)&d_output, output_size);
++
++  /// Copy data to CUDA memory
++  cudaMemcpy(d_input, input.getData<float>(), input_size,
++             cudaMemcpyHostToDevice);
++  cudaMemcpy(d_gamma, gamma.getData<float>(), gamma_size,
++             cudaMemcpyHostToDevice);
++
++  /// Reference implementation using CPU
++  std::function<float(float)> f = [](float x) { return 1 / std::sqrt(x); };
++  auto t = input.multiply(input).average(3).add(epsilon);
++  t.apply_i(f);
++  input.multiply(t, output_ref);
++  output_ref.multiply_i(gamma);
++
++  /// Create CUDA events for timing
++  cudaEvent_t start, stop;
++  cudaEventCreate(&start);
++  cudaEventCreate(&stop);
++
++  /// CUDA implementation
++  rmsnorm_cuda(d_input, d_gamma, d_output, epsilon,
++               input.batch() * input.channel() * input.height(), input.width());
++
++  /// Record start time
++  cudaEventRecord(start);
++
++  /// CUDA implementation
++  rmsnorm_cuda(d_input, d_gamma, d_output, epsilon,
++               input.batch() * input.channel() * input.height(), input.width());
++
++  /// Record stop time
++  cudaEventRecord(stop);
++  cudaEventSynchronize(stop);
++
++  /// Calculate elapsed time
++  float milliseconds = 0;
++  cudaEventElapsedTime(&milliseconds, start, stop);
++  std::cout << "RMSNorm CUDA kernel execution time for input size (" << batch
++            << ", " << channel << ", " << height << ", " << width
++            << "): " << milliseconds << " ms" << std::endl;
++
++  /// Copy result back to host
++  cudaMemcpy(output_cuda.getData<float>(), d_output, output_size,
++             cudaMemcpyDeviceToHost);
++
++  /// Destroy CUDA events
++  cudaEventDestroy(start);
++  cudaEventDestroy(stop);
++
++  /// Free CUDA memory
++  cudaFree(d_input);
++  cudaFree(d_gamma);
++  cudaFree(d_output);
++
++  /// Compare results
++  float mseError = mse<float>(output_cuda.getData<float>(),
++                              output_ref.getData<float>(), output_cuda.size());
++
++  double cosSim =
++    cosine_similarity<float>(output_cuda.getData<float>(),
++                             output_ref.getData<float>(), output_cuda.size());
++
++  const float error_threshold = 1e-5;
++  const float cosine_threshold = 0.999;
++
++  EXPECT_LE(mseError, error_threshold);
++  EXPECT_GE(cosSim, cosine_threshold);
++}
++
++/**
++ * @brief Test for rmsnorm_cuda function with different dimensions
++ */
++TEST(nntrainer_CUDA, rmsnorm_cuda_2) {
++  const int batch = 2;
++  const int channel = 3;
++  const int height = 32;
++  const int width = 1024;
++
++  const float epsilon = 1e-6;
++
++  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
++    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
++
++  /// Initialize CPU input data
++  nntrainer::Tensor input(batch, channel, height, width, t_type_nchw_fp32);
++  nntrainer::Tensor gamma(1, 1, 1, width, t_type_nchw_fp32);
++  nntrainer::Tensor output_cuda(batch, channel, height, width,
++                                t_type_nchw_fp32);
++  nntrainer::Tensor output_ref(batch, channel, height, width, t_type_nchw_fp32);
++
++  /// Generate test data
++  auto input_data = generate_test_data<float>(input.size(), -2.0f, 2.0f);
++  auto gamma_data = generate_test_data<float>(gamma.size(), 0.1f, 1.5f);
++
++  std::copy(input_data.begin(), input_data.end(), input.getData<float>());
++  std::copy(gamma_data.begin(), gamma_data.end(), gamma.getData<float>());
++
++  /// Allocate CUDA memory
++  float *d_input = nullptr, *d_gamma = nullptr, *d_output = nullptr;
++  size_t input_size = input.size() * sizeof(float);
++  size_t gamma_size = gamma.size() * sizeof(float);
++  size_t output_size = output_cuda.size() * sizeof(float);
++
++  cudaMalloc((void **)&d_input, input_size);
++  cudaMalloc((void **)&d_gamma, gamma_size);
++  cudaMalloc((void **)&d_output, output_size);
++
++  /// Copy data to CUDA memory
++  cudaMemcpy(d_input, input.getData<float>(), input_size,
++             cudaMemcpyHostToDevice);
++  cudaMemcpy(d_gamma, gamma.getData<float>(), gamma_size,
++             cudaMemcpyHostToDevice);
++
++  /// Reference implementation using CPU
++  std::function<float(float)> f = [](float x) { return 1 / std::sqrt(x); };
++  auto t = input.multiply(input).average(3).add(epsilon);
++  t.apply_i(f);
++  input.multiply(t, output_ref);
++  output_ref.multiply_i(gamma);
++
++  /// Create CUDA events for timing
++  cudaEvent_t start, stop;
++  cudaEventCreate(&start);
++  cudaEventCreate(&stop);
++
++  /// Record start time
++  cudaEventRecord(start);
++
++  /// CUDA implementation
++  rmsnorm_cuda(d_input, d_gamma, d_output, epsilon,
++               input.batch() * input.channel() * input.height(), input.width());
++
++  /// Record stop time
++  cudaEventRecord(stop);
++  cudaEventSynchronize(stop);
++
++  /// Calculate elapsed time
++  float milliseconds = 0;
++  cudaEventElapsedTime(&milliseconds, start, stop);
++  std::cout << "RMSNorm CUDA kernel execution time for input size (" << batch
++            << ", " << channel << ", " << height << ", " << width
++            << "): " << milliseconds << " ms" << std::endl;
++
++  /// Copy result back to host
++  cudaMemcpy(output_cuda.getData<float>(), d_output, output_size,
++             cudaMemcpyDeviceToHost);
++
++  /// Destroy CUDA events
++  cudaEventDestroy(start);
++  cudaEventDestroy(stop);
++
++  /// Free CUDA memory
++  cudaFree(d_input);
++  cudaFree(d_gamma);
++  cudaFree(d_output);
++
++  /// Compare results
++  float mseError = mse<float>(output_cuda.getData<float>(),
++                              output_ref.getData<float>(), output_cuda.size());
++
++  double cosSim =
++    cosine_similarity<float>(output_cuda.getData<float>(),
++                             output_ref.getData<float>(), output_cuda.size());
++
++  const float error_threshold = 1e-5;
++  const float cosine_threshold = 0.999;
++
++  EXPECT_LE(mseError, error_threshold);
++  EXPECT_GE(cosSim, cosine_threshold);
++}
++
++/**
++ * @brief Test for rmsnorm_cuda function with small epsilon
++ */
++TEST(nntrainer_CUDA, rmsnorm_cuda_3) {
++  const int batch = 1;
++  const int channel = 1;
++  const int height = 10;
++  const int width = 128;
++
++  const float epsilon = 1e-12;
++
++  nntrainer::TensorDim::TensorType t_type_nchw_fp32 = {
++    nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32};
++
++  /// Initialize CPU input data
++  nntrainer::Tensor input(batch, channel, height, width, t_type_nchw_fp32);
++  nntrainer::Tensor gamma(1, 1, 1, width, t_type_nchw_fp32);
++  nntrainer::Tensor output_cuda(batch, channel, height, width,
++                                t_type_nchw_fp32);
++  nntrainer::Tensor output_ref(batch, channel, height, width, t_type_nchw_fp32);
++
++  /// Generate test data
++  auto input_data = generate_test_data<float>(input.size(), -0.5f, 0.5f);
++  auto gamma_data = generate_test_data<float>(gamma.size(), 0.8f, 1.2f);
++
++  std::copy(input_data.begin(), input_data.end(), input.getData<float>());
++  std::copy(gamma_data.begin(), gamma_data.end(), gamma.getData<float>());
++
++  /// Allocate CUDA memory
++  float *d_input = nullptr, *d_gamma = nullptr, *d_output = nullptr;
++  size_t input_size = input.size() * sizeof(float);
++  size_t gamma_size = gamma.size() * sizeof(float);
++  size_t output_size = output_cuda.size() * sizeof(float);
++
++  cudaMalloc((void **)&d_input, input_size);
++  cudaMalloc((void **)&d_gamma, gamma_size);
++  cudaMalloc((void **)&d_output, output_size);
++
++  /// Copy data to CUDA memory
++  cudaMemcpy(d_input, input.getData<float>(), input_size,
++             cudaMemcpyHostToDevice);
++  cudaMemcpy(d_gamma, gamma.getData<float>(), gamma_size,
++             cudaMemcpyHostToDevice);
++
++  /// Reference implementation using CPU
++  std::function<float(float)> f = [](float x) { return 1 / std::sqrt(x); };
++  auto t = input.multiply(input).average(3).add(epsilon);
++  t.apply_i(f);
++  input.multiply(t, output_ref);
++  output_ref.multiply_i(gamma);
++
++  /// Create CUDA events for timing
++  cudaEvent_t start, stop;
++  cudaEventCreate(&start);
++  cudaEventCreate(&stop);
++
++  /// Record start time
++  cudaEventRecord(start);
++
++  /// CUDA implementation
++  rmsnorm_cuda(d_input, d_gamma, d_output, epsilon,
++               input.batch() * input.channel() * input.height(), input.width());
++
++  /// Record stop time
++  cudaEventRecord(stop);
++  cudaEventSynchronize(stop);
++
++  /// Calculate elapsed time
++  float milliseconds = 0;
++  cudaEventElapsedTime(&milliseconds, start, stop);
++  std::cout << "RMSNorm CUDA kernel execution time for input size (" << batch
++            << ", " << channel << ", " << height << ", " << width
++            << "): " << milliseconds << " ms" << std::endl;
++
++  /// Copy result back to host
++  cudaMemcpy(output_cuda.getData<float>(), d_output, output_size,
++             cudaMemcpyDeviceToHost);
++
++  /// Destroy CUDA events
++  cudaEventDestroy(start);
++  cudaEventDestroy(stop);
++
++  /// Free CUDA memory
++  cudaFree(d_input);
++  cudaFree(d_gamma);
++  cudaFree(d_output);
++
++  /// Compare results
++  float mseError = mse<float>(output_cuda.getData<float>(),
++                              output_ref.getData<float>(), output_cuda.size());
++
++  double cosSim =
++    cosine_similarity<float>(output_cuda.getData<float>(),
++                             output_ref.getData<float>(), output_cuda.size());
++
++  const float error_threshold = 1e-5;
++  const float cosine_threshold = 0.999;
++
++  EXPECT_LE(mseError, error_threshold);
++  EXPECT_GE(cosSim, cosine_threshold);
++}
++
++GTEST_API_ int main(int argc, char **argv) {
++  int result = -1;
++
++  try {
++    testing::InitGoogleTest(&argc, argv);
++  } catch (...) {
++    std::cerr << "Error during InitGoogleTest" << std::endl;
++    return 0;
++  }
++
++  try {
++    result = RUN_ALL_TESTS();
++  } catch (...) {
++    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
++  }
++
++  return result;
++}
+
+From e85b08165b2253e114c4996bb3e5876a56724ef1 Mon Sep 17 00:00:00 2001
+From: Daekyoung Jung <dk11.jung@samsung.com>
+Date: Thu, 20 Nov 2025 15:07:54 +0900
+Subject: [PATCH 4/9] Add CUDA addition operations and interface
+
+This commit introduces CUDA support for addition operations:
+
+1. Added new CUDA files:
+   - `nntrainer/tensor/cuda_operations/addition_cuda.cu`: Implementation
+     of CUDA addition kernel
+   - `nntrainer/tensor/cuda_operations/addition_cuda.h`: Header for CUDA
+     addition functions
+   - `nntrainer/tensor/cuda_operations/cuda_interface.cpp`: Implementation
+     of CUDA interface functions
+   - `nntrainer/tensor/cuda_operations/cuda_interface.h`: Header for CUDA
+     interface
+
+2. Updated build configuration:
+   - Modified meson.build to include new CUDA files in the build
+   - Updated test/unittest/meson.build to add unittest_cuda_addition target
+
+3. Added unit test:
+   - `test/unittest/unittest_cuda_addition.cpp`: Unit test for CUDA addition
+     operations with timing measurements
+
+The new implementation provides:
+- CUDA kernel for element-wise addition operations
+- CUDA interface functions for tensor operations
+- Comprehensive unit test with performance timing
+
+Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>
+---
+ .../tensor/cuda_operations/addition_cuda.cu   |  37 +++++
+ .../tensor/cuda_operations/addition_cuda.h    |  31 ++++
+ .../tensor/cuda_operations/cuda_interface.cpp |  71 +++++++++
+ .../tensor/cuda_operations/cuda_interface.h   | 124 +++++++++++++++
+ nntrainer/tensor/cuda_operations/meson.build  |  10 +-
+ test/unittest/meson.build                     |   1 +
+ test/unittest/unittest_cuda_addition.cpp      | 148 ++++++++++++++++++
+ 7 files changed, 420 insertions(+), 2 deletions(-)
+ create mode 100644 nntrainer/tensor/cuda_operations/addition_cuda.cu
+ create mode 100644 nntrainer/tensor/cuda_operations/addition_cuda.h
+ create mode 100644 nntrainer/tensor/cuda_operations/cuda_interface.cpp
+ create mode 100644 nntrainer/tensor/cuda_operations/cuda_interface.h
+ create mode 100644 test/unittest/unittest_cuda_addition.cpp
+
+diff --git a/nntrainer/tensor/cuda_operations/addition_cuda.cu b/nntrainer/tensor/cuda_operations/addition_cuda.cu
+new file mode 100644
+index 0000000000..112ceee42f
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/addition_cuda.cu
+@@ -0,0 +1,37 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file	addition_cuda.cu
++ * @date	20 Nov 2025
++ * @brief	Common blas CUDA kernels for addition
++ * @see		https://github.com/nnstreamer/nntrainer
++ * @author	Samsung Electronics Co., Ltd.
++ * @bug		No known bugs except for NYI items
++ *
++ */
++
++#include "addition_cuda.h"
++#include <cuda_runtime.h>
++
++namespace nntrainer {
++
++__global__ void addition_cuda_kernel(const float *input, float *output,
++                                     unsigned int size_input,
++                                     unsigned int size_res) {
++  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
++  if (idx < size_res) {
++    output[idx] = output[idx] + input[idx % size_input];
++  }
++}
++
++void addition_cuda(const float *input, float *res, unsigned int size_input,
++                   unsigned int size_res) {
++  const int blockSize = 256;
++  const int gridSize = (size_res + blockSize - 1) / blockSize;
++
++  addition_cuda_kernel<<<gridSize, blockSize>>>(input, res, size_input,
++                                                size_res);
++}
++
++} // namespace nntrainer
+diff --git a/nntrainer/tensor/cuda_operations/addition_cuda.h b/nntrainer/tensor/cuda_operations/addition_cuda.h
+new file mode 100644
+index 0000000000..b1390292fc
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/addition_cuda.h
+@@ -0,0 +1,31 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file	addition_cuda.h
++ * @date	20 Nov 2025
++ * @brief	Common blas CUDA kernels for addition
++ * @see		https://github.com/nnstreamer/nntrainer
++ * @author	Samsung Electronics Co., Ltd.
++ * @bug		No known bugs except for NYI items
++ *
++ */
++
++#ifndef __ADDITION_CUDA_H__
++#define __ADDITION_CUDA_H__
++
++namespace nntrainer {
++
++/**
++ * @brief     addition : sum of all input vectors
++ * @param[in] input float * for input
++ * @param[in] res float * for result/output
++ * @param[in] size_input number of elements in input vector
++ * @param[in] size_res number of elements in result vector
++ */
++void addition_cuda(const float *input, float *res, unsigned int size_input,
++                   unsigned int size_res);
++
++} // namespace nntrainer
++
++#endif /* __ADDITION_CUDA_H__ */
+diff --git a/nntrainer/tensor/cuda_operations/cuda_interface.cpp b/nntrainer/tensor/cuda_operations/cuda_interface.cpp
+new file mode 100644
+index 0000000000..a343eb20e1
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/cuda_interface.cpp
+@@ -0,0 +1,71 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file	cuda_interface.cpp
++ * @date	20 Nov 2025
++ * @brief	Interface for blas CUDA kernels
++ * @see		https://github.com/nnstreamer/nntrainer
++ * @author	Samsung Electronics Co., Ltd.
++ * @bug		No known bugs except for NYI items
++ *
++ */
++
++#include <cuda_interface.h>
++#include <tensor.h>
++
++namespace nntrainer {
++
++Tensor dotCuda(Tensor const &input, Tensor const &m, bool trans, bool trans_m) {
++  // TODO: Implement CUDA dot operation
++  return Tensor();
++}
++
++void dotCuda(Tensor const &input, Tensor const &m, Tensor &result, bool trans,
++             bool trans_m) {
++  // TODO: Implement CUDA dot operation
++}
++
++void dotBatchedCuda(Tensor const &input, Tensor const &m, Tensor &result,
++                    bool trans, bool trans_m) {
++  // TODO: Implement CUDA batched dot operation
++}
++
++void multiplyCuda(Tensor &input, float const &value) {
++  // TODO: Implement CUDA multiply operation
++}
++
++void add_i_cuda(Tensor &result, Tensor const &input) {
++  // TODO: Implement CUDA add operation
++}
++
++void transposeCuda(const std::string &direction, Tensor const &in,
++                   Tensor &result) {
++  // TODO: Implement CUDA transpose operation
++}
++
++void copyCuda(const Tensor &input, Tensor &result) {
++  // TODO: Implement CUDA copy operation
++}
++
++float nrm2Cuda(const Tensor &input) {
++  // TODO: Implement CUDA nrm2 operation
++  return 0.0f;
++}
++
++float asumCuda(const Tensor &input) {
++  // TODO: Implement CUDA asum operation
++  return 0.0f;
++}
++
++int amaxCuda(const Tensor &input) {
++  // TODO: Implement CUDA amax operation
++  return 0;
++}
++
++int aminCuda(const Tensor &input) {
++  // TODO: Implement CUDA amin operation
++  return 0;
++}
++
++} // namespace nntrainer
+diff --git a/nntrainer/tensor/cuda_operations/cuda_interface.h b/nntrainer/tensor/cuda_operations/cuda_interface.h
+new file mode 100644
+index 0000000000..628ff1e152
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/cuda_interface.h
+@@ -0,0 +1,124 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file	cuda_interface.h
++ * @date	20 Nov 2025
++ * @brief	Interface for blas CUDA kernels
++ * @see		https://github.com/nnstreamer/nntrainer
++ * @author	Samsung Electronics Co., Ltd.
++ * @bug		No known bugs except for NYI items
++ *
++ */
++
++#ifndef __CUDA_INTERFACE_H__
++#define __CUDA_INTERFACE_H__
++
++#include <string>
++#include <tensor.h>
++
++namespace nntrainer {
++
++/**
++ * @brief Process data and dimensions for CUDA dot operation
++ * @param[in] input Tensor
++ * @param[in] m Tensor
++ * @param[in] RunLayerContext reference
++ * @param[in] trans bool
++ * @param[in] trans_m bool
++ */
++Tensor dotCuda(Tensor const &input, Tensor const &m, bool trans = false,
++               bool trans_m = false);
++
++/**
++ * @brief Process data and dimensions for CUDA dot operation
++ * @param[in] input Tensor
++ * @param[in] m Tensor
++ * @param[in] result Tensor
++ * @param[in] RunLayerContext reference
++ * @param[in] trans bool
++ * @param[in] trans_m bool
++ */
++void dotCuda(Tensor const &input, Tensor const &m, Tensor &result,
++             bool trans = false, bool trans_m = false);
++
++/**
++ * @brief Process data and dimensions for CUDA dot operation
++ * @param[in] input Tensor
++ * @param[in] m Tensor
++ * @param[in] result Tensor
++ * @param[in] RunLayerContext reference
++ * @param[in] trans bool
++ * @param[in] trans_m bool
++ */
++void dotBatchedCuda(Tensor const &input, Tensor const &m, Tensor &result,
++                    bool trans = false, bool trans_m = false);
++
++/**
++ * @brief Multiply value element by element immediately
++ * @param[in] input Tensor
++ * @param[in] value multiplier
++ * @param[in] RunLayerContext reference
++ */
++void multiplyCuda(Tensor &input, float const &value);
++
++/**
++ * @brief Process data and dimensions for add operation
++ * @param[in] result Tensor
++ * @param[in] input Tensor
++ */
++void add_i_cuda(Tensor &result, Tensor const &input);
++
++/**
++ * @brief Process data and dimensions for transpose operation
++ * @param[in] direction string
++ * @param[in] input Tensor
++ * @param[in] result Tensor
++ */
++void transposeCuda(const std::string &direction, Tensor const &in,
++                   Tensor &result);
++
++/**
++ * @brief Copy data from one tensor to another
++ *
++ * @param input Tensor
++ * @param result Tensor
++ */
++void copyCuda(const Tensor &input, Tensor &result);
++
++/**
++ * @brief nrm2 computation : Euclidean norm
++ * @param input Tensor
++ * @return Euclidean norm
++ * @note This function is used to compute the Euclidean norm of a vector.
++ */
++float nrm2Cuda(const Tensor &input);
++
++/**
++ * @brief Absolute sum computation
++ *
++ * @param input Tensor
++ * @return float absolute sum of the elements
++ */
++float asumCuda(const Tensor &input);
++
++/**
++ * @brief Absolute max computation
++ *
++ * @param input Tensor
++ * @return int index of the maximum absolute value
++ * @note Not necessarily the first if there are multiple maximums.
++ */
++int amaxCuda(const Tensor &input);
++
++/**
++ * @brief Absolute min computation
++ *
++ * @param input Tensor
++ * @return int index of the minimum absolute value
++ * @note Not necessarily the first if there are multiple minimums.
++ */
++int aminCuda(const Tensor &input);
++
++} // namespace nntrainer
++#endif /* __CUDA_INTERFACE_H__ */
+diff --git a/nntrainer/tensor/cuda_operations/meson.build b/nntrainer/tensor/cuda_operations/meson.build
+index 61cafc73c6..9af6aff6a3 100644
+--- a/nntrainer/tensor/cuda_operations/meson.build
++++ b/nntrainer/tensor/cuda_operations/meson.build
+@@ -5,11 +5,14 @@ nvcc = find_program('nvcc', required: true)
+ 
+ if nvcc.found()
+   cuda_sources = [
+-    'rmsnorm_cuda.cu'
++    'rmsnorm_cuda.cu',
++    'addition_cuda.cu'
+   ]
+ 
+   cuda_headers = [
+-    'rmsnorm_cuda.h'
++    'rmsnorm_cuda.h',
++    'addition_cuda.h',
++    'cuda_interface.h'
+   ]
+ 
+   kernel_objects = []
+@@ -23,6 +26,9 @@ if nvcc.found()
+     kernel_objects += obj
+   endforeach
+ 
++  # Add cuda_interface.cpp to regular sources
++  nntrainer_sources += meson.current_source_dir() / 'cuda_interface.cpp'
++
+   nntrainer_sources += kernel_objects
+ 
+   foreach h : cuda_headers
+diff --git a/test/unittest/meson.build b/test/unittest/meson.build
+index e714a07f0b..f004d0401d 100644
+--- a/test/unittest/meson.build
++++ b/test/unittest/meson.build
+@@ -86,6 +86,7 @@ endif
+ 
+ if get_option('enable-cuda')
+   test_target += [['unittest_cuda', []]]
++  test_target += [['unittest_cuda_addition', []]]
+ endif
+ 
+ if get_option('enable-fp16')
+diff --git a/test/unittest/unittest_cuda_addition.cpp b/test/unittest/unittest_cuda_addition.cpp
+new file mode 100644
+index 0000000000..816927e16d
+--- /dev/null
++++ b/test/unittest/unittest_cuda_addition.cpp
+@@ -0,0 +1,148 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file   unittest_cuda_addition.cpp
++ * @date   20 Nov 2025
++ * @brief  Unit test for CUDA addition operations
++ * @see    https://github.com/nnstreamer/nntrainer
++ * @author Samsung Electronics Co., Ltd.
++ * @bug    No known bugs except for NYI items
++ */
++
++#include <gtest/gtest.h>
++#include <nntrainer_test_util.h>
++#include <tensor.h>
++#include <tensor_dim.h>
++#include "addition_cuda.h"
++#include <cuda_runtime.h>
++
++#define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
++  EXPECT_GE((VAL), (MIN));                                                     \
++  EXPECT_LE((VAL), (MAX))
++
++#define CUDA_CHECK(call)                                                       \
++  do {                                                                         \
++    cudaError_t error = call;                                                  \
++    if (error != cudaSuccess) {                                                \
++      std::cerr << "CUDA error at " << __FILE__ << ":" << __LINE__ << " - "    \
++                << cudaGetErrorString(error) << std::endl;                     \
++      FAIL();                                                                  \
++    }                                                                          \
++  } while (0)
++
++using namespace nntrainer;
++
++
++/**
++ * @brief Test for addition_cuda function
++ */
++TEST(nntrainer_CUDA, addition_cuda) {
++  const int size_input = 1024;
++  const int size_res = 1024;
++
++  // Allocate host memory
++  std::vector<float> input_data(size_input);
++  std::vector<float> res_data(size_res);
++  std::vector<float> expected_data(size_res);
++
++  // Allocate device memory
++  float *d_input = nullptr;
++  float *d_res = nullptr;
++  CUDA_CHECK(cudaMalloc(&d_input, size_input * sizeof(float)));
++  CUDA_CHECK(cudaMalloc(&d_res, size_res * sizeof(float)));
++
++  // Create CUDA events for timing
++  cudaEvent_t start, stop;
++  CUDA_CHECK(cudaEventCreate(&start));
++  CUDA_CHECK(cudaEventCreate(&stop));
++
++  // Call CUDA function 10 times
++  for (int i = 0; i < 10; ++i) {
++    // Initialize input data
++    for (int j = 0; j < size_input; ++j) {
++      input_data[j] = static_cast<float>((j + i) % 100) / 100.0f;
++    }
++
++    // Initialize result data
++    for (int j = 0; j < size_res; ++j) {
++      res_data[j] = static_cast<float>((j + i) % 50) / 100.0f;
++      expected_data[j] = res_data[j] + input_data[j % size_input];
++    }
++
++    // Copy data to device
++    CUDA_CHECK(cudaMemcpy(d_input, input_data.data(), size_input * sizeof(float),
++               cudaMemcpyHostToDevice));
++    CUDA_CHECK(cudaMemcpy(d_res, res_data.data(), size_res * sizeof(float),
++               cudaMemcpyHostToDevice));
++
++    if (i == 0) {
++      // First call without timing
++      addition_cuda(d_input, d_res, size_input, size_res);
++    } else {
++      // Subsequent calls with timing
++      CUDA_CHECK(cudaEventRecord(start));
++      addition_cuda(d_input, d_res, size_input, size_res);
++      CUDA_CHECK(cudaEventRecord(stop));
++      CUDA_CHECK(cudaEventSynchronize(stop));
++
++      float milliseconds = 0;
++      CUDA_CHECK(cudaEventElapsedTime(&milliseconds, start, stop));
++      std::cout << "addition_cuda kernel execution time for call " << (i + 1) 
++                << ": " << milliseconds << " ms" << std::endl;
++    }
++
++    // Copy result back to host
++    std::vector<float> result_data(size_res);
++    CUDA_CHECK(cudaMemcpy(result_data.data(), d_res, size_res * sizeof(float),
++               cudaMemcpyDeviceToHost));
++
++    // Check results (only for the last iteration)
++    if (i == 9) {
++      float mseError =
++          mse<float>(result_data.data(), expected_data.data(), size_res);
++
++      double cosSim = cosine_similarity<float>(result_data.data(),
++                                               expected_data.data(), size_res);
++
++      const float epsilon = 1e-5;
++
++      if (mseError > epsilon) {
++        std::cout << "MSE Error: " << mseError << std::endl;
++      }
++      EXPECT_IN_RANGE(mseError, 0, epsilon);
++      
++      if ((float)cosSim < 0.99) {
++        std::cout << "Cosine Similarity: " << (float)cosSim << std::endl;
++      }
++      EXPECT_IN_RANGE((float)cosSim, 0.99, 1);
++    }
++  }
++
++  // Destroy CUDA events
++  CUDA_CHECK(cudaEventDestroy(start));
++  CUDA_CHECK(cudaEventDestroy(stop));
++
++  // Free device memory
++  CUDA_CHECK(cudaFree(d_input));
++  CUDA_CHECK(cudaFree(d_res));
++}
++
++GTEST_API_ int main(int argc, char **argv) {
++  int result = -1;
++
++  try {
++    testing::InitGoogleTest(&argc, argv);
++  } catch (...) {
++    std::cerr << "Error during InitGoogleTest" << std::endl;
++    return 0;
++  }
++
++  try {
++    result = RUN_ALL_TESTS();
++  } catch (...) {
++    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
++  }
++
++  return result;
++}
+
+From 1de3b605c6ab3e95b79325c516c268dac677092c Mon Sep 17 00:00:00 2001
+From: Daekyoung Jung <dk11.jung@samsung.com>
+Date: Thu, 27 Nov 2025 18:36:59 +0900
+Subject: [PATCH 5/9] Apply clang-format and add GGML Q8_1 quantization
+
+- Format all CUDA files in nntrainer/tensor/cuda_operations with clang-format
+- Add GGML Q8_1 quantization/dequantization implementation for CUDA
+- Include CPU fallback functions for quantization operations
+- Add unit tests for CUDA Q8_1 quantization functionality
+- Update meson build files to include new CUDA operations
+
+Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>
+---
+ .../tensor/cuda_operations/addition_cuda.cu   |  19 +
+ .../tensor/cuda_operations/ggml_cuda_common.h |  57 +++
+ .../cuda_operations/ggml_dequantize_cpu.cpp   |  61 +++
+ .../cuda_operations/ggml_dequantize_cpu.h     |  16 +
+ .../cuda_operations/ggml_quantize_cpu.cpp     |  90 +++++
+ .../cuda_operations/ggml_quantize_cpu.h       |  17 +
+ .../cuda_operations/ggml_quantize_cuda.cu     | 230 ++++++++++++
+ .../cuda_operations/ggml_quantize_cuda.h      | 114 ++++++
+ nntrainer/tensor/cuda_operations/meson.build  |  15 +-
+ .../tensor/cuda_operations/rmsnorm_cuda.cu    |  35 +-
+ test/unittest/meson.build                     |   3 +-
+ test/unittest/unittest_cuda_quantize.cpp      | 355 ++++++++++++++++++
+ 12 files changed, 989 insertions(+), 23 deletions(-)
+ create mode 100644 nntrainer/tensor/cuda_operations/ggml_cuda_common.h
+ create mode 100644 nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.cpp
+ create mode 100644 nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.h
+ create mode 100644 nntrainer/tensor/cuda_operations/ggml_quantize_cpu.cpp
+ create mode 100644 nntrainer/tensor/cuda_operations/ggml_quantize_cpu.h
+ create mode 100644 nntrainer/tensor/cuda_operations/ggml_quantize_cuda.cu
+ create mode 100644 nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h
+ create mode 100644 test/unittest/unittest_cuda_quantize.cpp
+
+diff --git a/nntrainer/tensor/cuda_operations/addition_cuda.cu b/nntrainer/tensor/cuda_operations/addition_cuda.cu
+index 112ceee42f..b8e98d0ac9 100644
+--- a/nntrainer/tensor/cuda_operations/addition_cuda.cu
++++ b/nntrainer/tensor/cuda_operations/addition_cuda.cu
+@@ -12,10 +12,20 @@
+  */
+ 
+ #include "addition_cuda.h"
++#include <cuda_fp16.h>
+ #include <cuda_runtime.h>
+ 
+ namespace nntrainer {
+ 
++__global__ void addition_cuda_kernel_fp16(const __half *input, __half *output,
++                                          unsigned int size_input,
++                                          unsigned int size_res) {
++  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
++  if (idx < size_res) {
++    output[idx] = output[idx] + input[idx % size_input];
++  }
++}
++
+ __global__ void addition_cuda_kernel(const float *input, float *output,
+                                      unsigned int size_input,
+                                      unsigned int size_res) {
+@@ -34,4 +44,13 @@ void addition_cuda(const float *input, float *res, unsigned int size_input,
+                                                 size_res);
+ }
+ 
++void addition_cuda_fp16(const __half *input, __half *res,
++                        unsigned int size_input, unsigned int size_res) {
++  const int blockSize = 256;
++  const int gridSize = (size_res + blockSize - 1) / blockSize;
++
++  addition_cuda_kernel_fp16<<<gridSize, blockSize>>>(input, res, size_input,
++                                                     size_res);
++}
++
+ } // namespace nntrainer
+diff --git a/nntrainer/tensor/cuda_operations/ggml_cuda_common.h b/nntrainer/tensor/cuda_operations/ggml_cuda_common.h
+new file mode 100644
+index 0000000000..5972852da1
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/ggml_cuda_common.h
+@@ -0,0 +1,57 @@
++#pragma once
++
++#include <cstdint>
++
++#ifdef __CUDACC__
++#include <cuda_fp16.h>
++typedef half ggml_half;
++typedef half2 ggml_half2;
++#else
++typedef uint16_t ggml_half;
++typedef struct {
++  uint16_t x;
++  uint16_t y;
++} ggml_half2;
++#endif
++
++#define QK8_1 32
++
++// Macros for anonymous unions/structs
++#ifdef _MSC_VER
++#define GGML_EXTENSION
++#else
++#define GGML_EXTENSION __extension__
++#endif
++
++#define GGML_COMMON_AGGR_U
++#define GGML_COMMON_AGGR_S data
++
++typedef struct {
++  GGML_EXTENSION union {
++    struct {
++      ggml_half d; // delta
++      ggml_half s; // d * sum(qs[i])
++    } GGML_COMMON_AGGR_S;
++    ggml_half2 ds;
++  } GGML_COMMON_AGGR_U;
++  int8_t qs[QK8_1]; // quants
++} block_q8_1;
++
++enum ggml_type {
++  GGML_TYPE_F32 = 0,
++  GGML_TYPE_F16 = 1,
++  GGML_TYPE_Q4_0 = 2,
++  GGML_TYPE_Q4_1 = 3,
++  GGML_TYPE_Q5_0 = 6,
++  GGML_TYPE_Q5_1 = 7,
++  GGML_TYPE_Q8_0 = 8,
++  GGML_TYPE_Q8_1 = 9,
++  // ... add others if needed
++};
++
++// Enum for MMQ Q8_1 data layout
++enum mmq_q8_1_ds_layout {
++  MMQ_Q8_1_DS_LAYOUT_D4,
++  MMQ_Q8_1_DS_LAYOUT_DS4,
++  MMQ_Q8_1_DS_LAYOUT_D2S6,
++};
+diff --git a/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.cpp b/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.cpp
+new file mode 100644
+index 0000000000..bc26f86de3
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.cpp
+@@ -0,0 +1,61 @@
++#include "ggml_dequantize_cpu.h"
++#include "ggml_cuda_common.h"
++
++#include <cassert>
++#include <cstring>
++
++// Helper for half to float conversion on CPU
++static inline float ggml_compute_fp16_to_fp32(ggml_half h) {
++  uint16_t h_u = h;
++
++  const uint32_t sign = (h_u >> 15) & 0x1;
++  const uint32_t exp = (h_u >> 10) & 0x1F;
++  const uint32_t mant = h_u & 0x3FF;
++
++  uint32_t f_u;
++
++  if (exp == 0) {
++    if (mant == 0) {
++      // Zero
++      f_u = sign << 31;
++    } else {
++      // Denormal
++      int e = -14;
++      uint32_t m = mant;
++      while ((m & 0x400) == 0) {
++        m <<= 1;
++        e--;
++      }
++      m &= 0x3FF;
++      f_u = (sign << 31) | ((e + 127) << 23) | (m << 13);
++    }
++  } else if (exp == 31) {
++    // Inf or NaN
++    f_u = (sign << 31) | (0xFF << 23) | (mant << 13);
++  } else {
++    // Normal
++    f_u = (sign << 31) | ((exp - 15 + 127) << 23) | (mant << 13);
++  }
++
++  float result;
++  std::memcpy(&result, &f_u, sizeof(float));
++  return result;
++}
++
++#define GGML_FP16_TO_FP32(x) ggml_compute_fp16_to_fp32(x)
++
++void dequantize_row_q8_1_host(const void *vx, float *y, int64_t k) {
++  assert(QK8_1 == 32);
++  assert(k % QK8_1 == 0);
++  const int nb = k / QK8_1;
++
++  const block_q8_1 *x = (const block_q8_1 *)vx;
++
++  for (int i = 0; i < nb; i++) {
++    const float d = GGML_FP16_TO_FP32(x[i].GGML_COMMON_AGGR_S.d);
++
++    for (int j = 0; j < QK8_1; ++j) {
++      y[i * QK8_1 + j] = x[i].qs[j] * d;
++    }
++  }
++}
+diff --git a/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.h b/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.h
+new file mode 100644
+index 0000000000..599610c203
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.h
+@@ -0,0 +1,16 @@
++#pragma once
++
++#include <cstdint>
++
++/**
++ * @brief Dequantizes a row of Q8_1 data to FP32 format on the host (CPU).
++ *
++ * This function converts Q8_1 quantized blocks back to 32-bit floating point
++ * values. It is the inverse operation of quantize_row_q8_1_host.
++ *
++ * @param vx Pointer to the input Q8_1 blocks.
++ * @param y Pointer to the output FP32 data array.
++ * @param k The number of elements to dequantize. Must be a multiple of 32
++ * (QK8_1).
++ */
++void dequantize_row_q8_1_host(const void *vx, float *y, int64_t k);
+diff --git a/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.cpp b/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.cpp
+new file mode 100644
+index 0000000000..48c1cd7797
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.cpp
+@@ -0,0 +1,90 @@
++#include "ggml_quantize_cpu.h"
++#include "ggml_cuda_common.h"
++
++#include <algorithm>
++#include <cassert>
++#include <cmath>
++#include <cstring>
++
++// Helper for float to half conversion on CPU
++static inline ggml_half ggml_compute_fp32_to_fp16(float x) {
++  uint16_t rh;
++  // Simple implementation or use a library if available.
++  // For now, let's use a basic implementation or rely on bit manipulation.
++  // Since we don't want to depend on external libraries, we can implement a
++  // minimal version or assume the user has a way to handle this. However, for
++  // correctness, let's use a standard conversion logic.
++
++  // Using a simplified version or just casting if strict accuracy isn't
++  // critical for this test setup, but for Q8_1 we need reasonable accuracy.
++  // Let's use a known conversion routine.
++
++  // F16C intrinsic if available?
++  // _mm_cvtps_ph
++
++  // Fallback C implementation:
++  uint32_t x_u;
++  std::memcpy(&x_u, &x, sizeof(float));
++
++  const uint32_t sign = (x_u >> 16) & 0x8000;
++  const uint32_t exp = (x_u >> 23) & 0xFF;
++  const uint32_t mant = x_u & 0x7FFFFF;
++
++  if (exp == 0) {
++    rh = sign; // Denormal or zero -> zero
++  } else if (exp == 255) {
++    rh = sign | 0x7C00 | (mant ? 0x200 : 0); // Inf or NaN
++  } else {
++    int new_exp = (int)exp - 127 + 15;
++    if (new_exp < 0) {
++      rh = sign; // Underflow -> zero
++    } else if (new_exp >= 31) {
++      rh = sign | 0x7C00; // Overflow -> Inf
++    } else {
++      rh = sign | (new_exp << 10) | (mant >> 13);
++    }
++  }
++  return rh;
++}
++
++#define GGML_FP32_TO_FP16(x) ggml_compute_fp32_to_fp16(x)
++
++void quantize_row_q8_1_host(const float *__restrict x, void *__restrict vy,
++                            int64_t k) {
++  assert(QK8_1 == 32);
++  assert(k % QK8_1 == 0);
++  const int nb = k / QK8_1;
++
++  block_q8_1 *__restrict y = (block_q8_1 *)vy;
++
++  for (int i = 0; i < nb; i++) {
++    float amax = 0.0f; // absolute max
++
++    for (int j = 0; j < QK8_1; j++) {
++      const float v = x[i * QK8_1 + j];
++      amax = std::max(amax, std::abs(v));
++    }
++
++    const float d = amax / ((1 << 7) - 1);
++    const float id = d ? 1.0f / d : 0.0f;
++
++    y[i].GGML_COMMON_AGGR_S.d = GGML_FP32_TO_FP16(d);
++
++    int sum = 0;
++
++    for (int j = 0; j < QK8_1 / 2; ++j) {
++      const float v0 = x[i * QK8_1 + j];
++      const float v1 = x[i * QK8_1 + j + QK8_1 / 2];
++
++      const int8_t q0 = roundf(v0 * id);
++      const int8_t q1 = roundf(v1 * id);
++
++      y[i].qs[j] = q0;
++      y[i].qs[j + QK8_1 / 2] = q1;
++
++      sum += q0 + q1;
++    }
++
++    y[i].GGML_COMMON_AGGR_S.s = GGML_FP32_TO_FP16(sum * d);
++  }
++}
+diff --git a/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.h b/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.h
+new file mode 100644
+index 0000000000..cbe7f11270
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.h
+@@ -0,0 +1,17 @@
++#pragma once
++
++#include <cstdint>
++
++/**
++ * @brief Quantizes a row of FP32 data to Q8_1 format on the host (CPU).
++ *
++ * This function converts a contiguous array of 32-bit floating point values
++ * into the Q8_1 quantization format. The Q8_1 format uses blocks of 32 values,
++ * storing 8-bit quantized weights and shared scaling factors.
++ *
++ * @param x Pointer to the input FP32 data array. Must be 32-byte aligned.
++ * @param vy Pointer to the output buffer where Q8_1 blocks will be stored.
++ * @param k The number of elements in the input array. Must be a multiple of 32
++ * (QK8_1).
++ */
++void quantize_row_q8_1_host(const float *x, void *vy, int64_t k);
+diff --git a/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.cu b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.cu
+new file mode 100644
+index 0000000000..b57f23d18b
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.cu
+@@ -0,0 +1,230 @@
++#include "ggml_quantize_cuda.h"
++#include <cstdio>
++#include <cuda_fp16.h>
++
++#define CUDA_QUANTIZE_BLOCK_SIZE 256
++#define CUDA_QUANTIZE_BLOCK_SIZE_MMQ 128
++#define WARP_SIZE 32
++
++// Helper functions for warp reduction
++template <int width = WARP_SIZE>
++static __device__ __forceinline__ float warp_reduce_max(float x) {
++#pragma unroll
++  for (int offset = width / 2; offset > 0; offset >>= 1) {
++    x = fmaxf(x, __shfl_xor_sync(0xffffffff, x, offset, width));
++  }
++  return x;
++}
++
++template <int width = WARP_SIZE>
++static __device__ __forceinline__ float warp_reduce_sum(float x) {
++#pragma unroll
++  for (int offset = width / 2; offset > 0; offset >>= 1) {
++    x += __shfl_xor_sync(0xffffffff, x, offset, width);
++  }
++  return x;
++}
++
++static __global__ void quantize_q8_1(const float *__restrict__ x,
++                                     void *__restrict__ vy, const int64_t ne00,
++                                     const int64_t s01, const int64_t s02,
++                                     const int64_t s03, const int64_t ne0,
++                                     const int ne1, const int ne2) {
++  const int64_t i0 = (int64_t)blockDim.x * blockIdx.x + threadIdx.x;
++
++  if (i0 >= ne0) {
++    return;
++  }
++
++  const int64_t i1 = blockIdx.y;
++  const int64_t i2 = blockIdx.z % ne2;
++  const int64_t i3 = blockIdx.z / ne2;
++
++  const int64_t &i00 = i0;
++  const int64_t &i01 = i1;
++  const int64_t &i02 = i2;
++  const int64_t &i03 = i3;
++
++  // Calculate contiguous index
++  const int64_t i_cont = ((i3 * ne2 + i2) * ne1 + i1) * ne0 + i0;
++
++  block_q8_1 *y = (block_q8_1 *)vy;
++
++  const int64_t ib = i_cont / QK8_1;  // block index
++  const int64_t iqs = i_cont % QK8_1; // quant index
++
++  const float xi =
++    i0 < ne00 ? x[i03 * s03 + i02 * s02 + i01 * s01 + i00] : 0.0f;
++  float amax = fabsf(xi);
++  float sum = xi;
++
++  amax = warp_reduce_max(amax);
++  sum = warp_reduce_sum(sum);
++
++  const float d = amax / 127;
++  const int8_t q = amax == 0.0f ? 0 : roundf(xi / d);
++
++  y[ib].qs[iqs] = q;
++
++  if (iqs > 0) {
++    return;
++  }
++
++  reinterpret_cast<half &>(y[ib].ds.x) = __float2half(d);
++  reinterpret_cast<half &>(y[ib].ds.y) = __float2half(sum);
++}
++
++template <mmq_q8_1_ds_layout ds_layout>
++static __global__ void quantize_mmq_q8_1(const float *__restrict__ x,
++                                         void *__restrict__ vy,
++                                         const int64_t kx0, const int64_t kx1,
++                                         const int64_t kx0_padded) {
++
++  constexpr int vals_per_scale = ds_layout == MMQ_Q8_1_DS_LAYOUT_D2S6 ? 64 : 32;
++  constexpr int vals_per_sum = ds_layout == MMQ_Q8_1_DS_LAYOUT_D2S6 ? 16 : 32;
++
++  const int64_t ix0 = ((int64_t)blockDim.x * blockIdx.x + threadIdx.x) * 4;
++
++  if (ix0 >= kx0_padded) {
++    return;
++  }
++
++  const float4 *x4 = (const float4 *)x;
++
++  const int64_t ix1 = kx1 * blockIdx.z + blockIdx.y;
++
++  block_q8_1_mmq *y = (block_q8_1_mmq *)vy;
++
++  const int64_t ib0 =
++    blockIdx.z * ((int64_t)gridDim.y * gridDim.x * blockDim.x /
++                  QK8_1); // first block of channel
++  const int64_t ib =
++    ib0 + (ix0 / (4 * QK8_1)) * kx1 + blockIdx.y; // block index in channel
++  const int64_t iqs = ix0 % (4 * QK8_1);          // quant index in block
++
++  // Load 4 floats per thread and calculate max. abs. value between them:
++  const float4 xi =
++    ix0 < kx0 ? x4[(ix1 * kx0 + ix0) / 4] : make_float4(0.0f, 0.0f, 0.0f, 0.0f);
++  float amax = fabsf(xi.x);
++  amax = fmaxf(amax, fabsf(xi.y));
++  amax = fmaxf(amax, fabsf(xi.z));
++  amax = fmaxf(amax, fabsf(xi.w));
++
++  // Exchange max. abs. value between vals_per_scale/4 threads.
++#pragma unroll
++  for (int offset = vals_per_scale / 8; offset > 0; offset >>= 1) {
++    amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFF, amax, offset, WARP_SIZE));
++  }
++
++  float sum;
++  if (ds_layout != MMQ_Q8_1_DS_LAYOUT_D4) {
++    sum = xi.x + xi.y + xi.z + xi.w;
++
++    // Exchange calculate sum across vals_per_sum/4 threads.
++#pragma unroll
++    for (int offset = vals_per_sum / 8; offset > 0; offset >>= 1) {
++      sum += __shfl_xor_sync(0xFFFFFFFF, sum, offset, WARP_SIZE);
++    }
++  }
++
++  const float d_inv = 127.0f / amax;
++  char4 q;
++  q.x = roundf(xi.x * d_inv);
++  q.y = roundf(xi.y * d_inv);
++  q.z = roundf(xi.z * d_inv);
++  q.w = roundf(xi.w * d_inv);
++
++  // Write back 4 int8 values as a single 32 bit value for better memroy
++  // bandwidth:
++  char4 *yqs4 = (char4 *)y[ib].qs;
++  yqs4[iqs / 4] = q;
++
++  if (ds_layout == MMQ_Q8_1_DS_LAYOUT_D2S6) {
++    if (iqs % 16 != 0 || iqs >= 96) {
++      return;
++    }
++
++    y[ib].d2s6[2 + iqs / 16] = __float2half(sum);
++
++    if (iqs % 64 != 0) {
++      return;
++    }
++
++    const float d = 1.0f / d_inv;
++
++    y[ib].d2s6[iqs / 64] = __float2half(d);
++
++    return;
++  }
++
++  if (iqs % 32 != 0) {
++    return;
++  }
++
++  const float d = 1.0f / d_inv;
++
++  if (ds_layout == MMQ_Q8_1_DS_LAYOUT_DS4) {
++    y[ib].ds4[iqs / 32] = make_half2(__float2half(d), __float2half(sum));
++  } else {
++    y[ib].d4[iqs / 32] = d;
++  }
++}
++
++void quantize_row_q8_1_cuda(const float *x, void *vy, const int64_t ne00,
++                            const int64_t s01, const int64_t s02,
++                            const int64_t s03, const int64_t ne0,
++                            const int64_t ne1, const int64_t ne2,
++                            const int64_t ne3, cudaStream_t stream) {
++
++  const int64_t block_num_x =
++    (ne0 + CUDA_QUANTIZE_BLOCK_SIZE - 1) / CUDA_QUANTIZE_BLOCK_SIZE;
++  const dim3 num_blocks(block_num_x, ne1, ne2 * ne3);
++  const dim3 block_size(CUDA_QUANTIZE_BLOCK_SIZE, 1, 1);
++  quantize_q8_1<<<num_blocks, block_size, 0, stream>>>(x, vy, ne00, s01, s02,
++                                                       s03, ne0, ne1, ne2);
++}
++
++void quantize_row_q8_1_cuda(const float *x, void *vy, int64_t k,
++                            cudaStream_t stream) {
++  const int64_t ne0 = k;
++  const int64_t ne1 = 1;
++  const int64_t ne2 = 1;
++  const int64_t ne3 = 1;
++  const int64_t ne00 = k;
++  const int64_t s01 =
++    sizeof(float) * k;     // Stride for next row (not used for 1D)
++  const int64_t s02 = s01; // Stride for next matrix (not used for 1D)
++  const int64_t s03 = s01; // Stride for next batch (not used for 1D)
++
++  quantize_row_q8_1_cuda(x, vy, ne00, s01, s02, s03, ne0, ne1, ne2, ne3,
++                         stream);
++}
++
++void quantize_mmq_q8_1_cuda(const float *x, void *vy, const ggml_type type_src0,
++                            const int64_t ne00, const int64_t s01,
++                            const int64_t s02, const int64_t s03,
++                            const int64_t ne0, const int64_t ne1,
++                            const int64_t ne2, const int64_t ne3,
++                            cudaStream_t stream) {
++
++  const int64_t block_num_x = (ne0 + 4 * CUDA_QUANTIZE_BLOCK_SIZE_MMQ - 1) /
++                              (4 * CUDA_QUANTIZE_BLOCK_SIZE_MMQ);
++  const dim3 num_blocks(block_num_x, ne1, ne2 * ne3);
++  const dim3 block_size(CUDA_QUANTIZE_BLOCK_SIZE_MMQ, 1, 1);
++  switch (mmq_get_q8_1_ds_layout(type_src0)) {
++  case MMQ_Q8_1_DS_LAYOUT_D4:
++    quantize_mmq_q8_1<MMQ_Q8_1_DS_LAYOUT_D4>
++      <<<num_blocks, block_size, 0, stream>>>(x, vy, ne00, ne1, ne0);
++    break;
++  case MMQ_Q8_1_DS_LAYOUT_DS4:
++    quantize_mmq_q8_1<MMQ_Q8_1_DS_LAYOUT_DS4>
++      <<<num_blocks, block_size, 0, stream>>>(x, vy, ne00, ne1, ne0);
++    break;
++  case MMQ_Q8_1_DS_LAYOUT_D2S6:
++    quantize_mmq_q8_1<MMQ_Q8_1_DS_LAYOUT_D2S6>
++      <<<num_blocks, block_size, 0, stream>>>(x, vy, ne00, ne1, ne0);
++    break;
++  default:
++    break;
++  }
++}
+diff --git a/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h
+new file mode 100644
+index 0000000000..1d8bbdcb17
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h
+@@ -0,0 +1,114 @@
++#pragma once
++
++#include "ggml_cuda_common.h"
++#include <cstdint>
++#include <cuda_runtime.h>
++
++// Struct for MMQ Q8_1 block (CUDA specific)
++struct block_q8_1_mmq {
++  union {
++    float d4[4];       // 1 32 bit scale per 32 values, stored as d0,d1,d2,d3
++    ggml_half2 ds4[4]; // 1 16 bit scale + 1 16 bit partial sum per 32 values,
++                       // stored as d0,s0,d1,s1,d2,s2,d3,s3
++    ggml_half d2s6[8]; // 1 16 bit scale per 64 values + 1 16 bit partial sum
++                       // per 16 values for the first 96 values,
++                       //     stored as d0,d1,s1,s2,s3,s4,s5
++  };
++  int8_t qs[4 * QK8_1]; // 128 values quantized to 8 bit each
++};
++
++/**
++ * @brief Quantizes a row of FP32 data to Q8_1 format on the GPU (CUDA).
++ *
++ * This function launches a CUDA kernel to convert FP32 data into Q8_1 format.
++ * It handles the grid and block dimensions for the kernel launch.
++ *
++ * @param x Pointer to the input FP32 data array on the device.
++ * @param vy Pointer to the output buffer on the device where Q8_1 blocks will
++ * be stored.
++ * @param ne00 The number of elements in the 0-th dimension of the source
++ * tensor.
++ * @param s01 Stride of the 1st dimension of the source tensor (in bytes).
++ * @param s02 Stride of the 2nd dimension of the source tensor (in bytes).
++ * @param s03 Stride of the 3rd dimension of the source tensor (in bytes).
++ * @param ne0 The number of elements in the 0-th dimension.
++ * @param ne1 The number of elements in the 1st dimension.
++ * @param ne2 The number of elements in the 2nd dimension.
++ * @param ne3 The number of elements in the 3rd dimension.
++ * @param stream The CUDA stream to execute the kernel on.
++ */
++void quantize_row_q8_1_cuda(const float *x, void *vy, const int64_t ne00,
++                            const int64_t s01, const int64_t s02,
++                            const int64_t s03, const int64_t ne0,
++                            const int64_t ne1, const int64_t ne2,
++                            const int64_t ne3, cudaStream_t stream);
++
++/**
++ * @brief Simplified version of quantize_row_q8_1_cuda matching the host API.
++ *
++ * This overload assumes a contiguous 1D array (single row).
++ *
++ * @param x Pointer to the input FP32 data array on the device.
++ * @param vy Pointer to the output buffer on the device.
++ * @param k The number of elements in the array.
++ * @param stream The CUDA stream to execute the kernel on.
++ */
++void quantize_row_q8_1_cuda(const float *x, void *vy, int64_t k,
++                            cudaStream_t stream);
++
++/**
++ * @brief Quantizes data to MMQ-compatible Q8_1 format on the GPU (CUDA).
++ *
++ * This function quantizes data specifically for Matrix Multiplication Quantized
++ * (MMQ) operations. It supports different data layouts (D4, DS4, D2S6)
++ * depending on the source quantization type.
++ *
++ * @param x Pointer to the input FP32 data array on the device.
++ * @param vy Pointer to the output buffer on the device.
++ * @param type_src0 The GGML type of the source tensor, determining the target
++ * MMQ layout.
++ * @param ne00 The number of elements in the 0-th dimension of the source
++ * tensor.
++ * @param s01 Stride of the 1st dimension of the source tensor (in bytes).
++ * @param s02 Stride of the 2nd dimension of the source tensor (in bytes).
++ * @param s03 Stride of the 3rd dimension of the source tensor (in bytes).
++ * @param ne0 The number of elements in the 0-th dimension.
++ * @param ne1 The number of elements in the 1st dimension.
++ * @param ne2 The number of elements in the 2nd dimension.
++ * @param ne3 The number of elements in the 3rd dimension.
++ * @param stream The CUDA stream to execute the kernel on.
++ */
++void quantize_mmq_q8_1_cuda(const float *x, void *vy, const ggml_type type_src0,
++                            const int64_t ne00, const int64_t s01,
++                            const int64_t s02, const int64_t s03,
++                            const int64_t ne0, const int64_t ne1,
++                            const int64_t ne2, const int64_t ne3,
++                            cudaStream_t stream);
++
++/**
++ * @brief Determines the MMQ Q8_1 data layout based on the source quantization
++ * type.
++ *
++ * Different source quantization types (e.g., Q4_0, Q5_0) require different
++ * internal layouts (D4, DS4, D2S6) when converted to Q8_1 for efficient MMQ
++ * kernel execution.
++ *
++ * @param type_x The GGML type of the source tensor.
++ * @return The corresponding mmq_q8_1_ds_layout enum value.
++ */
++static mmq_q8_1_ds_layout mmq_get_q8_1_ds_layout(const ggml_type type_x) {
++  switch (type_x) {
++  case GGML_TYPE_Q4_0:
++  case GGML_TYPE_Q4_1:
++    return MMQ_Q8_1_DS_LAYOUT_DS4;
++  case GGML_TYPE_Q5_0:
++    return MMQ_Q8_1_DS_LAYOUT_D4;
++  case GGML_TYPE_Q5_1:
++    return MMQ_Q8_1_DS_LAYOUT_DS4;
++  case GGML_TYPE_Q8_0:
++    return MMQ_Q8_1_DS_LAYOUT_D4;
++  // Add other types as needed, defaulting to D4 for safety if unknown
++  default:
++    return MMQ_Q8_1_DS_LAYOUT_D4;
++  }
++}
+diff --git a/nntrainer/tensor/cuda_operations/meson.build b/nntrainer/tensor/cuda_operations/meson.build
+index 9af6aff6a3..58f18bed3b 100644
+--- a/nntrainer/tensor/cuda_operations/meson.build
++++ b/nntrainer/tensor/cuda_operations/meson.build
+@@ -1,25 +1,28 @@
+ # Find CUDA compiler
+-dep = dependency('cuda', version : '>=13', modules : ['cublas'])
+-
+ nvcc = find_program('nvcc', required: true)
+ 
+ if nvcc.found()
+   cuda_sources = [
+     'rmsnorm_cuda.cu',
+-    'addition_cuda.cu'
++    'addition_cuda.cu',
++    'ggml_quantize_cuda.cu'
+   ]
+ 
+   cuda_headers = [
+     'rmsnorm_cuda.h',
+     'addition_cuda.h',
+-    'cuda_interface.h'
++    'cuda_interface.h',
++    'ggml_cuda_common.h',
++    'ggml_quantize_cuda.h',
++    'ggml_quantize_cpu.h',
++    'ggml_dequantize_cpu.h'
+   ]
+ 
+   kernel_objects = []
+   foreach kernel : cuda_sources
+     obj_name = kernel.replace('.cu', '.o')
+     obj = custom_target(obj_name,
+-      command: [nvcc, '-c', '-Xcompiler', '/MD', '@INPUT@', '-o', '@OUTPUT@'],
++      command: [nvcc, '-gencode', 'arch=compute_89,code=sm_89', '-gencode', 'arch=compute_120,code=sm_120', '-c', '-Xcompiler', '/MD', '@INPUT@', '-o', '@OUTPUT@'],
+       input: kernel,
+       output: obj_name
+     )
+@@ -28,6 +31,8 @@ if nvcc.found()
+ 
+   # Add cuda_interface.cpp to regular sources
+   nntrainer_sources += meson.current_source_dir() / 'cuda_interface.cpp'
++  nntrainer_sources += meson.current_source_dir() / 'ggml_quantize_cpu.cpp'
++  nntrainer_sources += meson.current_source_dir() / 'ggml_dequantize_cpu.cpp'
+ 
+   nntrainer_sources += kernel_objects
+ 
+diff --git a/nntrainer/tensor/cuda_operations/rmsnorm_cuda.cu b/nntrainer/tensor/cuda_operations/rmsnorm_cuda.cu
+index cb885871f6..8048b8a5a2 100644
+--- a/nntrainer/tensor/cuda_operations/rmsnorm_cuda.cu
++++ b/nntrainer/tensor/cuda_operations/rmsnorm_cuda.cu
+@@ -14,34 +14,34 @@
+ #include "rmsnorm_cuda.h"
+ #include <cuda_runtime.h>
+ 
+- __global__ void rmsnorm_cuda_kernel(const float *input, float *output,
+-                                    const float *alpha, float epsilon,
+-                                    int H, int W) {
++__global__ void rmsnorm_cuda_kernel(const float *input, float *output,
++                                    const float *alpha, float epsilon, int H,
++                                    int W) {
+   // Each block processes one row (height index)
+   int h = blockIdx.x;
+   int index = h * W;
+-  
++
+   // Shared memory for reduction
+   extern __shared__ float sdata[];
+-  
++
+   // Thread index within block
+   int tid = threadIdx.x;
+   const int blockSize = blockDim.x;
+-  
++
+   // Load input data and compute sum of squares
+   const float *in = input + index;
+   float sum_squares = 0.0f;
+-  
++
+   // Each thread processes multiple elements if W > blockSize
+   for (int i = tid; i < W; i += blockSize) {
+     float val = in[i];
+     sum_squares += val * val;
+   }
+-  
++
+   // Store partial sum in shared memory
+   sdata[tid] = sum_squares;
+   __syncthreads();
+-  
++
+   // Reduction in shared memory
+   for (int s = blockSize / 2; s > 0; s >>= 1) {
+     if (tid < s) {
+@@ -49,20 +49,20 @@
+     }
+     __syncthreads();
+   }
+-  
++
+   // First thread in block computes the final result
+   if (tid == 0) {
+     float mean = sdata[0] / W;
+     float scale = 1.0f / sqrtf(mean + epsilon);
+-    
++
+     // Store the scale value in shared memory for reuse
+     sdata[0] = scale;
+   }
+   __syncthreads();
+-  
++
+   // Load the computed scale
+   float scale = sdata[0];
+-  
++
+   // Compute output values
+   float *out = output + index;
+   for (int i = tid; i < W; i += blockSize) {
+@@ -73,16 +73,17 @@
+ namespace nntrainer {
+ 
+ void rmsnorm_cuda(const float *input, const float *gamma, float *result,
+-                  const float epsilon, unsigned int height, unsigned int width) {
++                  const float epsilon, unsigned int height,
++                  unsigned int width) {
+   // Define block size
+   const int blockSize = 256;
+-  
++
+   // Calculate grid size (one block per row)
+   const int gridSize = height;
+-  
++
+   // Shared memory size for reduction
+   const int sharedMemSize = blockSize * sizeof(float);
+-  
++
+   // Launch the CUDA kernel
+   rmsnorm_cuda_kernel<<<gridSize, blockSize, sharedMemSize>>>(
+     input, result, gamma, epsilon, height, width);
+diff --git a/test/unittest/meson.build b/test/unittest/meson.build
+index f004d0401d..d1037cee2e 100644
+--- a/test/unittest/meson.build
++++ b/test/unittest/meson.build
+@@ -87,6 +87,7 @@ endif
+ if get_option('enable-cuda')
+   test_target += [['unittest_cuda', []]]
+   test_target += [['unittest_cuda_addition', []]]
++  test_target += [['unittest_cuda_quantize', []]]
+ endif
+ 
+ if get_option('enable-fp16')
+@@ -103,7 +104,7 @@ endif
+ foreach target: test_target
+   cuda_deps = []
+   cuda_link_args = []
+-  if target[0] == 'unittest_cuda' and get_option('enable-cuda')
++  if target[0].startswith('unittest_cuda') and get_option('enable-cuda')
+     cuda_deps = [cuda_dep]
+     cuda_link_args = ['-NODEFAULTLIB:LIBCMT', '-NOIMPLIB', '-NOEXP']
+   endif
+diff --git a/test/unittest/unittest_cuda_quantize.cpp b/test/unittest/unittest_cuda_quantize.cpp
+new file mode 100644
+index 0000000000..63854462d4
+--- /dev/null
++++ b/test/unittest/unittest_cuda_quantize.cpp
+@@ -0,0 +1,355 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file   unittest_cuda_quantize.cpp
++ * @date   27 Nov 2025
++ * @brief  Unit test for Q8_1 quantization operations
++ * @see    https://github.com/nnstreamer/nntrainer
++ * @author Samsung Electronics Co., Ltd.
++ * @bug    No known bugs except for NYI items
++ */
++
++#include <gtest/gtest.h>
++#include <vector>
++#include <random>
++#include <cmath>
++#include "ggml_quantize_cpu.h"
++#include "ggml_dequantize_cpu.h"
++#include "ggml_cuda_common.h"
++#include "ggml_quantize_cuda.h"
++#include <cuda_runtime.h>
++#include <iostream>
++
++#define CUDA_CHECK(call)                                                       \
++  do {                                                                         \
++    cudaError_t error = call;                                                  \
++    if (error != cudaSuccess) {                                                \
++      std::cerr << "CUDA error at " << __FILE__ << ":" << __LINE__ << " - "   \
++                << cudaGetErrorString(error) << std::endl;                     \
++      FAIL();                                                                  \
++    }                                                                          \
++  } while (0)
++
++#define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
++  EXPECT_GE((VAL), (MIN));                                                     \
++  EXPECT_LE((VAL), (MAX))
++
++/**
++ * @brief Compute Mean Squared Error between two arrays
++ */
++static float compute_mse(const float* a, const float* b, int64_t size) {
++  double sum = 0.0;
++  for (int64_t i = 0; i < size; ++i) {
++    double diff = a[i] - b[i];
++    sum += diff * diff;
++  }
++  return static_cast<float>(sum / size);
++}
++
++/**
++ * @brief Test Q8_1 quantization and dequantization round-trip
++ */
++TEST(nntrainer_CUDA_Quantize, q8_1_roundtrip_basic) {
++  const int64_t size = 1024; // Must be multiple of 32
++  
++  // 1. Generate random FP32 array
++  std::vector<float> original(size);
++  std::mt19937 gen(42); // Fixed seed for reproducibility
++  std::uniform_real_distribution<float> dis(-10.0f, 10.0f);
++  
++  for (int64_t i = 0; i < size; ++i) {
++    original[i] = dis(gen);
++  }
++  
++  // 2. Quantize to Q8_1
++  const int64_t num_blocks = size / QK8_1;
++  std::vector<block_q8_1> quantized(num_blocks);
++  quantize_row_q8_1_host(original.data(), quantized.data(), size);
++  
++  // 3. Dequantize back to FP32
++  std::vector<float> dequantized(size);
++  dequantize_row_q8_1_host(quantized.data(), dequantized.data(), size);
++  
++  // 4. Compute MSE and check it's within acceptable range
++  float mse = compute_mse(original.data(), dequantized.data(), size);
++  
++  // Q8_1 uses 8-bit quantization, so we expect some loss
++  // MSE should be small but non-zero due to quantization
++  EXPECT_IN_RANGE(mse, 0.0f, 0.1f); // Adjust threshold based on expected precision
++  
++  std::cout << "Q8_1 Round-trip MSE: " << mse << std::endl;
++}
++
++/**
++ * @brief Test Q8_1 with various sizes
++ */
++TEST(nntrainer_CUDA_Quantize, q8_1_roundtrip_various_sizes) {
++  std::vector<int64_t> test_sizes = {32, 64, 128, 256, 512, 2048, 4096};
++  
++  std::mt19937 gen(123);
++  std::uniform_real_distribution<float> dis(-5.0f, 5.0f);
++  
++  for (int64_t size : test_sizes) {
++    std::vector<float> original(size);
++    for (int64_t i = 0; i < size; ++i) {
++      original[i] = dis(gen);
++    }
++    
++    const int64_t num_blocks = size / QK8_1;
++    std::vector<block_q8_1> quantized(num_blocks);
++    quantize_row_q8_1_host(original.data(), quantized.data(), size);
++    
++    std::vector<float> dequantized(size);
++    dequantize_row_q8_1_host(quantized.data(), dequantized.data(), size);
++    
++    float mse = compute_mse(original.data(), dequantized.data(), size);
++    
++    EXPECT_IN_RANGE(mse, 0.0f, 0.1f);
++    
++    std::cout << "Size " << size << " - MSE: " << mse << std::endl;
++  }
++}
++
++/**
++ * @brief Test Q8_1 with edge cases (zeros, small values, large values)
++ */
++TEST(nntrainer_CUDA_Quantize, q8_1_edge_cases) {
++  const int64_t size = 128;
++  
++  // Test with all zeros
++  {
++    std::vector<float> original(size, 0.0f);
++    const int64_t num_blocks = size / QK8_1;
++    std::vector<block_q8_1> quantized(num_blocks);
++    quantize_row_q8_1_host(original.data(), quantized.data(), size);
++    
++    std::vector<float> dequantized(size);
++    dequantize_row_q8_1_host(quantized.data(), dequantized.data(), size);
++    
++    float mse = compute_mse(original.data(), dequantized.data(), size);
++    EXPECT_FLOAT_EQ(mse, 0.0f);
++  }
++  
++  // Test with very small values
++  {
++    std::vector<float> original(size);
++    std::mt19937 gen(456);
++    std::uniform_real_distribution<float> dis(-0.01f, 0.01f);
++    for (int64_t i = 0; i < size; ++i) {
++      original[i] = dis(gen);
++    }
++    
++    const int64_t num_blocks = size / QK8_1;
++    std::vector<block_q8_1> quantized(num_blocks);
++    quantize_row_q8_1_host(original.data(), quantized.data(), size);
++    
++    std::vector<float> dequantized(size);
++    dequantize_row_q8_1_host(quantized.data(), dequantized.data(), size);
++    
++    float mse = compute_mse(original.data(), dequantized.data(), size);
++    EXPECT_IN_RANGE(mse, 0.0f, 0.001f);
++  }
++  
++  // Test with large values
++  {
++    std::vector<float> original(size);
++    std::mt19937 gen(789);
++    std::uniform_real_distribution<float> dis(-100.0f, 100.0f);
++    for (int64_t i = 0; i < size; ++i) {
++      original[i] = dis(gen);
++    }
++    
++    const int64_t num_blocks = size / QK8_1;
++    std::vector<block_q8_1> quantized(num_blocks);
++    quantize_row_q8_1_host(original.data(), quantized.data(), size);
++    
++    std::vector<float> dequantized(size);
++    dequantize_row_q8_1_host(quantized.data(), dequantized.data(), size);
++    
++    float mse = compute_mse(original.data(), dequantized.data(), size);
++    EXPECT_IN_RANGE(mse, 0.0f, 10.0f); // Higher threshold for larger values
++  }
++}
++
++/**
++ * @brief Test CUDA Q8_1 quantization vs Host implementation
++ */
++TEST(nntrainer_CUDA_Quantize, q8_1_cuda_vs_host) {
++  const int64_t size = 1024;
++  
++  // Generate random FP32 array
++  std::vector<float> input_host(size);
++  std::mt19937 gen(999);
++  std::uniform_real_distribution<float> dis(-10.0f, 10.0f);
++  
++  for (int64_t i = 0; i < size; ++i) {
++    input_host[i] = dis(gen);
++  }
++  
++  const int64_t num_blocks = size / QK8_1;
++  
++  // Host quantization
++  std::vector<block_q8_1> quantized_host(num_blocks);
++  quantize_row_q8_1_host(input_host.data(), quantized_host.data(), size);
++  
++  // CUDA quantization
++  float *d_input = nullptr;
++  block_q8_1 *d_quantized = nullptr;
++  
++  CUDA_CHECK(cudaMalloc(&d_input, size * sizeof(float)));
++  CUDA_CHECK(cudaMalloc(&d_quantized, num_blocks * sizeof(block_q8_1)));
++  
++  CUDA_CHECK(cudaMemcpy(d_input, input_host.data(), size * sizeof(float), cudaMemcpyHostToDevice));
++  
++  cudaStream_t stream;
++  CUDA_CHECK(cudaStreamCreate(&stream));
++  
++  quantize_row_q8_1_cuda(d_input, d_quantized, size, stream);
++  
++  CUDA_CHECK(cudaStreamSynchronize(stream));
++  
++  std::vector<block_q8_1> quantized_cuda(num_blocks);
++  CUDA_CHECK(cudaMemcpy(quantized_cuda.data(), d_quantized, num_blocks * sizeof(block_q8_1), cudaMemcpyDeviceToHost));
++  
++  // Compare results
++  int mismatches = 0;
++  for (int64_t i = 0; i < num_blocks; ++i) {
++    // Compare quantized values
++    for (int j = 0; j < QK8_1; ++j) {
++      if (quantized_host[i].qs[j] != quantized_cuda[i].qs[j]) {
++        mismatches++;
++      }
++    }
++    
++    // Compare scale factors (d) - allow small FP16 differences
++    uint16_t d_host = quantized_host[i].GGML_COMMON_AGGR_S.d;
++    uint16_t d_cuda = quantized_cuda[i].GGML_COMMON_AGGR_S.d;
++    if (d_host != d_cuda) {
++      // Allow 1 ULP difference for FP16
++      int diff = std::abs(static_cast<int>(d_host) - static_cast<int>(d_cuda));
++      if (diff > 1) {
++        mismatches++;
++      }
++    }
++  }
++  
++  // Cleanup
++  CUDA_CHECK(cudaStreamDestroy(stream));
++  CUDA_CHECK(cudaFree(d_input));
++  CUDA_CHECK(cudaFree(d_quantized));
++  
++  // Expect very few or no mismatches (allowing for minor FP16 rounding differences)
++  EXPECT_LE(mismatches, num_blocks * QK8_1 * 0.01); // Allow up to 1% mismatch
++  
++  std::cout << "CUDA vs Host mismatches: " << mismatches << " out of " << (num_blocks * (QK8_1 + 1)) << std::endl;
++}
++
++/**
++ * @brief Performance benchmark for CUDA Q8_1 quantization
++ */
++TEST(nntrainer_CUDA_Quantize, q8_1_cuda_performance) {
++  const int64_t size = 3072 * 1024;
++  const int num_iterations = 10;
++  
++  // Generate random FP32 array
++  std::vector<float> input_host(size);
++  std::mt19937 gen(12345);
++  std::uniform_real_distribution<float> dis(-10.0f, 10.0f);
++  
++  for (int64_t i = 0; i < size; ++i) {
++    input_host[i] = dis(gen);
++  }
++  
++  const int64_t num_blocks = size / QK8_1;
++  
++  // Allocate device memory
++  float *d_input = nullptr;
++  block_q8_1 *d_quantized = nullptr;
++  
++  CUDA_CHECK(cudaMalloc(&d_input, size * sizeof(float)));
++  CUDA_CHECK(cudaMalloc(&d_quantized, num_blocks * sizeof(block_q8_1)));
++  
++  CUDA_CHECK(cudaMemcpy(d_input, input_host.data(), size * sizeof(float), cudaMemcpyHostToDevice));
++  
++  cudaStream_t stream;
++  CUDA_CHECK(cudaStreamCreate(&stream));
++  
++  // Create CUDA events for timing
++  cudaEvent_t start, stop;
++  CUDA_CHECK(cudaEventCreate(&start));
++  CUDA_CHECK(cudaEventCreate(&stop));
++  
++  std::vector<float> elapsed_times;
++  elapsed_times.reserve(num_iterations - 1);
++  
++  for (int iter = 0; iter < num_iterations; ++iter) {
++    if (iter == 0) {
++      // Warm-up iteration (not measured)
++      quantize_row_q8_1_cuda(d_input, d_quantized, size, stream);
++      CUDA_CHECK(cudaStreamSynchronize(stream));
++    } else {
++      // Measured iterations
++      CUDA_CHECK(cudaEventRecord(start, stream));
++      
++      quantize_row_q8_1_cuda(d_input, d_quantized, size, stream);
++      
++      CUDA_CHECK(cudaEventRecord(stop, stream));
++      CUDA_CHECK(cudaEventSynchronize(stop));
++      
++      float elapsed_ms = 0.0f;
++      CUDA_CHECK(cudaEventElapsedTime(&elapsed_ms, start, stop));
++      elapsed_times.push_back(elapsed_ms);
++    }
++  }
++  
++  // Cleanup
++  CUDA_CHECK(cudaEventDestroy(start));
++  CUDA_CHECK(cudaEventDestroy(stop));
++  CUDA_CHECK(cudaStreamDestroy(stream));
++  CUDA_CHECK(cudaFree(d_input));
++  CUDA_CHECK(cudaFree(d_quantized));
++  
++  // Calculate statistics
++  float total_time = 0.0f;
++  float min_time = elapsed_times[0];
++  float max_time = elapsed_times[0];
++  
++  for (float t : elapsed_times) {
++    total_time += t;
++    min_time = std::min(min_time, t);
++    max_time = std::max(max_time, t);
++  }
++  
++  float avg_time = total_time / elapsed_times.size();
++  
++  std::cout << "CUDA Q8_1 Quantization Performance (size=" << size << "):" << std::endl;
++  std::cout << "  Average time: " << avg_time << " ms" << std::endl;
++  std::cout << "  Min time:     " << min_time << " ms" << std::endl;
++  std::cout << "  Max time:     " << max_time << " ms" << std::endl;
++  std::cout << "  Throughput:   " << (size * sizeof(float) / (avg_time * 1e6)) << " GB/s" << std::endl;
++  
++  // Sanity check: time should be reasonable (not zero, not too large)
++  EXPECT_GT(avg_time, 0.0f);
++  EXPECT_LT(avg_time, 1000.0f); // Should complete in less than 1 second
++}
++
++GTEST_API_ int main(int argc, char **argv) {
++  int result = -1;
++
++  try {
++    testing::InitGoogleTest(&argc, argv);
++  } catch (...) {
++    std::cerr << "Error during InitGoogleTest" << std::endl;
++    return 0;
++  }
++
++  try {
++    result = RUN_ALL_TESTS();
++  } catch (...) {
++    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
++  }
++
++  return result;
++}
++
+
+From d28ce7f3d12a7355320e97fea621334e94f91746 Mon Sep 17 00:00:00 2001
+From: Daekyoung Jung <dk11.jung@samsung.com>
+Date: Fri, 28 Nov 2025 15:34:31 +0900
+Subject: [PATCH 6/9] test: refactor quantize unit tests to separate file
+
+- Move int4 quantization test from unittest_blas_kernels_cl.cpp to
+  new unittest_quantize_cl.cpp for better organization
+- Create shared test utilities (unittest_util.h/cpp) with:
+  * generate_random_vector template function
+  * allocateSVM/freeSVM helper functions
+- Add unittest_util.cpp to OpenCL test targets in meson.build
+- Update blas_kernels to support shared test utilities
+- Add CUDA int4 GEMM kernel implementation (gemm_int4_cuda.cu/h)
+- Update GGML quantization headers and implementations
+---
+ .../tensor/cl_operations/blas_kernels.cpp     |  50 ++++
+ nntrainer/tensor/cl_operations/blas_kernels.h |   7 +
+ .../tensor/cuda_operations/gemm_int4_cuda.cu  |  26 ++
+ .../tensor/cuda_operations/gemm_int4_cuda.h   |  37 +++
+ .../tensor/cuda_operations/ggml_cuda_common.h |   6 +
+ .../cuda_operations/ggml_dequantize_cpu.cpp   |   6 +
+ .../cuda_operations/ggml_dequantize_cpu.h     |   6 +
+ .../cuda_operations/ggml_quantize_cpu.cpp     |   6 +
+ .../cuda_operations/ggml_quantize_cpu.h       |   6 +
+ .../cuda_operations/ggml_quantize_cuda.h      |   9 +
+ test/unittest/meson.build                     |   5 +-
+ test/unittest/unittest_quantize_cl.cpp        | 228 ++++++++++++++++++
+ test/unittest/unittest_util.cpp               |  21 ++
+ test/unittest/unittest_util.h                 |  42 ++++
+ 14 files changed, 453 insertions(+), 2 deletions(-)
+ create mode 100644 nntrainer/tensor/cuda_operations/gemm_int4_cuda.cu
+ create mode 100644 nntrainer/tensor/cuda_operations/gemm_int4_cuda.h
+ create mode 100644 test/unittest/unittest_quantize_cl.cpp
+ create mode 100644 test/unittest/unittest_util.cpp
+ create mode 100644 test/unittest/unittest_util.h
+
+diff --git a/nntrainer/tensor/cl_operations/blas_kernels.cpp b/nntrainer/tensor/cl_operations/blas_kernels.cpp
+index 4a494fcecb..f123d4632c 100644
+--- a/nntrainer/tensor/cl_operations/blas_kernels.cpp
++++ b/nntrainer/tensor/cl_operations/blas_kernels.cpp
+@@ -1257,4 +1257,54 @@ void transpose_16(void *input, void *output, int width, int height,
+   }
+ }
+ */
++void openvino_quantize_input_int4_pad(void *input, void *quantized_input, void *scales,
++                                      unsigned int M, unsigned int K,
++                                      unsigned int quantization_group_size) {
++  int alignK = align(K, quantization_group_size);
++
++  bool result = false;
++  auto *blas_cc =
++    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
++  auto &clbuffInstance = ClBufferManager::Global();
++  const bool scale_row_major = false;
++  std::string compile_options =
++    " -D SIZE_N=" + std::to_string(M) + " -D SIZE_K=" + std::to_string(K) +
++    " -D SIZE_QUANTIZATION_GROUP=" + std::to_string(quantization_group_size) +
++    " -D SCALE_ROW_MAJOR=" + std::to_string(scale_row_major);
++
++  ClContext::SharedPtrClKernel kernel_ptr = blas_cc->registerClKernel(
++    int4_quantize_input_kernel, "quantize_input_int4_pad", compile_options);
++  if (!kernel_ptr) {
++    throw std::runtime_error("Failed to get kernel_ptr for quantize_input");
++    return;
++  }
++
++  int arg = 0;
++
++  result = kernel_ptr->SetKernelSVMArguments(arg++, input);
++
++  if (!result)
++    throw std::runtime_error("Failed to set kernel argument 0 for "
++                             "quantize_input");
++
++  result =
++    kernel_ptr->SetKernelSVMArguments(arg++, quantized_input);
++  if (!result)
++    throw std::runtime_error("Failed to set kernel argument 1 for "
++                             "quantize_input");
++
++  result =
++    kernel_ptr->SetKernelSVMArguments(arg++, scales);
++  if (!result)
++    throw std::runtime_error("Failed to set kernel argument 2 for "
++                             "quantize_input");
++
++  std::array<size_t, 3> global_work_size = {
++    (M * alignK) / quantization_group_size, 1, 1};
++
++  blas_cc->command_queue_inst_.enqueueKernel(
++    kernel_ptr->GetKernel(), global_work_size.size(), global_work_size.data(),
++    nullptr, 0, nullptr, nullptr);
++}
++
+ } // namespace nntrainer
+diff --git a/nntrainer/tensor/cl_operations/blas_kernels.h b/nntrainer/tensor/cl_operations/blas_kernels.h
+index b48c4fef11..16d63afc92 100644
+--- a/nntrainer/tensor/cl_operations/blas_kernels.h
++++ b/nntrainer/tensor/cl_operations/blas_kernels.h
+@@ -118,6 +118,13 @@ void openvino_gemm_cl(void *input, void *weights, void *scales, void *output,
+                       unsigned int M, unsigned int N, unsigned int K,
+                       unsigned int quantization_group_size);
+ 
++/**
++ * @brief INT4 input quantization using quantize_input_int4_pad kernel
++ */
++void openvino_quantize_input_int4_pad(void *input, void *quantized_input, void *scales,
++                                      unsigned int M, unsigned int K,
++                                      unsigned int quantization_group_size);
++
+ /**
+  * @brief INT4 GEMM async computation
+  */
+diff --git a/nntrainer/tensor/cuda_operations/gemm_int4_cuda.cu b/nntrainer/tensor/cuda_operations/gemm_int4_cuda.cu
+new file mode 100644
+index 0000000000..9058d0f82f
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/gemm_int4_cuda.cu
+@@ -0,0 +1,26 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2024 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file	gemm_int4_cuda.cu
++ * @date	28 Nov 2025
++ * @brief	CUDA implementation of int4 GEMM operation
++ * @see		https://github.com/nnstreamer/nntrainer
++ * @author	[Your Name] <[your.email@samsung.com]>
++ * @bug		No known bugs except for NYI items
++ *
++ */
++
++#include "gemm_int4_cuda.h"
++#include <cuda_runtime.h>
++#include <cuda_fp16.h>
++
++namespace nntrainer {
++
++void gemm_int4_cuda(void *input, void *weights, void *scales, void *output,
++                    unsigned int M, unsigned int N, unsigned int K,
++                    unsigned int quantization_group_size) {
++  // todo:
++}
++
++} // namespace nntrainer
+diff --git a/nntrainer/tensor/cuda_operations/gemm_int4_cuda.h b/nntrainer/tensor/cuda_operations/gemm_int4_cuda.h
+new file mode 100644
+index 0000000000..27bd84097d
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/gemm_int4_cuda.h
+@@ -0,0 +1,37 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2024 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file	gemm_int4_cuda.h
++ * @date	28 Nov 2025
++ * @brief	CUDA implementation of int4 GEMM operation
++ * @see		https://github.com/nnstreamer/nntrainer
++ * @author	[Your Name] <[your.email@samsung.com]>
++ * @bug		No known bugs except for NYI items
++ *
++ */
++
++#ifndef __GEMM_INT4_CUDA_H__
++#define __GEMM_INT4_CUDA_H__
++
++namespace nntrainer {
++
++/**
++ * @brief CUDA implementation of int4 GEMM operation equivalent to openvino_gemm_cl
++ * 
++ * @param input Input data pointer
++ * @param weights Weight data pointer
++ * @param scales Scale data pointer
++ * @param output Output data pointer
++ * @param M Number of rows in the matrix
++ * @param N Number of columns in the matrix
++ * @param K Inner dimension of the matrix multiplication
++ * @param quantization_group_size Quantization group size
++ */
++void gemm_int4_cuda(void *input, void *weights, void *scales, void *output,
++                    unsigned int M, unsigned int N, unsigned int K,
++                    unsigned int quantization_group_size);
++
++} // namespace nntrainer
++
++#endif // __GEMM_INT4_CUDA_H__
+diff --git a/nntrainer/tensor/cuda_operations/ggml_cuda_common.h b/nntrainer/tensor/cuda_operations/ggml_cuda_common.h
+index 5972852da1..3ce9165952 100644
+--- a/nntrainer/tensor/cuda_operations/ggml_cuda_common.h
++++ b/nntrainer/tensor/cuda_operations/ggml_cuda_common.h
+@@ -1,3 +1,9 @@
++/**
++ * @file ggml_cuda_common.h
++ * @brief Common definitions and structures for CUDA operations in GGML
++ * @author Samsung R&D Institute
++ * @bug No known bugs
++ */
+ #pragma once
+ 
+ #include <cstdint>
+diff --git a/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.cpp b/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.cpp
+index bc26f86de3..da4c771d2f 100644
+--- a/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.cpp
++++ b/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.cpp
+@@ -1,3 +1,9 @@
++/**
++ * @file ggml_dequantize_cpu.cpp
++ * @brief CPU implementation for dequantizing GGML data
++ * @author Samsung R&D Institute
++ * @bug No known bugs
++ */
+ #include "ggml_dequantize_cpu.h"
+ #include "ggml_cuda_common.h"
+ 
+diff --git a/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.h b/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.h
+index 599610c203..c0e1621dd5 100644
+--- a/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.h
++++ b/nntrainer/tensor/cuda_operations/ggml_dequantize_cpu.h
+@@ -1,3 +1,9 @@
++/**
++ * @file ggml_dequantize_cpu.h
++ * @brief Header file for CPU dequantization functions
++ * @author Samsung R&D Institute
++ * @bug No known bugs
++ */
+ #pragma once
+ 
+ #include <cstdint>
+diff --git a/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.cpp b/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.cpp
+index 48c1cd7797..7d1ef24854 100644
+--- a/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.cpp
++++ b/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.cpp
+@@ -1,3 +1,9 @@
++/**
++ * @file ggml_quantize_cpu.cpp
++ * @brief CPU implementation for quantizing GGML data
++ * @author Samsung R&D Institute
++ * @bug No known bugs
++ */
+ #include "ggml_quantize_cpu.h"
+ #include "ggml_cuda_common.h"
+ 
+diff --git a/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.h b/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.h
+index cbe7f11270..3b33366c65 100644
+--- a/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.h
++++ b/nntrainer/tensor/cuda_operations/ggml_quantize_cpu.h
+@@ -1,3 +1,9 @@
++/**
++ * @file ggml_quantize_cpu.h
++ * @brief Header file for CPU quantization functions
++ * @author Samsung R&D Institute
++ * @bug No known bugs
++ */
+ #pragma once
+ 
+ #include <cstdint>
+diff --git a/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h
+index 1d8bbdcb17..317c3701e1 100644
+--- a/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h
++++ b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h
+@@ -1,3 +1,9 @@
++/**
++ * @file ggml_quantize_cuda.h
++ * @brief Header file for CUDA quantization functions
++ * @author Samsung R&D Institute
++ * @bug No known bugs
++ */
+ #pragma once
+ 
+ #include "ggml_cuda_common.h"
+@@ -5,6 +11,9 @@
+ #include <cuda_runtime.h>
+ 
+ // Struct for MMQ Q8_1 block (CUDA specific)
++/**
++ * @brief Structure for MMQ Q8_1 block (CUDA specific)
++ */
+ struct block_q8_1_mmq {
+   union {
+     float d4[4];       // 1 32 bit scale per 32 values, stored as d0,d1,d2,d3
+diff --git a/test/unittest/meson.build b/test/unittest/meson.build
+index d1037cee2e..d490616cc2 100644
+--- a/test/unittest/meson.build
++++ b/test/unittest/meson.build
+@@ -80,8 +80,9 @@ if host_machine.system() != 'windows'
+ endif
+ 
+ if get_option('enable-opencl')
+-  test_target += [['unittest_blas_kernels_cl', []]]
+-  test_target += [['unittest_attention_kernels_cl', []]]
++  test_target += [['unittest_blas_kernels_cl', ['unittest_util.cpp']]]
++  test_target += [['unittest_attention_kernels_cl', ['unittest_util.cpp']]]
++  test_target += [['unittest_quantize_cl', ['unittest_util.cpp']]]
+ endif
+ 
+ if get_option('enable-cuda')
+diff --git a/test/unittest/unittest_quantize_cl.cpp b/test/unittest/unittest_quantize_cl.cpp
+new file mode 100644
+index 0000000000..f495ed4e79
+--- /dev/null
++++ b/test/unittest/unittest_quantize_cl.cpp
+@@ -0,0 +1,228 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2024 Debadri Samaddar <s.debadri@samsung.com>
++ *
++ * @file	unittest_quantize_cl.cpp
++ * @date	28 November 2024
++ * @brief	Test setup for quantization OpenCL kernels
++ * @see		https://github.com/nnstreamer/nntrainer
++ * @author	Debadri Samaddar <s.debadri@samsung.com>
++ * @bug		No known bugs except for NYI items
++ */
++
++#include <cstring>
++#include <gtest/gtest.h>
++#include <utility>
++
++#include "fallback_internal.h"
++#include "int4_utils.h"
++#include "nntrainer_test_util.h"
++#include "q4_0_utils.h"
++#include "swiglu_cl.h"
++#include "tensor_dim.h"
++#include "timer.h"
++#include <blas_kernel_interface.h>
++#include <blas_kernels.h>
++#include <cl_context.h>
++#include <cpu_backend.h>
++#include <fp16.h>
++#include <layer_context.h>
++#include <tensor.h>
++#include "unittest_util.h"
++
++#define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
++  EXPECT_GE((VAL), (MIN));                                                     \
++  EXPECT_LE((VAL), (MAX))
++
++using namespace nntrainer;
++
++// Helper for Round to Nearest Even (RTE)
++
++static int8_t round_half_to_even(float x) {
++  float r = roundf(x);
++  float d = r - x;
++  if (fabsf(d) != 0.5f) {
++    return (int8_t)r;
++  }
++  // If exactly halfway, round to even
++  int ir = (int)r;
++  return (int8_t)((ir % 2 == 0) ? ir : ir - (ir > 0 ? 1 : -1));
++}
++
++// CPU version of openvino_quantize_input_int4_pad for reference in tests
++static void cpu_openvino_quantize_input_int4_pad(float *input, int8_t *quantized_input, uint16_t *scales,
++                                                 unsigned int M, unsigned int K, unsigned int quantization_group_size) {
++  int alignK = (K + quantization_group_size - 1) / quantization_group_size * quantization_group_size;
++  int groups_in_row = alignK / quantization_group_size;
++  
++  for (int group_id = 0; group_id < M * groups_in_row; ++group_id) {
++    int row_id = group_id / groups_in_row;
++    int group_id_in_row = group_id % groups_in_row;
++    int input_offset = (row_id * K) + (group_id_in_row * quantization_group_size);
++    int output_offset = group_id * quantization_group_size;
++    int max_quantize_block = quantization_group_size / 4;
++    int quantize_block;
++    
++    if (group_id_in_row == groups_in_row - 1) {
++      quantize_block = (quantization_group_size - (alignK - K)) / 4;
++    } else {
++      quantize_block = quantization_group_size / 4;
++    }
++    
++    // Find maximum absolute value in the block
++    float max_value = 0.0f;
++    for (int i = 0; i < quantize_block; ++i) {
++      for (int j = 0; j < 4; ++j) {
++        int idx = input_offset + (i * 4) + j;
++        // Simulate half precision for input
++        float val = idx < row_id * K + K ? compute_fp16_to_fp32(compute_fp32_to_fp16(input[idx])) : 0.0f;
++        float abs_val = fabsf(val);
++        max_value = fmaxf(max_value, abs_val);
++      }
++    }
++    // Simulate half precision for max_value
++    max_value = compute_fp16_to_fp32(compute_fp32_to_fp16(max_value));
++    // Simulate half precision for epsilon 0.001h
++    float epsilon = compute_fp16_to_fp32(compute_fp32_to_fp16(0.001f));
++    max_value = fmaxf(max_value, epsilon);
++    
++    // Calculate quantization scale
++    float quan_scale = max_value / 127.0f;
++    
++    // Quantize the data
++    for (int i = 0; i < quantize_block; ++i) {
++      for (int j = 0; j < 4; ++j) {
++        int input_idx = input_offset + (i * 4) + j;
++        int output_idx = output_offset + (i * 4) + j;
++        // Simulate half precision for input
++        float val = (input_idx < row_id * K + K) ? compute_fp16_to_fp32(compute_fp32_to_fp16(input[input_idx])) : 0.0f;
++        float quantized_val = val / quan_scale;
++        // Round to nearest even (RTE)
++        int8_t rounded_val = round_half_to_even(quantized_val);
++        quantized_input[output_idx] = rounded_val;
++      }
++    }
++    
++    // Pad with zeros if necessary
++    for (int i = quantize_block * 4; i < max_quantize_block * 4; ++i) {
++      int output_idx = output_offset + i;
++      quantized_input[output_idx] = 0;
++    }
++    
++    // Store the scale
++    // Kernel writes to group_id * 2 (interleaved with activation sum)
++    scales[group_id * 2] = compute_fp32_to_fp16(quan_scale);
++    scales[group_id * 2 + 1] = 0; // Placeholder for activation sum
++  }
++}
++
++static void run_int4_quantize_input_test_(const uint32_t M, const uint32_t K,
++                                          const int scale_group_size) {
++  auto *blas_cc = static_cast<nntrainer::ClContext *>(
++    nntrainer::Engine::Global().getRegisteredContext("gpu"));
++
++  static constexpr uint32_t run_count = 200;
++
++  // Allocate & initialize data
++  // Input for kernel is half (uint16_t)
++  uint16_t *input_ptr = (uint16_t *)allocateSVM(M * K * sizeof(uint16_t));
++  int8_t *quantized_input_ptr = (int8_t *)allocateSVM(M * K / 2);
++  // Scales size is doubled for interleaved storage
++  uint16_t *scales_ptr =
++    (uint16_t *)allocateSVM(M * K / scale_group_size * sizeof(uint16_t) * 2);
++
++  std::vector<float> input =
++    generate_random_vector<float, false>(M * K, -2.0f, 2.0f);
++
++  for (unsigned int i = 0; i < M * K; ++i) {
++    input_ptr[i] = compute_fp32_to_fp16(input[i]);
++  }
++
++  // CPU quantization for reference
++  std::vector<int8_t> ref_quantized_input(M * K);
++  // Ref scales size is doubled
++  std::vector<uint16_t> ref_scales(M * K / scale_group_size * 2);
++  cpu_openvino_quantize_input_int4_pad(input.data(), ref_quantized_input.data(), ref_scales.data(), M, K, scale_group_size);
++
++  // GPU INT4 input quantization
++  auto t3 = std::chrono::high_resolution_clock::now();
++  nntrainer::openvino_quantize_input_int4_pad(
++    input_ptr, quantized_input_ptr, scales_ptr, M, K, scale_group_size);
++  clFinish(blas_cc->command_queue_inst_.GetCommandQueue());
++  auto t4 = std::chrono::high_resolution_clock::now();
++  auto gpu_dt = std::chrono::duration_cast<std::chrono::milliseconds>(t4 - t3);
++
++  std::cout << "INT4 input quantization : " << M << " x " << K << std::endl;
++  std::cout << " - time : GPU = " << gpu_dt.count()
++            << " ms" << std::endl;
++
++  // Compare results
++  bool quantized_data_match = true;
++  bool scales_match = true;
++
++  int mismatch_count = 0;
++  for (unsigned int i = 0; i < M * K / 2; ++i) {
++    if (quantized_input_ptr[i] != ref_quantized_input[i]) {
++      mismatch_count++;
++    }
++  }
++  
++  float mismatch_ratio = (float)mismatch_count / (M * K / 2);
++  if (mismatch_ratio > 0.01f) {
++    quantized_data_match = false;
++  }
++  std::cout << " - quantized data mismatch count: " << mismatch_count << " (" << mismatch_ratio * 100.0f << "%)" << std::endl;
++
++  float mse_scales = 0.0f;
++  for (unsigned int i = 0; i < M * K / scale_group_size; ++i) {
++    float val = compute_fp16_to_fp32(scales_ptr[i * 2]);
++    float ref = compute_fp16_to_fp32(ref_scales[i * 2]);
++    mse_scales += (val - ref) * (val - ref);
++  }
++  mse_scales /= (M * K / scale_group_size);
++  
++  if (mse_scales > 1e-5f) {
++    scales_match = false;
++  }
++  std::cout << " - scales MSE: " << mse_scales << std::endl;
++
++  EXPECT_TRUE(quantized_data_match);
++  EXPECT_TRUE(scales_match);
++
++  std::cout << " - quantized data match: " << (quantized_data_match ? "YES" : "NO") << std::endl;
++  std::cout << " - scales match: " << (scales_match ? "YES" : "NO") << std::endl;
++
++  freeSVM(input_ptr);
++  freeSVM(quantized_input_ptr);
++  freeSVM(scales_ptr);
++}
++
++#define DECLARE_int4_quantize_input_test_M_K_G(M, K, G)                        \
++  TEST(nntrainer_blas_kernel, int4_quantize_input_test_##M##_##K##_##G) {      \
++    run_int4_quantize_input_test_(M, K, G);                                    \
++  }
++
++DECLARE_int4_quantize_input_test_M_K_G(32, 3072, 32);
++DECLARE_int4_quantize_input_test_M_K_G(128, 3072, 32);
++DECLARE_int4_quantize_input_test_M_K_G(256, 3072, 32);
++DECLARE_int4_quantize_input_test_M_K_G(512, 3072, 32);
++DECLARE_int4_quantize_input_test_M_K_G(1024, 3072, 32);
++
++GTEST_API_ int main(int argc, char **argv) {
++  int result = -1;
++
++  try {
++    testing::InitGoogleTest(&argc, argv);
++  } catch (...) {
++    std::cerr << "Error during InitGoogleTest" << std::endl;
++    return 0;
++  }
++
++  try {
++    result = RUN_ALL_TESTS();
++  } catch (...) {
++    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
++  }
++
++  return result;
++}
+diff --git a/test/unittest/unittest_util.cpp b/test/unittest/unittest_util.cpp
+new file mode 100644
+index 0000000000..70a9822eb7
+--- /dev/null
++++ b/test/unittest/unittest_util.cpp
+@@ -0,0 +1,21 @@
++#include "unittest_util.h"
++#include <cl_context.h>
++#include <engine.h>
++
++namespace nntrainer {
++
++void *allocateSVM(size_t size_bytes) {
++  auto *blas_cc = static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
++  void *ptr = blas_cc->context_inst_.createSVMRegion(size_bytes);
++  if (!ptr) {
++    throw std::runtime_error("Failed to allocate SVM for unit test.");
++  }
++  return ptr;
++}
++
++void freeSVM(void *ptr) {
++  auto *blas_cc = static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
++  blas_cc->context_inst_.releaseSVMRegion(ptr);
++}
++
++} // namespace nntrainer
+diff --git a/test/unittest/unittest_util.h b/test/unittest/unittest_util.h
+new file mode 100644
+index 0000000000..9f4dd5f327
+--- /dev/null
++++ b/test/unittest/unittest_util.h
+@@ -0,0 +1,42 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * @file unittest_util.h
++ * @brief Shared utility functions for unit tests.
++ */
++
++#ifndef NNTRAINER_UNITTEST_UTIL_H
++#define NNTRAINER_UNITTEST_UTIL_H
++
++#include <vector>
++#include <cstddef>
++#include <random>
++
++namespace nntrainer {
++
++// Generate a random vector of given size and range.
++// The template type T is expected to be convertible from float.
++// This function is used across many unit tests.
++
++template <typename T, bool random_init = false>
++std::vector<T> generate_random_vector(size_t size, float min_val = -1.F,
++                                      float max_val = 1.F) {
++  std::random_device rd;
++  auto init_val = random_init ? rd() : 42;
++  std::mt19937 gen(init_val);
++  std::uniform_real_distribution<float> dist(min_val, max_val);
++  std::vector<T> vec(size);
++  for (auto &val : vec) {
++    val = static_cast<T>(dist(gen));
++  }
++  return vec;
++}
++
++// Allocate SVM memory using the OpenCL context.
++void *allocateSVM(size_t size_bytes);
++
++// Release SVM memory.
++void freeSVM(void *ptr);
++
++} // namespace nntrainer
++
++#endif // NNTRAINER_UNITTEST_UTIL_H
+
+From 3aaae29836e7fbb1bceb8521bcb392750b80b3b0 Mon Sep 17 00:00:00 2001
+From: Daekyoung Jung <dk11.jung@samsung.com>
+Date: Mon, 1 Dec 2025 16:32:38 +0900
+Subject: [PATCH 7/9] CUDA Impl INT4 input quantization with padding
+
+This commit adds CUDA impl for INT4 quantization with padding.
+It matches the existing OpenCL kernel behavior for compatibility.
+
+Changes:
+- Add quantize_input_int4_pad_kernel CUDA kernel function
+- Add quantize_input_int4_pad_cuda wrapper function
+- Update unit tests to use new CPU reference implementation
+- Add round_half_to_even helper function for rounding to nearest even
+- Add cpu_quantize_input_int4_pad CPU reference implementation
+- Add unittest_util.cpp to unittest_cuda_quantize target
+- Add new test case for M=63, K=3072, G=32
+
+Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>
+---
+ .../cuda_operations/ggml_quantize_cuda.cu     |  98 +++
+ .../cuda_operations/ggml_quantize_cuda.h      |  22 +
+ test/unittest/meson.build                     |   4 +-
+ test/unittest/unittest_cuda_quantize.cpp      | 583 +++++++++++++++---
+ test/unittest/unittest_quantize_cl.cpp        | 102 +--
+ test/unittest/unittest_util.cpp               |  86 ++-
+ test/unittest/unittest_util.h                 |  11 +-
+ 7 files changed, 735 insertions(+), 171 deletions(-)
+
+diff --git a/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.cu b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.cu
+index b57f23d18b..2c3f936bc7 100644
+--- a/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.cu
++++ b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.cu
+@@ -228,3 +228,101 @@ void quantize_mmq_q8_1_cuda(const float *x, void *vy, const ggml_type type_src0,
+     break;
+   }
+ }
++
++// CUDA kernel for INT4 quantization with padding
++static __global__ void quantize_input_int4_pad_kernel(
++  const float *__restrict__ input, int8_t *__restrict__ quantized_input,
++  half *__restrict__ scales, unsigned int M, unsigned int K,
++  unsigned int quantization_group_size) {
++
++  const unsigned int group_id = blockIdx.x;
++  const unsigned int tid = threadIdx.x;
++
++  const unsigned int align_k =
++    ((K + quantization_group_size - 1) / quantization_group_size) *
++    quantization_group_size;
++  const unsigned int groups_in_row = align_k / quantization_group_size;
++  const unsigned int row_id = group_id / groups_in_row;
++  const unsigned int group_id_in_row = group_id % groups_in_row;
++  const unsigned int input_offset =
++    (row_id * K) + (group_id_in_row * quantization_group_size);
++  const unsigned int output_offset = group_id * quantization_group_size;
++  const unsigned int max_quantize_block = quantization_group_size;
++
++  unsigned int quantize_block;
++  if (group_id_in_row == groups_in_row - 1) {
++    quantize_block = quantization_group_size - (align_k - K);
++  } else {
++    quantize_block = quantization_group_size;
++  }
++
++  // Shared memory for reduction
++  __shared__ float shared_max[32];
++
++  // Find maximum absolute value
++  float local_max = 0.0f;
++  for (unsigned int i = tid; i < quantize_block; i += blockDim.x) {
++    unsigned int idx = input_offset + i;
++    float val = (idx < row_id * K + K)
++                  ? fabsf(__half2float(__float2half(input[idx])))
++                  : 0.0f;
++    local_max = fmaxf(local_max, val);
++  }
++
++  shared_max[tid] = local_max;
++
++  // Reduction in shared memory
++  for (unsigned int s = blockDim.x / 2; s > 0; s >>= 1) {
++    if (tid < s) {
++      shared_max[tid] = fmaxf(shared_max[tid], shared_max[tid + s]);
++    }
++  }
++
++  float max_value = fmaxf(shared_max[0], 0.001f);
++
++  // Calculate quantization scale
++  float quan_scale = max_value / 127.0f;
++  float quan_scale_1 = 1.0f / quan_scale;
++
++  // Quantize the data
++  for (unsigned int i = tid; i < quantize_block; i += blockDim.x) {
++    unsigned int input_idx = input_offset + i;
++    unsigned int output_idx = output_offset + i;
++    float val = (input_idx < row_id * K + K)
++                  ? __half2float(__float2half(input[input_idx]))
++                  : 0.0f;
++    float quantized_val = val * quan_scale_1;
++    quantized_input[output_idx] = (int8_t)__float2int_rn(quantized_val);
++  }
++
++  // Pad with zeros if necessary
++  for (unsigned int i = quantize_block + tid; i < max_quantize_block;
++       i += blockDim.x) {
++    unsigned int output_idx = output_offset + i;
++    quantized_input[output_idx] = 0;
++  }
++
++  // Store the scale (thread 0 only)
++  if (tid == 0) {
++    scales[group_id * 2] = __float2half(quan_scale);
++    scales[group_id * 2 + 1] = (__half)0.0f; // Placeholder for activation sum
++  }
++}
++
++void quantize_input_int4_pad_cuda(const void *input, void *quantized_input,
++                                  void *scales, unsigned int M, unsigned int K,
++                                  unsigned int quantization_group_size,
++                                  cudaStream_t stream) {
++  const unsigned int align_k =
++    ((K + quantization_group_size - 1) / quantization_group_size) *
++    quantization_group_size;
++  const unsigned int groups_in_row = align_k / quantization_group_size;
++  const unsigned int total_groups = M * groups_in_row;
++
++  const dim3 grid(total_groups);
++  const dim3 block(32);
++
++  quantize_input_int4_pad_kernel<<<grid, block, 0, stream>>>(
++    (const float *)input, (int8_t *)quantized_input, (half *)scales, M, K,
++    quantization_group_size);
++}
+diff --git a/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h
+index 317c3701e1..95a2abe397 100644
+--- a/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h
++++ b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h
+@@ -121,3 +121,25 @@ static mmq_q8_1_ds_layout mmq_get_q8_1_ds_layout(const ggml_type type_x) {
+     return MMQ_Q8_1_DS_LAYOUT_D4;
+   }
+ }
++
++/**
++ * @brief Quantizes FP16 input to INT4 format with padding support (CUDA).
++ *
++ * This function quantizes FP16 input data to INT4 format in groups,
++ * matching the OpenCL openvino_quantize_input_int4_pad kernel behavior.
++ * Each group is quantized independently with its own scale factor.
++ *
++ * @param input Pointer to the input FP16 data array on the device.
++ * @param quantized_input Pointer to the output INT8 buffer on the device.
++ * @param scales Pointer to the output UINT16 (FP16) scales buffer on the
++ * device.
++ * @param M Number of rows in the input matrix.
++ * @param K Number of columns in the input matrix.
++ * @param quantization_group_size Size of each quantization group (typically
++ * 32).
++ * @param stream The CUDA stream to execute the kernel on (default: 0).
++ */
++void quantize_input_int4_pad_cuda(const void *input, void *quantized_input,
++                                  void *scales, unsigned int M, unsigned int K,
++                                  unsigned int quantization_group_size,
++                                  cudaStream_t stream = 0);
+diff --git a/test/unittest/meson.build b/test/unittest/meson.build
+index d490616cc2..30fcd4d69e 100644
+--- a/test/unittest/meson.build
++++ b/test/unittest/meson.build
+@@ -88,7 +88,7 @@ endif
+ if get_option('enable-cuda')
+   test_target += [['unittest_cuda', []]]
+   test_target += [['unittest_cuda_addition', []]]
+-  test_target += [['unittest_cuda_quantize', []]]
++  test_target += [['unittest_cuda_quantize', ['unittest_util.cpp']]]
+ endif
+ 
+ if get_option('enable-fp16')
+@@ -112,7 +112,7 @@ foreach target: test_target
+   
+   exe = executable(
+     target[0],
+-    [target[0] + '.cpp'] + [target[1]],
++    [target[0] + '.cpp'] + target[1],
+     # below is temporary measure, we will eventually remove unittest_nntrainer_models
+     include_directories: include_directories('models'),
+     dependencies: unittest_nntrainer_deps + cuda_deps,
+diff --git a/test/unittest/unittest_cuda_quantize.cpp b/test/unittest/unittest_cuda_quantize.cpp
+index 63854462d4..42d1a9c289 100644
+--- a/test/unittest/unittest_cuda_quantize.cpp
++++ b/test/unittest/unittest_cuda_quantize.cpp
+@@ -10,22 +10,28 @@
+  * @bug    No known bugs except for NYI items
+  */
+ 
++#include <cmath>
++#include <cuda_runtime.h>
+ #include <gtest/gtest.h>
+-#include <vector>
++#include <iostream>
+ #include <random>
+-#include <cmath>
+-#include "ggml_quantize_cpu.h"
+-#include "ggml_dequantize_cpu.h"
++#include <vector>
++
++#include "blas_kernels.h"
++#include "cl_context.h"
++#include "engine.h"
++#include "fp16.h"
+ #include "ggml_cuda_common.h"
++#include "ggml_dequantize_cpu.h"
++#include "ggml_quantize_cpu.h"
+ #include "ggml_quantize_cuda.h"
+-#include <cuda_runtime.h>
+-#include <iostream>
++#include "unittest_util.h"
+ 
+ #define CUDA_CHECK(call)                                                       \
+   do {                                                                         \
+     cudaError_t error = call;                                                  \
+     if (error != cudaSuccess) {                                                \
+-      std::cerr << "CUDA error at " << __FILE__ << ":" << __LINE__ << " - "   \
++      std::cerr << "CUDA error at " << __FILE__ << ":" << __LINE__ << " - "    \
+                 << cudaGetErrorString(error) << std::endl;                     \
+       FAIL();                                                                  \
+     }                                                                          \
+@@ -38,7 +44,7 @@
+ /**
+  * @brief Compute Mean Squared Error between two arrays
+  */
+-static float compute_mse(const float* a, const float* b, int64_t size) {
++static float compute_mse(const float *a, const float *b, int64_t size) {
+   double sum = 0.0;
+   for (int64_t i = 0; i < size; ++i) {
+     double diff = a[i] - b[i];
+@@ -52,32 +58,33 @@ static float compute_mse(const float* a, const float* b, int64_t size) {
+  */
+ TEST(nntrainer_CUDA_Quantize, q8_1_roundtrip_basic) {
+   const int64_t size = 1024; // Must be multiple of 32
+-  
++
+   // 1. Generate random FP32 array
+   std::vector<float> original(size);
+   std::mt19937 gen(42); // Fixed seed for reproducibility
+   std::uniform_real_distribution<float> dis(-10.0f, 10.0f);
+-  
++
+   for (int64_t i = 0; i < size; ++i) {
+     original[i] = dis(gen);
+   }
+-  
++
+   // 2. Quantize to Q8_1
+   const int64_t num_blocks = size / QK8_1;
+   std::vector<block_q8_1> quantized(num_blocks);
+   quantize_row_q8_1_host(original.data(), quantized.data(), size);
+-  
++
+   // 3. Dequantize back to FP32
+   std::vector<float> dequantized(size);
+   dequantize_row_q8_1_host(quantized.data(), dequantized.data(), size);
+-  
++
+   // 4. Compute MSE and check it's within acceptable range
+   float mse = compute_mse(original.data(), dequantized.data(), size);
+-  
++
+   // Q8_1 uses 8-bit quantization, so we expect some loss
+   // MSE should be small but non-zero due to quantization
+-  EXPECT_IN_RANGE(mse, 0.0f, 0.1f); // Adjust threshold based on expected precision
+-  
++  EXPECT_IN_RANGE(mse, 0.0f,
++                  0.1f); // Adjust threshold based on expected precision
++
+   std::cout << "Q8_1 Round-trip MSE: " << mse << std::endl;
+ }
+ 
+@@ -86,27 +93,27 @@ TEST(nntrainer_CUDA_Quantize, q8_1_roundtrip_basic) {
+  */
+ TEST(nntrainer_CUDA_Quantize, q8_1_roundtrip_various_sizes) {
+   std::vector<int64_t> test_sizes = {32, 64, 128, 256, 512, 2048, 4096};
+-  
++
+   std::mt19937 gen(123);
+   std::uniform_real_distribution<float> dis(-5.0f, 5.0f);
+-  
++
+   for (int64_t size : test_sizes) {
+     std::vector<float> original(size);
+     for (int64_t i = 0; i < size; ++i) {
+       original[i] = dis(gen);
+     }
+-    
++
+     const int64_t num_blocks = size / QK8_1;
+     std::vector<block_q8_1> quantized(num_blocks);
+     quantize_row_q8_1_host(original.data(), quantized.data(), size);
+-    
++
+     std::vector<float> dequantized(size);
+     dequantize_row_q8_1_host(quantized.data(), dequantized.data(), size);
+-    
++
+     float mse = compute_mse(original.data(), dequantized.data(), size);
+-    
++
+     EXPECT_IN_RANGE(mse, 0.0f, 0.1f);
+-    
++
+     std::cout << "Size " << size << " - MSE: " << mse << std::endl;
+   }
+ }
+@@ -116,21 +123,21 @@ TEST(nntrainer_CUDA_Quantize, q8_1_roundtrip_various_sizes) {
+  */
+ TEST(nntrainer_CUDA_Quantize, q8_1_edge_cases) {
+   const int64_t size = 128;
+-  
++
+   // Test with all zeros
+   {
+     std::vector<float> original(size, 0.0f);
+     const int64_t num_blocks = size / QK8_1;
+     std::vector<block_q8_1> quantized(num_blocks);
+     quantize_row_q8_1_host(original.data(), quantized.data(), size);
+-    
++
+     std::vector<float> dequantized(size);
+     dequantize_row_q8_1_host(quantized.data(), dequantized.data(), size);
+-    
++
+     float mse = compute_mse(original.data(), dequantized.data(), size);
+     EXPECT_FLOAT_EQ(mse, 0.0f);
+   }
+-  
++
+   // Test with very small values
+   {
+     std::vector<float> original(size);
+@@ -139,18 +146,18 @@ TEST(nntrainer_CUDA_Quantize, q8_1_edge_cases) {
+     for (int64_t i = 0; i < size; ++i) {
+       original[i] = dis(gen);
+     }
+-    
++
+     const int64_t num_blocks = size / QK8_1;
+     std::vector<block_q8_1> quantized(num_blocks);
+     quantize_row_q8_1_host(original.data(), quantized.data(), size);
+-    
++
+     std::vector<float> dequantized(size);
+     dequantize_row_q8_1_host(quantized.data(), dequantized.data(), size);
+-    
++
+     float mse = compute_mse(original.data(), dequantized.data(), size);
+     EXPECT_IN_RANGE(mse, 0.0f, 0.001f);
+   }
+-  
++
+   // Test with large values
+   {
+     std::vector<float> original(size);
+@@ -159,14 +166,14 @@ TEST(nntrainer_CUDA_Quantize, q8_1_edge_cases) {
+     for (int64_t i = 0; i < size; ++i) {
+       original[i] = dis(gen);
+     }
+-    
++
+     const int64_t num_blocks = size / QK8_1;
+     std::vector<block_q8_1> quantized(num_blocks);
+     quantize_row_q8_1_host(original.data(), quantized.data(), size);
+-    
++
+     std::vector<float> dequantized(size);
+     dequantize_row_q8_1_host(quantized.data(), dequantized.data(), size);
+-    
++
+     float mse = compute_mse(original.data(), dequantized.data(), size);
+     EXPECT_IN_RANGE(mse, 0.0f, 10.0f); // Higher threshold for larger values
+   }
+@@ -177,41 +184,44 @@ TEST(nntrainer_CUDA_Quantize, q8_1_edge_cases) {
+  */
+ TEST(nntrainer_CUDA_Quantize, q8_1_cuda_vs_host) {
+   const int64_t size = 1024;
+-  
++
+   // Generate random FP32 array
+   std::vector<float> input_host(size);
+   std::mt19937 gen(999);
+   std::uniform_real_distribution<float> dis(-10.0f, 10.0f);
+-  
++
+   for (int64_t i = 0; i < size; ++i) {
+     input_host[i] = dis(gen);
+   }
+-  
++
+   const int64_t num_blocks = size / QK8_1;
+-  
++
+   // Host quantization
+   std::vector<block_q8_1> quantized_host(num_blocks);
+   quantize_row_q8_1_host(input_host.data(), quantized_host.data(), size);
+-  
++
+   // CUDA quantization
+   float *d_input = nullptr;
+   block_q8_1 *d_quantized = nullptr;
+-  
++
+   CUDA_CHECK(cudaMalloc(&d_input, size * sizeof(float)));
+   CUDA_CHECK(cudaMalloc(&d_quantized, num_blocks * sizeof(block_q8_1)));
+-  
+-  CUDA_CHECK(cudaMemcpy(d_input, input_host.data(), size * sizeof(float), cudaMemcpyHostToDevice));
+-  
++
++  CUDA_CHECK(cudaMemcpy(d_input, input_host.data(), size * sizeof(float),
++                        cudaMemcpyHostToDevice));
++
+   cudaStream_t stream;
+   CUDA_CHECK(cudaStreamCreate(&stream));
+-  
++
+   quantize_row_q8_1_cuda(d_input, d_quantized, size, stream);
+-  
++
+   CUDA_CHECK(cudaStreamSynchronize(stream));
+-  
++
+   std::vector<block_q8_1> quantized_cuda(num_blocks);
+-  CUDA_CHECK(cudaMemcpy(quantized_cuda.data(), d_quantized, num_blocks * sizeof(block_q8_1), cudaMemcpyDeviceToHost));
+-  
++  CUDA_CHECK(cudaMemcpy(quantized_cuda.data(), d_quantized,
++                        num_blocks * sizeof(block_q8_1),
++                        cudaMemcpyDeviceToHost));
++
+   // Compare results
+   int mismatches = 0;
+   for (int64_t i = 0; i < num_blocks; ++i) {
+@@ -221,7 +231,7 @@ TEST(nntrainer_CUDA_Quantize, q8_1_cuda_vs_host) {
+         mismatches++;
+       }
+     }
+-    
++
+     // Compare scale factors (d) - allow small FP16 differences
+     uint16_t d_host = quantized_host[i].GGML_COMMON_AGGR_S.d;
+     uint16_t d_cuda = quantized_cuda[i].GGML_COMMON_AGGR_S.d;
+@@ -233,16 +243,18 @@ TEST(nntrainer_CUDA_Quantize, q8_1_cuda_vs_host) {
+       }
+     }
+   }
+-  
++
+   // Cleanup
+   CUDA_CHECK(cudaStreamDestroy(stream));
+   CUDA_CHECK(cudaFree(d_input));
+   CUDA_CHECK(cudaFree(d_quantized));
+-  
+-  // Expect very few or no mismatches (allowing for minor FP16 rounding differences)
++
++  // Expect very few or no mismatches (allowing for minor FP16 rounding
++  // differences)
+   EXPECT_LE(mismatches, num_blocks * QK8_1 * 0.01); // Allow up to 1% mismatch
+-  
+-  std::cout << "CUDA vs Host mismatches: " << mismatches << " out of " << (num_blocks * (QK8_1 + 1)) << std::endl;
++
++  std::cout << "CUDA vs Host mismatches: " << mismatches << " out of "
++            << (num_blocks * (QK8_1 + 1)) << std::endl;
+ }
+ 
+ /**
+@@ -251,38 +263,39 @@ TEST(nntrainer_CUDA_Quantize, q8_1_cuda_vs_host) {
+ TEST(nntrainer_CUDA_Quantize, q8_1_cuda_performance) {
+   const int64_t size = 3072 * 1024;
+   const int num_iterations = 10;
+-  
++
+   // Generate random FP32 array
+   std::vector<float> input_host(size);
+   std::mt19937 gen(12345);
+   std::uniform_real_distribution<float> dis(-10.0f, 10.0f);
+-  
++
+   for (int64_t i = 0; i < size; ++i) {
+     input_host[i] = dis(gen);
+   }
+-  
++
+   const int64_t num_blocks = size / QK8_1;
+-  
++
+   // Allocate device memory
+   float *d_input = nullptr;
+   block_q8_1 *d_quantized = nullptr;
+-  
++
+   CUDA_CHECK(cudaMalloc(&d_input, size * sizeof(float)));
+   CUDA_CHECK(cudaMalloc(&d_quantized, num_blocks * sizeof(block_q8_1)));
+-  
+-  CUDA_CHECK(cudaMemcpy(d_input, input_host.data(), size * sizeof(float), cudaMemcpyHostToDevice));
+-  
++
++  CUDA_CHECK(cudaMemcpy(d_input, input_host.data(), size * sizeof(float),
++                        cudaMemcpyHostToDevice));
++
+   cudaStream_t stream;
+   CUDA_CHECK(cudaStreamCreate(&stream));
+-  
++
+   // Create CUDA events for timing
+   cudaEvent_t start, stop;
+   CUDA_CHECK(cudaEventCreate(&start));
+   CUDA_CHECK(cudaEventCreate(&stop));
+-  
++
+   std::vector<float> elapsed_times;
+   elapsed_times.reserve(num_iterations - 1);
+-  
++
+   for (int iter = 0; iter < num_iterations; ++iter) {
+     if (iter == 0) {
+       // Warm-up iteration (not measured)
+@@ -291,49 +304,466 @@ TEST(nntrainer_CUDA_Quantize, q8_1_cuda_performance) {
+     } else {
+       // Measured iterations
+       CUDA_CHECK(cudaEventRecord(start, stream));
+-      
++
+       quantize_row_q8_1_cuda(d_input, d_quantized, size, stream);
+-      
++
+       CUDA_CHECK(cudaEventRecord(stop, stream));
+       CUDA_CHECK(cudaEventSynchronize(stop));
+-      
++
+       float elapsed_ms = 0.0f;
+       CUDA_CHECK(cudaEventElapsedTime(&elapsed_ms, start, stop));
+       elapsed_times.push_back(elapsed_ms);
+     }
+   }
+-  
++
+   // Cleanup
+   CUDA_CHECK(cudaEventDestroy(start));
+   CUDA_CHECK(cudaEventDestroy(stop));
+   CUDA_CHECK(cudaStreamDestroy(stream));
+   CUDA_CHECK(cudaFree(d_input));
+   CUDA_CHECK(cudaFree(d_quantized));
+-  
++
+   // Calculate statistics
+   float total_time = 0.0f;
+   float min_time = elapsed_times[0];
+   float max_time = elapsed_times[0];
+-  
++
+   for (float t : elapsed_times) {
+     total_time += t;
+     min_time = std::min(min_time, t);
+     max_time = std::max(max_time, t);
+   }
+-  
++
+   float avg_time = total_time / elapsed_times.size();
+-  
+-  std::cout << "CUDA Q8_1 Quantization Performance (size=" << size << "):" << std::endl;
++
++  std::cout << "CUDA Q8_1 Quantization Performance (size=" << size
++            << "):" << std::endl;
+   std::cout << "  Average time: " << avg_time << " ms" << std::endl;
+   std::cout << "  Min time:     " << min_time << " ms" << std::endl;
+   std::cout << "  Max time:     " << max_time << " ms" << std::endl;
+-  std::cout << "  Throughput:   " << (size * sizeof(float) / (avg_time * 1e6)) << " GB/s" << std::endl;
+-  
++  std::cout << "  Throughput:   " << (size * sizeof(float) / (avg_time * 1e6))
++            << " GB/s" << std::endl;
++
+   // Sanity check: time should be reasonable (not zero, not too large)
+   EXPECT_GT(avg_time, 0.0f);
+   EXPECT_LT(avg_time, 1000.0f); // Should complete in less than 1 second
+ }
+ 
++static void
++run_int4_quantize_input_test_cuda_(const unsigned int M, const unsigned int K,
++                                   const unsigned int quantization_group_size) {
++  // Generate random FP32 input
++  std::vector<float> input_host(M * K);
++  std::mt19937 gen(42);
++  std::uniform_real_distribution<float> dis(-2.0f, 2.0f);
++
++  for (unsigned int i = 0; i < M * K; ++i) {
++    input_host[i] = dis(gen);
++  }
++
++  // Convert to FP16 for GPU
++  std::vector<uint16_t> input_fp16(M * K);
++  for (unsigned int i = 0; i < M * K; ++i) {
++    input_fp16[i] = nntrainer::compute_fp32_to_fp16(input_host[i]);
++  }
++
++  const unsigned int align_k =
++    ((K + quantization_group_size - 1) / quantization_group_size) *
++    quantization_group_size;
++  const unsigned int groups_in_row = align_k / quantization_group_size;
++  const unsigned int total_groups = M * groups_in_row;
++
++  // CPU quantization
++  std::vector<int8_t> ref_quantized_input(M * K);
++  std::vector<uint16_t> ref_scales(total_groups * 2);
++  nntrainer::cpu_quantize_input_int4_pad(
++    input_host.data(), ref_quantized_input.data(), ref_scales.data(), M, K,
++    quantization_group_size);
++
++  // Allocate device memory
++  void *d_input = nullptr;
++  void *d_quantized_input = nullptr;
++  void *d_scales = nullptr;
++
++  CUDA_CHECK(cudaMalloc(&d_input, M * K * sizeof(float)));
++  CUDA_CHECK(cudaMalloc(&d_quantized_input, M * K * sizeof(int8_t)));
++  CUDA_CHECK(cudaMalloc(&d_scales, total_groups * 2 * sizeof(uint16_t)));
++
++  CUDA_CHECK(cudaMemcpy(d_input, input_host.data(), M * K * sizeof(float),
++                        cudaMemcpyHostToDevice));
++
++  cudaStream_t stream;
++  CUDA_CHECK(cudaStreamCreate(&stream));
++
++  // Create CUDA events for timing
++  cudaEvent_t start, stop;
++  CUDA_CHECK(cudaEventCreate(&start));
++  CUDA_CHECK(cudaEventCreate(&stop));
++
++  // CUDA quantization - 10 times to measure performance
++  std::vector<float> cuda_elapsed_times;
++  cuda_elapsed_times.reserve(9); // Exclude first iteration
++
++  for (int iter = 0; iter < 10; ++iter) {
++    if (iter == 0) {
++      // First iteration - no timing
++      quantize_input_int4_pad_cuda(d_input, d_quantized_input, d_scales, M, K,
++                                   quantization_group_size, stream);
++      CUDA_CHECK(cudaStreamSynchronize(stream));
++    } else {
++      // Measured iterations
++      CUDA_CHECK(cudaEventRecord(start, stream));
++
++      quantize_input_int4_pad_cuda(d_input, d_quantized_input, d_scales, M, K,
++                                   quantization_group_size, stream);
++
++      CUDA_CHECK(cudaEventRecord(stop, stream));
++      CUDA_CHECK(cudaEventSynchronize(stop));
++
++      float elapsed_ms = 0.0f;
++      CUDA_CHECK(cudaEventElapsedTime(&elapsed_ms, start, stop));
++      cuda_elapsed_times.push_back(elapsed_ms);
++
++      // Copy results back for verification
++      std::vector<int8_t> cuda_quantized_input_iter(M * K);
++      std::vector<uint16_t> cuda_scales_iter(total_groups * 2);
++
++      CUDA_CHECK(cudaMemcpy(cuda_quantized_input_iter.data(), d_quantized_input,
++                            M * K * sizeof(int8_t), cudaMemcpyDeviceToHost));
++      CUDA_CHECK(cudaMemcpy(cuda_scales_iter.data(), d_scales,
++                            total_groups * 2 * sizeof(uint16_t),
++                            cudaMemcpyDeviceToHost));
++
++      // Verify results for this iteration
++      int mismatch_count_iter = 0;
++      for (unsigned int i = 0; i < M * K; ++i) {
++        if (cuda_quantized_input_iter[i] != ref_quantized_input[i]) {
++          mismatch_count_iter++;
++        }
++      }
++
++      float mismatch_ratio_iter = (float)mismatch_count_iter / (M * K);
++      EXPECT_LE(mismatch_ratio_iter, 0.01f); // Allow up to 1% mismatch
++
++      // Compare scales (MSE) for this iteration
++      float mse_scales_iter = 0.0f;
++      for (unsigned int i = 0; i < total_groups; ++i) {
++        float cuda_scale =
++          nntrainer::compute_fp16_to_fp32(cuda_scales_iter[i * 2]);
++        float ref_scale = nntrainer::compute_fp16_to_fp32(ref_scales[i * 2]);
++        mse_scales_iter += (cuda_scale - ref_scale) * (cuda_scale - ref_scale);
++      }
++      mse_scales_iter /= total_groups;
++      EXPECT_LE(mse_scales_iter, 1e-5f);
++    }
++  }
++
++  // Calculate average CUDA time
++  float total_cuda_time = 0.0f;
++  for (float t : cuda_elapsed_times) {
++    total_cuda_time += t;
++  }
++  float avg_cuda_time = total_cuda_time / cuda_elapsed_times.size();
++
++  // Calculate throughput (GB/s)
++  float data_size_gb = (M * K * sizeof(float)) / (1024.0f * 1024.0f * 1024.0f);
++  float throughput = data_size_gb / (avg_cuda_time / 1000.0f); // GB/s
++
++  std::cout << "CUDA INT4 Quantization Average Time (M=" << M << ", K=" << K
++            << "): " << avg_cuda_time << " ms" << std::endl;
++  std::cout << "CUDA INT4 Quantization Throughput (M=" << M << ", K=" << K
++            << "): " << throughput << " GB/s" << std::endl;
++
++  // Copy final results back
++  std::vector<int8_t> cuda_quantized_input(M * K);
++  std::vector<uint16_t> cuda_scales(total_groups * 2);
++
++  CUDA_CHECK(cudaMemcpy(cuda_quantized_input.data(), d_quantized_input,
++                        M * K * sizeof(int8_t), cudaMemcpyDeviceToHost));
++  CUDA_CHECK(cudaMemcpy(cuda_scales.data(), d_scales,
++                        total_groups * 2 * sizeof(uint16_t),
++                        cudaMemcpyDeviceToHost));
++
++  // Compare quantized data
++  int mismatch_count = 0;
++  for (unsigned int i = 0; i < M * K; ++i) {
++    if (cuda_quantized_input[i] != ref_quantized_input[i]) {
++      mismatch_count++;
++    }
++  }
++
++  float mismatch_ratio = (float)mismatch_count / (M * K);
++  std::cout << "INT4 quantization mismatch count (" << M << "x" << K
++            << "): " << mismatch_count << " (" << mismatch_ratio * 100.0f
++            << "%)" << std::endl;
++
++  // Compare scales (MSE)
++  float mse_scales = 0.0f;
++  for (unsigned int i = 0; i < total_groups; ++i) {
++    float cuda_scale = nntrainer::compute_fp16_to_fp32(cuda_scales[i * 2]);
++    float ref_scale = nntrainer::compute_fp16_to_fp32(ref_scales[i * 2]);
++    mse_scales += (cuda_scale - ref_scale) * (cuda_scale - ref_scale);
++  }
++  mse_scales /= total_groups;
++  std::cout << "Scales MSE: " << mse_scales << std::endl;
++  // Cleanup
++  CUDA_CHECK(cudaStreamDestroy(stream));
++  CUDA_CHECK(cudaFree(d_input));
++  CUDA_CHECK(cudaFree(d_quantized_input));
++  CUDA_CHECK(cudaFree(d_scales));
++  CUDA_CHECK(cudaEventDestroy(start));
++  CUDA_CHECK(cudaEventDestroy(stop));
++
++  // Assertions
++  EXPECT_LE(mismatch_ratio, 0.01f); // Allow up to 1% mismatch
++  EXPECT_LE(mse_scales, 1e-5f);
++}
++
++#define DECLARE_int4_quantize_input_test_cuda_M_K_G(M, K, G)                   \
++  TEST(nntrainer_CUDA_Quantize, int4_quantize_input_test_##M##_##K##_##G) {    \
++    run_int4_quantize_input_test_cuda_(M, K, G);                               \
++  }
++
++DECLARE_int4_quantize_input_test_cuda_M_K_G(32, 3072, 32);
++DECLARE_int4_quantize_input_test_cuda_M_K_G(63, 3072, 32);
++DECLARE_int4_quantize_input_test_cuda_M_K_G(128, 3072, 32);
++DECLARE_int4_quantize_input_test_cuda_M_K_G(256, 3072, 32);
++DECLARE_int4_quantize_input_test_cuda_M_K_G(512, 3072, 32);
++DECLARE_int4_quantize_input_test_cuda_M_K_G(1024, 3072, 32);
++
++/**
++ * @brief Performance benchmark for CUDA INT4 quantization
++ */
++TEST(nntrainer_CUDA_Quantize, int4_quantize_input_pad_cuda_performance) {
++  const unsigned int M = 128;
++  const unsigned int K = 3072;
++  const unsigned int quantization_group_size = 32;
++  const int num_iterations = 10;
++
++  // Generate random FP32 input
++  std::vector<float> input_host(M * K);
++  std::mt19937 gen(12345);
++  std::uniform_real_distribution<float> dis(-2.0f, 2.0f);
++
++  for (unsigned int i = 0; i < M * K; ++i) {
++    input_host[i] = dis(gen);
++  }
++
++  // Convert to FP16 for GPU
++  std::vector<uint16_t> input_fp16(M * K);
++  for (unsigned int i = 0; i < M * K; ++i) {
++    input_fp16[i] = nntrainer::compute_fp32_to_fp16(input_host[i]);
++  }
++
++  const unsigned int align_k =
++    ((K + quantization_group_size - 1) / quantization_group_size) *
++    quantization_group_size;
++  const unsigned int groups_in_row = align_k / quantization_group_size;
++  const unsigned int total_groups = M * groups_in_row;
++
++  // Allocate device memory
++  void *d_input = nullptr;
++  void *d_quantized_input = nullptr;
++  void *d_scales = nullptr;
++
++  CUDA_CHECK(cudaMalloc(&d_input, M * K * sizeof(float)));
++  CUDA_CHECK(cudaMalloc(&d_quantized_input, M * K * sizeof(int8_t)));
++  CUDA_CHECK(cudaMalloc(&d_scales, total_groups * 2 * sizeof(uint16_t)));
++
++  CUDA_CHECK(cudaMemcpy(d_input, input_host.data(), M * K * sizeof(float),
++                        cudaMemcpyHostToDevice));
++
++  cudaStream_t stream;
++  CUDA_CHECK(cudaStreamCreate(&stream));
++
++  // Create CUDA events for timing
++  cudaEvent_t start, stop;
++  CUDA_CHECK(cudaEventCreate(&start));
++  CUDA_CHECK(cudaEventCreate(&stop));
++
++  std::vector<float> elapsed_times;
++  elapsed_times.reserve(num_iterations - 1);
++
++  for (int iter = 0; iter < num_iterations; ++iter) {
++    if (iter == 0) {
++      // Warm-up iteration (not measured)
++      quantize_input_int4_pad_cuda(d_input, d_quantized_input, d_scales, M, K,
++                                   quantization_group_size, stream);
++      CUDA_CHECK(cudaStreamSynchronize(stream));
++    } else {
++      // Measured iterations
++      CUDA_CHECK(cudaEventRecord(start, stream));
++
++      quantize_input_int4_pad_cuda(d_input, d_quantized_input, d_scales, M, K,
++                                   quantization_group_size, stream);
++
++      CUDA_CHECK(cudaEventRecord(stop, stream));
++      CUDA_CHECK(cudaEventSynchronize(stop));
++
++      float elapsed_ms = 0.0f;
++      CUDA_CHECK(cudaEventElapsedTime(&elapsed_ms, start, stop));
++      elapsed_times.push_back(elapsed_ms);
++    }
++  }
++
++  // Cleanup
++  CUDA_CHECK(cudaEventDestroy(start));
++  CUDA_CHECK(cudaEventDestroy(stop));
++  CUDA_CHECK(cudaStreamDestroy(stream));
++  CUDA_CHECK(cudaFree(d_input));
++  CUDA_CHECK(cudaFree(d_quantized_input));
++  CUDA_CHECK(cudaFree(d_scales));
++
++  // Calculate statistics
++  float total_time = 0.0f;
++  float min_time = elapsed_times[0];
++  float max_time = elapsed_times[0];
++
++  for (float t : elapsed_times) {
++    total_time += t;
++    min_time = std::min(min_time, t);
++    max_time = std::max(max_time, t);
++  }
++
++  float avg_time = total_time / elapsed_times.size();
++
++  std::cout << "CUDA INT4 Quantization Performance (M=" << M << ", K=" << K
++            << "):" << std::endl;
++  std::cout << "  Average time: " << avg_time << " ms" << std::endl;
++  std::cout << "  Min time:     " << min_time << " ms" << std::endl;
++  std::cout << "  Max time:     " << max_time << " ms" << std::endl;
++  std::cout << "  Throughput:   "
++            << (M * K * sizeof(uint16_t) / (avg_time * 1e6)) << " GB/s"
++            << std::endl;
++
++  // Sanity check
++  EXPECT_GT(avg_time, 0.0f);
++  EXPECT_LT(avg_time, 100.0f);
++}
++
++static void
++run_cuda_vs_openvino_quantize_test(const unsigned int M, const unsigned int K,
++                                   const unsigned int quantization_group_size) {
++#ifdef ENABLE_OPENCL
++  auto *blas_cc = static_cast<nntrainer::ClContext *>(
++    nntrainer::Engine::Global().getRegisteredContext("gpu"));
++
++  if (!blas_cc) {
++    GTEST_SKIP() << "OpenCL context not available";
++    return;
++  }
++
++  // Allocate OpenCL memory (SVM)
++  // Input is FP16 (uint16_t)
++  size_t input_size_bytes = M * K * sizeof(uint16_t);
++  uint16_t *input_cl = (uint16_t *)nntrainer::allocateSVM(input_size_bytes);
++
++  // Output is int8
++  size_t output_size_bytes = M * K * sizeof(int8_t);
++  int8_t *quantized_cl = (int8_t *)nntrainer::allocateSVM(output_size_bytes);
++
++  const unsigned int align_k =
++    ((K + quantization_group_size - 1) / quantization_group_size) *
++    quantization_group_size;
++  const unsigned int groups_in_row = align_k / quantization_group_size;
++  const unsigned int total_groups = M * groups_in_row;
++
++  size_t scales_size_bytes = total_groups * 2 * sizeof(uint16_t);
++  uint16_t *scales_cl = (uint16_t *)nntrainer::allocateSVM(scales_size_bytes);
++
++  // Generate random input (FP32)
++  std::vector<float> input_host(M * K);
++  std::mt19937 gen(42);
++  std::uniform_real_distribution<float> dis(-2.0f, 2.0f);
++  for (auto &v : input_host)
++    v = dis(gen);
++
++  // Convert to FP16 for OpenCL input
++  for (unsigned int i = 0; i < M * K; ++i) {
++    input_cl[i] = nntrainer::compute_fp32_to_fp16(input_host[i]);
++  }
++
++  // Run OpenCL quantization
++  nntrainer::openvino_quantize_input_int4_pad(input_cl, quantized_cl, scales_cl,
++                                              M, K, quantization_group_size);
++
++  // Run CUDA quantization
++  // Allocate CUDA memory
++  void *d_input = nullptr;
++  void *d_quantized = nullptr;
++  void *d_scales = nullptr;
++
++  CUDA_CHECK(cudaMalloc(&d_input, M * K * sizeof(float))); // Input is FP16
++  CUDA_CHECK(cudaMalloc(&d_quantized, output_size_bytes));
++  CUDA_CHECK(cudaMalloc(&d_scales, scales_size_bytes));
++
++  // Copy input to CUDA
++  CUDA_CHECK(cudaMemcpy(d_input, input_host.data(), M * K * sizeof(float),
++                        cudaMemcpyHostToDevice));
++
++  cudaStream_t stream;
++  CUDA_CHECK(cudaStreamCreate(&stream));
++
++  quantize_input_int4_pad_cuda(d_input, d_quantized, d_scales, M, K,
++                               quantization_group_size, stream);
++  CUDA_CHECK(cudaStreamSynchronize(stream));
++
++  // Copy results back
++  std::vector<int8_t> cuda_quantized(M * K);
++  std::vector<uint16_t> cuda_scales(total_groups * 2);
++
++  CUDA_CHECK(cudaMemcpy(cuda_quantized.data(), d_quantized, output_size_bytes,
++                        cudaMemcpyDeviceToHost));
++  CUDA_CHECK(cudaMemcpy(cuda_scales.data(), d_scales, scales_size_bytes,
++                        cudaMemcpyDeviceToHost));
++
++  // Compare
++  int mismatch_count = 0;
++  for (unsigned int i = 0; i < M * K; ++i) {
++    if (cuda_quantized[i] != quantized_cl[i]) {
++      mismatch_count++;
++    }
++  }
++
++  float mismatch_ratio = (float)mismatch_count / (M * K);
++  std::cout << "Mismatch count: " << mismatch_count << " ("
++            << mismatch_ratio * 100.0f << "%)" << std::endl;
++  EXPECT_LE(mismatch_ratio, 0.01f);
++
++  float mse_scales = 0.0f;
++  for (unsigned int i = 0; i < total_groups; ++i) {
++    float val = nntrainer::compute_fp16_to_fp32(cuda_scales[i * 2]);
++    float ref = nntrainer::compute_fp16_to_fp32(scales_cl[i * 2]);
++    mse_scales += (val - ref) * (val - ref);
++  }
++  mse_scales /= total_groups;
++  std::cout << "Scales MSE: " << mse_scales << std::endl;
++  EXPECT_LE(mse_scales, 1e-5f);
++
++  // Cleanup
++  CUDA_CHECK(cudaStreamDestroy(stream));
++  CUDA_CHECK(cudaFree(d_input));
++  CUDA_CHECK(cudaFree(d_quantized));
++  CUDA_CHECK(cudaFree(d_scales));
++
++  nntrainer::freeSVM(input_cl);
++  nntrainer::freeSVM(quantized_cl);
++  nntrainer::freeSVM(scales_cl);
++
++#else
++  GTEST_SKIP() << "OpenCL not enabled";
++#endif
++}
++
++#define DECLARE_CUDA_VS_OPENVINO_TEST(M, K, G)                                 \
++  TEST(nntrainer_CUDA_Quantize_OpenVINO_Ref, test_##M##_##K##_##G) {           \
++    run_cuda_vs_openvino_quantize_test(M, K, G);                               \
++  }
++
++DECLARE_CUDA_VS_OPENVINO_TEST(32, 3072, 32);
++DECLARE_CUDA_VS_OPENVINO_TEST(128, 3072, 32);
++DECLARE_CUDA_VS_OPENVINO_TEST(1024, 3072, 32);
++
+ GTEST_API_ int main(int argc, char **argv) {
+   int result = -1;
+ 
+@@ -352,4 +782,3 @@ GTEST_API_ int main(int argc, char **argv) {
+ 
+   return result;
+ }
+-
+diff --git a/test/unittest/unittest_quantize_cl.cpp b/test/unittest/unittest_quantize_cl.cpp
+index f495ed4e79..75952b7f6b 100644
+--- a/test/unittest/unittest_quantize_cl.cpp
++++ b/test/unittest/unittest_quantize_cl.cpp
+@@ -21,6 +21,7 @@
+ #include "swiglu_cl.h"
+ #include "tensor_dim.h"
+ #include "timer.h"
++#include "unittest_util.h"
+ #include <blas_kernel_interface.h>
+ #include <blas_kernels.h>
+ #include <cl_context.h>
+@@ -28,7 +29,6 @@
+ #include <fp16.h>
+ #include <layer_context.h>
+ #include <tensor.h>
+-#include "unittest_util.h"
+ 
+ #define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
+   EXPECT_GE((VAL), (MIN));                                                     \
+@@ -36,86 +36,6 @@
+ 
+ using namespace nntrainer;
+ 
+-// Helper for Round to Nearest Even (RTE)
+-
+-static int8_t round_half_to_even(float x) {
+-  float r = roundf(x);
+-  float d = r - x;
+-  if (fabsf(d) != 0.5f) {
+-    return (int8_t)r;
+-  }
+-  // If exactly halfway, round to even
+-  int ir = (int)r;
+-  return (int8_t)((ir % 2 == 0) ? ir : ir - (ir > 0 ? 1 : -1));
+-}
+-
+-// CPU version of openvino_quantize_input_int4_pad for reference in tests
+-static void cpu_openvino_quantize_input_int4_pad(float *input, int8_t *quantized_input, uint16_t *scales,
+-                                                 unsigned int M, unsigned int K, unsigned int quantization_group_size) {
+-  int alignK = (K + quantization_group_size - 1) / quantization_group_size * quantization_group_size;
+-  int groups_in_row = alignK / quantization_group_size;
+-  
+-  for (int group_id = 0; group_id < M * groups_in_row; ++group_id) {
+-    int row_id = group_id / groups_in_row;
+-    int group_id_in_row = group_id % groups_in_row;
+-    int input_offset = (row_id * K) + (group_id_in_row * quantization_group_size);
+-    int output_offset = group_id * quantization_group_size;
+-    int max_quantize_block = quantization_group_size / 4;
+-    int quantize_block;
+-    
+-    if (group_id_in_row == groups_in_row - 1) {
+-      quantize_block = (quantization_group_size - (alignK - K)) / 4;
+-    } else {
+-      quantize_block = quantization_group_size / 4;
+-    }
+-    
+-    // Find maximum absolute value in the block
+-    float max_value = 0.0f;
+-    for (int i = 0; i < quantize_block; ++i) {
+-      for (int j = 0; j < 4; ++j) {
+-        int idx = input_offset + (i * 4) + j;
+-        // Simulate half precision for input
+-        float val = idx < row_id * K + K ? compute_fp16_to_fp32(compute_fp32_to_fp16(input[idx])) : 0.0f;
+-        float abs_val = fabsf(val);
+-        max_value = fmaxf(max_value, abs_val);
+-      }
+-    }
+-    // Simulate half precision for max_value
+-    max_value = compute_fp16_to_fp32(compute_fp32_to_fp16(max_value));
+-    // Simulate half precision for epsilon 0.001h
+-    float epsilon = compute_fp16_to_fp32(compute_fp32_to_fp16(0.001f));
+-    max_value = fmaxf(max_value, epsilon);
+-    
+-    // Calculate quantization scale
+-    float quan_scale = max_value / 127.0f;
+-    
+-    // Quantize the data
+-    for (int i = 0; i < quantize_block; ++i) {
+-      for (int j = 0; j < 4; ++j) {
+-        int input_idx = input_offset + (i * 4) + j;
+-        int output_idx = output_offset + (i * 4) + j;
+-        // Simulate half precision for input
+-        float val = (input_idx < row_id * K + K) ? compute_fp16_to_fp32(compute_fp32_to_fp16(input[input_idx])) : 0.0f;
+-        float quantized_val = val / quan_scale;
+-        // Round to nearest even (RTE)
+-        int8_t rounded_val = round_half_to_even(quantized_val);
+-        quantized_input[output_idx] = rounded_val;
+-      }
+-    }
+-    
+-    // Pad with zeros if necessary
+-    for (int i = quantize_block * 4; i < max_quantize_block * 4; ++i) {
+-      int output_idx = output_offset + i;
+-      quantized_input[output_idx] = 0;
+-    }
+-    
+-    // Store the scale
+-    // Kernel writes to group_id * 2 (interleaved with activation sum)
+-    scales[group_id * 2] = compute_fp32_to_fp16(quan_scale);
+-    scales[group_id * 2 + 1] = 0; // Placeholder for activation sum
+-  }
+-}
+-
+ static void run_int4_quantize_input_test_(const uint32_t M, const uint32_t K,
+                                           const int scale_group_size) {
+   auto *blas_cc = static_cast<nntrainer::ClContext *>(
+@@ -142,7 +62,8 @@ static void run_int4_quantize_input_test_(const uint32_t M, const uint32_t K,
+   std::vector<int8_t> ref_quantized_input(M * K);
+   // Ref scales size is doubled
+   std::vector<uint16_t> ref_scales(M * K / scale_group_size * 2);
+-  cpu_openvino_quantize_input_int4_pad(input.data(), ref_quantized_input.data(), ref_scales.data(), M, K, scale_group_size);
++  cpu_quantize_input_int4_pad(input.data(), ref_quantized_input.data(),
++                              ref_scales.data(), M, K, scale_group_size);
+ 
+   // GPU INT4 input quantization
+   auto t3 = std::chrono::high_resolution_clock::now();
+@@ -153,8 +74,7 @@ static void run_int4_quantize_input_test_(const uint32_t M, const uint32_t K,
+   auto gpu_dt = std::chrono::duration_cast<std::chrono::milliseconds>(t4 - t3);
+ 
+   std::cout << "INT4 input quantization : " << M << " x " << K << std::endl;
+-  std::cout << " - time : GPU = " << gpu_dt.count()
+-            << " ms" << std::endl;
++  std::cout << " - time : GPU = " << gpu_dt.count() << " ms" << std::endl;
+ 
+   // Compare results
+   bool quantized_data_match = true;
+@@ -166,12 +86,13 @@ static void run_int4_quantize_input_test_(const uint32_t M, const uint32_t K,
+       mismatch_count++;
+     }
+   }
+-  
++
+   float mismatch_ratio = (float)mismatch_count / (M * K / 2);
+   if (mismatch_ratio > 0.01f) {
+     quantized_data_match = false;
+   }
+-  std::cout << " - quantized data mismatch count: " << mismatch_count << " (" << mismatch_ratio * 100.0f << "%)" << std::endl;
++  std::cout << " - quantized data mismatch count: " << mismatch_count << " ("
++            << mismatch_ratio * 100.0f << "%)" << std::endl;
+ 
+   float mse_scales = 0.0f;
+   for (unsigned int i = 0; i < M * K / scale_group_size; ++i) {
+@@ -180,7 +101,7 @@ static void run_int4_quantize_input_test_(const uint32_t M, const uint32_t K,
+     mse_scales += (val - ref) * (val - ref);
+   }
+   mse_scales /= (M * K / scale_group_size);
+-  
++
+   if (mse_scales > 1e-5f) {
+     scales_match = false;
+   }
+@@ -189,8 +110,10 @@ static void run_int4_quantize_input_test_(const uint32_t M, const uint32_t K,
+   EXPECT_TRUE(quantized_data_match);
+   EXPECT_TRUE(scales_match);
+ 
+-  std::cout << " - quantized data match: " << (quantized_data_match ? "YES" : "NO") << std::endl;
+-  std::cout << " - scales match: " << (scales_match ? "YES" : "NO") << std::endl;
++  std::cout << " - quantized data match: "
++            << (quantized_data_match ? "YES" : "NO") << std::endl;
++  std::cout << " - scales match: " << (scales_match ? "YES" : "NO")
++            << std::endl;
+ 
+   freeSVM(input_ptr);
+   freeSVM(quantized_input_ptr);
+@@ -203,6 +126,7 @@ static void run_int4_quantize_input_test_(const uint32_t M, const uint32_t K,
+   }
+ 
+ DECLARE_int4_quantize_input_test_M_K_G(32, 3072, 32);
++DECLARE_int4_quantize_input_test_M_K_G(63, 3072, 32);
+ DECLARE_int4_quantize_input_test_M_K_G(128, 3072, 32);
+ DECLARE_int4_quantize_input_test_M_K_G(256, 3072, 32);
+ DECLARE_int4_quantize_input_test_M_K_G(512, 3072, 32);
+diff --git a/test/unittest/unittest_util.cpp b/test/unittest/unittest_util.cpp
+index 70a9822eb7..a72ec85c09 100644
+--- a/test/unittest/unittest_util.cpp
++++ b/test/unittest/unittest_util.cpp
+@@ -1,11 +1,13 @@
+ #include "unittest_util.h"
+ #include <cl_context.h>
+ #include <engine.h>
++#include <fp16.h>
+ 
+ namespace nntrainer {
+ 
+ void *allocateSVM(size_t size_bytes) {
+-  auto *blas_cc = static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
++  auto *blas_cc =
++    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+   void *ptr = blas_cc->context_inst_.createSVMRegion(size_bytes);
+   if (!ptr) {
+     throw std::runtime_error("Failed to allocate SVM for unit test.");
+@@ -14,8 +16,88 @@ void *allocateSVM(size_t size_bytes) {
+ }
+ 
+ void freeSVM(void *ptr) {
+-  auto *blas_cc = static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
++  auto *blas_cc =
++    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+   blas_cc->context_inst_.releaseSVMRegion(ptr);
+ }
+ 
++int8_t round_half_to_even(float x) {
++  float r = roundf(x);
++  float d = r - x;
++  if (fabsf(d) != 0.5f) {
++    return (int8_t)r;
++  }
++  // If exactly halfway, round to even
++  int ir = (int)r;
++  return (int8_t)((ir % 2 == 0) ? ir : ir - (ir > 0 ? 1 : -1));
++}
++
++void cpu_quantize_input_int4_pad(float *input, int8_t *quantized_input,
++                                 uint16_t *scales, unsigned int M,
++                                 unsigned int K,
++                                 unsigned int quantization_group_size) {
++  int alignK = (K + quantization_group_size - 1) / quantization_group_size *
++               quantization_group_size;
++  int groups_in_row = alignK / quantization_group_size;
++
++  for (int group_id = 0; group_id < M * groups_in_row; ++group_id) {
++    int row_id = group_id / groups_in_row;
++    int group_id_in_row = group_id % groups_in_row;
++    int input_offset =
++      (row_id * K) + (group_id_in_row * quantization_group_size);
++    int output_offset = group_id * quantization_group_size;
++    int max_quantize_block = quantization_group_size;
++    int quantize_block;
++
++    if (group_id_in_row == groups_in_row - 1) {
++      quantize_block = quantization_group_size - (alignK - K);
++    } else {
++      quantize_block = quantization_group_size;
++    }
++
++    // Find maximum absolute value in the block
++    float max_value = 0.0f;
++    for (int i = 0; i < quantize_block; ++i) {
++      int idx = input_offset + i;
++      // Simulate half precision for input
++      float val = idx < row_id * K + K
++                    ? compute_fp16_to_fp32(compute_fp32_to_fp16(input[idx]))
++                    : 0.0f;
++      float abs_val = fabsf(val);
++      max_value = fmaxf(max_value, abs_val);
++    }
++    float epsilon = 0.001f;
++    max_value = fmaxf(max_value, epsilon);
++
++    // Calculate quantization scale
++    float quan_scale = max_value / 127.0f;
++
++    // Quantize the data
++    for (int i = 0; i < quantize_block; ++i) {
++      int input_idx = input_offset + i;
++      int output_idx = output_offset + i;
++      // Simulate half precision for input
++      float val =
++        (input_idx < row_id * K + K)
++          ? compute_fp16_to_fp32(compute_fp32_to_fp16(input[input_idx]))
++          : 0.0f;
++      float quantized_val = val / quan_scale;
++      // Round to nearest even (RTE)
++      int8_t rounded_val = round_half_to_even(quantized_val);
++      quantized_input[output_idx] = rounded_val;
++    }
++
++    // Pad with zeros if necessary
++    for (int i = quantize_block; i < max_quantize_block; ++i) {
++      int output_idx = output_offset + i;
++      quantized_input[output_idx] = 0;
++    }
++
++    // Store the scale
++    // Kernel writes to group_id * 2 (interleaved with activation sum)
++    scales[group_id * 2] = compute_fp32_to_fp16(quan_scale);
++    scales[group_id * 2 + 1] = 0; // Placeholder for activation sum
++  }
++}
++
+ } // namespace nntrainer
+diff --git a/test/unittest/unittest_util.h b/test/unittest/unittest_util.h
+index 9f4dd5f327..0b9a4319ca 100644
+--- a/test/unittest/unittest_util.h
++++ b/test/unittest/unittest_util.h
+@@ -7,9 +7,9 @@
+ #ifndef NNTRAINER_UNITTEST_UTIL_H
+ #define NNTRAINER_UNITTEST_UTIL_H
+ 
+-#include <vector>
+ #include <cstddef>
+ #include <random>
++#include <vector>
+ 
+ namespace nntrainer {
+ 
+@@ -37,6 +37,15 @@ void *allocateSVM(size_t size_bytes);
+ // Release SVM memory.
+ void freeSVM(void *ptr);
+ 
++// Helper for Round to Nearest Even (RTE)
++int8_t round_half_to_even(float x);
++
++// CPU reference implementation for INT4 quantization
++void cpu_quantize_input_int4_pad(float *input, int8_t *quantized_input,
++                                 uint16_t *scales, unsigned int M,
++                                 unsigned int K,
++                                 unsigned int quantization_group_size);
++
+ } // namespace nntrainer
+ 
+ #endif // NNTRAINER_UNITTEST_UTIL_H
+
+From 669d89f88baf07b52fc5955a4874f172e547501c Mon Sep 17 00:00:00 2001
+From: Daekyoung Jung <dk11.jung@samsung.com>
+Date: Thu, 4 Dec 2025 11:01:00 +0900
+Subject: [PATCH 8/9] Implement int4 GEMM operations for CPU and CUDA
+
+- Add CPU implementation of int4 GEMM with packed block optimization
+- Add CUDA implementation of int4 GEMM operation
+- Add unit tests for int4 GEMM operations
+- Update quantize related files to support int4 operations
+- Fix function name from int4 to int8 in quantize functions
+- Add utility functions for matrix operations and vector generation
+
+Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>
+---
+ .../tensor/cuda_operations/gemm_int4_cpu.cpp  | 175 ++++++++
+ .../tensor/cuda_operations/gemm_int4_cpu.h    |  59 +++
+ .../tensor/cuda_operations/gemm_int4_cuda.cu  | 364 ++++++++++++++-
+ .../tensor/cuda_operations/gemm_int4_cuda.h   |  45 +-
+ .../cuda_operations/ggml_quantize_cuda.cu     |   2 +-
+ .../cuda_operations/ggml_quantize_cuda.h      |   2 +-
+ nntrainer/tensor/cuda_operations/meson.build  |   7 +-
+ nntrainer/utils/util_func.h                   |  12 +
+ test/unittest/unittest_blas_kernels_cl.cpp    |  99 +---
+ test/unittest/unittest_cpu_gemm_int4.cpp      | 425 ++++++++++++++++++
+ test/unittest/unittest_cuda_gemm_int4.cpp     | 368 +++++++++++++++
+ test/unittest/unittest_cuda_gemm_q40.cpp      | 283 ++++++++++++
+ test/unittest/unittest_cuda_quantize.cpp      |  14 +-
+ test/unittest/unittest_gemm_nomacro_cl.cpp    | 286 ++++++++++++
+ test/unittest/unittest_quantize_cl.cpp        |   2 +-
+ test/unittest/unittest_util.cpp               |  80 +++-
+ test/unittest/unittest_util.h                 |  35 +-
+ 17 files changed, 2110 insertions(+), 148 deletions(-)
+ create mode 100644 nntrainer/tensor/cuda_operations/gemm_int4_cpu.cpp
+ create mode 100644 nntrainer/tensor/cuda_operations/gemm_int4_cpu.h
+ create mode 100644 test/unittest/unittest_cpu_gemm_int4.cpp
+ create mode 100644 test/unittest/unittest_cuda_gemm_int4.cpp
+ create mode 100644 test/unittest/unittest_cuda_gemm_q40.cpp
+ create mode 100644 test/unittest/unittest_gemm_nomacro_cl.cpp
+
+diff --git a/nntrainer/tensor/cuda_operations/gemm_int4_cpu.cpp b/nntrainer/tensor/cuda_operations/gemm_int4_cpu.cpp
+new file mode 100644
+index 0000000000..1bb2f6fdbb
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/gemm_int4_cpu.cpp
+@@ -0,0 +1,175 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file   gemm_int4_cpu.cpp
++ * @brief  CPU implementation of int4 GEMM operation
++ * @author Samsung Electronics Co., Ltd.
++ * @bug    No known bugs except for NYI items
++ *
++ */
++
++#include "gemm_int4_cpu.h"
++#include "fp16.h"
++#include "int4_utils.h"
++#include <cmath>
++#include <iostream>
++#include <vector>
++
++namespace nntrainer {
++
++void gemm_int4_cpu(const void *input, const void *weights, const void *scales,
++                   const void *input_scales, float *output, unsigned int M,
++                   unsigned int N, unsigned int K,
++                   unsigned int quantization_group_size) {
++
++  const int8_t *q_input = static_cast<const int8_t *>(input);
++  const uint8_t *q_weights = static_cast<const uint8_t *>(weights);
++  const uint16_t *w_scales = static_cast<const uint16_t *>(scales);
++  const uint16_t *in_scales = static_cast<const uint16_t *>(input_scales);
++
++  // Buffer to hold one dequantized row of weights (size K)
++  // Since weights are packed as N rows x K columns (passed to quantize),
++  // the n-th row of weights corresponds to the n-th column of the GEMM matrix
++  // B.
++  std::vector<float> dequantized_weight_row(K);
++
++  // Input quantization layout parameters
++  // Matches cpu_quantize_input_int8_pad logic
++  unsigned int alignK = (K + quantization_group_size - 1) /
++                        quantization_group_size * quantization_group_size;
++  unsigned int groups_in_row = alignK / quantization_group_size;
++
++  // Iterate over columns of output (N)
++  for (unsigned int n = 0; n < N; ++n) {
++    // 1. Dequantize the n-th row of weights (which is n-th col of B)
++    Int4Utils::dequantizePackedRow(
++      const_cast<uint8_t *>(q_weights), const_cast<uint16_t *>(w_scales), N, K,
++      quantization_group_size, n, dequantized_weight_row.data());
++
++    // 2. Compute dot product with each row of input (M)
++    for (unsigned int m = 0; m < M; ++m) {
++      float sum = 0.0f;
++
++      for (unsigned int k = 0; k < K; ++k) {
++        // Calculate index for quantized input
++        unsigned int group_id_in_row = k / quantization_group_size;
++        unsigned int global_group_id = m * groups_in_row + group_id_in_row;
++        unsigned int offset_in_group = k % quantization_group_size;
++
++        // Input is stored block-wise: group_id * group_size + offset
++        unsigned int input_idx =
++          global_group_id * quantization_group_size + offset_in_group;
++
++        int8_t q_val = q_input[input_idx];
++
++        // Get input scale
++        // scales[group_id * 2] = scale, scales[group_id * 2 + 1] =
++        // offset/unused
++        float in_scale = compute_fp16_to_fp32(in_scales[global_group_id * 2]);
++
++        float in_val = static_cast<float>(q_val) * in_scale;
++        float w_val = dequantized_weight_row[k];
++
++        sum += in_val * w_val;
++      }
++
++      output[m * N + n] = sum;
++    }
++  }
++}
++
++void gemm_int4_cpu_packed_block(const void *input, const void *weights,
++                                const void *scales, const void *input_scales,
++                                float *output, unsigned int M, unsigned int N,
++                                unsigned int K,
++                                unsigned int quantization_group_size) {
++  const int8_t *q_input = static_cast<const int8_t *>(input);
++  const uint8_t *q_weights = static_cast<const uint8_t *>(weights);
++  const uint16_t *w_scales = static_cast<const uint16_t *>(scales);
++  const uint16_t *in_scales = static_cast<const uint16_t *>(input_scales);
++
++  // Initialize output to 0
++  for (unsigned int i = 0; i < M * N; ++i) {
++    output[i] = 0.0f;
++  }
++
++  // Input quantization layout parameters
++  unsigned int alignK = (K + quantization_group_size - 1) /
++                        quantization_group_size * quantization_group_size;
++  unsigned int groups_in_row = alignK / quantization_group_size;
++
++  // Outer loop: Height / 32 (N direction)
++  // Blocks of 32 rows (output channels)
++  for (unsigned int n_blk = 0; n_blk < N / 32; ++n_blk) {
++    unsigned int n_start = n_blk * 32;
++
++    // Inner loop: Width / 2 (K direction)
++    // Blocks of 2 columns (input channels)
++    for (unsigned int k_blk = 0; k_blk < K / 2; ++k_blk) {
++      unsigned int k_start = k_blk * 2;
++
++      // Pointer to the 32-byte block of weights
++      // Block index = n_blk * (K / 2) + k_blk
++      // Each block is 32 bytes
++      const uint8_t *w_block = q_weights + (n_blk * (K / 2) + k_blk) * 32;
++
++      // Process for all M rows of input
++      for (unsigned int m = 0; m < M; ++m) {
++        // Load input values and scale
++        // k_start and k_start+1 are in the same group (assuming group_size >=
++        // 2)
++        unsigned int group_id_in_row = k_start / quantization_group_size;
++        unsigned int global_group_id = m * groups_in_row + group_id_in_row;
++
++        // Input scale
++        float i_scale = compute_fp16_to_fp32(in_scales[global_group_id * 2]);
++
++        // Input indices
++        // Note: input is quantized with padding, so we use block addressing
++        unsigned int offset_in_group = k_start % quantization_group_size;
++        unsigned int input_idx =
++          global_group_id * quantization_group_size + offset_in_group;
++
++        float val0 = static_cast<float>(q_input[input_idx]) * i_scale;
++        float val1 = static_cast<float>(q_input[input_idx + 1]) * i_scale;
++
++        // Iterate over the 32 rows in the weight block
++        for (unsigned int i = 0; i < 32; ++i) {
++          unsigned int n = n_start + i;
++          uint8_t w_byte = w_block[i];
++
++          // Decode weights (2 per byte)
++          // Low nibble is first weight (k_start), High nibble is second weight
++          // (k_start+1)
++          int8_t w0_int4 = (w_byte & 0x0F);
++          int8_t w1_int4 = (w_byte >> 4);
++
++          // Sign extension
++          if (w0_int4 >= 8)
++            w0_int4 -= 16;
++          if (w1_int4 >= 8)
++            w1_int4 -= 16;
++
++          // Get weight scale
++          // Scale depends on N (row) and K group
++          unsigned int w_group_id = k_start / quantization_group_size;
++          // Scales are stored as N x (K / group_size)
++          // But wait, K passed to quantizeAndRepack was actually K (columns
++          // count). So scales are N rows x (K/group_size) cols. Index = n * (K
++          // / group_size) + w_group_id
++          unsigned int scale_idx =
++            n * (K / quantization_group_size) + w_group_id;
++          float w_scale = compute_fp16_to_fp32(w_scales[scale_idx]);
++
++          float w0 = static_cast<float>(w0_int4) * w_scale;
++          float w1 = static_cast<float>(w1_int4) * w_scale;
++
++          output[m * N + n] += val0 * w0 + val1 * w1;
++        }
++      }
++    }
++  }
++}
++
++} // namespace nntrainer
+diff --git a/nntrainer/tensor/cuda_operations/gemm_int4_cpu.h b/nntrainer/tensor/cuda_operations/gemm_int4_cpu.h
+new file mode 100644
+index 0000000000..f32434836d
+--- /dev/null
++++ b/nntrainer/tensor/cuda_operations/gemm_int4_cpu.h
+@@ -0,0 +1,59 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file   gemm_int4_cpu.h
++ * @brief  CPU implementation of int4 GEMM operation
++ * @author Samsung Electronics Co., Ltd.
++ * @bug    No known bugs except for NYI items
++ *
++ */
++
++#ifndef __GEMM_INT4_CPU_H__
++#define __GEMM_INT4_CPU_H__
++
++#include <cstdint>
++
++namespace nntrainer {
++
++/**
++ * @brief CPU implementation of int4 GEMM operation
++ *
++ * @param input Quantized input data pointer (int8_t*)
++ * @param weights Quantized weight data pointer (packed int4)
++ * @param scales Weight scale data pointer (fp16)
++ * @param input_scales Input scale data pointer (fp16)
++ * @param output Output data pointer (float*)
++ * @param M Number of rows in the matrix
++ * @param N Number of columns in the matrix
++ * @param K Inner dimension of the matrix multiplication
++ * @param quantization_group_size Quantization group size
++ */
++void gemm_int4_cpu(const void *input, const void *weights, const void *scales,
++                   const void *input_scales, float *output, unsigned int M,
++                   unsigned int N, unsigned int K,
++                   unsigned int quantization_group_size);
++
++/**
++ * @brief Optimized CPU implementation of int4 GEMM operation using packed
++ * blocks
++ *
++ * @param input Quantized input data pointer (int8_t*)
++ * @param weights Quantized weight data pointer (packed int4)
++ * @param scales Weight scale data pointer (fp16)
++ * @param input_scales Input scale data pointer (fp16)
++ * @param output Output data pointer (float*)
++ * @param M Number of rows in the matrix
++ * @param N Number of columns in the matrix
++ * @param K Inner dimension of the matrix multiplication
++ * @param quantization_group_size Quantization group size
++ */
++void gemm_int4_cpu_packed_block(const void *input, const void *weights,
++                                const void *scales, const void *input_scales,
++                                float *output, unsigned int M, unsigned int N,
++                                unsigned int K,
++                                unsigned int quantization_group_size);
++
++} // namespace nntrainer
++
++#endif // __GEMM_INT4_CPU_H__
+diff --git a/nntrainer/tensor/cuda_operations/gemm_int4_cuda.cu b/nntrainer/tensor/cuda_operations/gemm_int4_cuda.cu
+index 9058d0f82f..5fc116e0bc 100644
+--- a/nntrainer/tensor/cuda_operations/gemm_int4_cuda.cu
++++ b/nntrainer/tensor/cuda_operations/gemm_int4_cuda.cu
+@@ -1,26 +1,350 @@
+-// SPDX-License-Identifier: Apache-2.0
+-/**
+- * Copyright (C) 2024 Samsung Electronics Co., Ltd. All Rights Reserved.
+- *
+- * @file	gemm_int4_cuda.cu
+- * @date	28 Nov 2025
+- * @brief	CUDA implementation of int4 GEMM operation
+- * @see		https://github.com/nnstreamer/nntrainer
+- * @author	[Your Name] <[your.email@samsung.com]>
+- * @bug		No known bugs except for NYI items
+- *
+- */
++#include <cuda_fp16.h>
++#include <cuda_runtime.h>
++#include <iostream>
+ 
+ #include "gemm_int4_cuda.h"
+-#include <cuda_runtime.h>
+-#include <cuda_fp16.h>
++#include "ggml_quantize_cuda.h"
++
++// Helper for ceil division
++#define CEIL_DIV(a, b) (((a) + (b) - 1) / (b))
++#define ALIGN(a, b) (CEIL_DIV(a, b) * (b))
++
++__global__ void gemm_int4_kernel_packed_block(
++  const int8_t *input, const uint8_t *weights, const __half *scales,
++  const __half *input_scales, float *output, unsigned int M, unsigned int N,
++  unsigned int K, unsigned int quantization_group_size) {
++  // Block dimensions: 32x32
++  // Grid dimensions: (N+31)/32, (M+31)/32
++
++  unsigned int tx = threadIdx.x; // 0..31 (N direction within block)
++  unsigned int ty = threadIdx.y; // 0..31 (M direction within block)
++
++  unsigned int bx = blockIdx.x;
++  unsigned int by = blockIdx.y;
++
++  unsigned int row = by * 32 + ty; // Global row index (M)
++  unsigned int col = bx * 32 + tx; // Global col index (N)
++
++  // Shared memory
++  // Input block: 32x32 int8_t
++  __shared__ int8_t s_input[32][32];
++
++  // Weight block: 32x32 int8_t (unpacked)
++  // [N][K] layout to allow contiguous access along K
++  __shared__ int8_t s_weights[32][32];
++
++  float sum = 0.0f;
++
++  // Loop over K in chunks of 32
++  for (unsigned int k_chunk = 0; k_chunk < (K + 31) / 32; ++k_chunk) {
++    unsigned int k_start = k_chunk * 32;
++
++    // 1. Load Input to Shared Memory
++    if (row < M && (k_start + tx) < K) {
++      // Input is stored as [M, K] (quantized)
++      // We assume row-major linear layout for input_quantized
++      // We need alignK for correct indexing if padding was used
++      unsigned int alignK = (K + quantization_group_size - 1) /
++                            quantization_group_size * quantization_group_size;
++      unsigned int groups_in_row = alignK / quantization_group_size;
++
++      unsigned int current_k = k_start + tx;
++      unsigned int group_id_in_row = current_k / quantization_group_size;
++      unsigned int global_group_id = row * groups_in_row + group_id_in_row;
++      unsigned int offset_in_group = current_k % quantization_group_size;
++
++      unsigned int input_idx =
++        global_group_id * quantization_group_size + offset_in_group;
++
++      s_input[ty][tx] = input[input_idx];
++    } else {
++      s_input[ty][tx] = 0;
++    }
++
++    // 2. Load Weights to Shared Memory and Unpack
++    // Each thread loads one int8 weight
++    // tid covers 0..1023, mapping to 32x32 s_weights
++    // n = tx, k = ty
++    unsigned int n = tx;
++    unsigned int k = ty; // 0..31 relative to k_start
++
++    unsigned int global_n = bx * 32 + n;
++    unsigned int global_k = k_start + k;
++
++    if (global_n < N && global_k < K) {
++      unsigned int k_pair = k / 2;
++      unsigned int k_parity = k % 2;
+ 
+-namespace nntrainer {
++      // Address calculation
++      // Block index: n_blk * (K/2) + k_blk
++      // n_blk = bx
++      // k_blk = global_k / 2
++      unsigned int block_idx = bx * (K / 2) + (global_k / 2);
++      unsigned int byte_offset = n; // n is offset within 32-byte block
+ 
+-void gemm_int4_cuda(void *input, void *weights, void *scales, void *output,
+-                    unsigned int M, unsigned int N, unsigned int K,
+-                    unsigned int quantization_group_size) {
+-  // todo:
++      unsigned int weight_idx = block_idx * 32 + byte_offset;
++      uint8_t packed_w = weights[weight_idx];
++
++      int8_t w_val = k_parity == 0 ? packed_w & 0x0F : packed_w >> 4;
++
++      if (w_val >= 8)
++        w_val -= 16;
++      s_weights[n][k] = w_val;
++    }
++
++    __syncthreads();
++
++    // 3. Compute
++    int chunk_acc[8] = {0};
++
++#pragma unroll
++    for (int i = 0; i < 8; ++i) {
++      int input_packed = *reinterpret_cast<int *>(&s_input[ty][i * 4]);
++      int weight_packed = *reinterpret_cast<int *>(&s_weights[tx][i * 4]);
++      chunk_acc[i] = __dp4a(input_packed, weight_packed, chunk_acc[i]);
++    }
++
++    int total_acc = 0;
++#pragma unroll
++    for (int i = 0; i < 8; ++i) {
++      total_acc += chunk_acc[i];
++    }
++
++    // Apply scales
++    // Input scale
++    unsigned int alignK = (K + quantization_group_size - 1) /
++                          quantization_group_size * quantization_group_size;
++    unsigned int groups_in_row = alignK / quantization_group_size;
++    unsigned int group_id_in_row = k_start / quantization_group_size;
++    unsigned int global_group_id = row * groups_in_row + group_id_in_row;
++    float i_scale = __half2float(input_scales[global_group_id * 2]);
++
++    // Weight scale
++    unsigned int scale_idx =
++      col * (K / quantization_group_size) + group_id_in_row;
++    float w_scale = __half2float(scales[scale_idx]);
++
++    sum += total_acc * i_scale * w_scale;
++
++    __syncthreads();
++  }
++
++  if (row < M && col < N) {
++    output[row * N + col] = sum;
++  }
++}
++
++void gemm_int4_cuda_packed_block(const void *input, const void *weights,
++                                 const void *scales, const void *input_scales,
++                                 float *output, unsigned int M, unsigned int N,
++                                 unsigned int K,
++                                 unsigned int quantization_group_size) {
++
++  // Launch Kernel
++  dim3 blockDim(32, 32);
++  dim3 gridDim((N + 31) / 32, (M + 31) / 32);
++
++  gemm_int4_kernel_packed_block<<<gridDim, blockDim>>>(
++    static_cast<const int8_t *>(input), static_cast<const uint8_t *>(weights),
++    static_cast<const __half *>(scales),
++    static_cast<const __half *>(input_scales), output, M, N, K,
++    quantization_group_size);
+ }
+ 
+-} // namespace nntrainer
++__global__ void gemm_int4_kernel_packed_block_16(
++  const int8_t *input, const uint8_t *weights, const __half *scales,
++  const __half *input_scales, float *output, unsigned int M, unsigned int N,
++  unsigned int K, unsigned int quantization_group_size) {
++  // Block dimensions: 16x16 threads
++  // Grid dimensions: (N+31)/32, (M+31)/32
++  // Each block computes 32x32 output tile, each thread computes 4 outputs (2x2)
++
++  unsigned int tx = threadIdx.x;   // 0..15
++  unsigned int ty = threadIdx.y;   // 0..15
++  unsigned int tid = ty * 16 + tx; // 0..255
++
++  unsigned int bx = blockIdx.x;
++  unsigned int by = blockIdx.y;
++
++  unsigned int row_start = by * 32; // Global row start
++  unsigned int col_start = bx * 32; // Global col start
++
++  // Shared memory: 32x32 blocks
++  __shared__ int8_t s_input[32][32];
++  __shared__ int8_t s_weights[32][32];
++
++  // Accumulators for 4 outputs: [ty][tx], [ty][tx+16], [ty+16][tx],
++  // [ty+16][tx+16]
++  float sum[4] = {0.0f};
++
++  // Loop over K in chunks of 32
++  for (unsigned int k_chunk = 0; k_chunk < (K + 31) / 32; ++k_chunk) {
++    unsigned int k_start = k_chunk * 32;
++
++    // 1. Load Input to Shared Memory (32x32)
++    // 256 threads load 1024 elements, each thread loads 4 elements
++    {
++      unsigned int r = tid / 8;            // 0..31
++      unsigned int c_base = (tid % 8) * 4; // 0, 4, 8, ..., 28
++
++      unsigned int global_r = row_start + r;
++
++#pragma unroll
++      for (int i = 0; i < 4; ++i) {
++        unsigned int c = c_base + i;
++        unsigned int global_c = k_start + c;
++
++        if (global_r < M && global_c < K) {
++          unsigned int alignK = (K + quantization_group_size - 1) /
++                                quantization_group_size *
++                                quantization_group_size;
++          unsigned int groups_in_row = alignK / quantization_group_size;
++          unsigned int group_id = global_c / quantization_group_size;
++          unsigned int offset = global_c % quantization_group_size;
++          unsigned int global_group = global_r * groups_in_row + group_id;
++          unsigned int idx = global_group * quantization_group_size + offset;
++
++          s_input[r][c] = input[idx];
++        } else {
++          s_input[r][c] = 0;
++        }
++      }
++    }
++
++    // 2. Load Weights to Shared Memory and Unpack (32x32)
++    // 256 threads load 1024 elements, each thread loads 4 weights
++    {
++      unsigned int r = tid / 8;            // 0..31 (N within block)
++      unsigned int c_base = (tid % 8) * 4; // 0, 4, 8, ..., 28 (K within block)
++
++      unsigned int global_n = col_start + r; // Global N
++
++// Load 4 weights for this thread
++#pragma unroll
++      for (int i = 0; i < 4; ++i) {
++        unsigned int c = c_base + i;
++        unsigned int global_k = k_start + c;
++
++        int8_t w_val = 0;
++
++        if (global_n < N && global_k < K) {
++          // Use block-based packed layout matching
++          // gemm_int4_kernel_packed_block
++          unsigned int k_parity = global_k % 2;
++
++          // Block index: n_blk * (K/2) + k_blk
++          unsigned int n_blk = global_n / 32;
++          unsigned int k_blk = global_k / 2;
++          unsigned int block_idx = n_blk * (K / 2) + k_blk;
++
++          // Offset within 32-byte block
++          unsigned int byte_offset = global_n % 32;
++
++          unsigned int weight_idx = block_idx * 32 + byte_offset;
++          uint8_t packed_w = weights[weight_idx];
++
++          w_val = k_parity == 0 ? (packed_w & 0x0F) : (packed_w >> 4);
++          if (w_val >= 8)
++            w_val -= 16;
++        }
++
++        s_weights[r][c] = w_val;
++      }
++    }
++
++    __syncthreads();
++
++    // 3. Compute - each thread computes 4 outputs
++    int acc[4] = {0};
++
++#pragma unroll
++    for (int ki = 0; ki < 8; ++ki) {
++      int k_idx = ki * 4;
++
++      // Load inputs for 2 rows
++      int i0 = *reinterpret_cast<int *>(&s_input[ty][k_idx]);
++      int i1 = *reinterpret_cast<int *>(&s_input[ty + 16][k_idx]);
++
++      // Load weights for 2 cols
++      int w0 = *reinterpret_cast<int *>(&s_weights[tx][k_idx]);
++      int w1 = *reinterpret_cast<int *>(&s_weights[tx + 16][k_idx]);
++
++      // Accumulate 4 outputs
++      acc[0] = __dp4a(i0, w0, acc[0]); // [ty][tx]
++      acc[1] = __dp4a(i0, w1, acc[1]); // [ty][tx+16]
++      acc[2] = __dp4a(i1, w0, acc[2]); // [ty+16][tx]
++      acc[3] = __dp4a(i1, w1, acc[3]); // [ty+16][tx+16]
++    }
++
++    // Apply scales for each of the 4 outputs
++    unsigned int alignK = (K + quantization_group_size - 1) /
++                          quantization_group_size * quantization_group_size;
++    unsigned int groups_in_row = alignK / quantization_group_size;
++    unsigned int group_id_in_row = k_start / quantization_group_size;
++
++    // For each of the 4 outputs
++    unsigned int rows[2] = {row_start + ty, row_start + ty + 16};
++    unsigned int cols[2] = {col_start + tx, col_start + tx + 16};
++
++    for (int r_idx = 0; r_idx < 2; ++r_idx) {
++      unsigned int r = rows[r_idx];
++      if (r >= M)
++        continue;
++
++      unsigned int global_group_id = r * groups_in_row + group_id_in_row;
++      float i_scale = __half2float(input_scales[global_group_id * 2]);
++
++      for (int c_idx = 0; c_idx < 2; ++c_idx) {
++        unsigned int c = cols[c_idx];
++        if (c >= N)
++          continue;
++
++        unsigned int scale_idx =
++          c * (K / quantization_group_size) + group_id_in_row;
++        float w_scale = __half2float(scales[scale_idx]);
++
++        int acc_idx = r_idx * 2 + c_idx;
++        sum[acc_idx] += acc[acc_idx] * i_scale * w_scale;
++      }
++    }
++
++    __syncthreads();
++  }
++
++  // Store 4 outputs
++  unsigned int rows[2] = {row_start + ty, row_start + ty + 16};
++  unsigned int cols[2] = {col_start + tx, col_start + tx + 16};
++
++  for (int r_idx = 0; r_idx < 2; ++r_idx) {
++    unsigned int r = rows[r_idx];
++    if (r >= M)
++      continue;
++
++    for (int c_idx = 0; c_idx < 2; ++c_idx) {
++      unsigned int c = cols[c_idx];
++      if (c >= N)
++        continue;
++
++      int sum_idx = r_idx * 2 + c_idx;
++      output[r * N + c] = sum[sum_idx];
++    }
++  }
++}
++
++void gemm_int4_cuda_packed_block_16(const void *input, const void *weights,
++                                    const void *scales,
++                                    const void *input_scales, float *output,
++                                    unsigned int M, unsigned int N,
++                                    unsigned int K,
++                                    unsigned int quantization_group_size) {
++
++  // Launch Kernel - each block computes 32x32 outputs
++  dim3 blockDim(16, 16);
++  dim3 gridDim((N + 31) / 32, (M + 31) / 32);
++
++  gemm_int4_kernel_packed_block_16<<<gridDim, blockDim>>>(
++    static_cast<const int8_t *>(input), static_cast<const uint8_t *>(weights),
++    static_cast<const __half *>(scales),
++    static_cast<const __half *>(input_scales), output, M, N, K,
++    quantization_group_size);
++}
+diff --git a/nntrainer/tensor/cuda_operations/gemm_int4_cuda.h b/nntrainer/tensor/cuda_operations/gemm_int4_cuda.h
+index 27bd84097d..c62fe94016 100644
+--- a/nntrainer/tensor/cuda_operations/gemm_int4_cuda.h
++++ b/nntrainer/tensor/cuda_operations/gemm_int4_cuda.h
+@@ -14,24 +14,45 @@
+ #ifndef __GEMM_INT4_CUDA_H__
+ #define __GEMM_INT4_CUDA_H__
+ 
+-namespace nntrainer {
+-
+ /**
+- * @brief CUDA implementation of int4 GEMM operation equivalent to openvino_gemm_cl
+- * 
+- * @param input Input data pointer
+- * @param weights Weight data pointer
+- * @param scales Scale data pointer
+- * @param output Output data pointer
++ * @brief Optimized CUDA implementation of int4 GEMM operation using packed
++ * blocks
++ *
++ * @param input Quantized input data pointer (device memory, int8_t*)
++ * @param weights Quantized weight data pointer (device memory, packed int4)
++ * @param scales Weight scale data pointer (device memory, fp16)
++ * @param input_scales Input scale data pointer (device memory, fp16)
++ * @param output Output data pointer (device memory, float*)
+  * @param M Number of rows in the matrix
+  * @param N Number of columns in the matrix
+  * @param K Inner dimension of the matrix multiplication
+  * @param quantization_group_size Quantization group size
+  */
+-void gemm_int4_cuda(void *input, void *weights, void *scales, void *output,
+-                    unsigned int M, unsigned int N, unsigned int K,
+-                    unsigned int quantization_group_size);
++void gemm_int4_cuda_packed_block(const void *input, const void *weights,
++                                 const void *scales, const void *input_scales,
++                                 float *output, unsigned int M, unsigned int N,
++                                 unsigned int K,
++                                 unsigned int quantization_group_size);
+ 
+-} // namespace nntrainer
++/**
++ * @brief Optimized CUDA implementation of int4 GEMM operation using packed
++ * blocks (16x16)
++ *
++ * @param input Input data pointer (device)
++ * @param weights Weight data pointer (device)
++ * @param scales Scale data pointer (device)
++ * @param input_scales Input scale data pointer (device)
++ * @param output Output data pointer (device)
++ * @param M Number of rows in the matrix
++ * @param N Number of columns in the matrix
++ * @param K Inner dimension of the matrix multiplication
++ * @param quantization_group_size Quantization group size
++ */
++void gemm_int4_cuda_packed_block_16(const void *input, const void *weights,
++                                    const void *scales,
++                                    const void *input_scales, float *output,
++                                    unsigned int M, unsigned int N,
++                                    unsigned int K,
++                                    unsigned int quantization_group_size);
+ 
+ #endif // __GEMM_INT4_CUDA_H__
+diff --git a/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.cu b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.cu
+index 2c3f936bc7..7994e10730 100644
+--- a/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.cu
++++ b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.cu
+@@ -309,7 +309,7 @@ static __global__ void quantize_input_int4_pad_kernel(
+   }
+ }
+ 
+-void quantize_input_int4_pad_cuda(const void *input, void *quantized_input,
++void quantize_input_int8_pad_cuda(const void *input, void *quantized_input,
+                                   void *scales, unsigned int M, unsigned int K,
+                                   unsigned int quantization_group_size,
+                                   cudaStream_t stream) {
+diff --git a/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h
+index 95a2abe397..54a75defb9 100644
+--- a/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h
++++ b/nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h
+@@ -139,7 +139,7 @@ static mmq_q8_1_ds_layout mmq_get_q8_1_ds_layout(const ggml_type type_x) {
+  * 32).
+  * @param stream The CUDA stream to execute the kernel on (default: 0).
+  */
+-void quantize_input_int4_pad_cuda(const void *input, void *quantized_input,
++void quantize_input_int8_pad_cuda(const void *input, void *quantized_input,
+                                   void *scales, unsigned int M, unsigned int K,
+                                   unsigned int quantization_group_size,
+                                   cudaStream_t stream = 0);
+diff --git a/nntrainer/tensor/cuda_operations/meson.build b/nntrainer/tensor/cuda_operations/meson.build
+index 58f18bed3b..0e3818ed73 100644
+--- a/nntrainer/tensor/cuda_operations/meson.build
++++ b/nntrainer/tensor/cuda_operations/meson.build
+@@ -5,7 +5,8 @@ if nvcc.found()
+   cuda_sources = [
+     'rmsnorm_cuda.cu',
+     'addition_cuda.cu',
+-    'ggml_quantize_cuda.cu'
++    'ggml_quantize_cuda.cu',
++    'gemm_int4_cuda.cu'
+   ]
+ 
+   cuda_headers = [
+@@ -15,7 +16,8 @@ if nvcc.found()
+     'ggml_cuda_common.h',
+     'ggml_quantize_cuda.h',
+     'ggml_quantize_cpu.h',
+-    'ggml_dequantize_cpu.h'
++    'ggml_dequantize_cpu.h',
++    'gemm_int4_cuda.h'
+   ]
+ 
+   kernel_objects = []
+@@ -31,6 +33,7 @@ if nvcc.found()
+ 
+   # Add cuda_interface.cpp to regular sources
+   nntrainer_sources += meson.current_source_dir() / 'cuda_interface.cpp'
++  nntrainer_sources += meson.current_source_dir() / 'gemm_int4_cpu.cpp'
+   nntrainer_sources += meson.current_source_dir() / 'ggml_quantize_cpu.cpp'
+   nntrainer_sources += meson.current_source_dir() / 'ggml_dequantize_cpu.cpp'
+ 
+diff --git a/nntrainer/utils/util_func.h b/nntrainer/utils/util_func.h
+index edb3c45794..e037a6823d 100644
+--- a/nntrainer/utils/util_func.h
++++ b/nntrainer/utils/util_func.h
+@@ -117,8 +117,20 @@ template <typename T = float> T logFloat(T x) {
+  */
+ template <typename T = float> T exp_util(T x) { return static_cast<T>(exp(x)); }
+ 
++/**
++ * @brief     Calculate the ceiling of division
++ * @param[in] a dividend
++ * @param[in] b divisor
++ * @return    ceiling of a/b
++ */
+ uint32_t ceilDiv(uint32_t a, uint32_t b);
+ 
++/**
++ * @brief     Align a to the nearest multiple of b (round up)
++ * @param[in] a value to align
++ * @param[in] b alignment boundary
++ * @return    a aligned to the nearest multiple of b
++ */
+ uint32_t align(uint32_t a, uint32_t b);
+ 
+ #ifdef _WIN32
+diff --git a/test/unittest/unittest_blas_kernels_cl.cpp b/test/unittest/unittest_blas_kernels_cl.cpp
+index 3da5216ed4..6c2f6606e1 100644
+--- a/test/unittest/unittest_blas_kernels_cl.cpp
++++ b/test/unittest/unittest_blas_kernels_cl.cpp
+@@ -29,10 +29,7 @@
+ #include <layer_context.h>
+ #include <tensor.h>
+ 
+-#define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
+-  EXPECT_GE((VAL), (MIN));                                                     \
+-  EXPECT_LE((VAL), (MAX))
+-
++#include "unittest_util.h"
+ using namespace nntrainer;
+ 
+ // -----
+@@ -136,28 +133,6 @@ dot_gemm_fp16(const int batch, const int channel, const int height,
+ }
+ #endif
+ 
+-void *allocateSVM(size_t size_bytes) {
+-  auto *blas_cc = static_cast<nntrainer::ClContext *>(
+-    nntrainer::Engine::Global().getRegisteredContext("gpu"));
+-
+-  void *ptr = blas_cc->context_inst_.createSVMRegion(size_bytes);
+-
+-  if (ptr == nullptr) {
+-    throw std::runtime_error(
+-      "Failed to allocated SVM for the OpenCL BLAS unit test.");
+-  }
+-
+-  return ptr;
+-}
+-
+-void freeSVM(void *ptr) {
+-  auto *blas_cc = static_cast<nntrainer::ClContext *>(
+-    nntrainer::Engine::Global().getRegisteredContext("gpu"));
+-
+-  blas_cc->context_inst_.releaseSVMRegion(ptr);
+-  ptr = nullptr;
+-}
+-
+ auto debug_print_data = [](const float *const data, const unsigned int len,
+                            const uint32_t count = 5) {
+   std::cout << "[";
+@@ -171,44 +146,6 @@ auto debug_print_data = [](const float *const data, const unsigned int len,
+   std::cout << "]";
+ };
+ 
+-/**
+- * @brief Helper function to generate random data
+- *
+- * @tparam T data type
+- * @tparam random_init True if want random
+- * @param size data length
+- * @param min_val minimum value
+- * @param max_val maximum value
+- * @return std::vector<T> random vector
+- */
+-template <typename T, bool random_init = false>
+-static inline std::vector<T>
+-generate_random_vector(size_t size, float min_val = -1.F, float max_val = 1.F) {
+-  std::random_device rd;
+-  auto init_val = random_init ? rd() : 42;
+-  std::mt19937 gen(init_val);
+-  std::uniform_real_distribution<float> dist(min_val, max_val);
+-  std::vector<T> vec(size);
+-  for (auto &val : vec) {
+-    val = static_cast<T>(dist(gen));
+-  }
+-  return vec;
+-}
+-
+-static inline std::vector<float> generate_vector(const size_t size,
+-                                                 float min_val, float max_val) {
+-  const float step = (max_val - min_val) / (float)size;
+-  float current_value = min_val;
+-  std::vector<float> vec(size, 0.0f);
+-
+-  for (int i = 0; i < vec.size(); ++i) {
+-    vec[i] = current_value;
+-    current_value += step;
+-  }
+-
+-  return vec;
+-}
+-
+ static inline void printMatrixF(const char *name, float *data, int Y, int X) {
+   printf("%s :\n", name);
+   for (int y = 0; y < Y; y++) {
+@@ -220,39 +157,6 @@ static inline void printMatrixF(const char *name, float *data, int Y, int X) {
+   }
+ }
+ 
+-static inline void printMatrixI(const char *name, float *data, int Y, int X) {
+-  printf("%s :\n", name);
+-  for (int y = 0; y < Y; y++) {
+-    // printf("[");
+-    for (int x = 0; x < X; x++) {
+-      if (x % 10 == 0) {
+-        printf("| ");
+-      }
+-      std::cout << (int)(0.5f + data[y * X + x]) << " ";
+-    }
+-    printf("\n");
+-  }
+-}
+-
+-static inline std::vector<float> generate_01_vector(const size_t size,
+-                                                    const float ones_ratio) {
+-  std::random_device rd;
+-  std::mt19937 gen(rd());
+-  std::uniform_real_distribution<float> dist(0.0f, (float)size);
+-  if (ones_ratio >= 1.0) {
+-    std::vector<float> vec(size, 1.0f);
+-    return vec;
+-  } else {
+-    std::vector<float> vec(size, 0.0f);
+-    size_t ones_cnt = (size_t)(size * ones_ratio);
+-    for (size_t i = 0; i < ones_cnt; i++) {
+-      int pos = static_cast<int>(dist(gen));
+-      vec[pos] = 1.0f;
+-    }
+-    return vec;
+-  }
+-}
+-
+ /**
+  * @brief Helper function to print data
+  *
+@@ -1172,6 +1076,7 @@ DECLARE_int4_gemm_test_M_K_N(28, 3072, 256, 32);
+ DECLARE_int4_gemm_test_M_K_N(28, 3072, 8192, 32);
+ DECLARE_int4_gemm_test_M_K_N(28, 8192, 3072, 32);
+ DECLARE_int4_gemm_test_M_K_N(28, 3072, 3072, 32);
++DECLARE_int4_gemm_test_M_K_N(28, 32, 3072, 32);
+ 
+ DECLARE_int4_gemm_test_M_K_N(28, 3072, 256, 128);
+ DECLARE_int4_gemm_test_M_K_N(28, 3072, 8192, 128);
+diff --git a/test/unittest/unittest_cpu_gemm_int4.cpp b/test/unittest/unittest_cpu_gemm_int4.cpp
+new file mode 100644
+index 0000000000..abb46fef9f
+--- /dev/null
++++ b/test/unittest/unittest_cpu_gemm_int4.cpp
+@@ -0,0 +1,425 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file   unittest_cpu_gemm_int4.cpp
++ * @brief  Unit test for CPU int4 GEMM operations
++ * @author Samsung Electronics Co., Ltd.
++ * @bug    No known bugs except for NYI items
++ *
++ */
++
++#include <cmath>
++#include <gtest/gtest.h>
++#include <iostream>
++#include <random>
++#include <vector>
++
++#include "gemm_int4_cpu.h"
++#include "int4_utils.h"
++#include "unittest_util.h" // For generate_random_vector, etc.
++
++using namespace nntrainer;
++
++// Helper for ceil division
++#define CEIL_DIV(a, b) (((a) + (b) - 1) / (b))
++#define ALIGN(a, b) (CEIL_DIV(a, b) * (b))
++
++static void run_cpu_int4_gemm_test_(const uint32_t M, const uint32_t K,
++                                    const uint32_t N,
++                                    const int scale_group_size) {
++  // 1. Prepare Data
++  float input_min = -1.0f, input_max = 1.0f;
++  float weight_min = -0.5f, weight_max = 0.5f;
++
++  std::vector<float> input =
++    generate_random_vector<float>(M * K, input_min, input_max);
++  std::vector<float> weights_fp32 =
++    generate_random_vector<float>(K * N, weight_min, weight_max);
++  std::vector<float> output_cpu(M * N);
++  std::vector<float> output_ref(M * N);
++
++  // 2. Quantize Weights using Int4Utils
++  // weights_fp32 is K x N. Transpose to N x K for quantization.
++  std::vector<float> weights_NxK(N * K);
++  for (unsigned int k = 0; k < K; ++k) {
++    for (unsigned int n = 0; n < N; ++n) {
++      weights_NxK[n * K + k] = weights_fp32[k * N + n];
++    }
++  }
++
++  std::vector<uint8_t> weights_int4;
++  std::vector<uint16_t> scales_fp16;
++
++  Int4Utils::quantizeAndRepack(weights_NxK.data(), N, K, scale_group_size,
++                               weights_int4, scales_fp16);
++
++  // 3. Quantize Input using cpu_quantize_input_int8_pad
++  unsigned int alignK = ALIGN(K, scale_group_size);
++  unsigned int groups_in_row = alignK / scale_group_size;
++  std::vector<int8_t> input_quantized(M * alignK);
++  std::vector<uint16_t> input_scales(M * groups_in_row * 2);
++
++  cpu_quantize_input_int8_pad(input.data(), input_quantized.data(),
++                              input_scales.data(), M, K, scale_group_size);
++
++  // 4. Run CPU INT4 GEMM
++  gemm_int4_cpu(input_quantized.data(), weights_int4.data(), scales_fp16.data(),
++                input_scales.data(), output_cpu.data(), M, N, K,
++                scale_group_size);
++
++  // 5. Run Reference FP32 GEMM
++  gemm_fp32_ref(input.data(), weights_fp32.data(), output_ref.data(), M, N, K);
++
++  // 6. Compare
++  // Note: INT4 quantization introduces error.
++  // We check if the MSE is within a reasonable range.
++  float mse = 0.0f;
++  float max_diff = 0.0f;
++  for (size_t i = 0; i < output_cpu.size(); ++i) {
++    float diff = output_cpu[i] - output_ref[i];
++    mse += diff * diff;
++    if (std::abs(diff) > max_diff) {
++      max_diff = std::abs(diff);
++    }
++  }
++  mse /= output_cpu.size();
++
++  std::cout << "M: " << M << " K: " << K << " N: " << N
++            << " Group: " << scale_group_size << " MSE: " << mse
++            << " MaxDiff: " << max_diff << std::endl;
++
++  // Threshold calculation based on quantization error variance
++  // 1. Quantization Step Sizes
++  float input_range = input_max - input_min;
++  float weight_range = weight_max - weight_min;
++  float delta_input = input_range / 255.0f;  // 8-bit
++  float delta_weight = weight_range / 15.0f; // 4-bit
++
++  // 2. Error Variances (Uniform distribution assumption)
++  float var_err_input = (delta_input * delta_input) / 12.0f;
++  float var_err_weight = (delta_weight * delta_weight) / 12.0f;
++
++  // 3. Signal Mean Squared Values (Uniform distribution assumption)
++  float mean_sq_input =
++    (input_min * input_min + input_min * input_max + input_max * input_max) /
++    3.0f;
++  float mean_sq_weight = (weight_min * weight_min + weight_min * weight_max +
++                          weight_max * weight_max) /
++                         3.0f;
++
++  // 4. Product Error Variance
++  // Var(xy) approx E[x^2]Var(y) + E[y^2]Var(x)
++  float var_err_product =
++    mean_sq_input * var_err_weight + mean_sq_weight * var_err_input;
++
++  // 5. Accumulated Error Variance (Sum of K products)
++  float expected_mse = K * var_err_product;
++
++  // 6. Threshold with safety margin (e.g., 2.0x for outliers/distribution
++  // mismatch)
++  float threshold = expected_mse * 2.0f;
++
++  std::cout << "Expected MSE: " << expected_mse << " Threshold: " << threshold
++            << std::endl;
++  EXPECT_LT(mse, threshold);
++}
++
++#define DECLARE_CPU_INT4_GEMM_TEST(M, K, N, G)                                 \
++  TEST(gemm_int4_cpu, test_##M##_##K##_##N##_Group##G) {                       \
++    run_cpu_int4_gemm_test_(M, K, N, G);                                       \
++  }
++
++DECLARE_CPU_INT4_GEMM_TEST(28, 3072, 256, 32);
++DECLARE_CPU_INT4_GEMM_TEST(28, 3072, 8192, 32);
++DECLARE_CPU_INT4_GEMM_TEST(28, 8192, 3072, 32);
++DECLARE_CPU_INT4_GEMM_TEST(28, 3072, 3072, 32);
++
++// DECLARE_CPU_INT4_GEMM_TEST(28, 3072, 256, 128);
++// DECLARE_CPU_INT4_GEMM_TEST(28, 3072, 8192, 128);
++// DECLARE_CPU_INT4_GEMM_TEST(28, 8192, 3072, 128);
++// DECLARE_CPU_INT4_GEMM_TEST(28, 3072, 3072, 128);
++
++DECLARE_CPU_INT4_GEMM_TEST(28, 32, 3072, 32);
++DECLARE_CPU_INT4_GEMM_TEST(28, 64, 3072, 32);
++DECLARE_CPU_INT4_GEMM_TEST(28, 128, 3072, 32);
++DECLARE_CPU_INT4_GEMM_TEST(28, 256, 3072, 32);
++
++// DECLARE_CPU_INT4_GEMM_TEST(28, 3000, 3072, 128);
++// DECLARE_CPU_INT4_GEMM_TEST(28, 2000, 3072, 128);
++
++// DECLARE_CPU_INT4_GEMM_TEST(4, 3060, 3072, 32);
++// DECLARE_CPU_INT4_GEMM_TEST(4, 3072, 3072, 32);
++
++#include "fp16.h"
++
++// Helper to dequantize input
++// input_quantized: int8_t
++// input_scales: uint16_t (fp16)
++// M, K, group_size
++static void dequantize_input(const int8_t *input_quantized,
++                             const uint16_t *input_scales,
++                             float *input_dequantized, unsigned int M,
++                             unsigned int K, unsigned int group_size) {
++  unsigned int alignK = ALIGN(K, group_size);
++  unsigned int groups_in_row = alignK / group_size;
++
++  for (unsigned int m = 0; m < M; ++m) {
++    for (unsigned int k = 0; k < K; ++k) {
++      unsigned int group_id_in_row = k / group_size;
++      unsigned int global_group_id = m * groups_in_row + group_id_in_row;
++      unsigned int offset_in_group = k % group_size;
++      unsigned int input_idx = global_group_id * group_size + offset_in_group;
++
++      int8_t q_val = input_quantized[input_idx];
++      float scale = compute_fp16_to_fp32(input_scales[global_group_id * 2]);
++
++      input_dequantized[m * K + k] = static_cast<float>(q_val) * scale;
++    }
++  }
++}
++
++static void run_quantization_gemm_test_(const uint32_t M, const uint32_t K,
++                                        const uint32_t N,
++                                        const int scale_group_size) {
++  // 1. Prepare Data
++  float input_min = -1.0f, input_max = 1.0f;
++  float weight_min = -0.5f, weight_max = 0.5f;
++
++  std::vector<float> input =
++    generate_random_vector<float>(M * K, input_min, input_max);
++  std::vector<float> weights_fp32 =
++    generate_random_vector<float>(K * N, weight_min, weight_max);
++  std::vector<float> output_dequantized(M * N);
++  std::vector<float> output_ref(M * N);
++
++  // 2. Quantize Weights
++  // weights_fp32 is K x N (Row-Major).
++  // Int4Utils::quantizeAndRepack expects N x K (N rows, K columns), where each
++  // row is quantized together. So we must transpose weights_fp32 to N x K.
++  std::vector<float> weights_NxK(N * K);
++  for (unsigned int k = 0; k < K; ++k) {
++    for (unsigned int n = 0; n < N; ++n) {
++      weights_NxK[n * K + k] = weights_fp32[k * N + n];
++    }
++  }
++
++  std::vector<uint8_t> weights_int4;
++  std::vector<uint16_t> scales_fp16;
++  Int4Utils::quantizeAndRepack(weights_NxK.data(), N, K, scale_group_size,
++                               weights_int4, scales_fp16);
++
++  // 3. Quantize Input
++  unsigned int alignK = ALIGN(K, scale_group_size);
++  unsigned int groups_in_row = alignK / scale_group_size;
++  std::vector<int8_t> input_quantized(M * alignK);
++  std::vector<uint16_t> input_scales(M * groups_in_row * 2);
++  cpu_quantize_input_int8_pad(input.data(), input_quantized.data(),
++                              input_scales.data(), M, K, scale_group_size);
++
++  // 4. Dequantize Weights back to FP32
++  std::vector<float> weights_dequantized_NxK;
++  Int4Utils::dequantizePacked(weights_int4, scales_fp16, N, K, scale_group_size,
++                              weights_dequantized_NxK);
++
++  // Transpose weights_dequantized (N x K) -> (K x N) for GEMM reference
++  std::vector<float> weights_dequantized_KxN(K * N);
++  for (unsigned int n = 0; n < N; ++n) {
++    for (unsigned int k = 0; k < K; ++k) {
++      weights_dequantized_KxN[k * N + n] = weights_dequantized_NxK[n * K + k];
++    }
++  }
++
++  // 5. Dequantize Input back to FP32
++  std::vector<float> input_dequantized(M * K);
++  dequantize_input(input_quantized.data(), input_scales.data(),
++                   input_dequantized.data(), M, K, scale_group_size);
++
++  // 6. Run Reference FP32 GEMM on Dequantized Data
++  gemm_fp32_ref(input_dequantized.data(), weights_dequantized_KxN.data(),
++                output_dequantized.data(), M, N, K);
++
++  // 7. Run Reference FP32 GEMM on Original Data
++  gemm_fp32_ref(input.data(), weights_fp32.data(), output_ref.data(), M, N, K);
++
++  // 8. Compare
++  float mse = 0.0f;
++  float max_diff = 0.0f;
++  for (size_t i = 0; i < output_dequantized.size(); ++i) {
++    float diff = output_dequantized[i] - output_ref[i];
++    mse += diff * diff;
++    if (std::abs(diff) > max_diff) {
++      max_diff = std::abs(diff);
++    }
++  }
++  mse /= output_dequantized.size();
++
++  std::cout << "[Quantization Error] M: " << M << " K: " << K << " N: " << N
++            << " Group: " << scale_group_size << " MSE: " << mse
++            << " MaxDiff: " << max_diff << std::endl;
++
++  // This MSE represents the pure quantization loss.
++  // If this is high, then INT4 is just lossy.
++  // If this is low, but the GEMM test fails, then GEMM implementation is wrong.
++  // Threshold calculation based on quantization error variance
++  // 1. Quantization Step Sizes
++  float input_range = input_max - input_min;
++  float weight_range = weight_max - weight_min;
++  float delta_input = input_range / 255.0f;  // 8-bit
++  float delta_weight = weight_range / 15.0f; // 4-bit
++
++  // 2. Error Variances (Uniform distribution assumption)
++  float var_err_input = (delta_input * delta_input) / 12.0f;
++  float var_err_weight = (delta_weight * delta_weight) / 12.0f;
++
++  // 3. Signal Mean Squared Values (Uniform distribution assumption)
++  float mean_sq_input =
++    (input_min * input_min + input_min * input_max + input_max * input_max) /
++    3.0f;
++  float mean_sq_weight = (weight_min * weight_min + weight_min * weight_max +
++                          weight_max * weight_max) /
++                         3.0f;
++
++  // 4. Product Error Variance
++  // Var(xy) approx E[x^2]Var(y) + E[y^2]Var(x)
++  float var_err_product =
++    mean_sq_input * var_err_weight + mean_sq_weight * var_err_input;
++
++  // 5. Accumulated Error Variance (Sum of K products)
++  float expected_mse = K * var_err_product;
++
++  // 6. Threshold with safety margin (e.g., 2.0x for outliers/distribution
++  // mismatch)
++  float threshold = expected_mse * 2.0f;
++
++  std::cout << "Expected MSE: " << expected_mse << " Threshold: " << threshold
++            << std::endl;
++  EXPECT_LT(mse, threshold);
++}
++
++#define DECLARE_QUANTIZATION_TEST(M, K, N, G)                                  \
++  TEST(gemm_int4_cpu, quantization_##M##_##K##_##N##_Group##G) {               \
++    run_quantization_gemm_test_(M, K, N, G);                                   \
++  }
++
++DECLARE_QUANTIZATION_TEST(28, 32, 3072, 32);
++DECLARE_QUANTIZATION_TEST(28, 64, 3072, 32);
++DECLARE_QUANTIZATION_TEST(28, 128, 3072, 32);
++DECLARE_QUANTIZATION_TEST(28, 256, 3072, 32);
++
++static void run_cpu_int4_gemm_packed_block_test_(const uint32_t M,
++                                                 const uint32_t K,
++                                                 const uint32_t N,
++                                                 const int scale_group_size) {
++  // 1. Prepare Data
++  float input_min = -1.0f, input_max = 1.0f;
++  float weight_min = -0.5f, weight_max = 0.5f;
++
++  std::vector<float> input =
++    generate_random_vector<float>(M * K, input_min, input_max);
++  std::vector<float> weights_fp32 =
++    generate_random_vector<float>(K * N, weight_min, weight_max);
++  std::vector<float> output_cpu(M * N);
++  std::vector<float> output_ref(M * N);
++
++  // 2. Quantize Weights
++  std::vector<float> weights_NxK(N * K);
++  for (unsigned int k = 0; k < K; ++k) {
++    for (unsigned int n = 0; n < N; ++n) {
++      weights_NxK[n * K + k] = weights_fp32[k * N + n];
++    }
++  }
++
++  std::vector<uint8_t> weights_int4;
++  std::vector<uint16_t> scales_fp16;
++  Int4Utils::quantizeAndRepack(weights_NxK.data(), N, K, scale_group_size,
++                               weights_int4, scales_fp16);
++
++  // 3. Quantize Input
++  unsigned int alignK = ALIGN(K, scale_group_size);
++  unsigned int groups_in_row = alignK / scale_group_size;
++  std::vector<int8_t> input_quantized(M * alignK);
++  std::vector<uint16_t> input_scales(M * groups_in_row * 2);
++
++  cpu_quantize_input_int8_pad(input.data(), input_quantized.data(),
++                              input_scales.data(), M, K, scale_group_size);
++
++  // 4. Run Optimized CPU INT4 GEMM
++  gemm_int4_cpu_packed_block(input_quantized.data(), weights_int4.data(),
++                             scales_fp16.data(), input_scales.data(),
++                             output_cpu.data(), M, N, K, scale_group_size);
++
++  // 5. Run Reference FP32 GEMM
++  gemm_fp32_ref(input.data(), weights_fp32.data(), output_ref.data(), M, N, K);
++
++  // 6. Compare
++  float mse = 0.0f;
++  float max_diff = 0.0f;
++  for (size_t i = 0; i < output_cpu.size(); ++i) {
++    float diff = output_cpu[i] - output_ref[i];
++    mse += diff * diff;
++    if (std::abs(diff) > max_diff) {
++      max_diff = std::abs(diff);
++    }
++  }
++  mse /= output_cpu.size();
++
++  std::cout << "[Packed Block] M: " << M << " K: " << K << " N: " << N
++            << " Group: " << scale_group_size << " MSE: " << mse
++            << " MaxDiff: " << max_diff << std::endl;
++
++  // Threshold calculation
++  float input_range = input_max - input_min;
++  float weight_range = weight_max - weight_min;
++  float delta_input = input_range / 255.0f;
++  float delta_weight = weight_range / 15.0f;
++  float var_err_input = (delta_input * delta_input) / 12.0f;
++  float var_err_weight = (delta_weight * delta_weight) / 12.0f;
++  float mean_sq_input =
++    (input_min * input_min + input_min * input_max + input_max * input_max) /
++    3.0f;
++  float mean_sq_weight = (weight_min * weight_min + weight_min * weight_max +
++                          weight_max * weight_max) /
++                         3.0f;
++  float var_err_product =
++    mean_sq_input * var_err_weight + mean_sq_weight * var_err_input;
++  float expected_mse = K * var_err_product;
++  float threshold = expected_mse * 2.0f;
++
++  std::cout << "Expected MSE: " << expected_mse << " Threshold: " << threshold
++            << std::endl;
++  EXPECT_LT(mse, threshold);
++}
++
++#define DECLARE_CPU_INT4_GEMM_PACKED_BLOCK_TEST(M, K, N, G)                    \
++  TEST(gemm_int4_cpu, packed_block_##M##_##K##_##N##_Group##G) {               \
++    run_cpu_int4_gemm_packed_block_test_(M, K, N, G);                          \
++  }
++
++DECLARE_CPU_INT4_GEMM_PACKED_BLOCK_TEST(28, 32, 3072, 32);
++DECLARE_CPU_INT4_GEMM_PACKED_BLOCK_TEST(28, 64, 3072, 32);
++DECLARE_CPU_INT4_GEMM_PACKED_BLOCK_TEST(28, 128, 3072, 32);
++DECLARE_CPU_INT4_GEMM_PACKED_BLOCK_TEST(28, 256, 3072, 32);
++
++DECLARE_CPU_INT4_GEMM_PACKED_BLOCK_TEST(28, 3072, 3072, 32);
++DECLARE_CPU_INT4_GEMM_PACKED_BLOCK_TEST(28, 3072, 8192, 32);
++DECLARE_CPU_INT4_GEMM_PACKED_BLOCK_TEST(28, 8192, 3072, 32);
++
++GTEST_API_ int main(int argc, char **argv) {
++  int result = -1;
++
++  try {
++    testing::InitGoogleTest(&argc, argv);
++  } catch (...) {
++    std::cerr << "Error during InitGoogleTest" << std::endl;
++    return 0;
++  }
++
++  try {
++    result = RUN_ALL_TESTS();
++  } catch (...) {
++    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
++  }
++
++  return result;
++}
+diff --git a/test/unittest/unittest_cuda_gemm_int4.cpp b/test/unittest/unittest_cuda_gemm_int4.cpp
+new file mode 100644
+index 0000000000..a932a3fe90
+--- /dev/null
++++ b/test/unittest/unittest_cuda_gemm_int4.cpp
+@@ -0,0 +1,368 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file   unittest_cuda_gemm_int4.cpp
++ * @brief  Unit test for CUDA int4 GEMM operations
++ * @author Samsung Electronics Co., Ltd.
++ * @bug    No known bugs except for NYI items
++ *
++ */
++
++#include <cmath>
++#include <gtest/gtest.h>
++#include <iostream>
++#include <random>
++#include <vector>
++
++#include <cuda_runtime.h>
++
++#include "gemm_int4_cpu.h"
++#include "gemm_int4_cuda.h"
++#include "int4_utils.h"
++#include "unittest_util.h" // For generate_random_vector, etc.
++
++using namespace nntrainer;
++
++// Helper for ceil division
++#define CEIL_DIV(a, b) (((a) + (b) - 1) / (b))
++#define ALIGN(a, b) (CEIL_DIV(a, b) * (b))
++
++static void run_cuda_int4_gemm_packed_block_test_(const uint32_t M,
++                                                  const uint32_t K,
++                                                  const uint32_t N,
++                                                  const int scale_group_size) {
++  // 1. Prepare Data
++  std::vector<float> input = generate_random_vector<float>(M * K, -1.0f, 1.0f);
++  std::vector<float> weights_fp32 =
++    generate_random_vector<float>(K * N, -0.5f, 0.5f);
++  std::vector<float> output_cuda(M * N);
++  std::vector<float> output_ref(M * N);
++
++  // 2. Quantize Weights using Int4Utils
++  // Note: quantizeAndRepack expects weights in N x K layout (N rows, K cols)
++  // But our weights_fp32 is K x N (K rows, N cols)
++  // We need to transpose weights to N x K before quantization
++  std::vector<float> weights_NxK(N * K);
++  for (unsigned int k = 0; k < K; ++k) {
++    for (unsigned int n = 0; n < N; ++n) {
++      weights_NxK[n * K + k] = weights_fp32[k * N + n];
++    }
++  }
++
++  std::vector<uint8_t> weights_int4;
++  std::vector<uint16_t> scales_fp16;
++
++  Int4Utils::quantizeAndRepack(weights_NxK.data(), N, K, scale_group_size,
++                               weights_int4, scales_fp16);
++
++  // 3. Quantize Input using cpu_quantize_input_int8_pad
++  unsigned int alignK = ALIGN(K, scale_group_size);
++  unsigned int groups_in_row = alignK / scale_group_size;
++  std::vector<int8_t> input_quantized(M * alignK);
++  std::vector<uint16_t> input_scales(M * groups_in_row * 2);
++
++  cpu_quantize_input_int8_pad(input.data(), input_quantized.data(),
++                              input_scales.data(), M, K, scale_group_size);
++
++  // 4. Run CUDA Kernel
++  float *d_output;
++  int8_t *d_quantized_input;
++  uint8_t *d_weights;
++  uint16_t *d_scales;
++  uint16_t *d_input_scales;
++
++  // Allocate device memory
++  size_t input_bytes = input_quantized.size() * sizeof(int8_t);
++  size_t weights_bytes = weights_int4.size() * sizeof(uint8_t);
++  size_t scales_bytes = scales_fp16.size() * sizeof(uint16_t);
++  size_t input_scales_bytes = input_scales.size() * sizeof(uint16_t);
++  size_t output_bytes = output_cuda.size() * sizeof(float);
++
++  cudaMalloc(&d_quantized_input, input_bytes);
++  cudaMalloc(&d_weights, weights_bytes);
++  cudaMalloc(&d_scales, scales_bytes);
++  cudaMalloc(&d_input_scales, input_scales_bytes);
++  cudaMalloc(&d_output, output_bytes);
++
++  // Copy data to device
++  cudaMemcpy(d_quantized_input, input_quantized.data(), input_bytes,
++             cudaMemcpyHostToDevice);
++  cudaMemcpy(d_weights, weights_int4.data(), weights_bytes,
++             cudaMemcpyHostToDevice);
++  cudaMemcpy(d_scales, scales_fp16.data(), scales_bytes,
++             cudaMemcpyHostToDevice);
++  cudaMemcpy(d_input_scales, input_scales.data(), input_scales_bytes,
++             cudaMemcpyHostToDevice);
++
++  // Warmup run
++  gemm_int4_cuda_packed_block(d_quantized_input, d_weights, d_scales,
++                              d_input_scales, d_output, M, N, K,
++                              scale_group_size);
++
++  // Benchmark runs
++  cudaEvent_t start, stop;
++  cudaEventCreate(&start);
++  cudaEventCreate(&stop);
++
++  cudaEventRecord(start);
++  for (int i = 0; i < 9; ++i) {
++    gemm_int4_cuda_packed_block(d_quantized_input, d_weights, d_scales,
++                                d_input_scales, d_output, M, N, K,
++                                scale_group_size);
++  }
++  cudaEventRecord(stop);
++  cudaEventSynchronize(stop);
++
++  float milliseconds = 0;
++  cudaEventElapsedTime(&milliseconds, start, stop);
++  std::cout << "Average execution time (over 9 runs): " << milliseconds / 9.0f
++            << " ms" << std::endl;
++
++  cudaEventDestroy(start);
++  cudaEventDestroy(stop);
++
++  // Copy output back
++  cudaMemcpy(output_cuda.data(), d_output, output_bytes,
++             cudaMemcpyDeviceToHost);
++
++  // Cleanup
++  cudaFree(d_quantized_input);
++  cudaFree(d_weights);
++  cudaFree(d_scales);
++  cudaFree(d_input_scales);
++  cudaFree(d_output);
++
++  // 5. Run Reference (FP32 GEMM)
++  // Use FP32 reference as requested
++  gemm_fp32_ref(input.data(), weights_fp32.data(), output_ref.data(), M, N, K);
++
++  // 6. Compare
++  float mse = 0.0f;
++  float max_diff = 0.0f;
++  for (size_t i = 0; i < output_cuda.size(); ++i) {
++    float diff = output_cuda[i] - output_ref[i];
++    mse += diff * diff;
++    if (std::abs(diff) > max_diff) {
++      max_diff = std::abs(diff);
++    }
++  }
++  mse /= output_cuda.size();
++
++  std::cout << "[Packed Block] M: " << M << " K: " << K << " N: " << N
++            << " Group: " << scale_group_size << " MSE: " << mse
++            << " MaxDiff: " << max_diff << std::endl;
++
++  // Threshold calculation (same as CPU test)
++  float input_min = -1.0f, input_max = 1.0f;
++  float weight_min = -0.5f, weight_max = 0.5f;
++  float input_range = input_max - input_min;
++  float weight_range = weight_max - weight_min;
++  float delta_input = input_range / 255.0f;
++  float delta_weight = weight_range / 15.0f;
++  float var_err_input = (delta_input * delta_input) / 12.0f;
++  float var_err_weight = (delta_weight * delta_weight) / 12.0f;
++  float mean_sq_input =
++    (input_min * input_min + input_min * input_max + input_max * input_max) /
++    3.0f;
++  float mean_sq_weight = (weight_min * weight_min + weight_min * weight_max +
++                          weight_max * weight_max) /
++                         3.0f;
++  float var_err_product =
++    mean_sq_input * var_err_weight + mean_sq_weight * var_err_input;
++  float expected_mse = K * var_err_product;
++  float threshold = expected_mse * 2.0f;
++
++  std::cout << "Expected MSE: " << expected_mse << " Threshold: " << threshold
++            << std::endl;
++  EXPECT_LT(mse, threshold);
++}
++
++#define DECLARE_CUDA_INT4_GEMM_PACKED_BLOCK_TEST(M, K, N, G)                   \
++  TEST(gemm_int4_cuda, packed_block_##M##_##K##_##N##_Group##G) {              \
++    run_cuda_int4_gemm_packed_block_test_(M, K, N, G);                         \
++  }
++
++DECLARE_CUDA_INT4_GEMM_PACKED_BLOCK_TEST(28, 3072, 256, 32);
++DECLARE_CUDA_INT4_GEMM_PACKED_BLOCK_TEST(28, 3072, 3072, 32);
++DECLARE_CUDA_INT4_GEMM_PACKED_BLOCK_TEST(28, 3072, 8192, 32);
++DECLARE_CUDA_INT4_GEMM_PACKED_BLOCK_TEST(28, 8192, 3072, 32);
++
++static void
++run_cuda_int4_gemm_packed_block_16_test_(const uint32_t M, const uint32_t K,
++                                         const uint32_t N,
++                                         const int scale_group_size) {
++  // 1. Prepare Data
++  std::vector<float> input = generate_random_vector<float>(M * K, -1.0f, 1.0f);
++  std::vector<float> weights_fp32 =
++    generate_random_vector<float>(K * N, -0.5f, 0.5f);
++  std::vector<float> output_cuda(M * N);
++  std::vector<float> output_ref(M * N);
++
++  // 2. Quantize Weights using Int4Utils
++  // Note: quantizeAndRepack expects weights in N x K layout (N rows, K cols)
++  // But our weights_fp32 is K x N (K rows, N cols)
++  // We need to transpose weights to N x K before quantization
++  std::vector<float> weights_NxK(N * K);
++  for (unsigned int k = 0; k < K; ++k) {
++    for (unsigned int n = 0; n < N; ++n) {
++      weights_NxK[n * K + k] = weights_fp32[k * N + n];
++    }
++  }
++
++  std::vector<uint8_t> weights_int4;
++  std::vector<uint16_t> scales_fp16;
++
++  Int4Utils::quantizeAndRepack(weights_NxK.data(), N, K, scale_group_size,
++                               weights_int4, scales_fp16);
++
++  // 3. Quantize Input using cpu_quantize_input_int8_pad
++  unsigned int alignK = ALIGN(K, scale_group_size);
++  unsigned int groups_in_row = alignK / scale_group_size;
++  std::vector<int8_t> input_quantized(M * alignK);
++  std::vector<uint16_t> input_scales(M * groups_in_row * 2);
++
++  cpu_quantize_input_int8_pad(input.data(), input_quantized.data(),
++                              input_scales.data(), M, K, scale_group_size);
++
++  // 4. Run CUDA Kernel
++  float *d_output;
++  int8_t *d_quantized_input;
++  uint8_t *d_weights;
++  uint16_t *d_scales;
++  uint16_t *d_input_scales;
++
++  // Allocate device memory
++  size_t input_bytes = input_quantized.size() * sizeof(int8_t);
++  size_t weights_bytes = weights_int4.size() * sizeof(uint8_t);
++  size_t scales_bytes = scales_fp16.size() * sizeof(uint16_t);
++  size_t input_scales_bytes = input_scales.size() * sizeof(uint16_t);
++  size_t output_bytes = output_cuda.size() * sizeof(float);
++
++  cudaMalloc(&d_quantized_input, input_bytes);
++  cudaMalloc(&d_weights, weights_bytes);
++  cudaMalloc(&d_scales, scales_bytes);
++  cudaMalloc(&d_input_scales, input_scales_bytes);
++  cudaMalloc(&d_output, output_bytes);
++
++  // Copy data to device
++  cudaMemcpy(d_quantized_input, input_quantized.data(), input_bytes,
++             cudaMemcpyHostToDevice);
++  cudaMemcpy(d_weights, weights_int4.data(), weights_bytes,
++             cudaMemcpyHostToDevice);
++  cudaMemcpy(d_scales, scales_fp16.data(), scales_bytes,
++             cudaMemcpyHostToDevice);
++  cudaMemcpy(d_input_scales, input_scales.data(), input_scales_bytes,
++             cudaMemcpyHostToDevice);
++
++  // Warmup run
++  gemm_int4_cuda_packed_block_16(d_quantized_input, d_weights, d_scales,
++                                 d_input_scales, d_output, M, N, K,
++                                 scale_group_size);
++
++  // Benchmark runs
++  cudaEvent_t start, stop;
++  cudaEventCreate(&start);
++  cudaEventCreate(&stop);
++
++  cudaEventRecord(start);
++  for (int i = 0; i < 9; ++i) {
++    gemm_int4_cuda_packed_block_16(d_quantized_input, d_weights, d_scales,
++                                   d_input_scales, d_output, M, N, K,
++                                   scale_group_size);
++  }
++  cudaEventRecord(stop);
++  cudaEventSynchronize(stop);
++
++  float milliseconds = 0;
++  cudaEventElapsedTime(&milliseconds, start, stop);
++  std::cout << "Average execution time (over 9 runs): " << milliseconds / 9.0f
++            << " ms" << std::endl;
++
++  cudaEventDestroy(start);
++  cudaEventDestroy(stop);
++
++  // Copy output back
++  cudaMemcpy(output_cuda.data(), d_output, output_bytes,
++             cudaMemcpyDeviceToHost);
++
++  // Cleanup
++  cudaFree(d_quantized_input);
++  cudaFree(d_weights);
++  cudaFree(d_scales);
++  cudaFree(d_input_scales);
++  cudaFree(d_output);
++
++  // 5. Run Reference (FP32 GEMM)
++  // Use FP32 reference as requested
++  gemm_fp32_ref(input.data(), weights_fp32.data(), output_ref.data(), M, N, K);
++
++  // 6. Compare
++  float mse = 0.0f;
++  float max_diff = 0.0f;
++  for (size_t i = 0; i < output_cuda.size(); ++i) {
++    float diff = output_cuda[i] - output_ref[i];
++    mse += diff * diff;
++    if (std::abs(diff) > max_diff) {
++      max_diff = std::abs(diff);
++    }
++  }
++  mse /= output_cuda.size();
++
++  std::cout << "[Packed Block 16x16] M: " << M << " K: " << K << " N: " << N
++            << " Group: " << scale_group_size << " MSE: " << mse
++            << " MaxDiff: " << max_diff << std::endl;
++
++  // Threshold calculation (same as CPU test)
++  float input_min = -1.0f, input_max = 1.0f;
++  float weight_min = -0.5f, weight_max = 0.5f;
++  float input_range = input_max - input_min;
++  float weight_range = weight_max - weight_min;
++  float delta_input = input_range / 255.0f;
++  float delta_weight = weight_range / 15.0f;
++  float var_err_input = (delta_input * delta_input) / 12.0f;
++  float var_err_weight = (delta_weight * delta_weight) / 12.0f;
++  float mean_sq_input =
++    (input_min * input_min + input_min * input_max + input_max * input_max) /
++    3.0f;
++  float mean_sq_weight = (weight_min * weight_min + weight_min * weight_max +
++                          weight_max * weight_max) /
++                         3.0f;
++  float var_err_product =
++    mean_sq_input * var_err_weight + mean_sq_weight * var_err_input;
++  float expected_mse = K * var_err_product;
++  float threshold = expected_mse * 2.0f;
++
++  std::cout << "Expected MSE: " << expected_mse << " Threshold: " << threshold
++            << std::endl;
++  EXPECT_LT(mse, threshold);
++}
++
++#define DECLARE_CUDA_INT4_GEMM_PACKED_BLOCK_16_TEST(M, K, N, G)                \
++  TEST(gemm_int4_cuda, packed_block_16_##M##_##K##_##N##_Group##G) {           \
++    run_cuda_int4_gemm_packed_block_16_test_(M, K, N, G);                      \
++  }
++
++DECLARE_CUDA_INT4_GEMM_PACKED_BLOCK_16_TEST(28, 3072, 256, 32);
++DECLARE_CUDA_INT4_GEMM_PACKED_BLOCK_16_TEST(28, 3072, 3072, 32);
++DECLARE_CUDA_INT4_GEMM_PACKED_BLOCK_16_TEST(28, 3072, 8192, 32);
++DECLARE_CUDA_INT4_GEMM_PACKED_BLOCK_16_TEST(28, 8192, 3072, 32);
++
++GTEST_API_ int main(int argc, char **argv) {
++  int result = -1;
++
++  try {
++    testing::InitGoogleTest(&argc, argv);
++  } catch (...) {
++    std::cerr << "Error during InitGoogleTest" << std::endl;
++    return 0;
++  }
++
++  try {
++    result = RUN_ALL_TESTS();
++  } catch (...) {
++    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
++  }
++
++  return result;
++}
+diff --git a/test/unittest/unittest_cuda_gemm_q40.cpp b/test/unittest/unittest_cuda_gemm_q40.cpp
+new file mode 100644
+index 0000000000..43045764ec
+--- /dev/null
++++ b/test/unittest/unittest_cuda_gemm_q40.cpp
+@@ -0,0 +1,283 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file   unittest_cuda_gemm_q40.cpp
++ * @date   25 Nov 2025
++ * @brief  Unit test for CUDA Q4_0 quantized matrix multiplication
++ * @see    https://github.com/nnstreamer/nntrainer
++ * @author Samsung Electronics Co., Ltd.
++ * @bug    No known bugs except for NYI items
++ */
++
++#include <gtest/gtest.h>
++#include <nntrainer_test_util.h>
++#include <cuda_runtime.h>
++#include <vector>
++#include <random>
++#include <cmath>
++
++#include <cpu_backend.h>
++
++// Include the function under test
++#include "ggml_mmq.h"
++
++#define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
++  EXPECT_GE((VAL), (MIN));                                                     \
++  EXPECT_LE((VAL), (MAX))
++
++#define CUDA_CHECK(call)                                                       \
++  do {                                                                         \
++    cudaError_t error = call;                                                  \
++    if (error != cudaSuccess) {                                                \
++      std::cerr << "CUDA error at " << __FILE__ << ":" << __LINE__ << " - "    \
++                << cudaGetErrorString(error) << std::endl;                     \
++      FAIL();                                                                  \
++    }                                                                          \
++  } while (0)
++
++/**
++ * @brief Compute reference matrix multiplication C = A * B (FP32)
++ */
++void matmul_fp32_ref(const float* A, const float* B, float* C,
++                     int M, int K, int N) {
++  for (int i = 0; i < M; ++i) {
++    for (int j = 0; j < N; ++j) {
++      float sum = 0.0f;
++      for (int k = 0; k < K; ++k) {
++        sum += A[i * K + k] * B[k * N + j];
++      }
++      C[i * N + j] = sum;
++    }
++  }
++}
++
++/**
++ * @brief Compute Mean Squared Error between two arrays
++ */
++float compute_mse(const float* a, const float* b, int size) {
++  double sum = 0.0;
++  for (int i = 0; i < size; ++i) {
++    double diff = static_cast<double>(a[i]) - static_cast<double>(b[i]);
++    sum += diff * diff;
++  }
++  return static_cast<float>(sum / size);
++}
++
++/**
++ * @brief Test for ggml_cuda_op_mul_mat_q40 function
++ */
++TEST(nntrainer_CUDA, gemm_q40_basic) {
++  // Matrix dimensions
++  const int M = 128;  // Rows of A
++  const int K = 256;  // Cols of A, Rows of B (must be multiple of 32 for Q4_0)
++  const int N = 64;   // Cols of B
++
++  // Allocate host memory for FP32 matrices
++  std::vector<float> A_fp32(M * K);
++  std::vector<float> B_fp32(K * N);
++  std::vector<float> C_ref(M * N);
++  std::vector<float> C_result(M * N);
++
++  // Initialize random number generator
++  std::mt19937 gen(42);  // Fixed seed for reproducibility
++  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
++
++  // Initialize matrices A and B with random values
++  for (int i = 0; i < M * K; ++i) {
++    A_fp32[i] = dist(gen);
++  }
++  for (int i = 0; i < K * N; ++i) {
++    B_fp32[i] = dist(gen);
++  }
++
++  // Step 1: Compute reference result C_ref = A * B (FP32)
++  matmul_fp32_ref(A_fp32.data(), B_fp32.data(), C_ref.data(), M, K, N);
++
++  // Step 2: Quantize A to Q4_0 format
++  const int q4_0_block_size = 36;  // sizeof(block_q4_0) = 2 + 16 = 18 bytes per 32 elements
++  const int num_blocks_A = (M * K) / 32;
++  std::vector<uint8_t> A_q40(num_blocks_A * q4_0_block_size);
++  
++  nntrainer::quantize_q4_0(A_fp32.data(), A_q40.data(), M, K, nullptr);
++
++  // Step 3: Quantize B to Q8_1 format (using quantize_row_q8_1_ref)
++  const int q8_1_block_size = 36;  // sizeof(block_q8_1) = 4 + 32 = 36 bytes per 32 elements
++  const int num_blocks_B = (K * N) / 32;
++  std::vector<uint8_t> B_q81(num_blocks_B * q8_1_block_size);
++  
++  // Quantize B row by row
++  for (int row = 0; row < K; ++row) {
++    quantize_row_q8_1_ref(
++      B_fp32.data() + row * N,
++      reinterpret_cast<block_q8_1*>(B_q81.data()) + row * (N / 32),
++      N
++    );
++  }
++
++  // Allocate device memory
++  char* d_A_q40 = nullptr;
++  char* d_B_q81 = nullptr;
++  float* d_C = nullptr;
++
++  CUDA_CHECK(cudaMalloc(&d_A_q40, A_q40.size()));
++  CUDA_CHECK(cudaMalloc(&d_B_q81, B_q81.size()));
++  CUDA_CHECK(cudaMalloc(&d_C, M * N * sizeof(float)));
++
++  // Copy quantized data to device
++  CUDA_CHECK(cudaMemcpy(d_A_q40, A_q40.data(), A_q40.size(), cudaMemcpyHostToDevice));
++  CUDA_CHECK(cudaMemcpy(d_B_q81, B_q81.data(), B_q81.size(), cudaMemcpyHostToDevice));
++  CUDA_CHECK(cudaMemset(d_C, 0, M * N * sizeof(float)));
++
++  // Create CUDA stream
++  cudaStream_t stream;
++  CUDA_CHECK(cudaStreamCreate(&stream));
++
++  // Step 4: Call ggml_cuda_op_mul_mat_q40
++  ggml_cuda_op_mul_mat_q40(
++    d_A_q40,        // src0_dd_i: quantized matrix A (Q4_0)
++    nullptr,        // src1_ddf_i: unused
++    d_B_q81,        // src1_ddq_i: quantized matrix B (Q8_1)
++    d_C,            // dst_dd_i: output matrix C (FP32)
++    0,              // row_low
++    M,              // row_high
++    N,              // src1_ncols
++    N,              // src1_padded_row_size
++    K,              // ne00: K dimension
++    K,              // ne10: K dimension
++    N,              // ne11: N dimension
++    N,              // ne0: leading dimension of output
++    stream
++  );
++
++  // Synchronize stream
++  CUDA_CHECK(cudaStreamSynchronize(stream));
++
++  // Copy result back to host
++  CUDA_CHECK(cudaMemcpy(C_result.data(), d_C, M * N * sizeof(float), cudaMemcpyDeviceToHost));
++
++  // Step 5: Compute MSE between C_ref and C_result
++  float mse = compute_mse(C_ref.data(), C_result.data(), M * N);
++
++  std::cout << "Matrix dimensions: M=" << M << ", K=" << K << ", N=" << N << std::endl;
++  std::cout << "MSE between FP32 and Q4_0×Q8_1: " << mse << std::endl;
++
++  // Q4_0 quantization introduces error, so we use a relaxed threshold
++  // Typical MSE for 4-bit quantization is in the range of 1e-3 to 1e-2
++  const float mse_threshold = 1e-2f;
++  EXPECT_IN_RANGE(mse, 0.0f, mse_threshold);
++
++  // Cleanup
++  CUDA_CHECK(cudaStreamDestroy(stream));
++  CUDA_CHECK(cudaFree(d_A_q40));
++  CUDA_CHECK(cudaFree(d_B_q81));
++  CUDA_CHECK(cudaFree(d_C));
++}
++
++/**
++ * @brief Test with different matrix sizes
++ */
++TEST(nntrainer_CUDA, gemm_q40_various_sizes) {
++  struct TestCase {
++    int M, K, N;
++    float max_mse;
++  };
++
++  std::vector<TestCase> test_cases = {
++    {32, 64, 32, 1e-2f},
++    {64, 128, 64, 1e-2f},
++    {128, 256, 128, 1e-2f},
++  };
++
++  for (const auto& tc : test_cases) {
++    std::cout << "\nTesting M=" << tc.M << ", K=" << tc.K << ", N=" << tc.N << std::endl;
++
++    // Allocate and initialize matrices
++    std::vector<float> A_fp32(tc.M * tc.K);
++    std::vector<float> B_fp32(tc.K * tc.N);
++    std::vector<float> C_ref(tc.M * tc.N);
++    std::vector<float> C_result(tc.M * tc.N);
++
++    std::mt19937 gen(42);
++    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
++
++    for (auto& val : A_fp32) val = dist(gen);
++    for (auto& val : B_fp32) val = dist(gen);
++
++    // Compute reference
++    matmul_fp32_ref(A_fp32.data(), B_fp32.data(), C_ref.data(), tc.M, tc.K, tc.N);
++
++    // Quantize
++    const int num_blocks_A = (tc.M * tc.K) / 32;
++    const int num_blocks_B = (tc.K * tc.N) / 32;
++    std::vector<uint8_t> A_q40(num_blocks_A * 36);
++    std::vector<uint8_t> B_q81(num_blocks_B * 36);
++
++    nntrainer::quantize_q4_0(A_fp32.data(), A_q40.data(), tc.M, tc.K, nullptr);
++    
++    for (int row = 0; row < tc.K; ++row) {
++      quantize_row_q8_1_ref(
++        B_fp32.data() + row * tc.N,
++        reinterpret_cast<block_q8_1*>(B_q81.data()) + row * (tc.N / 32),
++        tc.N
++      );
++    }
++
++    // Allocate device memory
++    char* d_A_q40 = nullptr;
++    char* d_B_q81 = nullptr;
++    float* d_C = nullptr;
++
++    CUDA_CHECK(cudaMalloc(&d_A_q40, A_q40.size()));
++    CUDA_CHECK(cudaMalloc(&d_B_q81, B_q81.size()));
++    CUDA_CHECK(cudaMalloc(&d_C, tc.M * tc.N * sizeof(float)));
++
++    CUDA_CHECK(cudaMemcpy(d_A_q40, A_q40.data(), A_q40.size(), cudaMemcpyHostToDevice));
++    CUDA_CHECK(cudaMemcpy(d_B_q81, B_q81.data(), B_q81.size(), cudaMemcpyHostToDevice));
++    CUDA_CHECK(cudaMemset(d_C, 0, tc.M * tc.N * sizeof(float)));
++
++    cudaStream_t stream;
++    CUDA_CHECK(cudaStreamCreate(&stream));
++
++    // Execute
++    ggml_cuda_op_mul_mat_q40(
++      d_A_q40, nullptr, d_B_q81, d_C,
++      0, tc.M, tc.N, tc.N,
++      tc.K, tc.K, tc.N, tc.N,
++      stream
++    );
++
++    CUDA_CHECK(cudaStreamSynchronize(stream));
++    CUDA_CHECK(cudaMemcpy(C_result.data(), d_C, tc.M * tc.N * sizeof(float), cudaMemcpyDeviceToHost));
++
++    // Validate
++    float mse = compute_mse(C_ref.data(), C_result.data(), tc.M * tc.N);
++    std::cout << "  MSE: " << mse << std::endl;
++    EXPECT_IN_RANGE(mse, 0.0f, tc.max_mse);
++
++    // Cleanup
++    CUDA_CHECK(cudaStreamDestroy(stream));
++    CUDA_CHECK(cudaFree(d_A_q40));
++    CUDA_CHECK(cudaFree(d_B_q81));
++    CUDA_CHECK(cudaFree(d_C));
++  }
++}
++
++GTEST_API_ int main(int argc, char **argv) {
++  int result = -1;
++
++  try {
++    testing::InitGoogleTest(&argc, argv);
++  } catch (...) {
++    std::cerr << "Error during InitGoogleTest" << std::endl;
++    return 0;
++  }
++
++  try {
++    result = RUN_ALL_TESTS();
++  } catch (...) {
++    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
++  }
++
++  return result;
++}
+diff --git a/test/unittest/unittest_cuda_quantize.cpp b/test/unittest/unittest_cuda_quantize.cpp
+index 42d1a9c289..b8f12a44b8 100644
+--- a/test/unittest/unittest_cuda_quantize.cpp
++++ b/test/unittest/unittest_cuda_quantize.cpp
+@@ -17,8 +17,10 @@
+ #include <random>
+ #include <vector>
+ 
++#if defined(ENABLE_OPENCL)
+ #include "blas_kernels.h"
+ #include "cl_context.h"
++#endif
+ #include "engine.h"
+ #include "fp16.h"
+ #include "ggml_cuda_common.h"
+@@ -376,7 +378,7 @@ run_int4_quantize_input_test_cuda_(const unsigned int M, const unsigned int K,
+   // CPU quantization
+   std::vector<int8_t> ref_quantized_input(M * K);
+   std::vector<uint16_t> ref_scales(total_groups * 2);
+-  nntrainer::cpu_quantize_input_int4_pad(
++  nntrainer::cpu_quantize_input_int8_pad(
+     input_host.data(), ref_quantized_input.data(), ref_scales.data(), M, K,
+     quantization_group_size);
+ 
+@@ -407,14 +409,14 @@ run_int4_quantize_input_test_cuda_(const unsigned int M, const unsigned int K,
+   for (int iter = 0; iter < 10; ++iter) {
+     if (iter == 0) {
+       // First iteration - no timing
+-      quantize_input_int4_pad_cuda(d_input, d_quantized_input, d_scales, M, K,
++      quantize_input_int8_pad_cuda(d_input, d_quantized_input, d_scales, M, K,
+                                    quantization_group_size, stream);
+       CUDA_CHECK(cudaStreamSynchronize(stream));
+     } else {
+       // Measured iterations
+       CUDA_CHECK(cudaEventRecord(start, stream));
+ 
+-      quantize_input_int4_pad_cuda(d_input, d_quantized_input, d_scales, M, K,
++      quantize_input_int8_pad_cuda(d_input, d_quantized_input, d_scales, M, K,
+                                    quantization_group_size, stream);
+ 
+       CUDA_CHECK(cudaEventRecord(stop, stream));
+@@ -587,14 +589,14 @@ TEST(nntrainer_CUDA_Quantize, int4_quantize_input_pad_cuda_performance) {
+   for (int iter = 0; iter < num_iterations; ++iter) {
+     if (iter == 0) {
+       // Warm-up iteration (not measured)
+-      quantize_input_int4_pad_cuda(d_input, d_quantized_input, d_scales, M, K,
++      quantize_input_int8_pad_cuda(d_input, d_quantized_input, d_scales, M, K,
+                                    quantization_group_size, stream);
+       CUDA_CHECK(cudaStreamSynchronize(stream));
+     } else {
+       // Measured iterations
+       CUDA_CHECK(cudaEventRecord(start, stream));
+ 
+-      quantize_input_int4_pad_cuda(d_input, d_quantized_input, d_scales, M, K,
++      quantize_input_int8_pad_cuda(d_input, d_quantized_input, d_scales, M, K,
+                                    quantization_group_size, stream);
+ 
+       CUDA_CHECK(cudaEventRecord(stop, stream));
+@@ -704,7 +706,7 @@ run_cuda_vs_openvino_quantize_test(const unsigned int M, const unsigned int K,
+   cudaStream_t stream;
+   CUDA_CHECK(cudaStreamCreate(&stream));
+ 
+-  quantize_input_int4_pad_cuda(d_input, d_quantized, d_scales, M, K,
++  quantize_input_int8_pad_cuda(d_input, d_quantized, d_scales, M, K,
+                                quantization_group_size, stream);
+   CUDA_CHECK(cudaStreamSynchronize(stream));
+ 
+diff --git a/test/unittest/unittest_gemm_nomacro_cl.cpp b/test/unittest/unittest_gemm_nomacro_cl.cpp
+new file mode 100644
+index 0000000000..36e160f67d
+--- /dev/null
++++ b/test/unittest/unittest_gemm_nomacro_cl.cpp
+@@ -0,0 +1,286 @@
++#include "gtest/gtest.h"
++
++#include "fallback_internal.h"
++#include "int4_utils.h"
++#include "nntrainer_test_util.h"
++#include "q4_0_utils.h"
++#include "swiglu_cl.h"
++#include "tensor_dim.h"
++#include "timer.h"
++#include <blas_kernel_interface.h>
++#include <blas_kernels.h>
++#include <cl_context.h>
++#include <cpu_backend.h>
++#include <fp16.h>
++#include <layer_context.h>
++#include <tensor.h>
++
++#include "unittest_util.h"
++
++using namespace nntrainer;
++
++static void run_int4_gemm_test_(const uint32_t M, const uint32_t K,
++                                const uint32_t N, const int scale_group_size,
++                                bool use_ones = false, bool print = false) {
++  auto *blas_cc = static_cast<nntrainer::ClContext *>(
++    nntrainer::Engine::Global().getRegisteredContext("gpu"));
++
++  const int INT4_BLOCK_N_SIZE = 32;
++  uint32_t alignN = align(N, INT4_BLOCK_N_SIZE);
++  uint32_t alignK = align(K, scale_group_size);
++
++  static constexpr uint32_t run_count = 200;
++
++  uint32_t input_size = M * alignK;
++
++  std::vector<float> input;
++  std::vector<float> weight_fp32;
++  if (use_ones) {
++    float ones_ratio = 0.1f;
++    if (M * N * K > 1000000) { // For large input/output decrease ones_ratio to
++                               // decrese results error
++      ones_ratio = 0.01f;
++    }
++    // input = generate_vector(input_size, 1.0f, 1.0f);
++    input = generate_01_vector(input_size, ones_ratio);
++    weight_fp32 = generate_01_vector(N * K, ones_ratio);
++  } else {
++    input = generate_random_vector<float, false>(input_size, -1.0, 1.0);
++    weight_fp32 = generate_random_vector<float, false>(N * K, -1.0, 1.0);
++    // input = generate_vector(input_size, -2.0f, 2.0f);
++    // weight_fp32 = generate_vector(N * K, -2.0f, 2.0f);
++  }
++
++  // Print input weights ones
++  if (print && use_ones) {
++    for (int x = 0; x < K; x++) {
++      for (int y = 0; y < N; y++) {
++        if (y % 10 == 0) {
++          printf("| ");
++        }
++        if (weight_fp32[y * K + x] > 0.1) {
++          printf("1 ");
++        } else {
++          printf("0 ");
++        }
++      }
++      printf("\n");
++    }
++  }
++
++  // Reference SGEMM
++  std::vector<float> ref_dst(M * N, 0.0f);
++  nntrainer::sgemm(0, false, true, M, N, K, 1.F, input.data(), K,
++                   weight_fp32.data(), K, 0.F, ref_dst.data(), N);
++
++  // Reference Q4_0 GEMV
++  if (K % Q4_0 == 0 && N % 8 == 0) {
++    size_t q4_data_size = K * N / Q4_0 * sizeof(block_q4_0);
++    std::vector<float> q4_output_fp32(M * N);
++    std::vector<uint8_t> q4_weight(q4_data_size);
++    std::vector<uint8_t> q4_weight_repack(q4_data_size);
++    nntrainer::quantize_q4_0(weight_fp32.data(), q4_weight.data(), N, K,
++                             nullptr);
++    nntrainer::repack_q4_0(q4_weight_repack.data(), q4_weight.data(),
++                           q4_data_size, N, K);
++    nntrainer::gemm_q4_0(M, N, K, input.data(), K, q4_weight_repack.data(), N,
++                         q4_output_fp32.data(), N);
++    float mse_q4 = mse<float>(ref_dst.data(), q4_output_fp32.data(), M * N);
++    std::cout << "MSE Q4_0: " << std::setprecision(10) << mse_q4 << std::endl;
++  }
++
++  // Int4 GEMM - THE MAIN TEST
++  uint16_t *input_ptr = (uint16_t *)allocateSVM(input_size * sizeof(uint16_t));
++  int8_t *weight_ptr = (int8_t *)allocateSVM(alignK * alignN / 2);
++  uint16_t *scale_ptr = (uint16_t *)allocateSVM(ceilDiv(K, scale_group_size) *
++                                                alignN * sizeof(uint16_t));
++  uint16_t *output_ptr = (uint16_t *)allocateSVM(M * alignN * sizeof(uint16_t));
++
++  blas_cc->command_queue_inst_.enqueueSVMMap(
++    input_ptr, input_size * sizeof(uint16_t), false);
++  blas_cc->command_queue_inst_.enqueueSVMMap(weight_ptr, alignK * alignN / 2,
++                                             false);
++  blas_cc->command_queue_inst_.enqueueSVMMap(
++    scale_ptr, ceilDiv(K, scale_group_size) * alignN * sizeof(uint16_t), false);
++
++  std::vector<uint8_t> quantized_weights;
++  std::vector<uint16_t> quantized_scales;
++  Int4Utils::quantizeAndRepack(weight_fp32.data(), N, K, scale_group_size,
++                               quantized_weights, quantized_scales);
++
++  for (unsigned int i = 0; i < input_size; ++i) {
++    input_ptr[i] = compute_fp32_to_fp16((input.data())[i]);
++  }
++
++  for (unsigned int i = 0; i < ceilDiv(K, scale_group_size) * alignN; ++i) {
++    scale_ptr[i] = quantized_scales[i];
++  }
++
++  for (unsigned int i = 0; i < alignN * align(K, scale_group_size) / 2; ++i) {
++    weight_ptr[i] = quantized_weights[i];
++  }
++
++  blas_cc->command_queue_inst_.enqueueSVMUnmap(input_ptr);
++  blas_cc->command_queue_inst_.enqueueSVMUnmap(weight_ptr);
++  blas_cc->command_queue_inst_.enqueueSVMUnmap(scale_ptr);
++  // GPU INT4 GEMM
++  auto t3 = std::chrono::high_resolution_clock::now();
++  for (unsigned int i = 0; i < run_count; ++i) {
++    nntrainer::openvino_gemm_cl_nomacro(input_ptr, weight_ptr, scale_ptr, output_ptr, M,
++                                N, K, scale_group_size);
++  }
++
++  auto t4 = std::chrono::high_resolution_clock::now();
++  auto gpu_dt =
++    std::chrono::duration_cast<std::chrono::milliseconds>(t4 - t3).count();
++
++  std::vector<float> output_fp32(M * N);
++  for (unsigned int i = 0; i < M * N; ++i) {
++    output_fp32[i] = compute_fp16_to_fp32(output_ptr[i]);
++  }
++
++  uint32_t first_zero_index = UINT32_MAX;
++  uint32_t first_nonzero_index = UINT32_MAX;
++  int zeros = 0;
++  int non_zeros = 0;
++  int nans = 0;
++
++  for (uint32_t i = 0; i < M * N; ++i) {
++    if (compute_fp16_to_fp32(output_ptr[i]) == 0) {
++      zeros++;
++      if (first_zero_index == UINT32_MAX) {
++        first_zero_index = i;
++      }
++    } else {
++      non_zeros++;
++      if (first_nonzero_index == UINT32_MAX) {
++        first_nonzero_index = i;
++      }
++    }
++
++    if (std::isnan(compute_fp16_to_fp32(output_ptr[i]))) {
++      nans++;
++    }
++  }
++
++  auto debug_print_beg_end = [M, K, N](const uint16_t *const data,
++                                       const uint32_t count = 6) {
++    std::cout << "[";
++    for (unsigned int i = 0; i < count; ++i) {
++      std::cout << compute_fp16_to_fp32(data[i]) << " ";
++    }
++    std::cout << "][";
++    for (unsigned int i = M * N - count; i < M * N; ++i) {
++      std::cout << compute_fp16_to_fp32(data[i]) << " ";
++    }
++    std::cout << "]";
++  };
++
++  auto debug_print_beg_end_float = [M, K, N](const float *const data,
++                                             const uint32_t count = 6) {
++    std::cout << "[";
++    for (unsigned int i = 0; i < count; ++i) {
++      std::cout << data[i] << " ";
++    }
++    std::cout << "][";
++    for (unsigned int i = M * N - count; i < M * N; ++i) {
++      std::cout << data[i] << " ";
++    }
++    std::cout << "]";
++  };
++
++  std::cout << "INT4 GEMM : M:" << M << " x K:" << K << " x N:" << N
++            << std::endl;
++  std::cout << " - time : GPU = " << gpu_dt / (run_count * 1.0f) << " ms"
++            << std::endl;
++
++  std::vector<float> diff(M * N);
++  float maxDiff = 0;
++  for (int i = 0; i < M * N; i++) {
++    diff[i] = ref_dst[i] - output_fp32[i];
++    if (abs(diff[i]) > maxDiff) {
++      maxDiff = diff[i];
++    }
++  }
++
++  if (print) {
++    if (use_ones) {
++      printMatrixI("REF ", ref_dst.data(), M, N);
++      printMatrixI("INT4", output_fp32.data(), M, N);
++      printMatrixI("DIFF", diff.data(), M, N);
++    } else {
++      std::cout << " - sample: REF = ";
++      debug_print_beg_end_float(ref_dst.data(), 16);
++      std::cout << std::endl;
++      std::cout << " - sample : GPU = ";
++      debug_print_beg_end(output_ptr, 16);
++      std::cout << std::endl;
++
++      std::cout << " - zeros : " << zeros << " / " << M * N << " [ "
++                << zeros * 100.0f / float(M * N) << " %] - first at [ "
++                << first_zero_index << " ]" << std::endl;
++      std::cout << " - non zeros : " << non_zeros << " / " << M * N << " [ "
++                << non_zeros * 100.0f / float(M * N) << " %] - first at [ "
++                << first_nonzero_index << " ]" << std::endl;
++      std::cout << " - nans : " << nans << " / " << M * N << " [ "
++                << nans * 100.0f / float(M * N) << " %]" << std::endl;
++    }
++  }
++  printf("maxDiff:%f\n", maxDiff);
++
++  float mse_int4_err = mse<float>(ref_dst.data(), output_fp32.data(), M * N);
++  std::cout << "MSE int4: " << mse_int4_err << std::endl;
++
++  if (use_ones) {
++    EXPECT_IN_RANGE(mse_int4_err, 0.0f, 0.0001f);
++  }
++
++  freeSVM(weight_ptr);
++  freeSVM(scale_ptr);
++  freeSVM(input_ptr);
++  freeSVM(output_ptr);
++}
++
++#define DECLARE_int4_gemm_test_M_K_N(M, K, N, G)                               \
++  TEST(nntrainer_blas_kernel, int4_gemm_nomacro_test_##M##_##K##_##N##_Group##G) {     \
++    run_int4_gemm_test_(M, K, N, G);                                           \
++  }
++
++DECLARE_int4_gemm_test_M_K_N(28, 3072, 256, 32);
++DECLARE_int4_gemm_test_M_K_N(28, 3072, 8192, 32);
++DECLARE_int4_gemm_test_M_K_N(28, 8192, 3072, 32);
++DECLARE_int4_gemm_test_M_K_N(28, 3072, 3072, 32);
++
++DECLARE_int4_gemm_test_M_K_N(28, 3072, 256, 128);
++DECLARE_int4_gemm_test_M_K_N(28, 3072, 8192, 128);
++DECLARE_int4_gemm_test_M_K_N(28, 8192, 3072, 128);
++DECLARE_int4_gemm_test_M_K_N(28, 3072, 3072, 128);
++
++DECLARE_int4_gemm_test_M_K_N(28, 32, 3072, 32);
++DECLARE_int4_gemm_test_M_K_N(28, 64, 3072, 32);
++
++DECLARE_int4_gemm_test_M_K_N(28, 3000, 3072, 128);
++DECLARE_int4_gemm_test_M_K_N(28, 2000, 3072, 128);
++
++DECLARE_int4_gemm_test_M_K_N(4, 3060, 3072, 32);
++DECLARE_int4_gemm_test_M_K_N(4, 3072, 3072, 32);
++
++
++GTEST_API_ int main(int argc, char **argv) {
++  int result = -1;
++
++  try {
++    testing::InitGoogleTest(&argc, argv);
++  } catch (...) {
++    std::cerr << "Error during InitGoogleTest" << std::endl;
++    return 0;
++  }
++
++  try {
++    result = RUN_ALL_TESTS();
++  } catch (...) {
++    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
++  }
++
++  return result;
++}
+diff --git a/test/unittest/unittest_quantize_cl.cpp b/test/unittest/unittest_quantize_cl.cpp
+index 75952b7f6b..74cdc58d9a 100644
+--- a/test/unittest/unittest_quantize_cl.cpp
++++ b/test/unittest/unittest_quantize_cl.cpp
+@@ -62,7 +62,7 @@ static void run_int4_quantize_input_test_(const uint32_t M, const uint32_t K,
+   std::vector<int8_t> ref_quantized_input(M * K);
+   // Ref scales size is doubled
+   std::vector<uint16_t> ref_scales(M * K / scale_group_size * 2);
+-  cpu_quantize_input_int4_pad(input.data(), ref_quantized_input.data(),
++  cpu_quantize_input_int8_pad(input.data(), ref_quantized_input.data(),
+                               ref_scales.data(), M, K, scale_group_size);
+ 
+   // GPU INT4 input quantization
+diff --git a/test/unittest/unittest_util.cpp b/test/unittest/unittest_util.cpp
+index a72ec85c09..c69f402eee 100644
+--- a/test/unittest/unittest_util.cpp
++++ b/test/unittest/unittest_util.cpp
+@@ -1,10 +1,23 @@
++// SPDX-License-Identifier: Apache-2.0
++/**
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file   unittest_util.cpp
++ * @brief  Shared utility functions for unit tests
++ * @author Samsung Electronics Co., Ltd.
++ * @bug    No known bugs except for NYI items
++ *
++ */
++
+ #include "unittest_util.h"
++#if defined(ENABLE_OPENCL)
+ #include <cl_context.h>
++#endif
+ #include <engine.h>
+ #include <fp16.h>
+ 
+ namespace nntrainer {
+-
++#if defined(ENABLE_OPENCL)
+ void *allocateSVM(size_t size_bytes) {
+   auto *blas_cc =
+     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+@@ -20,7 +33,7 @@ void freeSVM(void *ptr) {
+     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+   blas_cc->context_inst_.releaseSVMRegion(ptr);
+ }
+-
++#endif
+ int8_t round_half_to_even(float x) {
+   float r = roundf(x);
+   float d = r - x;
+@@ -32,7 +45,7 @@ int8_t round_half_to_even(float x) {
+   return (int8_t)((ir % 2 == 0) ? ir : ir - (ir > 0 ? 1 : -1));
+ }
+ 
+-void cpu_quantize_input_int4_pad(float *input, int8_t *quantized_input,
++void cpu_quantize_input_int8_pad(float *input, int8_t *quantized_input,
+                                  uint16_t *scales, unsigned int M,
+                                  unsigned int K,
+                                  unsigned int quantization_group_size) {
+@@ -100,4 +113,65 @@ void cpu_quantize_input_int4_pad(float *input, int8_t *quantized_input,
+   }
+ }
+ 
++void printMatrixI(const char *name, float *data, int Y, int X) {
++  printf("%s :\n", name);
++  for (int y = 0; y < Y; y++) {
++    // printf("[");
++    for (int x = 0; x < X; x++) {
++      if (x % 10 == 0) {
++        printf("| ");
++      }
++      std::cout << (int)(0.5f + data[y * X + x]) << " ";
++    }
++    printf("\n");
++  }
++}
++
++std::vector<float> generate_vector(const size_t size, float min_val,
++                                   float max_val) {
++  const float step = (max_val - min_val) / (float)size;
++  float current_value = min_val;
++  std::vector<float> vec(size, 0.0f);
++
++  for (int i = 0; i < vec.size(); ++i) {
++    vec[i] = current_value;
++    current_value += step;
++  }
++
++  return vec;
++}
++
++std::vector<float> generate_01_vector(const size_t size,
++                                      const float ones_ratio) {
++  std::random_device rd;
++  std::mt19937 gen(rd());
++  std::uniform_real_distribution<float> dist(0.0f, (float)size);
++  if (ones_ratio >= 1.0) {
++    std::vector<float> vec(size, 1.0f);
++    return vec;
++  } else {
++    std::vector<float> vec(size, 0.0f);
++    size_t ones_cnt = (size_t)(size * ones_ratio);
++    for (size_t i = 0; i < ones_cnt; i++) {
++      int pos = static_cast<int>(dist(gen));
++      vec[pos] = 1.0f;
++    }
++    return vec;
++  }
++}
++
++void gemm_fp32_ref(const float *input, const float *weights, float *output,
++                   unsigned int M, unsigned int N, unsigned int K) {
++  for (unsigned int m = 0; m < M; ++m) {
++    for (unsigned int n = 0; n < N; ++n) {
++      float sum = 0.0f;
++      for (unsigned int k = 0; k < K; ++k) {
++        sum += input[m * K + k] *
++               weights[k * N + n]; // Assuming KxN weights (row-major)
++      }
++      output[m * N + n] = sum;
++    }
++  }
++}
++
+ } // namespace nntrainer
+diff --git a/test/unittest/unittest_util.h b/test/unittest/unittest_util.h
+index 0b9a4319ca..f9819d2640 100644
+--- a/test/unittest/unittest_util.h
++++ b/test/unittest/unittest_util.h
+@@ -1,7 +1,12 @@
+ // SPDX-License-Identifier: Apache-2.0
+ /**
+- * @file unittest_util.h
+- * @brief Shared utility functions for unit tests.
++ * Copyright (C) 2025 Samsung Electronics Co., Ltd. All Rights Reserved.
++ *
++ * @file   unittest_util.h
++ * @brief  Shared utility functions for unit tests
++ * @author Samsung Electronics Co., Ltd.
++ * @bug    No known bugs except for NYI items
++ *
+  */
+ 
+ #ifndef NNTRAINER_UNITTEST_UTIL_H
+@@ -11,6 +16,10 @@
+ #include <random>
+ #include <vector>
+ 
++#define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
++  EXPECT_GE((VAL), (MIN));                                                     \
++  EXPECT_LE((VAL), (MAX))
++
+ namespace nntrainer {
+ 
+ // Generate a random vector of given size and range.
+@@ -30,22 +39,38 @@ std::vector<T> generate_random_vector(size_t size, float min_val = -1.F,
+   }
+   return vec;
+ }
+-
++#if defined(ENABLE_OPENCL)
+ // Allocate SVM memory using the OpenCL context.
+ void *allocateSVM(size_t size_bytes);
+ 
+ // Release SVM memory.
+ void freeSVM(void *ptr);
+-
++#endif
+ // Helper for Round to Nearest Even (RTE)
+ int8_t round_half_to_even(float x);
+ 
+ // CPU reference implementation for INT4 quantization
+-void cpu_quantize_input_int4_pad(float *input, int8_t *quantized_input,
++void cpu_quantize_input_int8_pad(float *input, int8_t *quantized_input,
+                                  uint16_t *scales, unsigned int M,
+                                  unsigned int K,
+                                  unsigned int quantization_group_size);
+ 
++void printMatrixI(const char *name, float *data, int Y, int X);
++
++std::vector<float> generate_vector(const size_t size, float min_val,
++                                   float max_val);
++
++std::vector<float> generate_01_vector(const size_t size,
++                                      const float ones_ratio);
++
++// Standard FP32 GEMM for Reference
++// C = A * B
++// A: M x K
++// B: K x N
++// C: M x N
++void gemm_fp32_ref(const float *input, const float *weights, float *output,
++                   unsigned int M, unsigned int N, unsigned int K);
++
+ } // namespace nntrainer
+ 
+ #endif // NNTRAINER_UNITTEST_UTIL_H
+
+From 7577eae2a2b3a21f9e8ffa1d92bcbfb2b167af2d Mon Sep 17 00:00:00 2001
+From: Daekyoung Jung <dk11.jung@samsung.com>
+Date: Fri, 12 Dec 2025 09:44:18 +0900
+Subject: [PATCH 9/9] Refactor CUDA memory management and fix unit tests
+
+- Introduce `CudaContextManager` and `CudaBufferManager` to encapsulate
+  CUDA context and buffer operations.
+- Integrate `CudaContext` retrieval in `MemoryPool` for robust device
+  memory allocation and dealloc, addressing potential SEH exceptions.
+- Update `unittest_memory_planner` to support CUDA execution paths,
+  ensuring proper memory initialization and verification using
+  `cudaMemset` and `cudaMemcpy` when `ENABLE_CUDA` is active.
+- Register `CudaContext` within the `Engine` to ensure availability
+  during memory operations.
+
+Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>
+---
+ nntrainer-windows-resource | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/nntrainer-windows-resource b/nntrainer-windows-resource
+index cacf4d37bd..15e34cf53a 160000
+--- a/nntrainer-windows-resource
++++ b/nntrainer-windows-resource
+@@ -1 +1 @@
+-Subproject commit cacf4d37bd5ba89f1bf606989c4a870f5254739c
++Subproject commit 15e34cf53a6ab8d30f26e1e108a415b51062ee4c


### PR DESCRIPTION
## Dependency of the PR

This PR introduces initial CUDA support and related operations. It depends on the CUDA toolkit being available for compilation when the `enable-cuda` option is set.

## Commits to be reviewed in this PR

<details><summary>fd48dca6700c6848783521257e7258b98d171a38</summary><br />

Add CUDA context support with build configuration

Adds CUDA context management files (cuda_context.h
and cuda_context.cpp) that provide similar
functionality to the existing OpenCL context.

The changes include:

- CudaContext class inheriting from Context and Singleton
- CUDA kernel management and execution interfaces
- Build system updates to support CUDA with enable-cuda option
- Conditional linking of CUDA runtime library for both Windows and Linux
- Addition of enable-cuda option in meson_options.txt

**Self evaluation:**
1. Build test: [X]Passed
2. Run test: [X]Passed

Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>

</details>

<details><summary>42922deae71bb4992cf75e49324dca2b336b60c9</summary><br />

Add CUDA context support and build configuration

This commit adds CUDA context management files (cuda_context.h and cuda_context.cpp)
that provide similar functionality to the existing OpenCL context.

The changes include:

- Implementation of CudaContext class inheriting from Context and Singleton
- CUDA kernel management and execution interface
- Build system updates to support CUDA with enable-cuda meson_options
- Conditional linking of CUDA runtime library for both Windows and Linux
- Addition of enable-cuda option in meson_options.txt
- Implementation of RMSNorm CUDA kernel and build configuration

**Self evaluation:**
1. Build test: [X]Passed
2. Run test: [X]Passed

Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>

</details>

<details><summary>078308c94c0cb38d49e5f831b0e3064c8c25f55e</summary><br />

Add CUDA unit test and fix CUDA build configuration

This commit includes the following changes:
1. Add new CUDA unit test file (unittest_cuda.cpp) with RMSNorm CUDA kernel
   tests
2. Reorganize CUDA operations directory structure by moving subdir inclusion
   from nntrainer/meson.build to nntrainer/tensor/meson.build
3. Add CUDA test target in test/unittest/meson.build
4. Fix CUDA linking issues by adding proper link arguments (-NOIMPLIB, -NOEXP)
   to prevent generation of unnecessary .lib and .exp files
5. Add CUDA dependencies handling in unit test build configuration

The changes ensure proper CUDA support in the build system and add
comprehensive unit tests for CUDA operations.

**Self evaluation:**
1. Build test: [X]Passed
2. Run test: [X]Passed

Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>

</details>

<details><summary>e85b08165b2253e114c4996bb3e5876a56724ef1</summary><br />

Add CUDA addition operations and interface

This commit introduces CUDA support for addition operations:

1. Added new CUDA files:
   - `nntrainer/tensor/cuda_operations/addition_cuda.cu`: Implementation
     of CUDA addition kernel
   - `nntrainer/tensor/cuda_operations/addition_cuda.h`: Header for CUDA
     addition functions
   - `nntrainer/tensor/cuda_operations/cuda_interface.cpp`: Implementation
     of CUDA interface functions
   - `nntrainer/tensor/cuda_operations/cuda_interface.h`: Header for CUDA
     interface

2. Updated build configuration:
   - Modified meson.build to include new CUDA files in the build
   - Updated test/unittest/meson.build to add unittest_cuda_addition target

3. Added unit test:
   - `test/unittest/unittest_cuda_addition.cpp`: Unit test for CUDA addition
     operations with timing measurements

The new implementation provides:
- CUDA kernel for element-wise addition operations
- CUDA interface functions for tensor operations
- Comprehensive unit test with performance timing

**Self evaluation:**
1. Build test: [X]Passed
2. Run test: [X]Passed

Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>

</details>

<details><summary>1de3b605c6ab3e95b79325c516c268dac677092c</summary><br />

Apply clang-format and add GGML Q8_1 quantization

- Format all CUDA files in nntrainer/tensor/cuda_operations with clang-format
- Add GGML Q8_1 quantization/dequantization implementation for CUDA
- Include CPU fallback functions for quantization operations
- Add unit tests for CUDA Q8_1 quantization functionality
- Update meson build files to include new CUDA operations

**Self evaluation:**
1. Build test: [X]Passed
2. Run test: [X]Passed

Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>

</details>

<details><summary>d28ce7f3d12a7355320e97fea621334e94f91746</summary><br />

test: refactor quantize unit tests to separate file

- Move int4 quantization test from unittest_blas_kernels_cl.cpp to
  new unittest_quantize_cl.cpp for better organization
- Create shared test utilities (unittest_util.h/cpp) with:
  * generate_random_vector template function
  * allocateSVM/freeSVM helper functions
- Add unittest_util.cpp to OpenCL test targets in meson.build
- Update blas_kernels to support shared test utilities
- Add CUDA int4 GEMM kernel implementation (gemm_int4_cuda.cu/h)
- Update GGML quantization headers and implementations

**Self evaluation:**
1. Build test: [X]Passed
2. Run test: [X]Passed

Signed-off-by: Daekyoung Jung <dk11.jung@samsung.com>

</details>

### Summary

- **Initial CUDA Integration**: This PR introduces core CUDA context management, RMSNorm, and element-wise addition operations, along with their respective build configurations and unit tests.
- **GGML Q8_1 Quantization**: Adds support for GGML Q8_1 quantization and dequantization, including both CUDA kernels and CPU fallback implementations, with dedicated unit tests.
- **Test Refactoring**: Refactors quantization unit tests and introduces shared test utilities for better organization and reusability.
- **Identified Issues**:
    - **Misleading PR Title**: The PR title and the original PR's final commit message (as identified in the review) are misleading, as the changes primarily focus on adding CUDA operations and context, not refactoring existing memory management.
    - **Build Regressions**: Windows builds fail due to `meson.build` not adapting to new submodule layout (`x64/OpenBLAS`). CUDA unit test linking options are Windows-specific but applied unconditionally, breaking Linux builds. `nntrainer/engine.cpp` is missing `cuda_context.h` include when CUDA is enabled.
    - **Logical Bugs**: CPU INT4 GEMM implementation lacks proper input constraint checks and tail handling. INT8 quantization (both CPU and CUDA) lacks clamping, potentially leading to overflow.
    - **Performance Concerns**: Test utilities use non-deterministic and potentially slow RNG seeding. Reference GEMM implementation is a pure O(MNK) triple loop, which can be inefficient for large test cases.
    - **Style Violations**: Doxygen header missing in `test/unittest/unittest_gemm_nomacro_cl.cpp` and multiple `clang-format` violations were detected.
    - **API Inconsistencies**: Comments in `nntrainer/tensor/cuda_operations/ggml_quantize_cuda.h` describe FP16->INT4 quantization, but the implementation performs FP32/FP16->INT8.

Signed-off-by: AI Assistant <assistant@example.com>

---
<a href="https://cursor.com/background-agent?bcId=bc-b70237af-efe1-4ec1-a995-e88a4542cffd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b70237af-efe1-4ec1-a995-e88a4542cffd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

