### PR TITLE
[CausalLM] Fix build errors after supporting Deberta V2 model

### DIFF
--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -479,13 +479,12 @@ void DebertaAttentionLayer::compute_kcaches(
       _FP16 *out_data = out.getData<_FP16>();
 
       auto &tm = nntrainer::ThreadManager::Global();
-      tm.parallel_for(0, static_cast<size_t>(num_cache_head),
-                      [=](size_t head_kv) {
-                        nntrainer::compute_kcaches(
-                          in_data, cache_data, out_data, num_rows,
-                          num_cache_head, head_dim, group_size, tile_size,
-                          local_window_size, head_kv, head_kv + 1);
-                      });
+      tm.parallel_for(
+        0, static_cast<size_t>(num_cache_head), [=](size_t head_kv) {
+          nntrainer::compute_kcaches(
+            in_data, cache_data, out_data, num_rows, num_cache_head, head_dim,
+            group_size, tile_size, local_window_size, head_kv, head_kv + 1);
+        });
     } else {
       const unsigned int seq = static_cast<unsigned int>(sequence_len);
 

--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -29,6 +29,7 @@
 #include <nntrainer_error.h>
 
 #include <node_exporter.h>
+#include <thread_manager.h>
 
 namespace causallm {
 
@@ -424,19 +425,24 @@ void DebertaAttentionLayer::compute_kcaches(
       const float *in_data = in.getData<float>();
       float *out_data = out.getData<float>();
 
-#pragma omp parallel for schedule(static)
-      for (unsigned int head_kv = 0; head_kv < num_cache_head; ++head_kv) {
-        if (cache.getDataType() == ml::train::TensorDim::DataType::FP32) {
-          compute_kcaches_fp32_reference(
-            in_data, cache.getData<float>(), out_data, row_to_compute,
-            num_cache_head, head_dim, group_size, local_window_size, head_kv,
-            head_kv + 1);
-        } else {
-          nntrainer::compute_kcaches<uint16_t>(
-            in_data, cache.getData<uint16_t>(), out_data, row_to_compute,
-            num_cache_head, head_dim, group_size, tile_size, local_window_size,
-            head_kv, head_kv + 1);
-        }
+      auto &tm = nntrainer::ThreadManager::Global();
+      if (cache.getDataType() == ml::train::TensorDim::DataType::FP32) {
+        const float *cache_data = cache.getData<float>();
+        tm.parallel_for(
+          0, static_cast<size_t>(num_cache_head), [=](size_t head_kv) {
+            compute_kcaches_fp32_reference(
+              in_data, cache_data, out_data, row_to_compute, num_cache_head,
+              head_dim, group_size, local_window_size, head_kv, head_kv + 1);
+          });
+      } else {
+        const uint16_t *cache_data = cache.getData<uint16_t>();
+        tm.parallel_for(0, static_cast<size_t>(num_cache_head),
+                        [=](size_t head_kv) {
+                          nntrainer::compute_kcaches<uint16_t>(
+                            in_data, cache_data, out_data, row_to_compute,
+                            num_cache_head, head_dim, group_size, tile_size,
+                            local_window_size, head_kv, head_kv + 1);
+                        });
       }
 
     } else {
@@ -472,12 +478,14 @@ void DebertaAttentionLayer::compute_kcaches(
       const _FP16 *cache_data = cache.getData<_FP16>();
       _FP16 *out_data = out.getData<_FP16>();
 
-#pragma omp parallel for schedule(static)
-      for (unsigned int head_kv = 0; head_kv < num_cache_head; ++head_kv) {
-        nntrainer::compute_kcaches(
-          in_data, cache_data, out_data, num_rows, num_cache_head, head_dim,
-          group_size, tile_size, local_window_size, head_kv, head_kv + 1);
-      }
+      auto &tm = nntrainer::ThreadManager::Global();
+      tm.parallel_for(0, static_cast<size_t>(num_cache_head),
+                      [=](size_t head_kv) {
+                        nntrainer::compute_kcaches(
+                          in_data, cache_data, out_data, num_rows,
+                          num_cache_head, head_dim, group_size, tile_size,
+                          local_window_size, head_kv, head_kv + 1);
+                      });
     } else {
       const unsigned int seq = static_cast<unsigned int>(sequence_len);
 
@@ -600,19 +608,23 @@ void DebertaAttentionLayer::compute_fp16vcache_transposed(
       const float *in_data = in.getData<float>();
       float *output_data = output.getData<float>();
 
-#pragma omp parallel for schedule(static)
-      for (int head_kv = 0; head_kv < num_cache_head; ++head_kv) {
-        if (vcache.getDataType() == ml::train::TensorDim::DataType::FP32) {
-          compute_vcache_fp32_transposed_reference(
-            row_num, in_data, vcache.getData<float>(), output_data,
-            num_cache_head, gqa_size, head_dim, local_window_size, head_kv,
-            head_kv + 1);
-        } else {
-          nntrainer::compute_fp16vcache_fp32_transposed(
-            row_num, in_data, vcache.getData<uint16_t>(), output_data,
-            num_cache_head, gqa_size, head_dim, local_window_size, head_kv,
-            head_kv + 1);
-        }
+      auto &tm = nntrainer::ThreadManager::Global();
+      if (vcache.getDataType() == ml::train::TensorDim::DataType::FP32) {
+        const float *vcache_data = vcache.getData<float>();
+        tm.parallel_for(
+          0, static_cast<size_t>(num_cache_head), [=](size_t head_kv) {
+            compute_vcache_fp32_transposed_reference(
+              row_num, in_data, vcache_data, output_data, num_cache_head,
+              gqa_size, head_dim, local_window_size, head_kv, head_kv + 1);
+          });
+      } else {
+        const uint16_t *vcache_data = vcache.getData<uint16_t>();
+        tm.parallel_for(
+          0, static_cast<size_t>(num_cache_head), [=](size_t head_kv) {
+            nntrainer::compute_fp16vcache_fp32_transposed(
+              row_num, in_data, vcache_data, output_data, num_cache_head,
+              gqa_size, head_dim, local_window_size, head_kv, head_kv + 1);
+          });
       }
     }
 
@@ -641,12 +653,13 @@ void DebertaAttentionLayer::compute_fp16vcache_transposed(
       const _FP16 *vcache_data = vcache.getData<_FP16>();
       _FP16 *output_data = output.getData<_FP16>();
 
-#pragma omp parallel for schedule(static)
-      for (int head_kv = 0; head_kv < num_cache_head; ++head_kv) {
-        nntrainer::compute_fp16vcache_transposed(
-          row_num, in_data, vcache_data, output_data, num_cache_head, gqa_size,
-          head_dim, local_window_size, head_kv, head_kv + 1);
-      }
+      auto &tm = nntrainer::ThreadManager::Global();
+      tm.parallel_for(
+        0, static_cast<size_t>(num_cache_head), [=](size_t head_kv) {
+          nntrainer::compute_fp16vcache_transposed(
+            row_num, in_data, vcache_data, output_data, num_cache_head,
+            gqa_size, head_dim, local_window_size, head_kv, head_kv + 1);
+        });
     }
 #else
     NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
@@ -714,8 +727,8 @@ void DebertaAttentionLayer::add_relative_attn_score(
       rel_idx_local.p2c_idx.resize(static_cast<size_t>(S_q) * S_k);
     }
 
-#pragma omp parallel for schedule(static)
-    for (unsigned int q = 0; q < S_q; ++q) {
+    auto &tm_idx = nntrainer::ThreadManager::Global();
+    tm_idx.parallel_for(0, static_cast<size_t>(S_q), [&](size_t q) {
       for (unsigned int k = 0; k < S_k; ++k) {
         if (c2p) {
           const int rel = static_cast<int>(q + from) - static_cast<int>(k);
@@ -733,7 +746,7 @@ void DebertaAttentionLayer::add_relative_attn_score(
                    static_cast<int>(rel_len_q) - 1);
         }
       }
-    }
+    });
 
     tl_rel_index_key = cache_key;
     tl_rel_index_ready = true;
@@ -805,8 +818,8 @@ void DebertaAttentionLayer::add_relative_attn_score(
     NNTR_THROW_IF(p2c && key_unpacked_ptr == nullptr, std::invalid_argument)
       << "FP32 p2c path expected FP32, UINT16, or FP16 key cache";
 
-#pragma omp parallel for schedule(static)
-    for (unsigned int q_idx = 0; q_idx < S_q; ++q_idx) {
+    auto &tm_fp32 = nntrainer::ThreadManager::Global();
+    tm_fp32.parallel_for(0, static_cast<size_t>(S_q), [&](size_t q_idx) {
       const size_t qk_row = static_cast<size_t>(q_idx) * S_k;
 
       for (unsigned int h = 0; h < num_heads_Q; ++h) {
@@ -822,7 +835,6 @@ void DebertaAttentionLayer::add_relative_attn_score(
               rel_key_ptr + static_cast<size_t>(rel_index) * hidden + h_base;
 
             float c2p_dot = 0.0f;
-#pragma omp simd reduction(+ : c2p_dot)
             for (unsigned int d = 0; d < head_dim; ++d) {
               c2p_dot += q_head[d] * rk_head[d];
             }
@@ -837,7 +849,6 @@ void DebertaAttentionLayer::add_relative_attn_score(
             float p2c_dot = 0.0f;
             const float *k_head =
               key_unpacked_ptr + static_cast<size_t>(k_idx) * hidden + h_base;
-#pragma omp simd reduction(+ : p2c_dot)
             for (unsigned int d = 0; d < head_dim; ++d) {
               p2c_dot += k_head[d] * rq_head[d];
             }
@@ -849,7 +860,7 @@ void DebertaAttentionLayer::add_relative_attn_score(
           score_ptr[linear_idx] += rel_score;
         }
       }
-    }
+    });
   } else if (score.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
     NNTR_THROW_IF(key_cache.getDataType() !=
@@ -863,8 +874,8 @@ void DebertaAttentionLayer::add_relative_attn_score(
     const _FP16 *rel_key_ptr = c2p ? rel_key.getData<_FP16>() : nullptr;
     const _FP16 *key_fp16_ptr = key_cache.getData<_FP16>();
 
-#pragma omp parallel for schedule(static)
-    for (unsigned int q_idx = 0; q_idx < S_q; ++q_idx) {
+    auto &tm_fp16 = nntrainer::ThreadManager::Global();
+    tm_fp16.parallel_for(0, static_cast<size_t>(S_q), [&](size_t q_idx) {
       const size_t qk_row_base = static_cast<size_t>(q_idx) * S_k;
 
       for (unsigned int h = 0; h < num_heads_Q; ++h) {
@@ -880,7 +891,6 @@ void DebertaAttentionLayer::add_relative_attn_score(
               rel_key_ptr + static_cast<size_t>(rel_index) * hidden + h_base;
 
             float c2p_dot = 0.0f;
-#pragma omp simd reduction(+ : c2p_dot)
             for (unsigned int d = 0; d < head_dim; ++d) {
               c2p_dot +=
                 static_cast<float>(q_head[d]) * static_cast<float>(rk_head[d]);
@@ -896,7 +906,6 @@ void DebertaAttentionLayer::add_relative_attn_score(
               key_fp16_ptr + static_cast<size_t>(k_idx) * hidden + h_base;
 
             float p2c_dot = 0.0f;
-#pragma omp simd reduction(+ : p2c_dot)
             for (unsigned int d = 0; d < head_dim; ++d) {
               p2c_dot +=
                 static_cast<float>(k_head[d]) * static_cast<float>(rq_head[d]);
@@ -910,7 +919,7 @@ void DebertaAttentionLayer::add_relative_attn_score(
             (_FP16)(static_cast<float>(score_ptr[linear_idx]) + rel_score);
         }
       }
-    }
+    });
 #else
     NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
 #endif

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.cpp
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.cpp
@@ -207,7 +207,8 @@ void SharedFullyConnectedLayer::read(
 void SharedFullyConnectedLayer::save(
   std::ofstream &file, nntrainer::RunLayerContext &run_context, bool opt_var,
   ml::train::ExecutionMode mode, bool trainable,
-  nntrainer::TensorDim::DataType definedWeightDataType) const {
+  nntrainer::TensorDim::DataType definedWeightDataType,
+  ml::train::ISA target_isa) const {
   if (!shared_mode_) {
     for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
       run_context.getWeight(i).save(file);

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.h
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.h
@@ -85,8 +85,7 @@ public:
   void save(std::ofstream &file, nntrainer::RunLayerContext &run_context,
             bool opt_var, ml::train::ExecutionMode mode, bool trainable,
             nntrainer::TensorDim::DataType definedWeightDataType,
-            ml::train::ISA target_isa =
-              ml::train::ISA::DEFAULT) const override;
+            ml::train::ISA target_isa = ml::train::ISA::DEFAULT) const override;
 
   /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.h
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.h
@@ -82,10 +82,11 @@ public:
   /**
    * @copydic Layer::save()
    */
-  void
-  save(std::ofstream &file, nntrainer::RunLayerContext &run_context,
-       bool opt_var, ml::train::ExecutionMode mode, bool trainable,
-       nntrainer::TensorDim::DataType definedWeightDataType) const override;
+  void save(std::ofstream &file, nntrainer::RunLayerContext &run_context,
+            bool opt_var, ml::train::ExecutionMode mode, bool trainable,
+            nntrainer::TensorDim::DataType definedWeightDataType,
+            ml::train::ISA target_isa =
+              ml::train::ISA::DEFAULT) const override;
 
   /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] Replace OpenMP with ThreadManager Util</summary><br />

[[CausalLM] Replace OpenMP with ThreadManager Util](https://github.com/nntrainer/nntrainer/pull/3936/changes/52b133609093dd2352a8c3f8990b0d2959ab3995)
- This commit replaces OpenMP pragmas in deberta_attention_layer wtih ThreadManager.
- This commit resolves build error for including OpenMP.

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
</details>



<details><summary>Fix SharedFullyConnectedLayer::save signature</summary><br />

[[CausalLM] Fix SharedFullyConnectedLayer::save signature](https://github.com/nntrainer/nntrainer/commit/7c66cf3532b35721fb0191b2981e891f4182dc22) 

- This commit fixes SharedFullyConnectedLayer::save to match the new signature.
- This commit resolves build fail for override save method.

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

### Summary

Fixes two build regressions exposed by the recent DeBERTa V2 attention
merge on top of the OpenMP-removal and `Layer::save` ISA-arg changes:

- `deberta_attention_layer.cpp` still used `#pragma omp parallel for` /
  `#pragma omp simd`, which now trips `-Werror=unknown-pragmas` because
  the project moved off OpenMP onto `nntrainer::ThreadManager`.
- `SharedFullyConnectedLayer::save` kept the old 5-arg signature with
  `override`, but `Layer::save` gained a trailing
  `ml::train::ISA target_isa = ISA::DEFAULT` argument, so g++ rejected

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
