### PR TITLE
[Wait 4 #3834] [x86] feat: Add AVX2 FP16 implementation for x86 CPU Backend

### DIFF
--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -33,6 +33,8 @@
 /usr/include/nntrainer/weight.h
 /usr/include/nntrainer/quantizer.h
 /usr/include/nntrainer/avx2_impl.h
+/usr/include/nntrainer/avx2_mathfun.h
+/usr/include/nntrainer/avx2_mathfun.hxx
 # todo: update dataset headers
 /usr/include/nntrainer/databuffer.h
 /usr/include/nntrainer/databuffer_factory.h

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -409,9 +409,18 @@ void __fallback_calc_trigonometric_vals_dup(unsigned int N_half, float *angle,
                                             float *cos_, float *sin_,
                                             unsigned int from,
                                             float attention_scaling) {
-  throw std::runtime_error(
-    "Error: No implementation of rotary embedding layer incremental_forwarding "
-    "with SIMD acceleration except for NEON!");
+  const float from_f = static_cast<float>(from);
+  for (unsigned int i = 0; i < N_half; ++i) {
+    const float a = from_f * angle[i];
+    cos_[i] = std::cos(a) * attention_scaling;
+    sin_[i] = std::sin(a) * attention_scaling;
+  }
+  const unsigned int N = 2 * N_half;
+  for (unsigned int j = N_half, j_half = 0; j < N && j_half < N_half;
+       ++j, ++j_half) {
+    cos_[j] = cos_[j_half];
+    sin_[j] = sin_[j_half];
+  }
 }
 
 void __fallback_swiglu(const unsigned int N, float *X, float *Y, float *Z) {

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -19,13 +19,13 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <fallback_internal.h>
 #include <fp16.h>
 #include <immintrin.h>
 #include <limits>
-#include <type_traits>
-#include <fallback_internal.h>
 #include <nntrainer_error.h>
 #include <thread_manager.h>
+#include <type_traits>
 #include <util_func.h>
 #include <vector>
 
@@ -731,8 +731,8 @@ void swiglu(const unsigned int N, float *X, const float *Y, const float *Z,
 }
 
 // poly_gelu_tanh_avx2 / poly_gelu_erf_avx2 are defined in avx2_internal.h
-using nntrainer::avx2::internal::poly_gelu_tanh_avx2;
 using nntrainer::avx2::internal::poly_gelu_erf_avx2;
+using nntrainer::avx2::internal::poly_gelu_tanh_avx2;
 
 // exp256_ps, hsum_avx, rcp_ps are also in avx2_internal.h
 using nntrainer::avx2::internal::exp256_ps;

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -328,6 +328,10 @@ avx2_approx_swiglu_alpha(__m256 x, __m256 s, __m256 alpha) noexcept -> __m256 {
 
 namespace nntrainer::avx2 {
 
+// Forward declarations for internal helpers used across the file
+static inline __m256 exp256_ps(__m256 x);
+static float hsum_avx(__m256 v);
+
 /**
  * @brief struct of q4_0x8 block
  */
@@ -701,16 +705,25 @@ static inline void convert_q4_0x8_noshuffle(const void *src,
 
 // ================== wrappers for your K,N combinations ==================
 // K = 3072 (UNIT = 768)
+/**
+ * @brief convert_q4_0x8_shuffle for K=3072 N=98304
+ */
 void convert_q4_0x8_shuffle_K3072_N98304(const void *src, uint16_t *d_out,
                                          uint8_t *qs_out) {
   // groups = (N*8)/UNIT = 1024
   convert_q4_0x8_noshuffle<768, 1024>(src, d_out, qs_out);
 }
+/**
+ * @brief convert_q4_0x8_shuffle for K=3072 N=36864
+ */
 void convert_q4_0x8_shuffle_K3072_N36864(const void *src, uint16_t *d_out,
                                          uint8_t *qs_out) {
   // groups = 384
   convert_q4_0x8_noshuffle<768, 384>(src, d_out, qs_out);
 }
+/**
+ * @brief convert_q4_0x8_shuffle for K=3072 N=3072
+ */
 void convert_q4_0x8_shuffle_K3072_N3072(const void *src, uint16_t *d_out,
                                         uint8_t *qs_out) {
   // groups = 32
@@ -718,16 +731,25 @@ void convert_q4_0x8_shuffle_K3072_N3072(const void *src, uint16_t *d_out,
 }
 
 // K = 8192 (UNIT = 2048)
+/**
+ * @brief convert_q4_0x8_shuffle for K=8192 N=98304
+ */
 void convert_q4_0x8_shuffle_K8192_N98304(const void *src, uint16_t *d_out,
                                          uint8_t *qs_out) {
   // groups = 384
   convert_q4_0x8_noshuffle<2048, 384>(src, d_out, qs_out);
 }
+/**
+ * @brief convert_q4_0x8_shuffle for K=8192 N=36864
+ */
 void convert_q4_0x8_shuffle_K8192_N36864(const void *src, uint16_t *d_out,
                                          uint8_t *qs_out) {
   // groups = 144
   convert_q4_0x8_noshuffle<2048, 144>(src, d_out, qs_out);
 }
+/**
+ * @brief convert_q4_0x8_shuffle for K=8192 N=3072
+ */
 void convert_q4_0x8_shuffle_K8192_N3072(const void *src, uint16_t *d_out,
                                         uint8_t *qs_out) {
   // groups = 12
@@ -1140,6 +1162,223 @@ void gelu_v2(const unsigned int N, const float *X, float *Y) {
   }
 }
 
+void tanh_gelu(const unsigned int N, const float *X, float *Y) {
+  unsigned int i = 0;
+
+  for (; i + 8 <= N; i += 8) {
+    __m256 x = _mm256_loadu_ps(&X[i]);
+    __m256 y = poly_gelu_tanh_avx2(x);
+    _mm256_storeu_ps(&Y[i], y);
+  }
+
+  for (; i < N; ++i) {
+    const float x = X[i];
+    Y[i] = 0.5f * x *
+           (1.0f + std::tanh(0.7978845608f * (x + 0.044715f * x * x * x)));
+  }
+}
+
+void tanh_gelu_mul(const unsigned int N, float *X, float *Y, float *Z) {
+  unsigned int i = 0;
+
+  for (; i + 8 <= N; i += 8) {
+    __m256 y = _mm256_loadu_ps(&Y[i]);
+    __m256 g = poly_gelu_tanh_avx2(y);
+    __m256 z = _mm256_loadu_ps(&Z[i]);
+    _mm256_storeu_ps(&X[i], _mm256_mul_ps(g, z));
+  }
+
+  for (; i < N; ++i) {
+    const float y = Y[i];
+    float gelu_y =
+      0.5f * y *
+      (1.0f + std::tanh(0.7978845608f * (y + 0.044715f * y * y * y)));
+    X[i] = gelu_y * Z[i];
+  }
+}
+
+void tanh_gelu_v2_mul(const unsigned int N, float *X, float *Y, float *Z) {
+  tanh_gelu_mul(N, X, Y, Z);
+}
+
+float max_val(const unsigned int N, float *X) {
+  unsigned int i = 0;
+  __m256 vmax = _mm256_set1_ps(-std::numeric_limits<float>::infinity());
+
+  for (; i + 8 <= N; i += 8) {
+    __m256 x = _mm256_loadu_ps(&X[i]);
+    vmax = _mm256_max_ps(vmax, x);
+  }
+
+  // Horizontal max reduction
+  __m128 hi = _mm256_extractf128_ps(vmax, 1);
+  __m128 lo = _mm256_castps256_ps128(vmax);
+  lo = _mm_max_ps(lo, hi);
+  __m128 shuf = _mm_movehl_ps(lo, lo);
+  lo = _mm_max_ps(lo, shuf);
+  shuf = _mm_movehdup_ps(lo);
+  lo = _mm_max_ss(lo, shuf);
+  float result = _mm_cvtss_f32(lo);
+
+  for (; i < N; ++i) {
+    result = std::max(result, X[i]);
+  }
+  return result;
+}
+
+void softmax(const unsigned int N, float *X, float *Y) {
+  // Step 1: find max
+  float max_x = max_val(N, X);
+  __m256 vmax = _mm256_set1_ps(max_x);
+
+  // Step 2: exp(x - max) and accumulate sum
+  unsigned int i = 0;
+  unsigned int N8 = (N & ~(7));
+  __m256 vsum = _mm256_setzero_ps();
+
+  for (; i < N8; i += 8) {
+    __m256 x = _mm256_loadu_ps(&X[i]);
+    __m256 e = exp256_ps(_mm256_sub_ps(x, vmax));
+    _mm256_storeu_ps(&Y[i], e);
+    vsum = _mm256_add_ps(vsum, e);
+  }
+
+  float sum = hsum_avx(vsum);
+  for (; i < N; ++i) {
+    float e = std::exp(X[i] - max_x);
+    Y[i] = e;
+    sum += e;
+  }
+
+  // Step 3: normalize
+  float inv_sum = 1.0f / sum;
+  __m256 vinv = _mm256_set1_ps(inv_sum);
+
+  i = 0;
+  for (; i < N8; i += 8) {
+    __m256 y = _mm256_loadu_ps(&Y[i]);
+    _mm256_storeu_ps(&Y[i], _mm256_mul_ps(y, vinv));
+  }
+  for (; i < N; ++i) {
+    Y[i] *= inv_sum;
+  }
+}
+
+void inv_sqrt_inplace(const unsigned int N, float *X) {
+  unsigned int i = 0;
+  const __m256 zero = _mm256_setzero_ps();
+  const __m256 inf_val = _mm256_set1_ps(INFINITY);
+  const __m256 three_half = _mm256_set1_ps(1.5f);
+  const __m256 half = _mm256_set1_ps(0.5f);
+
+  for (; i + 8 <= N; i += 8) {
+    __m256 x = _mm256_loadu_ps(&X[i]);
+    __m256 is_zero = _mm256_cmp_ps(x, zero, _CMP_EQ_OQ);
+    __m256 est = _mm256_rsqrt_ps(x);
+    // Newton-Raphson: y = y * (1.5 - 0.5 * x * y * y)
+    __m256 half_x = _mm256_mul_ps(half, x);
+    __m256 yy = _mm256_mul_ps(est, est);
+    __m256 refined =
+      _mm256_mul_ps(est, _mm256_fnmadd_ps(half_x, yy, three_half));
+    refined = _mm256_blendv_ps(refined, inf_val, is_zero);
+    _mm256_storeu_ps(&X[i], refined);
+  }
+
+  for (; i < N; ++i) {
+    X[i] = 1.0f / std::sqrt(X[i]);
+  }
+}
+
+void sine(const unsigned int N, float *X, float *Y, float alpha, float beta) {
+  unsigned int i = 0;
+  const __m256 v_alpha = _mm256_set1_ps(alpha);
+  const __m256 v_beta = _mm256_set1_ps(beta);
+  const bool need_alpha = (alpha != 1.0f);
+  const bool need_beta = (beta != 1.0f);
+
+  for (; i + 8 <= N; i += 8) {
+    __m256 x = _mm256_loadu_ps(&X[i]);
+    if (need_alpha)
+      x = _mm256_mul_ps(x, v_alpha);
+    __m256 result = sin256_ps(x);
+    if (need_beta)
+      result = _mm256_mul_ps(result, v_beta);
+    _mm256_storeu_ps(&Y[i], result);
+  }
+
+  for (; i < N; ++i) {
+    Y[i] =
+      std::sin(static_cast<float>(alpha) * X[i]) * static_cast<float>(beta);
+  }
+}
+
+void cosine(const unsigned int N, float *X, float *Y, float alpha, float beta) {
+  unsigned int i = 0;
+  const __m256 v_alpha = _mm256_set1_ps(alpha);
+  const __m256 v_beta = _mm256_set1_ps(beta);
+  const bool need_alpha = (alpha != 1.0f);
+  const bool need_beta = (beta != 1.0f);
+
+  for (; i + 8 <= N; i += 8) {
+    __m256 x = _mm256_loadu_ps(&X[i]);
+    if (need_alpha)
+      x = _mm256_mul_ps(x, v_alpha);
+    __m256 result = cos256_ps(x);
+    if (need_beta)
+      result = _mm256_mul_ps(result, v_beta);
+    _mm256_storeu_ps(&Y[i], result);
+  }
+
+  for (; i < N; ++i) {
+    Y[i] =
+      std::cos(static_cast<float>(alpha) * X[i]) * static_cast<float>(beta);
+  }
+}
+
+void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
+                                 float *sin_, unsigned int from,
+                                 float attention_scaling) {
+  unsigned int i = 0;
+  const __m256 v_from = _mm256_set1_ps(static_cast<float>(from));
+  const __m256 v_scale = _mm256_set1_ps(attention_scaling);
+  const bool need_scale = (attention_scaling != 1.0f);
+
+  for (; i + 8 <= N_half; i += 8) {
+    __m256 x = _mm256_loadu_ps(&angle[i]);
+    x = _mm256_mul_ps(x, v_from);
+    __m256 s, c;
+    sincos256_ps(x, &s, &c);
+    if (need_scale) {
+      s = _mm256_mul_ps(s, v_scale);
+      c = _mm256_mul_ps(c, v_scale);
+    }
+    _mm256_storeu_ps(&cos_[i], c);
+    _mm256_storeu_ps(&sin_[i], s);
+  }
+
+  for (; i < N_half; ++i) {
+    cos_[i] = std::cos(static_cast<float>(from) * angle[i]) * attention_scaling;
+    sin_[i] = std::sin(static_cast<float>(from) * angle[i]) * attention_scaling;
+  }
+
+  unsigned int N = 2 * N_half;
+
+  // Copy first half to second half (duplicate)
+  unsigned int j = N_half;
+  unsigned int j_half = 0;
+
+  for (; j + 8 <= N && j_half + 8 <= N_half; j += 8, j_half += 8) {
+    __m256 c = _mm256_loadu_ps(&cos_[j_half]);
+    __m256 s = _mm256_loadu_ps(&sin_[j_half]);
+    _mm256_storeu_ps(&cos_[j], c);
+    _mm256_storeu_ps(&sin_[j], s);
+  }
+  for (; j < N && j_half < N_half; ++j, ++j_half) {
+    cos_[j] = cos_[j_half];
+    sin_[j] = sin_[j_half];
+  }
+}
+
 void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
@@ -1174,12 +1413,53 @@ void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
       Z++;
     }
   } else {
-    // TODO: AVX2 implementation if used
-    for (unsigned int i = 0; i < N; ++i) {
-      *Z = *X * alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
-      X += o_stride;
-      Y += i_stride;
-      Z += o_stride;
+    if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+      unsigned int N8 = (N & ~(7));
+      auto alpha_v = _mm256_set1_ps(alpha);
+      auto beta_v = _mm256_set1_ps(beta);
+
+      if (i_stride == 0) {
+        auto y = _mm256_set1_ps(Y[0]);
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto z = _mm256_mul_ps(_mm256_mul_ps(x, y), alpha_v);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Z += 8;
+        }
+      } else {
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto y = _mm256_loadu_ps(Y);
+          auto z = _mm256_mul_ps(_mm256_mul_ps(x, y), alpha_v);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Y += 8;
+          Z += 8;
+        }
+      }
+
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X * alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X++;
+        Y += i_stride;
+        Z++;
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        *Z = *X * alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X += o_stride;
+        Y += i_stride;
+        Z += o_stride;
+      }
     }
   }
 }
@@ -1218,12 +1498,245 @@ void ele_add(const unsigned int N, const float *X, const float *Y, float *Z,
       Z++;
     }
   } else {
-    // TODO: AVX2 implementation if used
-    for (unsigned int i = 0; i < N; ++i) {
-      *Z = *X + alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
-      X += o_stride;
-      Y += i_stride;
-      Z += o_stride;
+    if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+      unsigned int N8 = (N & ~(7));
+      auto alpha_v = _mm256_set1_ps(alpha);
+      auto beta_v = _mm256_set1_ps(beta);
+
+      if (i_stride == 0) {
+        auto y = _mm256_set1_ps(Y[0]);
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto z = _mm256_fmadd_ps(alpha_v, y, x);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Z += 8;
+        }
+      } else {
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto y = _mm256_loadu_ps(Y);
+          auto z = _mm256_fmadd_ps(alpha_v, y, x);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Y += 8;
+          Z += 8;
+        }
+      }
+
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X + alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X++;
+        Y += i_stride;
+        Z++;
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        *Z = *X + alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X += o_stride;
+        Y += i_stride;
+        Z += o_stride;
+      }
+    }
+  }
+}
+
+void ele_sub(const unsigned int N, const float *X, const float *Y, float *Z,
+             float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride) {
+  if (alpha == 1.0f && beta == 0.0f && o_stride == 1) {
+    unsigned int N8 = (N & ~(7));
+    if (i_stride == 0) {
+      auto y = _mm256_set1_ps(Y[0]);
+      for (unsigned int i = 0; i < N8; i += 8) {
+        auto x = _mm256_loadu_ps(X);
+        auto z = _mm256_sub_ps(x, y);
+        _mm256_storeu_ps(Z, z);
+        X += 8;
+        Z += 8;
+      }
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X - Y[0];
+        X++;
+        Z++;
+      }
+    } else if (i_stride == 1) {
+      for (unsigned int i = 0; i < N8; i += 8) {
+        auto x = _mm256_loadu_ps(X);
+        auto y = _mm256_loadu_ps(Y);
+        auto z = _mm256_sub_ps(x, y);
+        _mm256_storeu_ps(Z, z);
+        X += 8;
+        Y += 8;
+        Z += 8;
+      }
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X - *Y;
+        X++;
+        Y++;
+        Z++;
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        *Z = *X - *Y;
+        X++;
+        Y += i_stride;
+        Z++;
+      }
+    }
+  } else {
+    if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+      unsigned int N8 = (N & ~(7));
+      auto alpha_v = _mm256_set1_ps(alpha);
+      auto beta_v = _mm256_set1_ps(beta);
+
+      if (i_stride == 0) {
+        auto y = _mm256_set1_ps(Y[0]);
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto z = _mm256_fnmadd_ps(alpha_v, y, x);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Z += 8;
+        }
+      } else {
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto y = _mm256_loadu_ps(Y);
+          auto z = _mm256_fnmadd_ps(alpha_v, y, x);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Y += 8;
+          Z += 8;
+        }
+      }
+
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X - alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X++;
+        Y += i_stride;
+        Z++;
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        *Z = *X - alpha * *Y + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X += o_stride;
+        Y += i_stride;
+        Z += o_stride;
+      }
+    }
+  }
+}
+
+void ele_div(const unsigned int N, const float *X, const float *Y, float *Z,
+             float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride) {
+  if (alpha == 1.0f && beta == 0.0f && o_stride == 1) {
+    unsigned int N8 = (N & ~(7));
+    if (i_stride == 0) {
+      auto y = _mm256_set1_ps(Y[0]);
+      for (unsigned int i = 0; i < N8; i += 8) {
+        auto x = _mm256_loadu_ps(X);
+        auto z = _mm256_div_ps(x, y);
+        _mm256_storeu_ps(Z, z);
+        X += 8;
+        Z += 8;
+      }
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X / Y[0];
+        X++;
+        Z++;
+      }
+    } else if (i_stride == 1) {
+      for (unsigned int i = 0; i < N8; i += 8) {
+        auto x = _mm256_loadu_ps(X);
+        auto y = _mm256_loadu_ps(Y);
+        auto z = _mm256_div_ps(x, y);
+        _mm256_storeu_ps(Z, z);
+        X += 8;
+        Y += 8;
+        Z += 8;
+      }
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X / *Y;
+        X++;
+        Y++;
+        Z++;
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        *Z = *X / *Y;
+        X++;
+        Y += i_stride;
+        Z++;
+      }
+    }
+  } else {
+    if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+      unsigned int N8 = (N & ~(7));
+      auto alpha_v = _mm256_set1_ps(alpha);
+      auto beta_v = _mm256_set1_ps(beta);
+
+      if (i_stride == 0) {
+        auto y = _mm256_set1_ps(Y[0]);
+        auto denom = _mm256_mul_ps(alpha_v, y);
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto z = _mm256_div_ps(x, denom);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Z += 8;
+        }
+      } else {
+        for (unsigned int i = 0; i < N8; i += 8) {
+          auto x = _mm256_loadu_ps(X);
+          auto y = _mm256_loadu_ps(Y);
+          auto denom = _mm256_mul_ps(alpha_v, y);
+          auto z = _mm256_div_ps(x, denom);
+          if (beta != 0.0f) {
+            auto z_old = _mm256_loadu_ps(Z);
+            z = _mm256_fmadd_ps(beta_v, z_old, z);
+          }
+          _mm256_storeu_ps(Z, z);
+          X += 8;
+          Y += 8;
+          Z += 8;
+        }
+      }
+
+      for (unsigned int i = N8; i < N; ++i) {
+        *Z = *X / (alpha * *Y) + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X++;
+        Y += i_stride;
+        Z++;
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        *Z = *X / (alpha * *Y) + ((0.0f == beta) ? 0.0f : beta * *Z);
+        X += o_stride;
+        Y += i_stride;
+        Z += o_stride;
+      }
     }
   }
 }
