### PR TITLE
[tensor_api] Decouple multi-input layer restriction

### DIFF
--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -476,10 +476,15 @@ Tensor Transformer::createMlp(const int layer_id, int dim, int hidden_dim,
      withKey("weight_initializer", "ones")}));
   Tensor gate = ffn_gate(input);
 
+  /// @note nntrainer binary stores mlp weights in up, gate order.
+  /// For backward compatibility,
+  /// * layers are in up, gate order
+  /// * swiglu input[0] = gate
+  /// * swiglu input[1] = up
   LayerHandle swiglu(createLayer(
     "swiglu",
     {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_swiglu")}));
-  Tensor act = swiglu({gate, up});
+  Tensor act = swiglu({up, gate}, {1, 0});
 
   LayerHandle ffn_down(createLayer(
     "fully_connected",

--- a/Applications/CausalLM/res/qwen3/qwen3-4b/weight_converter.py
+++ b/Applications/CausalLM/res/qwen3/qwen3-4b/weight_converter.py
@@ -44,7 +44,7 @@ def save_qwen3_for_nntrainer(params, config, dtype, file):
         save_weight(params[f"{layer_name}post_attention_layernorm.weight"])  
           
         # Save MLP projections using helper  
-        for proj in ["gate_proj", "up_proj", "down_proj"]:
+        for proj in ["up_proj", "gate_proj", "down_proj"]:
             save_projection(layer_name, f"mlp.{proj}")  
 
     # Save embedding layer  

--- a/api/ccapi/include/tensor_api.h
+++ b/api/ccapi/include/tensor_api.h
@@ -638,6 +638,22 @@ public:
    */
   Tensor operator()(const std::vector<Tensor> &inputs);
 
+  /**
+   * @brief Call the layer with multiple inputs and explicit input slot mapping
+   *
+   * Decouples layer order from runtime input index assignment.
+   * inputs[i] is connected as input_layers[input_indices[i]].
+   *
+   * Example: layer({up, gate}, {1, 0}) will place layers in up, gate order, but
+   * at runtime context.getInput(0)=gate and context.getInput(1)=up.
+   *
+   * @param inputs Vector of input tensors (affects layer order)
+   * @param input_indices Maps each input to its runtime slot index
+   * @return Output tensor with graph edge info
+   */
+  Tensor operator()(const std::vector<Tensor> &inputs,
+                    std::vector<unsigned int> &&input_indices);
+
 private:
   std::shared_ptr<Layer> ptr_;
 };

--- a/api/ccapi/src/tensor_api_graph.cpp
+++ b/api/ccapi/src/tensor_api_graph.cpp
@@ -43,6 +43,7 @@ Tensor Tensor::output(unsigned int index) const {
   if (impl_ && impl_->graph_edge) {
     indexed_edge->producing_layer = impl_->graph_edge->producing_layer;
     indexed_edge->inputs = impl_->graph_edge->inputs;
+    indexed_edge->input_indices = impl_->graph_edge->input_indices;
     indexed_edge->dim = impl_->graph_edge->dim;
     indexed_edge->name = impl_->graph_edge->name;
   }
@@ -225,6 +226,66 @@ Tensor LayerHandle::operator()(const std::vector<Tensor> &inputs) {
   return output;
 }
 
+Tensor LayerHandle::operator()(const std::vector<Tensor> &inputs,
+                               std::vector<unsigned int> &&input_indices) {
+  if (!ptr_) {
+    throw std::runtime_error("LayerHandle: layer is null");
+  }
+  if (inputs.empty()) {
+    throw std::invalid_argument("LayerHandle: at least one input required");
+  }
+  if (input_indices.size() != inputs.size()) {
+    throw std::invalid_argument(
+      "LayerHandle: input_indices size must match inputs size");
+  }
+
+  // Infer output dimensions
+  TensorDim out_dim = inferOutputDim(ptr_, inputs);
+
+  // Build output name from layer name
+  std::string out_name;
+  try {
+    out_name = ptr_->getName();
+    if (!out_name.empty()) {
+      out_name += ":output";
+    }
+  } catch (...) {
+    // getName() might throw if layer isn't fully initialized
+  }
+
+  // Create symbolic output tensor
+  Tensor output;
+  if (out_dim.batch() > 0 && out_dim.width() > 0) {
+    output = Tensor(out_dim, out_name);
+  } else {
+    // Couldn't infer shape — create a valid but shapeless tensor
+    output = Tensor(TensorDim(), out_name);
+  }
+
+  // Record graph edge (shared, no deep copies)
+  auto edge = std::make_shared<SymbolicGraphNode>();
+  edge->producing_layer = ptr_;
+  edge->dim = out_dim;
+  edge->name = out_name;
+  for (unsigned int i = 0; i < inputs.size(); ++i) {
+    if (inputs[i].impl_ && inputs[i].impl_->graph_edge) {
+      edge->inputs.push_back(inputs[i].impl_->graph_edge);
+    } else {
+      // Leaf tensor — create a leaf edge with no producer
+      auto leaf = std::make_shared<SymbolicGraphNode>();
+      if (inputs[i].isValid()) {
+        leaf->dim = inputs[i].shape();
+        leaf->name = inputs[i].name();
+      }
+      edge->inputs.push_back(leaf);
+    }
+  }
+  edge->input_indices = std::move(input_indices);
+  output.impl_->graph_edge = edge;
+
+  return output;
+}
+
 // --- Model::compile(Tensor, Tensor) — graph extraction ---
 
 int Model::compile(Tensor &input, Tensor &output, ExecutionMode mode) {
@@ -287,15 +348,20 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
         dfs(inp);
       }
 
-      // Build input_layers names
-      std::vector<std::string> input_names;
-      for (auto &inp : edge->inputs) {
+      // Build input_layers names, respecting input_indices for slot mapping.
+      // First, collect (name, target_slot) pairs for each input.
+      std::vector<std::pair<std::string, unsigned int>> name_slot_pairs;
+      for (unsigned int i = 0; i < edge->inputs.size(); ++i) {
+        auto &inp = edge->inputs[i];
+        unsigned int target_slot =
+          (i < edge->input_indices.size()) ? edge->input_indices[i] : i;
+
         if (inp && inp->producing_layer) {
           std::string layer_ref = inp->producing_layer->getName();
           if (inp->output_index >= 0) {
             layer_ref += "(" + std::to_string(inp->output_index) + ")";
           }
-          input_names.push_back(layer_ref);
+          name_slot_pairs.push_back({layer_ref, target_slot});
         } else {
           // Leaf tensor
           std::string leaf_name = inp ? inp->name : "";
@@ -307,7 +373,6 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
             if (edge->producing_layer) {
               try {
                 if (edge->producing_layer->getType() == "input") {
-                  // Input layer's sentinel leaf — skip, no input_layers needed
                   continue;
                 }
               } catch (...) {
@@ -316,14 +381,20 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
             leaf_name = "ext_input_" + std::to_string(unnamed_leaf_counter++);
           }
           if (input_leaf_names.count(leaf_name)) {
-            input_names.push_back(leaf_name);
+            name_slot_pairs.push_back({leaf_name, target_slot});
           } else {
             if (additional_leaves.find(leaf_name) == additional_leaves.end()) {
               additional_leaves[leaf_name] = {inp ? inp->dim : TensorDim()};
             }
-            input_names.push_back(leaf_name);
+            name_slot_pairs.push_back({leaf_name, target_slot});
           }
         }
+      }
+
+      // Place names into input_names at their target slots
+      std::vector<std::string> input_names(name_slot_pairs.size());
+      for (auto &[name, slot] : name_slot_pairs) {
+        input_names[slot] = name;
       }
 
       layers_in_order.push_back({edge->producing_layer, input_names});

--- a/api/ccapi/src/tensor_api_impl.h
+++ b/api/ccapi/src/tensor_api_impl.h
@@ -39,6 +39,13 @@ namespace train {
 struct SymbolicGraphNode {
   std::shared_ptr<Layer> producing_layer;
   std::vector<std::shared_ptr<SymbolicGraphNode>> inputs;
+  std::vector<unsigned int> input_indices;
+  /**
+   * input_indices maps each input to its runtime slot index.
+   * input_indices[i] = j means inputs[i] should be
+   * connected as input_layers[j].
+   * If its size() == 0, it means [0,1,2,...].
+   */
   TensorDim dim;
   std::string name;
   int output_index = -1; ///< >=0 means indexed output, e.g. split(0)


### PR DESCRIPTION
This PR decouples restriction between layer node order and input index.
Since previous update, legacy nntrainer binaries were in conflict in swiglu layer.
* swiglu input[0] should be gate
* swiglu input[1] should be up
* weights are in up, gate, swiglu order(fixed in binary)
* layer nodes are in gate, up, swiglu order(by swiglu({gate, up}))

In this condition, we always get swiglu input[0] = up and swiglu input[1] = gate
regardless of changing the order like swiglu({up, gate}).
With this commit, we can set each orders in separate which keeps backward compatiblity.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>