### PR TITLE
[GPU Backend] OpenCL Kernel for Flash attention both fp32 and fp16 version

### DIFF
--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -212,6 +212,7 @@ void ClContext::initBlasClKernels() {
   registerClKernel(hgemm_trans_ab_kernel, "sgemm_cl_transAB_fp16");
   registerClKernel(addition_fp16_kernel, "addition_cl_fp16");
   registerClKernel(hscal_kernel, "sscal_cl_fp16");
+  registerClKernel(flash_attention_fp16_kernel, "flash_attention_fp16");
 #endif
   blas_kernels_initialized = true;
 }

--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -195,6 +195,7 @@ void ClContext::initBlasClKernels() {
   registerClKernel(transpose_16bit_kernel, "kernel_transpose_16");
   registerClKernel(transpose_32bit_16bit_kernel, "kernel_transpose_32_16");
   registerClKernel(q4_0_ab_bi_8x4_kernel, "kernel_mul_mat_Ab_Bi_8x4");
+  registerClKernel(flash_attention_fp32_kernel, "flash_attention_fp32");
 
   // register INT4 computation kernels
   registerClKernel(int4_gemv_kernel, "fully_connected_gpu_int4_gemv");

--- a/nntrainer/tensor/cl_operations/cl_kernels/flash_attention_fp16.cl
+++ b/nntrainer/tensor/cl_operations/cl_kernels/flash_attention_fp16.cl
@@ -1,0 +1,325 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+#define SOFTMAX_MIN -1e4h
+
+// Local memory size - adjust based on device capabilities
+#define LOCAL_SIZE 256
+
+__kernel void flash_attention_fp16(__global const half *query,
+                                   __global const half *key,
+                                   __global const half *value,
+                                   __global half *output,
+                                   const int seqlen_q,
+                                   const int seqlen_k,
+                                   const int head_dim,
+                                   const int num_heads_q,
+                                   const int num_heads_kv,
+                                   const int batch,
+                                   const half scale) {
+  
+  const int total_work_items = batch * num_heads_q * seqlen_q;
+  const int global_id = get_global_id(0);
+  
+  // Local memory for caching query values
+  __local half local_query[LOCAL_SIZE];
+  
+  if (global_id >= total_work_items) return;
+  
+  // Calculate indices
+  const int batch_id = global_id / (num_heads_q * seqlen_q);
+  const int head_batch_id = global_id % (num_heads_q * seqlen_q);
+  const int head_id = head_batch_id / seqlen_q;
+  const int q_id = head_batch_id % seqlen_q;
+  
+  // For GQA, map query head to corresponding key/value head
+  const int kv_head_id = head_id * num_heads_kv / num_heads_q;
+  
+  // Calculate offsets for query (per head)
+  const int query_batch_offset = batch_id * num_heads_q * seqlen_q * head_dim;
+  const int query_head_offset = query_batch_offset + head_id * seqlen_q * head_dim;
+  const int q_offset = query_head_offset + q_id * head_dim;
+  
+  // Calculate offsets for key/value (per kv_head)
+  const int kv_batch_offset = batch_id * num_heads_kv * seqlen_k * head_dim;
+  const int kv_head_offset = kv_batch_offset + kv_head_id * seqlen_k * head_dim;
+  
+  // Cache query values in local memory for better reuse
+  const int local_size = get_local_size(0);
+  const int local_id = get_local_id(0);
+  
+  // Preload query values into local memory in chunks
+  for (int d = local_id; d < head_dim; d += local_size) {
+    local_query[d] = query[q_offset + d];
+  }
+  barrier(CLK_LOCAL_MEM_FENCE);
+  
+  half max_val = SOFTMAX_MIN;
+  
+  // First pass: compute max for numerical stability
+  // Process in chunks of 4 for better vectorization
+  int k_id = 0;
+  for (; k_id < seqlen_k - 3; k_id += 4) {
+    half4 sums = (half4)(0.0h);
+    const int k_offset_0 = kv_head_offset + (k_id + 0) * head_dim;
+    const int k_offset_1 = kv_head_offset + (k_id + 1) * head_dim;
+    const int k_offset_2 = kv_head_offset + (k_id + 2) * head_dim;
+    const int k_offset_3 = kv_head_offset + (k_id + 3) * head_dim;
+    
+    // Process in chunks of 4 for better vectorization
+    int d = 0;
+    for (; d < head_dim - 3; d += 4) {
+      half4 q_vals = vload4(d >> 2, local_query);
+      half4 k_vals_0 = vload4((k_offset_0 + d) >> 2, key);
+      half4 k_vals_1 = vload4((k_offset_1 + d) >> 2, key);
+      half4 k_vals_2 = vload4((k_offset_2 + d) >> 2, key);
+      half4 k_vals_3 = vload4((k_offset_3 + d) >> 2, key);
+      
+      sums.s0 = fma(q_vals.s0, k_vals_0.s0, sums.s0);
+      sums.s0 = fma(q_vals.s1, k_vals_0.s1, sums.s0);
+      sums.s0 = fma(q_vals.s2, k_vals_0.s2, sums.s0);
+      sums.s0 = fma(q_vals.s3, k_vals_0.s3, sums.s0);
+      sums.s0 *= scale;
+      
+      sums.s1 = fma(q_vals.s0, k_vals_1.s0, sums.s1);
+      sums.s1 = fma(q_vals.s1, k_vals_1.s1, sums.s1);
+      sums.s1 = fma(q_vals.s2, k_vals_1.s2, sums.s1);
+      sums.s1 = fma(q_vals.s3, k_vals_1.s3, sums.s1);
+      sums.s1 *= scale;
+      
+      sums.s2 = fma(q_vals.s0, k_vals_2.s0, sums.s2);
+      sums.s2 = fma(q_vals.s1, k_vals_2.s1, sums.s2);
+      sums.s2 = fma(q_vals.s2, k_vals_2.s2, sums.s2);
+      sums.s2 = fma(q_vals.s3, k_vals_2.s3, sums.s2);
+      sums.s2 *= scale;
+      
+      sums.s3 = fma(q_vals.s0, k_vals_3.s0, sums.s3);
+      sums.s3 = fma(q_vals.s1, k_vals_3.s1, sums.s3);
+      sums.s3 = fma(q_vals.s2, k_vals_3.s2, sums.s3);
+      sums.s3 = fma(q_vals.s3, k_vals_3.s3, sums.s3);
+      sums.s3 *= scale;
+    }
+    
+    // Handle remaining elements
+    for (; d < head_dim; d++) {
+      half q_val = local_query[d];
+      sums.s0 = fma(q_val, key[k_offset_0 + d], sums.s0) * scale;
+      sums.s1 = fma(q_val, key[k_offset_1 + d], sums.s1) * scale;
+      sums.s2 = fma(q_val, key[k_offset_2 + d], sums.s2) * scale;
+      sums.s3 = fma(q_val, key[k_offset_3 + d], sums.s3) * scale;
+    }
+    
+    max_val = fmax(max_val, fmax(fmax(fmax(sums.s0, sums.s1), sums.s2), sums.s3));
+  }
+  
+  // Handle remaining k_ids
+  for (; k_id < seqlen_k; k_id++) {
+    half sum = 0.0h;
+    const int k_offset = kv_head_offset + k_id * head_dim;
+    
+    // Process in chunks of 4 for better vectorization
+    int d = 0;
+    for (; d < head_dim - 3; d += 4) {
+      half4 q_vals = vload4(d >> 2, local_query);
+      half4 k_vals = vload4((k_offset + d) >> 2, key);
+      sum = fma(q_vals.s0, k_vals.s0, sum);
+      sum = fma(q_vals.s1, k_vals.s1, sum);
+      sum = fma(q_vals.s2, k_vals.s2, sum);
+      sum = fma(q_vals.s3, k_vals.s3, sum);
+    }
+    
+    // Handle remaining elements
+    for (; d < head_dim; d++) {
+      half q_val = local_query[d];
+      half k_val = key[k_offset + d];
+      sum = fma(q_val, k_val, sum);
+    }
+    
+    sum *= scale;
+    max_val = fmax(max_val, sum);
+  }
+  
+  // Second pass: compute attention weights and output
+  half exp_sum = 0.0h;
+  
+  // Initialize output
+  for (int d = 0; d < head_dim; d++) {
+    output[q_offset + d] = 0.0h;
+  }
+  
+  // Process in chunks of 4 for better vectorization
+  k_id = 0;
+  for (; k_id < seqlen_k - 3; k_id += 4) {
+    half4 sums = (half4)(0.0h);
+    const int k_offset_0 = kv_head_offset + (k_id + 0) * head_dim;
+    const int k_offset_1 = kv_head_offset + (k_id + 1) * head_dim;
+    const int k_offset_2 = kv_head_offset + (k_id + 2) * head_dim;
+    const int k_offset_3 = kv_head_offset + (k_id + 3) * head_dim;
+    
+    // Process in chunks of 4 for better vectorization
+    int d = 0;
+    for (; d < head_dim - 3; d += 4) {
+      half4 q_vals = vload4(d >> 2, local_query);
+      half4 k_vals_0 = vload4((k_offset_0 + d) >> 2, key);
+      half4 k_vals_1 = vload4((k_offset_1 + d) >> 2, key);
+      half4 k_vals_2 = vload4((k_offset_2 + d) >> 2, key);
+      half4 k_vals_3 = vload4((k_offset_3 + d) >> 2, key);
+      
+      sums.s0 = fma(q_vals.s0, k_vals_0.s0, sums.s0);
+      sums.s0 = fma(q_vals.s1, k_vals_0.s1, sums.s0);
+      sums.s0 = fma(q_vals.s2, k_vals_0.s2, sums.s0);
+      sums.s0 = fma(q_vals.s3, k_vals_0.s3, sums.s0);
+      sums.s0 *= scale;
+      
+      sums.s1 = fma(q_vals.s0, k_vals_1.s0, sums.s1);
+      sums.s1 = fma(q_vals.s1, k_vals_1.s1, sums.s1);
+      sums.s1 = fma(q_vals.s2, k_vals_1.s2, sums.s1);
+      sums.s1 = fma(q_vals.s3, k_vals_1.s3, sums.s1);
+      sums.s1 *= scale;
+      
+      sums.s2 = fma(q_vals.s0, k_vals_2.s0, sums.s2);
+      sums.s2 = fma(q_vals.s1, k_vals_2.s1, sums.s2);
+      sums.s2 = fma(q_vals.s2, k_vals_2.s2, sums.s2);
+      sums.s2 = fma(q_vals.s3, k_vals_2.s3, sums.s2);
+      sums.s2 *= scale;
+      
+      sums.s3 = fma(q_vals.s0, k_vals_3.s0, sums.s3);
+      sums.s3 = fma(q_vals.s1, k_vals_3.s1, sums.s3);
+      sums.s3 = fma(q_vals.s2, k_vals_3.s2, sums.s3);
+      sums.s3 = fma(q_vals.s3, k_vals_3.s3, sums.s3);
+      sums.s3 *= scale;
+    }
+    
+    // Handle remaining elements
+    for (; d < head_dim; d++) {
+      half q_val = local_query[d];
+      sums.s0 = fma(q_val, key[k_offset_0 + d], sums.s0) * scale;
+      sums.s1 = fma(q_val, key[k_offset_1 + d], sums.s1) * scale;
+      sums.s2 = fma(q_val, key[k_offset_2 + d], sums.s2) * scale;
+      sums.s3 = fma(q_val, key[k_offset_3 + d], sums.s3) * scale;
+    }
+    
+    half4 exp_vals;
+    exp_vals.s0 = exp(sums.s0 - max_val);
+    exp_vals.s1 = exp(sums.s1 - max_val);
+    exp_vals.s2 = exp(sums.s2 - max_val);
+    exp_vals.s3 = exp(sums.s3 - max_val);
+    
+    exp_sum += exp_vals.s0 + exp_vals.s1 + exp_vals.s2 + exp_vals.s3;
+    
+    // Accumulate weighted values
+    // Process in chunks of 4 for better vectorization
+    d = 0;
+    for (; d < head_dim - 3; d += 4) {
+      half4 v_vals_0 = vload4((k_offset_0 + d) >> 2, value);
+      half4 v_vals_1 = vload4((k_offset_1 + d) >> 2, value);
+      half4 v_vals_2 = vload4((k_offset_2 + d) >> 2, value);
+      half4 v_vals_3 = vload4((k_offset_3 + d) >> 2, value);
+      half4 out_vals = vload4((q_offset + d) >> 2, output);
+      
+      out_vals.s0 = fma(exp_vals.s0, v_vals_0.s0, out_vals.s0);
+      out_vals.s0 = fma(exp_vals.s1, v_vals_1.s0, out_vals.s0);
+      out_vals.s0 = fma(exp_vals.s2, v_vals_2.s0, out_vals.s0);
+      out_vals.s0 = fma(exp_vals.s3, v_vals_3.s0, out_vals.s0);
+      
+      out_vals.s1 = fma(exp_vals.s0, v_vals_0.s1, out_vals.s1);
+      out_vals.s1 = fma(exp_vals.s1, v_vals_1.s1, out_vals.s1);
+      out_vals.s1 = fma(exp_vals.s2, v_vals_2.s1, out_vals.s1);
+      out_vals.s1 = fma(exp_vals.s3, v_vals_3.s1, out_vals.s1);
+      
+      out_vals.s2 = fma(exp_vals.s0, v_vals_0.s2, out_vals.s2);
+      out_vals.s2 = fma(exp_vals.s1, v_vals_1.s2, out_vals.s2);
+      out_vals.s2 = fma(exp_vals.s2, v_vals_2.s2, out_vals.s2);
+      out_vals.s2 = fma(exp_vals.s3, v_vals_3.s2, out_vals.s2);
+      
+      out_vals.s3 = fma(exp_vals.s0, v_vals_0.s3, out_vals.s3);
+      out_vals.s3 = fma(exp_vals.s1, v_vals_1.s3, out_vals.s3);
+      out_vals.s3 = fma(exp_vals.s2, v_vals_2.s3, out_vals.s3);
+      out_vals.s3 = fma(exp_vals.s3, v_vals_3.s3, out_vals.s3);
+      
+      vstore4(out_vals, (q_offset + d) >> 2, output);
+    }
+    
+    // Handle remaining elements
+    for (; d < head_dim; d++) {
+      half v_val_0 = value[k_offset_0 + d];
+      half v_val_1 = value[k_offset_1 + d];
+      half v_val_2 = value[k_offset_2 + d];
+      half v_val_3 = value[k_offset_3 + d];
+      half out_val = output[q_offset + d];
+      output[q_offset + d] = fma(exp_vals.s0, v_val_0, out_val);
+      output[q_offset + d] = fma(exp_vals.s1, v_val_1, output[q_offset + d]);
+      output[q_offset + d] = fma(exp_vals.s2, v_val_2, output[q_offset + d]);
+      output[q_offset + d] = fma(exp_vals.s3, v_val_3, output[q_offset + d]);
+    }
+  }
+  
+  // Handle remaining k_ids
+  for (; k_id < seqlen_k; k_id++) {
+    half sum = 0.0h;
+    const int k_offset = kv_head_offset + k_id * head_dim;
+    
+    // Process in chunks of 4 for better vectorization
+    int d = 0;
+    for (; d < head_dim - 3; d += 4) {
+      half4 q_vals = vload4(d >> 2, local_query);
+      half4 k_vals = vload4((k_offset + d) >> 2, key);
+      sum = fma(q_vals.s0, k_vals.s0, sum);
+      sum = fma(q_vals.s1, k_vals.s1, sum);
+      sum = fma(q_vals.s2, k_vals.s2, sum);
+      sum = fma(q_vals.s3, k_vals.s3, sum);
+    }
+    
+    // Handle remaining elements
+    for (; d < head_dim; d++) {
+      half q_val = local_query[d];
+      half k_val = key[k_offset + d];
+      sum = fma(q_val, k_val, sum);
+    }
+    
+    sum *= scale;
+    half exp_val = exp(sum - max_val);
+    exp_sum += exp_val;
+    
+    // Accumulate weighted values
+    // Process in chunks of 4 for better vectorization
+    d = 0;
+    for (; d < head_dim - 3; d += 4) {
+      half4 v_vals = vload4((k_offset + d) >> 2, value);
+      half4 out_vals = vload4((q_offset + d) >> 2, output);
+      
+      out_vals.s0 = fma(exp_val, v_vals.s0, out_vals.s0);
+      out_vals.s1 = fma(exp_val, v_vals.s1, out_vals.s1);
+      out_vals.s2 = fma(exp_val, v_vals.s2, out_vals.s2);
+      out_vals.s3 = fma(exp_val, v_vals.s3, out_vals.s3);
+      
+      vstore4(out_vals, (q_offset + d) >> 2, output);
+    }
+    
+    // Handle remaining elements
+    for (; d < head_dim; d++) {
+      half v_val = value[k_offset + d];
+      half out_val = output[q_offset + d];
+      output[q_offset + d] = fma(exp_val, v_val, out_val);
+    }
+  }
+  
+  // Normalize by exp_sum
+  // Process in chunks of 4 for better vectorization
+  int d_norm = 0;
+  for (; d_norm < head_dim - 3; d_norm += 4) {
+    half4 out_vals = vload4((q_offset + d_norm) >> 2, output);
+    
+    out_vals.s0 /= exp_sum;
+    out_vals.s1 /= exp_sum;
+    out_vals.s2 /= exp_sum;
+    out_vals.s3 /= exp_sum;
+    
+    vstore4(out_vals, (q_offset + d_norm) >> 2, output);
+  }
+  
+  // Handle remaining elements
+  for (; d_norm < head_dim; d_norm++) {
+    half out_val = output[q_offset + d_norm];
+    output[q_offset + d_norm] = out_val / exp_sum;
+  }
+}

--- a/nntrainer/tensor/cl_operations/cl_kernels/flash_attention_fp32.cl
+++ b/nntrainer/tensor/cl_operations/cl_kernels/flash_attention_fp32.cl
@@ -1,0 +1,266 @@
+#define SOFTMAX_MIN -1e30f
+
+__kernel void flash_attention_fp32(__global const float *query,
+                                          __global const float *key,
+                                          __global const float *value,
+                                          __global float *output,
+                                          const int seqlen_q,
+                                          const int seqlen_k,
+                                          const int head_dim,
+                                          const int num_heads_q,
+                                          const int num_heads_kv,
+                                          const int batch,
+                                          const float scale) {
+  
+  const int total_work_items = batch * num_heads_q * seqlen_q;
+  const int global_id = get_global_id(0);
+  
+  if (global_id >= total_work_items) return;
+  
+  // Calculate indices
+  const int batch_id = global_id / (num_heads_q * seqlen_q);
+  const int head_batch_id = global_id % (num_heads_q * seqlen_q);
+  const int head_id = head_batch_id / seqlen_q;
+  const int q_id = head_batch_id % seqlen_q;
+  
+  // For GQA, map query head to corresponding key/value head
+  const int kv_head_id = head_id * num_heads_kv / num_heads_q;
+  
+  // Calculate offsets for query (per head)
+  const int query_batch_offset = batch_id * num_heads_q * seqlen_q * head_dim;
+  const int query_head_offset = query_batch_offset + head_id * seqlen_q * head_dim;
+  const int q_offset = query_head_offset + q_id * head_dim;
+  
+  // Calculate offsets for key/value (per kv_head)
+  const int kv_batch_offset = batch_id * num_heads_kv * seqlen_k * head_dim;
+  const int kv_head_offset = kv_batch_offset + kv_head_id * seqlen_k * head_dim;
+  
+  float max_val = SOFTMAX_MIN;
+  
+  // First pass: compute max for numerical stability
+  // Process in chunks of 4 for better vectorization on Adreno
+  int k_id = 0;
+  for (; k_id < seqlen_k - 3; k_id += 4) {
+    float4 sums = (float4)(0.0f);
+    const int k_offset_0 = kv_head_offset + (k_id + 0) * head_dim;
+    const int k_offset_1 = kv_head_offset + (k_id + 1) * head_dim;
+    const int k_offset_2 = kv_head_offset + (k_id + 2) * head_dim;
+    const int k_offset_3 = kv_head_offset + (k_id + 3) * head_dim;
+    
+    // Process in chunks of 4 for better vectorization on Adreno
+    int d = 0;
+    for (; d < head_dim - 3; d += 4) {
+      float4 q_vals = vload4((q_offset + d) >> 2, query);
+      float4 k_vals_0 = vload4((k_offset_0 + d) >> 2, key);
+      float4 k_vals_1 = vload4((k_offset_1 + d) >> 2, key);
+      float4 k_vals_2 = vload4((k_offset_2 + d) >> 2, key);
+      float4 k_vals_3 = vload4((k_offset_3 + d) >> 2, key);
+      
+      sums.s0 += dot(q_vals, k_vals_0) * scale;
+      sums.s1 += dot(q_vals, k_vals_1) * scale;
+      sums.s2 += dot(q_vals, k_vals_2) * scale;
+      sums.s3 += dot(q_vals, k_vals_3) * scale;
+    }
+    
+    // Handle remaining elements
+    for (; d < head_dim; d++) {
+      float q_val = query[q_offset + d];
+      sums.s0 += q_val * key[k_offset_0 + d] * scale;
+      sums.s1 += q_val * key[k_offset_1 + d] * scale;
+      sums.s2 += q_val * key[k_offset_2 + d] * scale;
+      sums.s3 += q_val * key[k_offset_3 + d] * scale;
+    }
+    
+    max_val = fmax(max_val, fmax(fmax(fmax(sums.s0, sums.s1), sums.s2), sums.s3));
+  }
+  
+  // Handle remaining k_ids
+  for (; k_id < seqlen_k; k_id++) {
+    float sum = 0.0f;
+    const int k_offset = kv_head_offset + k_id * head_dim;
+    
+    // Process in chunks of 4 for better vectorization on Adreno
+    int d = 0;
+    for (; d < head_dim - 3; d += 4) {
+      float4 q_vals = vload4((q_offset + d) >> 2, query);
+      float4 k_vals = vload4((k_offset + d) >> 2, key);
+      sum += dot(q_vals, k_vals) * scale;
+    }
+    
+    // Handle remaining elements
+    for (; d < head_dim; d++) {
+      float q_val = query[q_offset + d];
+      float k_val = key[k_offset + d];
+      sum += q_val * k_val * scale;
+    }
+    
+    max_val = fmax(max_val, sum);
+  }
+  
+  // Second pass: compute attention weights and output
+  float4 exp_sums = (float4)(0.0f);
+  
+  // Process in chunks of 4 for better vectorization on Adreno
+  k_id = 0;
+  for (; k_id < seqlen_k - 3; k_id += 4) {
+    float4 sums = (float4)(0.0f);
+    const int k_offset_0 = kv_head_offset + (k_id + 0) * head_dim;
+    const int k_offset_1 = kv_head_offset + (k_id + 1) * head_dim;
+    const int k_offset_2 = kv_head_offset + (k_id + 2) * head_dim;
+    const int k_offset_3 = kv_head_offset + (k_id + 3) * head_dim;
+    
+    // Process in chunks of 4 for better vectorization on Adreno
+    int d = 0;
+    for (; d < head_dim - 3; d += 4) {
+      float4 q_vals = vload4((q_offset + d) >> 2, query);
+      float4 k_vals_0 = vload4((k_offset_0 + d) >> 2, key);
+      float4 k_vals_1 = vload4((k_offset_1 + d) >> 2, key);
+      float4 k_vals_2 = vload4((k_offset_2 + d) >> 2, key);
+      float4 k_vals_3 = vload4((k_offset_3 + d) >> 2, key);
+      
+      sums.s0 += dot(q_vals, k_vals_0) * scale;
+      sums.s1 += dot(q_vals, k_vals_1) * scale;
+      sums.s2 += dot(q_vals, k_vals_2) * scale;
+      sums.s3 += dot(q_vals, k_vals_3) * scale;
+    }
+    
+    // Handle remaining elements
+    for (; d < head_dim; d++) {
+      float q_val = query[q_offset + d];
+      sums.s0 += q_val * key[k_offset_0 + d] * scale;
+      sums.s1 += q_val * key[k_offset_1 + d] * scale;
+      sums.s2 += q_val * key[k_offset_2 + d] * scale;
+      sums.s3 += q_val * key[k_offset_3 + d] * scale;
+    }
+    
+    float4 exp_vals;
+    exp_vals.s0 = exp(sums.s0 - max_val);
+    exp_vals.s1 = exp(sums.s1 - max_val);
+    exp_vals.s2 = exp(sums.s2 - max_val);
+    exp_vals.s3 = exp(sums.s3 - max_val);
+    
+    exp_sums += exp_vals;
+    
+    // Accumulate weighted values
+    // Initialize output on first iteration
+    if (k_id == 0) {
+      for (int d = 0; d < head_dim; d++) {
+        output[q_offset + d] = 0.0f;
+      }
+    }
+    
+    // Process in chunks of 4 for better vectorization on Adreno
+    d = 0;
+    for (; d < head_dim - 3; d += 4) {
+      float4 v_vals_0 = vload4((k_offset_0 + d) >> 2, value);
+      float4 v_vals_1 = vload4((k_offset_1 + d) >> 2, value);
+      float4 v_vals_2 = vload4((k_offset_2 + d) >> 2, value);
+      float4 v_vals_3 = vload4((k_offset_3 + d) >> 2, value);
+      float4 out_vals = vload4((q_offset + d) >> 2, output);
+      
+      out_vals.s0 += exp_vals.s0 * v_vals_0.s0;
+      out_vals.s1 += exp_vals.s0 * v_vals_0.s1;
+      out_vals.s2 += exp_vals.s0 * v_vals_0.s2;
+      out_vals.s3 += exp_vals.s0 * v_vals_0.s3;
+      
+      out_vals.s0 += exp_vals.s1 * v_vals_1.s0;
+      out_vals.s1 += exp_vals.s1 * v_vals_1.s1;
+      out_vals.s2 += exp_vals.s1 * v_vals_1.s2;
+      out_vals.s3 += exp_vals.s1 * v_vals_1.s3;
+      
+      out_vals.s0 += exp_vals.s2 * v_vals_2.s0;
+      out_vals.s1 += exp_vals.s2 * v_vals_2.s1;
+      out_vals.s2 += exp_vals.s2 * v_vals_2.s2;
+      out_vals.s3 += exp_vals.s2 * v_vals_2.s3;
+      
+      out_vals.s0 += exp_vals.s3 * v_vals_3.s0;
+      out_vals.s1 += exp_vals.s3 * v_vals_3.s1;
+      out_vals.s2 += exp_vals.s3 * v_vals_3.s2;
+      out_vals.s3 += exp_vals.s3 * v_vals_3.s3;
+      
+      vstore4(out_vals, (q_offset + d) >> 2, output);
+    }
+    
+    // Handle remaining elements
+    for (; d < head_dim; d++) {
+      float v_val_0 = value[k_offset_0 + d];
+      float v_val_1 = value[k_offset_1 + d];
+      float v_val_2 = value[k_offset_2 + d];
+      float v_val_3 = value[k_offset_3 + d];
+      float out_val = output[q_offset + d];
+      output[q_offset + d] = out_val + 
+        exp_vals.s0 * v_val_0 + 
+        exp_vals.s1 * v_val_1 + 
+        exp_vals.s2 * v_val_2 + 
+        exp_vals.s3 * v_val_3;
+    }
+  }
+  
+  // Handle remaining k_ids
+  float exp_sum_remaining = exp_sums.s0 + exp_sums.s1 + exp_sums.s2 + exp_sums.s3;
+  for (; k_id < seqlen_k; k_id++) {
+    float sum = 0.0f;
+    const int k_offset = kv_head_offset + k_id * head_dim;
+    
+    // Process in chunks of 4 for better vectorization on Adreno
+    int d = 0;
+    for (; d < head_dim - 3; d += 4) {
+      float4 q_vals = vload4((q_offset + d) >> 2, query);
+      float4 k_vals = vload4((k_offset + d) >> 2, key);
+      sum += dot(q_vals, k_vals) * scale;
+    }
+    
+    // Handle remaining elements
+    for (; d < head_dim; d++) {
+      float q_val = query[q_offset + d];
+      float k_val = key[k_offset + d];
+      sum += q_val * k_val * scale;
+    }
+    
+    float exp_val = exp(sum - max_val);
+    exp_sum_remaining += exp_val;
+    
+    // Accumulate weighted values
+    // Process in chunks of 4 for better vectorization on Adreno
+    d = 0;
+    for (; d < head_dim - 3; d += 4) {
+      float4 v_vals = vload4((k_offset + d) >> 2, value);
+      float4 out_vals = vload4((q_offset + d) >> 2, output);
+      
+      out_vals.s0 += exp_val * v_vals.s0;
+      out_vals.s1 += exp_val * v_vals.s1;
+      out_vals.s2 += exp_val * v_vals.s2;
+      out_vals.s3 += exp_val * v_vals.s3;
+      
+      vstore4(out_vals, (q_offset + d) >> 2, output);
+    }
+    
+    // Handle remaining elements
+    for (; d < head_dim; d++) {
+      float v_val = value[k_offset + d];
+      float out_val = output[q_offset + d];
+      output[q_offset + d] = out_val + exp_val * v_val;
+    }
+  }
+  
+  // Normalize by exp_sum
+  float total_exp_sum = exp_sum_remaining;
+  // Process in chunks of 4 for better vectorization on Adreno
+  int d_norm = 0;
+  for (; d_norm < head_dim - 3; d_norm += 4) {
+    float4 out_vals = vload4((q_offset + d_norm) >> 2, output);
+    
+    out_vals.s0 /= total_exp_sum;
+    out_vals.s1 /= total_exp_sum;
+    out_vals.s2 /= total_exp_sum;
+    out_vals.s3 /= total_exp_sum;
+    
+    vstore4(out_vals, (q_offset + d_norm) >> 2, output);
+  }
+  
+  // Handle remaining elements
+  for (; d_norm < head_dim; d_norm++) {
+    float out_val = output[q_offset + d_norm];
+    output[q_offset + d_norm] = out_val / total_exp_sum;
+  }
+}

--- a/nntrainer/tensor/cl_operations/cl_kernels/flash_attention_fp32.cl
+++ b/nntrainer/tensor/cl_operations/cl_kernels/flash_attention_fp32.cl
@@ -1,5 +1,8 @@
 #define SOFTMAX_MIN -1e30f
 
+// Local memory size - adjust based on device capabilities
+#define LOCAL_SIZE 256
+
 __kernel void flash_attention_fp32(__global const float *query,
                                           __global const float *key,
                                           __global const float *value,
@@ -14,6 +17,9 @@ __kernel void flash_attention_fp32(__global const float *query,
   
   const int total_work_items = batch * num_heads_q * seqlen_q;
   const int global_id = get_global_id(0);
+  
+  // Local memory for caching query values
+  __local float local_query[LOCAL_SIZE];
   
   if (global_id >= total_work_items) return;
   
@@ -35,10 +41,20 @@ __kernel void flash_attention_fp32(__global const float *query,
   const int kv_batch_offset = batch_id * num_heads_kv * seqlen_k * head_dim;
   const int kv_head_offset = kv_batch_offset + kv_head_id * seqlen_k * head_dim;
   
+  // Cache query values in local memory for better reuse
+  const int local_size = get_local_size(0);
+  const int local_id = get_local_id(0);
+  
+  // Preload query values into local memory in chunks
+  for (int d = local_id; d < head_dim; d += local_size) {
+    local_query[d] = query[q_offset + d];
+  }
+  barrier(CLK_LOCAL_MEM_FENCE);
+  
   float max_val = SOFTMAX_MIN;
   
   // First pass: compute max for numerical stability
-  // Process in chunks of 4 for better vectorization on Adreno
+  // Process in chunks of 4 for better vectorization
   int k_id = 0;
   for (; k_id < seqlen_k - 3; k_id += 4) {
     float4 sums = (float4)(0.0f);
@@ -47,10 +63,10 @@ __kernel void flash_attention_fp32(__global const float *query,
     const int k_offset_2 = kv_head_offset + (k_id + 2) * head_dim;
     const int k_offset_3 = kv_head_offset + (k_id + 3) * head_dim;
     
-    // Process in chunks of 4 for better vectorization on Adreno
+    // Process in chunks of 4 for better vectorization
     int d = 0;
     for (; d < head_dim - 3; d += 4) {
-      float4 q_vals = vload4((q_offset + d) >> 2, query);
+      float4 q_vals = vload4(d >> 2, local_query);
       float4 k_vals_0 = vload4((k_offset_0 + d) >> 2, key);
       float4 k_vals_1 = vload4((k_offset_1 + d) >> 2, key);
       float4 k_vals_2 = vload4((k_offset_2 + d) >> 2, key);
@@ -64,7 +80,7 @@ __kernel void flash_attention_fp32(__global const float *query,
     
     // Handle remaining elements
     for (; d < head_dim; d++) {
-      float q_val = query[q_offset + d];
+      float q_val = local_query[d];
       sums.s0 += q_val * key[k_offset_0 + d] * scale;
       sums.s1 += q_val * key[k_offset_1 + d] * scale;
       sums.s2 += q_val * key[k_offset_2 + d] * scale;
@@ -79,17 +95,17 @@ __kernel void flash_attention_fp32(__global const float *query,
     float sum = 0.0f;
     const int k_offset = kv_head_offset + k_id * head_dim;
     
-    // Process in chunks of 4 for better vectorization on Adreno
+    // Process in chunks of 4 for better vectorization
     int d = 0;
     for (; d < head_dim - 3; d += 4) {
-      float4 q_vals = vload4((q_offset + d) >> 2, query);
+      float4 q_vals = vload4(d >> 2, local_query);
       float4 k_vals = vload4((k_offset + d) >> 2, key);
       sum += dot(q_vals, k_vals) * scale;
     }
     
     // Handle remaining elements
     for (; d < head_dim; d++) {
-      float q_val = query[q_offset + d];
+      float q_val = local_query[d];
       float k_val = key[k_offset + d];
       sum += q_val * k_val * scale;
     }
@@ -98,9 +114,14 @@ __kernel void flash_attention_fp32(__global const float *query,
   }
   
   // Second pass: compute attention weights and output
-  float4 exp_sums = (float4)(0.0f);
+  float exp_sum = 0.0f;
   
-  // Process in chunks of 4 for better vectorization on Adreno
+  // Initialize output
+  for (int d = 0; d < head_dim; d++) {
+    output[q_offset + d] = 0.0f;
+  }
+  
+  // Process in chunks of 4 for better vectorization
   k_id = 0;
   for (; k_id < seqlen_k - 3; k_id += 4) {
     float4 sums = (float4)(0.0f);
@@ -109,10 +130,10 @@ __kernel void flash_attention_fp32(__global const float *query,
     const int k_offset_2 = kv_head_offset + (k_id + 2) * head_dim;
     const int k_offset_3 = kv_head_offset + (k_id + 3) * head_dim;
     
-    // Process in chunks of 4 for better vectorization on Adreno
+    // Process in chunks of 4 for better vectorization
     int d = 0;
     for (; d < head_dim - 3; d += 4) {
-      float4 q_vals = vload4((q_offset + d) >> 2, query);
+      float4 q_vals = vload4(d >> 2, local_query);
       float4 k_vals_0 = vload4((k_offset_0 + d) >> 2, key);
       float4 k_vals_1 = vload4((k_offset_1 + d) >> 2, key);
       float4 k_vals_2 = vload4((k_offset_2 + d) >> 2, key);
@@ -126,7 +147,7 @@ __kernel void flash_attention_fp32(__global const float *query,
     
     // Handle remaining elements
     for (; d < head_dim; d++) {
-      float q_val = query[q_offset + d];
+      float q_val = local_query[d];
       sums.s0 += q_val * key[k_offset_0 + d] * scale;
       sums.s1 += q_val * key[k_offset_1 + d] * scale;
       sums.s2 += q_val * key[k_offset_2 + d] * scale;
@@ -139,17 +160,10 @@ __kernel void flash_attention_fp32(__global const float *query,
     exp_vals.s2 = exp(sums.s2 - max_val);
     exp_vals.s3 = exp(sums.s3 - max_val);
     
-    exp_sums += exp_vals;
+    exp_sum += exp_vals.s0 + exp_vals.s1 + exp_vals.s2 + exp_vals.s3;
     
     // Accumulate weighted values
-    // Initialize output on first iteration
-    if (k_id == 0) {
-      for (int d = 0; d < head_dim; d++) {
-        output[q_offset + d] = 0.0f;
-      }
-    }
-    
-    // Process in chunks of 4 for better vectorization on Adreno
+    // Process in chunks of 4 for better vectorization
     d = 0;
     for (; d < head_dim - 3; d += 4) {
       float4 v_vals_0 = vload4((k_offset_0 + d) >> 2, value);
@@ -158,25 +172,10 @@ __kernel void flash_attention_fp32(__global const float *query,
       float4 v_vals_3 = vload4((k_offset_3 + d) >> 2, value);
       float4 out_vals = vload4((q_offset + d) >> 2, output);
       
-      out_vals.s0 += exp_vals.s0 * v_vals_0.s0;
-      out_vals.s1 += exp_vals.s0 * v_vals_0.s1;
-      out_vals.s2 += exp_vals.s0 * v_vals_0.s2;
-      out_vals.s3 += exp_vals.s0 * v_vals_0.s3;
-      
-      out_vals.s0 += exp_vals.s1 * v_vals_1.s0;
-      out_vals.s1 += exp_vals.s1 * v_vals_1.s1;
-      out_vals.s2 += exp_vals.s1 * v_vals_1.s2;
-      out_vals.s3 += exp_vals.s1 * v_vals_1.s3;
-      
-      out_vals.s0 += exp_vals.s2 * v_vals_2.s0;
-      out_vals.s1 += exp_vals.s2 * v_vals_2.s1;
-      out_vals.s2 += exp_vals.s2 * v_vals_2.s2;
-      out_vals.s3 += exp_vals.s2 * v_vals_2.s3;
-      
-      out_vals.s0 += exp_vals.s3 * v_vals_3.s0;
-      out_vals.s1 += exp_vals.s3 * v_vals_3.s1;
-      out_vals.s2 += exp_vals.s3 * v_vals_3.s2;
-      out_vals.s3 += exp_vals.s3 * v_vals_3.s3;
+      out_vals.s0 += exp_vals.s0 * v_vals_0.s0 + exp_vals.s1 * v_vals_1.s0 + exp_vals.s2 * v_vals_2.s0 + exp_vals.s3 * v_vals_3.s0;
+      out_vals.s1 += exp_vals.s0 * v_vals_0.s1 + exp_vals.s1 * v_vals_1.s1 + exp_vals.s2 * v_vals_2.s1 + exp_vals.s3 * v_vals_3.s1;
+      out_vals.s2 += exp_vals.s0 * v_vals_0.s2 + exp_vals.s1 * v_vals_1.s2 + exp_vals.s2 * v_vals_2.s2 + exp_vals.s3 * v_vals_3.s2;
+      out_vals.s3 += exp_vals.s0 * v_vals_0.s3 + exp_vals.s1 * v_vals_1.s3 + exp_vals.s2 * v_vals_2.s3 + exp_vals.s3 * v_vals_3.s3;
       
       vstore4(out_vals, (q_offset + d) >> 2, output);
     }
@@ -197,31 +196,30 @@ __kernel void flash_attention_fp32(__global const float *query,
   }
   
   // Handle remaining k_ids
-  float exp_sum_remaining = exp_sums.s0 + exp_sums.s1 + exp_sums.s2 + exp_sums.s3;
   for (; k_id < seqlen_k; k_id++) {
     float sum = 0.0f;
     const int k_offset = kv_head_offset + k_id * head_dim;
     
-    // Process in chunks of 4 for better vectorization on Adreno
+    // Process in chunks of 4 for better vectorization
     int d = 0;
     for (; d < head_dim - 3; d += 4) {
-      float4 q_vals = vload4((q_offset + d) >> 2, query);
+      float4 q_vals = vload4(d >> 2, local_query);
       float4 k_vals = vload4((k_offset + d) >> 2, key);
       sum += dot(q_vals, k_vals) * scale;
     }
     
     // Handle remaining elements
     for (; d < head_dim; d++) {
-      float q_val = query[q_offset + d];
+      float q_val = local_query[d];
       float k_val = key[k_offset + d];
       sum += q_val * k_val * scale;
     }
     
     float exp_val = exp(sum - max_val);
-    exp_sum_remaining += exp_val;
+    exp_sum += exp_val;
     
     // Accumulate weighted values
-    // Process in chunks of 4 for better vectorization on Adreno
+    // Process in chunks of 4 for better vectorization
     d = 0;
     for (; d < head_dim - 3; d += 4) {
       float4 v_vals = vload4((k_offset + d) >> 2, value);
@@ -244,16 +242,15 @@ __kernel void flash_attention_fp32(__global const float *query,
   }
   
   // Normalize by exp_sum
-  float total_exp_sum = exp_sum_remaining;
-  // Process in chunks of 4 for better vectorization on Adreno
+  // Process in chunks of 4 for better vectorization
   int d_norm = 0;
   for (; d_norm < head_dim - 3; d_norm += 4) {
     float4 out_vals = vload4((q_offset + d_norm) >> 2, output);
     
-    out_vals.s0 /= total_exp_sum;
-    out_vals.s1 /= total_exp_sum;
-    out_vals.s2 /= total_exp_sum;
-    out_vals.s3 /= total_exp_sum;
+    out_vals.s0 /= exp_sum;
+    out_vals.s1 /= exp_sum;
+    out_vals.s2 /= exp_sum;
+    out_vals.s3 /= exp_sum;
     
     vstore4(out_vals, (q_offset + d_norm) >> 2, output);
   }
@@ -261,6 +258,6 @@ __kernel void flash_attention_fp32(__global const float *query,
   // Handle remaining elements
   for (; d_norm < head_dim; d_norm++) {
     float out_val = output[q_offset + d_norm];
-    output[q_offset + d_norm] = out_val / total_exp_sum;
+    output[q_offset + d_norm] = out_val / exp_sum;
   }
 }

--- a/nntrainer/tensor/cl_operations/cl_kernels/meson.build
+++ b/nntrainer/tensor/cl_operations/cl_kernels/meson.build
@@ -8,6 +8,7 @@ cl_op_kernels = [
   'convert_block_q4_0.cl',
   'copy.cl',
   'dot.cl',
+  'flash_attention_fp32.cl',
   'int4_gemv.cl',
   'int4_quantize_input.cl',
   'int4_gemm.cl',

--- a/nntrainer/tensor/cl_operations/cl_kernels/meson.build
+++ b/nntrainer/tensor/cl_operations/cl_kernels/meson.build
@@ -32,6 +32,7 @@ cl_op_kernels = [
   'transpose_axis_2.cl',
 ]
 
+
 if get_option('enable-fp16')
   cl_op_kernels += [
     'addition_fp16.cl',
@@ -40,6 +41,7 @@ if get_option('enable-fp16')
     'concat_axis_3_fp16.cl',
     'copy_fp16.cl',
     'dot_fp16.cl',
+    'flash_attention_fp16.cl',
     'hgemm_no_trans.cl',
     'hgemm_trans_a.cl',
     'hgemm_trans_ab.cl',
@@ -55,6 +57,7 @@ if get_option('enable-fp16')
     'transpose_axis_2_fp16.cl',
   ]
 endif
+
 
 all_includes = ''
 foreach k : cl_op_kernels

--- a/nntrainer/tensor/cl_operations/flash_attention.cpp
+++ b/nntrainer/tensor/cl_operations/flash_attention.cpp
@@ -13,6 +13,7 @@
 
 #include "flash_attention.h"
 #include <cl_kernels/flash_attention_fp32.h>
+#include <cl_kernels/flash_attention_fp16.h>
 
 namespace nntrainer {
 
@@ -174,6 +175,120 @@ void flash_attention_fp32_cl(float *query, float *key, float *value, float *outp
                                              true);
   if (!result) {
     throw std::runtime_error("Failed to read output data for flash_attention_fp32");
+    return;
+  }
+}
+
+void flash_attention_fp16_cl(_FP16 *query, _FP16 *key, _FP16 *value, _FP16 *output,
+                             unsigned int seqlen_q, unsigned int seqlen_k,
+                             unsigned int head_dim, unsigned int num_heads_q,
+                             unsigned int num_heads_kv, unsigned int batch,
+                             float scale) {
+  // For very small workloads, use CPU implementation to avoid GPU overhead
+  const unsigned int total_elements = batch * num_heads_q * seqlen_q * head_dim;
+  const unsigned int total_work_items = batch * num_heads_q * seqlen_q;
+  
+  // Threshold for switching to CPU - tune based on empirical testing
+  if (total_work_items < 32 || total_elements < 4096) {
+    // Convert FP16 to FP32 for CPU computation
+    std::vector<float> query_fp32(total_elements);
+    std::vector<float> key_fp32(batch * num_heads_kv * seqlen_k * head_dim);
+    std::vector<float> value_fp32(batch * num_heads_kv * seqlen_k * head_dim);
+    std::vector<float> output_fp32(total_elements);
+    
+    // Convert inputs to FP32
+    for (size_t i = 0; i < total_elements; ++i) {
+      query_fp32[i] = static_cast<float>(query[i]);
+    }
+    for (size_t i = 0; i < batch * num_heads_kv * seqlen_k * head_dim; ++i) {
+      key_fp32[i] = static_cast<float>(key[i]);
+      value_fp32[i] = static_cast<float>(value[i]);
+    }
+    
+    // Compute on CPU
+    flash_attention_cpu(query_fp32.data(), key_fp32.data(), value_fp32.data(),
+                       output_fp32.data(), seqlen_q, seqlen_k, head_dim,
+                       num_heads_q, num_heads_kv, batch, scale);
+    
+    // Convert output back to FP16
+    for (size_t i = 0; i < total_elements; ++i) {
+      output[i] = static_cast<_FP16>(output_fp32[i]);
+    }
+    return;
+  }
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+
+  ClContext::SharedPtrClKernel kernel_ptr = blas_cc->registerClKernel(
+    flash_attention_fp16_kernel, "flash_attention_fp16");
+  if (!kernel_ptr) {
+    throw std::runtime_error("Failed to get kernel_ptr for flash_attention_fp16");
+    return;
+  }
+
+  int arg = 0;
+  bool result = false;
+
+  result = kernel_ptr->SetKernelSVMArguments(arg++, query);
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 0 for flash_attention_fp16");
+
+  result = kernel_ptr->SetKernelSVMArguments(arg++, key);
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 1 for flash_attention_fp16");
+
+  result = kernel_ptr->SetKernelSVMArguments(arg++, value);
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 2 for flash_attention_fp16");
+
+  result = kernel_ptr->SetKernelSVMArguments(arg++, output);
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 3 for flash_attention_fp16");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &seqlen_q, sizeof(int));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 4 for flash_attention_fp16");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &seqlen_k, sizeof(int));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 5 for flash_attention_fp16");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &head_dim, sizeof(int));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 6 for flash_attention_fp16");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &num_heads_q, sizeof(int));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 7 for flash_attention_fp16");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &num_heads_kv, sizeof(int));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 8 for flash_attention_fp16");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &batch, sizeof(int));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 9 for flash_attention_fp16");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &scale, sizeof(float));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 10 for flash_attention_fp16");
+
+  const int work_groups_count[3] = {(int)total_work_items, 1, 1};
+  const int work_group_size[3] = {64, 1, 1};
+
+  result = blas_cc->command_queue_inst_.DispatchCommand(
+    kernel_ptr, work_groups_count, work_group_size);
+  if (!result) {
+    throw std::runtime_error("Failed to dispatch kernel for flash_attention_fp16");
+    return;
+  }
+
+  blas_cc->command_queue_inst_.enqueueSVMMap(output, 
+                                             batch * num_heads_q * seqlen_q * head_dim * sizeof(_FP16),
+                                             true);
+  if (!result) {
+    throw std::runtime_error("Failed to read output data for flash_attention_fp16");
     return;
   }
 }

--- a/nntrainer/tensor/cl_operations/flash_attention.cpp
+++ b/nntrainer/tensor/cl_operations/flash_attention.cpp
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Anup Tiwari <anup.tiwari@samsung.com>
+ *
+ * @file	flash_attention.cpp
+ * @date	25 March 2026
+ * @brief	Common flash attention OpenCL kernels
+ * @see		https://github.com/nntrainer/nntrainer
+ * @author	Anup Tiwari <anup.tiwari@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#include "flash_attention.h"
+#include <cl_kernels/flash_attention_fp32.h>
+
+namespace nntrainer {
+
+
+void flash_attention_cpu(const float *query, const float *key, 
+                                   const float *value, float *output,
+                                   int seqlen_q, int seqlen_k, int head_dim, 
+                                   int num_heads_q, int num_heads_kv, int batch,
+                                   float scale) {
+  for (int b = 0; b < batch; b++) {
+    for (int q_head = 0; q_head < num_heads_q; q_head++) {
+      // Map query head to corresponding key/value head
+      int kv_head = q_head * num_heads_kv / num_heads_q;
+      
+      // Calculate offsets
+      int query_batch_offset = b * num_heads_q * seqlen_q * head_dim;
+      int query_head_offset = query_batch_offset + q_head * seqlen_q * head_dim;
+      
+      int kv_batch_offset = b * num_heads_kv * seqlen_k * head_dim;
+      int kv_head_offset = kv_batch_offset + kv_head * seqlen_k * head_dim;
+      
+      for (int q = 0; q < seqlen_q; q++) {
+        int q_offset = query_head_offset + q * head_dim;
+        
+        // Compute attention scores
+        std::vector<float> scores(seqlen_k, 0.0f);
+        float max_score = -1e9f;
+        
+        for (int k = 0; k < seqlen_k; k++) {
+          float sum = 0.0f;
+          int k_offset = kv_head_offset + k * head_dim;
+          
+          for (int d = 0; d < head_dim; d++) {
+            float q_val = query[q_offset + d];
+            float k_val = key[k_offset + d];
+            sum += q_val * k_val * scale;
+          }
+          scores[k] = sum;
+          max_score = std::max(max_score, sum);
+        }
+        
+        // Compute softmax
+        std::vector<float> attn_weights(seqlen_k, 0.0f);
+        float exp_sum = 0.0f;
+        for (int k = 0; k < seqlen_k; k++) {
+          float exp_val = std::exp(scores[k] - max_score);
+          attn_weights[k] = exp_val;
+          exp_sum += exp_val;
+        }
+        
+        // Normalize
+        for (int k = 0; k < seqlen_k; k++) {
+          attn_weights[k] /= exp_sum;
+        }
+        
+        // Compute output
+        for (int d = 0; d < head_dim; d++) {
+          float sum = 0.0f;
+          for (int k = 0; k < seqlen_k; k++) {
+            int v_offset = kv_head_offset + k * head_dim;
+            sum += attn_weights[k] * value[v_offset + d];
+          }
+          output[q_offset + d] = sum;
+        }
+      }
+    }
+  }
+}
+
+void flash_attention_fp32_cl(float *query, float *key, float *value, float *output,
+                             unsigned int seqlen_q, unsigned int seqlen_k,
+                             unsigned int head_dim, unsigned int num_heads_q,
+                             unsigned int num_heads_kv, unsigned int batch,
+                             float scale) {
+  // For very small workloads, use CPU implementation to avoid GPU overhead
+  const unsigned int total_elements = batch * num_heads_q * seqlen_q * head_dim;
+  const unsigned int total_work_items = batch * num_heads_q * seqlen_q;
+  
+  // Threshold for switching to CPU - tune based on empirical testing
+  if (total_work_items < 32 || total_elements < 4096) {
+    // Fall back to CPU implementation for small workloads
+    // This is a simplified fallback - in practice, you might want to implement
+    // a more sophisticated CPU version or use a different GPU strategy
+    flash_attention_cpu(query, key, value, output, 
+                                      seqlen_q, seqlen_k, head_dim, 
+                                      num_heads_q, num_heads_kv, batch, scale);
+    return;
+  }
+
+  auto *blas_cc =
+    static_cast<ClContext *>(Engine::Global().getRegisteredContext("gpu"));
+
+  ClContext::SharedPtrClKernel kernel_ptr = blas_cc->registerClKernel(
+    flash_attention_fp32_kernel, "flash_attention_fp32");
+  if (!kernel_ptr) {
+    throw std::runtime_error("Failed to get kernel_ptr for flash_attention_fp32");
+    return;
+  }
+
+  int arg = 0;
+  bool result = false;
+
+  result = kernel_ptr->SetKernelSVMArguments(arg++, query);
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 0 for flash_attention_fp32");
+
+  result = kernel_ptr->SetKernelSVMArguments(arg++, key);
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 1 for flash_attention_fp32");
+
+  result = kernel_ptr->SetKernelSVMArguments(arg++, value);
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 2 for flash_attention_fp32");
+
+  result = kernel_ptr->SetKernelSVMArguments(arg++, output);
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 3 for flash_attention_fp32");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &seqlen_q, sizeof(int));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 4 for flash_attention_fp32");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &seqlen_k, sizeof(int));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 5 for flash_attention_fp32");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &head_dim, sizeof(int));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 6 for flash_attention_fp32");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &num_heads_q, sizeof(int));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 7 for flash_attention_fp32");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &num_heads_kv, sizeof(int));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 8 for flash_attention_fp32");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &batch, sizeof(int));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 9 for flash_attention_fp32");
+
+  result = kernel_ptr->SetKernelArguments(arg++, &scale, sizeof(float));
+  if (!result)
+    throw std::runtime_error("Failed to set kernel argument 10 for flash_attention_fp32");
+
+  const int work_groups_count[3] = {(int)total_work_items, 1, 1};
+  const int work_group_size[3] = {64, 1, 1};
+
+  result = blas_cc->command_queue_inst_.DispatchCommand(
+    kernel_ptr, work_groups_count, work_group_size);
+  if (!result) {
+    throw std::runtime_error("Failed to dispatch kernel for flash_attention_fp32");
+    return;
+  }
+
+  blas_cc->command_queue_inst_.enqueueSVMMap(output, 
+                                             batch * num_heads_q * seqlen_q * head_dim * sizeof(float),
+                                             true);
+  if (!result) {
+    throw std::runtime_error("Failed to read output data for flash_attention_fp32");
+    return;
+  }
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/cl_operations/flash_attention.h
+++ b/nntrainer/tensor/cl_operations/flash_attention.h
@@ -19,6 +19,16 @@
 #include <opencl_buffer.h>
 #include <opencl_kernel.h>
 
+#ifdef ENABLE_FP16
+#ifndef _FP16
+#ifdef USE__FP16
+#define _FP16 __fp16
+#else
+#define _FP16 _Float16
+#endif
+#endif
+#endif
+
 #include <string>
 
 namespace nntrainer {
@@ -69,9 +79,27 @@ void flash_attention_fp32_cl(float *query, float *key, float *value, float *outp
                              unsigned int num_heads_kv, unsigned int batch,
                              float scale);
 
-#ifdef ENABLE_FP16
 
-#endif
+/**
+ * @brief Flash Attention FP16 computation with GQA support
+ * @param[in] query _FP16 * for Query matrix
+ * @param[in] key _FP16 * for Key matrix
+ * @param[in] value _FP16 * for Value matrix
+ * @param[out] output _FP16 * for Output matrix
+ * @param[in] seqlen_q sequence length of query
+ * @param[in] seqlen_k sequence length of key
+ * @param[in] head_dim dimension of each attention head
+ * @param[in] num_heads_q number of query attention heads
+ * @param[in] num_heads_kv number of key/value attention heads
+ * @param[in] batch batch size
+ * @param[in] scale scaling factor for attention scores
+ */
+void flash_attention_fp16_cl(_FP16 *query, _FP16 *key, _FP16 *value, _FP16 *output,
+                             unsigned int seqlen_q, unsigned int seqlen_k,
+                             unsigned int head_dim, unsigned int num_heads_q,
+                             unsigned int num_heads_kv, unsigned int batch,
+                             float scale);
+
 
 } // namespace nntrainer
 #endif /* __FLASH_ATTENTION_H__ */

--- a/nntrainer/tensor/cl_operations/flash_attention.h
+++ b/nntrainer/tensor/cl_operations/flash_attention.h
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Anup Tiwari <anup.tiwari@samsung.com>
+ *
+ * @file	flash_attention.h
+ * @date	25 March 2026
+ * @brief	Common flash attention OpenCL kernels
+ * @see		https://github.com/nntrainer/nntrainer
+ * @author	Anup Tiwari <anup.tiwari@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ */
+
+#ifndef __FLASH_ATTENTION_H__
+#define __FLASH_ATTENTION_H__
+
+#include <cl_context.h>
+#include <engine.h>
+#include <opencl_buffer.h>
+#include <opencl_kernel.h>
+
+#include <string>
+
+namespace nntrainer {
+
+
+/**
+ * @brief CPU reference implementation of flash attention with Grouped-Query Attention (GQA) support
+ * @detail This function implements the flash attention algorithm on CPU for verification purposes.
+ *         It supports Grouped-Query Attention where the number of query heads can be different
+ *         from the number of key/value heads. The attention computation follows the standard
+ *         scaled dot-product attention mechanism with softmax normalization.
+ * @param[in] query Pointer to the query matrix data (float)
+ * @param[in] key Pointer to the key matrix data (float)
+ * @param[in] value Pointer to the value matrix data (float)
+ * @param[out] output Pointer to the output matrix data (float)
+ * @param[in] seqlen_q Sequence length of the query matrix
+ * @param[in] seqlen_k Sequence length of the key matrix
+ * @param[in] head_dim Dimension of each attention head
+ * @param[in] num_heads_q Number of query attention heads
+ * @param[in] num_heads_kv Number of key/value attention heads
+ * @param[in] batch Batch size
+ * @param[in] scale Scaling factor applied to the dot products (typically 1/sqrt(head_dim))
+ * @note This is a reference implementation for correctness verification and not optimized for performance
+ */
+void flash_attention_cpu(const float *query, const float *key, 
+                         const float *value, float *output,
+                         int seqlen_q, int seqlen_k, int head_dim, 
+                         int num_heads_q, int num_heads_kv, int batch,
+                         float scale);
+
+/**
+ * @brief Flash Attention FP32 computation with GQA support
+ * @param[in] query float * for Query matrix
+ * @param[in] key float * for Key matrix
+ * @param[in] value float * for Value matrix
+ * @param[out] output float * for Output matrix
+ * @param[in] seqlen_q sequence length of query
+ * @param[in] seqlen_k sequence length of key
+ * @param[in] head_dim dimension of each attention head
+ * @param[in] num_heads_q number of query attention heads
+ * @param[in] num_heads_kv number of key/value attention heads
+ * @param[in] batch batch size
+ * @param[in] scale scaling factor for attention scores
+ */
+void flash_attention_fp32_cl(float *query, float *key, float *value, float *output,
+                             unsigned int seqlen_q, unsigned int seqlen_k,
+                             unsigned int head_dim, unsigned int num_heads_q,
+                             unsigned int num_heads_kv, unsigned int batch,
+                             float scale);
+
+#ifdef ENABLE_FP16
+
+#endif
+
+} // namespace nntrainer
+#endif /* __FLASH_ATTENTION_H__ */

--- a/nntrainer/tensor/cl_operations/meson.build
+++ b/nntrainer/tensor/cl_operations/meson.build
@@ -3,13 +3,15 @@ cl_op_sources = [
   'blas_kernel_interface.cpp',
   'attention_kernel_interface.cpp',
   'attention_kernels.cpp',
-  'clblast_interface.cpp'
+  'clblast_interface.cpp',
+  'flash_attention.cpp'
 ]
 
 cl_op_headers = [
   'blas_kernel_interface.h',
   'attention_kernel_interface.h',
-  'clblast_interface.h'
+  'clblast_interface.h',
+  'flash_attention.h'
 ]
 
 if get_option('enable-fp16')

--- a/run_flash_attention.sh
+++ b/run_flash_attention.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# Script to build and run flash attention OpenCL kernel tests
+# Optimized for Qualcomm Adreno GPUs
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/storage_data/snap/anup/android-ndk-r26d/
+export PATH=$PATH:/storage_data/snap/anup/android-ndk-r26d/
+export ANDROID_NDK=/storage_data/snap/anup/android-ndk-r26d/
+
+echo "Building NNTrainer with OpenCL support..."
+./tools/package_android.sh -Denable-opencl=true
+
+echo "Copying googletest library..."
+cp -r $ANDROID_NDK/sources/third_party/googletest test/jni
+
+echo "Installing built libraries..."
+ninja install -C builddir
+mkdir -p libs/arm64-v8a
+cp builddir/android_build_result/lib/arm64-v8a/*.so libs/arm64-v8a
+
+echo "Building flash attention unittest..."
+ndk-build -C test/jni -j$(nproc) MESON_ENABLE_OPENCL=1 unittest_flash_attention_cl NDK_DEBUG=0
+
+echo "Deploying to device..."
+adb shell "mkdir -p /data/local/tmp/nntrainer/test"
+adb push test/obj/local/arm64-v8a/unittest_flash_attention_cl /data/local/tmp/nntrainer/test
+adb push libs/arm64-v8a/*.so /data/local/tmp/nntrainer/test
+adb shell chmod +x /data/local/tmp/nntrainer/test/unittest_flash_attention_cl
+
+echo "Running flash attention tests..."
+adb shell "cd /data/local/tmp/nntrainer/test; export LD_LIBRARY_PATH=.; ./unittest_flash_attention_cl $@"
+
+echo "Collecting logs..."
+adb pull /data/local/tmp/nntrainer/test/logs/. ./logs/ 2>/dev/null || echo "No logs to pull"
+adb shell "rm -f /data/local/tmp/nntrainer/test/logs/*" 2>/dev/null || echo "No log files to clean"
+
+echo "Flash attention tests completed!"

--- a/run_flash_attention_fp16.sh
+++ b/run_flash_attention_fp16.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# Script to build and run flash attention FP16 OpenCL kernel tests
+# Optimized for Qualcomm Adreno GPUs
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/storage_data/snap/anup/android-ndk-r26d/
+export PATH=$PATH:/storage_data/snap/anup/android-ndk-r26d/
+export ANDROID_NDK=/storage_data/snap/anup/android-ndk-r26d/
+
+echo "Building NNTrainer with OpenCL and FP16 support..."
+./tools/package_android.sh -Denable-opencl=true -Denable-fp16=true
+
+echo "Copying googletest library..."
+cp -r $ANDROID_NDK/sources/third_party/googletest test/jni
+
+echo "Installing built libraries..."
+ninja install -C builddir
+mkdir -p libs/arm64-v8a
+cp builddir/android_build_result/lib/arm64-v8a/*.so libs/arm64-v8a
+
+echo "Building flash attention FP16 unittest..."
+ndk-build -C test/jni -j$(nproc) MESON_ENABLE_OPENCL=1 MESON_ENABLE_FP16=1 q NDK_DEBUG=0
+
+echo "Deploying to device..."
+adb shell "mkdir -p /data/local/tmp/nntrainer/test"
+adb push test/obj/local/arm64-v8a/unittest_flash_attention_fp16_cl /data/local/tmp/nntrainer/test
+adb push libs/arm64-v8a/*.so /data/local/tmp/nntrainer/test
+adb shell chmod +x /data/local/tmp/nntrainer/test/unittest_flash_attention_fp16_cl
+
+echo "Running flash attention FP16 tests..."
+adb shell "cd /data/local/tmp/nntrainer/test; export LD_LIBRARY_PATH=.; ./unittest_flash_attention_fp16_cl $@"
+
+echo "Collecting logs..."
+adb pull /data/local/tmp/nntrainer/test/logs/. ./logs/ 2>/dev/null || echo "No logs to pull"
+adb shell "rm -f /data/local/tmp/nntrainer/test/logs/*" 2>/dev/null || echo "No log files to clean"
+
+echo "Flash attention FP16 tests completed!"

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -119,7 +119,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -142,7 +141,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -165,7 +163,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -189,7 +186,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -213,7 +209,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -237,7 +232,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -261,7 +255,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -284,7 +277,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -307,7 +299,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -330,7 +321,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -353,7 +343,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -375,7 +364,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -397,7 +385,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -419,7 +406,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -441,7 +427,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -463,7 +448,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -485,7 +469,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -509,7 +492,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -533,7 +515,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -559,7 +540,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -589,7 +569,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -659,7 +638,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -682,7 +660,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -704,7 +681,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -726,7 +702,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -749,7 +724,51 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
+endif
+
+include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := unittest_opencl_kernels_int4_adreno
+LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 $(ARM_MARCH_FLAGS) -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DENABLE_OPENCL=1 
+ifeq ($(NDK_DEBUG),1)
+LOCAL_CFLAGS += -DDEBUG
+endif
+LOCAL_CXXFLAGS += -std=c++17 -frtti
+LOCAL_LDLIBS := -llog -landroid -fopenmp -static-openmp
+
+LOCAL_SRC_FILES := ../unittest/unittest_opencl_kernels_int4_adreno.cpp
+
+LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
+
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+LOCAL_STATIC_LIBRARIES := googletest_main test_util
+
+ifeq ($(MESON_ENABLE_OPENCL), 1)
+LOCAL_SHARED_LIBRARIES += opencl
+endif
+
+include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := unittest_flash_attention_cl
+LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 $(ARM_MARCH_FLAGS) -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DENABLE_OPENCL=1 
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions
+LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
+
+LOCAL_SRC_FILES := \
+	 ../unittest/unittest_flash_attention_cl.cpp
+
+LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
+
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer 
+LOCAL_STATIC_LIBRARIES := googletest_main test_util
+
+
+ifeq ($(MESON_ENABLE_OPENCL), 1)
+LOCAL_SHARED_LIBRARIES += opencl
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -772,7 +791,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -794,7 +812,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
@@ -817,7 +834,6 @@ LOCAL_STATIC_LIBRARIES := googletest_main test_util
 
 ifeq ($(MESON_ENABLE_OPENCL), 1)
 LOCAL_SHARED_LIBRARIES += opencl
-LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -34,6 +34,7 @@ NNTRAINER_INCLUDES := $(NNTRAINER_ROOT)/nntrainer \
 	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend/arm \
 	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend/ggml_interface \
 	$(NNTRAINER_ROOT)/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl \
+	$(NNTRAINER_ROOT)/nntrainer/tensor/cl_operations \
 	$(NNTRAINER_ROOT)/nntrainer/utils \
 	$(NNTRAINER_ROOT)/api \
 	$(NNTRAINER_ROOT)/api/ccapi/include \
@@ -772,7 +773,51 @@ LOCAL_SHARED_LIBRARIES += opencl
 endif
 
 include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := unittest_flash_attention_fp16_cl
+LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 $(ARM_MARCH_FLAGS) -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DENABLE_OPENCL=1 -DUSE__FP16=1
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions
+LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
+
+LOCAL_SRC_FILES := \
+	 ../unittest/unittest_flash_attention_fp16_cl.cpp
+
+LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
+
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer 
+LOCAL_STATIC_LIBRARIES := googletest_main test_util
+
+
+ifeq ($(MESON_ENABLE_OPENCL), 1)
+LOCAL_SHARED_LIBRARIES += opencl
 endif
+
+include $(BUILD_EXECUTABLE)
+endif
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := simple_test
+LOCAL_CFLAGS := -Igoogletest/include -I../include -I../unittest/layers -I../../nntrainer/layers/loss -pthread -fexceptions -fopenmp -static-openmp -DMIN_CPP_VERSION=201703L -DNNTR_NUM_THREADS=1 -D__LOGGING__=1 -DENABLE_TEST=1 -DREDUCE_TOLERANCE=1 $(ARM_MARCH_FLAGS) -O3 -frtti -DNDK_BUILD=1 -DENABLE_FP16=1 -DENABLE_OPENCL=1 
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions
+LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
+
+LOCAL_SRC_FILES := \
+	 ../unittest/simple_test.cpp
+
+LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES)
+
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer 
+LOCAL_STATIC_LIBRARIES := googletest_main test_util
+
+
+ifeq ($(MESON_ENABLE_OPENCL), 1)
+LOCAL_SHARED_LIBRARIES += opencl
+endif
+
+include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
 

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -94,6 +94,7 @@ endif
 if get_option('enable-fp16')
   test_target += [['unittest_nntrainer_tensor_fp16', []]]
   test_target += [['unittest_nntrainer_tensor_pool_fp16', []]]
+  test_target += [['unittest_flash_attention_fp16_cl', []]]
 endif
 
 if get_option('enable-profile')

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -88,6 +88,7 @@ if get_option('enable-opencl')
   test_target += [['unittest_opencl_kernels_int4', []]]
   test_target += [['unittest_opencl_kernels_qk_k', []]]
   test_target += [['unittest_attention_kernels_cl', []]]
+  test_target += [['unittest_flash_attention_cl', []]]
 endif
 
 if get_option('enable-fp16')

--- a/test/unittest/simple_test.cpp
+++ b/test/unittest/simple_test.cpp
@@ -1,0 +1,14 @@
+#include <flash_attention.h>
+#include <iostream>
+#include <cl_context.h>
+
+int main() {
+    std::cout << "Test program" << std::endl;
+    
+    // Try to call the function to see if it links
+    // This is just a test call, not a real test
+    _FP16* dummy = nullptr;
+    nntrainer::flash_attention_fp16_cl(dummy, dummy, dummy, dummy, 0, 0, 0, 0, 0, 0, 0.0f);
+    
+    return 0;
+}

--- a/test/unittest/unittest_flash_attention_cl.cpp
+++ b/test/unittest/unittest_flash_attention_cl.cpp
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file	unittest_flash_attention_cl.cpp
+ * @date	24 March 2026
+ * @brief	Test setup for flash attention OpenCL kernels
+ * @see		https://github.com/nntrainer/nntrainer
+ * @author	Anup Dhakal <anup.dhakal@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#include <fstream>
+#include <gtest/gtest.h>
+#include <type_traits>
+
+#include "nntrainer_test_util.h"
+#include "util_func.h"
+#include <flash_attention.h>
+#include <cl_context.h>
+#include <layer_context.h>
+#include <tensor.h>
+
+#define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
+  EXPECT_GE((VAL), (MIN));                                                     \
+  EXPECT_LE((VAL), (MAX))
+
+using namespace nntrainer;
+
+/**
+ * @brief Test flash attention kernel implementation for GQA
+ */
+static void run_flash_attention_test(const int seqlen_q, const int seqlen_k,
+                                        const int head_dim, const int num_heads_q,
+                                        const int num_heads_kv, const int batch);
+
+/**
+ * @brief Test case for GQA configuration: head_dim=128, q_len=512, kv_len=512, n_heads_q=16, n_heads_kv=8, batch=1
+ */
+TEST(nntrainer_opencl_kernels_flash_attention, flash_attention_test_gqa_512_512_128_16_8) {
+  // For GQA, we need to adjust the test to handle different numbers of query and key/value heads
+  const int seqlen_q = 512;
+  const int seqlen_k = 512;
+  const int head_dim = 128;
+  const int num_heads_q = 16;
+  const int num_heads_kv = 8;
+  const int batch = 1;
+  
+  // Run GQA test with the above configuration
+  run_flash_attention_test(seqlen_q, seqlen_k, head_dim, num_heads_q, num_heads_kv, batch);
+}
+
+/**
+ * @brief Test case for GQA configuration: head_dim=128, q_len=1, kv_len=512, n_heads_q=16, n_heads_kv=8, batch=1
+ */
+TEST(nntrainer_opencl_kernels_flash_attention, flash_attention_test_gqa_1_512_128_16_8) {
+  // For GQA, we need to adjust the test to handle different numbers of query and key/value heads
+  const int seqlen_q = 1;
+  const int seqlen_k = 512;
+  const int head_dim = 128;
+  const int num_heads_q = 16;
+  const int num_heads_kv = 8;
+  const int batch = 1;
+  
+  // Run GQA test with the above configuration
+  run_flash_attention_test(seqlen_q, seqlen_k, head_dim, num_heads_q, num_heads_kv, batch);
+}
+
+/**
+ * @brief Test flash attention kernel implementation for GQA
+ */
+static void run_flash_attention_test(const int seqlen_q, const int seqlen_k,
+                                        const int head_dim, const int num_heads_q,
+                                        const int num_heads_kv, const int batch) {
+  auto *blas_cc = static_cast<nntrainer::ClContext *>(
+    nntrainer::Engine::Global().getRegisteredContext("gpu"));
+
+  const float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+  const float alpha = 1e-3f;
+  const int MOD = 10;
+
+  // Allocate host memory for GQA
+  // Query: batch * num_heads_q * seqlen_q * head_dim
+  // Key/Value: batch * num_heads_kv * seqlen_k * head_dim
+  // Output: batch * num_heads_q * seqlen_q * head_dim
+  std::vector<float> query_h(batch * num_heads_q * seqlen_q * head_dim);
+  std::vector<float> key_h(batch * num_heads_kv * seqlen_k * head_dim);
+  std::vector<float> value_h(batch * num_heads_kv * seqlen_k * head_dim);
+  std::vector<float> output_h_ref(batch * num_heads_q * seqlen_q * head_dim, 0.0f);
+  std::vector<float> output_h_gpu(batch * num_heads_q * seqlen_q * head_dim, 0.0f);
+
+  // Initialize input data
+  for (size_t i = 0; i < query_h.size(); ++i) {
+    query_h[i] = ((static_cast<float>(i % MOD) - MOD/2.0f) * alpha);
+  }
+  for (size_t i = 0; i < key_h.size(); ++i) {
+    key_h[i] = ((static_cast<float>(i % MOD) - MOD/2.0f) * alpha);
+  }
+  for (size_t i = 0; i < value_h.size(); ++i) {
+    value_h[i] = ((static_cast<float>(i % MOD) - MOD/2.0f) * alpha);
+  }
+
+  // Compute reference output for GQA
+  auto cpu_t1 = std::chrono::high_resolution_clock::now();
+  flash_attention_cpu(query_h.data(), key_h.data(), value_h.data(),
+                                output_h_ref.data(), seqlen_q, seqlen_k, head_dim,
+                                num_heads_q, num_heads_kv, batch, scale);
+  auto cpu_t2 = std::chrono::high_resolution_clock::now();
+  auto cpu_dt = std::chrono::duration_cast<std::chrono::microseconds>(cpu_t2 - cpu_t1).count();
+
+  // Allocate GPU memory
+  float *query_d = (float *)allocateSVM(batch * num_heads_q * seqlen_q * head_dim * sizeof(float));
+  float *key_d = (float *)allocateSVM(batch * num_heads_kv * seqlen_k * head_dim * sizeof(float));
+  float *value_d = (float *)allocateSVM(batch * num_heads_kv * seqlen_k * head_dim * sizeof(float));
+  float *output_d = (float *)allocateSVM(batch * num_heads_q * seqlen_q * head_dim * sizeof(float));
+
+  // Copy data to GPU
+  blas_cc->command_queue_inst_.enqueueSVMMap(query_d, batch * num_heads_q * seqlen_q * head_dim * sizeof(float), false);
+  blas_cc->command_queue_inst_.enqueueSVMMap(key_d, batch * num_heads_kv * seqlen_k * head_dim * sizeof(float), false);
+  blas_cc->command_queue_inst_.enqueueSVMMap(value_d, batch * num_heads_kv * seqlen_k * head_dim * sizeof(float), false);
+  blas_cc->command_queue_inst_.enqueueSVMMap(output_d, batch * num_heads_q * seqlen_q * head_dim * sizeof(float), false);
+
+  for (size_t i = 0; i < query_h.size(); ++i) {
+    query_d[i] = query_h[i];
+  }
+  for (size_t i = 0; i < key_h.size(); ++i) {
+    key_d[i] = key_h[i];
+  }
+  for (size_t i = 0; i < value_h.size(); ++i) {
+    value_d[i] = value_h[i];
+  }
+
+  blas_cc->command_queue_inst_.enqueueSVMUnmap(query_d);
+  blas_cc->command_queue_inst_.enqueueSVMUnmap(key_d);
+  blas_cc->command_queue_inst_.enqueueSVMUnmap(value_d);
+  blas_cc->command_queue_inst_.enqueueSVMUnmap(output_d);
+
+  // Run standard GPU kernel with GQA support
+  auto t1 = std::chrono::high_resolution_clock::now();
+  nntrainer::flash_attention_fp32_cl(query_d, key_d, value_d, output_d, 
+                                 seqlen_q, seqlen_k, head_dim, num_heads_q, num_heads_kv, batch, scale);
+  
+  auto t2 = std::chrono::high_resolution_clock::now();
+  auto gpu_dt = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
+
+  std::cout << "Flash Attention GQA Standard GPU time: " << gpu_dt << " μs" << std::endl;
+  std::cout << "Flash Attention GQA CPU time: " << cpu_dt << " μs" << std::endl;
+  std::cout << "GQA Standard Speedup: " << (float)cpu_dt / (float)gpu_dt << "x" << std::endl;
+
+  // Copy result back to host
+  blas_cc->command_queue_inst_.enqueueSVMMap(output_d, batch * num_heads_q * seqlen_q * head_dim * sizeof(float), true);
+  for (size_t i = 0; i < output_h_gpu.size(); ++i) {
+    output_h_gpu[i] = output_d[i];
+  }
+  blas_cc->command_queue_inst_.enqueueSVMUnmap(output_d);
+
+  // Compare results
+  float mse_error = mse<float>(output_h_ref.data(), output_h_gpu.data(), output_h_ref.size());
+  double cos_sim = cosine_similarity<float>(output_h_ref.data(), output_h_gpu.data(), output_h_ref.size());
+
+  const float epsilon = 1e-5f;
+  EXPECT_IN_RANGE(mse_error, 0, epsilon);
+  EXPECT_IN_RANGE((float)cos_sim, 0.99, 1);
+
+  std::cout << "GQA MSE Error: " << mse_error << std::endl;
+  std::cout << "GQA Cosine Similarity: " << cos_sim << std::endl;
+  
+  std::cout << "GQA Configuration: seqlen_q=" << seqlen_q << ", seqlen_k=" << seqlen_k 
+            << ", head_dim=" << head_dim << ", num_heads_q=" << num_heads_q 
+            << ", num_heads_kv=" << num_heads_kv << ", batch=" << batch << std::endl;
+
+  // Cleanup
+  freeSVM(query_d);
+  freeSVM(key_d);
+  freeSVM(value_d);
+  freeSVM(output_d);
+}
+
+/**
+ * @brief Main function for the test
+ */
+GTEST_API_ int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during InitGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}

--- a/test/unittest/unittest_flash_attention_fp16_cl.cpp
+++ b/test/unittest/unittest_flash_attention_fp16_cl.cpp
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file	unittest_flash_attention_fp16_cl.cpp
+ * @date	24 March 2026
+ * @brief	Test setup for flash attention FP16 OpenCL kernels
+ * @see		https://github.com/nntrainer/nntrainer
+ * @author	Anup Dhakal <anup.dhakal@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#include <fstream>
+#include <gtest/gtest.h>
+#include <type_traits>
+
+#include "nntrainer_test_util.h"
+#include "util_func.h"
+#include <flash_attention.h>
+#include <cl_context.h>
+#include <layer_context.h>
+#include <tensor.h>
+
+#define EXPECT_IN_RANGE(VAL, MIN, MAX)                                         \
+  EXPECT_GE((VAL), (MIN));                                                     \
+  EXPECT_LE((VAL), (MAX))
+
+using namespace nntrainer;
+
+/**
+ * @brief Test flash attention kernel implementation for GQA with FP16
+ */
+static void run_flash_attention_fp16_test(const int seqlen_q, const int seqlen_k,
+                                        const int head_dim, const int num_heads_q,
+                                        const int num_heads_kv, const int batch);
+
+/**
+ * @brief Test case for GQA configuration: head_dim=128, q_len=512, kv_len=512, n_heads_q=16, n_heads_kv=8, batch=1
+ */
+TEST(nntrainer_opencl_kernels_flash_attention, flash_attention_test_fp16_gqa_512_512_128_16_8) {
+  // For GQA, we need to adjust the test to handle different numbers of query and key/value heads
+  const int seqlen_q = 512;
+  const int seqlen_k = 512;
+  const int head_dim = 128;
+  const int num_heads_q = 16;
+  const int num_heads_kv = 8;
+  const int batch = 1;
+  
+  // Run GQA test with the above configuration
+  run_flash_attention_fp16_test(seqlen_q, seqlen_k, head_dim, num_heads_q, num_heads_kv, batch);
+}
+
+/**
+ * @brief Test case for GQA configuration: head_dim=128, q_len=1, kv_len=512, n_heads_q=16, n_heads_kv=8, batch=1
+ */
+TEST(nntrainer_opencl_kernels_flash_attention, flash_attention_test_fp16_gqa_1_512_128_16_8) {
+  // For GQA, we need to adjust the test to handle different numbers of query and key/value heads
+  const int seqlen_q = 1;
+  const int seqlen_k = 512;
+  const int head_dim = 128;
+  const int num_heads_q = 16;
+  const int num_heads_kv = 8;
+  const int batch = 1;
+  
+  // Run GQA test with the above configuration
+  run_flash_attention_fp16_test(seqlen_q, seqlen_k, head_dim, num_heads_q, num_heads_kv, batch);
+}
+
+/**
+ * @brief Test flash attention kernel implementation for GQA with FP16
+ */
+static void run_flash_attention_fp16_test(const int seqlen_q, const int seqlen_k,
+                                        const int head_dim, const int num_heads_q,
+                                        const int num_heads_kv, const int batch) {
+  auto *blas_cc = static_cast<nntrainer::ClContext *>(
+    nntrainer::Engine::Global().getRegisteredContext("gpu"));
+
+  const float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+  const float alpha = 1e-3f;
+  const int MOD = 10;
+
+  // Allocate host memory for GQA
+  // Query: batch * num_heads_q * seqlen_q * head_dim
+  // Key/Value: batch * num_heads_kv * seqlen_k * head_dim
+  // Output: batch * num_heads_q * seqlen_q * head_dim
+  std::vector<_FP16> query_h(batch * num_heads_q * seqlen_q * head_dim);
+  std::vector<_FP16> key_h(batch * num_heads_kv * seqlen_k * head_dim);
+  std::vector<_FP16> value_h(batch * num_heads_kv * seqlen_k * head_dim);
+  std::vector<float> output_h_ref(batch * num_heads_q * seqlen_q * head_dim, 0.0f);
+  std::vector<_FP16> output_h_gpu(batch * num_heads_q * seqlen_q * head_dim, 0.0f);
+
+  // Initialize input data
+  for (size_t i = 0; i < query_h.size(); ++i) {
+    query_h[i] = static_cast<_FP16>(((static_cast<float>(i % MOD) - MOD/2.0f) * alpha));
+  }
+  for (size_t i = 0; i < key_h.size(); ++i) {
+    key_h[i] = static_cast<_FP16>(((static_cast<float>(i % MOD) - MOD/2.0f) * alpha));
+  }
+  for (size_t i = 0; i < value_h.size(); ++i) {
+    value_h[i] = static_cast<_FP16>(((static_cast<float>(i % MOD) - MOD/2.0f) * alpha));
+  }
+
+  // Compute reference output for GQA using FP32 (run 100 times for average timing)
+  std::vector<float> query_fp32(query_h.size());
+  std::vector<float> key_fp32(key_h.size());
+  std::vector<float> value_fp32(value_h.size());
+  
+  for (size_t i = 0; i < query_h.size(); ++i) {
+    query_fp32[i] = static_cast<float>(query_h[i]);
+  }
+  for (size_t i = 0; i < key_h.size(); ++i) {
+    key_fp32[i] = static_cast<float>(key_h[i]);
+  }
+  for (size_t i = 0; i < value_h.size(); ++i) {
+    value_fp32[i] = static_cast<float>(value_h[i]);
+  }
+  
+  // Run CPU computation once to get single run time
+  auto cpu_t1 = std::chrono::high_resolution_clock::now();
+  flash_attention_cpu(query_fp32.data(), key_fp32.data(), value_fp32.data(),
+                                output_h_ref.data(), seqlen_q, seqlen_k, head_dim,
+                                num_heads_q, num_heads_kv, batch, scale);
+  auto cpu_t2 = std::chrono::high_resolution_clock::now();
+  auto single_cpu_dt = std::chrono::duration_cast<std::chrono::microseconds>(cpu_t2 - cpu_t1).count();
+  
+  // Run CPU computation 100 times for average timing
+  const int cpu_iterations = 100;
+  long long total_cpu_time = 0;
+  
+  // Warmup run
+  std::vector<float> output_h_ref_warmup(batch * num_heads_q * seqlen_q * head_dim, 0.0f);
+  flash_attention_cpu(query_fp32.data(), key_fp32.data(), value_fp32.data(),
+                                output_h_ref_warmup.data(), seqlen_q, seqlen_k, head_dim,
+                                num_heads_q, num_heads_kv, batch, scale);
+  
+  // Actual timing runs
+  for (int i = 0; i < cpu_iterations; ++i) {
+    std::vector<float> output_h_ref_timed(batch * num_heads_q * seqlen_q * head_dim, 0.0f);
+    auto cpu_t1 = std::chrono::high_resolution_clock::now();
+    flash_attention_cpu(query_fp32.data(), key_fp32.data(), value_fp32.data(),
+                                  output_h_ref_timed.data(), seqlen_q, seqlen_k, head_dim,
+                                  num_heads_q, num_heads_kv, batch, scale);
+    auto cpu_t2 = std::chrono::high_resolution_clock::now();
+    auto cpu_dt = std::chrono::duration_cast<std::chrono::microseconds>(cpu_t2 - cpu_t1).count();
+    total_cpu_time += cpu_dt;
+  }
+  
+  auto avg_cpu_dt = total_cpu_time / cpu_iterations;
+
+  // Allocate GPU memory
+  _FP16 *query_d = (_FP16 *)allocateSVM(batch * num_heads_q * seqlen_q * head_dim * sizeof(_FP16));
+  _FP16 *key_d = (_FP16 *)allocateSVM(batch * num_heads_kv * seqlen_k * head_dim * sizeof(_FP16));
+  _FP16 *value_d = (_FP16 *)allocateSVM(batch * num_heads_kv * seqlen_k * head_dim * sizeof(_FP16));
+  _FP16 *output_d = (_FP16 *)allocateSVM(batch * num_heads_q * seqlen_q * head_dim * sizeof(_FP16));
+
+  // Copy data to GPU
+  blas_cc->command_queue_inst_.enqueueSVMMap(query_d, batch * num_heads_q * seqlen_q * head_dim * sizeof(_FP16), false);
+  blas_cc->command_queue_inst_.enqueueSVMMap(key_d, batch * num_heads_kv * seqlen_k * head_dim * sizeof(_FP16), false);
+  blas_cc->command_queue_inst_.enqueueSVMMap(value_d, batch * num_heads_kv * seqlen_k * head_dim * sizeof(_FP16), false);
+  blas_cc->command_queue_inst_.enqueueSVMMap(output_d, batch * num_heads_q * seqlen_q * head_dim * sizeof(_FP16), false);
+
+  for (size_t i = 0; i < query_h.size(); ++i) {
+    query_d[i] = query_h[i];
+  }
+  for (size_t i = 0; i < key_h.size(); ++i) {
+    key_d[i] = key_h[i];
+  }
+  for (size_t i = 0; i < value_h.size(); ++i) {
+    value_d[i] = value_h[i];
+  }
+
+  blas_cc->command_queue_inst_.enqueueSVMUnmap(query_d);
+  blas_cc->command_queue_inst_.enqueueSVMUnmap(key_d);
+  blas_cc->command_queue_inst_.enqueueSVMUnmap(value_d);
+  blas_cc->command_queue_inst_.enqueueSVMUnmap(output_d);
+
+  // Run FP16 GPU kernel with GQA support for timing
+  // First, do a single run to get the single run time
+  auto t1 = std::chrono::high_resolution_clock::now();
+  nntrainer::flash_attention_fp16_cl(query_d, key_d, value_d, output_d, 
+                                 seqlen_q, seqlen_k, head_dim, num_heads_q, num_heads_kv, batch, scale);
+  auto t2 = std::chrono::high_resolution_clock::now();
+  auto single_gpu_dt = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
+  
+  // Then run 100 times more for average timing
+  const int num_iterations = 100;
+  long long total_gpu_time = 0;
+  
+  // Warmup run
+  nntrainer::flash_attention_fp16_cl(query_d, key_d, value_d, output_d, 
+                                 seqlen_q, seqlen_k, head_dim, num_heads_q, num_heads_kv, batch, scale);
+  
+  // Actual timing runs
+  for (int i = 0; i < num_iterations; ++i) {
+    auto t1 = std::chrono::high_resolution_clock::now();
+    nntrainer::flash_attention_fp16_cl(query_d, key_d, value_d, output_d, 
+                                   seqlen_q, seqlen_k, head_dim, num_heads_q, num_heads_kv, batch, scale);
+    auto t2 = std::chrono::high_resolution_clock::now();
+    auto gpu_dt = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
+    total_gpu_time += gpu_dt;
+  }
+  
+  auto avg_gpu_dt = total_gpu_time / num_iterations;
+
+  std::cout << "Flash Attention GQA FP16 CPU time (single run): " << single_cpu_dt / 1000 << " ms" << std::endl;
+  std::cout << "Flash Attention GQA FP16 CPU time (100 runs average): " << avg_cpu_dt / 1000 << " ms" << std::endl;
+  std::cout << "Flash Attention GQA FP16 GPU time (single run): " << single_gpu_dt / 1000 << " ms" << std::endl;
+  std::cout << "Flash Attention GQA FP16 GPU time (100 runs average): " << avg_gpu_dt / 1000 << " ms" << std::endl;
+  std::cout << "GQA FP16 Speedup (single run): " << (float)single_cpu_dt / (float)single_gpu_dt << "x" << std::endl;
+  std::cout << "GQA FP16 Speedup (average): " << (float)avg_cpu_dt / (float)avg_gpu_dt << "x" << std::endl;
+
+  // Copy result back to host
+  blas_cc->command_queue_inst_.enqueueSVMMap(output_d, batch * num_heads_q * seqlen_q * head_dim * sizeof(_FP16), true);
+  for (size_t i = 0; i < output_h_gpu.size(); ++i) {
+    output_h_gpu[i] = output_d[i];
+  }
+  blas_cc->command_queue_inst_.enqueueSVMUnmap(output_d);
+
+  // Compare results (convert FP16 output to FP32 for comparison)
+  std::vector<float> output_h_gpu_fp32(output_h_gpu.size());
+  for (size_t i = 0; i < output_h_gpu.size(); ++i) {
+    output_h_gpu_fp32[i] = static_cast<float>(output_h_gpu[i]);
+  }
+  
+  float mse_error = mse<float>(output_h_ref.data(), output_h_gpu_fp32.data(), output_h_ref.size());
+  double cos_sim = cosine_similarity<float>(output_h_ref.data(), output_h_gpu_fp32.data(), output_h_ref.size());
+
+  const float epsilon = 1e-2f; // Looser epsilon for FP16
+  EXPECT_IN_RANGE(mse_error, 0, epsilon);
+  EXPECT_IN_RANGE((float)cos_sim, 0.95, 1); // Looser cosine similarity for FP16
+
+  std::cout << "GQA FP16 MSE Error: " << mse_error << std::endl;
+  std::cout << "GQA FP16 Cosine Similarity: " << cos_sim << std::endl;
+  
+  std::cout << "GQA FP16 Configuration: seqlen_q=" << seqlen_q << ", seqlen_k=" << seqlen_k 
+            << ", head_dim=" << head_dim << ", num_heads_q=" << num_heads_q 
+            << ", num_heads_kv=" << num_heads_kv << ", batch=" << batch << std::endl;
+
+  // Cleanup
+  freeSVM(query_d);
+  freeSVM(key_d);
+  freeSVM(value_d);
+  freeSVM(output_d);
+}
+
+/**
+ * @brief Main function for the test
+ */
+GTEST_API_ int main(int argc, char **argv) {
+  std::cout << "Inside Main fp16\n";
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during InitGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+} // ENABLE_FP16


### PR DESCRIPTION
## Changes
- Added Flash attention opencl kernel for fp32
- Added unittests for testing the implementation

## Test Report

Test   Case | LLAMA CPU Time | Quick.AI CPU   Time | LLAMA GPU Time | Quick.AI GPU Time
-- | -- | -- | -- | --
head_dim=128   q_len=1 kv_len=512 n_heads_q=16 n_heads_kv=8 batch=1 | 0.210 ms | 6.19396 ms | 0.831 ms | 2.118 ms
head_dim=128   q_len=512 kv_len=512 n_heads_q=16 n_heads_kv=8 batch=1 | 15.944 ms | 814.47 ms | 44.977 ms | 60.3528 ms

**After optimization using local memory**


Test   Case | LLAMA CPU Time | Quick.AI CPU   Time | LLAMA GPU Time | Quick.AI GPU Time
-- | -- | -- | -- | --
head_dim=128   q_len=1 kv_len=512 n_heads_q=16 n_heads_kv=8 batch=1 | 0.210 ms | 1.92 ms | 0.831 ms | 4.98095 ms
head_dim=128   q_len=512 kv_len=512 n_heads_q=16 n_heads_kv=8 batch=1 | 15.944 ms | 607.964 ms | 44.977 ms | 31.9615 ms






