### PR TITLE
[ Windows ] Add ini for Windows Cross compilation

### DIFF
--- a/configurations/windows_cross_arm.ini
+++ b/configurations/windows_cross_arm.ini
@@ -1,0 +1,46 @@
+# This file enables the cross-compile with clang-cl for ARM64 on Windows using Visual Studio 2022.
+# Make sure to use x86_x64 Cross Tools Command Prompt for ARM64 compile
+# Also you have to set the env with call below.
+# You should set the VC PATH to your configuration.
+# If you are using professional, you should change Community to Professional.
+#
+# call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64_arm64
+# meson setup build --cross-file windows-cross-arm.ini
+# meson compile -C build
+#
+# for debug
+#
+# meson setup build_debug --cross-file widnows-cross-arm.ini -Dbuidltype=debug
+# meson compile -C build_debug
+#
+
+[project options]
+enable-tflite-backbone=false
+enable-nnstreamer-backbone=false
+enable-tflite-interpreter=false
+install-app=false
+
+[built-in options]
+werror=false
+c_std='c17'
+cpp_std='c++20'
+platform='windows'
+vsenv = true
+default_library = 'static'
+c_args = ['--target=aarch64-pc-windows-msvc','-Xclang', '-fopenmp']
+cpp_args = ['--target=aarch64-pc-windows-msvc','-Xclang', '-fopenmp']
+c_link_args = ['/machine:ARM64','-LIBPATH:../libiomp_win/ARM64','-LIBPATH:C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/lib/arm64/uwp','-LIBPATH:C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/lib/arm64/']
+cpp_link_args = ['/machine:ARM64','-LIBPATH:../libiomp_win/ARM64','-LIBPATH:C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/lib/arm64/uwp','-LIBPATH:C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/lib/arm64']
+
+[binaries]
+c = 'clang-cl'
+cpp = 'clang-cl'
+ar = 'llvm-ar'
+ld='clang-cl'
+strip = 'llvm-objcopy'
+
+[host_machine]
+system='windows'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'


### PR DESCRIPTION
This PR add the windows ini file to compile for ARM with clang-cl.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com> 