### PR TITLE
[TurboQuant] Add naive-version TurboQuant kernels to cpu_backend

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -27,6 +27,7 @@
 /usr/include/nntrainer/cblas_interface.h
 /usr/include/nntrainer/x86_compute_backend.h
 /usr/include/nntrainer/cpu_backend.h
+/usr/include/nntrainer/turboquant_utils.h
 /usr/include/nntrainer/var_grad.h
 /usr/include/nntrainer/weight.h
 /usr/include/nntrainer/quantizer.h

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -586,4 +586,34 @@ void transform_int4_osv32_isv2_to_q4_0(size_t N, size_t K,
 #endif
 }
 
+void quantize_kv_turboquant(const float *input, uint8_t *out_packed,
+                            float *out_norms, const float *rot_signs,
+                            int head_dim, int num_heads) {
+  __fallback_quantize_kv_turboquant(input, out_packed, out_norms, rot_signs,
+                                    head_dim, num_heads);
+}
+
+void compute_kcaches_packed4(const float *query, const uint8_t *kcache_packed,
+                             const float *kcache_norms, float *output,
+                             int num_rows, int num_cache_head, int head_dim,
+                             int gqa_size, int tile_size,
+                             const float *rot_signs, size_t local_window_size,
+                             int head_start, int head_end) {
+  __fallback_compute_kcaches_packed4(query, kcache_packed, kcache_norms, output,
+                                     num_rows, num_cache_head, head_dim,
+                                     gqa_size, tile_size, rot_signs,
+                                     local_window_size, head_start, head_end);
+}
+
+void compute_vcache_packed4(int row_num, const float *attn_weights,
+                            const uint8_t *vcache_packed,
+                            const float *vcache_norms, float *output,
+                            int num_cache_head, int gqa_size, int head_dim,
+                            const float *rot_signs, size_t local_window_size,
+                            int head_start, int head_end) {
+  __fallback_compute_vcache_packed4(
+    row_num, attn_weights, vcache_packed, vcache_norms, output, num_cache_head,
+    gqa_size, head_dim, rot_signs, local_window_size, head_start, head_end);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1502,6 +1502,35 @@ void transform_int4_osv32_isv2_to_q4_0(size_t N, size_t K,
                                        size_t scale_group_size,
                                        void *dst_q4_0x);
 
+/**
+ * @copydoc quantize_kv_turboquant in cpu_backend.h
+ */
+void quantize_kv_turboquant(const float *input, uint8_t *out_packed,
+                            float *out_norms, const float *rot_signs,
+                            int head_dim, int num_heads);
+
+/**
+ * @copydoc compute_kcaches_packed4 in cpu_backend.h
+ */
+void compute_kcaches_packed4(const float *query, const uint8_t *kcache_packed,
+                             const float *kcache_norms, float *output,
+                             int num_rows, int num_cache_head, int head_dim,
+                             int gqa_size, int tile_size,
+                             const float *rot_signs,
+                             size_t local_window_size = UINT_MAX,
+                             int head_start = 0, int head_end = -1);
+
+/**
+ * @copydoc compute_vcache_packed4 in cpu_backend.h
+ */
+void compute_vcache_packed4(int row_num, const float *attn_weights,
+                            const uint8_t *vcache_packed,
+                            const float *vcache_norms, float *output,
+                            int num_cache_head, int gqa_size, int head_dim,
+                            const float *rot_signs,
+                            size_t local_window_size = UINT_MAX,
+                            int head_start = 0, int head_end = -1);
+
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __ARM_COMPUTE_BACKEND_H__ */

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -1510,5 +1510,40 @@ extern void transform_int4_osv32_isv2_to_q4_0(size_t N, size_t K,
                                               size_t scale_group_size,
                                               void *dst_q4_0x);
 
+/**
+ * @brief TurboQuant : norm-normalized + rotated + Lloyd-Max quantize per head
+ * @param[in]   input       FP32 input (num_head * head_dim elements)
+ * @param[out]  out_packed  4-bit packed output (num_heads * head_dim / 2 bytes)
+ * @param[out]  out_nrms    per-head L2 norms (num_headds floats)
+ * @param[in]   rot_signs   random sign vector for roatation (head_dim elements)
+ * @param[in]   head_dim    dimension per head (power of 2)
+ * @param[in]   num_heads   number of heads
+ */
+extern void quantize_kv_turboquant(const float *input, uint8_t *out_packed,
+                                   float *out_norms, const float *rot_signs,
+                                   int head_dim, int num_heads);
+
+/**
+ * @brief Compute Q*K^T with TurboQuant v2 packed key cache.
+ *        Dequantizes via centroid lookup + inverse rotation + norm rescale,
+ *        then dot product with query.
+ */
+extern void compute_kcaches_packed4(
+  const float *query, const uint8_t *kcache_packed, const float *kcache_norms,
+  float *output, int num_rows, int num_cache_head, int head_dim, int gqa_size,
+  int tile_size, const float *rot_signs, size_t local_window_size = UINT_MAX,
+  int head_start = 0, int head_end = -1);
+
+/**
+ * @brief Compute attention-weighted V aggregation with TurboQuant v2.
+ */
+extern void compute_vcache_packed4(int row_num, const float *attn_weights,
+                                   const uint8_t *vcache_packed,
+                                   const float *vcache_norms, float *output,
+                                   int num_cache_head, int gqa_size,
+                                   int head_dim, const float *rot_signs,
+                                   size_t local_window_size = UINT_MAX,
+                                   int head_start = 0, int head_end = -1);
+
 #endif
 #endif

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -205,6 +205,10 @@ void tanh_gelu_v2(const unsigned int N, const float *X, float *Y) {
   __fallback_tanh_gelu(N, X, Y);
 }
 
+void gelu_v2(const unsigned int N, const float *X, float *Y) {
+  __fallback_gelu_v2(N, X, Y);
+}
+
 void tanh_gelu_mul(const unsigned int N, float *X, float *Y, float *Z) {
   __fallback_tanh_gelu_mul(N, X, Y, Z);
 }
@@ -373,6 +377,36 @@ void transform_int4_osv32_isv2_to_q4_0(size_t N, size_t K,
                                        void *dst_q4_0x) {
   __fallback_transform_int4_osv32_isv2_to_q4_0(
     N, K, osv32_weights, osv32_scales, scale_group_size, 8, dst_q4_0x);
+}
+
+void quantize_kv_turboquant(const float *input, uint8_t *out_packed,
+                            float *out_norms, const float *rot_signs,
+                            int head_dim, int num_heads) {
+  __fallback_quantize_kv_turboquant(input, out_packed, out_norms, rot_signs,
+                                    head_dim, num_heads);
+}
+
+void compute_kcaches_packed4(const float *query, const uint8_t *kcache_packed,
+                             const float *kcache_norms, float *output,
+                             int num_rows, int num_cache_head, int head_dim,
+                             int gqa_size, int tile_size,
+                             const float *rot_signs, size_t local_window_size,
+                             int head_start, int head_end) {
+  __fallback_compute_kcaches_packed4(query, kcache_packed, kcache_norms, output,
+                                     num_rows, num_cache_head, head_dim,
+                                     gqa_size, tile_size, rot_signs,
+                                     local_window_size, head_start, head_end);
+}
+
+void compute_vcache_packed4(int row_num, const float *attn_weights,
+                            const uint8_t *vcache_packed,
+                            const float *vcache_norms, float *output,
+                            int num_cache_head, int gqa_size, int head_dim,
+                            const float *rot_signs, size_t local_window_size,
+                            int head_start, int head_end) {
+  __fallback_compute_vcache_packed4(
+    row_num, attn_weights, vcache_packed, vcache_norms, output, num_cache_head,
+    gqa_size, head_dim, rot_signs, local_window_size, head_start, head_end);
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -646,6 +646,15 @@ void tanh_gelu(const unsigned int N, const float *X, float *Y);
 void tanh_gelu_v2(const unsigned int N, const float *X, float *Y);
 
 /**
+ * @brief gelu v2 function : Y = 0.5 * X * (1 + erf(X / sqrt(2)))
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X (input)
+ * @param Y float * for Vector Y (output)
+ */
+void gelu_v2(const unsigned int N, const float *X, float *Y);
+
+/**
  * @brief tanh_gelu function with neon but as
  * X = Y / (1 + exp(-pi/4*(Y
  *      + 0.044715Y^3)) * Z
@@ -1426,6 +1435,35 @@ void transform_int4_osv32_isv2_to_q4_0(size_t N, size_t K,
                                        const uint16_t *osv32_scales,
                                        size_t scale_group_size,
                                        void *dst_q4_0x);
+
+/**
+ * @copydoc quantize_kv_turboquant in cpu_backend.h
+ */
+void quantize_kv_turboquant(const float *input, uint8_t *out_packed,
+                            float *out_norms, const float *rot_signs,
+                            int head_dim, int num_heads);
+
+/**
+ * @copydoc compute_kcaches_packed4 in cpu_backend.h
+ */
+void compute_kcaches_packed4(const float *query, const uint8_t *kcache_packed,
+                             const float *kcache_norms, float *output,
+                             int num_rows, int num_cache_head, int head_dim,
+                             int gqa_size, int tile_size,
+                             const float *rot_signs,
+                             size_t local_window_size = UINT_MAX,
+                             int head_start = 0, int head_end = -1);
+
+/**
+ * @copydoc compute_vcache_packed4 in cpu_backend.h
+ */
+void compute_vcache_packed4(int row_num, const float *attn_weights,
+                            const uint8_t *vcache_packed,
+                            const float *vcache_norms, float *output,
+                            int num_cache_head, int gqa_size, int head_dim,
+                            const float *rot_signs,
+                            size_t local_window_size = UINT_MAX,
+                            int head_start = 0, int head_end = -1);
 
 #endif /* __cplusplus */
 #endif /* __FALLBACK_H__ */

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -21,7 +21,9 @@
 #include <q4_0_utils.h>
 #include <stdexcept>
 #include <tensor_dim.h>
+#include <turboquant_utils.h>
 #include <util_func.h>
+#include <vector>
 
 #define sgemv_loop(ci, cj, cM, cN)                                             \
   do {                                                                         \
@@ -662,6 +664,108 @@ void __fallback_transform_int4_osv32_isv2_to_q4_0(size_t N, size_t K,
   Q4_0Utils::transformQ4_0x_FromInt4(N, K, osv32_weights, osv32_scales,
                                      scale_group_size, q4_0x_block_size,
                                      dst_q4_0x);
+}
+
+void __fallback_quantize_kv_turboquant(const float *input, uint8_t *out_packed,
+                                       float *out_norms, const float *rot_signs,
+                                       int head_dim, int num_heads) {
+  const LloydMaxCodebook &cb = get_codebook(head_dim);
+  for (int h = 0; h < num_heads; ++h) {
+    turboquant_quantize_head(input + h * head_dim, head_dim,
+                             out_packed + h * head_dim / 2, out_norms + h,
+                             rot_signs, cb);
+  }
+}
+
+void __fallback_compute_kcaches_packed4(
+  const float *query, const uint8_t *kcache_packed, const float *kcache_norms,
+  float *output, int num_rows, int num_cache_head, int head_dim, int gqa_size,
+  int tile_size, const float *rot_signs, size_t local_window_size,
+  int head_start, int head_end) {
+  const LloydMaxCodebook &cb = get_codebook(head_dim);
+  int actual_head_end = (head_end < 0) ? num_cache_head : head_end;
+  int start_row =
+    (size_t)num_rows < local_window_size ? 0 : num_rows - local_window_size;
+  int row_cnt =
+    (size_t)num_rows < local_window_size ? num_rows : local_window_size;
+  int packed_row_bytes = num_cache_head * head_dim / 2;
+  float inv_sqrt_d = 1.0f / std::sqrt((float)head_dim);
+
+  std::vector<float> rotated_queries(gqa_size * head_dim);
+
+  for (int n = head_start; n < actual_head_end; ++n) {
+    for (int g = 0; g < gqa_size; ++g) {
+      const float *q_ptr = query + n * gqa_size * head_dim + g * head_dim;
+      float *rq = rotated_queries.data() + g * head_dim;
+      for (int i = 0; i < head_dim; ++i)
+        rq[i] = q_ptr[i] * rot_signs[i];
+      hadamard_transform(rq, head_dim);
+    }
+
+    for (int t_row = 0; t_row < row_cnt; ++t_row) {
+      int row = start_row + t_row;
+      const uint8_t *packed_ptr =
+        kcache_packed + row * packed_row_bytes + n * head_dim / 2;
+      float norm = kcache_norms[row * num_cache_head + n];
+
+      for (int g = 0; g < gqa_size; ++g) {
+        const float *rq = rotated_queries.data() + g * head_dim;
+        float sum = 0.0f;
+        for (int d = 0; d < head_dim; d += 2) {
+          uint8_t byte = packed_ptr[d / 2];
+          sum += rq[d] * cb.centroids[byte & 0x0F];
+          if (d + 1 < head_dim)
+            sum += rq[d + 1] * cb.centroids[(byte >> 4) & 0x0F];
+        }
+        output[t_row * num_cache_head * gqa_size + n * gqa_size + g] =
+          sum * norm * inv_sqrt_d;
+      }
+    }
+  }
+}
+
+void __fallback_compute_vcache_packed4(int row_num, const float *attn_weights,
+                                       const uint8_t *vcache_packed,
+                                       const float *vcache_norms, float *output,
+                                       int num_cache_head, int gqa_size,
+                                       int head_dim, const float *rot_signs,
+                                       size_t local_window_size, int head_start,
+                                       int head_end) {
+  const LloydMaxCodebook &cb = get_codebook(head_dim);
+  int actual_head_end = (head_end < 0) ? num_cache_head : head_end;
+  int packed_row_bytes = num_cache_head * head_dim / 2;
+  int j_start = (size_t)row_num < local_window_size
+                  ? 0
+                  : row_num + 1 - (int)local_window_size;
+
+  std::vector<float> acc(head_dim);
+
+  for (int n = head_start; n < actual_head_end; ++n) {
+    for (int h = 0; h < gqa_size; ++h) {
+      std::fill(acc.begin(), acc.end(), 0.0f);
+
+      for (int j = j_start; j <= row_num; ++j) {
+        float a_val =
+          attn_weights[((j - j_start) * num_cache_head + n) * gqa_size + h];
+        const uint8_t *packed_ptr =
+          vcache_packed + j * packed_row_bytes + n * head_dim / 2;
+        float norm = vcache_norms[j * num_cache_head + n];
+        float scale = a_val * norm;
+
+        for (int d = 0; d < head_dim; d += 2) {
+          uint8_t byte = packed_ptr[d / 2];
+          acc[d] += scale * cb.centroids[byte & 0x0F];
+          if (d + 1 < head_dim)
+            acc[d + 1] += scale * cb.centroids[(byte >> 4) & 0x0F];
+        }
+      }
+
+      hadamard_transform(acc.data(), head_dim);
+      int out_base = (n * gqa_size + h) * head_dim;
+      for (int d = 0; d < head_dim; ++d)
+        output[out_base + d] = acc[d] * rot_signs[d];
+    }
+  }
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -1348,6 +1348,33 @@ void __fallback_transform_int4_osv32_isv2_to_q4_0(size_t N, size_t K,
                                                   int q4_0x_block_size,
                                                   void *dst_q4_0x);
 
+/**
+ * @copydoc quantize_kv_turboquant in cpu_backend.h
+ */
+void __fallback_quantize_kv_turboquant(const float *input, uint8_t *out_packed,
+                                       float *out_norms, const float *rot_signs,
+                                       int head_dim, int num_heads);
+
+/**
+ * @copydoc compute_kcaches_packed4 in cpu_backend.h
+ */
+void __fallback_compute_kcaches_packed4(
+  const float *query, const uint8_t *kcache_packed, const float *kcache_norms,
+  float *output, int num_rows, int num_cache_head, int head_dim, int gqa_size,
+  int tile_size, const float *rot_signs, size_t local_window_size = UINT_MAX,
+  int head_start = 0, int head_end = -1);
+
+/**
+ * @copydoc compute_vcache_packed4 in cpu_backend.h
+ */
+void __fallback_compute_vcache_packed4(int row_num, const float *attn_weights,
+                                       const uint8_t *vcache_packed,
+                                       const float *vcache_norms, float *output,
+                                       int num_cache_head, int gqa_size,
+                                       int head_dim, const float *rot_signs,
+                                       size_t local_window_size = UINT_MAX,
+                                       int head_start = 0, int head_end = -1);
+
 } // namespace nntrainer
 #endif
 #endif

--- a/nntrainer/tensor/cpu_backend/meson.build
+++ b/nntrainer/tensor/cpu_backend/meson.build
@@ -1,5 +1,6 @@
 cpu_backend_headers = [
   'cpu_backend.h',
+  'turboquant_utils.h',
 ]
 
 subdir('fallback')

--- a/nntrainer/tensor/cpu_backend/turboquant_utils.h
+++ b/nntrainer/tensor/cpu_backend/turboquant_utils.h
@@ -24,6 +24,8 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace nntrainer {
@@ -114,10 +116,20 @@ static constexpr LloydMaxCodebook CODEBOOK_D128 = {
    -0.04596127f, -0.02272669f, 0.0f, 0.02272669f, 0.04596127f, 0.07029944f,
    0.09655728f, 0.12604554f, 0.16131932f, 0.20924874f}};
 
+/**
+ * @brief  Return the Lloyd-Max codebook for the requested head dimension.
+ *         Only the precomputed codebooks (head_dim == 64 or 128) are valid;
+ *         any other head_dim is explicitly rejected to avoid silently using a
+ *         mismatched quantizer that would degrade attention quality.
+ */
 inline const LloydMaxCodebook &get_codebook(int head_dim) {
   if (head_dim == 64)
     return CODEBOOK_D64;
-  return CODEBOOK_D128;
+  if (head_dim == 128)
+    return CODEBOOK_D128;
+  throw std::invalid_argument("TurboQuant get_codebook: unsupported head_dim=" +
+                              std::to_string(head_dim) +
+                              " (only 64 and 128 are supported)");
 }
 
 /** Lloyd-Max quantize: boundary search for optimal bin index (4-bit). */

--- a/nntrainer/tensor/cpu_backend/turboquant_utils.h
+++ b/nntrainer/tensor/cpu_backend/turboquant_utils.h
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2025 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   turboquant_utils.h
+ * @date   28 March 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  TurboQuant KV cache compression utilities.
+ *
+ *         Norm normalization + Hadamard rotation + Lloyd-Max codebook
+ *         (paper Algorithm 1: MSE-optimal, 4-bit per coordinate)
+ *
+ * Packing layout (per byte):
+ *   Lower nibble (bits 0-3): element[2i]   → [data(4)]
+ *   Upper nibble (bits 4-7): element[2i+1] → [data(4)]
+ */
+
+#ifndef __TURBOQUANT_UTILS_H__
+#define __TURBOQUANT_UTILS_H__
+#ifdef __cplusplus
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace nntrainer {
+
+/***********************************************************************
+ * Hadamard transform and rotation utilities
+ ***********************************************************************/
+
+/**
+ * @brief In-place Walsh-Hadamard Transform (WHT).
+ *        Normalizes by 1/sqrt(n) so the transform is orthogonal.
+ *        Fast Walsh-Hadmard Transform (FWHT)
+ */
+inline void hadamard_transform(float *x, int n) {
+  for (int len = 1; len < n; len <<= 1) {
+    for (int i = 0; i < n; i += len << 1) {
+      for (int j = 0; j < len; ++j) {
+        float u = x[i + j];
+        float v = x[i + j + len];
+        x[i + j] = u + v;
+        x[i + j + len] = u - v;
+      }
+    }
+  }
+  float inv_sqrt_n = 1.0f / std::sqrt((float)n);
+  for (int i = 0; i < n; ++i)
+    x[i] *= inv_sqrt_n;
+}
+
+/**
+ * @brief Generate deterministic random sign vector (±1) via LCG.
+ * */
+inline void generate_random_signs(float *signs, int n,
+                                  uint32_t seed = 0x5EED1234) {
+  uint32_t state = seed;
+  for (int i = 0; i < n; ++i) {
+    state = state * 1664525u + 1013904223u; // LCG
+    signs[i] = (state & 0x80000000u) ? -1.0f : 1.0f;
+  }
+}
+
+/**
+ * @brief Forward rotation: R = (1/sqrt(n)) * H * D
+ *        Forward: R∙x  = (1/sqrt(n))∙H∙(D∙x)
+ * */
+inline void apply_rotation(const float *input, float *output,
+                           const float *signs, int n) {
+  for (int i = 0; i < n; ++i)
+    output[i] = input[i] * signs[i];
+  hadamard_transform(output, n);
+}
+
+/**
+ * @brief Inverse rotation: R^T = D * (1/sqrt(n)) * H
+ * */
+inline void apply_inverse_rotation(float *data, const float *signs, int n) {
+  hadamard_transform(data, n);
+  for (int i = 0; i < n; ++i)
+    data[i] *= signs[i];
+}
+
+/***********************************************************************
+ * Lloyd-Max optimal codebooks (precomputed for Beta distribution)
+ ***********************************************************************/
+
+struct LloydMaxCodebook {
+  float centroids[16];
+  float boundaries[15];
+};
+
+/** d=64, 4-bit (16 levels), Beta(31.5, 31.5) on [-1,1] */
+static constexpr LloydMaxCodebook CODEBOOK_D64 = {
+  {-0.33079493f, -0.25291211f, -0.19885445f, -0.15492391f, -0.11648534f,
+   -0.08131068f, -0.04808909f, -0.01591879f, 0.01591879f, 0.04808909f,
+   0.08131068f, 0.11648534f, 0.15492391f, 0.19885445f, 0.25291211f,
+   0.33079493f},
+  {-0.29185352f, -0.22588328f, -0.17688918f, -0.13570463f, -0.09889801f,
+   -0.06469988f, -0.03200394f, 0.0f, 0.03200394f, 0.06469988f, 0.09889801f,
+   0.13570463f, 0.17688918f, 0.22588328f, 0.29185352f}};
+
+/** d=128, 4-bit (16 levels), Beta(63.5, 63.5) on [-1,1] */
+static constexpr LloydMaxCodebook CODEBOOK_D128 = {
+  {-0.23766275f, -0.18083472f, -0.14180392f, -0.11028715f, -0.08282740f,
+   -0.05777148f, -0.03415105f, -0.01130232f, 0.01130232f, 0.03415105f,
+   0.05777148f, 0.08282740f, 0.11028715f, 0.14180392f, 0.18083472f,
+   0.23766275f},
+  {-0.20924874f, -0.16131932f, -0.12604554f, -0.09655728f, -0.07029944f,
+   -0.04596127f, -0.02272669f, 0.0f, 0.02272669f, 0.04596127f, 0.07029944f,
+   0.09655728f, 0.12604554f, 0.16131932f, 0.20924874f}};
+
+inline const LloydMaxCodebook &get_codebook(int head_dim) {
+  if (head_dim == 64)
+    return CODEBOOK_D64;
+  return CODEBOOK_D128;
+}
+
+/** Lloyd-Max quantize: boundary search for optimal bin index (4-bit). */
+inline uint8_t lloydmax_quantize(float val, const LloydMaxCodebook &cb) {
+  int idx = 0;
+  for (int i = 0; i < 15; ++i) {
+    if (val > cb.boundaries[i])
+      idx = i + 1;
+  }
+  return (uint8_t)idx;
+}
+
+/***********************************************************************
+ * Norm + Rotation + Lloyd-Max (paper Algorithm 1)
+ ***********************************************************************/
+
+/**
+ * @brief Full TurboQuant quantize pipeline (paper Algorithm 1):
+ *        1. Compute norm, normalize to unit vector
+ *        2. Apply Hadamard rotation
+ *        3. Lloyd-Max quantize each coordinate (4-bit, 16 levels)
+ *        4. Pack into nibbles (2 elements per byte)
+ */
+inline void turboquant_quantize_head(const float *input, int head_dim,
+                                     uint8_t *out_packed, float *out_norm,
+                                     const float *rot_signs,
+                                     const LloydMaxCodebook &cb) {
+  // Step 1: caculcate norm and save
+  float norm_sq = 0.0f;
+  for (int i = 0; i < head_dim; ++i)
+    norm_sq += input[i] * input[i];
+  float norm = std::sqrt(norm_sq);
+  *out_norm = norm;
+
+  // Step 2: normalize to the unit vector + random sign + Hadamard
+  std::vector<float> rotated(head_dim);
+  float inv_norm = (norm > 1e-10f) ? (1.0f / norm) : 0.0f;
+  for (int i = 0; i < head_dim; ++i)
+    rotated[i] = input[i] * inv_norm * rot_signs[i];
+  hadamard_transform(rotated.data(), head_dim);
+
+  // Step 3: 4-bit quantize each coordinate (lloydmax-quantize)
+  // Step 4: packing to 1 byte with 2 elements
+  for (int d = 0; d < head_dim; d += 2) {
+    uint8_t q0 = lloydmax_quantize(rotated[d], cb);
+    uint8_t q1 = 8; // midpoint default (near zero centroid)
+    if (d + 1 < head_dim)
+      q1 = lloydmax_quantize(rotated[d + 1], cb);
+
+    out_packed[d / 2] = (q1 << 4) | q0;
+  }
+}
+
+/**
+ * @brief Dequantize one head: centroid lookup + inverse rotation + norm
+ * rescale.
+ */
+inline void turboquant_dequantize_head(const uint8_t *packed, float norm,
+                                       int head_dim, float *output,
+                                       const float *rot_signs,
+                                       const LloydMaxCodebook &cb) {
+  // Step 1: Unpack + centroid lookup
+  for (int d = 0; d < head_dim; d += 2) {
+    uint8_t byte = packed[d / 2];
+    uint8_t q0 = byte & 0x0F;
+    uint8_t q1 = (byte >> 4) & 0x0F;
+    output[d] = cb.centroids[q0];
+    if (d + 1 < head_dim)
+      output[d + 1] = cb.centroids[q1];
+  }
+  // Step 2: Inverse rotation
+  hadamard_transform(output, head_dim);
+  for (int i = 0; i < head_dim; ++i)
+    output[i] *= rot_signs[i] * norm;
+}
+
+} // namespace nntrainer
+
+#endif /* __cplusplus */
+#endif /* __TURBOQUANT_UTILS_H__ */

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -17,10 +17,14 @@
 #ifdef USE_BLAS
 #include <cblas_interface.h>
 #endif
+#include <cstring>
 #include <fallback_internal.h>
 #include <ggml_interface.h>
+#include <immintrin.h>
 #include <nntrainer_error.h>
 #include <q4_0_utils.h>
+#include <turboquant_utils.h>
+#include <vector>
 #include <x86_compute_backend.h>
 
 #define ROW_MAJOR 0
@@ -503,4 +507,35 @@ void transform_int4_osv32_isv2_to_q4_0(size_t N, size_t K,
     N, K, osv32_weights, osv32_scales, scale_group_size, 8, dst_q4_0x);
 #endif
 }
+
+void quantize_kv_turboquant(const float *input, uint8_t *out_packed,
+                            float *out_norms, const float *rot_signs,
+                            int head_dim, int num_heads) {
+  __fallback_quantize_kv_turboquant(input, out_packed, out_norms, rot_signs,
+                                    head_dim, num_heads);
+}
+
+void compute_kcaches_packed4(const float *query, const uint8_t *kcache_packed,
+                             const float *kcache_norms, float *output,
+                             int num_rows, int num_cache_head, int head_dim,
+                             int gqa_size, int tile_size,
+                             const float *rot_signs, size_t local_window_size,
+                             int head_start, int head_end) {
+  __fallback_compute_kcaches_packed4(query, kcache_packed, kcache_norms, output,
+                                     num_rows, num_cache_head, head_dim,
+                                     gqa_size, tile_size, rot_signs,
+                                     local_window_size, head_start, head_end);
+}
+
+void compute_vcache_packed4(int row_num, const float *attn_weights,
+                            const uint8_t *vcache_packed,
+                            const float *vcache_norms, float *output,
+                            int num_cache_head, int gqa_size, int head_dim,
+                            const float *rot_signs, size_t local_window_size,
+                            int head_start, int head_end) {
+  __fallback_compute_vcache_packed4(
+    row_num, attn_weights, vcache_packed, vcache_norms, output, num_cache_head,
+    gqa_size, head_dim, rot_signs, local_window_size, head_start, head_end);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1332,6 +1332,35 @@ void transform_int4_osv32_isv2_to_q4_0(size_t N, size_t K,
                                        size_t scale_group_size,
                                        void *dst_q4_0x);
 
+/**
+ * @copydoc quantize_kv_turboquant in cpu_backend.h
+ */
+void quantize_kv_turboquant(const float *input, uint8_t *out_packed,
+                            float *out_norms, const float *rot_signs,
+                            int head_dim, int num_heads);
+
+/**
+ * @copydoc compute_kcaches_packed4 in cpu_backend.h
+ */
+void compute_kcaches_packed4(const float *query, const uint8_t *kcache_packed,
+                             const float *kcache_norms, float *output,
+                             int num_rows, int num_cache_head, int head_dim,
+                             int gqa_size, int tile_size,
+                             const float *rot_signs,
+                             size_t local_window_size = UINT_MAX,
+                             int head_start = 0, int head_end = -1);
+
+/**
+ * @copydoc compute_vcache_packed4 in cpu_backend.h
+ */
+void compute_vcache_packed4(int row_num, const float *attn_weights,
+                            const uint8_t *vcache_packed,
+                            const float *vcache_norms, float *output,
+                            int num_cache_head, int gqa_size, int head_dim,
+                            const float *rot_signs,
+                            size_t local_window_size = UINT_MAX,
+                            int head_start = 0, int head_end = -1);
+
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __x86_COMPUTE_BACKEND_H__ */

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -597,6 +597,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %endif
 %{_includedir}/nntrainer/tensor_wrap_specs.h
 %{_includedir}/nntrainer/cpu_backend.h
+%{_includedir}/nntrainer/turboquant_utils.h
 %{_includedir}/nntrainer/fallback_internal.h
 %{_includedir}/nntrainer/fallback_kleidiai.h
 %if 0%{?use_cblas}

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -58,6 +58,7 @@ test_target = [
   ['unittest_nntrainer_activations', []],
   ['unittest_nntrainer_cpu_backend', []],
   ['unittest_nntrainer_fallback', []],
+  ['unittest_turboquant', []],
   ['unittest_nntrainer_tensor_types', []],
   ['unittest_nntrainer_tensor_advanced', []],
   ['unittest_nntrainer_exe_order', []],

--- a/test/unittest/unittest_turboquant.cpp
+++ b/test/unittest/unittest_turboquant.cpp
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file   unittest_turboquant.cpp
+ * @date   28 March 2026
+ * @brief  Unit tests for TurboQuant (norm + rotation + Lloyd-Max codebook)
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ */
+
+#include <cpu_backend.h>
+#include <fallback_internal.h>
+#include <gtest/gtest.h>
+#include <turboquant_utils.h>
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <random>
+#include <vector>
+
+/***************************************************
+ * Test Hadamard Transform-related utils
+ ***************************************************/
+
+/**
+ * @brief Test hadamard_transform is orthogonal: applying twice returns
+ * original. i.e., Test H(Hx)) == x
+ */
+TEST(turboquant, hadamard_roundtrip) {
+  constexpr int n = 64;
+  std::vector<float> x(n), orig(n);
+
+  std::mt19937 gen(42);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  for (int i = 0; i < n; ++i)
+    x[i] = orig[i] = dist(gen);
+
+  nntrainer::hadamard_transform(x.data(), n);
+  nntrainer::hadamard_transform(x.data(), n);
+
+  for (int i = 0; i < n; ++i) {
+    EXPECT_NEAR(x[i], orig[i], 1e-5f) << "Roundtrip failed at index " << i;
+  }
+}
+
+/**
+ * @brief Test apply_rotation / apply_inverse_rotation roundtrip
+ *        i.e., Test R^-1(R(x)) == x
+ */
+TEST(turboquant, rotation_roundtrip) {
+  constexpr int n = 128;
+  std::vector<float> signs(n), input(n), rotated(n);
+
+  nntrainer::generate_random_signs(signs.data(), n, 0xDEADBEEF);
+
+  std::mt19937 gen(123);
+  std::uniform_real_distribution<float> dist(-2.0f, 2.0f);
+  for (int i = 0; i < n; ++i)
+    input[i] = dist(gen);
+
+  nntrainer::apply_rotation(input.data(), rotated.data(), signs.data(), n);
+  nntrainer::apply_inverse_rotation(rotated.data(), signs.data(), n);
+
+  for (int i = 0; i < n; ++i) {
+    EXPECT_NEAR(rotated[i], input[i], 1e-5f)
+      << "Rotation roundtrip failed at " << i;
+  }
+}
+
+/**
+ * @brief Test rotation preserves L2 norm (orthogonal transform).
+ *        i.e., Test || R(x) ||^2 == ||x||^2
+ */
+TEST(turboquant, rotation_preserves_norm) {
+  constexpr int n = 64;
+  std::vector<float> signs(n), input(n), rotated(n);
+
+  nntrainer::generate_random_signs(signs.data(), n, 0x12345678);
+
+  std::mt19937 gen(99);
+  std::uniform_real_distribution<float> dist(-3.0f, 3.0f);
+  float norm_sq_in = 0.0f;
+  for (int i = 0; i < n; ++i) {
+    input[i] = dist(gen);
+    norm_sq_in += input[i] * input[i];
+  }
+
+  nntrainer::apply_rotation(input.data(), rotated.data(), signs.data(), n);
+
+  float norm_sq_out = 0.0f;
+  for (int i = 0; i < n; ++i)
+    norm_sq_out += rotated[i] * rotated[i];
+
+  EXPECT_NEAR(norm_sq_out, norm_sq_in, 1e-3f) << "Rotation changed the norm";
+}
+
+/***************************************************
+ * Test Lloyd-Max Codebook-related utils
+ ***************************************************/
+
+/**
+ * @brief Test Lloyd-Max codebook symmetry and monotonicity.
+ *        Test CODEBOOK_D128
+ */
+TEST(turboquant, codebook_properties) {
+  const auto &cb = nntrainer::CODEBOOK_D128;
+
+  // Test c[i] == -c[15-i]
+  for (int i = 0; i < 8; ++i) {
+    EXPECT_NEAR(cb.centroids[i], -cb.centroids[15 - i], 1e-7f)
+      << "Centroids not symmetric at " << i;
+  }
+
+  // Test monotonically increasing
+  for (int i = 0; i < 15; ++i) {
+    EXPECT_LT(cb.centroids[i], cb.centroids[i + 1])
+      << "Centroids not monotonic at " << i;
+  }
+
+  for (int i = 0; i < 14; ++i) {
+    EXPECT_LT(cb.boundaries[i], cb.boundaries[i + 1])
+      << "Boundaries not monotonic at " << i;
+  }
+
+  // 0 at the end of the boundary
+  EXPECT_FLOAT_EQ(cb.boundaries[7], 0.0f);
+}
+
+/**
+ * @brief Test lloydmax_quantize for known values.
+ *        Test quantization for the known value:
+ *          quantize(0) \in {7, 8}
+ */
+TEST(turboquant, lloydmax_quantize_known) {
+  const auto &cb = nntrainer::CODEBOOK_D128;
+
+  uint8_t q0 = nntrainer::lloydmax_quantize(0.0f, cb);
+  EXPECT_TRUE(q0 == 7 || q0 == 8)
+    << "Zero mapped to unexpected bin " << (int)q0;
+
+  uint8_t q_pos = nntrainer::lloydmax_quantize(1.0f, cb);
+  EXPECT_EQ(q_pos, 15);
+
+  uint8_t q_neg = nntrainer::lloydmax_quantize(-1.0f, cb);
+  EXPECT_EQ(q_neg, 0);
+}
+
+/***************************************************
+ * Qunatize/Dequantize
+ ***************************************************/
+
+/**
+ * @brief Test turboquant_quantize_head -> turboquant_dequantize_head roundtrip.
+ */
+TEST(turboquant, quantize_dequantize_roundtrip) {
+  constexpr int head_dim = 128;
+  std::vector<float> signs(head_dim);
+  nntrainer::generate_random_signs(signs.data(), head_dim, 0xCAFE);
+
+  std::mt19937 gen(7);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+  std::vector<float> input(head_dim), output(head_dim);
+  for (auto &v : input)
+    v = dist(gen);
+
+  std::vector<uint8_t> packed(head_dim / 2);
+  float norm;
+  const auto &cb = nntrainer::get_codebook(head_dim);
+
+  nntrainer::turboquant_quantize_head(input.data(), head_dim, packed.data(),
+                                      &norm, signs.data(), cb);
+  nntrainer::turboquant_dequantize_head(packed.data(), norm, head_dim,
+                                        output.data(), signs.data(), cb);
+
+  float input_norm = 0.0f;
+  for (auto v : input)
+    input_norm += v * v;
+  input_norm = std::sqrt(input_norm);
+  EXPECT_NEAR(norm, input_norm, 1e-6f);
+
+  float max_diff = 0.0f, sum_sq = 0.0f;
+  for (int i = 0; i < head_dim; ++i) {
+    float d = std::fabs(input[i] - output[i]);
+    max_diff = std::max(max_diff, d);
+    sum_sq += d * d;
+  }
+  float rmse = std::sqrt(sum_sq / head_dim);
+
+  EXPECT_LT(rmse, 0.15f) << "RMSE too large for 4-bit quantization";
+  EXPECT_LT(max_diff, 0.5f) << "Max diff too large";
+}
+
+/**
+ * @brief Test quantize_kv_turboquant multi-head pipeline.
+ */
+TEST(turboquant, quantize_multihead) {
+  constexpr int head_dim = 64;
+  constexpr int num_heads = 4;
+  constexpr int total = num_heads * head_dim;
+
+  std::mt19937 gen(42);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  std::vector<float> input(total);
+  for (auto &v : input)
+    v = dist(gen);
+
+  std::vector<uint8_t> packed(total / 2);
+  std::vector<float> norms(num_heads);
+  std::vector<float> signs(head_dim);
+  nntrainer::generate_random_signs(signs.data(), head_dim, 0x5EED);
+
+  nntrainer::quantize_kv_turboquant(input.data(), packed.data(), norms.data(),
+                                    signs.data(), head_dim, num_heads);
+
+  const auto &cb = nntrainer::get_codebook(head_dim);
+  for (int h = 0; h < num_heads; ++h) {
+    float expected_norm = 0.0f;
+    for (int i = 0; i < head_dim; ++i) {
+      float v = input[h * head_dim + i];
+      expected_norm += v * v;
+    }
+    expected_norm = std::sqrt(expected_norm);
+    EXPECT_NEAR(norms[h], expected_norm, 1e-5f) << "Head " << h;
+  }
+
+  for (int h = 0; h < num_heads; ++h) {
+    std::vector<float> output(head_dim);
+    nntrainer::turboquant_dequantize_head(packed.data() + h * head_dim / 2,
+                                          norms[h], head_dim, output.data(),
+                                          signs.data(), cb);
+    float max_diff = 0.0f;
+    for (int i = 0; i < head_dim; ++i) {
+      float d = std::fabs(input[h * head_dim + i] - output[i]);
+      max_diff = std::max(max_diff, d);
+    }
+    EXPECT_LT(max_diff, 0.5f) << "Head " << h << " reconstruction too coarse";
+  }
+}
+
+/**
+ * @brief Test compute_kcaches_packed4 against FP32 reference.
+ */
+TEST(turboquant, kcaches_vs_fp32) {
+  constexpr int num_heads_Q = 8;
+  constexpr int num_heads_KV = 2;
+  constexpr int gqa_size = num_heads_Q / num_heads_KV;
+  constexpr int head_dim = 64;
+  constexpr int num_rows = 16;
+
+  std::mt19937 gen(55);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+  std::vector<float> query(num_heads_Q * head_dim);
+  std::vector<float> keys(num_rows * num_heads_KV * head_dim);
+  for (auto &v : query)
+    v = dist(gen);
+  for (auto &v : keys)
+    v = dist(gen);
+
+  // FP32 reference: Q * K^T / sqrt(d)
+  std::vector<float> ref_scores(num_rows * num_heads_Q, 0.0f);
+  float inv_sqrt_d = 1.0f / std::sqrt((float)head_dim);
+  for (int n = 0; n < num_heads_KV; ++n) {
+    for (int r = 0; r < num_rows; ++r) {
+      for (int g = 0; g < gqa_size; ++g) {
+        float dot = 0.0f;
+        for (int d = 0; d < head_dim; ++d)
+          dot += query[(n * gqa_size + g) * head_dim + d] *
+                 keys[r * num_heads_KV * head_dim + n * head_dim + d];
+        ref_scores[r * num_heads_Q + n * gqa_size + g] = dot * inv_sqrt_d;
+      }
+    }
+  }
+
+  // TurboQuant
+  std::vector<float> rot_signs(head_dim);
+  nntrainer::generate_random_signs(rot_signs.data(), head_dim, 0xBEEF);
+
+  int packed_row_bytes = num_heads_KV * head_dim / 2;
+  std::vector<uint8_t> pk(num_rows * packed_row_bytes);
+  std::vector<float> knorms(num_rows * num_heads_KV);
+
+  for (int r = 0; r < num_rows; ++r) {
+    nntrainer::quantize_kv_turboquant(keys.data() + r * num_heads_KV * head_dim,
+                                      pk.data() + r * packed_row_bytes,
+                                      knorms.data() + r * num_heads_KV,
+                                      rot_signs.data(), head_dim, num_heads_KV);
+  }
+
+  std::vector<float> tq_scores(num_rows * num_heads_Q, 0.0f);
+  nntrainer::compute_kcaches_packed4(query.data(), pk.data(), knorms.data(),
+                                     tq_scores.data(), num_rows, num_heads_KV,
+                                     head_dim, gqa_size, 4, rot_signs.data());
+
+  float max_diff = 0.0f;
+  for (size_t i = 0; i < ref_scores.size(); ++i) {
+    float d = std::fabs(ref_scores[i] - tq_scores[i]);
+    max_diff = std::max(max_diff, d);
+  }
+
+  EXPECT_LT(max_diff, 0.5f) << "compute_kcaches_packed4 error too large";
+}
+
+/**
+ * @brief Test compute_vcache_packed4 against FP32 reference.
+ */
+TEST(turboquant, vcache_vs_fp32) {
+  constexpr int num_heads_Q = 4;
+  constexpr int num_heads_KV = 2;
+  constexpr int gqa_size = num_heads_Q / num_heads_KV;
+  constexpr int head_dim = 64;
+  constexpr int num_rows = 8;
+  constexpr int row_num = num_rows - 1;
+
+  std::mt19937 gen(77);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+  std::vector<float> values(num_rows * num_heads_KV * head_dim);
+  for (auto &v : values)
+    v = dist(gen);
+
+  std::vector<float> attn(num_rows * num_heads_Q);
+  for (auto &v : attn)
+    v = std::fabs(dist(gen));
+  for (int h = 0; h < num_heads_Q; ++h) {
+    float sum = 0.0f;
+    for (int r = 0; r < num_rows; ++r)
+      sum += attn[r * num_heads_Q + h];
+    for (int r = 0; r < num_rows; ++r)
+      attn[r * num_heads_Q + h] /= sum;
+  }
+
+  // FP32 reference
+  std::vector<float> ref_out(num_heads_Q * head_dim, 0.0f);
+  for (int n = 0; n < num_heads_KV; ++n) {
+    for (int g = 0; g < gqa_size; ++g) {
+      int qh = n * gqa_size + g;
+      for (int r = 0; r < num_rows; ++r) {
+        float w = attn[r * num_heads_Q + qh];
+        for (int d = 0; d < head_dim; ++d)
+          ref_out[qh * head_dim + d] +=
+            w * values[r * num_heads_KV * head_dim + n * head_dim + d];
+      }
+    }
+  }
+
+  // TurboQuant v2 path
+  std::vector<float> rot_signs(head_dim);
+  nntrainer::generate_random_signs(rot_signs.data(), head_dim, 0xFACE);
+
+  int packed_row_bytes = num_heads_KV * head_dim / 2;
+  std::vector<uint8_t> pv(num_rows * packed_row_bytes);
+  std::vector<float> vnorms(num_rows * num_heads_KV);
+
+  for (int r = 0; r < num_rows; ++r) {
+    nntrainer::quantize_kv_turboquant(
+      values.data() + r * num_heads_KV * head_dim,
+      pv.data() + r * packed_row_bytes, vnorms.data() + r * num_heads_KV,
+      rot_signs.data(), head_dim, num_heads_KV);
+  }
+
+  std::vector<float> tq_out(num_heads_Q * head_dim, 0.0f);
+  nntrainer::compute_vcache_packed4(row_num, attn.data(), pv.data(),
+                                    vnorms.data(), tq_out.data(), num_heads_KV,
+                                    gqa_size, head_dim, rot_signs.data());
+
+  float max_diff = 0.0f;
+  for (size_t i = 0; i < ref_out.size(); ++i) {
+    float d = std::fabs(ref_out[i] - tq_out[i]);
+    max_diff = std::max(max_diff, d);
+  }
+
+  EXPECT_LT(max_diff, 0.5f) << "compute_vcache_packed4 error too large";
+}
+
+int main(int argc, char **argv) {
+  int result = -1;
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during InitGoogleTest" << std::endl;
+    return result;
+  }
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+  return result;
+}

--- a/test/unittest/unittest_turboquant.cpp
+++ b/test/unittest/unittest_turboquant.cpp
@@ -5,6 +5,7 @@
  * @brief  Unit tests for TurboQuant (norm + rotation + Lloyd-Max codebook)
  * @see    https://github.com/nntrainer/nntrainer
  * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
  */
 
 #include <cpu_backend.h>


### PR DESCRIPTION
## Summary

This PR introduces **TurboQuant**, a 4-bit packed KV-cache quantization scheme,
into nntrainer's cpu_backend. Only the naive/fallback kernels are landed here;
arch-specific optimized kernels (NEON / AVX) will follow in later PRs.

TurboQuant sits entirely inside `nntrainer/tensor/cpu_backend/` as pure math
utilities — no layer or model in this tree consumes it yet. The consumer side
(MHA layer + Qwen3 wiring) lives in the separate `Quick.AI` repository on
branch `feat/turboquant-kvcache`, which depends on this PR.

## What's in this PR

1. **`[Feat] add naive-version TurboQuant & unittest`**
   - `nntrainer/tensor/cpu_backend/turboquant_utils.h` — norm + rotation +
     Lloyd-Max codebook (64- and 128-dim precomputed).
   - Fallback / ARM / x86 backend stubs in `cpu_backend.h` + dispatch wiring
     so consumers can call the turboquant kernels through the normal
     cpu_backend interface.
   - `test/unittest/unittest_turboquant.cpp` covering the norm / rotation /
     codebook kernels.
   - Packaging updates (`packaging/nntrainer.spec`,
     `test/unittest/meson.build`).

2. **`[TurboQuant] Address PR #3880 review comments`**
   - `get_codebook()` now `throw std::invalid_argument` on unsupported
     `head_dim` instead of silently falling back to the 128-dim codebook,
     so users see a clear error rather than degraded attention quality.
   - Added the missing `@bug` doxygen tag required by the static-checker
     CI.

3. **`[CI] Fix debian install missing file`**
   - Adds `turboquant_utils.h` to `debian/nntrainer-dev.install` so the
     header ships in the `-dev` package.

## Scope / boundary

- **Only** files under `nntrainer/tensor/cpu_backend/`, `test/unittest/`,
  `packaging/`, and `debian/` are touched. No changes to
  `Applications/CausalLM/`, no model or layer changes.
- Integration of TurboQuant into the MHA KV-cache path is intentionally
  out of scope for this PR and moves to `Quick.AI` as part of the ongoing
  CausalLM separation.

## Test plan

- [x] `meson setup build -Denable-test=false -Denable-tflite-backbone=false
      -Denable-tflite-interpreter=false -Denable-app=false` → `ninja` builds
      clean with `-Werror` (161/161 targets).
- [x] `unittest_turboquant` covers codebook / rotation / norm kernels
      (added in this PR).
- [x] Verified downstream consumer (`Quick.AI` on `feat/turboquant-kvcache`,
      which pulls this branch as its `subprojects/nntrainer`) builds clean
      (398/398 targets).