### PR TITLE
Fix top-k and top-p sampling in CausalLM Application

### DIFF
--- a/Applications/CausalLM/llm_util.cpp
+++ b/Applications/CausalLM/llm_util.cpp
@@ -82,9 +82,23 @@ float applyTKP(float *logits, int len, float temperature, unsigned int top_k,
     top_indices_and_logits.push_back({i, logits[i]});
   }
   std::partial_sort(top_indices_and_logits.begin(),
-                    top_indices_and_logits.begin() + 1,
+                    top_indices_and_logits.begin() + top_k,
                     top_indices_and_logits.end(),
                     [](auto &a, auto &b) { return a.second > b.second; });
+
+  // Accumulate logits
+  float cum_prob = 0;
+  unsigned int top_index = 0;
+  while (cum_prob <= top_p && top_index < top_k) {
+    cum_prob += top_indices_and_logits[top_index].second;
+    ++top_index;
+  }
+
+  // Apply Top-K and Top-P
+  std::fill_n(logits, len, -INFINITY);
+  for (unsigned int i = 0; i < top_index; ++i) {
+    logits[top_indices_and_logits[i].first] = top_indices_and_logits[i].second;
+  }
 
   return top_indices_and_logits[0].second;
 }


### PR DESCRIPTION
## Dependency of the PR
None

## Commits to be reviewed in this PR


<details><summary>Fix top-k and top-p sampling in CausalLM Application</summary><br />

As @jaemini-shin pointed out in #3709, `applyTKP` function in CausalLM application did not apply top-k and top-p sampling at all.

This PR correctly applies them, using same code with LLaMA application.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Haehun Yang <haehun.yang@samsung.com>

</details>



### Summary

- Fix top-k and top-p sampling in CausalLM Application

Signed-off-by: Haehun Yang <haehun.yang@samsung.com>
