### PR TITLE
[Quantizer] add ggml quantizer

### DIFF
--- a/nntrainer/tensor/quantizer.cpp
+++ b/nntrainer/tensor/quantizer.cpp
@@ -8,6 +8,7 @@
  * @bug		No known bugs except for NYI items
  */
 
+#include <cpu_backend.h>
 #include <math.h>
 #include <quantizer.h>
 #include <tensor.h>
@@ -236,5 +237,165 @@ Tensor BinaryCodeBasedQuantizer::dequantize(const Tensor &input,
 QScheme BinaryCodeBasedQuantizer::qscheme() const {
   return QScheme::BINARY_CODE_BASED;
 }
+
+/**
+ * @brief GgmlQuantizer class
+ */
+std::unique_ptr<Quantizer> GgmlQuantizer::create() {
+  return std::make_unique<GgmlQuantizer>(scheme_);
+}
+
+Tensor GgmlQuantizer::quantize(const Tensor &input, Tdatatype qtype) {
+  NNTR_THROW_IF(input.getDataType() != Tdatatype::FP32, std::invalid_argument)
+    << "[GgmlQuantizer::quantize] Input tensor must be FP32.";
+
+  TensorDim dim = input.getDim();
+  unsigned int K = dim.height();
+  unsigned int N = dim.width();
+
+  Tdatatype out_dtype;
+  switch (scheme_) {
+  case QScheme::Q4_Kx8:
+    out_dtype = Tdatatype::Q4_K;
+    break;
+  case QScheme::Q6_K:
+    out_dtype = Tdatatype::Q6_K;
+    break;
+  case QScheme::Q4_0:
+    out_dtype = Tdatatype::Q4_0;
+    break;
+  default:
+    throw std::invalid_argument(
+      "[GgmlQuantizer::quantize] Unsupported QScheme.");
+  }
+
+  // For GGML quantization, we need to transpose the weight first (row-major
+  // to column-major style), then quantize per row of the transposed matrix.
+  // The quantization functions expect data as (nrow, n_per_row).
+  Tensor W_t = input.transpose("0:2:1");
+  const float *src = W_t.getData<float>();
+
+  // Create output quantized tensor
+  Tensor output({dim.batch(), dim.channel(), K, N, Tformat::NCHW, out_dtype},
+                true, nntrainer::Initializer::NONE, "", scheme_);
+
+  // Quantize into a temporary buffer first
+  size_t out_size = output.size();
+  std::vector<char> tmp(out_size);
+
+  switch (scheme_) {
+  case QScheme::Q4_Kx8:
+    quantize_q4_K(src, tmp.data(), N, K, nullptr);
+    break;
+  case QScheme::Q6_K:
+    quantize_q6_K(src, tmp.data(), N, K, nullptr);
+    break;
+  case QScheme::Q4_0:
+    quantize_q4_0(src, tmp.data(), N, K, nullptr);
+    break;
+  default:
+    break;
+  }
+
+  // For Q4_Kx8 and Q4_0, repack into the optimized layout
+  if (scheme_ == QScheme::Q4_Kx8) {
+    repack_q4_K(output.getData<uint8_t>(), tmp.data(), out_size, N, K);
+  } else if (scheme_ == QScheme::Q4_0) {
+    repack_q4_0(output.getData<uint8_t>(), tmp.data(), out_size, N, K);
+  } else {
+    // Q6_K: copy directly (no repacking needed)
+    memcpy(output.getData<uint8_t>(), tmp.data(), out_size);
+  }
+
+  return output;
+}
+
+Tensor &GgmlQuantizer::quantize(const Tensor &input, Tensor &output,
+                                float *scales, unsigned int *zero_points) {
+  NNTR_THROW_IF(input.getDataType() != Tdatatype::FP32, std::invalid_argument)
+    << "[GgmlQuantizer::quantize] Input tensor must be FP32.";
+
+  NNTR_THROW_IF(output.empty(), std::invalid_argument)
+    << "[GgmlQuantizer::quantize] Output tensor is empty.";
+
+  NNTR_THROW_IF(output.q_scheme() != scheme_, std::invalid_argument)
+    << "[GgmlQuantizer::quantize] Output tensor's quantization scheme does not "
+       "match.";
+
+  TensorDim dim = input.getDim();
+  unsigned int K = dim.height();
+  unsigned int N = dim.width();
+
+  Tensor W_t = input.transpose("0:2:1");
+  const float *src = W_t.getData<float>();
+
+  size_t out_size = output.size();
+  std::vector<char> tmp(out_size);
+
+  switch (scheme_) {
+  case QScheme::Q4_Kx8:
+    quantize_q4_K(src, tmp.data(), N, K, nullptr);
+    break;
+  case QScheme::Q6_K:
+    quantize_q6_K(src, tmp.data(), N, K, nullptr);
+    break;
+  case QScheme::Q4_0:
+    quantize_q4_0(src, tmp.data(), N, K, nullptr);
+    break;
+  default:
+    throw std::invalid_argument(
+      "[GgmlQuantizer::quantize] Unsupported QScheme.");
+  }
+
+  if (scheme_ == QScheme::Q4_Kx8) {
+    repack_q4_K(output.getData<uint8_t>(), tmp.data(), out_size, N, K);
+  } else if (scheme_ == QScheme::Q4_0) {
+    repack_q4_0(output.getData<uint8_t>(), tmp.data(), out_size, N, K);
+  } else {
+    memcpy(output.getData<uint8_t>(), tmp.data(), out_size);
+  }
+
+  return output;
+}
+
+Tensor GgmlQuantizer::dequantize(const Tensor &input, Tdatatype dtype) {
+  NNTR_THROW_IF(dtype != Tdatatype::FP32, std::invalid_argument)
+    << "[GgmlQuantizer::dequantize] Output dtype must be FP32.";
+
+  TensorDim dim = input.getDim();
+  unsigned int K = dim.height();
+  unsigned int N = dim.width();
+  unsigned int total_elems = K * N;
+
+  Tensor output(dim.batch(), dim.channel(), K, N,
+                {Tformat::NCHW, Tdatatype::FP32});
+  size_t data_size = input.size();
+  std::vector<char> tmp(input.size());
+
+  const void *src = input.getData<uint8_t>();
+
+  switch (scheme_) {
+  case QScheme::Q4_Kx8:
+    ///@todo unpack should be supported to fully support dequtize
+    // dequantize_row_q4_K(src, output.getData(), total_elems);
+    throw std::invalid_argument(
+      "[GgmlQuantizer::dequantize] Q4_Kx8 is not supported yet.");
+    break;
+  case QScheme::Q6_K:
+    dequantize_row_q6_K(src, output.getData(), total_elems);
+    break;
+  case QScheme::Q4_0:
+    unpack_q4_0(src, tmp.data(), data_size, N, K);
+    dequantize_row_q4_0(tmp.data(), output.getData(), total_elems);
+    break;
+  default:
+    throw std::invalid_argument(
+      "[GgmlQuantizer::dequantize] Unsupported QScheme.");
+  }
+
+  return output;
+}
+
+QScheme GgmlQuantizer::qscheme() const { return scheme_; }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/quantizer.h
+++ b/nntrainer/tensor/quantizer.h
@@ -347,6 +347,60 @@ private:
 };
 
 /**
+ * @class GgmlQuantizer class
+ * @brief GgmlQuantizer class supports Q4_K, Q6_K, Q4_0 type.
+ */
+class GgmlQuantizer : public NonUniformQuantizer {
+public:
+  /**
+   * @brief Constructor of a GgmlQuantizer
+   * @param scheme Quantization scheme (Q4_Kx8, Q6_K, or Q4_0)
+   */
+  GgmlQuantizer(QScheme scheme = QScheme::Q4_Kx8) :
+    NonUniformQuantizer(), scheme_(scheme) {}
+
+  /**
+   * @copydoc Quantizer::create
+   */
+  std::unique_ptr<Quantizer> create() override;
+
+  /**
+   * @copydoc Quantizer::quantize(const Tensor &input,
+   * ml::train::TensorDim::DataType qtype)
+   */
+  Tensor quantize(const Tensor &input,
+                  ml::train::TensorDim::DataType qtype) override;
+
+  /**
+   * @copydoc Quantizer::quantize(const Tensor &input, Tensor &output, float
+   * *scales, unsigned int *zero_points)
+   */
+  Tensor &quantize(const Tensor &input, Tensor &output, float *scales,
+                   unsigned int *zero_points = nullptr) override;
+
+  /**
+   * @copydoc Quantizer::dequantize(const Tensor &input)
+   */
+  Tensor dequantize(const Tensor &input,
+                    ml::train::TensorDim::DataType dtype) override;
+
+  /**
+   * @copydoc Quantizer::qscheme()
+   */
+  QScheme qscheme() const override;
+
+private:
+  QScheme scheme_;
+
+  /**
+   * @copydoc Quantizer::calculateQParams(const Tensor &input,
+   * ml::train::TensorDim::DataType qtype)
+   */
+  void calculateQParams(const Tensor &input,
+                        ml::train::TensorDim::DataType qtype) override {}
+};
+
+/**
  * @brief Quantization class to create a quantizer
  *
  * @details The quantization class is a creator class to create a predefined
@@ -375,6 +429,11 @@ public:
       break;
     case QScheme::BINARY_CODE_BASED:
       return std::make_unique<BinaryCodeBasedQuantizer>();
+      break;
+    case QScheme::Q4_Kx8:
+    case QScheme::Q6_K:
+    case QScheme::Q4_0:
+      return std::make_unique<GgmlQuantizer>(qscheme);
       break;
     default:
       return Quantizer::getRegisteredQuantizer(qscheme)->create();

--- a/test/unittest/unittest_nntrainer_quantizer.cpp
+++ b/test/unittest/unittest_nntrainer_quantizer.cpp
@@ -18,6 +18,8 @@
 #include <quantizer.h>
 #include <tensor.h>
 
+#include <cpu_backend.h>
+
 /**
  * @brief Quantize to FP32 Tensor (negative test)
  */
