### PR TITLE
[CausalLM] fix mmap read in tie-word-embedding

### DIFF
--- a/Applications/CausalLM/build_android.sh
+++ b/Applications/CausalLM/build_android.sh
@@ -94,7 +94,7 @@ if [ ! -f "$NNTRAINER_ROOT/builddir/android_build_result/lib/arm64-v8a/libnntrai
     if [ -d "$NNTRAINER_ROOT/builddir" ]; then
         rm -rf builddir
     fi
-    ./tools/package_android.sh -Dmmap-read=false
+    ./tools/package_android.sh
 else
     log_info "nntrainer for Android already built (skipping)"
 fi

--- a/Applications/CausalLM/layers/tie_word_embedding.cpp
+++ b/Applications/CausalLM/layers/tie_word_embedding.cpp
@@ -357,6 +357,27 @@ void TieWordEmbedding::read(
   }
 }
 
+void TieWordEmbedding::read(
+  nntrainer::ReadSource src, nntrainer::RunLayerContext &context, bool opt_var,
+  ml::train::ExecutionMode mode, bool trainable,
+  nntrainer::TensorDim::DataType definedWeightDataType, bool fsu,
+  size_t start_offset, bool read_from_offset) {
+
+  // Only read when mode is embedding
+  if (mode_ == mode::embedding) {
+    for (unsigned int i = 0; i < context.getNumWeights(); ++i) {
+      /// @note shared weights are only be read at the first acecss
+      if (context.isGradientFirstAccess(i)) {
+        context.getWeight(i).read(src);
+        if (context.isMixedPrecision(i) && trainable &&
+            !context.getWeightFP32(i).empty()) {
+          context.getWeightFP32(i).copyData(context.getWeight(i));
+        }
+      }
+    }
+  }
+}
+
 void TieWordEmbedding::save(std::ofstream &file,
                             nntrainer::RunLayerContext &run_context,
                             bool opt_var, ml::train::ExecutionMode mode,

--- a/Applications/CausalLM/layers/tie_word_embedding.h
+++ b/Applications/CausalLM/layers/tie_word_embedding.h
@@ -122,6 +122,16 @@ public:
                        int file_fd = -1) override;
 
   /**
+   * @copydoc Layer::read() (ReadSource/mmap variant)
+   */
+  WIN_EXPORT void read(nntrainer::ReadSource src,
+                       nntrainer::RunLayerContext &context, bool opt_var,
+                       ml::train::ExecutionMode mode, bool trainable,
+                       nntrainer::TensorDim::DataType definedWeightDataType,
+                       bool fsu, size_t start_offset = 0,
+                       bool read_from_offset = false) override;
+
+  /**
    * @copydic Layer::save()
    */
   WIN_EXPORT void save(std::ofstream &file,

--- a/meson.build
+++ b/meson.build
@@ -143,12 +143,7 @@ if get_option('enable-npu')
 endif
 
 if get_option('mmap-read')
-  if get_option('enable-transformer')
-    message('mmap-read cannot be enabled with enable-transformer. mmap-read is turned off.')
-    extra_defines += '-DMMAP_READ=0'
-  else
     extra_defines += '-DMMAP_READ=1'
-  endif
 else
     extra_defines += '-DMMAP_READ=0'
 endif


### PR DESCRIPTION

## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>causallm/fix-tie-word-embedding-mmap</summary><br />

- This commit fixes the bugs in tie-word-embedding
- Tie-word-embedding didn't support read with mmap before.
- This commit adds read with mmap and remove enforced flag of mmap disablement when enable-transformer is enabled


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



### Summary

- This commit fixes the bugs in tie-word-embedding
- Tie-word-embedding didn't support read with mmap before.
- This commit adds read with mmap and remove enforced flag of mmap disablement when enable-transformer is enabled



Signed-off-by: Eunju Yang <ej.yang@samsung.com>
