### PR TITLE
[CausalLM] log error of unknown architecture

### DIFF
--- a/Applications/CausalLM/factory.h
+++ b/Applications/CausalLM/factory.h
@@ -14,6 +14,7 @@
 #ifndef __CAUSALLM_FACTORY_H__
 #define __CAUSALLM_FACTORY_H__
 
+#include <ostream>
 #include <transformer.h>
 #include <unordered_map>
 
@@ -44,6 +45,12 @@ public:
       return (it->second)(cfg, generation_cfg, nntr_cfg);
     }
     return nullptr;
+  }
+
+  void printRegistered(std::ostream &os) const {
+    for (const auto &pair : creators) {
+      os << "\n\t" << pair.first;
+    }
   }
 
 private:

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -266,6 +266,13 @@ int main(int argc, char *argv[]) {
 
     auto model = causallm::Factory::Instance().create(architecture, cfg,
                                                       generation_cfg, nntr_cfg);
+    if (!model) {
+      std::cerr << "Unknown architecture: " << architecture << std::endl;
+      std::cerr << "Registered architectures:";
+      causallm::Factory::Instance().printRegistered(std::cerr);
+      std::cerr << std::endl;
+      return EXIT_FAILURE;
+    }
     model->initialize();
     model->load_weight(weight_file);
 


### PR DESCRIPTION

## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] log error of unknown architecture</summary><br />

- This commit adds code lines to show error message for unknown architecture.
- This commit adds utility function to print the list of registered models


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


### Summary
- This commit adds code lines to show error message for unknown architecture.
- This commit adds utility function to print the list of registered models


Signed-off-by: Eunju Yang <ej.yang@samsung.com>
