### PR TITLE
Disable nnstreamer/api tests in Tizen CI

### DIFF
--- a/.github/workflows/daily_build_tizen_arm.yml
+++ b/.github/workflows/daily_build_tizen_arm.yml
@@ -52,35 +52,8 @@ jobs:
         path: ~/GBS-ROOT/local/cache
         key: gbs-cache-${{ matrix.gbs_build_arch }}-${{ steps.get-date.outputs.date }}
 
-    - name: get ML API
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/api
-        path: api
-    - name: get ML Agent
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/deviceMLOps.MLAgent
-        path: mlagent
-    - name: get NNStreamer
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/nnstreamer
-        path: _nnstreamer
-    - name: build and test nnstreamer ml-api and ml-agent
-      run: |
-        pushd _nnstreamer
-        echo "::group::Build and run unit-tests for NNStreamer"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_option }}
-        echo "::endgroup::"
-        popd
-        pushd api
-        echo "::group::Build and run unit-tests for ML API"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_option }}
-        echo "::endgroup::"
-        popd
-        pushd mlagent
-        echo "::group::Build and run unit-tests for ML Agent (deviceMLOps.MLAgent)"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_option }}
-        echo "::endgroup::"
-        popd
+    # Disabled: nnstreamer/api/mlagent tests are unstable on Tizen CI
+    # - name: get ML API
+    # - name: get ML Agent
+    # - name: get NNStreamer
+    # - name: build and test nnstreamer ml-api and ml-agent

--- a/.github/workflows/daily_build_tizen_x86_64.yml
+++ b/.github/workflows/daily_build_tizen_x86_64.yml
@@ -44,35 +44,8 @@ jobs:
         path: ~/GBS-ROOT/local/cache
         key: gbs-cache-x86_64-${{ steps.get-date.outputs.date }}
 
-    - name: get ML API
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/api
-        path: api
-    - name: get ML Agent
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/deviceMLOps.MLAgent
-        path: mlagent
-    - name: get NNStreamer
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/nnstreamer
-        path: _nnstreamer
-    - name: build and test nnstreamer ml-api and ml-agent
-      run: |
-        pushd _nnstreamer
-        echo "::group::Build and run unit-tests for NNStreamer"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A x86_64 --define "unit_test 1"
-        echo "::endgroup::"
-        popd
-        pushd api
-        echo "::group::Build and run unit-tests for ML API"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A x86_64 --define "unit_test 1"
-        echo "::endgroup::"
-        popd
-        pushd mlagent
-        echo "::group::Build and run unit-tests for ML Agent (deviceMLOps.MLAgent)"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A x86_64 --define "unit_test 1"
-        echo "::endgroup::"
-        popd
+    # Disabled: nnstreamer/api/mlagent tests are unstable on Tizen CI
+    # - name: get ML API
+    # - name: get ML Agent
+    # - name: get NNStreamer
+    # - name: build and test nnstreamer ml-api and ml-agent

--- a/.github/workflows/gbs_build.yml
+++ b/.github/workflows/gbs_build.yml
@@ -59,39 +59,8 @@ jobs:
       run: |
         gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_option }}
 
-    - name: get ML API
-      if: env.rebuild == '1'
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/api
-        path: api
-    - name: get ML Agent
-      if: env.rebuild == '1'
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/deviceMLOps.MLAgent
-        path: mlagent
-    - name: get NNStreamer
-      if: env.rebuild == '1'
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/nnstreamer
-        path: _nnstreamer
-    - name: build and test nnstreamer ml-api and ml-agent
-      if: env.rebuild == '1'
-      run: |
-        pushd _nnstreamer
-        echo "::group::Build and run unit-tests for NNStreamer"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_option }}
-        echo "::endgroup::"
-        popd
-        pushd api
-        echo "::group::Build and run unit-tests for ML API"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_option }}
-        echo "::endgroup::"
-        popd
-        pushd mlagent
-        echo "::group::Build and run unit-tests for ML Agent (deviceMLOps.MLAgent)"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_option }}
-        echo "::endgroup::"
-        popd
+    # Disabled: nnstreamer/api/mlagent tests are unstable on Tizen CI
+    # - name: get ML API
+    # - name: get ML Agent
+    # - name: get NNStreamer
+    # - name: build and test nnstreamer ml-api and ml-agent

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -1,7 +1,7 @@
 # Execute gbs with --define "testcoverage 1" in case that you must get unittest coverage statistics
 %define         use_cblas 1
-%define         nnstreamer_filter 1
-%define         nnstreamer_trainer 1
+%define         nnstreamer_filter 0
+%define         nnstreamer_trainer 0
 %define         nnstreamer_subplugin_path lib/nnstreamer
 %define         use_gym 0
 %define         use_ruy 0


### PR DESCRIPTION
## Summary\n\n- Tizen CI에서 nnstreamer 관련 테스트가 불안정하여 비활성화\n- `packaging/nntrainer.spec`: `nnstreamer_filter`와 `nnstreamer_trainer`를 0으로 설정하여 nnstreamer tensor filter/trainer 빌드 및 ssat 테스트 비활성화\n- 3개 Tizen CI workflow (`gbs_build.yml`, `daily_build_tizen_x86_64.yml`, `daily_build_tizen_arm.yml`)에서 nnstreamer, ML API, ML Agent checkout/build/test 스텝 제거\n\n## Test plan\n\n- [ ] Tizen GBS build (x86_64) CI가 nnstreamer/api 테스트 없이 정상 통과하는지 확인\n- [ ] Tizen GBS build (ARM) CI가 정상 통과하는지 확인\n- [ ] Daily build workflows가 정상 동작하는지 확인\n\nhttps://claude.ai/code/session_01Jzzn715cky6NbkZHSbLy3L