### PR TITLE
Enhance/causallm multiturn api

### DIFF
--- a/Applications/CausalLM/api/README.md
+++ b/Applications/CausalLM/api/README.md
@@ -117,7 +117,23 @@ Retrieves performance metrics of the last run.
 - `total_duration_ms`: Total execution time from start to finish.
 - `peak_memory_kb`: Peak resident set size (memory usage) in KB.
 
-## Usage Example
+#### `ErrorCode applyChatTemplate(const CausalLMChatMessage *messages, size_t num_messages, bool add_generation_prompt, const char **formattedText)`
+Applies chat template to messages without running inference. Useful for debugging or verifying prompt formatting.
+- **messages**: Array of `CausalLMChatMessage` structs (role + content).
+- **num_messages**: Number of messages in the array.
+- **add_generation_prompt**: Whether to append generation prompt (e.g., `<|im_start|>assistant\n`).
+- **formattedText**: Pointer to store the formatted prompt string.
+
+#### `ErrorCode runModelWithMessages(const CausalLMChatMessage *messages, size_t num_messages, bool add_generation_prompt, const char **outputText)`
+Applies chat template to messages and runs inference. Internally calls `applyChatTemplate()` then `runModel()`.
+- **messages**: Array of `CausalLMChatMessage` structs (role + content).
+- **num_messages**: Number of messages in the array.
+- **add_generation_prompt**: Whether to append generation prompt.
+- **outputText**: Pointer to store the generated output string.
+
+## Usage Examples
+
+### 1. Single Prompt
 
 ```c
 #include "causal_lm_api.h"
@@ -159,3 +175,65 @@ int main() {
     return 0;
 }
 ```
+
+### 2. Chat Template with Messages
+
+```c
+#include "causal_lm_api.h"
+#include <stdio.h>
+
+int main() {
+    Config config = {.use_chat_template = true, .debug_mode = false, .verbose = true};
+    setOptions(config);
+
+    loadModel(CAUSAL_LM_BACKEND_CPU, CAUSAL_LM_MODEL_QWEN3_0_6B,
+              CAUSAL_LM_QUANTIZATION_W16A16);
+
+    // System prompt + user message
+    CausalLMChatMessage msgs[] = {
+        {"system", "You are a helpful AI assistant."},
+        {"user",   "What is machine learning?"}
+    };
+
+    const char *output;
+    runModelWithMessages(msgs, 2, true, &output);
+    printf("Response: %s\n", output);
+
+    return 0;
+}
+```
+
+### 3. Conversation History
+
+```c
+    // Multiple user/assistant turns
+    CausalLMChatMessage msgs[] = {
+        {"user",      "Hello, how are you?"},
+        {"assistant", "I'm doing great. How can I help you today?"},
+        {"user",      "What is deep learning?"},
+        {"assistant", "Deep learning uses neural networks with many layers."},
+        {"user",      "How is it different from traditional ML?"}
+    };
+
+    const char *output;
+    runModelWithMessages(msgs, 5, true, &output);
+    printf("Response: %s\n", output);
+```
+
+### 4. Preview Formatted Prompt (No Inference)
+```c
+    CausalLMChatMessage msgs[] = {
+        {"system", "You are a helpful assistant."},
+        {"user",   "Hello!"}
+    };
+    const char *formatted;
+    applyChatTemplate(msgs, 2, true, &formatted);
+    printf("Formatted prompt:\n%s\n", formatted);
+    // Output (Qwen3):
+    // <|im_start|>system
+    // You are a helpful assistant.<|im_end|>
+    // <|im_start|>user
+    // Hello!<|im_end|>
+    // <|im_start|>assistant
+```
+

--- a/Applications/CausalLM/api/README.md
+++ b/Applications/CausalLM/api/README.md
@@ -96,7 +96,10 @@ Supported quantization formats.
 
 #### `ErrorCode setOptions(Config config)`
 Sets global configuration options.
-- **config**: Structure containing options like `use_chat_template` and `debug_mode`.
+- **config.use_chat_template**: Whether to apply chat template in `runModel()`.
+- **config.debug_mode**: Validate model files during initialization.
+- **config.verbose**: Print output during generation.
+- **config.chat_template_name**: Template name to select when `chat_template` is an array (e.g., `"default"`, `"tool_use"`). `NULL` defaults to `"default"`.
 
 #### `ErrorCode loadModel(BackendType compute, ModelType modeltype, ModelQuantizationType quant_type)`
 Loads a registered model.
