### PR TITLE
Add safetensors format support to NeuralNetwork save/load

### DIFF
--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -229,7 +229,16 @@ void Transformer::load_weight(const std::string &weight_path) {
   }
 
   try {
-    model->load(weight_path, ml::train::ModelFormat::MODEL_FORMAT_BIN);
+    // Auto-detect format from file extension: *.safetensors -> safetensors,
+    // anything else -> legacy BIN.
+    ml::train::ModelFormat format = ml::train::ModelFormat::MODEL_FORMAT_BIN;
+    const std::string ext = ".safetensors";
+    if (weight_path.size() >= ext.size() &&
+        weight_path.compare(weight_path.size() - ext.size(), ext.size(), ext) ==
+          0) {
+      format = ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS;
+    }
+    model->load(weight_path, format);
   } catch (const std::exception &e) {
     throw std::runtime_error("Failed to load model weights: " +
                              std::string(e.what()));
@@ -245,7 +254,15 @@ void Transformer::save_weight(const std::string &weight_path) {
   }
 
   try {
-    model->save(weight_path, ml::train::ModelFormat::MODEL_FORMAT_BIN);
+    // Auto-detect format from file extension; mirrors load_weight().
+    ml::train::ModelFormat format = ml::train::ModelFormat::MODEL_FORMAT_BIN;
+    const std::string ext = ".safetensors";
+    if (weight_path.size() >= ext.size() &&
+        weight_path.compare(weight_path.size() - ext.size(), ext.size(), ext) ==
+          0) {
+      format = ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS;
+    }
+    model->save(weight_path, format);
   } catch (const std::exception &e) {
     throw std::runtime_error("Failed to save model weights: " +
                              std::string(e.what()));

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -94,7 +94,11 @@ for inference and training without any configurations*/
     ML_TRAIN_MODEL_FORMAT_FLATBUFFER,             /**< flatbuffer file */
   MODEL_FORMAT_ONNX = ML_TRAIN_MODEL_FORMAT_ONNX, /**< ONNX file */
 
-  MODEL_FORMAT_QNN = ML_TRAIN_MODEL_FORMAT_QNN /**< qnn binary file */
+  MODEL_FORMAT_QNN = ML_TRAIN_MODEL_FORMAT_QNN, /**< qnn binary file */
+
+  MODEL_FORMAT_SAFETENSORS =
+    ML_TRAIN_MODEL_FORMAT_SAFETENSORS /**< safetensors format with JSON header
+                                        for name-based parallel loading */
 };
 
 /**

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -288,7 +288,10 @@ typedef enum {
   ML_TRAIN_MODEL_FORMAT_ONNX =
     4, /**< QNNX binary format file saves model configurations and weights. */
   ML_TRAIN_MODEL_FORMAT_QNN =
-    5 /**< QNN binary format file saves model configurations and weights. */
+    5, /**< QNN binary format file saves model configurations and weights. */
+  ML_TRAIN_MODEL_FORMAT_SAFETENSORS =
+    6 /**< Safetensors format file saves model weights with JSON header for
+          name-based, offset-based parallel loading. */
 } ml_train_model_format_e;
 
 /**

--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -65,6 +65,7 @@
 /usr/include/nntrainer/bs_thread_pool_manager.hpp
 /usr/include/nntrainer/fp16.h
 /usr/include/nntrainer/util_simd.h
+/usr/include/nntrainer/safetensors_util.h
 /usr/include/nntrainer/dynamic_library_loader.h
 /usr/include/nntrainer/mman_windows.h
 # model

--- a/docs/weight-format-specification.md
+++ b/docs/weight-format-specification.md
@@ -1,0 +1,542 @@
+# NNTrainer Weight Binary Format Specification
+
+This document describes the weight serialization formats used by NNTrainer,
+including the legacy BIN format and the new safetensors format, along with
+the TorchFXConverter integration for HuggingFace model conversion.
+
+---
+
+## Format Overview
+
+NNTrainer supports two weight file formats:
+
+```
+                    +-------------------+
+                    |   Weight Formats  |
+                    +-------------------+
+                           |
+              +------------+------------+
+              |                         |
+     +--------+--------+     +---------+---------+
+     |   BIN v0        |     |   Safetensors     |
+     |   (Legacy)      |     |   (Name-based)    |
+     +-----------------+     +-------------------+
+     | Sequential      |     | JSON header with  |
+     | offset-based    |     | name -> offset    |
+     | Order-dependent |     | Order-independent |
+     +-----------------+     +-------------------+
+```
+
+| Aspect              | BIN v0 (Legacy)          | Safetensors             |
+|---------------------|--------------------------|-------------------------|
+| Header              | None                     | 8B size + JSON header   |
+| Offset lookup       | Sequential accumulation  | Name-based (JSON)       |
+| Order dependency    | Strict (topological)     | None (name-based)       |
+| Metadata            | None                     | dtype, shape, offsets   |
+| Parallel loading    | Yes (per-layer threads)  | Yes (per-layer threads) |
+| Cross-graph compat  | No (order must match)    | Yes (name lookup)       |
+
+---
+
+## 1. BIN v0 Format (Legacy)
+
+The original binary format stores weights sequentially in the order they
+appear during model graph iteration (topological sort order).
+
+### File Layout
+
+```
++================================================================+
+|                     BIN v0 File Layout                         |
++================================================================+
+
+Byte offset
+    0  +-----------------------------------------------------+
+       | Weight data (Layer 0, Weight 0)                      |
+       |   Raw bytes: getMemoryBytes() of tensor              |
+       +-----------------------------------------------------+
+       | Weight data (Layer 0, Weight 1)  [if exists]         |
+       +-----------------------------------------------------+
+       | Weight data (Layer 1, Weight 0)                      |
+       +-----------------------------------------------------+
+       |                    ...                               |
+       +-----------------------------------------------------+
+       | Weight data (Layer N, Weight M)                      |
+       +=====================================================+
+       | [Optional] "adam" magic (4 bytes ASCII)              |
+       +-----------------------------------------------------+
+       | [Optional] Adam optimizer state per weight           |
+       |   (same layer/weight iteration order)                |
+       +=====================================================+
+       | [Optional, TRAIN mode] epoch_idx (size_t)            |
+       +-----------------------------------------------------+
+       | [Optional, TRAIN mode] iteration (size_t)            |
+       +-----------------------------------------------------+
+```
+
+### Offset Calculation
+
+```
+Weight offsets are calculated sequentially during load():
+
+  start_from = 0
+  for each layer in model_graph (topological order):
+      for each weight in layer:
+          weight.setFileOffset(start_from)
+          start_from += weight.getMemoryBytes()
+          if quantized type (not FP32/FP16/Q6_K/Q4_0):
+              start_from += 2   // uint16_t qparam
+```
+
+### Limitation
+
+```
+  TorchFXConverter                    NeuralNetwork
+  (FX execution order)                (Topological sort order)
+  +-----------------------+           +-----------------------+
+  | 1. embedding          |           | 1. embedding          |
+  | 2. attn_q_proj        |           | 2. attn_k_proj   <--- | Different!
+  | 3. attn_k_proj        |           | 3. attn_q_proj   <--- |
+  | 4. attn_v_proj        |           | 4. attn_v_proj        |
+  | 5. ffn_gate           |           | 5. ffn_down      <--- |
+  | 6. ffn_up             |           | 6. ffn_gate      <--- |
+  | 7. ffn_down           |           | 7. ffn_up        <--- |
+  +-----------------------+           +-----------------------+
+      |                                     |
+      v                                     v
+  Writes weights in                 Reads weights in
+  FX order to .bin                  topological order
+                                          |
+                                          v
+                                    WRONG WEIGHTS!
+                                    (offset mismatch)
+```
+
+**This ordering mismatch is why safetensors was introduced.**
+
+---
+
+## 2. Safetensors Format
+
+The safetensors format uses a JSON header with per-tensor name, dtype,
+shape, and byte offset information. This makes weight loading
+**order-independent** -- weights are found by name, not position.
+
+### File Layout
+
+```
++================================================================+
+|                  Safetensors File Layout                        |
++================================================================+
+
+Byte 0                    8              8 + header_size
+  |                       |                    |
+  v                       v                    v
+  +----------+---------------------------+---------------------------+
+  | header   |       JSON Header         |       Data Section        |
+  | size     |    (8-byte aligned,       |    (raw tensor bytes)     |
+  | (8B LE)  |     padded with ' ')      |                           |
+  +----------+---------------------------+---------------------------+
+
+  |<- 8B  -->|<----- header_size B ----->|<---- total data size ---->|
+```
+
+### Header Detail
+
+```
++----------+
+| uint64   |  header_size (little-endian, 8 bytes)
++----------+
+|          |
+|  JSON    |  {
+|  Header  |    "__metadata__": {
+|          |      "format": "nntrainer"
+|  (UTF-8) |    },
+|          |    "layer0_wq:weight": {
+|          |      "dtype": "F32",
+|          |      "shape": [64, 64],
+|          |      "data_offsets": [0, 16384]
+|          |    },
+|          |    "layer0_wk:weight": {
+|          |      "dtype": "F32",
+|          |      "shape": [32, 64],
+|          |      "data_offsets": [16384, 24576]
+|          |    },
+|          |    ...
+|          |  }
+|          |
++----------+  (padded to 8-byte boundary with spaces)
+```
+
+### Data Section Detail
+
+```
+data_offsets are relative to the start of the data section:
+
+  Data section start = 8 + header_size
+
+  +--------+--------+--------+--------+--------+-----+
+  | Tensor | Tensor | Tensor | Tensor | Tensor | ... |
+  |   0    |   1    |   2    |   3    |   4    |     |
+  +--------+--------+--------+--------+--------+-----+
+  ^        ^        ^
+  |        |        |
+  off=0    off=sz0  off=sz0+sz1
+  |                 |
+  |  data_offsets   |
+  |  [0, sz0]       [sz0, sz0+sz1]
+```
+
+### Supported Data Types
+
+| TensorDim::DataType | Safetensors dtype | Byte size per element |
+|---------------------|-------------------|-----------------------|
+| FP32                | "F32"             | 4                     |
+| FP16                | "F16"             | 2                     |
+| QINT4               | "I4"              | 0.5                   |
+| QINT8               | "I8"              | 1                     |
+| QINT16              | "I16"             | 2                     |
+| UINT4               | "U4"              | 0.5                   |
+| UINT8               | "U8"              | 1                     |
+| UINT16              | "U16"             | 2                     |
+| UINT32              | "U32"             | 4                     |
+
+### Shape Encoding
+
+Tensor dimensions are encoded compactly by stripping leading 1s:
+
+```
+  TensorDim [1, 1, 512, 768]  -->  "shape": [512, 768]
+  TensorDim [1, 1, 1, 64]     -->  "shape": [64]
+  TensorDim [1, 1, 1, 1]      -->  "shape": [1]
+```
+
+---
+
+## 3. Offset Assignment: BIN vs Safetensors
+
+```
+                        load() function
+                             |
+                +------------+------------+
+                |                         |
+      +---------v----------+    +---------v-----------+
+      |    BIN v0           |    |    Safetensors      |
+      +--------------------+    +---------------------+
+      |                    |    |                     |
+      |  Sequential scan:  |    |  Parse JSON header: |
+      |  start_from = 0    |    |  header_size -> JSON|
+      |  for each weight:  |    |  -> name_offset_map |
+      |    offset = start  |    |                     |
+      |    start += size   |    |  Name-based lookup: |
+      |                    |    |  for each weight:   |
+      |  ORDER MATTERS!    |    |    name -> (off,sz) |
+      |                    |    |    offset = data_   |
+      |                    |    |      section_start  |
+      |                    |    |      + off          |
+      |                    |    |                     |
+      |                    |    |  ORDER FREE!        |
+      +--------------------+    +---------------------+
+                |                         |
+                +------------+------------+
+                             |
+                             v
+                   Per-layer parallel
+                   loading (threads)
+```
+
+---
+
+## 4. Parallel Loading Architecture
+
+Both formats support per-layer parallel loading during inference.
+Each layer reads its weights independently using either per-thread
+file streams or memory-mapped I/O.
+
+```
+                    load() -- INFERENCE mode
+                              |
+             +----------------+----------------+
+             |                                 |
+    +--------v--------+              +---------v--------+
+    |  Non-MMAP mode  |              |    MMAP mode     |
+    +-----------------+              +------------------+
+    |                 |              |                  |
+    | Thread per layer|              | Thread per layer |
+    | Each opens own  |              | Each creates own |
+    | ifstream to     |              | mmap mapping     |
+    | same file       |              | to same file     |
+    +-----------------+              +------------------+
+
+    Thread 0           Thread 1           Thread 2
+    +------------+     +------------+     +------------+
+    | Layer 0    |     | Layer 1    |     | Layer 2    |
+    | read at    |     | read at    |     | read at    |
+    | offset 0   |     | offset 4K  |     | offset 12K |
+    +-----+------+     +-----+------+     +-----+------+
+          |                  |                  |
+          v                  v                  v
+    +-----+------------------+------------------+------+
+    |  File: model.safetensors                         |
+    |  [header] [tensor0] [tensor1] [tensor2] [...]    |
+    +--------------------------------------------------+
+```
+
+### POSIX mmap Strategy
+
+```
+  Per thread:
+    1. fd = open(file, O_RDONLY)
+    2. mmap(NULL, file_size, PROT_READ, MAP_PRIVATE, fd, 0)
+    3. close(fd)                          // fd not needed after mmap
+    4. posix_madvise(ptr, size, POSIX_MADV_RANDOM)  // scattered access
+    5. node->read(view, ...)              // read weights at offset
+    6. posix_madvise(ptr, size, POSIX_MADV_DONTNEED) // drop pages
+    7. munmap(ptr, size)                  // release mapping
+```
+
+### Windows mmap Strategy
+
+```
+  Per thread:
+    1. hFile = CreateFileA(path, GENERIC_READ, ...)
+    2. hMap = CreateFileMapping(hFile, PAGE_READONLY, ...)
+    3. view = MapViewOfFile(hMap, FILE_MAP_READ, ...)
+    4. node->read(view, ...)
+    5. UnmapViewOfFile(view)              // early page release
+    6. CloseHandle(hMap)
+    7. CloseHandle(hFile)
+```
+
+---
+
+## 5. TorchFXConverter Integration
+
+The TorchFXConverter pipeline generates weights in two formats,
+with safetensors as the primary format for order-independent loading.
+
+### Conversion Pipeline
+
+```
+  HuggingFace Model
+  (state_dict)
+        |
+        v
+  +---------------------+
+  | WeightConverter      |
+  |                      |
+  | 1. build_weight_map()|     Weight ordering:
+  |    layers -> entries |     FX symbolic graph
+  |    (FX exec order)   |     execution order
+  |                      |
+  | 2. For each entry:   |
+  |    - Load HF tensor  |
+  |    - Apply transform |     Linear: transpose
+  |      (transpose for  |     [out,in] -> [in,out]
+  |       Linear layers) |
+  |    - Convert dtype   |     float32 / float16
+  +----------+-----------+
+             |
+    +--------+--------+
+    |                  |
+    v                  v
+  .bin               .safetensors
+  (raw sequential)   (JSON header + data)
+```
+
+### Tensor Naming Convention
+
+Every writer that produces a safetensors file for nntrainer **must** use
+the canonical weight name that the loader expects. nntrainer assembles
+that name in `nntrainer/layers/layer_context.h::InitLayerContext::requestWeight`:
+
+```cpp
+weights_spec.emplace_back(
+    dim, dim_g, init, reg, ..., prefix + ":" + name, ...);
+```
+
+where
+
+- `prefix` = the layer's user-given name (the `name=<...>` property passed
+  to `createLayer()` — e.g. `fc1`, `embedding0`, `layer0_attn_q_proj`);
+- `name` = the short role string hard-coded by the layer implementation
+  (e.g. `"weight"`, `"bias"`, `"gamma"`, `"beta"`, `"lora_A_weight"`).
+
+The resulting canonical form is therefore:
+
+```
+  <layer_name>:<param_role>
+```
+
+Common roles used across layers:
+
+```
+  Layer                Role strings (produced by layer code)
+  -------------------------------------------------------------
+  fully_connected      "weight", "bias", "lora_A_weight", "lora_B_weight"
+  embedding            "weight"
+  conv2d / conv1d      "weight", "bias"
+  batch_normalization  "mu", "var", "gamma", "beta"
+  layer_normalization  "gamma", "beta"
+  rms_norm             "gamma"
+  multi_head_attention "q_proj:weight", "k_proj:weight", ... (nested)
+  lstm / gru / rnn     "weight_ih", "weight_hh", "bias_h"
+```
+
+Writers of safetensors files (TorchFXConverter, per-model
+`res/*/weight_converter.py`, and the planned `bin_to_safetensors` CLI)
+must map every tensor they emit to this `<layer>:<role>` key so that
+`NeuralNetwork::load()` finds it by name. A name that is not present
+in the header falls back to the legacy sequential offset path with a
+warning in the log — which defeats the whole point of the format.
+
+Example mapping from HuggingFace state_dict keys to nntrainer canonical
+names, assuming the CausalLM pipeline names its layers
+`embedding0`, `layer<i>_attn_q_proj`, `output_norm`:
+
+```
+  HuggingFace key                           nntrainer canonical name
+  ----------------------------------------------------------------------
+  model.embed_tokens.weight                 embedding0:weight
+  model.layers.0.self_attn.q_proj.weight    layer0_attn_q_proj:weight
+  model.layers.0.self_attn.q_proj.bias      layer0_attn_q_proj:bias
+  model.layers.0.input_layernorm.weight     layer0_attn_norm:gamma
+  model.norm.weight                         output_norm:gamma
+```
+
+The actual layer names in any one pipeline are determined by the
+`name=` property passed to `createLayer()` for each layer — so a
+writer must either (a) match the names its companion converter hard-codes,
+or (b) consume a canonical name list produced by nntrainer itself
+(e.g. a `nntr_dump_weight_names` utility) as the ground truth.
+
+### Weight Transformation Rules
+
+```
+  Layer Type        Transform        Shape Change
+  ─────────────────────────────────────────────────
+  Linear (FC)       transpose        [out, in] → [in, out]
+  Embedding         none             [vocab, dim] → [vocab, dim]
+  RMSNorm           none             [dim] → [dim]
+  LayerNorm         none             [dim] → [dim]
+  Tied weights      skip (shared)    stored once, referenced by name
+```
+
+---
+
+## 6. Format Detection in load()
+
+```
+  load(file_path, format)
+        |
+        +-- format == MODEL_FORMAT_SAFETENSORS ?
+        |         |
+        |    YES  |  NO (MODEL_FORMAT_BIN)
+        |         |
+        v         v
+  +-----------+  +------------------+
+  | Read 8B   |  | Sequential       |
+  | header    |  | offset calc      |
+  | size      |  | (topological     |
+  |           |  |  order)           |
+  | Read JSON |  |                  |
+  | header    |  | start = 0       |
+  |           |  | for each weight: |
+  | Parse     |  |   off = start   |
+  | name ->   |  |   start += size |
+  | (off,sz)  |  +------------------+
+  | map       |
+  +-----------+
+        |
+        v
+  Assign file offsets to weights
+  (name-based or sequential)
+        |
+        v
+  Per-layer parallel read (threads + mmap)
+```
+
+---
+
+## 7. Example: Qwen3-0.6B Weight File
+
+For a tiny Qwen3 model (2 layers, hidden=64):
+
+```
+  Safetensors file:  78,090,344 bytes
+  Raw BIN file:      78,087,680 bytes
+  Header overhead:        2,664 bytes  (8B size + 2,656B JSON)
+
+  Weight breakdown:
+  ┌──────────────────────────────────────────────────┐
+  │  Type              Count    Params      Bytes    │
+  ├──────────────────────────────────────────────────┤
+  │  Embedding           1    9,723,904   38,895,616 │
+  │  Attention (Q/K/V/O) 8      varies    ~varies   │
+  │  FFN (gate/up/down)  6      varies    ~varies   │
+  │  Norm (RMS/QK)       9       ~576       ~2,304  │
+  │  LM Head             1    (tied to embedding)    │
+  ├──────────────────────────────────────────────────┤
+  │  Total              25   19,521,920   78,087,680 │
+  └──────────────────────────────────────────────────┘
+```
+
+### JSON Header Sample (abridged)
+
+```json
+{
+  "__metadata__": {"format": "nntrainer"},
+  "model_embed_tokens:weight": {
+    "dtype": "F32",
+    "shape": [151936, 64],
+    "data_offsets": [0, 38895616]
+  },
+  "model_layers_0_input_layernorm:weight": {
+    "dtype": "F32",
+    "shape": [64],
+    "data_offsets": [38895616, 38895872]
+  },
+  "model_layers_0_self_attn_q_proj:weight": {
+    "dtype": "F32",
+    "shape": [64, 64],
+    "data_offsets": [38895872, 38912256]
+  }
+}
+```
+
+---
+
+## 8. API Usage
+
+### C++ API
+
+```cpp
+#include <model.h>
+
+// Save as safetensors
+model.save("model.safetensors", ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS);
+
+// Load from safetensors (auto name-based offset, parallel if INFERENCE)
+model.load("model.safetensors", ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS);
+
+// Convert BIN to safetensors
+model.convertBinToSafetensors("model.bin", "model.safetensors");
+```
+
+### Python API (TorchFXConverter)
+
+```python
+from weight_converter import WeightConverter
+
+converter = WeightConverter(layers)
+
+# Auto-detect from extension
+converter.convert(state_dict, "model.safetensors")  # -> safetensors
+converter.convert(state_dict, "model.bin")           # -> raw binary
+
+# Explicit format
+converter.convert(state_dict, "out.dat", output_format="safetensors")
+
+# From pretrained
+converter.convert_from_pretrained("Qwen/Qwen3-0.6B", "model.safetensors")
+```

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -51,6 +51,7 @@
 #include <profiler.h>
 #include <recurrent_realizer.h>
 #include <remap_realizer.h>
+#include <safetensors_util.h>
 #include <slice_realizer.h>
 #include <util_func.h>
 
@@ -676,6 +677,58 @@ void NeuralNetwork::save(
     std::get<props::SavePath>(model_flex_props) = old_save_path;
     break;
   }
+  case ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS: {
+    // On-disk layout: [8B header_size][JSON header][raw tensor bytes].
+    // The JSON header and dtype/shape/offset bookkeeping live in
+    // nntrainer::safetensors (utils/safetensors_util.h).
+    auto model_file = checkedOpenStream<std::ofstream>(
+      file_path, std::ios::out | std::ios::binary | std::ios::trunc);
+
+    // Collect one TensorEntry per weight in graph order.
+    std::vector<nntrainer::safetensors::TensorEntry> entries;
+    size_t data_offset = 0;
+    for (auto iter = model_graph.cbegin(); iter != model_graph.cend(); iter++) {
+      auto weights = (*iter)->getRunContext().getWeights();
+      for (unsigned int i = 0; i < weights.size(); ++i) {
+        if (!(*iter)->getRunContext().isGradientFirstAccess(i))
+          continue;
+        auto &w = *weights[i];
+        const size_t sz = w.getVariable().getMemoryBytes();
+
+        // Drop leading 1s from the 4D dim so the shape matches what the
+        // original model author wrote, defaulting to [1] for scalars.
+        std::vector<size_t> shape;
+        const size_t *dims = w.getDim().getDim();
+        for (size_t d = 0; d < TensorDim::MAXDIM; ++d) {
+          if (!shape.empty() || dims[d] != 1)
+            shape.push_back(dims[d]);
+        }
+        if (shape.empty())
+          shape.push_back(1);
+
+        entries.push_back(
+          {w.getName(),
+           nntrainer::safetensors::dtypeToString(w.getDim().getDataType()),
+           std::move(shape), data_offset, data_offset + sz});
+        data_offset += sz;
+      }
+    }
+
+    // Serialize header, then write [header_size][header][data].
+    const std::string header = nntrainer::safetensors::buildHeader(entries);
+    const uint64_t header_size = header.size();
+    model_file.write(reinterpret_cast<const char *>(&header_size),
+                     sizeof(header_size));
+    model_file.write(header.data(), header.size());
+    for (auto iter = model_graph.cbegin(); iter != model_graph.cend(); iter++) {
+      (*iter)->save(model_file, false, exec_mode);
+    }
+
+    model_file.close();
+    ml_logi("Saved model in safetensors format: %s (%zu weights, %zu bytes)",
+            file_path.c_str(), entries.size(), data_offset);
+    break;
+  }
   case ml::train::ModelFormat::MODEL_FORMAT_ONNX: {
     throw nntrainer::exception::not_supported(
       "saving with ONNX format is not supported yet.");
@@ -685,6 +738,18 @@ void NeuralNetwork::save(
     throw nntrainer::exception::not_supported(
       "saving with given format is not supported yet");
   }
+}
+
+void NeuralNetwork::convertBinToSafetensors(const std::string &bin_path,
+                                            const std::string &st_path) {
+  NNTR_THROW_IF(!initialized, std::runtime_error)
+    << "Model must be initialized before converting weight format";
+
+  load(bin_path, ml::train::ModelFormat::MODEL_FORMAT_BIN);
+  save(st_path, ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS);
+
+  ml_logi("Converted weight file from BIN to safetensors: %s -> %s",
+          bin_path.c_str(), st_path.c_str());
 }
 
 void NeuralNetwork::load(const std::string &file_path,
@@ -697,6 +762,44 @@ void NeuralNetwork::load(const std::string &file_path,
   const std::regex reg_("\\s*\\;\\s*");
   auto v = split(file_path, reg_);
 
+  auto f_path = (v.size() == 2) ? v[1] : v[0];
+
+  /**
+   * For safetensors format, parse JSON header to get name-based offsets.
+   * For BIN format, use sequential offset assignment (legacy).
+   */
+  size_t data_section_start = 0;
+  std::unordered_map<std::string, std::pair<size_t, size_t>> name_offset_map;
+  bool is_safetensors =
+    (format == ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS);
+
+  if (is_safetensors) {
+    auto probe =
+      checkedOpenStream<std::ifstream>(f_path, std::ios::in | std::ios::binary);
+    uint64_t header_size = 0;
+    probe.read(reinterpret_cast<char *>(&header_size), sizeof(header_size));
+    NNTR_THROW_IF(!probe.good(), std::runtime_error)
+      << "Failed to read safetensors header size from: " << f_path;
+
+    data_section_start = sizeof(uint64_t) + static_cast<size_t>(header_size);
+
+    std::string header_json(static_cast<size_t>(header_size), '\0');
+    probe.read(&header_json[0], header_size);
+    NNTR_THROW_IF(!probe.good(), std::runtime_error)
+      << "Failed to read safetensors JSON header from: " << f_path;
+    probe.close();
+
+    name_offset_map = nntrainer::safetensors::parseHeader(header_json);
+    ml_logi("Loaded safetensors file with %zu tensor entries",
+            name_offset_map.size());
+  }
+
+  /**
+   * Assign file offsets to each weight tensor.
+   *   Safetensors: look up by weight name in the JSON header
+   * (order-independent). BIN: sequential accumulation in topological order
+   * (legacy).
+   */
   size_t start_from = 0;
   std::vector<std::pair<size_t, size_t>> file_offset;
   std::unordered_set<const Tensor *> visited_weights;
@@ -714,20 +817,30 @@ void NeuralNetwork::load(const std::string &file_path,
       }
       size_t size = weight->getVariable().getMemoryBytes();
       auto tensor_data_type = weight->getDim().getDataType();
-      weight->getVariableRef().setFileOffset(start_from);
-      ///@todo instead of checking the data type,
-      /// we may need to create a common parent class for
-      /// quantized tensors, requiring qparam to be saved
-      /// and creating a common interface to check if qparam is needed
-      /// this kind of type checking should be avoided
+
+      if (is_safetensors) {
+        auto it = name_offset_map.find(weight->getName());
+        if (it != name_offset_map.end()) {
+          weight->getVariableRef().setFileOffset(data_section_start +
+                                                 it->second.first);
+        } else {
+          ml_logw("Weight '%s' not found in safetensors header, "
+                  "using sequential offset",
+                  weight->getName().c_str());
+          weight->getVariableRef().setFileOffset(start_from);
+        }
+      } else {
+        weight->getVariableRef().setFileOffset(start_from);
+      }
+
       if (tensor_data_type != TensorDim::DataType::FP32 &&
           tensor_data_type != TensorDim::DataType::FP16 &&
           tensor_data_type != TensorDim::DataType::Q6_K &&
           tensor_data_type != TensorDim::DataType::Q4_0) {
-        // for tensor with qparam
         size += sizeof(uint16_t);
       }
-      file_offset.emplace_back(std::make_pair(start_from, size));
+      file_offset.emplace_back(
+        std::make_pair(weight->getVariable().getFileOffset(), size));
       start_from += size;
     }
   }
@@ -742,7 +855,6 @@ void NeuralNetwork::load(const std::string &file_path,
     NNTR_THROW_IF(!initialized, std::runtime_error)
       << "Cannot load if not initialized yet, path: " << file_path
       << " format: " << static_cast<unsigned>(format);
-    auto f_path = (v.size() == 2) ? v[1] : v[0];
 
     auto model_file =
       checkedOpenStream<std::ifstream>(f_path, std::ios::in | std::ios::binary);
@@ -900,6 +1012,78 @@ void NeuralNetwork::load(const std::string &file_path,
   case ml::train::ModelFormat::MODEL_FORMAT_ONNX: {
     int ret = loadFromConfig((v.size() == 2) ? v[1] : v[0]);
     throw_status(ret);
+    break;
+  }
+
+  case ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS: {
+    NNTR_THROW_IF(!initialized, std::runtime_error)
+      << "Cannot load if not initialized yet, path: " << file_path
+      << " format: safetensors";
+
+    // Safetensors: parallel mmap loading using name-based offsets
+    if (exec_mode == ml::train::ExecutionMode::INFERENCE) {
+      std::vector<std::thread> threads;
+      threads.reserve(model_graph.size());
+      for (auto iter = model_graph.cbegin(); iter != model_graph.cend();
+           ++iter) {
+        auto node = *iter;
+        threads.emplace_back([&, node]() {
+#if defined(_WIN32)
+          HANDLE hFile =
+            CreateFileA(f_path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL,
+                        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+          NNTR_THROW_IF((hFile == INVALID_HANDLE_VALUE), std::runtime_error)
+            << "CreateFileA failed";
+          HANDLE hMap =
+            CreateFileMapping(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
+          NNTR_THROW_IF((hMap == NULL), std::runtime_error)
+            << "CreateFileMapping failed";
+          char *view =
+            static_cast<char *>(MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0));
+          NNTR_THROW_IF((view == nullptr), std::runtime_error)
+            << "MapViewOfFile failed";
+          node->read(view, false, exec_mode, fsu_mode,
+                     std::numeric_limits<size_t>::max(), true);
+          UnmapViewOfFile(view);
+          CloseHandle(hMap);
+          CloseHandle(hFile);
+#else
+          int fd = ::open(f_path.c_str(), O_RDONLY);
+          NNTR_THROW_IF((fd == -1), std::invalid_argument)
+            << "Cannot open file : " << f_path;
+          struct stat st {};
+          NNTR_THROW_IF((::fstat(fd, &st) == -1), std::invalid_argument)
+            << "Cannot get file info (fstat): " << f_path;
+          size_t f_size = static_cast<size_t>(st.st_size);
+          void *mmap_ptr =
+            ::mmap(nullptr, f_size, PROT_READ, MAP_PRIVATE, fd, 0);
+          ::close(fd);
+          NNTR_THROW_IF((mmap_ptr == MAP_FAILED), std::runtime_error)
+            << "mmap failed";
+          (void)::posix_madvise(mmap_ptr, f_size, POSIX_MADV_RANDOM);
+          char *view = static_cast<char *>(mmap_ptr);
+          node->read(view, false, exec_mode, fsu_mode,
+                     std::numeric_limits<size_t>::max(), true);
+          (void)::posix_madvise(mmap_ptr, f_size, POSIX_MADV_DONTNEED);
+          ::munmap(mmap_ptr, f_size);
+#endif
+        });
+      }
+      for (auto &t : threads) {
+        if (t.joinable())
+          t.join();
+      }
+    } else {
+      // Training mode: sequential loading (no optimizer state in safetensors)
+      auto model_file = checkedOpenStream<std::ifstream>(
+        f_path, std::ios::in | std::ios::binary);
+      for (auto iter = model_graph.cbegin(); iter != model_graph.cend();
+           ++iter) {
+        (*iter)->read(model_file, false, exec_mode, fsu_mode);
+      }
+    }
+
+    ml_logi("read safetensors modelfile: %s", f_path.c_str());
     break;
   }
 

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -288,6 +288,17 @@ public:
               ml::train::ModelFormat::MODEL_FORMAT_BIN) override;
 
   /**
+   * @brief     Convert a BIN weight file (v0 or v1) to safetensors format.
+   *            The model must be initialized first. Loads the BIN file and
+   *            re-saves as safetensors with JSON header for name-based,
+   *            offset-based parallel loading.
+   * @param[in] bin_path path to the .bin file
+   * @param[in] st_path  path to write the .safetensors file
+   */
+  void convertBinToSafetensors(const std::string &bin_path,
+                               const std::string &st_path);
+
+  /**
    * @brief     get Epochs
    * @retval    epochs
    */

--- a/nntrainer/utils/meson.build
+++ b/nntrainer/utils/meson.build
@@ -8,7 +8,8 @@ util_sources = [
   'fp16.cpp',
   'util_simd.cpp',
   'mman_windows.cpp',
-  'bs_thread_pool_manager.cpp'
+  'bs_thread_pool_manager.cpp',
+  'safetensors_util.cpp'
 ]
 
 util_headers = [
@@ -26,6 +27,7 @@ util_headers = [
   'singleton.h',
   'nonmovable.h',
   'noncopyable.h',
+  'safetensors_util.h',
 ]
 
 if get_option('enable-trace')

--- a/nntrainer/utils/safetensors_util.cpp
+++ b/nntrainer/utils/safetensors_util.cpp
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   safetensors_util.cpp
+ * @date   24 April 2026
+ * @brief  safetensors dtype mapping + JSON header build/parse helpers.
+ * @see    https://github.com/huggingface/safetensors
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include "safetensors_util.h"
+
+#include <cctype>
+#include <sstream>
+#include <stdexcept>
+
+namespace nntrainer::safetensors {
+
+const char *dtypeToString(ml::train::TensorDim::DataType dtype) {
+  using DT = ml::train::TensorDim::DataType;
+  switch (dtype) {
+  case DT::FP32:
+    return "F32";
+  case DT::FP16:
+    return "F16";
+  case DT::QINT4:
+    return "I4";
+  case DT::QINT8:
+    return "I8";
+  case DT::QINT16:
+    return "I16";
+  case DT::UINT4:
+    return "U4";
+  case DT::UINT8:
+    return "U8";
+  case DT::UINT16:
+    return "U16";
+  case DT::UINT32:
+    return "U32";
+  default:
+    return "F32";
+  }
+}
+
+std::string buildHeader(const std::vector<TensorEntry> &entries) {
+  std::ostringstream out;
+  out << "{\"__metadata__\":{\"format\":\"nntrainer\"}";
+  for (const auto &e : entries) {
+    out << ",\"" << e.name << "\":{\"dtype\":\"" << e.dtype << "\",\"shape\":[";
+    for (size_t i = 0; i < e.shape.size(); ++i) {
+      if (i > 0)
+        out << ",";
+      out << e.shape[i];
+    }
+    out << "],\"data_offsets\":[" << e.offset_start << "," << e.offset_end
+        << "]}";
+  }
+  out << "}";
+
+  std::string s = out.str();
+  // Pad to an 8-byte boundary so the data section is aligned.
+  const size_t pad = (8 - (s.size() % 8)) % 8;
+  s.append(pad, ' ');
+  return s;
+}
+
+namespace {
+
+/**
+ * @brief Minimal forward-only JSON scanner tailored to safetensors headers:
+ *        only handles the shapes the safetensors spec actually uses
+ *        (objects, arrays of integers, strings, integers).
+ */
+class Scanner {
+public:
+  explicit Scanner(const std::string &s) : src(s), pos(0) {}
+
+  void skipWs() {
+    while (pos < src.size() &&
+           std::isspace(static_cast<unsigned char>(src[pos])))
+      ++pos;
+  }
+
+  bool peek(char c) {
+    skipWs();
+    return pos < src.size() && src[pos] == c;
+  }
+
+  void expect(char c) {
+    if (!peek(c))
+      throw std::runtime_error(std::string("safetensors header: expected '") +
+                               c + "'");
+    ++pos;
+  }
+
+  std::string readString() {
+    expect('"');
+    std::string out;
+    while (pos < src.size() && src[pos] != '"') {
+      if (src[pos] == '\\' && pos + 1 < src.size())
+        ++pos;
+      out += src[pos++];
+    }
+    expect('"');
+    return out;
+  }
+
+  size_t readNumber() {
+    skipWs();
+    size_t v = 0;
+    while (pos < src.size() && src[pos] >= '0' && src[pos] <= '9')
+      v = v * 10 + (src[pos++] - '0');
+    return v;
+  }
+
+  /// Skip any JSON value starting at the current position.
+  void skipValue() {
+    skipWs();
+    if (pos >= src.size())
+      return;
+    char c = src[pos];
+    if (c == '"') {
+      readString();
+      return;
+    }
+    if (c == '{' || c == '[') {
+      const char close = (c == '{') ? '}' : ']';
+      int depth = 0;
+      while (pos < src.size()) {
+        if (src[pos] == '"') {
+          readString();
+          continue;
+        }
+        if (src[pos] == c)
+          ++depth;
+        else if (src[pos] == close && --depth == 0) {
+          ++pos;
+          return;
+        }
+        ++pos;
+      }
+      return;
+    }
+    // number / literal
+    while (pos < src.size() && src[pos] != ',' && src[pos] != '}' &&
+           src[pos] != ']')
+      ++pos;
+  }
+
+private:
+  const std::string &src;
+  size_t pos;
+};
+
+} // namespace
+
+std::unordered_map<std::string, std::pair<size_t, size_t>>
+parseHeader(const std::string &json) {
+  std::unordered_map<std::string, std::pair<size_t, size_t>> out;
+  Scanner s(json);
+
+  s.expect('{');
+  for (bool first = true; !s.peek('}'); first = false) {
+    if (!first)
+      s.expect(',');
+
+    const std::string key = s.readString();
+    s.expect(':');
+
+    if (key == "__metadata__") {
+      s.skipValue();
+      continue;
+    }
+
+    // Tensor descriptor: { "dtype": "...", "shape": [...], "data_offsets": [s,
+    // e] }
+    s.expect('{');
+    size_t off_start = 0, off_end = 0;
+    bool have_offsets = false;
+    for (bool inner_first = true; !s.peek('}'); inner_first = false) {
+      if (!inner_first)
+        s.expect(',');
+      const std::string field = s.readString();
+      s.expect(':');
+      if (field == "data_offsets") {
+        s.expect('[');
+        off_start = s.readNumber();
+        s.expect(',');
+        off_end = s.readNumber();
+        s.expect(']');
+        have_offsets = true;
+      } else {
+        s.skipValue();
+      }
+    }
+    s.expect('}');
+
+    if (have_offsets)
+      out.emplace(key, std::make_pair(off_start, off_end - off_start));
+  }
+  s.expect('}');
+
+  return out;
+}
+
+} // namespace nntrainer::safetensors

--- a/nntrainer/utils/safetensors_util.h
+++ b/nntrainer/utils/safetensors_util.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   safetensors_util.h
+ * @date   24 April 2026
+ * @brief  Minimal helpers for the safetensors on-disk format: dtype
+ *         mapping, JSON header builder, JSON header parser.
+ * @see    https://github.com/huggingface/safetensors
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __SAFETENSORS_UTIL_H__
+#define __SAFETENSORS_UTIL_H__
+#ifdef __cplusplus
+
+#include <string>
+#include <tensor_dim.h>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace nntrainer::safetensors {
+
+/**
+ * @brief One tensor entry as it appears in the safetensors JSON header.
+ */
+struct TensorEntry {
+  std::string name;          /**< weight name, becomes the JSON key */
+  std::string dtype;         /**< safetensors dtype code, e.g. "F32" */
+  std::vector<size_t> shape; /**< tensor shape, most-significant first */
+  size_t offset_start;       /**< byte offset from data section start */
+  size_t offset_end;         /**< byte offset (exclusive) */
+};
+
+/**
+ * @brief Map an nntrainer data type to its safetensors dtype code.
+ *        Unknown / NONE types fall back to "F32".
+ */
+const char *dtypeToString(ml::train::TensorDim::DataType dtype);
+
+/**
+ * @brief Build the JSON header for a set of tensor entries. The returned
+ *        string is padded with spaces so its length is a multiple of 8,
+ *        matching the safetensors alignment convention.
+ */
+std::string buildHeader(const std::vector<TensorEntry> &entries);
+
+/**
+ * @brief Parse a safetensors JSON header and return a name -> (offset, size)
+ *        map, where offset is the byte offset from the start of the data
+ *        section and size is the number of bytes of that tensor's payload.
+ *        The "__metadata__" key (if present) is skipped.
+ */
+std::unordered_map<std::string, std::pair<size_t, size_t>>
+parseHeader(const std::string &json);
+
+} // namespace nntrainer::safetensors
+
+#endif /* __cplusplus */
+#endif /* __SAFETENSORS_UTIL_H__ */

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -685,6 +685,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/singleton.h
 %{_includedir}/nntrainer/fp16.h
 %{_includedir}/nntrainer/util_simd.h
+%{_includedir}/nntrainer/safetensors_util.h
 %{_includedir}/nntrainer/dynamic_library_loader.h
 %{_includedir}/nntrainer/mman_windows.h
 %{_includedir}/nntrainer/loss_layer.h

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -82,6 +82,7 @@ if host_machine.system() != 'windows'
   test_target += [['unittest_nntrainer_appcontext', []]]
   test_target += [['unittest_nntrainer_modelfile', []]]
   test_target += [['unittest_nntrainer_tensor_utils', []]]
+  test_target += [['unittest_nntrainer_safetensors', []]]
 endif
 
 if get_option('enable-opencl')

--- a/test/unittest/unittest_nntrainer_safetensors.cpp
+++ b/test/unittest/unittest_nntrainer_safetensors.cpp
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   unittest_nntrainer_safetensors.cpp
+ * @date   24 April 2026
+ * @brief  Round-trip tests for MODEL_FORMAT_SAFETENSORS save/load.
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <layer.h>
+#include <model.h>
+#include <nntrainer_error.h>
+#include <nntrainer_test_util.h>
+
+namespace {
+
+/**
+ * @brief Build a tiny {input -> fully_connected} model for roundtrip tests.
+ */
+static std::unique_ptr<ml::train::Model>
+buildTinyModel(const std::string &input_shape, unsigned int unit) {
+  auto model =
+    ml::train::createModel(ml::train::ModelType::NEURAL_NET, {"batch_size=1"});
+  model->addLayer(ml::train::createLayer(
+    "input", {"name=input", "input_shape=" + input_shape}));
+  model->addLayer(ml::train::createLayer(
+    "fully_connected",
+    {"name=fc", "unit=" + std::to_string(unit), "bias_initializer=zeros"}));
+  // Use INFERENCE mode: save/load roundtrip does not need a loss layer.
+  EXPECT_EQ(model->compile(ml::train::ExecutionMode::INFERENCE), ML_ERROR_NONE);
+  EXPECT_EQ(model->initialize(ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
+  return model;
+}
+
+/**
+ * @brief Compare two files byte-by-byte.
+ */
+static bool filesBitEqual(const std::string &a, const std::string &b) {
+  std::ifstream fa(a, std::ios::binary);
+  std::ifstream fb(b, std::ios::binary);
+  if (!fa.good() || !fb.good())
+    return false;
+  std::vector<char> va((std::istreambuf_iterator<char>(fa)),
+                       std::istreambuf_iterator<char>());
+  std::vector<char> vb((std::istreambuf_iterator<char>(fb)),
+                       std::istreambuf_iterator<char>());
+  return va == vb;
+}
+
+} // namespace
+
+/**
+ * @brief save(SAFETENSORS) produces a readable file that load(SAFETENSORS)
+ *        consumes without error on a freshly built identical model.
+ */
+TEST(nntrainer_safetensors, save_and_load_roundtrip_p) {
+  const std::string path = "unittest_safetensors_roundtrip.safetensors";
+  std::remove(path.c_str());
+
+  auto writer = buildTinyModel("1:1:4", 2);
+  ASSERT_NO_THROW(
+    writer->save(path, ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS));
+
+  // File must exist and carry the 8B header-size prefix at minimum.
+  std::ifstream f(path, std::ios::binary | std::ios::ate);
+  ASSERT_TRUE(f.good());
+  EXPECT_GT(static_cast<size_t>(f.tellg()), sizeof(uint64_t));
+  f.close();
+
+  auto reader = buildTinyModel("1:1:4", 2);
+  EXPECT_NO_THROW(
+    reader->load(path, ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS));
+
+  std::remove(path.c_str());
+}
+
+/**
+ * @brief Re-saving a just-loaded safetensors file must produce a byte-for-byte
+ *        identical payload (format is deterministic).
+ */
+TEST(nntrainer_safetensors, resave_is_byte_identical_p) {
+  const std::string first = "unittest_safetensors_first.safetensors";
+  const std::string second = "unittest_safetensors_second.safetensors";
+  std::remove(first.c_str());
+  std::remove(second.c_str());
+
+  auto a = buildTinyModel("1:1:4", 2);
+  ASSERT_NO_THROW(
+    a->save(first, ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS));
+
+  auto b = buildTinyModel("1:1:4", 2);
+  ASSERT_NO_THROW(
+    b->load(first, ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS));
+  ASSERT_NO_THROW(
+    b->save(second, ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS));
+
+  EXPECT_TRUE(filesBitEqual(first, second));
+
+  std::remove(first.c_str());
+  std::remove(second.c_str());
+}
+
+/**
+ * @brief The on-disk layout must start with an 8-byte little-endian header
+ *        size followed by a JSON object that references nntrainer metadata.
+ */
+TEST(nntrainer_safetensors, header_layout_p) {
+  const std::string path = "unittest_safetensors_header.safetensors";
+  std::remove(path.c_str());
+
+  auto model = buildTinyModel("1:1:4", 3);
+  ASSERT_NO_THROW(
+    model->save(path, ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS));
+
+  std::ifstream f(path, std::ios::binary);
+  ASSERT_TRUE(f.good());
+
+  uint64_t header_size = 0;
+  f.read(reinterpret_cast<char *>(&header_size), sizeof(header_size));
+  ASSERT_EQ(f.gcount(), static_cast<std::streamsize>(sizeof(header_size)));
+  ASSERT_GT(header_size, 0u);
+
+  std::string header_json(static_cast<size_t>(header_size), '\0');
+  f.read(&header_json[0], static_cast<std::streamsize>(header_size));
+  ASSERT_EQ(f.gcount(), static_cast<std::streamsize>(header_size));
+
+  EXPECT_NE(header_json.find("__metadata__"), std::string::npos);
+  EXPECT_NE(header_json.find("\"format\":\"nntrainer\""), std::string::npos);
+  EXPECT_NE(header_json.find("data_offsets"), std::string::npos);
+
+  std::remove(path.c_str());
+}
+
+/**
+ * @brief Loading a non-existent safetensors file must raise an exception
+ *        rather than silently succeeding or crashing.
+ */
+TEST(nntrainer_safetensors, load_missing_file_n) {
+  const std::string path = "unittest_safetensors_does_not_exist.safetensors";
+  std::remove(path.c_str()); // ensure absent
+
+  auto reader = buildTinyModel("1:1:4", 2);
+  EXPECT_ANY_THROW(
+    reader->load(path, ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS));
+}
+
+/**
+ * @brief Test entry point.
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during InitGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}


### PR DESCRIPTION
Adds MODEL_FORMAT_SAFETENSORS to the C API (ml_train_model_format_e) and the C++ API (ml::train::ModelFormat)

 so callers can select the safetensors layout when saving or loading model weights.

NeuralNetwork::save() serializes weights as:
  [8B]  header_size (little-endian uint64)
  [header_size B] JSON header with per-tensor {dtype, shape,
                  data_offsets: [start, end]}
  [data] raw tensor bytes in graph order

NeuralNetwork::load() consumes the same layout: it reads the header size and JSON body, resolves a name -> (offset, size) map, and assigns each weight's file offset by name. This removes the ordering constraint that the legacy BIN format imposes and makes loading safe against graph reordering. The BIN path keeps the sequential offset assignment it always used.

In INFERENCE mode the load path spawns one std::thread per graph node, each mmap'ing the file with POSIX_MADV_RANDOM and invoking node->read() against its own view so large weight files stream concurrently. Training mode keeps sequential loading.

The dtype string mapping, JSON header builder, and minimal JSON header parser all live in nntrainer::safetensors (in nntrainer/utils/safetensors_util.{h,cpp}) so that the save/load code in neuralnet.cpp stays short and readable, and so that tools outside the model loader can reuse the same serialization.

convertBinToSafetensors(bin_path, st_path) loads the weights in BIN form and re-serializes them as safetensors for in-place upgrades.

Applications/CausalLM/models/transformer.cpp::load_weight / save_weight now pick the format from the file extension (*.safetensors -> MODEL_FORMAT_SAFETENSORS, otherwise BIN) so CausalLM pipelines pick up the new format with no call-site change.

test/unittest/unittest_nntrainer_safetensors.cpp adds a round-trip suite (save -> load, deterministic re-save byte equality, header layout check, missing-file negative) to pin the on-disk contract.

docs/weight-format-specification.md documents both the legacy BIN layout and the new safetensors layout (header, dtype codes, offsets, alignment).

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>