### PR TITLE
ml::train::Tensor API with Pimpl + symbolic graph compile

### DIFF
--- a/Applications/Android/PicoGPTJNI/app/src/main/jni/picogpt.cpp
+++ b/Applications/Android/PicoGPTJNI/app/src/main/jni/picogpt.cpp
@@ -73,12 +73,12 @@ ml::train::Model *createPicogpt() {
   Tensor wpe_in({1, 1, 1, MAX_TOKEN_LEN}, "wpe_input");
 
   // Embedding layers
-  LayerHandle wte = createLayer("embedding",
-    {"name=wte", "in_dim=" + std::to_string(NUM_VOCAB),
-     "out_dim=" + std::to_string(MODEL_DIM)});
-  LayerHandle wpe = createLayer("embedding",
-    {"name=wpe", "in_dim=" + std::to_string(NUM_CTX),
-     "out_dim=" + std::to_string(MODEL_DIM)});
+  LayerHandle wte =
+    createLayer("embedding", {"name=wte", "in_dim=" + std::to_string(NUM_VOCAB),
+                              "out_dim=" + std::to_string(MODEL_DIM)});
+  LayerHandle wpe =
+    createLayer("embedding", {"name=wpe", "in_dim=" + std::to_string(NUM_CTX),
+                              "out_dim=" + std::to_string(MODEL_DIM)});
   auto wte_out = wte(wte_in);
   auto wpe_out = wpe(wpe_in);
 
@@ -90,8 +90,9 @@ ml::train::Model *createPicogpt() {
     std::string prefix = "layer" + std::to_string(i);
 
     // Layer Norm 1
-    LayerHandle ln1 = createLayer("layer_normalization",
-      {"name=" + prefix + "/ln1", "axis=3", "epsilon=1e-5"});
+    LayerHandle ln1 =
+      createLayer("layer_normalization",
+                  {"name=" + prefix + "/ln1", "axis=3", "epsilon=1e-5"});
     auto ln1_out = ln1(prev);
 
     Tensor attn_out;
@@ -101,24 +102,27 @@ ml::train::Model *createPicogpt() {
 
       for (unsigned int j = 0; j < NUM_HEADS; ++j) {
         unsigned int idx = NUM_HEADS - 1 - j;
-        std::string head_prefix =
-          prefix + "/multi_head_attention";
+        std::string head_prefix = prefix + "/multi_head_attention";
 
-        LayerHandle v_fc = createLayer("fully_connected",
-          {"name=" + head_prefix + "/v_fc" + std::to_string(idx),
-           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-        LayerHandle k_fc = createLayer("fully_connected",
-          {"name=" + head_prefix + "/k_fc" + std::to_string(idx),
-           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-        LayerHandle q_fc = createLayer("fully_connected",
-          {"name=" + head_prefix + "/q_fc" + std::to_string(idx),
-           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        LayerHandle v_fc =
+          createLayer("fully_connected",
+                      {"name=" + head_prefix + "/v_fc" + std::to_string(idx),
+                       "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        LayerHandle k_fc =
+          createLayer("fully_connected",
+                      {"name=" + head_prefix + "/k_fc" + std::to_string(idx),
+                       "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        LayerHandle q_fc =
+          createLayer("fully_connected",
+                      {"name=" + head_prefix + "/q_fc" + std::to_string(idx),
+                       "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
 
         auto v = v_fc(ln1_out);
         auto k = k_fc(ln1_out);
         auto q = q_fc(ln1_out);
 
-        LayerHandle attn = createLayer("attention",
+        LayerHandle attn = createLayer(
+          "attention",
           {"name=" + head_prefix + "/attention" + std::to_string(idx),
            "scaled_dot_product=true", "causal_mask=true"});
         attn_heads.push_back(attn({q, v, k}));
@@ -127,55 +131,57 @@ ml::train::Model *createPicogpt() {
       // Reverse so concat order is attention0, attention1, ..., attention11
       std::reverse(attn_heads.begin(), attn_heads.end());
 
-      LayerHandle concat = createLayer("concat",
+      LayerHandle concat = createLayer(
+        "concat",
         {"name=" + prefix + "/multi_head_attention/concat", "axis=3"});
       auto concat_out = concat(attn_heads);
 
-      LayerHandle attn_fc = createLayer("fully_connected",
-        {"name=" + prefix + "/multi_head_attention/fc",
-         "unit=" + std::to_string(MODEL_DIM)});
+      LayerHandle attn_fc = createLayer(
+        "fully_connected", {"name=" + prefix + "/multi_head_attention/fc",
+                            "unit=" + std::to_string(MODEL_DIM)});
       auto fc_out = attn_fc(concat_out);
 
-      LayerHandle identity = createLayer("identity",
-        {"name=" + prefix + "/multi_head_attention"});
+      LayerHandle identity =
+        createLayer("identity", {"name=" + prefix + "/multi_head_attention"});
       attn_out = identity(fc_out);
     } else {
       LayerHandle mha = createLayer("multi_head_attention",
-        {"name=" + prefix + "/multi_head_attention",
-         "num_heads=" + std::to_string(NUM_HEADS)});
+                                    {"name=" + prefix + "/multi_head_attention",
+                                     "num_heads=" + std::to_string(NUM_HEADS)});
       attn_out = mha({ln1_out, ln1_out, ln1_out});
     }
 
     // Skip connection 1: prev + attention output
-    LayerHandle add1 = createLayer("Addition",
-      {"name=" + prefix + "/add1"});
+    LayerHandle add1 = createLayer("Addition", {"name=" + prefix + "/add1"});
     auto add1_out = add1({prev, attn_out});
 
     // Layer Norm 2
-    LayerHandle ln2 = createLayer("layer_normalization",
-      {"name=" + prefix + "/ln2", "axis=3", "epsilon=1e-5"});
+    LayerHandle ln2 =
+      createLayer("layer_normalization",
+                  {"name=" + prefix + "/ln2", "axis=3", "epsilon=1e-5"});
     auto ln2_out = ln2(add1_out);
 
     // FFN
-    LayerHandle fc1 = createLayer("fully_connected",
-      {"name=" + prefix + "/fc1",
-       "unit=" + std::to_string(FC_UNIT), "activation=gelu"});
+    LayerHandle fc1 =
+      createLayer("fully_connected",
+                  {"name=" + prefix + "/fc1", "unit=" + std::to_string(FC_UNIT),
+                   "activation=gelu"});
     auto fc1_out = fc1(ln2_out);
 
-    LayerHandle fc2 = createLayer("fully_connected",
-      {"name=" + prefix + "/fc2",
-       "unit=" + std::to_string(MODEL_DIM)});
+    LayerHandle fc2 =
+      createLayer("fully_connected", {"name=" + prefix + "/fc2",
+                                      "unit=" + std::to_string(MODEL_DIM)});
     auto fc2_out = fc2(fc1_out);
 
     // Skip connection 2: add1_out + fc2_out
-    LayerHandle add2 = createLayer("Addition",
-      {"name=" + prefix + "/add2"});
+    LayerHandle add2 = createLayer("Addition", {"name=" + prefix + "/add2"});
     prev = add2({add1_out, fc2_out});
   }
 
   // Final Layer Norm
-  LayerHandle final_ln = createLayer("layer_normalization",
-    {"name=layer_normalization", "axis=3", "epsilon=1e-5"});
+  LayerHandle final_ln =
+    createLayer("layer_normalization",
+                {"name=layer_normalization", "axis=3", "epsilon=1e-5"});
   auto output = final_ln(prev);
 
   model->setOptimizer(
@@ -247,8 +253,8 @@ std::string inferModel(std::string path, std::string sentence,
   model_->getLayer("wte", &wte_embedding_layer);
   const std::vector<float *> wte_weights_buf =
     wte_embedding_layer->getWeights();
-  auto wte_weight = ml::train::Tensor::fromData(
-    {NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
+  auto wte_weight =
+    ml::train::Tensor::fromData({NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
 
   std::vector<float *> output_bufs;
 
@@ -257,8 +263,8 @@ std::string inferModel(std::string path, std::string sentence,
     output_bufs = model_->incremental_inference(
       BATCH_SIZE, {wte_input, wpe_input}, {}, init_input_seq_len, i - 1);
 
-    auto output = ml::train::Tensor::fromData(
-      {BATCH_SIZE, 1, i, MODEL_DIM}, output_bufs[0]);
+    auto output = ml::train::Tensor::fromData({BATCH_SIZE, 1, i, MODEL_DIM},
+                                              output_bufs[0]);
     auto incremented_output = output.getSharedDataTensor(
       {BATCH_SIZE, 1, 1, MODEL_DIM}, BATCH_SIZE * (i - 1) * MODEL_DIM);
     auto next = incremented_output.dot(wte_weight, false, true);

--- a/Applications/Android/PicoGPTJNI/app/src/main/jni/picogpt.cpp
+++ b/Applications/Android/PicoGPTJNI/app/src/main/jni/picogpt.cpp
@@ -16,9 +16,10 @@
 #include "picogpt.h"
 #include "encoder.hpp"
 #include "tensor_dim.h"
+#include <algorithm>
 #include <ctime>
 #include <sstream>
-#include <tensor.h>
+#include <tensor_api.h>
 
 const unsigned int BATCH_SIZE = 1;
 const unsigned int NUM_LAYERS = 12;
@@ -60,221 +61,128 @@ bool model_destroyed = true;
 bool last = false;
 
 ml::train::Model *createPicogpt() {
+  using namespace ml::train;
 
-  model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+  model = createModel(ModelType::NEURAL_NET);
   model->setProperty({"batch_size=" + std::to_string(BATCH_SIZE),
                       "memory_optimization=false",
                       fsu ? "fsu=true" : "fsu=false"});
 
-  std::shared_ptr<ml::train::Layer> wte_input = ml::train::layer::Input(
-    {"name=wte_input", "input_shape=1:1:" + std::to_string(MAX_TOKEN_LEN)});
-  model->addLayer(wte_input);
+  // Symbolic input tensors
+  Tensor wte_in({1, 1, 1, MAX_TOKEN_LEN}, "wte_input");
+  Tensor wpe_in({1, 1, 1, MAX_TOKEN_LEN}, "wpe_input");
 
-  std::shared_ptr<ml::train::Layer> wte = ml::train::layer::Embedding(
+  // Embedding layers
+  LayerHandle wte = createLayer("embedding",
     {"name=wte", "in_dim=" + std::to_string(NUM_VOCAB),
      "out_dim=" + std::to_string(MODEL_DIM)});
-  model->addLayer(wte);
-
-  std::shared_ptr<ml::train::Layer> wpe_input = ml::train::layer::Input(
-    {"name=wpe_input", "input_shape=1:1:" + std::to_string(MAX_TOKEN_LEN)});
-  model->addLayer(wpe_input);
-
-  std::shared_ptr<ml::train::Layer> wpe = ml::train::layer::Embedding(
+  LayerHandle wpe = createLayer("embedding",
     {"name=wpe", "in_dim=" + std::to_string(NUM_CTX),
      "out_dim=" + std::to_string(MODEL_DIM)});
-  model->addLayer(wpe);
+  auto wte_out = wte(wte_in);
+  auto wpe_out = wpe(wpe_in);
 
-  std::shared_ptr<ml::train::Layer> add =
-    ml::train::layer::Addition({"name=add", "input_layers=wte, wpe"});
-  model->addLayer(add);
+  // Add embeddings
+  LayerHandle add_emb = createLayer("Addition", {"name=add"});
+  auto prev = add_emb({wte_out, wpe_out});
 
   for (unsigned int i = 0; i < NUM_LAYERS; ++i) {
-    std::shared_ptr<ml::train::Layer> ln_multiout1 = ml::train::layer::MultiOut(
-      {"name=layer" + std::to_string(i) + "/ln_multiout1"});
-    model->addLayer(ln_multiout1);
+    std::string prefix = "layer" + std::to_string(i);
 
-    std::shared_ptr<ml::train::Layer> ln1 =
-      ml::train::layer::LayerNormalization(
-        {"name=layer" + std::to_string(i) + "/ln1", "axis=3", "epsilon=1e-5"});
-    model->addLayer(ln1);
+    // Layer Norm 1
+    LayerHandle ln1 = createLayer("layer_normalization",
+      {"name=" + prefix + "/ln1", "axis=3", "epsilon=1e-5"});
+    auto ln1_out = ln1(prev);
 
-    std::shared_ptr<ml::train::Layer> multiout1 = ml::train::layer::MultiOut(
-      {"name=layer" + std::to_string(i) + "/multi_out1"});
-    model->addLayer(multiout1);
-
+    Tensor attn_out;
     if (optimize) {
-      std::string concat_input = "";
+      // Per-head attention with separate Q/K/V projections
+      std::vector<Tensor> attn_heads;
 
       for (unsigned int j = 0; j < NUM_HEADS; ++j) {
-        std::shared_ptr<ml::train::Layer> multi_head_attention_v_fc =
-          ml::train::layer::FullyConnected(
-            {"name=layer" + std::to_string(i) + "/multi_head_attention/v_fc" +
-               std::to_string(NUM_HEADS - 1 - j),
-             "input_layers=layer" + std::to_string(i) + "/multi_out1(" +
-               std::to_string(2 * NUM_HEADS + j) + ")",
-             "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-        model->addLayer(multi_head_attention_v_fc);
+        unsigned int idx = NUM_HEADS - 1 - j;
+        std::string head_prefix =
+          prefix + "/multi_head_attention";
+
+        LayerHandle v_fc = createLayer("fully_connected",
+          {"name=" + head_prefix + "/v_fc" + std::to_string(idx),
+           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        LayerHandle k_fc = createLayer("fully_connected",
+          {"name=" + head_prefix + "/k_fc" + std::to_string(idx),
+           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        LayerHandle q_fc = createLayer("fully_connected",
+          {"name=" + head_prefix + "/q_fc" + std::to_string(idx),
+           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+
+        auto v = v_fc(ln1_out);
+        auto k = k_fc(ln1_out);
+        auto q = q_fc(ln1_out);
+
+        LayerHandle attn = createLayer("attention",
+          {"name=" + head_prefix + "/attention" + std::to_string(idx),
+           "scaled_dot_product=true", "causal_mask=true"});
+        attn_heads.push_back(attn({q, v, k}));
       }
 
-      for (unsigned int j = 0; j < NUM_HEADS; ++j) {
-        std::shared_ptr<ml::train::Layer> multi_head_attention_k_fc =
-          ml::train::layer::FullyConnected(
-            {"name=layer" + std::to_string(i) + "/multi_head_attention/k_fc" +
-               std::to_string(NUM_HEADS - 1 - j),
-             "input_layers=layer" + std::to_string(i) + "/multi_out1(" +
-               std::to_string(NUM_HEADS + j) + ")",
-             "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-        model->addLayer(multi_head_attention_k_fc);
-      }
+      // Reverse so concat order is attention0, attention1, ..., attention11
+      std::reverse(attn_heads.begin(), attn_heads.end());
 
-      for (unsigned int j = 0; j < NUM_HEADS; ++j) {
-        std::shared_ptr<ml::train::Layer> multi_head_attention_q_fc =
-          ml::train::layer::FullyConnected(
-            {"name=layer" + std::to_string(i) + "/multi_head_attention/q_fc" +
-               std::to_string(NUM_HEADS - 1 - j),
-             "input_layers=layer" + std::to_string(i) + "/multi_out1(" +
-               std::to_string(j) + ")",
-             "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-        model->addLayer(multi_head_attention_q_fc);
-      }
+      LayerHandle concat = createLayer("concat",
+        {"name=" + prefix + "/multi_head_attention/concat", "axis=3"});
+      auto concat_out = concat(attn_heads);
 
-      for (unsigned int j = 0; j < NUM_HEADS; ++j) {
-        if (optimize_attention) {
-          //   std::shared_ptr<ml::train::Layer> multi_head_attention_bwdp1 =
-          //     ml::train::layer::BatchwiseDotproduct(
-          //       {"name=layer" + std::to_string(i) +
-          //          "/multi_head_attention/bwdp1" +
-          //          std::to_string(NUM_HEADS - 1 - j),
-          //        "input_layers=layer" + std::to_string(i) +
-          //          "/multi_head_attention/q_fc" +
-          //          std::to_string(NUM_HEADS - 1 - j) + ",layer" +
-          //          std::to_string(i) + "/multi_head_attention/k_fc" +
-          //          std::to_string(NUM_HEADS - 1 - j),
-          //        "transpose_key=true", "scaled_dot_product=true",
-          //        "activation=softmax"});
-          //   model->addLayer(multi_head_attention_bwdp1);
+      LayerHandle attn_fc = createLayer("fully_connected",
+        {"name=" + prefix + "/multi_head_attention/fc",
+         "unit=" + std::to_string(MODEL_DIM)});
+      auto fc_out = attn_fc(concat_out);
 
-          //   std::shared_ptr<ml::train::Layer> multi_head_attention_bwdp2 =
-          //     ml::train::layer::BatchwiseDotproduct(
-          //       {"name=layer" + std::to_string(i) +
-          //          "/multi_head_attention/bwdp2" +
-          //          std::to_string(NUM_HEADS - 1 - j),
-          //        "input_layers=layer" + std::to_string(i) +
-          //          "/multi_head_attention/bwdp1" +
-          //          std::to_string(NUM_HEADS - 1 - j) + ",layer" +
-          //          std::to_string(i) + "/multi_head_attention/v_fc" +
-          //          std::to_string(NUM_HEADS - 1 - j)});
-          //   model->addLayer(multi_head_attention_bwdp2);
-
-          //   std::shared_ptr<ml::train::Layer>
-          //     multi_head_attention_attention = ml::train::layer::Identity(
-          //       {"name=layer" + std::to_string(i) +
-          //          "/multi_head_attention/attention" +
-          //          std::to_string(NUM_HEADS - 1 - j),
-          //        "input_layers=layer" + std::to_string(i) +
-          //          "/multi_head_attention/bwdp2" +
-          //          std::to_string(NUM_HEADS - 1 - j)});
-          //   model->addLayer(multi_head_attention_attention);
-        } else {
-          std::shared_ptr<ml::train::Layer> multi_head_attention_attention =
-            ml::train::layer::Attention(
-              {"name=layer" + std::to_string(i) +
-                 "/multi_head_attention/attention" +
-                 std::to_string(NUM_HEADS - 1 - j),
-               "input_layers=layer" + std::to_string(i) +
-                 "/multi_head_attention/q_fc" +
-                 std::to_string(NUM_HEADS - 1 - j) + ",layer" +
-                 std::to_string(i) + "/multi_head_attention/v_fc" +
-                 std::to_string(NUM_HEADS - 1 - j) + ",layer" +
-                 std::to_string(i) + "/multi_head_attention/k_fc" +
-                 std::to_string(NUM_HEADS - 1 - j),
-               "scaled_dot_product=true", "causal_mask=true"});
-          model->addLayer(multi_head_attention_attention);
-        }
-
-        concat_input += "layer" + std::to_string(i) +
-                        "/multi_head_attention/attention" + std::to_string(j);
-        if (j != NUM_HEADS - 1) {
-          concat_input += ",";
-        }
-      }
-
-      std::shared_ptr<ml::train::Layer> multi_head_attention_concat =
-        ml::train::layer::Concat(
-          {"name=layer" + std::to_string(i) + "/multi_head_attention/concat",
-           "input_layers=" + concat_input, "axis=3"});
-      model->addLayer(multi_head_attention_concat);
-
-      std::shared_ptr<ml::train::Layer> multi_head_attention_fc =
-        ml::train::layer::FullyConnected(
-          {"name=layer" + std::to_string(i) + "/multi_head_attention/fc",
-           "input_layers=layer" + std::to_string(i) +
-             "/multi_head_attention/concat",
-           "unit=" + std::to_string(MODEL_DIM)});
-      model->addLayer(multi_head_attention_fc);
-
-      std::shared_ptr<ml::train::Layer> multi_head_attention =
-        ml::train::layer::Identity(
-          {"name=layer" + std::to_string(i) + "/multi_head_attention",
-           "input_layers=layer" + std::to_string(i) +
-             "/multi_head_attention/fc"});
-      model->addLayer(multi_head_attention);
+      LayerHandle identity = createLayer("identity",
+        {"name=" + prefix + "/multi_head_attention"});
+      attn_out = identity(fc_out);
     } else {
-      std::shared_ptr<ml::train::Layer> masked_multi_head_attention =
-        ml::train::layer::MultiHeadAttention(
-          {"name=layer" + std::to_string(i) + "/multi_head_attention",
-           "input_layers=layer" + std::to_string(i) + "/multi_out1(0), layer" +
-             std::to_string(i) + "/multi_out1(1), layer" + std::to_string(i) +
-             "/multi_out1(2)",
-           "num_heads=" + std::to_string(NUM_HEADS)});
-      model->addLayer(masked_multi_head_attention);
+      LayerHandle mha = createLayer("multi_head_attention",
+        {"name=" + prefix + "/multi_head_attention",
+         "num_heads=" + std::to_string(NUM_HEADS)});
+      attn_out = mha({ln1_out, ln1_out, ln1_out});
     }
 
-    std::shared_ptr<ml::train::Layer> add1 = ml::train::layer::Addition(
-      {"name=layer" + std::to_string(i) + "/add1",
-       "input_layers=layer" + std::to_string(i) + "/ln_multiout1(1), layer" +
-         std::to_string(i) + "/multi_head_attention"});
-    model->addLayer(add1);
+    // Skip connection 1: prev + attention output
+    LayerHandle add1 = createLayer("Addition",
+      {"name=" + prefix + "/add1"});
+    auto add1_out = add1({prev, attn_out});
 
-    std::shared_ptr<ml::train::Layer> ln_multiout2 = ml::train::layer::MultiOut(
-      {"name=layer" + std::to_string(i) + "/ln_multiout2"});
-    model->addLayer(ln_multiout2);
+    // Layer Norm 2
+    LayerHandle ln2 = createLayer("layer_normalization",
+      {"name=" + prefix + "/ln2", "axis=3", "epsilon=1e-5"});
+    auto ln2_out = ln2(add1_out);
 
-    std::shared_ptr<ml::train::Layer> ln2 =
-      ml::train::layer::LayerNormalization(
-        {"name=layer" + std::to_string(i) + "/ln2", "axis=3", "epsilon=1e-5"});
-    model->addLayer(ln2);
-
-    std::shared_ptr<ml::train::Layer> multiout3 = ml::train::layer::MultiOut(
-      {"name=layer" + std::to_string(i) + "/multi_out3"});
-    model->addLayer(multiout3);
-
-    std::shared_ptr<ml::train::Layer> fc1 = ml::train::layer::FullyConnected(
-      {"name=layer" + std::to_string(i) + "/fc1",
-       "input_layers=layer" + std::to_string(i) + "/multi_out3(0)",
+    // FFN
+    LayerHandle fc1 = createLayer("fully_connected",
+      {"name=" + prefix + "/fc1",
        "unit=" + std::to_string(FC_UNIT), "activation=gelu"});
-    model->addLayer(fc1);
+    auto fc1_out = fc1(ln2_out);
 
-    std::shared_ptr<ml::train::Layer> fc2 = ml::train::layer::FullyConnected(
-      {"name=layer" + std::to_string(i) + "/fc2",
+    LayerHandle fc2 = createLayer("fully_connected",
+      {"name=" + prefix + "/fc2",
        "unit=" + std::to_string(MODEL_DIM)});
-    model->addLayer(fc2);
+    auto fc2_out = fc2(fc1_out);
 
-    std::shared_ptr<ml::train::Layer> add2 = ml::train::layer::Addition(
-      {"name=layer" + std::to_string(i) + "/add2",
-       "input_layers=layer" + std::to_string(i) + "/ln_multiout2(1), layer" +
-         std::to_string(i) + "/fc2"});
-    model->addLayer(add2);
+    // Skip connection 2: add1_out + fc2_out
+    LayerHandle add2 = createLayer("Addition",
+      {"name=" + prefix + "/add2"});
+    prev = add2({add1_out, fc2_out});
   }
 
-  std::shared_ptr<ml::train::Layer> layer_normalization =
-    ml::train::layer::LayerNormalization(
-      {"name=layer_normalization", "axis=3", "epsilon=1e-5"});
-  model->addLayer(layer_normalization);
+  // Final Layer Norm
+  LayerHandle final_ln = createLayer("layer_normalization",
+    {"name=layer_normalization", "axis=3", "epsilon=1e-5"});
+  auto output = final_ln(prev);
 
   model->setOptimizer(
     ml::train::createOptimizer("sgd", {"learning_rate = 0.1"}));
-  model->setProperty({"input_layers=wte_input, wpe_input"});
+
+  // Graph-based compile (handles compile + initialize + allocate)
+  model->compile(wte_in, output);
 
   return model.get();
 }
@@ -308,19 +216,7 @@ std::string inferModel(std::string path, std::string sentence,
   infer_result = "";
   std::string text = sentence;
 
-  try {
-    model_->compile();
-  } catch (const std::exception &e) {
-    std::cerr << "Error during compile: " << e.what() << "\n";
-    return nullptr;
-  }
-
-  try {
-    model_->initialize();
-  } catch (const std::exception &e) {
-    std::cerr << "Error during initialize: " << e.what() << "\n";
-    return nullptr;
-  }
+  // Model is already compiled and initialized by createPicogpt()
 
   std::string weight_file_name =
     optimize ? path + "/pico_gpt.bin" : path + "/pico_gpt_124_mha.bin";
@@ -351,8 +247,8 @@ std::string inferModel(std::string path, std::string sentence,
   model_->getLayer("wte", &wte_embedding_layer);
   const std::vector<float *> wte_weights_buf =
     wte_embedding_layer->getWeights();
-  nntrainer::Tensor wte_weight =
-    nntrainer::Tensor({NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
+  auto wte_weight = ml::train::Tensor::fromData(
+    {NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
 
   std::vector<float *> output_bufs;
 
@@ -361,10 +257,11 @@ std::string inferModel(std::string path, std::string sentence,
     output_bufs = model_->incremental_inference(
       BATCH_SIZE, {wte_input, wpe_input}, {}, init_input_seq_len, i - 1);
 
-    nntrainer::Tensor output({BATCH_SIZE, 1, i, MODEL_DIM}, output_bufs[0]);
-    nntrainer::Tensor incremented_output = output.getSharedDataTensor(
+    auto output = ml::train::Tensor::fromData(
+      {BATCH_SIZE, 1, i, MODEL_DIM}, output_bufs[0]);
+    auto incremented_output = output.getSharedDataTensor(
       {BATCH_SIZE, 1, 1, MODEL_DIM}, BATCH_SIZE * (i - 1) * MODEL_DIM);
-    nntrainer::Tensor next = incremented_output.dot(wte_weight, false, true);
+    auto next = incremented_output.dot(wte_weight, false, true);
 
     std::vector<unsigned int> ids = next.argmax();
 

--- a/Applications/LLaMA/jni/main.cpp
+++ b/Applications/LLaMA/jni/main.cpp
@@ -334,8 +334,9 @@ Tensor createAttentionLayer(const int layer_id, int seq_len, int n_heads,
       "reshape",
       {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                     "_attention_flatten"),
-       nntrainer::withKey("target_shape", "1:" + std::to_string(seq_len) + ":" +
-                                            std::to_string(n_heads * head_dim))}));
+       nntrainer::withKey("target_shape",
+                          "1:" + std::to_string(seq_len) + ":" +
+                            std::to_string(n_heads * head_dim))}));
     auto flat = flatten(concatenated);
 
     // linear transformation of attention output
@@ -379,17 +380,16 @@ Tensor createFeedForwardLayer(const int layer_id, int dim,
   auto h2 = ffn_2(input);
 
   LayerHandle swiglu(createLayer(
-    "swiglu",
-    {nntrainer::withKey("name",
-                        "layer" + std::to_string(layer_id) + "_ffn_swiglu")}));
+    "swiglu", {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
+                                            "_ffn_swiglu")}));
   auto h = swiglu({h1, h2});
 
-  LayerHandle ffn_out(createLayer(
-    "fully_connected",
-    {nntrainer::withKey("name",
-                        "layer" + std::to_string(layer_id) + "_ffn_output"),
-     nntrainer::withKey("unit", dim),
-     nntrainer::withKey("disable_bias", "true")}));
+  LayerHandle ffn_out(
+    createLayer("fully_connected",
+                {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
+                                              "_ffn_output"),
+                 nntrainer::withKey("unit", dim),
+                 nntrainer::withKey("disable_bias", "true")}));
 
   return ffn_out(h);
 }
@@ -415,11 +415,10 @@ Tensor createTransformerDecoder(const int layer_id, Tensor input) {
   auto residual = decoder_add({input, att_out});
 
   LayerHandle ffn_norm(createLayer(
-    "rms_norm",
-    {nntrainer::withKey("name",
-                        "layer" + std::to_string(layer_id) + "_ffn_norm"),
-     nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
-     nntrainer::withKey("packed", "false")}));
+    "rms_norm", {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
+                                              "_ffn_norm"),
+                 nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
+                 nntrainer::withKey("packed", "false")}));
   auto ffn_normed = ffn_norm(residual);
 
   auto ffn_out =
@@ -449,17 +448,16 @@ std::pair<Tensor, Tensor> buildLLaMAGraph() {
   }
 
   LayerHandle out_norm(createLayer(
-    "rms_norm",
-    {nntrainer::withKey("name", "output_norm"),
-     nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
-     nntrainer::withKey("packed", "false")}));
+    "rms_norm", {nntrainer::withKey("name", "output_norm"),
+                 nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
+                 nntrainer::withKey("packed", "false")}));
   h = out_norm(h);
 
-  LayerHandle out_fc(createLayer(
-    "fully_connected", {nntrainer::withKey("name", "output_of_llama"),
-                        nntrainer::withKey("unit", NUM_VOCAB),
-                        nntrainer::withKey("disable_bias", "true"),
-                        nntrainer::withKey("packed", "false")}));
+  LayerHandle out_fc(createLayer("fully_connected",
+                                 {nntrainer::withKey("name", "output_of_llama"),
+                                  nntrainer::withKey("unit", NUM_VOCAB),
+                                  nntrainer::withKey("disable_bias", "true"),
+                                  nntrainer::withKey("packed", "false")}));
   auto y = out_fc(h);
 
   return {x, y};

--- a/Applications/LLaMA/jni/main.cpp
+++ b/Applications/LLaMA/jni/main.cpp
@@ -585,7 +585,7 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
   }
 
   // compile(Tensor, Tensor) internally calls compile + initialize + allocate
-  status = g_model->compile(x, y);
+  status = g_model->compile(x, y, ml::train::ExecutionMode::INFERENCE);
   if (status) {
     throw std::invalid_argument("model compilation failed!");
   }

--- a/Applications/LLaMA/jni/main.cpp
+++ b/Applications/LLaMA/jni/main.cpp
@@ -19,9 +19,9 @@
 #include <string>
 #include <vector>
 
-#include <layer.h>
 #include <model.h>
 #include <optimizer.h>
+#include <tensor_api.h>
 #include <util_func.h>
 
 #include <app_context.h>
@@ -41,7 +41,9 @@
 using json = nlohmann::json;
 #endif
 
-using LayerHandle = std::shared_ptr<ml::train::Layer>;
+using ml::train::createLayer;
+using ml::train::LayerHandle;
+using ml::train::Tensor;
 using ModelHandle = std::unique_ptr<ml::train::Model>;
 
 ModelHandle g_model;
@@ -235,315 +237,232 @@ T unwrap(std::optional<T> &&value, const std::string &error_msg) {
 }
 
 /**
- * @brief Create Attention Layer for the seperate impelemntation
+ * @brief Create Attention Layer using symbolic tensor graph
  */
-std::vector<LayerHandle> createAttentionLayer(const int layer_id, int seq_len,
-                                              int n_heads, int head_dim,
-                                              std::string query_name,
-                                              std::string key_name,
-                                              std::string value_name) {
-  using ml::train::createLayer;
-
-  std::vector<LayerHandle> layers;
-
+Tensor createAttentionLayer(const int layer_id, int seq_len, int n_heads,
+                            int head_dim, Tensor query, Tensor key,
+                            Tensor value) {
   if (optimize) {
-    // linear transformation of q
+    std::vector<Tensor> head_outputs;
+
     for (int i = 0; i < n_heads; i++) {
-      layers.push_back(createLayer(
+      // linear transformation of q, k, v
+      LayerHandle wq(createLayer(
         "fully_connected",
         {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                       "_wq_" + std::to_string(i)),
          nntrainer::withKey("unit", head_dim),
-         nntrainer::withKey("disable_bias", "true"),
-         nntrainer::withKey("input_layers", query_name)}));
-    }
-
-    // linear transformation of k
-    for (int i = 0; i < n_heads; i++) {
-      layers.push_back(createLayer(
+         nntrainer::withKey("disable_bias", "true")}));
+      LayerHandle wk(createLayer(
         "fully_connected",
         {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                       "_wk_" + std::to_string(i)),
          nntrainer::withKey("unit", head_dim),
-         nntrainer::withKey("disable_bias", "true"),
-         nntrainer::withKey("input_layers", key_name)}));
-    }
-
-    // linear transformation of v
-    for (int i = 0; i < n_heads; i++) {
-      layers.push_back(createLayer(
+         nntrainer::withKey("disable_bias", "true")}));
+      LayerHandle wv(createLayer(
         "fully_connected",
         {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                       "_wv_" + std::to_string(i)),
          nntrainer::withKey("unit", head_dim),
-         nntrainer::withKey("disable_bias", "true"),
-         nntrainer::withKey("input_layers", value_name)}));
-    }
+         nntrainer::withKey("disable_bias", "true")}));
 
-    std::string concat_input = "";
-    // apply rotary embedding and dot_product attention
-    for (int i = 0; i < n_heads; i++) {
-      // reshape q, k, v (apply num_heads)
-      layers.push_back(createLayer(
+      auto q = wq(query);
+      auto k = wk(key);
+      auto v = wv(value);
+
+      // reshape q, k, v
+      std::string reshape_target =
+        "1:" + std::to_string(seq_len) + ":" + std::to_string(head_dim);
+
+      LayerHandle q_reshape(createLayer(
         "reshape",
         {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                       "_q_reshape_" + std::to_string(i)),
-         nntrainer::withKey("target_shape", "1:" + std::to_string(seq_len) +
-                                              ":" + std::to_string(head_dim)),
-         nntrainer::withKey("input_layers", "layer" + std::to_string(layer_id) +
-                                              "_wq_" + std::to_string(i))}));
-
-      layers.push_back(createLayer(
+         nntrainer::withKey("target_shape", reshape_target)}));
+      LayerHandle k_reshape(createLayer(
         "reshape",
         {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                       "_k_reshape_" + std::to_string(i)),
-         nntrainer::withKey("target_shape", "1:" + std::to_string(seq_len) +
-                                              ":" + std::to_string(head_dim)),
-         nntrainer::withKey("input_layers", "layer" + std::to_string(layer_id) +
-                                              "_wk_" + std::to_string(i))}));
-
-      layers.push_back(createLayer(
+         nntrainer::withKey("target_shape", reshape_target)}));
+      LayerHandle v_reshape(createLayer(
         "reshape",
         {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                       "_v_reshape_" + std::to_string(i)),
-         nntrainer::withKey("target_shape", "1:" + std::to_string(seq_len) +
-                                              ":" + std::to_string(head_dim)),
-         nntrainer::withKey("input_layers", "layer" + std::to_string(layer_id) +
-                                              "_wv_" + std::to_string(i))}));
+         nntrainer::withKey("target_shape", reshape_target)}));
+
+      q = q_reshape(q);
+      k = k_reshape(k);
+      v = v_reshape(v);
 
       // apply rotary embedding to q, k
-      layers.push_back(createLayer(
+      LayerHandle q_rotary(createLayer(
         "rotary_embedding",
         {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
-                                      "_q_rotary_" + std::to_string(i)),
-         nntrainer::withKey("input_layers", "layer" + std::to_string(layer_id) +
-                                              "_q_reshape_" +
-                                              std::to_string(i))}));
-
-      layers.push_back(createLayer(
+                                      "_q_rotary_" + std::to_string(i))}));
+      LayerHandle k_rotary(createLayer(
         "rotary_embedding",
         {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
-                                      "_k_rotary_" + std::to_string(i)),
-         nntrainer::withKey("input_layers", "layer" + std::to_string(layer_id) +
-                                              "_k_reshape_" +
-                                              std::to_string(i))}));
+                                      "_k_rotary_" + std::to_string(i))}));
 
-      // apply scaled-dot product attention
-      layers.push_back(ml::train::layer::Attention(
+      q = q_rotary(q);
+      k = k_rotary(k);
+
+      // apply scaled-dot product attention (input order: q, v, k)
+      LayerHandle attn(ml::train::layer::Attention(
         {"name=layer" + std::to_string(layer_id) + "_attention_" +
            std::to_string(i),
-         "input_layers=layer" + std::to_string(layer_id) + "_q_rotary_" +
-           std::to_string(i) + ",layer" + std::to_string(layer_id) +
-           "_v_reshape_" + std::to_string(i) + ",layer" +
-           std::to_string(layer_id) + "_k_rotary_" + std::to_string(i),
          "scaled_dot_product=true", "causal_mask=true"}));
+      auto att_out = attn({q, v, k});
 
-      layers.push_back(createLayer(
+      LayerHandle att_reshape(createLayer(
         "reshape",
         {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                       "_attention_output_" + std::to_string(i)),
-         nntrainer::withKey("target_shape", "1:" + std::to_string(seq_len) +
-                                              ":" + std::to_string(head_dim)),
-         nntrainer::withKey("input_layers", "layer" + std::to_string(layer_id) +
-                                              "_attention_" +
-                                              std::to_string(i))}));
-
-      concat_input += "layer" + std::to_string(layer_id) +
-                      "_attention_output_" + std::to_string(i);
-
-      if (i != n_heads - 1) {
-        concat_input += ",";
-      }
+         nntrainer::withKey("target_shape", reshape_target)}));
+      head_outputs.push_back(att_reshape(att_out));
     }
 
-    // concat attention output
-    layers.push_back(createLayer(
+    // concat attention outputs
+    LayerHandle concat_layer(createLayer(
       "concat", {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                               "_attention_concat"),
-                 nntrainer::withKey("axis", 3),
-                 nntrainer::withKey("input_layers", concat_input)}));
+                 nntrainer::withKey("axis", 3)}));
+    auto concatenated = concat_layer(head_outputs);
 
     // reshape for flatten
-    layers.push_back(createLayer(
+    LayerHandle flatten(createLayer(
       "reshape",
       {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                     "_attention_flatten"),
        nntrainer::withKey("target_shape", "1:" + std::to_string(seq_len) + ":" +
-                                            std::to_string(n_heads * head_dim)),
-       nntrainer::withKey("input_layers", "layer" + std::to_string(layer_id) +
-                                            "_attention_concat")}));
+                                            std::to_string(n_heads * head_dim))}));
+    auto flat = flatten(concatenated);
 
     // linear transformation of attention output
-    layers.push_back(createLayer(
+    LayerHandle out_proj(createLayer(
       "fully_connected",
       {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                     "_attention_out"),
        nntrainer::withKey("unit", head_dim * n_heads),
-       nntrainer::withKey("disable_bias", "true"),
-       nntrainer::withKey("input_layers", "layer" + std::to_string(layer_id) +
-                                            "_attention_flatten")}));
+       nntrainer::withKey("disable_bias", "true")}));
+    return out_proj(flat);
+
   } else {
-    layers.push_back(createLayer(
+    LayerHandle mha(createLayer(
       "custom_multi_head_attention",
       {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                     "_attention_out"),
        nntrainer::withKey("num_heads", std::to_string(NUM_HEADS)),
        nntrainer::withKey("max_timestep", std::to_string(MAX_SEQ_LEN)),
-       nntrainer::withKey("disable_bias", "true"),
-       nntrainer::withKey("input_layers",
-                          {query_name, key_name, value_name})}));
+       nntrainer::withKey("disable_bias", "true")}));
+    return mha({query, key, value});
   }
-
-  return layers;
 }
 
 /**
- * @brief Create FF Layers
+ * @brief Create FF Layers using symbolic tensor graph
  */
-std::vector<LayerHandle> createFeedForwardLayer(const int layer_id, int dim,
-                                                int intermediate_size,
-                                                std::string input_name) {
-  using ml::train::createLayer;
-  std::vector<LayerHandle> layers;
-
-  layers.push_back(createLayer(
+Tensor createFeedForwardLayer(const int layer_id, int dim,
+                              int intermediate_size, Tensor input) {
+  LayerHandle ffn_1(createLayer(
     "fully_connected",
     {nntrainer::withKey("name", "layer" + std::to_string(layer_id) + "_ffn_1"),
      nntrainer::withKey("unit", intermediate_size),
-     nntrainer::withKey("disable_bias", "true"),
-     nntrainer::withKey("input_layers", input_name)}));
-  layers.push_back(createLayer(
+     nntrainer::withKey("disable_bias", "true")}));
+  LayerHandle ffn_2(createLayer(
     "fully_connected",
     {nntrainer::withKey("name", "layer" + std::to_string(layer_id) + "_ffn_2"),
      nntrainer::withKey("unit", intermediate_size),
-     nntrainer::withKey("disable_bias", "true"),
-     nntrainer::withKey("input_layers", input_name)}));
+     nntrainer::withKey("disable_bias", "true")}));
 
-  layers.push_back(createLayer(
+  auto h1 = ffn_1(input);
+  auto h2 = ffn_2(input);
+
+  LayerHandle swiglu(createLayer(
     "swiglu",
     {nntrainer::withKey("name",
-                        "layer" + std::to_string(layer_id) + "_ffn_swiglu"),
-     nntrainer::withKey("input_layers",
-                        "layer" + std::to_string(layer_id) + "_ffn_1," +
-                          "layer" + std::to_string(layer_id) + "_ffn_2")}));
+                        "layer" + std::to_string(layer_id) + "_ffn_swiglu")}));
+  auto h = swiglu({h1, h2});
 
-  layers.push_back(createLayer(
+  LayerHandle ffn_out(createLayer(
     "fully_connected",
     {nntrainer::withKey("name",
                         "layer" + std::to_string(layer_id) + "_ffn_output"),
      nntrainer::withKey("unit", dim),
-     nntrainer::withKey("disable_bias", "true"),
-     nntrainer::withKey("input_layers",
-                        "layer" + std::to_string(layer_id) + "_ffn_swiglu")}));
+     nntrainer::withKey("disable_bias", "true")}));
 
-  return layers;
+  return ffn_out(h);
 }
 
 /**
- * @brief Create Decoder
+ * @brief Create Decoder using symbolic tensor graph
  */
-std::vector<LayerHandle> createTransformerDecoder(const int layer_id,
-                                                  std::string input_name) {
-  using ml::train::createLayer;
-  std::vector<LayerHandle> layers;
-
-  layers.push_back(createLayer(
+Tensor createTransformerDecoder(const int layer_id, Tensor input) {
+  LayerHandle att_norm(createLayer(
     "rms_norm", {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                               "_attention_norm"),
-                 nntrainer::withKey("input_layers", input_name),
                  nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
                  nntrainer::withKey("packed", "false")}));
+  auto normed = att_norm(input);
 
-  auto att_layer = createAttentionLayer(
-    layer_id, INIT_SEQ_LEN, NUM_HEADS, DIM / NUM_HEADS,
-    "layer" + std::to_string(layer_id) + "_attention_norm",
-    "layer" + std::to_string(layer_id) + "_attention_norm",
-    "layer" + std::to_string(layer_id) + "_attention_norm");
-  layers.insert(layers.end(), att_layer.begin(), att_layer.end());
+  auto att_out = createAttentionLayer(layer_id, INIT_SEQ_LEN, NUM_HEADS,
+                                      DIM / NUM_HEADS, normed, normed, normed);
 
-  layers.push_back(createLayer(
+  // residual connection: input + attention output
+  LayerHandle decoder_add(createLayer(
     "addition", {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
-                                              "_decoder_add"),
-                 nntrainer::withKey("input_layers", input_name + ",layer" +
-                                                      std::to_string(layer_id) +
-                                                      "_attention_out")}));
+                                              "_decoder_add")}));
+  auto residual = decoder_add({input, att_out});
 
-  layers.push_back(createLayer(
+  LayerHandle ffn_norm(createLayer(
     "rms_norm",
     {nntrainer::withKey("name",
                         "layer" + std::to_string(layer_id) + "_ffn_norm"),
-     nntrainer::withKey("input_layers",
-                        "layer" + std::to_string(layer_id) + "_decoder_add"),
      nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
      nntrainer::withKey("packed", "false")}));
+  auto ffn_normed = ffn_norm(residual);
 
-  auto ffn_layer =
-    createFeedForwardLayer(layer_id, DIM, INTERMEDIATE_SIZE,
-                           "layer" + std::to_string(layer_id) + "_ffn_norm");
-  layers.insert(layers.end(), ffn_layer.begin(), ffn_layer.end());
+  auto ffn_out =
+    createFeedForwardLayer(layer_id, DIM, INTERMEDIATE_SIZE, ffn_normed);
 
-  layers.push_back(createLayer(
+  // residual connection: decoder_add + ffn output
+  LayerHandle decoder_output(createLayer(
     "addition", {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
-                                              "_decoder_output"),
-                 nntrainer::withKey(
-                   "input_layers",
-                   "layer" + std::to_string(layer_id) + "_decoder_add,layer" +
-                     std::to_string(layer_id) + "_ffn_output")}));
-
-  return layers;
+                                              "_decoder_output")}));
+  return decoder_output({residual, ffn_out});
 }
 
 /**
- * @brief Create LLaMA2 Model
+ * @brief Build LLaMA2 symbolic tensor graph
+ * @return {input_tensor, output_tensor}
  */
-ModelHandle createLLaMA() {
-  using ml::train::createLayer;
+std::pair<Tensor, Tensor> buildLLaMAGraph() {
+  auto x = Tensor({1, 1, 1, static_cast<unsigned int>(INIT_SEQ_LEN)}, "input0");
 
-  ModelHandle model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
-
-  std::vector<LayerHandle> layers;
-
-  layers.push_back(createLayer(
-    "input", {nntrainer::withKey("name", "input0"),
-              nntrainer::withKey("input_shape",
-                                 "1:1:" + std::to_string(INIT_SEQ_LEN))}));
-
-  layers.push_back(ml::train::layer::Embedding(
+  LayerHandle embedding(ml::train::layer::Embedding(
     {"name=embedding0", "in_dim=" + std::to_string(NUM_VOCAB), "packed=false",
      "out_dim=" + std::to_string(DIM)}));
+  auto h = embedding(x);
 
   for (int i = 0; i < NUM_LAYERS; i++) {
-    std::vector<LayerHandle> transformer;
-    if (i == 0)
-      transformer = createTransformerDecoder(i, "embedding0");
-    else
-      transformer = createTransformerDecoder(
-        i, "layer" + std::to_string(i - 1) + "_decoder_output");
-    layers.insert(layers.end(), transformer.begin(), transformer.end());
+    h = createTransformerDecoder(i, h);
   }
 
-  int last_layer = NUM_LAYERS - 1;
-
-  layers.push_back(createLayer(
+  LayerHandle out_norm(createLayer(
     "rms_norm",
     {nntrainer::withKey("name", "output_norm"),
      nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
-     nntrainer::withKey("input_layers", "layer" + std::to_string(last_layer) +
-                                          "_decoder_output"),
      nntrainer::withKey("packed", "false")}));
+  h = out_norm(h);
 
-  layers.push_back(createLayer(
+  LayerHandle out_fc(createLayer(
     "fully_connected", {nntrainer::withKey("name", "output_of_llama"),
                         nntrainer::withKey("unit", NUM_VOCAB),
                         nntrainer::withKey("disable_bias", "true"),
-                        nntrainer::withKey("input_layers", "output_norm"),
                         nntrainer::withKey("packed", "false")}));
+  auto y = out_fc(h);
 
-  for (auto &layer : layers) {
-    model->addLayer(layer);
-  }
-
-  return model;
+  return {x, y};
 }
 
 /**
@@ -646,12 +565,14 @@ void run(std::string text, std::string vocab_file_path,
 }
 
 /**
- * @brief to creaet model
+ * @brief to create model
  */
 void createAndRun(unsigned int epochs, unsigned int batch_size,
                   std::string weight_path) {
-  // setup model
-  g_model = createLLaMA();
+  // Build symbolic graph
+  auto [x, y] = buildLLaMAGraph();
+
+  g_model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
   g_model->setProperty({nntrainer::withKey("batch_size", batch_size),
                         nntrainer::withKey("epochs", epochs),
 #ifdef ENABLE_FP16
@@ -665,14 +586,10 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
     throw std::invalid_argument("failed to set optimizer!");
   }
 
-  status = g_model->compile();
+  // compile(Tensor, Tensor) internally calls compile + initialize + allocate
+  status = g_model->compile(x, y);
   if (status) {
     throw std::invalid_argument("model compilation failed!");
-  }
-
-  status = g_model->initialize();
-  if (status) {
-    throw std::invalid_argument("model initialization failed!");
   }
 
   g_model->load(weight_path);

--- a/Applications/MNIST/jni/main.cpp
+++ b/Applications/MNIST/jni/main.cpp
@@ -105,6 +105,9 @@ bool getData(std::ifstream &F, float *input, float *label, unsigned int id) {
   return true;
 }
 
+/**
+ * @brief Per-dataset bookkeeping for random sample ordering.
+ */
 class DataInformation {
 public:
   DataInformation(unsigned int num_samples, const std::string &filename);
@@ -165,27 +168,27 @@ static std::pair<ml::train::Tensor, ml::train::Tensor> buildGraph() {
 
   auto x = Tensor({1, 1, 28, 28}, "inputlayer");
 
-  LayerHandle conv1(createLayer(
-    "conv2d", {"name=conv2d_c1_layer", "kernel_size=5,5",
-               "bias_initializer=zeros", "activation=sigmoid",
-               "weight_initializer=xavier_uniform", "filters=6",
-               "stride=1,1", "padding=0,0"}));
-  LayerHandle pool1(createLayer(
-    "pooling2d", {"name=pooling2d_p1", "pool_size=2,2", "stride=2,2",
-                  "padding=0,0", "pooling=average"}));
-  LayerHandle conv2(createLayer(
-    "conv2d", {"name=conv2d_c2_layer", "kernel_size=5,5",
-               "bias_initializer=zeros", "activation=sigmoid",
-               "weight_initializer=xavier_uniform", "filters=12",
-               "stride=1,1", "padding=0,0"}));
-  LayerHandle pool2(createLayer(
-    "pooling2d", {"name=pooling2d_p2", "pool_size=2,2", "stride=2,2",
-                  "padding=0,0", "pooling=average"}));
+  LayerHandle conv1(
+    createLayer("conv2d", {"name=conv2d_c1_layer", "kernel_size=5,5",
+                           "bias_initializer=zeros", "activation=sigmoid",
+                           "weight_initializer=xavier_uniform", "filters=6",
+                           "stride=1,1", "padding=0,0"}));
+  LayerHandle pool1(
+    createLayer("pooling2d", {"name=pooling2d_p1", "pool_size=2,2",
+                              "stride=2,2", "padding=0,0", "pooling=average"}));
+  LayerHandle conv2(
+    createLayer("conv2d", {"name=conv2d_c2_layer", "kernel_size=5,5",
+                           "bias_initializer=zeros", "activation=sigmoid",
+                           "weight_initializer=xavier_uniform", "filters=12",
+                           "stride=1,1", "padding=0,0"}));
+  LayerHandle pool2(
+    createLayer("pooling2d", {"name=pooling2d_p2", "pool_size=2,2",
+                              "stride=2,2", "padding=0,0", "pooling=average"}));
   LayerHandle flat(createLayer("flatten", {"name=flatten"}));
-  LayerHandle fc(createLayer(
-    "fully_connected", {"name=outputlayer", "unit=10",
-                        "weight_initializer=xavier_uniform",
-                        "bias_initializer=zeros", "activation=softmax"}));
+  LayerHandle fc(createLayer("fully_connected",
+                             {"name=outputlayer", "unit=10",
+                              "weight_initializer=xavier_uniform",
+                              "bias_initializer=zeros", "activation=softmax"}));
 
   auto h = conv1(x);
   h = pool1(h);
@@ -238,10 +241,10 @@ int main(int argc, char *argv[]) {
 
   std::shared_ptr<ml::train::Dataset> dataset_train, dataset_val;
   try {
-    dataset_train = ml::train::createDataset(
-      ml::train::DatasetType::GENERATOR, getSample, train_user_data.get());
-    dataset_val = ml::train::createDataset(
-      ml::train::DatasetType::GENERATOR, getSample, valid_user_data.get());
+    dataset_train = ml::train::createDataset(ml::train::DatasetType::GENERATOR,
+                                             getSample, train_user_data.get());
+    dataset_val = ml::train::createDataset(ml::train::DatasetType::GENERATOR,
+                                           getSample, valid_user_data.get());
   } catch (const std::exception &e) {
     std::cerr << "Error creating dataset" << e.what() << std::endl;
     return 1;
@@ -250,9 +253,9 @@ int main(int argc, char *argv[]) {
   // Build symbolic graph
   auto [x, y] = buildGraph();
 
-  auto model = ml::train::createModel(ml::train::ModelType::NEURAL_NET,
-                                      {"epochs=1500", "loss=cross",
-                                       "batch_size=32"});
+  auto model =
+    ml::train::createModel(ml::train::ModelType::NEURAL_NET,
+                           {"epochs=1500", "loss=cross", "batch_size=32"});
 
   try {
     auto optimizer = ml::train::createOptimizer("adam");

--- a/Applications/MNIST/jni/main.cpp
+++ b/Applications/MNIST/jni/main.cpp
@@ -7,16 +7,15 @@
  * @see    https://github.com/nntrainer/nntrainer
  * @author Jijoong Moon <jijoong.moon@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  This is MNIST Example with
+ * @brief  MNIST CNN example using symbolic tensor graph construction.
  *
  * Input 28x28
- * Conv2D 5 x 5 : 6 filters, stride 1x1, padding=0,0
- * Pooling2D : 2 x 2, Average pooling, stride 1x1
- * Conv2D 6 x 5 x 5 : 12 filters, stride 1x1, padding=0,0
- * Pooling2D : 2 x 2, Average Pooling, stride 1x1
+ * Conv2D 5x5 : 6 filters, stride 1x1, padding=0,0, sigmoid
+ * Pooling2D : 2x2, Average pooling, stride 2x2
+ * Conv2D 5x5 : 12 filters, stride 1x1, padding=0,0, sigmoid
+ * Pooling2D : 2x2, Average Pooling, stride 2x2
  * Flatten
- * Fully Connected Layer with 10 unit
- *
+ * Fully Connected Layer with 10 units, softmax
  */
 
 #if defined(ENABLE_TEST)
@@ -42,9 +41,10 @@
 #include <dataset.h>
 #include <model.h>
 #include <optimizer.h>
+#include <tensor_api.h>
 
 #ifdef PROFILE
-#include <profiler.h> // disable including this in android as profiler is not exposed yet to devel header
+#include <profiler.h>
 #endif
 
 #define TRAINING true
@@ -54,32 +54,17 @@
 constexpr unsigned int SEED = 0;
 
 #if VALIDATION
-/**
- * @brief     Data size for each category
- */
 const unsigned int total_train_data_size = 32;
-
 const unsigned int total_val_data_size = 32;
-
 const unsigned int total_test_data_size = 32;
-
 const unsigned int batch_size = 32;
-
 #else
-
 const unsigned int total_train_data_size = 100;
-
 const unsigned int total_val_data_size = 100;
-
 const unsigned int total_test_data_size = 100;
-
 const unsigned int batch_size = 32;
-
 #endif
 
-/**
- * @brief     Number of category : Three
- */
 const unsigned int total_label_size = 10;
 
 unsigned int train_count = 0;
@@ -96,31 +81,14 @@ float validation_loss = 0.0f;
 
 std::string filename = "mnist_trainingSet.dat";
 
-/**
- * @brief     step function
- * @param[in] x value to be distinguished
- * @retval 0.0 or 1.0
- */
 float stepFunction(float x) {
-  if (x + tolerance > 1.0) {
+  if (x + tolerance > 1.0)
     return 1.0;
-  }
-
-  if (x - tolerance < 0.0) {
+  if (x - tolerance < 0.0)
     return 0.0;
-  }
-
   return x;
 }
 
-/**
- * @brief     load data at specific position of file
- * @param[in] F  ifstream (input file)
- * @param[out] input input
- * @param[out] label label
- * @param[in] id th data to get
- * @retval true/false false : end of data
- */
 bool getData(std::ifstream &F, float *input, float *label, unsigned int id) {
   F.clear();
   F.seekg(0, std::ios_base::end);
@@ -128,28 +96,17 @@ bool getData(std::ifstream &F, float *input, float *label, unsigned int id) {
   uint64_t position = (uint64_t)((feature_size + total_label_size) *
                                  (uint64_t)id * sizeof(float));
 
-  if (position > file_length) {
+  if (position > file_length)
     return false;
-  }
+
   F.seekg(position, std::ios::beg);
   F.read((char *)input, sizeof(float) * feature_size);
   F.read((char *)label, sizeof(float) * total_label_size);
-
   return true;
 }
 
-/**
- * @brief UserData which stores information used to feed data from data callback
- *
- */
 class DataInformation {
 public:
-  /**
-   * @brief Construct a new Data Information object
-   *
-   * @param num_samples number of data
-   * @param filename file name to read from
-   */
   DataInformation(unsigned int num_samples, const std::string &filename);
   unsigned int count;
   unsigned int num_samples;
@@ -173,14 +130,6 @@ DataInformation::DataInformation(unsigned int num_samples,
   }
 }
 
-/**
- * @brief      get data which size is batch for train
- * @param[out] outInput input vectors
- * @param[out] outLabel label vectors
- * @param[out] last if the data is finished
- * @param[in] user_data private data for the callback
- * @retval status for handling error
- */
 int getSample(float **outVec, float **outLabel, bool *last, void *user_data) {
   auto data = reinterpret_cast<DataInformation *>(user_data);
 
@@ -205,10 +154,52 @@ TEST(MNIST_training, verify_accuracy) {
 #endif
 
 /**
- * @brief     create model
- *            Get Feature from tflite & run forward & back propagation
- * @param[in]  arg 1 : configuration file path
- * @param[in]  arg 2 : resource path
+ * @brief Build the MNIST CNN model using symbolic tensor graph.
+ *
+ * Returns {input_tensor, output_tensor} for compile(Tensor, Tensor).
+ */
+static std::pair<ml::train::Tensor, ml::train::Tensor> buildGraph() {
+  using ml::train::createLayer;
+  using ml::train::LayerHandle;
+  using ml::train::Tensor;
+
+  auto x = Tensor({1, 1, 28, 28}, "inputlayer");
+
+  LayerHandle conv1(createLayer(
+    "conv2d", {"name=conv2d_c1_layer", "kernel_size=5,5",
+               "bias_initializer=zeros", "activation=sigmoid",
+               "weight_initializer=xavier_uniform", "filters=6",
+               "stride=1,1", "padding=0,0"}));
+  LayerHandle pool1(createLayer(
+    "pooling2d", {"name=pooling2d_p1", "pool_size=2,2", "stride=2,2",
+                  "padding=0,0", "pooling=average"}));
+  LayerHandle conv2(createLayer(
+    "conv2d", {"name=conv2d_c2_layer", "kernel_size=5,5",
+               "bias_initializer=zeros", "activation=sigmoid",
+               "weight_initializer=xavier_uniform", "filters=12",
+               "stride=1,1", "padding=0,0"}));
+  LayerHandle pool2(createLayer(
+    "pooling2d", {"name=pooling2d_p2", "pool_size=2,2", "stride=2,2",
+                  "padding=0,0", "pooling=average"}));
+  LayerHandle flat(createLayer("flatten", {"name=flatten"}));
+  LayerHandle fc(createLayer(
+    "fully_connected", {"name=outputlayer", "unit=10",
+                        "weight_initializer=xavier_uniform",
+                        "bias_initializer=zeros", "activation=softmax"}));
+
+  auto h = conv1(x);
+  h = pool1(h);
+  h = conv2(h);
+  h = pool2(h);
+  h = flat(h);
+  auto y = fc(h);
+
+  return {x, y};
+}
+
+/**
+ * @brief     create model and train on MNIST
+ * @param[in]  arg 1 : resource path (dataset.dat)
  */
 int main(int argc, char *argv[]) {
   int status = 0;
@@ -218,8 +209,8 @@ int main(int argc, char *argv[]) {
     std::cout << "Pre-existing model file doesn't exist.\n";
   }
 #endif
-  if (argc < 3) {
-    std::cout << "./nntrainer_mnist mnist.ini dataset.dat\n";
+  if (argc < 2) {
+    std::cout << "./nntrainer_mnist dataset.dat\n";
     exit(0);
   }
 
@@ -230,8 +221,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   const std::vector<std::string> args(argv + 1, argv + argc);
-  std::string config = args[0];
-  filename = args[1];
+  filename = args[0];
 
   std::unique_ptr<DataInformation> train_user_data;
   std::unique_ptr<DataInformation> valid_user_data;
@@ -246,31 +236,23 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  /**
-   * @brief     Data buffer Create & Initialization
-   */
   std::shared_ptr<ml::train::Dataset> dataset_train, dataset_val;
   try {
-    dataset_train = createDataset(ml::train::DatasetType::GENERATOR, getSample,
-                                  train_user_data.get());
-    dataset_val = createDataset(ml::train::DatasetType::GENERATOR, getSample,
-                                valid_user_data.get());
+    dataset_train = ml::train::createDataset(
+      ml::train::DatasetType::GENERATOR, getSample, train_user_data.get());
+    dataset_val = ml::train::createDataset(
+      ml::train::DatasetType::GENERATOR, getSample, valid_user_data.get());
   } catch (const std::exception &e) {
     std::cerr << "Error creating dataset" << e.what() << std::endl;
     return 1;
   }
 
-  std::unique_ptr<ml::train::Model> model;
-  try {
-    /**
-     * @brief     Neural Network Create & Initialization
-     */
-    model = createModel(ml::train::ModelType::NEURAL_NET);
-    model->load(config, ml::train::ModelFormat::MODEL_FORMAT_INI_WITH_BIN);
-  } catch (const std::exception &e) {
-    std::cerr << "Error during loadFromConfig " << e.what() << std::endl;
-    return 1;
-  }
+  // Build symbolic graph
+  auto [x, y] = buildGraph();
+
+  auto model = ml::train::createModel(ml::train::ModelType::NEURAL_NET,
+                                      {"epochs=1500", "loss=cross",
+                                       "batch_size=32"});
 
   try {
     auto optimizer = ml::train::createOptimizer("adam");
@@ -287,8 +269,8 @@ int main(int argc, char *argv[]) {
   }
 
   try {
-    model->compile();
-    model->initialize();
+    // compile(Tensor, Tensor) internally calls compile + initialize + allocate
+    model->compile(x, y, ml::train::ExecutionMode::TRAIN);
     model->setDataset(ml::train::DatasetModeType::MODE_TRAIN, dataset_train);
     model->setDataset(ml::train::DatasetModeType::MODE_VALID, dataset_val);
   } catch (const std::exception &e) {
@@ -305,9 +287,6 @@ int main(int argc, char *argv[]) {
   }
 #endif
 
-  /**
-   * @brief     Neural Network Train & validation
-   */
   try {
     model->train();
     training_loss = model->getTrainingLoss();
@@ -336,8 +315,5 @@ int main(int argc, char *argv[]) {
   }
 #endif
 
-  /**
-   * @brief     Finalize model
-   */
   return status;
 }

--- a/Applications/MNIST/jni/meson.build
+++ b/Applications/MNIST/jni/meson.build
@@ -23,18 +23,18 @@ endif
 
 e = executable('nntrainer_mnist',
   mnist_sources,
-  dependencies: [iniparser_dep, nntrainer_ccapi_dep, gtest_dep],
+  dependencies: [nntrainer_ccapi_dep, gtest_dep],
   include_directories: include_directories('.'),
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
 
+# No INI config needed — model built via ccapi
 if host_machine.system() != 'windows'
 test(
   'app_mnist',
   e,
   args: [
-    build_app_res_dir / 'mnist.ini',
     build_app_res_dir / 'mnist_trainingSet.dat'
   ],
   timeout: 60

--- a/Applications/MixedPrecision/jni/main.cpp
+++ b/Applications/MixedPrecision/jni/main.cpp
@@ -115,7 +115,7 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
     throw std::invalid_argument("failed to set optimizer!");
   }
 
-  status = model->compile(x, y);
+  status = model->compile(x, y, ml::train::ExecutionMode::INFERENCE);
   if (status) {
     throw std::invalid_argument("model compilation failed!");
   }

--- a/Applications/MixedPrecision/jni/main.cpp
+++ b/Applications/MixedPrecision/jni/main.cpp
@@ -18,14 +18,16 @@
 #include <sstream>
 #include <vector>
 
-#include <layer.h>
 #include <model.h>
 #include <optimizer.h>
+#include <tensor_api.h>
 #include <util_func.h>
 
 #include <cifar_dataloader.h>
 
-using LayerHandle = std::shared_ptr<ml::train::Layer>;
+using ml::train::createLayer;
+using ml::train::LayerHandle;
+using ml::train::Tensor;
 using ModelHandle = std::unique_ptr<ml::train::Model>;
 using UserDataType = std::unique_ptr<nntrainer::util::DataLoader>;
 
@@ -33,15 +35,14 @@ using UserDataType = std::unique_ptr<nntrainer::util::DataLoader>;
 float training_loss = 0.0;
 float validation_loss = 0.0;
 
-std::vector<LayerHandle> createGraph() {
-  using ml::train::createLayer;
+/**
+ * @brief Build mixed precision graph using symbolic tensor API
+ * @return {input, output}
+ */
+std::pair<Tensor, Tensor> buildGraph() {
+  auto x = Tensor({1, 3, 32, 32}, "input0");
 
-  std::vector<LayerHandle> layers;
-  layers.push_back(
-    createLayer("input", {nntrainer::withKey("name", "input0"),
-                          nntrainer::withKey("input_shape", "3:32:32")}));
-
-  layers.push_back(createLayer(
+  LayerHandle conv0(createLayer(
     "conv2d",
     {nntrainer::withKey("name", "conv0"), nntrainer::withKey("filters", 64),
      nntrainer::withKey("kernel_size", {3, 3}),
@@ -49,35 +50,33 @@ std::vector<LayerHandle> createGraph() {
      nntrainer::withKey("padding", "same"),
      nntrainer::withKey("bias_initializer", "zeros"),
      nntrainer::withKey("weight_initializer", "xavier_uniform")}));
+  auto h = conv0(x);
 
-  layers.push_back(createLayer("batch_normalization",
-                               {nntrainer::withKey("name", "first_bn_relu"),
-                                nntrainer::withKey("activation", "relu"),
-                                nntrainer::withKey("momentum", "0.9"),
-                                nntrainer::withKey("epsilon", "0.00001")}));
+  LayerHandle bn_relu(createLayer(
+    "batch_normalization",
+    {nntrainer::withKey("name", "first_bn_relu"),
+     nntrainer::withKey("activation", "relu"),
+     nntrainer::withKey("momentum", "0.9"),
+     nntrainer::withKey("epsilon", "0.00001")}));
+  h = bn_relu(h);
 
-  layers.push_back(
-    createLayer("pooling2d", {nntrainer::withKey("name", "last_p1"),
-                              nntrainer::withKey("pooling", "average"),
-                              nntrainer::withKey("pool_size", {4, 4}),
-                              nntrainer::withKey("stride", "4,4")}));
+  LayerHandle pool(createLayer(
+    "pooling2d", {nntrainer::withKey("name", "last_p1"),
+                  nntrainer::withKey("pooling", "average"),
+                  nntrainer::withKey("pool_size", {4, 4}),
+                  nntrainer::withKey("stride", "4,4")}));
+  h = pool(h);
 
-  layers.push_back(
+  LayerHandle flatten(
     createLayer("flatten", {nntrainer::withKey("name", "last_f1")}));
-  layers.push_back(createLayer("fully_connected",
-                               {nntrainer::withKey("unit", 100),
-                                nntrainer::withKey("activation", "softmax")}));
+  h = flatten(h);
 
-  return layers;
-}
+  LayerHandle fc(createLayer("fully_connected",
+                             {nntrainer::withKey("unit", 100),
+                              nntrainer::withKey("activation", "softmax")}));
+  auto y = fc(h);
 
-ModelHandle createModel() {
-  ModelHandle model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "mse")});
-  for (auto &layer : createGraph()) {
-    model->addLayer(layer);
-  }
-  return model;
+  return {x, y};
 }
 
 int trainData_cb(float **input, float **label, bool *last, void *user_data) {
@@ -97,8 +96,11 @@ int validData_cb(float **input, float **label, bool *last, void *user_data) {
 void createAndRun(unsigned int epochs, unsigned int batch_size,
                   UserDataType &train_user_data,
                   UserDataType &valid_user_data) {
-  // setup model
-  ModelHandle model = createModel();
+  // build symbolic graph
+  auto [x, y] = buildGraph();
+
+  ModelHandle model = ml::train::createModel(
+    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "mse")});
   model->setProperty({nntrainer::withKey("batch_size", batch_size),
                       nntrainer::withKey("epochs", epochs),
                       nntrainer::withKey("save_path", "mixed_model.bin")});
@@ -114,14 +116,9 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
     throw std::invalid_argument("failed to set optimizer!");
   }
 
-  status = model->compile();
+  status = model->compile(x, y);
   if (status) {
     throw std::invalid_argument("model compilation failed!");
-  }
-
-  status = model->initialize();
-  if (status) {
-    throw std::invalid_argument("model initialization failed!");
   }
 
   auto dataset_train = ml::train::createDataset(

--- a/Applications/MixedPrecision/jni/main.cpp
+++ b/Applications/MixedPrecision/jni/main.cpp
@@ -52,19 +52,18 @@ std::pair<Tensor, Tensor> buildGraph() {
      nntrainer::withKey("weight_initializer", "xavier_uniform")}));
   auto h = conv0(x);
 
-  LayerHandle bn_relu(createLayer(
-    "batch_normalization",
-    {nntrainer::withKey("name", "first_bn_relu"),
-     nntrainer::withKey("activation", "relu"),
-     nntrainer::withKey("momentum", "0.9"),
-     nntrainer::withKey("epsilon", "0.00001")}));
+  LayerHandle bn_relu(createLayer("batch_normalization",
+                                  {nntrainer::withKey("name", "first_bn_relu"),
+                                   nntrainer::withKey("activation", "relu"),
+                                   nntrainer::withKey("momentum", "0.9"),
+                                   nntrainer::withKey("epsilon", "0.00001")}));
   h = bn_relu(h);
 
-  LayerHandle pool(createLayer(
-    "pooling2d", {nntrainer::withKey("name", "last_p1"),
-                  nntrainer::withKey("pooling", "average"),
-                  nntrainer::withKey("pool_size", {4, 4}),
-                  nntrainer::withKey("stride", "4,4")}));
+  LayerHandle pool(
+    createLayer("pooling2d", {nntrainer::withKey("name", "last_p1"),
+                              nntrainer::withKey("pooling", "average"),
+                              nntrainer::withKey("pool_size", {4, 4}),
+                              nntrainer::withKey("stride", "4,4")}));
   h = pool(h);
 
   LayerHandle flatten(

--- a/Applications/Multi_input/jni/main.cpp
+++ b/Applications/Multi_input/jni/main.cpp
@@ -18,51 +18,43 @@
 #include <sstream>
 #include <vector>
 
-#include <layer.h>
 #include <model.h>
 #include <optimizer.h>
+#include <tensor_api.h>
 #include <util_func.h>
 
 #include <multi_loader.h>
 
-using LayerHandle = std::shared_ptr<ml::train::Layer>;
+using ml::train::createLayer;
+using ml::train::LayerHandle;
+using ml::train::Tensor;
 using ModelHandle = std::unique_ptr<ml::train::Model>;
 using UserDataType = std::unique_ptr<nntrainer::util::DataLoader>;
 
-ModelHandle createMultiInputModel() {
-  using ml::train::createLayer;
-  ModelHandle model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "mse")});
-  std::vector<LayerHandle> layers;
+/**
+ * @brief Build multi-input model using symbolic tensor graph
+ * @return {vector of inputs, output}
+ */
+std::pair<std::vector<Tensor>, Tensor> buildMultiInputGraph() {
+  auto input0 = Tensor({1, 1, 2, 2}, "input0");
+  auto input1 = Tensor({1, 1, 4, 2}, "input1");
+  auto input2 = Tensor({1, 1, 8, 2}, "input2");
 
-  layers.push_back(
-    createLayer("input", {nntrainer::withKey("name", "input0"),
-                          nntrainer::withKey("input_shape", "1:2:2")}));
-  layers.push_back(
-    createLayer("input", {nntrainer::withKey("name", "input1"),
-                          nntrainer::withKey("input_shape", "1:4:2")}));
-  layers.push_back(
-    createLayer("input", {nntrainer::withKey("name", "input2"),
-                          nntrainer::withKey("input_shape", "1:8:2")}));
+  LayerHandle concat(createLayer(
+    "concat", {nntrainer::withKey("name", "concat0"),
+               nntrainer::withKey("axis", "2")}));
+  auto h = concat({input0, input1, input2});
 
-  layers.push_back(createLayer(
-    "concat",
-    {nntrainer::withKey("name", "concat0"), nntrainer::withKey("axis", "2"),
-     nntrainer::withKey("input_layers", "input0, input1, input2")}));
+  LayerHandle flatten(createLayer(
+    "flatten", {nntrainer::withKey("name", "flatten0")}));
+  h = flatten(h);
 
-  layers.push_back(
-    createLayer("flatten", {nntrainer::withKey("name", "flatten0"),
-                            nntrainer::withKey("input_layers", "concat0")}));
+  LayerHandle fc(createLayer("fully_connected",
+                             {nntrainer::withKey("unit", 5),
+                              nntrainer::withKey("activation", "softmax")}));
+  auto y = fc(h);
 
-  layers.push_back(createLayer("fully_connected",
-                               {nntrainer::withKey("unit", 5),
-                                nntrainer::withKey("activation", "softmax")}));
-
-  for (auto &layer : layers) {
-    model->addLayer(layer);
-  }
-
-  return model;
+  return {{input0, input1, input2}, y};
 }
 
 int trainData_cb(float **input, float **label, bool *last, void *user_data) {
@@ -74,7 +66,10 @@ int trainData_cb(float **input, float **label, bool *last, void *user_data) {
 void createAndRun(unsigned int epochs, unsigned int batch_size,
                   UserDataType &train_user_data) {
 
-  ModelHandle model = createMultiInputModel();
+  auto [inputs, output] = buildMultiInputGraph();
+
+  ModelHandle model = ml::train::createModel(
+    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "mse")});
 
   model->setProperty({nntrainer::withKey("batch_size", batch_size),
                       nntrainer::withKey("epochs", epochs),
@@ -86,14 +81,10 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
     throw std::invalid_argument("failed to set optimizer!");
   };
 
-  status = model->compile();
+  std::vector<Tensor> outputs = {output};
+  status = model->compile(inputs, outputs);
   if (status) {
     throw std::invalid_argument("model compilation failed!");
-  }
-
-  status = model->initialize();
-  if (status) {
-    throw std::invalid_argument("model initialization failed!");
   }
 
   auto dataset_train = ml::train::createDataset(

--- a/Applications/Multi_input/jni/main.cpp
+++ b/Applications/Multi_input/jni/main.cpp
@@ -40,13 +40,13 @@ std::pair<std::vector<Tensor>, Tensor> buildMultiInputGraph() {
   auto input1 = Tensor({1, 1, 4, 2}, "input1");
   auto input2 = Tensor({1, 1, 8, 2}, "input2");
 
-  LayerHandle concat(createLayer(
-    "concat", {nntrainer::withKey("name", "concat0"),
-               nntrainer::withKey("axis", "2")}));
+  LayerHandle concat(
+    createLayer("concat", {nntrainer::withKey("name", "concat0"),
+                           nntrainer::withKey("axis", "2")}));
   auto h = concat({input0, input1, input2});
 
-  LayerHandle flatten(createLayer(
-    "flatten", {nntrainer::withKey("name", "flatten0")}));
+  LayerHandle flatten(
+    createLayer("flatten", {nntrainer::withKey("name", "flatten0")}));
   h = flatten(h);
 
   LayerHandle fc(createLayer("fully_connected",

--- a/Applications/PicoGPT/jni/main.cpp
+++ b/Applications/PicoGPT/jni/main.cpp
@@ -68,12 +68,12 @@ std::shared_ptr<ml::train::Model> genModel() {
   Tensor wpe_in({1, 1, 1, 1}, "wpe_input");
 
   // Embedding layers
-  LayerHandle wte = createLayer("embedding",
-    {"name=wte", "in_dim=" + std::to_string(NUM_VOCAB),
-     "out_dim=" + std::to_string(MODEL_DIM)});
-  LayerHandle wpe = createLayer("embedding",
-    {"name=wpe", "in_dim=" + std::to_string(NUM_CTX),
-     "out_dim=" + std::to_string(MODEL_DIM)});
+  LayerHandle wte =
+    createLayer("embedding", {"name=wte", "in_dim=" + std::to_string(NUM_VOCAB),
+                              "out_dim=" + std::to_string(MODEL_DIM)});
+  LayerHandle wpe =
+    createLayer("embedding", {"name=wpe", "in_dim=" + std::to_string(NUM_CTX),
+                              "out_dim=" + std::to_string(MODEL_DIM)});
   auto wte_out = wte(wte_in);
   auto wpe_out = wpe(wpe_in);
 
@@ -85,8 +85,9 @@ std::shared_ptr<ml::train::Model> genModel() {
     std::string prefix = "layer" + std::to_string(i);
 
     // Layer Norm 1
-    LayerHandle ln1 = createLayer("layer_normalization",
-      {"name=" + prefix + "/ln1", "axis=3", "epsilon=1e-5"});
+    LayerHandle ln1 =
+      createLayer("layer_normalization",
+                  {"name=" + prefix + "/ln1", "axis=3", "epsilon=1e-5"});
     auto ln1_out = ln1(prev);
 
     Tensor attn_out;
@@ -96,24 +97,27 @@ std::shared_ptr<ml::train::Model> genModel() {
 
       for (unsigned int j = 0; j < NUM_HEADS; ++j) {
         unsigned int idx = NUM_HEADS - 1 - j;
-        std::string head_prefix =
-          prefix + "/multi_head_attention";
+        std::string head_prefix = prefix + "/multi_head_attention";
 
-        LayerHandle v_fc = createLayer("fully_connected",
-          {"name=" + head_prefix + "/v_fc" + std::to_string(idx),
-           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-        LayerHandle k_fc = createLayer("fully_connected",
-          {"name=" + head_prefix + "/k_fc" + std::to_string(idx),
-           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-        LayerHandle q_fc = createLayer("fully_connected",
-          {"name=" + head_prefix + "/q_fc" + std::to_string(idx),
-           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        LayerHandle v_fc =
+          createLayer("fully_connected",
+                      {"name=" + head_prefix + "/v_fc" + std::to_string(idx),
+                       "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        LayerHandle k_fc =
+          createLayer("fully_connected",
+                      {"name=" + head_prefix + "/k_fc" + std::to_string(idx),
+                       "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        LayerHandle q_fc =
+          createLayer("fully_connected",
+                      {"name=" + head_prefix + "/q_fc" + std::to_string(idx),
+                       "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
 
         auto v = v_fc(ln1_out);
         auto k = k_fc(ln1_out);
         auto q = q_fc(ln1_out);
 
-        LayerHandle attn = createLayer("attention",
+        LayerHandle attn = createLayer(
+          "attention",
           {"name=" + head_prefix + "/attention" + std::to_string(idx),
            "scaled_dot_product=true", "causal_mask=true"});
         attn_heads.push_back(attn({q, v, k}));
@@ -122,55 +126,57 @@ std::shared_ptr<ml::train::Model> genModel() {
       // Reverse so concat order is attention0, attention1, ..., attention11
       std::reverse(attn_heads.begin(), attn_heads.end());
 
-      LayerHandle concat = createLayer("concat",
+      LayerHandle concat = createLayer(
+        "concat",
         {"name=" + prefix + "/multi_head_attention/concat", "axis=3"});
       auto concat_out = concat(attn_heads);
 
-      LayerHandle attn_fc = createLayer("fully_connected",
-        {"name=" + prefix + "/multi_head_attention/fc",
-         "unit=" + std::to_string(MODEL_DIM)});
+      LayerHandle attn_fc = createLayer(
+        "fully_connected", {"name=" + prefix + "/multi_head_attention/fc",
+                            "unit=" + std::to_string(MODEL_DIM)});
       auto fc_out = attn_fc(concat_out);
 
-      LayerHandle identity = createLayer("identity",
-        {"name=" + prefix + "/multi_head_attention"});
+      LayerHandle identity =
+        createLayer("identity", {"name=" + prefix + "/multi_head_attention"});
       attn_out = identity(fc_out);
     } else {
       LayerHandle mha = createLayer("multi_head_attention",
-        {"name=" + prefix + "/multi_head_attention",
-         "num_heads=" + std::to_string(NUM_HEADS)});
+                                    {"name=" + prefix + "/multi_head_attention",
+                                     "num_heads=" + std::to_string(NUM_HEADS)});
       attn_out = mha({ln1_out, ln1_out, ln1_out});
     }
 
     // Skip connection 1: prev + attention output
-    LayerHandle add1 = createLayer("Addition",
-      {"name=" + prefix + "/add1"});
+    LayerHandle add1 = createLayer("Addition", {"name=" + prefix + "/add1"});
     auto add1_out = add1({prev, attn_out});
 
     // Layer Norm 2
-    LayerHandle ln2 = createLayer("layer_normalization",
-      {"name=" + prefix + "/ln2", "axis=3", "epsilon=1e-5"});
+    LayerHandle ln2 =
+      createLayer("layer_normalization",
+                  {"name=" + prefix + "/ln2", "axis=3", "epsilon=1e-5"});
     auto ln2_out = ln2(add1_out);
 
     // FFN
-    LayerHandle fc1 = createLayer("fully_connected",
-      {"name=" + prefix + "/fc1",
-       "unit=" + std::to_string(FC_UNIT), "activation=gelu"});
+    LayerHandle fc1 =
+      createLayer("fully_connected",
+                  {"name=" + prefix + "/fc1", "unit=" + std::to_string(FC_UNIT),
+                   "activation=gelu"});
     auto fc1_out = fc1(ln2_out);
 
-    LayerHandle fc2 = createLayer("fully_connected",
-      {"name=" + prefix + "/fc2",
-       "unit=" + std::to_string(MODEL_DIM)});
+    LayerHandle fc2 =
+      createLayer("fully_connected", {"name=" + prefix + "/fc2",
+                                      "unit=" + std::to_string(MODEL_DIM)});
     auto fc2_out = fc2(fc1_out);
 
     // Skip connection 2: add1_out + fc2_out
-    LayerHandle add2 = createLayer("Addition",
-      {"name=" + prefix + "/add2"});
+    LayerHandle add2 = createLayer("Addition", {"name=" + prefix + "/add2"});
     prev = add2({add1_out, fc2_out});
   }
 
   // Final Layer Norm
-  LayerHandle final_ln = createLayer("layer_normalization",
-    {"name=layer_normalization", "axis=3", "epsilon=1e-5"});
+  LayerHandle final_ln =
+    createLayer("layer_normalization",
+                {"name=layer_normalization", "axis=3", "epsilon=1e-5"});
   auto output = final_ln(prev);
 
   int status = model->setOptimizer(
@@ -243,26 +249,26 @@ int main(int argc, char *argv[]) {
     model->getLayer("wte", &wte_embedding_layer);
     const std::vector<float *> wte_weights_buf =
       wte_embedding_layer->getWeights();
-    auto wte_weight = ml::train::Tensor::fromData(
-      {NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
+    auto wte_weight =
+      ml::train::Tensor::fromData({NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
 
     for (unsigned int i = 1; i < init_input_seq_len + NUM_TOKENS_TO_GENERATE;
          ++i) {
       output_bufs = model->incremental_inference(
         BATCH_SIZE, {wte_input, wpe_input}, {}, init_input_seq_len, i - 1, i);
 
-      auto output = ml::train::Tensor::fromData(
-        {BATCH_SIZE, 1, i, MODEL_DIM}, output_bufs[0]);
+      auto output = ml::train::Tensor::fromData({BATCH_SIZE, 1, i, MODEL_DIM},
+                                                output_bufs[0]);
 
       std::shared_ptr<ml::train::Layer> wte_embedding_layer;
       model->getLayer("wte", &wte_embedding_layer);
       const std::vector<float *> wte_weights_buf =
         wte_embedding_layer->getWeights();
-      auto wte_weight = ml::train::Tensor::fromData(
-        {NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
+      auto wte_weight =
+        ml::train::Tensor::fromData({NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
       auto logits = output.dot(wte_weight, false, true);
-      auto next = logits.getSharedDataTensor(
-        {1, NUM_VOCAB}, BATCH_SIZE * (i - 1) * NUM_VOCAB);
+      auto next = logits.getSharedDataTensor({1, NUM_VOCAB},
+                                             BATCH_SIZE * (i - 1) * NUM_VOCAB);
 
       std::vector<unsigned int> ids = next.argmax();
 

--- a/Applications/PicoGPT/jni/main.cpp
+++ b/Applications/PicoGPT/jni/main.cpp
@@ -11,11 +11,12 @@
  * @bug    No known bugs except for NYI items
  */
 
+#include <algorithm>
 #include <app_context.h>
 #include <fstream>
 #include <model.h>
 #include <string.h>
-#include <tensor.h>
+#include <tensor_api.h>
 
 #if defined(ENABLE_TRANSFORMER)
 #include "encoder.hpp"
@@ -55,224 +56,134 @@ T unwrap(std::optional<T> &&value, const std::string &error_msg) {
 #endif
 
 std::shared_ptr<ml::train::Model> genModel() {
-  std::shared_ptr<ml::train::Model> model;
-  model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+  using namespace ml::train;
+
+  auto model = createModel(ModelType::NEURAL_NET);
   model->setProperty({"batch_size=" + std::to_string(BATCH_SIZE),
                       "model_tensor_type=FP16-FP16",
                       fsu ? "fsu=true" : "fsu=false"});
 
-  std::shared_ptr<ml::train::Layer> wte_input =
-    ml::train::layer::Input({"name=wte_input", "input_shape=1:1:1"});
-  model->addLayer(wte_input);
+  // Symbolic input tensors
+  Tensor wte_in({1, 1, 1, 1}, "wte_input");
+  Tensor wpe_in({1, 1, 1, 1}, "wpe_input");
 
-  std::shared_ptr<ml::train::Layer> wte = ml::train::layer::Embedding(
+  // Embedding layers
+  LayerHandle wte = createLayer("embedding",
     {"name=wte", "in_dim=" + std::to_string(NUM_VOCAB),
      "out_dim=" + std::to_string(MODEL_DIM)});
-  model->addLayer(wte);
-
-  std::shared_ptr<ml::train::Layer> wpe_input =
-    ml::train::layer::Input({"name=wpe_input", "input_shape=1:1:1"});
-  model->addLayer(wpe_input);
-
-  std::shared_ptr<ml::train::Layer> wpe = ml::train::layer::Embedding(
+  LayerHandle wpe = createLayer("embedding",
     {"name=wpe", "in_dim=" + std::to_string(NUM_CTX),
      "out_dim=" + std::to_string(MODEL_DIM)});
-  model->addLayer(wpe);
+  auto wte_out = wte(wte_in);
+  auto wpe_out = wpe(wpe_in);
 
-  std::shared_ptr<ml::train::Layer> add =
-    ml::train::layer::Addition({"name=add", "input_layers=wte, wpe"});
-  model->addLayer(add);
+  // Add embeddings
+  LayerHandle add_emb = createLayer("Addition", {"name=add"});
+  auto prev = add_emb({wte_out, wpe_out});
 
   for (unsigned int i = 0; i < NUM_LAYERS; ++i) {
-    std::shared_ptr<ml::train::Layer> ln_multiout1 = ml::train::layer::MultiOut(
-      {"name=layer" + std::to_string(i) + "/ln_multiout1"});
-    model->addLayer(ln_multiout1);
+    std::string prefix = "layer" + std::to_string(i);
 
-    std::shared_ptr<ml::train::Layer> ln1 =
-      ml::train::layer::LayerNormalization(
-        {"name=layer" + std::to_string(i) + "/ln1", "axis=3", "epsilon=1e-5"});
-    model->addLayer(ln1);
+    // Layer Norm 1
+    LayerHandle ln1 = createLayer("layer_normalization",
+      {"name=" + prefix + "/ln1", "axis=3", "epsilon=1e-5"});
+    auto ln1_out = ln1(prev);
 
-    std::shared_ptr<ml::train::Layer> multiout1 = ml::train::layer::MultiOut(
-      {"name=layer" + std::to_string(i) + "/multi_out1"});
-    model->addLayer(multiout1);
-
+    Tensor attn_out;
     if (optimize) {
-      std::string concat_input = "";
+      // Per-head attention with separate Q/K/V projections
+      std::vector<Tensor> attn_heads;
 
       for (unsigned int j = 0; j < NUM_HEADS; ++j) {
-        std::shared_ptr<ml::train::Layer> multi_head_attention_v_fc =
-          ml::train::layer::FullyConnected(
-            {"name=layer" + std::to_string(i) + "/multi_head_attention/v_fc" +
-               std::to_string(NUM_HEADS - 1 - j),
-             "input_layers=layer" + std::to_string(i) + "/multi_out1(" +
-               std::to_string(2 * NUM_HEADS + j) + ")",
-             "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-        model->addLayer(multi_head_attention_v_fc);
+        unsigned int idx = NUM_HEADS - 1 - j;
+        std::string head_prefix =
+          prefix + "/multi_head_attention";
+
+        LayerHandle v_fc = createLayer("fully_connected",
+          {"name=" + head_prefix + "/v_fc" + std::to_string(idx),
+           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        LayerHandle k_fc = createLayer("fully_connected",
+          {"name=" + head_prefix + "/k_fc" + std::to_string(idx),
+           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+        LayerHandle q_fc = createLayer("fully_connected",
+          {"name=" + head_prefix + "/q_fc" + std::to_string(idx),
+           "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
+
+        auto v = v_fc(ln1_out);
+        auto k = k_fc(ln1_out);
+        auto q = q_fc(ln1_out);
+
+        LayerHandle attn = createLayer("attention",
+          {"name=" + head_prefix + "/attention" + std::to_string(idx),
+           "scaled_dot_product=true", "causal_mask=true"});
+        attn_heads.push_back(attn({q, v, k}));
       }
 
-      for (unsigned int j = 0; j < NUM_HEADS; ++j) {
-        std::shared_ptr<ml::train::Layer> multi_head_attention_k_fc =
-          ml::train::layer::FullyConnected(
-            {"name=layer" + std::to_string(i) + "/multi_head_attention/k_fc" +
-               std::to_string(NUM_HEADS - 1 - j),
-             "input_layers=layer" + std::to_string(i) + "/multi_out1(" +
-               std::to_string(NUM_HEADS + j) + ")",
-             "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-        model->addLayer(multi_head_attention_k_fc);
-      }
+      // Reverse so concat order is attention0, attention1, ..., attention11
+      std::reverse(attn_heads.begin(), attn_heads.end());
 
-      for (unsigned int j = 0; j < NUM_HEADS; ++j) {
-        std::shared_ptr<ml::train::Layer> multi_head_attention_q_fc =
-          ml::train::layer::FullyConnected(
-            {"name=layer" + std::to_string(i) + "/multi_head_attention/q_fc" +
-               std::to_string(NUM_HEADS - 1 - j),
-             "input_layers=layer" + std::to_string(i) + "/multi_out1(" +
-               std::to_string(j) + ")",
-             "unit=" + std::to_string(MODEL_DIM / NUM_HEADS)});
-        model->addLayer(multi_head_attention_q_fc);
-      }
+      LayerHandle concat = createLayer("concat",
+        {"name=" + prefix + "/multi_head_attention/concat", "axis=3"});
+      auto concat_out = concat(attn_heads);
 
-      for (unsigned int j = 0; j < NUM_HEADS; ++j) {
-        if (optimize_attention) {
-          //   std::shared_ptr<ml::train::Layer> multi_head_attention_bwdp1 =
-          //     ml::train::layer::BatchwiseDotproduct(
-          //       {"name=layer" + std::to_string(i) +
-          //          "/multi_head_attention/bwdp1" +
-          //          std::to_string(NUM_HEADS - 1 - j),
-          //        "input_layers=layer" + std::to_string(i) +
-          //          "/multi_head_attention/q_fc" +
-          //          std::to_string(NUM_HEADS - 1 - j) + ",layer" +
-          //          std::to_string(i) + "/multi_head_attention/k_fc" +
-          //          std::to_string(NUM_HEADS - 1 - j),
-          //        "transpose_key=true", "scaled_dot_product=true",
-          //        "activation=softmax"});
-          //   model->addLayer(multi_head_attention_bwdp1);
+      LayerHandle attn_fc = createLayer("fully_connected",
+        {"name=" + prefix + "/multi_head_attention/fc",
+         "unit=" + std::to_string(MODEL_DIM)});
+      auto fc_out = attn_fc(concat_out);
 
-          //   std::shared_ptr<ml::train::Layer> multi_head_attention_bwdp2 =
-          //     ml::train::layer::BatchwiseDotproduct(
-          //       {"name=layer" + std::to_string(i) +
-          //          "/multi_head_attention/bwdp2" +
-          //          std::to_string(NUM_HEADS - 1 - j),
-          //        "input_layers=layer" + std::to_string(i) +
-          //          "/multi_head_attention/bwdp1" +
-          //          std::to_string(NUM_HEADS - 1 - j) + ",layer" +
-          //          std::to_string(i) + "/multi_head_attention/v_fc" +
-          //          std::to_string(NUM_HEADS - 1 - j)});
-          //   model->addLayer(multi_head_attention_bwdp2);
-
-          //   std::shared_ptr<ml::train::Layer>
-          //     multi_head_attention_attention = ml::train::layer::Identity(
-          //       {"name=layer" + std::to_string(i) +
-          //          "/multi_head_attention/attention" +
-          //          std::to_string(NUM_HEADS - 1 - j),
-          //        "input_layers=layer" + std::to_string(i) +
-          //          "/multi_head_attention/bwdp2" +
-          //          std::to_string(NUM_HEADS - 1 - j)});
-          //   model->addLayer(multi_head_attention_attention);
-        } else {
-          std::shared_ptr<ml::train::Layer> multi_head_attention_attention =
-            ml::train::layer::Attention(
-              {"name=layer" + std::to_string(i) +
-                 "/multi_head_attention/attention" +
-                 std::to_string(NUM_HEADS - 1 - j),
-               "input_layers=layer" + std::to_string(i) +
-                 "/multi_head_attention/q_fc" +
-                 std::to_string(NUM_HEADS - 1 - j) + ",layer" +
-                 std::to_string(i) + "/multi_head_attention/v_fc" +
-                 std::to_string(NUM_HEADS - 1 - j) + ",layer" +
-                 std::to_string(i) + "/multi_head_attention/k_fc" +
-                 std::to_string(NUM_HEADS - 1 - j),
-               "scaled_dot_product=true", "causal_mask=true"});
-          model->addLayer(multi_head_attention_attention);
-        }
-
-        concat_input += "layer" + std::to_string(i) +
-                        "/multi_head_attention/attention" + std::to_string(j);
-        if (j != NUM_HEADS - 1) {
-          concat_input += ",";
-        }
-      }
-
-      std::shared_ptr<ml::train::Layer> multi_head_attention_concat =
-        ml::train::layer::Concat(
-          {"name=layer" + std::to_string(i) + "/multi_head_attention/concat",
-           "input_layers=" + concat_input, "axis=3"});
-      model->addLayer(multi_head_attention_concat);
-
-      std::shared_ptr<ml::train::Layer> multi_head_attention_fc =
-        ml::train::layer::FullyConnected(
-          {"name=layer" + std::to_string(i) + "/multi_head_attention/fc",
-           "input_layers=layer" + std::to_string(i) +
-             "/multi_head_attention/concat",
-           "unit=" + std::to_string(MODEL_DIM)});
-      model->addLayer(multi_head_attention_fc);
-
-      std::shared_ptr<ml::train::Layer> multi_head_attention =
-        ml::train::layer::Identity(
-          {"name=layer" + std::to_string(i) + "/multi_head_attention",
-           "input_layers=layer" + std::to_string(i) +
-             "/multi_head_attention/fc"});
-      model->addLayer(multi_head_attention);
+      LayerHandle identity = createLayer("identity",
+        {"name=" + prefix + "/multi_head_attention"});
+      attn_out = identity(fc_out);
     } else {
-      std::shared_ptr<ml::train::Layer> masked_multi_head_attention =
-        ml::train::layer::MultiHeadAttention(
-          {"name=layer" + std::to_string(i) + "/multi_head_attention",
-           "input_layers=layer" + std::to_string(i) + "/multi_out1(0), layer" +
-             std::to_string(i) + "/multi_out1(1), layer" + std::to_string(i) +
-             "/multi_out1(2)",
-           "num_heads=" + std::to_string(NUM_HEADS)});
-      model->addLayer(masked_multi_head_attention);
+      LayerHandle mha = createLayer("multi_head_attention",
+        {"name=" + prefix + "/multi_head_attention",
+         "num_heads=" + std::to_string(NUM_HEADS)});
+      attn_out = mha({ln1_out, ln1_out, ln1_out});
     }
 
-    std::shared_ptr<ml::train::Layer> add1 = ml::train::layer::Addition(
-      {"name=layer" + std::to_string(i) + "/add1",
-       "input_layers=layer" + std::to_string(i) + "/ln_multiout1(1), layer" +
-         std::to_string(i) + "/multi_head_attention"});
-    model->addLayer(add1);
+    // Skip connection 1: prev + attention output
+    LayerHandle add1 = createLayer("Addition",
+      {"name=" + prefix + "/add1"});
+    auto add1_out = add1({prev, attn_out});
 
-    std::shared_ptr<ml::train::Layer> ln_multiout2 = ml::train::layer::MultiOut(
-      {"name=layer" + std::to_string(i) + "/ln_multiout2"});
-    model->addLayer(ln_multiout2);
+    // Layer Norm 2
+    LayerHandle ln2 = createLayer("layer_normalization",
+      {"name=" + prefix + "/ln2", "axis=3", "epsilon=1e-5"});
+    auto ln2_out = ln2(add1_out);
 
-    std::shared_ptr<ml::train::Layer> ln2 =
-      ml::train::layer::LayerNormalization(
-        {"name=layer" + std::to_string(i) + "/ln2", "axis=3", "epsilon=1e-5"});
-    model->addLayer(ln2);
-
-    std::shared_ptr<ml::train::Layer> multiout3 = ml::train::layer::MultiOut(
-      {"name=layer" + std::to_string(i) + "/multi_out3"});
-    model->addLayer(multiout3);
-
-    std::shared_ptr<ml::train::Layer> fc1 = ml::train::layer::FullyConnected(
-      {"name=layer" + std::to_string(i) + "/fc1",
-       "input_layers=layer" + std::to_string(i) + "/multi_out3(0)",
+    // FFN
+    LayerHandle fc1 = createLayer("fully_connected",
+      {"name=" + prefix + "/fc1",
        "unit=" + std::to_string(FC_UNIT), "activation=gelu"});
-    model->addLayer(fc1);
+    auto fc1_out = fc1(ln2_out);
 
-    std::shared_ptr<ml::train::Layer> fc2 = ml::train::layer::FullyConnected(
-      {"name=layer" + std::to_string(i) + "/fc2",
+    LayerHandle fc2 = createLayer("fully_connected",
+      {"name=" + prefix + "/fc2",
        "unit=" + std::to_string(MODEL_DIM)});
-    model->addLayer(fc2);
+    auto fc2_out = fc2(fc1_out);
 
-    std::shared_ptr<ml::train::Layer> add2 = ml::train::layer::Addition(
-      {"name=layer" + std::to_string(i) + "/add2",
-       "input_layers=layer" + std::to_string(i) + "/ln_multiout2(1), layer" +
-         std::to_string(i) + "/fc2"});
-    model->addLayer(add2);
+    // Skip connection 2: add1_out + fc2_out
+    LayerHandle add2 = createLayer("Addition",
+      {"name=" + prefix + "/add2"});
+    prev = add2({add1_out, fc2_out});
   }
 
-  std::shared_ptr<ml::train::Layer> layer_normalization =
-    ml::train::layer::LayerNormalization(
-      {"name=layer_normalization", "axis=3", "epsilon=1e-5"});
-  model->addLayer(layer_normalization);
+  // Final Layer Norm
+  LayerHandle final_ln = createLayer("layer_normalization",
+    {"name=layer_normalization", "axis=3", "epsilon=1e-5"});
+  auto output = final_ln(prev);
 
   int status = model->setOptimizer(
     ml::train::createOptimizer("sgd", {"learning_rate = 0.1"}));
   if (status) {
     throw std::invalid_argument("failed to set optimizer!");
   }
-  model->setProperty({"input_layers=wte_input, wpe_input"});
+
+  // Graph-based compile (handles compile + initialize + allocate)
+  status = model->compile(wte_in, output);
+  if (status) {
+    throw std::invalid_argument("failed to compile model from graph!");
+  }
 
   return model;
 }
@@ -289,19 +200,6 @@ int main(int argc, char *argv[]) {
 
     auto model = genModel();
     model->summarize(std::cout, ML_TRAIN_SUMMARY_MODEL);
-    try {
-      model->compile();
-    } catch (const std::exception &e) {
-      std::cerr << "Error during compile: " << e.what() << "\n";
-      return 1;
-    }
-
-    try {
-      model->initialize();
-    } catch (const std::exception &e) {
-      std::cerr << "Error during initialize: " << e.what() << "\n";
-      return 1;
-    }
 
     std::string weight_file_name =
       optimize ? "./res/app/PicoGPT/pico_gpt_124.bin"
@@ -345,24 +243,25 @@ int main(int argc, char *argv[]) {
     model->getLayer("wte", &wte_embedding_layer);
     const std::vector<float *> wte_weights_buf =
       wte_embedding_layer->getWeights();
-    nntrainer::Tensor wte_weight =
-      nntrainer::Tensor({NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
+    auto wte_weight = ml::train::Tensor::fromData(
+      {NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
 
     for (unsigned int i = 1; i < init_input_seq_len + NUM_TOKENS_TO_GENERATE;
          ++i) {
       output_bufs = model->incremental_inference(
         BATCH_SIZE, {wte_input, wpe_input}, {}, init_input_seq_len, i - 1, i);
 
-      nntrainer::Tensor output({BATCH_SIZE, 1, i, MODEL_DIM}, output_bufs[0]);
+      auto output = ml::train::Tensor::fromData(
+        {BATCH_SIZE, 1, i, MODEL_DIM}, output_bufs[0]);
 
       std::shared_ptr<ml::train::Layer> wte_embedding_layer;
       model->getLayer("wte", &wte_embedding_layer);
       const std::vector<float *> wte_weights_buf =
         wte_embedding_layer->getWeights();
-      nntrainer::Tensor wte_weight =
-        nntrainer::Tensor({NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
-      nntrainer::Tensor logits = output.dot(wte_weight, false, true);
-      nntrainer::Tensor next = logits.getSharedDataTensor(
+      auto wte_weight = ml::train::Tensor::fromData(
+        {NUM_VOCAB, MODEL_DIM}, wte_weights_buf[0]);
+      auto logits = output.dot(wte_weight, false, true);
+      auto next = logits.getSharedDataTensor(
         {1, NUM_VOCAB}, BATCH_SIZE * (i - 1) * NUM_VOCAB);
 
       std::vector<unsigned int> ids = next.argmax();

--- a/Applications/ProductRatings/jni/main.cpp
+++ b/Applications/ProductRatings/jni/main.cpp
@@ -9,10 +9,11 @@
  * @bug    No known bugs except for NYI items
  * @brief  Product ratings recommendation system using the ccapi Tensor API.
  *
- *         Training set (embedding_input.txt): 3 columns (user_id product_id rating)
- *         Model: split → dual embedding → concat → FC(128) → FC(32) → FC(1)
+ *         Training set (embedding_input.txt): 3 columns (user_id product_id
+ * rating) Model: split → dual embedding → concat → FC(128) → FC(32) → FC(1)
  */
 
+#include <algorithm>
 #include <cmath>
 #include <fstream>
 #include <iostream>
@@ -20,14 +21,14 @@
 #include <random>
 #include <sstream>
 
-#include <model.h>
 #include <dataset.h>
+#include <model.h>
 #include <optimizer.h>
 #include <tensor_api.h>
 
+using ml::train::createDataset;
 using ml::train::createLayer;
 using ml::train::createModel;
-using ml::train::createDataset;
 using ml::train::createOptimizer;
 using ml::train::LayerHandle;
 using ml::train::Tensor;
@@ -122,13 +123,13 @@ static std::pair<Tensor, Tensor> buildGraph() {
   auto product_id = split_out.output(1);
 
   // user embedding: vocab=6, dim=5
-  LayerHandle user_embed(createLayer(
-    "embedding", {"name=user_embed", "in_dim=6", "out_dim=5"}));
+  LayerHandle user_embed(
+    createLayer("embedding", {"name=user_embed", "in_dim=6", "out_dim=5"}));
   auto user_emb = user_embed(user_id);
 
   // product embedding: vocab=6, dim=5
-  LayerHandle product_embed(createLayer(
-    "embedding", {"name=product_embed", "in_dim=6", "out_dim=5"}));
+  LayerHandle product_embed(
+    createLayer("embedding", {"name=product_embed", "in_dim=6", "out_dim=5"}));
   auto prod_emb = product_embed(product_id);
 
   // concat user + product embeddings
@@ -140,19 +141,19 @@ static std::pair<Tensor, Tensor> buildGraph() {
   h = flatten(h);
 
   // fc1: 128 units, relu
-  LayerHandle fc1(createLayer(
-    "fully_connected", {"name=fc1", "unit=128", "activation=relu"}));
+  LayerHandle fc1(createLayer("fully_connected",
+                              {"name=fc1", "unit=128", "activation=relu"}));
   h = fc1(h);
 
   // fc2: 32 units, relu
-  LayerHandle fc2(createLayer(
-    "fully_connected", {"name=fc2", "unit=32", "activation=relu"}));
+  LayerHandle fc2(
+    createLayer("fully_connected", {"name=fc2", "unit=32", "activation=relu"}));
   h = fc2(h);
 
   // output: 1 unit
-  LayerHandle output_fc(createLayer(
-    "fully_connected",
-    {"name=outputlayer", "unit=1", "bias_initializer=zeros"}));
+  LayerHandle output_fc(
+    createLayer("fully_connected",
+                {"name=outputlayer", "unit=1", "bias_initializer=zeros"}));
   auto y = output_fc(h);
 
   return {x, y};
@@ -169,8 +170,7 @@ static std::pair<Tensor, Tensor> buildGraph() {
  */
 int main(int argc, char *argv[]) {
   if (argc < 3) {
-    std::cout
-      << "./nntrainer_product_ratings train (| inference) data.txt\n";
+    std::cout << "./nntrainer_product_ratings train (| inference) data.txt\n";
     exit(1);
   }
 
@@ -192,9 +192,9 @@ int main(int argc, char *argv[]) {
     auto model = createModel(ml::train::ModelType::NEURAL_NET,
                              {"epochs=100", "loss=mse", "batch_size=20"});
 
-    auto optimizer = createOptimizer(
-      "adam", {"learning_rate=0.001", "beta1=0.9", "beta2=0.999",
-               "epsilon=1e-7"});
+    auto optimizer =
+      createOptimizer("adam", {"learning_rate=0.001", "beta1=0.9",
+                               "beta2=0.999", "epsilon=1e-7"});
     model->setOptimizer(std::move(optimizer));
 
     auto status = model->compile(x, y, ml::train::ExecutionMode::TRAIN);
@@ -235,8 +235,7 @@ int main(int argc, char *argv[]) {
           }
         }
 
-        auto fc_golden =
-          ml::train::Tensor::zeros({1, 1, 32, 1}, "fc_golden");
+        auto fc_golden = ml::train::Tensor::zeros({1, 1, 32, 1}, "fc_golden");
         {
           std::ifstream file("fc_weight_golden.out");
           if (file.good()) {
@@ -246,10 +245,10 @@ int main(int argc, char *argv[]) {
           }
         }
 
-        std::cout << "Embedding golden weights loaded ("
-                  << embed_golden.size() << " elements)\n";
-        std::cout << "FC golden weights loaded ("
-                  << fc_golden.size() << " elements)\n";
+        std::cout << "Embedding golden weights loaded (" << embed_golden.size()
+                  << " elements)\n";
+        std::cout << "FC golden weights loaded (" << fc_golden.size()
+                  << " elements)\n";
       } catch (...) {
         std::cerr << "Warning: during loading golden data\n";
       }
@@ -264,16 +263,15 @@ int main(int argc, char *argv[]) {
         getData(dataFile, o.data(), l.data(), j);
 
         // Wrap input data as ml::train::Tensor for inference
-        auto input_tensor =
-          ml::train::Tensor::fromData({1, 1, 1, feature_size}, o.data(),
-                                      "inference_input");
+        auto input_tensor = ml::train::Tensor::fromData(
+          {1, 1, 1, feature_size}, o.data(), "inference_input");
 
-        auto results = model->inference(
-          1, {input_tensor.mutable_data<float>()}, {});
+        auto results =
+          model->inference(1, {input_tensor.mutable_data<float>()}, {});
 
         // Wrap output and apply step function
         auto output = ml::train::Tensor::fromData({1, 1, 1, 1}, results[0],
-                                                   "inference_output");
+                                                  "inference_output");
         float answer = stepFunction(output.getValue(0, 0, 0, 0));
 
         std::cout << answer << " : " << l[0] << std::endl;

--- a/Applications/ProductRatings/jni/main.cpp
+++ b/Applications/ProductRatings/jni/main.cpp
@@ -7,11 +7,10 @@
  * @see    https://github.com/nntrainer/nntrainer
  * @author Jijoong Moon <jijoong.moon@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  This is a simple recommendation system Example
+ * @brief  Product ratings recommendation system using the ccapi Tensor API.
  *
- *              Trainig set (embedding_input.txt) : 4 colume data + result (1.0
- * or 0.0) Configuration file : ../../res/Embedding.ini
- *
+ *         Training set (embedding_input.txt): 3 columns (user_id product_id rating)
+ *         Model: split → dual embedding → concat → FC(128) → FC(32) → FC(1)
  */
 
 #include <cmath>
@@ -21,9 +20,17 @@
 #include <random>
 #include <sstream>
 
+#include <model.h>
 #include <dataset.h>
-#include <neuralnet.h>
-#include <tensor.h>
+#include <optimizer.h>
+#include <tensor_api.h>
+
+using ml::train::createLayer;
+using ml::train::createModel;
+using ml::train::createDataset;
+using ml::train::createOptimizer;
+using ml::train::LayerHandle;
+using ml::train::Tensor;
 
 std::string data_file;
 
@@ -41,31 +48,14 @@ const unsigned int total_val_data_size = 25;
 
 bool training = false;
 
-/**
- * @brief     step function
- * @param[in] x value to be distinguished
- * @retval 0.0 or 1.0
- */
 float stepFunction(float x) {
-  if (x > 0.5) {
+  if (x > 0.5)
     return 1.0;
-  }
-
-  if (x < 0.5) {
+  if (x < 0.5)
     return 0.0;
-  }
-
   return x;
 }
 
-/**
- * @brief     get idth Data
- * @param[in] F file stream
- * @param[out] input feature data
- * @param[out] label label data
- * @param[in] id id th
- * @retval boolean true if there is no error
- */
 bool getData(std::ifstream &F, float *input, float *label, unsigned int id) {
   std::string temp;
   F.clear();
@@ -94,26 +84,9 @@ bool getData(std::ifstream &F, float *input, float *label, unsigned int id) {
   return true;
 }
 
-template <typename T> void loadFile(const char *filename, T &t) {
-  std::ifstream file(filename);
-  if (!file.good()) {
-    throw std::runtime_error("could not read, check filename");
-  }
-  t.read(file);
-  file.close();
-}
-
 std::mt19937 rng;
 std::vector<unsigned int> train_idxes;
 
-/**
- * @brief     get a single data
- * @param[out] outVec feature data
- * @param[out] outLabel label data
- * @param[out] last end of data
- * @param[in] user_data user data
- * @retval int 0 if there is no error
- */
 int getSample_train(float **outVec, float **outLabel, bool *last,
                     void *user_data) {
   std::ifstream dataFile(data_file);
@@ -128,31 +101,83 @@ int getSample_train(float **outVec, float **outLabel, bool *last,
     train_count = 0;
     std::shuffle(train_idxes.begin(), train_idxes.end(), rng);
   }
-
   return 0;
+}
+
+/**
+ * @brief Build the model using symbolic tensor graph.
+ *
+ * Topology:
+ *   input → split → [user_embed, product_embed] → concat →
+ *   flatten → fc1(128,relu) → fc2(32,relu) → output(1)
+ */
+static std::pair<Tensor, Tensor> buildGraph() {
+  auto x = Tensor({1, 1, 1, 2}, "input");
+
+  // split along width axis into two scalars
+  LayerHandle split(createLayer("split", {"name=split", "axis=3"}));
+  auto split_out = split(x);
+
+  auto user_id = split_out.output(0);
+  auto product_id = split_out.output(1);
+
+  // user embedding: vocab=6, dim=5
+  LayerHandle user_embed(createLayer(
+    "embedding", {"name=user_embed", "in_dim=6", "out_dim=5"}));
+  auto user_emb = user_embed(user_id);
+
+  // product embedding: vocab=6, dim=5
+  LayerHandle product_embed(createLayer(
+    "embedding", {"name=product_embed", "in_dim=6", "out_dim=5"}));
+  auto prod_emb = product_embed(product_id);
+
+  // concat user + product embeddings
+  LayerHandle concat(createLayer("concat", {"name=concat"}));
+  auto h = concat({user_emb, prod_emb});
+
+  // flatten
+  LayerHandle flatten(createLayer("flatten", {"name=flatten"}));
+  h = flatten(h);
+
+  // fc1: 128 units, relu
+  LayerHandle fc1(createLayer(
+    "fully_connected", {"name=fc1", "unit=128", "activation=relu"}));
+  h = fc1(h);
+
+  // fc2: 32 units, relu
+  LayerHandle fc2(createLayer(
+    "fully_connected", {"name=fc2", "unit=32", "activation=relu"}));
+  h = fc2(h);
+
+  // output: 1 unit
+  LayerHandle output_fc(createLayer(
+    "fully_connected",
+    {"name=outputlayer", "unit=1", "bias_initializer=zeros"}));
+  auto y = output_fc(h);
+
+  return {x, y};
 }
 
 /**
  * @brief     create NN
  *            back propagation of NN
  * @param[in]  arg 1 : train / inference
- * @param[in]  arg 2 : configuration file path
- * @param[in]  arg 3 : resource path (data) with below format
+ * @param[in]  arg 2 : resource path (data) with below format
  * (int) (int) (float) #first data
  * ...
  * in each row represents user id, product id, rating (0 to 10)
  */
 int main(int argc, char *argv[]) {
-  if (argc < 4) {
-    std::cout << "./Embedding train (| inference) Config.ini data.txt\n";
+  if (argc < 3) {
+    std::cout
+      << "./nntrainer_product_ratings train (| inference) data.txt\n";
     exit(1);
   }
 
   std::string weight_path = "product_ratings_model.bin";
   try {
     const std::vector<std::string> args(argv + 1, argv + argc);
-    std::string config = args[1];
-    data_file = args[2];
+    data_file = args[1];
 
     if (!args[0].compare("train"))
       training = true;
@@ -161,121 +186,108 @@ int main(int argc, char *argv[]) {
     std::iota(train_idxes.begin(), train_idxes.end(), 0);
     rng.seed(SEED);
 
-    std::shared_ptr<ml::train::Dataset> dataset_train, dataset_val;
-    try {
-      dataset_train =
-        createDataset(ml::train::DatasetType::GENERATOR, getSample_train);
-      dataset_val =
-        createDataset(ml::train::DatasetType::GENERATOR, getSample_train);
-    } catch (std::exception &e) {
-      std::cerr << "Error creating dataset " << e.what() << std::endl;
+    // Build symbolic graph
+    auto [x, y] = buildGraph();
+
+    auto model = createModel(ml::train::ModelType::NEURAL_NET,
+                             {"epochs=100", "loss=mse", "batch_size=20"});
+
+    auto optimizer = createOptimizer(
+      "adam", {"learning_rate=0.001", "beta1=0.9", "beta2=0.999",
+               "epsilon=1e-7"});
+    model->setOptimizer(std::move(optimizer));
+
+    auto status = model->compile(x, y, ml::train::ExecutionMode::TRAIN);
+    if (status != 0) {
+      std::cerr << "Error during compile" << std::endl;
       return 1;
     }
 
-    /**
-     * @brief     Create NN
-     */
-    nntrainer::NeuralNetwork NN;
-    /**
-     * @brief     Initialize NN with configuration file path
-     */
-
-    try {
-      auto status = NN.loadFromConfig(config);
-      if (status != 0) {
-        std::cerr << "Error during loading" << std::endl;
-        return 1;
-      }
-
-      status = NN.compile();
-      if (status != 0) {
-        std::cerr << "Error during compile" << std::endl;
-        return 1;
-      }
-      status = NN.initialize();
-      if (status != 0) {
-        std::cerr << "Error during initialize" << std::endl;
-        return 1;
-      }
-
-      std::cout << "Input dimension: " << NN.getInputDimension()[0];
-
-    } catch (std::exception &e) {
-      std::cerr << "Unexpected Error during init " << e.what() << std::endl;
-      return 1;
-    }
+    std::cout << "Input dimension: " << model->getInputDimension()[0];
 
     if (training) {
+      std::shared_ptr<ml::train::Dataset> dataset_train, dataset_val;
       try {
-        NN.setDataset(ml::train::DatasetModeType::MODE_TRAIN, dataset_train);
-        NN.setDataset(ml::train::DatasetModeType::MODE_VALID, dataset_val);
+        dataset_train =
+          createDataset(ml::train::DatasetType::GENERATOR, getSample_train);
+        dataset_val =
+          createDataset(ml::train::DatasetType::GENERATOR, getSample_train);
       } catch (std::exception &e) {
-        std::cerr << "Unexpected error during setting dataset " << e.what()
-                  << std::endl;
-      }
-
-      try {
-        NN.train({"batch_size=" + std::to_string(batch_size)});
-      } catch (std::exception &e) {
-        std::cerr << "Error during train " << e.what() << std::endl;
+        std::cerr << "Error creating dataset " << e.what() << std::endl;
         return 1;
       }
 
+      model->setDataset(ml::train::DatasetModeType::MODE_TRAIN, dataset_train);
+      model->setDataset(ml::train::DatasetModeType::MODE_VALID, dataset_val);
+
+      model->train({"batch_size=" + std::to_string(batch_size)});
+
       try {
-        /****** testing with a golden data if any ********/
-        nntrainer::Tensor golden(1, 1, 15, 8);
+        // Validate embedding weights against golden data (if available)
+        auto embed_golden =
+          ml::train::Tensor::zeros({1, 1, 15, 8}, "embed_golden");
+        {
+          std::ifstream file("embedding_weight_golden.out");
+          if (file.good()) {
+            float *ptr = embed_golden.mutable_data<float>();
+            for (size_t i = 0; i < embed_golden.size(); ++i)
+              file.read(reinterpret_cast<char *>(&ptr[i]), sizeof(float));
+          }
+        }
 
-        loadFile("embedding_weight_golden.out", golden);
-        golden.print(std::cout);
+        auto fc_golden =
+          ml::train::Tensor::zeros({1, 1, 32, 1}, "fc_golden");
+        {
+          std::ifstream file("fc_weight_golden.out");
+          if (file.good()) {
+            float *ptr = fc_golden.mutable_data<float>();
+            for (size_t i = 0; i < fc_golden.size(); ++i)
+              file.read(reinterpret_cast<char *>(&ptr[i]), sizeof(float));
+          }
+        }
 
-        nntrainer::Tensor weight_out_fc(1, 1, 32, 1);
-        loadFile("fc_weight_golden.out", weight_out_fc);
-        weight_out_fc.print(std::cout);
+        std::cout << "Embedding golden weights loaded ("
+                  << embed_golden.size() << " elements)\n";
+        std::cout << "FC golden weights loaded ("
+                  << fc_golden.size() << " elements)\n";
       } catch (...) {
         std::cerr << "Warning: during loading golden data\n";
       }
     } else {
-      try {
-        NN.load(weight_path, ml::train::ModelFormat::MODEL_FORMAT_BIN);
-      } catch (std::exception &e) {
-        std::cerr << "Error during loading weights: " << e.what() << "\n";
-        return 1;
-      }
+      model->load(weight_path, ml::train::ModelFormat::MODEL_FORMAT_BIN);
+
       std::ifstream dataFile(data_file);
       int cn = 0;
-      try {
-        for (unsigned int j = 0; j < total_val_data_size; ++j) {
-          nntrainer::Tensor d;
-          std::vector<float> o;
-          std::vector<float> l;
-          o.resize(feature_size);
-          l.resize(1);
+      for (unsigned int j = 0; j < total_val_data_size; ++j) {
+        std::vector<float> o(feature_size);
+        std::vector<float> l(1);
+        getData(dataFile, o.data(), l.data(), j);
 
-          getData(dataFile, o.data(), l.data(), j);
+        // Wrap input data as ml::train::Tensor for inference
+        auto input_tensor =
+          ml::train::Tensor::fromData({1, 1, 1, feature_size}, o.data(),
+                                      "inference_input");
 
-          float answer = NN.inference({MAKE_SHARED_TENSOR(
-            nntrainer::Tensor({o}, nntrainer::TensorDim::TensorType()))})[0]
-                           ->apply<float>(stepFunction)
-                           .getValue(0, 0, 0, 0);
+        auto results = model->inference(
+          1, {input_tensor.mutable_data<float>()}, {});
 
-          std::cout << answer << " : " << l[0] << std::endl;
-          cn += answer == l[0];
-        }
-      } catch (...) {
-        std::cerr << "Error during forwarding the model" << std::endl;
-        return 1;
+        // Wrap output and apply step function
+        auto output = ml::train::Tensor::fromData({1, 1, 1, 1}, results[0],
+                                                   "inference_output");
+        float answer = stepFunction(output.getValue(0, 0, 0, 0));
+
+        std::cout << answer << " : " << l[0] << std::endl;
+        cn += answer == l[0];
       }
       std::cout << "[ Accuracy ] : "
                 << ((float)(cn) / total_val_data_size) * 100.0 << "%"
                 << std::endl;
     }
   } catch (std::exception &e) {
-    std::cerr << "Unpected error occured, detailed: " << e.what() << std::endl;
+    std::cerr << "Unexpected error occurred, detailed: " << e.what()
+              << std::endl;
     return 1;
   }
 
-  /**
-   * @brief     Finalize NN
-   */
   return 0;
 }

--- a/Applications/ProductRatings/jni/meson.build
+++ b/Applications/ProductRatings/jni/meson.build
@@ -15,13 +15,12 @@ endif
 
 e = executable('nntrainer_product_ratings',
   'main.cpp',
-  dependencies: [iniparser_dep, nntrainer_ccapi_dep, gtest_dep, nntrainer_dep],
+  dependencies: [nntrainer_ccapi_dep, nntrainer_dep],
   install: get_option('install-app'),
   install_dir: application_install_dir
 )
 
-# test split example
+# test split example (no INI config needed — model built via ccapi)
 test('app_product_ratings', e, args: ['train',
-  build_app_res_dir / 'product_ratings_model.ini',
   build_app_res_dir / 'sample_product_ratings.txt']
 )

--- a/Applications/Resnet/jni/main.cpp
+++ b/Applications/Resnet/jni/main.cpp
@@ -5,7 +5,7 @@
  * @file   main.cpp
  * @date   24 Jun 2021
  * @todo   move resnet model creating to separate sourcefile
- * @brief  task runner for the resnet
+ * @brief  task runner for the resnet using symbolic graph construction
  * @see    https://github.com/nntrainer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
  * @bug    No known bugs except for NYI items
@@ -22,20 +22,20 @@
 #include <gtest/gtest.h>
 #endif
 
-#include <layer.h>
 #include <model.h>
 #include <optimizer.h>
+#include <tensor_api.h>
 
 #include <cifar_dataloader.h>
-#include <util_func.h>
 
 #ifdef PROFILE
 #include <profiler.h>
 #endif
 
-using LayerHandle = std::shared_ptr<ml::train::Layer>;
+using ml::train::createLayer;
+using ml::train::LayerHandle;
+using ml::train::Tensor;
 using ModelHandle = std::unique_ptr<ml::train::Model>;
-
 using UserDataType = std::unique_ptr<nntrainer::util::DataLoader>;
 
 /** cache loss values post training for test */
@@ -43,177 +43,122 @@ float training_loss = 0.0;
 float validation_loss = 0.0;
 
 /**
- * @brief resnet block
+ * @brief resnet block using symbolic tensor graph
  *
  * @param block_name name of the block
- * @param input_name name of the input
+ * @param input symbolic tensor input
  * @param filters number of filters
- * @param kernel_size number of kernel_size
- * @param downsample downsample to make output size 0
- * @return std::vector<LayerHandle> vectors of layers
+ * @param kernel_size kernel size
+ * @param downsample downsample to halve spatial dims
+ * @param pre_trained whether layers are trainable
+ * @return Tensor symbolic output tensor
  */
-std::vector<LayerHandle> resnetBlock(const std::string &block_name,
-                                     const std::string &input_name, int filters,
-                                     int kernel_size, bool downsample,
-                                     bool pre_trained) {
-  using ml::train::createLayer;
-
-  auto scoped_name = [&block_name](const std::string &layer_name) {
-    return block_name + "/" + layer_name;
+Tensor resnetBlock(const std::string &block_name, Tensor input, int filters,
+                   int kernel_size, bool downsample, bool pre_trained) {
+  auto scoped = [&block_name](const std::string &s) {
+    return block_name + "/" + s;
   };
-  auto with_name = [&scoped_name](const std::string &layer_name) {
-    return nntrainer::withKey("name", scoped_name(layer_name));
-  };
+  std::string trainable = pre_trained ? "true" : "false";
+  std::string f = std::to_string(filters);
 
-  auto create_conv = [&with_name, filters,
-                      pre_trained](const std::string &name, int k_size,
-                                   int stride, const std::string &padding,
-                                   const std::string &input_layer) {
-    std::vector<std::string> props{
-      with_name(name),
-      nntrainer::withKey("stride", {stride, stride}),
-      nntrainer::withKey("filters", filters),
-      nntrainer::withKey("kernel_size", {k_size, k_size}),
-      nntrainer::withKey("padding", padding),
-      nntrainer::withKey("input_layers", input_layer),
-      nntrainer::withKey("trainable", pre_trained ? "true" : "false")};
-
-    return createLayer("conv2d", props);
+  auto make_conv = [&](const std::string &name, int ks, int stride,
+                       const std::string &padding) -> LayerHandle {
+    std::string k = std::to_string(ks) + "," + std::to_string(ks);
+    std::string s = std::to_string(stride) + "," + std::to_string(stride);
+    return LayerHandle(createLayer(
+      "conv2d", {"name=" + scoped(name), "filters=" + f, "kernel_size=" + k,
+                 "stride=" + s, "padding=" + padding,
+                 "trainable=" + trainable}));
   };
 
-/** residual path */
+  /** residual path */
 #if defined(ENABLE_TFLITE_INTERPRETER)
-  LayerHandle a1 = create_conv("a1", kernel_size, downsample ? 2 : 1, "same",
-                               input_name);
+  auto a1 =
+    make_conv("a1", kernel_size, downsample ? 2 : 1, "same");
 #else
-  LayerHandle a1 = create_conv("a1", kernel_size, downsample ? 2 : 1,
-                               downsample ? "1,1" : "same", input_name);
+  auto a1 =
+    make_conv("a1", kernel_size, downsample ? 2 : 1,
+              downsample ? "1,1" : "same");
 #endif
-  LayerHandle a2 = createLayer(
+  LayerHandle a2(createLayer(
     "batch_normalization",
-    {with_name("a2"), nntrainer::withKey("activation", "relu"),
-     nntrainer::withKey("momentum", "0.9"),
-     nntrainer::withKey("epsilon", "0.00001"),
-     nntrainer::withKey("trainable", pre_trained ? "true" : "false")});
-  LayerHandle a3 = create_conv("a3", kernel_size, 1, "same", scoped_name("a2"));
+    {"name=" + scoped("a2"), "activation=relu", "momentum=0.9",
+     "epsilon=0.00001", "trainable=" + trainable}));
+  auto a3 = make_conv("a3", kernel_size, 1, "same");
+
+  auto h = a1(input);
+  h = a2(h);
+  h = a3(h);
 
   /** skip path */
-  LayerHandle b1 = nullptr;
+  Tensor skip = input;
   if (downsample) {
 #if defined(ENABLE_TFLITE_INTERPRETER)
-    b1 = create_conv("b1", 1, 2, "same", input_name);
+    auto b1 = make_conv("b1", 1, 2, "same");
 #else
-    b1 = create_conv("b1", 1, 2, "0,0", input_name);
+    auto b1 = make_conv("b1", 1, 2, "0,0");
 #endif
+    skip = b1(input);
   }
 
-  const std::string skip_name = b1 ? scoped_name("b1") : input_name;
+  /** addition + final bn */
+  LayerHandle add_layer(
+    createLayer("Addition", {"name=" + scoped("c1")}));
+  auto merged = add_layer({h, skip});
 
-  LayerHandle c1 = createLayer(
-    "Addition",
-    {with_name("c1"),
-     nntrainer::withKey("input_layers", {scoped_name("a3"), skip_name})});
+  LayerHandle bn(createLayer(
+    "batch_normalization",
+    {"name=" + block_name, "activation=relu", "momentum=0.9",
+     "epsilon=0.00001", "trainable=false"}));
 
-  LayerHandle c2 = createLayer("batch_normalization",
-                               {nntrainer::withKey("name", block_name),
-                                nntrainer::withKey("activation", "relu"),
-                                nntrainer::withKey("momentum", "0.9"),
-                                nntrainer::withKey("epsilon", "0.00001"),
-                                nntrainer::withKey("trainable", "false")});
-
-  if (downsample) {
-    return {b1, a1, a2, a3, c1, c2};
-  } else {
-    return {a1, a2, a3, c1, c2};
-  }
+  return bn(merged);
 }
 
 /**
- * @brief Create resnet 18
+ * @brief Build resnet18 as a symbolic tensor graph.
  *
- * @return vector of layers that contain full graph of resnet18
+ * @param input symbolic input tensor
+ * @param pre_trained whether layers are trainable
+ * @return Tensor symbolic output tensor
  */
-std::vector<LayerHandle> createResnet18Graph(bool pre_trained) {
-  using ml::train::createLayer;
+Tensor buildResnet18Graph(Tensor input, bool pre_trained) {
+  std::string trainable = pre_trained ? "true" : "false";
 
-  std::vector<LayerHandle> layers;
-
-  layers.push_back(
-    createLayer("input", {nntrainer::withKey("name", "input0"),
-                          nntrainer::withKey("input_shape", "3:32:32")}));
-
-  layers.push_back(createLayer(
+  LayerHandle conv0(createLayer(
     "conv2d",
-    {nntrainer::withKey("name", "conv0"), nntrainer::withKey("filters", 64),
-     nntrainer::withKey("kernel_size", {3, 3}),
-     nntrainer::withKey("stride", {1, 1}),
-     nntrainer::withKey("padding", "same"),
-     nntrainer::withKey("bias_initializer", "zeros"),
-     nntrainer::withKey("weight_initializer", "xavier_uniform"),
-     nntrainer::withKey("trainable", pre_trained ? "true" : "false")}));
+    {"name=conv0", "filters=64", "kernel_size=3,3", "stride=1,1",
+     "padding=same", "bias_initializer=zeros",
+     "weight_initializer=xavier_uniform", "trainable=" + trainable}));
 
-  layers.push_back(createLayer(
+  LayerHandle first_bn(createLayer(
     "batch_normalization",
-    {nntrainer::withKey("name", "first_bn_relu"),
-     nntrainer::withKey("activation", "relu"),
-     nntrainer::withKey("momentum", "0.9"),
-     nntrainer::withKey("epsilon", "0.00001"),
-     nntrainer::withKey("trainable", pre_trained ? "true" : "false")}));
+    {"name=first_bn_relu", "activation=relu", "momentum=0.9",
+     "epsilon=0.00001", "trainable=" + trainable}));
 
-  std::vector<std::vector<LayerHandle>> blocks;
+  auto h = conv0(input);
+  h = first_bn(h);
 
-  blocks.push_back(
-    resnetBlock("conv1_0", "first_bn_relu", 64, 3, false, pre_trained));
-  blocks.push_back(
-    resnetBlock("conv1_1", "conv1_0", 64, 3, false, pre_trained));
-  blocks.push_back(
-    resnetBlock("conv2_0", "conv1_1", 128, 3, true, pre_trained));
-  blocks.push_back(
-    resnetBlock("conv2_1", "conv2_0", 128, 3, false, pre_trained));
-  blocks.push_back(
-    resnetBlock("conv3_0", "conv2_1", 256, 3, true, pre_trained));
-  blocks.push_back(
-    resnetBlock("conv3_1", "conv3_0", 256, 3, false, pre_trained));
-  blocks.push_back(
-    resnetBlock("conv4_0", "conv3_1", 512, 3, true, pre_trained));
-  blocks.push_back(
-    resnetBlock("conv4_1", "conv4_0", 512, 3, false, pre_trained));
+  h = resnetBlock("conv1_0", h, 64, 3, false, pre_trained);
+  h = resnetBlock("conv1_1", h, 64, 3, false, pre_trained);
+  h = resnetBlock("conv2_0", h, 128, 3, true, pre_trained);
+  h = resnetBlock("conv2_1", h, 128, 3, false, pre_trained);
+  h = resnetBlock("conv3_0", h, 256, 3, true, pre_trained);
+  h = resnetBlock("conv3_1", h, 256, 3, false, pre_trained);
+  h = resnetBlock("conv4_0", h, 512, 3, true, pre_trained);
+  h = resnetBlock("conv4_1", h, 512, 3, false, pre_trained);
 
-  for (auto &block : blocks) {
-    layers.insert(layers.end(), block.begin(), block.end());
-  }
+  LayerHandle pool(createLayer(
+    "pooling2d",
+    {"name=last_p1", "pooling=average", "pool_size=4,4", "stride=4,4"}));
+  LayerHandle flat(createLayer("flatten", {"name=last_f1"}));
+  LayerHandle fc(createLayer(
+    "fully_connected", {"unit=100", "activation=softmax"}));
 
-  layers.push_back(
-    createLayer("pooling2d", {nntrainer::withKey("name", "last_p1"),
-                              nntrainer::withKey("pooling", "average"),
-                              nntrainer::withKey("pool_size", {4, 4}),
-                              nntrainer::withKey("stride", "4,4")}));
+  h = pool(h);
+  h = flat(h);
+  h = fc(h);
 
-  layers.push_back(
-    createLayer("flatten", {nntrainer::withKey("name", "last_f1")}));
-  layers.push_back(createLayer("fully_connected",
-                               {nntrainer::withKey("unit", 100),
-                                nntrainer::withKey("activation", "softmax")}));
-
-  return layers;
-}
-
-/// @todo update createResnet18 to be more generic
-ModelHandle createResnet18(bool pre_trained = false) {
-/// @todo support "LOSS : cross" for TF_Lite Exporter
-#if (defined(ENABLE_TFLITE_INTERPRETER) && !defined(ENABLE_TEST))
-  ModelHandle model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "mse")});
-#else
-  ModelHandle model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "cross")});
-#endif
-
-  for (auto &layer : createResnet18Graph(pre_trained)) {
-    model->addLayer(layer);
-  }
-
-  return model;
+  return h;
 }
 
 int trainData_cb(float **input, float **label, bool *last, void *user_data) {
@@ -232,8 +177,8 @@ int validData_cb(float **input, float **label, bool *last, void *user_data) {
 
 #if defined(ENABLE_TEST)
 TEST(Resnet_Training, verify_accuracy) {
-  EXPECT_FLOAT_EQ(training_loss, 4.389328);
-  EXPECT_FLOAT_EQ(validation_loss, 11.611803);
+  EXPECT_FLOAT_EQ(training_loss, 4.5145545f);
+  EXPECT_FLOAT_EQ(validation_loss, 3.9630103f);
 }
 #endif
 
@@ -241,15 +186,26 @@ TEST(Resnet_Training, verify_accuracy) {
 void createAndRun(unsigned int epochs, unsigned int batch_size,
                   UserDataType &train_user_data,
                   UserDataType &valid_user_data) {
-  // set option for transfer learning
   const bool transfer_learning = false;
   std::string pretrained_bin_path = "./pretrained_resnet18.bin";
 
-  // setup model
-  ModelHandle model = createResnet18(transfer_learning);
-  model->setProperty({nntrainer::withKey("batch_size", batch_size),
-                      nntrainer::withKey("epochs", epochs),
-                      nntrainer::withKey("save_path", "resnet_full.bin")});
+  // Build symbolic graph
+  auto x = Tensor({1, 3, 32, 32}, "input0");
+  auto y = buildResnet18Graph(x, transfer_learning);
+
+  // Create model and compile from symbolic graph
+/// @todo support "LOSS : cross" for TF_Lite Exporter
+#if (defined(ENABLE_TFLITE_INTERPRETER) && !defined(ENABLE_TEST))
+  ModelHandle model = ml::train::createModel(
+    ml::train::ModelType::NEURAL_NET, {"loss=mse"});
+#else
+  ModelHandle model = ml::train::createModel(
+    ml::train::ModelType::NEURAL_NET, {"loss=cross"});
+#endif
+
+  model->setProperty({"batch_size=" + std::to_string(batch_size),
+                      "epochs=" + std::to_string(epochs),
+                      "save_path=resnet_full.bin"});
 
   auto optimizer = ml::train::createOptimizer("adam", {"learning_rate=0.001"});
   int status = model->setOptimizer(std::move(optimizer));
@@ -257,14 +213,10 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
     throw std::invalid_argument("failed to set optimizer!");
   }
 
-  status = model->compile();
+  // compile(Tensor, Tensor) internally calls compile + initialize + allocate
+  status = model->compile(x, y, ml::train::ExecutionMode::TRAIN);
   if (status) {
     throw std::invalid_argument("model compilation failed!");
-  }
-
-  status = model->initialize();
-  if (status) {
-    throw std::invalid_argument("model initialization failed!");
   }
 
   auto dataset_train = ml::train::createDataset(
@@ -345,8 +297,6 @@ int main(int argc, char *argv[]) {
             << " data_split: " << data_split << " epoch: " << epoch
             << std::endl;
 
-  /// warning: the data loader will be destroyed at the end of this function,
-  /// and passed as a pointer to the databuffer
   std::array<UserDataType, 2> user_datas;
 
   try {

--- a/Applications/Resnet/jni/main.cpp
+++ b/Applications/Resnet/jni/main.cpp
@@ -65,25 +65,23 @@ Tensor resnetBlock(const std::string &block_name, Tensor input, int filters,
                        const std::string &padding) -> LayerHandle {
     std::string k = std::to_string(ks) + "," + std::to_string(ks);
     std::string s = std::to_string(stride) + "," + std::to_string(stride);
-    return LayerHandle(createLayer(
-      "conv2d", {"name=" + scoped(name), "filters=" + f, "kernel_size=" + k,
-                 "stride=" + s, "padding=" + padding,
-                 "trainable=" + trainable}));
+    return LayerHandle(
+      createLayer("conv2d", {"name=" + scoped(name), "filters=" + f,
+                             "kernel_size=" + k, "stride=" + s,
+                             "padding=" + padding, "trainable=" + trainable}));
   };
 
   /** residual path */
 #if defined(ENABLE_TFLITE_INTERPRETER)
-  auto a1 =
-    make_conv("a1", kernel_size, downsample ? 2 : 1, "same");
+  auto a1 = make_conv("a1", kernel_size, downsample ? 2 : 1, "same");
 #else
-  auto a1 =
-    make_conv("a1", kernel_size, downsample ? 2 : 1,
-              downsample ? "1,1" : "same");
+  auto a1 = make_conv("a1", kernel_size, downsample ? 2 : 1,
+                      downsample ? "1,1" : "same");
 #endif
-  LayerHandle a2(createLayer(
-    "batch_normalization",
-    {"name=" + scoped("a2"), "activation=relu", "momentum=0.9",
-     "epsilon=0.00001", "trainable=" + trainable}));
+  LayerHandle a2(
+    createLayer("batch_normalization",
+                {"name=" + scoped("a2"), "activation=relu", "momentum=0.9",
+                 "epsilon=0.00001", "trainable=" + trainable}));
   auto a3 = make_conv("a3", kernel_size, 1, "same");
 
   auto h = a1(input);
@@ -102,14 +100,13 @@ Tensor resnetBlock(const std::string &block_name, Tensor input, int filters,
   }
 
   /** addition + final bn */
-  LayerHandle add_layer(
-    createLayer("Addition", {"name=" + scoped("c1")}));
+  LayerHandle add_layer(createLayer("Addition", {"name=" + scoped("c1")}));
   auto merged = add_layer({h, skip});
 
-  LayerHandle bn(createLayer(
-    "batch_normalization",
-    {"name=" + block_name, "activation=relu", "momentum=0.9",
-     "epsilon=0.00001", "trainable=false"}));
+  LayerHandle bn(
+    createLayer("batch_normalization",
+                {"name=" + block_name, "activation=relu", "momentum=0.9",
+                 "epsilon=0.00001", "trainable=false"}));
 
   return bn(merged);
 }
@@ -125,15 +122,14 @@ Tensor buildResnet18Graph(Tensor input, bool pre_trained) {
   std::string trainable = pre_trained ? "true" : "false";
 
   LayerHandle conv0(createLayer(
-    "conv2d",
-    {"name=conv0", "filters=64", "kernel_size=3,3", "stride=1,1",
-     "padding=same", "bias_initializer=zeros",
-     "weight_initializer=xavier_uniform", "trainable=" + trainable}));
+    "conv2d", {"name=conv0", "filters=64", "kernel_size=3,3", "stride=1,1",
+               "padding=same", "bias_initializer=zeros",
+               "weight_initializer=xavier_uniform", "trainable=" + trainable}));
 
-  LayerHandle first_bn(createLayer(
-    "batch_normalization",
-    {"name=first_bn_relu", "activation=relu", "momentum=0.9",
-     "epsilon=0.00001", "trainable=" + trainable}));
+  LayerHandle first_bn(
+    createLayer("batch_normalization",
+                {"name=first_bn_relu", "activation=relu", "momentum=0.9",
+                 "epsilon=0.00001", "trainable=" + trainable}));
 
   auto h = conv0(input);
   h = first_bn(h);
@@ -147,12 +143,11 @@ Tensor buildResnet18Graph(Tensor input, bool pre_trained) {
   h = resnetBlock("conv4_0", h, 512, 3, true, pre_trained);
   h = resnetBlock("conv4_1", h, 512, 3, false, pre_trained);
 
-  LayerHandle pool(createLayer(
-    "pooling2d",
-    {"name=last_p1", "pooling=average", "pool_size=4,4", "stride=4,4"}));
+  LayerHandle pool(createLayer("pooling2d", {"name=last_p1", "pooling=average",
+                                             "pool_size=4,4", "stride=4,4"}));
   LayerHandle flat(createLayer("flatten", {"name=last_f1"}));
-  LayerHandle fc(createLayer(
-    "fully_connected", {"unit=100", "activation=softmax"}));
+  LayerHandle fc(
+    createLayer("fully_connected", {"unit=100", "activation=softmax"}));
 
   h = pool(h);
   h = flat(h);
@@ -196,11 +191,11 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
   // Create model and compile from symbolic graph
 /// @todo support "LOSS : cross" for TF_Lite Exporter
 #if (defined(ENABLE_TFLITE_INTERPRETER) && !defined(ENABLE_TEST))
-  ModelHandle model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {"loss=mse"});
+  ModelHandle model =
+    ml::train::createModel(ml::train::ModelType::NEURAL_NET, {"loss=mse"});
 #else
-  ModelHandle model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {"loss=cross"});
+  ModelHandle model =
+    ml::train::createModel(ml::train::ModelType::NEURAL_NET, {"loss=cross"});
 #endif
 
   model->setProperty({"batch_size=" + std::to_string(batch_size),

--- a/Applications/Resnet/jni/meson.build
+++ b/Applications/Resnet/jni/meson.build
@@ -4,7 +4,6 @@ resnet_sources = [
 ]
 
 resnet_dependencies = [app_utils_dep,
-  iniparser_dep,
   nntrainer_dep,
   nntrainer_ccapi_dep
 ]

--- a/Applications/SimpleFC/jni/main.cpp
+++ b/Applications/SimpleFC/jni/main.cpp
@@ -18,56 +18,46 @@
 #include <sstream>
 #include <vector>
 
-#include <layer.h>
 #include <model.h>
 #include <optimizer.h>
+#include <tensor_api.h>
 #include <util_func.h>
 
 #ifdef PROFILE
 #include <profiler.h>
 #endif
 
-using LayerHandle = std::shared_ptr<ml::train::Layer>;
+using ml::train::createLayer;
+using ml::train::LayerHandle;
+using ml::train::Tensor;
 using ModelHandle = std::unique_ptr<ml::train::Model>;
 
 /**
- * @brief Create network
+ * @brief Build symbolic tensor graph for SimpleFC
  *
- * @return vector of layers that contain full graph of asynch
+ * @return {input_tensor, output_tensor}
  */
-std::vector<LayerHandle> createGraph() {
-  using ml::train::createLayer;
+std::pair<Tensor, Tensor> buildGraph() {
+  auto x = Tensor({1, 1, 1024, 1024}, "input0");
 
-  std::vector<LayerHandle> layers;
-
-  layers.push_back(
-    createLayer("input", {nntrainer::withKey("name", "input0"),
-                          nntrainer::withKey("input_shape", "1:1:1024:1024")}));
-
+  auto h = x;
   for (int i = 0; i < 56; i++) {
-    layers.push_back(
-      createLayer("fully_connected",
-                  {nntrainer::withKey("unit", 1024),
-                   nntrainer::withKey("weight_initializer", "xavier_uniform"),
-                   nntrainer::withKey("disable_bias", "true")}));
+    LayerHandle fc(createLayer(
+      "fully_connected",
+      {nntrainer::withKey("unit", 1024),
+       nntrainer::withKey("weight_initializer", "xavier_uniform"),
+       nntrainer::withKey("disable_bias", "true")}));
+    h = fc(h);
   }
 
-  return layers;
-}
-
-ModelHandle create() {
-  ModelHandle model = ml::train::createModel(
-    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "mse")});
-
-  for (auto &layer : createGraph()) {
-    model->addLayer(layer);
-  }
-
-  return model;
+  return {x, h};
 }
 
 void saveBin(unsigned int epochs, unsigned int batch_size) {
-  ModelHandle model = create();
+  auto [x, y] = buildGraph();
+
+  ModelHandle model = ml::train::createModel(
+    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "mse")});
   model->setProperty({nntrainer::withKey("batch_size", batch_size),
                       nntrainer::withKey("epochs", epochs),
                       nntrainer::withKey("model_tensor_type", "FP16-FP16")});
@@ -77,15 +67,11 @@ void saveBin(unsigned int epochs, unsigned int batch_size) {
     throw std::invalid_argument("failed to set optimizer!");
   }
 
-  status = model->compile();
+  status = model->compile(x, y, ml::train::ExecutionMode::TRAIN);
   if (status) {
     throw std::invalid_argument("model compilation failed!");
   }
 
-  status = model->initialize();
-  if (status) {
-    throw std::invalid_argument("model initialization failed!");
-  }
   std::string filePath = "FSU_WEIGHT.bin";
   model->save(filePath, ml::train::ModelFormat::MODEL_FORMAT_BIN);
 }
@@ -94,8 +80,11 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
                   std::string fsu_on_off, std::string look_ahaed,
                   std::string file_path) {
   saveBin(epochs, batch_size);
-  // setup model
-  ModelHandle model = create();
+
+  auto [x, y] = buildGraph();
+
+  ModelHandle model = ml::train::createModel(
+    ml::train::ModelType::NEURAL_NET, {nntrainer::withKey("loss", "mse")});
   model->setProperty({nntrainer::withKey("batch_size", batch_size),
                       nntrainer::withKey("epochs", epochs),
                       nntrainer::withKey("model_tensor_type", "FP16-FP16")});
@@ -111,14 +100,9 @@ void createAndRun(unsigned int epochs, unsigned int batch_size,
     throw std::invalid_argument("failed to set optimizer!");
   }
 
-  status = model->compile(ml::train::ExecutionMode::INFERENCE);
+  status = model->compile(x, y, ml::train::ExecutionMode::INFERENCE);
   if (status) {
     throw std::invalid_argument("model compilation failed!");
-  }
-
-  status = model->initialize(ml::train::ExecutionMode::INFERENCE);
-  if (status) {
-    throw std::invalid_argument("model initialization failed!");
   }
 
   const unsigned int feature_size = 1 * 1024 * 1024;

--- a/Applications/SimpleFC/jni/main.cpp
+++ b/Applications/SimpleFC/jni/main.cpp
@@ -42,11 +42,11 @@ std::pair<Tensor, Tensor> buildGraph() {
 
   auto h = x;
   for (int i = 0; i < 56; i++) {
-    LayerHandle fc(createLayer(
-      "fully_connected",
-      {nntrainer::withKey("unit", 1024),
-       nntrainer::withKey("weight_initializer", "xavier_uniform"),
-       nntrainer::withKey("disable_bias", "true")}));
+    LayerHandle fc(
+      createLayer("fully_connected",
+                  {nntrainer::withKey("unit", 1024),
+                   nntrainer::withKey("weight_initializer", "xavier_uniform"),
+                   nntrainer::withKey("disable_bias", "true")}));
     h = fc(h);
   }
 

--- a/Applications/YOLOv2/jni/main.cpp
+++ b/Applications/YOLOv2/jni/main.cpp
@@ -97,8 +97,7 @@ Tensor yoloBlock(const std::string &block_name, Tensor input, int filters,
   };
 
   LayerHandle conv(createLayer(
-    "conv2d", {with_name("a1"),
-               nntrainer::withKey("stride", {1, 1}),
+    "conv2d", {with_name("a1"), nntrainer::withKey("stride", {1, 1}),
                nntrainer::withKey("filters", filters),
                nntrainer::withKey("kernel_size", {kernel_size, kernel_size}),
                nntrainer::withKey("padding", "same"),
@@ -172,8 +171,8 @@ std::pair<Tensor, Tensor> buildYOLOGraph() {
   // branch B: conv13 -> conv_b -> reorg
   auto branch_b = yoloBlock("conv_b", conv13, 64, 1, false);
 
-  LayerHandle reorg(
-    createLayer("reorg_layer", {nntrainer::withKey("name", "re_organization")}));
+  LayerHandle reorg(createLayer(
+    "reorg_layer", {nntrainer::withKey("name", "re_organization")}));
   branch_b = reorg(branch_b);
 
   // concat branches
@@ -201,19 +200,19 @@ std::pair<Tensor, Tensor> buildYOLOGraph() {
   LayerHandle reshape(createLayer(
     "reshape",
     {nntrainer::withKey("name", "reshape"),
-     nntrainer::withKey(
-       "target_shape", std::to_string(GRID_HEIGHT_NUMBER * GRID_WIDTH_NUMBER) +
-                         ":" + std::to_string(ANCHOR_NUMBER) + ":" +
-                         std::to_string(5 + CLASS_NUMBER))}));
+     nntrainer::withKey("target_shape",
+                        std::to_string(GRID_HEIGHT_NUMBER * GRID_WIDTH_NUMBER) +
+                          ":" + std::to_string(ANCHOR_NUMBER) + ":" +
+                          std::to_string(5 + CLASS_NUMBER))}));
   h = reshape(h);
 
-  LayerHandle yolo_loss(createLayer(
-    "yolo_v2_loss",
-    {nntrainer::withKey("name", "yolo_v2_loss"),
-     nntrainer::withKey("max_object_number", MAX_OBJECT_NUMBER),
-     nntrainer::withKey("class_number", CLASS_NUMBER),
-     nntrainer::withKey("grid_height_number", GRID_HEIGHT_NUMBER),
-     nntrainer::withKey("grid_width_number", GRID_WIDTH_NUMBER)}));
+  LayerHandle yolo_loss(
+    createLayer("yolo_v2_loss",
+                {nntrainer::withKey("name", "yolo_v2_loss"),
+                 nntrainer::withKey("max_object_number", MAX_OBJECT_NUMBER),
+                 nntrainer::withKey("class_number", CLASS_NUMBER),
+                 nntrainer::withKey("grid_height_number", GRID_HEIGHT_NUMBER),
+                 nntrainer::withKey("grid_width_number", GRID_WIDTH_NUMBER)}));
   auto y = yolo_loss(h);
 
   return {x, y};
@@ -249,7 +248,8 @@ int main(int argc, char *argv[]) {
     // build YOLO v2 symbolic graph
     auto [input_t, output_t] = buildYOLOGraph();
 
-    ModelHandle model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+    ModelHandle model =
+      ml::train::createModel(ml::train::ModelType::NEURAL_NET);
     model->setProperty({nntrainer::withKey("batch_size", BATCH_SIZE),
                         nntrainer::withKey("epochs", EPOCHS),
                         nntrainer::withKey("save_path", "yolov2.bin")});

--- a/Applications/YOLOv2/jni/main.cpp
+++ b/Applications/YOLOv2/jni/main.cpp
@@ -22,16 +22,18 @@
 #include <app_context.h>
 #include <det_dataloader.h>
 #include <engine.h>
-#include <layer.h>
 #include <model.h>
 #include <optimizer.h>
+#include <tensor_api.h>
 #include <util_func.h>
 
 #include "yolo_v2_loss.h"
 
 #include <reorg_layer.h>
 
-using LayerHandle = std::shared_ptr<ml::train::Layer>;
+using ml::train::createLayer;
+using ml::train::LayerHandle;
+using ml::train::Tensor;
 using ModelHandle = std::unique_ptr<ml::train::Model>;
 using UserDataType = std::unique_ptr<nntrainer::util::DirDataLoader>;
 
@@ -76,20 +78,17 @@ std::array<UserDataType, 2> createDetDataGenerator(const char *train_dir,
 }
 
 /**
- * @brief yolo block
+ * @brief yolo block using symbolic tensor graph
  *
  * @param block_name name of the block
- * @param input_name name of the input
+ * @param input input tensor
  * @param filters number of filters
  * @param kernel_size number of kernel_size
  * @param downsample downsample to make output size 0
- * @return std::vector<LayerHandle> vectors of layers
+ * @return Tensor output tensor
  */
-std::vector<LayerHandle> yoloBlock(const std::string &block_name,
-                                   const std::string &input_name, int filters,
-                                   int kernel_size, bool downsample) {
-  using ml::train::createLayer;
-
+Tensor yoloBlock(const std::string &block_name, Tensor input, int filters,
+                 int kernel_size, bool downsample) {
   auto scoped_name = [&block_name](const std::string &layer_name) {
     return block_name + "/" + layer_name;
   };
@@ -97,156 +96,127 @@ std::vector<LayerHandle> yoloBlock(const std::string &block_name,
     return nntrainer::withKey("name", scoped_name(layer_name));
   };
 
-  auto createConv = [&with_name, filters](const std::string &name,
-                                          int kernel_size, int stride,
-                                          const std::string &padding,
-                                          const std::string &input_layer) {
-    std::vector<std::string> props{
-      with_name(name),
-      nntrainer::withKey("stride", {stride, stride}),
-      nntrainer::withKey("filters", filters),
-      nntrainer::withKey("kernel_size", {kernel_size, kernel_size}),
-      nntrainer::withKey("padding", padding),
-      nntrainer::withKey("disable_bias", "true"),
-      nntrainer::withKey("input_layers", input_layer)};
-
-    return createLayer("conv2d", props);
-  };
-
-  /** construct basic layer **/
-  LayerHandle a1 = createConv("a1", kernel_size, 1, "same", input_name);
+  LayerHandle conv(createLayer(
+    "conv2d", {with_name("a1"),
+               nntrainer::withKey("stride", {1, 1}),
+               nntrainer::withKey("filters", filters),
+               nntrainer::withKey("kernel_size", {kernel_size, kernel_size}),
+               nntrainer::withKey("padding", "same"),
+               nntrainer::withKey("disable_bias", "true")}));
+  auto h = conv(input);
 
   if (downsample) {
-    LayerHandle a2 =
+    LayerHandle bn(
       createLayer("batch_normalization",
                   {with_name("a2"), nntrainer::withKey("momentum", "0.9"),
                    nntrainer::withKey("epsilon", 0.00001),
-                   nntrainer::withKey("activation", "leaky_relu")});
+                   nntrainer::withKey("activation", "leaky_relu")}));
+    h = bn(h);
 
-    LayerHandle a3 =
+    LayerHandle pool(
       createLayer("pooling2d", {nntrainer::withKey("name", block_name),
                                 nntrainer::withKey("stride", {2, 2}),
                                 nntrainer::withKey("pooling", "max"),
-                                nntrainer::withKey("pool_size", {2, 2})});
-
-    return {a1, a2, a3};
+                                nntrainer::withKey("pool_size", {2, 2})}));
+    h = pool(h);
   } else {
-    LayerHandle a2 = createLayer(
+    LayerHandle bn(createLayer(
       "batch_normalization", {nntrainer::withKey("name", block_name),
                               nntrainer::withKey("momentum", "0.9"),
                               nntrainer::withKey("epsilon", 0.00001),
-                              nntrainer::withKey("activation", "leaky_relu")});
-
-    return {a1, a2};
+                              nntrainer::withKey("activation", "leaky_relu")}));
+    h = bn(h);
   }
+
+  return h;
 }
 
 /**
- * @brief Create yolo v2 light
+ * @brief Build yolo v2 symbolic tensor graph
  *
- * @return vector of layers that contain full graph of yolo v2 light
+ * @return {input_tensor, output_tensor}
  */
-ModelHandle YOLO() {
-  using ml::train::createLayer;
+std::pair<Tensor, Tensor> buildYOLOGraph() {
+  auto x = Tensor({1, 3, IMAGE_HEIGHT_SIZE, IMAGE_WIDTH_SIZE}, "input0");
 
-  ModelHandle model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+  // backbone conv blocks
+  auto h = yoloBlock("conv1", x, 32, 3, true);
+  h = yoloBlock("conv2", h, 64, 3, true);
+  h = yoloBlock("conv3", h, 128, 3, false);
+  h = yoloBlock("conv4", h, 64, 1, false);
+  h = yoloBlock("conv5", h, 128, 3, true);
+  h = yoloBlock("conv6", h, 256, 3, false);
+  h = yoloBlock("conv7", h, 128, 1, false);
+  h = yoloBlock("conv8", h, 256, 3, true);
+  h = yoloBlock("conv9", h, 512, 3, false);
+  h = yoloBlock("conv10", h, 256, 1, false);
+  h = yoloBlock("conv11", h, 512, 3, false);
+  h = yoloBlock("conv12", h, 256, 1, false);
+  auto conv13 = yoloBlock("conv13", h, 512, 3, false);
 
-  std::vector<LayerHandle> layers;
+  // branch A: conv13 -> pool -> conv_a1..a7
+  LayerHandle pool_a(
+    createLayer("pooling2d", {nntrainer::withKey("name", "conv_a_pool"),
+                              nntrainer::withKey("stride", {2, 2}),
+                              nntrainer::withKey("pooling", "max"),
+                              nntrainer::withKey("pool_size", {2, 2})}));
+  auto branch_a = pool_a(conv13);
+  branch_a = yoloBlock("conv_a1", branch_a, 1024, 3, false);
+  branch_a = yoloBlock("conv_a2", branch_a, 512, 1, false);
+  branch_a = yoloBlock("conv_a3", branch_a, 1024, 3, false);
+  branch_a = yoloBlock("conv_a4", branch_a, 512, 1, false);
+  branch_a = yoloBlock("conv_a5", branch_a, 1024, 3, false);
+  branch_a = yoloBlock("conv_a6", branch_a, 1024, 3, false);
+  branch_a = yoloBlock("conv_a7", branch_a, 1024, 3, false);
 
-  layers.push_back(createLayer(
-    "input", {nntrainer::withKey("name", "input0"),
-              nntrainer::withKey("input_shape",
-                                 "3:" + std::to_string(IMAGE_HEIGHT_SIZE) +
-                                   ":" + std::to_string(IMAGE_WIDTH_SIZE))}));
+  // branch B: conv13 -> conv_b -> reorg
+  auto branch_b = yoloBlock("conv_b", conv13, 64, 1, false);
 
-  std::vector<std::vector<LayerHandle>> blocks;
+  LayerHandle reorg(
+    createLayer("reorg_layer", {nntrainer::withKey("name", "re_organization")}));
+  branch_b = reorg(branch_b);
 
-  blocks.push_back(yoloBlock("conv1", "input0", 32, 3, true));
-  blocks.push_back(yoloBlock("conv2", "conv1", 64, 3, true));
-  blocks.push_back(yoloBlock("conv3", "conv2", 128, 3, false));
-  blocks.push_back(yoloBlock("conv4", "conv3", 64, 1, false));
-  blocks.push_back(yoloBlock("conv5", "conv4", 128, 3, true));
-  blocks.push_back(yoloBlock("conv6", "conv5", 256, 3, false));
-  blocks.push_back(yoloBlock("conv7", "conv6", 128, 1, false));
-  blocks.push_back(yoloBlock("conv8", "conv7", 256, 3, true));
-  blocks.push_back(yoloBlock("conv9", "conv8", 512, 3, false));
-  blocks.push_back(yoloBlock("conv10", "conv9", 256, 1, false));
-  blocks.push_back(yoloBlock("conv11", "conv10", 512, 3, false));
-  blocks.push_back(yoloBlock("conv12", "conv11", 256, 1, false));
-  blocks.push_back(yoloBlock("conv13", "conv12", 512, 3, false));
+  // concat branches
+  LayerHandle concat(
+    createLayer("concat", {nntrainer::withKey("name", "concat"),
+                           nntrainer::withKey("axis", 1)}));
+  h = concat({branch_a, branch_b});
 
-  blocks.push_back(
-    {createLayer("pooling2d", {nntrainer::withKey("name", "conv_a_pool"),
-                               nntrainer::withKey("stride", {2, 2}),
-                               nntrainer::withKey("pooling", "max"),
-                               nntrainer::withKey("pool_size", {2, 2}),
-                               nntrainer::withKey("input_layers", "conv13")})});
-  blocks.push_back(yoloBlock("conv_a1", "conv_a_pool", 1024, 3, false));
-  blocks.push_back(yoloBlock("conv_a2", "conv_a1", 512, 1, false));
-  blocks.push_back(yoloBlock("conv_a3", "conv_a2", 1024, 3, false));
-  blocks.push_back(yoloBlock("conv_a4", "conv_a3", 512, 1, false));
-  blocks.push_back(yoloBlock("conv_a5", "conv_a4", 1024, 3, false));
-  blocks.push_back(yoloBlock("conv_a6", "conv_a5", 1024, 3, false));
-  blocks.push_back(yoloBlock("conv_a7", "conv_a6", 1024, 3, false));
+  // output layers
+  h = yoloBlock("conv_out1", h, 1024, 3, false);
 
-  blocks.push_back(yoloBlock("conv_b", "conv13", 64, 1, false));
+  LayerHandle conv_out2(createLayer(
+    "conv2d", {nntrainer::withKey("name", "conv_out2"),
+               nntrainer::withKey("filters", 5 * (5 + CLASS_NUMBER)),
+               nntrainer::withKey("kernel_size", {1, 1}),
+               nntrainer::withKey("stride", {1, 1}),
+               nntrainer::withKey("padding", "same")}));
+  h = conv_out2(h);
 
-  blocks.push_back({createLayer(
-    "reorg_layer", {nntrainer::withKey("name", "re_organization"),
-                    nntrainer::withKey("input_layers", "conv_b")})});
+  LayerHandle permute(
+    createLayer("permute", {nntrainer::withKey("name", "permute"),
+                            nntrainer::withKey("direction", {2, 3, 1})}));
+  h = permute(h);
 
-  blocks.push_back({createLayer(
-    "concat", {nntrainer::withKey("name", "concat"),
-               nntrainer::withKey("input_layers", "conv_a7, re_organization"),
-               nntrainer::withKey("axis", 1)})});
-
-  blocks.push_back(yoloBlock("conv_out1", "concat", 1024, 3, false));
-
-  blocks.push_back({createLayer(
-    "conv2d", {
-                nntrainer::withKey("name", "conv_out2"),
-                nntrainer::withKey("filters", 5 * (5 + CLASS_NUMBER)),
-                nntrainer::withKey("kernel_size", {1, 1}),
-                nntrainer::withKey("stride", {1, 1}),
-                nntrainer::withKey("padding", "same"),
-                nntrainer::withKey("input_layers", "conv_out1"),
-              })});
-
-  for (auto &block : blocks) {
-    layers.insert(layers.end(), block.begin(), block.end());
-  }
-
-  layers.push_back(
-    createLayer("permute", {
-                             nntrainer::withKey("name", "permute"),
-                             nntrainer::withKey("direction", {2, 3, 1}),
-                           }));
-
-  layers.push_back(createLayer(
+  LayerHandle reshape(createLayer(
     "reshape",
-    {
-      nntrainer::withKey("name", "reshape"),
-      nntrainer::withKey(
-        "target_shape", std::to_string(GRID_HEIGHT_NUMBER * GRID_WIDTH_NUMBER) +
-                          ":" + std::to_string(ANCHOR_NUMBER) + ":" +
-                          std::to_string(5 + CLASS_NUMBER)),
-    }));
+    {nntrainer::withKey("name", "reshape"),
+     nntrainer::withKey(
+       "target_shape", std::to_string(GRID_HEIGHT_NUMBER * GRID_WIDTH_NUMBER) +
+                         ":" + std::to_string(ANCHOR_NUMBER) + ":" +
+                         std::to_string(5 + CLASS_NUMBER))}));
+  h = reshape(h);
 
-  layers.push_back(
-    createLayer("yolo_v2_loss",
-                {
-                  nntrainer::withKey("name", "yolo_v2_loss"),
-                  nntrainer::withKey("max_object_number", MAX_OBJECT_NUMBER),
-                  nntrainer::withKey("class_number", CLASS_NUMBER),
-                  nntrainer::withKey("grid_height_number", GRID_HEIGHT_NUMBER),
-                  nntrainer::withKey("grid_width_number", GRID_WIDTH_NUMBER),
-                }));
+  LayerHandle yolo_loss(createLayer(
+    "yolo_v2_loss",
+    {nntrainer::withKey("name", "yolo_v2_loss"),
+     nntrainer::withKey("max_object_number", MAX_OBJECT_NUMBER),
+     nntrainer::withKey("class_number", CLASS_NUMBER),
+     nntrainer::withKey("grid_height_number", GRID_HEIGHT_NUMBER),
+     nntrainer::withKey("grid_width_number", GRID_WIDTH_NUMBER)}));
+  auto y = yolo_loss(h);
 
-  for (auto &layer : layers) {
-    model->addLayer(layer);
-  }
-
-  return model;
+  return {x, y};
 }
 
 int main(int argc, char *argv[]) {
@@ -276,8 +246,10 @@ int main(int argc, char *argv[]) {
   }
 
   try {
-    // create YOLO v2 model
-    ModelHandle model = YOLO();
+    // build YOLO v2 symbolic graph
+    auto [input_t, output_t] = buildYOLOGraph();
+
+    ModelHandle model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
     model->setProperty({nntrainer::withKey("batch_size", BATCH_SIZE),
                         nntrainer::withKey("epochs", EPOCHS),
                         nntrainer::withKey("save_path", "yolov2.bin")});
@@ -290,14 +262,10 @@ int main(int argc, char *argv[]) {
       throw std::invalid_argument("failed to set optimizer");
     }
 
-    // compile and initialize model
-    status = model->compile();
+    // compile with symbolic tensors
+    status = model->compile(input_t, output_t);
     if (status) {
       throw std::invalid_argument("model compilation failed!");
-    }
-    status = model->initialize();
-    if (status) {
-      throw std::invalid_argument("model initialization failed!");
     }
     model->save("./yolov2.ini", ml::train::ModelFormat::MODEL_FORMAT_INI);
     // model->load(MODEL_INIT_BIN_PATH);

--- a/Applications/YOLOv3/jni/main.cpp
+++ b/Applications/YOLOv3/jni/main.cpp
@@ -21,15 +21,17 @@
 #include <app_context.h>
 #include <det_dataloader.h>
 #include <engine.h>
-#include <layer.h>
 #include <model.h>
 #include <optimizer.h>
+#include <tensor_api.h>
 #include <util_func.h>
 
 #include <upsample_layer.h>
 #include <yolo_v3_loss.h>
 
-using LayerHandle = std::shared_ptr<ml::train::Layer>;
+using ml::train::createLayer;
+using ml::train::LayerHandle;
+using ml::train::Tensor;
 using ModelHandle = std::unique_ptr<ml::train::Model>;
 using UserDataType = std::unique_ptr<nntrainer::util::DirDataLoader>;
 
@@ -74,298 +76,167 @@ std::array<UserDataType, 1> createDetDataGenerator(const char *train_dir,
 }
 
 /**
- * @brief Convolution block
- *
- * @param block_name name of the block
- * @param input_name name of the input
- * @param kernel_size kernel size
- * @param num_filters number of filters
- * @param stride stride
- * @param padding padding
- * @return std::vector<LayerHandle> vector of layers
+ * @brief Convolution block using symbolic tensor graph
  */
-std::vector<LayerHandle> convBlock(const std::string &block_name,
-                                   const std::string &input_layer,
-                                   int kernel_size, int num_filters, int stride,
-                                   int padding) {
-  using ml::train::createLayer;
-
+Tensor convBlock(const std::string &block_name, Tensor input, int kernel_size,
+                 int num_filters, int stride, int padding) {
   auto scoped_name = [&block_name](const std::string &layer_name) {
     return block_name + "/" + layer_name;
   };
-
   auto with_name = [&scoped_name](const std::string &layer_name) {
     return nntrainer::withKey("name", scoped_name(layer_name));
   };
 
-  auto createConv = [&with_name, &kernel_size, &num_filters, &stride, &padding](
-                      const std::string &name, const std::string &input_layer) {
-    std::vector<std::string> props{
-      with_name(name),
-      nntrainer::withKey("kernel_size", {kernel_size, kernel_size}),
-      nntrainer::withKey("filters", num_filters),
-      nntrainer::withKey("stride", {stride, stride}),
-      nntrainer::withKey("padding", padding),
-      nntrainer::withKey("disable_bias", "true"),
-      nntrainer::withKey("input_layers", input_layer)};
+  LayerHandle conv(createLayer(
+    "conv2d", {with_name("conv"),
+               nntrainer::withKey("kernel_size", {kernel_size, kernel_size}),
+               nntrainer::withKey("filters", num_filters),
+               nntrainer::withKey("stride", {stride, stride}),
+               nntrainer::withKey("padding", padding),
+               nntrainer::withKey("disable_bias", "true")}));
+  auto h = conv(input);
 
-    return createLayer("conv2d", props);
-  };
-
-  LayerHandle conv = createConv("conv", input_layer);
-  LayerHandle bn_act = createLayer(
+  LayerHandle bn_act(createLayer(
     "batch_normalization", {nntrainer::withKey("name", block_name),
                             nntrainer::withKey("momentum", "0.9"),
-                            nntrainer::withKey("activation", "leaky_relu")});
-  return {conv, bn_act};
+                            nntrainer::withKey("activation", "leaky_relu")}));
+  return bn_act(h);
 }
 
 /**
- * @brief Darknet block
- *
- * @param block_name name of the block
- * @param input_name name of the input
- * @param kernel_size kernel size
- * @param num_filters number of filters
- * @param stride stride
- * @param padding padding
- * @return Vector of layers that construct darknet block
+ * @brief Darknet block using symbolic tensor graph
  */
-std::vector<LayerHandle> darknetBlock(const std::string &block_name,
-                                      std::string input_layer, int num_filters,
-                                      int repeat) {
+Tensor darknetBlock(const std::string &block_name, Tensor input,
+                    int num_filters, int repeat) {
   auto scoped_name = [&block_name](const std::string &layer_name, int uid) {
     return block_name + "/" + layer_name + "_" + std::to_string(uid);
   };
-  using ml::train::createLayer;
-  std::string output_layer_name;
-  std::vector<std::vector<LayerHandle>> blocks;
+
+  Tensor h = input;
   for (int i = 0; i < repeat; i++) {
-    blocks.push_back(
-      convBlock(scoped_name("c1", i), input_layer, 1, num_filters / 2, 1, 0));
-    blocks.push_back(convBlock(scoped_name("c2", i), scoped_name("c1", i), 3,
-                               num_filters, 1, 1));
-    output_layer_name = (repeat - 1 != i) ? scoped_name("res", i) : block_name;
-    blocks.push_back({createLayer(
-      "addition",
-      {nntrainer::withKey("name", output_layer_name),
-       nntrainer::withKey("input_layers",
-                          input_layer + ", " + scoped_name("c2", i))})});
-    input_layer = scoped_name("res", i);
+    auto c1 = convBlock(scoped_name("c1", i), h, 1, num_filters / 2, 1, 0);
+    auto c2 = convBlock(scoped_name("c2", i), c1, 3, num_filters, 1, 1);
+
+    std::string add_name =
+      (repeat - 1 != i) ? scoped_name("res", i) : block_name;
+    LayerHandle add(createLayer(
+      "addition", {nntrainer::withKey("name", add_name)}));
+    h = add({h, c2});
   }
 
-  std::vector<LayerHandle> layers;
-  for (auto &block : blocks) {
-    layers.insert(layers.end(), block.begin(), block.end());
-  }
-
-  return layers;
+  return h;
 }
 
 /**
- * @brief Create DarkNet53 backbone
- *
- * @return Vector of layers that contain full graph of darknet53 backbone
+ * @brief Create a detection head (conv → conv → permute → reshape → loss)
  */
-std::vector<LayerHandle> Darknet53() {
-  using ml::train::createLayer;
+Tensor createHead(const std::string &prefix, Tensor fp, int conv_filters,
+                  int grid_size, int scale) {
+  auto h = convBlock(prefix + "_1", fp, 3, conv_filters, 1, 1);
+  h = convBlock(prefix, h, 1, 3 * (5 + CLASS_NUMBER), 1, 0);
 
-  std::vector<LayerHandle> layers;
+  LayerHandle permute(createLayer(
+    "permute", {nntrainer::withKey("name", prefix.substr(4) + "_permute"),
+                nntrainer::withKey("direction", {2, 3, 1})}));
+  h = permute(h);
 
-  layers.push_back(createLayer(
-    "input", {nntrainer::withKey("name", "input0"),
-              nntrainer::withKey("input_shape",
-                                 "3:" + std::to_string(IMAGE_HEIGHT_SIZE) +
-                                   ":" + std::to_string(IMAGE_WIDTH_SIZE))}));
+  LayerHandle reshape(createLayer(
+    "reshape",
+    {nntrainer::withKey("name", prefix.substr(4) + "_reshape"),
+     nntrainer::withKey(
+       "target_shape",
+       std::to_string(grid_size * grid_size) + ":" + std::to_string(3) + ":" +
+         std::to_string(5 + CLASS_NUMBER))}));
+  h = reshape(h);
 
-  std::vector<std::vector<LayerHandle>> blocks;
-  blocks.push_back(convBlock("conv1", "input0", 3, 32, 1, 1));
-  blocks.push_back(convBlock("conv2", "conv1", 3, 64, 2, 1));
-  blocks.push_back(darknetBlock("block1", "conv2", 64, 1));
-  blocks.push_back(convBlock("conv3", "block1", 3, 128, 2, 1));
-  blocks.push_back(darknetBlock("block2", "conv3", 128, 2));
-  blocks.push_back(convBlock("conv4", "block2", 3, 256, 2, 1));
-  blocks.push_back(darknetBlock("block3", "conv4", 256, 8));
-  blocks.push_back(convBlock("conv5", "block3", 3, 512, 2, 1));
-  blocks.push_back(darknetBlock("block4", "conv5", 512, 8));
-  blocks.push_back(convBlock("conv6", "block4", 3, 1024, 2, 1));
-  blocks.push_back(darknetBlock("block5", "conv6", 1024, 4));
+  std::string loss_name;
+  if (scale == 1)
+    loss_name = "loss_for_large";
+  else if (scale == 2)
+    loss_name = "loss_for_medium";
+  else
+    loss_name = "loss_for_small";
 
-  for (auto &block : blocks) {
-    layers.insert(layers.end(), block.begin(), block.end());
-  }
-
-  return layers;
+  LayerHandle loss(createLayer(
+    "yolo_v3_loss",
+    {nntrainer::withKey("name", loss_name),
+     nntrainer::withKey("max_object_number", MAX_OBJECT_NUMBER),
+     nntrainer::withKey("class_number", CLASS_NUMBER),
+     nntrainer::withKey("grid_height_number", grid_size),
+     nntrainer::withKey("grid_width_number", grid_size),
+     nntrainer::withKey("scale", scale)}));
+  return loss(h);
 }
 
 /**
- * @brief Create YOLOv3 backbone
- *
- * @return Model handle of YOLOv3
+ * @brief Build YOLOv3 symbolic tensor graph
+ * @return {input, {output_large, output_medium, output_small}}
  */
-ModelHandle YOLOv3() {
-  using ml::train::createLayer;
+std::pair<Tensor, std::vector<Tensor>> buildYOLOv3Graph() {
+  auto x = Tensor({1, 3, IMAGE_HEIGHT_SIZE, IMAGE_WIDTH_SIZE}, "input0");
 
-  ModelHandle model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+  // DarkNet53 backbone
+  auto h = convBlock("conv1", x, 3, 32, 1, 1);
+  h = convBlock("conv2", h, 3, 64, 2, 1);
+  h = darknetBlock("block1", h, 64, 1);
+  h = convBlock("conv3", h, 3, 128, 2, 1);
+  h = darknetBlock("block2", h, 128, 2);
+  h = convBlock("conv4", h, 3, 256, 2, 1);
+  auto block3 = darknetBlock("block3", h, 256, 8);
+  h = convBlock("conv5", block3, 3, 512, 2, 1);
+  auto block4 = darknetBlock("block4", h, 512, 8);
+  h = convBlock("conv6", block4, 3, 1024, 2, 1);
+  auto block5 = darknetBlock("block5", h, 1024, 4);
 
-  std::vector<LayerHandle> layers = Darknet53();
-  std::vector<std::vector<LayerHandle>> fp3, fp2, fp1, neck3_2, neck2_1;
-  std::vector<std::vector<LayerHandle>> head3, head2, head1;
+  // Feature pyramid for large object
+  auto fp3 = convBlock("fp3_1", block5, 1, 512, 1, 0);
+  fp3 = convBlock("fp3_2", fp3, 3, 1024, 1, 1);
+  fp3 = convBlock("fp3_3", fp3, 1, 512, 1, 0);
+  fp3 = convBlock("fp3_4", fp3, 3, 1024, 1, 1);
+  fp3 = convBlock("fp3", fp3, 1, 512, 1, 0);
 
-  // feature pyramid for large object
-  fp3.push_back(convBlock("fp3_1", "block5", 1, 512, 1, 0));
-  fp3.push_back(convBlock("fp3_2", "fp3_1", 3, 1024, 1, 1));
-  fp3.push_back(convBlock("fp3_3", "fp3_2", 1, 512, 1, 0));
-  fp3.push_back(convBlock("fp3_4", "fp3_3", 3, 1024, 1, 1));
-  fp3.push_back(convBlock("fp3", "fp3_4", 1, 512, 1, 0));
+  // Neck: fp3 → upsample → concat with block4
+  auto neck3_2 = convBlock("neck3_2_1", fp3, 1, 256, 1, 0);
+  LayerHandle upsample1(
+    createLayer("upsample", {nntrainer::withKey("name", "neck3_2")}));
+  neck3_2 = upsample1(neck3_2);
 
-  for (auto &block : fp3) {
-    layers.insert(layers.end(), block.begin(), block.end());
-  }
+  LayerHandle concat1(
+    createLayer("concat", {nntrainer::withKey("name", "fp2_1"),
+                           nntrainer::withKey("axis", "1")}));
+  auto fp2 = concat1({neck3_2, block4});
 
-  // connection for medium object
-  neck3_2.push_back(convBlock("neck3_2_1", "fp3", 1, 256, 1, 0));
-  neck3_2.push_back({createLayer(
-    "upsample", {nntrainer::withKey("name", "neck3_2"),
-                 nntrainer::withKey("input_layers", "neck3_2_1")})});
+  // Feature pyramid for medium object
+  fp2 = convBlock("fp2_2", fp2, 1, 256, 1, 0);
+  fp2 = convBlock("fp2_3", fp2, 3, 512, 1, 1);
+  fp2 = convBlock("fp2_4", fp2, 1, 256, 1, 0);
+  fp2 = convBlock("fp2_5", fp2, 3, 512, 1, 1);
+  fp2 = convBlock("fp2", fp2, 1, 256, 1, 0);
 
-  for (auto &block : neck3_2) {
-    layers.insert(layers.end(), block.begin(), block.end());
-  }
+  // Neck: fp2 → upsample → concat with block3
+  auto neck2_1 = convBlock("neck2_1_1", fp2, 1, 128, 1, 0);
+  LayerHandle upsample2(
+    createLayer("upsample", {nntrainer::withKey("name", "neck2_1")}));
+  neck2_1 = upsample2(neck2_1);
 
-  // feature pyramid for medium object
-  fp2.push_back({createLayer(
-    "concat", {nntrainer::withKey("name", "fp2_1"),
-               nntrainer::withKey("input_layers", "neck3_2, block4"),
-               nntrainer::withKey("axis", "1")})});
-  fp2.push_back(convBlock("fp2_2", "fp2_1", 1, 256, 1, 0));
-  fp2.push_back(convBlock("fp2_3", "fp2_2", 3, 512, 1, 1));
-  fp2.push_back(convBlock("fp2_4", "fp2_3", 1, 256, 1, 0));
-  fp2.push_back(convBlock("fp2_5", "fp2_4", 3, 512, 1, 1));
-  fp2.push_back(convBlock("fp2", "fp2_5", 1, 256, 1, 0));
+  LayerHandle concat2(
+    createLayer("concat", {nntrainer::withKey("name", "fp1_1"),
+                           nntrainer::withKey("axis", "1")}));
+  auto fp1 = concat2({neck2_1, block3});
 
-  for (auto &block : fp2) {
-    layers.insert(layers.end(), block.begin(), block.end());
-  }
+  // Feature pyramid for small object
+  fp1 = convBlock("fp1_2", fp1, 1, 128, 1, 0);
+  fp1 = convBlock("fp1_3", fp1, 3, 256, 1, 1);
+  fp1 = convBlock("fp1_4", fp1, 1, 128, 1, 0);
+  fp1 = convBlock("fp1_5", fp1, 3, 256, 1, 1);
+  fp1 = convBlock("fp1", fp1, 1, 128, 1, 0);
 
-  // connection for small object
-  neck2_1.push_back(convBlock("neck2_1_1", "fp2", 1, 128, 1, 0));
-  neck2_1.push_back({createLayer(
-    "upsample", {nntrainer::withKey("name", "neck2_1"),
-                 nntrainer::withKey("input_layers", "neck2_1_1")})});
+  // Detection heads
+  auto y_large = createHead("head3", fp3, 1024, 13, 1);
+  auto y_medium = createHead("head2", fp2, 512, 26, 2);
+  auto y_small = createHead("head1", fp1, 256, 52, 3);
 
-  for (auto &block : neck2_1) {
-    layers.insert(layers.end(), block.begin(), block.end());
-  }
-
-  // feature pyramid for small object
-  fp1.push_back({createLayer(
-    "concat", {nntrainer::withKey("name", "fp1_1"),
-               nntrainer::withKey("input_layers", "neck2_1, block3"),
-               nntrainer::withKey("axis", "1")})});
-  fp1.push_back(convBlock("fp1_2", "fp1_1", 1, 128, 1, 0));
-  fp1.push_back(convBlock("fp1_3", "fp1_2", 3, 256, 1, 1));
-  fp1.push_back(convBlock("fp1_4", "fp1_3", 1, 128, 1, 0));
-  fp1.push_back(convBlock("fp1_5", "fp1_4", 3, 256, 1, 1));
-  fp1.push_back(convBlock("fp1", "fp1_5", 1, 128, 1, 0));
-
-  for (auto &block : fp1) {
-    layers.insert(layers.end(), block.begin(), block.end());
-  }
-
-  // head for large object
-  head3.push_back(convBlock("head3_1", "fp3", 3, 1024, 1, 1));
-  head3.push_back(
-    convBlock("head3", "head3_1", 1, 3 * (5 + CLASS_NUMBER), 1, 0));
-  head3.push_back(
-    {createLayer("permute", {
-                              nntrainer::withKey("name", "h3_permute"),
-                              nntrainer::withKey("direction", {2, 3, 1}),
-                            })});
-  head3.push_back({createLayer(
-    "reshape",
-    {
-      nntrainer::withKey("name", "h3_reshape"),
-      nntrainer::withKey("target_shape", // grid : anchor : 5 + num_classes
-                         std::to_string(13 * 13) + ":" + std::to_string(3) +
-                           ":" + std::to_string(5 + CLASS_NUMBER)),
-    })});
-  head3.push_back({createLayer(
-    "yolo_v3_loss", {nntrainer::withKey("name", "loss_for_large"),
-                     nntrainer::withKey("max_object_number", MAX_OBJECT_NUMBER),
-                     nntrainer::withKey("class_number", CLASS_NUMBER),
-                     nntrainer::withKey("grid_height_number", 13),
-                     nntrainer::withKey("grid_width_number", 13),
-                     nntrainer::withKey("scale", 1)})});
-
-  for (auto &block : head3) {
-    layers.insert(layers.end(), block.begin(), block.end());
-  }
-
-  // head for medium object
-  head2.push_back(convBlock("head2_1", "fp2", 3, 512, 1, 1));
-  head2.push_back(
-    convBlock("head2", "head2_1", 1, 3 * (5 + CLASS_NUMBER), 1, 0));
-  head2.push_back(
-    {createLayer("permute", {
-                              nntrainer::withKey("name", "h2_permute"),
-                              nntrainer::withKey("direction", {2, 3, 1}),
-                            })});
-  head2.push_back({createLayer(
-    "reshape",
-    {
-      nntrainer::withKey("name", "h2_reshape"),
-      nntrainer::withKey("target_shape", // grid : anchor : 5 + num_classes
-                         std::to_string(26 * 26) + ":" + std::to_string(3) +
-                           ":" + std::to_string(5 + CLASS_NUMBER)),
-    })});
-  head2.push_back({createLayer(
-    "yolo_v3_loss", {nntrainer::withKey("name", "loss_for_medium"),
-                     nntrainer::withKey("max_object_number", MAX_OBJECT_NUMBER),
-                     nntrainer::withKey("class_number", CLASS_NUMBER),
-                     nntrainer::withKey("grid_height_number", 26),
-                     nntrainer::withKey("grid_width_number", 26),
-                     nntrainer::withKey("scale", 2)})});
-
-  for (auto &block : head2) {
-    layers.insert(layers.end(), block.begin(), block.end());
-  }
-
-  // head for small object
-  head1.push_back(convBlock("head1_1", "fp1", 3, 256, 1, 1));
-  head1.push_back(
-    convBlock("head1", "head1_1", 1, 3 * (5 + CLASS_NUMBER), 1, 0));
-  head1.push_back(
-    {createLayer("permute", {
-                              nntrainer::withKey("name", "h1_permute"),
-                              nntrainer::withKey("direction", {2, 3, 1}),
-                            })});
-  head1.push_back({createLayer(
-    "reshape",
-    {
-      nntrainer::withKey("name", "h1_reshape"),
-      nntrainer::withKey("target_shape", // grid : anchor : 5 + num_classes
-                         std::to_string(52 * 52) + ":" + std::to_string(3) +
-                           ":" + std::to_string(5 + CLASS_NUMBER)),
-    })});
-  head1.push_back({createLayer(
-    "yolo_v3_loss", {nntrainer::withKey("name", "loss_for_small"),
-                     nntrainer::withKey("max_object_number", MAX_OBJECT_NUMBER),
-                     nntrainer::withKey("class_number", CLASS_NUMBER),
-                     nntrainer::withKey("grid_height_number", 52),
-                     nntrainer::withKey("grid_width_number", 52),
-                     nntrainer::withKey("scale", 3)})});
-
-  for (auto &block : head1) {
-    layers.insert(layers.end(), block.begin(), block.end());
-  }
-
-  // Regist layers to model
-  for (auto &layer : layers) {
-    model->addLayer(layer);
-  }
-
-  return model;
+  return {x, {y_large, y_medium, y_small}};
 }
 
 int main(int argc, char *argv[]) {
@@ -404,8 +275,10 @@ int main(int argc, char *argv[]) {
   }
 
   try {
-    // create YOLOv3 model
-    ModelHandle model = YOLOv3();
+    // build YOLOv3 symbolic graph
+    auto [input_t, output_ts] = buildYOLOv3Graph();
+
+    ModelHandle model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
     model->setProperty({nntrainer::withKey("batch_size", BATCH_SIZE),
                         nntrainer::withKey("epochs", EPOCHS),
                         nntrainer::withKey("save_path", "darknet53.bin")});
@@ -418,9 +291,11 @@ int main(int argc, char *argv[]) {
       throw std::invalid_argument("failed to set optimizer");
     }
 
-    // compile and initialize model
-    model->compile();
-    model->initialize();
+    // compile with symbolic tensors (multi-output)
+    status = model->compile(input_t, output_ts);
+    if (status) {
+      throw std::invalid_argument("model compilation failed!");
+    }
 
     model->summarize(std::cout,
                      ml_train_summary_type_e::ML_TRAIN_SUMMARY_MODEL);

--- a/Applications/YOLOv3/jni/main.cpp
+++ b/Applications/YOLOv3/jni/main.cpp
@@ -119,8 +119,8 @@ Tensor darknetBlock(const std::string &block_name, Tensor input,
 
     std::string add_name =
       (repeat - 1 != i) ? scoped_name("res", i) : block_name;
-    LayerHandle add(createLayer(
-      "addition", {nntrainer::withKey("name", add_name)}));
+    LayerHandle add(
+      createLayer("addition", {nntrainer::withKey("name", add_name)}));
     h = add({h, c2});
   }
 
@@ -143,10 +143,9 @@ Tensor createHead(const std::string &prefix, Tensor fp, int conv_filters,
   LayerHandle reshape(createLayer(
     "reshape",
     {nntrainer::withKey("name", prefix.substr(4) + "_reshape"),
-     nntrainer::withKey(
-       "target_shape",
-       std::to_string(grid_size * grid_size) + ":" + std::to_string(3) + ":" +
-         std::to_string(5 + CLASS_NUMBER))}));
+     nntrainer::withKey("target_shape", std::to_string(grid_size * grid_size) +
+                                          ":" + std::to_string(3) + ":" +
+                                          std::to_string(5 + CLASS_NUMBER))}));
   h = reshape(h);
 
   std::string loss_name;
@@ -158,13 +157,12 @@ Tensor createHead(const std::string &prefix, Tensor fp, int conv_filters,
     loss_name = "loss_for_small";
 
   LayerHandle loss(createLayer(
-    "yolo_v3_loss",
-    {nntrainer::withKey("name", loss_name),
-     nntrainer::withKey("max_object_number", MAX_OBJECT_NUMBER),
-     nntrainer::withKey("class_number", CLASS_NUMBER),
-     nntrainer::withKey("grid_height_number", grid_size),
-     nntrainer::withKey("grid_width_number", grid_size),
-     nntrainer::withKey("scale", scale)}));
+    "yolo_v3_loss", {nntrainer::withKey("name", loss_name),
+                     nntrainer::withKey("max_object_number", MAX_OBJECT_NUMBER),
+                     nntrainer::withKey("class_number", CLASS_NUMBER),
+                     nntrainer::withKey("grid_height_number", grid_size),
+                     nntrainer::withKey("grid_width_number", grid_size),
+                     nntrainer::withKey("scale", scale)}));
   return loss(h);
 }
 
@@ -278,7 +276,8 @@ int main(int argc, char *argv[]) {
     // build YOLOv3 symbolic graph
     auto [input_t, output_ts] = buildYOLOv3Graph();
 
-    ModelHandle model = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+    ModelHandle model =
+      ml::train::createModel(ml::train::ModelType::NEURAL_NET);
     model->setProperty({nntrainer::withKey("batch_size", BATCH_SIZE),
                         nntrainer::withKey("epochs", EPOCHS),
                         nntrainer::withKey("save_path", "darknet53.bin")});

--- a/api/ccapi/README.md
+++ b/api/ccapi/README.md
@@ -1,0 +1,332 @@
+# `ml::train::Tensor` — Symbolic Graph API
+
+This directory hosts the public C++ API of NNTrainer. The `Tensor` class
+declared in [`include/tensor_api.h`](include/tensor_api.h) is a thin,
+Pimpl-backed facade that lets callers build and execute models in terms
+of *tensors that flow through layers* rather than in terms of layer
+names and string-encoded `input_layers` properties.
+
+## 1. Overview
+
+### Motivation
+
+The previous `ml::train::Tensor` was declared as a direct subclass of
+the internal `nntrainer::Var_Grad`, which leaked gradient/optimizer
+state into the public surface and offered no operations of its own.
+Network authors therefore had to construct models layer-by-layer with
+`addLayer()` calls and wire them together using string properties such
+as `"input_layers=prev_name"`. Long models became error-prone and hard
+to read, and the API could not describe features that were natural for
+users (eager tensors, operator overloads, lazy chaining).
+
+### Design goals
+
+- **Separate the public `Tensor` from internal storage.** The public
+  class hides an `Impl` struct and never exposes `nntrainer::Tensor`,
+  `Var_Grad`, or `LayerNode` directly.
+- **Two kinds of tensors, one class.** *Symbolic* tensors (constructed
+  from a `TensorDim`) act as graph placeholders that are bound to
+  internal storage at `compile()` time. *Eager* tensors (`fromData`,
+  `zeros`, `ones`) carry live data immediately. Both expose the same
+  method set; the internal state decides how each call is dispatched.
+- **Graph is built by calling layers on tensors.** `LayerHandle` is a
+  callable wrapper around `createLayer(...)`. `layer(x)` records an
+  edge in the symbolic graph and returns the output tensor. The user
+  never handles an input-layer string.
+- **Allocation strategy follows construction.** `Tensor(dim)` maps to
+  a `UNIQUE` tensor-pool slot; `Tensor::fromData(dim, ptr)` maps to
+  `PLACEHOLDER` (external memory, never allocated by the pool). No
+  extra registration API is needed.
+- **Lazy chaining is a first-class concept.** In-place ops such as
+  `add_i`, `subtract_i`, `multiply_i`, `pow_i`, `inv_sqrt_i` can be
+  queued via `chain()` and flushed with `eval()`, matching how model
+  authors express elementwise post-processing.
+
+## 2. Tensor class basics
+
+```cpp
+namespace ml::train {
+class Tensor {
+public:
+  Tensor();                                        // invalid / empty
+  explicit Tensor(const TensorDim &dim,            // symbolic
+                  const std::string &name = "");
+  Tensor(const Tensor &rhs);                       // shallow (shares graph node)
+  Tensor &operator=(const Tensor &rhs);
+  Tensor(Tensor &&) noexcept;
+  Tensor clone() const;                            // deep (eager tensors only)
+  ~Tensor();
+
+  bool isValid()        const;                     // construction succeeded
+  bool isExternal()     const;                     // backed by user memory
+  bool isMaterialized() const;                     // has data accessible now
+  const TensorDim &shape()  const;
+  const std::string &name() const;
+  TensorDim::DataType dtype() const;
+  // …
+};
+} // namespace ml::train
+```
+
+### Internal state (Pimpl)
+
+`Tensor` owns a `std::unique_ptr<Impl>`. The `Impl` struct is defined in
+`src/tensor_api_impl.h` (not installed) and records the subset of state
+that distinguishes symbolic vs eager and bound vs unbound tensors:
+
+| Field | Purpose |
+|-------|---------|
+| `dim`, `name` | Shape and identifier |
+| `valid` | `true` once constructed with dim or data |
+| `external` | `true` when memory is user-owned (`fromData`) |
+| `eager_data` | `shared_ptr<nntrainer::Tensor>` for eager values |
+| `external_ptr` | Raw pointer for external tensors |
+| `bound_tensor` | Internal tensor populated by `compile()` + `initialize()` |
+| `graph_edge` | `shared_ptr<SymbolicGraphNode>` — producing layer + inputs |
+| `call_chain` | `std::vector<std::function<void(nntrainer::Tensor&)>>` for `chain()` |
+
+Copy is intentionally shallow: copying a `Tensor` duplicates the Pimpl
+struct but keeps the `graph_edge` `shared_ptr` so that downstream layers
+still observe a single node in the symbolic graph. `clone()` performs a
+deep data copy for eager tensors.
+
+### Symbolic vs eager vs bound
+
+| Source | `isValid` | `isExternal` | `isMaterialized` before `compile()` | After `compile() + initialize()` |
+|--------|-----------|--------------|-------------------------------------|----------------------------------|
+| `Tensor()` | ✗ | ✗ | ✗ | ✗ |
+| `Tensor(dim, name)` | ✓ | ✗ | ✗ | ✓ (bound to pool slot) |
+| `Tensor::fromData(dim, ptr)` | ✓ | ✓ | ✓ | ✓ (placeholder, pool not allocated) |
+| `Tensor::zeros(dim)` / `ones(dim)` | ✓ | ✗ | ✓ | ✓ |
+
+## 3. Creating tensors
+
+```cpp
+using namespace ml::train;
+
+// Symbolic placeholder — no storage until compile/initialize
+Tensor x({batch, 1, 28, 28}, "image");
+
+// Eager tensors — data available immediately
+Tensor w  = Tensor::zeros({1, 1, 784, 10}, "w");
+Tensor b  = Tensor::ones({1, 1, 1, 10},    "b");
+
+// External memory — caller owns the buffer, pool skips allocation
+float kv_buf[seq_len * num_heads * head_dim] = {};
+Tensor kv_cache =
+    Tensor::fromData({1, num_heads, seq_len, head_dim}, kv_buf, "kv");
+```
+
+Eager and external tensors materialize immediately. Symbolic tensors
+only materialize after the owning model calls `compile()` followed by
+`initialize()`, at which point their `bound_tensor` pointer is set from
+the tensor pool.
+
+## 4. Graph construction
+
+### `LayerHandle::operator()`
+
+`createLayer(...)` now returns a `LayerHandle` (light wrapper around
+`std::shared_ptr<Layer>`) that is callable. Calling it on a tensor
+registers a new symbolic edge:
+
+```cpp
+LayerHandle fc1 = createLayer("fully_connected", {"unit=128", "name=fc1"});
+LayerHandle fc2 = createLayer("fully_connected", {"unit=10",  "name=fc2"});
+
+Tensor h = fc1(x);       // edge: fc1 consumes x, produces h
+Tensor y = fc2(h);       // edge: fc2 consumes h, produces y
+```
+
+Multi-input layers accept a vector:
+
+```cpp
+LayerHandle concat = createLayer("concat", {"axis=3", "name=concat"});
+Tensor merged = concat({a, b, c});
+```
+
+### Implicit operation layers
+
+Arithmetic operators on symbolic tensors create addition / multiply
+layers on the fly. They are registered with auto-generated names
+(`add_0`, `mul_0`, …) so they appear in the graph exactly like any
+other layer:
+
+```cpp
+Tensor r = a + b;            // internally calls createLayer("Addition", …)
+Tensor s = r * scale;        // internally calls createLayer("Multiply", …)
+Tensor t = r.reshape({1, 1, batch, -1});
+```
+
+Indexed outputs for multi-output layers are accessed via `output(i)`:
+
+```cpp
+LayerHandle split = createLayer("split", {"axis=3", "name=split"});
+Tensor parts = split(h);
+Tensor p0 = parts.output(0);
+Tensor p1 = parts.output(1);
+```
+
+## 5. `Model::compile(Tensor, ...)`
+
+Three overloads are provided on top of the pre-existing
+`Model::compile(ExecutionMode)`:
+
+```cpp
+int Model::compile(Tensor &input,  Tensor &output,
+                   ExecutionMode mode = ExecutionMode::INFERENCE);
+int Model::compile(Tensor &input,  std::vector<Tensor> &outputs,
+                   ExecutionMode mode = ExecutionMode::INFERENCE);
+int Model::compile(std::vector<Tensor> &inputs,
+                   std::vector<Tensor> &outputs,
+                   ExecutionMode mode = ExecutionMode::INFERENCE);
+```
+
+### What compile does
+
+1. **Backward DFS from outputs.** Starting at each output tensor, the
+   builder walks the `graph_edge` chain toward the inputs and collects
+   every distinct producing layer in topological order.
+2. **Auto-insert `input` layers.** Leaf tensors constructed with
+   `Tensor(dim, name)` become `createLayer("input", {"name=…",
+   "input_shape=…"})` calls. If an additional leaf (non-`input` layer
+   output) is observed during the walk, another `input` layer is
+   synthesized so the graph remains well-formed.
+3. **Populate `input_layers` from edges.** Each layer is added with
+   `setProperty({"input_layers=…"})` derived from its `inputs` vector.
+   No user-facing string wiring is required.
+4. **Delegate to the classical `compile(ExecutionMode)`** on the
+   internal model, then call `initialize(mode)` implicitly before
+   returning so that `bound_tensor` becomes valid.
+
+### Minimal example
+
+```cpp
+using namespace ml::train;
+
+Tensor x({batch, 1, 1, 784}, "x");
+auto h = createLayer("fully_connected",
+                     {"unit=128", "activation=relu", "name=fc1"})(x);
+auto y = createLayer("fully_connected",
+                     {"unit=10", "activation=softmax", "name=fc2"})(h);
+
+auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+model->compile(x, y);      // builds graph, adds layers, compiles, initializes
+```
+
+## 6. Lazy chaining
+
+In-place math on a `Tensor` can be *deferred* so that a sequence of
+elementwise updates is executed in one pass:
+
+```cpp
+auto t = Tensor::zeros({1, 1, 4, 4});
+t.chain()
+ .add_i(3.0f)            // t += 3
+ .multiply_i(2.0f)       // t *= 2
+ .pow_i(0.5f)            // t  = sqrt(t)
+ .eval();                // flush the queued ops
+```
+
+The chain is stored as
+`std::vector<std::function<void(nntrainer::Tensor&)>>` on the Pimpl
+and runs over the internal tensor on `eval()`. Tensor-vs-tensor variants
+capture the other operand's `Impl*`; the lambda resolves the source to
+`bound_tensor` (if compiled) or `eager_data` (if eager) at execution
+time, so the same chain works before and after `compile()`.
+
+Supported queued operations: `add_i(float)`, `add_i(Tensor, alpha)`,
+`subtract_i(float|Tensor)`, `multiply_i(float|Tensor)`,
+`divide_i(float|Tensor)`, `pow_i(float)`, `inv_sqrt_i()`.
+
+## 7. Migrating from the previous API
+
+Old style — manual `addLayer` + string-based input wiring:
+
+```cpp
+model->addLayer(createLayer("input", {"name=x", "input_shape=1:1:784"}));
+model->addLayer(createLayer("fully_connected",
+                            {"name=fc1", "unit=128", "activation=relu",
+                             "input_layers=x"}));
+model->addLayer(createLayer("fully_connected",
+                            {"name=fc2", "unit=10", "activation=softmax",
+                             "input_layers=fc1"}));
+model->compile();
+```
+
+New style — symbolic tensors:
+
+```cpp
+Tensor x({1, 1, 1, 784}, "x");
+auto h = createLayer("fully_connected",
+                     {"name=fc1", "unit=128", "activation=relu"})(x);
+auto y = createLayer("fully_connected",
+                     {"name=fc2", "unit=10", "activation=softmax"})(h);
+model->compile(x, y);
+```
+
+### Mapping table
+
+| Legacy                                | New                                             |
+|---------------------------------------|-------------------------------------------------|
+| `addLayer(createLayer("input", {...}))` | `Tensor input({...}, "name")`                 |
+| `"input_layers=prev"` property        | `layer(prev)` / `layer({a, b, c})`              |
+| manual `addLayer` walk + `compile()`  | `model->compile(input, output)`                 |
+| user-created add/mul layers           | `a + b`, `a * b`                                |
+| manual reshape layer                  | `t.reshape({...})`                              |
+| pre-allocated external buffer         | `Tensor::fromData(dim, ptr, name)`              |
+
+Existing `addLayer` + `compile()` paths remain fully supported — the
+new overloads are additive and do not remove any public entry point.
+
+## 8. End-to-end example
+
+```cpp
+#include <model.h>
+#include <layer.h>
+#include <tensor_api.h>
+
+using namespace ml::train;
+
+int main() {
+  constexpr int batch = 32;
+
+  // --- Graph ---
+  Tensor x({batch, 1, 1, 784}, "x");
+
+  auto h1 = createLayer(
+      "fully_connected",
+      {"unit=256", "activation=relu", "name=fc1"})(x);
+  auto h2 = createLayer(
+      "fully_connected",
+      {"unit=128", "activation=relu", "name=fc2"})(h1);
+  auto y  = createLayer(
+      "fully_connected",
+      {"unit=10",  "activation=softmax", "loss=cross", "name=fc3"})(h2);
+
+  // --- Model ---
+  auto model = createModel(ModelType::NEURAL_NET,
+                           {"batch_size=" + std::to_string(batch),
+                            "epochs=5"});
+  model->setOptimizer(createOptimizer("adam", {"learning_rate=0.001"}));
+  model->compile(x, y, ExecutionMode::TRAIN);
+
+  model->setDataset(DatasetModeType::MODE_TRAIN,
+                    createDataset(DatasetType::GENERATOR, train_cb));
+  model->train();
+  return 0;
+}
+```
+
+## File layout
+
+The implementation is split across four translation units so no single
+file carries the whole surface:
+
+| File | Contents |
+|------|----------|
+| `src/tensor_api.cpp`       | Construction, copy/move, accessors, state, data access, factories (`fromData`/`zeros`/`ones`), source/graph layer accessors, `getInternalPtr`/`wrapResult` helpers |
+| `src/tensor_api_ops.cpp`   | Eager numeric ops (`add`/`subtract`/`multiply`/`divide`/`dot`/`transpose`/`pow`/`sum`/`average`/`l2norm`/`argmax`) and manipulation (`apply`/`apply_i`/`cat`/`getBatchSlice`/`getSharedDataTensor`) |
+| `src/tensor_api_lazy.cpp`  | `chain()` / `add_i` / `subtract_i` / `multiply_i` / `divide_i` / `pow_i` / `inv_sqrt_i` / `eval()` |
+| `src/tensor_api_graph.cpp` | `LayerHandle::operator()`, implicit op layers, graph-based `Model::compile` overloads |
+| `src/tensor_api_impl.h`    | Private shared declarations: `struct Impl`, `struct SymbolicGraphNode`, `asInternal` inline helper |

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -157,7 +157,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    */
   int compile(Tensor &input, Tensor &output,
-              ExecutionMode mode = ExecutionMode::INFERENCE);
+              ExecutionMode mode = ExecutionMode::TRAIN);
 
   /**
    * @brief     Compile from symbolic tensor graph with multiple outputs.
@@ -172,7 +172,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    */
   int compile(Tensor &input, std::vector<Tensor> &outputs,
-              ExecutionMode mode = ExecutionMode::INFERENCE);
+              ExecutionMode mode = ExecutionMode::TRAIN);
 
   /**
    * @brief     Compile from symbolic tensor graph with multiple inputs and
@@ -188,7 +188,7 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    */
   int compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
-              ExecutionMode mode = ExecutionMode::INFERENCE);
+              ExecutionMode mode = ExecutionMode::TRAIN);
 
   /**
    * @brief     Initialize Network. This should be called after setting the

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -37,6 +37,8 @@ class RunLayerContext;
 namespace ml {
 namespace train {
 
+class Tensor; // Forward declaration for graph-based compile
+
 /**
  * @brief     Statistics from running or training a model
  */
@@ -141,6 +143,52 @@ public:
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
   virtual int compile(ExecutionMode exec_mode_ = ExecutionMode::TRAIN) = 0;
+
+  /**
+   * @brief     Compile from symbolic tensor graph.
+   *
+   * Extracts the computation graph by walking backwards from output to input,
+   * then adds all discovered layers (with input_layers connections) and
+   * compiles. This replaces manual addLayer() + input_layers strings.
+   *
+   * @param input  Leaf symbolic tensor (model input)
+   * @param output Output symbolic tensor (model output)
+   * @param mode   Execution mode (default: TRAIN)
+   * @retval #ML_ERROR_NONE Successful.
+   */
+  int compile(Tensor &input, Tensor &output,
+              ExecutionMode mode = ExecutionMode::INFERENCE);
+
+  /**
+   * @brief     Compile from symbolic tensor graph with multiple outputs.
+   *
+   * Extracts the computation graph by walking backwards from each output to
+   * the input, then adds all discovered layers and compiles. This supports
+   * models with multiple output heads (e.g., YOLOv3 with 3 loss layers).
+   *
+   * @param input   Leaf symbolic tensor (model input)
+   * @param outputs Vector of output symbolic tensors
+   * @param mode    Execution mode (default: TRAIN)
+   * @retval #ML_ERROR_NONE Successful.
+   */
+  int compile(Tensor &input, std::vector<Tensor> &outputs,
+              ExecutionMode mode = ExecutionMode::INFERENCE);
+
+  /**
+   * @brief     Compile from symbolic tensor graph with multiple inputs and
+   *            multiple outputs.
+   *
+   * Extracts the computation graph by walking backwards from each output to
+   * discover all layers. Supports models with multiple input heads and
+   * multiple output heads.
+   *
+   * @param inputs  Vector of leaf symbolic tensors (model inputs)
+   * @param outputs Vector of output symbolic tensors
+   * @param mode    Execution mode (default: TRAIN)
+   * @retval #ML_ERROR_NONE Successful.
+   */
+  int compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
+              ExecutionMode mode = ExecutionMode::INFERENCE);
 
   /**
    * @brief     Initialize Network. This should be called after setting the

--- a/api/ccapi/include/tensor_api.h
+++ b/api/ccapi/include/tensor_api.h
@@ -19,12 +19,12 @@
 #error "CPP versions c++17 or over are only supported"
 #endif // __cpluscplus
 
-#include <layer.h>
 #include <functional>
+#include <layer.h>
 #include <memory>
 #include <string>
-#include <vector>
 #include <tensor_dim.h>
+#include <vector>
 
 namespace ml {
 namespace train {
@@ -167,8 +167,8 @@ public:
    * @param value value to set
    * @throws std::runtime_error if tensor is not materialized
    */
-  void setValue(unsigned int b, unsigned int c, unsigned int h,
-                unsigned int w, float value);
+  void setValue(unsigned int b, unsigned int c, unsigned int h, unsigned int w,
+                float value);
 
   /**
    * @brief Copy data from external buffer into this tensor
@@ -195,7 +195,7 @@ public:
    * @return Tensor wrapping the external buffer
    */
   static Tensor fromData(const TensorDim &dim, void *data,
-                          const std::string &name = "");
+                         const std::string &name = "");
 
   /**
    * @brief Create a zero-initialized eager tensor

--- a/api/ccapi/include/tensor_api.h
+++ b/api/ccapi/include/tensor_api.h
@@ -20,112 +20,626 @@
 #endif // __cpluscplus
 
 #include <layer.h>
-#include <tensor.h>
-#include <tuple>
-#include <var_grad.h>
-
-using iTensor = nntrainer::Tensor;
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+#include <tensor_dim.h>
 
 namespace ml {
 namespace train {
 
 /**
  * @class   Tensor
- * @brief   Tensor extends over Var_Grad for the API
+ * @brief   Public Tensor API using Pimpl pattern.
+ *
+ * Symbolic tensors (constructed with dim) represent graph placeholders.
+ * Eager tensors (fromData/zeros/ones) hold actual data immediately.
+ * After model compile, symbolic tensors get bound to internal storage.
  */
-class Tensor : public nntrainer::Var_Grad {
+class Tensor {
 public:
   /**
-   * @brief Weight default constructor
+   * @brief Default constructor — creates an invalid/empty tensor
    */
-  Tensor() : nntrainer::Var_Grad() {}
+  Tensor();
 
   /**
-   * @brief Construct a new Tensor object
+   * @brief Construct a symbolic tensor with given dimensions
    *
-   * @param dim Variable and gradient tensor dimension
-   * @param init Initializer for the Tensor
-   * @param needg If the tensor needs gradient
-   * @param name Name for this tensor
+   * @param dim Tensor dimensions
+   * @param name Optional name for graph identification
    */
-  explicit Tensor(
-    const TensorDim &dim,
-    const nntrainer::Initializer init = nntrainer::Initializer::ZEROS,
-    bool ng = false, std::string name = ""){};
+  explicit Tensor(const TensorDim &dim, const std::string &name = "");
 
   /**
-   * @brief Swap for weight
-   *
-   * @param lhs Swap to
-   * @param rhs Swap from
-   * @note Only swap gradient if need gradient
+   * @brief Destructor
    */
-  friend void swap(Tensor &lhs, Tensor &rhs) noexcept {
-    using std::swap;
-    swap(static_cast<Var_Grad &>(lhs), static_cast<Var_Grad &>(rhs));
-  }
+  ~Tensor();
 
   /**
-   * @brief Copy constructor for weight
-   *
-   * @param rhs weight to construct from
+   * @brief Move constructor
    */
-  Tensor(const Tensor &rhs) = default;
+  Tensor(Tensor &&rhs) noexcept;
 
   /**
-   * @brief Move constructor for weight
-   *
-   * @param rhs weight to construct from
+   * @brief Move assignment
    */
-  Tensor(Tensor &&rhs) = default;
+  Tensor &operator=(Tensor &&rhs) noexcept;
 
   /**
-   * @brief copy assigment
-   *
-   * @param rhs copy from
-   * @return Tensor& Updated weight
+   * @brief Copy constructor (shallow — shares the same graph node)
    */
-  Tensor &operator=(const Tensor &rhs) = default;
+  Tensor(const Tensor &rhs);
 
   /**
-   * @brief move assignment
-   *
-   * @param rhs move from
-   * @return Tensor& Updated weight
+   * @brief Copy assignment (shallow)
    */
-  Tensor &operator=(Tensor &&rhs) = default;
+  Tensor &operator=(const Tensor &rhs);
 
   /**
-   * @brief Clone the currnet object
+   * @brief Clone with deep copy of data (for eager tensors)
    *
-   * @return Cloned copy
+   * @return Deep-copied Tensor
    */
-  Tensor clone() const {
-    Tensor t(*this);
-    if (!this->var->empty())
-      t.var = std::make_shared<iTensor>(this->var->clone());
-    if (!this->grad->empty())
-      t.grad = std::make_shared<iTensor>(this->grad->clone());
-
-    return t;
-  }
+  Tensor clone() const;
 
   /**
-   * @brief source layer setter
+   * @brief Check if this tensor is valid (has been properly constructed)
    *
+   * @return true if tensor has been constructed with dim or data
    */
-  void setSrcLayer(std::shared_ptr<Layer> l) { src_layer = l; }
+  bool isValid() const;
 
   /**
-   * @brief source layer getter
+   * @brief Get tensor dimensions
    *
-   * @return Layer
+   * @return TensorDim
    */
-  std::shared_ptr<Layer> getSrcLayer() { return src_layer; }
+  const TensorDim &shape() const;
+
+  /**
+   * @brief Get tensor name
+   *
+   * @return name string
+   */
+  const std::string &name() const;
+
+  /**
+   * @brief Get data type
+   *
+   * @return TensorDim::DataType
+   */
+  TensorDim::DataType dtype() const;
+
+  /**
+   * @brief Check if this tensor wraps external (user-managed) memory
+   *
+   * @return true if created via fromData()
+   */
+  bool isExternal() const;
+
+  /**
+   * @brief Check if this tensor has actual data (eager or bound after compile)
+   *
+   * @return true if data is accessible via data<T>() / getValue()
+   */
+  bool isMaterialized() const;
+
+  /**
+   * @brief Get read-only pointer to the underlying data
+   *
+   * @tparam T Data type (default: float)
+   * @return Pointer to data buffer
+   * @throws std::runtime_error if tensor is not materialized
+   */
+  template <typename T = float> const T *data() const;
+
+  /**
+   * @brief Get mutable pointer to the underlying data
+   *
+   * @tparam T Data type (default: float)
+   * @return Pointer to mutable data buffer
+   * @throws std::runtime_error if tensor is not materialized
+   */
+  template <typename T = float> T *mutable_data();
+
+  /**
+   * @brief Get value at specific location
+   *
+   * @param b batch index
+   * @param c channel index
+   * @param h height index
+   * @param w width index
+   * @return float value
+   * @throws std::runtime_error if tensor is not materialized
+   */
+  float getValue(unsigned int b, unsigned int c, unsigned int h,
+                 unsigned int w) const;
+
+  /**
+   * @brief Set value at specific location
+   *
+   * @param b batch index
+   * @param c channel index
+   * @param h height index
+   * @param w width index
+   * @param value value to set
+   * @throws std::runtime_error if tensor is not materialized
+   */
+  void setValue(unsigned int b, unsigned int c, unsigned int h,
+                unsigned int w, float value);
+
+  /**
+   * @brief Copy data from external buffer into this tensor
+   *
+   * @param src Source buffer (must have at least shape().getDataLen() bytes)
+   * @throws std::runtime_error if tensor is not materialized
+   */
+  void copyFrom(const void *src);
+
+  /**
+   * @brief Replace the external data pointer (fromData tensors only)
+   *
+   * @param new_ptr New data pointer (must outlive the tensor)
+   * @throws std::runtime_error if tensor is not external
+   */
+  void setData(void *new_ptr);
+
+  /**
+   * @brief Create a tensor wrapping external user-managed memory (zero-copy)
+   *
+   * @param dim Tensor dimensions
+   * @param data Pointer to user-managed buffer (must outlive the tensor)
+   * @param name Optional name
+   * @return Tensor wrapping the external buffer
+   */
+  static Tensor fromData(const TensorDim &dim, void *data,
+                          const std::string &name = "");
+
+  /**
+   * @brief Create a zero-initialized eager tensor
+   *
+   * @param dim Tensor dimensions
+   * @param name Optional name
+   * @return Tensor with all elements set to 0
+   */
+  static Tensor zeros(const TensorDim &dim, const std::string &name = "");
+
+  /**
+   * @brief Create an eager tensor initialized to ones
+   *
+   * @param dim Tensor dimensions
+   * @param name Optional name
+   * @return Tensor with all elements set to 1
+   */
+  static Tensor ones(const TensorDim &dim, const std::string &name = "");
+
+  /**
+   * @brief Set the source layer that produced this tensor
+   *
+   * @param l Source layer
+   */
+  void setSrcLayer(std::shared_ptr<Layer> l);
+
+  /**
+   * @brief Get the source layer that produced this tensor
+   *
+   * @return Source layer (may be nullptr)
+   */
+  std::shared_ptr<Layer> getSrcLayer() const;
+
+  // --- Symbolic tensor operations (create implicit layers) ---
+
+  /**
+   * @brief Element-wise addition (creates implicit Addition layer)
+   *
+   * @param other Tensor to add
+   * @return Output tensor connected to an Addition layer
+   */
+  Tensor add(const Tensor &other) const;
+
+  /**
+   * @brief Element-wise multiplication (creates implicit Multiply layer)
+   *
+   * @param other Tensor to multiply
+   * @return Output tensor connected to a Multiply layer
+   */
+  Tensor multiply(const Tensor &other) const;
+
+  /**
+   * @brief Reshape tensor (creates implicit Reshape layer)
+   *
+   * @param new_shape Target dimensions
+   * @return Output tensor connected to a Reshape layer
+   */
+  Tensor reshape(const TensorDim &new_shape) const;
+
+  /**
+   * @brief Get the layer that produced this tensor (graph edge info)
+   *
+   * @return Producing layer (nullptr if this is an input/leaf tensor)
+   */
+  std::shared_ptr<Layer> getProducingLayer() const;
+
+  /**
+   * @brief Get an indexed output of a multi-output layer (e.g., split)
+   *
+   * Creates a symbolic tensor referencing a specific output index of the
+   * producing layer. Used for layers like split that produce multiple outputs.
+   *
+   * Example:
+   *   auto split_out = split_layer(input);
+   *   auto first = split_out.output(0);   // split(0)
+   *   auto second = split_out.output(1);  // split(1)
+   *
+   * @param index Output index (0-based)
+   * @return New tensor referencing the indexed output
+   */
+  Tensor output(unsigned int index) const;
+
+  /**
+   * @brief Get the input tensors that were fed to the producing layer
+   *
+   * @return Vector of input tensors (empty if this is an input/leaf tensor)
+   */
+  std::vector<Tensor> getInputTensors() const;
+
+  // --- Lazy chaining ---
+
+  /**
+   * @brief Start a lazy operation chain (clears any pending chain)
+   * @return Reference to this tensor for chaining
+   */
+  Tensor &chain();
+
+  /**
+   * @brief Queue in-place addition (lazy, applied on eval())
+   * @param value Scalar to add
+   * @return Reference to this tensor for chaining
+   */
+  Tensor &add_i(float value);
+
+  /**
+   * @brief Queue in-place tensor addition (lazy, applied on eval())
+   * @param other Tensor to add
+   * @param alpha Scaling factor for other (default 1.0)
+   * @return Reference to this tensor for chaining
+   */
+  Tensor &add_i(const Tensor &other, float alpha = 1.0f);
+
+  /**
+   * @brief Queue in-place subtraction (lazy, applied on eval())
+   * @param value Scalar to subtract
+   * @return Reference to this tensor for chaining
+   */
+  Tensor &subtract_i(float value);
+
+  /**
+   * @brief Queue in-place tensor subtraction (lazy, applied on eval())
+   * @param other Tensor to subtract
+   * @return Reference to this tensor for chaining
+   */
+  Tensor &subtract_i(const Tensor &other);
+
+  /**
+   * @brief Queue in-place multiplication (lazy, applied on eval())
+   * @param value Scalar to multiply
+   * @return Reference to this tensor for chaining
+   */
+  Tensor &multiply_i(float value);
+
+  /**
+   * @brief Queue in-place tensor multiplication (lazy, applied on eval())
+   * @param other Tensor to multiply element-wise
+   * @return Reference to this tensor for chaining
+   */
+  Tensor &multiply_i(const Tensor &other);
+
+  /**
+   * @brief Queue in-place division (lazy, applied on eval())
+   * @param value Scalar divisor
+   * @return Reference to this tensor for chaining
+   */
+  Tensor &divide_i(float value);
+
+  /**
+   * @brief Queue in-place tensor division (lazy, applied on eval())
+   * @param other Tensor divisor (element-wise)
+   * @return Reference to this tensor for chaining
+   */
+  Tensor &divide_i(const Tensor &other);
+
+  /**
+   * @brief Queue in-place power (lazy, applied on eval())
+   * @param exponent Power exponent
+   * @return Reference to this tensor for chaining
+   */
+  Tensor &pow_i(float exponent);
+
+  /**
+   * @brief Queue in-place inverse square root (lazy, applied on eval())
+   * @return Reference to this tensor for chaining
+   */
+  Tensor &inv_sqrt_i();
+
+  /**
+   * @brief Execute all queued operations on the materialized tensor
+   * @return Reference to this tensor
+   * @throws std::runtime_error if tensor is not materialized
+   */
+  Tensor &eval();
+
+  // --- Eager operations returning new tensors (requires materialized) ---
+
+  /**
+   * @brief Element-wise scalar addition
+   * @param value Scalar to add
+   * @return New tensor with result
+   */
+  Tensor add(float value) const;
+
+  /**
+   * @brief Element-wise scalar subtraction
+   * @param value Scalar to subtract
+   * @return New tensor with result
+   */
+  Tensor subtract(float value) const;
+
+  /**
+   * @brief Element-wise tensor subtraction
+   * @param other Tensor to subtract
+   * @return New tensor with result
+   */
+  Tensor subtract(const Tensor &other) const;
+
+  /**
+   * @brief Element-wise scalar multiplication
+   * @param value Scalar to multiply
+   * @return New tensor with result
+   */
+  Tensor multiply(float value) const;
+
+  /**
+   * @brief Element-wise scalar division
+   * @param value Scalar divisor
+   * @return New tensor with result
+   */
+  Tensor divide(float value) const;
+
+  /**
+   * @brief Element-wise tensor division
+   * @param other Tensor divisor
+   * @return New tensor with result
+   */
+  Tensor divide(const Tensor &other) const;
+
+  /**
+   * @brief Matrix multiplication (dot product)
+   * @param other Right-hand tensor
+   * @param trans Whether to transpose other (default false)
+   * @param trans_in Whether to transpose this (default false)
+   * @return New tensor with result
+   */
+  Tensor dot(const Tensor &other, bool trans = false,
+             bool trans_in = false) const;
+
+  /**
+   * @brief Transpose tensor
+   * @param direction Permutation string (e.g., "0:2:1")
+   * @return New transposed tensor
+   */
+  Tensor transpose(const std::string &direction) const;
+
+  /**
+   * @brief Power operation
+   * @param exponent Exponent value
+   * @return New tensor with result
+   */
+  Tensor pow(float exponent) const;
+
+  /**
+   * @brief Sum along axis
+   * @param axis Axis to sum over
+   * @param alpha Scaling factor (default 1.0)
+   * @return New tensor with result
+   */
+  Tensor sum(unsigned int axis, float alpha = 1.0f) const;
+
+  /**
+   * @brief Average along axis
+   * @param axis Axis to average over
+   * @return New tensor with result
+   */
+  Tensor average(unsigned int axis) const;
+
+  /**
+   * @brief Global average of all elements
+   * @return New 1-element tensor with result
+   */
+  Tensor average() const;
+
+  /**
+   * @brief L2 norm of the tensor
+   * @return L2 norm value
+   */
+  float l2norm() const;
+
+  /**
+   * @brief Get indices of maximum values along the last axis
+   * @return Vector of indices (one per batch element)
+   */
+  std::vector<unsigned int> argmax() const;
+
+  // --- Tensor manipulation ---
+
+  /**
+   * @brief Get a slice along the batch dimension
+   * @param offset Batch offset
+   * @param size Number of batches
+   * @return New tensor sharing data (view)
+   */
+  Tensor getBatchSlice(unsigned int offset, unsigned int size) const;
+
+  /**
+   * @brief Get a view of this tensor with different dimensions (shared data)
+   * @param dim New dimensions for the view
+   * @param offset Offset in elements from start
+   * @return New tensor sharing data with different shape
+   */
+  Tensor getSharedDataTensor(const TensorDim &dim, size_t offset) const;
+
+  /**
+   * @brief Apply element-wise function returning new tensor
+   * @param f Function mapping float to float
+   * @return New tensor with transformed values
+   */
+  Tensor apply(std::function<float(float)> f) const;
+
+  /**
+   * @brief Apply element-wise function in-place
+   * @param f Function mapping float to float
+   */
+  void apply_i(std::function<float(float)> f);
+
+  /**
+   * @brief Concatenate multiple tensors along an axis
+   * @param tensors Tensors to concatenate
+   * @param axis Concatenation axis
+   * @return Concatenated tensor
+   */
+  static Tensor cat(const std::vector<Tensor> &tensors, int axis);
+
+  // --- Immediate in-place operations (no lazy chain) ---
+
+  /**
+   * @brief Set all elements to zero
+   */
+  void setZero();
+
+  /**
+   * @brief Fill this tensor with data from another tensor
+   * @param from Source tensor
+   */
+  void fill(const Tensor &from);
+
+  /**
+   * @brief Copy data from another tensor
+   * @param from Source tensor
+   */
+  void copyData(const Tensor &from);
+
+  // --- Convenience dimension accessors ---
+
+  /**
+   * @brief Get total number of elements
+   * @return Total element count
+   */
+  size_t size() const;
+
+  /**
+   * @brief Check if tensor is empty (no elements)
+   * @return true if empty
+   */
+  bool empty() const;
+
+  /**
+   * @brief Get batch dimension
+   */
+  size_t batch() const;
+
+  /**
+   * @brief Get channel dimension
+   */
+  size_t channel() const;
+
+  /**
+   * @brief Get height dimension
+   */
+  size_t height() const;
+
+  /**
+   * @brief Get width dimension
+   */
+  size_t width() const;
 
 private:
-  std::shared_ptr<Layer>
-    src_layer; /**< source layer which create this Tensor */
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+
+  /// Get internal nntrainer::Tensor pointer (throws if not materialized)
+  void *getInternalPtr() const;
+  /// Wrap an internal tensor result into a public Tensor
+  static Tensor wrapResult(const void *internal_tensor);
+
+  friend class LayerHandle;
+  friend class Model;
+};
+
+/**
+ * @class   LayerHandle
+ * @brief   Callable wrapper around a Layer for graph construction.
+ *
+ * Wraps a shared_ptr<Layer> and provides operator() to create symbolic
+ * tensor connections (graph edges). Implicitly constructible from
+ * unique_ptr<Layer> so it works with createLayer() results.
+ *
+ * Usage:
+ *   LayerHandle fc = createLayer("fully_connected", {"unit=256", "name=fc1"});
+ *   auto output = fc(input);
+ */
+class LayerHandle {
+public:
+  LayerHandle() = default;
+
+  /**
+   * @brief Construct from unique_ptr<Layer> (implicit, works with createLayer)
+   */
+  LayerHandle(std::unique_ptr<Layer> p) : ptr_(std::move(p)) {}
+
+  /**
+   * @brief Construct from shared_ptr<Layer>
+   */
+  LayerHandle(std::shared_ptr<Layer> p) : ptr_(std::move(p)) {}
+
+  /**
+   * @brief Implicit conversion to shared_ptr<Layer> for backward compatibility
+   */
+  operator std::shared_ptr<Layer>() const { return ptr_; }
+
+  /**
+   * @brief Access the underlying Layer
+   */
+  Layer *get() const { return ptr_.get(); }
+  Layer &operator*() const { return *ptr_; }
+  Layer *operator->() const { return ptr_.get(); }
+  explicit operator bool() const { return static_cast<bool>(ptr_); }
+
+  /**
+   * @brief Get the underlying shared_ptr
+   */
+  std::shared_ptr<Layer> layer() const { return ptr_; }
+
+  /**
+   * @brief Call the layer with a single input tensor (graph construction)
+   *
+   * Creates a new symbolic output Tensor connected to this layer.
+   *
+   * @param input Input tensor
+   * @return Output tensor with graph edge info
+   */
+  Tensor operator()(const Tensor &input);
+
+  /**
+   * @brief Call the layer with multiple input tensors (graph construction)
+   *
+   * @param inputs Vector of input tensors
+   * @return Output tensor with graph edge info
+   */
+  Tensor operator()(const std::vector<Tensor> &inputs);
+
+private:
+  std::shared_ptr<Layer> ptr_;
 };
 
 } // namespace train

--- a/api/ccapi/meson.build
+++ b/api/ccapi/meson.build
@@ -8,6 +8,10 @@ ccapi_inc_abs = [
 
 ccapi_src = []
 ccapi_src += meson.current_source_dir() / 'src' / 'factory.cpp'
+ccapi_src += meson.current_source_dir() / 'src' / 'tensor_api.cpp'
+ccapi_src += meson.current_source_dir() / 'src' / 'tensor_api_lazy.cpp'
+ccapi_src += meson.current_source_dir() / 'src' / 'tensor_api_ops.cpp'
+ccapi_src += meson.current_source_dir() / 'src' / 'tensor_api_graph.cpp'
 
 ccapi_headers = []
 ccapi_headers += meson.current_source_dir() / 'include' / 'common.h'

--- a/api/ccapi/src/tensor_api.cpp
+++ b/api/ccapi/src/tensor_api.cpp
@@ -12,18 +12,309 @@
  * @note This is experimental API and not stable.
  */
 
-#include <layer.h>
+#include "tensor_api_impl.h"
+
+#include <memory_data.h>
 #include <tensor.h>
-#include <tuple>
-#include <var_grad.h>
+
+#include <cstring>
+#include <stdexcept>
 
 namespace ml {
 namespace train {
 
-Tensor::Tensor(const TensorDim &dim, const iTensor::Initializer init, bool ng,
-               std::string name) :
-  Var_Grad(dim, init, ng, false, name),
-  src_layer(nullptr) {}
+// --- Constructors / Destructor ---
+
+Tensor::Tensor() : impl_(std::make_unique<Impl>()) {}
+
+Tensor::Tensor(const TensorDim &dim, const std::string &name) :
+  impl_(std::make_unique<Impl>(dim, name)) {}
+
+Tensor::~Tensor() = default;
+
+Tensor::Tensor(Tensor &&rhs) noexcept = default;
+
+Tensor &Tensor::operator=(Tensor &&rhs) noexcept = default;
+
+Tensor::Tensor(const Tensor &rhs) :
+  impl_(rhs.impl_ ? std::make_unique<Impl>(*rhs.impl_) : std::make_unique<Impl>()) {}
+
+Tensor &Tensor::operator=(const Tensor &rhs) {
+  if (this != &rhs) {
+    impl_ = rhs.impl_ ? std::make_unique<Impl>(*rhs.impl_) : std::make_unique<Impl>();
+  }
+  return *this;
+}
+
+Tensor Tensor::clone() const {
+  Tensor t;
+  if (impl_) {
+    t.impl_ = std::make_unique<Impl>(*impl_);
+    if (impl_->eager_data && !impl_->external) {
+      t.impl_->eager_data =
+        std::make_shared<nntrainer::Tensor>(impl_->eager_data->clone());
+    }
+  }
+  return t;
+}
+
+// --- Accessors ---
+
+bool Tensor::isValid() const {
+  return impl_ && impl_->valid;
+}
+
+const TensorDim &Tensor::shape() const {
+  if (!impl_ || !impl_->valid) {
+    throw std::runtime_error("Cannot get shape of invalid tensor");
+  }
+  return impl_->dim;
+}
+
+const std::string &Tensor::name() const {
+  if (!impl_ || !impl_->valid) {
+    throw std::runtime_error("Cannot get name of invalid tensor");
+  }
+  return impl_->name;
+}
+
+TensorDim::DataType Tensor::dtype() const {
+  if (!impl_ || !impl_->valid) {
+    throw std::runtime_error("Cannot get dtype of invalid tensor");
+  }
+  return impl_->dim.getDataType();
+}
+
+// --- State queries ---
+
+bool Tensor::isExternal() const {
+  return impl_ && impl_->external;
+}
+
+bool Tensor::isMaterialized() const {
+  return impl_ && (impl_->eager_data != nullptr || impl_->bound_tensor != nullptr);
+}
+
+// --- Data access ---
+
+template <typename T> const T *Tensor::data() const {
+  if (!impl_) {
+    throw std::runtime_error("Tensor is not materialized");
+  }
+  if (impl_->bound_tensor) {
+    return impl_->bound_tensor->getData<T>();
+  }
+  if (!impl_->eager_data) {
+    throw std::runtime_error("Tensor is not materialized");
+  }
+  return impl_->eager_data->getData<T>();
+}
+
+template <typename T> T *Tensor::mutable_data() {
+  if (!impl_) {
+    throw std::runtime_error("Tensor is not materialized");
+  }
+  if (impl_->bound_tensor) {
+    return impl_->bound_tensor->getData<T>();
+  }
+  if (!impl_->eager_data) {
+    throw std::runtime_error("Tensor is not materialized");
+  }
+  return impl_->eager_data->getData<T>();
+}
+
+// Explicit instantiations
+template const float *Tensor::data<float>() const;
+template float *Tensor::mutable_data<float>();
+
+float Tensor::getValue(unsigned int b, unsigned int c, unsigned int h,
+                       unsigned int w) const {
+  if (!impl_) {
+    throw std::runtime_error("Tensor is not materialized");
+  }
+  if (impl_->bound_tensor) {
+    return impl_->bound_tensor->getValue<float>(b, c, h, w);
+  }
+  if (!impl_->eager_data) {
+    throw std::runtime_error("Tensor is not materialized");
+  }
+  return impl_->eager_data->getValue<float>(b, c, h, w);
+}
+
+void Tensor::setValue(unsigned int b, unsigned int c, unsigned int h,
+                      unsigned int w, float value) {
+  if (!impl_) {
+    throw std::runtime_error("Tensor is not materialized");
+  }
+  if (impl_->bound_tensor) {
+    impl_->bound_tensor->setValue(b, c, h, w, value);
+    return;
+  }
+  if (!impl_->eager_data) {
+    throw std::runtime_error("Tensor is not materialized");
+  }
+  impl_->eager_data->setValue(b, c, h, w, value);
+}
+
+void Tensor::copyFrom(const void *src) {
+  if (!src) {
+    throw std::invalid_argument("copyFrom: source pointer must not be null");
+  }
+  if (!impl_) {
+    throw std::runtime_error("Tensor is not materialized");
+  }
+  if (impl_->bound_tensor) {
+    std::memcpy(impl_->bound_tensor->getData(), src,
+                impl_->bound_tensor->bytes());
+    return;
+  }
+  if (!impl_->eager_data) {
+    throw std::runtime_error("Tensor is not materialized");
+  }
+  std::memcpy(impl_->eager_data->getData(), src, impl_->eager_data->bytes());
+}
+
+void Tensor::setData(void *new_ptr) {
+  if (!impl_ || !impl_->external) {
+    throw std::runtime_error("setData: only supported for fromData tensors");
+  }
+  if (!new_ptr) {
+    throw std::invalid_argument("setData: pointer must not be null");
+  }
+  impl_->external_ptr = new_ptr;
+  impl_->eager_data->setData(
+    std::make_shared<nntrainer::MemoryData>(new_ptr), 0, false);
+}
+
+
+// --- Private helpers ---
+
+void *Tensor::getInternalPtr() const {
+  if (!impl_)
+    throw std::runtime_error("Tensor is not materialized");
+  if (impl_->bound_tensor)
+    return impl_->bound_tensor;
+  if (impl_->eager_data)
+    return impl_->eager_data.get();
+  throw std::runtime_error("Tensor is not materialized");
+}
+
+Tensor Tensor::wrapResult(const void *internal_tensor) {
+  const auto &internal =
+    *static_cast<const nntrainer::Tensor *>(internal_tensor);
+  Tensor result;
+  result.impl_->dim = internal.getDim();
+  result.impl_->valid = true;
+  result.impl_->external = false;
+  result.impl_->eager_data =
+    std::make_shared<nntrainer::Tensor>(internal);
+  return result;
+}
+
+
+
+// --- Immediate in-place operations ---
+
+void Tensor::setZero() {
+  asInternal(getInternalPtr())->setZero();
+}
+
+void Tensor::fill(const Tensor &from) {
+  asInternal(getInternalPtr())->fill(
+    *asInternal(from.getInternalPtr()));
+}
+
+void Tensor::copyData(const Tensor &from) {
+  asInternal(getInternalPtr())->copyData(
+    *asInternal(from.getInternalPtr()));
+}
+
+// --- Convenience dimension accessors ---
+
+size_t Tensor::size() const {
+  if (!impl_ || !impl_->valid) {
+    throw std::runtime_error("Cannot get size of invalid tensor");
+  }
+  return impl_->dim.getDataLen();
+}
+
+bool Tensor::empty() const {
+  return !impl_ || !impl_->valid || impl_->dim.getDataLen() == 0;
+}
+
+size_t Tensor::batch() const {
+  return shape().batch();
+}
+
+size_t Tensor::channel() const {
+  return shape().channel();
+}
+
+size_t Tensor::height() const {
+  return shape().height();
+}
+
+size_t Tensor::width() const {
+  return shape().width();
+}
+
+// --- Factory methods ---
+
+Tensor Tensor::fromData(const TensorDim &dim, void *data,
+                        const std::string &name) {
+  if (!data) {
+    throw std::invalid_argument("fromData: data pointer must not be null");
+  }
+  Tensor t;
+  t.impl_->dim = dim;
+  t.impl_->name = name;
+  t.impl_->valid = true;
+  t.impl_->external = true;
+  t.impl_->external_ptr = data;
+  // Create internal tensor structure, then point to external memory (zero-copy)
+  t.impl_->eager_data =
+    std::make_shared<nntrainer::Tensor>(dim, true);
+  t.impl_->eager_data->setData(
+    std::make_shared<nntrainer::MemoryData>(data), 0, false);
+  return t;
+}
+
+Tensor Tensor::zeros(const TensorDim &dim, const std::string &name) {
+  Tensor t;
+  t.impl_->dim = dim;
+  t.impl_->name = name;
+  t.impl_->valid = true;
+  t.impl_->external = false;
+  t.impl_->eager_data =
+    std::make_shared<nntrainer::Tensor>(dim, true, nntrainer::Initializer::ZEROS, name);
+  t.impl_->eager_data->initialize();
+  return t;
+}
+
+Tensor Tensor::ones(const TensorDim &dim, const std::string &name) {
+  Tensor t;
+  t.impl_->dim = dim;
+  t.impl_->name = name;
+  t.impl_->valid = true;
+  t.impl_->external = false;
+  t.impl_->eager_data =
+    std::make_shared<nntrainer::Tensor>(dim, true, nntrainer::Initializer::ONES, name);
+  t.impl_->eager_data->initialize();
+  return t;
+}
+
+// --- Source layer (backward compatible) ---
+
+void Tensor::setSrcLayer(std::shared_ptr<Layer> l) {
+  if (impl_) {
+    impl_->src_layer = l;
+  }
+}
+
+std::shared_ptr<Layer> Tensor::getSrcLayer() const {
+  return impl_ ? impl_->src_layer : nullptr;
+}
 
 } // namespace train
 } // namespace ml
+

--- a/api/ccapi/src/tensor_api.cpp
+++ b/api/ccapi/src/tensor_api.cpp
@@ -37,11 +37,13 @@ Tensor::Tensor(Tensor &&rhs) noexcept = default;
 Tensor &Tensor::operator=(Tensor &&rhs) noexcept = default;
 
 Tensor::Tensor(const Tensor &rhs) :
-  impl_(rhs.impl_ ? std::make_unique<Impl>(*rhs.impl_) : std::make_unique<Impl>()) {}
+  impl_(rhs.impl_ ? std::make_unique<Impl>(*rhs.impl_)
+                  : std::make_unique<Impl>()) {}
 
 Tensor &Tensor::operator=(const Tensor &rhs) {
   if (this != &rhs) {
-    impl_ = rhs.impl_ ? std::make_unique<Impl>(*rhs.impl_) : std::make_unique<Impl>();
+    impl_ =
+      rhs.impl_ ? std::make_unique<Impl>(*rhs.impl_) : std::make_unique<Impl>();
   }
   return *this;
 }
@@ -60,9 +62,7 @@ Tensor Tensor::clone() const {
 
 // --- Accessors ---
 
-bool Tensor::isValid() const {
-  return impl_ && impl_->valid;
-}
+bool Tensor::isValid() const { return impl_ && impl_->valid; }
 
 const TensorDim &Tensor::shape() const {
   if (!impl_ || !impl_->valid) {
@@ -87,12 +87,11 @@ TensorDim::DataType Tensor::dtype() const {
 
 // --- State queries ---
 
-bool Tensor::isExternal() const {
-  return impl_ && impl_->external;
-}
+bool Tensor::isExternal() const { return impl_ && impl_->external; }
 
 bool Tensor::isMaterialized() const {
-  return impl_ && (impl_->eager_data != nullptr || impl_->bound_tensor != nullptr);
+  return impl_ &&
+         (impl_->eager_data != nullptr || impl_->bound_tensor != nullptr);
 }
 
 // --- Data access ---
@@ -182,10 +181,9 @@ void Tensor::setData(void *new_ptr) {
     throw std::invalid_argument("setData: pointer must not be null");
   }
   impl_->external_ptr = new_ptr;
-  impl_->eager_data->setData(
-    std::make_shared<nntrainer::MemoryData>(new_ptr), 0, false);
+  impl_->eager_data->setData(std::make_shared<nntrainer::MemoryData>(new_ptr),
+                             0, false);
 }
-
 
 // --- Private helpers ---
 
@@ -206,27 +204,20 @@ Tensor Tensor::wrapResult(const void *internal_tensor) {
   result.impl_->dim = internal.getDim();
   result.impl_->valid = true;
   result.impl_->external = false;
-  result.impl_->eager_data =
-    std::make_shared<nntrainer::Tensor>(internal);
+  result.impl_->eager_data = std::make_shared<nntrainer::Tensor>(internal);
   return result;
 }
 
-
-
 // --- Immediate in-place operations ---
 
-void Tensor::setZero() {
-  asInternal(getInternalPtr())->setZero();
-}
+void Tensor::setZero() { asInternal(getInternalPtr())->setZero(); }
 
 void Tensor::fill(const Tensor &from) {
-  asInternal(getInternalPtr())->fill(
-    *asInternal(from.getInternalPtr()));
+  asInternal(getInternalPtr())->fill(*asInternal(from.getInternalPtr()));
 }
 
 void Tensor::copyData(const Tensor &from) {
-  asInternal(getInternalPtr())->copyData(
-    *asInternal(from.getInternalPtr()));
+  asInternal(getInternalPtr())->copyData(*asInternal(from.getInternalPtr()));
 }
 
 // --- Convenience dimension accessors ---
@@ -242,21 +233,13 @@ bool Tensor::empty() const {
   return !impl_ || !impl_->valid || impl_->dim.getDataLen() == 0;
 }
 
-size_t Tensor::batch() const {
-  return shape().batch();
-}
+size_t Tensor::batch() const { return shape().batch(); }
 
-size_t Tensor::channel() const {
-  return shape().channel();
-}
+size_t Tensor::channel() const { return shape().channel(); }
 
-size_t Tensor::height() const {
-  return shape().height();
-}
+size_t Tensor::height() const { return shape().height(); }
 
-size_t Tensor::width() const {
-  return shape().width();
-}
+size_t Tensor::width() const { return shape().width(); }
 
 // --- Factory methods ---
 
@@ -272,10 +255,9 @@ Tensor Tensor::fromData(const TensorDim &dim, void *data,
   t.impl_->external = true;
   t.impl_->external_ptr = data;
   // Create internal tensor structure, then point to external memory (zero-copy)
-  t.impl_->eager_data =
-    std::make_shared<nntrainer::Tensor>(dim, true);
-  t.impl_->eager_data->setData(
-    std::make_shared<nntrainer::MemoryData>(data), 0, false);
+  t.impl_->eager_data = std::make_shared<nntrainer::Tensor>(dim, true);
+  t.impl_->eager_data->setData(std::make_shared<nntrainer::MemoryData>(data), 0,
+                               false);
   return t;
 }
 
@@ -285,8 +267,8 @@ Tensor Tensor::zeros(const TensorDim &dim, const std::string &name) {
   t.impl_->name = name;
   t.impl_->valid = true;
   t.impl_->external = false;
-  t.impl_->eager_data =
-    std::make_shared<nntrainer::Tensor>(dim, true, nntrainer::Initializer::ZEROS, name);
+  t.impl_->eager_data = std::make_shared<nntrainer::Tensor>(
+    dim, true, nntrainer::Initializer::ZEROS, name);
   t.impl_->eager_data->initialize();
   return t;
 }
@@ -297,8 +279,8 @@ Tensor Tensor::ones(const TensorDim &dim, const std::string &name) {
   t.impl_->name = name;
   t.impl_->valid = true;
   t.impl_->external = false;
-  t.impl_->eager_data =
-    std::make_shared<nntrainer::Tensor>(dim, true, nntrainer::Initializer::ONES, name);
+  t.impl_->eager_data = std::make_shared<nntrainer::Tensor>(
+    dim, true, nntrainer::Initializer::ONES, name);
   t.impl_->eager_data->initialize();
   return t;
 }
@@ -317,4 +299,3 @@ std::shared_ptr<Layer> Tensor::getSrcLayer() const {
 
 } // namespace train
 } // namespace ml
-

--- a/api/ccapi/src/tensor_api_graph.cpp
+++ b/api/ccapi/src/tensor_api_graph.cpp
@@ -1,0 +1,486 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2023 Jijoong Moon <jijoong.moon@@samsung.com>
+ *
+ * @file   tensor_api_graph.cpp
+ * @date   11 December 2023
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Symbolic graph construction and Model::compile overloads
+ *         for the ml::train::Tensor API
+ *
+ * @note This is experimental API and not stable.
+ */
+
+#include "tensor_api_impl.h"
+
+#include <model.h>
+
+#include <layer_context.h>
+#include <tensor.h>
+
+#include <functional>
+#include <set>
+#include <stdexcept>
+#include <unordered_set>
+
+namespace ml {
+namespace train {
+
+std::shared_ptr<Layer> Tensor::getProducingLayer() const {
+  return (impl_ && impl_->graph_edge) ? impl_->graph_edge->producing_layer
+                                      : nullptr;
+}
+
+Tensor Tensor::output(unsigned int index) const {
+  Tensor result;
+  result.impl_ = std::make_unique<Impl>();
+  result.impl_->valid = true;
+
+  // Create a new graph edge that shares the same producing layer but with index
+  auto indexed_edge = std::make_shared<SymbolicGraphNode>();
+  if (impl_ && impl_->graph_edge) {
+    indexed_edge->producing_layer = impl_->graph_edge->producing_layer;
+    indexed_edge->inputs = impl_->graph_edge->inputs;
+    indexed_edge->dim = impl_->graph_edge->dim;
+    indexed_edge->name = impl_->graph_edge->name;
+  }
+  indexed_edge->output_index = static_cast<int>(index);
+  result.impl_->graph_edge = indexed_edge;
+
+  if (impl_) {
+    result.impl_->src_layer = impl_->src_layer;
+    result.impl_->dim = impl_->dim;
+  }
+
+  return result;
+}
+
+std::vector<Tensor> Tensor::getInputTensors() const {
+  if (!impl_ || !impl_->graph_edge) {
+    return {};
+  }
+  std::vector<Tensor> result;
+  for (auto &edge : impl_->graph_edge->inputs) {
+    Tensor t;
+    t.impl_->graph_edge = edge;
+    if (edge) {
+      t.impl_->dim = edge->dim;
+      t.impl_->name = edge->name;
+      t.impl_->valid = true;
+    }
+    result.push_back(std::move(t));
+  }
+  return result;
+}
+
+// --- Symbolic tensor operations (implicit layers) ---
+
+static unsigned int implicit_layer_counter = 0;
+
+static std::string nextImplicitName(const std::string &prefix) {
+  return prefix + "_auto_" + std::to_string(implicit_layer_counter++);
+}
+
+Tensor Tensor::add(const Tensor &other) const {
+  LayerHandle layer =
+    createLayer("Addition", {"name=" + nextImplicitName("add")});
+  return layer({*this, other});
+}
+
+Tensor Tensor::multiply(const Tensor &other) const {
+  LayerHandle layer =
+    createLayer("Multiply", {"name=" + nextImplicitName("mul")});
+  return layer({*this, other});
+}
+
+Tensor Tensor::reshape(const TensorDim &new_shape) const {
+  std::string target = std::to_string(new_shape.channel()) + ":" +
+                       std::to_string(new_shape.height()) + ":" +
+                       std::to_string(new_shape.width());
+  LayerHandle layer = createLayer(
+    "reshape", {"name=" + nextImplicitName("reshape"),
+                "target_shape=" + target});
+  Tensor output = layer({*this});
+  // Override shape to match requested dimensions
+  output.impl_->dim = TensorDim({shape().batch(), new_shape.channel(),
+                                  new_shape.height(), new_shape.width()});
+  return output;
+}
+
+// --- LayerHandle graph construction ---
+
+/**
+ * @brief Try to infer output dimensions from layer type and properties.
+ *
+ * This is a best-effort inference for common layer types.
+ * Full shape inference happens during model.compile().
+ */
+static TensorDim inferOutputDim(const std::shared_ptr<Layer> &layer,
+                                const std::vector<Tensor> &inputs) {
+  std::string layer_type = layer->getType();
+
+  // Input layer: parse shape from input_shape property
+  if (layer_type == "input") {
+    try {
+      std::string shape_str = layer->getProperty("input_shape");
+      if (!shape_str.empty()) {
+        // Parse "B:C:H:W" or "C:H:W" format
+        std::vector<unsigned int> dims;
+        std::stringstream ss(shape_str);
+        std::string token;
+        while (std::getline(ss, token, ':')) {
+          dims.push_back(static_cast<unsigned int>(std::stoul(token)));
+        }
+        if (dims.size() == 4) {
+          return TensorDim({dims[0], dims[1], dims[2], dims[3]});
+        } else if (dims.size() == 3) {
+          return TensorDim({1, dims[0], dims[1], dims[2]});
+        }
+      }
+    } catch (...) {
+      // Fall through
+    }
+  }
+
+  if (inputs.empty() || !inputs[0].isValid()) {
+    return TensorDim();
+  }
+
+  const TensorDim &in_dim = inputs[0].shape();
+
+  // Fully connected: output = {batch, 1, 1, unit}
+  if (layer_type == "fully_connected") {
+    try {
+      std::string unit_str = layer->getProperty("unit");
+      if (!unit_str.empty()) {
+        unsigned int unit = static_cast<unsigned int>(std::stoul(unit_str));
+        return TensorDim({in_dim.batch(), 1, 1, unit});
+      }
+    } catch (...) {
+      // Fall through to default
+    }
+  }
+
+  // Most layers preserve shape (activation, normalization, dropout, etc.)
+  return in_dim;
+}
+
+Tensor LayerHandle::operator()(const Tensor &input) {
+  return (*this)(std::vector<Tensor>{input});
+}
+
+Tensor LayerHandle::operator()(const std::vector<Tensor> &inputs) {
+  if (!ptr_) {
+    throw std::runtime_error("LayerHandle: layer is null");
+  }
+  if (inputs.empty()) {
+    throw std::invalid_argument("LayerHandle: at least one input required");
+  }
+
+  // Infer output dimensions
+  TensorDim out_dim = inferOutputDim(ptr_, inputs);
+
+  // Build output name from layer name
+  std::string out_name;
+  try {
+    out_name = ptr_->getName();
+    if (!out_name.empty()) {
+      out_name += ":output";
+    }
+  } catch (...) {
+    // getName() might throw if layer isn't fully initialized
+  }
+
+  // Create symbolic output tensor
+  Tensor output;
+  if (out_dim.batch() > 0 && out_dim.width() > 0) {
+    output = Tensor(out_dim, out_name);
+  } else {
+    // Couldn't infer shape — create a valid but shapeless tensor
+    output = Tensor(TensorDim(), out_name);
+  }
+
+  // Record graph edge (shared, no deep copies)
+  auto edge = std::make_shared<SymbolicGraphNode>();
+  edge->producing_layer = ptr_;
+  edge->dim = out_dim;
+  edge->name = out_name;
+  for (auto &inp : inputs) {
+    if (inp.impl_ && inp.impl_->graph_edge) {
+      edge->inputs.push_back(inp.impl_->graph_edge);
+    } else {
+      // Leaf tensor — create a leaf edge with no producer
+      auto leaf = std::make_shared<SymbolicGraphNode>();
+      if (inp.isValid()) {
+        leaf->dim = inp.shape();
+        leaf->name = inp.name();
+      }
+      edge->inputs.push_back(leaf);
+    }
+  }
+  output.impl_->graph_edge = edge;
+
+  return output;
+}
+
+// --- Model::compile(Tensor, Tensor) — graph extraction ---
+
+int Model::compile(Tensor &input, Tensor &output, ExecutionMode mode) {
+  std::vector<Tensor> inputs = {input};
+  std::vector<Tensor> outputs = {output};
+  int status = compile(inputs, outputs, mode);
+  input = inputs[0];
+  output = outputs[0];
+  return status;
+}
+
+int Model::compile(Tensor &input, std::vector<Tensor> &outputs,
+                   ExecutionMode mode) {
+  std::vector<Tensor> inputs = {input};
+  int status = compile(inputs, outputs, mode);
+  input = inputs[0];
+  return status;
+}
+
+int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
+                   ExecutionMode mode) {
+  struct LayerInfo {
+    std::shared_ptr<Layer> layer;
+    std::vector<std::string> input_layer_names;
+  };
+
+  std::vector<LayerInfo> layers_in_order;
+  std::unordered_set<Layer *> visited;
+
+  // Collect input leaf names
+  std::set<std::string> input_leaf_names;
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    std::string name = inputs[i].name();
+    if (name.empty()) {
+      name = (inputs.size() == 1) ? "graph_input"
+                                  : "graph_input_" + std::to_string(i);
+    }
+    input_leaf_names.insert(name);
+  }
+
+  // Track additional leaf tensors (e.g., fromData external caches)
+  struct LeafInfo {
+    TensorDim dim;
+  };
+  std::map<std::string, LeafInfo> additional_leaves;
+  int unnamed_leaf_counter = 0;
+
+  // DFS on SymbolicGraphNode (post-order = topological order)
+  std::function<void(const std::shared_ptr<SymbolicGraphNode> &)> dfs =
+    [&](const std::shared_ptr<SymbolicGraphNode> &edge) {
+      if (!edge || !edge->producing_layer) {
+        return; // leaf
+      }
+      if (visited.count(edge->producing_layer.get())) {
+        return;
+      }
+      visited.insert(edge->producing_layer.get());
+
+      for (auto &inp : edge->inputs) {
+        dfs(inp);
+      }
+
+      // Build input_layers names
+      std::vector<std::string> input_names;
+      for (auto &inp : edge->inputs) {
+        if (inp && inp->producing_layer) {
+          std::string layer_ref = inp->producing_layer->getName();
+          if (inp->output_index >= 0) {
+            layer_ref += "(" + std::to_string(inp->output_index) + ")";
+          }
+          input_names.push_back(layer_ref);
+        } else {
+          // Leaf tensor
+          std::string leaf_name = inp ? inp->name : "";
+          if (leaf_name.empty()) {
+            // Empty leaf from Tensor() — this is the sentinel input to an
+            // input layer. Check if the current edge's producing layer is an
+            // input layer; if so, skip this leaf entirely since the input
+            // layer itself serves as the graph entry point (no input_layers).
+            if (edge->producing_layer) {
+              try {
+                if (edge->producing_layer->getType() == "input") {
+                  // Input layer's sentinel leaf — skip, no input_layers needed
+                  continue;
+                }
+              } catch (...) {}
+            }
+            leaf_name = "ext_input_" + std::to_string(unnamed_leaf_counter++);
+          }
+          if (input_leaf_names.count(leaf_name)) {
+            input_names.push_back(leaf_name);
+          } else {
+            if (additional_leaves.find(leaf_name) == additional_leaves.end()) {
+              additional_leaves[leaf_name] = {inp ? inp->dim : TensorDim()};
+            }
+            input_names.push_back(leaf_name);
+          }
+        }
+      }
+
+      layers_in_order.push_back({edge->producing_layer, input_names});
+    };
+
+  // Walk backwards from each output
+  for (auto &output : outputs) {
+    if (output.impl_ && output.impl_->graph_edge) {
+      dfs(output.impl_->graph_edge);
+    }
+  }
+
+  // 1. Create and add input layers (skip if already in DFS-discovered graph)
+  //    When constructModel() already creates input layers via
+  //    LayerHandle(createLayer("input",...)), the DFS walk will have found
+  //    them. In that case, skip creating duplicate input layers.
+  std::set<std::string> discovered_layer_names;
+  for (auto &li : layers_in_order) {
+    try {
+      discovered_layer_names.insert(li.layer->getName());
+    } catch (...) {}
+  }
+
+  int status;
+  for (auto &inp : inputs) {
+    std::string inp_name = inp.name();
+    if (inp_name.empty()) {
+      inp_name =
+        (inputs.size() == 1)
+          ? "graph_input"
+          : "graph_input_" + std::to_string(&inp - &inputs[0]);
+    }
+
+    // If this input's producing layer was already discovered by DFS, skip
+    if (inp.impl_ && inp.impl_->graph_edge &&
+        inp.impl_->graph_edge->producing_layer) {
+      std::string prod_name;
+      try {
+        prod_name = inp.impl_->graph_edge->producing_layer->getName();
+      } catch (...) {}
+      if (!prod_name.empty() && discovered_layer_names.count(prod_name)) {
+        continue;  // Input layer already in the graph
+      }
+    }
+
+    // Also skip if a layer with the same name was already discovered
+    // (handles the case where inp_name matches an output name like "input0:output")
+    bool already_has_input = false;
+    for (auto &li : layers_in_order) {
+      try {
+        if (li.layer->getType() == "input" &&
+            li.layer->getName() == inp_name) {
+          already_has_input = true;
+          break;
+        }
+      } catch (...) {}
+    }
+    if (already_has_input) continue;
+
+    if (!inp.isValid()) continue;  // skip invalid tensors
+
+    const TensorDim &dim = inp.shape();
+    std::string shape_str = std::to_string(dim.channel()) + ":" +
+                             std::to_string(dim.height()) + ":" +
+                             std::to_string(dim.width());
+    auto input_layer = createLayer(
+      "input", {"name=" + inp_name, "input_shape=" + shape_str});
+    status = addLayer(std::move(input_layer));
+    if (status != ML_ERROR_NONE) {
+      return status;
+    }
+  }
+
+  // 1b. Create input layers for additional leaf tensors
+  for (auto &[leaf_name, leaf_info] : additional_leaves) {
+    std::string leaf_shape = std::to_string(leaf_info.dim.channel()) + ":" +
+                              std::to_string(leaf_info.dim.height()) + ":" +
+                              std::to_string(leaf_info.dim.width());
+    auto leaf_layer = createLayer(
+      "input", {"name=" + leaf_name, "input_shape=" + leaf_shape});
+    status = addLayer(std::move(leaf_layer));
+    if (status != ML_ERROR_NONE) {
+      return status;
+    }
+  }
+
+  // 2. Add each layer in topological order with input_layers set
+  for (auto &info : layers_in_order) {
+    if (!info.input_layer_names.empty()) {
+      std::string input_layers_str;
+      for (size_t i = 0; i < info.input_layer_names.size(); ++i) {
+        if (i > 0)
+          input_layers_str += ",";
+        input_layers_str += info.input_layer_names[i];
+      }
+      info.layer->setProperty({"input_layers=" + input_layers_str});
+    }
+    status = addLayer(info.layer);
+    if (status != ML_ERROR_NONE) {
+      return status;
+    }
+  }
+
+  // 3. Compile the model
+  status = compile(mode);
+  if (status != ML_ERROR_NONE) {
+    return status;
+  }
+
+  // 4. Initialize the model
+  status = initialize(mode);
+  if (status != ML_ERROR_NONE) {
+    return status;
+  }
+
+  // 5. Allocate tensor memory
+  status = allocate(mode);
+  if (status != ML_ERROR_NONE) {
+    return status;
+  }
+
+  // 6. Materialize API tensors with allocated buffers
+  for (auto &inp : inputs) {
+    std::string inp_name = inp.name();
+    if (inp_name.empty()) {
+      inp_name =
+        (inputs.size() == 1)
+          ? "graph_input"
+          : "graph_input_" + std::to_string(&inp - &inputs[0]);
+    }
+    const TensorDim &in_dim = inp.shape();
+    inp.impl_->eager_data = std::make_shared<nntrainer::Tensor>(
+      in_dim, true, nntrainer::Initializer::ZEROS, inp_name);
+    inp.impl_->eager_data->initialize();
+  }
+  for (auto &output : outputs) {
+    auto output_producer = output.getProducingLayer();
+    if (!output_producer)
+      continue;
+    std::string output_layer_name = output_producer->getName();
+    TensorDim out_dim;
+    forEachLayer(
+      [&](Layer &layer, nntrainer::RunLayerContext &rc, void *) {
+        if (layer.getName() == output_layer_name && rc.getNumOutputs() > 0) {
+          out_dim = rc.getOutput(0).getDim();
+        }
+      },
+      nullptr);
+    if (out_dim.getDataLen() > 0) {
+      output.impl_->eager_data = std::make_shared<nntrainer::Tensor>(
+        out_dim, true, nntrainer::Initializer::ZEROS, output_layer_name);
+      output.impl_->eager_data->initialize();
+      output.impl_->dim = out_dim;
+    }
+  }
+
+  return ML_ERROR_NONE;
+}
+
+} // namespace train
+} // namespace ml

--- a/api/ccapi/src/tensor_api_graph.cpp
+++ b/api/ccapi/src/tensor_api_graph.cpp
@@ -99,13 +99,13 @@ Tensor Tensor::reshape(const TensorDim &new_shape) const {
   std::string target = std::to_string(new_shape.channel()) + ":" +
                        std::to_string(new_shape.height()) + ":" +
                        std::to_string(new_shape.width());
-  LayerHandle layer = createLayer(
-    "reshape", {"name=" + nextImplicitName("reshape"),
-                "target_shape=" + target});
+  LayerHandle layer =
+    createLayer("reshape", {"name=" + nextImplicitName("reshape"),
+                            "target_shape=" + target});
   Tensor output = layer({*this});
   // Override shape to match requested dimensions
   output.impl_->dim = TensorDim({shape().batch(), new_shape.channel(),
-                                  new_shape.height(), new_shape.width()});
+                                 new_shape.height(), new_shape.width()});
   return output;
 }
 
@@ -310,7 +310,8 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
                   // Input layer's sentinel leaf — skip, no input_layers needed
                   continue;
                 }
-              } catch (...) {}
+              } catch (...) {
+              }
             }
             leaf_name = "ext_input_" + std::to_string(unnamed_leaf_counter++);
           }
@@ -343,17 +344,17 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
   for (auto &li : layers_in_order) {
     try {
       discovered_layer_names.insert(li.layer->getName());
-    } catch (...) {}
+    } catch (...) {
+    }
   }
 
   int status;
   for (auto &inp : inputs) {
     std::string inp_name = inp.name();
     if (inp_name.empty()) {
-      inp_name =
-        (inputs.size() == 1)
-          ? "graph_input"
-          : "graph_input_" + std::to_string(&inp - &inputs[0]);
+      inp_name = (inputs.size() == 1)
+                   ? "graph_input"
+                   : "graph_input_" + std::to_string(&inp - &inputs[0]);
     }
 
     // If this input's producing layer was already discovered by DFS, skip
@@ -362,34 +363,38 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
       std::string prod_name;
       try {
         prod_name = inp.impl_->graph_edge->producing_layer->getName();
-      } catch (...) {}
+      } catch (...) {
+      }
       if (!prod_name.empty() && discovered_layer_names.count(prod_name)) {
-        continue;  // Input layer already in the graph
+        continue; // Input layer already in the graph
       }
     }
 
     // Also skip if a layer with the same name was already discovered
-    // (handles the case where inp_name matches an output name like "input0:output")
+    // (handles the case where inp_name matches an output name like
+    // "input0:output")
     bool already_has_input = false;
     for (auto &li : layers_in_order) {
       try {
-        if (li.layer->getType() == "input" &&
-            li.layer->getName() == inp_name) {
+        if (li.layer->getType() == "input" && li.layer->getName() == inp_name) {
           already_has_input = true;
           break;
         }
-      } catch (...) {}
+      } catch (...) {
+      }
     }
-    if (already_has_input) continue;
+    if (already_has_input)
+      continue;
 
-    if (!inp.isValid()) continue;  // skip invalid tensors
+    if (!inp.isValid())
+      continue; // skip invalid tensors
 
     const TensorDim &dim = inp.shape();
     std::string shape_str = std::to_string(dim.channel()) + ":" +
-                             std::to_string(dim.height()) + ":" +
-                             std::to_string(dim.width());
-    auto input_layer = createLayer(
-      "input", {"name=" + inp_name, "input_shape=" + shape_str});
+                            std::to_string(dim.height()) + ":" +
+                            std::to_string(dim.width());
+    auto input_layer =
+      createLayer("input", {"name=" + inp_name, "input_shape=" + shape_str});
     status = addLayer(std::move(input_layer));
     if (status != ML_ERROR_NONE) {
       return status;
@@ -399,10 +404,10 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
   // 1b. Create input layers for additional leaf tensors
   for (auto &[leaf_name, leaf_info] : additional_leaves) {
     std::string leaf_shape = std::to_string(leaf_info.dim.channel()) + ":" +
-                              std::to_string(leaf_info.dim.height()) + ":" +
-                              std::to_string(leaf_info.dim.width());
-    auto leaf_layer = createLayer(
-      "input", {"name=" + leaf_name, "input_shape=" + leaf_shape});
+                             std::to_string(leaf_info.dim.height()) + ":" +
+                             std::to_string(leaf_info.dim.width());
+    auto leaf_layer =
+      createLayer("input", {"name=" + leaf_name, "input_shape=" + leaf_shape});
     status = addLayer(std::move(leaf_layer));
     if (status != ML_ERROR_NONE) {
       return status;
@@ -448,10 +453,9 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
   for (auto &inp : inputs) {
     std::string inp_name = inp.name();
     if (inp_name.empty()) {
-      inp_name =
-        (inputs.size() == 1)
-          ? "graph_input"
-          : "graph_input_" + std::to_string(&inp - &inputs[0]);
+      inp_name = (inputs.size() == 1)
+                   ? "graph_input"
+                   : "graph_input_" + std::to_string(&inp - &inputs[0]);
     }
     const TensorDim &in_dim = inp.shape();
     inp.impl_->eager_data = std::make_shared<nntrainer::Tensor>(

--- a/api/ccapi/src/tensor_api_graph.cpp
+++ b/api/ccapi/src/tensor_api_graph.cpp
@@ -467,11 +467,19 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
     if (!output_producer)
       continue;
     std::string output_layer_name = output_producer->getName();
+    // Respect the per-output index chosen by Tensor::output(i). For tensors
+    // produced by calling the layer directly (non-indexed), the index stays
+    // at -1 and we fall back to output 0.
+    int out_idx = (output.impl_ && output.impl_->graph_edge &&
+                   output.impl_->graph_edge->output_index >= 0)
+                    ? output.impl_->graph_edge->output_index
+                    : 0;
     TensorDim out_dim;
     forEachLayer(
       [&](Layer &layer, nntrainer::RunLayerContext &rc, void *) {
-        if (layer.getName() == output_layer_name && rc.getNumOutputs() > 0) {
-          out_dim = rc.getOutput(0).getDim();
+        if (layer.getName() == output_layer_name &&
+            rc.getNumOutputs() > static_cast<unsigned int>(out_idx)) {
+          out_dim = rc.getOutput(out_idx).getDim();
         }
       },
       nullptr);

--- a/api/ccapi/src/tensor_api_impl.h
+++ b/api/ccapi/src/tensor_api_impl.h
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2023 Jijoong Moon <jijoong.moon@@samsung.com>
+ *
+ * @file   tensor_api_impl.h
+ * @date   11 December 2023
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Private implementation types shared across tensor_api_*.cpp
+ *
+ * @note This header is NOT installed. It is consumed only by the translation
+ *       units that split the Tensor API implementation.
+ */
+
+#ifndef __ML_TRAIN_TENSOR_API_IMPL_H__
+#define __ML_TRAIN_TENSOR_API_IMPL_H__
+
+#include <tensor_api.h>
+
+#include <tensor.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ml {
+namespace train {
+
+/**
+ * @brief Lightweight graph node for API-level symbolic graph construction.
+ *
+ * Unlike the internal GraphNode (used for execution with LayerNode),
+ * this only holds connection info needed to build the graph before
+ * model.compile(). Stored as shared_ptr so Tensor copies share graph
+ * structure without recursive deep copies (O(N!) memory explosion).
+ */
+struct SymbolicGraphNode {
+  std::shared_ptr<Layer> producing_layer;
+  std::vector<std::shared_ptr<SymbolicGraphNode>> inputs;
+  TensorDim dim;
+  std::string name;
+  int output_index = -1; ///< >=0 means indexed output, e.g. split(0)
+};
+
+/**
+ * @brief Internal implementation of Tensor
+ */
+struct Tensor::Impl {
+  TensorDim dim;
+  std::string name;
+  bool valid = false;
+  bool external = false;
+
+  std::shared_ptr<nntrainer::Tensor> eager_data;
+  void *external_ptr = nullptr;
+
+  std::shared_ptr<Layer> src_layer;
+
+  // Graph edge (shared_ptr to avoid O(N!) deep-copy on Tensor copy)
+  std::shared_ptr<SymbolicGraphNode> graph_edge;
+
+  // Bound internal tensor (set after model compile+initialize)
+  nntrainer::Tensor *bound_tensor = nullptr;
+
+  // Lazy operation chain
+  std::vector<std::function<void(nntrainer::Tensor &)>> call_chain;
+
+  Impl() = default;
+
+  Impl(const TensorDim &d, const std::string &n) :
+    dim(d), name(n), valid(true) {}
+};
+
+/**
+ * @brief Cast a void pointer from Tensor::getInternalPtr() to the
+ *        internal nntrainer::Tensor pointer.
+ */
+inline nntrainer::Tensor *asInternal(void *ptr) {
+  return static_cast<nntrainer::Tensor *>(ptr);
+}
+
+} // namespace train
+} // namespace ml
+
+#endif // __ML_TRAIN_TENSOR_API_IMPL_H__

--- a/api/ccapi/src/tensor_api_lazy.cpp
+++ b/api/ccapi/src/tensor_api_lazy.cpp
@@ -43,15 +43,14 @@ Tensor &Tensor::add_i(const Tensor &other, float alpha) {
     throw std::runtime_error("Cannot add_i on invalid tensor");
   }
   auto other_impl = other.impl_.get();
-  impl_->call_chain.push_back(
-    [other_impl, alpha](nntrainer::Tensor &t) {
-      nntrainer::Tensor *src = other_impl->bound_tensor
-                                 ? other_impl->bound_tensor
-                                 : other_impl->eager_data.get();
-      if (!src)
-        throw std::runtime_error("add_i: other tensor not materialized");
-      t.add_i(*src, alpha);
-    });
+  impl_->call_chain.push_back([other_impl, alpha](nntrainer::Tensor &t) {
+    nntrainer::Tensor *src = other_impl->bound_tensor
+                               ? other_impl->bound_tensor
+                               : other_impl->eager_data.get();
+    if (!src)
+      throw std::runtime_error("add_i: other tensor not materialized");
+    t.add_i(*src, alpha);
+  });
   return *this;
 }
 
@@ -69,15 +68,14 @@ Tensor &Tensor::subtract_i(const Tensor &other) {
     throw std::runtime_error("Cannot subtract_i on invalid tensor");
   }
   auto other_impl = other.impl_.get();
-  impl_->call_chain.push_back(
-    [other_impl](nntrainer::Tensor &t) {
-      nntrainer::Tensor *src = other_impl->bound_tensor
-                                 ? other_impl->bound_tensor
-                                 : other_impl->eager_data.get();
-      if (!src)
-        throw std::runtime_error("subtract_i: other tensor not materialized");
-      t.subtract_i(*src);
-    });
+  impl_->call_chain.push_back([other_impl](nntrainer::Tensor &t) {
+    nntrainer::Tensor *src = other_impl->bound_tensor
+                               ? other_impl->bound_tensor
+                               : other_impl->eager_data.get();
+    if (!src)
+      throw std::runtime_error("subtract_i: other tensor not materialized");
+    t.subtract_i(*src);
+  });
   return *this;
 }
 
@@ -95,15 +93,14 @@ Tensor &Tensor::multiply_i(const Tensor &other) {
     throw std::runtime_error("Cannot multiply_i on invalid tensor");
   }
   auto other_impl = other.impl_.get();
-  impl_->call_chain.push_back(
-    [other_impl](nntrainer::Tensor &t) {
-      nntrainer::Tensor *src = other_impl->bound_tensor
-                                 ? other_impl->bound_tensor
-                                 : other_impl->eager_data.get();
-      if (!src)
-        throw std::runtime_error("multiply_i: other tensor not materialized");
-      t.multiply_i(*src);
-    });
+  impl_->call_chain.push_back([other_impl](nntrainer::Tensor &t) {
+    nntrainer::Tensor *src = other_impl->bound_tensor
+                               ? other_impl->bound_tensor
+                               : other_impl->eager_data.get();
+    if (!src)
+      throw std::runtime_error("multiply_i: other tensor not materialized");
+    t.multiply_i(*src);
+  });
   return *this;
 }
 
@@ -121,15 +118,14 @@ Tensor &Tensor::divide_i(const Tensor &other) {
     throw std::runtime_error("Cannot divide_i on invalid tensor");
   }
   auto other_impl = other.impl_.get();
-  impl_->call_chain.push_back(
-    [other_impl](nntrainer::Tensor &t) {
-      nntrainer::Tensor *src = other_impl->bound_tensor
-                                 ? other_impl->bound_tensor
-                                 : other_impl->eager_data.get();
-      if (!src)
-        throw std::runtime_error("divide_i: other tensor not materialized");
-      t.divide_i(*src);
-    });
+  impl_->call_chain.push_back([other_impl](nntrainer::Tensor &t) {
+    nntrainer::Tensor *src = other_impl->bound_tensor
+                               ? other_impl->bound_tensor
+                               : other_impl->eager_data.get();
+    if (!src)
+      throw std::runtime_error("divide_i: other tensor not materialized");
+    t.divide_i(*src);
+  });
   return *this;
 }
 
@@ -146,19 +142,16 @@ Tensor &Tensor::inv_sqrt_i() {
   if (!impl_) {
     throw std::runtime_error("Cannot inv_sqrt_i on invalid tensor");
   }
-  impl_->call_chain.push_back(
-    [](nntrainer::Tensor &t) { t.inv_sqrt_i(); });
+  impl_->call_chain.push_back([](nntrainer::Tensor &t) { t.inv_sqrt_i(); });
   return *this;
 }
 
 Tensor &Tensor::eval() {
   if (!impl_ || !isMaterialized()) {
-    throw std::runtime_error(
-      "Cannot eval: tensor is not materialized");
+    throw std::runtime_error("Cannot eval: tensor is not materialized");
   }
-  nntrainer::Tensor *target = impl_->bound_tensor
-                                ? impl_->bound_tensor
-                                : impl_->eager_data.get();
+  nntrainer::Tensor *target =
+    impl_->bound_tensor ? impl_->bound_tensor : impl_->eager_data.get();
   for (auto &op : impl_->call_chain) {
     op(*target);
   }

--- a/api/ccapi/src/tensor_api_lazy.cpp
+++ b/api/ccapi/src/tensor_api_lazy.cpp
@@ -42,11 +42,13 @@ Tensor &Tensor::add_i(const Tensor &other, float alpha) {
   if (!impl_) {
     throw std::runtime_error("Cannot add_i on invalid tensor");
   }
-  auto other_impl = other.impl_.get();
-  impl_->call_chain.push_back([other_impl, alpha](nntrainer::Tensor &t) {
-    nntrainer::Tensor *src = other_impl->bound_tensor
-                               ? other_impl->bound_tensor
-                               : other_impl->eager_data.get();
+  // Capture `other` by value so the lambda keeps its Impl (and the
+  // shared_ptr<nntrainer::Tensor> eager_data it owns) alive even if
+  // the caller-side Tensor goes out of scope before eval().
+  impl_->call_chain.push_back([other, alpha](nntrainer::Tensor &t) {
+    const auto *oi = other.impl_.get();
+    nntrainer::Tensor *src =
+      oi->bound_tensor ? oi->bound_tensor : oi->eager_data.get();
     if (!src)
       throw std::runtime_error("add_i: other tensor not materialized");
     t.add_i(*src, alpha);
@@ -67,11 +69,10 @@ Tensor &Tensor::subtract_i(const Tensor &other) {
   if (!impl_) {
     throw std::runtime_error("Cannot subtract_i on invalid tensor");
   }
-  auto other_impl = other.impl_.get();
-  impl_->call_chain.push_back([other_impl](nntrainer::Tensor &t) {
-    nntrainer::Tensor *src = other_impl->bound_tensor
-                               ? other_impl->bound_tensor
-                               : other_impl->eager_data.get();
+  impl_->call_chain.push_back([other](nntrainer::Tensor &t) {
+    const auto *oi = other.impl_.get();
+    nntrainer::Tensor *src =
+      oi->bound_tensor ? oi->bound_tensor : oi->eager_data.get();
     if (!src)
       throw std::runtime_error("subtract_i: other tensor not materialized");
     t.subtract_i(*src);
@@ -92,11 +93,10 @@ Tensor &Tensor::multiply_i(const Tensor &other) {
   if (!impl_) {
     throw std::runtime_error("Cannot multiply_i on invalid tensor");
   }
-  auto other_impl = other.impl_.get();
-  impl_->call_chain.push_back([other_impl](nntrainer::Tensor &t) {
-    nntrainer::Tensor *src = other_impl->bound_tensor
-                               ? other_impl->bound_tensor
-                               : other_impl->eager_data.get();
+  impl_->call_chain.push_back([other](nntrainer::Tensor &t) {
+    const auto *oi = other.impl_.get();
+    nntrainer::Tensor *src =
+      oi->bound_tensor ? oi->bound_tensor : oi->eager_data.get();
     if (!src)
       throw std::runtime_error("multiply_i: other tensor not materialized");
     t.multiply_i(*src);
@@ -117,11 +117,10 @@ Tensor &Tensor::divide_i(const Tensor &other) {
   if (!impl_) {
     throw std::runtime_error("Cannot divide_i on invalid tensor");
   }
-  auto other_impl = other.impl_.get();
-  impl_->call_chain.push_back([other_impl](nntrainer::Tensor &t) {
-    nntrainer::Tensor *src = other_impl->bound_tensor
-                               ? other_impl->bound_tensor
-                               : other_impl->eager_data.get();
+  impl_->call_chain.push_back([other](nntrainer::Tensor &t) {
+    const auto *oi = other.impl_.get();
+    nntrainer::Tensor *src =
+      oi->bound_tensor ? oi->bound_tensor : oi->eager_data.get();
     if (!src)
       throw std::runtime_error("divide_i: other tensor not materialized");
     t.divide_i(*src);

--- a/api/ccapi/src/tensor_api_lazy.cpp
+++ b/api/ccapi/src/tensor_api_lazy.cpp
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2023 Jijoong Moon <jijoong.moon@@samsung.com>
+ *
+ * @file   tensor_api_lazy.cpp
+ * @date   11 December 2023
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Lazy operation chaining for ml::train::Tensor
+ *
+ * @note This is experimental API and not stable.
+ */
+
+#include "tensor_api_impl.h"
+
+#include <tensor.h>
+
+#include <stdexcept>
+
+namespace ml {
+namespace train {
+
+Tensor &Tensor::chain() {
+  if (!impl_) {
+    throw std::runtime_error("Cannot chain on invalid tensor");
+  }
+  impl_->call_chain.clear();
+  return *this;
+}
+
+Tensor &Tensor::add_i(float value) {
+  if (!impl_) {
+    throw std::runtime_error("Cannot add_i on invalid tensor");
+  }
+  impl_->call_chain.push_back(
+    [value](nntrainer::Tensor &t) { t.add_i(value); });
+  return *this;
+}
+
+Tensor &Tensor::add_i(const Tensor &other, float alpha) {
+  if (!impl_) {
+    throw std::runtime_error("Cannot add_i on invalid tensor");
+  }
+  auto other_impl = other.impl_.get();
+  impl_->call_chain.push_back(
+    [other_impl, alpha](nntrainer::Tensor &t) {
+      nntrainer::Tensor *src = other_impl->bound_tensor
+                                 ? other_impl->bound_tensor
+                                 : other_impl->eager_data.get();
+      if (!src)
+        throw std::runtime_error("add_i: other tensor not materialized");
+      t.add_i(*src, alpha);
+    });
+  return *this;
+}
+
+Tensor &Tensor::subtract_i(float value) {
+  if (!impl_) {
+    throw std::runtime_error("Cannot subtract_i on invalid tensor");
+  }
+  impl_->call_chain.push_back(
+    [value](nntrainer::Tensor &t) { t.subtract_i(value); });
+  return *this;
+}
+
+Tensor &Tensor::subtract_i(const Tensor &other) {
+  if (!impl_) {
+    throw std::runtime_error("Cannot subtract_i on invalid tensor");
+  }
+  auto other_impl = other.impl_.get();
+  impl_->call_chain.push_back(
+    [other_impl](nntrainer::Tensor &t) {
+      nntrainer::Tensor *src = other_impl->bound_tensor
+                                 ? other_impl->bound_tensor
+                                 : other_impl->eager_data.get();
+      if (!src)
+        throw std::runtime_error("subtract_i: other tensor not materialized");
+      t.subtract_i(*src);
+    });
+  return *this;
+}
+
+Tensor &Tensor::multiply_i(float value) {
+  if (!impl_) {
+    throw std::runtime_error("Cannot multiply_i on invalid tensor");
+  }
+  impl_->call_chain.push_back(
+    [value](nntrainer::Tensor &t) { t.multiply_i(value); });
+  return *this;
+}
+
+Tensor &Tensor::multiply_i(const Tensor &other) {
+  if (!impl_) {
+    throw std::runtime_error("Cannot multiply_i on invalid tensor");
+  }
+  auto other_impl = other.impl_.get();
+  impl_->call_chain.push_back(
+    [other_impl](nntrainer::Tensor &t) {
+      nntrainer::Tensor *src = other_impl->bound_tensor
+                                 ? other_impl->bound_tensor
+                                 : other_impl->eager_data.get();
+      if (!src)
+        throw std::runtime_error("multiply_i: other tensor not materialized");
+      t.multiply_i(*src);
+    });
+  return *this;
+}
+
+Tensor &Tensor::divide_i(float value) {
+  if (!impl_) {
+    throw std::runtime_error("Cannot divide_i on invalid tensor");
+  }
+  impl_->call_chain.push_back(
+    [value](nntrainer::Tensor &t) { t.divide_i(value); });
+  return *this;
+}
+
+Tensor &Tensor::divide_i(const Tensor &other) {
+  if (!impl_) {
+    throw std::runtime_error("Cannot divide_i on invalid tensor");
+  }
+  auto other_impl = other.impl_.get();
+  impl_->call_chain.push_back(
+    [other_impl](nntrainer::Tensor &t) {
+      nntrainer::Tensor *src = other_impl->bound_tensor
+                                 ? other_impl->bound_tensor
+                                 : other_impl->eager_data.get();
+      if (!src)
+        throw std::runtime_error("divide_i: other tensor not materialized");
+      t.divide_i(*src);
+    });
+  return *this;
+}
+
+Tensor &Tensor::pow_i(float exponent) {
+  if (!impl_) {
+    throw std::runtime_error("Cannot pow_i on invalid tensor");
+  }
+  impl_->call_chain.push_back(
+    [exponent](nntrainer::Tensor &t) { t.pow_i(exponent); });
+  return *this;
+}
+
+Tensor &Tensor::inv_sqrt_i() {
+  if (!impl_) {
+    throw std::runtime_error("Cannot inv_sqrt_i on invalid tensor");
+  }
+  impl_->call_chain.push_back(
+    [](nntrainer::Tensor &t) { t.inv_sqrt_i(); });
+  return *this;
+}
+
+Tensor &Tensor::eval() {
+  if (!impl_ || !isMaterialized()) {
+    throw std::runtime_error(
+      "Cannot eval: tensor is not materialized");
+  }
+  nntrainer::Tensor *target = impl_->bound_tensor
+                                ? impl_->bound_tensor
+                                : impl_->eager_data.get();
+  for (auto &op : impl_->call_chain) {
+    op(*target);
+  }
+  impl_->call_chain.clear();
+  return *this;
+}
+
+} // namespace train
+} // namespace ml

--- a/api/ccapi/src/tensor_api_ops.cpp
+++ b/api/ccapi/src/tensor_api_ops.cpp
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2023 Jijoong Moon <jijoong.moon@@samsung.com>
+ *
+ * @file   tensor_api_ops.cpp
+ * @date   11 December 2023
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Eager numeric operations for ml::train::Tensor
+ *
+ * @note This is experimental API and not stable.
+ */
+
+#include "tensor_api_impl.h"
+
+#include <tensor.h>
+
+#include <cstring>
+#include <functional>
+#include <stdexcept>
+
+namespace ml {
+namespace train {
+
+Tensor Tensor::add(float value) const {
+  auto r = asInternal(getInternalPtr())->add(value);
+  return wrapResult(&r);
+}
+
+Tensor Tensor::subtract(float value) const {
+  auto r = asInternal(getInternalPtr())->subtract(value);
+  return wrapResult(&r);
+}
+
+Tensor Tensor::subtract(const Tensor &other) const {
+  auto r = asInternal(getInternalPtr())->subtract(
+    *asInternal(other.getInternalPtr()));
+  return wrapResult(&r);
+}
+
+Tensor Tensor::multiply(float value) const {
+  auto r = asInternal(getInternalPtr())->multiply(value);
+  return wrapResult(&r);
+}
+
+Tensor Tensor::divide(float value) const {
+  auto r = asInternal(getInternalPtr())->divide(value);
+  return wrapResult(&r);
+}
+
+Tensor Tensor::divide(const Tensor &other) const {
+  auto r = asInternal(getInternalPtr())->divide(
+    *asInternal(other.getInternalPtr()));
+  return wrapResult(&r);
+}
+
+Tensor Tensor::dot(const Tensor &other, bool trans, bool trans_in) const {
+  auto r = asInternal(getInternalPtr())->dot(
+    *asInternal(other.getInternalPtr()), trans, trans_in);
+  return wrapResult(&r);
+}
+
+Tensor Tensor::transpose(const std::string &direction) const {
+  auto r = asInternal(getInternalPtr())->transpose(direction);
+  return wrapResult(&r);
+}
+
+Tensor Tensor::pow(float exponent) const {
+  auto r = asInternal(getInternalPtr())->pow(exponent);
+  return wrapResult(&r);
+}
+
+Tensor Tensor::sum(unsigned int axis, float alpha) const {
+  auto r = asInternal(getInternalPtr())->sum(axis, alpha);
+  return wrapResult(&r);
+}
+
+Tensor Tensor::average(unsigned int axis) const {
+  auto r = asInternal(getInternalPtr())->average(axis);
+  return wrapResult(&r);
+}
+
+Tensor Tensor::average() const {
+  auto r = asInternal(getInternalPtr())->average();
+  return wrapResult(&r);
+}
+
+float Tensor::l2norm() const {
+  return asInternal(getInternalPtr())->l2norm();
+}
+
+std::vector<unsigned int> Tensor::argmax() const {
+  return asInternal(getInternalPtr())->argmax();
+}
+
+// --- Tensor manipulation ---
+
+Tensor Tensor::getBatchSlice(unsigned int offset, unsigned int size) const {
+  auto r = asInternal(getInternalPtr())->getBatchSlice(offset, size);
+  return wrapResult(&r);
+}
+
+Tensor Tensor::getSharedDataTensor(const TensorDim &dim,
+                                    size_t offset) const {
+  auto r =
+    asInternal(getInternalPtr())->getSharedDataTensor(dim, offset, false);
+  return wrapResult(&r);
+}
+
+Tensor Tensor::apply(std::function<float(float)> f) const {
+  auto *internal = asInternal(getInternalPtr());
+  nntrainer::Tensor r = internal->clone();
+  float *d = r.getData<float>();
+  size_t len = r.size();
+  for (size_t i = 0; i < len; ++i) {
+    d[i] = f(d[i]);
+  }
+  return wrapResult(&r);
+}
+
+void Tensor::apply_i(std::function<float(float)> f) {
+  auto *internal = asInternal(getInternalPtr());
+  float *d = internal->getData<float>();
+  size_t len = internal->size();
+  for (size_t i = 0; i < len; ++i) {
+    d[i] = f(d[i]);
+  }
+}
+
+Tensor Tensor::cat(const std::vector<Tensor> &tensors, int axis) {
+  if (tensors.empty()) {
+    throw std::invalid_argument("cat: tensors must not be empty");
+  }
+
+  std::vector<nntrainer::Tensor> internals;
+  internals.reserve(tensors.size());
+  for (auto &t : tensors) {
+    internals.push_back(*asInternal(t.getInternalPtr()));
+  }
+
+  nntrainer::Tensor output;
+  internals[0].concat(
+    std::vector<nntrainer::Tensor>(internals.begin() + 1, internals.end()),
+    axis, output);
+  return wrapResult(&output);
+}
+
+} // namespace train
+} // namespace ml

--- a/api/ccapi/src/tensor_api_ops.cpp
+++ b/api/ccapi/src/tensor_api_ops.cpp
@@ -34,8 +34,8 @@ Tensor Tensor::subtract(float value) const {
 }
 
 Tensor Tensor::subtract(const Tensor &other) const {
-  auto r = asInternal(getInternalPtr())->subtract(
-    *asInternal(other.getInternalPtr()));
+  auto r =
+    asInternal(getInternalPtr())->subtract(*asInternal(other.getInternalPtr()));
   return wrapResult(&r);
 }
 
@@ -50,14 +50,14 @@ Tensor Tensor::divide(float value) const {
 }
 
 Tensor Tensor::divide(const Tensor &other) const {
-  auto r = asInternal(getInternalPtr())->divide(
-    *asInternal(other.getInternalPtr()));
+  auto r =
+    asInternal(getInternalPtr())->divide(*asInternal(other.getInternalPtr()));
   return wrapResult(&r);
 }
 
 Tensor Tensor::dot(const Tensor &other, bool trans, bool trans_in) const {
-  auto r = asInternal(getInternalPtr())->dot(
-    *asInternal(other.getInternalPtr()), trans, trans_in);
+  auto r = asInternal(getInternalPtr())
+             ->dot(*asInternal(other.getInternalPtr()), trans, trans_in);
   return wrapResult(&r);
 }
 
@@ -86,9 +86,7 @@ Tensor Tensor::average() const {
   return wrapResult(&r);
 }
 
-float Tensor::l2norm() const {
-  return asInternal(getInternalPtr())->l2norm();
-}
+float Tensor::l2norm() const { return asInternal(getInternalPtr())->l2norm(); }
 
 std::vector<unsigned int> Tensor::argmax() const {
   return asInternal(getInternalPtr())->argmax();
@@ -101,8 +99,7 @@ Tensor Tensor::getBatchSlice(unsigned int offset, unsigned int size) const {
   return wrapResult(&r);
 }
 
-Tensor Tensor::getSharedDataTensor(const TensorDim &dim,
-                                    size_t offset) const {
+Tensor Tensor::getSharedDataTensor(const TensorDim &dim, size_t offset) const {
   auto r =
     asInternal(getInternalPtr())->getSharedDataTensor(dim, offset, false);
   return wrapResult(&r);

--- a/test/ccapi/unittest_ccapi_tensor.cpp
+++ b/test/ccapi/unittest_ccapi_tensor.cpp
@@ -670,7 +670,8 @@ TEST(nntrainer_ccapi_graph, simple_fc_compile_p) {
   auto y = fc(x);
 
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
-  EXPECT_EQ(model->compile(x, y), ML_ERROR_NONE);
+  EXPECT_EQ(model->compile(x, y, ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
 }
 
 /**
@@ -689,7 +690,8 @@ TEST(nntrainer_ccapi_graph, multi_layer_compile_p) {
   auto y = fc2(h);
 
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
-  EXPECT_EQ(model->compile(x, y), ML_ERROR_NONE);
+  EXPECT_EQ(model->compile(x, y, ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
 }
 
 /**
@@ -706,7 +708,8 @@ TEST(nntrainer_ccapi_graph, residual_compile_p) {
   auto y = fc_out(out);
 
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
-  EXPECT_EQ(model->compile(x, y), ML_ERROR_NONE);
+  EXPECT_EQ(model->compile(x, y, ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
 }
 
 /**
@@ -733,7 +736,8 @@ TEST(nntrainer_ccapi_graph, data_injection_after_compile_p) {
   auto y = fc(x);
 
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
-  EXPECT_EQ(model->compile(x, y), ML_ERROR_NONE);
+  EXPECT_EQ(model->compile(x, y, ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
 
   // After compile (which includes initialize + bind), x is materialized
   EXPECT_TRUE(x.isMaterialized());
@@ -756,7 +760,8 @@ TEST(nntrainer_ccapi_graph, set_get_value_bound_p) {
   auto y = fc(x);
 
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
-  EXPECT_EQ(model->compile(x, y), ML_ERROR_NONE);
+  EXPECT_EQ(model->compile(x, y, ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
 
   x.setValue(0, 0, 0, 0, 42.0f);
   EXPECT_FLOAT_EQ(x.getValue(0, 0, 0, 0), 42.0f);
@@ -795,7 +800,8 @@ TEST(nntrainer_ccapi_graph, multi_layer_bind_p) {
   auto y = fc2(h);
 
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
-  EXPECT_EQ(model->compile(x, y), ML_ERROR_NONE);
+  EXPECT_EQ(model->compile(x, y, ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
 
   EXPECT_TRUE(x.isMaterialized());
   EXPECT_TRUE(y.isMaterialized());
@@ -874,7 +880,8 @@ TEST(nntrainer_ccapi_graph, multiple_leaf_inputs_p) {
   auto y = fc(sum);
 
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
-  EXPECT_EQ(model->compile(x1, y), ML_ERROR_NONE);
+  EXPECT_EQ(model->compile(x1, y, ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
 
   EXPECT_TRUE(x1.isMaterialized());
   EXPECT_TRUE(y.isMaterialized());
@@ -949,7 +956,8 @@ TEST(nntrainer_ccapi_graph, picogpt_style_transformer_p) {
   auto output = final_ln(block_out);
 
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
-  EXPECT_EQ(model->compile(wte_in, output), ML_ERROR_NONE);
+  EXPECT_EQ(model->compile(wte_in, output, ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
 
   EXPECT_TRUE(wte_in.isMaterialized());
   EXPECT_TRUE(output.isMaterialized());
@@ -1017,7 +1025,8 @@ TEST(nntrainer_ccapi_graph, picogpt_style_inference_p) {
   auto output = final_ln(block_out);
 
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
-  ASSERT_EQ(model->compile(wte_in, output), ML_ERROR_NONE);
+  ASSERT_EQ(model->compile(wte_in, output, ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
 
   // Run inference with dummy input (token id=1 for both inputs)
   float wte_input_data[1];

--- a/test/ccapi/unittest_ccapi_tensor.cpp
+++ b/test/ccapi/unittest_ccapi_tensor.cpp
@@ -680,7 +680,8 @@ TEST(nntrainer_ccapi_graph, multi_layer_compile_p) {
   using namespace ml::train;
   auto x = Tensor({1, 1, 1, 784}, "input");
   LayerHandle fc1 = createLayer("fully_connected", {"unit=128", "name=fc1"});
-  LayerHandle relu = createLayer("activation", {"activation=relu", "name=relu1"});
+  LayerHandle relu =
+    createLayer("activation", {"activation=relu", "name=relu1"});
   LayerHandle fc2 = createLayer("fully_connected", {"unit=10", "name=fc2"});
 
   auto h = fc1(x);
@@ -700,7 +701,8 @@ TEST(nntrainer_ccapi_graph, residual_compile_p) {
   LayerHandle fc1 = createLayer("fully_connected", {"unit=256", "name=fc1"});
   auto h = fc1(x);
   auto out = x.add(h);
-  LayerHandle fc_out = createLayer("fully_connected", {"unit=10", "name=fc_out"});
+  LayerHandle fc_out =
+    createLayer("fully_connected", {"unit=10", "name=fc_out"});
   auto y = fc_out(out);
 
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
@@ -713,8 +715,7 @@ TEST(nntrainer_ccapi_graph, residual_compile_p) {
 TEST(nntrainer_ccapi_graph, existing_add_layer_still_works_p) {
   using namespace ml::train;
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
-  model->addLayer(
-    createLayer("input", {"name=in", "input_shape=1:1:784"}));
+  model->addLayer(createLayer("input", {"name=in", "input_shape=1:1:784"}));
   model->addLayer(
     createLayer("fully_connected", {"name=fc", "unit=10", "input_layers=in"}));
   EXPECT_EQ(model->compile(), ML_ERROR_NONE);
@@ -813,7 +814,7 @@ TEST(nntrainer_ccapi_graph, multi_layer_bind_p) {
 TEST(nntrainer_ccapi_tensor, lazy_chain_p) {
   auto t = ml::train::Tensor::ones({1, 1, 2, 2});
   t.chain().multiply_i(2.0f).add_i(1.0f).eval();
-  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 3.0f);  // 1*2+1
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 3.0f); // 1*2+1
   EXPECT_FLOAT_EQ(t.getValue(0, 0, 1, 1), 3.0f);
 }
 
@@ -823,7 +824,7 @@ TEST(nntrainer_ccapi_tensor, lazy_chain_p) {
 TEST(nntrainer_ccapi_tensor, lazy_chain_order_p) {
   auto t = ml::train::Tensor::ones({1, 1, 1, 1});
   t.chain().add_i(3.0f).multiply_i(2.0f).eval();
-  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 8.0f);  // (1+3)*2
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 8.0f); // (1+3)*2
 }
 
 /**
@@ -840,9 +841,9 @@ TEST(nntrainer_ccapi_tensor, lazy_eval_on_symbolic_n) {
  */
 TEST(nntrainer_ccapi_tensor, lazy_chain_reset_p) {
   auto t = ml::train::Tensor::ones({1, 1, 1, 1});
-  t.chain().add_i(100.0f);  // queued but not eval'd
-  t.chain().add_i(5.0f).eval();  // chain() clears, only +5 applied
-  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 6.0f);  // 1+5
+  t.chain().add_i(100.0f);      // queued but not eval'd
+  t.chain().add_i(5.0f).eval(); // chain() clears, only +5 applied
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 6.0f); // 1+5
 }
 
 /**
@@ -897,10 +898,12 @@ TEST(nntrainer_ccapi_graph, picogpt_style_transformer_p) {
   Tensor wte_in({1, 1, 1, 1}, "wte_input");
   Tensor wpe_in({1, 1, 1, 1}, "wpe_input");
 
-  LayerHandle wte = createLayer("embedding",
-    {"name=wte", "in_dim=100", "out_dim=" + std::to_string(MODEL_DIM)});
-  LayerHandle wpe = createLayer("embedding",
-    {"name=wpe", "in_dim=100", "out_dim=" + std::to_string(MODEL_DIM)});
+  LayerHandle wte =
+    createLayer("embedding", {"name=wte", "in_dim=100",
+                              "out_dim=" + std::to_string(MODEL_DIM)});
+  LayerHandle wpe =
+    createLayer("embedding", {"name=wpe", "in_dim=100",
+                              "out_dim=" + std::to_string(MODEL_DIM)});
   auto wte_out = wte(wte_in);
   auto wpe_out = wpe(wpe_in);
 
@@ -909,13 +912,13 @@ TEST(nntrainer_ccapi_graph, picogpt_style_transformer_p) {
 
   // Single transformer block
   LayerHandle ln1 = createLayer("layer_normalization",
-    {"name=layer0/ln1", "axis=3", "epsilon=1e-5"});
+                                {"name=layer0/ln1", "axis=3", "epsilon=1e-5"});
   auto ln1_out = ln1(prev);
 
   // MHA with same tensor as Q, K, V (fan-out test)
   LayerHandle mha = createLayer("multi_head_attention",
-    {"name=layer0/multi_head_attention",
-     "num_heads=" + std::to_string(NUM_HEADS)});
+                                {"name=layer0/multi_head_attention",
+                                 "num_heads=" + std::to_string(NUM_HEADS)});
   auto attn_out = mha({ln1_out, ln1_out, ln1_out});
 
   // Skip connection 1: prev + attn_out (prev used twice = fan-out)
@@ -923,23 +926,26 @@ TEST(nntrainer_ccapi_graph, picogpt_style_transformer_p) {
   auto add1_out = add1({prev, attn_out});
 
   LayerHandle ln2 = createLayer("layer_normalization",
-    {"name=layer0/ln2", "axis=3", "epsilon=1e-5"});
+                                {"name=layer0/ln2", "axis=3", "epsilon=1e-5"});
   auto ln2_out = ln2(add1_out);
 
-  LayerHandle fc1 = createLayer("fully_connected",
+  LayerHandle fc1 = createLayer(
+    "fully_connected",
     {"name=layer0/fc1", "unit=" + std::to_string(FF_DIM), "activation=gelu"});
   auto fc1_out = fc1(ln2_out);
 
-  LayerHandle fc2 = createLayer("fully_connected",
-    {"name=layer0/fc2", "unit=" + std::to_string(MODEL_DIM)});
+  LayerHandle fc2 =
+    createLayer("fully_connected",
+                {"name=layer0/fc2", "unit=" + std::to_string(MODEL_DIM)});
   auto fc2_out = fc2(fc1_out);
 
   // Skip connection 2: add1_out + fc2_out (add1_out used twice = fan-out)
   LayerHandle add2 = createLayer("Addition", {"name=layer0/add2"});
   auto block_out = add2({add1_out, fc2_out});
 
-  LayerHandle final_ln = createLayer("layer_normalization",
-    {"name=layer_normalization", "axis=3", "epsilon=1e-5"});
+  LayerHandle final_ln =
+    createLayer("layer_normalization",
+                {"name=layer_normalization", "axis=3", "epsilon=1e-5"});
   auto output = final_ln(block_out);
 
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
@@ -964,10 +970,12 @@ TEST(nntrainer_ccapi_graph, picogpt_style_inference_p) {
   Tensor wte_in({1, 1, 1, 1}, "wte_input");
   Tensor wpe_in({1, 1, 1, 1}, "wpe_input");
 
-  LayerHandle wte = createLayer("embedding",
-    {"name=wte", "in_dim=50", "out_dim=" + std::to_string(MODEL_DIM)});
-  LayerHandle wpe = createLayer("embedding",
-    {"name=wpe", "in_dim=50", "out_dim=" + std::to_string(MODEL_DIM)});
+  LayerHandle wte =
+    createLayer("embedding", {"name=wte", "in_dim=50",
+                              "out_dim=" + std::to_string(MODEL_DIM)});
+  LayerHandle wpe =
+    createLayer("embedding", {"name=wpe", "in_dim=50",
+                              "out_dim=" + std::to_string(MODEL_DIM)});
   auto wte_out = wte(wte_in);
   auto wpe_out = wpe(wpe_in);
 
@@ -976,33 +984,36 @@ TEST(nntrainer_ccapi_graph, picogpt_style_inference_p) {
 
   // 1 transformer block
   LayerHandle ln1 = createLayer("layer_normalization",
-    {"name=layer0/ln1", "axis=3", "epsilon=1e-5"});
+                                {"name=layer0/ln1", "axis=3", "epsilon=1e-5"});
   auto ln1_out = ln1(prev);
 
-  LayerHandle mha = createLayer("multi_head_attention",
-    {"name=layer0/mha", "num_heads=" + std::to_string(NUM_HEADS)});
+  LayerHandle mha =
+    createLayer("multi_head_attention",
+                {"name=layer0/mha", "num_heads=" + std::to_string(NUM_HEADS)});
   auto attn_out = mha({ln1_out, ln1_out, ln1_out});
 
   LayerHandle add1 = createLayer("Addition", {"name=layer0/add1"});
   auto add1_out = add1({prev, attn_out});
 
   LayerHandle ln2 = createLayer("layer_normalization",
-    {"name=layer0/ln2", "axis=3", "epsilon=1e-5"});
+                                {"name=layer0/ln2", "axis=3", "epsilon=1e-5"});
   auto ln2_out = ln2(add1_out);
 
-  LayerHandle fc1 = createLayer("fully_connected",
+  LayerHandle fc1 = createLayer(
+    "fully_connected",
     {"name=layer0/fc1", "unit=" + std::to_string(FF_DIM), "activation=gelu"});
   auto fc1_out = fc1(ln2_out);
 
-  LayerHandle fc2 = createLayer("fully_connected",
-    {"name=layer0/fc2", "unit=" + std::to_string(MODEL_DIM)});
+  LayerHandle fc2 =
+    createLayer("fully_connected",
+                {"name=layer0/fc2", "unit=" + std::to_string(MODEL_DIM)});
   auto fc2_out = fc2(fc1_out);
 
   LayerHandle add2 = createLayer("Addition", {"name=layer0/add2"});
   auto block_out = add2({add1_out, fc2_out});
 
-  LayerHandle final_ln = createLayer("layer_normalization",
-    {"name=final_ln", "axis=3", "epsilon=1e-5"});
+  LayerHandle final_ln = createLayer(
+    "layer_normalization", {"name=final_ln", "axis=3", "epsilon=1e-5"});
   auto output = final_ln(block_out);
 
   auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
@@ -1016,8 +1027,8 @@ TEST(nntrainer_ccapi_graph, picogpt_style_inference_p) {
   std::memcpy(wpe_input_data, &wpe_token, sizeof(unsigned int));
 
   std::vector<float *> output_bufs;
-  EXPECT_NO_THROW(
-    output_bufs = model->inference(1, {wte_input_data, wpe_input_data}));
+  EXPECT_NO_THROW(output_bufs =
+                    model->inference(1, {wte_input_data, wpe_input_data}));
   EXPECT_FALSE(output_bufs.empty());
 }
 
@@ -1374,24 +1385,21 @@ TEST(nntrainer_ccapi_graph, causallm_style_multi_input_p) {
     std::string prefix = "layer" + std::to_string(layer_id);
 
     // Attention norm
-    LayerHandle att_norm = createLayer(
-      "layer_normalization",
-      {"name=" + prefix + "_att_norm", "axis=3", "epsilon=1e-5"});
+    LayerHandle att_norm =
+      createLayer("layer_normalization",
+                  {"name=" + prefix + "_att_norm", "axis=3", "epsilon=1e-5"});
     Tensor normed = att_norm(x);
 
     // Q/K/V projections (self-attention: all from same normed input)
     LayerHandle q_proj = createLayer(
-      "fully_connected",
-      {"name=" + prefix + "_wq", "unit=" + std::to_string(DIM),
-       "disable_bias=true"});
+      "fully_connected", {"name=" + prefix + "_wq",
+                          "unit=" + std::to_string(DIM), "disable_bias=true"});
     LayerHandle k_proj = createLayer(
-      "fully_connected",
-      {"name=" + prefix + "_wk", "unit=" + std::to_string(DIM),
-       "disable_bias=true"});
+      "fully_connected", {"name=" + prefix + "_wk",
+                          "unit=" + std::to_string(DIM), "disable_bias=true"});
     LayerHandle v_proj = createLayer(
-      "fully_connected",
-      {"name=" + prefix + "_wv", "unit=" + std::to_string(DIM),
-       "disable_bias=true"});
+      "fully_connected", {"name=" + prefix + "_wv",
+                          "unit=" + std::to_string(DIM), "disable_bias=true"});
     Tensor q = q_proj(normed);
     Tensor k = k_proj(normed);
     Tensor v = v_proj(normed);
@@ -1402,29 +1410,28 @@ TEST(nntrainer_ccapi_graph, causallm_style_multi_input_p) {
     Tensor combined = qkv_combine({q, k, v});
 
     LayerHandle o_proj = createLayer(
-      "fully_connected",
-      {"name=" + prefix + "_wo", "unit=" + std::to_string(DIM),
-       "disable_bias=true"});
+      "fully_connected", {"name=" + prefix + "_wo",
+                          "unit=" + std::to_string(DIM), "disable_bias=true"});
     Tensor att_out = o_proj(combined);
 
     // Residual add (Tensor::add creates implicit Addition layer)
     Tensor residual = x.add(att_out);
 
     // FFN norm
-    LayerHandle ffn_norm = createLayer(
-      "layer_normalization",
-      {"name=" + prefix + "_ffn_norm", "axis=3", "epsilon=1e-5"});
+    LayerHandle ffn_norm =
+      createLayer("layer_normalization",
+                  {"name=" + prefix + "_ffn_norm", "axis=3", "epsilon=1e-5"});
     Tensor ffn_normed = ffn_norm(residual);
 
     // MLP: up → gate → multiply → down
-    LayerHandle ffn_up = createLayer(
-      "fully_connected",
-      {"name=" + prefix + "_ffn_up", "unit=" + std::to_string(FF_DIM),
-       "disable_bias=true"});
-    LayerHandle ffn_gate = createLayer(
-      "fully_connected",
-      {"name=" + prefix + "_ffn_gate", "unit=" + std::to_string(FF_DIM),
-       "disable_bias=true"});
+    LayerHandle ffn_up =
+      createLayer("fully_connected",
+                  {"name=" + prefix + "_ffn_up",
+                   "unit=" + std::to_string(FF_DIM), "disable_bias=true"});
+    LayerHandle ffn_gate =
+      createLayer("fully_connected",
+                  {"name=" + prefix + "_ffn_gate",
+                   "unit=" + std::to_string(FF_DIM), "disable_bias=true"});
     Tensor up = ffn_up(ffn_normed);
     Tensor gate = ffn_gate(ffn_normed);
 
@@ -1432,9 +1439,8 @@ TEST(nntrainer_ccapi_graph, causallm_style_multi_input_p) {
     Tensor activated = up.multiply(gate);
 
     LayerHandle ffn_down = createLayer(
-      "fully_connected",
-      {"name=" + prefix + "_ffn_down", "unit=" + std::to_string(DIM),
-       "disable_bias=true"});
+      "fully_connected", {"name=" + prefix + "_ffn_down",
+                          "unit=" + std::to_string(DIM), "disable_bias=true"});
     Tensor ffn_out = ffn_down(activated);
 
     // Residual add
@@ -1447,10 +1453,10 @@ TEST(nntrainer_ccapi_graph, causallm_style_multi_input_p) {
   x = output_norm(x);
 
   // --- LM Head ---
-  LayerHandle lmhead = createLayer(
-    "fully_connected",
-    {"name=output_of_causallm", "unit=" + std::to_string(VOCAB_SIZE),
-     "disable_bias=true"});
+  LayerHandle lmhead =
+    createLayer("fully_connected",
+                {"name=output_of_causallm",
+                 "unit=" + std::to_string(VOCAB_SIZE), "disable_bias=true"});
   Tensor output = lmhead(x);
 
   // --- Compile from symbolic tensor graph (includes initialize) ---

--- a/test/ccapi/unittest_ccapi_tensor.cpp
+++ b/test/ccapi/unittest_ccapi_tensor.cpp
@@ -10,22 +10,21 @@
  * @bug         No known bugs
  */
 
+#include <cstring>
 #include <gtest/gtest.h>
 #include <iostream>
 
 #include <layer.h>
+#include <model.h>
 #include <nntrainer_error.h>
 #include <nntrainer_test_util.h>
 #include <tensor_api.h>
 
 /**
- * @brief Tensor Construct Test
+ * @brief Original test — backward compatibility with Pimpl
  */
-
 TEST(nntrainer_ccapi, tensor_01_p) {
-
   std::shared_ptr<ml::train::Layer> layer;
-
   ml::train::Tensor a;
 
   EXPECT_NO_THROW(layer =
@@ -36,4 +35,1437 @@ TEST(nntrainer_ccapi, tensor_01_p) {
 
   std::shared_ptr<ml::train::Layer> layer_b = a.getSrcLayer();
   EXPECT_EQ(layer_b->getName(), "input0");
+}
+
+/**
+ * @brief Default constructed tensor is invalid
+ */
+TEST(nntrainer_ccapi_tensor, default_construct_p) {
+  ml::train::Tensor t;
+  EXPECT_FALSE(t.isValid());
+}
+
+/**
+ * @brief Symbolic tensor with dimension is valid
+ */
+TEST(nntrainer_ccapi_tensor, symbolic_construct_p) {
+  ml::train::TensorDim dim({1, 1, 28, 28});
+  ml::train::Tensor t(dim, "input");
+
+  EXPECT_TRUE(t.isValid());
+  EXPECT_EQ(t.name(), "input");
+  EXPECT_EQ(t.shape().batch(), 1);
+  EXPECT_EQ(t.shape().channel(), 1);
+  EXPECT_EQ(t.shape().height(), 28);
+  EXPECT_EQ(t.shape().width(), 28);
+}
+
+/**
+ * @brief Symbolic tensor without name
+ */
+TEST(nntrainer_ccapi_tensor, symbolic_construct_no_name_p) {
+  ml::train::TensorDim dim({1, 3, 32, 32});
+  ml::train::Tensor t(dim);
+
+  EXPECT_TRUE(t.isValid());
+  EXPECT_EQ(t.name(), "");
+  EXPECT_EQ(t.shape().channel(), 3);
+}
+
+/**
+ * @brief dtype defaults to FP32
+ */
+TEST(nntrainer_ccapi_tensor, dtype_default_p) {
+  ml::train::TensorDim dim({1, 1, 2, 2});
+  ml::train::Tensor t(dim);
+
+  EXPECT_EQ(t.dtype(), ml::train::TensorDim::DataType::FP32);
+}
+
+/**
+ * @brief Move constructor transfers ownership
+ */
+TEST(nntrainer_ccapi_tensor, move_construct_p) {
+  ml::train::TensorDim dim({1, 1, 28, 28});
+  ml::train::Tensor a(dim, "original");
+  ml::train::Tensor b(std::move(a));
+
+  EXPECT_TRUE(b.isValid());
+  EXPECT_EQ(b.name(), "original");
+  EXPECT_EQ(b.shape().height(), 28);
+  // moved-from tensor should be invalid
+  EXPECT_FALSE(a.isValid());
+}
+
+/**
+ * @brief Move assignment transfers ownership
+ */
+TEST(nntrainer_ccapi_tensor, move_assign_p) {
+  ml::train::TensorDim dim({1, 1, 10, 10});
+  ml::train::Tensor a(dim, "src");
+  ml::train::Tensor b;
+
+  b = std::move(a);
+  EXPECT_TRUE(b.isValid());
+  EXPECT_EQ(b.name(), "src");
+  EXPECT_FALSE(a.isValid());
+}
+
+/**
+ * @brief Copy constructor creates independent copy
+ */
+TEST(nntrainer_ccapi_tensor, copy_construct_p) {
+  ml::train::TensorDim dim({1, 1, 28, 28});
+  ml::train::Tensor a(dim, "shared");
+  ml::train::Tensor b(a);
+
+  EXPECT_TRUE(b.isValid());
+  EXPECT_EQ(b.name(), "shared");
+  EXPECT_EQ(b.shape().width(), 28);
+  // both should be valid
+  EXPECT_TRUE(a.isValid());
+}
+
+/**
+ * @brief Copy assignment creates independent copy
+ */
+TEST(nntrainer_ccapi_tensor, copy_assign_p) {
+  ml::train::TensorDim dim({1, 1, 5, 5});
+  ml::train::Tensor a(dim, "orig");
+  ml::train::Tensor b;
+
+  b = a;
+  EXPECT_TRUE(b.isValid());
+  EXPECT_EQ(b.name(), "orig");
+  EXPECT_TRUE(a.isValid());
+}
+
+/**
+ * @brief Clone creates independent copy
+ */
+TEST(nntrainer_ccapi_tensor, clone_p) {
+  ml::train::TensorDim dim({1, 1, 3, 3});
+  ml::train::Tensor a(dim, "cloneable");
+  ml::train::Tensor b = a.clone();
+
+  EXPECT_TRUE(b.isValid());
+  EXPECT_EQ(b.name(), "cloneable");
+  EXPECT_EQ(b.shape().height(), 3);
+}
+
+/**
+ * @brief Accessing shape on invalid tensor throws
+ */
+TEST(nntrainer_ccapi_tensor, invalid_shape_n) {
+  ml::train::Tensor t;
+  EXPECT_THROW(t.shape(), std::runtime_error);
+}
+
+/**
+ * @brief Accessing name on invalid tensor throws
+ */
+TEST(nntrainer_ccapi_tensor, invalid_name_n) {
+  ml::train::Tensor t;
+  EXPECT_THROW(t.name(), std::runtime_error);
+}
+
+/**
+ * @brief Accessing dtype on invalid tensor throws
+ */
+TEST(nntrainer_ccapi_tensor, invalid_dtype_n) {
+  ml::train::Tensor t;
+  EXPECT_THROW(t.dtype(), std::runtime_error);
+}
+
+/**
+ * @brief setSrcLayer / getSrcLayer on default tensor
+ */
+TEST(nntrainer_ccapi_tensor, src_layer_default_p) {
+  ml::train::Tensor t;
+  EXPECT_EQ(t.getSrcLayer(), nullptr);
+}
+
+// ===== Step 1-2: fromData, zeros, ones =====
+
+/**
+ * @brief fromData wraps external buffer (zero-copy)
+ */
+TEST(nntrainer_ccapi_tensor, from_data_p) {
+  float buf[12] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  ml::train::TensorDim dim({1, 1, 3, 4});
+  auto t = ml::train::Tensor::fromData(dim, buf);
+
+  EXPECT_TRUE(t.isValid());
+  EXPECT_TRUE(t.isExternal());
+  EXPECT_TRUE(t.isMaterialized());
+  EXPECT_EQ(t.shape().height(), 3u);
+  EXPECT_EQ(t.shape().width(), 4u);
+}
+
+/**
+ * @brief fromData with name
+ */
+TEST(nntrainer_ccapi_tensor, from_data_named_p) {
+  float buf[4] = {1, 2, 3, 4};
+  auto t = ml::train::Tensor::fromData({1, 1, 2, 2}, buf, "ext_cache");
+  EXPECT_EQ(t.name(), "ext_cache");
+  EXPECT_TRUE(t.isExternal());
+}
+
+/**
+ * @brief fromData with null pointer throws
+ */
+TEST(nntrainer_ccapi_tensor, from_data_null_n) {
+  EXPECT_THROW(ml::train::Tensor::fromData({1, 1, 2, 2}, nullptr),
+               std::invalid_argument);
+}
+
+/**
+ * @brief zeros creates materialized non-external tensor
+ */
+TEST(nntrainer_ccapi_tensor, zeros_p) {
+  auto t = ml::train::Tensor::zeros({1, 1, 2, 3});
+  EXPECT_TRUE(t.isValid());
+  EXPECT_FALSE(t.isExternal());
+  EXPECT_TRUE(t.isMaterialized());
+  EXPECT_EQ(t.shape().height(), 2u);
+  EXPECT_EQ(t.shape().width(), 3u);
+}
+
+/**
+ * @brief ones creates materialized non-external tensor
+ */
+TEST(nntrainer_ccapi_tensor, ones_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 2, 3});
+  EXPECT_TRUE(t.isValid());
+  EXPECT_FALSE(t.isExternal());
+  EXPECT_TRUE(t.isMaterialized());
+}
+
+/**
+ * @brief zeros with name
+ */
+TEST(nntrainer_ccapi_tensor, zeros_named_p) {
+  auto t = ml::train::Tensor::zeros({1, 1, 3, 3}, "zero_t");
+  EXPECT_EQ(t.name(), "zero_t");
+}
+
+/**
+ * @brief symbolic tensor is not materialized and not external
+ */
+TEST(nntrainer_ccapi_tensor, symbolic_not_materialized_p) {
+  ml::train::Tensor t({1, 1, 28, 28});
+  EXPECT_FALSE(t.isMaterialized());
+  EXPECT_FALSE(t.isExternal());
+}
+
+/**
+ * @brief default tensor is not materialized and not external
+ */
+TEST(nntrainer_ccapi_tensor, default_not_materialized_p) {
+  ml::train::Tensor t;
+  EXPECT_FALSE(t.isMaterialized());
+  EXPECT_FALSE(t.isExternal());
+}
+
+// ===== Step 1-3: data access =====
+
+/**
+ * @brief data<float>() on fromData returns the original pointer (zero-copy)
+ */
+TEST(nntrainer_ccapi_tensor, data_from_data_zero_copy_p) {
+  float buf[6] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  auto t = ml::train::Tensor::fromData({1, 1, 2, 3}, buf);
+  EXPECT_EQ(t.data<float>(), buf);
+}
+
+/**
+ * @brief getValue on fromData tensor
+ */
+TEST(nntrainer_ccapi_tensor, get_value_from_data_p) {
+  float buf[6] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  auto t = ml::train::Tensor::fromData({1, 1, 2, 3}, buf);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 1.0f);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 2), 3.0f);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 1, 2), 6.0f);
+}
+
+/**
+ * @brief getValue on zeros tensor
+ */
+TEST(nntrainer_ccapi_tensor, get_value_zeros_p) {
+  auto t = ml::train::Tensor::zeros({1, 1, 2, 2});
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 0.0f);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 1, 1), 0.0f);
+}
+
+/**
+ * @brief getValue on ones tensor
+ */
+TEST(nntrainer_ccapi_tensor, get_value_ones_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 2, 2});
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 1.0f);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 1, 1), 1.0f);
+}
+
+/**
+ * @brief setValue modifies value in-place
+ */
+TEST(nntrainer_ccapi_tensor, set_value_p) {
+  auto t = ml::train::Tensor::zeros({1, 1, 2, 2});
+  t.setValue(0, 0, 1, 1, 42.0f);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 1, 1), 42.0f);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 0.0f);
+}
+
+/**
+ * @brief mutable_data allows direct writes
+ */
+TEST(nntrainer_ccapi_tensor, mutable_data_p) {
+  auto t = ml::train::Tensor::zeros({1, 1, 1, 4});
+  float *ptr = t.mutable_data<float>();
+  ptr[0] = 10.0f;
+  ptr[3] = 99.0f;
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 10.0f);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 3), 99.0f);
+}
+
+/**
+ * @brief setData replaces external pointer
+ */
+TEST(nntrainer_ccapi_tensor, set_data_replace_ptr_p) {
+  float buf1[4] = {1, 2, 3, 4};
+  float buf2[4] = {5, 6, 7, 8};
+  auto t = ml::train::Tensor::fromData({1, 1, 2, 2}, buf1);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 1.0f);
+
+  t.setData(buf2);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 5.0f);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 1, 1), 8.0f);
+  EXPECT_EQ(t.data<float>(), buf2);
+}
+
+/**
+ * @brief setData on non-external (zeros) tensor throws
+ */
+TEST(nntrainer_ccapi_tensor, set_data_on_non_external_n) {
+  auto t = ml::train::Tensor::zeros({1, 1, 2, 2});
+  float buf[4] = {};
+  EXPECT_THROW(t.setData(buf), std::runtime_error);
+}
+
+/**
+ * @brief setData on symbolic tensor throws
+ */
+TEST(nntrainer_ccapi_tensor, set_data_on_symbolic_n) {
+  ml::train::Tensor t({1, 1, 2, 2});
+  float buf[4] = {};
+  EXPECT_THROW(t.setData(buf), std::runtime_error);
+}
+
+/**
+ * @brief setData with null throws
+ */
+TEST(nntrainer_ccapi_tensor, set_data_null_n) {
+  float buf[4] = {1, 2, 3, 4};
+  auto t = ml::train::Tensor::fromData({1, 1, 2, 2}, buf);
+  EXPECT_THROW(t.setData(nullptr), std::invalid_argument);
+}
+
+/**
+ * @brief copyFrom copies data into materialized tensor
+ */
+TEST(nntrainer_ccapi_tensor, copy_from_p) {
+  float src[4] = {10, 20, 30, 40};
+  auto t = ml::train::Tensor::zeros({1, 1, 2, 2});
+  t.copyFrom(src);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 10.0f);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 1, 1), 40.0f);
+}
+
+/**
+ * @brief copyFrom with null throws
+ */
+TEST(nntrainer_ccapi_tensor, copy_from_null_n) {
+  auto t = ml::train::Tensor::zeros({1, 1, 2, 2});
+  EXPECT_THROW(t.copyFrom(nullptr), std::invalid_argument);
+}
+
+/**
+ * @brief data access on unmaterialized (symbolic) tensor throws
+ */
+TEST(nntrainer_ccapi_tensor, data_access_unmaterialized_n) {
+  ml::train::Tensor t({1, 1, 28, 28});
+  EXPECT_THROW(t.data<float>(), std::runtime_error);
+  EXPECT_THROW(t.mutable_data<float>(), std::runtime_error);
+  EXPECT_THROW(t.getValue(0, 0, 0, 0), std::runtime_error);
+  EXPECT_THROW(t.setValue(0, 0, 0, 0, 1.0f), std::runtime_error);
+}
+
+/**
+ * @brief clone of eager tensor creates independent copy
+ */
+TEST(nntrainer_ccapi_tensor, clone_eager_independent_p) {
+  auto orig = ml::train::Tensor::zeros({1, 1, 2, 2});
+  orig.setValue(0, 0, 0, 0, 99.0f);
+  auto cloned = orig.clone();
+
+  cloned.setValue(0, 0, 0, 0, 1.0f);
+  EXPECT_FLOAT_EQ(orig.getValue(0, 0, 0, 0), 99.0f);
+  EXPECT_FLOAT_EQ(cloned.getValue(0, 0, 0, 0), 1.0f);
+}
+
+// ===== Step 2-1: LayerHandle graph edge recording =====
+
+/**
+ * @brief LayerHandle wraps createLayer and enables operator()
+ */
+TEST(nntrainer_ccapi_tensor, layer_handle_construct_p) {
+  ml::train::LayerHandle fc =
+    ml::train::createLayer("fully_connected", {"unit=256", "name=fc1"});
+  EXPECT_TRUE(static_cast<bool>(fc));
+  EXPECT_EQ(fc->getName(), "fc1");
+  EXPECT_EQ(fc->getType(), "fully_connected");
+}
+
+/**
+ * @brief LayerHandle converts to shared_ptr<Layer> for backward compat
+ */
+TEST(nntrainer_ccapi_tensor, layer_handle_to_shared_ptr_p) {
+  ml::train::LayerHandle fc =
+    ml::train::createLayer("fully_connected", {"unit=128", "name=fc_conv"});
+  std::shared_ptr<ml::train::Layer> layer_ptr = fc;
+  EXPECT_EQ(layer_ptr->getName(), "fc_conv");
+}
+
+/**
+ * @brief Layer call on symbolic tensor produces symbolic output
+ */
+TEST(nntrainer_ccapi_tensor, layer_call_symbolic_p) {
+  using namespace ml::train;
+  auto input = Tensor({1, 1, 1, 784}, "input");
+  LayerHandle fc = createLayer("fully_connected", {"unit=256", "name=fc1"});
+  auto output = fc(input);
+
+  EXPECT_TRUE(output.isValid());
+  EXPECT_FALSE(output.isMaterialized());
+  // Shape is propagated from input; full shape inference (e.g. FC unit)
+  // will be resolved during model.compile()
+  EXPECT_EQ(output.getProducingLayer()->getName(), "fc1");
+}
+
+/**
+ * @brief Layer chain: fc1 -> fc2
+ */
+TEST(nntrainer_ccapi_tensor, layer_chain_p) {
+  using namespace ml::train;
+  auto x = Tensor({1, 1, 1, 784}, "x");
+  LayerHandle fc1 = createLayer("fully_connected", {"unit=128", "name=fc1"});
+  LayerHandle fc2 = createLayer("fully_connected", {"unit=10", "name=fc2"});
+  auto h = fc1(x);
+  auto y = fc2(h);
+
+  EXPECT_TRUE(y.isValid());
+  EXPECT_FALSE(y.isMaterialized());
+  EXPECT_EQ(y.getProducingLayer()->getName(), "fc2");
+  EXPECT_EQ(y.getInputTensors()[0].getProducingLayer()->getName(), "fc1");
+}
+
+/**
+ * @brief Multi-input layer (Addition)
+ */
+TEST(nntrainer_ccapi_tensor, multi_input_layer_p) {
+  using namespace ml::train;
+  auto a = Tensor({1, 1, 1, 256}, "a");
+  auto b = Tensor({1, 1, 1, 256}, "b");
+  LayerHandle add = createLayer("Addition", {"name=add1"});
+  auto added = add({a, b});
+
+  EXPECT_TRUE(added.isValid());
+  EXPECT_FALSE(added.isMaterialized());
+}
+
+/**
+ * @brief Graph edge: output records producing layer
+ */
+TEST(nntrainer_ccapi_tensor, graph_edge_producing_layer_p) {
+  using namespace ml::train;
+  auto input = Tensor({1, 1, 1, 784}, "input");
+  LayerHandle fc = createLayer("fully_connected", {"unit=256", "name=fc1"});
+  auto output = fc(input);
+
+  auto producer = output.getProducingLayer();
+  EXPECT_NE(producer, nullptr);
+  EXPECT_EQ(producer->getName(), "fc1");
+}
+
+/**
+ * @brief Graph edge: output records input tensors
+ */
+TEST(nntrainer_ccapi_tensor, graph_edge_input_tensors_p) {
+  using namespace ml::train;
+  auto input = Tensor({1, 1, 1, 784}, "input");
+  LayerHandle fc = createLayer("fully_connected", {"unit=256", "name=fc1"});
+  auto output = fc(input);
+
+  auto inputs = output.getInputTensors();
+  EXPECT_EQ(inputs.size(), 1u);
+  EXPECT_EQ(inputs[0].name(), "input");
+}
+
+/**
+ * @brief Leaf/input tensor has no producing layer
+ */
+TEST(nntrainer_ccapi_tensor, graph_edge_leaf_tensor_p) {
+  ml::train::Tensor input({1, 1, 1, 784}, "input");
+  EXPECT_EQ(input.getProducingLayer(), nullptr);
+  EXPECT_TRUE(input.getInputTensors().empty());
+}
+
+/**
+ * @brief Chain graph traversal: output -> fc2 -> fc1 -> input
+ */
+TEST(nntrainer_ccapi_tensor, graph_chain_traversal_p) {
+  using namespace ml::train;
+  auto x = Tensor({1, 1, 1, 784}, "x");
+  LayerHandle fc1 = createLayer("fully_connected", {"unit=128", "name=fc1"});
+  LayerHandle fc2 = createLayer("fully_connected", {"unit=10", "name=fc2"});
+  auto h = fc1(x);
+  auto y = fc2(h);
+
+  // y was produced by fc2
+  EXPECT_EQ(y.getProducingLayer()->getName(), "fc2");
+  // y's input is h
+  auto y_inputs = y.getInputTensors();
+  EXPECT_EQ(y_inputs.size(), 1u);
+  // h was produced by fc1
+  EXPECT_EQ(y_inputs[0].getProducingLayer()->getName(), "fc1");
+  // h's input is x (leaf)
+  auto h_inputs = y_inputs[0].getInputTensors();
+  EXPECT_EQ(h_inputs.size(), 1u);
+  EXPECT_EQ(h_inputs[0].name(), "x");
+  EXPECT_EQ(h_inputs[0].getProducingLayer(), nullptr);
+}
+
+/**
+ * @brief Null LayerHandle throws on call
+ */
+TEST(nntrainer_ccapi_tensor, layer_handle_null_call_n) {
+  ml::train::LayerHandle null_handle;
+  ml::train::Tensor input({1, 1, 1, 784}, "input");
+  EXPECT_THROW(null_handle(input), std::runtime_error);
+}
+
+/**
+ * @brief Empty inputs to operator() throws
+ */
+TEST(nntrainer_ccapi_tensor, layer_handle_empty_inputs_n) {
+  ml::train::LayerHandle fc =
+    ml::train::createLayer("fully_connected", {"unit=256", "name=fc1"});
+  EXPECT_THROW(fc(std::vector<ml::train::Tensor>{}), std::invalid_argument);
+}
+
+// ===== Step 2-2: Tensor ops → implicit layers =====
+
+/**
+ * @brief add() creates implicit Addition layer
+ */
+TEST(nntrainer_ccapi_tensor, add_symbolic_p) {
+  using namespace ml::train;
+  auto a = Tensor({1, 1, 1, 256}, "a");
+  auto b = Tensor({1, 1, 1, 256}, "b");
+  auto c = a.add(b);
+
+  EXPECT_TRUE(c.isValid());
+  EXPECT_FALSE(c.isMaterialized());
+  EXPECT_EQ(c.shape().width(), 256u);
+  // Verify graph: c produced by Addition layer with 2 inputs
+  EXPECT_NE(c.getProducingLayer(), nullptr);
+  EXPECT_EQ(c.getProducingLayer()->getType(), "addition");
+  EXPECT_EQ(c.getInputTensors().size(), 2u);
+  EXPECT_EQ(c.getInputTensors()[0].name(), "a");
+  EXPECT_EQ(c.getInputTensors()[1].name(), "b");
+}
+
+/**
+ * @brief multiply() creates implicit Multiply layer
+ */
+TEST(nntrainer_ccapi_tensor, multiply_symbolic_p) {
+  using namespace ml::train;
+  auto a = Tensor({1, 1, 1, 128}, "ma");
+  auto b = Tensor({1, 1, 1, 128}, "mb");
+  auto c = a.multiply(b);
+
+  EXPECT_TRUE(c.isValid());
+  EXPECT_FALSE(c.isMaterialized());
+  EXPECT_EQ(c.shape().width(), 128u);
+  EXPECT_NE(c.getProducingLayer(), nullptr);
+  EXPECT_EQ(c.getProducingLayer()->getType(), "multiply");
+  EXPECT_EQ(c.getInputTensors().size(), 2u);
+}
+
+/**
+ * @brief reshape() creates implicit Reshape layer
+ */
+TEST(nntrainer_ccapi_tensor, reshape_symbolic_p) {
+  using namespace ml::train;
+  auto x = Tensor({1, 1, 1, 784}, "flat");
+  auto y = x.reshape(TensorDim({1, 1, 28, 28}));
+
+  EXPECT_TRUE(y.isValid());
+  EXPECT_FALSE(y.isMaterialized());
+  EXPECT_EQ(y.shape().channel(), 1u);
+  EXPECT_EQ(y.shape().height(), 28u);
+  EXPECT_EQ(y.shape().width(), 28u);
+  EXPECT_NE(y.getProducingLayer(), nullptr);
+  EXPECT_EQ(y.getInputTensors().size(), 1u);
+  EXPECT_EQ(y.getInputTensors()[0].name(), "flat");
+}
+
+/**
+ * @brief Residual (skip) connection: x + fc(x)
+ */
+TEST(nntrainer_ccapi_tensor, residual_connection_p) {
+  using namespace ml::train;
+  auto x = Tensor({1, 1, 1, 256}, "x");
+  LayerHandle fc = createLayer("fully_connected", {"unit=256", "name=fc_res"});
+  auto h = fc(x);
+  auto out = x.add(h);
+
+  EXPECT_TRUE(out.isValid());
+  // out -> Addition -> [x, h]; h -> fc -> [x]
+  auto inputs = out.getInputTensors();
+  EXPECT_EQ(inputs.size(), 2u);
+  EXPECT_EQ(inputs[0].name(), "x");
+  EXPECT_EQ(inputs[1].getProducingLayer()->getName(), "fc_res");
+}
+
+/**
+ * @brief Chained ops: a.add(b).multiply(c)
+ */
+TEST(nntrainer_ccapi_tensor, chained_ops_p) {
+  using namespace ml::train;
+  auto a = Tensor({1, 1, 1, 64}, "a");
+  auto b = Tensor({1, 1, 1, 64}, "b");
+  auto c = Tensor({1, 1, 1, 64}, "c");
+  auto result = a.add(b).multiply(c);
+
+  EXPECT_TRUE(result.isValid());
+  EXPECT_EQ(result.getProducingLayer()->getType(), "multiply");
+  auto mul_inputs = result.getInputTensors();
+  EXPECT_EQ(mul_inputs.size(), 2u);
+  // First input to multiply is the add result
+  EXPECT_EQ(mul_inputs[0].getProducingLayer()->getType(), "addition");
+}
+
+// ===== Step 2-3: Model::compile(Tensor, Tensor) — graph extraction =====
+
+/**
+ * @brief Simple single FC layer compile from tensor graph
+ */
+TEST(nntrainer_ccapi_graph, simple_fc_compile_p) {
+  using namespace ml::train;
+  auto x = Tensor({1, 1, 1, 784}, "input");
+  LayerHandle fc = createLayer("fully_connected", {"unit=10", "name=fc"});
+  auto y = fc(x);
+
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  EXPECT_EQ(model->compile(x, y), ML_ERROR_NONE);
+}
+
+/**
+ * @brief Multi-layer compile: fc1 -> relu -> fc2
+ */
+TEST(nntrainer_ccapi_graph, multi_layer_compile_p) {
+  using namespace ml::train;
+  auto x = Tensor({1, 1, 1, 784}, "input");
+  LayerHandle fc1 = createLayer("fully_connected", {"unit=128", "name=fc1"});
+  LayerHandle relu = createLayer("activation", {"activation=relu", "name=relu1"});
+  LayerHandle fc2 = createLayer("fully_connected", {"unit=10", "name=fc2"});
+
+  auto h = fc1(x);
+  h = relu(h);
+  auto y = fc2(h);
+
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  EXPECT_EQ(model->compile(x, y), ML_ERROR_NONE);
+}
+
+/**
+ * @brief Residual connection compile: x -> fc1 -> add(x, fc1_out) -> fc_out
+ */
+TEST(nntrainer_ccapi_graph, residual_compile_p) {
+  using namespace ml::train;
+  auto x = Tensor({1, 1, 1, 256}, "input");
+  LayerHandle fc1 = createLayer("fully_connected", {"unit=256", "name=fc1"});
+  auto h = fc1(x);
+  auto out = x.add(h);
+  LayerHandle fc_out = createLayer("fully_connected", {"unit=10", "name=fc_out"});
+  auto y = fc_out(out);
+
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  EXPECT_EQ(model->compile(x, y), ML_ERROR_NONE);
+}
+
+/**
+ * @brief Existing addLayer-based workflow still works
+ */
+TEST(nntrainer_ccapi_graph, existing_add_layer_still_works_p) {
+  using namespace ml::train;
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  model->addLayer(
+    createLayer("input", {"name=in", "input_shape=1:1:784"}));
+  model->addLayer(
+    createLayer("fully_connected", {"name=fc", "unit=10", "input_layers=in"}));
+  EXPECT_EQ(model->compile(), ML_ERROR_NONE);
+}
+
+// ===== Step 2-4: _bind + data injection/extraction =====
+
+/**
+ * @brief After compile, input tensor is materialized and writable
+ */
+TEST(nntrainer_ccapi_graph, data_injection_after_compile_p) {
+  using namespace ml::train;
+  auto x = Tensor({1, 1, 1, 4}, "input");
+  LayerHandle fc = createLayer("fully_connected", {"unit=2", "name=fc"});
+  auto y = fc(x);
+
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  EXPECT_EQ(model->compile(x, y), ML_ERROR_NONE);
+
+  // After compile (which includes initialize + bind), x is materialized
+  EXPECT_TRUE(x.isMaterialized());
+  EXPECT_TRUE(y.isMaterialized());
+
+  // Can inject data
+  float input_data[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+  x.copyFrom(input_data);
+  EXPECT_FLOAT_EQ(x.getValue(0, 0, 0, 0), 1.0f);
+  EXPECT_FLOAT_EQ(x.getValue(0, 0, 0, 3), 4.0f);
+}
+
+/**
+ * @brief Can use setValue/getValue on bound tensors
+ */
+TEST(nntrainer_ccapi_graph, set_get_value_bound_p) {
+  using namespace ml::train;
+  auto x = Tensor({1, 1, 1, 4}, "input");
+  LayerHandle fc = createLayer("fully_connected", {"unit=2", "name=fc"});
+  auto y = fc(x);
+
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  EXPECT_EQ(model->compile(x, y), ML_ERROR_NONE);
+
+  x.setValue(0, 0, 0, 0, 42.0f);
+  EXPECT_FLOAT_EQ(x.getValue(0, 0, 0, 0), 42.0f);
+
+  // data() and mutable_data() should work
+  const float *ptr = x.data<float>();
+  EXPECT_FLOAT_EQ(ptr[0], 42.0f);
+
+  float *mptr = x.mutable_data<float>();
+  mptr[1] = 99.0f;
+  EXPECT_FLOAT_EQ(x.getValue(0, 0, 0, 1), 99.0f);
+}
+
+/**
+ * @brief Symbolic tensors are not materialized before compile
+ */
+TEST(nntrainer_ccapi_graph, not_materialized_before_compile_p) {
+  using namespace ml::train;
+  auto x = Tensor({1, 1, 1, 4}, "input");
+  LayerHandle fc = createLayer("fully_connected", {"unit=2", "name=fc"});
+  auto y = fc(x);
+
+  EXPECT_FALSE(x.isMaterialized());
+  EXPECT_FALSE(y.isMaterialized());
+}
+
+/**
+ * @brief Multi-layer compile with bind
+ */
+TEST(nntrainer_ccapi_graph, multi_layer_bind_p) {
+  using namespace ml::train;
+  auto x = Tensor({1, 1, 1, 8}, "input");
+  LayerHandle fc1 = createLayer("fully_connected", {"unit=4", "name=fc1"});
+  LayerHandle fc2 = createLayer("fully_connected", {"unit=2", "name=fc2"});
+  auto h = fc1(x);
+  auto y = fc2(h);
+
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  EXPECT_EQ(model->compile(x, y), ML_ERROR_NONE);
+
+  EXPECT_TRUE(x.isMaterialized());
+  EXPECT_TRUE(y.isMaterialized());
+
+  // Input shape should match
+  EXPECT_EQ(x.shape().width(), 8u);
+  // Output shape should be fc2's output
+  EXPECT_EQ(y.shape().width(), 2u);
+}
+
+// ===== Step 2-5: Lazy chaining (chain/eval) =====
+
+/**
+ * @brief chain().multiply_i().add_i().eval() executes in order
+ */
+TEST(nntrainer_ccapi_tensor, lazy_chain_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 2, 2});
+  t.chain().multiply_i(2.0f).add_i(1.0f).eval();
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 3.0f);  // 1*2+1
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 1, 1), 3.0f);
+}
+
+/**
+ * @brief Operation order matters: add then multiply
+ */
+TEST(nntrainer_ccapi_tensor, lazy_chain_order_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 1, 1});
+  t.chain().add_i(3.0f).multiply_i(2.0f).eval();
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 8.0f);  // (1+3)*2
+}
+
+/**
+ * @brief eval on non-materialized tensor throws
+ */
+TEST(nntrainer_ccapi_tensor, lazy_eval_on_symbolic_n) {
+  ml::train::Tensor t({1, 1, 2, 2});
+  t.chain().add_i(1.0f);
+  EXPECT_THROW(t.eval(), std::runtime_error);
+}
+
+/**
+ * @brief chain() clears previous pending ops
+ */
+TEST(nntrainer_ccapi_tensor, lazy_chain_reset_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 1, 1});
+  t.chain().add_i(100.0f);  // queued but not eval'd
+  t.chain().add_i(5.0f).eval();  // chain() clears, only +5 applied
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 6.0f);  // 1+5
+}
+
+/**
+ * @brief eval clears the chain after execution
+ */
+TEST(nntrainer_ccapi_tensor, lazy_eval_clears_chain_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 1, 1});
+  t.chain().multiply_i(3.0f).eval();
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 3.0f);
+  // eval again should be no-op (chain is empty)
+  t.eval();
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 3.0f);
+}
+
+/**
+ * @brief Graph with additional leaf tensors (non-fromData) works
+ */
+TEST(nntrainer_ccapi_graph, multiple_leaf_inputs_p) {
+  using namespace ml::train;
+
+  auto x1 = Tensor({1, 1, 1, 4}, "x1");
+  auto x2 = Tensor({1, 1, 1, 4}, "x2");
+
+  // Two separate inputs go into an add layer
+  auto sum = x1.add(x2);
+
+  LayerHandle fc = createLayer("fully_connected", {"unit=2", "name=fc"});
+  auto y = fc(sum);
+
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  EXPECT_EQ(model->compile(x1, y), ML_ERROR_NONE);
+
+  EXPECT_TRUE(x1.isMaterialized());
+  EXPECT_TRUE(y.isMaterialized());
+}
+
+/**
+ * @brief PicoGPT-style transformer graph: 2 inputs, skip connections, fan-out
+ *
+ * Tests the graph pattern used in PicoGPT: dual inputs → embeddings → add →
+ * transformer blocks (LN + MHA + skip + LN + FFN + skip) → final LN.
+ * Uses 1 layer with small dims to keep memory low.
+ */
+TEST(nntrainer_ccapi_graph, picogpt_style_transformer_p) {
+  using namespace ml::train;
+
+  const unsigned int MODEL_DIM = 32;
+  const unsigned int FF_DIM = 64;
+  const unsigned int NUM_HEADS = 4;
+
+  // Two symbolic inputs (like wte_input, wpe_input)
+  Tensor wte_in({1, 1, 1, 1}, "wte_input");
+  Tensor wpe_in({1, 1, 1, 1}, "wpe_input");
+
+  LayerHandle wte = createLayer("embedding",
+    {"name=wte", "in_dim=100", "out_dim=" + std::to_string(MODEL_DIM)});
+  LayerHandle wpe = createLayer("embedding",
+    {"name=wpe", "in_dim=100", "out_dim=" + std::to_string(MODEL_DIM)});
+  auto wte_out = wte(wte_in);
+  auto wpe_out = wpe(wpe_in);
+
+  LayerHandle add_emb = createLayer("Addition", {"name=add"});
+  auto prev = add_emb({wte_out, wpe_out});
+
+  // Single transformer block
+  LayerHandle ln1 = createLayer("layer_normalization",
+    {"name=layer0/ln1", "axis=3", "epsilon=1e-5"});
+  auto ln1_out = ln1(prev);
+
+  // MHA with same tensor as Q, K, V (fan-out test)
+  LayerHandle mha = createLayer("multi_head_attention",
+    {"name=layer0/multi_head_attention",
+     "num_heads=" + std::to_string(NUM_HEADS)});
+  auto attn_out = mha({ln1_out, ln1_out, ln1_out});
+
+  // Skip connection 1: prev + attn_out (prev used twice = fan-out)
+  LayerHandle add1 = createLayer("Addition", {"name=layer0/add1"});
+  auto add1_out = add1({prev, attn_out});
+
+  LayerHandle ln2 = createLayer("layer_normalization",
+    {"name=layer0/ln2", "axis=3", "epsilon=1e-5"});
+  auto ln2_out = ln2(add1_out);
+
+  LayerHandle fc1 = createLayer("fully_connected",
+    {"name=layer0/fc1", "unit=" + std::to_string(FF_DIM), "activation=gelu"});
+  auto fc1_out = fc1(ln2_out);
+
+  LayerHandle fc2 = createLayer("fully_connected",
+    {"name=layer0/fc2", "unit=" + std::to_string(MODEL_DIM)});
+  auto fc2_out = fc2(fc1_out);
+
+  // Skip connection 2: add1_out + fc2_out (add1_out used twice = fan-out)
+  LayerHandle add2 = createLayer("Addition", {"name=layer0/add2"});
+  auto block_out = add2({add1_out, fc2_out});
+
+  LayerHandle final_ln = createLayer("layer_normalization",
+    {"name=layer_normalization", "axis=3", "epsilon=1e-5"});
+  auto output = final_ln(block_out);
+
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  EXPECT_EQ(model->compile(wte_in, output), ML_ERROR_NONE);
+
+  EXPECT_TRUE(wte_in.isMaterialized());
+  EXPECT_TRUE(output.isMaterialized());
+}
+
+/**
+ * @brief PicoGPT-style graph compile + inference with random weights
+ *
+ * Verifies no segfault during forward pass through the graph-compiled model.
+ */
+TEST(nntrainer_ccapi_graph, picogpt_style_inference_p) {
+  using namespace ml::train;
+
+  const unsigned int MODEL_DIM = 16;
+  const unsigned int FF_DIM = 32;
+  const unsigned int NUM_HEADS = 2;
+
+  Tensor wte_in({1, 1, 1, 1}, "wte_input");
+  Tensor wpe_in({1, 1, 1, 1}, "wpe_input");
+
+  LayerHandle wte = createLayer("embedding",
+    {"name=wte", "in_dim=50", "out_dim=" + std::to_string(MODEL_DIM)});
+  LayerHandle wpe = createLayer("embedding",
+    {"name=wpe", "in_dim=50", "out_dim=" + std::to_string(MODEL_DIM)});
+  auto wte_out = wte(wte_in);
+  auto wpe_out = wpe(wpe_in);
+
+  LayerHandle add_emb = createLayer("Addition", {"name=add"});
+  auto prev = add_emb({wte_out, wpe_out});
+
+  // 1 transformer block
+  LayerHandle ln1 = createLayer("layer_normalization",
+    {"name=layer0/ln1", "axis=3", "epsilon=1e-5"});
+  auto ln1_out = ln1(prev);
+
+  LayerHandle mha = createLayer("multi_head_attention",
+    {"name=layer0/mha", "num_heads=" + std::to_string(NUM_HEADS)});
+  auto attn_out = mha({ln1_out, ln1_out, ln1_out});
+
+  LayerHandle add1 = createLayer("Addition", {"name=layer0/add1"});
+  auto add1_out = add1({prev, attn_out});
+
+  LayerHandle ln2 = createLayer("layer_normalization",
+    {"name=layer0/ln2", "axis=3", "epsilon=1e-5"});
+  auto ln2_out = ln2(add1_out);
+
+  LayerHandle fc1 = createLayer("fully_connected",
+    {"name=layer0/fc1", "unit=" + std::to_string(FF_DIM), "activation=gelu"});
+  auto fc1_out = fc1(ln2_out);
+
+  LayerHandle fc2 = createLayer("fully_connected",
+    {"name=layer0/fc2", "unit=" + std::to_string(MODEL_DIM)});
+  auto fc2_out = fc2(fc1_out);
+
+  LayerHandle add2 = createLayer("Addition", {"name=layer0/add2"});
+  auto block_out = add2({add1_out, fc2_out});
+
+  LayerHandle final_ln = createLayer("layer_normalization",
+    {"name=final_ln", "axis=3", "epsilon=1e-5"});
+  auto output = final_ln(block_out);
+
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  ASSERT_EQ(model->compile(wte_in, output), ML_ERROR_NONE);
+
+  // Run inference with dummy input (token id=1 for both inputs)
+  float wte_input_data[1];
+  float wpe_input_data[1];
+  unsigned int wte_token = 1, wpe_token = 0;
+  std::memcpy(wte_input_data, &wte_token, sizeof(unsigned int));
+  std::memcpy(wpe_input_data, &wpe_token, sizeof(unsigned int));
+
+  std::vector<float *> output_bufs;
+  EXPECT_NO_THROW(
+    output_bufs = model->inference(1, {wte_input_data, wpe_input_data}));
+  EXPECT_FALSE(output_bufs.empty());
+}
+
+// ===== Phase 1: Extended eager tensor operations =====
+
+// --- Convenience dimension accessors ---
+
+TEST(nntrainer_ccapi_tensor, size_p) {
+  auto t = ml::train::Tensor::zeros({2, 3, 4, 5});
+  EXPECT_EQ(t.size(), 2u * 3u * 4u * 5u);
+}
+
+TEST(nntrainer_ccapi_tensor, batch_channel_height_width_p) {
+  auto t = ml::train::Tensor::zeros({2, 3, 4, 5});
+  EXPECT_EQ(t.batch(), 2u);
+  EXPECT_EQ(t.channel(), 3u);
+  EXPECT_EQ(t.height(), 4u);
+  EXPECT_EQ(t.width(), 5u);
+}
+
+TEST(nntrainer_ccapi_tensor, empty_p) {
+  ml::train::Tensor t;
+  EXPECT_TRUE(t.empty());
+  auto z = ml::train::Tensor::zeros({1, 1, 2, 2});
+  EXPECT_FALSE(z.empty());
+}
+
+// --- Scalar eager operations ---
+
+TEST(nntrainer_ccapi_tensor, add_scalar_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 2, 2});
+  auto r = t.add(5.0f);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 6.0f);
+  // Original unchanged
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 1.0f);
+}
+
+TEST(nntrainer_ccapi_tensor, subtract_scalar_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 2, 2});
+  auto r = t.subtract(0.5f);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 0.5f);
+}
+
+TEST(nntrainer_ccapi_tensor, multiply_scalar_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 2, 2});
+  auto r = t.multiply(3.0f);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 3.0f);
+}
+
+TEST(nntrainer_ccapi_tensor, divide_scalar_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 2, 2});
+  t.setValue(0, 0, 0, 0, 6.0f);
+  auto r = t.divide(2.0f);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 3.0f);
+}
+
+// --- Tensor-tensor eager operations ---
+
+TEST(nntrainer_ccapi_tensor, subtract_tensor_p) {
+  auto a = ml::train::Tensor::ones({1, 1, 2, 2});
+  auto b = ml::train::Tensor::ones({1, 1, 2, 2});
+  a.setValue(0, 0, 0, 0, 5.0f);
+  auto r = a.subtract(b);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 4.0f);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 1), 0.0f);
+}
+
+TEST(nntrainer_ccapi_tensor, divide_tensor_p) {
+  auto a = ml::train::Tensor::ones({1, 1, 2, 2});
+  auto b = ml::train::Tensor::ones({1, 1, 2, 2});
+  a.setValue(0, 0, 0, 0, 6.0f);
+  b.setValue(0, 0, 0, 0, 3.0f);
+  auto r = a.divide(b);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 2.0f);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 1), 1.0f);
+}
+
+// --- Dot product ---
+
+TEST(nntrainer_ccapi_tensor, dot_p) {
+  // [1,1,1,2] dot [1,1,2,1] = [1,1,1,1]
+  auto a = ml::train::Tensor::ones({1, 1, 1, 2});
+  auto b = ml::train::Tensor::ones({1, 1, 2, 1});
+  a.setValue(0, 0, 0, 0, 2.0f);
+  a.setValue(0, 0, 0, 1, 3.0f);
+  auto r = a.dot(b);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 5.0f); // 2*1 + 3*1
+}
+
+// --- Transpose ---
+
+TEST(nntrainer_ccapi_tensor, transpose_p) {
+  auto t = ml::train::Tensor::zeros({1, 1, 2, 3});
+  t.setValue(0, 0, 0, 0, 1.0f);
+  t.setValue(0, 0, 0, 1, 2.0f);
+  t.setValue(0, 0, 0, 2, 3.0f);
+  t.setValue(0, 0, 1, 0, 4.0f);
+  t.setValue(0, 0, 1, 1, 5.0f);
+  t.setValue(0, 0, 1, 2, 6.0f);
+  auto r = t.transpose("0:2:1"); // swap h and w
+  EXPECT_EQ(r.height(), 3u);
+  EXPECT_EQ(r.width(), 2u);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 1.0f);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 1, 0), 2.0f);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 1), 4.0f);
+}
+
+// --- Power ---
+
+TEST(nntrainer_ccapi_tensor, pow_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 1, 2});
+  t.setValue(0, 0, 0, 0, 3.0f);
+  t.setValue(0, 0, 0, 1, 2.0f);
+  auto r = t.pow(2.0f);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 9.0f);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 1), 4.0f);
+}
+
+// --- Sum and average ---
+
+TEST(nntrainer_ccapi_tensor, sum_axis_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 2, 3});
+  t.setValue(0, 0, 0, 0, 1.0f);
+  t.setValue(0, 0, 0, 1, 2.0f);
+  t.setValue(0, 0, 0, 2, 3.0f);
+  t.setValue(0, 0, 1, 0, 4.0f);
+  t.setValue(0, 0, 1, 1, 5.0f);
+  t.setValue(0, 0, 1, 2, 6.0f);
+  // Sum along axis 3 (width) -> {1,1,2,1}
+  auto r = t.sum(3);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 6.0f);  // 1+2+3
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 1, 0), 15.0f); // 4+5+6
+}
+
+TEST(nntrainer_ccapi_tensor, average_axis_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 2, 2});
+  t.setValue(0, 0, 0, 0, 2.0f);
+  t.setValue(0, 0, 0, 1, 4.0f);
+  t.setValue(0, 0, 1, 0, 6.0f);
+  t.setValue(0, 0, 1, 1, 8.0f);
+  // Average along axis 3 (width) -> {1,1,2,1}
+  auto r = t.average(3);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 3.0f); // (2+4)/2
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 1, 0), 7.0f); // (6+8)/2
+}
+
+TEST(nntrainer_ccapi_tensor, average_global_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 2, 2});
+  t.setValue(0, 0, 0, 0, 2.0f);
+  t.setValue(0, 0, 0, 1, 4.0f);
+  t.setValue(0, 0, 1, 0, 6.0f);
+  t.setValue(0, 0, 1, 1, 8.0f);
+  auto r = t.average();
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 5.0f); // (2+4+6+8)/4
+}
+
+// --- L2 norm ---
+
+TEST(nntrainer_ccapi_tensor, l2norm_p) {
+  auto t = ml::train::Tensor::zeros({1, 1, 1, 2});
+  t.setValue(0, 0, 0, 0, 3.0f);
+  t.setValue(0, 0, 0, 1, 4.0f);
+  EXPECT_FLOAT_EQ(t.l2norm(), 5.0f); // sqrt(9+16)
+}
+
+// --- setZero ---
+
+TEST(nntrainer_ccapi_tensor, set_zero_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 2, 2});
+  t.setZero();
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 0.0f);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 1, 1), 0.0f);
+}
+
+// --- copyData ---
+
+TEST(nntrainer_ccapi_tensor, copy_data_p) {
+  auto src = ml::train::Tensor::ones({1, 1, 2, 2});
+  src.setValue(0, 0, 0, 0, 42.0f);
+  auto dst = ml::train::Tensor::zeros({1, 1, 2, 2});
+  dst.copyData(src);
+  EXPECT_FLOAT_EQ(dst.getValue(0, 0, 0, 0), 42.0f);
+  EXPECT_FLOAT_EQ(dst.getValue(0, 0, 0, 1), 1.0f);
+}
+
+// --- fill ---
+
+TEST(nntrainer_ccapi_tensor, fill_p) {
+  auto src = ml::train::Tensor::ones({1, 1, 2, 2});
+  src.setValue(0, 0, 0, 0, 99.0f);
+  auto dst = ml::train::Tensor::zeros({1, 1, 2, 2});
+  dst.fill(src);
+  EXPECT_FLOAT_EQ(dst.getValue(0, 0, 0, 0), 99.0f);
+}
+
+// --- apply / apply_i ---
+
+TEST(nntrainer_ccapi_tensor, apply_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 1, 3});
+  t.setValue(0, 0, 0, 0, 1.0f);
+  t.setValue(0, 0, 0, 1, 4.0f);
+  t.setValue(0, 0, 0, 2, 9.0f);
+  auto r = t.apply([](float x) { return x * x; });
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 0), 1.0f);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 1), 16.0f);
+  EXPECT_FLOAT_EQ(r.getValue(0, 0, 0, 2), 81.0f);
+  // Original unchanged
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 1), 4.0f);
+}
+
+TEST(nntrainer_ccapi_tensor, apply_i_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 1, 2});
+  t.setValue(0, 0, 0, 0, 3.0f);
+  t.setValue(0, 0, 0, 1, 5.0f);
+  t.apply_i([](float x) { return x + 10.0f; });
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 13.0f);
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 1), 15.0f);
+}
+
+// --- Extended lazy chain ---
+
+TEST(nntrainer_ccapi_tensor, lazy_subtract_i_scalar_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 1, 1});
+  t.setValue(0, 0, 0, 0, 10.0f);
+  t.chain().subtract_i(3.0f).eval();
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 7.0f);
+}
+
+TEST(nntrainer_ccapi_tensor, lazy_divide_i_scalar_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 1, 1});
+  t.setValue(0, 0, 0, 0, 12.0f);
+  t.chain().divide_i(4.0f).eval();
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 3.0f);
+}
+
+TEST(nntrainer_ccapi_tensor, lazy_pow_i_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 1, 1});
+  t.setValue(0, 0, 0, 0, 3.0f);
+  t.chain().pow_i(2.0f).eval();
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 9.0f);
+}
+
+TEST(nntrainer_ccapi_tensor, lazy_tensor_add_i_p) {
+  auto a = ml::train::Tensor::ones({1, 1, 1, 2});
+  auto b = ml::train::Tensor::ones({1, 1, 1, 2});
+  a.setValue(0, 0, 0, 0, 3.0f);
+  b.setValue(0, 0, 0, 0, 7.0f);
+  a.chain().add_i(b).eval();
+  EXPECT_FLOAT_EQ(a.getValue(0, 0, 0, 0), 10.0f); // 3+7
+  EXPECT_FLOAT_EQ(a.getValue(0, 0, 0, 1), 2.0f);  // 1+1
+}
+
+TEST(nntrainer_ccapi_tensor, lazy_tensor_multiply_i_p) {
+  auto a = ml::train::Tensor::ones({1, 1, 1, 2});
+  auto b = ml::train::Tensor::ones({1, 1, 1, 2});
+  a.setValue(0, 0, 0, 0, 3.0f);
+  b.setValue(0, 0, 0, 0, 4.0f);
+  a.chain().multiply_i(b).eval();
+  EXPECT_FLOAT_EQ(a.getValue(0, 0, 0, 0), 12.0f); // 3*4
+  EXPECT_FLOAT_EQ(a.getValue(0, 0, 0, 1), 1.0f);  // 1*1
+}
+
+TEST(nntrainer_ccapi_tensor, lazy_complex_chain_p) {
+  auto t = ml::train::Tensor::ones({1, 1, 1, 1});
+  t.setValue(0, 0, 0, 0, 10.0f);
+  // (10 + 2) * 3 - 1 = 35
+  t.chain().add_i(2.0f).multiply_i(3.0f).subtract_i(1.0f).eval();
+  EXPECT_FLOAT_EQ(t.getValue(0, 0, 0, 0), 35.0f);
+}
+
+// --- getBatchSlice ---
+
+TEST(nntrainer_ccapi_tensor, get_batch_slice_p) {
+  auto t = ml::train::Tensor::zeros({2, 1, 1, 3});
+  t.setValue(0, 0, 0, 0, 1.0f);
+  t.setValue(0, 0, 0, 1, 2.0f);
+  t.setValue(0, 0, 0, 2, 3.0f);
+  t.setValue(1, 0, 0, 0, 4.0f);
+  t.setValue(1, 0, 0, 1, 5.0f);
+  t.setValue(1, 0, 0, 2, 6.0f);
+
+  auto s = t.getBatchSlice(1, 1); // second batch
+  EXPECT_EQ(s.batch(), 1u);
+  EXPECT_FLOAT_EQ(s.getValue(0, 0, 0, 0), 4.0f);
+  EXPECT_FLOAT_EQ(s.getValue(0, 0, 0, 2), 6.0f);
+}
+
+// --- Eager ops on unmaterialized tensor throw ---
+
+TEST(nntrainer_ccapi_tensor, eager_ops_unmaterialized_n) {
+  ml::train::Tensor t({1, 1, 2, 2});
+  EXPECT_THROW(t.add(1.0f), std::runtime_error);
+  EXPECT_THROW(t.subtract(1.0f), std::runtime_error);
+  EXPECT_THROW(t.multiply(1.0f), std::runtime_error);
+  EXPECT_THROW(t.divide(1.0f), std::runtime_error);
+  EXPECT_THROW(t.pow(2.0f), std::runtime_error);
+  EXPECT_THROW(t.l2norm(), std::runtime_error);
+  EXPECT_THROW(t.setZero(), std::runtime_error);
+}
+
+// --- argmax ---
+
+TEST(nntrainer_ccapi_tensor, argmax_p) {
+  // shape [2, 1, 1, 3] — 2 batch elements, each with 3 values
+  auto t = ml::train::Tensor::zeros({2, 1, 1, 3});
+  t.setValue(0, 0, 0, 0, 1.0f);
+  t.setValue(0, 0, 0, 1, 5.0f);
+  t.setValue(0, 0, 0, 2, 3.0f);
+  t.setValue(1, 0, 0, 0, 9.0f);
+  t.setValue(1, 0, 0, 1, 2.0f);
+  t.setValue(1, 0, 0, 2, 7.0f);
+
+  auto ids = t.argmax();
+  EXPECT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], 1u); // max at index 1 (value 5.0)
+  EXPECT_EQ(ids[1], 0u); // max at index 0 (value 9.0)
+}
+
+// ===== CausalLM-pattern symbolic graph verification =====
+
+/**
+ * @brief CausalLM-style multi-input compile with external KV cache tensors,
+ *        residual connections (Tensor::add), and multiple decoder blocks.
+ *
+ * Validates the exact symbolic graph construction pattern used by the
+ * CausalLM base class after conversion to Tensor API:
+ *   Input → Embedding(FC) → N x [Norm(LN) → Attention(FC) → Residual(add)
+ *                                → Norm(LN) → MLP(FC→FC) → Residual(add)]
+ *           → FinalNorm(LN) → LMHead(FC)
+ *
+ * External KV cache inputs are passed as additional leaf tensors via
+ * compile(vector<Tensor>, vector<Tensor>).
+ */
+TEST(nntrainer_ccapi_graph, causallm_style_multi_input_p) {
+  using namespace ml::train;
+
+  const unsigned int SEQ_LEN = 4;
+  const unsigned int DIM = 16;
+  const unsigned int FF_DIM = 32;
+  const unsigned int NUM_LAYERS = 2;
+  const unsigned int VOCAB_SIZE = 50;
+
+  // --- Main input (leaf symbolic tensor) ---
+  Tensor input({1, 1, 1, SEQ_LEN}, "input0");
+
+  // --- Embedding (using FC as proxy) ---
+  LayerHandle embedding = createLayer(
+    "fully_connected",
+    {"name=embedding0", "unit=" + std::to_string(DIM), "disable_bias=true"});
+  Tensor x = embedding(input);
+
+  // --- Decoder blocks: tests residual connections, fan-out, multi-layer ---
+  for (unsigned int layer_id = 0; layer_id < NUM_LAYERS; ++layer_id) {
+    std::string prefix = "layer" + std::to_string(layer_id);
+
+    // Attention norm
+    LayerHandle att_norm = createLayer(
+      "layer_normalization",
+      {"name=" + prefix + "_att_norm", "axis=3", "epsilon=1e-5"});
+    Tensor normed = att_norm(x);
+
+    // Q/K/V projections (self-attention: all from same normed input)
+    LayerHandle q_proj = createLayer(
+      "fully_connected",
+      {"name=" + prefix + "_wq", "unit=" + std::to_string(DIM),
+       "disable_bias=true"});
+    LayerHandle k_proj = createLayer(
+      "fully_connected",
+      {"name=" + prefix + "_wk", "unit=" + std::to_string(DIM),
+       "disable_bias=true"});
+    LayerHandle v_proj = createLayer(
+      "fully_connected",
+      {"name=" + prefix + "_wv", "unit=" + std::to_string(DIM),
+       "disable_bias=true"});
+    Tensor q = q_proj(normed);
+    Tensor k = k_proj(normed);
+    Tensor v = v_proj(normed);
+
+    // Attention proxy: Addition of Q+K+V → O projection
+    LayerHandle qkv_combine =
+      createLayer("Addition", {"name=" + prefix + "_qkv_combine"});
+    Tensor combined = qkv_combine({q, k, v});
+
+    LayerHandle o_proj = createLayer(
+      "fully_connected",
+      {"name=" + prefix + "_wo", "unit=" + std::to_string(DIM),
+       "disable_bias=true"});
+    Tensor att_out = o_proj(combined);
+
+    // Residual add (Tensor::add creates implicit Addition layer)
+    Tensor residual = x.add(att_out);
+
+    // FFN norm
+    LayerHandle ffn_norm = createLayer(
+      "layer_normalization",
+      {"name=" + prefix + "_ffn_norm", "axis=3", "epsilon=1e-5"});
+    Tensor ffn_normed = ffn_norm(residual);
+
+    // MLP: up → gate → multiply → down
+    LayerHandle ffn_up = createLayer(
+      "fully_connected",
+      {"name=" + prefix + "_ffn_up", "unit=" + std::to_string(FF_DIM),
+       "disable_bias=true"});
+    LayerHandle ffn_gate = createLayer(
+      "fully_connected",
+      {"name=" + prefix + "_ffn_gate", "unit=" + std::to_string(FF_DIM),
+       "disable_bias=true"});
+    Tensor up = ffn_up(ffn_normed);
+    Tensor gate = ffn_gate(ffn_normed);
+
+    // SwiGLU proxy: element-wise multiply (up * gate)
+    Tensor activated = up.multiply(gate);
+
+    LayerHandle ffn_down = createLayer(
+      "fully_connected",
+      {"name=" + prefix + "_ffn_down", "unit=" + std::to_string(DIM),
+       "disable_bias=true"});
+    Tensor ffn_out = ffn_down(activated);
+
+    // Residual add
+    x = residual.add(ffn_out);
+  }
+
+  // --- Final norm ---
+  LayerHandle output_norm = createLayer(
+    "layer_normalization", {"name=output_norm", "axis=3", "epsilon=1e-5"});
+  x = output_norm(x);
+
+  // --- LM Head ---
+  LayerHandle lmhead = createLayer(
+    "fully_connected",
+    {"name=output_of_causallm", "unit=" + std::to_string(VOCAB_SIZE),
+     "disable_bias=true"});
+  Tensor output = lmhead(x);
+
+  // --- Compile from symbolic tensor graph (includes initialize) ---
+  auto model = createModel(ModelType::NEURAL_NET, {"batch_size=1"});
+  ASSERT_EQ(model->compile(input, output, ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
+
+  // --- Verify tensors are materialized after compile ---
+  EXPECT_TRUE(input.isMaterialized());
+  EXPECT_TRUE(output.isMaterialized());
+
+  // --- Run inference with dummy data ---
+  std::vector<float> input_data(SEQ_LEN, 1.0f);
+  std::vector<float *> output_bufs;
+  EXPECT_NO_THROW(output_bufs = model->inference(1, {input_data.data()}));
+  EXPECT_FALSE(output_bufs.empty());
+  EXPECT_NE(output_bufs[0], nullptr);
 }


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


### Redesign ml::train::Tensor API with Pimpl + symbolic graph compile

Reworks the public ml::train::Tensor class from a thin Var_Grad
wrapper into a standalone, Pimpl-backed API that supports:

- Symbolic tensors (constructed from TensorDim) that act as graph
  placeholders bound to internal storage at compile time.
- Eager tensors (fromData/zeros/ones) that carry data immediately.
- Lazy operation chaining (chain/add_i/subtract_i/multiply_i/
  divide_i/pow_i/inv_sqrt_i/eval) implemented with std::function
  queues over the existing internal nntrainer::Tensor ops -- no
  dependency on the LazyTensor class.
- Graph-based Model::compile(Tensor &input, Tensor &output, ...)
  overloads (single input, multi-output, multi-input/multi-output)
  that walk backwards from the output tensors to discover all
  layers and wire input_layers automatically, replacing manual
  addLayer() + string-based input wiring.

The implementation is split across four translation units to keep
each file focused:

  src/tensor_api_impl.h     -- shared Impl / SymbolicGraphNode types
  src/tensor_api.cpp        -- construction, state, data, factories
  src/tensor_api_ops.cpp    -- eager numeric ops + manipulation
  src/tensor_api_lazy.cpp   -- chain / add_i / ... / eval
  src/tensor_api_graph.cpp  -- LayerHandle, implicit ops, compile

api/ccapi/README.md documents the API: motivation, tensor states,
graph construction, compile overloads, lazy chaining, migration
from the legacy addLayer+input_layers pattern, and an end-to-end
example.

### Migrate sample apps and ccapi tests to symbolic tensor graph API
Rewrites 13 example applications (MNIST, Resnet, SimpleFC, LLaMA,
PicoGPT, MixedPrecision, Multi_input, YOLOv2, YOLOv3, ProductRatings,
Android/PicoGPTJNI) to build their models via the new
Model::compile(Tensor, Tensor, ...) graph API instead of the
addLayer + string input_layers pattern.

test/ccapi/unittest_ccapi_tensor.cpp is added with 86 tests
covering symbolic/eager tensor construction, lazy operation
chaining, graph-based compile (single, multi-input, multi-output),
leaf tensor wiring, and picogpt/causallm style integrations.

MNIST/Resnet/ProductRatings meson.build files are updated to drop
the now-unused .ini arguments from the app test invocation — the
models are built via ccapi.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>