### PR TITLE
[CausalLM] Fix memory leakage

### DIFF
--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -448,6 +448,11 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   if (init_len < INIT_SEQ_LEN)
     registerOutputs(tokenizer, id_list, init_len, eos_list);
 
+  // output should be deallocated after use
+  for (auto &out : output) {
+    delete[] out;
+  }
+
   auto finish_prefill = std::chrono::high_resolution_clock::now();
   auto prefill_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
     finish_prefill - start_prefill);
@@ -488,6 +493,11 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
       registerOutputs(tokenizer, ids_list, token_generation_idx, eos_list);
     }
     ++generation_cnt;
+
+    // output should be deallocated after use
+    for (auto out : output_interval) {
+      delete[] out;
+    }
 
     // check FINISH
     for (unsigned int j = 0; j < BATCH_SIZE; ++j) {

--- a/Applications/CausalLM/models/sentence_transformer.cpp
+++ b/Applications/CausalLM/models/sentence_transformer.cpp
@@ -199,6 +199,11 @@ void SentenceTransformer::run(const WSTR prompt, bool do_sample,
         std::cout << ", ...";
       std::cout << "] (Total DIM: " << DIM << ")" << std::endl;
     }
+
+    // output should be deallocated after use.
+    for (auto out : results) {
+      delete[] out;
+    }
   } catch (const std::exception &e) {
     std::cerr << "Error during embedding run: " << e.what() << std::endl;
   }

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -311,10 +311,12 @@ public:
    * @param[in] init_seq_len initial sequence length
    * @param[in] from current working step index
    * @param[in] to next working step index
-   * @param[in] output_hidden_state return last hidden state if true else return
-   * all hidden state
+   * @param[in] output_hidden_state (NYI) true to return all hidden state,
+   * false to return last hidden state
    * @retval list of output as float *
