### PR TITLE
[CI] enable CausalLM model unittests

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -39,6 +39,11 @@ jobs:
     - name: install build systems
       run: sudo apt install meson ninja-build
     - run: |
+        causallm_option="-Denable-transformer=false"
+        if [ "${{ matrix.meson_options }}" = "-Denable-fp16=false" ]; then
+          causallm_option="-Denable-transformer=true"
+        fi
+
         meson \
           --buildtype=plain \
           --prefix=/usr \
@@ -47,6 +52,7 @@ jobs:
           --bindir=lib/nntrainer/bin \
           --includedir=include \
           -Dinstall-app=true \
+          ${causallm_option} \
           -Dreduce-tolerance=false \
           -Denable-debug=true \
           -Dml-api-support=enabled \
@@ -58,6 +64,27 @@ jobs:
           -Denable-capi=enabled \
           ${{ matrix.meson_options }} \
           build
+    - name: Check CausalLM model tests are enabled
+      if: ${{ matrix.meson_options == '-Denable-fp16=false' }}
+      run: |
+        meson introspect build --tests > meson-tests.json
+        python3 - <<'PY'
+        import json
+
+        with open("meson-tests.json", encoding="utf-8") as test_file:
+            tests = {test["name"] for test in json.load(test_file)}
+
+        required_tests = {
+            "unittest_causallm_models",
+        }
+        missing_tests = sorted(required_tests - tests)
+        if missing_tests:
+            raise SystemExit(
+                "Missing CausalLM Meson tests: " + ", ".join(missing_tests)
+            )
+
+        print("CausalLM Meson model tests enabled: " + ", ".join(sorted(required_tests)))
+        PY
     - run: ninja -C build
     - name: run App Tests
       run: meson test -C build --no-suite unittests

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -205,7 +205,11 @@ if get_option('enable-test')
   # Ubuntu native builds use platform=none.
   model_unittest_platforms = ['none', 'windows', 'android']
   platform = get_option('platform')
-  enable_causallm_model_unittest = platform in model_unittest_platforms
+  # Tiny model-level tests cover FP32 and Q4_0-FP32 correctness. Keep them out
+  # of FP16 builds, where cache tensors intentionally use FP16 storage.
+  enable_causallm_model_unittest = (
+    platform in model_unittest_platforms and not get_option('enable-fp16')
+  )
   if enable_causallm_model_unittest
     unittest_causallm_models = executable(
       'unittest_causallm_models',

--- a/Applications/meson.build
+++ b/Applications/meson.build
@@ -51,10 +51,6 @@ if host_machine.system() != 'windows'
 endif
 
 if get_option('enable-transformer')
-  subdir('LLaMA/jni')
-  if host_machine.system() != 'windows'
-  subdir('PicoGPT/jni')
-  endif
   if get_option('platform') != 'tizen'
     subdir('CausalLM')
   endif

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -15,6 +15,7 @@
 #ifndef __LAYER_CONTEXT_H__
 #define __LAYER_CONTEXT_H__
 
+#include <map>
 #include <memory>
 #include <vector>
 

--- a/nntrainer/tensor/q4_0_tensor.cpp
+++ b/nntrainer/tensor/q4_0_tensor.cpp
@@ -102,6 +102,12 @@ void Q4_0_Tensor::initialize() {
   putData();
 }
 
+void Q4_0_Tensor::print(std::ostream &out) const {
+  out << "data addr: " << getData() << '\n';
+  out << dim;
+  out << "[Q4_0 data print skipped]" << std::endl;
+}
+
 QScheme Q4_0_Tensor::q_scheme() const { return QScheme::Q4_0; }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/q4_0_tensor.h
+++ b/nntrainer/tensor/q4_0_tensor.h
@@ -150,9 +150,7 @@ public:
   /**
    * @copydoc Tensor::print()
    */
-  void print(std::ostream &out) const override {
-    throw std::invalid_argument("Q4_0_Tensor::print() is not supported.");
-  }
+  void print(std::ostream &out) const override;
 
   /**
    * @copydoc Tensor::copy()

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -19,6 +19,7 @@
 #include <fp16.h>
 #include <fstream>
 #include <nntrainer_error.h>
+#include <sstream>
 #include <tensor.h>
 #include <tensor_dim.h>
 #include <thread_manager.h>
@@ -1042,6 +1043,9 @@ TEST(nntrainer_Tensor, QTensor_20_p) {
 
   EXPECT_EQ(q4_0_tensor.q_scheme(), nntrainer::QScheme::Q4_0);
   EXPECT_EQ(q4_0_tensor.size(), 1152);
+
+  std::ostringstream oss;
+  EXPECT_NO_THROW(q4_0_tensor.print(oss));
 }
 
 /**


### PR DESCRIPTION
- Enable CausalLM in the Ubuntu Meson CI path.
- Scope the transformer app gate so CI only builds CausalLM, not legacy transformer(llama and pico gpt) apps.

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>