### PR TITLE
Validate embedding indices before OpenMP region and reorganize parallel loops in EmbeddingLayer

### DIFF
--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -114,15 +114,20 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
 
     int iter = to - from;
 
-#pragma omp parallel for
+    /**
+     * @note Avoid throwing exceptions inside OpenMP parallel region.
+     *       Validate input indices before entering the parallel section.
+     */
     for (int i = 0; i < iter; ++i) {
       size_t embed_idx = static_cast<size_t>(in_data[i]);
       if (embed_idx >= in_dim) {
         throw std::invalid_argument("input word index is greater than in_dim");
       }
+    }
 
-      nntrainer::Tensor cur_weight =
-        weight.getSharedDataTensor(out_tensor_dim, out_dim * embed_idx);
+#pragma omp parallel for
+    for (int i = 0; i < iter; ++i) {
+      size_t embed_idx = static_cast<size_t>(in_data[i]);
       nntrainer::Tensor out_tensor =
         batchsliced_hidden.getSharedDataTensor(out_tensor_dim, out_dim * (i));
 
@@ -141,6 +146,8 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
                    (18 * num_blocks_per_row) * embed_idx),
           out_tensor.getData(), out_dim);
       } else {
+        nntrainer::Tensor cur_weight =
+          weight.getSharedDataTensor(out_tensor_dim, out_dim * embed_idx);
         out_tensor.copyData(cur_weight);
       }
 


### PR DESCRIPTION
### Motivation

- Prevent throwing exceptions from inside an OpenMP parallel region by validating input indices beforehand.
- Ensure safe and clear handling for both quantized and non-quantized `weight` tensor paths in `EmbeddingLayer::incremental_forwarding`.

### Description

- Added a sequential pre-check loop that validates `in_data[i] < in_dim` before entering the parallel section and documented the rationale.
- Reorganized the processing so the actual work is performed in a separate `#pragma omp parallel for` loop that handles dequantization, tensor copying, and scaling.
- Deferred creation of `cur_weight` into the non-quantized branch to avoid unnecessary tensor slicing when using quantized formats.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2f70e554483208e4c6cde18bf1c92)