### PR TITLE
[transformer] add prefill log to embedding model

### DIFF
--- a/Applications/CausalLM/models/embedding.cpp
+++ b/Applications/CausalLM/models/embedding.cpp
@@ -242,12 +242,23 @@ std::vector<float *> Embedding::encode(const WSTR prompt,
 
   std::vector<float *> label; // Empty label for inference
 
+  auto start_prefill = std::chrono::high_resolution_clock::now();
+
   // Run incremental inference for the prefill stage
   // start: 0, end: input_len (process all tokens at once)
   // This performs a single forward pass for the entire prompt sequence to get
   // embeddings.
   std::vector<float *> output = model->incremental_inference(
     BATCH_SIZE, input, label, input_len, 0, input_len, false);
+
+  auto finish_prefill = std::chrono::high_resolution_clock::now();
+  auto prefill_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+    finish_prefill - start_prefill);
+
+  std::cout << "prefill: " << input_len << " tokens, "
+            << prefill_duration.count() << " ms, "
+            << ((double)input_len / prefill_duration.count() * 1000)
+            << " TPS\n";
 
   free(input_sample);
 


### PR DESCRIPTION
added prefill time log to embedding model like causal model

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>