### PR TITLE
[Wait for #3685] [Transformers/layer] add embedding_normalize_layer 

### DIFF
--- a/Applications/CausalLM/layers/embedding_normalize_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_normalize_layer.cpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Eunju Yang <ej.yang@samsung.com>
+ *
+ * @file   embedding_normalize_layer.cpp
+ * @date   06 Jan 2026
+ * @brief  This is Embedding Normalize Layer Class
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Eunju Yang <ej.yang@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <embedding_normalize_layer.h>
+#include <layer_context.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <node_exporter.h>
+#include <util_func.h>
+
+namespace causallm {
+
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
+EmbeddingNormalizeLayer::EmbeddingNormalizeLayer() : LayerImpl() {}
+
+void EmbeddingNormalizeLayer::finalize(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
+    << "EmbeddingNormalize layer takes only one input";
+
+  const nntrainer::TensorDim &input_dim =
+    context.getInputDimensions()[SINGLE_INOUT_IDX];
+
+  context.setOutputDimensions({input_dim});
+}
+
+void EmbeddingNormalizeLayer::forwarding(nntrainer::RunLayerContext &context,
+                                         bool training) {
+  nntrainer::Tensor &input = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+
+  // Copy input to output as we will modify output in-place
+  output.copyData(input);
+  // Normalize along the last dimension (dim=3)
+  output.normalization_i(3);
+}
+
+void EmbeddingNormalizeLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+  // Incremental forwarding for element-wise/row-wise normalization is typically
+  // identical to forwarding if the input shape matches the processing chunk.
+  // However, often incremental_forwarding is used when we process a chunk of
+  // seq_len. BUT, EmbeddingNormalizeLayer usually comes AFTER Pooling, so
+  // seq_len is likely 1. In that case, incremental_forwarding might not even be
+  // called or acts same as forwarding. If we assume this layer is generic, we
+  // should process 'from' to 'to'. But strictly, this layer is designed for
+  // pooled output [batch, 1, 1, dim]. So 'from' and 'to' are likely 0 and 1.
+
+  forwarding(context, training);
+}
+
+void EmbeddingNormalizeLayer::calcDerivative(
+  nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "calcDerivative for EmbeddingNormalize layer is not supported");
+}
+
+void EmbeddingNormalizeLayer::calcGradient(
+  nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "calcGradient for EmbeddingNormalize layer is not supported");
+}
+
+void EmbeddingNormalizeLayer::exportTo(
+  nntrainer::Exporter &exporter, const ml::train::ExportMethods &method) const {
+  LayerImpl::exportTo(exporter, method);
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/layers/embedding_normalize_layer.h
+++ b/Applications/CausalLM/layers/embedding_normalize_layer.h
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Eunju Yang <ej.yang@samsung.com>
+ *
+ * @file   embedding_normalize_layer.h
+ * @date   06 Jan 2026
+ * @brief  This is Embedding Normalize Layer Class
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Eunju Yang <ej.yang@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __EMBEDDING_NORMALIZE_LAYER_H__
+#define __EMBEDDING_NORMALIZE_LAYER_H__
+
+#include <layer_impl.h>
+
+namespace causallm {
+
+/**
+ * @class   EmbeddingNormalizeLayer
+ * @brief   Embedding Normalize Layer
+ */
+class EmbeddingNormalizeLayer : public nntrainer::LayerImpl {
+public:
+  /**
+   * @brief     Constructor of EmbeddingNormalizeLayer
+   */
+  EmbeddingNormalizeLayer();
+
+  /**
+   * @brief     Destructor of EmbeddingNormalizeLayer
+   */
+  ~EmbeddingNormalizeLayer() = default;
+
+  /**
+   * @copydoc   Layer::finalize(InitLayerContext &context)
+   */
+  void finalize(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @copydoc   Layer::forwarding(RunLayerContext &context, bool training)
+   */
+  void forwarding(nntrainer::RunLayerContext &context, bool training) override;
+
+  /**
+   * @copydoc   Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(nntrainer::RunLayerContext &context,
+                              unsigned int from, unsigned int to,
+                              bool training) override;
+
+  /**
+   * @copydoc   Layer::calcDerivative(RunLayerContext &context)
+   */
+  void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc   Layer::calcGradient(RunLayerContext &context)
+   */
+  void calcGradient(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc   Layer::exportTo(Exporter &exporter, const ExportMethods &method)
+   */
+  void exportTo(nntrainer::Exporter &exporter,
+                const ml::train::ExportMethods &method) const override;
+
+  /**
+   * @copydoc   Layer::getType()
+   */
+  const std::string getType() const override {
+    return "EmbeddingNormalizeLayer";
+  }
+
+  /**
+   * @copydoc   Layer::supportBackwarding()
+   */
+  bool supportBackwarding() const override { return false; }
+};
+
+} // namespace causallm
+
+#endif /* __EMBEDDING_NORMALIZE_LAYER_H__ */


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary> [Transformers/layer] add embedding_normalize_layer  </summary><br />

- This commit adds a new layer for embedding model.
- This commit adds normalize_layer which is implemented in sentence_transformers/models/Normalize.py

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>




### Summary

- This PR adds a new layer for embedding model.
- This PR adds normalize_layer which is implemented in sentence_transformers/models/Normalize.py
- see #3673 


Signed-off-by: Eunju Yang <ej.yang@samsung.com>

