### PR TITLE
[Depend on #3867] Fix bugs in multi-turn

### DIFF
--- a/Applications/CausalLM/README.md
+++ b/Applications/CausalLM/README.md
@@ -28,6 +28,76 @@ The API allows loading models, running inference, and retrieving performance met
 
 For detailed documentation, please refer to [API Documentation](api/README.md).
 
+## Chat Template
+
+CausalLM supports automatic chat template formatting by reading the `chat_template` field from HuggingFace's `tokenizer_config.json`. This eliminates the need for hardcoded per-model chat formatting.
+
+### How It Works
+
+Most HuggingFace models include a `tokenizer_config.json` with a `chat_template` field (Jinja2 format) that defines how to format conversations. CausalLM includes a built-in mini Jinja2 renderer that processes these templates at runtime.
+
+When a `tokenizer_config.json` is present in the model directory:
+- **CLI (`nntr_causallm`)**: Raw user input provided as a command-line argument is automatically wrapped with the chat template.
+- **C API**: The `apply_chat_template()` function uses the dynamic template instead of hardcoded formats.
+
+If `tokenizer_config.json` is absent or does not contain a `chat_template` field, a warning is printed and the system falls back to hardcoded per-architecture templates (Llama, Qwen, Gemma3).
+
+### Supported Template Features
+
+The built-in Jinja2 renderer supports the following constructs commonly used in HuggingFace chat templates:
+
+| Feature | Example |
+|---------|---------|
+| For loops | `{% for message in messages %}...{% endfor %}` |
+| Conditionals | `{% if %}...{% elif %}...{% else %}...{% endif %}` |
+| Output expressions | `{{ bos_token }}` |
+| Variable assignment | `{% set offset = 1 %}` |
+| Dict/array access | `message['role']`, `messages[0]` |
+| String concatenation | `'<\|im_start\|>' + message['role']` |
+| Comparison operators | `==`, `!=`, `>`, `<`, `>=`, `<=` |
+| Boolean operators | `and`, `or`, `not` |
+| Loop variables | `loop.first`, `loop.last`, `loop.index`, `loop.index0` |
+| Filters | `\| trim`, `\| length`, `\| tojson` |
+| String methods | `.strip()`, `.startswith()`, `.upper()`, `.split()` |
+| Containment test | `'keyword' in message['content']` |
+| Namespace | `namespace()` for cross-scope variable mutation |
+| Whitespace control | `{%- -%}`, `{{- -}}` |
+
+### Required Files
+
+To use chat templates, ensure `tokenizer_config.json` is in your model directory alongside the other config files. This file is included by default when downloading models from HuggingFace.
+
+### Example
+
+```bash
+# With tokenizer_config.json present, raw input is auto-formatted:
+./nntr_causallm /path/to/model "What is machine learning?"
+
+# The input will be automatically wrapped, e.g. for Qwen3:
+# <|im_start|>user
+# What is machine learning?<|im_end|>
+# <|im_start|>assistant
+```
+
+### Multi-turn Conversations (API)
+
+The C API supports multi-turn conversations through `ChatMessage`:
+
+```cpp
+#include "chat_template.h"
+
+causallm::ChatTemplate tmpl = causallm::ChatTemplate::fromFile("tokenizer_config.json");
+
+std::vector<causallm::ChatMessage> messages = {
+  {"system", "You are a helpful assistant."},
+  {"user", "Hello!"},
+  {"assistant", "Hi there!"},
+  {"user", "How are you?"}
+};
+
+std::string formatted = tmpl.apply(messages);
+```
+
 ## How to run
 
 ### 1. Prepare Model Files

--- a/Applications/CausalLM/api/README.md
+++ b/Applications/CausalLM/api/README.md
@@ -117,7 +117,23 @@ Retrieves performance metrics of the last run.
 - `total_duration_ms`: Total execution time from start to finish.
 - `peak_memory_kb`: Peak resident set size (memory usage) in KB.
 
-## Usage Example
+#### `ErrorCode applyChatTemplate(const CausalLMChatMessage *messages, size_t num_messages, bool add_generation_prompt, const char **formattedText)`
+Applies chat template to messages without running inference. Useful for debugging or verifying prompt formatting.
+- **messages**: Array of `CausalLMChatMessage` structs (role + content).
+- **num_messages**: Number of messages in the array.
+- **add_generation_prompt**: Whether to append generation prompt (e.g., `<|im_start|>assistant\n`).
+- **formattedText**: Pointer to store the formatted prompt string.
+
+#### `ErrorCode runModelWithMessages(const CausalLMChatMessage *messages, size_t num_messages, bool add_generation_prompt, const char **outputText)`
+Applies chat template to messages and runs inference. Internally calls `applyChatTemplate()` then `runModel()`.
+- **messages**: Array of `CausalLMChatMessage` structs (role + content).
+- **num_messages**: Number of messages in the array.
+- **add_generation_prompt**: Whether to append generation prompt.
+- **outputText**: Pointer to store the generated output string.
+
+## Usage Examples
+
+### 1. Single Prompt
 
 ```c
 #include "causal_lm_api.h"
@@ -159,3 +175,65 @@ int main() {
     return 0;
 }
 ```
+
+### 2. Chat Template with Messages
+
+```c
+#include "causal_lm_api.h"
+#include <stdio.h>
+
+int main() {
+    Config config = {.use_chat_template = true, .debug_mode = false, .verbose = true};
+    setOptions(config);
+
+    loadModel(CAUSAL_LM_BACKEND_CPU, CAUSAL_LM_MODEL_QWEN3_0_6B,
+              CAUSAL_LM_QUANTIZATION_W16A16);
+
+    // System prompt + user message
+    CausalLMChatMessage msgs[] = {
+        {"system", "You are a helpful AI assistant."},
+        {"user",   "What is machine learning?"}
+    };
+
+    const char *output;
+    runModelWithMessages(msgs, 2, true, &output);
+    printf("Response: %s\n", output);
+
+    return 0;
+}
+```
+
+### 3. Conversation History
+
+```c
+    // Multiple user/assistant turns
+    CausalLMChatMessage msgs[] = {
+        {"user",      "Hello, how are you?"},
+        {"assistant", "I'm doing great. How can I help you today?"},
+        {"user",      "What is deep learning?"},
+        {"assistant", "Deep learning uses neural networks with many layers."},
+        {"user",      "How is it different from traditional ML?"}
+    };
+
+    const char *output;
+    runModelWithMessages(msgs, 5, true, &output);
+    printf("Response: %s\n", output);
+```
+
+### 4. Preview Formatted Prompt (No Inference)
+```c
+    CausalLMChatMessage msgs[] = {
+        {"system", "You are a helpful assistant."},
+        {"user",   "Hello!"}
+    };
+    const char *formatted;
+    applyChatTemplate(msgs, 2, true, &formatted);
+    printf("Formatted prompt:\n%s\n", formatted);
+    // Output (Qwen3):
+    // <|im_start|>system
+    // You are a helpful assistant.<|im_end|>
+    // <|im_start|>user
+    // Hello!<|im_end|>
+    // <|im_start|>assistant
+```
+

--- a/Applications/CausalLM/api/README.md
+++ b/Applications/CausalLM/api/README.md
@@ -96,7 +96,10 @@ Supported quantization formats.
 
 #### `ErrorCode setOptions(Config config)`
 Sets global configuration options.
-- **config**: Structure containing options like `use_chat_template` and `debug_mode`.
+- **config.use_chat_template**: Whether to apply chat template in `runModel()`.
+- **config.debug_mode**: Validate model files during initialization.
+- **config.verbose**: Print output during generation.
+- **config.chat_template_name**: Template name to select when `chat_template` is an array (e.g., `"default"`, `"tool_use"`). `NULL` defaults to `"default"`.
 
 #### `ErrorCode loadModel(BackendType compute, ModelType modeltype, ModelQuantizationType quant_type)`
 Loads a registered model.
@@ -237,3 +240,32 @@ int main() {
     // <|im_start|>assistant
 ```
 
+### 5. Named Template Selection (default / tool_use)
+
+When `tokenizer_config.json` contains an array of named templates, select by name:
+
+```c
+    // Use "default" template (normal conversation)
+    Config config;
+    config.use_chat_template = true;
+    config.chat_template_name = "default";
+    setOptions(config);
+    loadModel(...);
+
+    // Use "tool_use" template (function calling)
+    Config config;
+    config.use_chat_template = true;
+    config.chat_template_name = "tool_use";
+    setOptions(config);
+    loadModel(...);
+```
+
+Supported by models like Gemma3 that provide multiple templates:
+```json
+"chat_template": [
+    {"name": "default",  "template": "..."},
+    {"name": "tool_use", "template": "..."}
+]
+```
+
+If the requested name is not found, falls back to the first template with a warning.

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -47,6 +47,7 @@ static bool g_use_chat_template = false;
 static bool g_verbose = false;
 static std::string g_last_output = "";
 static double g_initialization_duration_ms = 0.0;
+static unsigned int g_turn_count = 0;
 static causallm::ChatTemplate g_chat_template;
 static std::string g_formatted_template;
 static std::string g_chat_template_name = "default";
@@ -165,6 +166,48 @@ static std::string apply_chat_template(const std::string &architecture,
            "<end_of_turn>\n<start_of_turn>model\n";
   }
   return input;
+}
+
+/**
+ * @brief Turn a freshly-rendered chat template into a continuation snippet
+ *        that splices cleanly onto an existing KV cache.
+ *
+ * Chat templates always re-render the full preamble (an auto-inserted
+ * system block, if no explicit system message was provided, followed by
+ * the user block and the generation prompt). On turn 0 that's exactly
+ * what we want. On turn N>0 the KV cache already contains the system
+ * preamble plus every prior user/assistant exchange, so we must:
+ *   1. strip the system prefix that the template re-emitted, and
+ *   2. insert a leading "\n" so the transition from the previous turn's
+ *      end-of-turn token to the new user block matches the pattern the
+ *      template itself uses between turns (e.g. Qwen's
+ *      "<|im_end|>\n<|im_start|>user").
+ *
+ * Unknown templates are returned unchanged with a leading "\n" — the
+ * newline is the minimal separator that is safe across ChatML, Gemma,
+ * and Llama-style formats.
+ */
+static std::string to_continuation(const std::string &templated) {
+  struct Marker {
+    const char *sys;
+    const char *user;
+  };
+  static const Marker markers[] = {
+    {"<|im_start|>system", "<|im_start|>user"},       // Qwen / ChatML
+    {"<start_of_turn>system", "<start_of_turn>user"}, // Gemma
+    {"<<SYS>>", "[INST]"},                            // Llama-2 style
+  };
+  for (const auto &m : markers) {
+    const size_t sys_len = std::strlen(m.sys);
+    if (templated.size() >= sys_len &&
+        templated.compare(0, sys_len, m.sys) == 0) {
+      const auto pos = templated.find(m.user);
+      if (pos != std::string::npos)
+        return "\n" + templated.substr(pos);
+      break;
+    }
+  }
+  return "\n" + templated;
 }
 
 static std::string get_quantization_suffix(ModelQuantizationType type) {
@@ -538,6 +581,7 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
 
     g_initialized = true;
     g_architecture = architecture;
+    g_turn_count = 0;
 
     auto finish_init = std::chrono::high_resolution_clock::now();
     auto init_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -570,6 +614,14 @@ ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
 
     if (g_use_chat_template) {
       input = apply_chat_template(g_architecture, input);
+      // On continuation turns, the KV cache already holds the system
+      // preamble and all prior Q/A pairs. Splice the freshly-rendered
+      // template onto that state by stripping the re-emitted system
+      // prefix and inserting a leading "\n" separator. resetConversation()
+      // zeroes g_turn_count, so turn 0 of a fresh dialogue is unaffected.
+      if (g_turn_count > 0) {
+        input = to_continuation(input);
+      }
     }
 
 // We assume single batch request for this API
@@ -588,9 +640,33 @@ ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
 
     *outputText = g_last_output.c_str();
 
+    ++g_turn_count;
+
   } catch (const std::exception &e) {
     std::cerr << "Exception in runModel: " << e.what() << std::endl;
     return CAUSAL_LM_ERROR_INFERENCE_FAILED;
+  }
+
+  return CAUSAL_LM_ERROR_NONE;
+}
+
+ErrorCode resetConversation(void) {
+  if (!g_initialized || !g_model) {
+    return CAUSAL_LM_ERROR_NOT_INITIALIZED;
+  }
+
+  try {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    auto causal_lm_model = dynamic_cast<causallm::CausalLM *>(g_model.get());
+    if (!causal_lm_model) {
+      return CAUSAL_LM_ERROR_UNKNOWN;
+    }
+    causal_lm_model->resetConversation();
+    g_last_output.clear();
+    g_turn_count = 0;
+  } catch (const std::exception &e) {
+    std::cerr << "Exception in resetConversation: " << e.what() << std::endl;
+    return CAUSAL_LM_ERROR_UNKNOWN;
   }
 
   return CAUSAL_LM_ERROR_NONE;

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -48,6 +48,7 @@ static bool g_verbose = false;
 static std::string g_last_output = "";
 static double g_initialization_duration_ms = 0.0;
 static causallm::ChatTemplate g_chat_template;
+static std::string g_formatted_template;
 
 static std::map<std::string, std::string> g_model_path_map = {
   {"QWEN3-0.6B", "qwen3-0.6b"},
@@ -617,4 +618,127 @@ ErrorCode getPerformanceMetrics(PerformanceMetrics *metrics) {
   }
 
   return CAUSAL_LM_ERROR_NONE;
+}
+
+/*****************************************************************************
+ * Chat Template API - role + content message support
+ *****************************************************************************/
+
+/**
+ * @brief Convert C message array to C++ ChatMessage vector
+ */
+static std::vector<causallm::ChatMessage>
+convertMessages(const CausalLMChatMessage *messages, size_t num_messages) {
+  std::vector<causallm::ChatMessage> result;
+  result.reserve(num_messages);
+  for (size_t i = 0; i < num_messages; ++i) {
+    causallm::ChatMessage msg;
+    msg.role = messages[i].role ? messages[i].role : "";
+    msg.content = messages[i].content ? messages[i].content : "";
+    result.push_back(std::move(msg));
+  }
+  return result;
+}
+
+/**
+ * @brief Apply chat template to messages with hardcoded fallback
+ */
+static std::string
+apply_chat_template_messages(const std::string &architecture,
+                             const std::vector<causallm::ChatMessage> &messages,
+                             bool add_generation_prompt) {
+  if (g_chat_template.isAvailable()) {
+    return g_chat_template.apply(messages, add_generation_prompt);
+  }
+
+  std::string result;
+
+  if (architecture == "LlamaForCausalLM") {
+    for (const auto &msg : messages) {
+      if (msg.role == "system") {
+        result += "<<SYS>>\n" + msg.content + "\n<</SYS>>\n\n";
+      } else if (msg.role == "user") {
+        result += "[INST] " + msg.content + " [/INST]";
+      } else if (msg.role == "assistant") {
+        result += msg.content + "\n";
+      }
+    }
+  } else if (architecture == "Qwen2ForCausalLM" ||
+             architecture == "Qwen3ForCausalLM" ||
+             architecture == "Qwen3MoeForCausalLM" ||
+             architecture == "Qwen3SlimMoeForCausalLM" ||
+             architecture == "Qwen3CachedSlimMoeForCausalLM") {
+    for (const auto &msg : messages) {
+      result +=
+        "<|im_start|>" + msg.role + "\n" + msg.content + "<|im_end|>\n";
+    }
+    if (add_generation_prompt) {
+      result += "<|im_start|>assistant\n";
+    }
+  } else if (architecture == "Gemma3ForCausalLM") {
+    for (const auto &msg : messages) {
+      if (msg.role == "user") {
+        result += "<start_of_turn>user\n" + msg.content + "<end_of_turn>\n";
+      } else if (msg.role == "assistant") {
+        result +=
+          "<start_of_turn>model\n" + msg.content + "<end_of_turn>\n";
+      }
+    }
+    if (add_generation_prompt) {
+      result += "<start_of_turn>model\n";
+    }
+  } else {
+    for (const auto &msg : messages) {
+      result += msg.content + "\n";
+    }
+  }
+
+  return result;
+}
+
+ErrorCode applyChatTemplate(const CausalLMChatMessage *messages,
+                            size_t num_messages, bool add_generation_prompt,
+                            const char **formattedText) {
+  if (messages == nullptr || num_messages == 0 || formattedText == nullptr) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  try {
+    std::lock_guard<std::mutex> lock(g_mutex);
+
+    auto chat_messages = convertMessages(messages, num_messages);
+    g_formatted_template = apply_chat_template_messages(
+      g_architecture, chat_messages, add_generation_prompt);
+
+    *formattedText = g_formatted_template.c_str();
+
+  } catch (const std::exception &e) {
+    std::cerr << "Exception in applyChatTemplate: " << e.what() << std::endl;
+    return CAUSAL_LM_ERROR_UNKNOWN;
+  }
+
+  return CAUSAL_LM_ERROR_NONE;
+}
+
+ErrorCode runModelWithMessages(const CausalLMChatMessage *messages,
+                               size_t num_messages, bool add_generation_prompt,
+                               const char **outputText) {
+  if (!g_initialized || !g_model) {
+    return CAUSAL_LM_ERROR_NOT_INITIALIZED;
+  }
+  if (outputText == nullptr) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  // Apply chat template to format the prompt
+  const char *formattedInput = nullptr;
+  ErrorCode err =
+    applyChatTemplate(messages, num_messages, add_generation_prompt,
+                      &formattedInput);
+  if (err != CAUSAL_LM_ERROR_NONE) {
+    return err;
+  }
+
+  // Run inference with the formatted prompt
+  return runModel(formattedInput, outputText);
 }

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "causal_lm.h"
+#include "chat_template.h"
 #include "gemma3_causallm.h"
 #include "gptoss_cached_slim_causallm.h"
 #include "gptoss_causallm.h"
@@ -46,6 +47,7 @@ static bool g_use_chat_template = false;
 static bool g_verbose = false;
 static std::string g_last_output = "";
 static double g_initialization_duration_ms = 0.0;
+static causallm::ChatTemplate g_chat_template;
 
 static std::map<std::string, std::string> g_model_path_map = {
   {"QWEN3-0.6B", "qwen3-0.6b"},
@@ -134,6 +136,12 @@ static const char *get_model_name_from_type(ModelType type) {
 
 static std::string apply_chat_template(const std::string &architecture,
                                        const std::string &input) {
+  // Use dynamic chat template from tokenizer_config.json if available
+  if (g_chat_template.isAvailable()) {
+    return g_chat_template.apply(input);
+  }
+
+  // Fallback: hardcoded per-architecture templates
   if (architecture == "LlamaForCausalLM") {
     // Llama 2/3 chat format: [INST] {prompt} [/INST]
     return "[INST] " + input + " [/INST]";
@@ -144,8 +152,6 @@ static std::string apply_chat_template(const std::string &architecture,
              architecture == "Qwen3CachedSlimMoeForCausalLM") {
     // Qwen chat format
     // <|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n
-    // Note: assuming model handles tokenizer specific special tokens or we
-    // might need to handle them raw if tokenizer enabled
     return "<|im_start|>user\n" + input + "<|im_end|>\n<|im_start|>assistant\n";
   } else if (architecture == "Gemma3ForCausalLM") {
     // Gemma chat format:
@@ -466,6 +472,12 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
         std::string t_file = nntr_cfg["tokenizer_file"];
         nntr_cfg["tokenizer_file"] = model_dir_path + "/" + t_file;
       }
+    }
+
+    // Load chat template from tokenizer_config.json if available
+    std::string tc_path = model_dir_path + "/tokenizer_config.json";
+    if (check_file_exists(tc_path)) {
+      g_chat_template = causallm::ChatTemplate::fromFile(tc_path);
     }
 
     // Construct weight file path

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -669,8 +669,7 @@ apply_chat_template_messages(const std::string &architecture,
              architecture == "Qwen3SlimMoeForCausalLM" ||
              architecture == "Qwen3CachedSlimMoeForCausalLM") {
     for (const auto &msg : messages) {
-      result +=
-        "<|im_start|>" + msg.role + "\n" + msg.content + "<|im_end|>\n";
+      result += "<|im_start|>" + msg.role + "\n" + msg.content + "<|im_end|>\n";
     }
     if (add_generation_prompt) {
       result += "<|im_start|>assistant\n";
@@ -680,8 +679,7 @@ apply_chat_template_messages(const std::string &architecture,
       if (msg.role == "user") {
         result += "<start_of_turn>user\n" + msg.content + "<end_of_turn>\n";
       } else if (msg.role == "assistant") {
-        result +=
-          "<start_of_turn>model\n" + msg.content + "<end_of_turn>\n";
+        result += "<start_of_turn>model\n" + msg.content + "<end_of_turn>\n";
       }
     }
     if (add_generation_prompt) {
@@ -732,9 +730,8 @@ ErrorCode runModelWithMessages(const CausalLMChatMessage *messages,
 
   // Apply chat template to format the prompt
   const char *formattedInput = nullptr;
-  ErrorCode err =
-    applyChatTemplate(messages, num_messages, add_generation_prompt,
-                      &formattedInput);
+  ErrorCode err = applyChatTemplate(messages, num_messages,
+                                    add_generation_prompt, &formattedInput);
   if (err != CAUSAL_LM_ERROR_NONE) {
     return err;
   }

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -478,6 +478,19 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
     std::string tc_path = model_dir_path + "/tokenizer_config.json";
     if (check_file_exists(tc_path)) {
       g_chat_template = causallm::ChatTemplate::fromFile(tc_path);
+      if (g_chat_template.isAvailable()) {
+        std::cout << "[Info] Chat template loaded from tokenizer_config.json"
+                  << std::endl;
+      } else {
+        std::cerr
+          << "[Warning] tokenizer_config.json found but chat template could "
+             "not be loaded. Falling back to hardcoded templates."
+          << std::endl;
+      }
+    } else {
+      std::cerr << "[Warning] tokenizer_config.json not found in "
+                << model_dir_path << ". Using hardcoded chat templates."
+                << std::endl;
     }
 
     // Construct weight file path

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -292,7 +292,9 @@ ErrorCode setOptions(Config config) {
   // Currently no options are being handled
   g_use_chat_template = config.use_chat_template;
   g_verbose = config.verbose;
-  g_chat_template_name = (config.chat_template_name != nullptr) ? config.chat_template_name : "default";
+  g_chat_template_name = (config.chat_template_name != nullptr)
+                           ? config.chat_template_name
+                           : "default";
   if (config.debug_mode) {
     // Ensure models are registered so we can validate them
     register_models();

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -53,6 +53,7 @@ static std::string g_chat_template_name = "default";
 
 static std::map<std::string, std::string> g_model_path_map = {
   {"QWEN3-0.6B", "qwen3-0.6b"},
+  {"QWEN3-1.7B", "qwen3-1.7b"},
 };
 
 /**
@@ -131,6 +132,8 @@ static const char *get_model_name_from_type(ModelType type) {
   switch (type) {
   case CAUSAL_LM_MODEL_QWEN3_0_6B:
     return "QWEN3-0.6B";
+  case CAUSAL_LM_MODEL_QWEN3_1_7B:
+    return "QWEN3-1.7B";
   default:
     return nullptr;
   }

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -49,6 +49,7 @@ static std::string g_last_output = "";
 static double g_initialization_duration_ms = 0.0;
 static causallm::ChatTemplate g_chat_template;
 static std::string g_formatted_template;
+static std::string g_chat_template_name = "default";
 
 static std::map<std::string, std::string> g_model_path_map = {
   {"QWEN3-0.6B", "qwen3-0.6b"},
@@ -291,6 +292,7 @@ ErrorCode setOptions(Config config) {
   // Currently no options are being handled
   g_use_chat_template = config.use_chat_template;
   g_verbose = config.verbose;
+  g_chat_template_name = (config.chat_template_name != nullptr) ? config.chat_template_name : "default";
   if (config.debug_mode) {
     // Ensure models are registered so we can validate them
     register_models();
@@ -478,7 +480,8 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
     // Load chat template from tokenizer_config.json if available
     std::string tc_path = model_dir_path + "/tokenizer_config.json";
     if (check_file_exists(tc_path)) {
-      g_chat_template = causallm::ChatTemplate::fromFile(tc_path);
+      g_chat_template =
+        causallm::ChatTemplate::fromFile(tc_path, g_chat_template_name);
       if (g_chat_template.isAvailable()) {
         std::cout << "[Info] Chat template loaded from tokenizer_config.json"
                   << std::endl;

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -488,6 +488,7 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
           << std::endl;
       }
     } else {
+      g_chat_template = causallm::ChatTemplate();
       std::cerr << "[Warning] tokenizer_config.json not found in "
                 << model_dir_path << ". Using hardcoded chat templates."
                 << std::endl;

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -53,6 +53,7 @@ typedef enum {
  */
 typedef enum {
   CAUSAL_LM_MODEL_QWEN3_0_6B = 0,
+  CAUSAL_LM_MODEL_QWEN3_1_7B = 1,
 } ModelType;
 
 /**

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -63,8 +63,9 @@ typedef struct {
   bool use_chat_template; /// < @brief Whether to apply chat template to input
   bool debug_mode; /// < @brief Check model file validity during initialization
   bool verbose;    /// < @brief Whether to print output during generation
-  const char *chat_template_name; /// < @brief Template name to select from array
-                                  ///  (e.g., "default", "tool_use"). NULL for "default".
+  const char
+    *chat_template_name; /// < @brief Template name to select from array
+                         ///  (e.g., "default", "tool_use"). NULL for "default".
 } Config;
 
 /**

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -123,6 +123,20 @@ WIN_EXPORT ErrorCode runModel(const char *inputTextPrompt,
                               const char **outputText);
 
 /**
+ * @brief Reset multi-turn conversation state.
+ *
+ * After this call, the next runModel() invocation starts a fresh
+ * conversation on the same loaded model: the KV-cache write position is
+ * rewound, accumulated token count is zeroed, and any pending decoder
+ * tokens from a prior turn are dropped. The loaded model weights and
+ * tokenizer are NOT touched.
+ *
+ * @return CAUSAL_LM_ERROR_NONE on success,
+ *         CAUSAL_LM_ERROR_NOT_INITIALIZED if no model is loaded.
+ */
+WIN_EXPORT ErrorCode resetConversation(void);
+
+/**
  * @brief Run inference with chat template formatted messages
  * @param messages Array of chat messages with role and content
  * @param num_messages Number of messages in the array

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -63,6 +63,8 @@ typedef struct {
   bool use_chat_template; /// < @brief Whether to apply chat template to input
   bool debug_mode; /// < @brief Check model file validity during initialization
   bool verbose;    /// < @brief Whether to print output during generation
+  const char *chat_template_name; /// < @brief Template name to select from array
+                                  ///  (e.g., "default", "tool_use"). NULL for "default".
 } Config;
 
 /**

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -84,6 +84,15 @@ typedef enum {
 } ModelQuantizationType;
 
 /**
+ * @brief Chat message structure for chat template formatting
+ * @note  Compatible with HuggingFace apply_chat_template() format
+ */
+typedef struct {
+  const char *role;    /**< Message role: "system", "user", or "assistant" */
+  const char *content; /**< Message content text */
+} CausalLMChatMessage;
+
+/**
  * @brief Load a model
  * @param compute Backend compute type
  * @param modeltype Model type
@@ -108,6 +117,32 @@ WIN_EXPORT ErrorCode getPerformanceMetrics(PerformanceMetrics *metrics);
  */
 WIN_EXPORT ErrorCode runModel(const char *inputTextPrompt,
                               const char **outputText);
+
+/**
+ * @brief Run inference with chat template formatted messages
+ * @param messages Array of chat messages with role and content
+ * @param num_messages Number of messages in the array
+ * @param add_generation_prompt Whether to append generation prompt at end
+ * @param outputText Buffer to store output text (owned by the library)
+ * @return ErrorCode
+ */
+WIN_EXPORT ErrorCode runModelWithMessages(const CausalLMChatMessage *messages,
+                                          size_t num_messages,
+                                          bool add_generation_prompt,
+                                          const char **outputText);
+
+/**
+ * @brief Apply chat template to messages without running inference
+ * @param messages Array of chat messages with role and content
+ * @param num_messages Number of messages in the array
+ * @param add_generation_prompt Whether to append generation prompt at end
+ * @param formattedText Buffer to store formatted text (owned by the library)
+ * @return ErrorCode
+ */
+WIN_EXPORT ErrorCode applyChatTemplate(const CausalLMChatMessage *messages,
+                                       size_t num_messages,
+                                       bool add_generation_prompt,
+                                       const char **formattedText);
 
 #ifdef __cplusplus
 }

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -13,6 +13,8 @@
 
 #include "../json.hpp"
 #include "causal_lm_api.h"
+#include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstring>
 #include <fstream>
@@ -92,7 +94,7 @@ void printUsage(const char *program_name) {
   std::cout << COLOR_YELLOW << "Usage:" << COLOR_RESET << "\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " <model_name> [prompt] [use_chat_template] [quantization] "
-               "[verbose] \n";
+               "[verbose] [--verify-memory|--multi-turn]\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " <model_name> --chat-file <path.json> [quantization] "
                "[verbose] \n\n";
@@ -114,9 +116,23 @@ void printUsage(const char *program_name) {
   std::cout << "  verbose           " << COLOR_GREEN << "OPTIONAL"
             << COLOR_RESET << "  - 0/1 or true/false (default: 0)\n\n";
 
+  std::cout << COLOR_CYAN << "Modes:" << COLOR_RESET << "\n";
+  std::cout << "  --verify-memory   " << COLOR_GREEN << "OPTIONAL"
+            << COLOR_RESET
+            << "  - Scripted 2-turn regression test, then reset+recheck\n";
+  std::cout << "  --multi-turn      " << COLOR_GREEN << "OPTIONAL"
+            << COLOR_RESET
+            << "  - Interactive REPL (/reset, /quit supported)\n\n";
+
   std::cout << COLOR_YELLOW << "Examples:" << COLOR_RESET << "\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " QWEN3-0.6B \"Tell me a joke\" 1 W4A32\n";
+  std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
+            << " QWEN3-0.6B \"Write a poem\" 1 W32A32 1\n";
+  std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
+            << " QWEN3-0.6B \"\" 1 W4A32 0 --verify-memory\n";
+  std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
+            << " QWEN3-0.6B \"\" 1 W4A32 0 --multi-turn\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " QWEN3-0.6B --chat-file chat.json W32A32 1\n\n";
 
@@ -130,10 +146,290 @@ void printUsage(const char *program_name) {
   std::cout << "    {\"role\": \"user\",      \"content\": \"How are you?\"}\n";
   std::cout << "  ]\n\n";
 }
+
+/**
+ * @brief Run a single inference turn and (optionally) print metrics.
+ * @param prompt        Input user prompt for this turn.
+ * @param verbose       Whether to stream tokens (matches global verbose flag).
+ * @param show_metrics  Whether to dump performance metrics for this turn.
+ * @param[out] out_text If non-null, receives the generated assistant text.
+ * @return ErrorCode from runModel().
+ */
+ErrorCode run_turn(const char *prompt, bool verbose, bool show_metrics,
+                   std::string *out_text = nullptr) {
+  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
+  std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
+            << "\n\n";
+
+  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET << "Running inference...\n\n";
+
+  const char *outputText = nullptr;
+
+  if (verbose) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GRAY;
+  }
+
+  ErrorCode err = runModel(prompt, &outputText);
+
+  if (verbose) {
+    std::cout << COLOR_RESET << "\n\n";
+  }
+
+  if (err != CAUSAL_LM_ERROR_NONE) {
+    printError("Failed to run model");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+    return err;
+  }
+
+  if (outputText) {
+    if (out_text)
+      *out_text = outputText;
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
+    std::string out(outputText);
+    size_t pos = 0;
+    while (pos < out.length()) {
+      size_t newlinePos = out.find('\n', pos);
+      if (newlinePos == std::string::npos) {
+        newlinePos = out.length();
+      }
+      std::string line = out.substr(pos, newlinePos - pos);
+      std::cout << line;
+      if (newlinePos < out.length()) {
+        std::cout << "\n  ";
+        pos = newlinePos + 1;
+      } else {
+        pos = out.length();
+      }
+    }
+    std::cout << COLOR_RESET << "\n\n";
+  } else {
+    printWarning("No output generated");
+  }
+
+  if (!show_metrics)
+    return err;
+
+  PerformanceMetrics metrics;
+  ErrorCode merr = getPerformanceMetrics(&metrics);
+  if (merr != CAUSAL_LM_ERROR_NONE) {
+    printWarning("Failed to get metrics");
+    std::cout << "  Error code: " << static_cast<int>(merr) << "\n";
+    return err;
+  }
+
+  double prefill_tps =
+    metrics.prefill_duration_ms > 0
+      ? (metrics.prefill_tokens / metrics.prefill_duration_ms * 1000.0)
+      : 0.0;
+  double gen_tps =
+    metrics.generation_duration_ms > 0
+      ? (metrics.generation_tokens / metrics.generation_duration_ms * 1000.0)
+      : 0.0;
+
+  std::cout << COLOR_CYAN << "  📊 " << COLOR_RESET << COLOR_BOLD
+            << "Prefill" << COLOR_RESET << "  tokens="
+            << metrics.prefill_tokens << "  "
+            << std::fixed << std::setprecision(2)
+            << metrics.prefill_duration_ms << " ms  "
+            << COLOR_GREEN << std::setprecision(1) << prefill_tps
+            << COLOR_RESET << " tok/s\n";
+  std::cout << COLOR_CYAN << "  📊 " << COLOR_RESET << COLOR_BOLD
+            << "Generation" << COLOR_RESET << " tokens="
+            << metrics.generation_tokens << "  "
+            << std::fixed << std::setprecision(2)
+            << metrics.generation_duration_ms << " ms  "
+            << COLOR_GREEN << std::setprecision(1) << gen_tps
+            << COLOR_RESET << " tok/s\n\n";
+
+  return err;
+}
+
+/**
+ * @brief Lower-case a string in-place.
+ */
+std::string to_lower(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return s;
+}
+
+/**
+ * @brief Trim ASCII whitespace from both ends.
+ */
+std::string trim(const std::string &s) {
+  size_t b = 0, e = s.size();
+  while (b < e && std::isspace(static_cast<unsigned char>(s[b])))
+    ++b;
+  while (e > b && std::isspace(static_cast<unsigned char>(s[e - 1])))
+    --e;
+  return s.substr(b, e - b);
+}
+
+/**
+ * @brief Scripted multi-turn regression: ensure the model remembers
+ *        a name across turns, and forgets it after resetConversation().
+ * @return 0 on success, non-zero on assertion failure.
+ */
+int run_verify_memory(bool verbose) {
+  printSection("Verify Memory: Multi-Turn Regression");
+
+  const char *turn1 = "My name is Alice. Please remember my name.";
+  const char *turn2 = "What is my name?";
+
+  std::cout << COLOR_BOLD << "Turn 1 (set context)" << COLOR_RESET << "\n";
+  std::string out1;
+  if (run_turn(turn1, verbose, true, &out1) != CAUSAL_LM_ERROR_NONE) {
+    printError("Turn 1 failed");
+    return 1;
+  }
+
+  std::cout << COLOR_BOLD << "Turn 2 (recall)" << COLOR_RESET << "\n";
+  std::string out2;
+  if (run_turn(turn2, verbose, true, &out2) != CAUSAL_LM_ERROR_NONE) {
+    printError("Turn 2 failed");
+    return 1;
+  }
+
+  bool remembered = to_lower(out2).find("alice") != std::string::npos;
+  if (!remembered) {
+    printError("Turn 2 output did not contain 'Alice' — multi-turn context "
+               "was NOT preserved.");
+    return 2;
+  }
+  printSuccess("Turn 2 recalled 'Alice' — multi-turn context preserved.");
+
+  std::cout << COLOR_BOLD << "Calling resetConversation()..." << COLOR_RESET
+            << "\n";
+  ErrorCode rerr = resetConversation();
+  if (rerr != CAUSAL_LM_ERROR_NONE) {
+    printError("resetConversation() failed");
+    std::cerr << "  Error code: " << static_cast<int>(rerr) << "\n";
+    return 3;
+  }
+  printSuccess("Conversation state reset.");
+
+  std::cout << COLOR_BOLD << "Turn 3 (post-reset recall, should NOT know)"
+            << COLOR_RESET << "\n";
+  std::string out3;
+  if (run_turn(turn2, verbose, true, &out3) != CAUSAL_LM_ERROR_NONE) {
+    printError("Turn 3 failed");
+    return 4;
+  }
+
+  // Accept any output that does NOT strongly assert the name is Alice.
+  // Small models may still emit the token "alice" while hedging (e.g.
+  // "I'm not sure — could it be Alice?"). We only flag a true leak:
+  // a confident affirmative statement such as "your name is alice" or
+  // "you are alice".
+  const std::string out3_lc = to_lower(out3);
+  const char *leak_patterns[] = {
+    "your name is alice",
+    "you are alice",
+    "you're alice",
+    "name is alice",
+    "you said your name is alice",
+  };
+  bool leaked = false;
+  for (const char *p : leak_patterns) {
+    if (out3_lc.find(p) != std::string::npos) {
+      leaked = true;
+      break;
+    }
+  }
+  if (leaked) {
+    printError("Turn 3 affirmatively stated the name is Alice AFTER reset — "
+               "resetConversation() did not clear context.");
+    return 5;
+  }
+  if (out3_lc.find("alice") != std::string::npos) {
+    printWarning("Turn 3 mentions 'alice' but does not affirmatively claim "
+                 "the name — accepted as hedged response.");
+  }
+  printSuccess("Turn 3 did not assert 'Alice' — reset cleared context.");
+
+  printLine("═", 63);
+  std::cout << COLOR_BOLD << COLOR_GREEN
+            << "  ✓ verify-memory PASSED" << COLOR_RESET << "\n";
+  printLine("═", 63);
+  std::cout << "\n";
+  return 0;
+}
+
+/**
+ * @brief Interactive multi-turn REPL.
+ *        Commands: /reset (clear context), /quit (exit), EOF -> exit.
+ */
+int run_multi_turn_repl(bool verbose) {
+  printSection("Multi-Turn REPL");
+  std::cout << "Commands: " << COLOR_BOLD << "/reset" << COLOR_RESET
+            << " clears context, " << COLOR_BOLD << "/quit" << COLOR_RESET
+            << " (or EOF) exits.\n\n";
+
+  while (true) {
+    std::cout << COLOR_BOLD << COLOR_CYAN << "you> " << COLOR_RESET
+              << std::flush;
+    std::string line;
+    if (!std::getline(std::cin, line)) {
+      std::cout << "\n[EOF] exiting.\n";
+      return 0;
+    }
+    std::string cmd = trim(line);
+    if (cmd.empty())
+      continue;
+    if (cmd == "/quit" || cmd == "/exit") {
+      std::cout << "Bye.\n";
+      return 0;
+    }
+    if (cmd == "/reset") {
+      ErrorCode rerr = resetConversation();
+      if (rerr != CAUSAL_LM_ERROR_NONE) {
+        printError("resetConversation() failed");
+        std::cerr << "  Error code: " << static_cast<int>(rerr) << "\n";
+      } else {
+        printSuccess("Conversation state reset.");
+      }
+      continue;
+    }
+    std::string out;
+    ErrorCode err = run_turn(cmd.c_str(), verbose, true, &out);
+    if (err != CAUSAL_LM_ERROR_NONE) {
+      printError("Turn failed; you may want to /reset.");
+    }
+  }
+  return 0;
+}
 } // namespace
 
 int main(int argc, char *argv[]) {
   printLogo();
+
+  // Strip mode flags (--verify-memory / --multi-turn) out of argv before
+  // the existing positional-argument parser runs, so older invocations
+  // remain byte-identical.
+  bool mode_verify_memory = false;
+  bool mode_multi_turn = false;
+  std::vector<char *> filtered_argv;
+  filtered_argv.reserve(argc);
+  for (int i = 0; i < argc; ++i) {
+    std::string a = argv[i];
+    if (a == "--verify-memory") {
+      mode_verify_memory = true;
+      continue;
+    }
+    if (a == "--multi-turn") {
+      mode_multi_turn = true;
+      continue;
+    }
+    filtered_argv.push_back(argv[i]);
+  }
+  if (mode_verify_memory && mode_multi_turn) {
+    printError("--verify-memory and --multi-turn are mutually exclusive.");
+    return 1;
+  }
+  argc = static_cast<int>(filtered_argv.size());
+  argv = filtered_argv.data();
 
   if (argc < 2) {
     printSection("ERROR: Missing Required Arguments");
@@ -142,7 +438,9 @@ int main(int argc, char *argv[]) {
   }
 
   const char *model_name = argv[1];
-  const char *prompt = "Hello, how are you?";
+  const char *prompt = (argc >= 3 && argv[2][0] != '\0')
+                         ? argv[2]
+                         : "Hello, how are you?";
   bool use_chat_template = true;
   std::string chat_file_path = "";
   std::string quant_str = "UNKNOWN";
@@ -255,6 +553,18 @@ int main(int argc, char *argv[]) {
     return 1;
   }
   printSuccess("Model loaded successfully");
+
+  // Mode dispatch: --verify-memory and --multi-turn run on top of the
+  // already-loaded model and exit; otherwise fall back to the default
+  // test flow below (applyChatTemplate + runModel + runModelWithMessages).
+  if (mode_verify_memory) {
+    int rc = run_verify_memory(verbose);
+    return rc;
+  }
+  if (mode_multi_turn) {
+    return run_multi_turn_repl(verbose);
+  }
+
 
   // ── --chat-file mode: load messages from JSON file ──
   using json = nlohmann::json;

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -12,8 +12,10 @@
  */
 
 #include "causal_lm_api.h"
+#include "../json.hpp"
 #include <cmath>
 #include <cstring>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -90,6 +92,9 @@ void printUsage(const char *program_name) {
   std::cout << COLOR_YELLOW << "Usage:" << COLOR_RESET << "\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " <model_name> [prompt] [use_chat_template] [quantization] "
+               "[verbose] \n";
+  std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
+            << " <model_name> --chat-file <path.json> [quantization] "
                "[verbose] \n\n";
 
   std::cout << COLOR_CYAN << "Arguments:" << COLOR_RESET << "\n";
@@ -98,6 +103,9 @@ void printUsage(const char *program_name) {
   std::cout << "  prompt            " << COLOR_GREEN << "OPTIONAL"
             << COLOR_RESET
             << "  - Input prompt (default: 'Hello, how are you?')\n";
+  std::cout << "  --chat-file       " << COLOR_GREEN << "OPTIONAL"
+            << COLOR_RESET
+            << "  - JSON file with chat messages [{role, content}, ...]\n";
   std::cout << "  use_chat_template " << COLOR_GREEN << "OPTIONAL"
             << COLOR_RESET << "  - 0/1 or true/false (default: 1)\n";
   std::cout << "  quantization      " << COLOR_GREEN << "OPTIONAL"
@@ -110,7 +118,15 @@ void printUsage(const char *program_name) {
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " QWEN3-0.6B \"Tell me a joke\" 1 W4A32\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
-            << " QWEN3-0.6B \"Write a poem\" 1 W32A32 1\n\n";
+            << " QWEN3-0.6B --chat-file chat.json W32A32 1\n\n";
+
+  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET << "\n";
+  std::cout << "  [\n";
+  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful assistant.\"},\n";
+  std::cout << "    {\"role\": \"user\",      \"content\": \"Hello!\"},\n";
+  std::cout << "    {\"role\": \"assistant\", \"content\": \"Hi there!\"},\n";
+  std::cout << "    {\"role\": \"user\",      \"content\": \"How are you?\"}\n";
+  std::cout << "  ]\n\n";
 }
 } // namespace
 
@@ -124,30 +140,51 @@ int main(int argc, char *argv[]) {
   }
 
   const char *model_name = argv[1];
-  const char *prompt = (argc >= 3) ? argv[2] : "Hello, how are you?";
+  const char *prompt = "Hello, how are you?";
   bool use_chat_template = true;
-  if (argc >= 4) {
-    use_chat_template =
-      (std::string(argv[3]) == "1" || std::string(argv[3]) == "true");
-  }
-
+  std::string chat_file_path = "";
   std::string quant_str = "UNKNOWN";
   ModelQuantizationType quant_type = CAUSAL_LM_QUANTIZATION_UNKNOWN;
-  if (argc >= 5) {
-    quant_str = std::string(argv[4]);
-    if (quant_str == "W4A32")
-      quant_type = CAUSAL_LM_QUANTIZATION_W4A32;
-    else if (quant_str == "W16A16")
-      quant_type = CAUSAL_LM_QUANTIZATION_W16A16;
-    else if (quant_str == "W8A16")
-      quant_type = CAUSAL_LM_QUANTIZATION_W8A16;
-    else if (quant_str == "W32A32")
-      quant_type = CAUSAL_LM_QUANTIZATION_W32A32;
-  }
-
   bool verbose = true;
-  if (argc >= 6) {
-    verbose = (std::string(argv[5]) == "1" || std::string(argv[5]) == "true");
+
+  // Parse --chat-file mode: <model> --chat-file <path> [quant] [verbose]
+  if (argc >= 4 && std::string(argv[2]) == "--chat-file") {
+    chat_file_path = argv[3];
+    use_chat_template = true;
+    if (argc >= 5) {
+      quant_str = std::string(argv[4]);
+      if (quant_str == "W4A32")
+        quant_type = CAUSAL_LM_QUANTIZATION_W4A32;
+      else if (quant_str == "W16A16")
+        quant_type = CAUSAL_LM_QUANTIZATION_W16A16;
+      else if (quant_str == "W8A16")
+        quant_type = CAUSAL_LM_QUANTIZATION_W8A16;
+      else if (quant_str == "W32A32")
+        quant_type = CAUSAL_LM_QUANTIZATION_W32A32;
+    }
+    if (argc >= 6) {
+      verbose = (std::string(argv[5]) == "1" || std::string(argv[5]) == "true");
+    }
+  } else {
+    // Normal mode: <model> [prompt] [chat_template] [quant] [verbose]
+    if (argc >= 3)
+      prompt = argv[2];
+    if (argc >= 4)
+      use_chat_template =
+        (std::string(argv[3]) == "1" || std::string(argv[3]) == "true");
+    if (argc >= 5) {
+      quant_str = std::string(argv[4]);
+      if (quant_str == "W4A32")
+        quant_type = CAUSAL_LM_QUANTIZATION_W4A32;
+      else if (quant_str == "W16A16")
+        quant_type = CAUSAL_LM_QUANTIZATION_W16A16;
+      else if (quant_str == "W8A16")
+        quant_type = CAUSAL_LM_QUANTIZATION_W8A16;
+      else if (quant_str == "W32A32")
+        quant_type = CAUSAL_LM_QUANTIZATION_W32A32;
+    }
+    if (argc >= 6)
+      verbose = (std::string(argv[5]) == "1" || std::string(argv[5]) == "true");
   }
 
   printSection("Configuration");
@@ -155,6 +192,9 @@ int main(int argc, char *argv[]) {
   printInfo("Use Chat Template", use_chat_template ? "true" : "false");
   printInfo("Quantization", quant_str);
   printInfo("Verbose", verbose ? "true" : "false");
+  if (!chat_file_path.empty()) {
+    printInfo("Chat File", chat_file_path);
+  }
   std::cout << "\n";
 
   printSection("Initialization");
@@ -196,7 +236,130 @@ int main(int argc, char *argv[]) {
   }
   printSuccess("Model loaded successfully");
 
-  printSection("Inference");
+  // ── --chat-file mode: load messages from JSON file ──
+  using json = nlohmann::json;
+  std::vector<CausalLMChatMessage> file_msgs;
+  std::vector<std::string> role_strs, content_strs;
+
+  if (!chat_file_path.empty()) {
+    printSection("Test: Chat Template from File");
+    std::ifstream chat_file(chat_file_path);
+    if (!chat_file.is_open()) {
+      printError("Cannot open chat file: " + chat_file_path);
+      return 1;
+    }
+
+    json chat_json;
+    try {
+      chat_file >> chat_json;
+    } catch (const json::parse_error &e) {
+      printError("JSON parse error: " + std::string(e.what()));
+      return 1;
+    }
+
+    // Support both formats:
+    //   Array:  [{"role":"user","content":"Hi"}]
+    //   Object: {"chat": [{"role":"user","content":"Hi"}]}
+    json messages_json;
+    if (chat_json.is_array()) {
+      messages_json = chat_json;
+    } else if (chat_json.is_object() && chat_json.contains("chat") &&
+               chat_json["chat"].is_array()) {
+      messages_json = chat_json["chat"];
+    } else {
+      printError("Chat file must contain a JSON array or {\"chat\": [...]}");
+      return 1;
+    }
+
+    // Store strings to keep pointers valid
+    for (const auto &msg : messages_json) {
+      if (msg.contains("role") && msg.contains("content")) {
+        role_strs.push_back(msg["role"].get<std::string>());
+        content_strs.push_back(msg["content"].get<std::string>());
+      }
+    }
+    for (size_t i = 0; i < role_strs.size(); ++i) {
+      file_msgs.push_back({role_strs[i].c_str(), content_strs[i].c_str()});
+    }
+
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Messages from "
+              << chat_file_path << ":\n";
+    for (size_t i = 0; i < file_msgs.size(); ++i) {
+      std::cout << COLOR_YELLOW << "  [" << file_msgs[i].role << "] "
+                << COLOR_RESET << file_msgs[i].content << "\n";
+    }
+    std::cout << "\n";
+
+    // Test applyChatTemplate with file messages
+    const char *formattedText = nullptr;
+    err = applyChatTemplate(file_msgs.data(), file_msgs.size(), true,
+                            &formattedText);
+    if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
+      std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
+                << "\n\n";
+      printSuccess("applyChatTemplate works");
+    } else {
+      printError("applyChatTemplate failed");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+    }
+
+    // Test runModelWithMessages with file messages
+    printSection("Test: runModelWithMessages from File");
+    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+              << "Running inference with messages...\n\n";
+
+    const char *msgOutput = nullptr;
+    if (verbose) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GRAY;
+    }
+
+    err = runModelWithMessages(file_msgs.data(), file_msgs.size(), true,
+                               &msgOutput);
+
+    if (verbose) {
+      std::cout << COLOR_RESET << "\n\n";
+    }
+
+    if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+                << "\n\n";
+      printSuccess("runModelWithMessages works");
+    } else {
+      printError("runModelWithMessages failed");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+    }
+
+    // Skip to performance metrics
+    goto print_metrics;
+  }
+
+  // ── Test 1: applyChatTemplate (no inference, format only) ──
+  {
+  printSection("Test: applyChatTemplate");
+  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+            << "Testing chat template formatting (no inference)...\n\n";
+
+  CausalLMChatMessage tmpl_msgs[] = {
+    {"system", "You are a helpful AI assistant."},
+    {"user", prompt}};
+
+  const char *formattedText = nullptr;
+  err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
+  if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
+    std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
+              << "\n\n";
+    printSuccess("applyChatTemplate works");
+  } else {
+    printError("applyChatTemplate failed");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+  }
+
+  // ── Test 2: runModel (single prompt, existing API) ──
+  printSection("Test: runModel (single prompt)");
   std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
   std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
             << "\n\n";
@@ -246,6 +409,48 @@ int main(int argc, char *argv[]) {
     printWarning("No output generated");
   }
 
+  // ── Test 3: runModelWithMessages (chat template with messages) ──
+  printSection("Test: runModelWithMessages");
+  CausalLMChatMessage chat_msgs[] = {
+    {"system", "You are a helpful AI assistant."},
+    {"user", prompt}};
+
+  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+            << "Messages:\n";
+  for (size_t i = 0; i < 2; ++i) {
+    std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
+              << COLOR_RESET << chat_msgs[i].content << "\n";
+  }
+  std::cout << "\n";
+
+  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+            << "Running inference with messages...\n\n";
+
+  const char *msgOutput = nullptr;
+
+  if (verbose) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GRAY;
+  }
+
+  err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
+
+  if (verbose) {
+    std::cout << COLOR_RESET << "\n\n";
+  }
+
+  if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+              << "\n\n";
+    printSuccess("runModelWithMessages works");
+  } else {
+    printError("runModelWithMessages failed");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+  }
+  } // end of normal mode tests
+
+print_metrics:
   printSection("Performance Metrics");
   PerformanceMetrics metrics;
   err = getPerformanceMetrics(&metrics);

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -99,7 +99,7 @@ void printUsage(const char *program_name) {
 
   std::cout << COLOR_CYAN << "Arguments:" << COLOR_RESET << "\n";
   std::cout << "  model_name        " << COLOR_BOLD << "REQUIRED" << COLOR_RESET
-            << "  - Model name (e.g., QWEN3-0.6B)\n";
+            << "  - Model name (e.g., QWEN3-0.6B, QWEN3-1.7B)\n";
   std::cout << "  prompt            " << COLOR_GREEN << "OPTIONAL"
             << COLOR_RESET
             << "  - Input prompt (default: 'Hello, how are you?')\n";
@@ -239,6 +239,8 @@ int main(int argc, char *argv[]) {
   std::string model_name_str(model_name);
   if (model_name_str == "QWEN3-0.6B") {
     model_type = CAUSAL_LM_MODEL_QWEN3_0_6B;
+  } else if (model_name_str == "QWEN3-1.7B") {
+    model_type = CAUSAL_LM_MODEL_QWEN3_1_7B;
   } else {
     std::cout << COLOR_YELLOW << "⚠ Warning: Unknown model name '"
               << model_name_str << "'. Defaulting to QWEN3-0.6B." << COLOR_RESET

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -11,8 +11,8 @@
  *
  */
 
-#include "causal_lm_api.h"
 #include "../json.hpp"
+#include "causal_lm_api.h"
 #include <cmath>
 #include <cstring>
 #include <fstream>
@@ -120,9 +120,11 @@ void printUsage(const char *program_name) {
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " QWEN3-0.6B --chat-file chat.json W32A32 1\n\n";
 
-  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET << "\n";
+  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET
+            << "\n";
   std::cout << "  [\n";
-  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful assistant.\"},\n";
+  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful "
+               "assistant.\"},\n";
   std::cout << "    {\"role\": \"user\",      \"content\": \"Hello!\"},\n";
   std::cout << "    {\"role\": \"assistant\", \"content\": \"Hi there!\"},\n";
   std::cout << "    {\"role\": \"user\",      \"content\": \"How are you?\"}\n";
@@ -148,7 +150,8 @@ int main(int argc, char *argv[]) {
   bool verbose = true;
   std::string template_name = "default";
 
-  // Parse --chat-file mode: <model> --chat-file <path> [--template name] [quant]
+  // Parse --chat-file mode: <model> --chat-file <path> [--template name]
+  // [quant]
   //                          [verbose]
   if (argc >= 4 && std::string(argv[2]) == "--chat-file") {
     chat_file_path = argv[3];
@@ -175,8 +178,8 @@ int main(int argc, char *argv[]) {
     }
     next_arg++;
     if (next_arg < argc) {
-      verbose =
-        (std::string(argv[next_arg]) == "1" || std::string(argv[next_arg]) == "true");
+      verbose = (std::string(argv[next_arg]) == "1" ||
+                 std::string(argv[next_arg]) == "true");
     }
   } else {
     // Normal mode: <model> [prompt] [chat_template] [quant] [verbose]
@@ -353,116 +356,114 @@ int main(int argc, char *argv[]) {
 
   // ── Test 1: applyChatTemplate (no inference, format only) ──
   {
-  printSection("Test: applyChatTemplate");
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
-            << "Testing chat template formatting (no inference)...\n\n";
+    printSection("Test: applyChatTemplate");
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+              << "Testing chat template formatting (no inference)...\n\n";
 
-  CausalLMChatMessage tmpl_msgs[] = {
-    {"system", "You are a helpful AI assistant."},
-    {"user", prompt}};
+    CausalLMChatMessage tmpl_msgs[] = {
+      {"system", "You are a helpful AI assistant."}, {"user", prompt}};
 
-  const char *formattedText = nullptr;
-  err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
-  if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
-    std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
-              << "\n\n";
-    printSuccess("applyChatTemplate works");
-  } else {
-    printError("applyChatTemplate failed");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-  }
-
-  // ── Test 2: runModel (single prompt, existing API) ──
-  printSection("Test: runModel (single prompt)");
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
-  std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
-            << "\n\n";
-
-  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET << "Running inference...\n\n";
-
-  const char *outputText = nullptr;
-
-  if (verbose) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GRAY;
-  }
-
-  err = runModel(prompt, &outputText);
-
-  if (verbose) {
-    std::cout << COLOR_RESET << "\n\n";
-  }
-
-  if (err != CAUSAL_LM_ERROR_NONE) {
-    printError("Failed to run model");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-    return 1;
-  }
-
-  if (outputText) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
-    std::string out(outputText);
-    size_t pos = 0;
-    while (pos < out.length()) {
-      size_t newlinePos = out.find('\n', pos);
-      if (newlinePos == std::string::npos) {
-        newlinePos = out.length();
-      }
-      std::string line = out.substr(pos, newlinePos - pos);
-      std::cout << line;
-      if (newlinePos < out.length()) {
-        std::cout << "\n  ";
-        pos = newlinePos + 1;
-      } else {
-        pos = out.length();
-      }
+    const char *formattedText = nullptr;
+    err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
+    if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
+      std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
+                << "\n\n";
+      printSuccess("applyChatTemplate works");
+    } else {
+      printError("applyChatTemplate failed");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
     }
-    std::cout << COLOR_RESET << "\n\n";
-  } else {
-    printWarning("No output generated");
-  }
 
-  // ── Test 3: runModelWithMessages (chat template with messages) ──
-  printSection("Test: runModelWithMessages");
-  CausalLMChatMessage chat_msgs[] = {
-    {"system", "You are a helpful AI assistant."},
-    {"user", prompt}};
-
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
-            << "Messages:\n";
-  for (size_t i = 0; i < 2; ++i) {
-    std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
-              << COLOR_RESET << chat_msgs[i].content << "\n";
-  }
-  std::cout << "\n";
-
-  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
-            << "Running inference with messages...\n\n";
-
-  const char *msgOutput = nullptr;
-
-  if (verbose) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GRAY;
-  }
-
-  err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
-
-  if (verbose) {
-    std::cout << COLOR_RESET << "\n\n";
-  }
-
-  if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+    // ── Test 2: runModel (single prompt, existing API) ──
+    printSection("Test: runModel (single prompt)");
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
+    std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
               << "\n\n";
-    printSuccess("runModelWithMessages works");
-  } else {
-    printError("runModelWithMessages failed");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-  }
+
+    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+              << "Running inference...\n\n";
+
+    const char *outputText = nullptr;
+
+    if (verbose) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GRAY;
+    }
+
+    err = runModel(prompt, &outputText);
+
+    if (verbose) {
+      std::cout << COLOR_RESET << "\n\n";
+    }
+
+    if (err != CAUSAL_LM_ERROR_NONE) {
+      printError("Failed to run model");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+      return 1;
+    }
+
+    if (outputText) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
+      std::string out(outputText);
+      size_t pos = 0;
+      while (pos < out.length()) {
+        size_t newlinePos = out.find('\n', pos);
+        if (newlinePos == std::string::npos) {
+          newlinePos = out.length();
+        }
+        std::string line = out.substr(pos, newlinePos - pos);
+        std::cout << line;
+        if (newlinePos < out.length()) {
+          std::cout << "\n  ";
+          pos = newlinePos + 1;
+        } else {
+          pos = out.length();
+        }
+      }
+      std::cout << COLOR_RESET << "\n\n";
+    } else {
+      printWarning("No output generated");
+    }
+
+    // ── Test 3: runModelWithMessages (chat template with messages) ──
+    printSection("Test: runModelWithMessages");
+    CausalLMChatMessage chat_msgs[] = {
+      {"system", "You are a helpful AI assistant."}, {"user", prompt}};
+
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Messages:\n";
+    for (size_t i = 0; i < 2; ++i) {
+      std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
+                << COLOR_RESET << chat_msgs[i].content << "\n";
+    }
+    std::cout << "\n";
+
+    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+              << "Running inference with messages...\n\n";
+
+    const char *msgOutput = nullptr;
+
+    if (verbose) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GRAY;
+    }
+
+    err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
+
+    if (verbose) {
+      std::cout << COLOR_RESET << "\n\n";
+    }
+
+    if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+                << "\n\n";
+      printSuccess("runModelWithMessages works");
+    } else {
+      printError("runModelWithMessages failed");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+    }
   } // end of normal mode tests
 
 print_metrics:

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -11,8 +11,8 @@
  *
  */
 
-#include "causal_lm_api.h"
 #include "../json.hpp"
+#include "causal_lm_api.h"
 #include <cmath>
 #include <cstring>
 #include <fstream>
@@ -120,9 +120,11 @@ void printUsage(const char *program_name) {
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " QWEN3-0.6B --chat-file chat.json W32A32 1\n\n";
 
-  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET << "\n";
+  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET
+            << "\n";
   std::cout << "  [\n";
-  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful assistant.\"},\n";
+  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful "
+               "assistant.\"},\n";
   std::cout << "    {\"role\": \"user\",      \"content\": \"Hello!\"},\n";
   std::cout << "    {\"role\": \"assistant\", \"content\": \"Hi there!\"},\n";
   std::cout << "    {\"role\": \"user\",      \"content\": \"How are you?\"}\n";
@@ -338,116 +340,114 @@ int main(int argc, char *argv[]) {
 
   // ── Test 1: applyChatTemplate (no inference, format only) ──
   {
-  printSection("Test: applyChatTemplate");
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
-            << "Testing chat template formatting (no inference)...\n\n";
+    printSection("Test: applyChatTemplate");
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+              << "Testing chat template formatting (no inference)...\n\n";
 
-  CausalLMChatMessage tmpl_msgs[] = {
-    {"system", "You are a helpful AI assistant."},
-    {"user", prompt}};
+    CausalLMChatMessage tmpl_msgs[] = {
+      {"system", "You are a helpful AI assistant."}, {"user", prompt}};
 
-  const char *formattedText = nullptr;
-  err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
-  if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
-    std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
-              << "\n\n";
-    printSuccess("applyChatTemplate works");
-  } else {
-    printError("applyChatTemplate failed");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-  }
-
-  // ── Test 2: runModel (single prompt, existing API) ──
-  printSection("Test: runModel (single prompt)");
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
-  std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
-            << "\n\n";
-
-  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET << "Running inference...\n\n";
-
-  const char *outputText = nullptr;
-
-  if (verbose) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GRAY;
-  }
-
-  err = runModel(prompt, &outputText);
-
-  if (verbose) {
-    std::cout << COLOR_RESET << "\n\n";
-  }
-
-  if (err != CAUSAL_LM_ERROR_NONE) {
-    printError("Failed to run model");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-    return 1;
-  }
-
-  if (outputText) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
-    std::string out(outputText);
-    size_t pos = 0;
-    while (pos < out.length()) {
-      size_t newlinePos = out.find('\n', pos);
-      if (newlinePos == std::string::npos) {
-        newlinePos = out.length();
-      }
-      std::string line = out.substr(pos, newlinePos - pos);
-      std::cout << line;
-      if (newlinePos < out.length()) {
-        std::cout << "\n  ";
-        pos = newlinePos + 1;
-      } else {
-        pos = out.length();
-      }
+    const char *formattedText = nullptr;
+    err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
+    if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
+      std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
+                << "\n\n";
+      printSuccess("applyChatTemplate works");
+    } else {
+      printError("applyChatTemplate failed");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
     }
-    std::cout << COLOR_RESET << "\n\n";
-  } else {
-    printWarning("No output generated");
-  }
 
-  // ── Test 3: runModelWithMessages (chat template with messages) ──
-  printSection("Test: runModelWithMessages");
-  CausalLMChatMessage chat_msgs[] = {
-    {"system", "You are a helpful AI assistant."},
-    {"user", prompt}};
-
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
-            << "Messages:\n";
-  for (size_t i = 0; i < 2; ++i) {
-    std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
-              << COLOR_RESET << chat_msgs[i].content << "\n";
-  }
-  std::cout << "\n";
-
-  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
-            << "Running inference with messages...\n\n";
-
-  const char *msgOutput = nullptr;
-
-  if (verbose) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GRAY;
-  }
-
-  err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
-
-  if (verbose) {
-    std::cout << COLOR_RESET << "\n\n";
-  }
-
-  if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+    // ── Test 2: runModel (single prompt, existing API) ──
+    printSection("Test: runModel (single prompt)");
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
+    std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
               << "\n\n";
-    printSuccess("runModelWithMessages works");
-  } else {
-    printError("runModelWithMessages failed");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-  }
+
+    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+              << "Running inference...\n\n";
+
+    const char *outputText = nullptr;
+
+    if (verbose) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GRAY;
+    }
+
+    err = runModel(prompt, &outputText);
+
+    if (verbose) {
+      std::cout << COLOR_RESET << "\n\n";
+    }
+
+    if (err != CAUSAL_LM_ERROR_NONE) {
+      printError("Failed to run model");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+      return 1;
+    }
+
+    if (outputText) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
+      std::string out(outputText);
+      size_t pos = 0;
+      while (pos < out.length()) {
+        size_t newlinePos = out.find('\n', pos);
+        if (newlinePos == std::string::npos) {
+          newlinePos = out.length();
+        }
+        std::string line = out.substr(pos, newlinePos - pos);
+        std::cout << line;
+        if (newlinePos < out.length()) {
+          std::cout << "\n  ";
+          pos = newlinePos + 1;
+        } else {
+          pos = out.length();
+        }
+      }
+      std::cout << COLOR_RESET << "\n\n";
+    } else {
+      printWarning("No output generated");
+    }
+
+    // ── Test 3: runModelWithMessages (chat template with messages) ──
+    printSection("Test: runModelWithMessages");
+    CausalLMChatMessage chat_msgs[] = {
+      {"system", "You are a helpful AI assistant."}, {"user", prompt}};
+
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Messages:\n";
+    for (size_t i = 0; i < 2; ++i) {
+      std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
+                << COLOR_RESET << chat_msgs[i].content << "\n";
+    }
+    std::cout << "\n";
+
+    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+              << "Running inference with messages...\n\n";
+
+    const char *msgOutput = nullptr;
+
+    if (verbose) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GRAY;
+    }
+
+    err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
+
+    if (verbose) {
+      std::cout << COLOR_RESET << "\n\n";
+    }
+
+    if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+                << "\n\n";
+      printSuccess("runModelWithMessages works");
+    } else {
+      printError("runModelWithMessages failed");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+    }
   } // end of normal mode tests
 
 print_metrics:

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -11,8 +11,8 @@
  *
  */
 
-#include "../json.hpp"
 #include "causal_lm_api.h"
+#include "../json.hpp"
 #include <cmath>
 #include <cstring>
 #include <fstream>
@@ -120,11 +120,9 @@ void printUsage(const char *program_name) {
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " QWEN3-0.6B --chat-file chat.json W32A32 1\n\n";
 
-  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET
-            << "\n";
+  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET << "\n";
   std::cout << "  [\n";
-  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful "
-               "assistant.\"},\n";
+  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful assistant.\"},\n";
   std::cout << "    {\"role\": \"user\",      \"content\": \"Hello!\"},\n";
   std::cout << "    {\"role\": \"assistant\", \"content\": \"Hi there!\"},\n";
   std::cout << "    {\"role\": \"user\",      \"content\": \"How are you?\"}\n";
@@ -148,13 +146,24 @@ int main(int argc, char *argv[]) {
   std::string quant_str = "UNKNOWN";
   ModelQuantizationType quant_type = CAUSAL_LM_QUANTIZATION_UNKNOWN;
   bool verbose = true;
+  std::string template_name = "default";
 
-  // Parse --chat-file mode: <model> --chat-file <path> [quant] [verbose]
+  // Parse --chat-file mode: <model> --chat-file <path> [--template name] [quant]
+  //                          [verbose]
   if (argc >= 4 && std::string(argv[2]) == "--chat-file") {
     chat_file_path = argv[3];
     use_chat_template = true;
-    if (argc >= 5) {
-      quant_str = std::string(argv[4]);
+    int next_arg = 4;
+    // Check for --template option
+    if (next_arg < argc && std::string(argv[next_arg]) == "--template") {
+      next_arg++;
+      if (next_arg < argc) {
+        template_name = argv[next_arg];
+        next_arg++;
+      }
+    }
+    if (next_arg < argc) {
+      quant_str = std::string(argv[next_arg]);
       if (quant_str == "W4A32")
         quant_type = CAUSAL_LM_QUANTIZATION_W4A32;
       else if (quant_str == "W16A16")
@@ -164,8 +173,10 @@ int main(int argc, char *argv[]) {
       else if (quant_str == "W32A32")
         quant_type = CAUSAL_LM_QUANTIZATION_W32A32;
     }
-    if (argc >= 6) {
-      verbose = (std::string(argv[5]) == "1" || std::string(argv[5]) == "true");
+    next_arg++;
+    if (next_arg < argc) {
+      verbose =
+        (std::string(argv[next_arg]) == "1" || std::string(argv[next_arg]) == "true");
     }
   } else {
     // Normal mode: <model> [prompt] [chat_template] [quant] [verbose]
@@ -194,6 +205,7 @@ int main(int argc, char *argv[]) {
   printInfo("Use Chat Template", use_chat_template ? "true" : "false");
   printInfo("Quantization", quant_str);
   printInfo("Verbose", verbose ? "true" : "false");
+  printInfo("Template Name", template_name);
   if (!chat_file_path.empty()) {
     printInfo("Chat File", chat_file_path);
   }
@@ -205,6 +217,7 @@ int main(int argc, char *argv[]) {
   config.use_chat_template = use_chat_template;
   config.debug_mode = true;
   config.verbose = verbose;
+  config.chat_template_name = template_name.c_str();
   ErrorCode err = setOptions(config);
   if (err != CAUSAL_LM_ERROR_NONE) {
     printError("Failed to set options");
@@ -340,114 +353,116 @@ int main(int argc, char *argv[]) {
 
   // ── Test 1: applyChatTemplate (no inference, format only) ──
   {
-    printSection("Test: applyChatTemplate");
-    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
-              << "Testing chat template formatting (no inference)...\n\n";
+  printSection("Test: applyChatTemplate");
+  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+            << "Testing chat template formatting (no inference)...\n\n";
 
-    CausalLMChatMessage tmpl_msgs[] = {
-      {"system", "You are a helpful AI assistant."}, {"user", prompt}};
+  CausalLMChatMessage tmpl_msgs[] = {
+    {"system", "You are a helpful AI assistant."},
+    {"user", prompt}};
 
-    const char *formattedText = nullptr;
-    err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
-    if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
-      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
-      std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
-                << "\n\n";
-      printSuccess("applyChatTemplate works");
-    } else {
-      printError("applyChatTemplate failed");
-      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-    }
-
-    // ── Test 2: runModel (single prompt, existing API) ──
-    printSection("Test: runModel (single prompt)");
-    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
-    std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
+  const char *formattedText = nullptr;
+  err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
+  if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
+    std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
               << "\n\n";
+    printSuccess("applyChatTemplate works");
+  } else {
+    printError("applyChatTemplate failed");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+  }
 
-    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
-              << "Running inference...\n\n";
+  // ── Test 2: runModel (single prompt, existing API) ──
+  printSection("Test: runModel (single prompt)");
+  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
+  std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
+            << "\n\n";
 
-    const char *outputText = nullptr;
+  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET << "Running inference...\n\n";
 
-    if (verbose) {
-      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-      std::cout << COLOR_BOLD << COLOR_GRAY;
-    }
+  const char *outputText = nullptr;
 
-    err = runModel(prompt, &outputText);
+  if (verbose) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GRAY;
+  }
 
-    if (verbose) {
-      std::cout << COLOR_RESET << "\n\n";
-    }
+  err = runModel(prompt, &outputText);
 
-    if (err != CAUSAL_LM_ERROR_NONE) {
-      printError("Failed to run model");
-      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-      return 1;
-    }
+  if (verbose) {
+    std::cout << COLOR_RESET << "\n\n";
+  }
 
-    if (outputText) {
-      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-      std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
-      std::string out(outputText);
-      size_t pos = 0;
-      while (pos < out.length()) {
-        size_t newlinePos = out.find('\n', pos);
-        if (newlinePos == std::string::npos) {
-          newlinePos = out.length();
-        }
-        std::string line = out.substr(pos, newlinePos - pos);
-        std::cout << line;
-        if (newlinePos < out.length()) {
-          std::cout << "\n  ";
-          pos = newlinePos + 1;
-        } else {
-          pos = out.length();
-        }
+  if (err != CAUSAL_LM_ERROR_NONE) {
+    printError("Failed to run model");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+    return 1;
+  }
+
+  if (outputText) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
+    std::string out(outputText);
+    size_t pos = 0;
+    while (pos < out.length()) {
+      size_t newlinePos = out.find('\n', pos);
+      if (newlinePos == std::string::npos) {
+        newlinePos = out.length();
       }
-      std::cout << COLOR_RESET << "\n\n";
-    } else {
-      printWarning("No output generated");
+      std::string line = out.substr(pos, newlinePos - pos);
+      std::cout << line;
+      if (newlinePos < out.length()) {
+        std::cout << "\n  ";
+        pos = newlinePos + 1;
+      } else {
+        pos = out.length();
+      }
     }
+    std::cout << COLOR_RESET << "\n\n";
+  } else {
+    printWarning("No output generated");
+  }
 
-    // ── Test 3: runModelWithMessages (chat template with messages) ──
-    printSection("Test: runModelWithMessages");
-    CausalLMChatMessage chat_msgs[] = {
-      {"system", "You are a helpful AI assistant."}, {"user", prompt}};
+  // ── Test 3: runModelWithMessages (chat template with messages) ──
+  printSection("Test: runModelWithMessages");
+  CausalLMChatMessage chat_msgs[] = {
+    {"system", "You are a helpful AI assistant."},
+    {"user", prompt}};
 
-    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Messages:\n";
-    for (size_t i = 0; i < 2; ++i) {
-      std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
-                << COLOR_RESET << chat_msgs[i].content << "\n";
-    }
-    std::cout << "\n";
+  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+            << "Messages:\n";
+  for (size_t i = 0; i < 2; ++i) {
+    std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
+              << COLOR_RESET << chat_msgs[i].content << "\n";
+  }
+  std::cout << "\n";
 
-    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
-              << "Running inference with messages...\n\n";
+  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+            << "Running inference with messages...\n\n";
 
-    const char *msgOutput = nullptr;
+  const char *msgOutput = nullptr;
 
-    if (verbose) {
-      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-      std::cout << COLOR_BOLD << COLOR_GRAY;
-    }
+  if (verbose) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GRAY;
+  }
 
-    err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
+  err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
 
-    if (verbose) {
-      std::cout << COLOR_RESET << "\n\n";
-    }
+  if (verbose) {
+    std::cout << COLOR_RESET << "\n\n";
+  }
 
-    if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
-      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-      std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
-                << "\n\n";
-      printSuccess("runModelWithMessages works");
-    } else {
-      printError("runModelWithMessages failed");
-      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-    }
+  if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+              << "\n\n";
+    printSuccess("runModelWithMessages works");
+  } else {
+    printError("runModelWithMessages failed");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+  }
   } // end of normal mode tests
 
 print_metrics:

--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -617,6 +617,9 @@ private:
   /** @brief Advance to next token and return the current one */
   const Token &advance() { return tokens_[pos_++]; }
 
+  /** @brief Peek at the next token without advancing */
+  const Token &peek() const { return tokens_[pos_ + 1]; }
+
   /** @brief Check if current token matches the given type */
   bool check(TokenType type) const { return current().type == type; }
 
@@ -965,9 +968,16 @@ private:
   }
 
   // "in" / "not in" containment
-  /** @brief Parse "in" containment expression */
+  /** @brief Parse "in" and "not in" containment expressions */
   ExprNodePtr parseContains() {
     auto left = parseAddition();
+
+    bool negated = false;
+    if (check(TokenType::NOT) && pos_ + 1 < tokens_.size() &&
+        peek().type == TokenType::IN) {
+      advance(); // skip 'not'
+      negated = true;
+    }
 
     if (check(TokenType::IN)) {
       advance();
@@ -975,9 +985,14 @@ private:
       auto node = std::make_shared<ContainsExpr>();
       node->item = left;
       node->container = right;
+      if (negated) {
+        auto not_node = std::make_shared<UnaryExpr>();
+        not_node->op = "not";
+        not_node->operand = node;
+        return not_node;
+      }
       return node;
     }
-    // "not in" is handled by parseNot wrapping this
 
     return left;
   }

--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -1407,7 +1407,10 @@ private:
       json index = evalExpr(idx->index.get());
       if (obj.is_array() && index.is_number_integer()) {
         int i = index.get<int>();
-        if (i >= 0 && i < static_cast<int>(obj.size()))
+        int sz = static_cast<int>(obj.size());
+        if (i < 0)
+          i += sz;
+        if (i >= 0 && i < sz)
           return obj[i];
       } else if (obj.is_object() && index.is_string()) {
         std::string key = index.get<std::string>();

--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -1,0 +1,1847 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file    chat_template.cpp
+ * @date    10 Apr 2026
+ * @brief   Chat template implementation with mini Jinja2 renderer
+ * @see     https://github.com/nntrainer/nntrainer
+ * @author  Eunju Yang <ej.yang@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#include "chat_template.h"
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace causallm {
+
+// ============================================================================
+// Token types for the Jinja2 lexer
+// ============================================================================
+enum class TokenType {
+  TEXT,
+  EXPRESSION_START, // {{
+  EXPRESSION_END,   // }}
+  STATEMENT_START,  // {%
+  STATEMENT_END,    // %}
+  STRING,
+  INTEGER,
+  FLOAT,
+  IDENTIFIER,
+  DOT,
+  LBRACKET,
+  RBRACKET,
+  LPAREN,
+  RPAREN,
+  PLUS,
+  MINUS,
+  PERCENT,
+  PIPE,
+  COMMA,
+  EQ,     // ==
+  NEQ,    // !=
+  ASSIGN, // =
+  NOT,    // not
+  AND,    // and
+  OR,     // or
+  TRUE_LIT,
+  FALSE_LIT,
+  NONE_LIT,
+  IF,
+  ELIF,
+  ELSE,
+  ENDIF,
+  FOR,
+  IN,
+  ENDFOR,
+  SET,
+  IS,
+  TILDE, // ~
+  COLON, // :
+  GT,    // >
+  LT,    // <
+  GTE,   // >=
+  LTE,   // <=
+  END_OF_INPUT,
+};
+
+struct Token {
+  TokenType type;
+  std::string value;
+  bool strip_before = false; // {%- or {{-
+  bool strip_after = false;  // -%} or -}}
+};
+
+// ============================================================================
+// Lexer
+// ============================================================================
+class Lexer {
+public:
+  explicit Lexer(const std::string &input) : input_(input), pos_(0) {}
+
+  std::vector<Token> tokenize() {
+    std::vector<Token> tokens;
+
+    while (pos_ < input_.size()) {
+      if (match("{{")) {
+        bool strip = false;
+        if (pos_ < input_.size() && input_[pos_] == '-') {
+          strip = true;
+          pos_++;
+        }
+        Token start;
+        start.type = TokenType::EXPRESSION_START;
+        start.strip_before = strip;
+        tokens.push_back(start);
+        skipWhitespace();
+        tokenizeInside(tokens, TokenType::EXPRESSION_END);
+      } else if (match("{%")) {
+        bool strip = false;
+        if (pos_ < input_.size() && input_[pos_] == '-') {
+          strip = true;
+          pos_++;
+        }
+        Token start;
+        start.type = TokenType::STATEMENT_START;
+        start.strip_before = strip;
+        tokens.push_back(start);
+        skipWhitespace();
+        tokenizeInside(tokens, TokenType::STATEMENT_END);
+      } else {
+        std::string text;
+        while (pos_ < input_.size()) {
+          if ((pos_ + 1 < input_.size()) &&
+              ((input_[pos_] == '{' &&
+                (input_[pos_ + 1] == '{' || input_[pos_ + 1] == '%')))) {
+            break;
+          }
+          text += input_[pos_++];
+        }
+        if (!text.empty()) {
+          Token t;
+          t.type = TokenType::TEXT;
+          t.value = text;
+          tokens.push_back(t);
+        }
+      }
+    }
+
+    Token eof;
+    eof.type = TokenType::END_OF_INPUT;
+    tokens.push_back(eof);
+    return tokens;
+  }
+
+private:
+  bool match(const std::string &s) {
+    if (pos_ + s.size() <= input_.size() &&
+        input_.substr(pos_, s.size()) == s) {
+      pos_ += s.size();
+      return true;
+    }
+    return false;
+  }
+
+  void skipWhitespace() {
+    while (pos_ < input_.size() && std::isspace(input_[pos_]))
+      pos_++;
+  }
+
+  void tokenizeInside(std::vector<Token> &tokens, TokenType end_type) {
+    while (pos_ < input_.size()) {
+      skipWhitespace();
+      if (pos_ >= input_.size())
+        break;
+
+      // Check for closing tag
+      if (end_type == TokenType::EXPRESSION_END) {
+        if (pos_ + 1 < input_.size() && input_[pos_] == '-' &&
+            input_[pos_ + 1] == '}' && pos_ + 2 < input_.size() &&
+            input_[pos_ + 2] == '}') {
+          pos_ += 3;
+          Token end;
+          end.type = end_type;
+          end.strip_after = true;
+          tokens.push_back(end);
+          return;
+        }
+        if (match("}}")) {
+          Token end;
+          end.type = end_type;
+          tokens.push_back(end);
+          return;
+        }
+      } else if (end_type == TokenType::STATEMENT_END) {
+        if (pos_ + 1 < input_.size() && input_[pos_] == '-' &&
+            input_[pos_ + 1] == '%' && pos_ + 2 < input_.size() &&
+            input_[pos_ + 2] == '}') {
+          pos_ += 3;
+          Token end;
+          end.type = end_type;
+          end.strip_after = true;
+          tokens.push_back(end);
+          return;
+        }
+        if (match("%}")) {
+          Token end;
+          end.type = end_type;
+          tokens.push_back(end);
+          return;
+        }
+      }
+
+      // String literal
+      if (input_[pos_] == '\'' || input_[pos_] == '"') {
+        tokens.push_back(readString());
+        continue;
+      }
+
+      // Number
+      if (std::isdigit(input_[pos_])) {
+        tokens.push_back(readNumber());
+        continue;
+      }
+
+      // Identifier or keyword
+      if (std::isalpha(input_[pos_]) || input_[pos_] == '_') {
+        tokens.push_back(readIdentifier());
+        continue;
+      }
+
+      // Operators and punctuation
+      Token t;
+      switch (input_[pos_]) {
+      case '.':
+        t.type = TokenType::DOT;
+        t.value = ".";
+        pos_++;
+        break;
+      case '[':
+        t.type = TokenType::LBRACKET;
+        t.value = "[";
+        pos_++;
+        break;
+      case ']':
+        t.type = TokenType::RBRACKET;
+        t.value = "]";
+        pos_++;
+        break;
+      case '(':
+        t.type = TokenType::LPAREN;
+        t.value = "(";
+        pos_++;
+        break;
+      case ')':
+        t.type = TokenType::RPAREN;
+        t.value = ")";
+        pos_++;
+        break;
+      case '+':
+        t.type = TokenType::PLUS;
+        t.value = "+";
+        pos_++;
+        break;
+      case '-':
+        t.type = TokenType::MINUS;
+        t.value = "-";
+        pos_++;
+        break;
+      case '%':
+        t.type = TokenType::PERCENT;
+        t.value = "%";
+        pos_++;
+        break;
+      case '|':
+        t.type = TokenType::PIPE;
+        t.value = "|";
+        pos_++;
+        break;
+      case ',':
+        t.type = TokenType::COMMA;
+        t.value = ",";
+        pos_++;
+        break;
+      case '=':
+        if (pos_ + 1 < input_.size() && input_[pos_ + 1] == '=') {
+          t.type = TokenType::EQ;
+          t.value = "==";
+          pos_ += 2;
+        } else {
+          t.type = TokenType::ASSIGN;
+          t.value = "=";
+          pos_++;
+        }
+        break;
+      case '!':
+        if (pos_ + 1 < input_.size() && input_[pos_ + 1] == '=') {
+          t.type = TokenType::NEQ;
+          t.value = "!=";
+          pos_ += 2;
+        } else {
+          pos_++;
+          continue;
+        }
+        break;
+      case '~':
+        t.type = TokenType::TILDE;
+        t.value = "~";
+        pos_++;
+        break;
+      case ':':
+        t.type = TokenType::COLON;
+        t.value = ":";
+        pos_++;
+        break;
+      case '>':
+        if (pos_ + 1 < input_.size() && input_[pos_ + 1] == '=') {
+          t.type = TokenType::GTE;
+          t.value = ">=";
+          pos_ += 2;
+        } else {
+          t.type = TokenType::GT;
+          t.value = ">";
+          pos_++;
+        }
+        break;
+      case '<':
+        if (pos_ + 1 < input_.size() && input_[pos_ + 1] == '=') {
+          t.type = TokenType::LTE;
+          t.value = "<=";
+          pos_ += 2;
+        } else {
+          t.type = TokenType::LT;
+          t.value = "<";
+          pos_++;
+        }
+        break;
+      default:
+        pos_++;
+        continue;
+      }
+      tokens.push_back(t);
+    }
+  }
+
+  Token readString() {
+    char quote = input_[pos_++];
+    std::string value;
+    while (pos_ < input_.size() && input_[pos_] != quote) {
+      if (input_[pos_] == '\\' && pos_ + 1 < input_.size()) {
+        pos_++;
+        switch (input_[pos_]) {
+        case 'n':
+          value += '\n';
+          break;
+        case 't':
+          value += '\t';
+          break;
+        case '\\':
+          value += '\\';
+          break;
+        case '\'':
+          value += '\'';
+          break;
+        case '"':
+          value += '"';
+          break;
+        default:
+          value += '\\';
+          value += input_[pos_];
+          break;
+        }
+      } else {
+        value += input_[pos_];
+      }
+      pos_++;
+    }
+    if (pos_ < input_.size())
+      pos_++; // skip closing quote
+
+    Token t;
+    t.type = TokenType::STRING;
+    t.value = value;
+    return t;
+  }
+
+  Token readNumber() {
+    std::string value;
+    bool has_dot = false;
+    while (pos_ < input_.size() &&
+           (std::isdigit(input_[pos_]) || input_[pos_] == '.')) {
+      if (input_[pos_] == '.') {
+        if (has_dot)
+          break;
+        has_dot = true;
+      }
+      value += input_[pos_++];
+    }
+    Token t;
+    t.type = has_dot ? TokenType::FLOAT : TokenType::INTEGER;
+    t.value = value;
+    return t;
+  }
+
+  Token readIdentifier() {
+    std::string value;
+    while (pos_ < input_.size() &&
+           (std::isalnum(input_[pos_]) || input_[pos_] == '_')) {
+      value += input_[pos_++];
+    }
+
+    Token t;
+    t.value = value;
+
+    // Check for keywords
+    if (value == "if")
+      t.type = TokenType::IF;
+    else if (value == "elif")
+      t.type = TokenType::ELIF;
+    else if (value == "else")
+      t.type = TokenType::ELSE;
+    else if (value == "endif")
+      t.type = TokenType::ENDIF;
+    else if (value == "for")
+      t.type = TokenType::FOR;
+    else if (value == "in")
+      t.type = TokenType::IN;
+    else if (value == "endfor")
+      t.type = TokenType::ENDFOR;
+    else if (value == "set")
+      t.type = TokenType::SET;
+    else if (value == "not")
+      t.type = TokenType::NOT;
+    else if (value == "and")
+      t.type = TokenType::AND;
+    else if (value == "or")
+      t.type = TokenType::OR;
+    else if (value == "is")
+      t.type = TokenType::IS;
+    else if (value == "true" || value == "True")
+      t.type = TokenType::TRUE_LIT;
+    else if (value == "false" || value == "False")
+      t.type = TokenType::FALSE_LIT;
+    else if (value == "none" || value == "None")
+      t.type = TokenType::NONE_LIT;
+    else
+      t.type = TokenType::IDENTIFIER;
+
+    return t;
+  }
+
+  std::string input_;
+  size_t pos_;
+};
+
+// ============================================================================
+// AST Nodes
+// ============================================================================
+struct ASTNode {
+  virtual ~ASTNode() = default;
+};
+
+using ASTNodePtr = std::shared_ptr<ASTNode>;
+
+struct ExprNode : ASTNode {};
+using ExprNodePtr = std::shared_ptr<ExprNode>;
+
+struct TextNode : ASTNode {
+  std::string text;
+};
+
+struct OutputNode : ASTNode {
+  ExprNodePtr expr;
+  bool strip_before = false;
+  bool strip_after = false;
+};
+
+struct IfBranch {
+  ExprNodePtr condition; // nullptr for else branch
+  std::vector<ASTNodePtr> body;
+};
+
+struct IfNode : ASTNode {
+  std::vector<IfBranch> branches;
+  bool strip_before = false;
+  bool strip_after = false;
+};
+
+struct ForNode : ASTNode {
+  std::string var_name;
+  ExprNodePtr iterable;
+  std::vector<ASTNodePtr> body;
+  bool strip_before = false;
+  bool strip_after = false;
+};
+
+struct SetNode : ASTNode {
+  std::string var_name;
+  std::string attr_name; // for "set ns.attr = val" (empty if simple set)
+  ExprNodePtr value;
+  bool strip_before = false;
+  bool strip_after = false;
+};
+
+// Expression nodes
+struct StringLiteral : ExprNode {
+  std::string value;
+};
+
+struct IntegerLiteral : ExprNode {
+  int value;
+};
+
+struct BoolLiteral : ExprNode {
+  bool value;
+};
+
+struct NoneLiteral : ExprNode {};
+
+struct VariableExpr : ExprNode {
+  std::string name;
+};
+
+struct AttributeExpr : ExprNode {
+  ExprNodePtr object;
+  std::string attribute;
+};
+
+struct IndexExpr : ExprNode {
+  ExprNodePtr object;
+  ExprNodePtr index;
+};
+
+struct BinaryExpr : ExprNode {
+  std::string op; // "+", "==", "!=", "and", "or", "%"
+  ExprNodePtr left;
+  ExprNodePtr right;
+};
+
+struct UnaryExpr : ExprNode {
+  std::string op; // "not"
+  ExprNodePtr operand;
+};
+
+struct FilterExpr : ExprNode {
+  ExprNodePtr value;
+  std::string filter_name;
+};
+
+struct IsDefinedExpr : ExprNode {
+  ExprNodePtr value;
+};
+
+struct FunctionCallExpr : ExprNode {
+  std::string name;
+  std::vector<ExprNodePtr> args;
+};
+
+struct MethodCallExpr : ExprNode {
+  ExprNodePtr object;
+  std::string method;
+  std::vector<ExprNodePtr> args;
+};
+
+struct SliceExpr : ExprNode {
+  ExprNodePtr object;
+  ExprNodePtr start; // nullable
+  ExprNodePtr stop;  // nullable
+  ExprNodePtr step;  // nullable
+};
+
+struct ContainsExpr : ExprNode {
+  ExprNodePtr item;
+  ExprNodePtr container;
+};
+
+// ============================================================================
+// Parser
+// ============================================================================
+class Parser {
+public:
+  explicit Parser(const std::vector<Token> &tokens) :
+    tokens_(tokens), pos_(0) {}
+
+  std::vector<ASTNodePtr> parse() {
+    std::vector<ASTNodePtr> nodes;
+    parseBody(nodes, {});
+    return nodes;
+  }
+
+private:
+  const Token &current() const { return tokens_[pos_]; }
+
+  const Token &advance() { return tokens_[pos_++]; }
+
+  bool check(TokenType type) const { return current().type == type; }
+
+  bool matchToken(TokenType type) {
+    if (check(type)) {
+      advance();
+      return true;
+    }
+    return false;
+  }
+
+  Token expect(TokenType type) {
+    if (!check(type)) {
+      throw std::runtime_error("ChatTemplate parser: unexpected token '" +
+                               current().value + "', expected type " +
+                               std::to_string(static_cast<int>(type)));
+    }
+    return advance();
+  }
+
+  void parseBody(std::vector<ASTNodePtr> &nodes,
+                 const std::vector<TokenType> &stop_keywords) {
+    while (pos_ < tokens_.size() && current().type != TokenType::END_OF_INPUT) {
+      if (current().type == TokenType::TEXT) {
+        auto node = std::make_shared<TextNode>();
+        node->text = current().value;
+        nodes.push_back(node);
+        advance();
+      } else if (current().type == TokenType::EXPRESSION_START) {
+        nodes.push_back(parseOutput());
+      } else if (current().type == TokenType::STATEMENT_START) {
+        // Peek at the keyword after {%
+        size_t save = pos_;
+        advance(); // skip STATEMENT_START
+
+        // Check if this is a stop keyword
+        bool is_stop = false;
+        for (auto sk : stop_keywords) {
+          if (check(sk)) {
+            is_stop = true;
+            break;
+          }
+        }
+
+        if (is_stop) {
+          pos_ = save; // rewind
+          return;
+        }
+
+        pos_ = save; // rewind
+        parseStatement(nodes);
+      } else {
+        advance(); // skip unexpected
+      }
+    }
+  }
+
+  ASTNodePtr parseOutput() {
+    auto node = std::make_shared<OutputNode>();
+    Token start = expect(TokenType::EXPRESSION_START);
+    node->strip_before = start.strip_before;
+    node->expr = parseExpression();
+    Token end = expect(TokenType::EXPRESSION_END);
+    node->strip_after = end.strip_after;
+    return node;
+  }
+
+  void parseStatement(std::vector<ASTNodePtr> &nodes) {
+    Token start = expect(TokenType::STATEMENT_START);
+    bool strip_before = start.strip_before;
+
+    if (check(TokenType::IF)) {
+      nodes.push_back(parseIf(strip_before));
+    } else if (check(TokenType::FOR)) {
+      nodes.push_back(parseFor(strip_before));
+    } else if (check(TokenType::SET)) {
+      nodes.push_back(parseSet(strip_before));
+    } else {
+      // Unknown statement - skip to end
+      while (pos_ < tokens_.size() &&
+             current().type != TokenType::STATEMENT_END) {
+        advance();
+      }
+      if (check(TokenType::STATEMENT_END))
+        advance();
+    }
+  }
+
+  ASTNodePtr parseIf(bool strip_before) {
+    auto node = std::make_shared<IfNode>();
+    node->strip_before = strip_before;
+
+    // Parse: if <expr> %}
+    expect(TokenType::IF);
+    IfBranch branch;
+    branch.condition = parseExpression();
+    Token end = expect(TokenType::STATEMENT_END);
+    node->strip_after = end.strip_after;
+
+    // Parse body until elif/else/endif
+    parseBody(branch.body,
+              {TokenType::ELIF, TokenType::ELSE, TokenType::ENDIF});
+    node->branches.push_back(branch);
+
+    // Parse elif/else branches
+    while (pos_ < tokens_.size() &&
+           current().type == TokenType::STATEMENT_START) {
+      advance(); // skip {%
+
+      if (check(TokenType::ELIF)) {
+        advance(); // skip elif
+        IfBranch elif_branch;
+        elif_branch.condition = parseExpression();
+        expect(TokenType::STATEMENT_END);
+        parseBody(elif_branch.body,
+                  {TokenType::ELIF, TokenType::ELSE, TokenType::ENDIF});
+        node->branches.push_back(elif_branch);
+      } else if (check(TokenType::ELSE)) {
+        advance(); // skip else
+        expect(TokenType::STATEMENT_END);
+        IfBranch else_branch;
+        else_branch.condition = nullptr; // no condition = else
+        parseBody(else_branch.body, {TokenType::ENDIF});
+        node->branches.push_back(else_branch);
+      } else if (check(TokenType::ENDIF)) {
+        advance(); // skip endif
+        expect(TokenType::STATEMENT_END);
+        break;
+      } else {
+        break;
+      }
+    }
+
+    return node;
+  }
+
+  ASTNodePtr parseFor(bool strip_before) {
+    auto node = std::make_shared<ForNode>();
+    node->strip_before = strip_before;
+
+    expect(TokenType::FOR);
+    node->var_name = expect(TokenType::IDENTIFIER).value;
+    expect(TokenType::IN);
+    node->iterable = parseExpression();
+    Token end = expect(TokenType::STATEMENT_END);
+    node->strip_after = end.strip_after;
+
+    parseBody(node->body, {TokenType::ENDFOR});
+
+    // Consume endfor
+    expect(TokenType::STATEMENT_START);
+    expect(TokenType::ENDFOR);
+    expect(TokenType::STATEMENT_END);
+
+    return node;
+  }
+
+  ASTNodePtr parseSet(bool strip_before) {
+    auto node = std::make_shared<SetNode>();
+    node->strip_before = strip_before;
+
+    expect(TokenType::SET);
+    node->var_name = expect(TokenType::IDENTIFIER).value;
+
+    // Handle dotted assignment: "set ns.attr = val"
+    if (check(TokenType::DOT)) {
+      advance();
+      node->attr_name = expect(TokenType::IDENTIFIER).value;
+    }
+
+    expect(TokenType::ASSIGN);
+    node->value = parseExpression();
+    Token end = expect(TokenType::STATEMENT_END);
+    node->strip_after = end.strip_after;
+
+    return node;
+  }
+
+  // Expression parsing with precedence
+  ExprNodePtr parseExpression() { return parseOr(); }
+
+  ExprNodePtr parseOr() {
+    auto left = parseAnd();
+    while (check(TokenType::OR)) {
+      advance();
+      auto right = parseAnd();
+      auto node = std::make_shared<BinaryExpr>();
+      node->op = "or";
+      node->left = left;
+      node->right = right;
+      left = node;
+    }
+    return left;
+  }
+
+  ExprNodePtr parseAnd() {
+    auto left = parseNot();
+    while (check(TokenType::AND)) {
+      advance();
+      auto right = parseNot();
+      auto node = std::make_shared<BinaryExpr>();
+      node->op = "and";
+      node->left = left;
+      node->right = right;
+      left = node;
+    }
+    return left;
+  }
+
+  ExprNodePtr parseNot() {
+    if (check(TokenType::NOT)) {
+      advance();
+      auto node = std::make_shared<UnaryExpr>();
+      node->op = "not";
+      node->operand = parseNot();
+      return node;
+    }
+    return parseComparison();
+  }
+
+  ExprNodePtr parseComparison() {
+    auto left = parseContains();
+
+    if (check(TokenType::EQ) || check(TokenType::NEQ) || check(TokenType::GT) ||
+        check(TokenType::LT) || check(TokenType::GTE) ||
+        check(TokenType::LTE)) {
+      std::string op = advance().value;
+      auto right = parseContains();
+      auto node = std::make_shared<BinaryExpr>();
+      node->op = op;
+      node->left = left;
+      node->right = right;
+      return node;
+    }
+
+    // "is" tests: "is defined", "is not defined", "is string", "is false", etc.
+    if (check(TokenType::IS)) {
+      advance();
+      bool negated = false;
+      if (check(TokenType::NOT)) {
+        negated = true;
+        advance();
+      }
+      if (check(TokenType::IDENTIFIER)) {
+        std::string test_name = current().value;
+        advance();
+        ExprNodePtr result;
+        if (test_name == "defined") {
+          auto node = std::make_shared<IsDefinedExpr>();
+          node->value = left;
+          result = node;
+        } else if (test_name == "string") {
+          // "is string" -> check if value is a string type
+          auto call = std::make_shared<FunctionCallExpr>();
+          call->name = "__is_string";
+          call->args.push_back(left);
+          result = call;
+        } else if (test_name == "none") {
+          auto call = std::make_shared<FunctionCallExpr>();
+          call->name = "__is_none";
+          call->args.push_back(left);
+          result = call;
+        } else if (test_name == "number") {
+          auto call = std::make_shared<FunctionCallExpr>();
+          call->name = "__is_number";
+          call->args.push_back(left);
+          result = call;
+        } else {
+          // Fallback: treat unknown test as comparison
+          result = left;
+        }
+        if (negated) {
+          auto not_node = std::make_shared<UnaryExpr>();
+          not_node->op = "not";
+          not_node->operand = result;
+          return not_node;
+        }
+        return result;
+      }
+      // "is true" / "is false" / "is none" (keyword forms)
+      if (check(TokenType::TRUE_LIT)) {
+        advance();
+        auto node = std::make_shared<BinaryExpr>();
+        node->op = "==";
+        node->left = left;
+        auto lit = std::make_shared<BoolLiteral>();
+        lit->value = true;
+        node->right = lit;
+        ExprNodePtr result = node;
+        if (negated) {
+          auto not_node = std::make_shared<UnaryExpr>();
+          not_node->op = "not";
+          not_node->operand = result;
+          return not_node;
+        }
+        return result;
+      }
+      if (check(TokenType::FALSE_LIT)) {
+        advance();
+        auto node = std::make_shared<BinaryExpr>();
+        node->op = "==";
+        node->left = left;
+        auto lit = std::make_shared<BoolLiteral>();
+        lit->value = false;
+        node->right = lit;
+        ExprNodePtr result = node;
+        if (negated) {
+          auto not_node = std::make_shared<UnaryExpr>();
+          not_node->op = "not";
+          not_node->operand = result;
+          return not_node;
+        }
+        return result;
+      }
+      if (check(TokenType::NONE_LIT)) {
+        advance();
+        auto node = std::make_shared<BinaryExpr>();
+        node->op = "==";
+        node->left = left;
+        node->right = std::make_shared<NoneLiteral>();
+        ExprNodePtr result = node;
+        if (negated) {
+          auto not_node = std::make_shared<UnaryExpr>();
+          not_node->op = "not";
+          not_node->operand = result;
+          return not_node;
+        }
+        return result;
+      }
+    }
+
+    return left;
+  }
+
+  // "in" / "not in" containment
+  ExprNodePtr parseContains() {
+    auto left = parseAddition();
+
+    if (check(TokenType::IN)) {
+      advance();
+      auto right = parseAddition();
+      auto node = std::make_shared<ContainsExpr>();
+      node->item = left;
+      node->container = right;
+      return node;
+    }
+    // "not in" is handled by parseNot wrapping this
+
+    return left;
+  }
+
+  ExprNodePtr parseAddition() {
+    auto left = parseModulo();
+    while (check(TokenType::PLUS) || check(TokenType::MINUS) ||
+           check(TokenType::TILDE)) {
+      std::string op = advance().value;
+      auto right = parseModulo();
+      auto node = std::make_shared<BinaryExpr>();
+      node->op = op;
+      node->left = left;
+      node->right = right;
+      left = node;
+    }
+    return left;
+  }
+
+  ExprNodePtr parseModulo() {
+    auto left = parseFilter();
+    while (check(TokenType::PERCENT)) {
+      advance();
+      auto right = parseFilter();
+      auto node = std::make_shared<BinaryExpr>();
+      node->op = "%";
+      node->left = left;
+      node->right = right;
+      left = node;
+    }
+    return left;
+  }
+
+  ExprNodePtr parseFilter() {
+    auto left = parsePostfix();
+    while (check(TokenType::PIPE)) {
+      advance();
+      std::string filter_name = expect(TokenType::IDENTIFIER).value;
+      auto node = std::make_shared<FilterExpr>();
+      node->value = left;
+      node->filter_name = filter_name;
+      left = node;
+    }
+    return left;
+  }
+
+  ExprNodePtr parsePostfix() {
+    auto node = parsePrimary();
+    while (true) {
+      if (check(TokenType::DOT)) {
+        advance();
+        std::string attr = expect(TokenType::IDENTIFIER).value;
+        // Check for method call: obj.method(args)
+        if (check(TokenType::LPAREN)) {
+          advance();
+          auto call = std::make_shared<MethodCallExpr>();
+          call->object = node;
+          call->method = attr;
+          if (!check(TokenType::RPAREN)) {
+            call->args.push_back(parseExpression());
+            while (check(TokenType::COMMA)) {
+              advance();
+              call->args.push_back(parseExpression());
+            }
+          }
+          expect(TokenType::RPAREN);
+          node = call;
+        } else {
+          auto access = std::make_shared<AttributeExpr>();
+          access->object = node;
+          access->attribute = attr;
+          node = access;
+        }
+      } else if (check(TokenType::LBRACKET)) {
+        advance();
+        // Check for slice: obj[start:stop:step] or obj[::step]
+        if (check(TokenType::COLON)) {
+          // [:stop] or [::step]
+          auto slice = std::make_shared<SliceExpr>();
+          slice->object = node;
+          slice->start = nullptr;
+          advance(); // skip first ':'
+          if (check(TokenType::COLON)) {
+            // [::step]
+            advance();
+            slice->stop = nullptr;
+            if (!check(TokenType::RBRACKET)) {
+              slice->step = parseExpression();
+            }
+          } else if (!check(TokenType::RBRACKET)) {
+            slice->stop = parseExpression();
+            if (check(TokenType::COLON)) {
+              advance();
+              if (!check(TokenType::RBRACKET)) {
+                slice->step = parseExpression();
+              }
+            }
+          }
+          expect(TokenType::RBRACKET);
+          node = slice;
+        } else {
+          auto index = parseExpression();
+          if (check(TokenType::COLON)) {
+            // [start:stop] or [start:stop:step]
+            advance();
+            auto slice = std::make_shared<SliceExpr>();
+            slice->object = node;
+            slice->start = index;
+            if (check(TokenType::COLON)) {
+              // [start::step]
+              advance();
+              slice->stop = nullptr;
+              if (!check(TokenType::RBRACKET)) {
+                slice->step = parseExpression();
+              }
+            } else if (!check(TokenType::RBRACKET)) {
+              slice->stop = parseExpression();
+              if (check(TokenType::COLON)) {
+                advance();
+                if (!check(TokenType::RBRACKET)) {
+                  slice->step = parseExpression();
+                }
+              }
+            }
+            expect(TokenType::RBRACKET);
+            node = slice;
+          } else {
+            expect(TokenType::RBRACKET);
+            auto access = std::make_shared<IndexExpr>();
+            access->object = node;
+            access->index = index;
+            node = access;
+          }
+        }
+      } else {
+        break;
+      }
+    }
+    return node;
+  }
+
+  ExprNodePtr parsePrimary() {
+    // Unary minus
+    if (check(TokenType::MINUS)) {
+      advance();
+      auto operand = parsePrimary();
+      if (auto *intLit = dynamic_cast<IntegerLiteral *>(operand.get())) {
+        intLit->value = -intLit->value;
+        return operand;
+      }
+      auto node = std::make_shared<BinaryExpr>();
+      node->op = "-";
+      auto zero = std::make_shared<IntegerLiteral>();
+      zero->value = 0;
+      node->left = zero;
+      node->right = operand;
+      return node;
+    }
+    if (check(TokenType::STRING)) {
+      auto node = std::make_shared<StringLiteral>();
+      node->value = advance().value;
+      return node;
+    }
+    if (check(TokenType::INTEGER)) {
+      auto node = std::make_shared<IntegerLiteral>();
+      node->value = std::stoi(advance().value);
+      return node;
+    }
+    if (check(TokenType::TRUE_LIT)) {
+      advance();
+      auto node = std::make_shared<BoolLiteral>();
+      node->value = true;
+      return node;
+    }
+    if (check(TokenType::FALSE_LIT)) {
+      advance();
+      auto node = std::make_shared<BoolLiteral>();
+      node->value = false;
+      return node;
+    }
+    if (check(TokenType::NONE_LIT)) {
+      advance();
+      return std::make_shared<NoneLiteral>();
+    }
+    if (check(TokenType::IDENTIFIER)) {
+      std::string name = advance().value;
+
+      // Check for function call
+      if (check(TokenType::LPAREN)) {
+        advance();
+        // Special case: namespace(key=val, ...) with keyword arguments
+        if (name == "namespace") {
+          // Parse keyword arguments and build a JSON object initializer
+          // We create a FunctionCallExpr where args[0] is a JSON-like init
+          auto call = std::make_shared<FunctionCallExpr>();
+          call->name = name;
+          // Parse key=value pairs and store as string literal pairs
+          json init_pairs = json::object();
+          while (!check(TokenType::RPAREN) && pos_ < tokens_.size()) {
+            if (check(TokenType::IDENTIFIER)) {
+              std::string key = advance().value;
+              if (check(TokenType::ASSIGN)) {
+                advance();
+                // We can't fully evaluate here, so skip for now
+                // Just consume until comma or rparen
+                auto val_expr = parseExpression();
+                // Store key for later reference
+              }
+            }
+            if (check(TokenType::COMMA))
+              advance();
+            else
+              break;
+          }
+          expect(TokenType::RPAREN);
+          return call;
+        }
+        auto call = std::make_shared<FunctionCallExpr>();
+        call->name = name;
+        if (!check(TokenType::RPAREN)) {
+          call->args.push_back(parseExpression());
+          while (check(TokenType::COMMA)) {
+            advance();
+            call->args.push_back(parseExpression());
+          }
+        }
+        expect(TokenType::RPAREN);
+        return call;
+      }
+
+      auto node = std::make_shared<VariableExpr>();
+      node->name = name;
+      return node;
+    }
+    if (check(TokenType::LPAREN)) {
+      advance();
+      auto expr = parseExpression();
+      expect(TokenType::RPAREN);
+      return expr;
+    }
+
+    // Fallback: return an empty string literal
+    return std::make_shared<StringLiteral>();
+  }
+
+  const std::vector<Token> &tokens_;
+  size_t pos_;
+};
+
+// ============================================================================
+// Evaluator
+// ============================================================================
+class Evaluator {
+public:
+  explicit Evaluator(const json &context) { scopes_.push_back(context); }
+
+  std::string evaluate(const std::vector<ASTNodePtr> &nodes) {
+    std::string result;
+    for (size_t i = 0; i < nodes.size(); ++i) {
+      std::string chunk = evalNode(nodes[i].get());
+
+      // Handle whitespace stripping
+      if (shouldStripBefore(nodes[i].get())) {
+        // Strip trailing whitespace from result
+        while (!result.empty() &&
+               (result.back() == ' ' || result.back() == '\t' ||
+                result.back() == '\n' || result.back() == '\r')) {
+          result.pop_back();
+        }
+      }
+
+      result += chunk;
+
+      // Handle strip_after: strip leading whitespace of next text
+      if (shouldStripAfter(nodes[i].get()) && i + 1 < nodes.size()) {
+        auto *text = dynamic_cast<TextNode *>(nodes[i + 1].get());
+        if (text) {
+          size_t start = 0;
+          while (start < text->text.size() &&
+                 (text->text[start] == ' ' || text->text[start] == '\t' ||
+                  text->text[start] == '\n' || text->text[start] == '\r')) {
+            start++;
+          }
+          text->text = text->text.substr(start);
+        }
+      }
+    }
+    return result;
+  }
+
+private:
+  bool shouldStripBefore(ASTNode *node) {
+    if (auto *o = dynamic_cast<OutputNode *>(node))
+      return o->strip_before;
+    if (auto *i = dynamic_cast<IfNode *>(node))
+      return i->strip_before;
+    if (auto *f = dynamic_cast<ForNode *>(node))
+      return f->strip_before;
+    if (auto *s = dynamic_cast<SetNode *>(node))
+      return s->strip_before;
+    return false;
+  }
+
+  bool shouldStripAfter(ASTNode *node) {
+    if (auto *o = dynamic_cast<OutputNode *>(node))
+      return o->strip_after;
+    if (auto *i = dynamic_cast<IfNode *>(node))
+      return i->strip_after;
+    if (auto *f = dynamic_cast<ForNode *>(node))
+      return f->strip_after;
+    if (auto *s = dynamic_cast<SetNode *>(node))
+      return s->strip_after;
+    return false;
+  }
+
+  std::string evalNode(ASTNode *node) {
+    if (auto *text = dynamic_cast<TextNode *>(node)) {
+      return text->text;
+    }
+    if (auto *output = dynamic_cast<OutputNode *>(node)) {
+      json val = evalExpr(output->expr.get());
+      return jsonToString(val);
+    }
+    if (auto *if_node = dynamic_cast<IfNode *>(node)) {
+      return evalIf(if_node);
+    }
+    if (auto *for_node = dynamic_cast<ForNode *>(node)) {
+      return evalFor(for_node);
+    }
+    if (auto *set_node = dynamic_cast<SetNode *>(node)) {
+      json val = evalExpr(set_node->value.get());
+      if (!set_node->attr_name.empty()) {
+        // Namespace attribute mutation: "set ns.attr = val"
+        // Find the namespace object and mutate it in place
+        for (auto it = scopes_.rbegin(); it != scopes_.rend(); ++it) {
+          if (it->contains(set_node->var_name)) {
+            (*it)[set_node->var_name][set_node->attr_name] = val;
+            break;
+          }
+        }
+      } else {
+        setVariable(set_node->var_name, val);
+      }
+      return "";
+    }
+    return "";
+  }
+
+  std::string evalIf(IfNode *node) {
+    for (auto &branch : node->branches) {
+      if (!branch.condition || isTruthy(evalExpr(branch.condition.get()))) {
+        return evaluate(branch.body);
+      }
+    }
+    return "";
+  }
+
+  std::string evalFor(ForNode *node) {
+    json iterable = evalExpr(node->iterable.get());
+    if (!iterable.is_array())
+      return "";
+
+    std::string result;
+    size_t size = iterable.size();
+
+    for (size_t i = 0; i < size; ++i) {
+      // Push new scope with loop variable
+      json scope;
+      scope[node->var_name] = iterable[i];
+
+      // Loop context
+      json loop;
+      loop["index"] = static_cast<int>(i + 1);
+      loop["index0"] = static_cast<int>(i);
+      loop["first"] = (i == 0);
+      loop["last"] = (i == size - 1);
+      loop["length"] = static_cast<int>(size);
+      scope["loop"] = loop;
+
+      scopes_.push_back(scope);
+      result += evaluate(node->body);
+      scopes_.pop_back();
+    }
+
+    return result;
+  }
+
+  json evalExpr(ExprNode *node) {
+    if (auto *str = dynamic_cast<StringLiteral *>(node)) {
+      return str->value;
+    }
+    if (auto *num = dynamic_cast<IntegerLiteral *>(node)) {
+      return num->value;
+    }
+    if (auto *b = dynamic_cast<BoolLiteral *>(node)) {
+      return b->value;
+    }
+    if (dynamic_cast<NoneLiteral *>(node)) {
+      return nullptr;
+    }
+    if (auto *var = dynamic_cast<VariableExpr *>(node)) {
+      return lookupVariable(var->name);
+    }
+    if (auto *attr = dynamic_cast<AttributeExpr *>(node)) {
+      json obj = evalExpr(attr->object.get());
+      if (obj.is_object() && obj.contains(attr->attribute)) {
+        return obj[attr->attribute];
+      }
+      return nullptr;
+    }
+    if (auto *idx = dynamic_cast<IndexExpr *>(node)) {
+      json obj = evalExpr(idx->object.get());
+      json index = evalExpr(idx->index.get());
+      if (obj.is_array() && index.is_number_integer()) {
+        int i = index.get<int>();
+        if (i >= 0 && i < static_cast<int>(obj.size()))
+          return obj[i];
+      } else if (obj.is_object() && index.is_string()) {
+        std::string key = index.get<std::string>();
+        if (obj.contains(key))
+          return obj[key];
+      }
+      return nullptr;
+    }
+    if (auto *bin = dynamic_cast<BinaryExpr *>(node)) {
+      return evalBinary(bin);
+    }
+    if (auto *unary = dynamic_cast<UnaryExpr *>(node)) {
+      if (unary->op == "not") {
+        return !isTruthy(evalExpr(unary->operand.get()));
+      }
+    }
+    if (auto *filter = dynamic_cast<FilterExpr *>(node)) {
+      json val = evalExpr(filter->value.get());
+      if (filter->filter_name == "trim" && val.is_string()) {
+        std::string s = val.get<std::string>();
+        // Trim whitespace
+        size_t start = s.find_first_not_of(" \t\n\r");
+        size_t end = s.find_last_not_of(" \t\n\r");
+        if (start == std::string::npos)
+          return "";
+        return s.substr(start, end - start + 1);
+      }
+      if (filter->filter_name == "length") {
+        if (val.is_array())
+          return static_cast<int>(val.size());
+        if (val.is_string())
+          return static_cast<int>(val.get<std::string>().size());
+        return 0;
+      }
+      if (filter->filter_name == "tojson") {
+        return val.dump();
+      }
+      return val; // unknown filter, passthrough
+    }
+    if (auto *def = dynamic_cast<IsDefinedExpr *>(node)) {
+      // Check if the variable exists in any scope
+      if (auto *var = dynamic_cast<VariableExpr *>(def->value.get())) {
+        for (auto it = scopes_.rbegin(); it != scopes_.rend(); ++it) {
+          if (it->contains(var->name))
+            return true;
+        }
+        return false;
+      }
+      // For attribute access, check if the parent exists and has the attr
+      if (auto *attr = dynamic_cast<AttributeExpr *>(def->value.get())) {
+        json obj = evalExpr(attr->object.get());
+        return obj.is_object() && obj.contains(attr->attribute);
+      }
+      return false;
+    }
+    if (auto *call = dynamic_cast<FunctionCallExpr *>(node)) {
+      if (call->name == "raise_exception") {
+        std::string msg = "Template error";
+        if (!call->args.empty()) {
+          json arg = evalExpr(call->args[0].get());
+          if (arg.is_string())
+            msg = arg.get<std::string>();
+        }
+        throw std::runtime_error("ChatTemplate: " + msg);
+      }
+      if (call->name == "namespace") {
+        // namespace() creates a mutable object that persists across scopes
+        // keyword args are not parsed at AST level, so we return empty object
+        // The actual initialization happens via {% set ns.attr = val %}
+        return json::object();
+      }
+      // Type-checking built-in tests
+      if (call->name == "__is_string") {
+        if (!call->args.empty()) {
+          json val = evalExpr(call->args[0].get());
+          return val.is_string();
+        }
+        return false;
+      }
+      if (call->name == "__is_none") {
+        if (!call->args.empty()) {
+          json val = evalExpr(call->args[0].get());
+          return val.is_null();
+        }
+        return false;
+      }
+      if (call->name == "__is_number") {
+        if (!call->args.empty()) {
+          json val = evalExpr(call->args[0].get());
+          return val.is_number();
+        }
+        return false;
+      }
+      return nullptr;
+    }
+    if (auto *method = dynamic_cast<MethodCallExpr *>(node)) {
+      return evalMethodCall(method);
+    }
+    if (auto *slice = dynamic_cast<SliceExpr *>(node)) {
+      return evalSlice(slice);
+    }
+    if (auto *contains = dynamic_cast<ContainsExpr *>(node)) {
+      json item = evalExpr(contains->item.get());
+      json container = evalExpr(contains->container.get());
+      // String containment: 'x' in 'xyz'
+      if (item.is_string() && container.is_string()) {
+        return container.get<std::string>().find(item.get<std::string>()) !=
+               std::string::npos;
+      }
+      // Array containment
+      if (container.is_array()) {
+        for (const auto &elem : container) {
+          if (elem == item)
+            return true;
+        }
+        return false;
+      }
+      // Object key containment
+      if (container.is_object() && item.is_string()) {
+        return container.contains(item.get<std::string>());
+      }
+      return false;
+    }
+    return nullptr;
+  }
+
+  json evalMethodCall(MethodCallExpr *node) {
+    json obj = evalExpr(node->object.get());
+    const std::string &method = node->method;
+
+    if (obj.is_string()) {
+      std::string s = obj.get<std::string>();
+
+      if (method == "startswith" && !node->args.empty()) {
+        json arg = evalExpr(node->args[0].get());
+        if (arg.is_string()) {
+          std::string prefix = arg.get<std::string>();
+          return s.size() >= prefix.size() &&
+                 s.compare(0, prefix.size(), prefix) == 0;
+        }
+        return false;
+      }
+      if (method == "endswith" && !node->args.empty()) {
+        json arg = evalExpr(node->args[0].get());
+        if (arg.is_string()) {
+          std::string suffix = arg.get<std::string>();
+          return s.size() >= suffix.size() &&
+                 s.compare(s.size() - suffix.size(), suffix.size(), suffix) ==
+                   0;
+        }
+        return false;
+      }
+      if (method == "strip") {
+        std::string chars = " \t\n\r";
+        if (!node->args.empty()) {
+          json arg = evalExpr(node->args[0].get());
+          if (arg.is_string())
+            chars = arg.get<std::string>();
+        }
+        size_t start = s.find_first_not_of(chars);
+        if (start == std::string::npos)
+          return std::string("");
+        size_t end = s.find_last_not_of(chars);
+        return s.substr(start, end - start + 1);
+      }
+      if (method == "lstrip") {
+        std::string chars = " \t\n\r";
+        if (!node->args.empty()) {
+          json arg = evalExpr(node->args[0].get());
+          if (arg.is_string())
+            chars = arg.get<std::string>();
+        }
+        size_t start = s.find_first_not_of(chars);
+        if (start == std::string::npos)
+          return std::string("");
+        return s.substr(start);
+      }
+      if (method == "rstrip") {
+        std::string chars = " \t\n\r";
+        if (!node->args.empty()) {
+          json arg = evalExpr(node->args[0].get());
+          if (arg.is_string())
+            chars = arg.get<std::string>();
+        }
+        size_t end = s.find_last_not_of(chars);
+        if (end == std::string::npos)
+          return std::string("");
+        return s.substr(0, end + 1);
+      }
+      if (method == "split" && !node->args.empty()) {
+        json arg = evalExpr(node->args[0].get());
+        if (arg.is_string()) {
+          std::string delimiter = arg.get<std::string>();
+          json result = json::array();
+          size_t pos = 0;
+          size_t found;
+          while ((found = s.find(delimiter, pos)) != std::string::npos) {
+            result.push_back(s.substr(pos, found - pos));
+            pos = found + delimiter.size();
+          }
+          result.push_back(s.substr(pos));
+          return result;
+        }
+      }
+      if (method == "upper") {
+        std::string result = s;
+        std::transform(result.begin(), result.end(), result.begin(), ::toupper);
+        return result;
+      }
+      if (method == "lower") {
+        std::string result = s;
+        std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+        return result;
+      }
+    }
+
+    return nullptr;
+  }
+
+  json evalSlice(SliceExpr *node) {
+    json obj = evalExpr(node->object.get());
+    if (!obj.is_array())
+      return json::array();
+
+    int size = static_cast<int>(obj.size());
+    int start = 0, stop = size, step = 1;
+
+    if (node->start)
+      start = evalExpr(node->start.get()).get<int>();
+    if (node->stop)
+      stop = evalExpr(node->stop.get()).get<int>();
+    if (node->step)
+      step = evalExpr(node->step.get()).get<int>();
+
+    // Handle negative indices
+    if (start < 0)
+      start = std::max(0, size + start);
+    if (stop < 0)
+      stop = std::max(0, size + stop);
+
+    // Clamp
+    start = std::max(0, std::min(start, size));
+    stop = std::max(0, std::min(stop, size));
+
+    json result = json::array();
+    if (step > 0) {
+      for (int i = start; i < stop; i += step)
+        result.push_back(obj[i]);
+    } else if (step < 0) {
+      // Reverse iteration: e.g., [::-1]
+      if (!node->start)
+        start = size - 1;
+      if (!node->stop)
+        stop = -1;
+      else if (stop < 0)
+        stop = std::max(-1, size + stop);
+      // Re-clamp for reverse
+      if (start >= size)
+        start = size - 1;
+      for (int i = start; i > stop; i += step) {
+        if (i >= 0 && i < size)
+          result.push_back(obj[i]);
+      }
+    }
+
+    return result;
+  }
+
+  json evalBinary(BinaryExpr *node) {
+    json left = evalExpr(node->left.get());
+    json right = evalExpr(node->right.get());
+
+    if (node->op == "+" || node->op == "~") {
+      if (node->op == "~") {
+        // Tilde always does string concat
+        return jsonToString(left) + jsonToString(right);
+      }
+      if (left.is_string() && right.is_string()) {
+        return left.get<std::string>() + right.get<std::string>();
+      }
+      if (left.is_number() && right.is_number()) {
+        return left.get<int>() + right.get<int>();
+      }
+      // String + non-string: convert to string
+      return jsonToString(left) + jsonToString(right);
+    }
+    if (node->op == "-") {
+      if (left.is_number() && right.is_number()) {
+        return left.get<int>() - right.get<int>();
+      }
+      return 0;
+    }
+    if (node->op == "==") {
+      return left == right;
+    }
+    if (node->op == "!=") {
+      return left != right;
+    }
+    if (node->op == ">") {
+      if (left.is_number() && right.is_number())
+        return left.get<int>() > right.get<int>();
+      return false;
+    }
+    if (node->op == "<") {
+      if (left.is_number() && right.is_number())
+        return left.get<int>() < right.get<int>();
+      return false;
+    }
+    if (node->op == ">=") {
+      if (left.is_number() && right.is_number())
+        return left.get<int>() >= right.get<int>();
+      return false;
+    }
+    if (node->op == "<=") {
+      if (left.is_number() && right.is_number())
+        return left.get<int>() <= right.get<int>();
+      return false;
+    }
+    if (node->op == "%") {
+      if (left.is_number_integer() && right.is_number_integer()) {
+        int r = right.get<int>();
+        if (r != 0)
+          return left.get<int>() % r;
+      }
+      return 0;
+    }
+    if (node->op == "and") {
+      return isTruthy(left) && isTruthy(right);
+    }
+    if (node->op == "or") {
+      return isTruthy(left) || isTruthy(right);
+    }
+    return nullptr;
+  }
+
+  bool isTruthy(const json &val) {
+    if (val.is_null())
+      return false;
+    if (val.is_boolean())
+      return val.get<bool>();
+    if (val.is_number_integer())
+      return val.get<int>() != 0;
+    if (val.is_string())
+      return !val.get<std::string>().empty();
+    if (val.is_array())
+      return !val.empty();
+    if (val.is_object())
+      return !val.empty();
+    return false;
+  }
+
+  std::string jsonToString(const json &val) {
+    if (val.is_string())
+      return val.get<std::string>();
+    if (val.is_null())
+      return "";
+    if (val.is_boolean())
+      return val.get<bool>() ? "True" : "False";
+    if (val.is_number_integer())
+      return std::to_string(val.get<int>());
+    if (val.is_number_float())
+      return std::to_string(val.get<double>());
+    return val.dump();
+  }
+
+  json lookupVariable(const std::string &name) {
+    // Search from innermost scope to outermost
+    for (auto it = scopes_.rbegin(); it != scopes_.rend(); ++it) {
+      if (it->contains(name))
+        return (*it)[name];
+    }
+    return nullptr;
+  }
+
+  void setVariable(const std::string &name, const json &value) {
+    // Set in the current (innermost) scope
+    if (!scopes_.empty()) {
+      scopes_.back()[name] = value;
+    }
+  }
+
+  std::vector<json> scopes_;
+};
+
+// ============================================================================
+// ChatTemplate Implementation
+// ============================================================================
+
+ChatTemplate::ChatTemplate() : available_(false) {}
+
+ChatTemplate ChatTemplate::fromFile(const std::string &tokenizer_config_path) {
+  ChatTemplate tmpl;
+
+  std::ifstream file(tokenizer_config_path);
+  if (!file.is_open()) {
+    std::cerr << "[ChatTemplate] Warning: cannot open " << tokenizer_config_path
+              << std::endl;
+    return tmpl;
+  }
+
+  json config;
+  try {
+    file >> config;
+  } catch (const json::parse_error &e) {
+    std::cerr << "[ChatTemplate] Warning: JSON parse error in "
+              << tokenizer_config_path << ": " << e.what() << std::endl;
+    return tmpl;
+  }
+
+  // Extract chat_template
+  if (config.contains("chat_template")) {
+    if (config["chat_template"].is_string()) {
+      tmpl.template_str_ = config["chat_template"].get<std::string>();
+    } else if (config["chat_template"].is_array()) {
+      // Some models have an array of templates; use the first one
+      for (const auto &entry : config["chat_template"]) {
+        if (entry.is_object() && entry.contains("template")) {
+          tmpl.template_str_ = entry["template"].get<std::string>();
+          break;
+        }
+      }
+    }
+  }
+
+  if (tmpl.template_str_.empty()) {
+    return tmpl;
+  }
+
+  // Extract bos_token (can be string or object with "content" field)
+  if (config.contains("bos_token")) {
+    if (config["bos_token"].is_string()) {
+      tmpl.bos_token_ = config["bos_token"].get<std::string>();
+    } else if (config["bos_token"].is_object() &&
+               config["bos_token"].contains("content")) {
+      tmpl.bos_token_ = config["bos_token"]["content"].get<std::string>();
+    }
+  }
+
+  // Extract eos_token
+  if (config.contains("eos_token")) {
+    if (config["eos_token"].is_string()) {
+      tmpl.eos_token_ = config["eos_token"].get<std::string>();
+    } else if (config["eos_token"].is_object() &&
+               config["eos_token"].contains("content")) {
+      tmpl.eos_token_ = config["eos_token"]["content"].get<std::string>();
+    }
+  }
+
+  tmpl.available_ = true;
+  return tmpl;
+}
+
+std::string ChatTemplate::apply(const std::vector<ChatMessage> &messages,
+                                bool add_generation_prompt) const {
+  if (!available_)
+    return "";
+
+  // Build context
+  json context;
+  json msgs = json::array();
+  for (const auto &msg : messages) {
+    json m;
+    m["role"] = msg.role;
+    m["content"] = msg.content;
+    msgs.push_back(m);
+  }
+  context["messages"] = msgs;
+  context["bos_token"] = bos_token_;
+  context["eos_token"] = eos_token_;
+  context["add_generation_prompt"] = add_generation_prompt;
+
+  return render(template_str_, context);
+}
+
+std::string ChatTemplate::apply(const std::string &user_input,
+                                bool add_generation_prompt) const {
+  std::vector<ChatMessage> messages = {{"user", user_input}};
+  return apply(messages, add_generation_prompt);
+}
+
+bool ChatTemplate::isAvailable() const { return available_; }
+
+std::string ChatTemplate::getBosToken() const { return bos_token_; }
+
+std::string ChatTemplate::getEosToken() const { return eos_token_; }
+
+std::string ChatTemplate::render(const std::string &tmpl,
+                                 const json &context) const {
+  try {
+    Lexer lexer(tmpl);
+    auto tokens = lexer.tokenize();
+
+    Parser parser(tokens);
+    auto ast = parser.parse();
+
+    Evaluator evaluator(context);
+    return evaluator.evaluate(ast);
+  } catch (const std::exception &e) {
+    std::cerr << "[ChatTemplate] Render error: " << e.what() << std::endl;
+    return "";
+  }
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -25,6 +25,7 @@ namespace causallm {
 // ============================================================================
 // Token types for the Jinja2 lexer
 // ============================================================================
+/** @brief TokenType - enum class for Jinja2 template processing */
 enum class TokenType {
   TEXT,
   EXPRESSION_START, // {{
@@ -72,6 +73,7 @@ enum class TokenType {
   END_OF_INPUT,
 };
 
+/** @brief Lexer token with type, value, and whitespace control flags */
 struct Token {
   TokenType type;
   std::string value;
@@ -82,10 +84,13 @@ struct Token {
 // ============================================================================
 // Lexer
 // ============================================================================
+/** @brief Tokenizes Jinja2 template strings into token sequences */
 class Lexer {
 public:
+  /** @brief Construct lexer with input template string */
   explicit Lexer(const std::string &input) : input_(input), pos_(0) {}
 
+  /** @brief Tokenize the input template into a sequence of tokens */
   std::vector<Token> tokenize() {
     std::vector<Token> tokens;
 
@@ -140,6 +145,7 @@ public:
   }
 
 private:
+  /** @brief Try to match a string at current position and advance */
   bool match(const std::string &s) {
     if (pos_ + s.size() <= input_.size() &&
         input_.substr(pos_, s.size()) == s) {
@@ -149,11 +155,13 @@ private:
     return false;
   }
 
+  /** @brief Skip whitespace characters at current position */
   void skipWhitespace() {
     while (pos_ < input_.size() && std::isspace(input_[pos_]))
       pos_++;
   }
 
+  /** @brief Tokenize content inside expression or statement tags */
   void tokenizeInside(std::vector<Token> &tokens, TokenType end_type) {
     while (pos_ < input_.size()) {
       skipWhitespace();
@@ -329,6 +337,7 @@ private:
     }
   }
 
+  /** @brief Read a string literal token */
   Token readString() {
     char quote = input_[pos_++];
     std::string value;
@@ -370,6 +379,7 @@ private:
     return t;
   }
 
+  /** @brief Read a numeric literal token */
   Token readNumber() {
     std::string value;
     bool has_dot = false;
@@ -388,6 +398,7 @@ private:
     return t;
   }
 
+  /** @brief Read an identifier or keyword token */
   Token readIdentifier() {
     std::string value;
     while (pos_ < input_.size() &&
@@ -442,36 +453,43 @@ private:
 // ============================================================================
 // AST Nodes
 // ============================================================================
+/** @brief Base AST node for template parsing */
 struct ASTNode {
   virtual ~ASTNode() = default;
 };
 
 using ASTNodePtr = std::shared_ptr<ASTNode>;
 
+/** @brief Base expression AST node */
 struct ExprNode : ASTNode {};
 using ExprNodePtr = std::shared_ptr<ExprNode>;
 
+/** @brief AST node for literal text output */
 struct TextNode : ASTNode {
   std::string text;
 };
 
+/** @brief AST node for expression output ({{ expr }}) */
 struct OutputNode : ASTNode {
   ExprNodePtr expr;
   bool strip_before = false;
   bool strip_after = false;
 };
 
+/** @brief Single branch of an if/elif/else block */
 struct IfBranch {
   ExprNodePtr condition; // nullptr for else branch
   std::vector<ASTNodePtr> body;
 };
 
+/** @brief AST node for if/elif/else conditional blocks */
 struct IfNode : ASTNode {
   std::vector<IfBranch> branches;
   bool strip_before = false;
   bool strip_after = false;
 };
 
+/** @brief AST node for for-loop iteration blocks */
 struct ForNode : ASTNode {
   std::string var_name;
   ExprNodePtr iterable;
@@ -480,6 +498,7 @@ struct ForNode : ASTNode {
   bool strip_after = false;
 };
 
+/** @brief AST node for variable assignment (set statement) */
 struct SetNode : ASTNode {
   std::string var_name;
   std::string attr_name; // for "set ns.attr = val" (empty if simple set)
@@ -489,65 +508,79 @@ struct SetNode : ASTNode {
 };
 
 // Expression nodes
+/** @brief Expression node for string literal values */
 struct StringLiteral : ExprNode {
   std::string value;
 };
 
+/** @brief Expression node for integer literal values */
 struct IntegerLiteral : ExprNode {
   int value;
 };
 
+/** @brief Expression node for boolean literal values */
 struct BoolLiteral : ExprNode {
   bool value;
 };
 
+/** @brief Expression node for None/null literal values */
 struct NoneLiteral : ExprNode {};
 
+/** @brief Expression node for variable references */
 struct VariableExpr : ExprNode {
   std::string name;
 };
 
+/** @brief Expression node for attribute access (obj.attr) */
 struct AttributeExpr : ExprNode {
   ExprNodePtr object;
   std::string attribute;
 };
 
+/** @brief Expression node for index access (obj[key]) */
 struct IndexExpr : ExprNode {
   ExprNodePtr object;
   ExprNodePtr index;
 };
 
+/** @brief Expression node for binary operations (+, ==, and, etc.) */
 struct BinaryExpr : ExprNode {
   std::string op; // "+", "==", "!=", "and", "or", "%"
   ExprNodePtr left;
   ExprNodePtr right;
 };
 
+/** @brief Expression node for unary operations (not) */
 struct UnaryExpr : ExprNode {
   std::string op; // "not"
   ExprNodePtr operand;
 };
 
+/** @brief Expression node for filter application (val | filter) */
 struct FilterExpr : ExprNode {
   ExprNodePtr value;
   std::string filter_name;
 };
 
+/** @brief Expression node for "is defined" test */
 struct IsDefinedExpr : ExprNode {
   ExprNodePtr value;
 };
 
+/** @brief Expression node for function calls */
 struct FunctionCallExpr : ExprNode {
   std::string name;
   std::vector<ExprNodePtr> args;
 };
 
+/** @brief Expression node for method calls (obj.method()) */
 struct MethodCallExpr : ExprNode {
   ExprNodePtr object;
   std::string method;
   std::vector<ExprNodePtr> args;
 };
 
+/** @brief Expression node for slice operations (obj[start:stop:step]) */
 struct SliceExpr : ExprNode {
   ExprNodePtr object;
   ExprNodePtr start; // nullable
@@ -555,6 +588,7 @@ struct SliceExpr : ExprNode {
   ExprNodePtr step;  // nullable
 };
 
+/** @brief Expression node for "in" containment test */
 struct ContainsExpr : ExprNode {
   ExprNodePtr item;
   ExprNodePtr container;
@@ -563,11 +597,13 @@ struct ContainsExpr : ExprNode {
 // ============================================================================
 // Parser
 // ============================================================================
+/** @brief Parses token sequences into an AST for template rendering */
 class Parser {
 public:
   explicit Parser(const std::vector<Token> &tokens) :
     tokens_(tokens), pos_(0) {}
 
+  /** @brief Parse tokens into AST node list */
   std::vector<ASTNodePtr> parse() {
     std::vector<ASTNodePtr> nodes;
     parseBody(nodes, {});
@@ -575,12 +611,16 @@ public:
   }
 
 private:
+  /** @brief Get the current token without advancing */
   const Token &current() const { return tokens_[pos_]; }
 
+  /** @brief Advance to next token and return the current one */
   const Token &advance() { return tokens_[pos_++]; }
 
+  /** @brief Check if current token matches the given type */
   bool check(TokenType type) const { return current().type == type; }
 
+  /** @brief Match current token type and advance if matched */
   bool matchToken(TokenType type) {
     if (check(type)) {
       advance();
@@ -589,6 +629,7 @@ private:
     return false;
   }
 
+  /** @brief Expect current token to match type, throw on mismatch */
   Token expect(TokenType type) {
     if (!check(type)) {
       throw std::runtime_error("ChatTemplate parser: unexpected token '" +
@@ -598,6 +639,7 @@ private:
     return advance();
   }
 
+  /** @brief Parse template body until a stop keyword is found */
   void parseBody(std::vector<ASTNodePtr> &nodes,
                  const std::vector<TokenType> &stop_keywords) {
     while (pos_ < tokens_.size() && current().type != TokenType::END_OF_INPUT) {
@@ -635,6 +677,7 @@ private:
     }
   }
 
+  /** @brief Parse an output expression block ({{ expr }}) */
   ASTNodePtr parseOutput() {
     auto node = std::make_shared<OutputNode>();
     Token start = expect(TokenType::EXPRESSION_START);
@@ -645,6 +688,7 @@ private:
     return node;
   }
 
+  /** @brief Parse a statement block ({% ... %}) */
   void parseStatement(std::vector<ASTNodePtr> &nodes) {
     Token start = expect(TokenType::STATEMENT_START);
     bool strip_before = start.strip_before;
@@ -666,6 +710,7 @@ private:
     }
   }
 
+  /** @brief Parse an if/elif/else/endif block */
   ASTNodePtr parseIf(bool strip_before) {
     auto node = std::make_shared<IfNode>();
     node->strip_before = strip_before;
@@ -714,6 +759,7 @@ private:
     return node;
   }
 
+  /** @brief Parse a for/endfor loop block */
   ASTNodePtr parseFor(bool strip_before) {
     auto node = std::make_shared<ForNode>();
     node->strip_before = strip_before;
@@ -735,6 +781,7 @@ private:
     return node;
   }
 
+  /** @brief Parse a set variable assignment statement */
   ASTNodePtr parseSet(bool strip_before) {
     auto node = std::make_shared<SetNode>();
     node->strip_before = strip_before;
@@ -757,8 +804,10 @@ private:
   }
 
   // Expression parsing with precedence
+  /** @brief Parse a complete expression with precedence */
   ExprNodePtr parseExpression() { return parseOr(); }
 
+  /** @brief Parse OR boolean expression */
   ExprNodePtr parseOr() {
     auto left = parseAnd();
     while (check(TokenType::OR)) {
@@ -773,6 +822,7 @@ private:
     return left;
   }
 
+  /** @brief Parse AND boolean expression */
   ExprNodePtr parseAnd() {
     auto left = parseNot();
     while (check(TokenType::AND)) {
@@ -787,6 +837,7 @@ private:
     return left;
   }
 
+  /** @brief Parse NOT unary boolean expression */
   ExprNodePtr parseNot() {
     if (check(TokenType::NOT)) {
       advance();
@@ -798,6 +849,7 @@ private:
     return parseComparison();
   }
 
+  /** @brief Parse comparison and "is" test expressions */
   ExprNodePtr parseComparison() {
     auto left = parseContains();
 
@@ -913,6 +965,7 @@ private:
   }
 
   // "in" / "not in" containment
+  /** @brief Parse "in" containment expression */
   ExprNodePtr parseContains() {
     auto left = parseAddition();
 
@@ -929,6 +982,7 @@ private:
     return left;
   }
 
+  /** @brief Parse addition, subtraction, and tilde concat */
   ExprNodePtr parseAddition() {
     auto left = parseModulo();
     while (check(TokenType::PLUS) || check(TokenType::MINUS) ||
@@ -944,6 +998,7 @@ private:
     return left;
   }
 
+  /** @brief Parse modulo arithmetic expression */
   ExprNodePtr parseModulo() {
     auto left = parseFilter();
     while (check(TokenType::PERCENT)) {
@@ -958,6 +1013,7 @@ private:
     return left;
   }
 
+  /** @brief Parse pipe filter expression (val | filter) */
   ExprNodePtr parseFilter() {
     auto left = parsePostfix();
     while (check(TokenType::PIPE)) {
@@ -971,6 +1027,7 @@ private:
     return left;
   }
 
+  /** @brief Parse postfix operations (dot, index, method, slice) */
   ExprNodePtr parsePostfix() {
     auto node = parsePrimary();
     while (true) {
@@ -1066,6 +1123,7 @@ private:
     return node;
   }
 
+  /** @brief Parse primary expression (literals, variables, parens) */
   ExprNodePtr parsePrimary() {
     // Unary minus
     if (check(TokenType::MINUS)) {
@@ -1177,10 +1235,13 @@ private:
 // ============================================================================
 // Evaluator
 // ============================================================================
+/** @brief Evaluates AST nodes to produce rendered template output */
 class Evaluator {
 public:
+  /** @brief Construct evaluator with template context variables */
   explicit Evaluator(const json &context) { scopes_.push_back(context); }
 
+  /** @brief Evaluate AST node list and return rendered string */
   std::string evaluate(const std::vector<ASTNodePtr> &nodes) {
     std::string result;
     for (size_t i = 0; i < nodes.size(); ++i) {
@@ -1216,6 +1277,7 @@ public:
   }
 
 private:
+  /** @brief Check if node has strip-before whitespace control */
   bool shouldStripBefore(ASTNode *node) {
     if (auto *o = dynamic_cast<OutputNode *>(node))
       return o->strip_before;
@@ -1228,6 +1290,7 @@ private:
     return false;
   }
 
+  /** @brief Check if node has strip-after whitespace control */
   bool shouldStripAfter(ASTNode *node) {
     if (auto *o = dynamic_cast<OutputNode *>(node))
       return o->strip_after;
@@ -1240,6 +1303,7 @@ private:
     return false;
   }
 
+  /** @brief Evaluate a single AST node and return its string result */
   std::string evalNode(ASTNode *node) {
     if (auto *text = dynamic_cast<TextNode *>(node)) {
       return text->text;
@@ -1273,6 +1337,7 @@ private:
     return "";
   }
 
+  /** @brief Evaluate an if/elif/else conditional node */
   std::string evalIf(IfNode *node) {
     for (auto &branch : node->branches) {
       if (!branch.condition || isTruthy(evalExpr(branch.condition.get()))) {
@@ -1282,6 +1347,7 @@ private:
     return "";
   }
 
+  /** @brief Evaluate a for-loop node over an iterable */
   std::string evalFor(ForNode *node) {
     json iterable = evalExpr(node->iterable.get());
     if (!iterable.is_array())
@@ -1312,6 +1378,7 @@ private:
     return result;
   }
 
+  /** @brief Evaluate an expression node and return JSON value */
   json evalExpr(ExprNode *node) {
     if (auto *str = dynamic_cast<StringLiteral *>(node)) {
       return str->value;
@@ -1467,6 +1534,7 @@ private:
     return nullptr;
   }
 
+  /** @brief Evaluate a method call on a string object */
   json evalMethodCall(MethodCallExpr *node) {
     json obj = evalExpr(node->object.get());
     const std::string &method = node->method;
@@ -1560,6 +1628,7 @@ private:
     return nullptr;
   }
 
+  /** @brief Evaluate an array slice expression */
   json evalSlice(SliceExpr *node) {
     json obj = evalExpr(node->object.get());
     if (!obj.is_array())
@@ -1609,6 +1678,7 @@ private:
     return result;
   }
 
+  /** @brief Evaluate a binary operation expression */
   json evalBinary(BinaryExpr *node) {
     json left = evalExpr(node->left.get());
     json right = evalExpr(node->right.get());
@@ -1676,6 +1746,7 @@ private:
     return nullptr;
   }
 
+  /** @brief Check if a JSON value is truthy */
   bool isTruthy(const json &val) {
     if (val.is_null())
       return false;
@@ -1692,6 +1763,7 @@ private:
     return false;
   }
 
+  /** @brief Convert a JSON value to its string representation */
   std::string jsonToString(const json &val) {
     if (val.is_string())
       return val.get<std::string>();
@@ -1706,6 +1778,7 @@ private:
     return val.dump();
   }
 
+  /** @brief Look up a variable name in scope chain */
   json lookupVariable(const std::string &name) {
     // Search from innermost scope to outermost
     for (auto it = scopes_.rbegin(); it != scopes_.rend(); ++it) {
@@ -1715,6 +1788,7 @@ private:
     return nullptr;
   }
 
+  /** @brief Set a variable in the current innermost scope */
   void setVariable(const std::string &name, const json &value) {
     // Set in the current (innermost) scope
     if (!scopes_.empty()) {
@@ -1766,6 +1840,8 @@ ChatTemplate ChatTemplate::fromFile(const std::string &tokenizer_config_path) {
   }
 
   if (tmpl.template_str_.empty()) {
+    std::cerr << "[ChatTemplate] Warning: no 'chat_template' field found in "
+              << tokenizer_config_path << std::endl;
     return tmpl;
   }
 

--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -1823,9 +1823,8 @@ private:
 
 ChatTemplate::ChatTemplate() : available_(false) {}
 
-ChatTemplate
-ChatTemplate::fromFile(const std::string &tokenizer_config_path,
-                       const std::string &template_name) {
+ChatTemplate ChatTemplate::fromFile(const std::string &tokenizer_config_path,
+                                    const std::string &template_name) {
   ChatTemplate tmpl;
 
   std::ifstream file(tokenizer_config_path);
@@ -1863,9 +1862,9 @@ ChatTemplate::fromFile(const std::string &tokenizer_config_path,
       if (tmpl.template_str_.empty()) {
         for (const auto &entry : config["chat_template"]) {
           if (entry.is_object() && entry.contains("template")) {
-            std::string fallback_name =
-              entry.contains("name") ? entry["name"].get<std::string>()
-                                     : "(unnamed)";
+            std::string fallback_name = entry.contains("name")
+                                          ? entry["name"].get<std::string>()
+                                          : "(unnamed)";
             std::cerr << "[ChatTemplate] Template '" << template_name
                       << "' not found. Using '" << fallback_name << "'."
                       << std::endl;

--- a/Applications/CausalLM/chat_template.cpp
+++ b/Applications/CausalLM/chat_template.cpp
@@ -1823,7 +1823,9 @@ private:
 
 ChatTemplate::ChatTemplate() : available_(false) {}
 
-ChatTemplate ChatTemplate::fromFile(const std::string &tokenizer_config_path) {
+ChatTemplate
+ChatTemplate::fromFile(const std::string &tokenizer_config_path,
+                       const std::string &template_name) {
   ChatTemplate tmpl;
 
   std::ifstream file(tokenizer_config_path);
@@ -1847,11 +1849,29 @@ ChatTemplate ChatTemplate::fromFile(const std::string &tokenizer_config_path) {
     if (config["chat_template"].is_string()) {
       tmpl.template_str_ = config["chat_template"].get<std::string>();
     } else if (config["chat_template"].is_array()) {
-      // Some models have an array of templates; use the first one
+      // Array of named templates: select by template_name
+      // First pass: find matching name
       for (const auto &entry : config["chat_template"]) {
-        if (entry.is_object() && entry.contains("template")) {
+        if (entry.is_object() && entry.contains("name") &&
+            entry.contains("template") &&
+            entry["name"].get<std::string>() == template_name) {
           tmpl.template_str_ = entry["template"].get<std::string>();
           break;
+        }
+      }
+      // Fallback: if requested name not found, use first template
+      if (tmpl.template_str_.empty()) {
+        for (const auto &entry : config["chat_template"]) {
+          if (entry.is_object() && entry.contains("template")) {
+            std::string fallback_name =
+              entry.contains("name") ? entry["name"].get<std::string>()
+                                     : "(unnamed)";
+            std::cerr << "[ChatTemplate] Template '" << template_name
+                      << "' not found. Using '" << fallback_name << "'."
+                      << std::endl;
+            tmpl.template_str_ = entry["template"].get<std::string>();
+            break;
+          }
         }
       }
     }

--- a/Applications/CausalLM/chat_template.h
+++ b/Applications/CausalLM/chat_template.h
@@ -48,9 +48,14 @@ public:
   /**
    * @brief Load chat template from tokenizer_config.json
    * @param tokenizer_config_path Path to tokenizer_config.json
+   * @param template_name Template name to select when chat_template is an
+   *        array (e.g., "default", "tool_use"). Ignored if chat_template
+   *        is a string. Defaults to "default".
    * @return ChatTemplate instance
    */
-  static ChatTemplate fromFile(const std::string &tokenizer_config_path);
+  static ChatTemplate fromFile(
+    const std::string &tokenizer_config_path,
+    const std::string &template_name = "default");
 
   /**
    * @brief Apply template to multi-turn messages

--- a/Applications/CausalLM/chat_template.h
+++ b/Applications/CausalLM/chat_template.h
@@ -53,9 +53,8 @@ public:
    *        is a string. Defaults to "default".
    * @return ChatTemplate instance
    */
-  static ChatTemplate fromFile(
-    const std::string &tokenizer_config_path,
-    const std::string &template_name = "default");
+  static ChatTemplate fromFile(const std::string &tokenizer_config_path,
+                               const std::string &template_name = "default");
 
   /**
    * @brief Apply template to multi-turn messages

--- a/Applications/CausalLM/chat_template.h
+++ b/Applications/CausalLM/chat_template.h
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file    chat_template.h
+ * @date    10 Apr 2026
+ * @brief   Chat template support using tokenizer_config.json
+ * @see     https://github.com/nntrainer/nntrainer
+ * @author  Eunju Yang <ej.yang@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifndef __CHAT_TEMPLATE_H__
+#define __CHAT_TEMPLATE_H__
+
+#include <string>
+#include <vector>
+
+#include "json.hpp"
+
+namespace causallm {
+
+using json = nlohmann::json;
+
+/**
+ * @brief Chat message structure for multi-turn conversations
+ */
+struct ChatMessage {
+  std::string role;    // "system", "user", "assistant"
+  std::string content; // message content
+};
+
+/**
+ * @brief Chat template class that reads and applies HuggingFace chat templates
+ *
+ * Loads chat_template from tokenizer_config.json and renders it using a
+ * minimal Jinja2 subset renderer. Supports common constructs used in
+ * HuggingFace chat templates: for loops, if/elif/else, variable access,
+ * string operations, loop variables, and filters.
+ */
+class ChatTemplate {
+public:
+  /**
+   * @brief Default constructor (no template loaded)
+   */
+  ChatTemplate();
+
+  /**
+   * @brief Load chat template from tokenizer_config.json
+   * @param tokenizer_config_path Path to tokenizer_config.json
+   * @return ChatTemplate instance
+   */
+  static ChatTemplate fromFile(const std::string &tokenizer_config_path);
+
+  /**
+   * @brief Apply template to multi-turn messages
+   * @param messages Vector of ChatMessage (role + content)
+   * @param add_generation_prompt Whether to add generation prompt at end
+   * @return Formatted prompt string
+   */
+  std::string apply(const std::vector<ChatMessage> &messages,
+                    bool add_generation_prompt = true) const;
+
+  /**
+   * @brief Apply template to a single user input (convenience)
+   * @param user_input Raw user input string
+   * @param add_generation_prompt Whether to add generation prompt at end
+   * @return Formatted prompt string
+   */
+  std::string apply(const std::string &user_input,
+                    bool add_generation_prompt = true) const;
+
+  /**
+   * @brief Check if a chat template is loaded and available
+   * @return true if template is available
+   */
+  bool isAvailable() const;
+
+  /**
+   * @brief Get BOS token
+   */
+  std::string getBosToken() const;
+
+  /**
+   * @brief Get EOS token
+   */
+  std::string getEosToken() const;
+
+private:
+  std::string template_str_;
+  std::string bos_token_;
+  std::string eos_token_;
+  bool available_ = false;
+
+  /**
+   * @brief Render a Jinja2 template with the given context
+   * @param tmpl Jinja2 template string
+   * @param context JSON object with template variables
+   * @return Rendered string
+   */
+  std::string render(const std::string &tmpl, const json &context) const;
+};
+
+} // namespace causallm
+
+#endif // __CHAT_TEMPLATE_H__

--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -58,6 +58,7 @@ LOCAL_MODULE := causallm_core
 LOCAL_LDLIBS := -llog -landroid -fopenmp -static-openmp -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1
 
 LOCAL_SRC_FILES := \
+    ../chat_template.cpp \
     ../models/causal_lm.cpp \
     ../models/transformer.cpp \
     ../models/sentence_transformer.cpp \

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -186,6 +186,29 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
 
 /************************************************************** */
 
+void MHACoreLayer::resetCache(nntrainer::RunLayerContext &context) {
+  cache_index = 0;
+  // Cache tensors are requested via requestTensor() during finalize but are
+  // not actually allocated until the first incremental_inference() call that
+  // triggers model_graph tensor allocation. resetConversation() may be
+  // invoked (by test harnesses, or by a user who resets before ever running
+  // a turn) before any inference has happened, in which case the cache
+  // tensors carry no backing memory yet and setZero() would crash. Zeroing
+  // is defense-in-depth anyway (cache_index=0 alone is sufficient because
+  // the attention read range is bounded by cache_index + step_size), so skip
+  // it when the tensor is not yet allocated.
+  nntrainer::Tensor &cache_key =
+    context.getTensor(tensor_idx[AttentionParams::cache_key]);
+  nntrainer::Tensor &cache_value =
+    context.getTensor(tensor_idx[AttentionParams::cache_value]);
+  if (cache_key.isAllocated())
+    cache_key.setZero();
+  if (cache_value.isAllocated())
+    cache_value.setZero();
+}
+
+/************************************************************** */
+
 /**
  * @note This forwarding function is used for training mode.
  *       This will be implemented ASAP.

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -296,6 +296,26 @@ public:
     nntrainer::RunLayerContext &context,
     std::vector<nntrainer::TensorDim> input_dimensions) override;
 
+  /**
+   * @brief Reset KV cache write position to 0.
+   * @note  Rewinds the write pointer only. The cache tensor data is left
+   *        in place; subsequent incremental forwards overwrite the range
+   *        that is read during attention.
+   */
+  WIN_EXPORT void resetCache() { cache_index = 0; }
+
+  /**
+   * @brief Reset KV cache write position to 0 and zero the cache tensors.
+   * @param context Run-time layer context holding the cache tensors.
+   * @note  Defense-in-depth variant used when starting a fresh multi-turn
+   *        conversation. In addition to rewinding the write pointer, the
+   *        underlying cache_key / cache_value tensors are zero-filled so
+   *        that any stale KV entries from the previous conversation can
+   *        never be read, even if a future code path were to read beyond
+   *        the freshly-written range.
+   */
+  WIN_EXPORT void resetCache(nntrainer::RunLayerContext &context);
+
   inline static const std::string type = "mha_core";
 
 private:

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -253,7 +253,17 @@ int main(int argc, char *argv[]) {
       if (chat_tmpl.isAvailable()) {
         std::cout << "[Info] Chat template loaded from tokenizer_config.json"
                   << std::endl;
+      } else {
+        std::cerr
+          << "[Warning] tokenizer_config.json found but chat template could "
+             "not be loaded. Chat formatting will not be applied to raw input."
+          << std::endl;
       }
+    } else {
+      std::cerr
+        << "[Warning] tokenizer_config.json not found in " << model_path
+        << ". Chat template will not be available for raw input formatting."
+        << std::endl;
     }
 
     // Determine input text

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -30,6 +30,7 @@
 #include <factory.h>
 
 #include "causal_lm.h"
+#include "chat_template.h"
 #include "embedding_gemma.h"
 #include "gemma3_causallm.h"
 #include "gptoss_cached_slim_causallm.h"
@@ -46,6 +47,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <filesystem>
 #include <thread>
 
 using json = nlohmann::json;
@@ -243,9 +245,24 @@ int main(int argc, char *argv[]) {
       architecture = resolve_architecture(model_type, architecture);
     }
 
+    // Load chat template from tokenizer_config.json (if available)
+    causallm::ChatTemplate chat_tmpl;
+    std::string tokenizer_config_path = model_path + "/tokenizer_config.json";
+    if (std::filesystem::exists(tokenizer_config_path)) {
+      chat_tmpl = causallm::ChatTemplate::fromFile(tokenizer_config_path);
+      if (chat_tmpl.isAvailable()) {
+        std::cout << "[Info] Chat template loaded from tokenizer_config.json"
+                  << std::endl;
+      }
+    }
+
     // Determine input text
     if (argc >= 3) {
       input_text = argv[2];
+      // Apply chat template to raw user input if available
+      if (chat_tmpl.isAvailable()) {
+        input_text = chat_tmpl.apply(input_text);
+      }
     } else {
       if (nntr_cfg.contains("chat_input")) {
         if (architecture == "Gemma3ForCausalLM") {

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -1,4 +1,5 @@
 causallm_src = [
+    meson.current_source_dir() / 'chat_template.cpp',
     meson.current_source_dir() / 'huggingface_tokenizer.cpp',
     meson.current_source_dir() / 'llm_util.cpp',
     meson.current_source_dir() / 'api' / 'causal_lm_api.cpp',

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -296,6 +296,11 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   has_run_ = false;
 
+  // Multi-turn safety: drop any decoder state left over from a previous run.
+  // If a prior turn ended mid-punctuation or mid-UTF-8 token, pending_ids_
+  // would leak into this turn's decoding and corrupt output.
+  pending_ids_.clear();
+
   output_list.clear();
   for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
     output_list.push_back("");
@@ -448,9 +453,28 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   } else {
     SYS_PROMP_LEN = 0;
   }
+
+  // Absolute base position for this turn in the (persistent) KV cache.
+  // - SYS_PROMP_LEN: precomputed system-prompt length (0 when not using a
+  //   precomputed system-prompt KV cache).
+  // - global_token_len: total tokens written by all previous run() calls on
+  //   this model instance, accumulated for multi-turn conversations.
+  // Using a single base_pos keeps prefill and generation phases consistent
+  // (RoPE indices and KV-cache write offsets all derive from the same base).
+  const unsigned int base_pos = SYS_PROMP_LEN + global_token_len;
+
+  if (base_pos + init_len + NUM_TO_GENERATE > MAX_SEQ_LEN) {
+    free(input_sample);
+    std::cerr << "[CausalLM] context overflow: base_pos=" << base_pos
+              << " input=" << init_len << " gen=" << NUM_TO_GENERATE
+              << " max_seq_len=" << MAX_SEQ_LEN
+              << ". Call resetConversation() to start a new conversation."
+              << std::endl;
+    throw std::runtime_error("CausalLM context overflow");
+  }
+
   output = model->incremental_inference(BATCH_SIZE, input, label, init_len,
-                                        SYS_PROMP_LEN,
-                                        SYS_PROMP_LEN + input_len, false);
+                                        base_pos, base_pos + input_len, false);
 
   // post process of model output
   std::vector<unsigned int> id_list(generate_multi_tokens(
@@ -472,7 +496,9 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
    * TOKEN GENERATION
    */
 
-  input_len += SYS_PROMP_LEN;
+  // Shift input_len into absolute-position space so that token_generation_idx
+  // below indexes the cache in the same frame as the prefill call above.
+  input_len += base_pos;
 
   // Update generated token by prefill as an input
   for (unsigned int b = 0; b < BATCH_SIZE; ++b)
@@ -487,13 +513,13 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
     auto output_interval =
       model->incremental_inference(BATCH_SIZE, input, label, input_len,
-                                   token_generation_idx - 1 + global_token_len,
-                                   token_generation_idx + global_token_len);
+                                   token_generation_idx - 1,
+                                   token_generation_idx);
     std::vector<unsigned int> ids_list(generate(output_interval[0], do_sample));
     if (token_generation_idx < input_len) {
       for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
         input_sample[static_cast<size_t>(b) * MAX_SEQ_LEN] =
-          static_cast<float>(init_input[token_generation_idx - SYS_PROMP_LEN]);
+          static_cast<float>(init_input[token_generation_idx - base_pos]);
       }
       registerOutputs(tokenizer, ids_list, token_generation_idx, eos_list,
                       log_output);

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -31,6 +31,7 @@
 
 #include <common.h>
 #include <layer_context.h>
+#include <layer_node.h>
 #include <lm_head.h>
 #include <mha_core.h>
 #include <tensor.h>
@@ -157,6 +158,42 @@ void CausalLM::registerOutputs(
       }
     }
   }
+}
+
+void CausalLM::resetConversation() {
+  global_token_len = 0;
+  SYS_PROMP_LEN = 0;
+  pending_ids_.clear();
+  output_list.clear();
+  has_run_ = false;
+
+  if (!model)
+    return;
+
+  // Reset cache_index in every MHACoreLayer and zero the underlying
+  // cache_key / cache_value tensors so no stale KV entries from the
+  // previous conversation can influence the next run.
+  //
+  // NeuralNetwork::forEachLayer hands us a reference to the LayerNode (which
+  // inherits from ml::train::Layer), not the concrete layer implementation.
+  // A direct dynamic_cast from ml::train::Layer& to MHACoreLayer* therefore
+  // always fails silently, which was the real root cause of cache_index
+  // leaking across turns (observed as cache_index(277) != _from(0) after a
+  // resetConversation()). Go through LayerNode::getLayer() to reach the
+  // wrapped implementation.
+  std::function<void(ml::train::Layer &, nntrainer::RunLayerContext &, void *)>
+    fn = [](ml::train::Layer &l, nntrainer::RunLayerContext &context,
+            void * /*user_data*/) {
+      if (l.getType() != causallm::MHACoreLayer::type)
+        return;
+      auto *node = dynamic_cast<nntrainer::LayerNode *>(&l);
+      if (!node)
+        return;
+      auto *mha = dynamic_cast<causallm::MHACoreLayer *>(node->getLayer());
+      if (mha)
+        mha->resetCache(context);
+    };
+  model->forEachLayer(fn, nullptr);
 }
 
 void CausalLM::save_kvcache(std::string path, int to_) {

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -85,6 +85,17 @@ public:
    */
   bool hasRun() const { return has_run_; }
 
+  /**
+   * @brief Reset multi-turn conversation state so the next run() starts a
+   *        fresh conversation on the same loaded model.
+   * @note  Clears accumulated token count, pending decoder tokens, the
+   *        last-turn output buffer, and resets the KV-cache write position
+   *        (cache_index) on every MHACoreLayer. The KV-cache tensor data
+   *        itself is not zeroed; subsequent writes overwrite the positions
+   *        that are read.
+   */
+  void resetConversation();
+
 protected:
   /**
    * @brief Setup the parameters for the CausalLM model

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -1074,6 +1074,7 @@ properties in the context/graph unless intended. */
 
   std::array<TensorDim::DataType, 2> data_type;
 
+public:
   /**
    * @brief   Get the effective layer managed by this layer node
    *
@@ -1090,6 +1091,7 @@ properties in the context/graph unless intended. */
    */
   nntrainer::Layer *getLayer();
 
+private:
   /**
    * @brief anchor point to override if PRINT_SHAPE_INFO is enabled for
    * Layer::print()


### PR DESCRIPTION
## Dependency of the PR
#3867

## Commits to be reviewed in this PR

One can ignore commits from #3867.
Please only review the following commits.

<details><summary>[nntrainer] Expose LayerNode::getLayer() as public API</summary><br />

LayerNode wraps a concrete nntrainer::Layer and is the object handed to
NeuralNetwork::forEachLayer() callbacks (as ml::train::Layer&, via the
LayerNode's base-class inheritance). Reaching the wrapped implementation
from user code currently requires a second dynamic_cast that is silently
denied because getLayer() sits under a private access specifier.

This blocks a legitimate caller pattern: application-level code iterates
layers of a known type (e.g. MHACoreLayer) and needs to invoke methods
specific to that type. Promoting the two getLayer() accessors to public
enables that pattern without changing their behavior.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



<details><summary>[CausalLM] Add MHACoreLayer::resetCache() for multi-turn support</summary><br />

MHACoreLayer maintains cache_index as the absolute write position into
cache_key / cache_value. That index also drives RoPE position encoding
on the next incremental forward, so it must be rewound to 0 before a
new conversation begins — otherwise the second conversation starts
writing at the tail of the previous one and reads back stale KV.

Add two overloads:

  - resetCache()                        : cheap inline, cache_index = 0.
    Sufficient on its own, because the attention read range is bounded
    by cache_index + step_size so garbage past the new write head is
    never dereferenced.

  - resetCache(RunLayerContext &)        : defense-in-depth variant used
    by CausalLM::resetConversation(). Also zero-fills cache_key /
    cache_value so stale entries cannot influence the next turn even
    under future code paths that might read beyond the freshly-written
    range. Guarded by isAllocated() because the tensors carry no backing
    memory until the first incremental_inference() call allocates them.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

<details><summary>[CausalLM] Add MHACoreLayer::resetCache() for multi-turn support</summary><br />

MHACoreLayer maintains cache_index as the absolute write position into
cache_key / cache_value. That index also drives RoPE position encoding
on the next incremental forward, so it must be rewound to 0 before a
new conversation begins — otherwise the second conversation starts
writing at the tail of the previous one and reads back stale KV.

Add two overloads:

  - resetCache()                        : cheap inline, cache_index = 0.
    Sufficient on its own, because the attention read range is bounded
    by cache_index + step_size so garbage past the new write head is
    never dereferenced.

  - resetCache(RunLayerContext &)        : defense-in-depth variant used
    by CausalLM::resetConversation(). Also zero-fills cache_key /
    cache_value so stale entries cannot influence the next turn even
    under future code paths that might read beyond the freshly-written
    range. Guarded by isAllocated() because the tensors carry no backing
    memory until the first incremental_inference() call allocates them.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


<details><summary>[CausalLM] Fix position indexing in run() for multi-turn conversations</summary><br />
The MHA layer keeps cache_index across run() calls, so KV cache state
naturally persists for multi-turn use. CausalLM::run() however was
mixing two different position conventions when stitching multi-turn:

  - Prefill called the model with (SYS_PROMP_LEN, SYS_PROMP_LEN+input_len),
    which ignored prior turns entirely and re-wrote the cache from the
    fixed system-prompt base.
  - Generation called the model with
    (token_generation_idx - 1 + global_token_len,
     token_generation_idx     + global_token_len),
    which DID account for prior turns.

The two phases therefore disagreed on the absolute position of the new
tokens in the cache, so RoPE encodings, the causal mask and the cache
write head all drifted apart on turn N>=2 and the model produced
nonsense.

Fix by snapshotting the absolute base position once per turn and
threading it consistently through prefill, generation and the
teacher-forcing replay index:

  base_pos = SYS_PROMP_LEN + global_token_len

Also:
  - Clear pending_ids_ at the top of run() so a partial UTF-8 / mid-
    punctuation tail from a prior turn does not corrupt this turn's
    decoded output.
  - Add a context-overflow guard before prefill: if base_pos + init_len
    + NUM_TO_GENERATE would exceed MAX_SEQ_LEN, free the input buffer,
    log a clear message, and throw. The C API already wraps run() in a
    try/catch and surfaces this as CAUSAL_LM_ERROR_INFERENCE_FAILED so
    the user is told to call resetConversation().

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


<details><summary>[CausalLM] Add CausalLM::resetConversation() to clear multi-turn state</summary><br />
Provide an explicit way to start a fresh conversation on an already-
loaded model without paying the model-load cost again. resetConversation()
returns the instance to the same state it had right after load:

  - global_token_len, SYS_PROMP_LEN, has_run_, output_list and
    pending_ids_ are all cleared.
  - Every MHACoreLayer's KV-cache write head (cache_index) is rewound
    to 0 and its cache_key / cache_value tensors are zero-filled when
    already allocated, so neither the position math nor the attention
    reads can pull in stale state from the previous conversation.

Reaching the wrapped MHACoreLayer through forEachLayer requires going
through LayerNode::getLayer() — the callback receives an
ml::train::Layer& that is in fact a LayerNode wrapper, so a direct
dynamic_cast to MHACoreLayer is silently denied. The lambda routes
through the now-public LayerNode accessor.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

<details><summary>[CausalLM] Add Qwen3-1.7B to C API model enumeration</summary><br />
Register QWEN3-1.7B in the ModelType enum, the path map
(./models/qwen3-1.7b), the reverse name lookup, and the
test_api name->enum dispatch so users can load the larger
model for better multi-turn evaluation.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


<details><summary>[CausalLM] Add resetConversation C API and automatic multi-turn promp…</summary><br />
…t splicing

Adds the public `resetConversation()` C entry point and a `g_turn_count`
state variable so the API layer can distinguish the first turn of a
conversation from continuations.

For continuation turns, the templated prompt is rewritten so that the
system block is dropped and the new user turn is spliced onto the
existing KV cache with a leading `\n` boundary. This matches the way the
chat template would have laid out the conversation if it had been
formatted in a single shot, which lets the cached system + prior turns
be reused verbatim.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



<details><summary>[CausalLM] Add --verify-memory and --multi-turn modes to test_api </summary><br />

Refactors the inference path in test_api into a `run_turn()` helper and
adds two trailing flags to exercise the new multi-turn API end-to-end:

* `--verify-memory` runs a scripted two-turn regression test ("My name
  is Alice" -> "What is my name?"), asserts that the second response
  recalls "Alice" from the cached prior turn, then calls
  `resetConversation()` and confirms the model no longer claims to know
  the name. Returns non-zero on assertion failure.
* `--multi-turn` drops into an interactive REPL with `/reset` and
  `/quit` commands so the multi-turn behavior can be smoke-tested by
  hand.

Existing single-turn invocations are unaffected.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


### Summary

#### Test result 
```
./test_api QWEN3-0.6B "" 1 W4A32 0 --multi-turn
```
```
you> My name is Alice. Please remember my name.
📝 Input Prompt:
  My name is Alice. Please remember my name.

⚡ Running inference...

💬 Output:
  <think>
  Okay, so I need to remember my name, which is Alice. Let me think. First, I should make sure I'm not mixing up my name with someone else's. Maybe I should write it down in my mind or on a card. But how do I do that without looking at something? Maybe I can visualize it. Like, if I picture a white house with a big door, that's Alice. Or maybe a tree with a big leaf. That's Alice. Or a car with a big engine. That's Alice. So, maybe I can think of different images that represent Alice. But how do I choose the right one? Maybe I can pick a simple image that's easy to remember. Like a house with a big door. That's Alice. So, I can say "Alice, the house with a big door." That's a good way to remember it. Alternatively, maybe a tree with a big leaf. That's also a good memory. But which one is better? Well, maybe the house is more common. But I can choose either. Let me pick the house. So, the answer would be "Alice, the house with a big door." That's a good way to remember it.
  </think>
  
  To remember your name, "Alice" is a simple and memorable name. Here's a way to recall it:
  
  **"Alice, the house with a big door."**  
  
  This is a classic and effective way to remember the name. Let me know if you'd like to add more details!<|im_end|>

  📊 Prefill  tokens=17  111.00 ms  153.2 tok/s
  📊 Generation tokens=313  4610.00 ms  67.9 tok/s

you> What is my name?
📝 Input Prompt:
  What is my name?

⚡ Running inference...

💬 Output:
  <think>
  Okay, the user is asking for their name. But wait, the previous message was about remembering their name. Let me check. The user just said, "What is my name?" But maybe they forgot to mention their name in the previous message. Let me make sure. In the history, the user wrote, "My name is Alice. Please remember my name." Then the assistant responded with "Alice, the house with a big door." Now the user is asking, "What is my name?" So, the user is probably asking for their name again. But maybe they forgot to mention it. Let me respond appropriately. Maybe the user is testing if I can remember their name even if they didn't mention it. So, I should confirm their name and maybe add a note. Let me do that.
  </think>
  
  Your name is Alice. If you ever need to remember it again, you can say, "Alice, the house with a big door." That's a good way to recall it. Let me know if you need anything else!<|im_end|>

  📊 Prefill  tokens=13  94.00 ms  138.3 tok/s
  📊 Generation tokens=213  3483.00 ms  61.2 tok/s

you> /reset
✓ Conversation state reset.

you> What is my name?
📝 Input Prompt:
  What is my name?

⚡ Running inference...

💬 Output:
  <think>
  Okay, the user is asking, "What is my name?" I need to respond appropriately. Since I'm a language model, I don't have a personal name. But maybe I can be helpful. I should acknowledge that I don't have a name but still be useful. I can offer assistance with tasks or help with something else. Let me make sure my response is friendly and helpful.
  </think>
  
  I don't have a name, but I'm here to help! If you have any questions or need assistance, feel free to ask! ��<|im_end|>

  📊 Prefill  tokens=12  43.00 ms  279.1 tok/s
  📊 Generation tokens=113  1585.00 ms  71.3 tok/s

```

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