@@ -401,6 +403,96 @@ TEST(nntrainer_Quantizer, per_tensor_affine_05_p) {
 
   ASSERT_EQ(output_s8, float_answer);
   ASSERT_EQ(output_u8, float_answer);
+}
+
+/**
+ * @brief GGMLQuantizer Q6_K quantize and dequantize
+ */
+TEST(nntrainer_Quantizer, ggml_q6k_01_p) {
+  nntrainer::init_backend();
+
+  uint32_t K = 512;
+  uint32_t N = 256;
+
+  std::vector<float> weight =
+    generate_random_vector<float>(K * N, -0.05f, 0.05f);
+
+  nntrainer::Tensor W_fp32(
+    1, 1, K, N, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
+
+  for (uint32_t k = 0; k < K; ++k)
+    for (uint32_t n = 0; n < N; ++n)
+      W_fp32.setValue(0, 0, k, n, weight[k * N + n]);
+
+  // Create GGML Q6_K quantizer
+  std::unique_ptr<nntrainer::Quantizer> quantizer =
+    nntrainer::Quantization::createQuantizer(nntrainer::QScheme::Q6_K);
+
+  EXPECT_EQ(quantizer->qscheme(), nntrainer::QScheme::Q6_K);
+
+  // Quantize
+  nntrainer::Tensor W_q6k =
+    quantizer->quantize(W_fp32, nntrainer::Tdatatype::Q6_K);
+
+  EXPECT_EQ(W_q6k.getDataType(), nntrainer::Tdatatype::Q6_K);
+
+  // Dequantize
+  nntrainer::Tensor W_deq =
+    quantizer->dequantize(W_q6k, nntrainer::Tdatatype::FP32);
+
+  EXPECT_EQ(W_deq.getDataType(), nntrainer::Tdatatype::FP32);
+
+  // Verify quantization quality: MSE should be small
+  auto mean_squared_error =
+    mse<float, float>(W_fp32.getData(), W_deq.getData(), K * N);
+
+  const float eps = 1e-5;
+  EXPECT_NEAR(mean_squared_error, 0., eps * K * N);
+}
+
+/**
+ * @brief GGMLQuantizer Q4_0 quantize and dequantize
+ */
+TEST(nntrainer_Quantizer, ggml_q4_0_01_p) {
+  nntrainer::init_backend();
+
+  uint32_t K = 768;
+  uint32_t N = 512;
+
+  std::vector<float> weight =
+    generate_random_vector<float>(K * N, -0.05f, 0.05f);
+
+  nntrainer::Tensor W_fp32(
+    1, 1, K, N, {nntrainer::Tformat::NCHW, nntrainer::Tdatatype::FP32});
+
+  for (uint32_t k = 0; k < K; ++k)
+    for (uint32_t n = 0; n < N; ++n)
+      W_fp32.setValue(0, 0, k, n, weight[k * N + n]);
+
+  // Create GGML Q4_0 quantizer
+  std::unique_ptr<nntrainer::Quantizer> quantizer =
+    nntrainer::Quantization::createQuantizer(nntrainer::QScheme::Q4_0);
+
+  EXPECT_EQ(quantizer->qscheme(), nntrainer::QScheme::Q4_0);
+
+  // Quantize
+  nntrainer::Tensor W_q40 =
+    quantizer->quantize(W_fp32, nntrainer::Tdatatype::Q4_0);
+
+  EXPECT_EQ(W_q40.getDataType(), nntrainer::Tdatatype::Q4_0);
+
+  // Dequantize
+  nntrainer::Tensor W_deq =
+    quantizer->dequantize(W_q40, nntrainer::Tdatatype::FP32);
+
+  EXPECT_EQ(W_deq.getDataType(), nntrainer::Tdatatype::FP32);
+
+  // Verify quantization quality: MSE should be small
+  auto mean_squared_error =
+    mse<float, float>(W_fp32.getData(), W_deq.getData(), K * N);
+
+  const float eps = 1e-5;
+  EXPECT_NEAR(mean_squared_error, 0., eps * K * N);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[Quantizer] add ggml quantizer</summary><br />

- This commit adds a ggml quantizer which supports Q4_K, Q4_0, Q6_K
- This commit adds unittest for ggml quantizer
- This commit resolves #3755

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


### Summary

- add ggml quantizer to support Q4_K/Q4_0/Q6_K quantization/dequtization support

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
