### PR TITLE
[backend] read OMP_NUM_THREADS env var at runtime

### DIFF
--- a/nntrainer/utils/thread_manager.h
+++ b/nntrainer/utils/thread_manager.h
@@ -89,14 +89,17 @@ private:
    * @brief return number of compute worker threads
    * priority order:
    *   1. environment variable NNTR_NUM_THREADS
-   *   2. compile flag NNTR_NUM_THREADS
-   *   3. std::thread::hardware_concurrency() / 2
+   *   2. environment variable OMP_NUM_THREADS
+   *   3. compile flag NNTR_NUM_THREADS
+   *   4. std::thread::hardware_concurrency() / 2
    */
   static uint32_t defaultComputeThreads() {
-    auto nntr_num_threads = std::getenv("NNTR_NUM_THREADS");
-    if (nntr_num_threads) {
-      return static_cast<uint32_t>(std::stoul(nntr_num_threads));
-    }
+    uint32_t env_threads = 0;
+    if (readThreadCountFromEnv("NNTR_NUM_THREADS", env_threads))
+      return env_threads;
+
+    if (readThreadCountFromEnv("OMP_NUM_THREADS", env_threads))
+      return env_threads;
 
 #if defined(NNTR_NUM_THREADS) && NNTR_NUM_THREADS > 0
     return NNTR_NUM_THREADS;
@@ -105,6 +108,18 @@ private:
     uint32_t hw = std::thread::hardware_concurrency();
     return hw > 0 ? hw / 2 : 1;
 #endif
+  }
+
+  /**
+   * @brief read thread count from an environment variable
+   */
+  static bool readThreadCountFromEnv(const char *name, uint32_t &thread_count) {
+    const char *value = std::getenv(name);
+    if (!value)
+      return false;
+
+    thread_count = static_cast<uint32_t>(std::stoul(value));
+    return true;
   }
 };
 

--- a/test/unittest/unittest_thread_manager.cpp
+++ b/test/unittest/unittest_thread_manager.cpp
@@ -13,14 +13,67 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
 #include <numeric>
 #include <stdexcept>
+#include <string>
 #include <thread>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 #include <thread_manager.h>
+
+namespace {
+
+/**
+ * @brief Temporarily set or unset an environment variable.
+ */
+class ScopedEnvVar {
+public:
+  ScopedEnvVar(const char *name, const char *value) : name(name) {
+    const char *current = std::getenv(name);
+    if (current) {
+      had_value = true;
+      old_value = current;
+    }
+
+    if (value)
+      set(name, value);
+    else
+      unset(name);
+  }
+
+  ~ScopedEnvVar() {
+    if (had_value)
+      set(name.c_str(), old_value.c_str());
+    else
+      unset(name.c_str());
+  }
+
+private:
+  static void set(const char *name, const char *value) {
+#if defined(_WIN32)
+    _putenv_s(name, value);
+#else
+    setenv(name, value, 1);
+#endif
+  }
+
+  static void unset(const char *name) {
+#if defined(_WIN32)
+    _putenv_s(name, "");
+#else
+    unsetenv(name);
+#endif
+  }
+
+  std::string name;
+  bool had_value = false;
+  std::string old_value;
+};
+
+} // namespace
 
 // ─── ThreadManager parallel_for Tests ───────────────────────
 
@@ -103,6 +156,22 @@ TEST(ThreadManager, ThreadCounts) {
   if (hw > 1) {
     EXPECT_LE(tm.getComputeThreadCount(), hw);
   }
+}
+
+TEST(ThreadManagerConfig, OmpNumThreadsFallback) {
+  ScopedEnvVar nntr_num_threads("NNTR_NUM_THREADS", nullptr);
+  ScopedEnvVar omp_num_threads("OMP_NUM_THREADS", "1");
+
+  nntrainer::ThreadManagerConfig config;
+  EXPECT_EQ(config.compute_threads, 1u);
+}
+
+TEST(ThreadManagerConfig, NntrNumThreadsOverridesOmp) {
+  ScopedEnvVar nntr_num_threads("NNTR_NUM_THREADS", "2");
+  ScopedEnvVar omp_num_threads("OMP_NUM_THREADS", "1");
+
+  nntrainer::ThreadManagerConfig config;
+  EXPECT_EQ(config.compute_threads, 2u);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[backend] read OMP_NUM_THREADS env var at runtime</summary><br />

- Previously, OMP_NUM_THREADS was only a compile-time macro (-DOMP_NUM_THREADS=1) baked into the binary by the Android build script.
- Create omp_setting.h in cpu_backend/ as a shared header
- Add get_runtime_omp_num_threads() and GEMM/GEMV thread helpers
- Add set_runtime_omp_num_threads() for dynamic override support
- Update neon_setting.h to be a thin wrapper including omp_setting.h

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



### Summary

- Previously, OMP_NUM_THREADS was only a compile-time macro (-DOMP_NUM_THREADS=1) baked into the binary by the Android build script.
- This PR makes the backend to read OMP_NUM_THREADS dynamically

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
