### PR TITLE
[CausalLM] add chat template feature

### DIFF
--- a/Applications/CausalLM/README.md
+++ b/Applications/CausalLM/README.md
@@ -28,6 +28,76 @@ The API allows loading models, running inference, and retrieving performance met
 
 For detailed documentation, please refer to [API Documentation](api/README.md).
 
+## Chat Template
+
+CausalLM supports automatic chat template formatting by reading the `chat_template` field from HuggingFace's `tokenizer_config.json`. This eliminates the need for hardcoded per-model chat formatting.
+
+### How It Works
+
+Most HuggingFace models include a `tokenizer_config.json` with a `chat_template` field (Jinja2 format) that defines how to format conversations. CausalLM includes a built-in mini Jinja2 renderer that processes these templates at runtime.
+
+When a `tokenizer_config.json` is present in the model directory:
+- **CLI (`nntr_causallm`)**: Raw user input provided as a command-line argument is automatically wrapped with the chat template.
+- **C API**: The `apply_chat_template()` function uses the dynamic template instead of hardcoded formats.
+
+If `tokenizer_config.json` is absent or does not contain a `chat_template` field, a warning is printed and the system falls back to hardcoded per-architecture templates (Llama, Qwen, Gemma3).
+
+### Supported Template Features
+
+The built-in Jinja2 renderer supports the following constructs commonly used in HuggingFace chat templates:
+
+| Feature | Example |
+|---------|---------|
+| For loops | `{% for message in messages %}...{% endfor %}` |
+| Conditionals | `{% if %}...{% elif %}...{% else %}...{% endif %}` |
+| Output expressions | `{{ bos_token }}` |
+| Variable assignment | `{% set offset = 1 %}` |
+| Dict/array access | `message['role']`, `messages[0]` |
+| String concatenation | `'<\|im_start\|>' + message['role']` |
+| Comparison operators | `==`, `!=`, `>`, `<`, `>=`, `<=` |
+| Boolean operators | `and`, `or`, `not` |
+| Loop variables | `loop.first`, `loop.last`, `loop.index`, `loop.index0` |
+| Filters | `\| trim`, `\| length`, `\| tojson` |
+| String methods | `.strip()`, `.startswith()`, `.upper()`, `.split()` |
+| Containment test | `'keyword' in message['content']` |
+| Namespace | `namespace()` for cross-scope variable mutation |
+| Whitespace control | `{%- -%}`, `{{- -}}` |
+
+### Required Files
+
+To use chat templates, ensure `tokenizer_config.json` is in your model directory alongside the other config files. This file is included by default when downloading models from HuggingFace.
+
+### Example
+
+```bash
+# With tokenizer_config.json present, raw input is auto-formatted:
+./nntr_causallm /path/to/model "What is machine learning?"
+
+# The input will be automatically wrapped, e.g. for Qwen3:
+# <|im_start|>user
+# What is machine learning?<|im_end|>
+# <|im_start|>assistant
+```
+
+### Multi-turn Conversations (API)
+
+The C API supports multi-turn conversations through `ChatMessage`:
+
+```cpp
+#include "chat_template.h"
+
+causallm::ChatTemplate tmpl = causallm::ChatTemplate::fromFile("tokenizer_config.json");
+
+std::vector<causallm::ChatMessage> messages = {
+  {"system", "You are a helpful assistant."},
+  {"user", "Hello!"},
+  {"assistant", "Hi there!"},
+  {"user", "How are you?"}
+};
+
+std::string formatted = tmpl.apply(messages);
+```
+
 ## How to run
 
 ### 1. Prepare Model Files

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "causal_lm.h"
+#include "chat_template.h"
 #include "gemma3_causallm.h"
 #include "gptoss_cached_slim_causallm.h"
 #include "gptoss_causallm.h"
@@ -46,6 +47,7 @@ static bool g_use_chat_template = false;
 static bool g_verbose = false;
 static std::string g_last_output = "";
 static double g_initialization_duration_ms = 0.0;
