### PR TITLE
Recent PR bug fixes

### DIFF
--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -1159,9 +1159,7 @@ std::vector<float *> NeuralNetwork::incremental_inference(
   // auto end_increment = std::chrono::high_resolution_clock::now();
   std::vector<float *> output;
 
-  ///@note Always we take the first position of output
-  // unsigned int step = ((to - from) == 0) ? 0 : (to - from) - 1;
-  unsigned int step = 0;
+  unsigned int step = ((to - from) == 0) ? 0 : (to - from) - 1;
 
   for (auto &out : output_tensors) {
     auto out_t = *out.get();
@@ -1172,13 +1170,14 @@ std::vector<float *> NeuralNetwork::incremental_inference(
     } else {
       last_out_buf_data = new float[batch_size * out_t.width()];
 
+      unsigned int effective_step = (out_t.getDim().height() == 1) ? 0 : step;
       for (unsigned int batch = 0; batch < batch_size; ++batch) {
         if (out->getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
 
           const _FP16 *out_t_batch_ptr =
             out_t.getData<_FP16>() + batch * out_t.getDim().getFeatureLen() +
-            step * out_t.width();
+            effective_step * out_t.width();
           scopy(out_t.width(), out_t_batch_ptr, 1,
                 last_out_buf_data + batch * out_t.width(), 1);
 
@@ -1189,7 +1188,7 @@ std::vector<float *> NeuralNetwork::incremental_inference(
 
           const float *out_t_batch_ptr =
             out_t.getData() + batch * out_t.getDim().getFeatureLen() +
-            step * out_t.width();
+            effective_step * out_t.width();
           // std::memcpy( last_out_buf_data + batch * out_t.width(),
           // out_t_batch_ptr, out_t.width()*sizeof(float));
           scopy(out_t.width(), out_t_batch_ptr, 1,

--- a/test/unittest/unittest_nntrainer_models.cpp
+++ b/test/unittest/unittest_nntrainer_models.cpp
@@ -11,6 +11,7 @@
  *
  */
 #include <algorithm>
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -1137,6 +1138,75 @@ TEST(nntrainerModels, loadFromLayersRecurrent_p) {
               expected_input_layers.at(i))
       << "at " << i;
   };
+}
+
+/**
+ * @brief Regression test for incremental_inference step selection.
+ *
+ * For sequence outputs, output_hidden_state=false must return the last step.
+ */
+TEST(nntrainerModels, incrementalInferenceReturnsLastStep_p) {
+  nntrainer::NeuralNetwork nn;
+
+  fc_softmax_mse_distribute.save_ini();
+  nn.load(fc_softmax_mse_distribute.getIniName(),
+          ml::train::ModelFormat::MODEL_FORMAT_INI);
+  fc_softmax_mse_distribute.erase_ini();
+
+  EXPECT_EQ(nn.compile(), ML_ERROR_NONE);
+  EXPECT_EQ(nn.initialize(), ML_ERROR_NONE);
+
+  auto in_dim = nn.getInputDimension();
+  auto out_dim = nn.getOutputDimension();
+  ASSERT_EQ(in_dim.size(), 1u);
+  ASSERT_EQ(out_dim.size(), 1u);
+  ASSERT_GT(out_dim[0].height(), 1u);
+
+  const unsigned int width = out_dim[0].width();
+  const unsigned int sequence_len = out_dim[0].height();
+  std::vector<float> input(in_dim[0].getDataLen(), 0.0f);
+  std::vector<float *> input_ptr{input.data()};
+  std::vector<float> first_step(width);
+  std::vector<float> last_step(width);
+
+  bool distinguished_steps = false;
+  for (unsigned int trial = 0; trial < 4; ++trial) {
+    for (unsigned int i = 0; i < input.size(); ++i) {
+      input[i] = static_cast<float>((trial + 1) * (i + 1));
+    }
+
+    auto full_hidden =
+      nn.incremental_inference(1, input_ptr, {}, sequence_len, 0, sequence_len,
+                               true);
+    ASSERT_EQ(full_hidden.size(), 1u);
+
+    for (unsigned int i = 0; i < width; ++i) {
+      first_step[i] = full_hidden[0][i];
+      last_step[i] = full_hidden[0][(sequence_len - 1) * width + i];
+    }
+
+    for (unsigned int i = 0; i < width; ++i) {
+      if (std::fabs(first_step[i] - last_step[i]) > 1e-5f) {
+        distinguished_steps = true;
+        break;
+      }
+    }
+    if (distinguished_steps)
+      break;
+  }
+
+  ASSERT_TRUE(distinguished_steps)
+    << "Failed to generate distinguishable first/last sequence outputs";
+
+  auto reduced =
+    nn.incremental_inference(1, input_ptr, {}, sequence_len, 0, sequence_len,
+                             false);
+  ASSERT_EQ(reduced.size(), 1u);
+
+  for (unsigned int i = 0; i < width; ++i) {
+    EXPECT_NEAR(reduced[0][i], last_step[i], 1e-5f)
+      << "Mismatch at width index " << i;
+  }
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Dependency of the PR
This PR fixes a regression introduced in PR #3737.

## Commits to be reviewed in this PR

<details><summary>Fix(nntrainer): Restore last step selection in incremental_inference</summary><br />

Fix(nntrainer): Restore last step selection in incremental_inference

This commit addresses a regression introduced in PR #3737 where `NeuralNetwork::incremental_inference()` incorrectly fixed the output step to `0`. This caused multi-token sequence outputs to return only the first token instead of the last.

A new unit test `nntrainerModels.incrementalInferenceReturnsLastStep_p` has been added to `test/unittest/unittest_nntrainer_models.cpp` to reproduce this issue.

The fix restores the original logic in `nntrainer/models/neuralnet.cpp`:
- If `height == 1`, select step `0`.
- Otherwise (for sequence outputs), select the last step (`height - 1`).

This ensures correct behavior for both single-step and multi-step incremental inferences.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Your Name <your_email@example.com>

</details>

### Summary

- Identified and fixed a regression in `NeuralNetwork::incremental_inference()` (introduced by PR #3737) where sequence outputs incorrectly returned the first step instead of the last.
- Added a dedicated unit test (`nntrainerModels.incrementalInferenceReturnsLastStep_p`) to reproduce the bug and verify the fix.

Signed-off-by: Your Name <your_email@example.com>

<div><a href="https://cursor.com/agents/bc-7a681cde-9e2c-450d-9386-b0e2cacf353e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a681cde-9e2c-450d-9386-b0e2cacf353e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->