### PR TITLE
[CausalLM] add option for build_tokenizer_android.sh

### DIFF
--- a/Applications/CausalLM/build_tokenizer_android.sh
+++ b/Applications/CausalLM/build_tokenizer_android.sh
@@ -77,7 +77,7 @@ cd "$BUILD_DIR/tokenizers-cpp"
 
 # Update submodules
 echo "Updating submodules..."
-git submodule update --init --recursive
+git submodule update --init --recursive --depth 1
 
 # Create build directory for specific ABI
 mkdir -p "build-android-$TARGET_ABI"
@@ -133,6 +133,8 @@ cmake .. \
     -DBUILD_SHARED_LIBS=OFF \
     -DTOKENIZERS_CPP_BUILD_TESTS=OFF \
     -DTOKENIZERS_CPP_BUILD_EXAMPLES=OFF \
+    -DMSGPACK_BUILD_TESTS=OFF \
+    -DMSGPACK_BUILD_EXAMPLES=OFF \
     -DCMAKE_VERBOSE_MAKEFILE=ON
 
 # Build the library


### PR DESCRIPTION


## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] add option for build_tokenizer_android.sh</summary><br />

- This commit adds a cmake option
- `-DMSGPACK_BUILD_TESTS=OFF` `-DMSGPACK_BUILD_EXAMPLES=OFF`
- git submodule init recursive depth = 1

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



### Summary

- This commit adds a cmake option
- `-DMSGPACK_BUILD_TESTS=OFF` `-DMSGPACK_BUILD_EXAMPLES=OFF`
- git submodule init recursive depth = 1

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
