### PR TITLE
[Log] add ml_logi for memory alloc

### DIFF
--- a/nntrainer/tensor/memory_pool.cpp
+++ b/nntrainer/tensor/memory_pool.cpp
@@ -124,6 +124,8 @@ void MemoryPool::allocate() {
   if (mem_pool != nullptr)
     throw std::runtime_error("Memory pool is already allocated");
 
+  ml_logi("MemoryPool::allocate size: %zu", pool_size);
+
 #if defined(__ANDROID__) && ENABLE_NPU
   int i = 0;
 #define RPCMEM_HEAP_ID_SYSTEM 25
@@ -201,6 +203,8 @@ void MemoryPool::allocate() {
 void MemoryPool::allocateFSU() {
   if (pool_size == 0)
     throw std::runtime_error("Allocating memory pool with size 0");
+
+  ml_logi("MemoryPool::allocateFSU size: %zu", pool_size);
 
   if (mem_pool != nullptr)
     throw std::runtime_error("Memory pool is already allocated");

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -231,6 +231,9 @@ void TensorPool::allocate(bool init) {
       continue;
     }
     spec.tensor->setData(mem_pool->getMemory(details->token), 0, init);
+    ml_logi("Memory Alloc Details (Tensor): %s : %zu : address %p",
+            spec.tensor->getName().c_str(), spec.tensor->getMemoryBytes(),
+            spec.tensor->getData());
 
     syncDependents(spec);
   }


### PR DESCRIPTION

## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[Log] add ml_logi for memory alloc</summary><br />

- This code adds ml_logi to support monitoring memory allocation in nntrainer.
- One can check the log with the following command line:

   ```
   adb logcat -v color | grep "MemoryPool"
   adb logcat -v color | grep "Memory Alloc"
   ```


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

### Summary


- This PR adds ml_logi to support monitoring memory allocation in nntrainer.
- One can check the log with the following command line:

   ```
   adb logcat -v color | grep "MemoryPool"
   adb logcat -v color | grep "Memory Alloc"
   ```

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
