### PR TITLE
Optimized Remaining Layernorm Kernels Using SIMD

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -243,6 +243,14 @@ void cosine(const unsigned int N, float *X, float *Y, float alpha, float beta) {
   nntrainer::neon::cosine(N, X, Y, alpha, beta);
 }
 
+void neon_square(const float *a, float *out, size_t len) {
+  nntrainer::neon::neon_square(a, out, len);
+}
+
+void neon_add_scalar(const float *a, float scalar, float *out, size_t len) {
+  nntrainer::neon::neon_add_scalar(a, scalar, out, len);
+}
+
 void inv_sqrt_inplace(const unsigned int N, float *X) {
   nntrainer::neon::inv_sqrt_inplace(N, X);
 }

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1108,6 +1108,26 @@ void cosine(const unsigned int N, T *X, T *Y, float alpha = 1.f,
  * @param X float * for Vector X
  */
 void inv_sqrt_inplace(const unsigned int N, float *X);
+
+/**
+ * @brief Vectorized squaring operation using NEON: out[i] = a[i] * a[i]
+ *
+ * @param a input float vector
+ * @param out output float vector
+ * @param len number of elements to process
+ */
+void neon_square(const float *a, float *out, size_t len);
+
+/**
+ * @brief Vectorized scalar addition using NEON: out[i] = a[i] + scalar
+ *
+ * @param a input float vector
+ * @param scalar scalar value to add
+ * @param out output float vector
+ * @param len number of elements to process
+ */
+void neon_add_scalar(const float *a, float scalar, float *out, size_t len);
+
 /**
  * @brief     elementwise vector multiplication : Z = X ⊙ alpha * Y +
  * beta * Z

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl.cpp
@@ -637,6 +637,32 @@ void inv_sqrt_inplace(const unsigned int N, float *X) {
   }
 }
 
+void neon_square(const float *a, float *out, size_t len) {
+  size_t i = 0;
+  for (; i + 4 <= len; i += 4) {
+    float32x4_t va = vld1q_f32(a + i);
+    float32x4_t vresult = vmulq_f32(va, va);  // Multiply by itself
+    vst1q_f32(out + i, vresult);
+  }
+  for (; i < len; ++i) {
+    out[i] = a[i] * a[i];
+  }
+}
+
+void neon_add_scalar(const float *a, float scalar, float *out, size_t len) {
+  size_t i = 0;
+  float32x4_t vscalar = vdupq_n_f32(scalar);  // Broadcast scalar ONCE
+  
+  for (; i + 4 <= len; i += 4) {
+    float32x4_t va = vld1q_f32(a + i);
+    float32x4_t vresult = vaddq_f32(va, vscalar);
+    vst1q_f32(out + i, vresult);
+  }
+  for (; i < len; ++i) {
+    out[i] = a[i] + scalar;
+  }
+}
+
 void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
              float alpha, float beta) {
   unsigned int i = 0;

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl.h
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl.h
@@ -727,6 +727,25 @@ void cosine(const unsigned int N, T *X, T *Y, float alpha = 1.f,
 void inv_sqrt_inplace(const unsigned int N, float *X);
 
 /**
+ * @brief Vectorized squaring operation using NEON: out[i] = a[i] * a[i]
+ *
+ * @param a input float vector
+ * @param out output float vector
+ * @param len number of elements to process
+ */
+void neon_square(const float *a, float *out, size_t len);
+
+/**
+ * @brief Vectorized scalar addition using NEON: out[i] = a[i] + scalar
+ *
+ * @param a input float vector
+ * @param scalar scalar value to add
+ * @param out output float vector
+ * @param len number of elements to process
+ */
+void neon_add_scalar(const float *a, float scalar, float *out, size_t len);
+
+/**
  * @brief     elementwise vector multiplication : Z = X ⊙ alpha * Y + beta * Z
  * @param[in] N  length of the vector
  * @param[in] X float * for Vector X

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -1443,6 +1443,26 @@ extern void compute_rotary_emb_value(unsigned int width, unsigned int dim,
 extern void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
                                               float *__restrict Y, size_t H,
                                               size_t W, float epsilon);
+
+/**
+ * @brief Element-wise squaring: out = a * a
+ *
+ * @param[in] a input array
+ * @param[out] out output array
+ * @param[in] len number of elements
+ */
+extern void neon_square(const float *a, float *out, size_t len);
+
+/**
+ * @brief Add scalar to array: out = a + scalar
+ *
+ * @param[in] a input array
+ * @param[in] scalar scalar value
+ * @param[out] out output array
+ * @param[in] len number of elements
+ */
+extern void neon_add_scalar(const float *a, float scalar, float *out, size_t len);
+
 /**
  * @brief rms normalization computation w.r.t. width in H*W matrix input
  *

--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -459,6 +459,18 @@ int FloatTensor::add_i_partial(unsigned int len, unsigned int addr_idx,
 }
 
 Tensor &FloatTensor::add(float const &value, Tensor &output) const {
+  CREATE_IF_EMPTY_DIMS(output, dim, nullptr);
+  
+  // Use SIMD for scalar addition when both tensors are contiguous
+  if (contiguous && output.getContiguous()) {
+    const float *data = (float *)getData();
+    float *out_data = (float *)output.getData();
+    size_t len = size();
+    neon_add_scalar(data, value, out_data, len);
+    return output;
+  }
+  
+  // Fallback to scalar implementation for non-contiguous tensors
   auto f = std::bind(std::plus<float>(), std::placeholders::_1, value);
   apply(f, output);
   return output;
@@ -675,6 +687,26 @@ void FloatTensor::normalization_i(unsigned int dim, float p, float epsilon) {
 }
 
 Tensor &FloatTensor::pow(float exponent, Tensor &output) const {
+  CREATE_IF_EMPTY_DIMS(output, dim, nullptr);
+
+  const float *data = (float *)getData();
+  float *out_data = (float *)output.getData();
+  size_t len = size();
+  
+  // Use SIMD for squaring (exponent = 2.0)
+  if (exponent == 2.0f && contiguous && output.getContiguous()) {
+    neon_square(data, out_data, len);
+    return output;
+  }
+  
+  // Use SIMD for inverse square root (exponent = -0.5)
+  if (exponent == -0.5f && contiguous && output.getContiguous()) {
+    scopy(len, data, 1, out_data, 1);
+    inv_sqrt_inplace(len, out_data);
+    return output;
+  }
+  
+  // Fallback to scalar implementation for other exponents
   auto f = [exponent](float in) { return powf(in, exponent); };
   apply(f, output);
   return output;
@@ -716,6 +748,19 @@ void FloatTensor::tan(Tensor &output, float alpha) {
 }
 
 void FloatTensor::inv_sqrt(Tensor &out) {
+  CREATE_IF_EMPTY_DIMS(out, dim);
+  
+  // Use SIMD for contiguous tensors
+  if (contiguous && out.getContiguous()) {
+    const float *data = (float *)getData();
+    float *out_data = (float *)out.getData();
+    size_t len = size();
+    scopy(len, data, 1, out_data, 1);
+    inv_sqrt_inplace(len, out_data);
+    return;
+  }
+  
+  // Fallback to scalar implementation for non-contiguous tensors
   apply([](float val) -> float { return 1 / std::sqrt(val); }, out);
 }
 


### PR DESCRIPTION
Added SIMD optimizations for add_i, pow and used existing SIMD implementation for inverse sqrt. All other kernels that are used in Layernorm implementation are already using SIMD/BLAS optimizations.