@@ -1791,10 +2304,8 @@ void compute_rotary_emb_value(unsigned int width, unsigned int dim,
         __m256 cos_v = _mm256_loadu_ps(&cos_[k]);
         __m256 sin_v = _mm256_loadu_ps(&sin_[k]);
 
-        __m256 out0 =
-          _mm256_sub_ps(_mm256_mul_ps(a, cos_v), _mm256_mul_ps(b, sin_v));
-        __m256 out1 =
-          _mm256_add_ps(_mm256_mul_ps(a, sin_v), _mm256_mul_ps(b, cos_v));
+        __m256 out0 = _mm256_fnmadd_ps(b, sin_v, _mm256_mul_ps(a, cos_v));
+        __m256 out1 = _mm256_fmadd_ps(a, sin_v, _mm256_mul_ps(b, cos_v));
 
         if (out_type == OutputType::FP16) {
           __m128i out0_fp16 = convert_vector_f32_to_f16(out0);

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -13,10 +13,8 @@
  */
 
 #include "avx2_impl.h"
+#include "avx2_internal.h"
 #include <array>
-#if __has_include(<bit>)
-#include <bit>
-#endif
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -24,13 +22,7 @@
 #include <fp16.h>
 #include <immintrin.h>
 #include <limits>
-#if __has_include(<numbers>)
-#include <numbers>
-#endif
 #include <type_traits>
-#if __has_include(<version>)
-#include <version>
-#endif
 #include <fallback_internal.h>
 #include <nntrainer_error.h>
 #include <thread_manager.h>
@@ -39,298 +31,21 @@
 
 #include "nntr_ggml_impl_common.h"
 
-#if !defined(__has_constexpr_builtin)
-#define __has_constexpr_builtin(x) (0)
-#endif
-
-#if !defined(__has_cpp_attribute)
-#define __has_cpp_attribute(x) (0)
-#endif
-
-// VECTORCALL calling-conv (default for x86_64-linux-gnu)
-#if _MSC_VER >= 1700
-#define _nnt_CC_VECTORCALL __vectorcall
-#else
-#define _nnt_CC_VECTORCALL
-#endif
-
-// Flatten attribute
-#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::flatten)
-#define _nnt_ATTR_FLATTEN [[msvc::flatten]]
-#elif __has_cpp_attribute(gnu::flatten)
-// clang, g++
-#define _nnt_ATTR_FLATTEN [[gnu::flatten]]
-#else
-#define _nnt_ATTR_FLATTEN
-#endif
-
-#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::noinline)
-#define _nnt_ATTR_NOINLINE [[msvc::noinline]]
-#elif __has_cpp_attribute(gnu::flatten)
-// clang, g++
-#define _nnt_ATTR_NOINLINE [[gnu::noinline]]
-#else
-#define _nnt_ATTR_NOINLINE
-#endif
-
-#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::forceinline)
-#define _nnt_ATTR_ALWAYS_INLINE [[msvc::forceinline]]
-#elif __has_cpp_attribute(gnu::always_inline)
-#define _nnt_ATTR_ALWAYS_INLINE [[gnu::always_inline]]
-#endif
-
-#if __has_cpp_attribute(unikely)
-#define UNLIKELY [[unlikely]]
-#else
-#define UNLIKELY
-#endif
-
 #if !defined(_MSC_VER) && !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wattributes"
 #endif
 
+#if !defined(RESTRICT)
 #if defined(__clang__) || defined(__GNUC__)
 #define RESTRICT __restrict__
 #else
 #define RESTRICT
 #endif
-
-namespace {
-
-template <typename To_, typename From_>
-constexpr inline bool concept17_BinaryCastable =
-  sizeof(To_) == sizeof(From_) &&
-  std::is_trivially_copyable_v<From_> &&std::is_trivially_copyable_v<To_>;
-
-template <class To_, class From_>
-auto compat_bit_cast(const From_ &src) noexcept
-  -> std::enable_if_t<concept17_BinaryCastable<To_, From_>, To_> {
-#if __cpp_lib_bit_cast >= 201806L
-  return std::bit_cast<To_>(src);
-#else
-  To_ dst;
-  std::memcpy(&dst, &src, sizeof(To_));
-  return dst;
-#endif
-}
-
-[[nodiscard]] constexpr inline unsigned
-constexpr_popcount(uint32_t v) noexcept {
-#if __cpp_lib_bitops >= 201907L
-  return std::popcount(v);
-#else
-  // Popcount via bit-hack
-  v = v - ((v >> 1) & 0x55555555);                // reuse input as temporary
-  v = (v & 0x33333333) + ((v >> 2) & 0x33333333); // temp
-  auto c = (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24; // count
-  return c;
-#endif
-}
-
-template <unsigned I_>
-constexpr inline bool concept17_PowerOfTwo = (constexpr_popcount(I_) == 1);
-
-namespace numbers {
-
-#if __has_include(<numbers>) && __cpp_lib_math_constants >= 201907L
-using std::numbers::ln2_v;
-using std::numbers::log2e_v;
-#else
-template <typename Float_> constexpr inline auto ln2_v = Float_{M_LN2};
-
-template <typename Float_> constexpr inline auto log2e_v = Float_{M_LOG2E};
-#endif
-} // namespace numbers
-
-constexpr inline float EXP_ARG_MIN = -87.0;
-constexpr inline float EXP_ARG_MAX = +88.3762626647949f;
-
-// @brief Precalculated lookup table for 2^x calculation
-template <unsigned N_, typename Ty_ = uint32_t, typename Float_ = float,
-          typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
-struct Exp2Table {
-
-  constexpr static inline auto MANTISSA_BITS =
-    std::numeric_limits<Float_>::digits - 1;
-
-#if __cpp_consteval >= 201811L && __has_constexpr_builtin(__builtin_exp2)
-  [[nodiscard]] static consteval auto calculate() noexcept {
-    std::array<Ty_, N_> t;
-    for (unsigned i = 0; i < N_; ++i)
-      t[i] = std::bit_cast<Ty_>(std::exp2(Float_{1.0} * i / N_)) -
-             ((i << MANTISSA_BITS) / N_);
-    return t;
-  }
-#endif
-};
-
-#if !__has_constexpr_builtin(__builtin_exp2) || !(__cpp_consteval >= 201811L)
-
-// @brief Precalculated lookup table for 2^x calculation when we don't have
-// constexpr math functions
-template <> struct Exp2Table<8, uint32_t, float> {
-  [[nodiscard]] static constexpr auto calculate() noexcept {
-    std::array<uint32_t, 8> t = {0x3f800000U, 0x3f7b95c2U, 0x3f7837f0U,
-                                 0x3f75fed7U, 0x3f7504f3U, 0x3f75672aU,
-                                 0x3f7744fdU, 0x3f7ac0c7U};
-    return t;
-  }
-};
-
 #endif
 
-template <unsigned N_> // requires PowerOfTwo<N_>
-alignas(__m256) inline constexpr auto exp2_table_v = Exp2Table<N_>::calculate();
-
-// Scalar version of expf() approximation with 3-th deg polynominal of
-// fractional part
-//
-// The error with regards to std::expf less than 5e-6
-// It is valid in range [-87, +88.37) - not handling +INF, NaN etc.
-// The function domain is clamped to valid function range.
-//
-// The strategy picked is to approximate exp as 2^K*2^F
-template <unsigned N_, typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
-[[nodiscard]] _nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline float
-approx_exp_exp2_lookup(float x) noexcept {
-  constexpr static unsigned N_MASK = uint32_t(N_ - 1U);
-  constexpr static unsigned FLT_MANTISSA_BITS =
-    std::numeric_limits<float>::digits - 1U;
-
-  x = std::max(x, EXP_ARG_MIN);
-  x *= float(0x1.0p1 / numbers::ln2_v<double> * N_);
-  x = std::min(x, float(EXP_ARG_MAX / numbers::ln2_v<double> * N_));
-
-  // Round nearest and convert integer part to an int (std::modf)
-  // NB: This way doesn't handle ties even.
-  auto x_int = x + 0x1.8p23f;
-  auto x_uint = compat_bit_cast<uint32_t>(x_int);
-  x_int -= 0x1.8p23f;
-  auto x_frac = x - x_int;
-
-  auto s_int = exp2_table_v<N_>[x_uint & N_MASK];
-  auto x_uint_shifted = x_uint
-                        << (FLT_MANTISSA_BITS - constexpr_popcount(N_MASK));
-  auto s_int_2 = s_int + x_uint_shifted;
-  auto s = compat_bit_cast<float>(s_int_2);
-
-  // Polynominal of form C0*x^3 + C1*x^2 + C2*x^1 + 1.0
-  static constexpr float poly_4[] = {0x1.c6af84b912394p-5f / N_ / N_ / N_,
-                                     0x1.ebfce50fac4f3p-3f / N_ / N_,
-                                     0x1.62e42ff0c52d6p-1f / N_};
-
-  auto q0 = std::fma(x_frac, poly_4[0], poly_4[1]);
-  auto x_frac_pow2 = x_frac * x_frac;
-  auto q2 = x_frac * poly_4[2]; // not adding +1.0
-
-  x = std::fma(q0, x_frac_pow2, q2);
-
-  return std::fma(x, s, s); // NB: (handles (x+1) by addition of s)
-}
-
-// Vectorized version of above
-template <unsigned N_, typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
-_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
-avx2_approx_exp_e2lookup(__m256 xs) noexcept {
-
-  constexpr static uint32_t N_MASK = uint32_t(N_ - 1U);
-  alignas(64) constexpr static auto EXP2_TBL = exp2_table_v<N_>;
-  constexpr static unsigned MANTISSA_BITS =
-    std::numeric_limits<float>::digits - 1;
-
-  // Ensure arg in range [exp_arg_min, exp_arg_max]
-  xs = _mm256_max_ps(xs, _mm256_set1_ps(EXP_ARG_MIN));
-  // Would clamp to EXP_ARG_MAX but we move it after multiplication for IPC:
-  // xs = _mm256_min_ps(xs, _mm256_set1_ps(EXP_ARG_MAX));
-
-  xs =
-    _mm256_mul_ps(xs, _mm256_set1_ps(float(1.0 / numbers::ln2_v<double> * N_)));
-  // Clamp EXP_ARG_MAX after multiply
-  xs = _mm256_min_ps(
-    xs, _mm256_set1_ps(float(EXP_ARG_MAX / numbers::ln2_v<double> * N_)));
-
-  // Mostly equivalent to, doesn't round ties to even
-  // auto xs_int = _mm256_round_ps(xs, _MM_FROUND_TO_NEAREST_INT |
-  // _MM_FROUND_NO_EXC); auto xs_int_as_u32 = _mm256_cvtps_epi32(xs_int);
-  auto xs_int = _mm256_add_ps(xs, _mm256_set1_ps(0x1.8p23f));
-  auto xs_int_as_u32 = _mm256_castps_si256(xs_int);
-  xs_int = _mm256_sub_ps(xs_int, _mm256_set1_ps(0x1.8p23f));
-
-  // Calculate fractional part
-  auto xs_frac = _mm256_sub_ps(xs, xs_int);
-  // Indices for lookup (modulo N_)
-  auto exp2_idxs = _mm256_and_si256(xs_int_as_u32, _mm256_set1_epi32(N_MASK));
-
-  __m256i s_ints;
-
-  // Lookup e^xs_int s factor
-  if constexpr (N_ == 8) {
-    // Lookup by vector permute
-    auto tbl = _mm256_load_si256((__m256i *)EXP2_TBL.data());
-    s_ints = _mm256_permutevar8x32_epi32(tbl, exp2_idxs);
-  } else {
-    // Falback for not fitting number of vector elements
-    s_ints = _mm256_i32gather_epi32(EXP2_TBL.data(), exp2_idxs, 1);
-  }
-
-  auto xs_uint_shifted = _mm256_slli_epi32(
-    xs_int_as_u32, MANTISSA_BITS - constexpr_popcount(N_MASK));
-  auto s_ints_2 = _mm256_add_epi32(s_ints, xs_uint_shifted);
-  auto s_floats = _mm256_castsi256_ps(s_ints_2);
-
-  static constexpr float poly_d4[] = {0x1.c6af84b912394p-5f / N_ / N_ / N_,
-                                      0x1.ebfce50fac4f3p-3f / N_ / N_,
-                                      0x1.62e42ff0c52d6p-1f / N_};
-
-  const auto C0 = _mm256_set1_ps(poly_d4[0]);
-  const auto C1 = _mm256_set1_ps(poly_d4[1]);
-  const auto C2 = _mm256_set1_ps(poly_d4[2]);
-
-  auto qs0 = _mm256_fmadd_ps(xs_frac, C0, C1);
-  auto xs_frac_pow2 = _mm256_mul_ps(xs_frac, xs_frac);
-  auto qs2 = _mm256_mul_ps(xs_frac, C2);
-
-  xs = _mm256_fmadd_ps(qs0, xs_frac_pow2, qs2);
-
-  return _mm256_fmadd_ps(xs, s_floats, s_floats);
-}
-
-_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN auto _nnt_CC_VECTORCALL
-avx2_negate_ps(__m256 x) noexcept -> __m256 {
-  constexpr auto SIGN_SHIFT = sizeof(float) * 8 - 1;
-  const auto UNDEF = _mm256_undefined_si256();
-  const auto sign_bit =
-    _mm256_slli_epi32(_mm256_cmpeq_epi16(UNDEF, UNDEF), SIGN_SHIFT);
-  auto flt_sign_bit = _mm256_castsi256_ps(sign_bit);
-  auto neg_x = _mm256_xor_ps(x, flt_sign_bit);
-  return neg_x;
-}
-
-_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN auto _nnt_CC_VECTORCALL
-avx2_approx_swiglu(__m256 x, __m256 s) noexcept -> __m256 {
-  auto neg_x = avx2_negate_ps(x);
-  auto inv_sigmoid =
-    _mm256_add_ps(avx2_approx_exp_e2lookup<8>(neg_x), _mm256_set1_ps(1.0f));
-  auto swiglu_nonscaled = _mm256_div_ps(x, inv_sigmoid);
-  return _mm256_mul_ps(swiglu_nonscaled, s);
-}
-
-_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN auto _nnt_CC_VECTORCALL
-avx2_approx_swiglu_alpha(__m256 x, __m256 s, __m256 alpha) noexcept -> __m256 {
-  auto alpha_x = _mm256_mul_ps(alpha, x);
-  auto neg_alpha_x = avx2_negate_ps(alpha_x);
-  auto inv_sigmoid = _mm256_add_ps(avx2_approx_exp_e2lookup<8>(neg_alpha_x),
-                                   _mm256_set1_ps(1.0f));
-  auto swiglu_nonscaled = _mm256_div_ps(x, inv_sigmoid);
-  return _mm256_mul_ps(swiglu_nonscaled, s);
-}
-} // namespace
+using namespace nntrainer::avx2::internal;
 
 namespace nntrainer::avx2 {
-
-// Forward declarations for internal helpers used across the file
-static inline __m256 exp256_ps(__m256 x);
-static float hsum_avx(__m256 v);
 
 /**
  * @brief struct of q4_0x8 block
@@ -1015,121 +730,14 @@ void swiglu(const unsigned int N, float *X, const float *Y, const float *Z,
   _mm_setcsr(oldcsr);
 }
 
-#define gelu_start_tanh -4.38086284326899f
-#define gelu_end_tanh 4.38086284326899f
+// poly_gelu_tanh_avx2 / poly_gelu_erf_avx2 are defined in avx2_internal.h
+using nntrainer::avx2::internal::poly_gelu_tanh_avx2;
+using nntrainer::avx2::internal::poly_gelu_erf_avx2;
 
-#define tanh_c_gelu_p0 5.91303808e-6f
-#define tanh_c_gelu_p1 5.00000000e-1f
-#define tanh_c_gelu_p2 3.98865869e-1f
-#define tanh_c_gelu_p4 -6.66574676e-2f
-#define tanh_c_gelu_p6 1.00712610e-2f
-#define tanh_c_gelu_p8 -1.19336340e-3f
-#define tanh_c_gelu_p10 1.09543224e-4f
-#define tanh_c_gelu_p12 -7.55788500e-6f
-#define tanh_c_gelu_p14 3.73374142e-7f
-#define tanh_c_gelu_p16 -1.23162678e-8f
-#define tanh_c_gelu_p18 2.40940960e-10f
-#define tanh_c_gelu_p20 -2.10237709e-12f
-
-#define gelu_start_erf -4.59373833108583f
-#define gelu_end_erf 4.59373833108583f
-
-#define erf_c_gelu_p0 8.70757509e-06f
-#define erf_c_gelu_p1 5.00000000e-1f
-#define erf_c_gelu_p2 3.98833088e-01f
-#define erf_c_gelu_p4 -6.62633808e-02f
-#define erf_c_gelu_p6 9.78776282e-03f
-#define erf_c_gelu_p8 -1.10798998e-03f
-#define erf_c_gelu_p10 9.51056006e-05f
-#define erf_c_gelu_p12 -6.04633051e-06f
-#define erf_c_gelu_p14 2.73076070e-07f
-#define erf_c_gelu_p16 -8.20707325e-09f
-#define erf_c_gelu_p18 1.46115955e-10f
-#define erf_c_gelu_p20 -1.16009840e-12f
-
-static inline __m256 poly_gelu_tanh_avx2(__m256 x) {
-  const __m256 x2 = _mm256_mul_ps(x, x);
-
-  __m256 y = _mm256_mul_ps(x2, _mm256_set1_ps(tanh_c_gelu_p20));
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p18));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p16));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p14));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p12));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p10));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p8));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p6));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p4));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p2));
-  y = _mm256_mul_ps(x2, y);
-
-  __m256 z = _mm256_mul_ps(x, _mm256_set1_ps(tanh_c_gelu_p1));
-  z = _mm256_add_ps(z, _mm256_set1_ps(tanh_c_gelu_p0));
-
-  y = _mm256_add_ps(y, z);
-
-  const __m256 gt_start =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_start_tanh), _CMP_GT_OQ);
-  const __m256 le_end =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_tanh), _CMP_LE_OQ);
-  const __m256 gt_end =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_tanh), _CMP_GT_OQ);
-
-  y = _mm256_and_ps(y, gt_start);
-  y = _mm256_and_ps(y, le_end);
-  __m256 x_hi = _mm256_and_ps(x, gt_end);
-
-  return _mm256_add_ps(y, x_hi);
-}
-
-static inline __m256 poly_gelu_erf_avx2(__m256 x) {
-  const __m256 x2 = _mm256_mul_ps(x, x);
-
-  __m256 y = _mm256_mul_ps(x2, _mm256_set1_ps(erf_c_gelu_p20));
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p18));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p16));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p14));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p12));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p10));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p8));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p6));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p4));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p2));
-  y = _mm256_mul_ps(x2, y);
-
-  __m256 z = _mm256_mul_ps(x, _mm256_set1_ps(erf_c_gelu_p1));
-  z = _mm256_add_ps(z, _mm256_set1_ps(erf_c_gelu_p0));
-
-  y = _mm256_add_ps(y, z);
-
-  const __m256 gt_start =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_start_erf), _CMP_GT_OQ);
-  const __m256 le_end =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_erf), _CMP_LE_OQ);
-  const __m256 gt_end =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_erf), _CMP_GT_OQ);
-
-  y = _mm256_and_ps(y, gt_start);
-  y = _mm256_and_ps(y, le_end);
-  __m256 x_hi = _mm256_and_ps(x, gt_end);
-
-  return _mm256_add_ps(y, x_hi);
-}
+// exp256_ps, hsum_avx, rcp_ps are also in avx2_internal.h
+using nntrainer::avx2::internal::exp256_ps;
+using nntrainer::avx2::internal::hsum_avx;
+using nntrainer::avx2::internal::rcp_ps;
 
 void tanh_gelu_v2(const unsigned int N, const float *X, float *Y) {
   unsigned int i = 0;
@@ -1741,109 +1349,7 @@ void ele_div(const unsigned int N, const float *X, const float *Y, float *Z,
   }
 }
 
-static inline __m256 exp256_ps(__m256 x) {
-  /*  Low-Precision Version I*/
-  // const __m256 c1 = _mm256_set1_ps(12102203.0f);
-  // const __m256 c2 = _mm256_set1_ps(1065353216.0f);
-  // __m256 fx = _mm256_add_ps(_mm256_mul_ps(x, c1),c2);
-  // return _mm256_castsi256_ps(_mm256_cvtps_epi32(fx));
-
-  /* Low-Precision Version II*/
-  /*    const __m256 ln2 = _mm256_set1_ps(0.69314718056f);
-    const __m256 inv_ln2 = _mm256_set1_ps(1.44269504089f); // 1 / ln(2)
-
-    // Range reduction: x = n * ln2 + r,  where n is integer and |r| <= ln2/2
-    __m256 fx = _mm256_mul_ps(x, inv_ln2);
-    fx = _mm256_round_ps(fx, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
-    __m256i emm0 = _mm256_cvtps_epi32(fx);
-
-    __m256 tmp = _mm256_mul_ps(fx, ln2);
-    __m256 r = _mm256_sub_ps(x, tmp);
-
-    // Compute polynomial approximation of exp(r)
-    const __m256 c1 = _mm256_set1_ps(1.9875691500E-4f);
-    const __m256 c2 = _mm256_set1_ps(1.3981999507E-3f);
-    const __m256 c3 = _mm256_set1_ps(8.3334519073E-3f);
-    const __m256 c4 = _mm256_set1_ps(4.1665795894E-2f);
-    const __m256 c5 = _mm256_set1_ps(1.6666665459E-1f);
-    const __m256 c6 = _mm256_set1_ps(5.0000001201E-1f);
-
-  //  __m256 r2 = _mm256_mul_ps(r, r);
-  //  __m256 r3 = _mm256_mul_ps(r2, r);
-  //  __m256 r4 = _mm256_mul_ps(r2, r2);
-
-    __m256 y = _mm256_fmadd_ps(c1, r, c2);
-    y = _mm256_fmadd_ps(y, r, c3);
-    y = _mm256_fmadd_ps(y, r, c4);
-    y = _mm256_fmadd_ps(y, r, c5);
-    y = _mm256_fmadd_ps(y, r, c6);
-    y = _mm256_fmadd_ps(y, r, _mm256_set1_ps(1.0f));
-
-    // Reconstruct exp(x) = 2^n * exp(r)
-    emm0 = _mm256_add_epi32(emm0, _mm256_set1_epi32(127));
-    emm0 = _mm256_slli_epi32(emm0, 23);
-    __m256 pow2n = _mm256_castsi256_ps(emm0);
-
-    return _mm256_mul_ps(y, pow2n);
-  */
-  /* Low-Precision Versino III */
-  const __m256 LOG2EF = _mm256_set1_ps(1.44269504088896341f); // 1 / ln(2)
-  const __m256 LN2 = _mm256_set1_ps(0.6931471805599453f);     // ln(2)
-
-  // Clamp input to range to prevent overflow/underflow
-  const __m256 max_x = _mm256_set1_ps(88.3762626647949f);  // log(FLT_MAX)
-  const __m256 min_x = _mm256_set1_ps(-88.3762626647949f); // log(FLT_MIN)
-  x = _mm256_max_ps(min_x, _mm256_min_ps(max_x, x));
-
-  // Range reduction: x = n * ln2 + r
-  __m256 fx = _mm256_mul_ps(x, LOG2EF); // x * (1/ln(2))
-  fx = _mm256_floor_ps(_mm256_add_ps(fx, _mm256_set1_ps(0.5f)));
-
-  __m256 tmp = _mm256_mul_ps(fx, LN2); // n * ln(2)
-  __m256 r = _mm256_sub_ps(x, tmp);    // r = x - n * ln2
-
-  // Compute exp(r) using 10th-order polynomial (Horner's method)
-  const __m256 c0 = _mm256_set1_ps(1.0f);
-  const __m256 c1 = _mm256_set1_ps(1.0f);
-  const __m256 c2 = _mm256_set1_ps(0.5f);
-  const __m256 c3 = _mm256_set1_ps(1.0f / 6.0f);
-  const __m256 c4 = _mm256_set1_ps(1.0f / 24.0f);
-  const __m256 c5 = _mm256_set1_ps(1.0f / 120.0f);
-  const __m256 c6 = _mm256_set1_ps(1.0f / 720.0f);
-  const __m256 c7 = _mm256_set1_ps(1.0f / 5040.0f);
-  const __m256 c8 = _mm256_set1_ps(1.0f / 40320.0f);
-  const __m256 c9 = _mm256_set1_ps(1.0f / 362880.0f);
-  const __m256 c10 = _mm256_set1_ps(1.0f / 3628800.0f);
-
-  __m256 y = c10;
-  y = _mm256_fmadd_ps(y, r, c9);
-  y = _mm256_fmadd_ps(y, r, c8);
-  y = _mm256_fmadd_ps(y, r, c7);
-  y = _mm256_fmadd_ps(y, r, c6);
-  y = _mm256_fmadd_ps(y, r, c5);
-  y = _mm256_fmadd_ps(y, r, c4);
-  y = _mm256_fmadd_ps(y, r, c3);
-  y = _mm256_fmadd_ps(y, r, c2);
-  y = _mm256_fmadd_ps(y, r, c1);
-  y = _mm256_fmadd_ps(y, r, c0); // final y = (((...r+...)*r+...)*r + 1)
-
-  // Reconstruct exp(x) = 2^n * exp(r)
-  __m256i emm0 = _mm256_cvtps_epi32(fx);
-  emm0 = _mm256_add_epi32(emm0, _mm256_set1_epi32(127));
-  emm0 = _mm256_slli_epi32(emm0, 23);
-  __m256 pow2n = _mm256_castsi256_ps(emm0);
-
-  return _mm256_mul_ps(y, pow2n);
-}
-
-static inline __m256 rcp_ps(__m256 x) {
-  // Use Newton-Raphson method to enhance accuracy
-  // x_n+1 = x_n * (2 - x_0 * x_n)
-  __m256 rcp = _mm256_rcp_ps(x);
-  __m256 two = _mm256_set1_ps(2.0f);
-  // rcp * (2 - x * rcp)
-  return _mm256_mul_ps(rcp, _mm256_fnmadd_ps(x, rcp, two));
-}
+// exp256_ps and rcp_ps are now in avx2_internal.h
 
 static void softmax_row_inplace(float *qk_out, size_t start_row, size_t end_row,
                                 size_t num_heads) {
@@ -2354,16 +1860,7 @@ void compute_rotary_emb_value(unsigned int width, unsigned int dim,
   }
 }
 
-static float hsum_avx(__m256 v) {
-  __m128 vlow = _mm256_castps256_ps128(v);
-  __m128 vhigh = _mm256_extractf128_ps(v, 1);
-  vlow = _mm_add_ps(vlow, vhigh);
-  __m128 shuf = _mm_movehdup_ps(vlow);
-  __m128 sums = _mm_add_ps(vlow, shuf);
-  shuf = _mm_movehl_ps(shuf, sums);
-  sums = _mm_add_ss(sums, shuf);
-  return _mm_cvtss_f32(sums);
-}
+// hsum_avx is now in avx2_internal.h
 
 void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
                                        float *__restrict Y, size_t H, size_t W,

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
@@ -52,6 +52,57 @@ void vcvt_f32_f16(unsigned int N, const float *input, _Float16 *output);
  * @param[out] false if it has NaN or inf
  */
 bool is_valid(const unsigned int N, const _Float16 *X);
+
+void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride);
+void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride);
+void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride);
+void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride);
+
+void saxpy(const unsigned int N, const float alpha, const _Float16 *X,
+           const unsigned int incX, _Float16 *Y, const unsigned int incY);
+_Float16 sdot(const unsigned int N, const _Float16 *X, const unsigned int incX,
+              const _Float16 *Y, const unsigned int incY);
+_Float16 snrm2(const unsigned int N, const _Float16 *X,
+               const unsigned int incX);
+void sscal(const unsigned int N, const float alpha, _Float16 *X,
+           const unsigned int incX);
+void custom_scopy(const unsigned int N, const _Float16 *X,
+                  const unsigned int incX, _Float16 *Y,
+                  const unsigned int incY);
+
+_Float16 max_val(const unsigned int N, _Float16 *X);
+void softmax(const unsigned int N, _Float16 *X, _Float16 *Y);
+void inv_sqrt_inplace(const unsigned int N, _Float16 *X);
+void swiglu(const unsigned int N, _Float16 *X, _Float16 *Y, _Float16 *Z);
+void rms_norm_wrt_width_fp16(const _Float16 *__restrict X,
+                             _Float16 *__restrict Y, size_t H, size_t W,
+                             float epsilon);
+void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
+                                    unsigned int w, _Float16 *in, _Float16 *out,
+                                    float *cos_, float *sin_);
+
+unsigned int isamax(const unsigned int N, const _Float16 *X,
+                    const unsigned int incX);
+void transpose_matrix(const unsigned int M, const unsigned int N,
+                      const _Float16 *src, unsigned int ld_src, _Float16 *dst,
+                      unsigned int ld_dst);
+void scopy_int4_to_float16(const unsigned int N, const uint8_t *X,
+                           const unsigned int incX, _Float16 *Y,
+                           const unsigned int incY);
+void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
+                           const unsigned int incX, _Float16 *Y,
+                           const unsigned int incY);
+void scopy_int8_to_float16(const unsigned int N, const int8_t *X,
+                           const unsigned int incX, _Float16 *Y,
+                           const unsigned int incY);
 #endif
 
 /**

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.h
@@ -15,6 +15,7 @@
 #define __AVX2_IMPL_H_
 #ifdef __cplusplus
 
+#include "avx2_mathfun.h"
 #include <cstdint>
 #include <limits.h>
 #include <limits>
@@ -102,6 +103,98 @@ void transpose_matrix(const unsigned int M, const unsigned int N,
                       unsigned int ld_dst);
 
 /**
+ * @brief tanh_gelu function with AVX2 polynomial approximation
+ *        Y = 0.5 * X * (1 + tanh(sqrt(2/pi) * (X + 0.044715 * X^3)))
+ *
+ * @param N number of elements in X
+ * @param X const float * for Vector X (input)
+ * @param Y float * for Vector Y (output)
+ */
+void tanh_gelu(const unsigned int N, const float *X, float *Y);
+
+/**
+ * @brief tanh_gelu_mul function with AVX2: X = GELU(Y) * Z
+ *
+ * @param N number of elements
+ * @param X float * for output
+ * @param Y float * for GELU input
+ * @param Z float * for multiply input
+ */
+void tanh_gelu_mul(const unsigned int N, float *X, float *Y, float *Z);
+
+/**
+ * @brief tanh_gelu_v2_mul function with AVX2: X = GELU(Y) * Z
+ *
+ * @param N number of elements
+ * @param X float * for output
+ * @param Y float * for GELU input
+ * @param Z float * for multiply input
+ */
+void tanh_gelu_v2_mul(const unsigned int N, float *X, float *Y, float *Z);
+
+/**
+ * @brief returns maximum value of the vector X
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X
+ * @return float maximum value of vector X
+ */
+float max_val(const unsigned int N, float *X);
+
+/**
+ * @brief softmax function y_i = exp(x_i) / sum( exp(x_i) )
+ *
+ * @param N number of elements in X
+ * @param X float * for Vector X (input)
+ * @param Y float * for Vector Y (output)
+ */
+void softmax(const unsigned int N, float *X, float *Y);
+
+/**
+ * @brief inversed squared root transformation inplace : X[i] = 1 / sqrt(X[i])
+ *
+ * @param N size of X
+ * @param X float * for Vector X
+ */
+void inv_sqrt_inplace(const unsigned int N, float *X);
+
+/**
+ * @brief sine function : Y[i] = sin(alpha * X[i]) * beta
+ *
+ * @param N number of elements
+ * @param X float * input
+ * @param Y float * output
+ * @param alpha scaling for input
+ * @param beta scaling for output
+ */
+void sine(const unsigned int N, float *X, float *Y, float alpha, float beta);
+
+/**
+ * @brief cosine function : Y[i] = cos(alpha * X[i]) * beta
+ *
+ * @param N number of elements
+ * @param X float * input
+ * @param Y float * output
+ * @param alpha scaling for input
+ * @param beta scaling for output
+ */
+void cosine(const unsigned int N, float *X, float *Y, float alpha, float beta);
+
+/**
+ * @brief compute cos and sin of angles, then duplicate to second half
+ *
+ * @param N_half half size of output arrays
+ * @param angle float * input angles
+ * @param cos_ float * output cosines (size 2*N_half)
+ * @param sin_ float * output sines (size 2*N_half)
+ * @param from starting index for angle calculation
+ * @param attention_scaling scaling factor for cos and sin values
+ */
+void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
+                                 float *sin_, unsigned int from,
+                                 float attention_scaling);
+
+/**
  * @brief swiglu function with AVX : X = (Y / (1 + exp( -Y ))) * Z
  *
  * @param N number of elements in X
@@ -176,6 +269,37 @@ void ele_add(const unsigned int N, const float *X, const float *Y, float *Z,
              unsigned int o_stride);
 
 /**
+ * @brief     elementwise vector subtraction : Z = X - alpha * Y + beta * Z
+ * @param[in] N  length of the vector
+ * @param[in] X float * for Vector X
+ * @param[in] Y float * for Vector Y
+ * @param[in] Z float * for Vector Z
+ * @param[in] alpha scalar multiplier for input
+ * @param[in] beta scalar multiplier for output
+ * @param[in] i_stride input stride
+ * @param[in] o_stride output stride
+ */
+void ele_sub(const unsigned int N, const float *X, const float *Y, float *Z,
+             float alpha = 1.f, float beta = 0.f, unsigned int i_stride = 1,
+             unsigned int o_stride = 1);
+
+/**
+ * @brief     elementwise vector division : Z = X / (alpha * Y) + beta * Z
+ * @note ZeroDivisionError is not guaranteed in this function
+ * @param[in] N  length of the vector
+ * @param[in] X float * for Vector X
+ * @param[in] Y float * for Vector Y
+ * @param[in] Z float * for Vector Z
+ * @param[in] alpha scalar multiplier for input
+ * @param[in] beta scalar multiplier for output
+ * @param[in] i_stride input stride
+ * @param[in] o_stride output stride
+ */
+void ele_div(const unsigned int N, const float *X, const float *Y, float *Z,
+             float alpha = 1.f, float beta = 0.f, unsigned int i_stride = 1,
+             unsigned int o_stride = 1);
+
+/**
  * @brief Multihead softmax, exp(x_i) / sum(exp(x_i)), inplace version
  * @param[in/out] qk_out float* input/output values
  * @param[in] start_row start row number
@@ -186,7 +310,7 @@ template <typename T = float>
 void softmax_row_inplace(T *qk_out, size_t start_row, size_t end_row,
                          size_t num_heads, T *sink = nullptr);
 
-/**f
+/**
  * @brief Multihead softmax, exp(x_i) / sum(exp(x_i))
  * @param[in/out] qk_out float* input/output values
  * @param[in] start_row start row number

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
@@ -13,11 +13,16 @@
  */
 
 #include <avx2_impl.h>
