### PR TITLE
Fix model load crashes on Android

### DIFF
--- a/api/ccapi/src/tensor_api_graph.cpp
+++ b/api/ccapi/src/tensor_api_graph.cpp
@@ -406,8 +406,37 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
     std::string leaf_shape = std::to_string(leaf_info.dim.channel()) + ":" +
                              std::to_string(leaf_info.dim.height()) + ":" +
                              std::to_string(leaf_info.dim.width());
-    auto leaf_layer =
-      createLayer("input", {"name=" + leaf_name, "input_shape=" + leaf_shape});
+    auto dtype_to_str = [](nntrainer::TensorDim::DataType dt) -> const char * {
+      using DT = nntrainer::TensorDim::DataType;
+      switch (dt) {
+      case DT::FP32: return "FP32";
+      case DT::FP16: return "FP16";
+      case DT::QINT4: return "QINT4";
+      case DT::QINT8: return "QINT8";
+      case DT::QINT16: return "QINT16";
+      case DT::UINT4: return "UINT4";
+      case DT::UINT8: return "UINT8";
+      case DT::UINT16: return "UINT16";
+      case DT::Q4_0: return "Q4_0";
+      case DT::Q4_K: return "Q4_K";
+      case DT::Q6_K: return "Q6_K";
+      case DT::BCQ: return "BCQ";
+      default: return "FP32";
+      }
+    };
+    std::vector<std::string> leaf_props = {"name=" + leaf_name,
+                                           "input_shape=" + leaf_shape};
+    // Only emit input_dtype when the leaf tensor explicitly carries a
+    // dtype other than FP32 — the input layer already defaults to the
+    // model's activation dtype, and threading FP32 through redundantly
+    // would shadow that default for callers that intentionally inherit
+    // it (the existing single-input "graph_input" path).
+    if (leaf_info.dim.getDataType() !=
+        nntrainer::TensorDim::DataType::FP32) {
+      leaf_props.push_back(std::string("input_dtype=") +
+                           dtype_to_str(leaf_info.dim.getDataType()));
+    }
+    auto leaf_layer = createLayer("input", leaf_props);
     status = addLayer(std::move(leaf_layer));
     if (status != ML_ERROR_NONE) {
       return status;

--- a/api/ccapi/src/tensor_api_graph.cpp
+++ b/api/ccapi/src/tensor_api_graph.cpp
@@ -409,19 +409,32 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
     auto dtype_to_str = [](nntrainer::TensorDim::DataType dt) -> const char * {
       using DT = nntrainer::TensorDim::DataType;
       switch (dt) {
-      case DT::FP32: return "FP32";
-      case DT::FP16: return "FP16";
-      case DT::QINT4: return "QINT4";
-      case DT::QINT8: return "QINT8";
-      case DT::QINT16: return "QINT16";
-      case DT::UINT4: return "UINT4";
-      case DT::UINT8: return "UINT8";
-      case DT::UINT16: return "UINT16";
-      case DT::Q4_0: return "Q4_0";
-      case DT::Q4_K: return "Q4_K";
-      case DT::Q6_K: return "Q6_K";
-      case DT::BCQ: return "BCQ";
-      default: return "FP32";
+      case DT::FP32:
+        return "FP32";
+      case DT::FP16:
+        return "FP16";
+      case DT::QINT4:
+        return "QINT4";
+      case DT::QINT8:
+        return "QINT8";
+      case DT::QINT16:
+        return "QINT16";
+      case DT::UINT4:
+        return "UINT4";
+      case DT::UINT8:
+        return "UINT8";
+      case DT::UINT16:
+        return "UINT16";
+      case DT::Q4_0:
+        return "Q4_0";
+      case DT::Q4_K:
+        return "Q4_K";
+      case DT::Q6_K:
+        return "Q6_K";
+      case DT::BCQ:
+        return "BCQ";
+      default:
+        return "FP32";
       }
     };
     std::vector<std::string> leaf_props = {"name=" + leaf_name,
@@ -431,8 +444,7 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
     // model's activation dtype, and threading FP32 through redundantly
     // would shadow that default for callers that intentionally inherit
     // it (the existing single-input "graph_input" path).
-    if (leaf_info.dim.getDataType() !=
-        nntrainer::TensorDim::DataType::FP32) {
+    if (leaf_info.dim.getDataType() != nntrainer::TensorDim::DataType::FP32) {
       leaf_props.push_back(std::string("input_dtype=") +
                            dtype_to_str(leaf_info.dim.getDataType()));
     }

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -762,6 +762,40 @@ void NeuralNetwork::load(const std::string &file_path,
       model_file_fd = open(f_path.c_str(), O_RDONLY);
       NNTR_THROW_IF((model_file_fd == -1), std::invalid_argument)
         << "Cannot open file : " << f_path;
+
+      // Map the .bin once and let every worker thread share the same view.
+      // The previous per-thread mmap pattern requested (graph_size * f_size)
+      // worth of virtual address space — e.g. ~100 nodes × ~3 GB for
+      // Qwen3-0.6B = ~300 GB. Linux desktops absorb that via overcommit,
+      // but Android tightens both the per-process virtual-memory limit and
+      // vm.max_map_count, so a fraction of the workers' mmap() calls return
+      // MAP_FAILED. With the call site inside a std::thread, the resulting
+      // throw bubbles to terminate() (the long "mmap failed" wall users see
+      // on-device).
+      //
+      // One mmap, shared read-only, MAP_PRIVATE — workers do not race
+      // because each weight reads from its own pre-assigned file_offset.
+      // POSIX_MADV_DONTNEED can't move here from the worker site safely
+      // (other threads may still be reading their slices), so we drop the
+      // whole region in one shot right before munmap.
+      void *shared_mmap_ptr = MAP_FAILED;
+      size_t shared_mmap_size = 0;
+#if !defined(_WIN32)
+      if (MMAP_READ) {
+        struct stat st {};
+        NNTR_THROW_IF((::fstat(model_file_fd, &st) == -1), std::invalid_argument)
+          << "Cannot get file info (fstat): " << f_path;
+        shared_mmap_size = static_cast<size_t>(st.st_size);
+        shared_mmap_ptr = ::mmap(nullptr, shared_mmap_size, PROT_READ,
+                                 MAP_PRIVATE, model_file_fd, 0);
+        NNTR_THROW_IF((shared_mmap_ptr == MAP_FAILED), std::runtime_error)
+          << "mmap failed for " << f_path << " (" << shared_mmap_size
+          << " bytes)";
+        (void)::posix_madvise(shared_mmap_ptr, shared_mmap_size,
+                              POSIX_MADV_RANDOM);
+      }
+#endif
+
       // std::vector<std::future<void>> futures;
       std::vector<std::thread> threads;
       threads.reserve(model_graph.size());
@@ -804,35 +838,11 @@ void NeuralNetwork::load(const std::string &file_path,
             CloseHandle(hMap);
             CloseHandle(hFile);
 #else
-            // POSIX: map per-task, advise kernel, drop pages, unmap
-            int fd = ::open(f_path.c_str(), O_RDONLY);
-            NNTR_THROW_IF((fd == -1), std::invalid_argument)
-              << "Cannot open file : " << f_path;
-
-            struct stat st {};
-            NNTR_THROW_IF((::fstat(fd, &st) == -1), std::invalid_argument)
-              << "Cannot get file info (fstat): " << f_path;
-
-            size_t f_size = static_cast<size_t>(st.st_size);
-            void *mmap_ptr =
-              ::mmap(nullptr, f_size, PROT_READ, MAP_PRIVATE, fd, 0);
-            ::close(fd); // fd not needed after mmap
-            NNTR_THROW_IF((mmap_ptr == MAP_FAILED), std::runtime_error)
-              << "mmap failed";
-
-            // Hint: many model loads touch scattered regions -> RANDOM helps
-            // reduce readahead
-            (void)::posix_madvise(mmap_ptr, f_size, POSIX_MADV_RANDOM);
-
-            char *view = static_cast<char *>(mmap_ptr);
+            // POSIX: read from the parent-owned shared mmap. No per-thread
+            // mmap/munmap — see the comment on shared_mmap_ptr above.
+            char *view = static_cast<char *>(shared_mmap_ptr);
             node->read(view, false, exec_mode, fsu_mode,
                        std::numeric_limits<size_t>::max(), true, model_file_fd);
-
-            // Early drop: pages no longer needed; helps lower peak RSS during
-            // overlap
-            (void)::posix_madvise(mmap_ptr, f_size, POSIX_MADV_DONTNEED);
-
-            ::munmap(mmap_ptr, f_size);
 #endif
           }
         });
@@ -841,6 +851,14 @@ void NeuralNetwork::load(const std::string &file_path,
         if (t.joinable())
           t.join();
       }
+
+#if !defined(_WIN32)
+      if (shared_mmap_ptr != MAP_FAILED) {
+        (void)::posix_madvise(shared_mmap_ptr, shared_mmap_size,
+                              POSIX_MADV_DONTNEED);
+        ::munmap(shared_mmap_ptr, shared_mmap_size);
+      }
+#endif
     } else {
       for (auto iter = model_graph.cbegin(); iter != model_graph.cend();
            ++iter) {

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -763,18 +763,19 @@ void NeuralNetwork::load(const std::string &file_path,
       NNTR_THROW_IF((model_file_fd == -1), std::invalid_argument)
         << "Cannot open file : " << f_path;
 
-      // Share a single read-only mmap across load workers. Per-worker mmap of the
-      // full weight file can exceed Android's virtual memory or mmap-count limits
-      // for large models.
+      // Share a single read-only mmap across load workers. Per-worker mmap of
+      // the full weight file can exceed Android's virtual memory or mmap-count
+      // limits for large models.
       //
-      // Each worker reads from its own file_offset, so sharing the mapped region is
-      // safe. Drop the region only after all workers have joined.  
+      // Each worker reads from its own file_offset, so sharing the mapped
+      // region is safe. Drop the region only after all workers have joined.
       void *shared_mmap_ptr = MAP_FAILED;
       size_t shared_mmap_size = 0;
 #if !defined(_WIN32)
       if (MMAP_READ) {
         struct stat st {};
-        NNTR_THROW_IF((::fstat(model_file_fd, &st) == -1), std::invalid_argument)
+        NNTR_THROW_IF((::fstat(model_file_fd, &st) == -1),
+                      std::invalid_argument)
           << "Cannot get file info (fstat): " << f_path;
         shared_mmap_size = static_cast<size_t>(st.st_size);
         shared_mmap_ptr = ::mmap(nullptr, shared_mmap_size, PROT_READ,

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -763,28 +763,18 @@ void NeuralNetwork::load(const std::string &file_path,
       NNTR_THROW_IF((model_file_fd == -1), std::invalid_argument)
         << "Cannot open file : " << f_path;
 
-      // Map the .bin once and let every worker thread share the same view.
-      // The previous per-thread mmap pattern requested (graph_size * f_size)
-      // worth of virtual address space — e.g. ~100 nodes × ~3 GB for
-      // Qwen3-0.6B = ~300 GB. Linux desktops absorb that via overcommit,
-      // but Android tightens both the per-process virtual-memory limit and
-      // vm.max_map_count, so a fraction of the workers' mmap() calls return
-      // MAP_FAILED. With the call site inside a std::thread, the resulting
-      // throw bubbles to terminate() (the long "mmap failed" wall users see
-      // on-device).
+      // Share a single read-only mmap across load workers. Per-worker mmap of the
+      // full weight file can exceed Android's virtual memory or mmap-count limits
+      // for large models.
       //
-      // One mmap, shared read-only, MAP_PRIVATE — workers do not race
-      // because each weight reads from its own pre-assigned file_offset.
-      // POSIX_MADV_DONTNEED can't move here from the worker site safely
-      // (other threads may still be reading their slices), so we drop the
-      // whole region in one shot right before munmap.
+      // Each worker reads from its own file_offset, so sharing the mapped region is
+      // safe. Drop the region only after all workers have joined.  
       void *shared_mmap_ptr = MAP_FAILED;
       size_t shared_mmap_size = 0;
 #if !defined(_WIN32)
       if (MMAP_READ) {
         struct stat st {};
-        NNTR_THROW_IF((::fstat(model_file_fd, &st) == -1),
-                      std::invalid_argument)
+        NNTR_THROW_IF((::fstat(model_file_fd, &st) == -1), std::invalid_argument)
           << "Cannot get file info (fstat): " << f_path;
         shared_mmap_size = static_cast<size_t>(st.st_size);
         shared_mmap_ptr = ::mmap(nullptr, shared_mmap_size, PROT_READ,

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -783,7 +783,8 @@ void NeuralNetwork::load(const std::string &file_path,
 #if !defined(_WIN32)
       if (MMAP_READ) {
         struct stat st {};
-        NNTR_THROW_IF((::fstat(model_file_fd, &st) == -1), std::invalid_argument)
+        NNTR_THROW_IF((::fstat(model_file_fd, &st) == -1),
+                      std::invalid_argument)
           << "Cannot get file info (fstat): " << f_path;
         shared_mmap_size = static_cast<size_t>(st.st_size);
         shared_mmap_ptr = ::mmap(nullptr, shared_mmap_size, PROT_READ,


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[api] tensor-api: preserve leaf tensor dtype for auto-created inputs</summary><br />

[[api] tensor-api: preserve leaf tensor dtype for auto-created inputs](https://github.com/nntrainer/nntrainer/commit/7a818e4c0ecf4e3470a05d1e369c7f4858881723) 

This commit preserve leaf tensor dtype for auto-created inputs.
- When Tensor API compile() finds additional leaf tensors, it creates input layers for tem automatically.
- However, the generated input layer only kept the tensor name and shape, dropping the dtype.
- This caused FP16 KV-cache placeholders created from symbolic tensors to be restored as the default dtype(FP32).
- On Android builds with ENABLE_FP16=1, the cache buffer was allocated as FP16 but the synthesized input placeholder became FP32, causing dtype mismatch.

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

</details>



<details><summary>[neuralnet] share a single mmap across model-load workers</summary><br />

[[neuralnet] share a single mmap across model-load workers](https://github.com/nntrainer/nntrainer/commit/0cab25b9cadf095f5cc4357d3e6730de4d0b1f71) 

This commit shares a single mmap across model-load workers.
- Parallel weight loading previously let each worker mmap the full weight file independently.
- For large models, this created many mappings of the same file and could exceed Android's virtual memory or map-count limits, causing mmap failures.
Create a single read-only mmap in the parent thread and shared it with all workers.
- Since each weight already has a fixed file offset, workers can safely read from the shared mapping without synchronization.
Run POSIX_MADV_DONTNEED only after all workers finish, avoiding races with other readers of the shared mapping.

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

</details>

### Summary

Fix two crashes that prevented Q4_0 models (e.g. Qwen3-0.6B) from loading on Android.

### Fixes

#### 1. Share a single mmap across model-load workers 
- Each worker thread was calling `mmap()` on the full `.bin` independently, consuming `graph_size × file_size` of virtual address space (~300 GB for a ~3 GB bin with 100 nodes)
- Fix: map the file once in the parent and share the read-only view across all workers; `munmap` after join

#### 2. Propagate leaf tensor dtype into auto-created input layers 
- With `ENABLE_FP16`, KV cache placeholders synthesized by `compile()` were defaulting to FP32, while `KVCacheManager` allocated FP16,causing `allocateAndBindKVCache: cache placeholder dtype mismatch`.
- Fix: carry `leaf_info.dim.getDataType()` as `input_dtype=` when non-FP32

**Self evaluation:**
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
