### PR TITLE
[CausalLM] fix segfault with mmap-read for SlimMoE virtual tensors

### DIFF
--- a/Applications/CausalLM/layers/tie_word_embedding.cpp
+++ b/Applications/CausalLM/layers/tie_word_embedding.cpp
@@ -361,14 +361,14 @@ void TieWordEmbedding::read(
   nntrainer::ReadSource src, nntrainer::RunLayerContext &context, bool opt_var,
   ml::train::ExecutionMode mode, bool trainable,
   nntrainer::TensorDim::DataType definedWeightDataType, bool fsu,
-  size_t start_offset, bool read_from_offset) {
+  size_t start_offset, bool read_from_offset, int file_fd) {
 
   // Only read when mode is embedding
   if (mode_ == mode::embedding) {
     for (unsigned int i = 0; i < context.getNumWeights(); ++i) {
       /// @note shared weights are only be read at the first acecss
       if (context.isGradientFirstAccess(i)) {
-        context.getWeight(i).read(src, start_offset, read_from_offset);
+        context.getWeight(i).read(src, start_offset, read_from_offset, file_fd);
         if (context.isMixedPrecision(i) && trainable &&
             !context.getWeightFP32(i).empty()) {
           context.getWeightFP32(i).copyData(context.getWeight(i));

--- a/Applications/CausalLM/layers/tie_word_embedding.h
+++ b/Applications/CausalLM/layers/tie_word_embedding.h
@@ -129,7 +129,8 @@ public:
                        ml::train::ExecutionMode mode, bool trainable,
                        nntrainer::TensorDim::DataType definedWeightDataType,
                        bool fsu, size_t start_offset = 0,
-                       bool read_from_offset = false) override;
+                       bool read_from_offset = false,
+                       int file_fd = -1) override;
 
   /**
    * @copydic Layer::save()

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -470,7 +470,7 @@ void BatchNormalizationLayer::read(ReadSource src, RunLayerContext &run_context,
                                    bool trainable,
                                    TensorDim::DataType definedWeightDataType,
                                    bool fsu, size_t start_offset,
-                                   bool read_from_offset) {
+                                   bool read_from_offset, int file_fd) {
   if (opt_var) {
     for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
       if (run_context.isGradientLastAccess(i) && trainable) {

--- a/nntrainer/layers/bn_layer.h
+++ b/nntrainer/layers/bn_layer.h
@@ -155,7 +155,8 @@ public:
   void read(ReadSource src, RunLayerContext &context, bool opt_var,
             ml::train::ExecutionMode mode, bool trainable,
             TensorDim::DataType definedWeightDataType, bool fsu = false,
-            size_t start_offset = 0, bool read_from_offset = false) override;
+            size_t start_offset = 0, bool read_from_offset = false,
+            int file_fd = -1) override;
 
 private:
   float divider; /**< size of the axes of the reduced */

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -482,7 +482,8 @@ public:
   virtual void read(ReadSource src, RunLayerContext &run_context, bool opt_var,
                     ml::train::ExecutionMode mode, bool trainable,
                     TensorDim::DataType defineWeightDataType, bool fsu,
-                    size_t start_offset = 0, bool read_from_offset = false) {
+                    size_t start_offset = 0, bool read_from_offset = false,
+                    int file_fd = -1) {
     if (fsu) {
       for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
         if (run_context.getWeight(i).getDataType() ==
@@ -505,7 +506,11 @@ public:
         for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
           /// @note shared weights are only be read at the first acecss
           if (run_context.isGradientFirstAccess(i)) {
-            run_context.getWeight(i).read(src, start_offset, read_from_offset);
+            // file_fd is forwarded so virtual weights (e.g. SlimMoE expert
+            // tensors) can capture a long-lived fd for later mmap-on-demand
+            // in activate(); non-virtual weights ignore it.
+            run_context.getWeight(i).read(src, start_offset, read_from_offset,
+                                          file_fd);
             if (run_context.isMixedPrecision(i) && trainable &&
                 !run_context.getWeightFP32(i).empty()) {
               run_context.getWeightFP32(i).copyData(run_context.getWeight(i));

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -509,12 +509,13 @@ void LayerNode::read(std::ifstream &file, bool opt_var,
 
 void LayerNode::read(ReadSource src, bool opt_var,
                      ml::train::ExecutionMode mode, bool fsu,
-                     size_t start_offset, bool read_from_offset) {
+                     size_t start_offset, bool read_from_offset, int file_fd) {
   NNTR_THROW_IF(!run_context, std::runtime_error)
     << __func__ << " layer needs to be finalized first!";
   getLayer()->read(src, *run_context, opt_var, mode,
                    (getTrainable() && mode == ml::train::ExecutionMode::TRAIN),
-                   getWeightDataType(), fsu, start_offset, read_from_offset);
+                   getWeightDataType(), fsu, start_offset, read_from_offset,
+                   file_fd);
 }
 
 void LayerNode::save(std::ofstream &file, bool opt_var,

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -778,11 +778,14 @@ public:
    * @param fsu fsu type
    * @param mode Execution mode
    * @param opt_var read optimizer variables
+   * @param file_fd long-lived backing file descriptor; required for virtual
+   *        tensors (e.g. SlimMoE expert weights) so they can mmap themselves
+   *        in activate() after the per-thread mmap source is unmapped.
    */
   void read(ReadSource src, bool opt_var = false,
             ml::train::ExecutionMode mode = ml::train::ExecutionMode::TRAIN,
             bool fsu = false, size_t start_offset = 0,
-            bool read_from_offset = false);
+            bool read_from_offset = false, int file_fd = -1);
 
   /**
    * @brief         save layer Weight & Bias data from file

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -752,12 +752,14 @@ void NeuralNetwork::load(const std::string &file_path,
 #endif
 
     if (exec_mode == ml::train::ExecutionMode::INFERENCE) {
-      if (!MMAP_READ) {
-        ///@note for slim-tensor. This should be removed.
-        model_file_fd = open(f_path.c_str(), O_RDONLY);
-        NNTR_THROW_IF((model_file_fd == -1), std::invalid_argument)
-          << "Cannot open file : " << f_path;
-      }
+      // Always keep a long-lived fd open during inference. Virtual (slim)
+      // tensors capture this fd at read-time and use it later in activate()
+      // to mmap their backing region on demand. Without it, virtual tensors
+      // end up with fd=-1 and activate() returns MAP_FAILED, segfaulting on
+      // first use (e.g. SlimMoE expert weights when MMAP_READ=true).
+      model_file_fd = open(f_path.c_str(), O_RDONLY);
+      NNTR_THROW_IF((model_file_fd == -1), std::invalid_argument)
+        << "Cannot open file : " << f_path;
       // std::vector<std::future<void>> futures;
       std::vector<std::thread> threads;
       threads.reserve(model_graph.size());
@@ -793,7 +795,7 @@ void NeuralNetwork::load(const std::string &file_path,
               << "MapViewOfFile failed";
 
             node->read(view, false, exec_mode, fsu_mode,
-                       std::numeric_limits<size_t>::max(), true);
+                       std::numeric_limits<size_t>::max(), true, model_file_fd);
 
             // Early unmap: let the OS reclaim the working set ASAP
             UnmapViewOfFile(view);
@@ -822,7 +824,7 @@ void NeuralNetwork::load(const std::string &file_path,
 
             char *view = static_cast<char *>(mmap_ptr);
             node->read(view, false, exec_mode, fsu_mode,
-                       std::numeric_limits<size_t>::max(), true);
+                       std::numeric_limits<size_t>::max(), true, model_file_fd);
 
             // Early drop: pages no longer needed; helps lower peak RSS during
             // overlap

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1393,9 +1393,25 @@ void Tensor::read(std::ifstream &file, size_t start_offset,
   itensor_->read(file, start_offset, read_from_offset);
 }
 
-void Tensor::read(ReadSource src, size_t start_offset, bool read_from_offset) {
+void Tensor::read(ReadSource src, size_t start_offset, bool read_from_offset,
+                  int file_fd) {
   NNTR_THROW_IF(!getContiguous(), std::invalid_argument)
     << getName() << " is not contiguous, cannot read.";
+
+  // save the start_offset_info
+  read_offset = start_offset;
+
+  // Virtual tensors are not backed by allocated memory; they are lazily
+  // mapped from the model file via activate(). Mirror the std::ifstream
+  // overload: do not actually read here, but remember the backing fd so
+  // a subsequent activate() can mmap(this->fd, ...) successfully. Without
+  // this, fd stays at -1 and activate() returns MAP_FAILED, leading to a
+  // segfault when the layer dereferences the mapped pointer.
+  if (is_virtual) {
+    if (file_fd != -1)
+      fd = file_fd;
+    return;
+  }
 
   itensor_->read(src, start_offset, read_from_offset);
 }
@@ -1624,13 +1640,22 @@ void Tensor::activate() {
   size_t diff = file_offset - off;
   size_t len = getMemoryBytes() + diff;
 
+  // A virtual tensor must have captured a backing fd during read (see
+  // Tensor::read overloads). Without it, mmap() below returns MAP_FAILED
+  // and dereferencing the resulting pointer segfaults the process.
+  NNTR_THROW_IF(this->fd == -1, std::runtime_error)
+    << "[activate] virtual tensor '" << getName()
+    << "' has no backing fd; the model file fd was not propagated at "
+       "read-time";
+
   mapped_ptr = mmap(NULL, len, PROT_READ, MAP_PRIVATE, this->fd, off);
 #ifdef __ANDROID__
-  madvise(mapped_ptr, len, MADV_WILLNEED);
+  if (mapped_ptr != MAP_FAILED)
+    madvise(mapped_ptr, len, MADV_WILLNEED);
 #endif
-  if (mapped_ptr == MAP_FAILED) {
-    std::cerr << "[activate] mmap failed: " << strerror(errno) << std::endl;
-  }
+  NNTR_THROW_IF(mapped_ptr == MAP_FAILED, std::runtime_error)
+    << "[activate] mmap failed for virtual tensor '" << getName()
+    << "': " << strerror(errno);
   itensor_->activate((void *)&((uint8_t *)mapped_ptr)[diff]);
 #endif
 }

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1657,9 +1657,15 @@ public:
   /**
    * @brief     ReadSource
    * @param[in] ReadSource input file source
+   * @param[in] start_offset offset within source to read from
+   * @param[in] read_from_offset whether to honor start_offset
+   * @param[in] file_fd backing file descriptor to remember for virtual
+   *            tensors (used by activate()/deactivate() to mmap on-the-fly).
+   *            Pass -1 if the source has no associated long-lived fd; in that
+   *            case virtual tensors will keep whatever fd they already hold.
    */
   void read(ReadSource src, size_t start_offset = 0,
-            bool read_from_offset = false);
+            bool read_from_offset = false, int file_fd = -1);
 
   /**
    * @brief     return argument index which value is max by batch


### PR DESCRIPTION


## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] fix segfault with mmap-read for SlimMoE virtual tensors</summary><br />

Running Applications/CausalLM with the slim Qwen3 MoE model and mmap-read=true segfaults during forwarding. SlimMoE expert weights are virtual tensors that are mmaped on-demand by Tensor::activate() using the file descriptor saved at read-time. The std::ifstream read overload already captures file_fd for virtual tensors, but the ReadSource (mmap) overload did not: it neither received nor stored an fd, so virtual tensors ended up with fd=-1. Tensor::activate() then called mmap() with fd=-1, the call returned MAP_FAILED, and the code only logged the error to stderr before dereferencing the bogus pointer, crashing the process.

This change plumbs file_fd through the ReadSource read chain (NeuralNetwork -> LayerNode -> Layer -> Tensor) so virtual tensors capture the model file fd in mmap mode just like in non-mmap mode.

- NeuralNetwork::load() always opens model_file_fd at inference time (regardless of MMAP_READ), and forwards it to node->read() in both POSIX and Windows mmap branches.
- Tensor::read(ReadSource, ...) now takes an int file_fd and, for virtual tensors, stores it without performing the read (mirrors the std::ifstream overload).
- LayerNode::read, Layer::read and the BatchNormalization / TieWordEmbedding overrides take and forward file_fd accordingly.
- Tensor::activate() throws clearly when fd == -1 or mmap fails instead of silently passing MAP_FAILED to itensor_->activate(), so any future regression surfaces as an exception instead of a segfault.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Eunju Yang <ej.yang@samsung.com>

</details>


### Summary

- This PR aims to fix segmentation fault with mmap-read=true for SlimMoE virtual tensors.

Signed-off-by: Eunju Yang <ej.yang@samsung.com>
