### PR TITLE
[cpu_backend] Optimize softmax kernel

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/neon_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl.cpp
@@ -1432,56 +1432,74 @@ void exp_i(const unsigned int N, float *X) {
 
 static void softmax_row_inplace(float *qk_out, size_t start_row, size_t end_row,
                                 size_t num_heads) {
-  size_t row_range = end_row - start_row;
-  const size_t full_blocks = (num_heads / 4) * 4;
-  // const size_t remainder = num_heads % 4;
+  const size_t vec_end = num_heads & ~((size_t)3); // floor(num_heads / 4) * 4
 
+  // 1. find max for each head
   float *max_vals = new float[num_heads];
+
+  // initialize max_vals with first row of qk_out
+  std::memcpy(max_vals, qk_out + start_row * num_heads,
+              num_heads * sizeof(float));
+
+  // update max_vals for each row
+  for (size_t r = start_row + 1; r < end_row; ++r) {
+    float *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 4) {
+      float32x4_t v = vld1q_f32(row + c);
+      float32x4_t m = vld1q_f32(max_vals + c);
+      m = vmaxq_f32(v, m);
+      vst1q_f32(max_vals + c, m);
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      max_vals[c] = std::max(max_vals[c], row[c]);
+    }
+  }
+
+  // 2. calc exp(x - max) and sum
   float *sum_vals = new float[num_heads];
+  std::memset(sum_vals, 0, num_heads * sizeof(float));
 
-  // 1. max
-  for (size_t c = 0; c < num_heads; ++c) {
-    float max_val = -INFINITY;
-    for (size_t r = start_row; r < end_row; ++r)
-      max_val = std::max(max_val, qk_out[r * num_heads + c]);
-    max_vals[c] = max_val;
+  for (size_t r = start_row; r < end_row; ++r) {
+    float *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 4) {
+      float32x4_t s = vld1q_f32(sum_vals + c);
+      float32x4_t v = vld1q_f32(row + c);
+      float32x4_t m = vld1q_f32(max_vals + c);
+      float32x4_t d = vsubq_f32(v, m); // x - max
+      float32x4_t e = exp_ps(d);       // exp(x - max)
+      vst1q_f32(row + c, e);           // overwrite qk_out
+      s = vaddq_f32(s, e);             // sum += exp(x - max)
+      vst1q_f32(sum_vals + c, s);      // update sum_vals
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      float e = std::exp(row[c] - max_vals[c]);
+      row[c] = e;
+      sum_vals[c] += e;
+    }
   }
 
-  // 2. inplace exp + sum
-  for (size_t c = 0; c < full_blocks; c += 4) {
-    float32x4_t maxv = vld1q_f32(&max_vals[c]);
-    float32x4_t sum = vdupq_n_f32(0.0f);
-    for (size_t r = 0; r < row_range; ++r) {
-      float *ptr = &qk_out[(start_row + r) * num_heads + c];
-      float32x4_t val = vld1q_f32(ptr);
-      float32x4_t e = exp_ps(vsubq_f32(val, maxv));
-      vst1q_f32(ptr, e); // overwrite qk_out
-      sum = vaddq_f32(sum, e);
-    }
-    vst1q_f32(&sum_vals[c], sum);
+  // 3. calc 1/sum
+  // vdivq_f32 is slow
+  // precalculate (1/sum) and then multiply is much faster
+  for (size_t c = 0; c < vec_end; c += 4) {
+    float32x4_t s = vld1q_f32(sum_vals + c);
+    s = rcp_ps(s); // sum = 1/sum
+    vst1q_f32(sum_vals + c, s);
+  }
+  for (size_t c = vec_end; c < num_heads; ++c) {
+    sum_vals[c] = 1 / sum_vals[c];
   }
 
-  for (size_t c = full_blocks; c < num_heads; ++c) {
-    float sum = 0.0f;
-    float maxv = max_vals[c];
-    for (size_t r = 0; r < row_range; ++r) {
-      float &a = qk_out[(start_row + r) * num_heads + c];
-      a = std::exp(a - maxv); // overwrite qk_out
-      sum += a;
+  for (size_t r = start_row; r < end_row; ++r) {
+    float *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 4) {
+      float32x4_t s = vld1q_f32(sum_vals + c); // 1/sum
+      float32x4_t v = vld1q_f32(row + c);      // exp(x - max)
+      float32x4_t o = vmulq_f32(v, s);         // exp(x - max) * (1/sum)
+      vst1q_f32(row + c, o);                   // overwrite qk_out
     }
-    sum_vals[c] = sum;
-  }
-  // 3. softmax = exp / sum (inplace)
-  for (size_t r = 0; r < row_range; ++r) {
-    for (size_t c = 0; c < full_blocks; c += 4) {
-      float *ptr = &qk_out[(start_row + r) * num_heads + c];
-      float32x4_t val = vld1q_f32(ptr); // already exp(x - max)
-      float32x4_t sumv = vld1q_f32(&sum_vals[c]);
-      float32x4_t soft = vdivq_f32(val, sumv);
-      vst1q_f32(ptr, soft);
-    }
-    for (size_t c = full_blocks; c < num_heads; ++c) {
-      qk_out[(start_row + r) * num_heads + c] /= sum_vals[c];
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      row[c] *= sum_vals[c];
     }
   }
 
@@ -1492,56 +1510,87 @@ static void softmax_row_inplace(float *qk_out, size_t start_row, size_t end_row,
 static void softmax_row_with_sink_inplace(float *qk_out, size_t start_row,
                                           size_t end_row, size_t num_heads,
                                           float *sink) {
-  size_t row_range = end_row - start_row;
-  const size_t full_blocks = (num_heads / 4) * 4;
+  const size_t vec_end = num_heads & ~((size_t)3); // floor(num_heads / 4) * 4
 
+  // 1. find max for each head
   float *max_vals = new float[num_heads];
+
+  // initialize max_vals with sink
+  std::memcpy(max_vals, sink, num_heads * sizeof(float));
+
+  // update max_vals for each row
+  for (size_t r = start_row; r < end_row; ++r) {
+    float *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 4) {
+      float32x4_t v = vld1q_f32(row + c);
+      float32x4_t m = vld1q_f32(max_vals + c);
+      m = vmaxq_f32(v, m);
+      vst1q_f32(max_vals + c, m);
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      max_vals[c] = std::max(max_vals[c], row[c]);
+    }
+  }
+
+  // 2. calc exp(x - max) and sum
   float *sum_vals = new float[num_heads];
-
-  // 1. max
-  for (size_t c = 0; c < num_heads; ++c) {
-    float max_val = sink[c];
-    for (size_t r = start_row; r < end_row; ++r)
-      max_val = std::max(max_val, qk_out[r * num_heads + c]);
+  // init sum_vals with exp(sink - max)
+  {
+    for (size_t c = 0; c < vec_end; c += 4) {
+      float32x4_t v = vld1q_f32(sink + c);
+      float32x4_t m = vld1q_f32(max_vals + c);
+      float32x4_t d = vsubq_f32(v, m); // sink - max
+      float32x4_t e = exp_ps(d);       // exp(sink - max)
+      vst1q_f32(sum_vals + c, e);
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      float e = std::exp(sink[c] - max_vals[c]);
+      sum_vals[c] = e;
+    }
   }
 
-  // 2. inplace exp + sum
-  for (size_t c = 0; c < full_blocks; c += 4) {
-    float32x4_t maxv = vld1q_f32(&max_vals[c]);
-    float32x4_t sum = exp_ps(vsubq_f32(vld1q_f32(&sink[c]), maxv));
-
-    for (size_t r = 0; r < row_range; ++r) {
-      float *ptr = &qk_out[(start_row + r) * num_heads + c];
-      float32x4_t val = vld1q_f32(ptr);
-      float32x4_t e = exp_ps(vsubq_f32(val, maxv));
-      vst1q_f32(ptr, e); // overwrite qk_out
-      sum = vaddq_f32(sum, e);
+  for (size_t r = start_row; r < end_row; ++r) {
+    float *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 4) {
+      float32x4_t s = vld1q_f32(sum_vals + c);
+      float32x4_t v = vld1q_f32(row + c);
+      float32x4_t m = vld1q_f32(max_vals + c);
+      float32x4_t d = vsubq_f32(v, m); // x - max
+      float32x4_t e = exp_ps(d);       // exp(x - max)
+      vst1q_f32(row + c, e);           // overwrite qk_out
+      s = vaddq_f32(s, e);             // sum += exp(x - max)
+      vst1q_f32(sum_vals + c, s);      // update sum_vals
     }
-    vst1q_f32(&sum_vals[c], sum);
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      float e = std::exp(row[c] - max_vals[c]);
+      row[c] = e;
+      sum_vals[c] += e;
+    }
   }
 
-  for (size_t c = full_blocks; c < num_heads; ++c) {
-    float maxv = max_vals[c];
-    float sum = std::exp(sink[c] - maxv);
-
-    for (size_t r = 0; r < row_range; ++r) {
-      float &a = qk_out[(start_row + r) * num_heads + c];
-      a = std::exp(a - maxv); // overwrite qk_out
-      sum += a;
-    }
-    sum_vals[c] = sum;
+  // 3. calc 1/sum
+  // vdivq_f32 is slow
+  // precalculate (1/sum) and then multiply is much faster
+  for (size_t c = 0; c < vec_end; c += 4) {
+    float32x4_t s = vld1q_f32(sum_vals + c);
+    s = rcp_ps(s); // sum = 1/sum
+    vst1q_f32(sum_vals + c, s);
   }
-  // 3. softmax = exp / sum (inplace)
-  for (size_t r = 0; r < row_range; ++r) {
-    for (size_t c = 0; c < full_blocks; c += 4) {
-      float *ptr = &qk_out[(start_row + r) * num_heads + c];
-      float32x4_t val = vld1q_f32(ptr); // already exp(x - max)
-      float32x4_t sumv = vld1q_f32(&sum_vals[c]);
-      float32x4_t soft = vdivq_f32(val, sumv);
-      vst1q_f32(ptr, soft);
+  for (size_t c = vec_end; c < num_heads; ++c) {
+    sum_vals[c] = 1 / sum_vals[c];
+  }
+
+  // 4. calc exp(x - max) * (1/sum)
+  for (size_t r = start_row; r < end_row; ++r) {
+    float *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 4) {
+      float32x4_t s = vld1q_f32(sum_vals + c); // 1/sum
+      float32x4_t v = vld1q_f32(row + c);      // exp(x - max)
+      float32x4_t o = vmulq_f32(v, s);         // exp(x - max) * (1/sum)
+      vst1q_f32(row + c, o);                   // overwrite qk_out
     }
-    for (size_t c = full_blocks; c < num_heads; ++c) {
-      qk_out[(start_row + r) * num_heads + c] /= sum_vals[c];
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      row[c] *= sum_vals[c];
     }
   }
 
@@ -1562,120 +1611,13 @@ void softmax_row_inplace(float *qk_out, size_t start_row, size_t end_row,
 
 static void softmax_row(float *qk_out, size_t start_row, size_t end_row,
                         size_t num_heads) {
-  const size_t full_block = (num_heads / 4) * 4;
-
-  float *max_vals = new float[num_heads];
-  float *sum_vals = new float[num_heads];
-
-  // 1. Find Max along with col
-  for (size_t c = 0; c < num_heads; ++c) {
-    float max_val = -INFINITY;
-    for (size_t r = start_row; r < end_row; ++r) {
-      max_val = std::max(max_val, qk_out[r * num_heads + c]);
-    }
-    max_vals[c] = max_val;
-  }
-
-  // 2. Compute sum along with col (exp vectorized)
-  for (size_t c = 0; c < full_block; c += 4) {
-    float32x4_t sum = vdupq_n_f32(0.0f);
-    for (size_t r = start_row; r < end_row; ++r) {
-      float32x4_t val = vld1q_f32(&qk_out[r * num_heads + c]);
-      float32x4_t maxv = vld1q_f32(&max_vals[c]);
-      float32x4_t sub = vsubq_f32(val, maxv);
-      float32x4_t e = exp_ps(sub);
-      sum = vaddq_f32(sum, e);
-    }
-    vst1q_f32(&sum_vals[c], sum);
-  }
-
-  for (size_t c = full_block; c < num_heads; ++c) {
-    float sum = 0.0f;
-    for (size_t r = start_row; r < end_row; ++r) {
-      sum += std::exp(qk_out[r * num_heads + c] - max_vals[c]);
-    }
-    sum_vals[c] = sum;
-  }
-
-  // 3. apply softmax
-  for (size_t r = start_row; r < end_row; ++r) {
-    for (size_t c = 0; c < full_block; c += 4) {
-      float32x4_t val = vld1q_f32(&qk_out[r * num_heads + c]);
-      float32x4_t maxv = vld1q_f32(&max_vals[c]);
-      float32x4_t sub = vsubq_f32(val, maxv);
-      float32x4_t e = exp_ps(sub);
-      float32x4_t sumv = vld1q_f32(&sum_vals[c]);
-      float32x4_t softmax = vdivq_f32(e, sumv);
-      vst1q_f32(&qk_out[r * num_heads + c], softmax);
-    }
-    for (size_t c = full_block; c < num_heads; ++c) {
-      qk_out[r * num_heads + c] =
-        std::exp(qk_out[r * num_heads + c] - max_vals[c]) / sum_vals[c];
-    }
-  }
-
-  delete[] max_vals;
-  delete[] sum_vals;
+  softmax_row_inplace(qk_out, start_row, end_row, num_heads);
 }
 
 static void softmax_with_sink_row(float *qk_out, size_t start_row,
                                   size_t end_row, size_t num_heads,
                                   float *sink) {
-  const size_t full_block = (num_heads / 4) * 4;
-
-  float *max_vals = new float[num_heads];
-  float *sum_vals = new float[num_heads];
-
-  // 1. Find Max along with col
-  for (size_t c = 0; c < num_heads; ++c) {
-    float max_val = sink[c];
-    for (size_t r = start_row; r < end_row; ++r) {
-      max_val = std::max(max_val, qk_out[r * num_heads + c]);
-    }
-    max_vals[c] = max_val;
-  }
-
-  // 2. Compute sum along with col (exp vectorized)
-  for (size_t c = 0; c < full_block; c += 4) {
-    float32x4_t maxv = vld1q_f32(&max_vals[c]);
-    float32x4_t sum = exp_ps(vsubq_f32(vld1q_f32(&sink[c]), maxv));
-
-    for (size_t r = start_row; r < end_row; ++r) {
-      float32x4_t val = vld1q_f32(&qk_out[r * num_heads + c]);
-      float32x4_t sub = vsubq_f32(val, maxv);
-      float32x4_t e = exp_ps(sub);
-      sum = vaddq_f32(sum, e);
-    }
-    vst1q_f32(&sum_vals[c], sum);
-  }
-
-  for (size_t c = full_block; c < num_heads; ++c) {
-    float sum = std::exp(sink[c] - max_vals[c]);
-    for (size_t r = start_row; r < end_row; ++r) {
-      sum += std::exp(qk_out[r * num_heads + c] - max_vals[c]);
-    }
-    sum_vals[c] = sum;
-  }
-
-  // 3. apply softmax
-  for (size_t r = start_row; r < end_row; ++r) {
-    for (size_t c = 0; c < full_block; c += 4) {
-      float32x4_t val = vld1q_f32(&qk_out[r * num_heads + c]);
-      float32x4_t maxv = vld1q_f32(&max_vals[c]);
-      float32x4_t sub = vsubq_f32(val, maxv);
-      float32x4_t e = exp_ps(sub);
-      float32x4_t sumv = vld1q_f32(&sum_vals[c]);
-      float32x4_t softmax = vdivq_f32(e, sumv);
-      vst1q_f32(&qk_out[r * num_heads + c], softmax);
-    }
-    for (size_t c = full_block; c < num_heads; ++c) {
-      qk_out[r * num_heads + c] =
-        std::exp(qk_out[r * num_heads + c] - max_vals[c]) / sum_vals[c];
-    }
-  }
-
-  delete[] max_vals;
-  delete[] sum_vals;
+  softmax_row_with_sink_inplace(qk_out, start_row, end_row, num_heads, sink);
 }
 
 template <>

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl_fp16.cpp
@@ -1393,70 +1393,81 @@ inline static float16x8_t exp_f16x8(float16x8_t x) {
   return vcombine_f16(vcvt_f16_f32(res_low), vcvt_f16_f32(res_high));
 }
 
+
 // Static helper function for softmax_row_inplace with __fp16 sink
-// Performs softmax along the row dimension (sequence length) for each head.
 // Includes handling of a "sink" token (attention sink)
 static void softmax_row_inplace_with_fp16_sink(__fp16 *qk_out, size_t start_row,
                                                size_t end_row, size_t num_heads,
                                                __fp16 *sink) {
-  size_t row_range = end_row - start_row;
-  const size_t full_blocks = (num_heads / 8) * 8;
+  const size_t vec_end = num_heads & ~((size_t)7); // floor(num_heads / 8) * 8
 
+  // 1. find max for each head
   __fp16 *max_vals = new __fp16[num_heads];
+
+  // initialize max_vals with sink
+  std::memcpy(max_vals, sink, num_heads * sizeof(__fp16));
+
+  // update max_vals for each row
+  for (size_t r = start_row; r < end_row; ++r) {
+    __fp16 *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      float16x8_t v = vld1q_f16(row + c);
+      float16x8_t m = vld1q_f16(max_vals + c);
+      m = vmaxq_f16(v, m);
+      vst1q_f16(max_vals + c, m);
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      max_vals[c] = std::max(max_vals[c], row[c]);
+    }
+  }
+
+  // 2. calc exp(x - max) and sum
   __fp16 *sum_vals = new __fp16[num_heads];
-
-  // 1. Find max value for numerical stability (Safe Softmax)
-  // Formula: Softmax(x) = Softmax(x - max(x))
-  // Iterate over columns (heads)
-  for (size_t c = 0; c < num_heads; ++c) {
-    __fp16 max_val = sink[c]; // Include sink in max calculation
-    for (size_t r = start_row; r < end_row; ++r)
-      max_val = std::max<__fp16>(max_val, qk_out[r * num_heads + c]);
-    max_vals[c] = max_val;
+  // init sum_vals with exp(sink - max)
+  {
+    for (size_t c = 0; c < vec_end; c += 8) {
+      float16x8_t v = vld1q_f16(sink + c);
+      float16x8_t m = vld1q_f16(max_vals + c);
+      float16x8_t d = vsubq_f16(v, m); // sink - max
+      float16x8_t e = exp_f16x8(d);    // exp(sink - max)
+      vst1q_f16(sum_vals + c, e);
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      float e = std::exp(sink[c] - max_vals[c]);
+      sum_vals[c] = e;
+    }
   }
 
-  // 2. Compute Exponentials and Sum
-  // exp_val = exp(val - max_val)
-  // sum_val = sum(exp_val)
-  for (size_t c = 0; c < full_blocks; c += 8) {
-    float16x8_t maxv = vld1q_f16(&max_vals[c]);
-    float16x8_t sinkv = vld1q_f16(&sink[c]);
-    float16x8_t sum = exp_f16x8(vsubq_f16(sinkv, maxv)); // Include sink in sum
-
-    for (size_t r = 0; r < row_range; ++r) {
-      __fp16 *ptr = &qk_out[(start_row + r) * num_heads + c];
-      float16x8_t val = vld1q_f16(ptr);
-      float16x8_t e = exp_f16x8(vsubq_f16(val, maxv));
-      vst1q_f16(ptr, e);       // overwrite qk_out
-      sum = vaddq_f16(sum, e); // Accumulate sum
+  for (size_t r = start_row; r < end_row; ++r) {
+    __fp16 *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      float16x8_t s = vld1q_f16(sum_vals + c);
+      float16x8_t v = vld1q_f16(row + c);
+      float16x8_t m = vld1q_f16(max_vals + c);
+      float16x8_t d = vsubq_f16(v, m); // x - max
+      float16x8_t e = exp_f16x8(d);    // exp(x - max)
+      vst1q_f16(row + c, e);           // overwrite qk_out
+      s = vaddq_f16(s, e);             // sum += exp(x - max)
+      vst1q_f16(sum_vals + c, s);      // update sum_vals
     }
-    vst1q_f16(&sum_vals[c], sum);
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      float e = std::exp(row[c] - max_vals[c]);
+      row[c] = e;
+      sum_vals[c] += e;
+    }
   }
 
-  for (size_t c = full_blocks; c < num_heads; ++c) {
-    __fp16 maxv = max_vals[c];
-    __fp16 sum = std::exp(sink[c] - maxv); // Include sink in sum
-
-    for (size_t r = 0; r < row_range; ++r) {
-      __fp16 &a = qk_out[(start_row + r) * num_heads + c];
-      a = std::exp(a - maxv); // overwrite qk_out
-      sum += a;
+  // 3. calc exp(x - max) / sum
+  for (size_t r = start_row; r < end_row; ++r) {
+    __fp16 *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      float16x8_t s = vld1q_f16(sum_vals + c); // sum
+      float16x8_t v = vld1q_f16(row + c);      // exp(x - max)
+      float16x8_t o = vdivq_f16(v, s);         // exp(x - max) / sum
+      vst1q_f16(row + c, o);                   // overwrite qk_out
     }
-    sum_vals[c] = sum;
-  }
-
-  // 3. Normalize to get Probabilities
-  // prob = exp_val / sum_val
-  for (size_t r = 0; r < row_range; ++r) {
-    for (size_t c = 0; c < full_blocks; c += 8) {
-      __fp16 *ptr = &qk_out[(start_row + r) * num_heads + c];
-      float16x8_t val = vld1q_f16(ptr); // already exp(x - max)
-      float16x8_t sumv = vld1q_f16(&sum_vals[c]);
-      float16x8_t soft = vdivq_f16(val, sumv);
-      vst1q_f16(ptr, soft);
-    }
-    for (size_t c = full_blocks; c < num_heads; ++c) {
-      qk_out[(start_row + r) * num_heads + c] /= sum_vals[c];
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      row[c] /= sum_vals[c];
     }
   }
 
@@ -1467,56 +1478,64 @@ static void softmax_row_inplace_with_fp16_sink(__fp16 *qk_out, size_t start_row,
 // Static helper function for softmax_row_inplace without sink
 static void softmax_row_inplace_no_sink(__fp16 *qk_out, size_t start_row,
                                         size_t end_row, size_t num_heads) {
-  size_t row_range = end_row - start_row;
-  const size_t full_blocks = (num_heads / 8) * 8;
-  // const size_t remainder = num_heads % 8;
+  const size_t vec_end = num_heads & ~((size_t)7); // floor(num_heads / 8) * 8
 
+  // 1. find max for each head
   __fp16 *max_vals = new __fp16[num_heads];
+
+  // initialize max_vals with first row of qk_out
+  std::memcpy(max_vals, qk_out + start_row * num_heads,
+              num_heads * sizeof(__fp16));
+
+  // update max_vals for each row
+  for (size_t r = start_row + 1; r < end_row; ++r) {
+    __fp16 *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      float16x8_t v = vld1q_f16(row + c);
+      float16x8_t m = vld1q_f16(max_vals + c);
+      m = vmaxq_f16(v, m);
+      vst1q_f16(max_vals + c, m);
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      max_vals[c] = std::max(max_vals[c], row[c]);
+    }
+  }
+
+  // 2. calc exp(x - max) and sum
   __fp16 *sum_vals = new __fp16[num_heads];
+  std::memset(sum_vals, 0, num_heads * sizeof(__fp16));
 
-  // 1. max
-  for (size_t c = 0; c < num_heads; ++c) {
-    __fp16 max_val = -INFINITY;
-    for (size_t r = start_row; r < end_row; ++r)
-      max_val = std::max<__fp16>(max_val, qk_out[r * num_heads + c]);
-    max_vals[c] = max_val;
+  for (size_t r = start_row; r < end_row; ++r) {
+    __fp16 *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      float16x8_t s = vld1q_f16(sum_vals + c);
+      float16x8_t v = vld1q_f16(row + c);
+      float16x8_t m = vld1q_f16(max_vals + c);
+      float16x8_t d = vsubq_f16(v, m); // x - max
+      float16x8_t e = exp_f16x8(d);    // exp(x - max)
+      vst1q_f16(row + c, e);           // overwrite qk_out
+      s = vaddq_f16(s, e);             // sum += exp(x - max)
+      vst1q_f16(sum_vals + c, s);      // update sum_vals
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      float e = std::exp(row[c] - max_vals[c]);
+      row[c] = e;
+      sum_vals[c] += e;
+    }
   }
 
-  // 2. inplace exp + sum
-  for (size_t c = 0; c < full_blocks; c += 8) {
-    float16x8_t maxv = vld1q_f16(&max_vals[c]);
-    float16x8_t sum = vdupq_n_f16(0.0f);
-    for (size_t r = 0; r < row_range; ++r) {
-      __fp16 *ptr = &qk_out[(start_row + r) * num_heads + c];
-      float16x8_t val = vld1q_f16(ptr);
-      float16x8_t e = exp_f16x8(vsubq_f16(val, maxv));
-      vst1q_f16(ptr, e); // overwrite qk_out
-      sum = vaddq_f16(sum, e);
-    }
-    vst1q_f16(&sum_vals[c], sum);
-  }
+  // 3. calc exp(x - max) / sum
+  for (size_t r = start_row; r < end_row; ++r) {
+    __fp16 *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
 
-  for (size_t c = full_blocks; c < num_heads; ++c) {
-    __fp16 sum = 0.0f;
-    __fp16 maxv = max_vals[c];
-    for (size_t r = 0; r < row_range; ++r) {
-      __fp16 &a = qk_out[(start_row + r) * num_heads + c];
-      a = std::exp(a - maxv); // overwrite qk_out
-      sum += a;
+      float16x8_t s = vld1q_f16(sum_vals + c); // sum
+      float16x8_t v = vld1q_f16(row + c);      // exp(x - max)
+      float16x8_t o = vdivq_f16(v, s);         // exp(x - max) / sum
+      vst1q_f16(row + c, o);                   // overwrite qk_out
     }
-    sum_vals[c] = sum;
-  }
-  // 3. softmax = exp / sum (inplace)
-  for (size_t r = 0; r < row_range; ++r) {
-    for (size_t c = 0; c < full_blocks; c += 8) {
-      __fp16 *ptr = &qk_out[(start_row + r) * num_heads + c];
-      float16x8_t val = vld1q_f16(ptr); // already exp(x - max)
-      float16x8_t sumv = vld1q_f16(&sum_vals[c]);
-      float16x8_t soft = vdivq_f16(val, sumv);
-      vst1q_f16(ptr, soft);
-    }
-    for (size_t c = full_blocks; c < num_heads; ++c) {
-      qk_out[(start_row + r) * num_heads + c] /= sum_vals[c];
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      row[c] /= sum_vals[c];
     }
   }
 
@@ -1539,97 +1558,145 @@ void softmax_row_inplace(__fp16 *qk_out, size_t start_row, size_t end_row,
 static void softmax_row_inplace_with_fp32_sink(__fp16 *qk_out, size_t start_row,
                                                size_t end_row, size_t num_heads,
                                                float *sink) {
-  size_t row_range = end_row - start_row;
-  const size_t full_blocks = (num_heads / 8) * 8;
 
+  const size_t vec_end = num_heads & ~((size_t)7); // floor(num_heads / 8) * 8
+
+  // 1. find max for each head
   float *max_vals = new float[num_heads];
+
+  // initialize max_vals with sink
+  std::memcpy(max_vals, sink, num_heads * sizeof(float));
+
+  // update max_vals for each row
+  for (size_t r = start_row; r < end_row; ++r) {
+    __fp16 *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      float16x8_t v = vld1q_f16(row + c);
+      float32x4_t v_lo = vcvt_f32_f16(vget_low_f16(v));
+      float32x4_t v_hi = vcvt_high_f32_f16(v);
+
+      float32x4_t m_lo = vld1q_f32(max_vals + c);
+      float32x4_t m_hi = vld1q_f32(max_vals + c + 4);
+
+      m_lo = vmaxq_f32(v_lo, m_lo);
+      m_hi = vmaxq_f32(v_hi, m_hi);
+
+      vst1q_f32(max_vals + c, m_lo);
+      vst1q_f32(max_vals + c + 4, m_hi);
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      max_vals[c] = std::max(max_vals[c], static_cast<float>(row[c]));
+    }
+  }
+
+  // 2. calc exp(x - max) and sum
   float *sum_vals = new float[num_heads];
+  // init sum_vals with exp(sink - max)
+  {
+    for (size_t c = 0; c < vec_end; c += 8) {
+      float32x4_t v_lo = vld1q_f32(sink + c);
+      float32x4_t v_hi = vld1q_f32(sink + c + 4);
 
-  // 1. max (including sink)
-  for (size_t c = 0; c < num_heads; ++c) {
-    float max_val = sink[c]; // Include sink in max calculation
-    for (size_t r = start_row; r < end_row; ++r) {
-      float val = static_cast<float>(qk_out[r * num_heads + c]);
-      max_val = std::max(max_val, val);
+      float32x4_t m_lo = vld1q_f32(max_vals + c);
+      float32x4_t m_hi = vld1q_f32(max_vals + c + 4);
+
+      // sink - max
+      float32x4_t d_lo = vsubq_f32(v_lo, m_lo);
+      float32x4_t d_hi = vsubq_f32(v_hi, m_hi);
+
+      // exp(sink - max)
+      float32x4_t e_lo = exp_ps(d_lo);
+      float32x4_t e_hi = exp_ps(d_hi);
+
+      vst1q_f32(sum_vals + c, e_lo);
+      vst1q_f32(sum_vals + c + 4, e_hi);
     }
-    max_vals[c] = max_val;
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      float e = std::exp(sink[c] - max_vals[c]);
+      sum_vals[c] = e;
+    }
   }
 
-  // 2. inplace exp + sum (including sink)
-  for (size_t c = 0; c < full_blocks; c += 8) {
-    float32x4_t maxv_low = vld1q_f32(&max_vals[c]);
-    float32x4_t maxv_high = vld1q_f32(&max_vals[c + 4]);
-    float32x4_t sinkv_low = vld1q_f32(&sink[c]);
-    float32x4_t sinkv_high = vld1q_f32(&sink[c + 4]);
+  for (size_t r = start_row; r < end_row; ++r) {
+    __fp16 *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      float32x4_t s_lo = vld1q_f32(sum_vals + c);
+      float32x4_t s_hi = vld1q_f32(sum_vals + c + 4);
 
-    // Calculate exp(sink - max) for sum initialization
-    float32x4_t sum_low = exp_ps(vsubq_f32(sinkv_low, maxv_low));
-    float32x4_t sum_high = exp_ps(vsubq_f32(sinkv_high, maxv_high));
+      float16x8_t v = vld1q_f16(row + c);
+      float32x4_t v_lo = vcvt_f32_f16(vget_low_f16(v));
+      float32x4_t v_hi = vcvt_high_f32_f16(v);
 
-    for (size_t r = 0; r < row_range; ++r) {
-      __fp16 *ptr = &qk_out[(start_row + r) * num_heads + c];
-      float16x8_t val_fp16 = vld1q_f16(ptr);
+      float32x4_t m_lo = vld1q_f32(max_vals + c);
+      float32x4_t m_hi = vld1q_f32(max_vals + c + 4);
 
-      // Convert to float32 for computation
-      float32x4_t val_low = vcvt_f32_f16(vget_low_f16(val_fp16));
-      float32x4_t val_high = vcvt_f32_f16(vget_high_f16(val_fp16));
+      // x - max
+      float32x4_t d_lo = vsubq_f32(v_lo, m_lo);
+      float32x4_t d_hi = vsubq_f32(v_hi, m_hi);
 
-      // Compute exp(val - max)
-      float32x4_t e_low = exp_ps(vsubq_f32(val_low, maxv_low));
-      float32x4_t e_high = exp_ps(vsubq_f32(val_high, maxv_high));
+      // exp(x - max)
+      float32x4_t e_lo = exp_ps(d_lo);
+      float32x4_t e_hi = exp_ps(d_hi);
 
-      // Convert back to fp16 and store
-      float16x8_t e_fp16 =
-        vcombine_f16(vcvt_f16_f32(e_low), vcvt_f16_f32(e_high));
-      vst1q_f16(ptr, e_fp16);
+      // sum += exp(x - max)
+      s_lo = vaddq_f32(s_lo, e_lo);
+      s_hi = vaddq_f32(s_hi, e_hi);
 
-      // Accumulate sum
-      sum_low = vaddq_f32(sum_low, e_low);
-      sum_high = vaddq_f32(sum_high, e_high);
+      // update sum_vals
+      vst1q_f32(sum_vals + c, s_lo);
+      vst1q_f32(sum_vals + c + 4, s_hi);
+
+      // overwrite qk_out
+      vst1q_f16(row + c, vcombine_f16(vcvt_f16_f32(e_lo), vcvt_f16_f32(e_hi)));
     }
-
-    vst1q_f32(&sum_vals[c], sum_low);
-    vst1q_f32(&sum_vals[c + 4], sum_high);
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      float e = std::exp(static_cast<float>(row[c]) - max_vals[c]);
+      sum_vals[c] += e;
+      row[c] = static_cast<__fp16>(e);
+    }
   }
 
-  for (size_t c = full_blocks; c < num_heads; ++c) {
-    float maxv = max_vals[c];
-    float sum = std::exp(sink[c] - maxv); // Include sink in sum
+  // 3. calc 1/sum
+  // vdivq_f32 is slow
+  // precalculate (1/sum) and then multiply is much faster
+  // If accuracy matters, use direct division instead
+  for (size_t c = 0; c < vec_end; c += 8) {
+    float32x4_t s_lo = vld1q_f32(sum_vals + c);
+    float32x4_t s_hi = vld1q_f32(sum_vals + c + 4);
 
-    for (size_t r = 0; r < row_range; ++r) {
-      __fp16 &a = qk_out[(start_row + r) * num_heads + c];
-      float val = static_cast<float>(a);
-      float e = std::exp(val - maxv);
-      a = static_cast<__fp16>(e); // overwrite qk_out with exp value
-      sum += e;
-    }
-    sum_vals[c] = sum;
+    // sum = 1/sum
+    s_lo = rcp_ps(s_lo);
+    s_hi = rcp_ps(s_hi);
+
+    vst1q_f32(sum_vals + c, s_lo);
+    vst1q_f32(sum_vals + c + 4, s_hi);
+  }
+  for (size_t c = vec_end; c < num_heads; ++c) {
+    sum_vals[c] = 1 / sum_vals[c];
   }
 
-  // 3. softmax = exp / sum (inplace)
-  for (size_t r = 0; r < row_range; ++r) {
-    for (size_t c = 0; c < full_blocks; c += 8) {
-      __fp16 *ptr = &qk_out[(start_row + r) * num_heads + c];
-      float16x8_t val_fp16 = vld1q_f16(ptr); // already exp(x - max)
+  // 4. calc exp(x - max) * (1/sum)
+  for (size_t r = start_row; r < end_row; ++r) {
+    __fp16 *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      // 1/sum
+      float32x4_t s_lo = vld1q_f32(sum_vals + c);
+      float32x4_t s_hi = vld1q_f32(sum_vals + c + 4);
 
-      // Convert to float32 for division
-      float32x4_t val_low = vcvt_f32_f16(vget_low_f16(val_fp16));
-      float32x4_t val_high = vcvt_f32_f16(vget_high_f16(val_fp16));
+      // exp(x - max)
+      float16x8_t v = vld1q_f16(row + c);
+      float32x4_t v_lo = vcvt_f32_f16(vget_low_f16(v));
+      float32x4_t v_hi = vcvt_high_f32_f16(v);
 
-      float32x4_t sumv_low = vld1q_f32(&sum_vals[c]);
-      float32x4_t sumv_high = vld1q_f32(&sum_vals[c + 4]);
+      // exp(x - max) * (1/sum)
+      float32x4_t o_lo = vmulq_f32(v_lo, s_lo);
+      float32x4_t o_hi = vmulq_f32(v_hi, s_hi);
 
-      float32x4_t soft_low = vdivq_f32(val_low, sumv_low);
-      float32x4_t soft_high = vdivq_f32(val_high, sumv_high);
-
-      // Convert back to fp16 and store
-      float16x8_t soft_fp16 =
-        vcombine_f16(vcvt_f16_f32(soft_low), vcvt_f16_f32(soft_high));
-      vst1q_f16(ptr, soft_fp16);
+      // overwrite qk_out
+      vst1q_f16(row + c, vcombine_f16(vcvt_f16_f32(o_lo), vcvt_f16_f32(o_hi)));
     }
-    for (size_t c = full_blocks; c < num_heads; ++c) {
-      __fp16 &val = qk_out[(start_row + r) * num_heads + c];
-      val = static_cast<__fp16>(static_cast<float>(val) / sum_vals[c]);
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      row[c] = static_cast<__fp16>(static_cast<float>(row[c]) * sum_vals[c]);
     }
   }
 
@@ -1652,121 +1719,14 @@ void softmax_row_inplace(__fp16 *qk_out, size_t start_row, size_t end_row,
 static void softmax_row_with_fp16_sink(__fp16 *qk_out, size_t start_row,
                                        size_t end_row, size_t num_heads,
                                        __fp16 *sink) {
-  const size_t full_block = (num_heads / 8) * 8;
-
-  __fp16 *max_vals = new __fp16[num_heads];
-  __fp16 *sum_vals = new __fp16[num_heads];
-
-  // 1. Find Max along with col (including sink)
-  for (size_t c = 0; c < num_heads; ++c) {
-    __fp16 max_val = sink[c];
-    for (size_t r = start_row; r < end_row; ++r) {
-      max_val = std::max<__fp16>(max_val, qk_out[r * num_heads + c]);
-    }
-    max_vals[c] = max_val;
-  }
-
-  // 2. Compute sum along with col (exp vectorized, including sink)
-  for (size_t c = 0; c < full_block; c += 8) {
-    float16x8_t maxv = vld1q_f16(&max_vals[c]);
-    float16x8_t sinkv = vld1q_f16(&sink[c]);
-    float16x8_t sum = exp_f16x8(vsubq_f16(sinkv, maxv)); // Include sink in sum
-
-    for (size_t r = start_row; r < end_row; ++r) {
-      float16x8_t val = vld1q_f16(&qk_out[r * num_heads + c]);
-      float16x8_t sub = vsubq_f16(val, maxv);
-      float16x8_t e = exp_f16x8(sub);
-      sum = vaddq_f16(sum, e);
-    }
-    vst1q_f16(&sum_vals[c], sum);
-  }
-
-  for (size_t c = full_block; c < num_heads; ++c) {
-    float sum = std::exp(sink[c] - max_vals[c]); // Include sink in sum
-    for (size_t r = start_row; r < end_row; ++r) {
-      sum += std::exp(qk_out[r * num_heads + c] - max_vals[c]);
-    }
-    sum_vals[c] = sum;
-  }
-
-  // 3. apply softmax
-  for (size_t r = start_row; r < end_row; ++r) {
-    for (size_t c = 0; c < full_block; c += 8) {
-      float16x8_t val = vld1q_f16(&qk_out[r * num_heads + c]);
-      float16x8_t maxv = vld1q_f16(&max_vals[c]);
-      float16x8_t sub = vsubq_f16(val, maxv);
-      float16x8_t e = exp_f16x8(sub);
-      float16x8_t sumv = vld1q_f16(&sum_vals[c]);
-      float16x8_t softmax = vdivq_f16(e, sumv);
-      vst1q_f16(&qk_out[r * num_heads + c], softmax);
-    }
-    for (size_t c = full_block; c < num_heads; ++c) {
-      qk_out[r * num_heads + c] =
-        std::exp(qk_out[r * num_heads + c] - max_vals[c]) / sum_vals[c];
-    }
-  }
-
-  delete[] max_vals;
-  delete[] sum_vals;
+  softmax_row_inplace_with_fp16_sink(qk_out, start_row, end_row, num_heads,
+                                     sink);
 }
 
 // Static helper function for softmax_row without sink
 static void softmax_row_no_sink(__fp16 *qk_out, size_t start_row,
                                 size_t end_row, size_t num_heads) {
-  const size_t full_block = (num_heads / 8) * 8;
-
-  __fp16 *max_vals = new __fp16[num_heads];
-  __fp16 *sum_vals = new __fp16[num_heads];
-
-  // 1. Find Max along with col
-  for (size_t c = 0; c < num_heads; ++c) {
-    __fp16 max_val = -INFINITY;
-    for (size_t r = start_row; r < end_row; ++r) {
-      max_val = std::max<__fp16>(max_val, qk_out[r * num_heads + c]);
-    }
-    max_vals[c] = max_val;
-  }
-
-  // 2. Compute sum along with col (exp vectorized)
-  for (size_t c = 0; c < full_block; c += 8) {
-    float16x8_t sum = vdupq_n_f16(0.0f);
-    for (size_t r = start_row; r < end_row; ++r) {
-      float16x8_t val = vld1q_f16(&qk_out[r * num_heads + c]);
-      float16x8_t maxv = vld1q_f16(&max_vals[c]);
-      float16x8_t sub = vsubq_f16(val, maxv);
-      float16x8_t e = exp_f16x8(sub);
-      sum = vaddq_f16(sum, e);
-    }
-    vst1q_f16(&sum_vals[c], sum);
-  }
-
-  for (size_t c = full_block; c < num_heads; ++c) {
-    float sum = 0.0f;
-    for (size_t r = start_row; r < end_row; ++r) {
-      sum += std::exp(qk_out[r * num_heads + c] - max_vals[c]);
-    }
-    sum_vals[c] = sum;
-  }
-
-  // 3. apply softmax
-  for (size_t r = start_row; r < end_row; ++r) {
-    for (size_t c = 0; c < full_block; c += 8) {
-      float16x8_t val = vld1q_f16(&qk_out[r * num_heads + c]);
-      float16x8_t maxv = vld1q_f16(&max_vals[c]);
-      float16x8_t sub = vsubq_f16(val, maxv);
-      float16x8_t e = exp_f16x8(sub);
-      float16x8_t sumv = vld1q_f16(&sum_vals[c]);
-      float16x8_t softmax = vdivq_f16(e, sumv);
-      vst1q_f16(&qk_out[r * num_heads + c], softmax);
-    }
-    for (size_t c = full_block; c < num_heads; ++c) {
-      qk_out[r * num_heads + c] =
-        std::exp(qk_out[r * num_heads + c] - max_vals[c]) / sum_vals[c];
-    }
-  }
-
-  delete[] max_vals;
-  delete[] sum_vals;
+  softmax_row_inplace_no_sink(qk_out, start_row, end_row, num_heads);
 }
 
 template <>
@@ -1784,101 +1744,8 @@ void softmax_row(__fp16 *qk_out, size_t start_row, size_t end_row,
 static void softmax_row_with_fp32_sink(__fp16 *qk_out, size_t start_row,
                                        size_t end_row, size_t num_heads,
                                        float *sink) {
-  const size_t full_block = (num_heads / 8) * 8;
-
-  float *max_vals = new float[num_heads];
-  float *sum_vals = new float[num_heads];
-
-  // 1. Find Max along with col (including sink)
-  for (size_t c = 0; c < num_heads; ++c) {
-    float max_val = sink[c];
-    for (size_t r = start_row; r < end_row; ++r) {
-      float val = static_cast<float>(qk_out[r * num_heads + c]);
-      max_val = std::max(max_val, val);
-    }
-    max_vals[c] = max_val;
-  }
-
-  // 2. Compute sum along with col (exp vectorized, including sink)
-  for (size_t c = 0; c < full_block; c += 8) {
-    float32x4_t maxv_low = vld1q_f32(&max_vals[c]);
-    float32x4_t maxv_high = vld1q_f32(&max_vals[c + 4]);
-    float32x4_t sinkv_low = vld1q_f32(&sink[c]);
-    float32x4_t sinkv_high = vld1q_f32(&sink[c + 4]);
-
-    // Calculate exp(sink - max) for sum initialization
-    float32x4_t sum_low = exp_ps(vsubq_f32(sinkv_low, maxv_low));
-    float32x4_t sum_high = exp_ps(vsubq_f32(sinkv_high, maxv_high));
-
-    for (size_t r = start_row; r < end_row; ++r) {
-      float16x8_t val_fp16 = vld1q_f16(&qk_out[r * num_heads + c]);
-
-      // Convert to float32 for computation
-      float32x4_t val_low = vcvt_f32_f16(vget_low_f16(val_fp16));
-      float32x4_t val_high = vcvt_f32_f16(vget_high_f16(val_fp16));
-
-      float32x4_t sub_low = vsubq_f32(val_low, maxv_low);
-      float32x4_t sub_high = vsubq_f32(val_high, maxv_high);
-
-      float32x4_t e_low = exp_ps(sub_low);
-      float32x4_t e_high = exp_ps(sub_high);
-
-      sum_low = vaddq_f32(sum_low, e_low);
-      sum_high = vaddq_f32(sum_high, e_high);
-    }
-
-    vst1q_f32(&sum_vals[c], sum_low);
-    vst1q_f32(&sum_vals[c + 4], sum_high);
-  }
-
-  for (size_t c = full_block; c < num_heads; ++c) {
-    float maxv = max_vals[c];
-    float sum = std::exp(sink[c] - maxv); // Include sink in sum
-    for (size_t r = start_row; r < end_row; ++r) {
-      float val = static_cast<float>(qk_out[r * num_heads + c]);
-      sum += std::exp(val - maxv);
-    }
-    sum_vals[c] = sum;
-  }
-
-  // 3. apply softmax
-  for (size_t r = start_row; r < end_row; ++r) {
-    for (size_t c = 0; c < full_block; c += 8) {
-      float16x8_t val_fp16 = vld1q_f16(&qk_out[r * num_heads + c]);
-
-      // Convert to float32 for computation
-      float32x4_t val_low = vcvt_f32_f16(vget_low_f16(val_fp16));
-      float32x4_t val_high = vcvt_f32_f16(vget_high_f16(val_fp16));
-
-      float32x4_t maxv_low = vld1q_f32(&max_vals[c]);
-      float32x4_t maxv_high = vld1q_f32(&max_vals[c + 4]);
-
-      float32x4_t sub_low = vsubq_f32(val_low, maxv_low);
-      float32x4_t sub_high = vsubq_f32(val_high, maxv_high);
-
-      float32x4_t e_low = exp_ps(sub_low);
-      float32x4_t e_high = exp_ps(sub_high);
-
-      float32x4_t sumv_low = vld1q_f32(&sum_vals[c]);
-      float32x4_t sumv_high = vld1q_f32(&sum_vals[c + 4]);
-
-      float32x4_t softmax_low = vdivq_f32(e_low, sumv_low);
-      float32x4_t softmax_high = vdivq_f32(e_high, sumv_high);
-
-      // Convert back to fp16 and store
-      float16x8_t softmax_fp16 =
-        vcombine_f16(vcvt_f16_f32(softmax_low), vcvt_f16_f32(softmax_high));
-      vst1q_f16(&qk_out[r * num_heads + c], softmax_fp16);
-    }
-    for (size_t c = full_block; c < num_heads; ++c) {
-      float val = static_cast<float>(qk_out[r * num_heads + c]);
-      qk_out[r * num_heads + c] =
-        static_cast<__fp16>(std::exp(val - max_vals[c]) / sum_vals[c]);
-    }
-  }
-
-  delete[] max_vals;
-  delete[] sum_vals;
+  softmax_row_inplace_with_fp32_sink(qk_out, start_row, end_row, num_heads,
+                                     sink);
 }
 
 // Overloaded function for softmax_row with __fp16 input and float sink

--- a/nntrainer/tensor/cpu_backend/arm/neon_mathfun.h
+++ b/nntrainer/tensor/cpu_backend/arm/neon_mathfun.h
@@ -80,6 +80,12 @@ inline v4sf cos_ps(v4sf x);
  */
 inline void sincos_ps(v4sf x, v4sf *s, v4sf *c);
 
+/**
+ * @brief reciprocal function with neon x = 1/x
+ * @param[in] x input register variable (float32x4_t)
+ */
+inline v4sf rcp_ps(v4sf x);
+
 #include "neon_mathfun.hxx"
 
 #endif

--- a/nntrainer/tensor/cpu_backend/arm/neon_mathfun.hxx
+++ b/nntrainer/tensor/cpu_backend/arm/neon_mathfun.hxx
@@ -361,4 +361,18 @@ inline v4sf tanh_ps(v4sf x) {
   return res;
 }
 
+/**
+ * @brief reciprocal function with simd
+ *
+ * @param x input register variable
+ * @return v4sf
+ */
+v4sf rcp_ps(v4sf x) {
+  // apply reciprocal once
+  v4sf rcp = vrecpeq_f32(x);
+  // apply Newton-Rapson method to enhance accuracy
+  // x_n+1 = x_n * (2 - x_0 * x_n)
+  return vmulq_f32(rcp, vrecpsq_f32(x, rcp));
+}
+
 #endif

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -1181,57 +1181,86 @@ static inline __m256 exp256_ps(__m256 x) {
   return _mm256_mul_ps(y, pow2n);
 }
 
+static inline __m256 rcp_ps(__m256 x) {
+  // Use Newton-Raphson method to enhance accuracy
+  // x_n+1 = x_n * (2 - x_0 * x_n)
+  __m256 rcp = _mm256_rcp_ps(x);
+  __m256 two = _mm256_set1_ps(2.0f);
+  // rcp * (2 - x * rcp)
+  return _mm256_mul_ps(rcp, _mm256_fnmadd_ps(x, rcp, two));
+}
+
 static void softmax_row_inplace(float *qk_out, size_t start_row, size_t end_row,
                                 size_t num_heads) {
-  size_t row_range = end_row - start_row;
-  const size_t full_blocks = (num_heads / 8) * 8;
-  // const size_t remainder = num_heads % 8;
+  const size_t vec_end = num_heads & ~((size_t)7); // floor(num_heads / 8) * 8
 
+  // 1. find max for each head
   float *max_vals = new float[num_heads];
+
+  // initialize max_vals with first row of qk_out
+  std::memcpy(max_vals, qk_out + start_row * num_heads,
+              num_heads * sizeof(float));
+
+  // update max_vals for each row
+  for (size_t r = start_row + 1; r < end_row; ++r) {
+    float *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      __m256 v = _mm256_loadu_ps(row + c);
+      __m256 m = _mm256_loadu_ps(max_vals + c);
+      m = _mm256_max_ps(v, m);
+      _mm256_storeu_ps(max_vals + c, m);
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      max_vals[c] = std::max(max_vals[c], row[c]);
+    }
+  }
+
+  // 2. calc exp(x - max) and sum
   float *sum_vals = new float[num_heads];
-  // 1. max
-  for (size_t c = 0; c < num_heads; ++c) {
-    float max_val = -INFINITY;
-    for (size_t r = start_row; r < end_row; ++r)
-      max_val = std::max(max_val, qk_out[r * num_heads + c]);
-    max_vals[c] = max_val;
+  std::memset(sum_vals, 0, num_heads * sizeof(float));
+
+  for (size_t r = start_row; r < end_row; ++r) {
+    float *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      __m256 s = _mm256_loadu_ps(sum_vals + c);
+      __m256 v = _mm256_loadu_ps(row + c);
+      __m256 m = _mm256_loadu_ps(max_vals + c);
+      __m256 d = _mm256_sub_ps(v, m);    // x - max
+      __m256 e = exp256_ps(d);           // exp(x - max)
+      _mm256_storeu_ps(row + c, e);      // overwrite qk_out
+      s = _mm256_add_ps(s, e);           // sum += exp(x - max)
+      _mm256_storeu_ps(sum_vals + c, s); // update sum_vals
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      float e = std::exp(row[c] - max_vals[c]);
+      row[c] = e;
+      sum_vals[c] += e;
+    }
   }
 
-  // 2. inplace exp + sum
-  for (size_t c = 0; c < full_blocks; c += 8) {
-    __m256 maxv = _mm256_loadu_ps(&max_vals[c]);
-    __m256 sum = _mm256_setzero_ps();
-    for (size_t r = 0; r < row_range; ++r) {
-      float *ptr = &qk_out[(start_row + r) * num_heads + c];
-      __m256 val = _mm256_loadu_ps(ptr);
-      __m256 e = exp256_ps(_mm256_sub_ps(val, maxv));
-      _mm256_storeu_ps(ptr, e); // overwrite qk_out
-      sum = _mm256_add_ps(sum, e);
-    }
-    _mm256_storeu_ps(&sum_vals[c], sum);
+  // 3. calc 1/sum
+  // _mm256_div_ps is slow
+  // precalculate (1/sum) and then multiply is much faster
+  for (size_t c = 0; c < vec_end; c += 8) {
+    __m256 s = _mm256_loadu_ps(sum_vals + c);
+    s = rcp_ps(s); // sum = 1/sum
+    _mm256_storeu_ps(sum_vals + c, s);
+  }
+  for (size_t c = vec_end; c < num_heads; ++c) {
+    sum_vals[c] = 1 / sum_vals[c];
   }
 
-  for (size_t c = full_blocks; c < num_heads; ++c) {
-    float sum = 0.0f;
-    float maxv = max_vals[c];
-    for (size_t r = 0; r < row_range; ++r) {
-      float &a = qk_out[(start_row + r) * num_heads + c];
-      a = std::exp(a - maxv); // overwrite qk_out
-      sum += a;
+  // 4. calc exp(x - max) * (1/sum)
+  for (size_t r = start_row; r < end_row; ++r) {
+    float *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      __m256 s = _mm256_loadu_ps(sum_vals + c); // 1/sum
+      __m256 v = _mm256_loadu_ps(row + c);      // exp(x - max)
+      __m256 o = _mm256_mul_ps(v, s);           // exp(x - max) * (1/sum)
+      _mm256_storeu_ps(row + c, o);             // overwrite qk_out
     }
-    sum_vals[c] = sum;
-  }
-  // 3. softmax = exp / sum (inplace)
-  for (size_t r = 0; r < row_range; ++r) {
-    for (size_t c = 0; c < full_blocks; c += 8) {
-      float *ptr = &qk_out[(start_row + r) * num_heads + c];
-      __m256 val = _mm256_loadu_ps(ptr); // already exp(x - max)
-      __m256 sumv = _mm256_loadu_ps(&sum_vals[c]);
-      __m256 soft = _mm256_div_ps(val, sumv);
-      _mm256_storeu_ps(ptr, soft);
-    }
-    for (size_t c = full_blocks; c < num_heads; ++c) {
-      qk_out[(start_row + r) * num_heads + c] /= sum_vals[c];
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      row[c] *= sum_vals[c];
     }
   }
 
@@ -1242,55 +1271,87 @@ static void softmax_row_inplace(float *qk_out, size_t start_row, size_t end_row,
 static void softmax_row_with_sink_inplace(float *qk_out, size_t start_row,
                                           size_t end_row, size_t num_heads,
                                           float *sink) {
-  size_t row_range = end_row - start_row;
-  const size_t full_blocks = (num_heads / 8) * 8;
+  const size_t vec_end = num_heads & ~((size_t)7); // floor(num_heads / 8) * 8
 
+  // 1. find max for each head
   float *max_vals = new float[num_heads];
+
+  // initialize max_vals with sink
+  std::memcpy(max_vals, sink, num_heads * sizeof(float));
+
+  // update max_vals for each row
+  for (size_t r = start_row; r < end_row; ++r) {
+    float *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      __m256 v = _mm256_loadu_ps(row + c);
+      __m256 m = _mm256_loadu_ps(max_vals + c);
+      m = _mm256_max_ps(v, m);
+      _mm256_storeu_ps(max_vals + c, m);
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      max_vals[c] = std::max(max_vals[c], row[c]);
+    }
+  }
+
+  // 2. calc exp(x - max) and sum
   float *sum_vals = new float[num_heads];
-  // 1. max
-  for (size_t c = 0; c < num_heads; ++c) {
-    float max_val = -INFINITY;
-    for (size_t r = start_row; r < end_row; ++r)
-      max_val = std::max(max_val, qk_out[r * num_heads + c]);
-    max_vals[c] = std::max(sink[c], max_val);
+  // init sum_vals with exp(sink - max)
+  {
+    for (size_t c = 0; c < vec_end; c += 8) {
+      __m256 v = _mm256_loadu_ps(sink + c);
+      __m256 m = _mm256_loadu_ps(max_vals + c);
+      __m256 d = _mm256_sub_ps(v, m); // sink - max
+      __m256 e = exp256_ps(d);        // exp(sink - max)
+      _mm256_storeu_ps(sum_vals + c, e);
+    }
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      float e = std::exp(sink[c] - max_vals[c]);
+      sum_vals[c] = e;
+    }
   }
 
-  // 2. inplace exp + sum
-  for (size_t c = 0; c < full_blocks; c += 8) {
-    __m256 maxv = _mm256_loadu_ps(&max_vals[c]);
-    __m256 sum = _mm256_loadu_ps(&sink[c]);
-    sum = exp256_ps(_mm256_sub_ps(sum, maxv));
-    for (size_t r = 0; r < row_range; ++r) {
-      float *ptr = &qk_out[(start_row + r) * num_heads + c];
-      __m256 val = _mm256_loadu_ps(ptr);
-      __m256 e = exp256_ps(_mm256_sub_ps(val, maxv));
-      _mm256_storeu_ps(ptr, e); // overwrite qk_out
-      sum = _mm256_add_ps(sum, e);
+  for (size_t r = start_row; r < end_row; ++r) {
+    float *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      __m256 s = _mm256_loadu_ps(sum_vals + c);
+      __m256 v = _mm256_loadu_ps(row + c);
+      __m256 m = _mm256_loadu_ps(max_vals + c);
+      __m256 d = _mm256_sub_ps(v, m);    // x - max
+      __m256 e = exp256_ps(d);           // exp(x - max)
+      _mm256_storeu_ps(row + c, e);      // overwrite qk_out
+      s = _mm256_add_ps(s, e);           // sum += exp(x - max)
+      _mm256_storeu_ps(sum_vals + c, s); // update sum_vals
     }
-    _mm256_storeu_ps(&sum_vals[c], sum);
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      float e = std::exp(row[c] - max_vals[c]);
+      row[c] = e;
+      sum_vals[c] += e;
+    }
   }
 
-  for (size_t c = full_blocks; c < num_heads; ++c) {
-    float maxv = max_vals[c];
-    float sum = std::exp(sink[c] - maxv);
-    for (size_t r = 0; r < row_range; ++r) {
-      float &a = qk_out[(start_row + r) * num_heads + c];
-      a = std::exp(a - maxv); // overwrite qk_out
-      sum += a;
-    }
-    sum_vals[c] = sum;
+  // 3. calc 1/sum
+  // _mm256_div_ps is slow
+  // precalculate (1/sum) and then multiply is much faster
+  for (size_t c = 0; c < vec_end; c += 8) {
+    __m256 s = _mm256_loadu_ps(sum_vals + c);
+    s = rcp_ps(s); // sum = 1/sum
+    _mm256_storeu_ps(sum_vals + c, s);
   }
-  // 3. softmax = exp / sum (inplace)
-  for (size_t r = 0; r < row_range; ++r) {
-    for (size_t c = 0; c < full_blocks; c += 8) {
-      float *ptr = &qk_out[(start_row + r) * num_heads + c];
-      __m256 val = _mm256_loadu_ps(ptr); // already exp(x - max)
-      __m256 sumv = _mm256_loadu_ps(&sum_vals[c]);
-      __m256 soft = _mm256_div_ps(val, sumv);
-      _mm256_storeu_ps(ptr, soft);
+  for (size_t c = vec_end; c < num_heads; ++c) {
+    sum_vals[c] = 1 / sum_vals[c];
+  }
+
+  // 4. calc exp(x - max) * (1/sum)
+  for (size_t r = start_row; r < end_row; ++r) {
+    float *row = qk_out + (num_heads * r);
+    for (size_t c = 0; c < vec_end; c += 8) {
+      __m256 s = _mm256_loadu_ps(sum_vals + c); // 1/sum
+      __m256 v = _mm256_loadu_ps(row + c);      // exp(x - max)
+      __m256 o = _mm256_mul_ps(v, s);           // exp(x - max) * (1/sum)
+      _mm256_storeu_ps(row + c, o);             // overwrite qk_out
     }
-    for (size_t c = full_blocks; c < num_heads; ++c) {
-      qk_out[(start_row + r) * num_heads + c] /= sum_vals[c];
+    for (size_t c = vec_end; c < num_heads; ++c) {
+      row[c] *= sum_vals[c];
     }
   }
 
@@ -1311,121 +1372,13 @@ void softmax_row_inplace(float *qk_out, size_t start_row, size_t end_row,
 
 static void softmax_row(float *qk_out, size_t start_row, size_t end_row,
                         size_t num_heads) {
-  const size_t full_block = (num_heads / 8) * 8;
-
-  float *max_vals = new float[num_heads];
-  float *sum_vals = new float[num_heads];
-
-  // 1. Find Max along with col
-  for (size_t c = 0; c < num_heads; ++c) {
-    float max_val = -INFINITY;
-    for (size_t r = start_row; r < end_row; ++r) {
-      max_val = std::max(max_val, qk_out[r * num_heads + c]);
-    }
-    max_vals[c] = max_val;
-  }
-
-  // 2. Compute sum along with col (exp vectorized)
-  for (size_t c = 0; c < full_block; c += 8) {
-    __m256 sum = _mm256_setzero_ps();
-    for (size_t r = start_row; r < end_row; ++r) {
-      __m256 val = _mm256_loadu_ps(&qk_out[r * num_heads + c]);
-      __m256 maxv = _mm256_loadu_ps(&max_vals[c]);
-      __m256 sub = _mm256_sub_ps(val, maxv);
-      __m256 e = exp256_ps(sub);
-      sum = _mm256_add_ps(sum, e);
-    }
-    _mm256_storeu_ps(&sum_vals[c], sum);
-  }
-
-  for (size_t c = full_block; c < num_heads; ++c) {
-    float sum = 0.0f;
-    for (size_t r = start_row; r < end_row; ++r) {
-      sum += std::exp(qk_out[r * num_heads + c] - max_vals[c]);
-    }
-    sum_vals[c] = sum;
-  }
-
-  // 3. apply softmax
-  for (size_t r = start_row; r < end_row; ++r) {
-    for (size_t c = 0; c < full_block; c += 8) {
-      __m256 val = _mm256_loadu_ps(&qk_out[r * num_heads + c]);
-      __m256 maxv = _mm256_loadu_ps(&max_vals[c]);
-      __m256 sub = _mm256_sub_ps(val, maxv);
-      __m256 e = exp256_ps(sub);
-      __m256 sumv = _mm256_loadu_ps(&sum_vals[c]);
-      __m256 softmax = _mm256_div_ps(e, sumv);
-      _mm256_storeu_ps(&qk_out[r * num_heads + c], softmax);
-    }
-    for (size_t c = full_block; c < num_heads; ++c) {
-      qk_out[r * num_heads + c] =
-        std::exp(qk_out[r * num_heads + c] - max_vals[c]) / sum_vals[c];
-    }
-  }
-
-  delete[] max_vals;
-  delete[] sum_vals;
+  softmax_row_inplace(qk_out, start_row, end_row, num_heads);
 }
 
 static void softmax_row_with_sink(float *qk_out, size_t start_row,
                                   size_t end_row, size_t num_heads,
                                   float *sink) {
-  const size_t full_block = (num_heads / 8) * 8;
-
-  float *max_vals = new float[num_heads];
-  float *sum_vals = new float[num_heads];
-
-  // 1. Find Max along with col
-  for (size_t c = 0; c < num_heads; ++c) {
-    float max_val = -INFINITY;
-    for (size_t r = start_row; r < end_row; ++r) {
-      max_val = std::max(max_val, qk_out[r * num_heads + c]);
-    }
-    max_vals[c] = std::max(max_val, sink[c]);
-  }
-
-  // 2. Compute sum along with col (exp vectorized)
-  for (size_t c = 0; c < full_block; c += 8) {
-    __m256 maxv = _mm256_loadu_ps(&max_vals[c]);
-    __m256 sum = _mm256_loadu_ps(&sink[c]);
-    sum = _mm256_sub_ps(sum, maxv);
-    sum = exp256_ps(sum);
-    for (size_t r = start_row; r < end_row; ++r) {
-      __m256 val = _mm256_loadu_ps(&qk_out[r * num_heads + c]);
-      __m256 sub = _mm256_sub_ps(val, maxv);
-      __m256 e = exp256_ps(sub);
-      sum = _mm256_add_ps(sum, e);
-    }
-    _mm256_storeu_ps(&sum_vals[c], sum);
-  }
-
-  for (size_t c = full_block; c < num_heads; ++c) {
-    float sum = std::exp(sink[c] - max_vals[c]);
-    for (size_t r = start_row; r < end_row; ++r) {
-      sum += std::exp(qk_out[r * num_heads + c] - max_vals[c]);
-    }
-    sum_vals[c] = sum;
-  }
-
-  // 3. apply softmax
-  for (size_t r = start_row; r < end_row; ++r) {
-    for (size_t c = 0; c < full_block; c += 8) {
-      __m256 val = _mm256_loadu_ps(&qk_out[r * num_heads + c]);
-      __m256 maxv = _mm256_loadu_ps(&max_vals[c]);
-      __m256 sub = _mm256_sub_ps(val, maxv);
-      __m256 e = exp256_ps(sub);
-      __m256 sumv = _mm256_loadu_ps(&sum_vals[c]);
-      __m256 softmax = _mm256_div_ps(e, sumv);
-      _mm256_storeu_ps(&qk_out[r * num_heads + c], softmax);
-    }
-    for (size_t c = full_block; c < num_heads; ++c) {
-      qk_out[r * num_heads + c] =
-        std::exp(qk_out[r * num_heads + c] - max_vals[c]) / sum_vals[c];
-    }
-  }
-
-  delete[] max_vals;
-  delete[] sum_vals;
+  softmax_row_with_sink_inplace(qk_out, start_row, end_row, num_heads, sink);
 }
 
 template <>


### PR DESCRIPTION
### Summary of this PR:
* Rewrite softmax kernel for avx, neon
* Deprecate non-inplace softmax kernerl

### Optimizations
* Access array in row major order
Previous kernel accessed array in column major order, which increases cache miss rate.
* Vectorize code
Some logics didn't use simd even if it can be vectorized.
* Use reciprocal (FP32 only)
When calculating `exp(x-max)/sum`, direct dividing `sum` is slow. Instead, pre-calculate recipocal `1/sum` than multiplying it is much efficient.
* Deprecate non-inplace softmax kernel
Unlike its name, non-inplace kernel was designed to work same as inplace kernel. Its interface doesn't have destination parameter, in other words, it's inplace one. Furthermore, it calculates exp twice, which is the bottle neck in softmax.

### Future items
* Optimize exp logic
Since exp is the main bottle neck of softmax, there're still more room to optimize
  * reduce polynomial order
  * remove redundant logic
  For softmax, input is always non positive. Using this, we can remove overflow cutoff.
  * rewrite float16x8_t exp
  Currently, float16x8_t exp works as two float32x4_t exp logic sequentially. If we can make this logic with float16x8_t simd only, its latency and throughput would be highly increased.
  * apply loop unrolling
  
---
### Softmax latency Comparison
Qwen3-4b with 1K length input
| | Before this PR | After this PR | Ratio |
|:--:|:--:|:--:|:--:|
| avx prefill | 20989527.11 | 12423431.33 | 0.59 |
| avx decode | 471529.5056 | 422052.9592 | 0.90 |
| neon(fp16) prefill | 22316899.5 | 16427413.1388889 | 0.68 |
| neon(fp16) decode | 270753.7624 | 214167.623480903 | 0.79 |

---
### Update
Due to accuracy of FP16, use division instead of reciprocal approximation.
Following charts are the errors from the unittest.

* FP32
<img width="1069" height="553" alt="image" src="https://github.com/user-attachments/assets/b70cbc99-cefd-4135-9841-e3fe07dd32f4" />

* FP16
<img width="1831" height="873" alt="image" src="https://github.com/user-attachments/assets/3623bb37-b6a1-4afd-97cb-f96771773b33" />
