### PR TITLE
[CausalLM] SwiGLU layer with forwarding and backpropagation support

### DIFF
--- a/Applications/CausalLM/layers/swiglu.cpp
+++ b/Applications/CausalLM/layers/swiglu.cpp
@@ -32,10 +32,28 @@ float swiglu(float x) { return x / (1 + nntrainer::exp_util(-x)); }
 
 void SwiGLULayer::finalize(nntrainer::InitLayerContext &context) {
   context.setOutputDimensions({context.getInputDimensions()[0]});
+  // Cache sigmoid(gate) for backward pass
+  tensor_idx[SwiGLUParams::sigmoid_gate] = context.requestTensor(
+    context.getInputDimensions()[0], "sigmoid_gate",
+    nntrainer::Initializer::NONE, false,
+    nntrainer::TensorLifespan::ITERATION_LIFESPAN);
 }
 
 void SwiGLULayer::forwarding(nntrainer::RunLayerContext &context,
-                             bool training) {}
+                             bool training) {
+  nntrainer::Tensor &gate = context.getInput(INPUT_IDX_1);
+  nntrainer::Tensor &up = context.getInput(INPUT_IDX_2);
+  nntrainer::Tensor &out = context.getOutput(OUT_IDX);
+  nntrainer::Tensor &sig_gate =
+    context.getTensor(tensor_idx[SwiGLUParams::sigmoid_gate]);
+  // sigmoid(gate)
+  gate.apply<float>([](float x) { return 1.0f / (1.0f + nntrainer::exp_util(-x)); },
+                    sig_gate);
+  // swish(gate) = gate * sigmoid(gate)
+  gate.multiply(sig_gate, out);
+  // output = swish(gate) * up
+  out.multiply_i(up);
+}
 
 void SwiGLULayer::incremental_forwarding(nntrainer::RunLayerContext &context,
                                          unsigned int from, unsigned int to,
@@ -94,8 +112,31 @@ void SwiGLULayer::updateTensorsByInputDimensions(
 }
 
 void SwiGLULayer::calcDerivative(nntrainer::RunLayerContext &context) {
-  // std::throw_with_nested(std::runtime_error("Training is not supported
-  // yet."));
+  const nntrainer::Tensor &incoming_deriv =
+    context.getIncomingDerivative(OUT_IDX);
+  nntrainer::Tensor &d_gate = context.getOutgoingDerivative(INPUT_IDX_1);
+  nntrainer::Tensor &d_up = context.getOutgoingDerivative(INPUT_IDX_2);
+  nntrainer::Tensor &gate = context.getInput(INPUT_IDX_1);
+  nntrainer::Tensor &up = context.getInput(INPUT_IDX_2);
+  nntrainer::Tensor &sig_gate =
+    context.getTensor(tensor_idx[SwiGLUParams::sigmoid_gate]);
+  // swish(gate) = gate * sigmoid(gate)
+  // d_up = swish(gate) * dy
+  gate.multiply(sig_gate, d_up);
+  d_up.multiply_i(incoming_deriv);
+  // swish'(gate) = sigmoid(gate) + gate * sigmoid(gate) * (1 - sigmoid(gate))
+  //              = sigmoid(gate) * (1 + gate * (1 - sigmoid(gate)))
+  // d_gate = up * swish'(gate) * dy
+  nntrainer::Tensor one_minus_sig = sig_gate.multiply(-1.0f);
+  one_minus_sig.add_i(1.0f);
+  // gate * (1 - sigmoid(gate))
+  gate.multiply(one_minus_sig, d_gate);
+  // sigmoid(gate) + gate * sigmoid(gate) * (1 - sigmoid(gate))
+  d_gate.multiply_i(sig_gate);
+  d_gate.add_i(sig_gate);
+  // up * swish'(gate) * dy
+  d_gate.multiply_i(up);
+  d_gate.multiply_i(incoming_deriv);
 }
 
 #ifdef PLUGGABLE

--- a/Applications/CausalLM/layers/swiglu.h
+++ b/Applications/CausalLM/layers/swiglu.h
@@ -14,6 +14,7 @@
 #ifndef __SWIGLU_LAYER_H__
 #define __SWIGLU_LAYER_H__
 
+#include <array>
 #include <layer_context.h>
 #include <layer_devel.h>
 #include <node_exporter.h>
@@ -38,7 +39,9 @@ public:
    * @brief Construct a new custom SwiGLU layer object
    *
    */
-  WIN_EXPORT SwiGLULayer() : Layer() {}
+  WIN_EXPORT SwiGLULayer() : Layer() {
+    tensor_idx.fill(std::numeric_limits<unsigned>::max());
+  }
 
   /**
    * @brief Destroy the custom SwiGLU layer object
@@ -100,6 +103,10 @@ public:
     std::vector<nntrainer::TensorDim> input_dimensions) override;
 
   inline static const std::string type = "swiglu";
+
+private:
+  enum SwiGLUParams { sigmoid_gate = 0 };
+  std::array<unsigned int, 1> tensor_idx;
 };
 
 } // namespace causallm

--- a/test/input_gen/gen_layer_tests.py
+++ b/test/input_gen/gen_layer_tests.py
@@ -914,6 +914,14 @@ if __name__ == "__main__":
         input_type="float",
     )
 
+    # CausalLM SwiGLU
+    record_single(
+        swiglu_layer,
+        [(2, 1, 1, 10), (2, 1, 1, 10)],
+        "causallm_swiglu",
+        input_type="float",
+    )
+
     def reshape_tensor(tensor, batch_size, input_channel, input_height, input_width):
         output_height = 1
         output_width = input_channel * input_height * input_width

--- a/test/unittest/layers/meson.build
+++ b/test/unittest/layers/meson.build
@@ -1,4 +1,4 @@
-layer_common_test_inc = [ include_directories('./', '../../include') ]
+layer_common_test_inc = [ include_directories('./', '../../include', '../../../Applications/CausalLM/layers') ]
 layer_common_test_standalone_files = files('layers_standalone_common_tests.cpp')
 layer_common_test_dependent_files = files('layers_dependent_common_tests.cpp')
 
@@ -123,6 +123,9 @@ if get_option('enable-opencl')
   test_target += 'unittest_layers_concat_cl.cpp'
   test_target += 'unittest_layers_swiglu_cl.cpp'
 endif
+
+test_target += 'unittest_layers_causallm_swiglu.cpp'
+test_target += meson.source_root() / 'Applications' / 'CausalLM' / 'layers' / 'swiglu.cpp'
 
 if get_option('enable-tflite-backbone')
   test_target += 'unittest_layers_tflite.cpp'

--- a/test/unittest/layers/unittest_layers_causallm_swiglu.cpp
+++ b/test/unittest/layers/unittest_layers_causallm_swiglu.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Niket Agarwal <niket.a@samsung.com>
+ *
+ * @file unittest_layers_causallm_swiglu.cpp
+ * @date 03 Apr 2026
+ * @brief CausalLM SwiGLU Layer Test
+ * @see	https://github.com/nntrainer/nntrainer
+ * @author Niket Agarwal <niket.a@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <tuple>
+#include <gtest/gtest.h>
+#include <layers_common_tests.h>
+#include "../../../Applications/CausalLM/layers/swiglu.h"
+
+auto causallm_swiglu_golden = LayerGoldenTestParamType(
+  nntrainer::createLayer<causallm::SwiGLULayer>, {}, "2:1:1:10,2:1:1:10",
+  "causallm_swiglu.nnlayergolden",
+  LayerGoldenTestParamOptions::DEFAULT, "nchw", "fp32", "fp32");
+
+GTEST_PARAMETER_TEST(CausalLMSwiGLU, LayerGoldenTest,
+                     ::testing::Values(causallm_swiglu_golden));


### PR DESCRIPTION
- Implement SwiGLU activation function with proper forward and backward passes
- Add  forwarding for training mode
- Add calcDerivative implementation for backpropagation support
- Add comprehensive unit tests with golden data validation
- Generate correct golden data using standard TensorFlow/Keras framework

## Files Modified/Added
- `Applications/CausalLM/layers/swiglu.cpp` 
- `Applications/CausalLM/layers/swiglu.h`
- `test/input_gen/gen_layer_tests.py` 
- `test/unittest/layers/unittest_layers_causallm_swiglu.cpp` 
- `test/unittest/layers/meson.build`

Signed-off-by: Niket Agarwal <niket.a@samsung.com>