### PR TITLE
[trivial] fix unittest error when tf_lite option is disabled

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -62,10 +62,8 @@ if get_option('enable-nnstreamer-tensor-filter').enabled() and nnstreamer_test_d
   subdir('nnstreamer')
 endif
 
-if get_option('enable-tflite-interpreter') or get_option('enable-nnstreamer-tensor-filter').enabled()
-  run_command(['cp','-lr',
-    meson.current_source_dir() / 'test_models/',
-    nntrainer_test_resdir],
-    check: true
-  )
-endif
+run_command(['cp','-lr',
+  meson.current_source_dir() / 'test_models/',
+  nntrainer_test_resdir],
+  check: true
+)


### PR DESCRIPTION
When the TFLite option and nnstreamer-tensor-filter option are disabled, the test_models directory is not copied to build directory. 

However, since these files are also used in INI interpreter unit tests, running unittest results in an error when we set these options disabled. So I modified it always to copy that directory.

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>