+static causallm::ChatTemplate g_chat_template;
 
 static std::map<std::string, std::string> g_model_path_map = {
   {"QWEN3-0.6B", "qwen3-0.6b"},
@@ -134,6 +136,12 @@ static const char *get_model_name_from_type(ModelType type) {
 
 static std::string apply_chat_template(const std::string &architecture,
                                        const std::string &input) {
+  // Use dynamic chat template from tokenizer_config.json if available
+  if (g_chat_template.isAvailable()) {
+    return g_chat_template.apply(input);
+  }
+
+  // Fallback: hardcoded per-architecture templates
   if (architecture == "LlamaForCausalLM") {
     // Llama 2/3 chat format: [INST] {prompt} [/INST]
     return "[INST] " + input + " [/INST]";
@@ -144,8 +152,6 @@ static std::string apply_chat_template(const std::string &architecture,
              architecture == "Qwen3CachedSlimMoeForCausalLM") {
     // Qwen chat format
     // <|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n
-    // Note: assuming model handles tokenizer specific special tokens or we
-    // might need to handle them raw if tokenizer enabled
     return "<|im_start|>user\n" + input + "<|im_end|>\n<|im_start|>assistant\n";
   } else if (architecture == "Gemma3ForCausalLM") {
     // Gemma chat format:
@@ -466,6 +472,12 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
         std::string t_file = nntr_cfg["tokenizer_file"];
         nntr_cfg["tokenizer_file"] = model_dir_path + "/" + t_file;
       }
+    }
+
+    // Load chat template from tokenizer_config.json if available
+    std::string tc_path = model_dir_path + "/tokenizer_config.json";
+    if (check_file_exists(tc_path)) {
+      g_chat_template = causallm::ChatTemplate::fromFile(tc_path);
     }
 
     // Construct weight file path

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -478,6 +478,19 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
     std::string tc_path = model_dir_path + "/tokenizer_config.json";
     if (check_file_exists(tc_path)) {
       g_chat_template = causallm::ChatTemplate::fromFile(tc_path);
+      if (g_chat_template.isAvailable()) {
+        std::cout << "[Info] Chat template loaded from tokenizer_config.json"
+                  << std::endl;
+      } else {
+        std::cerr
+          << "[Warning] tokenizer_config.json found but chat template could "
+             "not be loaded. Falling back to hardcoded templates."
+          << std::endl;
+      }
+    } else {
+      std::cerr << "[Warning] tokenizer_config.json not found in "
+                << model_dir_path << ". Using hardcoded chat templates."
+                << std::endl;
     }
 
     // Construct weight file path

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -488,6 +488,7 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
           << std::endl;
       }
     } else {
+      g_chat_template = causallm::ChatTemplate();
       std::cerr << "[Warning] tokenizer_config.json not found in "
                 << model_dir_path << ". Using hardcoded chat templates."
                 << std::endl;

--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -617,6 +617,9 @@ private:
   /** @brief Advance to next token and return the current one */
   const Token &advance() { return tokens_[pos_++]; }
 
+  /** @brief Peek at the next token without advancing */
+  const Token &peek() const { return tokens_[pos_ + 1]; }
+
   /** @brief Check if current token matches the given type */
   bool check(TokenType type) const { return current().type == type; }
 
@@ -965,9 +968,16 @@ private:
   }
 
   // "in" / "not in" containment
-  /** @brief Parse "in" containment expression */
+  /** @brief Parse "in" and "not in" containment expressions */
   ExprNodePtr parseContains() {
     auto left = parseAddition();
+
+    bool negated = false;
+    if (check(TokenType::NOT) && pos_ + 1 < tokens_.size() &&
+        peek().type == TokenType::IN) {
+      advance(); // skip 'not'
+      negated = true;
+    }
 
     if (check(TokenType::IN)) {
       advance();
@@ -975,9 +985,14 @@ private:
       auto node = std::make_shared<ContainsExpr>();
       node->item = left;
       node->container = right;
+      if (negated) {
+        auto not_node = std::make_shared<UnaryExpr>();
+        not_node->op = "not";
+        not_node->operand = node;
+        return not_node;
+      }
       return node;
     }
-    // "not in" is handled by parseNot wrapping this
 
     return left;
   }

--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -1407,7 +1407,10 @@ private:
       json index = evalExpr(idx->index.get());
       if (obj.is_array() && index.is_number_integer()) {
         int i = index.get<int>();
-        if (i >= 0 && i < static_cast<int>(obj.size()))
+        int sz = static_cast<int>(obj.size());
+        if (i < 0)
+          i += sz;
+        if (i >= 0 && i < sz)
           return obj[i];
       } else if (obj.is_object() && index.is_string()) {
         std::string key = index.get<std::string>();

--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -1,0 +1,1847 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file    chat_template.cpp
+ * @date    10 Apr 2026
+ * @brief   Chat template implementation with mini Jinja2 renderer
+ * @see     https://github.com/nntrainer/nntrainer
+ * @author  Eunju Yang <ej.yang@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#include "chat_template.h"
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace causallm {
+
+// ============================================================================
+// Token types for the Jinja2 lexer
+// ============================================================================
+enum class TokenType {
+  TEXT,
+  EXPRESSION_START, // {{
+  EXPRESSION_END,   // }}
+  STATEMENT_START,  // {%
+  STATEMENT_END,    // %}
+  STRING,
+  INTEGER,
+  FLOAT,
+  IDENTIFIER,
+  DOT,
+  LBRACKET,
+  RBRACKET,
+  LPAREN,
+  RPAREN,
+  PLUS,
+  MINUS,
+  PERCENT,
+  PIPE,
+  COMMA,
+  EQ,     // ==
+  NEQ,    // !=
+  ASSIGN, // =
+  NOT,    // not
+  AND,    // and
+  OR,     // or
+  TRUE_LIT,
+  FALSE_LIT,
+  NONE_LIT,
+  IF,
+  ELIF,
+  ELSE,
+  ENDIF,
+  FOR,
+  IN,
+  ENDFOR,
+  SET,
+  IS,
+  TILDE, // ~
+  COLON, // :
+  GT,    // >
+  LT,    // <
+  GTE,   // >=
+  LTE,   // <=
+  END_OF_INPUT,
+};
+
+struct Token {
+  TokenType type;
+  std::string value;
+  bool strip_before = false; // {%- or {{-
+  bool strip_after = false;  // -%} or -}}
+};
+
+// ============================================================================
+// Lexer
+// ============================================================================
+class Lexer {
+public:
+  explicit Lexer(const std::string &input) : input_(input), pos_(0) {}
+
+  std::vector<Token> tokenize() {
+    std::vector<Token> tokens;
+
+    while (pos_ < input_.size()) {
+      if (match("{{")) {
+        bool strip = false;
+        if (pos_ < input_.size() && input_[pos_] == '-') {
+          strip = true;
+          pos_++;
+        }
+        Token start;
+        start.type = TokenType::EXPRESSION_START;
+        start.strip_before = strip;
+        tokens.push_back(start);
+        skipWhitespace();
+        tokenizeInside(tokens, TokenType::EXPRESSION_END);
+      } else if (match("{%")) {
+        bool strip = false;
+        if (pos_ < input_.size() && input_[pos_] == '-') {
+          strip = true;
+          pos_++;
+        }
+        Token start;
+        start.type = TokenType::STATEMENT_START;
+        start.strip_before = strip;
+        tokens.push_back(start);
+        skipWhitespace();
+        tokenizeInside(tokens, TokenType::STATEMENT_END);
+      } else {
+        std::string text;
+        while (pos_ < input_.size()) {
+          if ((pos_ + 1 < input_.size()) &&
+              ((input_[pos_] == '{' &&
+                (input_[pos_ + 1] == '{' || input_[pos_ + 1] == '%')))) {
+            break;
+          }
+          text += input_[pos_++];
+        }
+        if (!text.empty()) {
+          Token t;
+          t.type = TokenType::TEXT;
+          t.value = text;
+          tokens.push_back(t);
+        }
+      }
+    }
+
+    Token eof;
+    eof.type = TokenType::END_OF_INPUT;
+    tokens.push_back(eof);
+    return tokens;
+  }
+
+private:
+  bool match(const std::string &s) {
+    if (pos_ + s.size() <= input_.size() &&
+        input_.substr(pos_, s.size()) == s) {
+      pos_ += s.size();
+      return true;
+    }
+    return false;
+  }
+
+  void skipWhitespace() {
+    while (pos_ < input_.size() && std::isspace(input_[pos_]))
+      pos_++;
+  }
+
+  void tokenizeInside(std::vector<Token> &tokens, TokenType end_type) {
+    while (pos_ < input_.size()) {
+      skipWhitespace();
+      if (pos_ >= input_.size())
+        break;
+
+      // Check for closing tag
+      if (end_type == TokenType::EXPRESSION_END) {
+        if (pos_ + 1 < input_.size() && input_[pos_] == '-' &&
+            input_[pos_ + 1] == '}' && pos_ + 2 < input_.size() &&
+            input_[pos_ + 2] == '}') {
+          pos_ += 3;
+          Token end;
+          end.type = end_type;
+          end.strip_after = true;
+          tokens.push_back(end);
+          return;
+        }
+        if (match("}}")) {
+          Token end;
+          end.type = end_type;
+          tokens.push_back(end);
+          return;
+        }
+      } else if (end_type == TokenType::STATEMENT_END) {
+        if (pos_ + 1 < input_.size() && input_[pos_] == '-' &&
+            input_[pos_ + 1] == '%' && pos_ + 2 < input_.size() &&
+            input_[pos_ + 2] == '}') {
+          pos_ += 3;
+          Token end;
+          end.type = end_type;
+          end.strip_after = true;
+          tokens.push_back(end);
+          return;
+        }
+        if (match("%}")) {
+          Token end;
+          end.type = end_type;
+          tokens.push_back(end);
+          return;
+        }
+      }
+
+      // String literal
+      if (input_[pos_] == '\'' || input_[pos_] == '"') {
+        tokens.push_back(readString());
+        continue;
+      }
+
+      // Number
+      if (std::isdigit(input_[pos_])) {
+        tokens.push_back(readNumber());
+        continue;
+      }
+
+      // Identifier or keyword
+      if (std::isalpha(input_[pos_]) || input_[pos_] == '_') {
+        tokens.push_back(readIdentifier());
+        continue;
+      }
+
+      // Operators and punctuation
+      Token t;
+      switch (input_[pos_]) {
+      case '.':
+        t.type = TokenType::DOT;
+        t.value = ".";
+        pos_++;
+        break;
+      case '[':
+        t.type = TokenType::LBRACKET;
+        t.value = "[";
+        pos_++;
+        break;
+      case ']':
+        t.type = TokenType::RBRACKET;
+        t.value = "]";
+        pos_++;
+        break;
+      case '(':
+        t.type = TokenType::LPAREN;
+        t.value = "(";
+        pos_++;
+        break;
+      case ')':
+        t.type = TokenType::RPAREN;
+        t.value = ")";
+        pos_++;
+        break;
+      case '+':
+        t.type = TokenType::PLUS;
+        t.value = "+";
+        pos_++;
+        break;
+      case '-':
+        t.type = TokenType::MINUS;
+        t.value = "-";
+        pos_++;
+        break;
+      case '%':
+        t.type = TokenType::PERCENT;
+        t.value = "%";
+        pos_++;
+        break;
+      case '|':
+        t.type = TokenType::PIPE;
+        t.value = "|";
+        pos_++;
+        break;
+      case ',':
+        t.type = TokenType::COMMA;
+        t.value = ",";
+        pos_++;
+        break;
+      case '=':
+        if (pos_ + 1 < input_.size() && input_[pos_ + 1] == '=') {
+          t.type = TokenType::EQ;
+          t.value = "==";
+          pos_ += 2;
+        } else {
+          t.type = TokenType::ASSIGN;
+          t.value = "=";
+          pos_++;
+        }
+        break;
+      case '!':
+        if (pos_ + 1 < input_.size() && input_[pos_ + 1] == '=') {
+          t.type = TokenType::NEQ;
+          t.value = "!=";
+          pos_ += 2;
+        } else {
+          pos_++;
+          continue;
+        }
+        break;
+      case '~':
+        t.type = TokenType::TILDE;
+        t.value = "~";
+        pos_++;
+        break;
+      case ':':
+        t.type = TokenType::COLON;
+        t.value = ":";
+        pos_++;
+        break;
+      case '>':
+        if (pos_ + 1 < input_.size() && input_[pos_ + 1] == '=') {
+          t.type = TokenType::GTE;
+          t.value = ">=";
+          pos_ += 2;
+        } else {
+          t.type = TokenType::GT;
+          t.value = ">";
+          pos_++;
+        }
+        break;
+      case '<':
+        if (pos_ + 1 < input_.size() && input_[pos_ + 1] == '=') {
+          t.type = TokenType::LTE;
+          t.value = "<=";
+          pos_ += 2;
+        } else {
+          t.type = TokenType::LT;
+          t.value = "<";
+          pos_++;
+        }
+        break;
+      default:
+        pos_++;
+        continue;
+      }
+      tokens.push_back(t);
+    }
+  }
+
+  Token readString() {
+    char quote = input_[pos_++];
+    std::string value;
+    while (pos_ < input_.size() && input_[pos_] != quote) {
+      if (input_[pos_] == '\\' && pos_ + 1 < input_.size()) {
+        pos_++;
+        switch (input_[pos_]) {
+        case 'n':
+          value += '\n';
+          break;
+        case 't':
+          value += '\t';
+          break;
+        case '\\':
+          value += '\\';
+          break;
+        case '\'':
+          value += '\'';
+          break;
+        case '"':
+          value += '"';
+          break;
+        default:
+          value += '\\';
+          value += input_[pos_];
+          break;
+        }
+      } else {
+        value += input_[pos_];
+      }
+      pos_++;
+    }
+    if (pos_ < input_.size())
+      pos_++; // skip closing quote
+
+    Token t;
+    t.type = TokenType::STRING;
+    t.value = value;
+    return t;
+  }
+
+  Token readNumber() {
+    std::string value;
+    bool has_dot = false;
+    while (pos_ < input_.size() &&
+           (std::isdigit(input_[pos_]) || input_[pos_] == '.')) {
+      if (input_[pos_] == '.') {
+        if (has_dot)
+          break;
+        has_dot = true;
+      }
+      value += input_[pos_++];
+    }
+    Token t;
+    t.type = has_dot ? TokenType::FLOAT : TokenType::INTEGER;
+    t.value = value;
+    return t;
+  }
+
+  Token readIdentifier() {
+    std::string value;
+    while (pos_ < input_.size() &&
+           (std::isalnum(input_[pos_]) || input_[pos_] == '_')) {
+      value += input_[pos_++];
+    }
+
+    Token t;
+    t.value = value;
+
+    // Check for keywords
+    if (value == "if")
+      t.type = TokenType::IF;
+    else if (value == "elif")
+      t.type = TokenType::ELIF;
+    else if (value == "else")
+      t.type = TokenType::ELSE;
+    else if (value == "endif")
+      t.type = TokenType::ENDIF;
+    else if (value == "for")
+      t.type = TokenType::FOR;
+    else if (value == "in")
+      t.type = TokenType::IN;
+    else if (value == "endfor")
+      t.type = TokenType::ENDFOR;
+    else if (value == "set")
+      t.type = TokenType::SET;
+    else if (value == "not")
+      t.type = TokenType::NOT;
+    else if (value == "and")
+      t.type = TokenType::AND;
+    else if (value == "or")
+      t.type = TokenType::OR;
+    else if (value == "is")
+      t.type = TokenType::IS;
+    else if (value == "true" || value == "True")
+      t.type = TokenType::TRUE_LIT;
+    else if (value == "false" || value == "False")
+      t.type = TokenType::FALSE_LIT;
+    else if (value == "none" || value == "None")
+      t.type = TokenType::NONE_LIT;
+    else
+      t.type = TokenType::IDENTIFIER;
+
+    return t;
+  }
+
+  std::string input_;
+  size_t pos_;
+};
+
+// ============================================================================
+// AST Nodes
+// ============================================================================
+struct ASTNode {
+  virtual ~ASTNode() = default;
+};
+
+using ASTNodePtr = std::shared_ptr<ASTNode>;
+
+struct ExprNode : ASTNode {};
+using ExprNodePtr = std::shared_ptr<ExprNode>;
+
+struct TextNode : ASTNode {
+  std::string text;
+};
+
+struct OutputNode : ASTNode {
+  ExprNodePtr expr;
+  bool strip_before = false;
+  bool strip_after = false;
+};
+
+struct IfBranch {
+  ExprNodePtr condition; // nullptr for else branch
+  std::vector<ASTNodePtr> body;
+};
+
+struct IfNode : ASTNode {
+  std::vector<IfBranch> branches;
+  bool strip_before = false;
+  bool strip_after = false;
+};
+
+struct ForNode : ASTNode {
+  std::string var_name;
+  ExprNodePtr iterable;
+  std::vector<ASTNodePtr> body;
+  bool strip_before = false;
+  bool strip_after = false;
+};
+
+struct SetNode : ASTNode {
+  std::string var_name;
+  std::string attr_name; // for "set ns.attr = val" (empty if simple set)
+  ExprNodePtr value;
+  bool strip_before = false;
+  bool strip_after = false;
+};
+
+// Expression nodes
+struct StringLiteral : ExprNode {
+  std::string value;
+};
+
+struct IntegerLiteral : ExprNode {
+  int value;
+};
+
+struct BoolLiteral : ExprNode {
+  bool value;
+};
+
+struct NoneLiteral : ExprNode {};
+
+struct VariableExpr : ExprNode {
+  std::string name;
+};
+
+struct AttributeExpr : ExprNode {
+  ExprNodePtr object;
+  std::string attribute;
+};
+
+struct IndexExpr : ExprNode {
+  ExprNodePtr object;
+  ExprNodePtr index;
+};
+
+struct BinaryExpr : ExprNode {
+  std::string op; // "+", "==", "!=", "and", "or", "%"
+  ExprNodePtr left;
+  ExprNodePtr right;
+};
+
+struct UnaryExpr : ExprNode {
+  std::string op; // "not"
+  ExprNodePtr operand;
+};
+
+struct FilterExpr : ExprNode {
+  ExprNodePtr value;
+  std::string filter_name;
+};
+
+struct IsDefinedExpr : ExprNode {
+  ExprNodePtr value;
+};
+
+struct FunctionCallExpr : ExprNode {
+  std::string name;
+  std::vector<ExprNodePtr> args;
+};
+
+struct MethodCallExpr : ExprNode {
+  ExprNodePtr object;
+  std::string method;
+  std::vector<ExprNodePtr> args;
+};
+
+struct SliceExpr : ExprNode {
+  ExprNodePtr object;
+  ExprNodePtr start; // nullable
+  ExprNodePtr stop;  // nullable
+  ExprNodePtr step;  // nullable
+};
+
+struct ContainsExpr : ExprNode {
+  ExprNodePtr item;
+  ExprNodePtr container;
+};
+
+// ============================================================================
+// Parser
+// ============================================================================
+class Parser {
+public:
+  explicit Parser(const std::vector<Token> &tokens) :
+    tokens_(tokens), pos_(0) {}
+
+  std::vector<ASTNodePtr> parse() {
+    std::vector<ASTNodePtr> nodes;
+    parseBody(nodes, {});
+    return nodes;
+  }
+
+private:
+  const Token &current() const { return tokens_[pos_]; }
+
+  const Token &advance() { return tokens_[pos_++]; }
+
+  bool check(TokenType type) const { return current().type == type; }
+
+  bool matchToken(TokenType type) {
+    if (check(type)) {
+      advance();
+      return true;
+    }
+    return false;
+  }
+
+  Token expect(TokenType type) {
+    if (!check(type)) {
+      throw std::runtime_error("ChatTemplate parser: unexpected token '" +
+                               current().value + "', expected type " +
+                               std::to_string(static_cast<int>(type)));
+    }
+    return advance();
+  }
+
+  void parseBody(std::vector<ASTNodePtr> &nodes,
+                 const std::vector<TokenType> &stop_keywords) {
+    while (pos_ < tokens_.size() && current().type != TokenType::END_OF_INPUT) {
+      if (current().type == TokenType::TEXT) {
+        auto node = std::make_shared<TextNode>();
+        node->text = current().value;
+        nodes.push_back(node);
+        advance();
+      } else if (current().type == TokenType::EXPRESSION_START) {
+        nodes.push_back(parseOutput());
+      } else if (current().type == TokenType::STATEMENT_START) {
+        // Peek at the keyword after {%
+        size_t save = pos_;
+        advance(); // skip STATEMENT_START
+
+        // Check if this is a stop keyword
+        bool is_stop = false;
+        for (auto sk : stop_keywords) {
+          if (check(sk)) {
+            is_stop = true;
+            break;
+          }
+        }
+
+        if (is_stop) {
+          pos_ = save; // rewind
+          return;
+        }
+
+        pos_ = save; // rewind
+        parseStatement(nodes);
+      } else {
+        advance(); // skip unexpected
+      }
+    }
+  }
+
+  ASTNodePtr parseOutput() {
+    auto node = std::make_shared<OutputNode>();
+    Token start = expect(TokenType::EXPRESSION_START);
+    node->strip_before = start.strip_before;
+    node->expr = parseExpression();
+    Token end = expect(TokenType::EXPRESSION_END);
+    node->strip_after = end.strip_after;
+    return node;
+  }
+
+  void parseStatement(std::vector<ASTNodePtr> &nodes) {
+    Token start = expect(TokenType::STATEMENT_START);
+    bool strip_before = start.strip_before;
+
+    if (check(TokenType::IF)) {
+      nodes.push_back(parseIf(strip_before));
+    } else if (check(TokenType::FOR)) {
+      nodes.push_back(parseFor(strip_before));
+    } else if (check(TokenType::SET)) {
+      nodes.push_back(parseSet(strip_before));
+    } else {
+      // Unknown statement - skip to end
+      while (pos_ < tokens_.size() &&
+             current().type != TokenType::STATEMENT_END) {
+        advance();
+      }
+      if (check(TokenType::STATEMENT_END))
+        advance();
+    }
+  }
+
+  ASTNodePtr parseIf(bool strip_before) {
+    auto node = std::make_shared<IfNode>();
+    node->strip_before = strip_before;
+
+    // Parse: if <expr> %}
+    expect(TokenType::IF);
+    IfBranch branch;
+    branch.condition = parseExpression();
+    Token end = expect(TokenType::STATEMENT_END);
+    node->strip_after = end.strip_after;
+
+    // Parse body until elif/else/endif
+    parseBody(branch.body,
+              {TokenType::ELIF, TokenType::ELSE, TokenType::ENDIF});
+    node->branches.push_back(branch);
+
+    // Parse elif/else branches
+    while (pos_ < tokens_.size() &&
+           current().type == TokenType::STATEMENT_START) {
+      advance(); // skip {%
+
+      if (check(TokenType::ELIF)) {
+        advance(); // skip elif
+        IfBranch elif_branch;
+        elif_branch.condition = parseExpression();
+        expect(TokenType::STATEMENT_END);
+        parseBody(elif_branch.body,
+                  {TokenType::ELIF, TokenType::ELSE, TokenType::ENDIF});
+        node->branches.push_back(elif_branch);
+      } else if (check(TokenType::ELSE)) {
+        advance(); // skip else
+        expect(TokenType::STATEMENT_END);
+        IfBranch else_branch;
+        else_branch.condition = nullptr; // no condition = else
+        parseBody(else_branch.body, {TokenType::ENDIF});
+        node->branches.push_back(else_branch);
+      } else if (check(TokenType::ENDIF)) {
+        advance(); // skip endif
+        expect(TokenType::STATEMENT_END);
+        break;
+      } else {
+        break;
+      }
+    }
+
+    return node;
+  }
+
+  ASTNodePtr parseFor(bool strip_before) {
+    auto node = std::make_shared<ForNode>();
+    node->strip_before = strip_before;
+
+    expect(TokenType::FOR);
+    node->var_name = expect(TokenType::IDENTIFIER).value;
+    expect(TokenType::IN);
+    node->iterable = parseExpression();
+    Token end = expect(TokenType::STATEMENT_END);
+    node->strip_after = end.strip_after;
+
+    parseBody(node->body, {TokenType::ENDFOR});
+
+    // Consume endfor
+    expect(TokenType::STATEMENT_START);
+    expect(TokenType::ENDFOR);
+    expect(TokenType::STATEMENT_END);
+
+    return node;
+  }
+
+  ASTNodePtr parseSet(bool strip_before) {
+    auto node = std::make_shared<SetNode>();
+    node->strip_before = strip_before;
+
+    expect(TokenType::SET);
+    node->var_name = expect(TokenType::IDENTIFIER).value;
+
+    // Handle dotted assignment: "set ns.attr = val"
+    if (check(TokenType::DOT)) {
+      advance();
+      node->attr_name = expect(TokenType::IDENTIFIER).value;
+    }
+
+    expect(TokenType::ASSIGN);
+    node->value = parseExpression();
+    Token end = expect(TokenType::STATEMENT_END);
+    node->strip_after = end.strip_after;
+
+    return node;
+  }
+
+  // Expression parsing with precedence
+  ExprNodePtr parseExpression() { return parseOr(); }
+
+  ExprNodePtr parseOr() {
+    auto left = parseAnd();
+    while (check(TokenType::OR)) {
+      advance();
+      auto right = parseAnd();
+      auto node = std::make_shared<BinaryExpr>();
+      node->op = "or";
+      node->left = left;
+      node->right = right;
+      left = node;
+    }
+    return left;
+  }
+
+  ExprNodePtr parseAnd() {
+    auto left = parseNot();
+    while (check(TokenType::AND)) {
+      advance();
+      auto right = parseNot();
+      auto node = std::make_shared<BinaryExpr>();
+      node->op = "and";
+      node->left = left;
+      node->right = right;
+      left = node;
+    }
+    return left;
+  }
+
+  ExprNodePtr parseNot() {
+    if (check(TokenType::NOT)) {
+      advance();
+      auto node = std::make_shared<UnaryExpr>();
+      node->op = "not";
+      node->operand = parseNot();
+      return node;
+    }
+    return parseComparison();
+  }
+
+  ExprNodePtr parseComparison() {
+    auto left = parseContains();
+
+    if (check(TokenType::EQ) || check(TokenType::NEQ) || check(TokenType::GT) ||
+        check(TokenType::LT) || check(TokenType::GTE) ||
+        check(TokenType::LTE)) {
+      std::string op = advance().value;
+      auto right = parseContains();
+      auto node = std::make_shared<BinaryExpr>();
+      node->op = op;
+      node->left = left;
+      node->right = right;
+      return node;
+    }
+
+    // "is" tests: "is defined", "is not defined", "is string", "is false", etc.
+    if (check(TokenType::IS)) {
+      advance();
+      bool negated = false;
+      if (check(TokenType::NOT)) {
+        negated = true;
+        advance();
+      }
+      if (check(TokenType::IDENTIFIER)) {
+        std::string test_name = current().value;
+        advance();
+        ExprNodePtr result;
+        if (test_name == "defined") {
+          auto node = std::make_shared<IsDefinedExpr>();
+          node->value = left;
+          result = node;
+        } else if (test_name == "string") {
+          // "is string" -> check if value is a string type
+          auto call = std::make_shared<FunctionCallExpr>();
+          call->name = "__is_string";
+          call->args.push_back(left);
+          result = call;
+        } else if (test_name == "none") {
+          auto call = std::make_shared<FunctionCallExpr>();
+          call->name = "__is_none";
+          call->args.push_back(left);
+          result = call;
+        } else if (test_name == "number") {
+          auto call = std::make_shared<FunctionCallExpr>();
+          call->name = "__is_number";
+          call->args.push_back(left);
+          result = call;
+        } else {
+          // Fallback: treat unknown test as comparison
+          result = left;
+        }
+        if (negated) {
+          auto not_node = std::make_shared<UnaryExpr>();
+          not_node->op = "not";
+          not_node->operand = result;
+          return not_node;
+        }
+        return result;
+      }
+      // "is true" / "is false" / "is none" (keyword forms)
+      if (check(TokenType::TRUE_LIT)) {
+        advance();
+        auto node = std::make_shared<BinaryExpr>();
+        node->op = "==";
+        node->left = left;
+        auto lit = std::make_shared<BoolLiteral>();
+        lit->value = true;
+        node->right = lit;
+        ExprNodePtr result = node;
+        if (negated) {
+          auto not_node = std::make_shared<UnaryExpr>();
+          not_node->op = "not";
+          not_node->operand = result;
+          return not_node;
+        }
+        return result;
+      }
+      if (check(TokenType::FALSE_LIT)) {
+        advance();
+        auto node = std::make_shared<BinaryExpr>();
+        node->op = "==";
+        node->left = left;
+        auto lit = std::make_shared<BoolLiteral>();
+        lit->value = false;
+        node->right = lit;
+        ExprNodePtr result = node;
+        if (negated) {
+          auto not_node = std::make_shared<UnaryExpr>();
+          not_node->op = "not";
+          not_node->operand = result;
+          return not_node;
+        }
+        return result;
+      }
+      if (check(TokenType::NONE_LIT)) {
+        advance();
+        auto node = std::make_shared<BinaryExpr>();
+        node->op = "==";
+        node->left = left;
+        node->right = std::make_shared<NoneLiteral>();
+        ExprNodePtr result = node;
+        if (negated) {
+          auto not_node = std::make_shared<UnaryExpr>();
+          not_node->op = "not";
+          not_node->operand = result;
+          return not_node;
+        }
+        return result;
+      }
+    }
+
+    return left;
+  }
+
+  // "in" / "not in" containment
+  ExprNodePtr parseContains() {
+    auto left = parseAddition();
+
+    if (check(TokenType::IN)) {
+      advance();
+      auto right = parseAddition();
+      auto node = std::make_shared<ContainsExpr>();
+      node->item = left;
+      node->container = right;
+      return node;
+    }
+    // "not in" is handled by parseNot wrapping this
+
+    return left;
+  }
+
+  ExprNodePtr parseAddition() {
+    auto left = parseModulo();
+    while (check(TokenType::PLUS) || check(TokenType::MINUS) ||
+           check(TokenType::TILDE)) {
+      std::string op = advance().value;
+      auto right = parseModulo();
+      auto node = std::make_shared<BinaryExpr>();
+      node->op = op;
+      node->left = left;
+      node->right = right;
+      left = node;
+    }
+    return left;
+  }
+
+  ExprNodePtr parseModulo() {
+    auto left = parseFilter();
+    while (check(TokenType::PERCENT)) {
+      advance();
+      auto right = parseFilter();
+      auto node = std::make_shared<BinaryExpr>();
+      node->op = "%";
+      node->left = left;
+      node->right = right;
+      left = node;
+    }
+    return left;
+  }
+
+  ExprNodePtr parseFilter() {
+    auto left = parsePostfix();
+    while (check(TokenType::PIPE)) {
+      advance();
+      std::string filter_name = expect(TokenType::IDENTIFIER).value;
+      auto node = std::make_shared<FilterExpr>();
+      node->value = left;
+      node->filter_name = filter_name;
+      left = node;
+    }
+    return left;
+  }
+
+  ExprNodePtr parsePostfix() {
+    auto node = parsePrimary();
+    while (true) {
+      if (check(TokenType::DOT)) {
+        advance();
+        std::string attr = expect(TokenType::IDENTIFIER).value;
+        // Check for method call: obj.method(args)
+        if (check(TokenType::LPAREN)) {
+          advance();
+          auto call = std::make_shared<MethodCallExpr>();
+          call->object = node;
+          call->method = attr;
+          if (!check(TokenType::RPAREN)) {
+            call->args.push_back(parseExpression());
+            while (check(TokenType::COMMA)) {
+              advance();
+              call->args.push_back(parseExpression());
+            }
+          }
+          expect(TokenType::RPAREN);
+          node = call;
+        } else {
+          auto access = std::make_shared<AttributeExpr>();
+          access->object = node;
+          access->attribute = attr;
+          node = access;
+        }
+      } else if (check(TokenType::LBRACKET)) {
+        advance();
+        // Check for slice: obj[start:stop:step] or obj[::step]
+        if (check(TokenType::COLON)) {
+          // [:stop] or [::step]
+          auto slice = std::make_shared<SliceExpr>();
+          slice->object = node;
+          slice->start = nullptr;
+          advance(); // skip first ':'
+          if (check(TokenType::COLON)) {
+            // [::step]
+            advance();
+            slice->stop = nullptr;
+            if (!check(TokenType::RBRACKET)) {
+              slice->step = parseExpression();
+            }
+          } else if (!check(TokenType::RBRACKET)) {
+            slice->stop = parseExpression();
+            if (check(TokenType::COLON)) {
+              advance();
+              if (!check(TokenType::RBRACKET)) {
+                slice->step = parseExpression();
+              }
+            }
+          }
+          expect(TokenType::RBRACKET);
+          node = slice;
+        } else {
+          auto index = parseExpression();
+          if (check(TokenType::COLON)) {
+            // [start:stop] or [start:stop:step]
+            advance();
+            auto slice = std::make_shared<SliceExpr>();
+            slice->object = node;
+            slice->start = index;
+            if (check(TokenType::COLON)) {
+              // [start::step]
+              advance();
+              slice->stop = nullptr;
+              if (!check(TokenType::RBRACKET)) {
+                slice->step = parseExpression();
+              }
+            } else if (!check(TokenType::RBRACKET)) {
+              slice->stop = parseExpression();
+              if (check(TokenType::COLON)) {
+                advance();
+                if (!check(TokenType::RBRACKET)) {
+                  slice->step = parseExpression();
+                }
+              }
+            }
+            expect(TokenType::RBRACKET);
+            node = slice;
+          } else {
+            expect(TokenType::RBRACKET);
+            auto access = std::make_shared<IndexExpr>();
+            access->object = node;
+            access->index = index;
+            node = access;
+          }
+        }
+      } else {
+        break;
+      }
+    }
+    return node;
+  }
+
+  ExprNodePtr parsePrimary() {
+    // Unary minus
+    if (check(TokenType::MINUS)) {
+      advance();
+      auto operand = parsePrimary();
+      if (auto *intLit = dynamic_cast<IntegerLiteral *>(operand.get())) {
+        intLit->value = -intLit->value;
+        return operand;
+      }
+      auto node = std::make_shared<BinaryExpr>();
+      node->op = "-";
+      auto zero = std::make_shared<IntegerLiteral>();
+      zero->value = 0;
+      node->left = zero;
+      node->right = operand;
+      return node;
+    }
+    if (check(TokenType::STRING)) {
+      auto node = std::make_shared<StringLiteral>();
+      node->value = advance().value;
+      return node;
+    }
+    if (check(TokenType::INTEGER)) {
+      auto node = std::make_shared<IntegerLiteral>();
+      node->value = std::stoi(advance().value);
+      return node;
+    }
+    if (check(TokenType::TRUE_LIT)) {
+      advance();
+      auto node = std::make_shared<BoolLiteral>();
+      node->value = true;
+      return node;
+    }
+    if (check(TokenType::FALSE_LIT)) {
+      advance();
+      auto node = std::make_shared<BoolLiteral>();
+      node->value = false;
+      return node;
+    }
+    if (check(TokenType::NONE_LIT)) {
+      advance();
+      return std::make_shared<NoneLiteral>();
+    }
+    if (check(TokenType::IDENTIFIER)) {
+      std::string name = advance().value;
+
+      // Check for function call
+      if (check(TokenType::LPAREN)) {
+        advance();
+        // Special case: namespace(key=val, ...) with keyword arguments
+        if (name == "namespace") {
+          // Parse keyword arguments and build a JSON object initializer
+          // We create a FunctionCallExpr where args[0] is a JSON-like init
+          auto call = std::make_shared<FunctionCallExpr>();
+          call->name = name;
+          // Parse key=value pairs and store as string literal pairs
+          json init_pairs = json::object();
+          while (!check(TokenType::RPAREN) && pos_ < tokens_.size()) {
+            if (check(TokenType::IDENTIFIER)) {
+              std::string key = advance().value;
+              if (check(TokenType::ASSIGN)) {
+                advance();
+                // We can't fully evaluate here, so skip for now
+                // Just consume until comma or rparen
+                auto val_expr = parseExpression();
+                // Store key for later reference
+              }
+            }
+            if (check(TokenType::COMMA))
+              advance();
+            else
+              break;
+          }
+          expect(TokenType::RPAREN);
+          return call;
+        }
+        auto call = std::make_shared<FunctionCallExpr>();
+        call->name = name;
+        if (!check(TokenType::RPAREN)) {
+          call->args.push_back(parseExpression());
+          while (check(TokenType::COMMA)) {
+            advance();
+            call->args.push_back(parseExpression());
+          }
+        }
+        expect(TokenType::RPAREN);
+        return call;
+      }
+
+      auto node = std::make_shared<VariableExpr>();
+      node->name = name;
+      return node;
+    }
+    if (check(TokenType::LPAREN)) {
+      advance();
+      auto expr = parseExpression();
+      expect(TokenType::RPAREN);
+      return expr;
+    }
+
+    // Fallback: return an empty string literal
+    return std::make_shared<StringLiteral>();
+  }
+
+  const std::vector<Token> &tokens_;
+  size_t pos_;
+};
+
+// ============================================================================
+// Evaluator
+// ============================================================================
+class Evaluator {
+public:
+  explicit Evaluator(const json &context) { scopes_.push_back(context); }
+
+  std::string evaluate(const std::vector<ASTNodePtr> &nodes) {
+    std::string result;
+    for (size_t i = 0; i < nodes.size(); ++i) {
+      std::string chunk = evalNode(nodes[i].get());
+
+      // Handle whitespace stripping
+      if (shouldStripBefore(nodes[i].get())) {
+        // Strip trailing whitespace from result
+        while (!result.empty() &&
+               (result.back() == ' ' || result.back() == '\t' ||
+                result.back() == '\n' || result.back() == '\r')) {
+          result.pop_back();
+        }
+      }
+
+      result += chunk;
+
+      // Handle strip_after: strip leading whitespace of next text
+      if (shouldStripAfter(nodes[i].get()) && i + 1 < nodes.size()) {
+        auto *text = dynamic_cast<TextNode *>(nodes[i + 1].get());
+        if (text) {
+          size_t start = 0;
+          while (start < text->text.size() &&
+                 (text->text[start] == ' ' || text->text[start] == '\t' ||
+                  text->text[start] == '\n' || text->text[start] == '\r')) {
+            start++;
+          }
+          text->text = text->text.substr(start);
+        }
+      }
+    }
+    return result;
+  }
+
+private:
+  bool shouldStripBefore(ASTNode *node) {
+    if (auto *o = dynamic_cast<OutputNode *>(node))
+      return o->strip_before;
+    if (auto *i = dynamic_cast<IfNode *>(node))
+      return i->strip_before;
+    if (auto *f = dynamic_cast<ForNode *>(node))
+      return f->strip_before;
+    if (auto *s = dynamic_cast<SetNode *>(node))
+      return s->strip_before;
+    return false;
+  }
+
+  bool shouldStripAfter(ASTNode *node) {
+    if (auto *o = dynamic_cast<OutputNode *>(node))
+      return o->strip_after;
+    if (auto *i = dynamic_cast<IfNode *>(node))
+      return i->strip_after;
+    if (auto *f = dynamic_cast<ForNode *>(node))
+      return f->strip_after;
+    if (auto *s = dynamic_cast<SetNode *>(node))
+      return s->strip_after;
+    return false;
+  }
+
+  std::string evalNode(ASTNode *node) {
+    if (auto *text = dynamic_cast<TextNode *>(node)) {
+      return text->text;
+    }
+    if (auto *output = dynamic_cast<OutputNode *>(node)) {
+      json val = evalExpr(output->expr.get());
+      return jsonToString(val);
+    }
+    if (auto *if_node = dynamic_cast<IfNode *>(node)) {
+      return evalIf(if_node);
+    }
+    if (auto *for_node = dynamic_cast<ForNode *>(node)) {
+      return evalFor(for_node);
+    }
+    if (auto *set_node = dynamic_cast<SetNode *>(node)) {
+      json val = evalExpr(set_node->value.get());
+      if (!set_node->attr_name.empty()) {
+        // Namespace attribute mutation: "set ns.attr = val"
+        // Find the namespace object and mutate it in place
+        for (auto it = scopes_.rbegin(); it != scopes_.rend(); ++it) {
+          if (it->contains(set_node->var_name)) {
+            (*it)[set_node->var_name][set_node->attr_name] = val;
+            break;
+          }
+        }
+      } else {
+        setVariable(set_node->var_name, val);
+      }
+      return "";
+    }
+    return "";
+  }
+
+  std::string evalIf(IfNode *node) {
+    for (auto &branch : node->branches) {
+      if (!branch.condition || isTruthy(evalExpr(branch.condition.get()))) {
+        return evaluate(branch.body);
+      }
+    }
+    return "";
+  }
+
+  std::string evalFor(ForNode *node) {
+    json iterable = evalExpr(node->iterable.get());
+    if (!iterable.is_array())
+      return "";
+
+    std::string result;
+    size_t size = iterable.size();
+
+    for (size_t i = 0; i < size; ++i) {
+      // Push new scope with loop variable
+      json scope;
+      scope[node->var_name] = iterable[i];
+
+      // Loop context
+      json loop;
+      loop["index"] = static_cast<int>(i + 1);
+      loop["index0"] = static_cast<int>(i);
+      loop["first"] = (i == 0);
+      loop["last"] = (i == size - 1);
+      loop["length"] = static_cast<int>(size);
+      scope["loop"] = loop;
+
+      scopes_.push_back(scope);
+      result += evaluate(node->body);
+      scopes_.pop_back();
+    }
+
+    return result;
+  }
+
+  json evalExpr(ExprNode *node) {
+    if (auto *str = dynamic_cast<StringLiteral *>(node)) {
+      return str->value;
+    }
+    if (auto *num = dynamic_cast<IntegerLiteral *>(node)) {
+      return num->value;
+    }
+    if (auto *b = dynamic_cast<BoolLiteral *>(node)) {
+      return b->value;
+    }
+    if (dynamic_cast<NoneLiteral *>(node)) {
+      return nullptr;
+    }
+    if (auto *var = dynamic_cast<VariableExpr *>(node)) {
+      return lookupVariable(var->name);
+    }
+    if (auto *attr = dynamic_cast<AttributeExpr *>(node)) {
+      json obj = evalExpr(attr->object.get());
+      if (obj.is_object() && obj.contains(attr->attribute)) {
+        return obj[attr->attribute];
+      }
+      return nullptr;
+    }
+    if (auto *idx = dynamic_cast<IndexExpr *>(node)) {
+      json obj = evalExpr(idx->object.get());
+      json index = evalExpr(idx->index.get());
+      if (obj.is_array() && index.is_number_integer()) {
+        int i = index.get<int>();
+        if (i >= 0 && i < static_cast<int>(obj.size()))
+          return obj[i];
+      } else if (obj.is_object() && index.is_string()) {
+        std::string key = index.get<std::string>();
+        if (obj.contains(key))
+          return obj[key];
+      }
+      return nullptr;
+    }
+    if (auto *bin = dynamic_cast<BinaryExpr *>(node)) {
+      return evalBinary(bin);
+    }
+    if (auto *unary = dynamic_cast<UnaryExpr *>(node)) {
+      if (unary->op == "not") {
+        return !isTruthy(evalExpr(unary->operand.get()));
+      }
+    }
+    if (auto *filter = dynamic_cast<FilterExpr *>(node)) {
+      json val = evalExpr(filter->value.get());
+      if (filter->filter_name == "trim" && val.is_string()) {
+        std::string s = val.get<std::string>();
+        // Trim whitespace
+        size_t start = s.find_first_not_of(" \t\n\r");
+        size_t end = s.find_last_not_of(" \t\n\r");
+        if (start == std::string::npos)
+          return "";
+        return s.substr(start, end - start + 1);
+      }
+      if (filter->filter_name == "length") {
+        if (val.is_array())
+          return static_cast<int>(val.size());
+        if (val.is_string())
+          return static_cast<int>(val.get<std::string>().size());
+        return 0;
+      }
+      if (filter->filter_name == "tojson") {
+        return val.dump();
+      }
+      return val; // unknown filter, passthrough
+    }
+    if (auto *def = dynamic_cast<IsDefinedExpr *>(node)) {
+      // Check if the variable exists in any scope
+      if (auto *var = dynamic_cast<VariableExpr *>(def->value.get())) {
+        for (auto it = scopes_.rbegin(); it != scopes_.rend(); ++it) {
+          if (it->contains(var->name))
+            return true;
+        }
+        return false;
+      }
+      // For attribute access, check if the parent exists and has the attr
+      if (auto *attr = dynamic_cast<AttributeExpr *>(def->value.get())) {
+        json obj = evalExpr(attr->object.get());
+        return obj.is_object() && obj.contains(attr->attribute);
+      }
+      return false;
+    }
+    if (auto *call = dynamic_cast<FunctionCallExpr *>(node)) {
+      if (call->name == "raise_exception") {
+        std::string msg = "Template error";
+        if (!call->args.empty()) {
+          json arg = evalExpr(call->args[0].get());
+          if (arg.is_string())
+            msg = arg.get<std::string>();
+        }
+        throw std::runtime_error("ChatTemplate: " + msg);
+      }
+      if (call->name == "namespace") {
+        // namespace() creates a mutable object that persists across scopes
+        // keyword args are not parsed at AST level, so we return empty object
+        // The actual initialization happens via {% set ns.attr = val %}
+        return json::object();
+      }
+      // Type-checking built-in tests
+      if (call->name == "__is_string") {
+        if (!call->args.empty()) {
+          json val = evalExpr(call->args[0].get());
+          return val.is_string();
+        }
+        return false;
+      }
+      if (call->name == "__is_none") {
+        if (!call->args.empty()) {
+          json val = evalExpr(call->args[0].get());
+          return val.is_null();
+        }
+        return false;
+      }
+      if (call->name == "__is_number") {
+        if (!call->args.empty()) {
+          json val = evalExpr(call->args[0].get());
+          return val.is_number();
+        }
+        return false;
+      }
+      return nullptr;
+    }
+    if (auto *method = dynamic_cast<MethodCallExpr *>(node)) {
+      return evalMethodCall(method);
+    }
+    if (auto *slice = dynamic_cast<SliceExpr *>(node)) {
+      return evalSlice(slice);
+    }
+    if (auto *contains = dynamic_cast<ContainsExpr *>(node)) {
+      json item = evalExpr(contains->item.get());
+      json container = evalExpr(contains->container.get());
+      // String containment: 'x' in 'xyz'
+      if (item.is_string() && container.is_string()) {
+        return container.get<std::string>().find(item.get<std::string>()) !=
+               std::string::npos;
+      }
+      // Array containment
+      if (container.is_array()) {
+        for (const auto &elem : container) {
+          if (elem == item)
+            return true;
+        }
+        return false;
+      }
+      // Object key containment
+      if (container.is_object() && item.is_string()) {
+        return container.contains(item.get<std::string>());
+      }
+      return false;
+    }
+    return nullptr;
+  }
+
+  json evalMethodCall(MethodCallExpr *node) {
+    json obj = evalExpr(node->object.get());
+    const std::string &method = node->method;
+
+    if (obj.is_string()) {
+      std::string s = obj.get<std::string>();
+
+      if (method == "startswith" && !node->args.empty()) {
+        json arg = evalExpr(node->args[0].get());
+        if (arg.is_string()) {
+          std::string prefix = arg.get<std::string>();
+          return s.size() >= prefix.size() &&
+                 s.compare(0, prefix.size(), prefix) == 0;
+        }
+        return false;
+      }
+      if (method == "endswith" && !node->args.empty()) {
+        json arg = evalExpr(node->args[0].get());
+        if (arg.is_string()) {
+          std::string suffix = arg.get<std::string>();
+          return s.size() >= suffix.size() &&
+                 s.compare(s.size() - suffix.size(), suffix.size(), suffix) ==
+                   0;
+        }
+        return false;
+      }
+      if (method == "strip") {
+        std::string chars = " \t\n\r";
+        if (!node->args.empty()) {
+          json arg = evalExpr(node->args[0].get());
+          if (arg.is_string())
+            chars = arg.get<std::string>();
+        }
+        size_t start = s.find_first_not_of(chars);
+        if (start == std::string::npos)
+          return std::string("");
+        size_t end = s.find_last_not_of(chars);
+        return s.substr(start, end - start + 1);
+      }
+      if (method == "lstrip") {
+        std::string chars = " \t\n\r";
+        if (!node->args.empty()) {
+          json arg = evalExpr(node->args[0].get());
+          if (arg.is_string())
+            chars = arg.get<std::string>();
+        }
+        size_t start = s.find_first_not_of(chars);
+        if (start == std::string::npos)
+          return std::string("");
+        return s.substr(start);
+      }
+      if (method == "rstrip") {
+        std::string chars = " \t\n\r";
+        if (!node->args.empty()) {
+          json arg = evalExpr(node->args[0].get());
+          if (arg.is_string())
+            chars = arg.get<std::string>();
+        }
+        size_t end = s.find_last_not_of(chars);
+        if (end == std::string::npos)
+          return std::string("");
+        return s.substr(0, end + 1);
+      }
+      if (method == "split" && !node->args.empty()) {
+        json arg = evalExpr(node->args[0].get());
+        if (arg.is_string()) {
+          std::string delimiter = arg.get<std::string>();
+          json result = json::array();
+          size_t pos = 0;
+          size_t found;
+          while ((found = s.find(delimiter, pos)) != std::string::npos) {
+            result.push_back(s.substr(pos, found - pos));
+            pos = found + delimiter.size();
+          }
+          result.push_back(s.substr(pos));
+          return result;
+        }
+      }
+      if (method == "upper") {
+        std::string result = s;
+        std::transform(result.begin(), result.end(), result.begin(), ::toupper);
+        return result;
+      }
+      if (method == "lower") {
+        std::string result = s;
+        std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+        return result;
+      }
+    }
+
+    return nullptr;
+  }
+
+  json evalSlice(SliceExpr *node) {
+    json obj = evalExpr(node->object.get());
+    if (!obj.is_array())
+      return json::array();
+
+    int size = static_cast<int>(obj.size());
+    int start = 0, stop = size, step = 1;
+
+    if (node->start)
+      start = evalExpr(node->start.get()).get<int>();
+    if (node->stop)
+      stop = evalExpr(node->stop.get()).get<int>();
+    if (node->step)
+      step = evalExpr(node->step.get()).get<int>();
+
+    // Handle negative indices
+    if (start < 0)
+      start = std::max(0, size + start);
+    if (stop < 0)
+      stop = std::max(0, size + stop);
+
+    // Clamp
+    start = std::max(0, std::min(start, size));
+    stop = std::max(0, std::min(stop, size));
+
+    json result = json::array();
+    if (step > 0) {
+      for (int i = start; i < stop; i += step)
+        result.push_back(obj[i]);
+    } else if (step < 0) {
+      // Reverse iteration: e.g., [::-1]
+      if (!node->start)
+        start = size - 1;
+      if (!node->stop)
+        stop = -1;
+      else if (stop < 0)
+        stop = std::max(-1, size + stop);
+      // Re-clamp for reverse
+      if (start >= size)
+        start = size - 1;
+      for (int i = start; i > stop; i += step) {
+        if (i >= 0 && i < size)
+          result.push_back(obj[i]);
+      }
+    }
+
+    return result;
+  }
+
+  json evalBinary(BinaryExpr *node) {
+    json left = evalExpr(node->left.get());
+    json right = evalExpr(node->right.get());
+
+    if (node->op == "+" || node->op == "~") {
+      if (node->op == "~") {
+        // Tilde always does string concat
+        return jsonToString(left) + jsonToString(right);
+      }
+      if (left.is_string() && right.is_string()) {
+        return left.get<std::string>() + right.get<std::string>();
+      }
+      if (left.is_number() && right.is_number()) {
+        return left.get<int>() + right.get<int>();
+      }
+      // String + non-string: convert to string
+      return jsonToString(left) + jsonToString(right);
+    }
+    if (node->op == "-") {
+      if (left.is_number() && right.is_number()) {
+        return left.get<int>() - right.get<int>();
+      }
+      return 0;
+    }
+    if (node->op == "==") {
+      return left == right;
+    }
+    if (node->op == "!=") {
+      return left != right;
+    }
+    if (node->op == ">") {
+      if (left.is_number() && right.is_number())
+        return left.get<int>() > right.get<int>();
+      return false;
+    }
+    if (node->op == "<") {
+      if (left.is_number() && right.is_number())
+        return left.get<int>() < right.get<int>();
+      return false;
+    }
+    if (node->op == ">=") {
+      if (left.is_number() && right.is_number())
+        return left.get<int>() >= right.get<int>();
+      return false;
+    }
+    if (node->op == "<=") {
+      if (left.is_number() && right.is_number())
+        return left.get<int>() <= right.get<int>();
+      return false;
+    }
+    if (node->op == "%") {
+      if (left.is_number_integer() && right.is_number_integer()) {
+        int r = right.get<int>();
+        if (r != 0)
+          return left.get<int>() % r;
+      }
+      return 0;
+    }
+    if (node->op == "and") {
+      return isTruthy(left) && isTruthy(right);
+    }
+    if (node->op == "or") {
+      return isTruthy(left) || isTruthy(right);
+    }
+    return nullptr;
+  }
+
+  bool isTruthy(const json &val) {
+    if (val.is_null())
+      return false;
+    if (val.is_boolean())
+      return val.get<bool>();
+    if (val.is_number_integer())
+      return val.get<int>() != 0;
+    if (val.is_string())
+      return !val.get<std::string>().empty();
+    if (val.is_array())
+      return !val.empty();
+    if (val.is_object())
+      return !val.empty();
+    return false;
+  }
+
+  std::string jsonToString(const json &val) {
+    if (val.is_string())
+      return val.get<std::string>();
+    if (val.is_null())
+      return "";
+    if (val.is_boolean())
+      return val.get<bool>() ? "True" : "False";
+    if (val.is_number_integer())
+      return std::to_string(val.get<int>());
+    if (val.is_number_float())
+      return std::to_string(val.get<double>());
+    return val.dump();
+  }
+
+  json lookupVariable(const std::string &name) {
+    // Search from innermost scope to outermost
+    for (auto it = scopes_.rbegin(); it != scopes_.rend(); ++it) {
+      if (it->contains(name))
+        return (*it)[name];
+    }
+    return nullptr;
+  }
+
+  void setVariable(const std::string &name, const json &value) {
+    // Set in the current (innermost) scope
+    if (!scopes_.empty()) {
+      scopes_.back()[name] = value;
+    }
+  }
+
+  std::vector<json> scopes_;
+};
+
+// ============================================================================
+// ChatTemplate Implementation
+// ============================================================================
+
+ChatTemplate::ChatTemplate() : available_(false) {}
+
+ChatTemplate ChatTemplate::fromFile(const std::string &tokenizer_config_path) {
+  ChatTemplate tmpl;
+
+  std::ifstream file(tokenizer_config_path);
+  if (!file.is_open()) {
+    std::cerr << "[ChatTemplate] Warning: cannot open " << tokenizer_config_path
+              << std::endl;
+    return tmpl;
+  }
+
+  json config;
+  try {
+    file >> config;
+  } catch (const json::parse_error &e) {
+    std::cerr << "[ChatTemplate] Warning: JSON parse error in "
+              << tokenizer_config_path << ": " << e.what() << std::endl;
+    return tmpl;
+  }
+
+  // Extract chat_template
+  if (config.contains("chat_template")) {
+    if (config["chat_template"].is_string()) {
+      tmpl.template_str_ = config["chat_template"].get<std::string>();
+    } else if (config["chat_template"].is_array()) {
+      // Some models have an array of templates; use the first one
+      for (const auto &entry : config["chat_template"]) {
+        if (entry.is_object() && entry.contains("template")) {
+          tmpl.template_str_ = entry["template"].get<std::string>();
+          break;
+        }
+      }
+    }
+  }
+
+  if (tmpl.template_str_.empty()) {
+    return tmpl;
+  }
+
+  // Extract bos_token (can be string or object with "content" field)
+  if (config.contains("bos_token")) {
+    if (config["bos_token"].is_string()) {
+      tmpl.bos_token_ = config["bos_token"].get<std::string>();
+    } else if (config["bos_token"].is_object() &&
+               config["bos_token"].contains("content")) {
+      tmpl.bos_token_ = config["bos_token"]["content"].get<std::string>();
+    }
+  }
+
+  // Extract eos_token
+  if (config.contains("eos_token")) {
+    if (config["eos_token"].is_string()) {
+      tmpl.eos_token_ = config["eos_token"].get<std::string>();
+    } else if (config["eos_token"].is_object() &&
+               config["eos_token"].contains("content")) {
+      tmpl.eos_token_ = config["eos_token"]["content"].get<std::string>();
+    }
+  }
+
+  tmpl.available_ = true;
+  return tmpl;
+}
+
+std::string ChatTemplate::apply(const std::vector<ChatMessage> &messages,
+                                bool add_generation_prompt) const {
+  if (!available_)
+    return "";
+
+  // Build context
+  json context;
+  json msgs = json::array();
+  for (const auto &msg : messages) {
+    json m;
+    m["role"] = msg.role;
+    m["content"] = msg.content;
+    msgs.push_back(m);
+  }
+  context["messages"] = msgs;
+  context["bos_token"] = bos_token_;
+  context["eos_token"] = eos_token_;
+  context["add_generation_prompt"] = add_generation_prompt;
+
+  return render(template_str_, context);
+}
+
+std::string ChatTemplate::apply(const std::string &user_input,
+                                bool add_generation_prompt) const {
+  std::vector<ChatMessage> messages = {{"user", user_input}};
+  return apply(messages, add_generation_prompt);
+}
+
+bool ChatTemplate::isAvailable() const { return available_; }
+
+std::string ChatTemplate::getBosToken() const { return bos_token_; }
+
+std::string ChatTemplate::getEosToken() const { return eos_token_; }
+
+std::string ChatTemplate::render(const std::string &tmpl,
+                                 const json &context) const {
+  try {
+    Lexer lexer(tmpl);
+    auto tokens = lexer.tokenize();
+
+    Parser parser(tokens);
+    auto ast = parser.parse();
+
+    Evaluator evaluator(context);
+    return evaluator.evaluate(ast);
+  } catch (const std::exception &e) {
+    std::cerr << "[ChatTemplate] Render error: " << e.what() << std::endl;
+    return "";
+  }
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -25,6 +25,7 @@ namespace causallm {
 // ============================================================================
 // Token types for the Jinja2 lexer
 // ============================================================================
+/** @brief TokenType - enum class for Jinja2 template processing */
 enum class TokenType {
   TEXT,
   EXPRESSION_START, // {{
@@ -72,6 +73,7 @@ enum class TokenType {
   END_OF_INPUT,
 };
 
+/** @brief Lexer token with type, value, and whitespace control flags */
 struct Token {
   TokenType type;
   std::string value;
@@ -82,10 +84,13 @@ struct Token {
 // ============================================================================
 // Lexer
 // ============================================================================
+/** @brief Tokenizes Jinja2 template strings into token sequences */
 class Lexer {
 public:
+  /** @brief Construct lexer with input template string */
   explicit Lexer(const std::string &input) : input_(input), pos_(0) {}
 
+  /** @brief Tokenize the input template into a sequence of tokens */
   std::vector<Token> tokenize() {
     std::vector<Token> tokens;
 
@@ -140,6 +145,7 @@ public:
   }
 
 private:
+  /** @brief Try to match a string at current position and advance */
   bool match(const std::string &s) {
     if (pos_ + s.size() <= input_.size() &&
         input_.substr(pos_, s.size()) == s) {
@@ -149,11 +155,13 @@ private:
     return false;
   }
 
+  /** @brief Skip whitespace characters at current position */
   void skipWhitespace() {
     while (pos_ < input_.size() && std::isspace(input_[pos_]))
       pos_++;
   }
 
+  /** @brief Tokenize content inside expression or statement tags */
   void tokenizeInside(std::vector<Token> &tokens, TokenType end_type) {
     while (pos_ < input_.size()) {
       skipWhitespace();
@@ -329,6 +337,7 @@ private:
     }
   }
 
+  /** @brief Read a string literal token */
   Token readString() {
     char quote = input_[pos_++];
     std::string value;
@@ -370,6 +379,7 @@ private:
     return t;
   }
 
+  /** @brief Read a numeric literal token */
   Token readNumber() {
     std::string value;
     bool has_dot = false;
@@ -388,6 +398,7 @@ private:
     return t;
   }
 
+  /** @brief Read an identifier or keyword token */
   Token readIdentifier() {
     std::string value;
     while (pos_ < input_.size() &&
@@ -442,36 +453,43 @@ private:
 // ============================================================================
 // AST Nodes
 // ============================================================================
+/** @brief Base AST node for template parsing */
 struct ASTNode {
   virtual ~ASTNode() = default;
 };
 
 using ASTNodePtr = std::shared_ptr<ASTNode>;
 
+/** @brief Base expression AST node */
 struct ExprNode : ASTNode {};
 using ExprNodePtr = std::shared_ptr<ExprNode>;
 
+/** @brief AST node for literal text output */
 struct TextNode : ASTNode {
   std::string text;
 };
 
+/** @brief AST node for expression output ({{ expr }}) */
 struct OutputNode : ASTNode {
   ExprNodePtr expr;
   bool strip_before = false;
   bool strip_after = false;
 };
 
+/** @brief Single branch of an if/elif/else block */
 struct IfBranch {
   ExprNodePtr condition; // nullptr for else branch
   std::vector<ASTNodePtr> body;
 };
 
+/** @brief AST node for if/elif/else conditional blocks */
 struct IfNode : ASTNode {
   std::vector<IfBranch> branches;
   bool strip_before = false;
   bool strip_after = false;
 };
 
+/** @brief AST node for for-loop iteration blocks */
 struct ForNode : ASTNode {
   std::string var_name;
   ExprNodePtr iterable;
@@ -480,6 +498,7 @@ struct ForNode : ASTNode {
   bool strip_after = false;
 };
 
+/** @brief AST node for variable assignment (set statement) */
 struct SetNode : ASTNode {
   std::string var_name;
   std::string attr_name; // for "set ns.attr = val" (empty if simple set)
@@ -489,65 +508,79 @@ struct SetNode : ASTNode {
 };
 
 // Expression nodes
+/** @brief Expression node for string literal values */
 struct StringLiteral : ExprNode {
   std::string value;
 };
 
+/** @brief Expression node for integer literal values */
 struct IntegerLiteral : ExprNode {
   int value;
 };
 
+/** @brief Expression node for boolean literal values */
 struct BoolLiteral : ExprNode {
   bool value;
 };
 
+/** @brief Expression node for None/null literal values */
 struct NoneLiteral : ExprNode {};
 
+/** @brief Expression node for variable references */
 struct VariableExpr : ExprNode {
   std::string name;
 };
 
+/** @brief Expression node for attribute access (obj.attr) */
 struct AttributeExpr : ExprNode {
   ExprNodePtr object;
   std::string attribute;
 };
 
+/** @brief Expression node for index access (obj[key]) */
 struct IndexExpr : ExprNode {
   ExprNodePtr object;
   ExprNodePtr index;
 };
 
+/** @brief Expression node for binary operations (+, ==, and, etc.) */
 struct BinaryExpr : ExprNode {
   std::string op; // "+", "==", "!=", "and", "or", "%"
   ExprNodePtr left;
   ExprNodePtr right;
 };
 
+/** @brief Expression node for unary operations (not) */
 struct UnaryExpr : ExprNode {
   std::string op; // "not"
   ExprNodePtr operand;
 };
 
+/** @brief Expression node for filter application (val | filter) */
 struct FilterExpr : ExprNode {
   ExprNodePtr value;
   std::string filter_name;
 };
 
+/** @brief Expression node for "is defined" test */
 struct IsDefinedExpr : ExprNode {
   ExprNodePtr value;
 };
 
+/** @brief Expression node for function calls */
 struct FunctionCallExpr : ExprNode {
   std::string name;
   std::vector<ExprNodePtr> args;
 };
 
+/** @brief Expression node for method calls (obj.method()) */
 struct MethodCallExpr : ExprNode {
   ExprNodePtr object;
   std::string method;
   std::vector<ExprNodePtr> args;
 };
 
+/** @brief Expression node for slice operations (obj[start:stop:step]) */
 struct SliceExpr : ExprNode {
   ExprNodePtr object;
   ExprNodePtr start; // nullable
@@ -555,6 +588,7 @@ struct SliceExpr : ExprNode {
   ExprNodePtr step;  // nullable
 };
 
+/** @brief Expression node for "in" containment test */
 struct ContainsExpr : ExprNode {
   ExprNodePtr item;
   ExprNodePtr container;
@@ -563,11 +597,13 @@ struct ContainsExpr : ExprNode {
 // ============================================================================
 // Parser
 // ============================================================================
+/** @brief Parses token sequences into an AST for template rendering */
 class Parser {
 public:
   explicit Parser(const std::vector<Token> &tokens) :
     tokens_(tokens), pos_(0) {}
 
+  /** @brief Parse tokens into AST node list */
   std::vector<ASTNodePtr> parse() {
     std::vector<ASTNodePtr> nodes;
     parseBody(nodes, {});
@@ -575,12 +611,16 @@ public:
   }
 
 private:
+  /** @brief Get the current token without advancing */
   const Token &current() const { return tokens_[pos_]; }
 
+  /** @brief Advance to next token and return the current one */
   const Token &advance() { return tokens_[pos_++]; }
 
+  /** @brief Check if current token matches the given type */
   bool check(TokenType type) const { return current().type == type; }
 
+  /** @brief Match current token type and advance if matched */
   bool matchToken(TokenType type) {
     if (check(type)) {
       advance();
@@ -589,6 +629,7 @@ private:
     return false;
   }
 
+  /** @brief Expect current token to match type, throw on mismatch */
   Token expect(TokenType type) {
     if (!check(type)) {
       throw std::runtime_error("ChatTemplate parser: unexpected token '" +
@@ -598,6 +639,7 @@ private:
     return advance();
   }
 
+  /** @brief Parse template body until a stop keyword is found */
   void parseBody(std::vector<ASTNodePtr> &nodes,
                  const std::vector<TokenType> &stop_keywords) {
     while (pos_ < tokens_.size() && current().type != TokenType::END_OF_INPUT) {
@@ -635,6 +677,7 @@ private:
     }
   }
 
+  /** @brief Parse an output expression block ({{ expr }}) */
   ASTNodePtr parseOutput() {
     auto node = std::make_shared<OutputNode>();
     Token start = expect(TokenType::EXPRESSION_START);
@@ -645,6 +688,7 @@ private:
     return node;
   }
 
+  /** @brief Parse a statement block ({% ... %}) */
   void parseStatement(std::vector<ASTNodePtr> &nodes) {
     Token start = expect(TokenType::STATEMENT_START);
     bool strip_before = start.strip_before;
@@ -666,6 +710,7 @@ private:
     }
   }
 
+  /** @brief Parse an if/elif/else/endif block */
   ASTNodePtr parseIf(bool strip_before) {
     auto node = std::make_shared<IfNode>();
     node->strip_before = strip_before;
@@ -714,6 +759,7 @@ private:
     return node;
   }
 
+  /** @brief Parse a for/endfor loop block */
   ASTNodePtr parseFor(bool strip_before) {
     auto node = std::make_shared<ForNode>();
     node->strip_before = strip_before;
@@ -735,6 +781,7 @@ private:
     return node;
   }
 
+  /** @brief Parse a set variable assignment statement */
   ASTNodePtr parseSet(bool strip_before) {
     auto node = std::make_shared<SetNode>();
     node->strip_before = strip_before;
@@ -757,8 +804,10 @@ private:
   }
 
   // Expression parsing with precedence
+  /** @brief Parse a complete expression with precedence */
   ExprNodePtr parseExpression() { return parseOr(); }
 
+  /** @brief Parse OR boolean expression */
   ExprNodePtr parseOr() {
     auto left = parseAnd();
     while (check(TokenType::OR)) {
@@ -773,6 +822,7 @@ private:
     return left;
   }
 
+  /** @brief Parse AND boolean expression */
   ExprNodePtr parseAnd() {
     auto left = parseNot();
     while (check(TokenType::AND)) {
@@ -787,6 +837,7 @@ private:
     return left;
   }
 
+  /** @brief Parse NOT unary boolean expression */
   ExprNodePtr parseNot() {
     if (check(TokenType::NOT)) {
       advance();
@@ -798,6 +849,7 @@ private:
     return parseComparison();
   }
 
+  /** @brief Parse comparison and "is" test expressions */
   ExprNodePtr parseComparison() {
     auto left = parseContains();
 
@@ -913,6 +965,7 @@ private:
   }
 
   // "in" / "not in" containment
+  /** @brief Parse "in" containment expression */
   ExprNodePtr parseContains() {
     auto left = parseAddition();
 
@@ -929,6 +982,7 @@ private:
     return left;
   }
 
+  /** @brief Parse addition, subtraction, and tilde concat */
   ExprNodePtr parseAddition() {
     auto left = parseModulo();
     while (check(TokenType::PLUS) || check(TokenType::MINUS) ||
@@ -944,6 +998,7 @@ private:
     return left;
   }
 
+  /** @brief Parse modulo arithmetic expression */
   ExprNodePtr parseModulo() {
     auto left = parseFilter();
     while (check(TokenType::PERCENT)) {
@@ -958,6 +1013,7 @@ private:
     return left;
   }
 
+  /** @brief Parse pipe filter expression (val | filter) */
   ExprNodePtr parseFilter() {
     auto left = parsePostfix();
     while (check(TokenType::PIPE)) {
@@ -971,6 +1027,7 @@ private:
     return left;
   }
 
+  /** @brief Parse postfix operations (dot, index, method, slice) */
   ExprNodePtr parsePostfix() {
     auto node = parsePrimary();
     while (true) {
@@ -1066,6 +1123,7 @@ private:
     return node;
   }
 
+  /** @brief Parse primary expression (literals, variables, parens) */
   ExprNodePtr parsePrimary() {
     // Unary minus
     if (check(TokenType::MINUS)) {
@@ -1177,10 +1235,13 @@ private:
 // ============================================================================
 // Evaluator
 // ============================================================================
+/** @brief Evaluates AST nodes to produce rendered template output */
 class Evaluator {
 public:
+  /** @brief Construct evaluator with template context variables */
   explicit Evaluator(const json &context) { scopes_.push_back(context); }
 
+  /** @brief Evaluate AST node list and return rendered string */
   std::string evaluate(const std::vector<ASTNodePtr> &nodes) {
     std::string result;
     for (size_t i = 0; i < nodes.size(); ++i) {
@@ -1216,6 +1277,7 @@ public:
   }
 
 private:
+  /** @brief Check if node has strip-before whitespace control */
   bool shouldStripBefore(ASTNode *node) {
     if (auto *o = dynamic_cast<OutputNode *>(node))
       return o->strip_before;
@@ -1228,6 +1290,7 @@ private:
     return false;
   }
 
+  /** @brief Check if node has strip-after whitespace control */
   bool shouldStripAfter(ASTNode *node) {
     if (auto *o = dynamic_cast<OutputNode *>(node))
       return o->strip_after;
@@ -1240,6 +1303,7 @@ private:
     return false;
   }
 
+  /** @brief Evaluate a single AST node and return its string result */
   std::string evalNode(ASTNode *node) {
     if (auto *text = dynamic_cast<TextNode *>(node)) {
       return text->text;
@@ -1273,6 +1337,7 @@ private:
     return "";
   }
 
+  /** @brief Evaluate an if/elif/else conditional node */
   std::string evalIf(IfNode *node) {
     for (auto &branch : node->branches) {
       if (!branch.condition || isTruthy(evalExpr(branch.condition.get()))) {
@@ -1282,6 +1347,7 @@ private:
     return "";
   }
 
+  /** @brief Evaluate a for-loop node over an iterable */
   std::string evalFor(ForNode *node) {
     json iterable = evalExpr(node->iterable.get());
     if (!iterable.is_array())
@@ -1312,6 +1378,7 @@ private:
     return result;
   }
 
+  /** @brief Evaluate an expression node and return JSON value */
   json evalExpr(ExprNode *node) {
     if (auto *str = dynamic_cast<StringLiteral *>(node)) {
       return str->value;
@@ -1467,6 +1534,7 @@ private:
     return nullptr;
   }
 
+  /** @brief Evaluate a method call on a string object */
   json evalMethodCall(MethodCallExpr *node) {
     json obj = evalExpr(node->object.get());
     const std::string &method = node->method;
@@ -1560,6 +1628,7 @@ private:
     return nullptr;
   }
 
+  /** @brief Evaluate an array slice expression */
   json evalSlice(SliceExpr *node) {
     json obj = evalExpr(node->object.get());
     if (!obj.is_array())
@@ -1609,6 +1678,7 @@ private:
     return result;
   }
 
+  /** @brief Evaluate a binary operation expression */
   json evalBinary(BinaryExpr *node) {
     json left = evalExpr(node->left.get());
     json right = evalExpr(node->right.get());
@@ -1676,6 +1746,7 @@ private:
     return nullptr;
   }
 
+  /** @brief Check if a JSON value is truthy */
   bool isTruthy(const json &val) {
     if (val.is_null())
       return false;
@@ -1692,6 +1763,7 @@ private:
     return false;
   }
 
+  /** @brief Convert a JSON value to its string representation */
   std::string jsonToString(const json &val) {
     if (val.is_string())
       return val.get<std::string>();
@@ -1706,6 +1778,7 @@ private:
     return val.dump();
   }
 
+  /** @brief Look up a variable name in scope chain */
   json lookupVariable(const std::string &name) {
     // Search from innermost scope to outermost
     for (auto it = scopes_.rbegin(); it != scopes_.rend(); ++it) {
@@ -1715,6 +1788,7 @@ private:
     return nullptr;
   }
 
+  /** @brief Set a variable in the current innermost scope */
   void setVariable(const std::string &name, const json &value) {
     // Set in the current (innermost) scope
     if (!scopes_.empty()) {
@@ -1766,6 +1840,8 @@ ChatTemplate ChatTemplate::fromFile(const std::string &tokenizer_config_path) {
   }
 
   if (tmpl.template_str_.empty()) {
+    std::cerr << "[ChatTemplate] Warning: no 'chat_template' field found in "
+              << tokenizer_config_path << std::endl;
     return tmpl;
   }
 

--- a/Applications/CausalLM/chat_template.h
+++ b/Applications/CausalLM/chat_template.h
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file    chat_template.h
+ * @date    10 Apr 2026
+ * @brief   Chat template support using tokenizer_config.json
+ * @see     https://github.com/nntrainer/nntrainer
+ * @author  Eunju Yang <ej.yang@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifndef __CHAT_TEMPLATE_H__
+#define __CHAT_TEMPLATE_H__
+
+#include <string>
+#include <vector>
+
+#include "json.hpp"
+
+namespace causallm {
+
+using json = nlohmann::json;
+
+/**
+ * @brief Chat message structure for multi-turn conversations
+ */
+struct ChatMessage {
+  std::string role;    // "system", "user", "assistant"
+  std::string content; // message content
+};
+
+/**
+ * @brief Chat template class that reads and applies HuggingFace chat templates
+ *
+ * Loads chat_template from tokenizer_config.json and renders it using a
+ * minimal Jinja2 subset renderer. Supports common constructs used in
+ * HuggingFace chat templates: for loops, if/elif/else, variable access,
+ * string operations, loop variables, and filters.
+ */
+class ChatTemplate {
+public:
+  /**
+   * @brief Default constructor (no template loaded)
+   */
+  ChatTemplate();
+
+  /**
+   * @brief Load chat template from tokenizer_config.json
+   * @param tokenizer_config_path Path to tokenizer_config.json
+   * @return ChatTemplate instance
+   */
+  static ChatTemplate fromFile(const std::string &tokenizer_config_path);
+
+  /**
+   * @brief Apply template to multi-turn messages
+   * @param messages Vector of ChatMessage (role + content)
+   * @param add_generation_prompt Whether to add generation prompt at end
+   * @return Formatted prompt string
+   */
+  std::string apply(const std::vector<ChatMessage> &messages,
+                    bool add_generation_prompt = true) const;
+
+  /**
+   * @brief Apply template to a single user input (convenience)
+   * @param user_input Raw user input string
+   * @param add_generation_prompt Whether to add generation prompt at end
+   * @return Formatted prompt string
+   */
+  std::string apply(const std::string &user_input,
+                    bool add_generation_prompt = true) const;
+
+  /**
+   * @brief Check if a chat template is loaded and available
+   * @return true if template is available
+   */
+  bool isAvailable() const;
+
+  /**
+   * @brief Get BOS token
+   */
+  std::string getBosToken() const;
+
+  /**
+   * @brief Get EOS token
+   */
+  std::string getEosToken() const;
+
+private:
+  std::string template_str_;
+  std::string bos_token_;
+  std::string eos_token_;
+  bool available_ = false;
+
+  /**
+   * @brief Render a Jinja2 template with the given context
+   * @param tmpl Jinja2 template string
+   * @param context JSON object with template variables
+   * @return Rendered string
+   */
+  std::string render(const std::string &tmpl, const json &context) const;
+};
+
+} // namespace causallm
+
+#endif // __CHAT_TEMPLATE_H__

--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -58,6 +58,7 @@ LOCAL_MODULE := causallm_core
 LOCAL_LDLIBS := -llog -landroid -fopenmp -static-openmp -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1
 
 LOCAL_SRC_FILES := \
+    ../chat_template.cpp \
     ../models/causal_lm.cpp \
     ../models/transformer.cpp \
     ../models/sentence_transformer.cpp \

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -253,7 +253,17 @@ int main(int argc, char *argv[]) {
       if (chat_tmpl.isAvailable()) {
         std::cout << "[Info] Chat template loaded from tokenizer_config.json"
                   << std::endl;
+      } else {
+        std::cerr
+          << "[Warning] tokenizer_config.json found but chat template could "
+             "not be loaded. Chat formatting will not be applied to raw input."
+          << std::endl;
       }
+    } else {
+      std::cerr
+        << "[Warning] tokenizer_config.json not found in " << model_path
+        << ". Chat template will not be available for raw input formatting."
+        << std::endl;
     }
 
     // Determine input text

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -30,6 +30,7 @@
 #include <factory.h>
 
 #include "causal_lm.h"
+#include "chat_template.h"
 #include "embedding_gemma.h"
 #include "gemma3_causallm.h"
 #include "gptoss_cached_slim_causallm.h"
@@ -46,6 +47,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <filesystem>
 #include <thread>
 
 using json = nlohmann::json;
@@ -243,9 +245,24 @@ int main(int argc, char *argv[]) {
       architecture = resolve_architecture(model_type, architecture);
     }
 
+    // Load chat template from tokenizer_config.json (if available)
+    causallm::ChatTemplate chat_tmpl;
+    std::string tokenizer_config_path = model_path + "/tokenizer_config.json";
+    if (std::filesystem::exists(tokenizer_config_path)) {
+      chat_tmpl = causallm::ChatTemplate::fromFile(tokenizer_config_path);
+      if (chat_tmpl.isAvailable()) {
+        std::cout << "[Info] Chat template loaded from tokenizer_config.json"
+                  << std::endl;
+      }
+    }
+
     // Determine input text
     if (argc >= 3) {
       input_text = argv[2];
+      // Apply chat template to raw user input if available
+      if (chat_tmpl.isAvailable()) {
+        input_text = chat_tmpl.apply(input_text);
+      }
     } else {
       if (nntr_cfg.contains("chat_input")) {
         if (architecture == "Gemma3ForCausalLM") {

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -1,4 +1,5 @@
 causallm_src = [
+    meson.current_source_dir() / 'chat_template.cpp',
     meson.current_source_dir() / 'huggingface_tokenizer.cpp',
     meson.current_source_dir() / 'llm_util.cpp',
     meson.current_source_dir() / 'api' / 'causal_lm_api.cpp',


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] add ChatTemplate </summary><br />

- This commit adds a feature of chat template.
- This commit implements chat template (supporting qwen3)

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



<details><summary>[CausalLM] add chat template warnings</summary><br />

- Add warning/info messages when tokenizer_config.json is missing or
  chat_template field is not found, in both main.cpp and
causal_lm_api.cpp.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

<details><summary>[CausalLM] add chat template information to README </summary><br />

- Add Chat Template section to README with usage examples and supported
Jinja2 features.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
</details>


### Summary

- Add chat template feature to CausalLM
