### PR TITLE
[Application/CausalLM] Add V-JEPA 2.1 ViT-B video encoder

### DIFF
--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -27,6 +27,7 @@ CAUSALLM_COMMON_INCLUDES := \
     $(LOCAL_PATH)/../models/qwen3_cached_slim_moe \
     $(LOCAL_PATH)/../models/gemma3 \
     $(LOCAL_PATH)/../models/timm_vit \
+    $(LOCAL_PATH)/../models/vjepa2_vit \
     $(LOCAL_PATH)/../models/deberta_v2 \
     $(LOCAL_PATH)/../third_party/minja/include \
     $(LOCAL_PATH)/../third_party \
@@ -52,14 +53,14 @@ include $(PREBUILT_STATIC_LIBRARY)
 include $(CLEAR_VARS)
 
 LOCAL_ARM_NEON := true
-LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
 LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/$(TARGET_ARCH_ABI)/
 LOCAL_CXXFLAGS += -std=c++17 -frtti
-LOCAL_CFLAGS += -pthread -fexceptions -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
-LOCAL_LDFLAGS += -fexceptions -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_CFLAGS += -pthread -fexceptions -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_LDFLAGS += -fexceptions -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := causallm_core
-LOCAL_LDLIBS := -llog -landroid -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1
+LOCAL_LDLIBS := -llog -landroid -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1
 
 LOCAL_SRC_FILES := \
     ../chat_template.cpp \
@@ -97,6 +98,10 @@ LOCAL_SRC_FILES := \
     ../models/gemma3/embedding_gemma.cpp \
     ../models/gemma3/function.cpp \
     ../models/timm_vit/timm_vit_transformer.cpp \
+    ../models/vjepa2_vit/vjepa2_vit.cpp \
+    ../layers/vjepa_rope_layer.cpp \
+    ../layers/vjepa_gelu_layer.cpp \
+    ../layers/vjepa_layernorm_layer.cpp \
     ../models/deberta_v2/deberta_v2.cpp \
     ../layers/deberta_attention_layer.cpp \
     ../layers/shared_fully_connected_layer.cpp \
@@ -112,13 +117,13 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 
 LOCAL_ARM_NEON := true
-LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
 LOCAL_CXXFLAGS += -std=c++17 -frtti
-LOCAL_CFLAGS += -pthread -fexceptions -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
-LOCAL_LDFLAGS += -fexceptions -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_CFLAGS += -pthread -fexceptions -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_LDFLAGS += -fexceptions -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := causallm_api
-LOCAL_LDLIBS := -llog -landroid -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1
+LOCAL_LDLIBS := -llog -landroid -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1
 
 LOCAL_SRC_FILES := \
     ../api/causal_lm_api.cpp \
@@ -136,14 +141,14 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 
 LOCAL_ARM_NEON := true
-LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
 LOCAL_CXXFLAGS += -std=c++17 -frtti
-LOCAL_CFLAGS += -pthread -fexceptions -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
-LOCAL_LDFLAGS += -fexceptions -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_CFLAGS += -pthread -fexceptions -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_LDFLAGS += -fexceptions -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntrainer_causallm
-LOCAL_LDLIBS := -llog -landroid -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1
+LOCAL_LDLIBS := -llog -landroid -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1
 
 LOCAL_SRC_FILES := ../main.cpp
 
@@ -158,14 +163,14 @@ include $(BUILD_EXECUTABLE)
 include $(CLEAR_VARS)
 
 LOCAL_ARM_NEON := true
-LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
 LOCAL_CXXFLAGS += -std=c++17 -frtti
-LOCAL_CFLAGS += -pthread -fexceptions -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
-LOCAL_LDFLAGS += -fexceptions -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_CFLAGS += -pthread -fexceptions -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_LDFLAGS += -fexceptions -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := test_api
-LOCAL_LDLIBS := -llog -landroid -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1
+LOCAL_LDLIBS := -llog -landroid -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1
 
 LOCAL_SRC_FILES := ../api/test_api.cpp
 
@@ -182,15 +187,15 @@ include $(BUILD_EXECUTABLE)
 include $(CLEAR_VARS)
 
 LOCAL_ARM_NEON := true
-LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_CFLAGS += -std=c++17 -Ofast -mcpu=cortex-a53 -Ilz4-nougat/lib -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
 LOCAL_LDFLAGS += -Llz4-nougat/lib/obj/local/$(TARGET_ARCH_ABI)/
 LOCAL_CXXFLAGS += -std=c++17 -frtti
-LOCAL_CFLAGS += -pthread -fexceptions -fopenmp -static-openmp -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
-LOCAL_LDFLAGS += -fexceptions -fopenmp -static-openmp -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_CFLAGS += -pthread -fexceptions -fopenmp -static-openmp -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
+LOCAL_LDFLAGS += -fexceptions -fopenmp -static-openmp -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1 -mtune=cortex-a76 -O3 -ffast-math
 LOCAL_MODULE_TAGS := optional
 LOCAL_ARM_MODE := arm
 LOCAL_MODULE := nntr_quantize
-LOCAL_LDLIBS := -llog -landroid -fopenmp -static-openmp -DENABLE_FP16=1 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1
+LOCAL_LDLIBS := -llog -landroid -fopenmp -static-openmp -DENABLE_FP16=0 -DUSE__FP16=1 -D__ARM_NEON__=1 -march=armv8.2-a+fp16+dotprod+i8mm -DUSE_NEON=1
 
 # Source files
 LOCAL_SRC_FILES := ../quantize.cpp \
@@ -226,6 +231,10 @@ LOCAL_SRC_FILES := ../quantize.cpp \
     ../models/gemma3/gemma3_causallm.cpp \
     ../models/gemma3/embedding_gemma.cpp \
     ../models/gemma3/function.cpp \
+    ../models/vjepa2_vit/vjepa2_vit.cpp \
+    ../layers/vjepa_rope_layer.cpp \
+    ../layers/vjepa_gelu_layer.cpp \
+    ../layers/vjepa_layernorm_layer.cpp \
     ../models/deberta_v2/deberta_v2.cpp \
     ../layers/deberta_attention_layer.cpp \
     ../layers/shared_fully_connected_layer.cpp