+#include "avx2_internal.h"
 #include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <immintrin.h>
+#include <limits>
 #include <util_func.h>
+
+using namespace nntrainer::avx2::internal;
 
 namespace nntrainer::avx2 {
 
@@ -182,6 +187,1356 @@ bool is_valid(const unsigned int N, const _Float16 *input) {
   }
 
   return true;
+}
+
+// ============================================================
+// FP16 elementwise operations
+// ============================================================
+
+void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride) {
+  if (alpha == 1.0f && beta == 0.0f && o_stride == 1) {
+    unsigned int i = 0;
+    if (i_stride == 0) {
+      float y0_f32 = static_cast<float>(Y[0]);
+      __m256 vy = _mm256_set1_ps(y0_f32);
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_mul_ps(x_lo, vy);
+        __m256 z_hi = _mm256_mul_ps(x_hi, vy);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_mul_ps(x, vy);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) * y0_f32);
+      }
+    } else if (i_stride == 1) {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 z_lo = _mm256_mul_ps(x_lo, y_lo);
+        __m256 z_hi = _mm256_mul_ps(x_hi, y_hi);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 z = _mm256_mul_ps(x, y);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) *
+                                     static_cast<float>(Y[i]));
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) *
+                                     static_cast<float>(Y[i * i_stride]));
+      }
+    }
+  } else if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+    __m256 alpha_v = _mm256_set1_ps(alpha);
+    __m256 beta_v = _mm256_set1_ps(beta);
+    unsigned int i = 0;
+
+    if (i_stride == 0) {
+      __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_mul_ps(_mm256_mul_ps(x_lo, vy), alpha_v);
+        __m256 z_hi = _mm256_mul_ps(_mm256_mul_ps(x_hi, vy), alpha_v);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_mul_ps(_mm256_mul_ps(x, vy), alpha_v);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    } else {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 z_lo = _mm256_mul_ps(_mm256_mul_ps(x_lo, y_lo), alpha_v);
+        __m256 z_hi = _mm256_mul_ps(_mm256_mul_ps(x_hi, y_hi), alpha_v);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 z = _mm256_mul_ps(_mm256_mul_ps(x, y), alpha_v);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    }
+    for (; i < N; ++i) {
+      float xf = static_cast<float>(X[i]);
+      float yf = static_cast<float>(Y[i * i_stride]);
+      float zf = xf * alpha * yf + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      Z[i] = static_cast<_Float16>(zf);
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      float xf = static_cast<float>(*X);
+      float yf = static_cast<float>(*Y);
+      float zf = xf * alpha * yf +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
+      *Z = static_cast<_Float16>(zf);
+      X += o_stride;
+      Y += i_stride;
+      Z += o_stride;
+    }
+  }
+}
+
+void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride) {
+  if (alpha == 1.0f && beta == 0.0f && o_stride == 1) {
+    unsigned int i = 0;
+    if (i_stride == 0) {
+      __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_add_ps(x_lo, vy);
+        __m256 z_hi = _mm256_add_ps(x_hi, vy);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_add_ps(x, vy);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) +
+                                     static_cast<float>(Y[0]));
+      }
+    } else if (i_stride == 1) {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 z_lo = _mm256_add_ps(x_lo, y_lo);
+        __m256 z_hi = _mm256_add_ps(x_hi, y_hi);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 z = _mm256_add_ps(x, y);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) +
+                                     static_cast<float>(Y[i]));
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) +
+                                     static_cast<float>(Y[i * i_stride]));
+      }
+    }
+  } else if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+    __m256 alpha_v = _mm256_set1_ps(alpha);
+    __m256 beta_v = _mm256_set1_ps(beta);
+    unsigned int i = 0;
+
+    if (i_stride == 0) {
+      __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_fmadd_ps(alpha_v, vy, x_lo);
+        __m256 z_hi = _mm256_fmadd_ps(alpha_v, vy, x_hi);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_fmadd_ps(alpha_v, vy, x);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    } else {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 z_lo = _mm256_fmadd_ps(alpha_v, y_lo, x_lo);
+        __m256 z_hi = _mm256_fmadd_ps(alpha_v, y_hi, x_hi);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 z = _mm256_fmadd_ps(alpha_v, y, x);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    }
+    for (; i < N; ++i) {
+      float xf = static_cast<float>(X[i]);
+      float yf = static_cast<float>(Y[i * i_stride]);
+      float zf = xf + alpha * yf + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      Z[i] = static_cast<_Float16>(zf);
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      float xf = static_cast<float>(*X);
+      float yf = static_cast<float>(*Y);
+      float zf =
+        xf + alpha * yf +
+        ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
+      *Z = static_cast<_Float16>(zf);
+      X += o_stride;
+      Y += i_stride;
+      Z += o_stride;
+    }
+  }
+}
+
+void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride) {
+  if (alpha == 1.0f && beta == 0.0f && o_stride == 1) {
+    unsigned int i = 0;
+    if (i_stride == 0) {
+      __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_sub_ps(x_lo, vy);
+        __m256 z_hi = _mm256_sub_ps(x_hi, vy);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_sub_ps(x, vy);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) -
+                                     static_cast<float>(Y[0]));
+      }
+    } else if (i_stride == 1) {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 z_lo = _mm256_sub_ps(x_lo, y_lo);
+        __m256 z_hi = _mm256_sub_ps(x_hi, y_hi);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 z = _mm256_sub_ps(x, y);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) -
+                                     static_cast<float>(Y[i]));
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) -
+                                     static_cast<float>(Y[i * i_stride]));
+      }
+    }
+  } else if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+    __m256 alpha_v = _mm256_set1_ps(alpha);
+    __m256 beta_v = _mm256_set1_ps(beta);
+    unsigned int i = 0;
+
+    if (i_stride == 0) {
+      __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_fnmadd_ps(alpha_v, vy, x_lo);
+        __m256 z_hi = _mm256_fnmadd_ps(alpha_v, vy, x_hi);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_fnmadd_ps(alpha_v, vy, x);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    } else {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 z_lo = _mm256_fnmadd_ps(alpha_v, y_lo, x_lo);
+        __m256 z_hi = _mm256_fnmadd_ps(alpha_v, y_hi, x_hi);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 z = _mm256_fnmadd_ps(alpha_v, y, x);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    }
+    for (; i < N; ++i) {
+      float xf = static_cast<float>(X[i]);
+      float yf = static_cast<float>(Y[i * i_stride]);
+      float zf = xf - alpha * yf + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      Z[i] = static_cast<_Float16>(zf);
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      float xf = static_cast<float>(*X);
+      float yf = static_cast<float>(*Y);
+      float zf =
+        xf - alpha * yf +
+        ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
+      *Z = static_cast<_Float16>(zf);
+      X += o_stride;
+      Y += i_stride;
+      Z += o_stride;
+    }
+  }
+}
+
+void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
+             _Float16 *Z, float alpha, float beta, unsigned int i_stride,
+             unsigned int o_stride) {
+  // Newton-Raphson reciprocal helper constant
+  const __m256 two = _mm256_set1_ps(2.0f);
+
+  if (alpha == 1.0f && beta == 0.0f && o_stride == 1) {
+    unsigned int i = 0;
+    if (i_stride == 0) {
+      // Precompute refined reciprocal of Y[0] once (rcp + Newton-Raphson)
+      __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
+      __m256 rcp_est = _mm256_rcp_ps(vy);
+      __m256 vy_inv = _mm256_mul_ps(rcp_est, _mm256_fnmadd_ps(vy, rcp_est, two));
+
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_mul_ps(x_lo, vy_inv);
+        __m256 z_hi = _mm256_mul_ps(x_hi, vy_inv);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_mul_ps(x, vy_inv);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) /
+                                     static_cast<float>(Y[0]));
+      }
+    } else if (i_stride == 1) {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        // rcp + Newton-Raphson for per-element reciprocal
+        __m256 rcp_lo = _mm256_rcp_ps(y_lo);
+        __m256 inv_lo = _mm256_mul_ps(rcp_lo, _mm256_fnmadd_ps(y_lo, rcp_lo, two));
+        __m256 rcp_hi = _mm256_rcp_ps(y_hi);
+        __m256 inv_hi = _mm256_mul_ps(rcp_hi, _mm256_fnmadd_ps(y_hi, rcp_hi, two));
+        __m256 z_lo = _mm256_mul_ps(x_lo, inv_lo);
+        __m256 z_hi = _mm256_mul_ps(x_hi, inv_hi);
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 rcp_y = _mm256_rcp_ps(y);
+        __m256 inv_y = _mm256_mul_ps(rcp_y, _mm256_fnmadd_ps(y, rcp_y, two));
+        __m256 z = _mm256_mul_ps(x, inv_y);
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+      for (; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) /
+                                     static_cast<float>(Y[i]));
+      }
+    } else {
+      for (unsigned int i = 0; i < N; ++i) {
+        Z[i] = static_cast<_Float16>(static_cast<float>(X[i]) /
+                                     static_cast<float>(Y[i * i_stride]));
+      }
+    }
+  } else if (o_stride == 1 && (i_stride == 0 || i_stride == 1)) {
+    __m256 alpha_v = _mm256_set1_ps(alpha);
+    __m256 beta_v = _mm256_set1_ps(beta);
+    unsigned int i = 0;
+
+    if (i_stride == 0) {
+      // Precompute refined reciprocal of (alpha * Y[0])
+      __m256 denom = _mm256_mul_ps(alpha_v, _mm256_set1_ps(static_cast<float>(Y[0])));
+      __m256 rcp_d = _mm256_rcp_ps(denom);
+      __m256 inv_d = _mm256_mul_ps(rcp_d, _mm256_fnmadd_ps(denom, rcp_d, two));
+
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 z_lo = _mm256_mul_ps(x_lo, inv_d);
+        __m256 z_hi = _mm256_mul_ps(x_hi, inv_d);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 z = _mm256_mul_ps(x, inv_d);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    } else {
+      for (; i + 16 <= N; i += 16) {
+        __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
+        __m256i yd = _mm256_loadu_si256((const __m256i *)(Y + i));
+        __m256 x_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(xd));
+        __m256 x_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(xd, 1));
+        __m256 y_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(yd));
+        __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
+        __m256 d_lo = _mm256_mul_ps(alpha_v, y_lo);
+        __m256 d_hi = _mm256_mul_ps(alpha_v, y_hi);
+        // rcp + Newton-Raphson for per-element reciprocal
+        __m256 rcp_lo = _mm256_rcp_ps(d_lo);
+        __m256 inv_lo = _mm256_mul_ps(rcp_lo, _mm256_fnmadd_ps(d_lo, rcp_lo, two));
+        __m256 rcp_hi = _mm256_rcp_ps(d_hi);
+        __m256 inv_hi = _mm256_mul_ps(rcp_hi, _mm256_fnmadd_ps(d_hi, rcp_hi, two));
+        __m256 z_lo = _mm256_mul_ps(x_lo, inv_lo);
+        __m256 z_hi = _mm256_mul_ps(x_hi, inv_hi);
+        if (beta != 0.0f) {
+          __m256i zd = _mm256_loadu_si256((const __m256i *)(Z + i));
+          __m256 zo_lo = _mm256_cvtph_ps(_mm256_castsi256_si128(zd));
+          __m256 zo_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(zd, 1));
+          z_lo = _mm256_fmadd_ps(beta_v, zo_lo, z_lo);
+          z_hi = _mm256_fmadd_ps(beta_v, zo_hi, z_hi);
+        }
+        __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
+        __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256((__m256i *)(Z + i),
+          _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
+      }
+      for (; i + 8 <= N; i += 8) {
+        __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+        __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+        __m256 d = _mm256_mul_ps(alpha_v, y);
+        __m256 rcp_d = _mm256_rcp_ps(d);
+        __m256 inv_d = _mm256_mul_ps(rcp_d, _mm256_fnmadd_ps(d, rcp_d, two));
+        __m256 z = _mm256_mul_ps(x, inv_d);
+        if (beta != 0.0f) {
+          __m256 z_old =
+            _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+          z = _mm256_fmadd_ps(beta_v, z_old, z);
+        }
+        _mm_storeu_si128((__m128i *)(Z + i),
+                         _mm256_cvtps_ph(z, _MM_FROUND_TO_NEAREST_INT));
+      }
+    }
+    for (; i < N; ++i) {
+      float xf = static_cast<float>(X[i]);
+      float yf = static_cast<float>(Y[i * i_stride]);
+      float zf = xf / (alpha * yf) + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      Z[i] = static_cast<_Float16>(zf);
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      float xf = static_cast<float>(*X);
+      float yf = static_cast<float>(*Y);
+      float zf = xf / (alpha * yf) +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
+      *Z = static_cast<_Float16>(zf);
+      X += o_stride;
+      Y += i_stride;
+      Z += o_stride;
+    }
+  }
+}
+
+// ============================================================
+// FP16 BLAS-like operations
+// ============================================================
+
+void saxpy(const unsigned int N, const float alpha, const _Float16 *X,
+           const unsigned int incX, _Float16 *Y, const unsigned int incY) {
+  if (incX == 1 && incY == 1) {
+    unsigned int i = 0;
+    unsigned int N16 = (N & ~15u);
+    __m256 alpha_v = _mm256_set1_ps(alpha);
+
+    // Main loop: process 16 elements per iteration via 256-bit loads
+    for (; i < N16; i += 16) {
+      __m256i x_raw = _mm256_loadu_si256((const __m256i *)(X + i));
+      __m256i y_raw = _mm256_loadu_si256((const __m256i *)(Y + i));
+
+      __m128i x_lo = _mm256_castsi256_si128(x_raw);
+      __m128i x_hi = _mm256_extracti128_si256(x_raw, 1);
+      __m128i y_lo = _mm256_castsi256_si128(y_raw);
+      __m128i y_hi = _mm256_extracti128_si256(y_raw, 1);
+
+      __m256 xf0 = _mm256_cvtph_ps(x_lo);
+      __m256 xf1 = _mm256_cvtph_ps(x_hi);
+      __m256 yf0 = _mm256_cvtph_ps(y_lo);
+      __m256 yf1 = _mm256_cvtph_ps(y_hi);
+
+      __m256 r0 = _mm256_fmadd_ps(alpha_v, xf0, yf0);
+      __m256 r1 = _mm256_fmadd_ps(alpha_v, xf1, yf1);
+
+      __m128i out_lo = _mm256_cvtps_ph(r0, _MM_FROUND_TO_NEAREST_INT);
+      __m128i out_hi = _mm256_cvtps_ph(r1, _MM_FROUND_TO_NEAREST_INT);
+      __m256i out = _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo),
+                                           out_hi, 1);
+      _mm256_storeu_si256((__m256i *)(Y + i), out);
+    }
+
+    // Tail: process remaining 8 elements
+    if (i + 8 <= N) {
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+      __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+      __m256 result = _mm256_fmadd_ps(alpha_v, x, y);
+      _mm_storeu_si128((__m128i *)(Y + i),
+                       _mm256_cvtps_ph(result, _MM_FROUND_TO_NEAREST_INT));
+      i += 8;
+    }
+
+    // Scalar tail
+    for (; i < N; ++i) {
+      Y[i] = static_cast<_Float16>(static_cast<float>(Y[i]) +
+                                   alpha * static_cast<float>(X[i]));
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      Y[i * incY] = static_cast<_Float16>(
+        static_cast<float>(Y[i * incY]) +
+        alpha * static_cast<float>(X[i * incX]));
+    }
+  }
+}
+
+_Float16 sdot(const unsigned int N, const _Float16 *X, const unsigned int incX,
+              const _Float16 *Y, const unsigned int incY) {
+  assert(incX > 0 && incY > 0);
+  if (incX == 1 && incY == 1) {
+    unsigned int i = 0;
+    unsigned int N16 = (N & ~15u);
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
+
+    // Main loop: 16 elements with dual accumulators to break dependency
+    for (; i < N16; i += 16) {
+      __m256i x_raw = _mm256_loadu_si256((const __m256i *)(X + i));
+      __m256i y_raw = _mm256_loadu_si256((const __m256i *)(Y + i));
+
+      __m256 xf0 = _mm256_cvtph_ps(_mm256_castsi256_si128(x_raw));
+      __m256 xf1 = _mm256_cvtph_ps(_mm256_extracti128_si256(x_raw, 1));
+      __m256 yf0 = _mm256_cvtph_ps(_mm256_castsi256_si128(y_raw));
+      __m256 yf1 = _mm256_cvtph_ps(_mm256_extracti128_si256(y_raw, 1));
+
+      acc0 = _mm256_fmadd_ps(xf0, yf0, acc0);
+      acc1 = _mm256_fmadd_ps(xf1, yf1, acc1);
+    }
+
+    // Merge accumulators and reduce
+    __m256 acc = _mm256_add_ps(acc0, acc1);
+
+    // Tail: process remaining 8 elements
+    if (i + 8 <= N) {
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+      __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+      acc = _mm256_fmadd_ps(x, y, acc);
+      i += 8;
+    }
+
+    float sum = hsum_avx(acc);
+
+    // Scalar tail
+    for (; i < N; ++i) {
+      sum += static_cast<float>(X[i]) * static_cast<float>(Y[i]);
+    }
+    return static_cast<_Float16>(sum);
+  } else {
+    float sum = 0.0f;
+    for (unsigned int i = 0; i < N; ++i) {
+      sum += static_cast<float>(X[i * incX]) * static_cast<float>(Y[i * incY]);
+    }
+    return static_cast<_Float16>(sum);
+  }
+}
+
+_Float16 snrm2(const unsigned int N, const _Float16 *X,
+               const unsigned int incX) {
+  if (incX == 1) {
+    unsigned int i = 0;
+    unsigned int N16 = (N & ~15u);
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
+
+    // Main loop: 16 elements with dual accumulators
+    for (; i < N16; i += 16) {
+      __m256i x_raw = _mm256_loadu_si256((const __m256i *)(X + i));
+
+      __m256 xf0 = _mm256_cvtph_ps(_mm256_castsi256_si128(x_raw));
+      __m256 xf1 = _mm256_cvtph_ps(_mm256_extracti128_si256(x_raw, 1));
+
+      acc0 = _mm256_fmadd_ps(xf0, xf0, acc0);
+      acc1 = _mm256_fmadd_ps(xf1, xf1, acc1);
+    }
+
+    // Merge accumulators
+    __m256 acc = _mm256_add_ps(acc0, acc1);
+
+    // Tail: process remaining 8 elements
+    if (i + 8 <= N) {
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+      acc = _mm256_fmadd_ps(x, x, acc);
+      i += 8;
+    }
+
+    float sum = hsum_avx(acc);
+
+    // Scalar tail
+    for (; i < N; ++i) {
+      float xf = static_cast<float>(X[i]);
+      sum += xf * xf;
+    }
+    return static_cast<_Float16>(std::sqrt(sum));
+  } else {
+    float sum = 0.0f;
+    for (unsigned int i = 0; i < N; ++i) {
+      float xf = static_cast<float>(X[i * incX]);
+      sum += xf * xf;
+    }
+    return static_cast<_Float16>(std::sqrt(sum));
+  }
+}
+
+void sscal(const unsigned int N, const float alpha, _Float16 *X,
+           const unsigned int incX) {
+  if (incX == 1) {
+    unsigned int i = 0;
+    unsigned int N16 = (N & ~15u);
+    __m256 alpha_v = _mm256_set1_ps(alpha);
+
+    // Main loop: process 16 elements per iteration via 256-bit loads
+    for (; i < N16; i += 16) {
+      __m256i x_raw = _mm256_loadu_si256((const __m256i *)(X + i));
+
+      __m128i x_lo = _mm256_castsi256_si128(x_raw);
+      __m128i x_hi = _mm256_extracti128_si256(x_raw, 1);
+
+      __m256 xf0 = _mm256_cvtph_ps(x_lo);
+      __m256 xf1 = _mm256_cvtph_ps(x_hi);
+
+      __m256 r0 = _mm256_mul_ps(alpha_v, xf0);
+      __m256 r1 = _mm256_mul_ps(alpha_v, xf1);
+
+      __m128i out_lo = _mm256_cvtps_ph(r0, _MM_FROUND_TO_NEAREST_INT);
+      __m128i out_hi = _mm256_cvtps_ph(r1, _MM_FROUND_TO_NEAREST_INT);
+      __m256i out = _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo),
+                                           out_hi, 1);
+      _mm256_storeu_si256((__m256i *)(X + i), out);
+    }
+
+    // Tail: process remaining 8 elements
+    if (i + 8 <= N) {
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+      __m256 result = _mm256_mul_ps(alpha_v, x);
+      _mm_storeu_si128((__m128i *)(X + i),
+                       _mm256_cvtps_ph(result, _MM_FROUND_TO_NEAREST_INT));
+      i += 8;
+    }
+
+    // Scalar tail
+    for (; i < N; ++i) {
+      X[i] = static_cast<_Float16>(alpha * static_cast<float>(X[i]));
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      X[i * incX] = static_cast<_Float16>(alpha * static_cast<float>(X[i * incX]));
+    }
+  }
+}
+
+void custom_scopy(const unsigned int N, const _Float16 *X,
+                  const unsigned int incX, _Float16 *Y,
+                  const unsigned int incY) {
+  if (incX == 1 && incY == 1) {
+    unsigned int i = 0;
+    unsigned int N16 = (N & ~15u);
+    for (; i < N16; i += 16) {
+      __m256i data =
+        _mm256_loadu_si256((const __m256i *)(X + i));
+      _mm256_storeu_si256((__m256i *)(Y + i), data);
+    }
+    for (; i < N; ++i) {
+      Y[i] = X[i];
+    }
+  } else {
+    for (unsigned int i = 0; i < N; ++i) {
+      Y[i * incY] = X[i * incX];
+    }
+  }
+}
+
+// ============================================================
+// FP16 activation/norm functions
+// ============================================================
+
+_Float16 max_val(const unsigned int N, _Float16 *X) {
+  unsigned int i = 0;
+  __m256 vmax0 = _mm256_set1_ps(-std::numeric_limits<float>::infinity());
+  __m256 vmax1 = _mm256_set1_ps(-std::numeric_limits<float>::infinity());
+
+  // Main loop: 16 elements per iteration with dual max accumulators
+  unsigned int N16 = (N & ~15u);
+  for (; i < N16; i += 16) {
+    __m256i raw = _mm256_loadu_si256((const __m256i *)(X + i));
+    __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+    __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+    vmax0 = _mm256_max_ps(vmax0, x0);
+    vmax1 = _mm256_max_ps(vmax1, x1);
+  }
+
+  // Merge dual accumulators
+  __m256 vmax = _mm256_max_ps(vmax0, vmax1);
+
+  // Tail: 8 elements
+  if (i + 8 <= N) {
+    __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+    vmax = _mm256_max_ps(vmax, x);
+    i += 8;
+  }
+
+  // Horizontal max reduction
+  __m128 hi = _mm256_extractf128_ps(vmax, 1);
+  __m128 lo = _mm256_castps256_ps128(vmax);
+  lo = _mm_max_ps(lo, hi);
+  __m128 shuf = _mm_movehl_ps(lo, lo);
+  lo = _mm_max_ps(lo, shuf);
+  shuf = _mm_movehdup_ps(lo);
+  lo = _mm_max_ss(lo, shuf);
+  float result = _mm_cvtss_f32(lo);
+
+  for (; i < N; ++i) {
+    result = std::max(result, static_cast<float>(X[i]));
+  }
+  return static_cast<_Float16>(result);
+}
+
+void softmax(const unsigned int N, _Float16 *X, _Float16 *Y) {
+  // Step 1: find max
+  float max_x = static_cast<float>(max_val(N, X));
+  __m256 vmax = _mm256_set1_ps(max_x);
+
+  // Step 2: exp(x - max) and accumulate sum with 16-wide loop
+  unsigned int i = 0;
+  __m256 vsum0 = _mm256_setzero_ps();
+  __m256 vsum1 = _mm256_setzero_ps();
+
+  for (; i + 16 <= N; i += 16) {
+    __m256i raw = _mm256_loadu_si256((const __m256i *)(X + i));
+    __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+    __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+    __m256 e0 = exp256_ps(_mm256_sub_ps(x0, vmax));
+    __m256 e1 = exp256_ps(_mm256_sub_ps(x1, vmax));
+    __m128i out_lo = _mm256_cvtps_ph(e0, _MM_FROUND_TO_NEAREST_INT);
+    __m128i out_hi = _mm256_cvtps_ph(e1, _MM_FROUND_TO_NEAREST_INT);
+    _mm256_storeu_si256((__m256i *)(Y + i),
+      _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
+    vsum0 = _mm256_add_ps(vsum0, e0);
+    vsum1 = _mm256_add_ps(vsum1, e1);
+  }
+
+  // Tail: 8 elements
+  if (i + 8 <= N) {
+    __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+    __m256 e = exp256_ps(_mm256_sub_ps(x, vmax));
+    _mm_storeu_si128((__m128i *)(Y + i),
+                     _mm256_cvtps_ph(e, _MM_FROUND_TO_NEAREST_INT));
+    vsum0 = _mm256_add_ps(vsum0, e);
+    i += 8;
+  }
+
+  float sum = hsum_avx(_mm256_add_ps(vsum0, vsum1));
+  for (; i < N; ++i) {
+    float e = std::exp(static_cast<float>(X[i]) - max_x);
+    Y[i] = static_cast<_Float16>(e);
+    sum += e;
+  }
+
+  // Step 3: normalize with 16-wide loop
+  float inv_sum = 1.0f / sum;
+  __m256 vinv = _mm256_set1_ps(inv_sum);
+
+  i = 0;
+  for (; i + 16 <= N; i += 16) {
+    __m256i raw = _mm256_loadu_si256((const __m256i *)(Y + i));
+    __m256 y0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+    __m256 y1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+    __m256 r0 = _mm256_mul_ps(y0, vinv);
+    __m256 r1 = _mm256_mul_ps(y1, vinv);
+    __m128i out_lo = _mm256_cvtps_ph(r0, _MM_FROUND_TO_NEAREST_INT);
+    __m128i out_hi = _mm256_cvtps_ph(r1, _MM_FROUND_TO_NEAREST_INT);
+    _mm256_storeu_si256((__m256i *)(Y + i),
+      _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
+  }
+  if (i + 8 <= N) {
+    __m256 y = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+    __m256 result = _mm256_mul_ps(y, vinv);
+    _mm_storeu_si128((__m128i *)(Y + i),
+                     _mm256_cvtps_ph(result, _MM_FROUND_TO_NEAREST_INT));
+    i += 8;
+  }
+  for (; i < N; ++i) {
+    Y[i] = static_cast<_Float16>(static_cast<float>(Y[i]) * inv_sum);
+  }
+}
+
+void inv_sqrt_inplace(const unsigned int N, _Float16 *X) {
+  unsigned int i = 0;
+  const __m256 zero = _mm256_setzero_ps();
+  const __m256 inf_val = _mm256_set1_ps(INFINITY);
+  const __m256 three_half = _mm256_set1_ps(1.5f);
+  const __m256 half = _mm256_set1_ps(0.5f);
+
+  // Main loop: 16 elements per iteration
+  for (; i + 16 <= N; i += 16) {
+    __m256i raw = _mm256_loadu_si256((const __m256i *)(X + i));
+    __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+    __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+
+    __m256 is_zero0 = _mm256_cmp_ps(x0, zero, _CMP_EQ_OQ);
+    __m256 is_zero1 = _mm256_cmp_ps(x1, zero, _CMP_EQ_OQ);
+
+    __m256 est0 = _mm256_rsqrt_ps(x0);
+    __m256 est1 = _mm256_rsqrt_ps(x1);
+
+    // Newton-Raphson: y = y * (1.5 - 0.5 * x * y * y)
+    __m256 half_x0 = _mm256_mul_ps(half, x0);
+    __m256 half_x1 = _mm256_mul_ps(half, x1);
+    __m256 yy0 = _mm256_mul_ps(est0, est0);
+    __m256 yy1 = _mm256_mul_ps(est1, est1);
+    __m256 ref0 = _mm256_mul_ps(est0, _mm256_fnmadd_ps(half_x0, yy0, three_half));
+    __m256 ref1 = _mm256_mul_ps(est1, _mm256_fnmadd_ps(half_x1, yy1, three_half));
+
+    ref0 = _mm256_blendv_ps(ref0, inf_val, is_zero0);
+    ref1 = _mm256_blendv_ps(ref1, inf_val, is_zero1);
+
+    __m128i out_lo = _mm256_cvtps_ph(ref0, _MM_FROUND_TO_NEAREST_INT);
+    __m128i out_hi = _mm256_cvtps_ph(ref1, _MM_FROUND_TO_NEAREST_INT);
+    _mm256_storeu_si256((__m256i *)(X + i),
+      _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
+  }
+
+  // Tail: 8 elements
+  if (i + 8 <= N) {
+    __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+    __m256 is_zero = _mm256_cmp_ps(x, zero, _CMP_EQ_OQ);
+    __m256 est = _mm256_rsqrt_ps(x);
+    __m256 half_x = _mm256_mul_ps(half, x);
+    __m256 yy = _mm256_mul_ps(est, est);
+    __m256 refined = _mm256_mul_ps(est, _mm256_fnmadd_ps(half_x, yy, three_half));
+    refined = _mm256_blendv_ps(refined, inf_val, is_zero);
+    _mm_storeu_si128((__m128i *)(X + i),
+                     _mm256_cvtps_ph(refined, _MM_FROUND_TO_NEAREST_INT));
+    i += 8;
+  }
+
+  // Scalar tail
+  for (; i < N; ++i) {
+    X[i] = static_cast<_Float16>(1.0f / std::sqrt(static_cast<float>(X[i])));
+  }
+}
+
+void swiglu(const unsigned int N, _Float16 *X, _Float16 *Y, _Float16 *Z) {
+  unsigned int i = 0;
+
+  const auto oldcsr = _mm_getcsr();
+  _mm_setcsr(oldcsr | 0x8040); // DAZ | FTZ
+
+  // 16-wide blocks with 256-bit loads/stores
+  for (; i + 16 <= N; i += 16) {
+    __m256i y_raw = _mm256_loadu_si256((const __m256i *)(Y + i));
+    __m256i z_raw = _mm256_loadu_si256((const __m256i *)(Z + i));
+
+    __m256 y0 = _mm256_cvtph_ps(_mm256_castsi256_si128(y_raw));
+    __m256 y1 = _mm256_cvtph_ps(_mm256_extracti128_si256(y_raw, 1));
+    __m256 z0 = _mm256_cvtph_ps(_mm256_castsi256_si128(z_raw));
+    __m256 z1 = _mm256_cvtph_ps(_mm256_extracti128_si256(z_raw, 1));
+
+    __m128i out_lo = _mm256_cvtps_ph(avx2_approx_swiglu(y0, z0),
+                                     _MM_FROUND_TO_NEAREST_INT);
+    __m128i out_hi = _mm256_cvtps_ph(avx2_approx_swiglu(y1, z1),
+                                     _MM_FROUND_TO_NEAREST_INT);
+    _mm256_storeu_si256((__m256i *)(X + i),
+      _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
+  }
+
+  // One 8-wide block if available
+  if (i + 8 <= N) {
+    __m256 y0 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Y + i)));
+    __m256 z0 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(Z + i)));
+    _mm_storeu_si128(
+      (__m128i *)(X + i),
+      _mm256_cvtps_ph(avx2_approx_swiglu(y0, z0), _MM_FROUND_TO_NEAREST_INT));
+    i += 8;
+  }
+
+  // Scalar remainder
+  for (; i < N; ++i) {
+    float yf = static_cast<float>(Y[i]);
+    float zf = static_cast<float>(Z[i]);
+    X[i] = static_cast<_Float16>(
+      (yf / (1.0f + std::exp(-yf))) * zf);
+  }
+
+  _mm_setcsr(oldcsr);
+}
+
+// ============================================================
+// FP16 rms_norm and rotary embedding
+// ============================================================
+
+void rms_norm_wrt_width_fp16(const _Float16 *__restrict X,
+                             _Float16 *__restrict Y, size_t H, size_t W,
+                             float epsilon) {
+  for (size_t h = 0; h < H; ++h) {
+    const _Float16 *rowX = X + h * W;
+    _Float16 *rowY = Y + h * W;
+
+    size_t i = 0;
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
+    __m256 acc2 = _mm256_setzero_ps();
+    __m256 acc3 = _mm256_setzero_ps();
+
+    // Sum-of-squares: 32-wide loop with 256-bit loads
+    for (; i + 32 <= W; i += 32) {
+      __m256i raw0 = _mm256_loadu_si256((const __m256i *)(rowX + i));
+      __m256i raw1 = _mm256_loadu_si256((const __m256i *)(rowX + i + 16));
+      __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw0));
+      __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw0, 1));
+      __m256 x2 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw1));
+      __m256 x3 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw1, 1));
+      acc0 = _mm256_fmadd_ps(x0, x0, acc0);
+      acc1 = _mm256_fmadd_ps(x1, x1, acc1);
+      acc2 = _mm256_fmadd_ps(x2, x2, acc2);
+      acc3 = _mm256_fmadd_ps(x3, x3, acc3);
+    }
+    // 16-wide tail
+    if (i + 16 <= W) {
+      __m256i raw = _mm256_loadu_si256((const __m256i *)(rowX + i));
+      __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+      __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+      acc0 = _mm256_fmadd_ps(x0, x0, acc0);
+      acc1 = _mm256_fmadd_ps(x1, x1, acc1);
+      i += 16;
+    }
+    // 8-wide tail
+    if (i + 8 <= W) {
+      __m256 x =
+        _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(rowX + i)));
+      acc0 = _mm256_fmadd_ps(x, x, acc0);
+      i += 8;
+    }
+    float sumsq =
+      hsum_avx(acc0) + hsum_avx(acc1) + hsum_avx(acc2) + hsum_avx(acc3);
+    for (; i < W; ++i) {
+      float v = static_cast<float>(rowX[i]);
+      sumsq += v * v;
+    }
+
+    float mean = sumsq / static_cast<float>(W);
+    float scale = 1.0f / std::sqrt(mean + epsilon);
+    __m256 vscale = _mm256_set1_ps(scale);
+
+    // Scaling pass: 32-wide loop with 256-bit loads/stores
+    i = 0;
+    for (; i + 32 <= W; i += 32) {
+      __m256i raw0 = _mm256_loadu_si256((const __m256i *)(rowX + i));
+      __m256i raw1 = _mm256_loadu_si256((const __m256i *)(rowX + i + 16));
+      __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw0));
+      __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw0, 1));
+      __m256 x2 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw1));
+      __m256 x3 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw1, 1));
+      __m128i r0 = _mm256_cvtps_ph(_mm256_mul_ps(x0, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r1 = _mm256_cvtps_ph(_mm256_mul_ps(x1, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r2 = _mm256_cvtps_ph(_mm256_mul_ps(x2, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r3 = _mm256_cvtps_ph(_mm256_mul_ps(x3, vscale), _MM_FROUND_TO_NEAREST_INT);
+      _mm256_storeu_si256((__m256i *)(rowY + i),
+        _mm256_inserti128_si256(_mm256_castsi128_si256(r0), r1, 1));
+      _mm256_storeu_si256((__m256i *)(rowY + i + 16),
+        _mm256_inserti128_si256(_mm256_castsi128_si256(r2), r3, 1));
+    }
+    // 16-wide tail
+    if (i + 16 <= W) {
+      __m256i raw = _mm256_loadu_si256((const __m256i *)(rowX + i));
+      __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
+      __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
+      __m128i r0 = _mm256_cvtps_ph(_mm256_mul_ps(x0, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r1 = _mm256_cvtps_ph(_mm256_mul_ps(x1, vscale), _MM_FROUND_TO_NEAREST_INT);
+      _mm256_storeu_si256((__m256i *)(rowY + i),
+        _mm256_inserti128_si256(_mm256_castsi128_si256(r0), r1, 1));
+      i += 16;
+    }
+    // 8-wide tail
+    if (i + 8 <= W) {
+      __m256 x =
+        _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(rowX + i)));
+      _mm_storeu_si128(
+        (__m128i *)(rowY + i),
+        _mm256_cvtps_ph(_mm256_mul_ps(x, vscale), _MM_FROUND_TO_NEAREST_INT));
+      i += 8;
+    }
+    for (; i < W; ++i) {
+      rowY[i] = static_cast<_Float16>(static_cast<float>(rowX[i]) * scale);
+    }
+  }
+}
+
+void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
+                                    unsigned int w, _Float16 *in, _Float16 *out,
+                                    float *cos_, float *sin_) {
+  unsigned int k = 0;
+  for (; k + 7 < half_; k += 8) {
+    unsigned int i0 = w + k;
+    unsigned int i1 = w + k + half_;
+
+    __m256 a = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(in + i0)));
+    __m256 b = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(in + i1)));
+    __m256 cos_v = _mm256_loadu_ps(&cos_[k]);
+    __m256 sin_v = _mm256_loadu_ps(&sin_[k]);
+
+    // FMA: out0 = a*cos - b*sin, out1 = a*sin + b*cos
+    __m256 out0 = _mm256_fmsub_ps(a, cos_v, _mm256_mul_ps(b, sin_v));
+    __m256 out1 = _mm256_fmadd_ps(a, sin_v, _mm256_mul_ps(b, cos_v));
+
+    _mm_storeu_si128(
+      (__m128i *)(out + i0),
+      _mm256_cvtps_ph(out0, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128(
+      (__m128i *)(out + i1),
+      _mm256_cvtps_ph(out1, _MM_FROUND_TO_NEAREST_INT));
+  }
+
+  for (; k < dim; ++k) {
+    unsigned int span = w + k;
+    float value = static_cast<float>(in[span]);
+    float transformed_value;
+    if (k < half_) {
+      transformed_value = -1.0f * static_cast<float>(in[w + k + half_]);
+    } else {
+      transformed_value = static_cast<float>(in[w + k - half_]);
+    }
+    out[span] =
+      static_cast<_Float16>(value * cos_[k] + transformed_value * sin_[k]);
+  }
+}
+
+// ============================================================
+// FP16 Group B functions
+// ============================================================
+
+unsigned int isamax(const unsigned int N, const _Float16 *X,
+                    const unsigned int incX) {
+  if (incX == 1 && N >= 8) {
+    unsigned int N8 = (N & ~7u);
+    __m256 sign_mask = _mm256_set1_ps(-0.0f);
+    unsigned int max_idx = 0;
+    float max_abs = 0.0f;
+
+    for (unsigned int i = 0; i < N8; i += 8) {
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(X + i)));
+      __m256 abs_x = _mm256_andnot_ps(sign_mask, x);
+      // Check each element individually for max tracking
+      alignas(32) float buf[8];
+      _mm256_storeu_ps(buf, abs_x);
+      for (int j = 0; j < 8; ++j) {
+        if (buf[j] > max_abs) {
+          max_abs = buf[j];
+          max_idx = i + j;
+        }
+      }
+    }
+    for (unsigned int i = N8; i < N; ++i) {
+      float cur = std::abs(static_cast<float>(X[i]));
+      if (cur > max_abs) {
+        max_abs = cur;
+        max_idx = i;
+      }
+    }
+    return max_idx;
+  } else {
+    unsigned int max_idx = 0;
+    float max_val = 0.0f;
+    for (unsigned int i = 0; i < N; ++i) {
+      float cur = std::abs(static_cast<float>(X[i * incX]));
+      if (cur > max_val) {
+        max_val = cur;
+        max_idx = i;
+      }
+    }
+    return max_idx;
+  }
+}
+
+void transpose_matrix(const unsigned int M, const unsigned int N,
+                      const _Float16 *src, unsigned int ld_src, _Float16 *dst,
+                      unsigned int ld_dst) {
+  for (unsigned int i = 0; i < M; i++) {
+    for (unsigned int j = 0; j < N; j++) {
+      dst[i + j * ld_dst] = src[i * ld_src + j];
+    }
+  }
+}
+
+void scopy_int4_to_float16(const unsigned int N, const uint8_t *X,
+                           const unsigned int incX, _Float16 *Y,
+                           const unsigned int incY) {
+  if (incX == 1 && incY == 1) {
+    unsigned int i = 0;
+    unsigned int N8 = (N & ~7u);
+    for (; i < N8; i += 8) {
+      alignas(32) float buf[16];
+      for (int j = 0; j < 8; ++j) {
+        buf[2 * j] = static_cast<float>(X[i + j] >> 4);
+        buf[2 * j + 1] = static_cast<float>(X[i + j] & 0x0f);
+      }
+      __m256 v0 = _mm256_loadu_ps(buf);
+      __m256 v1 = _mm256_loadu_ps(buf + 8);
+      _mm_storeu_si128((__m128i *)(Y + 2 * i),
+                       _mm256_cvtps_ph(v0, _MM_FROUND_TO_NEAREST_INT));
+      _mm_storeu_si128((__m128i *)(Y + 2 * i + 8),
+                       _mm256_cvtps_ph(v1, _MM_FROUND_TO_NEAREST_INT));
+    }
+    for (; i < N; ++i) {
+      Y[2 * i] = static_cast<_Float16>(X[i] >> 4);
+      Y[2 * i + 1] = static_cast<_Float16>(X[i] & 0x0f);
+    }
+  } else {
+    for (unsigned int idx = 0; idx < N; idx++) {
+      Y[2 * idx] = static_cast<_Float16>(X[idx] >> 4);
+      Y[2 * idx + 1] = static_cast<_Float16>(X[idx] & 0x0f);
+    }
+  }
+}
+
+void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
+                           const unsigned int incX, _Float16 *Y,
+                           const unsigned int incY) {
+  if (incX == 1 && incY == 1) {
+    unsigned int i = 0;
+    unsigned int N8 = (N & ~7u);
+    for (; i < N8; i += 8) {
+      __m256i xi = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(X + i)));
+      __m256 xf = _mm256_cvtepi32_ps(xi);
+      _mm_storeu_si128((__m128i *)(Y + i),
+                       _mm256_cvtps_ph(xf, _MM_FROUND_TO_NEAREST_INT));
+    }
+    for (; i < N; ++i) {
+      Y[i] = static_cast<_Float16>(X[i]);
+    }
+  } else {
+    for (unsigned int idx = 0; idx < N; idx++) {
+      Y[idx * incY] = static_cast<_Float16>(X[idx * incX]);
+    }
+  }
+}
+
+void scopy_int8_to_float16(const unsigned int N, const int8_t *X,
+                           const unsigned int incX, _Float16 *Y,
+                           const unsigned int incY) {
+  if (incX == 1 && incY == 1) {
+    unsigned int i = 0;
+    unsigned int N8 = (N & ~7u);
+    for (; i < N8; i += 8) {
+      __m256i xi = _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(X + i)));
+      __m256 xf = _mm256_cvtepi32_ps(xi);
+      _mm_storeu_si128((__m128i *)(Y + i),
+                       _mm256_cvtps_ph(xf, _MM_FROUND_TO_NEAREST_INT));
+    }
+    for (; i < N; ++i) {
+      Y[i] = static_cast<_Float16>(X[i]);
+    }
+  } else {
+    for (unsigned int idx = 0; idx < N; idx++) {
+      Y[idx * incY] = static_cast<_Float16>(X[idx * incX]);
+    }
+  }
 }
 
 } // namespace nntrainer::avx2

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
@@ -12,8 +12,8 @@
  *
  */
 
