### PR TITLE
[ARM/CPU_BACKEND] open_blas init was missed

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -23,7 +23,11 @@
 
 namespace nntrainer {
 
-void init_backend() { __ggml_init(); }
+void init_backend() {
+  __ggml_init();
+  // Do not repeatedly call set_num_threads. It's a global config.
+  __openblas_set_num_threads(-1); // -1 = BLAS_NUM_THREADS if defined.
+}
 
 void unpack_q4_0x8_transpose16(const void *src, uint16_t *d_out,
                                uint16_t *qs_out, int N, int K) {


### PR DESCRIPTION
- This commit adds omp_num_thread setup in initialize

## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[ARM/CPU_BACKEND] open_blas init was missed</summary><br />

- This commit adds openblas_set_num_threads setup in arm backend init.
- Without this, numthread may not be well controlled across various
  frameworks to use multi-threading

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

### Summary
- The arm backend was not well initialized (openblas_set_num_threads should be called in init!)
- With this PR, you can face speed up in 0.6B qwen3 model at our target android device:
   - prefill : 237 → 307
   - decoding: 22.28 → 25.72

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
