### PR TITLE
Support safetensors

### DIFF
--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -31,6 +31,17 @@ namespace causallm {
 /**
  * @brief Load a file as a binary string.
  */
+ml::train::ModelFormat
+Transformer::formatFromExtension(const std::string &weight_path) {
+  const auto dot = weight_path.find_last_of('.');
+  if (dot != std::string::npos) {
+    const std::string ext = weight_path.substr(dot + 1);
+    if (ext == "safetensors")
+      return ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS;
+  }
+  return ml::train::ModelFormat::MODEL_FORMAT_BIN;
+}
+
 std::string LoadBytesFromFile(const std::string &path) {
   std::ifstream file(path, std::ios::binary | std::ios::ate);
   if (!file.is_open()) {
@@ -252,7 +263,7 @@ void Transformer::load_weight(const std::string &weight_path) {
   }
 
   try {
-    model->load(weight_path, ml::train::ModelFormat::MODEL_FORMAT_BIN);
+    model->load(weight_path, formatFromExtension(weight_path));
   } catch (const std::exception &e) {
     throw std::runtime_error("Failed to load model weights: " +
                              std::string(e.what()));
@@ -271,7 +282,7 @@ void Transformer::save_weight(const std::string &weight_path) {
   }
 
   try {
-    model->save(weight_path, ml::train::ModelFormat::MODEL_FORMAT_BIN);
+    model->save(weight_path, formatFromExtension(weight_path));
   } catch (const std::exception &e) {
     throw std::runtime_error("Failed to save model weights: " +
                              std::string(e.what()));

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -190,6 +190,11 @@ protected:
    */
   virtual void registerCustomLayers();
 
+  /*
+   * @brief support formatFromExtension (bin/safetensors)
+   */
+  virtual ml::train::ModelFormat formatFromExtension(const std::string &weight_path);
+
   /**
    * @brief register Outputs
    */

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -190,8 +190,10 @@ protected:
    */
   virtual void registerCustomLayers();
 
-  /*
-   * @brief support formatFromExtension (bin/safetensors)
+  /**
+   * @brief Get model format from weight file extension.
+   * @param weight_path Path to the weight file.
+   * @return Model format for the given file extension.
    */
   virtual ml::train::ModelFormat
   formatFromExtension(const std::string &weight_path);

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -193,7 +193,8 @@ protected:
   /*
    * @brief support formatFromExtension (bin/safetensors)
    */
-  virtual ml::train::ModelFormat formatFromExtension(const std::string &weight_path);
+  virtual ml::train::ModelFormat
+  formatFromExtension(const std::string &weight_path);
 
   /**
    * @brief register Outputs

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -97,7 +97,10 @@ for inference and training without any configurations*/
     ML_TRAIN_MODEL_FORMAT_FLATBUFFER,             /**< flatbuffer file */
   MODEL_FORMAT_ONNX = ML_TRAIN_MODEL_FORMAT_ONNX, /**< ONNX file */
 
-  MODEL_FORMAT_QNN = ML_TRAIN_MODEL_FORMAT_QNN /**< qnn binary file */
+  MODEL_FORMAT_QNN = ML_TRAIN_MODEL_FORMAT_QNN, /**< qnn binary file */
+  
+  MODEL_FORMAT_SAFETENSORS =
+    ML_TRAIN_MODEL_FORMAT_SAFETENSORS, /**< safetensors file */
 };
 
 /**

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -98,7 +98,7 @@ for inference and training without any configurations*/
   MODEL_FORMAT_ONNX = ML_TRAIN_MODEL_FORMAT_ONNX, /**< ONNX file */
 
   MODEL_FORMAT_QNN = ML_TRAIN_MODEL_FORMAT_QNN, /**< qnn binary file */
-  
+
   MODEL_FORMAT_SAFETENSORS =
     ML_TRAIN_MODEL_FORMAT_SAFETENSORS, /**< safetensors file */
 };

--- a/api/nntrainer-api-common.h
+++ b/api/nntrainer-api-common.h
@@ -288,7 +288,9 @@ typedef enum {
   ML_TRAIN_MODEL_FORMAT_ONNX =
     4, /**< QNNX binary format file saves model configurations and weights. */
   ML_TRAIN_MODEL_FORMAT_QNN =
-    5 /**< QNN binary format file saves model configurations and weights. */
+    5, /**< QNN binary format file saves model configurations and weights. */
+  ML_TRAIN_MODEL_FORMAT_SAFETENSORS =
+    6 /**< Safetensors format file saves model weights. */
 } ml_train_model_format_e;
 
 /**

--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -65,6 +65,7 @@
 /usr/include/nntrainer/singleton.h
 /usr/include/nntrainer/thread_manager.h
 /usr/include/nntrainer/thread_manager_util.h
+/usr/include/nntrainer/safetensors_util.h
 /usr/include/nntrainer/fp16.h
 /usr/include/nntrainer/util_simd.h
 /usr/include/nntrainer/dynamic_library_loader.h

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -54,6 +54,7 @@
 #include <remap_realizer.h>
 #include <slice_realizer.h>
 #include <util_func.h>
+#include <safetensors_util.h>
 
 #ifdef ENABLE_TFLITE_INTERPRETER
 #include <tflite_interpreter.h>
@@ -683,6 +684,55 @@ void NeuralNetwork::save(
       "saving with ONNX format is not supported yet.");
     break;
   }
+   case ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS: {
+    // Build the tensor entry list (graph order, deduped by pointer)
+    std::vector<safetensors::TensorEntry> entries;
+    std::unordered_set<const Tensor *> visited_st;
+    size_t data_offset = 0;
+    for (auto iter = model_graph.cbegin(); iter != model_graph.cend(); iter++) {
+      auto weights = (*iter)->getRunContext().getWeights();
+      for (auto weight : weights) {
+        if (!visited_st.insert(&weight->getVariableRef()).second)
+          continue;
+        const auto &t = weight->getVariableRef();
+        const auto &dim = t.getDim();
+        const size_t nbytes = t.getMemoryBytes();
+        safetensors::TensorEntry entry;
+        entry.name = t.getName();
+        entry.dtype = safetensors::dtypeToString(dim.getDataType());
+        entry.shape = {dim.batch(), dim.channel(), dim.height(), dim.width()};
+        entry.offset_start = data_offset;
+        entry.offset_end = data_offset + nbytes;
+        entries.push_back(std::move(entry));
+        data_offset += nbytes;
+      }
+    }
+
+    // Write: [8-byte header_size][header (padded to 8)][raw weight data]
+    const std::string header_json = safetensors::buildHeader(entries);
+    const uint64_t header_size = static_cast<uint64_t>(header_json.size());
+
+    auto st_file = checkedOpenStream<std::ofstream>(
+      file_path, std::ios::out | std::ios::binary | std::ios::trunc);
+    st_file.write(reinterpret_cast<const char *>(&header_size),
+                  sizeof(header_size));
+    st_file.write(header_json.data(), static_cast<std::streamsize>(header_json.size()));
+
+    visited_st.clear();
+    for (auto iter = model_graph.cbegin(); iter != model_graph.cend(); iter++) {
+      auto weights = (*iter)->getRunContext().getWeights();
+      for (auto weight : weights) {
+        if (!visited_st.insert(&weight->getVariableRef()).second)
+          continue;
+        const auto &t = weight->getVariableRef();
+        const size_t nbytes = t.getMemoryBytes();
+        st_file.write(reinterpret_cast<const char *>(t.getData<char>()),
+                      static_cast<std::streamsize>(nbytes));
+      }
+    }
+    st_file.close();
+    break;
+  }
   default:
     throw nntrainer::exception::not_supported(
       "saving with given format is not supported yet");
@@ -945,6 +995,111 @@ void NeuralNetwork::load(const std::string &file_path,
     }
 
     qnn_load.join();
+    break;
+  }
+  case ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS: {
+    NNTR_THROW_IF(!initialized, std::runtime_error)
+      << "Cannot load safetensors if not initialized yet, path: " << file_path;
+
+    const auto f_path = (v.size() == 2) ? v[1] : v[0];
+
+    // Read header_size (8 bytes) + header JSON
+    std::ifstream st_file(f_path, std::ios::in | std::ios::binary);
+    NNTR_THROW_IF(!st_file.is_open(), std::runtime_error)
+      << "Cannot open safetensors file: " << f_path;
+
+    uint64_t header_size = 0;
+    st_file.read(reinterpret_cast<char *>(&header_size), sizeof(header_size));
+    NNTR_THROW_IF(!st_file, std::runtime_error)
+      << "Failed to read safetensors header length from: " << f_path;
+
+    std::string header_json(header_size, '\0');
+    st_file.read(header_json.data(), static_cast<std::streamsize>(header_size));
+    NNTR_THROW_IF(!st_file, std::runtime_error)
+      << "Failed to read safetensors header from: " << f_path;
+    st_file.close();
+
+    // data_base: byte offset in file where the data section starts
+    const size_t data_base = sizeof(uint64_t) + static_cast<size_t>(header_size);
+
+    // Parse header: name -> (offset_start, size_in_bytes)
+    auto name_offset_map = safetensors::parseHeader(header_json);
+
+    // Assign file offsets to each weight by name
+    std::unordered_set<const Tensor *> visited_st;
+    for (auto iter = model_graph.cbegin(); iter != model_graph.cend(); iter++) {
+      auto weights = (*iter)->getRunContext().getWeights();
+      for (auto weight : weights) {
+        if (!visited_st.insert(&weight->getVariableRef()).second)
+          continue;
+        const std::string &name = weight->getName();
+        auto it = name_offset_map.find(name);
+        if (it == name_offset_map.end())
+          continue;
+        const size_t file_off = data_base + it->second.first;
+        weight->getVariableRef().setFileOffset(file_off);
+      }
+    }
+
+    if (exec_mode == ml::train::ExecutionMode::INFERENCE) {
+      model_file_fd = ::open(f_path.c_str(), O_RDONLY);
+      NNTR_THROW_IF((model_file_fd == -1), std::invalid_argument)
+        << "Cannot open safetensors file: " << f_path;
+
+      std::vector<std::thread> threads;
+      threads.reserve(model_graph.size());
+      for (auto iter = model_graph.cbegin(); iter != model_graph.cend();
+           ++iter) {
+        auto node = *iter;
+        threads.emplace_back([&, node]() {
+          if (!MMAP_READ) {
+            auto local_file =
+              checkedOpenStream<std::ifstream>(f_path, std::ios::in | std::ios::binary);
+            node->read(local_file, false, exec_mode, fsu_mode,
+                       std::numeric_limits<size_t>::max(), true, model_file_fd);
+          } else {
+            int fd = ::open(f_path.c_str(), O_RDONLY);
+            NNTR_THROW_IF((fd == -1), std::invalid_argument)
+              << "Cannot open safetensors file: " << f_path;
+
+            struct stat st {};
+            NNTR_THROW_IF((::fstat(fd, &st) == -1), std::invalid_argument)
+              << "Cannot stat safetensors file: " << f_path;
+
+            const size_t f_size = static_cast<size_t>(st.st_size);
+            void *mmap_ptr =
+              ::mmap(nullptr, f_size, PROT_READ, MAP_PRIVATE, fd, 0);
+            ::close(fd);
+            NNTR_THROW_IF((mmap_ptr == MAP_FAILED), std::runtime_error)
+              << "mmap failed for safetensors file: " << f_path;
+
+            (void)::posix_madvise(mmap_ptr, f_size, POSIX_MADV_RANDOM);
+
+            char *view = static_cast<char *>(mmap_ptr);
+            node->read(view, false, exec_mode, fsu_mode,
+                       std::numeric_limits<size_t>::max(), true, model_file_fd);
+
+            (void)::posix_madvise(mmap_ptr, f_size, POSIX_MADV_DONTNEED);
+            ::munmap(mmap_ptr, f_size);
+          }
+        });
+      }
+      for (auto &t : threads) {
+        if (t.joinable())
+          t.join();
+      }
+    } else {
+      // TRAINING mode: sequential read
+      std::ifstream st_in(f_path, std::ios::in | std::ios::binary);
+      NNTR_THROW_IF(!st_in.is_open(), std::runtime_error)
+        << "Cannot open safetensors file for training load: " << f_path;
+      for (auto iter = model_graph.cbegin(); iter != model_graph.cend();
+           ++iter) {
+        (*iter)->read(st_in, false, exec_mode, fsu_mode);
+      }
+    }
+
+    ml_logi("read safetensors model file: %s", f_path.c_str());
     break;
   }
   default:

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -52,9 +52,9 @@
 #include <profiler.h>
 #include <recurrent_realizer.h>
 #include <remap_realizer.h>
+#include <safetensors_util.h>
 #include <slice_realizer.h>
 #include <util_func.h>
-#include <safetensors_util.h>
 
 #ifdef ENABLE_TFLITE_INTERPRETER
 #include <tflite_interpreter.h>
@@ -684,7 +684,7 @@ void NeuralNetwork::save(
       "saving with ONNX format is not supported yet.");
     break;
   }
-   case ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS: {
+  case ml::train::ModelFormat::MODEL_FORMAT_SAFETENSORS: {
     // Build the tensor entry list (graph order, deduped by pointer)
     std::vector<safetensors::TensorEntry> entries;
     std::unordered_set<const Tensor *> visited_st;
@@ -716,7 +716,8 @@ void NeuralNetwork::save(
       file_path, std::ios::out | std::ios::binary | std::ios::trunc);
     st_file.write(reinterpret_cast<const char *>(&header_size),
                   sizeof(header_size));
-    st_file.write(header_json.data(), static_cast<std::streamsize>(header_json.size()));
+    st_file.write(header_json.data(),
+                  static_cast<std::streamsize>(header_json.size()));
 
     visited_st.clear();
     for (auto iter = model_graph.cbegin(); iter != model_graph.cend(); iter++) {
@@ -1020,7 +1021,8 @@ void NeuralNetwork::load(const std::string &file_path,
     st_file.close();
 
     // data_base: byte offset in file where the data section starts
-    const size_t data_base = sizeof(uint64_t) + static_cast<size_t>(header_size);
+    const size_t data_base =
+      sizeof(uint64_t) + static_cast<size_t>(header_size);
 
     // Parse header: name -> (offset_start, size_in_bytes)
     auto name_offset_map = safetensors::parseHeader(header_json);
@@ -1053,8 +1055,8 @@ void NeuralNetwork::load(const std::string &file_path,
         auto node = *iter;
         threads.emplace_back([&, node]() {
           if (!MMAP_READ) {
-            auto local_file =
-              checkedOpenStream<std::ifstream>(f_path, std::ios::in | std::ios::binary);
+            auto local_file = checkedOpenStream<std::ifstream>(
+              f_path, std::ios::in | std::ios::binary);
             node->read(local_file, false, exec_mode, fsu_mode,
                        std::numeric_limits<size_t>::max(), true, model_file_fd);
           } else {

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -1060,6 +1060,30 @@ void NeuralNetwork::load(const std::string &file_path,
             node->read(local_file, false, exec_mode, fsu_mode,
                        std::numeric_limits<size_t>::max(), true, model_file_fd);
           } else {
+#if defined(_WIN32)
+            HANDLE hFile =
+              CreateFileA(f_path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL,
+                          OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+            NNTR_THROW_IF((hFile == INVALID_HANDLE_VALUE), std::runtime_error)
+              << "CreateFileA failed for safetensors file: " << f_path;
+
+            HANDLE hMap =
+              CreateFileMapping(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
+            NNTR_THROW_IF((hMap == NULL), std::runtime_error)
+              << "CreateFileMapping failed for safetensors file: " << f_path;
+
+            char *view =
+              static_cast<char *>(MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0));
+            NNTR_THROW_IF((view == nullptr), std::runtime_error)
+              << "MapViewOfFile failed for safetensors file: " << f_path;
+
+            node->read(view, false, exec_mode, fsu_mode,
+                       std::numeric_limits<size_t>::max(), true, model_file_fd);
+
+            UnmapViewOfFile(view);
+            CloseHandle(hMap);
+            CloseHandle(hFile);
+#else
             int fd = ::open(f_path.c_str(), O_RDONLY);
             NNTR_THROW_IF((fd == -1), std::invalid_argument)
               << "Cannot open safetensors file: " << f_path;
@@ -1083,6 +1107,7 @@ void NeuralNetwork::load(const std::string &file_path,
 
             (void)::posix_madvise(mmap_ptr, f_size, POSIX_MADV_DONTNEED);
             ::munmap(mmap_ptr, f_size);
+#endif
           }
         });
       }

--- a/nntrainer/utils/meson.build
+++ b/nntrainer/utils/meson.build
@@ -9,7 +9,8 @@ util_sources = [
   'util_simd.cpp',
   'mman_windows.cpp',
   'thread_manager.cpp',
-  'thread_manager_util.cpp'
+  'thread_manager_util.cpp',
+  'safetensors_util.cpp',
 ]
 
 util_headers = [
@@ -27,6 +28,7 @@ util_headers = [
   'noncopyable.h',
   'thread_manager.h',
   'thread_manager_util.h',
+  'safetensors_util.h',
 ]
 
 if get_option('enable-trace')

--- a/nntrainer/utils/safetensors_util.cpp
+++ b/nntrainer/utils/safetensors_util.cpp
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   safetensors_util.cpp
+ * @date   18 May 2026
+ * @brief  safetensors dtype mapping + JSON header build/parse helpers.
+ */
+
+#include "safetensors_util.h"
+
+#include <cctype>
+#include <sstream>
+#include <stdexcept>
+
+namespace nntrainer::safetensors {
+
+const char *dtypeToString(ml::train::TensorDim::DataType dtype) {
+  using DT = ml::train::TensorDim::DataType;
+  switch (dtype) {
+  case DT::FP32:   return "F32";
+  case DT::FP16:   return "F16";
+  case DT::QINT4:  return "I4";
+  case DT::QINT8:  return "I8";
+  case DT::QINT16: return "I16";
+  case DT::UINT4:  return "U4";
+  case DT::UINT8:  return "U8";
+  case DT::UINT16: return "U16";
+  case DT::UINT32: return "U32";
+  default:         return "F32";
+  }
+}
+
+std::string buildHeader(const std::vector<TensorEntry> &entries) {
+  std::ostringstream out;
+  out << "{\"__metadata__\":{\"format\":\"nntrainer\"}";
+  for (const auto &e : entries) {
+    out << ",\"" << e.name << "\":{\"dtype\":\"" << e.dtype << "\",\"shape\":[";
+    for (size_t i = 0; i < e.shape.size(); ++i) {
+      if (i > 0) out << ",";
+      out << e.shape[i];
+    }
+    out << "],\"data_offsets\":[" << e.offset_start << "," << e.offset_end << "]}";
+  }
+  out << "}";
+  std::string s = out.str();
+  const size_t pad = (8 - (s.size() % 8)) % 8;
+  s.append(pad, ' ');
+  return s;
+}
+
+namespace {
+
+class Scanner {
+public:
+  explicit Scanner(const std::string &s) : src(s), pos(0) {}
+
+  void skipWs() {
+    while (pos < src.size() && std::isspace(static_cast<unsigned char>(src[pos])))
+      ++pos;
+  }
+
+  bool peek(char c) {
+    skipWs();
+    return pos < src.size() && src[pos] == c;
+  }
+
+  void expect(char c) {
+    if (!peek(c))
+      throw std::runtime_error(std::string("safetensors: expected '") + c + "'");
+    ++pos;
+  }
+
+  std::string readString() {
+    expect('"');
+    std::string out;
+    while (pos < src.size() && src[pos] != '"') {
+      if (src[pos] == '\\' && pos + 1 < src.size()) ++pos;
+      out += src[pos++];
+    }
+    expect('"');
+    return out;
+  }
+
+  size_t readNumber() {
+    skipWs();
+    size_t v = 0;
+    while (pos < src.size() && src[pos] >= '0' && src[pos] <= '9')
+      v = v * 10 + (src[pos++] - '0');
+    return v;
+  }
+
+  void skipValue() {
+    skipWs();
+    if (pos >= src.size()) return;
+    char c = src[pos];
+    if (c == '"') { readString(); return; }
+    if (c == '{' || c == '[') {
+      const char close = (c == '{') ? '}' : ']';
+      int depth = 0;
+      while (pos < src.size()) {
+        if (src[pos] == '"') { readString(); continue; }
+        if (src[pos] == c) ++depth;
+        else if (src[pos] == close && --depth == 0) { ++pos; return; }
+        ++pos;
+      }
+      return;
+    }
+    while (pos < src.size() && src[pos] != ',' && src[pos] != '}' && src[pos] != ']')
+      ++pos;
+  }
+
+private:
+  const std::string &src;
+  size_t pos;
+};
+
+} // namespace
+
+std::unordered_map<std::string, std::pair<size_t, size_t>>
+parseHeader(const std::string &json) {
+  std::unordered_map<std::string, std::pair<size_t, size_t>> out;
+  Scanner s(json);
+  s.expect('{');
+  for (bool first = true; !s.peek('}'); first = false) {
+    if (!first) s.expect(',');
+    const std::string key = s.readString();
+    s.expect(':');
+    if (key == "__metadata__") { s.skipValue(); continue; }
+    s.expect('{');
+    size_t off_start = 0, off_end = 0;
+    bool have_offsets = false;
+    for (bool inner_first = true; !s.peek('}'); inner_first = false) {
+      if (!inner_first) s.expect(',');
+      const std::string field = s.readString();
+      s.expect(':');
+      if (field == "data_offsets") {
+        s.expect('[');
+        off_start = s.readNumber();
+        s.expect(',');
+        off_end = s.readNumber();
+        s.expect(']');
+        have_offsets = true;
+      } else {
+        s.skipValue();
+      }
+    }
+    s.expect('}');
+    if (have_offsets)
+      out.emplace(key, std::make_pair(off_start, off_end - off_start));
+  }
+  s.expect('}');
+  return out;
+}
+
+} // namepsace safetensors

--- a/nntrainer/utils/safetensors_util.cpp
+++ b/nntrainer/utils/safetensors_util.cpp
@@ -18,16 +18,26 @@ namespace nntrainer::safetensors {
 const char *dtypeToString(ml::train::TensorDim::DataType dtype) {
   using DT = ml::train::TensorDim::DataType;
   switch (dtype) {
-  case DT::FP32:   return "F32";
-  case DT::FP16:   return "F16";
-  case DT::QINT4:  return "I4";
-  case DT::QINT8:  return "I8";
-  case DT::QINT16: return "I16";
-  case DT::UINT4:  return "U4";
-  case DT::UINT8:  return "U8";
-  case DT::UINT16: return "U16";
-  case DT::UINT32: return "U32";
-  default:         return "F32";
+  case DT::FP32:
+    return "F32";
+  case DT::FP16:
+    return "F16";
+  case DT::QINT4:
+    return "I4";
+  case DT::QINT8:
+    return "I8";
+  case DT::QINT16:
+    return "I16";
+  case DT::UINT4:
+    return "U4";
+  case DT::UINT8:
+    return "U8";
+  case DT::UINT16:
+    return "U16";
+  case DT::UINT32:
+    return "U32";
+  default:
+    return "F32";
   }
 }
 
@@ -37,10 +47,12 @@ std::string buildHeader(const std::vector<TensorEntry> &entries) {
   for (const auto &e : entries) {
     out << ",\"" << e.name << "\":{\"dtype\":\"" << e.dtype << "\",\"shape\":[";
     for (size_t i = 0; i < e.shape.size(); ++i) {
-      if (i > 0) out << ",";
+      if (i > 0)
+        out << ",";
       out << e.shape[i];
     }
-    out << "],\"data_offsets\":[" << e.offset_start << "," << e.offset_end << "]}";
+    out << "],\"data_offsets\":[" << e.offset_start << "," << e.offset_end
+        << "]}";
   }
   out << "}";
   std::string s = out.str();
@@ -56,7 +68,8 @@ public:
   explicit Scanner(const std::string &s) : src(s), pos(0) {}
 
   void skipWs() {
-    while (pos < src.size() && std::isspace(static_cast<unsigned char>(src[pos])))
+    while (pos < src.size() &&
+           std::isspace(static_cast<unsigned char>(src[pos])))
       ++pos;
   }
 
@@ -67,7 +80,8 @@ public:
 
   void expect(char c) {
     if (!peek(c))
-      throw std::runtime_error(std::string("safetensors: expected '") + c + "'");
+      throw std::runtime_error(std::string("safetensors: expected '") + c +
+                               "'");
     ++pos;
   }
 
@@ -75,7 +89,8 @@ public:
     expect('"');
     std::string out;
     while (pos < src.size() && src[pos] != '"') {
-      if (src[pos] == '\\' && pos + 1 < src.size()) ++pos;
+      if (src[pos] == '\\' && pos + 1 < src.size())
+        ++pos;
       out += src[pos++];
     }
     expect('"');
@@ -92,21 +107,33 @@ public:
 
   void skipValue() {
     skipWs();
-    if (pos >= src.size()) return;
+    if (pos >= src.size())
+      return;
     char c = src[pos];
-    if (c == '"') { readString(); return; }
+    if (c == '"') {
+      readString();
+      return;
+    }
     if (c == '{' || c == '[') {
       const char close = (c == '{') ? '}' : ']';
       int depth = 0;
       while (pos < src.size()) {
-        if (src[pos] == '"') { readString(); continue; }
-        if (src[pos] == c) ++depth;
-        else if (src[pos] == close && --depth == 0) { ++pos; return; }
+        if (src[pos] == '"') {
+          readString();
+          continue;
+        }
+        if (src[pos] == c)
+          ++depth;
+        else if (src[pos] == close && --depth == 0) {
+          ++pos;
+          return;
+        }
         ++pos;
       }
       return;
     }
-    while (pos < src.size() && src[pos] != ',' && src[pos] != '}' && src[pos] != ']')
+    while (pos < src.size() && src[pos] != ',' && src[pos] != '}' &&
+           src[pos] != ']')
       ++pos;
   }
 
@@ -123,15 +150,20 @@ parseHeader(const std::string &json) {
   Scanner s(json);
   s.expect('{');
   for (bool first = true; !s.peek('}'); first = false) {
-    if (!first) s.expect(',');
+    if (!first)
+      s.expect(',');
     const std::string key = s.readString();
     s.expect(':');
-    if (key == "__metadata__") { s.skipValue(); continue; }
+    if (key == "__metadata__") {
+      s.skipValue();
+      continue;
+    }
     s.expect('{');
     size_t off_start = 0, off_end = 0;
     bool have_offsets = false;
     for (bool inner_first = true; !s.peek('}'); inner_first = false) {
-      if (!inner_first) s.expect(',');
+      if (!inner_first)
+        s.expect(',');
       const std::string field = s.readString();
       s.expect(':');
       if (field == "data_offsets") {
@@ -153,4 +185,4 @@ parseHeader(const std::string &json) {
   return out;
 }
 
-} // namepsace safetensors
+} // namespace nntrainer::safetensors

--- a/nntrainer/utils/safetensors_util.cpp
+++ b/nntrainer/utils/safetensors_util.cpp
@@ -2,9 +2,9 @@
 /**
  * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
  *
+ * @brief  safetensors dtype mapping + JSON header build/parse helpers.
  * @file   safetensors_util.cpp
  * @date   18 May 2026
- * @brief  safetensors dtype mapping + JSON header build/parse helpers.
  */
 
 #include "safetensors_util.h"

--- a/nntrainer/utils/safetensors_util.cpp
+++ b/nntrainer/utils/safetensors_util.cpp
@@ -5,6 +5,9 @@
  * @brief  safetensors dtype mapping + JSON header build/parse helpers.
  * @file   safetensors_util.cpp
  * @date   18 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Seunghui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
  */
 
 #include "safetensors_util.h"

--- a/nntrainer/utils/safetensors_util.cpp
+++ b/nntrainer/utils/safetensors_util.cpp
@@ -66,6 +66,9 @@ std::string buildHeader(const std::vector<TensorEntry> &entries) {
 
 namespace {
 
+/**
+ * @brief Lightweight JSON scanner for parsing safetensors headers.
+ */
 class Scanner {
 public:
   explicit Scanner(const std::string &s) : src(s), pos(0) {}

--- a/nntrainer/utils/safetensors_util.h
+++ b/nntrainer/utils/safetensors_util.h
@@ -5,6 +5,9 @@
  * @brief  Util helpers for the safetensors format.
  * @file   safetensors_util.h
  * @date   18 May 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Seunghui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
  */
 
 #ifndef __SAFETENSORS_UTIL_H__

--- a/nntrainer/utils/safetensors_util.h
+++ b/nntrainer/utils/safetensors_util.h
@@ -2,9 +2,9 @@
 /**
  * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
  *
+ * @brief  Util helpers for the safetensors format.
  * @file   safetensors_util.h
  * @date   18 May 2026
- * @brief  Minimal helpers for the safetensors on-disk format.
  */
 
 #ifndef __SAFETENSORS_UTIL_H__

--- a/nntrainer/utils/safetensors_util.h
+++ b/nntrainer/utils/safetensors_util.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Seunghui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   safetensors_util.h
+ * @date   18 May 2026
+ * @brief  Minimal helpers for the safetensors on-disk format.
+ */
+
+#ifndef __SAFETENSORS_UTIL_H__
+#define __SAFETENSORS_UTIL_H__
+#ifdef __cplusplus
+
+#include <string>
+#include <tensor_dim.h>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace nntrainer::safetensors {
+
+struct TensorEntry {
+  std::string name;
+  std::string dtype;
+  std::vector<size_t> shape;
+  size_t offset_start;
+  size_t offset_end;
+};
+
+const char *dtypeToString(ml::train::TensorDim::DataType dtype);
+
+std::string buildHeader(const std::vector<TensorEntry> &entries);
+
+std::unordered_map<std::string, std::pair<size_t, size_t>>
+parseHeader(const std::string &json);
+
+} // namespace nntrainer::safetensors
+
+#endif /* __cplusplus */
+#endif /* __SAFETENSORS_UTIL_H__ */

--- a/nntrainer/utils/safetensors_util.h
+++ b/nntrainer/utils/safetensors_util.h
@@ -22,6 +22,9 @@
 
 namespace nntrainer::safetensors {
 
+/**
+ * @brief Metadata entry for a single tensor in a safetensors file.
+ */
 struct TensorEntry {
   std::string name;
   std::string dtype;

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -610,6 +610,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/nntr_ggml_impl_utils.h
 %{_includedir}/nntrainer/thread_manager.h
 %{_includedir}/nntrainer/thread_manager_util.h
+%{_includedir}/nntrainer/safetensors_util.h
 %ifarch %{ix86} x86_64
 %{_includedir}/nntrainer/x86_compute_backend.h
 %{_includedir}/nntrainer/avx2_impl.h


### PR DESCRIPTION
## Dependency of the PR

- This PR depends on #3824.


## Description

This PR adds safetensors weight format support to nntrainer.

It introduces safetensors utility functions and integrates safetensors into the model load/save path so that nntrainer can handle `.safetensors` weight files in addition to the existing binary format.

This PR also adds model format selection through `ModelFormat` and enables CausalLM Transformer to detect the weight format from the file extension. With this change, `.bin` and `.safetensors` weights can be selected automatically depending on the given weight file path.

Since safetensors is widely used in Hugging Face-based model workflows, this change makes it easier to integrate nntrainer with external model conversion pipelines and safetensors-based LLM weights.

## Summary

- Add safetensors utility functions for reading and writing safetensors weight files.
- Add model format selection through `ModelFormat` and support `MODEL_FORMAT_SAFETENSORS`.
- Enable `NeuralNetwork` to load and save model weights in safetensors format.
- Enable CausalLM Transformer to load and save `.safetensors` weights.
- Add automatic weight format detection from file extension, supporting `.safetensors` and `.bin`.
- Apply clang-format to safetensors-related changes.

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

## Test
- I checked that there is no difference between running with bin file and running with satetensors in local.

```bash
/home/leeseunghui/workspace/nntrainer/Applications/CausalLM/res/qwen3/qwen3-0.6b/nntr_qwen3_0.6b_fp32.bin
[Info] Chat template loaded from tokenizer_config.json
<|im_start|>user
Give me a short introduction to large language model.<|im_end|>
<|im_start|>assistant

<think>
Okay, the user wants a short introduction to a large language^C
```

```bash
/home/leeseunghui/workspace/nntrainer/Applications/CausalLM/res/qwen3/qwen3-0.6b/nntr_qwen3_0.6b_x86_fp32.safetensors
[Info] Chat template loaded from tokenizer_config.json
<|im_start|>user
Give me a short introduction to large language model.<|im_end|>
<|im_start|>assistant

<think>
Okay, the user wants a short introduction to a large language^C
```
- Self evaluation:

  1. Build test: [X]Passed [ ]Failed [ ]Skipped
  2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>