-#include <avx2_impl.h>
 #include "avx2_internal.h"
+#include <avx2_impl.h>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -209,7 +209,8 @@ void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_mul_ps(x_hi, vy);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -233,7 +234,8 @@ void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_mul_ps(x_hi, y_hi);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -275,7 +277,8 @@ void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -308,7 +311,8 @@ void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -327,7 +331,8 @@ void ele_mul(const unsigned int N, const _Float16 *X, const _Float16 *Y,
     for (; i < N; ++i) {
       float xf = static_cast<float>(X[i]);
       float yf = static_cast<float>(Y[i * i_stride]);
-      float zf = xf * alpha * yf + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      float zf = xf * alpha * yf +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
       Z[i] = static_cast<_Float16>(zf);
     }
   } else {
@@ -359,7 +364,8 @@ void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_add_ps(x_hi, vy);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -384,7 +390,8 @@ void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_add_ps(x_hi, y_hi);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -426,7 +433,8 @@ void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -459,7 +467,8 @@ void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -478,16 +487,16 @@ void ele_add(const unsigned int N, const _Float16 *X, const _Float16 *Y,
     for (; i < N; ++i) {
       float xf = static_cast<float>(X[i]);
       float yf = static_cast<float>(Y[i * i_stride]);
-      float zf = xf + alpha * yf + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      float zf = xf + alpha * yf +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
       Z[i] = static_cast<_Float16>(zf);
     }
   } else {
     for (unsigned int i = 0; i < N; ++i) {
       float xf = static_cast<float>(*X);
       float yf = static_cast<float>(*Y);
-      float zf =
-        xf + alpha * yf +
-        ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
+      float zf = xf + alpha * yf +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
       *Z = static_cast<_Float16>(zf);
       X += o_stride;
       Y += i_stride;
@@ -511,7 +520,8 @@ void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_sub_ps(x_hi, vy);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -536,7 +546,8 @@ void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_sub_ps(x_hi, y_hi);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -578,7 +589,8 @@ void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -611,7 +623,8 @@ void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -630,16 +643,16 @@ void ele_sub(const unsigned int N, const _Float16 *X, const _Float16 *Y,
     for (; i < N; ++i) {
       float xf = static_cast<float>(X[i]);
       float yf = static_cast<float>(Y[i * i_stride]);
-      float zf = xf - alpha * yf + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      float zf = xf - alpha * yf +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
       Z[i] = static_cast<_Float16>(zf);
     }
   } else {
     for (unsigned int i = 0; i < N; ++i) {
       float xf = static_cast<float>(*X);
       float yf = static_cast<float>(*Y);
-      float zf =
-        xf - alpha * yf +
-        ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
+      float zf = xf - alpha * yf +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(*Z));
       *Z = static_cast<_Float16>(zf);
       X += o_stride;
       Y += i_stride;
@@ -660,7 +673,8 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
       // Precompute refined reciprocal of Y[0] once (rcp + Newton-Raphson)
       __m256 vy = _mm256_set1_ps(static_cast<float>(Y[0]));
       __m256 rcp_est = _mm256_rcp_ps(vy);
-      __m256 vy_inv = _mm256_mul_ps(rcp_est, _mm256_fnmadd_ps(vy, rcp_est, two));
+      __m256 vy_inv =
+        _mm256_mul_ps(rcp_est, _mm256_fnmadd_ps(vy, rcp_est, two));
 
       for (; i + 16 <= N; i += 16) {
         __m256i xd = _mm256_loadu_si256((const __m256i *)(X + i));
@@ -670,7 +684,8 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 z_hi = _mm256_mul_ps(x_hi, vy_inv);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -693,14 +708,17 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 y_hi = _mm256_cvtph_ps(_mm256_extracti128_si256(yd, 1));
         // rcp + Newton-Raphson for per-element reciprocal
         __m256 rcp_lo = _mm256_rcp_ps(y_lo);
-        __m256 inv_lo = _mm256_mul_ps(rcp_lo, _mm256_fnmadd_ps(y_lo, rcp_lo, two));
+        __m256 inv_lo =
+          _mm256_mul_ps(rcp_lo, _mm256_fnmadd_ps(y_lo, rcp_lo, two));
         __m256 rcp_hi = _mm256_rcp_ps(y_hi);
-        __m256 inv_hi = _mm256_mul_ps(rcp_hi, _mm256_fnmadd_ps(y_hi, rcp_hi, two));
+        __m256 inv_hi =
+          _mm256_mul_ps(rcp_hi, _mm256_fnmadd_ps(y_hi, rcp_hi, two));
         __m256 z_lo = _mm256_mul_ps(x_lo, inv_lo);
         __m256 z_hi = _mm256_mul_ps(x_hi, inv_hi);
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -729,7 +747,8 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
 
     if (i_stride == 0) {
       // Precompute refined reciprocal of (alpha * Y[0])
-      __m256 denom = _mm256_mul_ps(alpha_v, _mm256_set1_ps(static_cast<float>(Y[0])));
+      __m256 denom =
+        _mm256_mul_ps(alpha_v, _mm256_set1_ps(static_cast<float>(Y[0])));
       __m256 rcp_d = _mm256_rcp_ps(denom);
       __m256 inv_d = _mm256_mul_ps(rcp_d, _mm256_fnmadd_ps(denom, rcp_d, two));
 
@@ -748,7 +767,8 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -774,9 +794,11 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         __m256 d_hi = _mm256_mul_ps(alpha_v, y_hi);
         // rcp + Newton-Raphson for per-element reciprocal
         __m256 rcp_lo = _mm256_rcp_ps(d_lo);
-        __m256 inv_lo = _mm256_mul_ps(rcp_lo, _mm256_fnmadd_ps(d_lo, rcp_lo, two));
+        __m256 inv_lo =
+          _mm256_mul_ps(rcp_lo, _mm256_fnmadd_ps(d_lo, rcp_lo, two));
         __m256 rcp_hi = _mm256_rcp_ps(d_hi);
-        __m256 inv_hi = _mm256_mul_ps(rcp_hi, _mm256_fnmadd_ps(d_hi, rcp_hi, two));
+        __m256 inv_hi =
+          _mm256_mul_ps(rcp_hi, _mm256_fnmadd_ps(d_hi, rcp_hi, two));
         __m256 z_lo = _mm256_mul_ps(x_lo, inv_lo);
         __m256 z_hi = _mm256_mul_ps(x_hi, inv_hi);
         if (beta != 0.0f) {
@@ -788,7 +810,8 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
         }
         __m128i r_lo = _mm256_cvtps_ph(z_lo, _MM_FROUND_TO_NEAREST_INT);
         __m128i r_hi = _mm256_cvtps_ph(z_hi, _MM_FROUND_TO_NEAREST_INT);
-        _mm256_storeu_si256((__m256i *)(Z + i),
+        _mm256_storeu_si256(
+          (__m256i *)(Z + i),
           _mm256_inserti128_si256(_mm256_castsi128_si256(r_lo), r_hi, 1));
       }
       for (; i + 8 <= N; i += 8) {
@@ -810,7 +833,8 @@ void ele_div(const unsigned int N, const _Float16 *X, const _Float16 *Y,
     for (; i < N; ++i) {
       float xf = static_cast<float>(X[i]);
       float yf = static_cast<float>(Y[i * i_stride]);
-      float zf = xf / (alpha * yf) + ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
+      float zf = xf / (alpha * yf) +
+                 ((0.0f == beta) ? 0.0f : beta * static_cast<float>(Z[i]));
       Z[i] = static_cast<_Float16>(zf);
     }
   } else {
@@ -858,8 +882,8 @@ void saxpy(const unsigned int N, const float alpha, const _Float16 *X,
 
       __m128i out_lo = _mm256_cvtps_ph(r0, _MM_FROUND_TO_NEAREST_INT);
       __m128i out_hi = _mm256_cvtps_ph(r1, _MM_FROUND_TO_NEAREST_INT);
-      __m256i out = _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo),
-                                           out_hi, 1);
+      __m256i out =
+        _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1);
       _mm256_storeu_si256((__m256i *)(Y + i), out);
     }
 
@@ -880,9 +904,9 @@ void saxpy(const unsigned int N, const float alpha, const _Float16 *X,
     }
   } else {
     for (unsigned int i = 0; i < N; ++i) {
-      Y[i * incY] = static_cast<_Float16>(
-        static_cast<float>(Y[i * incY]) +
-        alpha * static_cast<float>(X[i * incX]));
+      Y[i * incY] =
+        static_cast<_Float16>(static_cast<float>(Y[i * incY]) +
+                              alpha * static_cast<float>(X[i * incX]));
     }
   }
 }
@@ -1006,8 +1030,8 @@ void sscal(const unsigned int N, const float alpha, _Float16 *X,
 
       __m128i out_lo = _mm256_cvtps_ph(r0, _MM_FROUND_TO_NEAREST_INT);
       __m128i out_hi = _mm256_cvtps_ph(r1, _MM_FROUND_TO_NEAREST_INT);
-      __m256i out = _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo),
-                                           out_hi, 1);
+      __m256i out =
+        _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1);
       _mm256_storeu_si256((__m256i *)(X + i), out);
     }
 
