### PR TITLE
[causallm] add Qwen2 model

### DIFF
--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -50,6 +50,7 @@ LOCAL_SRC_FILES := ../main.cpp \
     ../models/causal_lm.cpp \
     ../models/transformer.cpp \
     ../models/embedding.cpp \
+    ../models/qwen2/qwen2_causallm.cpp \
     ../models/qwen3/qwen3_causallm.cpp \
     ../models/qwen3_moe/qwen3_moe_causallm.cpp \
     ../models/qwen3_slim_moe/qwen3_slim_moe_causallm.cpp \
@@ -81,6 +82,7 @@ LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES) \
     $(LOCAL_PATH)/../models \
     $(LOCAL_PATH)/../models/gpt_oss \
     $(LOCAL_PATH)/../models/gpt_oss_cached_slim \
+    $(LOCAL_PATH)/../models/qwen2 \
     $(LOCAL_PATH)/../models/qwen3 \
     $(LOCAL_PATH)/../models/qwen3_moe \
     $(LOCAL_PATH)/../models/qwen3_slim_moe \

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -33,6 +33,7 @@
 #include "gemma3_causallm.h"
 #include "gptoss_cached_slim_causallm.h"
 #include "gptoss_causallm.h"
+#include "qwen2_causallm.h"
 #include "qwen3_cached_slim_moe_causallm.h"
 #include "qwen3_causallm.h"
 #include "qwen3_moe_causallm.h"
