### PR TITLE
[WIP][cpu_backend] Optimize TanhGeLU activation using NEON intrinsics

### DIFF
--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -478,14 +478,8 @@ public:
    */
   template <typename T = float>
   static Tensor &tanhGelu(Tensor const &t_in, Tensor &t_out) {
-    t_in.apply<T>(
-      [&](T x) {
-        return static_cast<T>(
-          0.5 * x *
-          (1 + tanhFloat<T>(
-                 static_cast<T>(sqrt(2 / M_PI) * (x + 0.044715 * pow(x, 3))))));
-      },
-      t_out);
+    nntrainer::tanh_gelu(t_in.size(), t_in.getData<float>(),
+                         t_out.getData<float>());
     return t_out;
   }
 

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -46,6 +46,18 @@ void swiglu(const unsigned int N, float *X, float *Y, float *Z, float alpha) {
   nntrainer::neon::swiglu(N, X, Y, Z, alpha);
 }
 
+void tanh_gelu(const unsigned int N, const float *X, float *Y) {
+#ifdef __ARM_NEON
+  nntrainer::neon::tanh_gelu(N, X, Y);
+#else
+  for (unsigned int i = 0; i < N; ++i) {
+    float x = X[i];
+    Y[i] = 0.5f * x *
+           (1.0f + std::tanh(0.7978845608f * (x + 0.044715f * x * x * x)));
+  }
+#endif
+}
+
 float max_val(const unsigned int N, float *X) {
   return nntrainer::neon::max_val(N, X);
 }

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -765,6 +765,16 @@ void swiglu(const unsigned int N, float *X, float *Y, float *Z);
 void swiglu(const unsigned int N, float *X, float *Y, float *Z, float alpha);
 
 /**
+ * @brief tanh_gelu function : Y = 0.5 * X * (1 + tanh(sqrt(2/pi) * (X +
+ * 0.044715 * X^3)))
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X (input)
+ * @param Y float * for Vector Y (output)
+ */
+void tanh_gelu(const unsigned int N, const float *X, float *Y);
+
+/**
  * @brief returns maximum value of the vector X
  *
  * @param N number of elements in X

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl.h
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl.h
@@ -449,6 +449,16 @@ void swiglu(const unsigned int N, float *X, float *Y, float *Z);
 void swiglu(const unsigned int N, float *X, float *Y, float *Z, float alpha);
 
 /**
+ * @brief tanh_gelu function with neon : Y = 0.5 * X * (1 + tanh(sqrt(2/pi) * (X
+ * + 0.044715 * X^3)))
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X (input)
+ * @param Y float * for Vector Y (output)
+ */
+void tanh_gelu(const unsigned int N, const float *X, float *Y);
+
+/**
  * @brief returns maximum value of the vector X
  *
  * @param N number of elements in X

--- a/nntrainer/tensor/cpu_backend/arm/neon_mathfun.hxx
+++ b/nntrainer/tensor/cpu_backend/arm/neon_mathfun.hxx
@@ -40,6 +40,10 @@
 typedef uint32x4_t v4su; // vector of 4 uint32
 typedef int32x4_t v4si;  // vector of 4 uint32
 
+#ifdef ARMV7
+#include <armv7_neon.h>
+#endif
+
 #define c_inv_mant_mask ~0x7f800000u
 #define c_cephes_SQRTHF 0.707106781186547524
 #define c_cephes_log_p0 7.0376836292E-2
@@ -63,7 +67,7 @@ typedef int32x4_t v4si;  // vector of 4 uint32
  * @param x input register variable
  * @return v4sf
  */
