### PR TITLE
[tensor] Fix Q4_0 related comments

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1182,9 +1182,9 @@ bool is_valid(const unsigned int N, const float *X);
  * @param M Original row size of output
  * @param N Original col size of output
  * @param K Hidden size
- * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param A Input activation to be online-runtime quantized to q8_0 format
  * @param lda Leading dimension of A
- * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param B Offline-quantized transposed weight in block_q4_0x4
  * @param ldb Leading dimenstion of B
  * @param C T* output
  * @param ldc Leading dimension of C

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -1082,9 +1082,9 @@ extern bool is_valid(const unsigned int N, const float *X);
  * @param M Original row size of output
  * @param N Original col size of output
  * @param K Hidden size
- * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param A Input activation to be online-runtime quantized to q8_0 format
  * @param lda Leading dimension of A
- * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param B Offline-quantized transposed weight in block_q4_0x4, block_q4_0x8
  * @param ldb Leading dimenstion of B
  * @param C T* output
  * @param ldc Leading dimension of C

--- a/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/ggml_interface.h
@@ -128,7 +128,7 @@ void __ggml_q4_0_8x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
  * @param K as descripted above
  * @param A Activation
  * @param lda leading dimension of A
- * @param Bs vector of offline quantized and packed q4_kx8 Weights
+ * @param Bs vector of offline quantized and packed q4_0x8 Weights
  * @param ldbs vector of leading dimension of B
  * @param C vector of dst matrices
  * @param ldcs vector of leading dimension of C
@@ -150,7 +150,7 @@ void __ggml_q4_0_8x8_q8_0_GEMM(const unsigned int M,
  * @param K as descripted above
  * @param A Activation
  * @param lda leading dimension of A
- * @param B offline quantized and packed q4_0x8 Weight
+ * @param B offline quantized and packed q4_0x4 Weight
  * @param ldb leading dimension of B
  * @param C dst matrix
  * @param ldc leading dimension of C
@@ -170,7 +170,7 @@ void __ggml_q4_0_4x8_q8_0_GEMM(const unsigned int M, const unsigned int N,
  * @param K as descripted above
  * @param A Activation
  * @param lda leading dimension of A
- * @param Bs vector of offline quantized and packed q4_kx8 Weights
+ * @param Bs vector of offline quantized and packed q4_0x4 Weights
  * @param ldbs vector of leading dimension of B
  * @param C vector of dst matrices
  * @param ldcs vector of leading dimension of C

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -922,9 +922,9 @@ bool is_valid(const unsigned int N, const float *X);
  * @param M Original row size of output
  * @param N Original col size of output
  * @param K Hidden size
- * @param A Input activation to be online-runtime quantized to q8_K_MxN format
+ * @param A Input activation to be online-runtime quantized to q8_0 format
  * @param lda Leading dimension of A
- * @param B (void*) (block_q4_K*) for Offline-quantized transposed weight
+ * @param B Offline-quantized transposed weight in block_q4_0x8
  * @param ldb Leading dimenstion of B
  * @param C T* output
  * @param ldc Leading dimension of C

--- a/nntrainer/tensor/float_tensor.h
+++ b/nntrainer/tensor/float_tensor.h
@@ -558,7 +558,7 @@ private:
                             bool trans_in, float beta) const;
 
   /**
-   * @brief Float.dot(Q4K/Q6K)
+   * @brief Float.dot(Q40/Q4K/Q6K)
    * @return Tensor& reference to the output tensor
    */
   Tensor &dotQnK(Tensor const &input, Tensor &output, bool trans, bool trans_in,


### PR DESCRIPTION
This commit fixes wrong comments into correct description.
* add Q4_0 into supported quantization types
* fix Q8_0 online quantization types
* fix Q4_0 quantization types
* fix Q4_0 repacked types

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>