### PR TITLE
opencl_buffer: WriteDataRegion bound check fix

### DIFF
--- a/nntrainer/opencl/opencl_buffer.cpp
+++ b/nntrainer/opencl/opencl_buffer.cpp
@@ -103,10 +103,10 @@ bool Buffer::WriteDataRegion(CommandQueueManager &command_queue_inst,
                              size_t size_in_bytes, const void *data,
                              size_t host_origin_offset,
                              size_t buffer_origin_offset) {
-  if (size_in_bytes > size_) {
-    ml_loge("Failed to write buffer region. Region size(%d bytes) greater "
-            "than buffer size(%d bytes).",
-            (int)size_in_bytes, (int)size_);
+  if (size_in_bytes + buffer_origin_offset > size_) {
+    ml_loge("Failed to write buffer region. Region size(%zu bytes) + offet"
+            "(%zu bytes) greater than buffer size(%zu bytes).",
+            size_in_bytes, buffer_origin_offset, size_);
     return false;
   }
   return command_queue_inst.EnqueueWriteBufferRegion(
@@ -128,10 +128,10 @@ bool Buffer::ReadDataRegion(CommandQueueManager &command_queue_inst,
                             size_t size_in_bytes, void *data,
                             size_t host_origin_offset,
                             size_t buffer_origin_offset) {
-  if (size_in_bytes > size_) {
-    ml_loge("Failed to read from buffer region. Region size(%d bytes) greater "
-            "than buffer size(%d bytes).",
-            (int)size_in_bytes, (int)size_);
+  if (size_in_bytes + buffer_origin_offset > size_) {
+    ml_loge("Failed to read buffer region. Region size(%zu bytes) + offet"
+            "(%zu bytes) greater than buffer size(%zu bytes).",
+            size_in_bytes, buffer_origin_offset, size_);
     return false;
   }
   return command_queue_inst.EnqueueReadBufferRegion(


### PR DESCRIPTION
1. The bound check is not counting the offset.
2. Don't cast size_t to int.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Buffer read/write region bound checks to account for `buffer_origin_offset` and uses `%zu` for size_t in error logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 114171dc02d7e65a889ef170d497ae4721228d6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->