-   * @note The output memory must not be freed by the caller
+   * @note If output_hidden_state is false, the output memory must be freed by
+   * the caller after use. Otherwise, the output memory must not be freed by the
+   * caller.
    */
   virtual std::vector<float *>
   incremental_inference(unsigned int batch, const std::vector<float *> &input,

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -1159,43 +1159,29 @@ std::vector<float *> NeuralNetwork::incremental_inference(
   // auto end_increment = std::chrono::high_resolution_clock::now();
   std::vector<float *> output;
 
-  ///@note Always we take the first position of output
-  // unsigned int step = ((to - from) == 0) ? 0 : (to - from) - 1;
-  unsigned int step = 0;
-
   for (auto &out : output_tensors) {
     auto out_t = *out.get();
     float *last_out_buf_data;
 
     if (output_hidden_state) {
-      last_out_buf_data = out_t.getData();
-    } else {
-      last_out_buf_data = new float[batch_size * out_t.width()];
+      std::cout << "Warning: output_hidden_state is not supported yet.\n"
+                << "Returning last hidden state only...\n"
+                << "Please free output memory after use!";
+    }
+    const size_t buf_size = batch_size * out_t.getDim().getFeatureLen();
+    last_out_buf_data = new float[buf_size];
 
-      for (unsigned int batch = 0; batch < batch_size; ++batch) {
-        if (out->getDataType() == ml::train::TensorDim::DataType::FP16) {
+    if (out->getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
 
-          const _FP16 *out_t_batch_ptr =
-            out_t.getData<_FP16>() + batch * out_t.getDim().getFeatureLen() +
-            step * out_t.width();
-          scopy(out_t.width(), out_t_batch_ptr, 1,
-                last_out_buf_data + batch * out_t.width(), 1);
-
+      nntrainer::scopy(buf_size, out_t.getData<_FP16>(), 1, last_out_buf_data,
+                       1);
 #else
-          throw std::invalid_argument("Error: enable-fp16 is not set");
+      throw std::invalid_argument("Error: enable-fp16 is not set");
 #endif
-        } else if (out->getDataType() == ml::train::TensorDim::DataType::FP32) {
+    } else if (out->getDataType() == ml::train::TensorDim::DataType::FP32) {
 
-          const float *out_t_batch_ptr =
-            out_t.getData() + batch * out_t.getDim().getFeatureLen() +
-            step * out_t.width();
-          // std::memcpy( last_out_buf_data + batch * out_t.width(),
-          // out_t_batch_ptr, out_t.width()*sizeof(float));
-          scopy(out_t.width(), out_t_batch_ptr, 1,
-                last_out_buf_data + batch * out_t.width(), 1);
-        }
-      }
+      std::memcpy(last_out_buf_data, out_t.getData(), sizeof(float) * buf_size);
     }
 
     output.push_back(last_out_buf_data);

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -403,10 +403,12 @@ public:
    * @param[in] init_seq_len initial sequence length
    * @param[in] from current working step index
    * @param[in] to next working step index
-   * @param[in] output_hidden_state return last hidden state if true else return
-   * all hidden state
+   * @param[in] output_hidden_state (NYI) true to return all hidden state,
+   * false to return last hidden state only
    * @retval list of output as float *
-   * @note The output memory must not be freed by the caller
+   * @note If output_hidden_state is false, the output memory must be freed by
+   * the caller after use. Otherwise, the output memory must not be freed by the
+   * caller.
    */
   std::vector<float *>
   incremental_inference(unsigned int batch, const std::vector<float *> &input,


### PR DESCRIPTION
### Related issue
* #3783 

This PR resolves memory leakage for CausalLM(causallm, embedding).

### How to check
Run any causallm, embedding model with following flag.
```bash
meson setup build -Denable-transformer=true -Dbuildtype=debug -Db_sanitize=address
```
* Before this PR
<details>

```
Direct leak of 12154880 byte(s) in 20 object(s) allocated from:
    #0 0x77cc8cedfd28 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:98
    #1 0x77cc79718f2a in nntrainer::NeuralNetwork::incremental_inference(unsigned int, std::vector<float*, std::allocator<float*> > const&, std::vector<float*, std::allocator<float*> > const&, unsigned int, unsigned int, unsigned int, bool) /home/master/github/nntrainer/nntrainer/models/neuralnet.cpp:1173
    #2 0x77cc8a9daa0e in causallm::CausalLM::run(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /home/master/github/nntrainer/Applications/CausalLM/models/causal_lm.cpp:475
    #3 0x5c995ed72e9c in main /home/master/github/nntrainer/Applications/CausalLM/main.cpp:266
    #4 0x77cc88229d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Direct leak of 607744 byte(s) in 1 object(s) allocated from:
    #0 0x77cc8cedfd28 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:98
    #1 0x77cc79718f2a in nntrainer::NeuralNetwork::incremental_inference(unsigned int, std::vector<float*, std::allocator<float*> > const&, std::vector<float*, std::allocator<float*> > const&, unsigned int, unsigned int, unsigned int, bool) /home/master/github/nntrainer/nntrainer/models/neuralnet.cpp:1173
    #2 0x77cc8a9d70ad in causallm::CausalLM::run(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /home/master/github/nntrainer/Applications/CausalLM/models/causal_lm.cpp:440
    #3 0x5c995ed72e9c in main /home/master/github/nntrainer/Applications/CausalLM/main.cpp:266
    #4 0x77cc88229d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Direct leak of 8192 byte(s) in 1 object(s) allocated from:
    #0 0x77cc8cedefdf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x77cc8a9d2203 in causallm::CausalLM::run(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /home/master/github/nntrainer/Applications/CausalLM/models/causal_lm.cpp:376
    #2 0x5c995ed72e9c in main /home/master/github/nntrainer/Applications/CausalLM/main.cpp:266
    #3 0x77cc88229d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 12770816 byte(s) leaked in 22 allocation(s).
```
</details>

* After this PR
<details>

```
Direct leak of 8192 byte(s) in 1 object(s) allocated from:
    #0 0x7a3848cdefdf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7a38467d4273 in causallm::CausalLM::run(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /home/master/github/nntrainer/Applications/CausalLM/models/causal_lm.cpp:376
    #2 0x55a9276a0e9c in main /home/master/github/nntrainer/Applications/CausalLM/main.cpp:266
    #3 0x7a3844029d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 8192 byte(s) leaked in 1 allocation(s).
```
</details>

Note that remaining leakage is resolved in https://github.com/nntrainer/nntrainer/pull/3752

---
### Future work
This PR is a workaround for this issue. It'd be better to introduce another API.