@@ -237,3 +240,32 @@ int main() {
     // <|im_start|>assistant
 ```
 
+### 5. Named Template Selection (default / tool_use)
+
+When `tokenizer_config.json` contains an array of named templates, select by name:
+
+```c
+    // Use "default" template (normal conversation)
+    Config config;
+    config.use_chat_template = true;
+    config.chat_template_name = "default";
+    setOptions(config);
+    loadModel(...);
+
+    // Use "tool_use" template (function calling)
+    Config config;
+    config.use_chat_template = true;
+    config.chat_template_name = "tool_use";
+    setOptions(config);
+    loadModel(...);
+```
+
+Supported by models like Gemma3 that provide multiple templates:
+```json
+"chat_template": [
+    {"name": "default",  "template": "..."},
+    {"name": "tool_use", "template": "..."}
+]
+```
+
+If the requested name is not found, falls back to the first template with a warning.

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -66,6 +66,7 @@ struct ChatMessage {
 
 static std::map<std::string, std::string> g_model_path_map = {
   {"QWEN3-0.6B", "qwen3-0.6b"},
+  {"QWEN3-1.7B", "qwen3-1.7b"},
 };
 
 /**
@@ -148,6 +149,8 @@ static const char *get_model_name_from_type(ModelType type) {
   switch (type) {
   case CAUSAL_LM_MODEL_QWEN3_0_6B:
     return "QWEN3-0.6B";
+  case CAUSAL_LM_MODEL_QWEN3_1_7B:
+    return "QWEN3-1.7B";
   default:
     return nullptr;
   }

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -688,8 +688,7 @@ apply_chat_template_messages(const std::string &architecture,
              architecture == "Qwen3SlimMoeForCausalLM" ||
              architecture == "Qwen3CachedSlimMoeForCausalLM") {
     for (const auto &msg : messages) {
-      result +=
-        "<|im_start|>" + msg.role + "\n" + msg.content + "<|im_end|>\n";
+      result += "<|im_start|>" + msg.role + "\n" + msg.content + "<|im_end|>\n";
     }
     if (add_generation_prompt) {
       result += "<|im_start|>assistant\n";
@@ -699,8 +698,7 @@ apply_chat_template_messages(const std::string &architecture,
       if (msg.role == "user") {
         result += "<start_of_turn>user\n" + msg.content + "<end_of_turn>\n";
       } else if (msg.role == "assistant") {
-        result +=
-          "<start_of_turn>model\n" + msg.content + "<end_of_turn>\n";
+        result += "<start_of_turn>model\n" + msg.content + "<end_of_turn>\n";
       }
     }
     if (add_generation_prompt) {
@@ -751,9 +749,8 @@ ErrorCode runModelWithMessages(const CausalLMChatMessage *messages,
 
   // Apply chat template to format the prompt
   const char *formattedInput = nullptr;
-  ErrorCode err =
-    applyChatTemplate(messages, num_messages, add_generation_prompt,
-                      &formattedInput);
+  ErrorCode err = applyChatTemplate(messages, num_messages,
+                                    add_generation_prompt, &formattedInput);
   if (err != CAUSAL_LM_ERROR_NONE) {
     return err;
   }

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -54,6 +54,14 @@ static bool g_verbose = false;
 static std::string g_last_output = "";
 static double g_initialization_duration_ms = 0.0;
 static std::unique_ptr<causallm::ChatTemplate> g_chat_template;
+static std::string g_formatted_template;
+
+namespace {
+struct ChatMessage {
+  std::string role;
+  std::string content;
+};
+} // namespace
 
 static std::map<std::string, std::string> g_model_path_map = {
   {"QWEN3-0.6B", "qwen3-0.6b"},
@@ -625,4 +633,131 @@ ErrorCode getPerformanceMetrics(PerformanceMetrics *metrics) {
   }
 
   return CAUSAL_LM_ERROR_NONE;
+}
+
+/*****************************************************************************
+ * Chat Template API - role + content message support
+ *****************************************************************************/
+
+/**
+ * @brief Convert C message array to C++ ChatMessage vector
+ */
+static std::vector<ChatMessage>
+convertMessages(const CausalLMChatMessage *messages, size_t num_messages) {
+  std::vector<ChatMessage> result;
+  result.reserve(num_messages);
+  for (size_t i = 0; i < num_messages; ++i) {
+    ChatMessage msg;
+    msg.role = messages[i].role ? messages[i].role : "";
+    msg.content = messages[i].content ? messages[i].content : "";
+    result.push_back(std::move(msg));
+  }
+  return result;
+}
+
+/**
+ * @brief Apply chat template to messages with hardcoded fallback
+ */
+static std::string
+apply_chat_template_messages(const std::string &architecture,
+                             const std::vector<ChatMessage> &messages,
+                             bool add_generation_prompt) {
+  if (g_chat_template) {
+    nlohmann::json request = nlohmann::json::array();
+    for (const auto &msg : messages) {
+      request.push_back({{"role", msg.role}, {"content", msg.content}});
+    }
+    return g_chat_template->apply(request);
+  }
+
+  std::string result;
+
+  if (architecture == "LlamaForCausalLM") {
+    for (const auto &msg : messages) {
+      if (msg.role == "system") {
+        result += "<<SYS>>\n" + msg.content + "\n<</SYS>>\n\n";
+      } else if (msg.role == "user") {
+        result += "[INST] " + msg.content + " [/INST]";
+      } else if (msg.role == "assistant") {
+        result += msg.content + "\n";
+      }
+    }
+  } else if (architecture == "Qwen2ForCausalLM" ||
+             architecture == "Qwen3ForCausalLM" ||
+             architecture == "Qwen3MoeForCausalLM" ||
+             architecture == "Qwen3SlimMoeForCausalLM" ||
+             architecture == "Qwen3CachedSlimMoeForCausalLM") {
+    for (const auto &msg : messages) {
+      result +=
+        "<|im_start|>" + msg.role + "\n" + msg.content + "<|im_end|>\n";
+    }
+    if (add_generation_prompt) {
+      result += "<|im_start|>assistant\n";
+    }
+  } else if (architecture == "Gemma3ForCausalLM") {
+    for (const auto &msg : messages) {
+      if (msg.role == "user") {
+        result += "<start_of_turn>user\n" + msg.content + "<end_of_turn>\n";
+      } else if (msg.role == "assistant") {
+        result +=
+          "<start_of_turn>model\n" + msg.content + "<end_of_turn>\n";
+      }
+    }
+    if (add_generation_prompt) {
+      result += "<start_of_turn>model\n";
+    }
+  } else {
+    for (const auto &msg : messages) {
+      result += msg.content + "\n";
+    }
+  }
+
+  return result;
+}
+
+ErrorCode applyChatTemplate(const CausalLMChatMessage *messages,
+                            size_t num_messages, bool add_generation_prompt,
+                            const char **formattedText) {
+  if (messages == nullptr || num_messages == 0 || formattedText == nullptr) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  try {
+    std::lock_guard<std::mutex> lock(g_mutex);
+
+    auto chat_messages = convertMessages(messages, num_messages);
+    g_formatted_template = apply_chat_template_messages(
+      g_architecture, chat_messages, add_generation_prompt);
+
+    *formattedText = g_formatted_template.c_str();
+
+  } catch (const std::exception &e) {
+    std::cerr << "Exception in applyChatTemplate: " << e.what() << std::endl;
+    return CAUSAL_LM_ERROR_UNKNOWN;
+  }
+
+  return CAUSAL_LM_ERROR_NONE;
+}
+
+ErrorCode runModelWithMessages(const CausalLMChatMessage *messages,
+                               size_t num_messages, bool add_generation_prompt,
+                               const char **outputText) {
+  if (!g_initialized || !g_model) {
+    return CAUSAL_LM_ERROR_NOT_INITIALIZED;
+  }
+  if (outputText == nullptr) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  // Apply chat template to format the prompt
+  const char *formattedInput = nullptr;
+  ErrorCode err =
+    applyChatTemplate(messages, num_messages, add_generation_prompt,
+                      &formattedInput);
+  if (err != CAUSAL_LM_ERROR_NONE) {
+    return err;
+  }
+
+  // Run inference with the formatted prompt
+  return runModel(formattedInput, outputText);
 }

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -53,6 +53,7 @@ static bool g_use_chat_template = false;
 static bool g_verbose = false;
 static std::string g_last_output = "";
 static double g_initialization_duration_ms = 0.0;
+static unsigned int g_turn_count = 0;
 static std::unique_ptr<causallm::ChatTemplate> g_chat_template;
 static std::string g_formatted_template;
 static std::string g_chat_template_name = "default";
@@ -185,6 +186,48 @@ static std::string apply_chat_template(const std::string &architecture,
            "<end_of_turn>\n<start_of_turn>model\n";
   }
   return input;
+}
+
+/**
+ * @brief Turn a freshly-rendered chat template into a continuation snippet
+ *        that splices cleanly onto an existing KV cache.
+ *
+ * Chat templates always re-render the full preamble (an auto-inserted
+ * system block, if no explicit system message was provided, followed by
+ * the user block and the generation prompt). On turn 0 that's exactly
+ * what we want. On turn N>0 the KV cache already contains the system
+ * preamble plus every prior user/assistant exchange, so we must:
+ *   1. strip the system prefix that the template re-emitted, and
+ *   2. insert a leading "\n" so the transition from the previous turn's
+ *      end-of-turn token to the new user block matches the pattern the
+ *      template itself uses between turns (e.g. Qwen's
+ *      "<|im_end|>\n<|im_start|>user").
+ *
+ * Unknown templates are returned unchanged with a leading "\n" — the
+ * newline is the minimal separator that is safe across ChatML, Gemma,
+ * and Llama-style formats.
+ */
+static std::string to_continuation(const std::string &templated) {
+  struct Marker {
+    const char *sys;
+    const char *user;
+  };
+  static const Marker markers[] = {
+    {"<|im_start|>system", "<|im_start|>user"},       // Qwen / ChatML
+    {"<start_of_turn>system", "<start_of_turn>user"}, // Gemma
+    {"<<SYS>>", "[INST]"},                            // Llama-2 style
+  };
+  for (const auto &m : markers) {
+    const size_t sys_len = std::strlen(m.sys);
+    if (templated.size() >= sys_len &&
+        templated.compare(0, sys_len, m.sys) == 0) {
+      const auto pos = templated.find(m.user);
+      if (pos != std::string::npos)
+        return "\n" + templated.substr(pos);
+      break;
+    }
+  }
+  return "\n" + templated;
 }
 
 static std::string get_quantization_suffix(ModelQuantizationType type) {
@@ -555,6 +598,7 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
 
     g_initialized = true;
     g_architecture = architecture;
+    g_turn_count = 0;
 
     auto finish_init = std::chrono::high_resolution_clock::now();
     auto init_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -587,6 +631,14 @@ ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
 
     if (g_use_chat_template) {
       input = apply_chat_template(g_architecture, input);
+      // On continuation turns, the KV cache already holds the system
+      // preamble and all prior Q/A pairs. Splice the freshly-rendered
+      // template onto that state by stripping the re-emitted system
+      // prefix and inserting a leading "\n" separator. resetConversation()
+      // zeroes g_turn_count, so turn 0 of a fresh dialogue is unaffected.
+      if (g_turn_count > 0) {
+        input = to_continuation(input);
+      }
     }
 
     // We assume single batch request for this API.
@@ -600,9 +652,33 @@ ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
 
     *outputText = g_last_output.c_str();
 
+    ++g_turn_count;
+
   } catch (const std::exception &e) {
     std::cerr << "Exception in runModel: " << e.what() << std::endl;
     return CAUSAL_LM_ERROR_INFERENCE_FAILED;
+  }
+
+  return CAUSAL_LM_ERROR_NONE;
+}
+
+ErrorCode resetConversation(void) {
+  if (!g_initialized || !g_model) {
+    return CAUSAL_LM_ERROR_NOT_INITIALIZED;
+  }
+
+  try {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    auto causal_lm_model = dynamic_cast<causallm::CausalLM *>(g_model.get());
+    if (!causal_lm_model) {
+      return CAUSAL_LM_ERROR_UNKNOWN;
+    }
+    causal_lm_model->resetConversation();
+    g_last_output.clear();
+    g_turn_count = 0;
+  } catch (const std::exception &e) {
+    std::cerr << "Exception in resetConversation: " << e.what() << std::endl;
+    return CAUSAL_LM_ERROR_UNKNOWN;
   }
 
   return CAUSAL_LM_ERROR_NONE;

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -312,9 +312,9 @@ ErrorCode setOptions(Config config) {
   // Currently no options are being handled
   g_use_chat_template = config.use_chat_template;
   g_verbose = config.verbose;
-  g_chat_template_name =
-    (config.chat_template_name != nullptr) ? config.chat_template_name
-                                           : "default";
+  g_chat_template_name = (config.chat_template_name != nullptr)
+                           ? config.chat_template_name
+                           : "default";
   if (config.debug_mode) {
     // Ensure models are registered so we can validate them
     register_models();

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -863,8 +863,7 @@ ErrorCode runModelWithMessages(const CausalLMChatMessage *messages,
     return runModelInternal(formatted, outputText);
 
   } catch (const std::exception &e) {
-    std::cerr << "Exception in runModelWithMessages: " << e.what()
-              << std::endl;
+    std::cerr << "Exception in runModelWithMessages: " << e.what() << std::endl;
     return CAUSAL_LM_ERROR_INFERENCE_FAILED;
   }
 }

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -616,6 +616,35 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
   return CAUSAL_LM_ERROR_NONE;
 }
 
+// Run inference on a fully-prepared prompt string. Caller is responsible
+// for any chat-template formatting and continuation splicing - this helper
+// must NOT re-apply them, otherwise paths that pre-format the prompt (e.g.
+// runModelWithMessages) end up double-wrapping the entire transcript as a
+// new user message and corrupt multi-turn behavior.
+//
+// Caller MUST hold g_mutex.
+static ErrorCode runModelInternal(const std::string &input,
+                                  const char **outputText) {
+// We assume single batch request for this API
+#if defined(_WIN32)
+  g_model->run(std::wstring(input.begin(), input.end()), false, L"", L"",
+               g_verbose);
+#else
+  g_model->run(input, false, "", "", g_verbose);
+#endif
+
+  auto causal_lm_model = dynamic_cast<causallm::CausalLM *>(g_model.get());
+  g_last_output = ""; // Reset last output
+  if (causal_lm_model) {
+    g_last_output = causal_lm_model->getOutput(0);
+  }
+
+  *outputText = g_last_output.c_str();
+
+  ++g_turn_count;
+  return CAUSAL_LM_ERROR_NONE;
+}
+
 ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
   if (!g_initialized || !g_model) {
     return CAUSAL_LM_ERROR_NOT_INITIALIZED;
@@ -641,25 +670,12 @@ ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
       }
     }
 
-    // We assume single batch request for this API.
-    g_model->run(input, false, "", "", g_verbose);
-
-    auto causal_lm_model = dynamic_cast<causallm::CausalLM *>(g_model.get());
-    g_last_output = ""; // Reset last output
-    if (causal_lm_model) {
-      g_last_output = causal_lm_model->getOutput(0);
-    }
-
-    *outputText = g_last_output.c_str();
-
-    ++g_turn_count;
+    return runModelInternal(input, outputText);
 
   } catch (const std::exception &e) {
     std::cerr << "Exception in runModel: " << e.what() << std::endl;
     return CAUSAL_LM_ERROR_INFERENCE_FAILED;
   }
-
-  return CAUSAL_LM_ERROR_NONE;
 }
 
 ErrorCode resetConversation(void) {
@@ -828,18 +844,27 @@ ErrorCode runModelWithMessages(const CausalLMChatMessage *messages,
   if (!g_initialized || !g_model) {
     return CAUSAL_LM_ERROR_NOT_INITIALIZED;
   }
-  if (outputText == nullptr) {
+  if (messages == nullptr || num_messages == 0 || outputText == nullptr) {
     return CAUSAL_LM_ERROR_INVALID_PARAMETER;
   }
 
-  // Apply chat template to format the prompt
-  const char *formattedInput = nullptr;
-  ErrorCode err = applyChatTemplate(messages, num_messages,
-                                    add_generation_prompt, &formattedInput);
-  if (err != CAUSAL_LM_ERROR_NONE) {
-    return err;
-  }
+  try {
+    std::lock_guard<std::mutex> lock(g_mutex);
 
-  // Run inference with the formatted prompt
-  return runModel(formattedInput, outputText);
+    // The caller passes the entire conversation as a message array, so the
+    // chat template is applied exactly once here. We MUST NOT funnel the
+    // result back through runModel() - that would invoke
+    // apply_chat_template() a second time and wrap the already-rendered
+    // transcript as a brand new user turn, breaking multi-turn behavior.
+    auto chat_messages = convertMessages(messages, num_messages);
+    std::string formatted = apply_chat_template_messages(
+      g_architecture, chat_messages, add_generation_prompt);
+
+    return runModelInternal(formatted, outputText);
+
+  } catch (const std::exception &e) {
+    std::cerr << "Exception in runModelWithMessages: " << e.what()
+              << std::endl;
+    return CAUSAL_LM_ERROR_INFERENCE_FAILED;
+  }
 }

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -55,6 +55,7 @@ static std::string g_last_output = "";
 static double g_initialization_duration_ms = 0.0;
 static std::unique_ptr<causallm::ChatTemplate> g_chat_template;
 static std::string g_formatted_template;
+static std::string g_chat_template_name = "default";
 
 namespace {
 struct ChatMessage {
@@ -311,6 +312,9 @@ ErrorCode setOptions(Config config) {
   // Currently no options are being handled
   g_use_chat_template = config.use_chat_template;
   g_verbose = config.verbose;
+  g_chat_template_name =
+    (config.chat_template_name != nullptr) ? config.chat_template_name
+                                           : "default";
   if (config.debug_mode) {
     // Ensure models are registered so we can validate them
     register_models();
@@ -667,7 +671,9 @@ apply_chat_template_messages(const std::string &architecture,
     for (const auto &msg : messages) {
       request.push_back({{"role", msg.role}, {"content", msg.content}});
     }
-    return g_chat_template->apply(request);
+    causallm::ChatTemplate::Options opts;
+    opts.template_name = g_chat_template_name;
+    return g_chat_template->apply(request, opts);
   }
 
   std::string result;

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -75,8 +75,9 @@ typedef struct {
   bool use_chat_template; /// < @brief Whether to apply chat template to input
   bool debug_mode; /// < @brief Check model file validity during initialization
   bool verbose;    /// < @brief Whether to print output during generation
-  const char *chat_template_name; /// < @brief Template name to select from array
-                                  ///  (e.g., "default", "tool_use"). NULL for "default".
+  const char
+    *chat_template_name; /// < @brief Template name to select from array
+                         ///  (e.g., "default", "tool_use"). NULL for "default".
 } Config;
 
 /**

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -96,6 +96,15 @@ typedef enum {
 } ModelQuantizationType;
 
 /**
+ * @brief Chat message structure for chat template formatting
+ * @note  Compatible with HuggingFace apply_chat_template() format
+ */
+typedef struct {
+  const char *role;    /**< Message role: "system", "user", or "assistant" */
+  const char *content; /**< Message content text */
+} CausalLMChatMessage;
+
+/**
  * @brief Load a model
  * @param compute Backend compute type
  * @param modeltype Model type
@@ -120,6 +129,32 @@ WIN_EXPORT ErrorCode getPerformanceMetrics(PerformanceMetrics *metrics);
  */
 WIN_EXPORT ErrorCode runModel(const char *inputTextPrompt,
                               const char **outputText);
+
+/**
+ * @brief Run inference with chat template formatted messages
+ * @param messages Array of chat messages with role and content
+ * @param num_messages Number of messages in the array
+ * @param add_generation_prompt Whether to append generation prompt at end
+ * @param outputText Buffer to store output text (owned by the library)
+ * @return ErrorCode
+ */
+WIN_EXPORT ErrorCode runModelWithMessages(const CausalLMChatMessage *messages,
+                                          size_t num_messages,
+                                          bool add_generation_prompt,
+                                          const char **outputText);
+
+/**
+ * @brief Apply chat template to messages without running inference
+ * @param messages Array of chat messages with role and content
+ * @param num_messages Number of messages in the array
+ * @param add_generation_prompt Whether to append generation prompt at end
+ * @param formattedText Buffer to store formatted text (owned by the library)
+ * @return ErrorCode
+ */
+WIN_EXPORT ErrorCode applyChatTemplate(const CausalLMChatMessage *messages,
+                                       size_t num_messages,
+                                       bool add_generation_prompt,
+                                       const char **formattedText);
 
 #ifdef __cplusplus
 }

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -75,6 +75,8 @@ typedef struct {
   bool use_chat_template; /// < @brief Whether to apply chat template to input
   bool debug_mode; /// < @brief Check model file validity during initialization
   bool verbose;    /// < @brief Whether to print output during generation
+  const char *chat_template_name; /// < @brief Template name to select from array
+                                  ///  (e.g., "default", "tool_use"). NULL for "default".
 } Config;
 
 /**

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -70,6 +70,16 @@ typedef enum {
 
 /**
  * @brief Configuration structure
+ *
+ * @warning Callers MUST value-initialize this struct before populating it
+ *          (e.g. `Config config = {};` in C++ or `Config config = {0};` in
+ *          C). The struct contains pointer fields whose indeterminate value
+ *          would otherwise be dereferenced by setOptions(); leaving any
+ *          field uninitialized is undefined behavior. This is especially
+ *          important for callers compiled before a new field was added -
+ *          value-initialization gives newly introduced pointer fields a
+ *          defined NULL default that setOptions() interprets as "use the
+ *          built-in default".
  */
 typedef struct {
   // Add configuration options here as needed

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -65,6 +65,7 @@ typedef enum {
  */
 typedef enum {
   CAUSAL_LM_MODEL_QWEN3_0_6B = 0,
+  CAUSAL_LM_MODEL_QWEN3_1_7B = 1,
 } ModelType;
 
 /**

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -135,6 +135,20 @@ WIN_EXPORT ErrorCode runModel(const char *inputTextPrompt,
                               const char **outputText);
 
 /**
+ * @brief Reset multi-turn conversation state.
+ *
+ * After this call, the next runModel() invocation starts a fresh
+ * conversation on the same loaded model: the KV-cache write position is
+ * rewound, accumulated token count is zeroed, and any pending decoder
+ * tokens from a prior turn are dropped. The loaded model weights and
+ * tokenizer are NOT touched.
+ *
+ * @return CAUSAL_LM_ERROR_NONE on success,
+ *         CAUSAL_LM_ERROR_NOT_INITIALIZED if no model is loaded.
+ */
+WIN_EXPORT ErrorCode resetConversation(void);
+
+/**
  * @brief Run inference with chat template formatted messages
  * @param messages Array of chat messages with role and content
  * @param num_messages Number of messages in the array

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -514,7 +514,9 @@ int main(int argc, char *argv[]) {
 
   printSection("Initialization");
   std::cout << COLOR_CYAN << "⏳ " << COLOR_RESET << "Configuring options...\n";
-  Config config;
+  // Value-initialize so any field not explicitly assigned (now or after a
+  // future Config extension) is zero / NULL rather than indeterminate.
+  Config config = {};
   config.use_chat_template = use_chat_template;
   config.debug_mode = true;
   config.verbose = verbose;

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -13,6 +13,8 @@
 
 #include "../json.hpp"
 #include "causal_lm_api.h"
+#include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstring>
 #include <fstream>
@@ -92,7 +94,7 @@ void printUsage(const char *program_name) {
   std::cout << COLOR_YELLOW << "Usage:" << COLOR_RESET << "\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " <model_name> [prompt] [use_chat_template] [quantization] "
-               "[verbose] \n";
+               "[verbose] [--verify-memory|--multi-turn]\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " <model_name> --chat-file <path.json> [quantization] "
                "[verbose] \n\n";
@@ -114,9 +116,23 @@ void printUsage(const char *program_name) {
   std::cout << "  verbose           " << COLOR_GREEN << "OPTIONAL"
             << COLOR_RESET << "  - 0/1 or true/false (default: 0)\n\n";
 
+  std::cout << COLOR_CYAN << "Modes:" << COLOR_RESET << "\n";
+  std::cout << "  --verify-memory   " << COLOR_GREEN << "OPTIONAL"
+            << COLOR_RESET
+            << "  - Scripted 2-turn regression test, then reset+recheck\n";
+  std::cout << "  --multi-turn      " << COLOR_GREEN << "OPTIONAL"
+            << COLOR_RESET
+            << "  - Interactive REPL (/reset, /quit supported)\n\n";
+
   std::cout << COLOR_YELLOW << "Examples:" << COLOR_RESET << "\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " QWEN3-0.6B \"Tell me a joke\" 1 W4A32\n";
+  std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
+            << " QWEN3-0.6B \"Write a poem\" 1 W32A32 1\n";
+  std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
+            << " QWEN3-0.6B \"\" 1 W4A32 0 --verify-memory\n";
+  std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
+            << " QWEN3-0.6B \"\" 1 W4A32 0 --multi-turn\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " QWEN3-0.6B --chat-file chat.json W32A32 1\n\n";
 
@@ -130,10 +146,290 @@ void printUsage(const char *program_name) {
   std::cout << "    {\"role\": \"user\",      \"content\": \"How are you?\"}\n";
   std::cout << "  ]\n\n";
 }
+
+/**
+ * @brief Run a single inference turn and (optionally) print metrics.
+ * @param prompt        Input user prompt for this turn.
+ * @param verbose       Whether to stream tokens (matches global verbose flag).
+ * @param show_metrics  Whether to dump performance metrics for this turn.
+ * @param[out] out_text If non-null, receives the generated assistant text.
+ * @return ErrorCode from runModel().
+ */
+ErrorCode run_turn(const char *prompt, bool verbose, bool show_metrics,
+                   std::string *out_text = nullptr) {
+  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
+  std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
+            << "\n\n";
+
+  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET << "Running inference...\n\n";
+
+  const char *outputText = nullptr;
+
+  if (verbose) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GRAY;
+  }
+
+  ErrorCode err = runModel(prompt, &outputText);
+
+  if (verbose) {
+    std::cout << COLOR_RESET << "\n\n";
+  }
+
+  if (err != CAUSAL_LM_ERROR_NONE) {
+    printError("Failed to run model");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+    return err;
+  }
+
+  if (outputText) {
+    if (out_text)
+      *out_text = outputText;
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
+    std::string out(outputText);
+    size_t pos = 0;
+    while (pos < out.length()) {
+      size_t newlinePos = out.find('\n', pos);
+      if (newlinePos == std::string::npos) {
+        newlinePos = out.length();
+      }
+      std::string line = out.substr(pos, newlinePos - pos);
+      std::cout << line;
+      if (newlinePos < out.length()) {
+        std::cout << "\n  ";
+        pos = newlinePos + 1;
+      } else {
+        pos = out.length();
+      }
+    }
+    std::cout << COLOR_RESET << "\n\n";
+  } else {
+    printWarning("No output generated");
+  }
+
+  if (!show_metrics)
+    return err;
+
+  PerformanceMetrics metrics;
+  ErrorCode merr = getPerformanceMetrics(&metrics);
+  if (merr != CAUSAL_LM_ERROR_NONE) {
+    printWarning("Failed to get metrics");
+    std::cout << "  Error code: " << static_cast<int>(merr) << "\n";
+    return err;
+  }
+
+  double prefill_tps =
+    metrics.prefill_duration_ms > 0
+      ? (metrics.prefill_tokens / metrics.prefill_duration_ms * 1000.0)
+      : 0.0;
+  double gen_tps =
+    metrics.generation_duration_ms > 0
+      ? (metrics.generation_tokens / metrics.generation_duration_ms * 1000.0)
+      : 0.0;
+
+  std::cout << COLOR_CYAN << "  📊 " << COLOR_RESET << COLOR_BOLD
+            << "Prefill" << COLOR_RESET << "  tokens="
+            << metrics.prefill_tokens << "  "
+            << std::fixed << std::setprecision(2)
+            << metrics.prefill_duration_ms << " ms  "
+            << COLOR_GREEN << std::setprecision(1) << prefill_tps
+            << COLOR_RESET << " tok/s\n";
+  std::cout << COLOR_CYAN << "  📊 " << COLOR_RESET << COLOR_BOLD
+            << "Generation" << COLOR_RESET << " tokens="
+            << metrics.generation_tokens << "  "
+            << std::fixed << std::setprecision(2)
+            << metrics.generation_duration_ms << " ms  "
+            << COLOR_GREEN << std::setprecision(1) << gen_tps
+            << COLOR_RESET << " tok/s\n\n";
+
+  return err;
+}
+
+/**
+ * @brief Lower-case a string in-place.
+ */
+std::string to_lower(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return s;
+}
+
+/**
+ * @brief Trim ASCII whitespace from both ends.
+ */
+std::string trim(const std::string &s) {
+  size_t b = 0, e = s.size();
+  while (b < e && std::isspace(static_cast<unsigned char>(s[b])))
+    ++b;
+  while (e > b && std::isspace(static_cast<unsigned char>(s[e - 1])))
+    --e;
+  return s.substr(b, e - b);
+}
+
+/**
+ * @brief Scripted multi-turn regression: ensure the model remembers
+ *        a name across turns, and forgets it after resetConversation().
+ * @return 0 on success, non-zero on assertion failure.
+ */
+int run_verify_memory(bool verbose) {
+  printSection("Verify Memory: Multi-Turn Regression");
+
+  const char *turn1 = "My name is Alice. Please remember my name.";
+  const char *turn2 = "What is my name?";
+
+  std::cout << COLOR_BOLD << "Turn 1 (set context)" << COLOR_RESET << "\n";
+  std::string out1;
+  if (run_turn(turn1, verbose, true, &out1) != CAUSAL_LM_ERROR_NONE) {
+    printError("Turn 1 failed");
+    return 1;
+  }
+
+  std::cout << COLOR_BOLD << "Turn 2 (recall)" << COLOR_RESET << "\n";
+  std::string out2;
+  if (run_turn(turn2, verbose, true, &out2) != CAUSAL_LM_ERROR_NONE) {
+    printError("Turn 2 failed");
+    return 1;
+  }
+
+  bool remembered = to_lower(out2).find("alice") != std::string::npos;
+  if (!remembered) {
+    printError("Turn 2 output did not contain 'Alice' — multi-turn context "
+               "was NOT preserved.");
+    return 2;
+  }
+  printSuccess("Turn 2 recalled 'Alice' — multi-turn context preserved.");
+
+  std::cout << COLOR_BOLD << "Calling resetConversation()..." << COLOR_RESET
+            << "\n";
+  ErrorCode rerr = resetConversation();
+  if (rerr != CAUSAL_LM_ERROR_NONE) {
+    printError("resetConversation() failed");
+    std::cerr << "  Error code: " << static_cast<int>(rerr) << "\n";
+    return 3;
+  }
+  printSuccess("Conversation state reset.");
+
+  std::cout << COLOR_BOLD << "Turn 3 (post-reset recall, should NOT know)"
+            << COLOR_RESET << "\n";
+  std::string out3;
+  if (run_turn(turn2, verbose, true, &out3) != CAUSAL_LM_ERROR_NONE) {
+    printError("Turn 3 failed");
+    return 4;
+  }
+
+  // Accept any output that does NOT strongly assert the name is Alice.
+  // Small models may still emit the token "alice" while hedging (e.g.
+  // "I'm not sure — could it be Alice?"). We only flag a true leak:
+  // a confident affirmative statement such as "your name is alice" or
+  // "you are alice".
+  const std::string out3_lc = to_lower(out3);
+  const char *leak_patterns[] = {
+    "your name is alice",
+    "you are alice",
+    "you're alice",
+    "name is alice",
+    "you said your name is alice",
+  };
+  bool leaked = false;
+  for (const char *p : leak_patterns) {
+    if (out3_lc.find(p) != std::string::npos) {
+      leaked = true;
+      break;
+    }
+  }
+  if (leaked) {
+    printError("Turn 3 affirmatively stated the name is Alice AFTER reset — "
+               "resetConversation() did not clear context.");
+    return 5;
+  }
+  if (out3_lc.find("alice") != std::string::npos) {
+    printWarning("Turn 3 mentions 'alice' but does not affirmatively claim "
+                 "the name — accepted as hedged response.");
+  }
+  printSuccess("Turn 3 did not assert 'Alice' — reset cleared context.");
+
+  printLine("═", 63);
+  std::cout << COLOR_BOLD << COLOR_GREEN
+            << "  ✓ verify-memory PASSED" << COLOR_RESET << "\n";
+  printLine("═", 63);
+  std::cout << "\n";
+  return 0;
+}
+
+/**
+ * @brief Interactive multi-turn REPL.
+ *        Commands: /reset (clear context), /quit (exit), EOF -> exit.
+ */
+int run_multi_turn_repl(bool verbose) {
+  printSection("Multi-Turn REPL");
+  std::cout << "Commands: " << COLOR_BOLD << "/reset" << COLOR_RESET
+            << " clears context, " << COLOR_BOLD << "/quit" << COLOR_RESET
+            << " (or EOF) exits.\n\n";
+
+  while (true) {
+    std::cout << COLOR_BOLD << COLOR_CYAN << "you> " << COLOR_RESET
+              << std::flush;
+    std::string line;
+    if (!std::getline(std::cin, line)) {
+      std::cout << "\n[EOF] exiting.\n";
+      return 0;
+    }
+    std::string cmd = trim(line);
+    if (cmd.empty())
+      continue;
+    if (cmd == "/quit" || cmd == "/exit") {
+      std::cout << "Bye.\n";
+      return 0;
+    }
+    if (cmd == "/reset") {
+      ErrorCode rerr = resetConversation();
+      if (rerr != CAUSAL_LM_ERROR_NONE) {
+        printError("resetConversation() failed");
+        std::cerr << "  Error code: " << static_cast<int>(rerr) << "\n";
+      } else {
+        printSuccess("Conversation state reset.");
+      }
+      continue;
+    }
+    std::string out;
+    ErrorCode err = run_turn(cmd.c_str(), verbose, true, &out);
+    if (err != CAUSAL_LM_ERROR_NONE) {
+      printError("Turn failed; you may want to /reset.");
+    }
+  }
+  return 0;
+}
 } // namespace
 
 int main(int argc, char *argv[]) {
   printLogo();
+
+  // Strip mode flags (--verify-memory / --multi-turn) out of argv before
+  // the existing positional-argument parser runs, so older invocations
+  // remain byte-identical.
+  bool mode_verify_memory = false;
+  bool mode_multi_turn = false;
+  std::vector<char *> filtered_argv;
+  filtered_argv.reserve(argc);
+  for (int i = 0; i < argc; ++i) {
+    std::string a = argv[i];
+    if (a == "--verify-memory") {
+      mode_verify_memory = true;
+      continue;
+    }
+    if (a == "--multi-turn") {
+      mode_multi_turn = true;
+      continue;
+    }
+    filtered_argv.push_back(argv[i]);
+  }
+  if (mode_verify_memory && mode_multi_turn) {
+    printError("--verify-memory and --multi-turn are mutually exclusive.");
+    return 1;
+  }
+  argc = static_cast<int>(filtered_argv.size());
+  argv = filtered_argv.data();
 
   if (argc < 2) {
     printSection("ERROR: Missing Required Arguments");
@@ -142,7 +438,9 @@ int main(int argc, char *argv[]) {
   }
 
   const char *model_name = argv[1];
-  const char *prompt = "Hello, how are you?";
+  const char *prompt = (argc >= 3 && argv[2][0] != '\0')
+                         ? argv[2]
+                         : "Hello, how are you?";
   bool use_chat_template = true;
   std::string chat_file_path = "";
   std::string quant_str = "UNKNOWN";
@@ -255,6 +553,18 @@ int main(int argc, char *argv[]) {
     return 1;
   }
   printSuccess("Model loaded successfully");
+
+  // Mode dispatch: --verify-memory and --multi-turn run on top of the
+  // already-loaded model and exit; otherwise fall back to the default
+  // test flow below (applyChatTemplate + runModel + runModelWithMessages).
+  if (mode_verify_memory) {
+    int rc = run_verify_memory(verbose);
+    return rc;
+  }
+  if (mode_multi_turn) {
+    return run_multi_turn_repl(verbose);
+  }
+
 
   // ── --chat-file mode: load messages from JSON file ──
   using json = nlohmann::json;

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -12,8 +12,10 @@
  */
 
 #include "causal_lm_api.h"
+#include "../json.hpp"
 #include <cmath>
 #include <cstring>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -90,6 +92,9 @@ void printUsage(const char *program_name) {
   std::cout << COLOR_YELLOW << "Usage:" << COLOR_RESET << "\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " <model_name> [prompt] [use_chat_template] [quantization] "
+               "[verbose] \n";
+  std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
+            << " <model_name> --chat-file <path.json> [quantization] "
                "[verbose] \n\n";
 
   std::cout << COLOR_CYAN << "Arguments:" << COLOR_RESET << "\n";
@@ -98,6 +103,9 @@ void printUsage(const char *program_name) {
   std::cout << "  prompt            " << COLOR_GREEN << "OPTIONAL"
             << COLOR_RESET
             << "  - Input prompt (default: 'Hello, how are you?')\n";
+  std::cout << "  --chat-file       " << COLOR_GREEN << "OPTIONAL"
+            << COLOR_RESET
+            << "  - JSON file with chat messages [{role, content}, ...]\n";
   std::cout << "  use_chat_template " << COLOR_GREEN << "OPTIONAL"
             << COLOR_RESET << "  - 0/1 or true/false (default: 1)\n";
   std::cout << "  quantization      " << COLOR_GREEN << "OPTIONAL"
@@ -110,7 +118,15 @@ void printUsage(const char *program_name) {
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " QWEN3-0.6B \"Tell me a joke\" 1 W4A32\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
-            << " QWEN3-0.6B \"Write a poem\" 1 W32A32 1\n\n";
+            << " QWEN3-0.6B --chat-file chat.json W32A32 1\n\n";
+
+  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET << "\n";
+  std::cout << "  [\n";
+  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful assistant.\"},\n";
+  std::cout << "    {\"role\": \"user\",      \"content\": \"Hello!\"},\n";
+  std::cout << "    {\"role\": \"assistant\", \"content\": \"Hi there!\"},\n";
+  std::cout << "    {\"role\": \"user\",      \"content\": \"How are you?\"}\n";
+  std::cout << "  ]\n\n";
 }
 } // namespace
 
@@ -124,30 +140,51 @@ int main(int argc, char *argv[]) {
   }
 
   const char *model_name = argv[1];
-  const char *prompt = (argc >= 3) ? argv[2] : "Hello, how are you?";
+  const char *prompt = "Hello, how are you?";
   bool use_chat_template = true;
-  if (argc >= 4) {
-    use_chat_template =
-      (std::string(argv[3]) == "1" || std::string(argv[3]) == "true");
-  }
-
+  std::string chat_file_path = "";
   std::string quant_str = "UNKNOWN";
   ModelQuantizationType quant_type = CAUSAL_LM_QUANTIZATION_UNKNOWN;
-  if (argc >= 5) {
-    quant_str = std::string(argv[4]);
-    if (quant_str == "W4A32")
-      quant_type = CAUSAL_LM_QUANTIZATION_W4A32;
-    else if (quant_str == "W16A16")
-      quant_type = CAUSAL_LM_QUANTIZATION_W16A16;
-    else if (quant_str == "W8A16")
-      quant_type = CAUSAL_LM_QUANTIZATION_W8A16;
-    else if (quant_str == "W32A32")
-      quant_type = CAUSAL_LM_QUANTIZATION_W32A32;
-  }
-
   bool verbose = true;
-  if (argc >= 6) {
-    verbose = (std::string(argv[5]) == "1" || std::string(argv[5]) == "true");
+
+  // Parse --chat-file mode: <model> --chat-file <path> [quant] [verbose]
+  if (argc >= 4 && std::string(argv[2]) == "--chat-file") {
+    chat_file_path = argv[3];
+    use_chat_template = true;
+    if (argc >= 5) {
+      quant_str = std::string(argv[4]);
+      if (quant_str == "W4A32")
+        quant_type = CAUSAL_LM_QUANTIZATION_W4A32;
+      else if (quant_str == "W16A16")
+        quant_type = CAUSAL_LM_QUANTIZATION_W16A16;
+      else if (quant_str == "W8A16")
+        quant_type = CAUSAL_LM_QUANTIZATION_W8A16;
+      else if (quant_str == "W32A32")
+        quant_type = CAUSAL_LM_QUANTIZATION_W32A32;
+    }
+    if (argc >= 6) {
+      verbose = (std::string(argv[5]) == "1" || std::string(argv[5]) == "true");
+    }
+  } else {
+    // Normal mode: <model> [prompt] [chat_template] [quant] [verbose]
+    if (argc >= 3)
+      prompt = argv[2];
+    if (argc >= 4)
+      use_chat_template =
+        (std::string(argv[3]) == "1" || std::string(argv[3]) == "true");
+    if (argc >= 5) {
+      quant_str = std::string(argv[4]);
+      if (quant_str == "W4A32")
+        quant_type = CAUSAL_LM_QUANTIZATION_W4A32;
+      else if (quant_str == "W16A16")
+        quant_type = CAUSAL_LM_QUANTIZATION_W16A16;
+      else if (quant_str == "W8A16")
+        quant_type = CAUSAL_LM_QUANTIZATION_W8A16;
+      else if (quant_str == "W32A32")
+        quant_type = CAUSAL_LM_QUANTIZATION_W32A32;
+    }
+    if (argc >= 6)
+      verbose = (std::string(argv[5]) == "1" || std::string(argv[5]) == "true");
   }
 
   printSection("Configuration");
@@ -155,6 +192,9 @@ int main(int argc, char *argv[]) {
   printInfo("Use Chat Template", use_chat_template ? "true" : "false");
   printInfo("Quantization", quant_str);
   printInfo("Verbose", verbose ? "true" : "false");
+  if (!chat_file_path.empty()) {
+    printInfo("Chat File", chat_file_path);
+  }
   std::cout << "\n";
 
   printSection("Initialization");
@@ -196,7 +236,130 @@ int main(int argc, char *argv[]) {
   }
   printSuccess("Model loaded successfully");
 
-  printSection("Inference");
+  // ── --chat-file mode: load messages from JSON file ──
+  using json = nlohmann::json;
+  std::vector<CausalLMChatMessage> file_msgs;
+  std::vector<std::string> role_strs, content_strs;
+
+  if (!chat_file_path.empty()) {
+    printSection("Test: Chat Template from File");
+    std::ifstream chat_file(chat_file_path);
+    if (!chat_file.is_open()) {
+      printError("Cannot open chat file: " + chat_file_path);
+      return 1;
+    }
+
+    json chat_json;
+    try {
+      chat_file >> chat_json;
+    } catch (const json::parse_error &e) {
+      printError("JSON parse error: " + std::string(e.what()));
+      return 1;
+    }
+
+    // Support both formats:
+    //   Array:  [{"role":"user","content":"Hi"}]
+    //   Object: {"chat": [{"role":"user","content":"Hi"}]}
+    json messages_json;
+    if (chat_json.is_array()) {
+      messages_json = chat_json;
+    } else if (chat_json.is_object() && chat_json.contains("chat") &&
+               chat_json["chat"].is_array()) {
+      messages_json = chat_json["chat"];
+    } else {
+      printError("Chat file must contain a JSON array or {\"chat\": [...]}");
+      return 1;
+    }
+
+    // Store strings to keep pointers valid
+    for (const auto &msg : messages_json) {
+      if (msg.contains("role") && msg.contains("content")) {
+        role_strs.push_back(msg["role"].get<std::string>());
+        content_strs.push_back(msg["content"].get<std::string>());
+      }
+    }
+    for (size_t i = 0; i < role_strs.size(); ++i) {
+      file_msgs.push_back({role_strs[i].c_str(), content_strs[i].c_str()});
+    }
+
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Messages from "
+              << chat_file_path << ":\n";
+    for (size_t i = 0; i < file_msgs.size(); ++i) {
+      std::cout << COLOR_YELLOW << "  [" << file_msgs[i].role << "] "
+                << COLOR_RESET << file_msgs[i].content << "\n";
+    }
+    std::cout << "\n";
+
+    // Test applyChatTemplate with file messages
+    const char *formattedText = nullptr;
+    err = applyChatTemplate(file_msgs.data(), file_msgs.size(), true,
+                            &formattedText);
+    if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
+      std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
+                << "\n\n";
+      printSuccess("applyChatTemplate works");
+    } else {
+      printError("applyChatTemplate failed");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+    }
+
+    // Test runModelWithMessages with file messages
+    printSection("Test: runModelWithMessages from File");
+    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+              << "Running inference with messages...\n\n";
+
+    const char *msgOutput = nullptr;
+    if (verbose) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GRAY;
+    }
+
+    err = runModelWithMessages(file_msgs.data(), file_msgs.size(), true,
+                               &msgOutput);
+
+    if (verbose) {
+      std::cout << COLOR_RESET << "\n\n";
+    }
+
+    if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+                << "\n\n";
+      printSuccess("runModelWithMessages works");
+    } else {
+      printError("runModelWithMessages failed");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+    }
+
+    // Skip to performance metrics
+    goto print_metrics;
+  }
+
+  // ── Test 1: applyChatTemplate (no inference, format only) ──
+  {
+  printSection("Test: applyChatTemplate");
+  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+            << "Testing chat template formatting (no inference)...\n\n";
+
+  CausalLMChatMessage tmpl_msgs[] = {
+    {"system", "You are a helpful AI assistant."},
+    {"user", prompt}};
+
+  const char *formattedText = nullptr;
+  err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
+  if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
+    std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
+              << "\n\n";
+    printSuccess("applyChatTemplate works");
+  } else {
+    printError("applyChatTemplate failed");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+  }
+
+  // ── Test 2: runModel (single prompt, existing API) ──
+  printSection("Test: runModel (single prompt)");
   std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
   std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
             << "\n\n";
@@ -246,6 +409,48 @@ int main(int argc, char *argv[]) {
     printWarning("No output generated");
   }
 
+  // ── Test 3: runModelWithMessages (chat template with messages) ──
+  printSection("Test: runModelWithMessages");
+  CausalLMChatMessage chat_msgs[] = {
+    {"system", "You are a helpful AI assistant."},
+    {"user", prompt}};
+
+  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+            << "Messages:\n";
+  for (size_t i = 0; i < 2; ++i) {
+    std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
+              << COLOR_RESET << chat_msgs[i].content << "\n";
+  }
+  std::cout << "\n";
+
+  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+            << "Running inference with messages...\n\n";
+
+  const char *msgOutput = nullptr;
+
+  if (verbose) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GRAY;
+  }
+
+  err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
+
+  if (verbose) {
+    std::cout << COLOR_RESET << "\n\n";
+  }
+
+  if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+              << "\n\n";
+    printSuccess("runModelWithMessages works");
+  } else {
+    printError("runModelWithMessages failed");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+  }
+  } // end of normal mode tests
+
+print_metrics:
   printSection("Performance Metrics");
   PerformanceMetrics metrics;
   err = getPerformanceMetrics(&metrics);

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -99,7 +99,7 @@ void printUsage(const char *program_name) {
 
   std::cout << COLOR_CYAN << "Arguments:" << COLOR_RESET << "\n";
   std::cout << "  model_name        " << COLOR_BOLD << "REQUIRED" << COLOR_RESET
-            << "  - Model name (e.g., QWEN3-0.6B)\n";
+            << "  - Model name (e.g., QWEN3-0.6B, QWEN3-1.7B)\n";
   std::cout << "  prompt            " << COLOR_GREEN << "OPTIONAL"
             << COLOR_RESET
             << "  - Input prompt (default: 'Hello, how are you?')\n";
@@ -239,6 +239,8 @@ int main(int argc, char *argv[]) {
   std::string model_name_str(model_name);
   if (model_name_str == "QWEN3-0.6B") {
     model_type = CAUSAL_LM_MODEL_QWEN3_0_6B;
+  } else if (model_name_str == "QWEN3-1.7B") {
+    model_type = CAUSAL_LM_MODEL_QWEN3_1_7B;
   } else {
     std::cout << COLOR_YELLOW << "⚠ Warning: Unknown model name '"
               << model_name_str << "'. Defaulting to QWEN3-0.6B." << COLOR_RESET

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -11,8 +11,8 @@
  *
  */
 
-#include "causal_lm_api.h"
 #include "../json.hpp"
+#include "causal_lm_api.h"
 #include <cmath>
 #include <cstring>
 #include <fstream>
@@ -120,9 +120,11 @@ void printUsage(const char *program_name) {
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " QWEN3-0.6B --chat-file chat.json W32A32 1\n\n";
 
-  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET << "\n";
+  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET
+            << "\n";
   std::cout << "  [\n";
-  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful assistant.\"},\n";
+  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful "
+               "assistant.\"},\n";
   std::cout << "    {\"role\": \"user\",      \"content\": \"Hello!\"},\n";
   std::cout << "    {\"role\": \"assistant\", \"content\": \"Hi there!\"},\n";
   std::cout << "    {\"role\": \"user\",      \"content\": \"How are you?\"}\n";
@@ -148,7 +150,8 @@ int main(int argc, char *argv[]) {
   bool verbose = true;
   std::string template_name = "default";
 
-  // Parse --chat-file mode: <model> --chat-file <path> [--template name] [quant]
+  // Parse --chat-file mode: <model> --chat-file <path> [--template name]
+  // [quant]
   //                          [verbose]
   if (argc >= 4 && std::string(argv[2]) == "--chat-file") {
     chat_file_path = argv[3];
@@ -175,8 +178,8 @@ int main(int argc, char *argv[]) {
     }
     next_arg++;
     if (next_arg < argc) {
-      verbose =
-        (std::string(argv[next_arg]) == "1" || std::string(argv[next_arg]) == "true");
+      verbose = (std::string(argv[next_arg]) == "1" ||
+                 std::string(argv[next_arg]) == "true");
     }
   } else {
     // Normal mode: <model> [prompt] [chat_template] [quant] [verbose]
@@ -353,116 +356,114 @@ int main(int argc, char *argv[]) {
 
   // ── Test 1: applyChatTemplate (no inference, format only) ──
   {
-  printSection("Test: applyChatTemplate");
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
-            << "Testing chat template formatting (no inference)...\n\n";
+    printSection("Test: applyChatTemplate");
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+              << "Testing chat template formatting (no inference)...\n\n";
 
-  CausalLMChatMessage tmpl_msgs[] = {
-    {"system", "You are a helpful AI assistant."},
-    {"user", prompt}};
+    CausalLMChatMessage tmpl_msgs[] = {
+      {"system", "You are a helpful AI assistant."}, {"user", prompt}};
 
-  const char *formattedText = nullptr;
-  err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
-  if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
-    std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
-              << "\n\n";
-    printSuccess("applyChatTemplate works");
-  } else {
-    printError("applyChatTemplate failed");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-  }
-
-  // ── Test 2: runModel (single prompt, existing API) ──
-  printSection("Test: runModel (single prompt)");
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
-  std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
-            << "\n\n";
-
-  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET << "Running inference...\n\n";
-
-  const char *outputText = nullptr;
-
-  if (verbose) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GRAY;
-  }
-
-  err = runModel(prompt, &outputText);
-
-  if (verbose) {
-    std::cout << COLOR_RESET << "\n\n";
-  }
-
-  if (err != CAUSAL_LM_ERROR_NONE) {
-    printError("Failed to run model");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-    return 1;
-  }
-
-  if (outputText) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
-    std::string out(outputText);
-    size_t pos = 0;
-    while (pos < out.length()) {
-      size_t newlinePos = out.find('\n', pos);
-      if (newlinePos == std::string::npos) {
-        newlinePos = out.length();
-      }
-      std::string line = out.substr(pos, newlinePos - pos);
-      std::cout << line;
-      if (newlinePos < out.length()) {
-        std::cout << "\n  ";
-        pos = newlinePos + 1;
-      } else {
-        pos = out.length();
-      }
+    const char *formattedText = nullptr;
+    err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
+    if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
+      std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
+                << "\n\n";
+      printSuccess("applyChatTemplate works");
+    } else {
+      printError("applyChatTemplate failed");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
     }
-    std::cout << COLOR_RESET << "\n\n";
-  } else {
-    printWarning("No output generated");
-  }
 
-  // ── Test 3: runModelWithMessages (chat template with messages) ──
-  printSection("Test: runModelWithMessages");
-  CausalLMChatMessage chat_msgs[] = {
-    {"system", "You are a helpful AI assistant."},
-    {"user", prompt}};
-
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
-            << "Messages:\n";
-  for (size_t i = 0; i < 2; ++i) {
-    std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
-              << COLOR_RESET << chat_msgs[i].content << "\n";
-  }
-  std::cout << "\n";
-
-  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
-            << "Running inference with messages...\n\n";
-
-  const char *msgOutput = nullptr;
-
-  if (verbose) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GRAY;
-  }
-
-  err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
-
-  if (verbose) {
-    std::cout << COLOR_RESET << "\n\n";
-  }
-
-  if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+    // ── Test 2: runModel (single prompt, existing API) ──
+    printSection("Test: runModel (single prompt)");
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
+    std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
               << "\n\n";
-    printSuccess("runModelWithMessages works");
-  } else {
-    printError("runModelWithMessages failed");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-  }
+
+    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+              << "Running inference...\n\n";
+
+    const char *outputText = nullptr;
+
+    if (verbose) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GRAY;
+    }
+
+    err = runModel(prompt, &outputText);
+
+    if (verbose) {
+      std::cout << COLOR_RESET << "\n\n";
+    }
+
+    if (err != CAUSAL_LM_ERROR_NONE) {
+      printError("Failed to run model");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+      return 1;
+    }
+
+    if (outputText) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
+      std::string out(outputText);
+      size_t pos = 0;
+      while (pos < out.length()) {
+        size_t newlinePos = out.find('\n', pos);
+        if (newlinePos == std::string::npos) {
+          newlinePos = out.length();
+        }
+        std::string line = out.substr(pos, newlinePos - pos);
+        std::cout << line;
+        if (newlinePos < out.length()) {
+          std::cout << "\n  ";
+          pos = newlinePos + 1;
+        } else {
+          pos = out.length();
+        }
+      }
+      std::cout << COLOR_RESET << "\n\n";
+    } else {
+      printWarning("No output generated");
+    }
+
+    // ── Test 3: runModelWithMessages (chat template with messages) ──
+    printSection("Test: runModelWithMessages");
+    CausalLMChatMessage chat_msgs[] = {
+      {"system", "You are a helpful AI assistant."}, {"user", prompt}};
+
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Messages:\n";
+    for (size_t i = 0; i < 2; ++i) {
+      std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
+                << COLOR_RESET << chat_msgs[i].content << "\n";
+    }
+    std::cout << "\n";
+
+    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+              << "Running inference with messages...\n\n";
+
+    const char *msgOutput = nullptr;
+
+    if (verbose) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GRAY;
+    }
+
+    err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
+
+    if (verbose) {
+      std::cout << COLOR_RESET << "\n\n";
+    }
+
+    if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+                << "\n\n";
+      printSuccess("runModelWithMessages works");
+    } else {
+      printError("runModelWithMessages failed");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+    }
   } // end of normal mode tests
 
 print_metrics:

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -11,8 +11,8 @@
  *
  */
 
-#include "causal_lm_api.h"
 #include "../json.hpp"
+#include "causal_lm_api.h"
 #include <cmath>
 #include <cstring>
 #include <fstream>
@@ -120,9 +120,11 @@ void printUsage(const char *program_name) {
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " QWEN3-0.6B --chat-file chat.json W32A32 1\n\n";
 
-  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET << "\n";
+  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET
+            << "\n";
   std::cout << "  [\n";
-  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful assistant.\"},\n";
+  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful "
+               "assistant.\"},\n";
   std::cout << "    {\"role\": \"user\",      \"content\": \"Hello!\"},\n";
   std::cout << "    {\"role\": \"assistant\", \"content\": \"Hi there!\"},\n";
   std::cout << "    {\"role\": \"user\",      \"content\": \"How are you?\"}\n";
@@ -338,116 +340,114 @@ int main(int argc, char *argv[]) {
 
   // ── Test 1: applyChatTemplate (no inference, format only) ──
   {
-  printSection("Test: applyChatTemplate");
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
-            << "Testing chat template formatting (no inference)...\n\n";
+    printSection("Test: applyChatTemplate");
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+              << "Testing chat template formatting (no inference)...\n\n";
 
-  CausalLMChatMessage tmpl_msgs[] = {
-    {"system", "You are a helpful AI assistant."},
-    {"user", prompt}};
+    CausalLMChatMessage tmpl_msgs[] = {
+      {"system", "You are a helpful AI assistant."}, {"user", prompt}};
 
-  const char *formattedText = nullptr;
-  err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
-  if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
-    std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
-              << "\n\n";
-    printSuccess("applyChatTemplate works");
-  } else {
-    printError("applyChatTemplate failed");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-  }
-
-  // ── Test 2: runModel (single prompt, existing API) ──
-  printSection("Test: runModel (single prompt)");
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
-  std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
-            << "\n\n";
-
-  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET << "Running inference...\n\n";
-
-  const char *outputText = nullptr;
-
-  if (verbose) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GRAY;
-  }
-
-  err = runModel(prompt, &outputText);
-
-  if (verbose) {
-    std::cout << COLOR_RESET << "\n\n";
-  }
-
-  if (err != CAUSAL_LM_ERROR_NONE) {
-    printError("Failed to run model");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-    return 1;
-  }
-
-  if (outputText) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
-    std::string out(outputText);
-    size_t pos = 0;
-    while (pos < out.length()) {
-      size_t newlinePos = out.find('\n', pos);
-      if (newlinePos == std::string::npos) {
-        newlinePos = out.length();
-      }
-      std::string line = out.substr(pos, newlinePos - pos);
-      std::cout << line;
-      if (newlinePos < out.length()) {
-        std::cout << "\n  ";
-        pos = newlinePos + 1;
-      } else {
-        pos = out.length();
-      }
+    const char *formattedText = nullptr;
+    err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
+    if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
+      std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
+                << "\n\n";
+      printSuccess("applyChatTemplate works");
+    } else {
+      printError("applyChatTemplate failed");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
     }
-    std::cout << COLOR_RESET << "\n\n";
-  } else {
-    printWarning("No output generated");
-  }
 
-  // ── Test 3: runModelWithMessages (chat template with messages) ──
-  printSection("Test: runModelWithMessages");
-  CausalLMChatMessage chat_msgs[] = {
-    {"system", "You are a helpful AI assistant."},
-    {"user", prompt}};
-
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
-            << "Messages:\n";
-  for (size_t i = 0; i < 2; ++i) {
-    std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
-              << COLOR_RESET << chat_msgs[i].content << "\n";
-  }
-  std::cout << "\n";
-
-  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
-            << "Running inference with messages...\n\n";
-
-  const char *msgOutput = nullptr;
-
-  if (verbose) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GRAY;
-  }
-
-  err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
-
-  if (verbose) {
-    std::cout << COLOR_RESET << "\n\n";
-  }
-
-  if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+    // ── Test 2: runModel (single prompt, existing API) ──
+    printSection("Test: runModel (single prompt)");
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
+    std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
               << "\n\n";
-    printSuccess("runModelWithMessages works");
-  } else {
-    printError("runModelWithMessages failed");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-  }
+
+    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+              << "Running inference...\n\n";
+
+    const char *outputText = nullptr;
+
+    if (verbose) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GRAY;
+    }
+
+    err = runModel(prompt, &outputText);
+
+    if (verbose) {
+      std::cout << COLOR_RESET << "\n\n";
+    }
+
+    if (err != CAUSAL_LM_ERROR_NONE) {
+      printError("Failed to run model");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+      return 1;
+    }
+
+    if (outputText) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
+      std::string out(outputText);
+      size_t pos = 0;
+      while (pos < out.length()) {
+        size_t newlinePos = out.find('\n', pos);
+        if (newlinePos == std::string::npos) {
+          newlinePos = out.length();
+        }
+        std::string line = out.substr(pos, newlinePos - pos);
+        std::cout << line;
+        if (newlinePos < out.length()) {
+          std::cout << "\n  ";
+          pos = newlinePos + 1;
+        } else {
+          pos = out.length();
+        }
+      }
+      std::cout << COLOR_RESET << "\n\n";
+    } else {
+      printWarning("No output generated");
+    }
+
+    // ── Test 3: runModelWithMessages (chat template with messages) ──
+    printSection("Test: runModelWithMessages");
+    CausalLMChatMessage chat_msgs[] = {
+      {"system", "You are a helpful AI assistant."}, {"user", prompt}};
+
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Messages:\n";
+    for (size_t i = 0; i < 2; ++i) {
+      std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
+                << COLOR_RESET << chat_msgs[i].content << "\n";
+    }
+    std::cout << "\n";
+
+    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+              << "Running inference with messages...\n\n";
+
+    const char *msgOutput = nullptr;
+
+    if (verbose) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GRAY;
+    }
+
+    err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
+
+    if (verbose) {
+      std::cout << COLOR_RESET << "\n\n";
+    }
+
+    if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
+      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+      std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+                << "\n\n";
+      printSuccess("runModelWithMessages works");
+    } else {
+      printError("runModelWithMessages failed");
+      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+    }
   } // end of normal mode tests
 
 print_metrics:

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -11,8 +11,8 @@
  *
  */
 
-#include "../json.hpp"
 #include "causal_lm_api.h"
+#include "../json.hpp"
 #include <cmath>
 #include <cstring>
 #include <fstream>
@@ -120,11 +120,9 @@ void printUsage(const char *program_name) {
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
             << " QWEN3-0.6B --chat-file chat.json W32A32 1\n\n";
 
-  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET
-            << "\n";
+  std::cout << COLOR_YELLOW << "Chat file format (JSON):" << COLOR_RESET << "\n";
   std::cout << "  [\n";
-  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful "
-               "assistant.\"},\n";
+  std::cout << "    {\"role\": \"system\",    \"content\": \"You are a helpful assistant.\"},\n";
   std::cout << "    {\"role\": \"user\",      \"content\": \"Hello!\"},\n";
   std::cout << "    {\"role\": \"assistant\", \"content\": \"Hi there!\"},\n";
   std::cout << "    {\"role\": \"user\",      \"content\": \"How are you?\"}\n";
@@ -148,13 +146,24 @@ int main(int argc, char *argv[]) {
   std::string quant_str = "UNKNOWN";
   ModelQuantizationType quant_type = CAUSAL_LM_QUANTIZATION_UNKNOWN;
   bool verbose = true;
+  std::string template_name = "default";
 
-  // Parse --chat-file mode: <model> --chat-file <path> [quant] [verbose]
+  // Parse --chat-file mode: <model> --chat-file <path> [--template name] [quant]
+  //                          [verbose]
   if (argc >= 4 && std::string(argv[2]) == "--chat-file") {
     chat_file_path = argv[3];
     use_chat_template = true;
-    if (argc >= 5) {
-      quant_str = std::string(argv[4]);
+    int next_arg = 4;
+    // Check for --template option
+    if (next_arg < argc && std::string(argv[next_arg]) == "--template") {
+      next_arg++;
+      if (next_arg < argc) {
+        template_name = argv[next_arg];
+        next_arg++;
+      }
+    }
+    if (next_arg < argc) {
+      quant_str = std::string(argv[next_arg]);
       if (quant_str == "W4A32")
         quant_type = CAUSAL_LM_QUANTIZATION_W4A32;
       else if (quant_str == "W16A16")
@@ -164,8 +173,10 @@ int main(int argc, char *argv[]) {
       else if (quant_str == "W32A32")
         quant_type = CAUSAL_LM_QUANTIZATION_W32A32;
     }
-    if (argc >= 6) {
-      verbose = (std::string(argv[5]) == "1" || std::string(argv[5]) == "true");
+    next_arg++;
+    if (next_arg < argc) {
+      verbose =
+        (std::string(argv[next_arg]) == "1" || std::string(argv[next_arg]) == "true");
     }
   } else {
     // Normal mode: <model> [prompt] [chat_template] [quant] [verbose]
@@ -194,6 +205,7 @@ int main(int argc, char *argv[]) {
   printInfo("Use Chat Template", use_chat_template ? "true" : "false");
   printInfo("Quantization", quant_str);
   printInfo("Verbose", verbose ? "true" : "false");
+  printInfo("Template Name", template_name);
   if (!chat_file_path.empty()) {
     printInfo("Chat File", chat_file_path);
   }
@@ -205,6 +217,7 @@ int main(int argc, char *argv[]) {
   config.use_chat_template = use_chat_template;
   config.debug_mode = true;
   config.verbose = verbose;
+  config.chat_template_name = template_name.c_str();
   ErrorCode err = setOptions(config);
   if (err != CAUSAL_LM_ERROR_NONE) {
     printError("Failed to set options");
@@ -340,114 +353,116 @@ int main(int argc, char *argv[]) {
 
   // ── Test 1: applyChatTemplate (no inference, format only) ──
   {
-    printSection("Test: applyChatTemplate");
-    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
-              << "Testing chat template formatting (no inference)...\n\n";
+  printSection("Test: applyChatTemplate");
+  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+            << "Testing chat template formatting (no inference)...\n\n";
 
-    CausalLMChatMessage tmpl_msgs[] = {
-      {"system", "You are a helpful AI assistant."}, {"user", prompt}};
+  CausalLMChatMessage tmpl_msgs[] = {
+    {"system", "You are a helpful AI assistant."},
+    {"user", prompt}};
 
-    const char *formattedText = nullptr;
-    err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
-    if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
-      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
-      std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
-                << "\n\n";
-      printSuccess("applyChatTemplate works");
-    } else {
-      printError("applyChatTemplate failed");
-      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-    }
-
-    // ── Test 2: runModel (single prompt, existing API) ──
-    printSection("Test: runModel (single prompt)");
-    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
-    std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
+  const char *formattedText = nullptr;
+  err = applyChatTemplate(tmpl_msgs, 2, true, &formattedText);
+  if (err == CAUSAL_LM_ERROR_NONE && formattedText) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Formatted prompt:\n";
+    std::cout << COLOR_BOLD << COLOR_YELLOW << formattedText << COLOR_RESET
               << "\n\n";
+    printSuccess("applyChatTemplate works");
+  } else {
+    printError("applyChatTemplate failed");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+  }
 
-    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
-              << "Running inference...\n\n";
+  // ── Test 2: runModel (single prompt, existing API) ──
+  printSection("Test: runModel (single prompt)");
+  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
+  std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
+            << "\n\n";
 
-    const char *outputText = nullptr;
+  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET << "Running inference...\n\n";
 
-    if (verbose) {
-      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-      std::cout << COLOR_BOLD << COLOR_GRAY;
-    }
+  const char *outputText = nullptr;
 
-    err = runModel(prompt, &outputText);
+  if (verbose) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GRAY;
+  }
 
-    if (verbose) {
-      std::cout << COLOR_RESET << "\n\n";
-    }
+  err = runModel(prompt, &outputText);
 
-    if (err != CAUSAL_LM_ERROR_NONE) {
-      printError("Failed to run model");
-      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-      return 1;
-    }
+  if (verbose) {
+    std::cout << COLOR_RESET << "\n\n";
+  }
 
-    if (outputText) {
-      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-      std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
-      std::string out(outputText);
-      size_t pos = 0;
-      while (pos < out.length()) {
-        size_t newlinePos = out.find('\n', pos);
-        if (newlinePos == std::string::npos) {
-          newlinePos = out.length();
-        }
-        std::string line = out.substr(pos, newlinePos - pos);
-        std::cout << line;
-        if (newlinePos < out.length()) {
-          std::cout << "\n  ";
-          pos = newlinePos + 1;
-        } else {
-          pos = out.length();
-        }
+  if (err != CAUSAL_LM_ERROR_NONE) {
+    printError("Failed to run model");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+    return 1;
+  }
+
+  if (outputText) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
+    std::string out(outputText);
+    size_t pos = 0;
+    while (pos < out.length()) {
+      size_t newlinePos = out.find('\n', pos);
+      if (newlinePos == std::string::npos) {
+        newlinePos = out.length();
       }
-      std::cout << COLOR_RESET << "\n\n";
-    } else {
-      printWarning("No output generated");
+      std::string line = out.substr(pos, newlinePos - pos);
+      std::cout << line;
+      if (newlinePos < out.length()) {
+        std::cout << "\n  ";
+        pos = newlinePos + 1;
+      } else {
+        pos = out.length();
+      }
     }
+    std::cout << COLOR_RESET << "\n\n";
+  } else {
+    printWarning("No output generated");
+  }
 
-    // ── Test 3: runModelWithMessages (chat template with messages) ──
-    printSection("Test: runModelWithMessages");
-    CausalLMChatMessage chat_msgs[] = {
-      {"system", "You are a helpful AI assistant."}, {"user", prompt}};
+  // ── Test 3: runModelWithMessages (chat template with messages) ──
+  printSection("Test: runModelWithMessages");
+  CausalLMChatMessage chat_msgs[] = {
+    {"system", "You are a helpful AI assistant."},
+    {"user", prompt}};
 
-    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Messages:\n";
-    for (size_t i = 0; i < 2; ++i) {
-      std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
-                << COLOR_RESET << chat_msgs[i].content << "\n";
-    }
-    std::cout << "\n";
+  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+            << "Messages:\n";
+  for (size_t i = 0; i < 2; ++i) {
+    std::cout << COLOR_YELLOW << "  [" << chat_msgs[i].role << "] "
+              << COLOR_RESET << chat_msgs[i].content << "\n";
+  }
+  std::cout << "\n";
 
-    std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
-              << "Running inference with messages...\n\n";
+  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET
+            << "Running inference with messages...\n\n";
 
-    const char *msgOutput = nullptr;
+  const char *msgOutput = nullptr;
 
-    if (verbose) {
-      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-      std::cout << COLOR_BOLD << COLOR_GRAY;
-    }
+  if (verbose) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GRAY;
+  }
 
-    err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
+  err = runModelWithMessages(chat_msgs, 2, true, &msgOutput);
 
-    if (verbose) {
-      std::cout << COLOR_RESET << "\n\n";
-    }
+  if (verbose) {
+    std::cout << COLOR_RESET << "\n\n";
+  }
 
-    if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
-      std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-      std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
-                << "\n\n";
-      printSuccess("runModelWithMessages works");
-    } else {
-      printError("runModelWithMessages failed");
-      std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-    }
+  if (err == CAUSAL_LM_ERROR_NONE && msgOutput) {
+    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
+    std::cout << COLOR_BOLD << COLOR_GREEN << "  " << msgOutput << COLOR_RESET
+              << "\n\n";
+    printSuccess("runModelWithMessages works");
+  } else {
+    printError("runModelWithMessages failed");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+  }
   } // end of normal mode tests
 
 print_metrics:

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -228,20 +228,16 @@ ErrorCode run_turn(const char *prompt, bool verbose, bool show_metrics,
       ? (metrics.generation_tokens / metrics.generation_duration_ms * 1000.0)
       : 0.0;
 
-  std::cout << COLOR_CYAN << "  📊 " << COLOR_RESET << COLOR_BOLD
-            << "Prefill" << COLOR_RESET << "  tokens="
-            << metrics.prefill_tokens << "  "
-            << std::fixed << std::setprecision(2)
-            << metrics.prefill_duration_ms << " ms  "
-            << COLOR_GREEN << std::setprecision(1) << prefill_tps
+  std::cout << COLOR_CYAN << "  📊 " << COLOR_RESET << COLOR_BOLD << "Prefill"
+            << COLOR_RESET << "  tokens=" << metrics.prefill_tokens << "  "
+            << std::fixed << std::setprecision(2) << metrics.prefill_duration_ms
+            << " ms  " << COLOR_GREEN << std::setprecision(1) << prefill_tps
             << COLOR_RESET << " tok/s\n";
-  std::cout << COLOR_CYAN << "  📊 " << COLOR_RESET << COLOR_BOLD
-            << "Generation" << COLOR_RESET << " tokens="
-            << metrics.generation_tokens << "  "
+  std::cout << COLOR_CYAN << "  📊 " << COLOR_RESET << COLOR_BOLD << "Generation"
+            << COLOR_RESET << " tokens=" << metrics.generation_tokens << "  "
             << std::fixed << std::setprecision(2)
-            << metrics.generation_duration_ms << " ms  "
-            << COLOR_GREEN << std::setprecision(1) << gen_tps
-            << COLOR_RESET << " tok/s\n\n";
+            << metrics.generation_duration_ms << " ms  " << COLOR_GREEN
+            << std::setprecision(1) << gen_tps << COLOR_RESET << " tok/s\n\n";
 
   return err;
 }
@@ -350,8 +346,8 @@ int run_verify_memory(bool verbose) {
   printSuccess("Turn 3 did not assert 'Alice' — reset cleared context.");
 
   printLine("═", 63);
-  std::cout << COLOR_BOLD << COLOR_GREEN
-            << "  ✓ verify-memory PASSED" << COLOR_RESET << "\n";
+  std::cout << COLOR_BOLD << COLOR_GREEN << "  ✓ verify-memory PASSED"
+            << COLOR_RESET << "\n";
   printLine("═", 63);
   std::cout << "\n";
   return 0;
@@ -438,9 +434,8 @@ int main(int argc, char *argv[]) {
   }
 
   const char *model_name = argv[1];
-  const char *prompt = (argc >= 3 && argv[2][0] != '\0')
-                         ? argv[2]
-                         : "Hello, how are you?";
+  const char *prompt =
+    (argc >= 3 && argv[2][0] != '\0') ? argv[2] : "Hello, how are you?";
   bool use_chat_template = true;
   std::string chat_file_path = "";
   std::string quant_str = "UNKNOWN";
@@ -566,7 +561,6 @@ int main(int argc, char *argv[]) {
   if (mode_multi_turn) {
     return run_multi_turn_repl(verbose);
   }
-
 
   // ── --chat-file mode: load messages from JSON file ──
   using json = nlohmann::json;

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -255,6 +255,29 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
 
 /************************************************************** */
 
+void MHACoreLayer::resetCache(nntrainer::RunLayerContext &context) {
+  cache_index = 0;
+  // Cache tensors are requested via requestTensor() during finalize but are
+  // not actually allocated until the first incremental_inference() call that
+  // triggers model_graph tensor allocation. resetConversation() may be
+  // invoked (by test harnesses, or by a user who resets before ever running
+  // a turn) before any inference has happened, in which case the cache
+  // tensors carry no backing memory yet and setZero() would crash. Zeroing
+  // is defense-in-depth anyway (cache_index=0 alone is sufficient because
+  // the attention read range is bounded by cache_index + step_size), so skip
+  // it when the tensor is not yet allocated.
+  nntrainer::Tensor &cache_key =
+    context.getTensor(tensor_idx[AttentionParams::cache_key]);
+  nntrainer::Tensor &cache_value =
+    context.getTensor(tensor_idx[AttentionParams::cache_value]);
+  if (cache_key.isAllocated())
+    cache_key.setZero();
+  if (cache_value.isAllocated())
+    cache_value.setZero();
+}
+
+/************************************************************** */
+
 /**
  * @note In external KV cache mode (use_external_cache == true), this
  *       implements the inference forward pass using cache tensors supplied

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -309,6 +309,26 @@ public:
    */
   WIN_EXPORT unsigned int getCacheIndex() const { return cache_index; }
 
+  /**
+   * @brief Reset KV cache write position to 0.
+   * @note  Rewinds the write pointer only. The cache tensor data is left
+   *        in place; subsequent incremental forwards overwrite the range
+   *        that is read during attention.
+   */
+  WIN_EXPORT void resetCache() { cache_index = 0; }
+
+  /**
+   * @brief Reset KV cache write position to 0 and zero the cache tensors.
+   * @param context Run-time layer context holding the cache tensors.
+   * @note  Defense-in-depth variant used when starting a fresh multi-turn
+   *        conversation. In addition to rewinding the write pointer, the
+   *        underlying cache_key / cache_value tensors are zero-filled so
+   *        that any stale KV entries from the previous conversation can
+   *        never be read, even if a future code path were to read beyond
+   *        the freshly-written range.
+   */
+  WIN_EXPORT void resetCache(nntrainer::RunLayerContext &context);
+
   inline static const std::string type = "mha_core";
 
 private:

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -34,6 +34,7 @@
 
 #include <common.h>
 #include <layer_context.h>
+#include <layer_node.h>
 #include <lm_head.h>
 #include <mha_core.h>
 #include <nntrainer_error.h>
@@ -242,6 +243,42 @@ void CausalLM::registerOutputs(
       }
     }
   }
+}
+
+void CausalLM::resetConversation() {
+  global_token_len = 0;
+  SYS_PROMP_LEN = 0;
+  pending_ids_.clear();
+  output_list.clear();
+  has_run_ = false;
+
+  if (!model)
+    return;
+
+  // Reset cache_index in every MHACoreLayer and zero the underlying
+  // cache_key / cache_value tensors so no stale KV entries from the
+  // previous conversation can influence the next run.
+  //
+  // NeuralNetwork::forEachLayer hands us a reference to the LayerNode (which
+  // inherits from ml::train::Layer), not the concrete layer implementation.
+  // A direct dynamic_cast from ml::train::Layer& to MHACoreLayer* therefore
+  // always fails silently, which was the real root cause of cache_index
+  // leaking across turns (observed as cache_index(277) != _from(0) after a
+  // resetConversation()). Go through LayerNode::getLayer() to reach the
+  // wrapped implementation.
+  std::function<void(ml::train::Layer &, nntrainer::RunLayerContext &, void *)>
+    fn = [](ml::train::Layer &l, nntrainer::RunLayerContext &context,
+            void * /*user_data*/) {
+      if (l.getType() != causallm::MHACoreLayer::type)
+        return;
+      auto *node = dynamic_cast<nntrainer::LayerNode *>(&l);
+      if (!node)
+        return;
+      auto *mha = dynamic_cast<causallm::MHACoreLayer *>(node->getLayer());
+      if (mha)
+        mha->resetCache(context);
+    };
+  model->forEachLayer(fn, nullptr);
 }
 
 void CausalLM::save_kvcache(std::string path, int to_) {

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -610,10 +610,9 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
        ++token_generation_idx) {
 
     allocateAndBindKVCache();
-    auto output_interval =
-      model->incremental_inference(BATCH_SIZE, input, label, input_len,
-                                   token_generation_idx - 1,
-                                   token_generation_idx);
+    auto output_interval = model->incremental_inference(
+      BATCH_SIZE, input, label, input_len, token_generation_idx - 1,
+      token_generation_idx);
     std::vector<unsigned int> ids_list(generate(output_interval[0], do_sample));
 
     // Feed the newly generated token back as the next input token.

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -347,6 +347,11 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   has_run_ = false;
 
+  // Multi-turn safety: drop any decoder state left over from a previous run.
+  // If a prior turn ended mid-punctuation or mid-UTF-8 token, pending_ids_
+  // would leak into this turn's decoding and corrupt output.
+  pending_ids_.clear();
+
   output_list.clear();
   for (unsigned int b = 0; b < BATCH_SIZE; ++b) {
     output_list.push_back("");
@@ -517,6 +522,17 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   allocateAndBindKVCache();
   const unsigned int prefill_from = SYS_PROMP_LEN + global_token_len;
   const unsigned int prefill_to = prefill_from + input_len;
+
+  if (prefill_from + init_len + NUM_TO_GENERATE > MAX_SEQ_LEN) {
+    free(input_sample);
+    std::cerr << "[CausalLM] context overflow: base_pos=" << prefill_from
+              << " input=" << init_len << " gen=" << NUM_TO_GENERATE
+              << " max_seq_len=" << MAX_SEQ_LEN
+              << ". Call resetConversation() to start a new conversation."
+              << std::endl;
+    throw std::runtime_error("CausalLM context overflow");
+  }
+
   setKVCachePosition(prefill_from);
   output = model->incremental_inference(BATCH_SIZE, input, label, init_len,
                                         prefill_from, prefill_to, false);
@@ -541,7 +557,9 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
    * TOKEN GENERATION
    */
 
-  input_len += SYS_PROMP_LEN;
+  // Shift input_len into absolute-position space so that token_generation_idx
+  // below indexes the cache in the same frame as the prefill call above.
+  input_len += prefill_from;
 
   // Update generated token by prefill as an input
   for (unsigned int b = 0; b < BATCH_SIZE; ++b)
@@ -557,8 +575,8 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     allocateAndBindKVCache();
     auto output_interval =
       model->incremental_inference(BATCH_SIZE, input, label, input_len,
-                                   token_generation_idx - 1 + global_token_len,
-                                   token_generation_idx + global_token_len);
+                                   token_generation_idx - 1,
+                                   token_generation_idx);
     std::vector<unsigned int> ids_list(generate(output_interval[0], do_sample));
 
     // Feed the newly generated token back as the next input token.

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -81,6 +81,24 @@ public:
    */
   std::string getOutput(int batch_idx = 0) const;
 
+
+  /**
+   * @brief get the status of run
+   */
+  bool hasRun() const { return has_run_; }
+
+  /**
+   * @brief Reset multi-turn conversation state so the next run() starts a
+   *        fresh conversation on the same loaded model.
+   * @note  Clears accumulated token count, pending decoder tokens, the
+   *        last-turn output buffer, and resets the KV-cache write position
+   *        (cache_index) on every MHACoreLayer. The KV-cache tensor data
+   *        itself is not zeroed; subsequent writes overwrite the positions
+   *        that are read.
+   */
+  void resetConversation();
+
+
 protected:
   /**
    * @brief Setup the parameters for the CausalLM model
@@ -147,6 +165,8 @@ protected:
   bool SAVE_KVCACHE;
   bool USE_KVCACHE;
   unsigned int global_token_len;
+
+  bool has_run_ = false; /**< True after at least one successful run() */
 
   std::mt19937 rng; /**< Random Number Gen */
 

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -81,7 +81,6 @@ public:
    */
   std::string getOutput(int batch_idx = 0) const;
 
-
   /**
    * @brief get the status of run
    */
@@ -97,7 +96,6 @@ public:
    *        that are read.
    */
   void resetConversation();
-
 
 protected:
   /**

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -1081,6 +1081,7 @@ properties in the context/graph unless intended. */
 
   std::array<TensorDim::DataType, 2> data_type;
 
+public:
   /**
    * @brief   Get the effective layer managed by this layer node
    *
@@ -1097,6 +1098,7 @@ properties in the context/graph unless intended. */
    */
   nntrainer::Layer *getLayer();
 
+private:
   /**
    * @brief anchor point to override if PRINT_SHAPE_INFO is enabled for
    * Layer::print()


### PR DESCRIPTION
## Dependency of the PR
#3867

## Commits to be reviewed in this PR

One can ignore commits from #3867.
Please only review the following commits.

<details><summary>[nntrainer] Expose LayerNode::getLayer() as public API</summary><br />

LayerNode wraps a concrete nntrainer::Layer and is the object handed to
NeuralNetwork::forEachLayer() callbacks (as ml::train::Layer&, via the
LayerNode's base-class inheritance). Reaching the wrapped implementation
from user code currently requires a second dynamic_cast that is silently
denied because getLayer() sits under a private access specifier.

This blocks a legitimate caller pattern: application-level code iterates
layers of a known type (e.g. MHACoreLayer) and needs to invoke methods
specific to that type. Promoting the two getLayer() accessors to public
enables that pattern without changing their behavior.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



<details><summary>[CausalLM] Add MHACoreLayer::resetCache() for multi-turn support</summary><br />

MHACoreLayer maintains cache_index as the absolute write position into
cache_key / cache_value. That index also drives RoPE position encoding
on the next incremental forward, so it must be rewound to 0 before a
new conversation begins — otherwise the second conversation starts
writing at the tail of the previous one and reads back stale KV.

Add two overloads:

  - resetCache()                        : cheap inline, cache_index = 0.
    Sufficient on its own, because the attention read range is bounded
    by cache_index + step_size so garbage past the new write head is
    never dereferenced.

  - resetCache(RunLayerContext &)        : defense-in-depth variant used
    by CausalLM::resetConversation(). Also zero-fills cache_key /
    cache_value so stale entries cannot influence the next turn even
    under future code paths that might read beyond the freshly-written
    range. Guarded by isAllocated() because the tensors carry no backing
    memory until the first incremental_inference() call allocates them.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

<details><summary>[CausalLM] Add MHACoreLayer::resetCache() for multi-turn support</summary><br />

MHACoreLayer maintains cache_index as the absolute write position into
cache_key / cache_value. That index also drives RoPE position encoding
on the next incremental forward, so it must be rewound to 0 before a
new conversation begins — otherwise the second conversation starts
writing at the tail of the previous one and reads back stale KV.

Add two overloads:

  - resetCache()                        : cheap inline, cache_index = 0.
    Sufficient on its own, because the attention read range is bounded
    by cache_index + step_size so garbage past the new write head is
    never dereferenced.

  - resetCache(RunLayerContext &)        : defense-in-depth variant used
    by CausalLM::resetConversation(). Also zero-fills cache_key /
    cache_value so stale entries cannot influence the next turn even
    under future code paths that might read beyond the freshly-written
    range. Guarded by isAllocated() because the tensors carry no backing
    memory until the first incremental_inference() call allocates them.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


<details><summary>[CausalLM] Fix position indexing in run() for multi-turn conversations</summary><br />
The MHA layer keeps cache_index across run() calls, so KV cache state
naturally persists for multi-turn use. CausalLM::run() however was
mixing two different position conventions when stitching multi-turn:

  - Prefill called the model with (SYS_PROMP_LEN, SYS_PROMP_LEN+input_len),
    which ignored prior turns entirely and re-wrote the cache from the
    fixed system-prompt base.
  - Generation called the model with
    (token_generation_idx - 1 + global_token_len,
     token_generation_idx     + global_token_len),
    which DID account for prior turns.

The two phases therefore disagreed on the absolute position of the new
tokens in the cache, so RoPE encodings, the causal mask and the cache
write head all drifted apart on turn N>=2 and the model produced
nonsense.

Fix by snapshotting the absolute base position once per turn and
threading it consistently through prefill, generation and the
teacher-forcing replay index:

  base_pos = SYS_PROMP_LEN + global_token_len

Also:
  - Clear pending_ids_ at the top of run() so a partial UTF-8 / mid-
    punctuation tail from a prior turn does not corrupt this turn's
    decoded output.
  - Add a context-overflow guard before prefill: if base_pos + init_len
    + NUM_TO_GENERATE would exceed MAX_SEQ_LEN, free the input buffer,
    log a clear message, and throw. The C API already wraps run() in a
    try/catch and surfaces this as CAUSAL_LM_ERROR_INFERENCE_FAILED so
    the user is told to call resetConversation().

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


<details><summary>[CausalLM] Add CausalLM::resetConversation() to clear multi-turn state</summary><br />
Provide an explicit way to start a fresh conversation on an already-
loaded model without paying the model-load cost again. resetConversation()
returns the instance to the same state it had right after load:

  - global_token_len, SYS_PROMP_LEN, has_run_, output_list and
    pending_ids_ are all cleared.
  - Every MHACoreLayer's KV-cache write head (cache_index) is rewound
    to 0 and its cache_key / cache_value tensors are zero-filled when
    already allocated, so neither the position math nor the attention
    reads can pull in stale state from the previous conversation.

Reaching the wrapped MHACoreLayer through forEachLayer requires going
through LayerNode::getLayer() — the callback receives an
ml::train::Layer& that is in fact a LayerNode wrapper, so a direct
dynamic_cast to MHACoreLayer is silently denied. The lambda routes
through the now-public LayerNode accessor.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>

<details><summary>[CausalLM] Add Qwen3-1.7B to C API model enumeration</summary><br />
Register QWEN3-1.7B in the ModelType enum, the path map
(./models/qwen3-1.7b), the reverse name lookup, and the
test_api name->enum dispatch so users can load the larger
model for better multi-turn evaluation.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


<details><summary>[CausalLM] Add resetConversation C API and automatic multi-turn promp…</summary><br />
…t splicing

Adds the public `resetConversation()` C entry point and a `g_turn_count`
state variable so the API layer can distinguish the first turn of a
conversation from continuations.

For continuation turns, the templated prompt is rewritten so that the
system block is dropped and the new user turn is spliced onto the
existing KV cache with a leading `\n` boundary. This matches the way the
chat template would have laid out the conversation if it had been
formatted in a single shot, which lets the cached system + prior turns
be reused verbatim.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>



<details><summary>[CausalLM] Add --verify-memory and --multi-turn modes to test_api </summary><br />

Refactors the inference path in test_api into a `run_turn()` helper and
adds two trailing flags to exercise the new multi-turn API end-to-end:

* `--verify-memory` runs a scripted two-turn regression test ("My name
  is Alice" -> "What is my name?"), asserts that the second response
  recalls "Alice" from the cached prior turn, then calls
  `resetConversation()` and confirms the model no longer claims to know
  the name. Returns non-zero on assertion failure.
* `--multi-turn` drops into an interactive REPL with `/reset` and
  `/quit` commands so the multi-turn behavior can be smoke-tested by
  hand.

Existing single-turn invocations are unaffected.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


### Summary

#### Test result 
```
./test_api QWEN3-0.6B "" 1 W4A32 0 --multi-turn
```
```
you> My name is Alice. Please remember my name.
📝 Input Prompt:
  My name is Alice. Please remember my name.

⚡ Running inference...

💬 Output:
  <think>
  Okay, so I need to remember my name, which is Alice. Let me think. First, I should make sure I'm not mixing up my name with someone else's. Maybe I should write it down in my mind or on a card. But how do I do that without looking at something? Maybe I can visualize it. Like, if I picture a white house with a big door, that's Alice. Or maybe a tree with a big leaf. That's Alice. Or a car with a big engine. That's Alice. So, maybe I can think of different images that represent Alice. But how do I choose the right one? Maybe I can pick a simple image that's easy to remember. Like a house with a big door. That's Alice. So, I can say "Alice, the house with a big door." That's a good way to remember it. Alternatively, maybe a tree with a big leaf. That's also a good memory. But which one is better? Well, maybe the house is more common. But I can choose either. Let me pick the house. So, the answer would be "Alice, the house with a big door." That's a good way to remember it.
  </think>
  
  To remember your name, "Alice" is a simple and memorable name. Here's a way to recall it:
  
  **"Alice, the house with a big door."**  
  
  This is a classic and effective way to remember the name. Let me know if you'd like to add more details!<|im_end|>

  📊 Prefill  tokens=17  111.00 ms  153.2 tok/s
  📊 Generation tokens=313  4610.00 ms  67.9 tok/s

you> What is my name?
📝 Input Prompt:
  What is my name?

⚡ Running inference...

💬 Output:
  <think>
  Okay, the user is asking for their name. But wait, the previous message was about remembering their name. Let me check. The user just said, "What is my name?" But maybe they forgot to mention their name in the previous message. Let me make sure. In the history, the user wrote, "My name is Alice. Please remember my name." Then the assistant responded with "Alice, the house with a big door." Now the user is asking, "What is my name?" So, the user is probably asking for their name again. But maybe they forgot to mention it. Let me respond appropriately. Maybe the user is testing if I can remember their name even if they didn't mention it. So, I should confirm their name and maybe add a note. Let me do that.
  </think>
  
  Your name is Alice. If you ever need to remember it again, you can say, "Alice, the house with a big door." That's a good way to recall it. Let me know if you need anything else!<|im_end|>

  📊 Prefill  tokens=13  94.00 ms  138.3 tok/s
  📊 Generation tokens=213  3483.00 ms  61.2 tok/s

you> /reset
✓ Conversation state reset.

you> What is my name?
📝 Input Prompt:
  What is my name?

⚡ Running inference...

💬 Output:
  <think>
  Okay, the user is asking, "What is my name?" I need to respond appropriately. Since I'm a language model, I don't have a personal name. But maybe I can be helpful. I should acknowledge that I don't have a name but still be useful. I can offer assistance with tasks or help with something else. Let me make sure my response is friendly and helpful.
  </think>
  
  I don't have a name, but I'm here to help! If you have any questions or need assistance, feel free to ask! ��<|im_end|>

  📊 Prefill  tokens=12  43.00 ms  279.1 tok/s
  📊 Generation tokens=113  1585.00 ms  71.3 tok/s

```

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
