### PR TITLE
[CausalLM] Add Reverse RMS norm

### DIFF
--- a/Applications/CausalLM/README.md
+++ b/Applications/CausalLM/README.md
@@ -191,15 +191,18 @@ nntr_quantize <model_path> [options]
 | `--lmhead_dtype <type>` | Target dtype for LM head layer | Same as `embd_dtype` |
 | `--output_bin <name>` | Output `.bin` filename | Auto-generated |
 | `--config <path>` | Use a target `nntr_config.json` for dtype settings | – |
+| `--isa <x86|ARM|AUTO>` | Target ISA for quantization | `AUTO` |
 
 ### Examples
-
 ```bash
 # Quantize FC layers to Q4_0 (default), embedding stays FP32:
 nntr_quantize /path/to/qwen3-4b
 
 # Quantize FC layers to Q4_0 and embedding to Q6_K:
 nntr_quantize /path/to/qwen3-4b --fc_dtype Q4_0 --embd_dtype Q6_K
+
+# Quantize FC layers to Q4_0 and embedding to Q6_K in ARM format:
+nntr_quantize /path/to/qwen3-4b --fc_dtype Q4_0 --embd_dtype Q6_K --isa ARM
 
 # Quantize to a different output directory:
 nntr_quantize /path/to/qwen3-4b -o /output/qwen3-4b-q4

--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -173,7 +173,8 @@ void EmbeddingLayer::exportTo(nntrainer::Exporter &exporter,
 void EmbeddingLayer::save(std::ofstream &file,
                           nntrainer::RunLayerContext &run_context, bool opt_var,
                           ml::train::ExecutionMode mode, bool trainable,
-                          nntrainer::TensorDim::DataType dtype) const {
+                          nntrainer::TensorDim::DataType dtype,
+                          ml::train::ISA target_isa) const {
   // @note shared weights are only be saved at the first access
   for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
     if (run_context.isGradientFirstAccess(i)) {

--- a/Applications/CausalLM/layers/embedding_layer.h
+++ b/Applications/CausalLM/layers/embedding_layer.h
@@ -115,13 +115,13 @@ public:
   WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
 
   /**
-   * @copydic Layer::save()
+   * @copydoc Layer::save()
    */
-  WIN_EXPORT void save(std::ofstream &file,
-                       nntrainer::RunLayerContext &run_context, bool opt_var,
-                       ml::train::ExecutionMode mode, bool trainable,
-                       nntrainer::TensorDim::DataType dtype =
-                         nntrainer::TensorDim::DataType::NONE) const override;
+  WIN_EXPORT void save(
+    std::ofstream &file, nntrainer::RunLayerContext &run_context, bool opt_var,
+    ml::train::ExecutionMode mode, bool trainable,
+    nntrainer::TensorDim::DataType dtype = nntrainer::TensorDim::DataType::NONE,
+    ml::train::ISA target_isa = ml::train::ISA::AUTO) const override;
 
   inline static const std::string type = "embedding_layer";
 

--- a/Applications/CausalLM/layers/meson.build
+++ b/Applications/CausalLM/layers/meson.build
@@ -9,6 +9,7 @@ causallm_mha_core_abs = [meson.current_source_dir()/ 'mha_core.cpp']
 causallm_embedding_src_abs = [meson.current_source_dir() / 'embedding_layer.cpp']
 causallm_reshaped_rms_norm_src_abs = [meson.current_source_dir() / 'reshaped_rms_norm.cpp']
 causallm_qkv_layer_src_abs = [meson.current_source_dir() / 'qkv_layer.cpp']
+causallm_rms_reverse_norm_src_abs = [meson.current_source_dir() / 'rms_reverse_norm.cpp']
 causallm_embedding_pooling_src_abs = [meson.current_source_dir() / 'embedding_pooling_layer.cpp']
 causallm_embedding_normalize_src_abs = [meson.current_source_dir() / 'embedding_normalize_layer.cpp']
 
@@ -142,5 +143,18 @@ causallm_qkv_layer = shared_library(
 
 causallm_qkv_layer_dep = declare_dependency(
     link_with: causallm_qkv_layer,
+    include_directories: causallm_layer_inc
+)
+
+causallm_rms_reverse_norm = shared_library(
+    'rms_reverse_norm_layer',
+    causallm_rms_reverse_norm_src_abs,
+    include_directories: causallm_layer_inc,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    install: true,
+    install_dir: application_install_dir
+)
+causallm_rms_reverse_norm_dep = declare_dependency(
+    link_with: causallm_rms_reverse_norm,
     include_directories: causallm_layer_inc
 )

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -149,6 +149,10 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
   /** Is Causal */
   is_causal = std::get<props::IsCausal>(mha_core_props).get();
 
+  if (!std::get<nntrainer::props::SkipPrefill>(*layer_impl_props).empty())
+    skip_prefill =
+      std::get<nntrainer::props::SkipPrefill>(*layer_impl_props).get();
+
   /** Tensor for KV-Cache */
 #ifdef ENABLE_FP16
   ml::train::TensorDim cache_key_dim(
@@ -343,7 +347,7 @@ void MHACoreLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
         cache_value_dim, cache_value_step_dim);
     }
   }
-  
+
   // increase cache size
   cache_index += step_size;
 }
@@ -495,10 +499,6 @@ void MHACoreLayer::one_batch_incremental_forwarding(
                                       cache_index * cache_value_dim.width(),
                                     true);
 
-  // apply rotary embedding for query
-  apply_rotary_emb_tensor_v2(query_step, query_step, head_dim, cache_index,
-                             false);
-
   // append kcache with rotary embedding
   apply_rotary_emb_tensor_v2(key_step, b_cache_key_step, head_dim, cache_index,
                              false);
@@ -515,6 +515,14 @@ void MHACoreLayer::one_batch_incremental_forwarding(
 #endif
   }
 
+  bool is_prefill = !from;
+  if (skip_prefill && is_prefill)
+    return;
+
+  // apply rotary embedding for query
+  apply_rotary_emb_tensor_v2(query_step, query_step, head_dim, cache_index,
+                             false);
+                             
   /// @todo replace step_size into input height
   unsigned int step_size = to - from;
   unsigned int cache_from = cache_index;

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -327,6 +327,7 @@ private:
   bool use_sink = false;
   float attn_logit_softcapping = 0.0f;
   bool is_causal;
+  bool skip_prefill = false;
 
   enum INOUT_INDEX {
     /** input index */

--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -2,7 +2,7 @@
 /**
  * Copyright (C) 2023 Seungbaek Hong <sb92.hong@samsung.com>
  *
- * @file   custom_rms_norm.cpp
+ * @file   reshaped_rms_norm.cpp
  * @date   19 July 2023
  * @brief  Implementation of custom RMS normalization function
  * @see    https://github.com/nntrainer/nntrainer
@@ -23,6 +23,9 @@ void ReshapedRMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
   std::vector<nntrainer::TensorDim> dim = context.getInputDimensions();
   context.setOutputDimensions(dim);
   feature_size = std::get<props::FeatureSize>(rms_props);
+
+  if (!std::get<nntrainer::props::SkipPrefill>(rms_props).empty())
+    skip_prefill = std::get<nntrainer::props::SkipPrefill>(rms_props).get();
 
   NNTR_THROW_IF(dim[0].width() % feature_size != 0, std::invalid_argument)
     << "feature size must be a divisor of width";
@@ -54,7 +57,9 @@ void ReshapedRMSNormLayer::incremental_forwarding(
   ml::train::TensorDim in_step_dim = in_dim;
   ml::train::TensorDim out_step_dim = out_dim;
 
-  unsigned int _from = from;
+  bool is_prefill = !from;
+  if (skip_prefill && is_prefill)
+    return;
 
   in_step_dim.batch(1);
   in_step_dim.height(to - from);

--- a/Applications/CausalLM/layers/reshaped_rms_norm.h
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.h
@@ -47,7 +47,7 @@ public:
   WIN_EXPORT ReshapedRMSNormLayer() :
     Layer(),
     rms_props(props::RMS_NORM_GAMMA_INIT(), nntrainer::props::Epsilon(),
-              props::FeatureSize()),
+              props::FeatureSize(), nntrainer::props::SkipPrefill()),
     feature_size(0) {
     wt_idx.fill(std::numeric_limits<unsigned int>::max());
   }
@@ -120,10 +120,11 @@ public:
 private:
   std::array<unsigned int, 1> wt_idx;
   std::tuple<props::RMS_NORM_GAMMA_INIT, nntrainer::props::Epsilon,
-             props::FeatureSize>
+             props::FeatureSize, nntrainer::props::SkipPrefill>
     rms_props;
 
   unsigned int feature_size;
+  bool skip_prefill = false;
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -2,7 +2,7 @@
 /**
  * Copyright (C) 2023 Seungbaek Hong <sb92.hong@samsung.com>
  *
- * @file   custom_rms_norm.cpp
+ * @file   rms_norm.cpp
  * @date   19 July 2023
  * @brief  Implementation of custom RMS normalization function
  * @see    https://github.com/nntrainer/nntrainer
@@ -23,6 +23,10 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 void RMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
   std::vector<nntrainer::TensorDim> dim = context.getInputDimensions();
   context.setOutputDimensions(dim);
+
+  if (!std::get<nntrainer::props::SkipPrefill>(rms_props).empty())
+    skip_prefill = std::get<nntrainer::props::SkipPrefill>(rms_props).get();
+
   nntrainer::TensorDim gamma_dim(
     1, 1, 1, dim[0].width(),
     nntrainer::TensorDim::TensorType(context.getFormat(),
@@ -50,7 +54,9 @@ void RMSNormLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
   ml::train::TensorDim in_step_dim = in_dim;
   ml::train::TensorDim out_step_dim = out_dim;
 
-  unsigned int _from = from;
+  bool is_prefill = !from;
+  if (skip_prefill && is_prefill)
+    return;
 
   in_step_dim.batch(1);
   in_step_dim.height(to - from);

--- a/Applications/CausalLM/layers/rms_norm.h
+++ b/Applications/CausalLM/layers/rms_norm.h
@@ -112,7 +112,10 @@ public:
 
 private:
   std::array<unsigned int, 1> wt_idx;
-  std::tuple<props::RMS_NORM_GAMMA_INIT, nntrainer::props::Epsilon> rms_props;
+  std::tuple<props::RMS_NORM_GAMMA_INIT, nntrainer::props::Epsilon,
+             nntrainer::props::SkipPrefill>
+    rms_props;
+  bool skip_prefill = false;
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/layers/rms_reverse_norm.cpp
+++ b/Applications/CausalLM/layers/rms_reverse_norm.cpp
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Joonseok Oh <jrock.oh@samsung.com>
+ *
+ * @file   rms_reverse_norm.cpp
+ * @date   27 March 2026
+ * @brief  This is Reverse RMS Norm Layer Class
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Joonseok Oh <jrock.oh@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#include <cmath>
+#include <iostream>
+
+#include "rms_reverse_norm.h"
+
+namespace causallm {
+
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
+enum RMSReverseParams { weight, out_scale };
+
+void RMSReverseNormLayer::finalize(nntrainer::InitLayerContext &context) {
+  std::vector<nntrainer::TensorDim> dim = context.getInputDimensions();
+
+  context.setOutputDimensions(dim);
+
+  // Initialize weight and out_scale parameters
+  auto weight_init = nntrainer::props::InitializerInfo::Enum::ONES;
+  auto outscale_init = nntrainer::props::InitializerInfo::Enum::ONES;
+
+  if (!std::get<props::RMS_REVERSE_NORM_WEIGHT_INIT>(rms_props).empty()) {
+    weight_init = std::get<props::RMS_REVERSE_NORM_WEIGHT_INIT>(rms_props).get();
+  }
+
+  if (!std::get<props::RMS_REVERSE_NORM_OUTSCALE_INIT>(rms_props).empty()) {
+    outscale_init =
+      std::get<props::RMS_REVERSE_NORM_OUTSCALE_INIT>(rms_props).get();
+  }
+
+  if (!std::get<nntrainer::props::SkipPrefill>(rms_props).empty()) {
+    skip_prefill = std::get<nntrainer::props::SkipPrefill>(rms_props).get();
+  }
+
+  // Request weight parameter (learnable multiplicative weight applied BEFORE norm)
+  nntrainer::TensorDim weight_dim(
+    1, 1, 1, dim[0].width(),
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()));
+  wt_idx[RMSReverseParams::weight] = context.requestWeight(
+    weight_dim, weight_init, nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f,
+    "weight", true);
+
+  // Request out_scale parameter (learnable scale applied AFTER norm)
+  nntrainer::TensorDim outscale_dim(
+    1, 1, 1, 1,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()));
+  wt_idx[RMSReverseParams::out_scale] = context.requestWeight(
+    outscale_dim, outscale_init, nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f,
+    "out_scale", true);
+}
+
+void RMSReverseNormLayer::forwarding(nntrainer::RunLayerContext &context,
+                                           bool training) {}
+
+void RMSReverseNormLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+  auto &epsilon = std::get<nntrainer::props::Epsilon>(rms_props).get();
+
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &weight =
+    context.getWeight(wt_idx[RMSReverseParams::weight]);
+  nntrainer::Tensor &out_scale =
+    context.getWeight(wt_idx[RMSReverseParams::out_scale]);
+
+  ml::train::TensorDim in_dim = in.getDim();
+  ml::train::TensorDim out_dim = out.getDim();
+
+  ml::train::TensorDim in_step_dim = in_dim;
+  ml::train::TensorDim out_step_dim = out_dim;
+
+  unsigned int _from = from;
+  bool is_prefill = !from;
+  if (from) {
+    NNTR_THROW_IF(to - from != 1, std::invalid_argument)
+      << "incremental step size is not 1";
+    from = 0;
+    to = 1;
+  } else if (skip_prefill && is_prefill)
+    return;
+
+  in_step_dim.batch(1);
+  in_step_dim.height(to - from);
+  out_step_dim.batch(1);
+  out_step_dim.height(to - from);
+
+
+  unsigned int b_size = in_dim.batch();
+
+ 
+
+  for (unsigned int b = 0; b < b_size; ++b) {
+    nntrainer::Tensor in_step =
+      in.getSharedDataTensor(in_step_dim, b * in_dim.getFeatureLen(), true);
+    nntrainer::Tensor out_step =
+      out.getSharedDataTensor(out_step_dim, b * out_dim.getFeatureLen(), true);
+
+    if (in_step.getDataType() == ml::train::TensorDim::DataType::FP32) {
+      // ReverseRMSNorm order: x * weight → normalize → multiply by out_scale
+
+      // Step 1: Multiply input by weight (BEFORE normalization)
+      in_step.multiply_i(weight);
+
+      // Step 2: Compute RMS normalization
+      // rsqrt(average(x^2) + eps)
+      auto t = in_step.multiply(in_step).average(3).add(epsilon);
+      t.inv_sqrt_i();
+
+      // Step 3: Apply normalization
+      in_step.multiply(t, out_step);
+
+      // Step 4: Apply output scale (AFTER normalization)
+      out_step.multiply_i(out_scale);
+
+    } else if (in_step.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+      ml::train::TensorDim instep_dim = in_step_dim;
+      ml::train::TensorDim outstep_dim = out_step_dim;
+
+      instep_dim.setDataType(ml::train::TensorDim::DataType::FP32);
+      outstep_dim.setDataType(ml::train::TensorDim::DataType::FP32);
+
+      nntrainer::Tensor in_step32(instep_dim, true);
+      nntrainer::Tensor out_step32(outstep_dim, true);
+
+      in_step32.copyData(in_step);
+
+      // ReverseRMSNorm order: x * weight → normalize → multiply by out_scale
+
+      // Step 1: Multiply input by weight (BEFORE normalization)
+      in_step32.multiply_i(weight);
+
+      // Step 2: Compute RMS normalization
+      auto t = in_step32.multiply(in_step32).average(3).add(epsilon);
+      t.inv_sqrt_i();
+
+      // Step 3: Apply normalization
+      in_step32.multiply(t, out_step32);
+
+      // Step 4: Apply output scale (AFTER normalization)
+      out_step32.multiply_i(out_scale);
+
+      out_step.copyData(out_step32);
+#else
+      throw std::invalid_argument("Error: enable-fp16 is not set");
+#endif
+    }
+
+#ifdef DEBUG
+    std::cout << context.getName() << " \n input:" << in_step
+              << "output:" << out_step << "weight:" << weight
+              << "out_scale:" << out_scale << std::endl;
+#endif
+  }
+}
+
+void RMSReverseNormLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  input_dim.height(input_dimensions[0].height());
+  output_dim.height(input_dimensions[0].height());
+
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
+void RMSReverseNormLayer::calcDerivative(
+  nntrainer::RunLayerContext &context) {
+  // Training not implemented yet
+  // std::throw_with_nested(std::runtime_error("Training is not supported yet."));
+}
+
+#ifdef PLUGGABLE
+
+nntrainer::Layer *create_rms_reverse_norm_layer() {
+  auto layer = new RMSReverseNormLayer();
+  return layer;
+}
+
+void destroy_rms_reverse_norm_layer(nntrainer::Layer *layer) { delete layer; }
+
+extern "C" {
+nntrainer::LayerPluggable ml_train_layer_pluggable{
+  create_rms_reverse_norm_layer, destroy_rms_reverse_norm_layer};
+}
+
+#endif
+
+} // namespace custom

--- a/Applications/CausalLM/layers/rms_reverse_norm.h
+++ b/Applications/CausalLM/layers/rms_reverse_norm.h
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Joonseok Oh <jrock.oh@samsung.com>
+ *
+ * @file   rms_reverse_norm.h
+ * @date   27 March 2026
+ * @brief  This is Reverse RMS Norm Layer Class
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Joonseok Oh <jrock.oh@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __RMS_REVERSE_NORM_LAYER_H__
+#define __RMS_REVERSE_NORM_LAYER_H__
+
+#pragma once
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#else
+#define WIN_EXPORT
+#endif
+
+#include <layer_context.h>
+#include <layer_devel.h>
+#include <node_exporter.h>
+#include <utility>
+
+#include <causallm_common_properties.h>
+#include <connection.h>
+#include <tensor.h>
+#include <tensor_wrap_specs.h>
+
+namespace causallm {
+
+namespace props {
+
+/**
+ * @brief RMS_REVERSE_NORM_WEIGHT_INIT Initialization Enumeration Information
+ *
+ */
+WIN_EXPORT class RMS_REVERSE_NORM_WEIGHT_INIT final
+  : public nntrainer::EnumProperty<nntrainer::props::InitializerInfo> {
+public:
+  /**
+   * @brief Construct a RMS_REVERSE_NORM_WEIGHT_INIT object
+   */
+  WIN_EXPORT RMS_REVERSE_NORM_WEIGHT_INIT(
+    nntrainer::Initializer value = nntrainer::Initializer::ONES) {
+    set(value);
+  };
+
+  using prop_tag = nntrainer::enum_class_prop_tag;
+  static constexpr const char *key = "weight_initializer";
+};
+
+/**
+ * @brief RMS_REVERSE_NORM_OUTSCALE_INIT Initialization Enumeration Information
+ *
+ */
+WIN_EXPORT class RMS_REVERSE_NORM_OUTSCALE_INIT final
+  : public nntrainer::EnumProperty<nntrainer::props::InitializerInfo> {
+public:
+  /**
+   * @brief Construct a RMS_REVERSE_NORM_OUTSCALE_INIT object
+   */
+  WIN_EXPORT RMS_REVERSE_NORM_OUTSCALE_INIT(
+    nntrainer::Initializer value = nntrainer::Initializer::ONES) {
+    set(value);
+  };
+
+  using prop_tag = nntrainer::enum_class_prop_tag;
+  static constexpr const char *key = "outscale_initializer";
+};
+
+}; // namespace props
+
+
+
+/**
+ * @brief A ReverseRMS normalization layer.
+ *        Order of operations: input * weight → normalize → multiply by out_scale
+ *
+ */
+WIN_EXPORT class RMSReverseNormLayer final : public nntrainer::Layer {
+public:
+  /**
+   * @brief Construct a new ReverseRMS normalization layer object
+   *
+   */
+  WIN_EXPORT RMSReverseNormLayer() : Layer() {}
+
+  /**
+   * @brief Destroy the ReverseRMS normalization layer object
+   *
+   */
+  WIN_EXPORT ~RMSReverseNormLayer() {}
+
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
+   */
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+
+  /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc bool supportBackwarding() const
+   */
+  WIN_EXPORT bool supportBackwarding() const override { return true; };
+
+  /**
+   * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
+   */
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override{};
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  WIN_EXPORT const std::string getType() const override {
+    return RMSReverseNormLayer::type;
+  };
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override {
+    auto remain_props = nntrainer::loadProperties(values, rms_props);
+    NNTR_THROW_IF(!remain_props.empty(), std::invalid_argument)
+      << "[rms_reverse_norm] Unknown Layer Properties count " +
+           std::to_string(values.size());
+  };
+
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  inline static const std::string type = "rms_reverse_norm";
+
+private:
+  std::array<unsigned int, 2> wt_idx;
+  std::tuple<props::RMS_REVERSE_NORM_WEIGHT_INIT,
+              props::RMS_REVERSE_NORM_OUTSCALE_INIT,
+              nntrainer::props::Epsilon, nntrainer::props::SkipPrefill>
+    rms_props;
+  bool skip_prefill = false;
+};
+
+} // namespace custom
+
+#endif /* RMS_REVERSE_NORM_LAYER_H__ */

--- a/Applications/CausalLM/layers/swiglu.cpp
+++ b/Applications/CausalLM/layers/swiglu.cpp
@@ -32,6 +32,9 @@ float swiglu(float x) { return x / (1 + nntrainer::exp_util(-x)); }
 
 void SwiGLULayer::finalize(nntrainer::InitLayerContext &context) {
   context.setOutputDimensions({context.getInputDimensions()[0]});
+
+  if (!std::get<nntrainer::props::SkipPrefill>(swiglu_props).empty())
+    skip_prefill = std::get<nntrainer::props::SkipPrefill>(swiglu_props).get();
 }
 
 void SwiGLULayer::forwarding(nntrainer::RunLayerContext &context,
@@ -44,7 +47,9 @@ void SwiGLULayer::incremental_forwarding(nntrainer::RunLayerContext &context,
   nntrainer::Tensor &in2 = context.getInput(INPUT_IDX_2);
   nntrainer::Tensor &out = context.getOutput(OUT_IDX);
 
-  unsigned int _from = from;
+  bool is_prefill = !from;
+  if (skip_prefill && is_prefill)
+    return;
 
   int iter = to - from;
 

--- a/Applications/CausalLM/layers/swiglu.h
+++ b/Applications/CausalLM/layers/swiglu.h
@@ -38,7 +38,8 @@ public:
    * @brief Construct a new custom SwiGLU layer object
    *
    */
-  WIN_EXPORT SwiGLULayer() : Layer() {}
+  WIN_EXPORT SwiGLULayer() :
+    Layer(), swiglu_props(nntrainer::props::SkipPrefill()) {}
 
   /**
    * @brief Destroy the custom SwiGLU layer object
@@ -92,14 +93,22 @@ public:
   /**
    * @copydoc Layer::setProperty(const std::vector<std::string> &values)
    */
-  WIN_EXPORT void
-  setProperty(const std::vector<std::string> &values) override{};
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override {
+    auto remain_props = loadProperties(values, swiglu_props);
+    NNTR_THROW_IF(!remain_props.empty(), std::invalid_argument)
+      << "[swiglu] Unknown Layer Properties count " +
+           std::to_string(values.size());
+  };
 
   WIN_EXPORT void updateTensorsByInputDimensions(
     nntrainer::RunLayerContext &context,
     std::vector<nntrainer::TensorDim> input_dimensions) override;
 
   inline static const std::string type = "swiglu";
+
+private:
+  std::tuple<nntrainer::props::SkipPrefill> swiglu_props;
+  bool skip_prefill = false;
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/layers/tie_word_embedding.cpp
+++ b/Applications/CausalLM/layers/tie_word_embedding.cpp
@@ -382,7 +382,8 @@ void TieWordEmbedding::save(std::ofstream &file,
                             nntrainer::RunLayerContext &run_context,
                             bool opt_var, ml::train::ExecutionMode mode,
                             bool trainable,
-                            nntrainer::TensorDim::DataType dtype) const {
+                            nntrainer::TensorDim::DataType dtype,
+                            ml::train::ISA target_isa) const {
   // Only read when mode is embedding
   if (mode_ == mode::embedding) {
     // @note shared weights are only be saved at the first access
@@ -410,7 +411,6 @@ void TieWordEmbedding::save(std::ofstream &file,
             //////////////////////////////////////////////////////////////////
             nntrainer::Tensor quant_weight(dim.batch(), dim.channel(), K, N,
                                            {nntrainer::Tformat::NCHW, dtype});
-
             nntrainer::quantize_q6_K(weight.getData<float>(),
                                      quant_weight.getData<uint8_t>(), K, N,
                                      nullptr);

--- a/Applications/CausalLM/layers/tie_word_embedding.h
+++ b/Applications/CausalLM/layers/tie_word_embedding.h
@@ -131,14 +131,15 @@ public:
                        bool fsu, size_t start_offset = 0,
                        bool read_from_offset = false) override;
 
+
   /**
-   * @copydic Layer::save()
+   * @copydoc Layer::save()
    */
-  WIN_EXPORT void save(std::ofstream &file,
-                       nntrainer::RunLayerContext &run_context, bool opt_var,
-                       ml::train::ExecutionMode mode, bool trainable,
-                       nntrainer::TensorDim::DataType dtype =
-                         nntrainer::TensorDim::DataType::NONE) const override;
+  WIN_EXPORT void save(
+    std::ofstream &file, nntrainer::RunLayerContext &run_context, bool opt_var,
+    ml::train::ExecutionMode mode, bool trainable,
+    nntrainer::TensorDim::DataType dtype = nntrainer::TensorDim::DataType::NONE,
+    ml::train::ISA target_isa = ml::train::ISA::AUTO) const override;
 
   using Layer::setProperty;
 

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -62,6 +62,10 @@ void CausalLM::setupParameters(json &cfg, json &generation_cfg,
                    ? nntr_cfg["lmhead_dtype"]
                    : nntr_cfg["embedding_dtype"];
 
+  SKIP_PREFILL = nntr_cfg.contains("skip_prefill")
+                   ? nntr_cfg["skip_prefill"].get<bool>()
+                   : false;
+
   USE_KVCACHE = false;
   PRE_COMPUTED_CACHE_PATH = "";
   SYS_PROMP_LEN = 0;
@@ -448,17 +452,37 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   } else {
     SYS_PROMP_LEN = 0;
   }
-  output = model->incremental_inference(BATCH_SIZE, input, label, init_len,
-                                        SYS_PROMP_LEN,
-                                        SYS_PROMP_LEN + input_len, false);
+  std::vector<unsigned int> id_list;
 
-  // post process of model output
-  std::vector<unsigned int> id_list(generate_multi_tokens(
-    output[0], NUM_VOCAB, BATCH_SIZE, 1, ids_history, _len));
+  if (SKIP_PREFILL && init_len > 1) {
+    // Prefill only N-1 tokens; the last input token will be used as the first
+    // token in the generation phase (assigned directly, not sampled).
+    unsigned int skipped_token =
+      static_cast<unsigned int>(init_input[init_len - 1]);
 
-  if (init_len < INIT_SEQ_LEN)
-    registerOutputs(tokenizer, id_list, init_len, eos_list, log_output);
+    output = model->incremental_inference(BATCH_SIZE, input, label,
+                                          init_len - 1, SYS_PROMP_LEN,
+                                          SYS_PROMP_LEN + input_len - 1, false);
 
+    for (unsigned int b = 0; b < BATCH_SIZE; ++b)
+      id_list.push_back(skipped_token);
+
+    // Adjust lengths so the generation loop processes the skipped token
+    // at the correct KV cache position.
+    input_len -= 1;
+    init_len -= 1;
+  } else {
+    output = model->incremental_inference(BATCH_SIZE, input, label, init_len,
+                                          SYS_PROMP_LEN,
+                                          SYS_PROMP_LEN + input_len, false);
+
+    // post process of model output
+    id_list = generate_multi_tokens(output[0], NUM_VOCAB, BATCH_SIZE, 1,
+                                    ids_history, _len);
+
+    if (init_len < INIT_SEQ_LEN)
+      registerOutputs(tokenizer, id_list, init_len, eos_list, log_output);
+  }
   // output should be deallocated after use
   for (auto &out : output) {
     delete[] out;

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -150,6 +150,7 @@ protected:
   std::string TAIL_PROMPT;
   bool SAVE_KVCACHE;
   bool USE_KVCACHE;
+  bool SKIP_PREFILL;
   unsigned int global_token_len;
 
   bool has_run_ = false;

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -165,7 +165,7 @@ void Transformer::initialize() {
   }
 
   is_initialized = true;
-
+  model->summarize(std::cout, ML_TRAIN_SUMMARY_MODEL);
 #ifdef DEBUG
   model->summarize(std::cout, ML_TRAIN_SUMMARY_MODEL);
 #endif

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -255,7 +255,8 @@ void Transformer::save_weight(const std::string &weight_path) {
 void Transformer::save_weight(
   const std::string &weight_path, ml::train::TensorDim::DataType dtype,
   const std::map<std::string, ml::train::TensorDim::DataType>
-    &layer_dtype_map) {
+    &layer_dtype_map, ml::train::ISA target_isa) {
+
 
   if (!is_initialized) {
     throw std::runtime_error(
@@ -264,8 +265,8 @@ void Transformer::save_weight(
   }
 
   try {
-    model->save(weight_path, ml::train::ModelFormat::MODEL_FORMAT_BIN, dtype,
-                layer_dtype_map);
+    model->save(weight_path, ml::train::ModelFormat::MODEL_FORMAT_BIN, dtype,layer_dtype_map, target_isa);
+
   } catch (const std::exception &e) {
     throw std::runtime_error("Failed to save model weights with dtype: " +
                              std::string(e.what()));

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -95,18 +95,17 @@ public:
    * @brief Save the weight to a file
    */
   virtual void save_weight(const std::string &weight_path);
-
   /**
    * @brief Save the weight to a file with type conversion
    * @param weight_path Path to save the weight file
    * @param dtype Global target data type for all layers (NONE = keep original)
    * @param layer_dtype_map Per-layer data type overrides (layer_name -> dtype)
+   * @param target_isa Target ISA for quantization (default: AUTO)
    */
-  virtual void
-  save_weight(const std::string &weight_path,
-              ml::train::TensorDim::DataType dtype,
-              const std::map<std::string, ml::train::TensorDim::DataType>
-                &layer_dtype_map = {});
+  virtual void save_weight(
+    const std::string &weight_path, ml::train::TensorDim::DataType dtype,
+    const std::map<std::string, ml::train::TensorDim::DataType>
+      &layer_dtype_map = {},ml::train::ISA target_isa = ml::train::ISA::AUTO);
 
   /**
    * @brief run the Transformer model

--- a/Applications/CausalLM/quantize.cpp
+++ b/Applications/CausalLM/quantize.cpp
@@ -166,7 +166,8 @@ std::string buildModelTensorType(const std::string &fc_dtype) {
  */
 std::string generateOutputBinName(const std::string &original_bin,
                                   const std::string &fc_dtype,
-                                  const std::string &embd_dtype) {
+                                  const std::string &embd_dtype,
+                                  const std::string &target_isa) {
   // Extract model name from original (e.g., "nntr_qwen3_4b_fp32.bin" ->
   // "nntr_qwen3_4b")
   std::string base = original_bin;
@@ -204,9 +205,9 @@ std::string generateOutputBinName(const std::string &original_bin,
                    embd_clean.end());
 
   if (embd_clean == fc_clean) {
-    return base + "_" + fc_clean + ".bin";
+    return base + "_" + fc_clean + "_"+ target_isa+".bin";
   }
-  return base + "_" + fc_clean + "_embd" + embd_clean + ".bin";
+  return base + "_" + fc_clean + "_embd" + embd_clean +  "_"+ target_isa+".bin";
 }
 
 /**
@@ -397,10 +398,39 @@ buildLayerDtypeMap(int num_layers, DataType fc_dtype, DataType embd_dtype,
       dtype_map[prefix + "_wv"] = fc_dtype;
       dtype_map[prefix + "_attention_out"] = fc_dtype;
 
-      // FFN FC layers
-      dtype_map[prefix + "_ffn_up"] = fc_dtype;
+      // Attention Gates
+      dtype_map[prefix + "_attention_gate_down"] = fc_dtype;
+      dtype_map[prefix + "_attention_gate_up"] = fc_dtype;
+
+      // Attention Gates
+      dtype_map[prefix + "_attention_gate_down"] = fc_dtype;
+      dtype_map[prefix + "_attention_gate_up"] = fc_dtype;
+
+      // FFN FC layers - version4
+      dtype_map[prefix + "_ffn_gate_up"] = fc_dtype;
+      dtype_map[prefix + "_ffn_gate_down"] = fc_dtype;
+      dtype_map[prefix + "_ffn_linear_up"] = fc_dtype;
+
+
+      // FFN FC layers - version3
       dtype_map[prefix + "_ffn_gate"] = fc_dtype;
+      dtype_map[prefix + "_ffn_up"] = fc_dtype;
       dtype_map[prefix + "_ffn_down"] = fc_dtype;
+      
+
+
+      
+
+
+      dtype_map[prefix + "_ffn_output"] = fc_dtype;
+
+      // for PLE
+      if (embd_dtype != DataType::FP32 && embd_dtype != DataType::NONE) {
+        dtype_map[prefix + "_ple"] = fc_dtype;
+      }
+
+      dtype_map[prefix + "_ple_projection"] = fc_dtype;
+      dtype_map[prefix + "_ple_input_gate"] = fc_dtype;
     }
   }
 
@@ -521,7 +551,7 @@ int main(int argc, char *argv[]) {
     std::string original_bin = nntr_cfg["model_file_name"].get<std::string>();
     if (output_bin_name.empty()) {
       output_bin_name = generateOutputBinName(
-        original_bin, dataTypeToStr(fc_dtype), dataTypeToStr(embd_dtype));
+        original_bin, dataTypeToStr(fc_dtype), dataTypeToStr(embd_dtype), isa_str);
     }
 
     std::string src_weight_path = model_path + "/" + original_bin;

--- a/Applications/CausalLM/quantize.cpp
+++ b/Applications/CausalLM/quantize.cpp
@@ -93,6 +93,41 @@ const std::map<std::string, DataType> dtype_str_map = {
 };
 
 /**
+ * @brief Map of string ISA names to ISA enum values
+ */
+const std::map<std::string, ml::train::ISA> isa_str_map = {
+  {"AUTO", ml::train::ISA::AUTO},
+  {"X86", ml::train::ISA::X86},
+  {"ARM", ml::train::ISA::ARM},
+};
+
+/**
+ * @brief Convert string to ISA enum
+ */
+ml::train::ISA strToISA(const std::string &s) {
+  std::string upper = s;
+  std::transform(upper.begin(), upper.end(), upper.begin(),
+                 [](unsigned char c) { return std::toupper(c); });
+  auto it = isa_str_map.find(upper);
+  if (it == isa_str_map.end()) {
+    throw std::invalid_argument("Unsupported ISA: " + s +
+                                ". Supported: AUTO, X86, ARM");
+  }
+  return it->second;
+}
+
+/**
+ * @brief Convert ISA enum to string
+ */
+std::string isaToStr(ml::train::ISA isa) {
+  for (const auto &[key, val] : isa_str_map) {
+    if (val == isa)
+      return key;
+  }
+  return "AUTO";
+}
+
+/**
  * @brief Convert string to DataType enum
  */
 DataType strToDataType(const std::string &s) {
@@ -287,6 +322,9 @@ void printUsage(const char *prog) {
     << "  --embd_dtype <type>   Target dtype for embedding (default: FP32)\n"
     << "  --lmhead_dtype <type> Target dtype for LM head (default: same as "
        "embd_dtype)\n"
+    << "  --isa <arch>          Target instruction set architecture for "
+       "quantized weights\n"
+    << "                        (default: AUTO). Options: AUTO, X86, ARM.\n"
     << "  --output_bin <name>   Output .bin filename (auto-generated if "
        "omitted)\n"
     << "  --config <path>       Use a target nntr_config.json instead of\n"
@@ -296,6 +334,7 @@ void printUsage(const char *prog) {
     << "  --help, -h            Show this help message\n"
     << "\n"
     << "Supported data types: FP32, FP16, Q4_0, Q6_K, Q4_K\n"
+    << "Supported ISA options: AUTO (current platform), X86, ARM\n"
     << "\n"
     << "Examples:\n"
     << "  # Quantize FC layers to Q4_0 (default):\n"
@@ -303,6 +342,12 @@ void printUsage(const char *prog) {
     << "\n"
     << "  # Quantize FC layers to Q4_0 and embedding to Q6_K:\n"
     << "  " << prog << " /path/to/qwen3-4b --fc_dtype Q4_0 --embd_dtype Q6_K\n"
+    << "\n"
+    << "  # Quantize to ARM format for deployment on ARM devices:\n"
+    << "  " << prog << " /path/to/qwen3-4b --isa ARM\n"
+    << "\n"
+    << "  # Quantize to X86 format for deployment on x86 devices:\n"
+    << "  " << prog << " /path/to/qwen3-4b --isa X86\n"
     << "\n"
     << "  # Quantize to a different output directory:\n"
     << "  " << prog << " /path/to/qwen3-4b -o /output/qwen3-4b-q4\n"
@@ -387,6 +432,7 @@ int main(int argc, char *argv[]) {
   std::string fc_dtype_str = "Q4_0";
   std::string embd_dtype_str = "FP32";
   std::string lmhead_dtype_str = "";
+  std::string isa_str = "AUTO";
   std::string output_bin_name = "";
   std::string target_config_path = "";
 
@@ -400,6 +446,8 @@ int main(int argc, char *argv[]) {
       embd_dtype_str = argv[++i];
     } else if (arg == "--lmhead_dtype" && i + 1 < argc) {
       lmhead_dtype_str = argv[++i];
+    } else if (arg == "--isa" && i + 1 < argc) {
+      isa_str = argv[++i];
     } else if (arg == "--output_bin" && i + 1 < argc) {
       output_bin_name = argv[++i];
     } else if (arg == "--config" && i + 1 < argc) {
@@ -446,6 +494,9 @@ int main(int argc, char *argv[]) {
     if (lmhead_dtype_str.empty())
       lmhead_dtype_str = embd_dtype_str;
 
+    // Parse target ISA
+    ml::train::ISA target_isa = strToISA(isa_str);
+
     // Parse target data types
     DataType fc_dtype = strToDataType(fc_dtype_str);
     DataType embd_dtype = strToDataType(embd_dtype_str);
@@ -488,6 +539,7 @@ int main(int argc, char *argv[]) {
     std::cout << "  FC dtype:     " << dataTypeToStr(fc_dtype) << "\n";
     std::cout << "  Embed dtype:  " << dataTypeToStr(embd_dtype) << "\n";
     std::cout << "  LMHead dtype: " << dataTypeToStr(lmhead_dtype) << "\n";
+    std::cout << "  Target ISA:   " << isaToStr(target_isa) << "\n";
     std::cout << "\n";
 
     // =========================================================================
@@ -536,7 +588,7 @@ int main(int argc, char *argv[]) {
       std::cout << "    " << name << " -> " << dataTypeToStr(dt) << "\n";
     }
 
-    model->save_weight(dst_weight_path, DataType::NONE, layer_dtype_map);
+    model->save_weight(dst_weight_path, DataType::NONE, layer_dtype_map, target_isa);
 
     // Report file size
     auto src_size = std::filesystem::file_size(src_weight_path);

--- a/api/ccapi/include/common.h
+++ b/api/ccapi/include/common.h
@@ -53,6 +53,19 @@ enum LayerComputeEngine {
 };
 
 /**
+ * @brief     Enumeration of ISA (Instruction Set Architecture) for quantization
+ *
+ * @details This enum allows specifying the target ISA format when saving
+ * quantized models, enabling cross-platform quantization (e.g., quantizing on
+ * x86 but saving in ARM format).
+ */
+enum ISA {
+  AUTO, /**< Use the current compiled backend format */
+  X86,  /**< Force x86 format (q4_0x8 for Q4_0) */
+  ARM   /**< Force ARM format (q4_0x4 for Q4_0) */
+};
+
+/**
  * @brief Get the version of NNTrainer
  */
 extern std::string getVersion();

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -168,16 +168,20 @@ public:
    * @param[in] layer_dtype_map a map of layer name to data type. If a layer
    * name is found in this map, its weights are saved with the specific data
    *            type instead of @a dtype.
+   * @param[in] target_isa target ISA (Instruction Set Architecture) format for
+   * quantization (AUTO/X86/ARM). Enables cross-platform quantization, e.g.,
+   * quantizing on x86 but saving in ARM format.
    * @note When @a dtype equals the current weight type of a layer and the layer
    *       is not in @a layer_dtype_map , the weights are saved as-is without
-   * any conversion.
+   *       any conversion.
    * @note save-with-dtype only supports the `MODEL_FORMAT_BIN` model format
    */
-  virtual void save(
-    const std::string &file_path,
-    ModelFormat format = ModelFormat::MODEL_FORMAT_BIN,
-    TensorDim::DataType dtype = TensorDim::DataType::NONE,
-    const std::map<std::string, TensorDim::DataType> &layer_dtype_map = {}) = 0;
+  virtual void
+  save(const std::string &file_path,
+       ModelFormat format = ModelFormat::MODEL_FORMAT_BIN,
+       TensorDim::DataType dtype = TensorDim::DataType::NONE,
+       const std::map<std::string, TensorDim::DataType> &layer_dtype_map = {},
+       ISA target_isa = ISA::AUTO) = 0;
 
   /**
    * @brief  load model with regard to the format

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -73,6 +73,37 @@ void ActivationLayer::forwarding(RunLayerContext &context, bool training) {
   acti_func.run_fn(input_, hidden_);
 }
 
+void ActivationLayer::incremental_forwarding(RunLayerContext &context,
+                                             unsigned int from,
+                                             unsigned int to, bool training) {
+  (void)training;
+  Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
+  Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+
+  TensorDim input_dim = input_.getDim();
+  TensorDim hidden_dim = hidden_.getDim();
+
+  TensorDim input_step_dim = input_dim;
+  TensorDim hidden_step_dim = hidden_dim;
+
+  input_step_dim.batch(1);
+  hidden_step_dim.batch(1);
+
+  if (input_dim.height() > 1)
+    input_step_dim.height(to - from);
+  if (hidden_dim.height() > 1)
+    hidden_step_dim.height(to - from);
+
+  for (unsigned int b = 0; b < hidden_.batch(); ++b) {
+    Tensor input_step = input_.getSharedDataTensor(
+      input_step_dim, b * input_dim.getFeatureLen(), true);
+    Tensor hidden_step = hidden_.getSharedDataTensor(
+      hidden_step_dim, b * hidden_dim.getFeatureLen(), true);
+
+    acti_func.run_fn(input_step, hidden_step);
+  }
+}
+
 void ActivationLayer::calcDerivative(RunLayerContext &context) {
   const Tensor &deriv = context.getIncomingDerivative(SINGLE_INOUT_IDX);
   Tensor &ret = context.getOutgoingDerivative(SINGLE_INOUT_IDX);

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -49,6 +49,14 @@ public:
    */
   void forwarding(RunLayerContext &context, bool training) override;
 
+
+  /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  void incremental_forwarding(RunLayerContext &context, unsigned int from,
+                            unsigned int to, bool training) override;
+
   /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -376,10 +376,12 @@ void BatchNormalizationLayer::setBatch(RunLayerContext &context,
   }
 }
 
-void BatchNormalizationLayer::save(
-  std::ofstream &file, RunLayerContext &run_context, bool opt_var,
-  ml::train::ExecutionMode mode, bool trainable,
-  TensorDim::DataType definedWeightDataType) const {
+void BatchNormalizationLayer::save(std::ofstream &file,
+                                   RunLayerContext &run_context, bool opt_var,
+                                   ml::train::ExecutionMode mode,
+                                   bool trainable,
+                                   TensorDim::DataType definedWeightDataType,
+                                   ml::train::ISA target_isa) const {
   if (opt_var) {
     for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
       if (run_context.isGradientFirstAccess(i) && trainable) {

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -130,11 +130,13 @@ public:
    *      bool opt_var,
    *      ml::train::ExecutionMode mode,
    *      bool trainable,
-   *      TensorDim::DataType definedWeightDataType)
+   *      TensorDim::DataType definedWeightDataType,
+   *      ml::train::ISA target_isa)
    */
   void save(std::ofstream &file, RunLayerContext &run_context, bool opt_var,
             ml::train::ExecutionMode mode, bool trainable,
-            TensorDim::DataType definedWeightDataType) const override;
+            TensorDim::DataType definedWeightDataType,
+            ml::train::ISA target_isa = ml::train::ISA::AUTO) const override;
 
   /**
    * @copydoc Layer::read(std::ifstream &file, RunLayerContext &context, bool

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -126,6 +126,21 @@ public:
 };
 
 /**
+ * @brief Whether the layer should skip prefill or not
+ *
+ */
+class SkipPrefill : public nntrainer::Property<bool> {
+public:
+  /**
+   * @brief Construct a new SkipPrefill object
+   *
+   */
+  SkipPrefill() : nntrainer::Property<bool>() {}
+  static constexpr const char *key = "skip_prefill";
+  using prop_tag = bool_prop_tag;
+};
+
+/**
  * @brief Inplace operation property
  *
  */

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -67,6 +67,8 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
   lora_scaling = (lora_rank && !std::get<props::LoraAlpha>(fc_props).empty())
                    ? (float)std::get<props::LoraAlpha>(fc_props) / lora_rank
                    : 1;
+  if (!std::get<props::SkipPrefill>(*layer_impl_props).empty())
+    skip_prefill = std::get<props::SkipPrefill>(*layer_impl_props).get();
 
   NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
     << "Fully connected layer takes only one input";
@@ -244,6 +246,10 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
   Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
   Tensor loraA, loraB, hidden_tmp_lora, hidden_out_lora;
+
+  bool is_prefill = !from;
+  if (skip_prefill && is_prefill)
+    return;
 
   if (!std::get<props::LoraRank>(fc_props).empty()) {
     loraA = context.getWeight(lora_idx[LORAParams::loraA]);

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -122,6 +122,7 @@ private:
   std::array<unsigned int, 2> weight_idx; /**< indices of the weights */
   std::array<unsigned int, 4> lora_idx;   /**< indices of the lora weights */
   std::unique_ptr<nntrainer::Quantizer> quantizer;
+  bool skip_prefill = false;
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -29,6 +29,7 @@
 
 #include <base_properties.h>
 #include <common.h>
+#include <cpu_backend.h>
 #include <layer_context.h>
 #include <tensor_dim.h>
 
@@ -350,11 +351,13 @@ public:
    * @param mode Execution mode
    * @param trainable is there trainable weight
    * @param dtype data type to save this layer
+   * @param target_isa target ISA (Instruction Set Architecture) format for
+   * quantization (AUTO/X86/ARM)
    */
-  virtual void
-  save(std::ofstream &file, RunLayerContext &run_context, bool opt_var,
-       ml::train::ExecutionMode mode, bool trainable,
-       TensorDim::DataType dtype = TensorDim::DataType::NONE) const {
+  virtual void save(std::ofstream &file, RunLayerContext &run_context,
+                    bool opt_var, ml::train::ExecutionMode mode, bool trainable,
+                    TensorDim::DataType dtype = TensorDim::DataType::NONE,
+                    ml::train::ISA target_isa = ml::train::ISA::AUTO) const {
 
     if (opt_var) {
       for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
@@ -405,7 +408,7 @@ public:
                 quantize_q4_0(weight_t.getData<float>(), tmp.data(), N, K,
                               nullptr);
                 repack_q4_0(quant_weight.getData<uint8_t>(), tmp.data(),
-                            quant_weight.size(), N, K);
+                            quant_weight.size(), N, K, target_isa);
                 quant_weight.save(file);
               }
             } else {

--- a/nntrainer/layers/layer_impl.cpp
+++ b/nntrainer/layers/layer_impl.cpp
@@ -27,8 +27,8 @@ LayerImpl::LayerImpl() :
     std::make_unique<
       std::tuple<props::WeightRegularizer, props::WeightRegularizerConstant,
                  props::WeightInitializer, props::WeightDecay, props::BiasDecay,
-                 props::BiasInitializer, props::DisableBias, props::Print>>()) {
-}
+                 props::BiasInitializer, props::DisableBias, props::Print,
+                 props::SkipPrefill>>()) {}
 
 void LayerImpl::setProperty(const std::vector<std::string> &values) {
   auto remain_props = loadProperties(values, *layer_impl_props);

--- a/nntrainer/layers/layer_impl.h
+++ b/nntrainer/layers/layer_impl.h
@@ -40,6 +40,7 @@ class BiasDecay;
 class BiasInitializer;
 class DisableBias;
 class Print;
+class SkipPrefill;
 } // namespace props
 
 /**
@@ -93,7 +94,8 @@ protected:
   std::unique_ptr<
     std::tuple<props::WeightRegularizer, props::WeightRegularizerConstant,
                props::WeightInitializer, props::WeightDecay, props::BiasDecay,
-               props::BiasInitializer, props::DisableBias, props::Print>>
+               props::BiasInitializer, props::DisableBias, props::Print,
+               props::SkipPrefill>>
     layer_impl_props; /**< layer_impl_props */
 };
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -519,12 +519,13 @@ void LayerNode::read(ReadSource src, bool opt_var,
 
 void LayerNode::save(std::ofstream &file, bool opt_var,
                      ml::train::ExecutionMode mode,
-                     TensorDim::DataType target_dtype) const {
+                     TensorDim::DataType target_dtype,
+                     ml::train::ISA target_isa) const {
   NNTR_THROW_IF(!run_context, std::runtime_error)
     << __func__ << " layer needs to be finalized first!";
   getLayer()->save(file, *run_context, opt_var, mode,
                    (getTrainable() && mode == ml::train::ExecutionMode::TRAIN),
-                   target_dtype);
+                   target_dtype, target_isa);
 }
 
 void LayerNode::clearOptVar() {

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -790,10 +790,13 @@ public:
    * @param opt_var save optimizer variables
    * @param mode    execution mode
    * @param target_dtype target data type to convert weights before saving
+   * @param target_isa target ISA (Instruction Set Architecture) format for
+   * quantization (AUTO/X86/ARM)
    */
   void save(std::ofstream &file, bool opt_var = false,
             ml::train::ExecutionMode mode = ml::train::ExecutionMode::TRAIN,
-            TensorDim::DataType target_dtype = TensorDim::DataType::NONE) const;
+            TensorDim::DataType target_dtype = TensorDim::DataType::NONE,
+            ml::train::ISA target_isa = ml::train::ISA::AUTO) const;
 
   /**
    * @brief clear optimizer variable to initial state

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -620,7 +620,8 @@ void NeuralNetwork::backwarding(int iteration,
 void NeuralNetwork::save(
   const std::string &file_path, ml::train::ModelFormat format,
   TensorDim::DataType dtype,
-  const std::map<std::string, TensorDim::DataType> &layer_dtype_map) {
+  const std::map<std::string, TensorDim::DataType> &layer_dtype_map,
+  ml::train::ISA target_isa) {
   NNTR_THROW_IF(!initialized, std::runtime_error)
     << "Cannot save model if not initialized yet, path: " << file_path
     << " format: " << static_cast<unsigned>(format);
@@ -642,7 +643,7 @@ void NeuralNetwork::save(
       const auto &layer_node = *iter;
       auto it = layer_dtype_map.find(layer_node->getName());
       auto target_dtype = (it != layer_dtype_map.end()) ? it->second : dtype;
-      layer_node->save(model_file, false, exec_mode, target_dtype);
+      layer_node->save(model_file, false, exec_mode, target_dtype, target_isa);
     }
 
     if (opt && istrequal(opt->getType(), "adam")) {

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -270,14 +270,15 @@ public:
   /**
    * @copydoc Model::save(const std::string &file_path, ml::train::ModelFormat
    * format, TensorDim::DataType dtype, const std::map<std::string,
-   * TensorDim::DataType> &layer_dtype_map);
+   * TensorDim::DataType> &layer_dtype_map, ml::train::ISA
+   * target_device);
    */
   void
   save(const std::string &file_path,
        ml::train::ModelFormat format = ml::train::ModelFormat::MODEL_FORMAT_BIN,
        TensorDim::DataType dtype = TensorDim::DataType::NONE,
-       const std::map<std::string, TensorDim::DataType> &layer_dtype_map = {})
-    override;
+       const std::map<std::string, TensorDim::DataType> &layer_dtype_map = {},
+       ml::train::ISA target_isa = ml::train::ISA::AUTO) override;
 
   /**
    * @copydoc Model::load(const std::string &file_path, ml::train::ModelFormat

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -461,9 +461,16 @@ void repack_q4_0_to_q4_0_8(void *dst, void *src, size_t data_size,
   __ggml_repack_q4_0_to_q4_0_8(dst, src, data_size, M, N);
 }
 
-void repack_q4_0(void *dst, void *src, size_t data_size, const unsigned int M,
-                 const unsigned int N) {
-  __ggml_repack_q4_0_to_q4_0_4(dst, src, data_size, M, N);
+void repack_q4_0(void *dst, void *src, size_t data_size,
+                 const unsigned int M, const unsigned int N,
+                 ml::train::ISA target) {
+  if (target == ml::train::ISA::AUTO || target == ml::train::ISA::ARM) {
+    // Use ARM format (q4_0x4)
+    __ggml_repack_q4_0_to_q4_0_4(dst, src, data_size, M, N);
+  } else if (target == ml::train::ISA::X86) {
+    // Use x86 format (q4_0x8) for cross-platform quantization
+    __ggml_repack_q4_0_to_q4_0_8(dst, src, data_size, M, N);
+  }
 }
 
 void repack_q4_K(void *dst, void *src, size_t data_size, const unsigned int M,

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -14,6 +14,7 @@
 #define __ARM_COMPUTE_BACKEND_H__
 #ifdef __cplusplus
 
+#include <common.h>
 #include <cstdint>
 #include <limits.h>
 #include <limits>
@@ -1360,9 +1361,11 @@ void quantize_row_q8_K(const T *src, void *dst, int64_t k);
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
+ * @param target target ISA for repacking (AUTO=ARM native format)
  */
-void repack_q4_0(void *dst, void *src, size_t data_size, const unsigned int M,
-                 const unsigned int N);
+void repack_q4_0(void *dst, void *src, size_t data_size,
+                 const unsigned int M, const unsigned int N,
+                 ml::train::ISA target = ml::train::ISA::AUTO);
 
 /**
  * @brief repack q4K to q4Kx8

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -25,6 +25,7 @@
 #include <fallback.h>
 #endif
 
+#include <common.h>
 #include <cstdint>
 #include <tensor_dim.h>
 
@@ -1247,16 +1248,23 @@ template <typename T = float>
 extern void quantize_row_q8_K(const T *src, void *dst, int64_t k);
 
 /**
- * @brief repack q40 to q40x8
+ * @brief repack q40 to q40x8 or q40x4 depending on target ISA
+ *
+ * @details This function enables cross-platform quantization by allowing
+ * specification of target ISA format regardless of current platform.
+ * For example, quantizing on x86 but saving in ARM format.
  *
  * @param dst output repacked data
  * @param src input quantized data
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
+ * @param target target ISA format (AUTO uses current backend, X86 forces x86
+ * format, ARM forces ARM format)
  */
 extern void repack_q4_0(void *dst, void *src, size_t data_size,
-                        const unsigned int M, const unsigned int N);
+                        const unsigned int M, const unsigned int N,
+                        ml::train::ISA target = ml::train::ISA::AUTO);
 
 /**
  * @brief repack q4K to q4Kx8

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -404,9 +404,16 @@ template <> void dequantize_row_q8_K(const void *x, float *y, int64_t k) {
   __ggml_dequantize_row_q8_K(x, y, k);
 }
 
-void repack_q4_0(void *dst, void *src, size_t data_size, const unsigned int M,
-                 const unsigned int N) {
-  __ggml_repack_q4_0_to_q4_0_8(dst, src, data_size, M, N);
+void repack_q4_0(void *dst, void *src, size_t data_size,
+                 const unsigned int M, const unsigned int N,
+                 ml::train::ISA target) {
+  if (target == ml::train::ISA::AUTO || target == ml::train::ISA::X86) {
+    // Use x86 format (q4_0x8)
+    __ggml_repack_q4_0_to_q4_0_8(dst, src, data_size, M, N);
+  } else if (target == ml::train::ISA::ARM) {
+    // Use ARM format (q4_0x4) for cross-platform quantization
+    __ggml_repack_q4_0_to_q4_0_4(dst, src, data_size, M, N);
+  }
 }
 
 void repack_q4_0_to_q4_0_8(void *dst, void *src, size_t data_size,

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -15,6 +15,7 @@
 #define __x86_COMPUTE_BACKEND_H__
 #ifdef __cplusplus
 
+#include <common.h>
 #include <cstdint>
 #include <limits.h>
 #include <limits>
@@ -1095,16 +1096,25 @@ template <typename T = float>
 void quantize_row_q8_K(const T *src, void *dst, int64_t k);
 
 /**
- * @brief repack q40 to q40x8
+ * @brief repack q40 to q40x8 or q40x4 depending on target ISA
+ *
+ * @details This function enables cross-platform quantization by allowing
+ * specification of target ISA format regardless of current platform.
+ * For example, quantizing on x86 but saving in ARM format.
  *
  * @param dst output repacked q40x8
  * @param src input q40
  * @param data_size total weight size
  * @param M number of rows
  * @param N number of columns
+ * @param target target ISA format (AUTO uses current backend, X86 forces x86
+ * format, ARM forces ARM format)
  */
+
 void repack_q4_0(void *dst, void *src, size_t data_size, const unsigned int M,
-                 const unsigned int N);
+                 const unsigned int N,
+                 ml::train::ISA target = ml::train::ISA::AUTO);
+
 
 /**
  * @brief repack q4K to q4Kx8


### PR DESCRIPTION
## Dependency 
https://github.com/nntrainer/nntrainer/pull/3858
https://github.com/nntrainer/nntrainer/pull/3799

## Summary

This PR adds reverse RMS norm layer to CausalLM

Self evaluation:

Build test: [X]Passed [ ]Failed [ ]Skipped
Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jayden0701 [jrock.oh@samsung.com]