@@ -1026,7 +1050,8 @@ void sscal(const unsigned int N, const float alpha, _Float16 *X,
     }
   } else {
     for (unsigned int i = 0; i < N; ++i) {
-      X[i * incX] = static_cast<_Float16>(alpha * static_cast<float>(X[i * incX]));
+      X[i * incX] =
+        static_cast<_Float16>(alpha * static_cast<float>(X[i * incX]));
     }
   }
 }
@@ -1038,8 +1063,7 @@ void custom_scopy(const unsigned int N, const _Float16 *X,
     unsigned int i = 0;
     unsigned int N16 = (N & ~15u);
     for (; i < N16; i += 16) {
-      __m256i data =
-        _mm256_loadu_si256((const __m256i *)(X + i));
+      __m256i data = _mm256_loadu_si256((const __m256i *)(X + i));
       _mm256_storeu_si256((__m256i *)(Y + i), data);
     }
     for (; i < N; ++i) {
@@ -1115,7 +1139,8 @@ void softmax(const unsigned int N, _Float16 *X, _Float16 *Y) {
     __m256 e1 = exp256_ps(_mm256_sub_ps(x1, vmax));
     __m128i out_lo = _mm256_cvtps_ph(e0, _MM_FROUND_TO_NEAREST_INT);
     __m128i out_hi = _mm256_cvtps_ph(e1, _MM_FROUND_TO_NEAREST_INT);
-    _mm256_storeu_si256((__m256i *)(Y + i),
+    _mm256_storeu_si256(
+      (__m256i *)(Y + i),
       _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
     vsum0 = _mm256_add_ps(vsum0, e0);
     vsum1 = _mm256_add_ps(vsum1, e1);
@@ -1151,7 +1176,8 @@ void softmax(const unsigned int N, _Float16 *X, _Float16 *Y) {
     __m256 r1 = _mm256_mul_ps(y1, vinv);
     __m128i out_lo = _mm256_cvtps_ph(r0, _MM_FROUND_TO_NEAREST_INT);
     __m128i out_hi = _mm256_cvtps_ph(r1, _MM_FROUND_TO_NEAREST_INT);
-    _mm256_storeu_si256((__m256i *)(Y + i),
+    _mm256_storeu_si256(
+      (__m256i *)(Y + i),
       _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
   }
   if (i + 8 <= N) {
@@ -1190,15 +1216,18 @@ void inv_sqrt_inplace(const unsigned int N, _Float16 *X) {
     __m256 half_x1 = _mm256_mul_ps(half, x1);
     __m256 yy0 = _mm256_mul_ps(est0, est0);
     __m256 yy1 = _mm256_mul_ps(est1, est1);
-    __m256 ref0 = _mm256_mul_ps(est0, _mm256_fnmadd_ps(half_x0, yy0, three_half));
-    __m256 ref1 = _mm256_mul_ps(est1, _mm256_fnmadd_ps(half_x1, yy1, three_half));
+    __m256 ref0 =
+      _mm256_mul_ps(est0, _mm256_fnmadd_ps(half_x0, yy0, three_half));
+    __m256 ref1 =
+      _mm256_mul_ps(est1, _mm256_fnmadd_ps(half_x1, yy1, three_half));
 
     ref0 = _mm256_blendv_ps(ref0, inf_val, is_zero0);
     ref1 = _mm256_blendv_ps(ref1, inf_val, is_zero1);
 
     __m128i out_lo = _mm256_cvtps_ph(ref0, _MM_FROUND_TO_NEAREST_INT);
     __m128i out_hi = _mm256_cvtps_ph(ref1, _MM_FROUND_TO_NEAREST_INT);
-    _mm256_storeu_si256((__m256i *)(X + i),
+    _mm256_storeu_si256(
+      (__m256i *)(X + i),
       _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
   }
 
@@ -1209,7 +1238,8 @@ void inv_sqrt_inplace(const unsigned int N, _Float16 *X) {
     __m256 est = _mm256_rsqrt_ps(x);
     __m256 half_x = _mm256_mul_ps(half, x);
     __m256 yy = _mm256_mul_ps(est, est);
-    __m256 refined = _mm256_mul_ps(est, _mm256_fnmadd_ps(half_x, yy, three_half));
+    __m256 refined =
+      _mm256_mul_ps(est, _mm256_fnmadd_ps(half_x, yy, three_half));
     refined = _mm256_blendv_ps(refined, inf_val, is_zero);
     _mm_storeu_si128((__m128i *)(X + i),
                      _mm256_cvtps_ph(refined, _MM_FROUND_TO_NEAREST_INT));
@@ -1238,11 +1268,12 @@ void swiglu(const unsigned int N, _Float16 *X, _Float16 *Y, _Float16 *Z) {
     __m256 z0 = _mm256_cvtph_ps(_mm256_castsi256_si128(z_raw));
     __m256 z1 = _mm256_cvtph_ps(_mm256_extracti128_si256(z_raw, 1));
 
-    __m128i out_lo = _mm256_cvtps_ph(avx2_approx_swiglu(y0, z0),
-                                     _MM_FROUND_TO_NEAREST_INT);
-    __m128i out_hi = _mm256_cvtps_ph(avx2_approx_swiglu(y1, z1),
-                                     _MM_FROUND_TO_NEAREST_INT);
-    _mm256_storeu_si256((__m256i *)(X + i),
+    __m128i out_lo =
+      _mm256_cvtps_ph(avx2_approx_swiglu(y0, z0), _MM_FROUND_TO_NEAREST_INT);
+    __m128i out_hi =
+      _mm256_cvtps_ph(avx2_approx_swiglu(y1, z1), _MM_FROUND_TO_NEAREST_INT);
+    _mm256_storeu_si256(
+      (__m256i *)(X + i),
       _mm256_inserti128_si256(_mm256_castsi128_si256(out_lo), out_hi, 1));
   }
 
@@ -1260,8 +1291,7 @@ void swiglu(const unsigned int N, _Float16 *X, _Float16 *Y, _Float16 *Z) {
   for (; i < N; ++i) {
     float yf = static_cast<float>(Y[i]);
     float zf = static_cast<float>(Z[i]);
-    X[i] = static_cast<_Float16>(
-      (yf / (1.0f + std::exp(-yf))) * zf);
+    X[i] = static_cast<_Float16>((yf / (1.0f + std::exp(-yf))) * zf);
   }
 
   _mm_setcsr(oldcsr);
@@ -1308,8 +1338,7 @@ void rms_norm_wrt_width_fp16(const _Float16 *__restrict X,
     }
     // 8-wide tail
     if (i + 8 <= W) {
-      __m256 x =
-        _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(rowX + i)));
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(rowX + i)));
       acc0 = _mm256_fmadd_ps(x, x, acc0);
       i += 8;
     }
@@ -1333,13 +1362,19 @@ void rms_norm_wrt_width_fp16(const _Float16 *__restrict X,
       __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw0, 1));
       __m256 x2 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw1));
       __m256 x3 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw1, 1));
-      __m128i r0 = _mm256_cvtps_ph(_mm256_mul_ps(x0, vscale), _MM_FROUND_TO_NEAREST_INT);
-      __m128i r1 = _mm256_cvtps_ph(_mm256_mul_ps(x1, vscale), _MM_FROUND_TO_NEAREST_INT);
-      __m128i r2 = _mm256_cvtps_ph(_mm256_mul_ps(x2, vscale), _MM_FROUND_TO_NEAREST_INT);
-      __m128i r3 = _mm256_cvtps_ph(_mm256_mul_ps(x3, vscale), _MM_FROUND_TO_NEAREST_INT);
-      _mm256_storeu_si256((__m256i *)(rowY + i),
+      __m128i r0 =
+        _mm256_cvtps_ph(_mm256_mul_ps(x0, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r1 =
+        _mm256_cvtps_ph(_mm256_mul_ps(x1, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r2 =
+        _mm256_cvtps_ph(_mm256_mul_ps(x2, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r3 =
+        _mm256_cvtps_ph(_mm256_mul_ps(x3, vscale), _MM_FROUND_TO_NEAREST_INT);
+      _mm256_storeu_si256(
+        (__m256i *)(rowY + i),
         _mm256_inserti128_si256(_mm256_castsi128_si256(r0), r1, 1));
-      _mm256_storeu_si256((__m256i *)(rowY + i + 16),
+      _mm256_storeu_si256(
+        (__m256i *)(rowY + i + 16),
         _mm256_inserti128_si256(_mm256_castsi128_si256(r2), r3, 1));
     }
     // 16-wide tail
@@ -1347,16 +1382,18 @@ void rms_norm_wrt_width_fp16(const _Float16 *__restrict X,
       __m256i raw = _mm256_loadu_si256((const __m256i *)(rowX + i));
       __m256 x0 = _mm256_cvtph_ps(_mm256_castsi256_si128(raw));
       __m256 x1 = _mm256_cvtph_ps(_mm256_extracti128_si256(raw, 1));
-      __m128i r0 = _mm256_cvtps_ph(_mm256_mul_ps(x0, vscale), _MM_FROUND_TO_NEAREST_INT);
-      __m128i r1 = _mm256_cvtps_ph(_mm256_mul_ps(x1, vscale), _MM_FROUND_TO_NEAREST_INT);
-      _mm256_storeu_si256((__m256i *)(rowY + i),
+      __m128i r0 =
+        _mm256_cvtps_ph(_mm256_mul_ps(x0, vscale), _MM_FROUND_TO_NEAREST_INT);
+      __m128i r1 =
+        _mm256_cvtps_ph(_mm256_mul_ps(x1, vscale), _MM_FROUND_TO_NEAREST_INT);
+      _mm256_storeu_si256(
+        (__m256i *)(rowY + i),
         _mm256_inserti128_si256(_mm256_castsi128_si256(r0), r1, 1));
       i += 16;
     }
     // 8-wide tail
     if (i + 8 <= W) {
-      __m256 x =
-        _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(rowX + i)));
+      __m256 x = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i *)(rowX + i)));
       _mm_storeu_si128(
         (__m128i *)(rowY + i),
         _mm256_cvtps_ph(_mm256_mul_ps(x, vscale), _MM_FROUND_TO_NEAREST_INT));
@@ -1385,12 +1422,10 @@ void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
     __m256 out0 = _mm256_fmsub_ps(a, cos_v, _mm256_mul_ps(b, sin_v));
     __m256 out1 = _mm256_fmadd_ps(a, sin_v, _mm256_mul_ps(b, cos_v));
 
-    _mm_storeu_si128(
-      (__m128i *)(out + i0),
-      _mm256_cvtps_ph(out0, _MM_FROUND_TO_NEAREST_INT));
-    _mm_storeu_si128(
-      (__m128i *)(out + i1),
-      _mm256_cvtps_ph(out1, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128((__m128i *)(out + i0),
+                     _mm256_cvtps_ph(out0, _MM_FROUND_TO_NEAREST_INT));
+    _mm_storeu_si128((__m128i *)(out + i1),
+                     _mm256_cvtps_ph(out1, _MM_FROUND_TO_NEAREST_INT));
   }
 
   for (; k < dim; ++k) {
@@ -1502,7 +1537,8 @@ void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
     unsigned int i = 0;
     unsigned int N8 = (N & ~7u);
     for (; i < N8; i += 8) {
-      __m256i xi = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(X + i)));
+      __m256i xi =
+        _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(X + i)));
       __m256 xf = _mm256_cvtepi32_ps(xi);
       _mm_storeu_si128((__m128i *)(Y + i),
                        _mm256_cvtps_ph(xf, _MM_FROUND_TO_NEAREST_INT));
@@ -1524,7 +1560,8 @@ void scopy_int8_to_float16(const unsigned int N, const int8_t *X,
     unsigned int i = 0;
     unsigned int N8 = (N & ~7u);
     for (; i < N8; i += 8) {
-      __m256i xi = _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(X + i)));
+      __m256i xi =
+        _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(X + i)));
       __m256 xf = _mm256_cvtepi32_ps(xi);
       _mm_storeu_si128((__m128i *)(Y + i),
                        _mm256_cvtps_ph(xf, _MM_FROUND_TO_NEAREST_INT));

--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl_fp16.cpp
@@ -2,7 +2,7 @@
 /**
  * Copyright (C) 2023 Donghyeon Jeong <dhyeon.jeong@samsung.com>
  *
- * @file   avx2_impl.cpp
+ * @file   avx2_impl_fp16.cpp
  * @date   20 Feb 2024
  * @see    https://github.com/nntrainer/nntrainer
  * @author Donghyeon Jeong <dhyeon.jeong@samsung.com>

--- a/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
@@ -139,6 +139,7 @@ constexpr inline float EXP_ARG_MAX = +88.3762626647949f;
 
 // --- Exp2 lookup table ---
 
+/** @brief Exp2 lookup table for fast vectorized exponential approximation */
 template <unsigned N_, typename Ty_ = uint32_t, typename Float_ = float,
           typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
 struct Exp2Table {
@@ -157,6 +158,7 @@ struct Exp2Table {
 };
 
 #if !__has_constexpr_builtin(__builtin_exp2) || !(__cpp_consteval >= 201811L)
+/** @brief Exp2 lookup table explicit specialization for 8-entry float table on platforms lacking consteval */
 template <> struct Exp2Table<8, uint32_t, float> {
   [[nodiscard]] static constexpr auto calculate() noexcept {
     std::array<uint32_t, 8> t = {0x3f800000U, 0x3f7b95c2U, 0x3f7837f0U,

--- a/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Sungsik Kong <ss.kong@samsung.com>
+ *
+ * @file   avx2_internal.h
+ * @date   10 Apr 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Sungsik Kong <ss.kong@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Shared AVX2 SIMD helper functions used by both avx2_impl.cpp and
+ *         avx2_impl_fp16.cpp
+ */
+
+#ifndef __AVX2_INTERNAL_H_
+#define __AVX2_INTERNAL_H_
+#ifdef __cplusplus
+
+#include <array>
+#if __has_include(<bit>)
+#include <bit>
+#endif
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <immintrin.h>
+#include <limits>
+#if __has_include(<numbers>)
+#include <numbers>
+#endif
+#include <type_traits>
+#if __has_include(<version>)
+#include <version>
+#endif
+
+#if !defined(__has_constexpr_builtin)
+#define __has_constexpr_builtin(x) (0)
+#endif
+
+#if !defined(__has_cpp_attribute)
+#define __has_cpp_attribute(x) (0)
+#endif
+
+// VECTORCALL calling-conv (default for x86_64-linux-gnu)
+#if !defined(_nnt_CC_VECTORCALL)
+#if _MSC_VER >= 1700
+#define _nnt_CC_VECTORCALL __vectorcall
+#else
+#define _nnt_CC_VECTORCALL
+#endif
+#endif
+
+// Flatten attribute
+#if !defined(_nnt_ATTR_FLATTEN)
+#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::flatten)
+#define _nnt_ATTR_FLATTEN [[msvc::flatten]]
+#elif __has_cpp_attribute(gnu::flatten)
+#define _nnt_ATTR_FLATTEN [[gnu::flatten]]
+#else
+#define _nnt_ATTR_FLATTEN
+#endif
+#endif
+
+#if !defined(_nnt_ATTR_NOINLINE)
+#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::noinline)
+#define _nnt_ATTR_NOINLINE [[msvc::noinline]]
+#elif __has_cpp_attribute(gnu::noinline)
+#define _nnt_ATTR_NOINLINE [[gnu::noinline]]
+#else
+#define _nnt_ATTR_NOINLINE
+#endif
+#endif
+
+#if !defined(_nnt_ATTR_ALWAYS_INLINE)
+#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::forceinline)
+#define _nnt_ATTR_ALWAYS_INLINE [[msvc::forceinline]]
+#elif __has_cpp_attribute(gnu::always_inline)
+#define _nnt_ATTR_ALWAYS_INLINE [[gnu::always_inline]]
+#endif
+#endif
+
+#if !defined(UNLIKELY)
+#if __has_cpp_attribute(unlikely)
+#define UNLIKELY [[unlikely]]
+#else
+#define UNLIKELY
+#endif
+#endif
+
+namespace nntrainer::avx2::internal {
+
+// --- bit_cast / popcount / power-of-two helpers ---
+
+template <typename To_, typename From_>
+constexpr inline bool concept17_BinaryCastable =
+  sizeof(To_) == sizeof(From_) &&
+  std::is_trivially_copyable_v<From_> &&std::is_trivially_copyable_v<To_>;
+
+template <class To_, class From_>
+inline auto compat_bit_cast(const From_ &src) noexcept
+  -> std::enable_if_t<concept17_BinaryCastable<To_, From_>, To_> {
+#if __cpp_lib_bit_cast >= 201806L
+  return std::bit_cast<To_>(src);
+#else
+  To_ dst;
+  std::memcpy(&dst, &src, sizeof(To_));
+  return dst;
+#endif
+}
+
+[[nodiscard]] constexpr inline unsigned
+constexpr_popcount(uint32_t v) noexcept {
+#if __cpp_lib_bitops >= 201907L
+  return std::popcount(v);
+#else
+  v = v - ((v >> 1) & 0x55555555);
+  v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
+  auto c = (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
+  return c;
+#endif
+}
+
+template <unsigned I_>
+constexpr inline bool concept17_PowerOfTwo = (constexpr_popcount(I_) == 1);
+
+namespace numbers {
+#if __has_include(<numbers>) && __cpp_lib_math_constants >= 201907L
+using std::numbers::ln2_v;
+using std::numbers::log2e_v;
+#else
+template <typename Float_> constexpr inline auto ln2_v = Float_{M_LN2};
+template <typename Float_> constexpr inline auto log2e_v = Float_{M_LOG2E};
+#endif
+} // namespace numbers
+
+// --- Exp constants ---
+
+constexpr inline float EXP_ARG_MIN = -87.0;
+constexpr inline float EXP_ARG_MAX = +88.3762626647949f;
+
+// --- Exp2 lookup table ---
+
+template <unsigned N_, typename Ty_ = uint32_t, typename Float_ = float,
+          typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
+struct Exp2Table {
+  constexpr static inline auto MANTISSA_BITS =
+    std::numeric_limits<Float_>::digits - 1;
+
+#if __cpp_consteval >= 201811L && __has_constexpr_builtin(__builtin_exp2)
+  [[nodiscard]] static consteval auto calculate() noexcept {
+    std::array<Ty_, N_> t;
+    for (unsigned i = 0; i < N_; ++i)
+      t[i] = std::bit_cast<Ty_>(std::exp2(Float_{1.0} * i / N_)) -
+             ((i << MANTISSA_BITS) / N_);
+    return t;
+  }
+#endif
+};
+
+#if !__has_constexpr_builtin(__builtin_exp2) || !(__cpp_consteval >= 201811L)
+template <> struct Exp2Table<8, uint32_t, float> {
+  [[nodiscard]] static constexpr auto calculate() noexcept {
+    std::array<uint32_t, 8> t = {0x3f800000U, 0x3f7b95c2U, 0x3f7837f0U,
+                                 0x3f75fed7U, 0x3f7504f3U, 0x3f75672aU,
+                                 0x3f7744fdU, 0x3f7ac0c7U};
+    return t;
+  }
+};
+#endif
+
+template <unsigned N_>
+alignas(__m256) inline constexpr auto exp2_table_v = Exp2Table<N_>::calculate();
+
+// --- Vectorized exp (lookup-based, used by swiglu) ---
+
+template <unsigned N_, typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
+_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
+avx2_approx_exp_e2lookup(__m256 xs) noexcept {
+  constexpr static uint32_t N_MASK = uint32_t(N_ - 1U);
+  alignas(64) constexpr static auto EXP2_TBL = exp2_table_v<N_>;
+  constexpr static unsigned MANTISSA_BITS =
+    std::numeric_limits<float>::digits - 1;
+
+  xs = _mm256_max_ps(xs, _mm256_set1_ps(EXP_ARG_MIN));
+  xs =
+    _mm256_mul_ps(xs, _mm256_set1_ps(float(1.0 / numbers::ln2_v<double> * N_)));
+  xs = _mm256_min_ps(
+    xs, _mm256_set1_ps(float(EXP_ARG_MAX / numbers::ln2_v<double> * N_)));
+
+  auto xs_int = _mm256_add_ps(xs, _mm256_set1_ps(0x1.8p23f));
+  auto xs_int_as_u32 = _mm256_castps_si256(xs_int);
+  xs_int = _mm256_sub_ps(xs_int, _mm256_set1_ps(0x1.8p23f));
+
+  auto xs_frac = _mm256_sub_ps(xs, xs_int);
+  auto exp2_idxs = _mm256_and_si256(xs_int_as_u32, _mm256_set1_epi32(N_MASK));
+
+  __m256i s_ints;
+  if constexpr (N_ == 8) {
+    auto tbl = _mm256_load_si256((__m256i *)EXP2_TBL.data());
+    s_ints = _mm256_permutevar8x32_epi32(tbl, exp2_idxs);
+  } else {
+    s_ints = _mm256_i32gather_epi32(EXP2_TBL.data(), exp2_idxs, 1);
+  }
+
+  auto xs_uint_shifted = _mm256_slli_epi32(
+    xs_int_as_u32, MANTISSA_BITS - constexpr_popcount(N_MASK));
+  auto s_ints_2 = _mm256_add_epi32(s_ints, xs_uint_shifted);
+  auto s_floats = _mm256_castsi256_ps(s_ints_2);
+
+  static constexpr float poly_d4[] = {0x1.c6af84b912394p-5f / N_ / N_ / N_,
+                                      0x1.ebfce50fac4f3p-3f / N_ / N_,
+                                      0x1.62e42ff0c52d6p-1f / N_};
+
+  const auto C0 = _mm256_set1_ps(poly_d4[0]);
+  const auto C1 = _mm256_set1_ps(poly_d4[1]);
+  const auto C2 = _mm256_set1_ps(poly_d4[2]);
+
+  auto qs0 = _mm256_fmadd_ps(xs_frac, C0, C1);
+  auto xs_frac_pow2 = _mm256_mul_ps(xs_frac, xs_frac);
+  auto qs2 = _mm256_mul_ps(xs_frac, C2);
+
+  xs = _mm256_fmadd_ps(qs0, xs_frac_pow2, qs2);
+
+  return _mm256_fmadd_ps(xs, s_floats, s_floats);
+}
+
+// --- Negate ---
+
+_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
+avx2_negate_ps(__m256 x) noexcept -> __m256 {
+  constexpr auto SIGN_SHIFT = sizeof(float) * 8 - 1;
+  const auto UNDEF = _mm256_undefined_si256();
+  const auto sign_bit =
+    _mm256_slli_epi32(_mm256_cmpeq_epi16(UNDEF, UNDEF), SIGN_SHIFT);
+  auto flt_sign_bit = _mm256_castsi256_ps(sign_bit);
+  auto neg_x = _mm256_xor_ps(x, flt_sign_bit);
+  return neg_x;
+}
+
+// --- SwiGLU helpers ---
+
+_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
+avx2_approx_swiglu(__m256 x, __m256 s) noexcept -> __m256 {
+  auto neg_x = avx2_negate_ps(x);
+  auto inv_sigmoid =
+    _mm256_add_ps(avx2_approx_exp_e2lookup<8>(neg_x), _mm256_set1_ps(1.0f));
+  auto swiglu_nonscaled = _mm256_div_ps(x, inv_sigmoid);
+  return _mm256_mul_ps(swiglu_nonscaled, s);
+}
+
+_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
+avx2_approx_swiglu_alpha(__m256 x, __m256 s, __m256 alpha) noexcept -> __m256 {
+  auto alpha_x = _mm256_mul_ps(alpha, x);
+  auto neg_alpha_x = avx2_negate_ps(alpha_x);
+  auto inv_sigmoid = _mm256_add_ps(avx2_approx_exp_e2lookup<8>(neg_alpha_x),
+                                   _mm256_set1_ps(1.0f));
+  auto swiglu_nonscaled = _mm256_div_ps(x, inv_sigmoid);
+  return _mm256_mul_ps(swiglu_nonscaled, s);
+}
+
+// --- exp256_ps (used by softmax) ---
+
+static inline __m256 exp256_ps(__m256 x) {
+  const __m256 LOG2EF = _mm256_set1_ps(1.44269504088896341f);
+  const __m256 LN2 = _mm256_set1_ps(0.6931471805599453f);
+
+  const __m256 max_x = _mm256_set1_ps(88.3762626647949f);
+  const __m256 min_x = _mm256_set1_ps(-88.3762626647949f);
+  x = _mm256_max_ps(min_x, _mm256_min_ps(max_x, x));
+
+  __m256 fx = _mm256_mul_ps(x, LOG2EF);
+  fx = _mm256_floor_ps(_mm256_add_ps(fx, _mm256_set1_ps(0.5f)));
+
+  __m256 tmp = _mm256_mul_ps(fx, LN2);
+  __m256 r = _mm256_sub_ps(x, tmp);
+
+  const __m256 c0 = _mm256_set1_ps(1.0f);
+  const __m256 c1 = _mm256_set1_ps(1.0f);
+  const __m256 c2 = _mm256_set1_ps(0.5f);
+  const __m256 c3 = _mm256_set1_ps(1.0f / 6.0f);
+  const __m256 c4 = _mm256_set1_ps(1.0f / 24.0f);
+  const __m256 c5 = _mm256_set1_ps(1.0f / 120.0f);
+  const __m256 c6 = _mm256_set1_ps(1.0f / 720.0f);
+  const __m256 c7 = _mm256_set1_ps(1.0f / 5040.0f);
+  const __m256 c8 = _mm256_set1_ps(1.0f / 40320.0f);
+  const __m256 c9 = _mm256_set1_ps(1.0f / 362880.0f);
+  const __m256 c10 = _mm256_set1_ps(1.0f / 3628800.0f);
+
+  __m256 y = c10;
+  y = _mm256_fmadd_ps(y, r, c9);
+  y = _mm256_fmadd_ps(y, r, c8);
+  y = _mm256_fmadd_ps(y, r, c7);
+  y = _mm256_fmadd_ps(y, r, c6);
+  y = _mm256_fmadd_ps(y, r, c5);
+  y = _mm256_fmadd_ps(y, r, c4);
+  y = _mm256_fmadd_ps(y, r, c3);
+  y = _mm256_fmadd_ps(y, r, c2);
+  y = _mm256_fmadd_ps(y, r, c1);
+  y = _mm256_fmadd_ps(y, r, c0);
+
+  __m256i emm0 = _mm256_cvtps_epi32(fx);
+  emm0 = _mm256_add_epi32(emm0, _mm256_set1_epi32(127));
+  emm0 = _mm256_slli_epi32(emm0, 23);
+  __m256 pow2n = _mm256_castsi256_ps(emm0);
+
+  return _mm256_mul_ps(y, pow2n);
+}
+
+// --- rcp_ps (Newton-Raphson reciprocal) ---
+
+static inline __m256 rcp_ps(__m256 x) {
+  __m256 rcp = _mm256_rcp_ps(x);
+  __m256 two = _mm256_set1_ps(2.0f);
+  return _mm256_mul_ps(rcp, _mm256_fnmadd_ps(x, rcp, two));
+}
+
+// --- hsum_avx (horizontal sum) ---
+
+static inline float hsum_avx(__m256 v) {
+  __m128 vlow = _mm256_castps256_ps128(v);
+  __m128 vhigh = _mm256_extractf128_ps(v, 1);
+  vlow = _mm_add_ps(vlow, vhigh);
+  __m128 shuf = _mm_movehdup_ps(vlow);
+  __m128 sums = _mm_add_ps(vlow, shuf);
+  shuf = _mm_movehl_ps(shuf, sums);
+  sums = _mm_add_ss(sums, shuf);
+  return _mm_cvtss_f32(sums);
+}
+
+// --- GELU polynomial approximation (tanh variant) ---
+
+#define gelu_start_tanh -4.38086284326899f
+#define gelu_end_tanh 4.38086284326899f
+
+#define tanh_c_gelu_p0 5.91303808e-6f
+#define tanh_c_gelu_p1 5.00000000e-1f
+#define tanh_c_gelu_p2 3.98865869e-1f
+#define tanh_c_gelu_p4 -6.66574676e-2f
+#define tanh_c_gelu_p6 1.00712610e-2f
+#define tanh_c_gelu_p8 -1.19336340e-3f
+#define tanh_c_gelu_p10 1.09543224e-4f
+#define tanh_c_gelu_p12 -7.55788500e-6f
+#define tanh_c_gelu_p14 3.73374142e-7f
+#define tanh_c_gelu_p16 -1.23162678e-8f
+#define tanh_c_gelu_p18 2.40940960e-10f
+#define tanh_c_gelu_p20 -2.10237709e-12f
+
+static inline __m256 poly_gelu_tanh_avx2(__m256 x) {
+  const __m256 x2 = _mm256_mul_ps(x, x);
+
+  __m256 y = _mm256_mul_ps(x2, _mm256_set1_ps(tanh_c_gelu_p20));
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p18));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p16));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p14));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p12));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p10));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p8));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p6));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p4));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p2));
+  y = _mm256_mul_ps(x2, y);
+
+  __m256 z = _mm256_mul_ps(x, _mm256_set1_ps(tanh_c_gelu_p1));
+  z = _mm256_add_ps(z, _mm256_set1_ps(tanh_c_gelu_p0));
+
+  y = _mm256_add_ps(y, z);
+
+  const __m256 gt_start =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_start_tanh), _CMP_GT_OQ);
+  const __m256 le_end =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_tanh), _CMP_LE_OQ);
+  const __m256 gt_end =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_tanh), _CMP_GT_OQ);
+
+  y = _mm256_and_ps(y, gt_start);
+  y = _mm256_and_ps(y, le_end);
+  __m256 x_hi = _mm256_and_ps(x, gt_end);
+
+  return _mm256_add_ps(y, x_hi);
+}
+
+// --- GELU polynomial approximation (erf variant) ---
+
+#define gelu_start_erf -4.59373833108583f
+#define gelu_end_erf 4.59373833108583f
+
+#define erf_c_gelu_p0 8.70757509e-06f
+#define erf_c_gelu_p1 5.00000000e-1f
+#define erf_c_gelu_p2 3.98833088e-01f
+#define erf_c_gelu_p4 -6.62633808e-02f
+#define erf_c_gelu_p6 9.78776282e-03f
+#define erf_c_gelu_p8 -1.10798998e-03f
+#define erf_c_gelu_p10 9.51056006e-05f
+#define erf_c_gelu_p12 -6.04633051e-06f
+#define erf_c_gelu_p14 2.73076070e-07f
+#define erf_c_gelu_p16 -8.20707325e-09f
+#define erf_c_gelu_p18 1.46115955e-10f
+#define erf_c_gelu_p20 -1.16009840e-12f
+
+static inline __m256 poly_gelu_erf_avx2(__m256 x) {
+  const __m256 x2 = _mm256_mul_ps(x, x);
+
+  __m256 y = _mm256_mul_ps(x2, _mm256_set1_ps(erf_c_gelu_p20));
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p18));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p16));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p14));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p12));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p10));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p8));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p6));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p4));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p2));
+  y = _mm256_mul_ps(x2, y);
+
+  __m256 z = _mm256_mul_ps(x, _mm256_set1_ps(erf_c_gelu_p1));
+  z = _mm256_add_ps(z, _mm256_set1_ps(erf_c_gelu_p0));
+
+  y = _mm256_add_ps(y, z);
+
+  const __m256 gt_start =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_start_erf), _CMP_GT_OQ);
+  const __m256 le_end =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_erf), _CMP_LE_OQ);
+  const __m256 gt_end =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_erf), _CMP_GT_OQ);
+
+  y = _mm256_and_ps(y, gt_start);
+  y = _mm256_and_ps(y, le_end);
+  __m256 x_hi = _mm256_and_ps(x, gt_end);
+
+  return _mm256_add_ps(y, x_hi);
+}
+
+} // namespace nntrainer::avx2::internal
+
+#endif /* __cplusplus */
+#endif /* __AVX2_INTERNAL_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
@@ -158,7 +158,8 @@ struct Exp2Table {
 };
 
 #if !__has_constexpr_builtin(__builtin_exp2) || !(__cpp_consteval >= 201811L)
