### PR TITLE
[Tensor] implement normalization_i(axis, p, epsilon)

### DIFF
--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -356,6 +356,12 @@ public:
   float l2norm() const override;
 
   /**
+   * @copydoc Tensor::normalization_i
+   */
+  void normalization_i(unsigned int dim, float p = 2.0,
+                       float epsilon = 1e-12) override;
+
+  /**
    * @copydoc Tensor::pow(float exponent, Tensor &output)
    */
   Tensor &pow(float exponent, Tensor &output) const override;

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -957,6 +957,10 @@ void Tensor::normalization_i() {
   }
 }
 
+void Tensor::normalization_i(unsigned int dim, float p, float epsilon) {
+  itensor_->normalization_i(dim, p, epsilon);
+}
+
 void Tensor::standardization_i() {
   Tensor mean_by_batch = this->sum_by_batch();
   mean_by_batch.divide_i(static_cast<float>(getDim().getFeatureLen()));

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1328,10 +1328,18 @@ public:
   Tensor &standardization(Tensor &output) const;
 
   /**
-   * @brief     Normalize the Tensor elements in-place
-   * @retval    Calculated Tensor
+   * @brief     Normalize the Tensor elements (in-place)
+   * @note      min-max normalization
    */
   void normalization_i();
+
+  /**
+   * @brief     Normalize the Tensor along dimension (in-place)
+   * @param[in] dim Dimension to normalize
+   * @param[in] p Norm order (default 2.0)
+   * @param[in] epsilon Epsilon for stability
+   */
+  void normalization_i(unsigned int dim, float p = 2.0, float epsilon = 1e-12);
 
   /**
    * @brief     Standardize the Tensor elements in-place

--- a/nntrainer/tensor/tensor_base.cpp
+++ b/nntrainer/tensor/tensor_base.cpp
@@ -521,6 +521,12 @@ float TensorBase::l2norm() const {
     getStringDataType());
 }
 
+void TensorBase::normalization_i(unsigned int dim, float p, float epsilon) {
+  throw std::runtime_error(
+    "Tensor::normalization_i() is not supported for this tensor type" +
+    getStringDataType());
+}
+
 Tensor &TensorBase::pow(float exponent, Tensor &output) const {
   throw std::invalid_argument(
     "Tensor::pow() is currently not supported in tensor data type " +

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -391,6 +391,12 @@ public:
   virtual float l2norm() const;
 
   /**
+   * @copydoc Tensor::normalization_i(unsigned int dim, float p, float epsilon)
+   */
+  virtual void normalization_i(unsigned int dim, float p = 2.0,
+                               float epsilon = 1e-12);
+
+  /**
    * @copydoc Tensor::pow(float exponent, Tensor &output)
    */
   virtual Tensor &pow(float exponent, Tensor &output) const;


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[Tensor] implement normalization_i(axis, p, epsilon)</summary><br />

- In the previous tensor, we only supported normalization_i which does not consider dimension to normalize.
- This commit adds an implementation of normalize() function commonly used in pytorch (torch.nn.functional)
- This commit adds unittest for normalizeation_i()

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


### Summary

- This PR adds a tensor operation named `normalization_i(axis, p, epsilon)`, which corresponds to `normalize()` in torch.nn.functional
- see : [here](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.normalize.html)

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
