### PR TITLE
Fix ErrorNotification exception message construction

### DIFF
--- a/nntrainer/nntrainer_error.h
+++ b/nntrainer/nntrainer_error.h
@@ -83,7 +83,7 @@ namespace exception {
  * @brief Error Notification class, error is thrown when the class is destroyed.
  * DO NOT use this outside as this contains throwing destructor.
  *
- * @tparam Err Error type that except cstring as an argument.
+ * @tparam Err Error type that accepts std::string (or compatible) argument.
  */
 template <typename Err,
           typename std::enable_if_t<std::is_base_of<std::exception, Err>::value,
@@ -122,7 +122,8 @@ public:
         std::cerr << "Exception during cleanup: " << e.what() << '\n';
       }
     }
-    throw Err(ss.str().c_str());
+    const auto error_msg = ss.str();
+    throw Err(error_msg);
   }
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Dependency of the PR
- None

## Commits to be reviewed in this PR

<details><summary>cd00f094</summary><br />

Fix ErrorNotification message construction

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Cursor Agent <cursoragent@cursor.com>

</details>

### Summary
- Replace `throw Err(ss.str().c_str());` with `std::string`-based construction to avoid temporary `c_str()` usage.
- Update the template documentation to state `std::string` compatibility for `Err`.

Signed-off-by: Cursor Agent <cursoragent@cursor.com>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2921b0f3-c472-4903-a7e2-628784ebc321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2921b0f3-c472-4903-a7e2-628784ebc321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