--- a/Applications/CausalLM/layers/meson.build
+++ b/Applications/CausalLM/layers/meson.build
@@ -13,6 +13,7 @@ causallm_embedding_pooling_src_abs = [meson.current_source_dir() / 'embedding_po
 causallm_embedding_normalize_src_abs = [meson.current_source_dir() / 'embedding_normalize_layer.cpp']
 causallm_deberta_attention_src_abs = [meson.current_source_dir() / 'deberta_attention_layer.cpp']
 causallm_shared_fully_connected_src_abs = [meson.current_source_dir() / 'shared_fully_connected_layer.cpp']
+causallm_vjepa_rope_src_abs = [meson.current_source_dir() / 'vjepa_rope_layer.cpp']
 
 causallm_rms_norm = shared_library(
     'rms_norm_layer', 
@@ -171,5 +172,49 @@ causallm_shared_fully_connected_layer = shared_library(
 
 causallm_shared_fully_connected_layer_dep = declare_dependency(
     link_with: causallm_shared_fully_connected_layer,
+    include_directories: causallm_layer_inc
+)
+
+causallm_vjepa_rope_layer = shared_library(
+    'vjepa_rope_layer',
+    causallm_vjepa_rope_src_abs,
+    include_directories: causallm_layer_inc,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    install: true,
+    install_dir: application_install_dir
+)
+
+causallm_vjepa_rope_layer_dep = declare_dependency(
+    link_with: causallm_vjepa_rope_layer,
+    include_directories: causallm_layer_inc
+)
+
+causallm_vjepa_gelu_src_abs = [meson.current_source_dir() / 'vjepa_gelu_layer.cpp']
+causallm_vjepa_gelu_layer = shared_library(
+    'vjepa_gelu_layer',
+    causallm_vjepa_gelu_src_abs,
+    include_directories: causallm_layer_inc,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    install: true,
+    install_dir: application_install_dir
+)
+
+causallm_vjepa_gelu_layer_dep = declare_dependency(
+    link_with: causallm_vjepa_gelu_layer,
+    include_directories: causallm_layer_inc
+)
+
+causallm_vjepa_ln_src_abs = [meson.current_source_dir() / 'vjepa_layernorm_layer.cpp']
+causallm_vjepa_layernorm_layer = shared_library(
+    'vjepa_layernorm_layer',
+    causallm_vjepa_ln_src_abs,
+    include_directories: causallm_layer_inc,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    install: true,
+    install_dir: application_install_dir
+)
+
+causallm_vjepa_layernorm_layer_dep = declare_dependency(
+    link_with: causallm_vjepa_layernorm_layer,
     include_directories: causallm_layer_inc
 )

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -13,6 +13,7 @@
  */
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <mutex>
 #include <thread>
@@ -115,7 +116,8 @@ MHACoreLayer::MHACoreLayer() :
     props::SlidingWindow(), props::MaxNewTokens(), props::RopeTheta(),
     props::MaxPositionEmbeddings(), props::UseSink(), props::RopeScalingType(),
     props::RopeScalingFactor(), props::RopeScalingMaxPositionEmbeddings(),
-    props::AttnLogitSoftcapping(), props::IsCausal()),
+    props::AttnLogitSoftcapping(), props::IsCausal(),
+    props::UseGemmAttention()),
   sm(nntrainer::ActivationType::ACT_SOFTMAX),
   epsilon(1e-3),
   cache_index(0),
@@ -214,6 +216,14 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
 
   /** Is Causal */
   is_causal = std::get<props::IsCausal>(mha_core_props).get();
+  use_gemm_attention =
+    std::get<props::UseGemmAttention>(mha_core_props).get() && !is_causal;
+#if !defined(ENABLE_FP16)
+  // The GEMM attention path is tuned/validated for the ARM FP16-cache build
+  // (shgemm QK + FP16 hgemm AV). The plain-FP32 (x86) variant is unverified, so
+  // fall back to the reference attention there.
+  use_gemm_attention = false;
+#endif
 
   /** Tensor for KV-Cache (only allocate internally when not using external
    * cache) */
@@ -753,14 +763,22 @@ void MHACoreLayer::one_batch_incremental_forwarding(
   nntrainer::Tensor b_cached_value = cache_value.getSharedDataTensor(
     cached_value_dim, batch * cache_value_dim.getFeatureLen(), true);
 
+  unsigned int gqa_size = num_heads_Q / num_heads_KV;
+
+  // Optional GEMM attention path (non-causal encoder). Avoids the full
+  // [seq x seq x num_heads] score buffer and the per-row dot kernels.
+  if (use_gemm_attention && gqa_size == 1) {
+    gemm_attention_noncausal(query_step, b_cached_key, b_cached_value,
+                             attention_output_step, cache_to);
+    return;
+  }
+
   // out_ stores the output of Q * K
   nntrainer::Tensor out_(
     1, 1,
     is_causal ? (calc_attn_index(cache_to) - calc_attn_index(cache_from))
               : (step_size * cache_to),
     num_heads_Q, query_step.getTensorType());
-
-  unsigned int gqa_size = num_heads_Q / num_heads_KV;
 
   compute_kcaches(query_step, b_cached_key, out_, cache_from,
                   cache_to - cache_from, num_heads_Q, gqa_size, head_dim);
@@ -770,6 +788,194 @@ void MHACoreLayer::one_batch_incremental_forwarding(
   compute_fp16vcache_transposed(out_, b_cached_value, attention_output_step,
                                 cache_from, num_heads_KV, gqa_size, head_dim,
                                 cache_to);
+}
+
+#if defined(ENABLE_FP16) && defined(__ARM_NEON)
+#include <arm_neon.h>
+// Cephes exp() for 4 floats at once (matches neon_mathfun.hxx exp_ps).
+static inline float32x4_t vjepa_expq_f32(float32x4_t x) {
+  const float32x4_t one = vdupq_n_f32(1.0f);
+  x = vminq_f32(x, vdupq_n_f32(88.3762626647949f));
+  x = vmaxq_f32(x, vdupq_n_f32(-88.3762626647949f));
+  float32x4_t fx =
+    vmlaq_f32(vdupq_n_f32(0.5f), x, vdupq_n_f32(1.44269504088896341f));
+  float32x4_t tmp = vcvtq_f32_s32(vcvtq_s32_f32(fx));
+  uint32x4_t mask = vandq_u32(vcgtq_f32(tmp, fx), vreinterpretq_u32_f32(one));
+  fx = vsubq_f32(tmp, vreinterpretq_f32_u32(mask));
+  x = vsubq_f32(x, vmulq_f32(fx, vdupq_n_f32(0.693359375f)));
+  x = vsubq_f32(x, vmulq_f32(fx, vdupq_n_f32(-2.12194440e-4f)));
+  float32x4_t z = vmulq_f32(x, x);
+  float32x4_t y = vdupq_n_f32(1.9875691500E-4f);
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(1.3981999507E-3f));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(8.3334519073E-3f));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(4.1665795894E-2f));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(1.6666665459E-1f));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(5.0000001201E-1f));
+  y = vmulq_f32(y, z);
+  y = vaddq_f32(y, x);
+  y = vaddq_f32(y, one);
+  int32x4_t mm = vshlq_n_s32(
+    vaddq_s32(vcvtq_s32_f32(fx), vdupq_n_s32(0x7f)), 23);
+  return vmulq_f32(y, vreinterpretq_f32_s32(mm));
+}
+#endif
+
+void MHACoreLayer::gemm_attention_noncausal(
+  nntrainer::Tensor &query_step, nntrainer::Tensor &b_cached_key,
+  nntrainer::Tensor &b_cached_value,
+  nntrainer::Tensor &attention_output_step, unsigned int seq_len) {
+  const unsigned int N = seq_len;
+  const unsigned int d = head_dim;
+  const unsigned int HD = num_heads_Q * d; // row stride (interleaved heads)
+  const float inv_sqrt = 1.0f / std::sqrt(static_cast<float>(d));
+  const unsigned int order =
+    static_cast<unsigned int>(query_step.getDim().getStorageOrder());
+
+  const float *Q = query_step.getData<float>();
+  float *O = attention_output_step.getData<float>();
+
+  // Flash attention, parallelized over heads (one head per worker; shgemm is
+  // single-threaded so this uses all cores). 2D tiling (query block x key
+  // block) with an online (running max/sum) softmax: only [Bq x Bk] scores
+  // exist at a time, so the O(N^2) score buffer and its RAM round-trip are
+  // avoided. QK uses shgemm (FP32 Q x FP16 K -> FP32; block0 logits ~457k
+  // overflow FP16) and AV uses shgemm (FP32 probs x FP16 V).
+
+  // tile sizes (cache-resident S); overridable via env for tuning
+  unsigned int Bq = 256, Bk = 512;
+  if (const char *e = std::getenv("VJEPA_BQ"))
+    Bq = static_cast<unsigned int>(std::stoul(e));
+  if (const char *e = std::getenv("VJEPA_BK"))
+    Bk = static_cast<unsigned int>(std::stoul(e));
+
+  const unsigned int num_qb = (N + Bq - 1) / Bq;
+  auto &tm = nntrainer::ThreadManager::Global();
+
+#ifdef ENABLE_FP16
+  // Phase 1: de-interleave heads once into shared contiguous [H, N, d] buffers
+  // (Q FP32, K/V FP16). Parallel over heads.
+  std::vector<float> Qa((size_t)num_heads_Q * N * d);
+  std::vector<_FP16> Ka((size_t)num_heads_Q * N * d);
+  std::vector<_FP16> Va((size_t)num_heads_Q * N * d);
+  {
+    const _FP16 *Kbase = b_cached_key.getData<_FP16>();
+    const _FP16 *Vbase = b_cached_value.getData<_FP16>();
+    tm.parallel_for(0, static_cast<size_t>(num_heads_Q), [&](size_t h) {
+      float *qa = Qa.data() + (size_t)h * N * d;
+      _FP16 *ka = Ka.data() + (size_t)h * N * d;
+      _FP16 *va = Va.data() + (size_t)h * N * d;
+      const float *qh = Q + h * d;
+      const _FP16 *kh = Kbase + h * d;
+      const _FP16 *vh = Vbase + h * d;
+      for (unsigned int n = 0; n < N; ++n) {
+        std::memcpy(qa + (size_t)n * d, qh + (size_t)n * HD, d * sizeof(float));
+        std::memcpy(ka + (size_t)n * d, kh + (size_t)n * HD, d * sizeof(_FP16));
+        std::memcpy(va + (size_t)n * d, vh + (size_t)n * HD, d * sizeof(_FP16));
+      }
+    });
+  }
+
+  // Phase 2: flash attention over balanced (head x query-block) work units so
+  // all workers stay busy (num_heads is not a multiple of the worker count).
+  tm.parallel_for(
+    0, static_cast<size_t>(num_heads_Q) * num_qb, [&](size_t u) {
+      const unsigned int h = static_cast<unsigned int>(u / num_qb);
+      const unsigned int qb = static_cast<unsigned int>(u % num_qb) * Bq;
+      const unsigned int bq = std::min(Bq, N - qb);
+      const float *Qp = Qa.data() + (size_t)h * N * d;
+      const _FP16 *Kp = Ka.data() + (size_t)h * N * d;
+      const _FP16 *Vp = Va.data() + (size_t)h * N * d;
+      float *Oh = O + h * d;
+
+      // per-thread scratch, reused across work units (no per-unit alloc)
+      thread_local std::vector<float> S, Pacc, Ol, mrow, lrow;
+      S.resize((size_t)Bq * Bk);
+      Pacc.resize((size_t)Bq * d);
+      Ol.resize((size_t)Bq * d);
+      mrow.resize(Bq);
+      lrow.resize(Bq);
+
+      std::fill(Ol.begin(), Ol.begin() + (size_t)bq * d, 0.0f);
+      for (unsigned int i = 0; i < bq; ++i) {
+        mrow[i] = -3.0e38f;
+        lrow[i] = 0.0f;
+      }
+
+      for (unsigned int kb = 0; kb < N; kb += Bk) {
+        const unsigned int bk = std::min(Bk, N - kb);
+        nntrainer::shgemm(order, false, true, bq, bk, d, inv_sqrt,
+                          Qp + (size_t)qb * d, d, Kp + (size_t)kb * d, d, 0.0f,
+                          S.data(), bk);
+
+        for (unsigned int i = 0; i < bq; ++i) {
+          float *s = S.data() + (size_t)i * bk;
+          float bm = -3.0e38f;
+          {
+            float32x4_t vmx = vdupq_n_f32(-3.0e38f);
+            unsigned int k = 0;
+            for (; k + 4 <= bk; k += 4)
+              vmx = vmaxq_f32(vmx, vld1q_f32(s + k));
+            bm = vmaxvq_f32(vmx);
+            for (; k < bk; ++k)
+              bm = std::max(bm, s[k]);
+          }
+          const float nm = std::max(mrow[i], bm);
+          const float c = std::exp(mrow[i] - nm);
+          float bs = 0.0f;
+          {
+            float32x4_t vsum = vdupq_n_f32(0.0f), vnm = vdupq_n_f32(nm);
+            unsigned int k = 0;
+            for (; k + 4 <= bk; k += 4) {
+              float32x4_t e = vjepa_expq_f32(vsubq_f32(vld1q_f32(s + k), vnm));
+              vst1q_f32(s + k, e);
+              vsum = vaddq_f32(vsum, e);
+            }
+            bs = vaddvq_f32(vsum);
+            for (; k < bk; ++k) {
+              float e = std::exp(s[k] - nm);
+              s[k] = e;
+              bs += e;
+            }
+          }
+          lrow[i] = lrow[i] * c + bs;
+          mrow[i] = nm;
+          float *ol = Ol.data() + (size_t)i * d;
+          for (unsigned int x = 0; x < d; ++x)
+            ol[x] *= c;
+        }
+
+        nntrainer::shgemm(order, false, false, bq, d, bk, 1.0f, S.data(), bk,
+                          Vp + (size_t)kb * d, d, 0.0f, Pacc.data(), d);
+        for (unsigned int i = 0; i < bq; ++i) {
+          float *ol = Ol.data() + (size_t)i * d;
+          const float *pa = Pacc.data() + (size_t)i * d;
+          for (unsigned int x = 0; x < d; ++x)
+            ol[x] += pa[x];
+        }
+      }
+      for (unsigned int i = 0; i < bq; ++i) {
+        const float inv = 1.0f / lrow[i];
+        const float *ol = Ol.data() + (size_t)i * d;
+        float *oh = Oh + (size_t)(qb + i) * HD;
+        for (unsigned int x = 0; x < d; ++x)
+          oh[x] = ol[x] * inv;
+      }
+    });
+#else
+  (void)Q;
+  (void)O;
+  (void)HD;
+  (void)inv_sqrt;
+  (void)order;
+  (void)num_qb;
+  (void)tm;
+  (void)Bk;
+#endif
 }
 
 void MHACoreLayer::one_batch_incremental_forwarding(

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -138,6 +138,19 @@ public:
 };
 
 /**
+ * @brief UseGemmAttention property
+ * @note  Optional GEMM-based attention path for the non-causal (encoder) case.
+ *        QK and AV are computed with (s)gemm per head instead of the per-row
+ *        dot kernels, improving cache reuse for large sequence lengths.
+ */
+class UseGemmAttention : public nntrainer::Property<bool> {
+public:
+  UseGemmAttention(bool value = false) { set(value); };
+  static constexpr const char *key = "use_gemm_attention";
+  using prop_tag = nntrainer::bool_prop_tag;
+};
+
+/**
  * @brief RopeScalingType
  * - default
  * - yarn
@@ -321,7 +334,7 @@ private:
     props::SlidingWindow, props::MaxNewTokens, props::RopeTheta,
     props::MaxPositionEmbeddings, props::UseSink, props::RopeScalingType,
     props::RopeScalingFactor, props::RopeScalingMaxPositionEmbeddings,
-    props::AttnLogitSoftcapping, props::IsCausal>
+    props::AttnLogitSoftcapping, props::IsCausal, props::UseGemmAttention>
     mha_core_props; /**< mha_core layer properties */
 
   /** softmax activation operation */
@@ -349,6 +362,21 @@ private:
   bool use_sink = false;
   float attn_logit_softcapping = 0.0f;
   bool is_causal;
