### PR TITLE
[CPU Backend] fix docstring and parameter name in `repack()`

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -417,19 +417,19 @@ template <> void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
   __ggml_dequantize_row_q8_K(x, y, k);
 }
 
-void repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
+void repack_q4_0_to_q4_0_8(void *dst, void *src, size_t data_size,
                            const unsigned int M, const unsigned int N) {
-  __ggml_repack_q4_0_to_q4_0_8(W, repacked_W, data_size, M, N);
+  __ggml_repack_q4_0_to_q4_0_8(dst, src, data_size, M, N);
 }
 
-void repack_q4_0(void *W, void *repacked_W, size_t data_size,
-                 const unsigned int M, const unsigned int N) {
-  __ggml_repack_q4_0_to_q4_0_4(W, repacked_W, data_size, M, N);
+void repack_q4_0(void *dst, void *src, size_t data_size, const unsigned int M,
+                 const unsigned int N) {
+  __ggml_repack_q4_0_to_q4_0_4(dst, src, data_size, M, N);
 }
 
-void repack_q4_K(void *W, void *repacked_W, size_t data_size,
-                 const unsigned int M, const unsigned int N) {
-  __ggml_repack_q4_K_to_q4_K_8(W, repacked_W, data_size, M, N);
+void repack_q4_K(void *dst, void *src, size_t data_size, const unsigned int M,
+                 const unsigned int N) {
+  __ggml_repack_q4_K_to_q4_K_8(dst, src, data_size, M, N);
 }
 
 void unpack_q4_0(const void *in_q4_0x, void *out_q4_0, size_t data_size,

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1298,28 +1298,29 @@ template <typename T = float>
 void quantize_row_q8_K(const T *src, void *dst, int64_t k);
 
 /**
- * @brief repack q40 to q40x8
+ * @brief repack q40 to q40x4
+ * @note  repacking q40 for ARM is different from x86's
  *
- * @param W output repacked q40x
- * @param repacked_W input q40
+ * @param dst output repacked q40x4
+ * @param src input q40
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void repack_q4_0(void *W, void *repacked_W, size_t data_size,
-                 const unsigned int M, const unsigned int N);
+void repack_q4_0(void *dst, void *src, size_t data_size, const unsigned int M,
+                 const unsigned int N);
 
 /**
  * @brief repack q4K to q4Kx8
  *
- * @param W output repacked q4Kx8
- * @param repacked_W input q4K
+ * @param dst output repacked q4Kx8
+ * @param src input q4K
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void repack_q4_K(void *W, void *repacked_W, size_t data_size,
-                 const unsigned int M, const unsigned int N);
+void repack_q4_K(void *dst, void *src, size_t data_size, const unsigned int M,
+                 const unsigned int N);
 
 /**
  * @brief unpack q40x4 to q40 - invers method: repack_q4_0

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -1192,25 +1192,25 @@ extern void quantize_row_q8_K(const T *src, void *dst, int64_t k);
 /**
  * @brief repack q40 to q40x8
  *
- * @param W output repacked q40x8
- * @param repacked_W input q40
+ * @param dst output repacked data
+ * @param src input quantized data
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-extern void repack_q4_0(void *W, void *repacked_W, size_t data_size,
+extern void repack_q4_0(void *dst, void *src, size_t data_size,
                         const unsigned int M, const unsigned int N);
 
 /**
  * @brief repack q4K to q4Kx8
  *
- * @param W output repacked q4Kx8
- * @param repacked_W input q4K
+ * @param dst output repacked data
+ * @param src input quantized data
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-extern void repack_q4_K(void *W, void *repacked_W, size_t data_size,
+extern void repack_q4_K(void *dst, void *src, size_t data_size,
                         const unsigned int M, const unsigned int N);
 
 /**

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1176,38 +1176,38 @@ void quantize_row_q8_K(const T *x, void *y, int64_t k);
 /**
  * @brief repack q40 to q40x8
  *
- * @param W output repacked q40x
- * @param repacked_W input q40
+ * @param dst output repacked q40x8
+ * @param src input q40
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
+void repack_q4_0_to_q4_0_8(void *dst, void *src, size_t data_size,
                            const unsigned int M, const unsigned int N);
 
 /**
  * @brief repack q4K to q4Kx8
  *
- * @param W output repacked q4Kx8
- * @param repacked_W input q4K
+ * @param dst output repacked q4Kx8
+ * @param src input q4K
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
+void repack_q4_K_to_q4_K_8(void *dst, void *src, size_t data_size,
                            const unsigned int M, const unsigned int N);
 
 /**
  * @brief repack q40 to q40x8
  *
- * @param W output repacked q40x
- * @param repacked_W input q40
+ * @param dst output repacked q40x8
+ * @param src input q40
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void repack_q4_0(void *W, void *repacked_W, size_t data_size,
-                 const unsigned int M, const unsigned int N);
+void repack_q4_0(void *dst, void *src, size_t data_size, const unsigned int M,
+                 const unsigned int N);
 
 /**
  * @brief unpack q40x8 to q40 - invers method: repack_q4_0

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -1067,42 +1067,42 @@ template <typename T = float>
 void __fallback_dequantize_row_q8_K(const void *x, T *y, int64_t k);
 
 /**
- * @brief repack q40 to q40x8
+ * @brief repack q40 to q40x4
  *
- * @param W output repacked q40x
- * @param repacked_W input q40
+ * @param dst output repacked q40x4
+ * @param src input q40
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void __fallback_repack_q4_0_to_q4_0_4(void *W, void *repacked_W,
-                                      size_t data_size, const unsigned int M,
+void __fallback_repack_q4_0_to_q4_0_4(void *dst, void *src, size_t data_size,
+                                      const unsigned int M,
                                       const unsigned int N);
 
 /**
  * @brief repack q40 to q40x8
  *
- * @param W output repacked q40x
- * @param repacked_W input q40
+ * @param dst output repacked q40x
+ * @param src input q40
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void __fallback_repack_q4_0_to_q4_0_8(void *W, void *repacked_W,
-                                      size_t data_size, const unsigned int M,
+void __fallback_repack_q4_0_to_q4_0_8(void *dst, void *src, size_t data_size,
+                                      const unsigned int M,
                                       const unsigned int N);
 
 /**
  * @brief repack q4K to q4Kx8
  *
- * @param W output repacked q4Kx8
- * @param repacked_W input q4K
+ * @param dst output repacked q4Kx8
+ * @param src input q4K
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void __fallback_repack_q4_K_to_q4_K_8(void *W, void *repacked_W,
-                                      size_t data_size, const unsigned int M,
+void __fallback_repack_q4_K_to_q4_K_8(void *dst, void *src, size_t data_size,
+                                      const unsigned int M,
                                       const unsigned int N);
 
 /**

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -106,19 +106,19 @@ float __ggml_vec_dot_q6_K(const unsigned int K, const void *__restrict v_q6_K,
   return result;
 }
 
-void __ggml_repack_q4_0_to_q4_0_4(void *W, void *repacked_W, size_t data_size,
+void __ggml_repack_q4_0_to_q4_0_4(void *dst, void *src, size_t data_size,
                                   const unsigned int M, const unsigned int N) {
-  nntr_repack_q4_0_to_q4_0_4_bl(W, 8, repacked_W, data_size, M, N);
+  nntr_repack_q4_0_to_q4_0_4_bl(dst, 8, src, data_size, M, N);
 }
 
-void __ggml_repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
+void __ggml_repack_q4_0_to_q4_0_8(void *dst, void *src, size_t data_size,
                                   const unsigned int M, const unsigned int N) {
-  nntr_repack_q4_0_to_q4_0_8_bl(W, 8, repacked_W, data_size, M, N);
+  nntr_repack_q4_0_to_q4_0_8_bl(dst, 8, src, data_size, M, N);
 }
 
-void __ggml_repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
+void __ggml_repack_q4_K_to_q4_K_8(void *dst, void *src, size_t data_size,
                                   const unsigned int M, const unsigned int N) {
-  nntr_repack_q4_K_to_q4_K_8_bl(W, 8, repacked_W, data_size, M, N);
+  nntr_repack_q4_K_to_q4_K_8_bl(dst, 8, src, data_size, M, N);
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -308,37 +308,37 @@ template <typename T = float>
 void __ggml_dequantize_row_q8_K(const void *x, T *y, int64_t k);
 
 /**
- * @brief repack q40 to q40x8
+ * @brief repack q40 to q40x4
  *
- * @param W output repacked q40x
- * @param repacked_W input q40
+ * @param dst output repacked q40x4
+ * @param src input q40
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void __ggml_repack_q4_0_to_q4_0_4(void *W, void *repacked_W, size_t data_size,
+void __ggml_repack_q4_0_to_q4_0_4(void *dst, void *src, size_t data_size,
                                   const unsigned int M, const unsigned int N);
 /**
  * @brief repack q40 to q40x8
  *
- * @param W output repacked q40x
- * @param repacked_W input q40
+ * @param dst output repacked q40x8
+ * @param src input q40
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void __ggml_repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
+void __ggml_repack_q4_0_to_q4_0_8(void *dst, void *src, size_t data_size,
                                   const unsigned int M, const unsigned int N);
 /**
  * @brief repack q4K to q4Kx8
  *
- * @param W output repacked q4Kx8
- * @param repacked_W input q4K
+ * @param dst output repacked q4Kx8
+ * @param src input q4K
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void __ggml_repack_q4_K_to_q4_K_8(void *W, void *repacked_W, size_t data_size,
+void __ggml_repack_q4_K_to_q4_K_8(void *dst, void *src, size_t data_size,
                                   const unsigned int M, const unsigned int N);
 
 #ifdef ENABLE_FP16

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -383,19 +383,19 @@ template <> void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
   __ggml_dequantize_row_q8_K(x, y, k);
 }
 
-void repack_q4_0(void *W, void *repacked_W, size_t data_size,
-                 const unsigned int M, const unsigned int N) {
-  __ggml_repack_q4_0_to_q4_0_8(W, repacked_W, data_size, M, N);
+void repack_q4_0(void *dst, void *src, size_t data_size, const unsigned int M,
+                 const unsigned int N) {
+  __ggml_repack_q4_0_to_q4_0_8(dst, src, data_size, M, N);
 }
 
-void repack_q4_0_to_q4_0_8(void *W, void *repacked_W, size_t data_size,
+void repack_q4_0_to_q4_0_8(void *dst, void *src, size_t data_size,
                            const unsigned int M, const unsigned int N) {
-  __ggml_repack_q4_0_to_q4_0_8(W, repacked_W, data_size, M, N);
+  __ggml_repack_q4_0_to_q4_0_8(dst, src, data_size, M, N);
 }
 
-void repack_q4_K(void *W, void *repacked_W, size_t data_size,
-                 const unsigned int M, const unsigned int N) {
-  __ggml_repack_q4_K_to_q4_K_8(W, repacked_W, data_size, M, N);
+void repack_q4_K(void *dst, void *src, size_t data_size, const unsigned int M,
+                 const unsigned int N) {
+  __ggml_repack_q4_K_to_q4_K_8(dst, src, data_size, M, N);
 }
 
 void unpack_q4_0(const void *in_q4_0x, void *out_q4_0, size_t data_size,

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1040,26 +1040,26 @@ void quantize_row_q8_K(const T *src, void *dst, int64_t k);
 /**
  * @brief repack q40 to q40x8
  *
- * @param W output repacked q40x8
- * @param repacked_W input q40
+ * @param dst output repacked q40x8
+ * @param src input q40
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void repack_q4_0(void *W, void *repacked_W, size_t data_size,
-                 const unsigned int M, const unsigned int N);
+void repack_q4_0(void *dst, void *src, size_t data_size, const unsigned int M,
+                 const unsigned int N);
 
 /**
  * @brief repack q4K to q4Kx8
  *
- * @param W output repacked q4Kx8
- * @param repacked_W input q4K
+ * @param dst output repacked q4Kx8
+ * @param src input q4K
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
  */
-void repack_q4_K(void *W, void *repacked_W, size_t data_size,
-                 const unsigned int M, const unsigned int N);
+void repack_q4_K(void *dst, void *src, size_t data_size, const unsigned int M,
+                 const unsigned int N);
 
 /**
  * @brief unpack q40x8 to q40 - invers method: repack_q4_0


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>Fix incorrect doxygen param descriptions for repack functions</summary><br />

The first parameter W is actually the output (destination) and
repacked_W is actually the input (source), as confirmed by tracing
through to nntr_repack_q4_0_to_q4_0_8_bl(dst, ..., data, ...).
Fix the @param annotations across all 6 header files for both
q4_0 and q4_K repack functions.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



<details><summary>Rename misleading repack param names W/repacked_W to dst/src</summary><br />

The repack functions had parameter names (W, repacked_W) that were
misleading - W is actually the output (dst) and repacked_W is the
input (src). Rename to dst/src across all backends (x86, ARM, ggml
interface, fallback) to match the actual semantics (dst-first, like
memcpy convention). Also fix the fallback repack implementation to
correctly map dst/src to the typed internal pointers.


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

### Summary

- Rename misleading parameter names (W, repacked_W) to dst/src across all backends to reflect actual semantics (dst-first), and fix the fallback implementation to correctly map dst/src to internal pointers.
- The first parameter W is the output (destination) and repacked_W is the input (source); update @param annotations in all 6 header files for both q4_0 and q4_K repack functions accordingly.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
