### PR TITLE
[CausalLM] Causal activation fp16

### DIFF
--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -236,6 +236,21 @@ void EmbeddingLayer::save(std::ofstream &file,
   }
 }
 
+void EmbeddingLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  nntrainer::TensorDim in_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  nntrainer::TensorDim out_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  unsigned int height = input_dimensions[0].height();
+
+  in_dim.width(height);
+  out_dim.height(height);
+
+  context.updateInput(SINGLE_INOUT_IDX, in_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, out_dim);
+}
+
 #ifdef PLUGGABLE
 
 nntrainer::Layer *create_embedding_layer() {

--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -140,8 +140,7 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
         void *q4_row = (void *)((char *)weight.getData<uint8_t>() +
                                 (18 * num_blocks_per_row) * embed_idx);
         if (out_tensor.getDataType() == nntrainer::TensorDim::DataType::FP32) {
-          nntrainer::dequantize_row_q4_0(q4_row, out_tensor.getData(),
-                                         out_dim);
+          nntrainer::dequantize_row_q4_0(q4_row, out_tensor.getData(), out_dim);
 #ifdef ENABLE_FP16
         } else if (out_tensor.getDataType() ==
                    nntrainer::TensorDim::DataType::FP16) {
@@ -149,8 +148,7 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
                                          out_dim);
 #endif
         } else {
-          nntrainer::dequantize_row_q4_0(q4_row, out_tensor.getData(),
-                                         out_dim);
+          nntrainer::dequantize_row_q4_0(q4_row, out_tensor.getData(), out_dim);
         }
       } else {
         out_tensor.copyData(cur_weight);

--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -137,10 +137,17 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
       } else if (weight.getDataType() == nntrainer::TensorDim::DataType::Q4_0) {
         ///@note this should be replaced with quantizer operation
         int num_blocks_per_row = (weight.width() + 32 - 1) / 32;
-        nntrainer::dequantize_row_q4_0(
-          (void *)((char *)weight.getData<uint8_t>() +
-                   (18 * num_blocks_per_row) * embed_idx),
-          out_tensor.getData(), out_dim);
+        if (out_tensor.getDataType() == nntrainer::TensorDim::DataType::FP32) {
+          nntrainer::dequantize_row_q4_0(
+            (void *)((char *)weight.getData<uint8_t>() +
+                     (18 * num_blocks_per_row) * embed_idx),
+            out_tensor.getData(), out_dim);
+        } else {
+          nntrainer::dequantize_row_q4_0(
+            (void *)((char *)weight.getData<uint8_t>() +
+                     (18 * num_blocks_per_row) * embed_idx),
+            out_tensor.getData<_FP16>(), out_dim);
+        }
       } else {
         out_tensor.copyData(cur_weight);
       }

