### PR TITLE
[OPTIMIZER] Added MeZO optimizer (backpropagation-free optimizer)

### DIFF
--- a/Applications/MeZO/jni/main.cpp
+++ b/Applications/MeZO/jni/main.cpp
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Sachin Singh <sachin.3@samsung.com>
+ *
+ * @file   main.cpp
+ * @date   17 March 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Sachin Singh <sachin.3@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  MeZO optimizer application for MNIST training
+ */
+
+#include <algorithm>
+#include <arpa/inet.h>
+#include <climits>
+#include <cmath>
+#include <dataset.h>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <model.h>
+#include <nntrainer_log.h>
+#include <numeric>
+#include <optimizer.h>
+#include <random>
+#include <util_func.h>
+#include <vector>
+
+using namespace nntrainer;
+
+using LayerHandle = std::shared_ptr<ml::train::Layer>;
+using ModelHandle = std::unique_ptr<ml::train::Model>;
+
+/**
+ * @struct UserData
+ * @brief User data structure for dataset callback
+ */
+struct UserData {
+  std::vector<float> data;
+  std::vector<float> labels;
+  unsigned int num_samples;
+  unsigned int current_index;
+  unsigned int feature_size;
+  unsigned int label_size;
+  std::vector<unsigned int> indices;
+  std::mt19937 rng;
+
+  UserData(const std::vector<float> &d, const std::vector<float> &l,
+           unsigned int fs, unsigned int ls) :
+    data(d),
+    labels(l),
+    num_samples(d.size() / fs),
+    current_index(0),
+    feature_size(fs),
+    label_size(ls),
+    indices(num_samples),
+    rng(0) {
+    std::iota(indices.begin(), indices.end(), 0);
+    std::shuffle(indices.begin(), indices.end(), rng);
+  }
+};
+
+// Dataset callback function
+int getSample(float **outVec, float **outLabel, bool *last, void *user_data) {
+  UserData *ud = static_cast<UserData *>(user_data);
+
+  if (ud->current_index >= ud->num_samples) {
+    // Reset and shuffle indices for next epoch
+    ud->current_index = 0;
+    std::shuffle(ud->indices.begin(), ud->indices.end(), ud->rng);
+  }
+
+  unsigned int idx = ud->indices[ud->current_index];
+
+  // Copy input data
+  std::copy(ud->data.begin() + idx * ud->feature_size,
+            ud->data.begin() + (idx + 1) * ud->feature_size, *outVec);
+
+  // Copy label data
+  std::copy(ud->labels.begin() + idx * ud->label_size,
+            ud->labels.begin() + (idx + 1) * ud->label_size, *outLabel);
+
+  ud->current_index++;
+
+  *last = (ud->current_index >= ud->num_samples);
+
+  return 0;
+}
+
+static uint32_t read_u32_be(std::ifstream &ifs) {
+  uint32_t val = 0;
+  ifs.read(reinterpret_cast<char *>(&val), sizeof(val));
+  return ntohl(val);
+}
+
+// Function to load raw MNIST data
+std::pair<std::vector<float>, std::vector<float>>
+loadMNISTData(const std::string &data_file, const std::string &label_file) {
+
+  std::vector<float> data;
+  std::vector<float> labels;
+  static constexpr float MNIST_MEAN = 0.1307f;
+  static constexpr float MNIST_STD = 0.3081f;
+
+  std::ifstream ifs_images(data_file, std::ios::binary);
+  if (!ifs_images.is_open()) {
+    ml_loge("Failed to open MNIST images file: %s", data_file.c_str());
+    return {data, labels};
+  }
+
+  uint32_t magic_images = read_u32_be(ifs_images);
+  uint32_t num_images = read_u32_be(ifs_images);
+  uint32_t rows = read_u32_be(ifs_images);
+  uint32_t cols = read_u32_be(ifs_images);
+
+  if (magic_images != 2051) {
+    ml_loge("Invalid MNIST images magic: %u", magic_images);
+    return {data, labels};
+  }
+
+  std::ifstream ifs_labels(label_file, std::ios::binary);
+  if (!ifs_labels.is_open()) {
+    ml_loge("Failed to open MNIST labels file: %s", label_file.c_str());
+    return {data, labels};
+  }
+
+  uint32_t magic_labels = read_u32_be(ifs_labels);
+  uint32_t num_labels = read_u32_be(ifs_labels);
+
+  if (magic_labels != 2049) {
+    ml_loge("Invalid MNIST labels magic: %u", magic_labels);
+    return {data, labels};
+  }
+
+  if (num_images != num_labels) {
+    ml_loge("Images/labels count mismatch: %u vs %u", num_images, num_labels);
+    return {data, labels};
+  }
+
+  size_t image_size = static_cast<size_t>(rows) * static_cast<size_t>(cols);
+  data.reserve((size_t)num_images * image_size);
+  labels.reserve((size_t)num_images * 10); // 10 classes for one-hot encoding
+
+  // Read images with normalization
+  for (uint32_t i = 0; i < num_images; ++i) {
+    std::vector<unsigned char> buf(image_size);
+    ifs_images.read(reinterpret_cast<char *>(buf.data()), image_size);
+    if (!ifs_images) {
+      ml_loge("Error reading image %u", i);
+      return {data, labels};
+    }
+    for (size_t p = 0; p < image_size; ++p) {
+      // Normalize: (pixel / 255.0 - mean) / std
+      float pixel = static_cast<float>(buf[p]) / 255.0f;
+      float normalized = (pixel - MNIST_MEAN) / MNIST_STD;
+      data.push_back(normalized);
+    }
+  }
+
+  // Read labels and convert to one-hot encoding
+  for (uint32_t i = 0; i < num_labels; ++i) {
+    unsigned char lab = 0;
+    ifs_labels.read(reinterpret_cast<char *>(&lab), 1);
+    if (!ifs_labels) {
+      ml_loge("Error reading label %u", i);
+      return {data, labels};
+    }
+
+    // Convert to one-hot encoding
+    for (int j = 0; j < 10; ++j) {
+      labels.push_back(j == lab ? 1.0f : 0.0f);
+    }
+  }
+
+  ml_logi("Loaded MNIST: %u samples, image=%ux%u, classes=%u", num_images, rows,
+          cols, 10);
+
+  return {data, labels};
+}
+
+std::vector<LayerHandle> createSimpleGraph() {
+  using ml::train::createLayer;
+
+  std::vector<LayerHandle> layers;
+
+  // Input layer
+  layers.push_back(
+    createLayer("input", {nntrainer::withKey("name", "input0"),
+                          nntrainer::withKey("input_shape", "1:1:784")}));
+
+  // Hidden layer
+  layers.push_back(
+    createLayer("fully_connected",
+                {nntrainer::withKey("unit", 256),
+                 nntrainer::withKey("weight_initializer", "xavier_uniform"),
+                 nntrainer::withKey("activation", "relu")}));
+
+  // Output layer
+  layers.push_back(
+    createLayer("fully_connected",
+                {
+                  nntrainer::withKey("unit", 10),
+                  nntrainer::withKey("weight_initializer", "xavier_uniform"),
+                }));
+
+  return layers;
+}
+
+int main(int argc, char *argv[]) {
+  // Check command line arguments
+  if (argc < 2) {
+    std::cout << "Usage: " << argv[0] << " <data_folder_path>" << std::endl;
+    std::cout << "Example: " << argv[0] << " /path/to/mnist/data/" << std::endl;
+    return 0;
+  }
+
+  try {
+    std::string data_folder = argv[1];
+    // Ensure folder path ends with '/'
+    if (data_folder.back() != '/') {
+      data_folder += '/';
+    }
+
+    std::string train_data_file = data_folder + "train-images-idx3-ubyte";
+    std::string train_label_file = data_folder + "train-labels-idx1-ubyte";
+    std::string val_data_file = data_folder + "t10k-images-idx3-ubyte";
+    std::string val_label_file = data_folder + "t10k-labels-idx1-ubyte";
+
+    std::cout << "Loading MNIST training and validation data..." << std::endl;
+
+    // Load MNIST data
+    auto [train_data, train_labels] =
+      loadMNISTData(train_data_file, train_label_file);
+    auto [val_data, val_labels] = loadMNISTData(val_data_file, val_label_file);
+
+    std::cout << "Data loaded successfully!" << std::endl;
+    std::cout << "Training data size: " << train_data.size() << " ("
+              << train_data.size() / 784 << " samples)" << std::endl;
+    std::cout << "Training labels size: " << train_labels.size() << " ("
+              << train_labels.size() / 10 << " samples)" << std::endl;
+    std::cout << "Validation data size: " << val_data.size() << " ("
+              << val_data.size() / 784 << " samples)" << std::endl;
+    std::cout << "Validation labels size: " << val_labels.size() << " ("
+              << val_labels.size() / 10 << " samples)" << std::endl;
+
+    // Create user data for training and validation
+    const unsigned int feature_size = 784;
+    const unsigned int label_size = 10;
+
+    auto train_user_data = std::make_unique<UserData>(train_data, train_labels,
+                                                      feature_size, label_size);
+    auto val_user_data = std::make_unique<UserData>(val_data, val_labels,
+                                                    feature_size, label_size);
+
+    // Create datasets
+    std::shared_ptr<ml::train::Dataset> dataset_train =
+      ml::train::createDataset(ml::train::DatasetType::GENERATOR, getSample,
+                               train_user_data.get());
+    std::shared_ptr<ml::train::Dataset> dataset_val = ml::train::createDataset(
+      ml::train::DatasetType::GENERATOR, getSample, val_user_data.get());
+
+    // Create model
+    auto model = ml::train::createModel(ml::train::ModelType::NEURAL_NET,
+                                        {nntrainer::withKey("loss", "mse")});
+
+    // Add layers to the model
+    auto layers = createSimpleGraph();
+    for (auto &layer : layers) {
+      model->addLayer(layer);
+    }
+
+    // Set the optimizer
+    auto optimizer = ml::train::createOptimizer(
+      "MeZO", {"MeZO_learning_rate=0.0001", "MeZO_epsilon=0.001"});
+    model->setOptimizer(std::move(optimizer));
+
+    // Set model properties
+    model->setProperty({"epochs=100", "batch_size=32"});
+
+    // Compile and initialize model
+
+    model->compile();
+    model->initialize();
+    model->summarize(std::cout, ML_TRAIN_SUMMARY_MODEL);
+
+    // Set datasets
+    model->setDataset(ml::train::DatasetModeType::MODE_TRAIN, dataset_train);
+    model->setDataset(ml::train::DatasetModeType::MODE_VALID, dataset_val);
+
+    // Train the model
+    model->train();
+
+    std::cout << "Training completed!" << std::endl;
+    std::cout << "Final training loss: " << model->getTrainingLoss()
+              << std::endl;
+    std::cout << "Final validation loss: " << model->getValidationLoss()
+              << std::endl;
+
+  } catch (const std::exception &e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return -1;
+  }
+
+  return 0;
+}

