### PR TITLE
Update Windows Daily Build Script

### DIFF
--- a/.github/workflows/daily_build_windows_arm.yml
+++ b/.github/workflows/daily_build_windows_arm.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           architecture: arm64
       - name: Prepare Build
-        run: meson setup --native-file windows-native.ini -Denable-blas=false builddir
+        run: meson setup --native-file configurations/windows-native-clang.ini builddir
       - name: Run Build
         run: meson compile -C builddir
       - name: Run Test Suite

--- a/.github/workflows/daily_build_windows_x86_64.yml
+++ b/.github/workflows/daily_build_windows_x86_64.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           architecture: x64
       - name: Prepare Build
-        run: meson setup --native-file windows-native.ini builddir
+        run: meson setup --native-file configurations/windows-native.ini builddir
       - name: Run Build
         run: meson compile -C builddir
       - name: Run Test Suite


### PR DESCRIPTION
This PR updates the Windows daily build script.
The native files were moved to the configuration directory in #3612; therefore, an update is needed.

**Self-evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test:   [ ]Passed [ ]Failed [X]Skipped
