### PR TITLE
Fix memory leaks in dataset and application paths (wait for #3801)

### DIFF
--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -23,10 +23,12 @@
 #include <algorithm>
 #include <app_context.h>
 #include <cmath>
+#include <cstdlib>
 #include <engine.h>
 #include <fstream>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <vector>
 
 #include <common.h>
@@ -372,8 +374,11 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   _input.clear();
 
   unsigned int init_len = init_input.size();
-  float *input_sample =
-    (float *)malloc(sizeof(float) * BATCH_SIZE * MAX_SEQ_LEN);
+  auto input_sample = std::unique_ptr<float, decltype(&free)>(
+    static_cast<float *>(malloc(sizeof(float) * BATCH_SIZE * MAX_SEQ_LEN)),
+    free);
+  NNTR_THROW_IF(input_sample == nullptr, std::bad_alloc)
+    << "failed to allocate input sample buffer";
   std::vector<bool> eos_list(BATCH_SIZE, false);
 
   unsigned int input_len = init_len;
@@ -381,7 +386,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
     for (unsigned int i = 0; i < input_len; ++i) {
-      input_sample[static_cast<size_t>(b) * MAX_SEQ_LEN + i] =
+      input_sample.get()[static_cast<size_t>(b) * MAX_SEQ_LEN + i] =
         static_cast<float>(init_input[i]);
       ids_history[static_cast<size_t>(b) * MAX_SEQ_LEN + i] = init_input[i];
     }
@@ -391,7 +396,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
    * PREFILL
    */
   std::vector<int64_t> token_ids;
-  input.push_back(input_sample);
+  input.push_back(input_sample.get());
 
   ///@note contains possible bug
   // std::vector<ml::train::TensorDim> input_dims;
@@ -460,7 +465,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   // Update generated token by prefill as an input
   for (unsigned int b = 0; b < BATCH_SIZE; ++b)
-    input_sample[static_cast<size_t>(b) * MAX_SEQ_LEN] =
+    input_sample.get()[static_cast<size_t>(b) * MAX_SEQ_LEN] =
       static_cast<float>(id_list[b]);
 
   auto start_generation = std::chrono::high_resolution_clock::now();
@@ -476,13 +481,13 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     std::vector<unsigned int> ids_list(generate(output_interval[0], do_sample));
     if (token_generation_idx < input_len) {
       for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
-        input_sample[static_cast<size_t>(b) * MAX_SEQ_LEN] =
+        input_sample.get()[static_cast<size_t>(b) * MAX_SEQ_LEN] =
           static_cast<float>(init_input[token_generation_idx - SYS_PROMP_LEN]);
       }
       registerOutputs(tokenizer, ids_list, token_generation_idx, eos_list);
     } else {
       for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
-        input_sample[static_cast<size_t>(b) * MAX_SEQ_LEN] =
+        input_sample.get()[static_cast<size_t>(b) * MAX_SEQ_LEN] =
           static_cast<float>(ids_list[b]);
       }
       registerOutputs(tokenizer, ids_list, token_generation_idx, eos_list);
@@ -506,7 +511,6 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     }
 
     if (is_finish) {
-      free(input_sample);
       break;
     }
   }

--- a/Applications/LLaMA/jni/custom_multi_head_attention_layer.cpp
+++ b/Applications/LLaMA/jni/custom_multi_head_attention_layer.cpp
@@ -351,7 +351,7 @@ void MultiHeadAttentionLayer::finalize(InitLayerContext &context) {
    * check query width and key width
    *
    */
-  if (freqs_cos == nullptr)
+  if (freqs_cos.empty())
     precompute_freqs(projected_key_dim_prop, max_timestep);
 }
 

--- a/Applications/LLaMA/jni/custom_multi_head_attention_layer.h
+++ b/Applications/LLaMA/jni/custom_multi_head_attention_layer.h
@@ -140,8 +140,8 @@ private:
 
   inline static unsigned int layer_progress;
 
