### PR TITLE
CI Test

### DIFF
--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -154,6 +154,7 @@ BuildRequires:	nnstreamer-devel
 %if 0%{tizen_version_major}%{tizen_version_minor} > 60
 BuildRequires:	nnstreamer-test-devel
 %endif
+
 BuildRequires:	gst-plugins-good-extra
 BuildRequires:	python
 %endif # unit_test


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CI/Fix] runnervmdwttx failed fix</summary><br />

- while preparing libgstimagfreeze.so from install of gst-plugins-good-extra, it conflicts with gst-plugins-good
- This patch aims to resolve the issue

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: {your_name} <{your_email}>

</details>


### Summary

- Test for CI fix

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
