### PR TITLE
[causallm] Support deberta_v2 embedding model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ Applications/**/data
 cifar-100-binary*
 Applications/**/*.bin
 Applications/**/res/*
+!Applications/CausalLM/res/deberta_v2/
+Applications/CausalLM/res/deberta_v2/*
+!Applications/CausalLM/res/deberta_v2/weight_converter.py
 Applications/**/tokenizers-cpp-build/*
 
 # CTag

--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -219,6 +219,10 @@ LOCAL_SRC_FILES := ../quantize.cpp \
     ../models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp \
     ../models/gemma3/gemma3_causallm.cpp \
     ../models/gemma3/embedding_gemma.cpp \
+    ../models/gemma3/function.cpp \
+    ../models/deberta_v2/deberta_v2.cpp \
+    ../layers/deberta_attention_layer.cpp \
+    ../layers/shared_fully_connected_layer.cpp
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
 LOCAL_STATIC_LIBRARIES := tokenizers_c
@@ -235,5 +239,6 @@ LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES) \
     $(LOCAL_PATH)/../models/qwen3_slim_moe \
     $(LOCAL_PATH)/../models/qwen3_cached_slim_moe \
     $(LOCAL_PATH)/../models/gemma3 \
+    $(LOCAL_PATH)/../models/deberta_v2 \
 
 include $(BUILD_EXECUTABLE)

--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -27,6 +27,7 @@ CAUSALLM_COMMON_INCLUDES := \
     $(LOCAL_PATH)/../models/qwen3_cached_slim_moe \
     $(LOCAL_PATH)/../models/gemma3 \
     $(LOCAL_PATH)/../models/timm_vit \
+    $(LOCAL_PATH)/../models/deberta_v2 \
 
 # Prebuilt nntrainer libraries
 include $(CLEAR_VARS)
@@ -94,6 +95,9 @@ LOCAL_SRC_FILES := \
     ../models/gemma3/embedding_gemma.cpp \
     ../models/gemma3/function.cpp \
     ../models/timm_vit/timm_vit_transformer.cpp \
+    ../models/deberta_v2/deberta_v2.cpp \
+    ../layers/deberta_attention_layer.cpp \
+    ../layers/shared_fully_connected_layer.cpp \
 
 LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
 LOCAL_STATIC_LIBRARIES := tokenizers_c

--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -19,22 +19,22 @@
 
 #include <deberta_attention_layer.h>
 
-#include <algorithm>   // std::min, std::max
-#include <cmath>       // std::log, std::ceil, std::sqrt, std::tanh, std::abs
-#include <future>      // std::future
-#include <limits>      // std::numeric_limits
-#include <mutex>       // std::lock_guard, std::mutex
-#include <vector>      // std::vector
+#include <algorithm> // std::min, std::max
+#include <cmath>     // std::log, std::ceil, std::sqrt, std::tanh, std::abs
+#include <future>    // std::future
+#include <limits>    // std::numeric_limits
+#include <mutex>     // std::lock_guard, std::mutex
+#include <vector>    // std::vector
 
-#include <omp.h>
 #include <engine.h>
 #include <fp16.h>
 #include <nntrainer_error.h>
+#include <omp.h>
 
 #include <node_exporter.h>
 
 #if !defined(__ANDROID__)
-  #include <cblas.h>
+#include <cblas.h>
 #endif
 
 namespace causallm {
@@ -103,8 +103,8 @@ static thread_local RelativeIndexKey tl_rel_index_key{};
 static thread_local RelativeIndexValue tl_rel_index_value{};
 
 /**
- * Scratch buffer for unpacking key cache to FP32 in FP32 relative-attention path.
- * Reused per-thread to avoid repeated allocation/resizing overhead.
+ * Scratch buffer for unpacking key cache to FP32 in FP32 relative-attention
+ * path. Reused per-thread to avoid repeated allocation/resizing overhead.
  */
 static thread_local std::vector<float> tl_key_cache_fp32_buf;
 
@@ -156,7 +156,8 @@ void DebertaAttentionLayer::finalize(nntrainer::InitLayerContext &context) {
       expected_inputs++;
   }
 
-  NNTR_THROW_IF(context.getNumInputs() != expected_inputs, std::invalid_argument)
+  NNTR_THROW_IF(context.getNumInputs() != expected_inputs,
+                std::invalid_argument)
     << "DebertaAttentionLayer expects " << expected_inputs
     << " inputs, but got " << context.getNumInputs();
 
@@ -196,8 +197,8 @@ void DebertaAttentionLayer::finalize(nntrainer::InitLayerContext &context) {
   is_causal = false;
 
   local_window_size = std::max<unsigned int>(
-    query_dim.height(), max_position_embeddings > 0 ? max_position_embeddings
-                                                    : query_dim.height());
+    query_dim.height(),
+    max_position_embeddings > 0 ? max_position_embeddings : query_dim.height());
 
   attn_logit_softcapping = 0.0f;
 
