### PR TITLE
[Wait for #3804] Fix/read offset shared tensor

### DIFF
--- a/Applications/CausalLM/layers/tie_word_embedding.cpp
+++ b/Applications/CausalLM/layers/tie_word_embedding.cpp
@@ -347,7 +347,7 @@ void TieWordEmbedding::read(
     for (unsigned int i = 0; i < context.getNumWeights(); ++i) {
       /// @note shared weights are only be read at the first acecss
       if (context.isGradientFirstAccess(i)) {
-        context.getWeight(i).read(file);
+        context.getWeight(i).read(file, start_offset, read_from_offset);
         if (context.isMixedPrecision(i) && trainable &&
             !context.getWeightFP32(i).empty()) {
           context.getWeightFP32(i).copyData(context.getWeight(i));
@@ -368,7 +368,7 @@ void TieWordEmbedding::read(
     for (unsigned int i = 0; i < context.getNumWeights(); ++i) {
       /// @note shared weights are only be read at the first acecss
       if (context.isGradientFirstAccess(i)) {
-        context.getWeight(i).read(src);
+        context.getWeight(i).read(src, start_offset, read_from_offset);
         if (context.isMixedPrecision(i) && trainable &&
             !context.getWeightFP32(i).empty()) {
           context.getWeightFP32(i).copyData(context.getWeight(i));

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -699,9 +699,19 @@ void NeuralNetwork::load(const std::string &file_path,
 
   size_t start_from = 0;
   std::vector<std::pair<size_t, size_t>> file_offset;
+  std::unordered_set<const Tensor *> visited_weights;
   for (auto iter = model_graph.cbegin(); iter != model_graph.cend(); iter++) {
     auto weights = (*iter)->getRunContext().getWeights();
     for (auto weight : weights) {
+      // Shared weights (e.g., TieWordEmbedding) reference the same Tensor
+      // object via requestOrExtend. Calling setFileOffset on the second
+      // occurrence overwrites the correct offset by the first.
+      // Skip duplicates so that:
+      // 1. file_offset is only set once (at the position where save writes)
+      // 2. start_from is only advanced once (matching actual file layout)
+      if (!visited_weights.insert(&weight->getVariableRef()).second) {
+        continue;
+      }
       size_t size = weight->getVariable().getMemoryBytes();
       auto tensor_data_type = weight->getDim().getDataType();
       weight->getVariableRef().setFileOffset(start_from);


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[neuralnet] fix read offset twice (shared tensor) </summary><br />

- This commit fixes the case where shared tensors are read twice.
- This commit updates neuralnet's load function to skip if the read
  operation is called more than twice.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



### Summary

- This PR fixes neuralnet.cpp's load function to avoid unexpected offset calaulcation multiple times.
- This PR fixes the issue mentioned in #3804. (cc: @jaemini-shin )

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