-  inline static std::vector<std::vector<float>> *freqs_cos = {};
-  inline static std::vector<std::vector<float>> *freqs_sin = {};
+  inline static std::vector<std::vector<float>> freqs_cos = {};
+  inline static std::vector<std::vector<float>> freqs_sin = {};
   inline static std::vector<float> freqs;
 
   /**
@@ -151,36 +151,34 @@ private:
    * @param[in] theta rotary angle
    */
   void precompute_freqs(int dim, unsigned int seq_len, float theta = 10000.0) {
-    if (freqs_cos == nullptr) {
+    if (freqs_cos.empty()) {
       unsigned int half_ = dim / 2;
       for (unsigned int i = 0; i < half_; ++i) {
         freqs.push_back(1.0 /
                         (std::pow(theta, (2 * i) / static_cast<float>(dim))));
       }
 
-      auto cos = new std::vector<std::vector<float>>();
-      cos->assign(seq_len, std::vector<float>(dim, 0));
+      std::vector<std::vector<float>> cos(seq_len, std::vector<float>(dim, 0));
 
-      auto sin = new std::vector<std::vector<float>>();
-      sin->assign(seq_len, std::vector<float>(dim, 0));
+      std::vector<std::vector<float>> sin(seq_len, std::vector<float>(dim, 0));
 
       for (unsigned int i = 0; i < seq_len; ++i) {
 #ifdef USE_NEON
-        calc_trigonometric_vals_dup(half_, freqs.data(), (*cos)[i].data(),
-                                    (*sin)[i].data(), i);
+        calc_trigonometric_vals_dup(half_, freqs.data(), cos[i].data(),
+                                    sin[i].data(), i);
 #else
         for (unsigned int j = 0; j < half_; ++j) {
           float angle = i * freqs[j];
-          (*cos)[i][j] = std::cos(angle);
-          (*cos)[i][j + half_] = std::cos(angle); // repeated 2 times
+          cos[i][j] = std::cos(angle);
+          cos[i][j + half_] = std::cos(angle); // repeated 2 times
 
-          (*sin)[i][j] = std::sin(angle);
-          (*sin)[i][j + half_] = std::sin(angle); // repeated 2 times
+          sin[i][j] = std::sin(angle);
+          sin[i][j + half_] = std::sin(angle); // repeated 2 times
         }
 #endif
       }
-      freqs_cos = cos;
-      freqs_sin = sin;
+      freqs_cos = std::move(cos);
+      freqs_sin = std::move(sin);
     }
   }
 
@@ -225,8 +223,8 @@ private:
         for (unsigned int c = 0; c < in.channel(); c++) {
           for (unsigned int h = 0; h < in.height(); h++) {
             if (from < max_timestep) {
-              cos_ = &(*freqs_cos)[from + h];
-              sin_ = &(*freqs_sin)[from + h];
+              cos_ = &freqs_cos[from + h];
+              sin_ = &freqs_sin[from + h];
             }
 
             for (unsigned int w = 0; w < in.width(); w = w + dim) {
@@ -253,8 +251,8 @@ private:
         for (unsigned int c = 0; c < in.channel(); c++) {
           for (unsigned int h = 0; h < in.height(); h++) {
             if (from < max_timestep) {
-              cos_ = &(*freqs_cos)[from + h];
-              sin_ = &(*freqs_sin)[from + h];
+              cos_ = &freqs_cos[from + h];
+              sin_ = &freqs_sin[from + h];
             }
             for (unsigned int w = 0; w < in.width(); w = w + dim) {
 #ifdef USE_NEON

--- a/Applications/utils/npy_reader/npy_reader.cpp
+++ b/Applications/utils/npy_reader/npy_reader.cpp
@@ -79,6 +79,8 @@ void NpyReader::read_npy_file(const char *file_path) {
   char *header_pos = header;
   if (*header_pos != '{') {
     ml_loge("Filed to read numpy file");
+    free(header);
+    fclose(file);
     return;
   }
 
@@ -99,6 +101,8 @@ void NpyReader::read_npy_file(const char *file_path) {
         header_pos += 3;
         if (*header_pos = !'(') {
           ml_loge("File to read numpy file");
+          free(header);
+          fclose(file);
           return;
         }
         ++header_pos;

--- a/nntrainer/dataset/dir_data_producers.cpp
+++ b/nntrainer/dataset/dir_data_producers.cpp
@@ -37,21 +37,21 @@
  */
 static void readImage(const std::string path, float *input, unsigned int width,
                       unsigned int height) {
-  FILE *f = fopen(path.c_str(), "rb");
+  std::unique_ptr<FILE, decltype(&fclose)> f(fopen(path.c_str(), "rb"), fclose);
 
   if (f == nullptr)
     throw std::invalid_argument("Cannot open file: " + path);
 
   unsigned char info[54];
-  size_t result = fread(info, sizeof(unsigned char), 54, f);
+  size_t result = fread(info, sizeof(unsigned char), 54, f.get());
   NNTR_THROW_IF(result != 54, std::invalid_argument)
     << "Cannot read bmp header";
 
   size_t row_padded = (width * 3 + 3) & (~3);
-  unsigned char *data = new unsigned char[row_padded];
+  std::vector<unsigned char> data(row_padded);
 
   for (unsigned int i = 0; i < height; i++) {
-    result = fread(data, sizeof(unsigned char), row_padded, f);
+    result = fread(data.data(), sizeof(unsigned char), row_padded, f.get());
     NNTR_THROW_IF(result != row_padded, std::invalid_argument)
       << "Cannot read bmp pixel data";
 
@@ -64,9 +64,6 @@ static void readImage(const std::string path, float *input, unsigned int width,
       input[(height * width) * 2 + height * i + j] = (float)data[j * 3];
     }
   }
-
-  delete[] data;
-  fclose(f);
 }
 
 namespace nntrainer {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Dependency of the PR

- None

## Commits to be reviewed in this PR

<details><summary>e0da3fea</summary><br />

dataset: fix readImage exception-path leak

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Cursor Agent <cursoragent@cursor.com>

</details>

<details><summary>837dce4f</summary><br />

causallm: fix input_sample leak across returns

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Cursor Agent <cursoragent@cursor.com>

</details>

<details><summary>50419c98</summary><br />

npy_reader: close/free on early-return error paths

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Cursor Agent <cursoragent@cursor.com>

</details>

<details><summary>b5c019ea</summary><br />

llama-mha: remove static rotary heap leak

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Cursor Agent <cursoragent@cursor.com>

</details>

### Summary

- Rewrote each memory-leak commit message to include bug cause and concrete fix details.
- Added Signed-off-by footer to every rewritten commit.

Signed-off-by: Cursor Agent <cursoragent@cursor.com>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c9e5d76-bac6-45ca-a22b-ca61c09b09ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c9e5d76-bac6-45ca-a22b-ca61c09b09ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

