### PR TITLE
[CausalLM] remove bugs and add some detailed comments @open sesame 2026-02-26 14:20

### DIFF
--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -419,7 +419,6 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   std::vector<bool> eos_list(BATCH_SIZE, false);
 
   unsigned int input_len = init_len;
-  unsigned int token_generation_idx = input_len + 1;
 
   for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
     for (unsigned int i = 0; i < input_len; ++i) {
@@ -544,7 +543,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   auto start_generation = std::chrono::high_resolution_clock::now();
 
-  for (token_generation_idx = input_len + 1;
+  for (unsigned int token_generation_idx = input_len + 1;
        token_generation_idx < input_len + 1 + NUM_TO_GENERATE;
        ++token_generation_idx) {
 

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -554,21 +554,15 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
                                    token_generation_idx - 1 + global_token_len,
                                    token_generation_idx + global_token_len);
     std::vector<unsigned int> ids_list(generate(output_interval[0], do_sample));
-    if (token_generation_idx < input_len) {
-      for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
-        input_sample[static_cast<size_t>(b) * MAX_SEQ_LEN] =
-          static_cast<float>(init_input[token_generation_idx - SYS_PROMP_LEN]);
-      }
-      registerOutputs(tokenizer, ids_list, token_generation_idx, eos_list,
-                      log_output);
-    } else {
-      for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
-        input_sample[static_cast<size_t>(b) * MAX_SEQ_LEN] =
-          static_cast<float>(ids_list[b]);
-      }
-      registerOutputs(tokenizer, ids_list, token_generation_idx, eos_list,
-                      log_output);
+
+    // Feed the newly generated token back as the next input token.
+    // token_generation_idx always starts at input_len + 1, so we are
+    // always in the auto-regressive generation phase here.
+    for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
+      input_sample[static_cast<size_t>(b) * MAX_SEQ_LEN] =
+        static_cast<float>(ids_list[b]);
     }
+    registerOutputs(tokenizer, ids_list, token_generation_idx, eos_list, log_output);
     ++generation_cnt;
 
     // output should be deallocated after use

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -593,10 +593,13 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     }
 
     if (is_finish) {
-      free(input_sample);
       break;
     }
   }
+
+  // Always release the input buffer after the generation loop, whether
+  // the loop exited early (EOS found) or ran to the maximum token limit.
+  free(input_sample);
 
   global_token_len += (generation_cnt + init_len);
 

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -398,7 +398,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   std::vector<int64_t> init_input;
   unsigned int _len = _input.size();
   unsigned int num_allow_str = MAX_SEQ_LEN - NUM_TO_GENERATE;
-  unsigned text_len = _len;
+  unsigned int text_len = _len;
 
   if (_len > num_allow_str)
     text_len = num_allow_str;
@@ -492,12 +492,13 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
     if (log_output) {
 
-      std::cout
-        << "kv caches are saved in " << PRE_COMPUTED_CACHE_PATH << std::endl
-        << "and the size of prompt is " << SYS_PROMP_LEN << ".\n"
-        << "You may need this prompt lenth to set the \"sys_prompt_token_size\""
-        << "\n==================================================\n"
-        << std::endl;
+      std::cout << "kv caches are saved in " << PRE_COMPUTED_CACHE_PATH
+                << std::endl
+                << "and the size of prompt is " << SYS_PROMP_LEN << ".\n"
+                << "You may need this prompt length to set the "
+                   "\"sys_prompt_token_size\""
+                << "\n==================================================\n"
+                << std::endl;
     }
     return;
   }
@@ -516,7 +517,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   // post process of model output
   std::vector<unsigned int> id_list(
-    generate(output[0], do_sample, 1, ids_history, _len));
+    generate(output[0], do_sample, 1, ids_history, init_len));
 
   if (init_len < INIT_SEQ_LEN)
     registerOutputs(tokenizer, id_list, init_len, eos_list, log_output);
@@ -561,7 +562,8 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
       input_sample[static_cast<size_t>(b) * MAX_SEQ_LEN] =
         static_cast<float>(ids_list[b]);
     }
-    registerOutputs(tokenizer, ids_list, token_generation_idx, eos_list, log_output);
+    registerOutputs(tokenizer, ids_list, token_generation_idx, eos_list,
+                    log_output);
     ++generation_cnt;
 
     // output should be deallocated after use

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -149,7 +149,6 @@ protected:
 
   unsigned int SYS_PROMP_LEN;
   std::string PRE_COMPUTED_CACHE_PATH;