--- a/Applications/MeZO/jni/main.cpp
+++ b/Applications/MeZO/jni/main.cpp
@@ -74,12 +74,14 @@ int getSample(float **outVec, float **outLabel, bool *last, void *user_data) {
   unsigned int idx = ud->indices[ud->current_index];
 
   // Copy input data
-  std::copy(ud->data.begin() + idx * ud->feature_size,
-            ud->data.begin() + (idx + 1) * ud->feature_size, *outVec);
+  std::copy(ud->data.begin() + static_cast<size_t>(idx) * ud->feature_size,
+            ud->data.begin() + static_cast<size_t>(idx + 1) * ud->feature_size,
+            *outVec);
 
   // Copy label data
-  std::copy(ud->labels.begin() + idx * ud->label_size,
-            ud->labels.begin() + (idx + 1) * ud->label_size, *outLabel);
+  std::copy(ud->labels.begin() + static_cast<size_t>(idx) * ud->label_size,
+            ud->labels.begin() + static_cast<size_t>(idx + 1) * ud->label_size,
+            *outLabel);
 
   ud->current_index++;
 

--- a/Applications/MeZO/jni/meson.build
+++ b/Applications/MeZO/jni/meson.build
@@ -1,0 +1,21 @@
+mezo_example_sources = [
+  'main.cpp',
+]
+
+mezo_example_dependencies = [app_utils_dep,
+  iniparser_dep,
+  nntrainer_dep,
+  nntrainer_ccapi_dep
+]
+
+if get_option('enable-test')
+  mezo_example_dependencies += [gtest_dep]
+endif
+
+e = executable('mezo_example',
+  mezo_example_sources,
+  include_directories: [include_directories('.')],
+  dependencies: mezo_example_dependencies,
+  install: get_option('install-app'),
+  install_dir: application_install_dir
+)

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -63,4 +63,6 @@ endif
 subdir('Optimizers/jni')
 
 # MeZO training example
-subdir('MeZO/jni')
+if get_option('platform') != 'tizen' and host_machine.system() != 'windows'
+  subdir('MeZO/jni')
+endif

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -61,3 +61,6 @@ if get_option('enable-transformer')
 endif
 
 subdir('Optimizers/jni')
+
+# MeZO training example
+subdir('MeZO/jni')

--- a/api/ccapi/include/optimizer.h
+++ b/api/ccapi/include/optimizer.h
@@ -37,6 +37,7 @@ enum OptimizerType {
   ADAMW = ML_TRAIN_OPTIMIZER_TYPE_ADAMW,    /** AdamW */
   LION = ML_TRAIN_OPTIMIZER_TYPE_LION,      /** Lion */
   SGD = ML_TRAIN_OPTIMIZER_TYPE_SGD,        /** sgd */
+  MeZO = ML_TRAIN_OPTIMIZER_TYPE_MeZO,      /** MeZO */
   UNKNOWN = ML_TRAIN_OPTIMIZER_TYPE_UNKNOWN /** unknown */
 };
 
@@ -151,6 +152,14 @@ AdamW(const std::vector<std::string> &properties = {}) {
 inline std::unique_ptr<Optimizer>
 Lion(const std::vector<std::string> &properties = {}) {
   return createOptimizer(OptimizerType::LION, properties);
+}
+
+/**
+ * @brief Helper function to create MeZO Optimizer
+ */
+inline std::unique_ptr<Optimizer>
+MeZO(const std::vector<std::string> &properties = {}) {
+  return createOptimizer(OptimizerType::MeZO, properties);
 }
 
 } // namespace optimizer

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -118,7 +118,7 @@ typedef enum {
   ML_TRAIN_OPTIMIZER_TYPE_ADAMW = 2, /**< AdamW Optimizer */
   ML_TRAIN_OPTIMIZER_TYPE_LION = 3,  /**< Lion Optimizer */
   ML_TRAIN_OPTIMIZER_TYPE_SGD = 1, /**< Stochastic Gradient Descent Optimizer */
-  ML_TRAIN_OPTIMIZER_TYPE_MeZO = 4, /**< MeZO optimizer */
+  ML_TRAIN_OPTIMIZER_TYPE_MeZO = 4,     /**< MeZO optimizer */
   ML_TRAIN_OPTIMIZER_TYPE_UNKNOWN = 999 /**< Unknown Optimizer */
 } ml_train_optimizer_type_e;
 

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -118,6 +118,7 @@ typedef enum {
   ML_TRAIN_OPTIMIZER_TYPE_ADAMW = 2, /**< AdamW Optimizer */
   ML_TRAIN_OPTIMIZER_TYPE_LION = 3,  /**< Lion Optimizer */
   ML_TRAIN_OPTIMIZER_TYPE_SGD = 1, /**< Stochastic Gradient Descent Optimizer */
+  ML_TRAIN_OPTIMIZER_TYPE_MeZO = 4,     /**< MeZO optimizer */
   ML_TRAIN_OPTIMIZER_TYPE_UNKNOWN = 999 /**< Unknown Optimizer */
 } ml_train_optimizer_type_e;
 

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -118,7 +118,7 @@ typedef enum {
   ML_TRAIN_OPTIMIZER_TYPE_ADAMW = 2, /**< AdamW Optimizer */
   ML_TRAIN_OPTIMIZER_TYPE_LION = 3,  /**< Lion Optimizer */
   ML_TRAIN_OPTIMIZER_TYPE_SGD = 1, /**< Stochastic Gradient Descent Optimizer */
-  ML_TRAIN_OPTIMIZER_TYPE_MeZO = 4,     /**< MeZO optimizer */
+  ML_TRAIN_OPTIMIZER_TYPE_MeZO = 4, /**< MeZO optimizer */
   ML_TRAIN_OPTIMIZER_TYPE_UNKNOWN = 999 /**< Unknown Optimizer */
 } ml_train_optimizer_type_e;
 

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -31,6 +31,7 @@
 #include <adam.h>
 #include <adamw.h>
 #include <lion.h>
+#include <mezo.h>
 #include <sgd.h>
 
 #include <activation_layer.h>
@@ -276,6 +277,7 @@ void AppContext::add_default_object() {
   registerFactory(nntrainer::createOptimizer<AdamW>, AdamW::type,
                   OptType::ADAMW);
   registerFactory(nntrainer::createOptimizer<Lion>, Lion::type, OptType::LION);
+  registerFactory(nntrainer::createOptimizer<MeZO>, MeZO::type, OptType::MeZO);
   registerFactory(AppContext::unknownFactory<nntrainer::Optimizer>, "unknown",
                   OptType::UNKNOWN);
 

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -1470,7 +1470,11 @@ int NeuralNetwork::train(const std::vector<std::string> &values,
   model_graph.setBatchSize(
     std::get<props::TrainingBatchSize>(model_flex_props));
 
-  status = allocate(ExecutionMode::TRAIN);
+  if (opt->requiresBackprop()) {
+    status = allocate(ExecutionMode::TRAIN);
+  } else {
+    status = allocate(ExecutionMode::INFERENCE);
+  }
   NN_RETURN_STATUS();
 
   status =
@@ -1573,10 +1577,20 @@ int NeuralNetwork::train_run(
 
   auto train_for_iteration =
     [this, stop_cb, stop_user_data](RunStats &stat, DataBuffer &buffer) {
-      ml_logi("train for iteration");
-      forwarding(true, stop_cb, stop_user_data);
-      backwarding(iter++, stop_cb, stop_user_data);
-
+      if (!opt->requiresBackprop()) {
+        ml_logi("train for iteration using gradient-free optimizer");
+        auto param_ptrs = getParameterPointers();
+        opt->trainStep(
+          [this, stop_cb, stop_user_data]() {
+            forwarding(true, stop_cb, stop_user_data);
+          },
+          [this]() { return getLoss(); }, param_ptrs);
+        iter++;
+      } else {
+        ml_logi("train for iteration");
+        forwarding(true, stop_cb, stop_user_data);
+        backwarding(iter++, stop_cb, stop_user_data);
+      }
       // To avoid unconsidered memory leak, we need to clear the cache
       model_graph.flushCache();
 
@@ -2097,4 +2111,20 @@ void NeuralNetwork::exports(const ml::train::ExportMethods &method,
     throw std::runtime_error{"Unsupported export method"};
   }
 }
+
+std::vector<nntrainer::Tensor *> NeuralNetwork::getParameterPointers() {
+  std::vector<nntrainer::Tensor *> params;
+  forEachLayer(
+    [&](ml::train::Layer &layer, RunLayerContext &rc, void *user_data) {
+      LayerNode &ln = static_cast<LayerNode &>(layer);
+      if (ln.getTrainable()) {
+        for (unsigned int i = 0; i < ln.getNumWeights(); ++i) {
+          params.push_back(&ln.getWeight(i));
+        }
+      }
+    },
+    nullptr);
+  return params;
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -785,6 +785,13 @@ private:
    * @retval true if matches, false is error
    */
   bool validateInput(sharedConstTensors X);
+
+  /**
+   * @brief Get pointers to all trainable weight parameters with their sizes
+   * @return std::vector<std::pair<float*, size_t>> Vector of pointers to weight
+   * parameters and their sizes
+   */
+  std::vector<nntrainer::Tensor *> getParameterPointers();
 };
 
 } /* namespace nntrainer */

--- a/nntrainer/optimizers/meson.build
+++ b/nntrainer/optimizers/meson.build
@@ -11,6 +11,7 @@ optimizer_sources = [
   'optimizer_wrapped.cpp',
   'adamw.cpp',
   'lion.cpp',
+  'mezo.cpp',
 ]
 
 optimizer_headers = [
@@ -27,4 +28,3 @@ endforeach
 foreach h : optimizer_headers
   nntrainer_headers += meson.current_source_dir() / h
 endforeach
-

--- a/nntrainer/optimizers/mezo.cpp
+++ b/nntrainer/optimizers/mezo.cpp
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Sachin Singh <sachin.3@samsung.com>
+ *
+ * @file   mezo.cpp
+ * @date   17 March 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Sachin Singh <sachin.3@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the MeZO optimizer.
+ */
+
+#include <mezo.h>
+#include <node_exporter.h>
+#include <random>
+#include <util_func.h>
+
+namespace nntrainer {
+
+MeZO::MeZO() : mezo_props(MeZOEpsilon(), MeZOLearningRate()) {
+
+  auto &[epsilon, learningRate] = mezo_props;
+  epsilon.set(0.01f);
+  learningRate.set(0.0001f);
+}
+
+void MeZO::perturbParameters(std::vector<Tensor *> &params, float epsilon,
+                             int seed) {
+  std::mt19937 gen(seed);
+  std::normal_distribution<float> normal_dist(0.0f, 1.0f);
+
+  for (auto *ptr : params) {
+    Tensor noise_tensor(ptr->getDim());
+    noise_tensor.allocate();
+
+    float *noise_data = (float *)(noise_tensor.getData());
+    size_t param_size = ptr->getDim().getDataLen();
+    for (size_t i = 0; i < param_size; ++i) {
+      noise_data[i] = normal_dist(gen);
+    }
+    // θi ← θi + ϵz
+    ptr->add_i(noise_tensor, epsilon);
+  }
+}
+
+void MeZO::trainStep(std::function<void()> forward_fn,
+                     std::function<float()> get_loss_fn,
+                     std::vector<Tensor *> &params) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> distrib(0, 1000000000 - 1);
+  int seed = distrib(gen);
+
+  float mezo_epsilon = getEpsilon();
+  float lr = getLearningRate();
+
+  // Perturb parameters with +epsilon
+  perturbParameters(params, mezo_epsilon, seed);
+
+  // Forward pass with positive perturbation
+  forward_fn();
+  float loss_plus = get_loss_fn();
+
+  // Perturb parameters with -2*epsilon (to get from +epsilon to -epsilon)
+  perturbParameters(params, -2 * mezo_epsilon, seed);
+
+  // Forward pass with negative perturbation
+  forward_fn();
+  float loss_minus = get_loss_fn();
+
+  // Restoring weight to original state
+  perturbParameters(params, mezo_epsilon, seed);
+
+  float projected_grad = (loss_plus - loss_minus) / (2.0f * mezo_epsilon);
+
+  updateWeightsMeZO(params, seed, projected_grad);
+}
+
+void MeZO::setProperty(const std::vector<std::string> &values) {
+
+  auto remain_props = loadProperties(values, mezo_props);
+
+  if (!remain_props.empty()) {
+    std::string msg = "[MeZO Optimizer] Unknown Properties count " +
+                      std::to_string(remain_props.size());
+    throw exception::not_supported(msg);
+  }
+}
+
+void MeZO::updateWeightsMeZO(std::vector<nntrainer::Tensor *> &weights,
+                             int seed, float projected_grad) {
+  std::mt19937 gen(seed);
+  std::normal_distribution<float> normal_dist(0.0f, 1.0f);
+
+  float mezo_epsilon = getEpsilon();
+  float lr = getLearningRate();
+
+  for (auto *ptr : weights) {
+    Tensor noise_tensor(ptr->getDim());
+    noise_tensor.allocate();
+
+    float *noise_data = (float *)(noise_tensor.getData());
+    size_t param_size = ptr->getDim().getDataLen();
+    for (size_t i = 0; i < param_size; ++i) {
+      noise_data[i] = normal_dist(gen);
+    }
+    // θi ← θi −ηt ∗ projected_grad ∗ z
+    ptr->add_i(noise_tensor, -lr * projected_grad);
+  }
+}
+
+} // namespace nntrainer

--- a/nntrainer/optimizers/mezo.h
+++ b/nntrainer/optimizers/mezo.h
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Sachin Singh <sachin.3@samsung.com>
+ *
+ * @file   mezo.h
+ * @date   17 March 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Sachin Singh <sachin.3@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  This is the MeZO optimizer.
+ */
+#ifndef __MeZO_H__
+#define __MeZO_H__
+#ifdef __cplusplus
+
+#include <common_properties.h>
+#include <optimizer_devel.h>
+
+namespace nntrainer {
+
+/**
+ * @class MeZOEpsilon
+ * @brief Property class for MeZO epsilon (perturbation magnitude)
+ */
+class MeZOEpsilon : public Property<float> {
+public:
+  static constexpr const char *key =
+    "MeZO_epsilon";                /**< unique key to access */
+  using prop_tag = float_prop_tag; /**< property type */
+};
+
+/**
+ * @class MeZOLearningRate
+ * @brief Property class for MeZO learning rate
+ */
+class MeZOLearningRate : public Property<float> {
+public:
+  static constexpr const char *key =
+    "MeZO_learning_rate";          /**< unique key to access */
+  using prop_tag = float_prop_tag; /**< property type */
+};
+
+/**
+ * @class   MeZO optimizer class
+ * @brief   MeZO (Zero'th order) optimizer class
+ */
+class MeZO : public Optimizer {
+public:
+  /**
+   * @brief Construct a new MeZO object
+   *
+   */
+  MeZO();
+
+  /**
+   * @copydoc Optimizer::getDefaultLearningRate()
+   *
+   */
+  double getDefaultLearningRate() const override { return 0.0002; }
+
+  /**
+   * @copydoc applyGradient(RunOptimizerContext &context)
+   */
+  void applyGradient(RunOptimizerContext &context) override { return; }
+
+  /**
+   * @brief     Check if this optimizer requires backpropagation
+   * @retval    true if backprop is required, false otherwise
+   */
+  bool requiresBackprop() const override { return false; }
+
+  /**
+   * @brief     Custom training step for MeZO optimizer
+   * @param[in] forward_fn Function to perform forward pass
+   * @param[in] get_loss_fn Function to get current loss
+   * @param[in] params Vector of parameter tensors to update
+   */
+  void trainStep(std::function<void()> forward_fn,
+                 std::function<float()> get_loss_fn,
+                 std::vector<Tensor *> &params) override;
+
+  /**
+   * @copydoc Optimizer::getType()
+   */
+  const std::string getType() const override { return MeZO::type; }
+
+  /**
+   * @copydoc Optimizer::getOptimizerVariableDim(const TensorDim &dim)
+   */
+  std::vector<TensorDim>
+  getOptimizerVariableDim(const TensorDim &dim) override {
+    return {};
+  }
+
+  /**
+   * @brief Set Optimizer Parameters
+   * @param[in] values Optimizer Parameter list
+   */
+  void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @brief Get the epsilon value for perturbation
+   * @return Perturbation magnitude
+   */
+  float getEpsilon() const { return std::get<MeZOEpsilon>(mezo_props).get(); }
+
+  /**
+   * @brief Get the learning rate
+   * @return Learning rate value
+   */
+  float getLearningRate() const {
+    return std::get<MeZOLearningRate>(mezo_props).get();
+  }
+
+  /**
+   * @brief Update multiple weights using MeZO gradient estimation
+   * @param weights Vector of weights to update
+   * @param seed Random seed for reproducibility
+   * @param projected_grad Estimated gradient computed as (loss_plus -
+   * loss_minus) / (2 * epsilon)
+   */
+  void updateWeightsMeZO(std::vector<nntrainer::Tensor *> &weights, int seed,
+                         float projected_grad);
+
+  /**
+   * @brief Perturb parameters using normal distribution
+   * @param params Vector of parameter tensors to perturb
+   * @param epsilon Perturbation magnitude. It is multipled with the direction
+   * of perturbation (+1, -1, or -2 etc)
+   * @param seed Random seed for reproducibility
+   */
+  void perturbParameters(std::vector<nntrainer::Tensor *> &params,
+                         float epsilon, int seed);
+
+  static constexpr const char *type = "MeZO";
+
+private:
+  std::tuple<MeZOEpsilon, MeZOLearningRate>
+    mezo_props; /**< MeZO epsilon and Learning rate */
+};
+} /* namespace nntrainer */
+
+#endif /* __cplusplus */
+#endif /* __MeZO_H__ */

--- a/nntrainer/optimizers/optimizer_devel.h
+++ b/nntrainer/optimizers/optimizer_devel.h
@@ -49,11 +49,11 @@ public:
    * @param[in] forward_fn Function to perform forward pass
    * @param[in] get_loss_fn Function to get current loss
    * @param[in] params Vector of parameter tensors to update
+   * @note      Default is no-op; gradient-free optimizers override this.
    */
-  virtual void trainStep(
-    std::function<void()> forward_fn, std::function<float()> get_loss_fn,
-    std::vector<Tensor *>
-      &params) { /**< default: no-op, backprop optimizers use existing path */ }
+  virtual void trainStep(std::function<void()> forward_fn,
+                         std::function<float()> get_loss_fn,
+                         std::vector<Tensor *> &params) {};
 
   /**
    * @brief     get Learning Rate

--- a/nntrainer/optimizers/optimizer_devel.h
+++ b/nntrainer/optimizers/optimizer_devel.h
@@ -53,7 +53,7 @@ public:
    */
   virtual void trainStep(std::function<void()> forward_fn,
                          std::function<float()> get_loss_fn,
-                         std::vector<Tensor *> &params) {};
+                         std::vector<Tensor *> &params){};
 
   /**
    * @brief     get Learning Rate
@@ -86,7 +86,7 @@ public:
   /**
    * @brief     finalize optimizer.
    */
-  virtual void finalize() {};
+  virtual void finalize(){};
 
   /**
    * @brief     Read Training optimizer parameters from file

--- a/nntrainer/optimizers/optimizer_devel.h
+++ b/nntrainer/optimizers/optimizer_devel.h
@@ -39,6 +39,23 @@ public:
   virtual ~Optimizer() = default;
 
   /**
+   * @brief     Check if this optimizer requires backpropagation
+   * @retval    true if backprop is required, false otherwise
+   */
+  virtual bool requiresBackprop() const { return true; }
+
+  /**
+   * @brief     Custom training step for gradient-free optimizers
+   * @param[in] forward_fn Function to perform forward pass
+   * @param[in] get_loss_fn Function to get current loss
+   * @param[in] params Vector of parameter tensors to update
+   */
+  virtual void trainStep(
+    std::function<void()> forward_fn, std::function<float()> get_loss_fn,
+    std::vector<Tensor *>
+      &params) { /**< default: no-op, backprop optimizers use existing path */ }
+
+  /**
    * @brief     get Learning Rate
    * @retval    Learning rate in float
    */
@@ -69,7 +86,7 @@ public:
   /**
    * @brief     finalize optimizer.
    */
-  virtual void finalize(){};
+  virtual void finalize() {};
 
   /**
    * @brief     Read Training optimizer parameters from file

--- a/nntrainer/optimizers/optimizer_wrapped.h
+++ b/nntrainer/optimizers/optimizer_wrapped.h
@@ -52,6 +52,24 @@ public:
    */
 
   /**
+   * @brief     Check if this optimizer requires backpropagation
+   * @retval    true if backprop is required, false otherwise
+   */
+  bool requiresBackprop() const { return optimizer->requiresBackprop(); }
+
+  /**
+   * @brief     Custom training step for gradient-free optimizers
+   * @param[in] forward_fn Function to perform forward pass
+   * @param[in] get_loss_fn Function to get current loss
+   * @param[in] params Vector of parameter tensors to update
+   */
+  void trainStep(std::function<void()> forward_fn,
+                 std::function<float()> get_loss_fn,
+                 std::vector<Tensor *> &params) {
+    optimizer->trainStep(forward_fn, get_loss_fn, params);
+  }
+
+  /**
    * @brief     get Optimizer Type
    * @retval    Optimizer type
    */

--- a/test/ccapi/unittest_ccapi.cpp
+++ b/test/ccapi/unittest_ccapi.cpp
@@ -158,6 +158,7 @@ TEST(ccapi_optimizer, construct_02_p) {
   EXPECT_NO_THROW(ml::train::optimizer::SGD());
   EXPECT_NO_THROW(ml::train::optimizer::AdamW());
   EXPECT_NO_THROW(ml::train::optimizer::Lion());
+  EXPECT_NO_THROW(ml::train::optimizer::MeZO());
 }
 
 /**

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -77,6 +77,7 @@ test_target = [
   ['unittest_nntrainer_lr_scheduler', []],
   ['unittest_nntrainer_save_with_dtype', []],
   ['unittest_thread_manager', []],
+  ['unittest_nntrainer_mezo_interface', []]
   #['unittest_nntrainer_task', []],
 ]
 

--- a/test/unittest/unittest_nntrainer_mezo_interface.cpp
+++ b/test/unittest/unittest_nntrainer_mezo_interface.cpp
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @file        unittest_nntrainer_mezo_interface.cpp
+ * @date        05 May 2026
+ * @brief       Unit test for MeZO optimizer interface changes.
+ * @see         https://github.com/nntrainer/nntrainer
+ * @author      Sachin Singh <sachin.3@samsung.com>
+ * @bug         No known bugs
+ */
+#include <gtest/gtest.h>
+
+#include <mezo.h>
+#include <neuralnet.h>
+#include <optimizer_devel.h>
+#include <optimizer_wrapped.h>
+#include <sgd.h>
+
+using namespace nntrainer;
+
+/**
+ * @brief Test that MeZO optimizer correctly reports it doesn't require backprop
+ */
+TEST(nntrainer_mezo_interface, requiresBackprop_01_p) {
+  MeZO mezo;
+  EXPECT_FALSE(mezo.requiresBackprop());
+}
+
+/**
+ * @brief Test that SGD optimizer correctly reports it requires backprop
+ */
+TEST(nntrainer_mezo_interface, requiresBackprop_02_p) {
+  SGD sgd;
+  EXPECT_TRUE(sgd.requiresBackprop());
+}
+
+/**
+ * @brief Test that OptimizerWrapped correctly delegates requiresBackprop for
+ * MeZO
+ */
+TEST(nntrainer_mezo_interface, requiresBackprop_wrapped_01_p) {
+  auto mezo_ptr = std::make_unique<MeZO>();
+  auto wrapped = createOptimizerWrapped(std::move(mezo_ptr));
+  EXPECT_FALSE(wrapped->requiresBackprop());
+}
+
+/**
+ * @brief Test that OptimizerWrapped correctly delegates requiresBackprop for
+ * SGD
+ */
+TEST(nntrainer_mezo_interface, requiresBackprop_wrapped_02_p) {
+  auto sgd_ptr = std::make_unique<SGD>();
+  auto wrapped = createOptimizerWrapped(std::move(sgd_ptr));
+  EXPECT_TRUE(wrapped->requiresBackprop());
+}
+
+/**
+ * @brief Mock function to test trainStep interface
+ */
+static bool forward_called = false;
+static bool get_loss_called = false;
+
+void mock_forward_fn() { forward_called = true; }
+
+float mock_get_loss_fn() {
+  get_loss_called = true;
+  return 0.5f;
+}
+
+/**
+ * @brief Test that MeZO optimizer trainStep method can be called
+ */
+TEST(nntrainer_mezo_interface, trainStep_01_p) {
+  MeZO mezo;
+  std::vector<Tensor *> params; // Empty params for this test
+
+  // This should not crash and should call the functions
+  forward_called = false;
+  get_loss_called = false;
+
+  mezo.trainStep(mock_forward_fn, mock_get_loss_fn, params);
+
+  // Note: The actual MeZO implementation will try to perturb parameters,
+  // but with empty params vector, it should complete without crashing
+  SUCCEED();
+}
+
+/**
+ * @brief Test that base Optimizer trainStep method is a no-op
+ */
+TEST(nntrainer_mezo_interface, trainStep_base_01_p) {
+  // Create a mock optimizer that inherits from base Optimizer
+  class MockOptimizer : public Optimizer {
+  public:
+    double getDefaultLearningRate() const override { return 0.01; }
+    void applyGradient(RunOptimizerContext &context) override {}
+    std::vector<TensorDim>
+    getOptimizerVariableDim(const TensorDim &dim) override {
+      return {};
+    }
+    const std::string getType() const override { return "Mock"; }
+    void setProperty(const std::vector<std::string> &values) override {}
+  };
+
+  MockOptimizer mock_opt;
+  std::vector<Tensor *> params;
+
+  // This should be a no-op and not crash
+  mock_opt.trainStep(mock_forward_fn, mock_get_loss_fn, params);
+  SUCCEED();
+}
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during InitGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}


### PR DESCRIPTION
MeZO is an Zeroth order optimizer based on the paper: [Fine-Tuning Language Models with Just Forward Passes](https://arxiv.org/abs/2305.17333)

Note: This PR has all the changes suggested in #3813 

This PR introduces MeZO (Memory-efficient Zeroth-Order) optimizer support to NNTrainer.  
It is the first backpropagation-free optimizer integrated into NNTrainer, enabling training without explicit gradient computation.

The implementation has been validated by training a fully connected (FC) network on the MNIST dataset within the NNTrainer framework.

### Motivation
Traditional optimizers in NNTrainer rely on backpropagation, which:
- Requires gradient storage
- Increases memory usage
- Can be inefficient for certain model classes or hardware constraints

MeZO provides an alternative by:
- Estimating gradients using zeroth-order optimization
- Eliminating the need for backpropagation
- Reducing memory footprint

This makes it particularly useful for:
- Memory-constrained environments
- On-device training scenarios
- Exploring gradient-free optimization techniques

### Accuracy Benchmarking
Dataset: MNIST (training sample: 60k, Validation sample: 10k)
Model: 3 fc layer with ReLU activation
Paramaters:  epochs=100 , MeZO_learning_rate=0.0001, MeZO_epsilon=0.001, batch_Size=32

Result:

Starting Training Loss: 0.687744
Starting Validation Loss: 0.506119
Accuracy: 18.0889%

Final training loss: 0.0897253
Final validation loss: 0.086979
Accuracy: 70.5729% 

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Sachin Singh <sachin.3@samsung.com>
