### PR TITLE
[OpenCL] fix ENABLE_OPENCL flag check

### DIFF
--- a/nntrainer/engine.cpp
+++ b/nntrainer/engine.cpp
@@ -45,7 +45,7 @@ void Engine::add_default_object() {
   init_backend(); // initialize cpu backend
   registerContext("cpu", &app_context);
 
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
   auto &cl_context = nntrainer::ClContext::Global();
 
   registerContext("gpu", &cl_context);

--- a/nntrainer/engine.h
+++ b/nntrainer/engine.h
@@ -30,7 +30,7 @@
 #include <mem_allocator.h>
 #include <nntrainer_error.h>
 
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
 #include <cl_context.h>
 #endif
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -34,7 +34,7 @@
 #include <tracer.h>
 #include <util_func.h>
 
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
 #include <cl_context.h>
 #endif
 

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -22,7 +22,7 @@
 #include <tensor.h>
 #include <util_func.h>
 
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
 #include "blas_kernels.h"
 #endif
 
@@ -775,7 +775,7 @@ void FloatTensor::dot(std::vector<Tensor *> input, std::vector<Tensor *> output,
     rdatas.push_back(output[i]->getData<float>());
   }
 
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
   if (input_dtype == Tdatatype::Q4_0) {
     if (M == 1) {
       for (unsigned int i = 0; i < input.size(); ++i) {
@@ -979,7 +979,7 @@ Tensor &FloatTensor::dotQnK(Tensor const &input, Tensor &output, bool trans,
     M = getDim().height();
     K = getDim().width();
     N = input.getDim().width();
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
     if (M == 1) {
       gemm_q4_0(M, N, K, data, K, (void *)mdata, N, rdata, N);
     } else {

--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -167,7 +167,7 @@ void MemoryPool::allocate() {
 
 #else
 
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
   auto *cl_context =
     static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
   mem_pool = cl_context->context_inst_.createSVMRegion(pool_size);
@@ -266,7 +266,7 @@ std::shared_ptr<MemoryData> MemoryPool::getMemory(unsigned int idx) {
  */
 void MemoryPool::deallocate() {
   if (mem_pool != nullptr) {
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
     if (svm_allocation) {
       auto *cl_context =
         static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));

--- a/nntrainer/tensor/memory_pool.h
+++ b/nntrainer/tensor/memory_pool.h
@@ -28,7 +28,7 @@
 #include <memory_planner.h>
 #include <tensor_wrap_specs.h>
 
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
 #include <cl_context.h>
 #endif
 

--- a/test/include/nntrainer_test_util.h
+++ b/test/include/nntrainer_test_util.h
@@ -439,7 +439,7 @@ struct static_cast_func {
   EXPECT_GE((VAL), (MIN));                                                     \
   EXPECT_LE((VAL), (MAX))
 
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
 #include <cl_context.h>
 #include <engine.h>
 

--- a/test/unittest/layers/layers_dependent_common_tests.cpp
+++ b/test/unittest/layers/layers_dependent_common_tests.cpp
@@ -18,7 +18,7 @@
 #include <layer_devel.h>
 #include <layer_node.h>
 
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
 #include <cl_context.h>
 #endif
 
@@ -122,7 +122,7 @@ TEST_P(LayerSemantics, setBatchValidateLayerNode_p) {
   }
 }
 
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
 TEST_P(LayerSemanticsGpu, createFromClContext_pn) {
   auto &eg = nntrainer::Engine::Global();
   auto cc = static_cast<nntrainer::ClContext *>(eg.getRegisteredContext("gpu"));

--- a/test/unittest/layers/layers_standalone_common_tests.cpp
+++ b/test/unittest/layers/layers_standalone_common_tests.cpp
@@ -82,7 +82,7 @@ TEST_P(LayerSemantics, setBatchValidate_p) {
   }
 }
 
-#ifdef ENABLE_OPENCL
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(LayerSemanticsGpu);
 
 TEST_P(LayerSemanticsGpu, setProperties_n) {


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[OpenCL] fix ENABLE_OPENCL flag check</summary><br />

- In the previous code, we used #ifdef ENABLE_OPENCL to ensure that the branch executes only when the option is enabled.
- ENABLE_OPENCL is declared only when -Denable-opencl=true is specified.
- However, this code might cause unexpected errors later if ENABLE_OPENCL is declared but set to 0.
- This commit addresses and fixes the issues that could arise from this problem.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



### Summary

- This commit is a pull request (PR) aimed at preventing potential bugs that could occur in the future rather than addressing an existing bug. 
- Specifically, it focuses on avoiding unintended issues that might arise from checking the ENABLE_OPENCL status using ifdef. This PR was created to mitigate such risks proactively.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
