### PR TITLE
[CI] Update stale PR closure policy from 14 days to 30 days

### DIFF
--- a/.github/workflows/close_stale_pr.yml
+++ b/.github/workflows/close_stale_pr.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
-          stale-pr-message: 'This PR is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 3 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 3 days with no activity.'
           days-before-issue-stale: 90
-          days-before-pr-stale: 14
+          days-before-pr-stale: 30
           days-before-issue-close: 3
           days-before-pr-close: 3


### PR DESCRIPTION

## Dependency of the PR

## Commits to be reviewed in this PR

<details> <summary>[CI] Modify day to close stale PR</summary> <br />

- This commit updates the policy for closing stale PR by extending the duration from 14 days to 30 days.
- The previous 14-day limit was found to be too short, often leading to premature closures of PRs that were still in progress or awaiting feedback.
- By increasing the threshold, contributors will have more time to address feedback and ensure smoother collaboration.
 



**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>





### Summary

- This PR extends stale PR closure duration from 14 to 30 days to prevent premature closures and allow contributors more time to address feedback.

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>
      