-v4sf log_ps(v4sf x) {
+inline v4sf log_ps(v4sf x) {
   v4sf one = vdupq_n_f32(1);
 
   x = vmaxq_f32(x, vdupq_n_f32(0)); /* force flush to zero on denormal values */
@@ -154,7 +158,7 @@ v4sf log_ps(v4sf x) {
  * @param x input register variable
  * @return v4sf
  */
-v4sf exp_ps(v4sf x) {
+inline v4sf exp_ps(v4sf x) {
   v4sf tmp, fx;
 
   v4sf one = vdupq_n_f32(1);
@@ -247,7 +251,7 @@ v4sf exp_ps(v4sf x) {
  * @param x input register variable
  * @return v4sf
  */
-void sincos_ps(v4sf x, v4sf *ysin, v4sf *ycos) { // any x
+inline void sincos_ps(v4sf x, v4sf *ysin, v4sf *ycos) { // any x
   v4sf xmm1, xmm2, xmm3, y;
 
   v4su emm2;
@@ -320,7 +324,7 @@ void sincos_ps(v4sf x, v4sf *ysin, v4sf *ycos) { // any x
  * @param x input register variable
  * @return v4sf
  */
-v4sf sin_ps(v4sf x) {
+inline v4sf sin_ps(v4sf x) {
   v4sf ysin, ycos;
   sincos_ps(x, &ysin, &ycos);
   return ysin;
@@ -332,10 +336,29 @@ v4sf sin_ps(v4sf x) {
  * @param x input register variable
  * @return v4sf
  */
-v4sf cos_ps(v4sf x) {
+inline v4sf cos_ps(v4sf x) {
   v4sf ysin, ycos;
   sincos_ps(x, &ysin, &ycos);
   return ycos;
+}
+
+/**
+ * @brief tanh function with simd
+ *
+ * @param x input register variable
+ * @return v4sf
+ */
+inline v4sf tanh_ps(v4sf x) {
+  v4sf one = vdupq_n_f32(1.0f);
+  v4sf two = vdupq_n_f32(2.0f);
+  v4sf minus_one = vdupq_n_f32(-1.0f);
+
+  v4sf y = vmulq_f32(x, two);
+  y = exp_ps(y);
+  v4sf num = vsubq_f32(y, one);
+  v4sf den = vaddq_f32(y, one);
+  v4sf res = vdivq_f32(num, den);
+  return res;
 }
 
 #endif

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -668,6 +668,16 @@ extern void swiglu(const unsigned int N, float *X, float *Y, float *Z,
                    float alpha);
 
 /**
+ * @brief tanh_gelu function : Y = 0.5 * X * (1 + tanh(sqrt(2/pi) * (X +
+ * 0.044715 * X^3)))
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X (input)
+ * @param Y float * for Vector Y (output)
+ */
+extern void tanh_gelu(const unsigned int N, const float *X, float *Y);
+
+/**
  * @brief returns maximum value of the vector X
  *
  * @param N number of elements in X

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <assert.h>
+#include <cmath>
 #include <fallback_internal.h>
 #include <nntrainer_error.h>
 
@@ -194,6 +195,14 @@ void swiglu(const unsigned int N, float *X, float *Y, float *Z) {
 
 void swiglu(const unsigned int N, float *X, float *Y, float *Z, float alpha) {
   __fallback_swiglu(N, X, Y, Z, alpha);
+}
+
+void tanh_gelu(const unsigned int N, const float *X, float *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    float x = X[i];
+    Y[i] = 0.5f * x *
+           (1.0f + std::tanh(0.7978845608f * (x + 0.044715f * x * x * x)));
+  }
 }
 
 float max_val(const unsigned int N, float *X) { return __fallback_max(N, X); }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -624,6 +624,16 @@ void swiglu(const unsigned int N, float *X, float *Y, float *Z);
 void swiglu(const unsigned int N, float *X, float *Y, float *Z, float alpha);
 
 /**
+ * @brief tanh_gelu function : Y = 0.5 * X * (1 + tanh(sqrt(2/pi) * (X +
+ * 0.044715 * X^3)))
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X (input)
+ * @param Y float * for Vector Y (output)
+ */
+void tanh_gelu(const unsigned int N, const float *X, float *Y);
+
+/**
  * @brief returns maximum value of the vector X
  *
  * @param N number of elements in X

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <assert.h>
+#include <cmath>
 
 #include <avx2_impl.h>
 #ifdef USE_BLAS
@@ -28,7 +29,8 @@
 
 namespace nntrainer {
 
-void init_backend() { __ggml_init();
+void init_backend() {
+  __ggml_init();
   // Do not repeatedly call set_num_threads. It's a global config.
   __openblas_set_num_threads(-1); // -1 = BLAS_NUM_THREADS if defined.
 }
@@ -292,6 +294,14 @@ void swiglu(const unsigned int N, float *X, float *Y, float *Z) {
 
 void swiglu(const unsigned int N, float *X, float *Y, float *Z, float alpha) {
   nntrainer::avx2::swiglu(N, X, Y, Z, alpha);
+}
+
+void tanh_gelu(const unsigned int N, const float *X, float *Y) {
+  for (unsigned int i = 0; i < N; ++i) {
+    float x = X[i];
+    Y[i] = 0.5f * x *
+           (1.0f + std::tanh(0.7978845608f * (x + 0.044715f * x * x * x)));
+  }
 }
 
 float max_val(const unsigned int N, float *X) { return __fallback_max(N, X); }

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -526,6 +526,16 @@ void swiglu(const unsigned int N, float *X, float *Y, float *Z);
 void swiglu(const unsigned int N, float *X, float *Y, float *Z, float alpha);
 
 /**
+ * @brief tanh_gelu function : Y = 0.5 * X * (1 + tanh(sqrt(2/pi) * (X +
+ * 0.044715 * X^3)))
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X (input)
+ * @param Y float * for Vector Y (output)
+ */
+void tanh_gelu(const unsigned int N, const float *X, float *Y);
+
+/**
  * @brief returns maximum value of the vector X
  *
  * @param N number of elements in X


### PR DESCRIPTION
This commit implements NEON optimization for the TanhGeLU activation function
to improve performance on ARM devices.

It is tested with gelu activation function of Gemma3(270m), and the result is as below
- before: 7.6 ms
- after(neon): 1.3 ms

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>