-  std::string TAIL_PROMPT;
   bool SAVE_KVCACHE;
   bool USE_KVCACHE;
   unsigned int global_token_len;


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] Fix memory leak: always free input_sample after generation</summary><br />


input_sample was only freed when an EOS token was found (is_finish == true).
When the generation loop ran to its maximum token limit without hitting EOS,
the buffer was leaked. Move free() to after the loop so it is unconditionally
released in both exit paths.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



<details><summary>[CausalLM] Remove dead code branch in token generation loop</summary><br />

The condition `token_generation_idx < input_len` is always false because the
loop initializes token_generation_idx = input_len + 1 and increments from
there. The "else" body (feed the generated token back) is the only path ever
executed, so flatten it and add a clarifying comment.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>


</details>

<details><summary>[CausalLM] Fix generate_multi_tokens: pass init_len instead of _len</summary><br />

_len holds the original tokenized-input size before the sequence may be
trimmed to fit within MAX_SEQ_LEN - NUM_TO_GENERATE. After trimming,
ids_history contains exactly init_len tokens. Passing _len as NUM_INPUT_IDS
would let the repetition-penalty window read beyond the initialized region
of ids_history. Use init_len so the window covers only the tokens the model
actually processed during prefill.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>


</details>

<details><summary>[CausalLM] Remove unused outer token_generation_idx declaration</summary><br />

token_generation_idx was declared and initialised to input_len + 1 before
the fill loop, but it is never read between that point and the for-loop
header where it is unconditionally re-initialised to the same value.
Remove the redundant declaration to avoid confusion about the variable's
intended initial state.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>


</details>


<details><summary>[CausalLM] Fix undefined variable text_ and TAIL_PROMPT in Windows br</summary><br />

The Windows code path used the undeclared identifier text_ (linker error on
MSVC) where the user prompt should be printed, and referenced the stale
member TAIL_PROMPT instead of the tail_prompt function parameter. Replace
both with the matching parameter names to align with the non-Windows branch.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>


</details>

<details><summary>[CausalLM] Add Doxygen comments to save_kvcache / load_kvcache</summary><br />
Document the purpose of each function, the on-disk serialisation format,
the meaning of the to_ parameter, and why getTensor(0/1) maps to K/V.
Also add inline comments explaining the shared-data-tensor view pattern
and the intptr_t / void* casting used by the forEachLayer callback API.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>


</details>

<details><summary>[CausalLM] Add detailed comments</summary><br />

Add an ASCII diagram in run() showing the three operating modes
(no-cache, save-cache, load-cache) and how KV-cache positions are assigned
across the MAX_SEQ_LEN context window, including the multi-turn case.

Replace terse inline comments in the input-preparation section with
detailed explanations for:
- SAVE_KVCACHE decision logic
- which text is tokenised in each mode
- SYS_PROMP_LEN derivation when absent from config
- the sequence-length budget clamp (and its known limitation)

Also fix a minor type: `unsigned text_len` → `unsigned int text_len`.

Document the prefill section step by step:
- input_sample and ids_history buffer layout
- input_len meaning and how it evolves
- KV-cache SAVE mode: explain incremental_inference arguments
- KV-cache LOAD mode: clarify what load_kvcache restores
- normal prefill: annotate start_pos / end_pos formula with the
  SYS_PROMP_LEN and global_token_len offsets

Also fix a minor copy-paste typo in the save-mode output message:
"prompt lenth" → "prompt length".

Document the auto-regressive decoding loop step by step:
- why input_len is extended by SYS_PROMP_LEN before the loop
- the role of input_sample slot [0] as the single new-token input
- token_generation_idx semantics (KV-cache position for each step)
- incremental_inference start_pos / end_pos formula with offsets
- EOS detection and early-exit logic

Add an explanation for the global_token_len update at the end of run():
- what the variable accumulates across turns
- why SYS_PROMP_LEN is excluded (applied separately per call)
- how the offset is consumed in the next turn's prefill

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>


</details>




### Summary

- This PR refactors and hardens CausalLM::run() and related helpers in causal_lm.cpp, fixing several latent bugs, removing dead code, and adding comprehensive inline documentation.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

