### PR TITLE
Multi session inference

### DIFF
--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -45,6 +45,8 @@
 #include <unistd.h>
 #endif
 
+#include "inference_dispatcher.h"
+
 using json = nlohmann::json;
 
 static std::unique_ptr<causallm::api::InferenceSession> g_default_session;
@@ -56,6 +58,20 @@ static bool g_verbose = false;
 static std::string g_last_output = "";
 static double g_initialization_duration_ms = 0.0;
 static std::unique_ptr<causallm::ChatTemplate> g_chat_template;
+
+// Multi-session state
+static std::unordered_map<SessionHandle,
+                          std::unique_ptr<causallm::api::InferenceSession>>
+  g_sessions;
+static std::mutex g_session_mutex;
+static SessionHandle g_next_handle = 1;
+
+// Async request state
+static std::unordered_map<int, std::future<causallm::api::InferenceResult>>
+  g_pending_futures;
+static std::mutex g_future_mutex;
+static int g_next_request_id = 1;
+static std::string g_async_output;
 
 static std::map<std::string, std::string> g_model_path_map = {
   {"QWEN3-0.6B", "qwen3-0.6b"},
@@ -638,5 +654,245 @@ ErrorCode getPerformanceMetrics(PerformanceMetrics *metrics) {
     return CAUSAL_LM_ERROR_UNKNOWN;
   }
 
+  return CAUSAL_LM_ERROR_NONE;
+}
+
+static std::string get_model_key(ModelType modeltype,
+                                 ModelQuantizationType quant_type) {
+  const char *target_model_name = get_model_name_from_type(modeltype);
+  if (target_model_name == nullptr) {
+    return "";
+  }
+
+  std::string input_name = target_model_name;
+  std::string input_name_upper = input_name;
+  std::transform(input_name_upper.begin(), input_name_upper.end(),
+                 input_name_upper.begin(), ::toupper);
+
+  std::string quant_suffix;
+  switch (quant_type) {
+  case CAUSAL_LM_QUANTIZATION_W4A32:
+    quant_suffix = "-W4A32";
+    break;
+  case CAUSAL_LM_QUANTIZATION_W16A16:
+    quant_suffix = "-W16A16";
+    break;
+  case CAUSAL_LM_QUANTIZATION_W8A16:
+    quant_suffix = "-W8A16";
+    break;
+  case CAUSAL_LM_QUANTIZATION_W32A32:
+    quant_suffix = "-W32A32";
+    break;
+  default:
+    break;
+  }
+
+  return input_name_upper + quant_suffix;
+}
+
+ErrorCode createSession(SessionHandle *handle, BackendType compute,
+                        ModelType modeltype, ModelQuantizationType quant_type) {
+  (void)compute;
+
+  if (handle == nullptr) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  std::string model_key = get_model_key(modeltype, quant_type);
+  if (model_key.empty()) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  if (!causallm::api::ModelPool::Instance().isLoaded(model_key)) {
+    std::cerr << "createSession: Model not loaded: " << model_key
+              << ". Call loadModel() first." << std::endl;
+    return CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
+  }
+
+  auto session = causallm::api::ModelPool::Instance().createSession(model_key);
+  if (!session || !session->model) {
+    return CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
+  }
+
+  session->use_chat_template = g_use_chat_template;
+  session->verbose = g_verbose;
+
+  std::lock_guard<std::mutex> lock(g_session_mutex);
+  SessionHandle h = g_next_handle++;
+  g_sessions[h] = std::move(session);
+  *handle = h;
+
+  return CAUSAL_LM_ERROR_NONE;
+}
+
+ErrorCode runSession(SessionHandle handle, const char *inputTextPrompt,
+                     const char **outputText) {
+  if (inputTextPrompt == nullptr || outputText == nullptr) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  causallm::api::InferenceSession *session = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(g_session_mutex);
+    auto it = g_sessions.find(handle);
+    if (it == g_sessions.end()) {
+      return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+    }
+    session = it->second.get();
+  }
+
+  if (!session || !session->model) {
+    return CAUSAL_LM_ERROR_NOT_INITIALIZED;
+  }
+
+  bool expected = false;
+  if (!session->is_running.compare_exchange_strong(expected, true)) {
+    return CAUSAL_LM_ERROR_INFERENCE_FAILED;
+  }
+
+  try {
+    std::string input(inputTextPrompt);
+    if (session->use_chat_template) {
+      input = apply_chat_template(g_architecture, input);
+    }
+
+#if defined(_WIN32)
+    session->model->run(std::wstring(input.begin(), input.end()), false, L"",
+                        L"", session->verbose);
+#else
+    session->model->run(input, false, "", "", session->verbose);
+#endif
+
+    auto causal_lm_model =
+      dynamic_cast<causallm::CausalLM *>(session->model.get());
+    session->last_output = "";
+    if (causal_lm_model) {
+      session->last_output = causal_lm_model->getOutput(0);
+    }
+
+    *outputText = session->last_output.c_str();
+    session->is_running = false;
+
+  } catch (const std::exception &e) {
+    std::cerr << "Exception in runSession: " << e.what() << std::endl;
+    session->is_running = false;
+    return CAUSAL_LM_ERROR_INFERENCE_FAILED;
+  }
+
+  return CAUSAL_LM_ERROR_NONE;
+}
+
+ErrorCode runSessionAsync(SessionHandle handle, const char *inputTextPrompt,
+                          int *requestId) {
+  if (inputTextPrompt == nullptr || requestId == nullptr) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  causallm::api::InferenceSession *session = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(g_session_mutex);
+    auto it = g_sessions.find(handle);
+    if (it == g_sessions.end()) {
+      return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+    }
+    session = it->second.get();
+  }
+
+  if (!session || !session->model) {
+    return CAUSAL_LM_ERROR_NOT_INITIALIZED;
+  }
+
+  std::string prompt(inputTextPrompt);
+  if (session->use_chat_template) {
+    prompt = apply_chat_template(g_architecture, prompt);
+  }
+
+  auto future = causallm::api::InferenceDispatcher::Instance().submit(
+    session->model_key, prompt, session->use_chat_template, session->verbose,
+    g_architecture);
+
+  std::lock_guard<std::mutex> lock(g_future_mutex);
+  int req_id = g_next_request_id++;
+  g_pending_futures[req_id] = std::move(future);
+  *requestId = req_id;
+
+  return CAUSAL_LM_ERROR_NONE;
+}
+
+ErrorCode awaitResult(int requestId, const char **outputText) {
+  if (outputText == nullptr) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  std::future<causallm::api::InferenceResult> future;
+  {
+    std::lock_guard<std::mutex> lock(g_future_mutex);
+    auto it = g_pending_futures.find(requestId);
+    if (it == g_pending_futures.end()) {
+      return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+    }
+    future = std::move(it->second);
+    g_pending_futures.erase(it);
+  }
+
+  auto result = future.get();
+  if (result.error_code != CAUSAL_LM_ERROR_NONE) {
+    return result.error_code;
+  }
+
+  g_async_output = result.output;
+  *outputText = g_async_output.c_str();
+
+  return CAUSAL_LM_ERROR_NONE;
+}
+
+ErrorCode getSessionMetrics(SessionHandle handle, PerformanceMetrics *metrics) {
+  if (metrics == nullptr) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  causallm::api::InferenceSession *session = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(g_session_mutex);
+    auto it = g_sessions.find(handle);
+    if (it == g_sessions.end()) {
+      return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+    }
+    session = it->second.get();
+  }
+
+  if (!session || !session->model) {
+    return CAUSAL_LM_ERROR_NOT_INITIALIZED;
+  }
+
+  try {
+    auto causal_lm_model =
+      dynamic_cast<causallm::CausalLM *>(session->model.get());
+    if (!causal_lm_model) {
+      return CAUSAL_LM_ERROR_UNKNOWN;
+    }
+
+    if (!causal_lm_model->hasRun()) {
+      return CAUSAL_LM_ERROR_INFERENCE_NOT_RUN;
+    }
+
+    *metrics = causal_lm_model->getPerformanceMetrics();
+
+  } catch (const std::exception &e) {
+    std::cerr << "Exception in getSessionMetrics: " << e.what() << std::endl;
+    return CAUSAL_LM_ERROR_UNKNOWN;
+  }
+
+  return CAUSAL_LM_ERROR_NONE;
+}
+
+ErrorCode destroySession(SessionHandle handle) {
+  std::lock_guard<std::mutex> lock(g_session_mutex);
+  auto it = g_sessions.find(handle);
+  if (it == g_sessions.end()) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  g_sessions.erase(it);
   return CAUSAL_LM_ERROR_NONE;
 }

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -27,8 +27,10 @@
 #include "gptoss_cached_slim_causallm.h"
 #endif
 #include "gptoss_causallm.h"
+#include "inference_session.h"
 #include "json.hpp"
 #include "model_config_internal.h"
+#include "model_pool.h"
 #include "qwen2_causallm.h"
 #if !defined(_WIN32)
 #include "qwen3_cached_slim_moe_causallm.h"
@@ -45,7 +47,7 @@
 
 using json = nlohmann::json;
 
-static std::unique_ptr<causallm::Transformer> g_model;
+static std::unique_ptr<causallm::api::InferenceSession> g_default_session;
 static std::mutex g_mutex;
 static bool g_initialized = false;
 static std::string g_architecture = "";
@@ -529,14 +531,17 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
       return CAUSAL_LM_ERROR_INVALID_PARAMETER;
     }
 