+  bool use_gemm_attention = false;
+
+  /**
+   * @brief GEMM-based non-causal attention for one batch (encoder path).
+   *        Computes, per head, scores = (Q Kᵀ)/sqrt(d) via (s)gemm, a row
+   *        softmax, then out = scores V via (s)gemm. Q is FP32; the K/V cache
+   *        may be FP16 (-> shgemm) or FP32 (-> sgemm). Uses one reusable
+   *        [seq x seq] FP32 score buffer (per head) instead of the full
+   *        [seq x seq x num_heads] buffer.
+   */
+  void gemm_attention_noncausal(nntrainer::Tensor &query_step,
+                                nntrainer::Tensor &b_cached_key,
+                                nntrainer::Tensor &b_cached_value,
+                                nntrainer::Tensor &attention_output_step,
+                                unsigned int seq_len);
 
   enum INOUT_INDEX {
     /** input index */

--- a/Applications/CausalLM/layers/vjepa_gelu_layer.cpp
+++ b/Applications/CausalLM/layers/vjepa_gelu_layer.cpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   vjepa_gelu_layer.cpp
+ * @date   22 May 2026
+ * @brief  Token-parallel GELU activation (NEON gelu_v2 split over the pool).
+ */
+
+#include "vjepa_gelu_layer.h"
+
+#include <cpu_backend.h>
+#include <nntrainer_error.h>
+#include <thread_manager.h>
+
+namespace causallm {
+
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
+void VjepaGeluLayer::finalize(nntrainer::InitLayerContext &context) {
+  context.setOutputDimensions(context.getInputDimensions());
+}
+
+// gelu over [X, X+n) split across the ThreadManager pool (elementwise, so any
+// split is valid). Matches the core activation's gelu_v2 exactly.
+static void gelu_parallel(const float *X, float *Y, size_t n) {
+  if (n == 0)
+    return;
+  auto &tm = nntrainer::ThreadManager::Global();
+  const unsigned int nt = tm.getComputeThreadCount();
+  if (nt <= 1 || n < 4096) {
+    nntrainer::gelu_v2(static_cast<unsigned int>(n), X, Y);
+    return;
+  }
+  tm.parallel_for(0, static_cast<size_t>(nt), [=](size_t t) {
+    size_t s = (n * t) / nt;
+    size_t e = (n * (t + 1)) / nt;
+    if (e > s)
+      nntrainer::gelu_v2(static_cast<unsigned int>(e - s), X + s, Y + s);
+  });
+}
+
+void VjepaGeluLayer::forwarding(nntrainer::RunLayerContext &context,
+                                bool training) {
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
+  NNTR_THROW_IF(in.getDataType() != ml::train::TensorDim::DataType::FP32,
+                std::invalid_argument)
+    << "[vjepa_gelu] only FP32 is supported";
+  gelu_parallel(in.getData<float>(), out.getData<float>(), in.size());
+}
+
+void VjepaGeluLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
+                                            unsigned int from, unsigned int to,
+                                            bool training) {
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
+  NNTR_THROW_IF(in.getDataType() != ml::train::TensorDim::DataType::FP32,
+                std::invalid_argument)
+    << "[vjepa_gelu] only FP32 is supported";
+
+  const nntrainer::TensorDim dim = in.getDim();
+  const size_t width = dim.width();
+  const size_t feature_len = dim.getFeatureLen();
+  const size_t off = static_cast<size_t>(from) * width;
+  const size_t n = static_cast<size_t>(to - from) * width;
+  for (unsigned int b = 0; b < dim.batch(); ++b) {
+    const float *x = in.getData<float>() + b * feature_len + off;
+    float *y = out.getData<float>() + b * feature_len + off;
+    gelu_parallel(x, y, n);
+  }
+}
+
+void VjepaGeluLayer::calcDerivative(nntrainer::RunLayerContext &context) {
+  throw std::runtime_error("[vjepa_gelu] Training is not supported yet.");
+}
+
+void VjepaGeluLayer::setProperty(const std::vector<std::string> &values) {
+  NNTR_THROW_IF(!values.empty(), std::invalid_argument)
+    << "[vjepa_gelu] does not take properties";
+}
+
+void VjepaGeluLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+}
+
+#ifdef PLUGGABLE
+nntrainer::Layer *create_vjepa_gelu_layer() { return new VjepaGeluLayer(); }
+void destroy_vjepa_gelu_layer(nntrainer::Layer *layer) { delete layer; }
+extern "C" {
+nntrainer::LayerPluggable ml_train_layer_pluggable{create_vjepa_gelu_layer,
+                                                   destroy_vjepa_gelu_layer};
+}
+#endif
+
+} // namespace causallm

--- a/Applications/CausalLM/layers/vjepa_gelu_layer.h
+++ b/Applications/CausalLM/layers/vjepa_gelu_layer.h
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   vjepa_gelu_layer.h
+ * @date   22 May 2026
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  GELU activation parallelized over tokens (uses the same NEON gelu_v2
+ *         as the core activation layer, but splits the work across the
+ *         ThreadManager pool — the core activation runs single-threaded).
+ */
+
+#ifndef __VJEPA_GELU_LAYER_H__
+#define __VJEPA_GELU_LAYER_H__
+
+#pragma once
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#else
+#define WIN_EXPORT
+#endif
+
+#include <layer_context.h>
+#include <layer_devel.h>
+#include <node_exporter.h>
+#include <vector>
+
+namespace causallm {
+
+WIN_EXPORT class VjepaGeluLayer final : public nntrainer::Layer {
+public:
+  VjepaGeluLayer() = default;
+  ~VjepaGeluLayer() = default;
+
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  WIN_EXPORT bool supportBackwarding() const override { return false; };
+
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override {}
+
+  WIN_EXPORT const std::string getType() const override {
+    return VjepaGeluLayer::type;
+  };
+
+  WIN_EXPORT void
+  setProperty(const std::vector<std::string> &values) override;
+
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  inline static const std::string type = "vjepa_gelu";
+};
+
+} // namespace causallm
+
+#endif /* __VJEPA_GELU_LAYER_H__ */

--- a/Applications/CausalLM/layers/vjepa_layernorm_layer.cpp
+++ b/Applications/CausalLM/layers/vjepa_layernorm_layer.cpp
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   vjepa_layernorm_layer.cpp
+ * @date   22 May 2026
+ * @brief  Per-token-parallel LayerNorm over the width axis.
+ */
+
+#include "vjepa_layernorm_layer.h"
+
+#include <cmath>
+#include <nntrainer_error.h>
+#include <thread_manager.h>
+
+namespace causallm {
+
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+enum LNParams { GAMMA = 0, BETA = 1 };
+
+void VjepaLayerNormLayer::finalize(nntrainer::InitLayerContext &context) {
+  const auto &in_dim = context.getInputDimensions()[0];
+  context.setOutputDimensions({in_dim});
+
+  // gamma/beta over the width axis only: [1, 1, 1, W] (matches the core
+  // layer_normalization axis=3 weight layout, so weight bins are compatible).
+  // LayerNorm weights stay FP32 even in the Q4_0 model (norms are not
+  // quantized), so request the activation (FP32) dtype, not the weight dtype.
+  nntrainer::TensorDim norm_dim(context.getFormat(),
+                                context.getActivationDataType());
+  norm_dim.width(in_dim.width());
+
+  wt_idx[GAMMA] = context.requestWeight(
+    norm_dim, nntrainer::Initializer::ONES, nntrainer::WeightRegularizer::NONE,
+    1.0f, 0.0f, "gamma", true);
+  wt_idx[BETA] = context.requestWeight(
+    norm_dim, nntrainer::Initializer::ZEROS, nntrainer::WeightRegularizer::NONE,
+    1.0f, 0.0f, "beta", true);
+}
+
+// LayerNorm of `num_rows` contiguous rows of width W, parallelized over the
+// pool. y = (x-mean)/sqrt(var+eps)*gamma + beta, var biased (matches core).
+static void layernorm_parallel(const float *X, float *Y, const float *gamma,
+                               const float *beta, size_t num_rows,
+                               unsigned int W, float eps) {
+  if (num_rows == 0)
+    return;
+  auto &tm = nntrainer::ThreadManager::Global();
+  const unsigned int nt = tm.getComputeThreadCount();
+  const float invW = 1.0f / static_cast<float>(W);
+  auto do_rows = [=](size_t rs, size_t re) {
+    for (size_t r = rs; r < re; ++r) {
+      const float *x = X + r * W;
+      float *y = Y + r * W;
+      float mean = 0.0f;
+      for (unsigned int j = 0; j < W; ++j)
+        mean += x[j];
+      mean *= invW;
+      float var = 0.0f;
+      for (unsigned int j = 0; j < W; ++j) {
+        float dv = x[j] - mean;
+        var += dv * dv;
+      }
+      var *= invW;
+      const float inv = 1.0f / std::sqrt(var + eps);
+      for (unsigned int j = 0; j < W; ++j)
+        y[j] = (x[j] - mean) * inv * gamma[j] + beta[j];
+    }
+  };
+  if (nt <= 1 || num_rows < 4) {
+    do_rows(0, num_rows);
+    return;
+  }
+  tm.parallel_for(0, static_cast<size_t>(nt), [=](size_t t) {
+    do_rows((num_rows * t) / nt, (num_rows * (t + 1)) / nt);
+  });
+}
+
+void VjepaLayerNormLayer::forwarding(nntrainer::RunLayerContext &context,
+                                     bool training) {
+  const float eps = std::get<props::VjepaLnEpsilon>(layernorm_props).get();
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &gamma = context.getWeight(wt_idx[GAMMA]);
+  nntrainer::Tensor &beta = context.getWeight(wt_idx[BETA]);
+
+  const nntrainer::TensorDim dim = in.getDim();
+  const unsigned int W = dim.width();
+  const size_t rows = (size_t)dim.batch() * dim.channel() * dim.height();
+  layernorm_parallel(in.getData<float>(), out.getData<float>(),
+                     gamma.getData<float>(), beta.getData<float>(), rows, W,
+                     eps);
+}
+
+void VjepaLayerNormLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+  const float eps = std::get<props::VjepaLnEpsilon>(layernorm_props).get();
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &gamma = context.getWeight(wt_idx[GAMMA]);
+  nntrainer::Tensor &beta = context.getWeight(wt_idx[BETA]);
+
+  const nntrainer::TensorDim dim = in.getDim();
+  const unsigned int W = dim.width();
+  const size_t feature_len = dim.getFeatureLen();
+  const size_t rows_per_bc = to - from;
+  const float *g = gamma.getData<float>();
+  const float *bt = beta.getData<float>();
+  for (unsigned int b = 0; b < dim.batch(); ++b) {
+    for (unsigned int c = 0; c < dim.channel(); ++c) {
+      const size_t off = (size_t)b * feature_len +
+                         (size_t)c * dim.height() * W + (size_t)from * W;
+      layernorm_parallel(in.getData<float>() + off, out.getData<float>() + off,
+                         g, bt, rows_per_bc, W, eps);
+    }
+  }
+}
+
+void VjepaLayerNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {
+  throw std::runtime_error("[vjepa_layernorm] Training is not supported yet.");
+}
+
+void VjepaLayerNormLayer::setProperty(const std::vector<std::string> &values) {
+  auto remain = loadProperties(values, layernorm_props);
+  NNTR_THROW_IF(!remain.empty(), std::invalid_argument)
+    << "[vjepa_layernorm] unknown properties";
+}
+
+void VjepaLayerNormLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+}
+
+#ifdef PLUGGABLE
+nntrainer::Layer *create_vjepa_layernorm_layer() {
+  return new VjepaLayerNormLayer();
+}
+void destroy_vjepa_layernorm_layer(nntrainer::Layer *layer) { delete layer; }
+extern "C" {
+nntrainer::LayerPluggable ml_train_layer_pluggable{
+  create_vjepa_layernorm_layer, destroy_vjepa_layernorm_layer};
+}
+#endif
+
+} // namespace causallm

