### PR TITLE
[graph] Skip input tensor check for weight-only layers

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -225,7 +225,7 @@ int NetworkGraph::checkCompiledGraph() {
   /** Dimension of input layers must be known */
   for (auto iter = cbegin(); iter != cend(); iter++) {
     auto lnode = (*iter);
-    if (lnode->getNumInputConnections() == 0) {
+    if (lnode->getNumInputConnections() == 0 && lnode->getType() != "weight") {
       if (!lnode->hasInputShapeProperty()) {
         ml_loge("Layer with no inbound connection need input_shape property");
         return ML_ERROR_INVALID_PARAMETER;
@@ -1207,7 +1207,7 @@ int NetworkGraph::initialize(ExecutionMode mode,
      * Set input dimension for all the layers.
      * For input layer, as input dimension is known, set input tensor.
      */
-    if (!is_input_node(lnode.get())) {
+    if (!is_input_node(lnode.get()) && lnode->getType() != "weight") {
       if (input_map.find(lnode->getName()) == input_map.end())
         throw std::runtime_error("Cannot find input buffers for the node");
       inputs = input_map.at(lnode->getName());
@@ -1420,7 +1420,7 @@ int NetworkGraph::reinitialize(
      * Set input dimension for all the layers.
      * For input layer, as input dimension is known, set input tensor.
      */
-    if (!is_input_node(lnode.get())) {
+    if (!is_input_node(lnode.get()) && lnode->getType() != "weight") {
       if (input_map.find(lnode->getName()) == input_map.end())
         throw std::runtime_error("Cannot find input buffers for the node");
       inputs = input_map.at(lnode->getName());

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -228,8 +228,8 @@ int NetworkGraph::checkCompiledGraph() {
     /**
      * Weight layers may have input connections in the graph, but they do not
      * consume input tensors. They own their weights and expose them as output
-     * tensors instead. Therefore, treat weight-only layers as input-like nodes here
-     * to avoid looking up non-existent input tensors for them.
+     * tensors instead. Therefore, treat weight-only layers as input-like nodes
+     * here to avoid looking up non-existent input tensors for them.
      */
     if (lnode->getNumInputConnections() == 0 && lnode->getType() != "weight") {
       if (!lnode->hasInputShapeProperty()) {
@@ -1214,8 +1214,8 @@ int NetworkGraph::initialize(ExecutionMode mode,
      * For input layer, as input dimension is known, set input tensor.
      * Weight layers may have input connections in the graph, but they do not
      * consume input tensors. They own their weights and expose them as output
-     * tensors instead. Therefore, treat weight-only layers as input-like nodes here
-     * to avoid looking up non-existent input tensors for them.
+     * tensors instead. Therefore, treat weight-only layers as input-like nodes
+     * here to avoid looking up non-existent input tensors for them.
      */
     if (!is_input_node(lnode.get()) && lnode->getType() != "weight") {
       if (input_map.find(lnode->getName()) == input_map.end())
@@ -1432,9 +1432,9 @@ int NetworkGraph::reinitialize(
      *
      * Weight layers may have input connections in the graph, but they do not
      * consume input tensors. They own their weights and expose them as output
-     * tensors instead. Therefore, treat weight-only layers as input-like nodes here
-     * to avoid looking up non-existent input tensors for them.
-    */
+     * tensors instead. Therefore, treat weight-only layers as input-like nodes
+     * here to avoid looking up non-existent input tensors for them.
+     */
     if (!is_input_node(lnode.get()) && lnode->getType() != "weight") {
       if (input_map.find(lnode->getName()) == input_map.end())
         throw std::runtime_error("Cannot find input buffers for the node");

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -225,6 +225,12 @@ int NetworkGraph::checkCompiledGraph() {
   /** Dimension of input layers must be known */
   for (auto iter = cbegin(); iter != cend(); iter++) {
     auto lnode = (*iter);
+    /**
+     * Weight layers may have input connections in the graph, but they do not
+     * consume input tensors. They own their weights and expose them as output
+     * tensors instead. Therefore, treat weight-only layers as input-like nodes here
+     * to avoid looking up non-existent input tensors for them.
+     */
     if (lnode->getNumInputConnections() == 0 && lnode->getType() != "weight") {
       if (!lnode->hasInputShapeProperty()) {
         ml_loge("Layer with no inbound connection need input_shape property");
@@ -1206,6 +1212,10 @@ int NetworkGraph::initialize(ExecutionMode mode,
     /**
      * Set input dimension for all the layers.
      * For input layer, as input dimension is known, set input tensor.
+     * Weight layers may have input connections in the graph, but they do not
+     * consume input tensors. They own their weights and expose them as output
+     * tensors instead. Therefore, treat weight-only layers as input-like nodes here
+     * to avoid looking up non-existent input tensors for them.
      */
     if (!is_input_node(lnode.get()) && lnode->getType() != "weight") {
       if (input_map.find(lnode->getName()) == input_map.end())
@@ -1419,7 +1429,12 @@ int NetworkGraph::reinitialize(
     /**
      * Set input dimension for all the layers.
      * For input layer, as input dimension is known, set input tensor.
-     */
+     *
+     * Weight layers may have input connections in the graph, but they do not
+     * consume input tensors. They own their weights and expose them as output
+     * tensors instead. Therefore, treat weight-only layers as input-like nodes here
+     * to avoid looking up non-existent input tensors for them.
+    */
     if (!is_input_node(lnode.get()) && lnode->getType() != "weight") {
       if (input_map.find(lnode->getName()) == input_map.end())
         throw std::runtime_error("Cannot find input buffers for the node");

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -231,7 +231,8 @@ int NetworkGraph::checkCompiledGraph() {
      * tensors instead. Therefore, treat weight-only layers as input-like nodes
      * here to avoid looking up non-existent input tensors for them.
      */
-    if (lnode->getNumInputConnections() == 0 && lnode->getType() != "weight") {
+    if (lnode->getNumInputConnections() == 0 &&
+        lnode->getType() != WeightLayer::type) {
       if (!lnode->hasInputShapeProperty()) {
         ml_loge("Layer with no inbound connection need input_shape property");
         return ML_ERROR_INVALID_PARAMETER;
@@ -1217,7 +1218,7 @@ int NetworkGraph::initialize(ExecutionMode mode,
      * tensors instead. Therefore, treat weight-only layers as input-like nodes
      * here to avoid looking up non-existent input tensors for them.
      */
-    if (!is_input_node(lnode.get()) && lnode->getType() != "weight") {
+    if (!is_input_node(lnode.get()) && lnode->getType() != WeightLayer::type) {
       if (input_map.find(lnode->getName()) == input_map.end())
         throw std::runtime_error("Cannot find input buffers for the node");
       inputs = input_map.at(lnode->getName());
@@ -1435,7 +1436,7 @@ int NetworkGraph::reinitialize(
      * tensors instead. Therefore, treat weight-only layers as input-like nodes
      * here to avoid looking up non-existent input tensors for them.
      */
-    if (!is_input_node(lnode.get()) && lnode->getType() != "weight") {
+    if (!is_input_node(lnode.get()) && lnode->getType() != WeightLayer::type) {
       if (input_map.find(lnode->getName()) == input_map.end())
         throw std::runtime_error("Cannot find input buffers for the node");
       inputs = input_map.at(lnode->getName());

--- a/test/unittest/unittest_nntrainer_graph.cpp
+++ b/test/unittest/unittest_nntrainer_graph.cpp
@@ -672,6 +672,31 @@ TEST(nntrainerGraphUnitTest, topological_sort_complex_multi_output) {
                              "fc4", "fc3", "fc5"});
 }
 
+TEST(nntrainerGraphUnitTest, weight_layer_compile_and_initialize) {
+  /* A standalone WeightLayer node must compile and initialize without error.
+   * This exercises the skip added to initialize() so that weight-only nodes
+   * are not treated as regular non-input layers that require an entry in the
+   * input buffer map. Without the fix, initialize() throws "Cannot find input
+   * buffers for the node" even when input_shape is provided. */
+  std::unique_ptr<ml::train::Model> model =
+    ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+
+  model->addLayer(ml::train::createLayer(
+    "weight",
+    {nntrainer::withKey("name", "wt0"),
+     nntrainer::withKey("dim", "1:1:4"),
+     nntrainer::withKey("input_shape", "1:1:4"),
+     nntrainer::withKey("tensor_dtype", "FP32"),
+     nntrainer::withKey("weight_name", "test_weight")}));
+
+  model->setProperty({nntrainer::withKey("batch_size", 1),
+                      nntrainer::withKey("model_tensor_type", "FP32-FP32")});
+
+  EXPECT_EQ(model->compile(ml::train::ExecutionMode::INFERENCE), ML_ERROR_NONE);
+  EXPECT_EQ(model->initialize(ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
+}
+
 int main(int argc, char **argv) {
   int result = -1;
 

--- a/test/unittest/unittest_nntrainer_graph.cpp
+++ b/test/unittest/unittest_nntrainer_graph.cpp
@@ -673,11 +673,11 @@ TEST(nntrainerGraphUnitTest, topological_sort_complex_multi_output) {
 }
 
 TEST(nntrainerGraphUnitTest, weight_layer_compile_and_initialize) {
-  /* A standalone WeightLayer node must compile and initialize without error.
-   * This exercises the skip added to initialize() so that weight-only nodes
-   * are not treated as regular non-input layers that require an entry in the
-   * input buffer map. Without the fix, initialize() throws "Cannot find input
-   * buffers for the node" even when input_shape is provided. */
+  // A standalone WeightLayer node must compile and initialize without error.
+  // This exercises the skip added to initialize() so that weight-only nodes
+  // are not treated as regular non-input layers that require an entry in the
+  // input buffer map. Without the fix, initialize() throws "Cannot find input
+  // buffers for the node" even when input_shape is provided.
   std::unique_ptr<ml::train::Model> model =
     ml::train::createModel(ml::train::ModelType::NEURAL_NET);
 

--- a/test/unittest/unittest_nntrainer_graph.cpp
+++ b/test/unittest/unittest_nntrainer_graph.cpp
@@ -683,8 +683,7 @@ TEST(nntrainerGraphUnitTest, weight_layer_compile_and_initialize) {
 
   model->addLayer(ml::train::createLayer(
     "weight",
-    {nntrainer::withKey("name", "wt0"),
-     nntrainer::withKey("dim", "1:1:4"),
+    {nntrainer::withKey("name", "wt0"), nntrainer::withKey("dim", "1:1:4"),
      nntrainer::withKey("input_shape", "1:1:4"),
      nntrainer::withKey("tensor_dtype", "FP32"),
      nntrainer::withKey("weight_name", "test_weight")}));


### PR DESCRIPTION
This commit skips input tensor check for weight-only layers.

## Overview
Update `nntrainer/graph/network_graph.cpp` so that graph construction does not fail for weight-only layers without input tensor.

## Description
- WeightLayer is a source node that does not consume any input tensor — it only outputs its stored weight. 
- However, the graph initialization logic in network_graph.cpp determines whether a node is a source node based solely on the presence of input connections (getInputConnections().empty()). 
- This change adds the required exception handling so valid weight-only layers can be processed correctly.

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

