### PR TITLE
[Transformer] process model type with lower case

### DIFF
--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -45,16 +45,21 @@ std::string LoadBytesFromFile(const std::string &path) {
 
 static ModelType strToModelType(const std::string &model_type) {
 
-  static const std::unordered_map<std::string, ModelType> model_type_map = {
-    {"Model", ModelType::MODEL},
-    {"CausalLM", ModelType::CAUSAL_LM},
-    {"Embedding", ModelType::EMBEDDING}};
+  std::string model_type_lower = model_type;
+  std::transform(model_type_lower.begin(), model_type_lower.end(),
+                 model_type_lower.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
 
-  if (model_type_map.find(model_type) == model_type_map.end()) {
+  static const std::unordered_map<std::string, ModelType> model_type_map = {
+    {"model", ModelType::MODEL},
+    {"causallm", ModelType::CAUSALLM},
+    {"embedding", ModelType::EMBEDDING}};
+
+  if (model_type_map.find(model_type_lower) == model_type_map.end()) {
     return ModelType::UNKNOWN;
   }
 
-  return model_type_map.at(model_type);
+  return model_type_map.at(model_type_lower);
 }
 
 Transformer::Transformer(json &cfg, json &generation_cfg, json &nntr_cfg,

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -56,7 +56,7 @@ using json = nlohmann::json;
 /**
  * @brief Model Type Enum
  */
-enum class ModelType { MODEL, CAUSAL_LM, EMBEDDING, UNKNOWN };
+enum class ModelType { MODEL, CAUSALLM, EMBEDDING, UNKNOWN };
 
 /**
  * @brief Transformer Class


### PR DESCRIPTION

## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[Transformer] process model type with lower case</summary><br />

- This Commit Fix CAUSAL_LM -> CAUSALLM
- This commit Fix "rigid" string match to "lower case" string match


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>




</details>

### Summary

- This PR modifies the model_type string matching to convert strings to lowercase before matching.
- To prevent significant human errors caused by incorrect capitalization when users input "CausalLM" in the nntr_config file, the code has been updated to convert all strings to lowercase before performing the match.
- Additionally, the variable previously written as CAUSAL_LM has been changed to CAUSALLM in accordance with the project's naming policy.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