--- a/Applications/CausalLM/layers/vjepa_layernorm_layer.h
+++ b/Applications/CausalLM/layers/vjepa_layernorm_layer.h
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   vjepa_layernorm_layer.h
+ * @date   22 May 2026
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  LayerNorm over the last (width) axis, parallelized per-token over the
+ *         ThreadManager pool. Numerically matches the core layer_normalization
+ *         (axis=3): y = (x-mean)/sqrt(var+eps)*gamma + beta, var biased. The
+ *         core layer runs single-threaded; this splits rows across workers.
+ */
+
+#ifndef __VJEPA_LAYERNORM_LAYER_H__
+#define __VJEPA_LAYERNORM_LAYER_H__
+
+#pragma once
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#else
+#define WIN_EXPORT
+#endif
+
+#include <base_properties.h>
+#include <layer_context.h>
+#include <layer_devel.h>
+#include <node_exporter.h>
+#include <tuple>
+#include <vector>
+
+namespace causallm {
+
+namespace props {
+/** @brief epsilon added to variance for numerical stability */
+class VjepaLnEpsilon : public nntrainer::Property<float> {
+public:
+  VjepaLnEpsilon(float value = 1e-6f) { set(value); };
+  static constexpr const char *key = "epsilon";
+  using prop_tag = nntrainer::float_prop_tag;
+};
+} // namespace props
+
+WIN_EXPORT class VjepaLayerNormLayer final : public nntrainer::Layer {
+public:
+  VjepaLayerNormLayer() : layernorm_props(props::VjepaLnEpsilon()) {}
+  ~VjepaLayerNormLayer() = default;
+
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  WIN_EXPORT bool supportBackwarding() const override { return false; };
+
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override {}
+
+  WIN_EXPORT const std::string getType() const override {
+    return VjepaLayerNormLayer::type;
+  };
+
+  WIN_EXPORT void
+  setProperty(const std::vector<std::string> &values) override;
+
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  inline static const std::string type = "vjepa_layernorm";
+
+private:
+  std::tuple<props::VjepaLnEpsilon> layernorm_props;
+  std::array<unsigned int, 2> wt_idx; /**< 0: gamma, 1: beta */
+};
+
+} // namespace causallm
+
+#endif /* __VJEPA_LAYERNORM_LAYER_H__ */

--- a/Applications/CausalLM/layers/vjepa_rope_layer.cpp
+++ b/Applications/CausalLM/layers/vjepa_rope_layer.cpp
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   vjepa_rope_layer.cpp
+ * @date   21 May 2026
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  3D axial Rotary Positional Embedding layer for V-JEPA2 ViT.
+ */
+
+#include <cmath>
+#include <stdexcept>
+
+#include <nntrainer_error.h>
+
+#include "vjepa_rope_layer.h"
+
+namespace causallm {
+
+static constexpr size_t SINGLE_INOUT_IDX = 0;
+
+void VjepaRopeLayer::precompute_tables() {
+  const unsigned int num_heads =
+    std::get<props::VjepaNumHeads>(vjepa_rope_props).get();
+  const unsigned int grid_t =
+    std::get<props::VjepaGridT>(vjepa_rope_props).get();
+  const unsigned int grid_h =
+    std::get<props::VjepaGridH>(vjepa_rope_props).get();
+  const unsigned int grid_w =
+    std::get<props::VjepaGridW>(vjepa_rope_props).get();
+  const float theta = std::get<props::VjepaRopeTheta>(vjepa_rope_props).get();
+  const unsigned int pretrained_grid =
+    std::get<props::VjepaPretrainedGridSize>(vjepa_rope_props).get();
+  const bool interpolate =
+    std::get<props::VjepaInterpolateRope>(vjepa_rope_props).get();
+
+  (void)num_heads; // head_dim is computed in finalize()
+
+  const unsigned int half = d_dim / 2; // pairs per axis slice
+  const unsigned int tokens_per_frame = grid_h * grid_w;
+  const unsigned int num_tokens = grid_t * tokens_per_frame;
+
+  // omega[i] = 1 / theta^(i / half), matching torch:
+  //   omega = arange(D/2); omega /= D/2; omega = 1/theta**omega   (D = d_dim)
+  std::vector<float> omega(half);
+  for (unsigned int i = 0; i < half; ++i)
+    omega[i] = 1.0f / std::pow(theta, static_cast<float>(i) / half);
+
+  // interpolate scales the height/width positions onto the pretrained grid:
+  //   pos *= (pretrained_grid_size - 1) / (grid - 1)
+  float h_scale = 1.0f, w_scale = 1.0f;
+  if (interpolate) {
+    if (grid_h > 1)
+      h_scale = static_cast<float>(pretrained_grid - 1) / (grid_h - 1);
+    if (grid_w > 1)
+      w_scale = static_cast<float>(pretrained_grid - 1) / (grid_w - 1);
+  }
+
+  cos_table.assign(num_tokens, std::vector<float>(head_dim, 1.0f));
+  sin_table.assign(num_tokens, std::vector<float>(head_dim, 0.0f));
+
+  for (unsigned int n = 0; n < num_tokens; ++n) {
+    const unsigned int frame = n / tokens_per_frame;
+    const unsigned int rem = n % tokens_per_frame;
+    const unsigned int height = rem / grid_w;
+    const unsigned int width = rem % grid_w;
+
+    const float pos[3] = {static_cast<float>(frame),
+                          static_cast<float>(height) * h_scale,
+                          static_cast<float>(width) * w_scale};
+
+    // three contiguous axis slices: [0, d_dim), [d_dim, 2*d_dim), [2*d_dim, ..)
+    for (unsigned int axis = 0; axis < 3; ++axis) {
+      const unsigned int base = axis * d_dim;
+      for (unsigned int i = 0; i < half; ++i) {
+        const float ang = pos[axis] * omega[i];
+        const float c = std::cos(ang);
+        const float s = std::sin(ang);
+        // repeat_interleave(2): the pair (2i, 2i+1) shares one (cos, sin)
+        cos_table[n][base + 2 * i] = c;
+        cos_table[n][base + 2 * i + 1] = c;
+        sin_table[n][base + 2 * i] = s;
+        sin_table[n][base + 2 * i + 1] = s;
+      }
+    }
+    // tail dims [3*d_dim, head_dim) keep cos=1, sin=0 (passthrough)
+  }
+}
+
+void VjepaRopeLayer::finalize(nntrainer::InitLayerContext &context) {
+  std::vector<nntrainer::TensorDim> dims = context.getInputDimensions();
+  context.setOutputDimensions(dims);
+
+  const unsigned int num_heads =
+    std::get<props::VjepaNumHeads>(vjepa_rope_props).get();
+  const unsigned int width = dims[0].width();
+
+  NNTR_THROW_IF(num_heads == 0 || width % num_heads != 0, std::invalid_argument)
+    << "[vjepa_rope] width (" << width << ") must be a multiple of num_heads ("
+    << num_heads << ")";
+
+  head_dim = width / num_heads;
+  // d_dim = 2 * ((head_dim // 3) // 2), per V-JEPA2 RoPEAttention
+  d_dim = 2 * ((head_dim / 3) / 2);
+
+  NNTR_THROW_IF(3 * d_dim > head_dim, std::invalid_argument)
+    << "[vjepa_rope] invalid head_dim " << head_dim;
+
+  precompute_tables();
+}
+
+void VjepaRopeLayer::forwarding(nntrainer::RunLayerContext &context,
+                                bool training) {
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
+
+  const nntrainer::TensorDim in_dim = in.getDim();
+  const unsigned int width = in_dim.width();
+  const unsigned int rows = in_dim.height();
+  const unsigned int feature_len = in_dim.getFeatureLen();
+
+  for (unsigned int b = 0; b < in_dim.batch(); ++b) {
+    if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
+      rotate<float>(in.getData<float>() + b * feature_len,
+                    out.getData<float>() + b * feature_len, 0, rows, width);
+    } else {
+      throw std::invalid_argument(
+        "[vjepa_rope] only FP32 is supported in forwarding");
+    }
+  }
+}
+
+void VjepaRopeLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &out = context.getOutput(SINGLE_INOUT_IDX);
+
+  const nntrainer::TensorDim in_dim = in.getDim();
+  const unsigned int width = in_dim.width();
+  const unsigned int rows = to - from;
+  const unsigned int feature_len = in_dim.getFeatureLen();
+
+  for (unsigned int b = 0; b < in_dim.batch(); ++b) {
+    if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
+      rotate<float>(in.getData<float>() + b * feature_len,
+                    out.getData<float>() + b * feature_len, from, rows, width);
+    } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+      rotate<_FP16>(in.getData<_FP16>() + b * feature_len,
+                    out.getData<_FP16>() + b * feature_len, from, rows, width);
+#else
+      throw std::invalid_argument("[vjepa_rope] enable-fp16 is not set!");
+#endif
+    } else {
+      throw std::invalid_argument("[vjepa_rope] unsupported data type");
+    }
+  }
+}
+
+template <typename T>
+void VjepaRopeLayer::rotate(const T *in, T *out, unsigned int from,
+                            unsigned int rows, unsigned int width) const {
+  const unsigned int num_heads = width / head_dim;
+  const unsigned int pairs = head_dim / 2;
+
+  for (unsigned int r = 0; r < rows; ++r) {
+    const unsigned int token = from + r;
+    const std::vector<float> &cos_t = cos_table[token];
+    const std::vector<float> &sin_t = sin_table[token];
+    const T *in_row = in + static_cast<size_t>(r) * width;
+    T *out_row = out + static_cast<size_t>(r) * width;
+
+    for (unsigned int h = 0; h < num_heads; ++h) {
+      const unsigned int o = h * head_dim;
+      for (unsigned int p = 0; p < pairs; ++p) {
+        const unsigned int d = 2 * p;
+        const float x0 = static_cast<float>(in_row[o + d]);
+        const float x1 = static_cast<float>(in_row[o + d + 1]);
+        const float c = cos_t[d];
+        const float s = sin_t[d];
+        // y = (-x1, x0); out = x * cos + y * sin
+        out_row[o + d] = static_cast<T>(x0 * c - x1 * s);
+        out_row[o + d + 1] = static_cast<T>(x1 * c + x0 * s);
+      }
+    }
+  }
+}
+
+void VjepaRopeLayer::setProperty(const std::vector<std::string> &values) {
+  auto remain_props = loadProperties(values, vjepa_rope_props);
+  NNTR_THROW_IF(!remain_props.empty(), std::invalid_argument)
+    << "[vjepa_rope] Unknown Layer Properties count "
+    << std::to_string(remain_props.size());
+}
+
+void VjepaRopeLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+}
+
+void VjepaRopeLayer::calcDerivative(nntrainer::RunLayerContext &context) {
+  throw std::runtime_error("[vjepa_rope] Training is not supported yet.");
+}
+
+#ifdef PLUGGABLE
+
+nntrainer::Layer *create_vjepa_rope_layer() { return new VjepaRopeLayer(); }
+
+void destroy_vjepa_rope_layer(nntrainer::Layer *layer) { delete layer; }
+
+extern "C" {
+nntrainer::LayerPluggable ml_train_layer_pluggable{create_vjepa_rope_layer,
+                                                   destroy_vjepa_rope_layer};
+}
+
+#endif
+
+} // namespace causallm

