### PR TITLE
[trivial] fix CausalLM build error

### DIFF
--- a/Applications/CausalLM/layers/rms_norm.h
+++ b/Applications/CausalLM/layers/rms_norm.h
@@ -43,7 +43,7 @@ public:
    * @brief Construct a new custom RMS normalization layer object
    *
    */
-  WIN_EXPORT RMSNormLayer() : Layer(), wt_idx:{0} {}
+  WIN_EXPORT RMSNormLayer() : Layer(), wt_idx({0}) {}
 
   /**
    * @brief Destroy the custom RMS normalization layer object


### PR DESCRIPTION
There is a typo error, and it causes an build error for CausalLM.

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>