--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -137,16 +137,20 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
       } else if (weight.getDataType() == nntrainer::TensorDim::DataType::Q4_0) {
         ///@note this should be replaced with quantizer operation
         int num_blocks_per_row = (weight.width() + 32 - 1) / 32;
+        void *q4_row = (void *)((char *)weight.getData<uint8_t>() +
+                                (18 * num_blocks_per_row) * embed_idx);
         if (out_tensor.getDataType() == nntrainer::TensorDim::DataType::FP32) {
-          nntrainer::dequantize_row_q4_0(
-            (void *)((char *)weight.getData<uint8_t>() +
-                     (18 * num_blocks_per_row) * embed_idx),
-            out_tensor.getData(), out_dim);
+          nntrainer::dequantize_row_q4_0(q4_row, out_tensor.getData(),
+                                         out_dim);
+#ifdef ENABLE_FP16
+        } else if (out_tensor.getDataType() ==
+                   nntrainer::TensorDim::DataType::FP16) {
+          nntrainer::dequantize_row_q4_0(q4_row, out_tensor.getData<_FP16>(),
+                                         out_dim);
+#endif
         } else {
-          nntrainer::dequantize_row_q4_0(
-            (void *)((char *)weight.getData<uint8_t>() +
-                     (18 * num_blocks_per_row) * embed_idx),
-            out_tensor.getData<_FP16>(), out_dim);
+          nntrainer::dequantize_row_q4_0(q4_row, out_tensor.getData(),
+                                         out_dim);
         }
       } else {
         out_tensor.copyData(cur_weight);

--- a/Applications/CausalLM/layers/embedding_layer.h
+++ b/Applications/CausalLM/layers/embedding_layer.h
@@ -94,6 +94,10 @@ public:
   exportTo(nntrainer::Exporter &exporter,
            const ml::train::ExportMethods &method) const override;
 
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
   /**
    * @copydoc Layer::getType()
    */

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -1476,25 +1476,25 @@ void MHACoreLayer::updateTensorsByInputDimensions(
     std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
   unsigned int &max_new_tokens =
     std::get<props::MaxNewTokens>(mha_core_props).get();
-  max_position_embeddings =
-    std::get<props::MaxPositionEmbeddings>(mha_core_props).get();
   max_timestep = height + max_new_tokens;
 
-  ml::train::TensorDim kv_dim = input_dimensions[0];
-  kv_dim.width(kv_dim.width() / (num_heads_Q / num_heads_KV));
+  ml::train::TensorDim q_dim = context.getInput(INOUT_INDEX::QUERY).getDim();
+  q_dim.height(input_dimensions[0].height());
 
-  ml::train::TensorDim kv_cache_dim = kv_dim;
-#ifdef ENABLE_FP16
-  kv_cache_dim.setDataType(ml::train::TensorDim::DataType::FP16);
-#else
-  kv_cache_dim.setDataType(ml::train::TensorDim::DataType::UINT16);
-#endif
+  ml::train::TensorDim kv_dim = context.getInput(INOUT_INDEX::KEY).getDim();
+
+  ml::train::TensorDim kv_cache_dim =
+    context.getTensor(tensor_idx[AttentionParams::cache_key]).getDim();
   kv_cache_dim.height(max_timestep);
 
-  context.updateInput(INOUT_INDEX::QUERY, input_dimensions[0]);
+  ml::train::TensorDim output_dim =
+    context.getOutput(INOUT_INDEX::OUTPUT).getDim();
+  output_dim.height(input_dimensions[0].height());
+
+  context.updateInput(INOUT_INDEX::QUERY, q_dim);
   context.updateInput(INOUT_INDEX::KEY, kv_dim);
   context.updateInput(INOUT_INDEX::VALUE, kv_dim);
-  context.updateOutput(0, input_dimensions[0]);
+  context.updateOutput(0, output_dim);
 
   context.updateTensor(tensor_idx[AttentionParams::cache_key], kv_cache_dim);
   context.updateTensor(tensor_idx[AttentionParams::cache_value], kv_cache_dim);

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -1483,9 +1483,14 @@ void MHACoreLayer::updateTensorsByInputDimensions(
 
   ml::train::TensorDim kv_dim = context.getInput(INOUT_INDEX::KEY).getDim();
 
-  ml::train::TensorDim kv_cache_dim =
-    context.getTensor(tensor_idx[AttentionParams::cache_key]).getDim();
-  kv_cache_dim.height(max_timestep);
+  if (!use_external_cache) {
+    ml::train::TensorDim kv_cache_dim =
+      context.getTensor(tensor_idx[AttentionParams::cache_key]).getDim();
+    kv_cache_dim.height(max_timestep);
+
+    context.updateTensor(tensor_idx[AttentionParams::cache_key], kv_cache_dim);
+    context.updateTensor(tensor_idx[AttentionParams::cache_value], kv_cache_dim);
+  }
 
   ml::train::TensorDim output_dim =
     context.getOutput(INOUT_INDEX::OUTPUT).getDim();
@@ -1495,9 +1500,6 @@ void MHACoreLayer::updateTensorsByInputDimensions(
   context.updateInput(INOUT_INDEX::KEY, kv_dim);
   context.updateInput(INOUT_INDEX::VALUE, kv_dim);
   context.updateOutput(0, output_dim);
-
-  context.updateTensor(tensor_idx[AttentionParams::cache_key], kv_cache_dim);
-  context.updateTensor(tensor_idx[AttentionParams::cache_value], kv_cache_dim);
 }
 
 void MHACoreLayer::calcDerivative(nntrainer::RunLayerContext &context) {}

--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -27,6 +27,13 @@ void ReshapedRMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
   NNTR_THROW_IF(dim[0].width() % feature_size != 0, std::invalid_argument)
     << "feature size must be a divisor of width";
 
+  if (dim[0].getDataType() == ml::train::TensorDim::DataType::FP16) {
+    ml::train::TensorDim in_out_fp32_dim = dim[0];
+    in_out_fp32_dim.setDataType(ml::train::TensorDim::DataType::FP32);
+    input_fp32 = std::make_shared<nntrainer::Tensor>(in_out_fp32_dim);
+    output_fp32 = std::make_shared<nntrainer::Tensor>(in_out_fp32_dim);
+  }
+
   nntrainer::TensorDim gamma_dim(
     1, 1, 1, feature_size,
     nntrainer::TensorDim::TensorType(context.getFormat(),
@@ -93,11 +100,39 @@ void ReshapedRMSNormLayer::incremental_forwarding(
         in_step.getData<float>(), out_step.getData<float>(),
         in_step.getDim().height(), in_step.getDim().width(), epsilon);
 #endif
+      out_step.multiply_i(gamma);
+    } else if (in_step.getDataType() == ml::train::TensorDim::DataType::FP16) {
+      ml::train::TensorDim in_step_fp32_dim = in_step_dim;
+      ml::train::TensorDim out_step_fp32_dim = out_step_dim;
+      in_step_fp32_dim.setDataType(ml::train::TensorDim::DataType::FP32);
+      out_step_fp32_dim.setDataType(ml::train::TensorDim::DataType::FP32);
+
+      nntrainer::Tensor in_step_fp32 = input_fp32->getSharedDataTensor(
+        in_step_fp32_dim, b * in_dim.getFeatureLen(), true);
+      nntrainer::Tensor out_step_fp32 = output_fp32->getSharedDataTensor(
+        out_step_fp32_dim, b * out_dim.getFeatureLen(), true);
+
+      in_step_fp32.reshape(step_reshaped_dim);
+      out_step_fp32.reshape(step_reshaped_dim);
+
+      in_step_fp32.copyData(in_step);
+
+#ifdef ENABLE_FP16
+      nntrainer::rms_norm_wrt_width_fp16_intrinsic(
+        in_step_fp32.getData<float>(), out_step_fp32.getData<float>(),
+        in_step_fp32.getDim().height(), in_step_fp32.getDim().width(), epsilon);
+#else
+      nntrainer::rms_norm_wrt_width_fp32_intrinsic(
+        in_step_fp32.getData<float>(), out_step_fp32.getData<float>(),
+        in_step_fp32.getDim().height(), in_step_fp32.getDim().width(), epsilon);
+#endif
+      out_step_fp32.multiply_i(gamma);
+
+      out_step.copyData(out_step_fp32);
     } else {
       throw std::invalid_argument(
         "Error: not yet implemented for this data type");
     }
-    out_step.multiply_i(gamma);
 
     // reshape again out_step
     out_step.reshape(out_step_dim);
@@ -112,8 +147,22 @@ void ReshapedRMSNormLayer::incremental_forwarding(
 void ReshapedRMSNormLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  input_dim.height(input_dimensions[0].height());
+  output_dim.height(input_dimensions[0].height());
+
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  if (input_dim.getDataType() == ml::train::TensorDim::DataType::FP16) {
+    ml::train::TensorDim in_out_fp32_dim = input_dim;
+    in_out_fp32_dim.setDataType(ml::train::TensorDim::DataType::FP32);
+    input_fp32 = std::make_shared<nntrainer::Tensor>(in_out_fp32_dim);
+    output_fp32 = std::make_shared<nntrainer::Tensor>(in_out_fp32_dim);
+  }
 }
 
 void ReshapedRMSNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/reshaped_rms_norm.h
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.h
@@ -11,8 +11,8 @@
  * @note   This layer only supports inference mode.
  */
 
-#ifndef __RMS_NORM_LAYER_H__
-#define __RMS_NORM_LAYER_H__
+#ifndef __RESHAPED_RMS_NORM_LAYER_H__
+#define __RESHAPED_RMS_NORM_LAYER_H__
 
 #pragma once
 #ifdef _WIN32
@@ -48,7 +48,9 @@ public:
     Layer(),
     rms_props(props::RMS_NORM_GAMMA_INIT(), nntrainer::props::Epsilon(),
               props::FeatureSize()),
-    feature_size(0) {
+    feature_size(0),
+    input_fp32(),
+    output_fp32() {
     wt_idx.fill(std::numeric_limits<unsigned int>::max());
   }
 
@@ -122,6 +124,8 @@ private:
   std::tuple<props::RMS_NORM_GAMMA_INIT, nntrainer::props::Epsilon,
              props::FeatureSize>
     rms_props;
+  std::shared_ptr<nntrainer::Tensor> input_fp32;
+  std::shared_ptr<nntrainer::Tensor> output_fp32;
 
   unsigned int feature_size;
 };

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -23,6 +23,14 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 void RMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
   std::vector<nntrainer::TensorDim> dim = context.getInputDimensions();
   context.setOutputDimensions(dim);
+
+  if (dim[0].getDataType() == ml::train::TensorDim::DataType::FP16) {
+    ml::train::TensorDim in_out_fp32_dim = dim[0];
+    in_out_fp32_dim.setDataType(ml::train::TensorDim::DataType::FP32);
+    input_fp32 = std::make_shared<nntrainer::Tensor>(in_out_fp32_dim);
+    output_fp32 = std::make_shared<nntrainer::Tensor>(in_out_fp32_dim);
+  }
+
   nntrainer::TensorDim gamma_dim(
     1, 1, 1, dim[0].width(),
     nntrainer::TensorDim::TensorType(context.getFormat(),
@@ -69,11 +77,30 @@ void RMSNormLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
       auto t = in_step.multiply(in_step).average(3).add(epsilon);
       t.inv_sqrt_i();
       in_step.multiply(t, out_step);
+      out_step.multiply_i(gamma);
+    } else if (in_step.getDataType() == ml::train::TensorDim::DataType::FP16) {
+      ml::train::TensorDim in_step_fp32_dim = in_step_dim;
+      ml::train::TensorDim out_step_fp32_dim = out_step_dim;
+      in_step_fp32_dim.setDataType(ml::train::TensorDim::DataType::FP32);
+      out_step_fp32_dim.setDataType(ml::train::TensorDim::DataType::FP32);
+
+      nntrainer::Tensor in_step_fp32 = input_fp32->getSharedDataTensor(
+        in_step_fp32_dim, b * in_dim.getFeatureLen(), true);
+      nntrainer::Tensor out_step_fp32 = output_fp32->getSharedDataTensor(
+        out_step_fp32_dim, b * out_dim.getFeatureLen(), true);
+
+      in_step_fp32.copyData(in_step);
+
+      auto t = in_step_fp32.multiply(in_step_fp32).average(3).add(epsilon);
+      t.inv_sqrt_i();
+      in_step_fp32.multiply(t, out_step_fp32);
+      out_step_fp32.multiply_i(gamma);
+
+      out_step.copyData(out_step_fp32);
     } else {
       throw std::invalid_argument(
         "Error: not yet implemented for this data type");
     }
-    out_step.multiply_i(gamma);
 
 #ifdef DEBUG
     std::cout << context.getName() << " \n input:" << in_step
@@ -85,8 +112,22 @@ void RMSNormLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
 void RMSNormLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  input_dim.height(input_dimensions[0].height());
+  output_dim.height(input_dimensions[0].height());
+
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  if (input_dim.getDataType() == ml::train::TensorDim::DataType::FP16) {
+    ml::train::TensorDim in_out_fp32_dim = input_dim;
+    in_out_fp32_dim.setDataType(ml::train::TensorDim::DataType::FP32);
+    input_fp32 = std::make_shared<nntrainer::Tensor>(in_out_fp32_dim);
+    output_fp32 = std::make_shared<nntrainer::Tensor>(in_out_fp32_dim);
+  }
 }
 
 void RMSNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/rms_norm.h
+++ b/Applications/CausalLM/layers/rms_norm.h
@@ -43,7 +43,8 @@ public:
    * @brief Construct a new custom RMS normalization layer object
    *
    */
-  WIN_EXPORT RMSNormLayer() : Layer(), wt_idx({0}) {}
+  WIN_EXPORT RMSNormLayer() :
+    Layer(), wt_idx({0}), input_fp32(), output_fp32() {}
 
   /**
    * @brief Destroy the custom RMS normalization layer object
@@ -113,6 +114,8 @@ public:
 private:
   std::array<unsigned int, 1> wt_idx;
   std::tuple<props::RMS_NORM_GAMMA_INIT, nntrainer::props::Epsilon> rms_props;
+  std::shared_ptr<nntrainer::Tensor> input_fp32;
+  std::shared_ptr<nntrainer::Tensor> output_fp32;
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/llm_util.cpp
+++ b/Applications/CausalLM/llm_util.cpp
@@ -12,6 +12,40 @@
  */
 
 #include <llm_util.hpp>
+#include <tensor_dim.h>
+
+std::vector<unsigned int>
+generate_multi_tokens(ml::train::TensorDim::IO_TensorType logits,
+                      unsigned int NUM_VOCAB, unsigned int NUM_TARGET_TOKENS,
+                      float repetition_penalty, unsigned int *input_ids,
+                      unsigned int NUM_INPUT_IDS, unsigned int *bad_words_ids,
+                      unsigned int NUM_BAD_WORDS_IDS) {
+
+  std::vector<unsigned int> ret;
+  float *logits_fp32;
+
+  if (std::holds_alternative<float *>(logits)) {
+    logits_fp32 = std::get<float *>(logits);
+  } else if (std::holds_alternative<_FP16 *>(logits)) {
+    logits_fp32 = new float[NUM_VOCAB];
+    _FP16 *logits_fp16 = std::get<_FP16 *>(logits);
+    for (size_t i = 0; i < NUM_VOCAB; ++i) {
+      logits_fp32[i] = (float)logits_fp16[i];
+    }
+  } else {
+    throw std::invalid_argument("logit data type is not supported");
+  }
+
+  ret = generate_multi_tokens(logits_fp32, NUM_VOCAB, NUM_TARGET_TOKENS,
+                              repetition_penalty, input_ids, NUM_INPUT_IDS,
+                              bad_words_ids, NUM_BAD_WORDS_IDS);
+
+  if (std::holds_alternative<_FP16 *>(logits)) {
+    delete[] logits_fp32;
+  }
+
+  return ret;
+}
 
 std::vector<unsigned int> generate_multi_tokens(
   float *logits, unsigned int NUM_VOCAB, unsigned int NUM_TARGET_TOKENS,

--- a/Applications/CausalLM/llm_util.cpp
+++ b/Applications/CausalLM/llm_util.cpp
@@ -26,12 +26,14 @@ generate_multi_tokens(ml::train::TensorDim::IO_TensorType logits,
 
   if (std::holds_alternative<float *>(logits)) {
     logits_fp32 = std::get<float *>(logits);
+#ifdef ENABLE_FP16
   } else if (std::holds_alternative<_FP16 *>(logits)) {
     logits_fp32 = new float[NUM_VOCAB];
     _FP16 *logits_fp16 = std::get<_FP16 *>(logits);
     for (size_t i = 0; i < NUM_VOCAB; ++i) {
       logits_fp32[i] = (float)logits_fp16[i];
     }
+#endif
   } else {
     throw std::invalid_argument("logit data type is not supported");
   }
@@ -40,9 +42,11 @@ generate_multi_tokens(ml::train::TensorDim::IO_TensorType logits,
                               repetition_penalty, input_ids, NUM_INPUT_IDS,
                               bad_words_ids, NUM_BAD_WORDS_IDS);
 
+#ifdef ENABLE_FP16
   if (std::holds_alternative<_FP16 *>(logits)) {
     delete[] logits_fp32;
   }
+#endif
 
   return ret;
 }

--- a/Applications/CausalLM/llm_util.hpp
+++ b/Applications/CausalLM/llm_util.hpp
@@ -88,6 +88,17 @@ T unwrap(std::optional<T> &&value, const std::string &error_msg) {
  * generate multiple tokens
  */
 std::vector<unsigned int> generate_multi_tokens(
+  ml::train::TensorDim::IO_TensorType logits, unsigned int NUM_VOCAB = 0,
+  unsigned int NUM_TARGET_TOKENS = 1, float repetition_penalty = 1,
+  unsigned int *input_ids = nullptr, unsigned int NUM_INPUT_IDS = 0,
+  unsigned int *bad_words_ids = nullptr, unsigned int NUM_BAD_WORDS_IDS = 0);
+
+/**
+ * @brief generate multi tokens from logits
+ * @note This function apply repetition penalty, bad words penalty, and sort to
+ * generate multiple tokens
+ */
+std::vector<unsigned int> generate_multi_tokens(
   float *logits, unsigned int NUM_VOCAB = 0, unsigned int NUM_TARGET_TOKENS = 1,
   float repetition_penalty = 1, unsigned int *input_ids = nullptr,
   unsigned int NUM_INPUT_IDS = 0, unsigned int *bad_words_ids = nullptr,

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -272,6 +272,7 @@ CausalLM::generate(ml::train::TensorDim::IO_TensorType logits, bool do_sample,
 
   if (std::holds_alternative<float *>(logits)) {
     logits_fp32_ptr = std::get<float *>(logits);
+#ifdef ENABLE_FP16
   } else if (std::holds_alternative<_FP16 *>(logits)) {
     if (!logits_fp32) {
       std::shared_ptr<float[]> buffer(new float[NUM_VOCAB]);
@@ -282,6 +283,9 @@ CausalLM::generate(ml::train::TensorDim::IO_TensorType logits, bool do_sample,
     for (size_t i = 0; i < NUM_VOCAB; ++i) {
       logits_fp32_ptr[i] = (float)logits_fp16[i];
     }
+#endif
+  } else {
+    throw std::invalid_argument("logit data type is not supported");
   }
 
   ret = generate(logits_fp32_ptr, do_sample, repetition_penalty, input_ids,
@@ -483,7 +487,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
       cache_inputs.begin(), cache_inputs.end(),
       [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
 
-    std::vector<float *> inference_inputs;
+    std::vector<ml::train::TensorDim::IO_TensorType> inference_inputs;
     inference_inputs.reserve(1 + cache_inputs.size());
     inference_inputs.push_back(input_sample);
     for (const auto &cache_input : cache_inputs)
@@ -561,9 +565,11 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     if (std::holds_alternative<float *>(out)) {
       float *out_ptr = std::get<float *>(out);
       delete[] out_ptr;
+#ifdef ENABLE_FP16
     } else if (std::holds_alternative<_FP16 *>(out)) {
       _FP16 *out_ptr = std::get<_FP16 *>(out);
       delete[] out_ptr;
+#endif
     }
   }
 
@@ -611,9 +617,11 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
       if (std::holds_alternative<float *>(out)) {
         float *out_ptr = std::get<float *>(out);
         delete[] out_ptr;
+#ifdef ENABLE_FP16
       } else if (std::holds_alternative<_FP16 *>(out)) {
         _FP16 *out_ptr = std::get<_FP16 *>(out);
         delete[] out_ptr;
+#endif
       }
     }
 

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -465,10 +465,10 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   input = build_inference_inputs();
 
   ///@note contains possible bug
-  // std::vector<ml::train::TensorDim> input_dims;
-  // ml::train::TensorDim input_dim(1, 1, input_len, DIM);
-  // input_dims.push_back(input_dim);
-  // model->resetInputDimension(input_dims);
+  std::vector<ml::train::TensorDim> input_dims;
+  ml::train::TensorDim input_dim(1, 1, input_len, DIM);
+  input_dims.push_back(input_dim);
+  model->resetInputDimension(input_dims);
 
   auto start_prefill = std::chrono::high_resolution_clock::now();
 

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -268,24 +268,24 @@ CausalLM::generate(ml::train::TensorDim::IO_TensorType logits, bool do_sample,
                    float repetition_penalty, unsigned int *input_ids,
                    unsigned int NUM_INPUT_IDS) {
   std::vector<unsigned int> ret;
-  float *logits_fp32;
+  float *logits_fp32_ptr;
 
   if (std::holds_alternative<float *>(logits)) {
-    logits_fp32 = std::get<float *>(logits);
+    logits_fp32_ptr = std::get<float *>(logits);
   } else if (std::holds_alternative<_FP16 *>(logits)) {
-    logits_fp32 = new float[NUM_VOCAB];
+    if (!logits_fp32) {
+      std::shared_ptr<float[]> buffer(new float[NUM_VOCAB]);
+      logits_fp32 = std::move(buffer);
+    }
+    logits_fp32_ptr = logits_fp32.get();
     const _FP16 *logits_fp16 = std::get<_FP16 *>(logits);
     for (size_t i = 0; i < NUM_VOCAB; ++i) {
-      logits_fp32[i] = (float)logits_fp16[i];
+      logits_fp32_ptr[i] = (float)logits_fp16[i];
     }
   }
 
-  ret = generate(logits_fp32, do_sample, repetition_penalty, input_ids,
+  ret = generate(logits_fp32_ptr, do_sample, repetition_penalty, input_ids,
                  NUM_INPUT_IDS);
-
-  if (std::holds_alternative<_FP16 *>(logits)) {
-    delete[] logits_fp32;
-  }
 
   return ret;
 }

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -38,6 +38,7 @@
 #include <mha_core.h>
 #include <nntrainer_error.h>
 #include <tensor.h>
+#include <tensor_dim.h>
 
 #include <causal_lm.h>
 #include <llm_util.hpp>
@@ -262,6 +263,33 @@ void CausalLM::load_kvcache(std::string path, int to_) {
   setKVCachePosition(static_cast<unsigned int>(to_));
 }
 
+std::vector<unsigned int>
+CausalLM::generate(ml::train::TensorDim::IO_TensorType logits, bool do_sample,
+                   float repetition_penalty, unsigned int *input_ids,
+                   unsigned int NUM_INPUT_IDS) {
+  std::vector<unsigned int> ret;
+  float *logits_fp32;
+
+  if (std::holds_alternative<float *>(logits)) {
+    logits_fp32 = std::get<float *>(logits);
+  } else if (std::holds_alternative<_FP16 *>(logits)) {
+    logits_fp32 = new float[NUM_VOCAB];
+    const _FP16 *logits_fp16 = std::get<_FP16 *>(logits);
+    for (size_t i = 0; i < NUM_VOCAB; ++i) {
+      logits_fp32[i] = (float)logits_fp16[i];
+    }
+  }
+
+  ret = generate(logits_fp32, do_sample, repetition_penalty, input_ids,
+                 NUM_INPUT_IDS);
+
+  if (std::holds_alternative<_FP16 *>(logits)) {
+    delete[] logits_fp32;
+  }
+
+  return ret;
+}
+
 std::vector<unsigned int> CausalLM::generate(float *logits, bool do_sample,
                                              float repetition_penalty,
                                              unsigned int *input_ids,
@@ -366,8 +394,8 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   /**
    * INPUT PREPARATION
    */
-  std::vector<float *> input;
-  std::vector<float *> label;
+  std::vector<ml::train::TensorDim::IO_TensorType> input;
+  std::vector<ml::train::TensorDim::IO_TensorType> label;
 
   /**
    * SAVE_KVCACHE ?
@@ -472,7 +500,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   auto start_prefill = std::chrono::high_resolution_clock::now();
 
-  std::vector<float *> output;
+  std::vector<ml::train::TensorDim::IO_TensorType> output;
 
   if (SAVE_KVCACHE) {
     //@note This is for the save the kv cache. precomputed kv cache should be
@@ -530,7 +558,13 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   // output should be deallocated after use
   for (auto &out : output) {
-    delete[] out;
+    if (std::holds_alternative<float *>(out)) {
+      float *out_ptr = std::get<float *>(out);
+      delete[] out_ptr;
+    } else if (std::holds_alternative<_FP16 *>(out)) {
+      _FP16 *out_ptr = std::get<_FP16 *>(out);
+      delete[] out_ptr;
+    }
   }
 
   auto finish_prefill = std::chrono::high_resolution_clock::now();
@@ -574,7 +608,13 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
     // output should be deallocated after use
     for (auto out : output_interval) {
-      delete[] out;
+      if (std::holds_alternative<float *>(out)) {
+        float *out_ptr = std::get<float *>(out);
+        delete[] out_ptr;
+      } else if (std::holds_alternative<_FP16 *>(out)) {
+        _FP16 *out_ptr = std::get<_FP16 *>(out);
+        delete[] out_ptr;
+      }
     }
 
     // check FINISH

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -115,6 +115,15 @@ protected:
   /**
    * @brief generate
    */
+  std::vector<unsigned int> generate(ml::train::TensorDim::IO_TensorType logits,
+                                     bool do_sample,
+                                     float repetition_penalty = 1,
+                                     unsigned int *input_ids = nullptr,
+                                     unsigned int NUM_INPUT_IDS = 0);
+
+  /**
+   * @brief generate
+   */
   std::vector<unsigned int> generate(float *logits, bool do_sample,
                                      float repetition_penalty = 1,
                                      unsigned int *input_ids = nullptr,

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -39,6 +39,8 @@
 #define WCHAR_P std::string &
 #endif
 
+#include <memory>
+
 #include <kv_cache_manager.h>
 #include <transformer.h>
 
@@ -158,6 +160,8 @@ protected:
   unsigned int global_token_len;
 
   std::mt19937 rng; /**< Random Number Gen */
+
+  std::shared_ptr<float[]> logits_fp32;
 
   /**
    * @brief Externalized KV cache (host-owned). Allocated by allocateKVCache()

--- a/Applications/CausalLM/models/gemma3/gemma3_causallm.cpp
+++ b/Applications/CausalLM/models/gemma3/gemma3_causallm.cpp
@@ -83,7 +83,7 @@ Tensor Gemma3Transformer::createTransformerDecoderBlock(const int layer_id,
     "rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_attention_norm"),
      withKey("epsilon", std::to_string(NORM_EPS)),
-     withKey("packed", "false")}));
+     withKey("weight_dtype", "fp32")}));
   Tensor normed = attn_norm(input);
 
   Tensor att_out = createAttention(layer_id, INIT_SEQ_LEN, NUM_HEADS, HEAD_DIM,
@@ -93,7 +93,7 @@ Tensor Gemma3Transformer::createTransformerDecoderBlock(const int layer_id,
     "rms_norm", {withKey("name", "layer" + std::to_string(layer_id) +
                                    "_post_attention_norm"),
                  withKey("epsilon", std::to_string(NORM_EPS)),
-                 withKey("packed", "false")}));
+                 withKey("weight_dtype", "fp32")}));
   Tensor post_normed = post_attn_norm(att_out);
 
   LayerHandle post_attn_add(createLayer(
@@ -105,7 +105,7 @@ Tensor Gemma3Transformer::createTransformerDecoderBlock(const int layer_id,
     "rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "pre_ffn_norm"),
      withKey("epsilon", std::to_string(NORM_EPS)),
-     withKey("packed", "false")}));
+     withKey("weight_dtype", "fp32")}));
   Tensor pre_ffn = pre_ffn_norm(post_attn);
 
   Tensor ffn_out = createMlp(layer_id, DIM, INTERMEDIATE_SIZE, pre_ffn);
@@ -114,7 +114,7 @@ Tensor Gemma3Transformer::createTransformerDecoderBlock(const int layer_id,
     "rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "post_ffn_norm"),
      withKey("epsilon", std::to_string(NORM_EPS)),
-     withKey("packed", "false")}));
+     withKey("weight_dtype", "fp32")}));
   Tensor post_ffn = post_ffn_norm(ffn_out);
 
   LayerHandle decoder_output(createLayer(
@@ -159,7 +159,8 @@ Tensor Gemma3Transformer::createAttention(const int layer_id, int seq_len,
   LayerHandle q_norm(createLayer(
     "reshaped_rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_q_norm"),
-     withKey("packed", "false"), withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("weight_dtype", "fp32"),
+     withKey("epsilon", std::to_string(NORM_EPS)),
      withKey("feature_size", std::to_string(head_dim))}));
   Tensor q_normed = q_norm(q);
 
@@ -167,7 +168,8 @@ Tensor Gemma3Transformer::createAttention(const int layer_id, int seq_len,
   LayerHandle k_norm(createLayer(
     "reshaped_rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_k_norm"),
-     withKey("packed", "false"), withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("weight_dtype", "fp32"),
+     withKey("epsilon", std::to_string(NORM_EPS)),
      withKey("feature_size", std::to_string(head_dim))}));
   Tensor k_normed = k_norm(k);
 

--- a/Applications/CausalLM/models/qwen3/qwen3_causallm.cpp
+++ b/Applications/CausalLM/models/qwen3/qwen3_causallm.cpp
@@ -47,7 +47,8 @@ Tensor Qwen3Transformer::createAttention(const int layer_id, int seq_len,
   LayerHandle q_norm(createLayer(
     "reshaped_rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_q_norm"),
-     withKey("packed", "false"), withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("weight_dtype", "fp32"),
+     withKey("epsilon", std::to_string(NORM_EPS)),
      withKey("feature_size", std::to_string(head_dim))}));
   Tensor q_normed = q_norm(q);
 
@@ -63,7 +64,8 @@ Tensor Qwen3Transformer::createAttention(const int layer_id, int seq_len,
   LayerHandle k_norm(createLayer(
     "reshaped_rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_k_norm"),
-     withKey("packed", "false"), withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("weight_dtype", "fp32"),
+     withKey("epsilon", std::to_string(NORM_EPS)),
      withKey("feature_size", std::to_string(head_dim))}));
   Tensor k_normed = k_norm(k);
 

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -246,7 +246,7 @@ std::pair<Tensor, Tensor> Transformer::constructModel() {
   LayerHandle out_norm(
     createLayer("rms_norm", {withKey("name", "output_norm"),
                              withKey("epsilon", std::to_string(NORM_EPS)),
-                             withKey("packed", "false")}));
+                             withKey("weight_dtype", "fp32")}));
   h = out_norm(h);
 
   return {x, h};
@@ -339,7 +339,7 @@ Tensor Transformer::createTransformerDecoderBlock(const int layer_id,
     "rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_attention_norm"),
      withKey("epsilon", std::to_string(NORM_EPS)),
-     withKey("packed", "false")}));
+     withKey("weight_dtype", "fp32")}));
   Tensor normed = attn_norm(input);
 
   Tensor att_out = createAttention(layer_id, INIT_SEQ_LEN, NUM_HEADS, HEAD_DIM,
@@ -354,7 +354,7 @@ Tensor Transformer::createTransformerDecoderBlock(const int layer_id,
     "rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_norm"),
      withKey("epsilon", std::to_string(NORM_EPS)),
-     withKey("packed", "false")}));
+     withKey("weight_dtype", "fp32")}));
   Tensor ffn_normed = ffn_norm(residual);
 
   Tensor ffn_out = createMlp(layer_id, DIM, INTERMEDIATE_SIZE, ffn_normed);

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -232,6 +232,7 @@ std::pair<Tensor, Tensor> Transformer::constructModel() {
   LayerHandle embedding(createLayer(
     embedding_type,
     {"name=embedding0", "in_dim=" + std::to_string(NUM_VOCAB),
+     "input_shape=1:1:" + std::to_string(INIT_SEQ_LEN), "input_dtype=FP32",
      "weight_dtype=" + EMBEDDING_DTYPE, "out_dim=" + std::to_string(DIM),
      "scale=" + std::to_string(EMBEDDING_SCALE)}));
   Tensor h = embedding(x);

--- a/Applications/LLaMA/jni/main.cpp
+++ b/Applications/LLaMA/jni/main.cpp
@@ -402,7 +402,7 @@ Tensor createTransformerDecoder(const int layer_id, Tensor input) {
     "rms_norm", {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                               "_attention_norm"),
                  nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
-                 nntrainer::withKey("packed", "false")}));
+                 nntrainer::withKey("weight_dtype", "fp32")}));
   auto normed = att_norm(input);
 
   auto att_out = createAttentionLayer(layer_id, INIT_SEQ_LEN, NUM_HEADS,
@@ -418,7 +418,7 @@ Tensor createTransformerDecoder(const int layer_id, Tensor input) {
     "rms_norm", {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                               "_ffn_norm"),
                  nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
-                 nntrainer::withKey("packed", "false")}));
+                 nntrainer::withKey("weight_dtype", "fp32")}));
   auto ffn_normed = ffn_norm(residual);
 
   auto ffn_out =
@@ -450,7 +450,7 @@ std::pair<Tensor, Tensor> buildLLaMAGraph() {
   LayerHandle out_norm(createLayer(
     "rms_norm", {nntrainer::withKey("name", "output_norm"),
                  nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
-                 nntrainer::withKey("packed", "false")}));
+                 nntrainer::withKey("weight_dtype", "fp32")}));
   h = out_norm(h);
 
   LayerHandle out_fc(createLayer("fully_connected",

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -18,6 +18,7 @@
 
 #if __cplusplus >= MIN_CPP_VERSION
 
+#include <initializer_list>
 #include <map>
 #include <string>
 #include <type_traits>
@@ -400,6 +401,33 @@ public:
   virtual std::vector<float *>
   inference(unsigned int batch, const std::vector<float *> &input,
             const std::vector<float *> &label = std::vector<float *>()) = 0;
+
+  /**
+   * @brief     Run the inference of the model with float pointer inputs
+   * @param[in] batch batch size of current input
+   * @param[in] input inputs as a list of each input data
+   * @retval list of output as float *
+   * @note The output memory must not be freed by the caller
+   */
+  std::vector<float *> inference(unsigned int batch,
+                                 std::initializer_list<float *> input) {
+    return inference(batch, std::vector<float *>(input));
+  }
+
+  /**
+   * @brief     Run the inference of the model with float pointer inputs
+   * @param[in] batch batch size of current input
+   * @param[in] input inputs as a list of each input data
+   * @param[in] label labels as a list of each label data
+   * @retval list of output as float *
+   * @note The output memory must not be freed by the caller
+   */
+  std::vector<float *> inference(unsigned int batch,
+                                 std::initializer_list<float *> input,
+                                 std::initializer_list<float *> label) {
+    return inference(batch, std::vector<float *>(input),
+                     std::vector<float *>(label));
+  }
 
   /**
    * @brief     Run the incremental inference of the model

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -439,10 +439,10 @@ public:
    * @param[in] to next working step index
    * @param[in] output_hidden_state (NYI) true to return all hidden state,
    * false to return last hidden state
-   * @retval list of output as float *
-   * @note If output_hidden_state is false, the output memory must be freed by
-   * the caller after use. Otherwise, the output memory must not be freed by the
-   * caller.
+   * @retval list of output as IO_TensorType
+   * @note If output_hidden_state is false, the output memory inside each
+   * IO_TensorType variant must be freed by the caller after use. Otherwise,
+   * the output memory must not be freed by the caller.
    */
   virtual std::vector<TensorDim::IO_TensorType>
   incremental_inference(unsigned int batch,

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -380,6 +380,20 @@ public:
    * @param[in] batch batch size of current input
    * @param[in] input inputs as a list of each input data
    * @param[in] label labels as a list of each label data
+   * @retval list of output as IO_TensorType
+   * @note The output memory must not be freed by the caller
+   */
+  virtual std::vector<TensorDim::IO_TensorType>
+  inference(unsigned int batch,
+            const std::vector<TensorDim::IO_TensorType> &input,
+            const std::vector<TensorDim::IO_TensorType> &label =
+              std::vector<TensorDim::IO_TensorType>()) = 0;
+
+  /**
+   * @brief     Run the inference of the model
+   * @param[in] batch batch size of current input
+   * @param[in] input inputs as a list of each input data
+   * @param[in] label labels as a list of each label data
    * @retval list of output as float *
    * @note The output memory must not be freed by the caller
    */
@@ -401,6 +415,26 @@ public:
    * @note If output_hidden_state is false, the output memory must be freed by
    * the caller after use. Otherwise, the output memory must not be freed by the
    * caller.
+   */
+  virtual std::vector<TensorDim::IO_TensorType>
+  incremental_inference(unsigned int batch,
+                        const std::vector<TensorDim::IO_TensorType> &input,
+                        const std::vector<TensorDim::IO_TensorType> &label,
+                        unsigned int init_seq_len, unsigned int from,
+                        unsigned int to, bool output_hidden_state = false) = 0;
+
+  /**
+   * @brief     Run the incremental inference of the model
+   * @param[in] batch batch size of current input
+   * @param[in] input inputs as a list of each input data
+   * @param[in] label labels as a list of each label data
+   * @param[in] init_seq_len initial sequence length
+   * @param[in] from current working step index
+   * @param[in] to next working step index
+   * @param[in] output_hidden_state return last hidden state if true else return
+   * all hidden state
+   * @retval list of output as float *
+   * @note The output memory must not be freed by the caller
    */
   virtual std::vector<float *>
   incremental_inference(unsigned int batch, const std::vector<float *> &input,

--- a/api/ccapi/include/tensor_dim.h
+++ b/api/ccapi/include/tensor_dim.h
@@ -17,9 +17,10 @@
 #ifdef __cplusplus
 
 #include <array>
-#include <iosfwd>
-
 #include <bitset>
+#include <cstdint>
+#include <iosfwd>
+#include <variant>
 #include <vector>
 
 #ifdef ENABLE_FP16
@@ -39,6 +40,14 @@ namespace train {
  */
 class TensorDim {
 public:
+#ifdef ENABLE_FP16
+  using IO_TensorType = std::variant<float *, uint32_t *, uint16_t *, uint8_t *,
+                                     int16_t *, int8_t *, _FP16 *>;
+#else
+  using IO_TensorType = std::variant<float *, uint32_t *, uint16_t *, uint8_t *,
+                                     int16_t *, int8_t *>;
+#endif
+
   static constexpr const size_t MAXDIM = 4;
 
   /**

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -694,11 +694,6 @@ NetworkGraph::canExecuteInPlace(const std::shared_ptr<LayerNode> &lnode) {
     return inplace_type;
   }
 
-  if (lnode->getType() == InputLayer::type &&
-      !istrequal(getTensorType()[2], "FP32")) {
-    return InPlaceType::NONE;
-  }
-
   if (lnode->getType() == MultiOutLayer::type) {
     return InPlaceType::RESTRICTING;
   }
@@ -812,21 +807,26 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
           TensorSpecV2::RequestType::READ_ONLY_VIEW;
         if (lnode->getType() == IdentityLayer::type) {
           s.variable_spec.reference_name = inputs[i]->getName();
+          s.variable_spec.dim.setDataType(inputs[i]->getDim().getDataType());
           s.variable_spec.dim.setFormat(inputs[i]->getDim().getFormat());
         } else if (lnode->getInPlaceDirection() == InPlaceDirection::RIGHT) {
           s.variable_spec.reference_name = inputs[1]->getName();
+          s.variable_spec.dim.setDataType(inputs[1]->getDim().getDataType());
           s.variable_spec.dim.setFormat(inputs[1]->getDim().getFormat());
         } else if (lnode->getType() == WeightLayer::type) {
           WeightSpec w_spec = init_context.getWeightsSpec()[i];
           s.variable_spec.reference_name = std::get<8>(w_spec);
+          s.variable_spec.dim.setDataType(std::get<0>(w_spec).getDataType());
           s.variable_spec.dim.setFormat(std::get<0>(w_spec).getFormat());
         } else if (lnode->getType() == TensorLayer::type) {
           InitLayerContext::TensorSpec t_spec =
             init_context.getTensorsSpec()[i];
           s.variable_spec.reference_name = std::get<3>(t_spec);
+          s.variable_spec.dim.setDataType(std::get<0>(t_spec).getDataType());
           s.variable_spec.dim.setFormat(std::get<0>(t_spec).getFormat());
         } else {
           s.variable_spec.reference_name = inputs[0]->getName();
+          s.variable_spec.dim.setDataType(inputs[0]->getDim().getDataType());
           s.variable_spec.dim.setFormat(inputs[0]->getDim().getFormat());
         }
       }
@@ -835,23 +835,28 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
           TensorSpecV2::RequestType::READ_ONLY_VIEW;
         if (lnode->getType() == IdentityLayer::type) {
           s.gradient_spec->reference_name = inputs[i]->getGradientName();
+          s.gradient_spec->dim.setDataType(inputs[i]->getDim().getDataType());
           s.gradient_spec->dim.setFormat(inputs[i]->getDim().getFormat());
         } else if (lnode->getInPlaceDirection() == InPlaceDirection::RIGHT) {
           s.gradient_spec->reference_name = inputs[1]->getGradientName();
+          s.gradient_spec->dim.setDataType(inputs[1]->getDim().getDataType());
           s.gradient_spec->dim.setFormat(inputs[1]->getDim().getFormat());
         } else if (lnode->getType() == WeightLayer::type) {
           WeightSpec w_spec = init_context.getWeightsSpec()[i];
           s.gradient_spec->reference_name =
             std::get<8>(w_spec) + Var_Grad::grad_suffix;
+          s.gradient_spec->dim.setDataType(std::get<0>(w_spec).getDataType());
           s.gradient_spec->dim.setFormat(std::get<0>(w_spec).getFormat());
         } else if (lnode->getType() == TensorLayer::type) {
           InitLayerContext::TensorSpec t_spec =
             init_context.getTensorsSpec()[i];
           s.gradient_spec->reference_name =
             std::get<3>(t_spec) + Var_Grad::grad_suffix;
+          s.gradient_spec->dim.setDataType(std::get<0>(t_spec).getDataType());
           s.gradient_spec->dim.setFormat(std::get<0>(t_spec).getFormat());
         } else {
           s.gradient_spec->reference_name = inputs[0]->getGradientName();
+          s.gradient_spec->dim.setDataType(inputs[0]->getDim().getDataType());
           s.gradient_spec->dim.setFormat(inputs[0]->getDim().getFormat());
         }
       }

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -100,10 +100,17 @@ void AdditionLayer::setProperty(const std::vector<std::string> &values) {
 void AdditionLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  input_dim.height(input_dimensions[0].height());
+  output_dim.height(input_dimensions[0].height());
+
   for (size_t i = 0; i < context.getNumInputs(); ++i) {
-    context.updateInput(i, input_dimensions[0]);
+    context.updateInput(i, input_dim);
   }
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -376,4 +376,18 @@ void FullyConnectedLayer::calcGradient(RunLayerContext &context) {
   }
 }
 
+void FullyConnectedLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  input_dim.height(input_dimensions[0].height());
+  output_dim.height(input_dimensions[0].height());
+
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -109,6 +109,10 @@ public:
   void setBatch(nntrainer::RunLayerContext &context,
                 unsigned int batch) override;
 
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "fully_connected";
 
 private:

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -71,13 +71,11 @@ void InputLayer::exportTo(Exporter &exporter,
 }
 
 void InputLayer::finalize(InitLayerContext &context) {
-
   std::vector<TensorDim> output_dims = context.getInputDimensions();
   for (auto &d : output_dims) {
     if (d.getDataType() == ml::train::TensorDim::DataType::FP32)
       d.setDataType(context.getActivationDataType());
   }
-
   context.setOutputDimensions(output_dims);
   is_inplace = output_dims == context.getInputDimensions();
 }

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -83,8 +83,15 @@ void InputLayer::finalize(InitLayerContext &context) {
 void InputLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  input_dim.width(input_dimensions[0].height());
+  output_dim.width(input_dimensions[0].height());
+
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -577,9 +577,9 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
       for (auto &d : actual_prop_dims) {
         d.setDataType(
           input_dtype.empty()
-            ? str_converter<enum_class_prop_tag,
-                            nntrainer::TensorDataTypeInfo>::from_string(
-                tensor_type[2])
+            ? str_converter<
+                enum_class_prop_tag,
+                nntrainer::TensorDataTypeInfo>::from_string(tensor_type[2])
             : input_dtype.get());
         d.setFormat(
           str_converter<enum_class_prop_tag, nntrainer::TensorFormatInfo>::

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -562,6 +562,7 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
   auto &prop_dims = std::get<std::vector<props::InputShape>>(*layer_node_props);
   auto &prop_in_layers =
     std::get<std::vector<props::InputConnection>>(*layer_node_props);
+  auto &input_dtype = std::get<props::InputDtype>(*layer_node_props);
 
   /** prepare input dimensions */
   if (!input_dims.empty()) {
@@ -575,11 +576,19 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
            "property";
       for (auto &d : actual_prop_dims) {
         d.setDataType(
-          str_converter<enum_class_prop_tag, nntrainer::TensorDataTypeInfo>::
-            from_string(tensor_type[2]));
+          input_dtype.empty()
+            ? str_converter<enum_class_prop_tag,
+                            nntrainer::TensorDataTypeInfo>::from_string(
+                tensor_type[2])
+            : input_dtype.get());
         d.setFormat(
           str_converter<enum_class_prop_tag, nntrainer::TensorFormatInfo>::
             from_string(tensor_type[0]));
+      }
+    }
+    if (!input_dtype.empty()) {
+      for (auto &d : actual_input_dims) {
+        d.setDataType(input_dtype.get());
       }
     }
   } else {
@@ -595,7 +604,6 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
       << prop_dims.size();
     actual_input_dims =
       std::vector<TensorDim>(prop_dims.begin(), prop_dims.end());
-    auto &input_dtype = std::get<props::InputDtype>(*layer_node_props);
     const auto dtype =
       input_dtype.empty()
         ? str_converter<enum_class_prop_tag,

--- a/nntrainer/layers/multiout_layer.cpp
+++ b/nntrainer/layers/multiout_layer.cpp
@@ -92,10 +92,16 @@ void MultiOutLayer::setProperty(const std::vector<std::string> &values) {
 void MultiOutLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
 
+  input_dim.height(input_dimensions[0].height());
+  output_dim.height(input_dimensions[0].height());
+
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
   for (size_t i = 0; i < context.getNumOutputs(); ++i) {
-    context.updateOutput(i, input_dimensions[0]);
+    context.updateOutput(i, output_dim);
   }
 }
 

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -1523,6 +1523,9 @@ std::vector<IO_TensorType> NeuralNetwork::incremental_inference(
 #endif
       } else if (out->getDataType() == ml::train::TensorDim::DataType::FP32) {
         last_out_buf_data = new float[batch_size * width];
+      } else {
+        throw std::invalid_argument(
+          "unsupported output data type for incremental_inference");
       }
 
       for (unsigned int batch = 0; batch < batch_size; ++batch) {

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -1262,6 +1262,90 @@ sharedConstTensors NeuralNetwork::inference(sharedConstTensors X,
   return out;
 }
 
+std::vector<IO_TensorType>
+NeuralNetwork::inference(unsigned int batch_size,
+                         const std::vector<IO_TensorType> &input,
+                         const std::vector<IO_TensorType> &label) {
+  sharedConstTensors input_tensors, output_tensors;
+  auto in_dim = getInputDimension();
+
+  input_tensors.reserve(input.size());
+  for (unsigned int idx = 0; idx < in_dim.size(); idx++) {
+    in_dim[idx].batch(batch_size);
+    std::visit(
+      [&input_tensors, &in_dim, idx](auto &&input_ptr) {
+        input_tensors.emplace_back(MAKE_SHARED_TENSOR(
+          Tensor::Map(input_ptr, in_dim[idx].getDataLen() * sizeof(*input_ptr),
+                      in_dim[idx], 0)));
+      },
+      input[idx]);
+  }
+
+  if (!label.empty()) {
+    sharedConstTensors label_tensors;
+    auto label_dim = getOutputDimension();
+    label_tensors.reserve(label.size());
+    for (unsigned int idx = 0; idx < label_dim.size(); idx++) {
+      label_dim[idx].batch(batch_size);
+      std::visit(
+        [&label_tensors, &label_dim, idx](auto &&label_ptr) {
+          label_tensors.emplace_back(MAKE_SHARED_TENSOR(Tensor::Map(
+            label_ptr, label_dim[idx].getDataLen() * sizeof(*label_ptr),
+            label_dim[idx], 0)));
+        },
+        label[idx]);
+    }
+    output_tensors = inference(input_tensors, label_tensors, false);
+  } else {
+    output_tensors = inference(input_tensors, false);
+  }
+
+  std::vector<IO_TensorType> output;
+  output.reserve(output_tensors.size());
+
+  for (auto &out : output_tensors) {
+    auto out_t = *out.get();
+    switch (out_t.getDataType()) {
+    case ml::train::TensorDim::DataType::QINT4:
+    case ml::train::TensorDim::DataType::QINT8:
+      output.push_back(out_t.getData<int8_t>());
+      break;
+    case ml::train::TensorDim::DataType::QINT16:
+      output.push_back(out_t.getData<int16_t>());
+      break;
+    case ml::train::TensorDim::DataType::BCQ:
+      output.push_back(out_t.getData<uint32_t>());
+      break;
+    case ml::train::TensorDim::DataType::UINT4:
+    case ml::train::TensorDim::DataType::UINT8:
+    case ml::train::TensorDim::DataType::Q4_K:
+    case ml::train::TensorDim::DataType::Q6_K:
+    case ml::train::TensorDim::DataType::Q4_0:
+      output.push_back(out_t.getData<uint8_t>());
+      break;
+    case ml::train::TensorDim::DataType::UINT16:
+      output.push_back(out_t.getData<uint16_t>());
+      break;
+    case ml::train::TensorDim::DataType::UINT32:
+      output.push_back(out_t.getData<uint32_t>());
+      break;
+    case ml::train::TensorDim::DataType::FP32:
+      output.push_back(out_t.getData());
+      break;
+#ifdef ENABLE_FP16
+    case ml::train::TensorDim::DataType::FP16:
+      output.push_back(out_t.getData<_FP16>());
+      break;
+#endif
+    default:
+      output.push_back(out_t.getData());
+      break;
+    }
+  }
+
+  return output;
+}
+
 std::vector<float *>
 NeuralNetwork::inference(unsigned int batch_size,
                          const std::vector<float *> &input,
@@ -1337,6 +1421,134 @@ sharedConstTensors NeuralNetwork::incremental_inference(
   model_graph.setInputsLabels({}, {});
 
   return out;
+}
+
+std::vector<IO_TensorType> NeuralNetwork::incremental_inference(
+  unsigned int batch_size, const std::vector<IO_TensorType> &input,
+  const std::vector<IO_TensorType> &label, unsigned int init_seq_len,
+  unsigned int from, unsigned int to, bool output_hidden_state) {
+
+  sharedConstTensors input_tensors, output_tensors;
+  auto in_dim = getInputDimension();
+
+  input_tensors.reserve(input.size());
+  for (unsigned int idx = 0; idx < in_dim.size(); idx++) {
+    in_dim[idx].batch(batch_size);
+    std::visit(
+      [&input_tensors, &in_dim, idx](auto &&input_ptr) {
+        input_tensors.emplace_back(MAKE_SHARED_TENSOR(
+          Tensor::Map(input_ptr, in_dim[idx].getDataLen() * sizeof(*input_ptr),
+                      in_dim[idx], 0)));
+      },
+      input[idx]);
+  }
+
+  if (!label.empty()) {
+    sharedConstTensors label_tensors;
+    auto label_dim = getOutputDimension();
+    label_tensors.reserve(label.size());
+    for (unsigned int idx = 0; idx < label_dim.size(); idx++) {
+      label_dim[idx].batch(batch_size);
+      std::visit(
+        [&label_tensors, &label_dim, idx](auto &&label_ptr) {
+          label_tensors.emplace_back(MAKE_SHARED_TENSOR(Tensor::Map(
+            label_ptr, label_dim[idx].getDataLen() * sizeof(*label_ptr),
+            label_dim[idx], 0)));
+        },
+        label[idx]);
+    }
+    output_tensors = incremental_inference(input_tensors, label_tensors,
+                                           init_seq_len, from, to);
+  } else {
+    output_tensors =
+      incremental_inference(input_tensors, init_seq_len, from, to);
+  }
+
+  std::vector<IO_TensorType> output;
+  output.reserve(output_tensors.size());
+
+  ///@note Always we take the first position of output
+  // unsigned int step = ((to - from) == 0) ? 0 : (to - from) - 1;
+  unsigned int step = 0;
+
+  for (auto &out : output_tensors) {
+    auto out_t = *out.get();
+
+    if (output_hidden_state) {
+      switch (out_t.getDataType()) {
+      case ml::train::TensorDim::DataType::QINT4:
+      case ml::train::TensorDim::DataType::QINT8:
+        output.push_back(out_t.getData<int8_t>());
+        break;
+      case ml::train::TensorDim::DataType::QINT16:
+        output.push_back(out_t.getData<int16_t>());
+        break;
+      case ml::train::TensorDim::DataType::BCQ:
+        output.push_back(out_t.getData<uint32_t>());
+        break;
+      case ml::train::TensorDim::DataType::UINT4:
+      case ml::train::TensorDim::DataType::UINT8:
+      case ml::train::TensorDim::DataType::Q4_K:
+      case ml::train::TensorDim::DataType::Q6_K:
+      case ml::train::TensorDim::DataType::Q4_0:
+        output.push_back(out_t.getData<uint8_t>());
+        break;
+      case ml::train::TensorDim::DataType::UINT16:
+        output.push_back(out_t.getData<uint16_t>());
+        break;
+      case ml::train::TensorDim::DataType::UINT32:
+        output.push_back(out_t.getData<uint32_t>());
+        break;
+      case ml::train::TensorDim::DataType::FP32:
+        output.push_back(out_t.getData());
+        break;
+#ifdef ENABLE_FP16
+      case ml::train::TensorDim::DataType::FP16:
+        output.push_back(out_t.getData<_FP16>());
+        break;
+#endif
+      default:
+        output.push_back(out_t.getData());
+        break;
+      }
+    } else {
+      IO_TensorType last_out_buf_data;
+      size_t width = out_t.width();
+
+      if (out->getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+        last_out_buf_data = new _FP16[batch_size * width];
+#else
+        throw std::invalid_argument("Error: enable-fp16 is not set");
+#endif
+      } else if (out->getDataType() == ml::train::TensorDim::DataType::FP32) {
+        last_out_buf_data = new float[batch_size * width];
+      }
+
+      for (unsigned int batch = 0; batch < batch_size; ++batch) {
+        if (out->getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+          const _FP16 *out_t_batch_ptr =
+            out_t.getData<_FP16>() + batch * out_t.getDim().getFeatureLen() +
+            step * width;
+          scopy(width, out_t_batch_ptr, 1,
+                std::get<_FP16 *>(last_out_buf_data) + batch * width, 1);
+#else
+          throw std::invalid_argument("Error: enable-fp16 is not set");
+#endif
+        } else if (out->getDataType() == ml::train::TensorDim::DataType::FP32) {
+          const float *out_t_batch_ptr =
+            out_t.getData() + batch * out_t.getDim().getFeatureLen() +
+            step * width;
+          scopy(width, out_t_batch_ptr, 1,
+                std::get<float *>(last_out_buf_data) + batch * width, 1);
+        }
+      }
+      output.push_back(last_out_buf_data);
+    }
+  }
+
+  return output;
 }
 
 std::vector<float *> NeuralNetwork::incremental_inference(

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -69,6 +69,7 @@ class DataBuffer;
 using DatasetType = ml::train::DatasetType;
 using DatasetModeType = ml::train::DatasetModeType;
 using RunStats = ml::train::RunStats;
+using IO_TensorType = ml::train::TensorDim::IO_TensorType;
 
 /**
  * @class   NeuralNetwork Class
@@ -367,6 +368,19 @@ public:
    * @param[in] batch batch size of current input
    * @param[in] input inputs as a list of each input data
    * @param[in] label labels as a list of each label data
+   * @retval list of output as IO_TensorType
+   * @note The output memory must not be freed by the caller
+   */
+  std::vector<IO_TensorType> inference(unsigned int batch,
+                                       const std::vector<IO_TensorType> &input,
+                                       const std::vector<IO_TensorType> &label =
+                                         std::vector<IO_TensorType>()) override;
+
+  /**
+   * @brief     Run the inference of the model
+   * @param[in] batch batch size of current input
+   * @param[in] input inputs as a list of each input data
+   * @param[in] label labels as a list of each label data
    * @retval list of output as float *
    * @note The output memory must not be freed by the caller
    */
@@ -414,6 +428,25 @@ public:
    * @note If output_hidden_state is false, the output memory must be freed by
    * the caller after use. Otherwise, the output memory must not be freed by the
    * caller.
+   */
+  std::vector<IO_TensorType> incremental_inference(
+    unsigned int batch, const std::vector<IO_TensorType> &input,
+    const std::vector<IO_TensorType> &label, unsigned int init_seq_len,
+    unsigned int from, unsigned int to,
+    bool output_hidden_state = false) override;
+
+  /**
+   * @brief     Run the incremental inference of the model
+   * @param[in] batch batch size of current input
+   * @param[in] input inputs as a list of each input data
+   * @param[in] label labels as a list of each label data
+   * @param[in] init_seq_len initial sequence length
+   * @param[in] from current working step index
+   * @param[in] to next working step index
+   * @param[in] output_hidden_state return last hidden state if true else return
+   * all hidden state
+   * @retval list of output as float *
+   * @note The output memory must not be freed by the caller
    */
   std::vector<float *>
   incremental_inference(unsigned int batch, const std::vector<float *> &input,

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -424,7 +424,7 @@ public:
    * @param[in] to next working step index
    * @param[in] output_hidden_state (NYI) true to return all hidden state,
    * false to return last hidden state only
-   * @retval list of output as float *
+   * @retval list of output as IO_TensorType
    * @note If output_hidden_state is false, the output memory must be freed by
    * the caller after use. Otherwise, the output memory must not be freed by the
    * caller.

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -452,6 +452,12 @@ void dequantize_row_q4_0(const void *x_raw, float *y, int64_t k) {
   __ggml_dequantize_row_q4_0(x_raw, y, k);
 }
 
+#ifdef ENABLE_FP16
+void dequantize_row_q4_0(const void *x_raw, _FP16 *y, int64_t k) {
+  __ggml_dequantize_row_q4_0(x_raw, y, k);
+}
+#endif
+
 void dequantize_row_q6_K(const void *x, float *y, int64_t k) {
   __ggml_dequantize_row_q6_K(x, y, k);
 }

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1320,6 +1320,17 @@ void dequantize_row_q4_K(const void *x, float *y, int64_t k);
  */
 void dequantize_row_q4_0(const void *x, float *y, int64_t k);
 
+#ifdef ENABLE_FP16
+/**
+ * @brief dequantize row of q4_0 data to float
+ *
+ * @param x input to be dequantized from q4_0 to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+void dequantize_row_q4_0(const void *x, _FP16 *y, int64_t k);
+#endif
+
 /**
  * @brief dequantize row of q6_K data to float
  *

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl_fp16.cpp
@@ -1311,6 +1311,89 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
 
 void swiglu(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z) {
   unsigned int i = 0;
+  float16x8_t neg_alpha_vec = vdupq_n_f16(-1.0f);
+  float16x8_t one = vdupq_n_f16(1.0f);
+
+  for (; N - i >= 32; i += 32) {
+    float16x8_t y0 = vld1q_f16(&Y[i]);
+    float16x8_t y1 = vld1q_f16(&Y[i + 8]);
+    float16x8_t y2 = vld1q_f16(&Y[i + 16]);
+    float16x8_t y3 = vld1q_f16(&Y[i + 24]);
+
+    float16x8_t z0 = vld1q_f16(&Z[i]);
+    float16x8_t z1 = vld1q_f16(&Z[i + 8]);
+    float16x8_t z2 = vld1q_f16(&Z[i + 16]);
+    float16x8_t z3 = vld1q_f16(&Z[i + 24]);
+
+    float16x8_t alpha_y0 = vmulq_f16(y0, neg_alpha_vec);
+    float16x8_t alpha_y1 = vmulq_f16(y1, neg_alpha_vec);
+    float16x8_t alpha_y2 = vmulq_f16(y2, neg_alpha_vec);
+    float16x8_t alpha_y3 = vmulq_f16(y3, neg_alpha_vec);
+
+    float32x4_t exp0_0 = exp_ps(vcvt_f32_f16(vget_low_f16(alpha_y0)));
+    float32x4_t exp0_1 = exp_ps(vcvt_f32_f16(vget_high_f16(alpha_y0)));
+    float16x8_t exp0 = vcombine_f16(vcvt_f16_f32(exp0_0), vcvt_f16_f32(exp0_1));
+    float32x4_t exp1_0 = exp_ps(vcvt_f32_f16(vget_low_f16(alpha_y1)));
+    float32x4_t exp1_1 = exp_ps(vcvt_f32_f16(vget_high_f16(alpha_y1)));
+    float16x8_t exp1 = vcombine_f16(vcvt_f16_f32(exp1_0), vcvt_f16_f32(exp1_1));
+    float32x4_t exp2_0 = exp_ps(vcvt_f32_f16(vget_low_f16(alpha_y2)));
+    float32x4_t exp2_1 = exp_ps(vcvt_f32_f16(vget_high_f16(alpha_y2)));
+    float16x8_t exp2 = vcombine_f16(vcvt_f16_f32(exp2_0), vcvt_f16_f32(exp2_1));
+    float32x4_t exp3_0 = exp_ps(vcvt_f32_f16(vget_low_f16(alpha_y3)));
+    float32x4_t exp3_1 = exp_ps(vcvt_f32_f16(vget_high_f16(alpha_y3)));
+    float16x8_t exp3 = vcombine_f16(vcvt_f16_f32(exp3_0), vcvt_f16_f32(exp3_1));
+
+    exp0 = vaddq_f16(exp0, one);
+    exp1 = vaddq_f16(exp1, one);
+    exp2 = vaddq_f16(exp2, one);
+    exp3 = vaddq_f16(exp3, one);
+
+    exp0 = vdivq_f16(y0, exp0);
+    exp1 = vdivq_f16(y1, exp1);
+    exp2 = vdivq_f16(y2, exp2);
+    exp3 = vdivq_f16(y3, exp3);
+
+    exp0 = vmulq_f16(exp0, z0);
+    exp1 = vmulq_f16(exp1, z1);
+    exp2 = vmulq_f16(exp2, z2);
+    exp3 = vmulq_f16(exp3, z3);
+
+    vst1q_f16(&X[i], exp0);
+    vst1q_f16(&X[i + 8], exp1);
+    vst1q_f16(&X[i + 16], exp2);
+    vst1q_f16(&X[i + 24], exp3);
+  }
+
+  for (; N - i >= 16; i += 16) {
+    float16x8_t y0 = vld1q_f16(&Y[i]);
+    float16x8_t y1 = vld1q_f16(&Y[i + 8]);
+
+    float16x8_t z0 = vld1q_f16(&Z[i]);
+    float16x8_t z1 = vld1q_f16(&Z[i + 8]);
+
+    float16x8_t alpha_y0 = vmulq_f16(y0, neg_alpha_vec);
+    float16x8_t alpha_y1 = vmulq_f16(y1, neg_alpha_vec);
+
+    float32x4_t exp0_0 = exp_ps(vcvt_f32_f16(vget_low_f16(alpha_y0)));
+    float32x4_t exp0_1 = exp_ps(vcvt_f32_f16(vget_high_f16(alpha_y0)));
+    float16x8_t exp0 = vcombine_f16(vcvt_f16_f32(exp0_0), vcvt_f16_f32(exp0_1));
+    float32x4_t exp1_0 = exp_ps(vcvt_f32_f16(vget_low_f16(alpha_y1)));
+    float32x4_t exp1_1 = exp_ps(vcvt_f32_f16(vget_high_f16(alpha_y1)));
+    float16x8_t exp1 = vcombine_f16(vcvt_f16_f32(exp1_0), vcvt_f16_f32(exp1_1));
+
+    exp0 = vaddq_f16(exp0, one);
+    exp1 = vaddq_f16(exp1, one);
+
+    exp0 = vdivq_f16(y0, exp0);
+    exp1 = vdivq_f16(y1, exp1);
+
+    exp0 = vmulq_f16(exp0, z0);
+    exp1 = vmulq_f16(exp1, z1);
+
+    vst1q_f16(&X[i], exp0);
+    vst1q_f16(&X[i + 8], exp1);
+  }
+
   for (; N - i >= 8; i += 8) {
     float16x8_t y0_7 = vld1q_f16(&Y[i]);
     float16x8_t z0_7 = vld1q_f16(&Z[i]);
@@ -1332,6 +1415,30 @@ void swiglu(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z) {
     ++i;
   }
 }
+
+// void swiglu(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z) {
+//   unsigned int i = 0;
+//   for (; N - i >= 8; i += 8) {
+//     float16x8_t y0_7 = vld1q_f16(&Y[i]);
+//     float16x8_t z0_7 = vld1q_f16(&Z[i]);
+//     float16x8_t y0_7_minus = vmulq_n_f16(y0_7, -1);
+
+//     float32x4_t exp0_3 = exp_ps(vcvt_f32_f16(vget_low_f16(y0_7_minus)));
+//     float32x4_t exp4_7 = exp_ps(vcvt_f32_f16(vget_high_f16(y0_7_minus)));
+
+//     float16x8_t exp0_7 =
+//       vcombine_f16(vcvt_f16_f32(exp0_3), vcvt_f16_f32(exp4_7));
+//     exp0_7 = vaddq_f16(exp0_7, vmovq_n_f16(1.f));
+//     exp0_7 = vdivq_f16(y0_7, exp0_7);
+//     exp0_7 = vmulq_f16(exp0_7, z0_7);
+
+//     vst1q_f16(&X[i], exp0_7);
+//   }
+//   while (i < N) {
+//     X[i] = (Y[i] / (1.f + std::exp(static_cast<float>(-Y[i])))) * Z[i];
+//     ++i;
+//   }
+// }
 
 __fp16 max_val(const unsigned int N, __fp16 *X) {
   unsigned int i = 0;

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl_fp16.cpp
@@ -1416,7 +1416,6 @@ void swiglu(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z) {
   }
 }
 
-
 __fp16 max_val(const unsigned int N, __fp16 *X) {
   unsigned int i = 0;
   __fp16 ret = X[i];

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl_fp16.cpp
@@ -1416,29 +1416,6 @@ void swiglu(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z) {
   }
 }
 
-// void swiglu(const unsigned int N, __fp16 *X, __fp16 *Y, __fp16 *Z) {
-//   unsigned int i = 0;
-//   for (; N - i >= 8; i += 8) {
-//     float16x8_t y0_7 = vld1q_f16(&Y[i]);
-//     float16x8_t z0_7 = vld1q_f16(&Z[i]);
-//     float16x8_t y0_7_minus = vmulq_n_f16(y0_7, -1);
-
-//     float32x4_t exp0_3 = exp_ps(vcvt_f32_f16(vget_low_f16(y0_7_minus)));
-//     float32x4_t exp4_7 = exp_ps(vcvt_f32_f16(vget_high_f16(y0_7_minus)));
-
-//     float16x8_t exp0_7 =
-//       vcombine_f16(vcvt_f16_f32(exp0_3), vcvt_f16_f32(exp4_7));
-//     exp0_7 = vaddq_f16(exp0_7, vmovq_n_f16(1.f));
-//     exp0_7 = vdivq_f16(y0_7, exp0_7);
-//     exp0_7 = vmulq_f16(exp0_7, z0_7);
-
-//     vst1q_f16(&X[i], exp0_7);
-//   }
-//   while (i < N) {
-//     X[i] = (Y[i] / (1.f + std::exp(static_cast<float>(-Y[i])))) * Z[i];
-//     ++i;
-//   }
-// }
 
 __fp16 max_val(const unsigned int N, __fp16 *X) {
   unsigned int i = 0;

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -1211,6 +1211,17 @@ extern void dequantize_row_q4_K(const void *x, float *y, int64_t k);
  */
 extern void dequantize_row_q4_0(const void *x, float *y, int64_t k);
 
+#ifdef ENABLE_FP16
+/**
+ * @brief dequantize row of q4_0 data to float
+ *
+ * @param x input to be dequantized from q4_0 to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+extern void dequantize_row_q4_0(const void *x, _FP16 *y, int64_t k);
+#endif
+
 /**
  * @brief dequantize row of q6_K data to float
  *

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -279,6 +279,12 @@ void dequantize_row_q4_0(const void *x_raw, float *y, int64_t k) {
   return __fallback_dequantize_row_q4_0(x_raw, y, k);
 }
 
+#ifdef ENABLE_FP16
+void dequantize_row_q4_0(const void *x_raw, _FP16 *y, int64_t k) {
+  return __fallback_dequantize_row_q4_0(x_raw, y, k);
+}
+#endif
+
 void dequantize_row_q6_K(const void *x, float *y, int64_t k) {
   return __fallback_dequantize_row_q6_K(x, y, k);
 }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1191,6 +1191,17 @@ void dequantize_row_q4_K(const void *x, float *y, int64_t k);
  */
 void dequantize_row_q4_0(const void *x, float *y, int64_t k);
 
+#ifdef ENABLE_FP16
+/**
+ * @brief dequantize row of q4_0 data to float
+ *
+ * @param x input to be dequantized from q4_0 to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+void dequantize_row_q4_0(const void *x, _FP16 *y, int64_t k);
+#endif
+
 /**
  * @brief dequantize row of q6_K data to float
  *

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -541,6 +541,12 @@ void __fallback_dequantize_row_q4_0(const void *x_raw, float *y, int64_t k) {
   throw std::runtime_error("NYI : __fallback_dequantize_row_q4_0");
 }
 
+#ifdef ENABLE_FP16
+void __fallback_dequantize_row_q4_0(const void *x_raw, _FP16 *y, int64_t k) {
+  throw std::runtime_error("NYI : __fallback_dequantize_row_q4_0");
+}
+#endif
+
 void __fallback_dequantize_row_q6_K(const void *x, float *y, int64_t k) {
   throw std::runtime_error("NYI : __fallback_dequantize_row_q6_K");
 }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -1109,6 +1109,17 @@ void __fallback_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k);
  */
 void __fallback_dequantize_row_q4_0(const void *x_raw, float *y, int64_t k);
 
+#ifdef ENABLE_FP16
+/**
+ * @brief dequantize row of q4_0 data to float
+ *
+ * @param x input to be dequantized from q4_0 to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+void __fallback_dequantize_row_q4_0(const void *x_raw, _FP16 *y, int64_t k);
+#endif
+
 /**
  * @brief dequantize row of q6_K data to float
  *

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.cpp
@@ -56,6 +56,12 @@ void __ggml_dequantize_row_q4_0(const void *x_raw, float *y, int64_t k) {
   nntr_dequantize_row_q4_0(x_raw, y, k);
 }
 
+#ifdef ENABLE_FP16
+void __ggml_dequantize_row_q4_0(const void *x_raw, _FP16 *y, int64_t k) {
+  nntr_dequantize_row_q4_0(x_raw, y, k);
+}
+#endif
+
 void __ggml_dequantize_row_q4_K(const void *x_raw, float *y, int64_t k) {
   nntr_dequantize_row_q4_K(x_raw, y, k);
 }

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -270,6 +270,17 @@ float __ggml_vec_dot_q6_K_f32(const unsigned int K, const void *v_q6_K,
  */
 void __ggml_dequantize_row_q4_0(const void *x_raw, float *y, int64_t k);
 
+#ifdef ENABLE_FP16
+/**
+ * @brief q4_0 to float dequantize
+ *
+ * @param x_raw input src to be dequantized
+ * @param y output destination for dequantized data
+ * @param k data length
+ */
+void __ggml_dequantize_row_q4_0(const void *x_raw, _FP16 *y, int64_t k);
+#endif
+
 /**
  * @brief q8_0 to float dequantize
  *

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface_fp16.cpp
@@ -29,7 +29,7 @@
 #endif
 namespace nntrainer {
 
-std::shared_ptr<std::vector<float>> C32;
+thread_local std::shared_ptr<std::vector<float>> C32;
 
 static inline void __copy_f16_from_f32(const float *src, _FP16 *dst,
                                        int64_t k) {

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface_fp16.cpp
@@ -27,8 +27,9 @@
 #if defined(__ARM_NEON)
 #include <arm_neon.h>
 #endif
-
 namespace nntrainer {
+
+std::shared_ptr<std::vector<float>> C32;
 
 static inline void __copy_f16_from_f32(const float *src, _FP16 *dst,
                                        int64_t k) {
@@ -326,8 +327,10 @@ void __ggml_gemm_q6_K(const unsigned int M, const unsigned int N,
                       const unsigned int lda, const void *B,
                       const unsigned int ldb, _FP16 *C,
                       const unsigned int ldc) {
-  std::vector<float> C32 = std::vector<float>(M * N);
-  float *C32_ptr = C32.data();
+  if (!C32 || C32->empty() || C32->size() < M * N) {
+    C32 = std::make_shared<std::vector<float>>(M * N);
+  }
+  float *C32_ptr = C32->data();
 
   auto &tm = ThreadManager::Global();
 
@@ -385,8 +388,10 @@ static inline void __ggml_q4_0_4x8_q8_0_GEMM_BSTP(
   const unsigned int M, const unsigned int N, const unsigned int K,
   const _FP16 *A, const unsigned int lda, const void *B, const unsigned int ldb,
   _FP16 *C16, const unsigned int ldc) {
-  std::vector<float> C32 = std::vector<float>(M * N);
-  float *C = C32.data();
+  if (!C32 || C32->empty() || C32->size() < M * N) {
+    C32 = std::make_shared<std::vector<float>>(M * N);
+  }
+  float *C = C32->data();
   int NB_COLS = 4;
   auto &tm = ThreadManager::Global();
   unsigned int blocks_per_4_rows = (K + QK8_0 - 1) / QK8_0;
@@ -457,7 +462,10 @@ void __ggml_q4_0_4x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
                                const unsigned int ldb, _FP16 *C,
                                const unsigned int ldc) {
   int NB_COLS = 4;
-  std::vector<float> C32 = std::vector<float>(M * N);
+
+  if (!C32 || C32->empty() || C32->size() < M * N) {
+    C32 = std::make_shared<std::vector<float>>(M * N);
+  }
 
   // q40 GEMV accuracy explodes?
   if (M == 1) { // GEMV
@@ -478,13 +486,14 @@ void __ggml_q4_0_4x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
                    ? M_step_end + NB_COLS - (M_step_end % NB_COLS)
                    : M_step_end;
 
-    nntr_gemv_q4_0_4x8_q8_0(K, (float *)((C32.data()) + M_step_start), N,
+    nntr_gemv_q4_0_4x8_q8_0(K, (float *)((C32->data()) + M_step_start), N,
                             (void *)((char *)B + M_step_start * B_step),
                             QA.data(), M, M_step_end - M_step_start);
   } else {
     return __ggml_q4_0_4x8_q8_0_GEMM_BSTP(M, N, K, A, lda, B, ldb, C, ldc);
   }
-  __copy_f16_from_f32(C32.data(), C, M * N);
+
+  __copy_f16_from_f32(C32->data(), C, M * N);
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl.h
@@ -17,6 +17,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <tensor_dim.h>
+
 void nntr_ggml_init();
 
 void nntr_gemm_q4_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
@@ -85,6 +87,11 @@ void nntr_quantize_row_q8_K(const float *__restrict x, void *__restrict y,
 
 void nntr_dequantize_row_q4_0(const void *__restrict x, float *__restrict y,
                               int64_t k);
+
+#ifdef ENABLE_FP16
+void nntr_dequantize_row_q4_0(const void *__restrict x, _FP16 *__restrict y,
+                              int64_t k);
+#endif
 
 void nntr_dequantize_row_q4_K(const void *__restrict x, float *__restrict y,
                               int64_t k);

--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_quant.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_quant.cpp
@@ -487,10 +487,40 @@ void dequantize_row_q4_0_impl(const block_q4_0 *__restrict x,
   }
 }
 
+#ifdef ENABLE_FP16
+void dequantize_row_q4_0_impl(const block_q4_0 *__restrict x,
+                              _FP16 *__restrict y, int64_t k) {
+  static const int qk = QK4_0;
+
+  assert(k % qk == 0);
+
+  const int nb = k / qk;
+
+  for (int i = 0; i < nb; i++) {
+    const float d = nntr_fp16_to_fp32(x[i].d);
+
+    for (int j = 0; j < qk / 2; ++j) {
+      const int x0 = (x[i].qs[j] & 0x0F) - 8;
+      const int x1 = (x[i].qs[j] >> 4) - 8;
+
+      y[i * qk + j + 0] = static_cast<_FP16>(x0 * d);
+      y[i * qk + j + qk / 2] = static_cast<_FP16>(x1 * d);
+    }
+  }
+}
+#endif
+
 void nntr_dequantize_row_q4_0(const void *__restrict x, float *__restrict y,
                               int64_t k) {
   dequantize_row_q4_0_impl((const block_q4_0 *)x, y, k);
 }
+
+#ifdef ENABLE_FP16
+void nntr_dequantize_row_q4_0(const void *__restrict x, _FP16 *__restrict y,
+                              int64_t k) {
+  dequantize_row_q4_0_impl((const block_q4_0 *)x, y, k);
+}
+#endif
 
 // -------- Q8_0 -----------------
 

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -400,6 +400,12 @@ void dequantize_row_q4_0(const void *x_raw, float *y, int64_t k) {
   __ggml_dequantize_row_q4_0(x_raw, y, k);
 }
 
+#ifdef ENABLE_FP16
+void dequantize_row_q4_0(const void *x_raw, _FP16 *y, int64_t k) {
+  __ggml_dequantize_row_q4_0(x_raw, y, k);
+}
+#endif
+
 void dequantize_row_q6_K(const void *x, float *y, int64_t k) {
   __ggml_dequantize_row_q6_K(x, y, k);
 }

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1055,6 +1055,17 @@ void dequantize_row_q4_K(const void *x, float *y, int64_t k);
  */
 void dequantize_row_q4_0(const void *x, float *y, int64_t k);
 
+#ifdef ENABLE_FP16
+/**
+ * @brief dequantize row of q4_0 data to float
+ *
+ * @param x input to be dequantized from q4_0 to float
+ * @param y dequantized data output
+ * @param k number of elements in x
+ */
+void dequantize_row_q4_0(const void *x, _FP16 *y, int64_t k);
+#endif
+
 /**
  * @brief dequantize row of q6_K data to float
  *

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -716,6 +716,7 @@ Tensor &HalfTensor::dot(Tensor const &input, Tensor &output, bool trans,
     dotHalf(input, output, trans, trans_in, beta);
     break;
   case Tdatatype::Q4_0:
+    dotQnK(input, output, trans, trans_in, beta, input.getDataType());
     break;
   default:
     throw std::invalid_argument("Error: unsupported datatype");

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -93,7 +93,8 @@ void Exporter::saveTflResult(
                    std::vector<props::InputShape>, props::SharedFrom,
                    props::ClipGradByGlobalNorm, props::Packed,
                    props::WeightDtype, props::InputDtype,
-                   props::LossScaleForMixed, props::ComputeEngine> &props,
+                   props::LossScaleForMixed, props::ComputeEngine,
+                   props::InputTensorDataType> &props,
   const LayerNode *self) {
   createIfNull(tf_node);
   tf_node->setLayerNode(*self);

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -93,8 +93,7 @@ void Exporter::saveTflResult(
                    std::vector<props::InputShape>, props::SharedFrom,
                    props::ClipGradByGlobalNorm, props::Packed,
                    props::WeightDtype, props::InputDtype,
-                   props::LossScaleForMixed, props::ComputeEngine,
-                   props::InputTensorDataType> &props,
+                   props::LossScaleForMixed, props::ComputeEngine> &props,
   const LayerNode *self) {
   createIfNull(tf_node);
   tf_node->setLayerNode(*self);

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -254,7 +254,8 @@ void Exporter::saveTflResult(
                    std::vector<props::InputShape>, props::SharedFrom,
                    props::ClipGradByGlobalNorm, props::Packed,
                    props::WeightDtype, props::InputDtype,
-                   props::LossScaleForMixed, props::ComputeEngine> &props,
+                   props::LossScaleForMixed, props::ComputeEngine,
+                   props::InputTensorDataType> &props,
   const LayerNode *self);
 
 class BatchNormalizationLayer;

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -254,8 +254,7 @@ void Exporter::saveTflResult(
                    std::vector<props::InputShape>, props::SharedFrom,
                    props::ClipGradByGlobalNorm, props::Packed,
                    props::WeightDtype, props::InputDtype,
-                   props::LossScaleForMixed, props::ComputeEngine,
-                   props::InputTensorDataType> &props,
+                   props::LossScaleForMixed, props::ComputeEngine> &props,
   const LayerNode *self);
 
 class BatchNormalizationLayer;

--- a/test/unittest/models/unittest_models_mixed_precision.cpp
+++ b/test/unittest/models/unittest_models_mixed_precision.cpp
@@ -28,7 +28,7 @@ static std::unique_ptr<NeuralNetwork> fc_mixed_training() {
     {"batch_size=1", "model_tensor_type=FP16-FP16", "loss_scale=65536"});
 
   auto graph = makeGraph({
-    {"input", {"name=in", "input_shape=1:1:3"}},
+    {"input", {"name=in", "input_shape=1:1:3", "input_dtype=FP32"}},
     {"Fully_connected", {"name=fc", "input_layers=in", "unit=10"}},
     {"mse", {"name=loss", "input_layers=fc"}},
   });
@@ -48,7 +48,7 @@ static std::unique_ptr<NeuralNetwork> fc_mixed_training_nan_sgd() {
     {"batch_size=1", "model_tensor_type=FP16-FP16", "loss_scale=65536"});
 
   auto graph = makeGraph({
-    {"input", {"name=in", "input_shape=1:1:1"}},
+    {"input", {"name=in", "input_shape=1:1:1", "input_dtype=FP32"}},
     {"Fully_connected", {"name=fc0", "input_layers=in", "unit=1"}},
     {"Fully_connected", {"name=fc1", "input_layers=fc0", "unit=1"}},
     {"mse", {"name=loss", "input_layers=fc1"}},


### PR DESCRIPTION
Commit 1:     [Application] enable resetInputDimension in causallm
    
     - Enable resetInputDimension in Causal lm
    
    Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

Commit 2:     [causallm] applied fp16 input/output dtype on causallm
    
     - Added generate for fp16 input/output
    
    Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

Commit 3:     [dotQnK] enable dot operation of q4_0 and fp16
    
     - Enable dotQnK on half tensor
     - set thread number for gemm
     - Optimizing gemm of q4_0 and fp16 by removed temporary local variable(C32) and declared as global variable
    
    Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

Commit 4:     [embedding] Directly dequantize q4_0 to half tensor
    
     - Added dequantize_row_q4_0 for half tensor
    
    Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

Commit 5:     [swiglu] improve performance of swiglu for fp16 data type
    
     - Loop unrolling swiglu to improve computation speed for fp16 data type
    
    Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

Commit 6:     [normalization] set rms norm weight as fp32
    
     - Set weight dtype of rms norm as fp32 even though input/output dtype is not fp32
    
    Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>