### PR TITLE
[Applications] Optimize token sampling

### DIFF
--- a/Applications/CausalLM/llm_util.cpp
+++ b/Applications/CausalLM/llm_util.cpp
@@ -35,8 +35,10 @@ std::vector<unsigned int> generate_multi_tokens(
   for (unsigned int i = 0; i < NUM_VOCAB; ++i) {
     top_indices_and_logits.push_back({i, logits[i]});
   }
-  sort(top_indices_and_logits.begin(), top_indices_and_logits.end(),
-       [](auto &a, auto &b) { return a.second > b.second; });
+  std::partial_sort(top_indices_and_logits.begin(),
+                    top_indices_and_logits.begin() + NUM_TARGET_TOKENS,
+                    top_indices_and_logits.end(),
+                    [](auto &a, auto &b) { return a.second > b.second; });
 
   // add sampled words
   for (unsigned int i = 0; i < NUM_TARGET_TOKENS; ++i) {
@@ -79,8 +81,10 @@ float applyTKP(float *logits, int len, float temperature, unsigned int top_k,
       logits[i] = logits[i] / temperature;
     top_indices_and_logits.push_back({i, logits[i]});
   }
-  sort(top_indices_and_logits.begin(), top_indices_and_logits.end(),
-       [](auto &a, auto &b) { return a.second > b.second; });
+  std::partial_sort(top_indices_and_logits.begin(),
+                    top_indices_and_logits.begin() + 1,
+                    top_indices_and_logits.end(),
+                    [](auto &a, auto &b) { return a.second > b.second; });
 
   return top_indices_and_logits[0].second;
 }

--- a/Applications/LLaMA/jni/main.cpp
+++ b/Applications/LLaMA/jni/main.cpp
@@ -82,8 +82,10 @@ float applyTKP(float *logits, int len, float temperature, unsigned int top_k,
       logits[i] = logits[i] / temperature;
     top_indices_and_logits.push_back({i, logits[i]});
   }
-  sort(top_indices_and_logits.begin(), top_indices_and_logits.end(),
-       [](auto &a, auto &b) { return a.second > b.second; });
+  std::partial_sort(top_indices_and_logits.begin(),
+                    top_indices_and_logits.begin() + top_k,
+                    top_indices_and_logits.end(),
+                    [](auto &a, auto &b) { return a.second > b.second; });
 
   // Accumulate logits
   float cum_prob = 0;
@@ -94,7 +96,7 @@ float applyTKP(float *logits, int len, float temperature, unsigned int top_k,
   }
 
   // Apply Top-K and Top-P
-  std::fill_n(logits, sizeof(len), -INFINITY);
+  std::fill_n(logits, len, -INFINITY);
   for (unsigned int i = 0; i < top_index; ++i) {
     logits[top_indices_and_logits[i].first] = top_indices_and_logits[i].second;
   }
@@ -210,8 +212,10 @@ std::vector<int> generate_multi_tokens(
   for (unsigned int i = 0; i < NUM_VOCAB; ++i) {
     top_indices_and_logits.push_back({i, logits[i]});
   }
-  sort(top_indices_and_logits.begin(), top_indices_and_logits.end(),
-       [](auto &a, auto &b) { return a.second > b.second; });
+  std::partial_sort(top_indices_and_logits.begin(),
+                    top_indices_and_logits.begin() + NUM_TARGET_TOKENS,
+                    top_indices_and_logits.end(),
+                    [](auto &a, auto &b) { return a.second > b.second; });
 
   // add sampled words
   for (unsigned int i = 0; i < NUM_TARGET_TOKENS; ++i) {


### PR DESCRIPTION
## Dependency of the PR
None

## Commits to be reviewed in this PR


<details><summary>Faster sampling</summary><br />

Let `n` be number of tokens and `k` be k in top-k sampling.
In current sampling code, the time complexity is O(nlogn) from `std::sort`.
This PR improves time complexity to O(nlogk) with `std::partial_sort`.
In a typical model, where `n ~ 10 ^ 5` and `k ~ 40`, this PR makes significant difference in token generation.

With Qwen2-0.5b model, the improvement is from...

```
=================[ LLM with NNTrainer ]===================
prefill: 8 tokens, 161 ms, 49.6894 TPS
generation: 512 tokens, 50984 ms, 10.0424 TPS
==========================================================
```

to
```
=================[ LLM with NNTrainer ]===================
prefill: 8 tokens, 155 ms, 51.6129 TPS
generation: 512 tokens, 46860 ms, 10.9262 TPS
==========================================================
```

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Haehun Yang <haehun.yang@samsung.com>

</details>

### Summary

- Faster sampling

Signed-off-by: Haehun Yang <haehun.yang@samsung.com>