@@ -109,6 +110,11 @@ int main(int argc, char *argv[]) {
     "LlamaForCausalLM", [](json cfg, json generation_cfg, json nntr_cfg) {
       return std::make_unique<causallm::CausalLM>(cfg, generation_cfg,
                                                   nntr_cfg);
+    });
+  causallm::Factory::Instance().registerModel(
+    "Qwen2ForCausalLM", [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::Qwen2CausalLM>(cfg, generation_cfg,
+                                                       nntr_cfg);
     });
   causallm::Factory::Instance().registerModel(
     "Qwen3ForCausalLM", [](json cfg, json generation_cfg, json nntr_cfg) {

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -74,10 +74,15 @@ void CausalLM::setupParameters(json &cfg, json &generation_cfg,
           .get<unsigned int>();
   }
 
-  EOS_TOKEN_ID =
-    generation_cfg["eos_token_id"].empty()
-      ? cfg["eos_token_id"].get<std::vector<unsigned int>>()
-      : generation_cfg["eos_token_id"].get<std::vector<unsigned int>>();
+  if (generation_cfg["eos_token_id"].is_array()) {
+    EOS_TOKEN_ID =
+      generation_cfg["eos_token_id"].empty()
+        ? cfg["eos_token_id"].get<std::vector<unsigned int>>()
+        : generation_cfg["eos_token_id"].get<std::vector<unsigned int>>();
+  } else {
+    EOS_TOKEN_ID.clear();
+    EOS_TOKEN_ID.push_back(generation_cfg["eos_token_id"].get<unsigned int>());
+  }
   BOS_TOKEN_ID = generation_cfg["bos_token_id"].empty()
                    ? cfg["bos_token_id"].get<unsigned int>()
                    : generation_cfg["bos_token_id"].get<unsigned int>();

--- a/Applications/CausalLM/models/meson.build
+++ b/Applications/CausalLM/models/meson.build
@@ -8,6 +8,7 @@ causallm_inc += include_directories('.')
 
 subdir('gpt_oss')
 subdir('gpt_oss_cached_slim')
+subdir('qwen2')
 subdir('qwen3')
 subdir('qwen3_moe')
 subdir('qwen3_slim_moe')

--- a/Applications/CausalLM/models/qwen2/meson.build
+++ b/Applications/CausalLM/models/qwen2/meson.build
@@ -1,0 +1,8 @@
+qwen2_src = [
+    meson.current_source_dir() / 'qwen2_causallm.cpp',
+]
+
+qwen2_inc = include_directories('.')
+
+causallm_inc += qwen2_inc
+causallm_src += qwen2_src

--- a/Applications/CausalLM/models/qwen2/qwen2_causallm.cpp
+++ b/Applications/CausalLM/models/qwen2/qwen2_causallm.cpp
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   qwen2_causallm.h
+ * @date   6 January 2026
+ * @brief  This defines a qwen2 causal language model.
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Seunghui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+#include <llm_util.hpp>
+#include <model.h>
+#include <qwen2_causallm.h>
+
+#include <app_context.h>
+#include <engine.h>
+#include <reshaped_rms_norm.h>
+
+namespace causallm {
+
+std::vector<LayerHandle> Qwen2Transformer::createAttention(
+  const int layer_id, int seq_len, int n_heads, int head_dim,
+  std::string query_name, std::string key_name, std::string value_name) {
+  std::vector<LayerHandle> layers;
+  auto Q = "layer" + std::to_string(layer_id) + "_wq";
+  auto K = "layer" + std::to_string(layer_id) + "_wk";
+  auto V = "layer" + std::to_string(layer_id) + "_wv";
+  auto A = "layer" + std::to_string(layer_id) + "_attention";
+  auto O = "layer" + std::to_string(layer_id) + "_attention_out";
+
+  // V layer
+  std::vector<std::string> v_params = {
+    withKey("name", V), withKey("unit", head_dim * n_heads / GQA_SIZE),
+    withKey("disable_bias", "false"), withKey("input_layers", value_name),
+    withKey("weight_initializer", "ones")};
+  layers.push_back(createLayer("fully_connected", v_params));
+
+  // K layer
+  std::vector<std::string> k_params = {
+    withKey("name", K), withKey("unit", head_dim * n_heads / GQA_SIZE),
+    withKey("disable_bias", "false"), withKey("input_layers", key_name),
+    withKey("weight_initializer", "ones")};
+  layers.push_back(createLayer("fully_connected", k_params));
+
+  // Q layer
+  std::vector<std::string> q_params = {
+    withKey("name", Q), withKey("unit", head_dim * n_heads),
+    withKey("disable_bias", "false"), withKey("input_layers", query_name),
+    withKey("weight_initializer", "ones")};
+  layers.push_back(createLayer("fully_connected", q_params));
+
+  // Attention core layer
+  std::vector<std::string> a_params = {
+    withKey("name", A),
+    withKey("num_heads", n_heads),
+    withKey("num_heads_kv", n_heads / GQA_SIZE),
+    withKey("max_timestep", std::to_string(INIT_SEQ_LEN + NUM_TO_GENERATE)),
+    withKey("sliding_window", SLIDING_WINDOW),
+    withKey("rope_theta", ROPE_THETA),
+    withKey("max_position_embeddings", MAX_POSITION_EMBEDDINGS),
+    withKey("max_new_tokens", std::to_string(NUM_TO_GENERATE)),
+    withKey("input_layers", {Q, K, V})};
+  layers.push_back(createLayer("mha_core", a_params));
+
+  // O layer
+  std::vector<std::string> o_params = {
+    withKey("name", O), withKey("unit", DIM), withKey("disable_bias", "true"),
+    withKey("input_layers", A), withKey("weight_initializer", "ones")};
+  layers.push_back(createLayer("fully_connected", o_params));
+
+  return layers;
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/models/qwen2/qwen2_causallm.h
+++ b/Applications/CausalLM/models/qwen2/qwen2_causallm.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   qwen2_causallm.h
+ * @date   6 January 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Seunghui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @note   Please refer to the following code :
+ *  https://github.com/huggingface/transformers/blob/v4.37.0/src/transformers/models/qwen2/modeling_qwen2.py
+ */
+
+#ifndef __QWEN2_CAUSAL_LM_H__
+#define __QWEN2_CAUSAL_LM_H__
+
+#include <causal_lm.h>
+
+namespace causallm {
+
+/**
+ * @brief Qwen2Transformer class
+ */
+class Qwen2Transformer : virtual public Transformer {
+
+public:
+  static constexpr const char *architectures = "Qwen2Transformer";
+
+  Qwen2Transformer(json &cfg, json &generation_cfg, json &nntr_cfg) :
+    Transformer(cfg, generation_cfg, nntr_cfg) {}
+
+  virtual ~Qwen2Transformer() = default;
+
+  std::vector<LayerHandle> createAttention(const int layer_id, int seq_len,
+                                           int n_heads, int head_dim,
+                                           std::string query_name,
+                                           std::string key_name,
+                                           std::string value_name) override;
+};
+
+/**
+ * @brief Qwen2CausalLM class
+ */
+class Qwen2CausalLM : public CausalLM, public Qwen2Transformer {
+
+public:
+  static constexpr const char *architectures = "Qwen2CausalLM";
+
+  Qwen2CausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
+    Transformer(cfg, generation_cfg, nntr_cfg, ModelType::CAUSAL_LM),
+    CausalLM(cfg, generation_cfg, nntr_cfg),
+    Qwen2Transformer(cfg, generation_cfg, nntr_cfg) {}
+
+  virtual ~Qwen2CausalLM() = default;
+};
+} // namespace causallm
+
+#endif /* __QWEN2_CAUSAL_LM_H__*/

--- a/Applications/CausalLM/res/qwen2-0.5b/nntr_config.json
+++ b/Applications/CausalLM/res/qwen2-0.5b/nntr_config.json
@@ -1,0 +1,23 @@
+{
+    "model_type": "CausalLM",
+    "model_tensor_type": "FP32-FP32",
+    "model_file_name": "nntr_qwen2_0.5b_fp32.bin",
+
+    "fc_layer_dtype" : "FP32",
+    "embedding_dtype" : "FP32",
+
+    "lora_rank" : 0,
+    "lora_alpha" : 0,
+    "lora_target": [],
+
+    "bad_word_ids": [],
+    "fsu": false,
+    "fsu_lookahead": 2,
+    "num_to_generate": 512,
+    "init_seq_len": 1024,
+    "max_seq_len": 2048,
+    "batch_size": 1,
+
+    "tokenizer_file": "/tmp/nntrainer/Applications/CausalLM/res/qwen2-0.5b/tokenizer.json",
+    "sample_input": "<|im_start|>user\nGive me a short introduction to large language model.<|im_end|>\n<|im_start|>assistant\n"
+}

--- a/Applications/CausalLM/res/qwen2-0.5b/weight_converter.py
+++ b/Applications/CausalLM/res/qwen2-0.5b/weight_converter.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
+
+# @file weight_converter.py
+# @brief weight conversion script for qwen2 model
+# @author Seunghui Lee <shsh1004.lee@samsung.com>
+
+import argparse
+import torch
+import numpy as np
+from transformers import AutoConfig, AutoTokenizer, AutoModelForCausalLM
+
+def save_qwen2_for_nntrainer(params, n_layers, dtype, file):  
+    """Convert and save weights as nntrainer format for multi-head attention model"""  
+      
+    def save_weight(weight):
+        np.array(weight, dtype=dtype).tofile(file)  
+
+    def save_projection(layer_name, proj_name):  
+        """Helper function to handle base/lora weight saving"""  
+        lora_key = f"{layer_name}{proj_name}.lora_A.default.weight"  
+        if lora_key in params:  
+            save_weight(params[f"{layer_name}{proj_name}.base_layer.weight"].permute(1, 0))  
+            save_weight(params[f"{layer_name}{proj_name}.lora_A.default.weight"].permute(1, 0))  
+            save_weight(params[f"{layer_name}{proj_name}.lora_B.default.weight"].permute(1, 0))  
+        else:  
+            save_weight(params[f"{layer_name}{proj_name}.weight"].permute(1, 0))  
+
+    def save_attention(layer_name):  
+        """Save attention layer weights"""  
+        save_weight(params[f"{layer_name}input_layernorm.weight"])  
+          
+        # Save Q/K/V/O projections using helper  
+        for proj in ["q_proj", "k_proj", "v_proj", "o_proj"]:
+            save_projection(layer_name, f"self_attn.{proj}")
+            if proj != "o_proj":
+                save_weight(params[f"{layer_name}self_attn.{proj}.bias"])
+
+    def save_feed_forward(layer_name):
+        """Save feed forward layer weights"""  
+        save_weight(params[f"{layer_name}post_attention_layernorm.weight"])   
+
+        # Save MLP projections using helper  
+        for proj in ["up_proj", "gate_proj", "down_proj"]:  
+            save_projection(layer_name, f"mlp.{proj}")  
+
+    # Save embedding layer  
+    save_weight(params["model.embed_tokens.weight"])  
+
+    # Process all layers  
+    for layer_idx in range(n_layers):  
+        layer_prefix = f"model.layers.{layer_idx}."  
+        save_attention(layer_prefix)  
+        save_feed_forward(layer_prefix)  
+
+    # Save final layers  
+    save_weight(params["model.norm.weight"])  
+    
+    # Qwen2 model uses tie_word_embedding.
+    # embed_token shares weights with lm_head.
+    # so lm_head weights don't need to be saved separately.
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_path", type=str, default="Qwen/Qwen2-0.5B")
+    parser.add_argument("--output_name", type=str, default="./nntr_qwen2_0.5b_fp32.bin")
+    parser.add_argument("--data_type", type=str, default="float32")
+    args = parser.parse_args()
+    
+    data_dtype = args.data_type
+    model_path = args.model_path
+    output_name = args.output_name
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    config = AutoConfig.from_pretrained(model_path)
+    model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=data_dtype, trust_remote_code=True)
+    model.eval()
+
+    with open(output_name, "wb") as f_model :
+        save_qwen2_for_nntrainer(model.state_dict(), config.num_hidden_layers, data_dtype, f_model)


### PR DESCRIPTION
This commit adds Qwen2 model.
- For Qwen2, Eos token's type was not array, so we need to support it.
- Since Qwen2 uses weight as well as bias in Q, K, V projection, I implemented createAttention through overriding.

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped


Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
