### PR TITLE
[CausalLM] Update weight_converter.py and transformers.cpp for latest qwen3 version

### DIFF
--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -129,7 +129,12 @@ void Transformer::setupParameters(json &cfg, json &generation_cfg,
                              ? cfg["sliding_window_pattern"].get<unsigned int>()
                              : 1;
   MAX_POSITION_EMBEDDINGS = cfg["max_position_embeddings"].get<unsigned int>();
-  ROPE_THETA = cfg["rope_theta"].get<unsigned int>();
+  if (cfg.contains("rope_theta")) {
+    ROPE_THETA = cfg["rope_theta"].get<unsigned int>();
+  } else if (cfg.contains("rope_parameters") &&
+             cfg["rope_parameters"].contains("rope_theta")) {
+    ROPE_THETA = cfg["rope_parameters"]["rope_theta"].get<unsigned int>();
+  }
   TIE_WORD_EMBEDDINGS = cfg["tie_word_embeddings"].get<bool>();
   NORM_EPS = cfg["rms_norm_eps"];
   GQA_SIZE = NUM_HEADS / NUM_KEY_VALUE_HEADS;

--- a/Applications/CausalLM/res/qwen3/qwen3-4b/weight_converter.py
+++ b/Applications/CausalLM/res/qwen3/qwen3-4b/weight_converter.py
@@ -3,16 +3,18 @@
 ## @author Eunju Yang <ej.yang@samsung.com>
 
 import argparse
-import torch
+
 import numpy as np
-from transformers import AutoConfig, AutoTokenizer, AutoModelForCausalLM
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
 
 total_size = 0
-def save_qwen3_for_nntrainer(params, n_layers, dtype, file):  
+def save_qwen3_for_nntrainer(params, config, dtype, file):  
     """Convert and save weights as nntrainer format for multi-head attention model"""  
+    n_layers = config.num_hidden_layers
       
     def save_weight(weight):
-        np.array(weight, dtype=dtype).tofile(file)  
+        np.array(weight.detach().cpu(), dtype=dtype).tofile(file)  
 
     def save_projection(layer_name, proj_name):  
         """Helper function to handle base/lora weight saving"""  
@@ -42,7 +44,7 @@ def save_qwen3_for_nntrainer(params, n_layers, dtype, file):
         save_weight(params[f"{layer_name}post_attention_layernorm.weight"])  
           
         # Save MLP projections using helper  
-        for proj in ["up_proj", "gate_proj", "down_proj"]:  
+        for proj in ["gate_proj", "up_proj", "down_proj"]:
             save_projection(layer_name, f"mlp.{proj}")  
 
     # Save embedding layer  
@@ -56,7 +58,9 @@ def save_qwen3_for_nntrainer(params, n_layers, dtype, file):
 
     # Save final layers  
     save_weight(params["model.norm.weight"])  
-    save_weight(params["lm_head.weight"].permute(1, 0))  
+
+    if not getattr(config, "tie_word_embeddings", False):
+        save_weight(params["lm_head.weight"].permute(1, 0))
 
 
 if __name__ == "__main__":
@@ -71,10 +75,10 @@ if __name__ == "__main__":
     output_name = args.output_name
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
     config = AutoConfig.from_pretrained(model_path)
-    model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype="float", trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path, torch_dtype=torch.float32, trust_remote_code=True)
     model.eval()
 
     with open(output_name, "wb") as f_model :
-        save_qwen3_for_nntrainer(model.state_dict(), config.num_hidden_layers, data_dtype, f_model)
+        save_qwen3_for_nntrainer(model.state_dict(), config, data_dtype, f_model)


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] Update weight_converter.py for Qwen3</summary><br />

- Update weight_converter.py for Qwen3 
- Change the save order of ffn layers

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>


<details><summary>[CausalLM] chore: update transformer.cpp for latest config</summary><br />

- Latest config.json in Qwen3 has rope_parameters, not rope_theta
- Add rope_parameters for reading rope theta

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>

### Summary

This PR is for support to latest qwen3 model version.

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>
