### PR TITLE
Causallm/make transformer base

### DIFF
--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -45,7 +45,7 @@
 
 using json = nlohmann::json;
 
-static std::unique_ptr<causallm::Transformer> g_model;
+static std::unique_ptr<causallm::TransformerBase> g_model;
 static std::mutex g_mutex;
 static bool g_initialized = false;
 static std::string g_architecture = "";

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -575,7 +575,7 @@ ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
     }
 
     // We assume single batch request for this API.
-    g_model->run(input, false, "", "", g_verbose);
+    g_model->run(input, "", "", nullptr, g_verbose);
 
     auto causal_lm_model = dynamic_cast<causallm::CausalLM *>(g_model.get());
     g_last_output = ""; // Reset last output

--- a/Applications/CausalLM/factory.h
+++ b/Applications/CausalLM/factory.h
@@ -15,7 +15,7 @@
 #define __CAUSALLM_FACTORY_H__
 
 #include <ostream>
-#include <transformer.h>
+#include <transformer_base.h>
 #include <unordered_map>
 
 namespace causallm {
@@ -26,7 +26,7 @@ namespace causallm {
 class Factory {
 public:
   using Creator =
-    std::function<std::unique_ptr<Transformer>(json &, json &, json &)>;
+    std::function<std::unique_ptr<TransformerBase>(json &, json &, json &)>;
 
   static Factory &Instance() {
     static Factory factory;
@@ -37,9 +37,9 @@ public:
     creators[key] = creator;
   }
 
-  std::unique_ptr<Transformer> create(const std::string &key, json &cfg,
-                                      json &generation_cfg,
-                                      json &nntr_cfg) const {
+  std::unique_ptr<TransformerBase> create(const std::string &key, json &cfg,
+                                          json &generation_cfg,
+                                          json &nntr_cfg) const {
     auto it = creators.find(key);
     if (it != creators.end()) {
       return (it->second)(cfg, generation_cfg, nntr_cfg);

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -381,16 +381,14 @@ int main(int argc, char *argv[]) {
     model->initialize();
     model->load_weight(weight_file);
 
-    bool do_sample = generation_cfg.value("do_sample", false);
-
 #ifdef PROFILE
     start_peak_tracker();
 #endif
 #if defined(_WIN32)
-    model->run(input_text.c_str(), do_sample, system_head_prompt.c_str(),
+    model->run(input_text.c_str(), system_head_prompt.c_str(),
                system_tail_prompt.c_str());
 #else
-    model->run(input_text, do_sample, system_head_prompt, system_tail_prompt);
+    model->run(input_text, system_head_prompt, system_tail_prompt);
 #endif
 #ifdef PROFILE
     stop_and_print_peak();

--- a/Applications/CausalLM/models/bert/bert_transformer.cpp
+++ b/Applications/CausalLM/models/bert/bert_transformer.cpp
@@ -247,8 +247,13 @@ Tensor BertTransformer::createMlp(const int layer_id, int dim, int hidden_dim,
   return down(activated);
 }
 
-void BertTransformer::run(const WSTR prompt, bool do_sample,
-                          const WSTR system_prompt, const WSTR tail_prompt,
+void BertTransformer::run(const WSTR prompt, void *output_buf,
+                          bool log_output) {
+  run(prompt, WSTR(), WSTR(), output_buf, log_output);
+}
+
+void BertTransformer::run(const WSTR prompt, const WSTR system_prompt,
+                          const WSTR tail_prompt, void *output_buf,
                           bool log_output) {
 
   try {
@@ -272,9 +277,14 @@ void BertTransformer::run(const WSTR prompt, bool do_sample,
       }
     }
 
-    // output should be deallocated after use.
-    for (auto out : results) {
-      delete[] out;
+    if (output_buf != nullptr) {
+      // Caller is responsible for deallocation.
+      *static_cast<std::vector<float *> *>(output_buf) = results;
+    } else {
+      // output should be deallocated after use.
+      for (auto out : results) {
+        delete[] out;
+      }
     }
   } catch (const std::exception &e) {
     std::cerr << "Error during embedding run: " << e.what() << std::endl;

--- a/Applications/CausalLM/models/bert/bert_transformer.h
+++ b/Applications/CausalLM/models/bert/bert_transformer.h
@@ -96,10 +96,17 @@ public:
                                       const WSTR tail_prompt = "") = 0;
 
   /**
-   * @brief run the BertTransformer model
+   * @copydoc TransformerBase::run(const WSTR, void *, bool)
    */
-  void run(const WSTR prompt, bool do_sample = false,
-           const WSTR system_prompt = "", const WSTR tail_prmopt = "",
+  void run(const WSTR prompt, void *output_buf = nullptr,
+           bool log_output = true) override;
+
+  /**
+   * @brief TransformerBase::run(const WSTR, const WSTR, const WSTR, void *,
+   * bool)
+   */
+  void run(const WSTR prompt, const WSTR system_prompt = WSTR(),
+           const WSTR tail_prompt = WSTR(), void *output_buf = nullptr,
            bool log_output = true) override;
 };
 

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -102,6 +102,9 @@ void CausalLM::setupParameters(json &cfg, json &generation_cfg,
   TEMPERATURE = generation_cfg.contains("temperature")
                   ? generation_cfg["temperature"].get<float>()
                   : 0.7;
+  DO_SAMPLE = generation_cfg.contains("do_sample")
+                ? generation_cfg["do_sample"].get<bool>()
+                : false;
   global_token_len = 0;
 }
 
@@ -330,8 +333,12 @@ void CausalLM::registerCustomLayers() {
   }
 }
 
-void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
-                   const WSTR tail_prompt, bool log_output) {
+void CausalLM::run(const WSTR prompt, void *output_buf, bool log_output) {
+  run(prompt, WSTR(), WSTR(), output_buf, log_output);
+}
+
+void CausalLM::run(const WSTR prompt, const WSTR system_prompt,
+                   const WSTR tail_prompt, void *output_buf, bool log_output) {
 
   auto start_total = std::chrono::high_resolution_clock::now();
   if (!is_initialized) {
@@ -523,7 +530,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   // post process of model output
   std::vector<unsigned int> id_list(
-    generate(output[0], do_sample, 1, ids_history, init_len));
+    generate(output[0], DO_SAMPLE, 1, ids_history, init_len));
 
   if (init_len < INIT_SEQ_LEN)
     registerOutputs(tokenizer, id_list, init_len, eos_list, log_output);
@@ -559,7 +566,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
       model->incremental_inference(BATCH_SIZE, input, label, input_len,
                                    token_generation_idx - 1 + global_token_len,
                                    token_generation_idx + global_token_len);
-    std::vector<unsigned int> ids_list(generate(output_interval[0], do_sample));
+    std::vector<unsigned int> ids_list(generate(output_interval[0], DO_SAMPLE));
 
     // Feed the newly generated token back as the next input token.
     // token_generation_idx always starts at input_len + 1, so we are
@@ -603,6 +610,10 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   free(input_sample);
 
   global_token_len += (generation_cnt + init_len);
+
+  if (output_buf != nullptr) {
+    *static_cast<std::vector<std::string> *>(output_buf) = output_list;
+  }
 
   auto finish_generation = std::chrono::high_resolution_clock::now();
   auto generation_duration =

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -68,10 +68,16 @@ public:
   }
 
   /**
-   * @brief run the CausalLM model
+   * @brief run the CausalLM model (simple)
    */
-  void run(const WSTR prompt, bool do_sample = false,
-           const WSTR system_prompt = "", const WSTR tail_prompt = "",
+  void run(const WSTR prompt, void *output_buf = nullptr,
+           bool log_output = true) override;
+
+  /**
+   * @brief run the CausalLM model (full)
+   */
+  void run(const WSTR prompt, const WSTR system_prompt = WSTR(),
+           const WSTR tail_prompt = WSTR(), void *output_buf = nullptr,
            bool log_output = true) override;
 
   /**
@@ -138,6 +144,8 @@ protected:
   float TEMPERATURE;
   unsigned int TOP_K;
   float TOP_P;
+
+  bool DO_SAMPLE = false; /**< Whther to use sampling for generation */
 
   std::vector<unsigned int> BAD_WORD_IDS; /**< List of bad word IDs */
   unsigned int NUM_BADWORDS;              /**< Number of bad words */

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -145,7 +145,7 @@ protected:
   unsigned int TOP_K;
   float TOP_P;
 
-  bool DO_SAMPLE = false; /**< Whther to use sampling for generation */
+  bool DO_SAMPLE = false; /**< Whether to use sampling for generation */
 
   std::vector<unsigned int> BAD_WORD_IDS; /**< List of bad word IDs */
   unsigned int NUM_BADWORDS;              /**< Number of bad words */

--- a/Applications/CausalLM/models/sentence_transformer.cpp
+++ b/Applications/CausalLM/models/sentence_transformer.cpp
@@ -265,8 +265,13 @@ void SentenceTransformer::allocateAndBindKVCache() {
   }
 }
 
-void SentenceTransformer::run(const WSTR prompt, bool do_sample,
-                              const WSTR system_prompt, const WSTR tail_prompt,
+void SentenceTransformer::run(const WSTR prompt, void *output_buf,
+                              bool log_output) {
+  run(prompt, WSTR(), WSTR(), output_buf, log_output);
+}
+
+void SentenceTransformer::run(const WSTR prompt, const WSTR system_prompt,
+                              const WSTR tail_prompt, void *output_buf,
                               bool log_output) {
 
   try {
@@ -290,9 +295,14 @@ void SentenceTransformer::run(const WSTR prompt, bool do_sample,
       }
     }
 
-    // output should be deallocated after use.
-    for (auto out : results) {
-      delete[] out;
+    if (output_buf != nullptr) {
+      // Caller is responsible for dellocation
+      *static_cast<std::vector<float *> *>(output_buf) = results;
+    } else {
+      // output should be deallocated after use.
+      for (auto out : results) {
+        delete[] out;
+      }
     }
   } catch (const std::exception &e) {
     std::cerr << "Error during embedding run: " << e.what() << std::endl;

--- a/Applications/CausalLM/models/sentence_transformer.h
+++ b/Applications/CausalLM/models/sentence_transformer.h
@@ -51,7 +51,7 @@ public:
    * @brief run the SentenceTransformer model (full)
    */
   void run(const WSTR prompt, const WSTR system_prompt = WSTR(),
-           const WSTR tail_prmopt = WSTR(), void *output_buf = nullptr,
+           const WSTR tail_prompt = WSTR(), void *output_buf = nullptr,
            bool log_output = true) override;
 
   /**

--- a/Applications/CausalLM/models/sentence_transformer.h
+++ b/Applications/CausalLM/models/sentence_transformer.h
@@ -42,10 +42,16 @@ public:
   virtual ~SentenceTransformer() {}
 
   /**
-   * @brief run the SentenceTransformer model
+   * @brief run the SentenceTransformer model (simple)
    */
-  void run(const WSTR prompt, bool do_sample = false,
-           const WSTR system_prompt = "", const WSTR tail_prmopt = "",
+  void run(const WSTR prompt, void *output_buf = nullptr,
+           bool log_output = true) override;
+
+  /**
+   * @brief run the SentenceTransformer model (full)
+   */
+  void run(const WSTR prompt, const WSTR system_prompt = WSTR(),
+           const WSTR tail_prmopt = WSTR(), void *output_buf = nullptr,
            bool log_output = true) override;
 
   /**

--- a/Applications/CausalLM/models/timm_vit/timm_vit_transformer.cpp
+++ b/Applications/CausalLM/models/timm_vit/timm_vit_transformer.cpp
@@ -338,13 +338,19 @@ void TimmViTTransformer::registerCustomLayers() {
 /**
  * @brief Run ViT inference on an image file path.
  */
-void TimmViTTransformer::run(const WSTR prompt, bool do_sample,
-                             const WSTR system_prompt, const WSTR tail_prompt,
+void TimmViTTransformer::run(const WSTR prompt, void *output_buf,
                              bool log_output) {
-  (void)do_sample;
+  run(prompt, WSTR(), WSTR(), output_buf, log_output);
+}
+
+/**
+ * @brief Run ViT inference on an image file path.
+ */
+void TimmViTTransformer::run(const WSTR prompt, const WSTR system_prompt,
+                             const WSTR tail_prompt, void *output_buf,
+                             bool log_output) {
   (void)system_prompt;
   (void)tail_prompt;
-  (void)log_output;
 
   if (!is_initialized) {
     throw std::runtime_error("TimmViT model is not initialized. Please call "
@@ -365,12 +371,22 @@ void TimmViTTransformer::run(const WSTR prompt, bool do_sample,
   std::vector<float *> output = model->incremental_inference(
     BATCH_SIZE, input, label, NUM_PATCHES, 0, NUM_PATCHES, false);
 
-  std::cout << std::setprecision(9) << "First 10 values: ";
-  const int print_count = DIM > 10 ? 10 : static_cast<int>(DIM);
-  for (int i = 0; i < print_count; ++i) {
-    std::cout << "[" << i << "]=" << output[0][i] << " ";
+  if (log_output) {
+    std::cout << std::setprecision(9) << "First 10 values: ";
+    const int print_count = DIM > 10 ? 10 : static_cast<int>(DIM);
+    for (int i = 0; i < print_count; ++i) {
+      std::cout << "[" << i << "]=" << output[0][i] << " ";
+    }
+    std::cout << std::endl;
   }
-  std::cout << std::endl;
+
+  if (output_buf != nullptr) {
+    *static_cast<std::vector<float *> *>(output_buf) = output;
+  } else {
+    for (auto out : output) {
+      delete[] out;
+    }
+  }
 }
 
 } // namespace causallm

--- a/Applications/CausalLM/models/timm_vit/timm_vit_transformer.h
+++ b/Applications/CausalLM/models/timm_vit/timm_vit_transformer.h
@@ -81,8 +81,14 @@ protected:
   /**
    * @brief Run the model (override for ViT specific behavior)
    */
-  void run(const WSTR prompt, bool do_sample = false,
-           const WSTR system_prompt = WSTR(), const WSTR tail_prompt = WSTR(),
+  void run(const WSTR prompt, void *output_buf = nullptr,
+           bool log_output = true) override;
+
+  /**
+   * @brief Run the model (override for ViT specific behavior)
+   */
+  void run(const WSTR prompt, const WSTR system_prompt = WSTR(),
+           const WSTR tail_prompt = WSTR(), void *output_buf = nullptr,
            bool log_output = true) override;
 
 private:

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -316,8 +316,12 @@ void Transformer::save_weight(
 /**
  * @brief Run a transformer model for a prompt.
  */
-void Transformer::run(const WSTR prompt, bool do_sample,
-                      const WSTR system_prompt, const WSTR tail_prompt,
+void Transformer::run(const WSTR prompt, void *output_buf, bool log_output) {
+  run(prompt, WSTR(), WSTR(), output_buf, log_output);
+}
+
+void Transformer::run(const WSTR prompt, const WSTR system_prompt,
+                      const WSTR tail_prompt, void *output_buf,
                       bool log_output) {
   if (!is_initialized) {
     throw std::runtime_error(

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -101,14 +101,14 @@ public:
   /**
    * @brief Get TransformerPerformanceMetrics
    */
-  TransformerPerformanceMetrics getPerformanceMetrics() const {
+  TransformerPerformanceMetrics getPerformanceMetrics() const override {
     return performance_metrics;
   }
 
   /**
    * @brief get the status of run
    */
-  bool hasRun() const { return has_run_; }
+  bool hasRun() const override { return has_run_; }
 
 protected:
   /**

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -24,49 +24,20 @@
 #define __TRANSFORMER_H__
 
 #pragma once
-#ifdef _WIN32
-#define WIN_EXPORT __declspec(dllexport)
-#define WSTR std::string
-#define WCHAR_P std::string &
-#else
-#define WIN_EXPORT
-#define WSTR std::string
-#define WCHAR_P std::string &
-#endif
-
-#include <layer.h>
-#include <map>
-#include <model.h>
-#include <random>
-#include <tensor_api.h>
-#include <utility>
 
 #include <limits.h>
+#include <map>
+#include <random>
+#include <utility>
 
-#include "json.hpp"
-#include "performance_metrics.h"
-#include <fstream>
-#include <tokenizers_c.h>
-#include <tokenizers_cpp.h>
+#include <transformer_base.h>
 
 namespace causallm {
-
-/*** ALIAS ****/
-using LayerHandle = ml::train::LayerHandle;
-using Tensor = ml::train::Tensor;
-using ModelHandle = std::unique_ptr<ml::train::Model>;
-
-using json = nlohmann::json;
-
-/**
- * @brief Model Type Enum
- */
-enum class ModelType { MODEL, CAUSALLM, EMBEDDING, UNKNOWN };
 
 /**
  * @brief Transformer Class
  */
-WIN_EXPORT class Transformer {
+WIN_EXPORT class Transformer : virtual public TransformerBase {
 
 public:
   /**
@@ -87,17 +58,18 @@ public:
   /**
    * @brief Initialize and Construct the Transformer model
    */
-  virtual void initialize();
+  void initialize() override;
 
   /**
    * @brief Load the model weights from a file
    */
-  virtual void load_weight(const std::string &weight_path);
+  void load_weight(const std::string &weight_path) override;
 
   /**
    * @brief Save the weight to a file
    */
-  virtual void save_weight(const std::string &weight_path);
+  void save_weight(const std::string &weight_path) override;
+
   /**
    * @brief Save the weight to a file with type conversion
    * @param weight_path Path to save the weight file
@@ -105,19 +77,19 @@ public:
    * @param layer_dtype_map Per-layer data type overrides (layer_name -> dtype)
    * @param target_isa Target ISA for quantization (default: DEFAULT)
    */
-  virtual void
+  void
   save_weight(const std::string &weight_path,
               ml::train::TensorDim::DataType dtype,
               const std::map<std::string, ml::train::TensorDim::DataType>
                 &layer_dtype_map = {},
-              ml::train::ISA target_isa = ml::train::ISA::DEFAULT);
+              ml::train::ISA target_isa = ml::train::ISA::DEFAULT) override;
 
   /**
    * @brief run the Transformer model
    */
-  virtual void run(const WSTR prompt, bool do_sample = false,
-                   const WSTR system_prompt = WSTR(),
-                   const WSTR tail_prompt = WSTR(), bool log_output = true);
+  void run(const WSTR prompt, bool do_sample = false,
+           const WSTR system_prompt = WSTR(),
+           const WSTR tail_prompt = WSTR(), bool log_output = true) override;
 
   /**
    * @brief Get TransformerPerformanceMetrics
@@ -198,26 +170,12 @@ protected:
   virtual ml::train::ModelFormat
   formatFromExtension(const std::string &weight_path);
 
-  /**
-   * @brief register Outputs
-   */
-  bool is_initialized = false; /**< Flag to check if the model is initialized */
-  ModelHandle model;
-
-  /** tokenizer */
-  std::unique_ptr<tokenizers::Tokenizer> tokenizer;
-
-  unsigned int NUM_VOCAB;
-  int DIM;
   int HEAD_DIM;
   int INTERMEDIATE_SIZE;
-  int NUM_LAYERS;
   bool USE_VOCAB_SELECTION;
   bool TIE_WORD_EMBEDDINGS;
-  unsigned int MAX_SEQ_LEN;
   int NUM_HEADS;
   int NUM_KEY_VALUE_HEADS;
-  int NUM_TO_GENERATE;
   std::string MODEL_TENSOR_TYPE;
   std::string EMBEDDING_DTYPE; /** embedding dtype */
   std::string FC_LAYER_DTYPE;  /** custom_fc_lora */
@@ -229,8 +187,6 @@ protected:
   float EMBEDDING_SCALE = 1.0f;
   int GQA_SIZE;
 
-  unsigned int BATCH_SIZE;              /**< Batch size for the model */
-  unsigned int INIT_SEQ_LEN;            /**< Initial sequence length */
   unsigned int MAX_POSITION_EMBEDDINGS; /**< max_position embeddings */
   bool MEMORY_SWAP;                     /**< memory swap option */
   unsigned int FSU_LOOKAHEAD;
@@ -242,28 +198,7 @@ protected:
 
   bool has_run_ = false;
 };
-/**
- * Loads JSON data from a file with detailed error handling
- * @param file_path Path to JSON file
- * @return JSON object
- * @throws std::runtime_error on file open or parse failure
- */
-inline json LoadJsonFile(const std::string &file_path) {
-  std::ifstream file(file_path);
-  if (!file.is_open()) {
-    throw std::runtime_error("Failed to open file: " + file_path +
-                             " | Reason: " + std::strerror(errno));
-  }
 
-  try {
-    json data;
-    file >> data;
-    return data;
-  } catch (const json::parse_error &e) {
-    throw std::runtime_error("JSON parse error in " + file_path +
-                             " | Details: " + e.what());
-  }
-}
 } // namespace causallm
 
 #endif

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -85,11 +85,18 @@ public:
               ml::train::ISA target_isa = ml::train::ISA::DEFAULT) override;
 
   /**
-   * @brief run the Transformer model
+   * @copydoc TransformerBase::run(const WSTR, void *, bool)
    */
-  void run(const WSTR prompt, bool do_sample = false,
-           const WSTR system_prompt = WSTR(),
-           const WSTR tail_prompt = WSTR(), bool log_output = true) override;
+  void run(const WSTR prompt, void *output_buf = nullptr,
+           bool log_output = true) override;
+
+  /**
+   * @brief TransformerBase::run(const WSTR, const WSTR, const WSTR, void *,
+   * bool)
+   */
+  void run(const WSTR prompt, const WSTR system_prompt = WSTR(),
+           const WSTR tail_prompt = WSTR(), void *output_buf = nullptr,
+           bool log_output = true) override;
 
   /**
    * @brief Get TransformerPerformanceMetrics

--- a/Applications/CausalLM/models/transformer_base.h
+++ b/Applications/CausalLM/models/transformer_base.h
@@ -18,8 +18,8 @@
 #pragma once
 #ifdef _WIN32
 #define WIN_EXPORT __declspec(dllexport)
-#define WSTR std::wstring
-#define WCHAR_P wchar_t *
+#define WSTR std::string
+#define WCHAR_P std::string &
 #else
 #define WIN_EXPORT
 #define WSTR std::string
@@ -113,11 +113,27 @@ public:
   }
 
   /**
-   * @brief run the Transformer model
+   * @brief run the Transformer model (simple)
+   * @param prompt User prompt
+   * @param output_buf Optional output pointer. For CausalLM, pass
+   *                   std::vector<std::string>*. For Sentence Transformer, pass
+   *                   std::vector<float *>*. nullptr to skip output collection.
+   * @param log_output Whether to log output to stdout
    */
-  virtual void run(const WSTR prompt, bool do_sample = false,
-                   const WSTR system_prompt = "", const WSTR tail_prompt = "",
+  virtual void run(const WSTR prompt, void *output_buf = nullptr,
                    bool log_output = true) = 0;
+
+  /**
+   * @brief run the Transformer model (full)
+   * @param prompt User prompt
+   * @param system_prompt System prompt prepended to user prompt
+   * @param tail_prompt Tail prompt appended to user prompt
+   * @param output_buf Optional output pointer (see simple overload for types)
+   * @param log_output Whether to log output to stdout
+   */
+  virtual void run(const WSTR prompt, const WSTR system_prompt = WSTR(),
+                   const WSTR tail_prompt = WSTR(),
+                   void *output_buf = nullptr, bool log_output = true) = 0;
 
 protected:
   bool is_initialized = false; /**< Flag to check if the model is initialized */

--- a/Applications/CausalLM/models/transformer_base.h
+++ b/Applications/CausalLM/models/transformer_base.h
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Eunju Yang <ej.yang@samsung.com>
+ *
+ * @file   transformer_base.h
+ * @date   31 Mar 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Eunju Yang <ej.yang@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @note   This transformer_base.h defines an abstract base class for
+ * Transformer-based models. It provides the common interface and shared state
+ * that both NNTrainer-based Transformer and QNN-based Transformer can inherit.
+ */
+
+#ifndef __TRANSFORMER_BASE_H__
+#define __TRANSFORMER_BASE_H__
+
+#pragma once
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#define WSTR std::wstring
+#define WCHAR_P wchar_t *
+#else
+#define WIN_EXPORT
+#define WSTR std::string
+#define WCHAR_P std::string &
+#endif
+
+#include <cerrno>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <string>
+
+#include <layer.h>
+#include <model.h>
+#include <tensor_api.h>
+
+#include <fstream>
+#include <tokenizers_c.h>
+#include <tokenizers_cpp.h>
+
+#include "json.hpp"
+#include "performance_metrics.h"
+
+namespace causallm {
+
+/*** ALIAS ****/
+using LayerHandle = ml::train::LayerHandle;
+using Tensor = ml::train::Tensor;
+using ModelHandle = std::unique_ptr<ml::train::Model>;
+
+using json = nlohmann::json;
+
+/**
+ * @brief Model Type Enum
+ */
+enum class ModelType { MODEL, CAUSALLM, EMBEDDING, UNKNOWN };
+
+/**
+ * @brief TransformerBase Abstract Class
+ * @note  This is the common interface for all Transformer-based models.
+ *        Both NNTrainer Transformer and QNN Transformer inherit from this
+ */
+WIN_EXPORT class TransformerBase {
+
+public:
+  /**
+   * @brief Default constructor
+   */
+  TransformerBase() = default;
+
+  /**
+   * @brief Destroy the TransformerBase object
+   */
+  virtual ~TransformerBase() = default;
+
+  /**
+   * @brief Initialize and Construct the Transformer model
+   */
+  virtual void initialize() = 0;
+
+  /**
+   * @brief Load the model weights from a file
+   */
+  virtual void load_weight(const std::string &weight_path) = 0;
+
+  /**
+   * @brief Save the weight to a file
+   */
+  virtual void save_weight(const std::string &weight_path) = 0;
+
+  /**
+   * @brief Save the weight to a file with type conversion
+   * @param weight_path Path to save the weight file
+   * @param dtype Global target data type for all layers (NONE = keep original)
+   * @param layer_dtype_map Per-layer data type overrides (layer name -> dtype)
+   * @param target_isa Target ISA for quantization (default: DEFAULT)
+   */
+  virtual void
+  save_weight(const std::string &weight_path,
+              ml::train::TensorDim::DataType dtype,
+              const std::map<std::string, ml::train::TensorDim::DataType>
+                &layer_dtype_map = {},
+              ml::train::ISA target_isa = ml::train::ISA::DEFAULT) {
+    (void)weight_path;
+    (void)dtype;
+    (void)layer_dtype_map;
+    (void)target_isa;
+    throw std::runtime_error(
+      "This TransformerBase implementation does not support dtype conversion "
+      "while saving weights.");
+  }
+
+  /**
+   * @brief run the Transformer model
+   */
+  virtual void run(const WSTR prompt, bool do_sample = false,
+                   const WSTR system_prompt = "", const WSTR tail_prompt = "",
+                   bool log_output = true) = 0;
+
+protected:
+  bool is_initialized = false; /**< Flag to check if the model is initialized */
+  ModelHandle model;
+
+  /** tokenizer */
+  std::unique_ptr<tokenizers::Tokenizer> tokenizer;
+
+  unsigned int NUM_VOCAB;
+  int DIM;
+  int NUM_LAYERS;
+
+  unsigned int MAX_SEQ_LEN;
+  unsigned int BATCH_SIZE;
+  unsigned int INIT_SEQ_LEN;
+  unsigned int NUM_TO_GENERATE;
+};
+
+/**
+ * Loads JSON data from a file with detailed error handling
+ * @param file_path Path to JSON file
+ * @return JSON object
+ * @throws std::runtime_error on file open or parse failure
+ */
+inline json LoadJsonFile(const std::string &file_path) {
+  std::ifstream file(file_path);
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open file: " + file_path +
+                             " | Reason: " + std::strerror(errno));
+  }
+
+  try {
+    json data;
+    file >> data;
+    return data;
+  } catch (const json::parse_error &e) {
+    throw std::runtime_error("JSON parse error in " + file_path +
+                             " | Details: " + e.what());
+  }
+}
+
+} // namespace causallm
+
+#endif

--- a/Applications/CausalLM/models/transformer_base.h
+++ b/Applications/CausalLM/models/transformer_base.h
@@ -30,6 +30,7 @@
 #include <cstring>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 
 #include <layer.h>
@@ -132,8 +133,18 @@ public:
    * @param log_output Whether to log output to stdout
    */
   virtual void run(const WSTR prompt, const WSTR system_prompt = WSTR(),
-                   const WSTR tail_prompt = WSTR(),
-                   void *output_buf = nullptr, bool log_output = true) = 0;
+                   const WSTR tail_prompt = WSTR(), void *output_buf = nullptr,
+                   bool log_output = true) = 0;
+
+  /**
+   * @brief Get the latest transformer performance metrics.
+   */
+  virtual TransformerPerformanceMetrics getPerformanceMetrics() const = 0;
+
+  /**
+   * @brief Get whether run has completed successfully.
+   */
+  virtual bool hasRun() const = 0;
 
 protected:
   bool is_initialized = false; /**< Flag to check if the model is initialized */

--- a/test/unittest/models/unittest_causallm_gemma3.cpp
+++ b/test/unittest/models/unittest_causallm_gemma3.cpp
@@ -104,7 +104,7 @@ public:
    * @brief Run one prompt through the tiny Gemma3 model
    */
   void runPrompt(const std::string &prompt) override {
-    run(prompt, false, "", "", false);
+    run(prompt, "", "", nullptr, false);
   }
 
   /**

--- a/test/unittest/models/unittest_causallm_qwen2.cpp
+++ b/test/unittest/models/unittest_causallm_qwen2.cpp
@@ -105,7 +105,7 @@ public:
    * @brief Run one prompt through the tiny Qwen2 model
    */
   void runPrompt(const std::string &prompt) override {
-    run(prompt, false, "", "", false);
+    run(prompt, "", "", nullptr, false);
   }
 
   /**

--- a/test/unittest/models/unittest_causallm_qwen3.cpp
+++ b/test/unittest/models/unittest_causallm_qwen3.cpp
@@ -105,7 +105,7 @@ public:
    * @brief Run one prompt through the tiny Qwen3 model
    */
   void runPrompt(const std::string &prompt) override {
-    run(prompt, false, "", "", false);
+    run(prompt, "", "", nullptr, false);
   }
 
   /**


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] Extract TransformerBase abstract class from Transformer</summary><br />

Introduce TransformerBase as an abstract base class that defines the
common interface (initialize, load_weight, save_weight, run) and shared
state (model, tokenizer, basic dimension params) for all Transformer
variants. This enables QNNTransformer to coexist alongside the existing
NNTrainer-based Transformer without inheriting HuggingFace-specific
config parsing logic.

- Create transformer_base.h with pure virtual interface
- Refactor Transformer to inherit from TransformerBase
- Update Factory to use TransformerBase as the base type
- Move LoadJsonFile, ModelType enum, and type aliases to
  transformer_base.h
- Update api.cpp (Transformer to TransformerBase)

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
</details>



<details><summary>[CausalLM] Refactor run() - remove do_sample, add void* touput and </summary><br />

- Remove do_sample from TransformerBase::run() interface since only
  CausalLM uses it. CausalLM now read do_sample
  from generation_config.json during setupParameters
  and store as DO_SAMPLE member variable.
- Add void* output_buf parameter to run() for retrieving results:
  CausalLM fills std::vector<std:: string>*, SentenceTransformer fills
std::vector<float*>*. nullptr (default) keeps existing stdout-only
behavior.
- Add simple overload run(prompt, output_buf) that delegates to the full
  version with empty system/tail prompts.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

### Summary

- create `TransformerBase`
- update `run` prototype for common TransformerBase


Signed-off-by: Eunju Yang <ej.yang@samsung.com>