-/** @brief Exp2 lookup table explicit specialization for 8-entry float table on platforms lacking consteval */
+/** @brief Exp2 lookup table explicit specialization for 8-entry float table on
+ * platforms lacking consteval */
 template <> struct Exp2Table<8, uint32_t, float> {
   [[nodiscard]] static constexpr auto calculate() noexcept {
     std::array<uint32_t, 8> t = {0x3f800000U, 0x3f7b95c2U, 0x3f7837f0U,

--- a/nntrainer/tensor/cpu_backend/x86/avx2_mathfun.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_mathfun.h
@@ -1,0 +1,70 @@
+/**
+ * @file   avx2_mathfun.h
+ * @date   03 Apr 2026
+ * @brief  This is collection of sin, cos function with AVX2 SIMD
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Julien Pommier (original cephes-based algorithm)
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+/** AVX2 implementation of sin, cos
+
+   Inspired by Intel Approximate Math library, and based on the
+   corresponding algorithms of the cephes math library.
+
+   Ported from the NEON implementation (neon_mathfun.h/hxx) to AVX2
+   intrinsics, processing 8 floats at a time instead of 4.
+*/
+
+/** Copyright (C) 2011  Julien Pommier
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  (this is the zlib license)
+*/
+
+#ifndef __AVX2_MATHFUN_H_
+#define __AVX2_MATHFUN_H_
+
+#include <immintrin.h>
+
+/**
+ * @brief     sincos function with AVX2 SIMD
+ * @param[in] x input register variable (__m256, 8 floats)
+ * @param[out] ysin sin register variable (__m256, 8 floats)
+ * @param[out] ycos cos register variable (__m256, 8 floats)
+ */
+inline void sincos256_ps(__m256 x, __m256 *ysin, __m256 *ycos);
+
+/**
+ * @brief     sin function with AVX2 SIMD
+ * @param[in] x input register variable (__m256, 8 floats)
+ * @return    __m256 result of sin(x)
+ */
+inline __m256 sin256_ps(__m256 x);
+
+/**
+ * @brief     cos function with AVX2 SIMD
+ * @param[in] x input register variable (__m256, 8 floats)
+ * @return    __m256 result of cos(x)
+ */
+inline __m256 cos256_ps(__m256 x);
+
+#include "avx2_mathfun.hxx"
+
+#endif /* __AVX2_MATHFUN_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/avx2_mathfun.hxx
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_mathfun.hxx
@@ -1,0 +1,185 @@
+/**
+ * @file   avx2_mathfun.hxx
+ * @date   03 Apr 2026
+ * @brief  This is collection of sin, cos function with AVX2 SIMD
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Julien Pommier (original cephes-based algorithm)
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+/* AVX2 implementation of sin, cos
+
+   Inspired by Intel Approximate Math library, and based on the
+   corresponding algorithms of the cephes math library.
+
+   Ported from the NEON implementation (neon_mathfun.hxx) to AVX2
+   intrinsics, processing 8 floats at a time instead of 4.
+*/
+
+/* Copyright (C) 2011  Julien Pommier
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  (this is the zlib license)
+*/
+
+#define c_minus_cephes_DP1 -0.78515625
+#define c_minus_cephes_DP2 -2.4187564849853515625e-4
+#define c_minus_cephes_DP3 -3.77489497744594108e-8
+#define c_sincof_p0 -1.9515295891E-4
+#define c_sincof_p1 8.3321608736E-3
+#define c_sincof_p2 -1.6666654611E-1
+#define c_coscof_p0 2.443315711809948E-005
+#define c_coscof_p1 -1.388731625493765E-003
+#define c_coscof_p2 4.166664568298827E-002
+#define c_cephes_FOPI 1.27323954473516 // 4 / M_PI
+
+/**
+ * @brief AVX2 equivalent of NEON vtstq_u32 : test bits
+ * @note  returns all 1s per lane where (a & b) != 0
+ *
+ * @param a first operand
+ * @param b second operand
+ * @return __m256i mask with all 1s where (a & b) != 0
+ */
+static inline __m256i _mm256_tst_epi32(__m256i a, __m256i b) {
+  __m256i t = _mm256_and_si256(a, b);
+  __m256i zero = _mm256_setzero_si256();
+  __m256i eq_zero = _mm256_cmpeq_epi32(t, zero);
+  return _mm256_xor_si256(eq_zero, _mm256_cmpeq_epi32(zero, zero));
+}
+
+/* evaluation of 8 sines & cosines at once.
+
+   The code is the exact rewriting of the cephes sinf function.
+   Precision is excellent as long as x < 8192 (I did not bother to
+   take into account the special handling they have for greater values
+   -- it does not return garbage for arguments over 8192, though, but
+   the extra precision is missing).
+
+   Note that it is such that sinf((float)M_PI) = 8.74e-8, which is the
+   surprising but correct result.
+
+   Note also that when you compute sin(x), cos(x) is available at
+   almost no extra price so both sin256_ps and cos256_ps make use of
+   sincos256_ps..
+  */
+/**
+ * @brief sincos function with AVX2 SIMD
+ *
+ * @param x input register variable (__m256, 8 floats)
+ * @param ysin output sin register variable
+ * @param ycos output cos register variable
+ */
+inline void sincos256_ps(__m256 x, __m256 *ysin, __m256 *ycos) {
+  __m256 xmm1, xmm2, xmm3, y;
+
+  __m256i emm2;
+
+  __m256i sign_mask_sin, sign_mask_cos;
+  sign_mask_sin =
+    _mm256_castps_si256(_mm256_cmp_ps(x, _mm256_setzero_ps(), _CMP_LT_OQ));
+  x = _mm256_andnot_ps(_mm256_set1_ps(-0.0f), x); /* abs(x) */
+
+  /* scale by 4/Pi */
+  y = _mm256_mul_ps(x, _mm256_set1_ps(c_cephes_FOPI));
+
+  /* store the integer part of y in emm2 */
+  emm2 = _mm256_cvttps_epi32(y);
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = _mm256_add_epi32(emm2, _mm256_set1_epi32(1));
+  emm2 = _mm256_and_si256(emm2, _mm256_set1_epi32(~1));
+  y = _mm256_cvtepi32_ps(emm2);
+
+  /* get the polynom selection mask
+     there is one polynom for 0 <= x <= Pi/4
+     and another one for Pi/4<x<=Pi/2
+
+     Both branches will be computed.
+  */
+  __m256i poly_mask = _mm256_tst_epi32(emm2, _mm256_set1_epi32(2));
+
+  /* The magic pass: "Extended precision modular arithmetic"
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+  xmm1 = _mm256_mul_ps(y, _mm256_set1_ps(c_minus_cephes_DP1));
+  xmm2 = _mm256_mul_ps(y, _mm256_set1_ps(c_minus_cephes_DP2));
+  xmm3 = _mm256_mul_ps(y, _mm256_set1_ps(c_minus_cephes_DP3));
+  x = _mm256_add_ps(x, xmm1);
+  x = _mm256_add_ps(x, xmm2);
+  x = _mm256_add_ps(x, xmm3);
+
+  sign_mask_sin = _mm256_xor_si256(
+    sign_mask_sin, _mm256_tst_epi32(emm2, _mm256_set1_epi32(4)));
+  sign_mask_cos = _mm256_tst_epi32(_mm256_sub_epi32(emm2, _mm256_set1_epi32(2)),
+                                   _mm256_set1_epi32(4));
+
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) in y1,
+     and the second polynom      (Pi/4 <= x <= 0) in y2 */
+  __m256 z = _mm256_mul_ps(x, x);
+  __m256 y1, y2;
+
+  y1 = _mm256_fmadd_ps(_mm256_set1_ps(c_coscof_p0), z,
+                       _mm256_set1_ps(c_coscof_p1));
+  y2 = _mm256_fmadd_ps(_mm256_set1_ps(c_sincof_p0), z,
+                       _mm256_set1_ps(c_sincof_p1));
+  y1 = _mm256_fmadd_ps(y1, z, _mm256_set1_ps(c_coscof_p2));
+  y2 = _mm256_fmadd_ps(y2, z, _mm256_set1_ps(c_sincof_p2));
+  y1 = _mm256_mul_ps(y1, z);
+  y2 = _mm256_mul_ps(y2, z);
+  y1 = _mm256_mul_ps(y1, z);
+  y2 = _mm256_mul_ps(y2, x);
+  y1 = _mm256_sub_ps(y1, _mm256_mul_ps(z, _mm256_set1_ps(0.5f)));
+  y2 = _mm256_add_ps(y2, x);
+  y1 = _mm256_add_ps(y1, _mm256_set1_ps(1));
+
+  /* select the correct result from the two polynoms */
+  __m256 pm = _mm256_castsi256_ps(poly_mask);
+  __m256 ys = _mm256_blendv_ps(y2, y1, pm);
+  __m256 yc = _mm256_blendv_ps(y1, y2, pm);
+
+  /* apply sign */
+  __m256 sign_bit = _mm256_set1_ps(-0.0f);
+  __m256 neg_ys = _mm256_xor_ps(ys, sign_bit);
+  __m256 neg_yc = _mm256_xor_ps(yc, sign_bit);
+  *ysin = _mm256_blendv_ps(ys, neg_ys, _mm256_castsi256_ps(sign_mask_sin));
+  *ycos = _mm256_blendv_ps(neg_yc, yc, _mm256_castsi256_ps(sign_mask_cos));
+}
+
+/**
+ * @brief sin function with AVX2 SIMD
+ *
+ * @param x input register variable
+ * @return __m256 result of sin(x)
+ */
+inline __m256 sin256_ps(__m256 x) {
+  __m256 ysin, ycos;
+  sincos256_ps(x, &ysin, &ycos);
+  return ysin;
+}
+
+/**
+ * @brief cos function with AVX2 SIMD
+ *
+ * @param x input register variable
+ * @return __m256 result of cos(x)
+ */
+inline __m256 cos256_ps(__m256 x) {
+  __m256 ysin, ycos;
+  sincos256_ps(x, &ysin, &ycos);
+  return ycos;
+}

--- a/nntrainer/tensor/cpu_backend/x86/meson.build
+++ b/nntrainer/tensor/cpu_backend/x86/meson.build
@@ -1,6 +1,8 @@
 simd_interface_x86_headers = [
   'x86_compute_backend.h',
   'avx2_impl.h',
+  'avx2_mathfun.h',
+  'avx2_mathfun.hxx',
 ]
 simd_interface_x86_sources = [
   'x86_compute_backend.cpp',

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -144,16 +144,16 @@ void scopy_int8_to_float32(const unsigned int N, const int8_t *X,
 
 template <>
 void sine(const unsigned int N, float *X, float *Y, float alpha, float beta) {
-  __fallback_sine(N, X, Y, alpha, beta);
+  nntrainer::avx2::sine(N, X, Y, alpha, beta);
 }
 
 template <>
 void cosine(const unsigned int N, float *X, float *Y, float alpha, float beta) {
-  __fallback_cosine(N, X, Y, alpha, beta);
+  nntrainer::avx2::cosine(N, X, Y, alpha, beta);
 }
 
 void inv_sqrt_inplace(const unsigned int N, float *X) {
-  __fallback_inv_sqrt_inplace(N, X);
+  nntrainer::avx2::inv_sqrt_inplace(N, X);
 }
 
 void ele_mul(const unsigned int N, const float *X, const float *Y, float *Z,
@@ -171,13 +171,13 @@ void ele_add(const unsigned int N, const float *X, const float *Y, float *Z,
 void ele_sub(const unsigned N, const float *X, const float *Y, float *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
-  __fallback_ele_sub(N, X, Y, Z, alpha, beta, i_stride, o_stride);
+  nntrainer::avx2::ele_sub(N, X, Y, Z, alpha, beta, i_stride, o_stride);
 }
 
 void ele_div(const unsigned N, const float *X, const float *Y, float *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
-  __fallback_ele_div(N, X, Y, Z, alpha, beta, i_stride, o_stride);
+  nntrainer::avx2::ele_div(N, X, Y, Z, alpha, beta, i_stride, o_stride);
 }
 
 void saxpy(const unsigned int N, const float alpha, const float *X,
@@ -287,8 +287,8 @@ template <>
 void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
                                  float *sin_, unsigned int from,
                                  float attention_scaling) {
-  __fallback_calc_trigonometric_vals_dup(N_half, angle, cos_, sin_, from,
-                                         attention_scaling);
+  nntrainer::avx2::calc_trigonometric_vals_dup(N_half, angle, cos_, sin_, from,
+                                               attention_scaling);
 }
 
 void swiglu(const unsigned int N, float *X, float *Y, float *Z) {
@@ -300,8 +300,7 @@ void swiglu(const unsigned int N, float *X, float *Y, float *Z, float alpha) {
 }
 
 void tanh_gelu(const unsigned int N, const float *X, float *Y) {
-  // AVX implmenetation will be implemented, now fallback instead
-  __fallback_tanh_gelu(N, X, Y);
+  nntrainer::avx2::tanh_gelu(N, X, Y);
 }
 
 void tanh_gelu_v2(const unsigned int N, const float *X, float *Y) {
@@ -313,17 +312,19 @@ void gelu_v2(const unsigned int N, const float *X, float *Y) {
 }
 
 void tanh_gelu_mul(const unsigned int N, float *X, float *Y, float *Z) {
-  __fallback_tanh_gelu_mul(N, X, Y, Z);
+  nntrainer::avx2::tanh_gelu_mul(N, X, Y, Z);
 }
 
 void tanh_gelu_v2_mul(const unsigned int N, float *X, float *Y, float *Z) {
-  __fallback_tanh_gelu_mul(N, X, Y, Z);
+  nntrainer::avx2::tanh_gelu_v2_mul(N, X, Y, Z);
 }
 
-float max_val(const unsigned int N, float *X) { return __fallback_max(N, X); }
+float max_val(const unsigned int N, float *X) {
+  return nntrainer::avx2::max_val(N, X);
+}
 
 void softmax(const unsigned int N, float *X, float *Y) {
-  __fallback_softmax(N, X, Y);
+  nntrainer::avx2::softmax(N, X, Y);
 }
 
 template <>

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend_fp16.cpp
@@ -112,27 +112,24 @@ void hsgemv(const unsigned int TStorageOrder, bool TransA, const unsigned int M,
 
 void sscal(const unsigned int N, const float alpha, _FP16 *X,
            const unsigned int incX) {
-  __fallback_sscal(N, alpha, X, incX);
+  avx2::sscal(N, alpha, X, incX);
 }
 
 _FP16 snrm2(const unsigned int N, const _FP16 *X, const unsigned int incX) {
   assert(incX > 0);
-  _FP16 sum = __fallback_snrm2(N, X, incX);
+  _FP16 sum = avx2::snrm2(N, X, incX);
   return sum;
 }
 
 void scopy(const unsigned int N, const _FP16 *X, const unsigned int incX,
            _FP16 *Y, const unsigned int incY) {
-  if (incX == 1 && incY == 1) {
-    __fallback_scopy(N, X, incX, Y, incY);
-  }
+  avx2::custom_scopy(N, X, incX, Y, incY);
 }
 
 void scopy(const unsigned int N, const float *X, const unsigned int incX,
            _FP16 *Y, const unsigned int incY) {
   if (incX == 1 && incY == 1) {
     nntrainer::avx2::vcvt_f32_f16(N, X, Y);
-
   } else {
     __fallback_scopy(N, X, incX, Y, incY);
   }
@@ -150,33 +147,30 @@ void scopy(const unsigned int N, const _FP16 *X, const unsigned int incX,
 void scopy_int4_to_float16(const unsigned int N, const uint8_t *X,
                            const unsigned int incX, _FP16 *Y,
                            const unsigned int incY) {
-  if (incX == 1 && incY == 1) {
-    __fallback_scopy_int4_to_float16(N, X, incX, Y, incY);
-  }
+  avx2::scopy_int4_to_float16(N, X, incX, Y, incY);
 }
 
 void scopy_int8_to_float16(const unsigned int N, const uint8_t *X,
                            const unsigned int incX, _FP16 *Y,
                            const unsigned int incY) {
-  __fallback_scopy_int8_to_float16(N, X, incX, Y, incY);
+  avx2::scopy_int8_to_float16(N, X, incX, Y, incY);
 }
 
 void scopy_int8_to_float16(const unsigned int N, const int8_t *X,
                            const unsigned int incX, _FP16 *Y,
                            const unsigned int incY) {
-  __fallback_scopy_int8_to_float16(N, X, incX, Y, incY);
+  avx2::scopy_int8_to_float16(N, X, incX, Y, incY);
 }
 
 _FP16 sdot(const unsigned int N, const _FP16 *X, const unsigned int incX,
            const _FP16 *Y, const unsigned int incY) {
   assert(incX > 0 && incY > 0);
-  _FP16 ret = 0;
-  return __fallback_sdot(N, X, incX, Y, incY);
+  return avx2::sdot(N, X, incX, Y, incY);
 }
 
 void saxpy(const unsigned int N, const float alpha, const _FP16 *X,
            const unsigned int incX, _FP16 *Y, const unsigned int incY) {
-  __fallback_saxpy(N, alpha, X, incX, Y, incY);
+  avx2::saxpy(N, alpha, X, incX, Y, incY);
 }
 
 void sgemm(const unsigned int TStorageOrder, bool TransA, bool TransB,
@@ -242,42 +236,42 @@ void sgemv(const unsigned int TStorageOrder, bool TransA, const unsigned int M,
 void ele_mul(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
-  __fallback_ele_mul(N, X, Y, Z, alpha, beta, i_stride, o_stride);
+  avx2::ele_mul(N, X, Y, Z, alpha, beta, i_stride, o_stride);
 }
 
 void ele_add(const unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
-  __fallback_ele_add(N, X, Y, Z, alpha, beta, i_stride, o_stride);
+  avx2::ele_add(N, X, Y, Z, alpha, beta, i_stride, o_stride);
 }
 
 void ele_sub(const unsigned N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
-  __fallback_ele_sub(N, X, Y, Z, alpha, beta, i_stride, o_stride);
+  avx2::ele_sub(N, X, Y, Z, alpha, beta, i_stride, o_stride);
 }
 
 void ele_div(const unsigned N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
              float alpha, float beta, unsigned int i_stride,
              unsigned int o_stride) {
-  __fallback_ele_div(N, X, Y, Z, alpha, beta, i_stride, o_stride);
+  avx2::ele_div(N, X, Y, Z, alpha, beta, i_stride, o_stride);
 }
 
 unsigned int isamax(const unsigned int N, const _FP16 *X,
                     const unsigned int incX) {
   unsigned int max_idx = 0;
-  max_idx = __fallback_isamax(N, X, incX);
+  max_idx = avx2::isamax(N, X, incX);
   return max_idx;
 }
 
 void inv_sqrt_inplace(const unsigned int N, _FP16 *X) {
-  __fallback_inv_sqrt_inplace(N, X);
+  avx2::inv_sqrt_inplace(N, X);
 }
 
 void transpose_matrix(const unsigned int M, const unsigned int N,
                       const _FP16 *src, unsigned int ld_src, _FP16 *dst,
                       unsigned int ld_dst) {
-  __fallback_transpose_matrix(M, N, src, ld_src, dst, ld_dst);
+  avx2::transpose_matrix(M, N, src, ld_src, dst, ld_dst);
 }
 
 bool is_valid(const unsigned int N, const _FP16 *input) {
@@ -287,17 +281,17 @@ bool is_valid(const unsigned int N, const _FP16 *input) {
 void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
                                     unsigned int w, _FP16 *in, _FP16 *out,
                                     float *cos_, float *sin_) {
-  __fallback_compute_rotary_embedding_value(dim, half_, w, in, out, cos_, sin_);
+  avx2::compute_rotary_embedding_value(dim, half_, w, in, out, cos_, sin_);
 }
 
 void swiglu(const unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z) {
-  __fallback_swiglu(N, X, Y, Z);
+  avx2::swiglu(N, X, Y, Z);
 }
 
-_FP16 max_val(const unsigned int N, _FP16 *X) { return __fallback_max(N, X); }
+_FP16 max_val(const unsigned int N, _FP16 *X) { return avx2::max_val(N, X); }
 
 void softmax(const unsigned int N, _FP16 *X, _FP16 *Y) {
-  __fallback_softmax(N, X, Y);
+  avx2::softmax(N, X, Y);
 }
 
 template <> void dequantize_row_q8_0(const void *x_raw, _FP16 *y, int64_t k) {
@@ -314,7 +308,19 @@ template <>
 void gemm_q4_0(const unsigned int M, const unsigned int N, const unsigned int K,
                const _FP16 *A, const unsigned int lda, const void *B,
                const unsigned int ldb, _FP16 *C, const unsigned int ldc) {
-  return __fallback_gemm_q4_0(M, N, K, A, lda, B, ldb, C, ldc);
+  float *A_fp32 = new float[M * lda];
+  float *C_fp32 = new float[M * ldc];
+
+  for (unsigned int i = 0; i < M; ++i)
+    nntrainer::avx2::vcvt_f16_f32(K, A + i * lda, A_fp32 + i * lda);
+
+  __ggml_q4_0_8x8_q8_0_GEMM(M, N, K, A_fp32, lda, B, ldb, C_fp32, ldc);
+
+  for (unsigned int i = 0; i < M; ++i)
+    nntrainer::avx2::vcvt_f32_f16(N, C_fp32 + i * ldc, C + i * ldc);
+
+  delete[] A_fp32;
+  delete[] C_fp32;
 }
 
 template <> void quantize_row_q8_K(const _FP16 *src, void *dst, int64_t k) {
@@ -336,7 +342,7 @@ template <>
 void rms_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
                                        _FP16 *__restrict Y, size_t H, size_t W,
                                        float epsilon) {
-  __fallback_rms_norm_wrt_width_fp16_intrinsic<_FP16>(X, Y, H, W, epsilon);
+  avx2::rms_norm_wrt_width_fp16(X, Y, H, W, epsilon);
 }
 
 void nntr_quant_qs4cx_f32(size_t n, size_t k, void *rhs_native_mtx_f32,

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -613,6 +613,8 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %ifarch %{ix86} x86_64
 %{_includedir}/nntrainer/x86_compute_backend.h
 %{_includedir}/nntrainer/avx2_impl.h
+%{_includedir}/nntrainer/avx2_mathfun.h
+%{_includedir}/nntrainer/avx2_mathfun.hxx
 %endif
 %ifarch aarch64
 %{_includedir}/nntrainer/arm_compute_backend.h

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -2251,10 +2251,8 @@ TEST(nntrainer_cpu_backend_standalone, swiglu_fp16_3072) {
   const int TEST_CNT = 20;
   for (int i = 0; i < TEST_CNT; i++) {
     std::vector<_FP16> X(N), X_ref(N);
-    std::vector<_FP16> Y =
-      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
-    std::vector<_FP16> Z =
-      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Z = generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
     std::vector<_FP16> Y_ref = Y, Z_ref = Z;
 
     nntrainer::__fallback_swiglu(N, X_ref.data(), Y_ref.data(), Z_ref.data());
@@ -2270,10 +2268,8 @@ TEST(nntrainer_cpu_backend_standalone, swiglu_fp16_7) {
   const int TEST_CNT = 20;
   for (int i = 0; i < TEST_CNT; i++) {
     std::vector<_FP16> X(N), X_ref(N);
-    std::vector<_FP16> Y =
-      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
-    std::vector<_FP16> Z =
-      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Z = generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
     std::vector<_FP16> Y_ref = Y, Z_ref = Z;
 
     nntrainer::__fallback_swiglu(N, X_ref.data(), Y_ref.data(), Z_ref.data());
@@ -2344,9 +2340,8 @@ static void run_rotary_emb_fp16_test(unsigned int dim, unsigned int half_) {
 
     nntrainer::__fallback_compute_rotary_embedding_value(
       dim, half_, w, in.data(), out_ref.data(), cos_v.data(), sin_v.data());
-    nntrainer::compute_rotary_embedding_value(dim, half_, w, in.data(),
-                                              out.data(), cos_v.data(),
-                                              sin_v.data());
+    nntrainer::compute_rotary_embedding_value(
+      dim, half_, w, in.data(), out.data(), cos_v.data(), sin_v.data());
 
     auto mse_val = mse<_FP16, _FP16>(out_ref.data(), out.data(), dim);
     ASSERT_LE(mse_val, 0.005f);

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -322,6 +322,9 @@ TEST(nntrainer_cpu_backend_standalone, q4_0_repack_unpack_dequantize) {
   }
 }
 
+/**
+ * @brief test for gemm_q4_0
+ */
 float test_gemm_q4_0(const uint32_t M, const uint32_t K, const uint32_t N,
                      const float *weights, const float *activations,
                      std::vector<float> &ref_dst, bool print = false) {
@@ -368,6 +371,9 @@ float test_gemm_q4_0(const uint32_t M, const uint32_t K, const uint32_t N,
   return mean_squared_error;
 }
 
+/**
+ * @brief test for gemm_q4_K
+ */
 float test_gemm_q4_K(const uint32_t M, const uint32_t K, const uint32_t N,
                      const float *weights, const float *activations,
                      std::vector<float> &ref_dst, bool print = false) {
@@ -411,6 +417,9 @@ float test_gemm_q4_K(const uint32_t M, const uint32_t K, const uint32_t N,
   return mean_squared_error;
 }
 
+/**
+ * @brief test for gemm_q6_K
+ */
 float test_gemm_q6_K(const uint32_t M, const uint32_t K, const uint32_t N,
                      const float *weights, const float *activations,
                      std::vector<float> &ref_dst, bool print = false) {
@@ -448,6 +457,9 @@ float test_gemm_q6_K(const uint32_t M, const uint32_t K, const uint32_t N,
   return mean_squared_error;
 }
 
+/**
+ * @brief run quantization tests
+ */
 static void run_quant_test(const uint32_t M, const uint32_t K, const uint32_t N,
                            float &q4_0_mse, float &q4_k_mse, float &q6_k_mse,
                            bool print = false) {
@@ -544,6 +556,9 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x512x512) {
   ASSERT_LE(q6_k_mse, q4_k_mse);
 }
 
+/**
+ * @brief run vec dot tests
+ */
 static void run_vec_dot_test(const uint32_t K, bool print = false) {
   const int TEST_CNT = 20;
   nanoseconds ref_time = (nanoseconds)0;
@@ -614,6 +629,9 @@ TEST(nntrainer_cpu_backend_standalone, quant_q_6_K_DOT_10240) {
   run_vec_dot_test(K);
 }
 
+/**
+ * @brief run elementwise multiplication test (Z = X ⊙ alpha * Y + beta * Z)
+ */
 static void run_ele_mul_test(const unsigned int N, float alpha, float beta,
                              unsigned int i_stride, unsigned int o_stride,
                              bool print = false) {
@@ -694,6 +712,9 @@ TEST(nntrainer_cpu_backend_standalone, ele_mul_3072_istr_16_ostr_16) {
   run_ele_mul_test(N, alpha, beta, i_stride, o_stride);
 }
 
+/**
+ * @brief run elementwise addition test (Z = X + alpha * Y + beta * Z)
+ */
 static void run_ele_add_test(const unsigned int N, float alpha, float beta,
                              unsigned int i_stride, unsigned int o_stride,
                              bool print = false) {
@@ -1438,6 +1459,292 @@ DECLARE_transform_int4_test_K_N(1024, 648, 32);
 DECLARE_transform_int4_test_K_N(1024, 648, 64);
 DECLARE_transform_int4_test_K_N(1024, 648, 128);
 DECLARE_transform_int4_test_K_N(3072, 8192, 32);
+
+// ============================================================================
+// P1: AVX2 replacement tests for formerly-fallback FP32 functions
+// ============================================================================
+
+static void run_ele_sub_test(const unsigned int N, float alpha, float beta,
+                             unsigned int i_stride, unsigned int o_stride) {
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X =
+      generate_random_vector<float, false>((size_t)N * o_stride);
+    std::vector<float> Y = generate_random_vector<float, false>(
+      std::max<size_t>(1, (size_t)N * i_stride));
+    std::vector<float> Z =
+      generate_random_vector<float, false>((size_t)N * o_stride);
+    std::vector<float> Z_ref = Z;
+
+    nntrainer::__fallback_ele_sub(N, X.data(), Y.data(), Z_ref.data(), alpha,
+                                  beta, i_stride, o_stride);
+    nntrainer::ele_sub(N, X.data(), Y.data(), Z.data(), alpha, beta, i_stride,
+                       o_stride);
+
+    auto mean_squared_error = compute_mse(1, N, Z_ref, Z, false);
+    ASSERT_LE(mean_squared_error, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_sub_3072_istr_0) {
+  run_ele_sub_test(3072, 1.f, 0.f, 0, 1);
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_sub_3072_istr_1) {
+  run_ele_sub_test(3072, 1.f, 0.f, 1, 1);
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_sub_3072_istr_16_ostrid_16) {
+  run_ele_sub_test(3072, 3.f, 2.f, 16, 16);
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_sub_3072_alpha1_beta0_istr_2) {
+  run_ele_sub_test(3072, 1.f, 0.f, 2, 1);
+}
+
+static void run_ele_div_test(const unsigned int N, float alpha, float beta,
+                             unsigned int i_stride, unsigned int o_stride) {
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X =
+      generate_random_vector<float, false>((size_t)N * o_stride);
+    std::vector<float> Y = generate_random_vector<float, false>(
+      std::max<size_t>(1, (size_t)N * i_stride), 0.1f, 1.0f);
+    std::vector<float> Z =
+      generate_random_vector<float, false>((size_t)N * o_stride);
+    std::vector<float> Z_ref = Z;
+
+    nntrainer::__fallback_ele_div(N, X.data(), Y.data(), Z_ref.data(), alpha,
+                                  beta, i_stride, o_stride);
+    nntrainer::ele_div(N, X.data(), Y.data(), Z.data(), alpha, beta, i_stride,
+                       o_stride);
+
+    auto mean_squared_error = compute_mse(1, N, Z_ref, Z, false);
+    ASSERT_LE(mean_squared_error, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_div_3072_istr_0) {
+  run_ele_div_test(3072, 1.f, 0.f, 0, 1);
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_div_3072_istr_1) {
+  run_ele_div_test(3072, 1.f, 0.f, 1, 1);
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_div_3072_istr_16_ostrid_16) {
+  run_ele_div_test(3072, 3.f, 2.f, 16, 16);
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_div_3072_alpha1_beta0_istr_2) {
+  run_ele_div_test(3072, 1.f, 0.f, 2, 1);
+}
+
+TEST(nntrainer_cpu_backend_standalone, tanh_gelu_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N);
+    std::vector<float> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_tanh_gelu(N, X.data(), Y_ref.data());
+    nntrainer::tanh_gelu(N, X.data(), Y.data());
+
+    auto mse = compute_mse(1, N, Y_ref, Y, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, tanh_gelu_mul_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> Y = generate_random_vector<float, false>(N);
+    std::vector<float> Z = generate_random_vector<float, false>(N);
+    std::vector<float> X(N), X_ref(N);
+
+    nntrainer::__fallback_tanh_gelu_mul(N, X_ref.data(), Y.data(), Z.data());
+    // Restore Y since fallback may modify it
+    std::vector<float> Y2 = Y;
+    std::vector<float> Z2 = Z;
+    nntrainer::tanh_gelu_mul(N, X.data(), Y2.data(), Z2.data());
+
+    auto mse = compute_mse(1, N, X_ref, X, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, tanh_gelu_v2_mul_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> Y = generate_random_vector<float, false>(N);
+    std::vector<float> Z = generate_random_vector<float, false>(N);
+    std::vector<float> X(N), X_ref(N);
+
+    nntrainer::__fallback_tanh_gelu_mul(N, X_ref.data(), Y.data(), Z.data());
+    std::vector<float> Y2 = Y;
+    std::vector<float> Z2 = Z;
+    nntrainer::tanh_gelu_v2_mul(N, X.data(), Y2.data(), Z2.data());
+
+    auto mse = compute_mse(1, N, X_ref, X, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, max_val_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N);
+
+    float ref = nntrainer::__fallback_max(N, X.data());
+    float result = nntrainer::max_val(N, X.data());
+
+    ASSERT_FLOAT_EQ(ref, result);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, softmax_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N);
+    std::vector<float> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_softmax(N, X.data(), Y_ref.data());
+    nntrainer::softmax(N, X.data(), Y.data());
+
+    auto mse = compute_mse(1, N, Y_ref, Y, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, inv_sqrt_inplace_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X =
+      generate_random_vector<float, false>(N, 0.01f, 10.0f);
+    std::vector<float> X_ref = X;
+
+    nntrainer::__fallback_inv_sqrt_inplace(N, X_ref.data());
+    nntrainer::inv_sqrt_inplace(N, X.data());
+
+    auto mse = compute_mse(1, N, X_ref, X, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, inv_sqrt_inplace_with_zeros) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X =
+      generate_random_vector<float, false>(N, 0.01f, 10.0f);
+    // Insert zeros at various positions (boundary, middle, tail)
+    X[0] = 0.0f;
+    X[7] = 0.0f; // AVX2 boundary
+    X[8] = 0.0f; // start of second AVX2 chunk
+    X[N / 2] = 0.0f;
+    X[N - 1] = 0.0f; // scalar tail
+    std::vector<float> X_ref = X;
+
+    nntrainer::__fallback_inv_sqrt_inplace(N, X_ref.data());
+    nntrainer::inv_sqrt_inplace(N, X.data());
+
+    for (unsigned int j = 0; j < N; j++) {
+      if (std::isinf(X_ref[j])) {
+        ASSERT_TRUE(std::isinf(X[j]))
+          << "Expected inf at index " << j << ", got " << X[j];
+      } else {
+        ASSERT_FALSE(std::isnan(X[j])) << "Unexpected NaN at index " << j;
+        ASSERT_NEAR(X[j], X_ref[j], 0.001f);
+      }
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sine_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  const float alpha = 0.5f;
+  const float beta = 2.0f;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N);
+    std::vector<float> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_sine(N, X.data(), Y_ref.data(), alpha, beta);
+    nntrainer::sine<float>(N, X.data(), Y.data(), alpha, beta);
+
+    auto mse = compute_mse(1, N, Y_ref, Y, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, cosine_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  const float alpha = 0.5f;
+  const float beta = 2.0f;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N);
+    std::vector<float> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_cosine(N, X.data(), Y_ref.data(), alpha, beta);
+    nntrainer::cosine<float>(N, X.data(), Y.data(), alpha, beta);
+
+    auto mse = compute_mse(1, N, Y_ref, Y, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, tanh_gelu_v2_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> X = generate_random_vector<float, false>(N);
+    std::vector<float> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_tanh_gelu(N, X.data(), Y_ref.data());
+    nntrainer::tanh_gelu_v2(N, X.data(), Y.data());
+
+    auto mse = compute_mse(1, N, Y_ref, Y, false);
+    ASSERT_LE(mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, calc_trigonometric_vals_dup_512) {
+  const unsigned int N_half = 512;
+  const unsigned int N = 2 * N_half;
+  const unsigned int from = 3;
+  const float attention_scaling = 0.5f;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<float> angle =
+      generate_random_vector<float, false>(N_half, 0.0f, 6.28f);
+    std::vector<float> cos_ref(N, 0.0f), sin_ref(N, 0.0f);
+    std::vector<float> cos_out(N, 0.0f), sin_out(N, 0.0f);
+
+    nntrainer::__fallback_calc_trigonometric_vals_dup(
+      N_half, angle.data(), cos_ref.data(), sin_ref.data(), from,
+      attention_scaling);
+    nntrainer::calc_trigonometric_vals_dup<float>(
+      N_half, angle.data(), cos_out.data(), sin_out.data(), from,
+      attention_scaling);
+
+    auto cos_mse = compute_mse(1, N, cos_ref, cos_out, false);
+    auto sin_mse = compute_mse(1, N, sin_ref, sin_out, false);
+    ASSERT_LE(cos_mse, 0.00001f);
+    ASSERT_LE(sin_mse, 0.00001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, rms_norm_fp16_template_float) {
+  GTEST_SKIP()
+    << "rms_norm_wrt_width_fp16_intrinsic<float> is NYI on x86 (tracked for "
+       "separate PR)";
+}
 
 int main(int argc, char **argv) {
   int result = -1;

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -1746,6 +1746,751 @@ TEST(nntrainer_cpu_backend_standalone, rms_norm_fp16_template_float) {
        "separate PR)";
 }
 
+// ============================================================================
+// P2: AVX2+F16C replacement tests for formerly-fallback FP16 functions
+// ============================================================================
+#ifdef ENABLE_FP16
+
+static void run_ele_mul_fp16_test(const unsigned int N, float alpha, float beta,
+                                  unsigned int i_stride,
+                                  unsigned int o_stride) {
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(
+      std::max<size_t>(1, (size_t)N * i_stride));
+    std::vector<_FP16> Z =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Z_ref = Z;
+
+    nntrainer::__fallback_ele_mul(N, X.data(), Y.data(), Z_ref.data(), alpha,
+                                  beta, i_stride, o_stride);
+    nntrainer::ele_mul(N, X.data(), Y.data(), Z.data(), alpha, beta, i_stride,
+                       o_stride);
+
+    auto mse_val = mse<_FP16, _FP16>(Z_ref.data(), Z.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_mul_fp16_3072_istr_0) {
+  run_ele_mul_fp16_test(3072, 1.f, 0.f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_mul_fp16_3072_istr_1) {
+  run_ele_mul_fp16_test(3072, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_mul_fp16_7_istr_1) {
+  run_ele_mul_fp16_test(7, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_mul_fp16_3072_alpha_beta) {
+  run_ele_mul_fp16_test(3072, 3.f, 2.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_mul_fp16_alpha_beta_istr_0) {
+  run_ele_mul_fp16_test(3072, 2.f, 1.5f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_mul_fp16_ostr_2) {
+  run_ele_mul_fp16_test(256, 1.f, 0.f, 1, 2);
+}
+
+static void run_ele_add_fp16_test(const unsigned int N, float alpha, float beta,
+                                  unsigned int i_stride,
+                                  unsigned int o_stride) {
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(
+      std::max<size_t>(1, (size_t)N * i_stride));
+    std::vector<_FP16> Z =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Z_ref = Z;
+
+    nntrainer::__fallback_ele_add(N, X.data(), Y.data(), Z_ref.data(), alpha,
+                                  beta, i_stride, o_stride);
+    nntrainer::ele_add(N, X.data(), Y.data(), Z.data(), alpha, beta, i_stride,
+                       o_stride);
+
+    auto mse_val = mse<_FP16, _FP16>(Z_ref.data(), Z.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_add_fp16_3072_istr_0) {
+  run_ele_add_fp16_test(3072, 1.f, 0.f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_add_fp16_3072_istr_1) {
+  run_ele_add_fp16_test(3072, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_add_fp16_7_istr_1) {
+  run_ele_add_fp16_test(7, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_add_fp16_3072_alpha_beta) {
+  run_ele_add_fp16_test(3072, 3.f, 2.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_add_fp16_alpha_beta_istr_0) {
+  run_ele_add_fp16_test(3072, 2.f, 1.5f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_add_fp16_ostr_2) {
+  run_ele_add_fp16_test(256, 1.f, 0.f, 1, 2);
+}
+
+static void run_ele_sub_fp16_test(const unsigned int N, float alpha, float beta,
+                                  unsigned int i_stride,
+                                  unsigned int o_stride) {
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(
+      std::max<size_t>(1, (size_t)N * i_stride));
+    std::vector<_FP16> Z =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Z_ref = Z;
+
+    nntrainer::__fallback_ele_sub(N, X.data(), Y.data(), Z_ref.data(), alpha,
+                                  beta, i_stride, o_stride);
+    nntrainer::ele_sub(N, X.data(), Y.data(), Z.data(), alpha, beta, i_stride,
+                       o_stride);
+
+    auto mse_val = mse<_FP16, _FP16>(Z_ref.data(), Z.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_3072_istr_0) {
+  run_ele_sub_fp16_test(3072, 1.f, 0.f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_3072_istr_1) {
+  run_ele_sub_fp16_test(3072, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_alpha1_beta0_istr_2) {
+  run_ele_sub_fp16_test(3072, 1.f, 0.f, 2, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_3072_alpha_beta) {
+  run_ele_sub_fp16_test(3072, 3.f, 2.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_alpha_beta_istr_0) {
+  run_ele_sub_fp16_test(3072, 2.f, 1.5f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_7_istr_1) {
+  run_ele_sub_fp16_test(7, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_sub_fp16_ostr_2) {
+  run_ele_sub_fp16_test(256, 1.f, 0.f, 1, 2);
+}
+
+static void run_ele_div_fp16_test(const unsigned int N, float alpha, float beta,
+                                  unsigned int i_stride,
+                                  unsigned int o_stride) {
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(
+      std::max<size_t>(1, (size_t)N * i_stride), 0.1f, 1.0f);
+    std::vector<_FP16> Z =
+      generate_random_vector<_FP16, false>((size_t)N * o_stride);
+    std::vector<_FP16> Z_ref = Z;
+
+    nntrainer::__fallback_ele_div(N, X.data(), Y.data(), Z_ref.data(), alpha,
+                                  beta, i_stride, o_stride);
+    nntrainer::ele_div(N, X.data(), Y.data(), Z.data(), alpha, beta, i_stride,
+                       o_stride);
+
+    auto mse_val = mse<_FP16, _FP16>(Z_ref.data(), Z.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_3072_istr_0) {
+  run_ele_div_fp16_test(3072, 1.f, 0.f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_3072_istr_1) {
+  run_ele_div_fp16_test(3072, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_alpha1_beta0_istr_2) {
+  run_ele_div_fp16_test(3072, 1.f, 0.f, 2, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_3072_alpha_beta) {
+  run_ele_div_fp16_test(3072, 3.f, 2.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_alpha_beta_istr_0) {
+  run_ele_div_fp16_test(3072, 2.f, 1.5f, 0, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_7_istr_1) {
+  run_ele_div_fp16_test(7, 1.f, 0.f, 1, 1);
+}
+TEST(nntrainer_cpu_backend_standalone, ele_div_fp16_ostr_2) {
+  run_ele_div_fp16_test(256, 1.f, 0.f, 1, 2);
+}
+
+TEST(nntrainer_cpu_backend_standalone, saxpy_fp16_3072) {
+  const unsigned int N = 3072;
+  const float alpha = 2.5f;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y_ref = Y;
+
+    nntrainer::__fallback_saxpy(N, alpha, X.data(), 1, Y_ref.data(), 1);
+    nntrainer::saxpy(N, alpha, X.data(), 1, Y.data(), 1);
+
+    auto mse_val = mse<_FP16, _FP16>(Y_ref.data(), Y.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, saxpy_fp16_7) {
+  const unsigned int N = 7;
+  const float alpha = 1.5f;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y_ref = Y;
+
+    nntrainer::__fallback_saxpy(N, alpha, X.data(), 1, Y_ref.data(), 1);
+    nntrainer::saxpy(N, alpha, X.data(), 1, Y.data(), 1);
+
+    auto mse_val = mse<_FP16, _FP16>(Y_ref.data(), Y.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, saxpy_fp16_stride) {
+  const unsigned int N = 512;
+  const float alpha = 2.0f;
+  const unsigned int incX = 2, incY = 3;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N * incX);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N * incY);
+    std::vector<_FP16> Y_ref = Y;
+
+    nntrainer::__fallback_saxpy(N, alpha, X.data(), incX, Y_ref.data(), incY);
+    nntrainer::saxpy(N, alpha, X.data(), incX, Y.data(), incY);
+
+    auto mse_val = mse<_FP16, _FP16>(Y_ref.data(), Y.data(), N * incY);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sdot_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N);
+
+    _FP16 ref = nntrainer::__fallback_sdot(N, X.data(), 1, Y.data(), 1);
+    _FP16 result = nntrainer::sdot(N, X.data(), 1, Y.data(), 1);
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 1.0f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sdot_fp16_5) {
+  const unsigned int N = 5;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N);
+
+    _FP16 ref = nntrainer::__fallback_sdot(N, X.data(), 1, Y.data(), 1);
+    _FP16 result = nntrainer::sdot(N, X.data(), 1, Y.data(), 1);
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 0.01f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sdot_fp16_stride) {
+  const unsigned int N = 512;
+  const unsigned int incX = 2, incY = 3;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N * incX);
+    std::vector<_FP16> Y = generate_random_vector<_FP16, false>(N * incY);
+
+    _FP16 ref = nntrainer::__fallback_sdot(N, X.data(), incX, Y.data(), incY);
+    _FP16 result = nntrainer::sdot(N, X.data(), incX, Y.data(), incY);
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 1.0f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, snrm2_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+
+    _FP16 ref = nntrainer::__fallback_snrm2(N, X.data(), 1);
+    _FP16 result = nntrainer::snrm2(N, X.data(), 1);
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 1.0f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, snrm2_fp16_5) {
+  const unsigned int N = 5;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+
+    _FP16 ref = nntrainer::__fallback_snrm2(N, X.data(), 1);
+    _FP16 result = nntrainer::snrm2(N, X.data(), 1);
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 0.01f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, snrm2_fp16_stride) {
+  const unsigned int N = 512;
+  const unsigned int incX = 2;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N * incX);
+
+    _FP16 ref = nntrainer::__fallback_snrm2(N, X.data(), incX);
+    _FP16 result = nntrainer::snrm2(N, X.data(), incX);
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 1.0f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sscal_fp16_3072) {
+  const unsigned int N = 3072;
+  const float alpha = 2.0f;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> X_ref = X;
+
+    nntrainer::__fallback_sscal(N, alpha, X_ref.data(), 1);
+    nntrainer::sscal(N, alpha, X.data(), 1);
+
+    auto mse_val = mse<_FP16, _FP16>(X_ref.data(), X.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sscal_fp16_5) {
+  const unsigned int N = 5;
+  const float alpha = 3.0f;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> X_ref = X;
+
+    nntrainer::__fallback_sscal(N, alpha, X_ref.data(), 1);
+    nntrainer::sscal(N, alpha, X.data(), 1);
+
+    auto mse_val = mse<_FP16, _FP16>(X_ref.data(), X.data(), N);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, sscal_fp16_stride) {
+  const unsigned int N = 512;
+  const float alpha = 2.0f;
+  const unsigned int incX = 2;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N * incX);
+    std::vector<_FP16> X_ref = X;
+
+    nntrainer::__fallback_sscal(N, alpha, X_ref.data(), incX);
+    nntrainer::sscal(N, alpha, X.data(), incX);
+
+    auto mse_val = mse<_FP16, _FP16>(X_ref.data(), X.data(), N * incX);
+    ASSERT_LE(mse_val, 0.0001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y(N, (_FP16)0);
+    std::vector<_FP16> Y_ref(N, (_FP16)0);
+
+    nntrainer::__fallback_scopy(N, X.data(), 1, Y_ref.data(), 1);
+    nntrainer::scopy(N, X.data(), 1, Y.data(), 1);
+
+    for (unsigned int j = 0; j < N; j++) {
+      ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_fp16_5) {
+  const unsigned int N = 5;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y(N, (_FP16)0);
+    std::vector<_FP16> Y_ref(N, (_FP16)0);
+
+    nntrainer::__fallback_scopy(N, X.data(), 1, Y_ref.data(), 1);
+    nntrainer::scopy(N, X.data(), 1, Y.data(), 1);
+
+    for (unsigned int j = 0; j < N; j++) {
+      ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, max_val_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+
+    _FP16 ref = nntrainer::__fallback_max(N, X.data());
+    _FP16 result = nntrainer::max_val(N, X.data());
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 0.001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, max_val_fp16_7) {
+  const unsigned int N = 7;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+
+    _FP16 ref = nntrainer::__fallback_max(N, X.data());
+    _FP16 result = nntrainer::max_val(N, X.data());
+
+    ASSERT_NEAR(static_cast<float>(ref), static_cast<float>(result), 0.001f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, softmax_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_softmax(N, X.data(), Y_ref.data());
+    nntrainer::softmax(N, X.data(), Y.data());
+
+    auto mse_val = mse<_FP16, _FP16>(Y_ref.data(), Y.data(), N);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, softmax_fp16_7) {
+  const unsigned int N = 7;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+    std::vector<_FP16> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_softmax(N, X.data(), Y_ref.data());
+    nntrainer::softmax(N, X.data(), Y.data());
+
+    auto mse_val = mse<_FP16, _FP16>(Y_ref.data(), Y.data(), N);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, inv_sqrt_inplace_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X =
+      generate_random_vector<_FP16, false>(N, 0.01f, 10.0f);
+    std::vector<_FP16> X_ref = X;
+
+    nntrainer::__fallback_inv_sqrt_inplace(N, X_ref.data());
+    nntrainer::inv_sqrt_inplace(N, X.data());
+
+    auto mse_val = mse<_FP16, _FP16>(X_ref.data(), X.data(), N);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, inv_sqrt_inplace_fp16_with_zeros) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X =
+      generate_random_vector<_FP16, false>(N, 0.01f, 10.0f);
+    X[0] = (_FP16)0.0f;
+    X[7] = (_FP16)0.0f;
+    X[8] = (_FP16)0.0f;
+    X[N / 2] = (_FP16)0.0f;
+    X[N - 1] = (_FP16)0.0f;
+    std::vector<_FP16> X_ref = X;
+
+    nntrainer::__fallback_inv_sqrt_inplace(N, X_ref.data());
+    nntrainer::inv_sqrt_inplace(N, X.data());
+
+    for (unsigned int j = 0; j < N; j++) {
+      if (std::isinf(static_cast<float>(X_ref[j]))) {
+        ASSERT_TRUE(std::isinf(static_cast<float>(X[j])))
+          << "Expected inf at index " << j << ", got "
+          << static_cast<float>(X[j]);
+      } else {
+        ASSERT_FALSE(std::isnan(static_cast<float>(X[j])))
+          << "Unexpected NaN at index " << j;
+        ASSERT_NEAR(static_cast<float>(X[j]), static_cast<float>(X_ref[j]),
+                    0.01f);
+      }
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, swiglu_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X(N), X_ref(N);
+    std::vector<_FP16> Y =
+      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Z =
+      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Y_ref = Y, Z_ref = Z;
+
+    nntrainer::__fallback_swiglu(N, X_ref.data(), Y_ref.data(), Z_ref.data());
+    nntrainer::swiglu(N, X.data(), Y.data(), Z.data());
+
+    auto mse_val = mse<_FP16, _FP16>(X_ref.data(), X.data(), N);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, swiglu_fp16_7) {
+  const unsigned int N = 7;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X(N), X_ref(N);
+    std::vector<_FP16> Y =
+      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Z =
+      generate_random_vector<_FP16, false>(N, -2.0f, 2.0f);
+    std::vector<_FP16> Y_ref = Y, Z_ref = Z;
+
+    nntrainer::__fallback_swiglu(N, X_ref.data(), Y_ref.data(), Z_ref.data());
+    nntrainer::swiglu(N, X.data(), Y.data(), Z.data());
+
+    auto mse_val = mse<_FP16, _FP16>(X_ref.data(), X.data(), N);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+static void run_rms_norm_fp16_test(size_t H, size_t W) {
+  const float epsilon = 1e-6f;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(H * W);
+    std::vector<_FP16> Y(H * W);
+    std::vector<float> Y_ref(H * W);
+
+    // Compute reference in FP32
+    for (size_t h = 0; h < H; h++) {
+      float sum_sq = 0.0f;
+      for (size_t w = 0; w < W; w++) {
+        float val = static_cast<float>(X[h * W + w]);
+        sum_sq += val * val;
+      }
+      float scale = 1.0f / std::sqrt(sum_sq / W + epsilon);
+      for (size_t w = 0; w < W; w++) {
+        Y_ref[h * W + w] = static_cast<float>(X[h * W + w]) * scale;
+      }
+    }
+
+    nntrainer::rms_norm_wrt_width_fp16_intrinsic<_FP16>(X.data(), Y.data(), H,
+                                                        W, epsilon);
+
+    auto mse_val = mse<_FP16, float>(Y.data(), Y_ref.data(), H * W);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, rms_norm_fp16_3072) {
+  run_rms_norm_fp16_test(4, 3072);
+}
+TEST(nntrainer_cpu_backend_standalone, rms_norm_fp16_13) {
+  run_rms_norm_fp16_test(4, 13);
+}
+TEST(nntrainer_cpu_backend_standalone, rms_norm_fp16_100) {
+  run_rms_norm_fp16_test(4, 100);
+}
+
+static void run_rotary_emb_fp16_test(unsigned int dim, unsigned int half_) {
+  const unsigned int w = 0;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> in =
+      generate_random_vector<_FP16, false>(dim, -1.0f, 1.0f);
+    std::vector<float> cos_half =
+      generate_random_vector<float, false>(half_, -1.0f, 1.0f);
+    std::vector<float> sin_half =
+      generate_random_vector<float, false>(half_, -1.0f, 1.0f);
+    std::vector<float> cos_v(dim), sin_v(dim);
+    for (unsigned int k = 0; k < half_; k++) {
+      cos_v[k] = cos_half[k];
+      cos_v[k + half_] = cos_half[k];
+      sin_v[k] = sin_half[k];
+      sin_v[k + half_] = sin_half[k];
+    }
+    std::vector<_FP16> out(dim), out_ref(dim);
+
+    nntrainer::__fallback_compute_rotary_embedding_value(
+      dim, half_, w, in.data(), out_ref.data(), cos_v.data(), sin_v.data());
+    nntrainer::compute_rotary_embedding_value(dim, half_, w, in.data(),
+                                              out.data(), cos_v.data(),
+                                              sin_v.data());
+
+    auto mse_val = mse<_FP16, _FP16>(out_ref.data(), out.data(), dim);
+    ASSERT_LE(mse_val, 0.005f);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, compute_rotary_emb_fp16_avx2) {
+  run_rotary_emb_fp16_test(64, 32);
+}
+TEST(nntrainer_cpu_backend_standalone, compute_rotary_emb_fp16_non_aligned) {
+  run_rotary_emb_fp16_test(26, 13);
+}
+TEST(nntrainer_cpu_backend_standalone, compute_rotary_emb_fp16_128) {
+  run_rotary_emb_fp16_test(128, 64);
+}
+
+TEST(nntrainer_cpu_backend_standalone, isamax_fp16_3072) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+
+    unsigned int ref = nntrainer::__fallback_isamax(N, X.data(), 1);
+    unsigned int result = nntrainer::isamax(N, X.data(), 1);
+
+    ASSERT_EQ(ref, result);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, isamax_fp16_5) {
+  const unsigned int N = 5;
+  const int TEST_CNT = 20;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> X = generate_random_vector<_FP16, false>(N);
+
+    unsigned int ref = nntrainer::__fallback_isamax(N, X.data(), 1);
+    unsigned int result = nntrainer::isamax(N, X.data(), 1);
+
+    ASSERT_EQ(ref, result);
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, transpose_matrix_fp16) {
+  const unsigned int M = 32;
+  const unsigned int N = 64;
+  const int TEST_CNT = 5;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> src = generate_random_vector<_FP16, false>(M * N);
+    std::vector<_FP16> dst(M * N), dst_ref(M * N);
+
+    nntrainer::__fallback_transpose_matrix(M, N, src.data(), N, dst_ref.data(),
+                                           M);
+    nntrainer::transpose_matrix(M, N, src.data(), N, dst.data(), M);
+
+    for (unsigned int j = 0; j < M * N; j++) {
+      ASSERT_EQ(static_cast<float>(dst[j]), static_cast<float>(dst_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, transpose_matrix_fp16_small) {
+  const unsigned int M = 3;
+  const unsigned int N = 5;
+  const int TEST_CNT = 5;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<_FP16> src = generate_random_vector<_FP16, false>(M * N);
+    std::vector<_FP16> dst(M * N), dst_ref(M * N);
+
+    nntrainer::__fallback_transpose_matrix(M, N, src.data(), N, dst_ref.data(),
+                                           M);
+    nntrainer::transpose_matrix(M, N, src.data(), N, dst.data(), M);
+
+    for (unsigned int j = 0; j < M * N; j++) {
+      ASSERT_EQ(static_cast<float>(dst[j]), static_cast<float>(dst_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_int8_to_fp16_uint8) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 5;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<uint8_t> X(N);
+    std::mt19937 gen(42);
+    std::uniform_int_distribution<int> dist(0, 255);
+    for (auto &v : X)
+      v = static_cast<uint8_t>(dist(gen));
+    std::vector<_FP16> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_scopy_int8_to_float16(N, X.data(), 1, Y_ref.data(),
+                                                1);
+    nntrainer::scopy_int8_to_float16(N, X.data(), 1, Y.data(), 1);
+
+    for (unsigned int j = 0; j < N; j++) {
+      ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_int8_to_fp16_int8) {
+  const unsigned int N = 3072;
+  const int TEST_CNT = 5;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<int8_t> X(N);
+    std::mt19937 gen(42);
+    std::uniform_int_distribution<int> dist(-128, 127);
+    for (auto &v : X)
+      v = static_cast<int8_t>(dist(gen));
+    std::vector<_FP16> Y(N), Y_ref(N);
+
+    nntrainer::__fallback_scopy_int8_to_float16(N, X.data(), 1, Y_ref.data(),
+                                                1);
+    nntrainer::scopy_int8_to_float16(N, X.data(), 1, Y.data(), 1);
+
+    for (unsigned int j = 0; j < N; j++) {
+      ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
+    }
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, scopy_int4_to_fp16) {
+  const unsigned int N_bytes = 1536;
+  const unsigned int N_out = 2 * N_bytes;
+  const int TEST_CNT = 5;
+  for (int i = 0; i < TEST_CNT; i++) {
+    std::vector<uint8_t> X(N_bytes);
+    std::mt19937 gen(42);
+    std::uniform_int_distribution<int> dist(0, 255);
+    for (auto &v : X)
+      v = static_cast<uint8_t>(dist(gen));
+    std::vector<_FP16> Y(N_out), Y_ref(N_out);
+
+    nntrainer::__fallback_scopy_int4_to_float16(N_bytes, X.data(), 1,
+                                                Y_ref.data(), 1);
+    nntrainer::scopy_int4_to_float16(N_bytes, X.data(), 1, Y.data(), 1);
+
+    for (unsigned int j = 0; j < N_out; j++) {
+      ASSERT_EQ(static_cast<float>(Y[j]), static_cast<float>(Y_ref[j]));
+    }
+  }
+}
+
+#endif // ENABLE_FP16
+
 int main(int argc, char **argv) {
   int result = -1;
 


### PR DESCRIPTION
## Dependency of the PR
+ Depends on: #3820 , #3834
+ Related to: #3821 

## Commits to be reviewed in this PR

<details><summary>refactor: extract shared AVX2 helpers into avx2_internal.h (5699b4e5) </summary><br />

- Add `avx2_internal.h` for shared AVX2 utility functions.
- Move common helpers used by FP32/FP16 kernels:
  - `exp256_ps`
  - `rcp_ps`
  - `hsum_avx`
  - GELU/SwiGLU polynomial helper routines
  - AVX2 constants and compiler attribute helpers
- Reduce duplicated helper code before adding FP16 AVX2/F16C kernels.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: YongHyeon02 <dyddyd8574@snu.ac.kr>

</details>

<details><summary>feat: replace FP16 scalar fallbacks with AVX2+F16C SIMD implementations (192e3d43)</summary><br />

Add AVX2+F16C optimized FP16 backend implementations and connect them to the x86 FP16 dispatch layer.

Add `avx2_impl_fp16.cpp` implementations for:
- FP16 conversion:
  - `vcvt_f16_f32`
  - `vcvt_f32_f16`
- Element-wise ops:
  - `ele_mul`
  - `ele_add`
  - `ele_sub`
  - `ele_div`
- BLAS-like vector ops:
  - `saxpy`
  - `sdot`
  - `snrm2`
  - `sscal`
  - `custom_scopy`
- Reduction / activation / normalization:
  - `max_val`
  - `softmax`
  - `inv_sqrt_inplace`
  - `swiglu`
  - `rms_norm_wrt_width_fp16`
- LLM-related helper ops:
  - `compute_rotary_embedding_value`
  - `isamax`
  - `transpose_matrix`
  - `scopy_int4_to_float16`
  - `scopy_int8_to_float16`

Implementation details:
- Use F16C conversion instructions to convert FP16 data to FP32 SIMD vectors.
- Perform arithmetic in FP32 using AVX2 intrinsics.
- Convert results back to FP16 before storing.
- Preserve the existing NNTrainer CPU backend public interface.

Integrate AVX2 dispatch into `x86_compute_backend_fp16.cpp` for:
- FP16 element-wise ops
- FP16 BLAS-like ops
- FP16 softmax / max / inv_sqrt
- FP16 SwiGLU / RMSNorm
- FP16 rotary embedding
- FP16 transpose
- int4/int8 to FP16 copy

Add unit tests for:
- FP16 element-wise operations
- FP16 BLAS-like operations
- FP16 softmax / max / inv_sqrt
- FP16 SwiGLU / RMSNorm
- FP16 rotary embedding
- FP16 transpose
- int4/int8 to FP16 conversion

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: YongHyeon02 <dyddyd8574@snu.ac.kr>

</details>

<details><summary>fix: correct macro typos and strengthen FP16 AVX2 test coverage (fbb8ccf5)</summary><br />

Fix minor macro issues and expand FP16 AVX2 unit test coverage.

Changes:
- Correct FP16 AVX2 related macro typo.
- Add additional unit tests for edge cases and non-contiguous layouts.
- Strengthen tests for element-wise operations with:
  - `i_stride == 0`
  - `i_stride == 1`
  - `i_stride > 1`
  - `o_stride > 1`
  - alpha / beta scaling
  - small tail sizes such as `N=5` and `N=7`

Additional tests include:
- `saxpy_fp16_stride`
- `sdot_fp16_stride`
- `snrm2_fp16_stride`
- `sscal_fp16_stride`
- `rms_norm_fp16_13`
- `rms_norm_fp16_100`
- `compute_rotary_emb_fp16_non_aligned`
- `transpose_matrix_fp16_small`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: YongHyeon02 <dyddyd8574@snu.ac.kr>

</details>

<details><summary>feat: apply 256-bit unrolling and FMA to AVX2 fp16 element-wise ops(ele_*) (8e1a21d0)</summary><br />

Optimize FP16 element-wise kernels using 256-bit FP16 load/store and FMA instructions.

Optimized functions:
- `ele_mul`
- `ele_add`
- `ele_sub`
- `ele_div`

Changes:
- Process 16 FP16 elements per main loop iteration.
- Load 16 FP16 values using `_mm256_loadu_si256`.
- Split the 256-bit FP16 data into two 128-bit halves.
- Convert each half into `__m256` FP32 vectors using `_mm256_cvtph_ps`.
- Perform computation using AVX2/FMA.
- Convert two FP32 vectors back to FP16 using `_mm256_cvtps_ph`.
- Store 16 FP16 results using `_mm256_storeu_si256`.

FMA optimizations:
- Replace multiply + add patterns with `_mm256_fmadd_ps`.
- Replace subtract multiply pattern with `_mm256_fnmadd_ps` where applicable.
- Apply FMA to alpha/beta paths such as:
  - `Z = X + alpha * Y + beta * Z`
  - `Z = X - alpha * Y + beta * Z`

Fallback behavior:
- Use vectorized path for contiguous or simple stride cases.
- Preserve scalar fallback path for unsupported stride/layout cases.
- Keep scalar tail handling for remaining elements.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: KWSMooBang <40kimwoosung@gmail.com>

</details>

<details><summary>feat: optimize BLAS ops with 256-bit unrolling and FMA for RoPE (1673977e)</summary><br />

Optimized BLAS-like functions:
- `saxpy`
- `sdot`
- `snrm2`
- `sscal`

Changes:
- Add 16-wide FP16 processing path using 256-bit loads/stores.
- Use `_mm256_fmadd_ps` for multiply-add operations.
- Use dual accumulators in reduction kernels to reduce dependency chains:
  - `sdot`: two FP32 vector accumulators for dot product
  - `snrm2`: two FP32 vector accumulators for sum of squares
- Accumulate in FP32 to reduce precision loss before converting to FP16.

RoPE optimization:
- Optimize `compute_rotary_embedding_value`.
- Use FMA instructions for rotary embedding equations:
  - `out0 = a * cos - b * sin`
  - `out1 = a * sin + b * cos`
- Replace separate multiply/add/sub operations with `_mm256_fmsub_ps` and `_mm256_fmadd_ps`.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: KWSMooBang <40kimwoosung@gmail.com>

</details>

<details><summary>feat: optimize x86 fp16 ele_div and inv_sqrt using Newton-Raphson FMA (48b672d3)</summary><br />

Optimize FP16 division and inverse square-root paths using reciprocal approximation and Newton-Raphson refinement.

Optimized functions:
- `ele_div`
- `inv_sqrt_inplace`

`ele_div` changes:
- Replace direct vector division with reciprocal approximation.
- Use `_mm256_rcp_ps` to get an approximate reciprocal.
- Apply one Newton-Raphson refinement step:
  - `inv_y = rcp_y * (2 - y * rcp_y)`
- Multiply input by refined reciprocal instead of using direct division.
- Apply this to both broadcast divisor and per-element divisor paths.

`inv_sqrt_inplace` changes:
- Use `_mm256_rsqrt_ps` to compute approximate reciprocal square-root.
- Apply Newton-Raphson refinement using FMA.
- Preserve zero-input behavior by producing `inf` for zero inputs, matching scalar fallback behavior.

Expected effect:
- Reduce expensive division/square-root operations.
- Improve throughput on FP16 kernels that internally compute in FP32 SIMD.
- Keep numerical error within FP16 tolerance.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: KWSMooBang <40kimwoosung@gmail.com>

</details>

<details><summary>feat: optimize x86 fp16 ops with 256-bit unrolling (max_val, softmax, inv_sqrt_inplace, swiglu, rms_norm) (55b740cc)</summary><br />

Apply 256-bit unrolling to FP16 reduction, activation, and normalization kernels.

Optimized functions:
- `max_val`
- `softmax`
- `inv_sqrt_inplace`
- `swiglu`
- `rms_norm_wrt_width_fp16`

`max_val` changes:
- Process 16 FP16 elements per iteration.
- Use two FP32 vector max accumulators.
- Merge accumulators before horizontal reduction.

`softmax` changes:
- Use 16-wide loop for `exp(x - max)` computation.
- Use dual FP32 sum accumulators.
- Store intermediate exponent values as FP16.
- Normalize using reciprocal sum in a vectorized second pass.

`inv_sqrt_inplace` changes:
- Add 16-wide path using 256-bit FP16 load/store.
- Apply rsqrt approximation and Newton-Raphson refinement to two FP32 vectors per iteration.
- Preserve zero handling through vector blend.

`swiglu` changes:
- Load 16 FP16 values from Y and Z using 256-bit loads.
- Convert to two FP32 vectors.
- Apply AVX2 SwiGLU approximation.
- Store 16 FP16 output values at once.

`rms_norm_wrt_width_fp16` changes:
- Add 32-wide unrolled sum-of-squares pass.
- Use four FP32 accumulators for reduction.
- Add 32-wide and 16-wide scaling paths.
- Convert FP16 input to FP32 for accumulation and scaling, then store FP16 output.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: KWSMooBang <40kimwoosung@gmail.com>

</details>

<details><summary>fix: apply FMA-optimized Newton-Raphson to FP16 inv_sqrt_inplace (38d8c6c6)</summary><br />

Refine the Newton-Raphson formula used in FP16 `inv_sqrt_inplace`.

Changes:
- Update inverse square-root refinement from:
  - `0.5 * y * (3 - x * y * y)`
- To the FMA-friendly form:
  - `y * (1.5 - 0.5 * x * y * y)`
- Use `_mm256_fnmadd_ps` to reduce multiply/subtract sequence in the refinement step.
- Apply the same refinement to both 16-wide and 8-wide vector paths.
- Keep zero-input handling unchanged.

Note:
- The commit title contains `FP116`, but the actual change targets FP16 `inv_sqrt_inplace`.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: YongHyeon02 <dyddyd8574@snu.ac.kr>

</details>

## Performance Improvements

Benchmark environment: Intel(R) Core i5-10400F (6C/12T, AVX2), Linux WSL2
Benchmark tool: benchmark_x86_backend (iters=1000, warmup=50)
Build: enable-fp16=true, GCC 11.4 (identical config for both baseline and AVX2)

### FP16 Activation & Element-wise Operations

| Function | Size | Baseline (Avg) | AVX2+F16C (Avg) | Speedup | AVX2+F16C Throughput |
|---|---:|---:|---:|---:|---:|
| ele_sub | N=256 | 637 ns | 98 ns | 6.5x | 2.60 Gelem/s |
| ele_sub | N=1024 | 2.62 us | 265 ns | 9.9x | 3.86 Gelem/s |
| ele_sub | N=4096 | 10.32 us | 861 ns | 12.0x | 4.76 Gelem/s |
| ele_div | N=256 | 770 ns | 99 ns | 7.8x | 2.58 Gelem/s |
| ele_div | N=1024 | 2.99 us | 318 ns | 9.4x | 3.22 Gelem/s |
| ele_div | N=4096 | 12.05 us | 1.19 us | 10.1x | 3.45 Gelem/s |
| ele_mul | N=256 | 646 ns | 83 ns | 7.8x | 3.08 Gelem/s |
| ele_mul | N=1024 | 2.66 us | 233 ns | 11.4x | 4.39 Gelem/s |
| ele_mul | N=4096 | 9.98 us | 5.52 us | 1.8x | 742 Melem/s |
| ele_add | N=256 | 635 ns | 80 ns | 7.9x | 3.18 Gelem/s |
| ele_add | N=1024 | 2.48 us | 230 ns | 10.8x | 4.45 Gelem/s |
| ele_add | N=4096 | 9.90 us | 847 ns | 11.7x | 4.84 Gelem/s |
| softmax | N=256 | 4.39 us | 335 ns | 13.1x | 764 Melem/s |
| softmax | N=1024 | 10.75 us | 1.18 us | 9.1x | 871 Melem/s |
| softmax | N=4096 | 40.89 us | 4.63 us | 8.8x | 885 Melem/s |
| inv_sqrt_inplace | N=256 | 420 ns | 119 ns | 3.5x | 2.15 Gelem/s |
| inv_sqrt_inplace | N=1024 | 1.78 us | 403 ns | 4.4x | 2.54 Gelem/s |
| inv_sqrt_inplace | N=4096 | 7.16 us | 1.52 us | 4.7x | 2.69 Gelem/s |
| max_val | N=256 | 431 ns | 55 ns | 7.8x | 4.64 Gelem/s |
| max_val | N=1024 | 1.40 us | 129 ns | 10.9x | 7.95 Gelem/s |
| max_val | N=4096 | 5.42 us | 423 ns | 12.8x | 9.68 Gelem/s |
| swiglu | N=256 | 2.14 us | 234 ns | 9.1x | 1.10 Gelem/s |
| swiglu | N=1024 | 8.63 us | 791 ns | 10.9x | 1.29 Gelem/s |
| swiglu | N=4096 | 34.87 us | 4.45 us | 7.8x | 921 Melem/s |

### FP16 BLAS-like Operations

| Function | Size | Baseline (Avg) | AVX2+F16C (Avg) | Speedup | AVX2+F16C Throughput |
|---|---:|---:|---:|---:|---:|
| sdot | N=256 | 303 ns | 66 ns | 4.6x | 3.90 Gelem/s |
| sdot | N=1024 | 1.45 us | 196 ns | 7.4x | 5.21 Gelem/s |
| sdot | N=4096 | 4.18 us | 774 ns | 5.4x | 5.29 Gelem/s |
| saxpy | N=256 | 476 ns | 120 ns | 4.0x | 2.14 Gelem/s |
| saxpy | N=1024 | 1.96 us | 262 ns | 7.5x | 3.91 Gelem/s |
| saxpy | N=4096 | 7.50 us | 999 ns | 7.5x | 4.10 Gelem/s |
| sscal | N=256 | 349 ns | 77 ns | 4.5x | 3.34 Gelem/s |
| sscal | N=1024 | 1.38 us | 214 ns | 6.4x | 4.79 Gelem/s |
| sscal | N=4096 | 5.35 us | 798 ns | 6.7x | 5.14 Gelem/s |

## Highlights

- `softmax`: up to 13.1x speedup at N=256 and 8.8x speedup at N=4096.
- `max_val`: up to 12.8x speedup at N=4096, reaching 9.68 Gelem/s.
- `ele_sub`: up to 12.0x speedup at N=4096.
- `ele_add`: up to 11.7x speedup at N=4096.
- `ele_div`: up to 10.1x speedup at N=4096 using reciprocal approximation and Newton-Raphson refinement.
- `swiglu`: up to 10.9x speedup at N=1024.
- `sdot`: up to 7.4x speedup at N=1024 with FP32 SIMD accumulation.
- `saxpy`: up to 7.5x speedup at N=4096.
- `sscal`: up to 6.7x speedup at N=4096.

## Known Limitations

FP16 arithmetic on AVX2 is implemented through FP16-to-FP32 and FP32-to-FP16 conversion using F16C. Therefore, it is not native FP16 arithmetic and still has conversion overhead.

## Summary

This PR introduces AVX2+F16C optimized FP16 compute kernels for the x86 CPU backend. The existing FP16 x86 backend relied heavily on scalar fallback paths or FP16-to-FP32 temporary conversion paths, which limited SIMD utilization in LLM-related operations.

Key changes:
1.  AVX2+F16C intrinsic implementations (`avx2_impl_fp16.cpp/h`): `ele_mul`, `ele_add`, `ele_sub`, `ele_div`, `saxpy`, `sdot`, `snrm2`, `sscal`, `softmax`, `max_val`, `inv_sqrt_inplace`, `swiglu`, `rms_norm_wrt_width_fp16`, `compute_rotary_embedding_value`, `transpose_matrix`, `isamax`, `scopy_int4_to_float16`, `scopy_int8_to_float16`
2. Shared AVX2 helper extraction (`avx2_internal.h`): common exp, reciprocal, horizontal reduction, and polynomial helper routines are reused by FP32/FP16 kernels
3. FP16 SIMD execution model: FP16 values are loaded in 16-wide blocks, converted to two FP32 `__m256` vectors, computed with AVX2/FMA, and packed back to FP16 using F16C
4. Stride and tail handling: contiguous fast paths, broadcast-like `i_stride == 0`, non-contiguous stride fallback, 8-wide tail, and scalar tail paths are preserved
5. FMA/Newton-Raphson optimizations: `ele_div` and `inv_sqrt_inplace` use reciprocal/rsqrt approximation with FMA-based refinement
6. FP16 LLM kernels: optimized paths are added for `softmax`, `SwiGLU`, `RMSNorm`, and rotary embedding
7. Comprehensive unit tests: fallback/reference comparison tests cover precision, tail sizes, stride cases, alpha/beta paths, zero-input behavior, non-aligned RoPE dimensions, transpose, and int4/int8-to-FP16 copy routines

Signed-off-by: KWSMooBang <40kimwoosung@gmail.com>
