### PR TITLE
[CausalLM] move hasRun to transformer

### DIFF
--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -571,17 +571,12 @@ ErrorCode getPerformanceMetrics(PerformanceMetrics *metrics) {
 
   try {
     std::lock_guard<std::mutex> lock(g_mutex);
-    auto causal_lm_model = dynamic_cast<causallm::CausalLM *>(g_model.get());
 
-    if (causal_lm_model) {
-      if (!causal_lm_model->hasRun()) {
-        return CAUSAL_LM_ERROR_INFERENCE_NOT_RUN;
-      }
-      *metrics = causal_lm_model->getPerformanceMetrics();
-      // Overwrite init duration with the one measured in loadModel API
-      metrics->initialization_duration_ms = g_initialization_duration_ms;
+    if (!g_model->hasRun()) {
+      return CAUSAL_LM_ERROR_INFERENCE_NOT_RUN;
     } else {
-      return CAUSAL_LM_ERROR_UNKNOWN;
+      *metrics = g_model->getPerformanceMetrics();
+      metrics->initialization_duration_ms = g_initialization_duration_ms;
     }
 
   } catch (const std::exception &e) {

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -597,25 +597,20 @@ ErrorCode getPerformanceMetrics(PerformanceMetrics *metrics) {
 
   try {
     std::lock_guard<std::mutex> lock(g_mutex);
-    auto causal_lm_model = dynamic_cast<causallm::CausalLM *>(g_model.get());
 
-    if (causal_lm_model) {
-      if (!causal_lm_model->hasRun()) {
-        return CAUSAL_LM_ERROR_INFERENCE_NOT_RUN;
-      }
-      auto internal_metrics = causal_lm_model->getPerformanceMetrics();
-      metrics->prefill_tokens = internal_metrics.prefill_tokens;
-      metrics->prefill_duration_ms = internal_metrics.prefill_duration_ms;
-      metrics->generation_tokens = internal_metrics.generation_tokens;
-      metrics->generation_duration_ms = internal_metrics.generation_duration_ms;
-      metrics->total_duration_ms = internal_metrics.total_duration_ms;
-      metrics->peak_memory_kb = internal_metrics.peak_memory_kb;
-
-      // Overwrite init duration with the one measured in loadModel API
-      metrics->initialization_duration_ms = g_initialization_duration_ms;
-    } else {
-      return CAUSAL_LM_ERROR_UNKNOWN;
+    if (!g_model->hasRun()) {
+      return CAUSAL_LM_ERROR_INFERENCE_NOT_RUN;
     }
+    auto internal_metrics = g_model->getPerformanceMetrics();
+    metrics->prefill_tokens = internal_metrics.prefill_tokens;
+    metrics->prefill_duration_ms = internal_metrics.prefill_duration_ms;
+    metrics->generation_tokens = internal_metrics.generation_tokens;
+    metrics->generation_duration_ms = internal_metrics.generation_duration_ms;
+    metrics->total_duration_ms = internal_metrics.total_duration_ms;
+    metrics->peak_memory_kb = internal_metrics.peak_memory_kb;
+
+    // Overwrite init duration with the one measured in loadModel API
+    metrics->initialization_duration_ms = g_initialization_duration_ms;
 
   } catch (const std::exception &e) {
     std::cerr << "Exception in getPerformanceMetrics: " << e.what()

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -80,11 +80,6 @@ public:
    */
   std::string getOutput(int batch_idx = 0) const;
 
-  /**
-   * @brief get the status of run
-   */
-  bool hasRun() const { return has_run_; }
-
 protected:
   /**
    * @brief Setup the parameters for the CausalLM model
@@ -151,8 +146,6 @@ protected:
   bool SAVE_KVCACHE;
   bool USE_KVCACHE;
   unsigned int global_token_len;
-
-  bool has_run_ = false;
 
   std::mt19937 rng; /**< Random Number Gen */
 };

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -122,6 +122,11 @@ public:
     return performance_metrics;
   }
 
+  /**
+   * @brief get the status of run
+   */
+  bool hasRun() const { return has_run_; }
+
 protected:
   /**
    * @brief Setup the parameters for the Transformer model
@@ -200,6 +205,8 @@ protected:
 
   // Performance metrics
   PerformanceMetrics performance_metrics;
+
+  bool has_run_ = false;
 };
 /**
  * Loads JSON data from a file with detailed error handling

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -122,6 +122,11 @@ public:
     return performance_metrics;
   }
 
+  /**
+   * @brief get the status of run
+   */
+  bool hasRun() const { return has_run_; }
+
 protected:
   /**
    * @brief Setup the parameters for the Transformer model
@@ -200,6 +205,8 @@ protected:
 
   // Performance metrics
   TransformerPerformanceMetrics performance_metrics;
+
+  bool has_run_ = false;
 };
 /**
  * Loads JSON data from a file with detailed error handling


### PR DESCRIPTION

## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] move hasRun to transformer</summary><br />

- This commit moves hasRun from causalLM to transformer
- With this commit, API can support getPerformanceMetrics for any model with transformer


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



### Summary

- This commit moves hasRun from causalLM to transformer
- With this commit, API can support getPerformanceMetrics for any model with transformer


Signed-off-by: Eunju Yang <ej.yang@samsung.com>
