### PR TITLE
[Transformer] add `model_type` to `nntr_cfg` and implement feature to validate the model_type matching

### DIFF
--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -38,7 +38,7 @@
 namespace causallm {
 
 CausalLM::CausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
-  Transformer(cfg, generation_cfg, nntr_cfg) {
+  Transformer(cfg, generation_cfg, nntr_cfg, ModelType::CAUSAL_LM) {
   setupParameters(cfg, generation_cfg, nntr_cfg);
 }
 

--- a/Applications/CausalLM/models/gpt_oss/gptoss_causallm.h
+++ b/Applications/CausalLM/models/gpt_oss/gptoss_causallm.h
@@ -26,7 +26,7 @@ public:
   static constexpr const char *architectures = "GptOssForCausalLM";
 
   GptOssForCausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
-    Transformer(cfg, generation_cfg, nntr_cfg),
+    Transformer(cfg, generation_cfg, nntr_cfg, ModelType::CAUSAL_LM),
     CausalLM(cfg, generation_cfg, nntr_cfg) {
     setupParameters(cfg, generation_cfg, nntr_cfg);
   }

--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gptoss_cached_slim_causallm.h
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gptoss_cached_slim_causallm.h
@@ -26,7 +26,7 @@ public:
   static constexpr const char *architectures = "GptOssCachedSlimCausalLM";
 
   GptOssCachedSlimCausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
-    Transformer(cfg, generation_cfg, nntr_cfg),
+    Transformer(cfg, generation_cfg, nntr_cfg, ModelType::CAUSAL_LM),
     CausalLM(cfg, generation_cfg, nntr_cfg) {
     setupParameters(cfg, generation_cfg, nntr_cfg);
   }

--- a/Applications/CausalLM/models/qwen3/qwen3_causallm.h
+++ b/Applications/CausalLM/models/qwen3/qwen3_causallm.h
@@ -48,7 +48,7 @@ public:
   static constexpr const char *architectures = "Qwen3ForCausalLM";
 
   Qwen3CausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
-    Transformer(cfg, generation_cfg, nntr_cfg),
+    Transformer(cfg, generation_cfg, nntr_cfg, ModelType::CAUSAL_LM),
     CausalLM(cfg, generation_cfg, nntr_cfg),
     Qwen3Transformer(cfg, generation_cfg, nntr_cfg) {}
 

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen3_cached_slim_moe_causallm.h
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen3_cached_slim_moe_causallm.h
@@ -28,7 +28,7 @@ public:
   static constexpr const char *architectures = "Qwen3CachedSlimMoeForCausalLM";
 
   Qwen3CachedSlimMoECausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
-    Transformer(cfg, generation_cfg, nntr_cfg),
+    Transformer(cfg, generation_cfg, nntr_cfg, ModelType::CAUSAL_LM),
     Qwen3CausalLM(cfg, generation_cfg, nntr_cfg) {
     setupParameters(cfg, generation_cfg, nntr_cfg);
   }

--- a/Applications/CausalLM/models/qwen3_moe/qwen3_moe_causallm.h
+++ b/Applications/CausalLM/models/qwen3_moe/qwen3_moe_causallm.h
@@ -28,7 +28,7 @@ public:
   static constexpr const char *architectures = "Qwen3MoeForCausalLM";
 
   Qwen3MoECausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
-    Transformer(cfg, generation_cfg, nntr_cfg),
+    Transformer(cfg, generation_cfg, nntr_cfg, ModelType::CAUSAL_LM),
     Qwen3CausalLM(cfg, generation_cfg, nntr_cfg) {
     setupParameters(cfg, generation_cfg, nntr_cfg);
   }

--- a/Applications/CausalLM/models/qwen3_slim_moe/qwen3_slim_moe_causallm.h
+++ b/Applications/CausalLM/models/qwen3_slim_moe/qwen3_slim_moe_causallm.h
@@ -28,7 +28,7 @@ public:
   static constexpr const char *architectures = "Qwen3SlimMoeForCausalLM";
 
   Qwen3SlimMoECausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
-    Transformer(cfg, generation_cfg, nntr_cfg),
+    Transformer(cfg, generation_cfg, nntr_cfg, ModelType::CAUSAL_LM),
     Qwen3CausalLM(cfg, generation_cfg, nntr_cfg) {
     setupParameters(cfg, generation_cfg, nntr_cfg);
   }

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -43,7 +43,35 @@ std::string LoadBytesFromFile(const std::string &path) {
   return buffer;
 }
 
-Transformer::Transformer(json &cfg, json &generation_cfg, json &nntr_cfg) {
+static ModelType strToModelType(const std::string &model_type) {
+
+  static const std::unordered_map<std::string, ModelType> model_type_map = {
+    {"Model", ModelType::MODEL},
+    {"CausalLM", ModelType::CAUSAL_LM},
+    {"Embedding", ModelType::EMBEDDING}};
+
+  if (model_type_map.find(model_type) == model_type_map.end()) {
+    return ModelType::UNKNOWN;
+  }
+
+  return model_type_map.at(model_type);
+}
+
+Transformer::Transformer(json &cfg, json &generation_cfg, json &nntr_cfg,
+                         ModelType model_type) {
+
+  std::string config_model_type_str = "Model";
+  if (nntr_cfg.contains("model_type")) {
+    config_model_type_str = nntr_cfg["model_type"].get<std::string>();
+  }
+
+  ModelType config_model_type = strToModelType(config_model_type_str);
+
+  if (model_type != config_model_type) {
+    throw std::runtime_error("model_type mismatch. Class Type: " +
+                             std::to_string(static_cast<int>(model_type)) +
+                             ", Config Type: " + config_model_type_str);
+  }
 
   // Initialize the model with the provided configurations
   // This is where you would set up the model layers, parameters, etc.

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -54,6 +54,11 @@ using ModelHandle = std::unique_ptr<ml::train::Model>;
 using json = nlohmann::json;
 
 /**
+ * @brief Model Type Enum
+ */
+enum class ModelType { MODEL, CAUSAL_LM, EMBEDDING, UNKNOWN };
+
+/**
  * @brief Transformer Class
  */
 WIN_EXPORT class Transformer {
@@ -64,8 +69,10 @@ public:
    * @param cfg Configuration for the model (config.json)
    * @param generation_cfg Configuration for the generation (generation.json)
    * @param nntr_cfg Configuration for nntrainer (nntrainer_config.json)
+   * @param model_type Type of the model (default: ModelType::MODEL)
    */
-  Transformer(json &cfg, json &generation_cfg, json &nntr_cfg);
+  Transformer(json &cfg, json &generation_cfg, json &nntr_cfg,
+              ModelType model_type = ModelType::MODEL);
 
   /**
    * @brief Destroy the Transformer object

--- a/Applications/CausalLM/res/gpt-oss-20b/nntr_config.json
+++ b/Applications/CausalLM/res/gpt-oss-20b/nntr_config.json
@@ -1,4 +1,5 @@
 {
+    "model_type": "CausalLM",
     "model_tensor_type": "FP32-FP32",
     "model_file_name": "nntr_gpt_oss_20b.bin",
 

--- a/Applications/CausalLM/res/qwen3-30b-a3b-slim-cached/nntr_config.json
+++ b/Applications/CausalLM/res/qwen3-30b-a3b-slim-cached/nntr_config.json
@@ -1,4 +1,5 @@
 {
+    "model_type": "CausalLM",
     "model_tensor_type": "Q4_0-FP32",
     "model_file_name": "qwen3-30b-moe-q6k-q40-q40-fp32-x86.bin",
 

--- a/Applications/CausalLM/res/qwen3-30b-a3b/nntr_config.json
+++ b/Applications/CausalLM/res/qwen3-30b-a3b/nntr_config.json
@@ -1,4 +1,5 @@
 {
+    "model_type": "CausalLM",
     "model_tensor_type": "Q4_0-FP32",
     "model_file_name": "nntr_qwen3-30b-moe-q40-fp32-x86.bin",
 

--- a/Applications/CausalLM/res/qwen3-4b/nntr_config.json
+++ b/Applications/CausalLM/res/qwen3-4b/nntr_config.json
@@ -1,4 +1,5 @@
 {
+    "model_type": "CausalLM",
     "model_tensor_type": "FP32-FP32",
     "model_file_name": "nntr_qwen3_4b_fp32.bin",
 


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[Transformer] add model_type to nntr_cfg</summary><br />

- This commit adds model_type to nntr_cfg.
- This commit defines model types supported in the transformer
- This commit validates the model type matches with the user's model

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


### Summary
See also #3674 
This PR resolves #3675 

- This PR adds the model type to nntr_cfg.
- Since the type of configuration files required varies depending on the model_type, we need to add a field to detect the model type and ensure it matches the corresponding model class.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>