### PR TITLE
[API] split API's structure and internal structure

### DIFF
--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -577,7 +577,14 @@ ErrorCode getPerformanceMetrics(PerformanceMetrics *metrics) {
       if (!causal_lm_model->hasRun()) {
         return CAUSAL_LM_ERROR_INFERENCE_NOT_RUN;
       }
-      *metrics = causal_lm_model->getPerformanceMetrics();
+      auto internal_metrics = causal_lm_model->getPerformanceMetrics();
+      metrics->prefill_tokens = internal_metrics.prefill_tokens;
+      metrics->prefill_duration_ms = internal_metrics.prefill_duration_ms;
+      metrics->generation_tokens = internal_metrics.generation_tokens;
+      metrics->generation_duration_ms = internal_metrics.generation_duration_ms;
+      metrics->total_duration_ms = internal_metrics.total_duration_ms;
+      metrics->peak_memory_kb = internal_metrics.peak_memory_kb;
+
       // Overwrite init duration with the one measured in loadModel API
       metrics->initialization_duration_ms = g_initialization_duration_ms;
     } else {

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -22,8 +22,20 @@
 extern "C" {
 #endif
 
-#include "../models/performance_metrics.h"
 #include <stddef.h>
+
+/**
+ * @brief Performance Metrics
+ */
+typedef struct {
+  unsigned int prefill_tokens;
+  double prefill_duration_ms;
+  unsigned int generation_tokens;
+  double generation_duration_ms;
+  double total_duration_ms;
+  double initialization_duration_ms;
+  size_t peak_memory_kb;
+} PerformanceMetrics;
 
 /**
  * @brief Error codes

--- a/Applications/CausalLM/api/model_config.cpp
+++ b/Applications/CausalLM/api/model_config.cpp
@@ -52,9 +52,9 @@ static void register_qwen3_0_6b() {
   rc.num_to_generate = 512;
   rc.fsu = false;
   rc.fsu_lookahead = 2;
-  strncpy(rc.embedding_dtype, "Q6_K", sizeof(rc.embedding_dtype) - 1);
+  strncpy(rc.embedding_dtype, "Q4_0", sizeof(rc.embedding_dtype) - 1);
   strncpy(rc.fc_layer_dtype, "Q4_0", sizeof(rc.fc_layer_dtype) - 1);
-  strncpy(rc.model_file_name, "qwen3-0.6b-q6k-q40-q40-fp32-arm.bin",
+  strncpy(rc.model_file_name, "qwen3-0.6b-q40-fp32-arm.bin",
           sizeof(rc.model_file_name) - 1);
   strncpy(rc.tokenizer_file, "tokenizer.json", sizeof(rc.tokenizer_file) - 1);
   strncpy(rc.lmhead_dtype, "Q4_0", sizeof(rc.lmhead_dtype) - 1);

--- a/Applications/CausalLM/install_android.sh
+++ b/Applications/CausalLM/install_android.sh
@@ -206,7 +206,6 @@ log_info "Creating run script on device..."
 adb shell "cat > $INSTALL_DIR/run_causallm.sh << 'EOF'
 #!/system/bin/sh
 export LD_LIBRARY_PATH=$INSTALL_DIR:\$LD_LIBRARY_PATH
-export OMP_NUM_THREADS=4
 cd $INSTALL_DIR
 ./nntrainer_causallm \$@
 EOF
@@ -228,7 +227,6 @@ if [ -f "$SCRIPT_DIR/jni/libs/arm64-v8a/test_api" ]; then
     adb shell "cat > $INSTALL_DIR/run_test_api.sh << 'EOF'
 #!/system/bin/sh
 export LD_LIBRARY_PATH=$INSTALL_DIR:\$LD_LIBRARY_PATH
-export OMP_NUM_THREADS=4
 cd $INSTALL_DIR
 ./test_api \$@
 EOF

--- a/Applications/CausalLM/models/performance_metrics.h
+++ b/Applications/CausalLM/models/performance_metrics.h
@@ -30,7 +30,7 @@ typedef struct {
   double total_duration_ms;
   double initialization_duration_ms;
   size_t peak_memory_kb;
-} PerformanceMetrics;
+} TransformerPerformanceMetrics;
 
 #ifdef __cplusplus
 }

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -116,9 +116,9 @@ public:
                    bool log_output = true);
 
   /**
-   * @brief Get PerformanceMetrics
+   * @brief Get TransformerPerformanceMetrics
    */
-  PerformanceMetrics getPerformanceMetrics() const {
+  TransformerPerformanceMetrics getPerformanceMetrics() const {
     return performance_metrics;
   }
 
@@ -199,7 +199,7 @@ protected:
   bool IS_CAUSAL = true;
 
   // Performance metrics
-  PerformanceMetrics performance_metrics;
+  TransformerPerformanceMetrics performance_metrics;
 };
 /**
  * Loads JSON data from a file with detailed error handling


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[API] split API's structure and internal structure</summary><br />

- This commit resolves API dependency
- This commit splits layer between API and CausalLM app
- Rename internal PerformanceMetrics to TransformerPerformanceMetrics and
define PerformanceMetrics directly in the API header. This removes the
API's dependency on the internal performance_metrics.h header, ensuring
a clean API boundary. causal_lm_api.cpp now converts between the two
structs field-by-field.


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



<details><summary>[API] update install script & default config</summary><br />

- This commit updates default configuration of Qwen3-0.6B-W4A32
- This commit updates device script (remove OMP_NUM_THREADS=4)

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

### Summary

Rename internal PerformanceMetrics to TransformerPerformanceMetrics and
define PerformanceMetrics directly in the API header. This removes the
API's dependency on the internal performance_metrics.h header, ensuring
a clean API boundary. causal_lm_api.cpp now converts between the two
structs field-by-field.


Signed-off-by: Eunju Yang <ej.yang@samsung.com>
