### PR TITLE
[engine] Fix dlopen context cleanup and static destruction order issues

### DIFF
--- a/nntrainer/engine.cpp
+++ b/nntrainer/engine.cpp
@@ -62,7 +62,52 @@ void Engine::initialize() noexcept {
   }
 };
 
-void Engine::release() { thread_pool_manager_.reset(); }
+void Engine::release() {
+  // Guard against double-release (could be called from both atexit and
+  // destructor)
+  if (engines.empty()) {
+    return;
+  }
+
+  // Clean up dynamically allocated contexts (those loaded from plugins)
+  // Note: Static contexts like AppContext::Global() are not deleted here
+  // as they are managed elsewhere
+
+  // Delete all dynamic contexts using their destroy functions
+  // Using destroyfunc ensures proper cleanup as defined by the plugin
+  for (auto &pair : engines) {
+    // Check if this is a dynamically allocated context
+    // by checking if it was loaded from a plugin library
+    bool is_dynamic = true;
+    if (pair.first == "cpu") {
+      is_dynamic = false; // AppContext is a static singleton
+    }
+#if defined(ENABLE_OPENCL) && ENABLE_OPENCL == 1
+    if (pair.first == "gpu") {
+      is_dynamic = false; // ClContext is a static singleton
+    }
+#endif
+    if (is_dynamic && pair.second) {
+      // Use destroyfunc if available, otherwise fall back to delete
+      auto it = destroy_funcs.find(pair.first);
+      if (it != destroy_funcs.end() && it->second) {
+        it->second(pair.second);
+      } else {
+        delete pair.second;
+      }
+    }
+  }
+  engines.clear();
+  allocator.clear();
+  destroy_funcs.clear();
+
+  // Do NOT close library handles - QNNContext destructor already handles
+  // its own library cleanup (dlClose on m_backendLibraryHandle)
+  // Closing library handles here would cause a double-free segfault
+  library_handles.clear();
+
+  thread_pool_manager_.reset();
+}
 
 std::string
 Engine::parseComputeEngine(const std::vector<std::string> &props) const {
@@ -84,7 +129,6 @@ Engine::parseComputeEngine(const std::vector<std::string> &props) const {
 
   return "cpu";
 }
-
 /**
  * @brief Get the Full Path from given string
  * @details path is resolved in the following order
@@ -167,7 +211,15 @@ int Engine::registerContext(const std::string &library_path,
   NNTR_THROW_IF_CLEANUP(type == "", std::invalid_argument, close_dl)
     << func_tag << "custom layer must specify type name, but it is empty";
 
-  registerContext(type, context);
+  // Pass library handle and destroy function for proper cleanup
+  registerContext(type, context, handle, pluggable->destroyfunc);
+
+  // Register cleanup with atexit to ensure it runs before static destruction
+  // This ensures QNN contexts are cleaned up before the driver state becomes
+  // invalid. Using std::call_once for thread safety.
+  static std::once_flag atexit_flag;
+  std::call_once(atexit_flag,
+                 []() { std::atexit([]() { Engine::Global().release(); }); });
 
   return 0;
 }

--- a/nntrainer/engine.h
+++ b/nntrainer/engine.h
@@ -61,7 +61,9 @@ protected:
 
   void add_default_object();
 
-  void registerContext(std::string name, nntrainer::Context *context) {
+  void registerContext(std::string name, nntrainer::Context *context,
+                       void *library_handle = nullptr,
+                       DestroyContextFunc destroy_func = nullptr) {
     const std::lock_guard<std::mutex> lock(engine_mutex);
     static int registerCount = 0;
 
@@ -83,6 +85,14 @@ protected:
     auto alloc = context->getMemAllocator();
 
     allocator.insert(std::make_pair(name, alloc));
+
+    // Store library handle and destroy function for plugin contexts
+    if (library_handle) {
+      library_handles[name] = library_handle;
+    }
+    if (destroy_func) {
+      destroy_funcs[name] = destroy_func;
+    }
   }
 
 public:
@@ -92,9 +102,9 @@ public:
   Engine() = default;
 
   /**
-   * @brief   Default Destructor
+   * @brief   Destructor - releases all contexts
    */
-  ~Engine() = default;
+  ~Engine() { release(); }
 
   /**
    * @brief   Release resources allocated by Engine
@@ -280,6 +290,18 @@ private:
    *
    */
   std::unordered_map<std::string, nntrainer::Context *> engines;
+
+  /**
+   * @brief map for library handles (context name -> library handle)
+   * These handles must be kept alive until contexts are destroyed
+   */
+  std::unordered_map<std::string, void *> library_handles;
+
+  /**
+   * @brief map for destroy functions (context name -> destroy function)
+   * Used to properly destroy contexts created by plugins
+   */
+  std::unordered_map<std::string, DestroyContextFunc> destroy_funcs;
 
   std::unordered_map<std::string, std::shared_ptr<nntrainer::MemAllocator>>
     allocator;


### PR DESCRIPTION
## Dependency of the PR
None

## Commits to be reviewed in this PR

<details><summary>[engine] Fix dlopen context cleanup and static destruction order issues</summary><br />

Currently, contexts registered using `Engine::registerContext(const std::string &library_path, const std::string &base_path)` are not released properly. This commit addresses releasing contexts registered this way.

- Added destructor that calls release()
- Added guard against double-release
- Registered cleanup via std::atexit() to ensure it runs before static destruction
- Use pluggable->destroyfunc to destroy contexts

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Haehun Yang <haehun.yang@samsung.com>

</details>
