### PR TITLE
[layer] override updateTensorsByInputDimensions (Embedding/FC)

### DIFF
--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -170,6 +170,21 @@ void EmbeddingLayer::exportTo(nntrainer::Exporter &exporter,
   exporter.saveResult(embedding_props, method, this);
 }
 
+void EmbeddingLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  nntrainer::TensorDim in_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  nntrainer::TensorDim out_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  unsigned int height = input_dimensions[0].height();
+
+  in_dim.width(height);
+  out_dim.height(height);
+
+  context.updateInput(SINGLE_INOUT_IDX, in_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, out_dim);
+}
+
 #ifdef PLUGGABLE
 
 nntrainer::Layer *create_embedding_layer() {

--- a/Applications/CausalLM/layers/embedding_layer.h
+++ b/Applications/CausalLM/layers/embedding_layer.h
@@ -114,6 +114,13 @@ public:
    */
   WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
 
+  /**
+   * @copydoc Layer::supportBackwarding()
+   */
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
   inline static const std::string type = "embedding_layer";
 
 private:

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -376,4 +376,19 @@ void FullyConnectedLayer::calcGradient(RunLayerContext &context) {
   }
 }
 
+void FullyConnectedLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  nntrainer::TensorDim in_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  nntrainer::TensorDim out_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  unsigned int height = input_dimensions[0].height();
+
+  in_dim.width(height);
+  out_dim.height(height);
+
+  context.updateInput(SINGLE_INOUT_IDX, in_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, out_dim);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -109,6 +109,13 @@ public:
   void setBatch(nntrainer::RunLayerContext &context,
                 unsigned int batch) override;
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions()
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "fully_connected";
 
 private:


### PR DESCRIPTION


## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[layer] override updateTensorsByInputDimensions (Embedding/FC)</summary><br />

- This commit overrides updateTensorsByInputDimensions in Embedding layer and Fully Connected layer

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: EunjuYang <ej.yang@samsung.com>

</details>




### Summary

- This PR overrides `updateTensorsByInputDimensions` in fully connected layer and Embedding layer in CausalLM custom layer.

Signed-off-by: EunjuYang <ej.yang@samsung.com>