-    g_model = causallm::Factory::Instance().create(architecture, cfg,
-                                                   generation_cfg, nntr_cfg);
-    if (!g_model) {
+    if (!causallm::api::ModelPool::Instance().loadModel(
+          lookup_name, architecture, cfg, generation_cfg, nntr_cfg,
+          weight_file)) {
       return CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
     }
 
-    g_model->initialize();
-    g_model->load_weight(weight_file);
+    g_default_session =
+      causallm::api::ModelPool::Instance().createSession(lookup_name);
+    if (!g_default_session || !g_default_session->model) {
+      return CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
+    }
 
     g_initialized = true;
     g_architecture = architecture;
@@ -558,7 +563,7 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
 }
 
 ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
-  if (!g_initialized || !g_model) {
+  if (!g_initialized || !g_default_session || !g_default_session->model) {
     return CAUSAL_LM_ERROR_NOT_INITIALIZED;
   }
   if (inputTextPrompt == nullptr || outputText == nullptr) {
@@ -574,11 +579,18 @@ ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
       input = apply_chat_template(g_architecture, input);
     }
 
-    // We assume single batch request for this API.
-    g_model->run(input, false, "", "", g_verbose);
+    auto *model = g_default_session->model.get();
 
-    auto causal_lm_model = dynamic_cast<causallm::CausalLM *>(g_model.get());
-    g_last_output = ""; // Reset last output
+// We assume single batch request for this API
+#if defined(_WIN32)
+    model->run(std::wstring(input.begin(), input.end()), false, L"", L"",
+               g_verbose);
+#else
+    model->run(input, false, "", "", g_verbose);
+#endif
+
+    auto causal_lm_model = dynamic_cast<causallm::CausalLM *>(model);
+    g_last_output = "";
     if (causal_lm_model) {
       g_last_output = causal_lm_model->getOutput(0);
     }
@@ -594,7 +606,7 @@ ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
 }
 
 ErrorCode getPerformanceMetrics(PerformanceMetrics *metrics) {
-  if (!g_initialized || !g_model) {
+  if (!g_initialized || !g_default_session || !g_default_session->model) {
     return CAUSAL_LM_ERROR_NOT_INITIALIZED;
   }
   if (metrics == nullptr) {
@@ -603,11 +615,13 @@ ErrorCode getPerformanceMetrics(PerformanceMetrics *metrics) {
 
   try {
     std::lock_guard<std::mutex> lock(g_mutex);
+    auto causal_lm_model =
+      dynamic_cast<causallm::CausalLM *>(g_default_session->model.get());
 
-    if (!g_model->hasRun()) {
+    if (!g_default_session->model->hasRun()) {
       return CAUSAL_LM_ERROR_INFERENCE_NOT_RUN;
     }
-    auto internal_metrics = g_model->getPerformanceMetrics();
+    auto internal_metrics = g_default_session->model->getPerformanceMetrics();
     metrics->prefill_tokens = internal_metrics.prefill_tokens;
     metrics->prefill_duration_ms = internal_metrics.prefill_duration_ms;
     metrics->generation_tokens = internal_metrics.generation_tokens;

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -734,7 +734,7 @@ ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
 
     auto *model = g_default_session->model.get();
 
-// We assume single batch request for this API
+    // We assume single batch request for this API
     model->run(input, false, "", "", g_verbose);
 
     auto causal_lm_model = dynamic_cast<causallm::CausalLM *>(model);

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -735,12 +735,7 @@ ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
     auto *model = g_default_session->model.get();
 
 // We assume single batch request for this API
-#if defined(_WIN32)
-    model->run(std::wstring(input.begin(), input.end()), false, L"", L"",
-               g_verbose);
-#else
     model->run(input, false, "", "", g_verbose);
-#endif
 
     auto causal_lm_model = dynamic_cast<causallm::CausalLM *>(model);
     g_last_output = "";
@@ -893,12 +888,7 @@ ErrorCode runSession(SessionHandle handle, const char *inputTextPrompt,
       input = apply_chat_template(g_architecture, input);
     }
 
-#if defined(_WIN32)
-    session->model->run(std::wstring(input.begin(), input.end()), false, L"",
-                        L"", session->verbose);
-#else
     session->model->run(input, false, "", "", session->verbose);
-#endif
 
     auto causal_lm_model =
       dynamic_cast<causallm::CausalLM *>(session->model.get());
@@ -1013,7 +1003,14 @@ ErrorCode getSessionMetrics(SessionHandle handle, PerformanceMetrics *metrics) {
       return CAUSAL_LM_ERROR_INFERENCE_NOT_RUN;
     }
 
-    *metrics = causal_lm_model->getPerformanceMetrics();
+    auto m = causal_lm_model->getPerformanceMetrics();
+    metrics->prefill_tokens = m.prefill_tokens;
+    metrics->prefill_duration_ms = m.prefill_duration_ms;
+    metrics->generation_tokens = m.generation_tokens;
+    metrics->generation_duration_ms = m.generation_duration_ms;
+    metrics->total_duration_ms = m.total_duration_ms;
+    metrics->initialization_duration_ms = m.initialization_duration_ms;
+    metrics->peak_memory_kb = m.peak_memory_kb;
 
   } catch (const std::exception &e) {
     std::cerr << "Exception in getSessionMetrics: " << e.what() << std::endl;

--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -578,6 +578,143 @@ ErrorCode loadModel(BackendType compute, ModelType modeltype,
   return CAUSAL_LM_ERROR_NONE;
 }
 
+static std::string get_model_key_from_path(const std::string &model_dir_path,
+                                           ModelQuantizationType quant_type) {
+  std::string base_name;
+  size_t last_slash = model_dir_path.find_last_of("/\\");
+  if (last_slash != std::string::npos) {
+    base_name = model_dir_path.substr(last_slash + 1);
+  } else {
+    base_name = model_dir_path;
+  }
+
+  std::string quant_suffix = get_quantization_suffix(quant_type);
+  std::transform(quant_suffix.begin(), quant_suffix.end(), quant_suffix.begin(),
+                 ::toupper);
+  return base_name + quant_suffix;
+}
+
+ErrorCode loadModelFromPath(BackendType compute, const char *model_path_cstr,
+                            ModelQuantizationType quant_type) {
+  (void)compute;
+  auto start_init = std::chrono::high_resolution_clock::now();
+
+  if (model_path_cstr == nullptr) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  std::string model_dir_path(model_path_cstr);
+
+  // Ensure models/configs are registered
+  register_models();
+
+  std::lock_guard<std::mutex> lock(g_mutex);
+  try {
+    json cfg;
+    json generation_cfg;
+    json nntr_cfg;
+
+    // Load configuration files from the given path
+    cfg = causallm::LoadJsonFile(model_dir_path + "/config.json");
+    generation_cfg =
+      causallm::LoadJsonFile(model_dir_path + "/generation_config.json");
+    nntr_cfg = causallm::LoadJsonFile(model_dir_path + "/nntr_config.json");
+
+    if (nntr_cfg.contains("tokenizer_file")) {
+      std::string t_file = nntr_cfg["tokenizer_file"];
+      if (!t_file.empty() && t_file[0] == '/') {
+        nntr_cfg["tokenizer_file"] = t_file;
+      } else {
+        nntr_cfg["tokenizer_file"] = model_dir_path + "/" + t_file;
+      }
+    }
+
+    // Construct weight file path
+    std::string weight_file_name;
+    if (nntr_cfg.contains("model_file_name")) {
+      weight_file_name = nntr_cfg["model_file_name"].get<std::string>();
+    } else {
+      weight_file_name = "pytorch_model.bin";
+    }
+    const std::string weight_file = model_dir_path + "/" + weight_file_name;
+
+    // Determine architecture from config
+    std::string architecture;
+    if (cfg.contains("architectures") && cfg["architectures"].is_array() &&
+        !cfg["architectures"].empty()) {
+      architecture = cfg["architectures"].get<std::vector<std::string>>()[0];
+    } else {
+      return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+    }
+
+    std::string lookup_name =
+      get_model_key_from_path(model_dir_path, quant_type);
+
+    if (!causallm::api::ModelPool::Instance().loadModel(
+          lookup_name, architecture, cfg, generation_cfg, nntr_cfg,
+          weight_file)) {
+      return CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
+    }
+
+    g_default_session =
+      causallm::api::ModelPool::Instance().createSession(lookup_name);
+    if (!g_default_session || !g_default_session->model) {
+      return CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
+    }
+
+    g_initialized = true;
+    g_architecture = architecture;
+
+    auto finish_init = std::chrono::high_resolution_clock::now();
+    auto init_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      finish_init - start_init);
+    g_initialization_duration_ms = init_duration.count();
+
+  } catch (const std::exception &e) {
+    std::cerr << "Exception in loadModelFromPath: " << e.what() << std::endl;
+    return CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
+  } catch (...) {
+    std::cerr << "Unknown exception in loadModelFromPath" << std::endl;
+    return CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
+  }
+
+  return CAUSAL_LM_ERROR_NONE;
+}
+
+ErrorCode createSessionFromPath(SessionHandle *handle, BackendType compute,
+                                const char *model_path_cstr,
+                                ModelQuantizationType quant_type) {
+  (void)compute;
+
+  if (handle == nullptr || model_path_cstr == nullptr) {
+    return CAUSAL_LM_ERROR_INVALID_PARAMETER;
+  }
+
+  std::string model_dir_path(model_path_cstr);
+  std::string model_key = get_model_key_from_path(model_dir_path, quant_type);
+
+  if (!causallm::api::ModelPool::Instance().isLoaded(model_key)) {
+    std::cerr << "createSessionFromPath: Model not loaded: " << model_key
+              << ". Call loadModelFromPath() first." << std::endl;
+    return CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
+  }
+
+  auto session = causallm::api::ModelPool::Instance().createSession(model_key);
+  if (!session || !session->model) {
+    return CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
+  }
+
+  session->use_chat_template = g_use_chat_template;
+  session->verbose = g_verbose;
+
+  std::lock_guard<std::mutex> lock(g_session_mutex);
+  SessionHandle h = g_next_handle++;
+  g_sessions[h] = std::move(session);
+  *handle = h;
+
+  return CAUSAL_LM_ERROR_NONE;
+}
+
 ErrorCode runModel(const char *inputTextPrompt, const char **outputText) {
   if (!g_initialized || !g_default_session || !g_default_session->model) {
     return CAUSAL_LM_ERROR_NOT_INITIALIZED;

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -106,6 +106,18 @@ WIN_EXPORT ErrorCode loadModel(BackendType compute, ModelType modeltype,
                                ModelQuantizationType quant_type);
 
 /**
+ * @brief Load a model from a custom directory path
+ * @param compute Backend compute type
+ * @param model_path Path to the model directory (containing config.json,
+ * nntr_config.json, etc.)
+ * @param quant_type Model quantization type
+ * @return ErrorCode
+ */
+WIN_EXPORT ErrorCode loadModelFromPath(BackendType compute,
+                                       const char *model_path,
+                                       ModelQuantizationType quant_type);
+
+/**
  * @brief Get performance metrics of the last run
  * @param metrics Pointer to PerformanceMetrics struct to be filled
  * @return ErrorCode
@@ -140,6 +152,22 @@ typedef int SessionHandle;
 WIN_EXPORT ErrorCode createSession(SessionHandle *handle, BackendType compute,
                                    ModelType modeltype,
                                    ModelQuantizationType quant_type);
+
+/**
+ * @brief Create a new inference session from a custom directory path
+ *
+ * The model must be loaded via loadModelFromPath() before creating a session.
+ *
+ * @param handle Pointer to store the new session handle
+ * @param compute Backend compute type
+ * @param model_path Path to the model directory
+ * @param quant_type Model quantization type
+ * @return ErrorCode
+ */
+WIN_EXPORT ErrorCode createSessionFromPath(SessionHandle *handle,
+                                           BackendType compute,
+                                           const char *model_path,
+                                           ModelQuantizationType quant_type);
 
 /**
  * @brief Run inference on a session (synchronous)

--- a/Applications/CausalLM/api/causal_lm_api.h
+++ b/Applications/CausalLM/api/causal_lm_api.h
@@ -121,6 +121,77 @@ WIN_EXPORT ErrorCode getPerformanceMetrics(PerformanceMetrics *metrics);
 WIN_EXPORT ErrorCode runModel(const char *inputTextPrompt,
                               const char **outputText);
 
+/**
+ * @brief Session handle for multi-session inference
+ */
+typedef int SessionHandle;
+
+/**
+ * @brief Create a new inference session
+ *
+ * The model must be loaded via loadModel() before creating a session.
+ *
+ * @param handle Pointer to store the new session handle
+ * @param compute Backend compute type
+ * @param modeltype Model type
+ * @param quant_type Model quantization type
+ * @return ErrorCode
+ */
+WIN_EXPORT ErrorCode createSession(SessionHandle *handle, BackendType compute,
+                                   ModelType modeltype,
+                                   ModelQuantizationType quant_type);
+
+/**
+ * @brief Run inference on a session (synchronous)
+ *
+ * @param handle Session handle
+ * @param inputTextPrompt Input prompt
+ * @param outputText Buffer to store output text
+ * @return ErrorCode
+ */
+WIN_EXPORT ErrorCode runSession(SessionHandle handle,
+                                const char *inputTextPrompt,
+                                const char **outputText);
+
+/**
+ * @brief Run inference on a session (asynchronous)
+ *
+ * @param handle Session handle
+ * @param inputTextPrompt Input prompt
+ * @param requestId Pointer to store the async request ID
+ * @return ErrorCode
+ */
+WIN_EXPORT ErrorCode runSessionAsync(SessionHandle handle,
+                                     const char *inputTextPrompt,
+                                     int *requestId);
+
+/**
+ * @brief Await the result of an async inference request
+ *
+ * @param requestId Request ID returned by runSessionAsync()
+ * @param outputText Buffer to store output text
+ * @return ErrorCode
+ */
+WIN_EXPORT ErrorCode awaitResult(int requestId, const char **outputText);
+
+/**
+ * @brief Get performance metrics of a session
+ *
+ * @param handle Session handle
+ * @param metrics Pointer to PerformanceMetrics struct to be filled
+ * @return ErrorCode
+ */
+WIN_EXPORT ErrorCode getSessionMetrics(SessionHandle handle,
+                                       PerformanceMetrics *metrics);
+
+/**
+ * @brief Destroy a session and free its resources
+ *
+ * @param handle Session handle
+ * @return ErrorCode
+ */
+WIN_EXPORT ErrorCode destroySession(SessionHandle handle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Applications/CausalLM/api/inference_dispatcher.cpp
+++ b/Applications/CausalLM/api/inference_dispatcher.cpp
@@ -51,52 +51,55 @@ InferenceDispatcher::submit(const std::string &model_key,
 
   int request_id = next_request_id_++;
 
-  return std::async(std::launch::async, [model_key, prompt, use_chat_template,
-                                         verbose, architecture,
-                                         request_id]() -> InferenceResult {
-    auto session = ModelPool::Instance().createSession(model_key);
-    if (!session || !session->model) {
+  return std::async(
+    std::launch::async,
+    [model_key, prompt, use_chat_template, verbose, architecture,
+     request_id]() -> InferenceResult {
+      auto session = ModelPool::Instance().createSession(model_key);
+      if (!session || !session->model) {
+        InferenceResult result;
+        result.error_code = CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
+        return result;
+      }
+
+      session->is_running = true;
+
       InferenceResult result;
-      result.error_code = CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
+      try {
+        std::string input = prompt;
+        if (use_chat_template) {
+          input = apply_chat_template_internal(architecture, input);
+        }
+
+        session->model->run(input, false, "", "", verbose);
+
+        auto causal_lm =
+          dynamic_cast<causallm::CausalLM *>(session->model.get());
+        if (causal_lm) {
+          result.output = causal_lm->getOutput(0);
+          auto m = causal_lm->getPerformanceMetrics();
+          result.metrics.prefill_tokens = m.prefill_tokens;
+          result.metrics.prefill_duration_ms = m.prefill_duration_ms;
+          result.metrics.generation_tokens = m.generation_tokens;
+          result.metrics.generation_duration_ms = m.generation_duration_ms;
+          result.metrics.total_duration_ms = m.total_duration_ms;
+          result.metrics.initialization_duration_ms =
+            m.initialization_duration_ms;
+          result.metrics.peak_memory_kb = m.peak_memory_kb;
+        }
+
+        result.error_code = CAUSAL_LM_ERROR_NONE;
+      } catch (const std::exception &e) {
+        std::cerr << "[InferenceDispatcher] Request " << request_id
+                  << " failed: " << e.what() << std::endl;
+        result.error_code = CAUSAL_LM_ERROR_INFERENCE_FAILED;
+      }
+
+      session->is_running = false;
+      ModelPool::Instance().releaseSession(session.get());
+
       return result;
-    }
-
-    session->is_running = true;
-
-    InferenceResult result;
-    try {
-      std::string input = prompt;
-      if (use_chat_template) {
-        input = apply_chat_template_internal(architecture, input);
-      }
-
-      session->model->run(input, false, "", "", verbose);
-
-      auto causal_lm = dynamic_cast<causallm::CausalLM *>(session->model.get());
-      if (causal_lm) {
-        result.output = causal_lm->getOutput(0);
-        auto m = causal_lm->getPerformanceMetrics();
-        result.metrics.prefill_tokens = m.prefill_tokens;
-        result.metrics.prefill_duration_ms = m.prefill_duration_ms;
-        result.metrics.generation_tokens = m.generation_tokens;
-        result.metrics.generation_duration_ms = m.generation_duration_ms;
-        result.metrics.total_duration_ms = m.total_duration_ms;
-        result.metrics.initialization_duration_ms = m.initialization_duration_ms;
-        result.metrics.peak_memory_kb = m.peak_memory_kb;
-      }
-
-      result.error_code = CAUSAL_LM_ERROR_NONE;
-    } catch (const std::exception &e) {
-      std::cerr << "[InferenceDispatcher] Request " << request_id
-                << " failed: " << e.what() << std::endl;
-      result.error_code = CAUSAL_LM_ERROR_INFERENCE_FAILED;
-    }
-
-    session->is_running = false;
-    ModelPool::Instance().releaseSession(session.get());
-
-    return result;
-  });
+    });
 }
 
 InferenceResult InferenceDispatcher::runSync(const std::string &model_key,
@@ -109,11 +112,11 @@ InferenceResult InferenceDispatcher::runSync(const std::string &model_key,
   return future.get();
 }
 
-void InferenceDispatcher::setThreadCount(size_t count) { thread_count_ = count; }
-
-size_t InferenceDispatcher::getThreadCount() const {
-  return thread_count_;
+void InferenceDispatcher::setThreadCount(size_t count) {
+  thread_count_ = count;
 }
+
+size_t InferenceDispatcher::getThreadCount() const { return thread_count_; }
 
 } // namespace api
 } // namespace causallm

--- a/Applications/CausalLM/api/inference_dispatcher.cpp
+++ b/Applications/CausalLM/api/inference_dispatcher.cpp
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   inference_dispatcher.cpp
+ * @brief  InferenceDispatcher implementation
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Eunju Yang <ej.yang@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include "inference_dispatcher.h"
+#include "causal_lm.h"
+#include "model_pool.h"
+#include "transformer.h"
+
+#include <iostream>
+
+namespace causallm {
+namespace api {
+
+static std::string apply_chat_template_internal(const std::string &architecture,
+                                                const std::string &input) {
+  if (architecture == "LlamaForCausalLM") {
+    return "[INST] " + input + " [/INST]";
+  } else if (architecture == "Qwen2ForCausalLM" ||
+             architecture == "Qwen3ForCausalLM" ||
+             architecture == "Qwen3MoeForCausalLM" ||
+             architecture == "Qwen3SlimMoeForCausalLM" ||
+             architecture == "Qwen3CachedSlimMoeForCausalLM") {
+    return "<|im_start|>user\n" + input + "<|im_end|>\n<|im_start|>assistant\n";
+  } else if (architecture == "Gemma3ForCausalLM") {
+    return "<start_of_turn>user\n" + input +
+           "<end_of_turn>\n<start_of_turn>model\n";
+  }
+  return input;
+}
+
+InferenceDispatcher &InferenceDispatcher::Instance() {
+  static InferenceDispatcher dispatcher;
+  return dispatcher;
+}
+
+InferenceDispatcher::InferenceDispatcher() :
+  pool_(std::thread::hardware_concurrency()) {}
+
+std::future<InferenceResult>
+InferenceDispatcher::submit(const std::string &model_key,
+                            const std::string &prompt, bool use_chat_template,
+                            bool verbose, const std::string &architecture) {
+
+  int request_id = next_request_id_++;
+
+  return pool_.submit_task([model_key, prompt, use_chat_template, verbose,
+                            architecture, request_id]() -> InferenceResult {
+    auto session = ModelPool::Instance().createSession(model_key);
+    if (!session || !session->model) {
+      InferenceResult result;
+      result.error_code = CAUSAL_LM_ERROR_MODEL_LOAD_FAILED;
+      return result;
+    }
+
+    session->is_running = true;
+
+    InferenceResult result;
+    try {
+      std::string input = prompt;
+      if (use_chat_template) {
+        input = apply_chat_template_internal(architecture, input);
+      }
+
+#if defined(_WIN32)
+      session->model->run(std::wstring(input.begin(), input.end()), false, L"",
+                          L"", verbose);
+#else
+      session->model->run(input, false, "", "", verbose);
+#endif
+
+      auto causal_lm = dynamic_cast<causallm::CausalLM *>(session->model.get());
+      if (causal_lm) {
+        result.output = causal_lm->getOutput(0);
+        result.metrics = causal_lm->getPerformanceMetrics();
+      }
+
+      result.error_code = CAUSAL_LM_ERROR_NONE;
+    } catch (const std::exception &e) {
+      std::cerr << "[InferenceDispatcher] Request " << request_id
+                << " failed: " << e.what() << std::endl;
+      result.error_code = CAUSAL_LM_ERROR_INFERENCE_FAILED;
+    }
+
+    session->is_running = false;
+    ModelPool::Instance().releaseSession(session.get());
+
+    return result;
+  });
+}
+
+InferenceResult InferenceDispatcher::runSync(const std::string &model_key,
+                                             const std::string &prompt,
+                                             bool use_chat_template,
+                                             bool verbose,
+                                             const std::string &architecture) {
+  auto future =
+    submit(model_key, prompt, use_chat_template, verbose, architecture);
+  return future.get();
+}
+
+void InferenceDispatcher::setThreadCount(size_t count) { pool_.reset(count); }
+
+size_t InferenceDispatcher::getThreadCount() const {
+  return pool_.get_thread_count();
+}
+
+} // namespace api
+} // namespace causallm

--- a/Applications/CausalLM/api/inference_dispatcher.cpp
+++ b/Applications/CausalLM/api/inference_dispatcher.cpp
@@ -42,7 +42,7 @@ InferenceDispatcher &InferenceDispatcher::Instance() {
 }
 
 InferenceDispatcher::InferenceDispatcher() :
-  pool_(std::thread::hardware_concurrency()) {}
+  thread_count_(std::thread::hardware_concurrency()) {}
 
 std::future<InferenceResult>
 InferenceDispatcher::submit(const std::string &model_key,
@@ -51,8 +51,9 @@ InferenceDispatcher::submit(const std::string &model_key,
 
   int request_id = next_request_id_++;
 
-  return pool_.submit_task([model_key, prompt, use_chat_template, verbose,
-                            architecture, request_id]() -> InferenceResult {
+  return std::async(std::launch::async, [model_key, prompt, use_chat_template,
+                                         verbose, architecture,
+                                         request_id]() -> InferenceResult {
     auto session = ModelPool::Instance().createSession(model_key);
     if (!session || !session->model) {
       InferenceResult result;
@@ -69,17 +70,19 @@ InferenceDispatcher::submit(const std::string &model_key,
         input = apply_chat_template_internal(architecture, input);
       }
 
-#if defined(_WIN32)
-      session->model->run(std::wstring(input.begin(), input.end()), false, L"",
-                          L"", verbose);
-#else
       session->model->run(input, false, "", "", verbose);
-#endif
 
       auto causal_lm = dynamic_cast<causallm::CausalLM *>(session->model.get());
       if (causal_lm) {
         result.output = causal_lm->getOutput(0);
-        result.metrics = causal_lm->getPerformanceMetrics();
+        auto m = causal_lm->getPerformanceMetrics();
+        result.metrics.prefill_tokens = m.prefill_tokens;
+        result.metrics.prefill_duration_ms = m.prefill_duration_ms;
+        result.metrics.generation_tokens = m.generation_tokens;
+        result.metrics.generation_duration_ms = m.generation_duration_ms;
+        result.metrics.total_duration_ms = m.total_duration_ms;
+        result.metrics.initialization_duration_ms = m.initialization_duration_ms;
+        result.metrics.peak_memory_kb = m.peak_memory_kb;
       }
 
       result.error_code = CAUSAL_LM_ERROR_NONE;
@@ -106,10 +109,10 @@ InferenceResult InferenceDispatcher::runSync(const std::string &model_key,
   return future.get();
 }
 
-void InferenceDispatcher::setThreadCount(size_t count) { pool_.reset(count); }
+void InferenceDispatcher::setThreadCount(size_t count) { thread_count_ = count; }
 
 size_t InferenceDispatcher::getThreadCount() const {
-  return pool_.get_thread_count();
+  return thread_count_;
 }
 
 } // namespace api

--- a/Applications/CausalLM/api/inference_dispatcher.h
+++ b/Applications/CausalLM/api/inference_dispatcher.h
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   inference_dispatcher.h
+ * @brief  Async inference dispatcher with thread pool
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Eunju Yang <ej.yang@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __INFERENCE_DISPATCHER_H__
+#define __INFERENCE_DISPATCHER_H__
+
+#include <atomic>
+#include <future>
+#include <memory>
+#include <string>
+
+#include "causal_lm_api.h"
+#include "performance_metrics.h"
+#include <bs_thread_pool.h>
+
+namespace causallm {
+namespace api {
+
+/**
+ * @brief Result of an async inference request
+ */
+struct InferenceResult {
+  std::string output;         /**< Generated output text */
+  PerformanceMetrics metrics; /**< Performance metrics */
+  ErrorCode error_code;       /**< Error code */
+};
+
+/**
+ * @brief Dispatches inference requests to a thread pool
+ *
+ * Each request creates an independent session, runs inference asynchronously,
+ * and returns the result via std::future.
+ */
+class InferenceDispatcher {
+public:
+  /**
+   * @brief Get the process-wide InferenceDispatcher singleton
+   */
+  static InferenceDispatcher &Instance();
+
+  /**
+   * @brief Submit an async inference request
+   *
+   * @param model_key Model key in ModelPool
+   * @param prompt Input prompt text
+   * @param use_chat_template Whether to apply chat template
+   * @param verbose Whether to print output during generation
+   * @param architecture Model architecture name (for chat template)
+   * @return std::future<InferenceResult> Future holding the result
+   */
+  std::future<InferenceResult> submit(const std::string &model_key,
+                                      const std::string &prompt,
+                                      bool use_chat_template, bool verbose,
+                                      const std::string &architecture);
+
+  /**
+   * @brief Run inference synchronously
+   *
+   * @param model_key Model key in ModelPool
+   * @param prompt Input prompt text
+   * @param use_chat_template Whether to apply chat template
+   * @param verbose Whether to print output during generation
+   * @param architecture Model architecture name (for chat template)
+   * @return InferenceResult Result of the inference
+   */
+  InferenceResult runSync(const std::string &model_key,
+                          const std::string &prompt, bool use_chat_template,
+                          bool verbose, const std::string &architecture);
+
+  /**
+   * @brief Set the number of threads in the pool
+   */
+  void setThreadCount(size_t count);
+
+  /**
+   * @brief Get the current number of threads
+   */
+  size_t getThreadCount() const;
+
+private:
+  InferenceDispatcher();
+  ~InferenceDispatcher() = default;
+
+  BS::thread_pool<> pool_;
+  std::atomic<int> next_request_id_{1};
+};
+
+} // namespace api
+} // namespace causallm
+
+#endif // __INFERENCE_DISPATCHER_H__

--- a/Applications/CausalLM/api/inference_dispatcher.h
+++ b/Applications/CausalLM/api/inference_dispatcher.h
@@ -16,10 +16,10 @@
 #include <future>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "causal_lm_api.h"
 #include "performance_metrics.h"
-#include <bs_thread_pool.h>
 
 namespace causallm {
 namespace api {
@@ -89,8 +89,8 @@ private:
   InferenceDispatcher();
   ~InferenceDispatcher() = default;
 
-  BS::thread_pool<> pool_;
   std::atomic<int> next_request_id_{1};
+  size_t thread_count_;
 };
 
 } // namespace api

--- a/Applications/CausalLM/api/inference_session.h
+++ b/Applications/CausalLM/api/inference_session.h
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   inference_session.h
+ * @brief  Session structure for independent inference execution
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Eunju Yang <ej.yang@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __INFERENCE_SESSION_H__
+#define __INFERENCE_SESSION_H__
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace causallm {
+class Transformer;
+}
+
+namespace causallm {
+namespace api {
+
+/**
+ * @brief Represents a single inference session with independent state
+ *
+ * Each session holds its own Transformer model instance, ensuring
+ * thread-safe concurrent inference across multiple sessions.
+ */
+struct InferenceSession {
+  int id;                /**< Unique session identifier */
+  std::string model_key; /**< Model key in the pool */
+  std::unique_ptr<causallm::Transformer>
+    model;                     /**< Independent model instance */
+  bool is_initialized = false; /**< Whether the session is ready */
+
+  /** Session creation timestamp */
+  std::chrono::steady_clock::time_point created_at;
+
+  /** True if the session is currently running inference */
+  std::atomic<bool> is_running{false};
+
+  /** Per-session config overrides */
+  bool use_chat_template = false;
+  bool verbose = false;
+
+  InferenceSession() = default;
+  ~InferenceSession() = default;
+
+  // Disable copy to prevent accidental sharing of model instance
+  InferenceSession(const InferenceSession &) = delete;
+  InferenceSession &operator=(const InferenceSession &) = delete;
+
+  // Enable move
+  InferenceSession(InferenceSession &&) = default;
+  InferenceSession &operator=(InferenceSession &&) = default;
+};
+
+} // namespace api
+} // namespace causallm
+
+#endif // __INFERENCE_SESSION_H__

--- a/Applications/CausalLM/api/inference_session.h
+++ b/Applications/CausalLM/api/inference_session.h
@@ -47,6 +47,9 @@ struct InferenceSession {
   bool use_chat_template = false;
   bool verbose = false;
 
+  /** Last inference output (session-local storage) */
+  std::string last_output;
+
   InferenceSession() = default;
   ~InferenceSession() = default;
 

--- a/Applications/CausalLM/api/model_pool.cpp
+++ b/Applications/CausalLM/api/model_pool.cpp
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   model_pool.cpp
+ * @brief  ModelPool implementation for multi-session inference
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Eunju Yang <ej.yang@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include "model_pool.h"
+#include "factory.h"
+#include "transformer.h"
+
+#include <iostream>
+
+namespace causallm {
+namespace api {
+
+ModelPool &ModelPool::Instance() {
+  static ModelPool pool;
+  return pool;
+}
+
+bool ModelPool::loadModel(const std::string &model_key,
+                          const std::string &architecture, nlohmann::json cfg,
+                          nlohmann::json generation_cfg,
+                          nlohmann::json nntr_cfg,
+                          const std::string &weight_path) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (pool_.find(model_key) != pool_.end()) {
+    return true;
+  }
+
+  PooledModel pm;
+  pm.model_key = model_key;
+  pm.architecture = architecture;
+  pm.cfg = std::move(cfg);
+  pm.generation_cfg = std::move(generation_cfg);
+  pm.nntr_cfg = std::move(nntr_cfg);
+  pm.weight_path = weight_path;
+  pm.ref_count = 0;
+
+  pool_[model_key] = std::move(pm);
+  return true;
+}
+
+std::unique_ptr<InferenceSession>
+ModelPool::createSession(const std::string &model_key) {
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = pool_.find(model_key);
+  if (it == pool_.end()) {
+    std::cerr << "[ModelPool] Model not loaded: " << model_key << std::endl;
+    return nullptr;
+  }
+
+  auto &pm = it->second;
+
+  auto model = Factory::Instance().create(pm.architecture, pm.cfg,
+                                          pm.generation_cfg, pm.nntr_cfg);
+  if (!model) {
+    std::cerr << "[ModelPool] Failed to create model instance for: "
+              << model_key << std::endl;
+    return nullptr;
+  }
+
+  try {
+    model->initialize();
+    model->load_weight(pm.weight_path);
+  } catch (const std::exception &e) {
+    std::cerr << "[ModelPool] Failed to initialize/load model: " << e.what()
+              << std::endl;
+    return nullptr;
+  }
+
+  auto session = std::make_unique<InferenceSession>();
+  session->id = next_session_id_++;
+  session->model_key = model_key;
+  session->model = std::move(model);
+  session->is_initialized = true;
+  session->created_at = std::chrono::steady_clock::now();
+
+  pm.ref_count++;
+
+  return session;
+}
+
+void ModelPool::releaseSession(InferenceSession *session) {
+  if (!session)
+    return;
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = pool_.find(session->model_key);
+  if (it != pool_.end()) {
+    it->second.ref_count--;
+    if (it->second.ref_count < 0) {
+      it->second.ref_count = 0;
+    }
+  }
+}
+
+bool ModelPool::isLoaded(const std::string &model_key) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return pool_.find(model_key) != pool_.end();
+}
+
+bool ModelPool::unloadModel(const std::string &model_key) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = pool_.find(model_key);
+  if (it == pool_.end()) {
+    return false;
+  }
+
+  if (it->second.ref_count > 0) {
+    std::cerr << "[ModelPool] Cannot unload model " << model_key
+              << ": still has " << it->second.ref_count << " active session(s)"
+              << std::endl;
+    return false;
+  }
+
+  pool_.erase(it);
+  return true;
+}
+
+} // namespace api
+} // namespace causallm

--- a/Applications/CausalLM/api/model_pool.h
+++ b/Applications/CausalLM/api/model_pool.h
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   model_pool.h
+ * @brief  Process-wide model pool for multi-session inference
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Eunju Yang <ej.yang@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __MODEL_POOL_H__
+#define __MODEL_POOL_H__
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include "inference_session.h"
+#include "json.hpp"
+
+namespace causallm {
+namespace api {
+
+/**
+ * @brief Manages loaded model templates and creates inference sessions
+ *
+ * ModelPool is a process-wide singleton that maintains a pool of loaded
+ * model templates. Each template stores the configuration needed to create
+ * independent model instances that share weights via OS page cache.
+ */
+class ModelPool {
+public:
+  /**
+   * @brief Model template stored in the pool
+   */
+  struct PooledModel {
+    std::string model_key;
+    std::string architecture;
+    nlohmann::json cfg;
+    nlohmann::json generation_cfg;
+    nlohmann::json nntr_cfg;
+    std::string weight_path;
+    int ref_count = 0;
+  };
+
+  /**
+   * @brief Get the process-wide ModelPool singleton
+   */
+  static ModelPool &Instance();
+
+  /**
+   * @brief Load a model template into the pool
+   *
+   * @param model_key Unique model key (e.g., "QWEN3-0.6B-W16A16")
+   * @param architecture Architecture name for Factory
+   * @param cfg Model configuration JSON
+   * @param generation_cfg Generation configuration JSON
+   * @param nntr_cfg NNTrainer configuration JSON
+   * @param weight_path Path to the weight binary file
+   * @return true if loaded successfully (or already loaded)
+   * @return false on error
+   */
+  bool loadModel(const std::string &model_key, const std::string &architecture,
+                 nlohmann::json cfg, nlohmann::json generation_cfg,
+                 nlohmann::json nntr_cfg, const std::string &weight_path);
+
+  /**
+   * @brief Create a new inference session for a loaded model
+   *
+   * Creates an independent Transformer instance from the template.
+   * Weights are loaded via load_weight(), leveraging OS page cache
+   * for sharing across sessions of the same model.
+   *
+   * @param model_key Model key in the pool
+   * @return Unique pointer to InferenceSession, or nullptr on error
+   */
+  std::unique_ptr<InferenceSession> createSession(const std::string &model_key);
+
+  /**
+   * @brief Release a session back to the pool
+   *
+   * Decrements the reference count. The session object is destroyed.
+   *
+   * @param session Pointer to the session being released
+   */
+  void releaseSession(InferenceSession *session);
+
+  /**
+   * @brief Check if a model template is loaded in the pool
+   */
+  bool isLoaded(const std::string &model_key) const;
+
+  /**
+   * @brief Unload a model template from the pool
+   *
+   * Only succeeds if ref_count is 0.
+   *
+   * @param model_key Model key to unload
+   * @return true if unloaded, false if not found or still in use
+   */
+  bool unloadModel(const std::string &model_key);
+
+private:
+  ModelPool() = default;
+  ~ModelPool() = default;
+
+  mutable std::mutex mutex_;
+  std::unordered_map<std::string, PooledModel> pool_;
+  int next_session_id_ = 1;
+};
+
+} // namespace api
+} // namespace causallm
+
+#endif // __MODEL_POOL_H__

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -6,18 +6,21 @@
  * @date   21 Jan 2026
  * @see    https://github.com/nntrainer/nntrainer
  * @author Eunju Yang <ej.yang@samsung.com>
- * @brief  Simple application to test CausalLM API
- * @bug    No known bugs except for NYI items
+ * @brief  Simple application to test CausalLM API with multi-thread support
  *
  */
 
 #include "causal_lm_api.h"
+#include <atomic>
+#include <chrono>
 #include <cmath>
 #include <cstring>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -29,7 +32,6 @@ constexpr const char *COLOR_YELLOW = "\033[33m";
 constexpr const char *COLOR_BLUE = "\033[34m";
 constexpr const char *COLOR_RED = "\033[31m";
 constexpr const char *COLOR_MAGENTA = "\033[35m";
-constexpr const char *COLOR_GRAY = "\033[90m";
 
 void printLine(const std::string &s, int length = 80) {
   for (int i = 0; i < length; ++i)
@@ -60,10 +62,6 @@ void printError(const std::string &msg) {
             << msg << "\n";
 }
 
-void printWarning(const std::string &msg) {
-  std::cout << COLOR_YELLOW << "⚠ " << msg << COLOR_RESET << "\n";
-}
-
 void printInfo(const std::string &label, const std::string &value) {
   std::cout << COLOR_CYAN << "  " << label << ":" << COLOR_RESET << " " << value
             << "\n";
@@ -89,15 +87,15 @@ void printLogo() {
 void printUsage(const char *program_name) {
   std::cout << COLOR_YELLOW << "Usage:" << COLOR_RESET << "\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
-            << " <model_name> [prompt] [use_chat_template] [quantization] "
-               "[verbose] \n\n";
+            << " <model_path> [num_threads] [use_chat_template] [quantization] "
+               "[verbose]\n\n";
 
   std::cout << COLOR_CYAN << "Arguments:" << COLOR_RESET << "\n";
-  std::cout << "  model_name        " << COLOR_BOLD << "REQUIRED" << COLOR_RESET
-            << "  - Model name (e.g., QWEN3-0.6B)\n";
-  std::cout << "  prompt            " << COLOR_GREEN << "OPTIONAL"
+  std::cout << "  model_path        " << COLOR_BOLD << "REQUIRED" << COLOR_RESET
+            << "  - Path to model directory (e.g., /path/to/qwen3-0.6b)\n";
+  std::cout << "  num_threads       " << COLOR_GREEN << "OPTIONAL"
             << COLOR_RESET
-            << "  - Input prompt (default: 'Hello, how are you?')\n";
+            << "  - Number of concurrent sessions (default: 4)\n";
   std::cout << "  use_chat_template " << COLOR_GREEN << "OPTIONAL"
             << COLOR_RESET << "  - 0/1 or true/false (default: 1)\n";
   std::cout << "  quantization      " << COLOR_GREEN << "OPTIONAL"
@@ -108,10 +106,20 @@ void printUsage(const char *program_name) {
 
   std::cout << COLOR_YELLOW << "Examples:" << COLOR_RESET << "\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
-            << " QWEN3-0.6B \"Tell me a joke\" 1 W4A32\n";
+            << " /path/to/qwen3-0.6b 4 1 W32A32\n";
   std::cout << "  " << COLOR_BOLD << program_name << COLOR_RESET
-            << " QWEN3-0.6B \"Write a poem\" 1 W32A32 1\n\n";
+            << " /path/to/qwen3-0.6b 8 0 UNKNOWN 1\n\n";
 }
+
+struct ThreadResult {
+  int thread_id;
+  std::string prompt;
+  std::string output;
+  ErrorCode error_code;
+  PerformanceMetrics metrics;
+  double elapsed_ms;
+};
+
 } // namespace
 
 int main(int argc, char *argv[]) {
@@ -123,8 +131,11 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  const char *model_name = argv[1];
-  const char *prompt = (argc >= 3) ? argv[2] : "Hello, how are you?";
+  const char *model_path = argv[1];
+  int num_threads = (argc >= 3) ? std::stoi(argv[2]) : 4;
+  if (num_threads <= 0)
+    num_threads = 4;
+
   bool use_chat_template = true;
   if (argc >= 4) {
     use_chat_template =
@@ -145,13 +156,14 @@ int main(int argc, char *argv[]) {
       quant_type = CAUSAL_LM_QUANTIZATION_W32A32;
   }
 
-  bool verbose = true;
+  bool verbose = false;
   if (argc >= 6) {
     verbose = (std::string(argv[5]) == "1" || std::string(argv[5]) == "true");
   }
 
   printSection("Configuration");
-  printInfo("Model Name", model_name);
+  printInfo("Model Path", model_path);
+  printInfo("Num Threads", std::to_string(num_threads));
   printInfo("Use Chat Template", use_chat_template ? "true" : "false");
   printInfo("Quantization", quant_str);
   printInfo("Verbose", verbose ? "true" : "false");
@@ -173,21 +185,10 @@ int main(int argc, char *argv[]) {
 
   printSection("Model Loading");
   std::cout << COLOR_CYAN << "⏳ " << COLOR_RESET
-            << "Loading model: " << COLOR_BOLD << model_name << COLOR_RESET
+            << "Loading model from: " << COLOR_BOLD << model_path << COLOR_RESET
             << "\n";
 
-  // Map string to ModelType
-  ModelType model_type = CAUSAL_LM_MODEL_QWEN3_0_6B;
-  std::string model_name_str(model_name);
-  if (model_name_str == "QWEN3-0.6B") {
-    model_type = CAUSAL_LM_MODEL_QWEN3_0_6B;
-  } else {
-    std::cout << COLOR_YELLOW << "⚠ Warning: Unknown model name '"
-              << model_name_str << "'. Defaulting to QWEN3-0.6B." << COLOR_RESET
-              << "\n";
-  }
-
-  err = loadModel(CAUSAL_LM_BACKEND_CPU, model_type, quant_type);
+  err = loadModelFromPath(CAUSAL_LM_BACKEND_CPU, model_path, quant_type);
 
   if (err != CAUSAL_LM_ERROR_NONE) {
     printError("Failed to load model");
@@ -196,176 +197,170 @@ int main(int argc, char *argv[]) {
   }
   printSuccess("Model loaded successfully");
 
-  printSection("Inference");
-  std::cout << COLOR_CYAN << "📝 " << COLOR_RESET << "Input Prompt:\n";
-  std::cout << COLOR_BOLD << COLOR_YELLOW << "  " << prompt << COLOR_RESET
-            << "\n\n";
+  // Different prompts for each thread
+  std::vector<std::string> prompts = {
+    "Hello! How are you today?",
+    "What is the capital of France?",
+    "Explain quantum computing in simple terms.",
+    "Write a haiku about technology.",
+    "What are the benefits of exercise?",
+    "Describe the taste of chocolate.",
+    "How do airplanes fly?",
+    "What is machine learning?",
+    "Tell me an interesting fact about space.",
+    "Why is the sky blue?",
+  };
 
-  std::cout << COLOR_CYAN << "⚡ " << COLOR_RESET << "Running inference...\n\n";
-
-  const char *outputText = nullptr;
-
-  if (verbose) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Streaming Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GRAY;
+  if (num_threads > (int)prompts.size()) {
+    size_t original_size = prompts.size();
+    for (int i = original_size; i < num_threads; ++i) {
+      prompts.push_back(prompts[i % original_size]);
+    }
   }
 
-  err = runModel(prompt, &outputText);
+  printSection("Multi-Threaded Inference Test");
+  std::cout << COLOR_CYAN << "⏳ " << COLOR_RESET << "Creating " << num_threads
+            << " sessions and running concurrently...\n\n";
 
-  if (verbose) {
-    std::cout << COLOR_RESET << "\n\n";
-  }
+  std::vector<ThreadResult> results(num_threads);
+  std::vector<std::thread> threads;
+  std::atomic<int> completed_count{0};
 
-  if (err != CAUSAL_LM_ERROR_NONE) {
-    printError("Failed to run model");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-    return 1;
-  }
+  auto start_all = std::chrono::high_resolution_clock::now();
 
-  if (outputText) {
-    std::cout << COLOR_CYAN << "💬 " << COLOR_RESET << "Output:\n";
-    std::cout << COLOR_BOLD << COLOR_GREEN << "  ";
-    std::string out(outputText);
-    size_t pos = 0;
-    while (pos < out.length()) {
-      size_t newlinePos = out.find('\n', pos);
-      if (newlinePos == std::string::npos) {
-        newlinePos = out.length();
+  for (int i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&, i]() {
+      SessionHandle session = 0;
+      ErrorCode err = createSessionFromPath(&session, CAUSAL_LM_BACKEND_CPU,
+                                            model_path, quant_type);
+      if (err != CAUSAL_LM_ERROR_NONE) {
+        results[i].thread_id = i;
+        results[i].error_code = err;
+        results[i].prompt = prompts[i];
+        std::cerr << COLOR_RED << "✗ Thread " << i
+                  << ": Failed to create session (error="
+                  << static_cast<int>(err) << ")" << COLOR_RESET << "\n";
+        return;
       }
-      std::string line = out.substr(pos, newlinePos - pos);
-      std::cout << line;
-      if (newlinePos < out.length()) {
-        std::cout << "\n  ";
-        pos = newlinePos + 1;
+
+      const std::string &prompt = prompts[i];
+      results[i].thread_id = i;
+      results[i].prompt = prompt;
+      results[i].error_code = CAUSAL_LM_ERROR_NONE;
+
+      std::string out_filename =
+        std::string("session") + std::to_string(i) + ".txt";
+      std::ofstream out_file(out_filename);
+
+      auto start = std::chrono::high_resolution_clock::now();
+
+      const char *output = nullptr;
+      err = runSession(session, prompt.c_str(), &output);
+
+      auto end = std::chrono::high_resolution_clock::now();
+      results[i].elapsed_ms =
+        std::chrono::duration<double, std::milli>(end - start).count();
+
+      if (err == CAUSAL_LM_ERROR_NONE && output) {
+        results[i].output = std::string(output);
       } else {
-        pos = out.length();
+        results[i].error_code = err;
       }
-    }
-    std::cout << COLOR_RESET << "\n\n";
-  } else {
-    printWarning("No output generated");
+
+      PerformanceMetrics metrics;
+      err = getSessionMetrics(session, &metrics);
+      if (err == CAUSAL_LM_ERROR_NONE) {
+        results[i].metrics = metrics;
+      }
+
+      if (out_file.is_open()) {
+        out_file << "Session: " << i << "\n";
+        out_file << "Prompt: " << prompt << "\n\n";
+        if (results[i].error_code == CAUSAL_LM_ERROR_NONE) {
+          out_file << "Output:\n" << results[i].output << "\n\n";
+          out_file << "Performance Metrics:\n";
+          out_file << "  Prefill tokens: " << metrics.prefill_tokens << "\n";
+          out_file << "  Prefill duration: " << std::fixed
+                   << std::setprecision(2) << metrics.prefill_duration_ms
+                   << " ms\n";
+          out_file << "  Generation tokens: " << metrics.generation_tokens
+                   << "\n";
+          out_file << "  Generation duration: " << std::fixed
+                   << std::setprecision(2) << metrics.generation_duration_ms
+                   << " ms\n";
+          out_file << "  Total duration: " << std::fixed << std::setprecision(2)
+                   << metrics.total_duration_ms << " ms\n";
+          out_file << "  Peak memory: " << metrics.peak_memory_kb / 1024
+                   << " MB\n";
+          out_file << "  Thread elapsed: " << std::fixed << std::setprecision(2)
+                   << results[i].elapsed_ms << " ms\n";
+        } else {
+          out_file << "Error: Inference failed (code="
+                   << static_cast<int>(results[i].error_code) << ")\n";
+        }
+        out_file.close();
+      }
+
+      int completed = ++completed_count;
+      std::cout << COLOR_GREEN << "✓ Thread " << i << " completed ("
+                << completed << "/" << num_threads << ")" << COLOR_RESET
+                << " -> " << out_filename << "\n";
+
+      destroySession(session);
+    });
   }
 
-  printSection("Performance Metrics");
-  PerformanceMetrics metrics;
-  err = getPerformanceMetrics(&metrics);
-  if (err != CAUSAL_LM_ERROR_NONE) {
-    printWarning("Failed to get metrics");
-    std::cout << "  Error code: " << static_cast<int>(err) << "\n";
-  } else {
-    double prefill_tps =
-      metrics.prefill_duration_ms > 0
-        ? (metrics.prefill_tokens / metrics.prefill_duration_ms * 1000.0)
-        : 0.0;
-    double gen_tps =
-      metrics.generation_duration_ms > 0
-        ? (metrics.generation_tokens / metrics.generation_duration_ms * 1000.0)
-        : 0.0;
-
-    std::cout << COLOR_CYAN << "  📊 " << COLOR_RESET << COLOR_BOLD
-              << "Prefill Stage" << COLOR_RESET << "\n";
-    std::cout << COLOR_CYAN << "    Tokens:" << COLOR_RESET << "       "
-              << metrics.prefill_tokens << "\n";
-    std::cout << COLOR_CYAN << "    Duration:" << COLOR_RESET << "     "
-              << std::fixed << std::setprecision(2)
-              << metrics.prefill_duration_ms << " ms\n";
-    std::cout << COLOR_CYAN << "    Throughput:" << COLOR_RESET << "   "
-              << COLOR_BOLD << COLOR_GREEN << std::fixed << std::setprecision(1)
-              << prefill_tps << COLOR_RESET << " tokens/sec\n\n";
-
-    std::cout << COLOR_CYAN << "  📊 " << COLOR_RESET << COLOR_BOLD
-              << "Generation Stage" << COLOR_RESET << "\n";
-    std::cout << COLOR_CYAN << "    Tokens:" << COLOR_RESET << "       "
-              << metrics.generation_tokens << "\n";
-    std::cout << COLOR_CYAN << "    Duration:" << COLOR_RESET << "     "
-              << std::fixed << std::setprecision(2)
-              << metrics.generation_duration_ms << " ms\n";
-    std::cout << COLOR_CYAN << "    Throughput:" << COLOR_RESET << "   "
-              << COLOR_BOLD << COLOR_GREEN << std::fixed << std::setprecision(1)
-              << gen_tps << COLOR_RESET << " tokens/sec\n\n";
-
-    std::cout << COLOR_CYAN << "  📊 " << COLOR_RESET << COLOR_BOLD
-              << "Total Stats" << COLOR_RESET << "\n";
-    std::cout << COLOR_CYAN << "    Init time:" << COLOR_RESET << "    "
-              << std::fixed << std::setprecision(2)
-              << metrics.initialization_duration_ms << " ms\n";
-    std::cout << COLOR_CYAN << "    Duration :" << COLOR_RESET << "    "
-              << std::fixed << std::setprecision(2) << metrics.total_duration_ms
-              << " ms\n";
-    std::cout << COLOR_CYAN << "    Peak Mem:" << COLOR_RESET << "     "
-              << metrics.peak_memory_kb / 1024 << " MB\n\n";
+  for (auto &t : threads) {
+    t.join();
   }
 
-  printLine("═", 63);
-  std::cout << COLOR_BOLD << COLOR_GREEN << "  ✓ Test completed successfully!"
-            << COLOR_RESET << "\n";
-  printLine("═", 63);
-  std::cout << "\n";
+  auto end_all = std::chrono::high_resolution_clock::now();
+  double total_elapsed_ms =
+    std::chrono::duration<double, std::milli>(end_all - start_all).count();
 
-  // Multi-session test
-  printSection("Multi-Session Test");
-  std::cout << COLOR_CYAN << "⏳ " << COLOR_RESET
-            << "Creating multiple independent sessions...\n";
+  printSection("Results Summary");
+  std::cout << COLOR_CYAN << "  Total elapsed time: " << COLOR_RESET
+            << std::fixed << std::setprecision(2) << total_elapsed_ms
+            << " ms\n";
+  std::cout << COLOR_CYAN << "  Number of sessions: " << COLOR_RESET
+            << num_threads << "\n";
+  std::cout << COLOR_CYAN << "  Average per session: " << COLOR_RESET
+            << std::fixed << std::setprecision(2)
+            << total_elapsed_ms / num_threads << " ms\n\n";
 
-  SessionHandle session1 = 0, session2 = 0;
-  err = createSession(&session1, CAUSAL_LM_BACKEND_CPU, model_type, quant_type);
-  if (err != CAUSAL_LM_ERROR_NONE) {
-    printError("Failed to create session 1");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-  } else {
-    printSuccess("Session 1 created");
-  }
+  for (int i = 0; i < num_threads; ++i) {
+    const auto &r = results[i];
+    std::cout << "  " << COLOR_BOLD << "Session " << i << ":" << COLOR_RESET
+              << "\n";
+    std::cout << "    Prompt: " << COLOR_YELLOW << r.prompt << COLOR_RESET
+              << "\n";
+    if (r.error_code == CAUSAL_LM_ERROR_NONE) {
+      double prefill_tps =
+        r.metrics.prefill_duration_ms > 0
+          ? (r.metrics.prefill_tokens / r.metrics.prefill_duration_ms * 1000.0)
+          : 0.0;
+      double gen_tps = r.metrics.generation_duration_ms > 0
+                         ? (r.metrics.generation_tokens /
+                            r.metrics.generation_duration_ms * 1000.0)
+                         : 0.0;
 
-  err = createSession(&session2, CAUSAL_LM_BACKEND_CPU, model_type, quant_type);
-  if (err != CAUSAL_LM_ERROR_NONE) {
-    printError("Failed to create session 2");
-    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
-  } else {
-    printSuccess("Session 2 created");
-  }
-
-  if (session1 && session2) {
-    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
-              << "Running inference on session 1...\n";
-    const char *out1 = nullptr;
-    err = runSession(session1, prompt, &out1);
-    if (err == CAUSAL_LM_ERROR_NONE && out1) {
-      std::cout << COLOR_GREEN << "  Output: " << COLOR_RESET << out1 << "\n";
+      std::cout << "    Tokens: " << r.metrics.generation_tokens
+                << " (prefill: " << r.metrics.prefill_tokens << ")\n";
+      std::cout << "    Throughput: " << std::fixed << std::setprecision(1)
+                << prefill_tps << " / " << gen_tps << " tokens/sec\n";
+      std::cout << "    Duration: " << std::fixed << std::setprecision(2)
+                << r.elapsed_ms << " ms\n";
+      std::cout << "    Output file: session" << i << ".txt\n";
     } else {
-      printError("Session 1 inference failed");
+      std::cout << "    " << COLOR_RED
+                << "FAILED (error=" << static_cast<int>(r.error_code) << ")"
+                << COLOR_RESET << "\n";
     }
-
-    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
-              << "Running inference on session 2...\n";
-    const char *out2 = nullptr;
-    err = runSession(session2, prompt, &out2);
-    if (err == CAUSAL_LM_ERROR_NONE && out2) {
-      std::cout << COLOR_GREEN << "  Output: " << COLOR_RESET << out2 << "\n";
-    } else {
-      printError("Session 2 inference failed");
-    }
-
-    PerformanceMetrics metrics1;
-    err = getSessionMetrics(session1, &metrics1);
-    if (err == CAUSAL_LM_ERROR_NONE) {
-      std::cout << COLOR_CYAN << "  Session 1 tokens: " << COLOR_RESET
-                << metrics1.generation_tokens << "\n";
-    }
-
-    PerformanceMetrics metrics2;
-    err = getSessionMetrics(session2, &metrics2);
-    if (err == CAUSAL_LM_ERROR_NONE) {
-      std::cout << COLOR_CYAN << "  Session 2 tokens: " << COLOR_RESET
-                << metrics2.generation_tokens << "\n";
-    }
-
-    destroySession(session1);
-    destroySession(session2);
-    printSuccess("Multi-session test completed");
+    std::cout << "\n";
   }
 
   printLine("═", 63);
-  std::cout << COLOR_BOLD << COLOR_GREEN << "  ✓ All tests completed!"
+  std::cout << COLOR_BOLD << COLOR_GREEN << "  ✓ Multi-threaded test completed!"
             << COLOR_RESET << "\n";
   printLine("═", 63);
   std::cout << "\n";

--- a/Applications/CausalLM/api/test_api.cpp
+++ b/Applications/CausalLM/api/test_api.cpp
@@ -302,5 +302,73 @@ int main(int argc, char *argv[]) {
   printLine("═", 63);
   std::cout << "\n";
 
+  // Multi-session test
+  printSection("Multi-Session Test");
+  std::cout << COLOR_CYAN << "⏳ " << COLOR_RESET
+            << "Creating multiple independent sessions...\n";
+
+  SessionHandle session1 = 0, session2 = 0;
+  err = createSession(&session1, CAUSAL_LM_BACKEND_CPU, model_type, quant_type);
+  if (err != CAUSAL_LM_ERROR_NONE) {
+    printError("Failed to create session 1");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+  } else {
+    printSuccess("Session 1 created");
+  }
+
+  err = createSession(&session2, CAUSAL_LM_BACKEND_CPU, model_type, quant_type);
+  if (err != CAUSAL_LM_ERROR_NONE) {
+    printError("Failed to create session 2");
+    std::cerr << "  Error code: " << static_cast<int>(err) << "\n";
+  } else {
+    printSuccess("Session 2 created");
+  }
+
+  if (session1 && session2) {
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+              << "Running inference on session 1...\n";
+    const char *out1 = nullptr;
+    err = runSession(session1, prompt, &out1);
+    if (err == CAUSAL_LM_ERROR_NONE && out1) {
+      std::cout << COLOR_GREEN << "  Output: " << COLOR_RESET << out1 << "\n";
+    } else {
+      printError("Session 1 inference failed");
+    }
+
+    std::cout << COLOR_CYAN << "📝 " << COLOR_RESET
+              << "Running inference on session 2...\n";
+    const char *out2 = nullptr;
+    err = runSession(session2, prompt, &out2);
+    if (err == CAUSAL_LM_ERROR_NONE && out2) {
+      std::cout << COLOR_GREEN << "  Output: " << COLOR_RESET << out2 << "\n";
+    } else {
+      printError("Session 2 inference failed");
+    }
+
+    PerformanceMetrics metrics1;
+    err = getSessionMetrics(session1, &metrics1);
+    if (err == CAUSAL_LM_ERROR_NONE) {
+      std::cout << COLOR_CYAN << "  Session 1 tokens: " << COLOR_RESET
+                << metrics1.generation_tokens << "\n";
+    }
+
+    PerformanceMetrics metrics2;
+    err = getSessionMetrics(session2, &metrics2);
+    if (err == CAUSAL_LM_ERROR_NONE) {
+      std::cout << COLOR_CYAN << "  Session 2 tokens: " << COLOR_RESET
+                << metrics2.generation_tokens << "\n";
+    }
+
+    destroySession(session1);
+    destroySession(session2);
+    printSuccess("Multi-session test completed");
+  }
+
+  printLine("═", 63);
+  std::cout << COLOR_BOLD << COLOR_GREEN << "  ✓ All tests completed!"
+            << COLOR_RESET << "\n";
+  printLine("═", 63);
+  std::cout << "\n";
+
   return 0;
 }

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -5,6 +5,7 @@ causallm_src = [
     meson.current_source_dir() / 'api' / 'causal_lm_api.cpp',
     meson.current_source_dir() / 'api' / 'model_config.cpp',
     meson.current_source_dir() / 'kv_cache_manager.cpp',
+    meson.current_source_dir() / 'api' / 'model_pool.cpp',
 ]
 
 executable_src = [

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -3,6 +3,7 @@ causallm_src = [
     meson.current_source_dir() / 'huggingface_tokenizer.cpp',
     meson.current_source_dir() / 'llm_util.cpp',
     meson.current_source_dir() / 'api' / 'causal_lm_api.cpp',
+    meson.current_source_dir() / 'api' / 'inference_dispatcher.cpp',
     meson.current_source_dir() / 'api' / 'model_config.cpp',
     meson.current_source_dir() / 'kv_cache_manager.cpp',
     meson.current_source_dir() / 'api' / 'model_pool.cpp',


### PR DESCRIPTION
Dependency of the PR
Commits to be reviewed in this PR
<details><summary>Phase 1: Add InferenceSession and ModelPool for multi-session support</summary><br />
Phase 1: Add InferenceSession and ModelPool for multi-session support
- Create InferenceSession struct for independent per-session state
- Create ModelPool singleton to manage loaded model templates
- ModelPool::createSession() creates independent Transformer instances
  from templates, sharing weights via OS page cache
- ModelPool tracks ref_count for safe unload
- Add model_pool.cpp to meson build
Self evaluation:
1. Build test: XPassed  Failed  Skipped
2. Run test: XPassed  Failed  Skipped
Signed-off-by: Junbong Yu <junbong.yu@samsung.com>
</details>
<details><summary>Phase 2: Integrate ModelPool into existing C API</summary><br />
Phase 2: Integrate ModelPool into existing C API
- Replace g_model with g_default_session (InferenceSession)
- loadModel() now loads template into ModelPool and creates default session
- runModel() uses g_default_session->model (backward compatible)
- getPerformanceMetrics() uses g_default_session
- Maintains existing single-session behavior with mutex protection
- Prepares foundation for multi-session API in Phase 4
Self evaluation:
1. Build test: XPassed  Failed  Skipped
2. Run test: XPassed  Failed  Skipped
Signed-off-by: Junbong Yu <junbong.yu@samsung.com>
</details>
<details><summary>Phase 3: Add InferenceDispatcher with thread pool for async inference</summary><br />
Phase 3: Add InferenceDispatcher with thread pool for async inference
- Create InferenceDispatcher singleton wrapping BS::thread_pool
- submit() creates independent session, runs inference async, returns future
- runSync() synchronous wrapper for blocking inference
- Each dispatched task: createSession -> run -> releaseSession
- Uses hardware_concurrency() for default thread count
- Supports configurable thread count via setThreadCount()
Self evaluation:
1. Build test: XPassed  Failed  Skipped
2. Run test: XPassed  Failed  Skipped
Signed-off-by: Junbong Yu <junbong.yu@samsung.com>
</details>
<details><summary>Phase 4: Add session-based C API for multi-threaded inference</summary><br />
Phase 4: Add session-based C API for multi-threaded inference
- New API functions in causal_lm_api.h:
  - createSession(): Creates independent inference session from ModelPool
  - runSession(): Synchronous inference on a specific session
  - runSessionAsync(): Async inference returning requestId
  - awaitResult(): Blocks and retrieves async inference result
  - getSessionMetrics(): Per-session performance metrics
  - destroySession(): Cleans up session resources
- Each session has independent model instance (thread-safe concurrent run)
- Sessions share model weights via OS page cache
- Existing loadModel/runModel API remains backward compatible
- Add last_output to InferenceSession for session-local output storage
Self evaluation:
1. Build test: XPassed  Failed  Skipped
2. Run test: XPassed  Failed  Skipped
Signed-off-by: Junbong Yu <junbong.yu@samsung.com>
</details>
<details><summary>Phase 5: Add multi-session test to test_api.cpp</summary><br />
Phase 5: Add multi-session test to test_api.cpp
- Extend test_api to verify session-based API functionality
- Creates two independent sessions after legacy API test
- Runs inference on both sessions sequentially
- Retrieves per-session performance metrics
- Validates backward compatibility: existing test flow unchanged
Self evaluation:
1. Build test: XPassed  Failed  Skipped
2. Run test: XPassed  Failed  Skipped
Signed-off-by: Junbong Yu <junbong.yu@samsung.com>
</details>
<details><summary>feat(api): add path-based model loading and multi-threaded test</summary><br />
feat(api): add path-based model loading and multi-threaded test
- Add loadModelFromPath() to load models from custom directory paths
- Add createSessionFromPath() to create sessions from loaded path-based models
- Refactor test_api.cpp to use model paths instead of hardcoded model names
- Implement multi-threaded concurrent inference test with per-session output files
- test_api example run:
  ./build/Applications/CausalLM/test_api { model dir paht (eg, qwen3-0.6b) } 2 1 W32A32 0
Self evaluation:
1. Build test: XPassed  Failed  Skipped
2. Run test: XPassed  Failed  Skipped
Signed-off-by: Junbong Yu <junbong.yu@samsung.com>
</details>
Summary
- Phase 1: Introduce InferenceSession and ModelPool for managing independent session states while sharing model weights via OS page cache
- Phase 2: Integrate ModelPool into existing C API (causal_lm_api.cpp) without breaking backward compatibility
- Phase 3: Add InferenceDispatcher with thread pool to support asynchronous inference dispatch
- Phase 4: Add session-based C API (createSession, runSession, runSessionAsync, etc.) for multi-threaded concurrent inference
- Phase 5: Extend test_api.cpp with multi-session test to validate session-based API
- feat(api): Add path-based model loading (loadModelFromPath, createSessionFromPath) and implement multi-threaded concurrent inference test
Signed-off-by: Junbong Yu <junbong.yu@samsung.com>