### PR TITLE
[DRAFT][CausalLM] Add Qwen3.5 CausalLM

### DIFF
--- a/Applications/CausalLM/api/causal_lm_api.cpp
+++ b/Applications/CausalLM/api/causal_lm_api.cpp
@@ -31,6 +31,7 @@
 #include "qwen3_causallm.h"
 #include "qwen3_moe_causallm.h"
 #include "qwen3_slim_moe_causallm.h"
+#include "qwen35_causallm.h"
 #include <factory.h>
 #include <fstream>
 #include <sys/stat.h>
@@ -83,6 +84,12 @@ static void register_models() {
       "Qwen3ForCausalLM", [](json cfg, json generation_cfg, json nntr_cfg) {
         return std::make_unique<causallm::Qwen3CausalLM>(cfg, generation_cfg,
                                                          nntr_cfg);
+      });
+    causallm::Factory::Instance().registerModel(
+      "Qwen3_5ForConditionalGeneration",
+      [](json cfg, json generation_cfg, json nntr_cfg) {
+        return std::make_unique<causallm::Qwen35CausalLM>(cfg, generation_cfg,
+                                                          nntr_cfg);
       });
     causallm::Factory::Instance().registerModel(
       "Qwen3MoeForCausalLM", [](json cfg, json generation_cfg, json nntr_cfg) {

--- a/Applications/CausalLM/layers/embedding_normalize_layer.h
+++ b/Applications/CausalLM/layers/embedding_normalize_layer.h
@@ -14,6 +14,12 @@
 #ifndef __EMBEDDING_NORMALIZE_LAYER_H__
 #define __EMBEDDING_NORMALIZE_LAYER_H__
 
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#else
+#define WIN_EXPORT
+#endif
+
 #include <layer_impl.h>
 
 namespace causallm {
@@ -22,51 +28,53 @@ namespace causallm {
  * @class   EmbeddingNormalizeLayer
  * @brief   Embedding Normalize Layer
  */
-class EmbeddingNormalizeLayer : public nntrainer::LayerImpl {
+WIN_EXPORT class EmbeddingNormalizeLayer : public nntrainer::LayerImpl {
 public:
   /**
    * @brief     Constructor of EmbeddingNormalizeLayer
    */
-  EmbeddingNormalizeLayer();
+  WIN_EXPORT EmbeddingNormalizeLayer();
 
   /**
    * @brief     Destructor of EmbeddingNormalizeLayer
    */
-  ~EmbeddingNormalizeLayer() = default;
+  WIN_EXPORT ~EmbeddingNormalizeLayer() = default;
 
   /**
    * @copydoc   Layer::finalize(InitLayerContext &context)
    */
-  void finalize(nntrainer::InitLayerContext &context) override;
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
    * @copydoc   Layer::forwarding(RunLayerContext &context, bool training)
    */
-  void forwarding(nntrainer::RunLayerContext &context, bool training) override;
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
 
   /**
    * @copydoc   Layer::incremental_forwarding(RunLayerContext &context, unsigned
    * int from, unsigned int to, bool training)
    */
-  void incremental_forwarding(nntrainer::RunLayerContext &context,
-                              unsigned int from, unsigned int to,
-                              bool training) override;
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
 
   /**
    * @copydoc   Layer::calcDerivative(RunLayerContext &context)
    */
-  void calcDerivative(nntrainer::RunLayerContext &context) override;
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
 
   /**
    * @copydoc   Layer::calcGradient(RunLayerContext &context)
    */
-  void calcGradient(nntrainer::RunLayerContext &context) override;
+  WIN_EXPORT void calcGradient(nntrainer::RunLayerContext &context) override;
 
   /**
    * @copydoc   Layer::exportTo(Exporter &exporter, const ExportMethods &method)
    */
-  void exportTo(nntrainer::Exporter &exporter,
-                const ml::train::ExportMethods &method) const override;
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override;
 
   /**
    * @copydoc   Layer::getType()

--- a/Applications/CausalLM/layers/embedding_pooling_layer.h
+++ b/Applications/CausalLM/layers/embedding_pooling_layer.h
@@ -13,6 +13,12 @@
 #ifndef __EMBEDDING_POOLING_LAYER_H__
 #define __EMBEDDING_POOLING_LAYER_H__
 
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#else
+#define WIN_EXPORT
+#endif
+
 #include <base_properties.h>
 #include <common_properties.h>
 #include <layer_impl.h>
@@ -114,56 +120,58 @@ public:
  * implemented. Other pooling modes are defined as properties but their logic is
  * not yet implemented.
  */
-class EmbeddingPoolingLayer : public nntrainer::LayerImpl {
+WIN_EXPORT class EmbeddingPoolingLayer : public nntrainer::LayerImpl {
 public:
   /**
    * @brief Construct a new Embedding Pooling Layer object
    */
-  EmbeddingPoolingLayer();
+  WIN_EXPORT EmbeddingPoolingLayer();
 
   /**
    * @brief Destroy the Embedding Pooling Layer object
    */
-  ~EmbeddingPoolingLayer() {}
+  WIN_EXPORT ~EmbeddingPoolingLayer() {}
 
   /**
    * @copydoc Layer::finalize(InitLayerContext &context)
    */
-  void finalize(nntrainer::InitLayerContext &context) override;
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
-  void forwarding(nntrainer::RunLayerContext &context, bool training) override;
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
 
   /**
    * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
    * int from, unsigned int to, bool training)
    */
-  void incremental_forwarding(nntrainer::RunLayerContext &context,
-                              unsigned int from, unsigned int to,
-                              bool training) override;
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
 
   /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
-  void calcDerivative(nntrainer::RunLayerContext &context) override;
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
 
   /**
    * @copydoc Layer::calcGradient(RunLayerContext &context)
    */
-  void calcGradient(nntrainer::RunLayerContext &context) override;
+  WIN_EXPORT void calcGradient(nntrainer::RunLayerContext &context) override;
 
   /**
    * @copydoc Layer::exportTo(Exporter &exporter, const ExportMethods &method)
    */
-  void exportTo(nntrainer::Exporter &exporter,
-                const ml::train::ExportMethods &method) const override;
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override;
 
   /**
    * @copydoc Layer::setProperty(const std::vector<std::string> &values)
    */
-  void setProperty(const std::vector<std::string> &values) override;
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
 
   /**
    * @copydoc Layer::getType()

--- a/Applications/CausalLM/layers/meson.build
+++ b/Applications/CausalLM/layers/meson.build
@@ -9,8 +9,9 @@ causallm_mha_core_abs = [meson.current_source_dir()/ 'mha_core.cpp']
 causallm_embedding_src_abs = [meson.current_source_dir() / 'embedding_layer.cpp']
 causallm_reshaped_rms_norm_src_abs = [meson.current_source_dir() / 'reshaped_rms_norm.cpp']
 causallm_qkv_layer_src_abs = [meson.current_source_dir() / 'qkv_layer.cpp']
-causallm_embedding_pooling_src_abs = [meson.current_source_dir() / 'embedding_pooling_layer.cpp']
-causallm_embedding_normalize_src_abs = [meson.current_source_dir() / 'embedding_normalize_layer.cpp']
+causallm_qwen35_layers_src_abs = [meson.current_source_dir() / 'qwen35_layers.cpp']
+causallm_embedding_pooling_src = ['embedding_pooling_layer.cpp']
+causallm_embedding_normalize_src = ['embedding_normalize_layer.cpp']
 
 openmp_dep = dependency('openmp')
 causallm_rms_norm = shared_library(
@@ -93,7 +94,7 @@ causallm_embedding_layer_dep = declare_dependency(
 
 causallm_embedding_pooling_layer = shared_library(
     'embedding_pooling_layer',
-    causallm_embedding_pooling_src_abs,
+    causallm_embedding_pooling_src,
     include_directories: causallm_layer_inc,
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep, openmp_dep],
     install: true,
@@ -106,7 +107,7 @@ causallm_embedding_pooling_layer_dep = declare_dependency(
 
 causallm_embedding_normalize_layer = shared_library(
     'embedding_normalize_layer',
-    causallm_embedding_normalize_src_abs,
+    causallm_embedding_normalize_src,
     include_directories: causallm_layer_inc,
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
     install: true,
@@ -142,5 +143,19 @@ causallm_qkv_layer = shared_library(
 
 causallm_qkv_layer_dep = declare_dependency(
     link_with: causallm_qkv_layer,
+    include_directories: causallm_layer_inc
+)
+
+causallm_qwen35_layers = shared_library(
+    'qwen35_layers',
+    causallm_qwen35_layers_src_abs,
+    include_directories: causallm_layer_inc,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    install: true,
+    install_dir: application_install_dir
+)
+
+causallm_qwen35_layers_dep = declare_dependency(
+    link_with: causallm_qwen35_layers,
     include_directories: causallm_layer_inc
 )

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -52,13 +52,15 @@ MHACoreLayer::MHACoreLayer() :
     props::SlidingWindow(), props::MaxNewTokens(), props::RopeTheta(),
     props::MaxPositionEmbeddings(), props::UseSink(), props::RopeScalingType(),
     props::RopeScalingFactor(), props::RopeScalingMaxPositionEmbeddings(),
-    props::AttnLogitSoftcapping(), props::IsCausal()),
+    props::PartialRotaryFactor(), props::AttnLogitSoftcapping(),
+    props::IsCausal()),
   sm(nntrainer::ActivationType::ACT_SOFTMAX),
   epsilon(1e-3),
   cache_index(0),
   num_heads_Q(0),
   num_heads_KV(0),
   head_dim(0),
+  rotary_dim(0),
   cache_shift(false) {
   tensor_idx.fill(std::numeric_limits<unsigned>::max());
 }
@@ -123,6 +125,16 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
     << "num_heads_Q and num_heads_KV are not properly given. Please check the "
        "num_heads_* are set correctly so that the `head_dim`s are all same for "
        "query / key / value";
+
+  const float partial_rotary_factor =
+    std::get<props::PartialRotaryFactor>(mha_core_props).get();
+  NNTR_THROW_IF(partial_rotary_factor <= 0.0f || partial_rotary_factor > 1.0f,
+                std::invalid_argument)
+    << "partial_rotary_factor should be in (0, 1]";
+  rotary_dim = static_cast<size_t>(head_dim * partial_rotary_factor);
+  rotary_dim -= rotary_dim % 2;
+  NNTR_THROW_IF(rotary_dim == 0, std::invalid_argument)
+    << "rotary dimension must be positive";
 
   /** Weight for Sink */
   use_sink = std::get<props::UseSink>(mha_core_props).get();
@@ -378,11 +390,13 @@ void MHACoreLayer::compute_kcaches(
       float *out_data = out.getData<float>();
 
 #pragma omp parallel for schedule(static)
-      for (unsigned int head_kv = 0; head_kv < num_cache_head; ++head_kv) {
+      for (int head_kv = 0; head_kv < static_cast<int>(num_cache_head);
+           ++head_kv) {
         nntrainer::compute_kcaches<uint16_t>(
           in_data, cache_data, out_data, row_to_compute, num_cache_head,
-          head_dim, group_size, tile_size, local_window_size, head_kv,
-          head_kv + 1);
+          head_dim, group_size, tile_size, local_window_size,
+          static_cast<unsigned int>(head_kv),
+          static_cast<unsigned int>(head_kv + 1));
       }
 
     } else {
@@ -496,11 +510,12 @@ void MHACoreLayer::one_batch_incremental_forwarding(
                                     true);
 
   // apply rotary embedding for query
-  apply_rotary_emb_tensor_v2(query_step, query_step, head_dim, cache_index,
+  apply_rotary_emb_tensor_v2(query_step, query_step, rotary_dim, cache_index,
                              false);
 
   // append kcache with rotary embedding
-  apply_rotary_emb_tensor_v2(key_step, b_cache_key_step, head_dim, cache_index,
+  apply_rotary_emb_tensor_v2(key_step, b_cache_key_step, rotary_dim,
+                             cache_index,
                              false);
 
   // append vcache without rotary embedding
@@ -586,9 +601,9 @@ void MHACoreLayer::one_batch_incremental_forwarding(
     batch * cache_value_dim.getFeatureLen() + from * cache_value_dim.width(),
     true);
 
-  apply_rotary_emb_tensor_v2(query_step, query_step, head_dim, _from, false);
+  apply_rotary_emb_tensor_v2(query_step, query_step, rotary_dim, _from, false);
 
-  apply_rotary_emb_tensor_v2(key_step, b_cache_key_step, head_dim, _from,
+  apply_rotary_emb_tensor_v2(key_step, b_cache_key_step, rotary_dim, _from,
                              false);
 
   if (query_step.getDataType() == ml::train::TensorDim::DataType::FP32) {
@@ -640,6 +655,21 @@ void MHACoreLayer::one_batch_incremental_forwarding(
 void MHACoreLayer::precompute_freqs(int head_dim, unsigned int seq_len,
                                     float theta, bool is_fp16) {
   // compute the freqs only when it is the first time to call this function
+  if (freqs_dim != static_cast<unsigned int>(head_dim)) {
+    delete freqs_cos;
+    delete freqs_sin;
+    freqs_cos = nullptr;
+    freqs_sin = nullptr;
+#ifdef ENABLE_FP16
+    delete freqs_cos_fp16;
+    delete freqs_sin_fp16;
+    freqs_cos_fp16 = nullptr;
+    freqs_sin_fp16 = nullptr;
+#endif
+    thetas.clear();
+    freqs_dim = static_cast<unsigned int>(head_dim);
+  }
+
 #ifdef ENABLE_FP16
   if (freqs_cos_fp16 != nullptr && freqs_cos_fp16->size() == seq_len)
     return;
@@ -847,10 +877,10 @@ void MHACoreLayer::apply_rotary_emb_tensor_v2(nntrainer::Tensor &in,
     std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
 
   if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
-    if (freqs_cos == nullptr) {
+    if (freqs_cos == nullptr || freqs_dim != dim) {
       const std::lock_guard<std::mutex> lock(rope_init_mtx);
-      if (freqs_cos == nullptr) {
-        precompute_freqs(head_dim, max_position_embeddings, theta, false);
+      if (freqs_cos == nullptr || freqs_dim != dim) {
+        precompute_freqs(dim, max_position_embeddings, theta, false);
       }
     }
     std::vector<float> *cos_ = nullptr;
@@ -869,9 +899,24 @@ void MHACoreLayer::apply_rotary_emb_tensor_v2(nntrainer::Tensor &in,
 
           if (out.getDataType() == ml::train::TensorDim::DataType::FP32) {
 
-            nntrainer::compute_rotary_emb_value(in.width(), dim, half_, in_ptr,
-                                                nullptr, cos_->data(),
-                                                sin_->data(), convert_only);
+            if (dim == head_dim) {
+              nntrainer::compute_rotary_emb_value(
+                in.width(), dim, half_, in_ptr, nullptr, cos_->data(),
+                sin_->data(), convert_only);
+            } else if (!convert_only) {
+              for (unsigned int w = 0; w < in.width(); w += head_dim) {
+                for (unsigned int k = 0; k < half_; ++k) {
+                  const unsigned int i0 = w + k;
+                  const unsigned int i1 = w + k + half_;
+                  const float a = in_ptr[i0];
+                  const float b = in_ptr[i1];
+                  const float c_val = (*cos_)[k];
+                  const float s_val = (*sin_)[k];
+                  in_ptr[i0] = a * c_val - b * s_val;
+                  in_ptr[i1] = a * s_val + b * c_val;
+                }
+              }
+            }
           } else if (out.getDataType() ==
                        ml::train::TensorDim::DataType::UINT16 ||
                      out.getDataType() ==
@@ -881,19 +926,44 @@ void MHACoreLayer::apply_rotary_emb_tensor_v2(nntrainer::Tensor &in,
                                 c * out.height() * out.width() +
                                 h * out.width();
 
-            nntrainer::compute_rotary_emb_value(in.width(), dim, half_, in_ptr,
-                                                out_ptr, cos_->data(),
-                                                sin_->data(), convert_only);
+            if (dim == head_dim) {
+              nntrainer::compute_rotary_emb_value(
+                in.width(), dim, half_, in_ptr, out_ptr, cos_->data(),
+                sin_->data(), convert_only);
+            } else {
+              for (unsigned int w = 0; w < in.width(); w += head_dim) {
+                unsigned int k = 0;
+                if (!convert_only) {
+                  for (; k < half_; ++k) {
+                    const unsigned int i0 = w + k;
+                    const unsigned int i1 = w + k + half_;
+                    const float a = in_ptr[i0];
+                    const float b = in_ptr[i1];
+                    const float c_val = (*cos_)[k];
+                    const float s_val = (*sin_)[k];
+                    out_ptr[i0] =
+                      nntrainer::compute_fp32_to_fp16(a * c_val - b * s_val);
+                    out_ptr[i1] =
+                      nntrainer::compute_fp32_to_fp16(a * s_val + b * c_val);
+                  }
+                }
+                for (unsigned int i = convert_only ? 0 : dim; i < head_dim;
+                     ++i) {
+                  out_ptr[w + i] =
+                    nntrainer::compute_fp32_to_fp16(in_ptr[w + i]);
+                }
+              }
+            }
           }
         }
       }
     }
   } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-    if (freqs_cos_fp16 == nullptr) {
+    if (freqs_cos_fp16 == nullptr || freqs_dim != dim) {
       const std::lock_guard<std::mutex> lock(rope_init_mtx);
-      if (freqs_cos_fp16 == nullptr) {
-        precompute_freqs(head_dim, max_position_embeddings, theta, true);
+      if (freqs_cos_fp16 == nullptr || freqs_dim != dim) {
+        precompute_freqs(dim, max_position_embeddings, theta, true);
       }
     }
     std::vector<_FP16> *cos_ = nullptr;
@@ -913,9 +983,27 @@ void MHACoreLayer::apply_rotary_emb_tensor_v2(nntrainer::Tensor &in,
                            b * out.channel() * out.height() * out.width() +
                            c * out.height() * out.width() + h * out.width();
 
-          nntrainer::compute_rotary_emb_value(in.width(), dim, half_, in_ptr,
-                                              out_ptr, cos_->data(),
-                                              sin_->data());
+          if (dim == head_dim) {
+            nntrainer::compute_rotary_emb_value(in.width(), dim, half_, in_ptr,
+                                                out_ptr, cos_->data(),
+                                                sin_->data());
+          } else {
+            for (unsigned int w = 0; w < in.width(); w += head_dim) {
+              for (unsigned int k = 0; k < half_; ++k) {
+                const unsigned int i0 = w + k;
+                const unsigned int i1 = w + k + half_;
+                const float a = static_cast<float>(in_ptr[i0]);
+                const float b = static_cast<float>(in_ptr[i1]);
+                const float c_val = static_cast<float>((*cos_)[k]);
+                const float s_val = static_cast<float>((*sin_)[k]);
+                out_ptr[i0] = static_cast<_FP16>(a * c_val - b * s_val);
+                out_ptr[i1] = static_cast<_FP16>(a * s_val + b * c_val);
+              }
+              for (unsigned int i = dim; i < head_dim; ++i) {
+                out_ptr[w + i] = in_ptr[w + i];
+              }
+            }
+          }
         }
       }
     }

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -171,6 +171,17 @@ public:
   using prop_tag = nntrainer::uint_prop_tag; /**< property type */
 };
 
+/**
+ * @brief Partial rotary factor.
+ */
+class PartialRotaryFactor : public nntrainer::Property<float> {
+public:
+  PartialRotaryFactor(float value = 1.0f) { set(value); };
+  static constexpr const char *key =
+    "partial_rotary_factor";                 /**< unique key to access */
+  using prop_tag = nntrainer::float_prop_tag; /**< property type */
+};
+
 }; // namespace props
 
 /**
@@ -308,7 +319,7 @@ private:
     props::SlidingWindow, props::MaxNewTokens, props::RopeTheta,
     props::MaxPositionEmbeddings, props::UseSink, props::RopeScalingType,
     props::RopeScalingFactor, props::RopeScalingMaxPositionEmbeddings,
-    props::AttnLogitSoftcapping, props::IsCausal>
+    props::PartialRotaryFactor, props::AttnLogitSoftcapping, props::IsCausal>
     mha_core_props; /**< mha_core layer properties */
 
   /** softmax activation operation */
@@ -321,6 +332,7 @@ private:
   size_t num_heads_Q;
   size_t num_heads_KV;
   size_t head_dim;
+  size_t rotary_dim;
   bool cache_shift;
   float theta;
   size_t local_window_size;
@@ -370,6 +382,7 @@ private:
   inline static std::vector<std::vector<float>> *freqs_cos = {};
   inline static std::vector<std::vector<float>> *freqs_sin = {};
   inline static std::vector<float> thetas;
+  inline static unsigned int freqs_dim = 0;
 #ifdef ENABLE_FP16
   inline static std::vector<std::vector<_FP16>> *freqs_cos_fp16 = {};
   inline static std::vector<std::vector<_FP16>> *freqs_sin_fp16 = {};

--- a/Applications/CausalLM/layers/qwen35_layers.cpp
+++ b/Applications/CausalLM/layers/qwen35_layers.cpp
@@ -1,0 +1,589 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   qwen35_layers.cpp
+ * @brief  Missing Qwen3.5 token mixer helper layers.
+ */
+
+#include <qwen35_layers.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+#include <nntrainer_error.h>
+
+namespace causallm {
+
+namespace {
+
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+static constexpr float DEFAULT_L2_EPSILON = 1.0e-6f;
+
+void require_fp32(const nntrainer::Tensor &tensor, const std::string &name) {
+  NNTR_THROW_IF(tensor.getDataType() != ml::train::TensorDim::DataType::FP32,
+                std::invalid_argument)
+    << name << " supports FP32 tensors only";
+}
+
+void normalize_sequence_range(unsigned int &from, unsigned int &to,
+                              const nntrainer::Tensor &input) {
+  const unsigned int step_size = to - from;
+  NNTR_THROW_IF(step_size > input.height(), std::invalid_argument)
+    << "incremental step size is larger than local input height";
+  from = 0;
+  to = step_size;
+}
+
+} // namespace
+
+ReshapedL2NormLayer::ReshapedL2NormLayer() :
+  props_(props::FeatureSize(), nntrainer::props::Epsilon()),
+  feature_size(0) {}
+
+void ReshapedL2NormLayer::finalize(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
+    << "reshaped_l2_norm takes one input";
+
+  const auto &input_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  feature_size = std::get<props::FeatureSize>(props_).get();
+  NNTR_THROW_IF(input_dim.width() % feature_size != 0, std::invalid_argument)
+    << "feature_size should divide input width";
+
+  context.setOutputDimensions(context.getInputDimensions());
+}
+
+void ReshapedL2NormLayer::forwarding(nntrainer::RunLayerContext &context,
+                                     bool training) {
+  incremental_forwarding(context, 0, context.getInput(SINGLE_INOUT_IDX).height(),
+                         training);
+}
+
+void ReshapedL2NormLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+  nntrainer::Tensor &input = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+  require_fp32(input, getType());
+  require_fp32(output, getType());
+  normalize_sequence_range(from, to, input);
+
+  const float eps = std::get<nntrainer::props::Epsilon>(props_).empty()
+                      ? DEFAULT_L2_EPSILON
+                      : std::get<nntrainer::props::Epsilon>(props_).get();
+  const unsigned int width = input.width();
+
+  for (unsigned int b = 0; b < input.batch(); ++b) {
+    for (unsigned int c = 0; c < input.channel(); ++c) {
+      for (unsigned int h = from; h < to; ++h) {
+        const float *src = input.getData<float>() + input.getIndex(b, c, h, 0);
+        float *dst = output.getData<float>() + output.getIndex(b, c, h, 0);
+        for (unsigned int offset = 0; offset < width; offset += feature_size) {
+          float sum = 0.0f;
+          for (unsigned int i = 0; i < feature_size; ++i) {
+            const float v = src[offset + i];
+            sum += v * v;
+          }
+          const float scale = 1.0f / std::sqrt(sum + eps);
+          for (unsigned int i = 0; i < feature_size; ++i) {
+            dst[offset + i] = src[offset + i] * scale;
+          }
+        }
+      }
+    }
+  }
+}
+
+void ReshapedL2NormLayer::calcDerivative(
+  nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "calcDerivative for reshaped_l2_norm is not supported");
+}
+
+void ReshapedL2NormLayer::setProperty(
+  const std::vector<std::string> &values) {
+  auto remain_props = loadProperties(values, props_);
+  NNTR_THROW_IF(!remain_props.empty(), std::invalid_argument)
+    << "[reshaped_l2_norm] Unknown layer properties";
+}
+
+void ReshapedL2NormLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+}
+
+FeatureBiasLayer::FeatureBiasLayer() :
+  bias_idx(std::numeric_limits<unsigned int>::max()) {}
+
+void FeatureBiasLayer::finalize(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
+    << "feature_bias takes one input";
+
+  const auto &input_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  context.setOutputDimensions(context.getInputDimensions());
+
+  auto weight_type = nntrainer::TensorDim::TensorType(
+    context.getFormat(), context.getWeightDataType());
+  bias_idx = context.requestWeight(
+    nntrainer::TensorDim(1, 1, 1, input_dim.width(), weight_type),
+    nntrainer::Initializer::NONE, nntrainer::WeightRegularizer::NONE, 1.0f,
+    0.0f, "bias", false);
+}
+
+void FeatureBiasLayer::forwarding(nntrainer::RunLayerContext &context,
+                                  bool training) {
+  incremental_forwarding(context, 0, context.getInput(SINGLE_INOUT_IDX).height(),
+                         training);
+}
+
+void FeatureBiasLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+  nntrainer::Tensor &input = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &bias = context.getWeight(bias_idx);
+  require_fp32(input, getType());
+  require_fp32(output, getType());
+  require_fp32(bias, getType());
+  normalize_sequence_range(from, to, input);
+
+  const float *b_data = bias.getData<float>();
+  for (unsigned int b = 0; b < input.batch(); ++b) {
+    for (unsigned int c = 0; c < input.channel(); ++c) {
+      for (unsigned int h = from; h < to; ++h) {
+        const float *src = input.getData<float>() + input.getIndex(b, c, h, 0);
+        float *dst = output.getData<float>() + output.getIndex(b, c, h, 0);
+        for (unsigned int w = 0; w < input.width(); ++w)
+          dst[w] = src[w] + b_data[w];
+      }
+    }
+  }
+}
+
+void FeatureBiasLayer::calcDerivative(nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "calcDerivative for feature_bias is not supported");
+}
+
+void FeatureBiasLayer::setProperty(const std::vector<std::string> &values) {
+  NNTR_THROW_IF(!values.empty(), std::invalid_argument)
+    << "[feature_bias] Unknown layer properties";
+}
+
+void FeatureBiasLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+}
+
+FeatureScaleLayer::FeatureScaleLayer() :
+  scale_idx(std::numeric_limits<unsigned int>::max()) {}
+
+void FeatureScaleLayer::finalize(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
+    << "feature_scale takes one input";
+
+  const auto &input_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  context.setOutputDimensions(context.getInputDimensions());
+
+  auto weight_type = nntrainer::TensorDim::TensorType(
+    context.getFormat(), context.getWeightDataType());
+  scale_idx = context.requestWeight(
+    nntrainer::TensorDim(1, 1, 1, input_dim.width(), weight_type),
+    nntrainer::Initializer::NONE, nntrainer::WeightRegularizer::NONE, 1.0f,
+    0.0f, "scale", false);
+}
+
+void FeatureScaleLayer::forwarding(nntrainer::RunLayerContext &context,
+                                   bool training) {
+  incremental_forwarding(context, 0, context.getInput(SINGLE_INOUT_IDX).height(),
+                         training);
+}
+
+void FeatureScaleLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+  nntrainer::Tensor &input = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &scale = context.getWeight(scale_idx);
+  require_fp32(input, getType());
+  require_fp32(output, getType());
+  require_fp32(scale, getType());
+  normalize_sequence_range(from, to, input);
+
+  const float *s_data = scale.getData<float>();
+  for (unsigned int b = 0; b < input.batch(); ++b) {
+    for (unsigned int c = 0; c < input.channel(); ++c) {
+      for (unsigned int h = from; h < to; ++h) {
+        const float *src = input.getData<float>() + input.getIndex(b, c, h, 0);
+        float *dst = output.getData<float>() + output.getIndex(b, c, h, 0);
+        for (unsigned int w = 0; w < input.width(); ++w)
+          dst[w] = src[w] * s_data[w];
+      }
+    }
+  }
+}
+
+void FeatureScaleLayer::calcDerivative(nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "calcDerivative for feature_scale is not supported");
+}
+
+void FeatureScaleLayer::setProperty(const std::vector<std::string> &values) {
+  NNTR_THROW_IF(!values.empty(), std::invalid_argument)
+    << "[feature_scale] Unknown layer properties";
+}
+
+void FeatureScaleLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+}
+
+HeadPairSplitLayer::HeadPairSplitLayer() :
+  props_(props::FeatureSize(), props::Qwen35PairSelectIndex()),
+  feature_size(0),
+  select_index(0) {}
+
+void HeadPairSplitLayer::finalize(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
+    << "qwen35_head_pair_split takes one input";
+
+  const auto &input_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  feature_size = std::get<props::FeatureSize>(props_).get();
+  select_index = std::get<props::Qwen35PairSelectIndex>(props_).get();
+  NNTR_THROW_IF(select_index > 1, std::invalid_argument)
+    << "select_index should be 0 or 1";
+  NNTR_THROW_IF(input_dim.width() % (feature_size * 2) != 0,
+                std::invalid_argument)
+    << "input width should be divisible by feature_size * 2";
+
+  auto output_dim = input_dim;
+  output_dim.width(input_dim.width() / 2);
+  context.setOutputDimensions({output_dim});
+}
+
+void HeadPairSplitLayer::forwarding(nntrainer::RunLayerContext &context,
+                                    bool training) {
+  incremental_forwarding(context, 0, context.getInput(SINGLE_INOUT_IDX).height(),
+                         training);
+}
+
+void HeadPairSplitLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+  nntrainer::Tensor &input = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+  require_fp32(input, getType());
+  require_fp32(output, getType());
+  normalize_sequence_range(from, to, input);
+
+  const unsigned int output_width = output.width();
+  for (unsigned int b = 0; b < input.batch(); ++b) {
+    for (unsigned int c = 0; c < input.channel(); ++c) {
+      for (unsigned int h = from; h < to; ++h) {
+        const float *src = input.getData<float>() + input.getIndex(b, c, h, 0);
+        float *dst = output.getData<float>() + output.getIndex(b, c, h, 0);
+        for (unsigned int out_offset = 0; out_offset < output_width;
+             out_offset += feature_size) {
+          const unsigned int pair_offset = out_offset * 2;
+          const unsigned int src_offset =
+            pair_offset + select_index * feature_size;
+          std::copy(src + src_offset, src + src_offset + feature_size,
+                    dst + out_offset);
+        }
+      }
+    }
+  }
+}
+
+void HeadPairSplitLayer::calcDerivative(nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "calcDerivative for qwen35_head_pair_split is not supported");
+}
+
+void HeadPairSplitLayer::setProperty(
+  const std::vector<std::string> &values) {
+  auto remain_props = loadProperties(values, props_);
+  NNTR_THROW_IF(!remain_props.empty(), std::invalid_argument)
+    << "[qwen35_head_pair_split] Unknown layer properties";
+}
+
+void HeadPairSplitLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  auto output_dim = input_dimensions[0];
+  output_dim.width(input_dimensions[0].width() / 2);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
+Qwen35CausalDepthwiseConv1DLayer::Qwen35CausalDepthwiseConv1DLayer() :
+  wt_idx(), tensor_idx(), props_(props::Qwen35LinearConvKernelDim()) {
+  wt_idx.fill(std::numeric_limits<unsigned int>::max());
+  tensor_idx.fill(std::numeric_limits<unsigned int>::max());
+}
+
+void Qwen35CausalDepthwiseConv1DLayer::finalize(
+  nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
+    << "qwen35_causal_depthwise_conv1d takes one input";
+
+  const auto &input_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  const unsigned int kernel =
+    std::get<props::Qwen35LinearConvKernelDim>(props_).get();
+
+  context.setOutputDimensions(context.getInputDimensions());
+
+  auto tensor_type = nntrainer::TensorDim::TensorType(
+    context.getFormat(), context.getActivationDataType());
+  auto weight_type = nntrainer::TensorDim::TensorType(
+    context.getFormat(), context.getWeightDataType());
+
+  wt_idx[ConvWeight] = context.requestWeight(
+    nntrainer::TensorDim(1, 1, input_dim.width(), kernel, weight_type),
+    nntrainer::Initializer::NONE, nntrainer::WeightRegularizer::NONE, 1.0f,
+    0.0f, "weight", true);
+  tensor_idx[ConvState] = context.requestTensor(
+    nntrainer::TensorDim(input_dim.batch(), 1, input_dim.width(), kernel,
+                         tensor_type),
+    "conv_state", nntrainer::Initializer::ZEROS, false,
+    nntrainer::TensorLifespan::MAX_LIFESPAN);
+}
+
+void Qwen35CausalDepthwiseConv1DLayer::forwarding(
+  nntrainer::RunLayerContext &context, bool training) {
+  incremental_forwarding(context, 0, context.getInput(SINGLE_INOUT_IDX).height(),
+                         training);
+}
+
+void Qwen35CausalDepthwiseConv1DLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+  nntrainer::Tensor &input = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &weight = context.getWeight(wt_idx[ConvWeight]);
+  nntrainer::Tensor &state = context.getTensor(tensor_idx[ConvState]);
+  require_fp32(input, getType());
+  require_fp32(output, getType());
+  require_fp32(weight, getType());
+  require_fp32(state, getType());
+  normalize_sequence_range(from, to, input);
+
+  const unsigned int width = input.width();
+  const unsigned int kernel =
+    std::get<props::Qwen35LinearConvKernelDim>(props_).get();
+  const float *w_data = weight.getData<float>();
+
+  for (unsigned int b = 0; b < input.batch(); ++b) {
+    float *state_b =
+      state.getData<float>() + static_cast<size_t>(b) * state.getDim().getFeatureLen();
+    for (unsigned int h = from; h < to; ++h) {
+      const float *src = input.getData<float>() + input.getIndex(b, 0, h, 0);
+      float *dst = output.getData<float>() + output.getIndex(b, 0, h, 0);
+      for (unsigned int c = 0; c < width; ++c) {
+        float *channel_state = state_b + static_cast<size_t>(c) * kernel;
+        for (unsigned int k = 0; k + 1 < kernel; ++k)
+          channel_state[k] = channel_state[k + 1];
+        channel_state[kernel - 1] = src[c];
+
+        const float *kernel_w = w_data + static_cast<size_t>(c) * kernel;
+        float sum = 0.0f;
+        for (unsigned int k = 0; k < kernel; ++k)
+          sum += channel_state[k] * kernel_w[k];
+        dst[c] = sum;
+      }
+    }
+  }
+}
+
+void Qwen35CausalDepthwiseConv1DLayer::calcDerivative(
+  nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "calcDerivative for qwen35_causal_depthwise_conv1d is not supported");
+}
+
+void Qwen35CausalDepthwiseConv1DLayer::setProperty(
+  const std::vector<std::string> &values) {
+  auto remain_props = loadProperties(values, props_);
+  NNTR_THROW_IF(!remain_props.empty(), std::invalid_argument)
+    << "[qwen35_causal_depthwise_conv1d] Unknown layer properties";
+}
+
+void Qwen35CausalDepthwiseConv1DLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+}
+
+Qwen35GatedDeltaCoreLayer::Qwen35GatedDeltaCoreLayer() :
+  tensor_idx(),
+  props_(props::Qwen35LinearNumKeyHeads(),
+         props::Qwen35LinearNumValueHeads(),
+         props::Qwen35LinearKeyHeadDim(),
+         props::Qwen35LinearValueHeadDim()) {
+  tensor_idx.fill(std::numeric_limits<unsigned int>::max());
+}
+
+void Qwen35GatedDeltaCoreLayer::finalize(
+  nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != InputCount, std::invalid_argument)
+    << "qwen35_gated_delta_core takes query, key, value, beta, and decay";
+
+  const unsigned int num_k_heads =
+    std::get<props::Qwen35LinearNumKeyHeads>(props_).get();
+  const unsigned int num_v_heads =
+    std::get<props::Qwen35LinearNumValueHeads>(props_).get();
+  const unsigned int key_head_dim =
+    std::get<props::Qwen35LinearKeyHeadDim>(props_).get();
+  const unsigned int value_head_dim =
+    std::get<props::Qwen35LinearValueHeadDim>(props_).get();
+
+  const auto &query_dim = context.getInputDimensions()[Query];
+  const auto &key_dim = context.getInputDimensions()[Key];
+  const auto &value_dim = context.getInputDimensions()[Value];
+  const auto &beta_dim = context.getInputDimensions()[Beta];
+  const auto &decay_dim = context.getInputDimensions()[Decay];
+
+  NNTR_THROW_IF(query_dim.width() != num_k_heads * key_head_dim ||
+                  key_dim.width() != num_k_heads * key_head_dim,
+                std::invalid_argument)
+    << "query/key width does not match linear key head configuration";
+  NNTR_THROW_IF(value_dim.width() != num_v_heads * value_head_dim,
+                std::invalid_argument)
+    << "value width does not match linear value head configuration";
+  NNTR_THROW_IF(beta_dim.width() != num_v_heads ||
+                  decay_dim.width() != num_v_heads,
+                std::invalid_argument)
+    << "beta/decay width should match number of value heads";
+
+  context.setOutputDimensions({value_dim});
+
+  auto tensor_type = nntrainer::TensorDim::TensorType(
+    context.getFormat(), context.getActivationDataType());
+  tensor_idx[RecurrentState] = context.requestTensor(
+    nntrainer::TensorDim(query_dim.batch(), num_v_heads, key_head_dim,
+                         value_head_dim, tensor_type),
+    "recurrent_state", nntrainer::Initializer::ZEROS, false,
+    nntrainer::TensorLifespan::MAX_LIFESPAN);
+}
+
+void Qwen35GatedDeltaCoreLayer::forwarding(
+  nntrainer::RunLayerContext &context, bool training) {
+  incremental_forwarding(context, 0, context.getInput(Query).height(),
+                         training);
+}
+
+void Qwen35GatedDeltaCoreLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+  nntrainer::Tensor &query = context.getInput(Query);
+  nntrainer::Tensor &key = context.getInput(Key);
+  nntrainer::Tensor &value = context.getInput(Value);
+  nntrainer::Tensor &beta = context.getInput(Beta);
+  nntrainer::Tensor &decay = context.getInput(Decay);
+  nntrainer::Tensor &output = context.getOutput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &state = context.getTensor(tensor_idx[RecurrentState]);
+  require_fp32(query, getType());
+  require_fp32(key, getType());
+  require_fp32(value, getType());
+  require_fp32(beta, getType());
+  require_fp32(decay, getType());
+  require_fp32(output, getType());
+  require_fp32(state, getType());
+  normalize_sequence_range(from, to, query);
+
+  const unsigned int num_k_heads =
+    std::get<props::Qwen35LinearNumKeyHeads>(props_).get();
+  const unsigned int num_v_heads =
+    std::get<props::Qwen35LinearNumValueHeads>(props_).get();
+  const unsigned int key_head_dim =
+    std::get<props::Qwen35LinearKeyHeadDim>(props_).get();
+  const unsigned int value_head_dim =
+    std::get<props::Qwen35LinearValueHeadDim>(props_).get();
+  const unsigned int head_repeat = num_v_heads / num_k_heads;
+  const float query_scale = 1.0f / std::sqrt(static_cast<float>(key_head_dim));
+
+  for (unsigned int b = 0; b < query.batch(); ++b) {
+    float *state_b =
+      state.getData<float>() + static_cast<size_t>(b) * state.getDim().getFeatureLen();
+    for (unsigned int h = from; h < to; ++h) {
+      const float *q_base = query.getData<float>() + query.getIndex(b, 0, h, 0);
+      const float *k_base = key.getData<float>() + key.getIndex(b, 0, h, 0);
+      const float *v_base = value.getData<float>() + value.getIndex(b, 0, h, 0);
+      const float *beta_base =
+        beta.getData<float>() + beta.getIndex(b, 0, h, 0);
+      const float *decay_base =
+        decay.getData<float>() + decay.getIndex(b, 0, h, 0);
+      float *out_base = output.getData<float>() + output.getIndex(b, 0, h, 0);
+
+      for (unsigned int vh = 0; vh < num_v_heads; ++vh) {
+        const unsigned int kh = vh / head_repeat;
+        const float *q = q_base + kh * key_head_dim;
+        const float *k = k_base + kh * key_head_dim;
+        const float *v = v_base + vh * value_head_dim;
+        float *out = out_base + vh * value_head_dim;
+        float *head_state =
+          state_b + static_cast<size_t>(vh) * key_head_dim * value_head_dim;
+        const float g = std::exp(decay_base[vh]);
+
+        for (unsigned int kd = 0; kd < key_head_dim; ++kd) {
+          float *row = head_state + static_cast<size_t>(kd) * value_head_dim;
+          for (unsigned int vd = 0; vd < value_head_dim; ++vd)
+            row[vd] *= g;
+        }
+
+        for (unsigned int vd = 0; vd < value_head_dim; ++vd) {
+          float kv_mem = 0.0f;
+          for (unsigned int kd = 0; kd < key_head_dim; ++kd)
+            kv_mem += head_state[static_cast<size_t>(kd) * value_head_dim +
+                                 vd] *
+                      k[kd];
+          const float delta = (v[vd] - kv_mem) * beta_base[vh];
+          for (unsigned int kd = 0; kd < key_head_dim; ++kd) {
+            head_state[static_cast<size_t>(kd) * value_head_dim + vd] +=
+              k[kd] * delta;
+          }
+        }
+
+        for (unsigned int vd = 0; vd < value_head_dim; ++vd) {
+          float sum = 0.0f;
+          for (unsigned int kd = 0; kd < key_head_dim; ++kd)
+            sum += head_state[static_cast<size_t>(kd) * value_head_dim + vd] *
+                   q[kd] * query_scale;
+          out[vd] = sum;
+        }
+      }
+    }
+  }
+}
+
+void Qwen35GatedDeltaCoreLayer::calcDerivative(
+  nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "calcDerivative for qwen35_gated_delta_core is not supported");
+}
+
+void Qwen35GatedDeltaCoreLayer::setProperty(
+  const std::vector<std::string> &values) {
+  auto remain_props = loadProperties(values, props_);
+  NNTR_THROW_IF(!remain_props.empty(), std::invalid_argument)
+    << "[qwen35_gated_delta_core] Unknown layer properties";
+}
+
+void Qwen35GatedDeltaCoreLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  for (unsigned int i = 0; i < InputCount; ++i)
+    context.updateInput(i, input_dimensions[i]);
+  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[Value]);
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/layers/qwen35_layers.h
+++ b/Applications/CausalLM/layers/qwen35_layers.h
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   qwen35_layers.h
+ * @brief  Missing Qwen3.5 token mixer helper layers for CausalLM inference.
+ */
+
+#ifndef __QWEN35_LAYERS_H__
+#define __QWEN35_LAYERS_H__
+
+#pragma once
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#else
+#define WIN_EXPORT
+#endif
+
+#include <array>
+#include <common_properties.h>
+#include <causallm_common_properties.h>
+#include <layer_context.h>
+#include <layer_devel.h>
+#include <node_exporter.h>
+#include <tensor.h>
+
+namespace causallm {
+
+namespace props {
+
+class Qwen35LinearKeyHeadDim : public nntrainer::PositiveIntegerProperty {
+public:
+  Qwen35LinearKeyHeadDim(unsigned int value = 128) { set(value); }
+  static constexpr const char *key = "linear_key_head_dim";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+class Qwen35LinearValueHeadDim : public nntrainer::PositiveIntegerProperty {
+public:
+  Qwen35LinearValueHeadDim(unsigned int value = 128) { set(value); }
+  static constexpr const char *key = "linear_value_head_dim";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+class Qwen35LinearNumKeyHeads : public nntrainer::PositiveIntegerProperty {
+public:
+  Qwen35LinearNumKeyHeads(unsigned int value = 16) { set(value); }
+  static constexpr const char *key = "linear_num_key_heads";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+class Qwen35LinearNumValueHeads : public nntrainer::PositiveIntegerProperty {
+public:
+  Qwen35LinearNumValueHeads(unsigned int value = 16) { set(value); }
+  static constexpr const char *key = "linear_num_value_heads";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+class Qwen35LinearConvKernelDim : public nntrainer::PositiveIntegerProperty {
+public:
+  Qwen35LinearConvKernelDim(unsigned int value = 4) { set(value); }
+  static constexpr const char *key = "linear_conv_kernel_dim";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+class Qwen35PairSelectIndex : public nntrainer::Property<unsigned int> {
+public:
+  Qwen35PairSelectIndex(unsigned int value = 0) { set(value); }
+  static constexpr const char *key = "select_index";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+} // namespace props
+
+class ReshapedL2NormLayer final : public nntrainer::Layer {
+public:
+  WIN_EXPORT ReshapedL2NormLayer();
+  WIN_EXPORT ~ReshapedL2NormLayer() = default;
+
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+  WIN_EXPORT bool supportBackwarding() const override { return false; }
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override {}
+  WIN_EXPORT const std::string getType() const override { return type; }
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  inline static const std::string type = "reshaped_l2_norm";
+
+private:
+  std::tuple<props::FeatureSize, nntrainer::props::Epsilon> props_;
+  unsigned int feature_size;
+};
+
+class FeatureBiasLayer final : public nntrainer::Layer {
+public:
+  WIN_EXPORT FeatureBiasLayer();
+  WIN_EXPORT ~FeatureBiasLayer() = default;
+
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+  WIN_EXPORT bool supportBackwarding() const override { return false; }
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override {}
+  WIN_EXPORT const std::string getType() const override { return type; }
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  inline static const std::string type = "feature_bias";
+
+private:
+  unsigned int bias_idx;
+};
+
+class FeatureScaleLayer final : public nntrainer::Layer {
+public:
+  WIN_EXPORT FeatureScaleLayer();
+  WIN_EXPORT ~FeatureScaleLayer() = default;
+
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+  WIN_EXPORT bool supportBackwarding() const override { return false; }
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override {}
+  WIN_EXPORT const std::string getType() const override { return type; }
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  inline static const std::string type = "feature_scale";
+
+private:
+  unsigned int scale_idx;
+};
+
+class HeadPairSplitLayer final : public nntrainer::Layer {
+public:
+  WIN_EXPORT HeadPairSplitLayer();
+  WIN_EXPORT ~HeadPairSplitLayer() = default;
+
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+  WIN_EXPORT bool supportBackwarding() const override { return false; }
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override {}
+  WIN_EXPORT const std::string getType() const override { return type; }
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  inline static const std::string type = "qwen35_head_pair_split";
+
+private:
+  std::tuple<props::FeatureSize, props::Qwen35PairSelectIndex> props_;
+  unsigned int feature_size;
+  unsigned int select_index;
+};
+
+class Qwen35CausalDepthwiseConv1DLayer final : public nntrainer::Layer {
+public:
+  WIN_EXPORT Qwen35CausalDepthwiseConv1DLayer();
+  WIN_EXPORT ~Qwen35CausalDepthwiseConv1DLayer() = default;
+
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+  WIN_EXPORT bool supportBackwarding() const override { return false; }
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override {}
+  WIN_EXPORT const std::string getType() const override { return type; }
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  inline static const std::string type = "qwen35_causal_depthwise_conv1d";
+
+private:
+  enum WeightIndex { ConvWeight, WeightCount };
+  enum TensorIndex { ConvState, TensorCount };
+
+  std::array<unsigned int, WeightCount> wt_idx;
+  std::array<unsigned int, TensorCount> tensor_idx;
+  std::tuple<props::Qwen35LinearConvKernelDim> props_;
+};
+
+class Qwen35GatedDeltaCoreLayer final : public nntrainer::Layer {
+public:
+  WIN_EXPORT Qwen35GatedDeltaCoreLayer();
+  WIN_EXPORT ~Qwen35GatedDeltaCoreLayer() = default;
+
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+  WIN_EXPORT bool supportBackwarding() const override { return false; }
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override {}
+  WIN_EXPORT const std::string getType() const override { return type; }
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  inline static const std::string type = "qwen35_gated_delta_core";
+
+private:
+  enum InputIndex { Query, Key, Value, Beta, Decay, InputCount };
+  enum TensorIndex { RecurrentState, TensorCount };
+
+  std::array<unsigned int, TensorCount> tensor_idx;
+  std::tuple<props::Qwen35LinearNumKeyHeads,
+             props::Qwen35LinearNumValueHeads,
+             props::Qwen35LinearKeyHeadDim,
+             props::Qwen35LinearValueHeadDim>
+    props_;
+};
+
+} // namespace causallm
+
+#endif /* __QWEN35_LAYERS_H__ */

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -22,6 +22,7 @@
  */
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -30,6 +31,8 @@
 #include <factory.h>
 
 #include "causal_lm.h"
+#include "qwen35_causallm.h"
+#if !defined(_WIN32)
 #include "embedding_gemma.h"
 #include "gemma3_causallm.h"
 #include "gptoss_cached_slim_causallm.h"
@@ -42,7 +45,11 @@
 #include "qwen3_moe_causallm.h"
 #include "qwen3_slim_moe_causallm.h"
 #include <models/gemma3/function.h>
+#endif
+#include <performance_metrics.h>
+#if !defined(_WIN32)
 #include <sys/resource.h>
+#endif
 
 #include <atomic>
 #include <chrono>
@@ -54,13 +61,21 @@ std::atomic<size_t> peak_rss_kb{0};
 std::atomic<bool> tracking_enabled{true};
 
 void printMemoryUsage() {
+#if defined(_WIN32)
+  std::cout << "Peak memory usage: " << getPeakMemoryKb() << " KB"
+            << std::endl;
+#else
   struct rusage usage;
   getrusage(RUSAGE_SELF, &usage);
   std::cout << "Max Resident Set Size: " << usage.ru_maxrss << " KB"
             << std::endl;
+#endif
 }
 
 size_t read_vm_rss_kb() {
+#if defined(_WIN32)
+  return getPeakMemoryKb();
+#else
   std::ifstream status("/proc/self/status");
   std::string line;
   while (std::getline(status, line)) {
@@ -71,9 +86,13 @@ size_t read_vm_rss_kb() {
     }
   }
   return 0;
+#endif
 }
 
 size_t read_private_rss_kb() {
+#if defined(_WIN32)
+  return getPeakMemoryKb();
+#else
   std::ifstream smaps("/proc/self/smaps_rollup");
   std::string line;
   size_t total = 0;
@@ -85,6 +104,7 @@ size_t read_private_rss_kb() {
     }
   }
   return total;
+#endif
 }
 
 void start_peak_tracker() {
@@ -134,6 +154,7 @@ int main(int argc, char *argv[]) {
   auto start_time = std::chrono::high_resolution_clock::now();
 
   /** Register all runnable causallm models to factory */
+#if !defined(_WIN32)
   causallm::Factory::Instance().registerModel(
     "LlamaForCausalLM", [](json cfg, json generation_cfg, json nntr_cfg) {
       return std::make_unique<causallm::CausalLM>(cfg, generation_cfg,
@@ -154,6 +175,14 @@ int main(int argc, char *argv[]) {
       return std::make_unique<causallm::Qwen3CausalLM>(cfg, generation_cfg,
                                                        nntr_cfg);
     });
+#endif
+  causallm::Factory::Instance().registerModel(
+    "Qwen3_5ForConditionalGeneration",
+    [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::Qwen35CausalLM>(cfg, generation_cfg,
+                                                        nntr_cfg);
+    });
+#if !defined(_WIN32)
   causallm::Factory::Instance().registerModel(
     "Qwen3MoeForCausalLM", [](json cfg, json generation_cfg, json nntr_cfg) {
       return std::make_unique<causallm::Qwen3MoECausalLM>(cfg, generation_cfg,
@@ -197,6 +226,7 @@ int main(int argc, char *argv[]) {
       return std::make_unique<causallm::EmbeddingGemma>(cfg, generation_cfg,
                                                         nntr_cfg);
     });
+#endif
 
   // Validate arguments
   if (argc < 2) {
@@ -247,18 +277,34 @@ int main(int argc, char *argv[]) {
     if (argc >= 3) {
       input_text = argv[2];
     } else {
-      if (nntr_cfg.contains("chat_input")) {
+      const bool disable_tokenizer =
+        nntr_cfg.value("disable_tokenizer", false);
+      if (disable_tokenizer && nntr_cfg.contains("sample_input_ids")) {
+        std::ostringstream oss;
+        const auto input_ids =
+          nntr_cfg["sample_input_ids"].get<std::vector<int64_t>>();
+        for (size_t i = 0; i < input_ids.size(); ++i) {
+          if (i > 0)
+            oss << ' ';
+          oss << input_ids[i];
+        }
+        input_text = oss.str();
+      } else if (nntr_cfg.contains("chat_input")) {
+#if !defined(_WIN32)
         if (architecture == "Gemma3ForCausalLM") {
           input_text = causallm::gemma3::apply_function_gemma_template(
             nntr_cfg["chat_input"]);
         } else {
+#endif
           std::cerr << "[Warning] 'chat_input' is set but support for model "
                        "architecture '"
                     << architecture
                     << "' is not implemented. Falling back to 'sample_input'."
                     << std::endl;
           input_text = nntr_cfg["sample_input"].get<std::string>();
+#if !defined(_WIN32)
         }
+#endif
       } else {
         input_text = nntr_cfg["sample_input"].get<std::string>();
       }
@@ -282,8 +328,11 @@ int main(int argc, char *argv[]) {
     start_peak_tracker();
 #endif
 #if defined(_WIN32)
-    model->run(input_text.c_str(), do_sample, system_head_prompt.c_str(),
-               system_tail_prompt.c_str());
+    auto to_wstring = [](const std::string &text) {
+      return std::wstring(text.begin(), text.end());
+    };
+    model->run(to_wstring(input_text), do_sample, to_wstring(system_head_prompt),
+               to_wstring(system_tail_prompt));
 #else
     model->run(input_text, do_sample, system_head_prompt, system_tail_prompt);
 #endif

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -1,9 +1,14 @@
 causallm_src = [
-    meson.current_source_dir() / 'huggingface_tokenizer.cpp',
     meson.current_source_dir() / 'llm_util.cpp',
-    meson.current_source_dir() / 'api' / 'causal_lm_api.cpp',
-    meson.current_source_dir() / 'api' / 'model_config.cpp',
 ]
+
+if host_machine.system() != 'windows'
+    causallm_src += [
+        meson.current_source_dir() / 'huggingface_tokenizer.cpp',
+        meson.current_source_dir() / 'api' / 'causal_lm_api.cpp',
+        meson.current_source_dir() / 'api' / 'model_config.cpp',
+    ]
+endif
 
 executable_src = [
     meson.current_source_dir() / 'main.cpp',
@@ -27,6 +32,7 @@ causallm_layer_dependencies += [
     causallm_lm_head_dep,
     causallm_reshaped_rms_norm_dep,
     causallm_qkv_layer_dep,
+    causallm_qwen35_layers_dep,
     causallm_embedding_pooling_layer_dep,
     causallm_embedding_normalize_layer_dep,
 ]
@@ -40,7 +46,10 @@ elif get_option('platform') != 'tizen'
 endif
 
 tokenizer_dependencies = []
-tokenizer_path = meson.current_source_dir() / 'lib' / 'libtokenizers_c.a'
+tokenizer_link_args = []
+if host_machine.system() != 'windows'
+    tokenizer_link_args += [meson.current_source_dir() / 'lib' / 'libtokenizers_c.a']
+endif
 
 cpp_args = []
 
@@ -48,21 +57,37 @@ if get_option('default_library') == 'shared'
     cpp_args += [ '-DPLUGGABLE' ]
 endif
 
-causallm = shared_library('causallm',
-    causallm_src,
-    dependencies: [
-        nntrainer_dep,
-        nntrainer_ccapi_dep,
-        causallm_layer_dependencies, 
-        tokenizer_dependencies,
-        openmp_dep
-    ],
-    include_directories: causallm_inc,
-    install: true,
-    install_dir: application_install_dir,
-    link_args: [tokenizer_path],
-    cpp_args: cpp_args
-)
+if host_machine.system() == 'windows'
+    causallm = static_library('causallm',
+        causallm_src,
+        dependencies: [
+            nntrainer_dep,
+            nntrainer_ccapi_dep,
+            causallm_layer_dependencies,
+            tokenizer_dependencies,
+            openmp_dep
+        ],
+        include_directories: causallm_inc,
+        install: false,
+        cpp_args: cpp_args
+    )
+else
+    causallm = shared_library('causallm',
+        causallm_src,
+        dependencies: [
+            nntrainer_dep,
+            nntrainer_ccapi_dep,
+            causallm_layer_dependencies,
+            tokenizer_dependencies,
+            openmp_dep
+        ],
+        include_directories: causallm_inc,
+        install: true,
+        install_dir: application_install_dir,
+        link_args: tokenizer_link_args,
+        cpp_args: cpp_args
+    )
+endif
 
 causallm_dep = declare_dependency(
     link_with: [causallm],
@@ -75,6 +100,7 @@ e = executable('nntr_causallm',
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep, causallm_layer_dependencies, causallm_dep],
 )
 
+if host_machine.system() != 'windows'
 
 quantize_src = [
     meson.current_source_dir() / 'quantize.cpp',
@@ -98,3 +124,5 @@ test_api = executable('test_api',
     build_by_default: true,
     install: false,
 )
+
+endif

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -23,10 +23,15 @@
 #include <algorithm>
 #include <app_context.h>
 #include <cmath>
+#include <codecvt>
+#include <cstdint>
 #include <engine.h>
 #include <fstream>
 #include <iostream>
+#include <locale>
 #include <limits>
+#include <sstream>
+#include <unordered_map>
 #include <vector>
 
 #include <common.h>
@@ -40,6 +45,150 @@
 
 namespace causallm {
 
+#if defined(_WIN32)
+static std::wstring utf8_to_wstring(const std::string &text) {
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+  return converter.from_bytes(text);
+}
+
+static std::string wstring_to_utf8(const std::wstring &text) {
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+  return converter.to_bytes(text);
+}
+#endif
+
+static std::vector<int32_t> parse_input_ids(const std::string &text) {
+  std::string normalized = text;
+  for (char &ch : normalized) {
+    if (ch == ',' || ch == ';' || ch == '[' || ch == ']')
+      ch = ' ';
+  }
+
+  std::vector<int32_t> ids;
+  std::istringstream iss(normalized);
+  int64_t value;
+  while (iss >> value) {
+    ids.push_back(static_cast<int32_t>(value));
+  }
+  return ids;
+}
+
+static bool read_utf8_codepoint(const std::string &text, size_t pos,
+                                uint32_t &codepoint, size_t &length) {
+  const unsigned char first = static_cast<unsigned char>(text[pos]);
+  if (first < 0x80) {
+    codepoint = first;
+    length = 1;
+    return true;
+  }
+
+  auto is_continuation = [](unsigned char ch) {
+    return (ch & 0xC0) == 0x80;
+  };
+
+  if ((first & 0xE0) == 0xC0 && pos + 1 < text.size()) {
+    const unsigned char b1 = static_cast<unsigned char>(text[pos + 1]);
+    if (!is_continuation(b1))
+      return false;
+    codepoint = ((first & 0x1F) << 6) | (b1 & 0x3F);
+    length = 2;
+    return true;
+  }
+
+  if ((first & 0xF0) == 0xE0 && pos + 2 < text.size()) {
+    const unsigned char b1 = static_cast<unsigned char>(text[pos + 1]);
+    const unsigned char b2 = static_cast<unsigned char>(text[pos + 2]);
+    if (!is_continuation(b1) || !is_continuation(b2))
+      return false;
+    codepoint = ((first & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
+    length = 3;
+    return true;
+  }
+
+  if ((first & 0xF8) == 0xF0 && pos + 3 < text.size()) {
+    const unsigned char b1 = static_cast<unsigned char>(text[pos + 1]);
+    const unsigned char b2 = static_cast<unsigned char>(text[pos + 2]);
+    const unsigned char b3 = static_cast<unsigned char>(text[pos + 3]);
+    if (!is_continuation(b1) || !is_continuation(b2) ||
+        !is_continuation(b3))
+      return false;
+    codepoint = ((first & 0x07) << 18) | ((b1 & 0x3F) << 12) |
+                ((b2 & 0x3F) << 6) | (b3 & 0x3F);
+    length = 4;
+    return true;
+  }
+
+  return false;
+}
+
+static bool is_valid_utf8_string(const std::string &text) {
+  for (size_t pos = 0; pos < text.size();) {
+    uint32_t codepoint = 0;
+    size_t length = 0;
+    if (!read_utf8_codepoint(text, pos, codepoint, length))
+      return false;
+    pos += length;
+  }
+  return true;
+}
+
+static const std::unordered_map<uint32_t, unsigned char> &
+get_byte_level_decoder() {
+  static const std::unordered_map<uint32_t, unsigned char> decoder = [] {
+    std::vector<unsigned int> bytes;
+    for (unsigned int ch = static_cast<unsigned int>('!');
+         ch <= static_cast<unsigned int>('~'); ++ch)
+      bytes.push_back(ch);
+    for (unsigned int ch = 0xA1; ch <= 0xAC; ++ch)
+      bytes.push_back(ch);
+    for (unsigned int ch = 0xAE; ch <= 0xFF; ++ch)
+      bytes.push_back(ch);
+
+    std::vector<unsigned int> chars = bytes;
+    unsigned int n = 0;
+    for (unsigned int byte = 0; byte < 256; ++byte) {
+      if (std::find(bytes.begin(), bytes.end(), byte) == bytes.end()) {
+        bytes.push_back(byte);
+        chars.push_back(256 + n);
+        ++n;
+      }
+    }
+
+    std::unordered_map<uint32_t, unsigned char> byte_decoder;
+    for (size_t i = 0; i < bytes.size(); ++i)
+      byte_decoder[chars[i]] = static_cast<unsigned char>(bytes[i]);
+    return byte_decoder;
+  }();
+  return decoder;
+}
+
+static void append_byte_level_piece(const std::string &piece,
+                                    std::string &decoded) {
+  const auto &byte_decoder = get_byte_level_decoder();
+
+  for (size_t pos = 0; pos < piece.size();) {
+    uint32_t codepoint = 0;
+    size_t length = 0;
+    if (!read_utf8_codepoint(piece, pos, codepoint, length)) {
+      decoded.push_back(piece[pos++]);
+      continue;
+    }
+
+    auto it = byte_decoder.find(codepoint);
+    if (it != byte_decoder.end()) {
+      decoded.push_back(static_cast<char>(it->second));
+    } else {
+      decoded.append(piece, pos, length);
+    }
+    pos += length;
+  }
+}
+
+static bool is_special_token_piece(const std::string &piece) {
+  return piece.size() >= 4 && piece.rfind("<|", 0) == 0 &&
+         piece.compare(piece.size() - 2, 2, "|>") == 0;
+}
+
 CausalLM::CausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
   Transformer(cfg, generation_cfg, nntr_cfg, ModelType::CAUSALLM) {
   setupParameters(cfg, generation_cfg, nntr_cfg);
@@ -47,6 +196,11 @@ CausalLM::CausalLM(json &cfg, json &generation_cfg, json &nntr_cfg) :
 
 void CausalLM::setupParameters(json &cfg, json &generation_cfg,
                                json &nntr_cfg) {
+  json &model_cfg =
+    (cfg.contains("text_config") && cfg["text_config"].is_object())
+      ? cfg["text_config"]
+      : cfg;
+
   // Initialize output list
   for (unsigned int i = 0; i < BATCH_SIZE; ++i)
     output_list.push_back("");
@@ -77,18 +231,31 @@ void CausalLM::setupParameters(json &cfg, json &generation_cfg,
           .get<unsigned int>();
   }
 
-  if (generation_cfg["eos_token_id"].is_array()) {
+  if (!generation_cfg.contains("eos_token_id") ||
+      generation_cfg["eos_token_id"].is_null()) {
+    if (model_cfg["eos_token_id"].is_array()) {
+      EOS_TOKEN_ID = model_cfg["eos_token_id"].get<std::vector<unsigned int>>();
+    } else {
+      EOS_TOKEN_ID.clear();
+      EOS_TOKEN_ID.push_back(model_cfg["eos_token_id"].get<unsigned int>());
+    }
+  } else if (generation_cfg["eos_token_id"].is_array()) {
     EOS_TOKEN_ID =
       generation_cfg["eos_token_id"].empty()
-        ? cfg["eos_token_id"].get<std::vector<unsigned int>>()
+        ? model_cfg["eos_token_id"].get<std::vector<unsigned int>>()
         : generation_cfg["eos_token_id"].get<std::vector<unsigned int>>();
   } else {
     EOS_TOKEN_ID.clear();
     EOS_TOKEN_ID.push_back(generation_cfg["eos_token_id"].get<unsigned int>());
   }
-  BOS_TOKEN_ID = generation_cfg["bos_token_id"].empty()
-                   ? cfg["bos_token_id"].get<unsigned int>()
-                   : generation_cfg["bos_token_id"].get<unsigned int>();
+  BOS_TOKEN_ID =
+    (!generation_cfg.contains("bos_token_id") ||
+     generation_cfg["bos_token_id"].is_null() ||
+     generation_cfg["bos_token_id"].empty())
+      ? (model_cfg.contains("bos_token_id") && !model_cfg["bos_token_id"].is_null()
+           ? model_cfg["bos_token_id"].get<unsigned int>()
+           : EOS_TOKEN_ID.front())
+      : generation_cfg["bos_token_id"].get<unsigned int>();
   TOP_K = generation_cfg.contains("top_k")
             ? generation_cfg["top_k"].get<unsigned int>()
             : 20;
@@ -99,6 +266,86 @@ void CausalLM::setupParameters(json &cfg, json &generation_cfg,
                   ? generation_cfg["temperature"].get<float>()
                   : 0.7;
   global_token_len = 0;
+  setupFallbackTokenDecoder(nntr_cfg);
+}
+
+void CausalLM::setupFallbackTokenDecoder(json &nntr_cfg) {
+  fallback_token_id_to_piece_.clear();
+  fallback_special_token_ids_.clear();
+  has_fallback_token_decoder_ = false;
+
+  if (tokenizer)
+    return;
+
+  if (!nntr_cfg.contains("tokenizer_file"))
+    return;
+
+  try {
+    const std::string tokenizer_file =
+      nntr_cfg["tokenizer_file"].get<std::string>();
+    json tokenizer_json = LoadJsonFile(tokenizer_file);
+
+    auto add_piece = [this](int64_t id, const std::string &piece,
+                            bool is_special) {
+      if (id < 0 ||
+          id > static_cast<int64_t>(std::numeric_limits<unsigned int>::max()))
+        return;
+
+      const auto token_id = static_cast<unsigned int>(id);
+      fallback_token_id_to_piece_[token_id] = piece;
+      if (is_special)
+        fallback_special_token_ids_.insert(token_id);
+    };
+
+    if (tokenizer_json.contains("model") &&
+        tokenizer_json["model"].contains("vocab") &&
+        tokenizer_json["model"]["vocab"].is_object()) {
+      for (auto it = tokenizer_json["model"]["vocab"].begin();
+           it != tokenizer_json["model"]["vocab"].end(); ++it) {
+        if (!it.value().is_number_integer() &&
+            !it.value().is_number_unsigned())
+          continue;
+        add_piece(it.value().get<int64_t>(), it.key(),
+                  is_special_token_piece(it.key()));
+      }
+    }
+
+    if (tokenizer_json.contains("added_tokens") &&
+        tokenizer_json["added_tokens"].is_array()) {
+      for (const auto &token : tokenizer_json["added_tokens"]) {
+        if (!token.contains("id") || !token.contains("content"))
+          continue;
+        add_piece(token["id"].get<int64_t>(), token["content"].get<std::string>(),
+                  token.value("special", false));
+      }
+    }
+
+    has_fallback_token_decoder_ = !fallback_token_id_to_piece_.empty();
+  } catch (const std::exception &e) {
+    std::cerr << "[Warning] Failed to setup tokenizer.json fallback decoder: "
+              << e.what() << std::endl;
+  }
+}
+
+std::string CausalLM::decodeFallbackTokens(const std::vector<int> &ids) const {
+  std::string decoded;
+  for (int id : ids) {
+    if (id < 0)
+      continue;
+
+    const auto token_id = static_cast<unsigned int>(id);
+    if (fallback_special_token_ids_.find(token_id) !=
+        fallback_special_token_ids_.end())
+      continue;
+
+    auto it = fallback_token_id_to_piece_.find(token_id);
+    if (it == fallback_token_id_to_piece_.end())
+      continue;
+
+    append_byte_level_piece(it->second, decoded);
+  }
+
+  return decoded;
 }
 
 void CausalLM::constructModel() {
@@ -134,7 +381,32 @@ void CausalLM::registerOutputs(
     if (!eos_list[b]) {
       pending_ids_.push_back(static_cast<int>(ids[b]));
       ids_history[b * MAX_SEQ_LEN + pos] = ids[b];
-      std::string decoded_str = tokenizer->Decode(pending_ids_);
+
+      if (!tokenizer && !has_fallback_token_decoder_) {
+        std::string decoded_str = std::to_string(ids[b]);
+        if (log_output) {
+          std::cout << decoded_str << " ";
+          std::cout.flush();
+        }
+        if (!output_list[b].empty())
+          output_list[b].append(" ");
+        output_list[b].append(decoded_str);
+        pending_ids_.clear();
+        continue;
+      }
+
+      std::string decoded_str = tokenizer ? tokenizer->Decode(pending_ids_)
+                                          : decodeFallbackTokens(pending_ids_);
+
+      if (decoded_str.empty()) {
+        pending_ids_.clear();
+        continue;
+      }
+
+      if (!tokenizer && has_fallback_token_decoder_ &&
+          !is_valid_utf8_string(decoded_str)) {
+        continue;
+      }
 
       if (std::find(puncts.begin(), puncts.end(), decoded_str.back()) !=
           puncts.end()) {
@@ -323,17 +595,52 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
    *  if USE_KVCACHE && system_prompt is given && but the
    * PRE_COMPUTED_CACHE_PATH does not exist
    */
-  SAVE_KVCACHE = (USE_KVCACHE && system_prompt != "" &&
+  SAVE_KVCACHE = (USE_KVCACHE && system_prompt != WSTR{} &&
                   !std::filesystem::exists(PRE_COMPUTED_CACHE_PATH));
 
 #if defined(_WIN32)
-  if (log_output)
-    std::wcout << L"" << system_prompt << L"" << text_ << std::endl;
-  std::wstring prompt_ = prompt;
-  if (!SAVE_KVCACHE)
-    prompt_ += TAIL_PROMPT;
-  std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
-  auto _input = tokenizer->Encode(converter.to_bytes(prompt_));
+  std::vector<int32_t> _input;
+
+  std::wstring prompt_;
+
+  if (USE_KVCACHE) {
+    prompt_ = SAVE_KVCACHE ? system_prompt : (prompt + tail_prompt);
+  } else {
+    prompt_ = system_prompt + prompt + tail_prompt;
+  }
+
+  if (log_output) {
+    bool printed_decoded_prompt = false;
+    if (!tokenizer && has_fallback_token_decoder_) {
+      const std::vector<int32_t> prompt_ids =
+        parse_input_ids(wstring_to_utf8(prompt_));
+      if (!prompt_ids.empty()) {
+        const std::vector<int> display_ids(prompt_ids.begin(),
+                                           prompt_ids.end());
+        const std::string decoded_prompt = decodeFallbackTokens(display_ids);
+        if (!decoded_prompt.empty()) {
+          std::wcout << utf8_to_wstring(decoded_prompt) << std::endl;
+          printed_decoded_prompt = true;
+        }
+      }
+    }
+
+    if (!printed_decoded_prompt)
+      std::wcout << prompt_ << std::endl;
+  }
+
+  if (USE_KVCACHE && !SAVE_KVCACHE && SYS_PROMP_LEN == 0) {
+    SYS_PROMP_LEN =
+      tokenizer
+        ? tokenizer->Encode(wstring_to_utf8(system_prompt)).size()
+        : parse_input_ids(wstring_to_utf8(system_prompt)).size();
+  }
+
+  if (tokenizer) {
+    _input = tokenizer->Encode(wstring_to_utf8(prompt_));
+  } else {
+    _input = parse_input_ids(wstring_to_utf8(prompt_));
+  }
 #else
   // print input text
   if (log_output)
@@ -351,7 +658,12 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   if (USE_KVCACHE && !SAVE_KVCACHE && SYS_PROMP_LEN == 0)
     SYS_PROMP_LEN = tokenizer->Encode(system_prompt).size();
 
-  auto _input = tokenizer->Encode(prompt_);
+  std::vector<int32_t> _input;
+  if (tokenizer) {
+    _input = tokenizer->Encode(prompt_);
+  } else {
+    _input = parse_input_ids(prompt_);
+  }
   ///@note insert bos token at the beginning of the input
   // _input.insert(_input.begin(), BOS_TOKEN_ID);
 #endif

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -40,6 +40,8 @@
 #endif
 
 #include <transformer.h>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace causallm {
 
@@ -70,8 +72,8 @@ public:
    * @brief run the CausalLM model
    */
   void run(const WSTR prompt, bool do_sample = false,
-           const WSTR system_prompt = "", const WSTR tail_prompt = "",
-           bool log_output = true) override;
+           const WSTR system_prompt = WSTR{},
+           const WSTR tail_prompt = WSTR{}, bool log_output = true) override;
 
   /**
    * @brief Get the generated output text
@@ -104,6 +106,16 @@ protected:
   registerOutputs(std::unique_ptr<tokenizers::Tokenizer> &tokenizer,
                   std::vector<unsigned int> ids, unsigned int pos,
                   const std::vector<bool> &eos_list, bool log_output = true);
+
+  /**
+   * @brief Setup a lightweight token-id decoder from tokenizer.json
+   */
+  void setupFallbackTokenDecoder(json &nntr_cfg);
+
+  /**
+   * @brief Decode token IDs using the lightweight tokenizer.json decoder
+   */
+  std::string decodeFallbackTokens(const std::vector<int> &ids) const;
 
   /**
    * @brief save kv cache
@@ -155,6 +167,10 @@ protected:
   bool has_run_ = false;
 
   std::mt19937 rng; /**< Random Number Gen */
+
+  std::unordered_map<unsigned int, std::string> fallback_token_id_to_piece_;
+  std::unordered_set<unsigned int> fallback_special_token_ids_;
+  bool has_fallback_token_decoder_ = false;
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/models/meson.build
+++ b/Applications/CausalLM/models/meson.build
@@ -1,16 +1,24 @@
 causallm_src += [
     meson.current_source_dir() / 'causal_lm.cpp',
     meson.current_source_dir() / 'transformer.cpp',
-    meson.current_source_dir() / 'sentence_transformer.cpp',
 ]
 
 causallm_inc += include_directories('.')
 
-subdir('gpt_oss')
-subdir('gpt_oss_cached_slim')
-subdir('qwen2')
-subdir('qwen3')
-subdir('qwen3_moe')
-subdir('qwen3_slim_moe')
-subdir('qwen3_cached_slim_moe')
-subdir('gemma3')
+if host_machine.system() == 'windows'
+    subdir('qwen35')
+else
+    causallm_src += [
+        meson.current_source_dir() / 'sentence_transformer.cpp',
+    ]
+
+    subdir('gpt_oss')
+    subdir('gpt_oss_cached_slim')
+    subdir('qwen2')
+    subdir('qwen3')
+    subdir('qwen35')
+    subdir('qwen3_moe')
+    subdir('qwen3_slim_moe')
+    subdir('qwen3_cached_slim_moe')
+    subdir('gemma3')
+endif

--- a/Applications/CausalLM/models/performance_metrics.h
+++ b/Applications/CausalLM/models/performance_metrics.h
@@ -39,8 +39,8 @@ typedef struct {
 #ifdef __cplusplus
 
 #ifdef _WIN32
-#include <psapi.h>
 #include <windows.h>
+#include <psapi.h>
 #else
 #include <sys/resource.h>
 #endif

--- a/Applications/CausalLM/models/qwen35/meson.build
+++ b/Applications/CausalLM/models/qwen35/meson.build
@@ -1,0 +1,8 @@
+qwen35_src = [
+    meson.current_source_dir() / 'qwen35_causallm.cpp',
+]
+
+qwen35_inc = include_directories('.')
+
+causallm_src += qwen35_src
+causallm_inc += qwen35_inc

--- a/Applications/CausalLM/models/qwen35/qwen35_causallm.cpp
+++ b/Applications/CausalLM/models/qwen35/qwen35_causallm.cpp
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   qwen35_causallm.cpp
+ * @brief  Qwen3.5 text-only causal language model.
+ */
+
+#include <qwen35_causallm.h>
+
+#include <app_context.h>
+#include <engine.h>
+#include <llm_util.hpp>
+#include <model.h>
+#include <qwen35_layers.h>
+#include <reshaped_rms_norm.h>
+
+namespace causallm {
+
+namespace {
+
+json &text_config(json &cfg) {
+  if (cfg.contains("text_config") && cfg["text_config"].is_object())
+    return cfg["text_config"];
+  return cfg;
+}
+
+} // namespace
+
+Qwen35CausalLM::Qwen35CausalLM(json &cfg, json &generation_cfg,
+                               json &nntr_cfg) :
+  Transformer(cfg, generation_cfg, nntr_cfg, ModelType::CAUSALLM),
+  CausalLM(cfg, generation_cfg, nntr_cfg) {
+  setupQwen35Parameters(cfg);
+}
+
+void Qwen35CausalLM::setupQwen35Parameters(json &cfg) {
+  json &tcfg = text_config(cfg);
+
+  layer_types_ = tcfg["layer_types"].get<std::vector<std::string>>();
+  linear_num_key_heads = tcfg["linear_num_key_heads"].get<unsigned int>();
+  linear_num_value_heads = tcfg["linear_num_value_heads"].get<unsigned int>();
+  linear_key_head_dim = tcfg["linear_key_head_dim"].get<unsigned int>();
+  linear_value_head_dim = tcfg["linear_value_head_dim"].get<unsigned int>();
+  linear_conv_kernel_dim = tcfg["linear_conv_kernel_dim"].get<unsigned int>();
+
+  if (tcfg.contains("rope_parameters") &&
+      tcfg["rope_parameters"].contains("partial_rotary_factor")) {
+    partial_rotary_factor =
+      tcfg["rope_parameters"]["partial_rotary_factor"].get<float>();
+  }
+}
+
+std::vector<LayerHandle> Qwen35CausalLM::createQwen35FullAttention(
+  const int layer_id, std::string input_name) {
+  std::vector<LayerHandle> layers;
+
+  const unsigned int q_width = NUM_HEADS * HEAD_DIM;
+  const unsigned int kv_width = NUM_KEY_VALUE_HEADS * HEAD_DIM;
+
+  const auto Q = "layer" + std::to_string(layer_id) + "_wq";
+  const auto K = "layer" + std::to_string(layer_id) + "_wk";
+  const auto V = "layer" + std::to_string(layer_id) + "_wv";
+  const auto Q_query = "layer" + std::to_string(layer_id) + "_wq_query";
+  const auto Q_gate = "layer" + std::to_string(layer_id) + "_wq_gate";
+  const auto Q_gate_act =
+    "layer" + std::to_string(layer_id) + "_wq_gate_sigmoid";
+  const auto Q_norm = "layer" + std::to_string(layer_id) + "_q_norm";
+  const auto K_norm = "layer" + std::to_string(layer_id) + "_k_norm";
+  const auto A = "layer" + std::to_string(layer_id) + "_attention";
+  const auto A_gated = "layer" + std::to_string(layer_id) + "_attention_gated";
+  const auto O = "layer" + std::to_string(layer_id) + "_attention_out";
+
+  layers.push_back(createLayer(
+    "fully_connected",
+    {withKey("name", Q), withKey("unit", q_width * 2),
+     withKey("disable_bias", "true"), withKey("input_layers", input_name),
+     withKey("weight_initializer", "ones")}));
+  layers.push_back(createLayer(
+    "fully_connected",
+    {withKey("name", K), withKey("unit", kv_width),
+     withKey("disable_bias", "true"), withKey("input_layers", input_name),
+     withKey("weight_initializer", "ones")}));
+  layers.push_back(createLayer(
+    "fully_connected",
+    {withKey("name", V), withKey("unit", kv_width),
+     withKey("disable_bias", "true"), withKey("input_layers", input_name),
+     withKey("weight_initializer", "ones")}));
+
+  layers.push_back(createLayer(
+    "qwen35_head_pair_split",
+    {withKey("name", Q_query), withKey("input_layers", Q),
+     withKey("feature_size", HEAD_DIM), withKey("select_index", "0")}));
+  layers.push_back(createLayer(
+    "qwen35_head_pair_split",
+    {withKey("name", Q_gate), withKey("input_layers", Q),
+     withKey("feature_size", HEAD_DIM), withKey("select_index", "1")}));
+
+  layers.push_back(createLayer(
+    "reshaped_rms_norm",
+    {withKey("name", Q_norm), withKey("input_layers", Q_query),
+     withKey("packed", "false"), withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("feature_size", std::to_string(HEAD_DIM))}));
+  layers.push_back(createLayer(
+    "reshaped_rms_norm",
+    {withKey("name", K_norm), withKey("input_layers", K),
+     withKey("packed", "false"), withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("feature_size", std::to_string(HEAD_DIM))}));
+
+  layers.push_back(createLayer(
+    "mha_core",
+    {withKey("name", A), withKey("num_heads", NUM_HEADS),
+     withKey("num_heads_kv", NUM_KEY_VALUE_HEADS),
+     withKey("max_timestep", std::to_string(INIT_SEQ_LEN + NUM_TO_GENERATE)),
+     withKey("sliding_window", SLIDING_WINDOW),
+     withKey("rope_theta", ROPE_THETA),
+     withKey("max_position_embeddings", MAX_POSITION_EMBEDDINGS),
+     withKey("max_new_tokens", std::to_string(NUM_TO_GENERATE)),
+     withKey("partial_rotary_factor", partial_rotary_factor),
+     withKey("is_causal", IS_CAUSAL ? "true" : "false"),
+     withKey("input_layers", {Q_norm, K_norm, V})}));
+
+  layers.push_back(createLayer(
+    "activation",
+    {withKey("name", Q_gate_act), withKey("input_layers", Q_gate),
+     withKey("activation", "sigmoid")}));
+  layers.push_back(createLayer(
+    "multiply",
+    {withKey("name", A_gated), withKey("input_layers", {A, Q_gate_act})}));
+  layers.push_back(createLayer(
+    "fully_connected",
+    {withKey("name", O), withKey("unit", DIM),
+     withKey("disable_bias", "true"), withKey("input_layers", A_gated),
+     withKey("weight_initializer", "ones")}));
+
+  return layers;
+}
+
+std::vector<LayerHandle> Qwen35CausalLM::createQwen35LinearAttention(
+  const int layer_id, std::string input_name) {
+  std::vector<LayerHandle> layers;
+
+  const unsigned int key_dim = linear_num_key_heads * linear_key_head_dim;
+  const unsigned int value_dim =
+    linear_num_value_heads * linear_value_head_dim;
+  const unsigned int conv_dim = key_dim * 2 + value_dim;
+
+  const auto prefix = "layer" + std::to_string(layer_id) + "_linear_attn";
+  const auto QKV = prefix + "_qkv";
+  const auto Conv = prefix + "_conv";
+  const auto ConvAct = prefix + "_conv_silu";
+  const auto Q = prefix + "_q";
+  const auto K = prefix + "_k";
+  const auto V = prefix + "_v";
+  const auto QNorm = prefix + "_q_l2_norm";
+  const auto KNorm = prefix + "_k_l2_norm";
+  const auto Z = prefix + "_z";
+  const auto ZAct = prefix + "_z_silu";
+  const auto Beta = prefix + "_beta";
+  const auto BetaAct = prefix + "_beta_sigmoid";
+  const auto A = prefix + "_decay";
+  const auto ABias = prefix + "_decay_bias";
+  const auto ASoftplus = prefix + "_decay_softplus";
+  const auto AScale = prefix + "_decay_scale";
+  const auto Core = prefix + "_core";
+  const auto CoreNorm = prefix + "_norm";
+  const auto Gated = prefix + "_gated";
+  const auto O = "layer" + std::to_string(layer_id) + "_attention_out";
+
+  layers.push_back(createLayer(
+    "fully_connected",
+    {withKey("name", QKV), withKey("unit", conv_dim),
+     withKey("disable_bias", "true"), withKey("input_layers", input_name),
+     withKey("weight_initializer", "ones")}));
+  layers.push_back(createLayer(
+    "qwen35_causal_depthwise_conv1d",
+    {withKey("name", Conv), withKey("input_layers", QKV),
+     withKey("linear_conv_kernel_dim", linear_conv_kernel_dim)}));
+  layers.push_back(createLayer(
+    "activation",
+    {withKey("name", ConvAct), withKey("input_layers", Conv),
+     withKey("activation", "swish")}));
+
+  layers.push_back(createLayer(
+    "slice", {withKey("name", Q), withKey("input_layers", ConvAct),
+              withKey("axis", "3"), withKey("start_index", "1"),
+              withKey("end_index", std::to_string(key_dim + 1))}));
+  layers.push_back(createLayer(
+    "slice", {withKey("name", K), withKey("input_layers", ConvAct),
+              withKey("axis", "3"),
+              withKey("start_index", std::to_string(key_dim + 1)),
+              withKey("end_index", std::to_string(key_dim * 2 + 1))}));
+  layers.push_back(createLayer(
+    "slice", {withKey("name", V), withKey("input_layers", ConvAct),
+              withKey("axis", "3"),
+              withKey("start_index", std::to_string(key_dim * 2 + 1)),
+              withKey("end_index", std::to_string(conv_dim + 1))}));
+
+  layers.push_back(createLayer(
+    "reshaped_l2_norm",
+    {withKey("name", QNorm), withKey("input_layers", Q),
+     withKey("feature_size", linear_key_head_dim),
+     withKey("epsilon", "1e-6")}));
+  layers.push_back(createLayer(
+    "reshaped_l2_norm",
+    {withKey("name", KNorm), withKey("input_layers", K),
+     withKey("feature_size", linear_key_head_dim),
+     withKey("epsilon", "1e-6")}));
+
+  layers.push_back(createLayer(
+    "fully_connected",
+    {withKey("name", Z), withKey("unit", value_dim),
+     withKey("disable_bias", "true"), withKey("input_layers", input_name),
+     withKey("weight_initializer", "ones")}));
+  layers.push_back(createLayer(
+    "activation",
+    {withKey("name", ZAct), withKey("input_layers", Z),
+     withKey("activation", "swish")}));
+
+  layers.push_back(createLayer(
+    "fully_connected",
+    {withKey("name", Beta), withKey("unit", linear_num_value_heads),
+     withKey("disable_bias", "true"), withKey("input_layers", input_name),
+     withKey("weight_initializer", "ones")}));
+  layers.push_back(createLayer(
+    "activation",
+    {withKey("name", BetaAct), withKey("input_layers", Beta),
+     withKey("activation", "sigmoid")}));
+
+  layers.push_back(createLayer(
+    "fully_connected",
+    {withKey("name", A), withKey("unit", linear_num_value_heads),
+     withKey("disable_bias", "true"), withKey("input_layers", input_name),
+     withKey("weight_initializer", "ones")}));
+  layers.push_back(createLayer(
+    "feature_bias",
+    {withKey("name", ABias), withKey("input_layers", A)}));
+  layers.push_back(createLayer(
+    "activation",
+    {withKey("name", ASoftplus), withKey("input_layers", ABias),
+     withKey("activation", "softplus")}));
+  layers.push_back(createLayer(
+    "feature_scale",
+    {withKey("name", AScale), withKey("input_layers", ASoftplus)}));
+
+  layers.push_back(createLayer(
+    "qwen35_gated_delta_core",
+    {withKey("name", Core),
+     withKey("input_layers", {QNorm, KNorm, V, BetaAct, AScale}),
+     withKey("linear_num_key_heads", linear_num_key_heads),
+     withKey("linear_num_value_heads", linear_num_value_heads),
+     withKey("linear_key_head_dim", linear_key_head_dim),
+     withKey("linear_value_head_dim", linear_value_head_dim)}));
+  layers.push_back(createLayer(
+    "reshaped_rms_norm",
+    {withKey("name", CoreNorm), withKey("input_layers", Core),
+     withKey("packed", "false"), withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("feature_size", linear_value_head_dim)}));
+  layers.push_back(createLayer(
+    "multiply",
+    {withKey("name", Gated), withKey("input_layers", {CoreNorm, ZAct})}));
+  layers.push_back(createLayer(
+    "fully_connected",
+    {withKey("name", O), withKey("unit", DIM),
+     withKey("disable_bias", "true"), withKey("input_layers", Gated),
+     withKey("weight_initializer", "ones")}));
+
+  return layers;
+}
+
+std::vector<LayerHandle>
+Qwen35CausalLM::createTransformerDecoderBlock(const int layer_id,
+                                              std::string input_name) {
+  std::vector<LayerHandle> layers;
+
+  layers.push_back(createLayer(
+    "rms_norm",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_attention_norm"),
+     withKey("input_layers", input_name),
+     withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("packed", "false")}));
+
+  std::vector<LayerHandle> token_mixer;
+  if (layer_types_.at(layer_id) == "linear_attention") {
+    token_mixer = createQwen35LinearAttention(
+      layer_id, "layer" + std::to_string(layer_id) + "_attention_norm");
+  } else if (layer_types_.at(layer_id) == "full_attention") {
+    token_mixer = createQwen35FullAttention(
+      layer_id, "layer" + std::to_string(layer_id) + "_attention_norm");
+  } else {
+    throw std::invalid_argument("Unsupported Qwen3.5 layer type: " +
+                                layer_types_.at(layer_id));
+  }
+  layers.insert(layers.end(), token_mixer.begin(), token_mixer.end());
+
+  layers.push_back(createLayer(
+    "addition",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_decoder_add"),
+     withKey("input_layers", input_name + ",layer" + std::to_string(layer_id) +
+                               "_attention_out")}));
+
+  layers.push_back(createLayer(
+    "rms_norm",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_norm"),
+     withKey("input_layers",
+             "layer" + std::to_string(layer_id) + "_decoder_add"),
+     withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("packed", "false")}));
+
+  auto ffn_layer = createMlp(layer_id, DIM, INTERMEDIATE_SIZE,
+                             "layer" + std::to_string(layer_id) + "_ffn_norm");
+  layers.insert(layers.end(), ffn_layer.begin(), ffn_layer.end());
+
+  layers.push_back(createLayer(
+    "addition",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_decoder_output"),
+     withKey("input_layers", "layer" + std::to_string(layer_id) +
+                               "_decoder_add,layer" + std::to_string(layer_id) +
+                               "_ffn_down")}));
+
+  return layers;
+}
+
+void Qwen35CausalLM::registerCustomLayers() {
+  CausalLM::registerCustomLayers();
+
+  auto &ct_engine = nntrainer::Engine::Global();
+  auto app_context =
+    static_cast<nntrainer::AppContext *>(ct_engine.getRegisteredContext("cpu"));
+
+  try {
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::ReshapedRMSNormLayer>);
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::ReshapedL2NormLayer>);
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::FeatureBiasLayer>);
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::FeatureScaleLayer>);
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::HeadPairSplitLayer>);
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::Qwen35CausalDepthwiseConv1DLayer>);
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::Qwen35GatedDeltaCoreLayer>);
+  } catch (std::invalid_argument &e) {
+    std::cerr << "failed to register factory, reason: " << e.what()
+              << std::endl;
+  }
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/models/qwen35/qwen35_causallm.h
+++ b/Applications/CausalLM/models/qwen35/qwen35_causallm.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   qwen35_causallm.h
+ * @brief  Qwen3.5 text-only causal language model.
+ */
+
+#ifndef __QWEN35_CAUSAL_LM_H__
+#define __QWEN35_CAUSAL_LM_H__
+
+#include <causal_lm.h>
+
+namespace causallm {
+
+class WIN_EXPORT Qwen35CausalLM : public CausalLM {
+public:
+  static constexpr const char *architectures = "Qwen3_5ForConditionalGeneration";
+
+  Qwen35CausalLM(json &cfg, json &generation_cfg, json &nntr_cfg);
+  virtual ~Qwen35CausalLM() = default;
+
+  std::vector<LayerHandle>
+  createTransformerDecoderBlock(const int layer_id,
+                                std::string input_name) override;
+
+  void registerCustomLayers() override;
+
+private:
+  void setupQwen35Parameters(json &cfg);
+  std::vector<LayerHandle> createQwen35FullAttention(const int layer_id,
+                                                     std::string input_name);
+  std::vector<LayerHandle> createQwen35LinearAttention(const int layer_id,
+                                                       std::string input_name);
+
+  std::vector<std::string> layer_types_;
+  unsigned int linear_num_key_heads = 16;
+  unsigned int linear_num_value_heads = 16;
+  unsigned int linear_key_head_dim = 128;
+  unsigned int linear_value_head_dim = 128;
+  unsigned int linear_conv_kernel_dim = 4;
+  float partial_rotary_factor = 0.25f;
+};
+
+} // namespace causallm
+
+#endif /* __QWEN35_CAUSAL_LM_H__ */

--- a/Applications/CausalLM/models/sentence_transformer.h
+++ b/Applications/CausalLM/models/sentence_transformer.h
@@ -44,8 +44,8 @@ public:
    * @brief run the SentenceTransformer model
    */
   void run(const WSTR prompt, bool do_sample = false,
-           const WSTR system_prompt = "", const WSTR tail_prmopt = "",
-           bool log_output = true) override;
+           const WSTR system_prompt = WSTR{},
+           const WSTR tail_prmopt = WSTR{}, bool log_output = true) override;
 
   /**
    * @brief Encode the prompt and return the embedding
@@ -54,8 +54,9 @@ public:
    * @param tail_prompt Tail prompt
    * @return SentenceTransformer output from the model
    */
-  std::vector<float *> encode(const WSTR prompt, const WSTR system_prompt = "",
-                              const WSTR tail_prompt = "");
+  std::vector<float *> encode(const WSTR prompt,
+                              const WSTR system_prompt = WSTR{},
+                              const WSTR tail_prompt = WSTR{});
 
 protected:
   /**

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <fstream>
+#include <sstream>
 
 #include <app_context.h>
 #include <engine.h>
@@ -82,13 +83,23 @@ Transformer::Transformer(json &cfg, json &generation_cfg, json &nntr_cfg,
   // This is where you would set up the model layers, parameters, etc.
   setupParameters(cfg, generation_cfg, nntr_cfg);
 
-  // prep tokenizer
-  tokenizer = tokenizers::Tokenizer::FromBlobJSON(
-    LoadBytesFromFile(nntr_cfg["tokenizer_file"]));
+#if !defined(_WIN32)
+  if (!nntr_cfg.value("disable_tokenizer", false) &&
+      nntr_cfg.contains("tokenizer_file")) {
+    tokenizer = tokenizers::Tokenizer::FromBlobJSON(
+      LoadBytesFromFile(nntr_cfg["tokenizer_file"]));
+  }
+#else
+  tokenizer = nullptr;
+#endif
 };
 
 void Transformer::setupParameters(json &cfg, json &generation_cfg,
                                   json &nntr_cfg) {
+  json &model_cfg =
+    (cfg.contains("text_config") && cfg["text_config"].is_object())
+      ? cfg["text_config"]
+      : cfg;
 
   /** Initialize nntr prameters */
   BATCH_SIZE = nntr_cfg["batch_size"].get<unsigned int>();
@@ -104,34 +115,41 @@ void Transformer::setupParameters(json &cfg, json &generation_cfg,
   EMBEDDING_DTYPE = nntr_cfg["embedding_dtype"];
   FC_LAYER_DTYPE = nntr_cfg["fc_layer_dtype"];
 
-  if (cfg.contains("is_causal")) {
-    IS_CAUSAL = cfg["is_causal"].get<bool>();
-  } else if (cfg.contains("use_bidirectional_attention")) {
-    IS_CAUSAL = !cfg["use_bidirectional_attention"].get<bool>();
+  if (model_cfg.contains("is_causal")) {
+    IS_CAUSAL = model_cfg["is_causal"].get<bool>();
+  } else if (model_cfg.contains("use_bidirectional_attention")) {
+    IS_CAUSAL = !model_cfg["use_bidirectional_attention"].get<bool>();
   }
 
-  NUM_VOCAB = cfg["vocab_size"];
-  DIM = cfg["hidden_size"];
-  INTERMEDIATE_SIZE = cfg["intermediate_size"];
-  NUM_LAYERS = cfg["num_hidden_layers"];
-  NUM_HEADS = cfg["num_attention_heads"];
-  HEAD_DIM = cfg.contains("head_dim")
-               ? cfg["head_dim"].get<int>()
+  NUM_VOCAB = model_cfg["vocab_size"];
+  DIM = model_cfg["hidden_size"];
+  INTERMEDIATE_SIZE = model_cfg["intermediate_size"];
+  NUM_LAYERS = model_cfg["num_hidden_layers"];
+  NUM_HEADS = model_cfg["num_attention_heads"];
+  HEAD_DIM = model_cfg.contains("head_dim")
+               ? model_cfg["head_dim"].get<int>()
                : DIM / NUM_HEADS; // default value is hidden_size / num_heads
-  NUM_KEY_VALUE_HEADS = cfg.contains("num_key_value_heads")
-                          ? cfg["num_key_value_heads"].get<int>()
+  NUM_KEY_VALUE_HEADS = model_cfg.contains("num_key_value_heads")
+                          ? model_cfg["num_key_value_heads"].get<int>()
                           : NUM_HEADS;
   SLIDING_WINDOW =
-    cfg.contains("sliding_window") && !cfg["sliding_window"].is_null()
-      ? cfg["sliding_window"].get<unsigned int>()
+    model_cfg.contains("sliding_window") && !model_cfg["sliding_window"].is_null()
+      ? model_cfg["sliding_window"].get<unsigned int>()
       : UINT_MAX;
-  SLIDING_WINDOW_PATTERN = cfg.contains("sliding_window_pattern")
-                             ? cfg["sliding_window_pattern"].get<unsigned int>()
+  SLIDING_WINDOW_PATTERN = model_cfg.contains("sliding_window_pattern")
+                             ? model_cfg["sliding_window_pattern"].get<unsigned int>()
                              : 1;
-  MAX_POSITION_EMBEDDINGS = cfg["max_position_embeddings"].get<unsigned int>();
-  ROPE_THETA = cfg["rope_theta"].get<unsigned int>();
-  TIE_WORD_EMBEDDINGS = cfg["tie_word_embeddings"].get<bool>();
-  NORM_EPS = cfg["rms_norm_eps"];
+  MAX_POSITION_EMBEDDINGS =
+    model_cfg["max_position_embeddings"].get<unsigned int>();
+  if (model_cfg.contains("rope_theta")) {
+    ROPE_THETA = model_cfg["rope_theta"].get<unsigned int>();
+  } else if (model_cfg.contains("rope_parameters") &&
+             model_cfg["rope_parameters"].contains("rope_theta")) {
+    ROPE_THETA =
+      model_cfg["rope_parameters"]["rope_theta"].get<unsigned int>();
+  }
+  TIE_WORD_EMBEDDINGS = model_cfg["tie_word_embeddings"].get<bool>();
+  NORM_EPS = model_cfg["rms_norm_eps"];
   GQA_SIZE = NUM_HEADS / NUM_KEY_VALUE_HEADS;
 
   return;

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -112,8 +112,8 @@ public:
    * @brief run the Transformer model
    */
   virtual void run(const WSTR prompt, bool do_sample = false,
-                   const WSTR system_prompt = "", const WSTR tail_prompt = "",
-                   bool log_output = true);
+                   const WSTR system_prompt = WSTR{},
+                   const WSTR tail_prompt = WSTR{}, bool log_output = true);
 
   /**
    * @brief Get PerformanceMetrics

--- a/Applications/CausalLM/quantize.cpp
+++ b/Applications/CausalLM/quantize.cpp
@@ -78,6 +78,7 @@
 #include "qwen3_embedding.h"
 #include "qwen3_moe_causallm.h"
 #include "qwen3_slim_moe_causallm.h"
+#include "qwen35_causallm.h"
 
 using json = nlohmann::json;
 using DataType = ml::train::TensorDim::DataType;
@@ -220,6 +221,11 @@ void registerAllModels() {
   factory.registerModel("Qwen3ForCausalLM",
                         [](json cfg, json generation_cfg, json nntr_cfg) {
                           return std::make_unique<causallm::Qwen3CausalLM>(
+                            cfg, generation_cfg, nntr_cfg);
+                        });
+  factory.registerModel("Qwen3_5ForConditionalGeneration",
+                        [](json cfg, json generation_cfg, json nntr_cfg) {
+                          return std::make_unique<causallm::Qwen35CausalLM>(
                             cfg, generation_cfg, nntr_cfg);
                         });
   factory.registerModel("Qwen3MoeForCausalLM",

--- a/Applications/CausalLM/res/qwen35/weight_converter.py
+++ b/Applications/CausalLM/res/qwen35/weight_converter.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Convert Qwen3.5 text weights to nntrainer CausalLM format."""
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+import numpy as np
+from safetensors import safe_open
+
+
+class SafeTensorSet:
+    def __init__(self, files):
+        self.files = files
+        self.tensor_to_file = {}
+        for file_path in files:
+            with safe_open(str(file_path), framework="pt", device="cpu") as reader:
+                for key in reader.keys():
+                    if key in self.tensor_to_file:
+                        raise RuntimeError(f"Duplicate tensor key found: {key}")
+                    self.tensor_to_file[key] = file_path
+
+    def get_tensor(self, name):
+        file_path = self.tensor_to_file.get(name)
+        if file_path is None:
+            raise KeyError(f"Tensor not found in safetensors: {name}")
+        with safe_open(str(file_path), framework="pt", device="cpu") as reader:
+            return reader.get_tensor(name)
+
+
+def tensor_to_numpy(
+    tensor_set,
+    name,
+    dtype,
+    *,
+    transpose=False,
+    add_one=False,
+    squeeze_conv=False,
+    neg_exp=False,
+):
+    tensor = tensor_set.get_tensor(name).float()
+    if squeeze_conv:
+        tensor = tensor.squeeze(1)
+    if transpose:
+        tensor = tensor.t().contiguous()
+    array = tensor.cpu().numpy()
+    if add_one:
+        array = array + 1.0
+    if neg_exp:
+        array = -np.exp(array)
+    return np.asarray(array, dtype=dtype)
+
+
+def write_tensor(file, array):
+    array.tofile(file)
+
+
+def get_text_config(config):
+    return dict(config.get("text_config", config))
+
+
+def save_qwen35_for_nntrainer(model_path, output_file, dtype):
+    model_path = Path(model_path)
+    with open(model_path / "config.json", "r", encoding="utf-8") as fp:
+        config = json.load(fp)
+    text_config = get_text_config(config)
+    num_layers = int(text_config["num_hidden_layers"])
+    layer_types = text_config["layer_types"]
+
+    safetensor_files = sorted(model_path.glob("model*.safetensors"))
+    if not safetensor_files:
+        raise FileNotFoundError(f"No safetensors file found in {model_path}")
+
+    prefix = "model.language_model."
+    tensor_set = SafeTensorSet(safetensor_files)
+
+    with open(output_file, "wb") as fout:
+        write_tensor(fout, tensor_to_numpy(tensor_set, prefix + "embed_tokens.weight", dtype))
+
+        for layer_idx in range(num_layers):
+            layer = f"{prefix}layers.{layer_idx}."
+            write_tensor(
+                fout,
+                tensor_to_numpy(tensor_set, layer + "input_layernorm.weight", dtype, add_one=True),
+            )
+
+            if layer_types[layer_idx] == "linear_attention":
+                linear = layer + "linear_attn."
+                write_tensor(
+                    fout,
+                    tensor_to_numpy(tensor_set, linear + "in_proj_qkv.weight", dtype, transpose=True),
+                )
+                write_tensor(
+                    fout,
+                    tensor_to_numpy(tensor_set, linear + "conv1d.weight", dtype, squeeze_conv=True),
+                )
+                write_tensor(
+                    fout,
+                    tensor_to_numpy(tensor_set, linear + "in_proj_z.weight", dtype, transpose=True),
+                )
+                write_tensor(
+                    fout,
+                    tensor_to_numpy(tensor_set, linear + "in_proj_b.weight", dtype, transpose=True),
+                )
+                write_tensor(
+                    fout,
+                    tensor_to_numpy(tensor_set, linear + "in_proj_a.weight", dtype, transpose=True),
+                )
+                write_tensor(fout, tensor_to_numpy(tensor_set, linear + "dt_bias", dtype))
+                write_tensor(fout, tensor_to_numpy(tensor_set, linear + "A_log", dtype, neg_exp=True))
+                write_tensor(fout, tensor_to_numpy(tensor_set, linear + "norm.weight", dtype))
+                write_tensor(
+                    fout,
+                    tensor_to_numpy(tensor_set, linear + "out_proj.weight", dtype, transpose=True),
+                )
+            elif layer_types[layer_idx] == "full_attention":
+                attn = layer + "self_attn."
+                write_tensor(
+                    fout,
+                    tensor_to_numpy(tensor_set, attn + "q_proj.weight", dtype, transpose=True),
+                )
+                write_tensor(
+                    fout,
+                    tensor_to_numpy(tensor_set, attn + "k_proj.weight", dtype, transpose=True),
+                )
+                write_tensor(
+                    fout,
+                    tensor_to_numpy(tensor_set, attn + "v_proj.weight", dtype, transpose=True),
+                )
+                write_tensor(
+                    fout,
+                    tensor_to_numpy(tensor_set, attn + "q_norm.weight", dtype, add_one=True),
+                )
+                write_tensor(
+                    fout,
+                    tensor_to_numpy(tensor_set, attn + "k_norm.weight", dtype, add_one=True),
+                )
+                write_tensor(
+                    fout,
+                    tensor_to_numpy(tensor_set, attn + "o_proj.weight", dtype, transpose=True),
+                )
+            else:
+                raise RuntimeError(f"Unsupported layer type: {layer_types[layer_idx]}")
+
+            write_tensor(
+                fout,
+                tensor_to_numpy(tensor_set, layer + "post_attention_layernorm.weight", dtype, add_one=True),
+            )
+            write_tensor(
+                fout,
+                tensor_to_numpy(tensor_set, layer + "mlp.up_proj.weight", dtype, transpose=True),
+            )
+            write_tensor(
+                fout,
+                tensor_to_numpy(tensor_set, layer + "mlp.gate_proj.weight", dtype, transpose=True),
+            )
+            write_tensor(
+                fout,
+                tensor_to_numpy(tensor_set, layer + "mlp.down_proj.weight", dtype, transpose=True),
+            )
+
+        write_tensor(fout, tensor_to_numpy(tensor_set, prefix + "norm.weight", dtype, add_one=True))
+
+
+def write_runtime_files(model_path, output_dir, output_name, args):
+    model_path = Path(model_path)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(model_path / "config.json", "r", encoding="utf-8") as fp:
+        original_config = json.load(fp)
+    text_config = get_text_config(original_config)
+    text_config["architectures"] = ["Qwen3_5ForConditionalGeneration"]
+    text_config["model_type"] = "qwen3_5_text"
+    text_config["tie_word_embeddings"] = True
+    text_config.setdefault("bos_token_id", text_config.get("eos_token_id"))
+
+    with open(output_dir / "config.json", "w", encoding="utf-8") as fp:
+        json.dump(text_config, fp, indent=2)
+
+    generation_config = {
+        "bos_token_id": text_config.get("bos_token_id"),
+        "eos_token_id": text_config.get("eos_token_id"),
+        "do_sample": False,
+        "temperature": 1.0,
+        "top_k": 20,
+        "top_p": 0.95,
+    }
+    with open(output_dir / "generation_config.json", "w", encoding="utf-8") as fp:
+        json.dump(generation_config, fp, indent=2)
+
+    tokenizer_src = model_path / "tokenizer.json"
+    tokenizer_dst = output_dir / "tokenizer.json"
+    if tokenizer_src.resolve() != tokenizer_dst.resolve():
+        shutil.copy2(tokenizer_src, tokenizer_dst)
+
+    nntr_config = {
+        "model_type": "CausalLM",
+        "model_tensor_type": "FP32-FP32",
+        "model_file_name": output_name,
+        "fc_layer_dtype": "FP32",
+        "embedding_dtype": "FP32",
+        "lmhead_dtype": "FP32",
+        "lora_rank": 0,
+        "lora_alpha": 0,
+        "lora_target": [],
+        "bad_word_ids": [],
+        "fsu": False,
+        "fsu_lookahead": 2,
+        "num_to_generate": args.num_to_generate,
+        "init_seq_len": args.init_seq_len,
+        "max_seq_len": args.max_seq_len,
+        "batch_size": 1,
+        "tokenizer_file": str(tokenizer_dst),
+        "sample_input": args.sample_input,
+    }
+
+    if args.disable_tokenizer:
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+        nntr_config["sample_input_ids"] = tokenizer.encode(
+            args.sample_input, add_special_tokens=False
+        )
+        nntr_config["disable_tokenizer"] = True
+
+    with open(output_dir / "nntr_config.json", "w", encoding="utf-8") as fp:
+        json.dump(nntr_config, fp, indent=2)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_path", type=str, required=True)
+    parser.add_argument("--output_dir", type=str, default=None)
+    parser.add_argument("--output_name", type=str, default="nntr_qwen35_fp32.bin")
+    parser.add_argument("--data_type", type=str, default="float32")
+    parser.add_argument("--init_seq_len", type=int, default=32)
+    parser.add_argument("--max_seq_len", type=int, default=64)
+    parser.add_argument("--num_to_generate", type=int, default=1)
+    parser.add_argument(
+        "--disable_tokenizer",
+        action="store_true",
+        help="Write sample_input_ids and force the runtime to bypass tokenizer.",
+    )
+    parser.add_argument(
+        "--sample_input",
+        type=str,
+        default="<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    output_dir = Path(args.output_dir) if args.output_dir else Path(args.model_path) / "nntrainer"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_file = output_dir / args.output_name
+
+    dtype = np.dtype(args.data_type)
+    write_runtime_files(args.model_path, output_dir, args.output_name, args)
+    save_qwen35_for_nntrainer(args.model_path, output_file, dtype)
+    print(output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -51,11 +51,13 @@ if host_machine.system() != 'windows'
 endif
 
 if get_option('enable-transformer')
+  if host_machine.system() != 'windows'
   subdir('LLaMA/jni')
+  endif
   if host_machine.system() != 'windows'
   subdir('PicoGPT/jni')
   endif
-  if (get_option('platform') != 'tizen') and (get_option('platform') != 'windows')
+  if get_option('platform') != 'tizen'
     subdir('CausalLM')
   endif
 endif


### PR DESCRIPTION
Implement Qwen3.5 CausalLM support and validate it on Windows.

Using Qwen3.5 0.8B as the reference checkpoint, converted the weights and validated the logits against the Python implementation.

For input text `Samsung is`, the output validation results were:

Python: `Samsung is a global technology company that has been in the business for over 50 years. Samsung is a global technology company that has been in the business for over 50 years. Samsung is a global technology company that has been in the`

nntrainer: `Samsung is a global technology company that has been in the business for over 50 years. Samsung is a global technology company that has been in the business for over 50 years. Samsung is a global technology company that has been in the`

The logits were validated, but Ubuntu execution and code structure review have not been completed yet, so this is being opened as a draft.

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>