### PR TITLE
[Optimization] bind KV cache placeholders once for TG speed

### DIFF
--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -121,7 +121,11 @@ void CausalLM::allocateAndBindKVCache() {
                       max_timestep,
                       static_cast<unsigned int>(NUM_KEY_VALUE_HEADS),
                       static_cast<unsigned int>(HEAD_DIM), cache_dtype);
+    kv_cache_bound = false;
   }
+
+  if (kv_cache_bound)
+    return;
 
   // Bind each (layer, K|V) buffer into the corresponding input layer
   // declared by Transformer::createKVCachePlaceholders(). The names here
@@ -162,6 +166,8 @@ void CausalLM::allocateAndBindKVCache() {
     kp->setData(kc.getMemoryData(), kc.getOffset(), false);
     vp->setData(vc.getMemoryData(), vc.getOffset(), false);
   }
+
+  kv_cache_bound = true;
 }
 
 void CausalLM::setKVCachePosition(unsigned int pos) {

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -157,6 +157,7 @@ protected:
    *        cache_k_l<i> / cache_v_l<i> via Model::setExternalTensors.
    */
   KVCacheManager kv_cache;
+  bool kv_cache_bound = false; /**< True once KV cache tensors are bound */
 
   /**
    * @brief Allocate kv_cache and bind it to all mha_core layers via


### PR DESCRIPTION
## Summary
- Avoid rebinding external KV cache placeholders on every generated token

## Verification
- Observed about 30% generation TPS improvement in local Windows testing

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>