@@ -229,8 +230,8 @@ void DebertaAttentionLayer::finalize(nntrainer::InitLayerContext &context) {
   output_dims[0] = query_dim;
   context.setOutputDimensions(output_dims);
 
-  prepare_bucket_table(std::max<unsigned int>(query_dim.height(),
-                                              max_position_embeddings));
+  prepare_bucket_table(
+    std::max<unsigned int>(query_dim.height(), max_position_embeddings));
 
 #if !defined(__ANDROID__)
   // Keep BLAS single-threaded inside the layer to avoid oversubscription.
@@ -238,7 +239,8 @@ void DebertaAttentionLayer::finalize(nntrainer::InitLayerContext &context) {
 #endif
 }
 
-void DebertaAttentionLayer::setProperty(const std::vector<std::string> &values) {
+void DebertaAttentionLayer::setProperty(
+  const std::vector<std::string> &values) {
   auto remain_props = loadProperties(values, deberta_props);
   LayerImpl::setProperty(remain_props);
 }
@@ -259,9 +261,9 @@ void DebertaAttentionLayer::prepare_bucket_table(unsigned int max_seq_len) {
 
   for (int diff = -static_cast<int>(max_seq_len);
        diff <= static_cast<int>(max_seq_len); ++diff) {
-    bucket_table[diff + offset] = compute_bucket_pos_impl(
-      diff, static_cast<int>(position_buckets),
-      static_cast<int>(max_relative_positions));
+    bucket_table[diff + offset] =
+      compute_bucket_pos_impl(diff, static_cast<int>(position_buckets),
+                              static_cast<int>(max_relative_positions));
   }
 
   bucket_table_max_seq_len = max_seq_len;
@@ -273,8 +275,8 @@ int DebertaAttentionLayer::lookup_bucket(int relative_pos) const {
     return relative_pos;
 
   const int offset = static_cast<int>(bucket_table_max_seq_len);
-  const int idx = clampv(relative_pos + offset, 0,
-                         static_cast<int>(bucket_table.size()) - 1);
+  const int idx =
+    clampv(relative_pos + offset, 0, static_cast<int>(bucket_table.size()) - 1);
   return bucket_table[idx];
 }
 
@@ -330,8 +332,8 @@ void DebertaAttentionLayer::incremental_forwarding(
       query_step_dim,
       batch * query_dim.getFeatureLen() + _from * query_dim.width(), true);
     nntrainer::Tensor key_step = key.getSharedDataTensor(
-      key_step_dim,
-      batch * key_dim.getFeatureLen() + _from * key_dim.width(), true);
+      key_step_dim, batch * key_dim.getFeatureLen() + _from * key_dim.width(),
+      true);
     nntrainer::Tensor value_step = value.getSharedDataTensor(
       value_step_dim,
       batch * value_dim.getFeatureLen() + _from * value_dim.width(), true);
@@ -655,13 +657,11 @@ void DebertaAttentionLayer::add_relative_attn_score(
    * Shared relative index cache across attention layers
 
    */
-  const unsigned int rel_len_q =
-    p2c ? rel_query.height() : 0u;
-  const unsigned int rel_len_k =
-    c2p ? rel_key.height() : 0u;
+  const unsigned int rel_len_q = p2c ? rel_query.height() : 0u;
+  const unsigned int rel_len_k = c2p ? rel_key.height() : 0u;
 
-  const RelativeIndexKey cache_key{
-    from, to, att_span, rel_len_q, rel_len_k, c2p, p2c};
+  const RelativeIndexKey cache_key{from,      to,  att_span, rel_len_q,
+                                   rel_len_k, c2p, p2c};
 
   RelativeIndexValue &rel_idx_local = tl_rel_index_value;
 
@@ -676,27 +676,26 @@ void DebertaAttentionLayer::add_relative_attn_score(
       rel_idx_local.p2c_idx.resize(static_cast<size_t>(S_q) * S_k);
     }
 
-    #pragma omp parallel for schedule(static)
-      for (unsigned int q = 0; q < S_q; ++q) {
-        for (unsigned int k = 0; k < S_k; ++k) {
-          if (c2p) {
-            const int rel = static_cast<int>(q + from) - static_cast<int>(k);
-            const int bucketed = lookup_bucket(rel);
-            rel_idx_local.c2p_idx[static_cast<size_t>(q) * S_k + k] =
-              clampv(bucketed + static_cast<int>(att_span), 0,
-                    static_cast<int>(rel_len_k) - 1);
-          }
+#pragma omp parallel for schedule(static)
+    for (unsigned int q = 0; q < S_q; ++q) {
+      for (unsigned int k = 0; k < S_k; ++k) {
+        if (c2p) {
+          const int rel = static_cast<int>(q + from) - static_cast<int>(k);
+          const int bucketed = lookup_bucket(rel);
+          rel_idx_local.c2p_idx[static_cast<size_t>(q) * S_k + k] =
+            clampv(bucketed + static_cast<int>(att_span), 0,
+                   static_cast<int>(rel_len_k) - 1);
+        }
 
-          if (p2c) {
-            const int rel_rev =
-              static_cast<int>(k) - static_cast<int>(q + from);
-            const int bucketed_rev = lookup_bucket(rel_rev);
-            rel_idx_local.p2c_idx[static_cast<size_t>(q) * S_k + k] =
-              clampv(-bucketed_rev + static_cast<int>(att_span), 0,
-                    static_cast<int>(rel_len_q) - 1);
-          }
+        if (p2c) {
+          const int rel_rev = static_cast<int>(k) - static_cast<int>(q + from);
+          const int bucketed_rev = lookup_bucket(rel_rev);
+          rel_idx_local.p2c_idx[static_cast<size_t>(q) * S_k + k] =
+            clampv(-bucketed_rev + static_cast<int>(att_span), 0,
+                   static_cast<int>(rel_len_q) - 1);
         }
       }
+    }
 
     tl_rel_index_key = cache_key;
     tl_rel_index_ready = true;
@@ -705,24 +704,22 @@ void DebertaAttentionLayer::add_relative_attn_score(
   if (score.getDataType() == ml::train::TensorDim::DataType::FP32) {
     float *score_ptr = score.getData<float>();
     const float *q_ptr = query_step.getData<float>();
-    const float *rel_query_ptr =
-      p2c ? rel_query.getData<float>() : nullptr;
-    const float *rel_key_ptr =
-      c2p ? rel_key.getData<float>() : nullptr;
+    const float *rel_query_ptr = p2c ? rel_query.getData<float>() : nullptr;
+    const float *rel_key_ptr = c2p ? rel_key.getData<float>() : nullptr;
 
     const uint16_t *key_u16_ptr =
       key_cache.getDataType() == ml::train::TensorDim::DataType::UINT16
         ? key_cache.getData<uint16_t>()
         : nullptr;
 
-    #ifdef ENABLE_FP16
+#ifdef ENABLE_FP16
     const _FP16 *key_fp16_ptr =
       key_cache.getDataType() == ml::train::TensorDim::DataType::FP16
         ? key_cache.getData<_FP16>()
         : nullptr;
-    #else
+#else
     const void *key_fp16_ptr = nullptr;
-    #endif
+#endif
 
     std::vector<float> &key_cache_fp32_buf = tl_key_cache_fp32_buf;
     const float *key_unpacked_ptr = nullptr;
@@ -732,100 +729,97 @@ void DebertaAttentionLayer::add_relative_attn_score(
      * If cache is packed/FP16, unpack once outside the hot loop.
      */
     if (p2c && (key_u16_ptr
-      #ifdef ENABLE_FP16
-                  || key_fp16_ptr
-      #endif
-                  )) {
-        const size_t unpack_len = static_cast<size_t>(S_k) * hidden;
-        if (key_cache_fp32_buf.size() < unpack_len) {
-          key_cache_fp32_buf.resize(unpack_len);
-        }
+#ifdef ENABLE_FP16
+                || key_fp16_ptr
+#endif
+                )) {
+      const size_t unpack_len = static_cast<size_t>(S_k) * hidden;
+      if (key_cache_fp32_buf.size() < unpack_len) {
+        key_cache_fp32_buf.resize(unpack_len);
+      }
 
-        for (unsigned int k = 0; k < S_k; ++k) {
-          float *dst =
-            key_cache_fp32_buf.data() + static_cast<size_t>(k) * hidden;
+      for (unsigned int k = 0; k < S_k; ++k) {
+        float *dst =
+          key_cache_fp32_buf.data() + static_cast<size_t>(k) * hidden;
 
-          if (key_u16_ptr) {
-            const uint16_t *src =
-              key_u16_ptr + static_cast<size_t>(k) * hidden;
-            for (unsigned int i = 0; i < hidden; ++i) {
-              dst[i] = nntrainer::compute_fp16_to_fp32(src[i]);
-            }
+        if (key_u16_ptr) {
+          const uint16_t *src = key_u16_ptr + static_cast<size_t>(k) * hidden;
+          for (unsigned int i = 0; i < hidden; ++i) {
+            dst[i] = nntrainer::compute_fp16_to_fp32(src[i]);
           }
-      #ifdef ENABLE_FP16
-          else if (key_fp16_ptr) {
-            const _FP16 *src =
-              key_fp16_ptr + static_cast<size_t>(k) * hidden;
-            for (unsigned int i = 0; i < hidden; ++i) {
-              dst[i] = static_cast<float>(src[i]);
-            }
-          }
-      #endif
         }
+#ifdef ENABLE_FP16
+        else if (key_fp16_ptr) {
+          const _FP16 *src = key_fp16_ptr + static_cast<size_t>(k) * hidden;
+          for (unsigned int i = 0; i < hidden; ++i) {
+            dst[i] = static_cast<float>(src[i]);
+          }
+        }
+#endif
+      }
 
-        key_unpacked_ptr = key_cache_fp32_buf.data();
+      key_unpacked_ptr = key_cache_fp32_buf.data();
     }
 
-  NNTR_THROW_IF(key_unpacked_ptr == nullptr, std::invalid_argument)
-                  << "FP32 relative attention path expected UINT16 or FP16 key cache";
+    NNTR_THROW_IF(key_unpacked_ptr == nullptr, std::invalid_argument)
+      << "FP32 relative attention path expected UINT16 or FP16 key cache";
 
-  #pragma omp parallel for schedule(static)
-      for (unsigned int q_idx = 0; q_idx < S_q; ++q_idx) {
-        const size_t qk_row = static_cast<size_t>(q_idx) * S_k;
+#pragma omp parallel for schedule(static)
+    for (unsigned int q_idx = 0; q_idx < S_q; ++q_idx) {
+      const size_t qk_row = static_cast<size_t>(q_idx) * S_k;
 
-        for (unsigned int h = 0; h < num_heads_Q; ++h) {
-          const unsigned int h_base = h * head_dim;
-          const float *q_head = q_ptr + q_idx * hidden + h_base;
+      for (unsigned int h = 0; h < num_heads_Q; ++h) {
+        const unsigned int h_base = h * head_dim;
+        const float *q_head = q_ptr + q_idx * hidden + h_base;
 
-          for (unsigned int k_idx = 0; k_idx < S_k; ++k_idx) {
-            float rel_score = 0.0f;
+        for (unsigned int k_idx = 0; k_idx < S_k; ++k_idx) {
+          float rel_score = 0.0f;
 
-            if (c2p) {
-              const int rel_index = rel_idx_local.c2p_idx[qk_row + k_idx];
-              const float *rk_head =
-                rel_key_ptr + static_cast<size_t>(rel_index) * hidden + h_base;
+          if (c2p) {
+            const int rel_index = rel_idx_local.c2p_idx[qk_row + k_idx];
+            const float *rk_head =
+              rel_key_ptr + static_cast<size_t>(rel_index) * hidden + h_base;
 
-              float c2p_dot = 0.0f;
-  #pragma omp simd reduction(+ : c2p_dot)
-              for (unsigned int d = 0; d < head_dim; ++d) {
-                c2p_dot += q_head[d] * rk_head[d];
-              }
-              rel_score += c2p_dot * scale;
+            float c2p_dot = 0.0f;
+#pragma omp simd reduction(+ : c2p_dot)
+            for (unsigned int d = 0; d < head_dim; ++d) {
+              c2p_dot += q_head[d] * rk_head[d];
             }
-
-            if (p2c) {
-              const int rel_index = rel_idx_local.p2c_idx[qk_row + k_idx];
-              const float *rq_head =
-                rel_query_ptr + static_cast<size_t>(rel_index) * hidden + h_base;
-
-              float p2c_dot = 0.0f;
-              const float *k_head =
-                key_unpacked_ptr + static_cast<size_t>(k_idx) * hidden + h_base;
-  #pragma omp simd reduction(+ : p2c_dot)
-              for (unsigned int d = 0; d < head_dim; ++d) {
-                p2c_dot += k_head[d] * rq_head[d];
-              }
-              rel_score += p2c_dot * scale;
-            }
-
-            const size_t linear_idx =
-              (static_cast<size_t>(q_idx) * S_k + k_idx) * num_heads_Q + h;
-            score_ptr[linear_idx] += rel_score;
+            rel_score += c2p_dot * scale;
           }
+
+          if (p2c) {
+            const int rel_index = rel_idx_local.p2c_idx[qk_row + k_idx];
+            const float *rq_head =
+              rel_query_ptr + static_cast<size_t>(rel_index) * hidden + h_base;
+
+            float p2c_dot = 0.0f;
+            const float *k_head =
+              key_unpacked_ptr + static_cast<size_t>(k_idx) * hidden + h_base;
+#pragma omp simd reduction(+ : p2c_dot)
+            for (unsigned int d = 0; d < head_dim; ++d) {
+              p2c_dot += k_head[d] * rq_head[d];
+            }
+            rel_score += p2c_dot * scale;
+          }
+
+          const size_t linear_idx =
+            (static_cast<size_t>(q_idx) * S_k + k_idx) * num_heads_Q + h;
+          score_ptr[linear_idx] += rel_score;
         }
       }
+    }
   } else if (score.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-    NNTR_THROW_IF(key_cache.getDataType() != ml::train::TensorDim::DataType::FP16,
+    NNTR_THROW_IF(key_cache.getDataType() !=
+                    ml::train::TensorDim::DataType::FP16,
                   std::invalid_argument)
       << "FP16 relative attention path requires FP16 key cache";
 
     _FP16 *score_ptr = score.getData<_FP16>();
     const _FP16 *q_ptr = query_step.getData<_FP16>();
-    const _FP16 *rel_query_ptr =
-      p2c ? rel_query.getData<_FP16>() : nullptr;
-    const _FP16 *rel_key_ptr =
-      c2p ? rel_key.getData<_FP16>() : nullptr;
+    const _FP16 *rel_query_ptr = p2c ? rel_query.getData<_FP16>() : nullptr;
+    const _FP16 *rel_key_ptr = c2p ? rel_key.getData<_FP16>() : nullptr;
     const _FP16 *key_fp16_ptr = key_cache.getData<_FP16>();
 
 #pragma omp parallel for schedule(static)
@@ -847,8 +841,8 @@ void DebertaAttentionLayer::add_relative_attn_score(
             float c2p_dot = 0.0f;
 #pragma omp simd reduction(+ : c2p_dot)
             for (unsigned int d = 0; d < head_dim; ++d) {
-              c2p_dot += static_cast<float>(q_head[d]) *
-                         static_cast<float>(rk_head[d]);
+              c2p_dot +=
+                static_cast<float>(q_head[d]) * static_cast<float>(rk_head[d]);
             }
             rel_score += c2p_dot * scale;
           }
@@ -863,8 +857,8 @@ void DebertaAttentionLayer::add_relative_attn_score(
             float p2c_dot = 0.0f;
 #pragma omp simd reduction(+ : p2c_dot)
             for (unsigned int d = 0; d < head_dim; ++d) {
-              p2c_dot += static_cast<float>(k_head[d]) *
-                         static_cast<float>(rq_head[d]);
+              p2c_dot +=
+                static_cast<float>(k_head[d]) * static_cast<float>(rq_head[d]);
             }
             rel_score += p2c_dot * scale;
           }
@@ -891,8 +885,7 @@ void DebertaAttentionLayer::one_batch_incremental_forwarding(
   nntrainer::Tensor &query_step, nntrainer::Tensor &key_step,
   nntrainer::Tensor &value_step, nntrainer::Tensor &attention_output_step,
   nntrainer::Tensor &cache_key, nntrainer::Tensor &cache_value,
-  ml::train::TensorDim &cache_key_dim,
-  ml::train::TensorDim &cache_key_step_dim,
+  ml::train::TensorDim &cache_key_dim, ml::train::TensorDim &cache_key_step_dim,
   ml::train::TensorDim &cache_value_dim,
   ml::train::TensorDim &cache_value_step_dim) {
 
@@ -924,11 +917,12 @@ void DebertaAttentionLayer::one_batch_incremental_forwarding(
                          query_step.getTensorType());
 
   const unsigned int gqa_size = num_heads_Q / num_heads_KV;
-  
+
   compute_kcaches(query_step, b_cached_key, out_, _from, to - from, num_heads_Q,
                   gqa_size, head_dim, pool);
 
-  const bool relative_attention = std::get<props::RelativeAttention>(deberta_props).get();
+  const bool relative_attention =
+    std::get<props::RelativeAttention>(deberta_props).get();
   if (relative_attention) {
     const bool c2p = std::get<props::C2P>(deberta_props).get();
     const bool p2c = std::get<props::P2C>(deberta_props).get();
@@ -944,7 +938,7 @@ void DebertaAttentionLayer::one_batch_incremental_forwarding(
         ptr[i] *= content_rescale;
       }
     }
-  #ifdef ENABLE_FP16
+#ifdef ENABLE_FP16
     else if (out_.getDataType() == ml::train::TensorDim::DataType::FP16) {
       _FP16 *ptr = out_.getData<_FP16>();
       const size_t len =
@@ -953,8 +947,8 @@ void DebertaAttentionLayer::one_batch_incremental_forwarding(
         ptr[i] = (_FP16)((float)ptr[i] * content_rescale);
       }
     }
-  #endif
-    add_relative_attn_score(context, out_, query_step, b_cached_key, from, to);  
+#endif
+    add_relative_attn_score(context, out_, query_step, b_cached_key, from, to);
   }
   softmax_triangle(out_, to - from, num_heads_Q, from, pool);
 
@@ -1009,8 +1003,7 @@ void DebertaAttentionLayer::calcGradient(nntrainer::RunLayerContext &context) {
 }
 
 void DebertaAttentionLayer::exportTo(
-  nntrainer::Exporter &exporter,
-  const ml::train::ExportMethods &method) const {
+  nntrainer::Exporter &exporter, const ml::train::ExportMethods &method) const {
   LayerImpl::exportTo(exporter, method);
   exporter.saveResult(deberta_props, method, this);
 }

--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -21,15 +21,12 @@
 
 #include <algorithm> // std::min, std::max
 #include <cmath>     // std::log, std::ceil, std::sqrt, std::tanh, std::abs
-#include <future>    // std::future
 #include <limits>    // std::numeric_limits
 #include <mutex>     // std::lock_guard, std::mutex
 #include <vector>    // std::vector
 
-#include <engine.h>
 #include <fp16.h>
 #include <nntrainer_error.h>
-#include <omp.h>
 
 #include <node_exporter.h>
 
@@ -107,6 +104,69 @@ static thread_local RelativeIndexValue tl_rel_index_value{};
  */
 static thread_local std::vector<float> tl_key_cache_fp32_buf;
 
+static void compute_kcaches_fp32_reference(
+  const float *in, const float *kcache, float *output, int num_rows,
+  int num_cache_head, int head_dim, int gqa_size, size_t local_window_size,
+  int head_start = 0, int head_end = -1) {
+  const int actual_head_end = (head_end < 0) ? num_cache_head : head_end;
+  NNTR_THROW_IF(head_start >= actual_head_end, std::invalid_argument)
+    << "head_start (" << head_start << ") must be less than head_end ("
+    << actual_head_end << ")";
+
+  const int window = static_cast<int>(
+    std::min(static_cast<size_t>(num_rows), local_window_size));
+  const int start_row = num_rows - window;
+  const float inv_sqrt_head_dim =
+    1.0f / std::sqrt(static_cast<float>(head_dim));
+
+  for (int n = head_start; n < actual_head_end; ++n) {
+    for (int g = 0; g < gqa_size; ++g) {
+      const float *query = in + (n * gqa_size + g) * head_dim;
+      for (int row = start_row; row < num_rows; ++row) {
+        const float *key = kcache + (row * num_cache_head + n) * head_dim;
+        float sum = 0.0f;
+        for (int d = 0; d < head_dim; ++d) {
+          sum += query[d] * key[d];
+        }
+        output[(row - start_row) * num_cache_head * gqa_size + n * gqa_size +
+               g] = sum * inv_sqrt_head_dim;
+      }
+    }
+  }
+}
+
+static void compute_vcache_fp32_transposed_reference(
+  int row_num, const float *in, const float *vcache, float *output,
+  int num_cache_head, int gqa_size, int head_dim, size_t local_window_size,
+  int head_start = 0, int head_end = -1) {
+  const int actual_head_end = (head_end < 0) ? num_cache_head : head_end;
+  NNTR_THROW_IF(head_start >= actual_head_end, std::invalid_argument)
+    << "head_start (" << head_start << ") must be less than head_end ("
+    << actual_head_end << ")";
+
+  const int window = static_cast<int>(
+    std::min(static_cast<size_t>(row_num + 1), local_window_size));
+  const int start_row = row_num + 1 - window;
+
+  for (int n = head_start; n < actual_head_end; ++n) {
+    for (int h = 0; h < gqa_size; ++h) {
+      float *out = output + (n * gqa_size + h) * head_dim;
+      std::fill(out, out + head_dim, 0.0f);
+
+      for (int row = start_row; row <= row_num; ++row) {
+        const float *score =
+          in + row * num_cache_head * gqa_size + n * gqa_size + h;
+        const float *value = vcache + (row * num_cache_head + n) * head_dim;
+        const float weight = *score;
+
+        for (int d = 0; d < head_dim; ++d) {
+          out[d] += weight * value[d];
+        }
+      }
+    }
+  }
+}
+
 } // namespace
 
 /**
@@ -127,7 +187,9 @@ DebertaAttentionLayer::DebertaAttentionLayer() :
   max_relative_positions(0),
   position_buckets(0),
   local_window_size(0),
-  attn_logit_softcapping(0.0f) {
+  attn_logit_softcapping(0.0f),
+  bucket_table_max_seq_len(0),
+  bucket_table_ready(false) {
   tensor_idx.fill(std::numeric_limits<unsigned>::max());
 }
 
@@ -208,10 +270,10 @@ void DebertaAttentionLayer::finalize(nntrainer::InitLayerContext &context) {
 #else
   ml::train::TensorDim cache_key_dim(
     {query_dim.batch(), 1, query_dim.height(), key_dim.width()},
-    {context.getFormat(), ml::train::TensorDim::DataType::UINT16});
+    {context.getFormat(), key_dim.getDataType()});
   ml::train::TensorDim cache_value_dim(
     {query_dim.batch(), 1, query_dim.height(), value_dim.width()},
-    {context.getFormat(), ml::train::TensorDim::DataType::UINT16});
+    {context.getFormat(), value_dim.getDataType()});
 #endif
 
   tensor_idx[AttentionParams::cache_key] = context.requestTensor(
@@ -239,7 +301,7 @@ void DebertaAttentionLayer::setProperty(
 void DebertaAttentionLayer::prepare_bucket_table(unsigned int max_seq_len) {
   const bool relative_attention =
     std::get<props::RelativeAttention>(deberta_props).get();
-  if (!relative_attention || position_buckets == 0)
+  if (!relative_attention || position_buckets <= 0)
     return;
 
   std::lock_guard<std::mutex> lock(bucket_mtx);
@@ -262,7 +324,7 @@ void DebertaAttentionLayer::prepare_bucket_table(unsigned int max_seq_len) {
 }
 
 int DebertaAttentionLayer::lookup_bucket(int relative_pos) const {
-  if (!bucket_table_ready || position_buckets == 0)
+  if (!bucket_table_ready || position_buckets <= 0)
     return relative_pos;
 
   const int offset = static_cast<int>(bucket_table_max_seq_len);
@@ -352,7 +414,7 @@ void DebertaAttentionLayer::incremental_forwarding(
 void DebertaAttentionLayer::compute_kcaches(
   nntrainer::Tensor &in, nntrainer::Tensor &cache, nntrainer::Tensor &out,
   unsigned int from, size_t sequence_len, unsigned int num_head,
-  unsigned int group_size, unsigned int head_dim, BS::thread_pool<> &pool) {
+  unsigned int group_size, unsigned int head_dim) {
 
   if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
     if (sequence_len == 1) {
@@ -360,38 +422,44 @@ void DebertaAttentionLayer::compute_kcaches(
       const unsigned int num_cache_head = num_head / group_size;
 
       const float *in_data = in.getData<float>();
-      const uint16_t *cache_data = cache.getData<uint16_t>();
       float *out_data = out.getData<float>();
 
 #pragma omp parallel for schedule(static)
       for (unsigned int head_kv = 0; head_kv < num_cache_head; ++head_kv) {
-        nntrainer::compute_kcaches<uint16_t>(
-          in_data, cache_data, out_data, row_to_compute, num_cache_head,
-          head_dim, group_size, tile_size, local_window_size, head_kv,
-          head_kv + 1);
+        if (cache.getDataType() == ml::train::TensorDim::DataType::FP32) {
+          compute_kcaches_fp32_reference(
+            in_data, cache.getData<float>(), out_data, row_to_compute,
+            num_cache_head, head_dim, group_size, local_window_size, head_kv,
+            head_kv + 1);
+        } else {
+          nntrainer::compute_kcaches<uint16_t>(
+            in_data, cache.getData<uint16_t>(), out_data, row_to_compute,
+            num_cache_head, head_dim, group_size, tile_size, local_window_size,
+            head_kv, head_kv + 1);
+        }
       }
 
     } else {
-      std::vector<std::future<void>> futures;
       const unsigned int seq = static_cast<unsigned int>(sequence_len);
 
       for (unsigned int i = 0; i < seq; ++i) {
         float *input_addr = in.getData<float>() + num_head * head_dim * i;
-        uint16_t *cache_addr = cache.getData<uint16_t>();
         const int row_to_compute = from + sequence_len;
         const size_t out_start_row = i * (from + sequence_len);
         float *output_addr = out.getData<float>() + out_start_row * num_head;
 
-        futures.emplace_back(pool.submit_task([=]() {
+        if (cache.getDataType() == ml::train::TensorDim::DataType::FP32) {
+          compute_kcaches_fp32_reference(
+            input_addr, cache.getData<float>(), output_addr, row_to_compute,
+            num_head / group_size, head_dim, group_size, local_window_size);
+        } else {
+          uint16_t *cache_addr = cache.getData<uint16_t>();
           nntrainer::compute_kcaches<uint16_t>(
             input_addr, cache_addr, output_addr, row_to_compute,
             num_head / group_size, head_dim, group_size, tile_size,
             local_window_size);
-        }));
+        }
       }
-
-      for (auto &fut : futures)
-        fut.get();
     }
 
   } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
@@ -411,7 +479,6 @@ void DebertaAttentionLayer::compute_kcaches(
           group_size, tile_size, local_window_size, head_kv, head_kv + 1);
       }
     } else {
-      std::vector<std::future<void>> futures;
       const unsigned int seq = static_cast<unsigned int>(sequence_len);
 
       for (unsigned int i = 0; i < seq; ++i) {
@@ -421,16 +488,11 @@ void DebertaAttentionLayer::compute_kcaches(
         const size_t out_start_row = i * (from + sequence_len);
         _FP16 *output_addr = out.getData<_FP16>() + out_start_row * num_head;
 
-        futures.emplace_back(pool.submit_task([=]() {
-          nntrainer::compute_kcaches(input_addr, cache_addr, output_addr,
-                                     row_to_compute, num_head / group_size,
-                                     head_dim, group_size, tile_size,
-                                     local_window_size);
-        }));
+        nntrainer::compute_kcaches(input_addr, cache_addr, output_addr,
+                                   row_to_compute, num_head / group_size,
+                                   head_dim, group_size, tile_size,
+                                   local_window_size);
       }
-
-      for (auto &fut : futures)
-        fut.get();
     }
 #else
     NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
@@ -443,8 +505,7 @@ void DebertaAttentionLayer::compute_kcaches(
  */
 void DebertaAttentionLayer::softmax_triangle(nntrainer::Tensor &qk_out,
                                              size_t row, size_t num_head,
-                                             unsigned int from,
-                                             BS::thread_pool<> &pool) {
+                                             unsigned int from) {
   if (qk_out.getDataType() == ml::train::TensorDim::DataType::FP32) {
     float *qk_out_ = qk_out.getData<float>();
 
@@ -463,17 +524,12 @@ void DebertaAttentionLayer::softmax_triangle(nntrainer::Tensor &qk_out,
       const size_t end_row = from + row;
       nntrainer::softmax_row_inplace(qk_out_, start_row, end_row, num_head);
     } else {
-      std::vector<std::future<void>> futures;
       for (unsigned int i = 0; i < row; ++i) {
         const unsigned int to = from + row;
         const size_t start_row = i * to;
         const size_t end_row = (i + 1) * to;
-        futures.push_back(pool.submit_task([=]() {
-          nntrainer::softmax_row(qk_out_, start_row, end_row, num_head);
-        }));
+        nntrainer::softmax_row(qk_out_, start_row, end_row, num_head);
       }
-      for (auto &fut : futures)
-        fut.get();
     }
 
   } else if (qk_out.getDataType() == ml::train::TensorDim::DataType::FP16) {
@@ -495,17 +551,12 @@ void DebertaAttentionLayer::softmax_triangle(nntrainer::Tensor &qk_out,
       const size_t end_row = from + row;
       nntrainer::softmax_row_inplace(qk_out_, start_row, end_row, num_head);
     } else {
-      std::vector<std::future<void>> futures;
       for (unsigned int i = 0; i < row; ++i) {
         const unsigned int to = from + row;
         const size_t start_row = i * to;
         const size_t end_row = (i + 1) * to;
-        futures.push_back(pool.submit_task([=]() {
-          nntrainer::softmax_row_inplace(qk_out_, start_row, end_row, num_head);
-        }));
+        nntrainer::softmax_row_inplace(qk_out_, start_row, end_row, num_head);
       }
-      for (auto &fut : futures)
-        fut.get();
     }
 #else
     NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
@@ -518,72 +569,70 @@ void DebertaAttentionLayer::softmax_triangle(nntrainer::Tensor &qk_out,
  */
 void DebertaAttentionLayer::compute_fp16vcache_transposed(
   nntrainer::Tensor &in, nntrainer::Tensor &vcache, nntrainer::Tensor &output,
-  int from, int num_cache_head, int gqa_size, int head_dim, int to,
-  BS::thread_pool<> &pool) {
+  int from, int num_cache_head, int gqa_size, int head_dim, int to) {
 
   if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
     if ((to - from) != 1) {
-      std::vector<std::future<void>> futures;
       const int seq = to - from;
-      futures.reserve(seq);
 
       for (int i = 0; i < seq; ++i) {
-        futures.push_back(pool.submit_task([=]() {
-          const size_t start_idx = i * to;
-          const float *input =
-            in.getData<float>() + start_idx * num_cache_head * gqa_size;
-          float *out = output.getData<float>() +
-                       i * (num_cache_head * gqa_size * head_dim);
-          const int row_num = to - 1;
+        const size_t start_idx = i * to;
+        const float *input =
+          in.getData<float>() + start_idx * num_cache_head * gqa_size;
+        float *out =
+          output.getData<float>() + i * (num_cache_head * gqa_size * head_dim);
+        const int row_num = to - 1;
 
+        if (vcache.getDataType() == ml::train::TensorDim::DataType::FP32) {
+          compute_vcache_fp32_transposed_reference(
+            row_num, input, vcache.getData<float>(), out, num_cache_head,
+            gqa_size, head_dim, local_window_size);
+        } else {
           nntrainer::compute_fp16vcache_fp32_transposed(
             row_num, input, vcache.getData<uint16_t>(), out, num_cache_head,
             gqa_size, head_dim, local_window_size);
-        }));
+        }
       }
-
-      for (auto &fut : futures)
-        fut.get();
 
     } else {
       const int row_num = to - 1;
 
       const float *in_data = in.getData<float>();
-      const uint16_t *vcache_data = vcache.getData<uint16_t>();
       float *output_data = output.getData<float>();
 
 #pragma omp parallel for schedule(static)
       for (int head_kv = 0; head_kv < num_cache_head; ++head_kv) {
-        nntrainer::compute_fp16vcache_fp32_transposed(
-          row_num, in_data, vcache_data, output_data, num_cache_head, gqa_size,
-          head_dim, local_window_size, head_kv, head_kv + 1);
+        if (vcache.getDataType() == ml::train::TensorDim::DataType::FP32) {
+          compute_vcache_fp32_transposed_reference(
+            row_num, in_data, vcache.getData<float>(), output_data,
+            num_cache_head, gqa_size, head_dim, local_window_size, head_kv,
+            head_kv + 1);
+        } else {
+          nntrainer::compute_fp16vcache_fp32_transposed(
+            row_num, in_data, vcache.getData<uint16_t>(), output_data,
+            num_cache_head, gqa_size, head_dim, local_window_size, head_kv,
+            head_kv + 1);
+        }
       }
     }
 
   } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
     if ((to - from) != 1) {
-      std::vector<std::future<void>> futures;
       const int seq = to - from;
-      futures.reserve(seq);
 
       for (int i = 0; i < seq; ++i) {
-        futures.push_back(pool.submit_task([=]() {
-          const size_t start_idx = i * to;
-          const _FP16 *input =
-            in.getData<_FP16>() + start_idx * num_cache_head * gqa_size;
-          _FP16 *out = output.getData<_FP16>() +
-                       i * (num_cache_head * gqa_size * head_dim);
-          const int row_num = to - 1;
+        const size_t start_idx = i * to;
+        const _FP16 *input =
+          in.getData<_FP16>() + start_idx * num_cache_head * gqa_size;
+        _FP16 *out =
+          output.getData<_FP16>() + i * (num_cache_head * gqa_size * head_dim);
+        const int row_num = to - 1;
 
-          nntrainer::compute_fp16vcache_transposed(
-            row_num, input, vcache.getData<_FP16>(), out, num_cache_head,
-            gqa_size, head_dim, local_window_size);
-        }));
+        nntrainer::compute_fp16vcache_transposed(
+          row_num, input, vcache.getData<_FP16>(), out, num_cache_head,
+          gqa_size, head_dim, local_window_size);
       }
-
-      for (auto &fut : futures)
-        fut.get();
 
     } else {
       const int row_num = to - 1;
@@ -677,10 +726,10 @@ void DebertaAttentionLayer::add_relative_attn_score(
         }
 
         if (p2c) {
-          const int rel_rev = static_cast<int>(k) - static_cast<int>(q + from);
-          const int bucketed_rev = lookup_bucket(rel_rev);
+          const int rel = static_cast<int>(q + from) - static_cast<int>(k);
+          const int bucketed = lookup_bucket(rel);
           rel_idx_local.p2c_idx[static_cast<size_t>(q) * S_k + k] =
-            clampv(-bucketed_rev + static_cast<int>(att_span), 0,
+            clampv(-bucketed + static_cast<int>(att_span), 0,
                    static_cast<int>(rel_len_q) - 1);
         }
       }
@@ -711,7 +760,10 @@ void DebertaAttentionLayer::add_relative_attn_score(
 #endif
 
     std::vector<float> &key_cache_fp32_buf = tl_key_cache_fp32_buf;
-    const float *key_unpacked_ptr = nullptr;
+    const float *key_unpacked_ptr =
+      key_cache.getDataType() == ml::train::TensorDim::DataType::FP32
+        ? key_cache.getData<float>()
+        : nullptr;
 
     /**
      * p2c path needs key-cache values in FP32 for dot(q_rel, k_cache).
@@ -751,7 +803,7 @@ void DebertaAttentionLayer::add_relative_attn_score(
     }
 
     NNTR_THROW_IF(p2c && key_unpacked_ptr == nullptr, std::invalid_argument)
-      << "FP32 p2c path expected UINT16 or FP16 key cache";
+      << "FP32 p2c path expected FP32, UINT16, or FP16 key cache";
 
 #pragma omp parallel for schedule(static)
     for (unsigned int q_idx = 0; q_idx < S_q; ++q_idx) {
@@ -878,9 +930,6 @@ void DebertaAttentionLayer::one_batch_incremental_forwarding(
   ml::train::TensorDim &cache_value_dim,
   ml::train::TensorDim &cache_value_step_dim) {
 
-  auto &pool =
-    nntrainer::Engine::Global().getThreadPoolManager()->getThreadPool();
-
   nntrainer::Tensor b_cache_key_step = cache_key.getSharedDataTensor(
     cache_key_step_dim,
     batch * cache_key_dim.getFeatureLen() + from * cache_key_dim.width(), true);
@@ -908,7 +957,7 @@ void DebertaAttentionLayer::one_batch_incremental_forwarding(
   const unsigned int gqa_size = num_heads_Q / num_heads_KV;
 
   compute_kcaches(query_step, b_cached_key, out_, _from, to - from, num_heads_Q,
-                  gqa_size, head_dim, pool);
+                  gqa_size, head_dim);
 
   const bool relative_attention =
     std::get<props::RelativeAttention>(deberta_props).get();
@@ -939,11 +988,10 @@ void DebertaAttentionLayer::one_batch_incremental_forwarding(
 #endif
     add_relative_attn_score(context, out_, query_step, b_cached_key, from, to);
   }
-  softmax_triangle(out_, to - from, num_heads_Q, from, pool);
+  softmax_triangle(out_, to - from, num_heads_Q, from);
 
   compute_fp16vcache_transposed(out_, b_cached_value, attention_output_step,
-                                from, num_heads_KV, gqa_size, head_dim, to,
-                                pool);
+                                from, num_heads_KV, gqa_size, head_dim, to);
 }
 
 void DebertaAttentionLayer::setBatch(nntrainer::RunLayerContext &context,
@@ -964,8 +1012,8 @@ void DebertaAttentionLayer::updateTensorsByInputDimensions(
   k_dim.setDataType(ml::train::TensorDim::DataType::FP16);
   v_dim.setDataType(ml::train::TensorDim::DataType::FP16);
 #else
-  k_dim.setDataType(ml::train::TensorDim::DataType::UINT16);
-  v_dim.setDataType(ml::train::TensorDim::DataType::UINT16);
+  k_dim.setDataType(input_dimensions[INPUT_IDX_K].getDataType());
+  v_dim.setDataType(input_dimensions[INPUT_IDX_V].getDataType());
 #endif
 
   context.updateInput(INPUT_IDX_Q, input_dimensions[INPUT_IDX_Q]);

--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -85,6 +85,9 @@ struct RelativeIndexKey {
   }
 };
 
+/**
+ * @brief shared c2p/p2c relative index value
+ */
 struct RelativeIndexValue {
   std::vector<int> c2p_idx;
   std::vector<int> p2c_idx;

--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -128,8 +128,7 @@ DebertaAttentionLayer::DebertaAttentionLayer() :
   max_relative_positions(0),
   position_buckets(0),
   local_window_size(0),
-  attn_logit_softcapping(0.0f),
-  is_causal(false) {
+  attn_logit_softcapping(0.0f) {
   tensor_idx.fill(std::numeric_limits<unsigned>::max());
 }
 
@@ -193,8 +192,6 @@ void DebertaAttentionLayer::finalize(nntrainer::InitLayerContext &context) {
 
   if (max_relative_positions < 1)
     max_relative_positions = max_position_embeddings;
-
-  is_causal = false;
 
   local_window_size = std::max<unsigned int>(
     query_dim.height(),

--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -33,10 +33,6 @@
 
 #include <node_exporter.h>
 
-#if !defined(__ANDROID__)
-#include <cblas.h>
-#endif
-
 namespace causallm {
 
 #define tile_size 4
@@ -229,11 +225,6 @@ void DebertaAttentionLayer::finalize(nntrainer::InitLayerContext &context) {
 
   prepare_bucket_table(
     std::max<unsigned int>(query_dim.height(), max_position_embeddings));
-
-#if !defined(__ANDROID__)
-  // Keep BLAS single-threaded inside the layer to avoid oversubscription.
-  openblas_set_num_threads(4);
-#endif
 }
 
 void DebertaAttentionLayer::setProperty(
@@ -279,9 +270,8 @@ int DebertaAttentionLayer::lookup_bucket(int relative_pos) const {
 
 void DebertaAttentionLayer::forwarding(nntrainer::RunLayerContext &context,
                                        bool training) {
-  nntrainer::Tensor &q = context.getInput(INPUT_IDX_Q);
-  nntrainer::Tensor &output = context.getOutput(OUTPUT_IDX);
-  output.copyData(q);
+  throw nntrainer::exception::not_supported(
+    "DebertaAttentionLayer::forwarding is not supported yet");
 }
 
 /**
@@ -757,8 +747,8 @@ void DebertaAttentionLayer::add_relative_attn_score(
       key_unpacked_ptr = key_cache_fp32_buf.data();
     }
 
-    NNTR_THROW_IF(key_unpacked_ptr == nullptr, std::invalid_argument)
-      << "FP32 relative attention path expected UINT16 or FP16 key cache";
+    NNTR_THROW_IF(p2c && key_unpacked_ptr == nullptr, std::invalid_argument)
+      << "FP32 p2c path expected UINT16 or FP16 key cache";
 
 #pragma omp parallel for schedule(static)
     for (unsigned int q_idx = 0; q_idx < S_q; ++q_idx) {

--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -652,7 +652,6 @@ void DebertaAttentionLayer::add_relative_attn_score(
 
   /**
    * Shared relative index cache across attention layers
-
    */
   const unsigned int rel_len_q = p2c ? rel_query.height() : 0u;
   const unsigned int rel_len_k = c2p ? rel_key.height() : 0u;

--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -1,0 +1,1034 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   deberta_attention_layer.cpp
+ * @date   16 March 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Seunghui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  DeBERTa Attention Layer based on mha_core optimized path.
+ *
+ *         Main execution flow:
+ *           1) compute_kcaches()               -> content-to-content score
+ *           2) rescale content score           -> match DeBERTa scaling
+ *           3) add_relative_attn_score()       -> add c2p / p2c score
+ *           4) softmax_triangle()              -> softmax on score
+ *           5) compute_fp16vcache_transposed() -> score * value
+ */
+
+#include <deberta_attention_layer.h>
+
+#include <algorithm>   // std::min, std::max
+#include <cmath>       // std::log, std::ceil, std::sqrt, std::tanh, std::abs
+#include <future>      // std::future
+#include <limits>      // std::numeric_limits
+#include <mutex>       // std::lock_guard, std::mutex
+#include <vector>      // std::vector
+
+#include <omp.h>
+#include <engine.h>
+#include <fp16.h>
+#include <nntrainer_error.h>
+
+#include <node_exporter.h>
+
+#if !defined(__ANDROID__)
+  #include <cblas.h>
+#endif
+
+namespace causallm {
+
+#define tile_size 4
+
+namespace {
+
+/**
+ * @brief clamp helper
+ */
+template <typename T> static inline T clampv(T v, T lo, T hi) {
+  return std::min(std::max(v, lo), hi);
+}
+
+/**
+ * @brief exact bucket implementation used in the original working version
+ */
+static int compute_bucket_pos_impl(int relative_pos, int bucket_size,
+                                   int max_position) {
+  const int mid = bucket_size / 2;
+  const int sign = (relative_pos >= 0) ? 1 : -1;
+  const int abs_rp = std::abs(relative_pos);
+  const int abs_pos = (abs_rp < mid) ? (mid - 1) : abs_rp;
+
+  const double num = std::log((double)abs_pos / (double)mid);
+  const double den = std::log((double)(max_position - 1) / (double)mid);
+  int log_pos = (int)std::ceil(num / den * (mid - 1)) + mid;
+
+  return (abs_pos <= mid) ? relative_pos : (log_pos * sign);
+}
+
+/**
+ * @brief cache key for shared c2p/p2c relative index tables
+ *
+ * These indices depend only on relative geometry, not on layer weights.
+ * So all attention layers can reuse them.
+ */
+struct RelativeIndexKey {
+  unsigned int from;
+  unsigned int to;
+  unsigned int att_span;
+  unsigned int rel_len_q;
+  unsigned int rel_len_k;
+  bool c2p;
+  bool p2c;
+
+  bool operator==(const RelativeIndexKey &rhs) const {
+    return from == rhs.from && to == rhs.to && att_span == rhs.att_span &&
+           rel_len_q == rhs.rel_len_q && rel_len_k == rhs.rel_len_k &&
+           c2p == rhs.c2p && p2c == rhs.p2c;
+  }
+};
+
+struct RelativeIndexValue {
+  std::vector<int> c2p_idx;
+  std::vector<int> p2c_idx;
+};
+
+/**
+ * Android/mobile path prefers avoiding global lock + deep copy on every call.
+ * Reuse per-thread relative index cache instead.
+ */
+static thread_local bool tl_rel_index_ready = false;
+static thread_local RelativeIndexKey tl_rel_index_key{};
+static thread_local RelativeIndexValue tl_rel_index_value{};
+
+/**
+ * Scratch buffer for unpacking key cache to FP32 in FP32 relative-attention path.
+ * Reused per-thread to avoid repeated allocation/resizing overhead.
+ */
+static thread_local std::vector<float> tl_key_cache_fp32_buf;
+
+} // namespace
+
+/**
+ * @brief constructor
+ */
+DebertaAttentionLayer::DebertaAttentionLayer() :
+  LayerImpl(),
+  deberta_props(nntrainer::props::NumHeads(), props::MaxPositionEmbeddings(),
+                props::MaxRelativePositions(), props::C2P(), props::P2C(),
+                props::ShareAttKey(), props::RelativeAttention(),
+                props::PositionBuckets(), props::InputLen(),
+                nntrainer::props::DisableBias()),
+  epsilon(1e-3f),
+  num_heads_Q(0),
+  num_heads_KV(0),
+  head_dim(0),
+  max_position_embeddings(0),
+  max_relative_positions(0),
+  position_buckets(0),
+  local_window_size(0),
+  attn_logit_softcapping(0.0f),
+  is_causal(false) {
+  tensor_idx.fill(std::numeric_limits<unsigned>::max());
+}
+
+DebertaAttentionLayer::~DebertaAttentionLayer() {}
+
+/**
+ * @brief finalize
+ */
+void DebertaAttentionLayer::finalize(nntrainer::InitLayerContext &context) {
+  const bool share_att_key = std::get<props::ShareAttKey>(deberta_props).get();
+  const bool relative_attention =
+    std::get<props::RelativeAttention>(deberta_props).get();
+  const bool c2p = std::get<props::C2P>(deberta_props).get();
+  const bool p2c = std::get<props::P2C>(deberta_props).get();
+
+  NNTR_THROW_IF(!share_att_key, nntrainer::exception::not_supported)
+    << "DebertaAttentionLayer: share_att_key=false is not supported yet.";
+
+  unsigned int expected_inputs = 3;
+  if (relative_attention) {
+    if (p2c)
+      expected_inputs++;
+    if (c2p)
+      expected_inputs++;
+  }
+
+  NNTR_THROW_IF(context.getNumInputs() != expected_inputs, std::invalid_argument)
+    << "DebertaAttentionLayer expects " << expected_inputs
+    << " inputs, but got " << context.getNumInputs();
+
+  const auto &input_dims = context.getInputDimensions();
+  const auto &query_dim = input_dims[INPUT_IDX_Q];
+  const auto &key_dim = input_dims[INPUT_IDX_K];
+  const auto &value_dim = input_dims[INPUT_IDX_V];
+
+  NNTR_THROW_IF(query_dim.width() != key_dim.width(), std::invalid_argument)
+    << "query/key hidden width mismatch";
+
+  NNTR_THROW_IF(key_dim.width() != value_dim.width(), std::invalid_argument)
+    << "key/value hidden width mismatch";
+
+  num_heads_Q = static_cast<size_t>(
+    std::get<nntrainer::props::NumHeads>(deberta_props).get());
+  num_heads_KV = num_heads_Q;
+
+  NNTR_THROW_IF(num_heads_Q == 0, std::invalid_argument)
+    << "num_heads must be > 0";
+
+  head_dim = static_cast<size_t>(query_dim.width()) / num_heads_Q;
+
+  NNTR_THROW_IF(head_dim * num_heads_Q != query_dim.width(),
+                std::invalid_argument)
+    << "query width must be divisible by num_heads";
+
+  max_position_embeddings =
+    std::get<props::MaxPositionEmbeddings>(deberta_props).get();
+  max_relative_positions =
+    std::get<props::MaxRelativePositions>(deberta_props).get();
+  position_buckets = std::get<props::PositionBuckets>(deberta_props).get();
+
+  if (max_relative_positions < 1)
+    max_relative_positions = max_position_embeddings;
+
+  is_causal = false;
+
+  local_window_size = std::max<unsigned int>(
+    query_dim.height(), max_position_embeddings > 0 ? max_position_embeddings
+                                                    : query_dim.height());
+
+  attn_logit_softcapping = 0.0f;
+
+#ifdef ENABLE_FP16
+  ml::train::TensorDim cache_key_dim(
+    {query_dim.batch(), 1, query_dim.height(), key_dim.width()},
+    {context.getFormat(), ml::train::TensorDim::DataType::FP16});
+  ml::train::TensorDim cache_value_dim(
+    {query_dim.batch(), 1, query_dim.height(), value_dim.width()},
+    {context.getFormat(), ml::train::TensorDim::DataType::FP16});
+#else
+  ml::train::TensorDim cache_key_dim(
+    {query_dim.batch(), 1, query_dim.height(), key_dim.width()},
+    {context.getFormat(), ml::train::TensorDim::DataType::UINT16});
+  ml::train::TensorDim cache_value_dim(
+    {query_dim.batch(), 1, query_dim.height(), value_dim.width()},
+    {context.getFormat(), ml::train::TensorDim::DataType::UINT16});
+#endif
+
+  tensor_idx[AttentionParams::cache_key] = context.requestTensor(
+    cache_key_dim, "cache_key", nntrainer::Initializer::NONE, false,
+    nntrainer::TensorLifespan::MAX_LIFESPAN);
+
+  tensor_idx[AttentionParams::cache_value] = context.requestTensor(
+    cache_value_dim, "cache_value", nntrainer::Initializer::NONE, false,
+    nntrainer::TensorLifespan::MAX_LIFESPAN);
+
+  std::vector<nntrainer::TensorDim> output_dims(1);
+  output_dims[0] = query_dim;
+  context.setOutputDimensions(output_dims);
+
+  prepare_bucket_table(std::max<unsigned int>(query_dim.height(),
+                                              max_position_embeddings));
+
+#if !defined(__ANDROID__)
+  // Keep BLAS single-threaded inside the layer to avoid oversubscription.
+  openblas_set_num_threads(4);
+#endif
+}
+
+void DebertaAttentionLayer::setProperty(const std::vector<std::string> &values) {
+  auto remain_props = loadProperties(values, deberta_props);
+  LayerImpl::setProperty(remain_props);
+}
+
+void DebertaAttentionLayer::prepare_bucket_table(unsigned int max_seq_len) {
+  const bool relative_attention =
+    std::get<props::RelativeAttention>(deberta_props).get();
+  if (!relative_attention || position_buckets == 0)
+    return;
+
+  std::lock_guard<std::mutex> lock(bucket_mtx);
+
+  if (bucket_table_ready && bucket_table_max_seq_len >= max_seq_len)
+    return;
+
+  bucket_table.resize(max_seq_len * 2 + 1);
+  const int offset = static_cast<int>(max_seq_len);
+
+  for (int diff = -static_cast<int>(max_seq_len);
+       diff <= static_cast<int>(max_seq_len); ++diff) {
+    bucket_table[diff + offset] = compute_bucket_pos_impl(
+      diff, static_cast<int>(position_buckets),
+      static_cast<int>(max_relative_positions));
+  }
+
+  bucket_table_max_seq_len = max_seq_len;
+  bucket_table_ready = true;
+}
+
+int DebertaAttentionLayer::lookup_bucket(int relative_pos) const {
+  if (!bucket_table_ready || position_buckets == 0)
+    return relative_pos;
+
+  const int offset = static_cast<int>(bucket_table_max_seq_len);
+  const int idx = clampv(relative_pos + offset, 0,
+                         static_cast<int>(bucket_table.size()) - 1);
+  return bucket_table[idx];
+}
+
+void DebertaAttentionLayer::forwarding(nntrainer::RunLayerContext &context,
+                                       bool training) {
+  nntrainer::Tensor &q = context.getInput(INPUT_IDX_Q);
+  nntrainer::Tensor &output = context.getOutput(OUTPUT_IDX);
+  output.copyData(q);
+}
+
+/**
+ * @brief incremental forwarding
+ */
+void DebertaAttentionLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int _from, unsigned int _to,
+  bool training) {
+
+  auto get_step_dim = [_from, _to](const ml::train::TensorDim &dim) {
+    auto step_dim = dim;
+    step_dim.batch(1);
+    step_dim.height(_to - _from);
+    return step_dim;
+  };
+
+  nntrainer::Tensor &query = context.getInput(INPUT_IDX_Q);
+  nntrainer::Tensor &key = context.getInput(INPUT_IDX_K);
+  nntrainer::Tensor &value = context.getInput(INPUT_IDX_V);
+  nntrainer::Tensor &output = context.getOutput(OUTPUT_IDX);
+
+  nntrainer::Tensor &cache_key =
+    context.getTensor(tensor_idx[AttentionParams::cache_key]);
+  nntrainer::Tensor &cache_value =
+    context.getTensor(tensor_idx[AttentionParams::cache_value]);
+
+  ml::train::TensorDim query_dim = query.getDim();
+  ml::train::TensorDim key_dim = key.getDim();
+  ml::train::TensorDim value_dim = value.getDim();
+  ml::train::TensorDim output_dim = output.getDim();
+  ml::train::TensorDim cache_key_dim = cache_key.getDim();
+  ml::train::TensorDim cache_value_dim = cache_value.getDim();
+
+  ml::train::TensorDim query_step_dim = get_step_dim(query_dim);
+  ml::train::TensorDim key_step_dim = get_step_dim(key_dim);
+  ml::train::TensorDim value_step_dim = get_step_dim(value_dim);
+  ml::train::TensorDim output_step_dim = get_step_dim(output_dim);
+  ml::train::TensorDim cache_key_step_dim = get_step_dim(cache_key_dim);
+  ml::train::TensorDim cache_value_step_dim = get_step_dim(cache_value_dim);
+
+  const unsigned int batch_size = query_dim.batch();
+
+  for (unsigned int batch = 0; batch < batch_size; ++batch) {
+    nntrainer::Tensor query_step = query.getSharedDataTensor(
+      query_step_dim,
+      batch * query_dim.getFeatureLen() + _from * query_dim.width(), true);
+    nntrainer::Tensor key_step = key.getSharedDataTensor(
+      key_step_dim,
+      batch * key_dim.getFeatureLen() + _from * key_dim.width(), true);
+    nntrainer::Tensor value_step = value.getSharedDataTensor(
+      value_step_dim,
+      batch * value_dim.getFeatureLen() + _from * value_dim.width(), true);
+    nntrainer::Tensor output_step = output.getSharedDataTensor(
+      output_step_dim,
+      batch * output_dim.getFeatureLen() + _from * output_dim.width(), true);
+
+    one_batch_incremental_forwarding(
+      context, batch, _from, _from, _to, query_step, key_step, value_step,
+      output_step, cache_key, cache_value, cache_key_dim, cache_key_step_dim,
+      cache_value_dim, cache_value_step_dim);
+  }
+}
+
+/**
+ * @brief Function to compute Attention Scores using Tensor inputs. Wrapper
+ * around nntrainer::compute_kcaches with multi-threading support
+ *
+ * Expected Input Shapes:
+ * @param in (Query): [Batch, 1, sequence_len, Num_Heads_Q * Head_Dim]
+ * @param cache (Key Cache): [Batch, 1, Max_Timestep, Num_Heads_KV * Head_Dim]
+ * @param out (Attention Score): [Batch, 1, 1, Num_Heads_Q * Context_Len]
+ *            where Context_Len is usually the current timestep 'to'.
+ *
+ */
+void DebertaAttentionLayer::compute_kcaches(
+  nntrainer::Tensor &in, nntrainer::Tensor &cache, nntrainer::Tensor &out,
+  unsigned int from, size_t sequence_len, unsigned int num_head,
+  unsigned int group_size, unsigned int head_dim, BS::thread_pool<> &pool) {
+
+  if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    if (sequence_len == 1) {
+      const int row_to_compute = from + sequence_len;
+      const unsigned int num_cache_head = num_head / group_size;
+
+      const float *in_data = in.getData<float>();
+      const uint16_t *cache_data = cache.getData<uint16_t>();
+      float *out_data = out.getData<float>();
+
+#pragma omp parallel for schedule(static)
+      for (unsigned int head_kv = 0; head_kv < num_cache_head; ++head_kv) {
+        nntrainer::compute_kcaches<uint16_t>(
+          in_data, cache_data, out_data, row_to_compute, num_cache_head,
+          head_dim, group_size, tile_size, local_window_size, head_kv,
+          head_kv + 1);
+      }
+
+    } else {
+      std::vector<std::future<void>> futures;
+      const unsigned int seq = static_cast<unsigned int>(sequence_len);
+
+      for (unsigned int i = 0; i < seq; ++i) {
+        float *input_addr = in.getData<float>() + num_head * head_dim * i;
+        uint16_t *cache_addr = cache.getData<uint16_t>();
+        const int row_to_compute = from + sequence_len;
+        const size_t out_start_row = i * (from + sequence_len);
+        float *output_addr = out.getData<float>() + out_start_row * num_head;
+
+        futures.emplace_back(pool.submit_task([=]() {
+          nntrainer::compute_kcaches<uint16_t>(
+            input_addr, cache_addr, output_addr, row_to_compute,
+            num_head / group_size, head_dim, group_size, tile_size,
+            local_window_size);
+        }));
+      }
+
+      for (auto &fut : futures)
+        fut.get();
+    }
+
+  } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    if (sequence_len == 1) {
+      const int num_rows = from + sequence_len;
+      const unsigned int num_cache_head = num_head / group_size;
+
+      const _FP16 *in_data = in.getData<_FP16>();
+      const _FP16 *cache_data = cache.getData<_FP16>();
+      _FP16 *out_data = out.getData<_FP16>();
+
+#pragma omp parallel for schedule(static)
+      for (unsigned int head_kv = 0; head_kv < num_cache_head; ++head_kv) {
+        nntrainer::compute_kcaches(
+          in_data, cache_data, out_data, num_rows, num_cache_head, head_dim,
+          group_size, tile_size, local_window_size, head_kv, head_kv + 1);
+      }
+    } else {
+      std::vector<std::future<void>> futures;
+      const unsigned int seq = static_cast<unsigned int>(sequence_len);
+
+      for (unsigned int i = 0; i < seq; ++i) {
+        _FP16 *input_addr = in.getData<_FP16>() + num_head * head_dim * i;
+        _FP16 *cache_addr = cache.getData<_FP16>();
+        const int row_to_compute = from + sequence_len;
+        const size_t out_start_row = i * (from + sequence_len);
+        _FP16 *output_addr = out.getData<_FP16>() + out_start_row * num_head;
+
+        futures.emplace_back(pool.submit_task([=]() {
+          nntrainer::compute_kcaches(input_addr, cache_addr, output_addr,
+                                     row_to_compute, num_head / group_size,
+                                     head_dim, group_size, tile_size,
+                                     local_window_size);
+        }));
+      }
+
+      for (auto &fut : futures)
+        fut.get();
+    }
+#else
+    NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
+#endif
+  }
+}
+
+/**
+ * @brief softmax for linear layout [S_q, to, H]
+ */
+void DebertaAttentionLayer::softmax_triangle(nntrainer::Tensor &qk_out,
+                                             size_t row, size_t num_head,
+                                             unsigned int from,
+                                             BS::thread_pool<> &pool) {
+  if (qk_out.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    float *qk_out_ = qk_out.getData<float>();
+
+    if (attn_logit_softcapping > 0.0f) {
+      const size_t len =
+        qk_out.batch() * qk_out.height() * qk_out.width() * qk_out.channel();
+      const float inv_softcapping = 1.0f / attn_logit_softcapping;
+      for (size_t i = 0; i < len; ++i) {
+        qk_out_[i] =
+          std::tanh(qk_out_[i] * inv_softcapping) * attn_logit_softcapping;
+      }
+    }
+
+    if (row == 1) {
+      const size_t start_row = 0;
+      const size_t end_row = from + row;
+      nntrainer::softmax_row_inplace(qk_out_, start_row, end_row, num_head);
+    } else {
+      std::vector<std::future<void>> futures;
+      for (unsigned int i = 0; i < row; ++i) {
+        const unsigned int to = from + row;
+        const size_t start_row = i * to;
+        const size_t end_row = (i + 1) * to;
+        futures.push_back(pool.submit_task([=]() {
+          nntrainer::softmax_row(qk_out_, start_row, end_row, num_head);
+        }));
+      }
+      for (auto &fut : futures)
+        fut.get();
+    }
+
+  } else if (qk_out.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    _FP16 *qk_out_ = qk_out.getData<_FP16>();
+
+    if (attn_logit_softcapping > 0.0f) {
+      const size_t len =
+        qk_out.batch() * qk_out.height() * qk_out.width() * qk_out.channel();
+      const float inv_softcapping = 1.0f / attn_logit_softcapping;
+      for (size_t i = 0; i < len; ++i) {
+        qk_out_[i] = (_FP16)(std::tanh((float)qk_out_[i] * inv_softcapping) *
+                             attn_logit_softcapping);
+      }
+    }
+
+    if (row == 1) {
+      const size_t start_row = 0;
+      const size_t end_row = from + row;
+      nntrainer::softmax_row_inplace(qk_out_, start_row, end_row, num_head);
+    } else {
+      std::vector<std::future<void>> futures;
+      for (unsigned int i = 0; i < row; ++i) {
+        const unsigned int to = from + row;
+        const size_t start_row = i * to;
+        const size_t end_row = (i + 1) * to;
+        futures.push_back(pool.submit_task([=]() {
+          nntrainer::softmax_row_inplace(qk_out_, start_row, end_row, num_head);
+        }));
+      }
+      for (auto &fut : futures)
+        fut.get();
+    }
+#else
+    NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
+#endif
+  }
+}
+
+/**
+ * @brief score * value using mha_core optimized path
+ */
+void DebertaAttentionLayer::compute_fp16vcache_transposed(
+  nntrainer::Tensor &in, nntrainer::Tensor &vcache, nntrainer::Tensor &output,
+  int from, int num_cache_head, int gqa_size, int head_dim, int to,
+  BS::thread_pool<> &pool) {
+
+  if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    if ((to - from) != 1) {
+      std::vector<std::future<void>> futures;
+      const int seq = to - from;
+      futures.reserve(seq);
+
+      for (int i = 0; i < seq; ++i) {
+        futures.push_back(pool.submit_task([=]() {
+          const size_t start_idx = i * to;
+          const float *input =
+            in.getData<float>() + start_idx * num_cache_head * gqa_size;
+          float *out = output.getData<float>() +
+                       i * (num_cache_head * gqa_size * head_dim);
+          const int row_num = to - 1;
+
+          nntrainer::compute_fp16vcache_fp32_transposed(
+            row_num, input, vcache.getData<uint16_t>(), out, num_cache_head,
+            gqa_size, head_dim, local_window_size);
+        }));
+      }
+
+      for (auto &fut : futures)
+        fut.get();
+
+    } else {
+      const int row_num = to - 1;
+
+      const float *in_data = in.getData<float>();
+      const uint16_t *vcache_data = vcache.getData<uint16_t>();
+      float *output_data = output.getData<float>();
+
+#pragma omp parallel for schedule(static)
+      for (int head_kv = 0; head_kv < num_cache_head; ++head_kv) {
+        nntrainer::compute_fp16vcache_fp32_transposed(
+          row_num, in_data, vcache_data, output_data, num_cache_head, gqa_size,
+          head_dim, local_window_size, head_kv, head_kv + 1);
+      }
+    }
+
+  } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    if ((to - from) != 1) {
+      std::vector<std::future<void>> futures;
+      const int seq = to - from;
+      futures.reserve(seq);
+
+      for (int i = 0; i < seq; ++i) {
+        futures.push_back(pool.submit_task([=]() {
+          const size_t start_idx = i * to;
+          const _FP16 *input =
+            in.getData<_FP16>() + start_idx * num_cache_head * gqa_size;
+          _FP16 *out = output.getData<_FP16>() +
+                       i * (num_cache_head * gqa_size * head_dim);
+          const int row_num = to - 1;
+
+          nntrainer::compute_fp16vcache_transposed(
+            row_num, input, vcache.getData<_FP16>(), out, num_cache_head,
+            gqa_size, head_dim, local_window_size);
+        }));
+      }
+
+      for (auto &fut : futures)
+        fut.get();
+
+    } else {
+      const int row_num = to - 1;
+
+      const _FP16 *in_data = in.getData<_FP16>();
+      const _FP16 *vcache_data = vcache.getData<_FP16>();
+      _FP16 *output_data = output.getData<_FP16>();
+
+#pragma omp parallel for schedule(static)
+      for (int head_kv = 0; head_kv < num_cache_head; ++head_kv) {
+        nntrainer::compute_fp16vcache_transposed(
+          row_num, in_data, vcache_data, output_data, num_cache_head, gqa_size,
+          head_dim, local_window_size, head_kv, head_kv + 1);
+      }
+    }
+#else
+    NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
+#endif
+  }
+}
+
+/**
+ * @brief add DeBERTa relative score (c2p / p2c)
+ */
+void DebertaAttentionLayer::add_relative_attn_score(
+  nntrainer::RunLayerContext &context, nntrainer::Tensor &score,
+  nntrainer::Tensor &query_step, nntrainer::Tensor &key_cache,
+  unsigned int from, unsigned int to) {
+
+  const bool relative_attention =
+    std::get<props::RelativeAttention>(deberta_props).get();
+  const bool c2p = std::get<props::C2P>(deberta_props).get();
+  const bool p2c = std::get<props::P2C>(deberta_props).get();
+
+  if (!relative_attention || (!c2p && !p2c))
+    return;
+
+  size_t next_input_idx = 3;
+  nntrainer::Tensor rel_query;
+  nntrainer::Tensor rel_key;
+
+  if (p2c) {
+    rel_query = context.getInput(next_input_idx++);
+  }
+  if (c2p) {
+    rel_key = context.getInput(next_input_idx++);
+  }
+
+  const unsigned int S_q = to - from;
+  const unsigned int S_k = to;
+  const unsigned int hidden = static_cast<unsigned int>(num_heads_Q * head_dim);
+
+  const unsigned int att_span =
+    position_buckets > 0 ? position_buckets : max_relative_positions;
+
+  const int scale_factor_int = 1 + (c2p ? 1 : 0) + (p2c ? 1 : 0);
+  const float scale =
+    1.0f / std::sqrt(static_cast<float>(head_dim * scale_factor_int));
+
+  /**
+   * Shared relative index cache across attention layers
+
+   */
+  const unsigned int rel_len_q =
+    p2c ? rel_query.height() : 0u;
+  const unsigned int rel_len_k =
+    c2p ? rel_key.height() : 0u;
+
+  const RelativeIndexKey cache_key{
+    from, to, att_span, rel_len_q, rel_len_k, c2p, p2c};
+
+  RelativeIndexValue &rel_idx_local = tl_rel_index_value;
+
+  if (!tl_rel_index_ready || !(tl_rel_index_key == cache_key)) {
+    rel_idx_local.c2p_idx.clear();
+    rel_idx_local.p2c_idx.clear();
+
+    if (c2p) {
+      rel_idx_local.c2p_idx.resize(static_cast<size_t>(S_q) * S_k);
+    }
+    if (p2c) {
+      rel_idx_local.p2c_idx.resize(static_cast<size_t>(S_q) * S_k);
+    }
+
+    #pragma omp parallel for schedule(static)
+      for (unsigned int q = 0; q < S_q; ++q) {
+        for (unsigned int k = 0; k < S_k; ++k) {
+          if (c2p) {
+            const int rel = static_cast<int>(q + from) - static_cast<int>(k);
+            const int bucketed = lookup_bucket(rel);
+            rel_idx_local.c2p_idx[static_cast<size_t>(q) * S_k + k] =
+              clampv(bucketed + static_cast<int>(att_span), 0,
+                    static_cast<int>(rel_len_k) - 1);
+          }
+
+          if (p2c) {
+            const int rel_rev =
+              static_cast<int>(k) - static_cast<int>(q + from);
+            const int bucketed_rev = lookup_bucket(rel_rev);
+            rel_idx_local.p2c_idx[static_cast<size_t>(q) * S_k + k] =
+              clampv(-bucketed_rev + static_cast<int>(att_span), 0,
+                    static_cast<int>(rel_len_q) - 1);
+          }
+        }
+      }
+
+    tl_rel_index_key = cache_key;
+    tl_rel_index_ready = true;
+  }
+
+  if (score.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    float *score_ptr = score.getData<float>();
+    const float *q_ptr = query_step.getData<float>();
+    const float *rel_query_ptr =
+      p2c ? rel_query.getData<float>() : nullptr;
+    const float *rel_key_ptr =
+      c2p ? rel_key.getData<float>() : nullptr;
+
+    const uint16_t *key_u16_ptr =
+      key_cache.getDataType() == ml::train::TensorDim::DataType::UINT16
+        ? key_cache.getData<uint16_t>()
+        : nullptr;
+
+    #ifdef ENABLE_FP16
+    const _FP16 *key_fp16_ptr =
+      key_cache.getDataType() == ml::train::TensorDim::DataType::FP16
+        ? key_cache.getData<_FP16>()
+        : nullptr;
+    #else
+    const void *key_fp16_ptr = nullptr;
+    #endif
+
+    std::vector<float> &key_cache_fp32_buf = tl_key_cache_fp32_buf;
+    const float *key_unpacked_ptr = nullptr;
+
+    /**
+     * p2c path needs key-cache values in FP32 for dot(q_rel, k_cache).
+     * If cache is packed/FP16, unpack once outside the hot loop.
+     */
+    if (p2c && (key_u16_ptr
+      #ifdef ENABLE_FP16
+                  || key_fp16_ptr
+      #endif
+                  )) {
+        const size_t unpack_len = static_cast<size_t>(S_k) * hidden;
+        if (key_cache_fp32_buf.size() < unpack_len) {
+          key_cache_fp32_buf.resize(unpack_len);
+        }
+
+        for (unsigned int k = 0; k < S_k; ++k) {
+          float *dst =
+            key_cache_fp32_buf.data() + static_cast<size_t>(k) * hidden;
+
+          if (key_u16_ptr) {
+            const uint16_t *src =
+              key_u16_ptr + static_cast<size_t>(k) * hidden;
+            for (unsigned int i = 0; i < hidden; ++i) {
+              dst[i] = nntrainer::compute_fp16_to_fp32(src[i]);
+            }
+          }
+      #ifdef ENABLE_FP16
+          else if (key_fp16_ptr) {
+            const _FP16 *src =
+              key_fp16_ptr + static_cast<size_t>(k) * hidden;
+            for (unsigned int i = 0; i < hidden; ++i) {
+              dst[i] = static_cast<float>(src[i]);
+            }
+          }
+      #endif
+        }
+
+        key_unpacked_ptr = key_cache_fp32_buf.data();
+    }
+
+  NNTR_THROW_IF(key_unpacked_ptr == nullptr, std::invalid_argument)
+                  << "FP32 relative attention path expected UINT16 or FP16 key cache";
+
+  #pragma omp parallel for schedule(static)
+      for (unsigned int q_idx = 0; q_idx < S_q; ++q_idx) {
+        const size_t qk_row = static_cast<size_t>(q_idx) * S_k;
+
+        for (unsigned int h = 0; h < num_heads_Q; ++h) {
+          const unsigned int h_base = h * head_dim;
+          const float *q_head = q_ptr + q_idx * hidden + h_base;
+
+          for (unsigned int k_idx = 0; k_idx < S_k; ++k_idx) {
+            float rel_score = 0.0f;
+
+            if (c2p) {
+              const int rel_index = rel_idx_local.c2p_idx[qk_row + k_idx];
+              const float *rk_head =
+                rel_key_ptr + static_cast<size_t>(rel_index) * hidden + h_base;
+
+              float c2p_dot = 0.0f;
+  #pragma omp simd reduction(+ : c2p_dot)
+              for (unsigned int d = 0; d < head_dim; ++d) {
+                c2p_dot += q_head[d] * rk_head[d];
+              }
+              rel_score += c2p_dot * scale;
+            }
+
+            if (p2c) {
+              const int rel_index = rel_idx_local.p2c_idx[qk_row + k_idx];
+              const float *rq_head =
+                rel_query_ptr + static_cast<size_t>(rel_index) * hidden + h_base;
+
+              float p2c_dot = 0.0f;
+              const float *k_head =
+                key_unpacked_ptr + static_cast<size_t>(k_idx) * hidden + h_base;
+  #pragma omp simd reduction(+ : p2c_dot)
+              for (unsigned int d = 0; d < head_dim; ++d) {
+                p2c_dot += k_head[d] * rq_head[d];
+              }
+              rel_score += p2c_dot * scale;
+            }
+
+            const size_t linear_idx =
+              (static_cast<size_t>(q_idx) * S_k + k_idx) * num_heads_Q + h;
+            score_ptr[linear_idx] += rel_score;
+          }
+        }
+      }
+  } else if (score.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    NNTR_THROW_IF(key_cache.getDataType() != ml::train::TensorDim::DataType::FP16,
+                  std::invalid_argument)
+      << "FP16 relative attention path requires FP16 key cache";
+
+    _FP16 *score_ptr = score.getData<_FP16>();
+    const _FP16 *q_ptr = query_step.getData<_FP16>();
+    const _FP16 *rel_query_ptr =
+      p2c ? rel_query.getData<_FP16>() : nullptr;
+    const _FP16 *rel_key_ptr =
+      c2p ? rel_key.getData<_FP16>() : nullptr;
+    const _FP16 *key_fp16_ptr = key_cache.getData<_FP16>();
+
+#pragma omp parallel for schedule(static)
+    for (unsigned int q_idx = 0; q_idx < S_q; ++q_idx) {
+      const size_t qk_row_base = static_cast<size_t>(q_idx) * S_k;
+
+      for (unsigned int h = 0; h < num_heads_Q; ++h) {
+        const unsigned int h_base = h * head_dim;
+        const _FP16 *q_head = q_ptr + q_idx * hidden + h_base;
+
+        for (unsigned int k_idx = 0; k_idx < S_k; ++k_idx) {
+          float rel_score = 0.0f;
+
+          if (c2p) {
+            const int rel_index = rel_idx_local.c2p_idx[qk_row_base + k_idx];
+            const _FP16 *rk_head =
+              rel_key_ptr + static_cast<size_t>(rel_index) * hidden + h_base;
+
+            float c2p_dot = 0.0f;
+#pragma omp simd reduction(+ : c2p_dot)
+            for (unsigned int d = 0; d < head_dim; ++d) {
+              c2p_dot += static_cast<float>(q_head[d]) *
+                         static_cast<float>(rk_head[d]);
+            }
+            rel_score += c2p_dot * scale;
+          }
+
+          if (p2c) {
+            const int rel_index = rel_idx_local.p2c_idx[qk_row_base + k_idx];
+            const _FP16 *rq_head =
+              rel_query_ptr + static_cast<size_t>(rel_index) * hidden + h_base;
+            const _FP16 *k_head =
+              key_fp16_ptr + static_cast<size_t>(k_idx) * hidden + h_base;
+
+            float p2c_dot = 0.0f;
+#pragma omp simd reduction(+ : p2c_dot)
+            for (unsigned int d = 0; d < head_dim; ++d) {
+              p2c_dot += static_cast<float>(k_head[d]) *
+                         static_cast<float>(rq_head[d]);
+            }
+            rel_score += p2c_dot * scale;
+          }
+
+          const size_t linear_idx =
+            (static_cast<size_t>(q_idx) * S_k + k_idx) * num_heads_Q + h;
+          score_ptr[linear_idx] =
+            (_FP16)(static_cast<float>(score_ptr[linear_idx]) + rel_score);
+        }
+      }
+    }
+#else
+    NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
+#endif
+  }
+}
+
+/**
+ * @brief one-batch path
+ */
+void DebertaAttentionLayer::one_batch_incremental_forwarding(
+  nntrainer::RunLayerContext &context, const unsigned int batch,
+  const unsigned int _from, const unsigned int from, const unsigned int to,
+  nntrainer::Tensor &query_step, nntrainer::Tensor &key_step,
+  nntrainer::Tensor &value_step, nntrainer::Tensor &attention_output_step,
+  nntrainer::Tensor &cache_key, nntrainer::Tensor &cache_value,
+  ml::train::TensorDim &cache_key_dim,
+  ml::train::TensorDim &cache_key_step_dim,
+  ml::train::TensorDim &cache_value_dim,
+  ml::train::TensorDim &cache_value_step_dim) {
+
+  auto &pool =
+    nntrainer::Engine::Global().getThreadPoolManager()->getThreadPool();
+
+  nntrainer::Tensor b_cache_key_step = cache_key.getSharedDataTensor(
+    cache_key_step_dim,
+    batch * cache_key_dim.getFeatureLen() + from * cache_key_dim.width(), true);
+  nntrainer::Tensor b_cache_value_step = cache_value.getSharedDataTensor(
+    cache_value_step_dim,
+    batch * cache_value_dim.getFeatureLen() + from * cache_value_dim.width(),
+    true);
+
+  b_cache_key_step.copyData(key_step);
+  b_cache_value_step.copyData(value_step);
+
+  ml::train::TensorDim cached_key_dim = cache_key_dim;
+  ml::train::TensorDim cached_value_dim = cache_value_dim;
+  cached_key_dim.height(to);
+  cached_value_dim.height(to);
+
+  nntrainer::Tensor b_cached_key = cache_key.getSharedDataTensor(
+    cached_key_dim, batch * cache_key_dim.getFeatureLen(), true);
+  nntrainer::Tensor b_cached_value = cache_value.getSharedDataTensor(
+    cached_value_dim, batch * cache_value_dim.getFeatureLen(), true);
+
+  nntrainer::Tensor out_(1, 1, (to - from) * to, num_heads_Q,
+                         query_step.getTensorType());
+
+  const unsigned int gqa_size = num_heads_Q / num_heads_KV;
+  
+  compute_kcaches(query_step, b_cached_key, out_, _from, to - from, num_heads_Q,
+                  gqa_size, head_dim, pool);
+
+  const bool relative_attention = std::get<props::RelativeAttention>(deberta_props).get();
+  if (relative_attention) {
+    const bool c2p = std::get<props::C2P>(deberta_props).get();
+    const bool p2c = std::get<props::P2C>(deberta_props).get();
+    const int scale_factor_int = 1 + (c2p ? 1 : 0) + (p2c ? 1 : 0);
+    const float content_rescale =
+      1.0f / std::sqrt(static_cast<float>(scale_factor_int));
+
+    if (out_.getDataType() == ml::train::TensorDim::DataType::FP32) {
+      float *ptr = out_.getData<float>();
+      const size_t len =
+        out_.batch() * out_.channel() * out_.height() * out_.width();
+      for (size_t i = 0; i < len; ++i) {
+        ptr[i] *= content_rescale;
+      }
+    }
+  #ifdef ENABLE_FP16
+    else if (out_.getDataType() == ml::train::TensorDim::DataType::FP16) {
+      _FP16 *ptr = out_.getData<_FP16>();
+      const size_t len =
+        out_.batch() * out_.channel() * out_.height() * out_.width();
+      for (size_t i = 0; i < len; ++i) {
+        ptr[i] = (_FP16)((float)ptr[i] * content_rescale);
+      }
+    }
+  #endif
+    add_relative_attn_score(context, out_, query_step, b_cached_key, from, to);  
+  }
+  softmax_triangle(out_, to - from, num_heads_Q, from, pool);
+
+  compute_fp16vcache_transposed(out_, b_cached_value, attention_output_step,
+                                from, num_heads_KV, gqa_size, head_dim, to,
+                                pool);
+}
+
+void DebertaAttentionLayer::setBatch(nntrainer::RunLayerContext &context,
+                                     unsigned int batch) {
+  context.updateTensor(tensor_idx[AttentionParams::cache_key], batch);
+  context.updateTensor(tensor_idx[AttentionParams::cache_value], batch);
+}
+
+void DebertaAttentionLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+
+  ml::train::TensorDim q_dim = input_dimensions[INPUT_IDX_Q];
+  ml::train::TensorDim k_dim = input_dimensions[INPUT_IDX_K];
+  ml::train::TensorDim v_dim = input_dimensions[INPUT_IDX_V];
+
+#ifdef ENABLE_FP16
+  k_dim.setDataType(ml::train::TensorDim::DataType::FP16);
+  v_dim.setDataType(ml::train::TensorDim::DataType::FP16);
+#else
+  k_dim.setDataType(ml::train::TensorDim::DataType::UINT16);
+  v_dim.setDataType(ml::train::TensorDim::DataType::UINT16);
+#endif
+
+  context.updateInput(INPUT_IDX_Q, input_dimensions[INPUT_IDX_Q]);
+  context.updateInput(INPUT_IDX_K, input_dimensions[INPUT_IDX_K]);
+  context.updateInput(INPUT_IDX_V, input_dimensions[INPUT_IDX_V]);
+  context.updateOutput(OUTPUT_IDX, input_dimensions[INPUT_IDX_Q]);
+
+  context.updateTensor(tensor_idx[AttentionParams::cache_key], k_dim);
+  context.updateTensor(tensor_idx[AttentionParams::cache_value], v_dim);
+
+  prepare_bucket_table(std::max<unsigned int>(
+    input_dimensions[INPUT_IDX_Q].height(), max_position_embeddings));
+}
+
+void DebertaAttentionLayer::calcDerivative(
+  nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "DebertaAttentionLayer::calcDerivative not supported");
+}
+
+void DebertaAttentionLayer::calcGradient(nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "DebertaAttentionLayer::calcGradient not supported");
+}
+
+void DebertaAttentionLayer::exportTo(
+  nntrainer::Exporter &exporter,
+  const ml::train::ExportMethods &method) const {
+  LayerImpl::exportTo(exporter, method);
+  exporter.saveResult(deberta_props, method, this);
+}
+
+#ifdef PLUGGABLE
+
+nntrainer::Layer *create_deberta_attention_layer() {
+  auto layer = new DebertaAttentionLayer();
+  return layer;
+}
+
+void destroy_deberta_attention_layer(nntrainer::Layer *layer) { delete layer; }
+
+extern "C" {
+nntrainer::LayerPluggable ml_train_layer_pluggable{
+  create_deberta_attention_layer, destroy_deberta_attention_layer};
+}
+
+#endif
+
+} // namespace causallm

--- a/Applications/CausalLM/layers/deberta_attention_layer.h
+++ b/Applications/CausalLM/layers/deberta_attention_layer.h
@@ -14,12 +14,20 @@
 #ifndef __DEBERTA_ATTENTION_LAYER_H__
 #define __DEBERTA_ATTENTION_LAYER_H__
 
+#pragma once
+#ifndef WIN_EXPORT
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#else
+#define WIN_EXPORT
+#endif
+#endif
+
 #include <array>
 #include <mutex>
 #include <tuple>
 #include <vector>
 
-#include <bs_thread_pool_manager.hpp>
 #include <common_properties.h>
 #include <layer_impl.h>
 
@@ -113,7 +121,7 @@ public:
  * @class DebertaAttentionLayer
  * @brief DeBERTa Attention Layer
  */
-class DebertaAttentionLayer : public nntrainer::LayerImpl {
+class WIN_EXPORT DebertaAttentionLayer : public nntrainer::LayerImpl {
 public:
   /**
    * @brief Construct a new Deberta Attention Layer object
@@ -197,14 +205,13 @@ public:
   void compute_kcaches(nntrainer::Tensor &in, nntrainer::Tensor &cache,
                        nntrainer::Tensor &out, unsigned int from,
                        size_t sequence_len, unsigned int num_heads,
-                       unsigned int group_size, unsigned int head_dim,
-                       BS::thread_pool<> &pool);
+                       unsigned int group_size, unsigned int head_dim);
 
   /**
    * @brief softmax helper for score tensor
    */
   void softmax_triangle(nntrainer::Tensor &qk_out, size_t row, size_t num_heads,
-                        unsigned int from, BS::thread_pool<> &pool);
+                        unsigned int from);
 
   /**
    * @brief wrapper around nntrainer::compute_fp16vcache_transposed
@@ -213,8 +220,7 @@ public:
                                      nntrainer::Tensor &vcache,
                                      nntrainer::Tensor &output, int from,
                                      int num_cache_head, int gqa_size,
-                                     int head_dim, int to,
-                                     BS::thread_pool<> &pool);
+                                     int head_dim, int to);
 
 private:
   enum InputIndex {

--- a/Applications/CausalLM/layers/deberta_attention_layer.h
+++ b/Applications/CausalLM/layers/deberta_attention_layer.h
@@ -302,7 +302,6 @@ private:
   unsigned int local_window_size;
 
   float attn_logit_softcapping;
-  bool is_causal;
 
   /**
    * @brief relative bucket lookup table

--- a/Applications/CausalLM/layers/deberta_attention_layer.h
+++ b/Applications/CausalLM/layers/deberta_attention_layer.h
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   deberta_attention_layer.h
+ * @date   14 January 2026
+ * @see    https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta/modeling_deberta.py
+ * @author Seunghui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  DeBERTa attention layer based on mha_core-style optimized path
+ */
+
+#ifndef __DEBERTA_ATTENTION_LAYER_H__
+#define __DEBERTA_ATTENTION_LAYER_H__
+
+#include <array>
+#include <mutex>
+#include <tuple>
+#include <vector>
+
+#include <bs_thread_pool_manager.hpp>
+#include <common_properties.h>
+#include <layer_impl.h>
+
+namespace causallm {
+
+namespace props {
+
+/**
+ * @brief MaxRelativePositions property
+ */
+class MaxRelativePositions : public nntrainer::Property<unsigned int> {
+public:
+  static constexpr const char *key = "max_relative_positions";
+  using prop_tag = nntrainer::uint_prop_tag;
+  MaxRelativePositions(unsigned int value = 0) { set(value); }
+};
+
+/**
+ * @brief C2P property
+ */
+class C2P : public nntrainer::Property<bool> {
+public:
+  static constexpr const char *key = "c2p";
+  using prop_tag = nntrainer::bool_prop_tag;
+  C2P(bool value = false) { set(value); }
+};
+
+/**
+ * @brief P2C property
+ */
+class P2C : public nntrainer::Property<bool> {
+public:
+  static constexpr const char *key = "p2c";
+  using prop_tag = nntrainer::bool_prop_tag;
+  P2C(bool value = false) { set(value); }
+};
+
+/**
+ * @brief MaxPositionEmbeddings property
+ */
+class MaxPositionEmbeddings : public nntrainer::PositiveIntegerProperty {
+public:
+  static constexpr const char *key = "max_position_embeddings";
+  using prop_tag = nntrainer::uint_prop_tag;
+  MaxPositionEmbeddings(unsigned int value = 512) { set(value); }
+};
+
+/**
+ * @brief ShareAttKey property
+ */
+class ShareAttKey : public nntrainer::Property<bool> {
+public:
+  static constexpr const char *key = "share_att_key";
+  using prop_tag = nntrainer::bool_prop_tag;
+  ShareAttKey(bool value = false) { set(value); }
+};
+
+/**
+ * @brief RelativeAttention property
+ */
+class RelativeAttention : public nntrainer::Property<bool> {
+public:
+  static constexpr const char *key = "relative_attention";
+  using prop_tag = nntrainer::bool_prop_tag;
+  RelativeAttention(bool value = true) { set(value); }
+};
+
+/**
+ * @brief PositionBuckets property
+ */
+class PositionBuckets : public nntrainer::Property<int> {
+public:
+  static constexpr const char *key = "position_buckets";
+  using prop_tag = nntrainer::int_prop_tag;
+  PositionBuckets(int value = -1) { set(value); }
+};
+
+/**
+ * @brief InputLen property
+ */
+class InputLen : public nntrainer::Property<unsigned int> {
+public:
+  static constexpr const char *key = "input_len";
+  using prop_tag = nntrainer::uint_prop_tag;
+  InputLen(unsigned int value = 0) { set(value); }
+};
+
+} // namespace props
+
+/**
+ * @class DebertaAttentionLayer
+ * @brief DeBERTa Attention Layer
+ */
+class DebertaAttentionLayer : public nntrainer::LayerImpl {
+public:
+  /**
+   * @brief Construct a new Deberta Attention Layer object
+   */
+  DebertaAttentionLayer();
+
+  /**
+   * @brief Destroy the Deberta Attention Layer object
+   */
+  ~DebertaAttentionLayer() override;
+
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  void finalize(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
+   */
+  void forwarding(nntrainer::RunLayerContext &context, bool training) override;
+
+  /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context,
+   * unsigned int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(nntrainer::RunLayerContext &context,
+                              unsigned int from, unsigned int to,
+                              bool training) override;
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::calcGradient(RunLayerContext &context)
+   */
+  void calcGradient(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::exportTo(Exporter &exporter, const ExportMethods &method)
+   */
+  void exportTo(nntrainer::Exporter &exporter,
+                const ml::train::ExportMethods &method) const override;
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  const std::string getType() const override {
+    return DebertaAttentionLayer::type;
+  }
+
+  static constexpr const char *type = "deberta_attention";
+
+  /**
+   * @copydoc Layer::supportBackwarding()
+   */
+  bool supportBackwarding() const override { return false; }
+
+  /**
+   * @copydoc Layer::setBatch(RunLayerContext &context, unsigned int batch)
+   */
+  void setBatch(nntrainer::RunLayerContext &context,
+                unsigned int batch) override;
+
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(...)
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  /**
+   * @brief wrapper around nntrainer::compute_kcaches
+   */
+  void compute_kcaches(nntrainer::Tensor &in, nntrainer::Tensor &cache,
+                       nntrainer::Tensor &out, unsigned int from,
+                       size_t sequence_len, unsigned int num_heads,
+                       unsigned int group_size, unsigned int head_dim,
+                       BS::thread_pool<> &pool);
+
+  /**
+   * @brief softmax helper for score tensor
+   */
+  void softmax_triangle(nntrainer::Tensor &qk_out, size_t row,
+                        size_t num_heads, unsigned int from,
+                        BS::thread_pool<> &pool);
+
+  /**
+   * @brief wrapper around nntrainer::compute_fp16vcache_transposed
+   */
+  void compute_fp16vcache_transposed(nntrainer::Tensor &in,
+                                     nntrainer::Tensor &vcache,
+                                     nntrainer::Tensor &output, int from,
+                                     int num_cache_head, int gqa_size,
+                                     int head_dim, int to,
+                                     BS::thread_pool<> &pool);
+
+private:
+  enum InputIndex {
+    INPUT_IDX_Q = 0,
+    INPUT_IDX_K = 1,
+    INPUT_IDX_V = 2,
+  };
+
+  enum OutputIndex {
+    OUTPUT_IDX = 0,
+  };
+
+  enum AttentionParams {
+    cache_key = 0,
+    cache_value = 1,
+    max_params
+  };
+
+  /**
+   * @brief one-batch incremental forwarding path
+   *
+   * This follows mha_core-style execution:
+   *   compute_kcaches()
+   *   -> add_relative_attn_score()
+   *   -> softmax_triangle()
+   *   -> compute_fp16vcache_transposed()
+   */
+  void one_batch_incremental_forwarding(
+    nntrainer::RunLayerContext &context,
+    const unsigned int batch, const unsigned int _from, const unsigned int from,
+    const unsigned int to, nntrainer::Tensor &query_step,
+    nntrainer::Tensor &key_step, nntrainer::Tensor &value_step,
+    nntrainer::Tensor &attention_output_step, nntrainer::Tensor &cache_key,
+    nntrainer::Tensor &cache_value, ml::train::TensorDim &cache_key_dim,
+    ml::train::TensorDim &cache_key_step_dim,
+    ml::train::TensorDim &cache_value_dim,
+    ml::train::TensorDim &cache_value_step_dim);
+
+  /**
+   * @brief add DeBERTa relative attention score (c2p / p2c)
+   * into already computed qk score
+   */
+  void add_relative_attn_score(nntrainer::RunLayerContext &context,
+                               nntrainer::Tensor &score,
+                               nntrainer::Tensor &query_step,
+                               nntrainer::Tensor &key_cache,
+                               unsigned int from, unsigned int to);
+
+  /**
+   * @brief bucket helper
+   */
+  int make_log_bucket_position(int relative_pos, int bucket_size,
+                               int max_position);
+
+  /**
+   * @brief precompute bucket lookup table
+   */
+  void prepare_bucket_table(unsigned int max_seq_len);
+
+  /**
+   * @brief lookup precomputed bucket
+   */
+  int lookup_bucket(int relative_pos) const;
+
+private:
+  std::tuple<nntrainer::props::NumHeads, props::MaxPositionEmbeddings,
+             props::MaxRelativePositions, props::C2P, props::P2C,
+             props::ShareAttKey, props::RelativeAttention,
+             props::PositionBuckets, props::InputLen,
+             nntrainer::props::DisableBias>
+    deberta_props;
+
+  /**
+   * @brief internal tensor indices
+   */
+  std::array<unsigned int, max_params> tensor_idx;
+
+  /**
+   * @brief common runtime states, kept similar to mha_core
+   */
+  float epsilon;
+  size_t num_heads_Q;
+  size_t num_heads_KV;
+  size_t head_dim;
+
+  unsigned int max_position_embeddings;
+  unsigned int max_relative_positions;
+  int position_buckets;
+  unsigned int local_window_size;
+
+  float attn_logit_softcapping;
+  bool is_causal;
+
+  /**
+   * @brief relative bucket lookup table
+   */
+  std::vector<int> bucket_table;
+  unsigned int bucket_table_max_seq_len;
+  bool bucket_table_ready;
+  mutable std::mutex bucket_mtx;
+};
+
+} // namespace causallm
+
+#endif /* __DEBERTA_ATTENTION_LAYER_H__ */

--- a/Applications/CausalLM/layers/deberta_attention_layer.h
+++ b/Applications/CausalLM/layers/deberta_attention_layer.h
@@ -4,7 +4,8 @@
  *
  * @file   deberta_attention_layer.h
  * @date   14 January 2026
- * @see    https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta/modeling_deberta.py
+ * @see
+ * https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta/modeling_deberta.py
  * @author Seunghui Lee <shsh1004.lee@samsung.com>
  * @bug    No known bugs except for NYI items
  * @brief  DeBERTa attention layer based on mha_core-style optimized path
@@ -202,9 +203,8 @@ public:
   /**
    * @brief softmax helper for score tensor
    */
-  void softmax_triangle(nntrainer::Tensor &qk_out, size_t row,
-                        size_t num_heads, unsigned int from,
-                        BS::thread_pool<> &pool);
+  void softmax_triangle(nntrainer::Tensor &qk_out, size_t row, size_t num_heads,
+                        unsigned int from, BS::thread_pool<> &pool);
 
   /**
    * @brief wrapper around nntrainer::compute_fp16vcache_transposed
@@ -227,11 +227,7 @@ private:
     OUTPUT_IDX = 0,
   };
 
-  enum AttentionParams {
-    cache_key = 0,
-    cache_value = 1,
-    max_params
-  };
+  enum AttentionParams { cache_key = 0, cache_value = 1, max_params };
 
   /**
    * @brief one-batch incremental forwarding path
@@ -243,12 +239,12 @@ private:
    *   -> compute_fp16vcache_transposed()
    */
   void one_batch_incremental_forwarding(
-    nntrainer::RunLayerContext &context,
-    const unsigned int batch, const unsigned int _from, const unsigned int from,
-    const unsigned int to, nntrainer::Tensor &query_step,
-    nntrainer::Tensor &key_step, nntrainer::Tensor &value_step,
-    nntrainer::Tensor &attention_output_step, nntrainer::Tensor &cache_key,
-    nntrainer::Tensor &cache_value, ml::train::TensorDim &cache_key_dim,
+    nntrainer::RunLayerContext &context, const unsigned int batch,
+    const unsigned int _from, const unsigned int from, const unsigned int to,
+    nntrainer::Tensor &query_step, nntrainer::Tensor &key_step,
+    nntrainer::Tensor &value_step, nntrainer::Tensor &attention_output_step,
+    nntrainer::Tensor &cache_key, nntrainer::Tensor &cache_value,
+    ml::train::TensorDim &cache_key_dim,
     ml::train::TensorDim &cache_key_step_dim,
     ml::train::TensorDim &cache_value_dim,
     ml::train::TensorDim &cache_value_step_dim);
@@ -260,8 +256,8 @@ private:
   void add_relative_attn_score(nntrainer::RunLayerContext &context,
                                nntrainer::Tensor &score,
                                nntrainer::Tensor &query_step,
-                               nntrainer::Tensor &key_cache,
-                               unsigned int from, unsigned int to);
+                               nntrainer::Tensor &key_cache, unsigned int from,
+                               unsigned int to);
 
   /**
    * @brief bucket helper

--- a/Applications/CausalLM/layers/meson.build
+++ b/Applications/CausalLM/layers/meson.build
@@ -11,6 +11,8 @@ causallm_reshaped_rms_norm_src_abs = [meson.current_source_dir() / 'reshaped_rms
 causallm_qkv_layer_src_abs = [meson.current_source_dir() / 'qkv_layer.cpp']
 causallm_embedding_pooling_src_abs = [meson.current_source_dir() / 'embedding_pooling_layer.cpp']
 causallm_embedding_normalize_src_abs = [meson.current_source_dir() / 'embedding_normalize_layer.cpp']
+causallm_deberta_attention_src_abs = [meson.current_source_dir() / 'deberta_attention_layer.cpp']
+causallm_shared_fully_connected_src_abs = [meson.current_source_dir() / 'shared_fully_connected_layer.cpp']
 
 causallm_rms_norm = shared_library(
     'rms_norm_layer', 
@@ -141,5 +143,33 @@ causallm_qkv_layer = shared_library(
 
 causallm_qkv_layer_dep = declare_dependency(
     link_with: causallm_qkv_layer,
+    include_directories: causallm_layer_inc
+)
+
+causallm_deberta_attention_layer = shared_library(
+    'deberta_attention_layer',
+    causallm_deberta_attention_src_abs,
+    include_directories: causallm_layer_inc,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    install: true,
+    install_dir: application_install_dir
+)
+
+causallm_deberta_attention_layer_dep = declare_dependency(
+    link_with: causallm_deberta_attention_layer,
+    include_directories: causallm_layer_inc
+)
+
+causallm_shared_fully_connected_layer = shared_library(
+    'shared_fully_connected_layer',
+    causallm_shared_fully_connected_src_abs,
+    include_directories: causallm_layer_inc,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    install: true,
+    install_dir: application_install_dir
+)
+
+causallm_shared_fully_connected_layer_dep = declare_dependency(
+    link_with: causallm_shared_fully_connected_layer,
     include_directories: causallm_layer_inc
 )

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.cpp
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.cpp
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   shared_fully_connected_layer.cpp
+ * @date   20 January 2026
+ * @brief  Shared Fully Connected Layer Class implementation
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Seunghui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <fstream>
+#include <iostream>
+#include <layer_context.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <node_exporter.h>
+#include <shared_fully_connected_layer.h>
+#include <tensor.h>
+#include <tensor_dim.h>
+#include <util_func.h>
+
+namespace causallm {
+using namespace nntrainer;
+
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
+enum FCParams { weight, bias };
+
+SharedFullyConnectedLayer::SharedFullyConnectedLayer() :
+  nntrainer::LayerImpl() {
+  weight_idx.fill(std::numeric_limits<unsigned>::max());
+  shared_mode_ = std::get<props::SharedMode>(fc_props).get();
+}
+
+void SharedFullyConnectedLayer::finalize(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() < 1, std::invalid_argument)
+    << "SharedFullyConnectedLayer requires at least one input";
+
+  auto &disable_bias = std::get<nntrainer::props::DisableBias>(fc_props);
+  const auto &unit = std::get<nntrainer::props::Unit>(fc_props).get();
+
+  auto weight_initializer = nntrainer::props::InitializerInfo::Enum::NONE;
+  auto bias_initializer = nntrainer::props::InitializerInfo::Enum::NONE;
+  std::vector<nntrainer::TensorDim> output_dims(1);
+
+  /// @todo fc actaully supports multidimensions. EffDimFlag shouldn't be fixed
+  /// like this.
+  context.setEffDimFlagInputDimension(0, 0b1001);
+  context.setDynDimFlagInputDimension(0, 0b1000);
+
+  bool is_nchw = (context.getFormat() == ml::train::TensorDim::Format::NCHW);
+  /** set output dimensions */
+  auto const &in_dim = context.getInputDimensions()[0];
+  output_dims[0] = in_dim;
+  is_nchw ? output_dims[0].width(unit) : output_dims[0].channel(unit);
+
+  output_dims[0].setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+
+  context.setOutputDimensions(output_dims);
+
+  /** set weight specifications */
+  // @todo : This NCHW format setting is just temporal, it needs to be set by
+  // global configuration
+
+  /** Weight Dimension : (1, 1, in_dim.width(), unit)*/
+  nntrainer::TensorDim weight_dim(
+    1, is_nchw ? 1 : unit, is_nchw ? in_dim.width() : 1,
+    is_nchw ? unit : in_dim.channel(),
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+
+  /** Bias Dimension : (1, 1, 1, unit) */
+  nntrainer::TensorDim bias_dim(
+    1, is_nchw ? 1 : unit, 1, is_nchw ? unit : 1,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getActivationDataType()),
+    is_nchw ? 0b0001 : 0b0100);
+
+  weight_idx[FCParams::weight] =
+    context.requestWeight(weight_dim, weight_initializer,
+                          WeightRegularizer::NONE, 1.0f, 0.0f, "weight", true);
+
+  if (disable_bias.empty() || disable_bias.get() == false) {
+    weight_idx[FCParams::bias] =
+      context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
+                            1.0f, 0.0f, "bias", true);
+  }
+}
+
+void SharedFullyConnectedLayer::setProperty(
+  const std::vector<std::string> &values) {
+  auto remain_props = loadProperties(values, fc_props);
+  LayerImpl::setProperty(remain_props);
+  shared_mode_ = std::get<props::SharedMode>(fc_props).get();
+}
+
+void SharedFullyConnectedLayer::forwarding(nntrainer::RunLayerContext &context,
+                                           bool training) {
+  nntrainer::Tensor &weight = context.getWeight(weight_idx[FCParams::weight]);
+
+  nntrainer::Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+
+  input_.dot(weight, hidden_, false, false);
+
+  if (auto &disable_bias = std::get<nntrainer::props::DisableBias>(fc_props);
+      disable_bias.empty() || disable_bias.get() == false) {
+    nntrainer::Tensor &bias = context.getWeight(weight_idx[FCParams::bias]);
+
+    hidden_.add_i(bias);
+  }
+}
+
+void SharedFullyConnectedLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+  nntrainer::Tensor &weight = context.getWeight(weight_idx[FCParams::weight]);
+
+  nntrainer::Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
+
+  bool FullInputRange = std::get<props::FullInputRange>(fc_props).get();
+
+  if (FullInputRange) {
+    input_.dot(weight, hidden_, false, false);
+    if (auto &disable_bias = std::get<nntrainer::props::DisableBias>(fc_props);
+        disable_bias.empty() || disable_bias.get() == false) {
+      nntrainer::Tensor &bias = context.getWeight(weight_idx[FCParams::bias]);
+      hidden_.add_i(bias);
+    }
+    return;
+  }
+
+  nntrainer::TensorDim input_dim = input_.getDim();
+  nntrainer::TensorDim hidden_dim = hidden_.getDim();
+
+  nntrainer::TensorDim input_step_dim = input_dim;
+  nntrainer::TensorDim hidden_step_dim = hidden_dim;
+
+  input_step_dim.batch(1);
+  input_step_dim.height(to - from);
+  hidden_step_dim.batch(1);
+  hidden_step_dim.height(to - from);
+
+  for (unsigned int b = 0; b < hidden_.batch(); ++b) {
+    nntrainer::Tensor input_step = input_.getSharedDataTensor(
+      input_step_dim, b * hidden_dim.getFeatureLen(), true);
+    nntrainer::Tensor hidden_step = hidden_.getSharedDataTensor(
+      hidden_step_dim, b * hidden_dim.getFeatureLen(), true);
+
+    input_step.dot(weight, hidden_step, false, false);
+
+    if (auto &disable_bias = std::get<nntrainer::props::DisableBias>(fc_props);
+        disable_bias.empty() || disable_bias.get() == false) {
+      nntrainer::Tensor &bias = context.getWeight(weight_idx[FCParams::bias]);
+      hidden_step.add_i(bias);
+    }
+  }
+}
+
+void SharedFullyConnectedLayer::calcDerivative(
+  nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "calcDerivative for SharedFullyConnectedLayer is not supported");
+}
+
+void SharedFullyConnectedLayer::calcGradient(
+  nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "calcGradient for SharedFullyConnectedLayer is not supported");
+}
+
+void SharedFullyConnectedLayer::exportTo(
+  nntrainer::Exporter &exporter, const ml::train::ExportMethods &method) const {
+  LayerImpl::exportTo(exporter, method);
+  exporter.saveResult(fc_props, method, this);
+}
+
+void SharedFullyConnectedLayer::read(
+  std::ifstream &file, nntrainer::RunLayerContext &context, bool opt_var,
+  ml::train::ExecutionMode mode, bool trainable,
+  nntrainer::TensorDim::DataType definedWeightDataType, bool fsu,
+  size_t start_offset, bool read_from_offset, int file_fd) {
+  if (!shared_mode_) {
+    size_t current_offset = start_offset;
+    for (unsigned int i = 0; i < context.getNumWeights(); ++i) {
+      auto &w = context.getWeight(i);
+      w.read(file, current_offset, read_from_offset, file_fd);
+
+      if (read_from_offset &&
+          current_offset != std::numeric_limits<size_t>::max()) {
+        current_offset += w.bytes();
+      }
+
+      if (context.isMixedPrecision(i) && !context.getWeightFP32(i).empty()) {
+        context.getWeightFP32(i).copyData(context.getWeight(i));
+      }
+    }
+  }
+}
+
+void SharedFullyConnectedLayer::save(
+  std::ofstream &file, nntrainer::RunLayerContext &run_context, bool opt_var,
+  ml::train::ExecutionMode mode, bool trainable,
+  nntrainer::TensorDim::DataType definedWeightDataType) const {
+  if (!shared_mode_) {
+    for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
+      run_context.getWeight(i).save(file);
+    }
+  }
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.cpp
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <iostream>
 #include <layer_context.h>
+#include <limits>
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.h
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.h
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   shared_fully_connected_layer.h
+ * @date   20 January 2026
+ * @brief  Shared Fully Connected Layer Class
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Seunghui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __SHARED_FULLY_CONNECTED_LAYER_H__
+#define __SHARED_FULLY_CONNECTED_LAYER_H__
+
+#include <causallm_common_properties.h>
+#include <common_properties.h>
+#include <layer_impl.h>
+
+namespace causallm {
+
+namespace props {
+
+/**
+ * @brief Mode property
+ */
+class SharedMode : public nntrainer::Property<bool> {
+public:
+  static constexpr const char *key = "shared_mode";
+  using prop_tag = nntrainer::bool_prop_tag;
+  SharedMode(bool value = false) { set(value); }
+};
+
+/**
+ * @brief Full Input Range property
+ */
+class FullInputRange : public nntrainer::Property<bool> {
+public:
+  static constexpr const char *key = "full_input_range";
+  using prop_tag = nntrainer::bool_prop_tag;
+  FullInputRange(bool value = false) { set(value); }
+};
+
+} // namespace props
+
+/**
+ * @class   SharedFullyConnectedLayer
+ * @brief   A fully connected layer that skips reading weights from file
+ *          (intended for use with shared_from weights)
+ */
+class SharedFullyConnectedLayer : public nntrainer::LayerImpl {
+public:
+  SharedFullyConnectedLayer();
+
+  ~SharedFullyConnectedLayer() = default;
+
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  void finalize(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::read()
+   */
+  void read(std::ifstream &file, nntrainer::RunLayerContext &context,
+            bool opt_var, ml::train::ExecutionMode mode, bool trainable,
+            nntrainer::TensorDim::DataType definedWeightDataType,
+            bool fsu = false, size_t start_offset = 0,
+            bool read_from_offset = false, int file_fd = -1) override;
+
+  /**
+   * @copydic Layer::save()
+   */
+  void
+  save(std::ofstream &file, nntrainer::RunLayerContext &run_context,
+       bool opt_var, ml::train::ExecutionMode mode, bool trainable,
+       nntrainer::TensorDim::DataType definedWeightDataType) const override;
+
+  /**
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
+   */
+  void forwarding(nntrainer::RunLayerContext &context, bool training) override;
+
+  /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(nntrainer::RunLayerContext &context,
+                              unsigned int from, unsigned int to,
+                              bool training) override;
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::calcGradient(RunLayerContext &context)
+   */
+  void calcGradient(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::exportTo(Exporter &exporter, const ExportMethods &method)
+   */
+  void exportTo(nntrainer::Exporter &exporter,
+                const ml::train::ExportMethods &method) const override;
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  const std::string getType() const override {
+    return SharedFullyConnectedLayer::type;
+  };
+
+  /**
+   * @copydoc Layer::supportBackwarding()
+   */
+  bool supportBackwarding() const override { return true; }
+
+  static constexpr const char *type = "shared_fully_connected";
+
+private:
+  std::tuple<nntrainer::props::Unit, nntrainer::props::DisableBias,
+             nntrainer::props::WeightInitializer,
+             nntrainer::props::BiasInitializer, props::SharedMode,
+             props::FullInputRange>
+    fc_props;
+  bool shared_mode_ = false;
+  std::array<unsigned int, 2> weight_idx;
+};
+
+} // namespace causallm
+
+#endif /* __SHARED_FULLY_CONNECTED_LAYER_H__ */

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.h
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.h
@@ -13,9 +13,20 @@
 #ifndef __SHARED_FULLY_CONNECTED_LAYER_H__
 #define __SHARED_FULLY_CONNECTED_LAYER_H__
 
+#pragma once
+#ifndef WIN_EXPORT
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#else
+#define WIN_EXPORT
+#endif
+#endif
+
 #include <causallm_common_properties.h>
 #include <common_properties.h>
 #include <layer_impl.h>
+
+#include <array>
 
 namespace causallm {
 
@@ -48,7 +59,7 @@ public:
  * @brief   A fully connected layer that skips reading weights from file
  *          (intended for use with shared_from weights)
  */
-class SharedFullyConnectedLayer : public nntrainer::LayerImpl {
+class WIN_EXPORT SharedFullyConnectedLayer : public nntrainer::LayerImpl {
 public:
   SharedFullyConnectedLayer();
 

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -169,7 +169,9 @@ std::string resolve_architecture(std::string model_type,
     } else if (architecture == "TimmViT" ||
                architecture == "vit_base_patch16_siglip_224") {
       return "TimmViT";
-    } else if (architecture == "deberta-v2") {
+    } else if (architecture == "deberta-v2" ||
+               architecture == "DebertaV2Model" ||
+               architecture == "DebertaV2ForMaskedLM") {
       return "DebertaV2";
     } else {
       throw std::invalid_argument(
@@ -260,6 +262,11 @@ int main(int argc, char *argv[]) {
       return std::make_unique<causallm::EmbeddingGemma>(cfg, generation_cfg,
                                                         nntr_cfg);
     });
+  causallm::Factory::Instance().registerModel(
+    "DebertaV2", [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::DebertaV2>(cfg, generation_cfg,
+                                                   nntr_cfg);
+    });
 #if !defined(_WIN32) && !defined(__ANDROID__)
   causallm::Factory::Instance().registerModel(
     "MultilingualTinyBert", [](json cfg, json generation_cfg, json nntr_cfg) {
@@ -271,11 +278,6 @@ int main(int argc, char *argv[]) {
     "TimmViT", [](json cfg, json generation_cfg, json nntr_cfg) {
       return std::make_unique<causallm::TimmViTTransformer>(cfg, generation_cfg,
                                                             nntr_cfg);
-    });
-  causallm::Factory::Instance().registerModel(
-    "DebertaV2", [](json cfg, json generation_cfg, json nntr_cfg) {
-      return std::make_unique<causallm::DebertaV2>(cfg, generation_cfg,
-                                                   nntr_cfg);
     });
 
   // Validate arguments

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -32,6 +32,7 @@
 
 #include "causal_lm.h"
 #include "chat_template.h"
+#include "deberta_v2.h"
 #include "embedding_gemma.h"
 #include "gemma3_causallm.h"
 #if !defined(_WIN32)
@@ -168,6 +169,8 @@ std::string resolve_architecture(std::string model_type,
     } else if (architecture == "TimmViT" ||
                architecture == "vit_base_patch16_siglip_224") {
       return "TimmViT";
+    } else if (architecture == "deberta-v2") {
+      return "DebertaV2";
     } else {
       throw std::invalid_argument(
         "Unsupported architecture for embedding model: " + architecture);
@@ -269,6 +272,11 @@ int main(int argc, char *argv[]) {
       return std::make_unique<causallm::TimmViTTransformer>(cfg, generation_cfg,
                                                             nntr_cfg);
     });
+  causallm::Factory::Instance().registerModel(
+    "DebertaV2", [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::DebertaV2>(cfg, generation_cfg,
+                                                   nntr_cfg);
+    });
 
   // Validate arguments
   if (argc < 2) {
@@ -317,9 +325,12 @@ int main(int argc, char *argv[]) {
     } else if (cfg.contains("architecture") &&
                cfg["architecture"].is_string()) {
       architecture = cfg["architecture"].get<std::string>();
+    } else if (cfg.contains("model_type") && cfg["model_type"].is_string()) {
+      architecture = cfg["model_type"].get<std::string>();
     } else {
       throw std::invalid_argument(
-        "config.json must contain 'architectures' or 'architecture'.");
+        "config.json must contain 'architectures', 'architecture', or "
+        "'model_type'.");
     }
 
     if (nntr_cfg.contains("model_type")) {

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -31,6 +31,9 @@ causallm_layer_dependencies += [
     causallm_qkv_layer_dep,
     causallm_embedding_pooling_layer_dep,
     causallm_embedding_normalize_layer_dep,
+    causallm_qkv_layer_dep, 
+    causallm_deberta_attention_layer_dep, 
+    causallm_shared_fully_connected_layer_dep,
 ]
 
 subdir('models')

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -31,7 +31,6 @@ causallm_layer_dependencies += [
     causallm_qkv_layer_dep,
     causallm_embedding_pooling_layer_dep,
     causallm_embedding_normalize_layer_dep,
-    causallm_qkv_layer_dep, 
     causallm_deberta_attention_layer_dep, 
     causallm_shared_fully_connected_layer_dep,
 ]

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -31,7 +31,7 @@ causallm_layer_dependencies += [
     causallm_qkv_layer_dep,
     causallm_embedding_pooling_layer_dep,
     causallm_embedding_normalize_layer_dep,
-    causallm_deberta_attention_layer_dep, 
+    causallm_deberta_attention_layer_dep,
     causallm_shared_fully_connected_layer_dep,
 ]
 

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
@@ -2,316 +2,351 @@
 /**
  * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
  *
- * @file   debertav2.cpp
+ * @file   deberta_v2.cpp
  * @date   14 January 2026
+ * @brief  DeBERTa V2 encoder model for SentenceTransformer embeddings
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seunghui Lee <shsh1004.lee@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  Please refer to the following code :
- * https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta/modeling_deberta.py
+ * @note   Please refer to the following code :
+ * https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
  */
 
-#include "json.hpp"
-
-#include <app_context.h>
 #include <deberta_attention_layer.h>
 #include <deberta_v2.h>
-#include <engine.h>
-#include <filesystem>
-#include <fstream>
-#include <layer_context.h>
-#include <layer_node.h>
-#include <llm_util.hpp>
 #include <shared_fully_connected_layer.h>
-#include <weight_layer.h>
 
+#include <app_context.h>
+#include <engine.h>
+#include <llm_util.hpp>
+#include <model.h>
+
+#include <algorithm>
+#include <chrono>
 #include <filesystem>
+#include <iomanip>
+#include <iostream>
 #include <sstream>
-
-using json = nlohmann::json;
+#include <stdexcept>
 
 namespace causallm {
 
-void DebertaV2::constructModel() {
-  std::vector<LayerHandle> layers;
+namespace {
 
-  // create model
-  model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
-
-  layers.push_back(createLayer(
-    "input", {withKey("name", "input0"),
-              withKey("input_shape", "1:1:" + std::to_string(INIT_SEQ_LEN))}));
-
-  // create embedding layer
-  layers.push_back(createLayer("embedding_layer",
-                               {"name=embedding0", "input_layers=input0",
-                                "in_dim=" + std::to_string(NUM_VOCAB),
-                                "weight_dtype=" + EMBEDDING_DTYPE,
-                                "out_dim=" + std::to_string(DIM),
-                                "scale=" + std::to_string(EMBEDDING_SCALE)}));
-
-  layers.push_back(
-    createLayer("layer_normalization",
-                {withKey("name", "embeddings_norm"),
-                 withKey("input_layers", "embedding0"), withKey("axis", "3"),
-                 withKey("packed", "false"), withKey("epsilon", "1e-7")}));
-
-  int rel_embed_size =
-    (POSITION_BUCKETS > 0)
-      ? POSITION_BUCKETS * 2
-      : ((MAX_RELATIVE_POSITIONS < 1) ? MAX_POSITION_EMBEDDINGS * 2
-                                      : MAX_RELATIVE_POSITIONS * 2);
-  layers.push_back(createLayer(
-    "weight", {withKey("name", "rel_embeddings"),
-               withKey("input_layers", "embeddings_norm"),
-               withKey("weight_name", "rel_embeddings"),
-               withKey("dim", "1:1:" + std::to_string(rel_embed_size) + ":" +
-                                std::to_string(DIM)),
-               withKey("input_shape", "1:1:" + std::to_string(rel_embed_size) +
-                                        ":" + std::to_string(DIM)),
-               withKey("weight_initializer", "none")}));
-
-  layers.push_back(createLayer(
-    "layer_normalization",
-    {withKey("name", "rel_embeddings_norm"),
-     withKey("input_layers", "rel_embeddings"), withKey("axis", "3"),
-     withKey("packed", "false"), withKey("epsilon", "1e-7")}));
-
-  // create Deberta layers
-  std::string last_input = "embeddings_norm";
-
-  for (int i = 0; i < NUM_LAYERS; ++i) {
-    std::vector<LayerHandle> encoder_layer =
-      createDebertaLayer(i, last_input, "rel_embeddings_norm");
-    layers.insert(layers.end(), encoder_layer.begin(), encoder_layer.end());
-    last_input = "layer" + std::to_string(i) + "_output";
-  }
-
-  for (auto &layer : layers) {
-    model->addLayer(layer);
-  }
+/**
+ * @brief Convert a float to a string with enough precision to preserve eps.
+ */
+std::string toStringPrecise(float v) {
+  std::ostringstream oss;
+  oss << std::setprecision(20) << v;
+  return oss.str();
 }
 
-std::vector<LayerHandle>
-DebertaV2::createDebertaLayer(const int layer_id, std::string input_name,
-                              std::string rel_embeddings_name) {
-  std::vector<LayerHandle> layers;
-  std::string prefix = "layer" + std::to_string(layer_id);
+/**
+ * @brief Parse DeBERTa pos_att_type config field into a string vector.
+ */
+std::vector<std::string> parsePosAttType(const json &cfg) {
+  std::vector<std::string> result;
+  if (!cfg.contains("pos_att_type") || cfg["pos_att_type"].is_null())
+    return result;
 
-  // 1. Attention Block
-  std::vector<LayerHandle> attn_layers =
-    createDebertaV2Attention(layer_id, input_name, rel_embeddings_name);
-  layers.insert(layers.end(), attn_layers.begin(), attn_layers.end());
+  if (cfg["pos_att_type"].is_array()) {
+    result = cfg["pos_att_type"].get<std::vector<std::string>>();
+  } else if (cfg["pos_att_type"].is_string()) {
+    std::stringstream ss(cfg["pos_att_type"].get<std::string>());
+    std::string token;
+    while (std::getline(ss, token, '|')) {
+      token.erase(0, token.find_first_not_of(" \t"));
+      token.erase(token.find_last_not_of(" \t") + 1);
+      if (!token.empty())
+        result.push_back(token);
+    }
+  }
 
-  layers.push_back(createLayer(
-    "addition",
-    {withKey("name", prefix + "_attention_add"),
-     withKey("input_layers", {input_name, prefix + "_attention_out"})}));
-
-  layers.push_back(createLayer(
-    "layer_normalization",
-    {withKey("name", prefix + "_attention_norm"), withKey("epsilon", "1e-7"),
-     withKey("axis", "3"), withKey("packed", "false"),
-     withKey("input_layers", prefix + "_attention_add")}));
-
-  // 2. Intermediate Block
-  std::vector<std::string> inter_params = {
-    withKey("name", prefix + "_intermediate"),
-    withKey("unit", INTERMEDIATE_SIZE),
-    withKey("input_layers", prefix + "_attention_norm"),
-    withKey("activation", "gelu")};
-  layers.push_back(createLayer("fully_connected", inter_params));
-
-  std::vector<std::string> output_params = {
-    withKey("name", prefix + "_output_dense"), withKey("unit", DIM),
-    withKey("input_layers", prefix + "_intermediate")};
-  layers.push_back(createLayer("fully_connected", output_params));
-
-  layers.push_back(createLayer(
-    "addition", {withKey("name", prefix + "_output_add"),
-                 withKey("input_layers", {prefix + "_attention_norm",
-                                          prefix + "_output_dense"})}));
-
-  layers.push_back(createLayer(
-    "layer_normalization",
-    {withKey("name", prefix + "_output"), withKey("epsilon", "1e-7"),
-     withKey("axis", "3"), withKey("packed", "false"),
-     withKey("input_layers", prefix + "_output_add")}));
-
-  return layers;
+  return result;
 }
 
-std::vector<LayerHandle>
-DebertaV2::createDebertaV2Attention(const int layer_id, std::string input_name,
-                                    std::string rel_embeddings_name) {
-  std::vector<LayerHandle> layers;
-  auto Q = "layer" + std::to_string(layer_id) + "_wq";
-  auto K = "layer" + std::to_string(layer_id) + "_wk";
-  auto V = "layer" + std::to_string(layer_id) + "_wv";
-  auto A = "layer" + std::to_string(layer_id) + "_attention";
-  auto O = "layer" + std::to_string(layer_id) + "_attention_out";
+} // namespace
 
-  // V layer
-  std::vector<std::string> v_params = {
-    withKey("name", V), withKey("unit", DIM), withKey("disable_bias", "false"),
-    withKey("input_layers", input_name), withKey("weight_initializer", "ones")};
-  layers.push_back(createLayer("fully_connected", v_params));
-
-  // K layer
-  std::vector<std::string> k_params = {
-    withKey("name", K), withKey("unit", DIM), withKey("disable_bias", "false"),
-    withKey("input_layers", input_name), withKey("weight_initializer", "none")};
-  layers.push_back(createLayer("shared_fully_connected", k_params));
-
-  // Q layer
-  std::vector<std::string> q_params = {
-    withKey("name", Q), withKey("unit", DIM), withKey("disable_bias", "false"),
-    withKey("input_layers", input_name), withKey("weight_initializer", "none")};
-  layers.push_back(createLayer("shared_fully_connected", q_params));
-
-  std::string attn_input_layers = Q + "," + K + "," + V;
-
-  // P2C uses Q_rel (projected relative embeddings using Query weights)
-  // DebertaAttentionLayer expects p2c input 5th (idx 4)
-  if (P2C) {
-    auto Q_rel = "layer" + std::to_string(layer_id) + "_wq_rel";
-    // Add Q as dependency to force Q to be finalized before Q_rel
-    std::string q_rel_input_layers = rel_embeddings_name;
-    std::vector<std::string> q_rel_params = {
-      withKey("name", Q_rel),
-      withKey("unit", DIM),
-      withKey("shared_mode", "true"),
-      withKey("shared_from", Q),
-      withKey("disable_bias", "false"),
-      withKey("input_layers", {rel_embeddings_name, Q}),
-      withKey("full_input_range", "true"),
-      withKey("weight_initializer", "none")};
-
-    layers.push_back(createLayer("shared_fully_connected", q_rel_params));
-    attn_input_layers += "," + Q_rel;
+json &DebertaV2::sanitizeConfig(json &cfg) {
+  if (!cfg.contains("rope_theta")) {
+    cfg["rope_theta"] = 0u;
   }
 
-  // C2P uses K_rel (projected relative embeddings using Key weights)
-  // DebertaAttentionLayer expects C2P input 4th (idx 3)
-  if (C2P) {
-    auto K_rel = "layer" + std::to_string(layer_id) + "_wk_rel";
-    // Add K as dependency to force K to be finalized before K_rel
-    std::string k_rel_input_layers = rel_embeddings_name;
-    std::vector<std::string> k_rel_params = {
-      withKey("name", K_rel),
-      withKey("unit", DIM),
-      withKey("shared_mode", "true"),
-      withKey("shared_from", K),
-      withKey("disable_bias", "false"),
-      withKey("input_layers", {rel_embeddings_name, K}),
-      withKey("full_input_range", "true"),
-      withKey("weight_initializer", "none")};
-    layers.push_back(createLayer("shared_fully_connected", k_rel_params));
-    attn_input_layers += "," + K_rel;
+  if (!cfg.contains("rms_norm_eps")) {
+    cfg["rms_norm_eps"] = cfg.value("layer_norm_eps", 1e-7f);
   }
 
-  std::vector<std::string> attn_params = {
-    withKey("name", A),
-    withKey("num_heads", NUM_HEADS),
-    withKey("max_position_embeddings", MAX_POSITION_EMBEDDINGS),
-    withKey("max_relative_positions", MAX_RELATIVE_POSITIONS),
-    withKey("c2p", C2P ? "true" : "false"),
-    withKey("p2c", P2C ? "true" : "false"),
-    withKey("share_att_key", SHARE_ATT_KEY ? "true" : "false"),
-    withKey("position_buckets", POSITION_BUCKETS),
-    withKey("relative_attention", RELATIVE_ATTENTION ? "true" : "false"),
-    withKey("disable_bias", "false"), // Q/K/V bias control
-    withKey("input_layers", attn_input_layers)};
-  layers.push_back(createLayer("deberta_attention", attn_params));
+  if (!cfg.contains("tie_word_embeddings")) {
+    cfg["tie_word_embeddings"] = false;
+  }
 
-  // Output Projection
-  std::vector<std::string> out_params = {
-    withKey("name", O), withKey("unit", DIM), withKey("disable_bias", "false"),
-    withKey("input_layers", A), withKey("weight_initializer", "ones")};
-  layers.push_back(createLayer("fully_connected", out_params));
+  if (!cfg.contains("num_key_value_heads")) {
+    cfg["num_key_value_heads"] = cfg["num_attention_heads"];
+  }
 
-  return layers;
+  if (!cfg.contains("use_bidirectional_attention") &&
+      !cfg.contains("is_causal")) {
+    cfg["is_causal"] = false;
+  }
+
+  return cfg;
 }
 
 void DebertaV2::setupParameters(json &cfg, json &generation_cfg,
                                 json &nntr_cfg) {
-  Transformer::setupParameters(cfg, generation_cfg, nntr_cfg);
+  SentenceTransformer::setupParameters(cfg, generation_cfg, nntr_cfg);
 
+  const json *encoder_cfg = &cfg;
   try {
-    std::string tokenizer_file = nntr_cfg["tokenizer_file"].get<std::string>();
-    std::filesystem::path tokenizer_path(tokenizer_file);
-    std::string model_path = tokenizer_path.parent_path().string();
-    std::filesystem::path config_path =
-      std::filesystem::path(model_path) / "encoder_config" / "config.json";
+    if (nntr_cfg.contains("tokenizer_file")) {
+      std::filesystem::path tokenizer_path(
+        nntr_cfg["tokenizer_file"].get<std::string>());
+      std::filesystem::path model_path = tokenizer_path.parent_path();
+      std::filesystem::path encoder_config_path =
+        model_path / "encoder_config" / "config.json";
 
-    if (!std::filesystem::exists(config_path)) {
-      config_path = std::filesystem::path(model_path) / "config.json";
-    }
-
-    json encoder_cfg = causallm::LoadJsonFile(config_path.string());
-    if (encoder_cfg.contains("max_relative_positions")) {
-      MAX_RELATIVE_POSITIONS = encoder_cfg["max_relative_positions"].get<int>();
-      if (MAX_RELATIVE_POSITIONS == -1) {
-        MAX_RELATIVE_POSITIONS = MAX_POSITION_EMBEDDINGS;
+      if (std::filesystem::exists(encoder_config_path)) {
+        static json loaded_encoder_cfg;
+        loaded_encoder_cfg =
+          causallm::LoadJsonFile(encoder_config_path.string());
+        encoder_cfg = &loaded_encoder_cfg;
       }
     }
-
-    if (encoder_cfg.contains("pos_att_type")) {
-      std::vector<std::string> pos_att_type_vec;
-      if (encoder_cfg["pos_att_type"].is_array()) {
-        pos_att_type_vec =
-          encoder_cfg["pos_att_type"].get<std::vector<std::string>>();
-      } else if (encoder_cfg["pos_att_type"].is_string()) {
-        std::string pos_att_str =
-          encoder_cfg["pos_att_type"].get<std::string>();
-
-        std::stringstream ss(pos_att_str);
-        std::string token;
-
-        while (std::getline(ss, token, '|')) {
-          token.erase(0, token.find_first_not_of(" \t"));
-          token.erase(token.find_last_not_of(" \t") + 1);
-
-          if (!token.empty()) {
-            pos_att_type_vec.push_back(token);
-          }
-        }
-      }
-
-      C2P = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(),
-                      "c2p") != pos_att_type_vec.end();
-      P2C = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(),
-                      "p2c") != pos_att_type_vec.end();
-    } else {
-      C2P = false;
-      P2C = false;
-    }
-
-    if (encoder_cfg.contains("share_att_key")) {
-      SHARE_ATT_KEY = encoder_cfg["share_att_key"].get<bool>();
-    } else {
-      SHARE_ATT_KEY = false;
-    }
-
-    if (encoder_cfg.contains("relative_attention")) {
-      RELATIVE_ATTENTION = encoder_cfg["relative_attention"].get<bool>();
-    } else {
-      RELATIVE_ATTENTION = true;
-    }
-
-    if (encoder_cfg.contains("position_buckets")) {
-      POSITION_BUCKETS = encoder_cfg["position_buckets"].get<int>();
-    } else {
-      POSITION_BUCKETS = -1;
-    }
-
   } catch (const std::exception &e) {
-    std::cerr << "\n[!] FATAL ERROR: " << e.what() << "\n";
+    std::cerr << "Warning: failed to load DeBERTa encoder_config: " << e.what()
+              << std::endl;
   }
+
+  MAX_RELATIVE_POSITIONS = encoder_cfg->value(
+    "max_relative_positions", static_cast<int>(MAX_POSITION_EMBEDDINGS));
+  if (MAX_RELATIVE_POSITIONS == -1)
+    MAX_RELATIVE_POSITIONS = static_cast<int>(MAX_POSITION_EMBEDDINGS);
+
+  const auto pos_att_type = parsePosAttType(*encoder_cfg);
+  C2P = std::find(pos_att_type.begin(), pos_att_type.end(), "c2p") !=
+        pos_att_type.end();
+  P2C = std::find(pos_att_type.begin(), pos_att_type.end(), "p2c") !=
+        pos_att_type.end();
+
+  SHARE_ATT_KEY = encoder_cfg->value("share_att_key", true);
+  RELATIVE_ATTENTION = encoder_cfg->value("relative_attention", true);
+  POSITION_BUCKETS = encoder_cfg->value("position_buckets", -1);
+
+  std::string norm_rel_ebd =
+    encoder_cfg->value("norm_rel_ebd", std::string("none"));
+  std::transform(norm_rel_ebd.begin(), norm_rel_ebd.end(), norm_rel_ebd.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  NORM_REL_EBD = norm_rel_ebd.find("layer_norm") != std::string::npos;
+}
+
+std::pair<Tensor, Tensor> DebertaV2::constructTransformerModule() {
+  Tensor x({1, 1, 1, static_cast<unsigned int>(INIT_SEQ_LEN)}, "input0");
+
+  LayerHandle embedding(createLayer(
+    "embedding_layer",
+    {withKey("name", "embedding0"), withKey("in_dim", NUM_VOCAB),
+     withKey("weight_dtype", EMBEDDING_DTYPE), withKey("out_dim", DIM),
+     withKey("scale", std::to_string(EMBEDDING_SCALE))}));
+  Tensor h = embedding(x);
+
+  LayerHandle embedding_norm(createLayer(
+    "layer_normalization", {withKey("name", "embeddings_norm"),
+                            withKey("epsilon", toStringPrecise(NORM_EPS)),
+                            withKey("axis", 3), withKey("packed", "false")}));
+  h = embedding_norm(h);
+
+  const int rel_embed_size =
+    (POSITION_BUCKETS > 0) ? POSITION_BUCKETS * 2
+                           : ((MAX_RELATIVE_POSITIONS < 1)
+                                ? static_cast<int>(MAX_POSITION_EMBEDDINGS) * 2
+                                : MAX_RELATIVE_POSITIONS * 2);
+
+  const std::string rel_shape =
+    "1:1:" + std::to_string(rel_embed_size) + ":" + std::to_string(DIM);
+  const std::string rel_input_shape =
+    "1:1:" + std::to_string(INIT_SEQ_LEN) + ":" + std::to_string(DIM);
+  LayerHandle rel_embedding(createLayer(
+    "weight",
+    {withKey("name", "rel_embeddings"), withKey("weight_name", "weight"),
+     withKey("dim", rel_shape), withKey("input_shape", rel_input_shape),
+     withKey("weight_initializer", "none")}));
+  Tensor rel = rel_embedding(h);
+
+  if (NORM_REL_EBD) {
+    LayerHandle rel_embedding_norm(createLayer(
+      "layer_normalization", {withKey("name", "rel_embeddings_norm"),
+                              withKey("epsilon", toStringPrecise(NORM_EPS)),
+                              withKey("axis", 3), withKey("packed", "false")}));
+    rel = rel_embedding_norm(rel);
+  }
+
+  for (int i = 0; i < NUM_LAYERS; ++i) {
+    h = createDebertaLayer(i, h, rel);
+  }
+
+  return {x, h};
+}
+
+Tensor DebertaV2::createDebertaLayer(const int layer_id, Tensor input,
+                                     Tensor rel_embeddings) {
+  const std::string prefix = "layer" + std::to_string(layer_id);
+
+  Tensor att_out = createDebertaV2Attention(layer_id, input, rel_embeddings);
+
+  LayerHandle attention_res(
+    createLayer("addition", {withKey("name", prefix + "_attention_add")}));
+  Tensor attention_residual = attention_res({input, att_out});
+
+  LayerHandle attention_norm(createLayer(
+    "layer_normalization", {withKey("name", prefix + "_attention_norm"),
+                            withKey("epsilon", toStringPrecise(NORM_EPS)),
+                            withKey("axis", 3), withKey("packed", "false")}));
+  Tensor attention_normed = attention_norm(attention_residual);
+
+  LayerHandle intermediate(createLayer(
+    "fully_connected",
+    {withKey("name", prefix + "_intermediate"),
+     withKey("unit", INTERMEDIATE_SIZE), withKey("disable_bias", "false"),
+     withKey("activation", "gelu"), withKey("weight_initializer", "ones")}));
+  Tensor intermediate_out = intermediate(attention_normed);
+
+  LayerHandle output_dense(createLayer(
+    "fully_connected",
+    {withKey("name", prefix + "_output_dense"), withKey("unit", DIM),
+     withKey("disable_bias", "false"), withKey("weight_initializer", "ones")}));
+  Tensor output_dense_out = output_dense(intermediate_out);
+
+  LayerHandle output_res(
+    createLayer("addition", {withKey("name", prefix + "_output_add")}));
+  Tensor output_residual = output_res({attention_normed, output_dense_out});
+
+  LayerHandle output_norm(createLayer(
+    "layer_normalization", {withKey("name", prefix + "_output"),
+                            withKey("epsilon", toStringPrecise(NORM_EPS)),
+                            withKey("axis", 3), withKey("packed", "false")}));
+
+  return output_norm(output_residual);
+}
+
+Tensor DebertaV2::createDebertaV2Attention(const int layer_id, Tensor input,
+                                           Tensor rel_embeddings) {
+  const std::string prefix = "layer" + std::to_string(layer_id);
+  const std::string Q = prefix + "_wq";
+  const std::string K = prefix + "_wk";
+  const std::string V = prefix + "_wv";
+  const std::string A = prefix + "_attention";
+  const std::string O = prefix + "_attention_out";
+
+  LayerHandle query(createLayer("shared_fully_connected",
+                                {withKey("name", Q), withKey("unit", DIM),
+                                 withKey("disable_bias", "false"),
+                                 withKey("weight_initializer", "none")}));
+  Tensor q = query(input);
+
+  LayerHandle key(createLayer("shared_fully_connected",
+                              {withKey("name", K), withKey("unit", DIM),
+                               withKey("disable_bias", "false"),
+                               withKey("weight_initializer", "none")}));
+  Tensor k = key(input);
+
+  LayerHandle value(
+    createLayer("fully_connected", {withKey("name", V), withKey("unit", DIM),
+                                    withKey("disable_bias", "false"),
+                                    withKey("weight_initializer", "ones")}));
+  Tensor v = value(input);
+
+  std::vector<Tensor> attention_inputs = {q, k, v};
+
+  if (P2C) {
+    LayerHandle rel_query(createLayer(
+      "shared_fully_connected",
+      {withKey("name", prefix + "_wq_rel"), withKey("unit", DIM),
+       withKey("shared_from", Q), withKey("shared_mode", "true"),
+       withKey("full_input_range", "true"), withKey("disable_bias", "false"),
+       withKey("weight_initializer", "none")}));
+    attention_inputs.push_back(rel_query({rel_embeddings, q}));
+  }
+
+  if (C2P) {
+    LayerHandle rel_key(createLayer(
+      "shared_fully_connected",
+      {withKey("name", prefix + "_wk_rel"), withKey("unit", DIM),
+       withKey("shared_from", K), withKey("shared_mode", "true"),
+       withKey("full_input_range", "true"), withKey("disable_bias", "false"),
+       withKey("weight_initializer", "none")}));
+    attention_inputs.push_back(rel_key({rel_embeddings, k}));
+  }
+
+  LayerHandle attention(createLayer(
+    "deberta_attention",
+    {withKey("name", A), withKey("num_heads", NUM_HEADS),
+     withKey("max_position_embeddings", MAX_POSITION_EMBEDDINGS),
+     withKey("max_relative_positions", MAX_RELATIVE_POSITIONS),
+     withKey("c2p", C2P ? "true" : "false"),
+     withKey("p2c", P2C ? "true" : "false"),
+     withKey("share_att_key", SHARE_ATT_KEY ? "true" : "false"),
+     withKey("position_buckets", POSITION_BUCKETS),
+     withKey("relative_attention", RELATIVE_ATTENTION ? "true" : "false"),
+     withKey("disable_bias", "false")}));
+  Tensor a = attention(attention_inputs);
+
+  LayerHandle output(
+    createLayer("fully_connected", {withKey("name", O), withKey("unit", DIM),
+                                    withKey("disable_bias", "false"),
+                                    withKey("weight_initializer", "ones")}));
+
+  return output(a);
+}
+
+std::vector<float *> DebertaV2::encode(const WSTR prompt,
+                                       const WSTR system_prompt,
+                                       const WSTR tail_prompt) {
+  if (!is_initialized) {
+    throw std::runtime_error("DebertaV2 is not initialized. Please call "
+                             "initialize() before encode().");
+  }
+
+  std::string prompt_ = system_prompt + prompt + tail_prompt;
+  auto tokenized = tokenizer->Encode(prompt_, true);
+
+  unsigned int input_len =
+    std::min(static_cast<unsigned int>(tokenized.size()), INIT_SEQ_LEN);
+
+  std::vector<float> input_sample(static_cast<size_t>(BATCH_SIZE) *
+                                  INIT_SEQ_LEN);
+  std::fill(input_sample.begin(), input_sample.end(), 0.0f);
+
+  for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
+    for (unsigned int i = 0; i < input_len; ++i) {
+      input_sample[static_cast<size_t>(b) * INIT_SEQ_LEN + i] =
+        static_cast<float>(tokenized[i]);
+    }
+  }
+
+  std::vector<float *> input = {input_sample.data()};
+  std::vector<float *> label;
+
+  auto start_prefill = std::chrono::high_resolution_clock::now();
+  auto output = model->incremental_inference(BATCH_SIZE, input, label,
+                                             input_len, 0, input_len, false);
+  auto finish_prefill = std::chrono::high_resolution_clock::now();
+  auto prefill_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+    finish_prefill - start_prefill);
+
+  std::cout << "prefill: " << input_len << " tokens, "
+            << prefill_duration.count() << " ms";
+  if (prefill_duration.count() > 0) {
+    std::cout << ", " << ((double)input_len / prefill_duration.count() * 1000)
+              << " TPS";
+  }
+  std::cout << '\n';
+
+  return output;
 }
 
 void DebertaV2::registerCustomLayers() {
-  Transformer::registerCustomLayers();
+  SentenceTransformer::registerCustomLayers();
 
   const auto &ct_engine = nntrainer::Engine::Global();
   auto app_context =

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   deberta_v2.cpp
+ * @date   14 January 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Seunghui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Please refer to the following code :
+ *  https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+ */
+
+#include "json.hpp"
+
+#include <app_context.h>
+#include <deberta_attention_layer.h>
+#include <deberta_v2.h>
+#include <engine.h>
+#include <filesystem>
+#include <fstream>
+#include <layer_context.h>
+#include <layer_node.h>
+#include <llm_util.hpp>
+#include <shared_fully_connected_layer.h>
+#include <weight_layer.h>
+
+#include <filesystem>
+#include <sstream>
+
+using json = nlohmann::json;
+
+namespace causallm {
+
+void DebertaV2::constructModel() {
+  std::vector<LayerHandle> layers;
+
+  // create model
+  model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+
+  layers.push_back(createLayer(
+    "input", {withKey("name", "input0"),
+              withKey("input_shape", "1:1:" + std::to_string(INIT_SEQ_LEN))}));
+
+  // create embedding layer
+  layers.push_back(createLayer("embedding_layer",
+                               {"name=embedding0", "input_layers=input0",
+                                "in_dim=" + std::to_string(NUM_VOCAB),
+                                "weight_dtype=" + EMBEDDING_DTYPE,
+                                "out_dim=" + std::to_string(DIM),
+                                "scale=" + std::to_string(EMBEDDING_SCALE)}));
+
+  layers.push_back(createLayer(
+    "layer_normalization",
+    {withKey("name", "embeddings_norm"), withKey("input_layers", "embedding0"),
+     withKey("axis", "3"), withKey("epsilon", "1e-7")}));
+
+  int rel_embed_size =
+    (POSITION_BUCKETS > 0)
+      ? POSITION_BUCKETS * 2
+      : ((MAX_RELATIVE_POSITIONS < 1) ? MAX_POSITION_EMBEDDINGS * 2
+                                      : MAX_RELATIVE_POSITIONS * 2);
+  layers.push_back(createLayer(
+    "weight", {withKey("name", "rel_embeddings"),
+               withKey("input_layers", "embeddings_norm"),
+               withKey("weight_name", "rel_embeddings"),
+               withKey("dim", "1:1:" + std::to_string(rel_embed_size) + ":" +
+                                std::to_string(DIM)),
+               withKey("input_shape", "1:1:" + std::to_string(rel_embed_size) +
+                                        ":" + std::to_string(DIM)),
+               withKey("weight_initializer", "none")}));
+
+  layers.push_back(createLayer(
+    "layer_normalization", {withKey("name", "rel_embeddings_norm"),
+                            withKey("input_layers", "rel_embeddings"),
+                            withKey("axis", "3"), withKey("epsilon", "1e-7")}));
+
+  // create Deberta layers
+  std::string last_input = "embeddings_norm";
+
+  for (int i = 0; i < NUM_LAYERS; ++i) {
+    std::vector<LayerHandle> encoder_layer =
+      createDebertaLayer(i, last_input, "rel_embeddings_norm");
+    layers.insert(layers.end(), encoder_layer.begin(), encoder_layer.end());
+    last_input = "layer" + std::to_string(i) + "_output";
+  }
+
+  for (auto &layer : layers) {
+    model->addLayer(layer);
+  }
+}
+
+std::vector<LayerHandle>
+DebertaV2::createDebertaLayer(const int layer_id, std::string input_name,
+                              std::string rel_embeddings_name) {
+  std::vector<LayerHandle> layers;
+  std::string prefix = "layer" + std::to_string(layer_id);
+
+  // 1. Attention Block
+  std::vector<LayerHandle> attn_layers =
+    createDebertaV2Attention(layer_id, input_name, rel_embeddings_name);
+  layers.insert(layers.end(), attn_layers.begin(), attn_layers.end());
+
+  layers.push_back(createLayer(
+    "addition",
+    {withKey("name", prefix + "_attention_add"),
+     withKey("input_layers", {input_name, prefix + "_attention_out"})}));
+
+  layers.push_back(
+    createLayer("layer_normalization",
+                {withKey("name", prefix + "_attention_norm"),
+                 withKey("epsilon", "1e-7"), withKey("axis", "3"),
+                 withKey("input_layers", prefix + "_attention_add")}));
+
+  // 2. Intermediate Block
+  std::vector<std::string> inter_params = {
+    withKey("name", prefix + "_intermediate"),
+    withKey("unit", INTERMEDIATE_SIZE),
+    withKey("input_layers", prefix + "_attention_norm"),
+    withKey("activation", "gelu")};
+  layers.push_back(createLayer("fully_connected", inter_params));
+
+  std::vector<std::string> output_params = {
+    withKey("name", prefix + "_output_dense"), withKey("unit", DIM),
+    withKey("input_layers", prefix + "_intermediate")};
+  layers.push_back(createLayer("fully_connected", output_params));
+
+  layers.push_back(createLayer(
+    "addition", {withKey("name", prefix + "_output_add"),
+                 withKey("input_layers", {prefix + "_attention_norm",
+                                          prefix + "_output_dense"})}));
+
+  layers.push_back(createLayer(
+    "layer_normalization",
+    {withKey("name", prefix + "_output"), withKey("epsilon", "1e-7"),
+     withKey("axis", "3"), withKey("input_layers", prefix + "_output_add")}));
+
+  return layers;
+}
+
+std::vector<LayerHandle>
+DebertaV2::createDebertaV2Attention(const int layer_id, std::string input_name,
+                                    std::string rel_embeddings_name) {
+  std::vector<LayerHandle> layers;
+  auto Q = "layer" + std::to_string(layer_id) + "_wq";
+  auto K = "layer" + std::to_string(layer_id) + "_wk";
+  auto V = "layer" + std::to_string(layer_id) + "_wv";
+  auto A = "layer" + std::to_string(layer_id) + "_attention";
+  auto O = "layer" + std::to_string(layer_id) + "_attention_out";
+
+  // V layer
+  std::vector<std::string> v_params = {
+    withKey("name", V), withKey("unit", DIM), withKey("disable_bias", "false"),
+    withKey("input_layers", input_name), withKey("weight_initializer", "ones")};
+  layers.push_back(createLayer("fully_connected", v_params));
+
+  // K layer
+  std::vector<std::string> k_params = {
+    withKey("name", K), withKey("unit", DIM), withKey("disable_bias", "false"),
+    withKey("input_layers", input_name), withKey("weight_initializer", "none")};
+  layers.push_back(createLayer("shared_fully_connected", k_params));
+
+  // Q layer
+  std::vector<std::string> q_params = {
+    withKey("name", Q), withKey("unit", DIM), withKey("disable_bias", "false"),
+    withKey("input_layers", input_name), withKey("weight_initializer", "none")};
+  layers.push_back(createLayer("shared_fully_connected", q_params));
+
+  std::string attn_input_layers = Q + "," + K + "," + V;
+
+  // p2c uses Q_rel (projected relative embeddings using Query weights)
+  // DebertaAttentionLayer expects p2c input 5th (idx 4)
+  if (p2c) {
+    auto Q_rel = "layer" + std::to_string(layer_id) + "_wq_rel";
+    // Add Q as dependency to force Q to be finalized before Q_rel
+    std::string q_rel_input_layers = rel_embeddings_name;
+    std::vector<std::string> q_rel_params = {
+      withKey("name", Q_rel),
+      withKey("unit", DIM),
+      withKey("shared_mode", "true"),
+      withKey("shared_from", Q),
+      withKey("disable_bias", "false"),
+      withKey("input_layers", {rel_embeddings_name, Q}),
+      withKey("full_input_range", "true"),
+      withKey("weight_initializer", "none")};
+
+    layers.push_back(createLayer("shared_fully_connected", q_rel_params));
+    attn_input_layers += "," + Q_rel;
+  }
+
+  // c2p uses K_rel (projected relative embeddings using Key weights)
+  // DebertaAttentionLayer expects c2p input 4th (idx 3)
+  if (c2p) {
+    auto K_rel = "layer" + std::to_string(layer_id) + "_wk_rel";
+    // Add K as dependency to force K to be finalized before K_rel
+    std::string k_rel_input_layers = rel_embeddings_name;
+    std::vector<std::string> k_rel_params = {
+      withKey("name", K_rel),
+      withKey("unit", DIM),
+      withKey("shared_mode", "true"),
+      withKey("shared_from", K),
+      withKey("disable_bias", "false"),
+      withKey("input_layers", {rel_embeddings_name, K}),
+      withKey("full_input_range", "true"),
+      withKey("weight_initializer", "none")};
+    layers.push_back(createLayer("shared_fully_connected", k_rel_params));
+    attn_input_layers += "," + K_rel;
+  }
+
+  std::vector<std::string> attn_params = {
+    withKey("name", A),
+    withKey("num_heads", NUM_HEADS),
+    withKey("max_position_embeddings", MAX_POSITION_EMBEDDINGS),
+    withKey("max_relative_positions", MAX_RELATIVE_POSITIONS),
+    withKey("c2p", c2p ? "true" : "false"),
+    withKey("p2c", p2c ? "true" : "false"),
+    withKey("share_att_key", SHARE_ATT_KEY ? "true" : "false"),
+    withKey("position_buckets", POSITION_BUCKETS),
+    withKey("relative_attention", RELATIVE_ATTENTION ? "true" : "false"),
+    withKey("disable_bias", "false"), // Q/K/V bias control
+    withKey("input_layers", attn_input_layers)};
+  layers.push_back(createLayer("deberta_attention", attn_params));
+
+  // Output Projection
+  std::vector<std::string> out_params = {
+    withKey("name", O), withKey("unit", DIM), withKey("disable_bias", "false"),
+    withKey("input_layers", A), withKey("weight_initializer", "ones")};
+  layers.push_back(createLayer("fully_connected", out_params));
+
+  return layers;
+}
+
+void DebertaV2::setupParameters(json &cfg, json &generation_cfg,
+                                json &nntr_cfg) {
+  Transformer::setupParameters(cfg, generation_cfg, nntr_cfg);
+
+  try {
+    std::string tokenizer_file = nntr_cfg["tokenizer_file"].get<std::string>();
+    std::filesystem::path tokenizer_path(tokenizer_file);
+    std::string model_path = tokenizer_path.parent_path().string();
+    std::filesystem::path config_path =
+      std::filesystem::path(model_path) / "encoder_config" / "config.json";
+
+    if (!std::filesystem::exists(config_path)) {
+      config_path = std::filesystem::path(model_path) / "config.json";
+    }
+
+    json encoder_cfg = causallm::LoadJsonFile(config_path.string());
+    if (encoder_cfg.contains("max_relative_positions")) {
+      MAX_RELATIVE_POSITIONS = encoder_cfg["max_relative_positions"].get<int>();
+      if (MAX_RELATIVE_POSITIONS == -1) {
+        MAX_RELATIVE_POSITIONS = MAX_POSITION_EMBEDDINGS;
+      }
+    }
+
+    if (encoder_cfg.contains("pos_att_type")) {
+      std::vector<std::string> pos_att_type_vec;
+      if (encoder_cfg["pos_att_type"].is_array()) {
+        pos_att_type_vec =
+          encoder_cfg["pos_att_type"].get<std::vector<std::string>>();
+      } else if (encoder_cfg["pos_att_type"].is_string()) {
+        std::string pos_att_str =
+          encoder_cfg["pos_att_type"].get<std::string>();
+
+        std::stringstream ss(pos_att_str);
+        std::string token;
+
+        while (std::getline(ss, token, '|')) {
+          token.erase(0, token.find_first_not_of(" \t"));
+          token.erase(token.find_last_not_of(" \t") + 1);
+
+          if (!token.empty()) {
+            pos_att_type_vec.push_back(token);
+          }
+        }
+      }
+
+      c2p = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(),
+                      "c2p") != pos_att_type_vec.end();
+      p2c = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(),
+                      "p2c") != pos_att_type_vec.end();
+    } else {
+      c2p = false;
+      p2c = false;
+    }
+
+    if (encoder_cfg.contains("share_att_key")) {
+      SHARE_ATT_KEY = encoder_cfg["share_att_key"].get<bool>();
+    } else {
+      SHARE_ATT_KEY = false;
+    }
+
+    if (encoder_cfg.contains("relative_attention")) {
+      RELATIVE_ATTENTION = encoder_cfg["relative_attention"].get<bool>();
+    } else {
+      RELATIVE_ATTENTION = true;
+    }
+
+    if (encoder_cfg.contains("position_buckets")) {
+      POSITION_BUCKETS = encoder_cfg["position_buckets"].get<int>();
+    } else {
+      POSITION_BUCKETS = -1;
+    }
+
+  } catch (const std::exception &e) {
+    std::cerr << "\n[!] FATAL ERROR: " << e.what() << "\n";
+  }
+}
+
+void DebertaV2::registerCustomLayers() {
+  Transformer::registerCustomLayers();
+
+  const auto &ct_engine = nntrainer::Engine::Global();
+  auto app_context =
+    static_cast<nntrainer::AppContext *>(ct_engine.getRegisteredContext("cpu"));
+
+  try {
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::DebertaAttentionLayer>);
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::SharedFullyConnectedLayer>);
+  } catch (std::invalid_argument &e) {
+    std::cerr << "failed to register factory, reason: " << e.what()
+              << std::endl;
+  }
+}
+
+std::vector<float *> DebertaV2::encode(const WSTR prompt,
+                                       const WSTR system_prompt,
+                                       const WSTR tail_prompt) {
+  if (!is_initialized) {
+    throw std::runtime_error("Embedding model is not initialized. Please call "
+                             "initialize() before encode().");
+  }
+
+#if defined(_WIN32)
+  std::wstring prompt_ = system_prompt + prompt + tail_prompt;
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+  auto _input = tokenizer->Encode(converter.to_bytes(prompt_), true);
+#else
+  std::string prompt_ = system_prompt + prompt + tail_prompt;
+  auto _input = tokenizer->Encode(prompt_, true);
+#endif
+
+  const int cls_id = tokenizer->TokenToId("[CLS]");
+  if (!_input.empty() && _input.front() == cls_id) {
+    _input.erase(_input.begin());
+  }
+
+  const int eos_id = tokenizer->TokenToId("[SEP]");
+  if (!_input.empty() && _input.back() == eos_id) {
+    _input.pop_back();
+  }
+
+  std::vector<int64_t> init_input;
+  unsigned int input_len =
+    std::min((unsigned int)_input.size(), (unsigned int)MAX_SEQ_LEN);
+
+  // feed only available length
+  for (unsigned int i = 0; i < input_len; ++i)
+    init_input.push_back(_input[i]);
+
+  float *input_sample =
+    (float *)malloc(sizeof(float) * BATCH_SIZE * MAX_SEQ_LEN);
+
+  for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
+    for (unsigned int i = 0; i < input_len; ++i) {
+      input_sample[static_cast<size_t>(b) * MAX_SEQ_LEN + i] =
+        static_cast<float>(init_input[i]);
+    }
+  }
+
+  std::vector<float *> input;
+  input.push_back(input_sample);
+
+  std::vector<float *> label; // Empty label for inference
+
+  // Run incremental inference for the prefill stage
+  // start: 0, end: input_len (process all tokens at once)
+  // This performs a single forward pass for the entire prompt sequence to get
+  // embeddings.
+  std::vector<float *> output = model->incremental_inference(
+    BATCH_SIZE, input, label, input_len, 0, input_len, false);
+
+  free(input_sample);
+
+  return output;
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
@@ -278,13 +278,13 @@ void DebertaV2::setupParameters(json &cfg, json &generation_cfg,
         }
       }
 
-      c2p = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(),
+      C2P = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(),
                       "c2p") != pos_att_type_vec.end();
-      p2c = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(),
+      P2C = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(),
                       "p2c") != pos_att_type_vec.end();
     } else {
-      c2p = false;
-      p2c = false;
+      C2P = false;
+      P2C = false;
     }
 
     if (encoder_cfg.contains("share_att_key")) {

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
@@ -7,7 +7,7 @@
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seunghui Lee <shsh1004.lee@samsung.com>
  * @bug    No known bugs except for NYI items
- * @note  Please refer to the following code :
+ * @brief  Please refer to the following code :
  * https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta/modeling_deberta.py
  */
 

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
@@ -13,20 +13,20 @@
 
 #include "json.hpp"
 
+#include <app_context.h>
+#include <deberta_attention_layer.h>
+#include <deberta_v2.h>
+#include <engine.h>
 #include <filesystem>
 #include <fstream>
-#include <deberta_v2.h>
-#include <deberta_attention_layer.h>
-#include <shared_fully_connected_layer.h>
-#include <llm_util.hpp>
 #include <layer_context.h>
-#include <app_context.h>
-#include <weight_layer.h>
-#include <engine.h>
 #include <layer_node.h>
+#include <llm_util.hpp>
+#include <shared_fully_connected_layer.h>
+#include <weight_layer.h>
 
-#include <sstream>
 #include <filesystem>
+#include <sstream>
 
 using json = nlohmann::json;
 
@@ -43,47 +43,46 @@ void DebertaV2::constructModel() {
               withKey("input_shape", "1:1:" + std::to_string(INIT_SEQ_LEN))}));
 
   // create embedding layer
+  layers.push_back(createLayer("embedding_layer",
+                               {"name=embedding0", "input_layers=input0",
+                                "in_dim=" + std::to_string(NUM_VOCAB),
+                                "weight_dtype=" + EMBEDDING_DTYPE,
+                                "out_dim=" + std::to_string(DIM),
+                                "scale=" + std::to_string(EMBEDDING_SCALE)}));
+
+  layers.push_back(
+    createLayer("layer_normalization",
+                {withKey("name", "embeddings_norm"),
+                 withKey("input_layers", "embedding0"), withKey("axis", "3"),
+                 withKey("packed", "false"), withKey("epsilon", "1e-7")}));
+
+  int rel_embed_size =
+    (POSITION_BUCKETS > 0)
+      ? POSITION_BUCKETS * 2
+      : ((MAX_RELATIVE_POSITIONS < 1) ? MAX_POSITION_EMBEDDINGS * 2
+                                      : MAX_RELATIVE_POSITIONS * 2);
   layers.push_back(createLayer(
-    "embedding_layer",
-    {"name=embedding0",
-     "input_layers=input0",
-     "in_dim=" + std::to_string(NUM_VOCAB),
-     "weight_dtype=" + EMBEDDING_DTYPE, "out_dim=" + std::to_string(DIM),
-     "scale=" + std::to_string(EMBEDDING_SCALE)}));
-     
-  layers.push_back(createLayer(
-    "layer_normalization",
-    {withKey("name", "embeddings_norm"),
-     withKey("input_layers", "embedding0"),
-     withKey("axis", "3"),
-     withKey("packed", "false"),
-     withKey("epsilon", "1e-7")}));
-     
-  int rel_embed_size = (POSITION_BUCKETS > 0) ? POSITION_BUCKETS * 2 : ((MAX_RELATIVE_POSITIONS < 1) ? MAX_POSITION_EMBEDDINGS * 2 : MAX_RELATIVE_POSITIONS * 2);
-  layers.push_back(createLayer(
-    "weight",
-    {withKey("name", "rel_embeddings"),
-     withKey("input_layers", "embeddings_norm"),
-     withKey("weight_name", "rel_embeddings"),
-     withKey("dim",
-             "1:1:" + std::to_string(rel_embed_size) + ":" + std::to_string(DIM)),
-    withKey("input_shape",
-             "1:1:" + std::to_string(rel_embed_size) + ":" + std::to_string(DIM)),
-     withKey("weight_initializer", "none")}));
+    "weight", {withKey("name", "rel_embeddings"),
+               withKey("input_layers", "embeddings_norm"),
+               withKey("weight_name", "rel_embeddings"),
+               withKey("dim", "1:1:" + std::to_string(rel_embed_size) + ":" +
+                                std::to_string(DIM)),
+               withKey("input_shape", "1:1:" + std::to_string(rel_embed_size) +
+                                        ":" + std::to_string(DIM)),
+               withKey("weight_initializer", "none")}));
 
   layers.push_back(createLayer(
     "layer_normalization",
     {withKey("name", "rel_embeddings_norm"),
-     withKey("input_layers", "rel_embeddings"),
-     withKey("axis", "3"),
-     withKey("packed", "false"),
-     withKey("epsilon", "1e-7")}));
+     withKey("input_layers", "rel_embeddings"), withKey("axis", "3"),
+     withKey("packed", "false"), withKey("epsilon", "1e-7")}));
 
   // create Deberta layers
   std::string last_input = "embeddings_norm";
-  
+
   for (int i = 0; i < NUM_LAYERS; ++i) {
-    std::vector<LayerHandle> encoder_layer = createDebertaLayer(i, last_input, "rel_embeddings_norm");
+    std::vector<LayerHandle> encoder_layer =
+      createDebertaLayer(i, last_input, "rel_embeddings_norm");
     layers.insert(layers.end(), encoder_layer.begin(), encoder_layer.end());
     last_input = "layer" + std::to_string(i) + "_output";
   }
@@ -93,14 +92,15 @@ void DebertaV2::constructModel() {
   }
 }
 
-std::vector<LayerHandle> DebertaV2::createDebertaLayer(const int layer_id,
-                                                       std::string input_name,
-                                                       std::string rel_embeddings_name) {
+std::vector<LayerHandle>
+DebertaV2::createDebertaLayer(const int layer_id, std::string input_name,
+                              std::string rel_embeddings_name) {
   std::vector<LayerHandle> layers;
   std::string prefix = "layer" + std::to_string(layer_id);
 
   // 1. Attention Block
-  std::vector<LayerHandle> attn_layers = createDebertaV2Attention(layer_id, input_name, rel_embeddings_name);
+  std::vector<LayerHandle> attn_layers =
+    createDebertaV2Attention(layer_id, input_name, rel_embeddings_name);
   layers.insert(layers.end(), attn_layers.begin(), attn_layers.end());
 
   layers.push_back(createLayer(
@@ -110,16 +110,16 @@ std::vector<LayerHandle> DebertaV2::createDebertaLayer(const int layer_id,
 
   layers.push_back(createLayer(
     "layer_normalization",
-    {withKey("name", prefix + "_attention_norm"),
-     withKey("epsilon", "1e-7"),
-     withKey("axis", "3"),
-     withKey("packed", "false"),
+    {withKey("name", prefix + "_attention_norm"), withKey("epsilon", "1e-7"),
+     withKey("axis", "3"), withKey("packed", "false"),
      withKey("input_layers", prefix + "_attention_add")}));
 
   // 2. Intermediate Block
   std::vector<std::string> inter_params = {
-    withKey("name", prefix + "_intermediate"), withKey("unit", INTERMEDIATE_SIZE),
-    withKey("input_layers", prefix + "_attention_norm"), withKey("activation", "gelu")};
+    withKey("name", prefix + "_intermediate"),
+    withKey("unit", INTERMEDIATE_SIZE),
+    withKey("input_layers", prefix + "_attention_norm"),
+    withKey("activation", "gelu")};
   layers.push_back(createLayer("fully_connected", inter_params));
 
   std::vector<std::string> output_params = {
@@ -128,24 +128,22 @@ std::vector<LayerHandle> DebertaV2::createDebertaLayer(const int layer_id,
   layers.push_back(createLayer("fully_connected", output_params));
 
   layers.push_back(createLayer(
-    "addition",
-    {withKey("name", prefix + "_output_add"),
-     withKey("input_layers", {prefix + "_attention_norm", prefix + "_output_dense"})}));
+    "addition", {withKey("name", prefix + "_output_add"),
+                 withKey("input_layers", {prefix + "_attention_norm",
+                                          prefix + "_output_dense"})}));
 
   layers.push_back(createLayer(
     "layer_normalization",
-    {withKey("name", prefix + "_output"),
-     withKey("epsilon", "1e-7"),
-     withKey("axis", "3"),
-     withKey("packed", "false"),
+    {withKey("name", prefix + "_output"), withKey("epsilon", "1e-7"),
+     withKey("axis", "3"), withKey("packed", "false"),
      withKey("input_layers", prefix + "_output_add")}));
 
   return layers;
 }
 
-std::vector<LayerHandle> DebertaV2::createDebertaV2Attention(const int layer_id,
-                                                             std::string input_name,
-                                                             std::string rel_embeddings_name) {
+std::vector<LayerHandle>
+DebertaV2::createDebertaV2Attention(const int layer_id, std::string input_name,
+                                    std::string rel_embeddings_name) {
   std::vector<LayerHandle> layers;
   auto Q = "layer" + std::to_string(layer_id) + "_wq";
   auto K = "layer" + std::to_string(layer_id) + "_wk";
@@ -155,25 +153,22 @@ std::vector<LayerHandle> DebertaV2::createDebertaV2Attention(const int layer_id,
 
   // V layer
   std::vector<std::string> v_params = {
-    withKey("name", V), withKey("unit", DIM),
-    withKey("disable_bias", "false"), withKey("input_layers", input_name),
-    withKey("weight_initializer", "ones")};
+    withKey("name", V), withKey("unit", DIM), withKey("disable_bias", "false"),
+    withKey("input_layers", input_name), withKey("weight_initializer", "ones")};
   layers.push_back(createLayer("fully_connected", v_params));
 
   // K layer
   std::vector<std::string> k_params = {
-    withKey("name", K), withKey("unit", DIM),
-    withKey("disable_bias", "false"), withKey("input_layers", input_name),
-    withKey("weight_initializer", "none")};
+    withKey("name", K), withKey("unit", DIM), withKey("disable_bias", "false"),
+    withKey("input_layers", input_name), withKey("weight_initializer", "none")};
   layers.push_back(createLayer("shared_fully_connected", k_params));
 
   // Q layer
   std::vector<std::string> q_params = {
-    withKey("name", Q), withKey("unit", DIM),
-    withKey("disable_bias", "false"), withKey("input_layers", input_name),
-    withKey("weight_initializer", "none")};
+    withKey("name", Q), withKey("unit", DIM), withKey("disable_bias", "false"),
+    withKey("input_layers", input_name), withKey("weight_initializer", "none")};
   layers.push_back(createLayer("shared_fully_connected", q_params));
-  
+
   std::string attn_input_layers = Q + "," + K + "," + V;
 
   // p2c uses Q_rel (projected relative embeddings using Query weights)
@@ -183,13 +178,14 @@ std::vector<LayerHandle> DebertaV2::createDebertaV2Attention(const int layer_id,
     // Add Q as dependency to force Q to be finalized before Q_rel
     std::string q_rel_input_layers = rel_embeddings_name;
     std::vector<std::string> q_rel_params = {
-      withKey("name", Q_rel), withKey("unit", DIM),
+      withKey("name", Q_rel),
+      withKey("unit", DIM),
       withKey("shared_mode", "true"),
       withKey("shared_from", Q),
-      withKey("disable_bias", "false"), withKey("input_layers", {rel_embeddings_name, Q}),
+      withKey("disable_bias", "false"),
+      withKey("input_layers", {rel_embeddings_name, Q}),
       withKey("full_input_range", "true"),
-      withKey("weight_initializer", "none")
-    };
+      withKey("weight_initializer", "none")};
 
     layers.push_back(createLayer("shared_fully_connected", q_rel_params));
     attn_input_layers += "," + Q_rel;
@@ -202,89 +198,93 @@ std::vector<LayerHandle> DebertaV2::createDebertaV2Attention(const int layer_id,
     // Add K as dependency to force K to be finalized before K_rel
     std::string k_rel_input_layers = rel_embeddings_name;
     std::vector<std::string> k_rel_params = {
-      withKey("name", K_rel), withKey("unit", DIM),
+      withKey("name", K_rel),
+      withKey("unit", DIM),
       withKey("shared_mode", "true"),
       withKey("shared_from", K),
-      withKey("disable_bias", "false"), withKey("input_layers", {rel_embeddings_name, K}),
+      withKey("disable_bias", "false"),
+      withKey("input_layers", {rel_embeddings_name, K}),
       withKey("full_input_range", "true"),
-      withKey("weight_initializer", "none")
-    };
+      withKey("weight_initializer", "none")};
     layers.push_back(createLayer("shared_fully_connected", k_rel_params));
     attn_input_layers += "," + K_rel;
   }
- 
+
   std::vector<std::string> attn_params = {
     withKey("name", A),
     withKey("num_heads", NUM_HEADS),
     withKey("max_position_embeddings", MAX_POSITION_EMBEDDINGS),
     withKey("max_relative_positions", MAX_RELATIVE_POSITIONS),
-    withKey("c2p", c2p?"true":"false"),
-    withKey("p2c", p2c?"true":"false"),
-    withKey("share_att_key", SHARE_ATT_KEY?"true":"false"),
+    withKey("c2p", c2p ? "true" : "false"),
+    withKey("p2c", p2c ? "true" : "false"),
+    withKey("share_att_key", SHARE_ATT_KEY ? "true" : "false"),
     withKey("position_buckets", POSITION_BUCKETS),
-    withKey("relative_attention", RELATIVE_ATTENTION?"true":"false"),
+    withKey("relative_attention", RELATIVE_ATTENTION ? "true" : "false"),
     withKey("disable_bias", "false"), // Q/K/V bias control
-    withKey("input_layers", attn_input_layers)
-  };
+    withKey("input_layers", attn_input_layers)};
   layers.push_back(createLayer("deberta_attention", attn_params));
 
   // Output Projection
   std::vector<std::string> out_params = {
-    withKey("name", O), withKey("unit", DIM),
-    withKey("disable_bias", "false"), withKey("input_layers", A), withKey("weight_initializer", "ones")};
+    withKey("name", O), withKey("unit", DIM), withKey("disable_bias", "false"),
+    withKey("input_layers", A), withKey("weight_initializer", "ones")};
   layers.push_back(createLayer("fully_connected", out_params));
-  
+
   return layers;
 }
-
 
 void DebertaV2::setupParameters(json &cfg, json &generation_cfg,
                                 json &nntr_cfg) {
   Transformer::setupParameters(cfg, generation_cfg, nntr_cfg);
-  
+
   try {
     std::string tokenizer_file = nntr_cfg["tokenizer_file"].get<std::string>();
     std::filesystem::path tokenizer_path(tokenizer_file);
     std::string model_path = tokenizer_path.parent_path().string();
-    std::filesystem::path config_path = std::filesystem::path(model_path) / "encoder_config" / "config.json";
-    
+    std::filesystem::path config_path =
+      std::filesystem::path(model_path) / "encoder_config" / "config.json";
+
     if (!std::filesystem::exists(config_path)) {
       config_path = std::filesystem::path(model_path) / "config.json";
     }
 
     json encoder_cfg = causallm::LoadJsonFile(config_path.string());
     if (encoder_cfg.contains("max_relative_positions")) {
-        MAX_RELATIVE_POSITIONS = encoder_cfg["max_relative_positions"].get<int>();
-        if (MAX_RELATIVE_POSITIONS == -1) {
-            MAX_RELATIVE_POSITIONS = MAX_POSITION_EMBEDDINGS;
-        }
+      MAX_RELATIVE_POSITIONS = encoder_cfg["max_relative_positions"].get<int>();
+      if (MAX_RELATIVE_POSITIONS == -1) {
+        MAX_RELATIVE_POSITIONS = MAX_POSITION_EMBEDDINGS;
+      }
     }
 
     if (encoder_cfg.contains("pos_att_type")) {
       std::vector<std::string> pos_att_type_vec;
       if (encoder_cfg["pos_att_type"].is_array()) {
-        pos_att_type_vec = encoder_cfg["pos_att_type"].get<std::vector<std::string>>();
+        pos_att_type_vec =
+          encoder_cfg["pos_att_type"].get<std::vector<std::string>>();
       } else if (encoder_cfg["pos_att_type"].is_string()) {
-        std::string pos_att_str = encoder_cfg["pos_att_type"].get<std::string>();
+        std::string pos_att_str =
+          encoder_cfg["pos_att_type"].get<std::string>();
 
         std::stringstream ss(pos_att_str);
         std::string token;
-        
+
         while (std::getline(ss, token, '|')) {
           token.erase(0, token.find_first_not_of(" \t"));
           token.erase(token.find_last_not_of(" \t") + 1);
-          
+
           if (!token.empty()) {
             pos_att_type_vec.push_back(token);
           }
         }
-    }
-      
-      c2p = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(), "c2p") != pos_att_type_vec.end();
-      p2c = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(), "p2c") != pos_att_type_vec.end();
+      }
+
+      c2p = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(),
+                      "c2p") != pos_att_type_vec.end();
+      p2c = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(),
+                      "p2c") != pos_att_type_vec.end();
     } else {
       c2p = false;
-      p2c = false; 
+      p2c = false;
     }
 
     if (encoder_cfg.contains("share_att_key")) {
@@ -312,15 +312,19 @@ void DebertaV2::setupParameters(json &cfg, json &generation_cfg,
 
 void DebertaV2::registerCustomLayers() {
   Transformer::registerCustomLayers();
-  
+
   const auto &ct_engine = nntrainer::Engine::Global();
-  auto app_context = static_cast<nntrainer::AppContext *>(ct_engine.getRegisteredContext("cpu"));
+  auto app_context =
+    static_cast<nntrainer::AppContext *>(ct_engine.getRegisteredContext("cpu"));
 
   try {
-    app_context->registerFactory(nntrainer::createLayer<causallm::DebertaAttentionLayer>);
-    app_context->registerFactory(nntrainer::createLayer<causallm::SharedFullyConnectedLayer>);
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::DebertaAttentionLayer>);
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::SharedFullyConnectedLayer>);
   } catch (std::invalid_argument &e) {
-    std::cerr << "failed to register factory, reason: " << e.what() << std::endl;
+    std::cerr << "failed to register factory, reason: " << e.what()
+              << std::endl;
   }
 }
 

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
@@ -171,9 +171,9 @@ DebertaV2::createDebertaV2Attention(const int layer_id, std::string input_name,
 
   std::string attn_input_layers = Q + "," + K + "," + V;
 
-  // p2c uses Q_rel (projected relative embeddings using Query weights)
+  // P2C uses Q_rel (projected relative embeddings using Query weights)
   // DebertaAttentionLayer expects p2c input 5th (idx 4)
-  if (p2c) {
+  if (P2C) {
     auto Q_rel = "layer" + std::to_string(layer_id) + "_wq_rel";
     // Add Q as dependency to force Q to be finalized before Q_rel
     std::string q_rel_input_layers = rel_embeddings_name;
@@ -191,9 +191,9 @@ DebertaV2::createDebertaV2Attention(const int layer_id, std::string input_name,
     attn_input_layers += "," + Q_rel;
   }
 
-  // c2p uses K_rel (projected relative embeddings using Key weights)
-  // DebertaAttentionLayer expects c2p input 4th (idx 3)
-  if (c2p) {
+  // C2P uses K_rel (projected relative embeddings using Key weights)
+  // DebertaAttentionLayer expects C2P input 4th (idx 3)
+  if (C2P) {
     auto K_rel = "layer" + std::to_string(layer_id) + "_wk_rel";
     // Add K as dependency to force K to be finalized before K_rel
     std::string k_rel_input_layers = rel_embeddings_name;
@@ -215,8 +215,8 @@ DebertaV2::createDebertaV2Attention(const int layer_id, std::string input_name,
     withKey("num_heads", NUM_HEADS),
     withKey("max_position_embeddings", MAX_POSITION_EMBEDDINGS),
     withKey("max_relative_positions", MAX_RELATIVE_POSITIONS),
-    withKey("c2p", c2p ? "true" : "false"),
-    withKey("p2c", p2c ? "true" : "false"),
+    withKey("c2p", C2P ? "true" : "false"),
+    withKey("p2c", P2C ? "true" : "false"),
     withKey("share_att_key", SHARE_ATT_KEY ? "true" : "false"),
     withKey("position_buckets", POSITION_BUCKETS),
     withKey("relative_attention", RELATIVE_ATTENTION ? "true" : "false"),

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
@@ -2,31 +2,31 @@
 /**
  * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
  *
- * @file   deberta_v2.cpp
+ * @file   debertav2.cpp
  * @date   14 January 2026
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seunghui Lee <shsh1004.lee@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  Please refer to the following code :
- *  https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+ * @note  Please refer to the following code :
+ * https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta/modeling_deberta.py
  */
 
 #include "json.hpp"
 
-#include <app_context.h>
-#include <deberta_attention_layer.h>
-#include <deberta_v2.h>
-#include <engine.h>
 #include <filesystem>
 #include <fstream>
-#include <layer_context.h>
-#include <layer_node.h>
-#include <llm_util.hpp>
+#include <deberta_v2.h>
+#include <deberta_attention_layer.h>
 #include <shared_fully_connected_layer.h>
+#include <llm_util.hpp>
+#include <layer_context.h>
+#include <app_context.h>
 #include <weight_layer.h>
+#include <engine.h>
+#include <layer_node.h>
 
-#include <filesystem>
 #include <sstream>
+#include <filesystem>
 
 using json = nlohmann::json;
 
@@ -43,44 +43,47 @@ void DebertaV2::constructModel() {
               withKey("input_shape", "1:1:" + std::to_string(INIT_SEQ_LEN))}));
 
   // create embedding layer
-  layers.push_back(createLayer("embedding_layer",
-                               {"name=embedding0", "input_layers=input0",
-                                "in_dim=" + std::to_string(NUM_VOCAB),
-                                "weight_dtype=" + EMBEDDING_DTYPE,
-                                "out_dim=" + std::to_string(DIM),
-                                "scale=" + std::to_string(EMBEDDING_SCALE)}));
+  layers.push_back(createLayer(
+    "embedding_layer",
+    {"name=embedding0",
+     "input_layers=input0",
+     "in_dim=" + std::to_string(NUM_VOCAB),
+     "weight_dtype=" + EMBEDDING_DTYPE, "out_dim=" + std::to_string(DIM),
+     "scale=" + std::to_string(EMBEDDING_SCALE)}));
+     
+  layers.push_back(createLayer(
+    "layer_normalization",
+    {withKey("name", "embeddings_norm"),
+     withKey("input_layers", "embedding0"),
+     withKey("axis", "3"),
+     withKey("packed", "false"),
+     withKey("epsilon", "1e-7")}));
+     
+  int rel_embed_size = (POSITION_BUCKETS > 0) ? POSITION_BUCKETS * 2 : ((MAX_RELATIVE_POSITIONS < 1) ? MAX_POSITION_EMBEDDINGS * 2 : MAX_RELATIVE_POSITIONS * 2);
+  layers.push_back(createLayer(
+    "weight",
+    {withKey("name", "rel_embeddings"),
+     withKey("input_layers", "embeddings_norm"),
+     withKey("weight_name", "rel_embeddings"),
+     withKey("dim",
+             "1:1:" + std::to_string(rel_embed_size) + ":" + std::to_string(DIM)),
+    withKey("input_shape",
+             "1:1:" + std::to_string(rel_embed_size) + ":" + std::to_string(DIM)),
+     withKey("weight_initializer", "none")}));
 
   layers.push_back(createLayer(
     "layer_normalization",
-    {withKey("name", "embeddings_norm"), withKey("input_layers", "embedding0"),
-     withKey("axis", "3"), withKey("epsilon", "1e-7")}));
-
-  int rel_embed_size =
-    (POSITION_BUCKETS > 0)
-      ? POSITION_BUCKETS * 2
-      : ((MAX_RELATIVE_POSITIONS < 1) ? MAX_POSITION_EMBEDDINGS * 2
-                                      : MAX_RELATIVE_POSITIONS * 2);
-  layers.push_back(createLayer(
-    "weight", {withKey("name", "rel_embeddings"),
-               withKey("input_layers", "embeddings_norm"),
-               withKey("weight_name", "rel_embeddings"),
-               withKey("dim", "1:1:" + std::to_string(rel_embed_size) + ":" +
-                                std::to_string(DIM)),
-               withKey("input_shape", "1:1:" + std::to_string(rel_embed_size) +
-                                        ":" + std::to_string(DIM)),
-               withKey("weight_initializer", "none")}));
-
-  layers.push_back(createLayer(
-    "layer_normalization", {withKey("name", "rel_embeddings_norm"),
-                            withKey("input_layers", "rel_embeddings"),
-                            withKey("axis", "3"), withKey("epsilon", "1e-7")}));
+    {withKey("name", "rel_embeddings_norm"),
+     withKey("input_layers", "rel_embeddings"),
+     withKey("axis", "3"),
+     withKey("packed", "false"),
+     withKey("epsilon", "1e-7")}));
 
   // create Deberta layers
   std::string last_input = "embeddings_norm";
-
+  
   for (int i = 0; i < NUM_LAYERS; ++i) {
-    std::vector<LayerHandle> encoder_layer =
-      createDebertaLayer(i, last_input, "rel_embeddings_norm");
+    std::vector<LayerHandle> encoder_layer = createDebertaLayer(i, last_input, "rel_embeddings_norm");
     layers.insert(layers.end(), encoder_layer.begin(), encoder_layer.end());
     last_input = "layer" + std::to_string(i) + "_output";
   }
@@ -90,15 +93,14 @@ void DebertaV2::constructModel() {
   }
 }
 
-std::vector<LayerHandle>
-DebertaV2::createDebertaLayer(const int layer_id, std::string input_name,
-                              std::string rel_embeddings_name) {
+std::vector<LayerHandle> DebertaV2::createDebertaLayer(const int layer_id,
+                                                       std::string input_name,
+                                                       std::string rel_embeddings_name) {
   std::vector<LayerHandle> layers;
   std::string prefix = "layer" + std::to_string(layer_id);
 
   // 1. Attention Block
-  std::vector<LayerHandle> attn_layers =
-    createDebertaV2Attention(layer_id, input_name, rel_embeddings_name);
+  std::vector<LayerHandle> attn_layers = createDebertaV2Attention(layer_id, input_name, rel_embeddings_name);
   layers.insert(layers.end(), attn_layers.begin(), attn_layers.end());
 
   layers.push_back(createLayer(
@@ -106,18 +108,18 @@ DebertaV2::createDebertaLayer(const int layer_id, std::string input_name,
     {withKey("name", prefix + "_attention_add"),
      withKey("input_layers", {input_name, prefix + "_attention_out"})}));
 
-  layers.push_back(
-    createLayer("layer_normalization",
-                {withKey("name", prefix + "_attention_norm"),
-                 withKey("epsilon", "1e-7"), withKey("axis", "3"),
-                 withKey("input_layers", prefix + "_attention_add")}));
+  layers.push_back(createLayer(
+    "layer_normalization",
+    {withKey("name", prefix + "_attention_norm"),
+     withKey("epsilon", "1e-7"),
+     withKey("axis", "3"),
+     withKey("packed", "false"),
+     withKey("input_layers", prefix + "_attention_add")}));
 
   // 2. Intermediate Block
   std::vector<std::string> inter_params = {
-    withKey("name", prefix + "_intermediate"),
-    withKey("unit", INTERMEDIATE_SIZE),
-    withKey("input_layers", prefix + "_attention_norm"),
-    withKey("activation", "gelu")};
+    withKey("name", prefix + "_intermediate"), withKey("unit", INTERMEDIATE_SIZE),
+    withKey("input_layers", prefix + "_attention_norm"), withKey("activation", "gelu")};
   layers.push_back(createLayer("fully_connected", inter_params));
 
   std::vector<std::string> output_params = {
@@ -126,21 +128,24 @@ DebertaV2::createDebertaLayer(const int layer_id, std::string input_name,
   layers.push_back(createLayer("fully_connected", output_params));
 
   layers.push_back(createLayer(
-    "addition", {withKey("name", prefix + "_output_add"),
-                 withKey("input_layers", {prefix + "_attention_norm",
-                                          prefix + "_output_dense"})}));
+    "addition",
+    {withKey("name", prefix + "_output_add"),
+     withKey("input_layers", {prefix + "_attention_norm", prefix + "_output_dense"})}));
 
   layers.push_back(createLayer(
     "layer_normalization",
-    {withKey("name", prefix + "_output"), withKey("epsilon", "1e-7"),
-     withKey("axis", "3"), withKey("input_layers", prefix + "_output_add")}));
+    {withKey("name", prefix + "_output"),
+     withKey("epsilon", "1e-7"),
+     withKey("axis", "3"),
+     withKey("packed", "false"),
+     withKey("input_layers", prefix + "_output_add")}));
 
   return layers;
 }
 
-std::vector<LayerHandle>
-DebertaV2::createDebertaV2Attention(const int layer_id, std::string input_name,
-                                    std::string rel_embeddings_name) {
+std::vector<LayerHandle> DebertaV2::createDebertaV2Attention(const int layer_id,
+                                                             std::string input_name,
+                                                             std::string rel_embeddings_name) {
   std::vector<LayerHandle> layers;
   auto Q = "layer" + std::to_string(layer_id) + "_wq";
   auto K = "layer" + std::to_string(layer_id) + "_wk";
@@ -150,22 +155,25 @@ DebertaV2::createDebertaV2Attention(const int layer_id, std::string input_name,
 
   // V layer
   std::vector<std::string> v_params = {
-    withKey("name", V), withKey("unit", DIM), withKey("disable_bias", "false"),
-    withKey("input_layers", input_name), withKey("weight_initializer", "ones")};
+    withKey("name", V), withKey("unit", DIM),
+    withKey("disable_bias", "false"), withKey("input_layers", input_name),
+    withKey("weight_initializer", "ones")};
   layers.push_back(createLayer("fully_connected", v_params));
 
   // K layer
   std::vector<std::string> k_params = {
-    withKey("name", K), withKey("unit", DIM), withKey("disable_bias", "false"),
-    withKey("input_layers", input_name), withKey("weight_initializer", "none")};
+    withKey("name", K), withKey("unit", DIM),
+    withKey("disable_bias", "false"), withKey("input_layers", input_name),
+    withKey("weight_initializer", "none")};
   layers.push_back(createLayer("shared_fully_connected", k_params));
 
   // Q layer
   std::vector<std::string> q_params = {
-    withKey("name", Q), withKey("unit", DIM), withKey("disable_bias", "false"),
-    withKey("input_layers", input_name), withKey("weight_initializer", "none")};
+    withKey("name", Q), withKey("unit", DIM),
+    withKey("disable_bias", "false"), withKey("input_layers", input_name),
+    withKey("weight_initializer", "none")};
   layers.push_back(createLayer("shared_fully_connected", q_params));
-
+  
   std::string attn_input_layers = Q + "," + K + "," + V;
 
   // p2c uses Q_rel (projected relative embeddings using Query weights)
@@ -175,14 +183,13 @@ DebertaV2::createDebertaV2Attention(const int layer_id, std::string input_name,
     // Add Q as dependency to force Q to be finalized before Q_rel
     std::string q_rel_input_layers = rel_embeddings_name;
     std::vector<std::string> q_rel_params = {
-      withKey("name", Q_rel),
-      withKey("unit", DIM),
+      withKey("name", Q_rel), withKey("unit", DIM),
       withKey("shared_mode", "true"),
       withKey("shared_from", Q),
-      withKey("disable_bias", "false"),
-      withKey("input_layers", {rel_embeddings_name, Q}),
+      withKey("disable_bias", "false"), withKey("input_layers", {rel_embeddings_name, Q}),
       withKey("full_input_range", "true"),
-      withKey("weight_initializer", "none")};
+      withKey("weight_initializer", "none")
+    };
 
     layers.push_back(createLayer("shared_fully_connected", q_rel_params));
     attn_input_layers += "," + Q_rel;
@@ -195,93 +202,89 @@ DebertaV2::createDebertaV2Attention(const int layer_id, std::string input_name,
     // Add K as dependency to force K to be finalized before K_rel
     std::string k_rel_input_layers = rel_embeddings_name;
     std::vector<std::string> k_rel_params = {
-      withKey("name", K_rel),
-      withKey("unit", DIM),
+      withKey("name", K_rel), withKey("unit", DIM),
       withKey("shared_mode", "true"),
       withKey("shared_from", K),
-      withKey("disable_bias", "false"),
-      withKey("input_layers", {rel_embeddings_name, K}),
+      withKey("disable_bias", "false"), withKey("input_layers", {rel_embeddings_name, K}),
       withKey("full_input_range", "true"),
-      withKey("weight_initializer", "none")};
+      withKey("weight_initializer", "none")
+    };
     layers.push_back(createLayer("shared_fully_connected", k_rel_params));
     attn_input_layers += "," + K_rel;
   }
-
+ 
   std::vector<std::string> attn_params = {
     withKey("name", A),
     withKey("num_heads", NUM_HEADS),
     withKey("max_position_embeddings", MAX_POSITION_EMBEDDINGS),
     withKey("max_relative_positions", MAX_RELATIVE_POSITIONS),
-    withKey("c2p", c2p ? "true" : "false"),
-    withKey("p2c", p2c ? "true" : "false"),
-    withKey("share_att_key", SHARE_ATT_KEY ? "true" : "false"),
+    withKey("c2p", c2p?"true":"false"),
+    withKey("p2c", p2c?"true":"false"),
+    withKey("share_att_key", SHARE_ATT_KEY?"true":"false"),
     withKey("position_buckets", POSITION_BUCKETS),
-    withKey("relative_attention", RELATIVE_ATTENTION ? "true" : "false"),
+    withKey("relative_attention", RELATIVE_ATTENTION?"true":"false"),
     withKey("disable_bias", "false"), // Q/K/V bias control
-    withKey("input_layers", attn_input_layers)};
+    withKey("input_layers", attn_input_layers)
+  };
   layers.push_back(createLayer("deberta_attention", attn_params));
 
   // Output Projection
   std::vector<std::string> out_params = {
-    withKey("name", O), withKey("unit", DIM), withKey("disable_bias", "false"),
-    withKey("input_layers", A), withKey("weight_initializer", "ones")};
+    withKey("name", O), withKey("unit", DIM),
+    withKey("disable_bias", "false"), withKey("input_layers", A), withKey("weight_initializer", "ones")};
   layers.push_back(createLayer("fully_connected", out_params));
-
+  
   return layers;
 }
+
 
 void DebertaV2::setupParameters(json &cfg, json &generation_cfg,
                                 json &nntr_cfg) {
   Transformer::setupParameters(cfg, generation_cfg, nntr_cfg);
-
+  
   try {
     std::string tokenizer_file = nntr_cfg["tokenizer_file"].get<std::string>();
     std::filesystem::path tokenizer_path(tokenizer_file);
     std::string model_path = tokenizer_path.parent_path().string();
-    std::filesystem::path config_path =
-      std::filesystem::path(model_path) / "encoder_config" / "config.json";
-
+    std::filesystem::path config_path = std::filesystem::path(model_path) / "encoder_config" / "config.json";
+    
     if (!std::filesystem::exists(config_path)) {
       config_path = std::filesystem::path(model_path) / "config.json";
     }
 
     json encoder_cfg = causallm::LoadJsonFile(config_path.string());
     if (encoder_cfg.contains("max_relative_positions")) {
-      MAX_RELATIVE_POSITIONS = encoder_cfg["max_relative_positions"].get<int>();
-      if (MAX_RELATIVE_POSITIONS == -1) {
-        MAX_RELATIVE_POSITIONS = MAX_POSITION_EMBEDDINGS;
-      }
+        MAX_RELATIVE_POSITIONS = encoder_cfg["max_relative_positions"].get<int>();
+        if (MAX_RELATIVE_POSITIONS == -1) {
+            MAX_RELATIVE_POSITIONS = MAX_POSITION_EMBEDDINGS;
+        }
     }
 
     if (encoder_cfg.contains("pos_att_type")) {
       std::vector<std::string> pos_att_type_vec;
       if (encoder_cfg["pos_att_type"].is_array()) {
-        pos_att_type_vec =
-          encoder_cfg["pos_att_type"].get<std::vector<std::string>>();
+        pos_att_type_vec = encoder_cfg["pos_att_type"].get<std::vector<std::string>>();
       } else if (encoder_cfg["pos_att_type"].is_string()) {
-        std::string pos_att_str =
-          encoder_cfg["pos_att_type"].get<std::string>();
+        std::string pos_att_str = encoder_cfg["pos_att_type"].get<std::string>();
 
         std::stringstream ss(pos_att_str);
         std::string token;
-
+        
         while (std::getline(ss, token, '|')) {
           token.erase(0, token.find_first_not_of(" \t"));
           token.erase(token.find_last_not_of(" \t") + 1);
-
+          
           if (!token.empty()) {
             pos_att_type_vec.push_back(token);
           }
         }
-      }
-
-      c2p = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(),
-                      "c2p") != pos_att_type_vec.end();
-      p2c = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(),
-                      "p2c") != pos_att_type_vec.end();
+    }
+      
+      c2p = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(), "c2p") != pos_att_type_vec.end();
+      p2c = std::find(pos_att_type_vec.begin(), pos_att_type_vec.end(), "p2c") != pos_att_type_vec.end();
     } else {
       c2p = false;
-      p2c = false;
+      p2c = false; 
     }
 
     if (encoder_cfg.contains("share_att_key")) {
@@ -309,82 +312,16 @@ void DebertaV2::setupParameters(json &cfg, json &generation_cfg,
 
 void DebertaV2::registerCustomLayers() {
   Transformer::registerCustomLayers();
-
+  
   const auto &ct_engine = nntrainer::Engine::Global();
-  auto app_context =
-    static_cast<nntrainer::AppContext *>(ct_engine.getRegisteredContext("cpu"));
+  auto app_context = static_cast<nntrainer::AppContext *>(ct_engine.getRegisteredContext("cpu"));
 
   try {
-    app_context->registerFactory(
-      nntrainer::createLayer<causallm::DebertaAttentionLayer>);
-    app_context->registerFactory(
-      nntrainer::createLayer<causallm::SharedFullyConnectedLayer>);
+    app_context->registerFactory(nntrainer::createLayer<causallm::DebertaAttentionLayer>);
+    app_context->registerFactory(nntrainer::createLayer<causallm::SharedFullyConnectedLayer>);
   } catch (std::invalid_argument &e) {
-    std::cerr << "failed to register factory, reason: " << e.what()
-              << std::endl;
+    std::cerr << "failed to register factory, reason: " << e.what() << std::endl;
   }
-}
-
-std::vector<float *> DebertaV2::encode(const WSTR prompt,
-                                       const WSTR system_prompt,
-                                       const WSTR tail_prompt) {
-  if (!is_initialized) {
-    throw std::runtime_error("Embedding model is not initialized. Please call "
-                             "initialize() before encode().");
-  }
-
-#if defined(_WIN32)
-  std::wstring prompt_ = system_prompt + prompt + tail_prompt;
-  std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
-  auto _input = tokenizer->Encode(converter.to_bytes(prompt_), true);
-#else
-  std::string prompt_ = system_prompt + prompt + tail_prompt;
-  auto _input = tokenizer->Encode(prompt_, true);
-#endif
-
-  const int cls_id = tokenizer->TokenToId("[CLS]");
-  if (!_input.empty() && _input.front() == cls_id) {
-    _input.erase(_input.begin());
-  }
-
-  const int eos_id = tokenizer->TokenToId("[SEP]");
-  if (!_input.empty() && _input.back() == eos_id) {
-    _input.pop_back();
-  }
-
-  std::vector<int64_t> init_input;
-  unsigned int input_len =
-    std::min((unsigned int)_input.size(), (unsigned int)MAX_SEQ_LEN);
-
-  // feed only available length
-  for (unsigned int i = 0; i < input_len; ++i)
-    init_input.push_back(_input[i]);
-
-  float *input_sample =
-    (float *)malloc(sizeof(float) * BATCH_SIZE * MAX_SEQ_LEN);
-
-  for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
-    for (unsigned int i = 0; i < input_len; ++i) {
-      input_sample[static_cast<size_t>(b) * MAX_SEQ_LEN + i] =
-        static_cast<float>(init_input[i]);
-    }
-  }
-
-  std::vector<float *> input;
-  input.push_back(input_sample);
-
-  std::vector<float *> label; // Empty label for inference
-
-  // Run incremental inference for the prefill stage
-  // start: 0, end: input_len (process all tokens at once)
-  // This performs a single forward pass for the entire prompt sequence to get
-  // embeddings.
-  std::vector<float *> output = model->incremental_inference(
-    BATCH_SIZE, input, label, input_len, 0, input_len, false);
-
-  free(input_sample);
-
-  return output;
 }
 
 } // namespace causallm

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.h
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.h
@@ -45,9 +45,9 @@ protected:
                                               std::string input_name,
                                               std::string rel_embeddings_name);
 
-  std::vector<LayerHandle> createDebertaV2Attention(const int layer_id,
-                                                    std::string input_name,
-                                                    std::string rel_embeddings_name);
+  std::vector<LayerHandle>
+  createDebertaV2Attention(const int layer_id, std::string input_name,
+                           std::string rel_embeddings_name);
 
   /**
    * @brief Setup the parameters for the Deberta V2 model

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.h
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.h
@@ -2,70 +2,97 @@
 /**
  * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
  *
- * @file   debertav2.h
+ * @file   deberta_v2.h
  * @date   14 January 2026
+ * @brief  DeBERTa V2 encoder model for SentenceTransformer embeddings
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seunghui Lee <shsh1004.lee@samsung.com>
  * @bug    No known bugs except for NYI items
- * @note  Please refer to the following code :
- * https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta/modeling_deberta.py
+ * @note   Please refer to the following code :
+ * https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
  */
 
 #ifndef __DEBERTA_V2_H__
 #define __DEBERTA_V2_H__
 
 #include <sentence_transformer.h>
-#include <transformer.h>
 
 namespace causallm {
 
 /**
- * @brief DebertaV2 class
+ * @brief DebertaV2 embedding model
  */
 class DebertaV2 : public SentenceTransformer {
 
 public:
   static constexpr const char *architectures = "DebertaV2";
 
+  /**
+   * @brief Construct a new DebertaV2 object
+   * @param cfg Configuration for the model (config.json)
+   * @param generation_cfg Configuration for the generation
+   * @param nntr_cfg Configuration for nntrainer
+   */
   DebertaV2(json &cfg, json &generation_cfg, json &nntr_cfg) :
-    Transformer(cfg, generation_cfg, nntr_cfg, ModelType::EMBEDDING),
+    Transformer(sanitizeConfig(cfg), generation_cfg, nntr_cfg,
+                ModelType::EMBEDDING),
     SentenceTransformer(cfg, generation_cfg, nntr_cfg) {
     setupParameters(cfg, generation_cfg, nntr_cfg);
   }
 
+  /**
+   * @brief Destroy the DebertaV2 object
+   */
   virtual ~DebertaV2() = default;
+
+  /**
+   * @brief Encode the prompt and return the embedding output
+   */
+  std::vector<float *> encode(const WSTR prompt, const WSTR system_prompt = "",
+                              const WSTR tail_prompt = "") override;
 
 protected:
   /**
-   * @brief Construct Model
+   * @brief Fill defaults absent from typical DeBERTa V2 config.json files.
    */
-  void constructModel() override;
-
-  std::vector<LayerHandle> createDebertaLayer(const int layer_id,
-                                              std::string input_name,
-                                              std::string rel_embeddings_name);
-
-  std::vector<LayerHandle>
-  createDebertaV2Attention(const int layer_id, std::string input_name,
-                           std::string rel_embeddings_name);
+  static json &sanitizeConfig(json &cfg);
 
   /**
-   * @brief Setup the parameters for the Deberta V2 model
+   * @brief Setup the parameters for the DeBERTa V2 model
    */
   void setupParameters(json &cfg, json &generation_cfg,
                        json &nntr_cfg) override;
+
+  /**
+   * @brief Construct DeBERTa V2 before SentenceTransformer pooling modules.
+   */
+  std::pair<Tensor, Tensor> constructTransformerModule() override;
+
+  /**
+   * @brief Create one DeBERTa V2 encoder layer
+   */
+  Tensor createDebertaLayer(const int layer_id, Tensor input,
+                            Tensor rel_embeddings);
+
+  /**
+   * @brief Create DeBERTa V2 disentangled self-attention
+   */
+  Tensor createDebertaV2Attention(const int layer_id, Tensor input,
+                                  Tensor rel_embeddings);
 
   /**
    * @brief register CustomLayers
    */
   void registerCustomLayers() override;
 
-  int MAX_RELATIVE_POSITIONS;
-  bool C2P;
-  bool P2C;
-  bool SHARE_ATT_KEY;
-  bool RELATIVE_ATTENTION;
-  int POSITION_BUCKETS;
+private:
+  int MAX_RELATIVE_POSITIONS = 0;
+  bool C2P = false;
+  bool P2C = false;
+  bool SHARE_ATT_KEY = true;
+  bool RELATIVE_ATTENTION = true;
+  bool NORM_REL_EBD = false;
+  int POSITION_BUCKETS = -1;
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.h
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.h
@@ -2,19 +2,19 @@
 /**
  * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
  *
- * @file   deberta_v2.h
+ * @file   debertav2.h
  * @date   14 January 2026
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seunghui Lee <shsh1004.lee@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  Please refer to the following code :
- *  https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+ * @note  Please refer to the following code :
+ * https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta/modeling_deberta.py
  */
 
 #ifndef __DEBERTA_V2_H__
 #define __DEBERTA_V2_H__
 
-#include "../embedding.h"
+#include <sentence_transformer.h>
 #include <transformer.h>
 
 namespace causallm {
@@ -22,14 +22,14 @@ namespace causallm {
 /**
  * @brief DebertaV2 class
  */
-class DebertaV2 : public Embedding {
+class DebertaV2 : public SentenceTransformer {
 
 public:
   static constexpr const char *architectures = "DebertaV2";
 
   DebertaV2(json &cfg, json &generation_cfg, json &nntr_cfg) :
     Transformer(cfg, generation_cfg, nntr_cfg, ModelType::EMBEDDING),
-    Embedding(cfg, generation_cfg, nntr_cfg) {
+    SentenceTransformer(cfg, generation_cfg, nntr_cfg) {
     setupParameters(cfg, generation_cfg, nntr_cfg);
   }
 
@@ -45,9 +45,9 @@ protected:
                                               std::string input_name,
                                               std::string rel_embeddings_name);
 
-  std::vector<LayerHandle>
-  createDebertaV2Attention(const int layer_id, std::string input_name,
-                           std::string rel_embeddings_name);
+  std::vector<LayerHandle> createDebertaV2Attention(const int layer_id,
+                                                    std::string input_name,
+                                                    std::string rel_embeddings_name);
 
   /**
    * @brief Setup the parameters for the Deberta V2 model
@@ -59,12 +59,6 @@ protected:
    * @brief register CustomLayers
    */
   void registerCustomLayers() override;
-
-  /**
-   * @brief Encode the prompt and return the embedding
-   */
-  std::vector<float *> encode(const WSTR prompt, const WSTR system_prompt,
-                              const WSTR tail_prompt) override;
 
   int MAX_RELATIVE_POSITIONS;
   bool c2p;

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.h
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.h
@@ -61,8 +61,8 @@ protected:
   void registerCustomLayers() override;
 
   int MAX_RELATIVE_POSITIONS;
-  bool c2p;
-  bool p2c;
+  bool C2P;
+  bool P2C;
   bool SHARE_ATT_KEY;
   bool RELATIVE_ATTENTION;
   int POSITION_BUCKETS;

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.h
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.h
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   deberta_v2.h
+ * @date   14 January 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Seunghui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Please refer to the following code :
+ *  https://github.com/huggingface/transformers/blob/5c1c72b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+ */
+
+#ifndef __DEBERTA_V2_H__
+#define __DEBERTA_V2_H__
+
+#include "../embedding.h"
+#include <transformer.h>
+
+namespace causallm {
+
+/**
+ * @brief DebertaV2 class
+ */
+class DebertaV2 : public Embedding {
+
+public:
+  static constexpr const char *architectures = "DebertaV2";
+
+  DebertaV2(json &cfg, json &generation_cfg, json &nntr_cfg) :
+    Transformer(cfg, generation_cfg, nntr_cfg, ModelType::EMBEDDING),
+    Embedding(cfg, generation_cfg, nntr_cfg) {
+    setupParameters(cfg, generation_cfg, nntr_cfg);
+  }
+
+  virtual ~DebertaV2() = default;
+
+protected:
+  /**
+   * @brief Construct Model
+   */
+  void constructModel() override;
+
+  std::vector<LayerHandle> createDebertaLayer(const int layer_id,
+                                              std::string input_name,
+                                              std::string rel_embeddings_name);
+
+  std::vector<LayerHandle>
+  createDebertaV2Attention(const int layer_id, std::string input_name,
+                           std::string rel_embeddings_name);
+
+  /**
+   * @brief Setup the parameters for the Deberta V2 model
+   */
+  void setupParameters(json &cfg, json &generation_cfg,
+                       json &nntr_cfg) override;
+
+  /**
+   * @brief register CustomLayers
+   */
+  void registerCustomLayers() override;
+
+  /**
+   * @brief Encode the prompt and return the embedding
+   */
+  std::vector<float *> encode(const WSTR prompt, const WSTR system_prompt,
+                              const WSTR tail_prompt) override;
+
+  int MAX_RELATIVE_POSITIONS;
+  bool c2p;
+  bool p2c;
+  bool SHARE_ATT_KEY;
+  bool RELATIVE_ATTENTION;
+  int POSITION_BUCKETS;
+};
+
+} // namespace causallm
+
+#endif /* __DEBERTA_V2_H__ */

--- a/Applications/CausalLM/models/deberta_v2/meson.build
+++ b/Applications/CausalLM/models/deberta_v2/meson.build
@@ -1,0 +1,8 @@
+deberta_v2_src = [
+    meson.current_source_dir() / 'deberta_v2.cpp',
+]
+
+deberta_v2_inc = include_directories('.')
+
+causallm_src += deberta_v2_src
+causallm_inc += deberta_v2_inc

--- a/Applications/CausalLM/models/meson.build
+++ b/Applications/CausalLM/models/meson.build
@@ -6,6 +6,7 @@ causallm_src += [
 
 causallm_inc += include_directories('.')
 
+subdir('deberta_v2')
 subdir('gpt_oss')
 subdir('qwen2')
 subdir('qwen3')

--- a/Applications/CausalLM/models/sentence_transformer.cpp
+++ b/Applications/CausalLM/models/sentence_transformer.cpp
@@ -113,7 +113,7 @@ std::pair<Tensor, Tensor> SentenceTransformer::constructModel() {
     std::string component = getLastComponent(type);
 
     if (component == "Transformer") {
-      auto result = Transformer::constructModel();
+      auto result = constructTransformerModule();
       x = result.first;
       h = result.second;
     } else {
@@ -135,6 +135,10 @@ std::pair<Tensor, Tensor> SentenceTransformer::constructModel() {
   }
 
   return {x, h};
+}
+
+std::pair<Tensor, Tensor> SentenceTransformer::constructTransformerModule() {
+  return Transformer::constructModel();
 }
 
 Tensor SentenceTransformer::addModule(const std::string &type, int idx,

--- a/Applications/CausalLM/models/sentence_transformer.h
+++ b/Applications/CausalLM/models/sentence_transformer.h
@@ -72,6 +72,13 @@ protected:
   std::pair<Tensor, Tensor> constructModel() override;
 
   /**
+   * @brief Construct the base transformer module before SentenceTransformer
+   * modules are appended.
+   * @return {input_tensor, output_tensor} pair for the base encoder/decoder.
+   */
+  virtual std::pair<Tensor, Tensor> constructTransformerModule();
+
+  /**
    * @brief Map of module type suffix to layer type name
    * @note This map is used to dynamically resolve the nntrainer layer type from
    * the module configuration type suffix.

--- a/Applications/CausalLM/models/sentence_transformer.h
+++ b/Applications/CausalLM/models/sentence_transformer.h
@@ -55,8 +55,9 @@ public:
    * @param tail_prompt Tail prompt
    * @return SentenceTransformer output from the model
    */
-  std::vector<float *> encode(const WSTR prompt, const WSTR system_prompt = "",
-                              const WSTR tail_prompt = "");
+  virtual std::vector<float *> encode(const WSTR prompt,
+                                      const WSTR system_prompt = "",
+                                      const WSTR tail_prompt = "");
 
 protected:
   /**

--- a/Applications/CausalLM/res/deberta_v2/weight_converter.py
+++ b/Applications/CausalLM/res/deberta_v2/weight_converter.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+# @file weight_converter.py
+# @brief Weight conversion script for DeBERTa V2 sentence embedding models.
+# @author Samsung Electronics Co., Ltd.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+from transformers import DebertaV2Model
+
+
+def _to_numpy(weight, dtype):
+    return weight.detach().cpu().numpy().astype(dtype, copy=False)
+
+
+def _save_weight(file, weight, dtype):
+    _to_numpy(weight, dtype).tofile(file)
+
+
+def _save_linear(file, params, prefix, dtype):
+    _save_weight(file, params[f"{prefix}.weight"].transpose(0, 1), dtype)
+    _save_weight(file, params[f"{prefix}.bias"], dtype)
+
+
+def save_deberta_v2_for_nntrainer(params, config, dtype, file):
+    """Save DeBERTa V2 encoder weights in nntrainer layer order."""
+    _save_weight(file, params["embeddings.word_embeddings.weight"], dtype)
+    _save_weight(file, params["embeddings.LayerNorm.weight"], dtype)
+    _save_weight(file, params["embeddings.LayerNorm.bias"], dtype)
+
+    norm_rel_ebd = getattr(config, "norm_rel_ebd", "none").lower().split("|")
+    norm_rel_ebd = [item.strip() for item in norm_rel_ebd]
+    pos_att_type = getattr(config, "pos_att_type", None) or []
+    uses_relative_bias = getattr(config, "relative_attention", False) and (
+        "c2p" in pos_att_type or "p2c" in pos_att_type
+    )
+    saved_relative_embeddings = False
+
+    for layer_idx in range(config.num_hidden_layers):
+        layer_prefix = f"encoder.layer.{layer_idx}"
+        attn_prefix = f"{layer_prefix}.attention"
+        self_prefix = f"{attn_prefix}.self"
+
+        _save_linear(file, params, f"{self_prefix}.query_proj", dtype)
+        _save_linear(file, params, f"{self_prefix}.key_proj", dtype)
+        _save_linear(file, params, f"{self_prefix}.value_proj", dtype)
+        if uses_relative_bias and not saved_relative_embeddings:
+            _save_weight(file, params["encoder.rel_embeddings.weight"], dtype)
+            if "layer_norm" in norm_rel_ebd:
+                _save_weight(file, params["encoder.LayerNorm.weight"], dtype)
+                _save_weight(file, params["encoder.LayerNorm.bias"], dtype)
+            saved_relative_embeddings = True
+
+        _save_linear(file, params, f"{attn_prefix}.output.dense", dtype)
+        _save_weight(file, params[f"{attn_prefix}.output.LayerNorm.weight"], dtype)
+        _save_weight(file, params[f"{attn_prefix}.output.LayerNorm.bias"], dtype)
+        _save_linear(file, params, f"{layer_prefix}.intermediate.dense", dtype)
+        _save_linear(file, params, f"{layer_prefix}.output.dense", dtype)
+        _save_weight(file, params[f"{layer_prefix}.output.LayerNorm.weight"], dtype)
+        _save_weight(file, params[f"{layer_prefix}.output.LayerNorm.bias"], dtype)
+
+
+def _encoder_state_dict(model):
+    if hasattr(model, "deberta"):
+        return model.deberta.state_dict()
+    return model.state_dict()
+
+
+def _strip_encoder_prefix(params):
+    if "embeddings.word_embeddings.weight" in params:
+        return params
+
+    prefixes = (
+        "0.auto_model.",
+        "0.auto_model.deberta.",
+        "auto_model.",
+        "auto_model.deberta.",
+        "deberta.",
+    )
+    for prefix in prefixes:
+        key = prefix + "embeddings.word_embeddings.weight"
+        if key in params:
+            return {
+                name[len(prefix) :]: value
+                for name, value in params.items()
+                if name.startswith(prefix)
+            }
+
+    raise KeyError("Cannot find DeBERTa V2 encoder weights in state_dict")
+
+
+def _load_model_config_and_params(model_path):
+    try:
+        model = DebertaV2Model.from_pretrained(model_path)
+        return model.config, _strip_encoder_prefix(_encoder_state_dict(model))
+    except Exception as deberta_error:
+        try:
+            from sentence_transformers import SentenceTransformer
+
+            st_model = SentenceTransformer(model_path, trust_remote_code=True)
+            auto_model = getattr(st_model[0], "auto_model", None)
+            if auto_model is None:
+                raise AttributeError(
+                    "first SentenceTransformer module has no auto_model"
+                )
+            return auto_model.config, _strip_encoder_prefix(st_model.state_dict())
+        except Exception as st_error:
+            raise RuntimeError(
+                "Failed to load as DebertaV2Model or SentenceTransformer"
+            ) from st_error
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default="microsoft/deberta-v3-small",
+        help="Hugging Face model directory or hub id",
+    )
+    parser.add_argument(
+        "--output_name",
+        type=str,
+        default="./nntr_deberta_v2_fp32.bin",
+        help="Output nntrainer binary weight path",
+    )
+    parser.add_argument(
+        "--data_type",
+        type=str,
+        default="float32",
+        choices=["float32", "float16"],
+        help="Weight dtype written to the binary file",
+    )
+    args = parser.parse_args()
+
+    dtype = np.float16 if args.data_type == "float16" else np.float32
+    config, params = _load_model_config_and_params(args.model_path)
+
+    output_path = Path(args.output_name)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with torch.no_grad(), output_path.open("wb") as output_file:
+        save_deberta_v2_for_nntrainer(params, config, dtype, output_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit supports deberta_v2 embedding model.
- add debert_attention layer
- add shared_fully_connected layer to reuse proj weight for debert attention
- add weight converter for deberta_v2

for: https://github.com/nntrainer/nntrainer/issues/3716
draft: https://github.com/nntrainer/nntrainer/pull/3714

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

## Note for Review
### output comparison for sample input("DeBERTa v3 is a powerful encoder model.")
- transformers
<details>

<summary> used python file</summary>

```python
import torch
from transformers import AutoTokenizer, AutoModel

model_name = "microsoft/mdeberta-v3-base"

# tokenizer (SentencePiece 기반 → use_fast=False 권장)
tokenizer = AutoTokenizer.from_pretrained(
    model_name,
    torch_dtype=torch.float32,
    use_fast=False
)

# encoder model
model = AutoModel.from_pretrained(model_name, torch_dtype=torch.float32)
model.eval()

# sample input
text = "DeBERTa v3 is a powerful encoder model."

inputs = tokenizer(
    text,
    return_tensors="pt",
    padding=True,
    truncation=True
)

with torch.no_grad():
    outputs = model(**inputs)

# outputs
torch.set_printoptions(precision=7, sci_mode=False)
print(outputs.last_hidden_state[0, 0, :20])
```

</details>

```console
`torch_dtype` is deprecated! Use `dtype` instead!
Asking to truncate to max_length but no maximum length is provided and the model has no predefined maximum length. Default to no truncation.
tensor([-0.0164417, -0.1296964, -0.0693817,  0.0173562, -0.1183329, -0.1043039,
         0.2496491,  0.2931238, -0.0955804,  0.1029398, -0.0788064, -0.5542011,
         0.7671070,  0.0329785,  0.2213515,  0.0977408,  0.4115512, -0.1821359,
        -0.3463724, -0.0511756])
```
- nntrainer
```console
Embedding Result (1 batch(es)):
Batch 0: [-0.0164312, -0.129666, -0.0692946, 0.0176021, -0.118328, -0.104244, 0.249876, 0.29289, -0.0954586, 0.103098, ...] (Total DIM: 768)
[e2e time]: 918 ms 
Max Resident Set Size: 1327672 KB

```

### Rationale: Why I added deberta_attention_layer and shared_fully_connected_layer
- This PR adds DeBERTa v2/v3 encoder support to nntrainer. 
- The main gap was that DeBERTa’s attention mechanism isn't mapped for the existing Transformer attention layer, so we need to add dedicated attention layer. 

1) deberta_attention_layer: DeBERTa-style attention is structurally different from standard attention
  - The existing attention implementation in nntrainer is designed around standard scaled dot-product multi-head attention (Q·Kᵀ, softmax, then ·V). 
  - DeBERTa v2/v3 attention adds disentangled/relative attention components that change both the required inputs and the score computation.
  - Additional relative embedding inputs: depending on configuration, the layer requires extra inputs beyond (Q, K, V):K_rel for content-to-position (C2P), Q_rel for position-to-content (P2C)
  - Log-bucket relative position mapping: DeBERTa does not use a simple relative index lookup. Instead, it maps relative distances into buckets using a log-bucket function (compatible with HF), which is used when adding the C2P/P2C terms.

2) shared_fully_connected_layer: needed to reuse projection weights in DeBERTa attention
- shared_fully_connected_layer is needed because DeBERTa’s attention reuses the same Q/K projection weights to produce the C2P and P2C relative projections, so those weights must be shared (rather than duplicated) to match the intended DeBERTa computation and HF weight layout.
- In shared mode, the layer skips per-layer weight read/save, so the weight is expected to be loaded/saved once by the owning instance. 

## Commits to be reviewed in this PR
- [[causallm] Support deberta_v2 embedding model](https://github.com/nntrainer/nntrainer/commit/d7aa234ce24882c02cc60ff979782533aa558502)