--- a/Applications/CausalLM/layers/vjepa_rope_layer.h
+++ b/Applications/CausalLM/layers/vjepa_rope_layer.h
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   vjepa_rope_layer.h
+ * @date   21 May 2026
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  3D axial Rotary Positional Embedding layer for V-JEPA2 ViT.
+ *
+ * @note   This layer reproduces V-JEPA 2.1's `rotate_queries_or_keys`
+ *         (see app/vjepa_2_1/models/utils/modules.py). It is attached right
+ *         after the Q (or K) projection and before mha_core, which must be run
+ *         with rope disabled (rope_theta=0). The per-head feature dimension is
+ *         split into three contiguous axis slices of size `d_dim` each
+ *         (depth/frame, height, width); each slice is rotated using the token's
+ *         (frame, height, width) grid index. Any tail dimension beyond
+ *         `3 * d_dim` is left unrotated. Because the (T, H, W) grid is fixed at
+ *         inference time, the cos/sin tables are constants precomputed once in
+ *         finalize(); the layer therefore owns no trainable weights.
+ */
+
+#ifndef __VJEPA_ROPE_LAYER_H__
+#define __VJEPA_ROPE_LAYER_H__
+
+#pragma once
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#else
+#define WIN_EXPORT
+#endif
+
+#include <layer_context.h>
+#include <layer_devel.h>
+#include <node_exporter.h>
+#include <utility>
+#include <vector>
+
+#include <base_properties.h>
+
+namespace causallm {
+
+namespace props {
+
+/**
+ * @brief Number of attention heads (used to derive head_dim = width/num_heads)
+ */
+class VjepaNumHeads : public nntrainer::PositiveIntegerProperty {
+public:
+  VjepaNumHeads(unsigned int value = 12) { set(value); };
+  static constexpr const char *key = "num_heads";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+/**
+ * @brief Temporal grid size (number of tubelet frames, T = num_frames/tubelet)
+ */
+class VjepaGridT : public nntrainer::PositiveIntegerProperty {
+public:
+  VjepaGridT(unsigned int value = 1) { set(value); };
+  static constexpr const char *key = "grid_t";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+/**
+ * @brief Height grid size in patches (H_patches = img_h/patch_size)
+ */
+class VjepaGridH : public nntrainer::PositiveIntegerProperty {
+public:
+  VjepaGridH(unsigned int value = 1) { set(value); };
+  static constexpr const char *key = "grid_h";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+/**
+ * @brief Width grid size in patches (W_patches = img_w/patch_size)
+ */
+class VjepaGridW : public nntrainer::PositiveIntegerProperty {
+public:
+  VjepaGridW(unsigned int value = 1) { set(value); };
+  static constexpr const char *key = "grid_w";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+/**
+ * @brief Rope base theta (default 10000)
+ */
+class VjepaRopeTheta : public nntrainer::Property<float> {
+public:
+  VjepaRopeTheta(float value = 10000.0f) { set(value); };
+  static constexpr const char *key = "rope_theta";
+  using prop_tag = nntrainer::float_prop_tag;
+};
+
+/**
+ * @brief Pretrained grid size for rope position interpolation
+ *        (e.g. 256/patch_size = 16 for patch_size 16)
+ */
+class VjepaPretrainedGridSize : public nntrainer::PositiveIntegerProperty {
+public:
+  VjepaPretrainedGridSize(unsigned int value = 16) { set(value); };
+  static constexpr const char *key = "pretrained_grid_size";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+/**
+ * @brief Whether to interpolate the height/width rope positions to the
+ *        pretrained grid (V-JEPA 2.1 sets interpolate_rope=True)
+ */
+class VjepaInterpolateRope : public nntrainer::Property<bool> {
+public:
+  VjepaInterpolateRope(bool value = false) { set(value); };
+  static constexpr const char *key = "interpolate_rope";
+  using prop_tag = nntrainer::bool_prop_tag;
+};
+
+} // namespace props
+
+/**
+ * @brief 3D axial Rotary Positional Embedding layer for V-JEPA2 ViT encoder.
+ */
+WIN_EXPORT class VjepaRopeLayer final : public nntrainer::Layer {
+public:
+  /**
+   * @brief Construct a new VjepaRopeLayer object
+   */
+  WIN_EXPORT VjepaRopeLayer() :
+    Layer(),
+    vjepa_rope_props(props::VjepaNumHeads(), props::VjepaGridT(),
+                     props::VjepaGridH(), props::VjepaGridW(),
+                     props::VjepaRopeTheta(), props::VjepaPretrainedGridSize(),
+                     props::VjepaInterpolateRope()),
+    head_dim(0),
+    d_dim(0) {}
+
+  /**
+   * @brief Destroy the VjepaRopeLayer object
+   */
+  WIN_EXPORT ~VjepaRopeLayer() {}
+
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
+   */
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+
+  /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc bool supportBackwarding() const
+   */
+  WIN_EXPORT bool supportBackwarding() const override { return false; };
+
+  /**
+   * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
+   */
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override {
+    exporter.saveResult(vjepa_rope_props, method, this);
+  };
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  WIN_EXPORT const std::string getType() const override {
+    return VjepaRopeLayer::type;
+  };
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
+
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  inline static const std::string type = "vjepa_rope";
+
+private:
+  std::tuple<props::VjepaNumHeads, props::VjepaGridT, props::VjepaGridH,
+             props::VjepaGridW, props::VjepaRopeTheta,
+             props::VjepaPretrainedGridSize, props::VjepaInterpolateRope>
+    vjepa_rope_props;
+
+  unsigned int head_dim; /**< per-head feature dimension (width / num_heads) */
+  unsigned int d_dim;    /**< per-axis rotated dimension = 2*((head_dim/3)/2) */
+
+  /** constant rotation tables, sized [num_tokens][head_dim]. cos/sin are
+   *  repeat-interleaved across pairs and set to 1/0 for the unrotated tail. */
+  std::vector<std::vector<float>> cos_table;
+  std::vector<std::vector<float>> sin_table;
+
+  /**
+   * @brief Precompute the cos/sin rotation tables from the grid configuration.
+   */
+  void precompute_tables();
+
+  /**
+   * @brief Apply the 3D axial rotation to one [num_tokens, width] block.
+   * @param in   input data pointer (row-major, width-contiguous)
+   * @param out  output data pointer
+   * @param from absolute token index of the first row
+   * @param rows number of token rows to process
+   * @param width feature width (= num_heads * head_dim)
+   */
+  template <typename T>
+  void rotate(const T *in, T *out, unsigned int from, unsigned int rows,
+              unsigned int width) const;
+};
+
+} // namespace causallm
+
+#endif /* __VJEPA_ROPE_LAYER_H__ */

--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -53,6 +53,7 @@
 #include "qwen3_moe_causallm.h"
 #include "qwen3_slim_moe_causallm.h"
 #include "timm_vit/timm_vit_transformer.h"
+#include "vjepa2_vit/vjepa2_vit.h"
 #include <models/gemma3/function.h>
 #if !defined(_WIN32)
 #include <sys/resource.h>
@@ -185,6 +186,10 @@ std::string resolve_architecture(std::string model_type,
     return "TimmViT";
   }
 
+  if (architecture == "VJEPA2ViT" || architecture == "vjepa2_1_vit_base_384") {
+    return "VJEPA2ViT";
+  }
+
   return architecture;
 }
 
@@ -279,6 +284,11 @@ int main(int argc, char *argv[]) {
     "TimmViT", [](json cfg, json generation_cfg, json nntr_cfg) {
       return std::make_unique<causallm::TimmViTTransformer>(cfg, generation_cfg,
                                                             nntr_cfg);
+    });
+  causallm::Factory::Instance().registerModel(
+    "VJEPA2ViT", [](json cfg, json generation_cfg, json nntr_cfg) {
+      return std::make_unique<causallm::VJEPA2ViT>(cfg, generation_cfg,
+                                                   nntr_cfg);
     });
 
   // Validate arguments

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -35,6 +35,9 @@ causallm_layer_dependencies += [
     causallm_embedding_normalize_layer_dep,
     causallm_deberta_attention_layer_dep,
     causallm_shared_fully_connected_layer_dep,
+    causallm_vjepa_rope_layer_dep,
+    causallm_vjepa_gelu_layer_dep,
+    causallm_vjepa_layernorm_layer_dep,
 ]
 
 subdir('models')

--- a/Applications/CausalLM/models/meson.build
+++ b/Applications/CausalLM/models/meson.build
@@ -14,6 +14,7 @@ subdir('qwen3_moe')
 subdir('qwen3_slim_moe')
 subdir('gemma3')
 subdir('timm_vit')
+subdir('vjepa2_vit')
 if get_option('platform') != 'windows'
     subdir('bert')
     subdir('gpt_oss_cached_slim')

--- a/Applications/CausalLM/models/vjepa2_vit/README.md
+++ b/Applications/CausalLM/models/vjepa2_vit/README.md
@@ -1,0 +1,158 @@
+# V-JEPA 2.1 ViT-B Video Encoder
+
+A faithful nntrainer port of the **V-JEPA 2.1 `vit_base` (ViT-B/16)** video
+encoder, runnable through the CausalLM application on x86 and on-device (ARM,
+Android). Both an FP32 and a Q4_0-quantized variant are supported.
+
+## Model
+
+`architectures: "VJEPA2ViT"` (HF `model_type` mapped from
+`vjepa2_1_vit_base_384`).
+
+| | |
+|---|---|
+| embed_dim / depth / heads | 768 / 12 / 12 (head_dim 64) |
+| patch / tubelet | 16 (spatial) / 2 (temporal) |
+| MLP | GELU, intermediate 3072 |
+| norm | LayerNorm, eps 1e-6 |
+| positional | **3D axial RoPE** (no learned pos-embed, no CLS token) |
+| attention | **bidirectional** (non-causal), qkv_bias = true |
+| params | ~86 M |
+
+Key implementation choices:
+
+- **Patch embedding** – the non-overlapping `Conv3d` tubelet projection is
+  mathematically a linear map, so it is implemented as a host-side `patchify`
+  (re-order `[C,T,H,W]` into `[num_tokens, in_chans*tubelet*patch*patch]`)
+  followed by a single `fully_connected`. The video modality embedding is
+  folded into the patch-embed bias by the converter.
+- **3D axial RoPE** – `head_dim` (64) is split into depth/height/width slices
+  (20/20/20, last 4 dims unrotated) and rotated by the frame/row/col index.
+  Implemented by the custom `vjepa_rope` layer applied to Q and K; `mha_core`
+  runs with its own RoPE disabled (`rope_theta=0`).
+- Token ordering is `n = t·(Gh·Gw) + h·Gw + w` (matches `flatten(2)` of the
+  reference `PatchEmbed3D`).
+
+### Custom layers
+
+| layer | purpose |
+|---|---|
+| `vjepa_rope` | 3D axial RoPE on Q/K |
+| `vjepa_gelu` | NEON GELU parallelized over tokens (the core `activation` runs single-threaded) |
+| `vjepa_layernorm` | per-token LayerNorm parallelized over tokens, pure FP32 |
+| `mha_core` (`use_gemm_attention=true`) | optional non-causal flash attention |
+
+The **flash attention** path (enabled for this encoder) tiles the score matrix
+into `[Bq × Bk]` blocks with an online (running max/sum) softmax, so the
+`O(N²)` score buffer is never materialized. Work is distributed over
+`(head × query-block)` units across the thread pool so all cores stay busy.
+QK uses `shgemm` (FP32 Q × FP16 K → FP32) because block-0 logits reach ~457k
+and would overflow an FP16 product; AV uses the FP16 path. Tile sizes default
+to `Bq=256, Bk=512` and can be overridden with `VJEPA_BQ` / `VJEPA_BK`.
+
+## 1. Convert the released checkpoint
+
+`weight_converter.py` (in `res/vjepa2/`) reads the released V-JEPA 2.1
+`ema_encoder` checkpoint and writes the nntrainer weight blob in the exact
+order the graph requests it.
+
+```bash
+python res/vjepa2/weight_converter.py \
+    --input  vjepa2_1_vitb_dist_vitG_384.pt \
+    --output nntr_vjepa2_vitb_fp32.bin
+```
+
+This produces the **FP32** weights. Place the `.bin` next to a model
+directory containing `config.json`, `generation_config.json` and
+`nntr_config.json` (see "Running" below).
+
+## 2. Quantization (Q4_0)
+
+Quantize the FP32 model with `nntr_quantize`. The FC layers (patch-embed,
+q/k/v, attention-out, ffn-up/down) become `Q4_0`; activations stay FP32
+(`Q4_0-FP32`). LayerNorm γ/β and FC biases remain FP32.
+
+> **ARM / on-device: you must pass `--isa ARM`.**
+> The ARM `q4_0` GEMM kernel (`__ggml_q4_0_4x8_q8_0_GEMM`) expects the weights
+> repacked into the ggml 4×8 interleaved layout. The default (x86) layout
+> produces all-zero output on ARM. The repack is layout-only, so it can be run
+> on an x86 host; the resulting `.bin` is ARM-specific.
+
+```bash
+# x86 inference build:
+nntr_quantize <model_dir> --fc_dtype Q4_0 --embd_dtype FP32 \
+              --output_bin nntr_vjepa2_vitb_q40.bin
+
+# Android / ARM device:
+nntr_quantize <model_dir> --fc_dtype Q4_0 --embd_dtype FP32 --isa ARM \
+              --output_bin nntr_vjepa2_vitb_q40_arm.bin
+```
+
+`nntr_config.json` for the quantized model:
+
+```json
+{
+  "model_tensor_type": "Q4_0-FP32",
+  "model_file_name": "nntr_vjepa2_vitb_q40_arm.bin",
+  "model_type": "Model",
+  "embedding_dtype": "FP32",
+  "fc_layer_dtype": "Q4_0",
+  "batch_size": 1,
+  "max_seq_len": 4608,
+  "init_seq_len": 4608,
+  "num_to_generate": 0,
+  "fsu": false,
+  "skip_tokenizer": true
+}
+```
+
+`max_seq_len`/`init_seq_len` = number of tokens = `(T/2)·(384/16)²`
+(e.g. 16 frames → 8·24·24 = 4608, 32 frames → 9216). `config.json` carries the
+HF geometry (`num_frames`, `img_size`, `patch_size`, `tubelet_size`, …).
+
+## 3. Running
+
+The input is a raw `float32` `[C, T, H, W]` tensor (already resized and
+normalized to the model's expectations):
+
+```bash
+nntr_causallm <model_dir> <input_video.bin>
+```
+
+The last-token hidden state (`[hidden_size]`) is printed and dumped to
+`<input_video.bin>.nntr_out.bin` for offline comparison against a torch
+reference.
+
+On Android, set the thread count via the environment (the CausalLM core is
+built with a small default); 8 (= core count on recent Galaxy SoCs) is optimal:
+
+```bash
+NNTR_NUM_THREADS=8 LD_LIBRARY_PATH=. ./nntrainer_causallm <model_dir> <input.bin>
+```
+
+## Accuracy & performance
+
+Cosine similarity of the last-token output vs. the official torch reference:
+
+| variant | cos |
+|---|---|
+| x86 FP32 | ~1.000 |
+| x86 Q4_0 | ~0.991 |
+| device Q4_0 (ARM) | ~0.99 |
+
+End-to-end latency (Q4_0, Galaxy S25 Ultra, 8 threads), after the attention
+and activation optimizations (flash attention + load balancing + parallel
+GELU/LayerNorm):
+
+| frames (tokens) | e2e | peak RAM |
+|---|---|---|
+| 16 (4608) | ~3.8 s | ~0.6 GB |
+| 32 (9216) | ~13 s | ~1.0 GB |
+
+## Notes
+
+- The encoder is built with `ENABLE_FP16=0` (FP32 attention scores). A fully
+  FP16 attention path overflows on the large block-0 logits (~457k > 65504).
+- `vjepa_gelu` / `vjepa_layernorm` reproduce the core ops exactly (the LN even
+  improves device accuracy by keeping FP32 throughout) while parallelizing the
+  per-token work that the stock single-threaded layers leave on one core.

--- a/Applications/CausalLM/models/vjepa2_vit/meson.build
+++ b/Applications/CausalLM/models/vjepa2_vit/meson.build
@@ -1,0 +1,3 @@
+causallm_src += [
+    meson.current_source_dir() / 'vjepa2_vit.cpp',
+]

--- a/Applications/CausalLM/models/vjepa2_vit/vjepa2_vit.cpp
+++ b/Applications/CausalLM/models/vjepa2_vit/vjepa2_vit.cpp
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   vjepa2_vit.cpp
+ * @date   21 May 2026
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  V-JEPA 2.1 ViT encoder (ViT-B/16, video) for nntrainer.
+ */
+
+#include "vjepa2_vit.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iomanip>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <app_context.h>
+#include <engine.h>
+#include <factory.h>
+#include <llm_util.hpp>
+#include <vjepa_gelu_layer.h>
+#include <vjepa_layernorm_layer.h>
+#include <vjepa_rope_layer.h>
+
+namespace causallm {
+
+/**
+ * @brief Set ViT-specific parameters from model and runtime configs.
+ */
+void VJEPA2ViT::setupParameters(json &cfg, json &generation_cfg,
+                                json &nntr_cfg) {
+  (void)generation_cfg;
+
+  BATCH_SIZE = nntr_cfg.value("batch_size", 1);
+  MODEL_TENSOR_TYPE = nntr_cfg.value("model_tensor_type", "FP32-FP32");
+  EMBEDDING_DTYPE = nntr_cfg.value("embedding_dtype", "FP32");
+  FC_LAYER_DTYPE = nntr_cfg.value("fc_layer_dtype", "FP32");
+
+  DIM = cfg.value("hidden_size", 768);
+  INTERMEDIATE_SIZE = cfg.value("intermediate_size", 3072);
+  NUM_LAYERS = cfg.value("num_hidden_layers", 12);
+  NUM_HEADS = cfg.value("num_attention_heads", 12);
+  HEAD_DIM = cfg.value("head_dim", DIM / NUM_HEADS);
+  NUM_KEY_VALUE_HEADS = cfg.value("num_key_value_heads", NUM_HEADS);
+  GQA_SIZE = NUM_HEADS / NUM_KEY_VALUE_HEADS;
+  NORM_EPS = cfg.value("norm_eps", 1e-6);
+  TIE_WORD_EMBEDDINGS = false;
+  IS_CAUSAL = false;
+
+  // Vision / video geometry
+  IMG_SIZE = cfg.value("img_size", 384);
+  PATCH_SIZE = cfg.value("patch_size", 16);
+  TUBELET = cfg.value("tubelet_size", 2);
+  NUM_FRAMES = cfg.value("num_frames", 64);
+  IN_CHANS = cfg.value("in_chans", 3);
+  PRETRAINED_GRID = cfg.value("pretrained_grid_size", 256 / PATCH_SIZE);
+  INTERPOLATE_ROPE = cfg.value("interpolate_rope", true);
+
+  GRID_T = NUM_FRAMES / TUBELET;
+  GRID_H = IMG_SIZE / PATCH_SIZE;
+  GRID_W = IMG_SIZE / PATCH_SIZE;
+  NUM_PATCHES = GRID_T * GRID_H * GRID_W;
+  PATCH_VEC = IN_CHANS * TUBELET * PATCH_SIZE * PATCH_SIZE;
+
+  MAX_SEQ_LEN = nntr_cfg.value("max_seq_len", NUM_PATCHES);
+  INIT_SEQ_LEN = nntr_cfg.value("init_seq_len", NUM_PATCHES);
+  NUM_TO_GENERATE = nntr_cfg.value("num_to_generate", 0);
+  MEMORY_SWAP = nntr_cfg.contains("fsu") ? nntr_cfg["fsu"].get<bool>() : false;
+  FSU_LOOKAHEAD = nntr_cfg.contains("fsu_lookahead")
+                    ? nntr_cfg["fsu_lookahead"].get<unsigned int>()
+                    : 1;
+}
+
+/**
+ * @brief Extract non-overlapping tubelets matching Conv3d weight layout.
+ *
+ * Source video buffer is laid out [C, T, H, W] (C-order). Each output token
+ * corresponds to one (t', h', w') tubelet and is a PATCH_VEC vector ordered as
+ * (in_chan, kt, kh, kw) so that a single fully_connected with the reshaped
+ * Conv3d weight reproduces PatchEmbed3D exactly. Tokens are ordered
+ * n = t' * (GRID_H * GRID_W) + h' * GRID_W + w', matching the flatten(2) of the
+ * reference PatchEmbed3D.
+ */
+std::vector<float> VJEPA2ViT::patchify(const std::vector<float> &video) const {
+  const unsigned int T = NUM_FRAMES, H = IMG_SIZE, W = IMG_SIZE;
+  std::vector<float> tokens(static_cast<size_t>(NUM_PATCHES) * PATCH_VEC);
+
+  for (unsigned int tt = 0; tt < GRID_T; ++tt) {
+    for (unsigned int hh = 0; hh < GRID_H; ++hh) {
+      for (unsigned int ww = 0; ww < GRID_W; ++ww) {
+        const size_t token =
+          (static_cast<size_t>(tt) * GRID_H + hh) * GRID_W + ww;
+        float *dst = tokens.data() + token * PATCH_VEC;
+        size_t k = 0;
+        for (unsigned int c = 0; c < IN_CHANS; ++c) {
+          for (unsigned int kt = 0; kt < TUBELET; ++kt) {
+            const unsigned int frame = tt * TUBELET + kt;
+            for (unsigned int kh = 0; kh < PATCH_SIZE; ++kh) {
+              const unsigned int row = hh * PATCH_SIZE + kh;
+              for (unsigned int kw = 0; kw < PATCH_SIZE; ++kw) {
+                const unsigned int col = ww * PATCH_SIZE + kw;
+                const size_t vidx =
+                  ((static_cast<size_t>(c) * T + frame) * H + row) * W + col;
+                dst[k++] = video[vidx];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return tokens;
+}
+
+/**
+ * @brief Create the tubelet patch-embedding projection (Conv3d-equivalent FC).
+ */
+Tensor VJEPA2ViT::createPatchEmbed(Tensor input) {
+  // patch_embed is a plain FC, so it follows the model's global weight dtype
+  // (FP32 for the FP32 model, Q4_0 for the quantized model — nntr_quantize
+  // includes "patch_embed/proj" in its FC dtype map).
+  LayerHandle proj(createLayer(
+    "fully_connected", {withKey("name", "patch_embed/proj"),
+                        withKey("unit", std::to_string(DIM)),
+                        withKey("disable_bias", "false")}));
+  return proj(input);
+}
+
+/**
+ * @brief Create a pre-normalized self-attention block with 3D RoPE.
+ */
+Tensor VJEPA2ViT::createAttention(const int layer_id, Tensor input) {
+  const std::string prefix = "layer" + std::to_string(layer_id) + "_";
+
+  LayerHandle norm(
+    createLayer("vjepa_layernorm",
+                {withKey("name", prefix + "attention_norm"),
+                 withKey("epsilon", std::to_string(NORM_EPS))}));
+  Tensor normed = norm(input);
+
+  // Names follow the LLM convention (wq/wk/wv/attention_out, ffn_up/ffn_down)
+  // so the nntr_quantize layer-dtype map targets them for Q4_0.
+  const std::string q = prefix + "wq", k = prefix + "wk", v = prefix + "wv",
+                    a = prefix + "attention", o = prefix + "attention_out";
+
+  LayerHandle q_proj(
+    createLayer("fully_connected",
+                {withKey("name", q), withKey("unit", std::to_string(DIM)),
+                 withKey("disable_bias", "false")}));
+  LayerHandle k_proj(
+    createLayer("fully_connected",
+                {withKey("name", k), withKey("unit", std::to_string(DIM)),
+                 withKey("disable_bias", "false")}));
+  LayerHandle v_proj(
+    createLayer("fully_connected",
+                {withKey("name", v), withKey("unit", std::to_string(DIM)),
+                 withKey("disable_bias", "false")}));
+
+  Tensor query = q_proj(normed);
+  Tensor key = k_proj(normed);
+  Tensor value = v_proj(normed);
+
+  // 3D axial RoPE on Q and K (mha_core runs with rope disabled).
+  auto rope_props = [&](const std::string &name) {
+    return std::vector<std::string>{
+      withKey("name", name),
+      withKey("num_heads", std::to_string(NUM_HEADS)),
+      withKey("grid_t", std::to_string(GRID_T)),
+      withKey("grid_h", std::to_string(GRID_H)),
+      withKey("grid_w", std::to_string(GRID_W)),
+      withKey("rope_theta", "10000.0"),
+      withKey("pretrained_grid_size", std::to_string(PRETRAINED_GRID)),
+      withKey("interpolate_rope", INTERPOLATE_ROPE ? "true" : "false")};
+  };
+  LayerHandle q_rope(createLayer("vjepa_rope", rope_props(prefix + "q_rope")));
+  LayerHandle k_rope(createLayer("vjepa_rope", rope_props(prefix + "k_rope")));
+  query = q_rope(query);
+  key = k_rope(key);
+
+  LayerHandle attention(createLayer(
+    "mha_core",
+    {withKey("name", a), withKey("num_heads", std::to_string(NUM_HEADS)),
+     withKey("num_heads_KV", std::to_string(NUM_HEADS)),
+     withKey("max_timestep", std::to_string(NUM_PATCHES + 1)),
+     withKey("is_causal", "false"), withKey("rope_theta", "0"),
+     withKey("use_gemm_attention", "true")}));
+  Tensor context = attention({query, key, value});
+
+  LayerHandle out_proj(
+    createLayer("fully_connected",
+                {withKey("name", o), withKey("unit", std::to_string(DIM)),
+                 withKey("disable_bias", "false")}));
+  return out_proj(context);
+}
+
+/**
+ * @brief Create a pre-normalized GELU feed-forward block.
+ */
+Tensor VJEPA2ViT::createMlp(const int layer_id, Tensor input) {
+  const std::string prefix = "layer" + std::to_string(layer_id) + "_";
+
+  LayerHandle norm(
+    createLayer("vjepa_layernorm",
+                {withKey("name", prefix + "ffn_norm"),
+                 withKey("epsilon", std::to_string(NORM_EPS))}));
+  Tensor h = norm(input);
+
+  LayerHandle fc_up(createLayer(
+    "fully_connected", {withKey("name", prefix + "ffn_up"),
+                        withKey("unit", std::to_string(INTERMEDIATE_SIZE)),
+                        withKey("disable_bias", "false")}));
+  h = fc_up(h);
+
+  LayerHandle gelu(
+    createLayer("vjepa_gelu", {withKey("name", prefix + "ffn_gelu")}));
+  h = gelu(h);
+
+  LayerHandle fc_down(
+    createLayer("fully_connected", {withKey("name", prefix + "ffn_down"),
+                                    withKey("unit", std::to_string(DIM)),
+                                    withKey("disable_bias", "false")}));
+  return fc_down(h);
+}
+
+/**
+ * @brief Create one ViT transformer block with residual connections.
+ */
+Tensor VJEPA2ViT::createTransformerDecoderBlock(const int layer_id,
+                                                Tensor input) {
+  const std::string prefix = "layer" + std::to_string(layer_id) + "_";
+
+  Tensor att_out = createAttention(layer_id, input);
+  LayerHandle attention_res(
+    createLayer("addition", {withKey("name", prefix + "attention_residual")}));
+  Tensor residual = attention_res({input, att_out});
+
+  Tensor mlp_out = createMlp(layer_id, residual);
+  LayerHandle ffn_res(
+    createLayer("addition", {withKey("name", prefix + "ffn_residual")}));
+  return ffn_res({residual, mlp_out});
+}
+
+/**
+ * @brief Construct the symbolic ViT inference graph.
+ */
+std::pair<Tensor, Tensor> VJEPA2ViT::constructModel() {
+  // Host-side patchified tokens: [B, 1, NUM_PATCHES, PATCH_VEC]
+  Tensor input({BATCH_SIZE, 1, NUM_PATCHES, PATCH_VEC}, "input0");
+  Tensor h = createPatchEmbed(input);
+
+  for (int i = 0; i < NUM_LAYERS; i++) {
+    h = createTransformerDecoderBlock(i, h);
+  }
+
+  LayerHandle output_norm(
+    createLayer("vjepa_layernorm",
+                {withKey("name", "output_norm"),
+                 withKey("epsilon", std::to_string(NORM_EPS))}));
+  h = output_norm(h);
+
+  return {input, h};
+}
+
+/**
+ * @brief Register layers used by this model.
+ */
+void VJEPA2ViT::registerCustomLayers() {
+  Transformer::registerCustomLayers();
+
+  const auto &ct_engine = nntrainer::Engine::Global();
+  const auto app_context =
+    static_cast<nntrainer::AppContext *>(ct_engine.getRegisteredContext("cpu"));
+  try {
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::VjepaRopeLayer>);
+  } catch (std::invalid_argument &e) {
+    std::cerr << "failed to register vjepa_rope factory: " << e.what()
+              << std::endl;
+  }
+  try {
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::VjepaGeluLayer>);
+  } catch (std::invalid_argument &e) {
+    std::cerr << "failed to register vjepa_gelu factory: " << e.what()
+              << std::endl;
+  }
+  try {
+    app_context->registerFactory(
+      nntrainer::createLayer<causallm::VjepaLayerNormLayer>);
+  } catch (std::invalid_argument &e) {
+    std::cerr << "failed to register vjepa_layernorm factory: " << e.what()
+              << std::endl;
+  }
+}
+
+/**
+ * @brief Run the encoder on a preprocessed video tensor file.
+ *
+ * @param prompt path to a raw float32 file holding a [C, T, H, W] video tensor
+ *               (already resized and normalized to the model's expectations).
+ */
+void VJEPA2ViT::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
+                    const WSTR tail_prompt, bool log_output) {
+  (void)do_sample;
+  (void)system_prompt;
+  (void)tail_prompt;
+  (void)log_output;
+
+  if (!is_initialized) {
+    throw std::runtime_error("VJEPA2ViT model is not initialized. Please call "
+                             "initialize() before run().");
+  }
+
+  const size_t expected =
+    static_cast<size_t>(IN_CHANS) * NUM_FRAMES * IMG_SIZE * IMG_SIZE;
+
+  std::ifstream f(std::string(prompt), std::ios::binary);
+  if (!f.is_open()) {
+    throw std::runtime_error("Failed to open video tensor file: " +
+                             std::string(prompt));
+  }
+  std::vector<float> video(expected);
+  f.read(reinterpret_cast<char *>(video.data()), expected * sizeof(float));
+  if (static_cast<size_t>(f.gcount()) != expected * sizeof(float)) {
+    throw std::runtime_error(
+      "Video tensor file size mismatch; expected " + std::to_string(expected) +
+      " float32 values ([C,T,H,W] = [" + std::to_string(IN_CHANS) + "," +
+      std::to_string(NUM_FRAMES) + "," + std::to_string(IMG_SIZE) + "," +
+      std::to_string(IMG_SIZE) + "]).");
+  }
+
+  std::vector<float> tokens = patchify(video);
+
+  std::vector<float *> input;
+  input.push_back(tokens.data());
+  std::vector<float *> label;
+
+  std::vector<float *> output = model->incremental_inference(
+    BATCH_SIZE, input, label, NUM_PATCHES, 0, NUM_PATCHES, false);
+
+  std::cout << std::setprecision(9) << "First 10 values (last token): ";
+  const int print_count = DIM > 10 ? 10 : DIM;
+  for (int i = 0; i < print_count; ++i) {
+    std::cout << "[" << i << "]=" << output[0][i] << " ";
+  }
+  std::cout << std::endl;
+
+  // Dump the last-token hidden state (DIM floats) for offline verification.
+  const std::string dump_path = std::string(prompt) + ".nntr_out.bin";
+  std::ofstream of(dump_path, std::ios::binary);
+  if (of.is_open()) {
+    of.write(reinterpret_cast<const char *>(output[0]), DIM * sizeof(float));
+    std::cout << "Wrote last-token output [" << DIM << "] to " << dump_path
+              << std::endl;
+  }
+}
+
+} // namespace causallm

--- a/Applications/CausalLM/models/vjepa2_vit/vjepa2_vit.h
+++ b/Applications/CausalLM/models/vjepa2_vit/vjepa2_vit.h
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   vjepa2_vit.h
+ * @date   21 May 2026
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  V-JEPA 2.1 ViT encoder (ViT-B/16, video) for nntrainer.
+ *
+ * @note   Faithful reproduction of `vjepa2_1_vit_base_384` encoder:
+ *           - 3D tubelet patch embedding (Conv3d, non-overlapping) implemented
+ *             as a host-side patchify + a single fully_connected projection.
+ *           - 3D axial RoPE applied to Q/K via the custom `vjepa_rope` layer;
+ *             mha_core runs with rope disabled (rope_theta=0, is_causal=false).
+ *           - GELU MLP, LayerNorm (eps 1e-6), qkv_bias=True, no CLS token,
+ *             no learned positional embedding.
+ *           - The video modality embedding is folded into the patch-embed bias
+ *             by the weight converter (constant added to every token).
+ */
+
+#ifndef __VJEPA2_VIT_H__
+#define __VJEPA2_VIT_H__
+
+#include <transformer.h>
+
+namespace causallm {
+
+/**
+ * @brief V-JEPA2 ViT encoder model
+ */
+class VJEPA2ViT : virtual public Transformer {
+
+public:
+  static constexpr const char *architectures = "VJEPA2ViT";
+
+  /**
+   * @brief Construct a VJEPA2ViT object.
+   */
+  VJEPA2ViT(json &cfg, json &generation_cfg, json &nntr_cfg) :
+    Transformer(cfg, generation_cfg, nntr_cfg, ModelType::MODEL) {
+    setupParameters(cfg, generation_cfg, nntr_cfg);
+  }
+
+  /**
+   * @brief Destroy the VJEPA2ViT object.
+   */
+  virtual ~VJEPA2ViT() = default;
+
+public:
+  /**
+   * @brief Create the tubelet patch-embedding projection.
+   */
+  Tensor createPatchEmbed(Tensor input);
+
+  /**
+   * @brief Create a pre-normalized self-attention block with 3D RoPE.
+   */
+  Tensor createAttention(const int layer_id, Tensor input);
+
+  /**
+   * @brief Create a pre-normalized GELU feed-forward block.
+   */
+  Tensor createMlp(const int layer_id, Tensor input);
+
+protected:
+  /**
+   * @brief Construct the symbolic ViT inference graph.
+   */
+  std::pair<Tensor, Tensor> constructModel() override;
+
+  /**
+   * @brief Set model parameters from HuggingFace and nntrainer configs.
+   */
+  void setupParameters(json &cfg, json &generation_cfg,
+                       json &nntr_cfg) override;
+
+  /**
+   * @brief Create one ViT transformer block with residual connections.
+   */
+  Tensor createTransformerDecoderBlock(const int layer_id,
+                                       Tensor input) override;
+
+  /**
+   * @brief Register custom layers used by this model (vjepa_rope, mha_core).
+   */
+  void registerCustomLayers() override;
+
+  /**
+   * @brief Run the encoder on a preprocessed video tensor file.
+   */
+  void run(const WSTR prompt, bool do_sample = false,
+           const WSTR system_prompt = WSTR(), const WSTR tail_prompt = WSTR(),
+           bool log_output = true) override;
+
+private:
+  unsigned int IMG_SIZE = 384;   /**< Image height/width */
+  unsigned int PATCH_SIZE = 16;  /**< Spatial patch size */
+  unsigned int TUBELET = 2;      /**< Temporal tubelet size */
+  unsigned int NUM_FRAMES = 64;  /**< Number of input frames */
+  unsigned int IN_CHANS = 3;     /**< Input channels (RGB) */
+  unsigned int GRID_T = 32;      /**< Temporal grid (NUM_FRAMES / TUBELET) */
+  unsigned int GRID_H = 24;      /**< Height grid (IMG_SIZE / PATCH_SIZE) */
+  unsigned int GRID_W = 24;      /**< Width grid (IMG_SIZE / PATCH_SIZE) */
+  unsigned int NUM_PATCHES = 18432; /**< GRID_T * GRID_H * GRID_W */
+  unsigned int PATCH_VEC = 1536; /**< IN_CHANS * TUBELET * PATCH_SIZE^2 */
+  unsigned int PRETRAINED_GRID = 16;  /**< 256 / PATCH_SIZE for rope interp */
+  bool INTERPOLATE_ROPE = true;       /**< V-JEPA 2.1 uses rope interpolation */
+
+  /**
+   * @brief Extract non-overlapping tubelets from a [C,T,H,W] float buffer into
+   *        a [NUM_PATCHES, PATCH_VEC] token matrix, ordered to match Conv3d.
+   */
+  std::vector<float> patchify(const std::vector<float> &video) const;
+};
+
+} // namespace causallm
+
+#endif /* __VJEPA2_VIT_H__ */

--- a/Applications/CausalLM/quantize.cpp
+++ b/Applications/CausalLM/quantize.cpp
@@ -82,6 +82,7 @@
 #include "qwen3_embedding.h"
 #include "qwen3_moe_causallm.h"
 #include "qwen3_slim_moe_causallm.h"
+#include "vjepa2_vit/vjepa2_vit.h"
 
 using json = nlohmann::json;
 using DataType = ml::train::TensorDim::DataType;
@@ -242,6 +243,10 @@ std::string resolve_architecture(std::string model_type,
       throw std::invalid_argument(
         "Unsupported architecture for embedding model: " + architecture);
   }
+
+  if (architecture == "vjepa2_1_vit_base_384")
+    return "VJEPA2ViT";
+
   return architecture;
 }
 
@@ -326,6 +331,11 @@ void registerAllModels() {
   factory.registerModel("EmbeddingGemma",
                         [](json cfg, json generation_cfg, json nntr_cfg) {
                           return std::make_unique<causallm::EmbeddingGemma>(
+                            cfg, generation_cfg, nntr_cfg);
+                        });
+  factory.registerModel("VJEPA2ViT",
+                        [](json cfg, json generation_cfg, json nntr_cfg) {
+                          return std::make_unique<causallm::VJEPA2ViT>(
                             cfg, generation_cfg, nntr_cfg);
                         });
 }
@@ -413,6 +423,11 @@ buildLayerDtypeMap(int num_layers, DataType fc_dtype, DataType embd_dtype,
   // Embedding layer
   if (embd_dtype != DataType::FP32 && embd_dtype != DataType::NONE) {
     dtype_map["embedding0"] = embd_dtype;
+  }
+
+  // ViT (VJEPA2ViT/TimmViT) patch-embedding projection is a plain FC layer.
+  if (fc_dtype != DataType::FP32 && fc_dtype != DataType::NONE) {
+    dtype_map["patch_embed/proj"] = fc_dtype;
   }
 
   // Transformer decoder layers

--- a/Applications/CausalLM/res/vjepa2/weight_converter.py
+++ b/Applications/CausalLM/res/vjepa2/weight_converter.py
@@ -1,0 +1,151 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+##
+## @file weight_converter.py
+## @brief Weight conversion for V-JEPA 2.1 ViT-B/16 (video) encoder.
+## @author Jijoong Moon <jijoong.moon@samsung.com>
+##
+## Converts the released V-JEPA 2.1 checkpoint (vjepa2_1_vit_base_384) encoder
+## into the nntrainer binary format expected by the VJEPA2ViT model graph.
+##
+## The byte order of the output exactly follows the order in which VJEPA2ViT
+## creates its weight-bearing layers (see models/vjepa2_vit/vjepa2_vit.cpp):
+##
+##   patch_embed/proj          (FC: weight, bias)
+##   for each of 12 blocks:
+##     layer{i}_attention_norm (LN: weight, bias)   <- blocks.{i}.norm1
+##     layer{i}_qkv_q          (FC: weight, bias)   <- blocks.{i}.attn.qkv[0:768]
+##     layer{i}_qkv_k          (FC: weight, bias)   <- blocks.{i}.attn.qkv[768:1536]
+##     layer{i}_qkv_v          (FC: weight, bias)   <- blocks.{i}.attn.qkv[1536:2304]
+##     layer{i}_attention_out  (FC: weight, bias)   <- blocks.{i}.attn.proj
+##     layer{i}_ffn_norm       (LN: weight, bias)   <- blocks.{i}.norm2
+##     layer{i}_ffn_up         (FC: weight, bias)   <- blocks.{i}.mlp.fc1
+##     layer{i}_ffn_down       (FC: weight, bias)   <- blocks.{i}.mlp.fc2
+##   output_norm               (LN: weight, bias)   <- norms_block.{last}
+##
+## Notes:
+##   - The 3D tubelet patch embedding (Conv3d) is non-overlapping, hence exactly
+##     equivalent to a Linear over the flattened tubelet. The Conv3d weight
+##     [embed, in_ch, kT, kH, kW] is reshaped to [embed, in_ch*kT*kH*kW] (C
+##     order, matching VJEPA2ViT::patchify's (c, kt, kh, kw) layout) and then
+##     transposed to nntrainer's [in, out] FC layout.
+##   - The (video) modality embedding is a constant added to every token, so it
+##     is folded into the patch-embed bias here. The image modality path
+##     (patch_embed_img / img_mod_embed) is intentionally not exported.
+##   - 3D RoPE carries no weights.
+
+import argparse
+import numpy as np
+import torch
+
+
+def load_encoder_state(model_path, checkpoint_key):
+    """Load the encoder sub state-dict and strip module/backbone prefixes."""
+    sd = torch.load(model_path, map_location="cpu")
+    if isinstance(sd, dict) and checkpoint_key in sd:
+        sd = sd[checkpoint_key]
+    cleaned = {}
+    for k, v in sd.items():
+        k = k.replace("module.", "").replace("backbone.", "")
+        cleaned[k] = v
+    return cleaned
+
+
+def save_weight(weight, dtype, file, transpose=False):
+    """Save a tensor to nntrainer format (optionally transposing OI -> IO)."""
+    array = weight if isinstance(weight, np.ndarray) else weight.detach().cpu().numpy()
+    if transpose and array.ndim >= 2:
+        array = array.T
+    array.astype(dtype).tofile(file)
+
+
+def convert(model_path, output_path, dtype, cfg):
+    dim = cfg["hidden_size"]
+    num_layers = cfg["num_hidden_layers"]
+    checkpoint_key = cfg["checkpoint_key"]
+    final_norm_key = cfg["final_norm_key"]
+
+    print(f"Loading encoder ('{checkpoint_key}') from: {model_path}")
+    sd = load_encoder_state(model_path, checkpoint_key)
+
+    # Sanity: surface a few keys if expected ones are missing.
+    if "patch_embed.proj.weight" not in sd:
+        print("  [warn] 'patch_embed.proj.weight' not found. Available keys:")
+        for k in list(sd.keys())[:20]:
+            print("    ", k, tuple(sd[k].shape))
+
+    print(f"Writing nntrainer weights to: {output_path}")
+    with open(output_path, "wb") as f:
+        # 1. Patch embedding (Conv3d -> FC), modality embed folded into bias.
+        pw = sd["patch_embed.proj.weight"]            # [embed, in_ch, kT, kH, kW]
+        pw = pw.reshape(pw.shape[0], -1)              # [embed, in_ch*kT*kH*kW]
+        save_weight(pw, dtype, f, transpose=True)     # -> [in, out]
+
+        pb = sd["patch_embed.proj.bias"].clone()      # [embed]
+        if "video_mod_embed" in sd:
+            pb = pb + sd["video_mod_embed"].reshape(-1)
+            print("  folded video_mod_embed into patch-embed bias")
+        save_weight(pb, dtype, f)
+
+        # 2. Transformer blocks.
+        for i in range(num_layers):
+            p = f"blocks.{i}."
+
+            # norm1 -> attention_norm
+            save_weight(sd[p + "norm1.weight"], dtype, f)
+            save_weight(sd[p + "norm1.bias"], dtype, f)
+
+            # fused qkv -> q, k, v (each transposed + bias)
+            qkv_w = sd[p + "attn.qkv.weight"]          # [3*dim, dim]
+            qkv_b = sd[p + "attn.qkv.bias"]            # [3*dim]
+            for s in range(3):
+                save_weight(qkv_w[s * dim:(s + 1) * dim, :], dtype, f, transpose=True)
+                save_weight(qkv_b[s * dim:(s + 1) * dim], dtype, f)
+
+            # attn.proj -> attention_out
+            save_weight(sd[p + "attn.proj.weight"], dtype, f, transpose=True)
+            save_weight(sd[p + "attn.proj.bias"], dtype, f)
+
+            # norm2 -> ffn_norm
+            save_weight(sd[p + "norm2.weight"], dtype, f)
+            save_weight(sd[p + "norm2.bias"], dtype, f)
+
+            # mlp.fc1 -> ffn_up, mlp.fc2 -> ffn_down
+            save_weight(sd[p + "mlp.fc1.weight"], dtype, f, transpose=True)
+            save_weight(sd[p + "mlp.fc1.bias"], dtype, f)
+            save_weight(sd[p + "mlp.fc2.weight"], dtype, f, transpose=True)
+            save_weight(sd[p + "mlp.fc2.bias"], dtype, f)
+
+            print(f"  layer {i + 1}/{num_layers} done")
+
+        # 3. Final norm (norms_block[-1] in the reference forward).
+        save_weight(sd[final_norm_key + ".weight"], dtype, f)
+        save_weight(sd[final_norm_key + ".bias"], dtype, f)
+
+    print("Conversion complete.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=str, default="vjepa2_1_vitb_dist_vitG_384.pt",
+                        help="Input V-JEPA 2.1 checkpoint (.pt)")
+    parser.add_argument("--output", type=str, default="nntr_vjepa2_vitb_fp32.bin",
+                        help="Output nntrainer weight file")
+    parser.add_argument("--dtype", type=str, default="float32",
+                        choices=["float32", "float16"])
+    parser.add_argument("--hidden_size", type=int, default=768)
+    parser.add_argument("--num_hidden_layers", type=int, default=12)
+    parser.add_argument("--checkpoint_key", type=str, default="ema_encoder",
+                        help="Top-level state_dict key holding the encoder")
+    parser.add_argument("--final_norm_key", type=str, default="norms_block.3",
+                        help="Key of the final LayerNorm (norms_block[-1])")
+    args = parser.parse_args()
+
+    dtype = {"float32": np.float32, "float16": np.float16}[args.dtype]
+    cfg = dict(
+        hidden_size=args.hidden_size,
+        num_hidden_layers=args.num_hidden_layers,
+        checkpoint_key=args.checkpoint_key,
+        final_norm_key=args.final_norm_key,
+    )
+    convert(args.input, args.output, dtype, cfg)


### PR DESCRIPTION
Port the V-JEPA 2.1 ViT-B/16 video encoder to the CausalLM application.

- VJEPA2ViT model: 3D tubelet patch embedding implemented as a single
  fully_connected (Conv3d-equivalent), 3D axial RoPE, GELU MLP, LayerNorm
  (eps 1e-6), qkv_bias, no CLS token / learned positional embedding. Runs
  in FP32 and Q4_0 (weights quantized with nntr_quantize --isa ARM).
- Custom layers:
    * vjepa_rope      : 3D axial RoPE applied to Q/K (mha_core rope disabled)
    * vjepa_gelu      : NEON GELU parallelized over tokens (ThreadManager)
    * vjepa_layernorm : per-token LayerNorm parallelized over tokens (FP32)
- mha_core: optional non-causal flash attention (use_gemm_attention),
  2D-tiled (query x key block) with an online softmax to avoid the O(N^2)
  score buffer, balanced over (head x query-block) work units.
- weight_converter.py converts the released V-JEPA 2.1 ema_encoder
  checkpoint into the nntrainer weight layout.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>