### PR TITLE
[Optimization] rope caching for optimization

### DIFF
--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -1072,14 +1072,14 @@ void MHACoreLayer::apply_rotary_emb_tensor_v2(nntrainer::Tensor &in,
     std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
 
   if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
-    std::vector<std::vector<float>> *freqs_cos_local = nullptr;
-    std::vector<std::vector<float>> *freqs_sin_local = nullptr;
-    {
+    if (cached_freqs_cos == nullptr || cached_freqs_sin == nullptr) {
       const std::lock_guard<std::mutex> lock(rope_init_mtx);
       precompute_freqs(head_dim, max_position_embeddings, theta, false);
-      freqs_cos_local = freqs_cos;
-      freqs_sin_local = freqs_sin;
+      cached_freqs_cos = freqs_cos;
+      cached_freqs_sin = freqs_sin;
     }
+    std::vector<std::vector<float>> *freqs_cos_local = cached_freqs_cos;
+    std::vector<std::vector<float>> *freqs_sin_local = cached_freqs_sin;
     std::vector<float> *cos_ = nullptr;
     std::vector<float> *sin_ = nullptr;
 
@@ -1125,14 +1125,16 @@ void MHACoreLayer::apply_rotary_emb_tensor_v2(nntrainer::Tensor &in,
     }
   } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-    std::vector<std::vector<_FP16>> *freqs_cos_fp16_local = nullptr;
-    std::vector<std::vector<_FP16>> *freqs_sin_fp16_local = nullptr;
-    {
+    if (cached_freqs_cos_fp16 == nullptr || cached_freqs_sin_fp16 == nullptr) {
       const std::lock_guard<std::mutex> lock(rope_init_mtx);
       precompute_freqs(head_dim, max_position_embeddings, theta, true);
-      freqs_cos_fp16_local = freqs_cos_fp16;
-      freqs_sin_fp16_local = freqs_sin_fp16;
+      cached_freqs_cos_fp16 = freqs_cos_fp16;
+      cached_freqs_sin_fp16 = freqs_sin_fp16;
     }
+    std::vector<std::vector<_FP16>> *freqs_cos_fp16_local =
+      cached_freqs_cos_fp16;
+    std::vector<std::vector<_FP16>> *freqs_sin_fp16_local =
+      cached_freqs_sin_fp16;
     std::vector<_FP16> *cos_ = nullptr;
     std::vector<_FP16> *sin_ = nullptr;
 
@@ -1526,6 +1528,12 @@ void MHACoreLayer::setProperty(const std::vector<std::string> &values) {
 
   auto remain_props = loadProperties(props, mha_core_props);
   LayerImpl::setProperty(remain_props);
+  cached_freqs_cos = nullptr;
+  cached_freqs_sin = nullptr;
+#ifdef ENABLE_FP16
+  cached_freqs_cos_fp16 = nullptr;
+  cached_freqs_sin_fp16 = nullptr;
+#endif
 }
 
 size_t MHACoreLayer::calc_attn_index(size_t i) { return (i * (i + 1)) / 2; };

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -407,9 +407,13 @@ private:
   inline static std::vector<std::vector<float>> *freqs_cos = {};
   inline static std::vector<std::vector<float>> *freqs_sin = {};
   inline static std::vector<float> thetas;
+  std::vector<std::vector<float>> *cached_freqs_cos = {};
+  std::vector<std::vector<float>> *cached_freqs_sin = {};
 #ifdef ENABLE_FP16
   inline static std::vector<std::vector<_FP16>> *freqs_cos_fp16 = {};
   inline static std::vector<std::vector<_FP16>> *freqs_sin_fp16 = {};
+  std::vector<std::vector<_FP16>> *cached_freqs_cos_fp16 = {};
+  std::vector<std::vector<_FP16>> *cached_freqs_sin_fp16 = {};
 #endif
 
   /**


### PR DESCRIPTION
## Summary
- Cache resolved RoPE cos/sin frequency table pointers per MHA layer
- Avoid repeated mutex, cache-key construction, and map lookup on warm decode calls

## Verification
- Observed a small decode TPS improvement(4-6%) in local Windows testing

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>