### PR TITLE
[Wait for #3610] [CausalLM] delete copy from cached layers 

### DIFF
--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.h
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.h
@@ -43,13 +43,13 @@ public:
    * @brief  Move constructor.
    *  @param[in] CachedSlimGptOssMoELayer &&
    */
-  CachedSlimGptOssMoELayer(CachedSlimGptOssMoELayer &&rhs) noexcept = default;
+  CachedSlimGptOssMoELayer(CachedSlimGptOssMoELayer &&rhs) = delete;
 
   /**
    * @brief  Move assignment operator.
    * @param[in] rhs CachedSlimGptOssMoELayer to be moved.
    */
-  CachedSlimGptOssMoELayer &operator=(CachedSlimGptOssMoELayer &&rhs) = default;
+  CachedSlimGptOssMoELayer &operator=(CachedSlimGptOssMoELayer &&rhs) = delete;
 
   /**
    * @copydoc Layer::finalize(InitLayerContext &context)

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
@@ -48,13 +48,13 @@ public:
    * @brief  Move constructor.
    *  @param[in] CachedSlimMoELayer &&
    */
-  CachedSlimMoELayer(CachedSlimMoELayer &&rhs) noexcept = default;
+  CachedSlimMoELayer(CachedSlimMoELayer &&rhs) = delete;
 
   /**
    * @brief  Move assignment operator.
    * @param[in] rhs CachedSlimMoELayer to be moved.
    */
-  CachedSlimMoELayer &operator=(CachedSlimMoELayer &&rhs) = default;
+  CachedSlimMoELayer &operator=(CachedSlimMoELayer &&rhs) = delete;
 
   /**
    * @copydoc Layer::finalize(InitLayerContext &context)


### PR DESCRIPTION
## Dependency of the PR

#3610 

## Commits to be reviewed in this PR


<details><summary> [CausalLM] delete copy from cached layers </summary><br />

- The *cached layers have mutex, so it is desirable to delete move and
  copy opdrator.
- delete `copy` operators from cached layers


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


### Summary

- remove `copy` operators from cached layers, for it cannot support `move` for mutex.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
