### PR TITLE
[causallm] Fix MHA_Core layer to use actual step size in forwarding

### DIFF
--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -293,7 +293,8 @@ void MHACoreLayer::forwarding(nntrainer::RunLayerContext &context,
     sink = context.getWeight(sink_idx);
   }
 
-  unsigned int step_size = query.height();
+  unsigned int step_size =
+    (incremental_step_size > 0) ? incremental_step_size : (unsigned int)query.height();
   unsigned int from = cache_index;
   unsigned int to = cache_index + step_size;
 
@@ -398,7 +399,9 @@ void MHACoreLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
   // from input slots 3/4. forwarding() advances cache_index internally.
   if (use_external_cache) {
     cache_index = _from;
+    incremental_step_size = _to - _from;
     forwarding(context, training);
+    incremental_step_size = 0;
     return;
   }
 

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -293,8 +293,9 @@ void MHACoreLayer::forwarding(nntrainer::RunLayerContext &context,
     sink = context.getWeight(sink_idx);
   }
 
-  unsigned int step_size =
-    (incremental_step_size > 0) ? incremental_step_size : (unsigned int)query.height();
+  unsigned int step_size = (incremental_step_size > 0)
+                             ? incremental_step_size
+                             : (unsigned int)query.height();
   unsigned int from = cache_index;
   unsigned int to = cache_index + step_size;
 

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -387,6 +387,9 @@ private:
   float scale = 1.0f;
   unsigned int original_max_position_embeddings = 4096;
 
+  /** set by incremental_forwarding, used by forwarding */
+  unsigned int incremental_step_size = 0;
+
   /****************** ROTARY EMBEDDING *****************/
   /** static variable - they are all expected to be initialized once */
   /**


### PR DESCRIPTION
This commit fixes MHA_Core layer to use actual step size in external KV cache forwarding path
- Add incremental_step_size member to MHACore Layer to representation _to - _from for incremetal forwarding
- Replace query.height() with incremental_step_size in forwarding() so generation steps compute attention for 1 token, not MAX_SEQ_LEN

## Description

In `MHACoreLayer::incremental_forwarding()`, the external KV cache path passed `_from` to set `cache_index` but silently dropped `_to`. As a result, `forwarding()` fell back to `query.height()` (= MAX_SEQ_LEN = 1024)
as the step size for every call, including single-token generation steps.

This caused each generated token to run the full 1024-token attention computation — identical cost to a complete prefill — instead of attending over just 1 query token against the KV cache.

Fix by storing `_to - _from` in a new member `incremental_step_size` before delegating to `forwarding()`, and using it in place of `query.height()` when non-zero.

### Summary

- Fix external KV cache path ignoring `_to` in `incremental_forwarding()`, causing ~MAX_SEQ_LEN× slowdown during autoregressive generation

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
